### PR TITLE
perf: streamline progress refresh

### DIFF
--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -109,7 +109,10 @@ export class ProgressEventHandler {
   /**
    * Send instruction updates for the provided stream
    */
-  private sendInstructionUpdate(stream: StreamTabId | ''): void {
+  private sendInstructionUpdate(
+    stream: StreamTabId | '',
+    runIdHint?: string | null,
+  ): void {
     if (!this.webviewUpdater.isAvailable()) {
       return;
     }
@@ -123,9 +126,12 @@ export class ProgressEventHandler {
     const instructionUpdate = WebviewUpdater.createInstructionUpdate(taskState);
     const sessionKindHint = this.state.getSessionKindHint(stream);
     const sessionKind = taskState?.session?.agentCategory ?? sessionKindHint;
-    const runId = this.state.resolveRunId(stream, undefined, {
-      persist: false,
-    });
+    const runId =
+      runIdHint === undefined
+        ? this.state.resolveRunId(stream, undefined, {
+            persist: false,
+          })
+        : runIdHint;
 
     if (runId && instructionUpdate) {
       void this.state.runInstructions.setInstruction(
@@ -201,21 +207,12 @@ export class ProgressEventHandler {
       runUsage: usageByRun,
     });
 
-    // Send output files for current stream
-    this.webviewUpdater.updateFiles(stream, filesByRun);
-
-    // Send missing outputs for current stream
-    this.webviewUpdater.updateMissingOutputs(stream, missingByRun);
-
-    // Send usage for current stream
-    this.webviewUpdater.updateUsage(stream, usageByRun);
-
     // Update status for current stream - default to STOPPED when stream exists but no status is set
     const status = this._streamStatus.get(stream) || STATUS.STOPPED;
     this.webviewUpdater.updateStatus(status);
 
     if (updateInstruction) {
-      this.sendInstructionUpdate(stream);
+      this.sendInstructionUpdate(stream, activeRunId);
     }
   }
 

--- a/src/progressView/events/StreamStatusEvents.ts
+++ b/src/progressView/events/StreamStatusEvents.ts
@@ -29,7 +29,7 @@ export interface StreamStatusEventShared {
   logger: AgentLogger;
   streamStatus: Map<string, StreamStatusType>;
   setStreamStatus(stream: string, status: StreamStatusOrReadyType): void;
-  sendInstructionUpdate(stream: StreamTabId | ''): void;
+  sendInstructionUpdate(stream: StreamTabId | '', runId?: string | null): void;
   refreshStreamSurface(
     stream: string,
     options?: { updateInstruction?: boolean },


### PR DESCRIPTION
## Summary
- avoid recomputing the active run identifier when it is already known during surface refresh
- remove redundant file, missing-output, and usage updates that duplicated the bundled log payload

## Testing
- npm run format
- npm run compile
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691798f5f3008324940242737f9e3c37)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reuses known active run id when sending instruction updates and removes redundant file/missing/usage updates now bundled in log payload.
> 
> - **Progress View**
>   - `ProgressEventHandler.sendInstructionUpdate` now accepts an optional `runIdHint` and uses it if provided; otherwise resolves the run id.
>   - `refreshStreamSurface` stops calling separate `updateFiles`, `updateMissingOutputs`, and `updateUsage` since these are included in `updateLogContent`.
>   - Passes `activeRunId` to `sendInstructionUpdate` during surface refresh.
> - **Events API**
>   - `StreamStatusEventShared.sendInstructionUpdate` signature updated to `sendInstructionUpdate(stream, runId?)`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9d4cc2dd10a3e07e2425959e22455cc1e3048894. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->