### PR TITLE
Add optional description field to agent YAML

### DIFF
--- a/resources/agents/correct.yaml
+++ b/resources/agents/correct.yaml
@@ -1,4 +1,5 @@
 name: correct
+description: Corrects typos, grammar, and LaTeX formatting issues in your document.
 
 settings:
   agentType: direct

--- a/resources/agents/draw.yaml
+++ b/resources/agents/draw.yaml
@@ -1,4 +1,6 @@
 name: draw
+description: Creates or polishes TikZ figures for your research paper.
+
 settings:
   agentType: CoT
   documentTag: latex_document

--- a/resources/agents/generic.yaml
+++ b/resources/agents/generic.yaml
@@ -1,4 +1,5 @@
 name: generic
+description: General-purpose agent for flexible document editing tasks.
 
 settings:
   agentType: CoT

--- a/resources/agents/merge.yaml
+++ b/resources/agents/merge.yaml
@@ -1,4 +1,5 @@
 name: merge
+description: Merges partial edits back into the full original document.
 
 settings:
   agentType: direct

--- a/resources/agents/ocr.yaml
+++ b/resources/agents/ocr.yaml
@@ -1,4 +1,6 @@
 name: ocr
+description: Converts handwritten mathematical content from images into LaTeX.
+
 settings:
   agentType: CoT
   documentTag: latex_document

--- a/resources/agents/polish.yaml
+++ b/resources/agents/polish.yaml
@@ -1,4 +1,6 @@
 name: polish
+description: Improves writing quality and clarity based on your specific instructions.
+
 settings:
   documentTag: latex_document
   endTag: </latex_document>

--- a/resources/agents/transcribe_audio.yaml
+++ b/resources/agents/transcribe_audio.yaml
@@ -1,4 +1,6 @@
 name: transcribe_audio
+description: Transcribes audio with speaker identification and LaTeX math formatting.
+
 settings:
   agentType: CoT
   documentTag: audio_transcript

--- a/resources/tool_use_agents/ask.yaml
+++ b/resources/tool_use_agents/ask.yaml
@@ -1,4 +1,6 @@
 name: ask
+description: Read-only assistant for answering questions about your documents.
+
 settings:
   agentType: toolUse
   tools:

--- a/resources/tool_use_agents/chat.yaml
+++ b/resources/tool_use_agents/chat.yaml
@@ -1,4 +1,6 @@
 name: chat
+description: Interactive assistant with file editing and research tools.
+
 settings:
   agentType: toolUse
   tools:

--- a/resources/tool_use_agents/tex_linter_fix.yaml
+++ b/resources/tool_use_agents/tex_linter_fix.yaml
@@ -1,4 +1,6 @@
 name: tex_linter_fix
+description: Automatically fixes LaTeX linter warnings and errors.
+
 settings:
   agentType: toolUse
   tools:

--- a/resources/tool_use_agents/xml_validator.yaml
+++ b/resources/tool_use_agents/xml_validator.yaml
@@ -1,4 +1,6 @@
 name: xml_validator
+description: Validates and fixes XML syntax errors.
+
 settings:
   agentType: toolUse
   tools:

