### PR TITLE
Fix progress placeholder visibility when streams exist

### DIFF
--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -40,6 +40,7 @@ function scrollToBottom(element) {
 export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
   constructor() {
     super();
+    this._hasStreams = false;
     this._entryFormatter = getSharedLogEntryFormatter();
     this._handlers = {
       ...createThemeHandlers(),
@@ -68,6 +69,11 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
    * Toggle the placeholder based on active stream and log content
    */
   _updatePlaceholderVisibility() {
+    if (this._hasStreams) {
+      dom.placeholder.hide();
+      return;
+    }
+
     const logContent = document.getElementById(ELEMENT_IDS.LOG_CONTENT);
     if (!logContent) {
       return;
@@ -165,6 +171,9 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
   handleUpdateStreams(message) {
     try {
       state.activeStream = message.activeStream;
+      this._hasStreams = Array.isArray(message.streams)
+        ? message.streams.length > 0
+        : false;
       if (
         !state.pendingFilterUpdate &&
         message.agentFilter !== undefined &&
@@ -367,6 +376,8 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       }
       scrollToBottom(logContent);
     }
+
+    this._updatePlaceholderVisibility();
   }
 
   handleUpdateLog(message) {
@@ -416,6 +427,8 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       }
       scrollToBottom(logContent);
     }
+
+    this._updatePlaceholderVisibility();
   }
 
   handleUpdateTaskGroup(message) {
@@ -677,6 +690,7 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
 
   handleDeleteAll() {
     pendingLogUpdates.clear();
+    this._hasStreams = false;
     state.toggleStates.clearAll();
     state.resetExecutionIdAvailability();
     dom.instructionPanel.hide();
@@ -685,6 +699,7 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     state.clearRunMissingOutputs();
     state.clearAllActiveRuns();
     dom.runSelector.clear();
+    this._updatePlaceholderVisibility();
   }
 
   handleFollowUpTextPolished(message) {


### PR DESCRIPTION
## Summary
- track whether streams exist to prevent showing the progress placeholder once any stream is available
- invoke placeholder visibility updates after log and task additions so newly rendered content hides the empty state
- reset placeholder state when clearing all progress data

## Testing
- npm run format
- npm run compile
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f9635430883249af2bc6f6acecb1b)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Tracks stream presence to hide the empty-state placeholder and refreshes its visibility after log/task updates; resets state on full clear.
> 
> - **Progress View**
>   - **Placeholder visibility**:
>     - Add `this._hasStreams` and set it from `UPDATE_STREAMS` to hide `dom.placeholder` whenever any streams exist.
>     - Call `_updatePlaceholderVisibility()` after `UPDATE_STREAMS`, `UPDATE_LOGS` render, `APPEND_LOG`, and `ADD_TASK_GROUP`; reset via `DELETE_ALL` (also clears `this._hasStreams`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 636797540f129014d45e60e285e5f8ef5e54c4b9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->