### PR TITLE
Replace normalizePayload with modern Zod validation

### DIFF
--- a/src/commands/agent/executeCommand.ts
+++ b/src/commands/agent/executeCommand.ts
@@ -17,25 +17,37 @@ const CHANNEL = 'ExecuteCommand';
 // --- Schema ---
 
 /**
- * Explicit execute input with config field.
+ * Explicit wrapper format: { config, executionId?, resume? }
  *
  * Note: `config` is z.unknown() because validation is handled by parseAgentConfig(),
- * which owns AgentConfigSchema. Validating here would duplicate that logic.
- * Errors from invalid config will surface as ZodError in the catch block.
+ * which owns AgentConfigSchema. Errors will surface as ZodError in the catch block.
  */
-const ExplicitInputSchema = z.object({
+const ExplicitWrapperSchema = z.object({
   config: z.unknown(),
   executionId: z.string().optional(),
   resume: z.boolean().default(false),
 });
 
-/** Accepts {config, executionId?, resume?} or raw config directly */
-const ExecuteInputSchema = z
-  .unknown()
-  .transform((input): z.infer<typeof ExplicitInputSchema> => {
-    const explicit = ExplicitInputSchema.safeParse(input);
-    return explicit.success ? explicit.data : { config: input, resume: false };
-  });
+type ParsedInput = z.infer<typeof ExplicitWrapperSchema>;
+
+/** Check if input looks like an explicit wrapper (has 'config' property) */
+function hasConfigProperty(input: unknown): input is { config: unknown } {
+  return input !== null && typeof input === 'object' && 'config' in input;
+}
+
+/**
+ * Parse execute input: explicit wrapper or raw config.
+ *
+ * Discrimination logic:
+ * - If input has 'config' property → parse as explicit wrapper (fail if malformed)
+ * - Otherwise → treat entire input as raw config
+ */
+function parseExecuteInput(input: unknown): ParsedInput {
+  if (hasConfigProperty(input)) {
+    return ExplicitWrapperSchema.parse(input);
+  }
+  return { config: input, resume: false };
+}
 
 // --- Command ---
 
@@ -50,7 +62,7 @@ export function registerExecuteCommand(context: vscode.ExtensionContext) {
 export const executeCommand = {
   async executeCommand(input: unknown) {
     try {
-      const { config, executionId, resume } = ExecuteInputSchema.parse(input);
+      const { config, executionId, resume } = parseExecuteInput(input);
       const normalizedConfig = parseAgentConfig(config);
 
       if (resume && executionId) {

--- a/src/commands/agent/executeCommand.ts
+++ b/src/commands/agent/executeCommand.ts
@@ -1,24 +1,44 @@
+// Standard library imports
+import { randomUUID } from 'crypto';
+
 // Third-party imports
 import * as vscode from 'vscode';
-import { ZodError } from 'zod';
+import { z, ZodError } from 'zod';
 
-// Local imports - agent runtime
+// Local imports
 import { parseAgentConfig } from '@agent/core/AgentConfig';
-import {
-  executeAgent,
-  resumeAgentExecution,
-} from '@agent/runtime/executeAgent';
-// Type imports
+import { executeAgent, resumeAgentExecution } from '@agent/runtime/executeAgent';
 import type { ExecutionId } from '@agent/types/IdentifierTypes';
-import type { StreamTabId } from '@agent/types/IdentifierTypes';
-
-// Local imports - history
 import { AgentHistoryManager } from '@historyView/managers';
 import * as logger from '@logger/logUtils';
 
 const CHANNEL = 'ExecuteCommand';
 
-// Add the registration function
+// --- Schema ---
+
+/**
+ * Explicit execute input with config field.
+ *
+ * Note: `config` is z.unknown() because validation is handled by parseAgentConfig(),
+ * which owns AgentConfigSchema. Validating here would duplicate that logic.
+ * Errors from invalid config will surface as ZodError in the catch block.
+ */
+const ExplicitInputSchema = z.object({
+  config: z.unknown(),
+  executionId: z.string().optional(),
+  resume: z.boolean().default(false),
+});
+
+/** Accepts {config, executionId?, resume?} or raw config directly */
+const ExecuteInputSchema = z
+  .unknown()
+  .transform((input): z.infer<typeof ExplicitInputSchema> => {
+    const explicit = ExplicitInputSchema.safeParse(input);
+    return explicit.success ? explicit.data : { config: input, resume: false };
+  });
+
+// --- Command ---
+
 export function registerExecuteCommand(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     vscode.commands.registerCommand('texra.execute', (config: unknown) =>
@@ -28,76 +48,33 @@ export function registerExecuteCommand(context: vscode.ExtensionContext) {
 }
 
 export const executeCommand = {
-  async executeCommand(config: unknown) {
+  async executeCommand(input: unknown) {
     try {
-      const { payload, executionId, resume } = normalizePayload(config);
-      const normalizedConfig = parseAgentConfig(payload);
+      const { config, executionId, resume } = ExecuteInputSchema.parse(input);
+      const normalizedConfig = parseAgentConfig(config);
 
-      if (resume) {
-        if (!executionId) {
-          logger.warn(
-            CHANNEL,
-            'Resume requested without an execution ID; starting a new run instead.',
-          );
-        } else {
-          await resumeAgentExecution(normalizedConfig, executionId);
-          return;
-        }
-      }
-
-      const resolvedExecutionId: ExecutionId =
-        executionId ??
-        (await AgentHistoryManager.addToHistory(normalizedConfig));
-
-      await executeAgent(normalizedConfig, resolvedExecutionId);
-    } catch (error) {
-      if (error instanceof ZodError) {
-        const detail = error.issues.map((issue) => issue.message).join('; ');
-        const message =
-          'Invalid agent configuration provided for execution.' +
-          (detail ? ` ${detail}` : '');
-        logger.warn(CHANNEL, message, { data: error });
-        void vscode.window.showErrorMessage(message);
+      if (resume && executionId) {
+        await resumeAgentExecution(normalizedConfig, executionId);
         return;
       }
 
-      logger.error(CHANNEL, 'Agent execution failed before start.', {
-        data: error,
-      });
+      if (resume) {
+        logger.warn(CHANNEL, 'Resume requested without execution ID; starting new run.');
+      }
+
+      const newExecutionId = randomUUID() as ExecutionId;
+      await AgentHistoryManager.addToHistory(newExecutionId, normalizedConfig);
+      await executeAgent(normalizedConfig, newExecutionId);
+    } catch (error) {
+      if (error instanceof ZodError) {
+        const detail = error.issues.map((i) => i.message).join('; ');
+        logger.warn(CHANNEL, `Invalid agent configuration. ${detail}`, { data: error });
+        void vscode.window.showErrorMessage(`Invalid agent configuration. ${detail}`);
+        return;
+      }
+
+      logger.error(CHANNEL, 'Agent execution failed before start.', { data: error });
       throw error;
     }
   },
 };
-
-function normalizePayload(input: unknown): {
-  payload: unknown;
-  executionId?: ExecutionId;
-  resume: boolean;
-  stream?: StreamTabId;
-} {
-  if (input && typeof input === 'object' && 'config' in (input as any)) {
-    const candidate = input as {
-      config: unknown;
-      executionId?: unknown;
-      resume?: unknown;
-      stream?: unknown;
-    };
-
-    const executionId =
-      typeof candidate.executionId === 'string'
-        ? (candidate.executionId as ExecutionId)
-        : undefined;
-
-    return {
-      payload: candidate.config,
-      executionId,
-      resume: Boolean(candidate.resume),
-      stream:
-        typeof candidate.stream === 'string'
-          ? (candidate.stream as StreamTabId)
-          : undefined,
-    };
-  }
-
-  return { payload: input, resume: false };
-}

--- a/src/commands/housekeeping/packCommands.ts
+++ b/src/commands/housekeeping/packCommands.ts
@@ -1,10 +1,9 @@
 // Third-party imports
 import * as vscode from 'vscode';
+import { z } from 'zod';
 
-// Local imports - progress view
+// Local imports
 import type { FileOpResult } from '@agent/types/ResultTypes';
-
-// Internal imports
 import { showLoggedMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
 import { WorkspaceFS } from '@utils/files';
@@ -12,62 +11,72 @@ import { bus } from '@eventBus/ProgressEventBus';
 import { runPack, runPackSingle, runPackMultiple } from '@housekeeping';
 import { getStreamTabId } from '@/logger/streamUtils';
 
-// Local imports - housekeeping
-
 const CHANNEL = 'packCommands';
 logger.initialize(CHANNEL);
 
-/** Validates and logs required parameters, returns false if any are missing */
-async function validateParams(
-  inputFile: string,
-  agent: string,
-  model: string,
-  commandName: string,
-): Promise<boolean> {
-  logger.debug(
-    CHANNEL,
-    `Command called with: inputFile=${inputFile}, agent=${agent}, model=${model}`,
-  );
+// --- Schemas ---
 
-  if (!inputFile || !agent || !model) {
-    const missing = [];
-    if (!inputFile) missing.push('inputFile');
-    if (!agent) missing.push('agent');
-    if (!model) missing.push('model');
-    await showLoggedMessage(
-      CHANNEL,
-      `Missing required parameters for ${commandName}: ${missing.join(', ')}`,
-    );
-    return false;
-  }
-  return true;
+const RequiredString = z.string().min(1);
+
+/** Core fields required by all pack operations */
+const CorePackFields = z.object({
+  inputFile: RequiredString,
+  agent: RequiredString,
+});
+
+/** For packSingle - all fields required */
+const PackParamsSchema = CorePackFields.extend({
+  model: RequiredString,
+});
+
+/** For pack command - model optional (may come from stored config) */
+const PackConfigSchema = CorePackFields.extend({
+  model: z.string().default(''),
+  outputFiles: z.array(z.string()).default([]),
+  useMultipleOutputs: z.boolean().optional(),
+  streamId: z.string().optional(),
+  skipProgressViewClear: z.boolean().optional(),
+}).transform((c) => ({
+  ...c,
+  useMultipleOutputs: c.useMultipleOutputs ?? c.outputFiles.length > 1,
+}));
+
+/** For packMultiple - inputFile optional if outputFiles provided */
+const PackMultipleSchema = CorePackFields.extend({
+  model: RequiredString,
+  inputFile: z.string().default(''),
+  outputFiles: z.array(z.string()).default([]),
+}).refine((d) => d.inputFile || d.outputFiles.length > 0, {
+  message: 'inputFile or outputFiles required',
+});
+
+type PackConfig = z.infer<typeof PackConfigSchema>;
+
+// --- Helpers ---
+
+function formatZodError(error: z.ZodError): string {
+  return error.issues
+    .map((i) => (i.path.length ? `${i.path.join('.')}: ${i.message}` : i.message))
+    .join(', ');
 }
 
 function showPackResult(result: FileOpResult, inputFile: string): void {
   switch (result.status) {
-    case 'success':
-      if (result.outputFolder) {
-        const openFolder = 'Open Folder';
-        const outputFolder = result.outputFolder;
+    case 'success': {
+      const folder = result.outputFolder;
+      if (folder) {
         vscode.window
-          .showInformationMessage(
-            `Files packed into ${outputFolder}`,
-            openFolder,
-          )
-          .then((selection) => {
-            if (selection === openFolder) {
-              void vscode.commands.executeCommand(
-                'revealFileInOS',
-                vscode.Uri.file(WorkspaceFS.fullPath(outputFolder)),
-              );
+          .showInformationMessage(`Files packed into ${folder}`, 'Open Folder')
+          .then((sel) => {
+            if (sel === 'Open Folder') {
+              void vscode.commands.executeCommand('revealFileInOS', vscode.Uri.file(WorkspaceFS.fullPath(folder)));
             }
           });
       }
       break;
+    }
     case 'noFiles':
-      vscode.window.showInformationMessage(
-        `No files found to pack for ${inputFile}`,
-      );
+      vscode.window.showInformationMessage(`No files found to pack for ${inputFile}`);
       break;
     case 'missingParams':
       vscode.window.showErrorMessage('Missing required parameters for pack');
@@ -75,10 +84,65 @@ function showPackResult(result: FileOpResult, inputFile: string): void {
     case 'error':
       vscode.window.showErrorMessage(`Error during packing: ${result.error}`);
       break;
-    default:
-      break;
   }
 }
+
+// --- Handlers ---
+
+async function handlePack(config: unknown) {
+  const parsed = PackConfigSchema.safeParse(config);
+  if (!parsed.success) {
+    await showLoggedMessage(CHANNEL, `Invalid config: ${formatZodError(parsed.error)}`);
+    return;
+  }
+
+  const { agent, model, inputFile, outputFiles, useMultipleOutputs, streamId, skipProgressViewClear } =
+    parsed.data;
+
+  if (outputFiles.length > 1 && !useMultipleOutputs) {
+    logger.warn(CHANNEL, 'Multiple output files but multi-output mode disabled');
+  }
+
+  const result = await runPack(model, inputFile, agent, useMultipleOutputs ? outputFiles : []);
+  showPackResult(result, inputFile);
+
+  if (!skipProgressViewClear) {
+    bus.emit('clearMissingOutputs', streamId || getStreamTabId(agent, model, inputFile, { useMultipleOutputs }));
+  }
+}
+
+async function handlePackSingle(inputFile: string, agent: string, model: string) {
+  const parsed = PackParamsSchema.safeParse({ inputFile, agent, model });
+  if (!parsed.success) {
+    await showLoggedMessage(CHANNEL, `Invalid params: ${formatZodError(parsed.error)}`);
+    return;
+  }
+
+  const data = parsed.data;
+  const result = await runPackSingle(data.model, data.inputFile, data.agent);
+  showPackResult(result, data.inputFile);
+  bus.emit('clearMissingOutputs', getStreamTabId(data.agent, data.model, data.inputFile, { useMultipleOutputs: false }));
+}
+
+async function handlePackMultiple(
+  inputFile: string,
+  agent: string,
+  model: string,
+  outputFiles: string[] = [],
+) {
+  const parsed = PackMultipleSchema.safeParse({ inputFile, agent, model, outputFiles });
+  if (!parsed.success) {
+    await showLoggedMessage(CHANNEL, `Invalid params: ${formatZodError(parsed.error)}`);
+    return;
+  }
+
+  const data = parsed.data;
+  const result = await runPackMultiple(data.model, data.inputFile, data.agent, data.outputFiles);
+  showPackResult(result, data.inputFile);
+  bus.emit('clearMissingOutputs', getStreamTabId(data.agent, data.model, data.inputFile, { useMultipleOutputs: true }));
+}
+
+// --- Registration ---
 
 export function registerPackCommands(context: vscode.ExtensionContext) {
   context.subscriptions.push(
@@ -88,117 +152,4 @@ export function registerPackCommands(context: vscode.ExtensionContext) {
   );
 }
 
-async function handlePack(config: {
-  streamId?: string;
-  skipProgressViewClear?: boolean;
-  [key: string]: any;
-}) {
-  logger.debug(
-    CHANNEL,
-    `Pack command called with config: ${JSON.stringify(config)}`,
-  );
-
-  if (!config.agent || !config.inputFile) {
-    await showLoggedMessage(CHANNEL, 'Missing required parameters in config');
-    return;
-  }
-
-  const declaredOutputFiles = Array.isArray(config.outputFiles)
-    ? config.outputFiles
-    : [];
-  const legacyActiveFlag =
-    typeof config.activeFiles?.output === 'boolean'
-      ? config.activeFiles.output
-      : undefined;
-  const useMultipleOutputs =
-    typeof config.useMultipleOutputs === 'boolean'
-      ? config.useMultipleOutputs
-      : typeof legacyActiveFlag === 'boolean'
-        ? legacyActiveFlag
-        : declaredOutputFiles.length > 1;
-
-  if (declaredOutputFiles.length > 1 && !useMultipleOutputs) {
-    logger.warn(
-      CHANNEL,
-      'Pack command received multiple output files but multi-output mode is disabled. Verify stored task state.',
-    );
-  }
-
-  const outputFiles = useMultipleOutputs ? declaredOutputFiles : [];
-
-  const result = await runPack(
-    config.model,
-    config.inputFile,
-    config.agent,
-    outputFiles,
-  );
-  showPackResult(result, config.inputFile);
-
-  const streamId =
-    config.streamId ||
-    getStreamTabId(config.agent, config.model, config.inputFile, {
-      useMultipleOutputs,
-    });
-
-  if (!config.skipProgressViewClear) {
-    bus.emit('clearMissingOutputs', streamId);
-  }
-}
-
-async function handlePackSingle(
-  inputFile: string,
-  agent: string,
-  model: string,
-) {
-  if (!(await validateParams(inputFile, agent, model, 'packSingle'))) {
-    return;
-  }
-
-  const result = await runPackSingle(model, inputFile, agent);
-  showPackResult(result, inputFile);
-
-  const streamId = getStreamTabId(agent, model, inputFile, {
-    useMultipleOutputs: false,
-  });
-  bus.emit('clearMissingOutputs', streamId);
-}
-
-async function handlePackMultiple(
-  inputFile: string,
-  agent: string,
-  model: string,
-  outputFiles: string[] = [],
-) {
-  logger.debug(
-    CHANNEL,
-    `Command called with: inputFile=${inputFile}, agent=${agent}, model=${model}`,
-  );
-  logger.debug(CHANNEL, `Additional files: ${outputFiles.join(', ')}`);
-
-  if ((!inputFile && !outputFiles.length) || !agent || !model) {
-    const missing = [];
-    if (!inputFile && !outputFiles.length)
-      missing.push('inputFile or outputFiles');
-    if (!agent) missing.push('agent');
-    if (!model) missing.push('model');
-    await showLoggedMessage(
-      CHANNEL,
-      `Missing required parameters for packMultiple: ${missing.join(', ')}`,
-    );
-    return;
-  }
-
-  const result = await runPackMultiple(model, inputFile, agent, outputFiles);
-  showPackResult(result, inputFile);
-
-  const streamId = getStreamTabId(agent, model, inputFile, {
-    useMultipleOutputs: true,
-  });
-  bus.emit('clearMissingOutputs', streamId);
-}
-
-export const packCommands = {
-  handlePack,
-  handlePackSingle,
-  handlePackMultiple,
-};
+export const packCommands = { handlePack, handlePackSingle, handlePackMultiple };

--- a/src/commands/housekeeping/packCommands.ts
+++ b/src/commands/housekeeping/packCommands.ts
@@ -18,39 +18,40 @@ logger.initialize(CHANNEL);
 
 const RequiredString = z.string().min(1);
 
-/** Core fields required by all pack operations */
-const CorePackFields = z.object({
+/** For packSingle - all fields required */
+const PackParamsSchema = z.object({
   inputFile: RequiredString,
   agent: RequiredString,
-});
-
-/** For packSingle - all fields required */
-const PackParamsSchema = CorePackFields.extend({
   model: RequiredString,
 });
 
 /** For pack command - model optional (may come from stored config) */
-const PackConfigSchema = CorePackFields.extend({
-  model: z.string().default(''),
-  outputFiles: z.array(z.string()).default([]),
-  useMultipleOutputs: z.boolean().optional(),
-  streamId: z.string().optional(),
-  skipProgressViewClear: z.boolean().optional(),
-}).transform((c) => ({
-  ...c,
-  useMultipleOutputs: c.useMultipleOutputs ?? c.outputFiles.length > 1,
-}));
+const PackConfigSchema = z
+  .object({
+    inputFile: RequiredString,
+    agent: RequiredString,
+    model: z.string().default(''),
+    outputFiles: z.array(z.string()).default([]),
+    useMultipleOutputs: z.boolean().optional(),
+    streamId: z.string().optional(),
+    skipProgressViewClear: z.boolean().optional(),
+  })
+  .transform((c) => ({
+    ...c,
+    useMultipleOutputs: c.useMultipleOutputs ?? c.outputFiles.length > 1,
+  }));
 
 /** For packMultiple - inputFile optional if outputFiles provided */
-const PackMultipleSchema = CorePackFields.extend({
-  model: RequiredString,
-  inputFile: z.string().default(''),
-  outputFiles: z.array(z.string()).default([]),
-}).refine((d) => d.inputFile || d.outputFiles.length > 0, {
-  message: 'inputFile or outputFiles required',
-});
-
-type PackConfig = z.infer<typeof PackConfigSchema>;
+const PackMultipleSchema = z
+  .object({
+    agent: RequiredString,
+    model: RequiredString,
+    inputFile: z.string().default(''),
+    outputFiles: z.array(z.string()).default([]),
+  })
+  .refine((d) => d.inputFile || d.outputFiles.length > 0, {
+    message: 'inputFile or outputFiles required',
+  });
 
 // --- Helpers ---
 

--- a/src/historyView/managers/AgentHistoryManager.ts
+++ b/src/historyView/managers/AgentHistoryManager.ts
@@ -1,6 +1,3 @@
-// Standard library imports
-import { randomUUID } from 'crypto';
-
 // Third-party imports
 import * as vscode from 'vscode';
 
@@ -35,9 +32,12 @@ export class AgentHistoryManager {
   private static readonly MAX_HISTORY_ITEMS = 500;
 
   /**
-   * Add a new agent execution to history
+   * Add an agent execution to history with the given ID.
    */
-  public static async addToHistory(config: AgentConfig): Promise<string> {
+  public static async addToHistory(
+    executionId: ExecutionId,
+    config: AgentConfig,
+  ): Promise<void> {
     const normalizedConfig = parseAgentConfig(config);
     if (!normalizedConfig.session) {
       throw new Error(
@@ -46,26 +46,19 @@ export class AgentHistoryManager {
     }
 
     const historyItem: AgentHistoryItem = {
-      id: randomUUID(),
+      id: executionId,
       timestamp: new Date().toISOString(),
       agentConfig: normalizedConfig,
     };
 
-    // Get current workspace-specific history
     const history = await this.getHistory();
-
-    // Add new item at beginning (most recent first)
     history.unshift(historyItem);
 
-    // Limit history size
     if (history.length > this.MAX_HISTORY_ITEMS) {
       history.splice(this.MAX_HISTORY_ITEMS);
     }
 
-    // Save updated history
     await this.saveHistory(history);
-
-    return historyItem.id;
   }
 
   /**

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -32,6 +32,7 @@ import {
 import {
   handleProgressViewToolEditApprovalAction,
   resetToolEditApprovalSessionBypass,
+  ProgressViewApprovalActions,
 } from '@tools/approval/toolEditApproval';
 import { pathToLocation } from '@utils/files';
 import { ensureRunDir, getRunDir } from '@utils/files/taskRunStorage';
@@ -65,7 +66,7 @@ const PolishFollowUp = z.object({ stream: z.string().min(1), text: TrimmedString
 const InfoMessage = z.object({ text: TrimmedString });
 const ApprovalAction = z.object({
   requestId: z.string().min(1),
-  action: z.enum(['approve', 'reject', 'openDiff', 'approveAll', 'resumeApprovals']),
+  action: z.enum(ProgressViewApprovalActions),
   note: z.string().optional(),
 });
 

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 
 // Third-party imports
 import * as vscode from 'vscode';
+import { z } from 'zod';
 
 // Local imports - common
 
@@ -56,6 +57,17 @@ interface BaseFileCommandMessage extends FileCommandMessage {
 interface CompareMessage extends BaseFileCommandMessage {
   prev?: string;
 }
+
+// --- Message Schemas ---
+
+const TrimmedString = z.string().transform((s) => s.trim()).pipe(z.string().min(1));
+const PolishFollowUp = z.object({ stream: z.string().min(1), text: TrimmedString });
+const InfoMessage = z.object({ text: TrimmedString });
+const ApprovalAction = z.object({
+  requestId: z.string().min(1),
+  action: z.enum(['approve', 'reject', 'openDiff', 'approveAll', 'resumeApprovals']),
+  note: z.string().optional(),
+});
 
 export class ProgressViewMessageHandler extends BaseViewMessageHandler {
   private readonly recordingManager: RecordingManager;
@@ -332,19 +344,16 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
     });
   }
 
-  private async handlePolishFollowUp(message: any): Promise<void> {
-    const stream = message.stream as StreamTabId | undefined;
-    const text = typeof message.text === 'string' ? message.text.trim() : '';
-    if (!stream || !text) {
+  private async handlePolishFollowUp(message: unknown): Promise<void> {
+    const parsed = PolishFollowUp.safeParse(message);
+    if (!parsed.success) {
+      this.logger.debug(this.channel, 'Invalid polishFollowUp message', { data: parsed.error });
       return;
     }
 
-    const taskState = this.provider.state.getTaskState(stream) as
-      | TaskState
-      | undefined;
-    if (!taskState) {
-      return;
-    }
+    const { stream, text } = parsed.data;
+    const taskState = this.provider.state.getTaskState(stream as StreamTabId) as TaskState | undefined;
+    if (!taskState) return;
 
     const fileContext = buildFileContextFromTaskState(taskState);
 
@@ -387,27 +396,22 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
     );
   }
 
-  private async handleShowInformationMessage(message: any): Promise<void> {
-    const text = typeof message?.text === 'string' ? message.text.trim() : '';
-    if (!text) {
+  private async handleShowInformationMessage(message: unknown): Promise<void> {
+    const parsed = InfoMessage.safeParse(message);
+    if (!parsed.success) {
+      this.logger.debug(this.channel, 'Invalid infoMessage', { data: parsed.error });
       return;
     }
-    await vscode.window.showInformationMessage(text);
+    await vscode.window.showInformationMessage(parsed.data.text);
   }
 
-  private async handleToolEditApprovalAction(message: any): Promise<void> {
-    const requestId =
-      typeof message?.requestId === 'string' ? message.requestId : '';
-    const action = typeof message?.action === 'string' ? message.action : '';
-    if (!requestId || !action) {
+  private async handleToolEditApprovalAction(message: unknown): Promise<void> {
+    const parsed = ApprovalAction.safeParse(message);
+    if (!parsed.success) {
+      this.logger.debug(this.channel, 'Invalid approvalAction', { data: parsed.error });
       return;
     }
-
-    await handleProgressViewToolEditApprovalAction({
-      requestId,
-      action,
-      note: typeof message?.note === 'string' ? message.note : undefined,
-    });
+    await handleProgressViewToolEditApprovalAction(parsed.data);
   }
 
   private async handleResetToolEditApprovalBypass(): Promise<void> {

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -62,12 +62,16 @@ interface PendingApprovalEntry {
   settle: (result: ToolEditApprovalResult) => void;
 }
 
-type ProgressViewApprovalAction =
-  | 'approve'
-  | 'reject'
-  | 'openDiff'
-  | 'approveAll'
-  | 'resumeApprovals';
+/** All valid approval actions for tool edit prompts */
+export const ProgressViewApprovalActions = [
+  'approve',
+  'reject',
+  'openDiff',
+  'approveAll',
+  'resumeApprovals',
+] as const;
+
+export type ProgressViewApprovalAction = typeof ProgressViewApprovalActions[number];
 
 interface ProgressViewApprovalActionPayload {
   requestId: string;


### PR DESCRIPTION
Replace manual typeof/instanceof checks with declarative Zod schemas:
- executeCommand.ts: ExecutePayloadSchema replaces normalizePayload()
- packCommands.ts: PackParamsSchema, PackConfigSchema, PackMultipleParamsSchema
- ProgressViewMessageHandler.ts: schemas for polish, info message, and approval handlers

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adopts Zod-based validation across execute/pack commands and progress view, updates history API to accept provided IDs, and tightens resume/new-run logic.
> 
> - **Agent execution (`src/commands/agent/executeCommand.ts`)**:
>   - Add Zod parsing for inputs (explicit `{ config, executionId?, resume? }` or raw config).
>   - Resume only when both `resume` and `executionId` are provided; otherwise warn and start a new run.
>   - Generate `executionId` via `randomUUID()` and call `AgentHistoryManager.addToHistory(executionId, config)`.
>   - Streamlined Zod error reporting to users and logs.
> - **Pack commands (`src/commands/housekeeping/packCommands.ts`)**:
>   - Introduce `PackParamsSchema`, `PackConfigSchema`, `PackMultipleSchema` and validate inputs.
>   - Simplify handlers; warn on multi-output mismatch; preserve progress view clearing via `bus.emit`.
> - **History (`src/historyView/managers/AgentHistoryManager.ts`)**:
>   - Change `addToHistory` to accept externally provided `executionId` and stop generating IDs internally; enforce presence of session metadata.
> - **Progress view (`src/progressView/ProgressViewMessageHandler.ts`)**:
>   - Validate messages with Zod for polish follow-up, info messages, and tool edit approval actions using exported enum.
> - **Tool edit approval (`src/tools/approval/toolEditApproval.ts`)**:
>   - Export `ProgressViewApprovalActions` as a const enum-like array and type for consumers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a7e7ac6b83545d5b6950e18eb90c30538db97fa6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->