### PR TITLE
Explore Anthropic SDK types for cleaner code

### DIFF
--- a/src/agent/core/AgentWorkspaceState.ts
+++ b/src/agent/core/AgentWorkspaceState.ts
@@ -4,12 +4,17 @@ import { z } from 'zod';
 /**
  * Thinking block from reasoning models.
  * This represents the internal reasoning/thinking output from models like Claude Sonnet 4.
- * Uses a flexible structure to accommodate different provider formats.
+ * Supports both regular thinking blocks and redacted thinking blocks from Anthropic.
  */
 export interface ThinkingBlock {
+  /** Block type: 'thinking' for regular, 'redacted_thinking' for redacted */
   type: string;
-  thinking?: unknown;
-  [key: string]: unknown;
+  /** Thinking content (for regular thinking blocks) */
+  thinking?: string;
+  /** Signature for verification (for regular thinking blocks from Anthropic) */
+  signature?: string;
+  /** Encrypted data (for redacted thinking blocks from Anthropic) */
+  data?: string;
 }
 
 /**
@@ -184,12 +189,12 @@ export class DocumentStatsState {
   }
 }
 
-export const ThinkingBlockSchema = z
-  .object({
-    type: z.string(),
-    thinking: z.unknown().optional(),
-  })
-  .passthrough();
+export const ThinkingBlockSchema = z.object({
+  type: z.string(),
+  thinking: z.string().optional(),
+  signature: z.string().optional(),
+  data: z.string().optional(),
+});
 
 export const AgentWorkspaceStateSnapshotSchema = z.strictObject({
   assembly: z.strictObject({

--- a/src/agent/core/ResponseUsage.ts
+++ b/src/agent/core/ResponseUsage.ts
@@ -1,5 +1,9 @@
 // Third-party imports
-import type { Usage as AnthropicUsage } from '@anthropic-ai/sdk/resources/messages';
+import type {
+  Usage as AnthropicUsage,
+  CacheCreation,
+  ServerToolUsage,
+} from '@anthropic-ai/sdk/resources/messages';
 import type { GenerateContentResponseUsageMetadata } from '@google/genai';
 import type { CompletionUsage } from 'openai/resources/completions';
 
@@ -23,6 +27,8 @@ export interface ExtendedCompletionUsage extends CompletionUsage {
 export type {
   CompletionUsage,
   AnthropicUsage,
+  CacheCreation,
+  ServerToolUsage,
   GenerateContentResponseUsageMetadata,
 };
 
@@ -61,6 +67,12 @@ export interface AnthropicAPIResponseUsage extends ResponseUsageBase {
   output_tokens: number;
   cache_read_input_tokens: number | null;
   cache_creation_input_tokens: number | null;
+  /** Breakdown of cache creation tokens by TTL (5m vs 1h) */
+  cache_creation: CacheCreation | null;
+  /** Server tool usage statistics (e.g., web search requests) */
+  server_tool_use: ServerToolUsage | null;
+  /** Service tier used for the request (standard, priority, or batch) */
+  service_tier: 'standard' | 'priority' | 'batch' | null;
   // Optional field surfaced by compatibility layers that expose tool-use costs.
   tool_use_tokens?: number;
 }
@@ -146,11 +158,14 @@ export class ResponseUsageFactory {
       percentageCached,
       cost,
       responseTime,
-      // Anthropic specific fields (keeping snake_case)
+      // Anthropic specific fields (keeping snake_case to match SDK)
       input_tokens: responseUsage.input_tokens,
       output_tokens: responseUsage.output_tokens,
       cache_read_input_tokens: cacheReadInputTokens,
       cache_creation_input_tokens: cacheCreationInputTokens,
+      cache_creation: responseUsage.cache_creation ?? null,
+      server_tool_use: responseUsage.server_tool_use ?? null,
+      service_tier: responseUsage.service_tier ?? null,
     };
   }
 }

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -563,11 +563,8 @@ export class ModelHandlerAnthropic extends ModelHandler<
           response = await stream.finalMessage();
           const finalReasoning = this.processThinkingBlock(response);
           thinking.finalize(finalReasoning ?? undefined);
