### PR TITLE
Create agentic coding guide for AI agents

### DIFF
--- a/src/agent/core/AgentDataclass.ts
+++ b/src/agent/core/AgentDataclass.ts
@@ -25,15 +25,9 @@ export enum AgentCategory {
   ToolUse = 'toolUse',
 }
 
-/**
- * Shared metadata describing how an agent session should be classified.
- */
-export interface AgentSessionDescriptor {
-  /** Specific agent implementation type if known. */
-  agentType?: AgentType;
-  /** Canonical grouping used by the UI to filter sessions. */
-  agentCategory: AgentCategory;
-}
+// Re-export AgentSessionDescriptor from schema (single source of truth)
+// Note: The type is derived from AgentSessionDescriptorSchema in AgentSessionSchema.ts
+export type { AgentSessionDescriptor } from './AgentSessionSchema';
 
 /**
  * Derive the canonical {@link AgentCategory} from a specific agent type.

--- a/src/agent/core/AgentSessionSchema.ts
+++ b/src/agent/core/AgentSessionSchema.ts
@@ -6,8 +6,15 @@ import { AgentCategory, AgentType } from './AgentDataclass';
 
 /**
  * Canonical schema for agent session descriptors shared across agent modules.
+ * This is the SINGLE SOURCE OF TRUTH - the type is derived from this schema.
  */
 export const AgentSessionDescriptorSchema = z.strictObject({
   agentType: z.enum(AgentType).optional(),
   agentCategory: z.enum(AgentCategory),
 });
+
+/**
+ * Shared metadata describing how an agent session should be classified.
+ * Derived from AgentSessionDescriptorSchema (single source of truth).
+ */
+export type AgentSessionDescriptor = z.infer<typeof AgentSessionDescriptorSchema>;

--- a/src/agent/core/ResponseCycle.ts
+++ b/src/agent/core/ResponseCycle.ts
@@ -17,7 +17,7 @@ import type { TaskRunFileService, AgentFileLocation } from '@utils/files';
 import { AgentSharedStore } from './AgentSharedStore';
 import {
   createResponseCycleFlow,
-  type ResponseCycleContext,
+  type ResponseCycleShared,
   type ResponseCycleState,
 } from './flows/ResponseCycleFlow';
 import { createRetryState, type RetryCallbacks } from './flows/RetryState';
