### PR TITLE
Fix history view missing instructions and session info

### DIFF
--- a/src/historyView/HistoryViewMessageHandler.ts
+++ b/src/historyView/HistoryViewMessageHandler.ts
@@ -60,7 +60,7 @@ export class HistoryViewMessageHandler extends BaseViewMessageHandler<
         await vscode.window.showInformationMessage(
           'Rerunning agent from history',
         );
-        await executeCommand.executeCommand(historyItem.config);
+        await executeCommand.executeCommand(historyItem.agentConfig);
       } else {
         await vscode.window.showErrorMessage('History item not found');
       }
@@ -79,7 +79,7 @@ export class HistoryViewMessageHandler extends BaseViewMessageHandler<
       const historyItem =
         await AgentHistoryManager.getHistoryItemById(historyId);
       if (historyItem) {
-        const taskState = agentConfigToTaskState(historyItem.config);
+        const taskState = agentConfigToTaskState(historyItem.agentConfig);
         await vscode.commands.executeCommand('texra.restoreState', taskState);
       } else {
         await vscode.window.showErrorMessage('History item not found');

--- a/src/historyView/managers/AgentHistoryManager.ts
+++ b/src/historyView/managers/AgentHistoryManager.ts
@@ -7,7 +7,6 @@ import * as vscode from 'vscode';
 // Local imports - agent metadata
 import { type AgentConfig, parseAgentConfig } from '@agent/core/AgentConfig';
 // Type imports
-import { type AgentSessionDescriptor } from '@agent/core/AgentDataclass';
 import type { ExecutionId } from '@agent/types/IdentifierTypes';
 
 // Local imports - workspace state
@@ -17,13 +16,15 @@ import * as logger from '@logger/logUtils';
 const CHANNEL = 'AgentHistoryManager';
 
 /**
- * Represents a historical agent execution
+ * Represents a historical agent execution.
+ *
+ * Uses `agentConfig` field name for consistency with TaskState interface.
+ * Session metadata is accessed via `agentConfig.session` - single source of truth.
  */
 export interface AgentHistoryItem {
   id: ExecutionId;
   timestamp: string;
-  config: AgentConfig;
-  session: AgentSessionDescriptor;
+  agentConfig: AgentConfig;
 }
 
 /**
@@ -38,8 +39,7 @@ export class AgentHistoryManager {
    */
   public static async addToHistory(config: AgentConfig): Promise<string> {
     const normalizedConfig = parseAgentConfig(config);
-    const session = normalizedConfig.session;
-    if (!session) {
+    if (!normalizedConfig.session) {
       throw new Error(
         'Agent history cannot store configs without session metadata.',
       );
@@ -48,8 +48,7 @@ export class AgentHistoryManager {
     const historyItem: AgentHistoryItem = {
       id: randomUUID(),
       timestamp: new Date().toISOString(),
-      config: normalizedConfig,
-      session,
+      agentConfig: normalizedConfig,
     };
 
     // Get current workspace-specific history
@@ -92,6 +91,10 @@ export class AgentHistoryManager {
     await workspaceSM.update(storageKey, history);
   }
 
+  /**
+   * Sanitize and migrate history entries to current format.
+   * Handles legacy data with 'config' field and separate 'session' field.
+   */
   private static sanitizeHistoryEntries(entries: unknown[]): {
     normalized: AgentHistoryItem[];
     mutated: boolean;
@@ -105,18 +108,28 @@ export class AgentHistoryManager {
         continue;
       }
 
-      const candidate = rawEntry as Partial<AgentHistoryItem> & {
-        config?: AgentConfig;
+      // Support both new 'agentConfig' and legacy 'config' field names
+      const candidate = rawEntry as {
+        id?: ExecutionId;
+        timestamp?: string;
+        agentConfig?: AgentConfig;
+        config?: AgentConfig; // Legacy field name
       };
 
-      if (!candidate.id || !candidate.timestamp || !candidate.config) {
+      const rawConfig = candidate.agentConfig || candidate.config;
+      if (!candidate.id || !candidate.timestamp || !rawConfig) {
         mutated = true;
         continue;
       }
 
+      // Mark as mutated if we're migrating from legacy format
+      if (candidate.config && !candidate.agentConfig) {
+        mutated = true;
+      }
+
       let normalizedConfig: AgentConfig;
       try {
-        normalizedConfig = parseAgentConfig(candidate.config);
+        normalizedConfig = parseAgentConfig(rawConfig);
       } catch (error) {
         mutated = true;
         logger.warn(CHANNEL, 'Discarding malformed agent history entry', {
@@ -125,8 +138,7 @@ export class AgentHistoryManager {
         continue;
       }
 
-      const session = normalizedConfig.session;
-      if (!session) {
+      if (!normalizedConfig.session) {
         mutated = true;
         continue;
       }
@@ -134,8 +146,7 @@ export class AgentHistoryManager {
       normalized.push({
         id: candidate.id,
         timestamp: candidate.timestamp,
-        config: normalizedConfig,
-        session,
+        agentConfig: normalizedConfig,
       });
     }
 

--- a/src/historyView/managers/AgentHistoryManager.ts
+++ b/src/historyView/managers/AgentHistoryManager.ts
@@ -122,7 +122,7 @@ export class AgentHistoryManager {
         continue;
       }
 
-      // Mark as mutated if we're migrating from legacy format
+      // Legacy entries use 'config' field; mark for persistence with new 'agentConfig' field
       if (candidate.config && !candidate.agentConfig) {
         mutated = true;
       }

--- a/src/historyView/modules/constants.js
+++ b/src/historyView/modules/constants.js
@@ -30,3 +30,9 @@ export const LABELS = {
   CLEAR_ALL_HISTORY: 'Clear All History',
   MORE_DETAILS: 'More details',
 };
+
+// Agent category constants - must match AgentCategory enum in AgentDataclass.ts
+export const AGENT_CATEGORY = {
+  WORKFLOW: 'workflow',
+  TOOL_USE: 'toolUse',
+};

--- a/src/historyView/modules/uiManagers/HistoryRenderer.js
+++ b/src/historyView/modules/uiManagers/HistoryRenderer.js
@@ -1,5 +1,11 @@
 // Local imports - history view
-import { COMMANDS, ELEMENT_IDS, CLASS_NAMES, LABELS } from '../constants.js';
+import {
+  COMMANDS,
+  ELEMENT_IDS,
+  CLASS_NAMES,
+  LABELS,
+  AGENT_CATEGORY,
+} from '../constants.js';
 import { historyViewState } from '../historyViewState.js';
 import {
   addEventListenerSafely,
@@ -60,7 +66,7 @@ export class HistoryRenderer {
     const date = new Date(item.timestamp).toLocaleString();
 
     // Determine session kind display
-    const isToolUse = session?.agentCategory === 'toolUse';
+    const isToolUse = session?.agentCategory === AGENT_CATEGORY.TOOL_USE;
     const kindLabel = isToolUse ? 'Tool Use' : 'Workflow';
     const kindIcon = isToolUse ? 'tools' : 'symbol-method';
     const kindClass = isToolUse ? 'kind-tool-use' : 'kind-workflow';
@@ -98,7 +104,8 @@ export class HistoryRenderer {
 
     const encodedAgent = encodeHtml(config?.agent || 'Unknown');
     const encodedModel = encodeHtml(config?.model || 'Unknown');
-    // Show instruction content or indicate it wasn't set
+    // Instruction is a primary field shown prominently, so it gets "Not set" indicator when empty.
+    // Optional fields like reference/auxiliary files are in the collapsible section and can be omitted.
     const instructionText = config?.instruction;
     const encodedInstruction =
       instructionText && instructionText.trim()

--- a/src/historyView/modules/uiManagers/HistoryRenderer.js
+++ b/src/historyView/modules/uiManagers/HistoryRenderer.js
@@ -54,7 +54,14 @@ export class HistoryRenderer {
 
   _createHistoryItemElement(item) {
     const config = item.config;
+    const session = item.session;
     const date = new Date(item.timestamp).toLocaleString();
+
+    // Determine session kind display
+    const isToolUse = session?.agentCategory === 'toolUse';
+    const kindLabel = isToolUse ? 'Tool Use' : 'Workflow';
+    const kindIcon = isToolUse ? 'tools' : 'symbol-method';
+    const kindClass = isToolUse ? 'kind-tool-use' : 'kind-workflow';
 
     const container = createFromTemplate('historyItemTemplate', {
       text: {
@@ -93,7 +100,13 @@ export class HistoryRenderer {
       ? encodeHtml(config.instruction)
       : 'None';
 
+    // Build session kind badge with icon
+    const kindIconEl = createCodicon(kindIcon);
+    const kindIconHtml = kindIconEl ? kindIconEl.outerHTML : '';
+
     let basicHTML = `
+      <span class="history-label">Kind:</span>
+      <span class="history-value"><span class="session-kind-badge ${kindClass}">${kindIconHtml} ${kindLabel}</span></span>
       <span class="history-label">Agent:</span>
       <span class="history-value">${encodedAgent}</span>
       <span class="history-label">Model:</span>

--- a/src/historyView/modules/uiManagers/HistoryRenderer.js
+++ b/src/historyView/modules/uiManagers/HistoryRenderer.js
@@ -53,8 +53,9 @@ export class HistoryRenderer {
   }
 
   _createHistoryItemElement(item) {
-    const config = item.config;
-    const session = item.session;
+    // Support both naming conventions for consistency with TaskState
+    const config = item.agentConfig || item.config;
+    const session = item.session || config?.session;
     const date = new Date(item.timestamp).toLocaleString();
 
     // Determine session kind display
@@ -94,11 +95,14 @@ export class HistoryRenderer {
       return document.createElement('div');
     }
 
-    const encodedAgent = encodeHtml(config.agent);
-    const encodedModel = encodeHtml(config.model);
-    const encodedInstruction = config.instruction
-      ? encodeHtml(config.instruction)
-      : 'None';
+    const encodedAgent = encodeHtml(config?.agent || 'Unknown');
+    const encodedModel = encodeHtml(config?.model || 'Unknown');
+    // Show instruction content or indicate it wasn't set
+    const instructionText = config?.instruction;
+    const encodedInstruction =
+      instructionText && instructionText.trim()
+        ? encodeHtml(instructionText)
+        : '<em class="history-none">Not set</em>';
 
     // Build session kind badge with icon
     const kindIconEl = createCodicon(kindIcon);

--- a/src/historyView/modules/uiManagers/HistoryRenderer.js
+++ b/src/historyView/modules/uiManagers/HistoryRenderer.js
@@ -53,9 +53,10 @@ export class HistoryRenderer {
   }
 
   _createHistoryItemElement(item) {
-    // Support both naming conventions for consistency with TaskState
+    // Use agentConfig as primary (consistent with TaskState), with fallback for legacy data
     const config = item.agentConfig || item.config;
-    const session = item.session || config?.session;
+    // Session is accessed via config.session - single source of truth
+    const session = config?.session;
     const date = new Date(item.timestamp).toLocaleString();
 
     // Determine session kind display

--- a/src/historyView/styles/index.css
+++ b/src/historyView/styles/index.css
@@ -198,3 +198,9 @@ mark.current-match {
   );
   color: var(--vscode-editorWarning-foreground, #cca700);
 }
+
+/* Empty/unset value styling */
+.history-none {
+  color: var(--vscode-descriptionForeground);
+  font-style: italic;
+}

--- a/src/historyView/styles/index.css
+++ b/src/historyView/styles/index.css
@@ -170,3 +170,31 @@ mark.current-match {
     var(--width-button-min) + var(--spacing-xlarge) + var(--spacing-xlarge)
   );
 }
+
+/* Session kind badge */
+.session-kind-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-small);
+  padding: var(--spacing-xsmall) var(--spacing-medium);
+  border-radius: var(--border-radius);
+  font-size: var(--font-size-sm);
+  font-weight: 500;
+}
+
+.session-kind-badge .codicon {
+  font-size: var(--font-size-sm);
+}
+
+.kind-workflow {
+  background-color: var(--vscode-editorInfo-background, rgba(0, 127, 212, 0.15));
+  color: var(--vscode-editorInfo-foreground, #3794ff);
+}
+
+.kind-tool-use {
+  background-color: var(
+    --vscode-editorWarning-background,
+    rgba(255, 204, 0, 0.15)
+  );
+  color: var(--vscode-editorWarning-foreground, #cca700);
+}


### PR DESCRIPTION
Add session kind badge to history view items showing whether each execution was a Workflow or Tool Use agent. The badge includes an appropriate icon and color-coded styling to make the distinction visually clear.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a session kind badge (Workflow/Tool Use) in history UI and migrates history items to use `agentConfig` with legacy data handling.
> 
> - **History schema & logic**:
>   - Rename `config` → `agentConfig` in `AgentHistoryItem`; remove separate `session` field (use `agentConfig.session`).
>   - Add migration/sanitization to accept legacy entries (`config`) and persist normalized `agentConfig`.
>   - Update rerun/restore flows to use `historyItem.agentConfig`.
> - **UI (History view)**:
>   - Display session kind badge (Workflow/Tool Use) with icon and colors; add styles for `.session-kind-badge`, `.kind-workflow`, `.kind-tool-use`.
>   - Robust rendering: fall back to legacy `item.config`, default unknowns, and show "Not set" for empty instruction.
>   - Add `AGENT_CATEGORY` constants and use for kind detection.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aec62e43a106d7eec9310f082e4ee598fb363484. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->