### PR TITLE
Fix shell fallback quoting for array commands

### DIFF
--- a/src/test/utils/system/execUtils.test.ts
+++ b/src/test/utils/system/execUtils.test.ts
@@ -24,4 +24,15 @@ describe('executeCommand', () => {
     assert.strictEqual(result.stdout, 'fallback');
     assert.strictEqual(result.stderr, null);
   });
+
+  it('quotes array commands when falling back to the shell', async () => {
+    const result = await executeCommand([
+      'node -e "process.stdout.write(process.argv[1])"',
+      'argument with spaces | pipe',
+    ]);
+
+    assert.ok(result.success);
+    assert.strictEqual(result.stdout, 'argument with spaces | pipe');
+    assert.strictEqual(result.stderr, null);
+  });
 });

--- a/src/utils/system/execUtils.ts
+++ b/src/utils/system/execUtils.ts
@@ -93,7 +93,22 @@ export async function executeCommand(
         options.channel ?? CHANNEL,
         `Running command: ${commandForLog}`,
       );
-      const result = await execa(cmd, args, execaOptions);
+
+      let result;
+      try {
+        result = await execa(cmd, args, execaOptions);
+      } catch {
+        const fallbackCommand = shellQuote(command);
+        logger.debug(
+          options.channel ?? CHANNEL,
+          `Falling back to shell: ${fallbackCommand}`,
+        );
+        result = await execa(fallbackCommand, {
+          ...execaOptions,
+          shell: true,
+        });
+      }
+
       stdout = (result.stdout as string) ?? '';
       stderr = (result.stderr as string) ?? '';
       exitCode = result.exitCode ?? 1;


### PR DESCRIPTION
## Summary
- add shell-quoted fallback when array-based commands require shell execution
- log shell fallback usage and ensure arguments with special characters remain quoted
- cover shell fallback quoting with a new executeCommand test

## Testing
- npm run format
- npm run compile
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69208d51b8c88324bf01cfb5034db318)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a shell-quoted fallback when array-based commands fail direct exec, with logging and a test covering quoted arguments.
> 
> - **ExecUtils (`src/utils/system/execUtils.ts`)**
>   - When `command` is an array, wrap `execa(cmd, args)` in try/catch and on error fall back to shell execution using a shell-quoted command via `shell-quote`.
>   - Log the fallback path with the quoted command.
> - **Tests (`src/test/utils/system/execUtils.test.ts`)**
>   - Add test verifying array-command fallback preserves quoting for args with spaces and pipe.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 840c21fcffcd2cfa8ddfc19ffac8b80142be604a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->