### PR TITLE
Refactor runID and executionID confusion

### DIFF
--- a/src/agent/core/ToolUseCycle.ts
+++ b/src/agent/core/ToolUseCycle.ts
@@ -97,6 +97,13 @@ export async function runToolUseCycle<C = unknown>(
  *
  * For tool-use agents, we emit a simple file list without lineage or diff
  * stats since there's no meaningful base file to compare against.
+ *
+ * ## RunId for Tool-Use Agents
+ * Tool-use agents don't create task groups (logger hierarchy), so they use
+ * the ExecutionId as their RunId. This is intentional and documented in
+ * IdentifierTypes.ts. The executionId IS the runId for tool-use contexts.
+ *
+ * @see IdentifierTypes.ts for the full execution model documentation
  */
 function emitEditedFiles<C>(input: ToolUseCycleInput<C>): void {
   const { options, store } = input;
@@ -109,10 +116,10 @@ function emitEditedFiles<C>(input: ToolUseCycleInput<C>): void {
   const stream = options.context.streamId;
   const executionId = options.context.executionId;
   const roundIndex = store.round.roundIndex;
-  // Tool-use agents don't create logger groups. Use executionId (or streamId
-  // as fallback) to match the runId used by UsageMonitor for consistency.
-  // This ensures files and usage are stored under the same runId in the
-  // progress view, allowing resolveActiveRunId to correctly display files.
+
+  // For tool-use agents: ExecutionId IS the RunId (no task groups exist).
+  // Fallback to streamId only for legacy sessions without executionId.
+  // See IdentifierTypes.ts for the full execution model.
   const runId = executionId ?? stream;
 
   // Deduplicate by path in case the same file was edited multiple times

--- a/src/agent/types/IdentifierTypes.ts
+++ b/src/agent/types/IdentifierTypes.ts
@@ -1,4 +1,32 @@
 /**
+ * # Identifier Types and Execution Model
+ *
+ * TeXRA uses three distinct identifier types to track executions:
+ *
+ * ## Hierarchy
+ * ```
+ * StreamTabId (UI tab)
+ *   └── ExecutionId (history entry, UUID)
+ *         └── RunId (task group for files/usage, UUID or DEFAULT_RUN_ID)
+ * ```
+ *
+ * ## Workflow Agents (multi-round agents with task groups)
+ * - Create task groups via the logger hierarchy
+ * - RunId = task group ID from logger (a UUID)
+ * - Files and usage are stored under the task group's RunId
+ *
+ * ## Tool-Use Agents (interactive, single-session agents)
+ * - Do NOT create task groups (no logger hierarchy)
+ * - RunId = ExecutionId (they are the same value)
+ * - Files and usage are stored under the ExecutionId as the RunId
+ *
+ * ## Key Invariants
+ * - ExecutionId is ALWAYS a UUID (never null, never DEFAULT_RUN_ID)
+ * - RunId can be a UUID (task group or execution) OR DEFAULT_RUN_ID (legacy)
+ * - StreamTabId is human-readable and stable across executions
+ */
+
+/**
  * Stream Tab ID: Human-readable identifier used for UI tabs and execution deduplication
  * Format: "${agentName}@${modelName}: ${inputFileName}"
  * Example: "polish@sonnet37: paper.tex"
@@ -16,8 +44,30 @@ export type StreamTabId = string;
  * Example: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
  *
  * Purpose:
- * - Links executions to history entries
+ * - Links executions to history entries (created by AgentHistoryManager)
  * - Enables tracking of multiple executions of the same task
+ * - For tool-use agents, also serves as the RunId
  * - Used for audit and debugging purposes
+ *
+ * Note: ExecutionId is ALWAYS a UUID, never null or DEFAULT_RUN_ID.
  */
 export type ExecutionId = string;
+
+/**
+ * Run ID: Identifier for grouping files and usage statistics
+ * Format: UUID v4 OR DEFAULT_RUN_ID ("__default__")
+ *
+ * Purpose:
+ * - Primary dimension key for output files in progress view
+ * - Primary dimension key for usage statistics
+ * - Groups related outputs within a single execution
+ *
+ * For workflow agents: This is the task group ID from the logger hierarchy.
+ * For tool-use agents: This equals the ExecutionId (no task groups).
+ * For legacy sessions: This is DEFAULT_RUN_ID ("__default__").
+ *
+ * Note: When storing/retrieving data, use normalizeRunId() only for
+ * workflow agents or legacy data. Tool-use agents should use their
+ * ExecutionId directly without normalization.
+ */
+export type RunId = string;

--- a/src/agent/utils/UsageMonitor.ts
+++ b/src/agent/utils/UsageMonitor.ts
@@ -18,6 +18,12 @@ import { AgentExecutionContext } from '@agent/runtime/AgentExecutionContext';
  *
  * Cost is computed once during normalization and stored in the accumulator.
  * This class simply reads the pre-computed totals - no cost recomputation needed.
+ *
+ * ## RunId Resolution
+ * - Workflow agents: Uses task group ID from logger hierarchy (via usageReporter)
+ * - Tool-use agents: Uses executionId as the runId (no task groups exist)
+ *
+ * @see IdentifierTypes.ts for the full execution model documentation
  */
 type UsageMonitorRunKind = 'workflow' | 'tool-use';
 
@@ -82,6 +88,8 @@ export class UsageMonitor {
         }),
       };
 
+      // For tool-use agents: ExecutionId IS the RunId (no task groups exist).
+      // Fallback to streamId only for legacy sessions without executionId.
       const runId = this.context.executionId ?? this.context.streamId;
       usageReporter.report(payload, runId);
     } catch (error) {

--- a/src/common/constants/runIds.ts
+++ b/src/common/constants/runIds.ts
@@ -1,8 +1,15 @@
 /**
  * Run identifier utilities shared across agent runtime and UI layers.
  *
- * Moved from progressView to common to break the layer violation where
- * agent runtime was importing from the presentation layer.
+ * ## When to use normalizeRunId()
+ * - For workflow agents: Always normalize, as they may have null runId in legacy data
+ * - For legacy data migration: Normalize to DEFAULT_RUN_ID for backward compatibility
+ *
+ * ## When NOT to use normalizeRunId()
+ * - For tool-use agents: Use executionId directly as the runId (it's always a UUID)
+ * - For ExecutionId values: Never normalize - they are always UUIDs by design
+ *
+ * @see IdentifierTypes.ts for the full execution model documentation
  */
 
 /**
@@ -13,10 +20,29 @@
 export const DEFAULT_RUN_ID = '__default__';
 
 /**
- * Normalize a run ID, falling back to the default sentinel value.
+ * Normalize a run ID for workflow agents, falling back to the default sentinel value.
+ *
+ * Use this for workflow agents and legacy data where runId may be null/undefined.
+ * Do NOT use this for tool-use agents or ExecutionId values.
+ *
  * @param runId - The run ID to normalize, may be null or undefined
  * @returns Normalized run ID, never null or undefined
  */
 export function normalizeRunId(runId: string | null | undefined): string {
   return runId ?? DEFAULT_RUN_ID;
+}
+
+/**
+ * Check if a value is a valid UUID-format identifier (ExecutionId or task group RunId).
+ *
+ * Useful for distinguishing between UUID-based IDs and the DEFAULT_RUN_ID sentinel.
+ */
+export function isUuidRunId(runId: string | null | undefined): boolean {
+  if (!runId || runId === DEFAULT_RUN_ID) {
+    return false;
+  }
+  // UUID pattern: 8-4-4-4-12 hex digits (any version)
+  const uuidPattern =
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+  return uuidPattern.test(runId);
 }

--- a/src/progressView/managers/OutputFilesManager.ts
+++ b/src/progressView/managers/OutputFilesManager.ts
@@ -171,16 +171,30 @@ export class OutputFilesManager extends PersistentMapManager<
     return new Map(target);
   }
 
