### PR TITLE
Finalize and verify mathematical calculations

### DIFF
--- a/src/agent/core/ResponseCycle.ts
+++ b/src/agent/core/ResponseCycle.ts
@@ -39,10 +39,12 @@ export interface ResponseCycleResult {
   endTurn: boolean;
   /** Callbacks for triggering manual retry from UI. */
   retryCallbacks: RetryCallbacks;
-  /** True if the cycle stopped due to an error (not user interruption). */
+  /** True if the cycle stopped due to an error (not user cancellation). */
   failedWithError: boolean;
   /** Error message if failedWithError is true. */
   errorMessage?: string;
+  /** True if the user cancelled the retry wait (should stop gracefully). */
+  userCancelled: boolean;
 }
 
 /**
@@ -93,8 +95,12 @@ export async function runResponseCycle<C = unknown>(
   flow.setParams({ services: { options: input.options, store: input.store } });
   await flow.run(shared);
 
-  // Determine if the cycle failed due to an error (not just user interruption)
+  // Determine if the cycle failed due to an error (not user cancellation).
+  // User cancellation clears lastError in BaseRetryWaitNode, so:
+  // - Error failure: shouldStop=true, lastError exists → failedWithError=true
+  // - User cancelled: shouldStop=true, lastError=undefined → failedWithError=false
   const failedWithError = shared.state.shouldStop && !!shared.retryState.lastError;
+  const userCancelled = shared.state.shouldStop && !shared.retryState.lastError;
 
   return {
     store: input.store,
@@ -102,5 +108,6 @@ export async function runResponseCycle<C = unknown>(
     retryCallbacks,
     failedWithError,
     errorMessage: shared.retryState.lastError?.message,
+    userCancelled,
   };
 }

--- a/src/agent/core/ResponseCycle.ts
+++ b/src/agent/core/ResponseCycle.ts
@@ -39,6 +39,10 @@ export interface ResponseCycleResult {
   endTurn: boolean;
   /** Callbacks for triggering manual retry from UI. */
   retryCallbacks: RetryCallbacks;
