### PR TITLE
Replace boilerplate validation with Zod v4

### DIFF
--- a/src/progressView/managers/OutputFilesManager.ts
+++ b/src/progressView/managers/OutputFilesManager.ts
@@ -80,63 +80,44 @@ function isLegacyFormat(record: Record<string, unknown>): boolean {
   );
 }
 
-/** Schema for missing outputs with legacy format support */
-const MissingOutputsDataSchema = z.unknown().transform(
-  (data): Map<string, Map<number, string[]>> => {
+/**
+ * Factory for creating schemas that handle both legacy and modern run map formats.
+ * Legacy: { roundNum: items[] } -> wrapped in default run ID
+ * Modern: { runId: { roundNum: items[] } }
+ */
+function createLegacyAwareRunMapSchema<T>(
+  roundMapSchema: z.ZodType<Map<number, T[]>>,
+) {
+  return z.unknown().transform((data): Map<string, Map<number, T[]>> => {
     if (!data || typeof data !== 'object') {
       return new Map();
     }
 
     const record = data as Record<string, unknown>;
     if (isLegacyFormat(record)) {
-      // Legacy: { roundNum: paths[] } -> wrap in default run ID
-      const rounds = MissingOutputRoundMapSchema.parse(record);
+      const rounds = roundMapSchema.parse(record);
       return rounds.size > 0
         ? new Map([[normalizeRunId(null), rounds]])
         : new Map();
     }
 
-    // Modern: { runId: { roundNum: paths[] } }
-    const runMap = new Map<string, Map<number, string[]>>();
+    const runMap = new Map<string, Map<number, T[]>>();
     for (const [runId, value] of Object.entries(record)) {
       if (!value || typeof value !== 'object') continue;
-      const rounds = MissingOutputRoundMapSchema.parse(value);
+      const rounds = roundMapSchema.parse(value);
       if (rounds.size > 0) {
         runMap.set(runId, rounds);
       }
     }
     return runMap;
-  },
-);
+  });
+}
+
+/** Schema for missing outputs with legacy format support */
+const MissingOutputsDataSchema = createLegacyAwareRunMapSchema(MissingOutputRoundMapSchema);
 
 /** Schema for output files with legacy format support */
-const OutputFilesDataSchema = z.unknown().transform(
-  (data): Map<string, Map<number, OutputFileInfo[]>> => {
-    if (!data || typeof data !== 'object') {
-      return new Map();
-    }
-
-    const record = data as Record<string, unknown>;
-    if (isLegacyFormat(record)) {
-      // Legacy: { roundNum: files[] } -> wrap in default run ID
-      const rounds = OutputFilesRoundMapSchema.parse(record);
-      return rounds.size > 0
-        ? new Map([[normalizeRunId(null), rounds]])
-        : new Map();
-    }
-
-    // Modern: { runId: { roundNum: files[] } }
-    const runMap = new Map<string, Map<number, OutputFileInfo[]>>();
-    for (const [runId, value] of Object.entries(record)) {
-      if (!value || typeof value !== 'object') continue;
-      const rounds = OutputFilesRoundMapSchema.parse(value);
-      if (rounds.size > 0) {
-        runMap.set(runId, rounds);
-      }
-    }
-    return runMap;
-  },
-);
+const OutputFilesDataSchema = createLegacyAwareRunMapSchema(OutputFilesRoundMapSchema);
 
 /**
  * Manages output files collection with persistence and file existence validation.

--- a/src/progressView/managers/OutputFilesManager.ts
+++ b/src/progressView/managers/OutputFilesManager.ts
@@ -7,6 +7,7 @@ import type { StorageKey, StreamTabId } from '@agent/types/IdentifierTypes';
 // Internal imports
 import {
   OutputFileInfoListSchema,
+  OutputFileInfoSchema,
   type OutputFileInfo,
 } from '@agent/output/types';
 import { normalizeRunId } from '@common/constants/runIds';
@@ -41,17 +42,7 @@ function createRoundMapSchema<T>(itemSchema: z.ZodType<T>) {
 /** Schema for missing output paths (string arrays per round) */
 const MissingOutputRoundMapSchema = createRoundMapSchema(z.string());
 
