### PR TITLE
Design graceful agent concatenation approach

### DIFF
--- a/resources/agents/derive_criticize.yaml
+++ b/resources/agents/derive_criticize.yaml
@@ -1,0 +1,30 @@
+name: derive-criticize
+
+settings:
+  agentType: pipeline
+  chainOutputToInput: false  # Criticize needs to see both original and derivation
+  documentTag: latex_document
+  endTag: </latex_document>
+  outputExt: tex
+
+  pipeline:
+    - agent: derive
+      # First derives with full steps and verifies
+
+    - agent: criticize
+      # Then criticizes, seeing both original and derived version
+
+prompts:
+  systemPrompt: |
+    Two-phase scientific workflow: rigorous derivation followed by critical analysis.
+    This pipeline first derives mathematical content explicitly from first principles,
+    then provides detailed technical criticism of the derivation.
+
+  userPrefix: |
+    This is a two-phase pipeline for mathematical research documents:
+
+    Phase 1 (Derive): Show complete derivations from first principles with verification
+    Phase 2 (Criticize): Provide technical criticism with severity ratings
+
+  userRequest: |
+    Execute the two-phase pipeline on this document.

--- a/src/agent/core/AgentDataclass.ts
+++ b/src/agent/core/AgentDataclass.ts
@@ -13,6 +13,7 @@ export enum AgentType {
   CoT = 'CoT',
   Direct = 'direct',
   ToolUse = 'toolUse',
+  Pipeline = 'pipeline',
 }
 
 /**
@@ -132,12 +133,18 @@ export const AgentToolUseSettingSchema = AgentSettingBaseSchema.extend({
     .prefault(AgentCategory.ToolUse),
 });
 
+/** Pipeline agents define multi-step orchestration workflows. */
+// Import placed here to avoid circular dependencies
+import type { PipelineAgentSettingSchema } from './PipelineTypes';
+
 /**
- * Canonical agent settings schema combining workflow and tool-use variants.
+ * Canonical agent settings schema combining workflow, tool-use, and pipeline variants.
  */
 export const AgentSettingSchema = z.union([
   AgentWorkflowSettingSchema,
   AgentToolUseSettingSchema,
+  // Pipeline schema imported dynamically to avoid circular dependency
+  z.lazy(() => require('./PipelineTypes').PipelineAgentSettingSchema),
 ]);
 
 export type AgentWorkflowSetting = z.infer<typeof AgentWorkflowSettingSchema>;

--- a/src/agent/core/PipelineTypes.ts
+++ b/src/agent/core/PipelineTypes.ts
@@ -1,0 +1,52 @@
+// Third-party imports
+import { z } from 'zod';
+
+// Local imports
+import { AgentWorkflowSettingSchema } from './AgentDataclass';
+
+/**
+ * Configuration for a single step in a pipeline.
+ */
+export const PipelineStepConfigSchema = z.strictObject({
+  agent: z.string().min(1, 'Agent name cannot be empty'),
+  instruction: z.string().optional(),
+  chainOutputToInput: z.boolean().optional(),
+  model: z.string().optional(),
+});
+
+export type PipelineStepConfig = z.infer<typeof PipelineStepConfigSchema>;
+
+/**
+ * Settings for pipeline agents.
+ * Extends workflow settings with pipeline-specific configuration.
+ */
+export const PipelineAgentSettingSchema = AgentWorkflowSettingSchema.extend({
+  agentType: z.literal('pipeline'),
+  chainOutputToInput: z.boolean(),
+  pipeline: z.array(PipelineStepConfigSchema).min(1, 'Pipeline must have at least one step'),
+});
+
+export type PipelineAgentSetting = z.infer<typeof PipelineAgentSettingSchema>;
+
+/**
+ * Output information for a single pipeline step.
+ */
+export interface PipelineStepOutput {
+  stepIndex: number;      // 1-indexed
+  agentName: string;      // "derive", "criticize", etc.
+  outputFile: string;     // Final output file from this step (e.g., "paper_derive_r1_model.tex")
+}
+
+/**
+ * Context passed to child agents during pipeline execution.
+ * Contains information about the current pipeline state.
+ */
+export interface PipelineContext {
+  currentStep: number;           // 1-indexed (1, 2, 3, ...)
+  totalSteps: number;
+  currentAgent: string;          // Name of current step's agent
+  previousAgent?: string;        // Name of previous step's agent (if step > 1)
+  outputs: PipelineStepOutput[]; // All previous step outputs
+  originalInput: string;         // Original input file path
+  chainMode: boolean;            // For this specific step
+}

