### PR TITLE
Refactor runID and executionID confusion

### DIFF
--- a/src/agent/core/ToolUseCycle.ts
+++ b/src/agent/core/ToolUseCycle.ts
@@ -98,12 +98,12 @@ export async function runToolUseCycle<C = unknown>(
  * For tool-use agents, we emit a simple file list without lineage or diff
  * stats since there's no meaningful base file to compare against.
  *
- * ## RunId for Tool-Use Agents
- * Tool-use agents don't create task groups (logger hierarchy), so they use
- * the ExecutionId as their RunId. This is intentional and documented in
- * IdentifierTypes.ts. The executionId IS the runId for tool-use contexts.
+ * ## Storage Key for Tool-Use Agents
+ * Tool-use agents use context.storageKey which equals their executionId
+ * (since they don't create task groups). This is computed once at execution
+ * start and used consistently across all storage operations.
  *
- * @see IdentifierTypes.ts for the full execution model documentation
+ * @see ExecutionIdentity for the unified identity model
  */
 function emitEditedFiles<C>(input: ToolUseCycleInput<C>): void {
   const { options, store } = input;
@@ -113,14 +113,11 @@ function emitEditedFiles<C>(input: ToolUseCycleInput<C>): void {
     return;
   }
 
-  const stream = options.context.streamId;
-  const executionId = options.context.executionId;
+  const { context } = options;
+  const stream = context.streamId;
+  const storageKey = context.storageKey;
+  const executionId = context.executionId;
   const roundIndex = store.round.roundIndex;
-
-  // For tool-use agents: ExecutionId IS the RunId (no task groups exist).
-  // Fallback to streamId only for legacy sessions without executionId.
-  // See IdentifierTypes.ts for the full execution model.
-  const runId = executionId ?? stream;
 
   // Deduplicate by path in case the same file was edited multiple times
   const uniquePaths = [...new Set(interactions.edits.map((e) => e.path))];
@@ -133,7 +130,8 @@ function emitEditedFiles<C>(input: ToolUseCycleInput<C>): void {
 
   bus.emit('addOutputFiles', {
     stream,
-    runId,
+    storageKey,
+    runId: storageKey, // Backward compatibility
     executionId,
     filesByRound: { [roundIndex]: fileInfos },
   });

--- a/src/agent/core/ToolUseCycle.ts
+++ b/src/agent/core/ToolUseCycle.ts
@@ -131,7 +131,6 @@ function emitEditedFiles<C>(input: ToolUseCycleInput<C>): void {
   bus.emit('addOutputFiles', {
     stream,
     storageKey,
-    runId: storageKey, // Backward compatibility
     executionId,
     filesByRound: { [roundIndex]: fileInfos },
   });

--- a/src/agent/implementations/BaseAgent.ts
+++ b/src/agent/implementations/BaseAgent.ts
@@ -56,7 +56,7 @@ export abstract class BaseAgent<C = unknown> implements IAgent {
   protected client: C | null = null;
   protected isInterrupted = false;
   protected abortController: AbortController | null = null;
-  protected executionId?: ExecutionId;
+  protected readonly executionId: ExecutionId;
 
   private static runningAgents: Map<string, BaseAgent> = new Map();
 
@@ -247,11 +247,7 @@ export abstract class BaseAgent<C = unknown> implements IAgent {
     return this.isInterrupted;
   }
 
-  public setExecutionId(id: ExecutionId): void {
-    this.executionId = id;
-  }
-
-  public getExecutionId(): ExecutionId | undefined {
+  public getExecutionId(): ExecutionId {
     return this.executionId;
   }
 

--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -204,6 +204,14 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
     const hydration = (async () => {
       this.roundOutputs = [];
       this.fileService.updateRunContext(params.executionId);
+
+      // Set the resumed storageKey on context and outputHandler BEFORE hydrating
+      // This ensures subsequent events use the correct key
+      if (params.storageKey) {
+        this.context.updateStorageKey(params.storageKey);
+        this.outputHandler.setActiveRun(params.storageKey);
+      }
+
       this.outputHandler.hydrateFromArtifacts(
         params.storageKey ?? null,
         params.rounds,
@@ -848,11 +856,19 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
                   'Run group identifier is required for reflection runs.',
                 );
               }
-              // Update the context's storage key to the task group ID
-              // This is THE key for all storage operations
-              const storageKey = normalizeRunId(runStage.id);
-              this.context.updateStorageKey(runStage.id);
-              this.outputHandler.setActiveRun(storageKey);
+
+              // Check if we're resuming a previous run (have hydrated rounds)
+              // If resuming, the storageKey was already set by hydrateOutputState
+              // and we should NOT overwrite it with the new runStage.id
+              if (this.hydratedRoundCount === 0) {
+                // New run - use the task group ID as the storage key
+                const storageKey = normalizeRunId(runStage.id);
+                this.context.updateStorageKey(runStage.id);
+                this.outputHandler.setActiveRun(storageKey);
+              }
+              // For resumed runs, context.storageKey and outputHandler.activeRun
+              // were already set by hydrateOutputState() - preserve them
+
               return runStage;
             },
             resetPromptBuilder: () => this.resetPromptBuilder(),

--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -863,7 +863,7 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
               if (this.hydratedRoundCount === 0) {
                 // New run - use the task group ID as the storage key
                 const storageKey = normalizeRunId(runStage.id);
-                this.context.updateStorageKey(runStage.id);
+                this.context.updateStorageKey(storageKey);
                 this.outputHandler.setActiveRun(storageKey);
               }
               // For resumed runs, context.storageKey and outputHandler.activeRun

--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -857,10 +857,10 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
                 );
               }
 
-              // Check if we're resuming a previous run (have hydrated rounds)
-              // If resuming, the storageKey was already set by hydrateOutputState
-              // and we should NOT overwrite it with the new runStage.id
-              if (this.hydratedRoundCount === 0) {
+              // Check if storageKey was already set by hydrateOutputState (resume case)
+              // Initial storageKey equals executionId; if different, it was already set
+              const initialStorageKey = normalizeRunId(this.context.executionId);
+              if (this.context.storageKey === initialStorageKey) {
                 // New run - use the task group ID as the storage key
                 const storageKey = normalizeRunId(runStage.id);
                 this.context.updateStorageKey(storageKey);

--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -858,10 +858,8 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
               }
 
               // Check if storageKey was already set by hydrateOutputState (resume case)
-              // Initial storageKey equals executionId; if different, it was already set
-              const initialStorageKey = normalizeRunId(this.context.executionId);
-              if (this.context.storageKey === initialStorageKey) {
-                // New run - use the task group ID as the storage key
+              // If still initial, this is a new run - set to task group ID
+              if (this.context.hasInitialStorageKey()) {
                 const storageKey = normalizeRunId(runStage.id);
                 this.context.updateStorageKey(storageKey);
                 this.outputHandler.setActiveRun(storageKey);

--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -13,7 +13,7 @@ import {
 import type { AgentConfig } from '@agent/core/AgentConfig';
 import type { ResponseCycleOptions } from '@agent/core/ResponseCycle';
 import type { AgentRunHooks } from '@agent/implementations/flows/common/types';
-import type { ExecutionId } from '@agent/types/IdentifierTypes';
+import type { ExecutionId, StorageKey } from '@agent/types/IdentifierTypes';
 
 // Internal imports
 import {
@@ -42,6 +42,7 @@ import { createLifecycleState } from '@agent/implementations/flows/common/lifecy
 import { AgentExecutionContext } from '@agent/runtime/AgentExecutionContext';
 import { PromptBuilder } from '@agent/utils/PromptBuilder';
 import { writePromptToXml } from '@agent/utils/promptUtils';
+import { normalizeRunId } from '@common/constants/runIds';
 import type { AgentLogStage } from '@logger/AgentLogger';
 
 // Local imports - configuration
@@ -197,7 +198,7 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
 
   public async hydrateOutputState(params: {
     executionId: ExecutionId;
-    storageKey?: string | null;
+    storageKey?: StorageKey | null;
     rounds: Map<number, OutputFileInfo[]>;
   }): Promise<void> {
     const hydration = (async () => {
@@ -849,8 +850,9 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
               }
               // Update the context's storage key to the task group ID
               // This is THE key for all storage operations
+              const storageKey = normalizeRunId(runStage.id);
               this.context.updateStorageKey(runStage.id);
-              this.outputHandler.setActiveRun(runStage.id);
+              this.outputHandler.setActiveRun(storageKey);
               return runStage;
             },
             resetPromptBuilder: () => this.resetPromptBuilder(),

--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -197,14 +197,14 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
 
   public async hydrateOutputState(params: {
     executionId: ExecutionId;
-    runId?: string | null;
+    storageKey?: string | null;
     rounds: Map<number, OutputFileInfo[]>;
   }): Promise<void> {
     const hydration = (async () => {
       this.roundOutputs = [];
       this.fileService.updateRunContext(params.executionId);
       this.outputHandler.hydrateFromArtifacts(
-        params.runId ?? null,
+        params.storageKey ?? null,
         params.rounds,
       );
 

--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -842,11 +842,14 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
             },
             start: async () => {
               const runStage = await baseStart();
-              if (!runStage) {
+              if (!runStage || !runStage.id) {
                 throw new Error(
                   'Run group identifier is required for reflection runs.',
                 );
               }
+              // Update the context's storage key to the task group ID
+              // This is THE key for all storage operations
+              this.context.updateStorageKey(runStage.id);
               this.outputHandler.setActiveRun(runStage.id);
               return runStage;
             },

--- a/src/agent/output/IOutputHandler.ts
+++ b/src/agent/output/IOutputHandler.ts
@@ -65,8 +65,13 @@ export interface IOutputHandler {
     },
   ): Promise<void>;
 
+  /**
+   * Hydrate output artifacts from a saved state.
+   * @param storageKey - THE key for storage (from context.storageKey or saved state)
+   * @param rounds - Map of round number to output files
+   */
   hydrateFromArtifacts(
-    runId: string | null | undefined,
+    storageKey: string | null,
     rounds: Map<number, OutputFileInfo[]>,
   ): void;
 

--- a/src/agent/output/IOutputHandler.ts
+++ b/src/agent/output/IOutputHandler.ts
@@ -1,4 +1,5 @@
 // Local imports - agent
+import type { StorageKey } from '@agent/types/IdentifierTypes';
 import type { AgentLogStage } from '@logger/AgentLogger';
 
 // Local file imports
@@ -71,11 +72,16 @@ export interface IOutputHandler {
    * @param rounds - Map of round number to output files
    */
   hydrateFromArtifacts(
-    storageKey: string | null,
+    storageKey: StorageKey | null,
     rounds: Map<number, OutputFileInfo[]>,
   ): void;
 
   getRoundArtifacts(round: number): Promise<RoundOutput>;
   getRoundXmlSummary(round: number): OutputXmlSummary;
-  setActiveRun(runId?: string | null): void;
+
+  /**
+   * Set the active storage key for this handler.
+   * @param storageKey - THE key for storage operations (task group ID or execution ID)
+   */
+  setActiveRun(storageKey?: StorageKey | null): void;
 }

--- a/src/agent/output/IOutputHandler.ts
+++ b/src/agent/output/IOutputHandler.ts
@@ -83,5 +83,5 @@ export interface IOutputHandler {
    * Set the active storage key for this handler.
    * @param storageKey - THE key for storage operations (task group ID or execution ID)
    */
-  setActiveRun(storageKey?: StorageKey | null): void;
+  setActiveRun(storageKey: StorageKey): void;
 }

--- a/src/agent/output/OutputHandler.ts
+++ b/src/agent/output/OutputHandler.ts
@@ -113,7 +113,8 @@ export class OutputHandler implements IOutputHandler {
     this.logger = logger || new AgentLogger('OutputHandler');
     this.channel = this.logger.channelId;
     this.fileService = fileService || new TaskRunFileService();
-    this.executionId = executionId ?? this.fileService.getExecutionId();
+    // executionId is passed from the execution context - no fallback needed
+    this.executionId = executionId ?? undefined;
 
     this.xmlManager = new XmlOutputManager(
       this.agentSetting,
@@ -212,18 +213,15 @@ export class OutputHandler implements IOutputHandler {
 
   /**
    * Create a storage-scoped payload for event bus emissions.
-   * Returns an object with storageKey (the single source of truth)
-   * and runId (for backward compatibility).
+   * Returns an object with storageKey (the single source of truth).
    */
   private createStoragePayload(): {
     storageKey: StorageKey;
-    runId: string;
     executionId: string | undefined;
   } {
     const storageKey = this.getStorageKey();
     return {
       storageKey,
-      runId: storageKey, // Backward compatibility
       // Use stored executionId - no round-trip to fileService
       executionId: this.executionId,
     };

--- a/src/agent/output/OutputHandler.ts
+++ b/src/agent/output/OutputHandler.ts
@@ -11,6 +11,7 @@ import {
   requireWorkflowSetting,
 } from '@agent/core/AgentDataclass';
 import { AgentRunState, ConversationRoundState } from '@agent/core/AgentState';
+import type { StorageKey } from '@agent/types/IdentifierTypes';
 import { normalizeRunId } from '@common/constants/runIds';
 import { toErrorMessage } from '@common/errors/errorHandlingUtils';
 import { openBuildDisplayIfTex } from '@frontend/latex/openBuild';
@@ -87,6 +88,15 @@ export class OutputHandler implements IOutputHandler {
   private readonly openedOutputs: Set<string>;
   private readonly fileService: TaskRunFileService;
   private readonly executionId?: string;
+  /**
+   * The storage key for this handler.
+   * Set via setActiveRun() when a workflow agent creates its primary task group.
+   * This is THE key for storage operations.
+   */
+  private _storageKey: StorageKey | null;
+  /**
+   * @deprecated Use _storageKey instead. Kept for backward compatibility.
+   */
   private currentRunId: string | null | undefined;
   private runPreparation: Promise<void> | null;
 
@@ -125,11 +135,13 @@ export class OutputHandler implements IOutputHandler {
     );
     this.diffStatsManager = new DiffStatsManager();
     this.openedOutputs = new Set();
+    this._storageKey = null;
     this.currentRunId = undefined;
     this.runPreparation = null;
 
-    const initialRunId = this.logger.withCurrentGroup((id) => id);
-    this.setActiveRun(initialRunId ?? null);
+    // Don't ask logger for initial group - let the agent set it explicitly
+    // via setActiveRun() when it creates its primary task group.
+    // This eliminates the round-trip to logger for ID resolution.
   }
 
   private collectRunSnapshotFiles(): FileLocation[] {
@@ -161,18 +173,27 @@ export class OutputHandler implements IOutputHandler {
     return Array.from(extras.values());
   }
 
-  public setActiveRun(runId?: string | null): void {
+  /**
+   * Set the active storage key for this handler.
+   *
+   * Called by workflow agents when they create their primary task group.
+   * The storageKey becomes THE key for all storage operations.
+   *
+   * @param storageKey - The storage key (task group ID or execution ID)
+   */
+  public setActiveRun(storageKey?: string | null): void {
     const targetExecutionId =
       this.executionId ?? this.fileService.getExecutionId();
     this.fileService.updateRunContext(targetExecutionId ?? undefined);
 
-    const nextRunId = runId ?? null;
-    const previousRunId = this.currentRunId;
-    if (nextRunId === this.currentRunId) {
+    const nextStorageKey = (storageKey ?? null) as StorageKey | null;
+    if (nextStorageKey === this._storageKey) {
       return;
     }
 
-    this.currentRunId = nextRunId;
+    this._storageKey = nextStorageKey;
+    // Keep currentRunId in sync for backward compatibility
+    this.currentRunId = storageKey ?? null;
     this.openedOutputs.clear();
 
     if (targetExecutionId) {
@@ -187,8 +208,25 @@ export class OutputHandler implements IOutputHandler {
     }
   }
 
+  /**
+   * Get the current storage key.
+   * Returns the storageKey if set, otherwise falls back to normalized runId.
+   */
+  private getStorageKey(): StorageKey {
+    // Use _storageKey if available (new path)
+    if (this._storageKey) {
+      return this._storageKey;
+    }
+    // Fall back to normalized currentRunId for backward compatibility
+    return normalizeRunId(this.currentRunId) as StorageKey;
+  }
+
+  /**
+   * @deprecated Use getStorageKey() instead.
+   * Kept for backward compatibility.
+   */
   private getActiveRunId(): string {
-    return normalizeRunId(this.currentRunId);
+    return this.getStorageKey();
   }
 
   private async prepareRunWorkspaceIfNeeded(): Promise<void> {
@@ -514,11 +552,13 @@ export class OutputHandler implements IOutputHandler {
       stage,
       async () => {
         const executionId = this.fileService.getExecutionId();
-        const runId = this.getActiveRunId();
+        const storageKey = this.getStorageKey();
+        const runId = storageKey; // Backward compatibility
         const expected = this.agentConfig.outputFiles;
         if (!expected || expected.length === 0) {
           bus.emit('updateMissingOutputs', {
             stream: this.channel,
+            storageKey,
             runId,
             executionId,
             filesByRound: { [currRound]: [] },
@@ -566,6 +606,7 @@ export class OutputHandler implements IOutputHandler {
 
         bus.emit('updateMissingOutputs', {
           stream: this.channel,
+          storageKey,
           runId,
           executionId,
           filesByRound: { [currRound]: missing },
@@ -600,7 +641,8 @@ export class OutputHandler implements IOutputHandler {
         const fileInfos = await this.gatherOutputFileInfo(currRound);
         data.outputs = fileInfos;
         const executionId = this.fileService.getExecutionId();
-        const runId = this.getActiveRunId();
+        const storageKey = this.getStorageKey();
+        const runId = storageKey; // Backward compatibility
 
         if (endTurn) {
           try {
@@ -617,6 +659,7 @@ export class OutputHandler implements IOutputHandler {
 
         bus.emit('addOutputFiles', {
           stream: this.channel,
+          storageKey,
           runId,
           executionId,
           filesByRound: { [currRound]: fileInfos },
@@ -665,7 +708,8 @@ export class OutputHandler implements IOutputHandler {
         data.rawOutput = rawLocation;
         const rawPath = rawLocation.absolutePath;
         const executionId = this.fileService.getExecutionId();
-        const runId = this.getActiveRunId();
+        const storageKey = this.getStorageKey();
+        const runId = storageKey; // Backward compatibility
 
         const handleMultipleOutputs = async () => {
           this.logger.debug(
@@ -795,6 +839,7 @@ export class OutputHandler implements IOutputHandler {
             this.logger.missingOutputs(missingOutputsData);
             bus.emit('updateMissingOutputs', {
               stream: this.channel,
+              storageKey,
               runId,
               executionId,
               filesByRound: { [currRound]: [] },

--- a/src/agent/output/OutputHandler.ts
+++ b/src/agent/output/OutputHandler.ts
@@ -177,13 +177,12 @@ export class OutputHandler implements IOutputHandler {
    *
    * @param storageKey - THE key for storage operations (already branded via normalizeRunId)
    */
-  public setActiveRun(storageKey?: StorageKey | null): void {
+  public setActiveRun(storageKey: StorageKey): void {
     // Use the stored executionId directly - no round-trip to fileService
     // The executionId was resolved once in the constructor and should not change
     this.fileService.updateRunContext(this.executionId ?? undefined);
 
-    // storageKey is already branded - use normalizeRunId only for the null case
-    const nextStorageKey = storageKey ?? normalizeRunId(null);
+    const nextStorageKey = storageKey;
     if (nextStorageKey === this._storageKey) {
       return;
     }

--- a/src/agent/output/OutputHandler.ts
+++ b/src/agent/output/OutputHandler.ts
@@ -94,10 +94,6 @@ export class OutputHandler implements IOutputHandler {
    * This is THE key for storage operations.
    */
   private _storageKey: StorageKey | null;
-  /**
-   * @deprecated Use _storageKey instead. Kept for backward compatibility.
-   */
-  private currentRunId: string | null | undefined;
   private runPreparation: Promise<void> | null;
 
   constructor(
@@ -136,7 +132,6 @@ export class OutputHandler implements IOutputHandler {
     this.diffStatsManager = new DiffStatsManager();
     this.openedOutputs = new Set();
     this._storageKey = null;
-    this.currentRunId = undefined;
     this.runPreparation = null;
 
     // Don't ask logger for initial group - let the agent set it explicitly
@@ -186,14 +181,14 @@ export class OutputHandler implements IOutputHandler {
       this.executionId ?? this.fileService.getExecutionId();
     this.fileService.updateRunContext(targetExecutionId ?? undefined);
 
-    const nextStorageKey = (storageKey ?? null) as StorageKey | null;
+    const nextStorageKey = storageKey
+      ? (storageKey as StorageKey)
+      : normalizeRunId(null);
     if (nextStorageKey === this._storageKey) {
       return;
     }
 
     this._storageKey = nextStorageKey;
-    // Keep currentRunId in sync for backward compatibility
-    this.currentRunId = storageKey ?? null;
     this.openedOutputs.clear();
 
     if (targetExecutionId) {
@@ -210,23 +205,28 @@ export class OutputHandler implements IOutputHandler {
 
   /**
    * Get the current storage key.
-   * Returns the storageKey if set, otherwise falls back to normalized runId.
+   * Returns the storageKey if set, otherwise falls back to DEFAULT_RUN_ID.
    */
   private getStorageKey(): StorageKey {
-    // Use _storageKey if available (new path)
-    if (this._storageKey) {
-      return this._storageKey;
-    }
-    // Fall back to normalized currentRunId for backward compatibility
-    return normalizeRunId(this.currentRunId) as StorageKey;
+    return this._storageKey ?? normalizeRunId(null);
   }
 
   /**
-   * @deprecated Use getStorageKey() instead.
-   * Kept for backward compatibility.
+   * Create a storage-scoped payload for event bus emissions.
+   * Returns an object with storageKey (the single source of truth)
+   * and runId (for backward compatibility).
    */
-  private getActiveRunId(): string {
-    return this.getStorageKey();
+  private createStoragePayload(): {
+    storageKey: StorageKey;
+    runId: string;
+    executionId: string | undefined;
+  } {
+    const storageKey = this.getStorageKey();
+    return {
+      storageKey,
+      runId: storageKey, // Backward compatibility
+      executionId: this.fileService.getExecutionId(),
+    };
   }
 
   private async prepareRunWorkspaceIfNeeded(): Promise<void> {
@@ -559,20 +559,16 @@ export class OutputHandler implements IOutputHandler {
       `Validate expected r${currRound}`,
       stage,
       async () => {
-        const executionId = this.fileService.getExecutionId();
-        const storageKey = this.getStorageKey();
-        const runId = storageKey; // Backward compatibility
+        const storagePayload = this.createStoragePayload();
         const expected = this.agentConfig.outputFiles;
         if (!expected || expected.length === 0) {
           bus.emit('updateMissingOutputs', {
             stream: this.channel,
-            storageKey,
-            runId,
-            executionId,
+            ...storagePayload,
             filesByRound: { [currRound]: [] },
           });
           this.logger.debug(
-            `updateMissingOutputs emitted (no expected outputs) for round ${currRound} runId=${runId} executionId=${executionId ?? 'none'}`,
+            `updateMissingOutputs emitted (no expected outputs) for round ${currRound} storageKey=${storagePayload.storageKey}`,
             { messageType: MESSAGE_TYPES.INTERNAL },
           );
           return;
@@ -614,13 +610,11 @@ export class OutputHandler implements IOutputHandler {
 
         bus.emit('updateMissingOutputs', {
           stream: this.channel,
-          storageKey,
-          runId,
-          executionId,
+          ...storagePayload,
           filesByRound: { [currRound]: missing },
         });
         this.logger.debug(
-          `updateMissingOutputs emitted with ${missing.length} missing for round ${currRound} runId=${runId} executionId=${executionId ?? 'none'}`,
+          `updateMissingOutputs emitted with ${missing.length} missing for round ${currRound} storageKey=${storagePayload.storageKey}`,
           { messageType: MESSAGE_TYPES.INTERNAL },
         );
       },
@@ -648,9 +642,7 @@ export class OutputHandler implements IOutputHandler {
 
         const fileInfos = await this.gatherOutputFileInfo(currRound);
         data.outputs = fileInfos;
-        const executionId = this.fileService.getExecutionId();
-        const storageKey = this.getStorageKey();
-        const runId = storageKey; // Backward compatibility
+        const storagePayload = this.createStoragePayload();
 
         if (endTurn) {
           try {
@@ -667,13 +659,11 @@ export class OutputHandler implements IOutputHandler {
 
         bus.emit('addOutputFiles', {
           stream: this.channel,
-          storageKey,
-          runId,
-          executionId,
+          ...storagePayload,
           filesByRound: { [currRound]: fileInfos },
         });
         this.logger.debug(
-          `addOutputFiles emitted for round ${currRound} runId=${runId} executionId=${executionId ?? 'none'} files=${fileInfos.length}`,
+          `addOutputFiles emitted for round ${currRound} storageKey=${storagePayload.storageKey} files=${fileInfos.length}`,
           { messageType: MESSAGE_TYPES.INTERNAL },
         );
 
@@ -715,9 +705,7 @@ export class OutputHandler implements IOutputHandler {
         const rawLocation = data.rawOutput ?? outputLocation;
         data.rawOutput = rawLocation;
         const rawPath = rawLocation.absolutePath;
-        const executionId = this.fileService.getExecutionId();
-        const storageKey = this.getStorageKey();
-        const runId = storageKey; // Backward compatibility
+        const storagePayload = this.createStoragePayload();
 
         const handleMultipleOutputs = async () => {
           this.logger.debug(
@@ -847,9 +835,7 @@ export class OutputHandler implements IOutputHandler {
             this.logger.missingOutputs(missingOutputsData);
             bus.emit('updateMissingOutputs', {
               stream: this.channel,
-              storageKey,
-              runId,
-              executionId,
+              ...storagePayload,
               filesByRound: { [currRound]: [] },
             });
             this.setRoundOutputs(currRound, []);

--- a/src/agent/output/OutputHandler.ts
+++ b/src/agent/output/OutputHandler.ts
@@ -178,9 +178,9 @@ export class OutputHandler implements IOutputHandler {
    *                     Accepts string for convenience; branded internally via normalizeRunId.
    */
   public setActiveRun(storageKey?: string | null): void {
-    const targetExecutionId =
-      this.executionId ?? this.fileService.getExecutionId();
-    this.fileService.updateRunContext(targetExecutionId ?? undefined);
+    // Use the stored executionId directly - no round-trip to fileService
+    // The executionId was resolved once in the constructor and should not change
+    this.fileService.updateRunContext(this.executionId ?? undefined);
 
     // Use normalizeRunId for proper branding - no manual casts
     const nextStorageKey = normalizeRunId(storageKey);
@@ -191,7 +191,7 @@ export class OutputHandler implements IOutputHandler {
     this._storageKey = nextStorageKey;
     this.openedOutputs.clear();
 
-    if (targetExecutionId) {
+    if (this.executionId) {
       const snapshotTargets = this.collectRunSnapshotFiles();
       const supportFiles = this.collectRunSupportFiles();
       this.runPreparation = this.fileService.prepareRunWorkspace(
@@ -225,7 +225,8 @@ export class OutputHandler implements IOutputHandler {
     return {
       storageKey,
       runId: storageKey, // Backward compatibility
-      executionId: this.fileService.getExecutionId(),
+      // Use stored executionId - no round-trip to fileService
+      executionId: this.executionId,
     };
   }
 

--- a/src/agent/output/OutputHandler.ts
+++ b/src/agent/output/OutputHandler.ts
@@ -87,7 +87,7 @@ export class OutputHandler implements IOutputHandler {
   private diffStatsManager: DiffStatsManager;
   private readonly openedOutputs: Set<string>;
   private readonly fileService: TaskRunFileService;
-  private readonly executionId?: string;
+  private readonly executionId: string;
   /**
    * The storage key for this handler.
    * Set via setActiveRun() when a workflow agent creates its primary task group.
@@ -100,21 +100,20 @@ export class OutputHandler implements IOutputHandler {
     agentSetting: AgentSetting,
     agentConfig: AgentConfig,
     logId: number,
-    baseFiles: FileLocation[] = [],
-    logger?: AgentLogger,
-    fileService?: TaskRunFileService,
-    executionId?: string | null,
+    baseFiles: FileLocation[],
+    logger: AgentLogger,
+    fileService: TaskRunFileService,
+    executionId: string,
   ) {
     this.agentSetting = requireWorkflowSetting(agentSetting);
     this.agentConfig = agentConfig;
     this.logId = logId;
     this.rounds = new Map();
     this.baseFiles = baseFiles;
-    this.logger = logger || new AgentLogger('OutputHandler');
+    this.logger = logger;
     this.channel = this.logger.channelId;
-    this.fileService = fileService || new TaskRunFileService();
-    // executionId is passed from the execution context - no fallback needed
-    this.executionId = executionId ?? undefined;
+    this.fileService = fileService;
+    this.executionId = executionId;
 
     this.xmlManager = new XmlOutputManager(
       this.agentSetting,
@@ -179,27 +178,21 @@ export class OutputHandler implements IOutputHandler {
    */
   public setActiveRun(storageKey: StorageKey): void {
     // Use the stored executionId directly - no round-trip to fileService
-    // The executionId was resolved once in the constructor and should not change
-    this.fileService.updateRunContext(this.executionId ?? undefined);
+    this.fileService.updateRunContext(this.executionId);
 
-    const nextStorageKey = storageKey;
-    if (nextStorageKey === this._storageKey) {
+    if (storageKey === this._storageKey) {
       return;
     }
 
-    this._storageKey = nextStorageKey;
+    this._storageKey = storageKey;
     this.openedOutputs.clear();
 
-    if (this.executionId) {
-      const snapshotTargets = this.collectRunSnapshotFiles();
-      const supportFiles = this.collectRunSupportFiles();
-      this.runPreparation = this.fileService.prepareRunWorkspace(
-        snapshotTargets,
-        { linkFiles: supportFiles },
-      );
-    } else {
-      this.runPreparation = null;
-    }
+    const snapshotTargets = this.collectRunSnapshotFiles();
+    const supportFiles = this.collectRunSupportFiles();
+    this.runPreparation = this.fileService.prepareRunWorkspace(
+      snapshotTargets,
+      { linkFiles: supportFiles },
+    );
   }
 
   /**

--- a/src/agent/output/OutputHandler.ts
+++ b/src/agent/output/OutputHandler.ts
@@ -174,16 +174,15 @@ export class OutputHandler implements IOutputHandler {
    * Called by workflow agents when they create their primary task group.
    * The storageKey becomes THE key for all storage operations.
    *
-   * @param storageKey - The storage key (task group ID or execution ID).
-   *                     Accepts string for convenience; branded internally via normalizeRunId.
+   * @param storageKey - THE key for storage operations (already branded via normalizeRunId)
    */
-  public setActiveRun(storageKey?: string | null): void {
+  public setActiveRun(storageKey?: StorageKey | null): void {
     // Use the stored executionId directly - no round-trip to fileService
     // The executionId was resolved once in the constructor and should not change
     this.fileService.updateRunContext(this.executionId ?? undefined);
 
-    // Use normalizeRunId for proper branding - no manual casts
-    const nextStorageKey = normalizeRunId(storageKey);
+    // storageKey is already branded - use normalizeRunId only for the null case
+    const nextStorageKey = storageKey ?? normalizeRunId(null);
     if (nextStorageKey === this._storageKey) {
       return;
     }

--- a/src/agent/output/OutputHandler.ts
+++ b/src/agent/output/OutputHandler.ts
@@ -500,20 +500,28 @@ export class OutputHandler implements IOutputHandler {
     };
   }
 
+  /**
+   * Hydrate output artifacts from a saved state.
+   *
+   * @param storageKey - THE key for storage (from context.storageKey or saved state)
+   *                     Pass null only for legacy data without storage key.
+   * @param rounds - Map of round number to output files
+   */
   public hydrateFromArtifacts(
-    runId: string | null | undefined,
+    storageKey: StorageKey | null,
     rounds: Map<number, OutputFileInfo[]>,
   ): void {
-    const loggerRunId = this.logger.withCurrentGroup((id) => id);
-    const effectiveRunId = runId ?? loggerRunId ?? null;
-    const normalizedCurrent = normalizeRunId(this.currentRunId);
-    const normalizedTarget = normalizeRunId(effectiveRunId);
+    // storageKey is the single source of truth - no logger round-trips
+    const currentKey = this.getStorageKey();
+    const targetKey = storageKey ?? currentKey;
+
     this.logger.debug(
-      `Hydrate outputs for runId=${normalizeRunId(runId)} loggerRunId=${normalizeRunId(loggerRunId)} current=${normalizedCurrent} target=${normalizedTarget}`,
+      `Hydrate outputs: storageKey=${storageKey ?? 'null'} current=${currentKey} target=${targetKey}`,
       { messageType: MESSAGE_TYPES.INTERNAL },
     );
-    if (normalizedTarget !== normalizedCurrent) {
-      this.setActiveRun(effectiveRunId);
+
+    if (targetKey !== currentKey) {
+      this.setActiveRun(targetKey);
     }
 
     for (const [round, infos] of rounds.entries()) {

--- a/src/agent/output/OutputHandler.ts
+++ b/src/agent/output/OutputHandler.ts
@@ -174,16 +174,16 @@ export class OutputHandler implements IOutputHandler {
    * Called by workflow agents when they create their primary task group.
    * The storageKey becomes THE key for all storage operations.
    *
-   * @param storageKey - The storage key (task group ID or execution ID)
+   * @param storageKey - The storage key (task group ID or execution ID).
+   *                     Accepts string for convenience; branded internally via normalizeRunId.
    */
   public setActiveRun(storageKey?: string | null): void {
     const targetExecutionId =
       this.executionId ?? this.fileService.getExecutionId();
     this.fileService.updateRunContext(targetExecutionId ?? undefined);
 
-    const nextStorageKey = storageKey
-      ? (storageKey as StorageKey)
-      : normalizeRunId(null);
+    // Use normalizeRunId for proper branding - no manual casts
+    const nextStorageKey = normalizeRunId(storageKey);
     if (nextStorageKey === this._storageKey) {
       return;
     }

--- a/src/agent/runtime/AgentExecutionContext.ts
+++ b/src/agent/runtime/AgentExecutionContext.ts
@@ -132,6 +132,15 @@ export class AgentExecutionContext {
   }
 
   /**
+   * Check if the storageKey is still in its initial state (equals executionId).
+   * Returns true if storageKey hasn't been updated yet (new run, not resumed).
+   */
+  hasInitialStorageKey(): boolean {
+    const initialStorageKey = normalizeRunId(this._identity.executionId);
+    return this._identity.storageKey === initialStorageKey;
+  }
+
+  /**
    * Update the storage key to a task group ID.
    *
    * Called by workflow agents when they create their primary task group.
@@ -143,9 +152,7 @@ export class AgentExecutionContext {
    * @param storageKey - The branded StorageKey to use for storage operations
    */
   updateStorageKey(storageKey: StorageKey): void {
-    // Compare with branded executionId to avoid type mismatch
-    const initialStorageKey = normalizeRunId(this._identity.executionId);
-    if (this._identity.storageKey !== initialStorageKey) {
+    if (!this.hasInitialStorageKey()) {
       this.logger.warn(
         `Storage key already set to ${this._identity.storageKey}, ` +
           `updating to ${storageKey}. This may indicate a bug.`,

--- a/src/agent/runtime/AgentExecutionContext.ts
+++ b/src/agent/runtime/AgentExecutionContext.ts
@@ -1,5 +1,13 @@
+// Standard library imports
+import { randomUUID } from 'crypto';
+
 // Local imports - agent types
-import type { ExecutionId, StreamTabId } from '@agent/types/IdentifierTypes';
+import type {
+  ExecutionId,
+  ExecutionIdentity,
+  StorageKey,
+  StreamTabId,
+} from '@agent/types/IdentifierTypes';
 import { AgentCategory } from '@agent/core/AgentDataclass';
 
 // Local imports - logger
@@ -17,12 +25,37 @@ export interface AgentExecutionContextInit {
 }
 
 /**
- * Aggregates shared execution state so collaborators avoid plumbing IDs.
+ * Aggregates shared execution state and provides the unified ExecutionIdentity.
+ *
+ * This is the single source of truth for execution identity:
+ * - executionId: Always a UUID, generated if not provided
+ * - storageKey: THE key for storage operations
+ * - streamTabId: UI tab identifier
+ *
+ * ## Storage Key Resolution
+ *
+ * The storageKey is computed once and updated only when a workflow agent
+ * creates its primary task group:
+ * - Initial value: executionId (works for tool-use agents)
+ * - After updateStorageKey(): task group ID (for workflow agents)
+ *
+ * Components receive the identity and use storageKey directly, eliminating
+ * runtime resolution and "which ID do I use?" confusion.
  */
 export class AgentExecutionContext {
   public readonly logger: AgentLogger;
   public readonly usageReporter: AgentUsageReporter;
   private readonly agentCategory: AgentCategory;
+
+  /**
+   * Mutable identity - storageKey can be updated by workflow agents
+   * when they create their primary task group.
+   */
+  private _identity: {
+    readonly executionId: ExecutionId;
+    storageKey: StorageKey;
+    readonly streamTabId: StreamTabId;
+  };
 
   constructor(private readonly init: AgentExecutionContextInit) {
     this.logger = new AgentLogger(init.streamId, true);
@@ -32,18 +65,67 @@ export class AgentExecutionContext {
       init.streamId,
       this.agentCategory,
     );
+
+    // Generate executionId if not provided (always a UUID)
+    const executionId = init.executionId ?? randomUUID();
+
+    // Initialize identity with executionId as the initial storageKey
+    // Workflow agents will call updateStorageKey() when they create
+    // their primary task group
+    this._identity = {
+      executionId,
+      storageKey: executionId,
+      streamTabId: init.streamId,
+    };
+  }
+
+  /**
+   * The unified execution identity.
+   * Use this instead of accessing individual ID fields.
+   */
+  get identity(): ExecutionIdentity {
+    return this._identity;
+  }
+
+  /**
+   * THE key for storage operations (files, usage, artifacts).
+   * This is the single source of truth - use this instead of computing IDs.
+   */
+  get storageKey(): StorageKey {
+    return this._identity.storageKey;
   }
 
   get streamId(): StreamTabId {
     return this.init.streamId;
   }
 
-  get executionId(): ExecutionId | undefined {
-    return this.init.executionId;
+  get executionId(): ExecutionId {
+    return this._identity.executionId;
   }
 
   get sessionCategory(): AgentCategory {
     return this.agentCategory;
+  }
+
+  /**
+   * Update the storage key to a task group ID.
+   *
+   * Called by workflow agents when they create their primary task group.
+   * After this call, all storage operations use the task group ID.
+   *
+   * This should only be called ONCE per execution, when the primary
+   * task group is created. Multiple calls are allowed but logged as warnings.
+   *
+   * @param taskGroupId - The task group ID to use as the storage key
+   */
+  updateStorageKey(taskGroupId: string): void {
+    if (this._identity.storageKey !== this._identity.executionId) {
+      this.logger.warn(
+        `Storage key already set to ${this._identity.storageKey}, ` +
+          `updating to ${taskGroupId}. This may indicate a bug.`,
+      );
+    }
+    this._identity.storageKey = taskGroupId;
   }
 
   stage(

--- a/src/agent/runtime/AgentExecutionContext.ts
+++ b/src/agent/runtime/AgentExecutionContext.ts
@@ -140,16 +140,18 @@ export class AgentExecutionContext {
    * This should only be called ONCE per execution, when the primary
    * task group is created. Multiple calls are allowed but logged as warnings.
    *
-   * @param taskGroupId - The task group ID to use as the storage key
+   * @param storageKey - The branded StorageKey to use for storage operations
    */
-  updateStorageKey(taskGroupId: string): void {
-    if (this._identity.storageKey !== this._identity.executionId) {
+  updateStorageKey(storageKey: StorageKey): void {
+    // Compare with branded executionId to avoid type mismatch
+    const initialStorageKey = normalizeRunId(this._identity.executionId);
+    if (this._identity.storageKey !== initialStorageKey) {
       this.logger.warn(
         `Storage key already set to ${this._identity.storageKey}, ` +
-          `updating to ${taskGroupId}. This may indicate a bug.`,
+          `updating to ${storageKey}. This may indicate a bug.`,
       );
     }
-    this._identity.storageKey = normalizeRunId(taskGroupId);
+    this._identity.storageKey = storageKey;
   }
 
   stage(

--- a/src/agent/runtime/AgentExecutionContext.ts
+++ b/src/agent/runtime/AgentExecutionContext.ts
@@ -48,8 +48,31 @@ export class AgentExecutionContext {
   private readonly agentCategory: AgentCategory;
 
   /**
-   * Mutable identity - storageKey can be updated by workflow agents
-   * when they create their primary task group.
+   * Mutable identity for storage key resolution.
+   *
+   * ## Design Decision: Mutable storageKey
+   *
+   * The storageKey is intentionally mutable while other identity fields are readonly:
+   * - executionId: Immutable, set at construction, always a UUID
+   * - streamTabId: Immutable, set at construction, for UI identification
+   * - storageKey: Mutable, initially equals executionId
+   *
+   * ## Why Mutable?
+   *
+   * Workflow agents create their primary task group AFTER construction.
+   * When the task group is created, updateStorageKey() sets storageKey to the
+   * task group ID. This is the single moment of mutation - after that,
+   * storageKey remains constant for the execution lifetime.
+   *
+   * Tool-use agents never call updateStorageKey(), so storageKey remains
+   * equal to executionId throughout execution.
+   *
+   * ## Type Note
+   *
+   * The getter returns ExecutionIdentity (all readonly). This is intentional -
+   * consumers should not be able to mutate the identity directly. The mutable
+   * `storageKey` here is an internal implementation detail for the workflow
+   * agent lifecycle.
    */
   private _identity: {
     readonly executionId: ExecutionId;

--- a/src/agent/runtime/AgentExecutionContext.ts
+++ b/src/agent/runtime/AgentExecutionContext.ts
@@ -9,6 +9,7 @@ import type {
   StreamTabId,
 } from '@agent/types/IdentifierTypes';
 import { AgentCategory } from '@agent/core/AgentDataclass';
+import { normalizeRunId } from '@common/constants/runIds';
 
 // Local imports - logger
 import {
@@ -97,7 +98,7 @@ export class AgentExecutionContext {
     // their primary task group
     this._identity = {
       executionId,
-      storageKey: executionId as StorageKey,
+      storageKey: normalizeRunId(executionId), // Use normalizeRunId for consistent branding
       streamTabId: init.streamId,
     };
   }
@@ -148,7 +149,7 @@ export class AgentExecutionContext {
           `updating to ${taskGroupId}. This may indicate a bug.`,
       );
     }
-    this._identity.storageKey = taskGroupId as StorageKey;
+    this._identity.storageKey = normalizeRunId(taskGroupId);
   }
 
   stage(

--- a/src/agent/runtime/AgentExecutionContext.ts
+++ b/src/agent/runtime/AgentExecutionContext.ts
@@ -74,7 +74,7 @@ export class AgentExecutionContext {
     // their primary task group
     this._identity = {
       executionId,
-      storageKey: executionId,
+      storageKey: executionId as StorageKey,
       streamTabId: init.streamId,
     };
   }
@@ -125,7 +125,7 @@ export class AgentExecutionContext {
           `updating to ${taskGroupId}. This may indicate a bug.`,
       );
     }
-    this._identity.storageKey = taskGroupId;
+    this._identity.storageKey = taskGroupId as StorageKey;
   }
 
   stage(

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -369,8 +369,7 @@ export async function executeAgentWithLogging<T extends IAgent>(
     ) {
       const activeRunId = provider.state.getActiveRunId(activeStreamId);
       const runOutputs = provider.state.getRunOutputFiles(activeStreamId, {
-        executionId,
-        runId: activeRunId,
+        storageKey: activeRunId ?? executionId,
       });
 
       if (runOutputs) {
@@ -381,7 +380,7 @@ export async function executeAgentWithLogging<T extends IAgent>(
 
         await agent.hydrateOutputState({
           executionId,
-          runId: resolvedRunId,
+          storageKey: resolvedRunId,
           rounds: runOutputs,
         });
       }

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -34,6 +34,7 @@ import { ModelFactory } from '@agent/runtime/ModelFactory';
 import type { StreamTabId, ExecutionId } from '@agent/types/IdentifierTypes';
 // Internal imports
 import { STREAM_STATUS } from '@common/constants/streamStatus';
+import { normalizeRunId } from '@common/constants/runIds';
 import { toErrorMessage } from '@common/errors/errorHandlingUtils';
 import { formatProviderHttpError } from '@common/errors/sdkErrorUtils';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands';
@@ -369,9 +370,9 @@ export async function executeAgentWithLogging<T extends IAgent>(
     ) {
       // For resume, use a single storageKey for both fetching and hydrating
       // Priority: activeRunId (task group ID for workflow agents) ?? executionId (for tool-use)
-      // No complex resolution or multiple fallback chains
+      // Use normalizeRunId to brand as StorageKey
       const activeRunId = provider.state.getActiveRunId(activeStreamId);
-      const storageKey = activeRunId ?? executionId;
+      const storageKey = normalizeRunId(activeRunId ?? executionId);
 
       const runOutputs = provider.state.getRunOutputFiles(activeStreamId, {
         storageKey,
@@ -380,7 +381,7 @@ export async function executeAgentWithLogging<T extends IAgent>(
       if (runOutputs) {
         await agent.hydrateOutputState({
           executionId,
-          storageKey, // Use same key we fetched with - no inconsistency
+          storageKey, // Properly branded StorageKey
           rounds: runOutputs,
         });
       }

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -367,20 +367,20 @@ export async function executeAgentWithLogging<T extends IAgent>(
       executionId &&
       provider
     ) {
+      // For resume, use a single storageKey for both fetching and hydrating
+      // Priority: activeRunId (task group ID for workflow agents) ?? executionId (for tool-use)
+      // No complex resolution or multiple fallback chains
       const activeRunId = provider.state.getActiveRunId(activeStreamId);
+      const storageKey = activeRunId ?? executionId;
+
       const runOutputs = provider.state.getRunOutputFiles(activeStreamId, {
-        storageKey: activeRunId ?? executionId,
+        storageKey,
       });
 
       if (runOutputs) {
-        const resolvedRunId =
-          provider.state.resolveRunId(activeStreamId, activeRunId, {
-            persist: false,
-          }) ?? executionId;
-
         await agent.hydrateOutputState({
           executionId,
-          storageKey: resolvedRunId,
+          storageKey, // Use same key we fetched with - no inconsistency
           rounds: runOutputs,
         });
       }

--- a/src/agent/types/IdentifierTypes.ts
+++ b/src/agent/types/IdentifierTypes.ts
@@ -69,8 +69,11 @@ export type ExecutionId = string;
  * is created for workflow agents) and never changes during execution.
  *
  * Use ExecutionIdentity.storageKey to get this value - never compute it manually.
+ *
+ * This is a branded type for compile-time safety - you cannot accidentally
+ * pass a random string where a StorageKey is expected.
  */
-export type StorageKey = string;
+export type StorageKey = string & { readonly __brand: 'StorageKey' };
 
 /**
  * Run ID: Legacy identifier for grouping files and usage statistics.

--- a/src/agent/types/IdentifierTypes.ts
+++ b/src/agent/types/IdentifierTypes.ts
@@ -76,19 +76,6 @@ export type ExecutionId = string;
 export type StorageKey = string & { readonly __brand: 'StorageKey' };
 
 /**
- * Run ID: Legacy identifier for grouping files and usage statistics.
- *
- * @deprecated Use StorageKey and ExecutionIdentity instead.
- * This type is kept for backward compatibility with existing code.
- * New code should use ExecutionIdentity.storageKey.
- *
- * For workflow agents: This is the task group ID from the logger hierarchy.
- * For tool-use agents: This equals the ExecutionId (no task groups).
- * For legacy sessions: This is DEFAULT_RUN_ID ("__default__").
- */
-export type RunId = string;
-
-/**
  * Unified identity for an execution - computed once, used everywhere.
  *
  * This interface eliminates "which ID should I use?" confusion by providing:

--- a/src/agent/types/IdentifierTypes.ts
+++ b/src/agent/types/IdentifierTypes.ts
@@ -1,29 +1,34 @@
 /**
  * # Identifier Types and Execution Model
  *
- * TeXRA uses three distinct identifier types to track executions:
+ * TeXRA uses a unified identity model to track executions, eliminating
+ * confusion about which ID to use for storage and lookup.
  *
- * ## Hierarchy
+ * ## Identity Hierarchy
  * ```
- * StreamTabId (UI tab)
- *   └── ExecutionId (history entry, UUID)
- *         └── RunId (task group for files/usage, UUID or DEFAULT_RUN_ID)
+ * StreamTabId (UI tab, human-readable)
+ *   └── ExecutionIdentity
+ *         ├── executionId (unique instance, always UUID)
+ *         └── storageKey (THE key for files/usage storage)
  * ```
  *
- * ## Workflow Agents (multi-round agents with task groups)
- * - Create task groups via the logger hierarchy
- * - RunId = task group ID from logger (a UUID)
- * - Files and usage are stored under the task group's RunId
+ * ## Single Source of Truth: StorageKey
  *
- * ## Tool-Use Agents (interactive, single-session agents)
- * - Do NOT create task groups (no logger hierarchy)
- * - RunId = ExecutionId (they are the same value)
- * - Files and usage are stored under the ExecutionId as the RunId
+ * The storageKey is computed ONCE at execution start and used everywhere:
+ * - Workflow agents: storageKey = task group ID (set when group is created)
+ * - Tool-use agents: storageKey = executionId (no task groups)
+ *
+ * This eliminates:
+ * - Runtime ID resolution at every call site
+ * - Dual-lookup paths in storage managers
+ * - "Which ID do I use?" confusion
  *
  * ## Key Invariants
  * - ExecutionId is ALWAYS a UUID (never null, never DEFAULT_RUN_ID)
- * - RunId can be a UUID (task group or execution) OR DEFAULT_RUN_ID (legacy)
+ * - StorageKey is ALWAYS a valid key (UUID or DEFAULT_RUN_ID for legacy)
  * - StreamTabId is human-readable and stable across executions
+ *
+ * @see ExecutionIdentity for the unified identity interface
  */
 
 /**
@@ -46,7 +51,6 @@ export type StreamTabId = string;
  * Purpose:
  * - Links executions to history entries (created by AgentHistoryManager)
  * - Enables tracking of multiple executions of the same task
- * - For tool-use agents, also serves as the RunId
  * - Used for audit and debugging purposes
  *
  * Note: ExecutionId is ALWAYS a UUID, never null or DEFAULT_RUN_ID.
@@ -54,20 +58,74 @@ export type StreamTabId = string;
 export type ExecutionId = string;
 
 /**
- * Run ID: Identifier for grouping files and usage statistics
- * Format: UUID v4 OR DEFAULT_RUN_ID ("__default__")
+ * Storage Key: THE key for storing and retrieving files, usage, and other artifacts.
  *
- * Purpose:
- * - Primary dimension key for output files in progress view
- * - Primary dimension key for usage statistics
- * - Groups related outputs within a single execution
+ * This is the single source of truth for storage operations:
+ * - Workflow agents: This is the task group ID from the logger hierarchy
+ * - Tool-use agents: This equals the ExecutionId (no task groups)
+ * - Legacy sessions: This is DEFAULT_RUN_ID ("__default__")
+ *
+ * The storageKey is computed ONCE at execution start (or when a task group
+ * is created for workflow agents) and never changes during execution.
+ *
+ * Use ExecutionIdentity.storageKey to get this value - never compute it manually.
+ */
+export type StorageKey = string;
+
+/**
+ * Run ID: Legacy identifier for grouping files and usage statistics.
+ *
+ * @deprecated Use StorageKey and ExecutionIdentity instead.
+ * This type is kept for backward compatibility with existing code.
+ * New code should use ExecutionIdentity.storageKey.
  *
  * For workflow agents: This is the task group ID from the logger hierarchy.
  * For tool-use agents: This equals the ExecutionId (no task groups).
  * For legacy sessions: This is DEFAULT_RUN_ID ("__default__").
- *
- * Note: When storing/retrieving data, use normalizeRunId() only for
- * workflow agents or legacy data. Tool-use agents should use their
- * ExecutionId directly without normalization.
  */
 export type RunId = string;
+
+/**
+ * Unified identity for an execution - computed once, used everywhere.
+ *
+ * This interface eliminates "which ID should I use?" confusion by providing:
+ * - executionId: The unique execution instance (for history, audit, metadata)
+ * - storageKey: THE key for storage operations (files, usage, artifacts)
+ * - streamTabId: The UI tab identifier
+ *
+ * ## Usage
+ *
+ * Components receive ExecutionIdentity in their constructor or method parameters
+ * instead of computing IDs themselves:
+ *
+ * ```typescript
+ * class OutputHandler {
+ *   constructor(private readonly identity: ExecutionIdentity) {}
+ *
+ *   emit(files: OutputFileInfo[]): void {
+ *     bus.emit('addOutputFiles', {
+ *       stream: this.identity.streamTabId,
+ *       storageKey: this.identity.storageKey,  // THE key
+ *       executionId: this.identity.executionId, // For metadata
+ *       files,
+ *     });
+ *   }
+ * }
+ * ```
+ *
+ * ## Workflow vs Tool-Use
+ *
+ * - Workflow agents call `updateStorageKey()` when they create their first
+ *   task group, setting storageKey to the task group ID
+ * - Tool-use agents use executionId as storageKey (no task groups exist)
+ */
+export interface ExecutionIdentity {
+  /** The unique execution instance ID (always UUID) */
+  readonly executionId: ExecutionId;
+
+  /** THE key for storage operations (files, usage, artifacts) */
+  readonly storageKey: StorageKey;
+
+  /** The UI tab identifier */
+  readonly streamTabId: StreamTabId;
+}

--- a/src/agent/utils/UsageMonitor.ts
+++ b/src/agent/utils/UsageMonitor.ts
@@ -19,11 +19,12 @@ import { AgentExecutionContext } from '@agent/runtime/AgentExecutionContext';
  * Cost is computed once during normalization and stored in the accumulator.
  * This class simply reads the pre-computed totals - no cost recomputation needed.
  *
- * ## RunId Resolution
- * - Workflow agents: Uses task group ID from logger hierarchy (via usageReporter)
- * - Tool-use agents: Uses executionId as the runId (no task groups exist)
+ * ## Storage Key Resolution
+ * Uses context.storageKey which is already computed:
+ * - Workflow agents: storageKey = task group ID
+ * - Tool-use agents: storageKey = executionId
  *
- * @see IdentifierTypes.ts for the full execution model documentation
+ * @see ExecutionIdentity for the unified identity model
  */
 type UsageMonitorRunKind = 'workflow' | 'tool-use';
 
@@ -88,10 +89,10 @@ export class UsageMonitor {
         }),
       };
 
-      // For tool-use agents: ExecutionId IS the RunId (no task groups exist).
-      // Fallback to streamId only for legacy sessions without executionId.
-      const runId = this.context.executionId ?? this.context.streamId;
-      usageReporter.report(payload, runId);
+      // Use storageKey from context - already computed correctly for both
+      // workflow agents (task group ID) and tool-use agents (executionId)
+      const storageKey = this.context.storageKey;
+      usageReporter.report(payload, storageKey);
     } catch (error) {
       logger.error(`Error printing ${runKind} statistics: ${error}`);
     }

--- a/src/common/constants/runIds.ts
+++ b/src/common/constants/runIds.ts
@@ -11,13 +11,14 @@
  *
  * @see IdentifierTypes.ts for the full execution model documentation
  */
+import type { StorageKey } from '@agent/types/IdentifierTypes';
 
 /**
  * Sentinel run identifier retained for legacy sessions that predate
  * per-run scoping. Persisted state may still reference this ID when no
  * explicit task group identifier was available at the time.
  */
-export const DEFAULT_RUN_ID = '__default__';
+export const DEFAULT_RUN_ID: StorageKey = '__default__' as StorageKey;
 
 /**
  * Normalize a run ID for workflow agents, falling back to the default sentinel value.
@@ -26,10 +27,10 @@ export const DEFAULT_RUN_ID = '__default__';
  * Do NOT use this for tool-use agents or ExecutionId values.
  *
  * @param runId - The run ID to normalize, may be null or undefined
- * @returns Normalized run ID, never null or undefined
+ * @returns StorageKey - the branded type for storage operations
  */
-export function normalizeRunId(runId: string | null | undefined): string {
-  return runId ?? DEFAULT_RUN_ID;
+export function normalizeRunId(runId: string | null | undefined): StorageKey {
+  return (runId ?? DEFAULT_RUN_ID) as StorageKey;
 }
 
 /**

--- a/src/eventBus/ProgressEventBus.ts
+++ b/src/eventBus/ProgressEventBus.ts
@@ -64,14 +64,8 @@ interface SetTaskStatePayload {
  */
 interface RunScopedPayload {
   stream: StreamTabId;
-  /**
-   * THE key for storage operations. Required.
-   */
+  /** THE key for storage operations. Required. */
   storageKey: StorageKey;
-  /**
-   * @deprecated Redundant - equals storageKey. Kept for backward compatibility.
-   */
-  runId?: string;
   /** For metadata/audit purposes */
   executionId?: ExecutionId;
 }
@@ -98,8 +92,6 @@ export interface ProgressEventPayloads {
     usage: TokenUsageStats;
     /** THE key for storage operations. Required. */
     storageKey: StorageKey;
-    /** @deprecated Redundant - equals storageKey. */
-    runId?: string;
   };
   showRetryRequest: {
     streamId: StreamTabId;

--- a/src/eventBus/ProgressEventBus.ts
+++ b/src/eventBus/ProgressEventBus.ts
@@ -60,21 +60,18 @@ interface SetTaskStatePayload {
 /**
  * Payload for storage-scoped events (files, usage, etc.).
  *
- * storageKey is THE key for storage operations - use this preferentially.
- * runId is kept for backward compatibility during migration.
+ * storageKey is THE key for storage operations - required for all events.
  */
 interface RunScopedPayload {
   stream: StreamTabId;
   /**
-   * THE key for storage operations.
-   * For new code, prefer using this over runId.
+   * THE key for storage operations. Required.
    */
-  storageKey?: StorageKey;
+  storageKey: StorageKey;
   /**
-   * @deprecated Use storageKey instead.
-   * Kept for backward compatibility - will be removed in future.
+   * @deprecated Redundant - equals storageKey. Kept for backward compatibility.
    */
-  runId: string;
+  runId?: string;
   /** For metadata/audit purposes */
   executionId?: ExecutionId;
 }
@@ -99,10 +96,10 @@ export interface ProgressEventPayloads {
   updateStreamUsage: {
     stream: StreamTabId;
     usage: TokenUsageStats;
-    /** THE key for storage operations. Prefer using this over runId. */
-    storageKey?: StorageKey;
-    /** @deprecated Use storageKey instead. */
-    runId: string;
+    /** THE key for storage operations. Required. */
+    storageKey: StorageKey;
+    /** @deprecated Redundant - equals storageKey. */
+    runId?: string;
   };
   showRetryRequest: {
     streamId: StreamTabId;

--- a/src/eventBus/ProgressEventBus.ts
+++ b/src/eventBus/ProgressEventBus.ts
@@ -4,7 +4,11 @@ import { EventEmitter } from 'events';
 // Local imports - agent
 import type { AgentSessionDescriptor } from '@agent/core/AgentDataclass';
 import type { OutputFileInfo } from '@agent/output/types';
-import type { StreamTabId, ExecutionId } from '@agent/types/IdentifierTypes';
+import type {
+  StreamTabId,
+  ExecutionId,
+  StorageKey,
+} from '@agent/types/IdentifierTypes';
 import type { TokenUsageStats } from '@agent/types/UsageTypes';
 import type {
   LogMessageData,
@@ -53,9 +57,25 @@ interface SetTaskStatePayload {
   taskState: TaskState;
 }
 
+/**
+ * Payload for storage-scoped events (files, usage, etc.).
+ *
+ * storageKey is THE key for storage operations - use this preferentially.
+ * runId is kept for backward compatibility during migration.
+ */
 interface RunScopedPayload {
   stream: StreamTabId;
+  /**
+   * THE key for storage operations.
+   * For new code, prefer using this over runId.
+   */
+  storageKey?: StorageKey;
+  /**
+   * @deprecated Use storageKey instead.
+   * Kept for backward compatibility - will be removed in future.
+   */
   runId: string;
+  /** For metadata/audit purposes */
   executionId?: ExecutionId;
 }
 
@@ -79,6 +99,9 @@ export interface ProgressEventPayloads {
   updateStreamUsage: {
     stream: StreamTabId;
     usage: TokenUsageStats;
+    /** THE key for storage operations. Prefer using this over runId. */
+    storageKey?: StorageKey;
+    /** @deprecated Use storageKey instead. */
     runId: string;
   };
   showRetryRequest: {

--- a/src/eventBus/ProgressEventBus.ts
+++ b/src/eventBus/ProgressEventBus.ts
@@ -87,11 +87,8 @@ export interface ProgressEventPayloads {
   clearOutputFiles: StreamTabId;
   setTaskState: SetTaskStatePayload;
   clearTaskOutput: StreamTabId;
-  updateStreamUsage: {
-    stream: StreamTabId;
+  updateStreamUsage: RunScopedPayload & {
     usage: TokenUsageStats;
-    /** THE key for storage operations. Required. */
-    storageKey: StorageKey;
   };
   showRetryRequest: {
     streamId: StreamTabId;

--- a/src/logger/AgentUsageReporter.ts
+++ b/src/logger/AgentUsageReporter.ts
@@ -14,6 +14,15 @@ import { AgentLogger } from './AgentLogger';
  *
  * Usage data flows through without modification - cost and token counts
  * are already computed upstream in the model handlers.
+ *
+ * ## Single Source of Truth
+ * The storageKey parameter is THE authoritative key for storage operations.
+ * It is computed once at execution start:
+ * - Workflow agents: storageKey = task group ID
+ * - Tool-use agents: storageKey = executionId
+ *
+ * This class does NOT query the logger for group IDs - it trusts the
+ * passed storageKey as the single source of truth.
  */
 export class AgentUsageReporter {
   constructor(
@@ -25,18 +34,11 @@ export class AgentUsageReporter {
   /**
    * Emit usage data to the progress view and attach detailed stats to the log.
    *
-   * Usage flows to a single source of truth (UsageStatsManager) via updateStreamUsage.
-   * Detailed statistics are logged separately for display in the progress view.
-   *
    * @param stats - Token usage statistics to report
-   * @param storageKey - THE key for storage (from context.storageKey)
+   * @param storageKey - THE key for storage (from context.storageKey) - REQUIRED
    */
-  public report(stats: ExtendedTokenUsageStats, storageKey?: string): void {
+  public report(stats: ExtendedTokenUsageStats, storageKey: StorageKey): void {
     const logStatistics = this.agentCategory === AgentCategory.Workflow;
-
-    // Get the current task group ID for workflow agents
-    // For tool-use agents, this will be undefined and we use the passed storageKey
-    const groupId = this.logger.withCurrentGroup((id) => id);
 
     // Pass through usage without modification
     const usage = {
@@ -45,23 +47,18 @@ export class AgentUsageReporter {
       cost: stats.cost,
     };
 
-    // Use groupId if available (workflow agents within a task group),
-    // otherwise use the passed storageKey (tool-use agents or outside group context)
-    const targetKey = (groupId ?? storageKey) as StorageKey | undefined;
-
-    // Always emit to the single source of truth (UsageStatsManager)
-    if (targetKey) {
-      bus.emit('updateStreamUsage', {
-        stream: this.streamId,
-        storageKey: targetKey,
-        runId: targetKey, // Backward compatibility
-        usage,
-      });
-    }
+    // storageKey is THE single source of truth - no fallbacks, no round-trips
+    bus.emit('updateStreamUsage', {
+      stream: this.streamId,
+      storageKey,
+      runId: storageKey, // Backward compatibility
+      usage,
+    });
 
     // Log detailed statistics for display in the progress view
+    // Use storageKey for logging context as well
     if (logStatistics) {
-      this.logger.statistics(stats, groupId);
+      this.logger.statistics(stats, storageKey);
     }
   }
 }

--- a/src/logger/AgentUsageReporter.ts
+++ b/src/logger/AgentUsageReporter.ts
@@ -51,7 +51,6 @@ export class AgentUsageReporter {
     bus.emit('updateStreamUsage', {
       stream: this.streamId,
       storageKey,
-      runId: storageKey, // Backward compatibility
       usage,
     });
 

--- a/src/logger/AgentUsageReporter.ts
+++ b/src/logger/AgentUsageReporter.ts
@@ -1,5 +1,5 @@
 // Local imports - agent types
-import type { StreamTabId } from '@agent/types/IdentifierTypes';
+import type { StorageKey, StreamTabId } from '@agent/types/IdentifierTypes';
 import type { ExtendedTokenUsageStats } from '@agent/types/UsageTypes';
 import { AgentCategory } from '@agent/core/AgentDataclass';
 
@@ -28,14 +28,14 @@ export class AgentUsageReporter {
    * Usage flows to a single source of truth (UsageStatsManager) via updateStreamUsage.
    * Detailed statistics are logged separately for display in the progress view.
    *
-   * The groupId from the logger is the authoritative run identifier - it matches
-   * the TaskGroup ID that the frontend uses for activeRunId. The passed runId
-   * (executionId) is only used as a fallback when no group context exists.
+   * @param stats - Token usage statistics to report
+   * @param storageKey - THE key for storage (from context.storageKey)
    */
-  public report(stats: ExtendedTokenUsageStats, runId?: string): void {
+  public report(stats: ExtendedTokenUsageStats, storageKey?: string): void {
     const logStatistics = this.agentCategory === AgentCategory.Workflow;
 
-    // Get the current task group ID - this is what the frontend uses as activeRunId
+    // Get the current task group ID for workflow agents
+    // For tool-use agents, this will be undefined and we use the passed storageKey
     const groupId = this.logger.withCurrentGroup((id) => id);
 
     // Pass through usage without modification
@@ -45,14 +45,16 @@ export class AgentUsageReporter {
       cost: stats.cost,
     };
 
-    // Use groupId as the authoritative run identifier, fall back to passed runId
-    const targetRunId = groupId ?? runId;
+    // Use groupId if available (workflow agents within a task group),
+    // otherwise use the passed storageKey (tool-use agents or outside group context)
+    const targetKey = (groupId ?? storageKey) as StorageKey | undefined;
 
     // Always emit to the single source of truth (UsageStatsManager)
-    if (targetRunId) {
+    if (targetKey) {
       bus.emit('updateStreamUsage', {
         stream: this.streamId,
-        runId: targetRunId,
+        storageKey: targetKey,
+        runId: targetKey, // Backward compatibility
         usage,
       });
     }

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -267,7 +267,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
       const activeRunId = this.provider.state.getActiveRunId(message.stream);
       // Priority: activeRunId (task group ID for workflow agents) ?? executionId (for tool-use)
       // Workflow agents store files under task group ID, NOT executionId
-      const storageKey = activeRunId ?? executionId;
+      const storageKey = activeRunId ?? executionId ?? null;
       const runOutputs = this.provider.state.getRunOutputFiles(message.stream, {
         storageKey,
       });

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -284,7 +284,9 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
         outputFiles: taskState.agentConfig.outputFiles,
         outputFilesActive: taskState.activeFiles.output,
         streamId: message.stream,
-        runId: storageKey,
+        // executionId is for file system paths (taskRuns/<executionId>/...)
+        // storageKey is for logical storage indexing - different concepts
+        runId: executionId,
         outputsByRound,
       });
     });

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -268,7 +268,8 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
       const activeRunId = this.provider.state.getActiveRunId(message.stream);
       // Priority: activeRunId (task group ID for workflow agents) ?? executionId (for tool-use)
       // Workflow agents store files under task group ID, NOT executionId
-      const storageKey = activeRunId ?? executionId ?? null;
+      // Use normalizeRunId to brand as StorageKey at this boundary
+      const storageKey = normalizeRunId(activeRunId ?? executionId);
       const runOutputs = this.provider.state.getRunOutputFiles(message.stream, {
         storageKey,
       });
@@ -426,9 +427,11 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
     const resolvedRunId = this.provider.state.resolveRunId(stream, undefined, {
       persist: false,
     });
-    const runOutputs = this.provider.state.getRunOutputFiles(stream, {
-      storageKey: resolvedRunId,
-    });
+    // Only fetch output files if we have a resolved run ID
+    const storageKey = resolvedRunId ? normalizeRunId(resolvedRunId) : null;
+    const runOutputs = storageKey
+      ? this.provider.state.getRunOutputFiles(stream, { storageKey })
+      : undefined;
 
     // Trust stored executionId, don't extract from paths
     const executionId =

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -264,9 +264,9 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
   private async handleDiffStream(message: any): Promise<void> {
     await this.withToolbarTaskState(message.stream, async (taskState) => {
       const executionId = this.provider.state.getExecutionId(message.stream);
+      const activeRunId = this.provider.state.getActiveRunId(message.stream);
       const runOutputs = this.provider.state.getRunOutputFiles(message.stream, {
-        executionId,
-        runId: this.provider.state.getActiveRunId(message.stream),
+        storageKey: executionId ?? activeRunId,
       });
       const outputsByRound = runOutputs
         ? Object.fromEntries(runOutputs.entries())
@@ -424,8 +424,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
       persist: false,
     });
     const runOutputs = this.provider.state.getRunOutputFiles(stream, {
-      runId: resolvedRunId ?? undefined,
-      executionId: resolvedRunId ?? undefined,
+      storageKey: resolvedRunId,
     });
 
     // Trust stored executionId, don't extract from paths

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -22,6 +22,7 @@ import { ToolUseSessionPersistence } from '@agent/toolUse/ToolUseSessionPersiste
 import { toErrorMessage } from '@common/errors';
 import { BaseViewMessageHandler, MessageHandler } from '@common/webview';
 import { PROGRESS_VIEW_COMMANDS } from '@common/webview';
+import { normalizeRunId } from '@common/constants/runIds';
 import {
   isWorkflowTaskState,
   type WorkflowTaskState,
@@ -609,7 +610,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
     const generatedPaths = this.provider.state.outputFiles.getKnownFilePaths(
       stream,
       {
-        runId: resolvedRunId ?? undefined,
+        storageKey: resolvedRunId ? normalizeRunId(resolvedRunId) : null,
         workspaceOnly: true,
       },
     );

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -265,8 +265,11 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
     await this.withToolbarTaskState(message.stream, async (taskState) => {
       const executionId = this.provider.state.getExecutionId(message.stream);
       const activeRunId = this.provider.state.getActiveRunId(message.stream);
+      // Priority: activeRunId (task group ID for workflow agents) ?? executionId (for tool-use)
+      // Workflow agents store files under task group ID, NOT executionId
+      const storageKey = activeRunId ?? executionId;
       const runOutputs = this.provider.state.getRunOutputFiles(message.stream, {
-        storageKey: executionId ?? activeRunId,
+        storageKey,
       });
       const outputsByRound = runOutputs
         ? Object.fromEntries(runOutputs.entries())
@@ -279,8 +282,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
         outputFiles: taskState.agentConfig.outputFiles,
         outputFilesActive: taskState.activeFiles.output,
         streamId: message.stream,
-        runId:
-          executionId ?? this.provider.state.getActiveRunId(message.stream),
+        runId: storageKey,
         outputsByRound,
       });
     });

--- a/src/progressView/events/OutputEvents.ts
+++ b/src/progressView/events/OutputEvents.ts
@@ -105,14 +105,12 @@ const registerOutputFileListeners = (
 ): vscode.Disposable[] => {
   const addFiles = bus.on(
     'addOutputFiles',
-    ({ stream, storageKey, runId, executionId, filesByRound }) => {
+    ({ stream, storageKey, runId, filesByRound }) => {
       withErrorBoundary('failed to handle addOutputFiles', async () => {
-        // Use storageKey if provided (new path), fall back to runId for compatibility
-        const key: StorageKey = storageKey ?? (normalizeRunId(runId) as StorageKey);
-        await state.outputFiles.addFiles(stream, runId, filesByRound, {
-          storageKey: key,
-          executionId,
-        });
+        // storageKey is THE single source of truth, runId kept for backward compatibility
+        const key: StorageKey =
+          storageKey ?? (normalizeRunId(runId) as StorageKey);
+        await state.outputFiles.addFiles(stream, key, filesByRound);
         sendRunFileUpdate(state, updater, stream, key);
       });
     },
@@ -120,14 +118,12 @@ const registerOutputFileListeners = (
 
   const updateMissing = bus.on(
     'updateMissingOutputs',
-    ({ stream, storageKey, runId, executionId, filesByRound }) => {
+    ({ stream, storageKey, runId, filesByRound }) => {
       withErrorBoundary('failed to handle updateMissingOutputs', async () => {
-        // Use storageKey if provided (new path), fall back to runId for compatibility
-        const key: StorageKey = storageKey ?? (normalizeRunId(runId) as StorageKey);
-        await state.outputFiles.updateMissingOutputs(stream, runId, filesByRound, {
-          storageKey: key,
-          executionId,
-        });
+        // storageKey is THE single source of truth, runId kept for backward compatibility
+        const key: StorageKey =
+          storageKey ?? (normalizeRunId(runId) as StorageKey);
+        await state.outputFiles.updateMissingOutputs(stream, key, filesByRound);
         sendRunMissingUpdate(state, updater, stream, key);
       });
     },

--- a/src/progressView/events/OutputEvents.ts
+++ b/src/progressView/events/OutputEvents.ts
@@ -108,8 +108,8 @@ const registerOutputFileListeners = (
     ({ stream, storageKey, runId, filesByRound }) => {
       withErrorBoundary('failed to handle addOutputFiles', async () => {
         // storageKey is THE single source of truth, runId kept for backward compatibility
-        const key: StorageKey =
-          storageKey ?? (normalizeRunId(runId) as StorageKey);
+        // normalizeRunId returns StorageKey, no cast needed
+        const key = storageKey ?? normalizeRunId(runId);
         await state.outputFiles.addFiles(stream, key, filesByRound);
         sendRunFileUpdate(state, updater, stream, key);
       });
@@ -121,8 +121,8 @@ const registerOutputFileListeners = (
     ({ stream, storageKey, runId, filesByRound }) => {
       withErrorBoundary('failed to handle updateMissingOutputs', async () => {
         // storageKey is THE single source of truth, runId kept for backward compatibility
-        const key: StorageKey =
-          storageKey ?? (normalizeRunId(runId) as StorageKey);
+        // normalizeRunId returns StorageKey, no cast needed
+        const key = storageKey ?? normalizeRunId(runId);
         await state.outputFiles.updateMissingOutputs(stream, key, filesByRound);
         sendRunMissingUpdate(state, updater, stream, key);
       });

--- a/src/progressView/events/OutputEvents.ts
+++ b/src/progressView/events/OutputEvents.ts
@@ -2,8 +2,7 @@
 import * as vscode from 'vscode';
 
 // Local imports - progress view
-import type { StorageKey, StreamTabId } from '@agent/types/IdentifierTypes';
-import { normalizeRunId } from '@common/constants/runIds';
+import type { StreamTabId } from '@agent/types/IdentifierTypes';
 import type { AgentLogger } from '@logger/AgentLogger';
 import type { WebviewUpdater } from '@progressView/managers';
 import type { ProgressViewState } from '@progressView/state/ProgressViewState';
@@ -105,26 +104,22 @@ const registerOutputFileListeners = (
 ): vscode.Disposable[] => {
   const addFiles = bus.on(
     'addOutputFiles',
-    ({ stream, storageKey, runId, filesByRound }) => {
+    ({ stream, storageKey, filesByRound }) => {
       withErrorBoundary('failed to handle addOutputFiles', async () => {
-        // storageKey is THE single source of truth, runId kept for backward compatibility
-        // normalizeRunId returns StorageKey, no cast needed
-        const key = storageKey ?? normalizeRunId(runId);
-        await state.outputFiles.addFiles(stream, key, filesByRound);
-        sendRunFileUpdate(state, updater, stream, key);
+        // storageKey is THE single source of truth - no fallbacks
+        await state.outputFiles.addFiles(stream, storageKey, filesByRound);
+        sendRunFileUpdate(state, updater, stream, storageKey);
       });
     },
   );
 
   const updateMissing = bus.on(
     'updateMissingOutputs',
-    ({ stream, storageKey, runId, filesByRound }) => {
+    ({ stream, storageKey, filesByRound }) => {
       withErrorBoundary('failed to handle updateMissingOutputs', async () => {
-        // storageKey is THE single source of truth, runId kept for backward compatibility
-        // normalizeRunId returns StorageKey, no cast needed
-        const key = storageKey ?? normalizeRunId(runId);
-        await state.outputFiles.updateMissingOutputs(stream, key, filesByRound);
-        sendRunMissingUpdate(state, updater, stream, key);
+        // storageKey is THE single source of truth - no fallbacks
+        await state.outputFiles.updateMissingOutputs(stream, storageKey, filesByRound);
+        sendRunMissingUpdate(state, updater, stream, storageKey);
       });
     },
   );

--- a/src/progressView/events/OutputEvents.ts
+++ b/src/progressView/events/OutputEvents.ts
@@ -2,7 +2,7 @@
 import * as vscode from 'vscode';
 
 // Local imports - progress view
-import type { StreamTabId } from '@agent/types/IdentifierTypes';
+import type { StorageKey, StreamTabId } from '@agent/types/IdentifierTypes';
 import { normalizeRunId } from '@common/constants/runIds';
 import type { AgentLogger } from '@logger/AgentLogger';
 import type { WebviewUpdater } from '@progressView/managers';
@@ -105,34 +105,30 @@ const registerOutputFileListeners = (
 ): vscode.Disposable[] => {
   const addFiles = bus.on(
     'addOutputFiles',
-    ({ stream, runId, executionId, filesByRound }) => {
+    ({ stream, storageKey, runId, executionId, filesByRound }) => {
       withErrorBoundary('failed to handle addOutputFiles', async () => {
-        const normalizedRunId = normalizeRunId(runId);
-        await state.outputFiles.addFiles(
-          stream,
-          normalizedRunId,
-          filesByRound,
-          {
-            executionId,
-          },
-        );
-        sendRunFileUpdate(state, updater, stream, normalizedRunId);
+        // Use storageKey if provided (new path), fall back to runId for compatibility
+        const key: StorageKey = storageKey ?? (normalizeRunId(runId) as StorageKey);
+        await state.outputFiles.addFiles(stream, runId, filesByRound, {
+          storageKey: key,
+          executionId,
+        });
+        sendRunFileUpdate(state, updater, stream, key);
       });
     },
   );
 
   const updateMissing = bus.on(
     'updateMissingOutputs',
-    ({ stream, runId, executionId, filesByRound }) => {
+    ({ stream, storageKey, runId, executionId, filesByRound }) => {
       withErrorBoundary('failed to handle updateMissingOutputs', async () => {
-        const normalizedRunId = normalizeRunId(runId);
-        await state.outputFiles.updateMissingOutputs(
-          stream,
-          normalizedRunId,
-          filesByRound,
-          { executionId },
-        );
-        sendRunMissingUpdate(state, updater, stream, normalizedRunId);
+        // Use storageKey if provided (new path), fall back to runId for compatibility
+        const key: StorageKey = storageKey ?? (normalizeRunId(runId) as StorageKey);
+        await state.outputFiles.updateMissingOutputs(stream, runId, filesByRound, {
+          storageKey: key,
+          executionId,
+        });
+        sendRunMissingUpdate(state, updater, stream, key);
       });
     },
   );

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -7,6 +7,7 @@ import type { OutputFileInfo } from '@agent/output/types';
 import type { TokenUsageStats } from '@agent/types/UsageTypes';
 // Internal imports
 import { AgentCategory } from '@agent/core/AgentDataclass';
+import { normalizeRunId } from '@common/constants/runIds';
 import { STREAM_STATUS } from '@common/constants/streamStatus';
 import { AgentLogger } from '@logger/AgentLogger';
 import { WebviewUpdater } from '@progressView/managers';
@@ -149,11 +150,11 @@ export class ProgressEventHandler {
     if (runId && instructionUpdate) {
       void this.state.runInstructions.setInstruction(
         stream,
-        runId,
+        normalizeRunId(runId),
         instructionUpdate,
       );
     } else if (runId) {
-      void this.state.runInstructions.deleteRun(stream, runId);
+      void this.state.runInstructions.deleteRun(stream, normalizeRunId(runId));
     }
 
     if (instructionUpdate) {

--- a/src/progressView/events/UsageEvents.ts
+++ b/src/progressView/events/UsageEvents.ts
@@ -38,7 +38,7 @@ export function createUsageEvents(
     ): vscode.Disposable[] {
       const updateStreamUsage = bus.on(
         'updateStreamUsage',
-        ({ stream, usage, runId }) => {
+        ({ stream, usage, storageKey, runId }) => {
           withErrorBoundary('failed to handle updateStreamUsage', async () => {
             const normalizedUsage: TokenUsageStats = {
               inputTokens: Number(usage.inputTokens ?? 0),
@@ -46,13 +46,14 @@ export function createUsageEvents(
               cost: Number(usage.cost ?? 0),
             };
 
-            // The backend now emits the correct groupId as runId.
-            // Only fall back to activeRunId if runId is not provided.
-            const targetRunId = runId ?? state.getActiveRunId(stream) ?? null;
+            // storageKey is THE single source of truth
+            // runId is for backward compatibility (backend sets runId = storageKey)
+            // No round-trip to state.getActiveRunId - trust what the backend emitted
+            const targetRunId = storageKey ?? runId;
 
             if (!targetRunId) {
               shared.logger.warn(
-                `Skipping updateStreamUsage for ${stream}: unable to resolve run ID`,
+                `Skipping updateStreamUsage for ${stream}: no storageKey or runId in event`,
               );
               return;
             }

--- a/src/progressView/events/UsageEvents.ts
+++ b/src/progressView/events/UsageEvents.ts
@@ -38,7 +38,7 @@ export function createUsageEvents(
     ): vscode.Disposable[] {
       const updateStreamUsage = bus.on(
         'updateStreamUsage',
-        ({ stream, usage, storageKey, runId }) => {
+        ({ stream, usage, storageKey }) => {
           withErrorBoundary('failed to handle updateStreamUsage', async () => {
             const normalizedUsage: TokenUsageStats = {
               inputTokens: Number(usage.inputTokens ?? 0),
@@ -46,21 +46,10 @@ export function createUsageEvents(
               cost: Number(usage.cost ?? 0),
             };
 
-            // storageKey is THE single source of truth
-            // runId is for backward compatibility (backend sets runId = storageKey)
-            // No round-trip to state.getActiveRunId - trust what the backend emitted
-            const targetRunId = storageKey ?? runId;
-
-            if (!targetRunId) {
-              shared.logger.warn(
-                `Skipping updateStreamUsage for ${stream}: no storageKey or runId in event`,
-              );
-              return;
-            }
-
+            // storageKey is THE single source of truth - no fallbacks
             await state.usageStats.setRunUsage(
               stream,
-              targetRunId,
+              storageKey,
               normalizedUsage,
             );
 

--- a/src/progressView/managers/OutputFilesManager.ts
+++ b/src/progressView/managers/OutputFilesManager.ts
@@ -137,14 +137,14 @@ export class OutputFilesManager extends PersistentMapManager<
 
   getRun(
     stream: StreamTabId,
-    runId: string,
+    storageKey: StorageKey,
   ): Map<number, OutputFileInfo[]> | undefined {
     const runs = this.items.get(stream);
     if (!runs) {
       return undefined;
     }
 
-    const target = runs.get(runId);
+    const target = runs.get(storageKey);
     if (!target) {
       return undefined;
     }
@@ -161,7 +161,7 @@ export class OutputFilesManager extends PersistentMapManager<
 
   getRunMissingOutputs(
     stream: StreamTabId,
-    runId: string,
+    storageKey: StorageKey,
   ): Map<number, string[]> | undefined {
     if (!this.missingOutputsLoaded) {
       throw new Error('Missing outputs requested before load completed');
@@ -172,7 +172,7 @@ export class OutputFilesManager extends PersistentMapManager<
       return undefined;
     }
 
-    const target = runs.get(runId);
+    const target = runs.get(storageKey);
     if (!target) {
       return undefined;
     }
@@ -186,12 +186,12 @@ export class OutputFilesManager extends PersistentMapManager<
    * commands like pack/clean do not accidentally target run-storage artifacts.
    *
    * @param stream - The stream tab ID
-   * @param options.runId - The storage key for lookup. Normalized internally for safety.
+   * @param options.storageKey - THE key for storage lookup
    * @param options.workspaceOnly - If true, only returns workspace-scoped paths
    */
   getKnownFilePaths(
     stream: StreamTabId,
-    options: { runId?: string | null; workspaceOnly?: boolean } = {},
+    options: { storageKey?: StorageKey | null; workspaceOnly?: boolean } = {},
   ): Set<string> {
     const paths = new Set<string>();
     const runs = this.items.get(stream);
@@ -199,10 +199,10 @@ export class OutputFilesManager extends PersistentMapManager<
       return paths;
     }
 
-    // runId is normalized for safety - caller should pass the storageKey
+    // storageKey is THE single source of truth
     const targetRunIds =
-      options.runId !== undefined
-        ? [normalizeRunId(options.runId)]
+      options.storageKey !== undefined && options.storageKey !== null
+        ? [options.storageKey]
         : Array.from(runs.keys());
 
     for (const target of targetRunIds) {
@@ -278,17 +278,15 @@ export class OutputFilesManager extends PersistentMapManager<
    * Clear output files for a specific run within a stream.
    *
    * @param stream - The stream tab ID
-   * @param runId - The storage key for the run. Normalized internally for safety.
+   * @param storageKey - THE key for storage operations
    */
-  async clearRunFiles(stream: StreamTabId, runId: string): Promise<void> {
-    // runId is normalized for safety - caller should pass the storageKey
-    const normalizedRunId = normalizeRunId(runId);
+  async clearRunFiles(stream: StreamTabId, storageKey: StorageKey): Promise<void> {
     const runs = this.items.get(stream);
     if (!runs) {
       return;
     }
 
-    const removed = runs.delete(normalizedRunId);
+    const removed = runs.delete(storageKey);
     if (runs.size === 0) {
       this.items.delete(stream);
     }
@@ -311,21 +309,19 @@ export class OutputFilesManager extends PersistentMapManager<
    * Clear missing output records for a specific run within a stream.
    *
    * @param stream - The stream tab ID
-   * @param runId - The storage key for the run. Normalized internally for safety.
+   * @param storageKey - THE key for storage operations
    */
   async clearRunMissingOutputs(
     stream: StreamTabId,
-    runId: string,
+    storageKey: StorageKey,
   ): Promise<void> {
     await this.ensureMissingOutputsLoaded();
-    // runId is normalized for safety - caller should pass the storageKey
-    const normalizedRunId = normalizeRunId(runId);
     const runs = this._missingOutputs.get(stream);
     if (!runs) {
       return;
     }
 
-    const removed = runs.delete(normalizedRunId);
+    const removed = runs.delete(storageKey);
     if (runs.size === 0) {
       this._missingOutputs.delete(stream);
     }

--- a/src/progressView/managers/OutputFilesManager.ts
+++ b/src/progressView/managers/OutputFilesManager.ts
@@ -53,18 +53,17 @@ export class OutputFilesManager extends PersistentMapManager<
     storageKey: StorageKey,
     filesByRound: { [key: number]: OutputFileInfo[] },
   ): Promise<void> {
-    const key = normalizeRunId(storageKey) as StorageKey;
-
+    // storageKey is already branded - use directly, no normalization needed
     let streamRuns = this.items.get(stream);
     if (!streamRuns) {
       streamRuns = new Map();
       this.items.set(stream, streamRuns);
     }
 
-    let runRounds = streamRuns.get(key);
+    let runRounds = streamRuns.get(storageKey);
     if (!runRounds) {
       runRounds = new Map();
-      streamRuns.set(key, runRounds);
+      streamRuns.set(storageKey, runRounds);
     }
 
     for (const [round, files] of Object.entries(filesByRound)) {
@@ -102,7 +101,7 @@ export class OutputFilesManager extends PersistentMapManager<
     filesByRound: { [key: number]: string[] },
   ): Promise<void> {
     await this.ensureMissingOutputsLoaded();
-    const key = normalizeRunId(storageKey) as StorageKey;
+    // storageKey is already branded - use directly, no normalization needed
 
     let streamMissing = this._missingOutputs.get(stream);
     if (!streamMissing) {
@@ -110,10 +109,10 @@ export class OutputFilesManager extends PersistentMapManager<
       this._missingOutputs.set(stream, streamMissing);
     }
 
-    let runMissing = streamMissing.get(key);
+    let runMissing = streamMissing.get(storageKey);
     if (!runMissing) {
       runMissing = new Map();
-      streamMissing.set(key, runMissing);
+      streamMissing.set(storageKey, runMissing);
     }
 
     for (const [round, files] of Object.entries(filesByRound)) {

--- a/src/progressView/managers/OutputFilesManager.ts
+++ b/src/progressView/managers/OutputFilesManager.ts
@@ -2,7 +2,11 @@
 import * as vscode from 'vscode';
 
 // Local imports - progress view
-import type { ExecutionId, StreamTabId } from '@agent/types/IdentifierTypes';
+import type {
+  ExecutionId,
+  StorageKey,
+  StreamTabId,
+} from '@agent/types/IdentifierTypes';
 // Internal imports
 import {
   OutputFileInfoListSchema,
@@ -41,14 +45,24 @@ export class OutputFilesManager extends PersistentMapManager<
     this.logger = new AgentLogger('OutputFilesManager');
   }
 
-  /** Add output files for a stream and round */
+  /**
+   * Add output files for a stream and round.
+   *
+   * @param stream - The stream tab ID
+   * @param runId - Legacy parameter, use options.storageKey instead
+   * @param filesByRound - Map of round number to output files
+   * @param options - Additional options
+   * @param options.storageKey - THE key for storage (preferred over runId)
+   * @param options.executionId - For metadata purposes
+   */
   async addFiles(
     stream: StreamTabId,
     runId: string,
     filesByRound: { [key: number]: OutputFileInfo[] },
-    options: { executionId?: ExecutionId } = {},
+    options: { storageKey?: StorageKey; executionId?: ExecutionId } = {},
   ): Promise<void> {
-    const normalizedRunId = normalizeRunId(runId);
+    // Use storageKey if provided, otherwise fall back to normalizing runId
+    const key = options.storageKey ?? (normalizeRunId(runId) as StorageKey);
 
     let streamRuns = this.items.get(stream);
     if (!streamRuns) {
@@ -56,10 +70,10 @@ export class OutputFilesManager extends PersistentMapManager<
       this.items.set(stream, streamRuns);
     }
 
-    let runRounds = streamRuns.get(normalizedRunId);
+    let runRounds = streamRuns.get(key);
     if (!runRounds) {
       runRounds = new Map();
-      streamRuns.set(normalizedRunId, runRounds);
+      streamRuns.set(key, runRounds);
     }
 
     for (const [round, files] of Object.entries(filesByRound)) {
@@ -84,15 +98,25 @@ export class OutputFilesManager extends PersistentMapManager<
     await this.save();
   }
 
-  /** Update missing outputs for a stream */
+  /**
+   * Update missing outputs for a stream.
+   *
+   * @param stream - The stream tab ID
+   * @param runId - Legacy parameter, use options.storageKey instead
+   * @param filesByRound - Map of round number to missing file paths
+   * @param options - Additional options
+   * @param options.storageKey - THE key for storage (preferred over runId)
+   * @param options.executionId - For metadata purposes
+   */
   async updateMissingOutputs(
     stream: StreamTabId,
     runId: string,
     filesByRound: { [key: number]: string[] },
-    options: { executionId?: ExecutionId } = {},
+    options: { storageKey?: StorageKey; executionId?: ExecutionId } = {},
   ): Promise<void> {
     await this.ensureMissingOutputsLoaded();
-    const normalizedRunId = normalizeRunId(runId);
+    // Use storageKey if provided, otherwise fall back to normalizing runId
+    const key = options.storageKey ?? (normalizeRunId(runId) as StorageKey);
 
     let streamMissing = this._missingOutputs.get(stream);
     if (!streamMissing) {
@@ -100,10 +124,10 @@ export class OutputFilesManager extends PersistentMapManager<
       this._missingOutputs.set(stream, streamMissing);
     }
 
-    let runMissing = streamMissing.get(normalizedRunId);
+    let runMissing = streamMissing.get(key);
     if (!runMissing) {
       runMissing = new Map();
-      streamMissing.set(normalizedRunId, runMissing);
+      streamMissing.set(key, runMissing);
     }
 
     for (const [round, files] of Object.entries(filesByRound)) {

--- a/src/progressView/managers/OutputFilesManager.ts
+++ b/src/progressView/managers/OutputFilesManager.ts
@@ -184,6 +184,10 @@ export class OutputFilesManager extends PersistentMapManager<
    * Return a flattened set of file paths known for the provided stream.
    * When workspaceOnly is true, only workspace-scoped paths are returned so
    * commands like pack/clean do not accidentally target run-storage artifacts.
+   *
+   * @param stream - The stream tab ID
+   * @param options.runId - The storage key for lookup. Normalized internally for safety.
+   * @param options.workspaceOnly - If true, only returns workspace-scoped paths
    */
   getKnownFilePaths(
     stream: StreamTabId,
@@ -195,6 +199,7 @@ export class OutputFilesManager extends PersistentMapManager<
       return paths;
     }
 
+    // runId is normalized for safety - caller should pass the storageKey
     const targetRunIds =
       options.runId !== undefined
         ? [normalizeRunId(options.runId)]
@@ -269,7 +274,14 @@ export class OutputFilesManager extends PersistentMapManager<
     await this.delete(stream);
   }
 
+  /**
+   * Clear output files for a specific run within a stream.
+   *
+   * @param stream - The stream tab ID
+   * @param runId - The storage key for the run. Normalized internally for safety.
+   */
   async clearRunFiles(stream: StreamTabId, runId: string): Promise<void> {
+    // runId is normalized for safety - caller should pass the storageKey
     const normalizedRunId = normalizeRunId(runId);
     const runs = this.items.get(stream);
     if (!runs) {
@@ -295,11 +307,18 @@ export class OutputFilesManager extends PersistentMapManager<
     await this.saveMissingOutputs();
   }
 
+  /**
+   * Clear missing output records for a specific run within a stream.
+   *
+   * @param stream - The stream tab ID
+   * @param runId - The storage key for the run. Normalized internally for safety.
+   */
   async clearRunMissingOutputs(
     stream: StreamTabId,
     runId: string,
   ): Promise<void> {
     await this.ensureMissingOutputsLoaded();
+    // runId is normalized for safety - caller should pass the storageKey
     const normalizedRunId = normalizeRunId(runId);
     const runs = this._missingOutputs.get(stream);
     if (!runs) {

--- a/src/progressView/managers/OutputFilesManager.ts
+++ b/src/progressView/managers/OutputFilesManager.ts
@@ -2,11 +2,7 @@
 import * as vscode from 'vscode';
 
 // Local imports - progress view
-import type {
-  ExecutionId,
-  StorageKey,
-  StreamTabId,
-} from '@agent/types/IdentifierTypes';
+import type { StorageKey, StreamTabId } from '@agent/types/IdentifierTypes';
 // Internal imports
 import {
   OutputFileInfoListSchema,
@@ -49,20 +45,15 @@ export class OutputFilesManager extends PersistentMapManager<
    * Add output files for a stream and round.
    *
    * @param stream - The stream tab ID
-   * @param runId - Legacy parameter, use options.storageKey instead
+   * @param storageKey - THE key for storage (single source of truth)
    * @param filesByRound - Map of round number to output files
-   * @param options - Additional options
-   * @param options.storageKey - THE key for storage (preferred over runId)
-   * @param options.executionId - For metadata purposes
    */
   async addFiles(
     stream: StreamTabId,
-    runId: string,
+    storageKey: StorageKey,
     filesByRound: { [key: number]: OutputFileInfo[] },
-    options: { storageKey?: StorageKey; executionId?: ExecutionId } = {},
   ): Promise<void> {
-    // Use storageKey if provided, otherwise fall back to normalizing runId
-    const key = options.storageKey ?? (normalizeRunId(runId) as StorageKey);
+    const key = normalizeRunId(storageKey) as StorageKey;
 
     let streamRuns = this.items.get(stream);
     if (!streamRuns) {
@@ -102,21 +93,16 @@ export class OutputFilesManager extends PersistentMapManager<
    * Update missing outputs for a stream.
    *
    * @param stream - The stream tab ID
-   * @param runId - Legacy parameter, use options.storageKey instead
+   * @param storageKey - THE key for storage (single source of truth)
    * @param filesByRound - Map of round number to missing file paths
-   * @param options - Additional options
-   * @param options.storageKey - THE key for storage (preferred over runId)
-   * @param options.executionId - For metadata purposes
    */
   async updateMissingOutputs(
     stream: StreamTabId,
-    runId: string,
+    storageKey: StorageKey,
     filesByRound: { [key: number]: string[] },
-    options: { storageKey?: StorageKey; executionId?: ExecutionId } = {},
   ): Promise<void> {
     await this.ensureMissingOutputsLoaded();
-    // Use storageKey if provided, otherwise fall back to normalizing runId
-    const key = options.storageKey ?? (normalizeRunId(runId) as StorageKey);
+    const key = normalizeRunId(storageKey) as StorageKey;
 
     let streamMissing = this._missingOutputs.get(stream);
     if (!streamMissing) {
@@ -193,52 +179,6 @@ export class OutputFilesManager extends PersistentMapManager<
     }
 
     return new Map(target);
-  }
-
-  /**
-   * Find output files for a stream by executionId.
-   *
-   * For tool-use agents, executionId IS the runId (they are stored as such).
-   * For workflow agents, we search for files that have matching executionId
-   * in their location metadata.
-   *
-   * Note: ExecutionId is always a UUID, so we do NOT normalize it.
-   * normalizeRunId() is only for legacy workflow data that might have null runId.
-   *
-   * @see IdentifierTypes.ts for the full execution model documentation
-   */
-  getRunByExecution(
-    stream: StreamTabId,
-    executionId: ExecutionId,
-  ): Map<number, OutputFileInfo[]> | undefined {
-    // For tool-use agents: executionId IS the runId (no normalization needed)
-    // ExecutionId is always a UUID, never null or DEFAULT_RUN_ID
-    const direct = this.getRun(stream, executionId);
-    if (direct) {
-      return direct;
-    }
-
-    // For workflow agents: search for files with matching executionId in metadata
-    const runs = this.items.get(stream);
-    if (!runs) {
-      return undefined;
-    }
-
-    for (const [runKey, rounds] of runs.entries()) {
-      for (const infos of rounds.values()) {
-        if (
-          infos.some(
-            (info) =>
-              info.location.kind === 'runStorage' &&
-              info.location.executionId === executionId,
-          )
-        ) {
-          return this.getRun(stream, runKey);
-        }
-      }
-    }
-
-    return undefined;
   }
 
   /**

--- a/src/progressView/managers/RunInstructionManager.ts
+++ b/src/progressView/managers/RunInstructionManager.ts
@@ -1,5 +1,5 @@
 // Local imports - identifiers and logging
-import type { StreamTabId } from '@agent/types/IdentifierTypes';
+import type { StorageKey, StreamTabId } from '@agent/types/IdentifierTypes';
 
 // Internal imports
 import { WorkspaceStateKey } from '@common/state/stateManager';
@@ -36,19 +36,15 @@ export class RunInstructionManager extends PersistentMapManager<
 
   async setInstruction(
     stream: StreamTabId,
-    runId: string,
+    storageKey: StorageKey,
     instruction: InstructionUpdate | null,
   ): Promise<void> {
-    if (!runId) {
-      return;
-    }
-
     const existing = this.items.get(stream) ?? new Map();
 
     if (!instruction) {
-      existing.delete(runId);
+      existing.delete(storageKey);
     } else {
-      existing.set(runId, instruction);
+      existing.set(storageKey, instruction);
     }
 
     if (existing.size === 0) {
@@ -60,17 +56,13 @@ export class RunInstructionManager extends PersistentMapManager<
     await this.save();
   }
 
-  async deleteRun(stream: StreamTabId, runId: string): Promise<void> {
-    if (!runId) {
-      return;
-    }
-
+  async deleteRun(stream: StreamTabId, storageKey: StorageKey): Promise<void> {
     const existing = this.items.get(stream);
     if (!existing) {
       return;
     }
 
-    existing.delete(runId);
+    existing.delete(storageKey);
     if (existing.size === 0) {
       this.items.delete(stream);
     }

--- a/src/progressView/managers/UsageStatsManager.ts
+++ b/src/progressView/managers/UsageStatsManager.ts
@@ -1,9 +1,7 @@
 // Local imports - identifiers
-import type { StreamTabId } from '@agent/types/IdentifierTypes';
+import type { StorageKey, StreamTabId } from '@agent/types/IdentifierTypes';
 // Types
 import type { TokenUsageStats } from '@agent/types/UsageTypes';
-
-// Internal imports
 import { normalizeRunId } from '@common/constants/runIds';
 import { WorkspaceStateKey } from '@common/state/stateManager';
 import { AgentLogger } from '@logger/AgentLogger';
@@ -36,16 +34,13 @@ export class UsageStatsManager extends PersistentMapManager<
 
   /**
    * Update usage statistics for a stream
+   * @param storageKey - THE key for storage operations
    */
   async setRunUsage(
     stream: StreamTabId,
-    runId: string,
+    storageKey: StorageKey,
     usage: TokenUsageStats,
   ): Promise<void> {
-    if (!runId) {
-      return;
-    }
-
     const normalized = this.sanitizeUsage(usage);
     const current =
       this.items.get(stream) ?? new Map<string, TokenUsageStats>();
@@ -54,9 +49,9 @@ export class UsageStatsManager extends PersistentMapManager<
       normalized.outputTokens === 0 &&
       normalized.cost === 0
     ) {
-      current.delete(runId);
+      current.delete(storageKey);
     } else {
-      current.set(runId, normalized);
+      current.set(storageKey, normalized);
     }
 
     if (current.size === 0) {
@@ -70,18 +65,15 @@ export class UsageStatsManager extends PersistentMapManager<
 
   /**
    * Delete usage statistics for a specific run within a stream
+   * @param storageKey - THE key for storage operations
    */
-  async deleteRunUsage(stream: StreamTabId, runId: string): Promise<void> {
-    if (!runId) {
-      return;
-    }
-
+  async deleteRunUsage(stream: StreamTabId, storageKey: StorageKey): Promise<void> {
     const existing = this.items.get(stream);
     if (!existing) {
       return;
     }
 
-    existing.delete(runId);
+    existing.delete(storageKey);
     if (existing.size === 0) {
       this.items.delete(stream);
     }

--- a/src/progressView/state/ProgressViewState.ts
+++ b/src/progressView/state/ProgressViewState.ts
@@ -409,42 +409,30 @@ export class ProgressViewState {
   }
 
   /**
-   * Get output files for a stream, resolving the correct dimension key.
+   * Get output files for a stream using storageKey.
    *
-   * ## Resolution Strategy
-   * 1. If executionId is provided, try to find files stored under that ID
-   *    (works for both tool-use agents and workflow agents with runStorage)
-   * 2. Otherwise, use runId (task group) or fall back to activeRunId
+   * StorageKey is THE single source of truth for storage operations:
+   * - Workflow agents: storageKey = task group ID
+   * - Tool-use agents: storageKey = executionId
    *
-   * For tool-use agents: executionId IS the runId (same UUID)
-   * For workflow agents: runId is the task group ID, executionId is metadata
+   * The caller should pass storageKey directly. If not provided,
+   * falls back to activeRunId for the stream.
    *
+   * @param stream - The stream tab ID
+   * @param options.storageKey - THE key for storage lookup (preferred)
    * @see IdentifierTypes.ts for the full execution model documentation
    */
   getRunOutputFiles(
     stream: StreamTabId,
-    options: { executionId?: ExecutionId; runId?: string | null } = {},
+    options: { storageKey?: string | null } = {},
   ): Map<number, OutputFileInfo[]> | undefined {
-    // Try executionId first - works for tool-use agents where executionId IS runId
-    // and for workflow agents with runStorage metadata
-    if (options.executionId) {
-      const byExecution = this._outputFiles.getRunByExecution(
-        stream,
-        options.executionId,
-      );
-      if (byExecution) {
-        return byExecution;
-      }
-    }
-
-    // Fall back to runId (task group for workflow agents, or legacy data)
-    const candidateRunId =
-      options.runId ?? this.getActiveRunId(stream) ?? undefined;
-    if (!candidateRunId) {
+    // Use storageKey directly - no dual-lookup, no spaghetti
+    const key = options.storageKey ?? this.getActiveRunId(stream);
+    if (!key) {
       return undefined;
     }
 
-    return this._outputFiles.getRun(stream, normalizeRunId(candidateRunId));
+    return this._outputFiles.getRun(stream, normalizeRunId(key));
   }
 
   // Execution ID management

--- a/src/progressView/state/ProgressViewState.ts
+++ b/src/progressView/state/ProgressViewState.ts
@@ -8,7 +8,11 @@ import type { AgentCategory, AgentType } from '@agent/core/AgentDataclass';
 // Internal imports
 import { isAgentTypeFilter } from '@agent/types/AgentStreamTypes';
 // Type imports
-import type { StreamTabId, ExecutionId } from '@agent/types/IdentifierTypes';
+import type {
+  StreamTabId,
+  ExecutionId,
+  StorageKey,
+} from '@agent/types/IdentifierTypes';
 import type { OutputFileInfo } from '@agent/output/types';
 // Internal imports
 import { cleanupInactiveAgents } from '@agent/toolUse/ToolUseAgentRegistry';
@@ -416,19 +420,14 @@ export class ProgressViewState {
    * - Tool-use agents: storageKey = executionId
    *
    * @param stream - The stream tab ID
-   * @param options.storageKey - THE key for storage lookup. Required.
+   * @param options.storageKey - THE branded key for storage lookup.
    * @see IdentifierTypes.ts for the full execution model documentation
    */
   getRunOutputFiles(
     stream: StreamTabId,
-    options: { storageKey: string | null },
+    options: { storageKey: StorageKey },
   ): Map<number, OutputFileInfo[]> | undefined {
-    // storageKey is THE single source of truth - no fallbacks
-    if (!options.storageKey) {
-      return undefined;
-    }
-
-    return this._outputFiles.getRun(stream, normalizeRunId(options.storageKey));
+    return this._outputFiles.getRun(stream, options.storageKey);
   }
 
   // Execution ID management

--- a/src/progressView/state/ProgressViewState.ts
+++ b/src/progressView/state/ProgressViewState.ts
@@ -415,18 +415,17 @@ export class ProgressViewState {
    * - Workflow agents: storageKey = task group ID
    * - Tool-use agents: storageKey = executionId
    *
-   * The caller should pass storageKey directly. If not provided,
-   * falls back to activeRunId for the stream.
-   *
    * @param stream - The stream tab ID
-   * @param options.storageKey - THE key for storage lookup (preferred)
+   * @param options.storageKey - THE key for storage lookup. **Always pass this.**
+   *        Fallback to activeRunId is deprecated and will be removed.
    * @see IdentifierTypes.ts for the full execution model documentation
    */
   getRunOutputFiles(
     stream: StreamTabId,
     options: { storageKey?: string | null } = {},
   ): Map<number, OutputFileInfo[]> | undefined {
-    // Use storageKey directly - no dual-lookup, no spaghetti
+    // storageKey is THE single source of truth - use it directly when provided
+    // Fallback to activeRunId is for backward compatibility only (deprecated)
     const key = options.storageKey ?? this.getActiveRunId(stream);
     if (!key) {
       return undefined;

--- a/src/progressView/state/ProgressViewState.ts
+++ b/src/progressView/state/ProgressViewState.ts
@@ -79,7 +79,7 @@ export class ProgressViewState {
    * is cleared, so there is no need to persist these hints across sessions.
    */
   private _sessionCategoryHints: Map<StreamTabId, AgentCategory> = new Map();
-  private _activeRunIds: Map<StreamTabId, string | null> = new Map();
+  private _activeRunIds: Map<StreamTabId, StorageKey | null> = new Map();
   private readonly storage: StateStorage;
   private readonly logger: AgentLogger;
 
@@ -169,11 +169,13 @@ export class ProgressViewState {
   }
 
   setActiveRunId(stream: StreamTabId, runId: string | null): void {
-    this._activeRunIds.set(stream, runId);
+    // Normalize at boundary to ensure branded StorageKey storage
+    const storageKey = runId ? normalizeRunId(runId) : null;
+    this._activeRunIds.set(stream, storageKey);
     this.saveActiveRunIds();
   }
 
-  getActiveRunId(stream: StreamTabId): string | null {
+  getActiveRunId(stream: StreamTabId): StorageKey | null {
     return this._activeRunIds.get(stream) ?? null;
   }
 
@@ -333,8 +335,12 @@ export class ProgressViewState {
       {},
     );
 
+    // Normalize at boundary to ensure branded StorageKey storage
     this._activeRunIds = new Map(
-      Object.entries(stored).map(([stream, runId]) => [stream, runId ?? null]),
+      Object.entries(stored).map(([stream, runId]) => [
+        stream,
+        runId ? normalizeRunId(runId) : null,
+      ]),
     );
   }
 

--- a/src/progressView/state/ProgressViewState.ts
+++ b/src/progressView/state/ProgressViewState.ts
@@ -416,22 +416,19 @@ export class ProgressViewState {
    * - Tool-use agents: storageKey = executionId
    *
    * @param stream - The stream tab ID
-   * @param options.storageKey - THE key for storage lookup. **Always pass this.**
-   *        Fallback to activeRunId is deprecated and will be removed.
+   * @param options.storageKey - THE key for storage lookup. Required.
    * @see IdentifierTypes.ts for the full execution model documentation
    */
   getRunOutputFiles(
     stream: StreamTabId,
-    options: { storageKey?: string | null } = {},
+    options: { storageKey: string | null },
   ): Map<number, OutputFileInfo[]> | undefined {
-    // storageKey is THE single source of truth - use it directly when provided
-    // Fallback to activeRunId is for backward compatibility only (deprecated)
-    const key = options.storageKey ?? this.getActiveRunId(stream);
-    if (!key) {
+    // storageKey is THE single source of truth - no fallbacks
+    if (!options.storageKey) {
       return undefined;
     }
 
-    return this._outputFiles.getRun(stream, normalizeRunId(key));
+    return this._outputFiles.getRun(stream, normalizeRunId(options.storageKey));
   }
 
   // Execution ID management

--- a/src/test/logger/AgentUsageReporter.test.ts
+++ b/src/test/logger/AgentUsageReporter.test.ts
@@ -3,26 +3,35 @@ import { strict as assert } from 'assert';
 
 // Local imports
 import { AgentCategory } from '@agent/core/AgentDataclass';
+import type { StorageKey } from '@agent/types/IdentifierTypes';
 import type { ExtendedTokenUsageStats } from '@agent/types/UsageTypes';
 import type { AgentLogger } from '@logger/AgentLogger';
 import { bus } from '@eventBus/ProgressEventBus';
 import { AgentUsageReporter } from '@/logger/AgentUsageReporter';
 
 describe('AgentUsageReporter', () => {
-  it('falls back to passed runId when groupId is not available', () => {
+  /**
+   * AgentUsageReporter trusts the passed storageKey as the single source of truth.
+   * It does NOT query the logger for group IDs - no round-trips.
+   */
+  it('trusts storageKey as single source of truth (no round-trip to logger)', () => {
     const streamId = 'stream:test';
-    const runId = 'run-123';
+    const storageKey = 'task-group-123' as StorageKey;
     const streamEvents: unknown[] = [];
     const disposeStream = bus.on('updateStreamUsage', (payload) => {
       streamEvents.push(payload);
     });
 
     let recordedStats: ExtendedTokenUsageStats | undefined;
+    let recordedStorageKey: string | undefined;
     const loggerStub = {
-      withCurrentGroup: <T>(_: (groupId: string) => T): T | undefined =>
-        undefined,
-      statistics: (stats: ExtendedTokenUsageStats) => {
+      // This should NOT be called - we don't do round-trips anymore
+      withCurrentGroup: <T>(_: (groupId: string) => T): T | undefined => {
+        throw new Error('withCurrentGroup should not be called - no round-trips!');
+      },
+      statistics: (stats: ExtendedTokenUsageStats, key: string) => {
         recordedStats = stats;
+        recordedStorageKey = key;
       },
     } as unknown as AgentLogger;
 
@@ -39,66 +48,23 @@ describe('AgentUsageReporter', () => {
     };
 
     try {
-      reporter.report(stats, runId);
+      reporter.report(stats, storageKey);
 
       assert.equal(streamEvents.length, 1);
-      // inputTokens is passed through unchanged - cacheCreationInputTokens
-      // is tracked separately in the normalized usage system
+      // Verify both storageKey and runId are emitted
       assert.deepEqual(streamEvents[0], {
         stream: streamId,
-        runId,
+        storageKey, // THE single source of truth
+        runId: storageKey, // Backward compatibility
         usage: {
           inputTokens: 10,
           outputTokens: 5,
           cost: 0.25,
         },
       });
+      // Verify statistics were logged with storageKey
       assert.strictEqual(recordedStats, stats);
-    } finally {
-      disposeStream();
-    }
-  });
-
-  it('uses groupId from logger instead of passed runId when available', () => {
-    const streamId = 'stream:test';
-    const passedRunId = 'execution-id-123';
-    const groupId = 'task-group-id-456';
-    const streamEvents: unknown[] = [];
-    const disposeStream = bus.on('updateStreamUsage', (payload) => {
-      streamEvents.push(payload);
-    });
-
-    const loggerStub = {
-      withCurrentGroup: <T>(fn: (groupId: string) => T): T | undefined =>
-        fn(groupId),
-      statistics: () => {},
-    } as unknown as AgentLogger;
-
-    const reporter = new AgentUsageReporter(
-      loggerStub,
-      streamId,
-      AgentCategory.Workflow,
-    );
-    const stats: ExtendedTokenUsageStats = {
-      inputTokens: 10,
-      outputTokens: 5,
-      cost: 0.25,
-    };
-
-    try {
-      reporter.report(stats, passedRunId);
-
-      assert.equal(streamEvents.length, 1);
-      // groupId should be used instead of passedRunId
-      assert.deepEqual(streamEvents[0], {
-        stream: streamId,
-        runId: groupId, // NOT passedRunId!
-        usage: {
-          inputTokens: 10,
-          outputTokens: 5,
-          cost: 0.25,
-        },
-      });
+      assert.strictEqual(recordedStorageKey, storageKey);
     } finally {
       disposeStream();
     }
@@ -106,15 +72,16 @@ describe('AgentUsageReporter', () => {
 
   it('skips statistics logging for tool-use sessions', () => {
     const streamId = 'stream:test';
-    const runId = 'run-456';
+    const storageKey = 'execution-id-456' as StorageKey;
     const streamEvents: unknown[] = [];
     const disposeStream = bus.on('updateStreamUsage', (payload) => {
       streamEvents.push(payload);
     });
 
     const loggerStub = {
-      withCurrentGroup: <T>(_: (groupId: string) => T): T | undefined =>
-        undefined,
+      withCurrentGroup: <T>(_: (groupId: string) => T): T | undefined => {
+        throw new Error('withCurrentGroup should not be called');
+      },
       statistics: () => {
         throw new Error('statistics should not be called for tool-use runs');
       },
@@ -134,12 +101,13 @@ describe('AgentUsageReporter', () => {
     };
 
     try {
-      reporter.report(stats, runId);
+      reporter.report(stats, storageKey);
 
       assert.equal(streamEvents.length, 1);
       assert.deepEqual(streamEvents[0], {
         stream: streamId,
-        runId,
+        storageKey,
+        runId: storageKey, // Backward compatibility
         usage: {
           inputTokens: 6,
           outputTokens: 2,

--- a/src/test/logger/AgentUsageReporter.test.ts
+++ b/src/test/logger/AgentUsageReporter.test.ts
@@ -51,11 +51,10 @@ describe('AgentUsageReporter', () => {
       reporter.report(stats, storageKey);
 
       assert.equal(streamEvents.length, 1);
-      // Verify both storageKey and runId are emitted
+      // storageKey is THE single source of truth - no runId needed
       assert.deepEqual(streamEvents[0], {
         stream: streamId,
-        storageKey, // THE single source of truth
-        runId: storageKey, // Backward compatibility
+        storageKey,
         usage: {
           inputTokens: 10,
           outputTokens: 5,
@@ -107,7 +106,6 @@ describe('AgentUsageReporter', () => {
       assert.deepEqual(streamEvents[0], {
         stream: streamId,
         storageKey,
-        runId: storageKey, // Backward compatibility
         usage: {
           inputTokens: 6,
           outputTokens: 2,


### PR DESCRIPTION
…ce of truth

This refactor addresses the runId vs executionId confusion by introducing:

1. ExecutionIdentity interface - unified identity with:
   - executionId: Always UUID (for history/audit)
   - storageKey: THE key for storage operations (files, usage, artifacts)
   - streamTabId: UI tab identifier

2. StorageKey type - computed once at execution start:
   - Workflow agents: updated to task group ID when created
   - Tool-use agents: equals executionId (no task groups)

3. AgentExecutionContext.updateStorageKey() - called by workflow agents when they create their primary task group

Key changes:
- IdentifierTypes.ts: Add StorageKey, ExecutionIdentity, deprecate RunId
- AgentExecutionContext: Add identity property and updateStorageKey()
- OutputHandler: Use storageKey instead of asking logger for group ID
- ProgressEventBus: Add storageKey to RunScopedPayload
- OutputFilesManager: Accept storageKey in options
- BaseReflectionAgent: Call context.updateStorageKey() on task group creation
- ToolUseCycle: Use context.storageKey directly
- UsageMonitor/AgentUsageReporter: Use storageKey for reporting

Benefits:
- No round-trips: ID computed once, passed everywhere
- No dual-lookup: Single storage key, single lookup path
- No confusion: Clear separation between executionId and storageKey
- Type safety: Distinct types prevent accidental mixing
- Backward compatible: runId kept for legacy code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces scattered runId usage with a single StorageKey from a new ExecutionIdentity, updating runtime, event payloads, output handling, progress view managers, and usage reporting.
> 
> - **Identity model**
>   - Add `StorageKey` (branded) and `ExecutionIdentity` in `agent/types/IdentifierTypes.ts`.
>   - `AgentExecutionContext` now generates `executionId`, exposes `storageKey`, and supports `updateStorageKey()`; adds `hasInitialStorageKey()`.
> - **Runtime/agents**
>   - `BaseAgent` stores readonly `executionId`.
>   - `BaseReflectionAgent` hydrates/sets `storageKey` on resume/start; passes `storageKey` to `OutputHandler` hydration.
>   - `ToolUseCycle` emits files with `storageKey` (not `runId`).
>   - `executeAgent` derives `storageKey` for resume/hydration and diff actions.
> - **Output handling**
>   - `IOutputHandler`/`OutputHandler` switch to `storageKey`; remove logger round-trip; centralize storage payload via `createStoragePayload()`.
>   - Events `addOutputFiles`/`updateMissingOutputs` emitted with `{ storageKey, executionId }`.
> - **Event bus**
>   - `ProgressEventBus` replaces `runId` in run-scoped payloads with required `storageKey`; `updateStreamUsage` similarly updated.
> - **Progress view**
>   - Managers (`OutputFilesManager`, `UsageStatsManager`, `RunInstructionManager`) and handlers use `storageKey` for all lookups, persistence, and UI updates; legacy normalization via `normalizeRunId()` retained.
>   - `ProgressViewState` stores active run as `StorageKey`; `getRunOutputFiles()` keyed by `storageKey`.
>   - Output/Usage event handlers consume `storageKey`.
> - **Usage reporting**
>   - `UsageMonitor` and `AgentUsageReporter` report usage via `storageKey`; no logger group ID fallback.
> - **Utilities/tests**
>   - `runIds.ts` brands `DEFAULT_RUN_ID` and `normalizeRunId()` returns `StorageKey`.
>   - Tests updated for `AgentUsageReporter` to assert `storageKey`-based emissions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1ffda3afe85fa757d61885d0d00f6161e074ddf4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->