### PR TITLE
refactor: centralize toggle state application

### DIFF
--- a/src/common/modules/toggleStateUtils.js
+++ b/src/common/modules/toggleStateUtils.js
@@ -1,0 +1,110 @@
+// Local imports - common
+
+/**
+ * Tracks boolean toggle states and persists them when requested.
+ */
+export class ToggleStates {
+  constructor(saveCallback) {
+    this.states = new Map();
+    this.saveCallback = saveCallback;
+  }
+
+  set(id, value) {
+    if (!id) {
+      return;
+    }
+
+    this.states.set(id, value);
+    this.saveCallback?.();
+  }
+
+  get(id) {
+    return this.states.get(id);
+  }
+
+  clearSelection(ids) {
+    if (!Array.isArray(ids)) {
+      return;
+    }
+
+    ids.forEach((id) => {
+      if (id) {
+        this.states.delete(id);
+      }
+    });
+
+    this.saveCallback?.();
+  }
+
+  clearAll() {
+    this.states.clear();
+    this.saveCallback?.();
+  }
+
+  entries() {
+    return [...this.states.entries()];
+  }
+
+  load(data) {
+    this.states = new Map(data);
+  }
+}
+
+/**
+ * Applies `open` attributes to DOM elements resolved from a map of ids.
+ * @param {Map<string, boolean>|Array<[string, any]>} stateMap
+ * @param {(id: string) => string} selectorFormatter
+ * @param {(value: any, id: string) => boolean} [valueToOpenState]
+ */
+export function applyOpenStates(
+  stateMap,
+  selectorFormatter,
+  valueToOpenState = (value) => Boolean(value),
+) {
+  if (typeof selectorFormatter !== 'function') {
+    return;
+  }
+
+  const entries =
+    stateMap instanceof Map
+      ? stateMap.entries()
+      : Array.isArray(stateMap)
+        ? stateMap
+        : (stateMap ?? []);
+
+  for (const entry of entries) {
+    if (!entry) {
+      continue;
+    }
+
+    const [id, value] = entry;
+    if (!id) {
+      continue;
+    }
+
+    const selector = selectorFormatter(id);
+    if (!selector) {
+      continue;
+    }
+
+    const element = document.querySelector(selector);
+    if (!(element instanceof HTMLElement)) {
+      continue;
+    }
+
+    const isOpen = valueToOpenState(value, id);
+    if (typeof isOpen !== 'boolean') {
+      continue;
+    }
+
+    if ('open' in element) {
+      element.open = isOpen;
+    }
+
+    if (isOpen) {
+      element.setAttribute('open', '');
+    } else {
+      element.removeAttribute('open');
+    }
+  }
+}

--- a/src/common/webview/BaseViewContentProvider.ts
+++ b/src/common/webview/BaseViewContentProvider.ts
@@ -160,6 +160,10 @@ export abstract class BaseViewContentProvider {
         'modules/RecordingButtonManager.js',
       ),
       textareaUtilsUri: this.getCommonUri(webview, 'modules/textareaUtils.js'),
