### PR TITLE
Limit statistics logging to workflow sessions

### DIFF
--- a/src/agent/runtime/AgentExecutionContext.ts
+++ b/src/agent/runtime/AgentExecutionContext.ts
@@ -1,5 +1,6 @@
 // Local imports - agent types
 import type { ExecutionId, StreamTabId } from '@agent/types/IdentifierTypes';
+import { AgentCategory } from '@agent/core/AgentDataclass';
 
 // Local imports - logger
 import {
@@ -12,6 +13,7 @@ import { AgentUsageReporter } from '@logger/AgentUsageReporter';
 export interface AgentExecutionContextInit {
   streamId: StreamTabId;
   executionId?: ExecutionId;
+  agentCategory?: AgentCategory;
 }
 
 /**
@@ -20,10 +22,16 @@ export interface AgentExecutionContextInit {
 export class AgentExecutionContext {
   public readonly logger: AgentLogger;
   public readonly usageReporter: AgentUsageReporter;
+  private readonly agentCategory: AgentCategory;
 
   constructor(private readonly init: AgentExecutionContextInit) {
     this.logger = new AgentLogger(init.streamId, true);
-    this.usageReporter = new AgentUsageReporter(this.logger, init.streamId);
+    this.agentCategory = init.agentCategory ?? AgentCategory.Workflow;
+    this.usageReporter = new AgentUsageReporter(
+      this.logger,
+      init.streamId,
+      this.agentCategory,
+    );
   }
 
   get streamId(): StreamTabId {
@@ -32,6 +40,10 @@ export class AgentExecutionContext {
 
   get executionId(): ExecutionId | undefined {
     return this.init.executionId;
+  }
+
+  get sessionCategory(): AgentCategory {
+    return this.agentCategory;
   }
 
   stage(

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -300,8 +300,16 @@ export async function prepareAgentInstance<T extends IAgent = IAgent>(
   );
 
   const context = contextFactory
-    ? contextFactory({ streamId, executionId })
-    : new AgentExecutionContext({ streamId, executionId });
+    ? contextFactory({
+        streamId,
+        executionId,
+        agentCategory: sessionDescriptor.agentCategory,
+      })
+    : new AgentExecutionContext({
+        streamId,
+        executionId,
+        agentCategory: sessionDescriptor.agentCategory,
+      });
 
   const agent = new AgentClass(
     modelHandler,

--- a/src/logger/AgentUsageReporter.ts
+++ b/src/logger/AgentUsageReporter.ts
@@ -1,6 +1,7 @@
 // Local imports - agent types
 import type { StreamTabId } from '@agent/types/IdentifierTypes';
 import type { ExtendedTokenUsageStats } from '@agent/types/UsageTypes';
+import { AgentCategory } from '@agent/core/AgentDataclass';
 
 // Internal imports
 import { bus } from '@eventBus/ProgressEventBus';
@@ -15,12 +16,14 @@ export class AgentUsageReporter {
   constructor(
     private readonly logger: AgentLogger,
     private readonly streamId: StreamTabId,
+    private readonly agentCategory: AgentCategory = AgentCategory.Workflow,
   ) {}
 
   /**
    * Emit usage data to the progress view and attach detailed stats to the log.
    */
   public report(stats: ExtendedTokenUsageStats, runId?: string): void {
+    const logStatistics = this.agentCategory === AgentCategory.Workflow;
     const usage = {
       inputTokens: stats.inputTokens + (stats.cacheCreationInputTokens ?? 0),
       outputTokens: stats.outputTokens,
@@ -35,7 +38,9 @@ export class AgentUsageReporter {
         groupId,
         usage,
       });
-      this.logger.statistics(stats, groupId);
+      if (logStatistics) {
+        this.logger.statistics(stats, groupId);
+      }
       return;
     }
 
@@ -47,6 +52,8 @@ export class AgentUsageReporter {
       });
     }
 
-    this.logger.statistics(stats);
+    if (logStatistics) {
+      this.logger.statistics(stats);
+    }
   }
 }

--- a/src/test/logger/AgentUsageReporter.test.ts
+++ b/src/test/logger/AgentUsageReporter.test.ts
@@ -2,6 +2,7 @@
 import { strict as assert } from 'assert';
 
 // Local imports
+import { AgentCategory } from '@agent/core/AgentDataclass';
 import type { ExtendedTokenUsageStats } from '@agent/types/UsageTypes';
 import type { AgentLogger } from '@logger/AgentLogger';
 import { bus } from '@eventBus/ProgressEventBus';
@@ -29,7 +30,11 @@ describe('AgentUsageReporter', () => {
       },
     } as unknown as AgentLogger;
 
-    const reporter = new AgentUsageReporter(loggerStub, streamId);
+    const reporter = new AgentUsageReporter(
+      loggerStub,
+      streamId,
+      AgentCategory.Workflow,
+    );
     const stats: ExtendedTokenUsageStats = {
       inputTokens: 10,
       outputTokens: 5,
@@ -55,6 +60,53 @@ describe('AgentUsageReporter', () => {
     } finally {
       disposeStream();
       disposeGroup();
+    }
+  });
+
+  it('skips statistics logging for tool-use sessions', () => {
+    const streamId = 'stream:test';
+    const runId = 'run-456';
+    const streamEvents: unknown[] = [];
+    const disposeStream = bus.on('updateStreamUsage', (payload) => {
+      streamEvents.push(payload);
+    });
+
+    const loggerStub = {
+      withCurrentGroup: <T>(_: (groupId: string) => T): T | undefined =>
+        undefined,
+      statistics: () => {
+        throw new Error('statistics should not be called for tool-use runs');
+      },
+    } as unknown as AgentLogger;
+
+    const reporter = new AgentUsageReporter(
+      loggerStub,
+      streamId,
+      AgentCategory.ToolUse,
+    );
+
+    const stats: ExtendedTokenUsageStats = {
+      inputTokens: 6,
+      outputTokens: 2,
+      cost: 0.1,
+      cacheCreationInputTokens: 1,
+    };
+
+    try {
+      reporter.report(stats, runId);
+
+      assert.equal(streamEvents.length, 1);
+      assert.deepEqual(streamEvents[0], {
+        stream: streamId,
+        runId,
+        usage: {
+          inputTokens: 7,
+          outputTokens: 2,
+          cost: 0.1,
+        },
+      });
+    } finally {
+      disposeStream();
     }
   });
 });


### PR DESCRIPTION
## Summary
- pass agent session category through AgentExecutionContext to AgentUsageReporter
- emit usage statistics logs only for workflow sessions while continuing usage events
- add coverage to ensure tool-use sessions skip statistics logging

## Testing
- npm run format
- npm run compile
- npm run lint


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691faf642dd48324b3976e96d1514aaf)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Pass agent session category through execution context to usage reporting and only log detailed statistics for workflow sessions (events still emitted); add tests.
> 
> - **Runtime**:
>   - `AgentExecutionContext`: accepts optional `agentCategory`, stores it, exposes `sessionCategory`, and passes it to `AgentUsageReporter`.
>   - `executeAgent.ts`: injects `sessionDescriptor.agentCategory` into context creation.
> - **Logger**:
>   - `AgentUsageReporter`: constructor accepts `agentCategory`; conditionally calls `logger.statistics` only for `AgentCategory.Workflow` while still emitting `updateGroupUsage`/`updateStreamUsage` events.
> - **Tests**:
>   - Update existing test to provide `AgentCategory.Workflow`.
>   - Add test ensuring `AgentCategory.ToolUse` sessions skip statistics logging while emitting stream usage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1e31645612de71dbde224558eb6beeec989f301f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->