### PR TITLE
Remove indent.log and check subfolders

### DIFF
--- a/src/common/errors/errorHandlingUtils.ts
+++ b/src/common/errors/errorHandlingUtils.ts
@@ -87,6 +87,39 @@ export function toErrorMessage(err: unknown): string {
 }
 
 /**
+ * Check if an error represents a file-not-found condition.
+ *
+ * Handles both Node.js filesystem errors (ENOENT) and VS Code FileSystemError.
+ * Use this to differentiate between expected "file doesn't exist" errors and
+ * actual filesystem failures (permissions, disk issues, etc.).
+ *
+ * @param err - The error to check
+ * @returns true if the error indicates the file was not found
+ *
+ * @example
+ * ```typescript
+ * try {
+ *   await fs.unlink(filePath);
+ * } catch (err) {
+ *   if (isFileNotFoundError(err)) {
+ *     // File already deleted, this is fine
+ *   } else {
+ *     logger.warn(CHANNEL, `Error deleting file: ${err}`);
+ *   }
+ * }
+ * ```
+ */
+export function isFileNotFoundError(err: unknown): boolean {
+  if (err && typeof err === 'object' && 'code' in err) {
+    const code = (err as { code: string }).code;
+    if (code === 'ENOENT' || code === 'FileNotFound') {
+      return true;
+    }
+  }
+  return err instanceof vscode.FileSystemError && err.code === 'FileNotFound';
+}
+
+/**
  * Log a formatted error message and return the formatted message.
  *
  * This function combines error formatting with logging. It:

--- a/src/common/errors/errorHandlingUtils.ts
+++ b/src/common/errors/errorHandlingUtils.ts
@@ -110,9 +110,13 @@ export function toErrorMessage(err: unknown): string {
  * ```
  */
 export function isFileNotFoundError(err: unknown): boolean {
+  // VS Code FileSystemError (explicit check for type safety)
+  if (err instanceof vscode.FileSystemError) {
+    return err.code === 'FileNotFound';
+  }
+  // Node.js filesystem errors (ENOENT)
   if (err && typeof err === 'object' && 'code' in err) {
-    const code = (err as { code: string }).code;
-    return code === 'ENOENT' || code === 'FileNotFound';
+    return (err as { code: string }).code === 'ENOENT';
   }
   return false;
 }

