### PR TITLE
Fix usage reporting totals for cached prompts

### DIFF
--- a/src/logger/AgentUsageReporter.ts
+++ b/src/logger/AgentUsageReporter.ts
@@ -22,7 +22,7 @@ export class AgentUsageReporter {
    */
   public report(stats: ExtendedTokenUsageStats, runId?: string): void {
     const usage = {
-      inputTokens: stats.inputTokens + (stats.cacheCreationInputTokens ?? 0),
+      inputTokens: stats.inputTokens,
       outputTokens: stats.outputTokens,
       cost: stats.cost,
     };

--- a/src/test/logger/AgentUsageReporter.test.ts
+++ b/src/test/logger/AgentUsageReporter.test.ts
@@ -46,7 +46,7 @@ describe('AgentUsageReporter', () => {
         stream: streamId,
         runId,
         usage: {
-          inputTokens: 14,
+          inputTokens: 10,
           outputTokens: 5,
           cost: 0.25,
         },


### PR DESCRIPTION
## Summary
- stop adding cache creation tokens to AgentUsageReporter input totals
- adjust AgentUsageReporter test expectations to match corrected aggregation

## Testing
- npm test *(fails: /workspace/TeXRA/.vscode-test/vscode-linux-x64-1.106.0/code: error while loading shared libraries: libgtk-3.so.0)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b22eab81083248e2a0dae41abd2b8)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Stop including cache-creation tokens in input totals and update tests accordingly.
> 
> - **Logger**:
>   - `AgentUsageReporter.report`: compute `usage.inputTokens` from `stats.inputTokens` only (exclude `cacheCreationInputTokens`).
> - **Tests**:
>   - Update `AgentUsageReporter` test to expect `inputTokens: 10` (was 14) in `updateStreamUsage` payload.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3844134064d8ab02b20ca0fb2d4259e2ba060916. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->