### PR TITLE
Trim redundant progress refresh work

### DIFF
--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -109,7 +109,10 @@ export class ProgressEventHandler {
   /**
    * Send instruction updates for the provided stream
    */
-  private sendInstructionUpdate(stream: StreamTabId | ''): void {
+  private sendInstructionUpdate(
+    stream: StreamTabId | '',
+    precomputedRunId?: string | null,
+  ): void {
     if (!this.webviewUpdater.isAvailable()) {
       return;
     }
@@ -123,9 +126,12 @@ export class ProgressEventHandler {
     const instructionUpdate = WebviewUpdater.createInstructionUpdate(taskState);
     const sessionKindHint = this.state.getSessionKindHint(stream);
     const sessionKind = taskState?.session?.agentCategory ?? sessionKindHint;
-    const runId = this.state.resolveRunId(stream, undefined, {
-      persist: false,
-    });
+    const runId =
+      precomputedRunId !== undefined
+        ? precomputedRunId
+        : this.state.resolveRunId(stream, undefined, {
+            persist: false,
+          });
 
     if (runId && instructionUpdate) {
       void this.state.runInstructions.setInstruction(
@@ -201,21 +207,12 @@ export class ProgressEventHandler {
       runUsage: usageByRun,
     });
 
-    // Send output files for current stream
-    this.webviewUpdater.updateFiles(stream, filesByRun);
-
-    // Send missing outputs for current stream
-    this.webviewUpdater.updateMissingOutputs(stream, missingByRun);
-
-    // Send usage for current stream
-    this.webviewUpdater.updateUsage(stream, usageByRun);
-
     // Update status for current stream - default to STOPPED when stream exists but no status is set
     const status = this._streamStatus.get(stream) || STATUS.STOPPED;
     this.webviewUpdater.updateStatus(status);
 
     if (updateInstruction) {
-      this.sendInstructionUpdate(stream);
+      this.sendInstructionUpdate(stream, activeRunId);
     }
   }
 

--- a/src/progressView/events/StreamStatusEvents.ts
+++ b/src/progressView/events/StreamStatusEvents.ts
@@ -29,7 +29,10 @@ export interface StreamStatusEventShared {
   logger: AgentLogger;
   streamStatus: Map<string, StreamStatusType>;
   setStreamStatus(stream: string, status: StreamStatusOrReadyType): void;
-  sendInstructionUpdate(stream: StreamTabId | ''): void;
+  sendInstructionUpdate(
+    stream: StreamTabId | '',
+    precomputedRunId?: string | null,
+  ): void;
   refreshStreamSurface(
     stream: string,
     options?: { updateInstruction?: boolean },


### PR DESCRIPTION
## Summary
- avoid recomputing the active run during progress refreshes by threading the resolved id into instruction updates
- remove redundant file, missing output, and usage refresh messages now that the bundled log payload already includes those snapshots

## Testing
- npm run format
- npm run compile
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691798f5f3008324940242737f9e3c37)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Pass precomputed runId to instruction updates and consolidate file/missing/usage refreshes into the log payload to avoid redundant work.
> 
> - **Progress View**
>   - **Instruction updates**:
>     - Expand `sendInstructionUpdate(stream, precomputedRunId?)` to accept an optional run id and use it when provided.
>     - `refreshStreamSurface` resolves `activeRunId` once and passes it to `sendInstructionUpdate`.
>   - **Webview refresh consolidation**:
>     - Remove separate `updateFiles`, `updateMissingOutputs`, and `updateUsage` calls; these snapshots are now included in `updateLogContent` payload (`runFiles`, `runMissingOutputs`, `runUsage`).
>   - **Types/Interfaces**:
>     - Update `StreamStatusEventShared.sendInstructionUpdate` signature to include optional `precomputedRunId`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 97b3ff2d0c965e28522026de7f4bd4fa1ed61144. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->