### PR TITLE
Add missing Jarzynski equality definition

### DIFF
--- a/src/logger/sinks/ProgressViewSink.ts
+++ b/src/logger/sinks/ProgressViewSink.ts
@@ -1,6 +1,5 @@
 // Third-party imports
 import { randomUUID } from 'crypto';
-import { encode as encodeHtml } from 'he';
 
 // Local imports - logger
 import type { LogMessageData } from '@logger/LogTypes';
@@ -30,7 +29,6 @@ export class ProgressViewSink implements LogEventSink {
       return;
     }
 
-    const processedMessage = encodeHtml(event.message);
     const messageType: MessageType = isValidMessageType(event.messageType)
       ? event.messageType
       : MESSAGE_TYPES.DEFAULT;
@@ -42,7 +40,7 @@ export class ProgressViewSink implements LogEventSink {
     const timestamp = new Date(event.timestamp).getTime();
     const logMessage: LogMessageData = {
       id,
-      text: processedMessage,
+      text: event.message,
       level: event.level as LogMessageData['level'],
       timestamp,
       groupId: event.groupId,

--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -539,6 +539,36 @@ export class LogEntryFormatter {
       '@@LATEX-CREF:$2@@',
     );
 
+    // Handle Pandoc markdown-link format: [\[label\]](#anchor){reference-type="ref" reference="label"}
+    // This format combines a markdown link with Pandoc attributes
+    content = content.replace(
+      /\[\\?\[([^\]]+)\\?\]\]\(#[^)]*\)\{reference-type="ref"\s+reference="([^"]+)"\}/g,
+      '@@LATEX-REF:$2@@',
+    );
+    content = content.replace(
+      /\[\\?\[([^\]]+)\\?\]\]\(#[^)]*\)\{reference-type="eqref"\s+reference="([^"]+)"\}/g,
+      '@@LATEX-EQREF:$2@@',
+    );
+    content = content.replace(
+      /\[\\?\[([^\]]+)\\?\]\]\(#[^)]*\)\{reference-type="[Cc]ref"\s+reference="([^"]+)"\}/g,
+      '@@LATEX-CREF:$2@@',
+    );
+
+    // Handle plain markdown-link format: [label](#anchor){reference-type="ref" reference="label"}
+    // (without escaped brackets in the label)
+    content = content.replace(
+      /\[([^\[\]]+)\]\(#[^)]*\)\{reference-type="ref"\s+reference="([^"]+)"\}/g,
+      '@@LATEX-REF:$2@@',
+    );
+    content = content.replace(
+      /\[([^\[\]]+)\]\(#[^)]*\)\{reference-type="eqref"\s+reference="([^"]+)"\}/g,
+      '@@LATEX-EQREF:$2@@',
+    );
+    content = content.replace(
+      /\[([^\[\]]+)\]\(#[^)]*\)\{reference-type="[Cc]ref"\s+reference="([^"]+)"\}/g,
+      '@@LATEX-CREF:$2@@',
+    );
+
     const renderer = this.md || getMarkdownRenderer();
 
     // Process content as markdown

--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -516,54 +516,10 @@ export class LogEntryFormatter {
    */
   _processMarkdownContent(content) {
     // Pre-process LaTeX references to protect them from markdown parsing
+    // Note: Pandoc reference formats are normalized to LaTeX at the source (xmlUtils.ts)
     content = content.replace(/\\ref\{([^}]+)\}/g, '@@LATEX-REF:$1@@');
     content = content.replace(/\\cref\{([^}]+)\}/g, '@@LATEX-CREF:$1@@');
     content = content.replace(/\\eqref\{([^}]+)\}/g, '@@LATEX-EQREF:$1@@');
-
-    // Also handle Pandoc's reference format: [label]{reference-type="ref" reference="label"}
-    // This format is produced when LaTeX is converted through Pandoc
-    content = content.replace(
-      /\[([^\]]+)\]\{reference-type="ref"\s+reference="([^"]+)"\}/g,
-      '@@LATEX-REF:$2@@',
-    );
-    content = content.replace(
-      /\[([^\]]+)\]\{reference-type="eqref"\s+reference="([^"]+)"\}/g,
-      '@@LATEX-EQREF:$2@@',
-    );
-    content = content.replace(
-      /\[([^\]]+)\]\{reference-type="[Cc]ref"\s+reference="([^"]+)"\}/g,
-      '@@LATEX-CREF:$2@@',
-    );
-
-    // Handle Pandoc markdown-link format: [\[label\]](#anchor){reference-type="ref" reference="label"}
-    // This format combines a markdown link with Pandoc attributes
-    content = content.replace(
-      /\[\\?\[([^\]]+)\\?\]\]\(#[^)]*\)\{reference-type="ref"\s+reference="([^"]+)"\}/g,
-      '@@LATEX-REF:$2@@',
-    );
-    content = content.replace(
-      /\[\\?\[([^\]]+)\\?\]\]\(#[^)]*\)\{reference-type="eqref"\s+reference="([^"]+)"\}/g,
-      '@@LATEX-EQREF:$2@@',
-    );
-    content = content.replace(
-      /\[\\?\[([^\]]+)\\?\]\]\(#[^)]*\)\{reference-type="[Cc]ref"\s+reference="([^"]+)"\}/g,
-      '@@LATEX-CREF:$2@@',
-    );
-
-    // Handle plain markdown-link format: [label](#anchor){reference-type="ref" reference="label"}
-    // (without escaped brackets in the label)
-    content = content.replace(
-      /\[([^\[\]]+)\]\(#[^)]*\)\{reference-type="ref"\s+reference="([^"]+)"\}/g,
-      '@@LATEX-REF:$2@@',
-    );
-    content = content.replace(
-      /\[([^\[\]]+)\]\(#[^)]*\)\{reference-type="eqref"\s+reference="([^"]+)"\}/g,
-      '@@LATEX-EQREF:$2@@',
-    );
-    content = content.replace(
-      /\[([^\[\]]+)\]\(#[^)]*\)\{reference-type="[Cc]ref"\s+reference="([^"]+)"\}/g,
-      '@@LATEX-CREF:$2@@',
-    );
 
     const renderer = this.md || getMarkdownRenderer();
 

--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -29,7 +29,7 @@ import {
   CHEVRON_DOWN_CLASS,
 } from '@common/iconConstants.js';
 import { getBasename } from '@common/pathUtils.js';
-import { encodeHtml, decodeHtml } from '@common/htmlEncoding.js';
+import { encodeHtml } from '@common/htmlEncoding.js';
 
 // Constants
 export const BULLET_MARKUP =
@@ -123,8 +123,9 @@ const normalizeStructuredContent = (text, data) => {
     };
   }
 
-  const decodedText = typeof text === 'string' ? decodeHtml(text) : '';
-  return { decodedText, structured: tryParseJson(decodedText) };
+  // Content is now passed as raw text (no longer HTML-encoded at source)
+  const rawText = typeof text === 'string' ? text : '';
+  return { decodedText: rawText, structured: tryParseJson(rawText) };
 };
 
 const normalizeFileListEntries = (structured) => {
@@ -511,14 +512,9 @@ export class LogEntryFormatter {
   /**
    * Process markdown content with LaTeX reference protection
    * @param {string} content - Raw content to process
-   * @param {boolean} decode - Whether to decode HTML entities (default: true)
    * @returns {string} Processed markdown HTML
    */
-  _processMarkdownContent(content, decode = false) {
-    if (decode) {
-      content = decodeHtml(content);
-    }
-
+  _processMarkdownContent(content) {
     // Pre-process LaTeX references to protect them from markdown parsing
     content = content.replace(/\\ref\{([^}]+)\}/g, '@@LATEX-REF:$1@@');
     content = content.replace(/\\cref\{([^}]+)\}/g, '@@LATEX-CREF:$1@@');
@@ -688,7 +684,7 @@ export class LogEntryFormatter {
         verbose ? ` [${timeDisplay}]` : ''
       }</span> ` +
       levelMarkup +
-      `<span class="message-${level}">${text}</span>` +
+      `<span class="message-${level}">${encodeHtml(text)}</span>` +
       `</div>`;
 
     // Convert HTML string to DOM element
@@ -709,7 +705,7 @@ export class LogEntryFormatter {
 
     if (!trimmedContent) return null;
 
-    const parsedMarkdown = this._processMarkdownContent(trimmedContent, false);
+    const parsedMarkdown = this._processMarkdownContent(trimmedContent);
     const isThinking = contentType.includes('Thinking');
     const bannerEntry = this._createBannerEntry({
       logId,
@@ -896,10 +892,7 @@ export class LogEntryFormatter {
     if (contentElem) {
       contentElem.classList.add(`message-${level}`);
       contentElem.dataset.rawContent = trimmedContent;
-      contentElem.innerHTML = this._processMarkdownContent(
-        trimmedContent,
-        false,
-      );
+      contentElem.innerHTML = this._processMarkdownContent(trimmedContent);
     }
 
     return element;

--- a/src/utils/text/xmlUtils.ts
+++ b/src/utils/text/xmlUtils.ts
@@ -136,11 +136,65 @@ async function convertWithPandoc(text: string): Promise<string | null> {
         },
       );
     });
-    return result;
+    // Normalize Pandoc reference syntax to canonical LaTeX format
+    return normalizePandocReferences(result);
   } catch (err) {
     logger.error(CHANNEL, `Pandoc conversion failed: ${toErrorMessage(err)}`);
     return null;
   }
+}
+
+/**
+ * Normalize Pandoc reference syntax to canonical LaTeX format.
+ * Pandoc outputs references in formats like:
+ * - [label]{reference-type="ref" reference="label"}
+ * - [\[label\]](#anchor){reference-type="ref" reference="label"}
+ * These are converted to standard \ref{label}, \cref{label}, \eqref{label}
+ */
+function normalizePandocReferences(text: string): string {
+  // Handle markdown-link format: [\[label\]](#anchor){reference-type="ref" reference="label"}
+  text = text.replace(
+    /\[\\?\[([^\]]+)\\?\]\]\(#[^)]*\)\{reference-type="ref"\s+reference="([^"]+)"\}/g,
+    '\\ref{$2}',
+  );
+  text = text.replace(
+    /\[\\?\[([^\]]+)\\?\]\]\(#[^)]*\)\{reference-type="eqref"\s+reference="([^"]+)"\}/g,
+    '\\eqref{$2}',
+  );
+  text = text.replace(
+    /\[\\?\[([^\]]+)\\?\]\]\(#[^)]*\)\{reference-type="[Cc]ref"\s+reference="([^"]+)"\}/g,
+    '\\cref{$2}',
+  );
+
+  // Handle plain markdown-link format: [label](#anchor){reference-type="ref" reference="label"}
+  text = text.replace(
+    /\[([^\[\]]+)\]\(#[^)]*\)\{reference-type="ref"\s+reference="([^"]+)"\}/g,
+    '\\ref{$2}',
+  );
+  text = text.replace(
+    /\[([^\[\]]+)\]\(#[^)]*\)\{reference-type="eqref"\s+reference="([^"]+)"\}/g,
+    '\\eqref{$2}',
+  );
+  text = text.replace(
+    /\[([^\[\]]+)\]\(#[^)]*\)\{reference-type="[Cc]ref"\s+reference="([^"]+)"\}/g,
+    '\\cref{$2}',
+  );
+
+  // Handle simple Pandoc format: [label]{reference-type="ref" reference="label"}
+  text = text.replace(
+    /\[([^\]]+)\]\{reference-type="ref"\s+reference="([^"]+)"\}/g,
+    '\\ref{$2}',
+  );
+  text = text.replace(
+    /\[([^\]]+)\]\{reference-type="eqref"\s+reference="([^"]+)"\}/g,
+    '\\eqref{$2}',
+  );
+  text = text.replace(
+    /\[([^\]]+)\]\{reference-type="[Cc]ref"\s+reference="([^"]+)"\}/g,
+    '\\cref{$2}',
+  );
+
+  return text;
 }
 
 /**


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Pass raw log text to the progress view, escape it at render time, and normalize Pandoc reference syntax to LaTeX during XML-to-markdown conversion.
> 
> - **Progress View**:
>   - Expect raw text (no HTML-decoding); remove `decodeHtml` usage in `formatters.js`.
>   - Escape user-visible text at render with `encodeHtml` for default log lines and sections.
>   - Simplify `_processMarkdownContent` signature (remove decode flag) and rely on LaTeX ref placeholders only.
> - **Logging**:
>   - `ProgressViewSink`: stop HTML-encoding messages; send raw `text` to bus.
> - **Text Utils**:
>   - `xmlUtils.ts`: add `normalizePandocReferences` and apply after Pandoc conversion to output canonical `\ref{}`, `\cref{}`, `\eqref{}`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 35194d6761218fb389f66dc5750ba1d0ec7f65d6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->