### PR TITLE
fix: emit stream usage when groups are inactive

### DIFF
--- a/src/agent/utils/UsageMonitor.ts
+++ b/src/agent/utils/UsageMonitor.ts
@@ -91,7 +91,8 @@ export class UsageMonitor {
         }),
       };
 
-      usageReporter.report(payload);
+      const runId = this.context.executionId ?? this.context.streamId;
+      usageReporter.report(payload, runId);
     } catch (error) {
       logger.error(`Error printing statistics: ${error}`);
     }

--- a/src/logger/AgentUsageReporter.ts
+++ b/src/logger/AgentUsageReporter.ts
@@ -20,19 +20,30 @@ export class AgentUsageReporter {
   /**
    * Emit usage data to the progress view and attach detailed stats to the log.
    */
-  public report(stats: ExtendedTokenUsageStats): void {
+  public report(stats: ExtendedTokenUsageStats, runId?: string): void {
+    const usage = {
+      inputTokens: stats.inputTokens + (stats.cacheCreationInputTokens ?? 0),
+      outputTokens: stats.outputTokens,
+      cost: stats.cost,
+    };
+
     const groupId = this.logger.withCurrentGroup((id) => id);
 
     if (groupId) {
       bus.emit('updateGroupUsage', {
         stream: this.streamId,
         groupId,
-        usage: {
-          inputTokens:
-            stats.inputTokens + (stats.cacheCreationInputTokens ?? 0),
-          outputTokens: stats.outputTokens,
-          cost: stats.cost,
-        },
+        usage,
+      });
+      this.logger.statistics(stats, groupId);
+      return;
+    }
+
+    if (runId) {
+      bus.emit('updateStreamUsage', {
+        stream: this.streamId,
+        runId,
+        usage,
       });
     }
 

--- a/src/progressView/events/UsageEvents.ts
+++ b/src/progressView/events/UsageEvents.ts
@@ -227,7 +227,15 @@ export function createUsageEvents(
         'updateStreamUsage',
         ({ stream, usage, runId }) => {
           withErrorBoundary('failed to handle updateStreamUsage', async () => {
-            const targetRunId = resolveTargetRunId(stream, runId, state);
+            const normalizedUsage: TokenUsageStats = {
+              inputTokens: Number(usage.inputTokens ?? 0),
+              outputTokens: Number(usage.outputTokens ?? 0),
+              cost: Number(usage.cost ?? 0),
+            };
+
+            const resolvedRunId = resolveTargetRunId(stream, runId, state);
+            const targetRunId = resolvedRunId ?? runId ?? null;
+
             if (!targetRunId) {
               shared.logger.warn(
                 `Skipping updateStreamUsage for ${stream}: unable to resolve run ID`,
@@ -238,7 +246,11 @@ export function createUsageEvents(
             if (!state.getActiveRunId(stream)) {
               state.setActiveRunId(stream, targetRunId);
             }
-            await state.usageStats.setRunUsage(stream, targetRunId, usage);
+            await state.usageStats.setRunUsage(
+              stream,
+              targetRunId,
+              normalizedUsage,
+            );
             if (state.activeStream === stream && updater.isAvailable()) {
               const usageByRun = Object.fromEntries(
                 state.usageStats.getRunUsage(stream).entries(),

--- a/src/test/logger/AgentUsageReporter.test.ts
+++ b/src/test/logger/AgentUsageReporter.test.ts
@@ -1,0 +1,60 @@
+// Standard library imports
+import { strict as assert } from 'assert';
+
+// Local imports
+import type { ExtendedTokenUsageStats } from '@agent/types/UsageTypes';
+import type { AgentLogger } from '@logger/AgentLogger';
+import { bus } from '@eventBus/ProgressEventBus';
+import { AgentUsageReporter } from '@/logger/AgentUsageReporter';
+
+describe('AgentUsageReporter', () => {
+  it('emits updateStreamUsage when no group is active', () => {
+    const streamId = 'stream:test';
+    const runId = 'run-123';
+    const streamEvents: unknown[] = [];
+    const groupEvents: unknown[] = [];
+    const disposeStream = bus.on('updateStreamUsage', (payload) => {
+      streamEvents.push(payload);
+    });
+    const disposeGroup = bus.on('updateGroupUsage', (payload) => {
+      groupEvents.push(payload);
+    });
+
+    let recordedStats: ExtendedTokenUsageStats | undefined;
+    const loggerStub = {
+      withCurrentGroup: <T,>(_: (groupId: string) => T): T | undefined =>
+        undefined,
+      statistics: (stats: ExtendedTokenUsageStats) => {
+        recordedStats = stats;
+      },
+    } as unknown as AgentLogger;
+
+    const reporter = new AgentUsageReporter(loggerStub, streamId);
+    const stats: ExtendedTokenUsageStats = {
+      inputTokens: 10,
+      outputTokens: 5,
+      cost: 0.25,
+      cacheCreationInputTokens: 4,
+    };
+
+    try {
+      reporter.report(stats, runId);
+
+      assert.equal(groupEvents.length, 0);
+      assert.equal(streamEvents.length, 1);
+      assert.deepEqual(streamEvents[0], {
+        stream: streamId,
+        runId,
+        usage: {
+          inputTokens: 14,
+          outputTokens: 5,
+          cost: 0.25,
+        },
+      });
+      assert.strictEqual(recordedStats, stats);
+    } finally {
+      disposeStream();
+      disposeGroup();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- extend AgentUsageReporter to emit stream usage updates when no group is active
- ensure UsageMonitor forwards execution identifiers so runs without groups still register usage
- normalize stream usage handling in the progress view and cover the regression with a focused unit test

## Testing
- npm run compile-tests
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917b01b1fd883248b00b4beebf11935)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Propagates run IDs to usage reporting, emits stream-level usage when no group is active, normalizes update handling, and adds a targeted unit test.
> 
> - **Usage reporting**:
>   - `UsageMonitor`: forwards `runId` (`executionId` fallback to `streamId`) to `usageReporter.report`.
>   - `AgentUsageReporter`: `report(stats, runId?)` builds normalized `usage` and:
>     - Emits `updateGroupUsage` when a group is active and logs stats with `groupId`.
>     - Else emits `updateStreamUsage` with `runId` and logs stats.
> - **Progress view**:
>   - `UsageEvents.updateStreamUsage`: normalizes `usage` values to numbers, resolves/sets target `runId`, persists via `state.usageStats.setRunUsage`, and updates the webview when active.
> - **Tests**:
>   - Adds `AgentUsageReporter.test.ts` verifying `updateStreamUsage` emission with correct payload when no group is active.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f9c68bd976019acef85db063f345434581f547c9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->