### PR TITLE
Fix internal progress view log rendering

### DIFF
--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -371,6 +371,11 @@ export class LogEntryFormatter {
           () => this._formatStatistics(message.normalizedPayload, message.id),
           'statistics',
         ),
+      internal: (message) =>
+        this._safeFormat(
+          () => this._formatInternal(message),
+          'internal message',
+        ),
       userMessage: (message) =>
         this._safeFormat(
           () =>
@@ -587,6 +592,46 @@ export class LogEntryFormatter {
       `</div>`;
 
     // Convert HTML string to DOM element
+    const wrapper = document.createElement('div');
+    wrapper.innerHTML = htmlMessage;
+    return wrapper.firstElementChild;
+  }
+
+  _formatInternal(message) {
+    const { id, level, timestamp, groupId, verbose, normalizedPayload, text } =
+      message;
+
+    const decoded = (normalizedPayload?.decodedText || '').trim();
+    const structuredText = stringifyForDisplay(
+      normalizedPayload?.structured,
+    ).trim();
+    const content = decoded || structuredText || text || '';
+
+    if (!content) {
+      return null;
+    }
+
+    const emoji = EMOJI_BY_LEVEL[level] || '•';
+    const date = new Date(timestamp);
+    const { fullTimestamp, timeDisplay, tooltipTimestamp } =
+      this._formatTimestamp(date);
+
+    const prefix = `<div class="log-line" data-log-id="${id}" ${
+      groupId ? `data-group-id="${groupId}"` : ''
+    } data-full-timestamp="${fullTimestamp}">`;
+    const levelMarkup = verbose
+      ? `<span class="level-${level}">${level.toUpperCase().padEnd(8)}</span> `
+      : '';
+
+    const htmlMessage =
+      prefix +
+      `<span class="timestamp" title="${tooltipTimestamp}">${emoji}${
+        verbose ? ` [${timeDisplay}]` : ''
+      }</span> ` +
+      levelMarkup +
+      `<span class="message-${level}">${encodeHtml(content)}</span>` +
+      `</div>`;
+
     const wrapper = document.createElement('div');
     wrapper.innerHTML = htmlMessage;
     return wrapper.firstElementChild;


### PR DESCRIPTION
## Summary
- add a dedicated formatter for internal progress messages that renders decoded text or structured payload content
- preserve log-line styling while encoding rendered content to avoid blank entries

## Testing
- npm run format
- npm run compile
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f7ea61d0c8324914f9a51e96ef8b7)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce an `internal` message formatter to render decoded/structured content with HTML-encoding while preserving log-line styling and timestamps.
> 
> - **Progress View**:
>   - **New formatter**: Add `internal` handler in `LogEntryFormatter` to render internal messages from `normalizedPayload` (decoded text or structured), HTML-encoded via `encodeHtml`.
>   - **Rendering behavior**: Preserves log-line layout (emoji, timestamp, level), skips empty content, and supports verbose level display.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2179de93450e8fa03c7fbe4baf54c592817b732b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->