### PR TITLE
Strip trailing end{document} from fragment outputs after writing

### DIFF
--- a/src/agent/output/XmlOutputManager.ts
+++ b/src/agent/output/XmlOutputManager.ts
@@ -303,6 +303,7 @@ export class XmlOutputManager {
       );
       const texLocation = this.fileService.createLocation(texFile);
       await AbsoluteFS.write(texLocation.absolutePath, doc.content.trim());
+      await this.removeTrailingEndDocument(texLocation);
       outputFiles.push(this.buildOutputFileInfo(source, texLocation));
       this.logger.debug(
         `XML Source: ${source} -> TeX file written: ${texFile}`,
@@ -377,6 +378,28 @@ export class XmlOutputManager {
 
     if (fixed || content !== originalContent) {
       await AbsoluteFS.write(fileLocation.absolutePath, content);
+    }
+  }
+
+  private async removeTrailingEndDocument(
+    texLocation: FileLocation,
+  ): Promise<void> {
+    const fileContent = await AbsoluteFS.read(texLocation.absolutePath);
+    const trimmedContent = fileContent.trimEnd();
+
+    if (
+      !trimmedContent.includes('\\begin{document}') &&
+      trimmedContent.endsWith('\\end{document}')
+    ) {
+      const cleanedContent = trimmedContent.replace(
+        /\\end{document}\s*$/,
+        '',
+      );
+
+      await AbsoluteFS.write(texLocation.absolutePath, cleanedContent);
+      this.logger.debug(
+        `Removed trailing \\end{document} from ${path.basename(texLocation.absolutePath)}`,
+      );
     }
   }
 }

--- a/src/agent/output/XmlOutputManager.ts
+++ b/src/agent/output/XmlOutputManager.ts
@@ -302,8 +302,11 @@ export class XmlOutputManager {
         currRound,
       );
       const texLocation = this.fileService.createLocation(texFile);
-      await AbsoluteFS.write(texLocation.absolutePath, doc.content.trim());
-      await this.removeTrailingEndDocument(texLocation);
+      const cleanedContent = this.removeTrailingEndDocument(
+        doc.content.trim(),
+        texFile,
+      );
+      await AbsoluteFS.write(texLocation.absolutePath, cleanedContent);
       outputFiles.push(this.buildOutputFileInfo(source, texLocation));
       this.logger.debug(
         `XML Source: ${source} -> TeX file written: ${texFile}`,
@@ -381,25 +384,17 @@ export class XmlOutputManager {
     }
   }
 
-  private async removeTrailingEndDocument(
-    texLocation: FileLocation,
-  ): Promise<void> {
-    const fileContent = await AbsoluteFS.read(texLocation.absolutePath);
-    const trimmedContent = fileContent.trimEnd();
+  private removeTrailingEndDocument(content: string, fileName: string): string {
+    const trimmedContent = content.trimEnd();
 
     if (
       !trimmedContent.includes('\\begin{document}') &&
       trimmedContent.endsWith('\\end{document}')
     ) {
-      const cleanedContent = trimmedContent.replace(
-        /\\end{document}\s*$/,
-        '',
-      );
-
-      await AbsoluteFS.write(texLocation.absolutePath, cleanedContent);
-      this.logger.debug(
-        `Removed trailing \\end{document} from ${path.basename(texLocation.absolutePath)}`,
-      );
+      this.logger.debug(`Removed trailing \\end{document} from ${fileName}`);
+      return trimmedContent.replace(/\\end{document}\s*$/, '');
     }
+
+    return trimmedContent;
   }
 }


### PR DESCRIPTION
## Summary
- clean multi-document LaTeX outputs after writing to disk to remove trailing \end{document} tags when no matching \begin{document} exists
- log when a stray closing tag is trimmed so fragmented outputs compile cleanly

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c889c49808324b80a5838d5ed88ab)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes stray trailing \end{document} in LaTeX fragments without a matching \begin{document}, logging the cleanup before writing files.
> 
> - **Output handling (`src/agent/output/XmlOutputManager.ts`)**:
>   - Add `removeTrailingEndDocument` to trim trailing `\end{document}` when no matching `\begin{document}` exists, with debug logging.
>   - Use the cleaner in `processMultipleLatexDocuments` before writing TeX files.
>   - Minor: preserve trimmed content handling for XML structure fixes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fefb4f4f397f2eb68ef06568b55a7bb6c1076450. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->