### PR TITLE
Add more index tests

### DIFF
--- a/src/FolderExplorer.ts
+++ b/src/FolderExplorer.ts
@@ -5,7 +5,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 
 // Internal imports
-import { agentDirectories } from '@frontend/agents/AgentDirectoryManager';
+import { agentDirectories } from '@frontend/agents';
 import * as logger from '@logger/logUtils';
 import { AbsoluteFS } from '@utils/files';
 

--- a/src/MainViewProvider.ts
+++ b/src/MainViewProvider.ts
@@ -2,9 +2,9 @@
 import * as vscode from 'vscode';
 
 // Local imports - common
-import { BaseWebviewProvider } from '@common/webview/BaseWebviewProvider';
-import { getSharedLocalResourceRoots } from '@common/webview/resourceRoots';
-import { MAIN_VIEW_COMMANDS } from '@common/webview/commands';
+import { BaseWebviewProvider } from '@common/webview';
+import { getSharedLocalResourceRoots } from '@common/webview';
+import { MAIN_VIEW_COMMANDS } from '@common/webview';
 import { watchConfig, getConfig } from '@utils/config';
 import { consumePendingState } from '@utils/pendingStateManager';
 import { checkCoreDependencies } from '@utils/system/toolUtils';

--- a/src/agent/types/index.ts
+++ b/src/agent/types/index.ts
@@ -1,0 +1,6 @@
+// Barrel export for agent types
+export * from './AgentStreamTypes';
+export * from './DiffTypes';
+export * from './IdentifierTypes';
+export * from './ResultTypes';
+export * from './UsageTypes';

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -3,39 +3,53 @@ import * as vscode from 'vscode';
 
 // Local imports - commands
 import * as logger from '@logger/logUtils';
-import { registerFileSelectionCommands } from '@commands/files/fileSelectionCommands';
-import { registerLatexdiffCommands } from '@commands/latex/latexdiffCommands';
-import { registerGitCommands } from '@commands/git/gitCommands';
-import { registerPackCommands } from '@commands/housekeeping/packCommands';
-import { registerCleanCommands } from '@commands/housekeeping/cleanCommands';
-import { registerMergeCommands } from '@commands/agent/mergeCommands';
-import { registerExecuteCommand } from '@commands/agent/executeCommand';
-import { registerLatexCommands } from '@commands/latex/latexCommands';
-import { registerImageCommands } from '@commands/latex/imageCommands';
-import { registerFigureCommands } from '@commands/latex/figCommands';
-import { registerTestCommands } from '@commands/system/testCommands';
-import { registerXmlCommands } from '@commands/system/xmlCommands';
-import { registerYamlCommands } from '@commands/system/yamlCommands';
-import { registerAgentCommands } from '@commands/agent/agentCommands';
-import { registerAgentCreatorCommands } from '@commands/agent/agentCreatorCommands';
+import {
+  registerFileSelectionCommands,
+  registerOpenFileCommands,
+} from '@commands/files';
+import {
+  registerLatexdiffCommands,
+  registerLatexCommands,
+  registerImageCommands,
+  registerFigureCommands,
+  registerLinterCommands,
+  registerArXivCommands,
+  registerCompareCommands,
+} from '@commands/latex';
+import {
+  registerPackCommands,
+  registerCleanCommands,
+} from '@commands/housekeeping';
+import {
+  registerMergeCommands,
+  registerExecuteCommand,
+  registerAgentCommands,
+  registerAgentCreatorCommands,
+  registerFollowUpCommand,
+  registerResumeAgentCommand,
+} from '@commands/agent';
+import {
+  registerTestCommands,
+  registerXmlCommands,
+  registerYamlCommands,
+  registerTextEditorCommands,
+  registerHelpCommands,
+  registerSettingsCommands,
+  registerMainViewCommands,
+  registerSampleProjectCommands,
+  registerWalkthroughCommands,
+} from '@commands/system';
+import {
+  registerStateRestoreCommand,
+  registerHistoryCommands,
+} from '@commands/history';
+import {
+  registerWolframScriptCommands,
+  registerWolframToolCommands,
+} from '@commands/wolfram';
 import { registerApiKeyCommands } from '@commands/api/apiKeyCommands';
-import { registerStateRestoreCommand } from '@commands/history/stateRestoreCommand';
-import { registerFollowUpCommand } from '@commands/agent/followUpCommand';
-import { registerResumeAgentCommand } from '@commands/agent/resumeCommand';
-import { registerTextEditorCommands } from '@commands/system/textEditorCommands';
-import { registerLinterCommands } from '@commands/latex/linterCommands';
-import { registerWolframScriptCommands } from '@commands/wolfram/wolframScriptCommands';
-import { registerWolframToolCommands } from '@commands/wolfram/wolframToolCommands';
-import { registerHistoryCommands } from '@commands/history/historyCommands';
-import { registerArXivCommands } from '@commands/latex/arXivCommands';
-import { registerCompareCommands } from '@commands/latex/compareCommands';
-import { registerHelpCommands } from '@commands/system/helpCommands';
+import { registerGitCommands } from '@commands/git/gitCommands';
 import { registerProgressViewCommands } from '@commands/progress/progressViewCommands';
-import { registerOpenFileCommands } from '@commands/files/openFileCommands';
-import { registerSettingsCommands } from '@commands/system/settingsCommands';
-import { registerMainViewCommands } from '@commands/system/mainViewCommands';
-import { registerSampleProjectCommands } from '@commands/system/sampleProjectCommands';
-import { registerWalkthroughCommands } from '@commands/system/walkthroughCommands';
 
 // Local file imports
 import { MainViewProvider } from './MainViewProvider';
@@ -102,30 +116,34 @@ export function registerCommands(context: vscode.ExtensionContext) {
 }
 
 // Add exports for the command modules
-export { fileSelectionCommands } from '@commands/files/fileSelectionCommands';
-export { latexdiffCommands } from '@commands/latex/latexdiffCommands';
+export { fileSelectionCommands } from '@commands/files';
+export {
+  latexdiffCommands,
+  latexCommands,
+  imageCommands,
+  figureCommands,
+  linterCommands,
+  arXivCommands,
+  compareCommands,
+} from '@commands/latex';
 export { gitCommands } from '@commands/git/gitCommands';
-export { packCommands } from '@commands/housekeeping/packCommands';
-export { mergeCommands } from '@commands/agent/mergeCommands';
-export { executeCommand } from '@commands/agent/executeCommand';
-export { latexCommands } from '@commands/latex/latexCommands';
-export { imageCommands } from '@commands/latex/imageCommands';
-export { figureCommands } from '@commands/latex/figCommands';
-export { testCommands } from '@commands/system/testCommands';
-export { xmlCommands } from '@commands/system/xmlCommands';
-export { yamlCommands } from '@commands/system/yamlCommands';
+export { packCommands } from '@commands/housekeeping';
+export {
+  mergeCommands,
+  executeCommand,
+  agentCreatorCommands,
+} from '@commands/agent';
+export {
+  testCommands,
+  xmlCommands,
+  yamlCommands,
+  textEditorCommands,
+  helpCommands,
+  settingsCommands,
+  mainViewCommands,
+  sampleProjectCommands,
+} from '@commands/system';
 export { apiKeyCommands } from '@commands/api/apiKeyCommands';
-export { stateRestoreCommand } from '@commands/history/stateRestoreCommand';
-export { textEditorCommands } from '@commands/system/textEditorCommands';
-export { linterCommands } from '@commands/latex/linterCommands';
-export { wolframToolCommands } from '@commands/wolfram/wolframToolCommands';
-export { wolframScriptCommands } from '@commands/wolfram/wolframScriptCommands';
-export { historyCommands } from '@commands/history/historyCommands';
-export { arXivCommands } from '@commands/latex/arXivCommands';
-export { compareCommands } from '@commands/latex/compareCommands';
-export { helpCommands } from '@commands/system/helpCommands';
-export { agentCreatorCommands } from '@commands/agent/agentCreatorCommands';
-export { registerOpenFileCommands as openFileCommands } from '@commands/files/openFileCommands';
-export { settingsCommands } from '@commands/system/settingsCommands';
-export { mainViewCommands } from '@commands/system/mainViewCommands';
-export { sampleProjectCommands } from '@commands/system/sampleProjectCommands';
+export { stateRestoreCommand, historyCommands } from '@commands/history';
+export { wolframToolCommands, wolframScriptCommands } from '@commands/wolfram';
+export { registerOpenFileCommands as openFileCommands } from '@commands/files';

