### PR TITLE
Fix duplicate thinking log appends in progress view

### DIFF
--- a/src/progressView/events/LogEvents.ts
+++ b/src/progressView/events/LogEvents.ts
@@ -55,9 +55,9 @@ export function createLogEvents(shared: LogEventsShared): LogEventsModule {
         return;
       }
 
-      await state.streamTabs.addMessage(stream, logMessage);
+      const isNew = await state.streamTabs.addMessage(stream, logMessage);
 
-      if (updater.isAvailable()) {
+      if (isNew && updater.isAvailable()) {
         updater.appendLogMessage(stream, logMessage);
       }
     });

--- a/src/progressView/managers/StreamTabsManager.ts
+++ b/src/progressView/managers/StreamTabsManager.ts
@@ -32,7 +32,7 @@ export class StreamTabsManager extends PersistentMapManager<
   async addMessage(
     stream: StreamTabId,
     message: LogMessageData,
-  ): Promise<void> {
+  ): Promise<boolean> {
     const messages = this.ensureMessages(stream);
 
     const existingIndex = messages.findIndex(
@@ -40,6 +40,8 @@ export class StreamTabsManager extends PersistentMapManager<
     );
     if (existingIndex >= 0) {
       messages[existingIndex] = message;
+      await this.save();
+      return false;
     } else {
       messages.push(message);
     }
@@ -53,6 +55,7 @@ export class StreamTabsManager extends PersistentMapManager<
     }
 
     await this.save();
