### PR TITLE
Make error messages foldable in progress view

### DIFF
--- a/src/agent/core/flows/RetryState.ts
+++ b/src/agent/core/flows/RetryState.ts
@@ -192,7 +192,7 @@ export function applyFallbackResult(
   switch (result.outcome) {
     case 'manual_retry':
       logger.error(`${operationName} failed: ${result.error.message}`, {
-        messageType: MESSAGE_TYPES.PROGRESS_STATUS,
+        messageType: MESSAGE_TYPES.ERROR,
         data: { statusCode: result.error.statusCode, retryable: true },
       });
       return FlowTransition.AWAIT_RETRY;
@@ -201,7 +201,7 @@ export function applyFallbackResult(
       logger.error(
         `${operationName} failed (not retryable): ${result.error.message}`,
         {
-          messageType: MESSAGE_TYPES.PROGRESS_STATUS,
+          messageType: MESSAGE_TYPES.ERROR,
           data: { statusCode: result.error.statusCode, retryable: false },
         },
       );

--- a/src/agent/core/flows/RetryState.ts
+++ b/src/agent/core/flows/RetryState.ts
@@ -11,7 +11,6 @@
  */
 
 import type { AgentLogger } from '@logger/AgentLogger';
-import { MESSAGE_TYPES } from '@logger/messageTypes';
 import {
   getModelRetryBackoffMs,
   getModelRetryMaxAttempts,
@@ -191,19 +190,16 @@ export function applyFallbackResult(
 
   switch (result.outcome) {
     case 'manual_retry':
-      logger.error(`${operationName} failed: ${result.error.message}`, {
-        messageType: MESSAGE_TYPES.ERROR,
-        data: result.error,
-      });
+      logger.logErrorData(
+        `${operationName} failed: ${result.error.message}`,
+        result.error,
+      );
       return FlowTransition.AWAIT_RETRY;
 
     case 'fail':
-      logger.error(
+      logger.logErrorData(
         `${operationName} failed (not retryable): ${result.error.message}`,
-        {
-          messageType: MESSAGE_TYPES.ERROR,
-          data: result.error,
-        },
+        result.error,
       );
       return FlowTransition.COMPLETE;
 

--- a/src/agent/core/flows/RetryState.ts
+++ b/src/agent/core/flows/RetryState.ts
@@ -193,7 +193,7 @@ export function applyFallbackResult(
     case 'manual_retry':
       logger.error(`${operationName} failed: ${result.error.message}`, {
         messageType: MESSAGE_TYPES.ERROR,
-        data: { statusCode: result.error.statusCode, retryable: true },
+        data: result.error,
       });
       return FlowTransition.AWAIT_RETRY;
 
@@ -202,7 +202,7 @@ export function applyFallbackResult(
         `${operationName} failed (not retryable): ${result.error.message}`,
         {
           messageType: MESSAGE_TYPES.ERROR,
-          data: { statusCode: result.error.statusCode, retryable: false },
+          data: result.error,
         },
       );
       return FlowTransition.COMPLETE;

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -52,11 +52,7 @@ import type { NormalizedUsage } from '@agent/types/NormalizedUsage';
 import { createContinuationMessage } from '@agent/utils/continuationMessage';
 import { MediaEntry } from '@agent/utils/mediaTypes';
 import { calculateTokenPrice } from '@agent/utils/priceUtils';
-import {
-  formatProviderHttpError,
-  getSdkErrorMessage,
-} from '@common/errors/sdkErrorUtils';
-import { MESSAGE_TYPES } from '@logger/messageTypes';
+import { getSdkErrorMessage } from '@common/errors/sdkErrorUtils';
 
 // Internal imports
 import { cleanFileContent } from '@replacement/engine';
@@ -615,11 +611,11 @@ export class ModelHandlerAnthropic extends ModelHandler<
         );
       }
     } catch (err) {
-      const formattedError = formatProviderHttpError(err);
-      this.logger.error(`Error creating response: ${formattedError.message}`, {
-        messageType: MESSAGE_TYPES.PROGRESS_STATUS,
-        data: formattedError,
-      });
+      this.logger.logError(
+        `Error creating response: ${getSdkErrorMessage(err)}`,
+        err,
+        { operation: 'create response' },
+      );
       throw err;
     }
 
@@ -972,13 +968,10 @@ export class ModelHandlerAnthropic extends ModelHandler<
         const formattedMediaContent = await this.createMediaMessage(mediaFiles);
         roundContent.push(...formattedMediaContent);
       } catch (err) {
-        const formattedError = formatProviderHttpError(err);
-        this.logger.error(
-          `Error processing media files for follow-up round: ${formattedError.message}`,
-          {
-            messageType: MESSAGE_TYPES.PROGRESS_STATUS,
-            data: formattedError,
-          },
+        this.logger.logError(
+          `Error processing media files for follow-up round: ${getSdkErrorMessage(err)}`,
+          err,
+          { operation: 'process media files' },
         );
       }
     }
@@ -1257,7 +1250,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
       'scratchpad',
     );
     if (scratchpad) {
-      this.logger.info(scratchpad, { messageType: MESSAGE_TYPES.SCRATCHPAD });
+      this.logger.logScratchpad(scratchpad);
     }
 
     await flexibleFS.write(outputLocation, fileContent);

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -44,12 +44,8 @@ import type { NormalizedUsage } from '@agent/types/NormalizedUsage';
 import { createContinuationMessage } from '@agent/utils/continuationMessage';
 import { MediaEntry } from '@agent/utils/mediaTypes';
 import { calculateTokenPrice } from '@agent/utils/priceUtils';
-import {
-  formatProviderHttpError,
-  getSdkErrorMessage,
-} from '@common/errors/sdkErrorUtils';
+import { getSdkErrorMessage } from '@common/errors/sdkErrorUtils';
 import { AgentLogger } from '@logger/AgentLogger';
-import { MESSAGE_TYPES } from '@logger/messageTypes';
 
 import { ReasoningEffort } from '@model/ModelConfig';
 
@@ -603,13 +599,10 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
 
       return result;
     } catch (error) {
-      const formattedError = formatProviderHttpError(error);
-      this.logger.error(
-        `Error during Google GenAI Chat API call: ${formattedError.message}`,
-        {
-          messageType: MESSAGE_TYPES.PROGRESS_STATUS,
-          data: formattedError,
-        },
+      this.logger.logError(
+        `Error during Google GenAI Chat API call: ${getSdkErrorMessage(error)}`,
+        error,
+        { operation: 'Google GenAI Chat API call' },
       );
       if (
         error instanceof Error &&
@@ -1048,7 +1041,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
       'scratchpad',
     );
     if (scratchpad) {
-      this.logger.info(scratchpad, { messageType: MESSAGE_TYPES.SCRATCHPAD });
+      this.logger.logScratchpad(scratchpad);
     }
 
     await flexibleFS.write(outputLocation, fileContent);

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -32,7 +32,6 @@ import { createContinuationMessage } from '@agent/utils/continuationMessage';
 import { MediaEntry } from '@agent/utils/mediaTypes';
 import { calculateTokenPrice } from '@agent/utils/priceUtils';
 import { getSdkErrorMessage } from '@common/errors/sdkErrorUtils';
-import { MESSAGE_TYPES } from '@logger/messageTypes';
 
 // Type imports
 import type { ToolDefinition } from '@model';
@@ -857,7 +856,7 @@ export class ModelHandlerOpenAI<
       'scratchpad',
     );
     if (scratchpad) {
-      this.logger.info(scratchpad, { messageType: MESSAGE_TYPES.SCRATCHPAD });
+      this.logger.logScratchpad(scratchpad);
     }
 
     // Write file content to output file

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -20,11 +20,7 @@ import type { NormalizedUsage } from '@agent/types/NormalizedUsage';
 import { createContinuationMessage } from '@agent/utils/continuationMessage';
 import { MediaEntry } from '@agent/utils/mediaTypes';
 import { calculateTokenPrice } from '@agent/utils/priceUtils';
-import {
-  formatProviderHttpError,
-  getSdkErrorMessage,
-} from '@common/errors/sdkErrorUtils';
-import { MESSAGE_TYPES } from '@logger/messageTypes';
+import { getSdkErrorMessage } from '@common/errors/sdkErrorUtils';
 
 // Type imports
 import type { ModelConfig } from '@model';
@@ -239,13 +235,10 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         )) as ResponseInputMessageContentList;
         userContent.push(...mediaContent);
       } catch (err) {
-        const formattedError = formatProviderHttpError(err);
-        this.logger.error(
-          `Error processing media files: ${formattedError.message}`,
-          {
-            messageType: MESSAGE_TYPES.PROGRESS_STATUS,
-            data: formattedError,
-          },
+        this.logger.logError(
+          `Error processing media files: ${getSdkErrorMessage(err)}`,
+          err,
+          { operation: 'process media files' },
         );
       }
     }
@@ -297,13 +290,10 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         )) as ResponseInputMessageContentList;
         roundContent.push(...formattedMediaContent);
       } catch (err) {
-        const formattedError = formatProviderHttpError(err);
-        this.logger.error(
-          `Error processing media files for follow-up round: ${formattedError.message}`,
-          {
-            messageType: MESSAGE_TYPES.PROGRESS_STATUS,
-            data: formattedError,
-          },
+        this.logger.logError(
+          `Error processing media files for follow-up round: ${getSdkErrorMessage(err)}`,
+          err,
+          { operation: 'process media files' },
         );
       }
     }
