### PR TITLE
Fix workflow agent media file extraction bug

### DIFF
--- a/src/webview/managers/ExecutionManager.ts
+++ b/src/webview/managers/ExecutionManager.ts
@@ -136,7 +136,7 @@ export class ExecutionManager {
       auxiliaryFiles: getFilesIfNotEmpty<string>(message.auxiliaryFiles),
       mediaFile: mapMediaPath(message.mediaFile ?? null),
       mediaFiles: getFilesIfNotEmpty<string>(
-        (message.media?.files ?? [])
+        (message.mediaFiles ?? [])
           .map(mapMediaPath)
           .filter((f: string | null): f is string => f !== null),
       ),


### PR DESCRIPTION
The ExecutionManager was incorrectly accessing message.media?.files which doesn't exist, instead of message.mediaFiles where the UI stores the selected media files. This caused user-selected media files to be silently dropped and never passed to the workflow agent.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reads media files from message.mediaFiles instead of nonexistent message.media?.files so selected media are passed to agents.
> 
> - **Webview**:
>   - **ExecutionManager** (`src/webview/managers/ExecutionManager.ts`): Build `mediaFiles` from `message.mediaFiles` (mapped and filtered) instead of `message.media?.files`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2ca8db9224437766094c79d01039699648c39b1a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->