### PR TITLE
Document Opus 4.5 configuration updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.34.6] - 2025-11-24
+
+### Improvements
+
+- Added Claude Opus 4.5 (thinking and regular) to the default model catalog,
+  VS Code settings, and documentation so the latest Anthropic tier is
+  available out of the box.
+
 ## [0.34.5] - 2025-11-21
 
 ### Improvements

--- a/docs/guide/models.md
+++ b/docs/guide/models.md
@@ -24,8 +24,10 @@ Known for strong instruction following and context handling.
 
 | Model ID    | Key Strength / Use Case                     | Relative Cost | Relative Speed | Notes                           |
 | :---------- | :------------------------------------------ | :------------ | :------------- | :------------------------------ |
-| `opus41T`   | Latest Opus with explicit reasoning steps   | $$$$          | Slow           | Claude 4.1 Opus with thinking   |
-| `opus41`    | Latest high quality, complex tasks          | $$$$          | Slow           | Claude 4.1 Opus                 |
+| `opus45T`   | Latest Opus with explicit reasoning steps   | $$$$          | Slow           | Claude 4.5 Opus with thinking   |
+| `opus45`    | Latest high quality, complex tasks          | $$$$          | Slow           | Claude 4.5 Opus                 |
+| `opus41T`   | Previous-gen Opus with explicit reasoning   | $$$$          | Slow           | Claude 4.1 Opus with thinking   |
+| `opus41`    | Previous-gen high quality, complex tasks    | $$$$          | Slow           | Claude 4.1 Opus                 |
 | `opus4T`    | Opus 4 with explicit reasoning steps        | $$$$          | Slow           | Claude 4 Opus with thinking     |
 | `opus4`     | Opus 4 high quality, complex tasks          | $$$$          | Slow           | Claude 4 Opus                   |
 | `sonnet45T` | Latest Sonnet with explicit reasoning steps | $$$           | Medium         | Claude 4.5 Sonnet with thinking |