--- a/src/common/errors/errorHandlingUtils.ts
+++ b/src/common/errors/errorHandlingUtils.ts
@@ -112,11 +112,9 @@ export function toErrorMessage(err: unknown): string {
 export function isFileNotFoundError(err: unknown): boolean {
   if (err && typeof err === 'object' && 'code' in err) {
     const code = (err as { code: string }).code;
-    if (code === 'ENOENT' || code === 'FileNotFound') {
-      return true;
-    }
+    return code === 'ENOENT' || code === 'FileNotFound';
   }
-  return err instanceof vscode.FileSystemError && err.code === 'FileNotFound';
+  return false;
 }
 
 /**

--- a/src/common/errors/index.ts
+++ b/src/common/errors/index.ts
@@ -2,6 +2,7 @@
 export {
   DocId,
   formatError,
+  isFileNotFoundError,
   toErrorMessage,
   logErrorMessage,
   showLoggedErrorMessage,

--- a/src/latex/formatter/latexindentpt.ts
+++ b/src/latex/formatter/latexindentpt.ts
@@ -3,10 +3,9 @@ import * as path from 'path';
 
 // Third-party imports
 import { sync as globSync } from 'glob';
-import * as vscode from 'vscode';
 
 // Local imports - log
-import { toErrorMessage } from '@common/errors';
+import { isFileNotFoundError, toErrorMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
 import { AbsoluteFS, WorkspaceFS } from '@utils/files';
 import { getConfig } from '@utils/config';
@@ -16,27 +15,16 @@ import { runToolWithCheck } from '@utils/system';
 const CHANNEL = 'LaTeXCommands';
 logger.initialize(CHANNEL);
 
-function isFileNotFound(err: unknown): boolean {
-  if (err && typeof err === 'object' && 'code' in err) {
-    const code = (err as { code: string }).code;
-    if (code === 'ENOENT' || code === 'FileNotFound') {
-      return true;
-    }
-  }
-  return err instanceof vscode.FileSystemError && err.code === 'FileNotFound';
-}
-
 async function cleanupIndentLog(
   deleteFn: (path: string) => Promise<void>,
   logPath: string,
-  displayPath: string,
 ): Promise<void> {
   try {
     await deleteFn(logPath);
-    logger.debug(CHANNEL, `Removed ${displayPath}`);
+    logger.debug(CHANNEL, `Removed ${logPath}`);
   } catch (err) {
-    if (isFileNotFound(err)) {
-      logger.debug(CHANNEL, `No indent.log to remove at ${displayPath}`);
+    if (isFileNotFoundError(err)) {
+      logger.debug(CHANNEL, `No indent.log to remove at ${logPath}`);
     } else {
       logger.warn(CHANNEL, `Error removing indent.log: ${err}`);
     }
@@ -118,7 +106,7 @@ export async function runLatexIndent(filePath: string): Promise<boolean> {
             await WorkspaceFS.delete(backupFile);
             logger.debug(CHANNEL, `Removed backup file: ${backupFile}`);
           } catch (err) {
-            if (!isFileNotFound(err)) {
+            if (!isFileNotFoundError(err)) {
               logger.warn(
                 CHANNEL,
                 `Error removing backup file ${backupFile}: ${err}`,
@@ -132,7 +120,6 @@ export async function runLatexIndent(filePath: string): Promise<boolean> {
       const relativeIndentLog = path.join(relativeDir, 'indent.log');
       await cleanupIndentLog(
         WorkspaceFS.delete.bind(WorkspaceFS),
-        relativeIndentLog,
         relativeIndentLog,
       );
     } else {
@@ -148,7 +135,6 @@ export async function runLatexIndent(filePath: string): Promise<boolean> {
       const indentLogPath = path.join(fileDir, 'indent.log');
       await cleanupIndentLog(
         AbsoluteFS.delete.bind(AbsoluteFS),
-        indentLogPath,
         indentLogPath,
       );
     }

--- a/src/latex/formatter/latexindentpt.ts
+++ b/src/latex/formatter/latexindentpt.ts
@@ -26,6 +26,23 @@ function isFileNotFound(err: unknown): boolean {
   return err instanceof vscode.FileSystemError && err.code === 'FileNotFound';
 }
 
+async function cleanupIndentLog(
+  deleteFn: (path: string) => Promise<void>,
+  logPath: string,
+  displayPath: string,
+): Promise<void> {
+  try {
+    await deleteFn(logPath);
+    logger.debug(CHANNEL, `Removed ${displayPath}`);
+  } catch (err) {
+    if (isFileNotFound(err)) {
+      logger.debug(CHANNEL, `No indent.log to remove at ${displayPath}`);
+    } else {
+      logger.warn(CHANNEL, `Error removing indent.log: ${err}`);
+    }
+  }
+}
+
 export async function runLatexIndent(filePath: string): Promise<boolean> {
   try {
     // Check if latexindent is installed
@@ -101,44 +118,39 @@ export async function runLatexIndent(filePath: string): Promise<boolean> {
             await WorkspaceFS.delete(backupFile);
             logger.debug(CHANNEL, `Removed backup file: ${backupFile}`);
           } catch (err) {
-            logger.warn(
-              CHANNEL,
-              `Error removing backup file ${backupFile}: ${err}`,
-            );
+            if (!isFileNotFound(err)) {
+              logger.warn(
+                CHANNEL,
+                `Error removing backup file ${backupFile}: ${err}`,
+              );
+            }
           }
         }
       }
-      // Clean up indent.log in the file's directory (relative path for workspace)
+      // Clean up indent.log in the file's directory
       const relativeDir = path.relative(workspacePath, fileDir);
       const relativeIndentLog = path.join(relativeDir, 'indent.log');
-      try {
-        await WorkspaceFS.delete(relativeIndentLog);
-        logger.debug(CHANNEL, `Removed ${relativeIndentLog}`);
-      } catch (err) {
-        if (isFileNotFound(err)) {
-          logger.debug(CHANNEL, `No indent.log to remove in ${relativeDir}`);
-        } else {
-          logger.warn(CHANNEL, `Error removing indent.log: ${err}`);
-        }
-      }
+      await cleanupIndentLog(
+        WorkspaceFS.delete.bind(WorkspaceFS),
+        relativeIndentLog,
+        relativeIndentLog,
+      );
     } else {
+      // Skip backup cleanup for non-workspace files since glob patterns require
+      // a workspace context. The batch indent command (indent.ts) handles cleanup
+      // for workspace files via recursive directory traversal.
       logger.debug(
         CHANNEL,
-        `Skipping workspace backup cleanup for ${filePath} (outside workspace)`,
+        `Skipping backup cleanup for ${filePath} (outside workspace)`,
       );
 
-      // Clean up indent.log for non-workspace files (absolute path)
+      // Clean up indent.log for non-workspace files
       const indentLogPath = path.join(fileDir, 'indent.log');
-      try {
-        await AbsoluteFS.delete(indentLogPath);
-        logger.debug(CHANNEL, `Removed ${indentLogPath}`);
-      } catch (err) {
-        if (isFileNotFound(err)) {
-          logger.debug(CHANNEL, `No indent.log to remove at ${indentLogPath}`);
-        } else {
-          logger.warn(CHANNEL, `Error removing indent.log: ${err}`);
-        }
-      }
+      await cleanupIndentLog(
+        AbsoluteFS.delete.bind(AbsoluteFS),
+        indentLogPath,
+        indentLogPath,
+      );
     }
 
     logger.info(CHANNEL, `Indented ${filePath}`);

--- a/src/latex/formatter/latexindentpt.ts
+++ b/src/latex/formatter/latexindentpt.ts
@@ -97,11 +97,29 @@ export async function runLatexIndent(filePath: string): Promise<boolean> {
           }
         }
       }
+      // Clean up indent.log in the file's directory (relative path for workspace)
+      const relativeDir = path.relative(workspacePath, fileDir);
+      const relativeIndentLog = path.join(relativeDir, 'indent.log');
+      try {
+        await WorkspaceFS.delete(relativeIndentLog);
+        logger.debug(CHANNEL, `Removed ${relativeIndentLog}`);
+      } catch (err) {
+        logger.debug(CHANNEL, `No indent.log to remove in ${relativeDir}`);
+      }
     } else {
       logger.debug(
         CHANNEL,
         `Skipping workspace backup cleanup for ${filePath} (outside workspace)`,
       );
+
+      // Clean up indent.log for non-workspace files (absolute path)
+      const indentLogPath = path.join(fileDir, 'indent.log');
+      try {
+        await AbsoluteFS.delete(indentLogPath);
+        logger.debug(CHANNEL, `Removed ${indentLogPath}`);
+      } catch (err) {
+        logger.debug(CHANNEL, `No indent.log to remove at ${indentLogPath}`);
+      }
     }
 
     logger.info(CHANNEL, `Indented ${filePath}`);

--- a/src/latex/formatter/latexindentpt.ts
+++ b/src/latex/formatter/latexindentpt.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 
 // Third-party imports
 import { sync as globSync } from 'glob';
+import * as vscode from 'vscode';
 
 // Local imports - log
 import { toErrorMessage } from '@common/errors';
@@ -14,6 +15,16 @@ import { runToolWithCheck } from '@utils/system';
 
 const CHANNEL = 'LaTeXCommands';
 logger.initialize(CHANNEL);
+
+function isFileNotFound(err: unknown): boolean {
+  if (err && typeof err === 'object' && 'code' in err) {
+    const code = (err as { code: string }).code;
+    if (code === 'ENOENT' || code === 'FileNotFound') {
+      return true;
+    }
+  }
+  return err instanceof vscode.FileSystemError && err.code === 'FileNotFound';
+}
 
 export async function runLatexIndent(filePath: string): Promise<boolean> {
   try {
@@ -104,7 +115,11 @@ export async function runLatexIndent(filePath: string): Promise<boolean> {
         await WorkspaceFS.delete(relativeIndentLog);
         logger.debug(CHANNEL, `Removed ${relativeIndentLog}`);
       } catch (err) {
-        logger.debug(CHANNEL, `No indent.log to remove in ${relativeDir}`);
+        if (isFileNotFound(err)) {
+          logger.debug(CHANNEL, `No indent.log to remove in ${relativeDir}`);
+        } else {
+          logger.warn(CHANNEL, `Error removing indent.log: ${err}`);
+        }
       }
     } else {
       logger.debug(
@@ -118,7 +133,11 @@ export async function runLatexIndent(filePath: string): Promise<boolean> {
         await AbsoluteFS.delete(indentLogPath);
         logger.debug(CHANNEL, `Removed ${indentLogPath}`);
       } catch (err) {
-        logger.debug(CHANNEL, `No indent.log to remove at ${indentLogPath}`);
+        if (isFileNotFound(err)) {
+          logger.debug(CHANNEL, `No indent.log to remove at ${indentLogPath}`);
+        } else {
+          logger.warn(CHANNEL, `Error removing indent.log: ${err}`);
+        }
       }
     }
 

--- a/src/latex/formatter/latexindentpt.ts
+++ b/src/latex/formatter/latexindentpt.ts
@@ -104,18 +104,6 @@ export async function runLatexIndent(filePath: string): Promise<boolean> {
       );
     }
 
-    const indentLogPath = path.join(path.dirname(filePath), 'indent.log');
-    try {
-      if (isWorkspaceFile) {
-        await WorkspaceFS.delete(indentLogPath);
-      } else {
-        await AbsoluteFS.delete(indentLogPath);
-      }
-      logger.debug(CHANNEL, 'Removed indent.log');
-    } catch (err) {
-      logger.warn(CHANNEL, `Error removing indent.log: ${err}`);
-    }
-
     logger.info(CHANNEL, `Indented ${filePath}`);
     return true;
   } catch (err) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a file-not-found detection helper and refactors latexindent cleanup to safely remove backups and indent.log for workspace and non-workspace files.
> 
> - **Errors**:
>   - Add `isFileNotFoundError(err)` to detect VS Code `FileSystemError` and Node `ENOENT`.
>   - Export `isFileNotFoundError` from `@common/errors` barrel.
> - **LaTeX Formatter (`latexindentpt`)**:
>   - Introduce `cleanupIndentLog()` helper and use `isFileNotFoundError` to avoid noisy warnings when files are absent.
>   - Refactor backup removal: glob and delete `*.bak*` variants within workspace; skip when outside workspace.
>   - Clean up `indent.log` in both modes (workspace via `WorkspaceFS`, non-workspace via `AbsoluteFS`).
>   - Reduce warning logs; add detailed debug logs for patterns and deletions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a672bb9baf823fe95b48b70781775127010ddc2a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->