### PR TITLE
Fix agent icon indicators not displaying

### DIFF
--- a/src/agent/computeAgentOptions.ts
+++ b/src/agent/computeAgentOptions.ts
@@ -80,11 +80,12 @@ export async function computeAgentOptions(): Promise<AgentOptionsPayload> {
       const remoteAgents = await RemoteAgentLoader.listRemoteAgents();
       remoteAgentNames = remoteAgents.map((agent) => agent.name);
 
-      // Register remote agents with their metadata (description from DB)
+      // Register remote agents with their metadata from DB
       RemoteAgentRegistry.registerMultiple(
         remoteAgents.map((agent) => ({
           name: agent.name,
           description: agent.description,
+          agentType: agent.agentType,
         })),
       );
     } catch (error) {

--- a/src/agent/computeAgentOptions.ts
+++ b/src/agent/computeAgentOptions.ts
@@ -80,8 +80,13 @@ export async function computeAgentOptions(): Promise<AgentOptionsPayload> {
       const remoteAgents = await RemoteAgentLoader.listRemoteAgents();
       remoteAgentNames = remoteAgents.map((agent) => agent.name);
 
-      // Register remote agents in the registry (no more remote:// prefix!)
-      RemoteAgentRegistry.registerMultiple(remoteAgentNames);
+      // Register remote agents with their metadata (description from DB)
+      RemoteAgentRegistry.registerMultiple(
+        remoteAgents.map((agent) => ({
+          name: agent.name,
+          description: agent.description,
+        })),
+      );
     } catch (error) {
       // Silently fail - user can still use local agents even if remote agent loading fails
       // The listRemoteAgents method already handles logging

--- a/src/agent/remote/RemoteAgentLoader.ts
+++ b/src/agent/remote/RemoteAgentLoader.ts
@@ -22,6 +22,7 @@ export interface RemoteAgentMetadata {
   description: string;
   tags: string[];
   visibility: 'public' | 'researcher' | 'whitelist';
+  agentType?: string;
 }
 
 export interface RemoteAgentConfig {
@@ -252,7 +253,7 @@ export class RemoteAgentLoader {
       // RLS will automatically filter based on user's permissions
       const { data, error } = await supabase
         .from('remote_agents')
-        .select('id, name, description, tags, visibility')
+        .select('id, name, description, tags, visibility, agent_type')
         .order('name');
 
       if (error) {
@@ -260,7 +261,15 @@ export class RemoteAgentLoader {
         return [];
       }
 
-      return (data || []) as RemoteAgentMetadata[];
+      // Map snake_case DB columns to camelCase interface
+      return (data || []).map((row) => ({
+        id: row.id,
+        name: row.name,
+        description: row.description,
+        tags: row.tags,
+        visibility: row.visibility,
+        agentType: row.agent_type,
+      })) as RemoteAgentMetadata[];
     } catch (error) {
       const errorMessage =
         error instanceof Error ? error.message : String(error);

--- a/src/agent/remote/RemoteAgentRegistry.ts
+++ b/src/agent/remote/RemoteAgentRegistry.ts
@@ -6,12 +6,18 @@ export interface RemoteAgentInfo {
   agentType?: string;
 }
 
+/** Persisted state structure for remote agent registry. */
+interface PersistedState {
+  agents: string[];
+  metadata: Record<string, RemoteAgentInfo>;
+}
+
 /**
  * Registry tracking remote agent status without prefix markers.
  * State is persisted to ExtensionContext.globalState for resilience across VS Code reloads.
  */
 class RemoteAgentRegistryClass {
-  private static readonly STORAGE_KEY = 'texra.remoteAgentRegistry';
+  private static readonly STORAGE_KEY = 'texra.remoteAgentRegistry.v2';
   private remoteAgents = new Set<string>();
   private agentMetadata = new Map<string, RemoteAgentInfo>();
   private context: vscode.ExtensionContext | null = null;
@@ -21,11 +27,13 @@ class RemoteAgentRegistryClass {
    */
   initialize(context: vscode.ExtensionContext): void {
     this.context = context;
-    const persisted = context.globalState.get<string[]>(
+    const persisted = context.globalState.get<PersistedState>(
       RemoteAgentRegistryClass.STORAGE_KEY,
-      [],
     );
-    this.remoteAgents = new Set(persisted);
+    if (persisted) {
+      this.remoteAgents = new Set(persisted.agents);
+      this.agentMetadata = new Map(Object.entries(persisted.metadata || {}));
+    }
   }
 
   /**
@@ -33,9 +41,13 @@ class RemoteAgentRegistryClass {
    */
   private async persist(): Promise<void> {
     if (this.context) {
+      const state: PersistedState = {
+        agents: Array.from(this.remoteAgents),
+        metadata: Object.fromEntries(this.agentMetadata),
+      };
       await this.context.globalState.update(
         RemoteAgentRegistryClass.STORAGE_KEY,
-        Array.from(this.remoteAgents),
+        state,
       );
     }
   }

--- a/src/agent/remote/RemoteAgentRegistry.ts
+++ b/src/agent/remote/RemoteAgentRegistry.ts
@@ -1,5 +1,11 @@
 import * as vscode from 'vscode';
 
+/** Metadata stored for each remote agent. */
+export interface RemoteAgentInfo {
+  description?: string;
+  agentType?: string;
+}
+
 /**
  * Registry tracking remote agent status without prefix markers.
  * State is persisted to ExtensionContext.globalState for resilience across VS Code reloads.
@@ -7,6 +13,7 @@ import * as vscode from 'vscode';
 class RemoteAgentRegistryClass {
   private static readonly STORAGE_KEY = 'texra.remoteAgentRegistry';
   private remoteAgents = new Set<string>();
+  private agentMetadata = new Map<string, RemoteAgentInfo>();
   private context: vscode.ExtensionContext | null = null;
 
   /**
@@ -42,10 +49,17 @@ class RemoteAgentRegistryClass {
   }
 
   /**
-   * Register multiple agents as remote.
+   * Register multiple agents as remote with optional metadata.
    */
-  registerMultiple(agentNames: string[]): void {
-    agentNames.forEach((name) => this.remoteAgents.add(name));
+  registerMultiple(
+    agents: Array<{ name: string; description?: string; agentType?: string }>,
+  ): void {
+    agents.forEach(({ name, description, agentType }) => {
+      this.remoteAgents.add(name);
+      if (description || agentType) {
+        this.agentMetadata.set(name, { description, agentType });
+      }
+    });
     void this.persist();
   }
 
@@ -80,6 +94,7 @@ class RemoteAgentRegistryClass {
    */
   clear(): void {
     this.remoteAgents.clear();
+    this.agentMetadata.clear();
     void this.persist();
   }
 
@@ -88,6 +103,14 @@ class RemoteAgentRegistryClass {
    */
   getAll(): string[] {
     return Array.from(this.remoteAgents);
+  }
+
+  /**
+   * Get metadata for a remote agent.
+   */
+  getMetadata(agentName: string): RemoteAgentInfo | undefined {
+    const cleanName = this.getCleanName(agentName);
+    return this.agentMetadata.get(cleanName);
   }
 }
 

--- a/src/agent/remote/RemoteAgentRegistry.ts
+++ b/src/agent/remote/RemoteAgentRegistry.ts
@@ -98,6 +98,7 @@ class RemoteAgentRegistryClass {
    */
   unregister(agentName: string): void {
     this.remoteAgents.delete(agentName);
+    this.agentMetadata.delete(agentName);
     void this.persist();
   }
 

--- a/src/agent/utils/agentOptionMetadata.ts
+++ b/src/agent/utils/agentOptionMetadata.ts
@@ -94,6 +94,7 @@ export function getAgentOptionMetadata(
       isMultipleOutput: false,
       isToolUse: false, // Remote agents are workflow agents by default
       isRemote: true,
+      agentType: 'unknown', // Remote agent type is determined server-side
     };
   }
 

--- a/src/agent/utils/agentOptionMetadata.ts
+++ b/src/agent/utils/agentOptionMetadata.ts
@@ -86,15 +86,17 @@ export function getAgentOptionMetadata(
   const isRemote = RemoteAgentRegistry.isRemote(agentName);
   const cleanName = RemoteAgentRegistry.getCleanName(agentName);
 
-  // Handle remote agents specially
+  // Handle remote agents specially - retrieve cached metadata from registry
   if (isRemote) {
+    const remoteMetadata = RemoteAgentRegistry.getMetadata(cleanName);
     return {
       hasDefinition: true, // Remote agents always have definitions (on server)
       hasMultipleSibling: false,
       isMultipleOutput: false,
       isToolUse: false, // Remote agents are workflow agents by default
       isRemote: true,
-      agentType: 'unknown', // Remote agent type is determined server-side
+      description: remoteMetadata?.description,
+      agentType: remoteMetadata?.agentType ?? 'unknown',
     };
   }
 

--- a/src/agent/utils/agentOptionMetadata.ts
+++ b/src/agent/utils/agentOptionMetadata.ts
@@ -93,7 +93,7 @@ export function getAgentOptionMetadata(
       hasDefinition: true, // Remote agents always have definitions (on server)
       hasMultipleSibling: false,
       isMultipleOutput: false,
-      isToolUse: false, // Remote agents are workflow agents by default
+      isToolUse: false, // isToolUse defaults to false for remote agents
       isRemote: true,
       description: remoteMetadata?.description,
       agentType: remoteMetadata?.agentType,

--- a/src/agent/utils/agentOptionMetadata.ts
+++ b/src/agent/utils/agentOptionMetadata.ts
@@ -26,6 +26,7 @@ export interface AgentOptionMetadata {
   isToolUse: boolean;
   isRemote: boolean;
   description?: string;
+  agentType?: string;
 }
 
 export interface AgentOptionsPayload {
@@ -118,6 +119,7 @@ export function getAgentOptionMetadata(
     isToolUse: parsed?.settings.agentType === TOOL_USE_AGENT_TYPE,
     isRemote: false,
     description: parsed?.description,
+    agentType: parsed?.settings.agentType,
   };
 }
 
@@ -164,6 +166,9 @@ export function createAgentOptionTag(
   }
   if (metadata.description) {
     attributes.push(`data-description="${encodeHtml(metadata.description)}"`);
+  }
+  if (metadata.agentType) {
+    attributes.push(`data-agent-type="${encodeHtml(metadata.agentType)}"`);
   }
   if (options.isSelected) {
     attributes.push('selected');

--- a/src/agent/utils/agentOptionMetadata.ts
+++ b/src/agent/utils/agentOptionMetadata.ts
@@ -96,7 +96,7 @@ export function getAgentOptionMetadata(
       isToolUse: false, // Remote agents are workflow agents by default
       isRemote: true,
       description: remoteMetadata?.description,
-      agentType: remoteMetadata?.agentType ?? 'unknown',
+      agentType: remoteMetadata?.agentType,
     };
   }
 

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -267,7 +267,7 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
 
     // Add description (primary info about the agent)
     if (description) {
-      hints.push(`Description: ${description}`);
+      hints.push(description);
     }
 
     // Add multiple outputs icon (using shared config)

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -255,7 +255,7 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
     if (agentType) {
       const decorator = getAgentTypeDecorator(agentType);
       prefixIcons.push(this._createCodiconHtml(decorator.icon));
-      hints.push(`${decorator.label} agent`);
+      hints.push(`Type: ${decorator.label}`);
     }
 
     // Add cloud icon for remote agents (using shared config)
@@ -265,9 +265,9 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
       hints.push(hint);
     }
 
-    // Add description as the primary hint if available
+    // Add description (primary info about the agent)
     if (description) {
-      hints.push(description);
+      hints.push(`Description: ${description}`);
     }
 
     // Add multiple outputs icon (using shared config)

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -41,7 +41,11 @@ import {
   getSelectedOptionElement,
 } from '@common/domUtils.js';
 import { capitalize, uncapitalize } from '@common/stringUtils.js';
-import { AGENT_DECORATORS, getCodiconClass } from '@common/iconConstants.js';
+import {
+  AGENT_DECORATORS,
+  getCodiconClass,
+  getAgentTypeDecorator,
+} from '@common/iconConstants.js';
 
 // Import standardized commands
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
@@ -240,12 +244,19 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
   }
 
   _decorateAgentOption(opt) {
-    const { label, isMultiple, isToolUse, isRemote, description } =
+    const { label, isMultiple, isToolUse, isRemote, description, agentType } =
       this._readAgentOptionMetadata(opt);
 
     const hints = [];
     const prefixIcons = [];
     const suffixIcons = [];
+
+    // Add agent type icon (CoT, direct, toolUse)
+    if (agentType) {
+      const decorator = getAgentTypeDecorator(agentType);
+      prefixIcons.push(this._createCodiconHtml(decorator.icon));
+      hints.push(`${decorator.label} agent`);
+    }
 
     // Add cloud icon for remote agents (using shared config)
     if (isRemote) {
@@ -331,6 +342,7 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
       isToolUse: opt.dataset.toolUse === 'true',
       isRemote: opt.dataset.remote === 'true',
       description: opt.dataset.description ?? '',
+      agentType: opt.dataset.agentType ?? '',
     };
   }
 


### PR DESCRIPTION
Add agent type (CoT, direct, toolUse) icons to the agent dropdown menu. The icon configuration existed but wasn't being passed through to the UI.

- Add agentType field to AgentOptionMetadata interface
- Include data-agent-type attribute in option HTML tags
- Update _decorateAgentOption to read and display agent type icons

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Propagates agentType from DB/local definitions through the registry to option tags and webview, adding type icons and persisting remote agent metadata.
> 
> - **Agents/Backend**:
>   - Remote agents: fetch `agent_type` from DB, map to `agentType`, and return via `listRemoteAgents`.
>   - Register remote agents with metadata (`name`, `description`, `agentType`) in `RemoteAgentRegistry` and persist new v2 state (agents + metadata); added `getMetadata`, metadata clearing on unregister/clear.
>   - `AgentOptionMetadata` extended with `agentType`; remote metadata sourced from registry; local metadata includes parsed `settings.agentType`.
>   - Option tags include `data-agent-type` attribute.
> - **Webview/UI**:
>   - Read `data-agent-type` and display corresponding icon/hint via `getAgentTypeDecorator` in the agent dropdown.
>   - Preserve existing remote/multiple indicators and descriptions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e468f651ca10d76b3aba313de52fe8ba2b787441. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->