### PR TITLE
Streamline tool-use normalization paths

### DIFF
--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -26,7 +26,6 @@ import { maybeSaveDebugObject } from '@agent/utils/debugMessageSaver';
 import type { DebugObjectType } from '@agent/utils/debugMessageSaver';
 // Internal imports
 import { sanitizeToolResultForLog } from '@agent/modelHandlers/utils/toolAttachmentUtils';
-import { toErrorMessage } from '@common/errors/errorHandlingUtils';
 import { MESSAGE_TYPES } from '@logger/messageTypes';
 // Type imports
 import type { ToolDefinition } from '@model';
@@ -58,116 +57,66 @@ interface NormalizedToolCall {
   raw: RawToolCallPayload;
 }
 
-const RawToolCallPayloadSchema = z
-  .object({
-    call_id: z.string().optional(),
-    tool_call_id: z.string().optional(),
-    tool_use_id: z.string().optional(),
-    id: z.string().optional(),
-    name: z.string().optional(),
-    function: z
-      .object({
-        name: z.string().optional(),
-        arguments: z
-          .union([z.string(), z.record(z.string(), z.unknown())])
-          .optional(),
-      })
-      .optional(),
-    input: z.unknown().optional(),
-    args: z.union([z.string(), z.record(z.string(), z.unknown())]).optional(),
-    arguments: z
-      .union([z.string(), z.record(z.string(), z.unknown())])
-      .optional(),
-  })
-  .superRefine((value, ctx) => {
-    const trimmed = (val?: string | null) =>
-      typeof val === 'string' ? val.trim() : '';
-
-    if (
-      !trimmed(value.call_id) &&
-      !trimmed(value.tool_call_id) &&
-      !trimmed(value.tool_use_id) &&
-      !trimmed(value.id)
-    ) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ['call_id'],
-        message: 'Tool call is missing an identifier.',
-      });
-    }
-
-    if (!trimmed(value.name) && !trimmed(value.function?.name ?? '')) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ['name'],
-        message: 'Tool call is missing a name.',
-      });
-    }
-  });
+const RawToolCallPayloadSchema = z.object({
+  call_id: z.string().optional(),
+  tool_call_id: z.string().optional(),
+  tool_use_id: z.string().optional(),
+  id: z.string().optional(),
+  name: z.string().optional(),
+  function: z
+    .object({
+      name: z.string().optional(),
+      arguments: z
+        .union([z.string(), z.record(z.string(), z.unknown())])
+        .optional(),
+    })
+    .optional(),
+  input: z.unknown().optional(),
+  args: z.union([z.string(), z.record(z.string(), z.unknown())]).optional(),
+  arguments: z
+    .union([z.string(), z.record(z.string(), z.unknown())])
+    .optional(),
+});
 
 type RawToolCallPayload = z.infer<typeof RawToolCallPayloadSchema>;
 
