### PR TITLE
refactor: establish single source of truth for tool types and session management

### DIFF
--- a/src/agent/core/AgentDataclass.ts
+++ b/src/agent/core/AgentDataclass.ts
@@ -4,6 +4,9 @@ import { z } from 'zod';
 // Local imports - model types
 import { ToolDefinitionSchema } from '@model';
 
+// Local imports - session schema (imported for local use, re-exported below)
+import type { AgentSessionDescriptor } from './AgentSessionSchema';
+
 /** Temperature bounds for agent generation. */
 export const MIN_TEMPERATURE = 0;
 export const MAX_TEMPERATURE = 1;

--- a/src/agent/core/AgentSessionSchema.ts
+++ b/src/agent/core/AgentSessionSchema.ts
@@ -17,4 +17,6 @@ export const AgentSessionDescriptorSchema = z.strictObject({
  * Shared metadata describing how an agent session should be classified.
  * Derived from AgentSessionDescriptorSchema (single source of truth).
  */
-export type AgentSessionDescriptor = z.infer<typeof AgentSessionDescriptorSchema>;
+export type AgentSessionDescriptor = z.infer<
+  typeof AgentSessionDescriptorSchema
+>;

--- a/src/agent/core/ToolTypes.ts
+++ b/src/agent/core/ToolTypes.ts
@@ -1,0 +1,128 @@
+/**
+ * Core tool type definitions for the agent system.
+ *
+ * This module provides the SINGLE SOURCE OF TRUTH for tool-related interfaces
+ * used across the agent and tools packages. It defines:
+ *
+ * 1. ITool - Interface contract for all tool implementations
+ * 2. IToolRegistry - Interface for tool lookup and enumeration
+ * 3. Re-exports of ToolResult and related types from tools/result
+ *
+ * This enables:
+ * - Dependency injection (agents accept IToolRegistry instead of concrete types)
+ * - Cleaner separation between agent core and tool implementations
+ * - Testability (mock registries can be injected)
+ */
+
+// Re-export tool result types from canonical location
+export type {
+  ToolResult,
+  ErrorDiagnostics,
+  DiagnosticsPayload,
+  ToolFileAttachment,
+} from '@tools/result';
+export { toolResult, cliResult, ToolError } from '@tools/result';
+
+// Re-export ToolDefinition from model
+export type { ToolDefinition } from '@model/ToolDefinition';
+
+/**
+ * Interface contract for tool implementations.
+ *
+ * All tools must implement this interface to be usable in the agent system.
+ * BaseTool provides the canonical implementation with Zod validation.
+ */
+export interface ITool {
+  /** Tool definition containing name, description, and parameter schema */
+  readonly definition: import('@model/ToolDefinition').ToolDefinition;
+
+  /**
+   * Execute the tool with the given input.
+   *
+   * Implementations should:
+   * 1. Validate the input
+   * 2. Execute the tool logic
+   * 3. Return a ToolResult (success or error)
+   *
+   * @param rawInput - The raw input to validate and process
+   * @returns Promise resolving to a ToolResult
+   */
+  call(rawInput: unknown): Promise<import('@tools/result').ToolResult>;
+}
+
+/**
+ * Interface for tool registries that provide tool lookup and enumeration.
+ *
+ * This abstraction allows:
+ * - Dependency injection of custom tool sets
+ * - Filtering tools at runtime
+ * - Testing with mock tools
+ */
+export interface IToolRegistry {
+  /**
+   * Get a tool by name.
+   * @param name - The tool name
+   * @returns The tool if found, undefined otherwise
+   */
+  get(name: string): ITool | undefined;
+
+  /**
+   * Check if a tool exists in the registry.
+   * @param name - The tool name
+   * @returns True if the tool exists
+   */
+  has(name: string): boolean;
+
+  /**
+   * Get all tool names in the registry.
+   * @returns Iterator of tool names
+   */
+  keys(): IterableIterator<string>;
+
+  /**
+   * Get all tools in the registry.
+   * @returns Iterator of [name, tool] pairs
+   */
+  entries(): IterableIterator<[string, ITool]>;
+}
+
+/**
+ * Simple implementation of IToolRegistry backed by a Map or Record.
+ *
+ * Use createToolRegistry() to wrap an existing Record<string, ITool>.
+ */
+export class MapToolRegistry implements IToolRegistry {
+  private readonly tools: Map<string, ITool>;
+
+  constructor(tools: Map<string, ITool> | Record<string, ITool>) {
+    this.tools = tools instanceof Map ? tools : new Map(Object.entries(tools));
+  }
+
+  get(name: string): ITool | undefined {
+    return this.tools.get(name);
+  }
+
+  has(name: string): boolean {
+    return this.tools.has(name);
+  }
+
+  keys(): IterableIterator<string> {
+    return this.tools.keys();
+  }
+
+  entries(): IterableIterator<[string, ITool]> {
+    return this.tools.entries();
+  }
+}
+
+/**
+ * Create an IToolRegistry from a Record of tools.
+ *
+ * @param tools - Record mapping tool names to ITool implementations
+ * @returns An IToolRegistry wrapping the tools
+ */
+export function createToolRegistry(
+  tools: Record<string, ITool>,
+): IToolRegistry {
+  return new MapToolRegistry(tools);
+}

--- a/src/agent/core/ToolTypes.ts
+++ b/src/agent/core/ToolTypes.ts
@@ -14,6 +14,10 @@
  * - Testability (mock registries can be injected)
  */
 
+// Import types for local use in interfaces
+import type { ToolResult as ToolResultType } from '@tools/result';
+import type { ToolDefinition as ToolDefinitionType } from '@model/ToolDefinition';
+
 // Re-export tool result types from canonical location
 export type {
   ToolResult,
@@ -34,7 +38,7 @@ export type { ToolDefinition } from '@model/ToolDefinition';
  */
 export interface ITool {
   /** Tool definition containing name, description, and parameter schema */
-  readonly definition: import('@model/ToolDefinition').ToolDefinition;
+  readonly definition: ToolDefinitionType;
 
   /**
    * Execute the tool with the given input.
@@ -47,7 +51,7 @@ export interface ITool {
    * @param rawInput - The raw input to validate and process
    * @returns Promise resolving to a ToolResult
    */
-  call(rawInput: unknown): Promise<import('@tools/result').ToolResult>;
+  call(rawInput: unknown): Promise<ToolResultType>;
 }
 
 /**
@@ -59,6 +63,9 @@ export interface ITool {
  * - Testing with mock tools
  */
 export interface IToolRegistry {
+  /** Number of tools in the registry */
+  readonly size: number;
+
   /**
    * Get a tool by name.
    * @param name - The tool name
@@ -81,6 +88,12 @@ export interface IToolRegistry {
 
   /**
    * Get all tools in the registry.
+   * @returns Iterator of tool values
+   */
+  values(): IterableIterator<ITool>;
+
+  /**
+   * Get all tools in the registry.
    * @returns Iterator of [name, tool] pairs
    */
   entries(): IterableIterator<[string, ITool]>;
@@ -98,6 +111,10 @@ export class MapToolRegistry implements IToolRegistry {
     this.tools = tools instanceof Map ? tools : new Map(Object.entries(tools));
   }
 
+  get size(): number {
+    return this.tools.size;
+  }
+
   get(name: string): ITool | undefined {
     return this.tools.get(name);
   }
@@ -108,6 +125,10 @@ export class MapToolRegistry implements IToolRegistry {
 
   keys(): IterableIterator<string> {
     return this.tools.keys();
+  }
+
+  values(): IterableIterator<ITool> {
+    return this.tools.values();
   }
 
   entries(): IterableIterator<[string, ITool]> {

--- a/src/agent/core/ToolUseCycle.ts
+++ b/src/agent/core/ToolUseCycle.ts
@@ -34,7 +34,6 @@ import type { ToolUseCycleOptions } from './flows/CycleServices';
 export type { ToolUseCycleOptions };
 import type { AgentCycleBaseOptions } from './AgentCycleOptions';
 
-
 export interface ToolUseCycleInput<C = unknown> {
   options: ToolUseCycleOptions<C>;
   messages: ProviderMessage[];

--- a/src/agent/core/flows/CycleServices.ts
+++ b/src/agent/core/flows/CycleServices.ts
@@ -34,7 +34,7 @@ import type { AgentSharedStore } from '@agent/core/AgentSharedStore';
 import type { AgentCycleBaseOptions } from '@agent/core/AgentCycleOptions';
 import type { AgentConfig } from '@agent/core/AgentConfig';
 import type { AgentWorkspaceState } from '@agent/core/AgentWorkspaceState';
-import type { BaseTool } from '@tools/core/base';
+import type { IToolRegistry } from '@agent/core/ToolTypes';
 import type { TaskRunFileService } from '@utils/files';
 
 // ============================================================================
@@ -57,7 +57,7 @@ export interface ResponseCycleOptions<C = unknown>
  */
 export interface ToolUseCycleOptions<C = unknown>
   extends AgentCycleBaseOptions<C> {
-  toolRegistry: Record<string, BaseTool<any>>;
+  toolRegistry: IToolRegistry;
   workspaceState: AgentWorkspaceState;
   modelName?: string;
   agentName?: string;

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -22,15 +22,16 @@ import { maybeSaveDebugObject } from '@agent/utils/debugMessageSaver';
 import type { DebugObjectType } from '@agent/utils/debugMessageSaver';
 // Internal imports
 import { sanitizeToolResultForLog } from '@agent/modelHandlers/utils/toolAttachmentUtils';
-import { formatProviderHttpError } from '@common/errors/sdkErrorUtils';
 import { withToolFileInteractionContext } from '@agent/toolUse/ToolFileInteractionContext';
+import type { ToolResult } from '@agent/core/ToolTypes';
+import { toolResult } from '@agent/core/ToolTypes';
+import { formatProviderHttpError } from '@common/errors/sdkErrorUtils';
 // Local imports - logging
 import { AgentLogger } from '@logger/AgentLogger';
 import { MESSAGE_TYPES } from '@logger/messageTypes';
 // Type imports
 import type { ToolDefinition } from '@model';
-// Internal imports
-import { ToolResult, toolResult } from '@tools/result';
+// Internal imports - use core ToolTypes as single source of truth
 import { withToolEditApprovalContext } from '@tools/approval/toolEditApprovalContext';
 import { WorkspaceFS } from '@utils/files';
 import xmlUtils from '@utils/text/xmlUtils';
@@ -590,7 +591,7 @@ class ToolUseDispatchNode<C> extends BaseNode<
     const tracker = store.workspace.interactions;
 
     for (const [index, call] of calls.entries()) {
-      const tool = options.toolRegistry[call.name];
+      const tool = options.toolRegistry.get(call.name);
       let result: ToolResult;
       const parsedInput = parseToolInput(
         call.input,

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -20,7 +20,7 @@ import type { ExecutionId } from '@agent/types/IdentifierTypes';
 import { maybeSaveDebugObject } from '@agent/utils/debugMessageSaver';
 // Type imports
 import type { DebugObjectType } from '@agent/utils/debugMessageSaver';
-// Internal imports
+// Internal imports - use core ToolTypes as single source of truth
 import { sanitizeToolResultForLog } from '@agent/modelHandlers/utils/toolAttachmentUtils';
 import { withToolFileInteractionContext } from '@agent/toolUse/ToolFileInteractionContext';
 import type { ToolResult } from '@agent/core/ToolTypes';
@@ -31,7 +31,6 @@ import { AgentLogger } from '@logger/AgentLogger';
 import { MESSAGE_TYPES } from '@logger/messageTypes';
 // Type imports
 import type { ToolDefinition } from '@model';
-// Internal imports - use core ToolTypes as single source of truth
 import { withToolEditApprovalContext } from '@tools/approval/toolEditApprovalContext';
 import { WorkspaceFS } from '@utils/files';
 import xmlUtils from '@utils/text/xmlUtils';

--- a/src/agent/core/index.ts
+++ b/src/agent/core/index.ts
@@ -6,6 +6,8 @@ export * from './AgentSharedStoreRegistry';
 export * from './ToolConfig';
 export * from './AgentWorkspaceState';
 export * from './ResponseUsage';
+export * from './RunUsageAccumulator';
+export * from './ToolTypes';
 export * from './IAgent';
 export * from './ResponseCycle';
 export * from './ToolUseCycle';

--- a/src/agent/implementations/BaseToolUseAgent.ts
+++ b/src/agent/implementations/BaseToolUseAgent.ts
@@ -41,17 +41,25 @@ import {
 import { ToolUseSessionLifecycle } from '@agent/toolUse/ToolUseSessionLifecycle';
 
 // Type imports
+import type { IToolRegistry } from '@agent/core/ToolTypes';
 import type { ToolDefinition } from '@model';
 
-// Internal imports
-import { DEFAULT_TOOL_REGISTRY } from '@tools/registry';
-import { BaseTool } from '@tools/core/base';
+// Internal imports - use IToolRegistry from core (single source of truth)
+import { getDefaultToolRegistry } from '@tools/registry';
 
 // Local file imports
 import { BaseAgent } from './BaseAgent';
 
+export interface BaseToolUseAgentOptions {
+  /**
+   * Optional tool registry to use. Defaults to getDefaultToolRegistry().
+   * Enables dependency injection for testing and custom tool sets.
+   */
+  toolRegistry?: IToolRegistry;
+}
+
 export class BaseToolUseAgent<C = unknown> extends BaseAgent<C> {
-  private toolRegistry: Record<string, BaseTool<any>>;
+  private readonly toolRegistry: IToolRegistry;
   private readonly sessionLifecycle: ToolUseSessionLifecycle<C>;
   private resumeSnapshot: ToolUseSessionSnapshot | null = null;
   private activeState: ToolUseRunState<C> | null = null;
@@ -63,6 +71,7 @@ export class BaseToolUseAgent<C = unknown> extends BaseAgent<C> {
     agentPrompt: AgentPrompt,
     agentPath: string,
     context: AgentExecutionContext,
+    options?: BaseToolUseAgentOptions,
   ) {
     super(
       modelHandler,
@@ -72,7 +81,7 @@ export class BaseToolUseAgent<C = unknown> extends BaseAgent<C> {
       agentPath,
       context,
     );
-    this.toolRegistry = DEFAULT_TOOL_REGISTRY;
+    this.toolRegistry = options?.toolRegistry ?? getDefaultToolRegistry();
     this.sessionLifecycle = new ToolUseSessionLifecycle(this);
   }
 
@@ -91,7 +100,7 @@ export class BaseToolUseAgent<C = unknown> extends BaseAgent<C> {
     const tools: ToolDefinition[] = [];
     for (const t of cfg) {
       const def = typeof t === 'string' ? { name: t } : t;
-      if (!this.toolRegistry[def.name]) {
+      if (!this.toolRegistry.has(def.name)) {
         this.logger.warn(`Tool "${def.name}" not found in registry`);
         continue;
       }

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -542,7 +542,11 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         'Background mode toggle is enabled but this handler does not support background execution. Falling back to synchronous requests.',
       );
     }
-    if (backgroundToggleEnabled && this.backgroundModeSupported && !isEligible) {
+    if (
+      backgroundToggleEnabled &&
+      this.backgroundModeSupported &&
+      !isEligible
+    ) {
       this.logger.debug(
         'Background mode toggle is enabled but not eligible for this model/agent type (requires GPT 5 series with workflow agents). Falling back to synchronous requests.',
       );

--- a/src/agent/modelHandlers/utils/requestExecutor.ts
+++ b/src/agent/modelHandlers/utils/requestExecutor.ts
@@ -5,12 +5,12 @@
  * These utilities provide consistent error logging and abort handling for model requests.
  */
 
-import { MESSAGE_TYPES } from '@logger/messageTypes';
-import type { AgentLogger } from '@logger/AgentLogger';
 import {
   formatProviderHttpError,
   getSdkErrorMessage,
 } from '@common/errors/sdkErrorUtils';
+import { MESSAGE_TYPES } from '@logger/messageTypes';
+import type { AgentLogger } from '@logger/AgentLogger';
 
 /**
  * Options for request execution.

--- a/src/agent/toolUse/ToolUseFollowUpCoordinator.ts
+++ b/src/agent/toolUse/ToolUseFollowUpCoordinator.ts
@@ -10,7 +10,7 @@ import type { StreamTabId } from '@agent/types/IdentifierTypes';
 import { AgentLogger } from '@logger/AgentLogger';
 
 // Local imports - persistence
-import { ToolUseSnapshotCache } from './ToolUseSnapshotCache';
+import { ToolUseSessionManager } from './ToolUseSessionManager';
 import { ToolUseFollowUpQueue } from './ToolUseFollowUpQueue';
 import {
   ToolUseSessionPersistence,
@@ -46,7 +46,7 @@ export async function sendFollowUp(
     }
   }
 
-  const pendingSnapshot = ToolUseSnapshotCache.getByStream(streamId);
+  const pendingSnapshot = ToolUseSessionManager.getByStream(streamId);
   if (pendingSnapshot) {
     logger.debug(`Resuming agent lazily for stream ${streamId}.`);
     await ToolUseSessionPersistence.resumeFromSnapshot(pendingSnapshot, text);

--- a/src/agent/toolUse/ToolUseSessionManager.ts
+++ b/src/agent/toolUse/ToolUseSessionManager.ts
@@ -1,4 +1,17 @@
-export { ToolUseSnapshotCache as ToolUseSessionManager } from './ToolUseSnapshotCache';
+/**
+ * Re-exports for tool-use session management.
+ *
+ * This module provides the public API for session snapshot management:
+ * - ToolUseSessionManager: Primary class for in-memory snapshot caching
+ * - ToolUseSnapshotCache: Deprecated alias (use ToolUseSessionManager)
+ * - Type exports for snapshot payloads
+ */
+
+export {
+  ToolUseSessionManager,
+  ToolUseSnapshotCache,
+} from './ToolUseSnapshotCache';
+
 export type {
   ToolUseSessionSnapshot,
   SaveToolUseSnapshotPayload,

--- a/src/agent/toolUse/ToolUseSessionPersistence.ts
+++ b/src/agent/toolUse/ToolUseSessionPersistence.ts
@@ -31,7 +31,7 @@ import { getToolUsePersistenceEnabled } from '@utils/config';
 
 // Local file imports
 import { ToolUseFollowUpQueue } from './ToolUseFollowUpQueue';
-import { ToolUseSnapshotCache } from './ToolUseSnapshotCache';
+import { ToolUseSessionManager } from './ToolUseSessionManager';
 import { ToolUseSnapshotStore } from './ToolUseSnapshotStore';
 // Type imports
 import {
@@ -88,7 +88,7 @@ async function persistSnapshot({
     return false;
   }
 
-  ToolUseSnapshotCache.cacheSnapshot(stored);
+  ToolUseSessionManager.cacheSnapshot(stored);
   return true;
 }
 
@@ -132,11 +132,11 @@ export const ToolUseSessionPersistence = {
       return;
     }
 
-    ToolUseSnapshotCache.registerSnapshots(snapshots);
+    ToolUseSessionManager.registerSnapshots(snapshots);
   },
 
   clearAllPersistedSnapshots(): void {
-    ToolUseSnapshotCache.clearAll();
+    ToolUseSessionManager.clearAll();
   },
 
   async maybePersistIdleSnapshot({
@@ -179,7 +179,7 @@ export const ToolUseSessionPersistence = {
       return false;
     }
 
-    ToolUseSnapshotCache.cacheSnapshot(stored);
+    ToolUseSessionManager.cacheSnapshot(stored);
     return true;
   },
 
@@ -190,7 +190,7 @@ export const ToolUseSessionPersistence = {
       return;
     }
 
-    ToolUseSnapshotCache.clearByExecution(executionId);
+    ToolUseSessionManager.clearByExecution(executionId);
 
     await ToolUseSnapshotStore.delete(executionId);
   },
@@ -242,7 +242,7 @@ export const ToolUseSessionPersistence = {
         { resume: true },
       );
 
-      ToolUseSnapshotCache.clearByStream(streamId);
+      ToolUseSessionManager.clearByStream(streamId);
 
       return { success: true };
     } catch (error) {

--- a/src/agent/toolUse/ToolUseSnapshotCache.ts
+++ b/src/agent/toolUse/ToolUseSnapshotCache.ts
@@ -1,3 +1,14 @@
+/**
+ * In-memory cache for tool-use session snapshots.
+ *
+ * Manages session snapshots used for lazy resume when the user returns to
+ * a tool-use session. Snapshots are indexed by both stream ID and execution ID
+ * for efficient lookup and cleanup.
+ *
+ * @see ToolUseSessionPersistence for disk persistence
+ * @see ToolUseSnapshotStore for the persistent storage layer
+ */
+
 // Local imports - agent types
 import type { ExecutionId, StreamTabId } from '@agent/types/IdentifierTypes';
 // Local imports - core indexing
@@ -7,10 +18,18 @@ import { AgentLogger } from '@logger/AgentLogger';
 // Local file imports - tool-use snapshots
 import type { ToolUseSessionSnapshot } from './ToolUseSnapshotTypes';
 
-const CHANNEL = 'ToolUseSnapshotCache';
+const CHANNEL = 'ToolUseSessionManager';
 const logger = new AgentLogger(CHANNEL);
 
-export class ToolUseSnapshotCache {
+/**
+ * Manages in-memory caching of tool-use session snapshots for resume capability.
+ *
+ * This class provides:
+ * - Dual-indexed storage (by stream ID and execution ID)
+ * - Lazy registration from persisted snapshots on startup
+ * - Consume-on-read pattern for single-use resume operations
+ */
+export class ToolUseSessionManager {
   private static readonly index =
     new StreamExecutionIndex<ToolUseSessionSnapshot>();
 
@@ -86,3 +105,8 @@ export class ToolUseSnapshotCache {
     logger.debug('Cleared all pending tool-use snapshots.');
   }
 }
+
+/**
+ * @deprecated Use ToolUseSessionManager instead. This alias will be removed in a future version.
+ */
+export const ToolUseSnapshotCache = ToolUseSessionManager;

--- a/src/progressView/styles/tabs.css
+++ b/src/progressView/styles/tabs.css
@@ -133,7 +133,6 @@
   border-radius: var(--border-radius-small);
 }
 
-
 .tab-delete:hover::part(control),
 .tab-delete:focus-within::part(control) {
   background-color: var(--vscode-toolbar-hoverBackground);
@@ -143,4 +142,3 @@
 .tab-delete:focus-within {
   color: var(--vscode-errorForeground);
 }
-

--- a/src/test/tools/BashTool.test.ts
+++ b/src/test/tools/BashTool.test.ts
@@ -24,6 +24,7 @@ import type { ExecResult } from '@agent/types/ResultTypes';
 import type { StreamTabId } from '@agent/types/IdentifierTypes';
 
 // Internal imports
+import { createToolRegistry } from '@agent/core/ToolTypes';
 import { AgentLogger } from '@logger/AgentLogger';
 import {
   DEFAULT_MODEL_CAPABILITIES,
@@ -169,7 +170,7 @@ describe('BashTool', () => {
       },
       logger: new AgentLogger('BashToolTest', true),
       client: {} as OpenAI,
-      toolRegistry: { bash: bashTool },
+      toolRegistry: createToolRegistry({ bash: bashTool }),
       checkInterruption: () => false,
       setAbortController: () => {},
       workspaceState,

--- a/src/tools/core/base.ts
+++ b/src/tools/core/base.ts
@@ -2,15 +2,23 @@
 import { ZodError, type ZodType } from 'zod';
 
 // Local imports - common
+
+// Local imports - core tool types (single source of truth)
+import type { ITool, ToolDefinition, ToolResult } from '@agent/core/ToolTypes';
+import { toolResult } from '@agent/core/ToolTypes';
 import { toErrorMessage } from '@common/errors';
 
-// Local imports - model
-import type { ToolDefinition } from '@model';
-
-// Internal imports - tools
-import { ToolResult, toolResult } from '@tools/result';
-
-export abstract class BaseTool<T> {
+/**
+ * Abstract base class for tool implementations.
+ *
+ * Implements the ITool interface and provides:
+ * - Zod schema validation
+ * - Centralized error handling with diagnostics
+ * - Type-safe input parsing
+ *
+ * Subclasses must implement the execute() method.
+ */
+export abstract class BaseTool<T> implements ITool {
   readonly definition: ToolDefinition;
   readonly schema: ZodType<T>;
 

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -71,6 +71,14 @@ export function getDefaultToolRegistry(): IToolRegistry {
 }
 
 /**
+ * Reset the default tool registry singleton.
+ * @internal For testing only - prevents state leakage between tests.
+ */
+export function resetDefaultToolRegistry(): void {
+  defaultRegistryInstance = null;
+}
+
+/**
  * Default tool registry as a Record.
  * @deprecated Prefer getDefaultToolRegistry() for IToolRegistry interface.
  */

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -1,6 +1,9 @@
+// Local imports - core types
+import type { ITool, IToolRegistry } from '@agent/core/ToolTypes';
+import { createToolRegistry } from '@agent/core/ToolTypes';
+
 // Local imports - tools
 import { BashTool } from './bash';
-import { BaseTool } from './core/base';
 import { DiagnosticsTool } from './DiagnosticsTool';
 import { ApplyPathTool } from './applyPath';
 import { EditFileTool } from './EditTool';
@@ -23,7 +26,11 @@ import { WolframTool } from './wolfram';
 import { TexcountTool } from './texcount';
 import { CrossrefDoiTool, CrossrefSearchTool } from './citation';
 
-export const DEFAULT_TOOL_REGISTRY: Record<string, BaseTool<any>> = {
+/**
+ * Default tool instances as a plain Record.
+ * @deprecated Use getDefaultToolRegistry() for IToolRegistry interface.
+ */
+const DEFAULT_TOOLS: Record<string, ITool> = {
   str_replace_editor: new TextEditorTool(),
   diagnostics: new DiagnosticsTool(),
   bash: new BashTool(),
@@ -48,3 +55,23 @@ export const DEFAULT_TOOL_REGISTRY: Record<string, BaseTool<any>> = {
   web_fetch: new WebFetchTool(),
   web_search: new WebSearchTool(),
 };
+
+/** Singleton IToolRegistry instance for the default tools. */
+let defaultRegistryInstance: IToolRegistry | null = null;
+
+/**
+ * Get the default tool registry as an IToolRegistry.
+ * Uses lazy initialization and singleton pattern.
+ */
+export function getDefaultToolRegistry(): IToolRegistry {
+  if (!defaultRegistryInstance) {
+    defaultRegistryInstance = createToolRegistry(DEFAULT_TOOLS);
+  }
+  return defaultRegistryInstance;
+}
+
+/**
+ * Default tool registry as a Record.
+ * @deprecated Prefer getDefaultToolRegistry() for IToolRegistry interface.
+ */
+export const DEFAULT_TOOL_REGISTRY: Record<string, ITool> = DEFAULT_TOOLS;

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -41,10 +41,7 @@ import {
   getSelectedOptionElement,
 } from '@common/domUtils.js';
 import { capitalize, uncapitalize } from '@common/stringUtils.js';
-import {
-  AGENT_DECORATORS,
-  getCodiconClass,
-} from '@common/iconConstants.js';
+import { AGENT_DECORATORS, getCodiconClass } from '@common/iconConstants.js';
 
 // Import standardized commands
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';


### PR DESCRIPTION
Core Type System:
- Add agent/core/ToolTypes.ts with ITool interface, IToolRegistry interface,
  MapToolRegistry implementation, and createToolRegistry() factory
- Update BaseTool to implement ITool interface
- Re-export ToolResult and related types from ToolTypes for consistency

Tool Registry:
- Add getDefaultToolRegistry() function returning IToolRegistry
- Deprecate direct Record<string, ITool> export in favor of IToolRegistry
- Update CycleServices.ToolUseCycleOptions to use IToolRegistry

Dependency Injection:
- Add BaseToolUseAgentOptions interface with optional toolRegistry
- BaseToolUseAgent constructor now accepts optional IToolRegistry
- Default to getDefaultToolRegistry() when not provided

Session Management:
- Rename ToolUseSnapshotCache class to ToolUseSessionManager
- Add deprecated ToolUseSnapshotCache alias for backward compatibility
- Update all imports to use ToolUseSessionManager

Index Exports:
- Export RunUsageAccumulator from agent/core/index.ts
- Export ToolTypes from agent/core/index.ts

Bug Fix:
- Fix AgentDataclass.ts missing import for AgentSessionDescriptor type

Minor:
- Formatting fixes from prettier/lint

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add a core ToolTypes module with ITool/IToolRegistry and migrate tool-use flows/agents to a registry-based DI model; rename ToolUseSnapshotCache to ToolUseSessionManager with alias and update references.
> 
> - **Core types and exports**:
>   - Add `agent/core/ToolTypes.ts` defining `ITool`, `IToolRegistry`, `MapToolRegistry`, and `createToolRegistry()`, and re-export `ToolResult`/`ToolDefinition`.
>   - Update `agent/core/index.ts` to export `RunUsageAccumulator` and `ToolTypes`.
> - **Tool registry and DI**:
>   - Update `CycleServices.ToolUseCycleOptions` to use `IToolRegistry`; `ToolUseCycleFlow` dispatch now uses `toolRegistry.get()`.
>   - `BaseToolUseAgent`: accepts optional `toolRegistry` and defaults via `getDefaultToolRegistry()`; tool presence checks use `has()`.
>   - `tools/core/base.ts`: `BaseTool` now implements `ITool` and uses core `ToolTypes`.
>   - `tools/registry.ts`: introduce `getDefaultToolRegistry()` singleton, `resetDefaultToolRegistry()`, and deprecate `DEFAULT_TOOL_REGISTRY` (now `Record<string, ITool>`); base tools collected in `DEFAULT_TOOLS`.
>   - Tests (`BashTool.test.ts`) updated to build registries with `createToolRegistry()`.
> - **Session management**:
>   - Rename `ToolUseSnapshotCache` class to `ToolUseSessionManager`; keep deprecated alias and add re-export module `ToolUseSessionManager.ts`.
>   - Update follow-up coordinator and persistence to use `ToolUseSessionManager` (`getByStream`, `cacheSnapshot`, `clear*`).
> - **Misc/bug fix**:
>   - Fix missing `AgentSessionDescriptor` import/export consistency.
>   - Minor formatting/import order cleanups.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 55f12d11ad11fdbdf4f68af37f8a59f2a021197a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->