### PR TITLE
Fix missing icons in dropdown menus

### DIFF
--- a/src/common/modules/iconConstants.js
+++ b/src/common/modules/iconConstants.js
@@ -5,17 +5,25 @@ export const CHEVRON_RIGHT_CLASS = 'codicon codicon-chevron-right';
 /**
  * Agent decorator configuration - single source of truth for all agent indicators.
  * Used across dropdown, stream tabs, and history view.
+ *
+ * Each decorator has:
+ * - icon: codicon name for use in places that support HTML (stream tabs, etc.)
+ * - unicode: unicode character for use in dropdowns (vscode-option only supports text)
+ * - label: human-readable label
+ * - hint: tooltip text (optional)
  */
 export const AGENT_DECORATORS = {
   // Agent properties (remote, multiple outputs)
   properties: {
     remote: {
       icon: 'cloud',
+      unicode: '☁',
       label: 'Remote',
       hint: 'Agent prompts loaded from remote',
     },
     multipleOutputs: {
       icon: 'files',
+      unicode: '∶∶',
       label: 'Multiple outputs',
       hint: 'Generates multiple output files',
     },
@@ -23,16 +31,16 @@ export const AGENT_DECORATORS = {
 
   // Agent types (reasoning strategy)
   types: {
-    CoT: { icon: 'list-tree', label: 'Chain of Thought' },
-    direct: { icon: 'lightbulb', label: 'Direct' },
-    toolUse: { icon: 'tools', label: 'Tool Use' },
-    unknown: { icon: 'question', label: 'Unknown' },
+    CoT: { icon: 'list-tree', unicode: '⊢', label: 'Chain of Thought' },
+    direct: { icon: 'lightbulb', unicode: '◈', label: 'Direct' },
+    toolUse: { icon: 'tools', unicode: '⚙', label: 'Tool Use' },
+    unknown: { icon: 'question', unicode: '?', label: 'Unknown' },
   },
 
   // Session kinds (workflow vs tool-use category)
   sessionKinds: {
-    workflow: { icon: 'symbol-method', label: 'Workflow' },
-    toolUse: { icon: 'tools', label: 'Tool Use' },
+    workflow: { icon: 'symbol-method', unicode: '▷', label: 'Workflow' },
+    toolUse: { icon: 'tools', unicode: '⚙', label: 'Tool Use' },
   },
 };
 

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -43,7 +43,6 @@ import {
 import { capitalize, uncapitalize } from '@common/stringUtils.js';
 import {
   AGENT_DECORATORS,
-  getCodiconClass,
   getAgentTypeDecorator,
 } from '@common/iconConstants.js';
 
@@ -248,20 +247,20 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
       this._readAgentOptionMetadata(opt);
 
     const hints = [];
-    const prefixIcons = [];
-    const suffixIcons = [];
+    let displayLabel = label;
 
-    // Add agent type icon (CoT, direct, toolUse)
+    // Add agent type indicator (CoT, direct, toolUse)
+    // Uses unicode since vscode-option only supports text content
     if (agentType) {
       const decorator = getAgentTypeDecorator(agentType);
-      prefixIcons.push(this._createCodiconHtml(decorator.icon));
+      displayLabel = `${decorator.unicode} ${displayLabel}`;
       hints.push(`Type: ${decorator.label}`);
     }
 
     // Add cloud icon for remote agents (using shared config)
     if (isRemote) {
-      const { icon, hint } = AGENT_DECORATORS.properties.remote;
-      prefixIcons.push(this._createCodiconHtml(icon));
+      const { unicode, hint } = AGENT_DECORATORS.properties.remote;
+      displayLabel = `${unicode} ${displayLabel}`;
       hints.push(hint);
     }
 
@@ -270,10 +269,10 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
       hints.push(description);
     }
 
-    // Add multiple outputs icon (using shared config)
+    // Add multiple outputs indicator (using shared config)
     if (isMultiple) {
-      const { icon, hint } = AGENT_DECORATORS.properties.multipleOutputs;
-      suffixIcons.push(this._createCodiconHtml(icon));
+      const { unicode, hint } = AGENT_DECORATORS.properties.multipleOutputs;
+      displayLabel = `${displayLabel} ${unicode}`;
       hints.push(hint);
       opt.style.opacity = '0.9';
     } else {
@@ -284,11 +283,8 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
       hints.push('Uses tools for actions.');
     }
 
-    // Build display with codicons
-    const escapedLabel = this._escapeHtml(label);
-    const prefix = prefixIcons.length > 0 ? prefixIcons.join('') + ' ' : '';
-    const suffix = suffixIcons.length > 0 ? ' ' + suffixIcons.join('') : '';
-    opt.innerHTML = `${prefix}${escapedLabel}${suffix}`;
+    // Set text content (vscode-option doesn't support HTML)
+    opt.textContent = displayLabel;
 
     if (hints.length > 0) {
       opt.title = hints.join('\n');
@@ -299,26 +295,6 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
       opt.setAttribute('aria-label', label);
       opt.removeAttribute('aria-description');
     }
-  }
-
-  /**
-   * Create a codicon HTML string for inline use.
-   * @param {string} iconName - Icon name (e.g., 'cloud', 'files')
-   * @returns {string} HTML string for the codicon
-   */
-  _createCodiconHtml(iconName) {
-    return `<i class="${getCodiconClass(iconName)}"></i>`;
-  }
-
-  /**
-   * Escape HTML special characters in a string.
-   * @param {string} text - Text to escape
-   * @returns {string} Escaped text
-   */
-  _escapeHtml(text) {
-    const div = document.createElement('div');
-    div.textContent = text;
-    return div.innerHTML;
   }
 
   _readAgentOptionMetadata(opt) {


### PR DESCRIPTION
vscode-option elements only support text content, not HTML elements like codicons. This change reverts to using unicode characters for agent indicators in dropdown menus while keeping codicon names available for other UI components that support HTML.

Unicode indicators:
- Agent types: ⊢ (CoT), ◈ (Direct), ⚙ (Tool Use)
- Remote: ☁
- Multiple outputs: ∶∶

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches agent dropdown rendering from codicon HTML to unicode text and adds unicode symbols to shared agent decorator config.
> 
> - **Webview**:
>   - Replace codicon-based HTML in agent `<vscode-option>` rendering with unicode prefixes/suffixes; set `textContent` instead of `innerHTML`.
>   - Remove codicon HTML helpers and related import; keep tooltips/ARIA labels and styling tweaks (opacity for multiple outputs).
> - **Common**:
>   - Extend `AGENT_DECORATORS` with `unicode` for properties (`remote`, `multipleOutputs`), types (`CoT`, `direct`, `toolUse`, `unknown`), and session kinds (`workflow`, `toolUse`).
>   - Update documentation comments to clarify icon vs unicode usage across UI.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 598cdfca6f320e258e246b13754d07bbc14e7e1f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->