### PR TITLE
fix: restrict OpenAI background mode to GPT 5 series with workflow agents

### DIFF
--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -8,7 +8,7 @@ import OpenAI, { APIConnectionTimeoutError, toFile } from 'openai';
 import type { AgentConfig } from '@agent/core/AgentConfig';
 import type { AgentSetting } from '@agent/core/AgentDataclass';
 // Internal imports
-import { hasEndTag } from '@agent/core/AgentDataclass';
+import { AgentType, hasEndTag } from '@agent/core/AgentDataclass';
 import { ConversationRoundState } from '@agent/core/AgentState';
 import {
   ResponseUsageFactory,
@@ -144,14 +144,15 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
    * @returns true if background mode is eligible for this model and agent type
    */
   private isBackgroundModeEligible(): boolean {
-    const isGpt5 = this.config.name.startsWith('gpt5');
+    const isGpt5 = this.config.name.toLowerCase().startsWith('gpt5');
     if (!isGpt5) {
       return false;
     }
 
-    // Workflow agents are CoT or Direct - must explicitly match, not just exclude ToolUse
+    // Workflow agents are CoT or Direct - must explicitly match known types
     const agentType = this.getAgentType();
-    const isWorkflowAgent = agentType === 'CoT' || agentType === 'direct';
+    const isWorkflowAgent =
+      agentType === AgentType.CoT || agentType === AgentType.Direct;
     return isWorkflowAgent;
   }
 

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -149,9 +149,9 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       return false;
     }
 
-    // Workflow agents are CoT or Direct (anything except ToolUse)
+    // Workflow agents are CoT or Direct - must explicitly match, not just exclude ToolUse
     const agentType = this.getAgentType();
-    const isWorkflowAgent = agentType !== 'toolUse';
+    const isWorkflowAgent = agentType === 'CoT' || agentType === 'direct';
     return isWorkflowAgent;
   }
 

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -129,13 +129,32 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       'texra.model.useBackgroundResponses',
       false,
     );
-    if (useBackgroundResponses) {
+    if (useBackgroundResponses && this.isBackgroundModeEligible()) {
       return false;
     }
     return super.getStreamingConfig();
   }
 
   protected override backgroundModeSupported = true;
+
+  /**
+   * Determines if background mode should be enabled for this request.
+   * Background mode is only supported for GPT 5 series models when running
+   * workflow agents (CoT or Direct), not tool-use agents.
+   * @returns true if background mode is eligible for this model and agent type
+   */
+  private isBackgroundModeEligible(): boolean {
+    const isGpt5 = this.config.name.startsWith('gpt5');
+    if (!isGpt5) {
+      return false;
+    }
+
+    // Workflow agents are CoT or Direct (anything except ToolUse)
+    const agentType = this.getAgentType();
+    const isWorkflowAgent = agentType !== 'toolUse';
+    return isWorkflowAgent;
+  }
+
   private static readonly BACKGROUND_POLL_INTERVAL_MS = 15000;
   private static readonly BACKGROUND_RETRIEVE_MAX_RETRIES = 3;
   private static readonly BACKGROUND_MAX_DURATION_MS = 3 * 60 * 60 * 1000; // 3 hours
@@ -516,13 +535,19 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       'texra.model.useBackgroundResponses',
       false,
     );
+    const isEligible = this.isBackgroundModeEligible();
     if (backgroundToggleEnabled && !this.backgroundModeSupported) {
       this.logger.debug(
         'Background mode toggle is enabled but this handler does not support background execution. Falling back to synchronous requests.',
       );
     }
+    if (backgroundToggleEnabled && this.backgroundModeSupported && !isEligible) {
+      this.logger.debug(
+        'Background mode toggle is enabled but not eligible for this model/agent type (requires GPT 5 series with workflow agents). Falling back to synchronous requests.',
+      );
+    }
     const useBackgroundResponses =
-      this.backgroundModeSupported && backgroundToggleEnabled;
+      this.backgroundModeSupported && backgroundToggleEnabled && isEligible;
     const useStreaming = streamingToggleEnabled && !useBackgroundResponses;
 
     if (streamingToggleEnabled && useBackgroundResponses) {


### PR DESCRIPTION
Background mode for OpenAI Responses API should only apply when both
conditions are met:
- Model is a GPT 5 series (name starts with 'gpt5')
- Agent is a workflow agent (CoT or Direct, not ToolUse)

This prevents background mode from being enabled for non-GPT-5 models
or when running tool-use agents, which don't benefit from the long-running
background execution pattern.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Restricts OpenAI Responses background mode to GPT-5 models when running workflow agents (CoT/Direct), and disables streaming only in those eligible cases.
> 
> - **OpenAI Responses handler (`src/agent/modelHandlers/modelHandlerOpenAIResponse.ts`)**:
>   - **Background execution gating**:
>     - Add `isBackgroundModeEligible()` to allow background mode only for `gpt5*` models with `AgentType.CoT` or `AgentType.Direct`.
>     - Update `getStreamingConfig()` to disable streaming only when background mode is enabled and eligible.
>     - Update `createResponse()` to enable background requests only when eligible; otherwise, fall back to synchronous; add clarifying debug logs.
>   - **Imports**: Include `AgentType` for eligibility checks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4118375ad6423e3817b2b04a0d4e77060917c041. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->