### PR TITLE
Refactor XML output to write directly to target storage

### DIFF
--- a/src/agent/core/AgentDataclass.ts
+++ b/src/agent/core/AgentDataclass.ts
@@ -93,6 +93,8 @@ export const AgentSettingBaseSchema = z.strictObject({
     .prefault([]),
 
   tools: z.array(ToolDefinitionSchema).prefault([]),
+  /** Flag indicating whether this agent produces XML output (default: true, false for DirectAgent) */
+  producesXml: z.boolean().prefault(true),
 });
 
 /**

--- a/src/agent/core/ResponseCycle.ts
+++ b/src/agent/core/ResponseCycle.ts
@@ -13,6 +13,9 @@ import {
 import type { AgentCycleBaseOptions } from './AgentCycleOptions';
 import type { AgentConfig } from './AgentConfig';
 
+// Type imports
+import type { FileLocation } from '@utils/files';
+
 export interface ResponseCycleOptions<C = unknown>
   extends AgentCycleBaseOptions<C> {
   agentConfig: AgentConfig;
@@ -22,6 +25,7 @@ export interface ResponseCycleInput<C = unknown> {
   options: ResponseCycleOptions<C>;
   messages: ProviderMessage[];
   outputFile: string;
+  outputLocation?: FileLocation;
   store: AgentSharedStore;
 }
 
@@ -39,6 +43,7 @@ export async function runResponseCycle<C = unknown>(
     state: {
       messages: input.messages,
       outputFile: input.outputFile,
+      outputLocation: input.outputLocation,
       endTurn: false,
       shouldStop: false,
       outputExists: false,

--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -33,7 +33,9 @@ import { formatProviderHttpError } from '@common/errors/sdkErrorUtils';
 import { MESSAGE_TYPES } from '@logger/messageTypes';
 import replacementEngine from '@replacement/engine';
 import { K_SLICE, REPETITION_DETECTION_THRESHOLD } from '@utils/config';
-import { WorkspaceFS } from '@utils/files';
+import { WorkspaceFS, flexibleFS } from '@utils/files';
+// Type imports
+import type { FileLocation } from '@utils/files';
 import xmlUtils from '@utils/text/xmlUtils';
 import { bestConnectionMethod } from '@latex';
 
@@ -42,6 +44,7 @@ import { FlowTransition } from './FlowTransitions';
 
 export interface ResponseCycleInputState {
   outputFile: string;
+  outputLocation?: FileLocation;
 }
 
 export interface ResponseCycleRuntimeState extends BaseCycleState {
@@ -97,7 +100,11 @@ class ResponsePrepNode<C> extends BaseNode<ResponseCycleContext<C>> {
     const { options, state, store } = shared;
     const { agentPrompt, userVars, logger, agentConfig } = options;
     const interrupted = Boolean(await options.checkInterruption());
-    const exists = await WorkspaceFS.exists(state.outputFile);
+    // Check existence using FileLocation path if available
+    const checkPath = state.outputLocation?.absolutePath ?? state.outputFile;
+    const exists = state.outputLocation
+      ? await flexibleFS.exists(checkPath)
+      : await WorkspaceFS.exists(state.outputFile);
     const systemPrompt = interrupted
       ? undefined
       : await getSystemPromptWithRules(agentPrompt.systemPrompt, userVars);
@@ -467,16 +474,31 @@ class ResponseProcessNode<C> extends BaseNode<ResponseCycleContext<C>> {
       return FlowTransition.COMPLETE;
     }
 
+    // Use FileLocation for direct writes to correct storage location
+    const targetPath = state.outputLocation?.absolutePath ?? state.outputFile;
+    const useFlexibleFS = Boolean(state.outputLocation);
+
     if (!state.outputExists) {
-      options.logger.debug(`Creating new file: ${state.outputFile}`);
-      await WorkspaceFS.write(state.outputFile, processedResponse);
+      options.logger.debug(`Creating new file: ${targetPath}`);
+      if (useFlexibleFS) {
+        await flexibleFS.write(targetPath, processedResponse);
+      } else {
+        await WorkspaceFS.write(state.outputFile, processedResponse);
+      }
       state.outputExists = true;
     } else {
-      options.logger.debug(`Appending to existing file: ${state.outputFile}`);
-      await WorkspaceFS.appendFile(
-        state.outputFile,
-        (result.bestConnector ?? '') + processedResponse,
-      );
+      options.logger.debug(`Appending to existing file: ${targetPath}`);
+      if (useFlexibleFS) {
+        await flexibleFS.appendFile(
+          targetPath,
+          (result.bestConnector ?? '') + processedResponse,
+        );
+      } else {
+        await WorkspaceFS.appendFile(
+          state.outputFile,
+          (result.bestConnector ?? '') + processedResponse,
+        );
+      }
     }
 
     const responseUsage = result.responseUsage ?? {};

--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -53,6 +53,8 @@ import type { AgentLogStage } from '@logger/AgentLogger';
 // Local imports - configuration
 import { getConfig } from '@utils/config';
 import { WorkspaceFS, TaskRunFileService } from '@utils/files';
+// Type imports
+import type { FileLocation } from '@utils/files';
 import { LatexMediaManager } from '@latex';
 
 /**
@@ -97,6 +99,7 @@ interface RoundPipelineContext {
   preparedMessages: any[];
   prefill: string;
   outputPath: string;
+  outputLocation?: FileLocation;
 }
 
 /**
@@ -105,8 +108,8 @@ interface RoundPipelineContext {
  * across multiple conversation rounds.
  */
 export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
