### PR TITLE
perf: simplify progress view output syncing

### DIFF
--- a/src/progressView/events/OutputEvents.ts
+++ b/src/progressView/events/OutputEvents.ts
@@ -6,6 +6,7 @@ import type { StreamTabId } from '@agent/types/IdentifierTypes';
 import type { AgentLogger } from '@logger/AgentLogger';
 import type { WebviewUpdater } from '@progressView/managers';
 import type { ProgressViewState } from '@progressView/state/ProgressViewState';
+import { normalizeRunId } from '@progressView/constants/runIds';
 import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
 
 // Local file imports
@@ -31,7 +32,49 @@ interface OutputEventsShared {
   getAllStreamStatuses: () => Map<string, StreamStatusType>;
 }
 
-const updateActiveStreamOutputs = (
+const toRoundRecord = <T>(
+  rounds?: Map<number, T[]>,
+): Record<number, T[]> | undefined => {
+  if (!rounds || rounds.size === 0) {
+    return undefined;
+  }
+
+  return Object.fromEntries(rounds.entries());
+};
+
+const sendRunFileUpdate = (
+  state: ProgressViewState,
+  updater: WebviewUpdater,
+  stream: string,
+  runId: string,
+): void => {
+  if (state.activeStream !== stream || !updater.isAvailable()) {
+    return;
+  }
+
+  const runFiles = state.outputFiles.getFiles(stream).get(runId);
+  const rounds = toRoundRecord(runFiles);
+  const payload = rounds ? { runId, rounds } : { runId };
+  updater.updateFiles(stream, payload);
+};
+
+const sendRunMissingUpdate = (
+  state: ProgressViewState,
+  updater: WebviewUpdater,
+  stream: string,
+  runId: string,
+): void => {
+  if (state.activeStream !== stream || !updater.isAvailable()) {
+    return;
+  }
+
+  const runMissing = state.outputFiles.getMissingOutputs(stream).get(runId);
+  const rounds = toRoundRecord(runMissing);
+  const payload = rounds ? { runId, rounds } : { runId };
+  updater.updateMissingOutputs(stream, payload);
+};
+
+const resetFileSurface = (
   state: ProgressViewState,
   updater: WebviewUpdater,
   stream: string,
@@ -40,23 +83,19 @@ const updateActiveStreamOutputs = (
     return;
   }
 
-  const filesByRun = state.outputFiles.getFiles(stream);
-  const filesPayload = Object.fromEntries(
-    Array.from(filesByRun.entries(), ([runId, rounds]) => [
-      runId,
-      Object.fromEntries(rounds.entries()),
-    ]),
-  );
-  updater.updateFiles(stream, filesPayload);
+  updater.updateFiles(stream, { reset: true });
+};
 
-  const missingByRun = state.outputFiles.getMissingOutputs(stream);
-  const missingPayload = Object.fromEntries(
-    Array.from(missingByRun.entries(), ([runId, rounds]) => [
-      runId,
-      Object.fromEntries(rounds.entries()),
-    ]),
-  );
-  updater.updateMissingOutputs(stream, missingPayload);
+const resetMissingSurface = (
+  state: ProgressViewState,
+  updater: WebviewUpdater,
+  stream: string,
+): void => {
+  if (state.activeStream !== stream || !updater.isAvailable()) {
+    return;
+  }
+
+  updater.updateMissingOutputs(stream, { reset: true });
 };
 
 const registerOutputFileListeners = (
@@ -77,7 +116,8 @@ const registerOutputFileListeners = (
             executionId,
           },
         );
-        updateActiveStreamOutputs(state, updater, stream);
+        const runId = normalizeRunId(executionId ?? groupId);
+        sendRunFileUpdate(state, updater, stream, runId);
       });
     },
   );
@@ -92,7 +132,8 @@ const registerOutputFileListeners = (
           filesByRound,
           { executionId },
         );
-        updateActiveStreamOutputs(state, updater, stream);
+        const runId = normalizeRunId(executionId ?? groupId);
+        sendRunMissingUpdate(state, updater, stream, runId);
       });
     },
   );
