### PR TITLE
Implement background polling for OpenAI responses

### DIFF
--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -684,14 +684,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         );
         this.logger.info(
           `Running OpenAI Responses in background mode for response ${response.id}; polling every 15s. Completion may take longer than usual.`,
-          {
-            messageType: MESSAGE_TYPES.PROGRESS_STATUS,
-            data: {
-              responseId: response.id,
-              pollIntervalMs:
-                ModelHandlerOpenAIResponse.BACKGROUND_POLL_INTERVAL_MS,
-            },
-          },
+          { messageType: MESSAGE_TYPES.PROGRESS_STATUS },
         );
       }
       if (useBackgroundResponses) {


### PR DESCRIPTION
…ng log

The response ID and poll interval were displayed twice - once in the message text and again as separate data fields.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Simplifies background-mode progress log to only include message type, removing redundant responseId and pollInterval data.
> 
> - **Logging**:
>   - Background polling progress log now sends only `messageType: MESSAGE_TYPES.PROGRESS_STATUS`.
>   - Removes redundant `responseId` and `pollIntervalMs` fields from the progress payload during background responses.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 52aa43c0b6b8ffee4328a912b418a01f9be03136. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->