@@ -494,11 +484,11 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         delete content.filename;
       }
     } catch (err) {
-      const formattedError = formatProviderHttpError(err);
+      const errorMessage = getSdkErrorMessage(err);
 
       if (
         err instanceof APIConnectionTimeoutError ||
-        formattedError.message.includes('Request timed out')
+        errorMessage.includes('Request timed out')
       ) {
         this.logger.warn(
           `Timed out uploading file ${filename}. Falling back to inline payload.`,
@@ -506,12 +496,10 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         return;
       }
 
-      this.logger.error(
-        `Failed to upload file ${filename}: ${formattedError.message}`,
-        {
-          messageType: MESSAGE_TYPES.PROGRESS_STATUS,
-          data: formattedError,
-        },
+      this.logger.logError(
+        `Failed to upload file ${filename}: ${errorMessage}`,
+        err,
+        { operation: 'upload file' },
       );
       throw err;
     } finally {
@@ -682,9 +670,8 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
             },
           },
         );
-        this.logger.info(
+        this.logger.logProgress(
           `Running OpenAI Responses in background mode for response ${response.id}; polling every 15s. Completion may take longer than usual.`,
-          { messageType: MESSAGE_TYPES.PROGRESS_STATUS },
         );
       }
       if (useBackgroundResponses) {
@@ -698,11 +685,11 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       this.sentMessages = messages.length;
       return response;
     } catch (err) {
-      const formattedError = formatProviderHttpError(err);
-      this.logger.error(`Error in createResponse: ${formattedError.message}`, {
-        messageType: MESSAGE_TYPES.PROGRESS_STATUS,
-        data: formattedError,
-      });
+      this.logger.logError(
+        `Error in createResponse: ${getSdkErrorMessage(err)}`,
+        err,
+        { operation: 'create response' },
+      );
       throw err;
     }
   }
@@ -1104,7 +1091,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       'scratchpad',
     );
     if (scratchpad) {
-      this.logger.info(scratchpad, { messageType: MESSAGE_TYPES.SCRATCHPAD });
+      this.logger.logScratchpad(scratchpad);
     }
 
     await flexibleFS.write(outputLocation, fileContent);

