### PR TITLE
Refactor code to reduce coupling and improve architecture

### DIFF
--- a/src/agent/core/index.ts
+++ b/src/agent/core/index.ts
@@ -1,3 +1,15 @@
+/**
+ * Barrel exports for agent core types.
+ *
+ * PREFERRED IMPORT PATTERN: Import directly from specific modules for clarity:
+ *   import { AgentConfig } from '@agent/core/AgentConfig';
+ *   import { AgentType } from '@agent/core/AgentDataclass';
+ *
+ * This barrel exists for convenience but direct imports are encouraged to:
+ * - Make dependencies explicit and traceable
+ * - Avoid accidental circular imports
+ * - Enable better tree-shaking
+ */
 export * from './AgentConfig';
 export * from './AgentDataclass';
 export * from './AgentState';

--- a/src/common/files/fileTypeUtils.ts
+++ b/src/common/files/fileTypeUtils.ts
@@ -4,7 +4,14 @@ import * as path from 'path';
 // Internal imports
 import { getConfig } from '@utils/config';
 
-export type FileType =
+/**
+ * File categories for extension configuration lookups.
+ * These map to VS Code settings keys for allowed file extensions.
+ *
+ * Note: This is distinct from FileType in utils/config/constants.ts
+ * which defines UI file input field types.
+ */
+export type ExtensionCategory =
   | 'input'
   | 'reference'
   | 'auxiliary'
@@ -12,7 +19,13 @@ export type FileType =
   | 'audio'
   | 'edited';
 
-const INCLUDED_EXTENSION_KEYS: Record<FileType, string> = {
+/**
+ * @deprecated Use ExtensionCategory instead. This alias exists for
+ * backwards compatibility during migration.
+ */
+export type FileType = ExtensionCategory;
+
+const INCLUDED_EXTENSION_KEYS: Record<ExtensionCategory, string> = {
   input: 'texra.files.included.inputExtensions',
   reference: 'texra.files.included.referenceExtensions',
   auxiliary: 'texra.files.included.auxiliaryExtensions',
@@ -22,13 +35,16 @@ const INCLUDED_EXTENSION_KEYS: Record<FileType, string> = {
 };
 
 /**
- * Retrieve included extensions for the given file type.
+ * Retrieve included extensions for the given extension category.
  */
 export function getIncludedExtensions(
-  type: FileType,
+  category: ExtensionCategory,
   defaultExtensions: string[] = [],
 ): string[] {
-  return getConfig<string[]>(INCLUDED_EXTENSION_KEYS[type], defaultExtensions);
+  return getConfig<string[]>(
+    INCLUDED_EXTENSION_KEYS[category],
+    defaultExtensions,
+  );
 }
 
 /**

--- a/src/frontend/files/fileLister.ts
+++ b/src/frontend/files/fileLister.ts
@@ -5,7 +5,10 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 
 // Local imports - log
-import { getIncludedExtensions, FileType } from '@common/files/fileTypeUtils';
+import {
+  getIncludedExtensions,
+  ExtensionCategory,
+} from '@common/files/fileTypeUtils';
 import * as logger from '@logger/logUtils';
 import { getConfig, watchConfig } from '@utils/config';
 import { WorkspaceFS } from '@utils/files';
@@ -16,7 +19,7 @@ import { getFilesRecursively } from './listing';
 const CHANNEL = 'FileLister';
 logger.initialize(CHANNEL);
 
-export type ListableFileType = Exclude<FileType, 'audio'>;
+export type ListableFileType = Exclude<ExtensionCategory, 'audio'>;
 
 export class FileLister {
   private static instance: FileLister | null = null;

--- a/src/housekeeping/clean.ts
+++ b/src/housekeeping/clean.ts
@@ -11,15 +11,15 @@ import type { FileOpResult } from '@agent/types/ResultTypes';
 // Internal imports
 import { toErrorMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
-import { WorkspaceFS } from '@utils/files';
+import { MODELS } from '@model/ModelRegistry';
 import { getConfig } from '@utils/config';
+import { WorkspaceFS } from '@utils/files';
 
 // Local file imports
 import {
   EXCLUDED_DIRS,
   TEMP_EXTENSIONS,
   PACK_EXTENSIONS,
-  MODELS,
   DEFAULT_MAX_ROUNDS,
 } from './constants';
 import {

--- a/src/housekeeping/constants.ts
+++ b/src/housekeeping/constants.ts
@@ -1,6 +1,3 @@
-// Local imports
-import { MODEL_CONFIGS } from '@model/ModelRegistry';
-
 export const EXCLUDED_DIRS = new Set([
   'figs',
   'figures',
@@ -36,8 +33,6 @@ export const TEMP_EXTENSIONS = [
   '-blx.bib',
   'Notes.bib',
 ];
-
-export const MODELS = Object.keys(MODEL_CONFIGS);
 
 export const HISTORY_DIR = 'History';
 

--- a/src/model/ModelConfig.ts
+++ b/src/model/ModelConfig.ts
@@ -2,9 +2,6 @@
  * Configuration types and constants for language model interactions and capabilities.
  */
 
-// Local imports
-import { ToolConfig } from '@agent/core/ToolConfig';
-
 /**
  * Default configuration values
  */
@@ -88,5 +85,4 @@ export interface ModelConfig {
   capabilities: ModelCapabilities;
   openRouterOnly: boolean; // Whether this model is only available through OpenRouter
   openrouterFullName?: string; // Full model name for OpenRouter (e.g., "anthropic/claude-3-opus-20240229")
-  toolConfig?: ToolConfig; // Reference to tool configuration
 }

--- a/src/model/ModelRegistry.ts
+++ b/src/model/ModelRegistry.ts
@@ -38,3 +38,9 @@ export const MODEL_CONFIGS: Record<string, ModelConfig> = {
   ...DASHSCOPE_MODELS,
   ...COPILOT_MODELS,
 };
+
+/**
+ * List of all available model short names.
+ * Derived from MODEL_CONFIGS for single source of truth.
+ */
+export const MODELS = Object.keys(MODEL_CONFIGS);


### PR DESCRIPTION
- Remove unused toolConfig from ModelConfig to break model → agent circular dependency
- Rename FileType to ExtensionCategory in common/files/fileTypeUtils.ts to distinguish from the UI FileType in utils/config/constants.ts
- Move MODELS constant from housekeeping/constants.ts to model/ModelRegistry.ts where MODEL_CONFIGS is defined (single source of truth)
- Add documentation to agent/core/index.ts recommending direct imports over barrel exports for better dependency tracing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Renames file extension type, centralizes model list in ModelRegistry, removes unused model ToolConfig, and adds guidance to agent core barrel exports.
> 
> - **Models**:
>   - Remove `toolConfig` from `ModelConfig`.
>   - Add `MODELS` export in `model/ModelRegistry` (derived from `MODEL_CONFIGS`); update `housekeeping/clean.ts` to import it; remove from `housekeeping/constants.ts`.
> - **Files**:
>   - Rename `FileType` to `ExtensionCategory` in `common/files/fileTypeUtils.ts` (with deprecated alias); update `getIncludedExtensions` to accept `category`.
>   - Update `frontend/files/fileLister.ts` to use `ExtensionCategory` and adjust `ListableFileType`.
> - **Agent Core**:
>   - Add documentation in `agent/core/index.ts` recommending direct imports over barrel exports.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fd2da1bdf4cdbdd01e2e7bf0aac756af958e4169. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->