### PR TITLE
Fix output file list persistence per session

### DIFF
--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -220,13 +220,10 @@ export class ProgressEventHandler {
       runFiles: filesByRun,
     });
 
-    this.webviewUpdater.updateFiles(stream, { reset: true });
-    Object.entries(filesByRun).forEach(([runId, rounds]) => {
-      this.webviewUpdater.updateFiles(stream, {
-        runId,
-        rounds,
-      });
-    });
+    // Note: Files are already included in UPDATE_LOGS (runFiles) and handled
+    // by handleUpdateLogs in the frontend. We don't send separate UPDATE_FILES
+    // messages here to avoid a race condition where reset: true would clear
+    // the files just populated from UPDATE_LOGS.
 
     this.webviewUpdater.updateMissingOutputs(stream, { reset: true });
     Object.entries(missingByRun).forEach(([runId, rounds]) => {

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -216,6 +216,7 @@ export class ProgressEventHandler {
       runInstructions,
       activeRunId,
       runUsage: usageByRun,
+      runFiles: filesByRun,
     });
 
     this.webviewUpdater.updateFiles(stream, { reset: true });

--- a/src/progressView/managers/WebviewUpdater.ts
+++ b/src/progressView/managers/WebviewUpdater.ts
@@ -111,6 +111,7 @@ export class WebviewUpdater {
       runInstructions?: Record<string, InstructionUpdate>;
       activeRunId?: string | null;
       runUsage?: Record<string, TokenUsageStats>;
+      runFiles?: Record<string, { [key: number]: OutputFileInfo[] }>;
     },
   ): void {
     this.sendMessage({
@@ -121,6 +122,7 @@ export class WebviewUpdater {
       runInstructions: extras?.runInstructions,
       activeRunId: extras?.activeRunId,
       runUsage: extras?.runUsage,
+      runFiles: extras?.runFiles,
     });
   }
 

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -260,6 +260,7 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       dom.taskGroups.clear();
       state.taskGroups.clear();
       state.clearRunInstructions(message.stream);
+      state.clearRunFiles(message.stream);
       state.clearPendingInstruction(state.activeStream);
       const previousRunId = state.getActiveRunId(message.stream);
       state.clearActiveRun(message.stream);
@@ -283,6 +284,14 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
         if (message.runUsage) {
           Object.entries(message.runUsage).forEach(([runId, usage]) => {
             state.setRunUsage(message.stream, runId, usage);
+          });
+        }
+
+        if (message.runFiles) {
+          Object.entries(message.runFiles).forEach(([runId, filesByRound]) => {
+            if (runId) {
+              state.setRunFiles(message.stream, runId, filesByRound);
+            }
           });
         }
 


### PR DESCRIPTION
When switching sessions via the progress board dropdown, output files were not displaying because they were sent via separate UPDATE_FILES messages that arrived after the frontend had already refreshed the output display.

This fix includes runFiles in the UPDATE_LOGS message payload, consistent with how runInstructions and runUsage are already handled. The frontend now populates the file state before calling _refreshOutputsForActiveRun(), ensuring files are available for lookup when switching between sessions.

Changes:
- Add runFiles to WebviewUpdater.updateLogContent() extras parameter
- Include filesByRun in refreshStreamSurface() UPDATE_LOGS payload
- Handle message.runFiles in frontend handleUpdateLogs()
- Clear and repopulate runFiles per stream when logs are updated

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bundles per-run output files into UPDATE_LOGS and processes them on the frontend, removing separate UPDATE_FILES calls to prevent races and ensure files persist when switching sessions.
> 
> - **Progress View surface refresh**:
>   - `refreshStreamSurface` now includes `runFiles` in `UPDATE_LOGS` payload and stops sending separate `UPDATE_FILES` messages to avoid reset races.
> - **WebviewUpdater**:
>   - `updateLogContent` extras extended with optional `runFiles` and forwards it in the message.
> - **Frontend message handling**:
>   - `handleUpdateLogs` now clears and repopulates run files via `state.clearRunFiles(stream)` and `state.setRunFiles(...)` from `message.runFiles` before refreshing outputs.
>   - Ensures run selection and outputs are refreshed after logs render.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e5cb9ae0e9fd70d8a63ec9a8c49261049f2328c3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->