### PR TITLE
Remove left margins from stream tabs

### DIFF
--- a/docs/REMOTE_AGENTS_IMPLEMENTATION.md
+++ b/docs/REMOTE_AGENTS_IMPLEMENTATION.md
@@ -57,7 +57,7 @@ We've successfully implemented a complete authentication and remote agents syste
 - **`package.json`**
   - Added new configuration section: "Authentication & Remote Agents"
   - Added 6 new settings (Supabase URL, anon key, OAuth provider, etc.)
-  - Added 4 new commands (sign in/out, view profile, browse remote agents)
+  - Added 3 new commands (sign in/out, view profile)
 
 ---
 
@@ -82,8 +82,7 @@ We've successfully implemented a complete authentication and remote agents syste
 
 - `TeXRA: Sign In` - OAuth authentication flow
 - `TeXRA: Sign Out` - Clear session
-- `TeXRA: View Profile` - View user info and tier
-- `TeXRA: Browse Remote Agents` - List and select agents
+- `TeXRA: View Profile` - View user info, tier, and browse remote agents
 - Remote agents referenced as `remote://agent-name`
 
 ### 4. **Security**
@@ -114,11 +113,11 @@ We've successfully implemented a complete authentication and remote agents syste
 
 3. **Browse Remote Agents**:
    - Press `Cmd/Ctrl + Shift + P`
-   - Run `TeXRA: Browse Remote Agents`
-   - Select an agent (copies `remote://agent-name` to clipboard)
+   - Run `TeXRA: View Profile`
+   - Browse the Remote Agents table and click **Use** on any agent
 
 4. **Use Remote Agent**:
-   - In TeXRA's agent selector, paste `remote://agent-name`
+   - The agent is automatically added to your agent selector
    - Agent loads from Supabase (permissions checked automatically)
 
 ---

--- a/docs/SUPABASE_SETUP.md
+++ b/docs/SUPABASE_SETUP.md
@@ -540,8 +540,8 @@ For end users, the process is simple:
 1. **No configuration needed** - credentials are hardcoded in the extension
 2. **Sign in**: Run `TeXRA: Sign In` command
 3. **Authenticate** via browser (GitHub/Google)
-4. **Browse remote agents**: Run `TeXRA: Browse Remote Agents`
-5. **Use agents**: Paste `remote://agent-name` in agent selector
+4. **View profile**: Run `TeXRA: View Profile` to browse remote agents
+5. **Use agents**: Click **Use** on any agent in the Remote Agents table
 
 That's it! No Supabase URLs, API keys, or other configuration.
 

--- a/docs/guide/remote-agents.md
+++ b/docs/guide/remote-agents.md
@@ -28,12 +28,12 @@ You can check your authentication status anytime by running **TeXRA: View Profil
 
 ### 2. Browse Available Agents
 
-Once signed in, you can explore remote agents:
+Once signed in, you can explore remote agents from your profile:
 
 1. Open the Command Palette
-2. Run: **TeXRA: Browse Remote Agents**
-3. Browse through the list of available agents
-4. Select an agent to add it to your agent selector
+2. Run: **TeXRA: View Profile**
+3. Browse the **Remote Agents** table showing all available agents
+4. Click **Use** on any agent to add it to your agent selector
 
 The selected agent will appear in your main TeXRA view alongside your built-in agents.
 