--- a/src/commands/agent/agentCreatorCommands.ts
+++ b/src/commands/agent/agentCreatorCommands.ts
@@ -4,10 +4,10 @@ import * as vscode from 'vscode';
 
 // Local imports - agent runtime
 import { validateAgentYamlContent } from '@agent/runtime/agentLoad';
-import { toErrorMessage } from '@common/errors/errorHandlingUtils';
+import { toErrorMessage } from '@common/errors';
 import { SecretManager } from '@frontend/secretManager';
-import { agentDirectories } from '@frontend/agents/AgentDirectoryManager';
-import { promptToAddAgentToConfig } from '@frontend/agents/register';
+import { agentDirectories } from '@frontend/agents';
+import { promptToAddAgentToConfig } from '@frontend/agents';
 import * as logger from '@logger/logUtils';
 import { ANTHROPIC_MODELS } from '@model/providers/anthropicModels';
 import { AbsoluteFS } from '@utils/files';

--- a/src/commands/agent/index.ts
+++ b/src/commands/agent/index.ts
@@ -1,0 +1,10 @@
+// Barrel export for agent commands
+export { agentCommands, registerAgentCommands } from './agentCommands';
+export {
+  agentCreatorCommands,
+  registerAgentCreatorCommands,
+} from './agentCreatorCommands';
+export { executeCommand, registerExecuteCommand } from './executeCommand';
+export { registerFollowUpCommand } from './followUpCommand';
+export { mergeCommands, registerMergeCommands } from './mergeCommands';
+export { registerResumeAgentCommand } from './resumeCommand';

--- a/src/commands/agent/mergeCommands.ts
+++ b/src/commands/agent/mergeCommands.ts
@@ -6,7 +6,7 @@ import { executeMergeAgent } from '@agent/runtime/executeAgent';
 import {
   showLoggedMessageWithDocs,
   showLoggedErrorMessage,
-} from '@common/errors/errorHandlingUtils';
+} from '@common/errors';
 import * as logger from '@logger/logUtils';
 import { getConfig } from '@utils/config';
 

--- a/src/commands/api/apiKeyCommands.ts
+++ b/src/commands/api/apiKeyCommands.ts
@@ -2,7 +2,7 @@
 import * as vscode from 'vscode';
 
 // Local imports
