### PR TITLE
Refactor messy and repetitive code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -282,7 +282,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -326,7 +325,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -777,7 +775,6 @@
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.23.0.tgz",
       "integrity": "sha512-MCGd4K9aZKvuSqdoBkdMvZNcYXCkZRYVs/Gh92mdV5IHbctX9H9uIvd4X93+9g8tBbXv08sxc/QHXTzf8y65bA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
@@ -1272,7 +1269,6 @@
       "integrity": "sha512-PC0PDZfJg8sP7cmKe6L3QIL8GZwU5aRvUFedqSIpw3B+QjRSUZeeITC2M5XKeMXEzL6wccN196iy3JLwKNvDVA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.48.1",
         "@typescript-eslint/types": "8.48.1",
@@ -1885,7 +1881,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2433,7 +2428,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.9",
         "caniuse-lite": "^1.0.30001746",
@@ -3520,7 +3514,6 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3919,7 +3912,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
       "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.0",
@@ -7703,7 +7695,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -8826,7 +8817,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9043,7 +9033,6 @@
       "integrity": "sha512-HU1JOuV1OavsZ+mfigY0j8d1TgQgbZ6M+J75zDkpEAwYeXjWSqrGJtgnPblJjd/mAyTNQ7ygw0MiKOn6etz8yw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -9093,7 +9082,6 @@
       "integrity": "sha512-MfwFQ6SfwinsUVi0rNJm7rHZ31GyTcpVE5pgVA3hwFRb7COD4TzjUUwhGWKfO50+xdc2MQPuEBBJoqIMGt3JDw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.6.1",
         "@webpack-cli/configtest": "^3.0.1",
@@ -9786,7 +9774,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.13.tgz",
       "integrity": "sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/agent/core/flows/BaseRetryWaitNode.ts
+++ b/src/agent/core/flows/BaseRetryWaitNode.ts
@@ -100,12 +100,6 @@ class RetryWaitNode<
     const streamId = this.accessors.getStreamId(prepRes, this._params);
     const logger = this.accessors.getLogger(prepRes, this._params);
 
-    // Log waiting status
-    logger.info('Waiting for manual retry', {
-      messageType: MESSAGE_TYPES.PROGRESS_STATUS,
-      data: { error: retryState.lastError },
-    });
-
     // Emit waiting status to UI
     bus.emit('updateStreamStatus', { stream: streamId, status: 'waiting' });
 
@@ -175,9 +169,6 @@ class RetryWaitNode<
 
     if (execRes === 'retry') {
       clearRetryError(retryState);
-      logger.info('Manual retry triggered', {
-        messageType: MESSAGE_TYPES.PROGRESS_STATUS,
-      });
       bus.emit('updateStreamStatus', { stream: streamId, status: 'resuming' });
       return FlowTransition.MANUAL_RETRY;
     }

--- a/src/agent/core/flows/BaseRetryWaitNode.ts
+++ b/src/agent/core/flows/BaseRetryWaitNode.ts
@@ -101,7 +101,9 @@ class RetryWaitNode<
     const logger = this.accessors.getLogger(prepRes, this._params);
 
     // Internal log for debugging (output channel only)
-    logger.debug(`Waiting for manual retry: ${retryState.lastError?.message ?? 'unknown error'}`);
+    logger.debug(
+      `Waiting for manual retry: ${retryState.lastError?.message ?? 'unknown error'}`,
+    );
 
     // Emit waiting status to UI
     bus.emit('updateStreamStatus', { stream: streamId, status: 'waiting' });

--- a/src/agent/core/flows/BaseRetryWaitNode.ts
+++ b/src/agent/core/flows/BaseRetryWaitNode.ts
@@ -100,6 +100,9 @@ class RetryWaitNode<
     const streamId = this.accessors.getStreamId(prepRes, this._params);
     const logger = this.accessors.getLogger(prepRes, this._params);
 
+    // Internal log for debugging (output channel only)
+    logger.debug(`Waiting for manual retry: ${retryState.lastError?.message ?? 'unknown error'}`);
+
     // Emit waiting status to UI
     bus.emit('updateStreamStatus', { stream: streamId, status: 'waiting' });
 
@@ -169,6 +172,7 @@ class RetryWaitNode<
 
     if (execRes === 'retry') {
       clearRetryError(retryState);
+      logger.debug('Manual retry triggered');
       bus.emit('updateStreamStatus', { stream: streamId, status: 'resuming' });
       return FlowTransition.MANUAL_RETRY;
     }

--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -26,7 +26,10 @@ import { checkForMassiveRepetition } from '@agent/utils/text/repetitionUtils';
 // Local imports - logging
 // Internal imports
 import { isTokenLimitStopReason } from '@agent/modelHandlers/utils/stopReasonUtils';
-import { formatProviderHttpError } from '@common/errors/sdkErrorUtils';
+import {
+  formatProviderHttpError,
+  extractErrorContext,
+} from '@common/errors/sdkErrorUtils';
 import { MESSAGE_TYPES } from '@logger/messageTypes';
 import replacementEngine from '@replacement/engine';
 import type { AgentFileLocation } from '@utils/files';
@@ -332,10 +335,13 @@ class ResponseModelInvocationNode<C> extends Node<
     error: Error,
   ): Promise<InvocationExecResult> {
     const formatted = formatProviderHttpError(error);
+    // Extract enriched context attached by requestExecutor (operation name, model)
+    const context = extractErrorContext(error);
     const fallbackResult = determineFallbackAction(
       formatted.retryable,
       formatted.message,
       formatted.statusCode,
+      context,
     );
     return { kind: 'fallback', result: fallbackResult };
   }

--- a/src/agent/core/flows/RetryState.ts
+++ b/src/agent/core/flows/RetryState.ts
@@ -186,19 +186,17 @@ function formatErrorMessage(
   const context = error.context;
   const operation = context?.operation;
 
-  // Build message parts
-  const parts: string[] = [`${operationName} failed`];
-  if (suffix) {
-    parts[0] += ` ${suffix}`;
-  }
-  parts.push(error.message);
+  // Build base message
+  const prefix = suffix
+    ? `${operationName} failed ${suffix}`
+    : `${operationName} failed`;
 
   // Add operation context if available and different from operationName
   if (operation && !operationName.toLowerCase().includes(operation.toLowerCase())) {
-    return `${parts[0]} [${operation}]: ${error.message}`;
+    return `${prefix} [${operation}]: ${error.message}`;
   }
 
-  return `${parts[0]}: ${error.message}`;
+  return `${prefix}: ${error.message}`;
 }
 
 /**

--- a/src/agent/core/flows/RetryState.ts
+++ b/src/agent/core/flows/RetryState.ts
@@ -11,6 +11,7 @@
  */
 
 import type { AgentLogger } from '@logger/AgentLogger';
