### PR TITLE
fix: unify tex file detection helper

### DIFF
--- a/src/common/files/fileTypeUtils.ts
+++ b/src/common/files/fileTypeUtils.ts
@@ -35,5 +35,6 @@ export function getIncludedExtensions(
  * Returns true if the file has a .tex extension.
  */
 export function isTexFile(filePath: string): boolean {
-  return path.extname(filePath).toLowerCase() === '.tex';
+  const fileName = path.basename(filePath);
+  return fileName.toLowerCase().endsWith('.tex');
 }

--- a/src/test/utils/files/pathUtils.test.ts
+++ b/src/test/utils/files/pathUtils.test.ts
@@ -3,11 +3,7 @@ import * as assert from 'assert';
 import * as path from 'path';
 
 // Local imports - utils
-import {
-  getBasename,
-  isTexFile,
-  resolveFilePath,
-} from '@utils/files/pathUtils';
+import { getBasename, isTexFile, resolveFilePath } from '@utils/files';
 
 describe('pathUtils Test Suite', () => {
   describe('getBasename', () => {

--- a/src/utils/files/index.ts
+++ b/src/utils/files/index.ts
@@ -7,6 +7,7 @@ export * from './pastedImageUtils';
 export * from './baseFileUtils';
 export * from './fileMappingUtils';
 export * from './pathUtils';
+export { isTexFile } from '@common/files/fileTypeUtils';
 export * from './mimeUtils';
 export * from './taskRunStorage';
 export * from './copyUtils';

--- a/src/utils/files/pathUtils.ts
+++ b/src/utils/files/pathUtils.ts
@@ -9,11 +9,6 @@ export function resolveFilePath(file: string): string {
   return path.isAbsolute(file) ? file : WorkspaceFS.fullPath(file);
 }
 
-/** Determine if the given file has a TeX extension. */
-export function isTexFile(file: string): boolean {
-  return file.toLowerCase().endsWith('.tex');
-}
-
 /**
  * Extract the base name (filename) from a file path.
  * Handles platform-specific separators (\ on Windows, / on Unix).


### PR DESCRIPTION
## Summary
- centralize TeX file detection in `fileTypeUtils` so dotfile names like `.tex` are handled
- re-export the shared helper through `@utils/files` and drop the duplicate from `pathUtils`
- refresh the path utils tests to cover the unified helper

## Testing
- npm run compile-tests
- npm run compile
- npm run lint
- npx vscode-test pathUtils *(fails: VS Code binary requires libgtk-3.so.0 in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69179ab544f48324bfd6aac7cf87a0b1)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Unifies TeX file detection in a shared helper, updates logic to handle dotfiles, re-exports it, removes the duplicate, and refreshes related tests.
> 
> - **Files utilities**:
>   - Centralize `isTexFile` in `src/common/files/fileTypeUtils.ts`; update detection to `basename(...).toLowerCase().endsWith('.tex')` to cover dotfiles.
>   - Re-export `isTexFile` from `src/utils/files/index.ts`.
>   - Remove duplicate `isTexFile` from `src/utils/files/pathUtils.ts`.
> - **Tests**:
>   - Update `src/test/utils/files/pathUtils.test.ts` to import from `@utils/files`, add TeX dotfile and edge-case checks, and expand `getBasename` cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5020946d229420c4a14c5d841bf815cd08c2b228. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->