### PR TITLE
Require FileLocations for run support files

### DIFF
--- a/src/agent/output/OutputHandler.ts
+++ b/src/agent/output/OutputHandler.ts
@@ -28,6 +28,7 @@ import {
   flexibleFS,
   WorkspaceFS,
   AbsoluteFS,
+  pathToLocation,
   getComparablePath,
 } from '@utils/files';
 // Type imports
@@ -141,17 +142,16 @@ export class OutputHandler implements IOutputHandler {
     return this.baseFiles.filter((candidate) => candidate !== null);
   }
 
-  private collectRunSupportFiles(): string[] {
-    const extras = new Set<string>();
-    const add = (value?: string | null) => {
+  private collectRunSupportFiles(): FileLocation[] {
+    const extras = new Map<string, FileLocation>();
+    const add = (value?: string | FileLocation | null) => {
       if (!value) {
         return;
       }
-      const trimmed = value.trim();
-      if (trimmed.length === 0) {
-        return;
-      }
-      extras.add(trimmed);
+
+      const location =
+        typeof value === 'string' ? pathToLocation(value) : value;
+      extras.set(getComparablePath(location), location);
     };
 
     const cfg = this.agentConfig;
@@ -164,7 +164,7 @@ export class OutputHandler implements IOutputHandler {
     add(cfg.inputFile ?? undefined);
     cfg.inputFiles.forEach((file) => add(file));
 
-    return Array.from(extras);
+    return Array.from(extras.values());
   }
 
   public setActiveRun(runId?: string | null): void {

--- a/src/utils/files/taskRunStorage.ts
+++ b/src/utils/files/taskRunStorage.ts
@@ -286,7 +286,7 @@ export class TaskRunFileService {
   public async prepareRunWorkspace(
     baseFiles: FileLocation[],
     options: {
-      linkFiles?: string[];
+      linkFiles?: FileLocation[];
       mirrorBaseFiles?: boolean;
     } = {},
   ): Promise<void> {
@@ -306,18 +306,11 @@ export class TaskRunFileService {
     await this.ensureRunDirectory();
 
     const linkTargets = new Set<FileLocation>();
-    const workspaceRoot = WorkspaceFS.getPath()!;
-    const registerLink = (candidate?: string | null) => {
+    const registerLink = (candidate?: FileLocation | null) => {
       if (!candidate) {
         return;
       }
-      const trimmed = candidate.trim();
-      if (trimmed.length === 0) {
-        return;
-      }
-      // Convert absolute path to FileLocation
-      const relativePath = path.relative(workspaceRoot, trimmed);
-      linkTargets.add(createWorkspaceLocation(trimmed, relativePath));
+      linkTargets.add(candidate);
     };
 
     if (options.mirrorBaseFiles !== false) {


### PR DESCRIPTION
## Summary
- collect run support files as FileLocation entries and deduplicate by comparable path
- require run workspace preparation link inputs to already-resolved FileLocations

## Testing
- npm run format
- npm run compile
- npm run lint (warns on existing eqeqeq violations)
- npm test *(fails: VS Code test binary needs libgtk-3.so.0 in this container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69223b7a1b188324905e435ce5b4444b)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch run support and workspace link handling to `FileLocation` types with comparable-path deduplication.
> 
> - **OutputHandler**:
>   - Collect run support files as `FileLocation[]` instead of `string[]`, converting via `pathToLocation` and deduplicating by `getComparablePath`.
> - **TaskRunFileService**:
>   - Change `prepareRunWorkspace` signature to accept `linkFiles?: FileLocation[]` and pass through `FileLocation` values directly.
>   - Simplify link registration (no string trimming/relativizing); mirror using provided `FileLocation`s.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 583486cb9d0016b4c93121b2c8c2563e13759529. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->