--- a/package.json
+++ b/package.json
@@ -1192,12 +1192,6 @@
         "icon": "$(account)"
       },
       {
-        "command": "texra.remoteAgents.browse",
-        "title": "Browse Remote Agents",
-        "category": "TeXRA",
-        "icon": "$(cloud)"
-      },
-      {
         "command": "texra.testTextEditor",
         "title": "Test Text Editor Tool",
         "category": "TeXRA",

--- a/src/agent/modelHandlers/utils/requestExecutor.ts
+++ b/src/agent/modelHandlers/utils/requestExecutor.ts
@@ -46,10 +46,16 @@ export async function executeWithRequestRetry<T>(
   request: () => Promise<T> | T,
 ): Promise<T> {
   // Default to 1 attempt (no automatic retries) unless explicitly configured
-  const configuredMaxAttempts = options.maxAttempts ?? getModelRetryMaxAttempts();
-  const maxAttempts = Math.max(1, configuredMaxAttempts ?? DEFAULT_MODEL_RETRY_ATTEMPTS);
+  const configuredMaxAttempts =
+    options.maxAttempts ?? getModelRetryMaxAttempts();
+  const maxAttempts = Math.max(
+    1,
+    configuredMaxAttempts ?? DEFAULT_MODEL_RETRY_ATTEMPTS,
+  );
   const baseDelayMs =
-    options.baseDelayMs ?? getModelRetryBackoffMs() ?? DEFAULT_MODEL_RETRY_BACKOFF_MS;
+    options.baseDelayMs ??
+    getModelRetryBackoffMs() ??
+    DEFAULT_MODEL_RETRY_BACKOFF_MS;
   const allowManualRetry = options.enableManualRetry ?? true;
   const manualRetryKey = options.manualRetryKey ?? options.logger.channelId;
 

--- a/src/agent/utils/agentOptionMetadata.ts
+++ b/src/agent/utils/agentOptionMetadata.ts
@@ -49,7 +49,9 @@ interface ParsedAgentDefinition {
   description?: string;
 }
 
-function readAgentDefinition(yamlPath?: string): ParsedAgentDefinition | undefined {
+function readAgentDefinition(
+  yamlPath?: string,
+): ParsedAgentDefinition | undefined {
   if (!yamlPath) {
     return undefined;
   }

--- a/src/auth/authCommands.ts
+++ b/src/auth/authCommands.ts
@@ -11,7 +11,6 @@ export const AUTH_COMMANDS = {
   SIGN_OUT: 'texra.auth.signOut',
   VIEW_PROFILE: 'texra.auth.viewProfile',
   ACCOUNT_MENU: 'texra.auth.accountMenu',
-  BROWSE_REMOTE_AGENTS: 'texra.remoteAgents.browse',
 } as const;
 
 // Singleton instance of ProfileViewProvider
@@ -189,17 +188,12 @@ export async function showAccountMenu(): Promise<void> {
         await vscode.commands.executeCommand(AUTH_COMMANDS.SIGN_IN);
       }
     } else {
-      // Signed in - show profile, browse agents, and sign out options
+      // Signed in - show profile and sign out options
       const items = [
         {
           label: '$(account) View Profile',
           description: `Signed in as ${status.email || 'unknown'} (${status.tier} tier)`,
           action: 'viewProfile' as const,
-        },
-        {
-          label: '$(cloud) Browse Remote Agents',
-          description: 'Explore available remote agents',
-          action: 'browseAgents' as const,
         },
         {
           label: '$(sign-out) Sign Out',
@@ -216,11 +210,6 @@ export async function showAccountMenu(): Promise<void> {
         switch (choice.action) {
           case 'viewProfile':
             await vscode.commands.executeCommand(AUTH_COMMANDS.VIEW_PROFILE);
-            break;
-          case 'browseAgents':
-            await vscode.commands.executeCommand(
-              AUTH_COMMANDS.BROWSE_REMOTE_AGENTS,
-            );
             break;
           case 'signOut':
             await vscode.commands.executeCommand(AUTH_COMMANDS.SIGN_OUT);

--- a/src/commands/auth/index.ts
+++ b/src/commands/auth/index.ts
@@ -1,8 +1,4 @@
 import * as vscode from 'vscode';
-import {
-  loadAndRegisterRemoteAgents,
-  selectAgentInMainView,
-} from '@agent/remote/remoteAgentUtils';
 import * as authCommands from '@/auth/authCommands';
 import { AUTH_COMMANDS } from '@/auth/authCommands';
 
@@ -29,86 +25,10 @@ export function registerAuthCommands(
       AUTH_COMMANDS.ACCOUNT_MENU,
       authCommands.showAccountMenu,
     ),
-    vscode.commands.registerCommand(
-      AUTH_COMMANDS.BROWSE_REMOTE_AGENTS,
-      browseRemoteAgents,
-    ),
   ];
 
   context.subscriptions.push(...disposables);
   return disposables;
-}
-
-/**
- * Command to browse and select remote agents.
- */
-async function browseRemoteAgents(): Promise<void> {
-  try {
-    // Check authentication status first
-    const authStatus = await authCommands.getAuthStatus();
-
-    // Use shared utility to load and register agents
-    const { agents } = await loadAndRegisterRemoteAgents();
-
-    if (agents.length === 0) {
-      if (!authStatus.authenticated) {
-        // User is not authenticated - prompt to sign in
-        const signIn = 'Sign In';
-        const choice = await vscode.window.showInformationMessage(
-          'No remote agents available. Sign in to access remote agents from the researcher access program.',
-          signIn,
-        );
-
-        if (choice === signIn) {
-          await vscode.commands.executeCommand(AUTH_COMMANDS.SIGN_IN);
-        }
-      } else {
-        // User is authenticated but no agents available - suggest contacting support
-        const contactSupport = 'Contact Support';
-        const choice = await vscode.window.showInformationMessage(
-          'No remote agents available for your account tier. Please contact contact@texra.ai for assistance.',
-          contactSupport,
-        );
-
-        if (choice === contactSupport) {
-          await vscode.env.openExternal(
-            vscode.Uri.parse('mailto:contact@texra.ai'),
-          );
-        }
-      }
-      return;
-    }
-
-    // Create quick pick items
-    const items = agents.map((agent) => ({
-      label: `$(cloud) ${agent.name}`,
-      description: agent.description,
-      detail: `Visibility: ${agent.visibility} | Tags: ${agent.tags.join(', ') || 'none'}`,
-      agentName: agent.name,
-    }));
-
-    // Show quick pick
-    const selected = await vscode.window.showQuickPick(items, {
-      placeHolder: 'Select a remote agent to use',
-      matchOnDescription: true,
-      matchOnDetail: true,
-    });
-
-    if (!selected) {
-      return;
-    }
-
-    // Use shared utility for agent selection with clipboard fallback
-    await selectAgentInMainView(selected.agentName, {
-      showSuccessMessage: true,
-      copyToClipboardOnFailure: true,
-    });
-  } catch (error) {
-    const message = error instanceof Error ? error.message : 'Unknown error';
-    void vscode.window.showErrorMessage(
-      `Failed to browse remote agents: ${message}`,
-    );
-  }
 }
 
 // Re-export AUTH_COMMANDS for external use

--- a/src/historyView/styles/index.css
+++ b/src/historyView/styles/index.css
@@ -187,7 +187,10 @@ mark.current-match {
 }
 
 .kind-workflow {
-  background-color: var(--vscode-editorInfo-background, rgba(0, 127, 212, 0.15));
+  background-color: var(
+    --vscode-editorInfo-background,
+    rgba(0, 127, 212, 0.15)
+  );
   color: var(--vscode-editorInfo-foreground, #3794ff);
 }
 

--- a/src/progressView/styles/tabs.css
+++ b/src/progressView/styles/tabs.css
@@ -54,7 +54,8 @@
   flex-direction: column;
   align-items: flex-start;
   padding: var(--spacing-small)
-    calc(var(--spacing-medium) + var(--height-control));
+    calc(var(--spacing-medium) + var(--height-control)) var(--spacing-small)
+    var(--spacing-small);
   cursor: pointer;
   border: none;
   background: none;

--- a/src/progressView/styles/tabs.css
+++ b/src/progressView/styles/tabs.css
@@ -54,8 +54,7 @@
   flex-direction: column;
   align-items: flex-start;
   padding: var(--spacing-small)
-    calc(var(--spacing-medium) + var(--height-control)) var(--spacing-small)
-    var(--spacing-small);
+    calc(var(--spacing-medium) + var(--height-control)) var(--spacing-small) 0;
   cursor: pointer;
   border: none;
   background: none;

--- a/src/progressView/styles/tabs.css
+++ b/src/progressView/styles/tabs.css
@@ -53,8 +53,10 @@
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  padding: var(--spacing-small)
-    calc(var(--spacing-medium) + var(--height-control)) var(--spacing-small) 0;
+  padding-top: var(--spacing-small);
+  padding-right: calc(var(--spacing-medium) + var(--height-control));
+  padding-bottom: var(--spacing-small);
+  padding-left: 0;
   cursor: pointer;
   border: none;
   background: none;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Consolidates remote agent browsing into the View Profile flow and removes the Browse Remote Agents command, with corresponding doc updates and a small ProgressBoard tab padding tweak.
> 
> - **Auth & Commands**:
>   - Remove `texra.remoteAgents.browse` command and related identifiers/registration.
>   - Update account menu: keep `View Profile` and `Sign Out`; drop "Browse Remote Agents" option.
> - **Docs**:
>   - Replace "Browse Remote Agents" flow with `TeXRA: View Profile` to browse and use agents.
>   - Update implementation/setup guides and configuration to reference only 3 auth commands.
> - **UI**:
>   - ProgressBoard tabs: remove left padding on `.tab` to align content flush left.
> - **Code cleanup**:
>   - Minor formatting/line-wrap adjustments in TypeScript and CSS files.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8d62d8798b9a0ed1fc20d38ccf898d6422dff305. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->