### PR TITLE
Fix compilation errors from refactoring

### DIFF
--- a/src/agent/remote/remoteAgentUtils.ts
+++ b/src/agent/remote/remoteAgentUtils.ts
@@ -40,20 +40,26 @@ export async function loadAndRegisterRemoteAgents(): Promise<LoadedRemoteAgents>
     }
 
     // Register only unregistered agents
-    const agentNames = agents.map((agent) => agent.name);
-    const unregisteredAgents = agentNames.filter(
-      (name) => !RemoteAgentRegistry.isRemote(name),
+    const unregisteredAgents = agents.filter(
+      (agent) => !RemoteAgentRegistry.isRemote(agent.name),
     );
 
     if (unregisteredAgents.length > 0) {
-      RemoteAgentRegistry.registerMultiple(unregisteredAgents);
+      RemoteAgentRegistry.registerMultiple(
+        unregisteredAgents.map((agent) => ({
+          name: agent.name,
+          description: agent.description,
+          agentType: agent.agentType,
+        })),
+      );
       logger.debug(
         CHANNEL,
         `Registered ${unregisteredAgents.length} new remote agents`,
       );
     }
 
-    return { agents, newlyRegistered: unregisteredAgents };
+    const newlyRegistered = unregisteredAgents.map((agent) => agent.name);
+    return { agents, newlyRegistered };
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Unknown error';
     logger.error(CHANNEL, `Failed to load remote agents: ${message}`);


### PR DESCRIPTION
The registerMultiple function expects objects with name, description, and agentType properties, not plain strings. Updated loadAndRegisterRemoteAgents to properly map unregistered agents to the expected format.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Correctly registers unregistered remote agents by passing full metadata and returns newly registered agent names.
> 
> - **Remote agent loading/registration (`src/agent/remote/remoteAgentUtils.ts`)**:
>   - Filter unregistered agents using full agent objects instead of names.
>   - Pass full metadata (`name`, `description`, `agentType`) to `RemoteAgentRegistry.registerMultiple`.
>   - Return `newlyRegistered` as agent names derived from unregistered agents.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9cac45da218f47c33b2437cda9fef4e8f003ab21. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->