--- a/src/agent/implementations/BaseAgent.ts
+++ b/src/agent/implementations/BaseAgent.ts
@@ -161,6 +161,7 @@ export abstract class BaseAgent<C = unknown> implements IAgent {
       this.agentPath,
       this.modelHandler,
       this.logger,
+      this.context.pipelineContext,  // Pass pipeline context if available
     );
   }
 

--- a/src/agent/implementations/PipelineAgent.ts
+++ b/src/agent/implementations/PipelineAgent.ts
@@ -1,0 +1,262 @@
+// Local imports - agent
+import type { IModelHandler } from '@agent/modelHandlers';
+import type { AgentConfig } from '@agent/core/AgentConfig';
+// Internal imports
+import { AgentSetting, AgentPrompt } from '@agent/core/AgentDataclass';
+import type {
+  PipelineAgentSetting,
+  PipelineStepConfig,
+  PipelineStepOutput,
+  PipelineContext,
+} from '@agent/core/PipelineTypes';
+import { AgentExecutionContext } from '@agent/runtime/AgentExecutionContext';
+import { IAgent } from '@agent/core/IAgent';
+import { toErrorMessage } from '@common/errors/errorHandlingUtils';
+
+// Local file imports
+import { BaseReflectionAgent } from './BaseReflectionAgent';
+
+/**
+ * Pipeline agent implementation that orchestrates multiple agents sequentially.
+ * Each step in the pipeline executes a complete agent, passing outputs between steps
+ * according to the configured chainOutputToInput mode.
+ */
+export class PipelineAgent extends BaseReflectionAgent {
+  private readonly pipelineSettings: PipelineAgentSetting;
+  private readonly globalChainMode: boolean;
+  private readonly originalInput: string;
+  private readonly outputHistory: PipelineStepOutput[] = [];
+
+  constructor(
+    modelHandler: IModelHandler,
+    agentConfig: AgentConfig,
+    agentSetting: AgentSetting,
+    agentPrompt: AgentPrompt,
+    agentPath: string,
+    context: AgentExecutionContext,
+  ) {
+    super(
+      modelHandler,
+      agentConfig,
+      agentSetting,
+      agentPrompt,
+      agentPath,
+      context,
+    );
+
+    // Type guard - ensure we have pipeline settings
+    if (agentSetting.agentType !== 'pipeline') {
+      throw new Error('PipelineAgent requires pipeline agent type');
+    }
+
+    this.pipelineSettings = agentSetting as PipelineAgentSetting;
+    this.globalChainMode = this.pipelineSettings.chainOutputToInput;
+    this.originalInput = agentConfig.inputFile;
+  }
+
+  /**
+   * Override getTotalRounds to return number of pipeline steps.
+   * This allows BaseReflectionAgent infrastructure to treat steps as rounds.
+   */
+  protected override getTotalRounds(): number {
+    return this.pipelineSettings.pipeline.length;
+  }
+
+  /**
+   * Generate output file name for pipeline agent itself.
+   * Note: Individual step agents generate their own output filenames.
+   */
+  protected getOutputFile(currRound: number): string {
+    // For pipeline agent, we don't generate our own output files
+    // Each step agent generates its own outputs
+    // This method is called by BaseReflectionAgent constructor
+    return '';
+  }
+
+  /**
+   * Main execution method for pipeline agent.
+   * Executes each step sequentially, managing input/output flow between steps.
+   */
+  public override async run(): Promise<void> {
+    this.logger.info('Starting pipeline execution');
+
+    let currentInput = this.originalInput;
+
+    try {
+      for (let stepIndex = 0; stepIndex < this.pipelineSettings.pipeline.length; stepIndex++) {
+        const step = this.pipelineSettings.pipeline[stepIndex];
+        const useChainMode = step.chainOutputToInput ?? this.globalChainMode;
+
+        this.logger.info(
+          `Executing pipeline step ${stepIndex + 1}/${this.pipelineSettings.pipeline.length}: ${step.agent}`
+        );
+
+        // Log separator for UI
+        this.logPipelineStepSeparator(stepIndex + 1, step.agent);
+
+        // Build configuration for this step
+        const stepConfig = this.buildStepConfig(
+          step,
+          currentInput,
+          useChainMode,
+          stepIndex,
+        );
+
+        // Create and execute step agent
+        const stepAgent = await this.createAndInitStepAgent(stepConfig, stepIndex);
+        await stepAgent.run();
+
+        // Get the final output from the step
+        const finalOutput = await this.getStepFinalOutput(stepAgent, stepIndex);
+
+        if (!finalOutput) {
+          throw new Error(`Step ${stepIndex + 1} (${step.agent}) produced no output`);
+        }
+
+        // Record output
+        this.outputHistory.push({
+          stepIndex: stepIndex + 1,  // 1-indexed
+          agentName: step.agent,
+          outputFile: finalOutput,
+        });
+
+        this.logger.info(
+          `Completed step ${stepIndex + 1}: ${step.agent} → ${finalOutput}`
+        );
+
+        // Update input for next step if in chain mode
+        if (useChainMode) {
+          currentInput = finalOutput;
+        }
+      }
+
+      this.logger.info('Pipeline execution completed successfully');
+    } catch (error) {
+      this.logger.error(`Pipeline execution failed: ${toErrorMessage(error)}`);
+      throw error;
+    }
+  }
+
+  /**
+   * Log a visual separator for pipeline steps in the UI.
+   */
+  private logPipelineStepSeparator(stepNumber: number, agentName: string): void {
+    const separator = '─'.repeat(80);
+    this.logger.info(`\n${separator}`);
+    this.logger.info(`Pipeline Step ${stepNumber} / ${this.pipelineSettings.pipeline.length}: ${agentName}`);
+    this.logger.info(`${separator}\n`);
+  }
+
+  /**
+   * Build AgentConfig for a specific pipeline step.
+   */
+  private buildStepConfig(
+    step: PipelineStepConfig,
+    currentInput: string,
+    chainMode: boolean,
+    stepIndex: number,
+  ): AgentConfig {
+    const baseConfig: AgentConfig = {
+      model: step.model ?? this.agentConfig.model,
+      agent: step.agent,
+      instruction: step.instruction ?? this.agentConfig.instruction,
+      toolConfig: this.agentConfig.toolConfig,
+      inputFile: '',
+      inputFiles: [],
+      referenceFile: null,
+      referenceFiles: [],
+      auxiliaryFile: this.agentConfig.auxiliaryFile,
+      auxiliaryFiles: this.agentConfig.auxiliaryFiles,
+      mediaFile: this.agentConfig.mediaFile,
+      mediaFiles: this.agentConfig.mediaFiles,
+      outputFiles: this.agentConfig.outputFiles,
+      editedFile: this.agentConfig.editedFile,
+      useMultipleOutputs: this.agentConfig.useMultipleOutputs,
+      session: this.agentConfig.session,
+    };
+
+    if (chainMode) {
+      // Mode A: Sequential transformation
+      baseConfig.inputFile = currentInput;  // Previous output or original
+    } else {
+      // Mode B: Accumulating context
+      baseConfig.inputFile = this.originalInput;  // Always original
+
+      if (stepIndex > 0) {
+        // Add previous outputs as references
+        baseConfig.referenceFiles = this.outputHistory.map(o => o.outputFile);
+      }
+    }
+
+    return baseConfig;
+  }
+
+  /**
+   * Create and initialize a step agent with pipeline context.
+   */
+  private async createAndInitStepAgent(
+    config: AgentConfig,
+    stepIndex: number,
+  ): Promise<IAgent> {
+    // Import here to avoid circular dependency
+    const { prepareAgentInstance } = await import('@agent/runtime/executeAgent');
+
+    // Build pipeline context for this step
+    const pipelineContext: PipelineContext = {
+      currentStep: stepIndex + 1,
+      totalSteps: this.pipelineSettings.pipeline.length,
+      currentAgent: this.pipelineSettings.pipeline[stepIndex].agent,
+      previousAgent: stepIndex > 0 ? this.pipelineSettings.pipeline[stepIndex - 1].agent : undefined,
+      outputs: this.outputHistory,
+      originalInput: this.originalInput,
+      chainMode: this.pipelineSettings.pipeline[stepIndex].chainOutputToInput ?? this.globalChainMode,
+    };
+
+    // Prepare and return the agent instance with pipeline context
+    const { agent } = await prepareAgentInstance({
+      agentName: config.agent,
+      configPayload: config,
+      executionId: this.context.executionId,
+      pipelineContext,
+    });
+
+    return agent;
+  }
+
+  /**
+   * Extract the final output file from a completed step agent.
+   */
+  private async getStepFinalOutput(
+    stepAgent: IAgent,
+    stepIndex: number,
+  ): Promise<string | null> {
+    // Access the agent's output artifacts
+    if ('roundOutputArtifacts' in stepAgent && Array.isArray((stepAgent as any).roundOutputArtifacts)) {
+      const artifacts = (stepAgent as any).roundOutputArtifacts;
+
+      // Get the last round's artifacts
+      const lastRoundArtifacts = artifacts[artifacts.length - 1];
+
+      if (lastRoundArtifacts && lastRoundArtifacts.fileMapping) {
+        // Return the first output file (for single output agents)
+        // For multiple output agents, we might need to handle differently
+        const outputFiles = Object.keys(lastRoundArtifacts.fileMapping);
+        if (outputFiles.length > 0) {
+          return lastRoundArtifacts.fileMapping[outputFiles[0]].targetPath;
+        }
+      }
+    }
+
+    this.logger.warn(`Could not extract final output from step ${stepIndex + 1}`);
+    return null;
+  }
+
+  /**
+   * Override handleOutput - not used by pipeline agent
+   */
+  protected async handleOutput(): Promise<string[]> {
+    // Pipeline agent doesn't handle its own output
+    // Each step agent handles its own output
+    return [];
+  }
+}

