### PR TITLE
Simplify agent history retrieval

### DIFF
--- a/src/historyView/managers/AgentHistoryManager.ts
+++ b/src/historyView/managers/AgentHistoryManager.ts
@@ -12,9 +12,6 @@ import type { ExecutionId } from '@agent/types/IdentifierTypes';
 
 // Local imports - workspace state
 import { workspaceSM } from '@common/state/stateManager';
-import * as logger from '@logger/logUtils';
-
-const CHANNEL = 'AgentHistoryManager';
 
 /**
  * Represents a historical agent execution
@@ -32,6 +29,14 @@ export interface AgentHistoryItem {
 export class AgentHistoryManager {
   private static readonly HISTORY_STORAGE_KEY = 'texra.agentHistory';
   private static readonly MAX_HISTORY_ITEMS = 100;
+
+  private static isValidHistoryItem(
+    entry: AgentHistoryItem | undefined,
+  ): entry is AgentHistoryItem {
+    return Boolean(
+      entry?.id && entry.timestamp && entry.config?.session && entry.session,
+    );
+  }
 
   /**
    * Add a new agent execution to history
@@ -74,14 +79,8 @@ export class AgentHistoryManager {
    */
   public static async getHistory(): Promise<AgentHistoryItem[]> {
     const storageKey = this.getWorkspaceStorageKey();
-    const history = workspaceSM.get<unknown[]>(storageKey, []);
-    const { normalized, mutated } = this.sanitizeHistoryEntries(history);
-
-    if (mutated) {
-      await this.saveHistory(normalized);
-    }
-
-    return normalized;
+    const history = workspaceSM.get<AgentHistoryItem[]>(storageKey, []);
+    return history.filter((item) => this.isValidHistoryItem(item));
   }
 
   /**
@@ -90,65 +89,6 @@ export class AgentHistoryManager {
   private static async saveHistory(history: AgentHistoryItem[]): Promise<void> {
     const storageKey = this.getWorkspaceStorageKey();
     await workspaceSM.update(storageKey, history);
-  }
-
-  private static sanitizeHistoryEntries(entries: unknown[]): {
-    normalized: AgentHistoryItem[];
-    mutated: boolean;
-  } {
-    let mutated = false;
-    const normalized: AgentHistoryItem[] = [];
-
-    for (const rawEntry of entries) {
-      if (!rawEntry || typeof rawEntry !== 'object') {
-        mutated = true;
-        continue;
-      }
-
-      const candidate = rawEntry as Partial<AgentHistoryItem> & {
-        config?: AgentConfig;
-      };
-
-      if (!candidate.id || !candidate.timestamp || !candidate.config) {
-        mutated = true;
-        continue;
-      }
-
-      let normalizedConfig: AgentConfig;
-      try {
-        normalizedConfig = parseAgentConfig(candidate.config);
-      } catch (error) {
-        mutated = true;
-        logger.warn(
-          CHANNEL,
-          'Discarding malformed agent history entry',
-          undefined,
-          undefined,
-          false,
-          error,
-        );
-        continue;
-      }
-
-      const session = normalizedConfig.session;
-      if (!session) {
-        mutated = true;
-        continue;
-      }
-
-      normalized.push({
-        id: candidate.id,
-        timestamp: candidate.timestamp,
-        config: normalizedConfig,
-        session,
-      });
-    }
-
-    if (normalized.length !== entries.length) {
-      mutated = true;
-    }
-
-    return { normalized, mutated };
   }
 
   /**


### PR DESCRIPTION
## Summary
- add a lightweight validity guard for stored agent history items
- avoid re-parsing and re-saving history entries when reading from workspace state

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e169ae8388324bb13d59ab43afc90)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Simplifies history retrieval by filtering typed entries with a light validity guard, removing sanitize-and-rewrite logic and related logging.
> 
> - **Agent history retrieval** (`src/historyView/managers/AgentHistoryManager.ts`):
>   - Add `isValidHistoryItem` type guard and use it to filter results in `getHistory`.
>   - Replace generic `workspaceSM.get<unknown[]>` + `sanitizeHistoryEntries` with typed `workspaceSM.get<AgentHistoryItem[]>` and no re-save.
>   - Remove `sanitizeHistoryEntries` implementation and associated logging/constants.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c2a75f0b8eedcec726c1cd4c22d9020488e7f12b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->