### PR TITLE
Fix XML processing for direct agents with document tags

### DIFF
--- a/src/agent/output/OutputHandler.ts
+++ b/src/agent/output/OutputHandler.ts
@@ -740,10 +740,11 @@ export class OutputHandler implements IOutputHandler {
               this.agentSetting.prefills?.some((prefill) =>
                 /<scratchpad\s*>/i.test(prefill),
               ) ?? false;
+            const hasDocumentTag = Boolean(this.agentSetting.documentTag);
             const shouldProcessXml =
               this.agentSetting.agentType === AgentType.CoT ||
               (this.agentSetting.agentType === AgentType.Direct &&
-                hasScratchpadPrefill);
+                (hasDocumentTag || hasScratchpadPrefill));
 
             if (shouldProcessXml) {
               processed =


### PR DESCRIPTION
## Summary
- process XML outputs for direct agents whenever a documentTag is configured, even without a scratchpad prefill
- keep existing CoT XML handling unchanged

## Testing
- npm run format
- npm run compile
- npm run lint


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691fadb57a988324aab4418349508c56)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Extends XML processing to Direct agents when a `documentTag` is configured, not only when a scratchpad prefill exists.
> 
> - **Output handling (XML)**:
>   - Update condition in `OutputHandler.processOutputFiles()` (single-output path):
>     - Introduce `hasDocumentTag` and extend `shouldProcessXml` to `AgentType.Direct && (hasDocumentTag || hasScratchpadPrefill)`.
>     - Keeps existing `AgentType.CoT` behavior unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 831dee492f74a5834f48a55814eef06481a76559. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->