### PR TITLE
Debug duplicate streaming blocks in workflow agent

### DIFF
--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -346,13 +346,14 @@ class ResponseProcessNode<C> extends BaseNode<ResponseCycleContext<C>> {
       options.logger.debug(`Stop reason: ${stopReason}`);
       options.logger.debug(`Token usage: ${JSON.stringify(responseUsage)}`);
 
+      const hadThinking = Boolean(store.workspace?.reasoning.thinkingAdded);
       const thinkingContent = options.modelHandler.processThinkingBlock(
         state.responseObject,
         store.workspace,
       );
       const useStreaming = options.modelHandler.getStreamingConfig();
 
-      if (thinkingContent && !useStreaming) {
+      if (thinkingContent && !useStreaming && !hadThinking) {
         const formatted = await xmlUtils.formatContent(thinkingContent);
         if (formatted.trim().length > 0) {
           options.logger.info(formatted, undefined, MESSAGE_TYPES.THINKING);
@@ -507,9 +508,6 @@ class ResponseProcessNode<C> extends BaseNode<ResponseCycleContext<C>> {
       .map(([key, value]) => `${key}: ${value}`)
       .join(', ');
     options.logger.debug(`Usage summary: ${usageSummary}`);
-
-    // Thinking content already logged in exec() method above
-    // Removing duplicate log to fix duplicate streaming blocks in workflow agents
 
     options.logger.info(
       `Stop reason: ${result.stopReason}`,

--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -508,13 +508,8 @@ class ResponseProcessNode<C> extends BaseNode<ResponseCycleContext<C>> {
       .join(', ');
     options.logger.debug(`Usage summary: ${usageSummary}`);
 
-    if (result.thinkingContent && !result.useStreaming) {
-      options.logger.info(
-        result.thinkingContent,
-        undefined,
-        MESSAGE_TYPES.THINKING,
-      );
-    }
+    // Thinking content already logged in exec() method above
+    // Removing duplicate log to fix duplicate streaming blocks in workflow agents
 
     options.logger.info(
       `Stop reason: ${result.stopReason}`,


### PR DESCRIPTION
Remove duplicate thinking block logging in `ResponseCycleFlow.ts` to fix duplicate streaming blocks for workflow agents.

The previous fix for `ToolUseCycleFlow.ts` did not address the same duplication pattern in `ResponseCycleFlow.ts`, which caused thinking blocks to be logged twice in the `exec()` and `post()` methods, leading to duplicate "thinking" messages in the progress view.

---
<a href="https://cursor.com/background-agent?bcId=bc-4445289d-f195-41e8-a812-f9ca97a96dfc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4445289d-f195-41e8-a812-f9ca97a96dfc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents duplicate "thinking" messages by gating logging during processing and removing redundant post-stage logging.
> 
> - **Response processing (`src/agent/core/flows/ResponseCycleFlow.ts`)**:
>   - Gate thinking block logging with `hadThinking` and non-streaming check (`processThinkingBlock`), avoiding re-logs when reasoning was already added.
>   - Remove redundant `thinkingContent` log in post stage to eliminate duplicate "thinking" messages.
>   - Preserve existing stop reason and usage logging; no changes to streaming behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a0b87f82030d12481db05e512750bdcf56399f77. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->