### PR TITLE
refactor: dedupe progress view formatters

### DIFF
--- a/src/progressView/modules/domHandlers.js
+++ b/src/progressView/modules/domHandlers.js
@@ -1,5 +1,4 @@
 // Local imports - progress view
-import { LogEntryFormatter } from './formatters.js';
 // Local imports
 import { progressViewState } from './progressViewState.js';
 import { TaskGroupDomManager, LogEntryManager } from './taskManagers.js';
@@ -46,4 +45,3 @@ class ProgressViewDomHandler extends BaseDomHandler {
 export const progressViewDomHandler = new ProgressViewDomHandler();
 
 // Export formatter classes for reuse
-export { LogEntryFormatter };

--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -60,6 +60,37 @@ const TIME_FORMAT_OPTIONS = {
   hour12: false,
 };
 
+let cachedTimeFormatter;
+let cachedDateTimeFormatter;
+
+const getTimeFormatter = () => {
+  if (cachedTimeFormatter === undefined) {
+    try {
+      cachedTimeFormatter = new Intl.DateTimeFormat(
+        undefined,
+        TIME_FORMAT_OPTIONS,
+      );
+    } catch (error) {
+      cachedTimeFormatter = null;
+    }
+  }
+  return cachedTimeFormatter;
+};
+
+const getDateTimeFormatter = () => {
+  if (cachedDateTimeFormatter === undefined) {
+    try {
+      cachedDateTimeFormatter = new Intl.DateTimeFormat(
+        undefined,
+        DATETIME_FORMAT_OPTIONS,
+      );
+    } catch (error) {
+      cachedDateTimeFormatter = null;
+    }
+  }
+  return cachedDateTimeFormatter;
+};
+
 const toYamlString = (value) => {
   if (typeof value === 'string') {
     return value;
@@ -75,6 +106,18 @@ const toYamlString = (value) => {
   }
 };
 
+const formatIsoDateTimeFallback = (date) => {
+  const isoTimestamp = date.toISOString();
+  const [datePart, timePart = ''] = isoTimestamp.split('T');
+  const trimmedTime = timePart.split('.')[0] || timePart;
+  return `${datePart} ${trimmedTime}`.trim();
+};
+
+const formatIsoTimeFallback = (date) => {
+  const isoTimestamp = date.toISOString();
+  return isoTimestamp.split('T')[1]?.split('.')[0] ?? isoTimestamp;
+};
+
 /**
  * Represents different task group hierarchy levels with associated behaviors
  */
@@ -82,17 +125,15 @@ export const TaskGroupLevel = {
   ROOT: {
     name: 'root',
     formatTime: (date) => {
-      try {
-        return new Intl.DateTimeFormat(
-          undefined,
-          DATETIME_FORMAT_OPTIONS,
-        ).format(date);
-      } catch (error) {
-        const isoTimestamp = date.toISOString();
-        const timePart =
-          isoTimestamp.split('T')[1]?.split('.')[0] ?? isoTimestamp;
-        return `${isoTimestamp.split('T')[0]} ${timePart}`;
+      const formatter = getDateTimeFormatter();
+      if (formatter) {
+        try {
+          return formatter.format(date);
+        } catch (error) {
+          // Fall through to ISO fallback
+        }
       }
+      return formatIsoDateTimeFallback(date);
     },
     showTitle: false,
     headerOrder: 'time-first', // time → bullet → usage
@@ -101,15 +142,15 @@ export const TaskGroupLevel = {
   NESTED: {
     name: 'nested',
     formatTime: (date) => {
-      try {
-        return new Intl.DateTimeFormat(undefined, TIME_FORMAT_OPTIONS).format(
-          date,
-        );
-      } catch (error) {
-        return (
-          date.toISOString().split('T')[1]?.split('.')[0] ?? date.toISOString()
-        );
+      const formatter = getTimeFormatter();
+      if (formatter) {
+        try {
+          return formatter.format(date);
+        } catch (error) {
+          // Fall through to ISO fallback
+        }
       }
+      return formatIsoTimeFallback(date);
     },
     showTitle: true,
     headerOrder: 'usage-first', // usage → bullet → time
@@ -157,6 +198,8 @@ export class MessageTimestampExtractor {
 export class LogEntryFormatter {
   constructor() {
     this._initializeMarkdown();
+    this._formatters = this._buildFormatterMap();
+    this._autoExpandedTypes = new Set(['thinking', 'scratchpad']);
   }
 
   _initializeMarkdown() {
@@ -173,6 +216,140 @@ export class LogEntryFormatter {
       .use(highlight);
   }
 
+  _buildFormatterMap() {
+    return {
+      thinking: (message) =>
+        this._safeFormat(
+          () =>
+            this._formatBannerContent(
+              message.text,
+              'Thinking',
+              message.id,
+              message.groupId,
+              message.timestamp,
+            ),
+          'thinking',
+        ),
+      scratchpad: (message) =>
+        this._safeFormat(
+          () =>
+            this._formatBannerContent(
+              message.text,
+              'Scratchpad',
+              message.id,
+              message.groupId,
+              message.timestamp,
+            ),
+          'scratchpad',
+        ),
+      toolUse: (message) =>
+        this._safeFormat(
+          () =>
+            this._formatToolUse(
+              message.text,
+              message.data,
+              message.id,
+              message.groupId,
+              message.timestamp,
+            ),
+          'tool use',
+        ),
+      modelResponse: (message) =>
+        this._safeFormat(
+          () =>
+            this._formatModelResponse({
+              id: message.id,
+              groupId: message.groupId,
+              timestamp: message.timestamp,
+              verbose: message.verbose,
+              content: message.text,
+              level: message.level,
+            }),
+          'Assistant',
+        ),
+      fileList: (message) =>
+        this._safeFormat(
+          () => this._formatFileList(message.text, message.data, message.id),
+          'file list',
+        ),
+      missingOutputs: (message) =>
+        this._safeFormat(
+          () =>
+            this._formatMissingOutputs(message.text, message.data, message.id),
+          'missing outputs',
+        ),
+      latexdiff: (message) =>
+        this._safeFormat(
+          () => this._formatLatexdiff(message.text, message.data, message.id),
+          'latexdiff',
+        ),
+      statistics: (message) =>
+        this._safeFormat(
+          () => this._formatStatistics(message.text, message.data, message.id),
+          'statistics',
+        ),
+      userMessage: (message) =>
+        this._safeFormat(
+          () =>
+            this._formatUserMessage(
+              message.text,
+              message.id,
+              message.timestamp,
+            ),
+          'user message',
+        ),
+      progressStatus: (message) =>
+        this._safeFormat(
+          () =>
+            this._formatProgressStatus(
+              message.text,
+              message.id,
+              message.timestamp,
+            ),
+          'progress status',
+        ),
+    };
+  }
+
+  _applyOpenState(element, shouldOpen) {
+    if (!(element instanceof HTMLElement) || element.tagName !== 'DETAILS') {
+      return;
+    }
+
+    if (shouldOpen === undefined) {
+      return;
+    }
+
+    if (shouldOpen) {
+      element.setAttribute('open', '');
+    } else {
+      element.removeAttribute('open');
+    }
+
+    const toggleIcon = element.querySelector('.toggle-icon');
+    if (toggleIcon) {
+      toggleIcon.className = `${
+        shouldOpen ? CHEVRON_DOWN_CLASS : CHEVRON_RIGHT_CLASS
+      } toggle-icon`;
+    }
+  }
+
+  _resolveOpenState(messageType, options) {
+    if (!options) {
+      return undefined;
+    }
+
+    if (options.preservedOpen !== undefined) {
+      return options.preservedOpen;
+    }
+
+    if (options.defaultOpen && this._autoExpandedTypes.has(messageType)) {
+      return true;
+    }
+
+    return undefined;
+  }
+
   /**
    * Format timestamp consistently across all methods
    * @param {Date} date - Date object to format
@@ -181,30 +358,31 @@ export class LogEntryFormatter {
   _formatTimestamp(date) {
     const isoTimestamp = date.toISOString();
 
-    try {
-      const timeDisplay = new Intl.DateTimeFormat(
-        undefined,
-        TIME_FORMAT_OPTIONS,
-      ).format(date);
-      const tooltipTimestamp = new Intl.DateTimeFormat(
-        undefined,
-        DATETIME_FORMAT_OPTIONS,
-      ).format(date);
-
-      return {
-        fullTimestamp: isoTimestamp,
-        timeDisplay,
-        tooltipTimestamp,
-      };
-    } catch (error) {
-      const timeDisplay =
-        isoTimestamp.split('T')[1]?.split('.')[0] ?? isoTimestamp;
-      return {
-        fullTimestamp: isoTimestamp,
-        timeDisplay,
-        tooltipTimestamp: isoTimestamp,
-      };
+    let timeDisplay = formatIsoTimeFallback(date);
+    const timeFormatter = getTimeFormatter();
+    if (timeFormatter) {
+      try {
+        timeDisplay = timeFormatter.format(date);
+      } catch (error) {
+        // Fall through to ISO fallback
+      }
     }
+
+    let tooltipTimestamp = formatIsoDateTimeFallback(date);
+    const dateTimeFormatter = getDateTimeFormatter();
+    if (dateTimeFormatter) {
+      try {
+        tooltipTimestamp = dateTimeFormatter.format(date);
+      } catch (error) {
+        // Fall through to ISO fallback
+      }
+    }
+
+    return {
+      fullTimestamp: isoTimestamp,
+      timeDisplay,
+      tooltipTimestamp,
+    };
   }
 
   /**
@@ -262,71 +440,6 @@ export class LogEntryFormatter {
   }
 
   /**
-   * Get the formatter for a specific message type
-   * @private
-   * @returns {Object} Map of message types to their formatters with error handling
-   */
-  _getFormatters() {
-    return {
-      thinking: (text, id, groupId, timestamp) =>
-        this._safeFormat(
-          () =>
-            this._formatBannerContent(text, 'Thinking', id, groupId, timestamp),
-          'thinking',
-        ),
-      scratchpad: (text, id, groupId, timestamp) =>
-        this._safeFormat(
-          () =>
-            this._formatBannerContent(
-              text,
-              'Scratchpad',
-              id,
-              groupId,
-              timestamp,
-            ),
-          'scratchpad',
-        ),
-      toolUse: (text, data, id, groupId, timestamp) =>
-        this._safeFormat(
-          () => this._formatToolUse(text, data, id, groupId, timestamp),
-          'tool use',
-        ),
-      modelResponse: (params) =>
-        this._safeFormat(() => this._formatModelResponse(params), 'Assistant'),
-      fileList: (text, data, id) =>
-        this._safeFormat(
-          () => this._formatFileList(text, data, id),
-          'file list',
-        ),
-      missingOutputs: (text, data, id) =>
-        this._safeFormat(
-          () => this._formatMissingOutputs(text, data, id),
-          'missing outputs',
-        ),
-      latexdiff: (text, data, id) =>
-        this._safeFormat(
-          () => this._formatLatexdiff(text, data, id),
-          'latexdiff',
-        ),
-      statistics: (text, data, id) =>
-        this._safeFormat(
-          () => this._formatStatistics(text, data, id),
-          'statistics',
-        ),
-      userMessage: (text, id, timestamp) =>
-        this._safeFormat(
-          () => this._formatUserMessage(text, id, timestamp),
-          'user message',
-        ),
-      progressStatus: (text, id, timestamp) =>
-        this._safeFormat(
-          () => this._formatProgressStatus(text, id, timestamp),
-          'progress status',
-        ),
-    };
-  }
-
-  /**
    * Safely execute a formatting function with error handling
    * @private
    * @param {Function} formatter - The formatting function to execute
@@ -354,8 +467,8 @@ export class LogEntryFormatter {
    * DO NOT convert this to use templates unless you have a solution for the
    * whitespace formatting issue.
    */
-  format(logMessage) {
-    const { id, text, level, timestamp, groupId, messageType, verbose, data } =
+  format(logMessage, options = {}) {
+    const { id, text, level, timestamp, groupId, messageType, verbose } =
       logMessage;
 
     const emoji = EMOJI_BY_LEVEL[level] || '•';
@@ -363,42 +476,18 @@ export class LogEntryFormatter {
     const { fullTimestamp, timeDisplay, tooltipTimestamp } =
       this._formatTimestamp(date);
 
-    // Check if we have a custom formatter for this message type
-    const formatters = this._getFormatters();
-    const formatter = formatters[messageType];
+    const formatter = messageType ? this._formatters[messageType] : null;
 
-    if (formatter) {
-      let result;
-      if (messageType === 'modelResponse') {
-        // modelResponse needs the full parameter object
-        result = formatter({
-          id,
-          groupId,
-          timestamp,
-          verbose,
-          content: text,
-          level,
-        });
-      } else if (messageType === 'thinking' || messageType === 'scratchpad') {
-        // Pass identifiers so the formatter can apply grouping metadata
-        // Note: timestamp here is numeric (from Date.now())
-        result = formatter(text, id, groupId, timestamp);
-      } else if (messageType === 'toolUse') {
-        // Tool use needs both the rendered text and the structured payload
-        result = formatter(text, data, id, groupId, timestamp);
-      } else if (messageType === 'userMessage') {
-        // User message needs text, id, and timestamp
-        result = formatter(text, id, timestamp);
-      } else if (messageType === 'progressStatus') {
-        result = formatter(text, id, timestamp);
-      } else {
-        // File list, missing outputs, latexdiff, statistics need data
-        result = formatter(text, data, id);
-      }
-
+    if (typeof formatter === 'function') {
+      const result = formatter(logMessage);
       if (result) {
+        if (result instanceof HTMLElement) {
+          const openOverride = this._resolveOpenState(messageType, options);
+          this._applyOpenState(result, openOverride);
+        }
         return result;
       }
+
       if (
         messageType === 'thinking' ||
         messageType === 'scratchpad' ||
@@ -771,20 +860,11 @@ export class LogEntryFormatter {
     const element = createFromTemplate(templateId);
     if (!element) return null;
 
-    if (open) {
-      element.setAttribute('open', '');
-    } else {
-      element.removeAttribute('open');
-    }
+    this._applyOpenState(element, Boolean(open));
 
     if (logId) element.dataset.logId = logId;
     if (groupId) element.dataset.groupId = groupId;
     if (timestamp) element.dataset.fullTimestamp = timestamp;
-
-    const toggleIcon = element.querySelector('.toggle-icon');
-    if (toggleIcon) {
-      toggleIcon.className = `${open ? CHEVRON_DOWN_CLASS : CHEVRON_RIGHT_CLASS} toggle-icon`;
-    }
 
     const iconElem = element.querySelector('.icon');
     if (iconElem) {
@@ -1387,3 +1467,12 @@ export class TaskGroupHeaderFormatter {
     }
   }
 }
+
+let sharedLogEntryFormatter;
+
+export const getSharedLogEntryFormatter = () => {
+  if (!sharedLogEntryFormatter) {
+    sharedLogEntryFormatter = new LogEntryFormatter();
+  }
+  return sharedLogEntryFormatter;
+};

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -1,8 +1,9 @@
 // Local imports - progress view
 import { COMMANDS, STATUS, ELEMENT_IDS, GROUP_DOM_IDS } from './constants.js';
-import { progressViewDomHandler, LogEntryFormatter } from './domHandlers.js';
+import { progressViewDomHandler } from './domHandlers.js';
 import { createThemeHandlers } from './handlers/themeHandlers.js';
 import { appendFormatted } from './utils.js';
+import { getSharedLogEntryFormatter } from './formatters.js';
 // Local imports - log state
 import { progressViewState } from './progressViewState.js';
 import { BaseWebviewMessageHandler } from '@common/BaseWebviewMessageHandler.js';
@@ -38,7 +39,7 @@ function scrollToBottom(element) {
 export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
   constructor() {
     super();
-    this._entryFormatter = new LogEntryFormatter();
+    this._entryFormatter = getSharedLogEntryFormatter();
     this._handlers = {
       ...createThemeHandlers(),
       ...this._createHandlers(),
@@ -346,20 +347,22 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
   handleAppendLog(message) {
     if (message.stream === state.activeStream) {
       const logContent = document.getElementById(ELEMENT_IDS.LOG_CONTENT);
-      const addedToGroup = dom.logEntries.append(message.logMessage);
+      const messageType = message.logMessage.messageType;
+      const shouldAutoExpand =
+        messageType === 'thinking' || messageType === 'scratchpad';
+      const formatOptions = shouldAutoExpand
+        ? { defaultOpen: true }
+        : undefined;
+
+      const addedToGroup = dom.logEntries.append(
+        message.logMessage,
+        formatOptions,
+      );
       if (!addedToGroup) {
-        const formatted = this._entryFormatter.format(message.logMessage);
-        if (formatted instanceof HTMLElement) {
-          // For thinking and scratchpad, auto-expand when live streaming
-          const messageType = message.logMessage.messageType;
-          if (messageType === 'thinking' || messageType === 'scratchpad') {
-            formatted.setAttribute('open', '');
-            const toggleIcon = formatted.querySelector('.toggle-icon');
-            if (toggleIcon) {
-              toggleIcon.className = 'codicon codicon-chevron-down toggle-icon';
-            }
-          }
-        }
+        const formatted = this._entryFormatter.format(
+          message.logMessage,
+          formatOptions,
+        );
         appendFormatted(logContent, formatted);
       }
       scrollToBottom(logContent);
@@ -372,21 +375,22 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       const updated = dom.logEntries.update(message.logMessage);
       if (!updated) {
         // Fallback: append as new log with proper group placement
-        const addedToGroup = dom.logEntries.append(message.logMessage);
+        const messageType = message.logMessage.messageType;
+        const shouldAutoExpand =
+          messageType === 'thinking' || messageType === 'scratchpad';
+        const formatOptions = shouldAutoExpand
+          ? { defaultOpen: true }
+          : undefined;
+
+        const addedToGroup = dom.logEntries.append(
+          message.logMessage,
+          formatOptions,
+        );
         if (!addedToGroup) {
-          const formatted = this._entryFormatter.format(message.logMessage);
-          if (formatted instanceof HTMLElement) {
-            // For thinking and scratchpad, auto-expand when live streaming
-            const messageType = message.logMessage.messageType;
-            if (messageType === 'thinking' || messageType === 'scratchpad') {
-              formatted.setAttribute('open', '');
-              const toggleIcon = formatted.querySelector('.toggle-icon');
-              if (toggleIcon) {
-                toggleIcon.className =
-                  'codicon codicon-chevron-down toggle-icon';
-              }
-            }
-          }
+          const formatted = this._entryFormatter.format(
+            message.logMessage,
+            formatOptions,
+          );
           appendFormatted(logContent, formatted);
         }
         scrollToBottom(logContent);

--- a/src/progressView/modules/progressViewState.js
+++ b/src/progressView/modules/progressViewState.js
@@ -245,6 +245,74 @@ class ExecutionIdAvailability {
   }
 }
 
+class RunScopedMap {
+  constructor(resolveStreamId) {
+    this._resolveStreamId = resolveStreamId;
+    this._data = new Map();
+  }
+
+  set(streamId, runId, value) {
+    const targetStream = this._resolveStreamId(streamId);
+    if (targetStream == null || !runId) {
+      return;
+    }
+
+    let runs = this._data.get(targetStream);
+    if (!runs) {
+      runs = new Map();
+      this._data.set(targetStream, runs);
+    }
+    runs.set(runId, value);
+  }
+
+  get(streamId, runId) {
+    if (!runId) {
+      return null;
+    }
+    const runs = this.getStreamMap(streamId);
+    return runs ? runs.get(runId) || null : null;
+  }
+
+  delete(streamId, runId) {
+    const targetStream = this._resolveStreamId(streamId);
+    if (targetStream == null || !runId) {
+      return;
+    }
+    const runs = this._data.get(targetStream);
+    if (!runs) {
+      return;
+    }
+    runs.delete(runId);
+    if (runs.size === 0) {
+      this._data.delete(targetStream);
+    }
+  }
+
+  clearStream(streamId) {
+    const targetStream = this._resolveStreamId(streamId);
+    if (targetStream == null) {
+      return;
+    }
+    this._data.delete(targetStream);
+  }
+
+  clearAll() {
+    this._data.clear();
+  }
+
+  getStreamMap(streamId) {
+    const targetStream = this._resolveStreamId(streamId);
+    if (targetStream == null) {
+      return null;
+    }
+    return this._data.get(targetStream) || null;
+  }
+
+  streamEntries() {
+    return this._data.entries();
+  }
+}
+
 /**
  * Manages progress view state and handles persistence.
  */
@@ -260,10 +328,11 @@ export class ProgressViewState {
     this.pendingInstructions = new Map();
 
     this.activeRunIds = new Map();
-    this.runInstructions = new Map();
-    this.runFiles = new Map();
-    this.runMissingOutputs = new Map();
-    this.runUsage = new Map();
+    const streamResolver = this._resolveStreamId.bind(this);
+    this.runInstructions = new RunScopedMap(streamResolver);
+    this.runFiles = new RunScopedMap(streamResolver);
+    this.runMissingOutputs = new RunScopedMap(streamResolver);
+    this.runUsage = new RunScopedMap(streamResolver);
 
     // Initialize managers
     this.taskGroups = new TaskGroups();
@@ -282,20 +351,6 @@ export class ProgressViewState {
     }
 
     return null;
-  }
-
-  _getStreamMap(container, streamId, createIfMissing = false) {
-    const targetStream = this._resolveStreamId(streamId);
-    if (targetStream == null) {
-      return null;
-    }
-
-    let streamMap = container.get(targetStream) || null;
-    if (!streamMap && createIfMissing) {
-      streamMap = new Map();
-      container.set(targetStream, streamMap);
-    }
-    return streamMap;
   }
 
   setExecutionIdAvailable(stream, hasExecutionId) {
@@ -398,7 +453,7 @@ export class ProgressViewState {
   _collectRunCandidates(streamId) {
     const candidates = new Set();
 
-    const instructionRuns = this.runInstructions.get(streamId);
+    const instructionRuns = this.runInstructions.getStreamMap(streamId);
     if (instructionRuns) {
       for (const runId of instructionRuns.keys()) {
         if (runId) {
@@ -407,7 +462,7 @@ export class ProgressViewState {
       }
     }
 
-    const fileRuns = this.runFiles.get(streamId);
+    const fileRuns = this.runFiles.getStreamMap(streamId);
     if (fileRuns) {
       for (const runId of fileRuns.keys()) {
         if (runId) {
@@ -416,7 +471,7 @@ export class ProgressViewState {
       }
     }
 
-    const missingRuns = this.runMissingOutputs.get(streamId);
+    const missingRuns = this.runMissingOutputs.getStreamMap(streamId);
     if (missingRuns) {
       for (const runId of missingRuns.keys()) {
         if (runId) {
@@ -425,7 +480,7 @@ export class ProgressViewState {
       }
     }
 
-    const usageRuns = this.runUsage.get(streamId);
+    const usageRuns = this.runUsage.getStreamMap(streamId);
     if (usageRuns) {
       for (const runId of usageRuns.keys()) {
         if (runId) {
@@ -454,7 +509,7 @@ export class ProgressViewState {
     }
 
     if (rootGroups.length === 0) {
-      const usageRuns = this.runUsage.get(streamId);
+      const usageRuns = this.runUsage.getStreamMap(streamId);
       if (usageRuns && usageRuns.size > 0) {
         return Array.from(usageRuns.keys())[usageRuns.size - 1] || null;
       }
@@ -527,42 +582,21 @@ export class ProgressViewState {
       return;
     }
 
-    const streamMap = this._getStreamMap(
-      this.runInstructions,
-      targetStream,
-      true,
-    );
-    streamMap.set(runId, {
+    this.runInstructions.set(targetStream, runId, {
       text: text.trim(),
       metadata: instruction?.metadata,
     });
   }
 
   clearRunInstruction(streamId, runId) {
-    const targetStream = this._resolveStreamId(streamId);
-    if (targetStream == null || !runId) {
+    if (!runId) {
       return;
     }
-    const streamMap = this.runInstructions.get(targetStream);
-    if (!streamMap) {
-      return;
-    }
-    streamMap.delete(runId);
-    if (streamMap.size === 0) {
-      this.runInstructions.delete(targetStream);
-    }
+    this.runInstructions.delete(streamId, runId);
   }
 
   getRunInstruction(streamId, runId) {
-    const targetStream = this._resolveStreamId(streamId);
-    if (targetStream == null || !runId) {
-      return null;
-    }
-    const streamMap = this.runInstructions.get(targetStream);
-    if (!streamMap) {
-      return null;
-    }
-    return streamMap.get(runId) || null;
+    return this.runInstructions.get(streamId, runId);
   }
 
   clearRunInstructions(streamId) {
@@ -571,12 +605,12 @@ export class ProgressViewState {
       if (targetStream == null) {
         return;
       }
-      this.runInstructions.delete(targetStream);
+      this.runInstructions.clearStream(targetStream);
       this.clearPendingInstruction(targetStream);
       return;
     }
 
-    this.runInstructions.clear();
+    this.runInstructions.clearAll();
     this.clearAllPendingInstructions();
   }
 
@@ -585,20 +619,11 @@ export class ProgressViewState {
     if (targetStream == null || !runId) {
       return;
     }
-    const streamMap = this._getStreamMap(this.runFiles, targetStream, true);
-    streamMap.set(runId, filesByRound || {});
+    this.runFiles.set(targetStream, runId, filesByRound || {});
   }
 
   getRunFiles(streamId, runId) {
-    const targetStream = this._resolveStreamId(streamId);
-    if (targetStream == null || !runId) {
-      return null;
-    }
-    const streamMap = this.runFiles.get(targetStream);
-    if (!streamMap) {
-      return null;
-    }
-    return streamMap.get(runId) || null;
+    return this.runFiles.get(streamId, runId);
   }
 
   clearRunFiles(streamId) {
@@ -607,26 +632,15 @@ export class ProgressViewState {
       if (targetStream == null) {
         return;
       }
-      this.runFiles.delete(targetStream);
+      this.runFiles.clearStream(targetStream);
       return;
     }
 
-    this.runFiles.clear();
+    this.runFiles.clearAll();
   }
 
   deleteRunFiles(streamId, runId) {
-    const targetStream = this._resolveStreamId(streamId);
-    if (targetStream == null || !runId) {
-      return;
-    }
-    const streamMap = this.runFiles.get(targetStream);
-    if (!streamMap) {
-      return;
-    }
-    streamMap.delete(runId);
-    if (streamMap.size === 0) {
-      this.runFiles.delete(targetStream);
-    }
+    this.runFiles.delete(streamId, runId);
   }
 
   setRunMissingOutputs(streamId, runId, filesByRound) {
@@ -634,24 +648,11 @@ export class ProgressViewState {
     if (targetStream == null || !runId) {
       return;
     }
-    const streamMap = this._getStreamMap(
-      this.runMissingOutputs,
-      targetStream,
-      true,
-    );
-    streamMap.set(runId, filesByRound || {});
+    this.runMissingOutputs.set(targetStream, runId, filesByRound || {});
   }
 
   getRunMissingOutputs(streamId, runId) {
-    const targetStream = this._resolveStreamId(streamId);
-    if (targetStream == null || !runId) {
-      return null;
-    }
-    const streamMap = this.runMissingOutputs.get(targetStream);
-    if (!streamMap) {
-      return null;
-    }
-    return streamMap.get(runId) || null;
+    return this.runMissingOutputs.get(streamId, runId);
   }
 
   clearRunMissingOutputs(streamId) {
@@ -660,11 +661,11 @@ export class ProgressViewState {
       if (targetStream == null) {
         return;
       }
-      this.runMissingOutputs.delete(targetStream);
+      this.runMissingOutputs.clearStream(targetStream);
       return;
     }
 
-    this.runMissingOutputs.clear();
+    this.runMissingOutputs.clearAll();
   }
 
   setRunUsage(streamId, runId, usage) {
@@ -685,64 +686,29 @@ export class ProgressViewState {
       this.clearRunUsage(targetStream, runId);
       return;
     }
-    const streamMap = this._getStreamMap(this.runUsage, targetStream, true);
-    streamMap.set(runId, normalized);
+    this.runUsage.set(targetStream, runId, normalized);
   }
 
   getRunUsage(streamId, runId) {
-    const targetStream = this._resolveStreamId(streamId);
-    if (targetStream == null || !runId) {
-      return null;
-    }
-    const streamMap = this.runUsage.get(targetStream);
-    if (!streamMap) {
-      return null;
-    }
-    return streamMap.get(runId) || null;
+    return this.runUsage.get(streamId, runId);
   }
 
   clearRunUsage(streamId, runId) {
-    if (streamId !== undefined && streamId !== null && runId) {
-      const targetStream = this._resolveStreamId(streamId);
-      if (targetStream == null) {
-        return;
-      }
-      const streamMap = this.runUsage.get(targetStream);
-      if (!streamMap) {
-        return;
-      }
-      streamMap.delete(runId);
-      if (streamMap.size === 0) {
-        this.runUsage.delete(targetStream);
-      }
+    if (runId) {
+      this.runUsage.delete(streamId, runId);
       return;
     }
 
     if (streamId !== undefined && streamId !== null) {
-      const targetStream = this._resolveStreamId(streamId);
-      if (targetStream == null) {
-        return;
-      }
-      this.runUsage.delete(targetStream);
+      this.runUsage.clearStream(streamId);
       return;
     }
 
-    this.runUsage.clear();
+    this.runUsage.clearAll();
   }
 
   deleteRunMissingOutputs(streamId, runId) {
-    const targetStream = this._resolveStreamId(streamId);
-    if (targetStream == null || !runId) {
-      return;
-    }
-    const streamMap = this.runMissingOutputs.get(targetStream);
-    if (!streamMap) {
-      return;
-    }
-    streamMap.delete(runId);
-    if (streamMap.size === 0) {
-      this.runMissingOutputs.delete(targetStream);
-    }
+    this.runMissingOutputs.delete(streamId, runId);
   }
 }
 

--- a/src/progressView/modules/taskManagers.js
+++ b/src/progressView/modules/taskManagers.js
@@ -1,6 +1,9 @@
 // Local imports - progress view
 import { ELEMENT_IDS, GROUP_DOM_IDS } from './constants.js';
-import { TaskGroupHeaderFormatter, LogEntryFormatter } from './formatters.js';
+import {
+  TaskGroupHeaderFormatter,
+  getSharedLogEntryFormatter,
+} from './formatters.js';
 // Local imports
 import { progressViewState } from './progressViewState.js';
 import { insertChronologically } from './utils.js';
@@ -470,7 +473,7 @@ export class TaskGroupDomManager {
  */
 export class LogEntryManager {
   constructor() {
-    this.entryFormatter = new LogEntryFormatter();
+    this.entryFormatter = getSharedLogEntryFormatter();
   }
 
   /**
@@ -478,13 +481,13 @@ export class LogEntryManager {
    * @param {Object} logMessage - The log message to append
    * @returns {boolean} Whether the message was appended to a group
    */
-  append(logMessage) {
+  append(logMessage, options = {}) {
     // If the message has a group ID, append it to the right group
     if (logMessage.groupId) {
       const groupContentId = `${GROUP_DOM_IDS.CONTENT_PREFIX}${logMessage.groupId}`;
       const groupContent = document.getElementById(groupContentId);
       if (groupContent) {
-        const logLineElement = this.entryFormatter.format(logMessage);
+        const logLineElement = this.entryFormatter.format(logMessage, options);
         if (!logLineElement) {
           console.debug(
             'LogEntryManager.append: formatter returned null for message',
@@ -519,23 +522,12 @@ export class LogEntryManager {
     if (existing) {
       // Preserve the expanded/collapsed state for thinking and scratchpad
       const wasOpen = existing.hasAttribute('open');
-      const newEl = this.entryFormatter.format(logMessage);
+      const newEl = this.entryFormatter.format(logMessage, {
+        preservedOpen: wasOpen,
+      });
       if (!newEl) {
         existing.remove();
         return true;
-      }
-
-      // Restore the expanded state if it was open
-      if (
-        wasOpen &&
-        (logMessage.messageType === 'thinking' ||
-          logMessage.messageType === 'scratchpad')
-      ) {
-        newEl.setAttribute('open', '');
-        const toggleIcon = newEl.querySelector('.toggle-icon');
-        if (toggleIcon) {
-          toggleIcon.className = 'codicon codicon-chevron-down toggle-icon';
-        }
       }
 
       existing.replaceWith(newEl);


### PR DESCRIPTION
## Summary
- memoize expensive log formatting helpers, centralize banner open state handling, and provide a shared LogEntryFormatter instance for reuse
- switch progress view message and log managers to the shared formatter and rely on formatter-controlled expansion when streaming
- unify run-scoped state handling with a reusable RunScopedMap helper to eliminate duplicated map management logic

## Testing
- npm run format
- npm run compile
- npm run lint
- npm test *(fails: command output exceeded environment limits)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69178f6ea5e083249f2befdf99e3bff9)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Consolidates log formatting into a shared, memoized formatter with robust timestamp fallbacks and centralized open-state control, and replaces ad-hoc run-scoped maps with a reusable RunScopedMap; updates handlers to use the new APIs.
> 
> - **Progress View UI**:
>   - Switch `messageHandlers` and `taskManagers` to a shared `LogEntryFormatter` via `getSharedLogEntryFormatter()`.
>   - Rely on formatter-controlled expansion for `thinking`/`scratchpad` (using `defaultOpen` and `preservedOpen`), removing manual DOM toggling.
> - **Formatters**:
>   - Add cached `Intl.DateTimeFormat` helpers with ISO fallbacks; centralize timestamp formatting.
>   - Refactor `LogEntryFormatter`: build a formatter map, accept full `message` objects, and support `format(message, options)` with open-state application.
>   - Extract open-state helpers (`_applyOpenState`, `_resolveOpenState`) and add auto-expanded types set.
>   - Minor template usage cleanups while keeping string-based HTML where needed.
> - **State Management**:
>   - Introduce `RunScopedMap` to unify per-stream/run data storage.
>   - Replace duplicated maps (`runInstructions`, `runFiles`, `runMissingOutputs`, `runUsage`) with `RunScopedMap` and update accessors/clear/delete methods accordingly.
> - **Misc**:
>   - Remove redundant `LogEntryFormatter` export from `domHandlers.js`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aa544df2555b9b1f1e2d79cd9c87ea549d0dcbbc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->