### PR TITLE
fix: improve tool detection on Unix-like systems

### DIFF
--- a/src/utils/system/platformPaths.ts
+++ b/src/utils/system/platformPaths.ts
@@ -96,10 +96,11 @@ export function getExtraDirs(): string[] {
       }
     }
   } else {
+    // Linux/Unix paths
     dirs.push(
       '/usr/local/bin',
       '/usr/bin',
-      '/usr/texbin',
+      '/snap/bin', // Ubuntu snap packages
       '/home/linuxbrew/.linuxbrew/bin',
     );
   }
@@ -117,6 +118,9 @@ export function getExtraDirs(): string[] {
     for (const tool of TEX_TOOLS) {
       texScriptPatterns.push(`/usr/local/texlive/*/texmf-dist/scripts/${tool}`);
       texScriptPatterns.push(`/usr/share/texlive/texmf-dist/scripts/${tool}`);
+      // Additional Debian/Ubuntu paths
+      texScriptPatterns.push(`/usr/share/texmf/scripts/${tool}`);
+      texScriptPatterns.push(`/usr/share/texmf-dist/scripts/${tool}`);
     }
   }
 
@@ -253,17 +257,17 @@ export function findToolInCommonPaths(tool: string): string | null {
       // ignore kpsewhich errors
     }
   }
-  if (process.platform === 'win32') {
-    for (const name of candidates) {
-      try {
-        const result = execaSync('where', [name], execOptions);
-        const found = result.stdout.split(/\r?\n/)[0]?.trim();
-        if (result.exitCode === 0 && found) {
-          return found;
-        }
-      } catch {
-        // ignore where errors
+  // Use platform-specific command to locate tools: 'where' on Windows, 'which' on Unix
+  const locateCmd = process.platform === 'win32' ? 'where' : 'which';
+  for (const name of candidates) {
+    try {
+      const result = execaSync(locateCmd, [name], execOptions);
+      const found = result.stdout.split(/\r?\n/)[0]?.trim();
+      if (result.exitCode === 0 && found) {
+        return found;
       }
+    } catch {
+      // ignore locate command errors
     }
   }
   return null;


### PR DESCRIPTION
- Use `which` command on Linux/macOS as fallback for finding tools
  (previously only Windows had `where` fallback)
- Replace macOS-specific `/usr/texbin` with `/snap/bin` in Linux paths
  to support Ubuntu snap packages
- Add additional Debian/Ubuntu texmf paths for latexdiff, latexindent, etc.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use platform-specific `which/where` fallback and add Unix paths (`/snap/bin`, Debian/Ubuntu texmf) to improve TeX tool discovery.
> 
> - **Tool discovery**:
>   - Use platform-specific locate command: `which` on Unix, `where` on Windows (fallback after `kpsewhich`).
> - **Paths (Unix/Linux)**:
>   - Add `/snap/bin` to common search dirs.
>   - Add Debian/Ubuntu TeX script paths: `/usr/share/texmf/scripts/*` and `/usr/share/texmf-dist/scripts/*`.
>   - Keep existing TeX Live bin and user TinyTeX/TeX Live patterns.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 00f9e7701c3829026c4cac4bd0501c237cd46298. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->