### PR TITLE
Preserve selected items when refreshing

### DIFF
--- a/src/webview/modules/handlers/fileHandlers.js
+++ b/src/webview/modules/handlers/fileHandlers.js
@@ -22,23 +22,23 @@ import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
  */
 export function createFileHandlers(ctx) {
   const { postHandle, getElement, setToggleIcon } = ctx;
-  const createSetFileHandler = (fileType, domId) => (message) => {
+
+  /**
+   * Helper to get restoration options for a file select.
+   * Captures current UI value and stored state value.
+   */
+  const getRestorationOptions = (domId) => {
     const selectDiv = getElement(domId);
-    const currentValue = selectDiv?.value;
-
-    fileSelect.update(domId, message.files);
-
-    // Restore selection if the file still exists in the updated list
-    // Prioritize saved state over current UI value
     const state = mainViewState.get();
-    const storedValue = state?.[domId];
+    return {
+      currentValue: selectDiv?.value,
+      storedValue: state?.[domId],
+    };
+  };
 
-    if (storedValue && message.files.includes(storedValue)) {
-      safeSetElementValue(domId, storedValue);
-    } else if (currentValue && message.files.includes(currentValue)) {
-      safeSetElementValue(domId, currentValue);
-    }
-
+  const createSetFileHandler = (fileType, domId) => (message) => {
+    const options = getRestorationOptions(domId);
+    fileSelect.update(domId, message.files, options);
     postHandle();
   };
 
@@ -149,22 +149,12 @@ export function createFileHandlers(ctx) {
   function handleSetBaseFile(message) {
     const currentBaseFileDiv = getElement(BASE_FILE);
     if (currentBaseFileDiv) {
-      const currentBaseFile = currentBaseFileDiv.value;
-      fileSelect.update(BASE_FILE, message.files);
-
-      const state = mainViewState.get();
-      const storedBaseFile = state?.baseFile;
-
-      if (storedBaseFile && message.files.includes(storedBaseFile)) {
-        currentBaseFileDiv.value = storedBaseFile;
-      } else if (
-        message.preserveBaseFile &&
-        currentBaseFile &&
-        message.files.includes(currentBaseFile)
-      ) {
-        currentBaseFileDiv.value = currentBaseFile;
+      const options = getRestorationOptions(BASE_FILE);
+      // Only restore currentValue if preserveBaseFile flag is set
+      if (!message.preserveBaseFile) {
+        options.currentValue = undefined;
       }
-
+      fileSelect.update(BASE_FILE, message.files, options);
       fileSelect.updateEdited(currentBaseFileDiv.value);
     }
     postHandle();

--- a/src/webview/modules/handlers/fileHandlers.js
+++ b/src/webview/modules/handlers/fileHandlers.js
@@ -23,7 +23,22 @@ import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
 export function createFileHandlers(ctx) {
   const { postHandle, getElement, setToggleIcon } = ctx;
   const createSetFileHandler = (fileType, domId) => (message) => {
+    const selectDiv = getElement(domId);
+    const currentValue = selectDiv?.value;
+
     fileSelect.update(domId, message.files);
+
+    // Restore selection if the file still exists in the updated list
+    // Prioritize saved state over current UI value
+    const state = mainViewState.get();
+    const storedValue = state?.[domId];
+
+    if (storedValue && message.files.includes(storedValue)) {
+      safeSetElementValue(domId, storedValue);
+    } else if (currentValue && message.files.includes(currentValue)) {
+      safeSetElementValue(domId, currentValue);
+    }
+
     postHandle();
   };
 

--- a/src/webview/modules/handlers/fileHandlers.js
+++ b/src/webview/modules/handlers/fileHandlers.js
@@ -155,6 +155,7 @@ export function createFileHandlers(ctx) {
         options.currentValue = undefined;
       }
       fileSelect.update(BASE_FILE, message.files, options);
+      // Read value after update to get the actual restored value
       fileSelect.updateEdited(currentBaseFileDiv.value);
     }
     postHandle();

--- a/src/webview/modules/uiManagers/FileSelect.js
+++ b/src/webview/modules/uiManagers/FileSelect.js
@@ -62,8 +62,12 @@ export class FileSelect {
 
     if (restoredValue) {
       safeSetElementValue(id, restoredValue);
-      // Sync state so mainViewState.restore() doesn't overwrite with stale value
-      mainViewState.update({ [id]: restoredValue });
+    }
+
+    // Sync state: update to restored value, or clear stale value if file no longer exists
+    const hasStaleState = storedValue && !sortedFiles.includes(storedValue);
+    if (restoredValue || hasStaleState) {
+      mainViewState.update({ [id]: restoredValue ?? '' });
     }
   }
 

--- a/src/webview/modules/uiManagers/FileSelect.js
+++ b/src/webview/modules/uiManagers/FileSelect.js
@@ -52,10 +52,18 @@ export class FileSelect {
 
     // Restore selection if file still exists, prioritizing stored state
     const { storedValue, currentValue } = options;
+    let restoredValue = null;
+
     if (storedValue && sortedFiles.includes(storedValue)) {
-      safeSetElementValue(id, storedValue);
+      restoredValue = storedValue;
     } else if (currentValue && sortedFiles.includes(currentValue)) {
-      safeSetElementValue(id, currentValue);
+      restoredValue = currentValue;
+    }
+
+    if (restoredValue) {
+      safeSetElementValue(id, restoredValue);
+      // Sync state so mainViewState.restore() doesn't overwrite with stale value
+      mainViewState.update({ [id]: restoredValue });
     }
   }
 

--- a/src/webview/modules/uiManagers/FileSelect.js
+++ b/src/webview/modules/uiManagers/FileSelect.js
@@ -28,31 +28,34 @@ export class FileSelect {
     return this._agentDefaults;
   }
 
-  update(id, files) {
+  /**
+   * Updates a file select dropdown with new options and restores selection if possible.
+   * @param {string} id - The DOM element ID
+   * @param {string[]} files - Array of file paths to populate
+   * @param {Object} [options] - Restoration options
+   * @param {string} [options.storedValue] - Value from saved state (highest priority)
+   * @param {string} [options.currentValue] - Current UI value (fallback priority)
+   */
+  update(id, files, options = {}) {
     const selectDiv = document.getElementById(id);
     if (!selectDiv) {
       console.warn(`[FileSelect] Element with id '${id}' not found`);
       return;
     }
-    const previousValue = selectDiv.value;
+
     const normalizedFiles = Array.isArray(files) ? files : [];
     const sortedFiles = [...normalizedFiles].sort((a, b) => a.localeCompare(b));
-    const shouldPreserveValue =
-      previousValue !== undefined &&
-      previousValue !== null &&
-      previousValue !== '';
 
     selectDiv.innerHTML = '';
     this.addOption(selectDiv, '', 'None');
     sortedFiles.forEach((f) => this.addOption(selectDiv, f, f));
 
-    if (shouldPreserveValue) {
-      const hasPreviousOption = sortedFiles.includes(previousValue);
-      if (!hasPreviousOption) {
-        this.addOption(selectDiv, previousValue, previousValue);
-      }
-      safeSetElementValue(id, previousValue);
-      mainViewState.update({ [id]: previousValue });
+    // Restore selection if file still exists, prioritizing stored state
+    const { storedValue, currentValue } = options;
+    if (storedValue && sortedFiles.includes(storedValue)) {
+      safeSetElementValue(id, storedValue);
+    } else if (currentValue && sortedFiles.includes(currentValue)) {
+      safeSetElementValue(id, currentValue);
     }
   }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds state-aware restoration to file selects (prioritizing saved state over current UI) and updates base file handling to respect preserveBaseFile.
> 
> - **Webview UI**:
>   - **`FileSelect.update`**: Accepts `options` with `storedValue` and `currentValue`; repopulates options and restores selection (prefers `storedValue`, falls back to `currentValue`); syncs `mainViewState` and clears stale state.
>   - **Selection Preservation**: Removes prior ad-hoc preservation by re-adding missing values; now uses explicit restoration logic.
> - **Handlers**:
>   - **`fileHandlers`**: Adds `getRestorationOptions` helper and passes it to `fileSelect.update` for single-file selects.
>   - **Base File**: Refactors `handleSetBaseFile` to use restoration options and honor `preserveBaseFile`; updates edited file based on the restored base file.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit baf807b6edc61c5878f812a4d638664462ac2335. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->