### PR TITLE
Fix missing API key banner on initial load

### DIFF
--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -218,6 +218,15 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
         opt.title = `Provider: ${provider ?? 'N/A'}, Context: ${context ?? 'N/A'}, Cost: ${cost ?? 'N/A'}`;
       }
     });
+
+    const selectedOption = getSelectedOptionElement(selectElement);
+    if (selectedOption?.dataset?.requiresKey === 'true') {
+      bannerManager.showBanner(ELEMENT_IDS.API_KEY_BANNER, {
+        provider: selectedOption.dataset?.provider,
+      });
+    } else {
+      bannerManager.hideBanner(ELEMENT_IDS.API_KEY_BANNER);
+    }
   }
 
   _applyAgentOptions(selectElement, optionsHtml) {

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -26,7 +26,10 @@ import { mainViewState } from './mainViewState.js';
 // Local imports - UI managers
 import { fileSelect } from './uiManagers/FileSelect.js';
 import { bannerManager } from './uiManagers/BannerManager.js';
-import { updateModelApiKeyBanner } from './uiManagers/apiKeyBannerUtils.js';
+import {
+  hideModelApiKeyBanner,
+  updateModelApiKeyBanner,
+} from './uiManagers/apiKeyBannerUtils.js';
 import { fileList } from './uiManagers/FileList.js';
 import {
   safeSetElementValue,
@@ -78,8 +81,7 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
         updateModelApiKeyBanner(this._getElement('model'), m, {
           forceShow: true,
         }),
-      [MAIN_VIEW_COMMANDS.HIDE_API_KEY_BANNER]: () =>
-        bannerManager.hideBanner(ELEMENT_IDS.API_KEY_BANNER),
+      [MAIN_VIEW_COMMANDS.HIDE_API_KEY_BANNER]: () => hideModelApiKeyBanner(),
       [MAIN_VIEW_COMMANDS.SHOW_AGENT_CONFIG_BANNER]: (m) =>
         bannerManager.showBanner(ELEMENT_IDS.AGENT_CONFIG_BANNER, m),
       [MAIN_VIEW_COMMANDS.HIDE_AGENT_CONFIG_BANNER]: () =>

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -231,20 +231,7 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
     }
     const previous = selectElement.value;
     selectElement.innerHTML = optionsHtml ?? '';
-    if (previous) {
-      selectElement.value = previous;
-      if (
-        selectElement.value !== previous &&
-        getSelectOptionElements(selectElement).length > 0
-      ) {
-        const fallbackOption = getSelectOptionElements(selectElement).find(
-          (option) => !option.disabled,
-        );
-        if (fallbackOption) {
-          selectElement.value = fallbackOption.value;
-        }
-      }
-    }
+    this._restoreAgentSelection(selectElement, previous);
 
     getSelectOptionElements(selectElement).forEach((opt) => {
       this._decorateAgentOption(opt);
@@ -319,6 +306,49 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
     }
     const element = this._getElement(selectId);
     return isSelectLikeElement(element) ? element : null;
+  }
+
+  _getSessionTypeForSelect(selectElement) {
+    if (!selectElement?.id) {
+      return null;
+    }
+    const entry = Object.entries(AGENT_SELECT_IDS).find(
+      ([, id]) => id === selectElement.id,
+    );
+    return entry ? entry[0] : null;
+  }
+
+  _getSavedAgentValue(sessionType) {
+    const state = mainViewState.get?.() ?? {};
+    if (sessionType === SESSION_TYPES.TOOL_USE) {
+      return state.toolUseAgent ?? state.agent ?? '';
+    }
+    if (sessionType === SESSION_TYPES.WORKFLOW) {
+      return state.workflowAgent ?? state.agent ?? '';
+    }
+    return '';
+  }
+
+  _restoreAgentSelection(selectElement, previousValue) {
+    const sessionType = this._getSessionTypeForSelect(selectElement);
+    const savedValue = sessionType ? this._getSavedAgentValue(sessionType) : '';
+    const candidates = [savedValue, previousValue].filter(Boolean);
+
+    const options = getSelectOptionElements(selectElement);
+    const match = candidates.find((value) =>
+      options.some((option) => option.value === value),
+    );
+
+    if (match) {
+      selectElement.value = match;
+      return;
+    }
+
+    const fallbackOption =
+      options.find((option) => !option.disabled) ?? options[0];
+    if (fallbackOption) {
+      selectElement.value = fallbackOption.value;
+    }
   }
 
   _getActiveAgentSelection() {

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -26,6 +26,7 @@ import { mainViewState } from './mainViewState.js';
 // Local imports - UI managers
 import { fileSelect } from './uiManagers/FileSelect.js';
 import { bannerManager } from './uiManagers/BannerManager.js';
+import { updateModelApiKeyBanner } from './uiManagers/apiKeyBannerUtils.js';
 import { fileList } from './uiManagers/FileList.js';
 import {
   safeSetElementValue,
@@ -74,7 +75,9 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
       ...createRecordingHandlers({ postHandle: ctx.postHandle }),
       ...createFileHandlers(ctx),
       [MAIN_VIEW_COMMANDS.SHOW_API_KEY_BANNER]: (m) =>
-        bannerManager.showBanner(ELEMENT_IDS.API_KEY_BANNER, m),
+        updateModelApiKeyBanner(this._getElement('model'), m, {
+          forceShow: true,
+        }),
       [MAIN_VIEW_COMMANDS.HIDE_API_KEY_BANNER]: () =>
         bannerManager.hideBanner(ELEMENT_IDS.API_KEY_BANNER),
       [MAIN_VIEW_COMMANDS.SHOW_AGENT_CONFIG_BANNER]: (m) =>
@@ -219,14 +222,7 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
       }
     });
 