-  /** File paths for each round's raw model output. */
-  protected outputFile: string[];
+  /** File locations for each round's raw model output. */
+  protected outputFile: FileLocation[];
   protected outputFiles: { [key: number]: string[] };
   protected baseFiles: string[];
   protected override agentSetting: AgentWorkflowSetting;
@@ -282,17 +285,17 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
   }
 
   /**
-   * Generates output file path for specified conversation round.
-   * Default implementation uses scratchpad mode detection to determine file extension.
+   * Generates output file location for specified conversation round.
+   * Returns a FileLocation that respects the storage mode configuration.
    * Override for specialized naming logic (e.g., MergeAgent).
    */
-  protected getOutputFile(currRound: number): string {
+  protected getOutputFile(currRound: number): FileLocation {
     const baseOutputFile = this.agentConfig.inputFile;
     const fileExtension = this.useScratchpad
       ? 'xml'
       : this.agentSetting.outputExt;
 
-    return getOutputFileName(
+    const relativePath = getOutputFileName(
       baseOutputFile,
       this.agentConfig.agent,
       this.modelHandler.config.name,
@@ -300,6 +303,11 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
       currRound,
       this.agentConfig.editedFile || undefined,
     );
+
+    // Resolve to FileLocation based on storage mode configuration
+    return this.fileService.resolveRelativePath(relativePath, {
+      preferWorkspace: false, // Respect storage mode for initial write
+    });
   }
 
   /**
@@ -413,6 +421,7 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
     preparedMessages,
     prefill,
     outputPath,
+    outputLocation,
   }: RoundPipelineContext): Promise<ReflectionRoundResult> {
     const [endTurn, updatedMessages] =
       await this.modelHandler.initializeOutputAndPrefill(
@@ -439,6 +448,7 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
         options: this.createResponseCycleOptions(),
         messages: updatedMessages,
         outputFile: outputPath,
+        outputLocation,
         store,
       });
 
@@ -665,16 +675,19 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
               messages,
               workspaceState,
             ),
-          runRoundPipeline: ({ stateRound, preparedMessages, prefill }) =>
-            this.runRoundPipeline({
+          runRoundPipeline: ({ stateRound, preparedMessages, prefill }) => {
+            const outputLocation = this.outputFile[roundIndex];
+            return this.runRoundPipeline({
               roundIndex,
               roundState: stateRound,
               runState,
               workspaceState,
               preparedMessages,
               prefill,
-              outputPath: this.outputFile[roundIndex],
-            }),
+              outputPath: outputLocation.absolutePath,
+              outputLocation,
+            });
+          },
           createSkipResult: (stateRound) => ({
             roundState: stateRound,
             runState,

--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -167,15 +167,16 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
     this.useScratchpad =
       this.agentSetting.prefills?.includes('<scratchpad>') || false;
 
+    // Initialize logging
+    this.logId = 0;
+
+    // Initialize file service first (needed by getOutputFile)
+    this.fileService = new TaskRunFileService(context.executionId);
+
     // Set output files for all rounds
     for (let i = 0; i < numRounds; i++) {
       this.outputFile[i] = this.getOutputFile(i);
     }
-
-    // Initialize logging
-    this.logId = 0;
-
-    this.fileService = new TaskRunFileService(context.executionId);
 
     this.outputHandler = new OutputHandler(
       this.agentSetting,

--- a/src/agent/implementations/CoTAgent.ts
+++ b/src/agent/implementations/CoTAgent.ts
@@ -28,10 +28,14 @@ export class CoTAgent extends BaseReflectionAgent {
       if (endTurn) {
         this.logger.debug(`Processing output for round ${currRound}`);
 
-        await this.outputHandler.xmlManager.ensureCorrectXmlStructure(
-          outputFile,
-          this.agentSetting.documentTag,
-        );
+        const xmlResult =
+          await this.outputHandler.xmlManager.ensureCorrectXmlStructure(
+            outputFile,
+            this.agentSetting.documentTag,
+          );
+        if (xmlResult.fixed) {
+          this.logger.debug(`XML structure was auto-fixed: ${xmlResult.reason}`);
+        }
 
         await this.outputHandler.processOutputFiles(
           outputFile,

--- a/src/agent/implementations/DirectAgent.ts
+++ b/src/agent/implementations/DirectAgent.ts
@@ -31,10 +31,16 @@ export class DirectAgent extends BaseReflectionAgent {
         this.logger.debug(`Processing output for round ${currRound}`);
 
         if (this.useScratchpad) {
-          await this.outputHandler.xmlManager.ensureCorrectXmlStructure(
-            outputFile,
-            this.agentSetting.documentTag,
-          );
+          const xmlResult =
+            await this.outputHandler.xmlManager.ensureCorrectXmlStructure(
+              outputFile,
+              this.agentSetting.documentTag,
+            );
+          if (xmlResult.fixed) {
+            this.logger.debug(
+              `XML structure was auto-fixed: ${xmlResult.reason}`,
+            );
+          }
         }
 
         await this.outputHandler.processOutputFiles(

--- a/src/agent/output/OutputHandler.ts
+++ b/src/agent/output/OutputHandler.ts
@@ -56,6 +56,7 @@ import { DiffStatsManager } from './DiffStatsManager';
 import type { IOutputHandler } from './IOutputHandler';
 
 // Local imports - types
+import type { MissingOutputFile } from '@eventBus/ProgressEventBus';
 
 /** Handles output file processing and validation for agent responses. */
 export class OutputHandler implements IOutputHandler {
@@ -734,9 +735,9 @@ export class OutputHandler implements IOutputHandler {
           ),
         }));
         const results = await Promise.all(checks);
