### PR TITLE
Improve file selection lists

### DIFF
--- a/src/frontend/files/fileLister.ts
+++ b/src/frontend/files/fileLister.ts
@@ -11,7 +11,7 @@ import { getConfig, watchConfig } from '@utils/config';
 import { WorkspaceFS } from '@utils/files';
 
 // Local file imports
-import { getFilesInDirectory, getFilesRecursively } from './listing';
+import { getFilesRecursively } from './listing';
 
 const CHANNEL = 'FileLister';
 logger.initialize(CHANNEL);
@@ -122,7 +122,8 @@ export class FileLister {
           this.ignoredInputFiles,
         );
       case 'auxiliary':
-        return getFilesInDirectory(
+        return getFilesRecursively(
+          workspace,
           workspace,
           getIncludedExtensions('auxiliary'),
           this.ignoredFileExtensions,

--- a/src/webview/managers/FileManager.ts
+++ b/src/webview/managers/FileManager.ts
@@ -13,7 +13,6 @@ import { MAIN_VIEW_COMMANDS } from '@common/webview';
 import { fileLister } from '@frontend/files';
 import { uncapitalize } from '@frontend/ui/messageUtils';
 import * as logger from '@logger/logUtils';
-import { getConfig } from '@utils/config';
 import { WorkspaceFS } from '@utils/files';
 
 // Local imports - types
@@ -553,15 +552,10 @@ export class FileManager {
       return [];
     }
 
-    const modelNames = getConfig<string[]>('texra.models', []);
     const openedDocuments = workspace.textDocuments;
     const relevantFiles = openedDocuments
       .filter((doc) => doc.uri.scheme === 'file')
-      .map((doc) => workspace.asRelativePath(doc.uri.fsPath, false))
-      .filter((filePath) => {
-        const fileName = path.basename(filePath);
-        return !modelNames.some((model) => fileName.includes(`_${model}`));
-      });
+      .map((doc) => workspace.asRelativePath(doc.uri.fsPath, false));
 
     logger.debug(CHANNEL, `Found opened files: ${relevantFiles.join(', ')}`);
     return relevantFiles;

--- a/src/webview/modules/uiManagers/FileSelect.js
+++ b/src/webview/modules/uiManagers/FileSelect.js
@@ -36,6 +36,7 @@ export class FileSelect {
     }
     const previousValue = selectDiv.value;
     const normalizedFiles = Array.isArray(files) ? files : [];
+    const sortedFiles = [...normalizedFiles].sort((a, b) => a.localeCompare(b));
     const shouldPreserveValue =
       previousValue !== undefined &&
       previousValue !== null &&
@@ -43,10 +44,10 @@ export class FileSelect {
 
     selectDiv.innerHTML = '';
     this.addOption(selectDiv, '', 'None');
-    normalizedFiles.forEach((f) => this.addOption(selectDiv, f, f));
+    sortedFiles.forEach((f) => this.addOption(selectDiv, f, f));
 
     if (shouldPreserveValue) {
-      const hasPreviousOption = normalizedFiles.includes(previousValue);
+      const hasPreviousOption = sortedFiles.includes(previousValue);
       if (!hasPreviousOption) {
         this.addOption(selectDiv, previousValue, previousValue);
       }


### PR DESCRIPTION
## Summary
- sort single-file dropdowns alphabetically while preserving user selections
- allow adding any opened file without filtering model-suffixed names
- recurse through workspace directories when listing auxiliary files

## Testing
- npm run format
- npm run compile
- npm run lint


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692083f010308324b37cea4f45b57615)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Alphabetically sorts single-file dropdowns, includes all opened files without model-name filtering, and recursively lists auxiliary files across the workspace.
> 
> - **Webview UI**:
>   - **Single-file dropdowns**: Sort options alphabetically while preserving previous selection in `src/webview/modules/uiManagers/FileSelect.js`.
> - **Webview Manager**:
>   - **Opened files**: Include all currently opened files (remove model-suffix filtering) in `src/webview/managers/FileManager.ts`.
> - **Frontend Files**:
>   - **Auxiliary files**: Switch to `getFilesRecursively` for `auxiliary` to traverse workspace directories in `src/frontend/files/fileLister.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e1c61ee26ee0dab4c86dbc170906fbc6747b9cf0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->