--- a/src/agent/modelHandlers/utils/requestExecutor.ts
+++ b/src/agent/modelHandlers/utils/requestExecutor.ts
@@ -49,7 +49,7 @@ export async function executeRequest<T>(
     options.logger.error(
       `Error in ${options.operation}: ${formatted.message}`,
       {
-        messageType: MESSAGE_TYPES.PROGRESS_STATUS,
+        messageType: MESSAGE_TYPES.ERROR,
         data: {
           ...formatted,
           attempt: 1,

--- a/src/agent/modelHandlers/utils/requestExecutor.ts
+++ b/src/agent/modelHandlers/utils/requestExecutor.ts
@@ -5,8 +5,6 @@
  * These utilities provide consistent error logging and abort handling for model requests.
  */
 
-import { buildErrorLogData } from '@common/errors/sdkErrorUtils';
-import { MESSAGE_TYPES } from '@logger/messageTypes';
 import type { AgentLogger } from '@logger/AgentLogger';
 
 /**
@@ -42,13 +40,9 @@ export async function executeRequest<T>(
   try {
     return await request();
   } catch (error) {
-    const errorData = buildErrorLogData(error, {
+    options.logger.logError(`Error in ${options.operation}`, error, {
       operation: options.operation,
       model: options.model,
-    });
-    options.logger.error(`Error in ${options.operation}: ${errorData.message}`, {
-      messageType: MESSAGE_TYPES.ERROR,
-      data: errorData,
     });
     throw error;
   }

--- a/src/agent/modelHandlers/utils/requestExecutor.ts
+++ b/src/agent/modelHandlers/utils/requestExecutor.ts
@@ -5,10 +5,7 @@
  * These utilities provide consistent error logging and abort handling for model requests.
  */
 
-import {
-  formatProviderHttpError,
-  getSdkErrorMessage,
-} from '@common/errors/sdkErrorUtils';
+import { buildErrorLogData } from '@common/errors/sdkErrorUtils';
 import { MESSAGE_TYPES } from '@logger/messageTypes';
 import type { AgentLogger } from '@logger/AgentLogger';
 
@@ -45,21 +42,14 @@ export async function executeRequest<T>(
   try {
     return await request();
   } catch (error) {
-    const formatted = formatProviderHttpError(error);
-    options.logger.error(
-      `Error in ${options.operation}: ${formatted.message}`,
-      {
-        messageType: MESSAGE_TYPES.ERROR,
-        data: {
-          ...formatted,
-          attempt: 1,
-          maxAttempts: 1,
-          model: options.model,
-          operation: options.operation,
-          error: getSdkErrorMessage(error),
-        },
-      },
-    );
+    const errorData = buildErrorLogData(error, {
+      operation: options.operation,
+      model: options.model,
+    });
+    options.logger.error(`Error in ${options.operation}: ${errorData.message}`, {
+      messageType: MESSAGE_TYPES.ERROR,
+      data: errorData,
+    });
     throw error;
   }
 }

--- a/src/agent/output/XmlOutputManager.ts
+++ b/src/agent/output/XmlOutputManager.ts
@@ -11,7 +11,6 @@ import { AgentSetting } from '@agent/core/AgentDataclass';
 import { getOutputFileName } from '@agent/utils/outputFileUtils';
 import { toErrorMessage } from '@common/errors/errorHandlingUtils';
 import { AgentLogger } from '@logger/AgentLogger';
-import { MESSAGE_TYPES } from '@logger/messageTypes';
 import {
   applyReplacements,
   getReplacementsByCategory,
@@ -64,37 +63,21 @@ export class XmlOutputManager {
     );
 
     if (result.content) {
-      switch (result.method) {
-        case 'named':
-          this.logger.info(`Recovered ${documentTag} from named document tag`, {
-            messageType: MESSAGE_TYPES.INTERNAL,
-          });
-          break;
-        case 'simple':
-          this.logger.info(
-            `Successfully extracted ${documentTag} using fallback method`,
-            { messageType: MESSAGE_TYPES.INTERNAL },
-          );
-          break;
-        case 'markdown':
-          this.logger.info(
-            `Recovered ${documentTag} from markdown code block`,
-            { messageType: MESSAGE_TYPES.INTERNAL },
-          );
-          break;
-        case 'latex':
-          this.logger.info(
-            `Recovered ${documentTag} from \\documentclass block`,
-            { messageType: MESSAGE_TYPES.INTERNAL },
-          );
-          break;
+      const methodMessages: Record<string, string> = {
+        named: `Recovered ${documentTag} from named document tag`,
+        simple: `Successfully extracted ${documentTag} using fallback method`,
+        markdown: `Recovered ${documentTag} from markdown code block`,
+        latex: `Recovered ${documentTag} from \\documentclass block`,
+      };
+      const message = methodMessages[result.method];
+      if (message) {
+        this.logger.logInternal(message);
       }
       return result.content;
     }
 
-    this.logger.debug(
+    this.logger.debugInternal(
       `No ${documentTag} found in output file using fallback method`,
-      { messageType: MESSAGE_TYPES.INTERNAL },
     );
     return null;
   }
@@ -106,16 +89,14 @@ export class XmlOutputManager {
     const result = xmlUtils.extractDocuments(outputContent, documentTag);
 
     if (result.documents) {
-      this.logger.info(
+      this.logger.logInternal(
         `Successfully extracted multiple ${documentTag} using fallback method`,
-        { messageType: MESSAGE_TYPES.INTERNAL },
       );
       return result.documents;
     }
 
-    this.logger.debug(
+    this.logger.debugInternal(
       `No ${documentTag} found in output file using fallback method`,
-      { messageType: MESSAGE_TYPES.INTERNAL },
     );
     return null;
   }
@@ -206,9 +187,8 @@ export class XmlOutputManager {
       if (documents) {
         return this.processMultipleLatexDocuments(documents, outputLocation);
       }
-      this.logger.debug(
+      this.logger.debugInternal(
         `No ${documentTag} found in parsed XML, attempting fallback extraction...`,
-        { messageType: MESSAGE_TYPES.INTERNAL },
       );
       const fallbackDocuments = this.extractMultipleDocumentsbyRegex(
         outputContent,
@@ -222,9 +202,8 @@ export class XmlOutputManager {
       }
       return [];
     } catch (err) {
-      this.logger.debug(
+      this.logger.debugInternal(
         `Failed to parse XML content: ${toErrorMessage(err)}, attempting fallback extraction...`,
-        { messageType: MESSAGE_TYPES.INTERNAL },
       );
       const fallbackDocuments = this.extractMultipleDocumentsbyRegex(
         outputContent,

--- a/src/agent/runtime/ManualRetryController.ts
+++ b/src/agent/runtime/ManualRetryController.ts
@@ -14,9 +14,7 @@
  */
 
 // Local imports
-import { buildErrorLogData } from '@common/errors/sdkErrorUtils';
 import type { AgentLogger } from '@logger/AgentLogger';
-import { MESSAGE_TYPES } from '@logger/messageTypes';
 import { bus } from '@eventBus/ProgressEventBus';
 
 export interface ManualRetryTask {
@@ -52,6 +50,12 @@ function nextGeneration(key: string): number {
   return next;
 }
 
+/** Extract context from task for logging */
+const taskContext = (task: ManualRetryTask) => ({
+  operation: task.operation,
+  model: task.model,
+});
+
 /**
  * Register a manual retry task for a stream.
  * Does NOT emit UI events - caller is responsible for emitting 'showRetryRequest'.
@@ -59,10 +63,10 @@ function nextGeneration(key: string): number {
 export function registerManualRetry(key: string, task: ManualRetryTask): void {
   nextGeneration(key);
   pendingRetries.set(key, task);
-  task.logger.info(`Manual retry available for ${task.operation}`, {
-    messageType: MESSAGE_TYPES.PROGRESS_STATUS,
-    data: { model: task.model, operation: task.operation },
-  });
+  task.logger.logProgress(
+    `Manual retry available for ${task.operation}`,
+    taskContext(task),
+  );
 }
 
 /**
@@ -115,21 +119,18 @@ export function cancelManualRetry(key: string): boolean {
     try {
       task.cancel();
     } catch (error) {
-      const errorData = buildErrorLogData(error, {
-        operation: task.operation,
-        model: task.model,
-      });
-      task.logger.error(`Cancel callback failed for ${task.operation}`, {
-        messageType: MESSAGE_TYPES.ERROR,
-        data: errorData,
-      });
+      task.logger.logError(
+        `Cancel callback failed for ${task.operation}`,
+        error,
+        taskContext(task),
+      );
     }
   }
 
-  task.logger.info(`Retry cancelled for ${task.operation}`, {
-    messageType: MESSAGE_TYPES.PROGRESS_STATUS,
-    data: { model: task.model, operation: task.operation },
-  });
+  task.logger.logProgress(
+    `Retry cancelled for ${task.operation}`,
+    taskContext(task),
+  );
 
   // Emit UI resolution event
   bus.emit('resolveRetryRequest', { streamId: key });
@@ -153,27 +154,24 @@ export async function triggerManualRetry(key: string): Promise<boolean> {
   // Remove from registry before execution
   pendingRetries.delete(key);
 
-  task.logger.info(`Retry requested for ${task.operation}`, {
-    messageType: MESSAGE_TYPES.PROGRESS_STATUS,
-    data: { model: task.model, operation: task.operation },
-  });
+  task.logger.logProgress(
+    `Retry requested for ${task.operation}`,
+    taskContext(task),
+  );
 
   try {
     await task.run();
-    task.logger.info(`Retry succeeded for ${task.operation}`, {
-      messageType: MESSAGE_TYPES.PROGRESS_STATUS,
-      data: { model: task.model, operation: task.operation },
-    });
+    task.logger.logProgress(
+      `Retry succeeded for ${task.operation}`,
+      taskContext(task),
+    );
     return true;
   } catch (error) {
-    const errorData = buildErrorLogData(error, {
-      operation: task.operation,
-      model: task.model,
-    });
-    task.logger.error(`Retry failed for ${task.operation}`, {
-      messageType: MESSAGE_TYPES.ERROR,
-      data: errorData,
-    });
+    task.logger.logError(
+      `Retry failed for ${task.operation}`,
+      error,
+      taskContext(task),
+    );
     return false;
   } finally {
     // Only emit resolve if no new task was registered during execution

--- a/src/agent/runtime/ManualRetryController.ts
+++ b/src/agent/runtime/ManualRetryController.ts
@@ -115,7 +115,7 @@ export function cancelManualRetry(key: string): boolean {
       task.cancel();
     } catch (error) {
       task.logger.error(`Cancel callback failed for ${task.operation}`, {
-        messageType: MESSAGE_TYPES.PROGRESS_STATUS,
+        messageType: MESSAGE_TYPES.ERROR,
         data: { model: task.model, operation: task.operation, error },
       });
     }
@@ -162,7 +162,7 @@ export async function triggerManualRetry(key: string): Promise<boolean> {
     return true;
   } catch (error) {
     task.logger.error(`Retry failed for ${task.operation}`, {
-      messageType: MESSAGE_TYPES.PROGRESS_STATUS,
+      messageType: MESSAGE_TYPES.ERROR,
       data: { model: task.model, operation: task.operation, error },
     });
     return false;

--- a/src/agent/runtime/ManualRetryController.ts
+++ b/src/agent/runtime/ManualRetryController.ts
@@ -13,7 +13,8 @@
  * 4. Or: timeout/cancel → cleanup calls `removeRetryTask` and emits 'resolveRetryRequest'
  */
 
-// Local imports - logging
+// Local imports
+import { buildErrorLogData } from '@common/errors/sdkErrorUtils';
 import type { AgentLogger } from '@logger/AgentLogger';
 import { MESSAGE_TYPES } from '@logger/messageTypes';
 import { bus } from '@eventBus/ProgressEventBus';
@@ -114,9 +115,13 @@ export function cancelManualRetry(key: string): boolean {
     try {
       task.cancel();
     } catch (error) {
+      const errorData = buildErrorLogData(error, {
+        operation: task.operation,
+        model: task.model,
+      });
       task.logger.error(`Cancel callback failed for ${task.operation}`, {
         messageType: MESSAGE_TYPES.ERROR,
-        data: { model: task.model, operation: task.operation, error },
+        data: errorData,
       });
     }
   }
@@ -161,9 +166,13 @@ export async function triggerManualRetry(key: string): Promise<boolean> {
     });
     return true;
   } catch (error) {
+    const errorData = buildErrorLogData(error, {
+      operation: task.operation,
+      model: task.model,
+    });
     task.logger.error(`Retry failed for ${task.operation}`, {
       messageType: MESSAGE_TYPES.ERROR,
-      data: { model: task.model, operation: task.operation, error },
+      data: errorData,
     });
     return false;
   } finally {

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -36,11 +36,10 @@ import type { StreamTabId, ExecutionId } from '@agent/types/IdentifierTypes';
 import { STREAM_STATUS } from '@common/constants/streamStatus';
 import { normalizeRunId } from '@common/constants/runIds';
 import { toErrorMessage } from '@common/errors/errorHandlingUtils';
-import { buildErrorLogData } from '@common/errors/sdkErrorUtils';
+import { getSdkErrorMessage } from '@common/errors/sdkErrorUtils';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands';
 import { showInstructionWithSuppress } from '@frontend/ui/instruction';
 import { AgentLogger } from '@logger/AgentLogger';
-import { MESSAGE_TYPES } from '@logger/messageTypes';
 import { MODEL_CONFIGS } from '@model/ModelRegistry';
 import { ProgressViewProvider } from '@progressView/ProgressViewProvider';
 import { agentConfigToTaskState } from '@utils/config';
@@ -506,9 +505,10 @@ export async function executeAgentWithLogging<T extends IAgent>(
       { skip: isResume },
     );
   } catch (err) {
-    const errorData = buildErrorLogData(err, { operation: `execute ${agentName}` });
     const rawErrorMessage = toErrorMessage(err);
-    const errorMsg = `Error executing agent ${agentName}: ${errorData.message}`;
+    const formattedMessage = getSdkErrorMessage(err);
+    const errorMsg = `Error executing agent ${agentName}: ${formattedMessage}`;
+    const errorContext = { operation: `execute ${agentName}` };
 
     // Check if the error is related to missing API key
     if (
@@ -550,10 +550,7 @@ export async function executeAgentWithLogging<T extends IAgent>(
       await errorLogger.withExistingGroup(
         fallbackGroupId,
         async () => {
-          errorLogger.error(errorMsg, {
-            messageType: MESSAGE_TYPES.ERROR,
-            data: errorData,
-          });
+          errorLogger.logError(errorMsg, err, errorContext);
         },
         { label: `Error: ${agentName}` },
       );
@@ -561,10 +558,7 @@ export async function executeAgentWithLogging<T extends IAgent>(
       await errorLogger.withScope(
         `Error: ${agentName}`,
         async () => {
-          errorLogger.error(errorMsg, {
-            messageType: MESSAGE_TYPES.ERROR,
-            data: errorData,
-          });
+          errorLogger.logError(errorMsg, err, errorContext);
         },
         { errorStatus: 'error' },
       );

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -498,7 +498,7 @@ export async function executeAgentWithLogging<T extends IAgent>(
           logger.debug(`Task completed successfully`);
           StreamStatusService.set(activeStreamId, STREAM_STATUS.STOPPED);
         } catch (err) {
-          logger.error(`Task failed: ${toErrorMessage(err)}`);
+          // Don't log error here - it will be logged with full details in the outer catch block
           StreamStatusService.set(activeStreamId, STREAM_STATUS.ERROR);
           throw err;
         }
@@ -539,47 +539,37 @@ export async function executeAgentWithLogging<T extends IAgent>(
       vscode.window.showErrorMessage(errorMsg);
     }
 
-    const agentLoggerFallback =
+    // Use the agent's logger if available (has group context), otherwise use main logger
+    const errorLogger =
       executionContext?.logger ??
       contextLogger ??
-      (streamTabId ? new AgentLogger(streamTabId, true) : undefined);
-    if (agentLoggerFallback) {
-      const fallbackGroupId = agent?.getLastRunGroupId();
-      if (fallbackGroupId) {
-        await agentLoggerFallback.withExistingGroup(
-          fallbackGroupId,
-          async () => {
-            agentLoggerFallback.error(errorMsg, {
-              messageType: MESSAGE_TYPES.PROGRESS_STATUS,
-              data: errorData,
-            });
-          },
-          { label: `Error: ${agentName}` },
-        );
-      } else {
-        await agentLoggerFallback.withScope(
-          `Error: ${agentName}`,
-          async () => {
-            agentLoggerFallback.error(errorMsg, {
-              messageType: MESSAGE_TYPES.PROGRESS_STATUS,
-              data: errorData,
-            });
-          },
-          { errorStatus: 'error' },
-        );
-      }
-    }
+      (streamTabId ? new AgentLogger(streamTabId, true) : undefined) ??
+      logger;
 
-    await logger.withScope(
-      `Error: ${agentName}`,
-      async () => {
-        logger.error(errorMsg, {
-          messageType: MESSAGE_TYPES.PROGRESS_STATUS,
-          data: errorData,
-        });
-      },
-      { errorStatus: 'error' },
-    );
+    const fallbackGroupId = agent?.getLastRunGroupId();
+    if (fallbackGroupId && errorLogger !== logger) {
+      await errorLogger.withExistingGroup(
+        fallbackGroupId,
+        async () => {
+          errorLogger.error(errorMsg, {
+            messageType: MESSAGE_TYPES.ERROR,
+            data: errorData,
+          });
+        },
+        { label: `Error: ${agentName}` },
+      );
+    } else {
+      await errorLogger.withScope(
+        `Error: ${agentName}`,
+        async () => {
+          errorLogger.error(errorMsg, {
+            messageType: MESSAGE_TYPES.ERROR,
+            data: errorData,
+          });
+        },
+        { errorStatus: 'error' },
+      );
+    }
     throw new Error(errorMsg);
   }
 }

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -36,7 +36,7 @@ import type { StreamTabId, ExecutionId } from '@agent/types/IdentifierTypes';
 import { STREAM_STATUS } from '@common/constants/streamStatus';
 import { normalizeRunId } from '@common/constants/runIds';
 import { toErrorMessage } from '@common/errors/errorHandlingUtils';
-import { formatProviderHttpError } from '@common/errors/sdkErrorUtils';
+import { buildErrorLogData } from '@common/errors/sdkErrorUtils';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands';
 import { showInstructionWithSuppress } from '@frontend/ui/instruction';
 import { AgentLogger } from '@logger/AgentLogger';
@@ -506,10 +506,9 @@ export async function executeAgentWithLogging<T extends IAgent>(
       { skip: isResume },
     );
   } catch (err) {
-    const formattedError = formatProviderHttpError(err);
+    const errorData = buildErrorLogData(err, { operation: `execute ${agentName}` });
     const rawErrorMessage = toErrorMessage(err);
-    const errorMsg = `Error executing agent ${agentName}: ${formattedError.message}`;
-    const errorData = { ...formattedError, rawMessage: rawErrorMessage };
+    const errorMsg = `Error executing agent ${agentName}: ${errorData.message}`;
 
     // Check if the error is related to missing API key
     if (

--- a/src/common/errors/index.ts
+++ b/src/common/errors/index.ts
@@ -11,6 +11,9 @@ export {
 } from './errorHandlingUtils';
 export {
   ProviderHttpErrorDetails,
+  ErrorLogContext,
+  ErrorLogData,
   formatProviderHttpError,
   getSdkErrorMessage,
+  buildErrorLogData,
 } from './sdkErrorUtils';

--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -517,3 +517,45 @@ export function formatProviderHttpError(
 export function getSdkErrorMessage(err: unknown): string {
   return formatProviderHttpError(err).message;
 }
+
+/**
+ * Context for building error log data.
+ */
+export interface ErrorLogContext {
+  /** The operation that failed (e.g., 'API request', 'manual retry'). */
+  operation?: string;
+  /** The model being used when the error occurred. */
+  model?: string;
+}
+
+/**
+ * Structured data for error log messages.
+ * Used by progressView formatters to display error details.
+ */
+export interface ErrorLogData extends ProviderHttpErrorDetails {
+  /** Raw error message before formatting. */
+  rawMessage?: string;
+  /** The operation that failed. */
+  operation?: string;
+  /** The model being used. */
+  model?: string;
+}
+
+/**
+ * Builds consistent error data for logging with MESSAGE_TYPES.ERROR.
+ * Ensures all error logs have the same structure for DRY display formatting.
+ */
+export function buildErrorLogData(
+  err: unknown,
+  context?: ErrorLogContext,
+): ErrorLogData {
+  const formatted = formatProviderHttpError(err);
+  const rawMessage = err instanceof Error ? err.message : String(err);
+
+  return {
+    ...formatted,
+    rawMessage: rawMessage !== formatted.message ? rawMessage : undefined,
+    operation: context?.operation,
+    model: context?.model,
+  };
+}

--- a/src/logger/AgentLogger.ts
+++ b/src/logger/AgentLogger.ts
@@ -6,6 +6,10 @@ import { encode as encodeHtml } from 'he';
 import type { ExtendedTokenUsageStats } from '@agent/types/UsageTypes';
 
 // Internal imports
+import {
+  buildErrorLogData,
+  type ErrorLogContext,
+} from '@common/errors/sdkErrorUtils';
 import { sleep } from '@utils/helpers';
 import { SHORT_SLEEP_MS } from '@utils/config';
 import { bus } from '@eventBus/ProgressEventBus';
@@ -211,6 +215,66 @@ export class AgentLogger {
       messageType: options.messageType,
       isAgent: this.isAgentLogger,
       data: options.data,
+    });
+  }
+
+  /**
+   * Log a structured error with consistent formatting.
+   * Single source of truth for ERROR message type logging.
+   *
+   * @param message - Human-readable error description
+   * @param err - The error object to format
+   * @param context - Optional context (operation, model)
+   * @param groupId - Optional group ID for progress view
+   */
+  logError(
+    message: string,
+    err: unknown,
+    context?: ErrorLogContext,
+    groupId?: string,
+  ): void {
+    const errorData = buildErrorLogData(err, context);
+    this.error(message, {
+      groupId,
+      messageType: MESSAGE_TYPES.ERROR,
+      data: errorData,
+    });
+  }
+
+  /**
+   * Log a progress status update.
+   * Single source of truth for PROGRESS_STATUS message type logging.
+   *
+   * @param message - Status message
+   * @param context - Optional context (operation, model)
+   * @param groupId - Optional group ID for progress view
+   */
+  logProgress(
+    message: string,
+    context?: ErrorLogContext,
+    groupId?: string,
+  ): void {
+    this.info(message, {
+      groupId,
+      messageType: MESSAGE_TYPES.PROGRESS_STATUS,
+      data: context,
+    });
+  }
+
+  /**
+   * Log a structured error with pre-formatted error data.
+   * Use this when error data is already structured (e.g., RetryErrorInfo).
+   * For raw errors, use logError() instead.
+   *
+   * @param message - Human-readable error description
+   * @param errorData - Pre-structured error data
+   * @param groupId - Optional group ID for progress view
+   */
+  logErrorData(message: string, errorData: unknown, groupId?: string): void {
+    this.error(message, {
+      groupId,
+      messageType: MESSAGE_TYPES.ERROR,
+      data: errorData,
     });
   }
 

--- a/src/logger/AgentLogger.ts
+++ b/src/logger/AgentLogger.ts
@@ -279,6 +279,39 @@ export class AgentLogger {
   }
 
   /**
+   * Log an internal/system message (hidden in normal mode, shown in debug).
+   * Single source of truth for INTERNAL message type.
+   */
+  logInternal(message: string, groupId?: string): void {
+    this.info(message, {
+      groupId,
+      messageType: MESSAGE_TYPES.INTERNAL,
+    });
+  }
+
+  /**
+   * Log an internal debug message (hidden in normal mode, shown in debug).
+   * Single source of truth for INTERNAL message type at debug level.
+   */
+  debugInternal(message: string, groupId?: string): void {
+    this.debug(message, {
+      groupId,
+      messageType: MESSAGE_TYPES.INTERNAL,
+    });
+  }
+
+  /**
+   * Log scratchpad/thinking content.
+   * Single source of truth for SCRATCHPAD message type.
+   */
+  logScratchpad(content: string, groupId?: string): void {
+    this.info(content, {
+      groupId,
+      messageType: MESSAGE_TYPES.SCRATCHPAD,
+    });
+  }
+
+  /**
    * Log a list of files that were processed.
    */
   fileList(files: unknown[], groupId?: string): void {

--- a/src/logger/LogTypes.ts
+++ b/src/logger/LogTypes.ts
@@ -44,6 +44,7 @@ export interface LogMessageData {
     | 'toolUse'
     | 'userMessage'
     | 'progressStatus'
+    | 'error'
     | 'internal';
   /** Whether verbose details should be displayed */
   verbose?: boolean;

--- a/src/logger/messageTypes.ts
+++ b/src/logger/messageTypes.ts
@@ -9,6 +9,8 @@ export const MESSAGE_TYPES = {
   MODEL_RESPONSE: 'modelResponse',
   USER_MESSAGE: 'userMessage',
   PROGRESS_STATUS: 'progressStatus',
+  /** Error messages displayed as foldable banners */
+  ERROR: 'error',
   /** Internal/system messages used by the extension */
   INTERNAL: 'internal',
   DEFAULT: 'default',

--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -294,6 +294,58 @@ const normalizeToolUseLog = (structured) => {
   };
 };
 
+// =============================================================================
+// Helper Functions - DRY patterns extracted from formatters
+// =============================================================================
+
+/**
+ * Extract and trim content from normalized payload
+ * @param {Object} normalizedPayload - The normalized payload object
+ * @returns {{decoded: string, trimmed: string, isEmpty: boolean}}
+ */
+const extractTrimmedContent = (normalizedPayload) => {
+  const decoded = normalizedPayload?.decodedText || '';
+  const trimmed = decoded.trim();
+  return { decoded, trimmed, isEmpty: !trimmed };
+};
+
+/**
+ * Build a tool-use section HTML block
+ * @param {string} label - The section label (e.g., "Input:", "Output:")
+ * @param {string} content - The HTML content for the section
+ * @returns {string} HTML string for the section
+ */
+const buildToolUseSection = (label, content) => `
+  <div class="tool-use-section">
+    <div class="tool-use-subsection">
+      <span class="tool-use-sublabel">${label}</span>
+      ${content}
+    </div>
+  </div>
+`;
+
+/**
+ * Wrap text in a pre element with optional class
+ * @param {string} text - Text to wrap (will be HTML encoded)
+ * @param {string} [className] - Optional CSS class
+ * @returns {string} HTML string
+ */
+const wrapInPre = (text, className = '') => {
+  const classAttr = className ? ` class="${className}"` : '';
+  return `<pre${classAttr}>${encodeHtml(text)}</pre>`;
+};
+
+/**
+ * Set common dataset attributes on an element
+ * @param {HTMLElement} element - The element to modify
+ * @param {{logId?: string, groupId?: string, timestamp?: string}} data - Dataset values
+ */
+const setElementDataset = (element, { logId, groupId, timestamp }) => {
+  if (logId) element.dataset.logId = logId;
+  if (groupId) element.dataset.groupId = groupId;
+  if (timestamp) element.dataset.fullTimestamp = timestamp;
+};
+
 /**
  * Represents different task group hierarchy levels with associated behaviors
  */
@@ -661,10 +713,9 @@ export class LogEntryFormatter {
     groupId,
     timestamp,
   ) {
-    const decodedContent = normalizedPayload?.decodedText || '';
-    const trimmedContent = decodedContent.trim();
-
-    if (!trimmedContent) return null;
+    const { trimmed: trimmedContent, isEmpty } =
+      extractTrimmedContent(normalizedPayload);
+    if (isEmpty) return null;
 
     const parsedMarkdown = this._processMarkdownContent(trimmedContent);
     const isThinking = contentType.includes('Thinking');
@@ -695,9 +746,7 @@ export class LogEntryFormatter {
     const element = createFromTemplate('toolUseTemplate');
     if (!element) return null;
 
-    if (logId) element.dataset.logId = logId;
-    if (groupId) element.dataset.groupId = groupId;
-    if (timestamp) element.dataset.fullTimestamp = timestamp;
+    setElementDataset(element, { logId, groupId, timestamp });
 
     const headerLabel = element.querySelector('.tool-use-title');
     const iconElem = headerLabel ? headerLabel.previousElementSibling : null;
@@ -747,55 +796,32 @@ export class LogEntryFormatter {
 
     if (input !== undefined) {
       const inputValue = stringifyForDisplay(input);
-      sections.push(`
-        <div class="tool-use-section">
-          <div class="tool-use-subsection">
-            <span class="tool-use-sublabel">Input:</span>
-            <pre>${encodeHtml(inputValue)}</pre>
-          </div>
-        </div>
-      `);
+      sections.push(buildToolUseSection('Input:', wrapInPre(inputValue)));
     }
 
     if (files && files.length > 0) {
       const renderData = buildFileListRender(files);
       if (renderData?.items) {
-        sections.push(`
-          <div class="tool-use-section">
-            <div class="tool-use-subsection">
-              <span class="tool-use-sublabel">Edited files:</span>
-              <span class="file-list-summary">${encodeHtml(renderData.summary)}</span>
-              <ul class="detail-list">${renderData.items}</ul>
-            </div>
-          </div>
-        `);
+        const fileContent = `
+          <span class="file-list-summary">${encodeHtml(renderData.summary)}</span>
+          <ul class="detail-list">${renderData.items}</ul>
+        `;
+        sections.push(buildToolUseSection('Edited files:', fileContent));
       }
     }
 
     if (errorText) {
-      sections.push(`
-        <div class="tool-use-section">
-          <div class="tool-use-subsection">
-            <span class="tool-use-sublabel">Error:</span>
-            <pre>${encodeHtml(errorText)}</pre>
-          </div>
-        </div>
-      `);
+      sections.push(buildToolUseSection('Error:', wrapInPre(errorText)));
     } else if (outputText) {
-      sections.push(`
-        <div class="tool-use-section">
-          <div class="tool-use-subsection">
-            <span class="tool-use-sublabel">Output:</span>
-            <pre class="tool-output-full">${encodeHtml(outputText)}</pre>
-          </div>
-        </div>
-      `);
+      sections.push(
+        buildToolUseSection('Output:', wrapInPre(outputText, 'tool-output-full')),
+      );
     }
 
     const fallbackYaml = stringifyForDisplay(parsed);
     contentElem.innerHTML =
       sections.length === 0
-        ? `<pre>${encodeHtml(fallbackYaml || '')}</pre>`
+        ? wrapInPre(fallbackYaml || '')
         : sections.join('<hr class="tool-use-separator">');
 
     return element;

--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -1307,24 +1307,27 @@ export class LogEntryFormatter {
       (normalizedPayload.decodedText || message.text || '').trim() ||
       'Error occurred';
 
-    // Build error details from structured data
+    // Build error details from structured data - order defines display priority
     const structured = normalizedPayload.structured || {};
-    const detailLines = [];
+    const fieldConfig = [
+      { key: 'message', skip: (v) => v === summaryText },
+      { key: 'operation' },
+      { key: 'model' },
+      { key: 'provider' },
+      { key: 'statusCode' },
+      { key: 'retryable' },
+      { key: 'rawMessage' },
+      { key: 'requestId' },
+    ];
 
-    if (structured.message && structured.message !== summaryText) {
-      detailLines.push(`message: ${structured.message}`);
-    }
-    if (structured.provider) {
-      detailLines.push(`provider: ${structured.provider}`);
-    }
-    if (structured.rawMessage) {
-      detailLines.push(`rawMessage: ${structured.rawMessage}`);
-    }
-    if (structured.statusCode) {
-      detailLines.push(`statusCode: ${structured.statusCode}`);
-    }
+    const detailLines = fieldConfig
+      .filter(({ key, skip }) => {
+        const value = structured[key];
+        return value !== undefined && value !== null && (!skip || !skip(value));
+      })
+      .map(({ key }) => `${key}: ${structured[key]}`);
 
-    const detailText = detailLines.length > 0 ? detailLines.join('\n') : '';
+    const detailText = detailLines.join('\n');
 
     const bannerEntry = this._createBannerEntry({
       logId: message.id,

--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -900,10 +900,7 @@ export class LogEntryFormatter {
     if (!element) return null;
 
     this._applyOpenState(element, Boolean(open));
-
-    if (logId) element.dataset.logId = logId;
-    if (groupId) element.dataset.groupId = groupId;
-    if (timestamp) element.dataset.fullTimestamp = timestamp;
+    setElementDataset(element, { logId, groupId, timestamp });
 
     const iconElem = element.querySelector('.icon');
     if (iconElem) {
@@ -1273,9 +1270,11 @@ export class LogEntryFormatter {
     const emoji = EMOJI_BY_LEVEL[severity] || '•';
 
     const container = document.createElement('div');
-    container.dataset.fullTimestamp = fullTimestamp;
-    if (message.id) container.dataset.logId = message.id;
-    if (message.groupId) container.dataset.groupId = message.groupId;
+    setElementDataset(container, {
+      logId: message.id,
+      groupId: message.groupId,
+      timestamp: fullTimestamp,
+    });
 
     const summaryLine = document.createElement('div');
     summaryLine.className = 'log-line';

--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -452,6 +452,11 @@ export class LogEntryFormatter {
           () => this._formatProgressStatus(message),
           'progress status',
         ),
+      error: (message) =>
+        this._safeFormat(
+          () => this._formatError(message),
+          'error',
+        ),
     };
   }
 
@@ -1259,6 +1264,87 @@ export class LogEntryFormatter {
     }
 
     return container;
+  }
+
+  /**
+   * Format an error message as a foldable banner
+   * @private
+   * @param {Object} message - The message object
+   * @returns {HTMLElement|null} DOM element for the error banner
+   */
+  _formatError(message) {
+    const normalizedPayload = message.normalizedPayload || {};
+    const date = new Date(message.timestamp ?? Date.now());
+    const { fullTimestamp, timeDisplay, tooltipTimestamp } =
+      this._formatTimestamp(date);
+
+    const summaryText =
+      (normalizedPayload.decodedText || message.text || '').trim() ||
+      'Error occurred';
+
+    // Build error details from structured data
+    const structured = normalizedPayload.structured || {};
+    const detailLines = [];
+
+    if (structured.message && structured.message !== summaryText) {
+      detailLines.push(`message: ${structured.message}`);
+    }
+    if (structured.provider) {
+      detailLines.push(`provider: ${structured.provider}`);
+    }
+    if (structured.rawMessage) {
+      detailLines.push(`rawMessage: ${structured.rawMessage}`);
+    }
+    if (structured.statusCode) {
+      detailLines.push(`statusCode: ${structured.statusCode}`);
+    }
+
+    const detailText = detailLines.length > 0 ? detailLines.join('\n') : '';
+
+    const bannerEntry = this._createBannerEntry({
+      logId: message.id,
+      groupId: message.groupId,
+      timestamp: fullTimestamp,
+      iconClass: 'codicon-error',
+      labelText: `[${timeDisplay}] ${summaryText}`,
+      copyTitle: 'Copy error details',
+      contentClass: 'banner-content--error',
+      open: false,
+    });
+
+    if (!bannerEntry || !bannerEntry.element) {
+      return null;
+    }
+
+    // Add error class to the banner
+    bannerEntry.element.classList.add('banner-details--error');
+
+    // If there are no details, hide the copy button and make it non-expandable
+    if (!detailText) {
+      if (bannerEntry.copyButton) {
+        bannerEntry.copyButton.style.display = 'none';
+      }
+      // Remove toggle icon for non-expandable entries
+      const toggleIcon = bannerEntry.element.querySelector('.toggle-icon');
+      if (toggleIcon) {
+        toggleIcon.style.visibility = 'hidden';
+      }
+    }
+
+    if (bannerEntry.contentElem) {
+      bannerEntry.contentElem.dataset.rawContent = detailText || summaryText;
+      if (detailText) {
+        bannerEntry.contentElem.innerHTML = `<pre class="error-details">${encodeHtml(detailText)}</pre>`;
+      }
+    }
+
+    // Add timestamp tooltip to the label
+    const labelElem = bannerEntry.element.querySelector('.label');
+    if (labelElem) {
+      labelElem.title = tooltipTimestamp;
+    }
+
+    return bannerEntry.element;
   }
 
   _formatUserMessage(normalizedPayload, logId, timestamp) {

--- a/src/progressView/styles/approval-requests.css
+++ b/src/progressView/styles/approval-requests.css
@@ -1,53 +1,24 @@
+/**
+ * Approval requests - component-specific styles only
+ * Shared styles are in requests-shared.css
+ */
+
+/* Container theme */
 .approval-requests {
-  margin: 0.75rem 0;
-  padding: 0.75rem;
-  border-radius: 6px;
   border: 1px solid var(--vscode-input-border);
   background: var(--vscode-editor-background);
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
-  display: none;
-  flex-direction: column;
-  gap: 0.75rem;
-}
-
-.approval-requests.is-visible {
-  display: flex;
-}
-
-.approval-requests__header {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  font-weight: 600;
-  color: var(--vscode-editor-foreground);
 }
 
 .approval-requests__header .codicon {
   color: var(--vscode-editor-foreground);
 }
 
-.approval-requests__list {
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
+/* Button flex basis */
+.approval-request__actions vscode-toolbar-button {
+  flex: 1 1 12rem;
 }
 
-.approval-request {
-  border-radius: 4px;
-  border: 1px solid var(--vscode-editorHoverWidget-border);
-  background: var(--vscode-editorHoverWidget-background);
-  padding: 0.75rem;
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-}
-
-.approval-request__details {
-  display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
-}
-
+/* File path styling */
 .approval-request__path {
   font-family: var(--vscode-editor-font-family);
   font-size: 0.85rem;
@@ -55,15 +26,7 @@
   word-break: break-word;
 }
 
-.approval-request__meta {
-  font-size: 0.8rem;
-  color: var(--vscode-descriptionForeground);
-  display: flex;
-  align-items: center;
-  gap: 0.4rem;
-  flex-wrap: wrap;
-}
-
+/* Diff stats */
 .approval-request__diff {
   display: inline-flex;
   align-items: baseline;
@@ -84,30 +47,4 @@
   color: var(--vscode-descriptionForeground);
   font-size: 0.75rem;
   opacity: 0.9;
-}
-
-.approval-request__actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.35rem;
-}
-
-.approval-request__actions::part(container) {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.35rem;
-}
-
-.approval-request__actions vscode-toolbar-button {
-  min-width: auto;
-  flex: 1 1 12rem;
-}
-
-.approval-request__actions vscode-toolbar-button::part(control) {
-  justify-content: flex-start;
-  gap: 0.35rem;
-}
-
-.approval-request__actions [hidden] {
-  display: none !important;
 }

--- a/src/progressView/styles/index.css
+++ b/src/progressView/styles/index.css
@@ -6,6 +6,9 @@
 /* Import base styles */
 @import './base.css';
 
+/* Import utility classes (must come before components) */
+@import './utilities.css';
+
 /* Import component styles */
 @import './tabs.css';
 @import './buttons.css';
@@ -21,5 +24,6 @@
 @import './user-message.css';
 @import './follow-up-input.css';
 @import './instruction-panel.css';
+@import './requests-shared.css';
 @import './approval-requests.css';
 @import './retry-requests.css';

--- a/src/progressView/styles/instruction-panel.css
+++ b/src/progressView/styles/instruction-panel.css
@@ -40,10 +40,9 @@
   gap: var(--spacing-small);
 }
 
-/* Copy button - base in utilities.css */
+/* Copy button - transition/success handled in utilities.css */
 .instruction-panel__copy {
   opacity: 0.65;
-  transition: opacity 0.2s ease, color 0.2s ease;
 }
 
 .instruction-panel:hover .instruction-panel__copy {

--- a/src/progressView/styles/instruction-panel.css
+++ b/src/progressView/styles/instruction-panel.css
@@ -40,21 +40,14 @@
   gap: var(--spacing-small);
 }
 
+/* Copy button - base in utilities.css */
 .instruction-panel__copy {
   opacity: 0.65;
-  transition:
-    opacity 0.2s ease,
-    color 0.2s ease;
+  transition: opacity 0.2s ease, color 0.2s ease;
 }
 
-.instruction-panel:hover .instruction-panel__copy,
-.instruction-panel__copy:focus-visible,
-.instruction-panel__copy.copy-success {
+.instruction-panel:hover .instruction-panel__copy {
   opacity: 1;
-}
-
-.instruction-panel__copy.copy-success {
-  color: var(--vscode-testing-iconPassed, #2ea043);
 }
 
 .instruction-panel__body {

--- a/src/progressView/styles/logs.css
+++ b/src/progressView/styles/logs.css
@@ -28,24 +28,17 @@
   overflow: visible;
 }
 
-/* Banner copy button styling */
+/* Banner copy button styling - base in utilities.css */
 .banner-content-copy {
   min-width: 0;
   padding: 0 var(--spacing-tiny);
   opacity: 0;
-  transition: opacity 0.2s ease;
   margin-left: auto;
 }
 
 .details-summary:hover .banner-content-copy,
-.banner-details:focus-within .banner-content-copy,
-.banner-content-copy:focus-visible,
-.banner-content-copy.copy-success {
+.banner-details:focus-within .banner-content-copy {
   opacity: 1;
-}
-
-.banner-content-copy.copy-success {
-  color: var(--vscode-testing-iconPassed);
 }
 
 /* Timestamp color */

--- a/src/progressView/styles/requests-shared.css
+++ b/src/progressView/styles/requests-shared.css
@@ -1,6 +1,6 @@
 /**
  * Shared styles for approval-requests and retry-requests
- * DRY consolidation of common patterns
+ * Uses CSS variables from common.css
  */
 
 /* ==========================================================================
@@ -9,13 +9,13 @@
 
 .approval-requests,
 .retry-requests {
-  margin: 0.75rem 0;
-  padding: 0.75rem;
-  border-radius: 6px;
+  margin: var(--spacing-large) 0;
+  padding: var(--spacing-large);
+  border-radius: var(--border-radius-large);
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
   display: none;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: var(--spacing-large);
 }
 
 .approval-requests.is-visible,
@@ -31,46 +31,42 @@
 .retry-requests__header {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--spacing-medium);
   font-weight: 600;
   color: var(--vscode-editor-foreground);
 }
 
 /* ==========================================================================
-   Lists
+   Lists & Items
    ========================================================================== */
 
 .approval-requests__list,
-.retry-requests__list {
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
-}
-
-/* ==========================================================================
-   Individual Items
-   ========================================================================== */
-
+.retry-requests__list,
 .approval-request,
-.retry-request {
-  border-radius: 4px;
-  border: 1px solid var(--vscode-editorHoverWidget-border);
-  background: var(--vscode-editorHoverWidget-background);
-  padding: 0.75rem;
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-}
-
-/* ==========================================================================
-   Details Sections
-   ========================================================================== */
-
+.retry-request,
 .approval-request__details,
 .retry-request__details {
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
+}
+
+.approval-requests__list,
+.retry-requests__list {
+  gap: var(--spacing-large);
+}
+
+.approval-request,
+.retry-request {
+  border-radius: var(--border-radius);
+  border: var(--border-thin) solid var(--vscode-editorHoverWidget-border);
+  background: var(--vscode-editorHoverWidget-background);
+  padding: var(--spacing-large);
+  gap: var(--spacing-medium);
+}
+
+.approval-request__details,
+.retry-request__details {
+  gap: var(--spacing-small);
 }
 
 /* ==========================================================================
@@ -79,11 +75,11 @@
 
 .approval-request__meta,
 .retry-request__meta {
-  font-size: 0.8rem;
+  font-size: var(--font-size-sm);
   color: var(--vscode-descriptionForeground);
   display: flex;
   align-items: center;
-  gap: 0.4rem;
+  gap: var(--spacing-small);
   flex-wrap: wrap;
 }
 
@@ -95,14 +91,14 @@
 .retry-request__actions {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.35rem;
+  gap: var(--spacing-small);
 }
 
 .approval-request__actions::part(container),
 .retry-request__actions::part(container) {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.35rem;
+  gap: var(--spacing-small);
 }
 
 .approval-request__actions vscode-toolbar-button,
@@ -113,7 +109,7 @@
 .approval-request__actions vscode-toolbar-button::part(control),
 .retry-request__actions vscode-toolbar-button::part(control) {
   justify-content: flex-start;
-  gap: 0.35rem;
+  gap: var(--spacing-small);
 }
 
 .approval-request__actions [hidden],

--- a/src/progressView/styles/requests-shared.css
+++ b/src/progressView/styles/requests-shared.css
@@ -1,0 +1,122 @@
+/**
+ * Shared styles for approval-requests and retry-requests
+ * DRY consolidation of common patterns
+ */
+
+/* ==========================================================================
+   Container Panels
+   ========================================================================== */
+
+.approval-requests,
+.retry-requests {
+  margin: 0.75rem 0;
+  padding: 0.75rem;
+  border-radius: 6px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
+  display: none;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.approval-requests.is-visible,
+.retry-requests.is-visible {
+  display: flex;
+}
+
+/* ==========================================================================
+   Headers
+   ========================================================================== */
+
+.approval-requests__header,
+.retry-requests__header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 600;
+  color: var(--vscode-editor-foreground);
+}
+
+/* ==========================================================================
+   Lists
+   ========================================================================== */
+
+.approval-requests__list,
+.retry-requests__list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+/* ==========================================================================
+   Individual Items
+   ========================================================================== */
+
+.approval-request,
+.retry-request {
+  border-radius: 4px;
+  border: 1px solid var(--vscode-editorHoverWidget-border);
+  background: var(--vscode-editorHoverWidget-background);
+  padding: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+/* ==========================================================================
+   Details Sections
+   ========================================================================== */
+
+.approval-request__details,
+.retry-request__details {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+/* ==========================================================================
+   Metadata
+   ========================================================================== */
+
+.approval-request__meta,
+.retry-request__meta {
+  font-size: 0.8rem;
+  color: var(--vscode-descriptionForeground);
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  flex-wrap: wrap;
+}
+
+/* ==========================================================================
+   Actions
+   ========================================================================== */
+
+.approval-request__actions,
+.retry-request__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+.approval-request__actions::part(container),
+.retry-request__actions::part(container) {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+.approval-request__actions vscode-toolbar-button,
+.retry-request__actions vscode-toolbar-button {
+  min-width: auto;
+}
+
+.approval-request__actions vscode-toolbar-button::part(control),
+.retry-request__actions vscode-toolbar-button::part(control) {
+  justify-content: flex-start;
+  gap: 0.35rem;
+}
+
+.approval-request__actions [hidden],
+.retry-request__actions [hidden] {
+  display: none !important;
+}

--- a/src/progressView/styles/retry-requests.css
+++ b/src/progressView/styles/retry-requests.css
@@ -1,53 +1,24 @@
+/**
+ * Retry requests - component-specific styles only
+ * Shared styles are in requests-shared.css
+ */
+
+/* Container theme - warning style */
 .retry-requests {
-  margin: 0.75rem 0;
-  padding: 0.75rem;
-  border-radius: 6px;
   border: 1px solid var(--vscode-inputValidation-warningBorder, #856404);
   background: var(--vscode-inputValidation-warningBackground, #fff3cd);
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
-  display: none;
-  flex-direction: column;
-  gap: 0.75rem;
-}
-
-.retry-requests.is-visible {
-  display: flex;
-}
-
-.retry-requests__header {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  font-weight: 600;
-  color: var(--vscode-editor-foreground);
 }
 
 .retry-requests__header .codicon {
   color: var(--vscode-notificationsWarningIcon-foreground, #cca700);
 }
 
-.retry-requests__list {
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
+/* Button flex basis */
+.retry-request__actions vscode-toolbar-button {
+  flex: 1 1 8rem;
 }
 
-.retry-request {
-  border-radius: 4px;
-  border: 1px solid var(--vscode-editorHoverWidget-border);
-  background: var(--vscode-editorHoverWidget-background);
-  padding: 0.75rem;
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-}
-
-.retry-request__details {
-  display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
-}
-
+/* Operation label */
 .retry-request__operation {
   font-family: var(--vscode-editor-font-family);
   font-size: 0.85rem;
@@ -55,46 +26,12 @@
   font-weight: 500;
 }
 
-.retry-request__meta {
-  font-size: 0.8rem;
-  color: var(--vscode-descriptionForeground);
-  display: flex;
-  align-items: center;
-  gap: 0.4rem;
-  flex-wrap: wrap;
-}
-
+/* Error message */
 .retry-request__error {
   font-size: 0.8rem;
-  color: var(--vscode-errorForeground, #f14c4c);
+  color: var(--vscode-editorError-foreground, #f14c4c);
   word-break: break-word;
   max-height: 4em;
   overflow: hidden;
   text-overflow: ellipsis;
-}
-
-.retry-request__actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.35rem;
-}
-
-.retry-request__actions::part(container) {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.35rem;
-}
-
-.retry-request__actions vscode-toolbar-button {
-  min-width: auto;
-  flex: 1 1 8rem;
-}
-
-.retry-request__actions vscode-toolbar-button::part(control) {
-  justify-content: flex-start;
-  gap: 0.35rem;
-}
-
-.retry-request__actions [hidden] {
-  display: none !important;
 }

--- a/src/progressView/styles/scratchpad.css
+++ b/src/progressView/styles/scratchpad.css
@@ -37,17 +37,11 @@
   opacity: 0.3;
 }
 
+/* Error styling - shared across tool-use and banner errors */
 .tool-use-error > .details-summary .tool-use-title,
-.tool-use-error > .details-summary .codicon {
-  color: var(--vscode-errorForeground);
-}
-
-/* Error banner styling */
+.tool-use-error > .details-summary .codicon,
 .banner-details--error > .details-summary .label,
-.banner-details--error > .details-summary .codicon {
-  color: var(--vscode-editorError-foreground, #f14c4c);
-}
-
+.banner-details--error > .details-summary .codicon,
 .banner-content--error {
   color: var(--vscode-editorError-foreground, #f14c4c);
 }
@@ -57,6 +51,11 @@
   padding: var(--spacing-small);
   background-color: var(--vscode-inputValidation-errorBackground, rgba(255, 0, 0, 0.1));
   border-radius: var(--radius-small, 4px);
+}
+
+/* Pre-wrapped text content */
+.banner-content--error .error-details,
+.tool-output-full {
   white-space: pre-wrap;
   word-break: break-word;
 }
@@ -64,6 +63,4 @@
 .tool-output-full {
   max-height: var(--height-large);
   overflow: auto;
-  white-space: pre-wrap;
-  word-break: break-word;
 }

--- a/src/progressView/styles/scratchpad.css
+++ b/src/progressView/styles/scratchpad.css
@@ -42,6 +42,25 @@
   color: var(--vscode-errorForeground);
 }
 
+/* Error banner styling */
+.banner-details--error > .details-summary .label,
+.banner-details--error > .details-summary .codicon {
+  color: var(--vscode-editorError-foreground, #f14c4c);
+}
+
+.banner-content--error {
+  color: var(--vscode-editorError-foreground, #f14c4c);
+}
+
+.banner-content--error .error-details {
+  margin: 0;
+  padding: var(--spacing-small);
+  background-color: var(--vscode-inputValidation-errorBackground, rgba(255, 0, 0, 0.1));
+  border-radius: var(--radius-small, 4px);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
 .tool-output-full {
   max-height: var(--height-large);
   overflow: auto;

--- a/src/progressView/styles/utilities.css
+++ b/src/progressView/styles/utilities.css
@@ -1,21 +1,29 @@
 /**
  * Utility classes for ProgressView
- * Reusable patterns to avoid CSS repetition (DRY)
+ * Only structural utilities that can't be expressed with CSS variables
+ *
+ * Spacing, colors, and sizes should use CSS variables from common.css:
+ *   --spacing-tiny, --spacing-small, --spacing-medium, --spacing-large, --spacing-xlarge
+ *   --font-size-sm, --font-size-lg
+ *   --vscode-* color variables
  */
 
 /* ==========================================================================
-   Layout Utilities
+   Layout Utilities - structural only
    ========================================================================== */
 
-/* Flex utilities */
+.flex {
+  display: flex;
+}
+
+.flex-col {
+  display: flex;
+  flex-direction: column;
+}
+
 .flex-center {
   display: flex;
   align-items: center;
-}
-
-.flex-column {
-  display: flex;
-  flex-direction: column;
 }
 
 .flex-wrap {
@@ -23,148 +31,37 @@
   flex-wrap: wrap;
 }
 
-/* Gap utilities */
-.gap-xs {
-  gap: 0.25rem;
-}
-
-.gap-sm {
-  gap: 0.35rem;
-}
-
-.gap-md {
-  gap: 0.5rem;
-}
-
-.gap-lg {
-  gap: 0.75rem;
-}
-
 /* ==========================================================================
-   Text Utilities
+   Text Utilities - structural only
    ========================================================================== */
 
-/* Text truncation */
 .truncate {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-/* Pre-wrapped text */
 .pre-wrap {
   white-space: pre-wrap;
   word-break: break-word;
 }
 
 /* ==========================================================================
-   Visibility Utilities
+   Visibility
    ========================================================================== */
 
-/* Hidden until .is-visible is added */
-.hidden-panel {
+.hidden {
   display: none;
 }
 
-.hidden-panel.is-visible {
+.hidden.is-visible {
   display: flex;
 }
 
 /* ==========================================================================
-   Request Panel Base Styles
-   Shared between approval-requests and retry-requests
+   Interactive - Copy button base behavior
    ========================================================================== */
 
-/* Container panel */
-.request-panel {
-  margin: 0.75rem 0;
-  padding: 0.75rem;
-  border-radius: 6px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
-  display: none;
-  flex-direction: column;
-  gap: 0.75rem;
-}
-
-.request-panel.is-visible {
-  display: flex;
-}
-
-/* Panel header */
-.request-panel__header {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  font-weight: 600;
-  color: var(--vscode-editor-foreground);
-}
-
-/* Panel list container */
-.request-panel__list {
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
-}
-
-/* Individual request item */
-.request-item {
-  border-radius: 4px;
-  border: 1px solid var(--vscode-editorHoverWidget-border);
-  background: var(--vscode-editorHoverWidget-background);
-  padding: 0.75rem;
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-}
-
-/* Request details section */
-.request-item__details {
-  display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
-}
-
-/* Request metadata */
-.request-item__meta {
-  font-size: 0.8rem;
-  color: var(--vscode-descriptionForeground);
-  display: flex;
-  align-items: center;
-  gap: 0.4rem;
-  flex-wrap: wrap;
-}
-
-/* Request actions */
-.request-item__actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.35rem;
-}
-
-.request-item__actions::part(container) {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.35rem;
-}
-
-.request-item__actions vscode-toolbar-button {
-  min-width: auto;
-}
-
-.request-item__actions vscode-toolbar-button::part(control) {
-  justify-content: flex-start;
-  gap: 0.35rem;
-}
-
-.request-item__actions [hidden] {
-  display: none !important;
-}
-
-/* ==========================================================================
-   Copy Button Utilities
-   ========================================================================== */
-
-/* Base copy button behavior - shared transition and success state */
 .banner-content-copy,
 .instruction-panel__copy {
   transition: opacity 0.2s ease;
@@ -180,20 +77,4 @@
 .banner-content-copy.copy-success,
 .instruction-panel__copy.copy-success {
   color: var(--vscode-testing-iconPassed);
-}
-
-/* ==========================================================================
-   Status Colors
-   ========================================================================== */
-
-.status-success {
-  color: var(--vscode-testing-iconPassed, #2ea043);
-}
-
-.status-error {
-  color: var(--vscode-editorError-foreground, #f14c4c);
-}
-
-.status-warning {
-  color: var(--vscode-notificationsWarningIcon-foreground, #cca700);
 }

--- a/src/progressView/styles/utilities.css
+++ b/src/progressView/styles/utilities.css
@@ -1,0 +1,199 @@
+/**
+ * Utility classes for ProgressView
+ * Reusable patterns to avoid CSS repetition (DRY)
+ */
+
+/* ==========================================================================
+   Layout Utilities
+   ========================================================================== */
+
+/* Flex utilities */
+.flex-center {
+  display: flex;
+  align-items: center;
+}
+
+.flex-column {
+  display: flex;
+  flex-direction: column;
+}
+
+.flex-wrap {
+  display: flex;
+  flex-wrap: wrap;
+}
+
+/* Gap utilities */
+.gap-xs {
+  gap: 0.25rem;
+}
+
+.gap-sm {
+  gap: 0.35rem;
+}
+
+.gap-md {
+  gap: 0.5rem;
+}
+
+.gap-lg {
+  gap: 0.75rem;
+}
+
+/* ==========================================================================
+   Text Utilities
+   ========================================================================== */
+
+/* Text truncation */
+.truncate {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Pre-wrapped text */
+.pre-wrap {
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+/* ==========================================================================
+   Visibility Utilities
+   ========================================================================== */
+
+/* Hidden until .is-visible is added */
+.hidden-panel {
+  display: none;
+}
+
+.hidden-panel.is-visible {
+  display: flex;
+}
+
+/* ==========================================================================
+   Request Panel Base Styles
+   Shared between approval-requests and retry-requests
+   ========================================================================== */
+
+/* Container panel */
+.request-panel {
+  margin: 0.75rem 0;
+  padding: 0.75rem;
+  border-radius: 6px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
+  display: none;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.request-panel.is-visible {
+  display: flex;
+}
+
+/* Panel header */
+.request-panel__header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 600;
+  color: var(--vscode-editor-foreground);
+}
+
+/* Panel list container */
+.request-panel__list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+/* Individual request item */
+.request-item {
+  border-radius: 4px;
+  border: 1px solid var(--vscode-editorHoverWidget-border);
+  background: var(--vscode-editorHoverWidget-background);
+  padding: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+/* Request details section */
+.request-item__details {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+/* Request metadata */
+.request-item__meta {
+  font-size: 0.8rem;
+  color: var(--vscode-descriptionForeground);
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  flex-wrap: wrap;
+}
+
+/* Request actions */
+.request-item__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+.request-item__actions::part(container) {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+.request-item__actions vscode-toolbar-button {
+  min-width: auto;
+}
+
+.request-item__actions vscode-toolbar-button::part(control) {
+  justify-content: flex-start;
+  gap: 0.35rem;
+}
+
+.request-item__actions [hidden] {
+  display: none !important;
+}
+
+/* ==========================================================================
+   Copy Button Utilities
+   ========================================================================== */
+
+/* Base copy button behavior - shared transition and success state */
+.banner-content-copy,
+.instruction-panel__copy {
+  transition: opacity 0.2s ease;
+}
+
+.banner-content-copy:focus-visible,
+.banner-content-copy.copy-success,
+.instruction-panel__copy:focus-visible,
+.instruction-panel__copy.copy-success {
+  opacity: 1;
+}
+
+.banner-content-copy.copy-success,
+.instruction-panel__copy.copy-success {
+  color: var(--vscode-testing-iconPassed);
+}
+
+/* ==========================================================================
+   Status Colors
+   ========================================================================== */
+
+.status-success {
+  color: var(--vscode-testing-iconPassed, #2ea043);
+}
+
+.status-error {
+  color: var(--vscode-editorError-foreground, #f14c4c);
+}
+
+.status-warning {
+  color: var(--vscode-notificationsWarningIcon-foreground, #cca700);
+}


### PR DESCRIPTION
- Add ERROR message type for consistent error display
- Implement foldable error banners with expand/collapse functionality
- Add error-specific CSS styling (red text, error icon, expandable details)
- Fix duplicate error logging by consolidating error loggers in executeAgent.ts
- Remove redundant inner catch error log that was duplicating outer catch
- Update error logging in RetryState, requestExecutor, ManualRetryController to use new ERROR message type for consistent foldable display

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces foldable ERROR banners in ProgressView and consolidates error logging via new AgentLogger APIs, updating handlers and styles accordingly.
> 
> - **ProgressView UI**:
>   - **Foldable error banners**: Add new `error` message type with formatter and red-styled details; timestamped, copyable, and collapsible.
>   - **Refactors**: Extract shared formatter helpers (e.g., dataset setter, section builders); tighten whitespace handling.
>   - **Styles**: New `utilities.css` and `requests-shared.css`; update `scratchpad.css`, `logs.css`, `instruction-panel.css`, `approval-requests.css`, `retry-requests.css`, and `index.css` to support error banners and shared request panel layout.
> - **Logging API**:
>   - Add `AgentLogger` helpers: `logError`, `logErrorData`, `logProgress`, `logInternal`, `debugInternal`, `logScratchpad`.
>   - Add `MESSAGE_TYPES.ERROR`; extend `LogTypes` with `error`.
>   - Extend error utils with `ErrorLogContext`, `ErrorLogData`, and `buildErrorLogData`; re-export in `errors/index.ts`.
> - **Backend updates**:
>   - Replace ad‑hoc logging with new APIs in `RetryState`, `ManualRetryController`, `requestExecutor`, `executeAgent`, and model handlers (Anthropic, Google GenAI, OpenAI, OpenAI Responses).
>   - Remove legacy `MESSAGE_TYPES` usage where not needed; route scratchpad/internal logs via new helpers.
>   - `XmlOutputManager`: switch to internal/debug log helpers for extraction paths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 327a773db40e02a00aad923d002c773c4a9fe5b6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->