### PR TITLE
Move XML output to task run storage

### DIFF
--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -350,12 +350,9 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
 
     // Raw XML files always go to task run storage (when executionId exists)
     // to keep the user's workspace clean. Processed .tex files respect user settings.
-    if (this.useScratchpad) {
-      return this.fileService.createRawOutputLocation(fileName);
-    }
-
-    // Non-scratchpad outputs respect the user's storage mode setting
-    return this.fileService.createLocation(fileName) as AgentFileLocation;
+    return this.fileService.createLocation(fileName, {
+      forceRunStorage: this.useScratchpad,
+    }) as AgentFileLocation;
   }
 
   /**

--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -327,6 +327,10 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
    * Generates output file path for specified conversation round.
    * Default implementation uses scratchpad mode detection to determine file extension.
    * Override for specialized naming logic (e.g., MergeAgent).
+   *
+   * Raw XML files (scratchpad mode) are always stored in task run storage to keep
+   * the user's workspace clean. Processed outputs respect the user's storage mode setting.
+   *
    * @returns AgentFileLocation - always workspace or runStorage (never external)
    */
   public getOutputFileLocation(currRound: number): AgentFileLocation {
@@ -344,7 +348,13 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
       this.agentConfig.editedFile || undefined,
     );
 
-    // fileService.createLocation always returns workspace or runStorage for agent outputs
+    // Raw XML files always go to task run storage (when executionId exists)
+    // to keep the user's workspace clean. Processed .tex files respect user settings.
+    if (this.useScratchpad) {
+      return this.fileService.createRawOutputLocation(fileName) as AgentFileLocation;
+    }
+
+    // Non-scratchpad outputs respect the user's storage mode setting
     return this.fileService.createLocation(fileName) as AgentFileLocation;
   }
 

--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -351,7 +351,7 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
     // Raw XML files always go to task run storage (when executionId exists)
     // to keep the user's workspace clean. Processed .tex files respect user settings.
     if (this.useScratchpad) {
-      return this.fileService.createRawOutputLocation(fileName) as AgentFileLocation;
+      return this.fileService.createRawOutputLocation(fileName);
     }
 
     // Non-scratchpad outputs respect the user's storage mode setting