--- a/src/agent/implementations/index.ts
+++ b/src/agent/implementations/index.ts
@@ -4,3 +4,4 @@ export * from './CoTAgent';
 export * from './MergeAgent';
 export * from './BaseAgent';
 export * from './BaseToolUseAgent';
+export * from './PipelineAgent';

--- a/src/agent/runtime/AgentExecutionContext.ts
+++ b/src/agent/runtime/AgentExecutionContext.ts
@@ -1,5 +1,6 @@
 // Local imports - agent types
 import type { ExecutionId, StreamTabId } from '@agent/types/IdentifierTypes';
+import type { PipelineContext } from '@agent/core/PipelineTypes';
 
 // Local imports - logger
 import {
@@ -12,6 +13,7 @@ import { AgentUsageReporter } from '@logger/AgentUsageReporter';
 export interface AgentExecutionContextInit {
   streamId: StreamTabId;
   executionId?: ExecutionId;
+  pipelineContext?: PipelineContext;
 }
 
 /**
@@ -32,6 +34,10 @@ export class AgentExecutionContext {
 
   get executionId(): ExecutionId | undefined {
     return this.init.executionId;
+  }
+
+  get pipelineContext(): PipelineContext | undefined {
+    return this.init.pipelineContext;
   }
 
   stage(

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -11,6 +11,7 @@ import {
   MergeAgent,
   BaseToolUseAgent,
   BaseReflectionAgent,
+  PipelineAgent,
 } from '@agent/implementations';
 import { parseAgentConfig, type AgentConfig } from '@agent/core/AgentConfig';
 import {
@@ -143,6 +144,7 @@ function getAgentClass(settings: AgentSetting): AgentConstructor {
     direct: DirectAgent,
     CoT: CoTAgent,
     toolUse: BaseToolUseAgent,
+    pipeline: PipelineAgent,
   };
   return agentTypeMapping[settings.agentType] || DirectAgent;
 }
@@ -177,6 +179,8 @@ interface PrepareAgentInstanceParams {
   agentClassOverride?: AgentConstructor;
   /** Optional factory for constructing the execution context */
   contextFactory?: (init: AgentExecutionContextInit) => AgentExecutionContext;
+  /** Optional pipeline context for agents running within a pipeline */
+  pipelineContext?: import('@agent/core/PipelineTypes').PipelineContext;
 }
 
 /**
@@ -225,6 +229,7 @@ export async function prepareAgentInstance<T extends IAgent = IAgent>(
     executionId,
     agentClassOverride,
     contextFactory,
+    pipelineContext,
   } = params;
 
   const configInput: Partial<AgentConfig> = {
@@ -300,8 +305,8 @@ export async function prepareAgentInstance<T extends IAgent = IAgent>(
   );
 
   const context = contextFactory
-    ? contextFactory({ streamId, executionId })
-    : new AgentExecutionContext({ streamId, executionId });
+    ? contextFactory({ streamId, executionId, pipelineContext })
+    : new AgentExecutionContext({ streamId, executionId, pipelineContext });
 
   const agent = new AgentClass(
     modelHandler,

--- a/src/agent/utils/userVars.ts
+++ b/src/agent/utils/userVars.ts
@@ -4,6 +4,7 @@ import * as path from 'path';
 // Local imports - agent
 import type { IModelHandler } from '@agent/modelHandlers';
 import type { AgentConfig } from '@agent/core/AgentConfig';
+import type { PipelineContext } from '@agent/core/PipelineTypes';
 // Internal imports
 import {
   AgentSetting,
@@ -38,6 +39,7 @@ export async function buildUserVars(
   agentPath: string,
   modelHandler: IModelHandler,
   logger: AgentLogger,
+  pipelineContext?: PipelineContext,  // NEW optional parameter
 ): Promise<Record<string, any>> {
   const userVars: Record<string, any> = {};
   const allLoadedFiles: LoadedFileEntry[] = [];
@@ -57,6 +59,11 @@ export async function buildUserVars(
 
   Object.assign(userVars, getOutputFilesOrder(agentConfig, agentSetting));
   Object.assign(userVars, getToolFlags(agentConfig, agentSetting, agentPrompt));
+
+  // NEW: Add pipeline-specific variables if in pipeline context
+  if (pipelineContext) {
+    Object.assign(userVars, await getPipelineVars(pipelineContext, agentConfig));
+  }
 
   // Emit aggregated file list if any files were loaded
   if (allLoadedFiles.length > 0) {
@@ -312,4 +319,30 @@ export function getToolFlags(
   }
 
   return flags;
+}
+
+/**
+ * Build pipeline-specific variables for agents running within a pipeline.
+ */
+async function getPipelineVars(
+  context: PipelineContext,
+  agentConfig: AgentConfig,
+): Promise<Record<string, any>> {
+  const vars: Record<string, any> = {
+    PIPELINE_STEP: context.currentStep,
+    PIPELINE_TOTAL_STEPS: context.totalSteps,
+    PIPELINE_CURRENT_AGENT: context.currentAgent,
+  };
+
+  if (context.previousAgent) {
+    vars.PIPELINE_PREVIOUS_AGENT = context.previousAgent;
+  }
+
+  // In chain mode, provide ORIGINAL_INPUT_* variables
+  if (context.chainMode && context.currentStep > 1) {
+    vars.ORIGINAL_INPUT_FILE = context.originalInput;
+    vars.ORIGINAL_INPUT_CONTENT = await WorkspaceFS.read(context.originalInput);
+  }
+
+  return vars;
 }


