### PR TITLE
fix: streamline error logs

### DIFF
--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -224,12 +224,6 @@ class ResponseModelInvocationNode<C> extends BaseNode<ResponseCycleContext<C>> {
 
       return { skipped: false, value: { response, responseTime } };
     } catch (error) {
-      const formattedError = formatProviderHttpError(error);
-      const message = `Model invocation failed: ${formattedError.message}`;
-      options.logger.error(message, {
-        messageType: MESSAGE_TYPES.PROGRESS_STATUS,
-        data: formattedError,
-      });
       state.shouldStop = true;
       state.endTurn = false;
       throw error;

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -521,7 +521,6 @@ export class ModelHandlerAnthropic extends ModelHandler<
     } catch (err) {
       const formattedError = formatProviderHttpError(err);
       this.logger.error(`Error creating response: ${formattedError.message}`, {
-        messageType: MESSAGE_TYPES.PROGRESS_STATUS,
         data: formattedError,
       });
       throw err;
@@ -645,7 +644,6 @@ export class ModelHandlerAnthropic extends ModelHandler<
           this.logger.error(
             `Failed to upload document ${filename}: ${formattedError.message}`,
             {
-              messageType: MESSAGE_TYPES.PROGRESS_STATUS,
               data: formattedError,
             },
           );

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -603,10 +603,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
       const formattedError = formatProviderHttpError(error);
       this.logger.error(
         `Error during Google GenAI Chat API call: ${formattedError.message}`,
-        {
-          messageType: MESSAGE_TYPES.PROGRESS_STATUS,
-          data: formattedError,
-        },
+        { data: formattedError },
       );
       if (
         error instanceof Error &&

--- a/src/agent/modelHandlers/modelHandlerKimi.ts
+++ b/src/agent/modelHandlers/modelHandlerKimi.ts
@@ -232,7 +232,6 @@ export class ModelHandlerKimi extends ModelHandlerOpenAI {
         this.logger.error(
           `Error in createResponse for Kimi thinking model: ${formattedError.message}`,
           {
-            messageType: MESSAGE_TYPES.PROGRESS_STATUS,
             data: formattedError,
           },
         );

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -331,7 +331,6 @@ export class ModelHandlerOpenAI<
         this.logger.error(
           `Error in createResponse(streaming): ${formattedError.message}`,
           {
-            messageType: MESSAGE_TYPES.PROGRESS_STATUS,
             data: formattedError,
           },
         );
@@ -355,7 +354,6 @@ export class ModelHandlerOpenAI<
         this.logger.error(
           `Error in createResponse: ${formattedError.message}`,
           {
-            messageType: MESSAGE_TYPES.PROGRESS_STATUS,
             data: formattedError,
           },
         );

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -478,7 +478,6 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       this.logger.error(
         `Failed to upload file ${filename}: ${formattedError.message}`,
         {
-          messageType: MESSAGE_TYPES.PROGRESS_STATUS,
           data: formattedError,
         },
       );
@@ -660,7 +659,6 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     } catch (err) {
       const formattedError = formatProviderHttpError(err);
       this.logger.error(`Error in createResponse: ${formattedError.message}`, {
-        messageType: MESSAGE_TYPES.PROGRESS_STATUS,
         data: formattedError,
       });
       throw err;

--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -572,13 +572,15 @@ export class LogEntryFormatter {
       ? `<span class="level-${level}">${level.toUpperCase().padEnd(8)}</span> `
       : '';
 
+    const encodedMessageText = encodeHtml(text ?? '');
+
     const htmlMessage =
       prefix +
       `<span class="timestamp" title="${tooltipTimestamp}">${emoji}${
         verbose ? ` [${timeDisplay}]` : ''
       }</span> ` +
       levelMarkup +
-      `<span class="message-${level}">${text}</span>` +
+      `<span class="message-${level}">${encodedMessageText}</span>` +
       `</div>`;
 
     // Convert HTML string to DOM element


### PR DESCRIPTION
## Summary
- stop logging provider failures in the model invocation node and Google GenAI handler to avoid duplicated progress errors
- HTML-escape default progress log messages so error payloads render safely

## Testing
- npm run format
- npm run compile
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69208eb88b6c83249ef18804b3cf9490)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes redundant provider error progress logs across invocation/handlers and HTML-escapes default log message text for safe rendering.
> 
> - **Logging**:
>   - Remove progress-status error logs in `ResponseCycleFlow` model invocation catch and provider handlers (`modelHandlerAnthropic`, `modelHandlerGoogleGenAI`, `modelHandlerKimi`, `modelHandlerOpenAI`, `modelHandlerOpenAIResponse`), retaining concise error entries with `data` payloads.
> - **Progress View**:
>   - HTML-escape default log message text in `src/progressView/modules/formatters.js` to prevent unsafe rendering.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3122728ec8b280b18ac37b832cc1c613328a0729. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->