-    const selectedOption = getSelectedOptionElement(selectElement);
-    if (selectedOption?.dataset?.requiresKey === 'true') {
-      bannerManager.showBanner(ELEMENT_IDS.API_KEY_BANNER, {
-        provider: selectedOption.dataset?.provider,
-      });
-    } else {
-      bannerManager.hideBanner(ELEMENT_IDS.API_KEY_BANNER);
-    }
+    updateModelApiKeyBanner(selectElement);
   }
 
   _applyAgentOptions(selectElement, optionsHtml) {

--- a/src/webview/modules/uiManagers/SettingsButtonManager.js
+++ b/src/webview/modules/uiManagers/SettingsButtonManager.js
@@ -15,6 +15,7 @@ import { mainViewState } from '../mainViewState.js';
 import { BaseUIManager } from './BaseUIManager.js';
 import { webviewEventBus } from '../eventBus.js';
 import { bannerManager } from './BannerManager.js';
+import { updateModelApiKeyBanner } from './apiKeyBannerUtils.js';
 import {
   safeGetElementById,
   safeGetElementChecked,
@@ -415,7 +416,6 @@ export class SettingsButtonManager extends BaseUIManager {
       ) {
         return;
       }
-      const selectedOption = getSelectedOptionElement(selectElement);
 
       // Always notify about model selection
       this.vscode.postMessage({
@@ -424,23 +424,7 @@ export class SettingsButtonManager extends BaseUIManager {
       });
       this.state.save();
 
-      // Check if the selected option requires an API key (using data attribute)
-      // Show banner to guide API key setup if needed
-      if (selectedOption?.dataset?.requiresKey === 'true') {
-        // Get provider from the option
-        const provider = selectedOption?.dataset?.provider || 'Unknown';
-
-        // Show banner with provider info - user can click banner button to access setup
-        this.vscode.postMessage({
-          command: MAIN_VIEW_COMMANDS.SHOW_API_KEY_BANNER,
-          provider,
-        });
-      } else {
-        // Hide banner for models that don't require API keys
-        this.vscode.postMessage({
-          command: MAIN_VIEW_COMMANDS.HIDE_API_KEY_BANNER,
-        });
-      }
+      updateModelApiKeyBanner(selectElement);
     });
   }
 

--- a/src/webview/modules/uiManagers/apiKeyBannerUtils.js
+++ b/src/webview/modules/uiManagers/apiKeyBannerUtils.js
@@ -1,0 +1,46 @@
+// Local imports - webview
+import { ELEMENT_IDS } from '../constants.js';
+import { bannerManager } from './BannerManager.js';
+import {
+  getSelectedOptionElement,
+  isSelectLikeElement,
+} from '@common/domUtils.js';
+
+/**
+ * Syncs the API key banner with the currently selected model option.
+ *
+ * If a banner payload is provided, it will be used to show the banner even
+ * when the select element is not yet available. Provider information is
+ * derived from the payload or falls back to the selected option so the banner
+ * remains model-specific.
+ */
+export function updateModelApiKeyBanner(
+  selectElement,
+  bannerPayload = {},
+  options = {},
+) {
+  const { forceShow = false } = options;
+
+  if (!isSelectLikeElement(selectElement)) {
+    if (forceShow) {
+      bannerManager.showBanner(ELEMENT_IDS.API_KEY_BANNER, bannerPayload);
+    }
+    return;
+  }
+
+  const selectedOption = getSelectedOptionElement(selectElement);
+  const provider = bannerPayload.provider ?? selectedOption?.dataset?.provider;
+  const requiresKey =
+    bannerPayload.requiresKey === true ||
+    selectedOption?.dataset?.requiresKey === 'true';
+
+  if (forceShow || requiresKey) {
+    bannerManager.showBanner(ELEMENT_IDS.API_KEY_BANNER, {
+      ...bannerPayload,
+      provider,
+    });
+    return;
+  }
+
+  bannerManager.hideBanner(ELEMENT_IDS.API_KEY_BANNER);
+}

