### PR TITLE
refactor: generalize agent prompts to be domain-agnostic

### DIFF
--- a/resources/agents/correct.yaml
+++ b/resources/agents/correct.yaml
@@ -15,14 +15,14 @@ prompts:
     When writing a professional *.tex \LaTeX document, you must:
     \begin{itemize}
         \item Use appropriate notation and terminology consistently throughout the text.
-        \item Keep the comments that start with `%' in the document. For example, do not delete ``% We found the time step $\delta=1/16=0.0625$ to give sufficient accuracy for our simulations.'' in the output.
+        \item Keep the comments that start with `%' in the document. For example, do not delete ``% We set $\epsilon=0.01$ for sufficient precision in our numerical analysis.'' in the output.
         \item If there are duplicate labels, handle the collision correctly by renaming one of them using a condensed label and adjust accordingly where the labelled items are referenced.
         \item Use $\ldots$ or $\cdots$ rather than $\dots$ or ``...'' to achieve an ellipsis following the best practice of chktex.
-        \item Use non-breaking spaces when referencing equations, figures, sections, and references, e.g., use ``Eq.~\ref{eq:label}''; ``see Fig.~\ref{fig:label}''; ``Section~\ref{sec:label}''; ``see Ref.~\cite{Jarzynski1997Nonequilibrium}''.
+        \item Use non-breaking spaces when referencing equations, figures, sections, and references, e.g., use ``Eq.~\ref{eq:label}''; ``see Fig.~\ref{fig:label}''; ``Section~\ref{sec:label}''; ``see Ref.~\cite{AuthorYear}''.
         \item Use either `` or '' as an alternative to `"'.
         \item Put punctuation outside inner math mode.
         \item Use $\tr$ instead of \text{tr} or \textrm{tr}.
-        \item Prefer $\bra{...}$ and $\ket{...}$ over $|...\rangle$ and $\langle...|$.
+        \item If using Dirac notation (e.g., in quantum mechanics), prefer $\bra{...}$ and $\ket{...}$ over $|...\rangle$ and $\langle...|$.
         \item Treat formulas as part of the sentences and add punctuation accordingly in the displayed math environments depending on the next sentence.
         \item When in doubt, follow the best practice that will result in zero warnings when checked by chktex.
         \item Use the math commands defined in the auxiliary file command.tex if provided.

--- a/resources/agents/correct_multiple.yaml
+++ b/resources/agents/correct_multiple.yaml
@@ -16,14 +16,14 @@ prompts:
     When writing a professional \LaTeX document, you must:
     \begin{itemize}
         \item Use appropriate notation and terminology consistently throughout the text.
-        \item Keep the comments that start with `%' in the document. For example, do not delete ``% We found the time step $\delta=1/16=0.0625$ to give sufficient accuracy for our simulations.'' in the output.
+        \item Keep the comments that start with `%' in the document. For example, do not delete ``% We set $\epsilon=0.01$ for sufficient precision in our numerical analysis.'' in the output.
         \item If there are duplicate labels, handle the collision correctly by renaming one of them using a condensed label and adjust accordingly where the labelled items are referenced.
         \item Use $\ldots$ or $\cdots$ rather than $\dots$ or ``...'' to achieve an ellipsis following the best practice of chktex.
-        \item Use non-breaking spaces when referencing equations, figures, sections, and references, e.g., use ``Eq.~\ref{eq:label}''; ``see Fig.~\ref{fig:label}''; ``Section~\ref{sec:label}''; ``see Ref.~\cite{Jarzynski1997Nonequilibrium}''.
+        \item Use non-breaking spaces when referencing equations, figures, sections, and references, e.g., use ``Eq.~\ref{eq:label}''; ``see Fig.~\ref{fig:label}''; ``Section~\ref{sec:label}''; ``see Ref.~\cite{AuthorYear}''.
         \item Use either `` or '' as an alternative to `"'.
         \item Put punctuation outside inner math mode.
         \item Use $\tr$ instead of \text{tr} or \textrm{tr}.