+    return true;
   }
 
   /**

--- a/src/test/progressView/events/LogEvents.test.ts
+++ b/src/test/progressView/events/LogEvents.test.ts
@@ -1,0 +1,122 @@
+// Standard library imports
+import { strict as assert } from 'assert';
+
+// Local imports - logger
+import { AgentLogger } from '@logger/AgentLogger';
+import type { LogMessageData } from '@logger/LogTypes';
+import { MESSAGE_TYPES } from '@logger/messageTypes';
+
+// Local imports - progress view
+import { createLogEvents } from '@progressView/events/LogEvents';
+import type { ProgressEventBusLike } from '@progressView/events/types';
+import { StreamTabsManager } from '@progressView/managers/StreamTabsManager';
+import type { WebviewUpdater } from '@progressView/managers/WebviewUpdater';
+import type { StateStorage } from '@progressView/persistence/PersistentMapManager';
+import type { ProgressViewState } from '@progressView/state/ProgressViewState';
+
+class InMemoryStateStorage implements StateStorage {
+  private store = new Map<string, unknown>();
+
+  get<T>(key: string, defaultValue?: T): T | undefined {
+    if (this.store.has(key)) {
+      return this.store.get(key) as T;
+    }
+
+    return defaultValue;
+  }
+
+  update<T>(key: string, value: T): Thenable<void> {
+    this.store.set(key, value);
+    return Promise.resolve();
+  }
+}
+
+class TestBus implements ProgressEventBusLike {
+  private listeners: Record<string, ((payload: any) => void)[]> = {};
+
+  on<K extends keyof any>(
+    event: K,
+    listener: (payload: any) => void,
+  ): () => void {
+    const existing = this.listeners[event as string] ?? [];
+    existing.push(listener);
+    this.listeners[event as string] = existing;
+
+    return () => {
+      this.listeners[event as string] = (
+        this.listeners[event as string] ?? []
+      ).filter((handler) => handler !== listener);
+    };
+  }
+
+  emit<K extends keyof any>(event: K, payload: any): void {
+    (this.listeners[event as string] ?? []).forEach((listener) =>
+      listener(payload),
+    );
+  }
+}
+
+const flushMicrotasks = (): Promise<void> =>
+  new Promise((resolve) => setImmediate(resolve));
+
+describe('LogEvents', () => {
+  it('does not append duplicate thinking entries when a replayed message is updated', async () => {
+    const storage = new InMemoryStateStorage();
+    const streamTabs = new StreamTabsManager(storage);
+    const state = {
+      streamTabs,
+      activeStream: 'stream:123',
+    } as unknown as ProgressViewState;
+
+    const appended: LogMessageData[] = [];
+    const updated: LogMessageData[] = [];
+    const updater = {
+      isAvailable: () => true,
+      appendLogMessage: (_stream: string, log: LogMessageData) =>
+        appended.push(log),
+      updateLogMessage: (_stream: string, log: LogMessageData) =>
+        updated.push(log),
+    } as unknown as WebviewUpdater;
+
+    const bus = new TestBus();
+    const logger = new AgentLogger('LogEventsTest');
+    const { register } = createLogEvents({ logger });
+    const disposables = register(bus, state, updater);
+
+    const thinkingMessage: LogMessageData = {
+      id: 'log-1',
+      text: 'thinking...',
+      level: 'info',
+      timestamp: Date.now(),
+      messageType: MESSAGE_TYPES.THINKING,
+    };
+
+    bus.emit('addLogMessage', {
+      stream: state.activeStream,
+      logMessage: thinkingMessage,
+    });
+    await flushMicrotasks();
+
+    bus.emit('addLogMessage', {
+      stream: state.activeStream,
+      logMessage: { ...thinkingMessage, text: 'still thinking...' },
+    });
+    await flushMicrotasks();
+
+    bus.emit('updateLogMessage', {
+      stream: state.activeStream,
+      logMessage: {
+        id: thinkingMessage.id,
+        text: 'finished thinking',
+      },
+    });
+    await flushMicrotasks();
+
+    assert.equal(appended.length, 1);
+    assert.equal(appended[0].text, 'thinking...');
+    assert.equal(updated.length, 1);
+    assert.equal(updated[0].text, 'finished thinking');
+
+    disposables.forEach((disposable) => disposable.dispose());
+  });
+});

--- a/src/test/progressView/managers/StreamTabsManager.test.ts
+++ b/src/test/progressView/managers/StreamTabsManager.test.ts
@@ -42,10 +42,12 @@ describe('StreamTabsManager', () => {
       timestamp: Date.now() + 1,
     };
 
-    await manager.addMessage(streamId, firstMessage);
-    await manager.addMessage(streamId, updatedMessage);
+    const wasAdded = await manager.addMessage(streamId, firstMessage);
+    const wasUpdated = await manager.addMessage(streamId, updatedMessage);
 
     const messages = manager.getMessages(streamId);
+    assert.equal(wasAdded, true);
+    assert.equal(wasUpdated, false);
     assert.equal(messages.length, 1);
     assert.deepEqual(messages[0], updatedMessage);
 


### PR DESCRIPTION
## Summary
- add feedback from StreamTabsManager.addMessage to distinguish new versus updated log entries
- prevent progress view from appending log messages that were already stored and rely on updates instead
- add coverage to ensure replayed thinking messages only append once when later updates arrive

## Testing
- npm run format
- npm run compile
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691fad4d88fc8324b16ed2d6f58e4850)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Only append log messages when newly added; updates replace existing entries and trigger webview updates, with tests covering duplicate-prevention and return flags.
> 
> - **Progress View**
>   - `StreamTabsManager.addMessage` now returns `boolean` indicating new (`true`) vs updated (`false`); replaces existing messages by `id`, persists, and enforces history cap.
>   - `events/LogEvents`:
>     - `addLogMessage`: use `isNew` from `addMessage` to conditionally `appendLogMessage`.
>     - `updateLogMessage`: mutate existing entry fields, `save`, and `updateLogMessage` for the active stream.
> - **Tests**
>   - Add `src/test/progressView/events/LogEvents.test.ts` to ensure replayed thinking messages append once and later updates are applied.
>   - Update `StreamTabsManager` tests to assert replacement behavior and new return values.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d0c1d49d6d4896d7a62e410b9463ea9144339110. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->