### PR TITLE
feat(progressView): add native code execution tool display

### DIFF
--- a/src/logger/LogTypes.ts
+++ b/src/logger/LogTypes.ts
@@ -42,6 +42,7 @@ export interface LogMessageData {
     | 'statistics'
     | 'modelResponse'
     | 'toolUse'
+    | 'codeExecution'
     | 'userMessage'
     | 'progressStatus'
     | 'error'

--- a/src/logger/messageTypes.ts
+++ b/src/logger/messageTypes.ts
@@ -6,6 +6,8 @@ export const MESSAGE_TYPES = {
   LATEXDIFF: 'latexdiff',
   STATISTICS: 'statistics',
   TOOL_USE: 'toolUse',
+  /** Native server-side code execution results (Anthropic, OpenAI, Google) */
+  CODE_EXECUTION: 'codeExecution',
   MODEL_RESPONSE: 'modelResponse',
   USER_MESSAGE: 'userMessage',
   PROGRESS_STATUS: 'progressStatus',

--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -340,6 +340,20 @@
               <div class="banner-content log-entry-content"></div>
             </details>
           </template>
+          <template id="codeExecutionTemplate">
+            <details class="banner-details code-execution-details">
+              <summary class="details-summary">
+                <i class="toggle-icon"></i>
+                <i class="codicon codicon-play"></i>
+                <span class="code-execution-title">Code Execution</span>
+                <span class="code-execution-status"></span>
+              </summary>
+              <div class="banner-content log-entry-content">
+                <div class="code-execution-code"></div>
+                <div class="code-execution-output"></div>
+              </div>
+            </details>
+          </template>
           <template id="userMessageTemplate">
             <div class="user-message-container">
               <div class="user-message">

--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -890,16 +890,15 @@ export class LogEntryFormatter {
     // Set icon based on status
     const iconElem = element.querySelector('.codicon');
     if (iconElem) {
-      const iconClass =
-        status === 'success'
-          ? 'codicon-pass'
-          : status === 'failed'
-            ? 'codicon-error'
-            : status === 'running'
-              ? 'codicon-sync'
-              : status === 'timeout'
-                ? 'codicon-watch'
-                : 'codicon-play';
+      const iconMap = {
+        success: 'codicon-pass',
+        failed: 'codicon-error',
+        running: 'codicon-sync',
+        timeout: 'codicon-watch',
+        cancelled: 'codicon-circle-slash',
+        unknown: 'codicon-question',
+      };
+      const iconClass = iconMap[status] || 'codicon-play';
       iconElem.className = `codicon ${iconClass}`;
     }
 
@@ -989,8 +988,17 @@ export class LogEntryFormatter {
       if (outputs && Array.isArray(outputs) && outputs.length > 0) {
         const outputItems = outputs
           .map((output) => {
-            if (output.type === 'image' && output.url) {
-              return `<img src="${encodeHtml(output.url)}" class="code-execution-image" alt="Code execution output" />`;
+            if (output.type === 'image') {
+              // Handle both url (OpenAI Responses API) and fileId (OpenAI Assistant API)
+              if (output.url) {
+                return `<img src="${encodeHtml(output.url)}" class="code-execution-image" alt="Code execution output" />`;
+              }
+              if (output.fileId) {
+                return `<div class="code-execution-file">
+                  <i class="codicon codicon-file-media"></i>
+                  <span>Image: ${encodeHtml(output.fileId)}</span>
+                </div>`;
+              }
             }
             if (output.type === 'file' && output.fileId) {
               return `<div class="code-execution-file">

--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -455,6 +455,17 @@ export class LogEntryFormatter {
             ),
           'tool use',
         ),
+      codeExecution: (message) =>
+        this._safeFormat(
+          () =>
+            this._formatCodeExecution(
+              message.normalizedPayload,
+              message.id,
+              message.groupId,
+              message.timestamp,
+            ),
+          'code execution',
+        ),
       modelResponse: (message) =>
         this._safeFormat(
           () =>
@@ -823,6 +834,192 @@ export class LogEntryFormatter {
       sections.length === 0
         ? wrapInPre(fallbackYaml || '')
         : sections.join('<hr class="tool-use-separator">');
+
+    return element;
+  }
+
+  /**
+   * Format a code execution result from native server-side execution
+   * (Anthropic, OpenAI Code Interpreter, Google GenAI)
+   * @private
+   * @param {Object} normalizedPayload - The normalized payload containing code execution data
+   * @param {string} logId - Log entry ID
+   * @param {string} groupId - Group ID
+   * @param {number} timestamp - Timestamp
+   * @returns {HTMLElement|null} DOM element for the code execution display
+   */
+  _formatCodeExecution(normalizedPayload, logId, groupId, timestamp) {
+    const element = createFromTemplate('codeExecutionTemplate');
+    if (!element) return null;
+
+    setElementDataset(element, { logId, groupId, timestamp });
+
+    const { structured } = normalizedPayload || {};
+    if (!structured || typeof structured !== 'object') {
+      return null;
+    }
+
+    const {
+      provider = 'unknown',
+      language = 'unknown',
+      code = '',
+      status = 'unknown',
+      returnCode,
+      stdout,
+      stderr,
+      outputs,
+      durationMs,
+      errorMessage,
+      errorCode,
+    } = structured;
+
+    // Update header title
+    const titleElem = element.querySelector('.code-execution-title');
+    if (titleElem) {
+      const langDisplay = language !== 'unknown' ? ` (${language})` : '';
+      titleElem.textContent = `Code Execution${langDisplay}`;
+    }
+
+    // Update status badge
+    const statusElem = element.querySelector('.code-execution-status');
+    if (statusElem) {
+      statusElem.textContent = status;
+      statusElem.className = `code-execution-status code-execution-status--${status}`;
+    }
+
+    // Set icon based on status
+    const iconElem = element.querySelector('.codicon');
+    if (iconElem) {
+      const iconClass =
+        status === 'success'
+          ? 'codicon-pass'
+          : status === 'failed'
+            ? 'codicon-error'
+            : status === 'running'
+              ? 'codicon-sync'
+              : status === 'timeout'
+                ? 'codicon-watch'
+                : 'codicon-play';
+      iconElem.className = `codicon ${iconClass}`;
+    }
+
+    // Toggle icon
+    const toggleIcon = element.querySelector('.toggle-icon');
+    if (toggleIcon) {
+      toggleIcon.className = `${CHEVRON_RIGHT_CLASS} toggle-icon`;
+    }
+
+    // Mark as error state if applicable
+    if (status === 'failed' || status === 'timeout') {
+      element.classList.add('code-execution-details--error');
+    }
+
+    // Build content
+    const codeSection = element.querySelector('.code-execution-code');
+    const outputSection = element.querySelector('.code-execution-output');
+
+    // Code input section
+    if (codeSection && code) {
+      const codeHeader = `<div class="code-execution-code-header">
+        <span>Input Code</span>
+        <span class="code-execution-provider">${encodeHtml(provider)}</span>
+      </div>`;
+      const codeBlock = `<pre><code class="language-${encodeHtml(language)}">${encodeHtml(code)}</code></pre>`;
+      codeSection.innerHTML = codeHeader + codeBlock;
+    }
+
+    // Output section
+    if (outputSection) {
+      const outputParts = [];
+
+      // Return code display (Anthropic)
+      if (returnCode !== undefined) {
+        const rcClass =
+          returnCode === 0
+            ? 'code-execution-return-code--success'
+            : 'code-execution-return-code--error';
+        outputParts.push(
+          `<div class="code-execution-return-code ${rcClass}">
+            <i class="codicon ${returnCode === 0 ? 'codicon-check' : 'codicon-close'}"></i>
+            Exit code: ${returnCode}
+          </div>`,
+        );
+      }
+
+      // Duration display
+      if (durationMs !== undefined) {
+        outputParts.push(
+          `<span class="code-execution-duration">${durationMs}ms</span>`,
+        );
+      }
+
+      // Stdout
+      if (stdout) {
+        outputParts.push(
+          `<div class="code-execution-output-header">
+            <i class="codicon codicon-terminal"></i>
+            <span>Output</span>
+          </div>
+          <div class="code-execution-stdout">${encodeHtml(stdout)}</div>`,
+        );
+      }
+
+      // Stderr
+      if (stderr) {
+        outputParts.push(
+          `<div class="code-execution-output-header">
+            <i class="codicon codicon-warning"></i>
+            <span>Errors</span>
+          </div>
+          <div class="code-execution-stderr">${encodeHtml(stderr)}</div>`,
+        );
+      }
+
+      // Error message
+      if (errorMessage) {
+        let errorHtml = `<div class="code-execution-error">`;
+        if (errorCode) {
+          errorHtml += `<div class="code-execution-error-code">${encodeHtml(errorCode)}</div>`;
+        }
+        errorHtml += `${encodeHtml(errorMessage)}</div>`;
+        outputParts.push(errorHtml);
+      }
+
+      // Additional outputs (images, files)
+      if (outputs && Array.isArray(outputs) && outputs.length > 0) {
+        const outputItems = outputs
+          .map((output) => {
+            if (output.type === 'image' && output.url) {
+              return `<img src="${encodeHtml(output.url)}" class="code-execution-image" alt="Code execution output" />`;
+            }
+            if (output.type === 'file' && output.fileId) {
+              return `<div class="code-execution-file">
+                <i class="codicon codicon-file"></i>
+                <span>${encodeHtml(output.fileId)}</span>
+              </div>`;
+            }
+            if (output.type === 'logs' && output.content) {
+              return `<div class="code-execution-stdout">${encodeHtml(output.content)}</div>`;
+            }
+            return '';
+          })
+          .filter(Boolean)
+          .join('');
+
+        if (outputItems) {
+          outputParts.push(
+            `<div class="code-execution-outputs">
+              <div class="code-execution-outputs-header">Additional Outputs</div>
+              ${outputItems}
+            </div>`,
+          );
+        }
+      }
+
+      outputSection.innerHTML = outputParts.join(
+        '<hr class="code-execution-separator">',
+      );
+    }
 
     return element;
   }

--- a/src/progressView/styles/code-execution.css
+++ b/src/progressView/styles/code-execution.css
@@ -47,6 +47,12 @@
   color: var(--vscode-editor-background, #1e1e1e);
 }
 
+.code-execution-status--unknown {
+  background-color: var(--vscode-descriptionForeground, #888888);
+  color: var(--vscode-editor-background, #1e1e1e);
+  opacity: 0.7;
+}
+
 /* Language badge */
 .code-execution-language {
   display: inline-flex;

--- a/src/progressView/styles/code-execution.css
+++ b/src/progressView/styles/code-execution.css
@@ -1,0 +1,249 @@
+/**
+ * Code execution styles for ProgressView
+ * Display of native server-side code execution results
+ */
+
+/* Code execution container */
+.code-execution-details {
+  margin: var(--spacing-small) 0;
+}
+
+/* Status badge in header */
+.code-execution-status {
+  display: inline-flex;
+  align-items: center;
+  padding: 1px var(--spacing-small);
+  border-radius: var(--border-radius-small);
+  font-size: var(--font-size-xs, 11px);
+  font-weight: 500;
+  margin-left: var(--spacing-small);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.code-execution-status--success {
+  background-color: var(--vscode-testing-iconPassed, #388a34);
+  color: var(--vscode-editor-background, #1e1e1e);
+}
+
+.code-execution-status--failed {
+  background-color: var(--vscode-testing-iconFailed, #f14c4c);
+  color: var(--vscode-editor-background, #1e1e1e);
+}
+
+.code-execution-status--running {
+  background-color: var(--vscode-testing-runAction, #2ea043);
+  color: var(--vscode-editor-background, #1e1e1e);
+  animation: pulse 2s infinite;
+}
+
+.code-execution-status--timeout {
+  background-color: var(--vscode-editorWarning-foreground, #cca700);
+  color: var(--vscode-editor-background, #1e1e1e);
+}
+
+.code-execution-status--cancelled {
+  background-color: var(--vscode-descriptionForeground, #888888);
+  color: var(--vscode-editor-background, #1e1e1e);
+}
+
+/* Language badge */
+.code-execution-language {
+  display: inline-flex;
+  align-items: center;
+  padding: 1px var(--spacing-small);
+  border-radius: var(--border-radius-small);
+  font-size: var(--font-size-xs, 11px);
+  font-weight: 500;
+  margin-left: var(--spacing-small);
+  background-color: var(--vscode-badge-background);
+  color: var(--vscode-badge-foreground);
+}
+
+/* Provider indicator */
+.code-execution-provider {
+  font-size: var(--font-size-xs, 11px);
+  color: var(--vscode-descriptionForeground);
+  margin-left: var(--spacing-tiny);
+  opacity: 0.8;
+}
+
+/* Code input section */
+.code-execution-code {
+  margin: var(--spacing-small) 0;
+  border-radius: var(--border-radius-small);
+  overflow: hidden;
+}
+
+.code-execution-code-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--spacing-tiny) var(--spacing-small);
+  background-color: var(--vscode-editor-inactiveSelectionBackground);
+  border-bottom: 1px solid var(--vscode-panel-border);
+  font-size: var(--font-size-sm);
+  color: var(--vscode-descriptionForeground);
+}
+
+.code-execution-code pre {
+  margin: 0;
+  padding: var(--spacing-small);
+  background-color: var(--vscode-textCodeBlock-background);
+  overflow-x: auto;
+  max-height: 300px;
+  font-family: var(--vscode-editor-font-family, 'Consolas', 'Courier New', monospace);
+  font-size: var(--vscode-editor-font-size, 13px);
+  line-height: 1.5;
+}
+
+.code-execution-code code {
+  white-space: pre;
+  word-break: normal;
+}
+
+/* Output section */
+.code-execution-output {
+  margin: var(--spacing-small) 0;
+}
+
+.code-execution-output-header {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-small);
+  padding: var(--spacing-tiny) 0;
+  font-size: var(--font-size-sm);
+  font-weight: 500;
+  color: var(--vscode-foreground);
+}
+
+.code-execution-output-header .codicon {
+  font-size: 14px;
+}
+
+/* Stdout styling */
+.code-execution-stdout {
+  margin: var(--spacing-tiny) 0;
+  padding: var(--spacing-small);
+  background-color: var(--vscode-textCodeBlock-background);
+  border-radius: var(--border-radius-small);
+  border-left: 3px solid var(--vscode-testing-iconPassed, #388a34);
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-family: var(--vscode-editor-font-family, 'Consolas', 'Courier New', monospace);
+  font-size: var(--vscode-editor-font-size, 13px);
+  max-height: var(--height-large);
+  overflow: auto;
+}
+
+/* Stderr styling */
+.code-execution-stderr {
+  margin: var(--spacing-tiny) 0;
+  padding: var(--spacing-small);
+  background-color: var(--vscode-inputValidation-errorBackground, rgba(255, 0, 0, 0.1));
+  border-radius: var(--border-radius-small);
+  border-left: 3px solid var(--vscode-editorError-foreground, #f14c4c);
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-family: var(--vscode-editor-font-family, 'Consolas', 'Courier New', monospace);
+  font-size: var(--vscode-editor-font-size, 13px);
+  color: var(--vscode-editorError-foreground, #f14c4c);
+  max-height: var(--height-large);
+  overflow: auto;
+}
+
+/* Error message styling */
+.code-execution-error {
+  margin: var(--spacing-tiny) 0;
+  padding: var(--spacing-small);
+  background-color: var(--vscode-inputValidation-errorBackground, rgba(255, 0, 0, 0.1));
+  border-radius: var(--border-radius-small);
+  border: 1px solid var(--vscode-editorError-foreground, #f14c4c);
+  color: var(--vscode-editorError-foreground, #f14c4c);
+}
+
+.code-execution-error-code {
+  font-family: var(--vscode-editor-font-family, monospace);
+  font-size: var(--font-size-sm);
+  opacity: 0.8;
+  margin-bottom: var(--spacing-tiny);
+}
+
+/* Image output styling */
+.code-execution-image {
+  margin: var(--spacing-small) 0;
+  max-width: 100%;
+  border-radius: var(--border-radius-small);
+  border: 1px solid var(--vscode-panel-border);
+}
+
+/* File output reference */
+.code-execution-file {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-tiny);
+  padding: var(--spacing-tiny) var(--spacing-small);
+  background-color: var(--vscode-badge-background);
+  border-radius: var(--border-radius-small);
+  font-size: var(--font-size-sm);
+  margin: var(--spacing-tiny);
+}
+
+.code-execution-file .codicon {
+  font-size: 14px;
+}
+
+/* Return code display */
+.code-execution-return-code {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-tiny);
+  font-size: var(--font-size-sm);
+  color: var(--vscode-descriptionForeground);
+  margin-left: var(--spacing-small);
+}
+
+.code-execution-return-code--success {
+  color: var(--vscode-testing-iconPassed, #388a34);
+}
+
+.code-execution-return-code--error {
+  color: var(--vscode-editorError-foreground, #f14c4c);
+}
+
+/* Duration display */
+.code-execution-duration {
+  font-size: var(--font-size-xs, 11px);
+  color: var(--vscode-descriptionForeground);
+  margin-left: var(--spacing-small);
+  opacity: 0.8;
+}
+
+/* Error state for the whole container */
+.code-execution-details--error > .details-summary .code-execution-title,
+.code-execution-details--error > .details-summary .codicon {
+  color: var(--vscode-editorError-foreground, #f14c4c);
+}
+
+/* Separator between sections */
+.code-execution-separator {
+  margin: var(--spacing-small) 0;
+  border: none;
+  border-top: 1px solid var(--vscode-panel-border);
+  opacity: 0.3;
+}
+
+/* Outputs list container */
+.code-execution-outputs {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-small);
+  margin-top: var(--spacing-small);
+}
+
+.code-execution-outputs-header {
+  font-size: var(--font-size-sm);
+  font-weight: 500;
+  color: var(--vscode-descriptionForeground);
+  margin-bottom: var(--spacing-tiny);
+}

--- a/src/progressView/styles/index.css
+++ b/src/progressView/styles/index.css
@@ -18,6 +18,7 @@
 @import './groups.css';
 @import './markdown.css';
 @import './scratchpad.css';
+@import './code-execution.css';
 @import './file-list.css';
 @import './latexdiff.css';
 @import './statistics.css';

--- a/src/tools/codeExecution/index.ts
+++ b/src/tools/codeExecution/index.ts
@@ -1,6 +1,21 @@
 /**
  * Code execution tool support for native server-side code execution
  * across Anthropic, OpenAI, and Google GenAI SDKs.
+ *
+ * This module provides:
+ * - Unified types for code execution display (CodeExecutionDisplay)
+ * - Normalizers to convert provider-specific response blocks to unified format
+ * - Logging utilities to emit code execution events to progress view
+ *
+ * ## Display Layer (Implemented)
+ * Code execution results are logged and displayed in the progress view.
+ *
+ * ## Context Layer (TODO)
+ * For multi-turn conversations, model handlers need to preserve code execution
+ * result blocks (BetaCodeExecutionResultBlock, etc.) when building conversation
+ * history. Currently, only text, thinking, and tool_use blocks are preserved.
+ * See modelHandlerAnthropic.ts updateMessageContentWithPrefill() and
+ * createToolUseFollowUpMessages() for where this should be added.
  */
 
 export * from './types';

--- a/src/tools/codeExecution/index.ts
+++ b/src/tools/codeExecution/index.ts
@@ -1,0 +1,8 @@
+/**
+ * Code execution tool support for native server-side code execution
+ * across Anthropic, OpenAI, and Google GenAI SDKs.
+ */
+
+export * from './types';
+export * from './normalizers';
+export * from './logCodeExecution';

--- a/src/tools/codeExecution/logCodeExecution.ts
+++ b/src/tools/codeExecution/logCodeExecution.ts
@@ -1,0 +1,129 @@
+/**
+ * Utility for logging code execution events to the progress view.
+ */
+
+// Third-party imports
+import { MESSAGE_TYPES } from '@logger/messageTypes';
+
+// Local imports
+import type { AgentLogger } from '@logger/AgentLogger';
+import {
+  normalizeAnthropicCodeExecution,
+  normalizeOpenAICodeInterpreter,
+  normalizeGoogleCodeExecution,
+  isAnthropicCodeExecutionResult,
+  isOpenAICodeInterpreterCall,
+  isGoogleCodeExecutionPart,
+} from './normalizers';
+
+// Type imports
+import type { CodeExecutionDisplay } from './types';
+
+/**
+ * Log a code execution event to the progress view
+ */
+export function logCodeExecution(
+  logger: AgentLogger,
+  data: CodeExecutionDisplay,
+  groupId?: string,
+): void {
+  logger.info('', {
+    groupId,
+    messageType: MESSAGE_TYPES.CODE_EXECUTION,
+    data,
+  });
+}
+
+/**
+ * Process and log Anthropic code execution result blocks
+ * @returns true if any code execution blocks were found and logged
+ */
+export function processAnthropicCodeExecutionBlocks(
+  logger: AgentLogger,
+  contentBlocks: unknown[],
+  groupId?: string,
+): boolean {
+  let found = false;
+
+  for (const block of contentBlocks) {
+    if (isAnthropicCodeExecutionResult(block)) {
+      // Extract code from corresponding tool_use block if available
+      // For now, we don't have access to the original code, so leave it empty
+      const display = normalizeAnthropicCodeExecution(block, undefined, '');
+      logCodeExecution(logger, display, groupId);
+      found = true;
+    }
+  }
+
+  return found;
+}
+
+/**
+ * Process and log OpenAI code interpreter tool calls
+ * @returns true if any code interpreter calls were found and logged
+ */
+export function processOpenAICodeInterpreterCalls(
+  logger: AgentLogger,
+  toolCalls: unknown[],
+  groupId?: string,
+): boolean {
+  let found = false;
+
+  for (const call of toolCalls) {
+    if (isOpenAICodeInterpreterCall(call)) {
+      const display = normalizeOpenAICodeInterpreter(call);
+      logCodeExecution(logger, display, groupId);
+      found = true;
+    }
+  }
+
+  return found;
+}
+
+/**
+ * Process and log Google GenAI code execution parts
+ * @returns true if any code execution parts were found and logged
+ */
+export function processGoogleCodeExecutionParts(
+  logger: AgentLogger,
+  parts: unknown[],
+  groupId?: string,
+): boolean {
+  let found = false;
+
+  // Google returns executable code and result as separate parts
+  // We need to pair them up
+  type GoogleLanguage = 'LANGUAGE_UNSPECIFIED' | 'PYTHON';
+  type GoogleOutcome =
+    | 'OUTCOME_UNSPECIFIED'
+    | 'OUTCOME_OK'
+    | 'OUTCOME_FAILED'
+    | 'OUTCOME_DEADLINE_EXCEEDED';
+
+  let pendingCode: { code?: string; language?: GoogleLanguage } | null = null;
+
+  for (const part of parts) {
+    if (isGoogleCodeExecutionPart(part)) {
+      const p = part as {
+        executableCode?: { code?: string; language?: GoogleLanguage };
+        codeExecutionResult?: { outcome?: GoogleOutcome; output?: string };
+      };
+
+      if (p.executableCode) {
+        pendingCode = p.executableCode;
+      }
+
+      if (p.codeExecutionResult && pendingCode) {
+        const display = normalizeGoogleCodeExecution(
+          pendingCode,
+          p.codeExecutionResult,
+        );
+        logCodeExecution(logger, display, groupId);
+        pendingCode = null;
+        found = true;
+      }
+    }
+  }
+
+  return found;
+}

--- a/src/tools/codeExecution/logCodeExecution.ts
+++ b/src/tools/codeExecution/logCodeExecution.ts
@@ -125,5 +125,12 @@ export function processGoogleCodeExecutionParts(
     }
   }
 
+  // Warn about orphaned code blocks (code without result)
+  if (pendingCode) {
+    logger.debug(
+      'Code execution: orphaned executable code block without result',
+    );
+  }
+
   return found;
 }

--- a/src/tools/codeExecution/normalizers.ts
+++ b/src/tools/codeExecution/normalizers.ts
@@ -178,18 +178,16 @@ export function normalizeOpenAICodeInterpreter(
 ): CodeExecutionDisplay {
   const status = mapOpenAIStatusToStatus(toolCall.status);
 
+  // Only store non-text outputs in outputs array to avoid duplicate rendering
+  // Text logs are stored in stdout which is rendered separately
   const outputs: CodeExecutionOutput[] = [];
   let stdout: string | undefined;
 
   if (toolCall.outputs) {
     for (const output of toolCall.outputs) {
       if (output.type === 'logs') {
-        // Accumulate logs as stdout
+        // Accumulate logs as stdout only (not in outputs to avoid duplication)
         stdout = stdout ? `${stdout}\n${output.logs}` : output.logs;
-        outputs.push({
-          type: 'logs',
-          content: output.logs,
-        });
       } else if (output.type === 'image') {
         outputs.push({
           type: 'image',
@@ -216,16 +214,14 @@ export function normalizeOpenAICodeInterpreter(
 export function normalizeOpenAIAssistantCodeInterpreter(
   toolCall: OpenAIAssistantCodeInterpreter,
 ): CodeExecutionDisplay {
+  // Only store non-text outputs in outputs array to avoid duplicate rendering
   const outputs: CodeExecutionOutput[] = [];
   let stdout: string | undefined;
 
   for (const output of toolCall.code_interpreter.outputs) {
     if (output.type === 'logs') {
+      // Accumulate logs as stdout only (not in outputs to avoid duplication)
       stdout = stdout ? `${stdout}\n${output.logs}` : output.logs;
-      outputs.push({
-        type: 'logs',
-        content: output.logs,
-      });
     } else if (output.type === 'image') {
       outputs.push({
         type: 'image',
@@ -259,7 +255,7 @@ function mapOpenAIStatusToStatus(
     case 'incomplete':
       return 'cancelled';
     default:
-      return 'failed';
+      return 'unknown';
   }
 }
 
@@ -289,6 +285,11 @@ interface GoogleCodeExecutionResult {
 
 /**
  * Normalize Google GenAI code execution to unified format
+ *
+ * Google's CodeExecutionResult returns output in a single field that contains:
+ * - stdout when outcome is OUTCOME_OK
+ * - stderr/error description when outcome is OUTCOME_FAILED or OUTCOME_DEADLINE_EXCEEDED
+ * Reference: https://ai.google.dev/api/caching#CodeExecutionResult
  */
 export function normalizeGoogleCodeExecution(
   executableCode: GoogleExecutableCode,
@@ -297,16 +298,19 @@ export function normalizeGoogleCodeExecution(
   const status = mapGoogleOutcomeToStatus(result.outcome);
   const language = mapGoogleLanguage(executableCode.language);
 
-  // Google returns stdout on success, stderr on failure in the same field
+  // Google returns output in single field - content depends on outcome
+  // For unknown status, we can't determine if output is stdout or stderr
   const isSuccess = status === 'success';
+  const isUnknown = status === 'unknown';
 
   return {
     provider: 'google',
     language,
     code: executableCode.code ?? '',
     status,
-    stdout: isSuccess ? result.output : undefined,
-    stderr: !isSuccess ? result.output : undefined,
+    // For unknown status, put output in stdout as it's more likely to be useful
+    stdout: isSuccess || isUnknown ? result.output : undefined,
+    stderr: !isSuccess && !isUnknown ? result.output : undefined,
   };
 }
 
@@ -322,7 +326,9 @@ function mapGoogleOutcomeToStatus(
       return 'timeout';
     case 'OUTCOME_UNSPECIFIED':
     default:
-      return 'failed';
+      // Use 'unknown' for unspecified/unrecognized outcomes
+      // This avoids incorrectly treating valid output as stderr
+      return 'unknown';
   }
 }
 

--- a/src/tools/codeExecution/normalizers.ts
+++ b/src/tools/codeExecution/normalizers.ts
@@ -1,0 +1,394 @@
+/**
+ * Normalizer functions to convert provider-specific code execution responses
+ * to the unified CodeExecutionDisplay type.
+ */
+
+import type {
+  CodeExecutionDisplay,
+  CodeExecutionOutput,
+  CodeExecutionStatus,
+  CodeExecutionLanguage,
+} from './types';
+
+// ============================================================================
+// Anthropic Normalizers
+// ============================================================================
+
+/**
+ * Anthropic BetaCodeExecutionResultBlock shape from SDK
+ */
+interface AnthropicCodeExecutionResult {
+  type: 'code_execution_result';
+  content: Array<{ file_id: string; type: 'code_execution_output' }>;
+  return_code: number;
+  stdout: string;
+  stderr: string;
+}
+
+/**
+ * Anthropic BetaBashCodeExecutionResultBlock shape from SDK
+ */
+interface AnthropicBashCodeExecutionResult {
+  type: 'bash_code_execution_result';
+  content: Array<{ file_id: string; type: 'bash_code_execution_output' }>;
+  return_code: number;
+  stdout: string;
+  stderr: string;
+}
+
+/**
+ * Anthropic code execution error shape
+ */
+interface AnthropicCodeExecutionError {
+  type: 'code_execution_tool_result_error' | 'bash_code_execution_tool_result_error';
+  error_code:
+    | 'invalid_tool_input'
+    | 'unavailable'
+    | 'too_many_requests'
+    | 'execution_time_exceeded'
+    | 'output_file_too_large';
+}
+
+type AnthropicCodeExecutionContent =
+  | AnthropicCodeExecutionResult
+  | AnthropicBashCodeExecutionResult
+  | AnthropicCodeExecutionError;
+
+/**
+ * Normalize Anthropic code execution result to unified format
+ */
+export function normalizeAnthropicCodeExecution(
+  content: AnthropicCodeExecutionContent,
+  toolUseId?: string,
+  code?: string,
+): CodeExecutionDisplay {
+  // Handle error case
+  if (
+    content.type === 'code_execution_tool_result_error' ||
+    content.type === 'bash_code_execution_tool_result_error'
+  ) {
+    const errorContent = content as AnthropicCodeExecutionError;
+    const status = mapAnthropicErrorToStatus(errorContent.error_code);
+    return {
+      provider: 'anthropic',
+      language: content.type.includes('bash') ? 'bash' : 'python',
+      code: code ?? '',
+      status,
+      errorCode: errorContent.error_code,
+      errorMessage: getAnthropicErrorMessage(errorContent.error_code),
+      toolUseId,
+    };
+  }
+
+  // Handle success case
+  const result = content as
+    | AnthropicCodeExecutionResult
+    | AnthropicBashCodeExecutionResult;
+  const isBash = result.type === 'bash_code_execution_result';
+  const status: CodeExecutionStatus =
+    result.return_code === 0 ? 'success' : 'failed';
+
+  const outputs: CodeExecutionOutput[] = result.content.map((output) => ({
+    type: 'file' as const,
+    fileId: output.file_id,
+  }));
+
+  return {
+    provider: 'anthropic',
+    language: isBash ? 'bash' : 'python',
+    code: code ?? '',
+    status,
+    returnCode: result.return_code,
+    stdout: result.stdout || undefined,
+    stderr: result.stderr || undefined,
+    outputs: outputs.length > 0 ? outputs : undefined,
+    toolUseId,
+  };
+}
+
+function mapAnthropicErrorToStatus(
+  errorCode: AnthropicCodeExecutionError['error_code'],
+): CodeExecutionStatus {
+  switch (errorCode) {
+    case 'execution_time_exceeded':
+      return 'timeout';
+    default:
+      return 'failed';
+  }
+}
+
+function getAnthropicErrorMessage(
+  errorCode: AnthropicCodeExecutionError['error_code'],
+): string {
+  switch (errorCode) {
+    case 'invalid_tool_input':
+      return 'Invalid input provided to code execution tool';
+    case 'unavailable':
+      return 'Code execution service is currently unavailable';
+    case 'too_many_requests':
+      return 'Too many code execution requests';
+    case 'execution_time_exceeded':
+      return 'Code execution exceeded time limit';
+    case 'output_file_too_large':
+      return 'Output file size exceeded limit';
+    default:
+      return 'Unknown error during code execution';
+  }
+}
+
+// ============================================================================
+// OpenAI Normalizers
+// ============================================================================
+
+/**
+ * OpenAI ResponseCodeInterpreterToolCall shape from SDK
+ */
+interface OpenAICodeInterpreterToolCall {
+  id: string;
+  type: 'code_interpreter_call';
+  code: string | null;
+  container_id: string;
+  status: 'in_progress' | 'completed' | 'incomplete' | 'interpreting' | 'failed';
+  outputs: Array<
+    | { type: 'logs'; logs: string }
+    | { type: 'image'; url: string }
+  > | null;
+}
+
+/**
+ * OpenAI Assistant API CodeInterpreterToolCall shape
+ */
+interface OpenAIAssistantCodeInterpreter {
+  id: string;
+  type: 'code_interpreter';
+  code_interpreter: {
+    input: string;
+    outputs: Array<
+      | { type: 'logs'; logs: string }
+      | { type: 'image'; image: { file_id: string } }
+    >;
+  };
+}
+
+/**
+ * Normalize OpenAI Responses API code interpreter to unified format
+ */
+export function normalizeOpenAICodeInterpreter(
+  toolCall: OpenAICodeInterpreterToolCall,
+): CodeExecutionDisplay {
+  const status = mapOpenAIStatusToStatus(toolCall.status);
+
+  const outputs: CodeExecutionOutput[] = [];
+  let stdout: string | undefined;
+
+  if (toolCall.outputs) {
+    for (const output of toolCall.outputs) {
+      if (output.type === 'logs') {
+        // Accumulate logs as stdout
+        stdout = stdout ? `${stdout}\n${output.logs}` : output.logs;
+        outputs.push({
+          type: 'logs',
+          content: output.logs,
+        });
+      } else if (output.type === 'image') {
+        outputs.push({
+          type: 'image',
+          url: output.url,
+        });
+      }
+    }
+  }
+
+  return {
+    provider: 'openai',
+    language: 'python', // OpenAI code interpreter is Python
+    code: toolCall.code ?? '',
+    status,
+    stdout,
+    outputs: outputs.length > 0 ? outputs : undefined,
+    toolUseId: toolCall.id,
+  };
+}
+
+/**
+ * Normalize OpenAI Assistant API code interpreter to unified format
+ */
+export function normalizeOpenAIAssistantCodeInterpreter(
+  toolCall: OpenAIAssistantCodeInterpreter,
+): CodeExecutionDisplay {
+  const outputs: CodeExecutionOutput[] = [];
+  let stdout: string | undefined;
+
+  for (const output of toolCall.code_interpreter.outputs) {
+    if (output.type === 'logs') {
+      stdout = stdout ? `${stdout}\n${output.logs}` : output.logs;
+      outputs.push({
+        type: 'logs',
+        content: output.logs,
+      });
+    } else if (output.type === 'image') {
+      outputs.push({
+        type: 'image',
+        fileId: output.image.file_id,
+      });
+    }
+  }
+
+  return {
+    provider: 'openai',
+    language: 'python',
+    code: toolCall.code_interpreter.input,
+    status: 'success', // Assistant API doesn't provide status in the same way
+    stdout,
+    outputs: outputs.length > 0 ? outputs : undefined,
+    toolUseId: toolCall.id,
+  };
+}
+
+function mapOpenAIStatusToStatus(
+  status: OpenAICodeInterpreterToolCall['status'],
+): CodeExecutionStatus {
+  switch (status) {
+    case 'completed':
+      return 'success';
+    case 'failed':
+      return 'failed';
+    case 'in_progress':
+    case 'interpreting':
+      return 'running';
+    case 'incomplete':
+      return 'cancelled';
+    default:
+      return 'failed';
+  }
+}
+
+// ============================================================================
+// Google GenAI Normalizers
+// ============================================================================
+
+/**
+ * Google ExecutableCode shape from SDK
+ */
+interface GoogleExecutableCode {
+  code?: string;
+  language?: 'LANGUAGE_UNSPECIFIED' | 'PYTHON';
+}
+
+/**
+ * Google CodeExecutionResult shape from SDK
+ */
+interface GoogleCodeExecutionResult {
+  outcome?:
+    | 'OUTCOME_UNSPECIFIED'
+    | 'OUTCOME_OK'
+    | 'OUTCOME_FAILED'
+    | 'OUTCOME_DEADLINE_EXCEEDED';
+  output?: string;
+}
+
+/**
+ * Normalize Google GenAI code execution to unified format
+ */
+export function normalizeGoogleCodeExecution(
+  executableCode: GoogleExecutableCode,
+  result: GoogleCodeExecutionResult,
+): CodeExecutionDisplay {
+  const status = mapGoogleOutcomeToStatus(result.outcome);
+  const language = mapGoogleLanguage(executableCode.language);
+
+  // Google returns stdout on success, stderr on failure in the same field
+  const isSuccess = status === 'success';
+
+  return {
+    provider: 'google',
+    language,
+    code: executableCode.code ?? '',
+    status,
+    stdout: isSuccess ? result.output : undefined,
+    stderr: !isSuccess ? result.output : undefined,
+  };
+}
+
+function mapGoogleOutcomeToStatus(
+  outcome?: GoogleCodeExecutionResult['outcome'],
+): CodeExecutionStatus {
+  switch (outcome) {
+    case 'OUTCOME_OK':
+      return 'success';
+    case 'OUTCOME_FAILED':
+      return 'failed';
+    case 'OUTCOME_DEADLINE_EXCEEDED':
+      return 'timeout';
+    case 'OUTCOME_UNSPECIFIED':
+    default:
+      return 'failed';
+  }
+}
+
+function mapGoogleLanguage(
+  language?: GoogleExecutableCode['language'],
+): CodeExecutionLanguage {
+  switch (language) {
+    case 'PYTHON':
+      return 'python';
+    default:
+      return 'unknown';
+  }
+}
+
+// ============================================================================
+// Generic Helpers
+// ============================================================================
+
+/**
+ * Type guard for Anthropic code execution result blocks
+ */
+export function isAnthropicCodeExecutionResult(
+  block: unknown,
+): block is AnthropicCodeExecutionContent {
+  if (!block || typeof block !== 'object') return false;
+  const b = block as { type?: string };
+  return (
+    b.type === 'code_execution_result' ||
+    b.type === 'bash_code_execution_result' ||
+    b.type === 'code_execution_tool_result_error' ||
+    b.type === 'bash_code_execution_tool_result_error'
+  );
+}
+
+/**
+ * Type guard for OpenAI code interpreter tool calls
+ */
+export function isOpenAICodeInterpreterCall(
+  block: unknown,
+): block is OpenAICodeInterpreterToolCall {
+  if (!block || typeof block !== 'object') return false;
+  const b = block as { type?: string };
+  return b.type === 'code_interpreter_call';
+}
+
+/**
+ * Type guard for OpenAI Assistant code interpreter
+ */
+export function isOpenAIAssistantCodeInterpreter(
+  block: unknown,
+): block is OpenAIAssistantCodeInterpreter {
+  if (!block || typeof block !== 'object') return false;
+  const b = block as { type?: string; code_interpreter?: unknown };
+  return b.type === 'code_interpreter' && b.code_interpreter !== undefined;
+}
+
+/**
+ * Type guard for Google code execution parts
+ */
+export function isGoogleCodeExecutionPart(
+  part: unknown,
+): part is { executableCode?: GoogleExecutableCode; codeExecutionResult?: GoogleCodeExecutionResult } {
+  if (!part || typeof part !== 'object') return false;
+  const p = part as {
+    executableCode?: unknown;
+    codeExecutionResult?: unknown;
+  };
+  return p.executableCode !== undefined || p.codeExecutionResult !== undefined;
+}

--- a/src/tools/codeExecution/types.ts
+++ b/src/tools/codeExecution/types.ts
@@ -99,8 +99,15 @@ export const CodeExecutionDisplaySchema = z.object({
 });
 export type CodeExecutionDisplay = z.infer<typeof CodeExecutionDisplaySchema>;
 
+// =============================================================================
+// Provider-specific schemas for edge validation
+// These schemas can be used with safeParse() for runtime validation of
+// provider responses at the API boundary. Currently exported for future use.
+// =============================================================================
+
 /**
- * Anthropic-specific error codes for code execution
+ * Anthropic-specific error codes for code execution.
+ * Use with safeParse() to validate error responses from Anthropic API.
  */
 export const AnthropicCodeExecutionErrorCodeSchema = z.enum([
   'invalid_tool_input',
@@ -114,7 +121,8 @@ export type AnthropicCodeExecutionErrorCode = z.infer<
 >;
 
 /**
- * Google-specific outcome codes
+ * Google-specific outcome codes.
+ * Use with safeParse() to validate outcome from Google GenAI API.
  */
 export const GoogleCodeExecutionOutcomeSchema = z.enum([
   'OUTCOME_UNSPECIFIED',
@@ -127,7 +135,8 @@ export type GoogleCodeExecutionOutcome = z.infer<
 >;
 
 /**
- * OpenAI-specific status codes
+ * OpenAI-specific status codes.
+ * Use with safeParse() to validate status from OpenAI Responses API.
  */
 export const OpenAICodeInterpreterStatusSchema = z.enum([
   'in_progress',

--- a/src/tools/codeExecution/types.ts
+++ b/src/tools/codeExecution/types.ts
@@ -14,6 +14,7 @@ export const CodeExecutionStatusSchema = z.enum([
   'failed',
   'timeout',
   'cancelled',
+  'unknown',
 ]);
 export type CodeExecutionStatus = z.infer<typeof CodeExecutionStatusSchema>;
 

--- a/src/tools/codeExecution/types.ts
+++ b/src/tools/codeExecution/types.ts
@@ -1,0 +1,140 @@
+/**
+ * Unified code execution types for native server-side code execution
+ * across Anthropic, OpenAI, and Google GenAI SDKs.
+ */
+
+import { z } from 'zod';
+
+/**
+ * Execution status across all providers
+ */
+export const CodeExecutionStatusSchema = z.enum([
+  'running',
+  'success',
+  'failed',
+  'timeout',
+  'cancelled',
+]);
+export type CodeExecutionStatus = z.infer<typeof CodeExecutionStatusSchema>;
+
+/**
+ * Supported providers for native code execution
+ */
+export const CodeExecutionProviderSchema = z.enum([
+  'anthropic',
+  'openai',
+  'google',
+]);
+export type CodeExecutionProvider = z.infer<typeof CodeExecutionProviderSchema>;
+
+/**
+ * Programming language for execution
+ */
+export const CodeExecutionLanguageSchema = z.enum([
+  'python',
+  'bash',
+  'javascript',
+  'unknown',
+]);
+export type CodeExecutionLanguage = z.infer<typeof CodeExecutionLanguageSchema>;
+
+/**
+ * Output types from code execution
+ */
+export const CodeExecutionOutputTypeSchema = z.enum([
+  'logs',
+  'image',
+  'file',
+]);
+export type CodeExecutionOutputType = z.infer<
+  typeof CodeExecutionOutputTypeSchema
+>;
+
+/**
+ * Individual output from code execution (logs, images, files)
+ */
+export const CodeExecutionOutputSchema = z.object({
+  type: CodeExecutionOutputTypeSchema,
+  /** Text content for logs */
+  content: z.string().optional(),
+  /** URL for images (OpenAI) */
+  url: z.string().optional(),
+  /** File ID reference (Anthropic, OpenAI) */
+  fileId: z.string().optional(),
+  /** MIME type for files/images */
+  mimeType: z.string().optional(),
+});
+export type CodeExecutionOutput = z.infer<typeof CodeExecutionOutputSchema>;
+
+/**
+ * Unified code execution display data structure.
+ * Normalizes responses from Anthropic, OpenAI, and Google SDKs.
+ */
+export const CodeExecutionDisplaySchema = z.object({
+  /** Provider that executed the code */
+  provider: CodeExecutionProviderSchema,
+  /** Programming language */
+  language: CodeExecutionLanguageSchema,
+  /** The executed code */
+  code: z.string(),
+  /** Execution status */
+  status: CodeExecutionStatusSchema,
+  /** Exit/return code (Anthropic) */
+  returnCode: z.number().optional(),
+  /** Standard output */
+  stdout: z.string().optional(),
+  /** Standard error */
+  stderr: z.string().optional(),
+  /** Additional outputs (images, files) */
+  outputs: z.array(CodeExecutionOutputSchema).optional(),
+  /** Execution duration in milliseconds */
+  durationMs: z.number().optional(),
+  /** Tool use ID for correlation */
+  toolUseId: z.string().optional(),
+  /** Error message if execution failed */
+  errorMessage: z.string().optional(),
+  /** Error code from provider */
+  errorCode: z.string().optional(),
+});
+export type CodeExecutionDisplay = z.infer<typeof CodeExecutionDisplaySchema>;
+
+/**
+ * Anthropic-specific error codes for code execution
+ */
+export const AnthropicCodeExecutionErrorCodeSchema = z.enum([
+  'invalid_tool_input',
+  'unavailable',
+  'too_many_requests',
+  'execution_time_exceeded',
+  'output_file_too_large',
+]);
+export type AnthropicCodeExecutionErrorCode = z.infer<
+  typeof AnthropicCodeExecutionErrorCodeSchema
+>;
+
+/**
+ * Google-specific outcome codes
+ */
+export const GoogleCodeExecutionOutcomeSchema = z.enum([
+  'OUTCOME_UNSPECIFIED',
+  'OUTCOME_OK',
+  'OUTCOME_FAILED',
+  'OUTCOME_DEADLINE_EXCEEDED',
+]);
+export type GoogleCodeExecutionOutcome = z.infer<
+  typeof GoogleCodeExecutionOutcomeSchema
+>;
+
+/**
+ * OpenAI-specific status codes
+ */
+export const OpenAICodeInterpreterStatusSchema = z.enum([
+  'in_progress',
+  'completed',
+  'incomplete',
+  'interpreting',
+  'failed',
+]);
+export type OpenAICodeInterpreterStatus = z.infer<
+  typeof OpenAICodeInterpreterStatusSchema
+>;

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -19,3 +19,4 @@ export * from './latex';
 export * from './citation';
 export * from './web/WebFetchTool';
 export * from './web/WebSearchTool';
+export * from './codeExecution';


### PR DESCRIPTION
Add support for displaying native server-side code execution results
from Anthropic, OpenAI, and Google GenAI SDKs in the progress view.

- Add unified CodeExecutionDisplay types with Zod v4 schemas
- Create normalizers for Anthropic (code_execution, bash_code_execution),
  OpenAI (code_interpreter_call), and Google (ExecutableCode/CodeExecutionResult)
- Add 'codeExecution' message type to LogTypes and messageTypes
- Create codeExecutionTemplate HTML template with status badge and
  code/output sections
- Add code-execution.css with status indicators, stdout/stderr styling,
  and image output support
- Add _formatCodeExecution method to formatters.js
- Provide logCodeExecution utility and provider-specific processing
  functions for model handlers to emit code execution events

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a new codeExecution message and ProgressView UI to render server-side code execution outputs, plus tooling to normalize/log results from Anthropic, OpenAI, and Google.
> 
> - **ProgressView (UI)**:
>   - Add `codeExecutionTemplate` in `src/progressView/index.html` and formatter `_formatCodeExecution` in `modules/formatters.js` to render code, status, stdout/stderr, and outputs.
>   - Add styles `src/progressView/styles/code-execution.css` and import in `styles/index.css`.
> - **Logging**:
>   - Introduce `codeExecution` message type in `src/logger/LogTypes.ts` and `src/logger/messageTypes.ts`.
> - **Tools (provider integration)**:
>   - New module `src/tools/codeExecution/*` with unified `CodeExecutionDisplay` (Zod schemas), provider normalizers (Anthropic/OpenAI/Google), and logging utilities (`logCodeExecution`, `process*` helpers).
>   - Export from `src/tools/index.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2b51a8f7dba1067a40b72fe7feda58c566d8cf80. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->