### PR TITLE
docs: update changelog for 0.34.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,21 +8,21 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
-- Introduce an `extract_bib_entries` LaTeX tool that gathers the BibTeX records cited in your project—even when they live in explicit `.bib` paths—so agents can flag missing references automatically.
-- Add OpenAI GPT-5.1 (`gpt51`) to the model catalog with documentation on its reasoning mode, apply-patch, and shell tool support, giving you a drop-in alternative to GPT-5 pricing.
+- Added a **Collect references** helper that gathers the BibTeX entries your project cites and calls out anything missing, so you can tidy bibliographies before submitting.
+- Expanded the model catalog with **GPT-5.1** (`gpt51`), offering GPT-5-class reasoning with fresh pricing and full tool support.
 
 ### Improvements
 
-- Make the progress board feel snappier with leaner stream refreshes, faster output file loading, and lighter usage aggregation even on long-running sessions.
-- Smooth out run reviews by persisting per-run progress state, showing timestamps in the run picker, and auto-focusing the follow-up input whenever a run is waiting on you.
-- Treat workspace housekeeping more gently by preserving generated artifacts, keeping `.tex` detection consistent, and rewriting `\input{}` commands without stripping folder prefixes.
+- The progress board now loads conversations faster and keeps stream updates responsive, even for long sessions.
+- Run reviews feel smoother thanks to persistent run context, clearer timestamps, and an input box that’s ready whenever a follow-up is needed.
+- Workspace cleanup is less disruptive: generated artifacts stick around, TeX files are detected more reliably, and `\input{}` paths stay intact.
 
 ### Bug Fixes
 
-- Restore reliable workflow controls: resume and restart buttons are back, recording stops now reset cleanly, and stop acknowledgements are sent only once to avoid stuck captures.
-- Keep the progress board accurate by reloading agent defaults when options disappear, registering task groups before new logs arrive, and routing usage refreshes through the shared helper.
-- Stabilize tool calls so Gemini requests get the right parameters, OpenRouter runs skip redundant uploads, empty tool inputs are ignored, and workflow outputs hydrate without runtime errors.
-- Harden bibliography extraction with stricter regexes, a dedicated BibTeX parser, and safer workspace storage handling so complex citation files parse without crashes.
+- Workflow controls once again behave as expected—resume, restart, and stop actions reliably reflect the state of your run.
+- Progress board summaries stay in sync with agent defaults and usage totals, preventing stale data from lingering between refreshes.
+- Tool calls are steadier across providers, avoiding duplicate uploads, empty payload errors, and missing workflow outputs.
+- Bibliography parsing now handles complex citation files without crashing, keeping reference extraction dependable.
 
 ## [0.34.3] - 2025-11-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,25 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.34.4] - 2025-11-14
+
 ### Features
 
-- Add an `extract_bib_entries` LaTeX tool with shared helpers so agents can gather cited BibTeX records and surface missing files or keys directly in tool responses.
-- Add OpenAI GPT-5.1 (`gpt51`) to the model catalog with docs covering its default `none` reasoning mode, apply-patch and shell tooling support, and drop-in parity with GPT-5 pricing.
+- Introduce an `extract_bib_entries` LaTeX tool that gathers the BibTeX records cited in your project—even when they live in explicit `.bib` paths—so agents can flag missing references automatically.
+- Add OpenAI GPT-5.1 (`gpt51`) to the model catalog with documentation on its reasoning mode, apply-patch, and shell tool support, giving you a drop-in alternative to GPT-5 pricing.
+
+### Improvements
+
+- Make the progress board feel snappier with leaner stream refreshes, faster output file loading, and lighter usage aggregation even on long-running sessions.
+- Smooth out run reviews by persisting per-run progress state, showing timestamps in the run picker, and auto-focusing the follow-up input whenever a run is waiting on you.
+- Treat workspace housekeeping more gently by preserving generated artifacts, keeping `.tex` detection consistent, and rewriting `\input{}` commands without stripping folder prefixes.
+
+### Bug Fixes
+
+- Restore reliable workflow controls: resume and restart buttons are back, recording stops now reset cleanly, and stop acknowledgements are sent only once to avoid stuck captures.
+- Keep the progress board accurate by reloading agent defaults when options disappear, registering task groups before new logs arrive, and routing usage refreshes through the shared helper.
+- Stabilize tool calls so Gemini requests get the right parameters, OpenRouter runs skip redundant uploads, empty tool inputs are ignored, and workflow outputs hydrate without runtime errors.
+- Harden bibliography extraction with stricter regexes, a dedicated BibTeX parser, and safer workspace storage handling so complex citation files parse without crashes.
 
 ## [0.34.3] - 2025-11-07
 


### PR DESCRIPTION
## Summary
- document the 0.34.4 release with the latest user-facing changes since 0.34.3

## Testing
- not run (not needed)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917a82ee7188324b739dff609d3de59)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates CHANGELOG with 0.34.4 features, improvements, and bug fixes, including GPT-5.1 and a references collector.
> 
> - **Docs**:
>   - Update `CHANGELOG.md` with **0.34.4 (2025-11-14)** release notes:
>     - **Features**: Collect references helper; add **GPT-5.1** (`gpt51`) to model catalog.
>     - **Improvements**: Faster progress board; smoother run reviews; less disruptive workspace cleanup.
>     - **Bug Fixes**: Reliable workflow controls; synced progress summaries; steadier tool calls; robust bibliography parsing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d8b8814e38c9cfb6332a7330433cf867e6e36199. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->