@@ -210,15 +212,12 @@ The specific models available by default and their identifiers (`sonnet45`, `gpt
 ```json
 "texra.models": [
   "gemini3p",
-  "gemini25p",
-  "gemini25f",
-  "opus41T",
   "sonnet45T",
-  "sonnet4T",
-  "gpt5",
+  "opus45T",
+  "gpt51",
   "gpt41",
-  "deepseek",
   "deepseekT",
+  "kimi2T",
   "kimi2",
   "qwen3max",
   "grok4"

--- a/docs/guide/quick-start.md
+++ b/docs/guide/quick-start.md
@@ -250,7 +250,7 @@ Here are some common tasks you can try with TeXRA:
 ### Improving Writing Style
 
 - **Agent**: `polish`
-- **Model**: `opus41` or `sonnet45T`
+- **Model**: `opus45` or `sonnet45T`
 - **Instruction**: "Improve the writing style to make it more engaging and clear. Enhance the flow between paragraphs while preserving all technical content."
 
 ## Understanding the Output

--- a/package.json
+++ b/package.json
@@ -63,6 +63,8 @@
             "items": {
               "type": "string",
               "enum": [
+                "opus45T",
+                "opus45",
                 "opus41T",
                 "opus41",
                 "opus4T",
@@ -114,6 +116,7 @@
             "default": [
               "gemini3p",
               "sonnet45T",
+              "opus45T",
               "gpt51",
               "gpt41",
               "deepseekT",
@@ -122,7 +125,7 @@
               "qwen3max",
               "grok4"
             ],
-            "description": "List of available models. Model codes: opus41T/opus41 (Claude Opus 4.1 Thinking/Regular), opus4T/opus4 (Claude Opus 4 Thinking/Regular), sonnet45T/sonnet45 (Claude Sonnet 4.5 Thinking/Regular), haiku45T/haiku45 (Claude Haiku 4.5 Thinking/Regular), sonnet4T/sonnet4 (Claude Sonnet 4 Thinking/Regular), sonnet37T/sonnet37 (Claude Sonnet 3.7 Thinking/Regular), o4-/o3/o3pro/o3-/o1pro/o1/gptoss/gptoss- (OpenAI reasoning models), gpt51/gpt5/gpt5pro/gpt5-/gpt5--/gpt41/gpt4o (GPT-5.1/5/5 Pro/5 Mini/5 Nano/4.1/4O), gemini3p/gemini25p/gemini25f/gemini2fT (Gemini 3 Pro Preview, 2.5 Pro/Flash, 2.0 Flash Thinking), deepseek/deepseekT(DeepSeek V3.1 Regular/Thinking), dsv3/dsr1 (DeepSeek V3/R1), grok4 (Grok 4), grok3 (Grok 3), qwen3max (Qwen-Max latest), qwenplus (Qwen Plus latest), qwenturbo (Qwen Turbo), kimit/kimiv/kimi2/kimi2+/kimi2T/kimi2T+ (Kimi Thinking/Vision/K2/K2 Turbo/K2 Thinking/K2 Thinking Turbo)",
+            "description": "List of available models. Model codes: opus45T/opus45 (Claude Opus 4.5 Thinking/Regular), opus41T/opus41 (Claude Opus 4.1 Thinking/Regular), opus4T/opus4 (Claude Opus 4 Thinking/Regular), sonnet45T/sonnet45 (Claude Sonnet 4.5 Thinking/Regular), haiku45T/haiku45 (Claude Haiku 4.5 Thinking/Regular), sonnet4T/sonnet4 (Claude Sonnet 4 Thinking/Regular), sonnet37T/sonnet37 (Claude Sonnet 3.7 Thinking/Regular), o4-/o3/o3pro/o3-/o1pro/o1/gptoss/gptoss- (OpenAI reasoning models), gpt51/gpt5/gpt5pro/gpt5-/gpt5--/gpt41/gpt4o (GPT-5.1/5/5 Pro/5 Mini/5 Nano/4.1/4O), gemini3p/gemini25p/gemini25f/gemini2fT (Gemini 3 Pro Preview, 2.5 Pro/Flash, 2.0 Flash Thinking), deepseek/deepseekT(DeepSeek V3.1 Regular/Thinking), dsv3/dsr1 (DeepSeek V3/R1), grok4 (Grok 4), grok3 (Grok 3), qwen3max (Qwen-Max latest), qwenplus (Qwen Plus latest), qwenturbo (Qwen Turbo), kimit/kimiv/kimi2/kimi2+/kimi2T/kimi2T+ (Kimi Thinking/Vision/K2/K2 Turbo/K2 Thinking/K2 Thinking Turbo)",
             "scope": "resource"
           },
           "texra.agentOutputs.storageMode": {
@@ -264,6 +267,8 @@
             "type": "string",
             "default": "sonnet45",
             "enum": [
+              "opus45T",
+              "opus45",
               "opus41T",
               "opus41",
               "opus4T",

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -324,6 +324,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
       // Remove temperature for Claude 4 models when thinking is enabled as per Anthropic docs
       if (
         this.config.fullName.includes('claude-opus-4') ||
+        this.config.fullName.includes('claude-opus-4-5') ||
         this.config.fullName.includes('claude-sonnet-4-5') ||
         this.config.fullName.includes('claude-sonnet-4') ||
         this.config.fullName.includes('claude-haiku-4-5') ||

--- a/src/model/providers/anthropicModels.ts
+++ b/src/model/providers/anthropicModels.ts
@@ -26,6 +26,44 @@ const ANTHROPIC_DEFAULT_CAPABILITIES: ModelCapabilities = {
 };
 
 export const ANTHROPIC_MODELS: Record<string, ModelConfig> = {
+  opus45T: {
+    name: 'opus45T',
+    fullName: 'claude-opus-4-5',
+    openrouterFullName: 'anthropic/claude-opus-4.5:thinking',
+    provider: ModelProvider.ANTHROPIC,
+    maxOutputTokens: 64000, // Official Claude Opus 4.5 limit - streaming recommended for large outputs
+    contextWindow: 200000,
+    inputPrice: 5.0,
+    outputPrice: 25.0,
+    capabilities: {
+      ...ANTHROPIC_DEFAULT_CAPABILITIES,
+      supportsNativeMCPServer: true,
+      supportsNativeWebSearch: true,
+      supportsNativeCodeExecution: true,
+      supportsAssistantPrefill: false,
+      supportsReasoning: true,
+      supportsInterleavedThinking: true,
+    } satisfies ModelCapabilities,
+    openRouterOnly: false,
+  },
+  opus45: {
+    name: 'opus45',
+    fullName: 'claude-opus-4-5',
+    openrouterFullName: 'anthropic/claude-opus-4.5',
+    provider: ModelProvider.ANTHROPIC,
+    maxOutputTokens: 64000, // Official Claude Opus 4.5 limit - streaming recommended for large outputs
+    contextWindow: 200000,
+    inputPrice: 5.0,
+    outputPrice: 25.0,
+    capabilities: {
+      ...ANTHROPIC_DEFAULT_CAPABILITIES,
+      supportsNativeWebSearch: true,
+      supportsNativeCodeExecution: true,
+      supportsAssistantPrefill: true,
+      supportsReasoning: false,
+    } satisfies ModelCapabilities,
+    openRouterOnly: false,
+  },
   opus41T: {
     name: 'opus41T',
     fullName: 'claude-opus-4-1-20250805',


### PR DESCRIPTION
## Summary
- align the changelog with version 0.34.6 by recording the Opus 4.5 catalog and documentation updates under the current release.

## Testing
- npm run format
- npm run compile
- npm run lint


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924abd1ed0483249173dc1ae3ec32a8)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Claude Opus 4.5 (thinking and regular) to the catalog, defaults, and docs, with handler tweaks for thinking mode.
> 
> - **Models/Provider**:
>   - Add `opus45T` and `opus45` to `ANTHROPIC_MODELS` with capabilities, pricing, and OpenRouter IDs.
> - **VS Code Settings (`package.json`)**:
>   - Include `opus45T`/`opus45` in `texra.models` and `texra.model.instructionPolishModel` enums; add `opus45T` to defaults.
>   - Update model description to document Opus 4.5 codes.
> - **Anthropic Handler**:
>   - Treat `claude-opus-4-5` as a thinking model variant that drops `temperature` when reasoning is enabled.
> - **Docs**:
>   - Update model guide: add `opus45T`/`opus45`, demote `opus41*` to previous-gen, refresh default `texra.models` snippet, and quick-start recommends `opus45` for polishing.
> - **Changelog**:
>   - Record 0.34.6 improvements for Opus 4.5 availability across catalog, settings, and docs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 08a09183e903cf5cab1288b2970571c8bb4c4751. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->