### PR TITLE
Fix visibility of internal progress log messages

### DIFF
--- a/src/logger/messageTypes.ts
+++ b/src/logger/messageTypes.ts
@@ -9,7 +9,7 @@ export const MESSAGE_TYPES = {
   MODEL_RESPONSE: 'modelResponse',
   USER_MESSAGE: 'userMessage',
   PROGRESS_STATUS: 'progressStatus',
-  /** Messages that should be hidden from the progress view */
+  /** Internal/system messages used by the extension */
   INTERNAL: 'internal',
   DEFAULT: 'default',
 } as const;

--- a/src/logger/sinks/ProgressViewSink.ts
+++ b/src/logger/sinks/ProgressViewSink.ts
@@ -25,10 +25,6 @@ function isValidMessageType(type: unknown): type is MessageType {
 
 export class ProgressViewSink implements LogEventSink {
   handleLogMessage(event: LogMessageEvent): void {
-    if (event.messageType === MESSAGE_TYPES.INTERNAL) {
-      return;
-    }
-
     const debugMode = getConfig<boolean>('texra.logger.debugMode', false);
     if (event.level === 'debug' && !debugMode) {
       return;

--- a/src/progressView/events/LogEvents.ts
+++ b/src/progressView/events/LogEvents.ts
@@ -3,8 +3,6 @@ import * as vscode from 'vscode';
 
 // Local imports - progress view
 import type { LogMessageUpdate } from '@logger/LogTypes';
-// Internal imports
-import { MESSAGE_TYPES } from '@logger/messageTypes';
 // Type imports
 import type { AgentLogger } from '@logger/AgentLogger';
 import type { WebviewUpdater } from '@progressView/managers';
@@ -52,10 +50,6 @@ export function createLogEvents(shared: LogEventsShared): LogEventsModule {
         return;
       }
 
-      if (logMessage.messageType === MESSAGE_TYPES.INTERNAL) {
-        return;
-      }
-
       await state.streamTabs.addMessage(stream, logMessage);
 
       if (updater.isAvailable()) {
@@ -80,13 +74,6 @@ export function createLogEvents(shared: LogEventsShared): LogEventsModule {
 
       const existing = messages.find((m) => m.id === logMessage.id);
       if (!existing) return;
-
-      if (
-        existing.messageType === MESSAGE_TYPES.INTERNAL ||
-        logMessage.messageType === MESSAGE_TYPES.INTERNAL
-      ) {
-        return;
-      }
 
       if (logMessage.text !== undefined) {
         existing.text = logMessage.text;


### PR DESCRIPTION
## Summary
- Allow INTERNAL log messages to flow to the progress view sink and event handlers so user-facing status messages appear
- Clarify the INTERNAL message type description for future logging

## Testing
- npm run format
- npm run compile
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f767c733083248dd7f29fae49f030)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Allow `INTERNAL` log messages to appear in the Progress View by removing suppression and clarify the `INTERNAL` message type description.
> 
> - **Progress View**:
>   - Allow `INTERNAL` messages through `ProgressViewSink.handleLogMessage` (no longer filtered out).
>   - Process `INTERNAL` messages in event handlers (`addLogMessage`, `updateLogMessage`) by removing suppression checks in `src/progressView/events/LogEvents.ts`.
> - **Logging**:
>   - Clarify `MESSAGE_TYPES.INTERNAL` comment as "Internal/system messages used by the extension" in `src/logger/messageTypes.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e67c4f5f3728a23c65dc074ce7489d30a3c366ba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->