### PR TITLE
Migrate legacy usage data to new format

### DIFF
--- a/src/agent/core/AgentState.ts
+++ b/src/agent/core/AgentState.ts
@@ -27,6 +27,76 @@ export type NativeResponseUsage =
   | AnthropicUsage
   | GenerateContentResponseUsageMetadata;
 
+/**
+ * Migrates legacy UsageSummary format to NormalizedUsage.
+ * Extracts provider-specific fields (cached tokens, reasoning tokens, etc.)
+ * from the legacy format into the normalized structure.
+ */
+function migrateLegacyUsageSummary(
+  usageSummary: UsageSummary,
+  provider: UsageProvider,
+  responseTimeMs: number,
+  nativeUsage?: NativeUsagePayload | null,
+): NormalizedUsage {
+  if (!usageSummary) {
+    return {
+      inputTokens: 0,
+      outputTokens: 0,
+      cost: 0,
+      responseTimeMs,
+      provider,
+    };
+  }
+
+  const base: NormalizedUsage = {
+    inputTokens: usageSummary.totalInputTokens,
+    outputTokens: usageSummary.totalOutputTokens,
+    cost: usageSummary.cost,
+    responseTimeMs,
+    provider,
+    percentageCached:
+      usageSummary.percentageCached > 0
+        ? usageSummary.percentageCached
+        : undefined,
+    _native: nativeUsage ?? undefined,
+  };
+
+  // Extract provider-specific fields from legacy format
+  if (isAnthropicUsage(usageSummary)) {
+    if (usageSummary.cache_read_input_tokens) {
+      base.cachedInputTokens = usageSummary.cache_read_input_tokens;
+    }
+    if (usageSummary.cache_creation_input_tokens) {
+      base.cacheCreationTokens = usageSummary.cache_creation_input_tokens;
+    }
+    if (usageSummary.server_tool_use?.web_search_requests) {
+      base.serverToolRequests = usageSummary.server_tool_use.web_search_requests;
+    }
+  } else if (isOpenAIUsage(usageSummary)) {
+    if (usageSummary.cached_tokens > 0) {
+      base.cachedInputTokens = usageSummary.cached_tokens;
+    }
+    if (usageSummary.reasoning_tokens > 0) {
+      base.reasoningTokens = usageSummary.reasoning_tokens;
+    }
+    if (usageSummary.tool_use_tokens && usageSummary.tool_use_tokens > 0) {
+      base.toolUsePromptTokens = usageSummary.tool_use_tokens;
+    }
+  }
+
+  return base;
+}
+
+function isAnthropicUsage(
+  usage: UsageSummary,
+): usage is AnthropicAPIResponseUsage {
+  return usage !== null && 'input_tokens' in usage;
+}
+
+function isOpenAIUsage(usage: UsageSummary): usage is OpenAIAPIResponseUsage {
+  return usage !== null && 'prompt_tokens' in usage;
+}
+
 export const ConversationRoundStateSnapshotSchema = z.strictObject({
   roundIndex: z.number().int().nonnegative(),
   continuationCount: z.number().int().nonnegative(),
@@ -115,14 +185,12 @@ export class ConversationRoundState {
     }
     // Legacy: convert old format if present (for backward compatibility)
     else if (json.usageSummary && json.provider) {
-      state.normalizedUsage = {
-        inputTokens: json.usageSummary.totalInputTokens,
-        outputTokens: json.usageSummary.totalOutputTokens,
-        cost: json.usageSummary.cost,
-        responseTimeMs: json.usageSummary.responseTime,
-        provider: json.provider,
-        _native: json.nativeUsage ?? undefined,
-      };
+      state.normalizedUsage = migrateLegacyUsageSummary(
+        json.usageSummary,
+        json.provider,
+        json.responseTimeMs,
+        json.nativeUsage,
+      );
     }
 
     return state;

--- a/src/agent/core/RunUsageAccumulator.ts
+++ b/src/agent/core/RunUsageAccumulator.ts
@@ -1,5 +1,8 @@
 // Local imports - types
-import type { NormalizedUsage } from '@agent/types/NormalizedUsage';
+import type {
+  NormalizedUsage,
+  UsageProvider,
+} from '@agent/types/NormalizedUsage';
 
 // Re-export for backwards compatibility (used in AgentState legacy schema)
 import type {
@@ -17,6 +20,15 @@ export type UsageSummary =
   | OpenAIAPIResponseUsage
   | AnthropicAPIResponseUsage
   | null;
+
+/**
+ * @deprecated Legacy snapshot format - used only for migration
+ */
+interface LegacyNativeUsageSnapshot {
+  round: number;
+  provider: string;
+  payload: unknown;
+}
 
 /**
  * Snapshot of normalized usage for a single round.
@@ -144,8 +156,99 @@ export class RunUsageAccumulator {
     if (json.normalizedSnapshots) {
       acc.normalizedSnapshots.push(...json.normalizedSnapshots);
     }
-    // Note: Legacy `snapshots` field is ignored - totals are already aggregated
+    // Migrate legacy snapshots format to normalized format
+    else if (json.snapshots && Array.isArray(json.snapshots)) {
+      for (const snap of json.snapshots as LegacyNativeUsageSnapshot[]) {
+        const migrated = migrateLegacySnapshot(snap);
+        if (migrated) {
+          acc.normalizedSnapshots.push(migrated);
+        }
+      }
+    }
 
     return acc;
   }
+}
+
+/**
+ * Migrates a legacy native usage snapshot to normalized format.
+ * Extracts tokens from native payload; cost cannot be recovered (depends on pricing).
+ */
+function migrateLegacySnapshot(
+  legacy: LegacyNativeUsageSnapshot,
+): NormalizedUsageSnapshot | null {
+  if (!legacy.payload || typeof legacy.payload !== 'object') {
+    return null;
+  }
+
+  const payload = legacy.payload as Record<string, unknown>;
+  const provider = (legacy.provider || 'unknown') as UsageProvider;
+
+  // Try to detect payload format and extract tokens
+  // Anthropic format: input_tokens, output_tokens
+  if ('input_tokens' in payload) {
+    return {
+      round: legacy.round,
+      usage: {
+        inputTokens: (payload.input_tokens as number) ?? 0,
+        outputTokens: (payload.output_tokens as number) ?? 0,
+        cost: 0, // Cannot recover - depends on pricing at time of request
+        responseTimeMs: 0,
+        provider,
+        cachedInputTokens: (payload.cache_read_input_tokens as number) ?? undefined,
+        cacheCreationTokens: (payload.cache_creation_input_tokens as number) ?? undefined,
+        _native: payload,
+      },
+    };
+  }
+
+  // OpenAI format: prompt_tokens, completion_tokens
+  if ('prompt_tokens' in payload) {
+    const details = payload.prompt_tokens_details as Record<string, unknown> | undefined;
+    const completionDetails = payload.completion_tokens_details as Record<string, unknown> | undefined;
+    return {
+      round: legacy.round,
+      usage: {
+        inputTokens: (payload.prompt_tokens as number) ?? 0,
+        outputTokens: (payload.completion_tokens as number) ?? 0,
+        cost: 0, // Cannot recover - depends on pricing at time of request
+        responseTimeMs: 0,
+        provider,
+        cachedInputTokens: (details?.cached_tokens as number) ?? undefined,
+        reasoningTokens: (completionDetails?.reasoning_tokens as number) ?? undefined,
+        _native: payload,
+      },
+    };
+  }
+
+  // Google format: promptTokenCount, candidatesTokenCount
+  if ('promptTokenCount' in payload) {
+    return {
+      round: legacy.round,
+      usage: {
+        inputTokens: (payload.promptTokenCount as number) ?? 0,
+        outputTokens: (payload.candidatesTokenCount as number) ?? 0,
+        cost: 0, // Cannot recover - depends on pricing at time of request
+        responseTimeMs: 0,
+        provider,
+        cachedInputTokens: (payload.cachedContentTokenCount as number) ?? undefined,
+        reasoningTokens: (payload.thoughtsTokenCount as number) ?? undefined,
+        toolUsePromptTokens: (payload.toolUsePromptTokenCount as number) ?? undefined,
+        _native: payload,
+      },
+    };
+  }
+
+  // Unknown format - create minimal entry preserving native payload
+  return {
+    round: legacy.round,
+    usage: {
+      inputTokens: 0,
+      outputTokens: 0,
+      cost: 0,
+      responseTimeMs: 0,
+      provider,
+      _native: payload,
+    },
+  };
 }

--- a/src/common/state/stateManager.ts
+++ b/src/common/state/stateManager.ts
@@ -9,7 +9,6 @@ export enum WorkspaceStateKey {
   OUTPUT_FILES = 'texra.outputFiles',
   MISSING_OUTPUTS = 'texra.missingOutputs',
   RUN_INSTRUCTIONS = 'texra.runInstructions',
-  RUN_USAGE = 'texra.runUsage',
   ACTIVE_RUN_IDS = 'texra.activeRunIds',
   ACTIVE_STREAM_TAB = 'texra.activeStreamTab',
   TASK_STATES = 'texra.taskStates',

--- a/src/progressView/managers/UsageStatsManager.ts
+++ b/src/progressView/managers/UsageStatsManager.ts
@@ -18,6 +18,11 @@ import {
  */
 type RunUsageMap = Map<string, TokenUsageStats>;
 
+/** Stream ID used for migrated legacy data */
+const LEGACY_MIGRATION_STREAM = '_legacy_migrated_' as StreamTabId;
+/** Run ID used for migrated legacy data */
+const LEGACY_MIGRATION_RUN_ID = '_migrated_run_';
+
 export class UsageStatsManager extends PersistentMapManager<
   StreamTabId,
   RunUsageMap
@@ -194,11 +199,68 @@ export class UsageStatsManager extends PersistentMapManager<
    */
   async load(): Promise<void> {
     await super.load();
+
+    // Migrate orphaned texra.runUsage data (legacy key never loaded before)
+    await this.migrateLegacyRunUsage();
+
     if (this.items.size > 0) {
       this.logger.debug(
         `Loaded usage statistics for ${this.items.size} streams`,
       );
     }
+  }
+
+  /**
+   * Migrates orphaned data from legacy texra.runUsage key.
+   * This key was defined but never loaded, leaving data orphaned.
+   * Extracts totals and stores under a _legacy_ stream, then deletes the old key.
+   */
+  private async migrateLegacyRunUsage(): Promise<void> {
+    const LEGACY_KEY = 'texra.runUsage';
+
+    interface LegacyRunUsageTotals {
+      totalInputTokens?: number;
+      totalOutputTokens?: number;
+      totalCost?: number;
+    }
+
+    interface LegacyAgentRunStateJSON {
+      usageAccumulator?: {
+        totals?: LegacyRunUsageTotals;
+      };
+    }
+
+    const legacy = this.storage.get<LegacyAgentRunStateJSON>(LEGACY_KEY);
+    if (!legacy?.usageAccumulator?.totals) {
+      return;
+    }
+
+    const totals = legacy.usageAccumulator.totals;
+    const usage: TokenUsageStats = this.sanitizeUsage({
+      inputTokens: totals.totalInputTokens ?? 0,
+      outputTokens: totals.totalOutputTokens ?? 0,
+      cost: totals.totalCost ?? 0,
+    });
+
+    // Skip if no meaningful data
+    if (usage.inputTokens === 0 && usage.outputTokens === 0 && usage.cost === 0) {
+      await this.storage.update(LEGACY_KEY, undefined as never);
+      return;
+    }
+
+    // Store under legacy migration identifiers
+    const existing =
+      this.items.get(LEGACY_MIGRATION_STREAM) ?? new Map<string, TokenUsageStats>();
+    existing.set(LEGACY_MIGRATION_RUN_ID, usage);
+    this.items.set(LEGACY_MIGRATION_STREAM, existing);
+
+    // Save migrated data and clean up legacy key
+    await this.save();
+    await this.storage.update(LEGACY_KEY, undefined as never);
+
+    this.logger.info(
+      `Migrated legacy usage data: ${usage.inputTokens} input, ${usage.outputTokens} output, $${usage.cost.toFixed(4)} cost`,
+    );
   }
 
   /** Normalize loaded usage records */


### PR DESCRIPTION
- Fix responseTimeMs bug in ConversationRoundState.fromJSON() that was using accumulated time from usageSummary instead of per-round time
- Add migrateLegacyUsageSummary() to extract provider-specific fields (cached tokens, reasoning tokens, server tool requests) from legacy format
- Add legacy snapshots → normalizedSnapshots conversion in RunUsageAccumulator.fromJSON() with proper token extraction from native payloads (Anthropic, OpenAI, Google formats)
- Add migration for orphaned texra.runUsage data in UsageStatsManager that was never loaded due to missing code path
- Remove unused RUN_USAGE key from WorkspaceStateKey enum

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Migrates legacy usage/snapshots to normalized format with provider-specific fields, fixes per-round responseTimeMs, recovers orphaned `texra.runUsage` into stats, and removes an unused state key.
> 
> - **Agent core (`src/agent/core/AgentState.ts`)**:
>   - Add `migrateLegacyUsageSummary()` with provider-specific extraction (cached/reasoning/tool/server fields) and type guards.
>   - Use migrated normalized usage in `fromJSON()`; fix per-round `responseTimeMs` usage.
> - **Usage accumulation (`src/agent/core/RunUsageAccumulator.ts`)**:
>   - Convert legacy `snapshots` → `normalizedSnapshots` via `migrateLegacySnapshot()` with token extraction for Anthropic/OpenAI/Google formats; preserve native payload.
>   - Maintain totals with legacy field fallback.
> - **Usage stats persistence (`src/progressView/managers/UsageStatsManager.ts`)**:
>   - On load, migrate orphaned `texra.runUsage` totals into a legacy stream/run and delete old key.
> - **State keys (`src/common/state/stateManager.ts`)**:
>   - Remove unused `WorkspaceStateKey.RUN_USAGE`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1392d568a4af955720cc698b5920038534182520. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->