### PR TITLE
Refactor round trip spaghetti code

### DIFF
--- a/src/agent/runtime/RunStorageService.ts
+++ b/src/agent/runtime/RunStorageService.ts
@@ -1,0 +1,94 @@
+/**
+ * RunStorageService - Abstracts run state storage from UI components.
+ *
+ * This service decouples the agent runtime from the ProgressView UI layer,
+ * allowing agents to run without requiring the UI to be initialized.
+ * This enables headless execution and easier testing.
+ */
+
+// Type imports
+import type { OutputFileInfo } from '@agent/output/types';
+import type { StreamTabId, StorageKey } from '@agent/types/IdentifierTypes';
+
+/**
+ * Interface for accessing run storage state.
+ *
+ * This interface abstracts the storage operations needed by the agent runtime,
+ * breaking the direct dependency on ProgressViewProvider.
+ */
+export interface IRunStorageService {
+  /**
+   * Get the active run ID for a stream.
+   * For workflow agents this is a task group ID, for tool-use it's the execution ID.
+   */
+  getActiveRunId(stream: StreamTabId): StorageKey | null;
+
+  /**
+   * Get output files for a specific run within a stream.
+   * @param stream - The stream tab ID
+   * @param options.storageKey - The branded key for storage lookup
+   * @returns Map of round number to output file info, or undefined if not found
+   */
+  getRunOutputFiles(
+    stream: StreamTabId,
+    options: { storageKey: StorageKey },
+  ): Map<number, OutputFileInfo[]> | undefined;
+
+  /**
+   * Check if the progress view is currently visible.
+   * Used to determine whether to show notifications.
+   */
+  isViewVisible(): boolean;
+}
+
+/**
+ * Null implementation for when no storage service is available.
+ * Returns safe defaults that allow agent execution to proceed.
+ */
+export class NullRunStorageService implements IRunStorageService {
+  getActiveRunId(_stream: StreamTabId): StorageKey | null {
+    return null;
+  }
+
+  getRunOutputFiles(
+    _stream: StreamTabId,
+    _options: { storageKey: StorageKey },
+  ): Map<number, OutputFileInfo[]> | undefined {
+    return undefined;
+  }
+
+  isViewVisible(): boolean {
+    return false;
+  }
+}
+
+/**
+ * Registry for the run storage service.
+ *
+ * Uses a simple module-level registry pattern to allow the UI layer
+ * to register its implementation without creating import dependencies.
+ */
+let registeredService: IRunStorageService = new NullRunStorageService();
+
+/**
+ * Register a run storage service implementation.
+ * Called by ProgressViewProvider during initialization.
+ */
+export function registerRunStorageService(service: IRunStorageService): void {
+  registeredService = service;
+}
+
+/**
+ * Get the current run storage service.
+ * Returns NullRunStorageService if no implementation has been registered.
+ */
+export function getRunStorageService(): IRunStorageService {
+  return registeredService;
+}
+
+/**
+ * Clear the registered service (useful for testing).
+ */
+export function clearRunStorageService(): void {
+  registeredService = new NullRunStorageService();
+}

--- a/src/agent/runtime/RunStorageService.ts
+++ b/src/agent/runtime/RunStorageService.ts
@@ -27,3 +27,8 @@ export const getRunStorageService = (): IRunStorageService =>
     getRunOutputFiles: () => undefined,
     isViewVisible: () => false,
   };
+
+/** Reset to default state (for testing) */
+export const resetRunStorageService = (): void => {
+  service = null;
+};

--- a/src/agent/runtime/RunStorageService.ts
+++ b/src/agent/runtime/RunStorageService.ts
@@ -1,94 +1,29 @@
 /**
- * RunStorageService - Abstracts run state storage from UI components.
- *
- * This service decouples the agent runtime from the ProgressView UI layer,
- * allowing agents to run without requiring the UI to be initialized.
- * This enables headless execution and easier testing.
+ * Decouples agent runtime from ProgressView UI layer.
  */
