### PR TITLE
Fix progress output run identifiers

### DIFF
--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -832,6 +832,7 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
                   'Run group identifier is required for reflection runs.',
                 );
               }
+              this.outputHandler.setActiveRun(runStage.id);
               return runStage;
             },
             resetPromptBuilder: () => this.resetPromptBuilder(),

--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -192,7 +192,6 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
       this.fileService,
       this.executionId,
     );
-    this.outputHandler.setActiveRun(this.executionId ?? null);
 
     this.latexMediaManager = new LatexMediaManager(
       this.logger,

--- a/src/agent/modelHandlers/modelHandlerKimi.ts
+++ b/src/agent/modelHandlers/modelHandlerKimi.ts
@@ -9,9 +9,10 @@ import { MediaEntry } from '@agent/utils/mediaTypes';
 import { formatProviderHttpError } from '@common/errors/sdkErrorUtils';
 import { MESSAGE_TYPES } from '@logger/messageTypes';
 import { K_SLICE } from '@utils/config';
+import { BaseReasoningStreamAggregator } from './BaseReasoningStreamAggregator';
 import { ModelHandlerOpenAI } from './modelHandlerOpenAI';
-import type { CreateResponseOptions } from './types/IModelHandler';
 import { toOpenAITools } from './toolConversion';
+import type { CreateResponseOptions } from './types/IModelHandler';
 import type {
   ChatCompletion,
   ChatCompletionChunk,
@@ -22,7 +23,6 @@ import type { ContentDeltaEvent } from 'openai/lib/ChatCompletionStream';
 // Internal imports
 
 // Local file imports
-import { BaseReasoningStreamAggregator } from './BaseReasoningStreamAggregator';
 
 /**
  * Handler for Moonshot Kimi models using OpenAI-compatible API.

--- a/src/agent/output/OutputHandler.ts
+++ b/src/agent/output/OutputHandler.ts
@@ -195,7 +195,7 @@ export class OutputHandler implements IOutputHandler {
   private getActiveRunId(): string {
     const loggerRunId = this.logger.withCurrentGroup((id) => id);
     if (loggerRunId && loggerRunId !== this.currentRunId) {
-      this.currentRunId = loggerRunId;
+      this.setActiveRun(loggerRunId);
     }
 
     return normalizeRunId(this.currentRunId);
@@ -475,9 +475,12 @@ export class OutputHandler implements IOutputHandler {
     runId: string | null | undefined,
     rounds: Map<number, OutputFileInfo[]>,
   ): void {
-    const normalizedRunId = runId ?? this.logger.withCurrentGroup((id) => id);
-    if (normalizedRunId !== this.currentRunId) {
-      this.setActiveRun(normalizedRunId ?? null);
+    const loggerRunId = this.logger.withCurrentGroup((id) => id);
+    const effectiveRunId = runId ?? loggerRunId ?? null;
+    const normalizedCurrent = normalizeRunId(this.currentRunId);
+    const normalizedTarget = normalizeRunId(effectiveRunId);
+    if (normalizedTarget !== normalizedCurrent) {
+      this.setActiveRun(effectiveRunId);
     }
 
     for (const [round, infos] of rounds.entries()) {

--- a/src/agent/output/OutputHandler.ts
+++ b/src/agent/output/OutputHandler.ts
@@ -92,7 +92,7 @@ export class OutputHandler implements IOutputHandler {
   private readonly openedOutputs: Set<string>;
   private readonly fileService: TaskRunFileService;
   private readonly executionId?: string;
-  private currentRunId: string | null;
+  private currentRunId: string | null | undefined;
   private runPreparation: Promise<void> | null;
 
   constructor(
@@ -130,10 +130,11 @@ export class OutputHandler implements IOutputHandler {
     );
     this.diffStatsManager = new DiffStatsManager();
     this.openedOutputs = new Set();
-    this.currentRunId = null;
+    this.currentRunId = undefined;
     this.runPreparation = null;
 
-    this.setActiveRun(this.executionId ?? null);
+    const initialRunId = this.logger.withCurrentGroup((id) => id);
+    this.setActiveRun(initialRunId ?? null);
   }
 
   private collectRunSnapshotFiles(): FileLocation[] {
@@ -172,7 +173,7 @@ export class OutputHandler implements IOutputHandler {
     this.fileService.updateRunContext(targetExecutionId ?? undefined);
 
     const loggerRunId = this.logger.withCurrentGroup((id) => id);
-    const nextRunId = runId ?? loggerRunId ?? targetExecutionId ?? null;
+    const nextRunId = runId ?? loggerRunId ?? null;
     if (nextRunId === this.currentRunId) {
       return;
     }

--- a/src/agent/output/OutputHandler.ts
+++ b/src/agent/output/OutputHandler.ts
@@ -171,7 +171,8 @@ export class OutputHandler implements IOutputHandler {
       this.executionId ?? this.fileService.getExecutionId();
     this.fileService.updateRunContext(targetExecutionId ?? undefined);
 
-    const nextRunId = runId ?? targetExecutionId ?? null;
+    const loggerRunId = this.logger.withCurrentGroup((id) => id);
+    const nextRunId = runId ?? loggerRunId ?? targetExecutionId ?? null;
     if (nextRunId === this.currentRunId) {
       return;
     }
@@ -192,6 +193,11 @@ export class OutputHandler implements IOutputHandler {
   }
 
   private getActiveRunId(): string {
+    const loggerRunId = this.logger.withCurrentGroup((id) => id);
+    if (loggerRunId && loggerRunId !== this.currentRunId) {
+      this.currentRunId = loggerRunId;
+    }
+
     return normalizeRunId(this.currentRunId);
   }
 
@@ -469,9 +475,9 @@ export class OutputHandler implements IOutputHandler {
     runId: string | null | undefined,
     rounds: Map<number, OutputFileInfo[]>,
   ): void {
-    const normalizedRunId = runId ?? this.currentRunId ?? null;
+    const normalizedRunId = runId ?? this.logger.withCurrentGroup((id) => id);
     if (normalizedRunId !== this.currentRunId) {
-      this.setActiveRun(normalizedRunId);
+      this.setActiveRun(normalizedRunId ?? null);
     }
 
     for (const [round, infos] of rounds.entries()) {

--- a/src/agent/output/OutputHandler.ts
+++ b/src/agent/output/OutputHandler.ts
@@ -20,6 +20,7 @@ import { openBuildDisplayIfTex } from '@frontend/latex/openBuild';
 import { showInstructionWithSuppress } from '@frontend/ui/instruction';
 import { AgentLogger, type AgentLogStage } from '@logger/AgentLogger';
 import { MESSAGE_TYPES } from '@logger/messageTypes';
+import { normalizeRunId } from '@progressView/constants/runIds';
 import {
   replaceInputCommands,
   createFileMapping,
@@ -188,6 +189,10 @@ export class OutputHandler implements IOutputHandler {
     } else {
       this.runPreparation = null;
     }
+  }
+
+  private getActiveRunId(): string {
+    return normalizeRunId(this.currentRunId);
   }
 
   private async prepareRunWorkspaceIfNeeded(): Promise<void> {
@@ -504,12 +509,14 @@ export class OutputHandler implements IOutputHandler {
       `Validate expected r${currRound}`,
       stage,
       async () => {
+        const executionId = this.fileService.getExecutionId();
+        const runId = this.getActiveRunId();
         const expected = this.agentConfig.outputFiles;
         if (!expected || expected.length === 0) {
           bus.emit('updateMissingOutputs', {
             stream: this.channel,
-            groupId: this.currentRunId ?? undefined,
-            executionId: this.fileService.getExecutionId(),
+            runId,
+            executionId,
             filesByRound: { [currRound]: [] },
           });
           return;
@@ -551,8 +558,8 @@ export class OutputHandler implements IOutputHandler {
 
         bus.emit('updateMissingOutputs', {
           stream: this.channel,
-          groupId: this.currentRunId ?? undefined,
-          executionId: this.fileService.getExecutionId(),
+          runId,
+          executionId,
           filesByRound: { [currRound]: missing },
         });
       },
@@ -580,6 +587,8 @@ export class OutputHandler implements IOutputHandler {
 
         const fileInfos = await this.gatherOutputFileInfo(currRound);
         data.outputs = fileInfos;
+        const executionId = this.fileService.getExecutionId();
+        const runId = this.getActiveRunId();
 
         if (endTurn) {
           try {
@@ -596,8 +605,8 @@ export class OutputHandler implements IOutputHandler {
 
         bus.emit('addOutputFiles', {
           stream: this.channel,
-          groupId: this.currentRunId ?? undefined,
-          executionId: this.fileService.getExecutionId(),
+          runId,
+          executionId,
           filesByRound: { [currRound]: fileInfos },
         });
 
@@ -639,6 +648,8 @@ export class OutputHandler implements IOutputHandler {
         const rawLocation = data.rawOutput ?? outputLocation;
         data.rawOutput = rawLocation;
         const rawPath = rawLocation.absolutePath;
+        const executionId = this.fileService.getExecutionId();
+        const runId = this.getActiveRunId();
 
         const handleMultipleOutputs = async () => {
           this.logger.debug(
@@ -767,8 +778,8 @@ export class OutputHandler implements IOutputHandler {
             this.logger.missingOutputs(missingOutputsData);
             bus.emit('updateMissingOutputs', {
               stream: this.channel,
-              groupId: this.currentRunId ?? undefined,
-              executionId: this.fileService.getExecutionId(),
+              runId,
+              executionId,
               filesByRound: { [currRound]: [] },
             });
             this.setRoundOutputs(currRound, []);

--- a/src/agent/output/OutputHandler.ts
+++ b/src/agent/output/OutputHandler.ts
@@ -178,13 +178,12 @@ export class OutputHandler implements IOutputHandler {
       this.executionId ?? this.fileService.getExecutionId();
     this.fileService.updateRunContext(targetExecutionId ?? undefined);
 
-    const loggerRunId = this.logger.withCurrentGroup((id) => id);
-    const nextRunId = runId ?? loggerRunId ?? null;
+    const nextRunId = runId ?? null;
     const previousRunId = this.currentRunId;
     this.logger.debug(
-      `setActiveRun(runId=${normalizeRunId(runId)} loggerRunId=${normalizeRunId(loggerRunId)} prev=${normalizeRunId(
-        previousRunId,
-      )} next=${normalizeRunId(nextRunId)} executionId=${targetExecutionId ?? 'none'})`,
+      `setActiveRun(runId=${normalizeRunId(runId)} prev=${normalizeRunId(previousRunId)} next=${normalizeRunId(
+        nextRunId,
+      )} executionId=${targetExecutionId ?? 'none'})`,
       { messageType: MESSAGE_TYPES.INTERNAL },
     );
     if (nextRunId === this.currentRunId) {
@@ -207,15 +206,6 @@ export class OutputHandler implements IOutputHandler {
   }
 
   private getActiveRunId(): string {
-    const loggerRunId = this.logger.withCurrentGroup((id) => id);
-    if (loggerRunId && loggerRunId !== this.currentRunId) {
-      this.logger.debug(
-        `Logger group changed: current=${normalizeRunId(this.currentRunId)} logger=${normalizeRunId(loggerRunId)}`,
-        { messageType: MESSAGE_TYPES.INTERNAL },
-      );
-      this.setActiveRun(loggerRunId);
-    }
-
     return normalizeRunId(this.currentRunId);
   }
 

--- a/src/agent/output/OutputHandler.ts
+++ b/src/agent/output/OutputHandler.ts
@@ -135,6 +135,12 @@ export class OutputHandler implements IOutputHandler {
 
     const initialRunId = this.logger.withCurrentGroup((id) => id);
     this.setActiveRun(initialRunId ?? null);
+    this.logger.debug(
+      `OutputHandler initialized with runId=${normalizeRunId(this.currentRunId)} (loggerGroup=${normalizeRunId(initialRunId)} executionId=${
+        this.executionId ?? 'none'
+      })`,
+      { messageType: MESSAGE_TYPES.INTERNAL },
+    );
   }
 
   private collectRunSnapshotFiles(): FileLocation[] {
@@ -174,6 +180,13 @@ export class OutputHandler implements IOutputHandler {
 
     const loggerRunId = this.logger.withCurrentGroup((id) => id);
     const nextRunId = runId ?? loggerRunId ?? null;
+    const previousRunId = this.currentRunId;
+    this.logger.debug(
+      `setActiveRun(runId=${normalizeRunId(runId)} loggerRunId=${normalizeRunId(loggerRunId)} prev=${normalizeRunId(
+        previousRunId,
+      )} next=${normalizeRunId(nextRunId)} executionId=${targetExecutionId ?? 'none'})`,
+      { messageType: MESSAGE_TYPES.INTERNAL },
+    );
     if (nextRunId === this.currentRunId) {
       return;
     }
@@ -196,6 +209,10 @@ export class OutputHandler implements IOutputHandler {
   private getActiveRunId(): string {
     const loggerRunId = this.logger.withCurrentGroup((id) => id);
     if (loggerRunId && loggerRunId !== this.currentRunId) {
+      this.logger.debug(
+        `Logger group changed: current=${normalizeRunId(this.currentRunId)} logger=${normalizeRunId(loggerRunId)}`,
+        { messageType: MESSAGE_TYPES.INTERNAL },
+      );
       this.setActiveRun(loggerRunId);
     }
 
@@ -480,6 +497,10 @@ export class OutputHandler implements IOutputHandler {
     const effectiveRunId = runId ?? loggerRunId ?? null;
     const normalizedCurrent = normalizeRunId(this.currentRunId);
     const normalizedTarget = normalizeRunId(effectiveRunId);
+    this.logger.debug(
+      `Hydrate outputs for runId=${normalizeRunId(runId)} loggerRunId=${normalizeRunId(loggerRunId)} current=${normalizedCurrent} target=${normalizedTarget}`,
+      { messageType: MESSAGE_TYPES.INTERNAL },
+    );
     if (normalizedTarget !== normalizedCurrent) {
       this.setActiveRun(effectiveRunId);
     }
@@ -529,6 +550,10 @@ export class OutputHandler implements IOutputHandler {
             executionId,
             filesByRound: { [currRound]: [] },
           });
+          this.logger.debug(
+            `updateMissingOutputs emitted (no expected outputs) for round ${currRound} runId=${runId} executionId=${executionId ?? 'none'}`,
+            { messageType: MESSAGE_TYPES.INTERNAL },
+          );
           return;
         }
 
@@ -572,6 +597,10 @@ export class OutputHandler implements IOutputHandler {
           executionId,
           filesByRound: { [currRound]: missing },
         });
+        this.logger.debug(
+          `updateMissingOutputs emitted with ${missing.length} missing for round ${currRound} runId=${runId} executionId=${executionId ?? 'none'}`,
+          { messageType: MESSAGE_TYPES.INTERNAL },
+        );
       },
     );
   }
@@ -619,6 +648,10 @@ export class OutputHandler implements IOutputHandler {
           executionId,
           filesByRound: { [currRound]: fileInfos },
         });
+        this.logger.debug(
+          `addOutputFiles emitted for round ${currRound} runId=${runId} executionId=${executionId ?? 'none'} files=${fileInfos.length}`,
+          { messageType: MESSAGE_TYPES.INTERNAL },
+        );
 
         for (const info of fileInfos) {
           const filePath = info.location.absolutePath;

--- a/src/eventBus/ProgressEventBus.ts
+++ b/src/eventBus/ProgressEventBus.ts
@@ -53,6 +53,12 @@ interface SetTaskStatePayload {
   taskState: TaskState;
 }
 
+interface RunScopedPayload {
+  stream: StreamTabId;
+  runId: string;
+  executionId?: ExecutionId;
+}
+
 export interface ProgressEventPayloads {
   addLogMessage: { stream: StreamTabId; logMessage: LogMessageData };
   updateLogMessage: { stream: StreamTabId; logMessage: LogMessageUpdate };
@@ -60,16 +66,10 @@ export interface ProgressEventPayloads {
   updateTaskGroup: UpdateTaskGroupPayload;
   setActiveStream: SetActiveStreamPayload;
   updateStreamStatus: { stream: StreamTabId; status: StreamStatusOrReady };
-  addOutputFiles: {
-    stream: StreamTabId;
-    groupId?: string;
-    executionId?: ExecutionId;
+  addOutputFiles: RunScopedPayload & {
     filesByRound: { [key: number]: OutputFileInfo[] };
   };
-  updateMissingOutputs: {
-    stream: StreamTabId;
-    groupId?: string;
-    executionId?: ExecutionId;
+  updateMissingOutputs: RunScopedPayload & {
     filesByRound: { [key: number]: string[] };
   };
   clearMissingOutputs: StreamTabId;

--- a/src/logger/AgentLogger.ts
+++ b/src/logger/AgentLogger.ts
@@ -257,7 +257,7 @@ export class AgentLogger {
    */
   statistics(stats: ExtendedTokenUsageStats, groupId?: string): void {
     const summary = `Usage - input: ${stats.inputTokens ?? 0}, output: ${stats.outputTokens ?? 0}`;
-    this.debug(summary, {
+    this.info(summary, {
       groupId,
       messageType: MESSAGE_TYPES.STATISTICS,
       data: stats,

--- a/src/progressView/events/OutputEvents.ts
+++ b/src/progressView/events/OutputEvents.ts
@@ -106,34 +106,34 @@ const registerOutputFileListeners = (
 ): vscode.Disposable[] => {
   const addFiles = bus.on(
     'addOutputFiles',
-    ({ stream, groupId, executionId, filesByRound }) => {
+    ({ stream, runId, executionId, filesByRound }) => {
       withErrorBoundary('failed to handle addOutputFiles', async () => {
+        const normalizedRunId = normalizeRunId(runId);
         await state.outputFiles.addFiles(
           stream,
-          groupId ?? null,
+          normalizedRunId,
           filesByRound,
           {
             executionId,
           },
         );
-        const runId = normalizeRunId(executionId ?? groupId);
-        sendRunFileUpdate(state, updater, stream, runId);
+        sendRunFileUpdate(state, updater, stream, normalizedRunId);
       });
     },
   );
 
   const updateMissing = bus.on(
     'updateMissingOutputs',
-    ({ stream, groupId, executionId, filesByRound }) => {
+    ({ stream, runId, executionId, filesByRound }) => {
       withErrorBoundary('failed to handle updateMissingOutputs', async () => {
+        const normalizedRunId = normalizeRunId(runId);
         await state.outputFiles.updateMissingOutputs(
           stream,
-          groupId ?? null,
+          normalizedRunId,
           filesByRound,
           { executionId },
         );
-        const runId = normalizeRunId(executionId ?? groupId);
-        sendRunMissingUpdate(state, updater, stream, runId);
+        sendRunMissingUpdate(state, updater, stream, normalizedRunId);
       });
     },
   );

--- a/src/progressView/managers/OutputFilesManager.ts
+++ b/src/progressView/managers/OutputFilesManager.ts
@@ -47,11 +47,11 @@ export class OutputFilesManager extends PersistentMapManager<
   /** Add output files for a stream and round */
   async addFiles(
     stream: StreamTabId,
-    groupId: string | null | undefined,
+    runId: string,
     filesByRound: { [key: number]: OutputFileInfo[] },
     options: { executionId?: ExecutionId } = {},
   ): Promise<void> {
-    const runId = normalizeRunId(options.executionId ?? groupId);
+    const normalizedRunId = normalizeRunId(runId);
 
     let streamRuns = this.items.get(stream);
     if (!streamRuns) {
@@ -59,10 +59,10 @@ export class OutputFilesManager extends PersistentMapManager<
       this.items.set(stream, streamRuns);
     }
 
-    let runRounds = streamRuns.get(runId);
+    let runRounds = streamRuns.get(normalizedRunId);
     if (!runRounds) {
       runRounds = new Map();
-      streamRuns.set(runId, runRounds);
+      streamRuns.set(normalizedRunId, runRounds);
     }
 
     for (const [round, files] of Object.entries(filesByRound)) {
@@ -90,12 +90,12 @@ export class OutputFilesManager extends PersistentMapManager<
   /** Update missing outputs for a stream */
   async updateMissingOutputs(
     stream: StreamTabId,
-    groupId: string | null | undefined,
+    runId: string,
     filesByRound: { [key: number]: string[] },
     options: { executionId?: ExecutionId } = {},
   ): Promise<void> {
     await this.ensureMissingOutputsLoaded();
-    const runId = normalizeRunId(options.executionId ?? groupId);
+    const normalizedRunId = normalizeRunId(runId);
 
     let streamMissing = this._missingOutputs.get(stream);
     if (!streamMissing) {
@@ -103,10 +103,10 @@ export class OutputFilesManager extends PersistentMapManager<
       this._missingOutputs.set(stream, streamMissing);
     }
 
-    let runMissing = streamMissing.get(runId);
+    let runMissing = streamMissing.get(normalizedRunId);
     if (!runMissing) {
       runMissing = new Map();
-      streamMissing.set(runId, runMissing);
+      streamMissing.set(normalizedRunId, runMissing);
     }
 
     for (const [round, files] of Object.entries(filesByRound)) {
@@ -295,17 +295,14 @@ export class OutputFilesManager extends PersistentMapManager<
     await this.delete(stream);
   }
 
-  async clearRunFiles(
-    stream: StreamTabId,
-    groupId: string | null | undefined,
-  ): Promise<void> {
-    const runId = normalizeRunId(groupId);
+  async clearRunFiles(stream: StreamTabId, runId: string): Promise<void> {
+    const normalizedRunId = normalizeRunId(runId);
     const runs = this.items.get(stream);
     if (!runs) {
       return;
     }
 
-    const removed = runs.delete(runId);
+    const removed = runs.delete(normalizedRunId);
     if (runs.size === 0) {
       this.items.delete(stream);
     }
@@ -326,16 +323,16 @@ export class OutputFilesManager extends PersistentMapManager<
 
   async clearRunMissingOutputs(
     stream: StreamTabId,
-    groupId: string | null | undefined,
+    runId: string,
   ): Promise<void> {
     await this.ensureMissingOutputsLoaded();
-    const runId = normalizeRunId(groupId);
+    const normalizedRunId = normalizeRunId(runId);
     const runs = this._missingOutputs.get(stream);
     if (!runs) {
       return;
     }
 
-    const removed = runs.delete(runId);
+    const removed = runs.delete(normalizedRunId);
     if (runs.size === 0) {
       this._missingOutputs.delete(stream);
     }


### PR DESCRIPTION
## Summary
- require run-scoped progress events to carry an explicit runId and update listeners accordingly
- persist output and missing file state with the provided run identifier instead of mixing execution IDs
- emit output events with normalized run IDs from the output handler to keep UI state aligned

## Testing
- npm run format
- npm run compile
- npm run lint


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f52bc2844832485f8f817d1cecd4a)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enforces explicit runId across output handling and progress events, updating emitters, payload types, listeners, and persistence to normalize and track run-scoped files and missing outputs.
> 
> - **Output handling**:
>   - Normalize and track active run via `setActiveRun` and `getActiveRunId`; initialize from logger group, not executionId.
>   - Emit `addOutputFiles`/`updateMissingOutputs` with `runId` (replacing `groupId`) and add detailed debug logs.
>   - Adjust hydration to respect provided/logged runId; minor typing tweaks.
>   - Hook `setActiveRun(runStage.id)` at run start in `BaseReflectionAgent`.
> - **Event bus & types**:
>   - Introduce `RunScopedPayload`; change payloads for `addOutputFiles` and `updateMissingOutputs` to `{ stream, runId, executionId, ... }`.
> - **Progress view**:
>   - Update listeners in `OutputEvents` to use and normalize `runId`.
>   - `OutputFilesManager`: APIs now accept `runId` directly; state keyed and cleared by normalized runId only.
> - **Logging**:
>   - `AgentLogger.statistics` logs at `info` level.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1972be2c277cf18c8d7aefd2616328b908e6aabf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->