### PR TITLE
refactor: consolidate StreamStatus types into single source of truth

### DIFF
--- a/src/agent/runtime/StreamStatusService.ts
+++ b/src/agent/runtime/StreamStatusService.ts
@@ -1,19 +1,19 @@
 // Type imports
 import type { StreamTabId } from '@agent/types/IdentifierTypes';
-import type { StreamStatusOrReady } from '@common/constants/streamStatus';
+import type { StreamStatus } from '@common/constants/streamStatus';
 
 // Internal imports
 import { STREAM_STATUS } from '@common/constants/streamStatus';
 import { bus } from '@eventBus/ProgressEventBus';
 
-const statusMemory = new Map<StreamTabId, StreamStatusOrReady>();
+const statusMemory = new Map<StreamTabId, StreamStatus>();
 
 export const StreamStatusService = {
-  get(stream: StreamTabId): StreamStatusOrReady {
+  get(stream: StreamTabId): StreamStatus {
     return statusMemory.get(stream) ?? STREAM_STATUS.READY;
   },
 
-  set(stream: StreamTabId, status: StreamStatusOrReady): void {
+  set(stream: StreamTabId, status: StreamStatus): void {
     if (status === STREAM_STATUS.READY) {
       statusMemory.delete(stream);
     } else {

--- a/src/agent/runtime/StreamStatusService.ts
+++ b/src/agent/runtime/StreamStatusService.ts
@@ -1,11 +1,10 @@
 // Type imports
 import type { StreamTabId } from '@agent/types/IdentifierTypes';
+import type { StreamStatusOrReady } from '@common/constants/streamStatus';
 
 // Internal imports
 import { STREAM_STATUS } from '@common/constants/streamStatus';
 import { bus } from '@eventBus/ProgressEventBus';
-// Type imports
-import type { StreamStatusOrReady } from '@eventBus/ProgressEventBus';
 
 const statusMemory = new Map<StreamTabId, StreamStatusOrReady>();
 

--- a/src/agent/types/NormalizedUsage.ts
+++ b/src/agent/types/NormalizedUsage.ts
@@ -4,51 +4,57 @@
  *
  * This provides a single source of truth for usage tracking across all providers.
  */
+import { z } from 'zod';
 
 /**
- * Provider identifiers for usage tracking.
+ * Provider identifiers for usage tracking - single source of truth.
  */
-export type UsageProvider =
-  | 'anthropic'
-  | 'openai'
-  | 'openai-response'
-  | 'google'
-  | 'deepseek'
-  | 'openrouter'
-  | 'dashscope'
-  | 'xai'
-  | 'kimi'
-  | 'unknown';
+export const UsageProviderSchema = z.enum([
+  'anthropic',
+  'openai',
+  'openai-response',
+  'google',
+  'deepseek',
+  'openrouter',
+  'dashscope',
+  'xai',
+  'kimi',
+  'unknown',
+]);
+
+export type UsageProvider = z.infer<typeof UsageProviderSchema>;
 
 /**
  * Normalized usage statistics from any model provider.
  * Cost is computed once during normalization and never recomputed.
  */
-export interface NormalizedUsage {
+export const NormalizedUsageSchema = z.object({
   /** Total input tokens consumed */
-  inputTokens: number;
+  inputTokens: z.number(),
   /** Total output tokens generated */
-  outputTokens: number;
+  outputTokens: z.number(),
   /** Total cost in USD (computed once, never recomputed) */
-  cost: number;
+  cost: z.number(),
   /** Response time in milliseconds */
-  responseTimeMs: number;
+  responseTimeMs: z.number(),
   /** Provider that generated this usage data */
-  provider: UsageProvider;
+  provider: UsageProviderSchema,
 
   // Optional metrics (when supported by provider)
   /** Tokens served from cache (reduces cost) */
-  cachedInputTokens?: number;
+  cachedInputTokens: z.number().optional(),
   /** Tokens written to cache - Anthropic only (increases cost by 1.25x) */
-  cacheCreationTokens?: number;
+  cacheCreationTokens: z.number().optional(),
   /** Percentage of input tokens served from cache */
-  percentageCached?: number;
+  percentageCached: z.number().optional(),
   /** Tokens used for reasoning (o1, DeepSeek-R1, Gemini thinking) */
-  reasoningTokens?: number;
+  reasoningTokens: z.number().optional(),
   /** Tokens consumed by tool use prompts (Google) */
-  toolUsePromptTokens?: number;
+  toolUsePromptTokens: z.number().optional(),
   /** Number of server-side tool executions (Anthropic web search) */
-  serverToolRequests?: number;
+  serverToolRequests: z.number().optional(),
   /** Original API response payload (for debugging) */
-  _native?: unknown;
-}
+  _native: z.unknown().optional(),
+});
+
+export type NormalizedUsage = z.infer<typeof NormalizedUsageSchema>;

--- a/src/agent/types/ResultTypes.ts
+++ b/src/agent/types/ResultTypes.ts
@@ -17,16 +17,20 @@ export const ExecResultSchema = z.strictObject({
 
 export type ExecResult = z.infer<typeof ExecResultSchema>;
 
-export type FileOpStatus = 'success' | 'noFiles' | 'missingParams' | 'error';
+/** Status values for file operations - single source of truth */
+export const FileOpStatusSchema = z.enum([
+  'success',
+  'noFiles',
+  'missingParams',
+  'error',
+]);
+
+/** Derived type from schema */
+export type FileOpStatus = z.infer<typeof FileOpStatusSchema>;
 
 export const FileOpResultSchema = z.strictObject({
   /** Outcome of the pack or clean operation */
-  status: z.union([
-    z.literal('success'),
-    z.literal('noFiles'),
-    z.literal('missingParams'),
-    z.literal('error'),
-  ]),
+  status: FileOpStatusSchema,
   /** Output directory if files were packed */
   outputFolder: z.string().optional(),
   /** Error message when status is "error" */

--- a/src/agent/types/UsageTypes.ts
+++ b/src/agent/types/UsageTypes.ts
@@ -18,20 +18,24 @@ export type TokenUsageStats = z.infer<typeof TokenUsageStatsSchema>;
 /**
  * Extended statistics tracked during agent execution.
  */
-export interface ExtendedTokenUsageStats extends TokenUsageStats {
+export const ExtendedTokenUsageStatsSchema = TokenUsageStatsSchema.extend({
   /** Total elapsed time in seconds */
-  elapsedTime?: number;
+  elapsedTime: z.number().optional(),
   /** Tokens read from cache */
-  cacheReadInputTokens?: number;
+  cacheReadInputTokens: z.number().optional(),
   /** Tokens written to cache */
-  cacheCreationInputTokens?: number;
+  cacheCreationInputTokens: z.number().optional(),
   /** Percentage of tokens served from cache */
-  percentageCached?: number;
+  percentageCached: z.number().optional(),
   /** Tokens used for reasoning */
-  reasoningTokens?: number;
+  reasoningTokens: z.number().optional(),
   /** Tokens consumed by tool use */
-  toolUseTokens?: number;
-}
+  toolUseTokens: z.number().optional(),
+});
+
+export type ExtendedTokenUsageStats = z.infer<
+  typeof ExtendedTokenUsageStatsSchema
+>;
 
 /**
  * Message interface for updating usage stats in the progress view.

--- a/src/common/constants/streamStatus.ts
+++ b/src/common/constants/streamStatus.ts
@@ -22,13 +22,14 @@ export const STREAM_STATUS = {
 } as const;
 
 /**
+ * All stream states including 'ready'.
+ * Derived from STREAM_STATUS constant to maintain single source of truth.
+ */
+export type StreamStatusOrReady =
+  (typeof STREAM_STATUS)[keyof typeof STREAM_STATUS];
+
+/**
  * Active execution states (excludes 'ready').
  * Use when you need to distinguish between active and idle states.
  */
-export type StreamStatus = 'running' | 'error' | 'stopped' | 'waiting' | 'resuming';
-
-/**
- * All stream states including 'ready'.
- * Use for general stream state handling.
- */
-export type StreamStatusOrReady = StreamStatus | 'ready';
+export type StreamStatus = Exclude<StreamStatusOrReady, 'ready'>;

--- a/src/common/constants/streamStatus.ts
+++ b/src/common/constants/streamStatus.ts
@@ -21,4 +21,14 @@ export const STREAM_STATUS = {
   RESUMING: 'resuming',
 } as const;
 
-export type StreamStatus = (typeof STREAM_STATUS)[keyof typeof STREAM_STATUS];
+/**
+ * Active execution states (excludes 'ready').
+ * Use when you need to distinguish between active and idle states.
+ */
+export type StreamStatus = 'running' | 'error' | 'stopped' | 'waiting' | 'resuming';
+
+/**
+ * All stream states including 'ready'.
+ * Use for general stream state handling.
+ */
+export type StreamStatusOrReady = StreamStatus | 'ready';

--- a/src/common/constants/streamStatus.ts
+++ b/src/common/constants/streamStatus.ts
@@ -22,14 +22,7 @@ export const STREAM_STATUS = {
 } as const;
 
 /**
- * All stream states including 'ready'.
+ * All possible stream states.
  * Derived from STREAM_STATUS constant to maintain single source of truth.
  */
-export type StreamStatusOrReady =
-  (typeof STREAM_STATUS)[keyof typeof STREAM_STATUS];
-
-/**
- * Active execution states (excludes 'ready').
- * Use when you need to distinguish between active and idle states.
- */
-export type StreamStatus = Exclude<StreamStatusOrReady, 'ready'>;
+export type StreamStatus = (typeof STREAM_STATUS)[keyof typeof STREAM_STATUS];

--- a/src/common/webview/BaseViewMessageHandler.ts
+++ b/src/common/webview/BaseViewMessageHandler.ts
@@ -1,5 +1,6 @@
 // Third-party imports
 import * as vscode from 'vscode';
+import type { z } from 'zod';
 
 // Local imports - common
 import { toErrorMessage } from '@common/errors';
@@ -110,5 +111,30 @@ export abstract class BaseViewMessageHandler<
   ): Promise<void> {
     this.logger.debug(this.channel, 'Webview ready signal received');
     // Subclasses can override for custom ready handling
+  }
+
+  /**
+   * Helper method for validating messages with Zod schemas.
+   * Provides consistent validation and error logging pattern.
+   *
+   * @param schema - Zod schema to validate the message against
+   * @param message - The raw message to validate
+   * @param messageName - Human-readable name for logging
+   * @param handler - Callback to execute with validated data
+   */
+  protected async withValidatedMessage<S extends z.ZodTypeAny>(
+    schema: S,
+    message: unknown,
+    messageName: string,
+    handler: (data: z.infer<S>) => Promise<void> | void,
+  ): Promise<void> {
+    const parsed = schema.safeParse(message);
+    if (!parsed.success) {
+      this.logger.debug(this.channel, `Invalid ${messageName}`, {
+        data: parsed.error,
+      });
+      return;
+    }
+    await handler(parsed.data);
   }
 }

--- a/src/common/webview/BaseViewMessageHandler.ts
+++ b/src/common/webview/BaseViewMessageHandler.ts
@@ -1,6 +1,5 @@
 // Third-party imports
 import * as vscode from 'vscode';
-import type { z } from 'zod';
 
 // Local imports - common
 import { toErrorMessage } from '@common/errors';
@@ -8,6 +7,7 @@ import * as logger from '@logger/logUtils';
 
 // Local file imports
 import { COMMON_COMMANDS } from './commands';
+import type { z } from 'zod';
 
 export type MessageHandler<
   T extends vscode.WebviewView | vscode.WebviewPanel = vscode.WebviewView,

--- a/src/eventBus/ProgressEventBus.ts
+++ b/src/eventBus/ProgressEventBus.ts
@@ -11,6 +11,10 @@ import type {
 } from '@agent/types/IdentifierTypes';
 import type { TokenUsageStats } from '@agent/types/UsageTypes';
 import type {
+  StreamStatus,
+  StreamStatusOrReady,
+} from '@common/constants/streamStatus';
+import type {
   LogMessageData,
   LogMessageUpdate,
   TaskGroup,
@@ -18,16 +22,12 @@ import type {
 import type { TaskState } from '@logger/TaskState';
 import type { ToolEditApprovalPrompt, RetryRequestPrompt } from './types';
 
+// Re-export for consumers that import from this module
+export type { StreamStatus, StreamStatusOrReady };
+
 // Maximum number of events to buffer when no listeners are registered
 const MAX_BUFFER_SIZE = 1000;
 
-export type StreamStatus =
-  | 'running'
-  | 'error'
-  | 'stopped'
-  | 'waiting'
-  | 'resuming';
-export type StreamStatusOrReady = StreamStatus | 'ready';
 export type TaskGroupStatus = TaskGroup['status'];
 
 interface AddTaskGroupPayload {

--- a/src/eventBus/ProgressEventBus.ts
+++ b/src/eventBus/ProgressEventBus.ts
@@ -10,10 +10,7 @@ import type {
   StorageKey,
 } from '@agent/types/IdentifierTypes';
 import type { TokenUsageStats } from '@agent/types/UsageTypes';
-import type {
-  StreamStatus,
-  StreamStatusOrReady,
-} from '@common/constants/streamStatus';
+import type { StreamStatus } from '@common/constants/streamStatus';
 import type {
   LogMessageData,
   LogMessageUpdate,
@@ -23,7 +20,7 @@ import type { TaskState } from '@logger/TaskState';
 import type { ToolEditApprovalPrompt, RetryRequestPrompt } from './types';
 
 // Re-export for consumers that import from this module
-export type { StreamStatus, StreamStatusOrReady };
+export type { StreamStatus };
 
 // Maximum number of events to buffer when no listeners are registered
 const MAX_BUFFER_SIZE = 1000;
@@ -77,7 +74,7 @@ export interface ProgressEventPayloads {
   addTaskGroup: AddTaskGroupPayload;
   updateTaskGroup: UpdateTaskGroupPayload;
   setActiveStream: SetActiveStreamPayload;
-  updateStreamStatus: { stream: StreamTabId; status: StreamStatusOrReady };
+  updateStreamStatus: { stream: StreamTabId; status: StreamStatus };
   addOutputFiles: RunScopedPayload & {
     filesByRound: { [key: number]: OutputFileInfo[] };
   };

--- a/src/historyView/HistoryViewMessageHandler.ts
+++ b/src/historyView/HistoryViewMessageHandler.ts
@@ -1,5 +1,6 @@
 // Third-party imports
 import * as vscode from 'vscode';
+import { z } from 'zod';
 
 // Local imports - agent commands
 import { showLoggedErrorMessage } from '@common/errors';
@@ -9,6 +10,9 @@ import { HISTORY_VIEW_COMMANDS } from '@common/webview';
 import { AgentHistoryManager } from '@historyView/managers';
 import { agentConfigToTaskState } from '@utils/config';
 import { executeCommand } from '@commands/agent/executeCommand';
+
+// --- Message Schemas ---
+const HistoryIdMessage = z.object({ historyId: z.string().min(1) });
 
 export class HistoryViewMessageHandler extends BaseViewMessageHandler<
   vscode.WebviewView | vscode.WebviewPanel
@@ -47,75 +51,91 @@ export class HistoryViewMessageHandler extends BaseViewMessageHandler<
   }
 
   private async handleRerunAgent(
-    message: any,
+    message: unknown,
     _view: vscode.WebviewView | vscode.WebviewPanel,
   ): Promise<void> {
-    const historyId: string | undefined = message.historyId;
-    if (!historyId) return;
-
-    try {
-      const historyItem =
-        await AgentHistoryManager.getHistoryItemById(historyId);
-      if (historyItem) {
-        await vscode.window.showInformationMessage(
-          'Rerunning agent from history',
-        );
-        await executeCommand.executeCommand(historyItem.agentConfig);
-      } else {
-        await vscode.window.showErrorMessage('History item not found');
-      }
-    } catch (error) {
-      await vscode.window.showErrorMessage(`Failed to rerun agent: ${error}`);
-    }
+    await this.withValidatedMessage(
+      HistoryIdMessage,
+      message,
+      'rerunAgent',
+      async ({ historyId }) => {
+        try {
+          const historyItem =
+            await AgentHistoryManager.getHistoryItemById(historyId);
+          if (historyItem) {
+            await vscode.window.showInformationMessage(
+              'Rerunning agent from history',
+            );
+            await executeCommand.executeCommand(historyItem.agentConfig);
+          } else {
+            await vscode.window.showErrorMessage('History item not found');
+          }
+        } catch (error) {
+          await vscode.window.showErrorMessage(
+            `Failed to rerun agent: ${error}`,
+          );
+        }
+      },
+    );
   }
 
   private async handleRestoreAgent(
-    message: any,
+    message: unknown,
     _view: vscode.WebviewView | vscode.WebviewPanel,
   ): Promise<void> {
-    const historyId: string | undefined = message.historyId;
-    if (!historyId) return;
-    try {
-      const historyItem =
-        await AgentHistoryManager.getHistoryItemById(historyId);
-      if (historyItem) {
-        const taskState = agentConfigToTaskState(historyItem.agentConfig);
-        await vscode.commands.executeCommand('texra.restoreState', taskState);
-      } else {
-        await vscode.window.showErrorMessage('History item not found');
-      }
-    } catch (error) {
-      await showLoggedErrorMessage(
-        this.channel,
-        'Failed to restore configuration',
-        error,
-      );
-    }
+    await this.withValidatedMessage(
+      HistoryIdMessage,
+      message,
+      'restoreAgent',
+      async ({ historyId }) => {
+        try {
+          const historyItem =
+            await AgentHistoryManager.getHistoryItemById(historyId);
+          if (historyItem) {
+            const taskState = agentConfigToTaskState(historyItem.agentConfig);
+            await vscode.commands.executeCommand('texra.restoreState', taskState);
+          } else {
+            await vscode.window.showErrorMessage('History item not found');
+          }
+        } catch (error) {
+          await showLoggedErrorMessage(
+            this.channel,
+            'Failed to restore configuration',
+            error,
+          );
+        }
+      },
+    );
   }
 
   private async handleDeleteAgent(
-    message: any,
+    message: unknown,
     view: vscode.WebviewView | vscode.WebviewPanel,
   ): Promise<void> {
-    const historyId: string | undefined = message.historyId;
-    if (!historyId) return;
-    try {
-      const deleted =
-        await AgentHistoryManager.deleteHistoryItemById(historyId);
-      if (deleted) {
-        await this.sendHistoryData(view.webview);
-      } else {
-        await vscode.window.showWarningMessage(
-          `History item not found: ${historyId}`,
-        );
-      }
-    } catch (error) {
-      await showLoggedErrorMessage(
-        this.channel,
-        'Failed to delete history item',
-        error,
-      );
-    }
+    await this.withValidatedMessage(
+      HistoryIdMessage,
+      message,
+      'deleteAgent',
+      async ({ historyId }) => {
+        try {
+          const deleted =
+            await AgentHistoryManager.deleteHistoryItemById(historyId);
+          if (deleted) {
+            await this.sendHistoryData(view.webview);
+          } else {
+            await vscode.window.showWarningMessage(
+              `History item not found: ${historyId}`,
+            );
+          }
+        } catch (error) {
+          await showLoggedErrorMessage(
+            this.channel,
+            'Failed to delete history item',
+            error,
+          );
+        }
+      },
+    );
   }
 
   private async handleClearHistory(

--- a/src/profileView/ProfileViewMessageHandler.ts
+++ b/src/profileView/ProfileViewMessageHandler.ts
@@ -1,5 +1,6 @@
 // Third-party imports
 import * as vscode from 'vscode';
+import { z } from 'zod';
 
 // Local imports - agent
 import { getAgentsBySource, loadAgents, type AgentSource } from '@agent/index';
@@ -16,17 +17,8 @@ import {
 import { SupabaseClient } from '@/auth/SupabaseClient';
 import { AUTH_COMMANDS } from '@/auth/authCommands';
 
-/**
- * Message interfaces for type safety
- */
-interface SelectAgentMessage {
-  command: string;
-  agentName: string;
-}
-
-interface ProfileDataMessage {
-  command: string;
-}
+// --- Message Schemas ---
+const SelectAgentMessage = z.object({ agentName: z.string().min(1) });
 
 export class ProfileViewMessageHandler extends BaseViewMessageHandler<
   vscode.WebviewView | vscode.WebviewPanel
@@ -98,38 +90,39 @@ export class ProfileViewMessageHandler extends BaseViewMessageHandler<
   }
 
   private async handleGetProfileData(
-    _message: ProfileDataMessage,
+    _message: unknown,
     view: vscode.WebviewView | vscode.WebviewPanel,
   ): Promise<void> {
     await this.sendProfileData(view.webview);
   }
 
   private async handleSelectAgent(
-    message: SelectAgentMessage,
+    message: unknown,
     _view: vscode.WebviewView | vscode.WebviewPanel,
   ): Promise<void> {
-    const agentName = message.agentName;
-    if (!agentName) {
-      this.logger.warn(this.channel, 'SELECT_AGENT message missing agentName');
-      return;
-    }
-
-    // Use shared utility for agent selection
-    await selectAgentInMainView(agentName, {
-      showSuccessMessage: true,
-      copyToClipboardOnFailure: false,
-    });
+    await this.withValidatedMessage(
+      SelectAgentMessage,
+      message,
+      'selectAgent',
+      async ({ agentName }) => {
+        // Use shared utility for agent selection
+        await selectAgentInMainView(agentName, {
+          showSuccessMessage: true,
+          copyToClipboardOnFailure: false,
+        });
+      },
+    );
   }
 
   private async handleSignIn(
-    _message: ProfileDataMessage,
+    _message: unknown,
     _view: vscode.WebviewView | vscode.WebviewPanel,
   ): Promise<void> {
     await vscode.commands.executeCommand(AUTH_COMMANDS.SIGN_IN);
   }
 
   private async handleSignOut(
-    _message: ProfileDataMessage,
+    _message: unknown,
     _view: vscode.WebviewView | vscode.WebviewPanel,
   ): Promise<void> {
     await vscode.commands.executeCommand(AUTH_COMMANDS.SIGN_OUT);

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -351,81 +351,72 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
   }
 
   private async handlePolishFollowUp(message: unknown): Promise<void> {
-    const parsed = PolishFollowUp.safeParse(message);
-    if (!parsed.success) {
-      this.logger.debug(this.channel, 'Invalid polishFollowUp message', {
-        data: parsed.error,
-      });
-      return;
-    }
+    await this.withValidatedMessage(
+      PolishFollowUp,
+      message,
+      'polishFollowUp',
+      async ({ stream, text }) => {
+        const taskState = this.provider.state.getTaskState(
+          stream as StreamTabId,
+        ) as TaskState | undefined;
+        if (!taskState) return;
 
-    const { stream, text } = parsed.data;
-    const taskState = this.provider.state.getTaskState(
-      stream as StreamTabId,
-    ) as TaskState | undefined;
-    if (!taskState) return;
+        const fileContext = buildFileContextFromTaskState(taskState);
 
-    const fileContext = buildFileContextFromTaskState(taskState);
+        await vscode.window.withProgress(
+          {
+            location: vscode.ProgressLocation.Notification,
+            title: 'Polishing follow-up message',
+            cancellable: false,
+          },
+          async (progress) => {
+            try {
+              progress.report({
+                message: 'Sending to AI for polishing...',
+                increment: 30,
+              });
+              const result = await polishTextWithAI(text, fileContext);
+              progress.report({ message: 'Applying changes...', increment: 60 });
 
-    await vscode.window.withProgress(
-      {
-        location: vscode.ProgressLocation.Notification,
-        title: 'Polishing follow-up message',
-        cancellable: false,
-      },
-      async (progress) => {
-        try {
-          progress.report({
-            message: 'Sending to AI for polishing...',
-            increment: 30,
-          });
-          const result = await polishTextWithAI(text, fileContext);
-          progress.report({ message: 'Applying changes...', increment: 60 });
-
-          if (result.success) {
-            const view = this.getActiveView();
-            view?.webview.postMessage({
-              command: PROGRESS_VIEW_COMMANDS.FOLLOW_UP_TEXT_POLISHED,
-              text: result.text,
-            });
-          } else if (result.error) {
-            await vscode.window.showErrorMessage(result.error);
-          }
-        } catch (error) {
-          const messageText = toErrorMessage(error);
-          await vscode.window.showErrorMessage(
-            `Error polishing follow-up: ${messageText}`,
-          );
-          this.logger.error(
-            this.channel,
-            `Error polishing follow-up: ${messageText}`,
-            { data: error instanceof Error ? error : undefined },
-          );
-        }
+              if (result.success) {
+                const view = this.getActiveView();
+                view?.webview.postMessage({
+                  command: PROGRESS_VIEW_COMMANDS.FOLLOW_UP_TEXT_POLISHED,
+                  text: result.text,
+                });
+              } else if (result.error) {
+                await vscode.window.showErrorMessage(result.error);
+              }
+            } catch (error) {
+              const messageText = toErrorMessage(error);
+              await vscode.window.showErrorMessage(
+                `Error polishing follow-up: ${messageText}`,
+              );
+              this.logger.error(
+                this.channel,
+                `Error polishing follow-up: ${messageText}`,
+                { data: error instanceof Error ? error : undefined },
+              );
+            }
+          },
+        );
       },
     );
   }
 
   private async handleShowInformationMessage(message: unknown): Promise<void> {
-    const parsed = InfoMessage.safeParse(message);
-    if (!parsed.success) {
-      this.logger.debug(this.channel, 'Invalid infoMessage', {
-        data: parsed.error,
-      });
-      return;
-    }
-    await vscode.window.showInformationMessage(parsed.data.text);
+    await this.withValidatedMessage(InfoMessage, message, 'infoMessage', async (data) => {
+      await vscode.window.showInformationMessage(data.text);
+    });
   }
 
   private async handleToolEditApprovalAction(message: unknown): Promise<void> {
-    const parsed = ApprovalAction.safeParse(message);
-    if (!parsed.success) {
-      this.logger.debug(this.channel, 'Invalid approvalAction', {
-        data: parsed.error,
-      });
-      return;
-    }
-    await handleProgressViewToolEditApprovalAction(parsed.data);
+    await this.withValidatedMessage(
+      ApprovalAction,
+      message,
+      'approvalAction',
+      handleProgressViewToolEditApprovalAction,
+    );
   }
 
   private async handleResetToolEditApprovalBypass(): Promise<void> {

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -38,7 +38,7 @@ import {
 } from './ApprovalEvents';
 
 // Local imports - events
-import type { StreamStatusOrReadyType, StreamStatusType } from './types';
+import type { StreamStatus, StreamStatusOrReady } from '@eventBus/ProgressEventBus';
 
 /**
  * Handles progress event bus subscriptions for the progress view.
@@ -47,7 +47,7 @@ import type { StreamStatusOrReadyType, StreamStatusType } from './types';
  */
 export class ProgressEventHandler {
   private readonly logger: AgentLogger;
-  private _streamStatus: Map<string, StreamStatusType> = new Map();
+  private _streamStatus: Map<string, StreamStatus> = new Map();
   private readonly streamStatusEvents: StreamStatusEventModule;
   private readonly outputEvents: OutputEventsModule;
   private readonly logEvents: LogEventsModule;
@@ -277,18 +277,18 @@ export class ProgressEventHandler {
   /**
    * Get current stream status
    */
-  getStreamStatus(stream: string): StreamStatusType | undefined {
+  getStreamStatus(stream: string): StreamStatus | undefined {
     return this._streamStatus.get(stream);
   }
 
   /**
    * Set the status for a specific stream synchronously.
    */
-  setStreamStatus(stream: string, status: StreamStatusOrReadyType): void {
+  setStreamStatus(stream: string, status: StreamStatusOrReady): void {
     if (status === STREAM_STATUS.READY) {
       this._streamStatus.delete(stream);
     } else {
-      const nextStatus: StreamStatusType = status;
+      const nextStatus: StreamStatus = status;
       this._streamStatus.set(stream, nextStatus);
     }
 
@@ -331,7 +331,7 @@ export class ProgressEventHandler {
   /**
    * Get a copy of all stream statuses
    */
-  getAllStreamStatuses(): Map<string, StreamStatusType> {
+  getAllStreamStatuses(): Map<string, StreamStatus> {
     return new Map(this._streamStatus);
   }
 

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -38,7 +38,7 @@ import {
 } from './ApprovalEvents';
 
 // Local imports - events
-import type { StreamStatus, StreamStatusOrReady } from '@eventBus/ProgressEventBus';
+import type { StreamStatus } from '@eventBus/ProgressEventBus';
 
 /**
  * Handles progress event bus subscriptions for the progress view.
@@ -284,11 +284,12 @@ export class ProgressEventHandler {
   /**
    * Set the status for a specific stream synchronously.
    */
-  setStreamStatus(stream: string, status: StreamStatusOrReady): void {
+  setStreamStatus(stream: string, status: StreamStatus): void {
     if (status === STREAM_STATUS.READY) {
       this._streamStatus.delete(stream);
     } else {
-      const nextStatus: StreamStatus = status;
+      // Status is not 'ready', so it's a valid active status
+      const nextStatus = status;
       this._streamStatus.set(stream, nextStatus);
     }
 

--- a/src/progressView/events/StreamStatusEvents.ts
+++ b/src/progressView/events/StreamStatusEvents.ts
@@ -20,15 +20,12 @@ import { createErrorBoundary } from './errorHandling';
 
 // Type imports
 import type { ProgressEventBusLike } from './types';
-import type {
-  StreamStatus,
-  StreamStatusOrReady,
-} from '@eventBus/ProgressEventBus';
+import type { StreamStatus } from '@eventBus/ProgressEventBus';
 
 export interface StreamStatusEventShared {
   logger: AgentLogger;
   streamStatus: Map<string, StreamStatus>;
-  setStreamStatus(stream: string, status: StreamStatusOrReady): void;
+  setStreamStatus(stream: string, status: StreamStatus): void;
   sendInstructionUpdate(stream: StreamTabId | '', runId?: string | null): void;
   refreshStreamSurface(
     stream: string,
@@ -85,7 +82,7 @@ export function createStreamStatusEvents(
 
     state.activeStream = stream;
 
-    const status: StreamStatusOrReady =
+    const status: StreamStatus =
       shared.streamStatus.get(stream) ?? STREAM_STATUS.RUNNING;
 
     if (updater.isAvailable()) {

--- a/src/progressView/events/StreamStatusEvents.ts
+++ b/src/progressView/events/StreamStatusEvents.ts
@@ -19,16 +19,16 @@ import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
 import { createErrorBoundary } from './errorHandling';
 
 // Type imports
+import type { ProgressEventBusLike } from './types';
 import type {
-  ProgressEventBusLike,
-  StreamStatusType,
-  StreamStatusOrReadyType,
-} from './types';
+  StreamStatus,
+  StreamStatusOrReady,
+} from '@eventBus/ProgressEventBus';
 
 export interface StreamStatusEventShared {
   logger: AgentLogger;
-  streamStatus: Map<string, StreamStatusType>;
-  setStreamStatus(stream: string, status: StreamStatusOrReadyType): void;
+  streamStatus: Map<string, StreamStatus>;
+  setStreamStatus(stream: string, status: StreamStatusOrReady): void;
   sendInstructionUpdate(stream: StreamTabId | '', runId?: string | null): void;
   refreshStreamSurface(
     stream: string,
@@ -85,7 +85,7 @@ export function createStreamStatusEvents(
 
     state.activeStream = stream;
 
-    const status: StreamStatusOrReadyType =
+    const status: StreamStatusOrReady =
       shared.streamStatus.get(stream) ?? STREAM_STATUS.RUNNING;
 
     if (updater.isAvailable()) {

--- a/src/progressView/events/index.ts
+++ b/src/progressView/events/index.ts
@@ -23,5 +23,5 @@ export {
   createTaskGroupEvents,
 } from './TaskGroupEvents';
 export { ProgressEventBusLike } from './types';
-export type { StreamStatus, StreamStatusOrReady } from '@eventBus/ProgressEventBus';
+export type { StreamStatus } from '@eventBus/ProgressEventBus';
 export { UsageEventsModule, createUsageEvents } from './UsageEvents';

--- a/src/progressView/events/index.ts
+++ b/src/progressView/events/index.ts
@@ -22,10 +22,6 @@ export {
   TaskGroupEventsModule,
   createTaskGroupEvents,
 } from './TaskGroupEvents';
-export {
-  StreamStatusType,
-  StreamStatusOrReadyType,
-  StatusType,
-  ProgressEventBusLike,
-} from './types';
+export { ProgressEventBusLike } from './types';
+export type { StreamStatus, StreamStatusOrReady } from '@eventBus/ProgressEventBus';
 export { UsageEventsModule, createUsageEvents } from './UsageEvents';

--- a/src/progressView/events/types.ts
+++ b/src/progressView/events/types.ts
@@ -6,9 +6,22 @@ import type {
   StreamStatusOrReady,
 } from '@eventBus/ProgressEventBus';
 
-// Re-export for backward compatibility with existing consumers
+/**
+ * @deprecated Use `StreamStatus` from '@eventBus/ProgressEventBus' directly.
+ * This alias exists only for backward compatibility.
+ */
 export type StreamStatusType = StreamStatus;
+
+/**
+ * @deprecated Use `StreamStatusOrReady` from '@eventBus/ProgressEventBus' directly.
+ * This alias exists only for backward compatibility.
+ */
 export type StreamStatusOrReadyType = StreamStatusOrReady;
+
+/**
+ * @deprecated Use `StreamStatusOrReady` from '@eventBus/ProgressEventBus' directly.
+ * This alias exists only for backward compatibility.
+ */
 export type StatusType = StreamStatusOrReady;
 
 export interface ProgressEventBusLike {

--- a/src/progressView/events/types.ts
+++ b/src/progressView/events/types.ts
@@ -2,13 +2,14 @@
 import type {
   ProgressEvent,
   ProgressEventPayloads,
-  StreamStatus as ProgressStreamStatus,
-  StreamStatusOrReady as ProgressStreamStatusOrReady,
+  StreamStatus,
+  StreamStatusOrReady,
 } from '@eventBus/ProgressEventBus';
 
-export type StreamStatusType = ProgressStreamStatus;
-export type StreamStatusOrReadyType = ProgressStreamStatusOrReady;
-export type StatusType = ProgressStreamStatusOrReady;
+// Re-export for backward compatibility with existing consumers
+export type StreamStatusType = StreamStatus;
+export type StreamStatusOrReadyType = StreamStatusOrReady;
+export type StatusType = StreamStatusOrReady;
 
 export interface ProgressEventBusLike {
   on<K extends ProgressEvent>(

--- a/src/progressView/events/types.ts
+++ b/src/progressView/events/types.ts
@@ -2,27 +2,7 @@
 import type {
   ProgressEvent,
   ProgressEventPayloads,
-  StreamStatus,
-  StreamStatusOrReady,
 } from '@eventBus/ProgressEventBus';
-
-/**
- * @deprecated Use `StreamStatus` from '@eventBus/ProgressEventBus' directly.
- * This alias exists only for backward compatibility.
- */
-export type StreamStatusType = StreamStatus;
-
-/**
- * @deprecated Use `StreamStatusOrReady` from '@eventBus/ProgressEventBus' directly.
- * This alias exists only for backward compatibility.
- */
-export type StreamStatusOrReadyType = StreamStatusOrReady;
-
-/**
- * @deprecated Use `StreamStatusOrReady` from '@eventBus/ProgressEventBus' directly.
- * This alias exists only for backward compatibility.
- */
-export type StatusType = StreamStatusOrReady;
 
 export interface ProgressEventBusLike {
   on<K extends ProgressEvent>(

--- a/src/progressView/managers/OutputFilesManager.ts
+++ b/src/progressView/managers/OutputFilesManager.ts
@@ -17,27 +17,13 @@ import {
   PersistentMapManager,
   type StateStorage,
 } from '@progressView/persistence/PersistentMapManager';
+import {
+  RoundKeySchema,
+  createRoundMapSchema,
+  createLegacyAwareRunMapSchema,
+} from '@progressView/persistence/schemaUtils';
 
 // --- Zod Schemas for Output Files ---
-
-/** Schema for integer round keys (coerces string keys to numbers) */
-const RoundKey = z.coerce.number().int();
-
-/** Schema for a round map: { roundNumber: items[] } -> Map<number, T[]> */
-function createRoundMapSchema<T>(itemSchema: z.ZodType<T>) {
-  return z
-    .record(z.string(), z.array(itemSchema).catch([]))
-    .transform((record): Map<number, T[]> => {
-      const map = new Map<number, T[]>();
-      for (const [key, items] of Object.entries(record)) {
-        const round = RoundKey.safeParse(key);
-        if (round.success && items.length > 0) {
-          map.set(round.data, items);
-        }
-      }
-      return map;
-    });
-}
 
 /** Schema for missing output paths (string arrays per round) */
 const MissingOutputRoundMapSchema = createRoundMapSchema(z.string());
@@ -48,7 +34,7 @@ const OutputFilesRoundMapSchema = z
   .transform((record): Map<number, OutputFileInfo[]> => {
     const map = new Map<number, OutputFileInfo[]>();
     for (const [key, items] of Object.entries(record)) {
-      const round = RoundKey.safeParse(key);
+      const round = RoundKeySchema.safeParse(key);
       if (!round.success) continue;
       const parsed = items
         .map((item) => OutputFileInfoSchema.safeParse(item))
@@ -63,51 +49,6 @@ const OutputFilesRoundMapSchema = z
     }
     return map;
   });
-
-/**
- * Detects if a record looks like legacy format (all keys are numeric)
- * vs modern format (keys are run IDs like strings)
- */
-function isLegacyFormat(record: Record<string, unknown>): boolean {
-  const entries = Object.entries(record);
-  return (
-    entries.length > 0 &&
-    entries.every(([key]) => !Number.isNaN(Number.parseInt(key, 10)))
-  );
-}
-
-/**
- * Factory for creating schemas that handle both legacy and modern run map formats.
- * Legacy: { roundNum: items[] } -> wrapped in default run ID
- * Modern: { runId: { roundNum: items[] } }
- */
-function createLegacyAwareRunMapSchema<T>(
-  roundMapSchema: z.ZodType<Map<number, T[]>>,
-) {
-  return z.unknown().transform((data): Map<string, Map<number, T[]>> => {
-    if (!data || typeof data !== 'object') {
-      return new Map();
-    }
-
-    const record = data as Record<string, unknown>;
-    if (isLegacyFormat(record)) {
-      const rounds = roundMapSchema.parse(record);
-      return rounds.size > 0
-        ? new Map([[normalizeRunId(null), rounds]])
-        : new Map();
-    }
-
-    const runMap = new Map<string, Map<number, T[]>>();
-    for (const [runId, value] of Object.entries(record)) {
-      if (!value || typeof value !== 'object') continue;
-      const rounds = roundMapSchema.parse(value);
-      if (rounds.size > 0) {
-        runMap.set(runId, rounds);
-      }
-    }
-    return runMap;
-  });
-}
 
 /** Schema for missing outputs with legacy format support */
 const MissingOutputsDataSchema = createLegacyAwareRunMapSchema(

--- a/src/progressView/managers/OutputFilesManager.ts
+++ b/src/progressView/managers/OutputFilesManager.ts
@@ -20,7 +20,7 @@ import {
 import {
   RoundKeySchema,
   createRoundMapSchema,
-  createLegacyAwareRunMapSchema,
+  createRunMapSchema,
 } from '@progressView/persistence/schemaUtils';
 
 // --- Zod Schemas for Output Files ---
@@ -50,15 +50,11 @@ const OutputFilesRoundMapSchema = z
     return map;
   });
 
-/** Schema for missing outputs with legacy format support */
-const MissingOutputsDataSchema = createLegacyAwareRunMapSchema(
-  MissingOutputRoundMapSchema,
-);
+/** Schema for missing outputs run map */
+const MissingOutputsDataSchema = createRunMapSchema(MissingOutputRoundMapSchema);
 
-/** Schema for output files with legacy format support */
-const OutputFilesDataSchema = createLegacyAwareRunMapSchema(
-  OutputFilesRoundMapSchema,
-);
+/** Schema for output files run map */
+const OutputFilesDataSchema = createRunMapSchema(OutputFilesRoundMapSchema);
 
 /**
  * Manages output files collection with persistence and file existence validation.

--- a/src/progressView/managers/UsageStatsManager.ts
+++ b/src/progressView/managers/UsageStatsManager.ts
@@ -12,7 +12,7 @@ import {
   PersistentMapManager,
   type StateStorage,
 } from '@progressView/persistence/PersistentMapManager';
-import { createLegacyAwareSingleValueRunMapSchema } from '@progressView/persistence/schemaUtils';
+import { createSingleValueRunMapSchema } from '@progressView/persistence/schemaUtils';
 
 // --- Zod Schemas for Usage Stats ---
 
@@ -30,17 +30,6 @@ const TokenUsageStatsSchema = z
   })
   .catch({ inputTokens: 0, outputTokens: 0, cost: 0 });
 
-/**
- * Detects legacy flat format (single usage stats object) vs modern run map format.
- * Legacy: { inputTokens, outputTokens, cost } - flat object
- * Modern: { runId: { inputTokens, outputTokens, cost } } - nested objects
- */
-function isLegacyFlatUsageFormat(record: Record<string, unknown>): boolean {
-  const entries = Object.entries(record);
-  // Legacy format has primitive values (numbers), modern format has object values
-  return !entries.every(([, value]) => value && typeof value === 'object');
-}
-
 /** Checks if usage stats are all zeros (effectively empty) */
 function isEmptyUsage(usage: TokenUsageStats): boolean {
   return (
@@ -48,12 +37,10 @@ function isEmptyUsage(usage: TokenUsageStats): boolean {
   );
 }
 
-/** Schema that handles both legacy flat format and modern run map format */
-const UsageDataSchema = createLegacyAwareSingleValueRunMapSchema(
-  TokenUsageStatsSchema,
-  isLegacyFlatUsageFormat,
-  { isEmpty: isEmptyUsage },
-);
+/** Schema for run map format: { runId: { inputTokens, outputTokens, cost } } */
+const UsageDataSchema = createSingleValueRunMapSchema(TokenUsageStatsSchema, {
+  isEmpty: isEmptyUsage,
+});
 
 /**
  * Manages usage statistics collection with persistence.

--- a/src/progressView/managers/UsageStatsManager.ts
+++ b/src/progressView/managers/UsageStatsManager.ts
@@ -12,6 +12,7 @@ import {
   PersistentMapManager,
   type StateStorage,
 } from '@progressView/persistence/PersistentMapManager';
+import { createLegacyAwareSingleValueRunMapSchema } from '@progressView/persistence/schemaUtils';
 
 // --- Zod Schemas for Usage Stats ---
 
@@ -29,43 +30,22 @@ const TokenUsageStatsSchema = z
   })
   .catch({ inputTokens: 0, outputTokens: 0, cost: 0 });
 
-/** Schema for run map (runId -> usage) */
-const RunMapSchema = z.record(z.string(), TokenUsageStatsSchema);
+/**
+ * Detects legacy flat format (single usage stats object) vs modern run map format.
+ * Legacy: { inputTokens, outputTokens, cost } - flat object
+ * Modern: { runId: { inputTokens, outputTokens, cost } } - nested objects
+ */
+function isLegacyFlatUsageFormat(record: Record<string, unknown>): boolean {
+  const entries = Object.entries(record);
+  // Legacy format has primitive values (numbers), modern format has object values
+  return !entries.every(([, value]) => value && typeof value === 'object');
+}
 
 /** Schema that handles both legacy flat format and modern run map format */
-const UsageDataSchema = z
-  .unknown()
-  .transform((data): Map<string, TokenUsageStats> => {
-    if (!data || typeof data !== 'object') {
-      return new Map();
-    }
-
-    const entries = Object.entries(data as Record<string, unknown>);
-    const looksLikeRunMap = entries.every(
-      ([, value]) => value && typeof value === 'object',
-    );
-
-    if (!looksLikeRunMap) {
-      // Legacy flat format
-      const usage = TokenUsageStatsSchema.parse(data);
-      if (
-        usage.inputTokens === 0 &&
-        usage.outputTokens === 0 &&
-        usage.cost === 0
-      ) {
-        return new Map();
-      }
-      return new Map([[normalizeRunId(null), usage]]);
-    }
-
-    // Modern run map format
-    const runMap = RunMapSchema.parse(data);
-    const result = new Map<string, TokenUsageStats>();
-    for (const [runId, usage] of Object.entries(runMap)) {
-      result.set(runId, usage);
-    }
-    return result;
-  });
+const UsageDataSchema = createLegacyAwareSingleValueRunMapSchema(
+  TokenUsageStatsSchema,
+  isLegacyFlatUsageFormat,
+);
 
 /**
  * Manages usage statistics collection with persistence.

--- a/src/progressView/managers/UsageStatsManager.ts
+++ b/src/progressView/managers/UsageStatsManager.ts
@@ -41,10 +41,18 @@ function isLegacyFlatUsageFormat(record: Record<string, unknown>): boolean {
   return !entries.every(([, value]) => value && typeof value === 'object');
 }
 
+/** Checks if usage stats are all zeros (effectively empty) */
+function isEmptyUsage(usage: TokenUsageStats): boolean {
+  return (
+    usage.inputTokens === 0 && usage.outputTokens === 0 && usage.cost === 0
+  );
+}
+
 /** Schema that handles both legacy flat format and modern run map format */
 const UsageDataSchema = createLegacyAwareSingleValueRunMapSchema(
   TokenUsageStatsSchema,
   isLegacyFlatUsageFormat,
+  { isEmpty: isEmptyUsage },
 );
 
 /**

--- a/src/progressView/managers/WebviewUpdater.ts
+++ b/src/progressView/managers/WebviewUpdater.ts
@@ -8,7 +8,10 @@ import type { AgentTypeFilter } from '@agent/types/AgentStreamTypes';
 // Types
 import type { TokenUsageStats } from '@agent/types/UsageTypes';
 
-import { STREAM_STATUS } from '@common/constants/streamStatus';
+import {
+  STREAM_STATUS,
+  type StreamStatusOrReady,
+} from '@common/constants/streamStatus';
 import { AgentLogger } from '@logger/AgentLogger';
 import { LogMessageData } from '@logger/LogTypes';
 import type { TaskState } from '@logger/TaskState';
@@ -28,9 +31,6 @@ import type {
 
 // Logger imports
 // Type imports
-
-// Type aliases for status values
-type StatusType = (typeof STREAM_STATUS)[keyof typeof STREAM_STATUS];
 
 /**
  * Manages webview updates for the progress view.
@@ -299,7 +299,7 @@ export class WebviewUpdater {
   /**
    * Update stream status indicator (for active stream)
    */
-  updateStatus(status: StatusType): void {
+  updateStatus(status: StreamStatusOrReady): void {
     this.sendMessage({
       command: COMMANDS.UPDATE_STATUS,
       status,
@@ -310,7 +310,7 @@ export class WebviewUpdater {
    * Update a single stream's status in the stream tabs.
    * More efficient than updateStreams when only status changed.
    */
-  updateStreamStatus(stream: StreamTabId, status: StatusType | 'ready'): void {
+  updateStreamStatus(stream: StreamTabId, status: StreamStatusOrReady): void {
     this.sendMessage({
       command: COMMANDS.UPDATE_STREAM_STATUS,
       stream,

--- a/src/progressView/managers/WebviewUpdater.ts
+++ b/src/progressView/managers/WebviewUpdater.ts
@@ -10,7 +10,7 @@ import type { TokenUsageStats } from '@agent/types/UsageTypes';
 
 import {
   STREAM_STATUS,
-  type StreamStatusOrReady,
+  type StreamStatus,
 } from '@common/constants/streamStatus';
 import { AgentLogger } from '@logger/AgentLogger';
 import { LogMessageData } from '@logger/LogTypes';
@@ -299,7 +299,7 @@ export class WebviewUpdater {
   /**
    * Update stream status indicator (for active stream)
    */
-  updateStatus(status: StreamStatusOrReady): void {
+  updateStatus(status: StreamStatus): void {
     this.sendMessage({
       command: COMMANDS.UPDATE_STATUS,
       status,
@@ -310,7 +310,7 @@ export class WebviewUpdater {
    * Update a single stream's status in the stream tabs.
    * More efficient than updateStreams when only status changed.
    */
-  updateStreamStatus(stream: StreamTabId, status: StreamStatusOrReady): void {
+  updateStreamStatus(stream: StreamTabId, status: StreamStatus): void {
     this.sendMessage({
       command: COMMANDS.UPDATE_STREAM_STATUS,
       stream,

--- a/src/progressView/persistence/schemaUtils.ts
+++ b/src/progressView/persistence/schemaUtils.ts
@@ -71,17 +71,20 @@ export function createLegacyAwareRunMapSchema<T>(
 
     // Legacy format: all keys are numeric (round numbers)
     if (isLegacyNumericKeyFormat(record)) {
-      const rounds = roundMapSchema.parse(record);
-      return rounds.size > 0 ? new Map([[defaultRunId, rounds]]) : new Map();
+      const result = roundMapSchema.safeParse(record);
+      if (!result.success) return new Map();
+      return result.data.size > 0
+        ? new Map([[defaultRunId, result.data]])
+        : new Map();
     }
 
     // Modern format: keys are run IDs
     const runMap = new Map<string, Map<number, T[]>>();
     for (const [runId, value] of Object.entries(record)) {
       if (!value || typeof value !== 'object') continue;
-      const rounds = roundMapSchema.parse(value);
-      if (rounds.size > 0) {
-        runMap.set(runId, rounds);
+      const result = roundMapSchema.safeParse(value);
+      if (result.success && result.data.size > 0) {
+        runMap.set(runId, result.data);
       }
     }
     return runMap;
@@ -117,12 +120,13 @@ export function createLegacyAwareSingleValueRunMapSchema<T>(
 
     // Legacy format: flat object
     if (isLegacyFormat(record)) {
-      const item = itemSchema.parse(data);
+      const result = itemSchema.safeParse(data);
+      if (!result.success) return new Map();
       // Skip empty values in legacy format
-      if (isEmpty?.(item)) {
+      if (isEmpty?.(result.data)) {
         return new Map();
       }
-      return new Map([[defaultRunId, item]]);
+      return new Map([[defaultRunId, result.data]]);
     }
 
     // Modern format: keys are run IDs

--- a/src/progressView/persistence/schemaUtils.ts
+++ b/src/progressView/persistence/schemaUtils.ts
@@ -1,28 +1,10 @@
 // Third-party imports
 import { z } from 'zod';
 
-// Local imports
-import { normalizeRunId } from '@common/constants/runIds';
-
 /**
  * Coerces and validates integer round keys from string record keys.
  */
 export const RoundKeySchema = z.coerce.number().int();
-
-/**
- * Detects if a record uses legacy numeric-keyed format.
- * Legacy format: { "0": [...], "1": [...] } - round numbers as keys
- * Modern format: { "runId123": { "0": [...] } } - run IDs as keys
- */
-export function isLegacyNumericKeyFormat(
-  record: Record<string, unknown>,
-): boolean {
-  const entries = Object.entries(record);
-  return (
-    entries.length > 0 &&
-    entries.every(([key]) => !Number.isNaN(Number.parseInt(key, 10)))
-  );
-}
 
 /**
  * Factory for creating round map schemas that transform { roundNum: items[] } to Map<number, T[]>.
@@ -48,38 +30,22 @@ export function createRoundMapSchema<T>(
 }
 
 /**
- * Factory for creating schemas that handle both legacy flat format and modern run map format.
- *
- * Legacy format: { roundNum: items[] } - wrapped in default run ID
- * Modern format: { runId: { roundNum: items[] } }
+ * Factory for creating run map schemas.
+ * Format: { runId: { roundNum: items[] } }
  *
  * @param roundMapSchema - Schema for parsing the inner round map structure
- * @param options.defaultRunId - Run ID to use for legacy format (defaults to normalizeRunId(null))
  */
-export function createLegacyAwareRunMapSchema<T>(
+export function createRunMapSchema<T>(
   roundMapSchema: z.ZodType<Map<number, T[]>>,
-  options?: { defaultRunId?: string },
 ): z.ZodType<Map<string, Map<number, T[]>>> {
-  const defaultRunId = options?.defaultRunId ?? normalizeRunId(null);
-
   return z.unknown().transform((data): Map<string, Map<number, T[]>> => {
     if (!data || typeof data !== 'object') {
       return new Map();
     }
 
     const record = data as Record<string, unknown>;
-
-    // Legacy format: all keys are numeric (round numbers)
-    if (isLegacyNumericKeyFormat(record)) {
-      const result = roundMapSchema.safeParse(record);
-      if (!result.success) return new Map();
-      return result.data.size > 0
-        ? new Map([[defaultRunId, result.data]])
-        : new Map();
-    }
-
-    // Modern format: keys are run IDs
     const runMap = new Map<string, Map<number, T[]>>();
+
     for (const [runId, value] of Object.entries(record)) {
       if (!value || typeof value !== 'object') continue;
       const result = roundMapSchema.safeParse(value);
@@ -92,23 +58,16 @@ export function createLegacyAwareRunMapSchema<T>(
 }
 
 /**
- * Factory for creating schemas that handle both legacy flat format and modern run map format
- * for single-value items (not arrays per round).
- *
- * Legacy format: { field: value } - single flat object wrapped in default run ID
- * Modern format: { runId: { field: value } }
+ * Factory for creating run map schemas for single-value items (not arrays per round).
+ * Format: { runId: { field: value } }
  *
  * @param itemSchema - Schema for parsing individual item values
- * @param isLegacyFormat - Function to detect if data is in legacy format
- * @param options.defaultRunId - Run ID to use for legacy format (defaults to normalizeRunId(null))
- * @param options.isEmpty - Optional predicate to skip empty/zero values (returns empty map if true)
+ * @param options.isEmpty - Optional predicate to skip empty/zero values
  */
-export function createLegacyAwareSingleValueRunMapSchema<T>(
+export function createSingleValueRunMapSchema<T>(
   itemSchema: z.ZodType<T>,
-  isLegacyFormat: (data: Record<string, unknown>) => boolean,
-  options?: { defaultRunId?: string; isEmpty?: (item: T) => boolean },
+  options?: { isEmpty?: (item: T) => boolean },
 ): z.ZodType<Map<string, T>> {
-  const defaultRunId = options?.defaultRunId ?? normalizeRunId(null);
   const isEmpty = options?.isEmpty;
 
   return z.unknown().transform((data): Map<string, T> => {
@@ -117,25 +76,12 @@ export function createLegacyAwareSingleValueRunMapSchema<T>(
     }
 
     const record = data as Record<string, unknown>;
-
-    // Legacy format: flat object
-    if (isLegacyFormat(record)) {
-      const result = itemSchema.safeParse(data);
-      if (!result.success) return new Map();
-      // Skip empty values in legacy format
-      if (isEmpty?.(result.data)) {
-        return new Map();
-      }
-      return new Map([[defaultRunId, result.data]]);
-    }
-
-    // Modern format: keys are run IDs
     const runMap = new Map<string, T>();
+
     for (const [runId, value] of Object.entries(record)) {
       if (!value || typeof value !== 'object') continue;
       const result = itemSchema.safeParse(value);
       if (result.success) {
-        // Skip empty values in modern format
         if (isEmpty?.(result.data)) continue;
         runMap.set(runId, result.data);
       }

--- a/src/progressView/persistence/schemaUtils.ts
+++ b/src/progressView/persistence/schemaUtils.ts
@@ -97,13 +97,16 @@ export function createLegacyAwareRunMapSchema<T>(
  *
  * @param itemSchema - Schema for parsing individual item values
  * @param isLegacyFormat - Function to detect if data is in legacy format
+ * @param options.defaultRunId - Run ID to use for legacy format (defaults to normalizeRunId(null))
+ * @param options.isEmpty - Optional predicate to skip empty/zero values (returns empty map if true)
  */
 export function createLegacyAwareSingleValueRunMapSchema<T>(
   itemSchema: z.ZodType<T>,
   isLegacyFormat: (data: Record<string, unknown>) => boolean,
-  options?: { defaultRunId?: string },
+  options?: { defaultRunId?: string; isEmpty?: (item: T) => boolean },
 ): z.ZodType<Map<string, T>> {
   const defaultRunId = options?.defaultRunId ?? normalizeRunId(null);
+  const isEmpty = options?.isEmpty;
 
   return z.unknown().transform((data): Map<string, T> => {
     if (!data || typeof data !== 'object') {
@@ -115,6 +118,10 @@ export function createLegacyAwareSingleValueRunMapSchema<T>(
     // Legacy format: flat object
     if (isLegacyFormat(record)) {
       const item = itemSchema.parse(data);
+      // Skip empty values in legacy format
+      if (isEmpty?.(item)) {
+        return new Map();
+      }
       return new Map([[defaultRunId, item]]);
     }
 
@@ -124,6 +131,8 @@ export function createLegacyAwareSingleValueRunMapSchema<T>(
       if (!value || typeof value !== 'object') continue;
       const result = itemSchema.safeParse(value);
       if (result.success) {
+        // Skip empty values in modern format
+        if (isEmpty?.(result.data)) continue;
         runMap.set(runId, result.data);
       }
     }

--- a/src/progressView/persistence/schemaUtils.ts
+++ b/src/progressView/persistence/schemaUtils.ts
@@ -1,0 +1,132 @@
+// Third-party imports
+import { z } from 'zod';
+
+// Local imports
+import { normalizeRunId } from '@common/constants/runIds';
+
+/**
+ * Coerces and validates integer round keys from string record keys.
+ */
+export const RoundKeySchema = z.coerce.number().int();
+
+/**
+ * Detects if a record uses legacy numeric-keyed format.
+ * Legacy format: { "0": [...], "1": [...] } - round numbers as keys
+ * Modern format: { "runId123": { "0": [...] } } - run IDs as keys
+ */
+export function isLegacyNumericKeyFormat(
+  record: Record<string, unknown>,
+): boolean {
+  const entries = Object.entries(record);
+  return (
+    entries.length > 0 &&
+    entries.every(([key]) => !Number.isNaN(Number.parseInt(key, 10)))
+  );
+}
+
+/**
+ * Factory for creating round map schemas that transform { roundNum: items[] } to Map<number, T[]>.
+ * Filters out invalid round keys and empty item arrays.
+ *
+ * @param itemSchema - Zod schema for individual items in the round array
+ */
+export function createRoundMapSchema<T>(
+  itemSchema: z.ZodType<T>,
+): z.ZodType<Map<number, T[]>> {
+  return z
+    .record(z.string(), z.array(itemSchema).catch([]))
+    .transform((record): Map<number, T[]> => {
+      const map = new Map<number, T[]>();
+      for (const [key, items] of Object.entries(record)) {
+        const round = RoundKeySchema.safeParse(key);
+        if (round.success && items.length > 0) {
+          map.set(round.data, items);
+        }
+      }
+      return map;
+    }) as z.ZodType<Map<number, T[]>>;
+}
+
+/**
+ * Factory for creating schemas that handle both legacy flat format and modern run map format.
+ *
+ * Legacy format: { roundNum: items[] } - wrapped in default run ID
+ * Modern format: { runId: { roundNum: items[] } }
+ *
+ * @param roundMapSchema - Schema for parsing the inner round map structure
+ * @param options.defaultRunId - Run ID to use for legacy format (defaults to normalizeRunId(null))
+ */
+export function createLegacyAwareRunMapSchema<T>(
+  roundMapSchema: z.ZodType<Map<number, T[]>>,
+  options?: { defaultRunId?: string },
+): z.ZodType<Map<string, Map<number, T[]>>> {
+  const defaultRunId = options?.defaultRunId ?? normalizeRunId(null);
+
+  return z.unknown().transform((data): Map<string, Map<number, T[]>> => {
+    if (!data || typeof data !== 'object') {
+      return new Map();
+    }
+
+    const record = data as Record<string, unknown>;
+
+    // Legacy format: all keys are numeric (round numbers)
+    if (isLegacyNumericKeyFormat(record)) {
+      const rounds = roundMapSchema.parse(record);
+      return rounds.size > 0 ? new Map([[defaultRunId, rounds]]) : new Map();
+    }
+
+    // Modern format: keys are run IDs
+    const runMap = new Map<string, Map<number, T[]>>();
+    for (const [runId, value] of Object.entries(record)) {
+      if (!value || typeof value !== 'object') continue;
+      const rounds = roundMapSchema.parse(value);
+      if (rounds.size > 0) {
+        runMap.set(runId, rounds);
+      }
+    }
+    return runMap;
+  }) as z.ZodType<Map<string, Map<number, T[]>>>;
+}
+
+/**
+ * Factory for creating schemas that handle both legacy flat format and modern run map format
+ * for single-value items (not arrays per round).
+ *
+ * Legacy format: { field: value } - single flat object wrapped in default run ID
+ * Modern format: { runId: { field: value } }
+ *
+ * @param itemSchema - Schema for parsing individual item values
+ * @param isLegacyFormat - Function to detect if data is in legacy format
+ */
+export function createLegacyAwareSingleValueRunMapSchema<T>(
+  itemSchema: z.ZodType<T>,
+  isLegacyFormat: (data: Record<string, unknown>) => boolean,
+  options?: { defaultRunId?: string },
+): z.ZodType<Map<string, T>> {
+  const defaultRunId = options?.defaultRunId ?? normalizeRunId(null);
+
+  return z.unknown().transform((data): Map<string, T> => {
+    if (!data || typeof data !== 'object') {
+      return new Map();
+    }
+
+    const record = data as Record<string, unknown>;
+
+    // Legacy format: flat object
+    if (isLegacyFormat(record)) {
+      const item = itemSchema.parse(data);
+      return new Map([[defaultRunId, item]]);
+    }
+
+    // Modern format: keys are run IDs
+    const runMap = new Map<string, T>();
+    for (const [runId, value] of Object.entries(record)) {
+      if (!value || typeof value !== 'object') continue;
+      const result = itemSchema.safeParse(value);
+      if (result.success) {
+        runMap.set(runId, result.data);
+      }
+    }
+    return runMap;
+  }) as z.ZodType<Map<string, T>>;
+}

--- a/src/webview/types/messages.ts
+++ b/src/webview/types/messages.ts
@@ -1,136 +1,191 @@
 /**
- * TypeScript interfaces for webview message types
- * These interfaces replace generic 'any' types with proper type definitions
+ * Zod schemas for webview message types.
+ * Types are derived from schemas using z.infer<> for single source of truth.
  */
+import { z } from 'zod';
+
+// --- Base Schemas (composable building blocks) ---
+
+/** Base for all messages - command field */
+const BaseMessageSchema = z.object({
+  command: z.string(),
+});
+
+/** Common pattern: single file path */
+const WithFilePath = z.object({
+  filePath: z.string(),
+});
+
+/** Common pattern: notify when empty option */
+const WithNotifyWhenEmpty = z.object({
+  notifyWhenEmpty: z.boolean().optional(),
+});
+
+/** Common pattern: files array */
+const WithFiles = z.object({
+  files: z.array(z.string()).optional(),
+});
+
+/** Common pattern: file active flags */
+const WithFileActiveFlags = z.object({
+  inputFilesActive: z.boolean().optional(),
+  referenceFilesActive: z.boolean().optional(),
+  auxiliaryFilesActive: z.boolean().optional(),
+  mediaFilesActive: z.boolean().optional(),
+  outputFilesActive: z.boolean().optional(),
+});
+
+// --- Message Schemas ---
 
 /**
  * Polish instruction text message from webview
  */
-export interface PolishInstructionMessage {
-  command: string;
-  text: string;
-  agent?: string;
-  inputFile?: string;
-  referenceFile?: string;
-  auxiliaryFile?: string;
-  mediaFile?: string;
-  inputFiles?: string[];
-  inputFilesActive?: boolean;
-  referenceFiles?: string[];
-  referenceFilesActive?: boolean;
-  auxiliaryFiles?: string[];
-  auxiliaryFilesActive?: boolean;
-  mediaFiles?: string[];
-  mediaFilesActive?: boolean;
-  outputFiles?: string[];
-  outputFilesActive?: boolean;
-}
+export const PolishInstructionMessageSchema = BaseMessageSchema.extend({
+  text: z.string(),
+  agent: z.string().optional(),
+  inputFile: z.string().optional(),
+  referenceFile: z.string().optional(),
+  auxiliaryFile: z.string().optional(),
+  mediaFile: z.string().optional(),
+  inputFiles: z.array(z.string()).optional(),
+  referenceFiles: z.array(z.string()).optional(),
+  auxiliaryFiles: z.array(z.string()).optional(),
+  mediaFiles: z.array(z.string()).optional(),
+  outputFiles: z.array(z.string()).optional(),
+}).merge(WithFileActiveFlags);
+
+export type PolishInstructionMessage = z.infer<
+  typeof PolishInstructionMessageSchema
+>;
 
 /**
  * Clipboard image message from webview
  */
-export interface ClipboardImageMessage {
-  command: string;
-  base64: string;
-  mediaType: string;
-  fileName: string;
-}
+export const ClipboardImageMessageSchema = BaseMessageSchema.extend({
+  base64: z.string(),
+  mediaType: z.string(),
+  fileName: z.string(),
+});
+
+export type ClipboardImageMessage = z.infer<typeof ClipboardImageMessageSchema>;
 
 /**
  * File selection message from webview
  */
-export interface FileSelectionMessage {
-  command: string;
-}
+export const FileSelectionMessageSchema = BaseMessageSchema;
+
+export type FileSelectionMessage = z.infer<typeof FileSelectionMessageSchema>;
 
 /**
  * Input file selected message from webview
  */
-export interface InputFileSelectedMessage {
-  command: string;
-  filePath: string;
-}
+export const InputFileSelectedMessageSchema =
+  BaseMessageSchema.merge(WithFilePath);
+
+export type InputFileSelectedMessage = z.infer<
+  typeof InputFileSelectedMessageSchema
+>;
 
 /**
  * Generic file selected message from webview
  */
-export interface GenericFileSelectedMessage {
-  command: string;
-  filePath: string;
-}
+export const GenericFileSelectedMessageSchema =
+  BaseMessageSchema.merge(WithFilePath);
+
+export type GenericFileSelectedMessage = z.infer<
+  typeof GenericFileSelectedMessageSchema
+>;
 
 /**
  * Request input file message from webview
  */
-export interface RequestInputFileMessage {
-  command: string;
-  notifyWhenEmpty?: boolean;
-}
+export const RequestInputFileMessageSchema =
+  BaseMessageSchema.merge(WithNotifyWhenEmpty);
+
+export type RequestInputFileMessage = z.infer<
+  typeof RequestInputFileMessageSchema
+>;
 
 /**
  * Request file message from webview
  */
-export interface RequestFileMessage {
-  command: string;
-  notifyWhenEmpty?: boolean;
-}
+export const RequestFileMessageSchema =
+  BaseMessageSchema.merge(WithNotifyWhenEmpty);
+
+export type RequestFileMessage = z.infer<typeof RequestFileMessageSchema>;
 
 /**
  * Request edited file message from webview
  */
-export interface RequestEditedFileMessage {
-  command: string;
-  baseFile?: string;
-  notifyWhenEmpty?: boolean;
-}
+export const RequestEditedFileMessageSchema = BaseMessageSchema.merge(
+  WithNotifyWhenEmpty,
+).extend({
+  baseFile: z.string().optional(),
+});
+
+export type RequestEditedFileMessage = z.infer<
+  typeof RequestEditedFileMessageSchema
+>;
 
 /**
  * Request base file message from webview
  */
-export interface RequestBaseFileMessage {
-  command: string;
-  notifyWhenEmpty?: boolean;
-  preserveBaseFile?: boolean;
-}
+export const RequestBaseFileMessageSchema = BaseMessageSchema.merge(
+  WithNotifyWhenEmpty,
+).extend({
+  preserveBaseFile: z.boolean().optional(),
+});
+
+export type RequestBaseFileMessage = z.infer<
+  typeof RequestBaseFileMessageSchema
+>;
 
 /**
  * Request default output files message from webview
  */
-export interface RequestDefaultOutputFilesMessage {
-  command: string;
-  agent?: string;
-}
+export const RequestDefaultOutputFilesMessageSchema = BaseMessageSchema.extend({
+  agent: z.string().optional(),
+});
+
+export type RequestDefaultOutputFilesMessage = z.infer<
+  typeof RequestDefaultOutputFilesMessageSchema
+>;
 
 /**
  * Set multiple files message from webview
  */
-export interface SetMultipleFilesMessage {
-  command: string;
-  files?: string[];
-}
+export const SetMultipleFilesMessageSchema =
+  BaseMessageSchema.merge(WithFiles);
+
+export type SetMultipleFilesMessage = z.infer<
+  typeof SetMultipleFilesMessageSchema
+>;
 
 /**
  * Select multiple files message from webview
  */
-export interface SelectMultipleFilesMessage {
-  command: string;
-  fileType: string;
-  currentFile?: string;
-}
+export const SelectMultipleFilesMessageSchema = BaseMessageSchema.extend({
+  fileType: z.string(),
+  currentFile: z.string().optional(),
+});
+
+export type SelectMultipleFilesMessage = z.infer<
+  typeof SelectMultipleFilesMessageSchema
+>;
 
 /**
  * Get current file message from webview
  */
-export interface GetCurrentFileMessage {
-  command: string;
-  fileType?: string;
-  baseFile?: string;
-}
+export const GetCurrentFileMessageSchema = BaseMessageSchema.extend({
+  fileType: z.string().optional(),
+  baseFile: z.string().optional(),
+});
+
+export type GetCurrentFileMessage = z.infer<typeof GetCurrentFileMessageSchema>;
 
 /**
  * Update files message from webview
  */
-export interface UpdateFilesMessage {
-  command: string;
-  files?: string[];
-}
+export const UpdateFilesMessageSchema = BaseMessageSchema.merge(WithFiles);
+
+export type UpdateFilesMessage = z.infer<typeof UpdateFilesMessageSchema>;


### PR DESCRIPTION
- Move StreamStatus and StreamStatusOrReady type definitions to
  common/constants/streamStatus.ts
- Update ProgressEventBus to import and re-export from common
- Clean up redundant type aliases in progressView/events/types.ts
- Update StreamStatusService to import types from the source

This eliminates duplicate type definitions and ensures consistency
between the active states (StreamStatus) and all states including
'ready' (StreamStatusOrReady).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Consolidates stream status types into a common source, introduces Zod-based schemas for usage, results, messages, and persistence helpers, and refactors handlers/managers to use validated types.
> 
> - **Stream status consolidation**
>   - Move `StreamStatus` to `@common/constants/streamStatus` and use it across agent, event bus, and progress view (`updateStreamStatus` now strictly `StreamStatus`).
>   - Remove redundant status aliases in progress view events/types; update `WebviewUpdater`/`ProgressEventHandler`/`StreamStatusService` to new types.
> - **Zod schemas and type safety**
>   - Add schemas: `UsageProviderSchema`, `NormalizedUsageSchema`, `FileOpStatusSchema`, `ExtendedTokenUsageStatsSchema`.
>   - Introduce webview message schemas and derive types (`src/webview/types/messages.ts`).
>   - Add `BaseViewMessageHandler.withValidatedMessage` and refactor History/Profile/Progress handlers to validate inputs.
> - **Persistence schema utilities**
>   - Add `schemaUtils` (`RoundKeySchema`, `createRoundMapSchema`, `createRunMapSchema`, `createSingleValueRunMapSchema`).
>   - Refactor `OutputFilesManager` and `UsageStatsManager` to use new schemas for run/round maps and usage parsing; streamline legacy handling.
> - **Misc**
>   - Minor typing cleanups and stricter payloads in `ProgressEventBus`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f471b31cd36dceeeb4ed62b96ebbd5eb64f41369. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->