-          const finalOutput =
-            response.content
-              ?.filter((c: any) => c.type === 'text')
-              ?.map((c: any) => c.text)
-              .join('') ?? '';
+          // Use SDK's finalText() method to extract concatenated text content
+          const finalOutput = await stream.finalText();
           if (output) output.finalize(finalOutput);
         } finally {
           cleanupAbortListener?.();

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -89,14 +89,15 @@ import type {
 } from './types/IModelHandler';
 import type { AnthropicBeta } from '@anthropic-ai/sdk/resources/beta/beta';
 import type {
+  BetaContentBlock,
   BetaContextManagementConfig,
   BetaImageBlockParam,
   BetaMessage,
+  BetaRedactedThinkingBlock,
   BetaRequestDocumentBlock,
-  BetaTextBlockParam,
+  BetaThinkingBlock,
   MessageCountTokensParams,
   MessageCreateParams,
-  BetaToolResultBlockParam,
 } from '@anthropic-ai/sdk/resources/beta/messages';
 import type {
   Base64ImageSource,
@@ -108,7 +109,46 @@ import type {
   TextBlockParam,
   ImageBlockParam,
   DocumentBlockParam,
+  ThinkingBlockParam,
+  RedactedThinkingBlockParam,
 } from '@anthropic-ai/sdk/resources/messages';
+
+/**
+ * Union type for thinking content blocks from Anthropic Beta API responses.
+ * These blocks contain the model's internal reasoning process.
+ * Uses Beta types since BetaMessage.content returns BetaContentBlock[].
+ */
+type BetaThinkingContent = BetaThinkingBlock | BetaRedactedThinkingBlock;
+
+/**
+ * Union type for thinking block params used in API requests.
+ * Used when including thinking blocks in follow-up messages.
+ */
+type AnthropicThinkingContentParam = ThinkingBlockParam | RedactedThinkingBlockParam;
+
+/** Type guard for Anthropic thinking blocks in Beta API responses */
+const isBetaThinkingBlock = (block: BetaContentBlock): block is BetaThinkingBlock =>
+  block.type === 'thinking';
+
+/** Type guard for Anthropic redacted thinking blocks in Beta API responses */
+const isBetaRedactedThinkingBlock = (block: BetaContentBlock): block is BetaRedactedThinkingBlock =>
+  block.type === 'redacted_thinking';
+
+/** Type guard for any thinking-related content block in Beta API responses */
+const isAnyBetaThinkingBlock = (block: BetaContentBlock): block is BetaThinkingContent =>
+  isBetaThinkingBlock(block) || isBetaRedactedThinkingBlock(block);
+
+/** Type guard for thinking block params in message content */
+const isThinkingBlockParam = (block: ContentBlockParam): block is ThinkingBlockParam =>
+  block.type === 'thinking';
+
+/** Type guard for redacted thinking block params in message content */
+const isRedactedThinkingBlockParam = (block: ContentBlockParam): block is RedactedThinkingBlockParam =>
+  block.type === 'redacted_thinking';
+
+/** Type guard for any thinking-related content block param */
+const isAnyThinkingBlockParam = (block: ContentBlockParam): block is AnthropicThinkingContentParam =>
+  isThinkingBlockParam(block) || isRedactedThinkingBlockParam(block);
 
 /**
  * Anthropic-specific model handler implementation for managing API interactions and message processing.
@@ -123,9 +163,14 @@ const CONTEXT_MANAGEMENT_BETA: AnthropicBeta = 'context-management-2025-06-27';
 
 const ANTHROPIC_1M_CONTEXT_WINDOW = 1_000_000;
 
-type CacheControlEligibleBlock =
-  | (ContentBlockParam & BetaTextBlockParam)
-  | (ContentBlockParam & BetaToolResultBlockParam);
+/**
+ * Block types that support cache_control for prompt caching.
+ * Uses SDK's ContentBlockParam with Extract to get text and tool_result types.
+ */
+type CacheControlEligibleBlock = Extract<
+  ContentBlockParam,
+  { type: 'text' | 'tool_result' }
+>;
 
 const EPHEMERAL_CACHE_CONTROL: CacheControlEphemeral = {
   type: 'ephemeral',
@@ -993,7 +1038,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
           type: 'text',
           text: `${isPdf ? 'Document' : 'Image'}: ${media.file_name}`,
           citations: null,
-        } satisfies BetaTextBlockParam;
+        } satisfies TextBlockParam;
 
         if (isPdf) {
           const documentBlock = {
@@ -1390,10 +1435,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
       if (secondLastMessage && secondLastMessage.role === 'assistant') {
         // Preserve any thinking blocks that might exist in the content array
         const thinkingBlocks = Array.isArray(secondLastMessage.content)
-          ? secondLastMessage.content.filter(
-              (item) =>
-                item.type === 'thinking' || item.type === 'redacted_thinking',
-            )
+          ? secondLastMessage.content.filter(isAnyThinkingBlockParam)
           : [];
 
         // Text blocks filtering removed - was unused
@@ -1452,9 +1494,10 @@ export class ModelHandlerAnthropic extends ModelHandler<
           `Adding ${workspaceState.reasoning.thinkingBlocks.length} thinking blocks to new assistant message`,
         );
         if (Array.isArray(assistantMessage.content)) {
+          // Include thinking blocks from workspace state in the message content
           assistantMessage.content.push(
             ...(workspaceState.reasoning
-              .thinkingBlocks as unknown as ContentBlockParam[]),
+              .thinkingBlocks as AnthropicThinkingContentParam[]),
           );
         }
         // Clear cached thinking so the next response can store fresh blocks
@@ -1534,21 +1577,21 @@ export class ModelHandlerAnthropic extends ModelHandler<
       return null;
     }
 
-    // Extract all thinking blocks from the response
-    const thinkingBlocks = [];
-    let regularThinkingContent = null;
+    // Extract all thinking blocks from the response using SDK type guards
+    const thinkingBlocks: BetaThinkingContent[] = [];
+    let regularThinkingContent: string | null = null;
 
     try {
       if (responseObject.content && Array.isArray(responseObject.content)) {
-        // Collect all thinking and redacted_thinking blocks
+        // Collect all thinking and redacted_thinking blocks using type guards
         for (const item of responseObject.content) {
-          if (item.type === 'thinking' && item.thinking) {
+          if (isBetaThinkingBlock(item) && item.thinking) {
             thinkingBlocks.push(item);
             // Save the first regular thinking content for returning
             if (regularThinkingContent === null) {
               regularThinkingContent = item.thinking;
             }
-          } else if (item.type === 'redacted_thinking' && item.data) {
+          } else if (isBetaRedactedThinkingBlock(item) && item.data) {
             thinkingBlocks.push(item);
           }
         }
@@ -1574,8 +1617,9 @@ export class ModelHandlerAnthropic extends ModelHandler<
         regularThinkingContent &&
         !this.containCutOffMessage(regularThinkingContent)
       ) {
+        // Store SDK thinking blocks in workspace state for conversation continuation
         workspaceState.reasoning.thinkingBlocks =
-          thinkingBlocks as unknown as ThinkingBlock[];
+          thinkingBlocks as ThinkingBlock[];
         // thinkingBlock is now a getter that returns thinkingBlocks[0]
         workspaceState.reasoning.thinkingAdded = true;
         this.logger.debug(

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -5,19 +5,14 @@ import { basename } from 'node:path';
 // Third-party imports
 import { Anthropic, toFile } from '@anthropic-ai/sdk';
 
+/** Supported image media types from SDK's Base64ImageSource definition */
+const SUPPORTED_IMAGE_MEDIA_TYPES: ReadonlySet<Base64ImageSource['media_type']> =
+  new Set(['image/jpeg', 'image/png', 'image/gif', 'image/webp']);
+
 const isSupportedImageMediaType = (
   mediaType: string,
-): mediaType is BetaBase64ImageSource['media_type'] => {
-  switch (mediaType) {
-    case 'image/jpeg':
-    case 'image/png':
-    case 'image/gif':
-    case 'image/webp':
-      return true;
-    default:
-      return false;
-  }
-};
+): mediaType is Base64ImageSource['media_type'] =>
+  SUPPORTED_IMAGE_MEDIA_TYPES.has(mediaType as Base64ImageSource['media_type']);
 
 interface UploadedAnthropicAttachment {
   attachment: ToolFileAttachment;
@@ -94,8 +89,6 @@ import type {
 } from './types/IModelHandler';
 import type { AnthropicBeta } from '@anthropic-ai/sdk/resources/beta/beta';
 import type {
-  BetaBase64ImageSource,
-  BetaCacheControlEphemeral,
   BetaContextManagementConfig,
   BetaImageBlockParam,
   BetaMessage,
@@ -106,6 +99,8 @@ import type {
   BetaToolResultBlockParam,
 } from '@anthropic-ai/sdk/resources/beta/messages';
 import type {
+  Base64ImageSource,
+  CacheControlEphemeral,
   MessageParam,
   ContentBlock,
   ContentBlockParam,
@@ -132,7 +127,7 @@ type CacheControlEligibleBlock =
   | (ContentBlockParam & BetaTextBlockParam)
   | (ContentBlockParam & BetaToolResultBlockParam);
 
-const EPHEMERAL_CACHE_CONTROL: BetaCacheControlEphemeral = {
+const EPHEMERAL_CACHE_CONTROL: CacheControlEphemeral = {
   type: 'ephemeral',
 };
 
@@ -1013,7 +1008,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
           return [descriptionBlock, documentBlock];
         }
 
-        let imageMediaType: BetaBase64ImageSource['media_type'];
+        let imageMediaType: Base64ImageSource['media_type'];
         if (isSupportedImageMediaType(resolvedMediaType)) {
           imageMediaType = resolvedMediaType;
         } else {
@@ -1706,7 +1701,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
       if (uploaded.blockType === 'image') {
         if (supportsInlineImages && uploaded.base64Data) {
           const mediaType =
-            (uploaded.mediaType as BetaBase64ImageSource['media_type']) ??
+            (uploaded.mediaType as Base64ImageSource['media_type']) ??
             'image/png';
           toolResultContent.push({
             type: 'image',

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -6,13 +6,17 @@ import { basename } from 'node:path';
 import { Anthropic, toFile } from '@anthropic-ai/sdk';
 
 /** Supported image media types from SDK's Base64ImageSource definition */
-const SUPPORTED_IMAGE_MEDIA_TYPES: ReadonlySet<Base64ImageSource['media_type']> =
-  new Set(['image/jpeg', 'image/png', 'image/gif', 'image/webp']);
+const SUPPORTED_IMAGE_MEDIA_TYPES: ReadonlySet<string> = new Set([
+  'image/jpeg',
+  'image/png',
+  'image/gif',
+  'image/webp',
+]);
 
 const isSupportedImageMediaType = (
   mediaType: string,
 ): mediaType is Base64ImageSource['media_type'] =>
-  SUPPORTED_IMAGE_MEDIA_TYPES.has(mediaType as Base64ImageSource['media_type']);
+  SUPPORTED_IMAGE_MEDIA_TYPES.has(mediaType);
 
 interface UploadedAnthropicAttachment {
   attachment: ToolFileAttachment;
@@ -1676,9 +1680,10 @@ export class ModelHandlerAnthropic extends ModelHandler<
       workspaceState.reasoning.thinkingBlocks.length > 0
     ) {
       // Anthropic models expect thinking blocks before text
+      // Include thinking blocks from workspace state as SDK thinking params
       content.push(
         ...(workspaceState.reasoning
-          .thinkingBlocks as unknown as ContentBlockParam[]),
+          .thinkingBlocks as AnthropicThinkingContentParam[]),
       );
       // Clear cached thinking so the next response can store fresh blocks
       workspaceState.resetReasoning();

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -154,6 +154,10 @@ const isRedactedThinkingBlockParam = (block: ContentBlockParam): block is Redact
 const isAnyThinkingBlockParam = (block: ContentBlockParam): block is AnthropicThinkingContentParam =>
   isThinkingBlockParam(block) || isRedactedThinkingBlockParam(block);
 
+/** Type guard for tool use blocks in Beta API responses */
+const isBetaToolUseBlock = (block: BetaContentBlock): block is ToolUseBlock =>
+  block.type === 'tool_use';
+
 /**
  * Anthropic-specific model handler implementation for managing API interactions and message processing.
  */
@@ -1642,9 +1646,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
       return [];
     }
 
-    const toolUseBlocks = responseObject.content.filter(
-      (block): block is ToolUseBlock => block?.type === 'tool_use',
-    );
+    const toolUseBlocks = responseObject.content.filter(isBetaToolUseBlock);
 
     if (toolUseBlocks.length === 0) {
       return [];

--- a/src/agent/modelHandlers/types/StopReasonTypes.ts
+++ b/src/agent/modelHandlers/types/StopReasonTypes.ts
@@ -1,5 +1,6 @@
 // Third-party imports
 import { FinishReason } from '@google/genai';
+import type { StopReason as AnthropicSDKStopReason } from '@anthropic-ai/sdk/resources/messages';
 
 /**
  * Finish reasons returned by the OpenAI Chat Completion API.
@@ -54,7 +55,10 @@ export const MCP_STOP = {
 export const MCP_STOP_REASONS = Object.values(MCP_STOP);
 export type MCPStopReason = (typeof MCP_STOP_REASONS)[number];
 
-/** Stop reasons for Anthropic models. */
+/**
+ * Stop reasons for Anthropic models.
+ * Runtime constants for comparison - values match SDK's StopReason type.
+ */
 export const ANTHROPIC_STOP = {
   END_TURN: 'end_turn',
   MAX_TOKENS: 'max_tokens',
@@ -62,9 +66,10 @@ export const ANTHROPIC_STOP = {
   TOOL_USE: 'tool_use',
   PAUSE_TURN: 'pause_turn',
   REFUSAL: 'refusal',
-} as const;
+} as const satisfies Record<string, AnthropicSDKStopReason>;
 export const ANTHROPIC_STOP_REASONS = Object.values(ANTHROPIC_STOP);
-export type AnthropicStopReason = (typeof ANTHROPIC_STOP_REASONS)[number];
+/** Anthropic stop reason type - derived from SDK's StopReason */
+export type AnthropicStopReason = AnthropicSDKStopReason;
 
 /** Finish reasons returned by Google's API. */
 export const GOOGLE_FINISH_REASONS = [


### PR DESCRIPTION
- Replace BetaCacheControlEphemeral with stable CacheControlEphemeral
- Replace BetaBase64ImageSource with Base64ImageSource from main namespace
- Simplify image media type validation using SDK type and Set lookup
- Derive AnthropicStopReason from SDK's StopReason type with satisfies check
- Add better documentation for SDK-derived types

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches to stable Anthropic SDK types, adds support for thinking/redacted thinking blocks, and exposes additional Anthropic usage fields.
> 
> - **Reasoning/State**:
>   - Extend `ThinkingBlock` and `ThinkingBlockSchema` to support Anthropic `thinking` and `redacted_thinking` (with `signature`/`data`).
>   - Store/propagate Anthropic thinking blocks in `ReasoningCacheState` and across message flows.
> - **Model Handler (Anthropic)**:
>   - Replace beta types with stable SDK types (`Base64ImageSource`, `CacheControlEphemeral`); simplify image media-type validation via set lookup.
>   - Add precise type guards for thinking/tool_use blocks; use them to extract, persist, and resend thinking content.
>   - Use `stream.finalText()` for final output; refine cache-control typing via `Extract<ContentBlockParam, {type: 'text'|'tool_result'}>`.
>   - Include cached thinking blocks before text in assistant/tool messages; reset after use.
> - **Usage Metrics**:
>   - Re-export and surface Anthropic `cache_creation`, `server_tool_use`, and `service_tier` on `AnthropicAPIResponseUsage` and in factory mapping.
> - **Stop Reasons**:
>   - Derive `AnthropicStopReason` from SDK and validate constants with `satisfies`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b4625fb219a462671db4d042d153920606b48057. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->