### PR TITLE
Set up Supabase authentication and managers

### DIFF
--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -7,11 +7,11 @@ import type { OutputFileInfo } from '@agent/output/types';
 import type { TokenUsageStats } from '@agent/types/UsageTypes';
 // Internal imports
 import { AgentCategory } from '@agent/core/AgentDataclass';
+import { STREAM_STATUS } from '@common/constants/streamStatus';
 import { AgentLogger } from '@logger/AgentLogger';
 import { WebviewUpdater } from '@progressView/managers';
 import { buildStreamInfos } from '@progressView/streamInfoUtils';
 import { ProgressViewState } from '@progressView/state/ProgressViewState';
-import { STATUS } from '@progressView/modules/constants.js';
 import { bus } from '@eventBus/ProgressEventBus';
 
 // Local file imports
@@ -187,7 +187,7 @@ export class ProgressEventHandler {
       this.webviewUpdater.updateFiles('', { reset: true });
       this.webviewUpdater.updateMissingOutputs('', { reset: true });
       this.webviewUpdater.updateUsage('', {});
-      this.webviewUpdater.updateStatus(STATUS.READY);
+      this.webviewUpdater.updateStatus(STREAM_STATUS.READY);
       if (updateInstruction) {
         this.webviewUpdater.clearInstruction('');
       }
@@ -239,7 +239,7 @@ export class ProgressEventHandler {
     });
 
     // Update status for current stream - default to STOPPED when stream exists but no status is set
