### PR TITLE
fix: show quick links when logs are empty

### DIFF
--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -77,7 +77,7 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       (child) => child.id !== ELEMENT_IDS.LOG_PLACEHOLDER,
     );
 
-    if (!state.activeStream && !hasContent) {
+    if (!hasContent) {
       dom.placeholder.show();
     } else {
       dom.placeholder.hide();


### PR DESCRIPTION
## Summary
- show the progress view placeholder quick links whenever the log panel has no content so empty streams still surface the starter commands

## Testing
- npm run format
- npm run compile
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f6cc7488c832493bbe9a13c9b8ef0)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Show the progress view placeholder (quick links) whenever the log panel has no content, regardless of active stream state.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 59a97a25b3b1ee289587d3ac301d3581e51fdc80. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->