### PR TITLE
Fix abort functionality not working correctly

### DIFF
--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -286,6 +286,8 @@ class ResponseModelInvocationNode<C> extends Node<
     }
 
     const abortController = new AbortController();
+    // Set signal on Node so retry loop can detect user cancellation
+    this.signal = abortController.signal;
     options.setAbortController(abortController);
     options.modelHandler.setOutputStreaming(false);
 

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -318,6 +318,8 @@ class ToolUseCallNode<C> extends Node<
     };
 
     const abortController = new AbortController();
+    // Set signal on Node so retry loop can detect user cancellation
+    this.signal = abortController.signal;
     options.setAbortController(abortController);
 
     const start = Date.now();

--- a/src/agent/node/index.ts
+++ b/src/agent/node/index.ts
@@ -84,10 +84,17 @@ class Node<
   async execFallback(prepRes: unknown, error: Error): Promise<unknown> {
     throw error;
   }
+  /**
+   * Override clone to reset execution-specific state.
+   * Prevents stale signal/retry state from affecting new executions.
+   */
+  clone(): this {
+    const cloned = super.clone();
+    cloned.signal = undefined;
+    cloned.currentRetry = 0;
+    return cloned;
+  }
   async _exec(prepRes: unknown): Promise<unknown> {
-    // Reset signal to prevent stale abort state from cloned nodes
-    // exec() will set a fresh signal if needed
-    this.signal = undefined;
     for (
       this.currentRetry = 0;
       this.currentRetry < this.maxRetries;

--- a/src/agent/node/index.ts
+++ b/src/agent/node/index.ts
@@ -2,6 +2,40 @@ type NonIterableObject = Partial<Record<string, unknown>> & {
   [Symbol.iterator]?: never;
 };
 type Action = string;
+
+/**
+ * Detects if an error is an abort/cancellation error.
+ * These are NOT retryable since the user intentionally cancelled.
+ * Handles:
+ * - DOM AbortError (from AbortController)
+ * - Errors with 'abort' or 'cancel' in name/message
+ */
+function isAbortOrCancellationError(err: unknown): boolean {
+  if (!err || typeof err !== 'object') {
+    return false;
+  }
+
+  const errorObj = err as { name?: string; message?: string };
+
+  // Check for DOM AbortError (DOMException with name 'AbortError')
+  if (errorObj.name === 'AbortError') {
+    return true;
+  }
+
+  // Check for abort-related patterns in error name
+  const name = errorObj.name?.toLowerCase() ?? '';
+  if (name.includes('abort') || name.includes('cancel')) {
+    return true;
+  }
+
+  // Check for abort-related patterns in error message
+  const message = errorObj.message?.toLowerCase() ?? '';
+  if (message.includes('aborted') || message.includes('cancelled')) {
+    return true;
+  }
+
+  return false;
+}
 class BaseNode<S = unknown, P extends NonIterableObject = NonIterableObject> {
   protected _params: P = {} as P;
   protected _successors: Map<Action, BaseNode> = new Map();
@@ -86,7 +120,10 @@ class Node<
       try {
         return await this.exec(prepRes);
       } catch (e) {
-        if (this.currentRetry === this.maxRetries - 1)
+        // Abort/cancellation errors are NOT retryable - go directly to fallback
+        // This prevents unnecessary retries when the user intentionally cancelled
+        const isAbort = isAbortOrCancellationError(e);
+        if (this.currentRetry === this.maxRetries - 1 || isAbort)
           return await this.execFallback(prepRes, e as Error);
         if (this.wait > 0)
           await new Promise((resolve) => setTimeout(resolve, this.wait * 1000));

--- a/src/agent/node/index.ts
+++ b/src/agent/node/index.ts
@@ -2,40 +2,6 @@ type NonIterableObject = Partial<Record<string, unknown>> & {
   [Symbol.iterator]?: never;
 };
 type Action = string;
-
-/**
- * Detects if an error is an abort/cancellation error.
- * These are NOT retryable since the user intentionally cancelled.
- * Handles:
- * - DOM AbortError (from AbortController)
- * - Errors with 'abort' or 'cancel' in name/message
- */
-function isAbortOrCancellationError(err: unknown): boolean {
-  if (!err || typeof err !== 'object') {
-    return false;
-  }
-
-  const errorObj = err as { name?: string; message?: string };
-
-  // Check for DOM AbortError (DOMException with name 'AbortError')
-  if (errorObj.name === 'AbortError') {
-    return true;
-  }
-
-  // Check for abort-related patterns in error name
-  const name = errorObj.name?.toLowerCase() ?? '';
-  if (name.includes('abort') || name.includes('cancel')) {
-    return true;
-  }
-
-  // Check for abort-related patterns in error message
-  const message = errorObj.message?.toLowerCase() ?? '';
-  if (message.includes('aborted') || message.includes('cancelled')) {
-    return true;
-  }
-
-  return false;
-}
 class BaseNode<S = unknown, P extends NonIterableObject = NonIterableObject> {
   protected _params: P = {} as P;
   protected _successors: Map<Action, BaseNode> = new Map();
@@ -103,6 +69,13 @@ class Node<
   maxRetries: number;
   wait: number;
   currentRetry: number = 0;
+  /**
+   * Optional abort signal for cancellation support.
+   * When set and aborted, the retry loop will skip remaining retries
+   * and go directly to execFallback(). This prevents unnecessary API
+   * calls when the user has intentionally cancelled the operation.
+   */
+  signal?: AbortSignal;
   constructor(maxRetries: number = 1, wait: number = 0) {
     super();
     this.maxRetries = maxRetries;
@@ -120,10 +93,10 @@ class Node<
       try {
         return await this.exec(prepRes);
       } catch (e) {
-        // Abort/cancellation errors are NOT retryable - go directly to fallback
+        // If abort signal is set and aborted, skip retries and go to fallback
         // This prevents unnecessary retries when the user intentionally cancelled
-        const isAbort = isAbortOrCancellationError(e);
-        if (this.currentRetry === this.maxRetries - 1 || isAbort)
+        const isAborted = this.signal?.aborted === true;
+        if (this.currentRetry === this.maxRetries - 1 || isAborted)
           return await this.execFallback(prepRes, e as Error);
         if (this.wait > 0)
           await new Promise((resolve) => setTimeout(resolve, this.wait * 1000));

--- a/src/agent/node/index.ts
+++ b/src/agent/node/index.ts
@@ -85,6 +85,9 @@ class Node<
     throw error;
   }
   async _exec(prepRes: unknown): Promise<unknown> {
+    // Reset signal to prevent stale abort state from cloned nodes
+    // exec() will set a fresh signal if needed
+    this.signal = undefined;
     for (
       this.currentRetry = 0;
       this.currentRetry < this.maxRetries;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Propagates AbortSignal from flow invocations to Node and updates Node retry loop to skip retries on user cancellation, resetting state on clone.
> 
> - **Core Node (`@agent/node`)**:
>   - Add optional `signal?: AbortSignal` and check `signal.aborted` in retry loop to short-circuit retries and call `execFallback` on cancellation.
>   - Override `clone()` to reset `signal` and `currentRetry`.
> - **Flows**:
>   - **Response** (`core/flows/ResponseCycleFlow.ts`): set `this.signal` from `AbortController` during model invocation so cancellation is detected by retry loop.
>   - **Tool Use** (`core/flows/ToolUseCycleFlow.ts`): set `this.signal` from `AbortController` during tool-use call to enable cancellation-aware retries.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 02f2a8b9f2c14325872c2905c6eb544fda43808c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->