-        \item Prefer $\bra{...}$ and $\ket{...}$ over $|...\rangle$ and $\langle...|$.
+        \item If using Dirac notation (e.g., in quantum mechanics), prefer $\bra{...}$ and $\ket{...}$ over $|...\rangle$ and $\langle...|$.
         \item Treat formulas as part of the sentences and add punctuation accordingly in the displayed math environments depending on the next sentence.
         \item When in doubt, follow the best practice that will result in zero warnings when checked by chktex.
         \item Use the math commands defined in the auxiliary file command.tex if provided.

--- a/resources/agents/generic.yaml
+++ b/resources/agents/generic.yaml
@@ -16,14 +16,14 @@ prompts:
     When working with a professional *.tex \LaTeX document, you must adhere to the following format rules and conventions:
     \begin{itemize}
         \item Use appropriate notation and terminology consistently throughout the text.
-        \item Keep the comments that start with `%' in the document. For example, do not delete ``% We found the time step $t=1/16=0.0625$ to give sufficient accuracy for our simulations.'' in the output.
+        \item Keep the comments that start with `%' in the document. For example, do not delete ``% We set $\epsilon=0.01$ for sufficient precision in our numerical analysis.'' in the output.
         \item If there are duplicate labels, handle the collision correctly by renaming one of them using a condensed label and adjust accordingly where the labelled items are referenced.
         \item Use $\ldots$ or $\cdots$ rather than $\dots$ or ``...'' to achieve an ellipsis following the best practice of chktex.
-        \item Use non-breaking spaces when referencing equations, figures, sections, and references, e.g., use ``Eq.~\ref{eq:label}''; ``see Fig.~\ref{fig:label}''; ``Section~\ref{sec:label}''; ``see Ref.~\cite{Jarzynski1997Nonequilibrium}''.
+        \item Use non-breaking spaces when referencing equations, figures, sections, and references, e.g., use ``Eq.~\ref{eq:label}''; ``see Fig.~\ref{fig:label}''; ``Section~\ref{sec:label}''; ``see Ref.~\cite{AuthorYear}''.
         \item Use either `` or '' as an alternative to `"'.
         \item Put punctuation outside inner math mode.
         \item Use $\tr$ instead of \text{tr} or \textrm{tr}.
-        \item Prefer $\bra{...}$ and $\ket{...}$ over $|...\rangle$ and $\langle...|$ when working with quantum mechanics notation.
+        \item If using Dirac notation (e.g., in quantum mechanics), prefer $\bra{...}$ and $\ket{...}$ over $|...\rangle$ and $\langle...|$.
         \item Treat formulas as part of the sentences and add punctuation accordingly in the displayed math environments depending on the next sentence.
         \item When writing formal \LaTeX documents, never list things like 1.\ 2.\ 3.\ \ldots{} as in markdown. Use proper \LaTeX environments such as enumerate or itemize.
         \item When in doubt, follow the best practices that will result in zero warnings when checked by chktex.

--- a/resources/agents/generic_multiple.yaml
+++ b/resources/agents/generic_multiple.yaml
@@ -17,14 +17,14 @@ prompts:
     When working with professional *.tex \LaTeX documents, you must:
     \begin{itemize}
         \item Use appropriate notation and terminology consistently throughout all documents.
-        \item Keep the comments that start with `%' in the documents. For example, do not delete ``% We found the time step $t=1/16=0.0625$ to give sufficient accuracy for our simulations.'' in the output.
+        \item Keep the comments that start with `%' in the documents. For example, do not delete ``% We set $\epsilon=0.01$ for sufficient precision in our numerical analysis.'' in the output.
         \item If there are duplicate labels, handle the collision correctly by renaming one of them using a condensed label and adjust accordingly where the labelled items are referenced.
         \item Use $\ldots$ or $\cdots$ rather than $\dots$ or ``...'' to achieve an ellipsis following the best practice of chktex.
-        \item Use non-breaking spaces when referencing equations, figures, sections, and references, e.g., use ``Eq.~\ref{eq:label}''; ``see Fig.~\ref{fig:label}''; ``Section~\ref{sec:label}''; ``see Ref.~\cite{Jarzynski1997Nonequilibrium}''.
+        \item Use non-breaking spaces when referencing equations, figures, sections, and references, e.g., use ``Eq.~\ref{eq:label}''; ``see Fig.~\ref{fig:label}''; ``Section~\ref{sec:label}''; ``see Ref.~\cite{AuthorYear}''.
         \item Use either `` or '' as an alternative to `"'.
         \item Put punctuation outside inner math mode.
         \item Use $\tr$ instead of \text{tr} or \textrm{tr}.
