### PR TITLE
Preserve Gemini tool call thought signatures

### DIFF
--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -103,6 +103,15 @@ function findLastTextPart(
   return undefined;
 }
 
+function getThoughtSignature(part: Part): string | undefined {
+  const candidate = part as {
+    thoughtSignature?: string;
+    thought_signature?: string;
+  };
+
+  return candidate.thoughtSignature ?? candidate.thought_signature;
+}
+
 type GoogleGenerationConfig = GenerateContentConfig & {
   thinkingLevel?: 'low' | 'medium' | 'high';
 };
@@ -1084,18 +1093,32 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
     const candidate = responseObject?.candidates?.[0];
     const parts = candidate?.content?.parts;
     if (Array.isArray(parts)) {
-      const functionCalls = parts
-        .map((part) => part.functionCall)
-        .filter((call): call is FunctionCall => Boolean(call?.name));
+      const functionCalls: GoogleToolCall[] = [];
+
+      for (const part of parts) {
+        const functionCall = part.functionCall;
+        if (!functionCall?.name) {
+          continue;
+        }
+
+        const thoughtSignature = getThoughtSignature(part);
+        const rawCall = {
+          ...functionCall,
+          ...(thoughtSignature ? { thoughtSignature } : {}),
+        } as FunctionCall & { thoughtSignature?: string };
+
+        functionCalls.push({
+          provider: 'google',
+          callId: functionCall.id ?? randomUUID(),
+          name: functionCall.name!,
+          input: functionCall.args,
+          thoughtSignature,
+          raw: rawCall,
+        });
+      }
 
       if (functionCalls.length > 0) {
-        return functionCalls.map((call) => ({
-          provider: 'google',
-          callId: call.id ?? randomUUID(),
-          name: call.name!,
-          input: call.args,
-          raw: call,
-        }));
+        return functionCalls;
       }
     }
     return [];
@@ -1152,6 +1175,14 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
 
     if (callPart.functionCall) {
       callPart.functionCall.id = call.callId;
+    }
+
+    const thoughtSignature =
+      (call.raw as { thoughtSignature?: string }).thoughtSignature ??
+      call.thoughtSignature;
+    if (thoughtSignature) {
+      (callPart as { thoughtSignature?: string }).thoughtSignature =
+        thoughtSignature;
     }
 
     // Use the same ID for the result to maintain correlation

--- a/src/agent/modelHandlers/types/IModelHandler.ts
+++ b/src/agent/modelHandlers/types/IModelHandler.ts
@@ -97,6 +97,7 @@ export type GoogleToolCall = {
   callId: string;
   name: string;
   input: FunctionCall['args'];
+  thoughtSignature?: string;
   raw: FunctionCall;
 };
 

--- a/src/test/agent/modelHandlers/ModelHandlerGoogleGenAI.test.ts
+++ b/src/test/agent/modelHandlers/ModelHandlerGoogleGenAI.test.ts
@@ -33,6 +33,7 @@ import type {
   UploadFileParameters,
   FunctionCall,
   Content,
+  GenerateContentResponse,
 } from '@google/genai';
 
 interface LoggerStub extends Partial<AgentLogger> {
@@ -303,6 +304,81 @@ describe('ModelHandlerGoogleGenAI media uploads', () => {
 
     handlerMediaProcessor.mediaProcessor.loadEntries = originalLoadEntries;
     handlerMediaProcessor.mediaProcessor.logResults = originalLogResults;
+  });
+
+  it('adds thought signatures to follow-up function calls', async () => {
+    const handler = new ModelHandlerGoogleGenAI(buildGoogleConfig());
+    const { logger } = createLoggerStub();
+    handler.setLogger(logger);
+
+    const thoughtSignature = 'signature-123';
+    const rawCall = {
+      name: 'default_api:ls',
+      args: { path: '.' },
+      id: 'call-456',
+      thoughtSignature,
+    } as FunctionCall & { thoughtSignature: string };
+
+    const providerCall = {
+      provider: 'google' as const,
+      callId: rawCall.id!,
+      name: rawCall.name!,
+      input: rawCall.args,
+      thoughtSignature,
+      raw: rawCall,
+    };
+
+    const messages = await handler.createToolUseFollowUpMessages(
+      undefined,
+      providerCall,
+      {},
+    );
+
+    const callParts = messages[0].parts ?? [];
+    const callPart = callParts[callParts.length - 1] as unknown as {
+      thoughtSignature?: string;
+    };
+
+    assert.equal(callPart.thoughtSignature, thoughtSignature);
+  });
+});
+
+describe('ModelHandlerGoogleGenAI thought signatures', () => {
+  it('retains thought signatures when extracting tool calls', () => {
+    const handler = new ModelHandlerGoogleGenAI(buildGoogleConfig());
+    const { logger } = createLoggerStub();
+    handler.setLogger(logger);
+
+    const functionCall: FunctionCall = {
+      name: 'default_api:ls',
+      args: { path: '.' },
+      id: 'call-789',
+    };
+
+    const response = {
+      candidates: [
+        {
+          content: {
+            role: 'model',
+            parts: [
+              {
+                functionCall,
+                thoughtSignature: 'sig-789',
+              } as unknown as Part,
+            ],
+          },
+        },
+      ],
+    } as unknown as GenerateContentResponse;
+
+    const calls = handler.extractToolUse(response);
+
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].thoughtSignature, 'sig-789');
+    assert.equal(
+      (calls[0].raw as { thoughtSignature?: string }).thoughtSignature,
+      'sig-789',
+    );
   });
 });
 


### PR DESCRIPTION
## Summary
- capture Gemini function call thought signatures and store them on Google tool call metadata
- replay thought signatures when sending follow-up function calls back to Gemini 3 models
- add coverage to confirm extraction and follow-up messages retain the required signatures

## Testing
- npm run format
- npm run compile
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f5b5b06e08324932517859f88c2a1)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Capture Gemini tool-call thought signatures from responses, store on `GoogleToolCall`, and replay them in follow-up messages, with tests added.
> 
> - **Google GenAI handler**:
>   - Extracts `thoughtSignature` (supports `thought_signature`) from tool-call `parts` and includes it in `GoogleToolCall` and `raw`.
>   - Propagates `thoughtSignature` onto follow-up function call parts in `createToolUseFollowUpMessages`.
>   - Adds helper `getThoughtSignature`.
> - **Types**:
>   - Extend `GoogleToolCall` with optional `thoughtSignature`.
> - **Tests**:
>   - Add coverage to ensure extraction and follow-up messages retain `thoughtSignature` and verify existing media upload logic remains intact.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3b953fed537a9131beaef538dfe460b0f5274102. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->