+  /** True if the cycle stopped due to an error (not user interruption). */
+  failedWithError: boolean;
+  /** Error message if failedWithError is true. */
+  errorMessage?: string;
 }
 
 /**
@@ -89,9 +93,14 @@ export async function runResponseCycle<C = unknown>(
   flow.setParams({ services: { options: input.options, store: input.store } });
   await flow.run(shared);
 
+  // Determine if the cycle failed due to an error (not just user interruption)
+  const failedWithError = shared.state.shouldStop && !!shared.retryState.lastError;
+
   return {
     store: input.store,
     endTurn: shared.state.endTurn,
     retryCallbacks,
+    failedWithError,
+    errorMessage: shared.retryState.lastError?.message,
   };
 }

--- a/src/agent/core/flows/BaseRetryWaitNode.ts
+++ b/src/agent/core/flows/BaseRetryWaitNode.ts
@@ -24,6 +24,7 @@ import { bus } from '@eventBus/ProgressEventBus';
 import { FlowTransition } from './FlowTransitions';
 import {
   resetRetryState,
+  clearRetryError,
   MANUAL_RETRY_TIMEOUT_MS,
   type RetryState,
   type RetryCallbacks,
@@ -174,7 +175,11 @@ class RetryWaitNode<
       return FlowTransition.RETRY;
     }
 
-    // User cancelled
+    // User cancelled - clear the error since the user chose to stop
+    // This distinguishes user cancellation from error failure:
+    // - User cancelled: shouldStop=true, lastError=undefined
+    // - Error failure: shouldStop=true, lastError exists
+    clearRetryError(retryState);
     logger.info('Retry cancelled by user', {
       messageType: MESSAGE_TYPES.PROGRESS_STATUS,
     });

--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -329,6 +329,7 @@ class ResponseModelInvocationNode<C> extends BaseNode<
       retryState,
       formatted.message,
       formatted.statusCode,
+      formatted.retryable,
     );
 
     // Apply retry decision (logging, sleeping) via shared helper

--- a/src/agent/core/flows/RetryState.ts
+++ b/src/agent/core/flows/RetryState.ts
@@ -134,6 +134,44 @@ export function isRetryableStatusCode(statusCode?: number): boolean {
 }
 
 /**
+ * Determines if an error is retryable based on status code and message.
+ * Errors without status codes (e.g., network/connection errors) are considered
+ * retryable since they are typically transient issues that may resolve.
+ */
+export function isRetryableError(
+  statusCode?: number,
+  message?: string,
+): boolean {
+  // Known retryable status codes
+  if (isRetryableStatusCode(statusCode)) {
+    return true;
+  }
+
+  // Errors without status codes are typically network/connection errors
+  // which are transient and should be retryable
+  if (statusCode === undefined) {
+    // Check for known non-retryable error patterns
+    const lowerMessage = message?.toLowerCase() ?? '';
+    const nonRetryablePatterns = [
+      'invalid api key',
+      'authentication',
+      'unauthorized',
+      'permission denied',
+      'forbidden',
+      'not found',
+      'bad request',
+      'invalid',
+    ];
+    const isNonRetryable = nonRetryablePatterns.some((pattern) =>
+      lowerMessage.includes(pattern),
+    );
+    return !isNonRetryable;
+  }
+
+  return false;
+}
+
+/**
  * Determines if automatic retry should be attempted based on current state.
  * Uses <= so maxAutoAttempts represents the number of retry attempts allowed,
  * not total attempts (initial attempt + maxAutoAttempts retries).
@@ -174,7 +212,7 @@ export function recordRetryError(
   state.lastError = {
     message,
     statusCode,
-    retryable: isRetryableStatusCode(statusCode),
+    retryable: isRetryableError(statusCode, message),
   };
 }
 

--- a/src/agent/core/flows/RetryState.ts
+++ b/src/agent/core/flows/RetryState.ts
@@ -18,8 +18,6 @@ import { sleep } from '@utils/helpers';
 
 import { FlowTransition } from './FlowTransitions';
 
-const RETRYABLE_NON_5XX_STATUS_CODES = new Set([408, 429]);
-
 /** Timeout for manual retry wait (5 minutes) - exported for BaseRetryWaitNode */
 export const MANUAL_RETRY_TIMEOUT_MS = 5 * 60 * 1000;
 
