### PR TITLE
Fix: rely on usage refresh helper in progress view

### DIFF
--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -335,8 +335,6 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       });
       scrollToBottom(logContent);
 
-      // Recalculate cumulative usage after loading groups
-      dom.usageSummary.update();
       this._refreshInstructionForActiveRun();
       this._refreshOutputsForActiveRun();
       this._refreshUsageForActiveRun();


### PR DESCRIPTION
## Summary
- remove the direct usage summary update from `handleUpdateLogs`
- rely on `_refreshUsageForActiveRun` to refresh totals once after log updates

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917a6fe03cc832491b94ec2dc0dcd2c)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes direct usage summary update during log loading, deferring to `_refreshUsageForActiveRun` to refresh totals after updates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 15075a131dbb9c49a8308375b12bc7cfdc39ee0f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->