### PR TITLE
fix: emit edited files to progress view for tool-use agents

### DIFF
--- a/src/agent/core/ToolUseCycle.ts
+++ b/src/agent/core/ToolUseCycle.ts
@@ -9,9 +9,16 @@
  * @see ResponseCycle for workflow-based cycle execution
  */
 
+// Standard library imports
+import * as path from 'path';
+
 // Local imports - agent components
 import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
+import type { OutputFileInfo } from '@agent/output/types';
+import { normalizeRunId } from '@progressView/constants/runIds';
 import type { BaseTool } from '@tools/core/base';
+import { pathToLocation } from '@utils/files';
+import { bus } from '@eventBus/ProgressEventBus';
 
 // Local file imports
 import { AgentSharedStore } from './AgentSharedStore';
@@ -22,13 +29,7 @@ import {
   type ToolUseCycleState,
 } from './flows/ToolUseCycleFlow';
 import { createRetryState, type RetryCallbacks } from './flows/RetryState';
-
-// Local imports - option helpers
 import type { AgentCycleBaseOptions } from './AgentCycleOptions';
-
-// Local imports - model handlers
-
-// Local imports - tools
 
 export interface ToolUseCycleOptions<C = unknown>
   extends AgentCycleBaseOptions<C> {
@@ -89,5 +90,52 @@ export async function runToolUseCycle<C = unknown>(
   const flow = createToolUseCycleFlow<C>();
   await flow.run(context);
 
+  // Emit edited files to the progress view
+  emitEditedFiles(input);
+
   return { retryCallbacks };
+}
+
+/**
+ * Emits edited files from tool-use cycle to the progress view.
+ * Converts tracked file edits into OutputFileInfo format and emits
+ * them via the event bus so they appear in the "Generated files" section.
+ *
+ * For tool-use agents, we emit a simple file list without lineage or diff
+ * stats since there's no meaningful base file to compare against.
+ */
+function emitEditedFiles<C>(input: ToolUseCycleInput<C>): void {
+  const { options, store } = input;
+  const interactions = store.workspace.interactions.toJSON();
+
+  if (interactions.edits.length === 0) {
+    return;
+  }
+
+  const stream = options.context.streamId;
+  const executionId = options.context.executionId;
+  const roundIndex = store.round.roundIndex;
+  // Tool-use agents don't create logger groups, so runId may be undefined.
+  // normalizeRunId handles this by returning DEFAULT_RUN_ID ('__default__').
+  const runId = options.logger.withCurrentGroup((id) => id);
+
+  // Deduplicate by path in case the same file was edited multiple times
+  const uniquePaths = [...new Set(interactions.edits.map((e) => e.path))];
+  const fileInfos: OutputFileInfo[] = uniquePaths.map((editPath) => ({
+    source: path.basename(editPath),
+    location: pathToLocation(editPath),
+    lineage: null,
+    diff: null,
+  }));
+
+  bus.emit('addOutputFiles', {
+    stream,
+    runId: normalizeRunId(runId),
+    executionId,
+    filesByRound: { [roundIndex]: fileInfos },
+  });
+
+  options.logger.debug(
+    `addOutputFiles emitted for tool-use round ${roundIndex}: ${fileInfos.length} files`,
+  );
 }


### PR DESCRIPTION
Tool-use agents now emit their edited files via the addOutputFiles event
so they appear in the "Generated files" section of the progress view.

Previously, file edits from tool calls (write_file, edit_file) were only
logged but not surfaced in the generated files UI. This change extracts
the tracked edits from the workspace state after each cycle completes
and emits them in OutputFileInfo format.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Publishes deduped edited files from tool-use cycles to the progress view via addOutputFiles with normalized runId and round grouping.
> 
> - **Agent Core (`src/agent/core/ToolUseCycle.ts`)**:
>   - After completing the tool-use flow, now emits edited files to the progress view.
>   - Adds `emitEditedFiles` to:
>     - Read tracked edits from `store.workspace.interactions`, dedupe by `path`, and map to `OutputFileInfo` (`source`, `location`, `lineage: null`, `diff: null`).
>     - Emit `addOutputFiles` via `bus` with `stream`, `executionId`, `roundIndex`, and `normalizeRunId(runId)`.
>     - Log a debug message with the emitted file count.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 030182e3b497dafc8d5b8936fbc676b7fd3b821e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->