### PR TITLE
Fix missing vscode.getContextKeyValue command

### DIFF
--- a/src/MainViewProvider.ts
+++ b/src/MainViewProvider.ts
@@ -6,6 +6,7 @@ import { BaseWebviewProvider } from '@common/webview/BaseWebviewProvider';
 import { getSharedLocalResourceRoots } from '@common/webview/resourceRoots';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands';
 import { watchConfig, getConfig } from '@utils/config';
+import { consumePendingState } from '@utils/pendingStateManager';
 import { checkCoreDependencies } from '@utils/system/toolUtils';
 
 // Local file imports
@@ -146,39 +147,14 @@ export class MainViewProvider
       command: MAIN_VIEW_COMMANDS.REQUEST_BASE_FILE,
     });
 
-    // Check if there's state to restore from the command
-    const hasStateToRestore = await vscode.commands.executeCommand<boolean>(
-      'vscode.getContextKeyValue',
-      'texra.hasStateToRestore',
-    );
+    // Check if there's state to restore (consume it from pending state)
+    const state = consumePendingState();
 
-    if (!hasStateToRestore) {
-      return;
-    }
-
-    try {
-      const state = (await vscode.commands.executeCommand(
-        'vscode.getContextKeyValue',
-        'texra.stateToRestore',
-      )) as unknown;
-
-      if (state) {
-        webviewView.webview.postMessage({
-          command: MAIN_VIEW_COMMANDS.STATE_RESTORE,
-          state,
-        });
-      }
-    } finally {
-      await vscode.commands.executeCommand(
-        'setContext',
-        'texra.hasStateToRestore',
-        false,
-      );
-      await vscode.commands.executeCommand(
-        'setContext',
-        'texra.stateToRestore',
-        undefined,
-      );
+    if (state) {
+      webviewView.webview.postMessage({
+        command: MAIN_VIEW_COMMANDS.STATE_RESTORE,
+        state,
+      });
     }
   }
 }

--- a/src/commands/history/stateRestoreCommand.ts
+++ b/src/commands/history/stateRestoreCommand.ts
@@ -7,8 +7,9 @@ import {
   toErrorMessage,
 } from '@common/errors/errorHandlingUtils';
 import * as logger from '@logger/logUtils';
-// Type imports
 import type { TaskState } from '@logger/TaskState';
+import { setPendingState } from '@utils/pendingStateManager';
+// Type imports
 
 const CHANNEL = 'stateRestoreCommand';
 logger.initialize(CHANNEL);
@@ -77,16 +78,8 @@ export const stateRestoreCommand = {
 };
 
 async function storeStateForLater(state: TaskState): Promise<void> {
-  await vscode.commands.executeCommand(
-    'setContext',
-    'texra.hasStateToRestore',
-    true,
-  );
-  await vscode.commands.executeCommand(
-    'setContext',
-    'texra.stateToRestore',
-    state,
-  );
+  // Store the state in memory for the MainViewProvider to pick up
+  setPendingState(state);
   await vscode.commands.executeCommand('texra.mainView.focus');
-  logger.info(CHANNEL, 'State stored in context for later restoration');
+  logger.info(CHANNEL, 'State stored for later restoration');
 }

--- a/src/utils/pendingStateManager.ts
+++ b/src/utils/pendingStateManager.ts
@@ -1,0 +1,33 @@
+/**
+ * Simple in-memory storage for pending state restoration.
+ * This is used to pass state from the restore command to the MainViewProvider
+ * when the webview is not yet available.
+ */
+
+import type { TaskState } from '@logger/TaskState';
+
+let pendingState: TaskState | undefined = undefined;
+
+/**
+ * Store state for later restoration
+ */
+export function setPendingState(state: TaskState): void {
+  pendingState = state;
+}
+
+/**
+ * Get and clear the pending state
+ * @returns The pending state if any, undefined otherwise
+ */
+export function consumePendingState(): TaskState | undefined {
+  const state = pendingState;
+  pendingState = undefined;
+  return state;
+}
+
+/**
+ * Check if there is pending state
+ */
+export function hasPendingState(): boolean {
+  return pendingState !== undefined;
+}


### PR DESCRIPTION
The extension was using the internal VS Code command 'vscode.getContextKeyValue' which is not part of the public API and may not be available in all VS Code versions, causing the error: "command 'vscode.getContextKeyValue' not found".

Changes:
- Created new pendingStateManager module to handle temporary state storage
- Updated MainViewProvider to use consumePendingState() instead of executeCommand
- Updated stateRestoreCommand to use setPendingState() instead of setContext
- Removed dependency on internal VS Code APIs

This fixes the console error while maintaining the same state restoration functionality.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces internal context commands with an in-memory pending state manager to reliably restore the main view state.
> 
> - **State restoration**:
>   - Adds `utils/pendingStateManager` with `setPendingState`, `consumePendingState`, and `hasPendingState` for in-memory handoff.
>   - Updates `src/MainViewProvider.ts` to use `consumePendingState()` and post `MAIN_VIEW_COMMANDS.STATE_RESTORE` when available.
>   - Updates `src/commands/history/stateRestoreCommand.ts` to use `setPendingState()` and focus `texra.mainView`; posts state directly if `texra.getWebviewView` succeeds.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8ee2360e198541d68e7d4490076830eb6febfe6a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->