### PR TITLE
Fix agent finalize flow typings

### DIFF
--- a/src/agent/implementations/flows/common/createAgentRunFlow.ts
+++ b/src/agent/implementations/flows/common/createAgentRunFlow.ts
@@ -2,7 +2,11 @@
 import { BaseNode, Flow } from '@agent/node';
 
 // Internal imports
-import { AgentInitNode, type AgentInitNodeConfig } from './AgentInitNode';
+import {
+  AgentInitNode,
+  type AgentInitNodeConfig,
+  type AgentInitShared,
+} from './AgentInitNode';
 import { buildRunFlow } from './buildRunFlow';
 
 interface FlowLink<Shared> {
@@ -11,7 +15,7 @@ interface FlowLink<Shared> {
   to?: BaseNode<Shared>;
 }
 
-interface CreateAgentRunFlowOptions<Shared> {
+interface CreateAgentRunFlowOptions<Shared extends AgentInitShared<any, any>> {
   init: AgentInitNodeConfig<Shared>;
   finalize: BaseNode<Shared>;
   links(nodes: {
@@ -20,7 +24,7 @@ interface CreateAgentRunFlowOptions<Shared> {
   }): FlowLink<Shared>[];
 }
 
-export function createAgentRunFlow<Shared>({
+export function createAgentRunFlow<Shared extends AgentInitShared<any, any>>({
   init,
   finalize,
   links,

--- a/src/agent/implementations/flows/common/createFinalizeNode.ts
+++ b/src/agent/implementations/flows/common/createFinalizeNode.ts
@@ -3,7 +3,7 @@ import { BaseNode } from '@agent/node';
 
 // Internal imports
 import { finalizeLifecycle } from './finalizeLifecycle';
-import { setLifecyclePhase } from './lifecycle';
+import { completeLifecycle, setLifecyclePhase } from './lifecycle';
 
 // Type imports
 import type { AgentRunShared } from './types';
@@ -56,7 +56,9 @@ export function createAgentFinalizeNode<
         ? () => {
             void options.onSuccess?.(context);
           }
-        : () => {};
+        : () => {
+            completeLifecycle(context.lifecycle);
+          };
       const handleSecondaryError = options.onSecondaryError
         ? (error: unknown) => options.onSecondaryError?.(context, error)
         : undefined;

--- a/src/agent/implementations/flows/common/createFinalizeNode.ts
+++ b/src/agent/implementations/flows/common/createFinalizeNode.ts
@@ -11,14 +11,15 @@ import type { FinalizeNodeContext } from './nodeExecution';
 
 export interface AgentFinalizeNodeOptions<
   Shared extends AgentRunShared<any, any, any, any>,
+  Status extends 'error' | 'stopped' = 'error' | 'stopped',
 > {
   finalizePhase: Shared['lifecycle']['phase'];
   computeStatus(
     context: FinalizeNodeContext<Shared['lifecycle'], Shared['hooks']>,
-  ): string;
+  ): Status;
   runFinalize(
     context: FinalizeNodeContext<Shared['lifecycle'], Shared['hooks']>,
-    status: string,
+    status: Status,
   ): Promise<void>;
   runCleanup(
     context: FinalizeNodeContext<Shared['lifecycle'], Shared['hooks']>,
@@ -34,7 +35,8 @@ export interface AgentFinalizeNodeOptions<
 
 export function createAgentFinalizeNode<
   Shared extends AgentRunShared<any, any, any, any>,
->(options: AgentFinalizeNodeOptions<Shared>): BaseNode<Shared> {
+  Status extends 'error' | 'stopped' = 'error' | 'stopped',
+>(options: AgentFinalizeNodeOptions<Shared, Status>): BaseNode<Shared> {
   return new (class AgentFinalizeNode extends BaseNode<Shared> {
     async prep(
       shared: Shared,
@@ -50,16 +52,20 @@ export function createAgentFinalizeNode<
       context: FinalizeNodeContext<Shared['lifecycle'], Shared['hooks']>,
     ): Promise<void> {
       const status = options.computeStatus(context);
+      const runOnSuccess = options.onSuccess
+        ? () => {
+            void options.onSuccess?.(context);
+          }
+        : () => {};
+      const handleSecondaryError = options.onSecondaryError
+        ? (error: unknown) => options.onSecondaryError?.(context, error)
+        : undefined;
       await finalizeLifecycle({
         lifecycle: context.lifecycle,
         runFinalize: () => options.runFinalize(context, status),
         runCleanup: () => options.runCleanup(context),
-        onSuccess: options.onSuccess
-          ? () => options.onSuccess?.(context)
-          : undefined,
-        onSecondaryError: options.onSecondaryError
-          ? (error) => options.onSecondaryError?.(context, error)
-          : undefined,
+        onSuccess: runOnSuccess,
+        onSecondaryError: handleSecondaryError,
       });
     }
   })();


### PR DESCRIPTION
## Summary
- constrain agent run flow generics to the expected agent init shared contract
- tighten finalize node status typing and provide a default success handler to satisfy lifecycle expectations

## Testing
- npm run lint
- npm run compile

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919c12f87488324aa1fbe75adbbb961)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Constrain agent run flow generics to `AgentInitShared` and refine finalize node status typing with a default lifecycle completion handler.
> 
> - **Types**:
>   - `src/agent/implementations/flows/common/createAgentRunFlow.ts`:
>     - Constrain `Shared` to `AgentInitShared<any, any>` for `CreateAgentRunFlowOptions` and `createAgentRunFlow`.
>   - `src/agent/implementations/flows/common/createFinalizeNode.ts`:
>     - Add generic `Status extends 'error' | 'stopped'` across options and factory, ensuring typed `computeStatus` and `runFinalize`.
>     - Import and use `completeLifecycle`; provide default `onSuccess` handler that completes lifecycle when none is supplied.
>     - Minor refactor to derive `onSuccess` and `onSecondaryError` handlers before calling `finalizeLifecycle`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 21d52c6d33d468b51595009d3e1943f22400fa90. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->