### PR TITLE
Fix agent state restoration from progress view

### DIFF
--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -804,9 +804,7 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
       // Final fallback: check agentType from canonical session, then isToolUseAgent flag
       const agentType = canonicalSession?.agentType ?? state.agentType;
       const isToolUse =
-        agentType === 'toolUse' ||
-        state.isToolUseAgent ||
-        sessionCategory === SESSION_TYPES.TOOL_USE;
+        agentType === SESSION_TYPES.TOOL_USE || state.isToolUseAgent;
       sessionType = isToolUse ? SESSION_TYPES.TOOL_USE : SESSION_TYPES.WORKFLOW;
     }
 

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -776,17 +776,22 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
   _handleStateRestoration(state) {
     const config = state.agentConfig || state;
     const activeFiles = state.activeFiles || {};
+    // TaskState has session at top level - this is the canonical source of truth
+    // agentConfig.session should match, but may be missing in legacy data
+    const canonicalSession = state.session || config.session;
 
     const savedState = {};
-    this._restoreFormFields(config, savedState);
+    this._restoreFormFields(config, savedState, canonicalSession);
     this._restoreFileArrays(config, savedState, activeFiles);
     mainViewState.set(savedState);
     mainViewState.restore();
     this._skipNextRestoreState = true;
   }
 
-  _restoreFormFields(state, savedState) {
-    const sessionCategory = state.session?.agentCategory;
+  _restoreFormFields(state, savedState, canonicalSession) {
+    // Use the canonical session from TaskState (passed in), fallback to agentConfig.session
+    const sessionCategory =
+      canonicalSession?.agentCategory ?? state.session?.agentCategory;
 
     let sessionType = state.sessionType;
     if (sessionCategory === SESSION_TYPES.TOOL_USE) {
@@ -796,9 +801,13 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
     }
 
     if (!sessionType) {
-      sessionType = state.isToolUseAgent
-        ? SESSION_TYPES.TOOL_USE
-        : SESSION_TYPES.WORKFLOW;
+      // Final fallback: check agentType from canonical session, then isToolUseAgent flag
+      const agentType = canonicalSession?.agentType ?? state.agentType;
+      const isToolUse =
+        agentType === 'toolUse' ||
+        state.isToolUseAgent ||
+        sessionCategory === SESSION_TYPES.TOOL_USE;
+      sessionType = isToolUse ? SESSION_TYPES.TOOL_USE : SESSION_TYPES.WORKFLOW;
     }
 
     const normalizedSessionType = normalizeSessionType(sessionType);


### PR DESCRIPTION
When restoring state from progress view, the session type (workflow vs tool-use) was not being correctly determined because:

1. `_handleStateRestoration` passes `agentConfig` to `_restoreFormFields`
2. `_restoreFormFields` looked at `agentConfig.session.agentCategory`
3. But the canonical session is at the TaskState top level, not in agentConfig

The fix:
- Extract `canonicalSession` from TaskState's top-level `session` field
- Pass this to `_restoreFormFields` and use it as the primary source
- Fall back to `agentConfig.session` for backwards compatibility
- Improve fallback logic to also check `agentType` from canonical session

This ensures workflow agents restore as workflow and tool-use agents restore as tool-use, with the correct agent dropdown selection.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Restores session type and agent selection correctly by using the top-level TaskState `session` with improved fallbacks.
> 
> - **Webview state restoration (`src/webview/modules/messageHandlers.js`)**:
>   - Use canonical session from `TaskState.session` (fallback to `agentConfig.session`) during restore.
>   - Pass `canonicalSession` into `_restoreFormFields` and update its signature accordingly.
>   - Derive `sessionType` from `canonicalSession.agentCategory`; fallback to `agentType` or `isToolUseAgent` when needed.
>   - Ensure correct agent dropdown selection by normalizing session type and setting `workflow` vs `toolUse` values appropriately.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c5e2aef3bf1ab3aeee0747b24abea369908b5cc8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->