### PR TITLE
Fix cached token calculation for OpenAI usage reporting

### DIFF
--- a/src/agent/core/ResponseUsage.ts
+++ b/src/agent/core/ResponseUsage.ts
@@ -81,7 +81,10 @@ export class ResponseUsageFactory {
   ): OpenAIAPIResponseUsage {
     // Extract tokens from response usage
     const promptTokensDetails = responseUsage.prompt_tokens_details;
-    const cachedTokens = promptTokensDetails?.cached_tokens ?? 0;
+    const cachedTokens =
+      promptTokensDetails?.cached_tokens ??
+      responseUsage.prompt_cache_hit_tokens ??
+      0;
 
     // Extract completion details
     const completionDetails = responseUsage.completion_tokens_details;
@@ -111,6 +114,8 @@ export class ResponseUsageFactory {
       reasoning_tokens: reasoningTokens,
       accepted_prediction_tokens: acceptedPredictionTokens,
       rejected_prediction_tokens: rejectedPredictionTokens,
+      prompt_tokens_details: { cached_tokens: cachedTokens },
+      completion_tokens_details: { reasoning_tokens: reasoningTokens },
     };
   }
 


### PR DESCRIPTION
## Summary
- include prompt cache hit tokens when deriving cached token counts for OpenAI-compatible responses
- surface cached and reasoning token details in usage outputs for more accurate cache statistics

## Testing
- npm run format
- npm run compile -- --progress
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69208322b0788324b003e75bc6b1369d)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fix cached token computation and expose token detail fields in OpenAI usage output.
> 
> - **OpenAI usage (`src/agent/core/ResponseUsage.ts`)**:
>   - **Cached tokens**: Derive `cached_tokens` using `prompt_tokens_details.cached_tokens` with fallback to `prompt_cache_hit_tokens`.
>   - **Expose details**: Include `prompt_tokens_details` (with `cached_tokens`) and `completion_tokens_details` (with `reasoning_tokens`) in returned usage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit acd9a75085b29aadb031ee7f6610459e5401a317. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->