### PR TITLE
Configure Supabase connection for Texra domain

### DIFF
--- a/src/auth/config.ts
+++ b/src/auth/config.ts
@@ -34,15 +34,18 @@ export interface SupabaseConfig {
 
 export const SUPABASE_PROJECT_ID = 'jntubmcgbhwtcktubelv';
 
+/** Custom domain for Supabase (remote agent access) */
+export const SUPABASE_CUSTOM_DOMAIN = 'remote.texra.ai';
+
 export const SUPABASE_CONFIG: SupabaseConfig = {
-  // Production Supabase project URL
-  url: `https://${SUPABASE_PROJECT_ID}.supabase.co`,
+  // Production Supabase URL via custom domain
+  url: `https://${SUPABASE_CUSTOM_DOMAIN}`,
 
   // Production public key - safe to include in client code
   publicKey: 'sb_publishable_DUIDjtxk12ZYYncrVUfwOw_xWQYsSvw',
 
-  // Edge function URL
-  edgeFunctionUrl: `https://${SUPABASE_PROJECT_ID}.supabase.co/functions/v1/get-agent-config`,
+  // Edge function URL via custom domain
+  edgeFunctionUrl: `https://${SUPABASE_CUSTOM_DOMAIN}/functions/v1/get-agent-config`,
 };
 
 /**

--- a/src/auth/config.ts
+++ b/src/auth/config.ts
@@ -32,8 +32,6 @@ export interface SupabaseConfig {
  * Row Level Security (RLS) policies protect data access, not the key.
  */
 
-export const SUPABASE_PROJECT_ID = 'jntubmcgbhwtcktubelv';
-
 /** Custom domain for Supabase (remote agent access) */
 export const SUPABASE_CUSTOM_DOMAIN = 'remote.texra.ai';
 


### PR DESCRIPTION
Switch from default Supabase URL to custom domain for branded user experience during authentication and remote agent access.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch Supabase endpoints to `remote.texra.ai` via a new `SUPABASE_CUSTOM_DOMAIN` constant.
> 
> - **Auth config (`src/auth/config.ts`)**:
>   - Add `SUPABASE_CUSTOM_DOMAIN` (`remote.texra.ai`).
>   - Update `SUPABASE_CONFIG.url` and `edgeFunctionUrl` to use the custom domain.
>   - Remove `SUPABASE_PROJECT_ID` and project-id–based URLs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 50c9ec01d86735353c127494389ca2520dc6faae. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->