### PR TITLE
Fix missing baseFileUtils resource file

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -52,6 +52,7 @@ CLAUDE.md
 !src/common/webview/*.js
 !src/common/webview/commands.js
 !src/common/modules/*.js
+!src/common/modules/files/*.js
 
 !src/historyView/modules/*.js
 !src/historyView/modules/uiManagers/*.js


### PR DESCRIPTION
The baseFileUtils.js file in src/common/modules/files/ was being excluded from the packaged extension because .vscodeignore only included files directly in src/common/modules/, not subdirectories.

This caused a 404 error when webviews tried to load the file at runtime.

Added !src/common/modules/files/*.js to .vscodeignore to ensure the files subdirectory is included in the package.

Fixes the error:
Failed to load resource: the server responded with a status of 404 () file: src/common/modules/files/baseFileUtils.js

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update `.vscodeignore` to include `src/common/modules/files/*.js` so that files in this subdirectory are bundled.
> 
> - **Packaging**: Update `.vscodeignore` to include `src/common/modules/files/*.js`, ensuring `src/common/modules/files/` is bundled with the extension.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9494ac02125f1ceb733e94d5b8308d3074ddbabe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->