@@ -67,9 +67,9 @@ export async function runResponseCycle<C = unknown>(
   // and can be called by the UI to trigger manual retry
   const retryCallbacks: RetryCallbacks = {};
 
-  const context: ResponseCycleContext<C> = {
-    options: input.options,
-    store: input.store,
+  // Shared state contains only mutable data that flows through nodes.
+  // Services (options, store) are injected via setParams().
+  const shared: ResponseCycleShared<C> = {
     state: {
       messages: input.messages,
       outputLocation: input.outputLocation,
@@ -91,11 +91,13 @@ export async function runResponseCycle<C = unknown>(
   };
 
   const flow = createResponseCycleFlow<C>();
-  await flow.run(context);
+  // Inject immutable services via params (PocketFlow pattern)
+  flow.setParams({ services: { options: input.options, store: input.store } });
+  await flow.run(shared);
 
   return {
-    store: context.store,
-    endTurn: context.state.endTurn,
+    store: input.store,
+    endTurn: shared.state.endTurn,
     retryCallbacks,
   };
 }

--- a/src/agent/core/ResponseCycle.ts
+++ b/src/agent/core/ResponseCycle.ts
@@ -11,7 +11,7 @@
 
 // Local imports - agent components
 import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
-import type { TaskRunFileService, AgentFileLocation } from '@utils/files';
+import type { AgentFileLocation } from '@utils/files';
 
 // Local file imports
 import { AgentSharedStore } from './AgentSharedStore';
@@ -22,15 +22,9 @@ import {
 } from './flows/ResponseCycleFlow';
 import { createRetryState, type RetryCallbacks } from './flows/RetryState';
 
-// Local imports - option helpers
-import type { AgentCycleBaseOptions } from './AgentCycleOptions';
-import type { AgentConfig } from './AgentConfig';
-
-export interface ResponseCycleOptions<C = unknown>
-  extends AgentCycleBaseOptions<C> {
-  agentConfig: AgentConfig;
-  fileService: TaskRunFileService;
-}
+// Import and re-export from single source of truth
+import type { ResponseCycleOptions } from './flows/CycleServices';
+export type { ResponseCycleOptions };
 
 export interface ResponseCycleInput<C = unknown> {
   options: ResponseCycleOptions<C>;

--- a/src/agent/core/ToolUseCycle.ts
+++ b/src/agent/core/ToolUseCycle.ts
@@ -11,11 +11,9 @@
 
 // Local imports - agent components
 import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
-import type { BaseTool } from '@tools/core/base';
 
 // Local file imports
 import { AgentSharedStore } from './AgentSharedStore';
-import { AgentWorkspaceState } from './AgentWorkspaceState';
 import {
   createToolUseCycleFlow,
   type ToolUseCycleShared,
@@ -23,20 +21,9 @@ import {
 } from './flows/ToolUseCycleFlow';
 import { createRetryState, type RetryCallbacks } from './flows/RetryState';
 
-// Local imports - option helpers
-import type { AgentCycleBaseOptions } from './AgentCycleOptions';
-
-// Local imports - model handlers
-
-// Local imports - tools
-
-export interface ToolUseCycleOptions<C = unknown>
-  extends AgentCycleBaseOptions<C> {
-  toolRegistry: Record<string, BaseTool<any>>;
-  workspaceState: AgentWorkspaceState;
-  modelName?: string;
-  agentName?: string;
-}
+// Import and re-export from single source of truth
+import type { ToolUseCycleOptions } from './flows/CycleServices';
+export type { ToolUseCycleOptions };
 
 export interface ToolUseCycleInput<C = unknown> {
   options: ToolUseCycleOptions<C>;

--- a/src/agent/core/ToolUseCycle.ts
+++ b/src/agent/core/ToolUseCycle.ts
@@ -18,7 +18,7 @@ import { AgentSharedStore } from './AgentSharedStore';
 import { AgentWorkspaceState } from './AgentWorkspaceState';
 import {
   createToolUseCycleFlow,
-  type ToolUseCycleContext,
+  type ToolUseCycleShared,
   type ToolUseCycleState,
 } from './flows/ToolUseCycleFlow';
 import { createRetryState, type RetryCallbacks } from './flows/RetryState';
@@ -70,9 +70,9 @@ export async function runToolUseCycle<C = unknown>(
   // and can be called by the UI to trigger manual retry
   const retryCallbacks: RetryCallbacks = {};
 
-  const context: ToolUseCycleContext<C> = {
-    options: input.options,
-    store: input.store,
+  // Shared state contains only mutable data that flows through nodes.
+  // Services (options, store) are injected via setParams().
+  const shared: ToolUseCycleShared<C> = {
     state: {
       messages: input.messages,
       shouldStop: false,
@@ -87,7 +87,9 @@ export async function runToolUseCycle<C = unknown>(
   };
 
   const flow = createToolUseCycleFlow<C>();
-  await flow.run(context);
+  // Inject immutable services via params (PocketFlow pattern)
+  flow.setParams({ services: { options: input.options, store: input.store } });
+  await flow.run(shared);
 
   return { retryCallbacks };
 }

--- a/src/agent/core/flows/BaseRetryWaitNode.ts
+++ b/src/agent/core/flows/BaseRetryWaitNode.ts
@@ -1,0 +1,155 @@
+/**
+ * Shared retry wait node for manual retry handling.
+ * This is the SINGLE SOURCE OF TRUTH for manual retry wait behavior.
+ *
+ * Both ResponseCycleFlow and ToolUseCycleFlow use this to avoid duplication.
+ */
+
+import { BaseNode } from '@agent/node';
+import {
+  registerManualRetry,
+  clearManualRetry,
+} from '@agent/runtime/ManualRetryController';
+import type { AgentLogger } from '@logger/AgentLogger';
+import { MESSAGE_TYPES } from '@logger/messageTypes';
+import { bus } from '@eventBus/ProgressEventBus';
+
+import { FlowTransition } from './FlowTransitions';
+import { resetRetryState, type RetryState, type RetryCallbacks } from './RetryState';
+
+/** Timeout for manual retry wait (5 minutes) */
+const MANUAL_RETRY_TIMEOUT_MS = 5 * 60 * 1000;
+
+/**
+ * Minimal interface for contexts that support manual retry.
+ * Both ResponseCycleContext and ToolUseCycleContext satisfy this.
+ */
+export interface RetryableContext {
+  retryState: RetryState;
+  retryCallbacks: RetryCallbacks;
+  state: { shouldStop: boolean };
+}
+
+/**
+ * Accessors to extract flow-specific values from the context.
+ * This allows the base node to work with different context types.
+ */
+export interface RetryWaitAccessors<C extends RetryableContext> {
+  /** Get the stream ID for UI events and retry registration */
+  getStreamId: (context: C) => string;
+  /** Get the logger for status messages and retry registration */
+  getLogger: (context: C) => AgentLogger;
+  /** Operation name for logging (e.g., "Model invocation", "Tool-use call") */
+  operationName: string;
+}
+
+/**
+ * Creates a retry wait node with the given accessors.
+ * This is a factory function that returns a configured BaseNode.
+ */
+export function createRetryWaitNode<C extends RetryableContext>(
+  accessors: RetryWaitAccessors<C>,
+): BaseNode<C> {
+  return new RetryWaitNode(accessors);
+}
+
+/**
+ * Shared retry wait node implementation.
+ * Handles manual retry by waiting for UI callback with timeout.
+ */
+class RetryWaitNode<C extends RetryableContext> extends BaseNode<C> {
+  private accessors: RetryWaitAccessors<C>;
+
+  constructor(accessors: RetryWaitAccessors<C>) {
+    super();
+    this.accessors = accessors;
+  }
+
+  async exec(context: C): Promise<'retry' | 'cancel'> {
+    const { retryState, retryCallbacks } = context;
+    const streamId = this.accessors.getStreamId(context);
+    const logger = this.accessors.getLogger(context);
+
+    // Log waiting status
+    logger.info('Waiting for manual retry', {
+      messageType: MESSAGE_TYPES.PROGRESS_STATUS,
+      data: { error: retryState.lastError, awaitingManualRetry: true },
+    });
+
+    // Emit waiting status to UI
+    bus.emit('updateStreamStatus', { stream: streamId, status: 'waiting' });
+
+    // Wait for external signal via callbacks with timeout
+    return new Promise<'retry' | 'cancel'>((resolve) => {
+      let resolved = false;
+
+      const cleanup = () => {
+        clearManualRetry(streamId);
+        retryCallbacks.triggerRetry = undefined;
+        retryCallbacks.cancelRetry = undefined;
+      };
+
+      // Timeout after 5 minutes
+      const timeoutId = setTimeout(() => {
+        if (!resolved) {
+          resolved = true;
+          cleanup();
+          logger.warn('Manual retry wait timed out after 5 minutes');
+          resolve('cancel');
+        }
+      }, MANUAL_RETRY_TIMEOUT_MS);
+
+      retryCallbacks.triggerRetry = () => {
+        if (!resolved) {
+          resolved = true;
+          clearTimeout(timeoutId);
+          cleanup();
+          resolve('retry');
+        }
+      };
+
+      retryCallbacks.cancelRetry = () => {
+        if (!resolved) {
+          resolved = true;
+          clearTimeout(timeoutId);
+          cleanup();
+          resolve('cancel');
+        }
+      };
+
+      // Register with ManualRetryController for UI-triggered retries
+      registerManualRetry(streamId, {
+        run: async () => retryCallbacks.triggerRetry?.(),
+        logger,
+        operation: this.accessors.operationName,
+      });
+    });
+  }
+
+  async post(
+    context: C,
+    _prepRes: unknown,
+    execRes: 'retry' | 'cancel',
+  ): Promise<string | undefined> {
+    const { retryState, state } = context;
+    const streamId = this.accessors.getStreamId(context);
+    const logger = this.accessors.getLogger(context);
+
+    if (execRes === 'retry') {
+      resetRetryState(retryState);
+      logger.info('Manual retry triggered', {
+        messageType: MESSAGE_TYPES.PROGRESS_STATUS,
+      });
+      bus.emit('updateStreamStatus', { stream: streamId, status: 'resuming' });
+      return FlowTransition.RETRY;
+    }
+
+    // User cancelled
+    logger.info('Retry cancelled by user', {
+      messageType: MESSAGE_TYPES.PROGRESS_STATUS,
+    });
+    bus.emit('updateStreamStatus', { stream: streamId, status: 'stopped' });
+    state.shouldStop = true;
+    return FlowTransition.COMPLETE;
+  }
+}

--- a/src/agent/core/flows/BaseRetryWaitNode.ts
+++ b/src/agent/core/flows/BaseRetryWaitNode.ts
@@ -3,6 +3,13 @@
  * This is the SINGLE SOURCE OF TRUTH for manual retry wait behavior.
  *
  * Both ResponseCycleFlow and ToolUseCycleFlow use this to avoid duplication.
+ *
+ * ## Architecture
+ *
+ * This node uses accessors to extract flow-specific values. The accessors
+ * receive both `shared` state and `params` to support the services pattern:
+ * - Services (options, store) can be accessed via `params.services`
+ * - Mutable state (retryState, retryCallbacks) is in `shared`
  */
 
 import { BaseNode } from '@agent/node';
@@ -23,54 +30,67 @@ import {
 } from './RetryState';
 
 /**
- * Minimal interface for contexts that support manual retry.
- * Both ResponseCycleContext and ToolUseCycleContext satisfy this.
+ * Minimal interface for shared state that supports manual retry.
+ * Both ResponseCycleShared and ToolUseCycleShared satisfy this.
  */
-export interface RetryableContext {
+export interface RetryableShared {
   retryState: RetryState;
   retryCallbacks: RetryCallbacks;
   state: { shouldStop: boolean };
 }
 
 /**
- * Accessors to extract flow-specific values from the context.
- * This allows the base node to work with different context types.
+ * Accessors to extract flow-specific values from shared state and params.
+ * This allows the base node to work with different flow types.
+ *
+ * Accessors receive both `shared` and `params` to support:
+ * - Legacy pattern: values in shared context
+ * - Services pattern: values in params.services
  */
-export interface RetryWaitAccessors<C extends RetryableContext> {
+export interface RetryWaitAccessors<S extends RetryableShared, P = unknown> {
   /** Get the stream ID for UI events and retry registration */
-  getStreamId: (context: C) => string;
+  getStreamId: (shared: S, params: P) => string;
   /** Get the logger for status messages and retry registration */
-  getLogger: (context: C) => AgentLogger;
+  getLogger: (shared: S, params: P) => AgentLogger;
   /** Operation name for logging (e.g., "Model invocation", "Tool-use call") */
   operationName: string;
 }
+
+/** Index signature type for params constraint */
+type ParamsConstraint = { [key: string]: unknown };
 
 /**
  * Creates a retry wait node with the given accessors.
  * This is a factory function that returns a configured BaseNode.
  */
-export function createRetryWaitNode<C extends RetryableContext>(
-  accessors: RetryWaitAccessors<C>,
-): BaseNode<C> {
+export function createRetryWaitNode<
+  S extends RetryableShared,
+  P extends ParamsConstraint = ParamsConstraint,
+>(accessors: RetryWaitAccessors<S, P>): BaseNode<S, P> {
   return new RetryWaitNode(accessors);
 }
 
 /**
  * Shared retry wait node implementation.
  * Handles manual retry by waiting for UI callback with timeout.
+ *
+ * Uses `_params` to access services via the accessors pattern.
  */
-class RetryWaitNode<C extends RetryableContext> extends BaseNode<C> {
-  private accessors: RetryWaitAccessors<C>;
+class RetryWaitNode<
+  S extends RetryableShared,
+  P extends ParamsConstraint = ParamsConstraint,
+> extends BaseNode<S, P> {
+  private accessors: RetryWaitAccessors<S, P>;
 
-  constructor(accessors: RetryWaitAccessors<C>) {
+  constructor(accessors: RetryWaitAccessors<S, P>) {
     super();
     this.accessors = accessors;
   }
 
-  async exec(context: C): Promise<'retry' | 'cancel'> {
-    const { retryState, retryCallbacks } = context;
-    const streamId = this.accessors.getStreamId(context);
-    const logger = this.accessors.getLogger(context);
+  async exec(shared: S): Promise<'retry' | 'cancel'> {
+    const { retryState, retryCallbacks } = shared;
+    const streamId = this.accessors.getStreamId(shared, this._params);
+    const logger = this.accessors.getLogger(shared, this._params);
 
     // Log waiting status
     logger.info('Waiting for manual retry', {
@@ -129,13 +149,13 @@ class RetryWaitNode<C extends RetryableContext> extends BaseNode<C> {
   }
 
   async post(
-    context: C,
+    shared: S,
     _prepRes: unknown,
     execRes: 'retry' | 'cancel',
   ): Promise<string | undefined> {
-    const { retryState, state } = context;
-    const streamId = this.accessors.getStreamId(context);
-    const logger = this.accessors.getLogger(context);
+    const { retryState, state } = shared;
+    const streamId = this.accessors.getStreamId(shared, this._params);
+    const logger = this.accessors.getLogger(shared, this._params);
 
     if (execRes === 'retry') {
       resetRetryState(retryState);

--- a/src/agent/core/flows/BaseRetryWaitNode.ts
+++ b/src/agent/core/flows/BaseRetryWaitNode.ts
@@ -158,7 +158,7 @@ class RetryWaitNode<
 
   async post(
     shared: S,
-    _prepRes: unknown,
+    _prepRes: S,
     execRes: 'retry' | 'cancel',
   ): Promise<string | undefined> {
     const { retryState, state } = shared;

--- a/src/agent/core/flows/BaseRetryWaitNode.ts
+++ b/src/agent/core/flows/BaseRetryWaitNode.ts
@@ -87,10 +87,18 @@ class RetryWaitNode<
     this.accessors = accessors;
   }
 
-  async exec(shared: S): Promise<'retry' | 'cancel'> {
-    const { retryState, retryCallbacks } = shared;
-    const streamId = this.accessors.getStreamId(shared, this._params);
-    const logger = this.accessors.getLogger(shared, this._params);
+  /**
+   * Pass shared context through to exec.
+   * Required because BaseNode.exec receives the result of prep, not shared directly.
+   */
+  async prep(shared: S): Promise<S> {
+    return shared;
+  }
+
+  async exec(prepRes: S): Promise<'retry' | 'cancel'> {
+    const { retryState, retryCallbacks } = prepRes;
+    const streamId = this.accessors.getStreamId(prepRes, this._params);
+    const logger = this.accessors.getLogger(prepRes, this._params);
 
     // Log waiting status
     logger.info('Waiting for manual retry', {

--- a/src/agent/core/flows/BaseRetryWaitNode.ts
+++ b/src/agent/core/flows/BaseRetryWaitNode.ts
@@ -43,9 +43,9 @@ export interface RetryableShared {
  * Accessors to extract flow-specific values from shared state and params.
  * This allows the base node to work with different flow types.
  *
- * Accessors receive both `shared` and `params` to support:
- * - Legacy pattern: values in shared context
- * - Services pattern: values in params.services
+ * Accessors receive both `shared` and `params` to access:
+ * - Mutable state from `shared` (retryState, retryCallbacks)
+ * - Immutable services from `params.services` (options, store)
  */
 export interface RetryWaitAccessors<S extends RetryableShared, P = unknown> {
   /** Get the stream ID for UI events and retry registration */

--- a/src/agent/core/flows/BaseRetryWaitNode.ts
+++ b/src/agent/core/flows/BaseRetryWaitNode.ts
@@ -15,10 +15,12 @@ import { MESSAGE_TYPES } from '@logger/messageTypes';
 import { bus } from '@eventBus/ProgressEventBus';
 
 import { FlowTransition } from './FlowTransitions';
-import { resetRetryState, type RetryState, type RetryCallbacks } from './RetryState';
-
-/** Timeout for manual retry wait (5 minutes) */
-const MANUAL_RETRY_TIMEOUT_MS = 5 * 60 * 1000;
+import {
+  resetRetryState,
+  MANUAL_RETRY_TIMEOUT_MS,
+  type RetryState,
+  type RetryCallbacks,
+} from './RetryState';
 
 /**
  * Minimal interface for contexts that support manual retry.

--- a/src/agent/core/flows/CommonCycleTypes.ts
+++ b/src/agent/core/flows/CommonCycleTypes.ts
@@ -1,6 +1,23 @@
 /**
  * Common types shared across different flow cycles to reduce duplication
  * and provide consistent interfaces.
+ *
+ * ## Architectural Note: Pass-through prep() pattern
+ *
+ * Many flow nodes use a pass-through `prep()` that just returns `shared`:
+ * ```typescript
+ * async prep(shared: Context): Promise<Context> { return shared; }
+ * ```
+ *
+ * This pattern exists because:
+ * 1. `BaseNode._run()` calls `prep(shared)` and passes the result to `exec(prepRes)`
+ * 2. Nodes that need the full context in `exec()` must pass it through `prep()`
+ * 3. This deviates from PocketFlow's ideal separation where `prep()` extracts
+ *    only what `exec()` needs, keeping `exec()` isolated from shared state
+ *
+ * The tradeoff was made for simplicity - extracting specific fields in each
+ * `prep()` would add boilerplate without clear benefits in this codebase.
+ * Nodes that do meaningful preparation (PrepNodes) properly extract data.
  */
 
 import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';

--- a/src/agent/core/flows/CycleServices.ts
+++ b/src/agent/core/flows/CycleServices.ts
@@ -1,0 +1,83 @@
+/**
+ * Service interfaces for cycle flows.
+ *
+ * This module defines the service container pattern for separating
+ * immutable dependencies from mutable state in PocketFlow nodes.
+ *
+ * ## Architecture
+ *
+ * Services are injected via PocketFlow's `_params` mechanism:
+ * - `_params.services` - immutable dependencies (logger, modelHandler, store)
+ * - `shared` - mutable runtime state only
+ *
+ * This achieves:
+ * 1. **Separation of concerns**: Dependencies vs data clearly separated
+ * 2. **Single source of truth**: Services defined once, accessed consistently
+ * 3. **Clean code**: Uses existing PocketFlow infrastructure
+ *
+ * ## Usage
+ *
+ * ```typescript
+ * class MyNode extends BaseNode<CycleState, CycleParams<C>> {
+ *   async exec(state: CycleState) {
+ *     // Access services via _params
+ *     const { logger, store } = this._params.services;
+ *     // Access mutable state from shared
+ *     const { messages } = state;
+ *   }
+ * }
+ * ```
+ */
+
+import type { AgentSharedStore } from '@agent/core/AgentSharedStore';
+import type { ResponseCycleOptions } from '@agent/core/ResponseCycle';
+import type { ToolUseCycleOptions } from '@agent/core/ToolUseCycle';
+
+/**
+ * Base services shared by all cycle flows.
+ * Contains immutable dependencies that nodes need.
+ */
+export interface BaseCycleServices {
+  /** Shared store for workspace, round, and run state */
+  readonly store: AgentSharedStore;
+}
+
+/**
+ * Services for response cycle flows.
+ * Includes options specific to response generation.
+ */
+export interface ResponseCycleServices<C = unknown> extends BaseCycleServices {
+  /** Response cycle configuration and callbacks */
+  readonly options: ResponseCycleOptions<C>;
+}
+
+/**
+ * Services for tool-use cycle flows.
+ * Includes options specific to tool execution.
+ */
+export interface ToolUseCycleServices<C = unknown> extends BaseCycleServices {
+  /** Tool-use cycle configuration and callbacks */
+  readonly options: ToolUseCycleOptions<C>;
+}
+
+/**
+ * Params type for response cycle nodes.
+ * Used with BaseNode's `_params` mechanism.
+ *
+ * Note: Index signature required to satisfy NonIterableObject constraint.
+ */
+export interface ResponseCycleParams<C = unknown> {
+  [key: string]: unknown;
+  services: ResponseCycleServices<C>;
+}
+
+/**
+ * Params type for tool-use cycle nodes.
+ * Used with BaseNode's `_params` mechanism.
+ *
+ * Note: Index signature required to satisfy NonIterableObject constraint.
+ */
+export interface ToolUseCycleParams<C = unknown> {
+  [key: string]: unknown;
+  services: ToolUseCycleServices<C>;
+}

--- a/src/agent/core/flows/CycleServices.ts
+++ b/src/agent/core/flows/CycleServices.ts
@@ -1,8 +1,9 @@
 /**
- * Service interfaces for cycle flows.
+ * Service interfaces and option types for cycle flows.
  *
- * This module defines the service container pattern for separating
- * immutable dependencies from mutable state in PocketFlow nodes.
+ * This module defines:
+ * 1. Cycle option interfaces (ResponseCycleOptions, ToolUseCycleOptions)
+ * 2. Service container pattern for separating immutable dependencies from mutable state
  *
  * ## Architecture
  *
@@ -30,8 +31,41 @@
  */
 
 import type { AgentSharedStore } from '@agent/core/AgentSharedStore';
-import type { ResponseCycleOptions } from '@agent/core/ResponseCycle';
-import type { ToolUseCycleOptions } from '@agent/core/ToolUseCycle';
+import type { AgentCycleBaseOptions } from '@agent/core/AgentCycleOptions';
+import type { AgentConfig } from '@agent/core/AgentConfig';
+import type { AgentWorkspaceState } from '@agent/core/AgentWorkspaceState';
+import type { BaseTool } from '@tools/core/base';
+import type { TaskRunFileService } from '@utils/files';
+
+// ============================================================================
+// CYCLE OPTIONS (single source of truth)
+// ============================================================================
+
+/**
+ * Options for response cycle execution.
+ * Used by workflow agents (BaseReflectionAgent) for turn-based generation.
+ */
+export interface ResponseCycleOptions<C = unknown>
+  extends AgentCycleBaseOptions<C> {
+  agentConfig: AgentConfig;
+  fileService: TaskRunFileService;
+}
+
+/**
+ * Options for tool-use cycle execution.
+ * Used by interactive agents (BaseToolUseAgent) for session-based execution.
+ */
+export interface ToolUseCycleOptions<C = unknown>
+  extends AgentCycleBaseOptions<C> {
+  toolRegistry: Record<string, BaseTool<any>>;
+  workspaceState: AgentWorkspaceState;
+  modelName?: string;
+  agentName?: string;
+}
+
+// ============================================================================
+// SERVICE CONTAINERS
+// ============================================================================
 
 /**
  * Base services shared by all cycle flows.

--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -3,8 +3,8 @@ import * as path from 'path';
 
 // Local imports - core flow primitives
 import { BaseNode, Flow } from '@agent/node';
-import { AgentSharedStore } from '@agent/core/AgentSharedStore';
 // Type imports
+import type { AgentSharedStore } from '@agent/core/AgentSharedStore';
 import type { ResponseCycleOptions } from '@agent/core/ResponseCycle';
 // Internal imports
 import { resolveUsageProvider } from '@agent/core/UsageProviderUtils';
@@ -54,6 +54,10 @@ import {
   determineRetryStrategy,
 } from './RetryState';
 import { createRetryWaitNode } from './BaseRetryWaitNode';
+import type {
+  ResponseCycleServices,
+  ResponseCycleParams,
+} from './CycleServices';
 
 export interface ResponseCycleInputState {
   /** Agent output location - always workspace or runStorage (never external) */
@@ -84,15 +88,32 @@ function resetResponseCycleState(cycle: ResponseCycleRuntimeState): void {
   cycle.roundFinalized = false;
 }
 
-export interface ResponseCycleContext<C = unknown> {
-  options: ResponseCycleOptions<C>;
-  store: AgentSharedStore;
+/**
+ * Shared state for response cycle flows.
+ *
+ * This contains only MUTABLE state that flows through nodes.
+ * Services (options, store) are accessed via `_params.services`.
+ *
+ * ## Architecture
+ * - Mutable state: `shared` (this interface)
+ * - Immutable services: `_params.services` (ResponseCycleServices)
+ */
+export interface ResponseCycleShared<C = unknown> {
+  /** Runtime state for this cycle */
   state: ResponseCycleState;
-  /** Retry state for model invocation errors. */
+  /** Retry state for model invocation errors */
   retryState: RetryState;
-  /** Callbacks for manual retry control from UI. */
+  /** Callbacks for manual retry control from UI */
   retryCallbacks: RetryCallbacks;
 }
+
+/**
+ * @deprecated Use ResponseCycleShared instead. Kept for backward compatibility.
+ */
+export type ResponseCycleContext<C = unknown> = ResponseCycleShared<C> & {
+  options: ResponseCycleOptions<C>;
+  store: AgentSharedStore;
+};
 
 type InvocationNodeResult = SkippableNodeResult<{
   response: unknown;
@@ -107,9 +128,14 @@ type InvocationNodeResult = SkippableNodeResult<{
 /**
  * Prepares a response cycle by hydrating prompts, checking interruptions, and
  * establishing debug metadata before invoking the model.
+ *
+ * Services accessed via `_params.services`: options, store
  */
-class ResponsePrepNode<C> extends BaseNode<ResponseCycleContext<C>> {
-  async prep(shared: ResponseCycleContext<C>): Promise<{
+class ResponsePrepNode<C> extends BaseNode<
+  ResponseCycleShared<C>,
+  ResponseCycleParams<C>
+> {
+  async prep(shared: ResponseCycleShared<C>): Promise<{
     interrupted: boolean;
     exists: boolean;
     systemPrompt?: string;
@@ -117,7 +143,8 @@ class ResponsePrepNode<C> extends BaseNode<ResponseCycleContext<C>> {
     debugFileOptions?: CycleDebugFileOptions;
     outputLocation: AgentFileLocation;
   }> {
-    const { options, state, store } = shared;
+    const { options, store } = this._params.services;
+    const { state } = shared;
     const { agentPrompt, userVars, logger, agentConfig } = options;
     const interrupted = Boolean(await options.checkInterruption());
     const outputLocation = state.outputLocation;
@@ -154,7 +181,7 @@ class ResponsePrepNode<C> extends BaseNode<ResponseCycleContext<C>> {
   }
 
   async post(
-    { state }: ResponseCycleContext<C>,
+    shared: ResponseCycleShared<C>,
     prepRes: {
       interrupted: boolean;
       exists: boolean;
@@ -164,6 +191,8 @@ class ResponsePrepNode<C> extends BaseNode<ResponseCycleContext<C>> {
       outputLocation: AgentFileLocation;
     },
   ): Promise<string | undefined> {
+    const { state } = shared;
+
     if (prepRes.interrupted) {
       resetResponseCycleState(state);
       state.shouldStop = true;
@@ -207,16 +236,20 @@ type InvocationExecResult =
  * - AWAIT_RETRY: Pause for manual retry (goes to RetryWaitNode)
  * - default: Continue to next node on success
  * - COMPLETE: Non-retryable error
+ *
+ * Services accessed via `_params.services`: options
  */
-class ResponseModelInvocationNode<C> extends BaseNode<ResponseCycleContext<C>> {
-  async prep(
-    shared: ResponseCycleContext<C>,
-  ): Promise<ResponseCycleContext<C>> {
+class ResponseModelInvocationNode<C> extends BaseNode<
+  ResponseCycleShared<C>,
+  ResponseCycleParams<C>
+> {
+  async prep(shared: ResponseCycleShared<C>): Promise<ResponseCycleShared<C>> {
     return shared;
   }
 
-  async exec(context: ResponseCycleContext<C>): Promise<InvocationExecResult> {
-    const { options, state, retryState } = context;
+  async exec(shared: ResponseCycleShared<C>): Promise<InvocationExecResult> {
+    const { options } = this._params.services;
+    const { state, retryState } = shared;
     if (state.shouldStop) {
       return { success: true, response: undefined };
     }
@@ -261,11 +294,12 @@ class ResponseModelInvocationNode<C> extends BaseNode<ResponseCycleContext<C>> {
   }
 
   async post(
-    shared: ResponseCycleContext<C>,
-    prepRes: ResponseCycleContext<C>,
+    shared: ResponseCycleShared<C>,
+    _prepRes: ResponseCycleShared<C>,
     execRes: InvocationExecResult,
   ): Promise<string | undefined> {
-    const { options, state, retryState } = shared;
+    const { options } = this._params.services;
+    const { state, retryState } = shared;
 
     // Handle successful invocation
     if (execRes.success) {
@@ -373,16 +407,20 @@ type ContinuationNodeResult = SkippableNodeResult<{
 /**
  * Transforms the raw model response into output-ready text, updates usage metrics,
  * and persists incremental tool-state derived from the result.
+ *
+ * Services accessed via `_params.services`: options, store
  */
-class ResponseProcessNode<C> extends BaseNode<ResponseCycleContext<C>> {
-  async prep(
-    shared: ResponseCycleContext<C>,
-  ): Promise<ResponseCycleContext<C>> {
+class ResponseProcessNode<C> extends BaseNode<
+  ResponseCycleShared<C>,
+  ResponseCycleParams<C>
+> {
+  async prep(shared: ResponseCycleShared<C>): Promise<ResponseCycleShared<C>> {
     return shared;
   }
 
-  async exec(context: ResponseCycleContext<C>): Promise<ProcessNodeResult> {
-    const { options, state, store } = context;
+  async exec(shared: ResponseCycleShared<C>): Promise<ProcessNodeResult> {
+    const { options, store } = this._params.services;
+    const { state } = shared;
     if (state.shouldStop || !state.responseObject) {
       return { skipped: true };
     }
@@ -513,11 +551,12 @@ class ResponseProcessNode<C> extends BaseNode<ResponseCycleContext<C>> {
   }
 
   async post(
-    _shared: ResponseCycleContext<C>,
-    prepRes: ResponseCycleContext<C>,
+    shared: ResponseCycleShared<C>,
+    _prepRes: ResponseCycleShared<C>,
     execRes: ProcessNodeResult,
   ): Promise<string | undefined> {
-    const { options, state, store } = prepRes;
+    const { options, store } = this._params.services;
+    const { state } = shared;
 
     if (execRes.skipped) {
       state.endTurn = false;
@@ -634,18 +673,20 @@ class ResponseProcessNode<C> extends BaseNode<ResponseCycleContext<C>> {
 /**
  * Evaluates the processed response to decide whether the agent should end the turn,
  * stop entirely, or enqueue a continuation request.
+ *
+ * Services accessed via `_params.services`: options, store
  */
-class ResponseContinuationNode<C> extends BaseNode<ResponseCycleContext<C>> {
-  async prep(
-    shared: ResponseCycleContext<C>,
-  ): Promise<ResponseCycleContext<C>> {
+class ResponseContinuationNode<C> extends BaseNode<
+  ResponseCycleShared<C>,
+  ResponseCycleParams<C>
+> {
+  async prep(shared: ResponseCycleShared<C>): Promise<ResponseCycleShared<C>> {
     return shared;
   }
 
-  async exec(
-    context: ResponseCycleContext<C>,
-  ): Promise<ContinuationNodeResult> {
-    const { options, state, store } = context;
+  async exec(shared: ResponseCycleShared<C>): Promise<ContinuationNodeResult> {
+    const { options, store } = this._params.services;
+    const { state } = shared;
     if (state.shouldStop || !state.stopReason || !state.processedResponse) {
       return { skipped: true };
     }
@@ -693,11 +734,12 @@ class ResponseContinuationNode<C> extends BaseNode<ResponseCycleContext<C>> {
   }
 
   async post(
-    _shared: ResponseCycleContext<C>,
-    prepRes: ResponseCycleContext<C>,
+    shared: ResponseCycleShared<C>,
+    _prepRes: ResponseCycleShared<C>,
     execRes: ContinuationNodeResult,
   ): Promise<string | undefined> {
-    const { options, state, store } = prepRes;
+    const { options, store } = this._params.services;
+    const { state } = shared;
 
     if (execRes.skipped) {
       state.endTurn = false;
@@ -772,13 +814,33 @@ class ResponseContinuationNode<C> extends BaseNode<ResponseCycleContext<C>> {
   }
 }
 
-export function createResponseCycleFlow<C>(): Flow<ResponseCycleContext<C>> {
+/**
+ * Creates a response cycle flow with services injected via params.
+ *
+ * The returned flow uses the services pattern:
+ * - Services (options, store) are passed via `setParams({ services })`
+ * - Only mutable state flows through the shared context
+ *
+ * @example
+ * ```typescript
+ * const flow = createResponseCycleFlow<MyContext>();
+ * flow.setParams({ services: { options, store } });
+ * await flow.run(sharedState);
+ * ```
+ */
+export function createResponseCycleFlow<C>(): Flow<
+  ResponseCycleShared<C>,
+  ResponseCycleParams<C>
+> {
   const prepNode = new ResponsePrepNode<C>();
   const invokeNode = new ResponseModelInvocationNode<C>();
   // Use shared retry wait node (single source of truth)
-  const retryWaitNode = createRetryWaitNode<ResponseCycleContext<C>>({
-    getStreamId: (ctx) => ctx.options.context.streamId,
-    getLogger: (ctx) => ctx.options.logger,
+  // Note: RetryWaitNode accesses services via its own accessor pattern
+  const retryWaitNode = createRetryWaitNode<ResponseCycleShared<C>>({
+    getStreamId: (_shared, params) =>
+      (params as ResponseCycleParams<C>).services.options.context.streamId,
+    getLogger: (_shared, params) =>
+      (params as ResponseCycleParams<C>).services.options.logger,
     operationName: 'Model invocation',
   });
   const processNode = new ResponseProcessNode<C>();
@@ -803,5 +865,5 @@ export function createResponseCycleFlow<C>(): Flow<ResponseCycleContext<C>> {
   // Continuation can loop back to prep
   continuationNode.on(FlowTransition.CONTINUE, prepNode);
 
-  return new Flow<ResponseCycleContext<C>>(prepNode);
+  return new Flow<ResponseCycleShared<C>, ResponseCycleParams<C>>(prepNode);
 }

--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -3,8 +3,6 @@ import * as path from 'path';
 
 // Local imports - core flow primitives
 import { BaseNode, Flow } from '@agent/node';
-// Type imports
-import type { ResponseCycleOptions } from '@agent/core/ResponseCycle';
 // Internal imports
 import { resolveUsageProvider } from '@agent/core/UsageProviderUtils';
 import {
@@ -39,7 +37,6 @@ import type { AgentFileLocation } from '@utils/files';
 import { K_SLICE, REPETITION_DETECTION_THRESHOLD } from '@utils/config';
 import { AbsoluteFS, TaskRunFileService, flexibleFS } from '@utils/files';
 import type { FileLocation } from '@utils/files';
-import { sleep } from '@utils/helpers';
 import xmlUtils from '@utils/text/xmlUtils';
 import { bestConnectionMethod } from '@latex';
 
@@ -51,9 +48,11 @@ import {
   clearRetryError,
   beginAttempt,
   determineRetryStrategy,
+  applyRetryDecision,
 } from './RetryState';
 import { createRetryWaitNode } from './BaseRetryWaitNode';
 import type {
+  ResponseCycleOptions,
   ResponseCycleServices,
   ResponseCycleParams,
 } from './CycleServices';
@@ -324,7 +323,7 @@ class ResponseModelInvocationNode<C> extends BaseNode<
       return undefined; // Continue to process node
     }
 
-    // Handle error - use single source of truth for retry decision
+    // Handle error - use single source of truth for retry decision and side-effects
     const formatted = formatProviderHttpError(execRes.error);
     const decision = determineRetryStrategy(
       retryState,
@@ -332,44 +331,21 @@ class ResponseModelInvocationNode<C> extends BaseNode<
       formatted.statusCode,
     );
 
-    switch (decision.action) {
-      case 'auto_retry':
-        options.logger.warn(
-          `Retrying model invocation after ${decision.delayMs}ms (retry ${retryState.attemptCount - 1}/${retryState.maxAutoAttempts}): ${decision.error.message}`,
-          {
-            messageType: MESSAGE_TYPES.PROGRESS_STATUS,
-            data: {
-              attempt: retryState.attemptCount,
-              maxAttempts: retryState.maxAutoAttempts,
-              statusCode: decision.error.statusCode,
-            },
-          },
-        );
-        await sleep(decision.delayMs!);
-        return FlowTransition.RETRY;
+    // Apply retry decision (logging, sleeping) via shared helper
+    const transition = await applyRetryDecision(
+      decision,
+      options.logger,
+      retryState,
+      'Model invocation',
+    );
 
-      case 'manual_retry':
-        options.logger.error(
-          `Model invocation failed: ${decision.error.message}`,
-          {
-            messageType: MESSAGE_TYPES.PROGRESS_STATUS,
-            data: { statusCode: decision.error.statusCode, retryable: true },
-          },
-        );
-        return FlowTransition.AWAIT_RETRY;
-
-      case 'fail':
-        options.logger.error(
-          `Model invocation failed (not retryable): ${decision.error.message}`,
-          {
-            messageType: MESSAGE_TYPES.PROGRESS_STATUS,
-            data: { statusCode: decision.error.statusCode, retryable: false },
-          },
-        );
-        state.shouldStop = true;
-        state.endTurn = false;
-        return FlowTransition.COMPLETE;
+    // Set state flags on failure (response-cycle specific)
+    if (decision.action === 'fail') {
+      state.shouldStop = true;
+      state.endTurn = false;
     }
+
+    return transition;
   }
 }
 

--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -50,6 +50,7 @@ import {
   type RetryState,
   type RetryCallbacks,
   clearRetryError,
+  beginAttempt,
   determineRetryStrategy,
 } from './RetryState';
 import { createRetryWaitNode } from './BaseRetryWaitNode';
@@ -220,8 +221,8 @@ class ResponseModelInvocationNode<C> extends BaseNode<ResponseCycleContext<C>> {
       return { success: true, response: undefined };
     }
 
-    // Increment attempt counter
-    retryState.attemptCount++;
+    // Increment attempt counter (single source of truth)
+    beginAttempt(retryState);
 
     const abortController = new AbortController();
     options.setAbortController(abortController);

--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -16,10 +16,6 @@ import {
   SkippableNodeResult,
 } from '@agent/core/flows/CommonCycleTypes';
 import { RemoteAgentRegistry } from '@agent/remote/RemoteAgentRegistry';
-import {
-  registerManualRetry,
-  clearManualRetry,
-} from '@agent/runtime/ManualRetryController';
 // Type imports
 import type { ProviderStopReason } from '@agent/modelHandlers/types/StopReasonTypes';
 import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
@@ -46,7 +42,6 @@ import { AbsoluteFS, TaskRunFileService, flexibleFS } from '@utils/files';
 import type { FileLocation } from '@utils/files';
 import { sleep } from '@utils/helpers';
 import xmlUtils from '@utils/text/xmlUtils';
-import { bus } from '@eventBus/ProgressEventBus';
 import { bestConnectionMethod } from '@latex';
 
 // Local file imports
@@ -55,12 +50,9 @@ import {
   type RetryState,
   type RetryCallbacks,
   clearRetryError,
-  resetRetryState,
-  recordRetryError,
-  shouldAutoRetry,
-  shouldOfferManualRetry,
-  computeBackoffDelay,
+  determineRetryStrategy,
 } from './RetryState';
+import { createRetryWaitNode } from './BaseRetryWaitNode';
 
 export interface ResponseCycleInputState {
   /** Agent output location - always workspace or runStorage (never external) */
@@ -306,49 +298,52 @@ class ResponseModelInvocationNode<C> extends BaseNode<ResponseCycleContext<C>> {
       return undefined; // Continue to process node
     }
 
-    // Handle error - determine retry strategy
+    // Handle error - use single source of truth for retry decision
     const formatted = formatProviderHttpError(execRes.error);
-    recordRetryError(retryState, formatted.message, formatted.statusCode);
-
-    // Auto-retry available?
-    if (shouldAutoRetry(retryState)) {
-      const delay = computeBackoffDelay(retryState);
-      options.logger.warn(
-        `Retrying model invocation after ${delay}ms (retry ${retryState.attemptCount - 1}/${retryState.maxAutoAttempts}): ${formatted.message}`,
-        {
-          messageType: MESSAGE_TYPES.PROGRESS_STATUS,
-          data: {
-            attempt: retryState.attemptCount,
-            maxAttempts: retryState.maxAutoAttempts,
-            statusCode: formatted.statusCode,
-          },
-        },
-      );
-      await sleep(delay);
-      return FlowTransition.RETRY;
-    }
-
-    // Manual retry available?
-    if (shouldOfferManualRetry(retryState)) {
-      retryState.awaitingManualRetry = true;
-      options.logger.error(`Model invocation failed: ${formatted.message}`, {
-        messageType: MESSAGE_TYPES.PROGRESS_STATUS,
-        data: { statusCode: formatted.statusCode, retryable: true },
-      });
-      return FlowTransition.AWAIT_RETRY;
-    }
-
-    // Non-retryable error
-    options.logger.error(
-      `Model invocation failed (not retryable): ${formatted.message}`,
-      {
-        messageType: MESSAGE_TYPES.PROGRESS_STATUS,
-        data: { statusCode: formatted.statusCode, retryable: false },
-      },
+    const decision = determineRetryStrategy(
+      retryState,
+      formatted.message,
+      formatted.statusCode,
     );
-    state.shouldStop = true;
-    state.endTurn = false;
-    return FlowTransition.COMPLETE;
+
+    switch (decision.action) {
+      case 'auto_retry':
+        options.logger.warn(
+          `Retrying model invocation after ${decision.delayMs}ms (retry ${retryState.attemptCount - 1}/${retryState.maxAutoAttempts}): ${decision.error.message}`,
+          {
+            messageType: MESSAGE_TYPES.PROGRESS_STATUS,
+            data: {
+              attempt: retryState.attemptCount,
+              maxAttempts: retryState.maxAutoAttempts,
+              statusCode: decision.error.statusCode,
+            },
+          },
+        );
+        await sleep(decision.delayMs!);
+        return FlowTransition.RETRY;
+
+      case 'manual_retry':
+        options.logger.error(
+          `Model invocation failed: ${decision.error.message}`,
+          {
+            messageType: MESSAGE_TYPES.PROGRESS_STATUS,
+            data: { statusCode: decision.error.statusCode, retryable: true },
+          },
+        );
+        return FlowTransition.AWAIT_RETRY;
+
+      case 'fail':
+        options.logger.error(
+          `Model invocation failed (not retryable): ${decision.error.message}`,
+          {
+            messageType: MESSAGE_TYPES.PROGRESS_STATUS,
+            data: { statusCode: decision.error.statusCode, retryable: false },
+          },
+        );
+        state.shouldStop = true;
+        state.endTurn = false;
+        return FlowTransition.COMPLETE;
+    }
   }
 }
 
@@ -776,108 +771,15 @@ class ResponseContinuationNode<C> extends BaseNode<ResponseCycleContext<C>> {
   }
 }
 
-/**
- * Specialized retry wait node for response cycle.
- * Handles manual retry by waiting for UI callback.
- */
-class ResponseRetryWaitNode<C> extends BaseNode<ResponseCycleContext<C>> {
-  async prep(
-    shared: ResponseCycleContext<C>,
-  ): Promise<ResponseCycleContext<C>> {
-    return shared;
-  }
-
-  async exec(context: ResponseCycleContext<C>): Promise<'retry' | 'cancel'> {
-    const { retryState, options, retryCallbacks } = context;
-    const streamId = options.context.streamId;
-
-    // Log waiting status
-    options.logger.info('Waiting for manual retry', {
-      messageType: MESSAGE_TYPES.PROGRESS_STATUS,
-      data: { error: retryState.lastError, awaitingManualRetry: true },
-    });
-
-    // Emit waiting status to UI
-    bus.emit('updateStreamStatus', { stream: streamId, status: 'waiting' });
-
-    // Wait for external signal via callbacks with timeout
-    return new Promise<'retry' | 'cancel'>((resolve) => {
-      let resolved = false;
-
-      // Timeout after 5 minutes
-      const timeoutId = setTimeout(() => {
-        if (!resolved) {
-          resolved = true;
-          clearManualRetry(streamId);
-          retryCallbacks.triggerRetry = undefined;
-          retryCallbacks.cancelRetry = undefined;
-          options.logger.warn('Manual retry wait timed out after 5 minutes');
-          resolve('cancel');
-        }
-      }, 5 * 60 * 1000);
-
-      retryCallbacks.triggerRetry = () => {
-        if (!resolved) {
-          resolved = true;
-          clearTimeout(timeoutId);
-          clearManualRetry(streamId);
-          retryCallbacks.triggerRetry = undefined;
-          retryCallbacks.cancelRetry = undefined;
-          resolve('retry');
-        }
-      };
-      retryCallbacks.cancelRetry = () => {
-        if (!resolved) {
-          resolved = true;
-          clearTimeout(timeoutId);
-          clearManualRetry(streamId);
-          retryCallbacks.triggerRetry = undefined;
-          retryCallbacks.cancelRetry = undefined;
-          resolve('cancel');
-        }
-      };
-
-      // Register with ManualRetryController for UI-triggered retries
-      registerManualRetry(streamId, {
-        run: async () => retryCallbacks.triggerRetry?.(),
-        logger: options.logger,
-        operation: 'Model invocation',
-      });
-    });
-  }
-
-  async post(
-    shared: ResponseCycleContext<C>,
-    _prepRes: ResponseCycleContext<C>,
-    execRes: 'retry' | 'cancel',
-  ): Promise<string | undefined> {
-    const { retryState, options, state } = shared;
-    const streamId = options.context.streamId;
-
-    if (execRes === 'retry') {
-      resetRetryState(retryState);
-      options.logger.info('Manual retry triggered', {
-        messageType: MESSAGE_TYPES.PROGRESS_STATUS,
-      });
-      bus.emit('updateStreamStatus', { stream: streamId, status: 'resuming' });
-      return FlowTransition.RETRY;
-    }
-
-    // User cancelled
-    options.logger.info('Retry cancelled by user', {
-      messageType: MESSAGE_TYPES.PROGRESS_STATUS,
-    });
-    bus.emit('updateStreamStatus', { stream: streamId, status: 'stopped' });
-    state.shouldStop = true;
-    state.endTurn = false;
-    return FlowTransition.COMPLETE;
-  }
-}
-
 export function createResponseCycleFlow<C>(): Flow<ResponseCycleContext<C>> {
   const prepNode = new ResponsePrepNode<C>();
   const invokeNode = new ResponseModelInvocationNode<C>();
-  const retryWaitNode = new ResponseRetryWaitNode<C>();
+  // Use shared retry wait node (single source of truth)
+  const retryWaitNode = createRetryWaitNode<ResponseCycleContext<C>>({
+    getStreamId: (ctx) => ctx.options.context.streamId,
+    getLogger: (ctx) => ctx.options.logger,
+    operationName: 'Model invocation',
+  });
   const processNode = new ResponseProcessNode<C>();
   const continuationNode = new ResponseContinuationNode<C>();
 

--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -4,7 +4,6 @@ import * as path from 'path';
 // Local imports - core flow primitives
 import { BaseNode, Flow } from '@agent/node';
 // Type imports
-import type { AgentSharedStore } from '@agent/core/AgentSharedStore';
 import type { ResponseCycleOptions } from '@agent/core/ResponseCycle';
 // Internal imports
 import { resolveUsageProvider } from '@agent/core/UsageProviderUtils';
@@ -106,14 +105,6 @@ export interface ResponseCycleShared<C = unknown> {
   /** Callbacks for manual retry control from UI */
   retryCallbacks: RetryCallbacks;
 }
-
-/**
- * @deprecated Use ResponseCycleShared instead. Kept for backward compatibility.
- */
-export type ResponseCycleContext<C = unknown> = ResponseCycleShared<C> & {
-  options: ResponseCycleOptions<C>;
-  store: AgentSharedStore;
-};
 
 type InvocationNodeResult = SkippableNodeResult<{
   response: unknown;

--- a/src/agent/core/flows/RetryState.ts
+++ b/src/agent/core/flows/RetryState.ts
@@ -183,21 +183,22 @@ export function recordRetryError(
 // ============================================================================
 
 /**
- * Result of retry strategy determination.
- * The caller handles side effects (logging, sleeping, UI events).
+ * Error info included in retry decisions.
  */
-export interface RetryDecision {
-  /** The flow transition to take */
-  action: 'auto_retry' | 'manual_retry' | 'fail';
-  /** Backoff delay in ms (only for auto_retry) */
-  delayMs?: number;
-  /** Formatted error info for logging */
-  error: {
-    message: string;
-    statusCode?: number;
-    retryable: boolean;
-  };
+export interface RetryDecisionError {
+  message: string;
+  statusCode?: number;
+  retryable: boolean;
 }
+
+/**
+ * Result of retry strategy determination.
+ * Uses discriminated union to make delayMs type-safe (required for auto_retry only).
+ */
+export type RetryDecision =
+  | { action: 'auto_retry'; delayMs: number; error: RetryDecisionError }
+  | { action: 'manual_retry'; error: RetryDecisionError }
+  | { action: 'fail'; error: RetryDecisionError };
 
 /**
  * Determines retry strategy after an error.
@@ -281,7 +282,7 @@ export async function applyRetryDecision(
           },
         },
       );
-      await sleep(decision.delayMs!);
+      await sleep(decision.delayMs);
       return FlowTransition.RETRY;
 
     case 'manual_retry':

--- a/src/agent/core/flows/RetryState.ts
+++ b/src/agent/core/flows/RetryState.ts
@@ -161,3 +161,69 @@ export function recordRetryError(
     retryable: isRetryableStatusCode(statusCode),
   };
 }
+
+// ============================================================================
+// Retry decision (single source of truth for retry logic)
+// ============================================================================
+
+/**
+ * Result of retry strategy determination.
+ * The caller handles side effects (logging, sleeping, UI events).
+ */
+export interface RetryDecision {
+  /** The flow transition to take */
+  action: 'auto_retry' | 'manual_retry' | 'fail';
+  /** Backoff delay in ms (only for auto_retry) */
+  delayMs?: number;
+  /** Formatted error info for logging */
+  error: {
+    message: string;
+    statusCode?: number;
+    retryable: boolean;
+  };
+}
+
+/**
+ * Pure function to determine retry strategy after an error.
+ * This is the SINGLE SOURCE OF TRUTH for retry decision logic.
+ *
+ * Side effects (logging, sleeping, UI events) are handled by the caller.
+ */
+export function determineRetryStrategy(
+  state: RetryState,
+  errorMessage: string,
+  statusCode?: number,
+): RetryDecision {
+  // Record the error in state
+  recordRetryError(state, errorMessage, statusCode);
+
+  const error = {
+    message: errorMessage,
+    statusCode,
+    retryable: state.lastError?.retryable ?? false,
+  };
+
+  // Check auto-retry first
+  if (shouldAutoRetry(state)) {
+    return {
+      action: 'auto_retry',
+      delayMs: computeBackoffDelay(state),
+      error,
+    };
+  }
+
+  // Check manual retry
+  if (shouldOfferManualRetry(state)) {
+    state.awaitingManualRetry = true;
+    return {
+      action: 'manual_retry',
+      error,
+    };
+  }
+
+  // Non-retryable failure
+  return {
+    action: 'fail',
+    error,
+  };
+}

--- a/src/agent/core/flows/RetryState.ts
+++ b/src/agent/core/flows/RetryState.ts
@@ -1,8 +1,9 @@
 /**
  * Retry state management for flow-based retry handling.
  *
- * This module provides PURE state management functions only.
- * Side effects (logging, sleeping, events) belong in flow nodes.
+ * This module centralizes retry state management. Functions that mutate state
+ * are clearly documented. Side effects (logging, sleeping, events) belong in
+ * flow nodes.
  */
 
 import {
@@ -14,8 +15,8 @@ import {
 
 const RETRYABLE_NON_5XX_STATUS_CODES = new Set([408, 429]);
 
-// Timeout for manual retry wait (5 minutes)
-const MANUAL_RETRY_TIMEOUT_MS = 5 * 60 * 1000;
+/** Timeout for manual retry wait (5 minutes) - exported for BaseRetryWaitNode */
+export const MANUAL_RETRY_TIMEOUT_MS = 5 * 60 * 1000;
 
 // ============================================================================
 // Types
@@ -93,11 +94,21 @@ export function resetRetryState(state: RetryState): void {
 /**
  * Clears error state and resets attempt counter after successful operation.
  * This ensures the next invocation gets a fresh retry budget.
+ * @mutates state.attemptCount, state.lastError, state.awaitingManualRetry
  */
 export function clearRetryError(state: RetryState): void {
   state.attemptCount = 0;
   state.lastError = undefined;
   state.awaitingManualRetry = false;
+}
+
+/**
+ * Increments the attempt counter before each invocation attempt.
+ * Call this at the start of exec() in invocation nodes.
+ * @mutates state.attemptCount
+ */
+export function beginAttempt(state: RetryState): void {
+  state.attemptCount++;
 }
 
 // ============================================================================
@@ -184,9 +195,10 @@ export interface RetryDecision {
 }
 
 /**
- * Pure function to determine retry strategy after an error.
+ * Determines retry strategy after an error.
  * This is the SINGLE SOURCE OF TRUTH for retry decision logic.
  *
+ * @mutates state.lastError, state.awaitingManualRetry
  * Side effects (logging, sleeping, UI events) are handled by the caller.
  */
 export function determineRetryStrategy(

--- a/src/agent/core/flows/RetryState.ts
+++ b/src/agent/core/flows/RetryState.ts
@@ -1,17 +1,22 @@
 /**
  * Retry state management for flow-based retry handling.
  *
- * This module centralizes retry state management. Functions that mutate state
- * are clearly documented. Side effects (logging, sleeping, events) belong in
- * flow nodes.
+ * This module centralizes retry state management AND side-effect handling.
+ * - Pure functions: createRetryState, resetRetryState, determineRetryStrategy
+ * - Side-effect helper: applyRetryDecision (logging, sleeping)
  */
 
+import type { AgentLogger } from '@logger/AgentLogger';
+import { MESSAGE_TYPES } from '@logger/messageTypes';
 import {
   getModelRetryBackoffMs,
   getModelRetryMaxAttempts,
   DEFAULT_MODEL_RETRY_ATTEMPTS,
   DEFAULT_MODEL_RETRY_BACKOFF_MS,
 } from '@utils/config';
+import { sleep } from '@utils/helpers';
+
+import { FlowTransition } from './FlowTransitions';
 
 const RETRYABLE_NON_5XX_STATUS_CODES = new Set([408, 429]);
 
@@ -238,4 +243,62 @@ export function determineRetryStrategy(
     action: 'fail',
     error,
   };
+}
+
+// ============================================================================
+// Retry side-effects (single source of truth for retry handling)
+// ============================================================================
+
+/**
+ * Applies a retry decision by performing side effects (logging, sleeping).
+ * Returns the flow transition to take.
+ *
+ * This is the SINGLE SOURCE OF TRUTH for retry side-effect handling.
+ * Call this in flow node post() methods instead of duplicating switch logic.
+ *
+ * @param decision - The retry decision from determineRetryStrategy
+ * @param logger - Logger for status messages
+ * @param retryState - Current retry state (for logging attempt counts)
+ * @param operationName - Name of the operation for log messages (e.g., "Model invocation")
+ * @returns The flow transition string, or undefined to continue to next node
+ */
+export async function applyRetryDecision(
+  decision: RetryDecision,
+  logger: AgentLogger,
+  retryState: RetryState,
+  operationName: string,
+): Promise<string | undefined> {
+  switch (decision.action) {
+    case 'auto_retry':
+      logger.warn(
+        `Retrying ${operationName.toLowerCase()} after ${decision.delayMs}ms (retry ${retryState.attemptCount - 1}/${retryState.maxAutoAttempts}): ${decision.error.message}`,
+        {
+          messageType: MESSAGE_TYPES.PROGRESS_STATUS,
+          data: {
+            attempt: retryState.attemptCount,
+            maxAttempts: retryState.maxAutoAttempts,
+            statusCode: decision.error.statusCode,
+          },
+        },
+      );
+      await sleep(decision.delayMs!);
+      return FlowTransition.RETRY;
+
+    case 'manual_retry':
+      logger.error(`${operationName} failed: ${decision.error.message}`, {
+        messageType: MESSAGE_TYPES.PROGRESS_STATUS,
+        data: { statusCode: decision.error.statusCode, retryable: true },
+      });
+      return FlowTransition.AWAIT_RETRY;
+
+    case 'fail':
+      logger.error(
+        `${operationName} failed (not retryable): ${decision.error.message}`,
+        {
+          messageType: MESSAGE_TYPES.PROGRESS_STATUS,
+          data: { statusCode: decision.error.statusCode, retryable: false },
+        },
+      );
+      return FlowTransition.COMPLETE;
+  }
 }

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -45,6 +45,7 @@ import {
   type RetryState,
   type RetryCallbacks,
   clearRetryError,
+  beginAttempt,
   determineRetryStrategy,
 } from './RetryState';
 import { createRetryWaitNode } from './BaseRetryWaitNode';
@@ -259,8 +260,8 @@ class ToolUseCallNode<C> extends BaseNode<ToolUseCycleContext<C>> {
       };
     }
 
-    // Increment attempt counter
-    retryState.attemptCount++;
+    // Increment attempt counter (single source of truth)
+    beginAttempt(retryState);
 
     const debugContext: CycleDebugContext = {
       logger: options.logger,

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -11,10 +11,6 @@ import {
   SkippableNodeResult,
 } from '@agent/core/flows/CommonCycleTypes';
 import { RemoteAgentRegistry } from '@agent/remote/RemoteAgentRegistry';
-import {
-  registerManualRetry,
-  clearManualRetry,
-} from '@agent/runtime/ManualRetryController';
 import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
 import type { SdkToolCall } from '@agent/modelHandlers/types/IModelHandler';
 import type { ProviderStopReason } from '@agent/modelHandlers/types/StopReasonTypes';
@@ -42,7 +38,6 @@ import { withToolEditApprovalContext } from '@tools/approval/toolEditApprovalCon
 import { WorkspaceFS } from '@utils/files';
 import { sleep } from '@utils/helpers';
 import xmlUtils from '@utils/text/xmlUtils';
-import { bus } from '@eventBus/ProgressEventBus';
 
 // Local file imports
 import { FlowTransition } from './FlowTransitions';
@@ -50,12 +45,9 @@ import {
   type RetryState,
   type RetryCallbacks,
   clearRetryError,
-  resetRetryState,
-  recordRetryError,
-  shouldAutoRetry,
-  shouldOfferManualRetry,
-  computeBackoffDelay,
+  determineRetryStrategy,
 } from './RetryState';
+import { createRetryWaitNode } from './BaseRetryWaitNode';
 
 interface ToolValidationDiagnostics {
   type: 'validation_error';
@@ -342,48 +334,51 @@ class ToolUseCallNode<C> extends BaseNode<ToolUseCycleContext<C>> {
       return undefined; // Continue to process node
     }
 
-    // Handle error - determine retry strategy
+    // Handle error - use single source of truth for retry decision
     const formatted = formatProviderHttpError(execRes.error);
-    recordRetryError(retryState, formatted.message, formatted.statusCode);
-
-    // Auto-retry available?
-    if (shouldAutoRetry(retryState)) {
-      const delay = computeBackoffDelay(retryState);
-      options.logger.warn(
-        `Retrying tool-use call after ${delay}ms (retry ${retryState.attemptCount - 1}/${retryState.maxAutoAttempts}): ${formatted.message}`,
-        {
-          messageType: MESSAGE_TYPES.PROGRESS_STATUS,
-          data: {
-            attempt: retryState.attemptCount,
-            maxAttempts: retryState.maxAutoAttempts,
-            statusCode: formatted.statusCode,
-          },
-        },
-      );
-      await sleep(delay);
-      return FlowTransition.RETRY;
-    }
-
-    // Manual retry available?
-    if (shouldOfferManualRetry(retryState)) {
-      retryState.awaitingManualRetry = true;
-      options.logger.error(`Tool-use call failed: ${formatted.message}`, {
-        messageType: MESSAGE_TYPES.PROGRESS_STATUS,
-        data: { statusCode: formatted.statusCode, retryable: true },
-      });
-      return FlowTransition.AWAIT_RETRY;
-    }
-
-    // Non-retryable error
-    options.logger.error(
-      `Tool-use call failed (not retryable): ${formatted.message}`,
-      {
-        messageType: MESSAGE_TYPES.PROGRESS_STATUS,
-        data: { statusCode: formatted.statusCode, retryable: false },
-      },
+    const decision = determineRetryStrategy(
+      retryState,
+      formatted.message,
+      formatted.statusCode,
     );
-    state.shouldStop = true;
-    return FlowTransition.COMPLETE;
+
+    switch (decision.action) {
+      case 'auto_retry':
+        options.logger.warn(
+          `Retrying tool-use call after ${decision.delayMs}ms (retry ${retryState.attemptCount - 1}/${retryState.maxAutoAttempts}): ${decision.error.message}`,
+          {
+            messageType: MESSAGE_TYPES.PROGRESS_STATUS,
+            data: {
+              attempt: retryState.attemptCount,
+              maxAttempts: retryState.maxAutoAttempts,
+              statusCode: decision.error.statusCode,
+            },
+          },
+        );
+        await sleep(decision.delayMs!);
+        return FlowTransition.RETRY;
+
+      case 'manual_retry':
+        options.logger.error(
+          `Tool-use call failed: ${decision.error.message}`,
+          {
+            messageType: MESSAGE_TYPES.PROGRESS_STATUS,
+            data: { statusCode: decision.error.statusCode, retryable: true },
+          },
+        );
+        return FlowTransition.AWAIT_RETRY;
+
+      case 'fail':
+        options.logger.error(
+          `Tool-use call failed (not retryable): ${decision.error.message}`,
+          {
+            messageType: MESSAGE_TYPES.PROGRESS_STATUS,
+            data: { statusCode: decision.error.statusCode, retryable: false },
+          },
+        );
+        state.shouldStop = true;
+        return FlowTransition.COMPLETE;
+    }
   }
 }
 
@@ -696,105 +691,15 @@ class ToolUseDispatchNode<C> extends BaseNode<ToolUseCycleContext<C>> {
     return FlowTransition.CONTINUE;
   }
 }
-/**
- * Specialized retry wait node for tool-use cycle.
- * Handles manual retry by waiting for UI callback.
- */
-class ToolUseRetryWaitNode<C> extends BaseNode<ToolUseCycleContext<C>> {
-  async prep(shared: ToolUseCycleContext<C>): Promise<ToolUseCycleContext<C>> {
-    return shared;
-  }
-
-  async exec(context: ToolUseCycleContext<C>): Promise<'retry' | 'cancel'> {
-    const { retryState, options, retryCallbacks } = context;
-    const streamId = options.context.streamId;
-
-    // Log waiting status
-    options.logger.info('Waiting for manual retry', {
-      messageType: MESSAGE_TYPES.PROGRESS_STATUS,
-      data: { error: retryState.lastError, awaitingManualRetry: true },
-    });
-
-    // Emit waiting status to UI
-    bus.emit('updateStreamStatus', { stream: streamId, status: 'waiting' });
-
-    // Wait for external signal via callbacks with timeout
-    return new Promise<'retry' | 'cancel'>((resolve) => {
-      let resolved = false;
-
-      // Timeout after 5 minutes
-      const timeoutId = setTimeout(() => {
-        if (!resolved) {
-          resolved = true;
-          clearManualRetry(streamId);
-          retryCallbacks.triggerRetry = undefined;
-          retryCallbacks.cancelRetry = undefined;
-          options.logger.warn('Manual retry wait timed out after 5 minutes');
-          resolve('cancel');
-        }
-      }, 5 * 60 * 1000);
-
-      retryCallbacks.triggerRetry = () => {
-        if (!resolved) {
-          resolved = true;
-          clearTimeout(timeoutId);
-          clearManualRetry(streamId);
-          retryCallbacks.triggerRetry = undefined;
-          retryCallbacks.cancelRetry = undefined;
-          resolve('retry');
-        }
-      };
-      retryCallbacks.cancelRetry = () => {
-        if (!resolved) {
-          resolved = true;
-          clearTimeout(timeoutId);
-          clearManualRetry(streamId);
-          retryCallbacks.triggerRetry = undefined;
-          retryCallbacks.cancelRetry = undefined;
-          resolve('cancel');
-        }
-      };
-
-      // Register with ManualRetryController for UI-triggered retries
-      registerManualRetry(streamId, {
-        run: async () => retryCallbacks.triggerRetry?.(),
-        logger: options.logger,
-        operation: 'Tool-use call',
-      });
-    });
-  }
-
-  async post(
-    shared: ToolUseCycleContext<C>,
-    _prepRes: ToolUseCycleContext<C>,
-    execRes: 'retry' | 'cancel',
-  ): Promise<string | undefined> {
-    const { retryState, options, state } = shared;
-    const streamId = options.context.streamId;
-
-    if (execRes === 'retry') {
-      resetRetryState(retryState);
-      options.logger.info('Manual retry triggered', {
-        messageType: MESSAGE_TYPES.PROGRESS_STATUS,
-      });
-      bus.emit('updateStreamStatus', { stream: streamId, status: 'resuming' });
-      return FlowTransition.RETRY;
-    }
-
-    // User cancelled
-    options.logger.info('Retry cancelled by user', {
-      messageType: MESSAGE_TYPES.PROGRESS_STATUS,
-    });
-    bus.emit('updateStreamStatus', { stream: streamId, status: 'stopped' });
-    state.shouldStop = true;
-    return FlowTransition.COMPLETE;
-  }
-}
-
 export function createToolUseCycleFlow<C>(): Flow<ToolUseCycleContext<C>> {
   const prepNode = new ToolUsePrepNode<C>();
   const callNode = new ToolUseCallNode<C>();
-  const retryWaitNode = new ToolUseRetryWaitNode<C>();
+  // Use shared retry wait node (single source of truth)
+  const retryWaitNode = createRetryWaitNode<ToolUseCycleContext<C>>({
+    getStreamId: (ctx) => ctx.options.context.streamId,
+    getLogger: (ctx) => ctx.options.logger,
+    operationName: 'Tool-use call',
+  });
   const processNode = new ToolUseProcessNode<C>();
   const dispatchNode = new ToolUseDispatchNode<C>();
 

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -1,7 +1,5 @@
 // Local imports - core flow primitives
 import { BaseNode, Flow } from '@agent/node';
-// Type imports
-import type { ToolUseCycleOptions } from '@agent/core/ToolUseCycle';
 import {
   BaseCycleState,
   resetCycleState,
@@ -35,7 +33,6 @@ import type { ToolDefinition } from '@model';
 import { ToolResult, toolResult } from '@tools/result';
 import { withToolEditApprovalContext } from '@tools/approval/toolEditApprovalContext';
 import { WorkspaceFS } from '@utils/files';
-import { sleep } from '@utils/helpers';
 import xmlUtils from '@utils/text/xmlUtils';
 
 // Local file imports
@@ -46,9 +43,14 @@ import {
   clearRetryError,
   beginAttempt,
   determineRetryStrategy,
+  applyRetryDecision,
 } from './RetryState';
 import { createRetryWaitNode } from './BaseRetryWaitNode';
-import type { ToolUseCycleServices, ToolUseCycleParams } from './CycleServices';
+import type {
+  ToolUseCycleOptions,
+  ToolUseCycleServices,
+  ToolUseCycleParams,
+} from './CycleServices';
 
 interface ToolValidationDiagnostics {
   type: 'validation_error';
@@ -361,7 +363,7 @@ class ToolUseCallNode<C> extends BaseNode<
       return undefined; // Continue to process node
     }
 
-    // Handle error - use single source of truth for retry decision
+    // Handle error - use single source of truth for retry decision and side-effects
     const formatted = formatProviderHttpError(execRes.error);
     const decision = determineRetryStrategy(
       retryState,
@@ -369,43 +371,20 @@ class ToolUseCallNode<C> extends BaseNode<
       formatted.statusCode,
     );
 
-    switch (decision.action) {
-      case 'auto_retry':
-        options.logger.warn(
-          `Retrying tool-use call after ${decision.delayMs}ms (retry ${retryState.attemptCount - 1}/${retryState.maxAutoAttempts}): ${decision.error.message}`,
-          {
-            messageType: MESSAGE_TYPES.PROGRESS_STATUS,
-            data: {
-              attempt: retryState.attemptCount,
-              maxAttempts: retryState.maxAutoAttempts,
-              statusCode: decision.error.statusCode,
-            },
-          },
-        );
-        await sleep(decision.delayMs!);
-        return FlowTransition.RETRY;
+    // Apply retry decision (logging, sleeping) via shared helper
+    const transition = await applyRetryDecision(
+      decision,
+      options.logger,
+      retryState,
+      'Tool-use call',
+    );
 
-      case 'manual_retry':
-        options.logger.error(
-          `Tool-use call failed: ${decision.error.message}`,
-          {
-            messageType: MESSAGE_TYPES.PROGRESS_STATUS,
-            data: { statusCode: decision.error.statusCode, retryable: true },
-          },
-        );
-        return FlowTransition.AWAIT_RETRY;
-
-      case 'fail':
-        options.logger.error(
-          `Tool-use call failed (not retryable): ${decision.error.message}`,
-          {
-            messageType: MESSAGE_TYPES.PROGRESS_STATUS,
-            data: { statusCode: decision.error.statusCode, retryable: false },
-          },
-        );
-        state.shouldStop = true;
-        return FlowTransition.COMPLETE;
+    // Set state flags on failure
+    if (decision.action === 'fail') {
+      state.shouldStop = true;
     }
+
+    return transition;
   }
 }
 

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -1,7 +1,7 @@
 // Local imports - core flow primitives
 import { BaseNode, Flow } from '@agent/node';
-import { AgentSharedStore } from '@agent/core/AgentSharedStore';
 // Type imports
+import type { AgentSharedStore } from '@agent/core/AgentSharedStore';
 import type { ToolUseCycleOptions } from '@agent/core/ToolUseCycle';
 import {
   BaseCycleState,
@@ -49,6 +49,7 @@ import {
   determineRetryStrategy,
 } from './RetryState';
 import { createRetryWaitNode } from './BaseRetryWaitNode';
+import type { ToolUseCycleServices, ToolUseCycleParams } from './CycleServices';
 
 interface ToolValidationDiagnostics {
   type: 'validation_error';
@@ -144,23 +145,48 @@ function resetToolUseState(state: ToolUseCycleState): void {
   state.text = undefined;
 }
 
-export interface ToolUseCycleContext<C = unknown> {
-  options: ToolUseCycleOptions<C>;
+/**
+ * Shared state for tool-use cycle flows.
+ *
+ * This contains only MUTABLE state that flows through nodes.
+ * Services (options, store) are accessed via `_params.services`.
+ *
+ * ## Architecture
+ * - Mutable state: `shared` (this interface)
+ * - Immutable services: `_params.services` (ToolUseCycleServices)
+ */
+export interface ToolUseCycleShared<C = unknown> {
+  /** Runtime state for this cycle */
   state: ToolUseCycleState;
-  store: AgentSharedStore;
-  /** Retry state for model invocation errors. */
+  /** Retry state for model invocation errors */
   retryState: RetryState;
-  /** Callbacks for manual retry control from UI. */
+  /** Callbacks for manual retry control from UI */
   retryCallbacks: RetryCallbacks;
 }
 
-class ToolUsePrepNode<C> extends BaseNode<ToolUseCycleContext<C>> {
-  async prep(shared: ToolUseCycleContext<C>): Promise<{
+/**
+ * @deprecated Use ToolUseCycleShared instead. Kept for backward compatibility.
+ */
+export type ToolUseCycleContext<C = unknown> = ToolUseCycleShared<C> & {
+  options: ToolUseCycleOptions<C>;
+  store: AgentSharedStore;
+};
+
+/**
+ * Prepares a tool-use cycle by checking interruptions and setting up debug context.
+ *
+ * Services accessed via `_params.services`: options, store
+ */
+class ToolUsePrepNode<C> extends BaseNode<
+  ToolUseCycleShared<C>,
+  ToolUseCycleParams<C>
+> {
+  async prep(shared: ToolUseCycleShared<C>): Promise<{
     interrupted: boolean;
     debugContext: CycleDebugContext;
     debugFileOptions: CycleDebugFileOptions;
   }> {
-    const { options, state, store } = shared;
+    const { options, store } = this._params.services;
     const interrupted = Boolean(await options.checkInterruption());
     const debugContext: CycleDebugContext = {
       logger: options.logger,
@@ -178,13 +204,15 @@ class ToolUsePrepNode<C> extends BaseNode<ToolUseCycleContext<C>> {
   }
 
   async post(
-    { state }: ToolUseCycleContext<C>,
+    shared: ToolUseCycleShared<C>,
     prepRes: {
       interrupted: boolean;
       debugContext: CycleDebugContext;
       debugFileOptions: CycleDebugFileOptions;
     },
   ): Promise<string | undefined> {
+    const { state } = shared;
+
     if (prepRes.interrupted) {
       state.shouldStop = true;
       return FlowTransition.COMPLETE;
@@ -243,14 +271,20 @@ type ToolUseCallResult =
 
 /**
  * Handles model invocation for tool-use cycles with integrated retry support.
+ *
+ * Services accessed via `_params.services`: options, store
  */
-class ToolUseCallNode<C> extends BaseNode<ToolUseCycleContext<C>> {
-  async prep(shared: ToolUseCycleContext<C>): Promise<ToolUseCycleContext<C>> {
+class ToolUseCallNode<C> extends BaseNode<
+  ToolUseCycleShared<C>,
+  ToolUseCycleParams<C>
+> {
+  async prep(shared: ToolUseCycleShared<C>): Promise<ToolUseCycleShared<C>> {
     return shared;
   }
 
-  async exec(context: ToolUseCycleContext<C>): Promise<ToolUseCallResult> {
-    const { options, state, store, retryState } = context;
+  async exec(shared: ToolUseCycleShared<C>): Promise<ToolUseCallResult> {
+    const { options, store } = this._params.services;
+    const { state, retryState } = shared;
     if (state.shouldStop) {
       return {
         success: true,
@@ -307,11 +341,12 @@ class ToolUseCallNode<C> extends BaseNode<ToolUseCycleContext<C>> {
   }
 
   async post(
-    shared: ToolUseCycleContext<C>,
-    prepRes: ToolUseCycleContext<C>,
+    shared: ToolUseCycleShared<C>,
+    _prepRes: ToolUseCycleShared<C>,
     execRes: ToolUseCallResult,
   ): Promise<string | undefined> {
-    const { options, state, retryState } = shared;
+    const { options } = this._params.services;
+    const { state, retryState } = shared;
 
     // Handle successful invocation
     if (execRes.success) {
@@ -383,12 +418,20 @@ class ToolUseCallNode<C> extends BaseNode<ToolUseCycleContext<C>> {
   }
 }
 
-class ToolUseProcessNode<C> extends BaseNode<ToolUseCycleContext<C>> {
-  async prep(shared: ToolUseCycleContext<C>): Promise<ToolUseCycleContext<C>> {
+/**
+ * Processes the model response to extract tool calls and usage data.
+ *
+ * Services accessed via `_params.services`: options, store
+ */
+class ToolUseProcessNode<C> extends BaseNode<
+  ToolUseCycleShared<C>,
+  ToolUseCycleParams<C>
+> {
+  async prep(shared: ToolUseCycleShared<C>): Promise<ToolUseCycleShared<C>> {
     return shared;
   }
 
-  async exec(context: ToolUseCycleContext<C>): Promise<
+  async exec(shared: ToolUseCycleShared<C>): Promise<
     SkippableNodeResult<{
       toolCalls?: SdkToolCall[];
       stopReason: ProviderStopReason;
@@ -396,7 +439,8 @@ class ToolUseProcessNode<C> extends BaseNode<ToolUseCycleContext<C>> {
       endTurn: boolean;
     }>
   > {
-    const { options, state, store } = context;
+    const { options, store } = this._params.services;
+    const { state } = shared;
     if (state.shouldStop || !state.response) {
       return { skipped: true };
     }
@@ -488,7 +532,7 @@ class ToolUseProcessNode<C> extends BaseNode<ToolUseCycleContext<C>> {
   }
 
   async post(
-    shared: ToolUseCycleContext<C>,
+    shared: ToolUseCycleShared<C>,
     _prepRes: unknown,
     execRes: SkippableNodeResult<{
       toolCalls?: SdkToolCall[];
@@ -497,7 +541,8 @@ class ToolUseProcessNode<C> extends BaseNode<ToolUseCycleContext<C>> {
       endTurn: boolean;
     }>,
   ): Promise<string | undefined> {
-    const { options, state, store } = shared;
+    const { store } = this._params.services;
+    const { state } = shared;
 
     if (execRes.skipped) {
       store.round.clearUsage();
@@ -522,20 +567,27 @@ class ToolUseProcessNode<C> extends BaseNode<ToolUseCycleContext<C>> {
   }
 }
 
-class ToolUseDispatchNode<C> extends BaseNode<ToolUseCycleContext<C>> {
-  async prep(shared: ToolUseCycleContext<C>): Promise<ToolUseCycleContext<C>> {
+/**
+ * Dispatches tool calls and processes their results.
+ *
+ * Services accessed via `_params.services`: options, store
+ */
+class ToolUseDispatchNode<C> extends BaseNode<
+  ToolUseCycleShared<C>,
+  ToolUseCycleParams<C>
+> {
+  async prep(shared: ToolUseCycleShared<C>): Promise<ToolUseCycleShared<C>> {
     return shared;
   }
 
   async exec(
-    context: ToolUseCycleContext<C>,
+    shared: ToolUseCycleShared<C>,
   ): Promise<SkippableNodeResult<{ calls: SdkToolCall[] }>> {
-    const { options, state, store } = context;
+    const { options } = this._params.services;
+    const { state } = shared;
     if (state.shouldStop || !state.toolCalls || state.toolCalls.length === 0) {
       return { skipped: true };
     }
-
-    const groupId = options.logger.withCurrentGroup((id) => id);
 
     if (await options.checkInterruption()) {
       state.shouldStop = true;
@@ -549,12 +601,14 @@ class ToolUseDispatchNode<C> extends BaseNode<ToolUseCycleContext<C>> {
   }
 
   async post(
-    _shared: ToolUseCycleContext<C>,
-    prepRes: ToolUseCycleContext<C>,
+    shared: ToolUseCycleShared<C>,
+    _prepRes: ToolUseCycleShared<C>,
     execRes: SkippableNodeResult<{ calls: SdkToolCall[] }>,
   ): Promise<string | undefined> {
-    const { options, state, store } = prepRes;
+    const { options, store } = this._params.services;
+    const { state } = shared;
     const groupId = options.logger.withCurrentGroup((id) => id);
+
     if (execRes.skipped) {
       state.shouldStop = true;
       return FlowTransition.COMPLETE;
@@ -692,13 +746,33 @@ class ToolUseDispatchNode<C> extends BaseNode<ToolUseCycleContext<C>> {
     return FlowTransition.CONTINUE;
   }
 }
-export function createToolUseCycleFlow<C>(): Flow<ToolUseCycleContext<C>> {
+/**
+ * Creates a tool-use cycle flow with services injected via params.
+ *
+ * The returned flow uses the services pattern:
+ * - Services (options, store) are passed via `setParams({ services })`
+ * - Only mutable state flows through the shared context
+ *
+ * @example
+ * ```typescript
+ * const flow = createToolUseCycleFlow<MyContext>();
+ * flow.setParams({ services: { options, store } });
+ * await flow.run(sharedState);
+ * ```
+ */
+export function createToolUseCycleFlow<C>(): Flow<
+  ToolUseCycleShared<C>,
+  ToolUseCycleParams<C>
+> {
   const prepNode = new ToolUsePrepNode<C>();
   const callNode = new ToolUseCallNode<C>();
   // Use shared retry wait node (single source of truth)
-  const retryWaitNode = createRetryWaitNode<ToolUseCycleContext<C>>({
-    getStreamId: (ctx) => ctx.options.context.streamId,
-    getLogger: (ctx) => ctx.options.logger,
+  // Note: RetryWaitNode accesses services via its own accessor pattern
+  const retryWaitNode = createRetryWaitNode<ToolUseCycleShared<C>>({
+    getStreamId: (_shared, params) =>
+      (params as ToolUseCycleParams<C>).services.options.context.streamId,
+    getLogger: (_shared, params) =>
+      (params as ToolUseCycleParams<C>).services.options.logger,
     operationName: 'Tool-use call',
   });
   const processNode = new ToolUseProcessNode<C>();
@@ -723,5 +797,5 @@ export function createToolUseCycleFlow<C>(): Flow<ToolUseCycleContext<C>> {
   // Dispatch can loop back to prep for next tool cycle
   dispatchNode.on(FlowTransition.CONTINUE, prepNode);
 
-  return new Flow<ToolUseCycleContext<C>>(prepNode);
+  return new Flow<ToolUseCycleShared<C>, ToolUseCycleParams<C>>(prepNode);
 }

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -1,7 +1,6 @@
 // Local imports - core flow primitives
 import { BaseNode, Flow } from '@agent/node';
 // Type imports
-import type { AgentSharedStore } from '@agent/core/AgentSharedStore';
 import type { ToolUseCycleOptions } from '@agent/core/ToolUseCycle';
 import {
   BaseCycleState,
@@ -163,14 +162,6 @@ export interface ToolUseCycleShared<C = unknown> {
   /** Callbacks for manual retry control from UI */
   retryCallbacks: RetryCallbacks;
 }
-
-/**
- * @deprecated Use ToolUseCycleShared instead. Kept for backward compatibility.
- */
-export type ToolUseCycleContext<C = unknown> = ToolUseCycleShared<C> & {
-  options: ToolUseCycleOptions<C>;
-  store: AgentSharedStore;
-};
 
 /**
  * Prepares a tool-use cycle by checking interruptions and setting up debug context.

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -83,7 +83,7 @@ import {
 } from './utils/toolAttachmentUtils';
 import { ANTHROPIC_STOP } from './types/StopReasonTypes';
 import { toAnthropicTools } from './toolConversion';
-import { executeWithRequestRetry } from './utils/requestExecutor';
+import { executeRequest } from './utils/requestExecutor';
 
 // Type imports
 import type { ProviderStopReason } from './types/StopReasonTypes';
@@ -381,7 +381,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
           countTokensParams.betas = countTokenBetas;
         }
 
-        const responseTokenCount = await executeWithRequestRetry(
+        const responseTokenCount = await executeRequest(
           {
             logger: this.logger,
             model: this.config.name,
@@ -475,7 +475,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
       if (useStreaming) {
         // in the future if we pass stream to outside, calling stream.controller.abort() will abort the stream; which will be very useful for our stop button
         // we should also make sure partial results can be returned in the presence of errors!
-        const stream = await executeWithRequestRetry(
+        const stream = await executeRequest(
           {
             logger: this.logger,
             model: this.config.name,
@@ -533,7 +533,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
           cleanupAbortListener?.();
         }
       } else {
-        response = await executeWithRequestRetry(
+        response = await executeRequest(
           {
             logger: this.logger,
             model: this.config.name,
@@ -656,7 +656,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
 
         try {
           buffer = Buffer.from(base64Data, 'base64');
-          const uploadedFile = await executeWithRequestRetry(
+          const uploadedFile = await executeRequest(
             {
               logger: this.logger,
               model: this.config.name,
@@ -777,7 +777,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
         );
 
         const base64Data = buffer.toString('base64');
-        const uploadedFile = await executeWithRequestRetry(
+        const uploadedFile = await executeRequest(
           {
             logger: this.logger,
             model: this.config.name,

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -74,7 +74,7 @@ import {
   extractToolAttachments,
   loadAttachmentBuffer,
 } from './utils/toolAttachmentUtils';
-import { executeWithRequestRetry } from './utils/requestExecutor';
+import { executeRequest } from './utils/requestExecutor';
 import { toGoogleTools } from './toolConversion';
 
 // Type imports
@@ -263,7 +263,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
         this.logger.debug(
           `Uploading media entry ${fileName} via Google GenAI SDK from path ${uploadPath}`,
         );
-        const uploadResult: File = await executeWithRequestRetry(
+        const uploadResult: File = await executeRequest(
           {
             logger: this.logger,
             model: this.config.name,
@@ -421,7 +421,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
         // history, so append the final user message that will be sent next.
         countContents.push({ role: 'user', parts: [...lastMessageParts] });
 
-        const responseTokenCount = await executeWithRequestRetry(
+        const responseTokenCount = await executeRequest(
           {
             logger: this.logger,
             model: this.config.name,
@@ -484,7 +484,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
           message: [...lastMessageParts],
           config: { ...generationConfig, abortSignal: signal },
         };
-        const stream = await executeWithRequestRetry(
+        const stream = await executeRequest(
           {
             logger: this.logger,
             model: this.config.name,
@@ -614,7 +614,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
         message: [...lastMessageParts],
         config: { ...generationConfig, abortSignal: signal },
       };
-      const result = await executeWithRequestRetry(
+      const result = await executeRequest(
         {
           logger: this.logger,
           model: this.config.name,

--- a/src/agent/modelHandlers/modelHandlerKimi.ts
+++ b/src/agent/modelHandlers/modelHandlerKimi.ts
@@ -9,7 +9,7 @@ import { MediaEntry } from '@agent/utils/mediaTypes';
 import { K_SLICE } from '@utils/config';
 import { BaseReasoningStreamAggregator } from './BaseReasoningStreamAggregator';
 import { ModelHandlerOpenAI } from './modelHandlerOpenAI';
-import { executeWithRequestRetry } from './utils/requestExecutor';
+import { executeRequest } from './utils/requestExecutor';
 import { toOpenAITools } from './toolConversion';
 import type { CreateResponseOptions } from './types/IModelHandler';
 import type {
@@ -150,7 +150,7 @@ export class ModelHandlerKimi extends ModelHandlerOpenAI {
         kwargs.stream = true;
         kwargs.stream_options = { include_usage: true };
 
-        const stream = await executeWithRequestRetry(
+        const stream = await executeRequest(
           {
             logger: this.logger,
             model: this.config.name,
@@ -226,7 +226,7 @@ export class ModelHandlerKimi extends ModelHandlerOpenAI {
       }
 
       // Non-streaming request
-      return executeWithRequestRetry(
+      return executeRequest(
         {
           logger: this.logger,
           model: this.config.name,

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -59,10 +59,7 @@ import {
   describeAttachments,
   extractToolAttachments,
 } from './utils/toolAttachmentUtils';
-import {
-  executeStreamingWithRetry,
-  executeWithRequestRetry,
-} from './utils/requestExecutor';
+import { executeRequest } from './utils/requestExecutor';
 import { ModelHandler } from './ModelHandler';
 import type {
   CreateResponseOptions,
@@ -312,17 +309,17 @@ export class ModelHandlerOpenAI<
       stream_options: { include_usage: true },
     };
 
-    return executeStreamingWithRetry({
-      logger: this.logger,
-      model: this.config.name,
-      operation: 'openai.chat.completions.stream',
-      manualRetryKey: this.logger.channelId,
-      enableManualRetry: true,
-      signal,
-      onAttemptStart: (nextAttempt) => {
-        markRetryAttempt(nextAttempt);
+    return executeRequest(
+      {
+        logger: this.logger,
+        model: this.config.name,
+        operation: 'openai.chat.completions.stream',
+        signal,
+        onAttemptStart: (nextAttempt) => {
+          markRetryAttempt(nextAttempt);
+        },
       },
-      create: async () => {
+      async () => {
         const stream = await client.chat.completions.stream(streamParams, {
           signal,
         });
@@ -365,7 +362,7 @@ export class ModelHandlerOpenAI<
           cleanup();
         }
       },
-    });
+    );
   }
 
   protected async executeNonStreamingChat(
@@ -373,13 +370,11 @@ export class ModelHandlerOpenAI<
     baseParams: ChatCompletionRequestBase,
     signal?: AbortSignal,
   ): Promise<ChatCompletion> {
-    return executeWithRequestRetry(
+    return executeRequest(
       {
         logger: this.logger,
         model: this.config.name,
         operation: 'openai.chat.completions.create',
-        manualRetryKey: this.logger.channelId,
-        enableManualRetry: true,
         signal,
       },
       () =>

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -912,7 +912,6 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
           model: this.config.name,
           operation: `openai.responses.retrieve:${responseId}`,
           signal,
-          maxAttempts: maxRetries,
         },
         () => client.responses.retrieve(responseId, undefined, requestOptions),
       );

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -47,7 +47,7 @@ import {
   extractToolAttachments,
   loadAttachmentBuffer,
 } from './utils/toolAttachmentUtils';
-import { executeWithRequestRetry } from './utils/requestExecutor';
+import { executeRequest } from './utils/requestExecutor';
 import { OPENAI_CHAT_FINISH } from './types/StopReasonTypes';
 import { toOpenAIResponseTools } from './toolConversion';
 import { ModelHandler } from './ModelHandler';
@@ -453,7 +453,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
           : fileData;
 
       buffer = Buffer.from(payload, 'base64');
-      const uploadedFile = await executeWithRequestRetry(
+      const uploadedFile = await executeRequest(
         {
           logger: this.logger,
           model: this.config.name,
@@ -589,7 +589,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     if (useStreaming) {
       const { stream: _stream, ...rest } = params;
       const streamParams: ResponseStreamParams = { ...rest, stream: true };
-      const stream = await executeWithRequestRetry(
+      const stream = await executeRequest(
         {
           logger: this.logger,
           model: this.config.name,
@@ -636,7 +636,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         ...nonStreamRest,
         stream: false,
       };
-      let response = await executeWithRequestRetry(
+      let response = await executeRequest(
         {
           logger: this.logger,
           model: this.config.name,
@@ -906,7 +906,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       }
 
       const requestOptions = signal ? { signal } : undefined;
-      current = await executeWithRequestRetry(
+      current = await executeRequest(
         {
           logger: this.logger,
           model: this.config.name,
@@ -1443,7 +1443,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
             : 'attachment';
         const mimeType = attachment.mimeType ?? 'application/octet-stream';
 
-        const uploadedFile = await executeWithRequestRetry(
+        const uploadedFile = await executeRequest(
           {
             logger: this.logger,
             model: this.config.name,

--- a/src/agent/modelHandlers/modelHandlerOpenRouter.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenRouter.ts
@@ -10,7 +10,7 @@ import { K_SLICE } from '@utils/config';
 // Local file imports
 import { ModelHandlerOpenAI } from './modelHandlerOpenAI';
 import { toOpenAITools } from './toolConversion';
-import { executeWithRequestRetry } from './utils/requestExecutor';
+import { executeRequest } from './utils/requestExecutor';
 import type { CreateResponseOptions } from './types/IModelHandler';
 import type {
   ChatCompletion,
@@ -64,7 +64,7 @@ export class ModelHandlerOpenRouter extends ModelHandlerOpenAI {
 
     if (useStreaming) {
       kwargs.stream_options = { include_usage: true }; // Assuming OpenRouter passes this through
-      const stream = await executeWithRequestRetry(
+      const stream = await executeRequest(
         {
           logger: this.logger,
           model: this.config.name,
@@ -94,7 +94,7 @@ export class ModelHandlerOpenRouter extends ModelHandlerOpenAI {
       if (output) output.finalize(finalOutput);
       return response;
     } else {
-      return executeWithRequestRetry(
+      return executeRequest(
         {
           logger: this.logger,
           model: this.config.name,

--- a/src/agent/modelHandlers/utils/requestExecutor.ts
+++ b/src/agent/modelHandlers/utils/requestExecutor.ts
@@ -46,17 +46,20 @@ export async function executeRequest<T>(
     return await request();
   } catch (error) {
     const formatted = formatProviderHttpError(error);
-    options.logger.error(`Error in ${options.operation}: ${formatted.message}`, {
-      messageType: MESSAGE_TYPES.PROGRESS_STATUS,
-      data: {
-        ...formatted,
-        attempt: 1,
-        maxAttempts: 1,
-        model: options.model,
-        operation: options.operation,
-        error: getSdkErrorMessage(error),
+    options.logger.error(
+      `Error in ${options.operation}: ${formatted.message}`,
+      {
+        messageType: MESSAGE_TYPES.PROGRESS_STATUS,
+        data: {
+          ...formatted,
+          attempt: 1,
+          maxAttempts: 1,
+          model: options.model,
+          operation: options.operation,
+          error: getSdkErrorMessage(error),
+        },
       },
-    });
+    );
     throw error;
   }
 }

--- a/src/agent/modelHandlers/utils/requestExecutor.ts
+++ b/src/agent/modelHandlers/utils/requestExecutor.ts
@@ -60,39 +60,3 @@ export async function executeRequest<T>(
     throw error;
   }
 }
-
-// =============================================================================
-// Legacy aliases (for backward compatibility with existing model handlers)
-// =============================================================================
-
-/**
- * @deprecated Use `executeRequest` instead. This alias exists for backward compatibility.
- */
-export async function executeWithRequestRetry<T>(
-  options: RequestExecutionOptions & {
-    // Deprecated parameters - ignored but kept for API compatibility
-    maxAttempts?: number;
-    baseDelayMs?: number;
-    enableManualRetry?: boolean;
-    manualRetryKey?: string;
-  },
-  request: () => Promise<T> | T,
-): Promise<T> {
-  return executeRequest(options, request);
-}
-
-/**
- * @deprecated Use `executeRequest` instead. This alias exists for backward compatibility.
- */
-export async function executeStreamingWithRetry<T>(
-  options: RequestExecutionOptions & {
-    create: () => Promise<T>;
-    // Deprecated parameters - ignored but kept for API compatibility
-    maxAttempts?: number;
-    baseDelayMs?: number;
-    enableManualRetry?: boolean;
-    manualRetryKey?: string;
-  },
-): Promise<T> {
-  return executeRequest(options, options.create);
-}

--- a/src/agent/modelHandlers/utils/requestExecutor.ts
+++ b/src/agent/modelHandlers/utils/requestExecutor.ts
@@ -1,44 +1,41 @@
 /**
- * @deprecated Retry logic has been moved to flow-based handling in RetryState.ts.
- * This module now just executes requests without retry; ResponseCycleFlow and
- * ToolUseCycleFlow own all retry behavior at the flow level.
+ * Request execution utilities for model handlers.
+ *
+ * NOTE: Retry logic is handled at the flow level (ResponseCycleFlow/ToolUseCycleFlow).
+ * These utilities provide consistent error logging and abort handling for model requests.
  */
 
-// Local imports - logging
 import { MESSAGE_TYPES } from '@logger/messageTypes';
 import type { AgentLogger } from '@logger/AgentLogger';
-
-// Local imports - error utilities
 import {
   formatProviderHttpError,
   getSdkErrorMessage,
 } from '@common/errors/sdkErrorUtils';
 
-interface RequestRetryOptions {
+/**
+ * Options for request execution.
+ */
+export interface RequestExecutionOptions {
+  /** Logger for error reporting */
   logger: AgentLogger;
+  /** Operation name for error messages (e.g., "model response", "file upload") */
   operation: string;
+  /** Model name for diagnostics */
   model?: string;
+  /** Abort signal for cancellation */
   signal?: AbortSignal;
-  /** @deprecated Ignored - retry handled at flow level */
-  maxAttempts?: number;
-  /** @deprecated Ignored - retry handled at flow level */
-  baseDelayMs?: number;
-  /** @deprecated Ignored - retry handled at flow level */
-  enableManualRetry?: boolean;
-  /** @deprecated Ignored - retry handled at flow level */
-  manualRetryKey?: string;
+  /** Callback when attempt starts (always called with 1) */
   onAttemptStart?: (attempt: number) => void;
 }
 
 /**
- * Executes a request without retry logic.
- * Retry is handled at the flow level by ResponseCycleFlow/ToolUseCycleFlow.
+ * Executes a request with consistent error logging and abort handling.
+ * Retry logic is handled at the flow level, not here.
  */
-export async function executeWithRequestRetry<T>(
-  options: RequestRetryOptions,
+export async function executeRequest<T>(
+  options: RequestExecutionOptions,
   request: () => Promise<T> | T,
 ): Promise<T> {
-  // Always report the first attempt for downstream diagnostics
   options.onAttemptStart?.(1);
 
   if (options.signal?.aborted) {
@@ -49,35 +46,53 @@ export async function executeWithRequestRetry<T>(
     return await request();
   } catch (error) {
     const formatted = formatProviderHttpError(error);
-    options.logger.error(
-      `Error in ${options.operation}: ${formatted.message}`,
-      {
-        messageType: MESSAGE_TYPES.PROGRESS_STATUS,
-        data: {
-          ...formatted,
-          attempt: 1,
-          maxAttempts: 1,
-          model: options.model,
-          operation: options.operation,
-          error: getSdkErrorMessage(error),
-        },
+    options.logger.error(`Error in ${options.operation}: ${formatted.message}`, {
+      messageType: MESSAGE_TYPES.PROGRESS_STATUS,
+      data: {
+        ...formatted,
+        attempt: 1,
+        maxAttempts: 1,
+        model: options.model,
+        operation: options.operation,
+        error: getSdkErrorMessage(error),
       },
-    );
+    });
     throw error;
   }
 }
 
-interface StreamingRetryOptions<T> extends RequestRetryOptions {
-  create: () => Promise<T>;
+// =============================================================================
+// Legacy aliases (for backward compatibility with existing model handlers)
+// =============================================================================
+
+/**
+ * @deprecated Use `executeRequest` instead. This alias exists for backward compatibility.
+ */
+export async function executeWithRequestRetry<T>(
+  options: RequestExecutionOptions & {
+    // Deprecated parameters - ignored but kept for API compatibility
+    maxAttempts?: number;
+    baseDelayMs?: number;
+    enableManualRetry?: boolean;
+    manualRetryKey?: string;
+  },
+  request: () => Promise<T> | T,
+): Promise<T> {
+  return executeRequest(options, request);
 }
 
 /**
- * Executes a streaming request without retry logic.
- * Retry is handled at the flow level by ResponseCycleFlow/ToolUseCycleFlow.
+ * @deprecated Use `executeRequest` instead. This alias exists for backward compatibility.
  */
 export async function executeStreamingWithRetry<T>(
-  options: StreamingRetryOptions<T>,
+  options: RequestExecutionOptions & {
+    create: () => Promise<T>;
+    // Deprecated parameters - ignored but kept for API compatibility
+    maxAttempts?: number;
+    baseDelayMs?: number;
+    enableManualRetry?: boolean;
+    manualRetryKey?: string;
+  },
 ): Promise<T> {
-  const { create, ...requestOptions } = options;
-  return executeWithRequestRetry(requestOptions, create);
+  return executeRequest(options, options.create);
 }

--- a/src/agent/output/types.ts
+++ b/src/agent/output/types.ts
@@ -39,15 +39,6 @@ export const FileLineageSchema = z
   })
   .strict();
 
-/** @deprecated Old structure, use FileLineageSchema */
-const LegacyFileLineageSchema = z
-  .object({
-    base: z.custom<FileLocation>().nullable(),
-    previous: z.custom<FileLocation>().nullable(),
-    original: z.custom<FileLocation>().nullable(),
-  })
-  .strict();
-
 /**
  * Complete output file metadata.
  * - source: Document name (e.g., "main.tex")


### PR DESCRIPTION
- Add determineRetryStrategy() to RetryState.ts as the single source of truth for retry decision logic (auto/manual/fail)
- Create BaseRetryWaitNode.ts to eliminate ~90 lines of duplicate retry wait code between ResponseCycleFlow and ToolUseCycleFlow
- Update both cycle flows to use shared abstractions
- Simplify requestExecutor.ts by removing deprecated inline comments and providing clean executeRequest() function with legacy aliases
- Remove unused imports (bus, registerManualRetry, clearManualRetry) from cycle flows since they're now handled by BaseRetryWaitNode

This follows PocketFlow patterns more closely by centralizing retry state management and reducing code duplication across flows.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Centralizes retry handling and manual retry wait, refactors cycle flows to a services-based pattern, simplifies request execution, and updates model handlers and schemas accordingly.
> 
> - **Core Flows (Response/ToolUse)**:
>   - Add single-source retry APIs: `determineRetryStrategy`, `applyRetryDecision`, `beginAttempt`, export `MANUAL_RETRY_TIMEOUT_MS` in `flows/RetryState.ts`.
>   - Introduce shared `BaseRetryWaitNode` and use it in both `ResponseCycleFlow` and `ToolUseCycleFlow` (removes duplicated retry-wait code).
>   - Adopt services pattern via `flows/CycleServices.ts` (`Options`, `Services`, `Params`); flows now pass immutable services through `setParams` and keep only mutable state in `shared`.
>   - Refactor nodes to read from `_params.services`; align transitions and state updates.
> - **Cycle Runners**:
>   - Update `ResponseCycle.ts` and `ToolUseCycle.ts` to construct `shared` state and inject services with `flow.setParams({ services: { options, store } })`.
> - **Request Execution**:
>   - Replace deprecated retry wrappers with `executeRequest` in `modelHandlers/**` and simplify `utils/requestExecutor.ts` (consistent logging/abort, no retries).
> - **Schemas/Types**:
>   - Move `AgentSessionDescriptor` to `AgentSessionSchema.ts` and re-export from `AgentDataclass.ts`.
>   - Tidy `output/types.ts` (remove legacy lineage type, clarify schemas; re-export `FileLocation`).
> - **Docs/Comments**:
>   - Add architectural notes (pass-through `prep()` pattern, services SSoT).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ce366f7cc7b6b0570e1129624322e2acbe3c9b9e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->