### PR TITLE
Remove extraneous OutputHandler debug logs

### DIFF
--- a/src/agent/output/OutputHandler.ts
+++ b/src/agent/output/OutputHandler.ts
@@ -135,12 +135,6 @@ export class OutputHandler implements IOutputHandler {
 
     const initialRunId = this.logger.withCurrentGroup((id) => id);
     this.setActiveRun(initialRunId ?? null);
-    this.logger.debug(
-      `OutputHandler initialized with runId=${normalizeRunId(this.currentRunId)} (loggerGroup=${normalizeRunId(initialRunId)} executionId=${
-        this.executionId ?? 'none'
-      })`,
-      { messageType: MESSAGE_TYPES.INTERNAL },
-    );
   }
 
   private collectRunSnapshotFiles(): FileLocation[] {
@@ -180,12 +174,6 @@ export class OutputHandler implements IOutputHandler {
 
     const nextRunId = runId ?? null;
     const previousRunId = this.currentRunId;
-    this.logger.debug(
-      `setActiveRun(runId=${normalizeRunId(runId)} prev=${normalizeRunId(previousRunId)} next=${normalizeRunId(
-        nextRunId,
-      )} executionId=${targetExecutionId ?? 'none'})`,
-      { messageType: MESSAGE_TYPES.INTERNAL },
-    );
     if (nextRunId === this.currentRunId) {
       return;
     }


### PR DESCRIPTION
## Summary
- remove unnecessary debug logging from OutputHandler initialization and run switching

## Testing
- npm run format
- npm run compile
- npm run lint
- npm test *(fails: vscode-test requires libgtk-3.so.0 in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f7d5ca3648324a07477d655ff135f)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes internal debug logging in `OutputHandler` constructor and `setActiveRun`.
> 
> - **Logging**:
>   - Remove `logger.debug` calls in `OutputHandler` initialization and `setActiveRun` to reduce verbosity.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d47f70de8c9e2ac1909b1a74b14c15ab0ea0423f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->