### PR TITLE
refactor: modernize Zod v4 schemas and TypeScript patterns

### DIFF
--- a/src/agent/core/AgentConfig.ts
+++ b/src/agent/core/AgentConfig.ts
@@ -40,7 +40,7 @@ const stringArrayField = () =>
     .transform((value) => value ?? []);
 
 const AgentConfigBaseSchema = z
-  .object({
+  .strictObject({
     model: z.string().prefault('gemini25p'),
     agent: z.string().prefault('correct'),
     instruction: z.string().prefault(''),

--- a/src/agent/core/AgentDataclass.ts
+++ b/src/agent/core/AgentDataclass.ts
@@ -193,7 +193,7 @@ export function hasEndTag(
 /** Zod schema for AgentPrompt validation */
 const promptEntrySchema = z.union([z.string(), z.array(z.string())]);
 
-export const AgentPromptSchema = z.object({
+export const AgentPromptSchema = z.strictObject({
   systemPrompt: z.string().prefault(''),
   userPrefix: z.string().prefault(''),
   userRequest: promptEntrySchema.prefault(''),

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -1174,7 +1174,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
       this.logger.debug('End tag detected - skipping continuation');
       // this is suspicious, because the two conflicts!!! we should check
       if (lastMessage && Array.isArray(lastMessage.content)) {
-        const lastContent = lastMessage.content[lastMessage.content.length - 1];
+        const lastContent = lastMessage.content.at(-1);
         if (lastContent && lastContent.type === 'text') {
           lastContent.text = fileContent;
         }

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -889,7 +889,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
       workspaceState.assembly.updateAccumulatedOutput(prefill);
 
       // Add pseudo-prefill instruction instead of skipping it
-      const lastMessage = messages[messages.length - 1];
+      const lastMessage = messages.at(-1);
       const pseudoPrefillMsg = `Organize your response with XML tags. Start your response with:\n${prefill}`;
 
       if (lastMessage) {

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -1011,7 +1011,7 @@ export class ModelHandlerOpenAI extends ModelHandler<
       this.logger.debug('End tag detected - skipping continuation');
       if (lastMessage && Array.isArray(lastMessage.content)) {
         // this is suspicious, because the two conflicts!!!
-        const lastPart = lastMessage.content[lastMessage.content.length - 1];
+        const lastPart = lastMessage.content.at(-1);
         if (lastPart && 'text' in lastPart) {
           lastPart.text = fileContent;
         }

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -836,7 +836,7 @@ export class ModelHandlerOpenAI extends ModelHandler<
         }
 
         // For usage, we'll use empty values since they're not provided; TODO needs to test at some points
-        const usage = responseObject.usage || {
+        const usage = responseObject.usage ?? {
           prompt_tokens: 0,
           completion_tokens: 0,
         };

--- a/src/agent/modelHandlers/support/MediaAttachmentProcessor.ts
+++ b/src/agent/modelHandlers/support/MediaAttachmentProcessor.ts
@@ -4,6 +4,7 @@ import { Buffer } from 'buffer';
 
 // Local imports - agent utils
 import { MediaEntry } from '@agent/utils/mediaTypes';
+import { toErrorMessage } from '@common/errors/errorHandlingUtils';
 import { getSdkErrorMessage } from '@common/errors/sdkErrorUtils';
 import {
   countPdfPages,
@@ -209,7 +210,7 @@ export class MediaAttachmentProcessor {
       const stats = await AbsoluteFS.stat(absolutePath);
       fileSize = stats.size;
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
+      const message = toErrorMessage(err);
       this.logger.error(
         `Unable to read file info for ${mediaFile}: ${message}`,
       );

--- a/src/agent/output/LatexDiffManager.ts
+++ b/src/agent/output/LatexDiffManager.ts
@@ -4,6 +4,7 @@ import * as path from 'path';
 
 // Local imports - agent
 import { AgentWorkflowSetting } from '@agent/core/AgentDataclass';
+import { toErrorMessage } from '@common/errors/errorHandlingUtils';
 import { AgentLogger, type AgentLogStage } from '@logger/AgentLogger';
 import { MESSAGE_TYPES } from '@logger/messageTypes';
 import { getConfig } from '@utils/config';
@@ -139,9 +140,7 @@ export class LatexDiffManager {
       await this.fileService.mirrorWorkspaceFile(target);
     } catch (error) {
       this.logger.warn(
-        `Unable to mirror workspace dependency ${target}: ${
-          error instanceof Error ? error.message : String(error)
-        }`,
+        `Unable to mirror workspace dependency ${target}: ${toErrorMessage(error)}`,
         undefined,
         MESSAGE_TYPES.INTERNAL,
       );
@@ -428,7 +427,7 @@ export class LatexDiffManager {
       }
     } catch (err) {
       this.logger.error(
-        `Error during latexdiff processing: ${err instanceof Error ? err.message : String(err)}`,
+        `Error during latexdiff processing: ${toErrorMessage(err)}`,
         undefined,
         MESSAGE_TYPES.INTERNAL,
       );

--- a/src/agent/output/OutputHandler.ts
+++ b/src/agent/output/OutputHandler.ts
@@ -15,6 +15,7 @@ import {
 } from '@agent/core/AgentDataclass';
 import { AgentRunState, ConversationRoundState } from '@agent/core/AgentState';
 import { getOutputFileName } from '@agent/utils/outputFileUtils';
+import { toErrorMessage } from '@common/errors/errorHandlingUtils';
 import { openBuildDisplayIfTex } from '@frontend/latex/openBuild';
 import { showInstructionWithSuppress } from '@frontend/ui/instruction';
 import { AgentLogger, type AgentLogStage } from '@logger/AgentLogger';
@@ -952,7 +953,7 @@ export class OutputHandler implements IOutputHandler {
             }
           } catch (err) {
             this.logger.debug(
-              `Error processing output files: ${err instanceof Error ? err.message : String(err)}`,
+              `Error processing output files: ${toErrorMessage(err)}`,
               undefined,
               MESSAGE_TYPES.INTERNAL,
             );
@@ -1060,7 +1061,7 @@ export class OutputHandler implements IOutputHandler {
             );
           } catch (err) {
             this.logger.debug(
-              `Error processing output file: ${err instanceof Error ? err.message : String(err)}`,
+              `Error processing output file: ${toErrorMessage(err)}`,
               undefined,
               MESSAGE_TYPES.INTERNAL,
             );

--- a/src/agent/output/OutputHandler.ts
+++ b/src/agent/output/OutputHandler.ts
@@ -193,9 +193,7 @@ export class OutputHandler implements IOutputHandler {
       await this.runPreparation;
     } catch (error) {
       this.logger.debug(
-        `Failed to prepare run workspace: ${
-          error instanceof Error ? error.message : String(error)
-        }`,
+        `Failed to prepare run workspace: ${toErrorMessage(error)}`,
         undefined,
         MESSAGE_TYPES.INTERNAL,
       );
@@ -325,9 +323,7 @@ export class OutputHandler implements IOutputHandler {
         }
       } catch (error) {
         this.logger.debug(
-          `Failed to remove latexindent backup ${relative}: ${
-            error instanceof Error ? error.message : String(error)
-          }`,
+          `Failed to remove latexindent backup ${relative}: ${toErrorMessage(error)}`,
         );
       }
     }
@@ -679,9 +675,7 @@ export class OutputHandler implements IOutputHandler {
       } catch (error) {
         throw Object.assign(
           new Error(
-            `Failed to relocate processed output ${entry.location.absolutePath}: ${
-              error instanceof Error ? error.message : String(error)
-            }`,
+            `Failed to relocate processed output ${entry.location.absolutePath}: ${toErrorMessage(error)}`,
           ),
           { cause: error },
         );
@@ -821,9 +815,7 @@ export class OutputHandler implements IOutputHandler {
             );
           } catch (error) {
             this.logger.error(
-              `Expected output validation failed after round ${currRound}: ${
-                error instanceof Error ? error.message : String(error)
-              }`,
+              `Expected output validation failed after round ${currRound}: ${toErrorMessage(error)}`,
             );
           }
         }
@@ -845,9 +837,7 @@ export class OutputHandler implements IOutputHandler {
             this.openedOutputs.add(filePath);
           } catch (error) {
             this.logger.error(
-              `Failed to open output file ${filePath}: ${
-                error instanceof Error ? error.message : String(error)
-              }`,
+              `Failed to open output file ${filePath}: ${toErrorMessage(error)}`,
             );
           }
         }
@@ -1206,9 +1196,7 @@ export class OutputHandler implements IOutputHandler {
         };
       } catch (error) {
         this.logger.debug(
-          `Failed to collect XML summary for round ${round}: ${
-            error instanceof Error ? error.message : String(error)
-          }`,
+          `Failed to collect XML summary for round ${round}: ${toErrorMessage(error)}`,
           undefined,
           MESSAGE_TYPES.INTERNAL,
         );

--- a/src/agent/output/XmlOutputManager.ts
+++ b/src/agent/output/XmlOutputManager.ts
@@ -9,6 +9,7 @@ import type { AgentConfig } from '@agent/core/AgentConfig';
 // Internal imports
 import { AgentSetting } from '@agent/core/AgentDataclass';
 import { getOutputFileName } from '@agent/utils/outputFileUtils';
+import { toErrorMessage } from '@common/errors/errorHandlingUtils';
 import { AgentLogger } from '@logger/AgentLogger';
 import { MESSAGE_TYPES } from '@logger/messageTypes';
 import {
@@ -220,7 +221,7 @@ export class XmlOutputManager {
       return [];
     } catch (err) {
       this.logger.debug(
-        `Failed to parse XML content: ${err instanceof Error ? err.message : String(err)}, attempting fallback extraction...`,
+        `Failed to parse XML content: ${toErrorMessage(err)}, attempting fallback extraction...`,
         undefined,
         MESSAGE_TYPES.INTERNAL,
       );

--- a/src/agent/runtime/agentLoad.ts
+++ b/src/agent/runtime/agentLoad.ts
@@ -16,6 +16,7 @@ import {
   parseAgentSetting,
 } from '@agent/core/AgentDataclass';
 import { resolveAgentDefinitionInDirectory } from '@agent/utils/agentPathResolver';
+import { toErrorMessage } from '@common/errors/errorHandlingUtils';
 import * as logger from '@logger/logUtils';
 
 // Type imports
@@ -87,7 +88,7 @@ export function notifyYamlLoadFailure(
 
   void vscode.window
     .showErrorMessage(
-      `Error loading YAML file ${absolutePath}: ${error instanceof Error ? error.message : String(error)}`,
+      `Error loading YAML file ${absolutePath}: ${toErrorMessage(error)}`,
       moreInfo,
       openFile,
     )
@@ -226,7 +227,7 @@ export async function loadAgentSettingAndPrompts(
     return [settings as AgentSetting, prompts as AgentPrompt];
   } catch (err) {
     vscode.window.showErrorMessage(
-      `Error loading agent settings and prompts: ${err instanceof Error ? err.message : String(err)}`,
+      `Error loading agent settings and prompts: ${toErrorMessage(err)}`,
     );
     throw err;
   }
@@ -250,7 +251,7 @@ export async function isValidAgentYaml(
   } catch (err) {
     logger.debug(
       CHANNEL,
-      `isValidAgentYaml check failed for ${filePath}: ${err instanceof Error ? err.message : String(err)}`,
+      `isValidAgentYaml check failed for ${filePath}: ${toErrorMessage(err)}`,
     );
   }
   return null;

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -508,9 +508,7 @@ export async function executeAgentWithLogging<T extends IAgent>(
             { skip: isResume },
           );
         } catch (err) {
-          logger.error(
-            `Task initialization failed: ${toErrorMessage(err)}`,
-          );
+          logger.error(`Task initialization failed: ${toErrorMessage(err)}`);
           throw err;
         }
 
@@ -524,9 +522,7 @@ export async function executeAgentWithLogging<T extends IAgent>(
           logger.debug(`Task completed successfully`);
           StreamStatusService.set(activeStreamId, 'stopped');
         } catch (err) {
-          logger.error(
-            `Task failed: ${toErrorMessage(err)}`,
-          );
+          logger.error(`Task failed: ${toErrorMessage(err)}`);
           StreamStatusService.set(activeStreamId, 'error');
           throw err;
         }

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -34,6 +34,7 @@ import {
   type AgentDefinitionSearchOptions,
   type AgentDirectoryCandidate,
 } from '@agent/utils/agentPathResolver';
+import { toErrorMessage } from '@common/errors/errorHandlingUtils';
 import { formatProviderHttpError } from '@common/errors/sdkErrorUtils';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands';
 import { agentDirectories } from '@frontend/agents/AgentDirectoryManager';
@@ -124,7 +125,7 @@ export async function getAgentPath(
     const errorMsg = `Could not find yaml file for agent: ${agentName}`;
     throw new Error(errorMsg);
   } catch (err) {
-    const errorMsg = `Error finding agent path: ${err instanceof Error ? err.message : String(err)}`;
+    const errorMsg = `Error finding agent path: ${toErrorMessage(err)}`;
     // Don't show error notification for missing YAML files - we handle it with banner
     if (!err?.toString().includes('Could not find yaml file for agent')) {
       vscode.window.showErrorMessage(errorMsg);
@@ -508,7 +509,7 @@ export async function executeAgentWithLogging<T extends IAgent>(
           );
         } catch (err) {
           logger.error(
-            `Task initialization failed: ${err instanceof Error ? err.message : String(err)}`,
+            `Task initialization failed: ${toErrorMessage(err)}`,
           );
           throw err;
         }
@@ -524,7 +525,7 @@ export async function executeAgentWithLogging<T extends IAgent>(
           StreamStatusService.set(activeStreamId, 'stopped');
         } catch (err) {
           logger.error(
-            `Task failed: ${err instanceof Error ? err.message : String(err)}`,
+            `Task failed: ${toErrorMessage(err)}`,
           );
           StreamStatusService.set(activeStreamId, 'error');
           throw err;
@@ -534,7 +535,7 @@ export async function executeAgentWithLogging<T extends IAgent>(
     );
   } catch (err) {
     const formattedError = formatProviderHttpError(err);
-    const rawErrorMessage = err instanceof Error ? err.message : String(err);
+    const rawErrorMessage = toErrorMessage(err);
     const errorMsg = `Error executing agent ${agentName}: ${formattedError.message}`;
     const errorData = { ...formattedError, rawMessage: rawErrorMessage };
 

--- a/src/agent/types/DiffTypes.ts
+++ b/src/agent/types/DiffTypes.ts
@@ -4,7 +4,7 @@
 // Third-party imports
 import { z } from 'zod';
 
-export const DiffStatsSchema = z.object({
+export const DiffStatsSchema = z.strictObject({
   /** Number of added lines */
   added: z.number().optional(),
   /** Number of removed lines */

--- a/src/agent/types/ResultTypes.ts
+++ b/src/agent/types/ResultTypes.ts
@@ -4,7 +4,7 @@
 // Third-party imports
 import { z } from 'zod';
 
-export const ExecResultSchema = z.object({
+export const ExecResultSchema = z.strictObject({
   /** Indicates whether the command succeeded */
   success: z.boolean(),
   /** Standard output from the command, if available */
@@ -19,7 +19,7 @@ export type ExecResult = z.infer<typeof ExecResultSchema>;
 
 export type FileOpStatus = 'success' | 'noFiles' | 'missingParams' | 'error';
 
-export const FileOpResultSchema = z.object({
+export const FileOpResultSchema = z.strictObject({
   /** Outcome of the pack or clean operation */
   status: z.union([
     z.literal('success'),

--- a/src/agent/types/UsageTypes.ts
+++ b/src/agent/types/UsageTypes.ts
@@ -4,7 +4,7 @@
 // Third-party imports
 import { z } from 'zod';
 
-export const TokenUsageStatsSchema = z.object({
+export const TokenUsageStatsSchema = z.strictObject({
   /** Number of input tokens consumed */
   inputTokens: z.number(),
   /** Number of output tokens generated */
@@ -36,13 +36,10 @@ export interface ExtendedTokenUsageStats extends TokenUsageStats {
 /**
  * Message interface for updating usage stats in the progress view.
  */
-export const StreamUsageMessageSchema = z.object({
+export const StreamUsageMessageSchema = z.strictObject({
   command: z.literal('updateUsage'),
   stream: z.string(),
-  usageByRun: z
-    .record(z.string(), TokenUsageStatsSchema)
-    .default({})
-    .optional(),
+  usageByRun: z.record(z.string(), TokenUsageStatsSchema).prefault({}),
 });
 
 export type StreamUsageMessage = z.infer<typeof StreamUsageMessageSchema>;

--- a/src/agent/utils/UsageMonitor.ts
+++ b/src/agent/utils/UsageMonitor.ts
@@ -1,6 +1,8 @@
 // Local imports - agent
 import type { IModelHandler } from '@agent/modelHandlers';
 
+// Local imports - common
+
 // Internal imports
 import { AgentRunState } from '@agent/core/AgentState';
 // Type imports
@@ -10,6 +12,7 @@ import type {
 } from '@agent/types/UsageTypes';
 // Internal imports
 import { AgentExecutionContext } from '@agent/runtime/AgentExecutionContext';
+import { toErrorMessage } from '@common/errors/errorHandlingUtils';
 
 /**
  * Handles recording usage statistics to the log and progress view.
@@ -43,7 +46,7 @@ export class UsageMonitor {
         } catch (error) {
           logger.debug(
             `Failed to compute ${runKind} cost for round ${snapshot.round}: ${
-              error instanceof Error ? error.message : String(error)
+              toErrorMessage(error)
             }`,
           );
           return runningTotal;

--- a/src/agent/utils/promptUtils.ts
+++ b/src/agent/utils/promptUtils.ts
@@ -8,6 +8,7 @@ import * as nunjucks from 'nunjucks';
 import type { ExecutionId } from '@agent/types/IdentifierTypes';
 
 // Local imports - log
+import { toErrorMessage } from '@common/errors/errorHandlingUtils';
 import * as logger from '@logger/logUtils';
 import {
   StorageFS,
@@ -30,10 +31,7 @@ export async function getXmlFormatFromFile(file: string): Promise<string> {
     const content = await WorkspaceFS.read(file);
     return `<document name="${file}">\n${content}\n</document>`;
   } catch (err) {
-    logger.error(
-      CHANNEL,
-      `Error formatting file as XML: ${err instanceof Error ? err.message : String(err)}`,
-    );
+    logger.error(CHANNEL, `Error formatting file as XML: ${toErrorMessage(err)}`);
     throw err;
   }
 }
@@ -57,7 +55,7 @@ export async function getXmlFormatFromFiles(
   } catch (err) {
     logger.error(
       CHANNEL,
-      `Error formatting files as XML: ${err instanceof Error ? err.message : String(err)}`,
+      `Error formatting files as XML: ${toErrorMessage(err)}`,
     );
     throw err;
   }
@@ -79,10 +77,7 @@ export function getListOfFiles(files: string[] | null | undefined): string {
       )
       .join(', ');
   } catch (err) {
-    logger.error(
-      CHANNEL,
-      `Error creating file list: ${err instanceof Error ? err.message : String(err)}`,
-    );
+    logger.error(CHANNEL, `Error creating file list: ${toErrorMessage(err)}`);
     throw err;
   }
 }
@@ -127,10 +122,7 @@ export async function renderPrompt(
     const renderedPrompt = env.renderString(prompt, resolvedVariables);
     return renderedPrompt;
   } catch (err) {
-    logger.error(
-      CHANNEL,
-      `Error rendering prompt: ${err instanceof Error ? err.message : String(err)}`,
-    );
+    logger.error(CHANNEL, `Error rendering prompt: ${toErrorMessage(err)}`);
     throw err;
   }
 }
@@ -184,7 +176,7 @@ export async function writePromptToXml(
   } catch (err) {
     logger.error(
       CHANNEL,
-      `Error writing prompt to XML: ${err instanceof Error ? err.message : String(err)}`,
+      `Error writing prompt to XML: ${toErrorMessage(err)}`,
     );
     throw err;
   }

--- a/src/agent/utils/text/repetitionUtils.ts
+++ b/src/agent/utils/text/repetitionUtils.ts
@@ -3,6 +3,7 @@ import { diff_match_patch } from 'diff-match-patch';
 import * as difflib from 'difflib';
 
 // Local imports - logging
+import { toErrorMessage } from '@common/errors/errorHandlingUtils';
 import * as logger from '@logger/logUtils';
 import {
   REPETITION_DETECTION_THRESHOLD,
@@ -66,7 +67,7 @@ export function checkForMassiveRepetition(
   } catch (err) {
     logger.error(
       CHANNEL,
-      `Error checking repetition with DMP: ${err instanceof Error ? err.message : String(err)}`,
+      `Error checking repetition with DMP: ${toErrorMessage(err)}`,
     );
     throw err;
   }
@@ -113,7 +114,7 @@ export function checkRepetitionDifflib(
   } catch (err) {
     logger.error(
       CHANNEL,
-      `Error checking repetition with difflib: ${err instanceof Error ? err.message : String(err)}`,
+      `Error checking repetition with difflib: ${toErrorMessage(err)}`,
     );
     throw err;
   }

--- a/src/commands/agent/agentCreatorCommands.ts
+++ b/src/commands/agent/agentCreatorCommands.ts
@@ -4,6 +4,7 @@ import * as vscode from 'vscode';
 
 // Local imports - agent runtime
 import { validateAgentYamlContent } from '@agent/runtime/agentLoad';
+import { toErrorMessage } from '@common/errors/errorHandlingUtils';
 import { SecretManager } from '@frontend/secretManager';
 import { agentDirectories } from '@frontend/agents/AgentDirectoryManager';
 import { promptToAddAgentToConfig } from '@frontend/agents/register';
@@ -172,7 +173,7 @@ function validateAgentYamlString(content: string): string | null {
     validateAgentYamlContent(content);
     return null;
   } catch (err) {
-    return err instanceof Error ? err.message : String(err);
+    return toErrorMessage(err);
   }
 }
 
@@ -288,10 +289,7 @@ async function handleCreateAgentWithAI(_context: vscode.ExtensionContext) {
         }
       }
     } catch (err) {
-      logger.error(
-        CHANNEL,
-        `AI generation failed: ${err instanceof Error ? err.message : String(err)}`,
-      );
+      logger.error(CHANNEL, `AI generation failed: ${toErrorMessage(err)}`);
     }
 
     if (!yamlContent) {
@@ -319,12 +317,9 @@ async function handleCreateAgentWithAI(_context: vscode.ExtensionContext) {
     const doc = await vscode.workspace.openTextDocument(filePath);
     await vscode.window.showTextDocument(doc);
   } catch (err) {
-    logger.error(
-      CHANNEL,
-      `Error creating agent: ${err instanceof Error ? err.message : String(err)}`,
-    );
+    logger.error(CHANNEL, `Error creating agent: ${toErrorMessage(err)}`);
     vscode.window.showErrorMessage(
-      `Failed to create agent: ${err instanceof Error ? err.message : 'Unknown error'}`,
+      `Failed to create agent: ${toErrorMessage(err)}`,
     );
   }
 }

--- a/src/commands/files/openFileCommands.ts
+++ b/src/commands/files/openFileCommands.ts
@@ -1,6 +1,9 @@
 // Third-party imports
 import * as vscode from 'vscode';
 
+// Local imports - common
+import { toErrorMessage } from '@common/errors/errorHandlingUtils';
+
 // Local imports - utilities
 import { openBuildDisplayIfTex } from '@frontend/latex/openBuild';
 import { fileLister } from '@frontend/files/fileLister';
@@ -39,7 +42,7 @@ export async function openLabel(label: string): Promise<void> {
     } catch (error) {
       // Log but continue search - file might be inaccessible
       console.debug(
-        `Could not read file ${file}: ${error instanceof Error ? error.message : error}`,
+        `Could not read file ${file}: ${toErrorMessage(error)}`,
       );
     }
   }

--- a/src/commands/history/stateRestoreCommand.ts
+++ b/src/commands/history/stateRestoreCommand.ts
@@ -2,7 +2,10 @@
 import * as vscode from 'vscode';
 
 // Local imports - log
-import { showLoggedErrorMessage } from '@common/errors/errorHandlingUtils';
+import {
+  showLoggedErrorMessage,
+  toErrorMessage,
+} from '@common/errors/errorHandlingUtils';
 import * as logger from '@logger/logUtils';
 // Type imports
 import type { TaskState } from '@logger/TaskState';
@@ -56,7 +59,7 @@ async function restoreState(state: TaskState) {
     } catch (error) {
       logger.warn(
         CHANNEL,
-        `Could not access webview directly: ${error instanceof Error ? error.message : String(error)}`,
+        `Could not access webview directly: ${toErrorMessage(error)}`,
       );
 
       await storeStateForLater(state);

--- a/src/commands/latex/compareCommands.ts
+++ b/src/commands/latex/compareCommands.ts
@@ -5,6 +5,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 
 // Local imports - log
+import { toErrorMessage } from '@common/errors/errorHandlingUtils';
 import { registerDiffRefresh } from '@frontend/ui/diffView';
 import * as logger from '@logger/logUtils';
 import { flexibleFS } from '@utils/files';
@@ -75,7 +76,7 @@ async function handleCompare(
         await vscode.commands.executeCommand('workbench.action.closePanel');
       }
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
+      const message = toErrorMessage(err);
       if (message.includes(`command '${contextKeyCommandId}' not found`)) {
         logger.warn(
           CHANNEL,
@@ -105,12 +106,9 @@ async function handleCompare(
     );
   } catch (err) {
     vscode.window.showErrorMessage(
-      `Error comparing files: ${err instanceof Error ? err.message : String(err)}`,
+      `Error comparing files: ${toErrorMessage(err)}`,
     );
-    logger.error(
-      CHANNEL,
-      `Error in handleCompare: ${err instanceof Error ? err.message : String(err)}`,
-    );
+    logger.error(CHANNEL, `Error in handleCompare: ${toErrorMessage(err)}`);
   }
 }
 
@@ -174,11 +172,11 @@ async function handleAcceptEdited(
     );
   } catch (err) {
     vscode.window.showErrorMessage(
-      `Error accepting changes: ${err instanceof Error ? err.message : String(err)}`,
+      `Error accepting changes: ${toErrorMessage(err)}`,
     );
     logger.error(
       CHANNEL,
-      `Error in handleAcceptEdited: ${err instanceof Error ? err.message : String(err)}`,
+      `Error in handleAcceptEdited: ${toErrorMessage(err)}`,
     );
   }
 }

--- a/src/commands/latex/figCommands.ts
+++ b/src/commands/latex/figCommands.ts
@@ -115,7 +115,7 @@ async function handleExtractTikzFigures(): Promise<void> {
         ([label, tikzpicturess]: [string, string[]]) => ({
           label: `${label} (${tikzpicturess.length} TikZ picture${tikzpicturess.length > 1 ? 's' : ''})`,
           description: `Figure with label: ${label}`,
-          detail: tikzpicturess[0].substring(0, 100) + '...', // Show first 100 chars of first TikZ picture
+          detail: `${tikzpicturess[0].substring(0, 100)}...`, // Show first 100 chars of first TikZ picture
         }),
       );
 

--- a/src/commands/latex/imageCommands.ts
+++ b/src/commands/latex/imageCommands.ts
@@ -83,7 +83,7 @@ async function handleEncodeImageToBase64(): Promise<string | undefined> {
     const base64String = await getBase64EncodedMedia(selection.relativePath);
 
     // Also show a truncated version in the debug log for quick verification
-    const truncatedString = base64String.substring(0, 100) + '...';
+    const truncatedString = `${base64String.substring(0, 100)}...`;
     logger.debug(
       CHANNEL,
       `Truncated base64 string (first 100 chars): ${truncatedString}`,
@@ -212,7 +212,7 @@ async function handleTestPdfToImage(): Promise<string | undefined> {
     );
 
     // Show truncated result in debug log
-    const truncatedString = base64String.substring(0, 100) + '...';
+    const truncatedString = `${base64String.substring(0, 100)}...`;
     logger.debug(
       CHANNEL,
       `Truncated base64 string (first 100 chars): ${truncatedString}`,

--- a/src/commands/latex/latexCommands.ts
+++ b/src/commands/latex/latexCommands.ts
@@ -2,7 +2,10 @@
 import * as vscode from 'vscode';
 
 // Local imports - log
-import { showLoggedErrorMessage } from '@common/errors/errorHandlingUtils';
+import {
+  showLoggedErrorMessage,
+  toErrorMessage,
+} from '@common/errors/errorHandlingUtils';
 import * as logger from '@logger/logUtils';
 import replacementEngine from '@replacement/engine';
 import { WorkspaceFS } from '@utils/files';
@@ -74,7 +77,7 @@ async function handleApplyReplacements(): Promise<void> {
   } catch (err) {
     logger.error(
       CHANNEL,
-      `Error applying replacements: ${err instanceof Error ? err.message : String(err)}`,
+      `Error applying replacements: ${toErrorMessage(err)}`,
     );
     vscode.window.showErrorMessage('Error applying LaTeX replacements');
   }
@@ -209,7 +212,7 @@ async function handleGetTeXCount(): Promise<void> {
   } catch (err) {
     logger.error(
       CHANNEL,
-      `Error in getTeXCount command: ${err instanceof Error ? err.message : String(err)}`,
+      `Error in getTeXCount command: ${toErrorMessage(err)}`,
     );
     vscode.window.showErrorMessage('Error getting tex count');
   }

--- a/src/commands/latex/linterCommands.ts
+++ b/src/commands/latex/linterCommands.ts
@@ -4,6 +4,7 @@ import * as vscode from 'vscode';
 // Local imports - log
 import { parseAgentConfig } from '@agent/core/AgentConfig';
 import { executeAgent } from '@agent/runtime/executeAgent';
+import { toErrorMessage } from '@common/errors/errorHandlingUtils';
 import {
   getLinterMessages,
   getSeverityString,
@@ -79,7 +80,7 @@ export async function handleShowLinterMessages(): Promise<void> {
   } catch (err) {
     logger.error(
       CHANNEL,
-      `Error in showLinterMessages command: ${err instanceof Error ? err.message : String(err)}`,
+      `Error in showLinterMessages command: ${toErrorMessage(err)}`,
     );
     vscode.window.showErrorMessage('Error showing linter messages');
   }
@@ -129,7 +130,7 @@ export async function handleCountLinterMessages(): Promise<void> {
   } catch (err) {
     logger.error(
       CHANNEL,
-      `Error in countLinterMessages command: ${err instanceof Error ? err.message : String(err)}`,
+      `Error in countLinterMessages command: ${toErrorMessage(err)}`,
     );
     vscode.window.showErrorMessage('Error counting linter messages');
   }
@@ -186,11 +187,9 @@ export async function handleFixLinterIssues(
   } catch (err) {
     logger.error(
       CHANNEL,
-      `Error in fixLinterIssues command: ${err instanceof Error ? err.message : String(err)}`,
+      `Error in fixLinterIssues command: ${toErrorMessage(err)}`,
     );
-    vscode.window.showErrorMessage(
-      `Error fixing linter issues: ${String(err)}`,
-    );
+    vscode.window.showErrorMessage(`Error fixing linter issues: ${String(err)}`);
   }
 }
 

--- a/src/commands/latex/linterCommands.ts
+++ b/src/commands/latex/linterCommands.ts
@@ -189,7 +189,9 @@ export async function handleFixLinterIssues(
       CHANNEL,
       `Error in fixLinterIssues command: ${toErrorMessage(err)}`,
     );
-    vscode.window.showErrorMessage(`Error fixing linter issues: ${String(err)}`);
+    vscode.window.showErrorMessage(
+      `Error fixing linter issues: ${String(err)}`,
+    );
   }
 }
 

--- a/src/commands/system/sampleProjectCommands.ts
+++ b/src/commands/system/sampleProjectCommands.ts
@@ -5,6 +5,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 
 // Local imports - fs
+import { toErrorMessage } from '@common/errors/errorHandlingUtils';
 import * as logger from '@logger/logUtils';
 import { WorkspaceFS, copyDirToFS } from '@utils/files';
 
@@ -57,7 +58,7 @@ export function registerSampleProjectCommands(
           await vscode.window.showTextDocument(document, { preview: false });
         }
       } catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
+        const message = toErrorMessage(err);
         logger.error(CHANNEL, `Failed to create sample project: ${message}`);
         void vscode.window.showErrorMessage(
           `Failed to create sample project: ${message}`,

--- a/src/commands/system/xmlCommands.ts
+++ b/src/commands/system/xmlCommands.ts
@@ -5,6 +5,7 @@ import { XMLParser } from 'fast-xml-parser';
 // Local imports - core
 import { parseAgentConfig } from '@agent/core/AgentConfig';
 import { executeAgent } from '@agent/runtime/executeAgent';
+import { toErrorMessage } from '@common/errors/errorHandlingUtils';
 import * as logger from '@logger/logUtils';
 import {
   getActiveEditorWithGuards,
@@ -56,17 +57,11 @@ export async function handleParseXml(): Promise<void> {
         `Parsed structure: ${JSON.stringify(parsedXml, null, 2)}`,
       );
     } catch (err) {
-      logger.error(
-        CHANNEL,
-        `Failed to parse XML: ${err instanceof Error ? err.message : String(err)}`,
-      );
+      logger.error(CHANNEL, `Failed to parse XML: ${toErrorMessage(err)}`);
       vscode.window.showErrorMessage('Failed to parse XML content');
     }
   } catch (err) {
-    logger.error(
-      CHANNEL,
-      `Error in parseXml command: ${err instanceof Error ? err.message : String(err)}`,
-    );
+    logger.error(CHANNEL, `Error in parseXml command: ${toErrorMessage(err)}`);
     vscode.window.showErrorMessage('Error parsing XML');
   }
 }
@@ -103,7 +98,7 @@ export async function handleValidateAndFixXml(
   } catch (err) {
     logger.error(
       CHANNEL,
-      `Error in validateAndFixXml command: ${err instanceof Error ? err.message : String(err)}`,
+      `Error in validateAndFixXml command: ${toErrorMessage(err)}`,
     );
     vscode.window.showErrorMessage(`Error validating XML: ${String(err)}`);
   }

--- a/src/commands/system/yamlCommands.ts
+++ b/src/commands/system/yamlCommands.ts
@@ -11,6 +11,7 @@ import { AgentDirectorySource } from '@agent/runtime/AgentPathTypes';
 import { resolveAgentDefinitionInDirectory } from '@agent/utils/agentPathResolver';
 import { getAgentPath } from '@agent/runtime/executeAgent';
 import { AgentType } from '@agent/core/AgentDataclass';
+import { toErrorMessage } from '@common/errors/errorHandlingUtils';
 import { showInstructionWithSuppress } from '@frontend/ui/instruction';
 import * as logger from '@logger/logUtils';
 import { GlobalStorageFS, StorageFS } from '@utils/files';
@@ -145,7 +146,7 @@ export async function handleTestAgentLoading(
       'Agent loading tests completed. Check Debug Console for results.',
     );
   } catch (err) {
-    const errorMessage = err instanceof Error ? err.message : String(err);
+    const errorMessage = toErrorMessage(err);
     logger.error(CHANNEL, `Agent loading test failed: ${errorMessage}`);
     if (err instanceof Error && err.stack) {
       logger.debug(CHANNEL, `Stack trace: ${err.stack}`);
@@ -201,7 +202,7 @@ export async function handleLoadSpecificAgent(
       `Successfully loaded agent "${agentName}". Check Debug Console for details.`,
     );
   } catch (err) {
-    const errorMessage = err instanceof Error ? err.message : String(err);
+    const errorMessage = toErrorMessage(err);
     logger.error(CHANNEL, `Failed to load agent: ${errorMessage}`);
     if (err instanceof Error && err.stack) {
       logger.debug(CHANNEL, `Stack trace: ${err.stack}`);
@@ -239,10 +240,7 @@ export async function handleParseYaml(
         `Parsed structure: ${JSON.stringify(parsedYaml, null, 2)}`,
       );
     } catch (err) {
-      logger.error(
-        CHANNEL,
-        `Failed to parse YAML: ${err instanceof Error ? err.message : String(err)}`,
-      );
+      logger.error(CHANNEL, `Failed to parse YAML: ${toErrorMessage(err)}`);
       vscode.window.showErrorMessage('Failed to parse YAML content');
       await showInstructionWithSuppress(
         'yamlParseFail',
@@ -252,10 +250,7 @@ export async function handleParseYaml(
       );
     }
   } catch (err) {
-    logger.error(
-      CHANNEL,
-      `Error in parseYaml command: ${err instanceof Error ? err.message : String(err)}`,
-    );
+    logger.error(CHANNEL, `Error in parseYaml command: ${toErrorMessage(err)}`);
     vscode.window.showErrorMessage('Error parsing YAML');
   }
 }
@@ -318,7 +313,7 @@ export async function handleTestYamlBrackets(
       'YAML bracket test completed. Check Debug Console for results.',
     );
   } catch (err) {
-    const errorMessage = err instanceof Error ? err.message : String(err);
+    const errorMessage = toErrorMessage(err);
     logger.error(CHANNEL, `YAML bracket test failed: ${errorMessage}`);
     if (err instanceof Error && err.stack) {
       logger.debug(CHANNEL, `Stack trace: ${err.stack}`);

--- a/src/common/errors/errorHandlingUtils.ts
+++ b/src/common/errors/errorHandlingUtils.ts
@@ -59,7 +59,7 @@ export function formatError(prefix: string, err: unknown): string {
 
   // Truncate overly long error details for better readability
   if (detail.length > MAX_ERROR_LENGTH) {
-    detail = detail.substring(0, MAX_ERROR_LENGTH) + '...';
+    detail = `${detail.substring(0, MAX_ERROR_LENGTH)}...`;
   }
 
   return `${prefix}: ${detail}`;

--- a/src/common/webview/BaseViewContentProvider.ts
+++ b/src/common/webview/BaseViewContentProvider.ts
@@ -2,6 +2,7 @@
 import * as vscode from 'vscode';
 
 // Local imports - common
+import { toErrorMessage } from '@common/errors/errorHandlingUtils';
 import { buildWebviewHtml } from '@frontend/webview/html';
 import * as logger from '@logger/logUtils';
 
@@ -130,7 +131,7 @@ export abstract class BaseViewContentProvider {
     } catch (err) {
       this.logger.error(
         this.channel,
-        `Error generating HTML content: ${err instanceof Error ? err.message : String(err)}`,
+        `Error generating HTML content: ${toErrorMessage(err)}`,
       );
       return '<html><body>Error loading content</body></html>';
     }

--- a/src/common/webview/BaseViewMessageHandler.ts
+++ b/src/common/webview/BaseViewMessageHandler.ts
@@ -2,6 +2,7 @@
 import * as vscode from 'vscode';
 
 // Local imports - common
+import { toErrorMessage } from '@common/errors/errorHandlingUtils';
 import * as logger from '@logger/logUtils';
 
 // Local file imports
@@ -61,7 +62,7 @@ export abstract class BaseViewMessageHandler<
       this.logger.error(
         this.channel,
         `Error handling command ${message.command}: ${
-          error instanceof Error ? error.message : String(error)
+          toErrorMessage(error)
         }`,
       );
 

--- a/src/frontend/agents/AgentDirectoryManager.ts
+++ b/src/frontend/agents/AgentDirectoryManager.ts
@@ -5,7 +5,10 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 
 // Local imports - log
-import { showLoggedMessageWithDocs } from '@common/errors/errorHandlingUtils';
+import {
+  showLoggedMessageWithDocs,
+  toErrorMessage,
+} from '@common/errors/errorHandlingUtils';
 import * as logger from '@logger/logUtils';
 import { getConfig, updateConfig } from '@utils/config';
 import { GlobalStorageFS, StorageFS, AbsoluteFS } from '@utils/files';
@@ -62,7 +65,7 @@ export class AgentDirectoryManager {
     try {
       await GlobalStorageFS.ensureDir(DEFAULT_CUSTOM_AGENTS_DIR_NAME);
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
+      const message = toErrorMessage(error);
       logger.error(
         CHANNEL,
         `Failed to create default custom agents directory: ${message}`,

--- a/src/frontend/files/rules.ts
+++ b/src/frontend/files/rules.ts
@@ -2,6 +2,9 @@
 import * as os from 'os';
 import * as path from 'path';
 
+// Local imports - common
+import { toErrorMessage } from '@common/errors/errorHandlingUtils';
+
 // Local imports - log
 import * as logger from '@logger/logUtils';
 import { WorkspaceFS, AbsoluteFS } from '@utils/files';
@@ -37,7 +40,7 @@ export async function loadTexraRules(): Promise<string> {
   } catch (err) {
     logger.warn(
       CHANNEL,
-      `Failed to load ${'.texrarules'}: ${err instanceof Error ? err.message : String(err)}`,
+      `Failed to load ${'.texrarules'}: ${toErrorMessage(err)}`,
     );
   }
   return '';

--- a/src/frontend/latex/linter.ts
+++ b/src/frontend/latex/linter.ts
@@ -1,6 +1,9 @@
 // Third-party imports
 import * as vscode from 'vscode';
 
+// Local imports - common
+import { toErrorMessage } from '@common/errors/errorHandlingUtils';
+
 // Local imports - log
 import * as logger from '@logger/logUtils';
 import { WorkspaceFS } from '@utils/files';
@@ -92,7 +95,7 @@ export async function triggerLaTeXBuild(filePath: string): Promise<void> {
     } catch (openErr) {
       logger.warn(
         CHANNEL,
-        `Could not open file in editor: ${openErr instanceof Error ? openErr.message : String(openErr)}`,
+        `Could not open file in editor: ${toErrorMessage(openErr)}`,
       );
       // Continue anyway - we'll still try to trigger the build
     }
@@ -115,7 +118,7 @@ export async function triggerLaTeXBuild(filePath: string): Promise<void> {
   } catch (buildErr) {
     logger.warn(
       CHANNEL,
-      `Failed to trigger LaTeX build: ${buildErr instanceof Error ? buildErr.message : String(buildErr)}`,
+      `Failed to trigger LaTeX build: ${toErrorMessage(buildErr)}`,
     );
     // Continue anyway, as we'll use whatever diagnostics are available
   }
@@ -145,7 +148,7 @@ export function getDiagnostics(filePath: string): vscode.Diagnostic[] {
   } catch (err) {
     logger.error(
       CHANNEL,
-      `Error getting diagnostics for ${filePath}: ${err instanceof Error ? err.message : String(err)}`,
+      `Error getting diagnostics for ${filePath}: ${toErrorMessage(err)}`,
     );
     return [];
   }
@@ -171,7 +174,7 @@ export async function getLinterMessages(
   } catch (err) {
     logger.error(
       CHANNEL,
-      `Error formatting linter messages for ${filePath}: ${err instanceof Error ? err.message : String(err)}`,
+      `Error formatting linter messages for ${filePath}: ${toErrorMessage(err)}`,
     );
     return [];
   }

--- a/src/frontend/media/img.ts
+++ b/src/frontend/media/img.ts
@@ -8,6 +8,7 @@ import { PDFDocument } from '@cantoo/pdf-lib';
 import { fromPath } from 'pdf2pic';
 
 // Local imports - log
+import { toErrorMessage } from '@common/errors/errorHandlingUtils';
 import * as logger from '@logger/logUtils';
 import { getConfig } from '@utils/config';
 import { AbsoluteFS, getMimeType, resolveFilePath } from '@utils/files';
@@ -219,16 +220,13 @@ export async function getBase64EncodedMedia(
         } catch (err) {
           logger.warn(
             CHANNEL,
-            `Failed to remove temporary file ${tempPath}: ${err instanceof Error ? err.message : String(err)}`,
+            `Failed to remove temporary file ${tempPath}: ${toErrorMessage(err)}`,
           );
         }
       }
     }
   } catch (err) {
-    logger.error(
-      CHANNEL,
-      `Error encoding media to base64: ${err instanceof Error ? err.message : String(err)}`,
-    );
+    logger.error(CHANNEL, `Error encoding media to base64: ${toErrorMessage(err)}`);
     throw err;
   }
 }
@@ -249,10 +247,7 @@ export async function countPdfPages(pdfPath: string): Promise<number> {
 
     return await loadPdfPageCount(absolutePath, pdfPath);
   } catch (err) {
-    logger.error(
-      CHANNEL,
-      `Error counting PDF pages: ${err instanceof Error ? err.message : String(err)}`,
-    );
+    logger.error(CHANNEL, `Error counting PDF pages: ${toErrorMessage(err)}`);
     return 0;
   }
 }
@@ -335,7 +330,7 @@ export async function singlePagePdf2Png(
   } catch (err) {
     logger.error(
       CHANNEL,
-      `Error converting PDF page to PNG: ${err instanceof Error ? err.message : String(err)}`,
+      `Error converting PDF page to PNG: ${toErrorMessage(err)}`,
     );
     throw err;
   } finally {
@@ -382,7 +377,7 @@ export async function multiPagePdf2Png(
   } catch (err) {
     logger.error(
       CHANNEL,
-      `Error converting multiple PDF pages: ${err instanceof Error ? err.message : String(err)}`,
+      `Error converting multiple PDF pages: ${toErrorMessage(err)}`,
     );
     throw err;
   }
@@ -430,10 +425,7 @@ export async function processPdf2Png(
       );
     }
   } catch (err) {
-    logger.error(
-      CHANNEL,
-      `Error processing PDF input: ${err instanceof Error ? err.message : String(err)}`,
-    );
+    logger.error(CHANNEL, `Error processing PDF input: ${toErrorMessage(err)}`);
     return null;
   }
 }

--- a/src/housekeeping/clean.ts
+++ b/src/housekeeping/clean.ts
@@ -9,6 +9,7 @@ import { sync as globSync } from 'glob';
 import type { FileOpResult } from '@agent/types/ResultTypes';
 
 // Internal imports
+import { toErrorMessage } from '@common/errors/errorHandlingUtils';
 import * as logger from '@logger/logUtils';
 import { WorkspaceFS } from '@utils/files';
 import { getConfig } from '@utils/config';
@@ -93,11 +94,11 @@ export async function runCleanSingle(
     } catch (err) {
       logger.error(
         CHANNEL,
-        `Error during cleanup of ${inputFile}: ${err instanceof Error ? err.message : String(err)}`,
+        `Error during cleanup of ${inputFile}: ${toErrorMessage(err)}`,
       );
       result = {
         status: 'error',
-        error: err instanceof Error ? err.message : String(err),
+        error: toErrorMessage(err),
       };
     }
   }
@@ -177,7 +178,7 @@ export async function runCleanBuild(): Promise<void> {
     } catch (err) {
       logger.error(
         CHANNEL,
-        `Error removing build directory ${dir}: ${err instanceof Error ? err.message : String(err)}`,
+        `Error removing build directory ${dir}: ${toErrorMessage(err)}`,
       );
     }
   }

--- a/src/housekeeping/latexdiff.ts
+++ b/src/housekeeping/latexdiff.ts
@@ -8,6 +8,7 @@ import * as vscode from 'vscode';
 import {
   showLoggedErrorMessage,
   showLoggedMessage,
+  toErrorMessage,
 } from '@common/errors/errorHandlingUtils';
 import * as logger from '@logger/logUtils';
 import { WorkspaceFS } from '@utils/files';
@@ -104,10 +105,7 @@ export async function runPackLatexdiffvc(
           );
         }
       } catch (err) {
-        logger.error(
-          CHANNEL,
-          `Error during packing: ${err instanceof Error ? err.message : String(err)}`,
-        );
+        logger.error(CHANNEL, `Error during packing: ${toErrorMessage(err)}`);
         vscode.window.showErrorMessage(`Error during packing: ${err}`);
       }
     }

--- a/src/housekeeping/pack.ts
+++ b/src/housekeeping/pack.ts
@@ -8,6 +8,7 @@ import * as vscode from 'vscode';
 import type { FileOpResult } from '@agent/types/ResultTypes';
 
 // Local imports - log
+import { toErrorMessage } from '@common/errors/errorHandlingUtils';
 import * as logger from '@logger/logUtils';
 import { WorkspaceFS } from '@utils/files';
 import { getConfig } from '@utils/config';
@@ -131,11 +132,11 @@ export async function runPackSingle(
     } catch (err) {
       logger.error(
         CHANNEL,
-        `Error during file operations: ${err instanceof Error ? err.message : String(err)}`,
+        `Error during file operations: ${toErrorMessage(err)}`,
       );
       result = {
         status: 'error',
-        error: err instanceof Error ? err.message : String(err),
+        error: toErrorMessage(err),
       };
     }
   } else {
@@ -249,11 +250,11 @@ export async function runPackMultiple(
   } catch (err) {
     logger.error(
       CHANNEL,
-      `Error during multiple pack operation: ${err instanceof Error ? err.message : String(err)}`,
+      `Error during multiple pack operation: ${toErrorMessage(err)}`,
     );
     return {
       status: 'error',
-      error: err instanceof Error ? err.message : String(err),
+      error: toErrorMessage(err),
     };
   }
 }

--- a/src/latex/LatexMediaManager.ts
+++ b/src/latex/LatexMediaManager.ts
@@ -4,6 +4,7 @@ import * as path from 'path';
 // Local imports - log
 import { AgentWorkspaceState } from '@agent/core/AgentWorkspaceState';
 import { ToolConfig } from '@agent/core/ToolConfig';
+import { toErrorMessage } from '@common/errors/errorHandlingUtils';
 import { AgentLogger } from '@logger/AgentLogger';
 import { TaskRunFileService, flexibleFS } from '@utils/files';
 
@@ -57,7 +58,7 @@ export class LatexMediaManager {
       try {
         await this.fileService!.mirrorWorkspaceFile(target);
       } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
+        const message = toErrorMessage(error);
         this.logger.debug(
           `Unable to mirror figure dependency ${target}: ${message}`,
           groupId ?? undefined,
@@ -115,7 +116,7 @@ export class LatexMediaManager {
                 return undefined;
               }
             } catch (err) {
-              const message = err instanceof Error ? err.message : String(err);
+              const message = toErrorMessage(err);
               this.logger.error(
                 `Failed to stat compiled PDF ${pdfFile}: ${message}`,
                 activeGroupId,

--- a/src/latex/TikzPictureManager.ts
+++ b/src/latex/TikzPictureManager.ts
@@ -6,6 +6,7 @@ import * as nunjucks from 'nunjucks';
 
 // Local imports - log
 import { renderPrompt } from '@agent/utils/promptUtils';
+import { toErrorMessage } from '@common/errors/errorHandlingUtils';
 import * as logger from '@logger/logUtils';
 import { flexibleFS } from '@utils/files';
 import { getConfig } from '@utils/config';
@@ -85,7 +86,7 @@ export class TikzPictureManager {
     } catch (err) {
       logger.error(
         channel,
-        `Error extracting TikZ pictures: ${err instanceof Error ? err.message : String(err)}`,
+        `Error extracting TikZ pictures: ${toErrorMessage(err)}`,
       );
       throw err;
     }
@@ -122,7 +123,7 @@ export class TikzPictureManager {
     } catch (err) {
       logger.error(
         channel,
-        `Error creating standalone LaTeX: ${err instanceof Error ? err.message : String(err)}`,
+        `Error creating standalone LaTeX: ${toErrorMessage(err)}`,
       );
       throw err;
     }
@@ -184,7 +185,7 @@ export class TikzPictureManager {
     } catch (err) {
       logger.error(
         channel,
-        `Error extracting and compiling TikZ pictures: ${err instanceof Error ? err.message : String(err)}`,
+        `Error extracting and compiling TikZ pictures: ${toErrorMessage(err)}`,
       );
       throw err;
     }

--- a/src/latex/arxivProcessor.ts
+++ b/src/latex/arxivProcessor.ts
@@ -8,6 +8,7 @@ import * as arxivIdentifiers from 'identifiers-arxiv';
 import * as tar from 'tar';
 
 // Local imports - log
+import { toErrorMessage } from '@common/errors/errorHandlingUtils';
 import * as logger from '@logger/logUtils';
 import { WorkspaceFS, AbsoluteFS } from '@utils/files';
 import { indentLatexFilesInDirectory } from '@housekeeping/indent';
@@ -140,7 +141,7 @@ export class ArxivSourceProcessor {
       }
       return { success: true };
     } catch (err) {
-      const errorMsg = err instanceof Error ? err.message : String(err);
+      const errorMsg = toErrorMessage(err);
       logger.error(
         options.channel ?? this.channel,
         `Failed to extract tar file: ${errorMsg}`,
@@ -223,7 +224,7 @@ export class ArxivSourceProcessor {
       } catch (err) {
         logger.debug(
           this.channel,
-          `Could not remove download directory: ${err instanceof Error ? err.message : String(err)}`,
+          `Could not remove download directory: ${toErrorMessage(err)}`,
         );
       }
     } else {
@@ -240,7 +241,7 @@ export class ArxivSourceProcessor {
       } catch (err) {
         logger.debug(
           this.channel,
-          `Could not remove download directory: ${err instanceof Error ? err.message : String(err)}`,
+          `Could not remove download directory: ${toErrorMessage(err)}`,
         );
       }
     }

--- a/src/latex/extractFigure.ts
+++ b/src/latex/extractFigure.ts
@@ -2,6 +2,7 @@
 import * as path from 'path';
 
 // Local imports - log
+import { toErrorMessage } from '@common/errors/errorHandlingUtils';
 import * as logger from '@logger/logUtils';
 import { flexibleFS } from '@utils/files';
 
@@ -119,7 +120,7 @@ export async function extractFigurePathsFromLatex(
   } catch (err) {
     logger.error(
       CHANNEL,
-      `Error extracting figure paths: ${err instanceof Error ? err.message : String(err)}`,
+      `Error extracting figure paths: ${toErrorMessage(err)}`,
     );
     throw err;
   }

--- a/src/latex/formatter/latexindentpt.ts
+++ b/src/latex/formatter/latexindentpt.ts
@@ -5,6 +5,7 @@ import * as path from 'path';
 import { sync as globSync } from 'glob';
 
 // Local imports - log
+import { toErrorMessage } from '@common/errors/errorHandlingUtils';
 import * as logger from '@logger/logUtils';
 import { AbsoluteFS, WorkspaceFS } from '@utils/files';
 import { getConfig } from '@utils/config';
@@ -118,10 +119,7 @@ export async function runLatexIndent(filePath: string): Promise<boolean> {
     logger.info(CHANNEL, `Indented ${filePath}`);
     return true;
   } catch (err) {
-    logger.error(
-      CHANNEL,
-      `Error running LaTeX indent: ${err instanceof Error ? err.message : String(err)}`,
-    );
+    logger.error(CHANNEL, `Error running LaTeX indent: ${toErrorMessage(err)}`);
     return false;
   }
 }

--- a/src/latex/formatter/texfmt.ts
+++ b/src/latex/formatter/texfmt.ts
@@ -1,4 +1,5 @@
 // Local imports - log
+import { toErrorMessage } from '@common/errors/errorHandlingUtils';
 import * as logger from '@logger/logUtils';
 import { getConfig } from '@utils/config';
 import { runToolWithCheck } from '@utils/system';
@@ -29,10 +30,7 @@ export async function runTexFmt(filePath: string): Promise<boolean> {
     logger.info(CHANNEL, `Formatted ${filePath}`);
     return true;
   } catch (err) {
-    logger.error(
-      CHANNEL,
-      `Error running tex-fmt: ${err instanceof Error ? err.message : String(err)}`,
-    );
+    logger.error(CHANNEL, `Error running tex-fmt: ${toErrorMessage(err)}`);
     return false;
   }
 }

--- a/src/latex/latexdiff.ts
+++ b/src/latex/latexdiff.ts
@@ -8,6 +8,7 @@ import * as vscode from 'vscode';
 import {
   logErrorMessage,
   formatError,
+  toErrorMessage,
 } from '@common/errors/errorHandlingUtils';
 import * as logger from '@logger/logUtils';
 import { MESSAGE_TYPES } from '@logger/messageTypes';
@@ -223,7 +224,7 @@ export class LaTeXdiffService {
           results.failed.push(inputFile);
           logger.error(
             this.channel,
-            `Error processing ${inputFile}: ${err instanceof Error ? err.message : String(err)}`,
+            `Error processing ${inputFile}: ${toErrorMessage(err)}`,
           );
         }
       }

--- a/src/latex/latexdiff/diffFileProcessor.ts
+++ b/src/latex/latexdiff/diffFileProcessor.ts
@@ -1,4 +1,5 @@
 // Local imports - log
+import { toErrorMessage } from '@common/errors/errorHandlingUtils';
 import * as logger from '@logger/logUtils';
 import replacementEngine from '@replacement/engine';
 import { flexibleFS } from '@utils/files';
@@ -17,7 +18,7 @@ export class DiffFileProcessor {
     } catch (err) {
       logger.error(
         this.channel,
-        `Error processing diff file: ${err instanceof Error ? err.message : String(err)}`,
+        `Error processing diff file: ${toErrorMessage(err)}`,
       );
     }
   }

--- a/src/latex/latexdiff/diffFileProcessor.ts
+++ b/src/latex/latexdiff/diffFileProcessor.ts
@@ -89,7 +89,7 @@ export class DiffFileProcessor {
 
       // Add line if not in add block
       if (!addBlock) {
-        newContent += line + '\n';
+        newContent += `${line}\n`;
       }
 
       // Add extra newline after color package

--- a/src/latex/texTools.ts
+++ b/src/latex/texTools.ts
@@ -2,6 +2,7 @@
 import * as path from 'path';
 
 // Local imports - log
+import { toErrorMessage } from '@common/errors/errorHandlingUtils';
 import * as logger from '@logger/logUtils';
 import { runToolWithCheck } from '@utils/system';
 import { getConfig } from '@utils/config';
@@ -113,10 +114,7 @@ export async function compileLatex2Pdf(
     }
     return false;
   } catch (err) {
-    logger.error(
-      channel,
-      `Error compiling LaTeX: ${err instanceof Error ? err.message : String(err)}`,
-    );
+    logger.error(channel, `Error compiling LaTeX: ${toErrorMessage(err)}`);
     return false;
   }
 }

--- a/src/latex/texcount.ts
+++ b/src/latex/texcount.ts
@@ -1,4 +1,5 @@
 // Local imports - log
+import { toErrorMessage } from '@common/errors/errorHandlingUtils';
 import * as logger from '@logger/logUtils';
 import { flexibleFS } from '@utils/files';
 import { runToolWithCheck } from '@utils/system';
@@ -30,7 +31,7 @@ async function hasChinesePackages(filePath: string): Promise<boolean> {
   } catch (err) {
     logger.error(
       CHANNEL,
-      `Error checking Chinese packages: ${err instanceof Error ? err.message : String(err)}`,
+      `Error checking Chinese packages: ${toErrorMessage(err)}`,
     );
     return false;
   }
@@ -292,9 +293,7 @@ export async function getTeXCount(
     );
     return { output: combinedOutput, errors };
   } catch (err) {
-    const errorMessage = `Error in getTeXCount: ${
-      err instanceof Error ? err.message : String(err)
-    }`;
+    const errorMessage = `Error in getTeXCount: ${toErrorMessage(err)}`;
     logger.error(resolvedChannel, errorMessage);
     return { output: null, errors: [errorMessage] };
   }

--- a/src/latex/textConnection.ts
+++ b/src/latex/textConnection.ts
@@ -37,9 +37,9 @@ function preparePrompt(
   str2: string,
 ): { strings: TestStrings; prompt: string } {
   const strings = {
-    A: str1 + str2,
-    B: str1 + ' ' + str2,
-    C: str1 + '\n' + str2,
+    A: `${str1}${str2}`,
+    B: `${str1} ${str2}`,
+    C: `${str1}\n${str2}`,
   };
 
   const prompt =

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -4,6 +4,8 @@ import * as path from 'path';
 // Third-party imports
 import * as vscode from 'vscode';
 
+// Local imports - common
+
 // Local imports - progress view
 import {
   AgentTypeFilter,
@@ -14,6 +16,7 @@ import type { StreamTabId, ExecutionId } from '@agent/types/IdentifierTypes';
 import type { OutputFileInfo } from '@agent/output/types';
 // Internal imports
 import { ToolUseSessionPersistence } from '@agent/toolUse/ToolUseSessionPersistence';
+import { toErrorMessage } from '@common/errors/errorHandlingUtils';
 import {
   BaseViewMessageHandler,
   MessageHandler,
@@ -349,7 +352,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
           }
         } catch (error) {
           const messageText =
-            error instanceof Error ? error.message : 'Unknown error';
+            toErrorMessage(error);
           await vscode.window.showErrorMessage(
             `Error polishing follow-up: ${messageText}`,
           );
@@ -442,7 +445,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
       ]);
     } catch (error) {
       const errorMessage =
-        error instanceof Error ? error.message : String(error);
+        toErrorMessage(error);
       this.logger.error(
         this.channel,
         `Failed to open task storage for stream ${stream}, executionId ${executionId ?? 'unknown'}: ${errorMessage}`,

--- a/src/progressView/managers/TaskGroupManager.ts
+++ b/src/progressView/managers/TaskGroupManager.ts
@@ -74,8 +74,7 @@ export class TaskGroupManager extends PersistentMapManager<
     }
 
     // Apply updates
-    Object.assign(group, updates);
-    streamGroups.set(groupId, group);
+    streamGroups.set(groupId, { ...group, ...updates });
     await this.save();
   }
 

--- a/src/progressView/streamInfoUtils.ts
+++ b/src/progressView/streamInfoUtils.ts
@@ -61,8 +61,7 @@ export function buildStreamInfos(
     const taskState = state.getTaskState(id);
     const sessionKindHint = state.getSessionKindHint(id);
     const logs = state.streamTabs.getMessages(id);
-    const lastTimestamp =
-      logs.length > 0 ? logs.at(-1)?.timestamp : undefined;
+    const lastTimestamp = logs.length > 0 ? logs.at(-1)?.timestamp : undefined;
     const creationTimestamp = logs.length > 0 ? logs[0].timestamp : undefined;
     const outputs = taskState?.agentConfig.outputFiles ?? [];
     const inputFile = taskState?.agentConfig.inputFile || '';

--- a/src/progressView/streamInfoUtils.ts
+++ b/src/progressView/streamInfoUtils.ts
@@ -62,7 +62,7 @@ export function buildStreamInfos(
     const sessionKindHint = state.getSessionKindHint(id);
     const logs = state.streamTabs.getMessages(id);
     const lastTimestamp =
-      logs.length > 0 ? logs[logs.length - 1].timestamp : undefined;
+      logs.length > 0 ? logs.at(-1)?.timestamp : undefined;
     const creationTimestamp = logs.length > 0 ? logs[0].timestamp : undefined;
     const outputs = taskState?.agentConfig.outputFiles ?? [];
     const inputFile = taskState?.agentConfig.inputFile || '';

--- a/src/replacement/advanced.ts
+++ b/src/replacement/advanced.ts
@@ -383,7 +383,7 @@ export function replaceMathUnicode(text: string): string {
     // Replace HTML superscript tags with LaTeX superscript syntax
     content = content.replace(/<sup>(.*?)<\/sup>/g, '^{$1}');
 
-    return '$' + content + '$';
+    return `$${content}$`;
   });
 
   return text;

--- a/src/replacement/engine.ts
+++ b/src/replacement/engine.ts
@@ -2,6 +2,9 @@
  * Utilities for managing text replacements in the codebase.
  */
 
+// Local imports - common
+import { toErrorMessage } from '@common/errors/errorHandlingUtils';
+
 // Local imports - log
 import * as logger from '@logger/logUtils';
 import { getConfig } from '@utils/config';
@@ -287,7 +290,7 @@ export function applyReplacements(
         } catch (regexErr) {
           logger.error(
             CHANNEL,
-            `Error with regex pattern "${pattern}": ${regexErr instanceof Error ? regexErr.message : String(regexErr)}`,
+            `Error with regex pattern "${pattern}": ${toErrorMessage(regexErr)}`,
           );
         }
       }

--- a/src/replacement/maxRules.ts
+++ b/src/replacement/maxRules.ts
@@ -60,7 +60,7 @@ export const MAX_AUTO_REPLACEMENTS: ReplacementCategory = {
   isRegex: false,
   patterns: (() => {
     // Initialize patterns object
-    const patterns: { [key: string]: string } = {};
+    let patterns: { [key: string]: string } = {};
 
     // ====================================================================
     // Backslash and command fixes
@@ -81,7 +81,7 @@ export const MAX_AUTO_REPLACEMENTS: ReplacementCategory = {
     ];
 
     // Generate backslash fixes for all the above commands
-    Object.assign(patterns, generateBackslashFixes(backslashFixCommands));
+    patterns = { ...patterns, ...generateBackslashFixes(backslashFixCommands) };
 
     // ====================================================================
     // Specialized handling for math operators and text commands
@@ -153,7 +153,7 @@ export const MAX_AUTO_REPLACEMENTS: ReplacementCategory = {
       differentialVariables,
       '~',
     );
-    Object.assign(patterns, differentialSpacingPatterns);
+    patterns = { ...patterns, ...differentialSpacingPatterns };
 
     // Variables that need differential replacement in fractions and integrals
     // prettier-ignore
@@ -188,7 +188,7 @@ export const MAX_AUTO_REPLACEMENTS: ReplacementCategory = {
       Leftrightarrow: 'LRa',
       Longleftrightarrow: 'LRa',
     };
-    Object.assign(patterns, generateArrowRelationShortcuts(arrowRelationMap));
+    patterns = { ...patterns, ...generateArrowRelationShortcuts(arrowRelationMap) };
 
     // Calculus command shortcuts
     // Examples: \partial -> \der, \nabla -> \na
@@ -196,14 +196,14 @@ export const MAX_AUTO_REPLACEMENTS: ReplacementCategory = {
       partial: 'der',
       nabla: 'na',
     };
-    Object.assign(patterns, generateCommandShortcuts(calculusCommandMap));
+    patterns = { ...patterns, ...generateCommandShortcuts(calculusCommandMap) };
 
     // Vector Variables
     // Examples:
     // \vec{p} -> \vp (momentum vector)
     // \vec{x} -> \vx (position vector)
     const vectorLetters = 'pqvxyz'.split('');
-    Object.assign(patterns, generateVectorShortcuts(vectorLetters));
+    patterns = { ...patterns, ...generateVectorShortcuts(vectorLetters) };
 
     // Greek Letters (Regular)
     // Map full Greek letter names to shorter versions
@@ -215,7 +215,7 @@ export const MAX_AUTO_REPLACEMENTS: ReplacementCategory = {
     const greekShortcuts = { ...GREEK_LETTER_SHORTCUTS };
     delete greekShortcuts['Delta']; // Prevent Delta from being shortened to De
 
-    Object.assign(patterns, generateMathCommandShortcuts(greekShortcuts));
+    patterns = { ...patterns, ...generateMathCommandShortcuts(greekShortcuts) };
 
     // Greek Letters (Bold)
     // Generate patterns for bold Greek letters with \b prefix
@@ -224,108 +224,108 @@ export const MAX_AUTO_REPLACEMENTS: ReplacementCategory = {
 
     // prettier-ignore
     const greekBoldLetters = [...commonGreekLetters, 'chi', 'pi', 'varphi', 'Sigma', 'lambda', 'Gamma', 'Lambda'];
-    Object.assign(
-      patterns,
-      generateDecoratedMathShortcuts(['boldsymbol'], greekBoldLetters, 'b'),
-    );
+    patterns = {
+      ...patterns,
+      ...generateDecoratedMathShortcuts(['boldsymbol'], greekBoldLetters, 'b'),
+    };
 
     // Mathcal Letters
     // Map \mathcal{X} to shorter \cX versions for all uppercase letters
     const upperLetters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('');
-    Object.assign(
-      patterns,
-      generateMathFontShortcuts(upperLetters, 'mathcal', 'c'),
-    );
+    patterns = {
+      ...patterns,
+      ...generateMathFontShortcuts(upperLetters, 'mathcal', 'c'),
+    };
 
     // Mathbb Letters
     // Map \mathbb{X} to shorter \eX versions for specific letters
     const mathbbLetters = 'CEINPQRTV'.split('');
-    Object.assign(
-      patterns,
-      generateMathFontShortcuts(mathbbLetters, 'mathbb', 'e'),
-    );
+    patterns = {
+      ...patterns,
+      ...generateMathFontShortcuts(mathbbLetters, 'mathbb', 'e'),
+    };
 
     // Mathbf Letters (Lowercase)
     // Map \mathbf{x} to shorter \bx versions
     const lowerLetters = 'abcdefghjnpqrsuvwxyz'.split('');
-    Object.assign(
-      patterns,
-      generateMathFontShortcuts(lowerLetters, 'mathbf', 'b'),
-    );
+    patterns = {
+      ...patterns,
+      ...generateMathFontShortcuts(lowerLetters, 'mathbf', 'b'),
+    };
 
     // Mathbf Letters (Uppercase)
     // Map \mathbf{X} to shorter \bX versions for uppercase letters
     const mathbfUpperLetters = 'ABCDEFGIJKMQRUVWXYZ'.split('');
-    Object.assign(
-      patterns,
-      generateMathFontShortcuts(mathbfUpperLetters, 'mathbf', 'b'),
-    );
+    patterns = {
+      ...patterns,
+      ...generateMathFontShortcuts(mathbfUpperLetters, 'mathbf', 'b'),
+    };
 
     // Normalize legacy font commands {\rm X}, {\bf X} and {\cal X}
     const alphabetLetters =
       'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz'.split('');
-    Object.assign(
-      patterns,
-      generateLegacyTextCommandNormalization(alphabetLetters, 'mathrm', 'rm'),
-    );
-    Object.assign(
-      patterns,
-      generateLegacyTextCommandNormalization(alphabetLetters, 'mathbf', 'bf'),
-    );
-    Object.assign(
-      patterns,
-      generateLegacyTextCommandNormalization(alphabetLetters, 'mathcal', 'cal'),
-    );
+    patterns = {
+      ...patterns,
+      ...generateLegacyTextCommandNormalization(alphabetLetters, 'mathrm', 'rm'),
+    };
+    patterns = {
+      ...patterns,
+      ...generateLegacyTextCommandNormalization(alphabetLetters, 'mathbf', 'bf'),
+    };
+    patterns = {
+      ...patterns,
+      ...generateLegacyTextCommandNormalization(alphabetLetters, 'mathcal', 'cal'),
+    };
 
     // Tilde variables - simple letters
     // Examples: \tilde{x} -> \tx, \tilde{B} -> \tB
     const tildeLetters = 'xzpqBFJMPTZ'.split('');
-    Object.assign(
-      patterns,
-      generateDecoratorShortcuts('tilde', tildeLetters, 't'),
-    );
+    patterns = {
+      ...patterns,
+      ...generateDecoratorShortcuts('tilde', tildeLetters, 't'),
+    };
 
     // Tilde with mathbf - lowercase
     // Example: \tilde{\mathbf{x}} -> \tbx
     const tildeLettersMathbf = 'axpvwz'.split('');
-    Object.assign(
-      patterns,
-      generateNestedDecoratorShortcuts(
+    patterns = {
+      ...patterns,
+      ...generateNestedDecoratorShortcuts(
         'tilde',
         'mathbf',
         tildeLettersMathbf,
         't',
         'b',
       ),
-    );
+    };
 
     // Tilde with mathbf - uppercase
     // Example: \tilde{\mathbf{M}} -> \tbM
     const tildeLettersMathbfUppercase = 'MTX'.split('');
-    Object.assign(
-      patterns,
-      generateNestedDecoratorShortcuts(
+    patterns = {
+      ...patterns,
+      ...generateNestedDecoratorShortcuts(
         'tilde',
         'mathbf',
         tildeLettersMathbfUppercase,
         't',
         'b',
       ),
-    );
+    };
 
     // Tilde with mathcal - uppercase
     // Example: \tilde{\mathcal{H}} -> \tcH
     const tildeLettersMathcal = 'HQSW'.split('');
-    Object.assign(
-      patterns,
-      generateNestedDecoratorShortcuts(
+    patterns = {
+      ...patterns,
+      ...generateNestedDecoratorShortcuts(
         'tilde',
         'mathcal',
         tildeLettersMathcal,
         't',
         'c',
       ),
-    );
+    };
 
     // Tilde with Greek letters
     // Example: \tilde{\gamma} -> \tga
@@ -350,7 +350,7 @@ export const MAX_AUTO_REPLACEMENTS: ReplacementCategory = {
     // Hat variables
     // Example: \hat{H} -> \hH
     const hatLetters = 'HFP'.split('');
-    Object.assign(patterns, generateDecoratorShortcuts('hat', hatLetters, 'h'));
+    patterns = { ...patterns, ...generateDecoratorShortcuts('hat', hatLetters, 'h') };
 
     // Hat with Greek letters
     // Example: \hat{\sigma} -> \hsg
@@ -363,16 +363,16 @@ export const MAX_AUTO_REPLACEMENTS: ReplacementCategory = {
     // Hat with mathbf
     // Example: \hat{\mathbf{n}} -> \hbn
     const hatMathbfLetters = 'nv'.split('');
-    Object.assign(
-      patterns,
-      generateNestedDecoratorShortcuts(
+    patterns = {
+      ...patterns,
+      ...generateNestedDecoratorShortcuts(
         'hat',
         'mathbf',
         hatMathbfLetters,
         'h',
         'b',
       ),
-    );
+    };
 
     // Hat with boldsymbol+Greek
     // Example: \hat{\boldsymbol{\zeta}} -> \hbze
@@ -384,13 +384,13 @@ export const MAX_AUTO_REPLACEMENTS: ReplacementCategory = {
 
     // Fix for extra backslashes in bold symbols
     // Automatically generate fixes for lowercase bold letters (e.g., \\ba -> \ba)
-    Object.assign(patterns, generateBoldBackslashFixes('b', lowerLetters));
+    patterns = { ...patterns, ...generateBoldBackslashFixes('b', lowerLetters) };
 
     // Automatically generate fixes for uppercase bold letters (e.g., \\bA -> \bA)
-    Object.assign(
-      patterns,
-      generateBoldBackslashFixes('b', mathbfUpperLetters),
-    );
+    patterns = {
+      ...patterns,
+      ...generateBoldBackslashFixes('b', mathbfUpperLetters),
+    };
 
     // Fix for double backslashes in custom commands
     // Examples: \\bet -> \bet, \\bbf -> \bbf

--- a/src/replacement/maxRules.ts
+++ b/src/replacement/maxRules.ts
@@ -188,7 +188,10 @@ export const MAX_AUTO_REPLACEMENTS: ReplacementCategory = {
       Leftrightarrow: 'LRa',
       Longleftrightarrow: 'LRa',
     };
-    patterns = { ...patterns, ...generateArrowRelationShortcuts(arrowRelationMap) };
+    patterns = {
+      ...patterns,
+      ...generateArrowRelationShortcuts(arrowRelationMap),
+    };
 
     // Calculus command shortcuts
     // Examples: \partial -> \der, \nabla -> \na
@@ -266,15 +269,27 @@ export const MAX_AUTO_REPLACEMENTS: ReplacementCategory = {
       'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz'.split('');
     patterns = {
       ...patterns,
-      ...generateLegacyTextCommandNormalization(alphabetLetters, 'mathrm', 'rm'),
+      ...generateLegacyTextCommandNormalization(
+        alphabetLetters,
+        'mathrm',
+        'rm',
+      ),
     };
     patterns = {
       ...patterns,
-      ...generateLegacyTextCommandNormalization(alphabetLetters, 'mathbf', 'bf'),
+      ...generateLegacyTextCommandNormalization(
+        alphabetLetters,
+        'mathbf',
+        'bf',
+      ),
     };
     patterns = {
       ...patterns,
-      ...generateLegacyTextCommandNormalization(alphabetLetters, 'mathcal', 'cal'),
+      ...generateLegacyTextCommandNormalization(
+        alphabetLetters,
+        'mathcal',
+        'cal',
+      ),
     };
 
     // Tilde variables - simple letters
@@ -350,7 +365,10 @@ export const MAX_AUTO_REPLACEMENTS: ReplacementCategory = {
     // Hat variables
     // Example: \hat{H} -> \hH
     const hatLetters = 'HFP'.split('');
-    patterns = { ...patterns, ...generateDecoratorShortcuts('hat', hatLetters, 'h') };
+    patterns = {
+      ...patterns,
+      ...generateDecoratorShortcuts('hat', hatLetters, 'h'),
+    };
 
     // Hat with Greek letters
     // Example: \hat{\sigma} -> \hsg
@@ -384,7 +402,10 @@ export const MAX_AUTO_REPLACEMENTS: ReplacementCategory = {
 
     // Fix for extra backslashes in bold symbols
     // Automatically generate fixes for lowercase bold letters (e.g., \\ba -> \ba)
-    patterns = { ...patterns, ...generateBoldBackslashFixes('b', lowerLetters) };
+    patterns = {
+      ...patterns,
+      ...generateBoldBackslashFixes('b', lowerLetters),
+    };
 
     // Automatically generate fixes for uppercase bold letters (e.g., \\bA -> \bA)
     patterns = {

--- a/src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts
+++ b/src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts
@@ -170,7 +170,7 @@ describe('ModelHandlerAnthropic message guards', () => {
       [...baseMessages],
       '  follow up text  ',
     );
-    const followUp = updated.at(-1);
+    const followUp = updated.at(-1)!;
     const followUpContent = followUp.content as ContentBlock[];
     const textBlock = assertSingleTextBlock(followUpContent);
     assert.equal(textBlock.text, 'follow up text');
@@ -204,7 +204,7 @@ describe('ModelHandlerAnthropic message guards', () => {
       [...baseMessages],
       'next follow up',
     );
-    const followUp = updated.at(-1);
+    const followUp = updated.at(-1)!;
     const followUpContent = followUp.content as ContentBlockParam[];
     const followUpBlock = followUpContent.at(-1);
     const followUpMarker = getCacheMarker(followUpBlock);
@@ -372,7 +372,7 @@ describe('ModelHandlerAnthropic message guards', () => {
       [...baseMessages],
       '  another follow up  ',
     );
-    const followUp = withFollowUp.at(-1);
+    const followUp = withFollowUp.at(-1)!;
     const followUpContent = followUp.content as ContentBlock[];
     const textBlock = assertSingleTextBlock(followUpContent);
     assert.equal(textBlock.text, 'another follow up');

--- a/src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts
+++ b/src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts
@@ -170,7 +170,7 @@ describe('ModelHandlerAnthropic message guards', () => {
       [...baseMessages],
       '  follow up text  ',
     );
-    const followUp = updated[updated.length - 1];
+    const followUp = updated.at(-1);
     const followUpContent = followUp.content as ContentBlock[];
     const textBlock = assertSingleTextBlock(followUpContent);
     assert.equal(textBlock.text, 'follow up text');
@@ -204,7 +204,7 @@ describe('ModelHandlerAnthropic message guards', () => {
       [...baseMessages],
       'next follow up',
     );
-    const followUp = updated[updated.length - 1];
+    const followUp = updated.at(-1);
     const followUpContent = followUp.content as ContentBlockParam[];
     const followUpBlock = followUpContent.at(-1);
     const followUpMarker = getCacheMarker(followUpBlock);
@@ -372,7 +372,7 @@ describe('ModelHandlerAnthropic message guards', () => {
       [...baseMessages],
       '  another follow up  ',
     );
-    const followUp = withFollowUp[withFollowUp.length - 1];
+    const followUp = withFollowUp.at(-1);
     const followUpContent = followUp.content as ContentBlock[];
     const textBlock = assertSingleTextBlock(followUpContent);
     assert.equal(textBlock.text, 'another follow up');

--- a/src/test/tools/ReadTool.test.ts
+++ b/src/test/tools/ReadTool.test.ts
@@ -118,7 +118,7 @@ describe('ReadFileTool', () => {
       catFormat(rangeStart, `row ${rangeStart}`),
     );
     assert.strictEqual(
-      outputLines[outputLines.length - 1],
+      outputLines.at(-1),
       catFormat(rangeEnd, `row ${rangeEnd}`),
     );
   });

--- a/src/tools/DiagnosticsTool.ts
+++ b/src/tools/DiagnosticsTool.ts
@@ -23,7 +23,7 @@ import type { Diagnostic } from 'vscode';
 const CHANNEL = 'DiagnosticsTool';
 logger.initialize(CHANNEL);
 
-export const DiagnosticsInputSchema = z.object({
+export const DiagnosticsInputSchema = z.strictObject({
   command: z.enum(['list', 'count']),
   path: z.string(),
 });

--- a/src/tools/DiagnosticsTool.ts
+++ b/src/tools/DiagnosticsTool.ts
@@ -2,6 +2,7 @@
 import { z } from 'zod';
 
 // Internal imports
+import { toErrorMessage } from '@common/errors/errorHandlingUtils';
 import {
   getLinterMessages,
   countDiagnosticsBySeverity,
@@ -77,7 +78,7 @@ export class DiagnosticsTool extends defineTool({
       const severity = countDiagnosticsBySeverity(messages);
       return { messages, severity };
     } catch (error) {
-      const detail = error instanceof Error ? error.message : String(error);
+      const detail = toErrorMessage(error);
       logger.error(
         CHANNEL,
         `Failed to collect diagnostics for ${path}: ${detail}`,

--- a/src/tools/ReadTool.ts
+++ b/src/tools/ReadTool.ts
@@ -57,7 +57,7 @@ export class ReadFileTool extends defineTool({
 
     const content = await WorkspaceFS.read(input.path);
     const lines = content.split(/\r?\n/);
-    if (lines.length > 0 && lines[lines.length - 1] === '') {
+    if (lines.length > 0 && lines.at(-1) === '') {
       lines.pop();
     }
 

--- a/src/tools/TextEditorTool.ts
+++ b/src/tools/TextEditorTool.ts
@@ -33,7 +33,7 @@ import { ToolCallInput, EditorCommand, FileHistoryEntry } from './types';
 const CHANNEL = 'TextEditorTool';
 const SNIPPET_LINES = 4;
 
-export const TextEditorInputSchema = z.object({
+export const TextEditorInputSchema = z.strictObject({
   command: z.enum(['view', 'create', 'str_replace', 'insert', 'undo_edit']),
   path: z.string(),
   file_text: z.string().optional(),

--- a/src/tools/TextEditorTool.ts
+++ b/src/tools/TextEditorTool.ts
@@ -611,7 +611,7 @@ export class TextEditorTool extends defineTool({
       }
 
       // Restore previous content
-      const previousContent = history[history.length - 1]!;
+      const previousContent = history.at(-1)!;
       const currentContent = await WorkspaceFS.read(filePath);
 
       const approval = await requestToolEditApproval({

--- a/src/tools/applyPath.ts
+++ b/src/tools/applyPath.ts
@@ -2,6 +2,9 @@
 import { execa } from 'execa';
 import { z } from 'zod';
 
+// Local imports - common
+import { toErrorMessage } from '@common/errors/errorHandlingUtils';
+
 // Local imports - tools
 import { ToolError, toolResult, type ToolResult } from '@tools/result';
 import { WorkspaceFS } from '@utils/files';
@@ -53,7 +56,7 @@ export class ApplyPathTool extends defineTool({
       }
 
       const message =
-        error instanceof Error ? error.message : 'Unknown error applying patch';
+        toErrorMessage(error);
       throw new ToolError(`apply_path error: ${message}`);
     }
   }

--- a/src/tools/applyPath.ts
+++ b/src/tools/applyPath.ts
@@ -9,7 +9,7 @@ import { WorkspaceFS } from '@utils/files';
 // Local file imports
 import { defineTool } from './core/define';
 
-const ApplyPathInputSchema = z.object({
+const ApplyPathInputSchema = z.strictObject({
   patch: z.string().min(1, 'patch content is required'),
 });
 

--- a/src/tools/approval/toolEditApprovalContext.ts
+++ b/src/tools/approval/toolEditApprovalContext.ts
@@ -39,5 +39,5 @@ export function getCurrentToolEditApprovalContext():
   if (contextStack.length === 0) {
     return undefined;
   }
-  return contextStack[contextStack.length - 1];
+  return contextStack.at(-1);
 }

--- a/src/tools/arxiv/ArxivDownloadTool.ts
+++ b/src/tools/arxiv/ArxivDownloadTool.ts
@@ -2,6 +2,7 @@
 import { z } from 'zod';
 
 // Local imports - tools
+import { toErrorMessage } from '@common/errors/errorHandlingUtils';
 import { LsTool } from '@tools/ls';
 import { ToolError, ToolResult, toolResult } from '@tools/result';
 import { formatToolOutput, toPosixPath } from '@tools/utils';
@@ -40,8 +41,7 @@ export class ArxivDownloadTool extends defineTool({
         input.autoIndent ?? true,
       );
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      throw new ToolError(`Failed to download arXiv source: ${message}`);
+      throw new ToolError(`Failed to download arXiv source: ${toErrorMessage(err)}`);
     }
 
     const relativeRaw = WorkspaceFS.relativePath(downloadPath);
@@ -59,8 +59,7 @@ export class ArxivDownloadTool extends defineTool({
         listingOutput = `Failed to list directory: ${listingResult.error}`;
       }
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      listingOutput = `Failed to list directory: ${message}`;
+      listingOutput = `Failed to list directory: ${toErrorMessage(err)}`;
     }
 
     const summary = `Downloaded arXiv source to ${displayPath}`;

--- a/src/tools/arxiv/ArxivDownloadTool.ts
+++ b/src/tools/arxiv/ArxivDownloadTool.ts
@@ -41,7 +41,9 @@ export class ArxivDownloadTool extends defineTool({
         input.autoIndent ?? true,
       );
     } catch (err) {
-      throw new ToolError(`Failed to download arXiv source: ${toErrorMessage(err)}`);
+      throw new ToolError(
+        `Failed to download arXiv source: ${toErrorMessage(err)}`,
+      );
     }
 
     const relativeRaw = WorkspaceFS.relativePath(downloadPath);

--- a/src/tools/arxiv/ArxivMetadataTool.ts
+++ b/src/tools/arxiv/ArxivMetadataTool.ts
@@ -46,7 +46,9 @@ export class ArxivMetadataTool extends defineTool({
       // Use arxiv-client's ids() method for direct ID lookup
       entries = await createArxivClient().ids([requestId]).execute();
     } catch (error) {
-      throw new ToolError(`Failed to query arXiv API: ${toErrorMessage(error)}`);
+      throw new ToolError(
+        `Failed to query arXiv API: ${toErrorMessage(error)}`,
+      );
     }
 
     if (!entries || entries.length === 0) {

--- a/src/tools/arxiv/ArxivMetadataTool.ts
+++ b/src/tools/arxiv/ArxivMetadataTool.ts
@@ -2,6 +2,7 @@
 import { z } from 'zod';
 
 // Local imports - latex
+import { toErrorMessage } from '@common/errors/errorHandlingUtils';
 import { ToolError, toolResult } from '@tools/result';
 import {
   type ArxivPaperMetadata,
@@ -45,8 +46,7 @@ export class ArxivMetadataTool extends defineTool({
       // Use arxiv-client's ids() method for direct ID lookup
       entries = await createArxivClient().ids([requestId]).execute();
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      throw new ToolError(`Failed to query arXiv API: ${message}`);
+      throw new ToolError(`Failed to query arXiv API: ${toErrorMessage(error)}`);
     }
 
     if (!entries || entries.length === 0) {

--- a/src/tools/arxiv/ArxivSearchTool.ts
+++ b/src/tools/arxiv/ArxivSearchTool.ts
@@ -87,7 +87,9 @@ export class ArxivSearchTool extends defineTool({
       await waitForRateLimit('arxiv', ARXIV_CONSTANTS.RATE_LIMIT_DELAY_MS);
       entries = await client.execute();
     } catch (error) {
-      throw new ToolError(`Failed to query arXiv API: ${toErrorMessage(error)}`);
+      throw new ToolError(
+        `Failed to query arXiv API: ${toErrorMessage(error)}`,
+      );
     }
 
     const results: ArxivSearchResult[] = entries.map((entry) => {

--- a/src/tools/arxiv/ArxivSearchTool.ts
+++ b/src/tools/arxiv/ArxivSearchTool.ts
@@ -3,6 +3,7 @@ import { all, and, category as catQuery } from 'arxiv-client';
 import { z } from 'zod';
 
 // Local imports - latex
+import { toErrorMessage } from '@common/errors/errorHandlingUtils';
 import { ToolError, toolResult } from '@tools/result';
 import {
   type ArxivSearchResult,
@@ -86,8 +87,7 @@ export class ArxivSearchTool extends defineTool({
       await waitForRateLimit('arxiv', ARXIV_CONSTANTS.RATE_LIMIT_DELAY_MS);
       entries = await client.execute();
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      throw new ToolError(`Failed to query arXiv API: ${message}`);
+      throw new ToolError(`Failed to query arXiv API: ${toErrorMessage(error)}`);
     }
 
     const results: ArxivSearchResult[] = entries.map((entry) => {

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -8,7 +8,7 @@ import { executeCommand } from '@utils/system/execUtils';
 // Local file imports
 import { defineTool } from './core/define';
 
-const BashInputSchema = z.object({
+const BashInputSchema = z.strictObject({
   command: z.string(),
 });
 

--- a/src/tools/citation/CrossrefDoiTool.ts
+++ b/src/tools/citation/CrossrefDoiTool.ts
@@ -3,6 +3,7 @@ import { CrossrefClient } from '@jamesgopsill/crossref-client';
 import { z } from 'zod';
 
 // Local imports - metadata
+import { toErrorMessage } from '@common/errors/errorHandlingUtils';
 import { ToolError, toolResult } from '@tools/result';
 import { defineTool } from '@tools/core/define';
 
@@ -54,8 +55,7 @@ export class CrossrefDoiTool extends defineTool({
       }
       work = message;
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      throw new ToolError(`Crossref lookup failed: ${message}`);
+      throw new ToolError(`Crossref lookup failed: ${toErrorMessage(error)}`);
     }
 
     const titleValue = work.title;

--- a/src/tools/citation/CrossrefSearchTool.ts
+++ b/src/tools/citation/CrossrefSearchTool.ts
@@ -8,6 +8,7 @@ import {
 import { z } from 'zod';
 
 // Local imports - metadata
+import { toErrorMessage } from '@common/errors/errorHandlingUtils';
 import { ToolError, toolResult } from '@tools/result';
 import { defineTool } from '@tools/core/define';
 
@@ -97,8 +98,7 @@ export class CrossrefSearchTool extends defineTool({
       );
       response = await crossrefClient.works(options);
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      throw new ToolError(`Crossref search failed: ${message}`);
+      throw new ToolError(`Crossref search failed: ${toErrorMessage(error)}`);
     }
 
     if (!response.ok || !response.content || !response.content.message) {

--- a/src/tools/citation/rateLimiter.ts
+++ b/src/tools/citation/rateLimiter.ts
@@ -20,7 +20,7 @@ export async function waitForRateLimit(
   apiName: string,
   minDelayMs: number,
 ): Promise<void> {
-  const state = rateLimiters.get(apiName) || { lastRequestTime: 0 };
+  const state = rateLimiters.get(apiName) ?? { lastRequestTime: 0 };
   const now = Date.now();
   const timeSinceLastRequest = now - state.lastRequestTime;
 

--- a/src/tools/core/base.ts
+++ b/src/tools/core/base.ts
@@ -1,11 +1,13 @@
 // Third-party imports
 import { ZodError, type ZodType } from 'zod';
 
-// Local imports - tools
+// Local imports - common
+import { toErrorMessage } from '@common/errors/errorHandlingUtils';
+
+// Local imports - model
 import type { ToolDefinition } from '@model';
 
-// Internal imports
-import { toErrorMessage } from '@common/errors/errorHandlingUtils';
+// Internal imports - tools
 import { ToolResult, toolResult } from '@tools/result';
 
 export abstract class BaseTool<T> {

--- a/src/tools/core/base.ts
+++ b/src/tools/core/base.ts
@@ -5,6 +5,7 @@ import { ZodError, type ZodType } from 'zod';
 import type { ToolDefinition } from '@model';
 
 // Internal imports
+import { toErrorMessage } from '@common/errors/errorHandlingUtils';
 import { ToolResult, toolResult } from '@tools/result';
 
 export abstract class BaseTool<T> {
@@ -47,7 +48,7 @@ export abstract class BaseTool<T> {
           diagnostics: err.issues,
         });
       }
-      const message = err instanceof Error ? err.message : String(err);
+      const message = toErrorMessage(err);
       const diagnostics =
         err instanceof Error ? { name: err.name, stack: err.stack } : undefined;
       return toolResult({

--- a/src/tools/fileOp.ts
+++ b/src/tools/fileOp.ts
@@ -19,7 +19,7 @@ import { defineTool } from './core/define';
 
 // Local imports - tools
 
-const FileOpInputSchema = z.object({
+const FileOpInputSchema = z.strictObject({
   command: z.enum(['read', 'write', 'append']),
   path: z.string(),
   content: z.string().optional(),

--- a/src/tools/glob.ts
+++ b/src/tools/glob.ts
@@ -3,6 +3,7 @@ import { glob } from 'glob';
 import { z } from 'zod';
 
 // Local imports - tools
+import { toErrorMessage } from '@common/errors/errorHandlingUtils';
 import { ToolError, ToolResult, toolResult } from '@tools/result';
 import {
   joinWorkspaceRelativePath,
@@ -48,8 +49,7 @@ export class GlobTool extends defineTool({
         follow: false,
       });
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      throw new ToolError(`glob error: ${message}`);
+      throw new ToolError(`glob error: ${toErrorMessage(err)}`);
     }
 
     // Process matches in parallel for better performance
@@ -59,7 +59,7 @@ export class GlobTool extends defineTool({
         resolved = joinWorkspaceRelativePath(base.relative, match);
       } catch (err) {
         throw new ToolError(
-          `Match resolved outside the workspace: ${match} (${err instanceof Error ? err.message : String(err)})`,
+          `Match resolved outside the workspace: ${match} (${toErrorMessage(err)})`,
         );
       }
 

--- a/src/tools/ls.ts
+++ b/src/tools/ls.ts
@@ -72,7 +72,7 @@ export class LsTool extends defineTool({
 
     if (stats.type === vscode.FileType.File) {
       const relativePosix = toPosixPath(relative);
-      const fileName = relativePosix.split('/').pop() ?? relativePosix;
+      const fileName = relativePosix.split('/').at(-1) ?? relativePosix;
       if (
         isDefaultHiddenName(fileName) ||
         gitignore.ignores(relative) ||

--- a/src/tools/ls.ts
+++ b/src/tools/ls.ts
@@ -3,6 +3,7 @@ import * as vscode from 'vscode';
 import { z } from 'zod';
 
 // Local imports - tools
+import { toErrorMessage } from '@common/errors/errorHandlingUtils';
 import { ToolError, ToolResult, toolResult } from '@tools/result';
 import {
   createGlobMatcher,
@@ -59,7 +60,7 @@ export class LsTool extends defineTool({
     try {
       stats = await WorkspaceFS.stat(relative);
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
+      const message = toErrorMessage(err);
       throw new ToolError(`Path not found: ${display} (${message})`);
     }
 

--- a/src/tools/texcount/TexcountTool.ts
+++ b/src/tools/texcount/TexcountTool.ts
@@ -12,7 +12,7 @@ import {
 
 // Local imports - tool core
 
-const TexcountInputSchema = z.object({
+const TexcountInputSchema = z.strictObject({
   files: z.union([z.string(), z.array(z.string()).min(1)]),
   mode: z.enum(['separate', 'include', 'sum']).optional(),
   format: z.enum(['raw', 'stats']).optional(),

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -170,8 +170,7 @@ export async function buildFileAttachment({
   try {
     stats = await WorkspaceFS.stat(resolved.relative);
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    throw new ToolError(`Failed to inspect attachment ${display}: ${message}`);
+    throw new ToolError(`Failed to inspect attachment ${display}: ${toErrorMessage(err)}`);
   }
 
   if (stats.size > maxBytes) {
@@ -185,8 +184,7 @@ export async function buildFileAttachment({
   try {
     buffer = await WorkspaceFS.readFileBytes(resolved.relative);
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    throw new ToolError(`Failed to read attachment ${display}: ${message}`);
+    throw new ToolError(`Failed to read attachment ${display}: ${toErrorMessage(err)}`);
   }
 
   const inferredMime =

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -5,6 +5,7 @@ import * as path from 'path';
 import { Minimatch } from 'minimatch';
 
 // Local imports - tools
+import { toErrorMessage } from '@common/errors/errorHandlingUtils';
 import { ToolError, type ToolFileAttachment } from '@tools/result';
 import { toPosixPath } from '@tools/pathUtils';
 import { WorkspaceFS, getMimeType } from '@utils/files';
@@ -170,7 +171,9 @@ export async function buildFileAttachment({
   try {
     stats = await WorkspaceFS.stat(resolved.relative);
   } catch (err) {
-    throw new ToolError(`Failed to inspect attachment ${display}: ${toErrorMessage(err)}`);
+    throw new ToolError(
+      `Failed to inspect attachment ${display}: ${toErrorMessage(err)}`,
+    );
   }
 
   if (stats.size > maxBytes) {
@@ -184,7 +187,9 @@ export async function buildFileAttachment({
   try {
     buffer = await WorkspaceFS.readFileBytes(resolved.relative);
   } catch (err) {
-    throw new ToolError(`Failed to read attachment ${display}: ${toErrorMessage(err)}`);
+    throw new ToolError(
+      `Failed to read attachment ${display}: ${toErrorMessage(err)}`,
+    );
   }
 
   const inferredMime =

--- a/src/tools/web/WebFetchTool.ts
+++ b/src/tools/web/WebFetchTool.ts
@@ -119,7 +119,9 @@ export class WebFetchTool extends defineTool({
       try {
         markdown = this.turndown.turndown(rawBody);
       } catch (error) {
-        throw new ToolError(`Failed to convert HTML to Markdown: ${toErrorMessage(error)}`);
+        throw new ToolError(
+          `Failed to convert HTML to Markdown: ${toErrorMessage(error)}`,
+        );
       }
     } else {
       markdown = rawBody;

--- a/src/tools/web/WebFetchTool.ts
+++ b/src/tools/web/WebFetchTool.ts
@@ -7,6 +7,7 @@ import TurndownService from 'turndown';
 import { z } from 'zod';
 
 // Local imports - core
+import { toErrorMessage } from '@common/errors/errorHandlingUtils';
 import { ToolError, ToolResult, toolResult } from '@tools/result';
 import { defineTool } from '@tools/core/define';
 
@@ -99,8 +100,7 @@ export class WebFetchTool extends defineTool({
         }
       }
 
-      const message = error instanceof Error ? error.message : String(error);
-      throw new ToolError(`Failed to fetch ${url}: ${message}`);
+      throw new ToolError(`Failed to fetch ${url}: ${toErrorMessage(error)}`);
     }
 
     const rawBody = response.data;
@@ -119,8 +119,7 @@ export class WebFetchTool extends defineTool({
       try {
         markdown = this.turndown.turndown(rawBody);
       } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        throw new ToolError(`Failed to convert HTML to Markdown: ${message}`);
+        throw new ToolError(`Failed to convert HTML to Markdown: ${toErrorMessage(error)}`);
       }
     } else {
       markdown = rawBody;

--- a/src/tools/web/WebSearchTool.ts
+++ b/src/tools/web/WebSearchTool.ts
@@ -6,7 +6,7 @@ import { z } from 'zod';
 import { ToolResult, ToolError, toolResult } from '@tools/result';
 import { defineTool } from '@tools/core/define';
 
-const WebSearchInputSchema = z.object({
+const WebSearchInputSchema = z.strictObject({
   query: z.string(),
   max_results: z.number().min(1).max(5).optional(),
 });

--- a/src/tools/web/WebSearchTool.ts
+++ b/src/tools/web/WebSearchTool.ts
@@ -3,6 +3,7 @@ import axios from 'axios';
 import { z } from 'zod';
 
 // Internal imports
+import { toErrorMessage } from '@common/errors/errorHandlingUtils';
 import { ToolResult, ToolError, toolResult } from '@tools/result';
 import { defineTool } from '@tools/core/define';
 
@@ -26,8 +27,7 @@ export class WebSearchTool extends defineTool({
         params: { q: query, format: 'json', no_redirect: 1, no_html: 1 },
       });
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      throw new ToolError(`Web search failed: ${message}`);
+      throw new ToolError(`Web search failed: ${toErrorMessage(error)}`);
     }
     const data = response.data;
     const results: string[] = [];

--- a/src/tools/wolfram/WolframTool.ts
+++ b/src/tools/wolfram/WolframTool.ts
@@ -8,7 +8,7 @@ import { defineTool } from '@tools/core/define';
 // Local imports - tools
 import { executeWolframCode } from './wolframScriptUtils';
 
-const WolframInputSchema = z.object({
+const WolframInputSchema = z.strictObject({
   code: z.string(),
   timeout: z.number().optional(),
 });

--- a/src/tools/wolfram/wolframScriptUtils.ts
+++ b/src/tools/wolfram/wolframScriptUtils.ts
@@ -2,6 +2,7 @@
 import * as vscode from 'vscode';
 
 // Local imports - system utilities
+import { toErrorMessage } from '@common/errors/errorHandlingUtils';
 import { executeCommand, checkToolInstalled } from '@utils/system';
 
 // Wolfram configuration is now in toolUtils.ts
@@ -56,7 +57,7 @@ async function runWolfram(
       error: result.stderr,
     };
   } catch (err) {
-    const errorMessage = err instanceof Error ? err.message : String(err);
+    const errorMessage = toErrorMessage(err);
 
     if (opts.showErrorsToUser) {
       vscode.window.showErrorMessage(

--- a/src/utils/files/fileMappingUtils.ts
+++ b/src/utils/files/fileMappingUtils.ts
@@ -1,7 +1,10 @@
 // Standard library imports
 import * as path from 'path';
 
-// Local imports
+// Local imports - common
+import { toErrorMessage } from '@common/errors/errorHandlingUtils';
+
+// Local imports - logger
 import { AgentLogger } from '@logger/AgentLogger';
 
 // Local file imports
@@ -226,7 +229,7 @@ export async function replaceInputCommands(
       }
     } catch (err) {
       logger?.warn(
-        `Error processing input commands in ${outputFile}: ${err instanceof Error ? err.message : String(err)}`,
+        `Error processing input commands in ${outputFile}: ${toErrorMessage(err)}`,
       );
     }
   }

--- a/src/utils/files/taskRunStorage.ts
+++ b/src/utils/files/taskRunStorage.ts
@@ -5,6 +5,9 @@ import { promises as fs } from 'fs';
 // Local imports - log
 import type { ExecutionId } from '@agent/types/IdentifierTypes';
 
+// Local imports - common
+import { toErrorMessage } from '@common/errors/errorHandlingUtils';
+
 // Internal imports
 import * as logger from '@logger/logUtils';
 import { getConfig } from '@utils/config';
@@ -662,9 +665,7 @@ export class TaskRunFileService {
         }
         throw Object.assign(
           new Error(
-            `Failed to capture original file ${target}: ${
-              err instanceof Error ? err.message : String(err)
-            }`,
+            `Failed to capture original file ${target}: ${toErrorMessage(err)}`,
           ),
           { cause: error },
         );
@@ -680,11 +681,9 @@ export class TaskRunFileService {
           try {
             await this.mirrorWorkspaceFile(candidate);
           } catch (error) {
-            const message =
-              error instanceof Error ? error.message : String(error);
             logger.warn(
               CHANNEL,
-              `Failed to mirror workspace dependency ${candidate}: ${message}`,
+              `Failed to mirror workspace dependency ${candidate}: ${toErrorMessage(error)}`,
             );
           }
         }),

--- a/src/utils/files/taskRunStorage.ts
+++ b/src/utils/files/taskRunStorage.ts
@@ -723,7 +723,7 @@ export class TaskRunFileService {
     }
     const normalized = relativePath.replace(/\\/g, '/');
     const segments = normalized.split('/').filter(Boolean);
-    return segments.length === 0 ? normalized : segments[segments.length - 1];
+    return segments.length === 0 ? normalized : segments.at(-1);
   }
 
   public resolveRelativePath(

--- a/src/utils/files/taskRunStorage.ts
+++ b/src/utils/files/taskRunStorage.ts
@@ -723,7 +723,7 @@ export class TaskRunFileService {
     }
     const normalized = relativePath.replace(/\\/g, '/');
     const segments = normalized.split('/').filter(Boolean);
-    return segments.length === 0 ? normalized : segments.at(-1);
+    return segments.length === 0 ? normalized : segments.at(-1)!;
   }
 
   public resolveRelativePath(

--- a/src/utils/system/execUtils.ts
+++ b/src/utils/system/execUtils.ts
@@ -5,6 +5,9 @@ import { quote as shellQuote } from 'shell-quote';
 // Local imports - log
 import type { ExecResult } from '@agent/types/ResultTypes';
 
+// Local imports - common
+import { toErrorMessage } from '@common/errors/errorHandlingUtils';
+
 // Internal imports
 import * as logger from '@logger/logUtils';
 import { WorkspaceFS } from '@utils/files';
@@ -126,10 +129,9 @@ export async function executeCommand(
       timedOut,
     };
   } catch (err) {
-    const errorMessage = err instanceof Error ? err.message : String(err);
     logger.error(
       options.channel ?? CHANNEL,
-      `Error executing command: ${errorMessage}`,
+      `Error executing command: ${toErrorMessage(err)}`,
     );
 
     // Handle stderr from ExecaError
@@ -140,7 +142,7 @@ export async function executeCommand(
 
     // With reject: false, this catch block only handles actual execution errors
     // (e.g., command not found), not timeouts or non-zero exit codes
-    const fallbackOutput = stderr || errorMessage;
+    const fallbackOutput = stderr || toErrorMessage(err);
     const normalizedError = normalizeOutput(fallbackOutput);
     return {
       success: false,

--- a/src/utils/system/execUtils.ts
+++ b/src/utils/system/execUtils.ts
@@ -23,7 +23,7 @@ function truncateOutput(
   maxChars: number = MAX_OUTPUT_LENGTH,
 ): string | null {
   if (text && text.length > maxChars) {
-    return '...' + text.slice(-maxChars);
+    return `...${text.slice(-maxChars)}`;
   }
   return text;
 }

--- a/src/utils/text/xmlUtils.ts
+++ b/src/utils/text/xmlUtils.ts
@@ -3,7 +3,10 @@ import TurndownService from 'turndown';
 import { gfm } from 'turndown-plugin-gfm';
 import nodePandoc from 'node-pandoc';
 
-// Local imports - log
+// Local imports - common
+import { toErrorMessage } from '@common/errors/errorHandlingUtils';
+
+// Local imports - utils
 import * as logger from '@logger/logUtils';
 import { K_SLICE } from '@utils/config';
 import { checkToolInstalled } from '@utils/system/toolUtils';
@@ -135,10 +138,7 @@ async function convertWithPandoc(text: string): Promise<string | null> {
     });
     return result;
   } catch (err) {
-    logger.error(
-      CHANNEL,
-      `Pandoc conversion failed: ${err instanceof Error ? err.message : String(err)}`,
-    );
+    logger.error(CHANNEL, `Pandoc conversion failed: ${toErrorMessage(err)}`);
     return null;
   }
 }
@@ -171,10 +171,7 @@ export function addCdataToTags(xmlData: string, tags: string[]): string {
       return result.replace(pattern, '$1<![CDATA[$2]]>$3');
     }, xmlData);
   } catch (err) {
-    logger.error(
-      CHANNEL,
-      `Error adding CDATA to tags: ${err instanceof Error ? err.message : String(err)}`,
-    );
+    logger.error(CHANNEL, `Error adding CDATA to tags: ${toErrorMessage(err)}`);
     throw err;
   }
 }
@@ -379,7 +376,7 @@ export function extractContentFromXMLbyTagMultiple(
   } catch (err) {
     logger.error(
       CHANNEL,
-      `Error extracting multiple content from tag: ${err instanceof Error ? err.message : String(err)}. Structure: ${getObjectStructure(root)}`,
+      `Error extracting multiple content from tag: ${toErrorMessage(err)}. Structure: ${getObjectStructure(root)}`,
     );
     throw err;
   }

--- a/src/webview/MainViewMessageHandler.ts
+++ b/src/webview/MainViewMessageHandler.ts
@@ -1,8 +1,11 @@
 // Third-party imports
 import * as vscode from 'vscode';
 
-// Local imports - webview
+// Local imports - common
 import { computeAgentOptions } from '@agent/computeAgentOptions';
+import { toErrorMessage } from '@common/errors/errorHandlingUtils';
+
+// Local imports - webview
 import {
   BaseViewMessageHandler,
   MessageHandler,
@@ -435,7 +438,7 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
       this.logger.error(
         this.channel,
         `Failed to compute options: ${
-          error instanceof Error ? error.message : String(error)
+          toErrorMessage(error)
         }`,
       );
     }

--- a/src/webview/managers/FileManager.ts
+++ b/src/webview/managers/FileManager.ts
@@ -8,7 +8,10 @@ import { workspace } from 'vscode';
 // Local imports - webview
 import { loadAgentSettingAndPrompts } from '@agent/runtime/agentLoad';
 import { getAgentPath } from '@agent/runtime/executeAgent';
-import { showLoggedMessage } from '@common/errors/errorHandlingUtils';
+import {
+  showLoggedMessage,
+  toErrorMessage,
+} from '@common/errors/errorHandlingUtils';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands';
 import { fileLister } from '@frontend/files/fileLister';
 import { uncapitalize } from '@frontend/ui/messageUtils';
@@ -182,7 +185,7 @@ export class FileManager {
     } catch (err) {
       logger.error(
         CHANNEL,
-        `Error requesting default output files: ${err instanceof Error ? err.message : String(err)}`,
+        `Error requesting default output files: ${toErrorMessage(err)}`,
       );
       webviewView.webview.postMessage({
         command: MAIN_VIEW_COMMANDS.SET_DEFAULT_OUTPUT_FILES,
@@ -240,10 +243,10 @@ export class FileManager {
     } catch (error) {
       logger.error(
         CHANNEL,
-        `Error in handleSelectMultipleFiles: ${error instanceof Error ? error.message : String(error)}`,
+        `Error in handleSelectMultipleFiles: ${toErrorMessage(error)}`,
       );
       vscode.window.showErrorMessage(
-        `Error selecting ${fileType}: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        `Error selecting ${fileType}: ${toErrorMessage(error)}`,
       );
     }
   }
@@ -472,10 +475,10 @@ export class FileManager {
     } catch (err) {
       logger.error(
         CHANNEL,
-        `Error selecting output files: ${err instanceof Error ? err.message : String(err)}`,
+        `Error selecting output files: ${toErrorMessage(err)}`,
       );
       vscode.window.showErrorMessage(
-        `Error selecting output files: ${err instanceof Error ? err.message : String(err)}`,
+        `Error selecting output files: ${toErrorMessage(err)}`,
       );
       return null;
     }

--- a/src/webview/managers/InstructionManager.ts
+++ b/src/webview/managers/InstructionManager.ts
@@ -4,8 +4,11 @@ import * as path from 'path';
 // Third-party imports
 import * as vscode from 'vscode';
 
-// Local imports - commands
+// Local imports - common
+import { toErrorMessage } from '@common/errors/errorHandlingUtils';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands';
+
+// Local imports - logger
 import * as logger from '@logger/logUtils';
 import { StorageFS } from '@utils/files';
 import { THREE_DAYS_MS } from '@utils/config';
@@ -29,7 +32,7 @@ export class InstructionManager {
         .catch((e) =>
           logger.warn(
             CHANNEL,
-            `Error during initial cleanup: ${e instanceof Error ? e.message : String(e)}`,
+            `Error during initial cleanup: ${toErrorMessage(e)}`,
           ),
         );
     }, 100);
@@ -138,25 +141,21 @@ export class InstructionManager {
       } catch (error) {
         webviewView.webview.postMessage({
           command: MAIN_VIEW_COMMANDS.INSTRUCTION_TEXT_POLISH_ERROR,
-          error:
-            error instanceof Error ? error.message : 'Unknown error occurred',
+          error: toErrorMessage(error),
         });
         logger.error(
           CHANNEL,
-          `Error in handlePolishInstructionText: ${
-            error instanceof Error ? error.message : String(error)
-          }`,
+          `Error in handlePolishInstructionText: ${toErrorMessage(error)}`,
         );
       }
     } catch (error) {
       webviewView.webview.postMessage({
         command: MAIN_VIEW_COMMANDS.INSTRUCTION_TEXT_POLISH_ERROR,
-        error:
-          error instanceof Error ? error.message : 'Unknown error occurred',
+        error: toErrorMessage(error),
       });
       logger.error(
         CHANNEL,
-        `Error setting up text polishing: ${error instanceof Error ? error.message : String(error)}`,
+        `Error setting up text polishing: ${toErrorMessage(error)}`,
       );
     }
   }
@@ -188,7 +187,7 @@ export class InstructionManager {
     } catch (err) {
       logger.error(
         CHANNEL,
-        `Error handling clipboard image: ${err instanceof Error ? err.message : String(err)}`,
+        `Error handling clipboard image: ${toErrorMessage(err)}`,
       );
     }
   }

--- a/src/webview/managers/RecordingManager.ts
+++ b/src/webview/managers/RecordingManager.ts
@@ -1,6 +1,9 @@
 // Third-party imports
 import * as vscode from 'vscode';
 
+// Local imports - common
+import { toErrorMessage } from '@common/errors/errorHandlingUtils';
+
 // Local imports - media utilities
 import {
   startRecording,
@@ -41,15 +44,12 @@ export class RecordingManager {
       }
     } catch (error) {
       vscode.window.showErrorMessage(
-        `Error starting recording: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        `Error starting recording: ${toErrorMessage(error)}`,
       );
-      logger.error(
-        CHANNEL,
-        `Error in start: ${error instanceof Error ? error.message : String(error)}`,
-      );
+      logger.error(CHANNEL, `Error in start: ${toErrorMessage(error)}`);
       webviewView.webview.postMessage({
         command: this.commandConfig.recordingErrorCommand,
-        error: error instanceof Error ? error.message : 'Unknown error',
+        error: toErrorMessage(error),
       });
     }
   }
@@ -93,15 +93,12 @@ export class RecordingManager {
       );
     } catch (error) {
       vscode.window.showErrorMessage(
-        `Error stopping recording: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        `Error stopping recording: ${toErrorMessage(error)}`,
       );
-      logger.error(
-        CHANNEL,
-        `Error in stop: ${error instanceof Error ? error.message : String(error)}`,
-      );
+      logger.error(CHANNEL, `Error in stop: ${toErrorMessage(error)}`);
       webviewView.webview.postMessage({
         command: this.commandConfig.recordingErrorCommand,
-        error: error instanceof Error ? error.message : 'Unknown error',
+        error: toErrorMessage(error),
       });
       acknowledgeStop();
     }


### PR DESCRIPTION
- Fix Zod v4 syntax: replace .default().optional() with .prefault()
  in StreamUsageMessageSchema
- Migrate all z.object() to z.strictObject() for stricter type safety
  across all schemas (agent configs, tools, result types)
- Enhance type safety by preventing unexpected properties in schemas
- Make code more lean and maintainable with modern TypeScript patterns

Affected files:
- Agent schemas: AgentConfig, AgentDataclass, UsageTypes, DiffTypes, ResultTypes
- Tool schemas: DiagnosticsTool, TextEditorTool, applyPath, bash, fileOp,
  texcount, WebSearchTool, WolframTool

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Convert schemas to z.strictObject with prefault defaults, standardize errors via toErrorMessage, and modernize array/string ops across agents, tools, and webview.
> 
> - **Schemas & Validation**:
>   - Migrate numerous schemas from `z.object` to `z.strictObject` and adopt `.prefault()` defaults (e.g., Agent, Types, Tools, Web commands).
>   - Tighten `AgentConfig`, prompts, usage/diff/result types; refine `StreamUsageMessageSchema` defaults.
> - **Error Handling**:
>   - Replace ad-hoc error messages with centralized `toErrorMessage` across agents, tools, commands, utils, and webviews.
> - **Model Handlers**:
>   - Use modern array access (`.at(-1)`), nullish coalescing, and safer updates in Anthropic/Google/OpenAI handlers; minor token/usage handling tweaks.
> - **Output/XML Processing**:
>   - Strengthen logging and error paths; small refactors in `OutputHandler`, `LatexDiffManager`, `XmlOutputManager`.
> - **Tools**:
>   - Harden inputs with `z.strictObject`; improve IO/attachments, glob/ls handling, and CLI exec error paths.
> - **Webview/Commands**:
>   - Standardize message/error handling; minor logic cleanups and safer selections in file/recording/instruction managers.
> - **Utils/Tests**:
>   - Modernize helpers (`truncateOutput`, path/utils), adopt `.at`, and update tests accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 160da30acbdd6646bb3c3b25afb1dc87359bce64. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->