### PR TITLE
Identify round-trip spaghetti code patterns

### DIFF
--- a/src/eventBus/ProgressEventBus.ts
+++ b/src/eventBus/ProgressEventBus.ts
@@ -85,9 +85,7 @@ export interface ProgressEventPayloads {
     filesByRound: { [key: number]: string[] };
   };
   clearMissingOutputs: StreamTabId;
-  clearOutputFiles: StreamTabId;
   setTaskState: SetTaskStatePayload;
-  clearTaskOutput: StreamTabId;
   updateStreamUsage: RunScopedPayload & {
     usage: TokenUsageStats;
   };

--- a/src/explorer/ExplorerOperations.ts
+++ b/src/explorer/ExplorerOperations.ts
@@ -59,12 +59,24 @@ export class ExplorerOperations {
     _context: vscode.ExtensionContext | undefined,
     private refresh: () => void,
   ) {
-    agentDirectories.builtIn().then((p) => {
-      this.builtInAgentsPath = p;
-    });
-    agentDirectories.builtInToolUse().then((p) => {
-      this.builtInToolUsePath = p;
-    });
+    // Initialize agent directory paths asynchronously with error handling
+    agentDirectories
+      .builtIn()
+      .then((p) => {
+        this.builtInAgentsPath = p;
+      })
+      .catch((err) => {
+        logger.warn(CHANNEL, `Failed to get built-in agents path: ${err}`);
+      });
+
+    agentDirectories
+      .builtInToolUse()
+      .then((p) => {
+        this.builtInToolUsePath = p;
+      })
+      .catch((err) => {
+        logger.warn(CHANNEL, `Failed to get built-in tool-use path: ${err}`);
+      });
   }
 
   async open(uri: vscode.Uri) {

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -51,7 +51,12 @@ export class ProgressViewProvider
   private readonly _extensionUri: vscode.Uri;
   private readonly _viewTitle: string;
   private _webviewReady = false;
-  private _pendingUpdate = false;
+  /**
+   * Tracks pending update options when webview is not ready.
+   * Uses an object instead of boolean to preserve forceRebuild requests.
+   * null = no pending update, object = pending with accumulated options.
+   */
+  private _pendingUpdateOptions: { forceRebuild: boolean } | null = null;
   private _hasResolved = false;
   private _lastRenderedStream = ''; // Track last rendered stream for switch detection
   private readonly logger: AgentLogger;
@@ -131,7 +136,7 @@ export class ProgressViewProvider
   protected override cleanupView(): void {
     super.cleanupView();
     this._webviewReady = false;
-    this._pendingUpdate = false;
+    this._pendingUpdateOptions = null;
     this._lastRenderedStream = '';
   }
 
@@ -143,7 +148,7 @@ export class ProgressViewProvider
     this._hasResolved = true;
 
     this._webviewReady = false;
-    this._pendingUpdate = false;
+    this._pendingUpdateOptions = null;
     // Clear last rendered stream to force rebuild - DOM state is stale after resolve
     this._lastRenderedStream = '';
     webviewView.webview.options = {
@@ -186,7 +191,13 @@ export class ProgressViewProvider
     if (!this._view) return;
 
     if (!this._webviewReady) {
-      this._pendingUpdate = true;
+      // Queue the update, preserving forceRebuild if any caller requested it.
+      // Once forceRebuild is true, it stays true until the update is processed.
+      const currentForce = this._pendingUpdateOptions?.forceRebuild ?? false;
+      const requestedForce = options?.forceRebuild ?? false;
+      this._pendingUpdateOptions = {
+        forceRebuild: currentForce || requestedForce,
+      };
       return;
     }
 
@@ -215,7 +226,7 @@ export class ProgressViewProvider
 
     // Update tracking after refresh
     this._lastRenderedStream = activeStream;
-    this._pendingUpdate = false;
+    this._pendingUpdateOptions = null;
   }
 
   /**
@@ -223,8 +234,12 @@ export class ProgressViewProvider
    */
   public markWebviewReady(): void {
     this._webviewReady = true;
-    // Force rebuild on first load
-    this.updateWebview({ forceRebuild: true });
+
+    // Process any pending update with accumulated options.
+    // Always force rebuild on first load, but also honor any pending forceRebuild requests.
+    const pendingForceRebuild = this._pendingUpdateOptions?.forceRebuild ?? false;
+    this._pendingUpdateOptions = null;
+    this.updateWebview({ forceRebuild: true || pendingForceRebuild });
 
     if (this.webviewUpdater.isAvailable()) {
       // Replay pending approval prompts

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -235,11 +235,10 @@ export class ProgressViewProvider
   public markWebviewReady(): void {
     this._webviewReady = true;
 
-    // Process any pending update with accumulated options.
-    // Always force rebuild on first load, but also honor any pending forceRebuild requests.
-    const pendingForceRebuild = this._pendingUpdateOptions?.forceRebuild ?? false;
+    // Clear pending options - we always force rebuild on first load anyway,
+    // and that takes precedence over any pending options.
     this._pendingUpdateOptions = null;
-    this.updateWebview({ forceRebuild: true || pendingForceRebuild });
+    this.updateWebview({ forceRebuild: true });
 
     if (this.webviewUpdater.isAvailable()) {
       // Replay pending approval prompts

--- a/src/progressView/events/OutputEvents.ts
+++ b/src/progressView/events/OutputEvents.ts
@@ -2,7 +2,6 @@
 import * as vscode from 'vscode';
 
 // Local imports - progress view
-import type { StreamTabId } from '@agent/types/IdentifierTypes';
 import type { AgentLogger } from '@logger/AgentLogger';
 import type { WebviewUpdater } from '@progressView/managers';
 import type { ProgressViewState } from '@progressView/state/ProgressViewState';
@@ -11,7 +10,7 @@ import type { ProgressViewState } from '@progressView/state/ProgressViewState';
 import { createErrorBoundary } from './errorHandling';
 
 // Type imports
-import type { ProgressEventBusLike, StreamStatusType } from './types';
+import type { ProgressEventBusLike } from './types';
 
 export interface OutputEventsModule {
   register(
@@ -23,11 +22,6 @@ export interface OutputEventsModule {
 
 interface OutputEventsShared {
   logger: AgentLogger;
-  refreshStreamSurface: (
-    stream: string,
-    options?: { updateInstruction?: boolean; forceRebuild?: boolean },
-  ) => void;
-  getAllStreamStatuses: () => Map<string, StreamStatusType>;
 }
 
 const toRoundRecord = <T>(
@@ -70,18 +64,6 @@ const sendRunMissingUpdate = (
   const rounds = toRoundRecord(runMissing);
   const payload = rounds ? { runId, rounds } : { runId };
   updater.updateMissingOutputs(stream, payload);
-};
-
-const resetFileSurface = (
-  state: ProgressViewState,
-  updater: WebviewUpdater,
-  stream: string,
-): void => {
-  if (state.activeStream !== stream || !updater.isAvailable()) {
-    return;
-  }
-
-  updater.updateFiles(stream, { reset: true });
 };
 
 const resetMissingSurface = (
@@ -135,39 +117,8 @@ const registerOutputFileListeners = (
     });
   });
 
-  const clearFiles = bus.on('clearOutputFiles', (stream) => {
-    withErrorBoundary('failed to handle clearOutputFiles', async () => {
-      await state.outputFiles.clearFiles(stream);
-      resetFileSurface(state, updater, stream);
-    });
-  });
-
-  return [addFiles, updateMissing, clearMissing, clearFiles].map(
+  return [addFiles, updateMissing, clearMissing].map(
     (dispose) => new vscode.Disposable(dispose),
-  );
-};
-
-const registerClearTaskOutput = (
-  bus: ProgressEventBusLike,
-  state: ProgressViewState,
-  updater: WebviewUpdater,
-  shared: OutputEventsShared,
-  withErrorBoundary: ReturnType<typeof createErrorBoundary>,
-): vscode.Disposable => {
-  return new vscode.Disposable(
-    bus.on('clearTaskOutput', (streamTabId: StreamTabId) => {
-      withErrorBoundary('failed to handle clearTaskOutput', () => {
-        const cleared = state.clearOutputState(streamTabId);
-        if (cleared) {
-          const activeStream = updater.updateAll(
-            state,
-            shared.getAllStreamStatuses(),
-          );
-          // Force rebuild since we cleared data
-          shared.refreshStreamSurface(activeStream, { forceRebuild: true });
-        }
-      });
-    }),
   );
 };
 
@@ -182,16 +133,7 @@ export function createOutputEvents(
       state: ProgressViewState,
       updater: WebviewUpdater,
     ): vscode.Disposable[] {
-      const disposables = registerOutputFileListeners(
-        bus,
-        state,
-        updater,
-        withErrorBoundary,
-      );
-      disposables.push(
-        registerClearTaskOutput(bus, state, updater, shared, withErrorBoundary),
-      );
-      return disposables;
+      return registerOutputFileListeners(bus, state, updater, withErrorBoundary);
     },
   };
 }

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -81,9 +81,6 @@ export class ProgressEventHandler {
     });
     this.outputEvents = createOutputEvents({
       logger: this.logger,
-      refreshStreamSurface: (stream, options) =>
-        this.refreshStreamSurface(stream, options),
-      getAllStreamStatuses: () => this.getAllStreamStatuses(),
     });
     this.usageEvents = createUsageEvents({
       logger: this.logger,

--- a/src/progressView/managers/WebviewUpdater.ts
+++ b/src/progressView/managers/WebviewUpdater.ts
@@ -341,7 +341,11 @@ export class WebviewUpdater {
 
   /**
    * Update stream metadata and theme for the webview.
-   * Returns the resolved active stream after applying the update.
+   * Returns the active stream after applying the update.
+   *
+   * Note: This method delegates active stream resolution to ProgressViewState,
+   * which is the single source of truth. The WebviewUpdater only reads state
+   * and sends messages - it never mutates state.
    */
   updateAll(
     state: ProgressViewState,
@@ -349,32 +353,26 @@ export class WebviewUpdater {
     theme?: 'dark' | 'light',
   ): StreamTabId {
     const streams = buildStreamInfos(state, statuses, state.agentTypeFilter);
+    const streamNames = streams.map((info) => info.name);
 
-    const webview = this.getWebview();
-    let resolvedActiveStream = state.activeStream;
-    if (!streams.some((info) => info.name === resolvedActiveStream)) {
-      resolvedActiveStream = streams[0]?.name ?? '';
-    }
+    // Delegate active stream resolution to state (single source of truth)
+    const activeStream = state.resolveActiveStream(streamNames);
 
-    if (!webview) {
-      return resolvedActiveStream;
-    }
-
-    if (resolvedActiveStream !== state.activeStream) {
-      state.activeStream = resolvedActiveStream;
+    if (!this.getWebview()) {
+      return activeStream;
     }
 
     if (theme) {
       this.updateTheme(theme);
     }
 
-    this.updateStreams(streams, resolvedActiveStream, state.agentTypeFilter);
+    this.updateStreams(streams, activeStream, state.agentTypeFilter);
 
     this.logger.debug(
-      `Updated webview streams (${streams.length}) active: ${resolvedActiveStream}`,
+      `Updated webview streams (${streams.length}) active: ${activeStream}`,
     );
 
-    return resolvedActiveStream;
+    return activeStream;
   }
 
   /**

--- a/src/progressView/state/ProgressViewState.ts
+++ b/src/progressView/state/ProgressViewState.ts
@@ -130,6 +130,36 @@ export class ProgressViewState {
     this.saveActiveStream();
   }
 
+  /**
+   * Ensure the active stream is valid within the given set of available streams.
+   *
+   * This is the SINGLE SOURCE OF TRUTH for active stream resolution. If the
+   * current active stream is not in the available set (e.g., due to filtering),
+   * this method picks the first available stream and updates the state.
+   *
+   * @param availableStreamNames - Array of stream IDs that are currently visible/available
+   * @returns The resolved active stream ID (may be empty if no streams available)
+   */
+  resolveActiveStream(availableStreamNames: string[]): StreamTabId {
+    const currentActive = this._activeStream;
+
+    // If current active stream is in the available list, keep it
+    if (availableStreamNames.includes(currentActive)) {
+      return currentActive;
+    }
+
+    // Otherwise, pick the first available stream (or empty if none)
+    const resolved = availableStreamNames[0] ?? '';
+
+    // Only update state if it actually changed
+    if (resolved !== currentActive) {
+      this._activeStream = resolved;
+      this.saveActiveStream();
+    }
+
+    return resolved;
+  }
+
   get streamSortOrder(): string {
     return this._streamSortOrder;
   }

--- a/src/progressView/state/ProgressViewState.ts
+++ b/src/progressView/state/ProgressViewState.ts
@@ -137,19 +137,19 @@ export class ProgressViewState {
    * current active stream is not in the available set (e.g., due to filtering),
    * this method picks the first available stream and updates the state.
    *
-   * @param availableStreamNames - Array of stream IDs that are currently visible/available
-   * @returns The resolved active stream ID (may be empty if no streams available)
+   * @param availableStreams - Array of stream IDs that are currently visible/available
+   * @returns The resolved active stream ID (may be empty string if no streams available)
    */
-  resolveActiveStream(availableStreamNames: string[]): StreamTabId {
+  resolveActiveStream(availableStreams: StreamTabId[]): StreamTabId {
     const currentActive = this._activeStream;
 
     // If current active stream is in the available list, keep it
-    if (availableStreamNames.includes(currentActive)) {
+    if (availableStreams.includes(currentActive)) {
       return currentActive;
     }
 
     // Otherwise, pick the first available stream (or empty if none)
-    const resolved = availableStreamNames[0] ?? '';
+    const resolved = availableStreams[0] ?? '';
 
     // Only update state if it actually changed
     if (resolved !== currentActive) {

--- a/src/utils/pendingStateManager.ts
+++ b/src/utils/pendingStateManager.ts
@@ -2,6 +2,11 @@
  * Simple in-memory storage for pending state restoration.
  * This is used to pass state from the restore command to the MainViewProvider
  * when the webview is not yet available.
+ *
+ * Design notes:
+ * - Use getPendingState() to read without clearing (for inspection)
+ * - Use clearPendingState() to explicitly clear after processing
+ * - consumePendingState() combines both for atomic get-and-clear operations
  */
 
 import type { TaskState } from '@logger/TaskState';
@@ -9,14 +14,34 @@ import type { TaskState } from '@logger/TaskState';
 let pendingState: TaskState | undefined = undefined;
 
 /**
- * Store state for later restoration
+ * Store state for later restoration.
+ * Overwrites any existing pending state.
  */
 export function setPendingState(state: TaskState): void {
   pendingState = state;
 }
 
 /**
- * Get and clear the pending state
+ * Get the pending state without clearing it.
+ * Use this when you need to inspect the state before deciding to process it.
+ * @returns The pending state if any, undefined otherwise
+ */
+export function getPendingState(): TaskState | undefined {
+  return pendingState;
+}
+
+/**
+ * Clear the pending state.
+ * Call this after successfully processing the state.
+ */
+export function clearPendingState(): void {
+  pendingState = undefined;
+}
+
+/**
+ * Get and clear the pending state atomically.
+ * Prefer using getPendingState() + clearPendingState() separately
+ * when you need to handle errors during processing.
  * @returns The pending state if any, undefined otherwise
  */
 export function consumePendingState(): TaskState | undefined {
@@ -26,7 +51,7 @@ export function consumePendingState(): TaskState | undefined {
 }
 
 /**
- * Check if there is pending state
+ * Check if there is pending state without consuming it.
  */
 export function hasPendingState(): boolean {
   return pendingState !== undefined;

--- a/src/utils/pendingStateManager.ts
+++ b/src/utils/pendingStateManager.ts
@@ -2,11 +2,6 @@
  * Simple in-memory storage for pending state restoration.
  * This is used to pass state from the restore command to the MainViewProvider
  * when the webview is not yet available.
- *
- * Design notes:
- * - Use getPendingState() to read without clearing (for inspection)
- * - Use clearPendingState() to explicitly clear after processing
- * - consumePendingState() combines both for atomic get-and-clear operations
  */
 
 import type { TaskState } from '@logger/TaskState';
@@ -15,33 +10,13 @@ let pendingState: TaskState | undefined = undefined;
 
 /**
  * Store state for later restoration.
- * Overwrites any existing pending state.
  */
 export function setPendingState(state: TaskState): void {
   pendingState = state;
 }
 
 /**
- * Get the pending state without clearing it.
- * Use this when you need to inspect the state before deciding to process it.
- * @returns The pending state if any, undefined otherwise
- */
-export function getPendingState(): TaskState | undefined {
-  return pendingState;
-}
-
-/**
- * Clear the pending state.
- * Call this after successfully processing the state.
- */
-export function clearPendingState(): void {
-  pendingState = undefined;
-}
-
-/**
- * Get and clear the pending state atomically.
- * Prefer using getPendingState() + clearPendingState() separately
- * when you need to handle errors during processing.
+ * Get and clear the pending state.
  * @returns The pending state if any, undefined otherwise
  */
 export function consumePendingState(): TaskState | undefined {
@@ -51,7 +26,7 @@ export function consumePendingState(): TaskState | undefined {
 }
 
 /**
- * Check if there is pending state without consuming it.
+ * Check if there is pending state.
  */
 export function hasPendingState(): boolean {
   return pendingState !== undefined;


### PR DESCRIPTION
…ream

This change fixes the bidirectional data flow issue where active stream state was held and mutated in multiple places:

1. Added `resolveActiveStream()` method to ProgressViewState as the single source of truth for active stream resolution and fallback logic

2. Modified WebviewUpdater.updateAll() to delegate stream resolution to state instead of mutating state directly - now purely reads state and sends messages

3. Removed dead event handlers that were never emitted:
   - clearOutputFiles event and handler
   - clearTaskOutput event and handler

The result is cleaner unidirectional data flow where state mutations only happen in ProgressViewState, and WebviewUpdater is a pure reader.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Centralizes active stream resolution in state, makes webview updater read-only, removes unused output/clear events, and adds resilient initialization for webview and explorer paths.
> 
> - **State & Stream Resolution**:
>   - Add `ProgressViewState.resolveActiveStream()` as the single source of truth for active stream selection.
> - **Webview Update Flow**:
>   - `WebviewUpdater.updateAll()` now delegates active stream resolution to state and no longer mutates it; returns the resolved active stream.
>   - `ProgressViewProvider` queues pending updates via `_pendingUpdateOptions` to preserve `forceRebuild`, clears on ready, and triggers a forced initial rebuild.
> - **Event Bus & Handlers Cleanup**:
>   - Remove unused events: `clearOutputFiles` and `clearTaskOutput` from `ProgressEventBus` and their handlers in `OutputEvents` (including related reset logic) and `ProgressEventHandler` wiring.
> - **Explorer**:
>   - Add error-handled async initialization for built-in agent/tool-use directories in `ExplorerOperations`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 82e0e6dc8fe649120d20561056dfd5b1dcb116f0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->