### PR TITLE
docs: add Supabase API keys documentation and remove unused env var references

### DIFF
--- a/docs/supabase/SUPABASE_SETUP.md
+++ b/docs/supabase/SUPABASE_SETUP.md
@@ -82,7 +82,7 @@ Both the publishable and anon keys are designed to be embedded in client-side co
 
 1. Go to **Settings** → **API Keys** in Supabase dashboard
 2. Create a new publishable key
-3. Replace the `anonKey` value in `src/auth/config.ts` with your publishable key
+3. Replace the `publicKey` value in `src/auth/config.ts` with your publishable key
 4. Build and test the extension
 5. (Optional) Deactivate the old anon key once migration is complete
 
@@ -491,7 +491,7 @@ Edit `src/auth/config.ts`:
 ```typescript
 export const SUPABASE_CONFIG: SupabaseConfig = {
   url: 'https://your-actual-project-id.supabase.co', // Replace with your project URL
-  anonKey: 'your-actual-anon-key-here', // Replace with your anon/publishable key
+  publicKey: 'sb_publishable_...', // Replace with your publishable key (or anon JWT)
   edgeFunctionUrl:
     'https://your-actual-project-id.supabase.co/functions/v1/get-agent-config',
 };

--- a/docs/supabase/SUPABASE_SETUP.md
+++ b/docs/supabase/SUPABASE_SETUP.md
@@ -37,12 +37,56 @@ TeXRA uses Supabase for:
 
 Once your project is ready:
 
-1. Go to **Settings** → **API**
+1. Go to **Settings** → **API** (or **Settings** → **API Keys** for newer dashboard)
 2. **IMPORTANT**: Copy these values:
    - **Project URL**: `https://your-project-id.supabase.co`
-   - **anon public key**: Long string starting with `eyJ...`
+   - **Publishable key** (recommended): Starts with `sb_publishable_...`
+   - **OR anon key** (legacy): JWT starting with `eyJ...`
 
 **These will be hardcoded in the extension (see Part 6).**
+
+---
+
+## Understanding API Keys
+
+Supabase provides two types of public keys for client-side applications:
+
+### Publishable Key (Recommended)
+
+- **Format**: `sb_publishable_...`
+- **Advantages**:
+  - Easy rotation without downtime
+  - Shorter, simpler format
+  - Independent of JWT secret
+  - Browser-use detection for secret keys
+- **Use**: New projects should use publishable keys
+
+### Anon Key (Legacy)
+
+- **Format**: JWT starting with `eyJ...`
+- **Disadvantages**:
+  - Rotating requires JWT secret rotation (causes downtime)
+  - 10-year expiry embedded in token
+  - Large, complex format
+- **Use**: Still works, but consider migrating to publishable keys
+
+### Both Keys Are Safe for Client Code
+
+Both the publishable and anon keys are designed to be embedded in client-side code. They do **not** protect your data directly. Instead, Row Level Security (RLS) policies on your database tables control actual data access.
+
+**Important**:
+- Never expose `service_role` or secret keys (`sb_secret_...`) in client code
+- These elevated keys bypass RLS and should only be used in server-side code (Edge Functions)
+
+### Migrating from Anon to Publishable Key
+
+1. Go to **Settings** → **API Keys** in Supabase dashboard
+2. Create a new publishable key
+3. Replace the `anonKey` value in `src/auth/config.ts` with your publishable key
+4. Build and test the extension
+5. (Optional) Deactivate the old anon key once migration is complete
+
+The Supabase client initialization code remains identical - just swap the key value.
 
 ---
 
@@ -447,19 +491,10 @@ Edit `src/auth/config.ts`:
 ```typescript
 export const SUPABASE_CONFIG: SupabaseConfig = {
   url: 'https://your-actual-project-id.supabase.co', // Replace with your project URL
-  anonKey: 'your-actual-anon-key-here', // Replace with your anon key
+  anonKey: 'your-actual-anon-key-here', // Replace with your anon/publishable key
   edgeFunctionUrl:
     'https://your-actual-project-id.supabase.co/functions/v1/get-agent-config',
 };
-```
-
-**OR** use environment variables:
-
-```bash
-# .env (for development)
-TEXRA_SUPABASE_URL=https://your-project-id.supabase.co
-TEXRA_SUPABASE_ANON_KEY=your-anon-key
-TEXRA_SUPABASE_EDGE_FUNCTION_URL=https://your-project-id.supabase.co/functions/v1/get-agent-config
 ```
 
 ### 2. Build Extension

