### PR TITLE
Review OpenAI SDK for cleaner type usage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -282,7 +282,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -326,7 +325,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -777,7 +775,6 @@
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.22.0.tgz",
       "integrity": "sha512-VUpl106XVTCpDmTBil2ehgJZjhyLY2QZikzF8NvTXtLRF1CvO5iEE2UNZdVIUer35vFOwMKYeUGbjJtvPWan3g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
@@ -849,7 +846,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -1324,7 +1320,6 @@
       "integrity": "sha512-Ne4CTZyRh1BecBf84siv42wv5vQvVmgtk8AuiEffKTUo3DrBaGYZueJSxxBZ8fjk/N3DrgChH4TOdIOwOwiqqw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/tsconfig-utils": "^8.48.0",
         "@typescript-eslint/types": "^8.48.0",
@@ -1492,7 +1487,6 @@
       "integrity": "sha512-jCzKdm/QK0Kg4V4IK/oMlRZlY+QOcdjv89U2NgKHZk1CYTj82/RVSx1mV/0gqCVMJ/DA+Zf/S4NBWNF8GQ+eqQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.48.0",
         "@typescript-eslint/types": "8.48.0",
@@ -2416,7 +2410,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2964,7 +2957,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.9",
         "caniuse-lite": "^1.0.30001746",
@@ -4051,7 +4043,6 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4450,7 +4441,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
       "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.0",
@@ -8318,7 +8308,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -9441,7 +9430,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9510,7 +9498,6 @@
       "integrity": "sha512-lJi3PfxVmo0AkEY93ecfN+r8SofEqZNGByvHAI3GBLrvt1Cw6H5k1IM02nSzu0RfUafr2EvFSw0wAsZgubNplQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.47.0",
         "@typescript-eslint/types": "8.47.0",
@@ -9739,7 +9726,6 @@
       "integrity": "sha512-HU1JOuV1OavsZ+mfigY0j8d1TgQgbZ6M+J75zDkpEAwYeXjWSqrGJtgnPblJjd/mAyTNQ7ygw0MiKOn6etz8yw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -9789,7 +9775,6 @@
       "integrity": "sha512-MfwFQ6SfwinsUVi0rNJm7rHZ31GyTcpVE5pgVA3hwFRb7COD4TzjUUwhGWKfO50+xdc2MQPuEBBJoqIMGt3JDw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.6.1",
         "@webpack-cli/configtest": "^3.0.1",
@@ -10479,7 +10464,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.13.tgz",
       "integrity": "sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -82,7 +82,6 @@ import type {
   ResponseFunctionCallOutputItemList,
   ResponseOutputItem,
   ResponseOutputMessage,
-  ResponseOutputText,
   // Streaming event types
   ResponseTextDeltaEvent,
   ResponseReasoningTextDeltaEvent,
@@ -969,9 +968,9 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     const finalStatus = current.status;
 
     const isTerminal =
