### PR TITLE
Add DeepSeek V3.2 Speciale API support

### DIFF
--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -211,6 +211,7 @@ export abstract class ModelHandler<
     return resolveBaseUrl({
       provider: this.config.provider,
       openRouterOnly: this.config.openRouterOnly,
+      customBaseUrl: this.config.baseUrl,
       logger: this.logger,
     });
   }

--- a/src/agent/modelHandlers/support/ProxyConfigResolver.ts
+++ b/src/agent/modelHandlers/support/ProxyConfigResolver.ts
@@ -27,6 +27,7 @@ const BASE_URLS: Record<ModelProvider, string | null> = {
 export interface ProxyConfig {
   provider: ModelProvider;
   openRouterOnly: boolean;
+  customBaseUrl?: string; // Per-model custom base URL (overrides provider default)
   logger?: { debug: (message: string) => void };
 }
 
@@ -68,6 +69,12 @@ export function resolveBaseUrl(config: ProxyConfig): string | null {
   }
 
   if (useOpenRouter) return 'https://openrouter.ai/api/v1';
+
+  // Per-model custom base URL takes precedence
+  if (config.customBaseUrl) {
+    config.logger?.debug(`Using custom base URL for model: ${config.customBaseUrl}`);
+    return config.customBaseUrl;
+  }
 
   if (config.provider === ModelProvider.DEEPSEEK) {
     const customUrl = getConfig<string>('texra.model.baseUrlDeepSeek', '');

--- a/src/agent/modelHandlers/support/ProxyConfigResolver.ts
+++ b/src/agent/modelHandlers/support/ProxyConfigResolver.ts
@@ -32,6 +32,12 @@ export interface ProxyConfig {
 }
 
 export function resolveBaseUrl(config: ProxyConfig): string | null {
+  // Per-model custom base URL takes highest precedence (e.g., temporary endpoints)
+  if (config.customBaseUrl) {
+    config.logger?.debug(`Using custom base URL for model: ${config.customBaseUrl}`);
+    return config.customBaseUrl;
+  }
+
   const useOpenRouter =
     config.openRouterOnly ||
     getConfig<boolean>('texra.model.useOpenRouter', false);
@@ -69,12 +75,6 @@ export function resolveBaseUrl(config: ProxyConfig): string | null {
   }
 
   if (useOpenRouter) return 'https://openrouter.ai/api/v1';
-
-  // Per-model custom base URL takes precedence
-  if (config.customBaseUrl) {
-    config.logger?.debug(`Using custom base URL for model: ${config.customBaseUrl}`);
-    return config.customBaseUrl;
-  }
 
   if (config.provider === ModelProvider.DEEPSEEK) {
     const customUrl = getConfig<string>('texra.model.baseUrlDeepSeek', '');

--- a/src/model/ModelConfig.ts
+++ b/src/model/ModelConfig.ts
@@ -85,4 +85,5 @@ export interface ModelConfig {
   capabilities: ModelCapabilities;
   openRouterOnly: boolean; // Whether this model is only available through OpenRouter
   openrouterFullName?: string; // Full model name for OpenRouter (e.g., "anthropic/claude-3-opus-20240229")
+  baseUrl?: string; // Custom base URL for this specific model (overrides provider default)
 }

--- a/src/model/providers/deepseekModels.ts
+++ b/src/model/providers/deepseekModels.ts
@@ -48,6 +48,23 @@ export const DEEPSEEK_MODELS: Record<string, ModelConfig> = {
     } satisfies ModelCapabilities,
     openRouterOnly: false,
   },
+  'deepseekT+': {
+    name: 'deepseekT+',
+    fullName: 'deepseek-reasoner',
+    provider: ModelProvider.DEEPSEEK,
+    maxOutputTokens: 65536,
+    contextWindow: 128000,
+    inputPrice: 0.56,
+    outputPrice: 1.68,
+    capabilities: {
+      ...DEEPSEEK_DEFAULT_CAPABILITIES,
+      supportsReasoning: true,
+      supportsReasoningEffort: false,
+      supportsFunctionCalling: false,
+    } satisfies ModelCapabilities,
+    openRouterOnly: false,
+    baseUrl: 'https://api.deepseek.com/v3.2_speciale_expires_on_20251215',
+  },
   dsv3: {
     name: 'dsv3',
     fullName: 'deepseek-chat',

--- a/src/model/providers/deepseekModels.ts
+++ b/src/model/providers/deepseekModels.ts
@@ -51,11 +51,12 @@ export const DEEPSEEK_MODELS: Record<string, ModelConfig> = {
   'deepseekT+': {
     name: 'deepseekT+',
     fullName: 'deepseek-reasoner',
+    openrouterFullName: 'deepseek/deepseek-v3.2-speciale',
     provider: ModelProvider.DEEPSEEK,
     maxOutputTokens: 65536,
-    contextWindow: 128000,
-    inputPrice: 0.56,
-    outputPrice: 1.68,
+    contextWindow: 163840,
+    inputPrice: 0.28,
+    outputPrice: 0.4,
     capabilities: {
       ...DEEPSEEK_DEFAULT_CAPABILITIES,
       supportsReasoning: true,


### PR DESCRIPTION
Add support for DeepSeek V3.2-Speciale reasoning model (deepseekT+) with its temporary endpoint. This also adds per-model custom base URL support to ModelConfig to enable models with non-standard API endpoints.

- Add optional baseUrl field to ModelConfig interface
- Update ProxyConfigResolver to use per-model custom base URLs
- Add deepseekT+ model with V3.2-Speciale endpoint (expires Dec 15, 2025)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds DeepSeek V3.2 Speciale (`deepseekT+`) and introduces per-model `baseUrl` overrides wired through config, resolver, and handler.
> 
> - **Models**:
>   - Add `deepseekT+` (DeepSeek V3.2 Speciale) in `src/model/providers/deepseekModels.ts` with custom `baseUrl`, capabilities, pricing, and context limits.
> - **Config & Resolution**:
>   - Extend `ModelConfig` with optional `baseUrl` in `src/model/ModelConfig.ts`.
>   - Update `resolveBaseUrl` in `src/agent/modelHandlers/support/ProxyConfigResolver.ts` to prioritize per-model `customBaseUrl`; add it to `ProxyConfig`.
> - **Handler**:
>   - Pass model `baseUrl` to `resolveBaseUrl` in `getBaseUrl()` within `src/agent/modelHandlers/ModelHandler.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3e8f6bdc3d2bab1cad51f4e2af3bd3880e24cd8c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->