### PR DESCRIPTION
Implement pipeline agent system that allows chaining multiple agents sequentially with flexible data flow patterns. This enables workflows like "derive then criticize" or "expand then polish then proofread".

Core Implementation:
- Add new AgentType.Pipeline to agent type enum
- Create PipelineAgent class extending BaseReflectionAgent
- Add PipelineTypes with step configuration and context types
- Update agent factory to handle pipeline agent type

Variable System:
- Extend buildUserVars with optional PipelineContext parameter
- Add pipeline-specific variables (PIPELINE_STEP, PIPELINE_CURRENT_AGENT, etc.)
- Provide ORIGINAL_INPUT_* variables for chain mode
- Pass pipeline context through AgentExecutionContext

Configuration:
- Support per-step overrides for instruction, model, chainOutputToInput
- Add chainOutputToInput flag for two execution modes:
  * true: Sequential transformation (output → input)
  * false: Accumulating context (original input + references)

Pipeline YAML Example:
- Add derive_criticize.yaml demonstrating pipeline usage
- Supports declarative multi-agent workflow configuration

Features:
- Independent file naming per step for clear provenance
- UI separators between pipeline steps with agent names
- All intermediate outputs saved to disk for transparency
- Pipeline stops on any step failure (no error recovery)

Files Modified:
- src/agent/core/AgentDataclass.ts
- src/agent/implementations/BaseAgent.ts
- src/agent/implementations/index.ts
- src/agent/runtime/AgentExecutionContext.ts
- src/agent/runtime/executeAgent.ts
- src/agent/utils/userVars.ts

