### PR TITLE
Fix select component bug

### DIFF
--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -233,7 +233,7 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
 
         // Find the best matching option
         let targetValue = agentValue;
-        const options = Array.from(selectElement.children);
+        const options = getSelectOptionElements(selectElement);
 
         // First try exact match
         let matchingOption = options.find((opt) => opt.value === agentValue);
@@ -273,8 +273,8 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
         mainViewState.applySessionType(targetSessionType);
 
         // Decorate the placeholder option if it was just created
-        // Re-query children since _setAgentValue may have added a new option
-        const currentOptions = Array.from(selectElement.children);
+        // Re-query options since _setAgentValue may have added a new option
+        const currentOptions = getSelectOptionElements(selectElement);
         const option = currentOptions.find((opt) => opt.value === targetValue);
         if (option && !option.dataset.decorated) {
           this._decorateAgentOption(option);


### PR DESCRIPTION
The SET_SELECTED_AGENT handler was using selectElement.children to find options, but the rest of the codebase uses getSelectOptionElements() which uses querySelectorAll('vscode-option'). This caused the agent dropdown to not update when selecting a remote agent because children might not find nested vscode-option elements.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace children-based option lookup with getSelectOptionElements in SET_SELECTED_AGENT to correctly select and decorate agent options (including nested/remote).
> 
> - **Webview**:
>   - Update `SET_SELECTED_AGENT` in `src/webview/modules/messageHandlers.js` to use `getSelectOptionElements(selectElement)` instead of `selectElement.children` for:
>     - Finding the target option (exact/name match)
>     - Re-querying options after `_setAgentValue`
>   - Ensures correct selection and decoration of agent options when options are nested (e.g., remote agents).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0b8b7a5305ec7a713d806d6a1e3971908bba7465. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->