### PR TITLE
Move profile button in progress view

### DIFF
--- a/package.json
+++ b/package.json
@@ -1441,6 +1441,11 @@
           "group": "navigation@5"
         },
         {
+          "command": "texra.auth.accountMenu",
+          "when": "view == texra.progressView",
+          "group": "navigation@6"
+        },
+        {
           "command": "texra.folderExplorer.newFile",
           "when": "view == texra.folderExplorer",
           "group": "navigation"

--- a/src/progressView/modules/constants.js
+++ b/src/progressView/modules/constants.js
@@ -54,7 +54,6 @@ export const ELEMENT_IDS = {
   FILTER_ALL_BTN: 'filterAllBtn',
   FILTER_WORKFLOW_BTN: 'filterWorkflowBtn',
   FILTER_TOOL_BTN: 'filterToolBtn',
-  OPEN_PROFILE_BTN: 'openProfileBtn',
 };
 
 export const GROUP_DOM_IDS = Object.freeze({
@@ -101,14 +100,6 @@ const OPEN_TASK_STORAGE_BUTTON = Object.freeze({
   disabled: true,
 });
 
-const OPEN_PROFILE_BUTTON = Object.freeze({
-  id: ELEMENT_IDS.OPEN_PROFILE_BTN,
-  icon: 'account',
-  command: COMMANDS.OPEN_PROFILE,
-  title: 'Open profile view',
-  className: 'profile-button',
-  disabled: false,
-});
 
 /** @type {ToolbarButtonDefinition[]} */
 const WORKFLOW_TOOLBAR = [
@@ -162,7 +153,6 @@ const WORKFLOW_TOOLBAR = [
     className: 'pack-button',
     disabled: true,
   },
-  OPEN_PROFILE_BUTTON,
 ];
 
 /** @type {ToolbarButtonDefinition[]} */
@@ -178,7 +168,6 @@ const TOOL_USE_TOOLBAR = [
   },
   RESTORE_STATE_BUTTON,
   { ...OPEN_TASK_STORAGE_BUTTON },
-  OPEN_PROFILE_BUTTON,
 ];
 
 /** @type {Record<'workflow' | 'toolUse', ToolbarButtonDefinition[]>} */


### PR DESCRIPTION
Move the profile button from the webview toolbar to the VS Code view title bar, positioning it next to the history button as intended.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Moves profile control from the webview toolbar to the view title bar via `texra.auth.accountMenu`, removing the old profile button from the ProgressBoard toolbar.
> 
> - **ProgressBoard UI**:
>   - Add `texra.auth.accountMenu` to the `view/title` menu for `view == texra.progressView` in `package.json` (placed after history).
>   - Remove profile button from the webview toolbar in `src/progressView/modules/constants.js` by deleting `ELEMENT_IDS.OPEN_PROFILE_BTN`, the `OPEN_PROFILE_BUTTON` definition, and its inclusion in `WORKFLOW_TOOLBAR` and `TOOL_USE_TOOLBAR`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5212c8d73a39085710c8522b039103b572cdbc77. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->