### PR TITLE
Fix duplicate thinking logs for background responses

### DIFF
--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -508,12 +508,6 @@ class ResponseProcessNode<C> extends BaseNode<ResponseCycleContext<C>> {
       .join(', ');
     options.logger.debug(`Usage summary: ${usageSummary}`);
 
-    if (result.thinkingContent && !result.useStreaming) {
-      options.logger.info(result.thinkingContent, {
-        messageType: MESSAGE_TYPES.THINKING,
-      });
-    }
-
     options.logger.info(`Stop reason: ${result.stopReason}`, {
       messageType: MESSAGE_TYPES.PROGRESS_STATUS,
     });


### PR DESCRIPTION
## Summary
- remove the redundant thinking log emission in background/non-streaming response post-processing to avoid duplicate entries

## Testing
- npm run format
- npm run compile
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691fa2a6d9608324af8217e5fe75438a)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the redundant THINKING log emission in `ResponseCycleFlow` post-processing to prevent duplicate entries for non-streaming responses.
> 
> - **Logging**:
>   - Remove duplicate `THINKING` log emission in `src/agent/core/flows/ResponseCycleFlow.ts` during post-processing when not streaming, avoiding repeated THINKING messages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1b77e81791f25306ce2ab428089ade1b50332adf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->