### PR TITLE
Fix Gemini model statistics and type normalization

### DIFF
--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -550,7 +550,9 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
           ];
         }
 
-        if (!baseResponse.usageMetadata && usageFromChunks) {
+        // Always prefer the latest usage metadata from chunks (typically the final
+        // chunk has complete data). The first chunk may have partial/empty metadata.
+        if (usageFromChunks) {
           baseResponse.usageMetadata = usageFromChunks;
         }
 
@@ -800,15 +802,22 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
   ): number {
     if (!responseUsage) return 0.0;
     const promptTokens = responseUsage.promptTokenCount ?? 0;
-    const completionTokens = responseUsage.candidatesTokenCount ?? 0;
-    // const completionTokens = responseUsage.responseTokenCount ?? 0;
-    // responseTokenCount is not correct, we need to compute the completion tokens from the response, maybe it is response.usageMetadata.candidatesTokenCount
-    // completion token computed this way seems to be zero for some reason
+    const candidatesTokens = responseUsage.candidatesTokenCount ?? 0;
     const thoughtTokens = responseUsage.thoughtsTokenCount ?? 0;
     const toolUseTokens = responseUsage.toolUsePromptTokenCount ?? 0;
+
+    const inputTokens = promptTokens + toolUseTokens;
+    let outputTokens = candidatesTokens + thoughtTokens;
+
+    // Fallback: In streaming mode, individual output fields may be 0 while
+    // totalTokenCount is correct. Compute output from total if needed.
+    if (outputTokens === 0 && responseUsage.totalTokenCount) {
+      outputTokens = Math.max(0, responseUsage.totalTokenCount - inputTokens);
+    }
+
     return calculateTokenPrice(
-      promptTokens + toolUseTokens,
-      thoughtTokens + completionTokens,
+      inputTokens,
+      outputTokens,
       this.config.inputPrice,
       this.config.outputPrice,
     );
@@ -818,17 +827,30 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
     responseUsage: GenerateContentResponseUsageMetadata | null,
     responseTime: number,
   ): OpenAIAPIResponseUsage {
-    // Use the usageMetadata attribute on the response object after calling generate_content. (we did)
+    // Use the usageMetadata attribute on the response object after calling generate_content.
     // This returns the total number of tokens in both the input and the output: totalTokenCount.
     // It also returns the token counts of the input and output separately: promptTokenCount (input tokens) and candidatesTokenCount (output tokens).
 
-    // Include thoughtsTokenCount in completion_tokens to match OpenAI convention
-    // where completion_tokens is the total, and reasoning_tokens is the breakdown
+    const promptTokens = responseUsage?.promptTokenCount ?? 0;
+    const toolUseTokens = responseUsage?.toolUsePromptTokenCount ?? 0;
     const candidatesTokens = responseUsage?.candidatesTokenCount ?? 0;
     const thoughtsTokens = responseUsage?.thoughtsTokenCount ?? 0;
+
+    const inputTokens = promptTokens + toolUseTokens;
+    let completionTokens = candidatesTokens + thoughtsTokens;
+
+    // Fallback: In streaming mode, individual output fields may be 0 while
+    // totalTokenCount is correct. Compute output from total if needed.
+    if (completionTokens === 0 && responseUsage?.totalTokenCount) {
+      completionTokens = Math.max(
+        0,
+        responseUsage.totalTokenCount - inputTokens,
+      );
+    }
+
     const usageObj: ExtendedCompletionUsage = {
-      prompt_tokens: responseUsage?.promptTokenCount ?? 0,
-      completion_tokens: candidatesTokens + thoughtsTokens,
+      prompt_tokens: promptTokens,
+      completion_tokens: completionTokens,
       total_tokens: responseUsage?.totalTokenCount ?? 0,
       prompt_tokens_details: {
         cached_tokens: responseUsage?.cachedContentTokenCount ?? 0,
@@ -861,15 +883,23 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
       };
     }
 
-    const inputTokens =
-      (rawUsage.promptTokenCount ?? 0) +
-      (rawUsage.toolUsePromptTokenCount ?? 0);
+    const promptTokens = rawUsage.promptTokenCount ?? 0;
+    const toolUseTokens = rawUsage.toolUsePromptTokenCount ?? 0;
+    const inputTokens = promptTokens + toolUseTokens;
+
     // Include thoughtsTokenCount in output to match cost calculation.
     // For thinking models, candidatesTokenCount may be 0 while most output
     // is in thoughtsTokenCount. Track reasoningTokens separately for breakdown.
     const candidatesTokens = rawUsage.candidatesTokenCount ?? 0;
     const reasoningTokens = rawUsage.thoughtsTokenCount ?? 0;
-    const outputTokens = candidatesTokens + reasoningTokens;
+    let outputTokens = candidatesTokens + reasoningTokens;
+
+    // Fallback: In streaming mode, individual output fields may be 0 while
+    // totalTokenCount is correct. Compute output from total if needed.
+    if (outputTokens === 0 && rawUsage.totalTokenCount) {
+      outputTokens = Math.max(0, rawUsage.totalTokenCount - inputTokens);
+    }
+
     const cachedTokens = rawUsage.cachedContentTokenCount ?? 0;
 
     // Calculate percentage cached

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -809,6 +809,13 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
    * the documented formula.
    *
    * Note: candidatesTokenCount does NOT include thinking tokens per llm-gemini#75.
+   *
+   * TODO: Future work - extract per-modality token breakdown from promptTokensDetails[],
+   * candidatesTokensDetails[], cacheTokensDetails[], and toolUsePromptTokensDetails[].
+   * Each array contains ModalityTokenCount objects with modality (TEXT, IMAGE, VIDEO,
+   * AUDIO, DOCUMENT) and tokenCount. Note that PDF pages are currently reported under
+   * IMAGE modality, not DOCUMENT. This would enable modality-specific cost tracking
+   * and better insights into multimodal token consumption.
    */
   private computeTokenCounts(
     usage: GenerateContentResponseUsageMetadata | null,

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -822,15 +822,19 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
     // This returns the total number of tokens in both the input and the output: totalTokenCount.
     // It also returns the token counts of the input and output separately: promptTokenCount (input tokens) and candidatesTokenCount (output tokens).
 
+    // Include thoughtsTokenCount in completion_tokens to match OpenAI convention
+    // where completion_tokens is the total, and reasoning_tokens is the breakdown
+    const candidatesTokens = responseUsage?.candidatesTokenCount ?? 0;
+    const thoughtsTokens = responseUsage?.thoughtsTokenCount ?? 0;
     const usageObj: ExtendedCompletionUsage = {
       prompt_tokens: responseUsage?.promptTokenCount ?? 0,
-      completion_tokens: responseUsage?.candidatesTokenCount ?? 0,
+      completion_tokens: candidatesTokens + thoughtsTokens,
       total_tokens: responseUsage?.totalTokenCount ?? 0,
       prompt_tokens_details: {
         cached_tokens: responseUsage?.cachedContentTokenCount ?? 0,
       },
       completion_tokens_details: {
-        reasoning_tokens: responseUsage?.thoughtsTokenCount ?? 0,
+        reasoning_tokens: thoughtsTokens,
         accepted_prediction_tokens: undefined,
         rejected_prediction_tokens: undefined,
       },
@@ -860,8 +864,12 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
     const inputTokens =
       (rawUsage.promptTokenCount ?? 0) +
       (rawUsage.toolUsePromptTokenCount ?? 0);
-    const outputTokens = rawUsage.candidatesTokenCount ?? 0;
+    // Include thoughtsTokenCount in output to match cost calculation.
+    // For thinking models, candidatesTokenCount may be 0 while most output
+    // is in thoughtsTokenCount. Track reasoningTokens separately for breakdown.
+    const candidatesTokens = rawUsage.candidatesTokenCount ?? 0;
     const reasoningTokens = rawUsage.thoughtsTokenCount ?? 0;
+    const outputTokens = candidatesTokens + reasoningTokens;
     const cachedTokens = rawUsage.cachedContentTokenCount ?? 0;
 
     // Calculate percentage cached

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -797,23 +797,54 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
     return { response: responseText, usage, stopReason };
   }
 
+  /**
+   * Computes input and output token counts from Gemini usageMetadata.
+   *
+   * Google's formula: totalTokenCount = promptTokenCount + candidatesTokenCount
+   *                                   + toolUsePromptTokenCount + thoughtsTokenCount
+   *
+   * For output tokens, we prefer the sum of candidatesTokenCount + thoughtsTokenCount
+   * when available. When individual fields are unpopulated (which can happen in
+   * streaming mode for some models), we derive output from totalTokenCount using
+   * the documented formula.
+   *
+   * Note: candidatesTokenCount does NOT include thinking tokens per llm-gemini#75.
+   */
+  private computeTokenCounts(
+    usage: GenerateContentResponseUsageMetadata | null,
+  ): { inputTokens: number; outputTokens: number; reasoningTokens: number } {
+    if (!usage) {
+      return { inputTokens: 0, outputTokens: 0, reasoningTokens: 0 };
+    }
+
+    const promptTokens = usage.promptTokenCount ?? 0;
+    const toolUseTokens = usage.toolUsePromptTokenCount ?? 0;
+    const candidatesTokens = usage.candidatesTokenCount ?? 0;
+    const reasoningTokens = usage.thoughtsTokenCount ?? 0;
+
+    const inputTokens = promptTokens + toolUseTokens;
+
+    // Per Google's formula: outputTokens = candidatesTokenCount + thoughtsTokenCount
+    // When these fields are populated, use them directly.
+    // When unpopulated (some models in streaming), derive from totalTokenCount.
+    const directOutput = candidatesTokens + reasoningTokens;
+    const derivedOutput =
+      usage.totalTokenCount !== undefined
+        ? Math.max(0, usage.totalTokenCount - inputTokens)
+        : 0;
+
+    // Use direct values when available; otherwise use derived calculation
+    const outputTokens = directOutput > 0 ? directOutput : derivedOutput;
+
+    return { inputTokens, outputTokens, reasoningTokens };
+  }
+
   computePrice(
     responseUsage: GenerateContentResponseUsageMetadata | null,
   ): number {
     if (!responseUsage) return 0.0;
-    const promptTokens = responseUsage.promptTokenCount ?? 0;
-    const candidatesTokens = responseUsage.candidatesTokenCount ?? 0;
-    const thoughtTokens = responseUsage.thoughtsTokenCount ?? 0;
-    const toolUseTokens = responseUsage.toolUsePromptTokenCount ?? 0;
-
-    const inputTokens = promptTokens + toolUseTokens;
-    let outputTokens = candidatesTokens + thoughtTokens;
-
-    // Fallback: In streaming mode, individual output fields may be 0 while
-    // totalTokenCount is correct. Compute output from total if needed.
-    if (outputTokens === 0 && responseUsage.totalTokenCount) {
-      outputTokens = Math.max(0, responseUsage.totalTokenCount - inputTokens);
-    }
+    const { inputTokens, outputTokens } =
+      this.computeTokenCounts(responseUsage);
 
     return calculateTokenPrice(
       inputTokens,
@@ -827,36 +858,18 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
     responseUsage: GenerateContentResponseUsageMetadata | null,
     responseTime: number,
   ): OpenAIAPIResponseUsage {
-    // Use the usageMetadata attribute on the response object after calling generate_content.
-    // This returns the total number of tokens in both the input and the output: totalTokenCount.
-    // It also returns the token counts of the input and output separately: promptTokenCount (input tokens) and candidatesTokenCount (output tokens).
-
-    const promptTokens = responseUsage?.promptTokenCount ?? 0;
-    const toolUseTokens = responseUsage?.toolUsePromptTokenCount ?? 0;
-    const candidatesTokens = responseUsage?.candidatesTokenCount ?? 0;
-    const thoughtsTokens = responseUsage?.thoughtsTokenCount ?? 0;
-
-    const inputTokens = promptTokens + toolUseTokens;
-    let completionTokens = candidatesTokens + thoughtsTokens;
-
-    // Fallback: In streaming mode, individual output fields may be 0 while
-    // totalTokenCount is correct. Compute output from total if needed.
-    if (completionTokens === 0 && responseUsage?.totalTokenCount) {
-      completionTokens = Math.max(
-        0,
-        responseUsage.totalTokenCount - inputTokens,
-      );
-    }
+    const { outputTokens, reasoningTokens } =
+      this.computeTokenCounts(responseUsage);
 
     const usageObj: ExtendedCompletionUsage = {
-      prompt_tokens: promptTokens,
-      completion_tokens: completionTokens,
+      prompt_tokens: responseUsage?.promptTokenCount ?? 0,
+      completion_tokens: outputTokens,
       total_tokens: responseUsage?.totalTokenCount ?? 0,
       prompt_tokens_details: {
         cached_tokens: responseUsage?.cachedContentTokenCount ?? 0,
       },
       completion_tokens_details: {
-        reasoning_tokens: thoughtsTokens,
+        reasoning_tokens: reasoningTokens,
         accepted_prediction_tokens: undefined,
         rejected_prediction_tokens: undefined,
       },
@@ -883,26 +896,10 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
       };
     }
 
-    const promptTokens = rawUsage.promptTokenCount ?? 0;
-    const toolUseTokens = rawUsage.toolUsePromptTokenCount ?? 0;
-    const inputTokens = promptTokens + toolUseTokens;
-
-    // Include thoughtsTokenCount in output to match cost calculation.
-    // For thinking models, candidatesTokenCount may be 0 while most output
-    // is in thoughtsTokenCount. Track reasoningTokens separately for breakdown.
-    const candidatesTokens = rawUsage.candidatesTokenCount ?? 0;
-    const reasoningTokens = rawUsage.thoughtsTokenCount ?? 0;
-    let outputTokens = candidatesTokens + reasoningTokens;
-
-    // Fallback: In streaming mode, individual output fields may be 0 while
-    // totalTokenCount is correct. Compute output from total if needed.
-    if (outputTokens === 0 && rawUsage.totalTokenCount) {
-      outputTokens = Math.max(0, rawUsage.totalTokenCount - inputTokens);
-    }
+    const { inputTokens, outputTokens, reasoningTokens } =
+      this.computeTokenCounts(rawUsage);
 
     const cachedTokens = rawUsage.cachedContentTokenCount ?? 0;
-
-    // Calculate percentage cached
     const percentageCached =
       inputTokens > 0 ? (cachedTokens / inputTokens) * 100 : 0;
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Prefer chunk usage metadata and centralize token counting for accurate pricing, completion tokens, and normalized stats (incl. reasoning and caching).
> 
> - **Token accounting**:
>   - Add `computeTokenCounts` to derive `inputTokens`, `outputTokens`, and `reasoningTokens` from `usageMetadata` with fallback to `totalTokenCount`.
> - **Pricing and usage**:
>   - `computePrice`, `computeResponseUsage`, and `normalizeUsage` now use `computeTokenCounts`.
>   - `completion_tokens` now reflects combined output tokens; include `reasoning_tokens`, `toolUsePromptTokens`, `percentageCached`, and `_native` in normalized usage.
> - **Streaming**:
>   - Always prefer the latest chunk `usageMetadata` for final response aggregation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6814f09e5687ddaeb3fb795f3c5a7ffc36bfff87. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->