### PR TITLE
Fix finalize flow typings

### DIFF
--- a/src/agent/implementations/flows/ReflectionRunFlow.ts
+++ b/src/agent/implementations/flows/ReflectionRunFlow.ts
@@ -161,7 +161,10 @@ class ReflectionRoundNode<C> extends BaseNode<ReflectionRunShared<C>> {
 
 export function createReflectionRunFlow<C>(): Flow<ReflectionRunShared<C>> {
   const roundNode = new ReflectionRoundNode<C>();
-  const finalizeNode = createAgentFinalizeNode<ReflectionRunShared<C>>({
+  const finalizeNode = createAgentFinalizeNode<
+    ReflectionRunShared<C>,
+    'error' | 'stopped'
+  >({
     finalizePhase: 'finalize',
     computeStatus: ({ lifecycle }) => (lifecycle.error ? 'error' : 'stopped'),
     runFinalize: async ({ hooks }, status) => {

--- a/src/agent/implementations/flows/ToolUseRunFlow.ts
+++ b/src/agent/implementations/flows/ToolUseRunFlow.ts
@@ -190,7 +190,10 @@ class ToolUseCycleNode<C> extends BaseNode<ToolUseRunShared<C>> {
 export function createToolUseRunFlow<C>(): Flow<ToolUseRunShared<C>> {
   const prepareNode = new ToolUsePrepareNode<C>();
   const cycleNode = new ToolUseCycleNode<C>();
-  const finalizeNode = createAgentFinalizeNode<ToolUseRunShared<C>>({
+  const finalizeNode = createAgentFinalizeNode<
+    ToolUseRunShared<C>,
+    'error' | 'stopped'
+  >({
     finalizePhase: 'finalize',
     computeStatus: ({ lifecycle }) =>
       lifecycle.status === 'error' ? 'error' : 'stopped',

--- a/src/agent/implementations/flows/common/createAgentRunFlow.ts
+++ b/src/agent/implementations/flows/common/createAgentRunFlow.ts
@@ -2,7 +2,11 @@
 import { BaseNode, Flow } from '@agent/node';
 
 // Internal imports
-import { AgentInitNode, type AgentInitNodeConfig } from './AgentInitNode';
+import {
+  AgentInitNode,
+  type AgentInitNodeConfig,
+  type AgentInitShared,
+} from './AgentInitNode';
 import { buildRunFlow } from './buildRunFlow';
 
 interface FlowLink<Shared> {
@@ -11,7 +15,7 @@ interface FlowLink<Shared> {
   to?: BaseNode<Shared>;
 }
 
-interface CreateAgentRunFlowOptions<Shared> {
+interface CreateAgentRunFlowOptions<Shared extends AgentInitShared<any, any>> {
   init: AgentInitNodeConfig<Shared>;
   finalize: BaseNode<Shared>;
   links(nodes: {
@@ -20,7 +24,7 @@ interface CreateAgentRunFlowOptions<Shared> {
   }): FlowLink<Shared>[];
 }
 
-export function createAgentRunFlow<Shared>({
+export function createAgentRunFlow<Shared extends AgentInitShared<any, any>>({
   init,
   finalize,
   links,

--- a/src/agent/implementations/flows/common/createFinalizeNode.ts
+++ b/src/agent/implementations/flows/common/createFinalizeNode.ts
@@ -11,14 +11,15 @@ import type { FinalizeNodeContext } from './nodeExecution';
 
 export interface AgentFinalizeNodeOptions<
   Shared extends AgentRunShared<any, any, any, any>,
+  Status extends string = string,
 > {
   finalizePhase: Shared['lifecycle']['phase'];
   computeStatus(
     context: FinalizeNodeContext<Shared['lifecycle'], Shared['hooks']>,
-  ): string;
+  ): Status;
   runFinalize(
     context: FinalizeNodeContext<Shared['lifecycle'], Shared['hooks']>,
-    status: string,
+    status: Status,
   ): Promise<void>;
   runCleanup(
     context: FinalizeNodeContext<Shared['lifecycle'], Shared['hooks']>,
@@ -34,7 +35,8 @@ export interface AgentFinalizeNodeOptions<
 
 export function createAgentFinalizeNode<
   Shared extends AgentRunShared<any, any, any, any>,
->(options: AgentFinalizeNodeOptions<Shared>): BaseNode<Shared> {
+  Status extends string = string,
+>(options: AgentFinalizeNodeOptions<Shared, Status>): BaseNode<Shared> {
   return new (class AgentFinalizeNode extends BaseNode<Shared> {
     async prep(
       shared: Shared,
@@ -56,7 +58,7 @@ export function createAgentFinalizeNode<
         runCleanup: () => options.runCleanup(context),
         onSuccess: options.onSuccess
           ? () => options.onSuccess?.(context)
-          : undefined,
+          : () => {},
         onSecondaryError: options.onSecondaryError
           ? (error) => options.onSecondaryError?.(context, error)
           : undefined,


### PR DESCRIPTION
## Summary
- tighten finalize node typing to carry status literals and default success handling
- constrain agent run flow generics to valid initialization shapes
- pass explicit finalize status unions for reflection and tool-use flows

## Testing
- npm run lint
- npm run compile

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919c1e0ef4083249388643287e64a9e)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Tightens finalize node typing (status literals + default onSuccess), constrains agent run flow generics, and updates reflection/tool-use flows to pass explicit finalize statuses.
> 
> - **Common flow utilities**:
>   - `createFinalizeNode`: add generic `Status` type for `computeStatus`/`runFinalize`; default `onSuccess` to no-op; keep `onSecondaryError` signature.
>   - `createAgentRunFlow`: constrain `Shared` to `AgentInitShared` and update imports.
> - **Flows**:
>   - `ReflectionRunFlow` and `ToolUseRunFlow`: instantiate `createAgentFinalizeNode` with explicit status union `'error' | 'stopped'`; maintain existing finalize logic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 89a6e441395822c22cd563e12194b267bf857ef6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->