### PR TITLE
Clean up latexindent log after agent runs

### DIFF
--- a/src/agent/output/OutputHandler.ts
+++ b/src/agent/output/OutputHandler.ts
@@ -310,6 +310,7 @@ export class OutputHandler implements IOutputHandler {
       path.join(dir, `${name}.bak`),
       path.join(dir, `${name}.bak0`),
       path.join(dir, `${name}.bak1`),
+      path.join(dir, 'indent.log'),
     ]);
 
     for (const candidateAbsolute of backupCandidates) {


### PR DESCRIPTION
## Summary
- delete latexindent indent.log files alongside other backups after agent runs

## Testing
- npm run format
- npm run compile
- npm run lint
- npm test *(fails: VS Code test binary missing libgtk-3.so.0 in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692618a125bc8324986941eef870cbb0)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Delete latexindent `indent.log` during LaTeX backup cleanup in `OutputHandler.cleanupLatexBackups`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 51c65296d9a3efde57c7adcac3b71f110ca55bf2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->