--- a/src/webview/modules/uiManagers/apiKeyBannerUtils.js
+++ b/src/webview/modules/uiManagers/apiKeyBannerUtils.js
@@ -6,6 +6,8 @@ import {
   isSelectLikeElement,
 } from '@common/domUtils.js';
 
+let apiKeyBannerState = { forced: false, visible: false };
+
 /**
  * Syncs the API key banner with the currently selected model option.
  *
@@ -20,27 +22,45 @@ export function updateModelApiKeyBanner(
   options = {},
 ) {
   const { forceShow = false } = options;
+  const wasForced = apiKeyBannerState.forced === true;
+  const persistForced = wasForced || forceShow;
 
   if (!isSelectLikeElement(selectElement)) {
     if (forceShow) {
       bannerManager.showBanner(ELEMENT_IDS.API_KEY_BANNER, bannerPayload);
+      apiKeyBannerState = { forced: persistForced, visible: true };
     }
     return;
   }
 
   const selectedOption = getSelectedOptionElement(selectElement);
-  const provider = bannerPayload.provider ?? selectedOption?.dataset?.provider;
   const requiresKey =
-    bannerPayload.requiresKey === true ||
-    selectedOption?.dataset?.requiresKey === 'true';
+    bannerPayload.requiresKey !== undefined
+      ? bannerPayload.requiresKey === true
+      : selectedOption?.dataset?.requiresKey === 'true';
+  const provider =
+    bannerPayload.provider ??
+    (requiresKey ? selectedOption?.dataset?.provider : undefined);
 
   if (forceShow || requiresKey) {
-    bannerManager.showBanner(ELEMENT_IDS.API_KEY_BANNER, {
-      ...bannerPayload,
-      provider,
-    });
+    const payload = provider
+      ? { ...bannerPayload, provider }
+      : { ...bannerPayload };
+
+    bannerManager.showBanner(ELEMENT_IDS.API_KEY_BANNER, payload);
+    apiKeyBannerState = { forced: persistForced, visible: true };
     return;
   }
 
+  if (persistForced) {
+    return;
+  }
+
+  bannerManager.hideBanner(ELEMENT_IDS.API_KEY_BANNER);
+  apiKeyBannerState = { forced: false, visible: false };
+}
+
+export function hideModelApiKeyBanner() {
+  apiKeyBannerState = { forced: false, visible: false };
   bannerManager.hideBanner(ELEMENT_IDS.API_KEY_BANNER);
 }


### PR DESCRIPTION
## Summary
- show the API key banner during model option application when the selected option lacks a configured key
- hide the banner when the selected model does not require a key to keep the initial view accurate

## Testing
- npm run format
- npm run compile
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924a11881f48324aa3c61f69e0b1242)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Centralizes API key banner handling and ensures it updates with model selection (including initial load), while improving agent selection restoration.
> 
> - **Webview UI – API key banner**:
>   - Add `uiManagers/apiKeyBannerUtils.js` with `updateModelApiKeyBanner` and `hideModelApiKeyBanner` to manage banner state, support `forceShow`, and derive provider from the selected model option.
>   - Update `messageHandlers.js` to use the new utils for `SHOW_API_KEY_BANNER`/`HIDE_API_KEY_BANNER` and to call `updateModelApiKeyBanner` after applying `model` options.
>   - Update `SettingsButtonManager.js` to invoke `updateModelApiKeyBanner` on `model` changes instead of manual show/hide messaging.
> - **Agent selection**:
>   - Add `_getSessionTypeForSelect`, `_getSavedAgentValue`, and `_restoreAgentSelection` to restore agent dropdowns from saved state or previous value; update `_applyAgentOptions` to use this restoration.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 730ea94916ecbda6abf7a5d849b148ed837437ac. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->