### PR TITLE
Set up Supabase authentication and managers

### DIFF
--- a/src/common/constants/streamStatus.js
+++ b/src/common/constants/streamStatus.js
@@ -1,0 +1,21 @@
+/**
+ * Stream status constants shared across agent runtime and UI layers.
+ *
+ * These constants define the possible states of an agent execution stream.
+ * This is the JavaScript version for webview ES modules.
+ */
+
+export const STREAM_STATUS = {
+  /** Agent is actively processing. */
+  RUNNING: 'running',
+  /** Agent encountered an error. */
+  ERROR: 'error',
+  /** Agent was stopped by user request. */
+  STOPPED: 'stopped',
+  /** Agent completed and is ready for new tasks. */
+  READY: 'ready',
+  /** Agent is waiting for user input or external resource. */
+  WAITING: 'waiting',
+  /** Agent is resuming from a previous session. */
+  RESUMING: 'resuming',
+};

--- a/src/common/webview/BaseViewContentProvider.ts
+++ b/src/common/webview/BaseViewContentProvider.ts
@@ -178,6 +178,7 @@ export abstract class BaseViewContentProvider {
       ),
       stringUtilsUri: this.getCommonUri(webview, 'modules/stringUtils.js'),
       pathUtilsUri: this.getCommonUri(webview, 'modules/pathUtils.js'),
+      streamStatusUri: this.getCommonUri(webview, 'constants/streamStatus.js'),
       vscodeElementsBundleUri: this.getNodeModulesUri(
         webview,
         '@vscode-elements/elements/dist/bundled.js',

--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -67,6 +67,7 @@
           "@common/BaseDomHandler.js": "${baseDomHandlerUri}",
           "@common/stringUtils.js": "${stringUtilsUri}",
           "@common/pathUtils.js": "${pathUtilsUri}",
+          "@common/constants/streamStatus": "${streamStatusUri}",
           "@common/iconConstants.js": "${iconConstantsUri}",
           "@common/BaseWebviewMessageHandler.js": "${baseWebviewMessageHandlerUri}",
           "he": "https://esm.sh/he@1.2.0",


### PR DESCRIPTION
The progressView constants.js imports STREAM_STATUS from '@common/constants/streamStatus', but this path was not available in the ES module importmap. This caused the webview to fail silently during module loading, resulting in a blank ProgressView.

- Add streamStatus.js for webview ES module consumption
- Add streamStatusUri to BaseViewContentProvider
- Add importmap entry in progressView/index.html

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce `streamStatus.js` and expose it to webviews via `BaseViewContentProvider` and the ProgressView import map.
> 
> - **Common**:
>   - Add `src/common/constants/streamStatus.js` exporting `STREAM_STATUS` values.
>   - Expose `streamStatusUri` in `BaseViewContentProvider#getCommonModuleUris` for webview consumption.
> - **ProgressView**:
>   - Map `"@common/constants/streamStatus"` to `streamStatusUri` in `src/progressView/index.html` import map.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bd54119e01cff1d6e28fbf32a51965031f1d318b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->