### PR TITLE
fix: announce task groups before persistence

### DIFF
--- a/src/progressView/events/TaskGroupEvents.ts
+++ b/src/progressView/events/TaskGroupEvents.ts
@@ -69,14 +69,18 @@ export function createTaskGroupEvents(
         parentGroupId,
       };
 
-      await state.taskGroups.addGroup(stream, groupId, group);
+      const addGroupPromise = state.taskGroups.addGroup(stream, groupId, group);
 
-      if (!parentGroupId) {
-        state.setActiveRunId(stream, groupId);
-      }
+      try {
+        if (!parentGroupId) {
+          state.setActiveRunId(stream, groupId);
+        }
 
-      if (updater.isAvailable() && stream === state.activeStream) {
-        updater.addTaskGroup(stream, group);
+        if (updater.isAvailable() && stream === state.activeStream) {
+          updater.addTaskGroup(stream, group);
+        }
+      } finally {
+        await addGroupPromise;
       }
     });
   };


### PR DESCRIPTION
## Summary
- send addTaskGroup updates to the progress view immediately after creating the group payload
- defer awaiting persistence so log banners are not dropped into the root log when streaming

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917a9ecd4a48324b2c23f033e294cd3)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Send addTaskGroup UI updates and set active run immediately, deferring persistence await.
> 
> - **Progress View events (`src/progressView/events/TaskGroupEvents.ts`)**:
>   - **`handleAddTaskGroup`**:
>     - Defer awaiting `state.taskGroups.addGroup` via `addGroupPromise` and `finally`.
>     - Announce to UI (`updater.addTaskGroup`) and call `state.setActiveRunId` before persistence completes.
>     - Retains stream initialization when missing and conditional updater checks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ce793ec7671ec6810d45b12dbdea1f086d67f68c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->