### PR TITLE
Fix OutputFilesManager compilation error

### DIFF
--- a/src/progressView/managers/OutputFilesManager.ts
+++ b/src/progressView/managers/OutputFilesManager.ts
@@ -52,7 +52,7 @@ const OutputFilesRoundMapSchema = z
       if (!round.success) continue;
       const parsed = items
         .map((item) => OutputFileInfoSchema.safeParse(item))
-        .filter((result): result is z.SafeParseSuccess<OutputFileInfo> => result.success)
+        .filter((result): result is { success: true; data: OutputFileInfo } => result.success)
         .map((result) => result.data);
       if (parsed.length > 0) {
         map.set(round.data, parsed);

--- a/src/tools/arxiv/ArxivMetadataTool.ts
+++ b/src/tools/arxiv/ArxivMetadataTool.ts
@@ -72,7 +72,7 @@ export class ArxivMetadataTool extends defineTool({
       authors: authorNames,
       journalReference: targetEntry.journalRef ?? null,
       comment: targetEntry.comment ?? null,
-      primaryCategory: targetEntry.primaryCategory?.term ?? null,
+      primaryCategory: targetEntry.primaryCategory ?? null,
       links: targetEntry.links ?? null,
       // Conditionally include abstract field only when requested
       ...(includeAbstract && { abstract: targetEntry.summary ?? null }),

--- a/src/tools/arxiv/ArxivSearchTool.ts
+++ b/src/tools/arxiv/ArxivSearchTool.ts
@@ -108,7 +108,7 @@ export class ArxivSearchTool extends defineTool({
         published: entry.published ?? null,
         updated: entry.updated ?? null,
         authors: getAuthorNames(entry.authors),
-        primaryCategory: entry.primaryCategory?.term ?? null,
+        primaryCategory: entry.primaryCategory ?? null,
         arxivUrl: identifier
           ? `https://arxiv.org/abs/${normaliseArxivIdentifier(identifier)}`
           : null,


### PR DESCRIPTION
…ypes

- Replace z.SafeParseSuccess with inline type predicate for Zod v4 compatibility
- Use primaryCategory directly instead of .term property to match arxiv-client types

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces `z.SafeParseSuccess` type guard with an inline predicate and updates arXiv tools to use `primaryCategory` directly (not `.term`).
> 
> - **Types/Zod**
>   - In `src/progressView/managers/OutputFilesManager.ts`, replace `z.SafeParseSuccess<OutputFileInfo>` type predicate with inline `{ success: true; data: OutputFileInfo }` in `filter(...)` for Zod v4 compatibility.
> - **arXiv Tools**
>   - In `src/tools/arxiv/ArxivMetadataTool.ts` and `src/tools/arxiv/ArxivSearchTool.ts`, map `primaryCategory` directly from entries instead of accessing `.term` to match `arxiv-client` types.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d5c5bb93958851e3f961a8c05813782db27ceffe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->