### PR TITLE
Ensure Google tool calls include thought signatures

### DIFF
--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -1089,7 +1089,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
 
     type FunctionCallWithSignature = {
       call: FunctionCall;
-      thoughtSignature: string | undefined;
+      thoughtSignature: string;
     };
 
     const functionCalls = parts
@@ -1098,12 +1098,17 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
         if (!call?.name) {
           return null;
         }
+        if (
+          typeof part.thoughtSignature !== 'string' ||
+          part.thoughtSignature.length === 0
+        ) {
+          throw new Error(
+            'Google functionCall parts must include a thoughtSignature for tool use.',
+          );
+        }
         return {
           call,
-          thoughtSignature:
-            typeof part.thoughtSignature === 'string'
-              ? part.thoughtSignature
-              : undefined,
+          thoughtSignature: part.thoughtSignature,
         };
       })
       .filter((part): part is FunctionCallWithSignature => part !== null);
@@ -1164,6 +1169,12 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
       throw new Error('Function call id is required for follow-up messages');
     }
 
+    if (!call.thoughtSignature) {
+      throw new Error(
+        'Google function call follow-ups require a thoughtSignature from the model response.',
+      );
+    }
+
     const args = call.raw.args ?? {};
 
     const functionName = call.name;
@@ -1175,10 +1186,8 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
       callPart.functionCall.id = call.callId;
     }
 
-    if (call.thoughtSignature) {
-      (callPart as Part & { thoughtSignature: string }).thoughtSignature =
-        call.thoughtSignature;
-    }
+    (callPart as Part & { thoughtSignature: string }).thoughtSignature =
+      call.thoughtSignature;
 
     // Use the same ID for the result to maintain correlation
     const { attachments, sanitizedResult } = extractToolAttachments(result);

--- a/src/test/agent/modelHandlers/ModelHandlerGoogleGenAI.test.ts
+++ b/src/test/agent/modelHandlers/ModelHandlerGoogleGenAI.test.ts
@@ -364,6 +364,7 @@ describe('ModelHandlerGoogleGenAI tool attachments', () => {
       name: functionCall.name!,
       input: functionCall.args,
       raw: functionCall,
+      thoughtSignature: 'sig-call',
     } as const;
 
     const messages = await handler.createToolUseFollowUpMessages(

--- a/src/test/modelHandlers/ModelHandlerGoogle.test.ts
+++ b/src/test/modelHandlers/ModelHandlerGoogle.test.ts
@@ -91,6 +91,7 @@ describe('ModelHandlerGoogleGenAI.extractToolUse', () => {
                   name: 'read_file',
                   args: { path: 'syk_v5.tex' },
                 },
+                thoughtSignature: 'sig-123',
               },
             ],
           },
@@ -104,6 +105,29 @@ describe('ModelHandlerGoogleGenAI.extractToolUse', () => {
     assert.equal(toolInfo?.callId, 'google-call-1');
     assert.equal(toolInfo?.name, 'read_file');
     assert.deepEqual(toolInfo?.input, { path: 'syk_v5.tex' });
+    assert.equal(toolInfo?.thoughtSignature, 'sig-123');
+  });
+
+  it('throws when a function call part omits a thought signature', () => {
+    const response: any = {
+      candidates: [
+        {
+          content: {
+            parts: [
+              {
+                functionCall: {
+                  id: 'google-call-2',
+                  name: 'read_file',
+                  args: { path: 'syk_v6.tex' },
+                },
+              },
+            ],
+          },
+        },
+      ],
+    };
+
+    assert.throws(() => handler.extractToolUse(response));
   });
 });
 
@@ -127,6 +151,7 @@ describe('ModelHandlerGoogleGenAI.createToolUseFollowUpMessages', () => {
       name: 'read_file',
       input: { path: 'syk_v5.tex' },
       raw: { id: 'call-123', name: 'read_file', args: { path: 'syk_v5.tex' } },
+      thoughtSignature: 'sig-abc',
     } as const;
 
     const messages = await handler.createToolUseFollowUpMessages(
@@ -148,6 +173,26 @@ describe('ModelHandlerGoogleGenAI.createToolUseFollowUpMessages', () => {
     assert.equal('call_id' in functionCall, false);
     assert.equal('tool_call_id' in functionCall, false);
     assert.equal('tool_use_id' in functionCall, false);
+    assert.equal((callPart as any).thoughtSignature, 'sig-abc');
+  });
+
+  it('throws when the follow-up call lacks a thought signature', async () => {
+    const providerCall = {
+      provider: 'google',
+      callId: 'call-456',
+      name: 'read_file',
+      input: { path: 'syk_v6.tex' },
+      raw: { id: 'call-456', name: 'read_file', args: { path: 'syk_v6.tex' } },
+    } as const;
+
+    await assert.rejects(() =>
+      handler.createToolUseFollowUpMessages(
+        undefined,
+        providerCall,
+        {},
+        undefined,
+      ),
+    );
   });
 });
 


### PR DESCRIPTION
## Summary
- enforce thought signatures when extracting Google GenAI function calls and creating follow-up messages
- propagate the provided thought signature onto follow-up call parts
- add coverage for missing signatures and update existing tests to include them

## Testing
- npm run format
- npm run compile
- npm run lint


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920c02e9bd4832482833f99c868538c)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Require `thoughtSignature` on Google GenAI function call parts, propagate it in follow-up messages, and add tests including failure cases.
> 
> - **ModelHandler (`src/agent/modelHandlers/modelHandlerGoogleGenAI.ts`)**:
>   - Enforce `thoughtSignature` presence on `functionCall` parts in `extractToolUse` (throws if missing); type tightened to `string`.
>   - Require and always attach `thoughtSignature` on follow-up call parts in `createToolUseFollowUpMessages` (throws if absent).
> - **Tests**:
>   - Update existing tests to include `thoughtSignature` in tool calls and verify propagation on follow-ups.
>   - Add new tests asserting errors when missing `thoughtSignature` in extraction or follow-up creation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d9ebda15ad90c47152aae2d7bdb32fef92caed01. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->