### PR TITLE
Fix redirect URI configuration mismatch

### DIFF
--- a/docs/supabase/SUPABASE_SETUP.md
+++ b/docs/supabase/SUPABASE_SETUP.md
@@ -151,16 +151,22 @@ For the VS Code extension OAuth flow to work, you **MUST** add the VS Code URI s
    ```
    vscode://texra-ai.texra/auth-callback
    vscode-insiders://texra-ai.texra/auth-callback
+   cursor://texra-ai.texra/auth-callback
    ```
 3. Click "Save"
 
-**Why this is needed**: When users authenticate via GitHub/Google, the OAuth flow redirects back to VS Code using the `vscode://` URI scheme. Without adding these URLs to the allowed list, Supabase will redirect to `localhost:3000` which won't work in the VS Code extension.
+**Why this is needed**: When users authenticate via GitHub/Google, the OAuth flow redirects back to the IDE using a custom URI scheme. Without adding these URLs to the allowed list, Supabase will show an error "The redirect_uri is not associated with this application".
+
+**Supported IDEs and their URI schemes**:
+- **VS Code**: `vscode://`
+- **VS Code Insiders**: `vscode-insiders://`
+- **Cursor**: `cursor://`
 
 **Common mistakes**:
 
 - ❌ Using `vscode://LionSR.texra/auth-callback` (wrong extension ID)
 - ❌ Only adding `localhost:3000` (this is for web apps, not VS Code extensions)
-- ❌ Forgetting to add both `vscode://` and `vscode-insiders://` variants
+- ❌ Forgetting to add all IDE variants (vscode, vscode-insiders, cursor)
 
 ---
 

--- a/docs/supabase/SUPABASE_SETUP.md
+++ b/docs/supabase/SUPABASE_SETUP.md
@@ -152,6 +152,7 @@ For the VS Code extension OAuth flow to work, you **MUST** add the VS Code URI s
    vscode://texra-ai.texra/auth-callback
    vscode-insiders://texra-ai.texra/auth-callback
    cursor://texra-ai.texra/auth-callback
+   windsurf://texra-ai.texra/auth-callback
    ```
 3. Click "Save"
 
@@ -161,12 +162,13 @@ For the VS Code extension OAuth flow to work, you **MUST** add the VS Code URI s
 - **VS Code**: `vscode://`
 - **VS Code Insiders**: `vscode-insiders://`
 - **Cursor**: `cursor://`
+- **Windsurf**: `windsurf://`
 
 **Common mistakes**:
 
 - ❌ Using `vscode://LionSR.texra/auth-callback` (wrong extension ID)
 - ❌ Only adding `localhost:3000` (this is for web apps, not VS Code extensions)
-- ❌ Forgetting to add all IDE variants (vscode, vscode-insiders, cursor)
+- ❌ Forgetting to add all IDE variants (vscode, vscode-insiders, cursor, windsurf)
 
 ---
 

--- a/src/auth/SupabaseAuthProvider.ts
+++ b/src/auth/SupabaseAuthProvider.ts
@@ -4,7 +4,7 @@ import { SupabaseClient } from './SupabaseClient';
 import {
   SUPABASE_CONFIG,
   DEFAULT_OAUTH_PROVIDER,
-  EXTENSION_ID,
+  getExtensionId,
 } from './config';
 import type { SupabaseUriHandler } from './UriHandler';
 
@@ -137,7 +137,7 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
       const { data, error } = await supabase.auth.signInWithOAuth({
         provider: DEFAULT_OAUTH_PROVIDER,
         options: {
-          redirectTo: `${vscode.env.uriScheme}://${EXTENSION_ID}/auth-callback`,
+          redirectTo: `${vscode.env.uriScheme}://${getExtensionId()}/auth-callback`,
         },
       });
 

--- a/src/auth/config.ts
+++ b/src/auth/config.ts
@@ -74,5 +74,31 @@ export const DEFAULT_OAUTH_PROVIDER: OAuthProvider = 'github';
 /**
  * VS Code extension ID for OAuth redirects.
  * Format: publisher.extensionName (from package.json)
+ *
+ * This is the default/fallback value. At runtime, use getExtensionId()
+ * which returns the actual extension ID from context if available.
  */
 export const EXTENSION_ID = 'texra-ai.texra';
+
+/**
+ * Runtime extension ID set during activation.
+ * This ensures the redirect URI matches the actual extension ID,
+ * which is critical for OAuth flows.
+ */
+let runtimeExtensionId: string | null = null;
+
+/**
+ * Set the runtime extension ID from the extension context.
+ * Should be called during extension activation with context.extension.id
+ */
+export function setRuntimeExtensionId(id: string): void {
+  runtimeExtensionId = id;
+}
+
+/**
+ * Get the extension ID for OAuth redirects.
+ * Returns the runtime ID if set, otherwise falls back to the default.
+ */
+export function getExtensionId(): string {
+  return runtimeExtensionId ?? EXTENSION_ID;
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -113,7 +113,12 @@ export async function activate(context: vscode.ExtensionContext) {
     try {
       const { SupabaseAuthProvider } =
         await import('@/auth/SupabaseAuthProvider');
-      const { isSupabaseConfigured } = await import('@/auth/config');
+      const { isSupabaseConfigured, setRuntimeExtensionId } =
+        await import('@/auth/config');
+
+      // Set the runtime extension ID for OAuth redirects
+      // This ensures the redirect URI matches the actual extension ID
+      setRuntimeExtensionId(context.extension.id);
 
       // Check if Supabase credentials are configured
       if (!isSupabaseConfigured()) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Use the runtime extension ID for OAuth redirect URIs and update docs to include additional IDE schemes and guidance.
> 
> - **Auth/OAuth**:
>   - Replace hardcoded `EXTENSION_ID` with `getExtensionId()` in `src/auth/SupabaseAuthProvider.ts` to build `redirectTo` dynamically.
>   - Add runtime ID plumbing in `src/auth/config.ts` (`setRuntimeExtensionId`, `getExtensionId`) with fallback to `EXTENSION_ID`.
>   - Set runtime extension ID during activation in `src/extension.ts` via `setRuntimeExtensionId(context.extension.id)` before registering auth provider.
> - **Docs** (`docs/supabase/SUPABASE_SETUP.md`):
>   - Add redirect URI schemes for Cursor and Windsurf; generalize explanation and list supported IDE schemes.
>   - Update common mistakes to require all IDE variants.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 498920a44df7a9463b9b8d9e69341ca9f9bdeb97. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->