### PR TITLE
Fix progress placeholder visibility when streams are active

### DIFF
--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -65,23 +65,17 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
   }
 
   /**
-   * Toggle the placeholder based on active stream and log content
+   * Toggle the placeholder based on active stream presence
    */
   _updatePlaceholderVisibility() {
-    const logContent = document.getElementById(ELEMENT_IDS.LOG_CONTENT);
-    if (!logContent) {
+    const shouldShowPlaceholder = !state.hasActiveStream();
+
+    if (shouldShowPlaceholder) {
+      dom.placeholder.show();
       return;
     }
 
-    const hasContent = Array.from(logContent.children).some(
-      (child) => child.id !== ELEMENT_IDS.LOG_PLACEHOLDER,
-    );
-
-    if (!hasContent) {
-      dom.placeholder.show();
-    } else {
-      dom.placeholder.hide();
-    }
+    dom.placeholder.hide();
   }
 
   _handleRunSelectionChange(runId) {
@@ -164,7 +158,7 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
 
   handleUpdateStreams(message) {
     try {
-      state.activeStream = message.activeStream;
+      state.setActiveStream(message.activeStream);
       if (
         !state.pendingFilterUpdate &&
         message.agentFilter !== undefined &&
@@ -189,6 +183,8 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       state.setExecutionIdAvailable(s.name, Boolean(s.executionId));
       return { ...s, status };
     });
+
+    state.setStreams(streams);
 
     dom.streamTabs.update(streams, message.activeStream);
 
@@ -666,13 +662,17 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       state.clearRunFiles(message.stream);
       state.clearRunMissingOutputs(message.stream);
       state.clearRunUsage(message.stream);
+      state.removeStream(message.stream);
       if (message.stream === state.activeStream) {
         const groupIds = Array.from(state.taskGroups.getGroupMap().keys());
         state.toggleStates.clearSelection(groupIds);
         dom.instructionPanel.hide();
         dom.runSelector.clear();
+        state.setActiveStream(null);
       }
     }
+
+    this._updatePlaceholderVisibility();
   }
 
   handleDeleteAll() {
@@ -680,11 +680,15 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     state.toggleStates.clearAll();
     state.resetExecutionIdAvailability();
     dom.instructionPanel.hide();
+    state.clearStreams();
     state.clearRunInstructions();
     state.clearRunFiles();
     state.clearRunMissingOutputs();
     state.clearAllActiveRuns();
     dom.runSelector.clear();
+
+    state.setActiveStream(null);
+    this._updatePlaceholderVisibility();
   }
 
   handleFollowUpTextPolished(message) {

--- a/src/progressView/modules/progressViewState.js
+++ b/src/progressView/modules/progressViewState.js
@@ -320,6 +320,7 @@ export class ProgressViewState {
   constructor() {
     this.stateManager = new WebviewStateManager();
     this.activeStream = '';
+    this.streams = [];
     this.agentTypeFilter = 'all';
     this.pendingFilterUpdate = false;
     this.currentGroupId = null;
@@ -367,6 +368,41 @@ export class ProgressViewState {
 
   resetExecutionIdAvailability() {
     this.executionIdAvailability.clear();
+  }
+
+  setStreams(streams) {
+    if (!Array.isArray(streams)) {
+      this.streams = [];
+      return;
+    }
+
+    this.streams = streams
+      .map((stream) => stream?.name)
+      .filter((name) => typeof name === 'string' && name);
+  }
+
+  removeStream(streamId) {
+    if (!streamId) {
+      return;
+    }
+
+    this.streams = this.streams.filter((stream) => stream !== streamId);
+  }
+
+  clearStreams() {
+    this.streams = [];
+  }
+
+  setActiveStream(streamId) {
+    this.activeStream = streamId || '';
+  }
+
+  hasActiveStream() {
+    return Boolean(this.activeStream);
+  }
+
+  hasStreams() {
+    return this.streams.length > 0;
   }
 
   /** Load saved state from VS Code storage. */


### PR DESCRIPTION
## Summary
- track streams in progress view state so placeholder visibility keys off active streams instead of DOM content
- clear stream tracking when streams are removed to restore the sample project prompt at the right time

## Testing
- npm run format
- npm run compile
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f7f4e782483248c75285f1919c0c1)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Placeholder now toggles based on active stream presence; add stream tracking in state and update handlers to maintain it on stream updates and deletions.
> 
> - **Progress View behavior**
>   - Placeholder visibility now keyed to `state.hasActiveStream()` instead of DOM content.
> - **State management (`progressViewState`)**
>   - Add stream tracking: `streams` plus `setStreams`, `removeStream`, `clearStreams`.
>   - Add `setActiveStream`, `hasActiveStream`, `hasStreams` helpers.
> - **Message handlers (`messageHandlers`)**
>   - Use `state.setActiveStream` and `state.setStreams` in `handleUpdateStreams` and refresh placeholder.
>   - On `DELETE_STREAM` and `DELETE_ALL`: remove/clear streams, reset active stream, clear related run data, and refresh placeholder.
>   - Minor wiring to keep status, UI elements, and execution availability consistent with new stream state.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit af8a1d89f402b90916a66d120119fd439ca92876. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->