### PR TITLE
Split arXiv search queries into keyword terms

### DIFF
--- a/src/test/tools/ArxivSearchTool.test.ts
+++ b/src/test/tools/ArxivSearchTool.test.ts
@@ -1,0 +1,108 @@
+// Node.js built-in imports
+import * as assert from 'assert';
+
+// Local imports - tools
+import * as arxivShared from '@tools/latex/arxivShared';
+import * as rateLimiter from '@tools/citation/rateLimiter';
+import { ArxivSearchTool } from '@/tools/arxiv/ArxivSearchTool';
+
+describe('ArxivSearchTool', () => {
+  const originalCreateArxivClient = arxivShared.createArxivClient;
+  const originalWaitForRateLimit = rateLimiter.waitForRateLimit;
+
+  afterEach(() => {
+    (
+      arxivShared as unknown as {
+        createArxivClient: typeof originalCreateArxivClient;
+      }
+    ).createArxivClient = originalCreateArxivClient;
+    (
+      rateLimiter as unknown as {
+        waitForRateLimit: typeof originalWaitForRateLimit;
+      }
+    ).waitForRateLimit = originalWaitForRateLimit;
+  });
+
+  it('builds keyword queries for multi-word input', async () => {
+    const captured: {
+      query?: string;
+      start?: number;
+      maxResults?: number;
+      sortBy?: string;
+      sortOrder?: string;
+    } = {};
+
+    const sampleEntries = [
+      {
+        id: 'http://arxiv.org/abs/1234.5678v1',
+        title: 'Test Paper',
+        summary: 'Abstract',
+        doi: { id: '10.1000/example' },
+        published: new Date('2024-01-01'),
+        updated: new Date('2024-01-02'),
+        authors: [{ name: 'Author One' }],
+        primaryCategory: { term: 'cs.AI' },
+      },
+    ];
+
+    (
+      rateLimiter as unknown as {
+        waitForRateLimit: typeof originalWaitForRateLimit;
+      }
+    ).waitForRateLimit = async () => {};
+
+    (
+      arxivShared as unknown as {
+        createArxivClient: typeof originalCreateArxivClient;
+      }
+    ).createArxivClient = () =>
+      ({
+        query(value: { toString: () => string }) {
+          captured.query = value.toString();
+          return this;
+        },
+        start(value: number) {
+          captured.start = value;
+          return this;
+        },
+        maxResults(value: number) {
+          captured.maxResults = value;
+          return this;
+        },
+        sortBy(value: string) {
+          captured.sortBy = value;
+          return this;
+        },
+        sortOrder(value: string) {
+          captured.sortOrder = value;
+          return this;
+        },
+        async execute() {
+          return sampleEntries;
+        },
+      }) as unknown as arxivShared.ArxivClientInstance;
+
+    const tool = new ArxivSearchTool();
+    const result = await tool.call({
+      query: 'quantum error correction',
+      start: 2,
+      maxResults: 5,
+      sortBy: 'relevance',
+      sortOrder: 'descending',
+    });
+
+    assert.strictEqual(
+      captured.query,
+      '(all:"quantum" AND all:"error" AND all:"correction")',
+    );
+    assert.strictEqual(captured.start, 2);
+    assert.strictEqual(captured.maxResults, 5);
+    assert.strictEqual(captured.sortBy, 'relevance');
+    assert.strictEqual(captured.sortOrder, 'descending');
+
+    const output = result.output ? JSON.parse(result.output) : null;
+    assert.ok(output);
+    assert.strictEqual(output.count, sampleEntries.length);
+    assert.strictEqual(output.results[0].id, '1234.5678v1');
+  });
+});

--- a/src/tools/arxiv/ArxivSearchTool.ts
+++ b/src/tools/arxiv/ArxivSearchTool.ts
@@ -44,7 +44,13 @@ export class ArxivSearchTool extends defineTool({
     }
 
     // Build query using arxiv-client query builder
-    let query = all(trimmedQuery);
+    const terms = Array.from(
+      trimmedQuery.matchAll(/"([^"]+)"|\S+/g),
+      (match) => match[1] ?? match[0],
+    );
+
+    const termQueries = terms.map((term) => all(term));
+    let query = termQueries.length === 1 ? termQueries[0] : and(...termQueries);
 
     // Add category filters if provided
     if (input.categories && input.categories.length > 0) {


### PR DESCRIPTION
## Summary
- Build arXiv search queries from individual terms instead of a single phrase so multi-word searches return results
- Add a unit test that verifies multi-word queries generate keyword-style arXiv queries and preserve options

## Testing
- npm run format
- npm run compile
- npm run lint


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692060f7fa2883249f8069199b6d1365)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Construct arXiv queries by splitting input into terms (including quoted phrases) combined with AND, and add a test validating query building and option passthrough.
> 
> - **Arxiv search tool (`src/tools/arxiv/ArxivSearchTool.ts`)**:
>   - Parse input into terms (supports quoted phrases) via regex and build query as `and(...all(term))` instead of a single `all(trimmedQuery)`.
>   - Preserve category filters by AND-ing `category(...)` clauses with the term query.
>   - Keep pagination and sorting options (`start`, `maxResults`, `sortBy`, `sortOrder`) and rate limiting behavior.
> - **Tests (`src/test/tools/ArxivSearchTool.test.ts`)**:
>   - Add unit test that mocks the arXiv client and rate limiter to verify multi-word input produces `(all:"quantum" AND all:"error" AND all:"correction")` and that options are forwarded; validates output mapping of results.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 11865b14e9d5c65aaad5767bef7d055838f44a17. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->