+      toggleStateUtilsUri: this.getCommonUri(
+        webview,
+        'modules/toggleStateUtils.js',
+      ),
       htmlEncodingUri: this.getCommonUri(webview, 'modules/htmlEncoding.js'),
       iconConstantsUri: this.getCommonUri(webview, 'modules/iconConstants.js'),
       baseWebviewMessageHandlerUri: this.getCommonUri(

--- a/src/historyView/index.html
+++ b/src/historyView/index.html
@@ -34,6 +34,7 @@
           "@common/webviewContext.js": "${webviewContextUri}",
           "@common/domUtils.js": "${domUtilsUri}",
           "@common/templateUtils.js": "${templateUtilsUri}",
+          "@common/modules/toggleStateUtils.js": "${toggleStateUtilsUri}",
           "@common/htmlEncoding.js": "${htmlEncodingUri}",
           "@common/BaseWebviewMessageHandler.js": "${baseWebviewMessageHandlerUri}",
           "@common/BaseDomHandler.js": "${baseDomHandlerUri}",

--- a/src/historyView/modules/historyViewState.js
+++ b/src/historyView/modules/historyViewState.js
@@ -1,35 +1,6 @@
 // Local imports - history view
 import { WebviewStateManager } from '@common/webviewState.js';
-
-class ToggleStates {
-  constructor(saveCallback) {
-    this.states = new Map();
-    this.saveCallback = saveCallback;
-  }
-
-  set(id, expanded) {
-    if (!id) return;
-    this.states.set(id, expanded);
-    if (this.saveCallback) this.saveCallback();
-  }
-
-  get(id) {
-    return this.states.get(id);
-  }
-
-  entries() {
-    return [...this.states.entries()];
-  }
-
-  load(data) {
-    this.states = new Map(data);
-  }
-
-  clearAll() {
-    this.states.clear();
-    if (this.saveCallback) this.saveCallback();
-  }
-}
+import { ToggleStates } from '@common/modules/toggleStateUtils.js';
 
 export class HistoryViewState {
   constructor() {

--- a/src/historyView/modules/uiManagers/HistoryRenderer.js
+++ b/src/historyView/modules/uiManagers/HistoryRenderer.js
@@ -7,6 +7,7 @@ import {
 } from '@common/domUtils.js';
 import { createFromTemplate, createCodicon } from '@common/templateUtils.js';
 import { encodeHtml, encodeListForHtml } from '@common/htmlEncoding.js';
+import { applyOpenStates } from '@common/modules/toggleStateUtils.js';
 // Local imports
 import { vscode } from '@common/webviewContext.js';
 
@@ -254,21 +255,10 @@ export class HistoryRenderer {
 
   applyToggleStates() {
     const entries = historyViewState.toggleStates.entries();
-    for (const [id, expanded] of entries) {
-      const collapsible = document.querySelector(
-        `.${CLASS_NAMES.HISTORY_COLLAPSIBLE}[data-id="${id}"]`,
-      );
-      if (!collapsible) {
-        continue;
-      }
-      if ('open' in collapsible) {
-        collapsible.open = Boolean(expanded);
-      }
-      if (expanded) {
-        collapsible.setAttribute('open', '');
-      } else {
-        collapsible.removeAttribute('open');
-      }
-    }
+    applyOpenStates(entries, (id) => {
+      const safeId =
+        typeof id === 'string' ? (CSS?.escape?.(id) ?? id) : String(id);
+      return `.${CLASS_NAMES.HISTORY_COLLAPSIBLE}[data-id="${safeId}"]`;
+    });
   }
 }

--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -58,6 +58,7 @@
           "@common/templateUtils.js": "${templateUtilsUri}",
           "@common/RecordingButtonManager.js": "${recordingButtonManagerUri}",
           "@common/textareaUtils.js": "${textareaUtilsUri}",
+          "@common/modules/toggleStateUtils.js": "${toggleStateUtilsUri}",
           "@common/htmlEncoding.js": "${htmlEncodingUri}",
           "@common/domUtils.js": "${domUtilsUri}",
           "@common/BaseDomHandler.js": "${baseDomHandlerUri}",

--- a/src/progressView/modules/progressViewState.js
+++ b/src/progressView/modules/progressViewState.js
@@ -1,6 +1,7 @@
 // Local imports - progress view
 // Local imports - state management helper
 import { WebviewStateManager } from '@common/webviewState.js';
+import { ToggleStates } from '@common/modules/toggleStateUtils.js';
 
 /**
  * Manages task groups in the progress view.
@@ -140,52 +141,6 @@ class TaskGroups {
     if (children.size === 0) {
       this.childrenByParent.delete(parentId);
     }
-  }
-}
-
-/**
- * Manages group toggle states with persistence.
- */
-class ToggleStates {
-  constructor(saveCallback) {
-    this.states = new Map();
-    this.saveCallback = saveCallback;
-  }
-
-  set(id, collapsed) {
-    this.states.set(id, collapsed);
-    this.saveCallback?.();
-  }
-
-  get(id) {
-    return this.states.get(id);
-  }
-
-  clearSelection(ids) {
-    if (!Array.isArray(ids)) {
-      return;
-    }
-    ids.forEach((id) => {
-      if (id) {
-        this.states.delete(id);
-      }
-    });
-    this.saveCallback?.();
-  }
-
-  clearAll() {
-    this.states.clear();
-    this.saveCallback?.();
-  }
-
-  /** Get all entries for serialization */
-  entries() {
-    return [...this.states.entries()];
-  }
-
-  /** Load from serialized data */
-  load(data) {
-    this.states = new Map(data);
   }
 }
 

--- a/src/progressView/modules/uiManagers/EventsManager.js
+++ b/src/progressView/modules/uiManagers/EventsManager.js
@@ -9,6 +9,7 @@ import {
   setChevronIconHorizontal,
 } from '@common/domUtils.js';
 import { vscode } from '@common/webviewContext.js';
+import { applyOpenStates } from '@common/modules/toggleStateUtils.js';
 
 /**
  * Manages event handling and state application.
@@ -18,17 +19,16 @@ export class EventsManager {
    * Apply saved toggle states to any groups already in the DOM
    */
   applyToggleStates() {
-    const taskGroups = progressViewState.taskGroups.getGroupMap();
-    for (const [groupId] of taskGroups) {
-      const isCollapsed = progressViewState.toggleStates.get(groupId);
-      const detailsElem = document.getElementById(
-        `${GROUP_DOM_IDS.DETAILS_PREFIX}${groupId}`,
-      );
-
-      if (detailsElem && isCollapsed !== undefined) {
-        detailsElem.open = !isCollapsed;
-      }
-    }
+    const entries = progressViewState.toggleStates.entries();
+    applyOpenStates(
+      entries,
+      (id) => {
+        const safeId =
+          typeof id === 'string' ? (CSS?.escape?.(id) ?? id) : String(id);
+        return `#${GROUP_DOM_IDS.DETAILS_PREFIX}${safeId}`;
+      },
+      (isCollapsed) => !isCollapsed,
+    );
   }
 
   /**


### PR DESCRIPTION
## Summary
- add a shared toggle state utility with a helper for applying open attributes
- switch the history and progress views to use the shared helper
- expose the new module through the common webview import maps

## Testing
- npm run format
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917ca8fa498832481bdcd6b0951a3a6)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds shared toggle state utilities and updates history/progress views to use them, exposing the module via common webview import maps.
> 
> - **Common**:
>   - Add `modules/toggleStateUtils.js` with `ToggleStates` and `applyOpenStates` utilities.
> - **Webview plumbing**:
>   - Expose `@common/modules/toggleStateUtils.js` via `BaseViewContentProvider` and import maps in `historyView/index.html` and `progressView/index.html`.
> - **History View**:
>   - Replace local toggle state class with shared `ToggleStates` in `historyViewState.js`.
>   - Use `applyOpenStates` in `HistoryRenderer.applyToggleStates` to set `open` on collapsibles.
> - **Progress View**:
>   - Replace local toggle state class with shared `ToggleStates` in `progressViewState.js`.
>   - Use `applyOpenStates` in `EventsManager.applyToggleStates` (mapping collapsed->open).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a2826d0a6cbfa3df9ff942089b8e5a616f7a6c0b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->