### PR TITLE
Fix progress placeholder visibility for populated streams

### DIFF
--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -67,21 +67,27 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
   /**
    * Toggle the placeholder based on active stream and log content
    */
-  _updatePlaceholderVisibility() {
+  _updatePlaceholderVisibility(hasStreamsOverride) {
     const logContent = document.getElementById(ELEMENT_IDS.LOG_CONTENT);
     if (!logContent) {
       return;
     }
 
+    const streamTabs = document.getElementById(ELEMENT_IDS.STREAM_TABS);
+    const hasStreams =
+      typeof hasStreamsOverride === 'boolean'
+        ? hasStreamsOverride
+        : Boolean(streamTabs && streamTabs.children.length > 0);
     const hasContent = Array.from(logContent.children).some(
       (child) => child.id !== ELEMENT_IDS.LOG_PLACEHOLDER,
     );
 
-    if (!hasContent) {
+    if (!hasStreams && !hasContent) {
       dom.placeholder.show();
-    } else {
-      dom.placeholder.hide();
+      return;
     }
+
+    dom.placeholder.hide();
   }
 
   _handleRunSelectionChange(runId) {
@@ -207,7 +213,8 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       });
     }
 
-    this._updatePlaceholderVisibility();
+    const hasStreams = streams.length > 0;
+    this._updatePlaceholderVisibility(hasStreams);
 
     const activeStreamInfo = streams.find(
       (s) => s.name === message.activeStream,
@@ -367,6 +374,8 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       }
       scrollToBottom(logContent);
     }
+
+    this._updatePlaceholderVisibility();
   }
 
   handleUpdateLog(message) {
@@ -416,6 +425,8 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       }
       scrollToBottom(logContent);
     }
+
+    this._updatePlaceholderVisibility();
   }
 
   handleUpdateTaskGroup(message) {
@@ -639,6 +650,7 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
         }
       }
 
+      this._updatePlaceholderVisibility();
       return;
     }
 


### PR DESCRIPTION
## Summary
- update placeholder visibility logic to require an empty stream list and no log content before showing the empty state
- refresh placeholder state after incremental log additions, new runs, and inline instruction rendering so it hides once content exists

## Testing
- npm run format
- npm run compile
- npm run lint


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f9635430883249af2bc6f6acecb1b)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Show placeholder only when there are no streams and no log content, and re-evaluate visibility after logs append/reset, new runs, and inline instruction rendering.
> 
> - **Progress View placeholder logic**:
>   - Update `/_updatePlaceholderVisibility(hasStreamsOverride)/` to show placeholder only when both no streams and no content exist; otherwise hide.
>   - Infer `hasStreams` from `ELEMENT_IDS.STREAM_TABS` when not provided.
> - **Call site updates**:
>   - Pass `hasStreams` from `handleUpdateStreams` (`streams.length > 0`).
>   - Re-check placeholder after: `handleUpdateLogs`, `handleAppendLog`, `handleAddTaskGroup`, and tool-use `handleUpdateInstruction` (after inline user message insert).
> - **Behavioral tweaks**:
>   - Ensure placeholder hides once content appears and remains hidden for populated streams.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6f02cb310093d73e8d14f50a78c3d20155bf09e2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->