--- a/src/auth/SupabaseAuthProvider.ts
+++ b/src/auth/SupabaseAuthProvider.ts
@@ -39,7 +39,7 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
   constructor(private context: vscode.ExtensionContext) {
     SupabaseClient.initialize(
       SUPABASE_CONFIG.url,
-      SUPABASE_CONFIG.anonKey,
+      SUPABASE_CONFIG.publicKey,
       context,
     );
     SupabaseAuthProvider.instance = this;

--- a/src/auth/SupabaseClient.ts
+++ b/src/auth/SupabaseClient.ts
@@ -11,7 +11,7 @@ import * as logger from '@logger/logUtils';
  */
 export class SupabaseClient {
   private static instance: Client | null = null;
-  private static config: { url: string; anonKey: string } | null = null;
+  private static config: { url: string; publicKey: string } | null = null;
   private static context: vscode.ExtensionContext | null = null;
   private static readonly SESSION_KEY = 'texra.supabase.session';
 
@@ -20,19 +20,19 @@ export class SupabaseClient {
    */
   static initialize(
     url: string,
-    anonKey: string,
+    publicKey: string,
     context?: vscode.ExtensionContext,
   ): void {
-    if (!url || !anonKey) {
+    if (!url || !publicKey) {
       throw new Error(
         'Supabase credentials missing. Check extension configuration.',
       );
     }
-    this.config = { url, anonKey };
+    this.config = { url, publicKey };
     if (context) {
       this.context = context;
     }
-    this.instance = createClient(url, anonKey, {
+    this.instance = createClient(url, publicKey, {
       auth: {
         persistSession: false, // VS Code manages session storage
         autoRefreshToken: false, // Manual refresh via auth provider
@@ -179,7 +179,7 @@ export class SupabaseClient {
   }
 
   /** Get configuration for re-initialization. */
-  static getConfig(): { url: string; anonKey: string } | null {
+  static getConfig(): { url: string; publicKey: string } | null {
     return this.config;
   }
 }

--- a/src/auth/config.ts
+++ b/src/auth/config.ts
@@ -39,7 +39,7 @@ export const SUPABASE_CONFIG: SupabaseConfig = {
   url: `https://${SUPABASE_PROJECT_ID}.supabase.co`,
 
   // Production public key - safe to include in client code
-  publicKey: 'sb_publishable_DUIDjtxk12ZYYncrVUfwOw_xWQYsSvw?',
+  publicKey: 'sb_publishable_DUIDjtxk12ZYYncrVUfwOw_xWQYsSvw',
 
   // Edge function URL
   edgeFunctionUrl: `https://${SUPABASE_PROJECT_ID}.supabase.co/functions/v1/get-agent-config`,

--- a/src/auth/config.ts
+++ b/src/auth/config.ts
@@ -13,7 +13,12 @@
 export interface SupabaseConfig {
   /** Supabase project URL */
   url: string;
-  /** Supabase anonymous (public) key - safe to include in client code */
+  /**
+   * Supabase public key - safe to include in client code.
+   * Can be either:
+   * - Publishable key (recommended): starts with `sb_publishable_...`
+   * - Anon key (legacy): JWT starting with `eyJ...`
+   */
   anonKey: string;
   /** Edge function URL for fetching remote agent configurations */
   edgeFunctionUrl: string;
@@ -23,7 +28,8 @@ export interface SupabaseConfig {
  * Official TeXRA Supabase configuration.
  *
  * These are the production credentials for TeXRA's official Supabase backend.
- * The anon key is public and safe to include in client code (required for Supabase client initialization).
+ * The public key (anon or publishable) is safe to include in client code.
+ * Row Level Security (RLS) policies protect data access, not the key.
  */
 
 export const SUPABASE_PROJECT_ID = 'jntubmcgbhwtcktubelv';
@@ -32,7 +38,7 @@ export const SUPABASE_CONFIG: SupabaseConfig = {
   // Production Supabase project URL
   url: `https://${SUPABASE_PROJECT_ID}.supabase.co`,
 
-  // Production anon key - safe to include in client code, required for Supabase client
+  // Production public key - safe to include in client code (anon JWT or publishable key)
   anonKey:
     'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImpudHVibWNnYmh3dGNrdHViZWx2Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTkzMDI5ODksImV4cCI6MjA3NDg3ODk4OX0.67InRy428t3zSBelbC92wo1nj5Llo4Jfb3A0yWNSzFo',
 

--- a/src/auth/config.ts
+++ b/src/auth/config.ts
@@ -19,7 +19,7 @@ export interface SupabaseConfig {
    * - Publishable key (recommended): starts with `sb_publishable_...`
    * - Anon key (legacy): JWT starting with `eyJ...`
    */
-  anonKey: string;
+  publicKey: string;
   /** Edge function URL for fetching remote agent configurations */
   edgeFunctionUrl: string;
 }
@@ -38,9 +38,8 @@ export const SUPABASE_CONFIG: SupabaseConfig = {
   // Production Supabase project URL
   url: `https://${SUPABASE_PROJECT_ID}.supabase.co`,
 
-  // Production public key - safe to include in client code (anon JWT or publishable key)
-  anonKey:
-    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImpudHVibWNnYmh3dGNrdHViZWx2Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTkzMDI5ODksImV4cCI6MjA3NDg3ODk4OX0.67InRy428t3zSBelbC92wo1nj5Llo4Jfb3A0yWNSzFo',
+  // Production public key - safe to include in client code
+  publicKey: 'sb_publishable_DUIDjtxk12ZYYncrVUfwOw_xWQYsSvw?',
 
   // Edge function URL
   edgeFunctionUrl: `https://${SUPABASE_PROJECT_ID}.supabase.co/functions/v1/get-agent-config`,
@@ -53,7 +52,7 @@ export const SUPABASE_CONFIG: SupabaseConfig = {
 export function isSupabaseConfigured(): boolean {
   return (
     SUPABASE_CONFIG.url !== `placeholder-url` &&
-    SUPABASE_CONFIG.anonKey !== 'placeholder-anon-key' &&
+    SUPABASE_CONFIG.publicKey !== 'placeholder-public-key' &&
     !SUPABASE_CONFIG.url.includes('placeholder')
   );
 }

--- a/src/common/webview/commands.ts
+++ b/src/common/webview/commands.ts
@@ -214,6 +214,9 @@ export const PROGRESS_VIEW_COMMANDS = {
   MERGE_FILE: 'mergeFile',
   LATEXDIFF_FILE: 'latexdiffFile',
   OPEN_LABEL: 'openLabel',
+
+  // Profile
+  OPEN_PROFILE: 'openProfile',
 };
 
 // History view specific commands

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -119,7 +119,7 @@ export async function activate(context: vscode.ExtensionContext) {
       if (!isSupabaseConfigured()) {
         logger.warn(
           'extension',
-          'Supabase authentication is enabled but credentials are not configured. Please set TEXRA_SUPABASE_URL and TEXRA_SUPABASE_ANON_KEY environment variables or hardcode them in src/auth/config.ts before building.',
+          'Supabase authentication is enabled but credentials are not configured. Please configure credentials in src/auth/config.ts before building.',
         );
       } else {
         // Register authentication provider

--- a/src/profileView/ProfileViewMessageHandler.ts
+++ b/src/profileView/ProfileViewMessageHandler.ts
@@ -73,6 +73,7 @@ export class ProfileViewMessageHandler extends BaseViewMessageHandler<
       description: string;
       tags: string[];
       visibility: string;
+      agentType?: string;
     }> = [];
 
     if (tier === 'researcher') {
@@ -84,6 +85,7 @@ export class ProfileViewMessageHandler extends BaseViewMessageHandler<
           description: agent.description,
           tags: agent.tags,
           visibility: agent.visibility,
+          agentType: agent.agentType,
         }));
       } catch (error) {
         // Log error but continue - show profile without agents

--- a/src/profileView/index.html
+++ b/src/profileView/index.html
@@ -96,6 +96,9 @@
     <template id="agentRowTemplate">
       <tr class="agent-row">
         <td class="agent-name"></td>
+        <td class="agent-type">
+          <span class="type-badge"></span>
+        </td>
         <td class="agent-description"></td>
         <td class="agent-visibility">
           <span class="visibility-badge"></span>

--- a/src/profileView/modules/constants.js
+++ b/src/profileView/modules/constants.js
@@ -40,3 +40,8 @@ export const LABELS = {
     'No remote agents available. Contact support@texra.ai for assistance.',
   NOT_AUTHENTICATED_MESSAGE: 'You are not signed in to TeXRA.',
 };
+
+// Default values
+export const DEFAULTS = {
+  AGENT_TYPE: 'CoT',
+};

--- a/src/profileView/modules/uiManagers/AgentsTable.js
+++ b/src/profileView/modules/uiManagers/AgentsTable.js
@@ -1,6 +1,6 @@
 /* global document, console */
 // Local imports - profile view
-import { ELEMENT_IDS, LABELS, CLASS_NAMES } from '../constants.js';
+import { ELEMENT_IDS, LABELS, CLASS_NAMES, DEFAULTS } from '../constants.js';
 import { PROFILE_VIEW_COMMANDS } from '@common/webview/commands.js';
 import { vscode } from '@common/webviewContext.js';
 import { safeGetElementById } from '@common/domUtils.js';
@@ -172,9 +172,7 @@ export class AgentsTable {
     // Set agent type badge
     const typeBadge = row.querySelector('.type-badge');
     if (typeBadge) {
-      const typeValue = agent.agentType || 'CoT';
-      typeBadge.textContent = typeValue;
-      typeBadge.classList.add(`type-${typeValue.toLowerCase()}`);
+      typeBadge.textContent = agent.agentType || DEFAULTS.AGENT_TYPE;
     }
 
     // Set description

--- a/src/profileView/modules/uiManagers/AgentsTable.js
+++ b/src/profileView/modules/uiManagers/AgentsTable.js
@@ -124,6 +124,7 @@ export class AgentsTable {
     thead.innerHTML = `
       <tr>
         <th>Agent</th>
+        <th>Type</th>
         <th>Description</th>
         <th>Visibility</th>
         <th>Tags</th>
@@ -167,6 +168,14 @@ export class AgentsTable {
     // Set agent name
     const agentName = row.querySelector('.agent-name');
     if (agentName) agentName.textContent = agent.name;
+
+    // Set agent type badge
+    const typeBadge = row.querySelector('.type-badge');
+    if (typeBadge) {
+      const typeValue = agent.agentType || 'CoT';
+      typeBadge.textContent = typeValue;
+      typeBadge.classList.add(`type-${typeValue.toLowerCase()}`);
+    }
 
     // Set description
     const description = row.querySelector('.agent-description');

--- a/src/profileView/styles/index.css
+++ b/src/profileView/styles/index.css
@@ -169,20 +169,7 @@ h2 {
   border-radius: var(--border-radius-small);
   font-size: var(--font-size-sm);
   font-weight: 500;
-}
-
-.type-badge.type-cot {
   background: var(--vscode-badge-background);
-  color: var(--vscode-badge-foreground);
-}
-
-.type-badge.type-direct {
-  background: var(--vscode-testing-iconPassed);
-  color: var(--vscode-badge-foreground);
-}
-
-.type-badge.type-tooluse {
-  background: var(--vscode-charts-purple);
   color: var(--vscode-badge-foreground);
 }
 

--- a/src/profileView/styles/index.css
+++ b/src/profileView/styles/index.css
@@ -162,6 +162,30 @@ h2 {
   color: var(--vscode-inputValidation-warningForeground);
 }
 
+/* Type badges */
+.type-badge {
+  display: inline-block;
+  padding: 2px var(--spacing-small);
+  border-radius: var(--border-radius-small);
+  font-size: var(--font-size-sm);
+  font-weight: 500;
+}
+
+.type-badge.type-cot {
+  background: var(--vscode-badge-background);
+  color: var(--vscode-badge-foreground);
+}
+
+.type-badge.type-direct {
+  background: var(--vscode-testing-iconPassed);
+  color: white;
+}
+
+.type-badge.type-tooluse {
+  background: var(--vscode-charts-purple);
+  color: white;
+}
+
 /* Tags */
 .agent-tags {
   display: flex;

--- a/src/profileView/styles/index.css
+++ b/src/profileView/styles/index.css
@@ -178,12 +178,12 @@ h2 {
 
 .type-badge.type-direct {
   background: var(--vscode-testing-iconPassed);
-  color: white;
+  color: var(--vscode-badge-foreground);
 }
 
 .type-badge.type-tooluse {
   background: var(--vscode-charts-purple);
-  color: white;
+  color: var(--vscode-badge-foreground);
 }
 
 /* Tags */

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -149,6 +149,9 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
       [PROGRESS_VIEW_COMMANDS.RESET_TOOL_EDIT_APPROVAL_BYPASS]:
         this.handleResetToolEditApprovalBypass.bind(this),
 
+      // Profile
+      [PROGRESS_VIEW_COMMANDS.OPEN_PROFILE]: this.handleOpenProfile.bind(this),
+
       // File operations
       [PROGRESS_VIEW_COMMANDS.OPEN_FILE]: this.handleOpenFile.bind(this),
       [PROGRESS_VIEW_COMMANDS.OPEN_FILE_COMPILE]:
@@ -588,6 +591,10 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
 
   private async handleOpenLabel(message: any): Promise<void> {
     await vscode.commands.executeCommand('texra.openLabel', message.label);
+  }
+
+  private async handleOpenProfile(): Promise<void> {
+    await vscode.commands.executeCommand('texra.auth.viewProfile');
   }
 
   private async handleFileOperation(

--- a/src/progressView/modules/constants.js
+++ b/src/progressView/modules/constants.js
@@ -54,6 +54,7 @@ export const ELEMENT_IDS = {
   FILTER_ALL_BTN: 'filterAllBtn',
   FILTER_WORKFLOW_BTN: 'filterWorkflowBtn',
   FILTER_TOOL_BTN: 'filterToolBtn',
+  OPEN_PROFILE_BTN: 'openProfileBtn',
 };
 
 export const GROUP_DOM_IDS = Object.freeze({
@@ -98,6 +99,15 @@ const OPEN_TASK_STORAGE_BUTTON = Object.freeze({
   title: 'Open the workspace storage folder for this run',
   className: 'storage-button toolbar-button--hidden',
   disabled: true,
+});
+
+const OPEN_PROFILE_BUTTON = Object.freeze({
+  id: ELEMENT_IDS.OPEN_PROFILE_BTN,
+  icon: 'account',
+  command: COMMANDS.OPEN_PROFILE,
+  title: 'Open profile view',
+  className: 'profile-button',
+  disabled: false,
 });
 
 /** @type {ToolbarButtonDefinition[]} */
@@ -152,6 +162,7 @@ const WORKFLOW_TOOLBAR = [
     className: 'pack-button',
     disabled: true,
   },
+  OPEN_PROFILE_BUTTON,
 ];
 
 /** @type {ToolbarButtonDefinition[]} */
@@ -167,6 +178,7 @@ const TOOL_USE_TOOLBAR = [
   },
   RESTORE_STATE_BUTTON,
   { ...OPEN_TASK_STORAGE_BUTTON },
+  OPEN_PROFILE_BUTTON,
 ];
 
 /** @type {Record<'workflow' | 'toolUse', ToolbarButtonDefinition[]>} */


### PR DESCRIPTION
- Add comprehensive "Understanding API Keys" section explaining publishable vs anon keys
- Document migration path from anon to publishable keys
- Remove references to unused TEXRA_SUPABASE_* environment variables
- Update config.ts comments to reflect support for both key types

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches Supabase auth from anon key to public publishable key and updates docs; adds agent type badges and an “Open Profile” action/button in the progress view.
> 
> - **Auth/Supabase**:
>   - Replace `anonKey` with `publicKey` across auth (`src/auth/SupabaseClient.ts`, `src/auth/SupabaseAuthProvider.ts`, `src/auth/config.ts`).
>   - Update types, initialization, and config checks; adjust warning message in `src/extension.ts`.
> - **Profile & Progress UI**:
>   - Profile view now includes agent `agentType` (default `CoT`) and displays a type badge (`index.html`, `AgentsTable.js`, `styles/index.css`).
>   - Add `OPEN_PROFILE` command and handler; include toolbar button in progress view (`common/webview/commands.ts`, `progressView/modules/constants.js`, `ProgressViewMessageHandler.ts`).
> - **Docs**:
>   - Expand Supabase guide to explain publishable vs anon keys, migration steps, and updated key retrieval; reference `publicKey` in config (`docs/supabase/SUPABASE_SETUP.md`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 52dd5c1bd73e489677af4fe4ebf920e49235cf77. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->