-    const status = this._streamStatus.get(stream) || STATUS.STOPPED;
+    const status = this._streamStatus.get(stream) || STREAM_STATUS.STOPPED;
     this.webviewUpdater.updateStatus(status);
 
     if (updateInstruction) {
@@ -258,7 +258,7 @@ export class ProgressEventHandler {
    * Set the status for a specific stream synchronously.
    */
   setStreamStatus(stream: string, status: StreamStatusOrReadyType): void {
-    if (status === STATUS.READY) {
+    if (status === STREAM_STATUS.READY) {
       this._streamStatus.delete(stream);
     } else {
       const nextStatus: StreamStatusType = status;
@@ -320,7 +320,7 @@ export class ProgressEventHandler {
     await this.state.streamTabs.ensureStream(stream);
 
     if (!existingStatus) {
-      this.setStreamStatus(stream, STATUS.RUNNING);
+      this.setStreamStatus(stream, STREAM_STATUS.RUNNING);
     }
 
     this.state.setSessionKindHint(stream, AgentCategory.Workflow);
@@ -332,7 +332,7 @@ export class ProgressEventHandler {
 
     this.state.activeStream = stream;
 
-    const status = this._streamStatus.get(stream) ?? STATUS.RUNNING;
+    const status = this._streamStatus.get(stream) ?? STREAM_STATUS.RUNNING;
     this.setStreamStatus(stream, status);
 
     if (this.webviewUpdater.isAvailable()) {
@@ -346,8 +346,8 @@ export class ProgressEventHandler {
    */
   markAllRunningTasksAsCancelled(): void {
     for (const [stream, status] of this._streamStatus.entries()) {
-      if (status === STATUS.RUNNING) {
-        this._streamStatus.set(stream, STATUS.STOPPED);
+      if (status === STREAM_STATUS.RUNNING) {
+        this._streamStatus.set(stream, STREAM_STATUS.STOPPED);
       }
     }
   }
@@ -361,14 +361,14 @@ export class ProgressEventHandler {
     const waitingSet = waitingStreams ?? new Set<string>();
 
     for (const [stream, status] of this._streamStatus.entries()) {
-      if (status === STATUS.RUNNING) {
+      if (status === STREAM_STATUS.RUNNING) {
         if (waitingSet.has(stream)) {
-          this._streamStatus.set(stream, STATUS.WAITING);
+          this._streamStatus.set(stream, STREAM_STATUS.WAITING);
           this.logger.debug(
             `Stream ${stream} restored to WAITING after reload`,
           );
         } else {
-          this._streamStatus.set(stream, STATUS.ERROR);
+          this._streamStatus.set(stream, STREAM_STATUS.ERROR);
           affectedStreams.push(stream);
           this.logger.debug(
             `Stream ${stream} set to ERROR due to webview reload`,

--- a/src/progressView/events/StreamStatusEvents.ts
+++ b/src/progressView/events/StreamStatusEvents.ts
@@ -3,6 +3,7 @@ import * as vscode from 'vscode';
 
 // Local imports - identifiers
 import type { StreamTabId } from '@agent/types/IdentifierTypes';
+import { STREAM_STATUS } from '@common/constants/streamStatus';
 import type { AgentLogger } from '@logger/AgentLogger';
 import type { WebviewUpdater } from '@progressView/managers';
 import type { StreamTabInfo } from '@progressView/types';
@@ -10,7 +11,6 @@ import type { StreamTabInfo } from '@progressView/types';
 import { buildStreamInfos } from '@progressView/streamInfoUtils';
 // Type imports
 import type { ProgressViewState } from '@progressView/state/ProgressViewState';
-import { STATUS } from '@progressView/modules/constants.js';
 import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
 
 // Internal imports
@@ -82,7 +82,7 @@ export function createStreamStatusEvents(
     state.activeStream = stream;
 
     const status: StreamStatusOrReadyType =
-      shared.streamStatus.get(stream) ?? STATUS.RUNNING;
+      shared.streamStatus.get(stream) ?? STREAM_STATUS.RUNNING;
     shared.setStreamStatus(stream, status);
 
     if (updater.isAvailable()) {

--- a/src/progressView/managers/TaskGroupManager.ts
+++ b/src/progressView/managers/TaskGroupManager.ts
@@ -3,13 +3,13 @@ import type { StreamTabId } from '@agent/types/IdentifierTypes';
 
 // Internal imports
 import { WorkspaceStateKey } from '@common/state/stateManager';
+import { STREAM_STATUS } from '@common/constants/streamStatus';
 import { AgentLogger } from '@logger/AgentLogger';
 import { TaskGroup } from '@logger/LogTypes';
 import {
   PersistentMapManager,
   type StateStorage,
 } from '@progressView/persistence/PersistentMapManager';
-import { STATUS } from '@progressView/modules/constants.js';
 
 export interface TaskGroupUpdatePayload {
   stream: StreamTabId;
@@ -85,8 +85,8 @@ export class TaskGroupManager extends PersistentMapManager<
       let updated = false;
 
       for (const group of groups.values()) {
-        if (group.status === STATUS.RUNNING) {
-          group.status = STATUS.ERROR;
+        if (group.status === STREAM_STATUS.RUNNING) {
+          group.status = STREAM_STATUS.ERROR;
           group.endTime = now;
           updated = true;
         }


### PR DESCRIPTION
…pt files

The previous refactoring (d94e0e8) renamed STATUS to STREAM_STATUS in constants.js but missed updating three TypeScript files that were importing the old constant. This caused the progress view to fail silently because STATUS was undefined.

Updated imports and usages in:
- ProgressEventHandler.ts
- StreamStatusEvents.ts
- TaskGroupManager.ts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces `STATUS` with `STREAM_STATUS` and updates related imports/usages in progress view event handlers and manager.
> 
> - **Progress View**:
>   - **Constants migration**: Replace `STATUS` with `STREAM_STATUS`.
>     - Update imports from `@progressView/modules/constants.js` to `@common/constants/streamStatus`.
>     - Update status checks/assignments in:
>       - `src/progressView/events/ProgressEventHandler.ts`
>       - `src/progressView/events/StreamStatusEvents.ts`
>       - `src/progressView/managers/TaskGroupManager.ts`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit adc2255d13b2ca68104b50fc120d114147f2a760. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->