--- a/src/agent/core/AgentDataclass.ts
+++ b/src/agent/core/AgentDataclass.ts
@@ -211,6 +211,7 @@ const DefinitionBlockSchema = z.record(z.string(), z.unknown()).prefault({});
 
 export const AgentDefinitionSchema = z.strictObject({
   name: z.string().trim().min(1),
+  description: z.string().optional(),
   inherits: z.string().optional(),
   settings: DefinitionBlockSchema,
   prompts: DefinitionBlockSchema,

--- a/src/agent/utils/agentOptionMetadata.ts
+++ b/src/agent/utils/agentOptionMetadata.ts
@@ -25,6 +25,7 @@ export interface AgentOptionMetadata {
   isMultipleOutput: boolean;
   isToolUse: boolean;
   isRemote: boolean;
+  description?: string;
 }
 
 export interface AgentOptionsPayload {
@@ -43,27 +44,35 @@ export const DEFAULT_TOOL_USE_AGENT = 'chat';
 const MULTIPLE_SUFFIX = '_multiple';
 const TOOL_USE_AGENT_TYPE = AgentType.ToolUse;
 
-function readAgentDefinition(yamlPath?: string): AgentSetting | undefined {
+interface ParsedAgentDefinition {
+  settings: AgentSetting;
+  description?: string;
+}
+
+function readAgentDefinition(yamlPath?: string): ParsedAgentDefinition | undefined {
   if (!yamlPath) {
     return undefined;
   }
   try {
     const fileContent = AbsoluteFS.readSync(yamlPath);
     const parsed = AgentDefinitionSchema.parse(yaml.parse(fileContent));
-    return parseAgentSetting(parsed.settings);
+    return {
+      settings: parseAgentSetting(parsed.settings),
+      description: parsed.description,
+    };
   } catch {
     return undefined;
   }
 }
 
-function getMultipleOutputFlag(setting?: AgentSetting): boolean {
-  if (!setting) {
+function getMultipleOutputFlag(parsed?: ParsedAgentDefinition): boolean {
+  if (!parsed?.settings) {
     return false;
   }
-  if (setting.agentType === AgentType.ToolUse) {
+  if (parsed.settings.agentType === AgentType.ToolUse) {
     return false;
   }
-  return setting.isMultipleOutput ?? false;
+  return parsed.settings.isMultipleOutput ?? false;
 }
 
 export function getAgentOptionMetadata(
@@ -93,8 +102,8 @@ export function getAgentOptionMetadata(
   const multipleResolution = resolveAgentDefinitionSync(cleanName, candidates, {
     preferMultiple: true,
   });
-  const definition = readAgentDefinition(definitionResolution?.definitionPath);
-  const isMultipleOutput = getMultipleOutputFlag(definition);
+  const parsed = readAgentDefinition(definitionResolution?.definitionPath);
+  const isMultipleOutput = getMultipleOutputFlag(parsed);
   const hasMultipleSibling = Boolean(
     multipleResolution &&
       !multipleResolution.usedFallback &&
@@ -104,8 +113,9 @@ export function getAgentOptionMetadata(
     hasDefinition: Boolean(definitionResolution),
     hasMultipleSibling,
     isMultipleOutput,
-    isToolUse: definition?.agentType === TOOL_USE_AGENT_TYPE,
+    isToolUse: parsed?.settings.agentType === TOOL_USE_AGENT_TYPE,
     isRemote: false,
+    description: parsed?.description,
   };
 }
 
@@ -155,6 +165,9 @@ export function createAgentOptionTag(
   }
   if (metadata.isRemote) {
     attributes.push('data-remote="true"');
+  }
+  if (metadata.description) {
+    attributes.push(`data-description="${encodeHtml(metadata.description)}"`);
   }
   if (options.isSelected) {
     attributes.push('selected');

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -241,10 +241,16 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
   }
 
   _decorateAgentOption(opt) {
-    const { label, isMultiple, isToolUse } = this._readAgentOptionMetadata(opt);
+    const { label, isMultiple, isToolUse, description } =
+      this._readAgentOptionMetadata(opt);
 
     const hints = [];
     let displayLabel = label;
+
+    // Add description as the primary hint if available
+    if (description) {
+      hints.push(description);
+    }
 
     if (isMultiple) {
       displayLabel += ' ∶∶';
@@ -290,6 +296,7 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
       label,
       isMultiple: opt.dataset.multiple === 'true',
       isToolUse: opt.dataset.toolUse === 'true',
+      description: opt.dataset.description ?? '',
     };
   }
 


### PR DESCRIPTION
Add support for an optional one-sentence description field in agent YAML files that displays as a tooltip in the agent dropdown menu, similar to model information in the model dropdown.

Changes:
- Add `description` field to AgentDefinitionSchema
- Update AgentOptionMetadata interface to include description
- Pass description through to vscode-option data-description attribute
- Display description as primary hint in agent dropdown tooltip
- Add example descriptions to all built-in agents

The implementation follows DRY principles with single source of truth - the description is defined once in YAML and flows through the system.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce optional `description` in agent YAML and plumb it through metadata to display as hints/tooltips in the agent selector.
> 
> - **Core/Schema**:
>   - Add optional `description` to `AgentDefinitionSchema`.
> - **Metadata/Plumbing**:
>   - Extend `AgentOptionMetadata` with optional `description`.
>   - Parse YAML to return `{ settings, description }`; update multiple-output detection accordingly.
>   - Include `data-description` in option tags via `createAgentOptionTag`.
> - **Webview/UI**:
>   - Read `data-description` for agent options; show as primary hint in option title/ARIA.
> - **Resources**:
>   - Add `description` entries to built-in agents in `resources/agents/*` and `resources/tool_use_agents/*`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4a982476a8f86b369255a8faf7537c95046b85a8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->