### PR TITLE
Fix streaming file packing and cleanup

### DIFF
--- a/docs/guide/remote-agents.md
+++ b/docs/guide/remote-agents.md
@@ -127,7 +127,6 @@ If you prefer not to use remote agents:
 
 This will hide remote agents from your interface without affecting built-in agents.
 
-
 ## Need Help?
 
 If you encounter any issues with remote agents or have questions about the Researcher Access Program:

--- a/src/agent/index/agentRegistry.ts
+++ b/src/agent/index/agentRegistry.ts
@@ -435,6 +435,15 @@ export function parseKey(
   return { source: source as AgentSource, name };
 }
 
+/**
+ * Extract the clean agent name from an identifier.
+ * Handles source:name format (e.g., "custom:summarize" → "summarize").
+ */
+export function getCleanAgentName(agentIdentifier: string): string {
+  const parsed = parseKey(agentIdentifier);
+  return parsed ? parsed.name : agentIdentifier;
+}
+
 // =============================================================================
 // _MULTIPLE VARIANT HELPERS
 // =============================================================================

--- a/src/agent/index/index.ts
+++ b/src/agent/index/index.ts
@@ -29,6 +29,7 @@ export {
   // Key helpers
   createKey,
   parseKey,
+  getCleanAgentName,
   // _multiple helpers
   isMultipleVariant,
   getBaseName,

--- a/src/agent/utils/outputFileUtils.ts
+++ b/src/agent/utils/outputFileUtils.ts
@@ -2,16 +2,7 @@
 import * as path from 'path';
 
 // Local imports
-import { parseKey } from '@agent/index';
-
-/**
- * Extract the clean agent name from an identifier.
- * Handles source:name format (e.g., "custom:summarize" → "summarize").
- */
-function getCleanAgentName(agentIdentifier: string): string {
-  const parsed = parseKey(agentIdentifier);
-  return parsed ? parsed.name : agentIdentifier;
-}
+import { getCleanAgentName } from '@agent/index';
 
 /**
  * Generates an output filename incorporating model and round information.

--- a/src/agent/utils/outputFileUtils.ts
+++ b/src/agent/utils/outputFileUtils.ts
@@ -2,7 +2,7 @@
 import * as path from 'path';
 
 // Local imports
-import { getCleanAgentName } from '@agent/index';
+import { getAgentFirstNameChunk } from '@housekeeping/utils';
 
 /**
  * Generates an output filename incorporating model and round information.
@@ -26,9 +26,8 @@ export function getOutputFileName(
   },
 ): string {
   const { dir, name: fileName } = path.parse(inputFile);
-  // Extract clean agent name (strip source: prefix if present)
-  const cleanAgent = getCleanAgentName(agent);
-  const agentFirstNameChunk = cleanAgent.split('_')[0];
+  // Extract agent first name chunk (handles source: prefix and write- agents)
+  const agentFirstNameChunk = getAgentFirstNameChunk(agent);
 
   let newRound = currRound;
   if (editedFile) {

--- a/src/housekeeping/utils.ts
+++ b/src/housekeeping/utils.ts
@@ -5,6 +5,7 @@ import * as path from 'path';
 import { sync as globSync } from 'glob';
 
 // Local imports - log
+import { parseKey } from '@agent/index';
 import * as logger from '@logger/logUtils';
 import { WorkspaceFS } from '@utils/files';
 
@@ -12,11 +13,18 @@ const CHANNEL = 'Housekeeping';
 logger.initialize(CHANNEL);
 
 export function getAgentFirstNameChunk(agent: string): string {
+  // Extract clean agent name (strip source: prefix if present)
+  // Handles all agent sources: custom, local, remote, builtIn, builtInToolUse
+  const parsed = parseKey(agent);
+  const cleanAgent = parsed ? parsed.name : agent;
+
   let result: string;
-  if (agent.startsWith('write-')) {
-    result = agent.split('-')[1];
+  if (cleanAgent.startsWith('write-')) {
+    result = cleanAgent.split('-')[1];
   } else {
-    result = agent.includes('_') ? agent.split('_')[0] : agent.split('-')[0];
+    result = cleanAgent.includes('_')
+      ? cleanAgent.split('_')[0]
+      : cleanAgent.split('-')[0];
   }
   return result;
 }

--- a/src/housekeeping/utils.ts
+++ b/src/housekeeping/utils.ts
@@ -5,7 +5,7 @@ import * as path from 'path';
 import { sync as globSync } from 'glob';
 
 // Local imports - log
-import { parseKey } from '@agent/index';
+import { getCleanAgentName } from '@agent/index';
 import * as logger from '@logger/logUtils';
 import { WorkspaceFS } from '@utils/files';
 
@@ -15,8 +15,7 @@ logger.initialize(CHANNEL);
 export function getAgentFirstNameChunk(agent: string): string {
   // Extract clean agent name (strip source: prefix if present)
   // Handles all agent sources: custom, local, remote, builtIn, builtInToolUse
-  const parsed = parseKey(agent);
-  const cleanAgent = parsed ? parsed.name : agent;
+  const cleanAgent = getCleanAgentName(agent);
 
   let result: string;
   if (cleanAgent.startsWith('write-')) {

--- a/src/logger/streamUtils.ts
+++ b/src/logger/streamUtils.ts
@@ -3,7 +3,7 @@ import { randomUUID } from 'crypto';
 import * as path from 'path';
 
 // Local imports
-import { parseKey, getMultipleName } from '@agent/index';
+import { getCleanAgentName, getMultipleName } from '@agent/index';
 import { AgentType } from '@agent/core/AgentDataclass';
 // Type imports
 import type { ExecutionId, StreamTabId } from '@agent/types/IdentifierTypes';
@@ -13,15 +13,6 @@ type StreamTabIdOptions = {
   executionId?: ExecutionId;
   useMultipleOutputs?: boolean;
 };
-
-/**
- * Extract the clean agent name from an identifier.
- * Handles source:name format (e.g., "custom:summarize" → "summarize").
- */
-function getCleanAgentName(agentIdentifier: string): string {
-  const parsed = parseKey(agentIdentifier);
-  return parsed ? parsed.name : agentIdentifier;
-}
 
 function formatToolUseStreamId(
   agent: string,

--- a/src/progressView/streamInfoUtils.ts
+++ b/src/progressView/streamInfoUtils.ts
@@ -2,17 +2,8 @@
 import * as path from 'path';
 
 // Local imports - progress view
-import { isRemoteAgent, parseKey } from '@agent/index';
+import { getCleanAgentName, isRemoteAgent } from '@agent/index';
 import { AgentCategory } from '@agent/core/AgentDataclass';
-
-/**
- * Extract the clean agent name from an identifier.
- * Handles source:name format (e.g., "custom:summarize" → "summarize").
- */
-function getCleanAgentName(agentIdentifier: string): string {
-  const parsed = parseKey(agentIdentifier);
-  return parsed ? parsed.name : agentIdentifier;
-}
 
 // Type imports
 import type { ProgressViewState } from './state/ProgressViewState';


### PR DESCRIPTION
The packing/cleaning functions were generating file search patterns with source prefix (e.g., StatPhys-Preliminaries_custom:critiqueFix_r0) while streaming generates files without it (StatPhys-Preliminaries_critiqueFix_r0).

Use the same parseKey utility from agentRegistry that outputFileUtils.ts uses to properly handle all agent sources (custom, local, remote, builtIn, builtInToolUse) instead of fragile string prefix matching.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Centralizes agent name parsing and applies it across filename generation, file pattern matching, and stream labels/IDs to consistently strip source prefixes; minor docs cleanup.
> 
> - **Agent Registry**
>   - Add `getCleanAgentName` to normalize `source:name` → `name` and export via `@agent/index`.
> - **Housekeeping**
>   - Introduce `getAgentFirstNameChunk(agent)` (uses `getCleanAgentName`) for consistent base agent token extraction; update `getFilePatterns`.
> - **Output Files**
>   - `getOutputFileName` now uses `getAgentFirstNameChunk`; removes local parsing logic.
> - **Logging/Progress View**
>   - Replace ad-hoc parsing with `getCleanAgentName` in `streamUtils.ts` and `streamInfoUtils.ts` for stream IDs and labels; retain `getMultipleName` usage where needed.
> - **Docs**
>   - Minor cleanup in `docs/guide/remote-agents.md` around the "Need Help?" section.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 36b0eec45fad2da1884e9924291d7bf9659558cd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->