Files Added:
- src/agent/core/PipelineTypes.ts
- src/agent/implementations/PipelineAgent.ts
- resources/agents/derive_criticize.yaml

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a configurable pipeline agent that sequences multiple agents with optional output-chaining and exposes pipeline context to prompts; adds types, runtime wiring, and a derive→criticize example.
> 
> - **Agents/Core**:
>   - Add `AgentType.Pipeline` and extend `AgentSettingSchema` via lazy import of `PipelineAgentSettingSchema`.
>   - New `PipelineTypes` with `PipelineStepConfigSchema`, `PipelineAgentSettingSchema`, and pipeline context/output interfaces.
> - **Implementation**:
>   - New `PipelineAgent` executes steps sequentially, supports per-step `model/instruction/chainOutputToInput`, records outputs, and logs UI separators.
>   - `BaseAgent` passes `pipelineContext` to user vars; export `PipelineAgent` in implementations index.
> - **Runtime**:
>   - `AgentExecutionContext` now carries optional `pipelineContext`.
>   - `prepareAgentInstance`/factory support `pipeline` type and propagate `pipelineContext` when instantiating agents.
> - **Prompt/User Vars**:
>   - `buildUserVars` accepts `PipelineContext` and injects `PIPELINE_*` and `ORIGINAL_INPUT_*` variables.
> - **Config/Examples**:
>   - Add `resources/agents/derive_criticize.yaml` demonstrating a two-step derive→criticize pipeline.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ee48515500f457751e7688b1141953e0a5703ebd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->