-
-// Type imports
 import type { OutputFileInfo } from '@agent/output/types';
 import type { StreamTabId, StorageKey } from '@agent/types/IdentifierTypes';
 
-/**
- * Interface for accessing run storage state.
- *
- * This interface abstracts the storage operations needed by the agent runtime,
- * breaking the direct dependency on ProgressViewProvider.
- */
+/** Interface for run state access - implemented by ProgressViewProvider */
 export interface IRunStorageService {
-  /**
-   * Get the active run ID for a stream.
-   * For workflow agents this is a task group ID, for tool-use it's the execution ID.
-   */
   getActiveRunId(stream: StreamTabId): StorageKey | null;
-
-  /**
-   * Get output files for a specific run within a stream.
-   * @param stream - The stream tab ID
-   * @param options.storageKey - The branded key for storage lookup
-   * @returns Map of round number to output file info, or undefined if not found
-   */
   getRunOutputFiles(
     stream: StreamTabId,
     options: { storageKey: StorageKey },
   ): Map<number, OutputFileInfo[]> | undefined;
-
-  /**
-   * Check if the progress view is currently visible.
-   * Used to determine whether to show notifications.
-   */
   isViewVisible(): boolean;
 }
 
-/**
- * Null implementation for when no storage service is available.
- * Returns safe defaults that allow agent execution to proceed.
- */
-export class NullRunStorageService implements IRunStorageService {
-  getActiveRunId(_stream: StreamTabId): StorageKey | null {
-    return null;
-  }
+let service: IRunStorageService | null = null;
 
-  getRunOutputFiles(
-    _stream: StreamTabId,
-    _options: { storageKey: StorageKey },
-  ): Map<number, OutputFileInfo[]> | undefined {
-    return undefined;
-  }
+export const setRunStorageService = (s: IRunStorageService): void => {
+  service = s;
+};
 
-  isViewVisible(): boolean {
-    return false;
-  }
-}
-
-/**
- * Registry for the run storage service.
- *
- * Uses a simple module-level registry pattern to allow the UI layer
- * to register its implementation without creating import dependencies.
- */
-let registeredService: IRunStorageService = new NullRunStorageService();
-
-/**
- * Register a run storage service implementation.
- * Called by ProgressViewProvider during initialization.
- */
-export function registerRunStorageService(service: IRunStorageService): void {
-  registeredService = service;
-}
-
-/**
- * Get the current run storage service.
- * Returns NullRunStorageService if no implementation has been registered.
- */
-export function getRunStorageService(): IRunStorageService {
-  return registeredService;
-}
-
-/**
- * Clear the registered service (useful for testing).
- */
-export function clearRunStorageService(): void {
-  registeredService = new NullRunStorageService();
-}
+/** Returns service or safe defaults if not registered */
+export const getRunStorageService = (): IRunStorageService =>
+  service ?? {
+    getActiveRunId: () => null,
+    getRunOutputFiles: () => undefined,
+    isViewVisible: () => false,
+  };

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -41,13 +41,13 @@ import { MAIN_VIEW_COMMANDS } from '@common/webview/commands';
 import { showInstructionWithSuppress } from '@frontend/ui/instruction';
 import { AgentLogger } from '@logger/AgentLogger';
 import { MODEL_CONFIGS } from '@model/ModelRegistry';
-import { ProgressViewProvider } from '@progressView/ProgressViewProvider';
 import { agentConfigToTaskState } from '@utils/config';
 import { ensureRunDir } from '@utils/files/taskRunStorage';
 import { bus } from '@eventBus/ProgressEventBus';
 import { getStreamTabId } from '@/logger/streamUtils';
 
 // Local file imports