@@ -119,20 +117,6 @@ export function beginAttempt(state: RetryState): void {
 // ============================================================================
 // Pure predicates
 // ============================================================================
-
-/**
- * Determines if an HTTP status code is retryable (5xx or 408/429).
- * @deprecated Use the `retryable` field from `formatProviderHttpError` instead.
- */
-export function isRetryableStatusCode(statusCode?: number): boolean {
-  if (statusCode === undefined) {
-    return false;
-  }
-  if (statusCode >= 500) {
-    return true;
-  }
-  return RETRYABLE_NON_5XX_STATUS_CODES.has(statusCode);
-}
 
 /**
  * Determines if automatic retry should be attempted based on current state.

--- a/src/agent/core/flows/RetryState.ts
+++ b/src/agent/core/flows/RetryState.ts
@@ -122,6 +122,7 @@ export function beginAttempt(state: RetryState): void {
 
 /**
  * Determines if an HTTP status code is retryable (5xx or 408/429).
+ * @deprecated Use the `retryable` field from `formatProviderHttpError` instead.
  */
 export function isRetryableStatusCode(statusCode?: number): boolean {
   if (statusCode === undefined) {
@@ -131,44 +132,6 @@ export function isRetryableStatusCode(statusCode?: number): boolean {
     return true;
   }
   return RETRYABLE_NON_5XX_STATUS_CODES.has(statusCode);
-}
-
-/**
- * Determines if an error is retryable based on status code and message.
- * Errors without status codes (e.g., network/connection errors) are considered
- * retryable since they are typically transient issues that may resolve.
- */
-export function isRetryableError(
-  statusCode?: number,
-  message?: string,
-): boolean {
-  // Known retryable status codes
-  if (isRetryableStatusCode(statusCode)) {
-    return true;
-  }
-
-  // Errors without status codes are typically network/connection errors
-  // which are transient and should be retryable
-  if (statusCode === undefined) {
-    // Check for known non-retryable error patterns
-    const lowerMessage = message?.toLowerCase() ?? '';
-    const nonRetryablePatterns = [
-      'invalid api key',
-      'authentication',
-      'unauthorized',
-      'permission denied',
-      'forbidden',
-      'not found',
-      'bad request',
-      'invalid',
-    ];
-    const isNonRetryable = nonRetryablePatterns.some((pattern) =>
-      lowerMessage.includes(pattern),
-    );
-    return !isNonRetryable;
-  }
-
-  return false;
 }
 
 /**
@@ -203,16 +166,21 @@ export function computeBackoffDelay(state: RetryState): number {
 
 /**
  * Records an error in retry state.
+ * @param state - The retry state to update
+ * @param message - Error message
+ * @param statusCode - HTTP status code if available
+ * @param retryable - Whether the error is retryable (from formatProviderHttpError)
  */
 export function recordRetryError(
   state: RetryState,
   message: string,
-  statusCode?: number,
+  statusCode: number | undefined,
+  retryable: boolean,
 ): void {
   state.lastError = {
     message,
     statusCode,
-    retryable: isRetryableError(statusCode, message),
+    retryable,
   };
 }
 
@@ -242,21 +210,26 @@ export type RetryDecision =
  * Determines retry strategy after an error.
  * This is the SINGLE SOURCE OF TRUTH for retry decision logic.
  *
+ * @param state - The retry state to update
+ * @param errorMessage - Error message
+ * @param statusCode - HTTP status code if available
+ * @param retryable - Whether the error is retryable (from formatProviderHttpError)
  * @mutates state.lastError, state.awaitingManualRetry
  * Side effects (logging, sleeping, UI events) are handled by the caller.
  */
 export function determineRetryStrategy(
   state: RetryState,
   errorMessage: string,
-  statusCode?: number,
+  statusCode: number | undefined,
+  retryable: boolean,
 ): RetryDecision {
   // Record the error in state
-  recordRetryError(state, errorMessage, statusCode);
+  recordRetryError(state, errorMessage, statusCode, retryable);
 
   const error = {
     message: errorMessage,
     statusCode,
-    retryable: state.lastError?.retryable ?? false,
+    retryable,
   };
 
   // Check auto-retry first

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -369,6 +369,7 @@ class ToolUseCallNode<C> extends BaseNode<
       retryState,
       formatted.message,
       formatted.statusCode,
+      formatted.retryable,
     );
 
     // Apply retry decision (logging, sleeping) via shared helper

--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -477,6 +477,13 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
         store,
       });
 
+      // If the response cycle failed with an error, throw to stop round progression
+      if (cycleResult.failedWithError) {
+        throw new Error(
+          cycleResult.errorMessage ?? 'Response cycle failed with an error',
+        );
+      }
+
       const artifacts = await this.handleRoundCompletion(
         roundIndex,
         store.round,

--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -484,6 +484,18 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
         );
       }
 
