### PR TITLE
Fix: clean partial latex outputs

### DIFF
--- a/src/agent/output/XmlOutputManager.ts
+++ b/src/agent/output/XmlOutputManager.ts
@@ -292,6 +292,21 @@ export class XmlOutputManager {
         continue;
       }
 
+      const cleanedContent = (() => {
+        const trimmedContent = doc.content.trim();
+        const hasBegin = trimmedContent.includes('\\begin{document}');
+        const hasEnd = trimmedContent.includes('\\end{document}');
+
+        if (!hasBegin && hasEnd) {
+          this.logger.debug(
+            `Removed trailing \\end{document} from partial document ${source}`,
+          );
+          return trimmedContent.replace(/\\end{document}\s*$/u, '').trimEnd();
+        }
+
+        return trimmedContent;
+      })();
+
       const { ext } = path.parse(source);
       const extension = ext.replace('.', '') || 'tex';
       const texFile = getOutputFileName(
@@ -302,7 +317,7 @@ export class XmlOutputManager {
         currRound,
       );
       const texLocation = this.fileService.createLocation(texFile);
-      await AbsoluteFS.write(texLocation.absolutePath, doc.content.trim());
+      await AbsoluteFS.write(texLocation.absolutePath, cleanedContent);
       outputFiles.push(this.buildOutputFileInfo(source, texLocation));
       this.logger.debug(
         `XML Source: ${source} -> TeX file written: ${texFile}`,


### PR DESCRIPTION
## Summary
- trim partial LaTeX snippets during multi-document processing and drop trailing \end{document} when no matching \begin{document} is present
- log when cleanup occurs while leaving fully formed documents unchanged

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c889c49808324b80a5838d5ed88ab)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Trim LaTeX snippets and remove trailing \end{document} when \begin{document} is absent before writing multi-document outputs.
> 
> - **Output handling (`XmlOutputManager.processMultipleLatexDocuments`)**:
>   - Trim LaTeX content and detect mismatched document boundaries.
>   - If `\end{document}` exists without a matching `\begin{document}`, strip the trailing `\end{document}` and log the cleanup.
>   - Write the cleaned content (`cleanedContent`) instead of the raw trimmed content.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f6ffc5b65442d59cc0755a822c10f72503b3c018. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->