### PR TITLE
fix: hide verbose diagnostics in progress view

### DIFF
--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -743,15 +743,28 @@ export class LogEntryFormatter {
     }
 
     if (outputCandidate && outputCandidate.diagnostics !== undefined) {
-      const diagnosticsJson = toYamlString(outputCandidate.diagnostics);
-      sections.push(`
-        <div class="tool-use-section">
-          <div class="tool-use-subsection">
-            <span class="tool-use-sublabel">Diagnostics:</span>
-            <pre>${encodeHtml(diagnosticsJson)}</pre>
+      const diagnosticsText = toYamlString(outputCandidate.diagnostics).trim();
+      const MAX_DIAGNOSTICS_LENGTH = 600;
+
+      if (diagnosticsText && diagnosticsText.length <= MAX_DIAGNOSTICS_LENGTH) {
+        sections.push(`
+          <div class="tool-use-section">
+            <div class="tool-use-subsection">
+              <span class="tool-use-sublabel">Diagnostics:</span>
+              <pre>${encodeHtml(diagnosticsText)}</pre>
+            </div>
           </div>
-        </div>
-      `);
+        `);
+      } else if (diagnosticsText) {
+        sections.push(`
+          <div class="tool-use-section">
+            <div class="tool-use-subsection">
+              <span class="tool-use-sublabel">Diagnostics:</span>
+              <div>Diagnostics omitted (too verbose for progress view).</div>
+            </div>
+          </div>
+        `);
+      }
     }
 
     if (outputCandidate && typeof outputCandidate.system === 'string') {


### PR DESCRIPTION
## Summary
- omit overly long diagnostics blocks from progress view tool-use entries
- keep short diagnostic messages visible while avoiding verbose stack traces

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69199e1c55548324a0be33f189778c51)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Limits tool-use `diagnostics` display by showing trimmed YAML only if short; otherwise hides it with an omission notice.
> 
> - **Progress View**:
>   - **Tool-use `diagnostics` handling**:
>     - Convert to YAML and `trim()`; display only when length ≤ 600 chars.
>     - If longer, hide diagnostics and show a brief "Diagnostics omitted (too verbose for progress view)." notice.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dce4400e2e7a71aa9f24a38caeb9cdcc469a99a5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->