### PR TITLE
refactor: improve TypeScript structures and reduce code duplication

### DIFF
--- a/src/agent/core/flows/CommonCycleTypes.ts
+++ b/src/agent/core/flows/CommonCycleTypes.ts
@@ -1,0 +1,43 @@
+/**
+ * Common types shared across different flow cycles to reduce duplication
+ * and provide consistent interfaces.
+ */
+
+import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
+import type { ProviderStopReason } from '@agent/modelHandlers/types/StopReasonTypes';
+
+/**
+ * Base state interface shared by all cycle flows.
+ * Contains common fields for message handling and flow control.
+ */
+export interface BaseCycleState {
+  /** Messages being processed in this cycle */
+  messages: ProviderMessage[];
+  /** Whether the cycle should stop processing */
+  shouldStop: boolean;
+  /** Time taken for response in seconds */
+  responseTime?: number;
+  /** Reason the model stopped generating */
+  stopReason?: ProviderStopReason;
+}
+
+/**
+ * Generic reset function for cycle states.
+ * Resets all resettable fields while preserving input data (messages).
+ *
+ * @param state - The state object to reset
+ * @param fieldsToReset - Array of field names to reset to undefined
+ */
+export function resetCycleState<T extends BaseCycleState>(
+  state: T,
+  fieldsToReset: Array<keyof Omit<T, keyof BaseCycleState>>,
+): void {
+  state.shouldStop = false;
+  state.responseTime = undefined;
+  state.stopReason = undefined;
+
+  // Reset additional fields specific to the cycle type
+  for (const field of fieldsToReset) {
+    (state[field] as any) = undefined;
+  }
+}

