### PR TITLE
fix: parse Pandoc reference format for clickable LaTeX refs

### DIFF
--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -524,6 +524,21 @@ export class LogEntryFormatter {
     content = content.replace(/\\cref\{([^}]+)\}/g, '@@LATEX-CREF:$1@@');
     content = content.replace(/\\eqref\{([^}]+)\}/g, '@@LATEX-EQREF:$1@@');
 
+    // Also handle Pandoc's reference format: [label]{reference-type="ref" reference="label"}
+    // This format is produced when LaTeX is converted through Pandoc
+    content = content.replace(
+      /\[([^\]]+)\]\{reference-type="ref"\s+reference="([^"]+)"\}/g,
+      '@@LATEX-REF:$2@@',
+    );
+    content = content.replace(
+      /\[([^\]]+)\]\{reference-type="eqref"\s+reference="([^"]+)"\}/g,
+      '@@LATEX-EQREF:$2@@',
+    );
+    content = content.replace(
+      /\[([^\]]+)\]\{reference-type="[Cc]ref"\s+reference="([^"]+)"\}/g,
+      '@@LATEX-CREF:$2@@',
+    );
+
     const renderer = this.md || getMarkdownRenderer();
 
     // Process content as markdown


### PR DESCRIPTION
When LaTeX content passes through Pandoc, \ref{label} commands are
converted to Pandoc's internal format: [label]{reference-type="ref"
reference="label"}. This format was not being recognized, causing
references to display as raw markup instead of clickable links.

Add regex patterns to detect and convert Pandoc's reference format
for ref, eqref, and cref commands into the same clickable HTML
elements as native LaTeX references.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Handle Pandoc-formatted refs by converting them to LaTeX ref placeholders so they render as clickable links.
> 
> - **Markdown/Latex refs** (`src/progressView/modules/formatters.js`):
>   - Pre-process Pandoc reference patterns (`[label]{reference-type="ref|eqref|[Cc]ref" reference="label"}`) to `@@LATEX-REF|EQREF|CREF@@` placeholders alongside existing `\ref`, `\eqref`, `\cref` handling.
>   - Leverages existing post-processing to restore placeholders as clickable LaTeX reference elements.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5a196a132c35ac11b1ff3d790b081743a27b902c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->