### PR TITLE
Optimize progress view performance and reduce rebuilds

### DIFF
--- a/src/common/webview/commands.js
+++ b/src/common/webview/commands.js
@@ -180,6 +180,7 @@ export const PROGRESS_VIEW_COMMANDS = {
 
   // Usage
   UPDATE_USAGE: 'updateUsage',
+  UPDATE_RUN_USAGE: 'updateRunUsage', // Update single run's usage (incremental)
 
   // Actions
   RUN_AGAIN: 'runAgain',

--- a/src/common/webview/commands.js
+++ b/src/common/webview/commands.js
@@ -169,6 +169,7 @@ export const PROGRESS_VIEW_COMMANDS = {
 
   // Status and files
   UPDATE_STATUS: 'updateStatus',
+  UPDATE_STREAM_STATUS: 'updateStreamStatus', // Update single stream's status in tabs
   UPDATE_FILES: 'updateFiles',
   UPDATE_MISSING_OUTPUTS: 'updateMissingOutputs',
   SHOW_TOOL_EDIT_APPROVAL: 'showToolEditApproval',

--- a/src/common/webview/commands.ts
+++ b/src/common/webview/commands.ts
@@ -167,6 +167,7 @@ export const PROGRESS_VIEW_COMMANDS = {
 
   // Status and files
   UPDATE_STATUS: 'updateStatus',
+  UPDATE_STREAM_STATUS: 'updateStreamStatus', // Update single stream's status in tabs
   UPDATE_FILES: 'updateFiles',
   UPDATE_MISSING_OUTPUTS: 'updateMissingOutputs',
   SHOW_TOOL_EDIT_APPROVAL: 'showToolEditApproval',
@@ -177,6 +178,7 @@ export const PROGRESS_VIEW_COMMANDS = {
 
   // Usage
   UPDATE_USAGE: 'updateUsage',
+  UPDATE_RUN_USAGE: 'updateRunUsage', // Update single run's usage (incremental)
 
   // Actions
   RUN_AGAIN: 'runAgain',

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -209,7 +209,8 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
     // Delete persisted session data if any
     await this.deleteSessionSnapshot(message.stream);
     await this.provider.state.clearStream(message.stream);
-    this.provider.updateWebview();
+    // Force rebuild since we deleted a stream
+    this.provider.updateWebview({ forceRebuild: true });
   }
 
   private async handleDeleteAll(_message: any): Promise<void> {
@@ -232,7 +233,8 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
     }
 
     await this.provider.state.clearAll();
-    this.provider.updateWebview();
+    // Force rebuild since we deleted all streams
+    this.provider.updateWebview({ forceRebuild: true });
   }
 
   private async handleStopStream(message: any): Promise<void> {

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -96,7 +96,8 @@ export class ProgressViewProvider
     this._disposables.push(
       vscode.workspace.onDidChangeWorkspaceFolders(async () => {
         await this.state.load();
-        this.updateWebview();
+        // Force rebuild after state reload to ensure freshly loaded data is rendered
+        this.updateWebview({ forceRebuild: true });
       }),
     );
   }

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -46,6 +46,7 @@ export class ProgressViewProvider
   private _webviewReady = false;
   private _pendingUpdate = false;
   private _hasResolved = false;
+  private _lastRenderedStream = ''; // Track last rendered stream for switch detection
   private readonly logger: AgentLogger;
   private readonly pendingApprovalPrompts = new Map<
     string,
@@ -122,6 +123,7 @@ export class ProgressViewProvider
     super.cleanupView();
     this._webviewReady = false;
     this._pendingUpdate = false;
+    this._lastRenderedStream = '';
   }
 
   public resolveWebviewView(webviewView: vscode.WebviewView): void {
@@ -167,8 +169,9 @@ export class ProgressViewProvider
 
   /**
    * Update webview content using the new architecture
+   * @param options.forceRebuild - Force full DOM rebuild in frontend
    */
-  public updateWebview(): void {
+  public updateWebview(options?: { forceRebuild?: boolean }): void {
     if (!this._view) return;
 
     if (!this._webviewReady) {
@@ -187,8 +190,16 @@ export class ProgressViewProvider
       theme,
     );
 
-    this.eventHandler.refreshStreamSurface(activeStream || '');
+    // Detect stream switch by comparing to last rendered stream
+    const isStreamSwitch = this._lastRenderedStream !== activeStream;
+    const shouldForceRebuild = options?.forceRebuild ?? isStreamSwitch;
 
+    this.eventHandler.refreshStreamSurface(activeStream || '', {
+      forceRebuild: shouldForceRebuild,
+    });
+
+    // Update tracking after refresh
+    this._lastRenderedStream = activeStream;
     this._pendingUpdate = false;
   }
 
@@ -197,7 +208,8 @@ export class ProgressViewProvider
    */
   public markWebviewReady(): void {
     this._webviewReady = true;
-    this.updateWebview();
+    // Force rebuild on first load
+    this.updateWebview({ forceRebuild: true });
 
     if (this.webviewUpdater.isAvailable()) {
       // Replay pending approval prompts
@@ -265,7 +277,8 @@ export class ProgressViewProvider
   ): Promise<void> {
     // Use the same logic as webview reload to mark all running tasks/groups as ERROR
     await this.resetRunningStreamStatuses(waitingStreams);
-    this.updateWebview();
+    // Force rebuild since we modified task states
+    this.updateWebview({ forceRebuild: true });
   }
 
   /**

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -193,10 +193,11 @@ export class ProgressViewProvider
       theme,
     );
 
-    // Determine if full DOM rebuild is needed:
-    // - Explicit forceRebuild: true (e.g., after state.load())
-    // - Stream switch detected (different stream than last render)
-    // - First render after webview resolve (_lastRenderedStream is '')
+    // Determine if full DOM rebuild is needed.
+    // forceRebuild has tri-state behavior:
+    // - true: Always rebuild (e.g., after state.load(), data deletion)
+    // - false: Always use incremental update (caller explicitly knows content unchanged)
+    // - undefined: Auto-detect based on stream switch or first render
     const isStreamSwitch = this._lastRenderedStream !== activeStream;
     const shouldForceRebuild = options?.forceRebuild ?? isStreamSwitch;
 

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -136,6 +136,8 @@ export class ProgressViewProvider
 
     this._webviewReady = false;
     this._pendingUpdate = false;
+    // Clear last rendered stream to force rebuild - DOM state is stale after resolve
+    this._lastRenderedStream = '';
     webviewView.webview.options = {
       enableScripts: true,
       enableCommandUris: true,
@@ -191,7 +193,10 @@ export class ProgressViewProvider
       theme,
     );
 
-    // Detect stream switch by comparing to last rendered stream
+    // Determine if full DOM rebuild is needed:
+    // - Explicit forceRebuild: true (e.g., after state.load())
+    // - Stream switch detected (different stream than last render)
+    // - First render after webview resolve (_lastRenderedStream is '')
     const isStreamSwitch = this._lastRenderedStream !== activeStream;
     const shouldForceRebuild = options?.forceRebuild ?? isStreamSwitch;
 

--- a/src/progressView/events/OutputEvents.ts
+++ b/src/progressView/events/OutputEvents.ts
@@ -25,7 +25,7 @@ interface OutputEventsShared {
   logger: AgentLogger;
   refreshStreamSurface: (
     stream: string,
-    options?: { updateInstruction?: boolean },
+    options?: { updateInstruction?: boolean; forceRebuild?: boolean },
   ) => void;
   getAllStreamStatuses: () => Map<string, StreamStatusType>;
 }
@@ -163,7 +163,8 @@ const registerClearTaskOutput = (
             state,
             shared.getAllStreamStatuses(),
           );
-          shared.refreshStreamSurface(activeStream);
+          // Force rebuild since we cleared data
+          shared.refreshStreamSurface(activeStream, { forceRebuild: true });
         }
       });
     }),

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -197,7 +197,8 @@ export class ProgressEventHandler {
   /**
    * Refresh all webview surface data for a specific stream.
    * @param options.forceRebuild - If true, frontend will do full DOM rebuild.
-   *   Required when switching streams or after data deletion.
+   *   Required when switching streams or after data deletion. Defaults to false
+   *   for incremental updates.
    */
   public refreshStreamSurface(
     stream: string,
@@ -205,7 +206,7 @@ export class ProgressEventHandler {
   ): void {
     if (!this.webviewUpdater.isAvailable()) return;
 
-    const { updateInstruction = true, forceRebuild } = options;
+    const { updateInstruction = true, forceRebuild = false } = options;
 
     if (!stream) {
       this.webviewUpdater.updateLogContent('', [], []);

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -295,8 +295,14 @@ export class ProgressEventHandler {
     }
 
     if (this.webviewUpdater.isAvailable()) {
-      // Use targeted single-stream update instead of rebuilding all streams
-      this.webviewUpdater.updateStreamStatus(stream, status);
+      // Check if the stream tab exists before deciding update strategy
+      if (this.state.streamTabs.has(stream)) {
+        // Use targeted single-stream update for existing tabs
+        this.webviewUpdater.updateStreamStatus(stream, status);
+      } else {
+        // New stream: need full updateStreams to create the tab
+        this.webviewUpdater.updateAll(this.state, this._streamStatus);
+      }
 
       if (stream === this.state.activeStream) {
         this.webviewUpdater.updateStatus(status);

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -11,7 +11,6 @@ import { normalizeRunId } from '@common/constants/runIds';
 import { STREAM_STATUS } from '@common/constants/streamStatus';
 import { AgentLogger } from '@logger/AgentLogger';
 import { WebviewUpdater } from '@progressView/managers';
-import { buildStreamInfos } from '@progressView/streamInfoUtils';
 import { ProgressViewState } from '@progressView/state/ProgressViewState';
 import { bus } from '@eventBus/ProgressEventBus';
 
@@ -197,14 +196,16 @@ export class ProgressEventHandler {
 
   /**
    * Refresh all webview surface data for a specific stream.
+   * @param options.forceRebuild - If true, frontend will do full DOM rebuild.
+   *   Required when switching streams or after data deletion.
    */
   public refreshStreamSurface(
     stream: string,
-    options: { updateInstruction?: boolean } = {},
+    options: { updateInstruction?: boolean; forceRebuild?: boolean } = {},
   ): void {
     if (!this.webviewUpdater.isAvailable()) return;
 
-    const { updateInstruction = true } = options;
+    const { updateInstruction = true, forceRebuild } = options;
 
     if (!stream) {
       this.webviewUpdater.updateLogContent('', [], []);
@@ -240,12 +241,18 @@ export class ProgressEventHandler {
       this.state.usageStats.getRunUsage(stream).entries(),
     ) as Record<string, TokenUsageStats>;
 
-    this.webviewUpdater.updateLogContent(stream, messages, groups, {
-      runInstructions,
-      activeRunId,
-      runUsage: usageByRun,
-      runFiles: filesByRun,
-    });
+    this.webviewUpdater.updateLogContent(
+      stream,
+      messages,
+      groups,
+      {
+        runInstructions,
+        activeRunId,
+        runUsage: usageByRun,
+        runFiles: filesByRun,
+      },
+      { forceRebuild },
+    );
 
     // Note: Files are already included in UPDATE_LOGS (runFiles) and handled
     // by handleUpdateLogs in the frontend. We don't send separate UPDATE_FILES
@@ -288,16 +295,8 @@ export class ProgressEventHandler {
     }
 
     if (this.webviewUpdater.isAvailable()) {
-      const infos = buildStreamInfos(
-        this.state,
-        this._streamStatus,
-        this.state.agentTypeFilter,
-      );
-      this.webviewUpdater.updateStreams(
-        infos,
-        this.state.activeStream,
-        this.state.agentTypeFilter,
-      );
+      // Use targeted single-stream update instead of rebuilding all streams
+      this.webviewUpdater.updateStreamStatus(stream, status);
 
       if (stream === this.state.activeStream) {
         this.webviewUpdater.updateStatus(status);
@@ -358,7 +357,11 @@ export class ProgressEventHandler {
     this.setStreamStatus(stream, status);
 
     if (this.webviewUpdater.isAvailable()) {
-      this.refreshStreamSurface(stream, { updateInstruction: false });
+      // Force rebuild since this is a new stream initialization
+      this.refreshStreamSurface(stream, {
+        updateInstruction: false,
+        forceRebuild: true,
+      });
       this.sendInstructionUpdate(stream);
     }
   }

--- a/src/progressView/events/StreamStatusEvents.ts
+++ b/src/progressView/events/StreamStatusEvents.ts
@@ -32,7 +32,7 @@ export interface StreamStatusEventShared {
   sendInstructionUpdate(stream: StreamTabId | '', runId?: string | null): void;
   refreshStreamSurface(
     stream: string,
-    options?: { updateInstruction?: boolean },
+    options?: { updateInstruction?: boolean; forceRebuild?: boolean },
   ): void;
 }
 
@@ -63,6 +63,10 @@ export function createStreamStatusEvents(
       return;
     }
 
+    // Track if this is actually switching to a different stream
+    const previousStream = state.activeStream;
+    const isStreamSwitch = previousStream !== stream;
+
     await state.streamTabs.ensureStream(stream);
 
     if (session) {
@@ -86,7 +90,11 @@ export function createStreamStatusEvents(
     shared.setStreamStatus(stream, status);
 
     if (updater.isAvailable()) {
-      shared.refreshStreamSurface(stream, { updateInstruction: false });
+      // Only force rebuild when actually switching streams
+      shared.refreshStreamSurface(stream, {
+        updateInstruction: false,
+        forceRebuild: isStreamSwitch,
+      });
       shared.sendInstructionUpdate(stream);
     }
   };

--- a/src/progressView/events/StreamStatusEvents.ts
+++ b/src/progressView/events/StreamStatusEvents.ts
@@ -89,10 +89,14 @@ export function createStreamStatusEvents(
       shared.streamStatus.get(stream) ?? STREAM_STATUS.RUNNING;
 
     if (updater.isAvailable()) {
-      // ORDERING: Send UPDATE_STREAMS before setStreamStatus.
-      // updateAll sends UPDATE_STREAMS which creates the tab and sets activeStream.
-      // setStreamStatus then sends UPDATE_STREAM_STATUS to update the existing tab.
-      // Frontend processes messages in FIFO order, so tab exists before status update.
+      // ORDERING REQUIREMENTS:
+      // 1. ensureStream (line 70) must be awaited BEFORE this block to ensure
+      //    backend state.streamTabs.has(stream) returns true in setStreamStatus.
+      // 2. updateAll sends UPDATE_STREAMS which creates the frontend tab.
+      // 3. setStreamStatus sends UPDATE_STREAM_STATUS to update the existing tab.
+      // Frontend processes messages FIFO, so tab exists before status update.
+      // If setStreamStatus is called before stream is in backend state, it will
+      // trigger another full updateAll, which is inefficient but safe.
       updater.updateAll(state, shared.streamStatus);
     }
 

--- a/src/progressView/events/StreamStatusEvents.ts
+++ b/src/progressView/events/StreamStatusEvents.ts
@@ -89,8 +89,10 @@ export function createStreamStatusEvents(
       shared.streamStatus.get(stream) ?? STREAM_STATUS.RUNNING;
 
     if (updater.isAvailable()) {
-      // Send UPDATE_STREAMS first so frontend knows about the stream and active stream change
-      // This is required before setStreamStatus which now uses targeted updates
+      // ORDERING: Send UPDATE_STREAMS before setStreamStatus.
+      // updateAll sends UPDATE_STREAMS which creates the tab and sets activeStream.
+      // setStreamStatus then sends UPDATE_STREAM_STATUS to update the existing tab.
+      // Frontend processes messages in FIFO order, so tab exists before status update.
       updater.updateAll(state, shared.streamStatus);
     }
 

--- a/src/progressView/events/StreamStatusEvents.ts
+++ b/src/progressView/events/StreamStatusEvents.ts
@@ -87,6 +87,13 @@ export function createStreamStatusEvents(
 
     const status: StreamStatusOrReadyType =
       shared.streamStatus.get(stream) ?? STREAM_STATUS.RUNNING;
+
+    if (updater.isAvailable()) {
+      // Send UPDATE_STREAMS first so frontend knows about the stream and active stream change
+      // This is required before setStreamStatus which now uses targeted updates
+      updater.updateAll(state, shared.streamStatus);
+    }
+
     shared.setStreamStatus(stream, status);
 
     if (updater.isAvailable()) {

--- a/src/progressView/events/UsageEvents.ts
+++ b/src/progressView/events/UsageEvents.ts
@@ -54,10 +54,8 @@ export function createUsageEvents(
             );
 
             if (state.activeStream === stream && updater.isAvailable()) {
-              const usageByRun = Object.fromEntries(
-                state.usageStats.getRunUsage(stream).entries(),
-              ) as Record<string, TokenUsageStats>;
-              updater.updateUsage(stream, usageByRun);
+              // Send only the changed run's usage instead of all runs
+              updater.updateRunUsage(stream, storageKey, normalizedUsage);
             }
           });
         },

--- a/src/progressView/managers/WebviewUpdater.ts
+++ b/src/progressView/managers/WebviewUpdater.ts
@@ -227,7 +227,7 @@ export class WebviewUpdater {
   }
 
   /**
-   * Update usage statistics
+   * Update usage statistics (full replacement)
    */
   updateUsage(
     stream: StreamTabId,
@@ -237,6 +237,23 @@ export class WebviewUpdater {
       command: COMMANDS.UPDATE_USAGE,
       stream,
       usageByRun,
+    });
+  }
+
+  /**
+   * Update usage for a single run (incremental).
+   * More efficient than updateUsage when only one run's usage changed.
+   */
+  updateRunUsage(
+    stream: StreamTabId,
+    runId: string,
+    usage: TokenUsageStats,
+  ): void {
+    this.sendMessage({
+      command: COMMANDS.UPDATE_RUN_USAGE,
+      stream,
+      runId,
+      usage,
     });
   }
 

--- a/src/progressView/managers/WebviewUpdater.ts
+++ b/src/progressView/managers/WebviewUpdater.ts
@@ -102,9 +102,12 @@ export class WebviewUpdater {
 
   /**
    * Update log content for a specific stream
-   * @param options.forceRebuild - If true, frontend will do full DOM rebuild.
-   *   Set to true when switching streams or after data deletion.
-   *   When false/undefined, frontend will attempt incremental update.
+   * @param options.forceRebuild - Controls frontend DOM rebuild behavior:
+   *   - `true`: Full DOM rebuild (required when switching streams or after data deletion)
+   *   - `false`: Incremental update only (skip DOM rebuild, update metadata)
+   *   - `undefined`: Full DOM rebuild (legacy behavior, same as true)
+   *   Note: Frontend uses strict `=== false` check, so explicit `false` is required
+   *   for incremental updates.
    */
   updateLogContent(
     stream: StreamTabId,

--- a/src/progressView/managers/WebviewUpdater.ts
+++ b/src/progressView/managers/WebviewUpdater.ts
@@ -102,6 +102,9 @@ export class WebviewUpdater {
 
   /**
    * Update log content for a specific stream
+   * @param options.forceRebuild - If true, frontend will do full DOM rebuild.
+   *   Set to true when switching streams or after data deletion.
+   *   When false/undefined, frontend will attempt incremental update.
    */
   updateLogContent(
     stream: StreamTabId,
@@ -113,6 +116,9 @@ export class WebviewUpdater {
       runUsage?: Record<string, TokenUsageStats>;
       runFiles?: Record<string, { [key: number]: OutputFileInfo[] }>;
     },
+    options?: {
+      forceRebuild?: boolean;
+    },
   ): void {
     this.sendMessage({
       command: COMMANDS.UPDATE_LOGS,
@@ -123,6 +129,7 @@ export class WebviewUpdater {
       activeRunId: extras?.activeRunId,
       runUsage: extras?.runUsage,
       runFiles: extras?.runFiles,
+      forceRebuild: options?.forceRebuild,
     });
   }
 
@@ -271,11 +278,23 @@ export class WebviewUpdater {
   }
 
   /**
-   * Update stream status
+   * Update stream status indicator (for active stream)
    */
   updateStatus(status: StatusType): void {
     this.sendMessage({
       command: COMMANDS.UPDATE_STATUS,
+      status,
+    });
+  }
+
+  /**
+   * Update a single stream's status in the stream tabs.
+   * More efficient than updateStreams when only status changed.
+   */
+  updateStreamStatus(stream: StreamTabId, status: StatusType | 'ready'): void {
+    this.sendMessage({
+      command: COMMANDS.UPDATE_STREAM_STATUS,
+      stream,
       status,
     });
   }

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -304,17 +304,18 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       return;
     }
 
-    // When forceRebuild is explicitly false, do incremental update (skip DOM rebuild).
-    // NOTE: We check `=== false` (not `!message.forceRebuild`) intentionally.
-    // Backend explicitly passes forceRebuild: false for incremental updates.
-    // Strict equality distinguishes this from undefined (full rebuild needed).
-    if (message.forceRebuild === false) {
+    // Determine rebuild strategy based on forceRebuild flag:
+    // - false: Incremental update only (skip DOM rebuild)
+    // - true/undefined: Full DOM rebuild needed
+    // See WebviewUpdater.updateLogContent() JSDoc for contract details.
+    const useIncrementalUpdate = message.forceRebuild === false;
+    if (useIncrementalUpdate) {
       this._handleIncrementalUpdate(message);
       this._updatePlaceholderVisibility();
       return;
     }
 
-    // Full rebuild path (stream switch or explicit forceRebuild)
+    // Full rebuild path (stream switch, explicit forceRebuild, or legacy undefined)
     const logContent = document.getElementById(ELEMENT_IDS.LOG_CONTENT);
     pendingLogUpdates.clear();
     dom.taskGroups.clear();

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -306,8 +306,8 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
 
     // When forceRebuild is explicitly false, do incremental update (skip DOM rebuild).
     // NOTE: We check `=== false` (not `!message.forceRebuild`) intentionally.
-    // Backend defaults forceRebuild to false for performance, but we use strict
-    // equality to distinguish from undefined (legacy messages that need full rebuild).
+    // Backend explicitly passes forceRebuild: false for incremental updates.
+    // Strict equality distinguishes this from undefined (full rebuild needed).
     if (message.forceRebuild === false) {
       this._handleIncrementalUpdate(message);
       this._updatePlaceholderVisibility();
@@ -390,6 +390,7 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
    * - Log messages are NOT appended here; they arrive via APPEND_LOG command
    * - Only group status/endTime are updated; other group fields are immutable post-creation
    * - New groups are NOT created; they arrive via ADD_TASK_GROUP command
+   * - Stream status is NOT updated here; it arrives via UPDATE_STREAM_STATUS command
    */
   _handleIncrementalUpdate(message) {
     // Defensive guard: caller should verify stream matches active stream
@@ -571,16 +572,17 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       return;
     }
 
-    // Update the stream tab UI first - only update state if DOM update succeeded
-    // This keeps state and DOM in sync even if tab doesn't exist yet
-    const updated = dom.streamTabs.updateStreamStatus(stream, status);
-    if (updated) {
-      if (status && status !== STREAM_STATUS.READY) {
-        state.streamStatuses.set(stream, status);
-      } else {
-        state.streamStatuses.delete(stream);
-      }
+    // Always update state first - state is the single source of truth.
+    // If tab doesn't exist yet (race condition), UPDATE_STREAMS will read
+    // from state.streamStatuses and apply the status when creating the tab.
+    if (status && status !== STREAM_STATUS.READY) {
+      state.streamStatuses.set(stream, status);
+    } else {
+      state.streamStatuses.delete(stream);
     }
+
+    // Attempt DOM update (may fail if tab doesn't exist yet, which is OK)
+    dom.streamTabs.updateStreamStatus(stream, status);
   }
 
   handleUpdateUsage(message) {

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -571,15 +571,16 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       return;
     }
 
-    // Update status in state
-    if (status && status !== STREAM_STATUS.READY) {
-      state.streamStatuses.set(stream, status);
-    } else {
-      state.streamStatuses.delete(stream);
+    // Update the stream tab UI first - only update state if DOM update succeeded
+    // This keeps state and DOM in sync even if tab doesn't exist yet
+    const updated = dom.streamTabs.updateStreamStatus(stream, status);
+    if (updated) {
+      if (status && status !== STREAM_STATUS.READY) {
+        state.streamStatuses.set(stream, status);
+      } else {
+        state.streamStatuses.delete(stream);
+      }
     }
-
-    // Update the stream tab UI for just this stream
-    dom.streamTabs.updateStreamStatus(stream, status);
   }
 
   handleUpdateUsage(message) {

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -304,7 +304,10 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       return;
     }
 
-    // When forceRebuild is false, do incremental update (skip DOM rebuild)
+    // When forceRebuild is explicitly false, do incremental update (skip DOM rebuild).
+    // NOTE: We check `=== false` (not `!message.forceRebuild`) intentionally.
+    // Backend defaults forceRebuild to false for performance, but we use strict
+    // equality to distinguish from undefined (legacy messages that need full rebuild).
     if (message.forceRebuild === false) {
       this._handleIncrementalUpdate(message);
       this._updatePlaceholderVisibility();

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -133,6 +133,38 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     dom.usageSummary.update();
   }
 
+  /**
+   * Update run-scoped metadata (instructions, usage, files) from message.
+   * Shared by handleUpdateLogs and _handleIncrementalUpdate to avoid duplication.
+   * @param {string} stream - The stream to update
+   * @param {Object} message - Message containing runInstructions, runUsage, runFiles
+   */
+  _updateRunMetadata(stream, message) {
+    if (message.runInstructions) {
+      Object.entries(message.runInstructions).forEach(
+        ([runId, instruction]) => {
+          if (runId) {
+            state.setRunInstruction(stream, runId, instruction);
+          }
+        },
+      );
+    }
+
+    if (message.runUsage) {
+      Object.entries(message.runUsage).forEach(([runId, usage]) => {
+        state.setRunUsage(stream, runId, usage);
+      });
+    }
+
+    if (message.runFiles) {
+      Object.entries(message.runFiles).forEach(([runId, filesByRound]) => {
+        if (runId) {
+          state.setRunFiles(stream, runId, filesByRound);
+        }
+      });
+    }
+  }
+
   _createHandlers() {
     return {
       [COMMANDS.UPDATE_STREAMS]: (m) => this.handleUpdateStreams(m),
@@ -296,29 +328,8 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       dom.runSelector.setRuns(parentGroups);
       dom.taskGroups.renderInitial(groups);
 
-      if (message.runInstructions) {
-        Object.entries(message.runInstructions).forEach(
-          ([runId, instruction]) => {
-            if (runId) {
-              state.setRunInstruction(message.stream, runId, instruction);
-            }
-          },
-        );
-      }
-
-      if (message.runUsage) {
-        Object.entries(message.runUsage).forEach(([runId, usage]) => {
-          state.setRunUsage(message.stream, runId, usage);
-        });
-      }
-
-      if (message.runFiles) {
-        Object.entries(message.runFiles).forEach(([runId, filesByRound]) => {
-          if (runId) {
-            state.setRunFiles(message.stream, runId, filesByRound);
-          }
-        });
-      }
+      // Update run metadata using shared helper
+      this._updateRunMetadata(message.stream, message);
 
       if (parentGroups.length > 0) {
         const runIds = parentGroups.map((group) => group.id);
@@ -386,32 +397,9 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       return;
     }
 
-    // Update run-scoped metadata only (instructions, usage, files)
+    // Update run-scoped metadata using shared helper
     // Skip DOM reconstruction since content hasn't changed
-
-    if (message.runInstructions) {
-      Object.entries(message.runInstructions).forEach(
-        ([runId, instruction]) => {
-          if (runId) {
-            state.setRunInstruction(message.stream, runId, instruction);
-          }
-        },
-      );
-    }
-
-    if (message.runUsage) {
-      Object.entries(message.runUsage).forEach(([runId, usage]) => {
-        state.setRunUsage(message.stream, runId, usage);
-      });
-    }
-
-    if (message.runFiles) {
-      Object.entries(message.runFiles).forEach(([runId, filesByRound]) => {
-        if (runId) {
-          state.setRunFiles(message.stream, runId, filesByRound);
-        }
-      });
-    }
+    this._updateRunMetadata(message.stream, message);
 
     // Update task group statuses if they changed
     // Note: Only status/endTime are expected to change post-creation
@@ -568,6 +556,15 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
   handleUpdateStreamStatus(message) {
     const { stream, status } = message;
     if (!stream) {
+      return;
+    }
+
+    // Validate status against known values
+    const validStatuses = Object.values(STREAM_STATUS);
+    if (status && !validStatuses.includes(status)) {
+      console.debug(
+        `[updateStreamStatus] Invalid status "${status}" for stream: ${stream}`,
+      );
       return;
     }
 

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -378,6 +378,14 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
    * - New groups are NOT created; they arrive via ADD_TASK_GROUP command
    */
   _handleIncrementalUpdate(message) {
+    // Defensive guard: caller should verify stream matches active stream
+    if (message.stream !== state.activeStream) {
+      console.debug(
+        `[incremental] stream mismatch: ${message.stream} !== ${state.activeStream}`,
+      );
+      return;
+    }
+
     // Update run-scoped metadata only (instructions, usage, files)
     // Skip DOM reconstruction since content hasn't changed
 
@@ -406,10 +414,19 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     }
 
     // Update task group statuses if they changed
+    // Note: Only status/endTime are expected to change post-creation
     const groups = message.groups || [];
     groups.forEach((group) => {
       const existing = state.taskGroups.get(group.id);
-      if (existing && existing.status !== group.status) {
+      if (!existing) {
+        // New group during incremental update - this shouldn't happen
+        // Groups should arrive via ADD_TASK_GROUP command
+        console.debug(
+          `[incremental] unexpected new group ${group.id} - skipping`,
+        );
+        return;
+      }
+      if (existing.status !== group.status) {
         state.taskGroups.update({
           groupId: group.id,
           updates: { status: group.status, endTime: group.endTime },
@@ -555,7 +572,7 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     }
 
     // Update status in state
-    if (status && status !== 'ready') {
+    if (status && status !== STREAM_STATUS.READY) {
       state.streamStatuses.set(stream, status);
     } else {
       state.streamStatuses.delete(stream);

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -144,6 +144,7 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       [COMMANDS.UPDATE_STATUS]: (m) => this.handleUpdateStatus(m),
       [COMMANDS.UPDATE_STREAM_STATUS]: (m) => this.handleUpdateStreamStatus(m),
       [COMMANDS.UPDATE_USAGE]: (m) => this.handleUpdateUsage(m),
+      [COMMANDS.UPDATE_RUN_USAGE]: (m) => this.handleUpdateRunUsage(m),
       [COMMANDS.UPDATE_FILES]: (m) => this.handleUpdateFiles(m),
       [COMMANDS.UPDATE_MISSING_OUTPUTS]: (m) =>
         this.handleUpdateMissingOutputs(m),
@@ -579,6 +580,25 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     Object.entries(usageByRun).forEach(([runId, usage]) => {
       state.setRunUsage(targetStream, runId, usage);
     });
+    this._refreshUsageForActiveRun();
+  }
+
+  /**
+   * Handle incremental usage update for a single run.
+   * More efficient than handleUpdateUsage during streaming.
+   */
+  handleUpdateRunUsage(message) {
+    if (message.stream && message.stream !== state.activeStream) {
+      return;
+    }
+
+    const targetStream = message.stream || state.activeStream || null;
+    if (!targetStream || !message.runId) {
+      return;
+    }
+
+    // Update only the specific run's usage without clearing others
+    state.setRunUsage(targetStream, message.runId, message.usage);
     this._refreshUsageForActiveRun();
   }
 

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -370,6 +370,11 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
   /**
    * Handle incremental update - update state without DOM rebuild.
    * Used when refreshing the same stream to avoid expensive full rebuild.
+   *
+   * Limitations (by design):
+   * - Log messages are NOT appended here; they arrive via APPEND_LOG command
+   * - Only group status/endTime are updated; other group fields are immutable post-creation
+   * - New groups are NOT created; they arrive via ADD_TASK_GROUP command
    */
   _handleIncrementalUpdate(message) {
     // Update run-scoped metadata only (instructions, usage, files)

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -358,8 +358,8 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     });
     scrollToBottom(logContent);
 
-    // Use activeRunId from message if available to avoid redundant resolution
-    const activeRunId = message.activeRunId ?? state.resolveActiveRunId(message.stream);
+    // Use validated run ID from state (set earlier via setActiveRunId after validation)
+    const activeRunId = state.resolveActiveRunId(message.stream);
     this._refreshInstructionForActiveRun(activeRunId);
     this._refreshOutputsForActiveRun(activeRunId);
     this._refreshUsageForActiveRun();
@@ -415,8 +415,8 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       }
     });
 
-    // Refresh display panels - use activeRunId from message if available
-    const activeRunId = message.activeRunId ?? state.resolveActiveRunId(message.stream);
+    // Refresh display panels - use validated run ID from state
+    const activeRunId = state.resolveActiveRunId(message.stream);
     this._refreshInstructionForActiveRun(activeRunId);
     this._refreshOutputsForActiveRun(activeRunId);
     this._refreshUsageForActiveRun();

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -322,6 +322,7 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     state.taskGroups.clear();
     state.clearRunInstructions(message.stream);
     state.clearRunFiles(message.stream);
+    state.clearRunUsage(message.stream);
     state.clearPendingInstruction(state.activeStream);
     const previousRunId = state.getActiveRunId(message.stream);
     state.clearActiveRun(message.stream);

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -83,19 +83,24 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       state.setActiveRunId(activeStream, runId);
     }
     dom.taskGroups.showRun(runId);
-    this._refreshInstructionForActiveRun();
-    this._refreshOutputsForActiveRun();
+    // Pass runId directly to avoid redundant resolveActiveRunId calls
+    this._refreshInstructionForActiveRun(runId);
+    this._refreshOutputsForActiveRun(runId);
     this._refreshUsageForActiveRun();
   }
 
-  _refreshInstructionForActiveRun() {
+  /**
+   * Refresh instruction panel for the active run.
+   * @param {string} [runId] - Optional runId to use instead of resolving
+   */
+  _refreshInstructionForActiveRun(runId) {
     if (state.activeSessionKind === 'toolUse') {
       dom.instructionPanel.hide();
       return;
     }
 
     const stream = state.activeStream || null;
-    const activeRunId = state.resolveActiveRunId(stream);
+    const activeRunId = runId ?? state.resolveActiveRunId(stream);
     if (!activeRunId) {
       dom.instructionPanel.hide();
       return;
@@ -109,9 +114,13 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     }
   }
 
-  _refreshOutputsForActiveRun() {
+  /**
+   * Refresh output files for the active run.
+   * @param {string} [runId] - Optional runId to use instead of resolving
+   */
+  _refreshOutputsForActiveRun(runId) {
     const stream = state.activeStream || null;
-    const activeRunId = state.resolveActiveRunId(stream);
+    const activeRunId = runId ?? state.resolveActiveRunId(stream);
     const filesByRound = activeRunId
       ? state.getRunFiles(stream, activeRunId) || {}
       : {};
@@ -133,6 +142,7 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       [COMMANDS.ADD_TASK_GROUP]: (m) => this.handleAddTaskGroup(m),
       [COMMANDS.UPDATE_TASK_GROUP]: (m) => this.handleUpdateTaskGroup(m),
       [COMMANDS.UPDATE_STATUS]: (m) => this.handleUpdateStatus(m),
+      [COMMANDS.UPDATE_STREAM_STATUS]: (m) => this.handleUpdateStreamStatus(m),
       [COMMANDS.UPDATE_USAGE]: (m) => this.handleUpdateUsage(m),
       [COMMANDS.UPDATE_FILES]: (m) => this.handleUpdateFiles(m),
       [COMMANDS.UPDATE_MISSING_OUTPUTS]: (m) =>
@@ -256,92 +266,160 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
   }
 
   handleUpdateLogs(message) {
+    if (message.stream !== state.activeStream) {
+      this._updatePlaceholderVisibility();
+      return;
+    }
+
+    // When forceRebuild is false, do incremental update (skip DOM rebuild)
+    if (message.forceRebuild === false) {
+      this._handleIncrementalUpdate(message);
+      this._updatePlaceholderVisibility();
+      return;
+    }
+
+    // Full rebuild path (stream switch or explicit forceRebuild)
     const logContent = document.getElementById(ELEMENT_IDS.LOG_CONTENT);
-    if (message.stream === state.activeStream) {
-      pendingLogUpdates.clear();
-      dom.taskGroups.clear();
-      state.taskGroups.clear();
-      state.clearRunInstructions(message.stream);
-      state.clearRunFiles(message.stream);
-      state.clearPendingInstruction(state.activeStream);
-      const previousRunId = state.getActiveRunId(message.stream);
-      state.clearActiveRun(message.stream);
-      logContent.innerHTML = '';
-      const groups = message.groups || [];
-      if (groups.length > 0) {
-        const parentGroups = groups.filter((g) => !g.parentGroupId);
-        dom.runSelector.setRuns(parentGroups);
-        dom.taskGroups.renderInitial(groups);
+    pendingLogUpdates.clear();
+    dom.taskGroups.clear();
+    state.taskGroups.clear();
+    state.clearRunInstructions(message.stream);
+    state.clearRunFiles(message.stream);
+    state.clearPendingInstruction(state.activeStream);
+    const previousRunId = state.getActiveRunId(message.stream);
+    state.clearActiveRun(message.stream);
+    logContent.innerHTML = '';
+    const groups = message.groups || [];
+    if (groups.length > 0) {
+      const parentGroups = groups.filter((g) => !g.parentGroupId);
+      dom.runSelector.setRuns(parentGroups);
+      dom.taskGroups.renderInitial(groups);
 
-        if (message.runInstructions) {
-          Object.entries(message.runInstructions).forEach(
-            ([runId, instruction]) => {
-              if (runId) {
-                state.setRunInstruction(message.stream, runId, instruction);
-              }
-            },
-          );
-        }
-
-        if (message.runUsage) {
-          Object.entries(message.runUsage).forEach(([runId, usage]) => {
-            state.setRunUsage(message.stream, runId, usage);
-          });
-        }
-
-        if (message.runFiles) {
-          Object.entries(message.runFiles).forEach(([runId, filesByRound]) => {
+      if (message.runInstructions) {
+        Object.entries(message.runInstructions).forEach(
+          ([runId, instruction]) => {
             if (runId) {
-              state.setRunFiles(message.stream, runId, filesByRound);
+              state.setRunInstruction(message.stream, runId, instruction);
             }
-          });
-        }
+          },
+        );
+      }
 
-        if (parentGroups.length > 0) {
-          const runIds = parentGroups.map((group) => group.id);
-          const preferredRun =
-            message.activeRunId && runIds.includes(message.activeRunId)
-              ? message.activeRunId
-              : previousRunId && runIds.includes(previousRunId)
-                ? previousRunId
-                : runIds[runIds.length - 1];
-          state.setActiveRunId(message.stream, preferredRun);
-          dom.runSelector.setActiveRun(preferredRun);
-          dom.taskGroups.showRun(preferredRun);
-        } else {
-          dom.taskGroups.showRun(null);
-        }
+      if (message.runUsage) {
+        Object.entries(message.runUsage).forEach(([runId, usage]) => {
+          state.setRunUsage(message.stream, runId, usage);
+        });
+      }
 
-        const resolvedRunId = state.resolveActiveRunId(message.stream);
-        if (
-          resolvedRunId &&
-          state.getActiveRunId(message.stream) !== resolvedRunId
-        ) {
-          state.setActiveRunId(message.stream, resolvedRunId);
-        }
+      if (message.runFiles) {
+        Object.entries(message.runFiles).forEach(([runId, filesByRound]) => {
+          if (runId) {
+            state.setRunFiles(message.stream, runId, filesByRound);
+          }
+        });
+      }
+
+      if (parentGroups.length > 0) {
+        const runIds = parentGroups.map((group) => group.id);
+        const preferredRun =
+          message.activeRunId && runIds.includes(message.activeRunId)
+            ? message.activeRunId
+            : previousRunId && runIds.includes(previousRunId)
+              ? previousRunId
+              : runIds[runIds.length - 1];
+        state.setActiveRunId(message.stream, preferredRun);
+        dom.runSelector.setActiveRun(preferredRun);
+        dom.taskGroups.showRun(preferredRun);
       } else {
         dom.taskGroups.showRun(null);
       }
-      const logMessages = message.messages || [];
-      logMessages.forEach((msg) => {
-        if (msg.groupId) {
-          if (!dom.logEntries.append(msg)) {
-            const formatted = this._entryFormatter.format(msg);
-            appendFormatted(logContent, formatted);
-          }
-        } else {
+
+      const resolvedRunId = state.resolveActiveRunId(message.stream);
+      if (
+        resolvedRunId &&
+        state.getActiveRunId(message.stream) !== resolvedRunId
+      ) {
+        state.setActiveRunId(message.stream, resolvedRunId);
+      }
+    } else {
+      dom.taskGroups.showRun(null);
+    }
+    const logMessages = message.messages || [];
+    logMessages.forEach((msg) => {
+      if (msg.groupId) {
+        if (!dom.logEntries.append(msg)) {
           const formatted = this._entryFormatter.format(msg);
           appendFormatted(logContent, formatted);
         }
-      });
-      scrollToBottom(logContent);
+      } else {
+        const formatted = this._entryFormatter.format(msg);
+        appendFormatted(logContent, formatted);
+      }
+    });
+    scrollToBottom(logContent);
 
-      this._refreshInstructionForActiveRun();
-      this._refreshOutputsForActiveRun();
-      this._refreshUsageForActiveRun();
-    }
+    // Use activeRunId from message if available to avoid redundant resolution
+    const activeRunId = message.activeRunId ?? state.resolveActiveRunId(message.stream);
+    this._refreshInstructionForActiveRun(activeRunId);
+    this._refreshOutputsForActiveRun(activeRunId);
+    this._refreshUsageForActiveRun();
 
     this._updatePlaceholderVisibility();
+  }
+
+  /**
+   * Handle incremental update - update state without DOM rebuild.
+   * Used when refreshing the same stream to avoid expensive full rebuild.
+   */
+  _handleIncrementalUpdate(message) {
+    // Update run-scoped metadata only (instructions, usage, files)
+    // Skip DOM reconstruction since content hasn't changed
+
+    if (message.runInstructions) {
+      Object.entries(message.runInstructions).forEach(
+        ([runId, instruction]) => {
+          if (runId) {
+            state.setRunInstruction(message.stream, runId, instruction);
+          }
+        },
+      );
+    }
+
+    if (message.runUsage) {
+      Object.entries(message.runUsage).forEach(([runId, usage]) => {
+        state.setRunUsage(message.stream, runId, usage);
+      });
+    }
+
+    if (message.runFiles) {
+      Object.entries(message.runFiles).forEach(([runId, filesByRound]) => {
+        if (runId) {
+          state.setRunFiles(message.stream, runId, filesByRound);
+        }
+      });
+    }
+
+    // Update task group statuses if they changed
+    const groups = message.groups || [];
+    groups.forEach((group) => {
+      const existing = state.taskGroups.get(group.id);
+      if (existing && existing.status !== group.status) {
+        state.taskGroups.update({
+          groupId: group.id,
+          updates: { status: group.status, endTime: group.endTime },
+        });
+        dom.taskGroups.updateGroup({
+          groupId: group.id,
+          updates: { status: group.status, endTime: group.endTime },
+        });
+      }
+    });
+
+    // Refresh display panels - use activeRunId from message if available
+    const activeRunId = message.activeRunId ?? state.resolveActiveRunId(message.stream);
+    this._refreshInstructionForActiveRun(activeRunId);
+    this._refreshOutputsForActiveRun(activeRunId);
+    this._refreshUsageForActiveRun();
   }
 
   handleAppendLog(message) {
@@ -421,8 +499,9 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
         }
         dom.runSelector.setActiveRun(newRunId);
         dom.taskGroups.showRun(newRunId);
-        this._refreshInstructionForActiveRun();
-        this._refreshOutputsForActiveRun();
+        // Pass newRunId directly to avoid redundant resolveActiveRunId calls
+        this._refreshInstructionForActiveRun(newRunId);
+        this._refreshOutputsForActiveRun(newRunId);
         this._refreshUsageForActiveRun();
       }
       scrollToBottom(logContent);
@@ -457,6 +536,27 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     if (message.status === STREAM_STATUS.WAITING) {
       dom.followUpInput.focus({ scrollIntoView: true });
     }
+  }
+
+  /**
+   * Handle targeted single-stream status update.
+   * More efficient than UPDATE_STREAMS when only status changed.
+   */
+  handleUpdateStreamStatus(message) {
+    const { stream, status } = message;
+    if (!stream) {
+      return;
+    }
+
+    // Update status in state
+    if (status && status !== 'ready') {
+      state.streamStatuses.set(stream, status);
+    } else {
+      state.streamStatuses.delete(stream);
+    }
+
+    // Update the stream tab UI for just this stream
+    dom.streamTabs.updateStreamStatus(stream, status);
   }
 
   handleUpdateUsage(message) {

--- a/src/progressView/modules/uiManagers/StreamTabs.js
+++ b/src/progressView/modules/uiManagers/StreamTabs.js
@@ -1,4 +1,3 @@
-// Local imports - progress view
 // Local imports
 import { ELEMENT_IDS, STREAM_STATUS } from '../constants.js';
 import { createFromTemplate } from '@common/templateUtils.js';
@@ -133,6 +132,9 @@ export class StreamTabs {
       `.stream-tab .tab[data-stream="${streamName}"]`,
     );
     if (!tabEl) {
+      console.debug(
+        `[updateStreamStatus] Tab not found for stream: ${streamName}`,
+      );
       return;
     }
 

--- a/src/progressView/modules/uiManagers/StreamTabs.js
+++ b/src/progressView/modules/uiManagers/StreamTabs.js
@@ -155,8 +155,11 @@ export class StreamTabs {
     // Remove old status classes dynamically from STREAM_STATUS values
     // This ensures the class list stays in sync with constants
     Object.values(STREAM_STATUS).forEach((s) => statusEl.classList.remove(s));
+    // READY means execution completed - display as stopped (no active indicator)
     const normalizedStatus =
-      status === STREAM_STATUS.READY ? 'stopped' : status || 'stopped';
+      status === STREAM_STATUS.READY
+        ? STREAM_STATUS.STOPPED
+        : status || STREAM_STATUS.STOPPED;
     statusEl.classList.add(normalizedStatus);
     statusEl.dataset.status =
       normalizedStatus.charAt(0).toUpperCase() + normalizedStatus.slice(1);

--- a/src/progressView/modules/uiManagers/StreamTabs.js
+++ b/src/progressView/modules/uiManagers/StreamTabs.js
@@ -113,6 +113,48 @@ export class StreamTabs {
   }
 
   /**
+   * Update status for a single stream tab.
+   * More efficient than full update() when only status changed.
+   * @param {string} streamName - The stream to update
+   * @param {string} status - New status value
+   */
+  updateStreamStatus(streamName, status) {
+    if (!streamName) {
+      return;
+    }
+
+    const tabsContainer = document.getElementById(ELEMENT_IDS.STREAM_TABS);
+    if (!tabsContainer) {
+      return;
+    }
+
+    // Find the tab for this stream
+    const tabEl = tabsContainer.querySelector(
+      `.stream-tab .tab[data-stream="${streamName}"]`,
+    );
+    if (!tabEl) {
+      return;
+    }
+
+    const streamTab = tabEl.closest('.stream-tab');
+    if (!streamTab) {
+      return;
+    }
+
+    const statusEl = streamTab.querySelector('.tab-status');
+    if (!statusEl) {
+      return;
+    }
+
+    // Remove old status classes and add new one
+    statusEl.classList.remove('running', 'stopped', 'error', 'waiting', 'ready');
+    const normalizedStatus = status === 'ready' ? 'stopped' : status || 'stopped';
+    statusEl.classList.add(normalizedStatus);
+    statusEl.dataset.status =
+      normalizedStatus.charAt(0).toUpperCase() + normalizedStatus.slice(1);
+  }
+
+  /**
    * Apply agent decorator icons to a tab element.
    * Uses shared AGENT_DECORATORS config for consistency.
    * @param {HTMLElement} tabEl - The tab element

--- a/src/progressView/modules/uiManagers/StreamTabs.js
+++ b/src/progressView/modules/uiManagers/StreamTabs.js
@@ -133,10 +133,11 @@ export class StreamTabs {
       `.stream-tab .tab[data-stream="${streamName}"]`,
     );
     if (!tabEl) {
-      // Warn: tab should exist before status update (ordering issue)
-      console.warn(
+      // Tab doesn't exist yet - this is OK, status is stored in state and
+      // will be applied when UPDATE_STREAMS creates the tab
+      console.debug(
         `[updateStreamStatus] Tab not found for stream: ${streamName}. ` +
-          'UPDATE_STREAMS should be sent before UPDATE_STREAM_STATUS.',
+          'Status stored in state; will apply when tab is created.',
       );
       return false;
     }

--- a/src/progressView/modules/uiManagers/StreamTabs.js
+++ b/src/progressView/modules/uiManagers/StreamTabs.js
@@ -149,7 +149,15 @@ export class StreamTabs {
     }
 
     // Remove old status classes and add new one
-    statusEl.classList.remove('running', 'stopped', 'error', 'waiting', 'ready');
+    // Must include all STREAM_STATUS values that have CSS classes
+    statusEl.classList.remove(
+      'running',
+      'stopped',
+      'error',
+      'waiting',
+      'ready',
+      'resuming',
+    );
     const normalizedStatus =
       status === STREAM_STATUS.READY ? 'stopped' : status || 'stopped';
     statusEl.classList.add(normalizedStatus);

--- a/src/progressView/modules/uiManagers/StreamTabs.js
+++ b/src/progressView/modules/uiManagers/StreamTabs.js
@@ -1,6 +1,6 @@
 // Local imports - progress view
 // Local imports
-import { ELEMENT_IDS } from '../constants.js';
+import { ELEMENT_IDS, STREAM_STATUS } from '../constants.js';
 import { createFromTemplate } from '@common/templateUtils.js';
 import { formatRelativeTime } from '@common/stringUtils.js';
 import {
@@ -148,7 +148,8 @@ export class StreamTabs {
 
     // Remove old status classes and add new one
     statusEl.classList.remove('running', 'stopped', 'error', 'waiting', 'ready');
-    const normalizedStatus = status === 'ready' ? 'stopped' : status || 'stopped';
+    const normalizedStatus =
+      status === STREAM_STATUS.READY ? 'stopped' : status || 'stopped';
     statusEl.classList.add(normalizedStatus);
     statusEl.dataset.status =
       normalizedStatus.charAt(0).toUpperCase() + normalizedStatus.slice(1);

--- a/src/progressView/modules/uiManagers/StreamTabs.js
+++ b/src/progressView/modules/uiManagers/StreamTabs.js
@@ -116,15 +116,16 @@ export class StreamTabs {
    * More efficient than full update() when only status changed.
    * @param {string} streamName - The stream to update
    * @param {string} status - New status value
+   * @returns {boolean} True if DOM was updated, false if tab not found
    */
   updateStreamStatus(streamName, status) {
     if (!streamName) {
-      return;
+      return false;
     }
 
     const tabsContainer = document.getElementById(ELEMENT_IDS.STREAM_TABS);
     if (!tabsContainer) {
-      return;
+      return false;
     }
 
     // Find the tab for this stream
@@ -137,17 +138,17 @@ export class StreamTabs {
         `[updateStreamStatus] Tab not found for stream: ${streamName}. ` +
           'UPDATE_STREAMS should be sent before UPDATE_STREAM_STATUS.',
       );
-      return;
+      return false;
     }
 
     const streamTab = tabEl.closest('.stream-tab');
     if (!streamTab) {
-      return;
+      return false;
     }
 
     const statusEl = streamTab.querySelector('.tab-status');
     if (!statusEl) {
-      return;
+      return false;
     }
 
     // Remove old status classes dynamically from STREAM_STATUS values
@@ -158,6 +159,7 @@ export class StreamTabs {
     statusEl.classList.add(normalizedStatus);
     statusEl.dataset.status =
       normalizedStatus.charAt(0).toUpperCase() + normalizedStatus.slice(1);
+    return true;
   }
 
   /**

--- a/src/progressView/modules/uiManagers/StreamTabs.js
+++ b/src/progressView/modules/uiManagers/StreamTabs.js
@@ -149,7 +149,7 @@ export class StreamTabs {
     }
 
     // Remove old status classes and add new one
-    // Must include all STREAM_STATUS values that have CSS classes
+    // SYNC: These must match STREAM_STATUS values in @common/constants/streamStatus
     statusEl.classList.remove(
       'running',
       'stopped',

--- a/src/progressView/modules/uiManagers/StreamTabs.js
+++ b/src/progressView/modules/uiManagers/StreamTabs.js
@@ -132,8 +132,10 @@ export class StreamTabs {
       `.stream-tab .tab[data-stream="${streamName}"]`,
     );
     if (!tabEl) {
-      console.debug(
-        `[updateStreamStatus] Tab not found for stream: ${streamName}`,
+      // Warn: tab should exist before status update (ordering issue)
+      console.warn(
+        `[updateStreamStatus] Tab not found for stream: ${streamName}. ` +
+          'UPDATE_STREAMS should be sent before UPDATE_STREAM_STATUS.',
       );
       return;
     }
@@ -148,16 +150,9 @@ export class StreamTabs {
       return;
     }
 
-    // Remove old status classes and add new one
-    // SYNC: These must match STREAM_STATUS values in @common/constants/streamStatus
-    statusEl.classList.remove(
-      'running',
-      'stopped',
-      'error',
-      'waiting',
-      'ready',
-      'resuming',
-    );
+    // Remove old status classes dynamically from STREAM_STATUS values
+    // This ensures the class list stays in sync with constants
+    Object.values(STREAM_STATUS).forEach((s) => statusEl.classList.remove(s));
     const normalizedStatus =
       status === STREAM_STATUS.READY ? 'stopped' : status || 'stopped';
     statusEl.classList.add(normalizedStatus);


### PR DESCRIPTION
Key optimizations:

1. **Incremental UPDATE_LOGS handling**
   - Add `forceRebuild` flag to UPDATE_LOGS messages
   - Skip full DOM rebuild when refreshing same stream
   - Only rebuild on actual stream switch or explicit force

2. **Targeted stream status updates**
   - Add UPDATE_STREAM_STATUS command for single-stream status changes
   - Replace buildStreamInfos+updateStreams with lightweight update
   - Eliminates O(n) rebuild on every status change

3. **Reduce redundant refresh calls**
   - Pass runId directly to _refreshInstructionForActiveRun/OutputsForActiveRun
   - Avoid redundant resolveActiveRunId calls in cascading refreshes
   - Use message.activeRunId when available

Files changed:
- WebviewUpdater.ts: Add updateStreamStatus(), forceRebuild option
- ProgressEventHandler.ts: Use targeted status update
- StreamStatusEvents.ts: Track stream switch for forceRebuild
- OutputEvents.ts: Pass forceRebuild on clear
- ProgressViewProvider.ts: Track _lastRenderedStream for switch detection
- messageHandlers.js: Implement incremental updates, pass runId
- StreamTabs.js: Add updateStreamStatus() for single-stream updates
- commands.js: Add UPDATE_STREAM_STATUS command

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds incremental UPDATE_LOGS with forceRebuild control, targeted stream status/run usage updates, and stream-switch detection to reduce full DOM rebuilds.
> 
> - **Progress View (backend)**:
>   - `WebviewUpdater`: adds `updateStreamStatus`, `updateRunUsage`, and `updateLogContent(..., { forceRebuild })`.
>   - `ProgressEventHandler`: uses targeted `updateStreamStatus`; passes `forceRebuild` to `updateLogContent`; forces rebuild only on switches/deletions.
>   - `StreamStatusEvents`: ensures tab creation order; detects stream switches to conditionally `forceRebuild`.
>   - `OutputEvents`: forces rebuild after clearing output; maintains incremental refresh elsewhere.
>   - `UsageEvents`: sends per-run usage via `updateRunUsage`.
>   - `ProgressViewProvider`: tracks `_lastRenderedStream`; auto-detects stream switches; forces rebuild on first load/state reload/deletions.
>   - `ProgressViewMessageHandler`: forces rebuild after stream deletions and workspace changes.
> - **Webview (frontend)**:
>   - `messageHandlers.js`: implements incremental `UPDATE_LOGS` path (no DOM rebuild when `forceRebuild === false`); refactors run refresh helpers to accept `runId`; adds `_updateRunMetadata`; handles `UPDATE_STREAM_STATUS` and `UPDATE_RUN_USAGE`.
>   - `StreamTabs`: adds `updateStreamStatus` for single-tab updates.
> - **Commands**:
>   - Adds `UPDATE_STREAM_STATUS` and `UPDATE_RUN_USAGE` to `commands.{js,ts}`; existing handlers wired to new incremental pathways.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 12e22e4efafaa699e837b2c1a5ba222445378a4e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->