### PR TITLE
Improve progress status rendering and clean up message types

### DIFF
--- a/src/logger/sinks/ProgressViewSink.ts
+++ b/src/logger/sinks/ProgressViewSink.ts
@@ -34,6 +34,10 @@ export class ProgressViewSink implements LogEventSink {
     const messageType: MessageType = isValidMessageType(event.messageType)
       ? event.messageType
       : MESSAGE_TYPES.DEFAULT;
+
+    if (messageType === MESSAGE_TYPES.INTERNAL) {
+      return;
+    }
     const id = randomUUID();
     const timestamp = new Date(event.timestamp).getTime();
     const logMessage: LogMessageData = {

--- a/src/progressView/events/LogEvents.ts
+++ b/src/progressView/events/LogEvents.ts
@@ -5,6 +5,7 @@ import * as vscode from 'vscode';
 import type { LogMessageUpdate } from '@logger/LogTypes';
 // Type imports
 import type { AgentLogger } from '@logger/AgentLogger';
+import { MESSAGE_TYPES } from '@logger/messageTypes';
 import type { WebviewUpdater } from '@progressView/managers';
 import type { ProgressViewState } from '@progressView/state/ProgressViewState';
 
@@ -50,6 +51,10 @@ export function createLogEvents(shared: LogEventsShared): LogEventsModule {
         return;
       }
 
+      if (logMessage.messageType === MESSAGE_TYPES.INTERNAL) {
+        return;
+      }
+
       await state.streamTabs.addMessage(stream, logMessage);
 
       if (updater.isAvailable()) {
@@ -74,6 +79,13 @@ export function createLogEvents(shared: LogEventsShared): LogEventsModule {
 
       const existing = messages.find((m) => m.id === logMessage.id);
       if (!existing) return;
+
+      if (
+        existing.messageType === MESSAGE_TYPES.INTERNAL ||
+        logMessage.messageType === MESSAGE_TYPES.INTERNAL
+      ) {
+        return;
+      }
 
       if (logMessage.text !== undefined) {
         existing.text = logMessage.text;

--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -383,12 +383,7 @@ export class LogEntryFormatter {
         ),
       progressStatus: (message) =>
         this._safeFormat(
-          () =>
-            this._formatProgressStatus(
-              message.normalizedPayload,
-              message.id,
-              message.timestamp,
-            ),
+          () => this._formatProgressStatus(message),
           'progress status',
         ),
     };
@@ -1247,32 +1242,45 @@ export class LogEntryFormatter {
     return element;
   }
 
-  _formatProgressStatus(normalizedPayload, logId, timestamp) {
-    const element = createFromTemplate('nativeStatusTemplate');
-    if (!element) return null;
-
-    const date = new Date(timestamp ?? Date.now());
+  _formatProgressStatus(message) {
+    const normalizedPayload = message.normalizedPayload || {};
+    const severity = message.level || 'info';
+    const date = new Date(message.timestamp ?? Date.now());
     const { fullTimestamp, timeDisplay, tooltipTimestamp } =
       this._formatTimestamp(date);
 
-    element.dataset.fullTimestamp = fullTimestamp;
-    if (logId) {
-      element.dataset.logId = logId;
+    const summaryText =
+      (normalizedPayload.decodedText || message.text || '').trim() ||
+      'Status update';
+    const detailText = stringifyForDisplay(normalizedPayload.structured);
+
+    const container = document.createElement('div');
+    container.className = 'progress-status-entry';
+    container.dataset.fullTimestamp = fullTimestamp;
+    if (message.id) {
+      container.dataset.logId = message.id;
+    }
+    if (message.groupId) {
+      container.dataset.groupId = message.groupId;
     }
 
-    const timeElem = element.querySelector('.native-status-time');
-    if (timeElem) {
-      timeElem.textContent = timeDisplay;
-      timeElem.title = tooltipTimestamp;
+    const header = document.createElement('div');
+    header.className = `log-line progress-status-line level-${severity}`;
+    const emoji = EMOJI_BY_LEVEL[severity] || '•';
+    header.innerHTML = `
+      <span class="timestamp" title="${tooltipTimestamp}">${emoji} [${timeDisplay}]</span>
+      <span class="progress-status-summary">${encodeHtml(summaryText)}</span>
+    `;
+    container.appendChild(header);
+
+    if (detailText) {
+      const detailElem = document.createElement('pre');
+      detailElem.className = `progress-status-detail progress-status-${severity}`;
+      detailElem.textContent = detailText;
+      container.appendChild(detailElem);
     }
 
-    const textElem = element.querySelector('.native-status-text');
-    if (textElem) {
-      const decodedContent = normalizedPayload?.decodedText || '';
-      textElem.textContent = decodedContent;
-    }
-
-    return element;
+    return container;
   }
 
   _formatUserMessage(normalizedPayload, logId, timestamp) {

--- a/src/progressView/styles/logs.css
+++ b/src/progressView/styles/logs.css
@@ -91,6 +91,60 @@
   color: var(--vscode-editorError-foreground, #f14c4c);
 }
 
+.progress-status-entry {
+  padding: calc(var(--spacing-tiny) / 2) 0 var(--spacing-small);
+}
+
+.progress-status-line {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-small);
+  border-left: 3px solid var(--vscode-panel-border);
+  padding-left: var(--spacing-small);
+}
+
+.progress-status-line.level-info {
+  border-color: var(--vscode-notificationsInfoIcon-foreground, #75beff);
+}
+
+.progress-status-line.level-warn {
+  border-color: var(--vscode-editorWarning-foreground, #cca700);
+}
+
+.progress-status-line.level-error {
+  border-color: var(--vscode-editorError-foreground, #f14c4c);
+}
+
+.progress-status-line.level-debug {
+  border-color: var(--vscode-debugTokenExpression-name, #4b9ef9);
+}
+
+.progress-status-summary {
+  font-weight: 600;
+}
+
+.progress-status-detail {
+  margin: var(--spacing-tiny) 0 0 calc(var(--spacing-small) + 3px);
+  padding: var(--spacing-tiny) var(--spacing-small);
+  background: var(--vscode-editor-background);
+  border-radius: var(--border-radius-small);
+  border-left: 3px solid var(--vscode-panel-border);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.progress-status-detail.progress-status-info {
+  border-color: var(--vscode-notificationsInfoIcon-foreground, #75beff);
+}
+
+.progress-status-detail.progress-status-warn {
+  border-color: var(--vscode-editorWarning-foreground, #cca700);
+}
+
+.progress-status-detail.progress-status-error {
+  border-color: var(--vscode-editorError-foreground, #f14c4c);
+}
+
 .log-header {
   padding: var(--spacing-tiny) var(--spacing-small);
   font-size: var(--font-size-sm);


### PR DESCRIPTION
## Summary
- remove the unused `modelProgress` message type so progress updates rely on the existing `progressStatus`
- render `progressStatus` entries with severity-aware layout, emoji cues, and optional structured detail
- update progress log styles to match the new status entry presentation

## Testing
- npm run format
- npm run compile
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f8bcc9ff48324a1822189cc880616)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Render `progressStatus` with severity-aware layout and styles; filter `INTERNAL` messages from logging pipeline and updates.
> 
> - **Progress View**:
>   - **Rendering**: Refactor `progressStatus` formatter to consume full message and render severity-aware header with emoji, timestamp, and optional structured details.
>   - **Styles**: Add new CSS for `.progress-status-*` classes (borders, detail blocks, level-specific accents).
> - **Logging Pipeline**:
>   - **Filtering**: Ignore `MESSAGE_TYPES.INTERNAL` in `ProgressViewSink` and in add/update log event handlers.
>   - Preserve debug gating based on `texra.logger.debugMode`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bff42cb821fe5b33489a4aa3bd3fb83ba90f1f78. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->