### PR TITLE
fix: handle Anthropic tool-use responses without text blocks

### DIFF
--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -166,6 +166,23 @@ const isAnyThinkingBlockParam = (
 const isBetaToolUseBlock = (block: BetaContentBlock): block is ToolUseBlock =>
   block.type === 'tool_use';
 
+/** Extract concatenated text from content blocks, optionally trimming each block */
+const extractTextFromContent = (
+  content: BetaContentBlock[] | undefined,
+  trim = false,
+): string => {
+  if (!Array.isArray(content)) {
+    return '';
+  }
+  let text = '';
+  for (const block of content) {
+    if (block.type === 'text') {
+      text += trim ? block.text.trim() : block.text;
+    }
+  }
+  return text;
+};
+
 /**
  * Anthropic-specific model handler implementation for managing API interactions and message processing.
  */
@@ -579,8 +596,9 @@ export class ModelHandlerAnthropic extends ModelHandler<
           response = await stream.finalMessage();
           const finalReasoning = this.processThinkingBlock(response);
           thinking.finalize(finalReasoning ?? undefined);
-          // Use SDK's finalText() method to extract concatenated text content
-          const finalOutput = await stream.finalText();
+          // Extract text manually instead of using finalText() which throws
+          // when response contains only thinking + tool_use blocks with no text
+          const finalOutput = extractTextFromContent(response.content);
           if (output) output.finalize(finalOutput);
         } finally {
           cleanupAbortListener?.();
@@ -1122,27 +1140,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
 
     // Extract base response
     const stopReason = responseObject.stop_reason;
-    let newResponse = '';
-
-    if (
-      this.capabilities.supportsReasoning &&
-      Array.isArray(responseObject.content) &&
-      responseObject.content.length > 0
-    ) {
-      // Handle text blocks in Claude 3.7 Sonnet responses
-      for (const block of responseObject.content) {
-        if (block.type === 'text') {
-          newResponse += block.text.trim();
-        }
-        // We don't include thinking blocks in the response text
-      }
-    } else if (responseObject.content && responseObject.content.length > 0) {
-      // Handle regular text responses
-      const firstBlock = responseObject.content[0];
-      if (firstBlock.type === 'text') {
-        newResponse = firstBlock.text.trim();
-      }
-    }
+    let newResponse = extractTextFromContent(responseObject.content, true);
 
     // Add end tag if needed
     if (


### PR DESCRIPTION
The Anthropic SDK's finalText() method throws an error when the
response contains only thinking + tool_use blocks with no text.
This happens during tool-use flows where the model decides to
call tools without any accompanying text.

Instead of using finalText(), manually extract text from the
response content array, which gracefully handles the case of
no text blocks by returning an empty string.

Fixes streaming error: "stream ended without producing a content
block with type=text"

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Avoids SDK finalText() errors by manually extracting text from content blocks and reusing this logic in response extraction.
> 
> - **Anthropic Model Handler** (`src/agent/modelHandlers/modelHandlerAnthropic.ts`):
>   - **Text extraction utility**: Add `extractTextFromContent(content, trim?)` to concatenate `text` blocks from `BetaContentBlock[]`.
>   - **Streaming path**: Replace `stream.finalText()` with manual extraction from `response.content` to prevent errors when responses contain only `thinking`/`tool_use` blocks.
>   - **Response parsing**: Simplify `extractResponse` to use `extractTextFromContent(..., true)` and keep end-tag handling/replacements.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eea21d4e382704659a4cebc4d689680d8e7edd83. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->