### PR TITLE
Simplify URI-derived file locations

### DIFF
--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -152,6 +152,11 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
     // Initialize fileService first so we can use it below
     this.fileService = new TaskRunFileService(context.executionId);
 
+    const workspaceRoot = WorkspaceFS.getUri();
+    if (!workspaceRoot) {
+      throw new Error('Workspace path is not available.');
+    }
+
     this.outputFile = new Array<AgentFileLocation>(numRounds);
     this.outputFiles = {};
     for (let i = 0; i < numRounds; i++) {
@@ -162,12 +167,12 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
     this.baseFiles =
       this.agentConfig.outputFiles.length > 0
         ? this.agentConfig.outputFiles.map((f) =>
-            createWorkspaceLocation(WorkspaceFS.fullPath(f), f),
+            createWorkspaceLocation(WorkspaceFS.fullUri(f), workspaceRoot),
           )
         : [
             createWorkspaceLocation(
-              WorkspaceFS.fullPath(this.agentConfig.inputFile),
-              this.agentConfig.inputFile,
+              WorkspaceFS.fullUri(this.agentConfig.inputFile),
+              workspaceRoot,
             ),
           ];
 

--- a/src/commands/files/fileSelectionCommands.ts
+++ b/src/commands/files/fileSelectionCommands.ts
@@ -190,7 +190,7 @@ async function selectEditedFile(): Promise<string | null> {
 async function getCurrentFile(): Promise<string | null> {
   const currentFile = vscode.window.activeTextEditor?.document;
   if (currentFile && currentFile.uri.scheme === 'file') {
-    return WorkspaceFS.relativePath(currentFile.uri.fsPath);
+    return WorkspaceFS.relativePath(currentFile.uri);
   }
   return null;
 }

--- a/src/commands/latex/compareCommands.ts
+++ b/src/commands/latex/compareCommands.ts
@@ -58,8 +58,8 @@ async function handleCompare(
     }
 
     // Create URIs for diff editor
-    const baseUri = vscode.Uri.file(fileToUseLocation.absolutePath);
-    const editedUri = vscode.Uri.file(editedLocation.absolutePath);
+    const baseUri = fileToUseLocation.absoluteUri;
+    const editedUri = editedLocation.absoluteUri;
 
     // Create title for the diff editor
     const baseFileName = path.basename(fileToUseLocation.absolutePath);

--- a/src/commands/system/textEditorCommands.ts
+++ b/src/commands/system/textEditorCommands.ts
@@ -34,7 +34,7 @@ async function handleTestTextEditor(): Promise<void> {
       return;
     }
 
-    const filePath = WorkspaceFS.relativePath(editor.document.fileName);
+    const filePath = WorkspaceFS.relativePath(editor.document.uri);
     logger.info(CHANNEL, `Testing text editor tool with file: ${filePath}`);
 
     // Get command to test

--- a/src/housekeeping/utils.ts
+++ b/src/housekeeping/utils.ts
@@ -2,6 +2,7 @@
 import * as path from 'path';
 
 // Third-party imports
+import * as vscode from 'vscode';
 import { sync as globSync } from 'glob';
 
 // Local imports - log
@@ -80,7 +81,7 @@ export function findFilesFromPatterns(
           nodir: true,
         });
         if (matches.length > 0) {
-          results.add(WorkspaceFS.relativePath(matches[0]));
+          results.add(WorkspaceFS.relativePath(vscode.Uri.file(matches[0])));
           break;
         }
       }

--- a/src/latex/arxivProcessor.ts
+++ b/src/latex/arxivProcessor.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import { pipeline } from 'node:stream/promises';
 
 // Third-party imports
+import * as vscode from 'vscode';
 import axios from 'axios';
 import * as arxivIdentifiers from 'identifiers-arxiv';
 import * as tar from 'tar';