-import { MAIN_VIEW_COMMANDS } from '@common/webview/commands';
+import { MAIN_VIEW_COMMANDS } from '@common/webview';
 import { SecretManager, ApiProvider } from '@frontend/secretManager';
 
 export const PROVIDER_URLS: Record<ApiProvider, string> = {

--- a/src/commands/files/fileSelectionCommands.ts
+++ b/src/commands/files/fileSelectionCommands.ts
@@ -2,10 +2,10 @@
 import * as vscode from 'vscode';
 
 // Local imports - log
+import { showLoggedErrorMessage } from '@common/errors';
 import { getIncludedExtensions } from '@common/files/fileTypeUtils';
-import { showLoggedErrorMessage } from '@common/errors/errorHandlingUtils';
+import { fileLister } from '@frontend/files';
 import { showInfoMessage } from '@frontend/ui/messageUtils';
-import { fileLister } from '@frontend/files/fileLister';
 import * as logger from '@logger/logUtils';
 import { WorkspaceFS } from '@utils/files';
 import { selectFile, selectFiles } from '@utils/dialogs';

--- a/src/commands/files/index.ts
+++ b/src/commands/files/index.ts
@@ -1,0 +1,10 @@
+// Barrel export for file commands
+export {
+  fileSelectionCommands,
+  registerFileSelectionCommands,
+} from './fileSelectionCommands';
+export {
+  openFile,
+  openLabel,
+  registerOpenFileCommands,
+} from './openFileCommands';

--- a/src/commands/files/openFileCommands.ts
+++ b/src/commands/files/openFileCommands.ts
@@ -2,11 +2,11 @@
 import * as vscode from 'vscode';
 
 // Local imports - common
-import { toErrorMessage } from '@common/errors/errorHandlingUtils';
+import { toErrorMessage } from '@common/errors';
 
 // Local imports - utilities
+import { fileLister } from '@frontend/files';
 import { openBuildDisplayIfTex } from '@frontend/latex/openBuild';
-import { fileLister } from '@frontend/files/fileLister';
 import { resolveFilePath, WorkspaceFS } from '@utils/files';
 
 export async function openFile(file: string): Promise<void> {

--- a/src/commands/history/index.ts
+++ b/src/commands/history/index.ts
@@ -1,0 +1,6 @@
+// Barrel export for history commands
+export { historyCommands, registerHistoryCommands } from './historyCommands';
+export {
+  stateRestoreCommand,
+  registerStateRestoreCommand,
+} from './stateRestoreCommand';

--- a/src/commands/history/stateRestoreCommand.ts
+++ b/src/commands/history/stateRestoreCommand.ts
@@ -2,10 +2,7 @@
 import * as vscode from 'vscode';
 
 // Local imports - log
-import {
-  showLoggedErrorMessage,
-  toErrorMessage,
-} from '@common/errors/errorHandlingUtils';
+import { showLoggedErrorMessage, toErrorMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
 import type { TaskState } from '@logger/TaskState';
 import { setPendingState } from '@utils/pendingStateManager';

--- a/src/commands/housekeeping/cleanCommands.ts
+++ b/src/commands/housekeeping/cleanCommands.ts
@@ -5,7 +5,7 @@ import * as vscode from 'vscode';
 import type { FileOpResult } from '@agent/types/ResultTypes';
 
 // Internal imports
-import { showLoggedMessage } from '@common/errors/errorHandlingUtils';
+import { showLoggedMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
 import { bus } from '@eventBus/ProgressEventBus';
 import {

--- a/src/commands/housekeeping/index.ts
+++ b/src/commands/housekeeping/index.ts
@@ -1,0 +1,7 @@
+// Barrel export for housekeeping commands
+export {
+  cleanCommands,
+  handleClean,
+  registerCleanCommands,
+} from './cleanCommands';
+export { packCommands, registerPackCommands } from './packCommands';

--- a/src/commands/housekeeping/packCommands.ts
+++ b/src/commands/housekeeping/packCommands.ts
@@ -5,7 +5,7 @@ import * as vscode from 'vscode';
 import type { FileOpResult } from '@agent/types/ResultTypes';
 
 // Internal imports
-import { showLoggedMessage } from '@common/errors/errorHandlingUtils';
+import { showLoggedMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
 import { WorkspaceFS } from '@utils/files';
 import { bus } from '@eventBus/ProgressEventBus';

--- a/src/commands/latex/compareCommands.ts
+++ b/src/commands/latex/compareCommands.ts
@@ -5,7 +5,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 
 // Local imports - log
-import { toErrorMessage } from '@common/errors/errorHandlingUtils';
+import { toErrorMessage } from '@common/errors';
 import { registerDiffRefresh } from '@frontend/ui/diffView';
 import * as logger from '@logger/logUtils';
 import { flexibleFS } from '@utils/files';

--- a/src/commands/latex/figCommands.ts
+++ b/src/commands/latex/figCommands.ts
@@ -5,7 +5,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 
 // Local imports - errors
-import { showLoggedErrorMessage } from '@common/errors/errorHandlingUtils';
+import { showLoggedErrorMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
 import { WorkspaceFS } from '@utils/files';
 import {

--- a/src/commands/latex/imageCommands.ts
+++ b/src/commands/latex/imageCommands.ts
@@ -2,7 +2,7 @@
 import * as vscode from 'vscode';
 
 // Local imports - errors
-import { showLoggedErrorMessage } from '@common/errors/errorHandlingUtils';
+import { showLoggedErrorMessage } from '@common/errors';
 import {
   countPdfPages,
   getBase64EncodedMedia,

--- a/src/commands/latex/index.ts
+++ b/src/commands/latex/index.ts
@@ -1,0 +1,18 @@
+// Barrel export for latex commands
+export { arXivCommands, registerArXivCommands } from './arXivCommands';
+export { compareCommands, registerCompareCommands } from './compareCommands';
+export { figureCommands, registerFigureCommands } from './figCommands';
+export { imageCommands, registerImageCommands } from './imageCommands';
+export { latexCommands, registerLatexCommands } from './latexCommands';
+export {
+  latexdiffCommands,
+  latexdiffHelpers,
+  registerLatexdiffCommands,
+} from './latexdiffCommands';
+export {
+  linterCommands,
+  handleShowLinterMessages,
+  handleCountLinterMessages,
+  handleFixLinterIssues,
+  registerLinterCommands,
+} from './linterCommands';

--- a/src/commands/latex/latexCommands.ts
+++ b/src/commands/latex/latexCommands.ts
@@ -2,10 +2,7 @@
 import * as vscode from 'vscode';
 
 // Local imports - log
-import {
-  showLoggedErrorMessage,
-  toErrorMessage,
-} from '@common/errors/errorHandlingUtils';
+import { showLoggedErrorMessage, toErrorMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
 import replacementEngine from '@replacement/engine';
 import { WorkspaceFS } from '@utils/files';

--- a/src/commands/latex/latexdiffCommands.ts
+++ b/src/commands/latex/latexdiffCommands.ts
@@ -12,7 +12,7 @@ import {
   showLoggedErrorMessage,
   showLoggedMessage,
   showLoggedMessageWithDocs,
-} from '@common/errors/errorHandlingUtils';
+} from '@common/errors';
 import { openBuildDisplayIfTex } from '@frontend/latex/openBuild';
 import * as logger from '@logger/logUtils';
 import { getConfig } from '@utils/config';

--- a/src/commands/latex/linterCommands.ts
+++ b/src/commands/latex/linterCommands.ts
@@ -4,7 +4,7 @@ import * as vscode from 'vscode';
 // Local imports - log
 import { parseAgentConfig } from '@agent/core/AgentConfig';
 import { executeAgent } from '@agent/runtime/executeAgent';
-import { toErrorMessage } from '@common/errors/errorHandlingUtils';
+import { toErrorMessage } from '@common/errors';
 import {
   getLinterMessages,
   getSeverityString,

--- a/src/commands/system/index.ts
+++ b/src/commands/system/index.ts
@@ -1,0 +1,31 @@
+// Barrel export for system commands
+export { helpCommands, registerHelpCommands } from './helpCommands';
+export { mainViewCommands, registerMainViewCommands } from './mainViewCommands';
+export {
+  sampleProjectCommands,
+  registerSampleProjectCommands,
+} from './sampleProjectCommands';
+export { settingsCommands, registerSettingsCommands } from './settingsCommands';
+export { testCommands, registerTestCommands } from './testCommands';
+export {
+  textEditorCommands,
+  registerTextEditorCommands,
+} from './textEditorCommands';
+export {
+  walkthroughCommands,
+  registerWalkthroughCommands,
+} from './walkthroughCommands';
+export {
+  xmlCommands,
+  handleParseXml,
+  handleValidateAndFixXml,
+  registerXmlCommands,
+} from './xmlCommands';
+export {
+  yamlCommands,
+  handleTestAgentLoading,
+  handleLoadSpecificAgent,
+  handleParseYaml,
+  handleTestYamlBrackets,
+  registerYamlCommands,
+} from './yamlCommands';

--- a/src/commands/system/mainViewCommands.ts
+++ b/src/commands/system/mainViewCommands.ts
@@ -2,7 +2,7 @@
 import * as vscode from 'vscode';
 
 // Local imports - webview commands
-import { MAIN_VIEW_COMMANDS } from '@common/webview/commands';
+import { MAIN_VIEW_COMMANDS } from '@common/webview';
 import { computeModelOptions } from '@model/computeModelOptions';
 import { safeExecuteCommand } from '@utils/system';
 

--- a/src/commands/system/sampleProjectCommands.ts
+++ b/src/commands/system/sampleProjectCommands.ts
@@ -5,7 +5,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 
 // Local imports - fs
-import { toErrorMessage } from '@common/errors/errorHandlingUtils';
+import { toErrorMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
 import { WorkspaceFS, copyDirToFS } from '@utils/files';
 

--- a/src/commands/system/textEditorCommands.ts
+++ b/src/commands/system/textEditorCommands.ts
@@ -3,7 +3,7 @@ import * as vscode from 'vscode';
 
 // Local imports - Anthropic Tool
 import { TextEditorTool, ToolCallInput } from '@agent/toolUse';
-import { showLoggedErrorMessage } from '@common/errors/errorHandlingUtils';
+import { showLoggedErrorMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
 import { WorkspaceFS } from '@utils/files';
 

--- a/src/commands/system/xmlCommands.ts
+++ b/src/commands/system/xmlCommands.ts
@@ -5,7 +5,7 @@ import { XMLParser } from 'fast-xml-parser';
 // Local imports - core
 import { parseAgentConfig } from '@agent/core/AgentConfig';
 import { executeAgent } from '@agent/runtime/executeAgent';
-import { toErrorMessage } from '@common/errors/errorHandlingUtils';
+import { toErrorMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
 import {
   getActiveEditorWithGuards,

--- a/src/commands/system/yamlCommands.ts
+++ b/src/commands/system/yamlCommands.ts
@@ -11,7 +11,7 @@ import { AgentDirectorySource } from '@agent/runtime/AgentPathTypes';
 import { resolveAgentDefinitionInDirectory } from '@agent/utils/agentPathResolver';
 import { getAgentPath } from '@agent/runtime/executeAgent';
 import { AgentType } from '@agent/core/AgentDataclass';
-import { toErrorMessage } from '@common/errors/errorHandlingUtils';
+import { toErrorMessage } from '@common/errors';
 import { showInstructionWithSuppress } from '@frontend/ui/instruction';
 import * as logger from '@logger/logUtils';
 import { GlobalStorageFS, StorageFS } from '@utils/files';

--- a/src/commands/tests/connectionTests.ts
+++ b/src/commands/tests/connectionTests.ts
@@ -2,7 +2,7 @@
 import * as vscode from 'vscode';
 
 // Local imports - utilities
-import { showLoggedErrorMessage } from '@common/errors/errorHandlingUtils';
+import { showLoggedErrorMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
 import {
   bestConnectionMethod,

--- a/src/commands/wolfram/index.ts
+++ b/src/commands/wolfram/index.ts
@@ -1,0 +1,9 @@
+// Barrel export for wolfram commands
+export {
+  wolframScriptCommands,
+  registerWolframScriptCommands,
+} from './wolframScriptCommands';
+export {
+  wolframToolCommands,
+  registerWolframToolCommands,
+} from './wolframToolCommands';

--- a/src/commands/wolfram/wolframScriptCommands.ts
+++ b/src/commands/wolfram/wolframScriptCommands.ts
@@ -3,10 +3,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 
 // Local imports - log
-import {
-  showLoggedMessage,
-  showLoggedMessageWithDocs,
-} from '@common/errors/errorHandlingUtils';
+import { showLoggedMessage, showLoggedMessageWithDocs } from '@common/errors';
 import * as logger from '@logger/logUtils';
 import {
   executeWolframCode,

--- a/src/commands/wolfram/wolframToolCommands.ts
+++ b/src/commands/wolfram/wolframToolCommands.ts
@@ -2,7 +2,7 @@
 import * as vscode from 'vscode';
 
 // Local imports
-import { showLoggedErrorMessage } from '@common/errors/errorHandlingUtils';
+import { showLoggedErrorMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
 import { WolframTool } from '@tools/wolfram';
 

--- a/src/common/errors/index.ts
+++ b/src/common/errors/index.ts
@@ -1,0 +1,15 @@
+// Barrel export for error handling utilities
+export {
+  DocId,
+  formatError,
+  toErrorMessage,
+  logErrorMessage,
+  showLoggedErrorMessage,
+  showLoggedMessage,
+  showLoggedMessageWithDocs,
+} from './errorHandlingUtils';
+export {
+  ProviderHttpErrorDetails,
+  formatProviderHttpError,
+  getSdkErrorMessage,
+} from './sdkErrorUtils';

--- a/src/common/webview/BaseViewContentProvider.ts
+++ b/src/common/webview/BaseViewContentProvider.ts
@@ -2,7 +2,7 @@
 import * as vscode from 'vscode';
 
 // Local imports - common
-import { toErrorMessage } from '@common/errors/errorHandlingUtils';
+import { toErrorMessage } from '@common/errors';
 import { buildWebviewHtml } from '@frontend/webview/html';
 import * as logger from '@logger/logUtils';
 

--- a/src/common/webview/BaseViewMessageHandler.ts
+++ b/src/common/webview/BaseViewMessageHandler.ts
@@ -2,7 +2,7 @@
 import * as vscode from 'vscode';
 
 // Local imports - common
-import { toErrorMessage } from '@common/errors/errorHandlingUtils';
+import { toErrorMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
 
 // Local file imports

--- a/src/common/webview/index.ts
+++ b/src/common/webview/index.ts
@@ -1,0 +1,18 @@
+// Barrel export for common webview components
+export {
+  ModuleDescriptor,
+  BaseViewContentProvider,
+} from './BaseViewContentProvider';
+export {
+  MessageHandler,
+  BaseViewMessageHandler,
+} from './BaseViewMessageHandler';
+export { BaseWebviewProvider } from './BaseWebviewProvider';
+export {
+  COMMON_COMMANDS,
+  MAIN_VIEW_COMMANDS,
+  PROGRESS_VIEW_COMMANDS,
+  HISTORY_VIEW_COMMANDS,
+  WEBVIEW_COMMANDS,
+} from './commands';
+export { getSharedLocalResourceRoots } from './resourceRoots';

--- a/src/explorer/ExplorerOperations.ts
+++ b/src/explorer/ExplorerOperations.ts
@@ -5,9 +5,9 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 
 // Local imports - explorer
-import { showLoggedErrorMessage } from '@common/errors/errorHandlingUtils';
-import { agentDirectories } from '@frontend/agents/AgentDirectoryManager';
-import { validateYamlAndPromptAdd } from '@frontend/agents/register';
+import { showLoggedErrorMessage } from '@common/errors';
+import { agentDirectories } from '@frontend/agents';
+import { validateYamlAndPromptAdd } from '@frontend/agents';
 import * as logger from '@logger/logUtils';
 import { AbsoluteFS } from '@utils/files';
 import { safeExecuteCommand } from '@utils/system/commandUtils';

--- a/src/explorer/WatcherManager.ts
+++ b/src/explorer/WatcherManager.ts
@@ -5,8 +5,8 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 
 // Local imports
-import { agentDirectories } from '@frontend/agents/AgentDirectoryManager';
-import { validateYamlAndPromptAdd } from '@frontend/agents/register';
+import { agentDirectories } from '@frontend/agents';
+import { validateYamlAndPromptAdd } from '@frontend/agents';
 import * as logger from '@logger/logUtils';
 
 const CHANNEL = 'Webview';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,10 +11,10 @@ import { ToolUseSessionPersistence } from '@agent/toolUse/ToolUseSessionPersiste
 import { initializeStateManagers } from '@common/state/stateManager';
 import { SecretManager } from '@frontend/secretManager';
 import { copyDefaultAgents, configureLatexSettings } from '@frontend/setup';
+import { FileLister } from '@frontend/files';
+import { agentDirectories } from '@frontend/agents';
 import { disposeDiffRefresh } from '@frontend/ui/diffView';
 import { showInstructionWithSuppress } from '@frontend/ui/instruction';
-import { FileLister } from '@frontend/files/fileLister';
-import { agentDirectories } from '@frontend/agents/AgentDirectoryManager';
 import * as logger from '@logger/logUtils';
 import { initializeToolEditApproval } from '@tools/approval/toolEditApproval';
 import { StorageFS } from '@utils/files';

--- a/src/frontend/agents/AgentDirectoryManager.ts
+++ b/src/frontend/agents/AgentDirectoryManager.ts
@@ -5,10 +5,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 
 // Local imports - log
-import {
-  showLoggedMessageWithDocs,
-  toErrorMessage,
-} from '@common/errors/errorHandlingUtils';
+import { showLoggedMessageWithDocs, toErrorMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
 import { getConfig, updateConfig } from '@utils/config';
 import { GlobalStorageFS, StorageFS, AbsoluteFS } from '@utils/files';

--- a/src/frontend/agents/index.ts
+++ b/src/frontend/agents/index.ts
@@ -1,0 +1,12 @@
+// Barrel export for frontend agent utilities
+export {
+  AgentDirectoryManager,
+  agentDirectories,
+} from './AgentDirectoryManager';
+export {
+  AgentVariantMetadata,
+  AgentRegistrationSkipReason,
+  getAgentRegistrationSkipReason,
+  promptToAddAgentToConfig,
+  validateYamlAndPromptAdd,
+} from './register';

--- a/src/frontend/files/index.ts
+++ b/src/frontend/files/index.ts
@@ -1,0 +1,5 @@
+// Barrel export for frontend file utilities
+export { ListableFileType, FileLister, fileLister } from './fileLister';
+export { getFilesInDirectory, getFilesRecursively } from './listing';
+export { loadTexraRules } from './rules';
+export { setVarFromFile } from './vars';

--- a/src/frontend/files/rules.ts
+++ b/src/frontend/files/rules.ts
@@ -3,7 +3,7 @@ import * as os from 'os';
 import * as path from 'path';
 
 // Local imports - common
-import { toErrorMessage } from '@common/errors/errorHandlingUtils';
+import { toErrorMessage } from '@common/errors';
 
 // Local imports - log
 import * as logger from '@logger/logUtils';

--- a/src/frontend/latex/linter.ts
+++ b/src/frontend/latex/linter.ts
@@ -2,7 +2,7 @@
 import * as vscode from 'vscode';
 
 // Local imports - common
-import { toErrorMessage } from '@common/errors/errorHandlingUtils';
+import { toErrorMessage } from '@common/errors';
 
 // Local imports - log
 import * as logger from '@logger/logUtils';

--- a/src/frontend/media/audio.ts
+++ b/src/frontend/media/audio.ts
@@ -8,7 +8,7 @@ import { execa, type Subprocess } from 'execa';
 
 // Local imports - log
 import { ModelHandlerOpenAI } from '@agent/modelHandlers/modelHandlerOpenAI';
-import { getSdkErrorMessage } from '@common/errors/sdkErrorUtils';
+import { getSdkErrorMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
 import { MODEL_CONFIGS } from '@model/ModelRegistry';
 import { AbsoluteFS, StorageFS } from '@utils/files';

--- a/src/frontend/media/img.ts
+++ b/src/frontend/media/img.ts
@@ -8,7 +8,7 @@ import { PDFDocument } from '@cantoo/pdf-lib';
 import { fromPath } from 'pdf2pic';
 
 // Local imports - log
-import { toErrorMessage } from '@common/errors/errorHandlingUtils';
+import { toErrorMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
 import { getConfig } from '@utils/config';
 import { AbsoluteFS, getMimeType, resolveFilePath } from '@utils/files';

--- a/src/historyView/HistoryViewContentProvider.ts
+++ b/src/historyView/HistoryViewContentProvider.ts
@@ -2,10 +2,7 @@
 import * as vscode from 'vscode';
 
 // Local imports - history view
-import {
-  BaseViewContentProvider,
-  ModuleDescriptor,
-} from '@common/webview/BaseViewContentProvider';
+import { BaseViewContentProvider, ModuleDescriptor } from '@common/webview';
 
 export class HistoryViewContentProvider extends BaseViewContentProvider {
   constructor(context: vscode.ExtensionContext) {

--- a/src/historyView/HistoryViewMessageHandler.ts
+++ b/src/historyView/HistoryViewMessageHandler.ts
@@ -2,13 +2,10 @@
 import * as vscode from 'vscode';
 
 // Local imports - agent commands
-import { showLoggedErrorMessage } from '@common/errors/errorHandlingUtils';
-import {
-  BaseViewMessageHandler,
-  type MessageHandler,
-} from '@common/webview/BaseViewMessageHandler';
+import { showLoggedErrorMessage } from '@common/errors';
+import { BaseViewMessageHandler, type MessageHandler } from '@common/webview';
 // @ts-ignore - Import JavaScript module
-import { HISTORY_VIEW_COMMANDS } from '@common/webview/commands';
+import { HISTORY_VIEW_COMMANDS } from '@common/webview';
 import { AgentHistoryManager } from '@historyView/managers';
 import { agentConfigToTaskState } from '@utils/config';
 import { executeCommand } from '@commands/agent/executeCommand';

--- a/src/historyView/HistoryViewProvider.ts
+++ b/src/historyView/HistoryViewProvider.ts
@@ -2,8 +2,8 @@
 import * as vscode from 'vscode';
 
 // Local imports - common webview
-import { BaseWebviewProvider } from '@common/webview/BaseWebviewProvider';
-import { getSharedLocalResourceRoots } from '@common/webview/resourceRoots';
+import { BaseWebviewProvider } from '@common/webview';
+import { getSharedLocalResourceRoots } from '@common/webview';
 
 // Local imports - history view components
 import { HistoryViewContentProvider } from './HistoryViewContentProvider';

--- a/src/housekeeping/clean.ts
+++ b/src/housekeeping/clean.ts
@@ -9,7 +9,7 @@ import { sync as globSync } from 'glob';
 import type { FileOpResult } from '@agent/types/ResultTypes';
 
 // Internal imports
-import { toErrorMessage } from '@common/errors/errorHandlingUtils';
+import { toErrorMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
 import { WorkspaceFS } from '@utils/files';
 import { getConfig } from '@utils/config';

--- a/src/housekeeping/indent.ts
+++ b/src/housekeeping/indent.ts
@@ -5,7 +5,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 
 // Local imports - log
-import { showLoggedErrorMessage } from '@common/errors/errorHandlingUtils';
+import { showLoggedErrorMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
 import { WorkspaceFS, AbsoluteFS } from '@utils/files';
 import { getConfig } from '@utils/config';

--- a/src/housekeeping/latexdiff.ts
+++ b/src/housekeeping/latexdiff.ts
@@ -9,7 +9,7 @@ import {
   showLoggedErrorMessage,
   showLoggedMessage,
   toErrorMessage,
-} from '@common/errors/errorHandlingUtils';
+} from '@common/errors';
 import * as logger from '@logger/logUtils';
 import { WorkspaceFS } from '@utils/files';
 

--- a/src/housekeeping/pack.ts
+++ b/src/housekeeping/pack.ts
@@ -8,7 +8,7 @@ import * as vscode from 'vscode';
 import type { FileOpResult } from '@agent/types/ResultTypes';
 
 // Local imports - log
-import { toErrorMessage } from '@common/errors/errorHandlingUtils';
+import { toErrorMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
 import { WorkspaceFS } from '@utils/files';
 import { getConfig } from '@utils/config';

--- a/src/latex/LatexMediaManager.ts
+++ b/src/latex/LatexMediaManager.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 // Local imports - log
 import { AgentWorkspaceState } from '@agent/core/AgentWorkspaceState';
 import { ToolConfig } from '@agent/core/ToolConfig';
-import { toErrorMessage } from '@common/errors/errorHandlingUtils';
+import { toErrorMessage } from '@common/errors';
 import { AgentLogger } from '@logger/AgentLogger';
 import { TaskRunFileService, flexibleFS } from '@utils/files';
 

--- a/src/latex/TikzPictureManager.ts
+++ b/src/latex/TikzPictureManager.ts
@@ -6,7 +6,7 @@ import * as nunjucks from 'nunjucks';
 
 // Local imports - log
 import { renderPrompt } from '@agent/utils/promptUtils';
-import { toErrorMessage } from '@common/errors/errorHandlingUtils';
+import { toErrorMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
 import { flexibleFS } from '@utils/files';
 import { getConfig } from '@utils/config';

--- a/src/latex/arxivProcessor.ts
+++ b/src/latex/arxivProcessor.ts
@@ -8,7 +8,7 @@ import * as arxivIdentifiers from 'identifiers-arxiv';
 import * as tar from 'tar';
 
 // Local imports - log
-import { toErrorMessage } from '@common/errors/errorHandlingUtils';
+import { toErrorMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
 import { WorkspaceFS, AbsoluteFS } from '@utils/files';
 import { indentLatexFilesInDirectory } from '@housekeeping/indent';

--- a/src/latex/extractFigure.ts
+++ b/src/latex/extractFigure.ts
@@ -2,7 +2,7 @@
 import * as path from 'path';
 
 // Local imports - log
-import { toErrorMessage } from '@common/errors/errorHandlingUtils';
+import { toErrorMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
 import { flexibleFS } from '@utils/files';
 

--- a/src/latex/formatter/latexindentpt.ts
+++ b/src/latex/formatter/latexindentpt.ts
@@ -5,7 +5,7 @@ import * as path from 'path';
 import { sync as globSync } from 'glob';
 
 // Local imports - log
-import { toErrorMessage } from '@common/errors/errorHandlingUtils';
+import { toErrorMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
 import { AbsoluteFS, WorkspaceFS } from '@utils/files';
 import { getConfig } from '@utils/config';

--- a/src/latex/formatter/texfmt.ts
+++ b/src/latex/formatter/texfmt.ts
@@ -1,5 +1,5 @@
 // Local imports - log
-import { toErrorMessage } from '@common/errors/errorHandlingUtils';
+import { toErrorMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
 import { getConfig } from '@utils/config';
 import { runToolWithCheck } from '@utils/system';

--- a/src/latex/latexdiff.ts
+++ b/src/latex/latexdiff.ts
@@ -5,11 +5,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 
 // Local imports - log
-import {
-  logErrorMessage,
-  formatError,
-  toErrorMessage,
-} from '@common/errors/errorHandlingUtils';
+import { logErrorMessage, formatError, toErrorMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
 import { MESSAGE_TYPES } from '@logger/messageTypes';
 import { flexibleFS } from '@utils/files';

--- a/src/latex/latexdiff/diffFileProcessor.ts
+++ b/src/latex/latexdiff/diffFileProcessor.ts
@@ -1,5 +1,5 @@
 // Local imports - log
-import { toErrorMessage } from '@common/errors/errorHandlingUtils';
+import { toErrorMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
 import replacementEngine from '@replacement/engine';
 import { flexibleFS } from '@utils/files';

--- a/src/latex/texTools.ts
+++ b/src/latex/texTools.ts
@@ -2,7 +2,7 @@
 import * as path from 'path';
 
 // Local imports - log
-import { toErrorMessage } from '@common/errors/errorHandlingUtils';
+import { toErrorMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
 import { runToolWithCheck } from '@utils/system';
 import { getConfig } from '@utils/config';

--- a/src/latex/texcount.ts
+++ b/src/latex/texcount.ts
@@ -1,5 +1,5 @@
 // Local imports - log
-import { toErrorMessage } from '@common/errors/errorHandlingUtils';
+import { toErrorMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
 import { flexibleFS } from '@utils/files';
 import { runToolWithCheck } from '@utils/system';

--- a/src/latex/textConnection.ts
+++ b/src/latex/textConnection.ts
@@ -5,7 +5,7 @@ import OpenAI from 'openai';
 // Local imports - error utils
 import { ModelHandlerOpenAI } from '@agent/modelHandlers/modelHandlerOpenAI';
 import { ModelHandlerAnthropic } from '@agent/modelHandlers/modelHandlerAnthropic';
-import { getSdkErrorMessage } from '@common/errors/sdkErrorUtils';
+import { getSdkErrorMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
 import { MODEL_CONFIGS } from '@model/ModelRegistry';
 

--- a/src/logger/sinks/ProgressViewSink.ts
+++ b/src/logger/sinks/ProgressViewSink.ts
@@ -13,7 +13,7 @@ import type {
   LogGroupFinishedEvent,
   LogGroupStartedEvent,
   LogMessageEvent,
-} from '@logger/types/LogEventSink';
+} from '@logger/types';
 
 // Internal imports
 import { getConfig } from '@utils/config';

--- a/src/logger/transports/VSCodeTransport.ts
+++ b/src/logger/transports/VSCodeTransport.ts
@@ -3,16 +3,16 @@ import * as vscode from 'vscode';
 import Transport from 'winston-transport';
 
 // Local imports - logger
-import { getColorForLevel } from '@logger/utils/levelColors';
+import { getColorForLevel } from '@logger/utils';
 // Type imports
 import type {
   LogEventSink,
   LogGroupFinishedEvent,
   LogGroupStartedEvent,
   LogMessageEvent,
-} from '@logger/types/LogEventSink';
+} from '@logger/types';
 // Internal imports
-import { serializeLogData } from '@logger/utils/serializeLogData';
+import { serializeLogData } from '@logger/utils';
 
 interface VSCodeTransportOptions extends Transport.TransportStreamOptions {
   channel: vscode.OutputChannel;

--- a/src/logger/types/index.ts
+++ b/src/logger/types/index.ts
@@ -1,0 +1,8 @@
+// Barrel export for logger types
+export { TaskGroupId, LogMessageId } from './EntityTypes';
+export {
+  LogMessageEvent,
+  LogGroupStartedEvent,
+  LogGroupFinishedEvent,
+  LogEventSink,
+} from './LogEventSink';

--- a/src/logger/utils/index.ts
+++ b/src/logger/utils/index.ts
@@ -1,0 +1,3 @@
+// Barrel export for logger utilities
+export { getColorForLevel } from './levelColors';
+export { serializeLogData } from './serializeLogData';

--- a/src/model/ModelRegistry.ts
+++ b/src/model/ModelRegistry.ts
@@ -9,16 +9,18 @@
 
 // Local imports - agent components
 import { ModelConfig } from './ModelConfig';
-import { ANTHROPIC_MODELS } from './providers/anthropicModels';
-import { OPENAI_REASONING_MODELS } from './providers/openaiReasoningModels';
-import { OPENAI_MODELS } from './providers/openaiModels';
-import { GOOGLE_MODELS } from './providers/googleModels';
-import { XAI_MODELS } from './providers/xaiModels';
-import { OTHER_MODELS } from './providers/otherModels';
-import { DEEPSEEK_MODELS } from './providers/deepseekModels';
-import { MOONSHOT_MODELS } from './providers/moonshotModels';
-import { DASHSCOPE_MODELS } from './providers/dashscopeModels';
-import { COPILOT_MODELS } from './providers/copilotModels';
+import {
+  ANTHROPIC_MODELS,
+  OPENAI_REASONING_MODELS,
+  OPENAI_MODELS,
+  GOOGLE_MODELS,
+  XAI_MODELS,
+  OTHER_MODELS,
+  DEEPSEEK_MODELS,
+  MOONSHOT_MODELS,
+  DASHSCOPE_MODELS,
+  COPILOT_MODELS,
+} from './providers';
 
 /**
  * Available model configurations indexed by short name.

--- a/src/model/providers/index.ts
+++ b/src/model/providers/index.ts
@@ -1,0 +1,12 @@
+// Barrel export for model providers
+export { ANTHROPIC_MODELS } from './anthropicModels';
+export { COPILOT_MODELS } from './copilotModels';
+export { DASHSCOPE_MODELS } from './dashscopeModels';
+export { DEEPSEEK_MODELS } from './deepseekModels';
+export { GOOGLE_MODELS } from './googleModels';
+export { MOONSHOT_MODELS } from './moonshotModels';
+export { OPENAI_DEEP_RESEARCH_MODELS } from './openaiDeepResearchModels';
+export { OPENAI_MODELS } from './openaiModels';
+export { OPENAI_REASONING_MODELS } from './openaiReasoningModels';
+export { OTHER_MODELS } from './otherModels';
+export { XAI_MODELS } from './xaiModels';

--- a/src/progressView/ProgressViewContentProvider.ts
+++ b/src/progressView/ProgressViewContentProvider.ts
@@ -2,10 +2,7 @@
 import * as vscode from 'vscode';
 
 // Local imports - progress view
-import {
-  BaseViewContentProvider,
-  ModuleDescriptor,
-} from '@common/webview/BaseViewContentProvider';
+import { BaseViewContentProvider, ModuleDescriptor } from '@common/webview';
 
 export class ProgressViewContentProvider extends BaseViewContentProvider {
   constructor(context: vscode.ExtensionContext) {

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -16,12 +16,9 @@ import type { StreamTabId, ExecutionId } from '@agent/types/IdentifierTypes';
 import type { OutputFileInfo } from '@agent/output/types';
 // Internal imports
 import { ToolUseSessionPersistence } from '@agent/toolUse/ToolUseSessionPersistence';
-import { toErrorMessage } from '@common/errors/errorHandlingUtils';
-import {
-  BaseViewMessageHandler,
-  MessageHandler,
-} from '@common/webview/BaseViewMessageHandler';
-import { PROGRESS_VIEW_COMMANDS } from '@common/webview/commands';
+import { toErrorMessage } from '@common/errors';
+import { BaseViewMessageHandler, MessageHandler } from '@common/webview';
+import { PROGRESS_VIEW_COMMANDS } from '@common/webview';
 import {
   isWorkflowTaskState,
   type WorkflowTaskState,

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -6,8 +6,8 @@ import type { StreamTabId, ExecutionId } from '@agent/types/IdentifierTypes';
 import type { TokenUsageStats } from '@agent/types/UsageTypes';
 
 // Internal imports
-import { BaseWebviewProvider } from '@common/webview/BaseWebviewProvider';
-import { getSharedLocalResourceRoots } from '@common/webview/resourceRoots';
+import { BaseWebviewProvider } from '@common/webview';
+import { getSharedLocalResourceRoots } from '@common/webview';
 import { AgentLogger } from '@logger/AgentLogger';
 import { LogMessageData } from '@logger/LogTypes';
 

--- a/src/progressView/events/index.ts
+++ b/src/progressView/events/index.ts
@@ -1,0 +1,21 @@
+// Barrel export for progress view events
+export { createErrorBoundary } from './errorHandling';
+export { LogEventsModule, createLogEvents } from './LogEvents';
+export { OutputEventsModule, createOutputEvents } from './OutputEvents';
+export { ProgressEventHandler } from './ProgressEventHandler';
+export {
+  StreamStatusEventShared,
+  StreamStatusEventModule,
+  createStreamStatusEvents,
+} from './StreamStatusEvents';
+export {
+  TaskGroupEventsModule,
+  createTaskGroupEvents,
+} from './TaskGroupEvents';
+export {
+  StreamStatusType,
+  StreamStatusOrReadyType,
+  StatusType,
+  ProgressEventBusLike,
+} from './types';
+export { UsageEventsModule, createUsageEvents } from './UsageEvents';

--- a/src/replacement/engine.ts
+++ b/src/replacement/engine.ts
@@ -3,7 +3,7 @@
  */
 
 // Local imports - common
-import { toErrorMessage } from '@common/errors/errorHandlingUtils';
+import { toErrorMessage } from '@common/errors';
 
 // Local imports - log
 import * as logger from '@logger/logUtils';

--- a/src/replacement/rules/index.ts
+++ b/src/replacement/rules/index.ts
@@ -1,0 +1,16 @@
+// Barrel export for replacement rules
+export { CHARACTER_REPLACEMENTS } from './characters';
+export { EQUATION_MACRO_REPLACEMENTS } from './equationMacros';
+export { EQUATION_REPLACEMENTS } from './equations';
+export { FONT_COMMAND_REPLACEMENTS } from './fontCommands';
+export { LATEX_FORBIDDEN_REPLACEMENTS } from './forbiddenCommands';
+export { GPTNESS_REPLACEMENTS } from './gptness';
+export { HTML_ENTITY_REPLACEMENTS } from './htmlEntities';
+export { LATEX_DOCUMENT_REPLACEMENTS } from './latexDocument';
+export { LATEX_XML_REPLACEMENTS } from './latexXml';
+export { LATEXDIFF_REPLACEMENTS } from './latexdiff';
+export { PERSONAL_STYLE_REPLACEMENTS } from './personalStyle';
+export { SCRATCHPAD_XML_REPLACEMENTS } from './scratchpadXml';
+export { SECTION_REPLACEMENTS } from './sections';
+export { LATEX_SPACING_REPLACEMENTS } from './spacing';
+export { UNICODE_REPLACEMENTS } from './unicode';

--- a/src/test/commands/latex/latexdiffCommands.test.ts
+++ b/src/test/commands/latex/latexdiffCommands.test.ts
@@ -6,7 +6,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 
 // Local imports - commands
-import * as errorHandlingModule from '@common/errors/errorHandlingUtils';
+import * as errorHandlingModule from '@common/errors';
 import * as openBuildModule from '@frontend/latex/openBuild';
 import * as systemModule from '@utils/system';
 import * as configModule from '@utils/config';

--- a/src/test/commands/system/mainViewCommands.test.ts
+++ b/src/test/commands/system/mainViewCommands.test.ts
@@ -5,7 +5,7 @@ import { strict as assert } from 'assert';
 import * as vscode from 'vscode';
 
 // Local imports - test
-import { MAIN_VIEW_COMMANDS } from '@common/webview/commands';
+import { MAIN_VIEW_COMMANDS } from '@common/webview';
 import {
   registerMainViewCommands,
   mainViewCommands,

--- a/src/test/frontend/agents/register.test.ts
+++ b/src/test/frontend/agents/register.test.ts
@@ -5,7 +5,7 @@ import { strict as assert } from 'assert';
 import {
   getAgentRegistrationSkipReason,
   type AgentVariantMetadata,
-} from '@frontend/agents/register';
+} from '@frontend/agents';
 
 describe('getAgentRegistrationSkipReason', () => {
   it('returns alreadyRegistered when the agent is present', () => {

--- a/src/tools/DiagnosticsTool.ts
+++ b/src/tools/DiagnosticsTool.ts
@@ -2,7 +2,7 @@
 import { z } from 'zod';
 
 // Internal imports
-import { toErrorMessage } from '@common/errors/errorHandlingUtils';
+import { toErrorMessage } from '@common/errors';
 import {
   getLinterMessages,
   countDiagnosticsBySeverity,

--- a/src/tools/applyPath.ts
+++ b/src/tools/applyPath.ts
@@ -2,7 +2,7 @@
 import { z } from 'zod';
 
 // Local imports - common
-import { toErrorMessage } from '@common/errors/errorHandlingUtils';
+import { toErrorMessage } from '@common/errors';
 
 // Local imports - tools
 import { ToolError, toolResult, type ToolResult } from '@tools/result';

--- a/src/tools/arxiv/ArxivDownloadTool.ts
+++ b/src/tools/arxiv/ArxivDownloadTool.ts
@@ -2,7 +2,7 @@
 import { z } from 'zod';
 
 // Local imports - tools
-import { toErrorMessage } from '@common/errors/errorHandlingUtils';
+import { toErrorMessage } from '@common/errors';
 import { LsTool } from '@tools/ls';
 import { ToolError, ToolResult, toolResult } from '@tools/result';
 import { formatToolOutput, toPosixPath } from '@tools/utils';

--- a/src/tools/arxiv/ArxivMetadataTool.ts
+++ b/src/tools/arxiv/ArxivMetadataTool.ts
@@ -2,7 +2,7 @@
 import { z } from 'zod';
 
 // Local imports - latex
-import { toErrorMessage } from '@common/errors/errorHandlingUtils';
+import { toErrorMessage } from '@common/errors';
 import { ToolError, toolResult } from '@tools/result';
 import {
   type ArxivPaperMetadata,

--- a/src/tools/arxiv/ArxivSearchTool.ts
+++ b/src/tools/arxiv/ArxivSearchTool.ts
@@ -3,7 +3,7 @@ import { all, and, category as catQuery } from 'arxiv-client';
 import { z } from 'zod';
 
 // Local imports - latex
-import { toErrorMessage } from '@common/errors/errorHandlingUtils';
+import { toErrorMessage } from '@common/errors';
 import { ToolError, toolResult } from '@tools/result';
 import {
   type ArxivSearchResult,

--- a/src/tools/citation/CrossrefDoiTool.ts
+++ b/src/tools/citation/CrossrefDoiTool.ts
@@ -3,7 +3,7 @@ import { CrossrefClient } from '@jamesgopsill/crossref-client';
 import { z } from 'zod';
 
 // Local imports - metadata
-import { toErrorMessage } from '@common/errors/errorHandlingUtils';
+import { toErrorMessage } from '@common/errors';
 import { ToolError, toolResult } from '@tools/result';
 import { defineTool } from '@tools/core/define';
 

--- a/src/tools/citation/CrossrefSearchTool.ts
+++ b/src/tools/citation/CrossrefSearchTool.ts
@@ -8,7 +8,7 @@ import {
 import { z } from 'zod';
 
 // Local imports - metadata
-import { toErrorMessage } from '@common/errors/errorHandlingUtils';
+import { toErrorMessage } from '@common/errors';
 import { ToolError, toolResult } from '@tools/result';
 import { defineTool } from '@tools/core/define';
 

--- a/src/tools/core/base.ts
+++ b/src/tools/core/base.ts
@@ -2,7 +2,7 @@
 import { ZodError, type ZodType } from 'zod';
 
 // Local imports - common
-import { toErrorMessage } from '@common/errors/errorHandlingUtils';
+import { toErrorMessage } from '@common/errors';
 
 // Local imports - model
 import type { ToolDefinition } from '@model';

--- a/src/tools/glob.ts
+++ b/src/tools/glob.ts
@@ -3,7 +3,7 @@ import { glob } from 'glob';
 import { z } from 'zod';
 
 // Local imports - tools
-import { toErrorMessage } from '@common/errors/errorHandlingUtils';
+import { toErrorMessage } from '@common/errors';
 import { ToolError, ToolResult, toolResult } from '@tools/result';
 import {
   joinWorkspaceRelativePath,

--- a/src/tools/ls.ts
+++ b/src/tools/ls.ts
@@ -3,7 +3,7 @@ import * as vscode from 'vscode';
 import { z } from 'zod';
 
 // Local imports - tools
-import { toErrorMessage } from '@common/errors/errorHandlingUtils';
+import { toErrorMessage } from '@common/errors';
 import { ToolError, ToolResult, toolResult } from '@tools/result';
 import {
   createGlobMatcher,

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -5,7 +5,7 @@ import * as path from 'path';
 import { Minimatch } from 'minimatch';
 
 // Local imports - tools
-import { toErrorMessage } from '@common/errors/errorHandlingUtils';
+import { toErrorMessage } from '@common/errors';
 import { ToolError, type ToolFileAttachment } from '@tools/result';
 import { toPosixPath } from '@tools/pathUtils';
 import { WorkspaceFS, getMimeType } from '@utils/files';

--- a/src/tools/web/WebFetchTool.ts
+++ b/src/tools/web/WebFetchTool.ts
@@ -7,7 +7,7 @@ import TurndownService from 'turndown';
 import { z } from 'zod';
 
 // Local imports - core
-import { toErrorMessage } from '@common/errors/errorHandlingUtils';
+import { toErrorMessage } from '@common/errors';
 import { ToolError, ToolResult, toolResult } from '@tools/result';
 import { defineTool } from '@tools/core/define';
 

--- a/src/tools/web/WebSearchTool.ts
+++ b/src/tools/web/WebSearchTool.ts
@@ -3,7 +3,7 @@ import axios from 'axios';
 import { z } from 'zod';
 
 // Internal imports
-import { toErrorMessage } from '@common/errors/errorHandlingUtils';
+import { toErrorMessage } from '@common/errors';
 import { ToolResult, ToolError, toolResult } from '@tools/result';
 import { defineTool } from '@tools/core/define';
 

--- a/src/tools/wolfram/wolframScriptUtils.ts
+++ b/src/tools/wolfram/wolframScriptUtils.ts
@@ -2,7 +2,7 @@
 import * as vscode from 'vscode';
 
 // Local imports - system utilities
-import { toErrorMessage } from '@common/errors/errorHandlingUtils';
+import { toErrorMessage } from '@common/errors';
 import { executeCommand, checkToolInstalled } from '@utils/system';
 
 // Wolfram configuration is now in toolUtils.ts

--- a/src/utils/files/fileMappingUtils.ts
+++ b/src/utils/files/fileMappingUtils.ts
@@ -2,7 +2,7 @@
 import * as path from 'path';
 
 // Local imports - common
-import { toErrorMessage } from '@common/errors/errorHandlingUtils';
+import { toErrorMessage } from '@common/errors';
 
 // Local imports - logger
 import { AgentLogger } from '@logger/AgentLogger';

--- a/src/utils/files/taskRunStorage.ts
+++ b/src/utils/files/taskRunStorage.ts
@@ -6,7 +6,7 @@ import { promises as fs } from 'fs';
 import type { ExecutionId } from '@agent/types/IdentifierTypes';
 
 // Local imports - common
-import { toErrorMessage } from '@common/errors/errorHandlingUtils';
+import { toErrorMessage } from '@common/errors';
 
 // Internal imports
 import * as logger from '@logger/logUtils';

--- a/src/utils/system/commandUtils.ts
+++ b/src/utils/system/commandUtils.ts
@@ -2,7 +2,7 @@
 import * as vscode from 'vscode';
 
 // Local imports - log
-import { showLoggedErrorMessage } from '@common/errors/errorHandlingUtils';
+import { showLoggedErrorMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
 
 const CHANNEL = 'commandUtils';

--- a/src/utils/system/execUtils.ts
+++ b/src/utils/system/execUtils.ts
@@ -6,7 +6,7 @@ import { quote as shellQuote } from 'shell-quote';
 import type { ExecResult } from '@agent/types/ResultTypes';
 
 // Local imports - common
-import { toErrorMessage } from '@common/errors/errorHandlingUtils';
+import { toErrorMessage } from '@common/errors';
 
 // Internal imports
 import * as logger from '@logger/logUtils';

--- a/src/utils/text/textEnhancementUtils.ts
+++ b/src/utils/text/textEnhancementUtils.ts
@@ -6,7 +6,7 @@ import * as vscode from 'vscode';
 // Local imports - agent runtime
 import { ModelFactory } from '@agent/runtime/ModelFactory';
 import { ModelHandler } from '@agent/modelHandlers/ModelHandler';
-import { getSdkErrorMessage } from '@common/errors/sdkErrorUtils';
+import { getSdkErrorMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
 // Type imports
 import type { TaskState } from '@logger/TaskState';

--- a/src/utils/text/xmlUtils.ts
+++ b/src/utils/text/xmlUtils.ts
@@ -4,7 +4,7 @@ import { gfm } from 'turndown-plugin-gfm';
 import nodePandoc from 'node-pandoc';
 
 // Local imports - common
-import { toErrorMessage } from '@common/errors/errorHandlingUtils';
+import { toErrorMessage } from '@common/errors';
 
 // Local imports - utils
 import * as logger from '@logger/logUtils';

--- a/src/webview/MainViewContentProvider.ts
+++ b/src/webview/MainViewContentProvider.ts
@@ -14,10 +14,7 @@ import {
   DEFAULT_WORKFLOW_AGENT,
   type AgentDirectoryMap,
 } from '@agent/utils/agentOptionMetadata';
-import {
-  BaseViewContentProvider,
-  ModuleDescriptor,
-} from '@common/webview/BaseViewContentProvider';
+import { BaseViewContentProvider, ModuleDescriptor } from '@common/webview';
 import { getConfig } from '@utils/config';
 import { GlobalStorageFS } from '@utils/files';
 

--- a/src/webview/MainViewMessageHandler.ts
+++ b/src/webview/MainViewMessageHandler.ts
@@ -3,18 +3,15 @@ import * as vscode from 'vscode';
 
 // Local imports - common
 import { computeAgentOptions } from '@agent/computeAgentOptions';
-import { toErrorMessage } from '@common/errors/errorHandlingUtils';
+import { toErrorMessage } from '@common/errors';
 
 // Local imports - webview
-import {
-  BaseViewMessageHandler,
-  MessageHandler,
-} from '@common/webview/BaseViewMessageHandler';
+import { BaseViewMessageHandler, MessageHandler } from '@common/webview';
 // @ts-ignore - Import JavaScript module
-import { MAIN_VIEW_COMMANDS } from '@common/webview/commands';
+import { MAIN_VIEW_COMMANDS } from '@common/webview';
 import { SecretManager } from '@frontend/secretManager';
+import { agentDirectories } from '@frontend/agents';
 import { showInstructionWithSuppress } from '@frontend/ui/instruction';
-import { agentDirectories } from '@frontend/agents/AgentDirectoryManager';
 import { computeModelOptions } from '@model/computeModelOptions';
 import { getConfig, setConfig } from '@utils/config';
 import {

--- a/src/webview/managers/DiffManager.ts
+++ b/src/webview/managers/DiffManager.ts
@@ -2,7 +2,7 @@
 import * as vscode from 'vscode';
 
 // Local imports - webview commands
-import { MAIN_VIEW_COMMANDS } from '@common/webview/commands';
+import { MAIN_VIEW_COMMANDS } from '@common/webview';
 import * as logger from '@logger/logUtils';
 
 const CHANNEL = 'DiffManager';

--- a/src/webview/managers/FileManager.ts
+++ b/src/webview/managers/FileManager.ts
@@ -8,12 +8,9 @@ import { workspace } from 'vscode';
 // Local imports - webview
 import { loadAgentSettingAndPrompts } from '@agent/runtime/agentLoad';
 import { getAgentPath } from '@agent/runtime/executeAgent';
-import {
-  showLoggedMessage,
-  toErrorMessage,
-} from '@common/errors/errorHandlingUtils';
-import { MAIN_VIEW_COMMANDS } from '@common/webview/commands';
-import { fileLister } from '@frontend/files/fileLister';
+import { showLoggedMessage, toErrorMessage } from '@common/errors';
+import { MAIN_VIEW_COMMANDS } from '@common/webview';
+import { fileLister } from '@frontend/files';
 import { uncapitalize } from '@frontend/ui/messageUtils';
 import * as logger from '@logger/logUtils';
 import { getConfig } from '@utils/config';

--- a/src/webview/managers/InstructionManager.ts
+++ b/src/webview/managers/InstructionManager.ts
@@ -5,8 +5,8 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 
 // Local imports - common
-import { toErrorMessage } from '@common/errors/errorHandlingUtils';
-import { MAIN_VIEW_COMMANDS } from '@common/webview/commands';
+import { toErrorMessage } from '@common/errors';
+import { MAIN_VIEW_COMMANDS } from '@common/webview';
 
 // Local imports - logger
 import * as logger from '@logger/logUtils';

--- a/src/webview/managers/RecordingManager.ts
+++ b/src/webview/managers/RecordingManager.ts
@@ -2,7 +2,7 @@
 import * as vscode from 'vscode';
 
 // Local imports - common
-import { toErrorMessage } from '@common/errors/errorHandlingUtils';
+import { toErrorMessage } from '@common/errors';
 
 // Local imports - media utilities
 import {


### PR DESCRIPTION
Introduce index.ts files to 17 second-order directories to simplify imports while maintaining clear directory structure. This allows consolidating multiple file imports within each subdomain.

Added index.ts to:
- High priority (8 dirs): replacement/rules, model/providers, commands/system, progressView/events, commands/latex, commands/agent, agent/types, common/webview
- Medium priority (9 dirs): frontend/files, commands/files, commands/history, commands/housekeeping, commands/wolfram, common/errors, logger/types, logger/utils, frontend/agents

All changes validated with:
- TypeScript compilation ✓
- ESLint ✓
- Prettier formatting ✓

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds index.ts barrels across subsystems and refactors imports/exports to use consolidated module entrypoints (no functional changes).
> 
> - **Imports/Exports consolidation**:
>   - Add barrel `index.ts` modules for `@common/webview`, `@common/errors`, `@frontend/agents`, `@frontend/files`, `@commands/{agent,latex,files,history,housekeeping,system,wolfram}`, `@logger/{types,utils}`, `@model/providers`, `@agent/types`, `progressView/events`, and `replacement/rules`.
>   - Refactor project-wide imports to use new barrels (e.g., `@common/errors`, `@common/webview`, `@frontend/{agents,files}`) and grouped command exports.
>   - Update `ModelRegistry` to import providers via `./providers` barrel; logger sinks/transports now consume `@logger/types` and `@logger/utils`.
> - **Minor structure tweaks**:
>   - Centralize webview provider/handler imports; re-export command groups from package barrels; clean up duplicate/legacy paths.
>   - Adjust tests to import from new barrels.
> - **Behavior**: No functional logic changes; compile and tests updated to match new import structure.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ec5f08b8928ecb79309d730156a2e55bf1d3d7d0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->