### PR TITLE
Restore log-style progress status entries

### DIFF
--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -1256,24 +1256,18 @@ export class LogEntryFormatter {
     const emoji = EMOJI_BY_LEVEL[severity] || '•';
 
     const container = document.createElement('div');
+    container.dataset.fullTimestamp = fullTimestamp;
+    if (message.id) container.dataset.logId = message.id;
+    if (message.groupId) container.dataset.groupId = message.groupId;
 
     const summaryLine = document.createElement('div');
     summaryLine.className = 'log-line';
-    summaryLine.dataset.fullTimestamp = fullTimestamp;
-    if (message.id) summaryLine.dataset.logId = message.id;
-    if (message.groupId) summaryLine.dataset.groupId = message.groupId;
-    summaryLine.innerHTML = `
-      <span class="timestamp" title="${tooltipTimestamp}">${emoji} [${timeDisplay}]</span> 
-      <span class="message-${severity}">${encodeHtml(summaryText)}</span>
-    `;
+    summaryLine.innerHTML = `<span class="timestamp" title="${tooltipTimestamp}">${emoji} [${timeDisplay}]</span> <span class="message-${severity}">${encodeHtml(summaryText)}</span>`;
     container.appendChild(summaryLine);
 
     if (detailText) {
       const detailLine = document.createElement('pre');
       detailLine.className = `log-line message-${severity}`;
-      detailLine.dataset.fullTimestamp = fullTimestamp;
-      if (message.id) detailLine.dataset.logId = message.id;
-      if (message.groupId) detailLine.dataset.groupId = message.groupId;
       detailLine.textContent = detailText;
       container.appendChild(detailLine);
     }

--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -1253,31 +1253,29 @@ export class LogEntryFormatter {
       (normalizedPayload.decodedText || message.text || '').trim() ||
       'Status update';
     const detailText = stringifyForDisplay(normalizedPayload.structured);
+    const emoji = EMOJI_BY_LEVEL[severity] || '•';
 
     const container = document.createElement('div');
-    container.className = 'progress-status-entry';
-    container.dataset.fullTimestamp = fullTimestamp;
-    if (message.id) {
-      container.dataset.logId = message.id;
-    }
-    if (message.groupId) {
-      container.dataset.groupId = message.groupId;
-    }
 
-    const header = document.createElement('div');
-    header.className = `log-line progress-status-line level-${severity}`;
-    const emoji = EMOJI_BY_LEVEL[severity] || '•';
-    header.innerHTML = `
-      <span class="timestamp" title="${tooltipTimestamp}">${emoji} [${timeDisplay}]</span>
-      <span class="progress-status-summary">${encodeHtml(summaryText)}</span>
+    const summaryLine = document.createElement('div');
+    summaryLine.className = 'log-line';
+    summaryLine.dataset.fullTimestamp = fullTimestamp;
+    if (message.id) summaryLine.dataset.logId = message.id;
+    if (message.groupId) summaryLine.dataset.groupId = message.groupId;
+    summaryLine.innerHTML = `
+      <span class="timestamp" title="${tooltipTimestamp}">${emoji} [${timeDisplay}]</span> 
+      <span class="message-${severity}">${encodeHtml(summaryText)}</span>
     `;
-    container.appendChild(header);
+    container.appendChild(summaryLine);
 
     if (detailText) {
-      const detailElem = document.createElement('pre');
-      detailElem.className = `progress-status-detail progress-status-${severity}`;
-      detailElem.textContent = detailText;
-      container.appendChild(detailElem);
+      const detailLine = document.createElement('pre');
+      detailLine.className = `log-line message-${severity}`;
+      detailLine.dataset.fullTimestamp = fullTimestamp;
+      if (message.id) detailLine.dataset.logId = message.id;
+      if (message.groupId) detailLine.dataset.groupId = message.groupId;
+      detailLine.textContent = detailText;
+      container.appendChild(detailLine);
     }
 
     return container;

--- a/src/progressView/styles/logs.css
+++ b/src/progressView/styles/logs.css
@@ -91,60 +91,6 @@
   color: var(--vscode-editorError-foreground, #f14c4c);
 }
 
-.progress-status-entry {
-  padding: calc(var(--spacing-tiny) / 2) 0 var(--spacing-small);
-}
-
-.progress-status-line {
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-small);
-  border-left: 3px solid var(--vscode-panel-border);
-  padding-left: var(--spacing-small);
-}
-
-.progress-status-line.level-info {
-  border-color: var(--vscode-notificationsInfoIcon-foreground, #75beff);
-}
-
-.progress-status-line.level-warn {
-  border-color: var(--vscode-editorWarning-foreground, #cca700);
-}
-
-.progress-status-line.level-error {
-  border-color: var(--vscode-editorError-foreground, #f14c4c);
-}
-
-.progress-status-line.level-debug {
-  border-color: var(--vscode-debugTokenExpression-name, #4b9ef9);
-}
-
-.progress-status-summary {
-  font-weight: 600;
-}
-
-.progress-status-detail {
-  margin: var(--spacing-tiny) 0 0 calc(var(--spacing-small) + 3px);
-  padding: var(--spacing-tiny) var(--spacing-small);
-  background: var(--vscode-editor-background);
-  border-radius: var(--border-radius-small);
-  border-left: 3px solid var(--vscode-panel-border);
-  white-space: pre-wrap;
-  word-break: break-word;
-}
-
-.progress-status-detail.progress-status-info {
-  border-color: var(--vscode-notificationsInfoIcon-foreground, #75beff);
-}
-
-.progress-status-detail.progress-status-warn {
-  border-color: var(--vscode-editorWarning-foreground, #cca700);
-}
-
-.progress-status-detail.progress-status-error {
-  border-color: var(--vscode-editorError-foreground, #f14c4c);
-}
-
 .log-header {
   padding: var(--spacing-tiny) var(--spacing-small);
   font-size: var(--font-size-sm);


### PR DESCRIPTION
## Summary
- Render progress status updates with the standard log-line markup so timestamps, severity coloring, and structured detail text match other log entries.
- Remove bespoke progress status styling rules to revert to the legacy log presentation.

## Testing
- npm run format
- npm run compile
- npm run lint
- npm test (terminated early due to output limits while webpack was running)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f95c9f81c83249eace95cae4949a6)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Render progress status updates using standard log-line markup with severity coloring and drop bespoke CSS.
> 
> - **Progress view**:
>   - Progress status now uses standard `log-line` markup with `message-<level>` classes, emoji, and timestamp in `src/progressView/modules/formatters.js`.
>   - Detail text rendered as `<pre>` with `log-line message-<level>`.
> - **Styles**:
>   - Remove bespoke `.progress-status-*` rules from `src/progressView/styles/logs.css` to rely on shared log styles.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 24cad8ad872644c7a7f2ec0e35b7dfe6660bbeb9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->