+  /**
+   * Find output files for a stream by executionId.
+   *
+   * For tool-use agents, executionId IS the runId (they are stored as such).
+   * For workflow agents, we search for files that have matching executionId
+   * in their location metadata.
+   *
+   * Note: ExecutionId is always a UUID, so we do NOT normalize it.
+   * normalizeRunId() is only for legacy workflow data that might have null runId.
+   *
+   * @see IdentifierTypes.ts for the full execution model documentation
+   */
   getRunByExecution(
     stream: StreamTabId,
     executionId: ExecutionId,
   ): Map<number, OutputFileInfo[]> | undefined {
-    const normalized = normalizeRunId(executionId);
-    const direct = this.getRun(stream, normalized);
+    // For tool-use agents: executionId IS the runId (no normalization needed)
+    // ExecutionId is always a UUID, never null or DEFAULT_RUN_ID
+    const direct = this.getRun(stream, executionId);
     if (direct) {
       return direct;
     }
 
+    // For workflow agents: search for files with matching executionId in metadata
     const runs = this.items.get(stream);
     if (!runs) {
       return undefined;

--- a/src/progressView/state/ProgressViewState.ts
+++ b/src/progressView/state/ProgressViewState.ts
@@ -180,6 +180,24 @@ export class ProgressViewState {
     this.saveActiveRunIds();
   }
 
+  /**
+   * Resolve and optionally persist the active run ID for a stream.
+   *
+   * This method determines which run (task group) should be active for display
+   * in the progress view. The resolution strategy:
+   * 1. If a specific runId is requested, validate it exists and use it
+   * 2. Otherwise, check for a previously active runId
+   * 3. If only one run exists, use that
+   * 4. Otherwise, find the most recent run
+   *
+   * For tool-use agents: The runId will be the executionId (same UUID)
+   * For workflow agents: The runId will be a task group ID
+   *
+   * @param stream - The stream to resolve for
+   * @param requested - Optional specific runId to use
+   * @param options.persist - Whether to save the resolved runId (default: true)
+   * @returns The resolved runId, or null if none found
+   */
   resolveRunId(
     stream: StreamTabId,
     requested?: string | null,
@@ -390,10 +408,25 @@ export class ProgressViewState {
     );
   }
 
+  /**
+   * Get output files for a stream, resolving the correct dimension key.
+   *
+   * ## Resolution Strategy
+   * 1. If executionId is provided, try to find files stored under that ID
+   *    (works for both tool-use agents and workflow agents with runStorage)
+   * 2. Otherwise, use runId (task group) or fall back to activeRunId
+   *
+   * For tool-use agents: executionId IS the runId (same UUID)
+   * For workflow agents: runId is the task group ID, executionId is metadata
+   *
+   * @see IdentifierTypes.ts for the full execution model documentation
+   */
   getRunOutputFiles(
     stream: StreamTabId,
     options: { executionId?: ExecutionId; runId?: string | null } = {},
   ): Map<number, OutputFileInfo[]> | undefined {
+    // Try executionId first - works for tool-use agents where executionId IS runId
+    // and for workflow agents with runStorage metadata
     if (options.executionId) {
       const byExecution = this._outputFiles.getRunByExecution(
         stream,
@@ -404,6 +437,7 @@ export class ProgressViewState {
       }
     }
 
+    // Fall back to runId (task group for workflow agents, or legacy data)
     const candidateRunId =
       options.runId ?? this.getActiveRunId(stream) ?? undefined;
     if (!candidateRunId) {


### PR DESCRIPTION
Establish clear documentation and semantics for the three identifier types:
- StreamTabId: Human-readable UI tab identifier
- ExecutionId: UUID for each execution instance (always a UUID)
- RunId: Task group identifier (UUID for workflows, ExecutionId for tool-use)

Key changes:
- Add comprehensive documentation in IdentifierTypes.ts explaining the execution model hierarchy and how each agent type uses these IDs
- Add isUuidRunId() helper function to distinguish UUIDs from DEFAULT_RUN_ID
- Fix OutputFilesManager.getRunByExecution() to not incorrectly normalize ExecutionId values (they are always UUIDs, not legacy null values)
- Update comments in ToolUseCycle and UsageMonitor to clarify that tool-use agents intentionally use ExecutionId as RunId (not a bug)
- Add documentation to ProgressViewState for run resolution strategy

This refactoring improves maintainability by making the relationship between RunId and ExecutionId explicit and documenting when normalization is appropriate (workflow/legacy) vs when it should be avoided (tool-use).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Documents identifier hierarchy and updates run/file/usage resolution to use executionId as runId for tool-use agents while avoiding unnecessary normalization.
> 
> - **Identifiers & Constants**:
>   - Add comprehensive docs in `IdentifierTypes.ts` defining `StreamTabId` → `ExecutionId` → `RunId` hierarchy and invariants; clarify tool-use agents use `ExecutionId` as `RunId`.
>   - Clarify `normalizeRunId()` usage and add `isUuidRunId()` in `common/constants/runIds.ts`.
> - **Progress View**:
>   - `OutputFilesManager.getRunByExecution()` now uses `executionId` directly (no normalization); falls back to metadata search for workflow runs.
>   - `ProgressViewState.getRunOutputFiles()` prefers lookup by `executionId` before `runId`; add detailed run resolution docs.
> - **Agent Runtime**:
>   - `ToolUseCycle.emitEditedFiles()` explicitly uses `executionId ?? streamId` for `runId` with docs noting tool-use behavior.
>   - `UsageMonitor` reports usage under `executionId` (fallback to `streamId` for legacy) and documents runId resolution.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0588981b35e3e937714dc5e66112fce7fdd717cf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->