### PR TITLE
Use message item ids for API key prompt

### DIFF
--- a/src/commands/api/apiKeyCommands.ts
+++ b/src/commands/api/apiKeyCommands.ts
@@ -28,19 +28,20 @@ async function setApiKeyForProvider(
   skipDialog = false,
 ): Promise<void> {
   if (!skipDialog) {
-    const enterKey = 'Enter Key';
-    const getApiKey = 'Get API Key';
+    const actions: Array<vscode.MessageItem & { id: 'enter' | 'getApiKey' }> = [
+      { title: 'Enter Key', id: 'enter' },
+      { title: 'Get API Key', id: 'getApiKey' },
+    ];
     const action = await vscode.window.showInformationMessage(
       `Set your ${provider} API key`,
-      enterKey,
-      getApiKey,
+      ...actions,
     );
 
     if (!action) {
       return;
     }
 
-    if (action === getApiKey) {
+    if (action.id === 'getApiKey') {
       await vscode.env.openExternal(vscode.Uri.parse(PROVIDER_URLS[provider]));
       return;
     }


### PR DESCRIPTION
## Summary
- define message items with explicit identifiers in the API key prompt
- switch logic to compare selected action ids to avoid label coupling

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e2306958c83249f83eaf8685bd69d)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors the API key prompt to use typed message items with explicit ids and checks `action.id` instead of comparing labels.
> 
> - **API Key Prompt** (`src/commands/api/apiKeyCommands.ts`):
>   - Use typed `vscode.MessageItem` actions with explicit ids (`enter`, `getApiKey`) and spread into `showInformationMessage`.
>   - Update logic to branch on `action.id === 'getApiKey'` instead of label comparison.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c31411b72606894eac1882917914fa2e2f4608c9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->