### PR TITLE
Restore progress view empty-state reminder

### DIFF
--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -69,7 +69,15 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
    */
   _updatePlaceholderVisibility() {
     const logContent = document.getElementById(ELEMENT_IDS.LOG_CONTENT);
-    if (!state.activeStream && logContent.children.length === 0) {
+    if (!logContent) {
+      return;
+    }
+
+    const hasContent = Array.from(logContent.children).some(
+      (child) => child.id !== ELEMENT_IDS.LOG_PLACEHOLDER,
+    );
+
+    if (!state.activeStream && !hasContent) {
       dom.placeholder.show();
     } else {
       dom.placeholder.hide();


### PR DESCRIPTION
## Summary
- adjust progress view placeholder visibility check so the empty-state reminder remains visible when no runs are present

## Testing
- npm run format
- npm run compile
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f4b6533288324a1e8f4e0f9ddf617)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts progress view empty-state logic to ignore the placeholder element and safely handle missing log container.
> 
> - **Progress View**:
>   - **Placeholder visibility**: Compute `hasContent` by ignoring `ELEMENT_IDS.LOG_PLACEHOLDER`; show placeholder only when no `state.activeStream` and no actual content.
>   - **Null safety**: Early return if `document.getElementById(ELEMENT_IDS.LOG_CONTENT)` is missing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 64d8f340024711dd035c4437b5b33e6935773a5b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->