-/** Schema for output file info (uses existing schema with fallback) */
-const OutputFileInfoSchema = z.unknown().transform((v): OutputFileInfo | null => {
-  try {
-    const parsed = OutputFileInfoListSchema.parse([v]);
-    return parsed[0] ?? null;
-  } catch {
-    return null;
-  }
-});
-
-/** Schema for output files round map (filters nulls from parsing) */
+/** Schema for output files round map (filters invalid entries during parsing) */
 const OutputFilesRoundMapSchema = z
   .record(z.string(), z.array(z.unknown()).catch([]))
   .transform((record): Map<number, OutputFileInfo[]> => {
@@ -60,8 +51,9 @@ const OutputFilesRoundMapSchema = z
       const round = RoundKey.safeParse(key);
       if (!round.success) continue;
       const parsed = items
-        .map((item) => OutputFileInfoSchema.parse(item))
-        .filter((item): item is OutputFileInfo => item !== null);
+        .map((item) => OutputFileInfoSchema.safeParse(item))
+        .filter((result): result is z.SafeParseSuccess<OutputFileInfo> => result.success)
+        .map((result) => result.data);
       if (parsed.length > 0) {
         map.set(round.data, parsed);
       }

--- a/src/progressView/managers/OutputFilesManager.ts
+++ b/src/progressView/managers/OutputFilesManager.ts
@@ -1,5 +1,6 @@
 // Third-party imports
 import * as vscode from 'vscode';
+import { z } from 'zod';
 
 // Local imports - progress view
 import type { StorageKey, StreamTabId } from '@agent/types/IdentifierTypes';
@@ -16,9 +17,126 @@ import {
   type StateStorage,
 } from '@progressView/persistence/PersistentMapManager';
 
-// Local imports
+// --- Zod Schemas for Output Files ---
 
-// Types
+/** Schema for integer round keys (coerces string keys to numbers) */
+const RoundKey = z.coerce.number().int();
+
+/** Schema for a round map: { roundNumber: items[] } -> Map<number, T[]> */
+function createRoundMapSchema<T>(itemSchema: z.ZodType<T>) {
+  return z
+    .record(z.string(), z.array(itemSchema).catch([]))
+    .transform((record): Map<number, T[]> => {
+      const map = new Map<number, T[]>();
+      for (const [key, items] of Object.entries(record)) {
+        const round = RoundKey.safeParse(key);
+        if (round.success && items.length > 0) {
+          map.set(round.data, items);
+        }
+      }
+      return map;
+    });
+}
+
+/** Schema for missing output paths (string arrays per round) */
+const MissingOutputRoundMapSchema = createRoundMapSchema(z.string());
+
+/** Schema for output file info (uses existing schema with fallback) */
+const OutputFileInfoSchema = z.unknown().transform((v): OutputFileInfo | null => {
+  try {
+    const parsed = OutputFileInfoListSchema.parse([v]);
+    return parsed[0] ?? null;
+  } catch {
+    return null;
+  }
+});
+
+/** Schema for output files round map (filters nulls from parsing) */
+const OutputFilesRoundMapSchema = z
+  .record(z.string(), z.array(z.unknown()).catch([]))
+  .transform((record): Map<number, OutputFileInfo[]> => {
+    const map = new Map<number, OutputFileInfo[]>();
+    for (const [key, items] of Object.entries(record)) {
+      const round = RoundKey.safeParse(key);
+      if (!round.success) continue;
+      const parsed = items
+        .map((item) => OutputFileInfoSchema.parse(item))
+        .filter((item): item is OutputFileInfo => item !== null);
+      if (parsed.length > 0) {
+        map.set(round.data, parsed);
+      }
+    }
+    return map;
+  });
+
+/**
+ * Detects if a record looks like legacy format (all keys are numeric)
+ * vs modern format (keys are run IDs like strings)
+ */
+function isLegacyFormat(record: Record<string, unknown>): boolean {
+  const entries = Object.entries(record);
+  return entries.length > 0 && entries.every(
+    ([key]) => !Number.isNaN(Number.parseInt(key, 10)),
+  );
+}
+
+/** Schema for missing outputs with legacy format support */
+const MissingOutputsDataSchema = z.unknown().transform(
+  (data): Map<string, Map<number, string[]>> => {
+    if (!data || typeof data !== 'object') {
+      return new Map();
+    }
+
+    const record = data as Record<string, unknown>;
+    if (isLegacyFormat(record)) {
+      // Legacy: { roundNum: paths[] } -> wrap in default run ID
+      const rounds = MissingOutputRoundMapSchema.parse(record);
+      return rounds.size > 0
+        ? new Map([[normalizeRunId(null), rounds]])
+        : new Map();
+    }
+
+    // Modern: { runId: { roundNum: paths[] } }
+    const runMap = new Map<string, Map<number, string[]>>();
+    for (const [runId, value] of Object.entries(record)) {
+      if (!value || typeof value !== 'object') continue;
+      const rounds = MissingOutputRoundMapSchema.parse(value);
+      if (rounds.size > 0) {
+        runMap.set(runId, rounds);
+      }
+    }
+    return runMap;
+  },
+);
+
+/** Schema for output files with legacy format support */
+const OutputFilesDataSchema = z.unknown().transform(
+  (data): Map<string, Map<number, OutputFileInfo[]>> => {
+    if (!data || typeof data !== 'object') {
+      return new Map();
+    }
+
+    const record = data as Record<string, unknown>;
+    if (isLegacyFormat(record)) {
+      // Legacy: { roundNum: files[] } -> wrap in default run ID
+      const rounds = OutputFilesRoundMapSchema.parse(record);
+      return rounds.size > 0
+        ? new Map([[normalizeRunId(null), rounds]])
+        : new Map();
+    }
+
+    // Modern: { runId: { roundNum: files[] } }
+    const runMap = new Map<string, Map<number, OutputFileInfo[]>>();
+    for (const [runId, value] of Object.entries(record)) {
+      if (!value || typeof value !== 'object') continue;
+      const rounds = OutputFilesRoundMapSchema.parse(value);
+      if (rounds.size > 0) {
+        runMap.set(runId, rounds);
+      }
+    }
+    return runMap;
+  },
+);
 
 /**
  * Manages output files collection with persistence and file existence validation.
@@ -447,42 +565,8 @@ export class OutputFilesManager extends PersistentMapManager<
     >();
 
     for (const [stream, raw] of Object.entries(saved)) {
-      if (!raw || typeof raw !== 'object') {
-        processed.set(stream, new Map());
-        continue;
-      }
-
-      const entries = Object.entries(raw as Record<string, unknown>);
-      const looksLegacy = entries.every(
-        ([key]) => !Number.isNaN(Number.parseInt(key, 10)),
-      );
-
-      const runMap = new Map<string, Map<number, string[]>>();
-
-      if (looksLegacy) {
-        const rounds = this.deserializeRoundMap<string>(
-          raw as Record<string, unknown>,
-          (v) => (typeof v === 'string' ? v : null),
-        );
-        if (rounds.size > 0) {
-          runMap.set(normalizeRunId(null), rounds);
-        }
-      } else {
-        for (const [runId, value] of entries) {
-          if (!value || typeof value !== 'object') {
-            continue;
-          }
-          const rounds = this.deserializeRoundMap<string>(
-            value as Record<string, unknown>,
-            (v) => (typeof v === 'string' ? v : null),
-          );
-          if (rounds.size > 0) {
-            runMap.set(runId, rounds);
-          }
-        }
-      }
-
-      processed.set(stream, runMap);
+      const runMap = MissingOutputsDataSchema.parse(raw);
+      processed.set(stream as StreamTabId, runMap);
     }
 
     return processed;
@@ -518,38 +602,6 @@ export class OutputFilesManager extends PersistentMapManager<
     return true;
   }
 
-  private deserializeRoundMap<T>(
-    record: Record<string, unknown>,
-    parser?: (value: unknown) => T | null,
-  ): Map<number, T[]> {
-    const roundMap = new Map<number, T[]>();
-
-    for (const [roundKey, value] of Object.entries(record)) {
-      const round = Number.parseInt(roundKey, 10);
-      if (Number.isNaN(round)) {
-        this.logger.warn(`Invalid round number '${roundKey}' during load`);
-        continue;
-      }
-      if (!Array.isArray(value)) {
-        continue;
-      }
-
-      if (!parser) {
-        roundMap.set(round, value as T[]);
-        continue;
-      }
-
-      const parsed = (value as unknown[])
-        .map((entry) => parser(entry))
-        .filter((entry): entry is T => entry !== null);
-      if (parsed.length > 0) {
-        roundMap.set(round, parsed);
-      }
-    }
-
-    return roundMap;
-  }
-
   protected override serialize(
     value: Map<string, Map<number, OutputFileInfo[]>>,
     _key: StreamTabId,
@@ -568,52 +620,6 @@ export class OutputFilesManager extends PersistentMapManager<
     data: unknown,
     _streamId: StreamTabId,
   ): Promise<Map<string, Map<number, OutputFileInfo[]>>> {
-    if (!data || typeof data !== 'object') {
-      return new Map();
-    }
-
-    const record = data as Record<string, unknown>;
-    const entries = Object.entries(record);
-    const looksLegacy = entries.every(
-      ([key]) => !Number.isNaN(Number.parseInt(key, 10)),
-    );
-
-    const runMap = new Map<string, Map<number, OutputFileInfo[]>>();
-
-    if (looksLegacy) {
-      const rounds = this.deserializeRoundMap<OutputFileInfo>(record, (v) => {
-        try {
-          return OutputFileInfoListSchema.parse([v])[0] ?? null;
-        } catch {
-          return null;
-        }
-      });
-      if (rounds.size > 0) {
-        runMap.set(normalizeRunId(null), rounds);
-      }
-      return runMap;
-    }
-
-    for (const [runId, value] of entries) {
-      if (!value || typeof value !== 'object') {
-        continue;
-      }
-
-      const rounds = this.deserializeRoundMap<OutputFileInfo>(
-        value as Record<string, unknown>,
-        (v) => {
-          try {
-            return OutputFileInfoListSchema.parse([v])[0] ?? null;
-          } catch {
-            return null;
-          }
-        },
-      );
-      if (rounds.size > 0) {
-        runMap.set(runId, rounds);
-      }
-    }
-
-    return runMap;
+    return OutputFilesDataSchema.parse(data);
   }
 }

--- a/src/progressView/managers/UsageStatsManager.ts
+++ b/src/progressView/managers/UsageStatsManager.ts
@@ -1,3 +1,6 @@
+// Third-party imports
+import { z } from 'zod';
+
 // Local imports - identifiers
 import type { StorageKey, StreamTabId } from '@agent/types/IdentifierTypes';
 // Types
@@ -9,6 +12,54 @@ import {
   PersistentMapManager,
   type StateStorage,
 } from '@progressView/persistence/PersistentMapManager';
+
+// --- Zod Schemas for Usage Stats ---
+
+/** Coerces input to number, defaulting non-finite values to 0 */
+const FiniteNumber = z.coerce
+  .number()
+  .transform((n) => (Number.isFinite(n) ? n : 0));
+
+/** Schema for TokenUsageStats with safe number coercion */
+const TokenUsageStatsSchema = z
+  .object({
+    inputTokens: FiniteNumber,
+    outputTokens: FiniteNumber,
+    cost: FiniteNumber,
+  })
+  .catch({ inputTokens: 0, outputTokens: 0, cost: 0 });
+
+/** Schema for run map (runId -> usage) */
+const RunMapSchema = z.record(z.string(), TokenUsageStatsSchema);
+
+/** Schema that handles both legacy flat format and modern run map format */
+const UsageDataSchema = z.unknown().transform((data): Map<string, TokenUsageStats> => {
+  if (!data || typeof data !== 'object') {
+    return new Map();
+  }
+
+  const entries = Object.entries(data as Record<string, unknown>);
+  const looksLikeRunMap = entries.every(
+    ([, value]) => value && typeof value === 'object',
+  );
+
+  if (!looksLikeRunMap) {
+    // Legacy flat format
+    const usage = TokenUsageStatsSchema.parse(data);
+    if (usage.inputTokens === 0 && usage.outputTokens === 0 && usage.cost === 0) {
+      return new Map();
+    }
+    return new Map([[normalizeRunId(null), usage]]);
+  }
+
+  // Modern run map format
+  const runMap = RunMapSchema.parse(data);
+  const result = new Map<string, TokenUsageStats>();
+  for (const [runId, usage] of Object.entries(runMap)) {
+    result.set(runId, usage);
+  }
+  return result;
+});
 
 /**
  * Manages usage statistics collection with persistence.
@@ -41,7 +92,7 @@ export class UsageStatsManager extends PersistentMapManager<
     storageKey: StorageKey,
     usage: TokenUsageStats,
   ): Promise<void> {
-    const normalized = this.sanitizeUsage(usage);
+    const normalized = TokenUsageStatsSchema.parse(usage);
     const current =
       this.items.get(stream) ?? new Map<string, TokenUsageStats>();
     if (
@@ -138,8 +189,7 @@ export class UsageStatsManager extends PersistentMapManager<
         continue;
       }
 
-      const candidate = value as TokenUsageStats;
-      const usage = this.sanitizeUsage(candidate);
+      const usage = TokenUsageStatsSchema.parse(value);
       if (
         usage.inputTokens === 0 &&
         usage.outputTokens === 0 &&
@@ -231,7 +281,7 @@ export class UsageStatsManager extends PersistentMapManager<
     }
 
     const totals = legacy.usageAccumulator.totals;
-    const usage: TokenUsageStats = this.sanitizeUsage({
+    const usage: TokenUsageStats = TokenUsageStatsSchema.parse({
       inputTokens: totals.totalInputTokens ?? 0,
       outputTokens: totals.totalOutputTokens ?? 0,
       cost: totals.totalCost ?? 0,
@@ -272,60 +322,6 @@ export class UsageStatsManager extends PersistentMapManager<
     data: unknown,
     _key: StreamTabId,
   ): Promise<RunUsageMap> {
-    if (!data || typeof data !== 'object') {
-      return new Map();
-    }
-
-    const entries = Object.entries(data as Record<string, unknown>);
-    const looksLikeRunMap = entries.every(
-      ([, value]) => value && typeof value === 'object',
-    );
-
-    if (!looksLikeRunMap) {
-      const candidate = data as Partial<TokenUsageStats>;
-      const normalized = this.sanitizeUsage({
-        inputTokens: candidate.inputTokens ?? NaN,
-        outputTokens: candidate.outputTokens ?? NaN,
-        cost: candidate.cost ?? NaN,
-      });
-      const map: RunUsageMap = new Map();
-      if (
-        normalized.inputTokens !== 0 ||
-        normalized.outputTokens !== 0 ||
-        normalized.cost !== 0
-      ) {
-        map.set(normalizeRunId(null), normalized);
-      }
-      return map;
-    }
-
-    const runMap: RunUsageMap = new Map();
-    for (const [runId, rawUsage] of entries) {
-      if (!rawUsage || typeof rawUsage !== 'object') {
-        continue;
-      }
-      const candidate = rawUsage as Partial<TokenUsageStats>;
-      runMap.set(
-        runId,
-        this.sanitizeUsage({
-          inputTokens: candidate.inputTokens ?? NaN,
-          outputTokens: candidate.outputTokens ?? NaN,
-          cost: candidate.cost ?? NaN,
-        }),
-      );
-    }
-    return runMap;
-  }
-
-  private sanitizeUsage(usage: TokenUsageStats): TokenUsageStats {
-    return {
-      inputTokens: this.toSafeNumber(usage.inputTokens),
-      outputTokens: this.toSafeNumber(usage.outputTokens),
-      cost: this.toSafeNumber(usage.cost),
-    };
-  }
-
-  private toSafeNumber(value: number): number {
-    return Number.isFinite(value) ? value : 0;
+    return UsageDataSchema.parse(data);
   }
 }

--- a/src/tools/arxiv/ArxivMetadataTool.ts
+++ b/src/tools/arxiv/ArxivMetadataTool.ts
@@ -10,7 +10,6 @@ import {
   extractEntryIdentifier,
   getAuthorNames,
   normaliseArxivIdentifier,
-  readPrimaryCategory,
 } from '@tools/latex/arxivShared';
 import { ARXIV_CONSTANTS } from '@tools/citation/constants';
 import { waitForRateLimit } from '@tools/citation/rateLimiter';
@@ -73,7 +72,7 @@ export class ArxivMetadataTool extends defineTool({
       authors: authorNames,
       journalReference: targetEntry.journalRef ?? null,
       comment: targetEntry.comment ?? null,
-      primaryCategory: readPrimaryCategory(targetEntry.primaryCategory),
+      primaryCategory: targetEntry.primaryCategory ?? null,
       links: targetEntry.links ?? null,
       // Conditionally include abstract field only when requested
       ...(includeAbstract && { abstract: targetEntry.summary ?? null }),

--- a/src/tools/arxiv/ArxivMetadataTool.ts
+++ b/src/tools/arxiv/ArxivMetadataTool.ts
@@ -72,7 +72,7 @@ export class ArxivMetadataTool extends defineTool({
       authors: authorNames,
       journalReference: targetEntry.journalRef ?? null,
       comment: targetEntry.comment ?? null,
-      primaryCategory: targetEntry.primaryCategory ?? null,
+      primaryCategory: targetEntry.primaryCategory?.term ?? null,
       links: targetEntry.links ?? null,
       // Conditionally include abstract field only when requested
       ...(includeAbstract && { abstract: targetEntry.summary ?? null }),

--- a/src/tools/arxiv/ArxivSearchTool.ts
+++ b/src/tools/arxiv/ArxivSearchTool.ts
@@ -11,7 +11,6 @@ import {
   extractEntryIdentifier,
   getAuthorNames,
   normaliseArxivIdentifier,
-  readPrimaryCategory,
 } from '@tools/latex/arxivShared';
 import { ARXIV_CONSTANTS } from '@tools/citation/constants';
 import { waitForRateLimit } from '@tools/citation/rateLimiter';
@@ -109,7 +108,7 @@ export class ArxivSearchTool extends defineTool({
         published: entry.published ?? null,
         updated: entry.updated ?? null,
         authors: getAuthorNames(entry.authors),
-        primaryCategory: readPrimaryCategory(entry.primaryCategory),
+        primaryCategory: entry.primaryCategory ?? null,
         arxivUrl: identifier
           ? `https://arxiv.org/abs/${normaliseArxivIdentifier(identifier)}`
           : null,

--- a/src/tools/arxiv/ArxivSearchTool.ts
+++ b/src/tools/arxiv/ArxivSearchTool.ts
@@ -108,7 +108,7 @@ export class ArxivSearchTool extends defineTool({
         published: entry.published ?? null,
         updated: entry.updated ?? null,
         authors: getAuthorNames(entry.authors),
-        primaryCategory: entry.primaryCategory ?? null,
+        primaryCategory: entry.primaryCategory?.term ?? null,
         arxivUrl: identifier
           ? `https://arxiv.org/abs/${normaliseArxivIdentifier(identifier)}`
           : null,

--- a/src/tools/citation/CrossrefDoiTool.ts
+++ b/src/tools/citation/CrossrefDoiTool.ts
@@ -48,8 +48,8 @@ export class CrossrefDoiTool extends defineTool({
 
     const metadata = {
       doi: work.DOI,
-      title: work.title[0] ?? null,
-      titles: work.title,
+      title: work.title?.[0] ?? null,
+      titles: work.title ?? [],
       publisher: work.publisher,
       type: work.type,
       abstract: work.abstract ?? null,

--- a/src/tools/citation/CrossrefDoiTool.ts
+++ b/src/tools/citation/CrossrefDoiTool.ts
@@ -1,5 +1,5 @@
 // Third-party imports
-import { CrossrefClient } from '@jamesgopsill/crossref-client';
+import { CrossrefClient, type Work } from '@jamesgopsill/crossref-client';
 import { z } from 'zod';
 
 // Local imports - metadata
@@ -19,14 +19,6 @@ export type CrossrefDoiInput = z.infer<typeof CrossrefDoiInputSchema>;
 
 const crossrefClient = new CrossrefClient();
 
-/**
- * Type guard to safely access Crossref work metadata properties.
- * The library returns untyped objects, so we use this helper to access properties safely.
- */
-function isWorkMetadata(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
-}
-
 export class CrossrefDoiTool extends defineTool({
   name: 'crossref_doi',
   description: 'Look up detailed metadata for a DOI using Crossref.',
@@ -38,7 +30,7 @@ export class CrossrefDoiTool extends defineTool({
       throw new ToolError('Invalid DOI string.');
     }
 
-    let work: Record<string, unknown>;
+    let work: Work;
     try {
       // Respect Crossref API rate limits
       await waitForRateLimit(
@@ -46,41 +38,28 @@ export class CrossrefDoiTool extends defineTool({
         CROSSREF_CONSTANTS.RATE_LIMIT_DELAY_MS,
       );
       const response = await crossrefClient.work(trimmedDoi);
-      if (!response.ok || !response.content || !response.content.message) {
+      if (!response.ok || !response.content?.message) {
         throw new Error('Crossref response did not include metadata.');
       }
-      const message = response.content.message;
-      if (!isWorkMetadata(message)) {
-        throw new Error('Crossref metadata payload was empty.');
-      }
-      work = message;
+      work = response.content.message;
     } catch (error) {
       throw new ToolError(`Crossref lookup failed: ${toErrorMessage(error)}`);
     }
 
-    const titleValue = work.title;
-    const titles = Array.isArray(titleValue)
-      ? titleValue.filter((entry): entry is string => typeof entry === 'string')
-      : typeof titleValue === 'string'
-        ? [titleValue]
-        : [];
-    const resolvedTitle = titles.length > 0 ? titles[0] : null;
-
     const metadata = {
-      doi: typeof work.DOI === 'string' ? work.DOI : trimmedDoi,
-      title: resolvedTitle,
-      titles,
-      publisher: typeof work.publisher === 'string' ? work.publisher : null,
-      type: typeof work.type === 'string' ? work.type : null,
-      abstract: typeof work.abstract === 'string' ? work.abstract : null,
-      description:
-        typeof work.description === 'string' ? work.description : null,
-      created: work.created ?? null,
+      doi: work.DOI,
+      title: work.title[0] ?? null,
+      titles: work.title,
+      publisher: work.publisher,
+      type: work.type,
+      abstract: work.abstract ?? null,
+      description: null, // Not in library type
+      created: work.created,
       published: work.published ?? null,
-      url: typeof work.URL === 'string' ? work.URL : null,
-      language: typeof work.language === 'string' ? work.language : null,
-      authors: Array.isArray(work.author) ? work.author : [],
-      licenses: Array.isArray(work.license) ? work.license : [],
+      url: work.resource?.primary?.URL ?? null,
+      language: work.language ?? null,
+      authors: work.author,
+      licenses: work.license ?? [],
     };
 
     return toolResult({

--- a/src/tools/citation/CrossrefDoiTool.ts
+++ b/src/tools/citation/CrossrefDoiTool.ts
@@ -58,7 +58,7 @@ export class CrossrefDoiTool extends defineTool({
       published: work.published ?? null,
       url: work.resource?.primary?.URL ?? null,
       language: work.language ?? null,
-      authors: work.author,
+      authors: work.author ?? [],
       licenses: work.license ?? [],
     };
 

--- a/src/tools/citation/CrossrefSearchTool.ts
+++ b/src/tools/citation/CrossrefSearchTool.ts
@@ -3,6 +3,7 @@ import {
   CrossrefClient,
   SortOrder,
   type QueryWorksParams,
+  type Work,
   type WorkSortOptions,
 } from '@jamesgopsill/crossref-client';
 import { z } from 'zod';
@@ -15,8 +16,6 @@ import { defineTool } from '@tools/core/define';
 // Local file imports
 import { CROSSREF_CONSTANTS } from './constants';
 import { waitForRateLimit } from './rateLimiter';
-
-// Local imports - tools
 
 const CrossrefSearchInputSchema = z.strictObject({
   query: z.string(),
@@ -43,14 +42,6 @@ const crossrefClient = new CrossrefClient();
  * See: https://api.crossref.org/swagger-ui/index.html#/Works/get_works
  */
 type ExtendedQueryWorksParams = QueryWorksParams & { filter?: string };
-
-/**
- * Type guard to safely access Crossref work item properties.
- * The library returns untyped objects, so we use this helper to access properties safely.
- */
-function isWorkItem(item: unknown): item is Record<string, unknown> {
-  return typeof item === 'object' && item !== null;
-}
 
 export class CrossrefSearchTool extends defineTool({
   name: 'crossref_search',
@@ -106,35 +97,16 @@ export class CrossrefSearchTool extends defineTool({
     }
 
     const message = response.content.message;
-    const items = Array.isArray(message.items) ? message.items : [];
+    const items: Work[] = message.items;
 
-    const results = items.map((item) => {
-      if (!isWorkItem(item)) {
-        return {
-          title: null,
-          doi: null,
-          publisher: null,
-          type: null,
-          issued: null,
-          url: null,
-        };
-      }
-      const titleValue = item.title;
-      const primaryTitle = Array.isArray(titleValue)
-        ? (titleValue.find((entry) => typeof entry === 'string') ?? null)
-        : typeof titleValue === 'string'
-          ? titleValue
-          : null;
-
-      return {
-        title: primaryTitle,
-        doi: typeof item.DOI === 'string' ? item.DOI : null,
-        publisher: typeof item.publisher === 'string' ? item.publisher : null,
-        type: typeof item.type === 'string' ? item.type : null,
-        issued: item.issued ?? null,
-        url: typeof item.URL === 'string' ? item.URL : null,
-      };
-    });
+    const results = items.map((work) => ({
+      title: work.title[0] ?? null,
+      doi: work.DOI,
+      publisher: work.publisher,
+      type: work.type,
+      issued: work.issued,
+      url: work.resource?.primary?.URL ?? null,
+    }));
 
     const payload = {
       query: trimmedQuery,

--- a/src/tools/citation/CrossrefSearchTool.ts
+++ b/src/tools/citation/CrossrefSearchTool.ts
@@ -100,7 +100,7 @@ export class CrossrefSearchTool extends defineTool({
     const items: Work[] = message.items;
 
     const results = items.map((work) => ({
-      title: work.title[0] ?? null,
+      title: work.title?.[0] ?? null,
       doi: work.DOI,
       publisher: work.publisher,
       type: work.type,

--- a/src/tools/latex/arxivShared.ts
+++ b/src/tools/latex/arxivShared.ts
@@ -2,6 +2,9 @@
 import arxivClient from 'arxiv-client';
 import { extract as extractArxivId } from 'identifiers-arxiv';
 
+/** Infer ArxivEntry type from the client's execute() return type */
+type ArxivEntry = Awaited<ReturnType<typeof arxivClient.execute>>[number];
+
 /**
  * Base arXiv paper metadata shared between search and metadata tools.
  */
@@ -65,36 +68,11 @@ export const extractEntryIdentifier = (rawId: unknown): string | null => {
   return id ? normaliseArxivIdentifier(id) : null;
 };
 
+/** Extract author names, optionally limiting to maxAuthors */
 export const getAuthorNames = (
-  authors: unknown,
+  authors: ArxivEntry['authors'],
   maxAuthors?: number,
 ): string[] => {
-  const list = Array.isArray(authors) ? authors : authors ? [authors] : [];
-  const names = list
-    .map((entry) => {
-      if (entry && typeof entry === 'object' && 'name' in entry) {
-        const value = (entry as { name?: unknown }).name;
-        return typeof value === 'string' ? value : null;
-      }
-      return typeof entry === 'string' ? entry : null;
-    })
-    .filter((name): name is string => Boolean(name));
-  if (typeof maxAuthors === 'number') {
-    return names.slice(0, maxAuthors);
-  }
-  return names;
-};
-
-export const readPrimaryCategory = (primary: unknown): string | null => {
-  if (!primary) {
-    return null;
-  }
-  if (typeof primary === 'string') {
-    return primary;
-  }
-  if (typeof primary === 'object' && primary && 'term' in primary) {
-    const { term } = primary as { term?: unknown };
-    return typeof term === 'string' ? term : null;
-  }
-  return null;
+  const names = authors.map((author) => author.name);
+  return maxAuthors !== undefined ? names.slice(0, maxAuthors) : names;
 };


### PR DESCRIPTION
- UsageStatsManager: Replace sanitizeUsage/toSafeNumber with Zod FiniteNumber schema
- OutputFilesManager: Add Zod schemas for round map and output files deserialization
- CrossrefDoiTool/CrossrefSearchTool: Use library's Work type instead of custom schemas
- arxivShared: Use inferred ArxivEntry type, remove redundant readPrimaryCategory helper

Net reduction of ~70 lines by leveraging library types and Zod's declarative validation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Swap custom parsing/sanitization for Zod schemas and official library types, simplifying deserialization and legacy format handling across output/usage managers and citation tools.
> 
> - **Progress View**:
>   - **`OutputFilesManager`**:
>     - Add Zod schemas to parse `round -> items` and legacy/modern `runId -> round` maps (`MissingOutputsDataSchema`, `OutputFilesDataSchema`).
>     - Replace ad-hoc deserialization with schema parsing; remove round-map parsing helpers.
>   - **`UsageStatsManager`**:
>     - Introduce `FiniteNumber` and `TokenUsageStatsSchema`; parse legacy flat and modern run maps via `UsageDataSchema`.
>     - Remove `sanitizeUsage`/`toSafeNumber`; use schemas in setters, loaders, and migration.
> - **ArXiv Tools**:
>   - Use inferred `ArxivEntry` type; simplify `getAuthorNames` and read `primaryCategory` directly (`term`).
>   - `ArxivMetadataTool`/`ArxivSearchTool`: trim titles, return `primaryCategory` via `entry.primaryCategory?.term`.
> - **Crossref Tools**:
>   - Use `Work` type from `@jamesgopsill/crossref-client` for parsing.
>   - Simplify field extraction (title, URL, authors, licenses) and remove custom type guards.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eff03ecd7cc60d2cb305b5e4ad4ff4e159e7cb09. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->