### PR TITLE
Finalize and verify mathematical calculations

### DIFF
--- a/src/agent/core/ResponseCycle.ts
+++ b/src/agent/core/ResponseCycle.ts
@@ -98,10 +98,14 @@ export async function runResponseCycle<C = unknown>(
   // Determine if the cycle failed due to an error (not user cancellation).
   // User cancellation clears lastError in BaseRetryWaitNode, so:
   // - Error failure: shouldStop=true, lastError exists → failedWithError=true
-  // - User cancelled: shouldStop=true, lastError=undefined → failedWithError=false
+  // - User cancelled: shouldStop=true, lastError=undefined, endTurn=false → userCancelled=true
+  // - Successful completion: shouldStop=true, lastError=undefined, endTurn=true → neither
   const failedWithError =
     shared.state.shouldStop && !!shared.retryState.lastError;
-  const userCancelled = shared.state.shouldStop && !shared.retryState.lastError;
+  const userCancelled =
+    shared.state.shouldStop &&
+    !shared.retryState.lastError &&
+    !shared.state.endTurn;
 
   return {
     store: input.store,

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -1566,7 +1566,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
       if (!hasEndTag(agentSetting, newResponse)) {
         return true;
       } else {
-        this.logger.debug('Should not continue - end tag found');
+        this.logger.debug('Response complete (end tag found)');
         return false;
       }
     }

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -1566,7 +1566,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
       if (!hasEndTag(agentSetting, newResponse)) {
         return true;
       } else {
-        this.logger.debug('Should not continue - no end tag found');
+        this.logger.debug('Should not continue - end tag found');
         return false;
       }
     }


### PR DESCRIPTION
The log message said "no end tag found" when the code was actually in the else branch (meaning an end tag WAS found). This caused confusion when debugging agent continuation logic.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Tightens user cancellation detection in response cycles and updates Anthropic handler logging to correctly indicate end-tag completion.
> 
> - **Core** (`src/agent/core/ResponseCycle.ts`):
>   - Refine `userCancelled` to require `shouldStop && !lastError && !endTurn`.
>   - Update inline docs to distinguish error failure, user cancel, and successful completion.
> - **Model Handler (Anthropic)** (`src/agent/modelHandlers/modelHandlerAnthropic.ts`):
>   - Fix debug message when `STOP_SEQUENCE` with end tag: now logs "Response complete (end tag found)".
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 79ace57aea4e38eec9dc17ada93e4e9659e914b6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->