### PR TITLE
Formalize half ancillas lemma in graph section

### DIFF
--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -29,7 +29,7 @@ import {
   CHEVRON_DOWN_CLASS,
 } from '@common/iconConstants.js';
 import { getBasename } from '@common/pathUtils.js';
-import { encodeHtml } from '@common/htmlEncoding.js';
+import { encodeHtml, decodeHtml } from '@common/htmlEncoding.js';
 
 // Constants
 export const BULLET_MARKUP =
@@ -733,7 +733,7 @@ export class LogEntryFormatter {
       return bannerEntry ? bannerEntry.element : null;
     }
 
-    bannerEntry.contentElem.dataset.rawContent = trimmedContent;
+    bannerEntry.contentElem.dataset.rawContent = decodeHtml(trimmedContent);
     bannerEntry.contentElem.innerHTML = parsedMarkdown;
 
     return bannerEntry.element;
@@ -878,7 +878,7 @@ export class LogEntryFormatter {
 
     if (contentElem) {
       contentElem.classList.add(`message-${level}`);
-      contentElem.dataset.rawContent = trimmedContent;
+      contentElem.dataset.rawContent = decodeHtml(trimmedContent);
       contentElem.innerHTML = this._processMarkdownContent(trimmedContent);
     }
 


### PR DESCRIPTION
The thinking/scratchpad content is HTML-encoded in AgentLogger before being sent to the webview. When storing for the copy button, we need to decode it back to get the original source text.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Decode HTML-encoded thinking/scratchpad and model response content before saving to `data-rawContent` to ensure copy returns original text.
> 
> - **Progress View (formatters.js)**
>   - Import `decodeHtml` and use it to set `dataset.rawContent` for:
>     - `thinking`/`scratchpad` banner content in `_formatBannerContent`
>     - `modelResponse` content in `_formatModelResponse`
>   - Ensures copy actions use original, unencoded text.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0386e9cf55ee5395a9045a55333ef023ecda41c6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->