-const ToolCallPayloadSchema =
-  RawToolCallPayloadSchema.transform<NormalizedToolCall>((payload) => {
-    const trim = (value?: string | null) =>
-      typeof value === 'string' ? value.trim() : '';
+function buildNormalizedToolCall(
+  payload: RawToolCallPayload,
+): NormalizedToolCall {
+  const callId =
+    payload.call_id ||
+    payload.tool_call_id ||
+    payload.tool_use_id ||
+    payload.id;
 
-    const callId = [
-      payload.call_id,
-      payload.tool_call_id,
-      payload.tool_use_id,
-      payload.id,
-    ]
-      .map((candidate) => trim(candidate))
-      .find((candidate) => candidate.length > 0);
+  if (!callId) {
+    throw new Error('Tool call is missing an identifier.');
+  }
 
-    if (!callId) {
-      throw new Error('Tool call is missing an identifier.');
-    }
+  const name = payload.name || payload.function?.name;
 
-    const name = [payload.name, payload.function?.name]
-      .map((candidate) => trim(candidate))
-      .find((candidate) => candidate.length > 0);
+  if (!name) {
+    throw new Error('Tool call is missing a name.');
+  }
 
-    if (!name) {
-      throw new Error('Tool call is missing a name.');
-    }
+  const argumentSources: Array<unknown> = [
+    payload.input,
+    payload.args,
+    payload.arguments,
+    payload.function?.arguments,
+  ];
 
-    const argumentSources: Array<unknown> = [
-      payload.input,
-      payload.args,
-      payload.arguments,
-      payload.function?.arguments,
-    ];
+  const input = argumentSources.find(
+    (candidate) => candidate !== undefined && candidate !== null,
+  );
 
-    let input: unknown = {};
-    for (const candidate of argumentSources) {
-      if (candidate === undefined || candidate === null) {
-        continue;
-      }
-      if (typeof candidate === 'string') {
-        const trimmed = candidate.trim();
-        if (!trimmed) {
-          continue;
-        }
-        try {
-          input = JSON.parse(trimmed);
-        } catch {
-          input = trimmed;
-        }
-        break;
-      }
-      input = candidate;
-      break;
-    }
-
-    return {
-      callId,
-      name,
-      input,
-      raw: payload,
-    };
-  });
+  return {
+    callId,
+    name,
+    input,
+    raw: payload,
+  };
+}
 
 function normalizeToolCallError(
   toolName: string,
@@ -200,6 +149,26 @@ function normalizeToolCallError(
   return { message: fallbackMessage };
 }
 
+function normalizeToolCallPayload(
+  rawPayload: string | RawToolCallPayload | NormalizedToolCall,
+): { normalized: NormalizedToolCall; raw: RawToolCallPayload } {
+  if (typeof rawPayload === 'object') {
+    if ('callId' in rawPayload && 'name' in rawPayload) {
+      const normalized = rawPayload as NormalizedToolCall;
+      return { normalized, raw: normalized.raw };
+    }
+
+    const parsed = RawToolCallPayloadSchema.parse(rawPayload);
+    const normalized = buildNormalizedToolCall(parsed);
+    return { normalized, raw: parsed };
+  }
+
+  const parsedJson = JSON.parse(rawPayload);
+  const parsed = RawToolCallPayloadSchema.parse(parsedJson);
+  const normalized = buildNormalizedToolCall(parsed);
+  return { normalized, raw: parsed };
+}
+
 type ToolDispatchErrorResult = {
   handledError: true;
   toolCallId?: string;
@@ -213,10 +182,24 @@ export interface ToolUseCycleState extends BaseCycleState {
   response?: unknown;
   toolInfo?: string;
   text?: string;
+  toolCall?: NormalizedToolCall;
+  toolCallPayload?: RawToolCallPayload | unknown;
+  toolNormalizationError?: {
+    message: string;
+    diagnostics?: ToolValidationDiagnostics;
+    raw?: unknown;
+  };
 }
 
 function resetToolUseState(state: ToolUseCycleState): void {
-  resetCycleState(state, ['response', 'toolInfo', 'text']);
+  resetCycleState(state, [
+    'response',
+    'toolInfo',
+    'text',
+    'toolCall',
+    'toolCallPayload',
+    'toolNormalizationError',
+  ]);
 }
 
 export interface ToolUseCycleContext<C = unknown> {
@@ -463,6 +446,22 @@ class ToolUseProcessNode<C> extends BaseNode<ToolUseCycleContext<C>> {
       };
     }
 
+    try {
+      const normalizedToolCall = normalizeToolCallPayload(toolInfo);
+      state.toolCall = normalizedToolCall.normalized;
+      state.toolCallPayload = normalizedToolCall.raw;
+      state.toolNormalizationError = undefined;
+    } catch (error) {
+      const { message, diagnostics } = normalizeToolCallError('unknown', error);
+      state.toolCall = undefined;
+      state.toolCallPayload = toolInfo;
+      state.toolNormalizationError = {
+        message,
+        diagnostics,
+        raw: toolInfo,
+      };
+    }
+
     state.toolInfo = toolInfo;
     state.text = text ?? undefined;
     state.stopReason = stopReason;
@@ -536,44 +535,16 @@ class ToolUseDispatchNode<C> extends BaseNode<ToolUseCycleContext<C>> {
       return { skipped: true };
     }
 
-    let parsedJson: unknown;
-    try {
-      parsedJson = JSON.parse(state.toolInfo);
-    } catch (error) {
-      const errorMsg = `Malformed tool JSON: ${toErrorMessage(error)}`;
-      const errorResult = toolResult({ error: errorMsg, isError: true });
-      const toolUseLog = {
-        tool: 'unknown',
-        input: state.toolInfo,
-        output: sanitizeToolResultForLog(errorResult),
-      };
-      options.logger.info('', groupId, MESSAGE_TYPES.TOOL_USE, toolUseLog);
-      return {
-        skipped: false,
-        value: {
-          handledError: true,
-          toolName: 'unknown',
-          result: errorResult,
-          fallbackMessage:
-            'I could not understand the tool request. Please resend valid JSON with call_id, name, and arguments.',
-        },
-      };
-    }
-
-    const parsed = ToolCallPayloadSchema.safeParse(parsedJson);
-    if (!parsed.success) {
-      const { message, diagnostics } = normalizeToolCallError(
-        'unknown',
-        parsed.error,
-      );
+    const normalizationError = state.toolNormalizationError;
+    if (normalizationError) {
       const errorResult = toolResult({
-        error: message,
+        error: normalizationError.message,
         isError: true,
-        diagnostics,
+        diagnostics: normalizationError.diagnostics,
       });
       const toolUseLog = {
         tool: 'unknown',
-        input: parsedJson,
+        input: normalizationError.raw ?? state.toolInfo,
         output: sanitizeToolResultForLog(errorResult),
       };
       options.logger.info('', groupId, MESSAGE_TYPES.TOOL_USE, toolUseLog);
@@ -583,17 +554,22 @@ class ToolUseDispatchNode<C> extends BaseNode<ToolUseCycleContext<C>> {
           handledError: true,
           toolName: 'unknown',
           result: errorResult,
-          raw: parsedJson,
-          fallbackMessage: message,
+          raw: normalizationError.raw ?? state.toolInfo,
+          fallbackMessage: normalizationError.message,
         },
       };
     }
 
-    const payload = parsed.data;
+    if (!state.toolCall || !state.toolCallPayload) {
+      state.shouldStop = true;
+      return { skipped: true };
+    }
+
+    const payload = state.toolCall;
     return {
       skipped: false,
       value: {
-        raw: payload.raw,
+        raw: state.toolCallPayload as RawToolCallPayload,
         name: payload.name,
         input: payload.input,
         toolCallId: payload.callId,

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -1,6 +1,3 @@
-// Third-party imports
-import { z } from 'zod';
-
 // Local imports - core flow primitives
 import { BaseNode, Flow } from '@agent/node';
 import { AgentSharedStore } from '@agent/core/AgentSharedStore';
@@ -57,65 +54,16 @@ interface NormalizedToolCall {
   raw: RawToolCallPayload;
 }
 
-const RawToolCallPayloadSchema = z.object({
-  call_id: z.string().optional(),
-  tool_call_id: z.string().optional(),
-  tool_use_id: z.string().optional(),
-  id: z.string().optional(),
-  name: z.string().optional(),
-  function: z
-    .object({
-      name: z.string().optional(),
-      arguments: z
-        .union([z.string(), z.record(z.string(), z.unknown())])
-        .optional(),
-    })
-    .optional(),
-  input: z.unknown().optional(),
-  args: z.union([z.string(), z.record(z.string(), z.unknown())]).optional(),
-  arguments: z
-    .union([z.string(), z.record(z.string(), z.unknown())])
-    .optional(),
-});
+type RawToolCallPayload = Record<string, unknown>;
 
-type RawToolCallPayload = z.infer<typeof RawToolCallPayloadSchema>;
-
-function buildNormalizedToolCall(
-  payload: RawToolCallPayload,
-): NormalizedToolCall {
-  const callId =
-    payload.call_id ||
-    payload.tool_call_id ||
-    payload.tool_use_id ||
-    payload.id;
-
-  if (!callId) {
-    throw new Error('Tool call is missing an identifier.');
-  }
-
-  const name = payload.name || payload.function?.name;
-
-  if (!name) {
-    throw new Error('Tool call is missing a name.');
-  }
-
-  const argumentSources: Array<unknown> = [
-    payload.input,
-    payload.args,
-    payload.arguments,
-    payload.function?.arguments,
-  ];
-
-  const input = argumentSources.find(
-    (candidate) => candidate !== undefined && candidate !== null,
+function isNormalizedToolCall(value: unknown): value is NormalizedToolCall {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'callId' in value &&
+    'name' in value &&
+    'raw' in value
   );
-
-  return {
-    callId,
-    name,
-    input,
-    raw: payload,
-  };
 }
 
 function normalizeToolCallError(
@@ -152,21 +100,38 @@ function normalizeToolCallError(
 function normalizeToolCallPayload(
   rawPayload: string | RawToolCallPayload | NormalizedToolCall,
 ): { normalized: NormalizedToolCall; raw: RawToolCallPayload } {
-  if (typeof rawPayload === 'object') {
-    if ('callId' in rawPayload && 'name' in rawPayload) {
-      const normalized = rawPayload as NormalizedToolCall;
-      return { normalized, raw: normalized.raw };
-    }
+  const payload: RawToolCallPayload =
+    typeof rawPayload === 'string' ? JSON.parse(rawPayload) : rawPayload;
 
-    const parsed = RawToolCallPayloadSchema.parse(rawPayload);
-    const normalized = buildNormalizedToolCall(parsed);
-    return { normalized, raw: parsed };
+  if (isNormalizedToolCall(payload)) {
+    const normalized = payload;
+    return { normalized, raw: normalized.raw ?? (payload as RawToolCallPayload) };
   }
 
-  const parsedJson = JSON.parse(rawPayload);
-  const parsed = RawToolCallPayloadSchema.parse(parsedJson);
-  const normalized = buildNormalizedToolCall(parsed);
-  return { normalized, raw: parsed };
+  if (!payload || typeof payload !== 'object') {
+    throw new Error('Tool call payload is not an object.');
+  }
+
+  const callId =
+    (payload as any).callId ||
+    (payload as any).call_id ||
+    (payload as any).tool_call_id ||
+    (payload as any).id;
+  const name = (payload as any).name || (payload as any).function?.name;
+  const input = (payload as any).input ?? (payload as any).function?.arguments;
+
+  if (!callId || !name) {
+    throw new Error('Tool call is missing a callId or name.');
+  }
+
+  const normalized: NormalizedToolCall = {
+    callId: String(callId),
+    name: String(name),
+    input,
+    raw: payload,
+  };
+
+  return { normalized, raw: payload };
 }
 
 type ToolDispatchErrorResult = {

--- a/src/frontend/files/listing.ts
+++ b/src/frontend/files/listing.ts
@@ -4,22 +4,24 @@ import * as path from 'path';
 // Third-party imports
 import * as vscode from 'vscode';
 
-function createExcludePattern(
-  root: string,
-  directories: string[],
-): vscode.RelativePattern | undefined {
-  const sanitized = directories
+function sanitizeDirectories(directories: string[]): string[] {
+  return directories
     .map((dir) => dir.trim())
     .filter((dir) => dir.length > 0)
     .map((dir) =>
       dir.replace(/\\/g, '/').replace(/^\//, '').replace(/\/$/, ''),
     );
+}
 
-  if (sanitized.length === 0) {
+function createExcludePattern(
+  root: string,
+  sanitizedDirectories: string[],
+): vscode.RelativePattern | undefined {
+  if (sanitizedDirectories.length === 0) {
     return undefined;
   }
 
-  const globSegments = sanitized.map((dir) => `**/${dir}/**`);
+  const globSegments = sanitizedDirectories.map((dir) => `**/${dir}/**`);
   const globPattern =
     globSegments.length === 1 ? globSegments[0] : `{${globSegments.join(',')}}`;
 
@@ -59,7 +61,7 @@ interface NormalizedListingOptions {
   excludePattern?: vscode.RelativePattern;
 }
 
-function normalizeListingOptions(
+function prepareFilters(
   patternRoot: string,
   options: ListingOptions,
 ): NormalizedListingOptions {
@@ -69,13 +71,15 @@ function normalizeListingOptions(
   const excludeKeywords = options.excludeKeywords ?? [];
   const excludeFiles = options.excludeFiles ?? [];
 
+  const sanitizedDirectories = sanitizeDirectories(excludeDirectories);
+
   return {
     includeExt: includeExtensions.map((ext) => ext.toLowerCase()),
     excludeExt: excludeExtensions.map((ext) => ext.toLowerCase()),
     excludeKeywords: excludeKeywords.map((keyword) => keyword.toLowerCase()),
-    excludeDirs: excludeDirectories.map((dir) => dir.toLowerCase()),
+    excludeDirs: sanitizedDirectories.map((dir) => dir.toLowerCase()),
     excludeFiles: excludeFiles.map((file) => file.toLowerCase()),
-    excludePattern: createExcludePattern(patternRoot, excludeDirectories),
+    excludePattern: createExcludePattern(patternRoot, sanitizedDirectories),
   };
 }
 
@@ -86,7 +90,7 @@ export async function getFilesInDirectory(
   excludeDirectories: string[] = [],
   excludeKeywords: string[] = [],
 ): Promise<string[]> {
-  const filters = normalizeListingOptions(dir, {
+  const filters = prepareFilters(dir, {
     includeExtensions,
     excludeExtensions,
     excludeDirectories,
@@ -125,7 +129,7 @@ export async function getFilesRecursively(
   excludeKeywords: string[] = [],
   excludeFiles: string[] = [],
 ): Promise<string[]> {
-  const filters = normalizeListingOptions(root, {
+  const filters = prepareFilters(root, {
     includeExtensions,
     excludeExtensions,
     excludeDirectories,

--- a/src/historyView/modules/historyViewState.js
+++ b/src/historyView/modules/historyViewState.js
@@ -1,6 +1,9 @@
 // Local imports - history view
 import { WebviewStateManager } from '@common/webviewState.js';
 
+const restoreToggleStates = (savedState) =>
+  Array.isArray(savedState.toggleStates) ? savedState.toggleStates : [];
+
 class ToggleStates {
   constructor(saveCallback) {
     this.states = new Map();
@@ -44,36 +47,18 @@ export class HistoryViewState {
     const saved = typeof state === 'object' && state !== null ? state : {};
     this.searchIndex = saved.searchIndex || 0;
     this.totalMatches = saved.totalMatches || 0;
-    const { toggleStates } = saved;
-    if (Array.isArray(toggleStates)) {
-      this.toggleStates.load(toggleStates);
-    } else if (typeof toggleStates === 'string') {
-      try {
-        const parsed = JSON.parse(toggleStates);
-        if (Array.isArray(parsed)) {
-          this.toggleStates.load(parsed);
-          this.save();
-        } else {
-          console.error('Failed to restore toggle states: expected an array.');
-        }
-      } catch (e) {
-        console.error('Failed to migrate toggle states from string.', e);
-      }
-    } else if (toggleStates !== undefined) {
-      console.error('Failed to restore toggle states: expected an array.');
+    const restoredToggleStates = restoreToggleStates(saved);
+    if (restoredToggleStates.length > 0) {
+      this.toggleStates.load(restoredToggleStates);
     }
   }
 
   save() {
-    try {
-      this.stateManager.update({
-        searchIndex: this.searchIndex,
-        totalMatches: this.totalMatches,
-        toggleStates: this.toggleStates.entries(),
-      });
-    } catch (e) {
-      console.error('Failed to save state', e);
-    }
+    this.stateManager.update({
+      searchIndex: this.searchIndex,
+      totalMatches: this.totalMatches,
+      toggleStates: this.toggleStates.entries(),
+    });
   }
 
   setSearchIndex(index) {

--- a/src/historyView/modules/historyViewState.js
+++ b/src/historyView/modules/historyViewState.js
@@ -1,45 +1,12 @@
 // Local imports - history view
 import { WebviewStateManager } from '@common/webviewState.js';
 
-const restoreToggleStates = (savedState) =>
-  Array.isArray(savedState.toggleStates) ? savedState.toggleStates : [];
-
-class ToggleStates {
-  constructor(saveCallback) {
-    this.states = new Map();
-    this.saveCallback = saveCallback;
-  }
-
-  set(id, expanded) {
-    if (!id) return;
-    this.states.set(id, expanded);
-    if (this.saveCallback) this.saveCallback();
-  }
-
-  get(id) {
-    return this.states.get(id);
-  }
-
-  entries() {
-    return [...this.states.entries()];
-  }
-
-  load(data) {
-    this.states = new Map(data);
-  }
-
-  clearAll() {
-    this.states.clear();
-    if (this.saveCallback) this.saveCallback();
-  }
-}
-
 export class HistoryViewState {
   constructor() {
     this.stateManager = new WebviewStateManager();
     this.searchIndex = 0;
     this.totalMatches = 0;
-    this.toggleStates = new ToggleStates(() => this.save());
+    this.toggleStates = {};
   }
 
   initialize() {
@@ -47,17 +14,18 @@ export class HistoryViewState {
     const saved = typeof state === 'object' && state !== null ? state : {};
     this.searchIndex = saved.searchIndex || 0;
     this.totalMatches = saved.totalMatches || 0;
-    const restoredToggleStates = restoreToggleStates(saved);
-    if (restoredToggleStates.length > 0) {
-      this.toggleStates.load(restoredToggleStates);
-    }
+    const restored =
+      typeof saved.toggleStates === 'object' && saved.toggleStates !== null
+        ? saved.toggleStates
+        : {};
+    this.toggleStates = restored;
   }
 
   save() {
     this.stateManager.update({
       searchIndex: this.searchIndex,
       totalMatches: this.totalMatches,
-      toggleStates: this.toggleStates.entries(),
+      toggleStates: this.toggleStates,
     });
   }
 
@@ -68,6 +36,21 @@ export class HistoryViewState {
 
   setTotalMatches(count) {
     this.totalMatches = count;
+    this.save();
+  }
+
+  setToggleState(id, expanded) {
+    if (!id) return;
+    this.toggleStates[id] = expanded;
+    this.save();
+  }
+
+  getToggleState(id) {
+    return this.toggleStates[id];
+  }
+
+  clearToggleStates() {
+    this.toggleStates = {};
     this.save();
   }
 }

--- a/src/historyView/modules/uiManagers/HistoryRenderer.js
+++ b/src/historyView/modules/uiManagers/HistoryRenderer.js
@@ -247,13 +247,13 @@ export class HistoryRenderer {
           typeof detail?.open === 'boolean'
             ? detail.open
             : element.hasAttribute('open');
-        historyViewState.toggleStates.set(id, isOpen);
+        historyViewState.setToggleState(id, isOpen);
       });
     });
   }
 
   applyToggleStates() {
-    const entries = historyViewState.toggleStates.entries();
+    const entries = Object.entries(historyViewState.toggleStates);
     for (const [id, expanded] of entries) {
       const collapsible = document.querySelector(
         `.${CLASS_NAMES.HISTORY_COLLAPSIBLE}[data-id="${id}"]`,

--- a/src/historyView/modules/uiManagers/SearchManager.js
+++ b/src/historyView/modules/uiManagers/SearchManager.js
@@ -120,7 +120,7 @@ export class SearchManager {
           return;
         }
         const id = section.dataset.id;
-        const expanded = this.state.toggleStates.get(id);
+        const expanded = this.state.getToggleState(id);
         if ('open' in section) {
           section.open = Boolean(expanded);
         }

--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -16,7 +16,6 @@ import markdownItKatex from '@vscode/markdown-it-katex';
 // Third-party imports
 import MarkdownIt from 'markdown-it';
 import highlight from 'markdown-it-highlightjs';
-import { stringify as yamlStringify } from 'yaml';
 
 // Local imports - progress view
 import { STATUS, GROUP_DOM_IDS } from './constants.js';
@@ -68,21 +67,6 @@ const DATE_TIME_FORMATTER = new Intl.DateTimeFormat(
 
 let markdownRenderer;
 
-const toYamlString = (value) => {
-  if (typeof value === 'string') {
-    return value;
-  }
-
-  try {
-    const yamlValue = yamlStringify(value);
-    return typeof yamlValue === 'string'
-      ? yamlValue.replace(/\n$/, '')
-      : String(yamlValue);
-  } catch (error) {
-    return String(value);
-  }
-};
-
 const getMarkdownRenderer = () => {
   if (!markdownRenderer) {
     markdownRenderer = new MarkdownIt({
@@ -115,67 +99,27 @@ const tryParseJson = (text) => {
 
 const normalizeStructuredContent = (text, data) => {
   if (data !== undefined) {
-    return {
-      decodedText: typeof text === 'string' ? text : '',
-      structured: data,
-    };
+    return { structured: data };
   }
 
   const decodedText = typeof text === 'string' ? decodeHtml(text) : '';
   return { decodedText, structured: tryParseJson(decodedText) };
 };
 
-const normalizeFileListEntries = (structured) => {
-  if (!Array.isArray(structured)) {
-    return null;
-  }
+const normalizeFileListEntries = (structured) =>
+  Array.isArray(structured) ? structured : null;
 
-  return structured.map((file) => {
-    const rawPath = String(file?.path ?? '');
-    const source = file?.source || 'unknown';
-    const sourceDisplay = source
-      .replace('requiredFiles', 'required')
-      .replace('Pattern ', '')
-      .replace(/'/g, '');
+const normalizeMissingOutputsPayload = (structured) =>
+  structured && typeof structured === 'object' && !Array.isArray(structured)
+    ? {
+        missing: Array.isArray(structured.missing) ? structured.missing : [],
+        xmlFile: structured.xmlFile ?? null,
+        documentTag: structured.documentTag ?? null,
+      }
+    : null;
 
-    return {
-      filePath: rawPath,
-      fileName: getBasename(rawPath),
-      ok: Boolean(file?.ok),
-      source,
-      sourceDisplay,
-      internal: Boolean(file?.internal),
-      varName: typeof file?.varName === 'string' ? file.varName : '',
-    };
-  });
-};
-
-const normalizeMissingOutputsPayload = (structured) => {
-  if (
-    !structured ||
-    typeof structured !== 'object' ||
-    Array.isArray(structured)
-  ) {
-    return null;
-  }
-
-  return {
-    missing: Array.isArray(structured.missing) ? structured.missing : [],
-    xmlFile:
-      typeof structured.xmlFile === 'string' && structured.xmlFile
-        ? structured.xmlFile
-        : null,
-    documentTag:
-      typeof structured.documentTag === 'string' && structured.documentTag
-        ? structured.documentTag
-        : null,
-  };
-};
-
-const normalizeLatexdiffEntries = (structured) => {
-  if (!Array.isArray(structured)) return [];
-  return structured;
-};
+const normalizeLatexdiffEntries = (structured) =>
+  Array.isArray(structured) ? structured : null;
 
 const makePreview = (value, maxLength = 240) => {
   if (!value) return '';
@@ -187,69 +131,39 @@ const makePreview = (value, maxLength = 240) => {
 };
 
 const normalizeToolUseLog = (structured) => {
-  const parsed =
-    structured && typeof structured === 'object' && !Array.isArray(structured)
-      ? structured
-      : null;
-
-  if (!parsed) {
+  if (
+    !structured ||
+    typeof structured !== 'object' ||
+    Array.isArray(structured)
+  ) {
     return null;
   }
 
-  const outputCandidate =
-    parsed.output &&
-    typeof parsed.output === 'object' &&
-    !Array.isArray(parsed.output)
-      ? parsed.output
-      : parsed.result &&
-          typeof parsed.result === 'object' &&
-          !Array.isArray(parsed.result)
-        ? parsed.result
-        : {};
-
-  const summaryText =
-    typeof outputCandidate.summary === 'string' &&
-    outputCandidate.summary.trim()
-      ? outputCandidate.summary.trim()
-      : typeof parsed.summary === 'string' && parsed.summary.trim()
-        ? parsed.summary.trim()
-        : '';
-
-  const errorText =
-    typeof outputCandidate.error === 'string'
-      ? outputCandidate.error
-      : typeof parsed.error === 'string'
-        ? parsed.error
-        : '';
-
-  let outputText = '';
-  if (typeof outputCandidate.output === 'string') {
-    outputText = outputCandidate.output;
-  } else if (typeof parsed.output === 'string') {
-    outputText = parsed.output;
-  }
-
   const toolName =
-    typeof parsed.tool === 'string'
-      ? parsed.tool.trim()
-      : typeof parsed.name === 'string'
-        ? parsed.name.trim()
-        : '';
-
-  const isError = Boolean(
-    (typeof outputCandidate.isError === 'boolean' && outputCandidate.isError) ||
-      (typeof parsed.isError === 'boolean' && parsed.isError) ||
-      (typeof errorText === 'string' && errorText.trim().length > 0),
-  );
+    typeof structured.toolName === 'string'
+      ? structured.toolName
+      : typeof structured.tool === 'string'
+        ? structured.tool
+        : typeof structured.name === 'string'
+          ? structured.name
+          : '';
+  const summaryText =
+    typeof structured.summary === 'string' ? structured.summary : '';
+  const errorText =
+    typeof structured.error === 'string' ? structured.error : '';
+  const outputText =
+    typeof structured.output === 'string' ? structured.output : '';
+  const diagnostics = structured.diagnostics;
+  const isError = Boolean(structured.isError || errorText);
 
   return {
     kind: 'structured',
-    parsed,
+    parsed: structured,
     toolName,
-    outputCandidate,
     summaryText,
     errorText,
     outputText,
+    diagnostics,
     isError,
     headerSummary: summaryText || makePreview(errorText || outputText || ''),
   };
@@ -687,10 +601,10 @@ export class LogEntryFormatter {
     const {
       parsed,
       toolName,
-      outputCandidate,
       summaryText,
       errorText,
       outputText,
+      diagnostics,
     } = normalizedToolLog;
 
     const titlePrefix = normalizedToolLog.isError ? 'Tool Error' : 'Tool Use';
@@ -708,9 +622,18 @@ export class LogEntryFormatter {
     element.classList.toggle('tool-use-error', normalizedToolLog.isError);
 
     const sections = [];
+    const formatValue = (value) => {
+      if (typeof value === 'string') return value;
+      if (value === undefined) return '';
+      try {
+        return JSON.stringify(value, null, 2);
+      } catch (error) {
+        return String(value);
+      }
+    };
 
     if (parsed.input !== undefined) {
-      const inputValue = toYamlString(parsed.input);
+      const inputValue = formatValue(parsed.input);
       sections.push(`
         <div class="tool-use-section">
           <div class="tool-use-subsection">
@@ -763,8 +686,8 @@ export class LogEntryFormatter {
       }
     }
 
-    if (outputCandidate && outputCandidate.diagnostics !== undefined) {
-      const diagnosticsText = toYamlString(outputCandidate.diagnostics).trim();
+    if (diagnostics !== undefined) {
+      const diagnosticsText = formatValue(diagnostics).trim();
       const MAX_DIAGNOSTICS_LENGTH = 600;
 
       if (diagnosticsText && diagnosticsText.length <= MAX_DIAGNOSTICS_LENGTH) {
@@ -788,32 +711,10 @@ export class LogEntryFormatter {
       }
     }
 
-    if (outputCandidate && typeof outputCandidate.system === 'string') {
-      sections.push(`
-        <div class="tool-use-section">
-          <div class="tool-use-subsection">
-            <span class="tool-use-sublabel">System:</span>
-            <pre>${encodeHtml(outputCandidate.system)}</pre>
-          </div>
-        </div>
-      `);
-    }
-
-    if (outputCandidate && typeof outputCandidate.base64Image === 'string') {
-      sections.push(`
-        <div class="tool-use-section">
-          <div class="tool-use-subsection">
-            <span class="tool-use-sublabel">Image:</span>
-            <pre>(base64 image omitted)</pre>
-          </div>
-        </div>
-      `);
-    }
-
-    const fallbackYaml = toYamlString(parsed);
+    const fallbackText = formatValue(parsed);
     contentElem.innerHTML =
       sections.length === 0
-        ? `<pre>${encodeHtml(fallbackYaml || '')}</pre>`
+        ? `<pre>${encodeHtml(fallbackText || '')}</pre>`
         : sections.join('<hr class="tool-use-separator">');
 
     return element;
@@ -967,9 +868,12 @@ export class LogEntryFormatter {
     let items = '';
     Object.entries(filesBySource).forEach(([source, files]) => {
       files.forEach((f) => {
+        const filePath = f.filePath || f.path || '';
+        const fileName = f.fileName || getBasename(filePath);
+        const sourceDisplay = f.sourceDisplay || source;
         const icon = f.ok ? 'codicon-check' : 'codicon-warning';
-        const escaped = encodeHtml(f.filePath);
-        const fileNameEscaped = encodeHtml(f.fileName);
+        const escaped = encodeHtml(filePath);
+        const fileNameEscaped = encodeHtml(fileName);
 
         let metadata = '';
         if (f.varName) {
@@ -977,9 +881,9 @@ export class LogEntryFormatter {
         }
         if (source && source !== 'unknown') {
           if (f.internal) {
-            metadata += ` <span class="file-source">(${f.sourceDisplay}, internal)</span>`;
+            metadata += ` <span class="file-source">(${sourceDisplay}, internal)</span>`;
           } else {
-            metadata += ` <span class="file-source">(${f.sourceDisplay})</span>`;
+            metadata += ` <span class="file-source">(${sourceDisplay})</span>`;
           }
         }
 
@@ -1093,7 +997,7 @@ export class LogEntryFormatter {
 
     const entries = normalizeLatexdiffEntries(normalizedPayload?.structured);
 
-    if (entries.length === 0) {
+    if (!entries || entries.length === 0) {
       return null;
     }
 

--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -60,36 +60,13 @@ const TIME_FORMAT_OPTIONS = {
   hour12: false,
 };
 
-let cachedTimeFormatter;
-let cachedDateTimeFormatter;
+const TIME_FORMATTER = new Intl.DateTimeFormat(undefined, TIME_FORMAT_OPTIONS);
+const DATE_TIME_FORMATTER = new Intl.DateTimeFormat(
+  undefined,
+  DATETIME_FORMAT_OPTIONS,
+);
 
-const getTimeFormatter = () => {
-  if (cachedTimeFormatter === undefined) {
-    try {
-      cachedTimeFormatter = new Intl.DateTimeFormat(
-        undefined,
-        TIME_FORMAT_OPTIONS,
-      );
-    } catch (error) {
-      cachedTimeFormatter = null;
-    }
-  }
-  return cachedTimeFormatter;
-};
-
-const getDateTimeFormatter = () => {
-  if (cachedDateTimeFormatter === undefined) {
-    try {
-      cachedDateTimeFormatter = new Intl.DateTimeFormat(
-        undefined,
-        DATETIME_FORMAT_OPTIONS,
-      );
-    } catch (error) {
-      cachedDateTimeFormatter = null;
-    }
-  }
-  return cachedDateTimeFormatter;
-};
+let markdownRenderer;
 
 const toYamlString = (value) => {
   if (typeof value === 'string') {
@@ -106,16 +83,176 @@ const toYamlString = (value) => {
   }
 };
 
-const formatIsoDateTimeFallback = (date) => {
-  const isoTimestamp = date.toISOString();
-  const [datePart, timePart = ''] = isoTimestamp.split('T');
-  const trimmedTime = timePart.split('.')[0] || timePart;
-  return `${datePart} ${trimmedTime}`.trim();
+const getMarkdownRenderer = () => {
+  if (!markdownRenderer) {
+    markdownRenderer = new MarkdownIt({
+      breaks: false,
+      linkify: true,
+      html: false,
+    })
+      .use(markdownItKatex, {
+        throwOnError: false,
+        errorColor: '#cc0000',
+        macros: katexMacros,
+      })
+      .use(highlight);
+  }
+
+  return markdownRenderer;
 };
 
-const formatIsoTimeFallback = (date) => {
-  const isoTimestamp = date.toISOString();
-  return isoTimestamp.split('T')[1]?.split('.')[0] ?? isoTimestamp;
+const tryParseJson = (text) => {
+  if (!text || typeof text !== 'string') {
+    return null;
+  }
+
+  try {
+    return JSON.parse(text);
+  } catch (error) {
+    return null;
+  }
+};
+
+const normalizeStructuredContent = (text, data) => {
+  if (data !== undefined) {
+    return {
+      decodedText: typeof text === 'string' ? text : '',
+      structured: data,
+    };
+  }
+
+  const decodedText = typeof text === 'string' ? decodeHtml(text) : '';
+  return { decodedText, structured: tryParseJson(decodedText) };
+};
+
+const normalizeFileListEntries = (structured) => {
+  if (!Array.isArray(structured)) {
+    return null;
+  }
+
+  return structured.map((file) => {
+    const rawPath = String(file?.path ?? '');
+    const source = file?.source || 'unknown';
+    const sourceDisplay = source
+      .replace('requiredFiles', 'required')
+      .replace('Pattern ', '')
+      .replace(/'/g, '');
+
+    return {
+      filePath: rawPath,
+      fileName: getBasename(rawPath),
+      ok: Boolean(file?.ok),
+      source,
+      sourceDisplay,
+      internal: Boolean(file?.internal),
+      varName: typeof file?.varName === 'string' ? file.varName : '',
+    };
+  });
+};
+
+const normalizeMissingOutputsPayload = (structured) => {
+  if (
+    !structured ||
+    typeof structured !== 'object' ||
+    Array.isArray(structured)
+  ) {
+    return null;
+  }
+
+  return {
+    missing: Array.isArray(structured.missing) ? structured.missing : [],
+    xmlFile:
+      typeof structured.xmlFile === 'string' && structured.xmlFile
+        ? structured.xmlFile
+        : null,
+    documentTag:
+      typeof structured.documentTag === 'string' && structured.documentTag
+        ? structured.documentTag
+        : null,
+  };
+};
+
+const normalizeLatexdiffEntries = (structured) => {
+  if (!Array.isArray(structured)) return [];
+  return structured;
+};
+
+const makePreview = (value, maxLength = 240) => {
+  if (!value) return '';
+  const normalized = value.replace(/\s+/g, ' ').trim();
+  if (normalized.length <= maxLength) {
+    return normalized;
+  }
+  return `${normalized.slice(0, maxLength - 1)}…`;
+};
+
+const normalizeToolUseLog = (structured) => {
+  const parsed =
+    structured && typeof structured === 'object' && !Array.isArray(structured)
+      ? structured
+      : null;
+
+  if (!parsed) {
+    return null;
+  }
+
+  const outputCandidate =
+    parsed.output &&
+    typeof parsed.output === 'object' &&
+    !Array.isArray(parsed.output)
+      ? parsed.output
+      : parsed.result &&
+          typeof parsed.result === 'object' &&
+          !Array.isArray(parsed.result)
+        ? parsed.result
+        : {};
+
+  const summaryText =
+    typeof outputCandidate.summary === 'string' &&
+    outputCandidate.summary.trim()
+      ? outputCandidate.summary.trim()
+      : typeof parsed.summary === 'string' && parsed.summary.trim()
+        ? parsed.summary.trim()
+        : '';
+
+  const errorText =
+    typeof outputCandidate.error === 'string'
+      ? outputCandidate.error
+      : typeof parsed.error === 'string'
+        ? parsed.error
+        : '';
+
+  let outputText = '';
+  if (typeof outputCandidate.output === 'string') {
+    outputText = outputCandidate.output;
+  } else if (typeof parsed.output === 'string') {
+    outputText = parsed.output;
+  }
+
+  const toolName =
+    typeof parsed.tool === 'string'
+      ? parsed.tool.trim()
+      : typeof parsed.name === 'string'
+        ? parsed.name.trim()
+        : '';
+
+  const isError = Boolean(
+    (typeof outputCandidate.isError === 'boolean' && outputCandidate.isError) ||
+      (typeof parsed.isError === 'boolean' && parsed.isError) ||
+      (typeof errorText === 'string' && errorText.trim().length > 0),
+  );
+
+  return {
+    kind: 'structured',
+    parsed,
+    toolName,
+    outputCandidate,
+    summaryText,
+    errorText,
+    outputText,
+    isError,
+    headerSummary: summaryText || makePreview(errorText || outputText || ''),
+  };
 };
 
 /**
@@ -125,15 +262,7 @@ export const TaskGroupLevel = {
   ROOT: {
     name: 'root',
     formatTime: (date) => {
-      const formatter = getDateTimeFormatter();
-      if (formatter) {
-        try {
-          return formatter.format(date);
-        } catch (error) {
-          // Fall through to ISO fallback
-        }
-      }
-      return formatIsoDateTimeFallback(date);
+      return DATE_TIME_FORMATTER.format(date);
     },
     showTitle: false,
     headerOrder: 'time-first', // time → bullet → usage
@@ -142,15 +271,7 @@ export const TaskGroupLevel = {
   NESTED: {
     name: 'nested',
     formatTime: (date) => {
-      const formatter = getTimeFormatter();
-      if (formatter) {
-        try {
-          return formatter.format(date);
-        } catch (error) {
-          // Fall through to ISO fallback
-        }
-      }
-      return formatIsoTimeFallback(date);
+      return TIME_FORMATTER.format(date);
     },
     showTitle: true,
     headerOrder: 'usage-first', // usage → bullet → time
@@ -203,17 +324,7 @@ export class LogEntryFormatter {
   }
 
   _initializeMarkdown() {
-    this.md = new MarkdownIt({
-      breaks: false,
-      linkify: true,
-      html: false,
-    })
-      .use(markdownItKatex, {
-        throwOnError: false,
-        errorColor: '#cc0000',
-        macros: katexMacros,
-      })
-      .use(highlight);
+    this.md = getMarkdownRenderer();
   }
 
   _buildFormatterMap() {
@@ -222,7 +333,7 @@ export class LogEntryFormatter {
         this._safeFormat(
           () =>
             this._formatBannerContent(
-              message.text,
+              message.normalizedPayload,
               'Thinking',
               message.id,
               message.groupId,
@@ -234,7 +345,7 @@ export class LogEntryFormatter {
         this._safeFormat(
           () =>
             this._formatBannerContent(
-              message.text,
+              message.normalizedPayload,
               'Scratchpad',
               message.id,
               message.groupId,
@@ -246,8 +357,7 @@ export class LogEntryFormatter {
         this._safeFormat(
           () =>
             this._formatToolUse(
-              message.text,
-              message.data,
+              message.normalizedPayload,
               message.id,
               message.groupId,
               message.timestamp,
@@ -262,37 +372,37 @@ export class LogEntryFormatter {
               groupId: message.groupId,
               timestamp: message.timestamp,
               verbose: message.verbose,
-              content: message.text,
+              content: message.normalizedPayload,
               level: message.level,
             }),
           'Assistant',
         ),
       fileList: (message) =>
         this._safeFormat(
-          () => this._formatFileList(message.text, message.data, message.id),
+          () => this._formatFileList(message.normalizedPayload, message.id),
           'file list',
         ),
       missingOutputs: (message) =>
         this._safeFormat(
           () =>
-            this._formatMissingOutputs(message.text, message.data, message.id),
+            this._formatMissingOutputs(message.normalizedPayload, message.id),
           'missing outputs',
         ),
       latexdiff: (message) =>
         this._safeFormat(
-          () => this._formatLatexdiff(message.text, message.data, message.id),
+          () => this._formatLatexdiff(message.normalizedPayload, message.id),
           'latexdiff',
         ),
       statistics: (message) =>
         this._safeFormat(
-          () => this._formatStatistics(message.text, message.data, message.id),
+          () => this._formatStatistics(message.normalizedPayload, message.id),
           'statistics',
         ),
       userMessage: (message) =>
         this._safeFormat(
           () =>
             this._formatUserMessage(
-              message.text,
+              message.normalizedPayload,
               message.id,
               message.timestamp,
             ),
@@ -302,7 +412,7 @@ export class LogEntryFormatter {
         this._safeFormat(
           () =>
             this._formatProgressStatus(
-              message.text,
+              message.normalizedPayload,
               message.id,
               message.timestamp,
             ),
@@ -358,30 +468,10 @@ export class LogEntryFormatter {
   _formatTimestamp(date) {
     const isoTimestamp = date.toISOString();
 
-    let timeDisplay = formatIsoTimeFallback(date);
-    const timeFormatter = getTimeFormatter();
-    if (timeFormatter) {
-      try {
-        timeDisplay = timeFormatter.format(date);
-      } catch (error) {
-        // Fall through to ISO fallback
-      }
-    }
-
-    let tooltipTimestamp = formatIsoDateTimeFallback(date);
-    const dateTimeFormatter = getDateTimeFormatter();
-    if (dateTimeFormatter) {
-      try {
-        tooltipTimestamp = dateTimeFormatter.format(date);
-      } catch (error) {
-        // Fall through to ISO fallback
-      }
-    }
-
     return {
       fullTimestamp: isoTimestamp,
-      timeDisplay,
-      tooltipTimestamp,
+      timeDisplay: TIME_FORMATTER.format(date),
+      tooltipTimestamp: DATE_TIME_FORMATTER.format(date),
     };
   }
 
@@ -391,8 +481,7 @@ export class LogEntryFormatter {
    * @param {boolean} decode - Whether to decode HTML entities (default: true)
    * @returns {string} Processed markdown HTML
    */
-  _processMarkdownContent(content, decode = true) {
-    // Unescape HTML entities if requested
+  _processMarkdownContent(content, decode = false) {
     if (decode) {
       content = decodeHtml(content);
     }
@@ -402,8 +491,10 @@ export class LogEntryFormatter {
     content = content.replace(/\\cref\{([^}]+)\}/g, '@@LATEX-CREF:$1@@');
     content = content.replace(/\\eqref\{([^}]+)\}/g, '@@LATEX-EQREF:$1@@');
 
+    const renderer = this.md || getMarkdownRenderer();
+
     // Process content as markdown
-    let parsedMarkdown = this.md.render(content);
+    let parsedMarkdown = renderer.render(content);
 
     // Post-process to restore and style LaTeX references
     parsedMarkdown = this._restoreLatexReferences(parsedMarkdown);
@@ -468,8 +559,16 @@ export class LogEntryFormatter {
    * whitespace formatting issue.
    */
   format(logMessage, options = {}) {
+    const messageWithPayload = {
+      ...logMessage,
+      normalizedPayload: normalizeStructuredContent(
+        logMessage.text,
+        logMessage.data,
+      ),
+    };
+
     const { id, text, level, timestamp, groupId, messageType, verbose } =
-      logMessage;
+      messageWithPayload;
 
     const emoji = EMOJI_BY_LEVEL[level] || '•';
     const date = new Date(timestamp);
@@ -479,7 +578,7 @@ export class LogEntryFormatter {
     const formatter = messageType ? this._formatters[messageType] : null;
 
     if (typeof formatter === 'function') {
-      const result = formatter(logMessage);
+      const result = formatter(messageWithPayload);
       if (result) {
         if (result instanceof HTMLElement) {
           const openOverride = this._resolveOpenState(messageType, options);
@@ -520,14 +619,19 @@ export class LogEntryFormatter {
     return wrapper.firstElementChild;
   }
 
-  _formatBannerContent(content, contentType, logId, groupId, timestamp) {
-    if (!content || !content.trim()) return null;
-    const decodedContent = decodeHtml(content);
-    if (!decodedContent.trim()) {
-      return null;
-    }
+  _formatBannerContent(
+    normalizedPayload,
+    contentType,
+    logId,
+    groupId,
+    timestamp,
+  ) {
+    const decodedContent = normalizedPayload?.decodedText || '';
+    const trimmedContent = decodedContent.trim();
 
-    const parsedMarkdown = this._processMarkdownContent(decodedContent, false);
+    if (!trimmedContent) return null;
+
+    const parsedMarkdown = this._processMarkdownContent(trimmedContent, false);
     const isThinking = contentType.includes('Thinking');
     const bannerEntry = this._createBannerEntry({
       logId,
@@ -546,13 +650,13 @@ export class LogEntryFormatter {
       return bannerEntry ? bannerEntry.element : null;
     }
 
-    bannerEntry.contentElem.dataset.rawContent = decodedContent;
+    bannerEntry.contentElem.dataset.rawContent = trimmedContent;
     bannerEntry.contentElem.innerHTML = parsedMarkdown;
 
     return bannerEntry.element;
   }
 
-  _formatToolUse(content, structuredData, logId, groupId, timestamp) {
+  _formatToolUse(normalizedPayload, logId, groupId, timestamp) {
     const element = createFromTemplate('toolUseTemplate');
     if (!element) return null;
 
@@ -573,119 +677,35 @@ export class LogEntryFormatter {
       return element;
     }
 
-    const MAX_PREVIEW_CHARS = 240;
-    const makePreview = (value) => {
-      if (!value) return '';
-      const normalized = value.replace(/\s+/g, ' ').trim();
-      if (normalized.length <= MAX_PREVIEW_CHARS) {
-        return normalized;
-      }
-      return `${normalized.slice(0, MAX_PREVIEW_CHARS - 1)}…`;
-    };
+    const { structured } = normalizedPayload || {};
+    const normalizedToolLog = normalizeToolUseLog(structured);
 
-    const rawContent =
-      typeof content === 'string' && content.length > 0
-        ? decodeHtml(content)
-        : '';
-    const hasStructuredData =
-      structuredData &&
-      typeof structuredData === 'object' &&
-      !Array.isArray(structuredData);
-    let parsed = hasStructuredData ? structuredData : null;
-
-    if (!parsed && rawContent) {
-      try {
-        parsed = JSON.parse(rawContent);
-      } catch (error) {
-        parsed = null;
-      }
+    if (!normalizedToolLog) {
+      return null;
     }
 
-    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
-      if (headerLabel) headerLabel.textContent = 'Tool Use (raw entry)';
-      if (iconElem) iconElem.className = 'codicon codicon-wrench';
-      element.classList.remove('tool-use-error');
+    const {
+      parsed,
+      toolName,
+      outputCandidate,
+      summaryText,
+      errorText,
+      outputText,
+    } = normalizedToolLog;
 
-      let fallbackContent = rawContent;
-      if (!fallbackContent && structuredData !== undefined) {
-        fallbackContent = toYamlString(structuredData);
-      }
-
-      contentElem.innerHTML = `
-        <div class="tool-use-section">
-          <div class="tool-use-subsection">
-            <span class="tool-use-sublabel">Raw log:</span>
-            <pre>${encodeHtml(fallbackContent || '')}</pre>
-          </div>
-        </div>
-      `;
-
-      return element;
-    }
-
-    const toolName =
-      typeof parsed.tool === 'string'
-        ? parsed.tool.trim()
-        : typeof parsed.name === 'string'
-          ? parsed.name.trim()
-          : '';
-
-    const outputCandidate =
-      parsed.output &&
-      typeof parsed.output === 'object' &&
-      !Array.isArray(parsed.output)
-        ? parsed.output
-        : parsed.result &&
-            typeof parsed.result === 'object' &&
-            !Array.isArray(parsed.result)
-          ? parsed.result
-          : {};
-
-    const summaryText =
-      typeof outputCandidate.summary === 'string' &&
-      outputCandidate.summary.trim()
-        ? outputCandidate.summary.trim()
-        : typeof parsed.summary === 'string' && parsed.summary.trim()
-          ? parsed.summary.trim()
-          : '';
-
-    const errorText =
-      typeof outputCandidate.error === 'string'
-        ? outputCandidate.error
-        : typeof parsed.error === 'string'
-          ? parsed.error
-          : '';
-
-    let outputText = '';
-    if (typeof outputCandidate.output === 'string') {
-      outputText = outputCandidate.output;
-    } else if (typeof parsed.output === 'string') {
-      outputText = parsed.output;
-    }
-
-    const isError = Boolean(
-      (typeof outputCandidate.isError === 'boolean' &&
-        outputCandidate.isError) ||
-        (typeof parsed.isError === 'boolean' && parsed.isError) ||
-        (typeof errorText === 'string' && errorText.trim().length > 0),
-    );
-
-    const headerSummary =
-      summaryText || makePreview(errorText || outputText || '');
-
-    const titlePrefix = isError ? 'Tool Error' : 'Tool Use';
+    const titlePrefix = normalizedToolLog.isError ? 'Tool Error' : 'Tool Use';
     const titleBase = toolName ? `${titlePrefix}: ${toolName}` : titlePrefix;
-    const titleText = headerSummary
-      ? `${titleBase} — ${headerSummary}`
+    const titleText = normalizedToolLog.headerSummary
+      ? `${titleBase} — ${normalizedToolLog.headerSummary}`
       : titleBase;
 
     if (headerLabel) headerLabel.textContent = titleText;
     if (iconElem) {
-      iconElem.className = isError
+      iconElem.className = normalizedToolLog.isError
         ? 'codicon codicon-error'
         : 'codicon codicon-wrench';
     }
-    element.classList.toggle('tool-use-error', isError);
+    element.classList.toggle('tool-use-error', normalizedToolLog.isError);
 
     const sections = [];
 
@@ -714,6 +734,7 @@ export class LogEntryFormatter {
 
     if (outputText) {
       const encodedOutput = encodeHtml(outputText);
+      const MAX_PREVIEW_CHARS = 240;
       if (!summaryText && outputText.length > MAX_PREVIEW_CHARS) {
         const preview = encodeHtml(
           `${outputText.slice(0, MAX_PREVIEW_CHARS).trimEnd()}…`,
@@ -789,12 +810,11 @@ export class LogEntryFormatter {
       `);
     }
 
-    if (sections.length === 0) {
-      const fallbackYaml = toYamlString(parsed) || rawContent;
-      contentElem.innerHTML = `<pre>${encodeHtml(fallbackYaml || '')}</pre>`;
-    } else {
-      contentElem.innerHTML = sections.join('<hr class="tool-use-separator">');
-    }
+    const fallbackYaml = toYamlString(parsed);
+    contentElem.innerHTML =
+      sections.length === 0
+        ? `<pre>${encodeHtml(fallbackYaml || '')}</pre>`
+        : sections.join('<hr class="tool-use-separator">');
 
     return element;
   }
@@ -810,8 +830,9 @@ export class LogEntryFormatter {
       return null;
     }
 
-    const decodedContent = decodeHtml(content);
-    if (!decodedContent.trim()) {
+    const decodedContent = content.decodedText || '';
+    const trimmedContent = decodedContent.trim();
+    if (!trimmedContent) {
       return null;
     }
 
@@ -849,9 +870,9 @@ export class LogEntryFormatter {
 
     if (contentElem) {
       contentElem.classList.add(`message-${level}`);
-      contentElem.dataset.rawContent = decodedContent;
+      contentElem.dataset.rawContent = trimmedContent;
       contentElem.innerHTML = this._processMarkdownContent(
-        decodedContent,
+        trimmedContent,
         false,
       );
     }
@@ -919,7 +940,7 @@ export class LogEntryFormatter {
     };
   }
 
-  _formatFileList(content, data, logId) {
+  _formatFileList(normalizedPayload, logId) {
     const element = createFromTemplate('fileListDetailsTemplate');
     if (!element) return null;
     const contentElem = element.querySelector('.file-list-content');
@@ -927,49 +948,38 @@ export class LogEntryFormatter {
     const toggleIcon = element.querySelector('.toggle-icon');
     if (toggleIcon) toggleIcon.className = `${CHEVRON_RIGHT_CLASS} toggle-icon`;
 
-    const parsed = data ?? JSON.parse(decodeHtml(content));
+    const parsed = normalizeFileListEntries(normalizedPayload?.structured);
 
-    if (!Array.isArray(parsed)) {
+    if (!parsed) {
       console.warn('Missing structured data for file list log entry');
       return null;
     }
 
-    // Group files by source for better organization
     const filesBySource = {};
-    parsed.forEach((f) => {
-      const source = f.source || 'unknown';
+    parsed.forEach((file) => {
+      const source = file.source || 'unknown';
       if (!filesBySource[source]) {
         filesBySource[source] = [];
       }
-      filesBySource[source].push(f);
+      filesBySource[source].push(file);
     });
 
     let items = '';
     Object.entries(filesBySource).forEach(([source, files]) => {
       files.forEach((f) => {
         const icon = f.ok ? 'codicon-check' : 'codicon-warning';
-        const filePath = String(f.path ?? '');
-        const escaped = encodeHtml(filePath);
+        const escaped = encodeHtml(f.filePath);
+        const fileNameEscaped = encodeHtml(f.fileName);
 
-        // Extract just the filename for display
-        const fileName = getBasename(filePath);
-        const fileNameEscaped = encodeHtml(fileName);
-
-        // Build metadata string
         let metadata = '';
         if (f.varName) {
           metadata += `<span class="file-var">[${f.varName}]</span>`;
         }
         if (source && source !== 'unknown') {
-          // Simplify source display
-          const sourceDisplay = source
-            .replace('requiredFiles', 'required')
-            .replace('Pattern ', '')
-            .replace(/'/g, '');
           if (f.internal) {
-            metadata += ` <span class="file-source">(${sourceDisplay}, internal)</span>`;
+            metadata += ` <span class="file-source">(${f.sourceDisplay}, internal)</span>`;
           } else {
-            metadata += ` <span class="file-source">(${sourceDisplay})</span>`;
+            metadata += ` <span class="file-source">(${f.sourceDisplay})</span>`;
           }
         }
 
@@ -996,7 +1006,7 @@ export class LogEntryFormatter {
     return element;
   }
 
-  _formatMissingOutputs(content, data, logId) {
+  _formatMissingOutputs(normalizedPayload, logId) {
     const element = createFromTemplate('missingOutputsDetailsTemplate');
     if (!element) return null;
     const contentElem = element.querySelector('.file-list-content');
@@ -1004,27 +1014,18 @@ export class LogEntryFormatter {
     const toggleIcon = element.querySelector('.toggle-icon');
     if (toggleIcon) toggleIcon.className = `${CHEVRON_RIGHT_CLASS} toggle-icon`;
 
-    const parsed = data ?? JSON.parse(decodeHtml(content));
+    const parsed = normalizeMissingOutputsPayload(
+      normalizedPayload?.structured,
+    );
 
-    // Handle both old format (array) and new format (object with missing, xmlFile, documentTag)
-    let missingFiles = [];
-    let xmlFile = null;
-    let documentTag = null;
-
-    if (Array.isArray(parsed)) {
-      // Old format: just an array of missing files
-      missingFiles = parsed;
-    } else if (parsed && typeof parsed === 'object') {
-      // New format: object with missing files, XML file, and optional document tag
-      missingFiles = parsed.missing || [];
-      xmlFile = parsed.xmlFile;
-      documentTag = parsed.documentTag;
-    } else {
+    if (!parsed) {
       console.warn('Missing structured data for missing outputs log entry');
       return null;
     }
 
-    const items = missingFiles
+    const { missing, xmlFile, documentTag } = parsed;
+
+    const items = missing
       .map((f) => {
         const filePath = String(f);
         const escaped = encodeHtml(filePath);
@@ -1034,7 +1035,6 @@ export class LogEntryFormatter {
       })
       .join('');
 
-    // Add XML file link if available
     let xmlLink = '';
     if (xmlFile) {
       const xmlEscaped = encodeHtml(xmlFile);
@@ -1051,7 +1051,7 @@ export class LogEntryFormatter {
         </div>`;
     }
 
-    if (missingFiles.length === 0 && xmlFile) {
+    if (missing.length === 0 && xmlFile) {
       const wrapper = document.createElement('div');
       wrapper.innerHTML = xmlLink;
       const element = wrapper.firstElementChild;
@@ -1062,7 +1062,7 @@ export class LogEntryFormatter {
       return element;
     }
 
-    const summary = `Missing outputs (${missingFiles.length})`;
+    const summary = `Missing outputs (${missing.length})`;
 
     if (summaryElem) summaryElem.textContent = summary;
     if (contentElem) {
@@ -1083,7 +1083,7 @@ export class LogEntryFormatter {
     return element;
   }
 
-  _formatLatexdiff(content, data, logId) {
+  _formatLatexdiff(normalizedPayload, logId) {
     const element = createFromTemplate('latexdiffDetailsTemplate');
     if (!element) return null;
     const contentElem = element.querySelector('.latexdiff-content');
@@ -1091,12 +1091,7 @@ export class LogEntryFormatter {
     const toggleIcon = element.querySelector('.toggle-icon');
     if (toggleIcon) toggleIcon.className = `${CHEVRON_DOWN_CLASS} toggle-icon`;
 
-    const parsed = data ?? JSON.parse(decodeHtml(content));
-    const entries = Array.isArray(parsed)
-      ? parsed
-      : parsed && typeof parsed === 'object'
-        ? [parsed]
-        : [];
+    const entries = normalizeLatexdiffEntries(normalizedPayload?.structured);
 
     if (entries.length === 0) {
       return null;
@@ -1200,14 +1195,13 @@ export class LogEntryFormatter {
     return element;
   }
 
-  _formatStatistics(content, data, logId) {
-    // Note: content parameter kept for consistency with other formatters but not used
+  _formatStatistics(normalizedPayload, logId) {
     const element = createFromTemplate('statisticsDetailsTemplate');
     if (!element) return null;
     const contentElem = element.querySelector('.statistics-content');
     const toggleIcon = element.querySelector('.toggle-icon');
     if (toggleIcon) toggleIcon.className = `${CHEVRON_RIGHT_CLASS} toggle-icon`;
-    const parsed = data;
+    const parsed = normalizedPayload?.structured;
     if (!parsed || typeof parsed !== 'object') {
       return null;
     }
@@ -1283,7 +1277,7 @@ export class LogEntryFormatter {
     return element;
   }
 
-  _formatProgressStatus(content, logId, timestamp) {
+  _formatProgressStatus(normalizedPayload, logId, timestamp) {
     const element = createFromTemplate('nativeStatusTemplate');
     if (!element) return null;
 
@@ -1304,15 +1298,14 @@ export class LogEntryFormatter {
 
     const textElem = element.querySelector('.native-status-text');
     if (textElem) {
-      const decodedContent =
-        typeof content === 'string' ? decodeHtml(content) : '';
+      const decodedContent = normalizedPayload?.decodedText || '';
       textElem.textContent = decodedContent;
     }
 
     return element;
   }
 
-  _formatUserMessage(content, logId, timestamp) {
+  _formatUserMessage(normalizedPayload, logId, timestamp) {
     const element = createFromTemplate('userMessageTemplate');
     if (!element) return null;
 
@@ -1328,8 +1321,7 @@ export class LogEntryFormatter {
 
     const contentElem = element.querySelector('.user-message-content');
     if (contentElem) {
-      const decodedContent =
-        typeof content === 'string' ? decodeHtml(content) : '';
+      const decodedContent = normalizedPayload?.decodedText || '';
       contentElem.textContent = decodedContent;
       if (logId) contentElem.dataset.logId = logId;
     }


### PR DESCRIPTION
## Summary
- simplify tool-call parsing to trust normalized payloads and use a single catch point for malformed inputs
- trim progress view normalization layers by reusing decoded data, simplifying timestamp formatting, and tightening tool log handling
- drop legacy toggle-state migration in the history view to keep workspace state lean

## Testing
- npm run format
- npm run compile *(warning about existing nunjucks dynamic dependency)*
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e264b247883249ee6da9bab30fdf0)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Centralizes tool-call normalization and error handling, updates progress/history views to consume normalized payloads with consistent timestamps, and simplifies history toggle state and file listing filters.
> 
> - **Agent/Core**:
>   - **Tool call normalization**: Replace schema-based parsing with lightweight `normalizeToolCallPayload`, add `toolCall`, `toolCallPayload`, and `toolNormalizationError` to cycle state, and route dispatch through stored normalization (with unified error path).
>   - **Logging**: Emit structured tool-use logs using sanitized results; remove ad‑hoc JSON parsing paths.
> - **Progress View**:
>   - **Payload handling**: Introduce `normalizeStructuredContent`; formatters now consume `message.normalizedPayload` for thinking, toolUse, modelResponse, etc.
>   - **Tool-use rendering**: Consolidate parsing via `normalizeToolUseLog`; simpler value formatting and diagnostics truncation.
>   - **Timestamps/Markdown**: Use shared Intl formatters and a cached Markdown renderer.
> - **History View**:
>   - **Toggle state**: Drop `ToggleStates` class; store as plain object with `setToggleState/getToggleState`; update renderers/search manager accordingly.
> - **File Listing (VS Code)**:
>   - **Filters**: Add `sanitizeDirectories`, refactor to `prepareFilters`, and build exclude patterns from sanitized dirs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7fb09ec39e684232c86148f795a5cce52b83d74a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->