### PR TITLE
Add remote agent indicator icon to dropdown

### DIFF
--- a/src/agent/utils/agentOptionMetadata.ts
+++ b/src/agent/utils/agentOptionMetadata.ts
@@ -119,22 +119,16 @@ export function getAgentOptionMetadata(
   };
 }
 
+/**
+ * Get the clean label for an agent option.
+ * Note: Visual decoration (icons) is handled client-side by _decorateAgentOption
+ * using the data-remote and data-multiple attributes with the shared AGENT_DECORATORS config.
+ */
 function decorateLabel(
   agentName: string,
-  metadata: AgentOptionMetadata,
+  _metadata: AgentOptionMetadata,
 ): string {
-  const cleanName = RemoteAgentRegistry.getCleanName(agentName);
-  let label = cleanName;
-
-  // Add cloud icon for remote agents
-  if (metadata.isRemote) {
-    label = `☁ ${cleanName}`;
-  }
-
-  if (metadata.hasMultipleSibling || metadata.isMultipleOutput) {
-    label += ' ∶∶';
-  }
-  return label;
+  return RemoteAgentRegistry.getCleanName(agentName);
 }
 
 interface AgentOptionTagOptions {

--- a/src/common/modules/iconConstants.js
+++ b/src/common/modules/iconConstants.js
@@ -46,6 +46,15 @@ export function getCodiconClass(iconName) {
 }
 
 /**
+ * Apply codicon classes to an element.
+ * @param {HTMLElement} element - The element to apply classes to
+ * @param {string} iconName - Icon name (e.g., 'cloud', 'tools')
+ */
+export function applyCodiconClass(element, iconName) {
+  element.classList.add('codicon', `codicon-${iconName}`);
+}
+
+/**
  * Get the decorator config for an agent type.
  * @param {string} agentType - Agent type key (CoT, direct, toolUse)
  * @returns {{ icon: string, label: string }}

--- a/src/common/modules/iconConstants.js
+++ b/src/common/modules/iconConstants.js
@@ -17,7 +17,7 @@ export const AGENT_DECORATORS = {
     multipleOutputs: {
       icon: 'files',
       label: 'Multiple outputs',
-      hint: 'Supports multi-file inputs.',
+      hint: 'Generates multiple output files',
     },
   },
 

--- a/src/common/modules/iconConstants.js
+++ b/src/common/modules/iconConstants.js
@@ -11,8 +11,8 @@ export const AGENT_DECORATORS = {
   properties: {
     remote: {
       icon: 'cloud',
-      label: 'Remote agent',
-      hint: 'Remote agent',
+      label: 'Remote',
+      hint: 'Agent prompts loaded from remote',
     },
     multipleOutputs: {
       icon: 'files',

--- a/src/common/modules/iconConstants.js
+++ b/src/common/modules/iconConstants.js
@@ -1,3 +1,67 @@
 export const CHEVRON_UP_CLASS = 'codicon codicon-chevron-up';
 export const CHEVRON_DOWN_CLASS = 'codicon codicon-chevron-down';
 export const CHEVRON_RIGHT_CLASS = 'codicon codicon-chevron-right';
+
+/**
+ * Agent decorator configuration - single source of truth for all agent indicators.
+ * Used across dropdown, stream tabs, and history view.
+ */
+export const AGENT_DECORATORS = {
+  // Agent properties (remote, multiple outputs)
+  properties: {
+    remote: {
+      icon: 'cloud',
+      label: 'Remote agent',
+      hint: 'Remote agent',
+    },
+    multipleOutputs: {
+      icon: 'files',
+      label: 'Multiple outputs',
+      hint: 'Supports multi-file inputs.',
+    },
+  },
+
+  // Agent types (reasoning strategy)
+  types: {
+    CoT: { icon: 'list-tree', label: 'Chain of Thought' },
+    direct: { icon: 'lightbulb', label: 'Direct' },
+    toolUse: { icon: 'tools', label: 'Tool Use' },
+    unknown: { icon: 'question', label: 'Unknown' },
+  },
+
+  // Session kinds (workflow vs tool-use category)
+  sessionKinds: {
+    workflow: { icon: 'symbol-method', label: 'Workflow' },
+    toolUse: { icon: 'tools', label: 'Tool Use' },
+  },
+};
+
+/**
+ * Build a codicon CSS class string from an icon name.
+ * @param {string} iconName - Icon name (e.g., 'cloud', 'tools')
+ * @returns {string} Full codicon class string
+ */
+export function getCodiconClass(iconName) {
+  return `codicon codicon-${iconName}`;
+}
+
+/**
+ * Get the decorator config for an agent type.
+ * @param {string} agentType - Agent type key (CoT, direct, toolUse)
+ * @returns {{ icon: string, label: string }}
+ */
+export function getAgentTypeDecorator(agentType) {
+  return AGENT_DECORATORS.types[agentType] || AGENT_DECORATORS.types.unknown;
+}
+
+/**
+ * Get the decorator config for a session kind.
+ * @param {string} sessionKind - Session kind key (workflow, toolUse)
+ * @returns {{ icon: string, label: string }}
+ */
+export function getSessionKindDecorator(sessionKind) {
+  return (
+    AGENT_DECORATORS.sessionKinds[sessionKind] ||
+    AGENT_DECORATORS.sessionKinds.workflow
+  );
+}

--- a/src/historyView/index.html
+++ b/src/historyView/index.html
@@ -35,6 +35,7 @@
           "@common/domUtils.js": "${domUtilsUri}",
           "@common/templateUtils.js": "${templateUtilsUri}",
           "@common/htmlEncoding.js": "${htmlEncodingUri}",
+          "@common/iconConstants.js": "${iconConstantsUri}",
           "@common/BaseWebviewMessageHandler.js": "${baseWebviewMessageHandlerUri}",
           "@common/BaseDomHandler.js": "${baseDomHandlerUri}",
           "he": "https://esm.sh/he@1.2.0"

--- a/src/historyView/modules/uiManagers/HistoryRenderer.js
+++ b/src/historyView/modules/uiManagers/HistoryRenderer.js
@@ -13,6 +13,7 @@ import {
 } from '@common/domUtils.js';
 import { createFromTemplate, createCodicon } from '@common/templateUtils.js';
 import { encodeHtml, encodeListForHtml } from '@common/htmlEncoding.js';
+import { getSessionKindDecorator } from '@common/iconConstants.js';
 // Local imports
 import { vscode } from '@common/webviewContext.js';
 
@@ -65,10 +66,11 @@ export class HistoryRenderer {
     const session = config?.session;
     const date = new Date(item.timestamp).toLocaleString();
 
-    // Determine session kind display
+    // Determine session kind display using shared config
     const isToolUse = session?.agentCategory === AGENT_CATEGORY.TOOL_USE;
-    const kindLabel = isToolUse ? 'Tool Use' : 'Workflow';
-    const kindIcon = isToolUse ? 'tools' : 'symbol-method';
+    const sessionKind = isToolUse ? 'toolUse' : 'workflow';
+    const { icon: kindIcon, label: kindLabel } =
+      getSessionKindDecorator(sessionKind);
     const kindClass = isToolUse ? 'kind-tool-use' : 'kind-workflow';
 
     const container = createFromTemplate('historyItemTemplate', {

--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -274,6 +274,7 @@
                 <div class="tab-meta">
                   <span class="model"></span>
                   <span class="last-active"></span>
+                  <i class="remote-agent"></i>
                   <i class="agent-type"></i>
                   <i class="multi-file"></i>
                 </div>

--- a/src/progressView/modules/uiManagers/StreamTabs.js
+++ b/src/progressView/modules/uiManagers/StreamTabs.js
@@ -122,7 +122,7 @@ export class StreamTabs {
     // Agent type icon (CoT, direct, toolUse)
     const agentIcon = tabEl.querySelector('.agent-type');
     if (agentIcon) {
-      const key = info.agentType || info.agent || 'unknown';
+      const key = info.agentType ?? info.agent ?? 'unknown';
       const decorator = getAgentTypeDecorator(key);
       applyCodiconClass(agentIcon, decorator.icon);
       agentIcon.title = `Agent type: ${decorator.label}`;

--- a/src/progressView/modules/uiManagers/StreamTabs.js
+++ b/src/progressView/modules/uiManagers/StreamTabs.js
@@ -6,7 +6,7 @@ import { formatRelativeTime } from '@common/stringUtils.js';
 import {
   AGENT_DECORATORS,
   getAgentTypeDecorator,
-  getCodiconClass,
+  applyCodiconClass,
 } from '@common/iconConstants.js';
 
 /**
@@ -124,7 +124,7 @@ export class StreamTabs {
     if (agentIcon) {
       const key = info.agentType || info.agent || 'unknown';
       const decorator = getAgentTypeDecorator(key);
-      agentIcon.classList.add(...getCodiconClass(decorator.icon).split(' '));
+      applyCodiconClass(agentIcon, decorator.icon);
       agentIcon.title = `Agent type: ${decorator.label}`;
     }
 
@@ -132,9 +132,9 @@ export class StreamTabs {
     const remoteIcon = tabEl.querySelector('.remote-agent');
     if (remoteIcon) {
       if (info.isRemote) {
-        const { icon, label } = AGENT_DECORATORS.properties.remote;
-        remoteIcon.classList.add(...getCodiconClass(icon).split(' '));
-        remoteIcon.title = label;
+        const { icon, hint } = AGENT_DECORATORS.properties.remote;
+        applyCodiconClass(remoteIcon, icon);
+        remoteIcon.title = hint;
       } else {
         remoteIcon.remove();
       }
@@ -144,9 +144,9 @@ export class StreamTabs {
     const multiIcon = tabEl.querySelector('.multi-file');
     if (multiIcon) {
       if (info.hasMultipleOutputs) {
-        const { icon, label } = AGENT_DECORATORS.properties.multipleOutputs;
-        multiIcon.classList.add(...getCodiconClass(icon).split(' '));
-        multiIcon.title = label;
+        const { icon, hint } = AGENT_DECORATORS.properties.multipleOutputs;
+        applyCodiconClass(multiIcon, icon);
+        multiIcon.title = hint;
       } else {
         multiIcon.remove();
       }

--- a/src/progressView/modules/uiManagers/StreamTabs.js
+++ b/src/progressView/modules/uiManagers/StreamTabs.js
@@ -3,13 +3,11 @@
 import { ELEMENT_IDS } from '../constants.js';
 import { createFromTemplate } from '@common/templateUtils.js';
 import { formatRelativeTime } from '@common/stringUtils.js';
-
-const AGENT_ICONS = {
-  CoT: 'list-tree',
-  direct: 'lightbulb',
-  toolUse: 'tools',
-  unknown: 'question',
-};
+import {
+  AGENT_DECORATORS,
+  getAgentTypeDecorator,
+  getCodiconClass,
+} from '@common/iconConstants.js';
 
 /**
  * Manages stream tab UI updates.
@@ -62,22 +60,8 @@ export class StreamTabs {
         statusEl.dataset.status =
           status.charAt(0).toUpperCase() + status.slice(1);
       }
-      const agentIcon = tabEl.querySelector('.agent-type');
-      if (agentIcon) {
-        const key = info.agentType || info.agent || 'unknown';
-        const icon = AGENT_ICONS[key] || AGENT_ICONS.unknown;
-        agentIcon.classList.add('codicon', `codicon-${icon}`);
-        agentIcon.title = `Agent type: ${key}`;
-      }
-      const multiIcon = tabEl.querySelector('.multi-file');
-      if (multiIcon) {
-        if (info.hasMultipleOutputs) {
-          multiIcon.classList.add('codicon', 'codicon-files');
-          multiIcon.title = 'Multiple output files';
-        } else {
-          multiIcon.remove();
-        }
-      }
+      // Apply agent decorators from shared config
+      this._applyAgentDecorators(tabEl, info);
       if (info.name === activeStream) {
         tabEl.classList.add('active');
         activeInfo = info;
@@ -126,5 +110,46 @@ export class StreamTabs {
       }
     }
     return parts.filter(Boolean).join('\n');
+  }
+
+  /**
+   * Apply agent decorator icons to a tab element.
+   * Uses shared AGENT_DECORATORS config for consistency.
+   * @param {HTMLElement} tabEl - The tab element
+   * @param {Object} info - Stream info object
+   */
+  _applyAgentDecorators(tabEl, info) {
+    // Agent type icon (CoT, direct, toolUse)
+    const agentIcon = tabEl.querySelector('.agent-type');
+    if (agentIcon) {
+      const key = info.agentType || info.agent || 'unknown';
+      const decorator = getAgentTypeDecorator(key);
+      agentIcon.classList.add(...getCodiconClass(decorator.icon).split(' '));
+      agentIcon.title = `Agent type: ${decorator.label}`;
+    }
+
+    // Remote agent icon
+    const remoteIcon = tabEl.querySelector('.remote-agent');
+    if (remoteIcon) {
+      if (info.isRemote) {
+        const { icon, label } = AGENT_DECORATORS.properties.remote;
+        remoteIcon.classList.add(...getCodiconClass(icon).split(' '));
+        remoteIcon.title = label;
+      } else {
+        remoteIcon.remove();
+      }
+    }
+
+    // Multiple outputs icon
+    const multiIcon = tabEl.querySelector('.multi-file');
+    if (multiIcon) {
+      if (info.hasMultipleOutputs) {
+        const { icon, label } = AGENT_DECORATORS.properties.multipleOutputs;
+        multiIcon.classList.add(...getCodiconClass(icon).split(' '));
+        multiIcon.title = label;
+      } else {
+        multiIcon.remove();
+      }
+    }
   }
 }

--- a/src/progressView/streamInfoUtils.ts
+++ b/src/progressView/streamInfoUtils.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 
 // Local imports - progress view
 import { AgentCategory } from '@agent/core/AgentDataclass';
+import { RemoteAgentRegistry } from '@agent/remote/RemoteAgentRegistry';
 
 // Type imports
 import type { ProgressViewState } from './state/ProgressViewState';
@@ -81,6 +82,7 @@ export function buildStreamInfos(
     const agentType =
       taskState?.session?.agentType ?? taskState?.agentConfig.agentType;
     const isToolAgent = sessionCategory === AgentCategory.ToolUse;
+    const isRemote = RemoteAgentRegistry.isRemote(agentName);
     const executionId = state.getExecutionId(id);
     const label = buildStreamLabel(agentName, inputFile, sessionCategory);
     acc.push({
@@ -95,6 +97,7 @@ export function buildStreamInfos(
         isToolAgent,
       },
       hasMultipleOutputs: outputs.length > 1,
+      isRemote,
       lastTimestamp,
       inputFile,
       creationTimestamp,

--- a/src/progressView/styles/tabs.css
+++ b/src/progressView/styles/tabs.css
@@ -93,6 +93,7 @@
   width: 100%;
 }
 
+.tab-meta .remote-agent,
 .tab-meta .agent-type,
 .tab-meta .multi-file {
   margin-left: var(--spacing-small);

--- a/src/progressView/types.ts
+++ b/src/progressView/types.ts
@@ -20,6 +20,8 @@ export interface StreamTabInfo {
   agentSessionKind: AgentCategory;
   uiTraits: StreamUITraits;
   hasMultipleOutputs?: boolean;
+  /** Whether this is a remote agent */
+  isRemote?: boolean;
   lastTimestamp?: number;
   inputFile?: string;
   creationTimestamp?: number;

--- a/src/test/agent/utils/agentOptionMetadata.test.ts
+++ b/src/test/agent/utils/agentOptionMetadata.test.ts
@@ -38,7 +38,7 @@ describe('agentOptionMetadata', () => {
     assert.equal(metadata.isMultipleOutput, true);
     const optionTag = createAgentOptionTag('custom_multi', metadata);
     assert.ok(optionTag.includes('data-multiple="true"'));
-    assert.ok(optionTag.includes('∶∶'));
+    // Note: Visual decoration (icons) is now handled client-side via AGENT_DECORATORS
   });
 
   it('keeps base agents decorated when a sibling _multiple file exists', () => {
@@ -61,6 +61,6 @@ describe('agentOptionMetadata', () => {
     assert.equal(metadata.hasMultipleSibling, true);
     const optionTag = createAgentOptionTag('writer', metadata);
     assert.ok(optionTag.includes('data-multiple="true"'));
-    assert.ok(optionTag.includes('∶∶'));
+    // Note: Visual decoration (icons) is now handled client-side via AGENT_DECORATORS
   });
 });

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -41,6 +41,10 @@ import {
   getSelectedOptionElement,
 } from '@common/domUtils.js';
 import { capitalize, uncapitalize } from '@common/stringUtils.js';
+import {
+  AGENT_DECORATORS,
+  getCodiconClass,
+} from '@common/iconConstants.js';
 
 // Import standardized commands
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
@@ -243,12 +247,14 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
       this._readAgentOptionMetadata(opt);
 
     const hints = [];
-    let displayLabel = label;
+    const prefixIcons = [];
+    const suffixIcons = [];
 
-    // Add cloud icon for remote agents
+    // Add cloud icon for remote agents (using shared config)
     if (isRemote) {
-      displayLabel = `☁ ${displayLabel}`;
-      hints.push('Remote agent');
+      const { icon, hint } = AGENT_DECORATORS.properties.remote;
+      prefixIcons.push(this._createCodiconHtml(icon));
+      hints.push(hint);
     }
 
     // Add description as the primary hint if available
@@ -256,9 +262,11 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
       hints.push(description);
     }
 
+    // Add multiple outputs icon (using shared config)
     if (isMultiple) {
-      displayLabel += ' ∶∶';
-      hints.push('Supports multi-file inputs.');
+      const { icon, hint } = AGENT_DECORATORS.properties.multipleOutputs;
+      suffixIcons.push(this._createCodiconHtml(icon));
+      hints.push(hint);
       opt.style.opacity = '0.9';
     } else {
       opt.style.opacity = '';
@@ -268,7 +276,11 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
       hints.push('Uses tools for actions.');
     }
 
-    opt.textContent = displayLabel;
+    // Build display with codicons
+    const escapedLabel = this._escapeHtml(label);
+    const prefix = prefixIcons.length > 0 ? prefixIcons.join('') + ' ' : '';
+    const suffix = suffixIcons.length > 0 ? ' ' + suffixIcons.join('') : '';
+    opt.innerHTML = `${prefix}${escapedLabel}${suffix}`;
 
     if (hints.length > 0) {
       opt.title = hints.join('\n');
@@ -279,6 +291,26 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
       opt.setAttribute('aria-label', label);
       opt.removeAttribute('aria-description');
     }
+  }
+
+  /**
+   * Create a codicon HTML string for inline use.
+   * @param {string} iconName - Icon name (e.g., 'cloud', 'files')
+   * @returns {string} HTML string for the codicon
+   */
+  _createCodiconHtml(iconName) {
+    return `<i class="${getCodiconClass(iconName)}"></i>`;
+  }
+
+  /**
+   * Escape HTML special characters in a string.
+   * @param {string} text - Text to escape
+   * @returns {string} Escaped text
+   */
+  _escapeHtml(text) {
+    const div = document.createElement('div');
+    div.textContent = text;
+    return div.innerHTML;
   }
 
   _readAgentOptionMetadata(opt) {
@@ -333,13 +365,14 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
     // Check if this looks like it could be a remote agent and create the option
     if (!existingOption) {
       // This could be a remote agent being set programmatically
-      // Create the option with remote styling
+      // Create the option with remote styling using shared config
+      const { icon, hint } = AGENT_DECORATORS.properties.remote;
       const option = document.createElement('vscode-option');
       option.value = value;
-      option.textContent = `☁ ${value}`;
-      option.dataset.label = `☁ ${value}`;
+      option.innerHTML = `${this._createCodiconHtml(icon)} ${this._escapeHtml(value)}`;
+      option.dataset.label = value;
       option.dataset.remote = 'true';
-      option.setAttribute('title', `Remote agent: ${value}`);
+      option.setAttribute('title', hint);
 
       // Add the option to the select
       selectElement.appendChild(option);

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -239,11 +239,17 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
   }
 
   _decorateAgentOption(opt) {
-    const { label, isMultiple, isToolUse, description } =
+    const { label, isMultiple, isToolUse, isRemote, description } =
       this._readAgentOptionMetadata(opt);
 
     const hints = [];
     let displayLabel = label;
+
+    // Add cloud icon for remote agents
+    if (isRemote) {
+      displayLabel = `☁ ${displayLabel}`;
+      hints.push('Remote agent');
+    }
 
     // Add description as the primary hint if available
     if (description) {
@@ -294,6 +300,7 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
       label,
       isMultiple: opt.dataset.multiple === 'true',
       isToolUse: opt.dataset.toolUse === 'true',
+      isRemote: opt.dataset.remote === 'true',
       description: opt.dataset.description ?? '',
     };
   }

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -338,8 +338,10 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
   }
 
   /**
-   * Sets an agent selector value, creating the option if it's a remote agent.
-   * Remote agents are now identified by data-remote attribute instead of remote:// prefix.
+   * Sets an agent selector value, creating a placeholder option if needed.
+   * Note: Placeholder options are created without remote styling since we can't
+   * determine remote status on the client side. When SET_AGENT_OPTIONS arrives,
+   * it will replace options with properly decorated versions.
    * @param {string} selectId - The ID of the agent select element
    * @param {string} value - The agent value to set
    */
@@ -361,20 +363,17 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
       (opt) => opt.value === value,
     );
 
-    // If option doesn't exist, it might be a newly selected remote agent
-    // Check if this looks like it could be a remote agent and create the option
+    // If option doesn't exist, create a placeholder without remote styling.
+    // SET_AGENT_OPTIONS will replace this with properly decorated options.
     if (!existingOption) {
-      // This could be a remote agent being set programmatically
-      // Create the option with remote styling using shared config
-      const { icon, hint } = AGENT_DECORATORS.properties.remote;
       const option = document.createElement('vscode-option');
       option.value = value;
-      option.innerHTML = `${this._createCodiconHtml(icon)} ${this._escapeHtml(value)}`;
+      option.textContent = value;
       option.dataset.label = value;
-      option.dataset.remote = 'true';
-      option.setAttribute('title', hint);
+      // Note: We don't set data-remote here since we can't determine
+      // remote status on the client side. The server will provide this
+      // info when SET_AGENT_OPTIONS arrives.
 
-      // Add the option to the select
       selectElement.appendChild(option);
     }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Centralizes agent icon/label decorators and displays remote/type/multi-output indicators across agent dropdown, stream tabs, and history, with remote flag propagated from backend.
> 
> - **Shared**:
>   - Add `AGENT_DECORATORS` and helpers (`getCodiconClass`, `applyCodiconClass`, `getAgentTypeDecorator`, `getSessionKindDecorator`) in `src/common/modules/iconConstants.js`.
> - **Webview (Main)**:
>   - Decorate agent dropdown options using shared config; add remote and multiple-output codicons; improve ARIA/tooltips; create placeholder options without client-side remote inference in `messageHandlers.js`.
>   - Import `@common/iconConstants.js` in `index.html`.
> - **Progress View**:
>   - Template: add `.remote-agent` icon slot in `streamTabTemplate`.
>   - `StreamTabs.js`: replace inline icons with shared decorators; render type/remote/multi-output icons via `AGENT_DECORATORS`.
>   - `streamInfoUtils.ts`: compute `isRemote` via `RemoteAgentRegistry` and include on `StreamTabInfo`.
>   - `types.ts`: add `isRemote?: boolean`.
>   - Styles: support `.remote-agent` in `tabs.css`.
> - **History View**:
>   - Use `getSessionKindDecorator` for session kind icon/label in `HistoryRenderer.js`; import mapping in `index.html`.
> - **Agent Options (backend)**:
>   - `decorateLabel` returns clean agent name; visual decoration moved client-side.
>   - `createAgentOptionTag` emits `data-remote`, `data-multiple`, `data-tool-use`, `data-description` attributes.
>   - Tests updated to drop inline decoration assertions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e8aa48bcd804c83e883be8ab85bfd7a7f965519e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->