### PR TITLE
Fix missing output file list for Gemini model

### DIFF
--- a/src/agent/core/ToolUseCycle.ts
+++ b/src/agent/core/ToolUseCycle.ts
@@ -105,7 +105,12 @@ function emitEditedFiles<C>(input: ToolUseCycleInput<C>): void {
   const { options, store } = input;
   const interactions = store.workspace.interactions.toJSON();
 
+  options.logger.debug(
+    `emitEditedFiles called: ${interactions.edits.length} edits tracked, ${interactions.readFiles.length} files read`,
+  );
+
   if (interactions.edits.length === 0) {
+    options.logger.debug('emitEditedFiles: no edits to emit, returning early');
     return;
   }
 

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -642,7 +642,13 @@ class ToolUseDispatchNode<C> extends BaseNode<
     }
 
     // recordEdits returns per-call line changes as the single source of truth
+    options.logger.debug(
+      `executeToolCall ${call.name}: result.edits=${JSON.stringify(result.edits)}`,
+    );
     const trackedEdits = tracker.recordEdits(result.edits);
+    options.logger.debug(
+      `executeToolCall ${call.name}: trackedEdits=${JSON.stringify(trackedEdits.edits)}`,
+    );
     const lineChanges = result.lineChanges ?? trackedEdits.lineChanges;
     const sanitizedOutput = sanitizeToolResultForLog(result);
     if (lineChanges) {


### PR DESCRIPTION
Add debug logs to help diagnose why the generated files list isn't showing in the progress view for Gemini models. The logs track:
- When emitEditedFiles is called and how many edits are tracked
- When it returns early due to no edits
- Tool execution results and tracked edits in executeToolCall

This will help identify whether the issue is with edit recording, event emission, or UI state management.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add debug logging around emitting edited files and per-call edit tracking to diagnose missing generated files in progress view.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b88a95317e33ea1d92ef04541a1cb9d39c71fe17. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->