### PR TITLE
Ensure model selection restored after model list refresh

### DIFF
--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -373,13 +373,19 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
     return '';
   }
 
-  _restoreAgentSelection(selectElement, previousValue) {
-    const sessionType = this._getSessionTypeForSelect(selectElement);
-    const savedValue = sessionType ? this._getSavedAgentValue(sessionType) : '';
-    const candidates = [savedValue, previousValue].filter(Boolean);
-
+  /**
+   * Generic helper to restore a select element's value using a fallback chain.
+   * Attempts to restore from a list of candidate values in order, falling back
+   * to the first enabled option if no candidate matches.
+   *
+   * @param {HTMLElement} selectElement - The select element to restore
+   * @param {string[]} candidates - Array of candidate values to try, in priority order
+   */
+  _restoreSelectValue(selectElement, candidates) {
+    const filteredCandidates = candidates.filter(Boolean);
     const options = getSelectOptionElements(selectElement);
-    const match = candidates.find((value) =>
+
+    const match = filteredCandidates.find((value) =>
       options.some((option) => option.value === value),
     );
 
@@ -395,25 +401,17 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
     }
   }
 
+  _restoreAgentSelection(selectElement, previousValue) {
+    const sessionType = this._getSessionTypeForSelect(selectElement);
+    const savedValue = sessionType ? this._getSavedAgentValue(sessionType) : '';
+    // Prioritize saved state over previous UI value for agents
+    this._restoreSelectValue(selectElement, [savedValue, previousValue]);
+  }
+
   _restoreModelSelection(selectElement, previousValue) {
     const savedValue = mainViewState.get?.()?.model ?? '';
-    const candidates = [previousValue, savedValue].filter(Boolean);
-
-    const options = getSelectOptionElements(selectElement);
-    const match = candidates.find((value) =>
-      options.some((option) => option.value === value),
-    );
-
-    if (match) {
-      selectElement.value = match;
-      return;
-    }
-
-    const fallbackOption =
-      options.find((option) => !option.disabled) ?? options[0];
-    if (fallbackOption) {
-      selectElement.value = fallbackOption.value;
-    }
+    // Prioritize saved state over previous UI value for consistency
+    this._restoreSelectValue(selectElement, [savedValue, previousValue]);
   }
 
   _getActiveAgentSelection() {

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -214,9 +214,7 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
     }
     const previous = selectElement.value;
     selectElement.innerHTML = optionsHtml;
-    if (previous) {
-      selectElement.value = previous;
-    }
+    this._restoreModelSelection(selectElement, previous);
     getSelectOptionElements(selectElement).forEach((opt) => {
       const { provider, context, cost } = opt.dataset;
       if (provider || context || cost) {
@@ -379,6 +377,27 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
     const sessionType = this._getSessionTypeForSelect(selectElement);
     const savedValue = sessionType ? this._getSavedAgentValue(sessionType) : '';
     const candidates = [savedValue, previousValue].filter(Boolean);
+
+    const options = getSelectOptionElements(selectElement);
+    const match = candidates.find((value) =>
+      options.some((option) => option.value === value),
+    );
+
+    if (match) {
+      selectElement.value = match;
+      return;
+    }
+
+    const fallbackOption =
+      options.find((option) => !option.disabled) ?? options[0];
+    if (fallbackOption) {
+      selectElement.value = fallbackOption.value;
+    }
+  }
+
+  _restoreModelSelection(selectElement, previousValue) {
+    const savedValue = mainViewState.get?.()?.model ?? '';
+    const candidates = [previousValue, savedValue].filter(Boolean);
 
     const options = getSelectOptionElements(selectElement);
     const match = candidates.find((value) =>


### PR DESCRIPTION
## Summary
- restore the model dropdown to a saved or fallback choice when model options refresh
- reuse existing dropdown metadata to keep the model selection populated during model list reloads

## Testing
- npm run format
- npm run compile
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6926ce00a0788324bc5ef6bd4e905336)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Restores model and agent dropdown selections using saved state with fallback, via a new shared select restoration helper.
> 
> - **Webview**:
>   - **Model dropdown (`_applyModelOptions`)**: After refreshing options, restores selection using `_restoreModelSelection` (saved model → previous value → first enabled option).
>   - **Agent dropdowns**: Refactor `_restoreAgentSelection` to use new `_restoreSelectValue` with priority to saved state.
>   - **Shared utility**: Add `_restoreSelectValue(select, candidates)` to handle fallback chain for selects.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 06d8f8ef1046b8deae2dcf9f8ab056ce120a02eb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->