### PR TITLE
fix: refresh responses reasoning blocks

### DIFF
--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -1256,7 +1256,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
 
     const thoughtContent = summaryParts.map((part) => part.text).join('\n\n'); // to make the thinking markdown rendering more readable
 
-    if (workspaceState && !workspaceState.reasoning.thinkingAdded) {
+    if (workspaceState) {
       workspaceState.reasoning.thinkingBlocks = summaryParts.map((part) => ({
         type: 'thinking',
         thinking: part.text,


### PR DESCRIPTION
## Summary
- replace reasoning block updates for Responses API with an idempotent refresh to avoid duplicate thinking entries

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b22c46be883249897ddf996e77266)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Always refresh reasoning blocks from summary, removing the previous guard to prevent duplicate entries.
> 
> - **Reasoning handling**:
>   - Always refresh `workspaceState.reasoning.thinkingBlocks` from `reasoning.summary` (remove `thinkingAdded` guard) and set `thinkingAdded = true` to avoid duplicates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 538b16bbf5ed481e3c3eddbb366f8428e96bde87. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->