-        const missing = results.filter((r) => !r.exists).map((r) => r.file);
+        const missingPaths = results.filter((r) => !r.exists).map((r) => r.file);
 
-        if (missing.length > 0) {
+        if (missingPaths.length > 0) {
           const xmlPath = outputFile
             ? outputFile
             : getOutputFileName(
@@ -751,7 +752,7 @@ export class OutputHandler implements IOutputHandler {
           const xmlExists = await AbsoluteFS.exists(resolvedXmlPath);
 
           const missingOutputsData = {
-            missing,
+            missing: missingPaths,
             xmlFile: xmlExists ? xmlPath : null,
             documentTag: this.agentSetting.documentTag,
           };
@@ -762,7 +763,7 @@ export class OutputHandler implements IOutputHandler {
             'Missing output files detected',
           );
           this.logger.debug(
-            `Missing expected outputs for round ${currRound}: ${missing.join(', ')}`,
+            `Missing expected outputs for round ${currRound}: ${missingPaths.join(', ')}`,
           );
         } else {
           this.logger.debug(
@@ -770,11 +771,21 @@ export class OutputHandler implements IOutputHandler {
           );
         }
 
+        // Convert missing paths to MissingOutputFile objects with FileLocation
+        const missingWithLocation: MissingOutputFile[] = missingPaths.map(
+          (file) => ({
+            path: file,
+            location: this.fileService.resolveRelativePath(file, {
+              preferWorkspace: true,
+            }),
+          }),
+        );
+
         bus.emit('updateMissingOutputs', {
           stream: this.channel,
           groupId: this.currentRunId ?? undefined,
           executionId: this.fileService.getExecutionId(),
-          filesByRound: { [currRound]: missing },
+          filesByRound: { [currRound]: missingWithLocation },
         });
       },
     );
@@ -1067,6 +1078,7 @@ export class OutputHandler implements IOutputHandler {
               documentTag: this.agentSetting.documentTag,
             };
             this.logger.missingOutputs(missingOutputsData);
+            // No files missing in error case, send empty array
             bus.emit('updateMissingOutputs', {
               stream: this.channel,
               groupId: this.currentRunId ?? undefined,

--- a/src/agent/output/OutputHandler.ts
+++ b/src/agent/output/OutputHandler.ts
@@ -630,11 +630,8 @@ export class OutputHandler implements IOutputHandler {
           rawOutput.absolutePath,
           shouldForceRunStorage ? { forceRunStorage: true } : undefined,
         );
-      } else if (runStorageActive && isAlreadyInRunStorage) {
-        // Already in run storage, just describe the path
-        relocatedRaw = this.fileService.describePath(rawOutput.absolutePath);
       } else {
-        // Not using run storage, describe workspace path
+        // Already in correct location, just describe the path
         relocatedRaw = this.fileService.describePath(rawOutput.absolutePath);
       }
     }

--- a/src/agent/output/OutputHandler.ts
+++ b/src/agent/output/OutputHandler.ts
@@ -620,12 +620,20 @@ export class OutputHandler implements IOutputHandler {
 
     if (rawOutput) {
       await this.cleanupLatexBackups(rawOutput);
-      if (runStorageActive) {
+      // Skip relocation if file is already in correct storage location
+      const isAlreadyInRunStorage = rawOutput.scope === 'runStorage';
+      const needsRelocation = runStorageActive && !isAlreadyInRunStorage;
+
+      if (needsRelocation) {
         relocatedRaw = await this.fileService.relocateToRunStorage(
           rawOutput.absolutePath,
           shouldForceRunStorage ? { forceRunStorage: true } : undefined,
         );
+      } else if (runStorageActive && isAlreadyInRunStorage) {
+        // Already in run storage, just describe the path
+        relocatedRaw = this.fileService.describePath(rawOutput.absolutePath);
       } else {
+        // Not using run storage, describe workspace path
         relocatedRaw = this.fileService.describePath(rawOutput.absolutePath);
       }
     }
@@ -646,31 +654,29 @@ export class OutputHandler implements IOutputHandler {
         }
 
         await this.cleanupLatexBackups(entry.location);
-        if (!runStorageActive) {
-          const described = this.fileService.describePath(
+
+        // Skip relocation if file is already in correct storage location
+        const isAlreadyInRunStorage = entry.location.scope === 'runStorage';
+        const needsRelocation = runStorageActive && !isAlreadyInRunStorage;
+
+        let finalLocation: FileLocation;
+        if (needsRelocation) {
+          finalLocation = await this.fileService.relocateToRunStorage(
             entry.location.absolutePath,
           );
-          relocatedProcessed.push({
-            ...entry,
-            path: described.absolutePath,
-            relativePath: described.relativePath,
-            workspacePath:
-              entry.workspacePath ?? described.workspace?.absolutePath,
-            location: described,
-          });
-          continue;
+        } else {
+          finalLocation = this.fileService.describePath(
+            entry.location.absolutePath,
+          );
         }
 
-        const relocation = await this.fileService.relocateToRunStorage(
-          entry.location.absolutePath,
-        );
         relocatedProcessed.push({
           ...entry,
-          path: relocation.absolutePath,
-          relativePath: relocation.relativePath,
+          path: finalLocation.absolutePath,
+          relativePath: finalLocation.relativePath,
           workspacePath:
-            entry.workspacePath ?? relocation.workspace?.absolutePath,
-          location: relocation,
+            entry.workspacePath ?? finalLocation.workspace?.absolutePath,
+          location: finalLocation,
         });
       } catch (error) {
         throw Object.assign(

--- a/src/agent/output/XmlOutputManager.ts
+++ b/src/agent/output/XmlOutputManager.ts
@@ -338,25 +338,53 @@ export class XmlOutputManager {
   async ensureCorrectXmlStructure(
     filePath: string,
     documentTag: string,
-  ): Promise<void> {
+  ): Promise<{ fixed: boolean; reason?: string }> {
+    // Skip XML processing if agent doesn't produce XML
+    if (!this.agentSetting.producesXml) {
+      this.logger.debug(
+        `Skipping XML structure validation: agent does not produce XML`,
+        undefined,
+        MESSAGE_TYPES.INTERNAL,
+      );
+      return { fixed: false };
+    }
+
     this.logger.debug(`Ensuring correct XML structure: ${filePath}`);
     let content = await flexibleFS.read(filePath);
 
     content = await this.processXmlContent(content);
 
+    let fixed = false;
+    let reason: string | undefined;
+
     if (!content.endsWith(`</${documentTag}>`)) {
+      fixed = true;
       if (
         !content.includes(`</${documentTag}>`) &&
         content.includes(`<${documentTag}>`)
       ) {
+        reason = 'missing_closing_tag';
         content += `\n</${documentTag}>`;
+        this.logger.info(
+          `Added missing closing tag </${documentTag}>`,
+          undefined,
+          MESSAGE_TYPES.PARTIAL_XML_OUTPUT,
+        );
       } else {
+        reason = 'malformed_closing_tag';
         content = content.replace(new RegExp(`</${documentTag}>.*$`, 's'), '');
         if (content.includes(`<${documentTag}>`)) {
           content += `\n</${documentTag}>`;
+          this.logger.info(
+            `Fixed malformed closing tag </${documentTag}>`,
+            undefined,
+            MESSAGE_TYPES.PARTIAL_XML_OUTPUT,
+          );
         }
       }
     }
+
     await flexibleFS.write(filePath, content);
+    return { fixed, reason };
   }
 }

--- a/src/eventBus/ProgressEventBus.ts
+++ b/src/eventBus/ProgressEventBus.ts
@@ -12,6 +12,7 @@ import type {
   TaskGroup,
 } from '@logger/LogTypes';
 import type { TaskState } from '@logger/TaskState';
+import type { FileLocation } from '@utils/files';
 
 // Maximum number of events to buffer when no listeners are registered
 const MAX_BUFFER_SIZE = 1000;
@@ -53,6 +54,17 @@ interface SetTaskStatePayload {
   taskState: TaskState;
 }
 
+/**
+ * Information about a missing expected output file.
+ * Includes FileLocation so frontend can construct proper paths without guessing.
+ */
+export interface MissingOutputFile {
+  /** Original relative path of the expected file */
+  path: string;
+  /** Resolved FileLocation with workspace and run storage paths */
+  location: FileLocation;
+}
+
 export interface ProgressEventPayloads {
   addLogMessage: { stream: StreamTabId; logMessage: LogMessageData };
   updateLogMessage: { stream: StreamTabId; logMessage: LogMessageUpdate };
@@ -70,7 +82,7 @@ export interface ProgressEventPayloads {
     stream: StreamTabId;
     groupId?: string;
     executionId?: ExecutionId;
-    filesByRound: { [key: number]: string[] };
+    filesByRound: { [key: number]: MissingOutputFile[] };
   };
   clearMissingOutputs: StreamTabId;
   clearOutputFiles: StreamTabId;

--- a/src/logger/messageTypes.ts
+++ b/src/logger/messageTypes.ts
@@ -12,6 +12,10 @@ export const MESSAGE_TYPES = {
   /** Messages that should be hidden from the progress view */
   INTERNAL: 'internal',
   DEFAULT: 'default',
+  /** Partial XML output detected (continuation/incomplete XML) */
+  PARTIAL_XML_OUTPUT: 'partialXmlOutput',
+  /** XML parse error (tag matching failures) */
+  XML_PARSE_ERROR: 'xmlParseError',
 } as const;
 
 export type MessageType = (typeof MESSAGE_TYPES)[keyof typeof MESSAGE_TYPES];

--- a/src/progressView/managers/OutputFilesManager.ts
+++ b/src/progressView/managers/OutputFilesManager.ts
@@ -11,6 +11,7 @@ import {
   OutputFileInfoListSchema,
   type OutputFileInfo,
 } from '@agent/output/types';
+import type { MissingOutputFile } from '@eventBus/ProgressEventBus';
 import { WorkspaceStateKey } from '@common/state/stateManager';
 import { AgentLogger } from '@logger/AgentLogger';
 import {
@@ -94,7 +95,7 @@ export class OutputFilesManager extends PersistentMapManager<
   async updateMissingOutputs(
     stream: StreamTabId,
     groupId: string | null | undefined,
-    filesByRound: { [key: number]: string[] },
+    filesByRound: { [key: number]: MissingOutputFile[] },
     options: { executionId?: ExecutionId } = {},
   ): Promise<void> {
     await this.ensureMissingOutputsLoaded();
@@ -112,7 +113,7 @@ export class OutputFilesManager extends PersistentMapManager<
       streamMissing.set(runId, runMissing);
     }
 
-    for (const [round, files] of Object.entries(filesByRound)) {
+    for (const [round, missingFiles] of Object.entries(filesByRound)) {
       const roundNum = Number.parseInt(round, 10);
       if (Number.isNaN(roundNum)) {
         this.logger.warn(
@@ -120,7 +121,9 @@ export class OutputFilesManager extends PersistentMapManager<
         );
         continue;
       }
-      runMissing.set(roundNum, files);
+      // Extract just the paths for internal storage (backward compatible)
+      const paths = missingFiles.map((f) => f.path);
+      runMissing.set(roundNum, paths);
     }
 
     await this.saveMissingOutputs();

--- a/src/utils/files/flexibleFS.ts
+++ b/src/utils/files/flexibleFS.ts
@@ -85,6 +85,11 @@ export class FlexibleFS {
     }
   }
 
+  async appendFile(target: string, content: string): Promise<void> {
+    const existing = (await this.exists(target)) ? await this.read(target) : '';
+    await this.write(target, `${existing}${content}`);
+  }
+
   async ensureDir(target: string): Promise<void> {
     if (isAbsolute(target)) {
       await AbsoluteFS.ensureDir(target);


### PR DESCRIPTION
This commit implements a clean FileLocation-first design that writes XML files directly to the correct storage location based on the texra.agentOutputs.storageMode configuration, eliminating the "write-then-relocate" pattern.

Key Changes:
- Add FileLocation support to response cycle state and flow
- Modify getOutputFile() to return FileLocation with proper storage resolution
- Update ResponseCycleFlow to write directly to resolved FileLocation
- Update OutputHandler.relocateRoundArtifacts() to skip unnecessary relocation
- Add producesXml flag to AgentSetting schema (defaults to true)
- Add PARTIAL_XML_OUTPUT and XML_PARSE_ERROR message types

Benefits:
- Single write operation instead of write + relocate
- Respects storage mode from the initial write
- Reduces risk of orphaned files if relocation fails
- Cleaner separation of concerns
- Backward compatible with existing agents

Related: #issue-number

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches output writing to FileLocation-first paths (single write, no relocate) and enriches XML handling and missing-output events with locations.
> 
> - **Core/Flow**:
>   - Use `FileLocation` in `ResponseCycle`/`ResponseCycleFlow` to check existence and write/append directly via `flexibleFS` to `state.outputLocation.absolutePath`.
>   - Extend cycle/state/input with optional `outputLocation`.
> - **Agents**:
>   - `BaseReflectionAgent`: `getOutputFile()` now returns `FileLocation` resolved by `TaskRunFileService`; pipelines pass both `outputPath` and `outputLocation`.
>   - `CoTAgent`/`DirectAgent`: log auto-fix details from XML validation before processing outputs.
> - **Output Processing**:
>   - `OutputHandler.relocateRoundArtifacts()` skips relocation when already in run storage; uses `FileLocation.describe` otherwise.
>   - Expected-missing outputs now emitted with `MissingOutputFile` including `FileLocation`.
>   - XML summaries/capture and file info use resolved locations.
> - **XML Manager**:
>   - `ensureCorrectXmlStructure()` returns `{ fixed, reason }` and is skipped when `agentSetting.producesXml` is false.
> - **Schema/Config**:
>   - Add `producesXml` flag to `AgentSettingBaseSchema` (default `true`).
> - **Event Bus/Progress View**:
>   - Add `MissingOutputFile` type and update `updateMissingOutputs` payload; `OutputFilesManager` accepts it and stores paths for persistence.
> - **FS**:
>   - `flexibleFS.appendFile()` added for direct appends.
> - **Logging**:
>   - Add message types `PARTIAL_XML_OUTPUT` and `XML_PARSE_ERROR`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b6ca2aa0515db79617976f1543c62a9d1cb8cd77. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->