+import { getRunStorageService } from './RunStorageService';
 import { StreamStatusService } from './StreamStatusService';
 import {
   AgentExecutionContext,
@@ -356,24 +356,22 @@ export async function executeAgentWithLogging<T extends IAgent>(
 
     const activeStreamId: StreamTabId = streamTabId;
 
-    const provider = ProgressViewProvider.getInstance();
+    // Use the run storage service instead of directly accessing ProgressViewProvider
+    // This decouples agent execution from the UI layer
+    const runStorage = getRunStorageService();
+
     if (isResume) {
       StreamStatusService.set(activeStreamId, STREAM_STATUS.RESUMING);
     }
 
-    if (
-      isResume &&
-      agent instanceof BaseReflectionAgent &&
-      executionId &&
-      provider
-    ) {
+    if (isResume && agent instanceof BaseReflectionAgent && executionId) {
       // For resume, use a single storageKey for both fetching and hydrating
       // Priority: activeRunId (task group ID for workflow agents) ?? executionId (for tool-use)
       // Use normalizeRunId to brand as StorageKey
-      const activeRunId = provider.state.getActiveRunId(activeStreamId);
+      const activeRunId = runStorage.getActiveRunId(activeStreamId);
       const storageKey = normalizeRunId(activeRunId ?? executionId);
 
-      const runOutputs = provider.state.getRunOutputFiles(activeStreamId, {
+      const runOutputs = runStorage.getRunOutputFiles(activeStreamId, {
         storageKey,
       });
 
@@ -421,14 +419,14 @@ export async function executeAgentWithLogging<T extends IAgent>(
               StreamStatusService.set(activeStreamId, STREAM_STATUS.RUNNING);
 
               if (!isResume) {
-                const viewVisible = provider?.isViewVisible() ?? false;
+                const viewVisible = runStorage.isViewVisible();
                 if (!viewVisible) {
                   await vscode.commands.executeCommand(
                     'texra.showProgressView',
                   );
                 }
 
-                if (!provider?.isViewVisible()) {
+                if (!runStorage.isViewVisible()) {
                   const inputFileName = config.inputFile
                     ? path.basename(config.inputFile)
                     : 'selected input';

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -419,13 +419,13 @@ export async function executeAgentWithLogging<T extends IAgent>(
               StreamStatusService.set(activeStreamId, STREAM_STATUS.RUNNING);
 
               if (!isResume) {
-                const viewVisible = runStorage.isViewVisible();
-                if (!viewVisible) {
+                if (!runStorage.isViewVisible()) {
                   await vscode.commands.executeCommand(
                     'texra.showProgressView',
                   );
                 }
 
+                // Re-check after command: view might still be hidden (e.g., collapsed sidebar)
                 if (!runStorage.isViewVisible()) {
                   const inputFileName = config.inputFile
                     ? path.basename(config.inputFile)

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -1,3 +1,4 @@
 export * from './executeAgent';
 export * from './agentLoad';
 export * from './ModelFactory';
+export * from './RunStorageService';

--- a/src/eventBus/ProgressEventBus.ts
+++ b/src/eventBus/ProgressEventBus.ts
@@ -19,7 +19,7 @@ import type { TaskState } from '@logger/TaskState';
 import type {
   ToolEditApprovalPrompt,
   RetryRequestPrompt,
-} from '@progressView/types';
+} from './types';
 
 // Maximum number of events to buffer when no listeners are registered
 const MAX_BUFFER_SIZE = 1000;

--- a/src/eventBus/ProgressEventBus.ts
+++ b/src/eventBus/ProgressEventBus.ts
@@ -16,10 +16,7 @@ import type {
   TaskGroup,
 } from '@logger/LogTypes';
 import type { TaskState } from '@logger/TaskState';
-import type {
-  ToolEditApprovalPrompt,
-  RetryRequestPrompt,
-} from './types';
+import type { ToolEditApprovalPrompt, RetryRequestPrompt } from './types';
 
 // Maximum number of events to buffer when no listeners are registered
 const MAX_BUFFER_SIZE = 1000;

--- a/src/eventBus/index.ts
+++ b/src/eventBus/index.ts
@@ -1,0 +1,2 @@
+export * from './ProgressEventBus';
+export * from './types';

--- a/src/eventBus/types.ts
+++ b/src/eventBus/types.ts
@@ -1,0 +1,36 @@
+/**
+ * Shared types for the progress event bus.
+ *
+ * These types are used by both the event bus and UI components.
+ * They are defined here to break the circular dependency between
+ * @eventBus and @progressView.
+ */
+
+// Type imports
+import type { StreamTabId } from '@agent/types/IdentifierTypes';
+
+/**
+ * Prompt data for tool edit approval requests.
+ * Emitted via 'showToolEditApprovalPrompt' event.
+ */
+export interface ToolEditApprovalPrompt {
+  requestId: string;
+  path: string;
+  relativePath: string;
+  sourceTool: string;
+  allowBypass: boolean;
+  streamId: StreamTabId | '';
+  addedLines: number;
+  removedLines: number;
+}
+
+/**
+ * Prompt data for manual retry requests.
+ * Emitted via 'showRetryRequest' event.
+ */
+export interface RetryRequestPrompt {
+  streamId: StreamTabId;
+  operation: string;
+  model?: string;
+  errorMessage?: string;
+}

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -2,6 +2,10 @@
 import * as vscode from 'vscode';
 
 // Internal imports
+import type { OutputFileInfo } from '@agent/output/types';
+import type { IRunStorageService } from '@agent/runtime/RunStorageService';
+import { registerRunStorageService } from '@agent/runtime/RunStorageService';
+import type { StreamTabId, StorageKey } from '@agent/types/IdentifierTypes';
 import { BaseWebviewProvider } from '@common/webview';
 import { getSharedLocalResourceRoots } from '@common/webview';
 import { AgentLogger } from '@logger/AgentLogger';
@@ -24,10 +28,13 @@ import type { ToolEditApprovalPrompt } from './types';
  * Refactored ProgressViewProvider using the new modular architecture.
  * This class now focuses on orchestration and delegation to focused managers,
  * following the design principles from AGENTS.md.
+ *
+ * Implements IRunStorageService to provide run state access to the agent runtime
+ * without creating circular dependencies.
  */
 export class ProgressViewProvider
   extends BaseWebviewProvider
-  implements vscode.WebviewViewProvider
+  implements vscode.WebviewViewProvider, IRunStorageService
 {
   private static _instance: ProgressViewProvider | undefined;
 
@@ -89,8 +96,9 @@ export class ProgressViewProvider
     this.contentProvider = new ProgressViewContentProvider(context);
     this.messageHandler = new ProgressViewMessageHandler(this, context);
 
-    // Set instance
+    // Set instance and register as run storage service
     ProgressViewProvider._instance = this;
+    registerRunStorageService(this);
 
     // Listen for workspace folder changes
     this._disposables.push(
@@ -294,6 +302,29 @@ export class ProgressViewProvider
   public isViewVisible(): boolean {
     return this._view?.visible ?? false;
   }
+
+  // ===== IRunStorageService implementation =====
+
+  /**
+   * Get the active run ID for a stream.
+   * Implements IRunStorageService.getActiveRunId
+   */
+  public getActiveRunId(stream: StreamTabId): StorageKey | null {
+    return this.state.getActiveRunId(stream);
+  }
+
+  /**
+   * Get output files for a specific run within a stream.
+   * Implements IRunStorageService.getRunOutputFiles
+   */
+  public getRunOutputFiles(
+    stream: StreamTabId,
+    options: { storageKey: StorageKey },
+  ): Map<number, OutputFileInfo[]> | undefined {
+    return this.state.getRunOutputFiles(stream, options);
+  }
+
+  // ===== End IRunStorageService implementation =====
 
   /**
    * Reset running stream statuses when webview reloads

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -12,6 +12,7 @@ import { AgentLogger } from '@logger/AgentLogger';
 
 // Local file imports
 import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
+import type { ToolEditApprovalPrompt } from '@eventBus/types';
 import { ProgressEventHandler } from './events/ProgressEventHandler';
 import { WebviewUpdater } from './managers';
 // @ts-ignore - Import JavaScript module
@@ -22,7 +23,6 @@ import { ProgressViewState } from './state/ProgressViewState';
 // Types
 
 // Type imports
-import type { ToolEditApprovalPrompt } from '@eventBus/types';
 
 /**
  * Refactored ProgressViewProvider using the new modular architecture.

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -4,7 +4,7 @@ import * as vscode from 'vscode';
 // Internal imports
 import type { OutputFileInfo } from '@agent/output/types';
 import type { IRunStorageService } from '@agent/runtime/RunStorageService';
-import { registerRunStorageService } from '@agent/runtime/RunStorageService';
+import { setRunStorageService } from '@agent/runtime/RunStorageService';
 import type { StreamTabId, StorageKey } from '@agent/types/IdentifierTypes';
 import { BaseWebviewProvider } from '@common/webview';
 import { getSharedLocalResourceRoots } from '@common/webview';
@@ -22,7 +22,7 @@ import { ProgressViewState } from './state/ProgressViewState';
 // Types
 
 // Type imports
-import type { ToolEditApprovalPrompt } from './types';
+import type { ToolEditApprovalPrompt } from '@eventBus/types';
 
 /**
  * Refactored ProgressViewProvider using the new modular architecture.
@@ -98,7 +98,7 @@ export class ProgressViewProvider
 
     // Set instance and register as run storage service
     ProgressViewProvider._instance = this;
-    registerRunStorageService(this);
+    setRunStorageService(this);
 
     // Listen for workspace folder changes
     this._disposables.push(

--- a/src/progressView/managers/WebviewUpdater.ts
+++ b/src/progressView/managers/WebviewUpdater.ts
@@ -13,11 +13,10 @@ import { AgentLogger } from '@logger/AgentLogger';
 import { LogMessageData } from '@logger/LogTypes';
 import type { TaskState } from '@logger/TaskState';
 import type {
-  InstructionUpdate,
   RetryRequestPrompt,
-  StreamTabInfo,
   ToolEditApprovalPrompt,
-} from '@progressView/types';
+} from '@eventBus/types';
+import type { InstructionUpdate, StreamTabInfo } from '@progressView/types';
 // Internal imports
 import { buildStreamInfos } from '@progressView/streamInfoUtils';
 

--- a/src/progressView/managers/WebviewUpdater.ts
+++ b/src/progressView/managers/WebviewUpdater.ts
@@ -12,10 +12,6 @@ import { STREAM_STATUS } from '@common/constants/streamStatus';
 import { AgentLogger } from '@logger/AgentLogger';
 import { LogMessageData } from '@logger/LogTypes';
 import type { TaskState } from '@logger/TaskState';
-import type {
-  RetryRequestPrompt,
-  ToolEditApprovalPrompt,
-} from '@eventBus/types';
 import type { InstructionUpdate, StreamTabInfo } from '@progressView/types';
 // Internal imports
 import { buildStreamInfos } from '@progressView/streamInfoUtils';
@@ -25,6 +21,10 @@ import type { TaskGroupUpdatePayload } from '@progressView/managers/TaskGroupMan
 // Internal imports
 import { ProgressViewState } from '@progressView/state/ProgressViewState';
 import { COMMANDS } from '@progressView/modules/constants.js';
+import type {
+  RetryRequestPrompt,
+  ToolEditApprovalPrompt,
+} from '@eventBus/types';
 
 // Logger imports
 // Type imports

--- a/src/progressView/types.ts
+++ b/src/progressView/types.ts
@@ -3,6 +3,13 @@ import type { AgentCategory, AgentType } from '@agent/core/AgentDataclass';
 import type { ExecutionId, StreamTabId } from '@agent/types/IdentifierTypes';
 import type { AgentTypeFilter } from '@agent/types/AgentStreamTypes';
 
+// Re-export event bus types for backwards compatibility
+// These types are now defined in @eventBus/types to break circular dependency
+export type {
+  ToolEditApprovalPrompt,
+  RetryRequestPrompt,
+} from '@eventBus/types';
+
 export interface StreamUITraits {
   /** Canonical session grouping for the stream. */
   sessionKind: AgentCategory;
@@ -41,20 +48,3 @@ export interface InstructionUpdate {
   metadata?: InstructionMetadata;
 }
 
-export interface ToolEditApprovalPrompt {
-  requestId: string;
-  path: string;
-  relativePath: string;
-  sourceTool: string;
-  allowBypass: boolean;
-  streamId: StreamTabId | '';
-  addedLines: number;
-  removedLines: number;
-}
-
-export interface RetryRequestPrompt {
-  streamId: StreamTabId;
-  operation: string;
-  model?: string;
-  errorMessage?: string;
-}

--- a/src/progressView/types.ts
+++ b/src/progressView/types.ts
@@ -40,4 +40,3 @@ export interface InstructionUpdate {
   text: string;
   metadata?: InstructionMetadata;
 }
-

--- a/src/progressView/types.ts
+++ b/src/progressView/types.ts
@@ -3,13 +3,6 @@ import type { AgentCategory, AgentType } from '@agent/core/AgentDataclass';
 import type { ExecutionId, StreamTabId } from '@agent/types/IdentifierTypes';
 import type { AgentTypeFilter } from '@agent/types/AgentStreamTypes';
 
-// Re-export event bus types for backwards compatibility
-// These types are now defined in @eventBus/types to break circular dependency
-export type {
-  ToolEditApprovalPrompt,
-  RetryRequestPrompt,
-} from '@eventBus/types';
-
 export interface StreamUITraits {
   /** Canonical session grouping for the stream. */
   sessionKind: AgentCategory;


### PR DESCRIPTION
This commit addresses two critical spaghetti code patterns:

1. EventBus ↔ ProgressView Circular Dependency:
   - Created src/eventBus/types.ts with shared types (ToolEditApprovalPrompt, RetryRequestPrompt) that both modules can import
   - Updated ProgressEventBus.ts to import from local types instead of @progressView/types
   - Updated progressView/types.ts to re-export from @eventBus/types for backwards compatibility

2. Agent Runtime ↔ ProgressView Bidirectional Flow:
   - Created RunStorageService interface (IRunStorageService) to abstract run storage operations from UI components
   - Implemented NullRunStorageService for headless/testing scenarios
   - Added service registry pattern (registerRunStorageService/getRunStorageService)
   - Updated executeAgent.ts to use the service instead of directly accessing ProgressViewProvider.getInstance()
   - Made ProgressViewProvider implement IRunStorageService and register itself

Benefits:
- Agent execution can now run without requiring UI initialization
- EventBus is no longer coupled to progressView types
- Easier testing with dependency injection
- Clear separation between infrastructure and UI layers

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a RunStorageService to remove agent runtime’s dependency on ProgressView and extracts shared event types to eliminate circular imports.
> 
> - **Runtime**:
>   - **Run storage abstraction**: Add `IRunStorageService` and registry (`setRunStorageService`/`getRunStorageService`) in `agent/runtime/RunStorageService.ts`; export via `agent/runtime/index.ts`.
>   - **Agent execution decoupling**: Update `executeAgent.ts` to use `getRunStorageService()` for `getActiveRunId`, `getRunOutputFiles`, and `isViewVisible` (replacing direct `ProgressViewProvider` access) and to hydrate resume state via the service.
> - **UI / ProgressView**:
>   - Implement `IRunStorageService` in `ProgressViewProvider` (`getActiveRunId`, `getRunOutputFiles`, `isViewVisible`) and register with `setRunStorageService`.
>   - `WebviewUpdater.ts`: switch prompt types to `@eventBus/types`.
> - **Event Bus**:
>   - Add `eventBus/types.ts` defining `ToolEditApprovalPrompt` and `RetryRequestPrompt`; update `ProgressEventBus.ts` to import from it; add `eventBus/index.ts` barrel.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8976301e8671aa0ed9cce5f236b218e737f9f035. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->