--- a/src/agent/output/OutputHandler.ts
+++ b/src/agent/output/OutputHandler.ts
@@ -829,7 +829,6 @@ export class OutputHandler implements IOutputHandler {
     const roundData = this.rounds.get(round);
     return {
       round,
-      rawOutput: roundData?.rawOutput ?? null,
       outputs: fileInfos,
       xmlSummary: roundData?.xmlSummary ?? this.getRoundXmlSummary(round),
     };

--- a/src/agent/output/types.ts
+++ b/src/agent/output/types.ts
@@ -97,14 +97,12 @@ export type OutputXmlSummary = z.infer<typeof OutputXmlSummarySchema>;
 /**
  * Output from processing a conversation round.
  * - round: Round number
- * - rawOutput: The XML file the LLM wrote (before extraction)
  * - outputs: Extracted output files with metadata
- * - xmlSummary: Parsed XML metadata (TODO: Can this be simplified/removed?)
+ * - xmlSummary: Parsed XML metadata (sourceLocation contains the raw XML file path)
  */
 export const RoundOutputSchema = z
   .object({
     round: z.number(),
-    rawOutput: z.custom<FileLocation>().nullable(),
     outputs: OutputFileInfoSchema.array(),
     xmlSummary: OutputXmlSummarySchema,
   })

--- a/src/utils/files/taskRunStorage.ts
+++ b/src/utils/files/taskRunStorage.ts
@@ -403,6 +403,43 @@ export class TaskRunFileService {
   }
 
   /**
+   * Internal helper to resolve output location with configurable run storage behavior.
+   * Reduces duplication between createRawOutputLocation() and createLocation().
+   *
+   * @param relativePath - Workspace-relative path
+   * @param forceRunStorage - If true, always use run storage when executionId exists
+   * @returns AgentFileLocation (workspace or runStorage, never external when workspaceRoot exists)
+   */
+  private resolveOutputLocation(
+    relativePath: string,
+    forceRunStorage: boolean,
+  ): AgentFileLocation {
+    const workspaceRoot = this.workspaceRoot;
+    if (!workspaceRoot) {
+      // This shouldn't happen for agent outputs, but fallback to workspace-like behavior
+      const normalized = relativePath ? path.normalize(relativePath) : '';
+      return createWorkspaceLocation(normalized, normalized);
+    }
+
+    const normalized = relativePath ? path.normalize(relativePath) : '';
+    const executionId = this.activeExecutionId;
+
+    // Use run storage if forced OR if configured via storageMode
+    if (executionId && (forceRunStorage || this.useRunStorage)) {
+      const runDir = forceRunStorage
+        ? getRunDir(executionId)
+        : this.metadata.runDirectory;
+      if (runDir) {
+        const runAbsolute = path.join(runDir, normalized);
+        return createRunStorageLocation(runAbsolute, normalized, executionId);
+      }
+    }
+
+    const workspaceAbsolute = path.join(workspaceRoot, normalized);
+    return createWorkspaceLocation(workspaceAbsolute, normalized);
+  }
+
+  /**
    * Create a FileLocation for raw output files (e.g., XML intermediates).
    * This method ALWAYS uses run storage when an executionId is available,
    * regardless of the storageMode setting. This keeps intermediate files
@@ -412,28 +449,10 @@ export class TaskRunFileService {
    * Use createLocation() for processed outputs (.tex files) that respect user settings.
    *
    * @param relativePath - Workspace-relative path (e.g., "paper_polish_r0_sonnet.xml")
-   * @returns FileLocation (runStorage if executionId exists, otherwise workspace)
+   * @returns AgentFileLocation (runStorage if executionId exists, otherwise workspace)
    */
-  public createRawOutputLocation(relativePath: string): FileLocation {
-    const workspaceRoot = this.workspaceRoot;
-    if (!workspaceRoot) {
-      return createExternalLocation(relativePath);
-    }
-
-    // Normalize path separators for current platform
-    const normalized = relativePath ? path.normalize(relativePath) : '';
-
-    // Always use run storage for raw outputs when executionId is available
-    const executionId = this.activeExecutionId;
-    if (executionId) {
-      const runDir = getRunDir(executionId);
-      const runAbsolute = path.join(runDir, normalized);
-      return createRunStorageLocation(runAbsolute, normalized, executionId);
-    }
-
-    // Fallback to workspace when no executionId
-    const workspaceAbsolute = path.join(workspaceRoot, normalized);
-    return createWorkspaceLocation(workspaceAbsolute, normalized);
+  public createRawOutputLocation(relativePath: string): AgentFileLocation {
+    return this.resolveOutputLocation(relativePath, true);
   }
 
   /**
@@ -452,23 +471,7 @@ export class TaskRunFileService {
     if (!workspaceRoot) {
       return createExternalLocation(relativePath);
     }
-
-    // Normalize path separators for current platform (idempotent - safe to call on normalized paths)
-    const normalized = relativePath ? path.normalize(relativePath) : '';
-    const workspaceAbsolute = path.join(workspaceRoot, normalized);
-
-    // Check if run storage is enabled
-    const executionId = this.activeExecutionId;
-    if (executionId && this.useRunStorage) {
-      const runDir = this.metadata.runDirectory;
-      if (runDir) {
-        const runAbsolute = path.join(runDir, normalized);
-        return createRunStorageLocation(runAbsolute, normalized, executionId);
-      }
-    }
-
-    // Default to workspace location
-    return createWorkspaceLocation(workspaceAbsolute, normalized);
+    return this.resolveOutputLocation(relativePath, false);
   }
 
   /**

--- a/src/utils/files/taskRunStorage.ts
+++ b/src/utils/files/taskRunStorage.ts
@@ -403,24 +403,26 @@ export class TaskRunFileService {
   }
 
   /**
-   * Internal helper to resolve output location with configurable run storage behavior.
-   * Reduces duplication between createRawOutputLocation() and createLocation().
+   * Create a FileLocation from a workspace-relative path, with run-storage awareness.
    *
-   * @param relativePath - Workspace-relative path
-   * @param forceRunStorage - If true, always use run storage when executionId exists
-   * @returns AgentFileLocation (workspace or runStorage, never external when workspaceRoot exists)
+   * Path normalization is handled internally - you can pass paths with either
+   * forward slashes or backslashes, and the function will normalize them for
+   * the current platform. It's safe to pass already-normalized paths.
+   *
+   * @param relativePath - Workspace-relative path (e.g., "paper.tex" or "sub/paper.tex")
+   * @param options.forceRunStorage - Always use run storage when executionId exists (for raw XML intermediates)
+   * @returns FileLocation (workspace or runStorage based on mode/options)
    */
-  private resolveOutputLocation(
+  public createLocation(
     relativePath: string,
-    forceRunStorage: boolean,
-  ): AgentFileLocation {
+    options?: { forceRunStorage?: boolean },
+  ): FileLocation {
     const workspaceRoot = this.workspaceRoot;
     if (!workspaceRoot) {
-      // This shouldn't happen for agent outputs, but fallback to workspace-like behavior
-      const normalized = relativePath ? path.normalize(relativePath) : '';
-      return createWorkspaceLocation(normalized, normalized);
+      return createExternalLocation(relativePath);
     }
 
+    const forceRunStorage = options?.forceRunStorage ?? false;
     const normalized = relativePath ? path.normalize(relativePath) : '';
     const executionId = this.activeExecutionId;
 
@@ -437,41 +439,6 @@ export class TaskRunFileService {
 
     const workspaceAbsolute = path.join(workspaceRoot, normalized);
     return createWorkspaceLocation(workspaceAbsolute, normalized);
-  }
-
-  /**
-   * Create a FileLocation for raw output files (e.g., XML intermediates).
-   * This method ALWAYS uses run storage when an executionId is available,
-   * regardless of the storageMode setting. This keeps intermediate files
-   * out of the user's workspace.
-   *
-   * Use this for raw model outputs (XML files) that are intermediate artifacts.
-   * Use createLocation() for processed outputs (.tex files) that respect user settings.
-   *
-   * @param relativePath - Workspace-relative path (e.g., "paper_polish_r0_sonnet.xml")
-   * @returns AgentFileLocation (runStorage if executionId exists, otherwise workspace)
-   */
-  public createRawOutputLocation(relativePath: string): AgentFileLocation {
-    return this.resolveOutputLocation(relativePath, true);
-  }
-
-  /**
-   * Create a FileLocation from a workspace-relative path, with run-storage awareness.
-   * This is the preferred method for creating output file locations.
-   *
-   * Path normalization is handled internally - you can pass paths with either
-   * forward slashes or backslashes, and the function will normalize them for
-   * the current platform. It's safe to pass already-normalized paths.
-   *
-   * @param relativePath - Workspace-relative path (e.g., "paper.tex" or "sub/paper.tex")
-   * @returns FileLocation (workspace or runStorage based on current mode)
-   */
-  public createLocation(relativePath: string): FileLocation {
-    const workspaceRoot = this.workspaceRoot;
-    if (!workspaceRoot) {
-      return createExternalLocation(relativePath);
-    }
-    return this.resolveOutputLocation(relativePath, false);
   }
 
   /**

--- a/src/utils/files/taskRunStorage.ts
+++ b/src/utils/files/taskRunStorage.ts
@@ -403,6 +403,40 @@ export class TaskRunFileService {
   }
 
   /**
+   * Create a FileLocation for raw output files (e.g., XML intermediates).
+   * This method ALWAYS uses run storage when an executionId is available,
+   * regardless of the storageMode setting. This keeps intermediate files
+   * out of the user's workspace.
+   *
+   * Use this for raw model outputs (XML files) that are intermediate artifacts.
+   * Use createLocation() for processed outputs (.tex files) that respect user settings.
+   *
+   * @param relativePath - Workspace-relative path (e.g., "paper_polish_r0_sonnet.xml")
+   * @returns FileLocation (runStorage if executionId exists, otherwise workspace)
+   */
+  public createRawOutputLocation(relativePath: string): FileLocation {
+    const workspaceRoot = this.workspaceRoot;
+    if (!workspaceRoot) {
+      return createExternalLocation(relativePath);
+    }
+
+    // Normalize path separators for current platform
+    const normalized = relativePath ? path.normalize(relativePath) : '';
+
+    // Always use run storage for raw outputs when executionId is available
+    const executionId = this.activeExecutionId;
+    if (executionId) {
+      const runDir = getRunDir(executionId);
+      const runAbsolute = path.join(runDir, normalized);
+      return createRunStorageLocation(runAbsolute, normalized, executionId);
+    }
+
+    // Fallback to workspace when no executionId
+    const workspaceAbsolute = path.join(workspaceRoot, normalized);
+    return createWorkspaceLocation(workspaceAbsolute, normalized);
+  }
+
+  /**
    * Create a FileLocation from a workspace-relative path, with run-storage awareness.
    * This is the preferred method for creating output file locations.
    *


### PR DESCRIPTION
Raw XML files are intermediate artifacts that clutter the user's workspace. This change ensures XML output files always go to task run storage when an executionId is available, regardless of the storageMode setting.

- Add createRawOutputLocation() method to TaskRunFileService
- Use it in BaseReflectionAgent.getOutputFileLocation() for scratchpad mode
- Processed .tex files still respect user's storage mode preference

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Routes scratchpad XML outputs to task run storage and removes rawOutput from round artifacts, using xmlSummary.sourceLocation instead.
> 
> - **Storage/FS**:
>   - Extend `TaskRunFileService.createLocation(relativePath, { forceRunStorage })` to optionally force run-storage paths when `executionId` exists.
> - **Agent**:
>   - `BaseReflectionAgent.getOutputFileLocation()` now forces run-storage for scratchpad (raw XML) outputs; processed outputs still follow user storage mode.
> - **Output Handling**:
>   - Remove `rawOutput` from `RoundOutput` API and schema; use `xmlSummary.sourceLocation` to reference the raw XML file.
>   - Update `OutputHandler.getRoundArtifacts()` return shape accordingly; `getRoundXmlSummary()` and XML capture now populate `sourceLocation`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 04eee6da72934aa6307916a49f4efd3de75850d1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->