### PR TITLE
Add left padding and improve close button visibility

### DIFF
--- a/src/progressView/styles/tabs.css
+++ b/src/progressView/styles/tabs.css
@@ -112,10 +112,7 @@
   height: var(--height-control);
   margin: 0;
   color: var(--vscode-icon-foreground, var(--vscode-foreground));
-  opacity: var(--opacity-subtle);
-  transition:
-    opacity 120ms ease,
-    color 120ms ease;
+  transition: color 120ms ease;
 }
 
 .tab-container:hover {
@@ -135,10 +132,6 @@
   border-radius: var(--border-radius-small);
 }
 
-.tab-container:hover .tab-delete,
-.tab-delete:focus-within {
-  opacity: var(--opacity-full);
-}
 
 .tab-delete:hover::part(control),
 .tab-delete:focus-within::part(control) {
@@ -150,14 +143,3 @@
   color: var(--vscode-errorForeground);
 }
 
-.tab-delete vscode-icon {
-  opacity: var(--opacity-subtle);
-  transition:
-    opacity 120ms ease,
-    color 120ms ease;
-}
-
-.tab-container:hover .tab-delete vscode-icon,
-.tab-delete:focus-within vscode-icon {
-  opacity: var(--opacity-full);
-}

--- a/src/progressView/styles/tabs.css
+++ b/src/progressView/styles/tabs.css
@@ -56,7 +56,7 @@
   padding-top: var(--spacing-small);
   padding-right: calc(var(--spacing-medium) + var(--height-control));
   padding-bottom: var(--spacing-small);
-  padding-left: 0;
+  padding-left: var(--spacing-small);
   cursor: pointer;
   border: none;
   background: none;


### PR DESCRIPTION
- Add left padding (spacing-small) to stream tab content for better visual balance
- Change close button default opacity from subtle to 0, making it fully hidden until hovering over the tab container

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add left padding to tabs and remove opacity-based show/hide behavior for the delete button, simplifying its transitions.
> 
> - **Styles (`src/progressView/styles/tabs.css`)**:
>   - **Tab layout**: Add left padding (`padding-left: var(--spacing-small)`) to `.tab` for better spacing.
>   - **Delete button (`.tab-delete`)**:
>     - Remove default opacity and hover/focus opacity rules (for button and nested `vscode-icon`).
>     - Simplify transitions to only `color 120ms ease`.
>     - Retain hover/focus background (`::part(control)`) and error color on hover/focus.
>   - **Hover/active states**: No change to tab container hover/active backgrounds; active tab text color preserved.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f3fc853c1be2a0396f98db3c5e7f0702ed8c7aba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->