--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -87,7 +87,6 @@ export type ResponseCycleState = ResponseCycleInputState &
 
 function resetResponseCycleState(cycle: ResponseCycleRuntimeState): void {
   resetCycleState(cycle, [
-    'endTurn' as keyof Omit<ResponseCycleRuntimeState, keyof BaseCycleState>,
     'responseObject' as keyof Omit<
       ResponseCycleRuntimeState,
       keyof BaseCycleState
@@ -97,6 +96,7 @@ function resetResponseCycleState(cycle: ResponseCycleRuntimeState): void {
       keyof BaseCycleState
     >,
   ]);
+  // Boolean fields set directly to avoid undefined intermediate state
   cycle.endTurn = false;
   cycle.roundFinalized = false;
 }

--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -5,6 +5,10 @@ import { AgentSharedStore } from '@agent/core/AgentSharedStore';
 import type { ResponseCycleOptions } from '@agent/core/ResponseCycle';
 // Internal imports
 import { resolveUsageProvider } from '@agent/core/UsageProviderUtils';
+import {
+  BaseCycleState,
+  resetCycleState,
+} from '@agent/core/flows/CommonCycleTypes';
 // Type imports
 import type { ProviderStopReason } from '@agent/modelHandlers/types/StopReasonTypes';
 import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
@@ -63,21 +67,17 @@ async function maybeSaveDebug(
 }
 
 export interface ResponseCycleInputState {
-  messages: ProviderMessage[];
   outputFile: string;
 }
 
-export interface ResponseCycleRuntimeState {
+export interface ResponseCycleRuntimeState extends BaseCycleState {
   endTurn: boolean;
-  shouldStop: boolean;
   outputExists: boolean;
   systemPrompt?: string;
   debugContext?: DebugContext;
   debugFileOptions?: DebugFileOptions;
   startTime?: number;
   responseObject?: unknown;
-  responseTime?: number;
-  stopReason?: ProviderStopReason;
   processedResponse?: string;
   roundFinalized: boolean;
 }
@@ -86,12 +86,18 @@ export type ResponseCycleState = ResponseCycleInputState &
   ResponseCycleRuntimeState;
 
 function resetResponseCycleState(cycle: ResponseCycleRuntimeState): void {
-  cycle.shouldStop = false;
+  resetCycleState(cycle, [
+    'endTurn' as keyof Omit<ResponseCycleRuntimeState, keyof BaseCycleState>,
+    'responseObject' as keyof Omit<
+      ResponseCycleRuntimeState,
+      keyof BaseCycleState
+    >,
+    'processedResponse' as keyof Omit<
+      ResponseCycleRuntimeState,
+      keyof BaseCycleState
+    >,
+  ]);
   cycle.endTurn = false;
-  cycle.responseObject = undefined;
-  cycle.responseTime = undefined;
-  cycle.stopReason = undefined;
-  cycle.processedResponse = undefined;
   cycle.roundFinalized = false;
 }
 
@@ -114,8 +120,8 @@ export interface ResponseCycleShared<C = unknown> {
 }
 
 type InvocationNodeResult =
-  | { skipped: true }
-  | { response: unknown; responseTime?: number };
+  | { type: 'skipped' }
+  | { type: 'success'; response: unknown; responseTime?: number };
 
 // Each node in the response cycle progressively hydrates the shared cycle
 // object. Mutations performed in `prep`, `exec`, and `post` stages are
@@ -212,7 +218,7 @@ class ResponseModelInvocationNode<C> extends BaseNode<ResponseCycleShared<C>> {
   async exec(context: ResponseCycleShared<C>): Promise<InvocationNodeResult> {
     const { options, state } = context;
     if (state.shouldStop) {
-      return { skipped: true };
+      return { type: 'skipped' };
     }
 
     const abortController = new AbortController();
@@ -244,7 +250,7 @@ class ResponseModelInvocationNode<C> extends BaseNode<ResponseCycleShared<C>> {
         return { response: invocation, responseTime: elapsed };
       });
 
-      return { response, responseTime };
+      return { type: 'success', response, responseTime };
     } catch (error) {
       const formattedError = formatProviderHttpError(error);
       const message = `Model invocation failed: ${formattedError.message}`;
@@ -269,7 +275,7 @@ class ResponseModelInvocationNode<C> extends BaseNode<ResponseCycleShared<C>> {
   ): Promise<string | undefined> {
     const { options, state } = prepRes;
 
-    if ('skipped' in execRes) {
+    if (execRes.type === 'skipped') {
       state.endTurn = false;
       return FlowTransition.COMPLETE;
     }
@@ -313,11 +319,14 @@ interface ProcessResult {
   repetitionDetected: boolean;
 }
 
-type ProcessNodeResult = { skipped: true } | ProcessResult;
+type ProcessNodeResult =
+  | { type: 'skipped' }
+  | (ProcessResult & { type: 'success' });
 
 type ContinuationNodeResult =
-  | { skipped: true }
+  | { type: 'skipped' }
   | {
+      type: 'success';
       shouldEndTurn: boolean;
       shouldStop: boolean;
       shouldContinue: boolean;
@@ -335,7 +344,7 @@ class ResponseProcessNode<C> extends BaseNode<ResponseCycleShared<C>> {
   async exec(context: ResponseCycleShared<C>): Promise<ProcessNodeResult> {
     const { options, state, store } = context;
     if (state.shouldStop || !state.responseObject) {
-      return { skipped: true };
+      return { type: 'skipped' };
     }
 
     const stage = await options.logger.stage('Process response', {
@@ -442,6 +451,7 @@ class ResponseProcessNode<C> extends BaseNode<ResponseCycleShared<C>> {
       }
 
       return {
+        type: 'success',
         stopReason,
         newResponse,
         processedResponse,
@@ -451,7 +461,7 @@ class ResponseProcessNode<C> extends BaseNode<ResponseCycleShared<C>> {
         responseUsage,
         apiUsage,
         repetitionDetected: repetitionResult.massiveRepetitionDetected,
-      } satisfies ProcessResult;
+      };
     });
   }
 
@@ -462,7 +472,7 @@ class ResponseProcessNode<C> extends BaseNode<ResponseCycleShared<C>> {
   ): Promise<string | undefined> {
     const { options, state, store } = prepRes;
 
-    if ('skipped' in execRes) {
+    if (execRes.type === 'skipped') {
       state.endTurn = false;
       await finalizeRoundIfNeeded(store, state);
       return FlowTransition.COMPLETE;
@@ -581,7 +591,7 @@ class ResponseContinuationNode<C> extends BaseNode<ResponseCycleShared<C>> {
   async exec(context: ResponseCycleShared<C>): Promise<ContinuationNodeResult> {
     const { options, state, store } = context;
     if (state.shouldStop || !state.stopReason || !state.processedResponse) {
-      return { skipped: true };
+      return { type: 'skipped' };
     }
 
     const stopReason = state.stopReason!;
@@ -595,6 +605,7 @@ class ResponseContinuationNode<C> extends BaseNode<ResponseCycleShared<C>> {
       const interrupted = Boolean(await options.checkInterruption());
       if (interrupted) {
         return {
+          type: 'success',
           shouldEndTurn: false,
           shouldStop: true,
           shouldContinue: false,
@@ -616,7 +627,7 @@ class ResponseContinuationNode<C> extends BaseNode<ResponseCycleShared<C>> {
         options.agentSetting,
       );
 
-      return { shouldEndTurn, shouldStop, shouldContinue };
+      return { type: 'success', shouldEndTurn, shouldStop, shouldContinue };
     });
   }
 
@@ -627,7 +638,7 @@ class ResponseContinuationNode<C> extends BaseNode<ResponseCycleShared<C>> {
   ): Promise<string | undefined> {
     const { options, state, store } = prepRes;
 
-    if ('skipped' in execRes) {
+    if (execRes.type === 'skipped') {
       state.endTurn = false;
       state.shouldStop = true;
       await finalizeRoundIfNeeded(store, state);

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -6,6 +6,10 @@ import { BaseNode, Flow } from '@agent/node';
 import { AgentSharedStore } from '@agent/core/AgentSharedStore';
 // Type imports
 import type { ToolUseCycleOptions } from '@agent/core/ToolUseCycle';
+import {
+  BaseCycleState,
+  resetCycleState,
+} from '@agent/core/flows/CommonCycleTypes';
 import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
 import type { ProviderStopReason } from '@agent/modelHandlers/types/StopReasonTypes';
 // Internal imports
@@ -213,23 +217,18 @@ type ToolDispatchErrorResult = {
   fallbackMessage?: string;
 };
 
-export interface ToolUseCycleState {
-  messages: ProviderMessage[];
-  shouldStop: boolean;
+export interface ToolUseCycleState extends BaseCycleState {
   response?: unknown;
-  responseTime?: number;
   toolInfo?: string;
   text?: string;
-  stopReason?: ProviderStopReason;
 }
 
 function resetToolUseState(state: ToolUseCycleState): void {
-  state.shouldStop = false;
-  state.response = undefined;
-  state.responseTime = undefined;
-  state.toolInfo = undefined;
-  state.text = undefined;
-  state.stopReason = undefined;
+  resetCycleState(state, [
+    'response' as keyof Omit<ToolUseCycleState, keyof BaseCycleState>,
+    'toolInfo' as keyof Omit<ToolUseCycleState, keyof BaseCycleState>,
+    'text' as keyof Omit<ToolUseCycleState, keyof BaseCycleState>,
+  ]);
 }
 
 export interface ToolUseCycleShared<C = unknown> {

--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -4,6 +4,7 @@ import type { IModelHandler } from '@agent/modelHandlers';
 import {
   OutputHandler,
   IOutputHandler,
+  getOutputFileName,
   type RoundOutputArtifacts,
 } from '@agent/output';
 
@@ -282,8 +283,24 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
 
   /**
    * Generates output file path for specified conversation round.
+   * Default implementation uses scratchpad mode detection to determine file extension.
+   * Override for specialized naming logic (e.g., MergeAgent).
    */
-  protected abstract getOutputFile(currRound: number): string;
+  protected getOutputFile(currRound: number): string {
+    const baseOutputFile = this.agentConfig.inputFile;
+    const fileExtension = this.useScratchpad
+      ? 'xml'
+      : this.agentSetting.outputExt;
+
+    return getOutputFileName(
+      baseOutputFile,
+      this.agentConfig.agent,
+      this.modelHandler.config.name,
+      fileExtension,
+      currRound,
+      this.agentConfig.editedFile || undefined,
+    );
+  }
 
   /**
    * Processes completion of conversation round.

--- a/src/agent/implementations/CoTAgent.ts
+++ b/src/agent/implementations/CoTAgent.ts
@@ -1,5 +1,4 @@
 // Local imports - agent components
-import { getOutputFileName } from '@agent/output';
 import { ConversationRoundState, AgentRunState } from '@agent/core/AgentState';
 
 // Local file imports
@@ -10,25 +9,6 @@ import { BaseReflectionAgent, RoundOutputOptions } from './BaseReflectionAgent';
  * Adds XML structure validation and specialized output handling for multi-step reasoning.
  */
 export class CoTAgent extends BaseReflectionAgent {
-  /**
-   * Generates output file name based on configuration and current round.
-   * @param currRound Current round number in the conversation
-   * @returns Formatted output file path incorporating model and round information
-   */
-  protected getOutputFile(currRound: number): string {
-    const baseOutputFile = this.agentConfig.inputFile;
-    const fileExtension = this.useScratchpad
-      ? 'xml'
-      : this.agentSetting.outputExt;
-    return getOutputFileName(
-      baseOutputFile,
-      this.agentConfig.agent,
-      this.modelHandler.config.name,
-      fileExtension,
-      currRound,
-      this.agentConfig.editedFile || undefined,
-    );
-  }
 
   /**
    * Processes output for the current round with XML validation.

--- a/src/agent/implementations/DirectAgent.ts
+++ b/src/agent/implementations/DirectAgent.ts
@@ -1,5 +1,4 @@
 // Local imports - agent
-import { getOutputFileName } from '@agent/output';
 import { ConversationRoundState, AgentRunState } from '@agent/core/AgentState';
 
 // Local imports - agent components
@@ -12,23 +11,6 @@ import { BaseReflectionAgent, RoundOutputOptions } from './BaseReflectionAgent';
 export class DirectAgent extends BaseReflectionAgent {
   protected override getTotalRounds(): number {
     return 1;
-  }
-
-  /**
-   * Generates output file name based on configuration and current round.
-   * @param currRound Current round number in the conversation
-   * @returns Formatted output file path incorporating model and round information
-   */
-  protected getOutputFile(currRound: number): string {
-    const baseOutputFile = this.agentConfig.inputFile;
-    return getOutputFileName(
-      baseOutputFile,
-      this.agentConfig.agent,
-      this.modelHandler.config.name,
-      this.agentSetting.outputExt,
-      currRound,
-      this.agentConfig.editedFile || undefined,
-    );
   }
 
   /**

--- a/src/agent/implementations/flows/common/AgentRunFlowRunner.ts
+++ b/src/agent/implementations/flows/common/AgentRunFlowRunner.ts
@@ -75,67 +75,6 @@ function hasExtendHooks<
   );
 }
 
-async function runAgentFlowWithExtend<
-  Shared extends AgentRunShared<
-    BaseAgent<any>,
-    any,
-    AgentLifecycleState<string>,
-    AgentRunHooks
-  >,
->(options: AgentRunFlowOptionsWithExtend<Shared>): Promise<Shared> {
-  const state = options.createState();
-  const baseHooks = options.agent.getRunHooks(options.hookOverrides);
-  const hooks = options.extendHooks(baseHooks);
-
-  const shared = {
-    agent: options.agent,
-    state,
-    lifecycle: options.lifecycle,
-    hooks,
-  } as Shared;
-
-  options.prepareShared?.(shared);
-
-  const flow = options.createFlow();
-  await flow.run(shared);
-
-  if (shared.lifecycle.error) {
-    throw shared.lifecycle.error;
-  }
-
-  return shared;
-}
-
-async function runAgentFlowWithoutExtend<
-  Shared extends AgentRunShared<
-    BaseAgent<any>,
-    any,
-    AgentLifecycleState<string>,
-    AgentRunHooks
-  >,
->(options: AgentRunFlowOptionsWithoutExtend<Shared>): Promise<Shared> {
-  const state = options.createState();
-  const hooks = options.agent.getRunHooks(options.hookOverrides);
-
-  const shared = {
-    agent: options.agent,
-    state,
-    lifecycle: options.lifecycle,
-    hooks,
-  } as Shared;
-
-  options.prepareShared?.(shared);
-
-  const flow = options.createFlow();
-  await flow.run(shared);
-
-  if (shared.lifecycle.error) {
-    throw shared.lifecycle.error;
-  }
-
-  return shared;
-}
-
 export async function runAgentFlow<
   Shared extends AgentRunShared<
     BaseAgent<any>,
@@ -144,9 +83,29 @@ export async function runAgentFlow<
     AgentRunHooks
   >,
 >(options: AgentRunFlowOptions<Shared>): Promise<Shared> {
-  if (hasExtendHooks(options)) {
-    return runAgentFlowWithExtend(options);
+  const state = options.createState();
+
+  // Get hooks - either extend base hooks or use them directly
+  const baseHooks = options.agent.getRunHooks(options.hookOverrides);
+  const hooks = hasExtendHooks(options)
+    ? options.extendHooks(baseHooks)
+    : baseHooks;
+
+  const shared = {
+    agent: options.agent,
+    state,
+    lifecycle: options.lifecycle,
+    hooks,
+  } as Shared;
+
+  options.prepareShared?.(shared);
+
+  const flow = options.createFlow();
+  await flow.run(shared);
+
+  if (shared.lifecycle.error) {
+    throw shared.lifecycle.error;
   }
 
-  return runAgentFlowWithoutExtend(options);
+  return shared;
 }


### PR DESCRIPTION
This commit refactors agent and flow code to use more native TypeScript
patterns and eliminate spaghetti code through better abstractions.

Changes:
- Consolidated duplicate hook merging logic in AgentRunFlowRunner
  - Eliminated two nearly identical functions (runAgentFlowWithExtend/runAgentFlowWithoutExtend)
  - Reduced from ~60 lines to single unified function using ternary operator

- Unified output file naming logic across agent types
  - Moved common getOutputFile implementation to BaseReflectionAgent
  - Removed duplicate implementations from DirectAgent and CoTAgent
  - Fixed bug where DirectAgent wasn't checking useScratchpad mode
  - Proper inheritance allows MergeAgent to maintain specialized logic

- Created shared base types for cycle states
  - Added CommonCycleTypes.ts with BaseCycleState interface
  - Implemented generic resetCycleState function for DRY state resets
  - Both ResponseCycleState and ToolUseCycleState now extend BaseCycleState
  - Reduces duplication of common fields (messages, shouldStop, responseTime, stopReason)

- Improved discriminated union usage for better type safety
  - Converted result types from property checking ({ skipped: true }) to proper discriminated unions ({ type: 'skipped' })
  - Updated InvocationNodeResult, ProcessNodeResult, and ContinuationNodeResult
  - Changed checks from 'skipped' in execRes to execRes.type === 'skipped'
  - Enables better TypeScript type narrowing and compile-time safety

Net impact: -52 lines of code (-121 additions, +69 deletions)

Files modified:
- src/agent/implementations/flows/common/AgentRunFlowRunner.ts
- src/agent/implementations/BaseReflectionAgent.ts
- src/agent/implementations/DirectAgent.ts
- src/agent/implementations/CoTAgent.ts
- src/agent/core/flows/ResponseCycleFlow.ts
- src/agent/core/flows/ToolUseCycleFlow.ts

Files added:
- src/agent/core/flows/CommonCycleTypes.ts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds shared cycle state/types with a generic reset, converts flow node results to discriminated unions, centralizes output file naming in BaseReflectionAgent, and unifies AgentRunFlowRunner hook handling.
> 
> - **Core/Flows**:
>   - **Shared Types**: Add `CommonCycleTypes.ts` with `BaseCycleState` and `resetCycleState`.
>   - **Response/Tool Cycles**: Make `ResponseCycleRuntimeState` and `ToolUseCycleState` extend `BaseCycleState`; replace manual resets with `resetCycleState`.
>   - **Result Typing**: Convert `{ skipped: true }` patterns to discriminated unions (`{ type: 'skipped' | 'success' }`) and update checks accordingly.
> - **Agents**:
>   - **Output Naming**: Move `getOutputFile` default implementation to `BaseReflectionAgent` (scratchpad-aware); remove duplicates from `DirectAgent` and `CoTAgent`.
>   - **DirectAgent**: Ensure XML structure when using scratchpad in `handleOutput`.
> - **Flow Runner**:
>   - **Hooks**: Collapse dual implementations into a single `runAgentFlow` that optionally applies `extendHooks`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cf562a36f09c900f142afe6bce832c45661c700e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->