### PR TITLE
Fix dropdown menu visibility overflow issue

### DIFF
--- a/src/webview/styles/footer.css
+++ b/src/webview/styles/footer.css
@@ -61,3 +61,12 @@
 .agent-select--active {
   position: relative;
 }
+
+/* Make footer dropdowns open upward to avoid clipping at bottom of webview */
+.model-selection-footer vscode-single-select::part(listbox),
+#workflowAgent::part(listbox),
+#toolUseAgent::part(listbox),
+#model::part(listbox) {
+  bottom: 100%;
+  top: auto;
+}


### PR DESCRIPTION
Model and agent select dropdowns in the footer were being clipped when opening downward at the bottom of the webview panel. This change makes them open upward by positioning the listbox above the trigger button.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjust listbox positioning so footer model/agent selects open upward instead of downward to avoid being clipped at the bottom of the webview.
> 
> - **Styles**:
>   - Update `src/webview/styles/footer.css` to force footer dropdown listboxes (`vscode-single-select`, `#workflowAgent`, `#toolUseAgent`, `#model`) to open upward by setting `::part(listbox)` `bottom: 100%` and `top: auto`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f8f35539a20b19314a38ee72cc36568aa1b17e50. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->