-      !!finalStatus &&
+      finalStatus !== undefined &&
       ModelHandlerOpenAIResponse.BACKGROUND_TERMINAL_STATUSES.includes(
-        finalStatus as ResponseStatus,
+        finalStatus,
       );
 
     if (!isTerminal) {

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -80,6 +80,9 @@ import type {
   ResponseStreamEvent,
   ResponseStatus,
   ResponseFunctionCallOutputItemList,
+  ResponseOutputItem,
+  ResponseOutputMessage,
+  ResponseOutputText,
 } from 'openai/resources/responses/responses';
 
 interface UploadedOpenAIResponseAttachment {
@@ -737,20 +740,13 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       const fallbackSegments: string[] = [];
 
       for (const item of responseObject.output) {
-        if (item.type !== 'message') {
+        if (!this.isOutputMessage(item)) {
           continue;
         }
 
-        const content = (item as { content?: unknown[] }).content;
-        if (!Array.isArray(content)) {
-          continue;
-        }
-
-        for (const part of content) {
-          const partType = (part as { type?: unknown }).type;
-          const partText = (part as { text?: unknown }).text;
-          if (partType === 'output_text' && typeof partText === 'string') {
-            fallbackSegments.push(partText);
+        for (const part of item.content) {
+          if (part.type === 'output_text') {
+            fallbackSegments.push(part.text);
           }
         }
       }
@@ -1545,6 +1541,11 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
 
     const content = (item as { content?: unknown }).content;
     return typeof content === 'string' || Array.isArray(content);
+  }
+
+  /** Type guard for ResponseOutputMessage items from the SDK. */
+  private isOutputMessage(item: ResponseOutputItem): item is ResponseOutputMessage {
+    return item.type === 'message';
   }
 
   private getMessageContent(

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -78,6 +78,7 @@ import type {
   ResponseInputText,
   ResponseInputAudio,
   ResponseStreamEvent,
+  ResponseStatus,
 } from 'openai/resources/responses/responses';
 
 interface UploadedOpenAIResponseAttachment {
@@ -159,16 +160,12 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
   private static readonly BACKGROUND_POLL_INTERVAL_MS = 15000;
   private static readonly BACKGROUND_RETRIEVE_MAX_RETRIES = 3;
   private static readonly BACKGROUND_MAX_DURATION_MS = 3 * 60 * 60 * 1000; // 3 hours
-  private static readonly BACKGROUND_PENDING_STATUSES = [
-    'queued',
-    'in_progress',
-  ] as const;
-  private static readonly BACKGROUND_TERMINAL_STATUSES = [
-    'completed',
-    'failed',
-    'cancelled',
-    'expired',
-  ] as const;
+  /** Statuses indicating the background response is still processing. */
+  private static readonly BACKGROUND_PENDING_STATUSES: readonly ResponseStatus[] =
+    ['queued', 'in_progress'];
+  /** Statuses indicating the background response has finished (success or failure). */
+  private static readonly BACKGROUND_TERMINAL_STATUSES: readonly ResponseStatus[] =
+    ['completed', 'failed', 'cancelled', 'incomplete'];
   private previousResponseId: string | null = null;
   private sentMessages = 0;
 
@@ -853,7 +850,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     }
 
     return ModelHandlerOpenAIResponse.BACKGROUND_PENDING_STATUSES.includes(
-      status as (typeof ModelHandlerOpenAIResponse.BACKGROUND_PENDING_STATUSES)[number],
+      status,
     );
   }
 
@@ -981,7 +978,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     const isTerminal =
       !!finalStatus &&
       ModelHandlerOpenAIResponse.BACKGROUND_TERMINAL_STATUSES.includes(
-        finalStatus as (typeof ModelHandlerOpenAIResponse.BACKGROUND_TERMINAL_STATUSES)[number],
+        finalStatus as ResponseStatus,
       );
 
     if (!isTerminal) {

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -37,7 +37,7 @@ import type { FileLocation } from '@utils/files';
 
 // Internal imports
 import { K_SLICE, getConfig } from '@utils/config';
-import { sleep } from '@utils/helpers';
+import { sleepWithAbort } from '@utils/helpers';
 import { WorkspaceFS, flexibleFS, pathToLocation } from '@utils/files';
 import xmlUtils from '@utils/text/xmlUtils';
 
@@ -888,7 +888,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         },
       );
       try {
-        await this.waitWithAbort(pollInterval, signal);
+        await sleepWithAbort(pollInterval, signal);
       } catch (err) {
         if (err instanceof DOMException && err.name === 'AbortError') {
           this.logger.warn(
@@ -1011,56 +1011,6 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     }
 
     return current;
-  }
-
-  private async waitWithAbort(ms: number, signal?: AbortSignal): Promise<void> {
-    if (!signal) {
-      await sleep(ms);
-      return;
-    }
-
-    if (signal.aborted) {
-      throw new DOMException('The operation was aborted.', 'AbortError');
-    }
-
-    const supportsAbortTimeout = typeof AbortSignal.timeout === 'function';
-
-    await new Promise<void>((resolve, reject) => {
-      let timeoutId: NodeJS.Timeout | undefined;
-      let timeoutSignal: AbortSignal | undefined;
-
-      const cleanup = () => {
-        signal.removeEventListener('abort', onAbort);
-        timeoutSignal?.removeEventListener('abort', onTimeout);
-        if (timeoutId) {
-          clearTimeout(timeoutId);
-          timeoutId = undefined;
-        }
-      };
-
-      const onAbort = () => {
-        if (timeoutId) {
-          clearTimeout(timeoutId);
-          timeoutId = undefined;
-        }
-        cleanup();
-        reject(new DOMException('The operation was aborted.', 'AbortError'));
-      };
-
-      const onTimeout = () => {
-        cleanup();
-        resolve();
-      };
-
-      signal.addEventListener('abort', onAbort, { once: true });
-
-      if (supportsAbortTimeout) {
-        timeoutSignal = AbortSignal.timeout(ms);
-        timeoutSignal.addEventListener('abort', onTimeout, { once: true });
-      } else {
-        timeoutId = setTimeout(onTimeout, ms);
-      }
-    });
   }
 
   /** Adds continuation instructions for models without prefill support. */

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -60,7 +60,7 @@ import type {
   OpenAIResponseToolCall,
 } from './types/IModelHandler';
 import type { ResponseStreamParams } from 'openai/lib/responses/ResponseStream';
-import type { Reasoning } from 'openai/resources/shared';
+import type { Reasoning, ReasoningEffort } from 'openai/resources/shared';
 import type {
   EasyInputMessage,
   Response,
@@ -79,6 +79,7 @@ import type {
   ResponseInputAudio,
   ResponseStreamEvent,
   ResponseStatus,
+  ResponseFunctionCallOutputItemList,
 } from 'openai/resources/responses/responses';
 
 interface UploadedOpenAIResponseAttachment {
@@ -608,7 +609,8 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         reasoning.summary = 'auto';
       }
       if (this.capabilities.supportsReasoningEffort) {
-        reasoning.effort = 'high';
+        const effort: ReasoningEffort = 'high';
+        reasoning.effort = effort;
       }
       params.reasoning = reasoning;
     }
@@ -1401,14 +1403,12 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       ? `${primaryText}\n\n${summaryPayload}`
       : summaryPayload;
 
-    let outputPayload:
-      | string
-      | Array<ResponseInputText | ResponseInputImage | ResponseInputFile>;
+    let outputPayload: string | ResponseFunctionCallOutputItemList;
 
     if (uploadedAttachments.length > 0) {
-      const parts: Array<
-        ResponseInputText | ResponseInputImage | ResponseInputFile
-      > = [{ type: 'input_text', text: combinedText }];
+      const parts: ResponseFunctionCallOutputItemList = [
+        { type: 'input_text', text: combinedText },
+      ];
 
       for (const uploaded of uploadedAttachments) {
         if (supportsInlineImages && uploaded.isImage) {

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -83,6 +83,10 @@ import type {
   ResponseOutputItem,
   ResponseOutputMessage,
   ResponseOutputText,
+  // Streaming event types
+  ResponseTextDeltaEvent,
+  ResponseReasoningTextDeltaEvent,
+  ResponseReasoningSummaryTextDeltaEvent,
 } from 'openai/resources/responses/responses';
 
 interface UploadedOpenAIResponseAttachment {
@@ -634,20 +638,11 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       const output = this.isOutputStreamingEnabled()
         ? this.createOutputStream()
         : undefined;
-      const responseStream: AsyncIterable<ResponseStreamEvent> = stream;
-      for await (const event of responseStream) {
-        switch (event.type) {
-          case 'response.reasoning_text.delta':
-          case 'response.reasoning_summary_text.delta': {
-            thinking.append(event.delta);
-            break;
-          }
-          case 'response.output_text.delta': {
-            output?.append(event.delta);
-            break;
-          }
-          default:
-            break;
+      for await (const event of stream) {
+        if (this.isReasoningDeltaEvent(event)) {
+          thinking.append(event.delta);
+        } else if (this.isTextDeltaEvent(event)) {
+          output?.append(event.delta);
         }
       }
 
@@ -1546,6 +1541,23 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
   /** Type guard for ResponseOutputMessage items from the SDK. */
   private isOutputMessage(item: ResponseOutputItem): item is ResponseOutputMessage {
     return item.type === 'message';
+  }
+
+  /** Type alias for reasoning delta events (both raw and summary). */
+  private isReasoningDeltaEvent(
+    event: ResponseStreamEvent,
+  ): event is ResponseReasoningTextDeltaEvent | ResponseReasoningSummaryTextDeltaEvent {
+    return (
+      event.type === 'response.reasoning_text.delta' ||
+      event.type === 'response.reasoning_summary_text.delta'
+    );
+  }
+
+  /** Type guard for text output delta events. */
+  private isTextDeltaEvent(
+    event: ResponseStreamEvent,
+  ): event is ResponseTextDeltaEvent {
+    return event.type === 'response.output_text.delta';
   }
 
   private getMessageContent(

--- a/src/agent/modelHandlers/types/StopReasonTypes.ts
+++ b/src/agent/modelHandlers/types/StopReasonTypes.ts
@@ -33,7 +33,14 @@ export const OPENAI_COMPLETION_FINISH_REASONS = Object.values(
 export type OpenAICompletionFinishReason =
   (typeof OPENAI_COMPLETION_FINISH_REASONS)[number];
 
-/** Status values used by the OpenAI Responses API. */
+/**
+ * Status values used by the OpenAI Responses API.
+ * Re-exported from the SDK for convenience; the SDK's ResponseStatus type
+ * is the single source of truth.
+ */
+export { type ResponseStatus as OpenAIResponseStatus } from 'openai/resources/responses/responses';
+
+/** Constants matching SDK's ResponseStatus for runtime checks. */
 export const OPENAI_RESPONSE_STATUS = {
   COMPLETED: 'completed',
   FAILED: 'failed',
@@ -41,9 +48,7 @@ export const OPENAI_RESPONSE_STATUS = {
   CANCELLED: 'cancelled',
   QUEUED: 'queued',
   INCOMPLETE: 'incomplete',
-} as const;
-export const OPENAI_RESPONSE_STATUSES = Object.values(OPENAI_RESPONSE_STATUS);
-export type OpenAIResponseStatus = (typeof OPENAI_RESPONSE_STATUSES)[number];
+} as const satisfies Record<string, import('openai/resources/responses/responses').ResponseStatus>;
 
 /** Stop reasons defined in the Model Context Protocol SDK. */
 export const MCP_STOP = {

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -7,3 +7,65 @@
 export async function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
+
+/**
+ * Wait for the specified duration with support for AbortSignal cancellation.
+ * If the signal is aborted before the timeout completes, throws an AbortError.
+ * Uses AbortSignal.timeout() when available for better performance.
+ *
+ * @param ms Number of milliseconds to wait
+ * @param signal Optional AbortSignal to allow cancellation
+ * @throws DOMException with name 'AbortError' if signal is aborted
+ */
+export async function sleepWithAbort(
+  ms: number,
+  signal?: AbortSignal,
+): Promise<void> {
+  if (!signal) {
+    await sleep(ms);
+    return;
+  }
+
+  if (signal.aborted) {
+    throw new DOMException('The operation was aborted.', 'AbortError');
+  }
+
+  const supportsAbortTimeout = typeof AbortSignal.timeout === 'function';
+
+  await new Promise<void>((resolve, reject) => {
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+    let timeoutSignal: AbortSignal | undefined;
+
+    const cleanup = () => {
+      signal.removeEventListener('abort', onAbort);
+      timeoutSignal?.removeEventListener('abort', onTimeout);
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+        timeoutId = undefined;
+      }
+    };
+
+    const onAbort = () => {
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+        timeoutId = undefined;
+      }
+      cleanup();
+      reject(new DOMException('The operation was aborted.', 'AbortError'));
+    };
+
+    const onTimeout = () => {
+      cleanup();
+      resolve();
+    };
+
+    signal.addEventListener('abort', onAbort, { once: true });
+
+    if (supportsAbortTimeout) {
+      timeoutSignal = AbortSignal.timeout(ms);
+      timeoutSignal.addEventListener('abort', onTimeout, { once: true });
+    } else {
+      timeoutId = setTimeout(onTimeout, ms);
+    }
+  });
+}

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -46,10 +46,6 @@ export async function sleepWithAbort(
     };
 
     const onAbort = () => {
-      if (timeoutId) {
-        clearTimeout(timeoutId);
-        timeoutId = undefined;
-      }
       cleanup();
       reject(new DOMException('The operation was aborted.', 'AbortError'));
     };


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Reworks OpenAI Responses handler to use SDK-native types, introduces abortable sleep for background polling, and simplifies streaming/output handling with stricter type guards.
> 
> - **OpenAI Responses handler (`src/agent/modelHandlers/modelHandlerOpenAIResponse.ts`)**:
>   - Use SDK types (`ResponseStatus`, `ReasoningEffort`, streaming delta events) and new type guards (`isOutputMessage`, `isReasoningDeltaEvent`, `isTextDeltaEvent`).
>   - Simplify streaming loop to append reasoning/output deltas; refine output text fallback parsing via typed items.
>   - Background polling: replace custom wait with `sleepWithAbort`; use typed pending/terminal statuses; update terminal set to include `incomplete`.
>   - Reasoning config: explicitly set `effort` with typed value.
>   - Tool call follow-up: switch `output` to `ResponseFunctionCallOutputItemList` and construct typed parts (text/image/file).
> - **Types (`src/agent/modelHandlers/types/StopReasonTypes.ts`)**:
>   - Re-export `ResponseStatus` from SDK and type-check `OPENAI_RESPONSE_STATUS` via `satisfies`; remove custom union derivation.
> - **Utils (`src/utils/helpers.ts`)**:
>   - Add `sleepWithAbort(ms, signal)` for abortable delays; keep `sleep`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2da5960823a96355db44e6e0fbe11ef801d0c84d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->