-        \item Prefer $\bra{...}$ and $\ket{...}$ over $|...\rangle$ and $\langle...|$ when working with quantum mechanics notation.
+        \item If using Dirac notation (e.g., in quantum mechanics), prefer $\bra{...}$ and $\ket{...}$ over $|...\rangle$ and $\langle...|$.
         \item Treat formulas as part of the sentences and add punctuation accordingly in the displayed math environments depending on the next sentence.
         \item When writing formal \LaTeX documents, never list things like 1.\ 2.\ 3.\ \ldots{} as in markdown. Use proper \LaTeX environments such as enumerate or itemize.
         \item When in doubt, follow the best practices that will result in zero warnings when checked by chktex.

--- a/resources/agents/polish.yaml
+++ b/resources/agents/polish.yaml
@@ -15,7 +15,7 @@ prompts:
     \begin{itemize}
         \item Follow the best practices that will result in zero warnings when checked by chktex.
         \item Use appropriate notation and terminology consistently throughout the text.
-        \item Keep the comments that start with `%' in the document. For example, do not delete ``% We found the time step $t=1/16=0.0625$ to give sufficient accuracy for our simulations.'' in the output.
+        \item Keep the comments that start with `%' in the document. For example, do not delete ``% We set $\epsilon=0.01$ for sufficient precision in our numerical analysis.'' in the output.
         \item Use either `` or '' as an alternative to `"'.
         \item When writing formal \LaTeX documents rather than thinking in the scratchpad, never barely list things like 1.\ 2.\ 3.\ \ldots{} as in markdown.
         \item \textbf{IMPORTANT:} You must give the complete output containing all the sections in the order they are given in the input file.

--- a/resources/agents/polish_multiple.yaml
+++ b/resources/agents/polish_multiple.yaml
@@ -12,13 +12,13 @@ settings:
 
 prompts:
   systemPrompt: |
-    You are physics professor. Your task is to use your knowledge to improve a LaTeX research paper consisting of multiple documents focusing solely on addressing the given instructions.
+    You are a professional scientist. Your task is to use your knowledge to improve a LaTeX research paper consisting of multiple documents focusing solely on addressing the given instructions.
 
     When writing a professional *.tex \LaTeX document, you must:
     \begin{itemize}
         \item Follow the best practices that will result in zero warnings when checked by chktex.
         \item Use appropriate notation and terminology consistently throughout all papers.
-        \item Keep the comments that start with `%' in the documents. For example, do not delete ``% We found the time step $\delta=1/16=0.0625$ to give sufficient accuracy for our simulations.'' in the output.
+        \item Keep the comments that start with `%' in the documents. For example, do not delete ``% We set $\epsilon=0.01$ for sufficient precision in our numerical analysis.'' in the output.
         \item Use either `` or '' as an alternative to `"'.
         \item When writing formal \LaTeX documents rather than thinking in the scratchpad, never barely list things like 1.\ 2.\ 3.\ \ldots{} as in markdown.
         \item \textbf{IMPORTANT:} You must give the complete output containing all the sections in the order they are given in each input file.

--- a/resources/agents/write/paper2slide.yaml
+++ b/resources/agents/write/paper2slide.yaml
@@ -21,7 +21,8 @@ prompts:
     - Maintain a professional and scientifically rigorous tone throughout the presentation
     - Use appropriate notation and terminology consistently
     - Prioritize visual representations and key takeaways over verbose descriptions
-    - Cite relevant key papers using commands like \cite{Jarzynski2011Equalities} or \cite{Feynman1965Quantum} which include only the first word of the paper name.
+    - Cite relevant key papers using commands like \cite{Author2020Title} (e.g., \cite{Smith2020Analysis}) which include the author, year, and first word of the paper title
+    - Output a complete, self-contained LaTeX file that can be compiled directly
 
   userPrefix: |
     You are tasked with creating a LaTeX Beamer presentation based on the following research paper:
