### PR TITLE
Fix missing stream status constants file

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -53,6 +53,7 @@ CLAUDE.md
 !src/common/webview/commands.js
 !src/common/modules/*.js
 !src/common/modules/files/*.js
+!src/common/constants/*.js
 
 !src/historyView/modules/*.js
 !src/historyView/modules/uiManagers/*.js


### PR DESCRIPTION
Add !src/common/constants/*.js to .vscodeignore to ensure streamStatus.js is included in the packaged extension. Without this, webviews fail to load the file with a 404 error.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Include `src/common/constants/*.js` in the packaged extension by updating `.vscodeignore`.
> 
> - **Packaging/config**:
>   - Update `.vscodeignore` to include `src/common/constants/*.js`, ensuring constants are bundled with the extension.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8d02a5323c868dc4e33b89ffa9b08c3f1a370fd9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->