### PR TITLE
Simplify tool use error display

### DIFF
--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -699,65 +699,15 @@ export class LogEntryFormatter {
           </div>
         </div>
       `);
-    }
-
-    if (outputText) {
-      const encodedOutput = encodeHtml(outputText);
-      const MAX_PREVIEW_CHARS = 240;
-      const isTruncated = outputText.length > MAX_PREVIEW_CHARS;
-      if (!summaryText && isTruncated) {
-        const preview = encodeHtml(
-          `${outputText.slice(0, MAX_PREVIEW_CHARS).trimEnd()}…`,
-        );
-        sections.push(`
-          <div class="tool-use-section">
-            <div class="tool-use-subsection">
-              <span class="tool-use-sublabel">Output:</span>
-              <details class="tool-output-details">
-                <summary class="details-summary">
-                  <pre class="tool-output-preview">${preview}</pre>
-                  <span class="details-summary-label">Show full output</span>
-                </summary>
-                <pre class="tool-output-full">${encodedOutput}</pre>
-              </details>
-            </div>
+    } else if (outputText) {
+      sections.push(`
+        <div class="tool-use-section">
+          <div class="tool-use-subsection">
+            <span class="tool-use-sublabel">Output:</span>
+            <pre class="tool-output-full">${encodeHtml(outputText)}</pre>
           </div>
-        `);
-      } else {
-        sections.push(`
-          <div class="tool-use-section">
-            <div class="tool-use-subsection">
-              <span class="tool-use-sublabel">Output:</span>
-              <pre class="tool-output-full">${encodedOutput}</pre>
-            </div>
-          </div>
-        `);
-      }
-    }
-
-    if (diagnostics !== undefined) {
-      const diagnosticsText = stringifyForDisplay(diagnostics).trim();
-      const MAX_DIAGNOSTICS_LENGTH = 600;
-
-      if (diagnosticsText && diagnosticsText.length <= MAX_DIAGNOSTICS_LENGTH) {
-        sections.push(`
-          <div class="tool-use-section">
-            <div class="tool-use-subsection">
-              <span class="tool-use-sublabel">Diagnostics:</span>
-              <pre>${encodeHtml(diagnosticsText)}</pre>
-            </div>
-          </div>
-        `);
-      } else if (diagnosticsText) {
-        sections.push(`
-          <div class="tool-use-section">
-            <div class="tool-use-subsection">
-              <span class="tool-use-sublabel">Diagnostics:</span>
-              <div>Diagnostics omitted (too verbose for progress view).</div>
-            </div>
-          </div>
-        `);
-      }
+        </div>
+      `);
     }
 
     const fallbackYaml = stringifyForDisplay(parsed);

--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -658,7 +658,6 @@ export class LogEntryFormatter {
       summaryText,
       errorText,
       outputText,
-      diagnostics,
       input,
     } = normalizedToolLog;
 

--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -219,7 +219,6 @@ const normalizeToolUseLog = (structured) => {
     summaryText,
     errorText,
     outputText,
-    diagnostics: parsed.diagnostics ?? outputDetails.diagnostics,
     input: parsed.input,
     isError: Boolean(
       parsed.isError || outputDetails.isError || errorText.length > 0,
@@ -652,14 +651,8 @@ export class LogEntryFormatter {
       return null;
     }
 
-    const {
-      parsed,
-      toolName,
-      summaryText,
-      errorText,
-      outputText,
-      input,
-    } = normalizedToolLog;
+    const { parsed, toolName, summaryText, errorText, outputText, input } =
+      normalizedToolLog;
 
     const titlePrefix = normalizedToolLog.isError ? 'Tool Error' : 'Tool Use';
     const titleBase = toolName ? `${titlePrefix}: ${toolName}` : titlePrefix;

--- a/src/progressView/styles/scratchpad.css
+++ b/src/progressView/styles/scratchpad.css
@@ -42,17 +42,9 @@
   color: var(--vscode-errorForeground);
 }
 
-.tool-output-preview {
-  margin-bottom: var(--spacing-tiny);
-}
-
 .tool-output-full {
   max-height: var(--height-large);
   overflow: auto;
   white-space: pre-wrap;
   word-break: break-word;
-}
-
-.tool-output-details {
-  margin-top: var(--spacing-tiny);
 }


### PR DESCRIPTION
## Summary
- remove diagnostics rendering and the expandable output toggle from tool-use entries
- prioritize showing error text and only show full output inline when no error is present
- retain existing fallback formatting for tool payloads

## Testing
- npm run format
- npm run compile
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69206dce6c948324a59dbd74b16d7201)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Simplifies tool-use entries by removing diagnostics and the expandable output preview, showing error text or full output inline, and pruning related CSS.
> 
> - **Progress View**:
>   - **Tool use rendering (`src/progressView/modules/formatters.js`)**:
>     - Prioritize error display; show full `output` only when no `error`.
>     - Remove diagnostics handling and output preview/expand UI.
>     - Drop `diagnostics` from normalized tool log.
>   - Titles/icons still reflect error state; fallback YAML preserved.
> - **Styles (`src/progressView/styles/scratchpad.css`)**:
>   - Remove `.tool-output-preview` and `.tool-output-details` rules; keep `.tool-output-full`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 633459ab95d0b8c25ab0b8f0db6aa3f96bc2968a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->