### PR TITLE
Fix missing thought signature in API calls

### DIFF
--- a/src/agent/core/AgentWorkspaceState.ts
+++ b/src/agent/core/AgentWorkspaceState.ts
@@ -60,6 +60,7 @@ export class MediaAttachmentState {
 export class ReasoningCacheState {
   public thinkingBlocks: ThinkingBlock[] = [];
   public thinkingAdded = false;
+  public toolCallThoughtSignatures: Map<string, string> = new Map();
 
   get primaryBlock(): ThinkingBlock | null {
     return this.thinkingBlocks.length > 0 ? this.thinkingBlocks[0] : null;
@@ -68,6 +69,7 @@ export class ReasoningCacheState {
   reset(): void {
     this.thinkingBlocks = [];
     this.thinkingAdded = false;
+    this.toolCallThoughtSignatures.clear();
   }
 }
 
@@ -95,6 +97,7 @@ export const AgentWorkspaceStateSnapshotSchema = z.strictObject({
   reasoning: z.strictObject({
     thinkingBlocks: z.array(ThinkingBlockSchema),
     thinkingAdded: z.boolean(),
+    toolCallThoughtSignatures: z.record(z.string(), z.string()),
   }),
   document: z.strictObject({ texcountStats: z.string().nullable() }),
 });
@@ -125,6 +128,9 @@ export class AgentWorkspaceState {
       reasoning: {
         thinkingBlocks: [...this.reasoning.thinkingBlocks],
         thinkingAdded: this.reasoning.thinkingAdded,
+        toolCallThoughtSignatures: Object.fromEntries(
+          this.reasoning.toolCallThoughtSignatures,
+        ),
       },
       document: {
         texcountStats: this.document.texcountStats,
@@ -145,6 +151,9 @@ export class AgentWorkspaceState {
     state.media.files.push(...snapshot.media.files);
     state.reasoning.thinkingBlocks.push(...snapshot.reasoning.thinkingBlocks);
     state.reasoning.thinkingAdded = snapshot.reasoning.thinkingAdded;
+    state.reasoning.toolCallThoughtSignatures = new Map(
+      Object.entries(snapshot.reasoning.toolCallThoughtSignatures),
+    );
     state.document.texcountStats = snapshot.document.texcountStats;
     return state;
   }

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -175,7 +175,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
   Content,
   GenerateContentResponseUsageMetadata | null,
   OpenAIAPIResponseUsage,
-  Part,
+  FunctionCall,
   GoogleGenAI
 > {
   private static readonly INLINE_MEDIA_LIMIT_BYTES = 20 * 1024 * 1024;
@@ -1064,6 +1064,29 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
       workspaceState.reasoning.thinkingAdded = true;
     }
 
+    // Also check for ALL function call parts with thoughtSignature (for Gemini 3 Pro)
+    // Supports parallel function calling where multiple calls may each have signatures
+    if (workspaceState) {
+      const funcParts = parts.filter((part) => part.functionCall);
+      let signatureCount = 0;
+      for (const funcPart of funcParts) {
+        if (funcPart.thoughtSignature && funcPart.functionCall) {
+          // Store thoughtSignature keyed by call ID for later reconstruction
+          const callId = ensureCallId(funcPart.functionCall);
+          workspaceState.reasoning.toolCallThoughtSignatures.set(
+            callId,
+            funcPart.thoughtSignature,
+          );
+          signatureCount++;
+        }
+      }
+      if (signatureCount > 0) {
+        this.logger.debug(
+          `Stored ${signatureCount} thoughtSignature(s) from function call part(s) for later reconstruction`,
+        );
+      }
+    }
+
     if (thoughtContent) {
       this.logger.debug(
         `Google GenAI thought summary preview: ${thoughtContent.substring(0, K_SLICE)}...`,
@@ -1089,14 +1112,15 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
           );
         }
 
-        // Return the entire Part (preserves thoughtSignature and other metadata)
-        // instead of just the FunctionCall
-        const partWithId: Part = {
-          ...funcPart,
-          functionCall: { ...call, id: callId },
+        // Serialize flat structure for schema compatibility
+        // thoughtSignature is stored separately in processThinkingBlock
+        const flatCall = {
+          id: callId,
+          name: call.name ?? '',
+          args: call.args ?? {},
         };
 
-        return JSON.stringify(partWithId, null, 2);
+        return JSON.stringify(flatCall, null, 2);
       }
     }
     return null;
@@ -1137,27 +1161,31 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
     _client: GoogleGenAI | undefined,
     _id: string,
     name: string,
-    call: Part,
+    call: FunctionCall,
     result: Record<string, unknown>,
-    _workspaceState?: AgentWorkspaceState,
+    workspaceState?: AgentWorkspaceState,
     text?: string,
   ): Promise<Content[]> {
-    // call is now always a Part (preserves thoughtSignature)
-    const callPart = call;
-    const functionName = call.functionCall?.name ?? name;
-    const callId = ensureCallId(call.functionCall ?? ({} as FunctionCall));
+    // call is now a flat FunctionCall (from schema parsing)
+    const functionName = call.name ?? name;
+    const callId = ensureCallId(call);
 
-    // Update the ID if needed
-    const finalCallPart: Part =
-      callPart.functionCall && callPart.functionCall.id !== callId
-        ? {
-            ...callPart,
-            functionCall: { ...callPart.functionCall, id: callId },
-          }
-        : callPart;
+    // Reconstruct Part with thoughtSignature if available (for Gemini 3 Pro)
+    // Look up signature by call ID (supports parallel function calling)
+    const thoughtSig =
+      workspaceState?.reasoning.toolCallThoughtSignatures.get(callId);
+    const finalCallPart: Part = {
+      functionCall: { ...call, id: callId },
+      ...(thoughtSig && { thoughtSignature: thoughtSig }),
+    };
+
+    // Remove the used signature from the map
+    if (workspaceState?.reasoning && thoughtSig) {
+      workspaceState.reasoning.toolCallThoughtSignatures.delete(callId);
+    }
 
     this.logger.debug(
-      `Using Part for function '${functionName}'${finalCallPart.thoughtSignature ? ' (preserving thought signature)' : ''}`,
+      `Reconstructed Part for function '${functionName}'${thoughtSig ? ' (with thought signature)' : ''}`,
     );
 
     // Use the same ID for the result to maintain correlation

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -1082,14 +1082,21 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
         const call = funcPart.functionCall;
         // Ensure the call has an ID
         const callId = ensureCallId(call);
-        const callWithId = { ...call, id: callId };
 
         if (!call.id?.trim()) {
           this.logger.debug(
             `Generated ID for Google function call '${call.name ?? 'unknown'}': ${callId}`,
           );
         }
-        return JSON.stringify(callWithId, null, 2);
+
+        // Return the entire Part (preserves thoughtSignature and other metadata)
+        // instead of just the FunctionCall
+        const partWithId: Part = {
+          ...funcPart,
+          functionCall: { ...call, id: callId },
+        };
+
+        return JSON.stringify(partWithId, null, 2);
       }
     }
     return null;
@@ -1130,27 +1137,52 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
     _client: GoogleGenAI | undefined,
     _id: string,
     name: string,
-    call: FunctionCall,
+    call: FunctionCall | Part,
     result: Record<string, unknown>,
     _workspaceState?: AgentWorkspaceState,
     text?: string,
   ): Promise<Content[]> {
-    // Handle both args and input fields for backward compatibility
-    const args =
-      call?.args && typeof call.args === 'object'
-        ? (call.args as Record<string, unknown>)
-        : ((call as any)?.input ?? {});
+    let callPart: Part;
+    let functionName: string;
+    let callId: string;
 
-    // Use call.name if available, fall back to provided name
-    const functionName = call?.name ?? name;
+    // Check if call is a Part (from extractToolUse) or legacy FunctionCall
+    if ('functionCall' in call && call.functionCall) {
+      // This is a Part - use it directly to preserve thoughtSignature!
+      callPart = call as Part;
+      functionName = call.functionCall.name ?? name;
+      callId = ensureCallId(call.functionCall);
 
-    // Create the call part with the function name and arguments
-    const callPart = createPartFromFunctionCall(functionName, args);
+      // Update the ID if needed
+      if (callPart.functionCall && callPart.functionCall.id !== callId) {
+        callPart = {
+          ...callPart,
+          functionCall: { ...callPart.functionCall, id: callId },
+        };
+      }
 
-    // Ensure the function call has an ID for correlation with result
-    const callId = ensureCallId(call);
-    if (callPart.functionCall) {
-      callPart.functionCall.id = callId;
+      this.logger.debug(
+        `Using original Part for function '${functionName}'${callPart.thoughtSignature ? ' (preserving thought signature)' : ''}`,
+      );
+    } else {
+      // Legacy path: call is just a FunctionCall - reconstruct Part
+      const functionCall = call as FunctionCall;
+      const args =
+        functionCall?.args && typeof functionCall.args === 'object'
+          ? (functionCall.args as Record<string, unknown>)
+          : ((functionCall as any)?.input ?? {});
+
+      functionName = functionCall?.name ?? name;
+      callId = ensureCallId(functionCall);
+
+      callPart = createPartFromFunctionCall(functionName, args);
+      if (callPart.functionCall) {
+        callPart.functionCall.id = callId;
+      }
+
+      this.logger.debug(
+        `Reconstructed Part for function '${functionName}' (legacy path)`,
+      );
     }
 
     // Use the same ID for the result to maintain correlation

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -182,6 +182,10 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
 
   private googleClient: GoogleGenAI | null = null;
 
+  // Temporary storage for thought signatures extracted with function calls
+  // Cleared after being transferred to workspace state in createToolUseFollowUpMessages
+  private pendingThoughtSignatures = new Map<string, string>();
+
   private supportsFileUploads(): boolean {
     return (
       this.config.capabilities.supportsVision ||
@@ -1064,29 +1068,6 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
       workspaceState.reasoning.thinkingAdded = true;
     }
 
-    // Also check for ALL function call parts with thoughtSignature (for Gemini 3 Pro)
-    // Supports parallel function calling where multiple calls may each have signatures
-    if (workspaceState) {
-      const funcParts = parts.filter((part) => part.functionCall);
-      let signatureCount = 0;
-      for (const funcPart of funcParts) {
-        if (funcPart.thoughtSignature && funcPart.functionCall) {
-          // Store thoughtSignature keyed by call ID for later reconstruction
-          const callId = ensureCallId(funcPart.functionCall);
-          workspaceState.reasoning.toolCallThoughtSignatures.set(
-            callId,
-            funcPart.thoughtSignature,
-          );
-          signatureCount++;
-        }
-      }
-      if (signatureCount > 0) {
-        this.logger.debug(
-          `Stored ${signatureCount} thoughtSignature(s) from function call part(s) for later reconstruction`,
-        );
-      }
-    }
-
     if (thoughtContent) {
       this.logger.debug(
         `Google GenAI thought summary preview: ${thoughtContent.substring(0, K_SLICE)}...`,
@@ -1112,8 +1093,23 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
           );
         }
 
+        // Store thoughtSignature for later reconstruction (Gemini 3 Pro requirement)
+        // Supports parallel function calling by storing all signatures from all Parts
+        this.pendingThoughtSignatures.clear();
+        const funcParts = parts.filter((part) => part.functionCall);
+        for (const part of funcParts) {
+          if (part.thoughtSignature && part.functionCall) {
+            const id = ensureCallId(part.functionCall);
+            this.pendingThoughtSignatures.set(id, part.thoughtSignature);
+          }
+        }
+        if (this.pendingThoughtSignatures.size > 0) {
+          this.logger.debug(
+            `Stored ${this.pendingThoughtSignatures.size} thoughtSignature(s) for function call reconstruction`,
+          );
+        }
+
         // Serialize flat structure for schema compatibility
-        // thoughtSignature is stored separately in processThinkingBlock
         const flatCall = {
           id: callId,
           name: call.name ?? '',
@@ -1170,8 +1166,15 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
     const functionName = call.name ?? name;
     const callId = ensureCallId(call);
 
+    // Transfer pending thought signatures to workspace state for persistence
+    if (workspaceState && this.pendingThoughtSignatures.size > 0) {
+      for (const [id, sig] of this.pendingThoughtSignatures) {
+        workspaceState.reasoning.toolCallThoughtSignatures.set(id, sig);
+      }
+      this.pendingThoughtSignatures.clear();
+    }
+
     // Reconstruct Part with thoughtSignature if available (for Gemini 3 Pro)
-    // Look up signature by call ID (supports parallel function calling)
     const thoughtSig =
       workspaceState?.reasoning.toolCallThoughtSignatures.get(callId);
     const finalCallPart: Part = {
@@ -1179,7 +1182,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
       ...(thoughtSig && { thoughtSignature: thoughtSig }),
     };
 
-    // Remove the used signature from the map
+    // Remove the used signature from workspace state
     if (workspaceState?.reasoning && thoughtSig) {
       workspaceState.reasoning.toolCallThoughtSignatures.delete(callId);
     }

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -175,7 +175,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
   Content,
   GenerateContentResponseUsageMetadata | null,
   OpenAIAPIResponseUsage,
-  FunctionCall,
+  Part,
   GoogleGenAI
 > {
   private static readonly INLINE_MEDIA_LIMIT_BYTES = 20 * 1024 * 1024;
@@ -1137,53 +1137,28 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
     _client: GoogleGenAI | undefined,
     _id: string,
     name: string,
-    call: FunctionCall | Part,
+    call: Part,
     result: Record<string, unknown>,
     _workspaceState?: AgentWorkspaceState,
     text?: string,
   ): Promise<Content[]> {
-    let callPart: Part;
-    let functionName: string;
-    let callId: string;
+    // call is now always a Part (preserves thoughtSignature)
+    const callPart = call;
+    const functionName = call.functionCall?.name ?? name;
+    const callId = ensureCallId(call.functionCall ?? ({} as FunctionCall));
 
-    // Check if call is a Part (from extractToolUse) or legacy FunctionCall
-    if ('functionCall' in call && call.functionCall) {
-      // This is a Part - use it directly to preserve thoughtSignature!
-      callPart = call as Part;
-      functionName = call.functionCall.name ?? name;
-      callId = ensureCallId(call.functionCall);
+    // Update the ID if needed
+    const finalCallPart: Part =
+      callPart.functionCall && callPart.functionCall.id !== callId
+        ? {
+            ...callPart,
+            functionCall: { ...callPart.functionCall, id: callId },
+          }
+        : callPart;
 
-      // Update the ID if needed
-      if (callPart.functionCall && callPart.functionCall.id !== callId) {
-        callPart = {
-          ...callPart,
-          functionCall: { ...callPart.functionCall, id: callId },
-        };
-      }
-
-      this.logger.debug(
-        `Using original Part for function '${functionName}'${callPart.thoughtSignature ? ' (preserving thought signature)' : ''}`,
-      );
-    } else {
-      // Legacy path: call is just a FunctionCall - reconstruct Part
-      const functionCall = call as FunctionCall;
-      const args =
-        functionCall?.args && typeof functionCall.args === 'object'
-          ? (functionCall.args as Record<string, unknown>)
-          : ((functionCall as any)?.input ?? {});
-
-      functionName = functionCall?.name ?? name;
-      callId = ensureCallId(functionCall);
-
-      callPart = createPartFromFunctionCall(functionName, args);
-      if (callPart.functionCall) {
-        callPart.functionCall.id = callId;
-      }
-
-      this.logger.debug(
-        `Reconstructed Part for function '${functionName}' (legacy path)`,
-      );
-    }
+    this.logger.debug(
+      `Using Part for function '${functionName}'${finalCallPart.thoughtSignature ? ' (preserving thought signature)' : ''}`,
+    );
 
     // Use the same ID for the result to maintain correlation
     const { attachments, sanitizedResult } = extractToolAttachments(result);
@@ -1217,7 +1192,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
     if (text) {
       callParts.push(createPartFromText(text));
     }
-    callParts.push(callPart);
+    callParts.push(finalCallPart);
     const callMsg: Content = {
       role: 'model',
       parts: callParts,

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -123,7 +123,7 @@ export class ModelHandlerOpenAI extends ModelHandler<
   ChatCompletionMessageParam,
   ExtendedCompletionUsage | null,
   OpenAIAPIResponseUsage,
-  ChatCompletionMessageToolCall | ChatCompletionMessage.FunctionCall,
+  ChatCompletionMessageToolCall,
   OpenAI
 > {
   /**
@@ -691,9 +691,7 @@ export class ModelHandlerOpenAI extends ModelHandler<
     } else if (
       stopReason === OPENAI_CHAT_FINISH.TOOL_CALLS ||
       stopReason === OPENAI_CHAT_FINISH.TOOL_USE ||
-      stopReason === OPENAI_CHAT_FINISH.FUNCTION_CALL ||
-      Array.isArray(choice.message.tool_calls) ||
-      choice.message.function_call
+      Array.isArray(choice.message.tool_calls)
     ) {
       // Other provider SDKs (Anthropic, Google, etc.) keep a placeholder
       // message when a tool is invoked. OpenAI omits `content` entirely,
@@ -1172,9 +1170,9 @@ export class ModelHandlerOpenAI extends ModelHandler<
   private preserveToolCall(
     id: string,
     fallbackName: string,
-    call: ChatCompletionMessageToolCall | ChatCompletionMessage.FunctionCall,
+    call: ChatCompletionMessageToolCall,
   ): ChatCompletionMessageToolCall {
-    // If it's already a proper ChatCompletionMessageToolCall, preserve it
+    // Preserve the original ChatCompletionMessageToolCall
     if (this.isFunctionToolCall(call)) {
       return {
         ...call,
@@ -1187,25 +1185,14 @@ export class ModelHandlerOpenAI extends ModelHandler<
       };
     }
 
-    if (this.isCustomToolCall(call)) {
-      return {
-        ...call,
-        id: call.id ?? id,
-        custom: {
-          ...call.custom,
-          name: call.custom?.name ?? fallbackName,
-          input: this.ensureStringifiedArguments(call.custom?.input),
-        },
-      };
-    }
-
-    // Legacy FunctionCall format - must reconstruct
+    // Custom tool call
     return {
-      id,
-      type: 'function',
-      function: {
-        name: call.name ?? fallbackName,
-        arguments: this.ensureStringifiedArguments(call.arguments),
+      ...call,
+      id: call.id ?? id,
+      custom: {
+        ...call.custom,
+        name: call.custom?.name ?? fallbackName,
+        input: this.ensureStringifiedArguments(call.custom?.input),
       },
     };
   }
@@ -1215,10 +1202,6 @@ export class ModelHandlerOpenAI extends ModelHandler<
     if (Array.isArray(toolCalls) && toolCalls.length > 0) {
       return JSON.stringify(toolCalls[0], null, 2);
     }
-    const func = responseObject?.choices?.[0]?.message?.function_call;
-    if (func) {
-      return JSON.stringify(func, null, 2);
-    }
     return null;
   }
 
@@ -1226,7 +1209,7 @@ export class ModelHandlerOpenAI extends ModelHandler<
     _client: OpenAI | undefined,
     id: string,
     name: string,
-    call: ChatCompletionMessageToolCall | ChatCompletionMessage.FunctionCall,
+    call: ChatCompletionMessageToolCall,
     result: Record<string, unknown>,
     _workspaceState?: AgentWorkspaceState,
     text?: string,

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -1165,6 +1165,51 @@ export class ModelHandlerOpenAI extends ModelHandler<
     };
   }
 
+  /**
+   * Preserves the original tool call object while ensuring required fields.
+   * This prevents loss of metadata that might be present in the original object.
+   */
+  private preserveToolCall(
+    id: string,
+    fallbackName: string,
+    call: ChatCompletionMessageToolCall | ChatCompletionMessage.FunctionCall,
+  ): ChatCompletionMessageToolCall {
+    // If it's already a proper ChatCompletionMessageToolCall, preserve it
+    if (this.isFunctionToolCall(call)) {
+      return {
+        ...call,
+        id: call.id ?? id,
+        function: {
+          ...call.function,
+          name: call.function?.name ?? fallbackName,
+          arguments: this.ensureStringifiedArguments(call.function?.arguments),
+        },
+      };
+    }
+
+    if (this.isCustomToolCall(call)) {
+      return {
+        ...call,
+        id: call.id ?? id,
+        custom: {
+          ...call.custom,
+          name: call.custom?.name ?? fallbackName,
+          input: this.ensureStringifiedArguments(call.custom?.input),
+        },
+      };
+    }
+
+    // Legacy FunctionCall format - must reconstruct
+    return {
+      id,
+      type: 'function',
+      function: {
+        name: call.name ?? fallbackName,
+        arguments: this.ensureStringifiedArguments(call.arguments),
+      },
+    };
+  }
+
   extractToolUse(responseObject: any): string | null {
     const toolCalls = responseObject?.choices?.[0]?.message?.tool_calls;
     if (Array.isArray(toolCalls) && toolCalls.length > 0) {
@@ -1186,7 +1231,8 @@ export class ModelHandlerOpenAI extends ModelHandler<
     _workspaceState?: AgentWorkspaceState,
     text?: string,
   ): Promise<ChatCompletionMessageParam[]> {
-    const toolCall = this.normalizeToolCall(id, name, call);
+    // Preserve the original call object with minimal normalization
+    const toolCall = this.preserveToolCall(id, name, call);
     const callMsg: ChatCompletionAssistantMessageParam = {
       role: 'assistant',
       tool_calls: [toolCall],
@@ -1194,6 +1240,17 @@ export class ModelHandlerOpenAI extends ModelHandler<
     if (text) {
       callMsg.content = [{ type: 'text', text }];
     }
+
+    const toolName =
+      this.isFunctionToolCall(toolCall)
+        ? toolCall.function?.name
+        : this.isCustomToolCall(toolCall)
+          ? toolCall.custom?.name
+          : name;
+
+    this.logger.debug(
+      `Using original ChatCompletionMessageToolCall for function '${toolName}'`,
+    );
     const { attachments, sanitizedResult } = extractToolAttachments(result);
     if (attachments.length > 0) {
       (sanitizedResult as Record<string, unknown>).attachmentSummary =

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -1299,21 +1299,17 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       messages.push(this.createAssistantMessage(text));
     }
 
+    // Use the original call object (preserves all metadata)
+    // Only ensure call_id is set correctly
     const callMsg: ResponseFunctionToolCall = {
+      ...call,
       type: 'function_call',
-      call_id: id,
-      name,
-      arguments:
-        typeof call?.arguments === 'string'
-          ? call.arguments
-          : JSON.stringify(
-              (call as unknown as { input?: unknown; arguments?: unknown })
-                ?.input ??
-                (call as unknown as { input?: unknown; arguments?: unknown })
-                  ?.arguments ??
-                {},
-            ),
+      call_id: call.call_id ?? id,
     };
+
+    this.logger.debug(
+      `Using original ResponseFunctionToolCallItem for function '${call.name ?? name}'`,
+    );
 
     const { attachments, sanitizedResult } = extractToolAttachments(result);
     const supportsAttachments = this.supportsToolFileOutputs;

--- a/src/agent/modelHandlers/types/StopReasonTypes.ts
+++ b/src/agent/modelHandlers/types/StopReasonTypes.ts
@@ -11,7 +11,6 @@ export const OPENAI_CHAT_FINISH = {
   TOOL_CALLS: 'tool_calls',
   TOOL_USE: 'tool_use',
   CONTENT_FILTER: 'content_filter',
-  FUNCTION_CALL: 'function_call',
 } as const;
 export const OPENAI_CHAT_FINISH_REASONS = Object.values(OPENAI_CHAT_FINISH);
 export type OpenAIChatFinishReason =

--- a/src/test/agent/modelHandlers/ModelHandlerGoogleGenAI.test.ts
+++ b/src/test/agent/modelHandlers/ModelHandlerGoogleGenAI.test.ts
@@ -355,13 +355,19 @@ describe('ModelHandlerGoogleGenAI tool attachments', () => {
     const functionCall: FunctionCall = {
       name: 'extract_figures',
       args: { source: 'doc.tex' },
+      id: 'call-123',
+    };
+
+    // Wrap FunctionCall in a Part (as extractToolUse now does)
+    const partWithFunctionCall: Part = {
+      functionCall,
     };
 
     const messages = await handler.createToolUseFollowUpMessages(
       undefined,
       'call-123',
       'extract_figures',
-      functionCall,
+      partWithFunctionCall,
       toolResult,
     );
 

--- a/src/test/agent/modelHandlers/ModelHandlerGoogleGenAI.test.ts
+++ b/src/test/agent/modelHandlers/ModelHandlerGoogleGenAI.test.ts
@@ -358,16 +358,12 @@ describe('ModelHandlerGoogleGenAI tool attachments', () => {
       id: 'call-123',
     };
 
-    // Wrap FunctionCall in a Part (as extractToolUse now does)
-    const partWithFunctionCall: Part = {
-      functionCall,
-    };
-
+    // Pass FunctionCall directly (Part reconstruction happens internally)
     const messages = await handler.createToolUseFollowUpMessages(
       undefined,
       'call-123',
       'extract_figures',
-      partWithFunctionCall,
+      functionCall,
       toolResult,
     );
 

--- a/src/test/modelHandlers/ModelHandlerGoogle.test.ts
+++ b/src/test/modelHandlers/ModelHandlerGoogle.test.ts
@@ -123,13 +123,17 @@ describe('ModelHandlerGoogleGenAI.createToolUseFollowUpMessages', () => {
   });
 
   it('omits unsupported identifier fields on follow-up function call parts', async () => {
+    // Wrap in a Part as extractToolUse now returns the entire Part
     const messages = await handler.createToolUseFollowUpMessages(
       undefined,
       'call-123',
       'read_file',
       {
-        name: 'read_file',
-        args: { path: 'syk_v5.tex' },
+        functionCall: {
+          name: 'read_file',
+          args: { path: 'syk_v5.tex' },
+          id: 'call-123',
+        },
       } as any,
       {},
       undefined,

--- a/src/test/modelHandlers/ModelHandlerGoogle.test.ts
+++ b/src/test/modelHandlers/ModelHandlerGoogle.test.ts
@@ -123,17 +123,15 @@ describe('ModelHandlerGoogleGenAI.createToolUseFollowUpMessages', () => {
   });
 
   it('omits unsupported identifier fields on follow-up function call parts', async () => {
-    // Wrap in a Part as extractToolUse now returns the entire Part
+    // Pass FunctionCall directly (Part reconstruction happens internally)
     const messages = await handler.createToolUseFollowUpMessages(
       undefined,
       'call-123',
       'read_file',
       {
-        functionCall: {
-          name: 'read_file',
-          args: { path: 'syk_v5.tex' },
-          id: 'call-123',
-        },
+        name: 'read_file',
+        args: { path: 'syk_v5.tex' },
+        id: 'call-123',
       } as any,
       {},
       undefined,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Capture and persist Google thought signatures across tool calls, reconstructing call Parts with signatures, and preserve original OpenAI tool-call objects while updating schemas and tests accordingly.
> 
> - **Reasoning/State**:
>   - Add `reasoning.toolCallThoughtSignatures` to `AgentWorkspaceState` (schema, serialize/deserialize, reset).
> - **Google GenAI Handler**:
>   - Store per-call `thoughtSignature`s during `extractToolUse`; serialize flat `FunctionCall`.
>   - On follow-up, transfer signatures to workspace state and reconstruct call `Part` with matching `thoughtSignature`; clear after use.
>   - Keep attachment handling; minor logging improvements.
> - **OpenAI Chat Handler**:
>   - Drop legacy `function_call` path; only handle `tool_calls`.
>   - Preserve original `ChatCompletionMessageToolCall` in follow-ups (ensure required fields), improving metadata retention.
> - **OpenAI Responses Handler**:
>   - Preserve original `ResponseFunctionToolCallItem` in follow-ups; ensure `call_id`.
> - **Stop Reasons**:
>   - Remove `FUNCTION_CALL` from `OPENAI_CHAT_FINISH`.
> - **Tests**:
>   - Update Google/OpenAI tests for flat call format, ID handling, omission of unsupported fields, and attachment encoding.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f8f6531fd91fa29f10fe8c8b1694d225e0b0e291. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->