### PR TITLE
Fix duplicate progress view logs

### DIFF
--- a/src/progressView/managers/StreamTabsManager.ts
+++ b/src/progressView/managers/StreamTabsManager.ts
@@ -35,7 +35,14 @@ export class StreamTabsManager extends PersistentMapManager<
   ): Promise<void> {
     const messages = this.ensureMessages(stream);
 
-    messages.push(message);
+    const existingIndex = messages.findIndex(
+      (entry) => entry.id === message.id,
+    );
+    if (existingIndex >= 0) {
+      messages[existingIndex] = message;
+    } else {
+      messages.push(message);
+    }
 
     // Limit message history to prevent memory issues
     if (messages.length > StreamTabsManager.MAX_MESSAGE_HISTORY) {

--- a/src/test/progressView/managers/StreamTabsManager.test.ts
+++ b/src/test/progressView/managers/StreamTabsManager.test.ts
@@ -1,0 +1,59 @@
+// Standard library imports
+import { strict as assert } from 'assert';
+
+// Local imports
+import { WorkspaceStateKey } from '@common/state/stateManager';
+import { StreamTabsManager } from '@progressView/managers/StreamTabsManager';
+import type { StateStorage } from '@progressView/persistence/PersistentMapManager';
+
+describe('StreamTabsManager', () => {
+  class InMemoryStateStorage implements StateStorage {
+    private store = new Map<string, unknown>();
+
+    get<T>(key: string, defaultValue?: T): T | undefined {
+      if (this.store.has(key)) {
+        return this.store.get(key) as T;
+      }
+
+      return defaultValue;
+    }
+
+    update<T>(key: string, value: T): Thenable<void> {
+      this.store.set(key, value);
+      return Promise.resolve();
+    }
+  }
+
+  it('replaces duplicate message ids instead of appending', async () => {
+    const storage = new InMemoryStateStorage();
+    const manager = new StreamTabsManager(storage);
+    const streamId = 'stream:abc';
+
+    const firstMessage = {
+      id: 'log-1',
+      text: 'first entry',
+      level: 'info' as const,
+      timestamp: Date.now(),
+    };
+
+    const updatedMessage = {
+      ...firstMessage,
+      text: 'updated entry',
+      timestamp: Date.now() + 1,
+    };
+
+    await manager.addMessage(streamId, firstMessage);
+    await manager.addMessage(streamId, updatedMessage);
+
+    const messages = manager.getMessages(streamId);
+    assert.equal(messages.length, 1);
+    assert.deepEqual(messages[0], updatedMessage);
+
+    const persisted = storage.get<Record<string, unknown>>(
+      WorkspaceStateKey.STREAM_TABS,
+      {},
+    );
+    assert.ok(persisted);
+    assert.equal(Object.keys(persisted!).length, 1);
+  });
+});


### PR DESCRIPTION
## Summary
- replace duplicate stream log messages by id instead of appending
- add regression test ensuring stream tabs manager deduplicates persisted entries

## Testing
- npm run format
- npm run lint
- npm run compile

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691fa16f343c8324a6887ba46ab83777)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Deduplicate stream log messages by replacing entries with the same id and add a unit test validating behavior and persistence.
> 
> - **Stream logs management (`src/progressView/managers/StreamTabsManager.ts`)**
>   - Update `addMessage` to replace an existing message with the same `id` instead of appending to `messages`.
>   - Continues enforcing `MAX_MESSAGE_HISTORY` and saving state.
> - **Tests (`src/test/progressView/managers/StreamTabsManager.test.ts`)**
>   - Add unit test with in-memory storage to verify duplicate `id` messages are replaced and persistence keys remain minimal.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5589c5521daf0c409aac6edc494fb7bb6d324faa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->