@@ -100,14 +141,14 @@ const registerOutputFileListeners = (
   const clearMissing = bus.on('clearMissingOutputs', (stream) => {
     withErrorBoundary('failed to handle clearMissingOutputs', async () => {
       await state.outputFiles.clearMissingOutputs(stream);
-      updateActiveStreamOutputs(state, updater, stream);
+      resetMissingSurface(state, updater, stream);
     });
   });
 
   const clearFiles = bus.on('clearOutputFiles', (stream) => {
     withErrorBoundary('failed to handle clearOutputFiles', async () => {
       await state.outputFiles.clearFiles(stream);
-      updateActiveStreamOutputs(state, updater, stream);
+      resetFileSurface(state, updater, stream);
     });
   });
 

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -167,8 +167,8 @@ export class ProgressEventHandler {
 
     if (!stream) {
       this.webviewUpdater.updateLogContent('', [], []);
-      this.webviewUpdater.updateFiles('', {});
-      this.webviewUpdater.updateMissingOutputs('', {});
+      this.webviewUpdater.updateFiles('', { reset: true });
+      this.webviewUpdater.updateMissingOutputs('', { reset: true });
       this.webviewUpdater.updateUsage('', {});
       this.webviewUpdater.updateStatus(STATUS.READY);
       if (updateInstruction) {
@@ -202,9 +202,23 @@ export class ProgressEventHandler {
     this.webviewUpdater.updateLogContent(stream, messages, groups, {
       runInstructions,
       activeRunId,
-      runFiles: filesByRun,
-      runMissingOutputs: missingByRun,
       runUsage: usageByRun,
+    });
+
+    this.webviewUpdater.updateFiles(stream, { reset: true });
+    Object.entries(filesByRun).forEach(([runId, rounds]) => {
+      this.webviewUpdater.updateFiles(stream, {
+        runId,
+        rounds,
+      });
+    });
+
+    this.webviewUpdater.updateMissingOutputs(stream, { reset: true });
+    Object.entries(missingByRun).forEach(([runId, rounds]) => {
+      this.webviewUpdater.updateMissingOutputs(stream, {
+        runId,
+        rounds,
+      });
     });
 
     // Update status for current stream - default to STOPPED when stream exists but no status is set

--- a/src/progressView/managers/OutputFilesManager.ts
+++ b/src/progressView/managers/OutputFilesManager.ts
@@ -156,6 +156,27 @@ export class OutputFilesManager extends PersistentMapManager<
     return new Map(entries);
   }
 
+  getRunMissingOutputs(
+    stream: StreamTabId,
+    runId: string,
+  ): Map<number, string[]> | undefined {
+    if (!this.missingOutputsLoaded) {
+      throw new Error('Missing outputs requested before load completed');
+    }
+
+    const runs = this._missingOutputs.get(stream);
+    if (!runs) {
+      return undefined;
+    }
+
+    const target = runs.get(runId);
+    if (!target) {
+      return undefined;
+    }
+
+    return new Map(target);
+  }
+
   getRunByExecution(
     stream: StreamTabId,
     executionId: ExecutionId,

--- a/src/progressView/managers/WebviewUpdater.ts
+++ b/src/progressView/managers/WebviewUpdater.ts
@@ -103,8 +103,6 @@ export class WebviewUpdater {
     extras?: {
       runInstructions?: Record<string, InstructionUpdate>;
       activeRunId?: string | null;
-      runFiles?: Record<string, { [key: number]: OutputFileInfo[] }>;
-      runMissingOutputs?: Record<string, { [key: number]: string[] }>;
       runUsage?: Record<string, TokenUsageStats>;
     },
   ): void {
@@ -118,8 +116,6 @@ export class WebviewUpdater {
       groups,
       runInstructions: extras?.runInstructions,
       activeRunId: extras?.activeRunId,
-      runFiles: extras?.runFiles,
-      runMissingOutputs: extras?.runMissingOutputs,
       runUsage: extras?.runUsage,
     });
   }
@@ -157,7 +153,11 @@ export class WebviewUpdater {
    */
   updateFiles(
     stream: StreamTabId,
-    filesByRun: Record<string, { [key: number]: OutputFileInfo[] }>,
+    payload: {
+      runId?: string;
+      rounds?: { [key: number]: OutputFileInfo[] };
+      reset?: boolean;
+    },
   ): void {
     const webview = this.getWebview();
     if (!webview) return;
@@ -165,7 +165,7 @@ export class WebviewUpdater {
     webview.postMessage({
       command: COMMANDS.UPDATE_FILES,
       stream,
-      filesByRun,
+      ...payload,
     });
   }
 
@@ -174,7 +174,11 @@ export class WebviewUpdater {
    */
   updateMissingOutputs(
     stream: StreamTabId,
-    filesByRun: Record<string, { [key: number]: string[] }>,
+    payload: {
+      runId?: string;
+      rounds?: { [key: number]: string[] };
+      reset?: boolean;
+    },
   ): void {
     const webview = this.getWebview();
     if (!webview) return;
@@ -182,7 +186,7 @@ export class WebviewUpdater {
     webview.postMessage({
       command: COMMANDS.UPDATE_MISSING_OUTPUTS,
       stream,
-      filesByRun,
+      ...payload,
     });
   }
 

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -276,20 +276,6 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
           );
         }
 
-        if (message.runFiles) {
-          Object.entries(message.runFiles).forEach(([runId, files]) => {
-            state.setRunFiles(message.stream, runId, files);
-          });
-        }
-
-        if (message.runMissingOutputs) {
-          Object.entries(message.runMissingOutputs).forEach(
-            ([runId, files]) => {
-              state.setRunMissingOutputs(message.stream, runId, files);
-            },
-          );
-        }
-
         if (message.runUsage) {
           Object.entries(message.runUsage).forEach(([runId, usage]) => {
             state.setRunUsage(message.stream, runId, usage);
@@ -494,11 +480,23 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
         return;
       }
 
-      state.clearRunFiles(targetStream);
-      const filesByRun = message.filesByRun || {};
-      Object.entries(filesByRun).forEach(([runId, files]) => {
-        state.setRunFiles(targetStream, runId, files);
-      });
+      if (message.reset) {
+        state.clearRunFiles(targetStream);
+        this._refreshOutputsForActiveRun();
+        return;
+      }
+
+      const runId = message.runId;
+      if (!runId) {
+        return;
+      }
+
+      const rounds = message.rounds;
+      if (!rounds || Object.keys(rounds).length === 0) {
+        state.deleteRunFiles(targetStream, runId);
+      } else {
+        state.setRunFiles(targetStream, runId, rounds);
+      }
       this._refreshOutputsForActiveRun();
     }
   }
@@ -510,11 +508,22 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
         return;
       }
 
-      state.clearRunMissingOutputs(targetStream);
-      const filesByRun = message.filesByRun || {};
-      Object.entries(filesByRun).forEach(([runId, files]) => {
-        state.setRunMissingOutputs(targetStream, runId, files);
-      });
+      if (message.reset) {
+        state.clearRunMissingOutputs(targetStream);
+        return;
+      }
+
+      const runId = message.runId;
+      if (!runId) {
+        return;
+      }
+
+      const rounds = message.rounds;
+      if (!rounds || Object.keys(rounds).length === 0) {
+        state.deleteRunMissingOutputs(targetStream, runId);
+      } else {
+        state.setRunMissingOutputs(targetStream, runId, rounds);
+      }
     }
   }
 

--- a/src/progressView/state/ProgressViewState.ts
+++ b/src/progressView/state/ProgressViewState.ts
@@ -195,9 +195,16 @@ export class ProgressViewState {
     const persist = options?.persist ?? true;
     const preferred = requested ?? null;
 
-    const candidates = this.collectRunCandidates(stream);
+    let candidates: Set<string> | null = null;
+    const ensureCandidates = (): Set<string> => {
+      if (!candidates) {
+        candidates = this.collectRunCandidates(stream);
+      }
+      return candidates;
+    };
+
     if (preferred) {
-      if (!candidates.has(preferred)) {
+      if (!ensureCandidates().has(preferred)) {
         return null;
       }
       if (persist) {
@@ -211,8 +218,9 @@ export class ProgressViewState {
       return current;
     }
 
-    if (candidates.size === 1) {
-      const [only] = Array.from(candidates);
+    const candidateSet = ensureCandidates();
+    if (candidateSet.size === 1) {
+      const only = candidateSet.values().next().value;
       if (only) {
         if (persist) {
           this.setActiveRunId(stream, only);


### PR DESCRIPTION
## Summary
- send run-level output payloads without extra normalization when backend updates fire
- refresh the webview by clearing and replaying run outputs instead of shipping full maps in one message
- trim the webview handlers to respond to run updates and resets without defensive merging logic

## Testing
- npm run format
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69179e39d7988324a5f9d01e1eb47c9a)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Move from bulk maps to per-run incremental updates with reset semantics for files/missing outputs, updating event handlers, webview APIs, and message handling accordingly.
> 
> - **Progress surface refresh**
>   - `updateLogContent` no longer carries `runFiles`/`runMissingOutputs`; files are synced separately.
>   - `refreshStreamSurface` now clears outputs (`reset: true`) then replays per-run `updateFiles`/`updateMissingOutputs` updates.
> - **Events**
>   - Add run-scoped dispatch (`sendRunFileUpdate`, `sendRunMissingUpdate`) and reset helpers in `events/OutputEvents.ts`.
>   - Use `normalizeRunId` to target specific runs on add/update/clear.
> - **Webview API**
>   - Change `WebviewUpdater.updateFiles`/`updateMissingOutputs` to accept `{ runId?, rounds?, reset? }` payloads; remove bulk-by-run args.
>   - Remove `runFiles`/`runMissingOutputs` from `updateLogContent` extras.
> - **Webview message handlers**
>   - Handle `reset` to clear state; apply/dismiss per-run rounds via `runId` + `rounds`; drop defensive merging logic.
> - **Managers/State**
>   - Add `OutputFilesManager.getRunMissingOutputs`.
>   - Minor `ProgressViewState.resolveRunId` optimization to avoid recomputing candidates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1a3b476316ab6d1fad58c3da3bc90f274d9a8ddc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->