### PR TITLE
Preserve errored stream tab status in progress view

### DIFF
--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -176,17 +176,19 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       state.pendingFilterUpdate = false;
     }
     state.resetExecutionIdAvailability();
-    message.streams.forEach((s) => {
-      if (s.status) {
-        state.streamStatuses.set(s.name, s.status);
+    // Preserve existing statuses when updates omit them so errored streams
+    // remain marked as error instead of reverting to stopped
+    const streams = (message.streams || []).map((s) => {
+      const status =
+        s.status !== undefined ? s.status : state.streamStatuses.get(s.name);
+      if (status) {
+        state.streamStatuses.set(s.name, status);
       } else {
         state.streamStatuses.delete(s.name);
       }
       state.setExecutionIdAvailable(s.name, Boolean(s.executionId));
+      return { ...s, status };
     });
-
-    // Backend already sends filtered streams, no need to filter again
-    const streams = message.streams || [];
 
     dom.streamTabs.update(streams, message.activeStream);
 


### PR DESCRIPTION
## Summary
- preserve previously known stream statuses when update payloads omit a status field
- ensure progress view tabs and active status retain errored state instead of defaulting to stopped

## Testing
- npm run format
- npm run compile
- npm run lint
- npm test (fails: vscode-test missing libgtk-3.so.0 in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f61a8c00c83249aedbde408883399)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Preserves existing stream statuses during stream updates so errored tabs remain in error instead of reverting to stopped.
> 
> - **Progress View**:
>   - Preserve previous `state.streamStatuses` when `message.streams` entries omit `status`; compute merged `streams` with inferred `status` and pass to `dom.streamTabs.update`.
>   - Ensure errored streams remain marked as error; avoid defaulting to `STATUS.STOPPED` when status is missing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 35e5d40a6a3be77131f60ec4ef27464b0f7d9d7a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->