### PR TITLE
Remove extra VS Code notification message

### DIFF
--- a/src/agent/remote/remoteAgentUtils.ts
+++ b/src/agent/remote/remoteAgentUtils.ts
@@ -120,12 +120,10 @@ async function handleSelectionFallback(
 export async function selectAgentInMainView(
   agentName: string,
   options: {
-    showSuccessMessage?: boolean;
     copyToClipboardOnFailure?: boolean;
   } = {},
 ): Promise<SelectAgentResult> {
-  const { showSuccessMessage = true, copyToClipboardOnFailure = false } =
-    options;
+  const { copyToClipboardOnFailure = false } = options;
 
   // Focus the main view first
   await vscode.commands.executeCommand('texra.mainView.focus');
@@ -143,12 +141,6 @@ export async function selectAgentInMainView(
           workflowAgent: agentName,
         },
       });
-
-      if (showSuccessMessage) {
-        void vscode.window.showInformationMessage(
-          `Remote agent "${agentName}" is now selected.`,
-        );
-      }
 
       return {
         success: true,

--- a/src/profileView/ProfileViewMessageHandler.ts
+++ b/src/profileView/ProfileViewMessageHandler.ts
@@ -126,10 +126,7 @@ export class ProfileViewMessageHandler extends BaseViewMessageHandler<
     }
 
     // Use shared utility for agent selection
-    await selectAgentInMainView(agentName, {
-      showSuccessMessage: true,
-      copyToClipboardOnFailure: false,
-    });
+    await selectAgentInMainView(agentName);
   }
 
   private async handleSignIn(


### PR DESCRIPTION
The information message shown when an agent is selected is unnecessary since the dropdown already updates visually to reflect the new selection.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the success notification on agent selection, drops the `showSuccessMessage` option from `selectAgentInMainView`, and updates its call site.
> 
> - **Remote agent selection**:
>   - Remove `showSuccessMessage` option from `selectAgentInMainView` and stop showing success info messages on selection.
>   - Preserve fallback behavior (clipboard/manual) via `copyToClipboardOnFailure`.
> - **Call site update**:
>   - Update `ProfileViewMessageHandler` to call `selectAgentInMainView(agentName)` without options.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 753feac58211c457f1b44c9ba7a730cb25be31ad. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->