+      // If the user cancelled, stop gracefully without throwing
+      if (cycleResult.userCancelled) {
+        return {
+          roundState: store.round,
+          runState: store.run,
+          messages: updatedMessages,
+          shouldContinue: false,
+          workspaceState: store.workspace,
+          output: null,
+        };
+      }
+
       const artifacts = await this.handleRoundCompletion(
         roundIndex,
         store.round,

--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -256,10 +256,14 @@ function matchNativeHttpError(
     extractMessage(err) ?? fallbackMessage ?? 'Provider request failed';
 
   if (!statusCode) {
+    // Known SDK error types without status codes are unusual (SDK errors typically
+    // have status codes). Be conservative and don't retry.
+    // Note: This differs from formatProviderHttpError's fallback which treats
+    // unrecognized errors without status codes as retryable (likely network errors).
     return {
       message: finalMessage,
       provider: entry.provider,
-      retryable: false, // Unknown errors without status codes are not retryable by default
+      retryable: false,
     };
   }
 
@@ -405,8 +409,10 @@ export function formatProviderHttpError(
     extractMessage(err) ?? fallbackMessage ?? 'Provider request failed';
 
   if (!statusCode) {
-    // Unknown errors without status codes are likely network/connection errors
-    // which should be retryable
+    // Unrecognized errors without status codes reached the fallback path.
+    // These are likely network/connection errors (not SDK-typed) and should
+    // be retryable. Note: This differs from matchNativeHttpError which is
+    // conservative for known SDK types missing status codes.
     return {
       message: finalMessage,
       provider,

--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -378,6 +378,34 @@ function extractMessage(err: unknown): string | undefined {
 }
 
 /**
+ * Detects if an error is an abort/cancellation error.
+ * These are NOT retryable since the user intentionally cancelled.
+ * Handles:
+ * - DOM AbortError (from AbortController)
+ * - Errors with 'abort' or 'cancel' in name/message
+ */
+function isAbortError(err: unknown): boolean {
+  if (!err || typeof err !== 'object') {
+    return false;
+  }
+
+  const errorObj = err as { name?: string; message?: string };
+
+  // Check for DOM AbortError (DOMException with name 'AbortError')
+  if (errorObj.name === 'AbortError') {
+    return true;
+  }
+
+  // Check for abort-related patterns in error name
+  const name = errorObj.name?.toLowerCase() ?? '';
+  if (name.includes('abort') || name.includes('cancel')) {
+    return true;
+  }
+
+  return false;
+}
+
+/**
  * Formats SDK errors from model providers into a consistent message so agent logs
  * can surface status codes alongside concise descriptions.
  *
@@ -396,6 +424,16 @@ export function formatProviderHttpError(
   const nativeHttp = matchNativeHttpError(err);
   if (nativeHttp) {
     return nativeHttp;
+  }
+
+  // Check for abort/cancellation errors (e.g., DOM AbortError from cancelled fetch)
+  // These are NOT retryable since the user intentionally cancelled.
+  if (isAbortError(err)) {
+    return {
+      message: extractMessage(err) ?? 'Request aborted',
+      provider: detectProvider(err),
+      retryable: false,
+    };
   }
 
   const statusCode = detectStatusCode(err);

--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -44,6 +44,13 @@ export interface ProviderHttpErrorDetails {
   statusText?: string;
   /** Identifier for the provider that produced the error, when known. */
   provider?: string;
+  /**
+   * Whether the error is retryable. Based on native SDK error types:
+   * - Connection errors (timeout, network) → retryable
+   * - Server errors (5xx) and rate limits (429) → retryable
+   * - User abort, auth errors, bad requests → NOT retryable
+   */
+  retryable: boolean;
 }
 
 const STATUS_TITLES: Record<number, string> = {
@@ -84,6 +91,8 @@ interface NativeMessageErrorEntry {
   ctor: ErrorConstructor;
   provider: string;
   message?: string;
+  /** Whether this error type is retryable (e.g., connection errors are, user aborts are not) */
+  retryable: boolean;
 }
 
 interface NativeHttpErrorEntry {
@@ -97,31 +106,37 @@ const NATIVE_MESSAGE_ERRORS: NativeMessageErrorEntry[] = [
     ctor: OpenAIConnectionTimeoutError,
     provider: 'openai',
     message: 'Connection timed out',
+    retryable: true,
   },
   {
     ctor: AnthropicConnectionTimeoutError,
     provider: 'anthropic',
     message: 'Connection timed out',
+    retryable: true,
   },
   {
     ctor: OpenAIConnectionError,
     provider: 'openai',
     message: 'Connection error',
+    retryable: true,
   },
   {
     ctor: AnthropicConnectionError,
     provider: 'anthropic',
     message: 'Connection error',
+    retryable: true,
   },
   {
     ctor: OpenAIUserAbortError,
     provider: 'openai',
     message: 'Request aborted',
+    retryable: false,
   },
   {
     ctor: AnthropicUserAbortError,
     provider: 'anthropic',
     message: 'Request aborted',
+    retryable: false,
   },
 ];
 
@@ -206,7 +221,22 @@ function matchNativeMessageError(
   return {
     message: entry.message ?? extractMessage(err) ?? 'Provider request failed',
     provider: entry.provider,
+    retryable: entry.retryable,
   };
+}
+
+/** Status codes that are retryable (5xx server errors, rate limits, timeouts) */
+const RETRYABLE_STATUS_CODES = new Set([408, 429, 500, 502, 503, 504]);
+
+function isRetryableStatusCode(statusCode?: number): boolean {
+  if (statusCode === undefined) {
+    return false;
+  }
+  // All 5xx errors are retryable
+  if (statusCode >= 500) {
+    return true;
+  }
+  return RETRYABLE_STATUS_CODES.has(statusCode);
 }
 
 function matchNativeHttpError(
@@ -229,6 +259,7 @@ function matchNativeHttpError(
     return {
       message: finalMessage,
       provider: entry.provider,
+      retryable: false, // Unknown errors without status codes are not retryable by default
     };
   }
 
@@ -238,6 +269,7 @@ function matchNativeHttpError(
     statusCode,
     statusText,
     provider: entry.provider,
+    retryable: isRetryableStatusCode(statusCode),
   };
 }
 
@@ -373,9 +405,12 @@ export function formatProviderHttpError(
     extractMessage(err) ?? fallbackMessage ?? 'Provider request failed';
 
   if (!statusCode) {
+    // Unknown errors without status codes are likely network/connection errors
+    // which should be retryable
     return {
       message: finalMessage,
       provider,
+      retryable: true,
     };
   }
 
@@ -385,6 +420,7 @@ export function formatProviderHttpError(
     statusCode,
     statusText,
     provider,
+    retryable: isRetryableStatusCode(statusCode),
   };
 }
 


### PR DESCRIPTION
Two related fixes for agent execution error handling:

1. Round progression now stops when response cycle fails with error:
   - Added failedWithError and errorMessage fields to ResponseCycleResult
   - BaseReflectionAgent.runRoundPipeline now throws when cycle fails
   - Prevents r1 from running after r0 fails

2. Network/connection errors are now retryable:
   - Added isRetryableError() that considers both status code and message
   - Errors without status codes (e.g., internet disconnection) are considered retryable unless message indicates auth/validation error
   - recordRetryError now uses isRetryableError instead of isRetryableStatusCode
   - This enables retry button for connection errors like "terminated"

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Stops round progression when a response cycle fails, distinguishes user cancellation from errors, and propagates precise retryability (incl. network) from SDK error formatting into retry logic.
> 
> - **Agent workflow**:
>   - `ResponseCycle`: adds `failedWithError`, `errorMessage`, `userCancelled`; sets them based on `shouldStop` and `retryState.lastError`.
>   - `BaseRetryWaitNode`: clears retry error on user cancel to differentiate from error failures.
>   - `BaseReflectionAgent`: throws on `failedWithError`; returns gracefully when `userCancelled`.
> - **Retry logic**:
>   - `RetryState`: `recordRetryError` now accepts explicit `retryable`; `determineRetryStrategy` uses provided `retryable` and updates state accordingly.
>   - `ResponseCycleFlow` / `ToolUseCycleFlow`: pass `formatted.retryable` into `determineRetryStrategy`.
> - **Error formatting**:
>   - `sdkErrorUtils`: adds `retryable` to `ProviderHttpErrorDetails`; classifies retryability for native SDK/message errors, HTTP status codes (408/429/5xx retryable), aborts (non-retryable), and unknown non-status errors (retryable).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2b6dc4271083972032d1a44cf7c795a3d1b5bc1c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->