### PR TITLE
Consolidate token usage messages into one

### DIFF
--- a/src/agent/core/RunUsageAccumulator.ts
+++ b/src/agent/core/RunUsageAccumulator.ts
@@ -81,7 +81,11 @@ export class RunUsageAccumulator {
    */
   recordNormalizedUsage(round: number, usage: NormalizedUsage): void {
     if (this.totals.firstInputTokens === 0) {
-      this.totals.firstInputTokens = usage.inputTokens;
+      // Include cached tokens in first input count (Anthropic reports them separately)
+      this.totals.firstInputTokens =
+        usage.inputTokens +
+        (usage.cachedInputTokens ?? 0) +
+        (usage.cacheCreationTokens ?? 0);
     }
 
     this.totals.totalInputTokens += usage.inputTokens;

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -401,7 +401,7 @@ export abstract class ModelHandler<
 
     if (tokenFlags.maxOutputTokensExceeded) {
       const totals = stateGlobal.usageAccumulator.getTotals();
-      this.logger.info(
+      this.logger.warn(
         `Output tokens exceed ${this.maxOutputTokensFactor}x input tokens (total: ${totals.totalOutputTokens}, first input: ${totals.firstInputTokens})`,
       );
     }

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -402,10 +402,7 @@ export abstract class ModelHandler<
     if (tokenFlags.maxOutputTokensExceeded) {
       const totals = stateGlobal.usageAccumulator.getTotals();
       this.logger.warn(
-        `Output tokens exceed ${this.maxOutputTokensFactor}x input tokens`,
-      );
-      this.logger.warn(
-        `Total output tokens: ${totals.totalOutputTokens}, First input tokens: ${totals.firstInputTokens}`,
+        `Output tokens exceed ${this.maxOutputTokensFactor}x input tokens (total: ${totals.totalOutputTokens}, first input: ${totals.firstInputTokens})`,
       );
     }
 

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -401,7 +401,7 @@ export abstract class ModelHandler<
 
     if (tokenFlags.maxOutputTokensExceeded) {
       const totals = stateGlobal.usageAccumulator.getTotals();
-      this.logger.warn(
+      this.logger.info(
         `Output tokens exceed ${this.maxOutputTokensFactor}x input tokens (total: ${totals.totalOutputTokens}, first input: ${totals.firstInputTokens})`,
       );
     }


### PR DESCRIPTION
Combine the two separate warning messages about output token limits into a single log entry for cleaner output display.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Counts cached tokens in first-input totals and merges output-token limit warnings into a single log entry.
> 
> - **Usage tracking**:
>   - Update `RunUsageAccumulator.recordNormalizedUsage` to set `firstInputTokens` as `inputTokens + cachedInputTokens + cacheCreationTokens` (handles Anthropic separate reports).
> - **Logging**:
>   - Replace two warnings with one consolidated message in `ModelHandler.checkStopConditions` when output tokens exceed the input-based limit, including totals in-line.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 83527df7de6f654c7957cb0dcb6e59979ff39c81. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->