@@ -229,7 +230,9 @@ export class ArxivSourceProcessor {
       }
     } else {
       // For non-archive files, rename to main.tex and move to paper root
-      const downloadedRel = WorkspaceFS.relativePath(downloadedPath);
+      const downloadedRel = WorkspaceFS.relativePath(
+        vscode.Uri.file(downloadedPath),
+      );
       const targetRel = path.join(paperDirRelative, 'main.tex');
       // Always move the file to paper root, even if already named main.tex
       if (downloadedRel !== targetRel) {

--- a/src/latex/arxivProcessor.ts
+++ b/src/latex/arxivProcessor.ts
@@ -230,10 +230,10 @@ export class ArxivSourceProcessor {
       }
     } else {
       // For non-archive files, rename to main.tex and move to paper root
-      const downloadedRel = WorkspaceFS.relativePath(
-        vscode.Uri.file(downloadedPath),
+      const downloadedRel = path.normalize(
+        WorkspaceFS.relativePath(vscode.Uri.file(downloadedPath)),
       );
-      const targetRel = path.join(paperDirRelative, 'main.tex');
+      const targetRel = path.normalize(path.join(paperDirRelative, 'main.tex'));
       // Always move the file to paper root, even if already named main.tex
       if (downloadedRel !== targetRel) {
         await WorkspaceFS.rename(downloadedRel, targetRel);

--- a/src/latex/extractFigure.ts
+++ b/src/latex/extractFigure.ts
@@ -1,10 +1,13 @@
 // Standard library imports
 import * as path from 'path';
 
+// Third-party imports
+import * as vscode from 'vscode';
+
 // Local imports - log
 import { toErrorMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
-import { flexibleFS } from '@utils/files';
+import { createExternalLocation, flexibleFS } from '@utils/files';
 import type { FileLocation } from '@utils/files';
 
 const CHANNEL = 'LaTeXCommands';
@@ -101,10 +104,9 @@ export async function extractFigurePathsFromLatex(
             const pathToCheck = normPath + ext;
 
             if (
-              await flexibleFS.exists({
-                kind: 'external',
-                absolutePath: pathToCheck,
-              })
+              await flexibleFS.exists(
+                createExternalLocation(vscode.Uri.file(pathToCheck)),
+              )
             ) {
               const relative = path.relative(latexDir, pathToCheck);
               if (!discovered.has(relative)) {

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -411,7 +411,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
       resolvedRunId ?? this.provider.state.getExecutionId(stream);
 
     try {
-      let directoryToReveal: string | undefined;
+      let directoryToReveal: vscode.Uri | undefined;
 
       if (executionId) {
         await ensureRunDir(executionId);
@@ -424,7 +424,9 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
               info.location.kind === 'runStorage' ||
               info.location.kind === 'workspace'
             ) {
-              directoryToReveal = path.dirname(info.location.absolutePath);
+              directoryToReveal = vscode.Uri.file(
+                path.dirname(info.location.absolutePath),
+              );
               break;
             }
           }
@@ -439,9 +441,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
         return;
       }
 
-      await safeExecuteCommand('revealFileInOS', [
-        vscode.Uri.file(directoryToReveal),
-      ]);
+      await safeExecuteCommand('revealFileInOS', [directoryToReveal]);
     } catch (error) {
       const errorMessage = toErrorMessage(error);
       this.logger.error(

--- a/src/test/agent/core/ResponseCycleBackground.test.ts
+++ b/src/test/agent/core/ResponseCycleBackground.test.ts
@@ -368,8 +368,8 @@ describe('ResponseCycle background reasoning logs', () => {
       },
       messages,
       outputLocation: createWorkspaceLocation(
-        WorkspaceFS.fullPath('output.txt'),
-        'output.txt',
+        WorkspaceFS.fullUri('output.txt'),
+        WorkspaceFS.getUri() ?? vscode.Uri.file(process.cwd()),
       ),
       store,
     });

--- a/src/test/agent/utils/debugMessageSaver.test.ts
+++ b/src/test/agent/utils/debugMessageSaver.test.ts
@@ -8,6 +8,7 @@ import type { ExecutionId } from '@agent/types/IdentifierTypes';
 import { maybeSaveDebugObject } from '@agent/utils/debugMessageSaver';
 import * as configModule from '@utils/config';
 import { WorkspaceFS, StorageFS } from '@utils/files';
+import type { PathInput } from '@utils/files/baseFS';
 import { TASK_RUNS_DIR } from '@utils/files/taskRunStorage';
 
 describe('maybeSaveDebugObject', () => {
@@ -45,23 +46,26 @@ describe('maybeSaveDebugObject', () => {
     infoLogs = [];
     errorLogs = [];
 
-    storageFs.writeJson = async (relativePath, value) => {
-      storageWrites.push({ relativePath, value });
+    storageFs.writeJson = async (relativePath: PathInput, value) => {
+      storageWrites.push({ relativePath: relativePath.toString(), value });
     };
 
-    storageFs.ensureDir = async (relativePath) => {
-      ensured.push(relativePath);
+    storageFs.ensureDir = async (relativePath: PathInput) => {
+      ensured.push(relativePath.toString());
     };
 
-    storageFs.fullPath = (relativePath) =>
-      path.join('/mock/storage', relativePath);
+    storageFs.fullPath = (relativePath: PathInput) =>
+      path.join('/mock/storage', relativePath.toString());
 
-    workspaceFs.writeJson = async (relativePath, value) => {
-      workspaceWrites.push({ relativePath, value });
+    workspaceFs.writeJson = async (relativePath: PathInput, value) => {
+      workspaceWrites.push({
+        relativePath: relativePath.toString(),
+        value,
+      });
     };
 
-    workspaceFs.fullPath = (relativePath) =>
-      path.join('/mock/workspace', relativePath);
+    workspaceFs.fullPath = (relativePath: PathInput) =>
+      path.join('/mock/workspace', relativePath.toString());
 
     (configModule as { getConfig: typeof originalGetConfig }).getConfig = ((
       key: string,

--- a/src/test/agent/utils/promptUtils.test.ts
+++ b/src/test/agent/utils/promptUtils.test.ts
@@ -8,6 +8,7 @@ import { writePromptToXml } from '@agent/utils/promptUtils';
 import type { ExecutionId } from '@agent/types/IdentifierTypes';
 // Internal imports
 import { StorageFS, TASK_RUNS_DIR, WorkspaceFS } from '@utils/files';
+import type { PathInput } from '@utils/files/baseFS';
 
 describe('promptUtils.writePromptToXml', () => {
   type StorageFsMutable = {
@@ -45,23 +46,23 @@ describe('promptUtils.writePromptToXml', () => {
     ensured = [];
     workspaceWrites = [];
 
-    storageFs.write = async (relativePath, content) => {
-      writes.push({ relativePath, content });
+    storageFs.write = async (relativePath: PathInput, content) => {
+      writes.push({ relativePath: relativePath.toString(), content });
     };
 
-    storageFs.ensureDir = async (relativePath) => {
-      ensured.push(relativePath);
+    storageFs.ensureDir = async (relativePath: PathInput) => {
+      ensured.push(relativePath.toString());
     };
 
-    storageFs.fullPath = (relativePath) =>
-      path.join('/mock/storage', relativePath);
+    storageFs.fullPath = (relativePath: PathInput) =>
+      path.join('/mock/storage', relativePath.toString());
 
-    workspaceFs.write = async (relativePath, content) => {
-      workspaceWrites.push({ relativePath, content });
+    workspaceFs.write = async (relativePath: PathInput, content) => {
+      workspaceWrites.push({ relativePath: relativePath.toString(), content });
     };
 
-    workspaceFs.fullPath = (relativePath) =>
-      path.join('/mock/workspace', relativePath);
+    workspaceFs.fullPath = (relativePath: PathInput) =>
+      path.join('/mock/workspace', relativePath.toString());
   });
 
   afterEach(() => {

--- a/src/test/tools/ArxivDownloadTool.test.ts
+++ b/src/test/tools/ArxivDownloadTool.test.ts
@@ -1,6 +1,9 @@
 // Node.js built-in imports
 import * as assert from 'assert';
 
+// Third-party imports
+import * as vscode from 'vscode';
+
 // Local imports - tools
 import { LsTool } from '@tools/ls';
 import { toolResult } from '@tools/result';
@@ -76,7 +79,7 @@ describe('ArxivDownloadTool', () => {
       WorkspaceFS as unknown as {
         relativePath: typeof originalRelativePath;
       }
-    ).relativePath = () => 'sample';
+    ).relativePath = (_uri: vscode.Uri) => 'sample';
 
     (
       LsTool.prototype as unknown as {

--- a/src/test/utils/files/RelativeFSJson.test.ts
+++ b/src/test/utils/files/RelativeFSJson.test.ts
@@ -3,6 +3,7 @@ import * as assert from 'assert';
 import * as os from 'os';
 import * as path from 'path';
 import { promises as fs } from 'fs';
+import * as vscode from 'vscode';
 
 // Local imports - utils
 import { RelativeFS } from '@utils/files/relativeFS';
@@ -10,8 +11,8 @@ import { RelativeFS } from '@utils/files/relativeFS';
 const BASE_DIR = path.join(os.tmpdir(), 'texra-relativefs-json-tests');
 
 class TestRelativeFS extends RelativeFS {
-  protected static override getBasePath(): string {
-    return BASE_DIR;
+  protected static override getBaseUri(): vscode.Uri {
+    return vscode.Uri.file(BASE_DIR);
   }
 }
 

--- a/src/tools/arxiv/ArxivDownloadTool.ts
+++ b/src/tools/arxiv/ArxivDownloadTool.ts
@@ -1,4 +1,5 @@
 // Third-party imports
+import * as vscode from 'vscode';
 import { z } from 'zod';
 
 // Local imports - tools
@@ -46,7 +47,7 @@ export class ArxivDownloadTool extends defineTool({
       );
     }
 
-    const relativeRaw = WorkspaceFS.relativePath(downloadPath);
+    const relativeRaw = WorkspaceFS.relativePath(vscode.Uri.file(downloadPath));
     // WorkspaceFS.relativePath returns an empty string for the workspace root; normalise to '.' for tooling.
     const relativePath = relativeRaw === '' ? '.' : relativeRaw;
     const displayPath = toPosixPath(relativePath);

--- a/src/utils/dialogs.ts
+++ b/src/utils/dialogs.ts
@@ -56,7 +56,7 @@ export async function selectFiles(
   });
 
   return fileUris && fileUris.length > 0
-    ? fileUris.map((uri) => WorkspaceFS.relativePath(uri.fsPath))
+    ? fileUris.map((uri) => WorkspaceFS.relativePath(uri))
     : null;
 }
 

--- a/src/utils/editor/activeFileGuards.ts
+++ b/src/utils/editor/activeFileGuards.ts
@@ -86,7 +86,7 @@ export async function getActiveEditorWithGuards(
     }
   }
 
-  const relativePath = WorkspaceFS.relativePath(editor.document.fileName);
+  const relativePath = WorkspaceFS.relativePath(editor.document.uri);
 
   return {
     status: 'ok',

--- a/src/utils/files/absoluteFS.ts
+++ b/src/utils/files/absoluteFS.ts
@@ -1,23 +1,28 @@
 // Standard library imports
 import * as path from 'path';
 
+// Third-party imports
+import * as vscode from 'vscode';
+
 // Local imports - filesystem
-import { BaseFS } from './baseFS';
+import { BaseFS, type PathInput } from './baseFS';
 
 /**
  * Filesystem helper for absolute paths.
  */
 export class AbsoluteFS extends BaseFS {
-  protected static override resolvePath(target: string): string {
+  protected static override resolvePath(target: PathInput): PathInput {
     return target;
   }
 
   protected static override validateResolvedPath(
-    resolvedPath: string,
-    original: string,
+    resolvedPath: PathInput,
+    original: PathInput,
   ): void {
-    if (!path.isAbsolute(resolvedPath)) {
-      throw new Error(`Path must be absolute: ${original}`);
+    const candidate =
+      resolvedPath instanceof vscode.Uri ? resolvedPath.fsPath : resolvedPath;
+    if (!path.isAbsolute(candidate)) {
+      throw new Error(`Path must be absolute: ${candidate}`);
     }
   }
 }

--- a/src/utils/files/baseFS.ts
+++ b/src/utils/files/baseFS.ts
@@ -8,7 +8,7 @@ import * as vscode from 'vscode';
 // Local imports - utils
 import { ensureDirCommon } from './ensureDirCommon';
 
-type PathInput = string;
+export type PathInput = vscode.Uri | string;
 
 /**
  * Shared filesystem helpers backed by VS Code's workspace API.
@@ -18,26 +18,33 @@ type PathInput = string;
  */
 export abstract class BaseFS {
   /** Resolve caller supplied path to an absolute filesystem path. */
-  protected static resolvePath(target: PathInput): string {
+  protected static resolvePath(target: PathInput): PathInput {
     return target;
   }
 
   /** Allow subclasses to enforce additional invariants on resolved paths. */
   protected static validateResolvedPath(
-    _resolvedPath: string,
-    _original: string,
+    _resolvedPath: PathInput,
+    _original: PathInput,
   ): void {
     // Default implementation performs no validation.
   }
 
-  private static preparePath(this: typeof BaseFS, target: PathInput): string {
+  private static preparePath(
+    this: typeof BaseFS,
+    target: PathInput,
+  ): vscode.Uri {
     const resolved = this.resolvePath(target);
     this.validateResolvedPath(resolved, target);
-    return resolved;
+    if (resolved instanceof vscode.Uri) {
+      return resolved;
+    }
+
+    return vscode.Uri.file(resolved);
   }
 
   protected static toUri(this: typeof BaseFS, target: PathInput): vscode.Uri {
-    return vscode.Uri.file(this.preparePath(target));
+    return this.preparePath(target);
   }
 
   // ===== Async Methods =====
@@ -87,7 +94,7 @@ export abstract class BaseFS {
   ): Promise<void> {
     const data =
       typeof content === 'string' ? Buffer.from(content, 'utf-8') : content;
-    await fs.promises.appendFile(this.preparePath(target), data);
+    await fs.promises.appendFile(this.toUri(target).fsPath, data);
   }
 
   public static async delete(
@@ -198,15 +205,15 @@ export abstract class BaseFS {
   // ===== Sync Methods =====
 
   public static existsSync(this: typeof BaseFS, target: PathInput): boolean {
-    return fs.existsSync(this.preparePath(target));
+    return fs.existsSync(this.toUri(target).fsPath);
   }
 
   public static readSync(this: typeof BaseFS, target: PathInput): string {
-    return fs.readFileSync(this.preparePath(target), 'utf-8');
+    return fs.readFileSync(this.toUri(target).fsPath, 'utf-8');
   }
 
   public static readBytesSync(this: typeof BaseFS, target: PathInput): Buffer {
-    return fs.readFileSync(this.preparePath(target));
+    return fs.readFileSync(this.toUri(target).fsPath);
   }
 
   public static writeSync(
@@ -215,14 +222,14 @@ export abstract class BaseFS {
     content: string | Buffer,
   ): void {
     if (typeof content === 'string') {
-      fs.writeFileSync(this.preparePath(target), content, 'utf-8');
+      fs.writeFileSync(this.toUri(target).fsPath, content, 'utf-8');
       return;
     }
-    fs.writeFileSync(this.preparePath(target), content);
+    fs.writeFileSync(this.toUri(target).fsPath, content);
   }
 
   public static deleteSync(this: typeof BaseFS, target: PathInput): void {
-    fs.unlinkSync(this.preparePath(target));
+    fs.unlinkSync(this.toUri(target).fsPath);
   }
 
   public static mkdirSync(
@@ -230,7 +237,7 @@ export abstract class BaseFS {
     target: PathInput,
     options?: { recursive?: boolean },
   ): void {
-    fs.mkdirSync(this.preparePath(target), options);
+    fs.mkdirSync(this.toUri(target).fsPath, options);
   }
 
   public static ensureDirSync(this: typeof BaseFS, target: PathInput): void {
@@ -240,11 +247,11 @@ export abstract class BaseFS {
   }
 
   public static readDirSync(this: typeof BaseFS, target: PathInput): string[] {
-    return fs.readdirSync(this.preparePath(target));
+    return fs.readdirSync(this.toUri(target).fsPath);
   }
 
   public static statSync(this: typeof BaseFS, target: PathInput): fs.Stats {
-    return fs.statSync(this.preparePath(target));
+    return fs.statSync(this.toUri(target).fsPath);
   }
 
   // ===== Stream Methods =====
@@ -265,7 +272,7 @@ export abstract class BaseFS {
           highWaterMark?: number;
         }),
   ): fs.ReadStream {
-    return fs.createReadStream(this.preparePath(target), options);
+    return fs.createReadStream(this.toUri(target).fsPath, options);
   }
 
   public static createWriteStream(
@@ -282,7 +289,7 @@ export abstract class BaseFS {
           start?: number;
         }),
   ): fs.WriteStream {
-    return fs.createWriteStream(this.preparePath(target), options);
+    return fs.createWriteStream(this.toUri(target).fsPath, options);
   }
 
   public static unlink(
@@ -290,13 +297,17 @@ export abstract class BaseFS {
     target: PathInput,
     callback: (err: NodeJS.ErrnoException | null) => void,
   ): void {
-    fs.unlink(this.preparePath(target), callback);
+    fs.unlink(this.toUri(target).fsPath, callback);
   }
 
   // ===== Utility helpers =====
 
   public static fullPath(this: typeof BaseFS, target: PathInput): string {
-    return this.preparePath(target);
+    return this.toUri(target).fsPath;
+  }
+
+  public static fullUri(this: typeof BaseFS, target: PathInput): vscode.Uri {
+    return this.toUri(target);
   }
 }
 

--- a/src/utils/files/ensureDirCommon.ts
+++ b/src/utils/files/ensureDirCommon.ts
@@ -1,13 +1,16 @@
 // Third-party imports
 import * as vscode from 'vscode';
 
+// Local imports - filesystem
+import type { PathInput } from './baseFS';
+
 /**
  * Ensure a directory exists by checking and creating as needed.
  */
 export async function ensureDirCommon(
-  path: string,
-  exists: (p: string) => Promise<boolean>,
-  createDir: (p: string) => Promise<void>,
+  path: PathInput,
+  exists: (p: PathInput) => Promise<boolean>,
+  createDir: (p: PathInput) => Promise<void>,
 ): Promise<void> {
   try {
     const existsResult = await exists(path);

--- a/src/utils/files/flexibleFS.ts
+++ b/src/utils/files/flexibleFS.ts
@@ -1,6 +1,3 @@
-// Standard library imports
-import * as path from 'path';
-
 // Local imports - log
 import * as logger from '@logger/logUtils';
 
@@ -18,7 +15,7 @@ logger.initialize(CHANNEL);
  */
 export class FlexibleFS {
   exists(target: FileLocation): Promise<boolean> {
-    return AbsoluteFS.exists(target.absolutePath);
+    return AbsoluteFS.exists(target.absoluteUri);
   }
 
   /**
@@ -42,25 +39,25 @@ export class FlexibleFS {
   }
 
   read(target: FileLocation): Promise<string> {
-    return AbsoluteFS.read(target.absolutePath);
+    return AbsoluteFS.read(target.absoluteUri);
   }
 
   readBytes(target: FileLocation): Promise<Buffer> {
-    return AbsoluteFS.readBytes(target.absolutePath);
+    return AbsoluteFS.readBytes(target.absoluteUri);
   }
 
   appendFile(
     target: FileLocation,
     content: string | Uint8Array,
   ): Promise<void> {
-    return AbsoluteFS.appendFile(target.absolutePath, content);
+    return AbsoluteFS.appendFile(target.absoluteUri, content);
   }
 
   async write(
     target: FileLocation,
     content: string | Uint8Array,
   ): Promise<void> {
-    const absolutePath = target.absolutePath;
+    const absolutePath = target.absoluteUri;
 
     try {
       await AbsoluteFS.write(absolutePath, content);
@@ -76,7 +73,7 @@ export class FlexibleFS {
           : content.byteLength;
       logger.warn(
         CHANNEL,
-        `Detected circular symlink while writing ${absolutePath}, replaced with file (${replacementSize} bytes)`,
+        `Detected circular symlink while writing ${absolutePath.fsPath}, replaced with file (${replacementSize} bytes)`,
       );
       await AbsoluteFS.delete(absolutePath, {
         recursive: true,
@@ -87,18 +84,18 @@ export class FlexibleFS {
   }
 
   async ensureDir(target: FileLocation): Promise<void> {
-    await AbsoluteFS.ensureDir(target.absolutePath);
+    await AbsoluteFS.ensureDir(target.absoluteUri);
   }
 
   async delete(
     target: FileLocation,
     options?: { recursive?: boolean; useTrash?: boolean },
   ): Promise<void> {
-    await AbsoluteFS.delete(target.absolutePath, options);
+    await AbsoluteFS.delete(target.absoluteUri, options);
   }
 
   stat(target: FileLocation) {
-    return AbsoluteFS.stat(target.absolutePath);
+    return AbsoluteFS.stat(target.absoluteUri);
   }
 }
 

--- a/src/utils/files/relativeFS.ts
+++ b/src/utils/files/relativeFS.ts
@@ -1,5 +1,6 @@
 // Third-party imports
 import * as vscode from 'vscode';
+import path from 'path';
 
 // Local imports - filesystem
 import { BaseFS, type PathInput } from './baseFS';
@@ -15,8 +16,14 @@ export abstract class RelativeFS extends BaseFS {
       return target;
     }
 
-    const value = target.toString();
-    return vscode.Uri.joinPath(base, value);
+    const normalized = path.normalize(target.toString());
+    const segments = normalized.split(/\\|\//).filter(Boolean);
+
+    if (path.isAbsolute(normalized)) {
+      return vscode.Uri.file(normalized);
+    }
+
+    return vscode.Uri.joinPath(base, ...segments);
   }
 
   public static async writeJson<T>(target: PathInput, value: T): Promise<void> {

--- a/src/utils/files/relativeFS.ts
+++ b/src/utils/files/relativeFS.ts
@@ -1,37 +1,36 @@
-// Standard library imports
-import * as path from 'path';
-
 // Third-party imports
 import * as vscode from 'vscode';
 
 // Local imports - filesystem
-import { BaseFS } from './baseFS';
+import { BaseFS, type PathInput } from './baseFS';
 
 export abstract class RelativeFS extends BaseFS {
-  protected static getBasePath(): string {
+  protected static getBaseUri(): vscode.Uri {
     throw new Error('Relative filesystem requires a base path.');
   }
 
-  protected static override resolvePath(target: string): string {
-    return path.join(this.getBasePath(), target);
+  protected static override resolvePath(target: PathInput): PathInput {
+    const base = this.getBaseUri();
+    if (target instanceof vscode.Uri) {
+      return target;
+    }
+
+    const value = target.toString();
+    return vscode.Uri.joinPath(base, value);
   }
 
-  public static override fullPath(target: string): string {
-    return super.fullPath(target);
-  }
-
-  public static async writeJson<T>(target: string, value: T): Promise<void> {
+  public static async writeJson<T>(target: PathInput, value: T): Promise<void> {
     const json = JSON.stringify(value, null, 2);
     await this.write(target, json);
   }
 
-  public static async readJson<T>(target: string): Promise<T> {
+  public static async readJson<T>(target: PathInput): Promise<T> {
     const raw = await this.read(target);
     return JSON.parse(raw) as T;
   }
 
   public static async cleanupOldFiles(
-    target: string,
+    target: PathInput,
     maxAgeMs: number,
   ): Promise<void> {
     const entries = await this.readDir(target);
@@ -41,7 +40,7 @@ export abstract class RelativeFS extends BaseFS {
       entries
         .filter(([, type]) => type === vscode.FileType.File)
         .map(async ([name]) => {
-          const filePath = path.join(target, name);
+          const filePath = vscode.Uri.joinPath(this.toUri(target), name);
           const stats = await this.stat(filePath);
           if (stats.mtime <= cutoff) {
             await this.delete(filePath);

--- a/src/utils/files/storageFS.ts
+++ b/src/utils/files/storageFS.ts
@@ -21,25 +21,25 @@ export class StorageFS extends RelativeFS {
   /**
    * Return the workspace storage base path (per-workspace)
    */
-  protected static override getBasePath(): string {
+  protected static override getBaseUri(): vscode.Uri {
     if (!this.context?.storageUri) {
       throw new Error(
         'StorageFS not initialized. Call StorageFS.initialize(context) first.',
       );
     }
-    return this.context.storageUri.fsPath;
+    return this.context.storageUri;
   }
 
   /**
    * Get the global storage base path (shared across workspaces)
    */
-  public static getGlobalPath(): string {
+  public static getGlobalUri(): vscode.Uri {
     if (!this.context?.globalStorageUri) {
       throw new Error(
         'StorageFS not initialized. Call StorageFS.initialize(context) first.',
       );
     }
-    return this.context.globalStorageUri.fsPath;
+    return this.context.globalStorageUri;
   }
 
   // Inherit file operations from RelativeFS
@@ -50,8 +50,8 @@ export class StorageFS extends RelativeFS {
  * Extends StorageFS but uses global storage paths instead of workspace storage.
  */
 export class GlobalStorageFS extends RelativeFS {
-  protected static override getBasePath(): string {
-    return StorageFS.getGlobalPath();
+  protected static override getBaseUri(): vscode.Uri {
+    return StorageFS.getGlobalUri();
   }
 }
 

--- a/src/utils/files/taskRunStorage.ts
+++ b/src/utils/files/taskRunStorage.ts
@@ -2,6 +2,9 @@
 import * as path from 'path';
 import { promises as fs } from 'fs';
 
+// Third-party imports
+import * as vscode from 'vscode';
+
 // Local imports - log
 import type { ExecutionId } from '@agent/types/IdentifierTypes';
 
@@ -33,8 +36,9 @@ export const TASK_RUNS_DIR = 'taskRuns';
  */
 export interface WorkspaceFileLocation {
   kind: 'workspace';
-  absolutePath: string;
-  relativePath: string;
+  absoluteUri: vscode.Uri;
+  readonly absolutePath: string;
+  readonly relativePath: string;
 }
 
 /**
@@ -42,8 +46,9 @@ export interface WorkspaceFileLocation {
  */
 export interface RunStorageFileLocation {
   kind: 'runStorage';
-  absolutePath: string;
-  relativePath: string;
+  absoluteUri: vscode.Uri;
+  readonly absolutePath: string;
+  readonly relativePath: string;
   executionId: string;
 }
 
@@ -52,7 +57,8 @@ export interface RunStorageFileLocation {
  */
 export interface ExternalFileLocation {
   kind: 'external';
-  absolutePath: string;
+  absoluteUri: vscode.Uri;
+  readonly absolutePath: string;
 }
 
 /**
@@ -69,37 +75,88 @@ export type FileLocation =
  */
 export type AgentFileLocation = WorkspaceFileLocation | RunStorageFileLocation;
 
-export function createWorkspaceLocation(
-  absolutePath: string,
-  relativePath: string,
-): WorkspaceFileLocation {
-  return {
-    kind: 'workspace',
-    absolutePath,
-    relativePath,
+type LocationParams =
+  | { kind: 'workspace'; absoluteUri: vscode.Uri; baseUri: vscode.Uri }
+  | {
+      kind: 'runStorage';
+      absoluteUri: vscode.Uri;
+      baseUri: vscode.Uri;
+      executionId: string;
+    }
+  | { kind: 'external'; absoluteUri: vscode.Uri };
+
+function relativeFromBase(
+  absoluteUri: vscode.Uri,
+  baseUri: vscode.Uri,
+): string {
+  return path.relative(baseUri.fsPath, absoluteUri.fsPath);
+}
+
+function createFileLocation(params: LocationParams): FileLocation {
+  const { absoluteUri } = params;
+
+  const base = {
+    absoluteUri,
+    get absolutePath() {
+      return absoluteUri.fsPath;
+    },
   };
+
+  if (params.kind === 'external') {
+    return { ...base, kind: params.kind } satisfies ExternalFileLocation;
+  }
+
+  if (params.kind === 'workspace') {
+    return {
+      ...base,
+      kind: params.kind,
+      get relativePath() {
+        return relativeFromBase(absoluteUri, params.baseUri);
+      },
+    } satisfies WorkspaceFileLocation;
+  }
+
+  return {
+    ...base,
+    kind: params.kind,
+    executionId: params.executionId,
+    get relativePath() {
+      return relativeFromBase(absoluteUri, params.baseUri);
+    },
+  } satisfies RunStorageFileLocation;
+}
+
+export function createWorkspaceLocation(
+  absoluteUri: vscode.Uri,
+  baseUri: vscode.Uri,
+): WorkspaceFileLocation {
+  return createFileLocation({
+    kind: 'workspace',
+    absoluteUri,
+    baseUri,
+  }) as WorkspaceFileLocation;
 }
 
 export function createRunStorageLocation(
-  absolutePath: string,
-  relativePath: string,
+  absoluteUri: vscode.Uri,
+  baseUri: vscode.Uri,
   executionId: string,
 ): RunStorageFileLocation {
-  return {
+  return createFileLocation({
     kind: 'runStorage',
-    absolutePath,
-    relativePath,
+    absoluteUri,
+    baseUri,
     executionId,
-  };
+  }) as RunStorageFileLocation;
 }
 
 export function createExternalLocation(
-  absolutePath: string,
+  absoluteUri: vscode.Uri,
 ): ExternalFileLocation {
-  return {
+  return createFileLocation({
     kind: 'external',
-    absolutePath,
-  };
+    absoluteUri,
+  }) as ExternalFileLocation;
 }
 
 /**
@@ -107,8 +164,9 @@ export function createExternalLocation(
  * @param id - The execution ID for the task run
  * @returns The full path to the task run directory
  */
-export function getRunDir(id: ExecutionId): string {
-  return StorageFS.fullPath(path.join(TASK_RUNS_DIR, id));
+export function getRunDir(id: ExecutionId): vscode.Uri {
+  const runRoot = StorageFS.fullUri(TASK_RUNS_DIR);
+  return vscode.Uri.joinPath(runRoot, id);
 }
 
 /**
@@ -116,23 +174,27 @@ export function getRunDir(id: ExecutionId): string {
  */
 function getRunStoragePaths(
   id: ExecutionId,
-  workspaceRelative: string,
-): { absolute: string; storageRelative: string; runRelative: string } {
-  const relative = workspaceRelative ? path.normalize(workspaceRelative) : '';
-  const storageRelative = path.join(TASK_RUNS_DIR, id, relative);
+  workspaceRelative: string | string[],
+): { absolute: vscode.Uri; runRoot: vscode.Uri } {
+  const segments = Array.isArray(workspaceRelative)
+    ? workspaceRelative.filter(Boolean)
+    : workspaceRelative.replace(/\\/g, '/').split('/').filter(Boolean);
+  const runRoot = getRunDir(id);
+  const absolute =
+    segments.length > 0 ? vscode.Uri.joinPath(runRoot, ...segments) : runRoot;
+
   return {
-    absolute: StorageFS.fullPath(storageRelative),
-    storageRelative,
-    runRelative: relative,
+    absolute,
+    runRoot,
   };
 }
 
-async function ensureParentDir(filePath: string): Promise<void> {
-  const parentDir = path.dirname(filePath);
-  await fs.mkdir(parentDir, { recursive: true });
+async function ensureParentDir(filePath: vscode.Uri): Promise<void> {
+  const parentDir = vscode.Uri.file(path.dirname(filePath.fsPath));
+  await AbsoluteFS.ensureDir(parentDir);
 }
 
-async function removeIfExists(target: string): Promise<void> {
+async function removeIfExists(target: vscode.Uri): Promise<void> {
   if (await AbsoluteFS.exists(target)) {
     await AbsoluteFS.delete(target, { recursive: true, useTrash: false });
   }
@@ -140,17 +202,17 @@ async function removeIfExists(target: string): Promise<void> {
 
 async function createSymlink(
   source: FileLocation,
-  destination: string,
+  destination: vscode.Uri,
 ): Promise<void> {
-  const sourceAbsolute = source.absolutePath;
+  const sourceAbsolute = source.absoluteUri.fsPath;
   await ensureParentDir(destination);
   try {
-    await fs.symlink(sourceAbsolute, destination);
+    await fs.symlink(sourceAbsolute, destination.fsPath);
   } catch (error) {
     const err = error as NodeJS.ErrnoException;
     if (err.code === 'EEXIST') {
-      await fs.rm(destination, { recursive: true, force: true });
-      await fs.symlink(sourceAbsolute, destination);
+      await fs.rm(destination.fsPath, { recursive: true, force: true });
+      await fs.symlink(sourceAbsolute, destination.fsPath);
       return;
     }
     if (
@@ -159,13 +221,13 @@ async function createSymlink(
     ) {
       logger.warn(
         CHANNEL,
-        `Falling back to copy ${sourceAbsolute} -> ${destination} due to ${err.code}`,
+        `Falling back to copy ${sourceAbsolute} -> ${destination.fsPath} due to ${err.code}`,
       );
       const stats = await fs.lstat(sourceAbsolute);
       if (stats.isDirectory()) {
-        await fs.cp(sourceAbsolute, destination, { recursive: true });
+        await fs.cp(sourceAbsolute, destination.fsPath, { recursive: true });
       } else {
-        await fs.copyFile(sourceAbsolute, destination);
+        await fs.copyFile(sourceAbsolute, destination.fsPath);
       }
       return;
     }
@@ -186,31 +248,25 @@ function shouldSkipRelocation(relativePath: string): boolean {
     return false;
   }
 
-  const segments = relativePath.split(path.sep).filter(Boolean);
-  if (segments.length === 0) {
-    return false;
-  }
-
-  return IGNORED_WORKSPACE_ROOTS.has(segments[0]);
+  const [first] = relativePath.replace(/\\/g, '/').split('/').filter(Boolean);
+  return first ? IGNORED_WORKSPACE_ROOTS.has(first) : false;
 }
 
 export class TaskRunFileService {
-  private useRunStorage: boolean;
-  public metadata: {
+  private runContext: {
     mode: 'workspace' | 'taskRunStorage';
-    executionId: ExecutionId | undefined;
-    runDirectory: string | undefined;
+    executionId?: ExecutionId;
+    runDirectory?: vscode.Uri;
   };
   private hasPreparedSnapshot = false;
   private readonly mirroredDependencies = new Set<string>();
 
   constructor(executionId?: ExecutionId) {
-    this.metadata = {
+    this.runContext = {
       mode: 'workspace',
       executionId: undefined,
       runDirectory: undefined,
     };
-    this.useRunStorage = false;
     this.updateRunContext(executionId);
   }
 
@@ -229,14 +285,15 @@ export class TaskRunFileService {
       shouldUseRunStorage && executionId ? getRunDir(executionId) : undefined;
 
     const contextChanged =
-      this.metadata.mode !== nextMode ||
-      this.metadata.executionId !== executionId ||
-      this.metadata.runDirectory !== nextRunDirectory;
+      this.runContext.mode !== nextMode ||
+      this.runContext.executionId !== executionId ||
+      this.runContext.runDirectory !== nextRunDirectory;
 
-    this.metadata.mode = nextMode;
-    this.metadata.executionId = executionId ?? undefined;
-    this.metadata.runDirectory = nextRunDirectory;
-    this.useRunStorage = shouldUseRunStorage;
+    this.runContext = {
+      mode: nextMode,
+      executionId: executionId ?? undefined,
+      runDirectory: nextRunDirectory,
+    };
 
     if (contextChanged) {
       this.hasPreparedSnapshot = false;
@@ -248,21 +305,25 @@ export class TaskRunFileService {
     this.applyExecutionContext(executionId ?? undefined);
   }
 
-  private get workspaceRoot(): string | undefined {
-    return WorkspaceFS.getPath();
+  private get isRunStorageMode(): boolean {
+    return this.runContext.mode === 'taskRunStorage';
+  }
+
+  private get workspaceRoot(): vscode.Uri | undefined {
+    return WorkspaceFS.getUri();
   }
 
   // Direct access to activeExecutionId for internal use
   private get activeExecutionId(): ExecutionId | undefined {
-    return this.metadata.executionId;
+    return this.runContext.executionId;
   }
 
   public getExecutionId(): ExecutionId | undefined {
-    return this.metadata.executionId;
+    return this.runContext.executionId;
   }
 
   public hasRunDirectory(): boolean {
-    return Boolean(this.metadata.runDirectory);
+    return Boolean(this.runContext.runDirectory);
   }
 
   private async ensureRunDirectory(): Promise<void> {
@@ -295,7 +356,7 @@ export class TaskRunFileService {
       return;
     }
 
-    if (!this.useRunStorage) {
+    if (!this.isRunStorageMode) {
       return;
     }
 
@@ -306,7 +367,11 @@ export class TaskRunFileService {
     await this.ensureRunDirectory();
 
     const linkTargets = new Set<FileLocation>();
-    const workspaceRoot = WorkspaceFS.getPath()!;
+    const workspaceRoot = this.workspaceRoot;
+    if (!workspaceRoot) {
+      return;
+    }
+
     const registerLink = (candidate?: string | null) => {
       if (!candidate) {
         return;
@@ -315,9 +380,8 @@ export class TaskRunFileService {
       if (trimmed.length === 0) {
         return;
       }
-      // Convert absolute path to FileLocation
-      const relativePath = path.relative(workspaceRoot, trimmed);
-      linkTargets.add(createWorkspaceLocation(trimmed, relativePath));
+      const candidateUri = vscode.Uri.file(trimmed);
+      linkTargets.add(createWorkspaceLocation(candidateUri, workspaceRoot));
     };
 
     if (options.mirrorBaseFiles !== false) {
@@ -346,26 +410,29 @@ export class TaskRunFileService {
       }
 
       try {
-        const stats = await fs.stat(sourceLocation.absolutePath);
+        const stats = await fs.stat(sourceLocation.absoluteUri.fsPath);
         if (!stats.isFile()) {
           return;
         }
 
-        const snapshotRelative = path.join(
+        const snapshotSegments = [
           'original',
-          sourceLocation.relativePath,
-        );
-        const snapshotPaths = getRunStoragePaths(executionId, snapshotRelative);
+          ...sourceLocation.relativePath
+            .replace(/\\/g, '/')
+            .split('/')
+            .filter(Boolean),
+        ];
+        const snapshotPaths = getRunStoragePaths(executionId, snapshotSegments);
 
         try {
-          await fs.stat(snapshotPaths.absolute);
+          await fs.stat(snapshotPaths.absolute.fsPath);
           return;
         } catch (error) {
           const err = error as NodeJS.ErrnoException;
           if (err.code && err.code !== 'ENOENT') {
             throw Object.assign(
               new Error(
-                `Failed to inspect snapshot destination ${snapshotPaths.absolute}: ${err.message}`,
+                `Failed to inspect snapshot destination ${snapshotPaths.absolute.fsPath}: ${err.message}`,
               ),
               { cause: err },
             );
@@ -373,7 +440,10 @@ export class TaskRunFileService {
         }
 
         await ensureParentDir(snapshotPaths.absolute);
-        await fs.copyFile(sourceLocation.absolutePath, snapshotPaths.absolute);
+        await fs.copyFile(
+          sourceLocation.absoluteUri.fsPath,
+          snapshotPaths.absolute.fsPath,
+        );
       } catch (error) {
         const err = error as NodeJS.ErrnoException;
         if (err?.code === 'ENOENT') {
@@ -423,25 +493,35 @@ export class TaskRunFileService {
   public createLocation(relativePath: string): FileLocation {
     const workspaceRoot = this.workspaceRoot;
     if (!workspaceRoot) {
-      return createExternalLocation(relativePath);
+      const absolute = path.isAbsolute(relativePath)
+        ? vscode.Uri.file(path.normalize(relativePath))
+        : vscode.Uri.file(path.resolve(relativePath));
+      return createExternalLocation(absolute);
     }
 
     // Normalize path separators for current platform (idempotent - safe to call on normalized paths)
     const normalized = relativePath ? path.normalize(relativePath) : '';
-    const workspaceAbsolute = path.join(workspaceRoot, normalized);
+    const segments = normalized.split(/\\|\//).filter(Boolean);
+    const workspaceAbsolute =
+      segments.length > 0
+        ? vscode.Uri.joinPath(workspaceRoot, ...segments)
+        : workspaceRoot;
 
     // Check if run storage is enabled
     const executionId = this.activeExecutionId;
-    if (executionId && this.useRunStorage) {
-      const runDir = this.metadata.runDirectory;
+    if (executionId && this.isRunStorageMode) {
+      const runDir = this.runContext.runDirectory;
       if (runDir) {
-        const runAbsolute = path.join(runDir, normalized);
-        return createRunStorageLocation(runAbsolute, normalized, executionId);
+        const runAbsolute =
+          segments.length > 0
+            ? vscode.Uri.joinPath(runDir, ...segments)
+            : runDir;
+        return createRunStorageLocation(runAbsolute, runDir, executionId);
       }
     }
 
     // Default to workspace location
-    return createWorkspaceLocation(workspaceAbsolute, normalized);
+    return createWorkspaceLocation(workspaceAbsolute, workspaceRoot);
   }
 
   /**
@@ -474,7 +554,7 @@ export class TaskRunFileService {
 
     return createRunStorageLocation(
       runPaths.absolute,
-      runPaths.runRelative,
+      runPaths.runRoot,
       executionId,
     );
   }
@@ -488,7 +568,9 @@ export class TaskRunFileService {
  */
 export async function ensureRunDir(id: ExecutionId): Promise<void> {
   await StorageFS.ensureDir(TASK_RUNS_DIR);
-  await StorageFS.ensureDir(path.join(TASK_RUNS_DIR, id));
+  await StorageFS.ensureDir(
+    vscode.Uri.joinPath(StorageFS.fullUri(TASK_RUNS_DIR), id),
+  );
 }
 
 /**
@@ -514,39 +596,54 @@ export function getComparablePath(location: FileLocation): string {
  * @param target - Absolute or workspace-relative path
  * @returns FileLocation (workspace or external, never runStorage)
  */
-export function pathToLocation(target: string): FileLocation {
+export function pathToLocation(target: string | vscode.Uri): FileLocation {
   if (!target) {
-    // Empty strings should resolve to workspace root or error
-    const workspaceRoot = WorkspaceFS.getPath();
+    const workspaceRoot = WorkspaceFS.getUri();
     if (!workspaceRoot) {
       throw new Error('Cannot resolve empty path without workspace');
     }
-    return createWorkspaceLocation(workspaceRoot, '');
+    return createWorkspaceLocation(workspaceRoot, workspaceRoot);
+  }
+
+  if (target instanceof vscode.Uri) {
+    const workspaceRoot = WorkspaceFS.getUri();
+    if (workspaceRoot) {
+      const relative = WorkspaceFS.relativePath(target);
+      const workspaceCandidate = path.isAbsolute(relative)
+        ? undefined
+        : relative;
+      if (workspaceCandidate !== undefined && !relative.startsWith('..')) {
+        return createWorkspaceLocation(target, workspaceRoot);
+      }
+    }
+    return createExternalLocation(target);
   }
 
   if (!path.isAbsolute(target)) {
-    const workspaceRoot = WorkspaceFS.getPath();
+    const workspaceRoot = WorkspaceFS.getUri();
     if (!workspaceRoot) {
-      // Relative path without workspace: resolve to absolute using process.cwd()
       const absolutePath = path.resolve(target);
-      return createExternalLocation(absolutePath);
+      return createExternalLocation(vscode.Uri.file(absolutePath));
     }
-    // path.join() normalizes automatically
-    const absolutePath = path.join(workspaceRoot, target);
-    return createWorkspaceLocation(absolutePath, target);
+
+    const normalized = path.normalize(target);
+    const segments = normalized.split(/\\|\//).filter(Boolean);
+    const absolute =
+      segments.length > 0
+        ? vscode.Uri.joinPath(workspaceRoot, ...segments)
+        : workspaceRoot;
+    return createWorkspaceLocation(absolute, workspaceRoot);
   }
 
-  // Normalize only at entry point from external strings
   const normalized = path.normalize(target);
-
-  // Check if in workspace
-  const workspaceRoot = WorkspaceFS.getPath();
+  const absoluteUri = vscode.Uri.file(normalized);
+  const workspaceRoot = WorkspaceFS.getUri();
   if (workspaceRoot) {
-    const relative = path.relative(workspaceRoot, normalized);
+    const relative = WorkspaceFS.relativePath(absoluteUri);
     if (!relative.startsWith('..') && !path.isAbsolute(relative)) {
-      return createWorkspaceLocation(normalized, relative);
+      return createWorkspaceLocation(absoluteUri, workspaceRoot);
     }
   }
 
-  return createExternalLocation(normalized);
+  return createExternalLocation(absoluteUri);
 }

--- a/src/utils/files/taskRunStorage.ts
+++ b/src/utils/files/taskRunStorage.ts
@@ -380,7 +380,10 @@ export class TaskRunFileService {
       if (trimmed.length === 0) {
         return;
       }
-      const candidateUri = vscode.Uri.file(trimmed);
+      // Resolve relative paths against workspace root
+      const candidateUri = path.isAbsolute(trimmed)
+        ? vscode.Uri.file(trimmed)
+        : vscode.Uri.joinPath(workspaceRoot, trimmed);
       linkTargets.add(createWorkspaceLocation(candidateUri, workspaceRoot));
     };
 

--- a/src/utils/files/workspaceFS.ts
+++ b/src/utils/files/workspaceFS.ts
@@ -1,6 +1,3 @@
-// Standard library imports
-import * as path from 'path';
-
 // Third-party imports
 import * as vscode from 'vscode';
 
@@ -9,21 +6,38 @@ import { AbsoluteFS } from './absoluteFS';
 import { RelativeFS } from './relativeFS';
 
 export class WorkspaceFS extends RelativeFS {
-  protected static override getBasePath(): string {
+  private static workspaceFolder: vscode.WorkspaceFolder | undefined;
+
+  private static getWorkspaceFolder(): vscode.WorkspaceFolder {
     const folder = vscode.workspace.workspaceFolders?.[0];
     if (!folder) {
       throw new Error('Workspace path is not available.');
     }
-    return folder.uri.fsPath;
+    if (
+      !this.workspaceFolder ||
+      this.workspaceFolder.uri.toString() !== folder.uri.toString()
+    ) {
+      this.workspaceFolder = folder;
+    }
+    return this.workspaceFolder;
+  }
+
+  protected static override getBaseUri(): vscode.Uri {
+    return this.getWorkspaceFolder().uri;
   }
 
   public static getPath(): string | undefined {
-    return vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+    return this.getUri()?.fsPath;
   }
 
-  public static relativePath(filePath: string): string {
-    const base = this.getPath();
-    return base ? path.relative(base, filePath) : filePath;
+  public static getUri(): vscode.Uri | undefined {
+    return (
+      this.workspaceFolder?.uri ?? vscode.workspace.workspaceFolders?.[0]?.uri
+    );
+  }
+
+  public static relativePath(filePath: vscode.Uri): string {
+    return vscode.workspace.asRelativePath(filePath, false);
   }
 
   public static async existsAndNonTrivial(target: string): Promise<boolean> {

--- a/src/utils/files/workspaceFS.ts
+++ b/src/utils/files/workspaceFS.ts
@@ -38,8 +38,12 @@ export class WorkspaceFS extends RelativeFS {
   }
 
   public static relativePath(filePath: vscode.Uri): string {
-    const base = this.getBaseUri().fsPath;
-    const relative = path.relative(base, filePath.fsPath);
+    const baseUri = this.getUri();
+    if (!baseUri) {
+      // No workspace available - return the file path as-is
+      return filePath.fsPath;
+    }
+    const relative = path.relative(baseUri.fsPath, filePath.fsPath);
     return relative ? path.normalize(relative) : '';
   }
 

--- a/src/utils/files/workspaceFS.ts
+++ b/src/utils/files/workspaceFS.ts
@@ -1,5 +1,6 @@
 // Third-party imports
 import * as vscode from 'vscode';
+import path from 'path';
 
 // Local imports - filesystem
 import { AbsoluteFS } from './absoluteFS';
@@ -37,7 +38,9 @@ export class WorkspaceFS extends RelativeFS {
   }
 
   public static relativePath(filePath: vscode.Uri): string {
-    return vscode.workspace.asRelativePath(filePath, false);
+    const base = this.getBaseUri().fsPath;
+    const relative = path.relative(base, filePath.fsPath);
+    return relative ? path.normalize(relative) : '';
   }
 
   public static async existsAndNonTrivial(target: string): Promise<boolean> {

--- a/src/webview/managers/FileManager.ts
+++ b/src/webview/managers/FileManager.ts
@@ -488,7 +488,7 @@ export class FileManager {
       }
 
       const relativePaths = fileUris.map((uri) =>
-        WorkspaceFS.relativePath(uri.fsPath),
+        WorkspaceFS.relativePath(uri),
       );
       logger.info(
         CHANNEL,


### PR DESCRIPTION
## Summary
- derive file locations from URI bases with getter-backed relative paths and a shared creation helper
- streamline run storage path assembly and TaskRunFileService context handling to avoid duplicate state and string round trips
- standardize WorkspaceFS relativePath on URIs and update callers and tests accordingly

## Testing
- npm run format
- npm run lint -- --quiet
- npm run compile

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e3f4f53708324b763a392ee97a77b)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches filesystem and file-location APIs to URI-based paths, streamlines task-run storage and location creation, and updates commands, LaTeX tools, and tests accordingly.
> 
> - **Filesystem Core (major refactor)**:
>   - Introduce `PathInput` (`vscode.Uri | string`) and make `BaseFS`, `RelativeFS`, `AbsoluteFS` operate on URIs; add `fullUri` helper.
>   - Update `WorkspaceFS` to use `getUri()` and make `relativePath` accept `vscode.Uri`.
> - **Task-Run Storage & File Locations**:
>   - Redesign `FileLocation` to carry `absoluteUri` with getter-backed `absolutePath`/`relativePath`.
>   - Add creators `createWorkspaceLocation`, `createRunStorageLocation`, `createExternalLocation` using URIs; compute relatives from base URIs.
>   - Refactor `TaskRunFileService` context and run-dir handling to URIs; snapshot/mirroring logic uses URI paths; `ensureRunDir`/`getRunDir` return URIs.
>   - Make `flexibleFS` use `absoluteUri` for all ops.
>   - Update `pathToLocation` to accept `string | vscode.Uri` with workspace-aware resolution.
> - **Agents/Commands/UI**:
>   - `BaseReflectionAgent`: construct base files via `WorkspaceFS.fullUri(...)` and workspace root URI.
>   - Commands (`fileSelection`, `textEditorCommands`, `compareCommands`) and dialogs use URI-based `WorkspaceFS.relativePath` and `absoluteUri` for diffs/open dialogs.
>   - Progress view open-storage action now reveals URI directory directly.
> - **LaTeX Utilities/Tools**:
>   - `arxivProcessor`, `extractFigure`, and `ArxivDownloadTool` adopt URI-based relative path resolution and existence checks.
> - **Tests**:
>   - Update unit tests to new signatures (`PathInput`, URI-based `relativePath`, `getBaseUri`) and constructors; adjust stubs accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6b0943359192a7456e3a99895ec6bcd50a34779c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->