### PR TITLE
fix: persist gemini thought signatures

### DIFF
--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -1083,22 +1083,43 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
   extractToolUse(responseObject: GenerateContentResponse): GoogleToolCall[] {
     const candidate = responseObject?.candidates?.[0];
     const parts = candidate?.content?.parts;
-    if (Array.isArray(parts)) {
-      const functionCalls = parts
-        .map((part) => part.functionCall)
-        .filter((call): call is FunctionCall => Boolean(call?.name));
-
-      if (functionCalls.length > 0) {
-        return functionCalls.map((call) => ({
-          provider: 'google',
-          callId: call.id ?? randomUUID(),
-          name: call.name!,
-          input: call.args,
-          raw: call,
-        }));
-      }
+    if (!Array.isArray(parts)) {
+      return [];
     }
-    return [];
+
+    type FunctionCallWithSignature = {
+      call: FunctionCall;
+      thoughtSignature: string | undefined;
+    };
+
+    const functionCalls = parts
+      .map<FunctionCallWithSignature | null>((part) => {
+        const call = part.functionCall;
+        if (!call?.name) {
+          return null;
+        }
+        return {
+          call,
+          thoughtSignature:
+            typeof part.thoughtSignature === 'string'
+              ? part.thoughtSignature
+              : undefined,
+        };
+      })
+      .filter((part): part is FunctionCallWithSignature => part !== null);
+
+    if (functionCalls.length === 0) {
+      return [];
+    }
+
+    return functionCalls.map(({ call, thoughtSignature }) => ({
+      provider: 'google',
+      callId: call.id ?? randomUUID(),
+      name: call.name!,
+      input: call.args,
+      raw: call,
+      thoughtSignature,
+    }));
   }
 
   private async buildAttachmentPart(
@@ -1152,6 +1173,11 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
 
     if (callPart.functionCall) {
       callPart.functionCall.id = call.callId;
+    }
+
+    if (call.thoughtSignature) {
+      (callPart as Part & { thoughtSignature: string }).thoughtSignature =
+        call.thoughtSignature;
     }
 
     // Use the same ID for the result to maintain correlation

--- a/src/agent/modelHandlers/types/IModelHandler.ts
+++ b/src/agent/modelHandlers/types/IModelHandler.ts
@@ -98,6 +98,7 @@ export type GoogleToolCall = {
   name: string;
   input: FunctionCall['args'];
   raw: FunctionCall;
+  thoughtSignature?: string;
 };
 
 export type AnthropicToolCall = {


### PR DESCRIPTION
## Summary
- capture Gemini tool-call thought signatures when extracting Google function calls
- propagate stored thought signatures when replaying function call parts for follow-up tool responses
- add optional thoughtSignature metadata to Google tool call type

## Testing
- npm run format
- npm run compile
- npm run lint
- npm test *(fails: VS Code test runner requires libgtk-3.so.0 in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f5b5b06e08324932517859f88c2a1)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds extraction of Gemini thought signatures from tool-call parts and preserves them when emitting follow-up function call messages; updates Google tool call type to include optional thoughtSignature.
> 
> - **Google GenAI handler (`modelHandlerGoogleGenAI.ts`)**:
>   - Extracts `thoughtSignature` from tool-call parts in `extractToolUse` and includes it in returned `GoogleToolCall`s.
>   - Preserves `thoughtSignature` by attaching it to the function call part in `createToolUseFollowUpMessages`.
> - **Types (`types/IModelHandler.ts`)**:
>   - Extends `GoogleToolCall` with optional `thoughtSignature?: string`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dadd56909f8ef86839103189e54af72714bb4330. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->