### PR TITLE
Fix duplicate thinking banners for background responses

### DIFF
--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -403,12 +403,13 @@ class ToolUseProcessNode<C> extends BaseNode<ToolUseCycleContext<C>> {
 
     const groupId = options.logger.withCurrentGroup((id) => id);
 
+    const hadThinking = Boolean(store.workspace?.reasoning.thinkingAdded);
     const thinking = options.modelHandler.processThinkingBlock(
       state.response,
       store.workspace,
     );
     const useStreaming = options.modelHandler.getStreamingConfig();
-    if (thinking && !useStreaming) {
+    if (thinking && !useStreaming && !hadThinking) {
       const formatted = await xmlUtils.formatContent(thinking);
       if (formatted.trim().length > 0) {
         options.logger.info(formatted, groupId, MESSAGE_TYPES.THINKING);


### PR DESCRIPTION
## Summary
- prevent duplicate thinking log entries when processing non-streaming responses by tracking prior reasoning state

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691cbd4ed0608324b1f28fd68aab8509)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Avoids duplicate thinking log entries for non-streaming responses by checking prior reasoning state before logging.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 58eafc23a1cd81537784cb7c664fe2e5c9f6172d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->