### PR TITLE
fix(progressView): sync commands.js with commands.ts for retry requests

### DIFF
--- a/src/common/webview/commands.js
+++ b/src/common/webview/commands.js
@@ -177,6 +177,8 @@ export const PROGRESS_VIEW_COMMANDS = {
   SHOW_TOOL_EDIT_APPROVAL: 'showToolEditApproval',
   RESOLVE_TOOL_EDIT_APPROVAL: 'resolveToolEditApproval',
   UPDATE_TOOL_EDIT_APPROVAL_STATE: 'updateToolEditApprovalState',
+  SHOW_RETRY_REQUEST: 'showRetryRequest',
+  RESOLVE_RETRY_REQUEST: 'resolveRetryRequest',
 
   // Usage
   UPDATE_USAGE: 'updateUsage',
@@ -185,6 +187,8 @@ export const PROGRESS_VIEW_COMMANDS = {
   // Actions
   RUN_AGAIN: 'runAgain',
   RUN_NEW: 'runNew',
+  RETRY_STREAM_REQUEST: 'retryStreamRequest',
+  CANCEL_RETRY_REQUEST: 'cancelRetryRequest',
   DIFF_STREAM: 'diffStream',
   PACK_STREAM: 'packStream',
   SORT_STREAMS: 'sortStreams',


### PR DESCRIPTION
The JavaScript webview commands.js was missing retry request commands
that exist in the TypeScript commands.ts, causing the ProgressView
to fail silently during module loading (similar to commit bd54119).

Add missing commands:
- SHOW_RETRY_REQUEST
- RESOLVE_RETRY_REQUEST
- RETRY_STREAM_REQUEST
- CANCEL_RETRY_REQUEST

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `SHOW_RETRY_REQUEST`, `RESOLVE_RETRY_REQUEST`, `RETRY_STREAM_REQUEST`, and `CANCEL_RETRY_REQUEST` to `PROGRESS_VIEW_COMMANDS` in `src/common/webview/commands.js`.
> 
> - **Progress View Commands** (`src/common/webview/commands.js`):
>   - Add retry-related commands: `SHOW_RETRY_REQUEST`, `RESOLVE_RETRY_REQUEST`, `RETRY_STREAM_REQUEST`, `CANCEL_RETRY_REQUEST`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7684a7db0850f774ff9e95a32e1bb4c0530b4385. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->