+import type { ErrorLogContext } from '@common/errors/sdkErrorUtils';
 import {
   getModelRetryBackoffMs,
   getModelRetryMaxAttempts,
@@ -43,6 +44,8 @@ export interface RetryErrorInfo {
   message: string;
   statusCode?: number;
   retryable: boolean;
+  /** Operation context from error enrichment (e.g., operation name, model) */
+  context?: ErrorLogContext;
 }
 
 /**
@@ -151,14 +154,16 @@ export type FallbackResult =
  * @param retryable - Whether the error is retryable (from formatProviderHttpError)
  * @param message - Error message
  * @param statusCode - HTTP status code if available
+ * @param context - Operation context from error enrichment (operation name, model)
  * @returns FallbackResult for post() to handle
  */
 export function determineFallbackAction(
   retryable: boolean,
   message: string,
   statusCode?: number,
+  context?: ErrorLogContext,
 ): FallbackResult {
-  const error: RetryErrorInfo = { message, statusCode, retryable };
+  const error: RetryErrorInfo = { message, statusCode, retryable, context };
 
   if (retryable) {
     // Error is retryable but auto-retries exhausted → offer manual retry
@@ -170,8 +175,38 @@ export function determineFallbackAction(
 }
 
 /**
+ * Formats the error message with operation context for logging.
+ * Includes the specific operation that failed (e.g., "google.chat.sendMessageStream").
+ */
+function formatErrorMessage(
+  operationName: string,
+  error: RetryErrorInfo,
+  suffix?: string,
+): string {
+  const context = error.context;
+  const operation = context?.operation;
+
+  // Build message parts
+  const parts: string[] = [`${operationName} failed`];
+  if (suffix) {
+    parts[0] += ` ${suffix}`;
+  }
+  parts.push(error.message);
+
+  // Add operation context if available and different from operationName
+  if (operation && !operationName.toLowerCase().includes(operation.toLowerCase())) {
+    return `${parts[0]} [${operation}]: ${error.message}`;
+  }
+
+  return `${parts[0]}: ${error.message}`;
+}
+
+/**
  * Applies fallback result: records error, logs, and returns flow transition.
  * Called from post() after receiving FallbackResult from execFallback.
+ *
+ * This is the single source of truth for error logging (log at boundary principle).
+ * The error context from enrichError() is included in the log message.
  *
  * @param result - The fallback result from determineFallbackAction
  * @param state - The retry state to update
@@ -191,14 +226,14 @@ export function applyFallbackResult(
   switch (result.outcome) {
     case 'manual_retry':
       logger.logErrorData(
-        `${operationName} failed: ${result.error.message}`,
+        formatErrorMessage(operationName, result.error),
         result.error,
       );
       return FlowTransition.AWAIT_RETRY;
 
     case 'fail':
       logger.logErrorData(
-        `${operationName} failed (not retryable): ${result.error.message}`,
+        formatErrorMessage(operationName, result.error, '(not retryable)'),
         result.error,
       );
       return FlowTransition.COMPLETE;

--- a/src/agent/core/flows/RetryState.ts
+++ b/src/agent/core/flows/RetryState.ts
@@ -10,8 +10,8 @@
  * - This module tracks the last error for UI display and caller reporting
  */
 
-import type { AgentLogger } from '@logger/AgentLogger';
 import type { ErrorLogContext } from '@common/errors/sdkErrorUtils';
+import type { AgentLogger } from '@logger/AgentLogger';
 import {
   getModelRetryBackoffMs,
   getModelRetryMaxAttempts,
@@ -192,7 +192,10 @@ function formatErrorMessage(
     : `${operationName} failed`;
 
   // Add operation context if available and different from operationName
-  if (operation && !operationName.toLowerCase().includes(operation.toLowerCase())) {
+  if (
+    operation &&
+    !operationName.toLowerCase().includes(operation.toLowerCase())
+  ) {
     return `${prefix} [${operation}]: ${error.message}`;
   }
 

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -25,7 +25,10 @@ import { withToolFileInteractionContext } from '@agent/toolUse/ToolFileInteracti
 import type { FileInteractionState } from '@agent/core/AgentWorkspaceState';
 import type { ToolResult } from '@agent/core/ToolTypes';
 import { toolResult } from '@agent/core/ToolTypes';
-import { formatProviderHttpError } from '@common/errors/sdkErrorUtils';
+import {
+  formatProviderHttpError,
+  extractErrorContext,
+} from '@common/errors/sdkErrorUtils';
 
 // Local imports - logging
 import { AgentLogger } from '@logger/AgentLogger';
@@ -358,10 +361,13 @@ class ToolUseCallNode<C> extends Node<
     error: Error,
   ): Promise<ToolUseCallResult> {
     const formatted = formatProviderHttpError(error);
+    // Extract enriched context attached by requestExecutor (operation name, model)
+    const context = extractErrorContext(error);
     const fallbackResult = determineFallbackAction(
       formatted.retryable,
       formatted.message,
       formatted.statusCode,
+      context,
     );
     return { kind: 'fallback', result: fallbackResult };
   }

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -427,73 +427,81 @@ export class ModelHandlerAnthropic extends ModelHandler<
           'Skipping token counting because Anthropic countTokens does not support file-based document sources.',
         );
       } else {
-        const countTokensParams: MessageCountTokensParams = {
-          model: this.config.fullName,
-          system: systemPrompt,
-          messages,
-        };
+        // Token counting uses soft failure - if it fails, we proceed without adjustment
+        // and let the API enforce limits. This avoids unnecessary retries for non-critical operations.
+        try {
+          const countTokensParams: MessageCountTokensParams = {
+            model: this.config.fullName,
+            system: systemPrompt,
+            messages,
+          };
 
-        // If thinking is enabled, we need to pass it to countTokens as well
-        // to ensure consistency with the actual message creation.
-        // Without this, the API returns an error when messages contain thinking blocks.
-        if (options.thinking) {
-          countTokensParams.thinking = options.thinking;
-        }
+          // If thinking is enabled, we need to pass it to countTokens as well
+          // to ensure consistency with the actual message creation.
+          // Without this, the API returns an error when messages contain thinking blocks.
+          if (options.thinking) {
+            countTokensParams.thinking = options.thinking;
+          }
 
-        // Strip betas that only apply to message creation (e.g., output length)
-        // while keeping context headers needed for accurate token counting.
-        const countTokenBetas = options.betas?.filter(
-          (beta) => beta === CONTEXT_1M_BETA,
-        );
-        if (countTokenBetas && countTokenBetas.length > 0) {
-          countTokensParams.betas = countTokenBetas;
-        }
-
-        const responseTokenCount = await executeRequest(
-          {
-            model: this.config.name,
-            operation: 'anthropic.beta.messages.countTokens',
-            signal,
-          },
-          () => client.beta.messages.countTokens(countTokensParams),
-        );
-        const { input_tokens: inputTokens } = responseTokenCount;
-        this.logger.debug(`Token count of message: ${inputTokens}`);
-        if (inputTokens > effectiveContextWindow) {
-          const errMsg = `Token count of message exceeds context window: ${inputTokens} > ${effectiveContextWindow}`;
-          this.logger.error(errMsg);
-          throw new Error(errMsg);
-        }
-        if (effectiveContextWindow - inputTokens < options.max_tokens) {
-          const reducedMaxTokens = Math.max(
-            0,
-            effectiveContextWindow - inputTokens - 10,
+          // Strip betas that only apply to message creation (e.g., output length)
+          // while keeping context headers needed for accurate token counting.
+          const countTokenBetas = options.betas?.filter(
+            (beta) => beta === CONTEXT_1M_BETA,
           );
-          const warnMsg = `Token count of message plus max tokens exceeds context window: ${inputTokens} + ${options.max_tokens} > ${effectiveContextWindow}. Reducing max tokens to ${reducedMaxTokens}.`;
-          this.logger.warn(warnMsg);
-          options.max_tokens = reducedMaxTokens;
+          if (countTokenBetas && countTokenBetas.length > 0) {
+            countTokensParams.betas = countTokenBetas;
+          }
 
-          if (
-            this.capabilities.supportsReasoning &&
-            options.thinking &&
-            options.thinking.type === 'enabled'
-          ) {
-            const adjustedBudget = Math.max(
-              1,
-              Math.min(
-                options.thinking.budget_tokens,
-                Math.floor(options.max_tokens * 0.5),
-              ),
+          const responseTokenCount = await executeRequest(
+            {
+              model: this.config.name,
+              operation: 'anthropic.beta.messages.countTokens',
+              signal,
+            },
+            () => client.beta.messages.countTokens(countTokensParams),
+          );
+          const { input_tokens: inputTokens } = responseTokenCount;
+          this.logger.debug(`Token count of message: ${inputTokens}`);
+          if (inputTokens > effectiveContextWindow) {
+            const errMsg = `Token count of message exceeds context window: ${inputTokens} > ${effectiveContextWindow}`;
+            this.logger.error(errMsg);
+            throw new Error(errMsg);
+          }
+          if (effectiveContextWindow - inputTokens < options.max_tokens) {
+            const reducedMaxTokens = Math.max(
+              0,
+              effectiveContextWindow - inputTokens - 10,
             );
-            if (adjustedBudget !== options.thinking.budget_tokens) {
-              this.logger.debug(
-                `Adjusted thinking budget to ${adjustedBudget} due to reduced max_tokens`,
+            const warnMsg = `Token count of message plus max tokens exceeds context window: ${inputTokens} + ${options.max_tokens} > ${effectiveContextWindow}. Reducing max tokens to ${reducedMaxTokens}.`;
+            this.logger.warn(warnMsg);
+            options.max_tokens = reducedMaxTokens;
+
+            if (
+              this.capabilities.supportsReasoning &&
+              options.thinking &&
+              options.thinking.type === 'enabled'
+            ) {
+              const adjustedBudget = Math.max(
+                1,
+                Math.min(
+                  options.thinking.budget_tokens,
+                  Math.floor(options.max_tokens * 0.5),
+                ),
               );
-              options.thinking.budget_tokens = adjustedBudget;
+              if (adjustedBudget !== options.thinking.budget_tokens) {
+                this.logger.debug(
+                  `Adjusted thinking budget to ${adjustedBudget} due to reduced max_tokens`,
+                );
+                options.thinking.budget_tokens = adjustedBudget;
+              }
             }
           }
+          // in the future we log this in firstInputTokens of the AgentRunState
+        } catch (err) {
+          this.logger.warn(
+            `Token counting failed: ${getSdkErrorMessage(err)}. Proceeding without token adjustment.`,
+          );
         }
-        // in the future we log this in firstInputTokens of the AgentRunState
       }
     }
 

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -498,6 +498,12 @@ export class ModelHandlerAnthropic extends ModelHandler<
           }
           // in the future we log this in firstInputTokens of the AgentRunState
         } catch (err) {
+          // Re-throw context window violations - these are intentional validation errors
+          // that should fail fast, not be swallowed by soft failure
+          if (err instanceof Error && err.message.includes('exceeds context window')) {
+            throw err;
+          }
+          // Soft failure for token counting API errors - proceed without adjustment
           this.logger.warn(
             `Token counting failed: ${getSdkErrorMessage(err)}. Proceeding without token adjustment.`,
           );

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -546,74 +546,72 @@ export class ModelHandlerAnthropic extends ModelHandler<
 
     let response: BetaMessage;
 
-    try {
-      if (useStreaming) {
-        // in the future if we pass stream to outside, calling stream.controller.abort() will abort the stream; which will be very useful for our stop button
-        // we should also make sure partial results can be returned in the presence of errors!
-        const stream = await executeRequest(
-          {
-            model: this.config.name,
-            operation: 'anthropic.beta.messages.stream',
-            signal,
-          },
-          () => client.beta.messages.stream(options, { signal }),
-        );
+    if (useStreaming) {
+      // in the future if we pass stream to outside, calling stream.controller.abort() will abort the stream; which will be very useful for our stop button
+      // we should also make sure partial results can be returned in the presence of errors!
+      const stream = await executeRequest(
+        {
+          model: this.config.name,
+          operation: 'anthropic.beta.messages.stream',
+          signal,
+        },
+        () => client.beta.messages.stream(options, { signal }),
+      );
 
-        if (signal?.aborted) {
-          stream.controller.abort();
-          const abortError =
-            signal.reason ??
-            Object.assign(new Error('The operation was aborted.'), {
-              name: 'AbortError',
-            });
-          throw abortError;
-        }
-
-        let cleanupAbortListener: (() => void) | undefined;
-        if (signal) {
-          const abortListener = () => {
-            stream.controller.abort();
-            signal.removeEventListener('abort', abortListener);
-          };
-          signal.addEventListener('abort', abortListener);
-          cleanupAbortListener = () => {
-            signal.removeEventListener('abort', abortListener);
-          };
-        }
-
-        try {
-          const thinking = this.createThinkingStream();
-          const output = this.isOutputStreamingEnabled()
-            ? this.createOutputStream()
-            : undefined;
-          stream.on('thinking', (delta: string) => {
-            thinking.append(delta);
+      if (signal?.aborted) {
+        stream.controller.abort();
+        const abortError =
+          signal.reason ??
+          Object.assign(new Error('The operation was aborted.'), {
+            name: 'AbortError',
           });
-          stream.on('text', (delta: string) => {
-            output?.append(delta);
-          });
-
-          // Note that there is no second consumption problem as per anthropic sdk examples
-          response = await stream.finalMessage();
-          const finalReasoning = this.processThinkingBlock(response);
-          thinking.finalize(finalReasoning ?? undefined);
-          // Extract text manually instead of using finalText() which throws
-          // when response contains only thinking + tool_use blocks with no text
-          const finalOutput = extractTextFromContent(response.content);
-          if (output) output.finalize(finalOutput);
-        } finally {
-          cleanupAbortListener?.();
-        }
-      } else {
-        response = await executeRequest(
-          {
-            model: this.config.name,
-            operation: 'anthropic.beta.messages.create',
-            signal,
-          },
-          () => client.beta.messages.create(options, { signal }),
-        );
+        throw abortError;
       }
+
+      let cleanupAbortListener: (() => void) | undefined;
+      if (signal) {
+        const abortListener = () => {
+          stream.controller.abort();
+          signal.removeEventListener('abort', abortListener);
+        };
+        signal.addEventListener('abort', abortListener);
+        cleanupAbortListener = () => {
+          signal.removeEventListener('abort', abortListener);
+        };
+      }
+
+      try {
+        const thinking = this.createThinkingStream();
+        const output = this.isOutputStreamingEnabled()
+          ? this.createOutputStream()
+          : undefined;
+        stream.on('thinking', (delta: string) => {
+          thinking.append(delta);
+        });
+        stream.on('text', (delta: string) => {
+          output?.append(delta);
+        });
+
+        // Note that there is no second consumption problem as per anthropic sdk examples
+        response = await stream.finalMessage();
+        const finalReasoning = this.processThinkingBlock(response);
+        thinking.finalize(finalReasoning ?? undefined);
+        // Extract text manually instead of using finalText() which throws
+        // when response contains only thinking + tool_use blocks with no text
+        const finalOutput = extractTextFromContent(response.content);
+        if (output) output.finalize(finalOutput);
+      } finally {
+        cleanupAbortListener?.();
+      }
+    } else {
+      response = await executeRequest(
+        {
+          model: this.config.name,
+          operation: 'anthropic.beta.messages.create',
+          signal,
+        },
+        () => client.beta.messages.create(options, { signal }),
+      );
     }
     // Note: Errors propagate to PocketFlow's execFallback which logs once (log at boundary principle)
 

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -451,7 +451,6 @@ export class ModelHandlerAnthropic extends ModelHandler<
 
         const responseTokenCount = await executeRequest(
           {
-            logger: this.logger,
             model: this.config.name,
             operation: 'anthropic.beta.messages.countTokens',
             signal,
@@ -545,7 +544,6 @@ export class ModelHandlerAnthropic extends ModelHandler<
         // we should also make sure partial results can be returned in the presence of errors!
         const stream = await executeRequest(
           {
-            logger: this.logger,
             model: this.config.name,
             operation: 'anthropic.beta.messages.stream',
             signal,
@@ -601,7 +599,6 @@ export class ModelHandlerAnthropic extends ModelHandler<
       } else {
         response = await executeRequest(
           {
-            logger: this.logger,
             model: this.config.name,
             operation: 'anthropic.beta.messages.create',
             signal,
@@ -610,11 +607,8 @@ export class ModelHandlerAnthropic extends ModelHandler<
         );
       }
     } catch (err) {
-      this.logger.logError(
-        `Error creating response: ${getSdkErrorMessage(err)}`,
-        err,
-        { operation: 'create response' },
-      );
+      // Error logging follows "log at the boundary" principle - the fallback handler
+      // (RetryState.applyFallbackResult) will log the error once. Rethrow without logging.
       throw err;
     }
 
@@ -724,7 +718,6 @@ export class ModelHandlerAnthropic extends ModelHandler<
           buffer = Buffer.from(base64Data, 'base64');
           const uploadedFile = await executeRequest(
             {
-              logger: this.logger,
               model: this.config.name,
               operation: `anthropic.beta.files.upload:${sanitizedFilename}`,
             },
@@ -845,7 +838,6 @@ export class ModelHandlerAnthropic extends ModelHandler<
         const base64Data = buffer.toString('base64');
         const uploadedFile = await executeRequest(
           {
-            logger: this.logger,
             model: this.config.name,
             operation: `anthropic.beta.files.upload:${filename}`,
           },

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -51,7 +51,10 @@ import type { NormalizedUsage } from '@agent/types/NormalizedUsage';
 import { createContinuationMessage } from '@agent/utils/continuationMessage';
 import { MediaEntry } from '@agent/utils/mediaTypes';
 import { calculateTokenPrice } from '@agent/utils/priceUtils';
-import { getSdkErrorMessage } from '@common/errors/sdkErrorUtils';
+import {
+  getSdkErrorMessage,
+  isContextWindowError,
+} from '@common/errors/sdkErrorUtils';
 
 // Internal imports
 import { cleanFileContent } from '@replacement/engine';
@@ -500,7 +503,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
         } catch (err) {
           // Re-throw context window violations - these are intentional validation errors
           // that should fail fast, not be swallowed by soft failure
-          if (err instanceof Error && err.message.includes('exceeds context window')) {
+          if (isContextWindowError(err)) {
             throw err;
           }
           // Soft failure for token counting API errors - proceed without adjustment

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -606,11 +606,8 @@ export class ModelHandlerAnthropic extends ModelHandler<
           () => client.beta.messages.create(options, { signal }),
         );
       }
-    } catch (err) {
-      // Error logging follows "log at the boundary" principle - the fallback handler
-      // (RetryState.applyFallbackResult) will log the error once. Rethrow without logging.
-      throw err;
     }
+    // Note: Errors propagate to PocketFlow's execFallback which logs once (log at boundary principle)
 
     return response;
   }
@@ -734,8 +731,6 @@ export class ModelHandlerAnthropic extends ModelHandler<
             type: 'file',
             file_id: uploadedFile.id,
           } as BetaRequestDocumentBlock['source'];
-        } catch (err) {
-          throw err;
         } finally {
           if (buffer) {
             buffer.fill(0);

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -248,7 +248,6 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
         );
         const uploadResult: File = await executeRequest(
           {
-            logger: this.logger,
             model: this.config.name,
             operation: `google.files.upload:${fileName}`,
           },
@@ -393,7 +392,6 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
 
         const responseTokenCount = await executeRequest(
           {
-            logger: this.logger,
             model: this.config.name,
             operation: 'google.models.countTokens',
             signal,
@@ -456,7 +454,6 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
         };
         const stream = await executeRequest(
           {
-            logger: this.logger,
             model: this.config.name,
             operation: 'google.chat.sendMessageStream',
             signal,
@@ -588,7 +585,6 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
       };
       const result = await executeRequest(
         {
-          logger: this.logger,
           model: this.config.name,
           operation: 'google.chat.sendMessage',
           signal,
@@ -598,21 +594,19 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
 
       return result;
     } catch (error) {
-      this.logger.logError(
-        `Error during Google GenAI Chat API call: ${getSdkErrorMessage(error)}`,
-        error,
-        { operation: 'Google GenAI Chat API call' },
-      );
+      // Error logging follows "log at the boundary" principle - the fallback handler
+      // (RetryState.applyFallbackResult) will log the error once. We only add debug
+      // diagnostics here for specific error types that need additional context.
       if (
         error instanceof Error &&
         error.message?.includes('request.contents[0].parts')
       ) {
-        this.logger.error(
+        this.logger.debug(
           'Potential issue with sendMessage parameter structure. Check conversion.',
         );
       }
       if (error instanceof Error && error.message?.includes('SAFETY')) {
-        this.logger.error(
+        this.logger.debug(
           `Safety block details: ${JSON.stringify((error as any).response?.promptFeedback)}`,
         );
       }

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -43,7 +43,10 @@ import type { NormalizedUsage } from '@agent/types/NormalizedUsage';
 import { createContinuationMessage } from '@agent/utils/continuationMessage';
 import { MediaEntry } from '@agent/utils/mediaTypes';
 import { calculateTokenPrice } from '@agent/utils/priceUtils';
-import { getSdkErrorMessage } from '@common/errors/sdkErrorUtils';
+import {
+  getSdkErrorMessage,
+  isContextWindowError,
+} from '@common/errors/sdkErrorUtils';
 import { AgentLogger } from '@logger/AgentLogger';
 
 import { ReasoningEffort } from '@model/ModelConfig';
@@ -426,7 +429,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
       } catch (err) {
         // Re-throw context window violations - these are intentional validation errors
         // that should fail fast, not be swallowed by soft failure
-        if (err instanceof Error && err.message.includes('exceeds context window')) {
+        if (isContextWindowError(err)) {
           throw err;
         }
         // Soft failure for token counting API errors - proceed without adjustment

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -424,7 +424,12 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
             this.config.contextWindow - totalTokens - 10;
         }
       } catch (err) {
-        // Token counting uses soft failure - proceed without adjustment
+        // Re-throw context window violations - these are intentional validation errors
+        // that should fail fast, not be swallowed by soft failure
+        if (err instanceof Error && err.message.includes('exceeds context window')) {
+          throw err;
+        }
+        // Soft failure for token counting API errors - proceed without adjustment
         this.logger.warn(
           `Token counting failed: ${getSdkErrorMessage(err)}. Proceeding without token adjustment.`,
         );

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -614,8 +614,8 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
         );
       }
       if (error instanceof Error && error.message?.includes('SAFETY')) {
-        this.logger.debug(
-          `Safety block details: ${JSON.stringify((error as any).response?.promptFeedback)}`,
+        this.logger.warn(
+          `Content blocked by safety filter: ${JSON.stringify((error as any).response?.promptFeedback)}`,
         );
       }
       throw error;

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -424,9 +424,9 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
             this.config.contextWindow - totalTokens - 10;
         }
       } catch (err) {
-        this.logger.error(
-          `Token counting failed, proceeding without token adjustment: ${getSdkErrorMessage(err)}`,
-          { data: err },
+        // Token counting uses soft failure - proceed without adjustment
+        this.logger.warn(
+          `Token counting failed: ${getSdkErrorMessage(err)}. Proceeding without token adjustment.`,
         );
       }
     }

--- a/src/agent/modelHandlers/modelHandlerKimi.ts
+++ b/src/agent/modelHandlers/modelHandlerKimi.ts
@@ -157,7 +157,6 @@ export class ModelHandlerKimi extends ModelHandlerOpenAI {
 
         const stream = await executeRequest(
           {
-            logger: this.logger,
             model: this.config.name,
             operation: 'kimi.chat.completions.stream',
             signal,
@@ -233,7 +232,6 @@ export class ModelHandlerKimi extends ModelHandlerOpenAI {
       // Non-streaming request
       return executeRequest(
         {
-          logger: this.logger,
           model: this.config.name,
           operation: 'kimi.chat.completions.create',
           signal,

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -30,7 +30,10 @@ import type { NormalizedUsage } from '@agent/types/NormalizedUsage';
 import { createContinuationMessage } from '@agent/utils/continuationMessage';
 import { MediaEntry } from '@agent/utils/mediaTypes';
 import { calculateTokenPrice } from '@agent/utils/priceUtils';
-import { getSdkErrorMessage } from '@common/errors/sdkErrorUtils';
+import {
+  getSdkErrorMessage,
+  isContextWindowError,
+} from '@common/errors/sdkErrorUtils';
 
 // Type imports
 import type { ToolDefinition } from '@model';
@@ -246,9 +249,14 @@ export class ModelHandlerOpenAI<
         }
       }
     } catch (err) {
-      this.logger.error(
+      // Re-throw context window violations - these are intentional validation errors
+      // that should fail fast, not be swallowed by soft failure
+      if (isContextWindowError(err)) {
+        throw err;
+      }
+      // Soft failure for token counting errors - proceed without adjustment
+      this.logger.warn(
         `Token counting failed: ${getSdkErrorMessage(err)}. Proceeding without token adjustment.`,
-        { data: err },
       );
     }
   }

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -296,7 +296,6 @@ export class ModelHandlerOpenAI<
 
     return executeRequest(
       {
-        logger: this.logger,
         model: this.config.name,
         operation: 'openai.chat.completions.stream',
         signal,
@@ -367,7 +366,6 @@ export class ModelHandlerOpenAI<
   ): Promise<ChatCompletion> {
     return executeRequest(
       {
-        logger: this.logger,
         model: this.config.name,
         operation: 'openai.chat.completions.create',
         signal,

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -1334,35 +1334,34 @@ export class ModelHandlerOpenAI<
     // Note: This is a simplified token count. A more accurate count would
     // need to replicate OpenAI's specific chat message formatting rules.
     // https://github.com/openai/openai-cookbook/blob/main/examples/How_to_count_tokens_with_tiktoken.ipynb
-    try {
-      // Combine system prompt and messages for counting
-      // TODO: This might not be perfectly accurate for multi-modal or structured messages.
-      // gpt-tokenizer's countTokens might need a ChatMessage structure similar to Anthropic's.
-      // For now, concatenate text content.
-      let textToCount = systemPrompt ? `${systemPrompt}\n` : '';
-      messages.forEach((msg) => {
-        if (Array.isArray(msg.content)) {
-          msg.content.forEach((part: any) => {
-            if (part.type === 'text') {
-              textToCount += `${msg.role}: ${part.text}\n`;
-            }
-            // Basic handling for other types, might need refinement
-            else if (part.type === 'image_url') {
-              // Approximation: Count tokens for a placeholder text representation
-              textToCount += `${msg.role}: [Image]\n`;
-            } else if (part.type === 'input_audio') {
-              textToCount += `${msg.role}: [Audio]\n`;
-            }
-          });
-        } else if (typeof msg.content === 'string') {
-          textToCount += `${msg.role}: ${msg.content}\n`;
-        }
-      });
-      // Use the appropriate encoding based on the model, defaulting to cl100k_base
-      // Needs a mapping from model name to encoding or importing specific model tokenizers.
-      // Assuming cl100k_base for gpt-3.5/4 for now. Need to enhance this.
-      return countTokens(textToCount); // Assuming cl100k_base default
-    }
-    // Note: Errors propagate to caller which handles them appropriately
+    // Errors propagate to caller which handles them appropriately.
+
+    // Combine system prompt and messages for counting
+    // TODO: This might not be perfectly accurate for multi-modal or structured messages.
+    // gpt-tokenizer's countTokens might need a ChatMessage structure similar to Anthropic's.
+    // For now, concatenate text content.
+    let textToCount = systemPrompt ? `${systemPrompt}\n` : '';
+    messages.forEach((msg) => {
+      if (Array.isArray(msg.content)) {
+        msg.content.forEach((part: any) => {
+          if (part.type === 'text') {
+            textToCount += `${msg.role}: ${part.text}\n`;
+          }
+          // Basic handling for other types, might need refinement
+          else if (part.type === 'image_url') {
+            // Approximation: Count tokens for a placeholder text representation
+            textToCount += `${msg.role}: [Image]\n`;
+          } else if (part.type === 'input_audio') {
+            textToCount += `${msg.role}: [Audio]\n`;
+          }
+        });
+      } else if (typeof msg.content === 'string') {
+        textToCount += `${msg.role}: ${msg.content}\n`;
+      }
+    });
+    // Use the appropriate encoding based on the model, defaulting to cl100k_base
+    // Needs a mapping from model name to encoding or importing specific model tokenizers.
+    // Assuming cl100k_base for gpt-3.5/4 for now. Need to enhance this.
+    return countTokens(textToCount); // Assuming cl100k_base default
   }
 }

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -1362,12 +1362,7 @@ export class ModelHandlerOpenAI<
       // Needs a mapping from model name to encoding or importing specific model tokenizers.
       // Assuming cl100k_base for gpt-3.5/4 for now. Need to enhance this.
       return countTokens(textToCount); // Assuming cl100k_base default
-    } catch (err) {
-      // Log the error and re-throw to indicate failure
-      this.logger.error(`Error counting tokens: ${getSdkErrorMessage(err)}`, {
-        data: err,
-      });
-      throw err;
     }
+    // Note: Errors propagate to caller which handles them appropriately
   }
 }

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -638,49 +638,48 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       return response;
     }
 
-    try {
-      const { stream: _nonStream, ...nonStreamRest } = params;
-      const nonStreamingParams: ResponseCreateParamsNonStreaming = {
-        ...nonStreamRest,
-        stream: false,
-      };
-      let response = await executeRequest(
+    // Non-streaming path
+    // Errors propagate to PocketFlow's execFallback which logs once (log at boundary principle)
+    const { stream: _nonStream, ...nonStreamRest } = params;
+    const nonStreamingParams: ResponseCreateParamsNonStreaming = {
+      ...nonStreamRest,
+      stream: false,
+    };
+    let response = await executeRequest(
+      {
+        model: this.config.name,
+        operation: 'openai.responses.create',
+        signal,
+      },
+      () => client.responses.create(nonStreamingParams, { signal }),
+    );
+    if (useBackgroundResponses) {
+      this.logger.debug(
+        `Background response ${response.id} created with status ${
+          response.status ?? 'unknown'
+        }`,
         {
-          model: this.config.name,
-          operation: 'openai.responses.create',
-          signal,
-        },
-        () => client.responses.create(nonStreamingParams, { signal }),
-      );
-      if (useBackgroundResponses) {
-        this.logger.debug(
-          `Background response ${response.id} created with status ${
-            response.status ?? 'unknown'
-          }`,
-          {
-            data: {
-              responseId: response.id,
-              status: response.status,
-              usage: response.usage ?? undefined,
-            },
+          data: {
+            responseId: response.id,
+            status: response.status,
+            usage: response.usage ?? undefined,
           },
-        );
-        this.logger.logProgress(
-          `Running OpenAI Responses in background mode for response ${response.id}; polling every 15s. Completion may take longer than usual.`,
-        );
-      }
-      if (useBackgroundResponses) {
-        response = await this.waitForBackgroundCompletion(
-          client,
-          response,
-          signal,
-        );
-      }
-      this.previousResponseId = response.id;
-      this.sentMessages = messages.length;
-      return response;
+        },
+      );
+      this.logger.logProgress(
+        `Running OpenAI Responses in background mode for response ${response.id}; polling every 15s. Completion may take longer than usual.`,
+      );
     }
-    // Note: Errors propagate to PocketFlow's execFallback which logs once (log at boundary principle)
+    if (useBackgroundResponses) {
+      response = await this.waitForBackgroundCompletion(
+        client,
+        response,
+        signal,
+      );
+    }
+    this.previousResponseId = response.id;
+    this.sentMessages = messages.length;
+    return response;
   }
 
   /**

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -465,7 +465,6 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       buffer = Buffer.from(payload, 'base64');
       const uploadedFile = await executeRequest(
         {
-          logger: this.logger,
           model: this.config.name,
           operation: `openai.files.create:${filename}`,
         },
@@ -610,7 +609,6 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       const streamParams: ResponseStreamParams = { ...rest, stream: true };
       const stream = await executeRequest(
         {
-          logger: this.logger,
           model: this.config.name,
           operation: 'openai.responses.stream',
           signal,
@@ -648,7 +646,6 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       };
       let response = await executeRequest(
         {
-          logger: this.logger,
           model: this.config.name,
           operation: 'openai.responses.create',
           signal,
@@ -914,7 +911,6 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       const requestOptions = signal ? { signal } : undefined;
       current = await executeRequest(
         {
-          logger: this.logger,
           model: this.config.name,
           operation: `openai.responses.retrieve:${responseId}`,
           signal,
@@ -1397,7 +1393,6 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
 
         const uploadedFile = await executeRequest(
           {
-            logger: this.logger,
             model: this.config.name,
             operation: `openai.files.create:${filename}`,
           },

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -679,14 +679,8 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       this.previousResponseId = response.id;
       this.sentMessages = messages.length;
       return response;
-    } catch (err) {
-      this.logger.logError(
-        `Error in createResponse: ${getSdkErrorMessage(err)}`,
-        err,
-        { operation: 'create response' },
-      );
-      throw err;
     }
+    // Note: Errors propagate to PocketFlow's execFallback which logs once (log at boundary principle)
   }
 
   /**

--- a/src/agent/modelHandlers/modelHandlerOpenRouter.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenRouter.ts
@@ -72,7 +72,6 @@ export class ModelHandlerOpenRouter extends ModelHandlerOpenAI {
       kwargs.stream_options = { include_usage: true }; // Assuming OpenRouter passes this through
       const stream = await executeRequest(
         {
-          logger: this.logger,
           model: this.config.name,
           operation: 'openrouter.chat.completions.stream',
           signal,
@@ -112,7 +111,6 @@ export class ModelHandlerOpenRouter extends ModelHandlerOpenAI {
     } else {
       return executeRequest(
         {
-          logger: this.logger,
           model: this.config.name,
           operation: 'openrouter.chat.completions.create',
           signal,

--- a/src/agent/modelHandlers/utils/requestExecutor.ts
+++ b/src/agent/modelHandlers/utils/requestExecutor.ts
@@ -2,10 +2,13 @@
  * Request execution utilities for model handlers.
  *
  * NOTE: Retry logic is handled at the flow level (ResponseCycleFlow/ToolUseCycleFlow).
- * Error logging follows the "log at the boundary" principle - errors are NOT logged here.
- * The final fallback handler (RetryState.applyFallbackResult) is the single source of truth
- * for error logging, preventing duplicate log entries as errors propagate up the stack.
+ * Error logging follows the "log at the boundary" principle:
+ * - Errors are enriched with operation context here (not logged)
+ * - The final fallback handler (RetryState.applyFallbackResult) logs once with full context
+ * - This prevents duplicate log entries while preserving where errors originated
  */
+
+import { enrichError } from '@common/errors/sdkErrorUtils';
 
 /**
  * Options for request execution.
@@ -22,12 +25,12 @@ export interface RequestExecutionOptions {
 }
 
 /**
- * Executes a request with abort handling.
+ * Executes a request with error enrichment and abort handling.
  *
- * Error logging follows the "log at the boundary" principle:
- * - This function does NOT log errors
- * - Errors propagate up to the fallback handler which logs once
- * - This prevents the same error being logged at multiple abstraction layers
+ * Error handling follows the "log at the boundary" principle:
+ * - This function enriches errors with operation context (does NOT log)
+ * - Errors propagate up to the fallback handler which logs once with full context
+ * - This preserves where errors originated without duplicate logging
  *
  * Retry logic is handled at the flow level, not here.
  */
@@ -41,5 +44,13 @@ export async function executeRequest<T>(
     throw options.signal.reason ?? new Error('The request was aborted.');
   }
 
-  return await request();
+  try {
+    return await request();
+  } catch (error) {
+    // Enrich error with operation context (no logging - just attach metadata)
+    throw enrichError(error, {
+      operation: options.operation,
+      model: options.model,
+    });
+  }
 }

--- a/src/agent/modelHandlers/utils/requestExecutor.ts
+++ b/src/agent/modelHandlers/utils/requestExecutor.ts
@@ -2,18 +2,16 @@
  * Request execution utilities for model handlers.
  *
  * NOTE: Retry logic is handled at the flow level (ResponseCycleFlow/ToolUseCycleFlow).
- * These utilities provide consistent error logging and abort handling for model requests.
+ * Error logging follows the "log at the boundary" principle - errors are NOT logged here.
+ * The final fallback handler (RetryState.applyFallbackResult) is the single source of truth
+ * for error logging, preventing duplicate log entries as errors propagate up the stack.
  */
-
-import type { AgentLogger } from '@logger/AgentLogger';
 
 /**
  * Options for request execution.
  */
 export interface RequestExecutionOptions {
-  /** Logger for error reporting */
-  logger: AgentLogger;
-  /** Operation name for error messages (e.g., "model response", "file upload") */
+  /** Operation name for error context (e.g., "model response", "file upload") */
   operation: string;
   /** Model name for diagnostics */
   model?: string;
@@ -24,7 +22,13 @@ export interface RequestExecutionOptions {
 }
 
 /**
- * Executes a request with consistent error logging and abort handling.
+ * Executes a request with abort handling.
+ *
+ * Error logging follows the "log at the boundary" principle:
+ * - This function does NOT log errors
+ * - Errors propagate up to the fallback handler which logs once
+ * - This prevents the same error being logged at multiple abstraction layers
+ *
  * Retry logic is handled at the flow level, not here.
  */
 export async function executeRequest<T>(
@@ -37,13 +41,5 @@ export async function executeRequest<T>(
     throw options.signal.reason ?? new Error('The request was aborted.');
   }
 
-  try {
-    return await request();
-  } catch (error) {
-    options.logger.logError(`Error in ${options.operation}`, error, {
-      operation: options.operation,
-      model: options.model,
-    });
-    throw error;
-  }
+  return await request();
 }

--- a/src/agent/runtime/ManualRetryController.ts
+++ b/src/agent/runtime/ManualRetryController.ts
@@ -63,6 +63,7 @@ const taskContext = (task: ManualRetryTask) => ({
 export function registerManualRetry(key: string, task: ManualRetryTask): void {
   nextGeneration(key);
   pendingRetries.set(key, task);
+  task.logger.debug(`Manual retry registered for ${task.operation}`);
 }
 
 /**
@@ -110,6 +111,8 @@ export function cancelManualRetry(key: string): boolean {
   pendingRetries.delete(key);
   taskGenerations.delete(key);
 
+  task.logger.debug(`Retry cancelled for ${task.operation}`);
+
   // Trigger cancel callback if provided (with error boundary)
   if (task.cancel) {
     try {
@@ -145,8 +148,11 @@ export async function triggerManualRetry(key: string): Promise<boolean> {
   // Remove from registry before execution
   pendingRetries.delete(key);
 
+  task.logger.debug(`Retry requested for ${task.operation}`);
+
   try {
     await task.run();
+    task.logger.debug(`Retry succeeded for ${task.operation}`);
     return true;
   } catch (error) {
     task.logger.logError(

--- a/src/agent/runtime/ManualRetryController.ts
+++ b/src/agent/runtime/ManualRetryController.ts
@@ -63,10 +63,6 @@ const taskContext = (task: ManualRetryTask) => ({
 export function registerManualRetry(key: string, task: ManualRetryTask): void {
   nextGeneration(key);
   pendingRetries.set(key, task);
-  task.logger.logProgress(
-    `Manual retry available for ${task.operation}`,
-    taskContext(task),
-  );
 }
 
 /**
@@ -127,11 +123,6 @@ export function cancelManualRetry(key: string): boolean {
     }
   }
 
-  task.logger.logProgress(
-    `Retry cancelled for ${task.operation}`,
-    taskContext(task),
-  );
-
   // Emit UI resolution event
   bus.emit('resolveRetryRequest', { streamId: key });
   return true;
@@ -154,17 +145,8 @@ export async function triggerManualRetry(key: string): Promise<boolean> {
   // Remove from registry before execution
   pendingRetries.delete(key);
 
-  task.logger.logProgress(
-    `Retry requested for ${task.operation}`,
-    taskContext(task),
-  );
-
   try {
     await task.run();
-    task.logger.logProgress(
-      `Retry succeeded for ${task.operation}`,
-      taskContext(task),
-    );
     return true;
   } catch (error) {
     task.logger.logError(

--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -526,14 +526,20 @@ export function getSdkErrorMessage(err: unknown): string {
  * Patterns that indicate a context window/token limit violation.
  * These are intentional validation errors that should NOT be retried
  * and should propagate to fail fast.
+ *
+ * Pattern coverage by provider:
+ * - TeXRA internal: "exceeds context window" (token counting validation)
+ * - OpenAI: "maximum context length", "too many tokens"
+ * - Anthropic: "exceeds context window", "token limit exceeded"
+ * - Google: "input too long", "context length exceeded"
  */
 const CONTEXT_WINDOW_PATTERNS = [
-  'exceeds context window',
-  'context length exceeded',
-  'maximum context length',
-  'token limit exceeded',
-  'too many tokens',
-  'input too long',
+  'exceeds context window', // TeXRA internal, Anthropic
+  'context length exceeded', // Google
+  'maximum context length', // OpenAI
+  'token limit exceeded', // Anthropic
+  'too many tokens', // OpenAI
+  'input too long', // Google
 ] as const;
 
 /**

--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -620,7 +620,9 @@ export function enrichError<T>(error: T, context: ErrorLogContext): T {
  * Extracts enriched context from an error, if any was attached via enrichError().
  * Returns undefined if no context was attached.
  */
-export function extractErrorContext(error: unknown): ErrorLogContext | undefined {
+export function extractErrorContext(
+  error: unknown,
+): ErrorLogContext | undefined {
   if (error && typeof error === 'object') {
     return errorContextMap.get(error);
   }

--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -528,6 +528,55 @@ export interface ErrorLogContext {
   model?: string;
 }
 
+// ============================================================================
+// Error Enrichment
+// ============================================================================
+
+/**
+ * WeakMap to store operation context on error objects without modifying them.
+ * This allows us to track where errors originated as they propagate up the stack.
+ */
+const errorContextMap = new WeakMap<object, ErrorLogContext>();
+
+/**
+ * Enriches an error with operation context without logging.
+ * The context is stored in a WeakMap and can be extracted later when the error
+ * is finally logged at the boundary (e.g., in RetryState.applyFallbackResult).
+ *
+ * This follows the "log at the boundary" principle:
+ * - Middle layers enrich errors with context
+ * - Only the final handler logs, with full context
+ *
+ * @param error - The error to enrich
+ * @param context - Operation context (operation name, model)
+ * @returns The same error (for throw chaining)
+ */
+export function enrichError<T>(error: T, context: ErrorLogContext): T {
+  if (error && typeof error === 'object') {
+    // Merge with any existing context (inner operations are preserved)
+    const existing = errorContextMap.get(error) ?? {};
+    errorContextMap.set(error, {
+      ...context,
+      // Keep the innermost operation if already set (more specific)
+      operation: existing.operation ?? context.operation,
+      // Keep the model if already set
+      model: existing.model ?? context.model,
+    });
+  }
+  return error;
+}
+
+/**
+ * Extracts enriched context from an error, if any was attached via enrichError().
+ * Returns undefined if no context was attached.
+ */
+export function extractErrorContext(error: unknown): ErrorLogContext | undefined {
+  if (error && typeof error === 'object') {
+    return errorContextMap.get(error);
+  }
+  return undefined;
+}
+
 /**
  * Structured data for error log messages.
  * Used by progressView formatters to display error details.

--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -518,6 +518,50 @@ export function getSdkErrorMessage(err: unknown): string {
   return formatProviderHttpError(err).message;
 }
 
+// ============================================================================
+// Context Window Error Detection
+// ============================================================================
+
+/**
+ * Patterns that indicate a context window/token limit violation.
+ * These are intentional validation errors that should NOT be retried
+ * and should propagate to fail fast.
+ */
+const CONTEXT_WINDOW_PATTERNS = [
+  'exceeds context window',
+  'context length exceeded',
+  'maximum context length',
+  'token limit exceeded',
+  'too many tokens',
+  'input too long',
+] as const;
+
+/**
+ * Checks if an error is a context window violation.
+ * These errors should NOT be caught by soft failure handlers because
+ * they indicate the input needs to be reduced - retrying won't help.
+ *
+ * Use this to re-throw context window errors in token counting catch blocks:
+ * @example
+ * ```ts
+ * try {
+ *   await countTokens(input);
+ * } catch (err) {
+ *   if (isContextWindowError(err)) {
+ *     throw err; // Don't swallow - this is intentional validation
+ *   }
+ *   logger.warn('Token counting failed, proceeding without adjustment');
+ * }
+ * ```
+ */
+export function isContextWindowError(err: unknown): boolean {
+  if (!(err instanceof Error)) {
+    return false;
+  }
+  const message = err.message.toLowerCase();
+  return CONTEXT_WINDOW_PATTERNS.some((pattern) => message.includes(pattern));
+}
+
 /**
  * Context for building error log data.
  */


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Centralizes error logging with context enrichment, refactors manual-retry logging, and updates model handlers to use enriched request execution with soft-fail token counting and stricter context-window handling.
> 
> - **Core error handling/logging**:
>   - Add `enrichError`, `extractErrorContext`, and `isContextWindowError` in `@common/errors/sdkErrorUtils` and use them to enrich errors (no mid-layer logs).
>   - Update `requestExecutor.executeRequest` to remove logger usage, enrich errors with `{ operation, model }`, and rely on boundary logging.
>   - Extend `RetryState` (`RetryErrorInfo.context`) and add `formatErrorMessage`; `determineFallbackAction` now accepts context; `applyFallbackResult` logs once with enriched context.
> - **Flows (Response/ToolUse)**:
>   - In `execFallback`, extract error context and pass to `determineFallbackAction`.
>   - Use shared `BaseRetryWaitNode`; tone down wait/retry logs to `debug`; keep UI status events intact.
> - **Manual retry runtime**:
>   - Simplify `ManualRetryController` logs (debug-level) and keep UI resolution via `bus`.
> - **Model handlers**:
>   - Anthropic/Google/OpenAI/OpenRouter/Kimi/OpenAIResponse:
>     - Replace execute calls with new `executeRequest` (no logger param) and remove duplicate error logs.
>     - Token counting now soft-fails with `warn`; rethrow context-window violations via `isContextWindowError`.
>     - Minor stream/upload path cleanups and reduced noisy logging.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d179acb89989703cb0a6887a45450d08b3ee7f1d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->