@@ -79,10 +80,50 @@ prompts:
 
       </scratchpad>
 
-      Then, please create the LaTeX Beamer presentation, incorporating the key points outlined in the scratchpad. The presentation should be professional, condensed, and effectively highlight the main aspects of the research paper. Use the following format:
+      Then, please create a complete, self-contained LaTeX Beamer presentation, incorporating the key points outlined in the scratchpad. The presentation should be professional, condensed, and effectively highlight the main aspects of the research paper. Use the following format:
 
       <beamer_presentation>
-      {{ TEMPLATE_SLIDE_CONTENT }}
+      \documentclass{beamer}
+
+      \usetheme{Madrid}
+      \usecolortheme{dolphin}
+
+      \setbeamertemplate{footline}[page number]
+      \setbeamertemplate{navigation symbols}{}
+      \setbeamertemplate{frametitle}[default][center]
+
+      \AtBeginSection[]
+      {
+      \begin{frame}<beamer>
+      \frametitle{Outline}
+      \tableofcontents[currentsection]
+      \end{frame}
+      }
+
+      \usepackage{amsmath}
+      \usepackage{amssymb}
+      \usepackage{graphicx}
+      \usepackage{physics}
+      \usepackage{hyperref}
+      \usepackage{natbib}
+
+      % Add any additional packages needed
+
+      % Title information
+      \title{...}
+      \author{...}
+      \institute{...}
+      \date{\today}
+
+      \begin{document}
+
+      % SLIDE CONTENT HERE
+
+      \begin{frame}[allowframebreaks]{References}
+          \bibliography{...}
+      \end{frame}
+
+      \end{document}
       </beamer_presentation>
     - |
       Please review your draft LaTeX Beamer presentation critically, focusing on the following points:
@@ -123,8 +164,8 @@ prompts:
       </improvements>
       </scratchpad>
 
-      Based on this reflection, please revise your presentation to address any identified issues while maintaining its professional quality and technical accuracy. Output the new version based on the previous version you just wrote. Use the following format:
+      Based on this reflection, please revise your presentation to address any identified issues while maintaining its professional quality and technical accuracy. Output the complete, self-contained revised version based on the previous version you just wrote. Use the following format:
 
       <beamer_presentation>
-      {{ TEMPLATE_SLIDE_CONTENT }}
+      % Complete revised LaTeX Beamer presentation here
       </beamer_presentation>


### PR DESCRIPTION
Replace physics-specific terminology with general scientific terms:
- Change simulation example from physics time-step to generic numerical precision
- Replace Jarzynski1997 citation example with generic AuthorYear format
- Make Dirac notation guidance conditional (only when working with quantum mechanics)
- Fix polish_multiple.yaml to use 'professional scientist' instead of 'physics professor'

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Generalizes LaTeX agent prompts with domain-agnostic examples, makes Dirac notation guidance conditional, updates role wording, and ensures paper2slide outputs a complete self-contained Beamer file with a full template and generalized citation format.
> 
> - **Prompts (domain-agnostic updates)**
>   - Replace physics-specific examples with generic ones across `resources/agents/correct*.yaml`, `generic*.yaml`, and `polish*.yaml`:
>     - Comment example: use `"% We set $\epsilon=0.01$ for sufficient precision in our numerical analysis."`
>     - Citation example: use `\cite{AuthorYear}` instead of physics-specific citations.
>     - Make Dirac notation guidance conditional: “If using Dirac notation (e.g., in quantum mechanics)…”
> - **Role wording**
>   - Update `resources/agents/polish_multiple.yaml`: change role from “physics professor” to “professional scientist”.
> - **Beamer presentation generator (`resources/agents/write/paper2slide.yaml`)**
>   - Generalize citation guidance to `\cite{Author2020Title}` (e.g., `\cite{Smith2020Analysis}`).
>   - Require and output a complete, self-contained LaTeX file.
>   - Embed full Beamer template (theme, packages, outline section slide, references frame) in both initial and revised outputs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1075dd91ebade034a99f89be9d9f7a42afa17326. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->