### PR TITLE
Set up Supabase authentication and managers

### DIFF
--- a/src/common/webview/resourceRoots.ts
+++ b/src/common/webview/resourceRoots.ts
@@ -12,6 +12,7 @@ export function getSharedLocalResourceRoots(
     vscode.Uri.joinPath(extensionUri, 'src', 'common', 'styles'),
     vscode.Uri.joinPath(extensionUri, 'src', 'common', 'modules'),
     vscode.Uri.joinPath(extensionUri, 'src', 'common', 'webview'),
+    vscode.Uri.joinPath(extensionUri, 'src', 'common', 'constants'),
     vscode.Uri.joinPath(
       extensionUri,
       'node_modules',


### PR DESCRIPTION
The streamStatus.js module was moved to src/common/constants/ but the directory was not added to webview localResourceRoots, causing CSP to block module loading and preventing the progress view from rendering.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add `src/common/constants` to webview `localResourceRoots` to allow module loading from the moved constants directory.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6c91965de7e4a173672762385073d8347ae1d581. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->