### PR TITLE
refactor: consolidate payload structures with Zod schemas

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,6 +79,16 @@ Key directories in `src/`:
 - `tests/` - Test commands
 - `wolfram/` - Wolfram Alpha queries and script utilities
 
+### Schema and Type Guidelines
+
+Use Zod schemas as the single source of truth for data structures:
+
+- **Define schemas first**, then derive TypeScript types using `z.infer<typeof Schema>`
+- **Use schema composition** (`.extend()`, `.pick()`) instead of duplicating field definitions
+- **Avoid `z.custom<T>()`** when a proper schema exists—prefer `z.discriminatedUnion()` for union types
+- **Co-locate types with schemas** in the same file for maintainability
+- **Add compile-time assertions** (using `satisfies`) when schemas must stay synchronized with external types
+
 ### Path Aliases
 
 Common aliases (full list in `tsconfig.json`):

--- a/src/agent/core/AgentState.ts
+++ b/src/agent/core/AgentState.ts
@@ -2,13 +2,15 @@
 import { z } from 'zod';
 
 // Local imports - response usage types
-import type {
-  NormalizedUsage,
-  UsageProvider,
+import {
+  NormalizedUsageSchema,
+  UsageProviderSchema,
+  type NormalizedUsage,
+  type UsageProvider,
 } from '@agent/types/NormalizedUsage';
 import {
   RunUsageAccumulator,
-  type RunUsageAccumulatorJSON,
+  RunUsageAccumulatorJSONSchema,
   type UsageSummary,
   type NativeUsagePayload,
 } from './RunUsageAccumulator';
@@ -104,11 +106,11 @@ export const ConversationRoundStateSnapshotSchema = z.object({
   responseTimeMs: z.number().nonnegative(),
   outputFile: z.string(),
   // New: store normalized usage directly (nullish for backward compat with old saved states)
-  normalizedUsage: z.custom<NormalizedUsage>().nullish(),
+  normalizedUsage: NormalizedUsageSchema.nullish(),
   // Legacy fields for backward compatibility (deprecated)
   usageSummary: z.custom<UsageSummary>().nullable().optional(),
   nativeUsage: z.custom<NativeUsagePayload>().nullable().optional(),
-  provider: z.custom<UsageProvider>().nullable().optional(),
+  provider: UsageProviderSchema.nullable().optional(),
 });
 
 /**
@@ -194,7 +196,7 @@ export class ConversationRoundState {
 export const AgentRunStateSnapshotSchema = z.object({
   totalRounds: z.int().nonnegative(),
   totalResponseTimeMs: z.number().nonnegative(),
-  usageAccumulator: z.custom<RunUsageAccumulatorJSON>(),
+  usageAccumulator: RunUsageAccumulatorJSONSchema,
 });
 
 /**

--- a/src/agent/core/RunUsageAccumulator.ts
+++ b/src/agent/core/RunUsageAccumulator.ts
@@ -1,7 +1,11 @@
+// Third-party imports
+import { z } from 'zod';
+
 // Local imports - types
-import type {
-  NormalizedUsage,
-  UsageProvider,
+import {
+  NormalizedUsageSchema,
+  type NormalizedUsage,
+  type UsageProvider,
 } from '@agent/types/NormalizedUsage';
 
 // Re-export for backwards compatibility (used in AgentState legacy schema)
@@ -13,52 +17,55 @@ import type {
 
 export type { NativeUsagePayload };
 
-/**
- * @deprecated Used only for legacy JSON deserialization
- */
+/** @deprecated Used only for legacy JSON deserialization */
 export type UsageSummary =
   | OpenAIAPIResponseUsage
   | AnthropicAPIResponseUsage
   | null;
 
-/**
- * @deprecated Legacy snapshot format - used only for migration
- */
+/** @deprecated Legacy snapshot format - used only for migration */
 interface LegacyNativeUsageSnapshot {
   round: number;
   provider: string;
   payload: unknown;
 }
 
-/**
- * Snapshot of normalized usage for a single round.
- */
-export interface NormalizedUsageSnapshot {
-  round: number;
-  usage: NormalizedUsage;
-}
+/** Schema for run usage totals */
+export const RunUsageTotalsSchema = z.object({
+  firstInputTokens: z.number(),
+  totalInputTokens: z.number(),
+  totalOutputTokens: z.number(),
+  totalCost: z.number(),
+  totalCacheReadInputTokens: z.number(),
+  totalCacheCreationInputTokens: z.number(),
+  totalReasoningTokens: z.number(),
+  totalToolUsePromptTokens: z.number(),
+  totalServerToolRequests: z.number(),
+});
+export type RunUsageTotals = z.infer<typeof RunUsageTotalsSchema>;
 
-export interface RunUsageTotals {
-  firstInputTokens: number;
-  totalInputTokens: number;
-  totalOutputTokens: number;
-  totalCost: number;
-  totalCacheReadInputTokens: number;
-  totalCacheCreationInputTokens: number;
-  totalReasoningTokens: number;
-  totalToolUsePromptTokens: number;
-  totalServerToolRequests: number;
-}
+/** Schema for normalized usage snapshot */
+export const NormalizedUsageSnapshotSchema = z.object({
+  round: z.number(),
+  usage: NormalizedUsageSchema,
+});
+export type NormalizedUsageSnapshot = z.infer<
+  typeof NormalizedUsageSnapshotSchema
+>;
 
-export interface RunUsageAccumulatorJSON {
-  totals: Partial<RunUsageTotals> & {
+/** Schema for RunUsageAccumulator JSON serialization */
+export const RunUsageAccumulatorJSONSchema = z.object({
+  totals: RunUsageTotalsSchema.partial().extend({
     /** @deprecated Legacy field name */
-    totalToolUseTokens?: number;
-  };
-  normalizedSnapshots?: NormalizedUsageSnapshot[];
+    totalToolUseTokens: z.number().optional(),
+  }),
+  normalizedSnapshots: z.array(NormalizedUsageSnapshotSchema).optional(),
   /** @deprecated Legacy format - ignored on load */
-  snapshots?: unknown[];
-}
+  snapshots: z.array(z.unknown()).optional(),
+});
+export type RunUsageAccumulatorJSON = z.infer<
+  typeof RunUsageAccumulatorJSONSchema
+>;
 
 const DEFAULT_TOTALS: RunUsageTotals = {
   firstInputTokens: 0,

--- a/src/agent/output/types.ts
+++ b/src/agent/output/types.ts
@@ -3,8 +3,12 @@ import { z } from 'zod';
 
 // Local imports - agent
 import { DiffStatsSchema } from '@agent/types/DiffTypes';
-// Re-export FileLocation from its source of truth
-import type { FileLocation, AgentFileLocation } from '@utils/files';
+// Re-export FileLocation types and schemas from source of truth
+import {
+  FileLocationSchema,
+  type FileLocation,
+  type AgentFileLocation,
+} from '@utils/files';
 export type { FileLocation, AgentFileLocation };
 
 // ============================================================================
@@ -14,11 +18,11 @@ export type { FileLocation, AgentFileLocation };
 /**
  * Minimal output file reference - just source name + location.
  * Location contains all path variants (absolute, relative, workspace).
- * Note: FileLocation type is imported from @utils/files (not defined here)
+ * Uses FileLocationSchema for proper validation.
  */
 export const OutputFileSchema = z.strictObject({
   source: z.string(),
-  location: z.custom<FileLocation>(),
+  location: FileLocationSchema,
 });
 
 /**
@@ -28,11 +32,11 @@ export const OutputFileSchema = z.strictObject({
  */
 export const FileLineageSchema = z.strictObject({
   /** Original location before any agent processing */
-  original: z.custom<FileLocation>().nullable(),
+  original: FileLocationSchema.nullable(),
   /** What file to diff against (base/previous round, computed by getEffectiveBaseFile) */
-  diffBase: z.custom<FileLocation>().nullable(),
+  diffBase: FileLocationSchema.nullable(),
   /** Generated diff file location (if latexdiff was run) */
-  diffFile: z.custom<FileLocation>().nullable(),
+  diffFile: FileLocationSchema.nullable(),
 });
 
 /**
@@ -44,7 +48,7 @@ export const FileLineageSchema = z.strictObject({
  */
 export const OutputFileInfoSchema = z.strictObject({
   source: z.string(),
-  location: z.custom<FileLocation>(),
+  location: FileLocationSchema,
   lineage: FileLineageSchema.nullable(),
   diff: DiffStatsSchema.nullable(),
 });
@@ -67,7 +71,7 @@ const RawOutputXmlSummarySchema = z.strictObject({
     .optional(),
   documents: z.array(z.string()).optional(),
   singleOutputFile: z.string().nullable(),
-  sourceLocation: z.custom<FileLocation>().nullable(),
+  sourceLocation: FileLocationSchema.nullable(),
 });
 
 export const OutputXmlSummarySchema = RawOutputXmlSummarySchema.transform(
@@ -95,7 +99,7 @@ export type OutputXmlSummary = z.infer<typeof OutputXmlSummarySchema>;
  */
 export const RoundOutputSchema = z.strictObject({
   round: z.number(),
-  rawOutput: z.custom<FileLocation>().nullable(),
+  rawOutput: FileLocationSchema.nullable(),
   outputs: OutputFileInfoSchema.array(),
   xmlSummary: OutputXmlSummarySchema,
 });

--- a/src/agent/output/types.ts
+++ b/src/agent/output/types.ts
@@ -64,9 +64,15 @@ export const RoundOutputSchema = z.strictObject({
 });
 export type RoundOutput = z.infer<typeof RoundOutputSchema>;
 
-/** Internal mapping structure for file relationships (used by OutputHandler) */
+/**
+ * Internal mapping for file relationships (used by OutputHandler).
+ * All maps are indexed by OUTPUT path for efficient lineage lookup.
+ */
 export interface RoundFileMapping {
+  /** Output path → base FileLocation (for round-based diffs) */
   baseToOutput: Map<string, FileLocation>;
+  /** Output path → previous round FileLocation (for inter-round diffs) */
   prevToOutput: Map<string, FileLocation>;
+  /** Output path → original base FileLocation (for tracking lineage) */
   originByOutput: Map<string, FileLocation | undefined>;
 }

--- a/src/agent/output/types.ts
+++ b/src/agent/output/types.ts
@@ -1,9 +1,8 @@
-// Third-party imports
+/**
+ * Output file schemas. Types derived from schemas for single source of truth.
+ */
 import { z } from 'zod';
-
-// Local imports - agent
 import { DiffStatsSchema } from '@agent/types/DiffTypes';
-// Re-export FileLocation types and schemas from source of truth
 import {
   FileLocationSchema,
   type FileLocation,
@@ -11,60 +10,32 @@ import {
 } from '@utils/files';
 export type { FileLocation, AgentFileLocation };
 
-// ============================================================================
-// OUTPUT FILE SCHEMAS (types derived via z.infer)
-// ============================================================================
-
-/**
- * Minimal output file reference - just source name + location.
- * Location contains all path variants (absolute, relative, workspace).
- * Uses FileLocationSchema for proper validation.
- */
+/** Minimal output file reference - source name + location */
 export const OutputFileSchema = z.strictObject({
   source: z.string(),
   location: FileLocationSchema,
 });
 
-/**
- * File lineage - tracks where files came from and what to compare against.
- * Uses full FileLocation objects (not split across string + location fields).
- * Fields are nullable to support cases where lineage doesn't exist.
- */
+/** File lineage - tracks where files came from */
 export const FileLineageSchema = z.strictObject({
-  /** Original location before any agent processing */
   original: FileLocationSchema.nullable(),
-  /** What file to diff against (base/previous round, computed by getEffectiveBaseFile) */
   diffBase: FileLocationSchema.nullable(),
-  /** Generated diff file location (if latexdiff was run) */
   diffFile: FileLocationSchema.nullable(),
 });
 
-/**
- * Complete output file metadata.
- * - source: Document name (e.g., "main.tex")
- * - location: Where the file is (has all path variants)
- * - lineage: Where it came from (base/previous/original)
- * - diff: Line changes vs base
- */
-export const OutputFileInfoSchema = z.strictObject({
-  source: z.string(),
-  location: FileLocationSchema,
+/** Complete output file metadata (extends OutputFileSchema) */
+export const OutputFileInfoSchema = OutputFileSchema.extend({
   lineage: FileLineageSchema.nullable(),
   diff: DiffStatsSchema.nullable(),
 });
 
 export const OutputFileInfoListSchema = OutputFileInfoSchema.array();
 
-// Derive types from schemas (Zod v4)
-// Note: FileLocation is imported from @utils/files, not derived here
 export type OutputFile = z.infer<typeof OutputFileSchema>;
 export type FileLineage = z.infer<typeof FileLineageSchema>;
 export type OutputFileInfo = z.infer<typeof OutputFileInfoSchema>;
 
-// ============================================================================
-// XML SUMMARY SCHEMAS
-// ============================================================================
-
+/** XML summary with defaults applied via transform */
 const RawOutputXmlSummarySchema = z.strictObject({
   tagContents: z
     .record(z.string(), z.union([z.string(), z.array(z.string())]))
@@ -82,53 +53,20 @@ export const OutputXmlSummarySchema = RawOutputXmlSummarySchema.transform(
     sourceLocation: value.sourceLocation ?? null,
   }),
 );
-
-// Derive type from schema (Zod v4)
 export type OutputXmlSummary = z.infer<typeof OutputXmlSummarySchema>;
 
-// ============================================================================
-// ROUND OUTPUT SCHEMAS
-// ============================================================================
-
-/**
- * Output from processing a conversation round.
- * - round: Round number
- * - rawOutput: The XML file the LLM wrote (before extraction)
- * - outputs: Extracted output files with metadata
- * - xmlSummary: Parsed XML metadata (TODO: Can this be simplified/removed?)
- */
+/** Output from processing a conversation round */
 export const RoundOutputSchema = z.strictObject({
   round: z.number(),
   rawOutput: FileLocationSchema.nullable(),
   outputs: OutputFileInfoSchema.array(),
   xmlSummary: OutputXmlSummarySchema,
 });
-
-// Derive type from schema (Zod v4)
 export type RoundOutput = z.infer<typeof RoundOutputSchema>;
 
-// ============================================================================
-// INTERNAL MAPPING SCHEMAS (used by OutputHandler)
-// ============================================================================
-
-/**
- * Internal mapping structure for file relationships.
- * Uses string keys (comparable paths) for robust lookups and FileLocation values for data.
- * This ensures lookups work even when FileLocation objects are reconstructed.
- *
- * All maps are indexed by OUTPUT path for efficient lineage lookup during gatherOutputFileInfo.
- */
+/** Internal mapping structure for file relationships (used by OutputHandler) */
 export interface RoundFileMapping {
-  /** Maps output file path to its corresponding base FileLocation (for round-based diffs) */
   baseToOutput: Map<string, FileLocation>;
-  /** Maps output file path to its previous round FileLocation (for inter-round diffs) */
   prevToOutput: Map<string, FileLocation>;
-  /** Maps output file path to its original base FileLocation (for tracking lineage) */
   originByOutput: Map<string, FileLocation | undefined>;
 }
-
-// ============================================================================
-// LEGACY TYPES REMOVED
-// ============================================================================
-// NamedOutputFile has been eliminated. Use OutputFileInfo instead.
-// OutputFileInfo contains all necessary information without duplicate fields.

--- a/src/agent/types/IdentifierTypes.ts
+++ b/src/agent/types/IdentifierTypes.ts
@@ -22,10 +22,11 @@ export type StreamTabId = z.infer<typeof StreamTabIdSchema>;
 export const ExecutionIdSchema = z.string().uuid();
 export type ExecutionId = z.infer<typeof ExecutionIdSchema>;
 
-/** THE key for storage operations. Branded type for compile-time safety. */
+/** Valid storage key: UUID or '__default__' for legacy */
+const STORAGE_KEY_PATTERN = /^(__default__|[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$/i;
 export const StorageKeySchema = z
   .string()
-  .min(1)
+  .regex(STORAGE_KEY_PATTERN, 'Invalid storage key: must be UUID or __default__')
   .transform((val) => val as StorageKey);
 export type StorageKey = string & { readonly __brand: 'StorageKey' };
 

--- a/src/agent/types/IdentifierTypes.ts
+++ b/src/agent/types/IdentifierTypes.ts
@@ -40,14 +40,9 @@ export type StorageKey = string & { readonly __brand: 'StorageKey' };
  * - storageKey: THE key for storage (files, usage, artifacts)
  * - streamTabId: UI tab identifier
  */
-export interface ExecutionIdentity {
-  readonly executionId: ExecutionId;
-  readonly storageKey: StorageKey;
-  readonly streamTabId: StreamTabId;
-}
-
 export const ExecutionIdentitySchema = z.strictObject({
   executionId: ExecutionIdSchema,
   storageKey: StorageKeySchema,
   streamTabId: StreamTabIdSchema,
 });
+export type ExecutionIdentity = z.infer<typeof ExecutionIdentitySchema>;

--- a/src/agent/types/IdentifierTypes.ts
+++ b/src/agent/types/IdentifierTypes.ts
@@ -1,3 +1,6 @@
+// Third-party imports
+import { z } from 'zod';
+
 /**
  * # Identifier Types and Execution Model
  *
@@ -31,6 +34,10 @@
  * @see ExecutionIdentity for the unified identity interface
  */
 
+// ============================================================================
+// IDENTIFIER SCHEMAS (types derived via z.infer)
+// ============================================================================
+
 /**
  * Stream Tab ID: Human-readable identifier used for UI tabs and execution deduplication
  * Format: "${agentName}@${modelName}: ${inputFileName}"
@@ -41,7 +48,8 @@
  * - Prevents duplicate executions of the same task
  * - Used for logging channel identification
  */
-export type StreamTabId = string;
+export const StreamTabIdSchema = z.string().min(1);
+export type StreamTabId = z.infer<typeof StreamTabIdSchema>;
 
 /**
  * Execution ID: Unique UUID for each execution instance
@@ -55,7 +63,8 @@ export type StreamTabId = string;
  *
  * Note: ExecutionId is ALWAYS a UUID, never null or DEFAULT_RUN_ID.
  */
-export type ExecutionId = string;
+export const ExecutionIdSchema = z.string().uuid();
+export type ExecutionId = z.infer<typeof ExecutionIdSchema>;
 
 /**
  * Storage Key: THE key for storing and retrieving files, usage, and other artifacts.
@@ -72,7 +81,13 @@ export type ExecutionId = string;
  *
  * This is a branded type for compile-time safety - you cannot accidentally
  * pass a random string where a StorageKey is expected.
+ *
+ * The schema validates non-empty strings and brands them at runtime.
  */
+export const StorageKeySchema = z
+  .string()
+  .min(1)
+  .transform((val) => val as StorageKey);
 export type StorageKey = string & { readonly __brand: 'StorageKey' };
 
 /**
@@ -119,3 +134,13 @@ export interface ExecutionIdentity {
   /** The UI tab identifier */
   readonly streamTabId: StreamTabId;
 }
+
+/**
+ * Schema for ExecutionIdentity - validates all identifier fields.
+ * Note: Uses the individual identifier schemas for proper validation.
+ */
+export const ExecutionIdentitySchema = z.strictObject({
+  executionId: ExecutionIdSchema,
+  storageKey: StorageKeySchema,
+  streamTabId: StreamTabIdSchema,
+});

--- a/src/agent/types/IdentifierTypes.ts
+++ b/src/agent/types/IdentifierTypes.ts
@@ -1,89 +1,28 @@
-// Third-party imports
-import { z } from 'zod';
-
 /**
- * # Identifier Types and Execution Model
+ * Identifier Types and Execution Model
  *
- * TeXRA uses a unified identity model to track executions, eliminating
- * confusion about which ID to use for storage and lookup.
+ * Identity hierarchy:
+ *   StreamTabId (UI tab, human-readable)
+ *     └── ExecutionIdentity
+ *           ├── executionId (unique instance, always UUID)
+ *           └── storageKey (THE key for files/usage storage)
  *
- * ## Identity Hierarchy
- * ```
- * StreamTabId (UI tab, human-readable)
- *   └── ExecutionIdentity
- *         ├── executionId (unique instance, always UUID)
- *         └── storageKey (THE key for files/usage storage)
- * ```
- *
- * ## Single Source of Truth: StorageKey
- *
- * The storageKey is computed ONCE at execution start and used everywhere:
- * - Workflow agents: storageKey = task group ID (set when group is created)
- * - Tool-use agents: storageKey = executionId (no task groups)
- *
- * This eliminates:
- * - Runtime ID resolution at every call site
- * - Dual-lookup paths in storage managers
- * - "Which ID do I use?" confusion
- *
- * ## Key Invariants
+ * Key invariants:
  * - ExecutionId is ALWAYS a UUID (never null, never DEFAULT_RUN_ID)
  * - StorageKey is ALWAYS a valid key (UUID or DEFAULT_RUN_ID for legacy)
  * - StreamTabId is human-readable and stable across executions
- *
- * @see ExecutionIdentity for the unified identity interface
  */
+import { z } from 'zod';
 
-// ============================================================================
-// IDENTIFIER SCHEMAS (types derived via z.infer)
-// ============================================================================
-
-/**
- * Stream Tab ID: Human-readable identifier used for UI tabs and execution deduplication
- * Format: "${agentName}@${modelName}: ${inputFileName}"
- * Example: "polish@sonnet37: paper.tex"
- *
- * Purpose:
- * - Primary key for UI stream tabs
- * - Prevents duplicate executions of the same task
- * - Used for logging channel identification
- */
+/** Human-readable ID for UI tabs. Format: "${agentName}@${modelName}: ${inputFileName}" */
 export const StreamTabIdSchema = z.string().min(1);
 export type StreamTabId = z.infer<typeof StreamTabIdSchema>;
 
-/**
- * Execution ID: Unique UUID for each execution instance
- * Format: UUID v4
- * Example: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
- *
- * Purpose:
- * - Links executions to history entries (created by AgentHistoryManager)
- * - Enables tracking of multiple executions of the same task
- * - Used for audit and debugging purposes
- *
- * Note: ExecutionId is ALWAYS a UUID, never null or DEFAULT_RUN_ID.
- */
+/** Unique UUID for each execution instance */
 export const ExecutionIdSchema = z.string().uuid();
 export type ExecutionId = z.infer<typeof ExecutionIdSchema>;
 
-/**
- * Storage Key: THE key for storing and retrieving files, usage, and other artifacts.
- *
- * This is the single source of truth for storage operations:
- * - Workflow agents: This is the task group ID from the logger hierarchy
- * - Tool-use agents: This equals the ExecutionId (no task groups)
- * - Legacy sessions: This is DEFAULT_RUN_ID ("__default__")
- *
- * The storageKey is computed ONCE at execution start (or when a task group
- * is created for workflow agents) and never changes during execution.
- *
- * Use ExecutionIdentity.storageKey to get this value - never compute it manually.
- *
- * This is a branded type for compile-time safety - you cannot accidentally
- * pass a random string where a StorageKey is expected.
- *
- * The schema validates non-empty strings and brands them at runtime.
- */
+/** THE key for storage operations. Branded type for compile-time safety. */
 export const StorageKeySchema = z
   .string()
   .min(1)
@@ -92,53 +31,16 @@ export type StorageKey = string & { readonly __brand: 'StorageKey' };
 
 /**
  * Unified identity for an execution - computed once, used everywhere.
- *
- * This interface eliminates "which ID should I use?" confusion by providing:
- * - executionId: The unique execution instance (for history, audit, metadata)
- * - storageKey: THE key for storage operations (files, usage, artifacts)
- * - streamTabId: The UI tab identifier
- *
- * ## Usage
- *
- * Components receive ExecutionIdentity in their constructor or method parameters
- * instead of computing IDs themselves:
- *
- * ```typescript
- * class OutputHandler {
- *   constructor(private readonly identity: ExecutionIdentity) {}
- *
- *   emit(files: OutputFileInfo[]): void {
- *     bus.emit('addOutputFiles', {
- *       stream: this.identity.streamTabId,
- *       storageKey: this.identity.storageKey,  // THE key
- *       executionId: this.identity.executionId, // For metadata
- *       files,
- *     });
- *   }
- * }
- * ```
- *
- * ## Workflow vs Tool-Use
- *
- * - Workflow agents call `updateStorageKey()` when they create their first
- *   task group, setting storageKey to the task group ID
- * - Tool-use agents use executionId as storageKey (no task groups exist)
+ * - executionId: unique instance (for history, audit)
+ * - storageKey: THE key for storage (files, usage, artifacts)
+ * - streamTabId: UI tab identifier
  */
 export interface ExecutionIdentity {
-  /** The unique execution instance ID (always UUID) */
   readonly executionId: ExecutionId;
-
-  /** THE key for storage operations (files, usage, artifacts) */
   readonly storageKey: StorageKey;
-
-  /** The UI tab identifier */
   readonly streamTabId: StreamTabId;
 }
 
-/**
- * Schema for ExecutionIdentity - validates all identifier fields.
- * Note: Uses the individual identifier schemas for proper validation.
- */
 export const ExecutionIdentitySchema = z.strictObject({
   executionId: ExecutionIdSchema,
   storageKey: StorageKeySchema,

--- a/src/agent/types/IdentifierTypes.ts
+++ b/src/agent/types/IdentifierTypes.ts
@@ -23,10 +23,14 @@ export const ExecutionIdSchema = z.string().uuid();
 export type ExecutionId = z.infer<typeof ExecutionIdSchema>;
 
 /** Valid storage key: UUID or '__default__' for legacy */
-const STORAGE_KEY_PATTERN = /^(__default__|[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$/i;
+const STORAGE_KEY_PATTERN =
+  /^(__default__|[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$/i;
 export const StorageKeySchema = z
   .string()
-  .regex(STORAGE_KEY_PATTERN, 'Invalid storage key: must be UUID or __default__')
+  .regex(
+    STORAGE_KEY_PATTERN,
+    'Invalid storage key: must be UUID or __default__',
+  )
   .transform((val) => val as StorageKey);
 export type StorageKey = string & { readonly __brand: 'StorageKey' };
 

--- a/src/common/constants/streamStatus.ts
+++ b/src/common/constants/streamStatus.ts
@@ -1,33 +1,17 @@
-// Third-party imports
-import { z } from 'zod';
-
 /**
  * Stream status constants shared across agent runtime and UI layers.
- *
- * These constants define the possible states of an agent execution stream.
- * Moved from progressView to common to break the layer violation where
- * agent runtime was importing from the presentation layer.
  */
+import { z } from 'zod';
 
 export const STREAM_STATUS = {
-  /** Agent is actively processing. */
   RUNNING: 'running',
-  /** Agent encountered an error. */
   ERROR: 'error',
-  /** Agent was stopped by user request. */
   STOPPED: 'stopped',
-  /** Agent completed and is ready for new tasks. */
   READY: 'ready',
-  /** Agent is waiting for user input or external resource. */
   WAITING: 'waiting',
-  /** Agent is resuming from a previous session. */
   RESUMING: 'resuming',
 } as const;
 
-/**
- * Schema for stream status validation.
- * Ensures only valid status values are accepted.
- */
 export const StreamStatusSchema = z.enum([
   STREAM_STATUS.RUNNING,
   STREAM_STATUS.ERROR,
@@ -37,8 +21,4 @@ export const StreamStatusSchema = z.enum([
   STREAM_STATUS.RESUMING,
 ]);
 
-/**
- * All possible stream states.
- * Derived from STREAM_STATUS constant to maintain single source of truth.
- */
 export type StreamStatus = z.infer<typeof StreamStatusSchema>;

--- a/src/common/constants/streamStatus.ts
+++ b/src/common/constants/streamStatus.ts
@@ -1,3 +1,6 @@
+// Third-party imports
+import { z } from 'zod';
+
 /**
  * Stream status constants shared across agent runtime and UI layers.
  *
@@ -22,7 +25,20 @@ export const STREAM_STATUS = {
 } as const;
 
 /**
+ * Schema for stream status validation.
+ * Ensures only valid status values are accepted.
+ */
+export const StreamStatusSchema = z.enum([
+  STREAM_STATUS.RUNNING,
+  STREAM_STATUS.ERROR,
+  STREAM_STATUS.STOPPED,
+  STREAM_STATUS.READY,
+  STREAM_STATUS.WAITING,
+  STREAM_STATUS.RESUMING,
+]);
+
+/**
  * All possible stream states.
  * Derived from STREAM_STATUS constant to maintain single source of truth.
  */
-export type StreamStatus = (typeof STREAM_STATUS)[keyof typeof STREAM_STATUS];
+export type StreamStatus = z.infer<typeof StreamStatusSchema>;

--- a/src/eventBus/ProgressEventBus.ts
+++ b/src/eventBus/ProgressEventBus.ts
@@ -4,16 +4,11 @@ import { EventEmitter } from 'events';
 // Local imports - agent
 import type { AgentSessionDescriptor } from '@agent/core/AgentDataclass';
 import type { OutputFileInfo } from '@agent/output/types';
-import type { StreamTabId } from '@agent/types/IdentifierTypes';
+import type { StreamTabId, ExecutionId } from '@agent/types/IdentifierTypes';
 import type { TokenUsageStats } from '@agent/types/UsageTypes';
 import type { StreamStatus } from '@common/constants/streamStatus';
-import type {
-  LogMessageData,
-  LogMessageUpdate,
-  TaskGroup,
-} from '@logger/LogTypes';
+import type { LogMessageData, LogMessageUpdate } from '@logger/LogTypes';
 import type { TaskState } from '@logger/TaskState';
-// Import schemas and types from consolidated locations
 import type { ToolEditApprovalPrompt, RetryRequestPrompt } from './types';
 import type {
   AddTaskGroupPayload,
@@ -41,7 +36,7 @@ interface SetActiveStreamPayload {
 
 interface SetTaskStatePayload {
   streamTabId: StreamTabId;
-  executionId?: string;
+  executionId?: ExecutionId;
   taskState: TaskState;
 }
 

--- a/src/eventBus/ProgressEventBus.ts
+++ b/src/eventBus/ProgressEventBus.ts
@@ -4,11 +4,7 @@ import { EventEmitter } from 'events';
 // Local imports - agent
 import type { AgentSessionDescriptor } from '@agent/core/AgentDataclass';
 import type { OutputFileInfo } from '@agent/output/types';
-import type {
-  StreamTabId,
-  ExecutionId,
-  StorageKey,
-} from '@agent/types/IdentifierTypes';
+import type { StreamTabId } from '@agent/types/IdentifierTypes';
 import type { TokenUsageStats } from '@agent/types/UsageTypes';
 import type { StreamStatus } from '@common/constants/streamStatus';
 import type {
@@ -17,33 +13,27 @@ import type {
   TaskGroup,
 } from '@logger/LogTypes';
 import type { TaskState } from '@logger/TaskState';
+// Import schemas and types from consolidated locations
 import type { ToolEditApprovalPrompt, RetryRequestPrompt } from './types';
+import type {
+  AddTaskGroupPayload,
+  UpdateTaskGroupPayload,
+  RunScopedPayload,
+  TaskGroupStatus,
+} from './schemas';
 
 // Re-export for consumers that import from this module
 export type { StreamStatus };
 
+// Re-export schema types for consumers
+export type { TaskGroupStatus } from './schemas';
+
 // Maximum number of events to buffer when no listeners are registered
 const MAX_BUFFER_SIZE = 1000;
 
-export type TaskGroupStatus = TaskGroup['status'];
-
-interface AddTaskGroupPayload {
-  stream: StreamTabId;
-  groupId: string;
-  groupName: string;
-  startTime: number;
-  status: TaskGroupStatus;
-  endTime?: number;
-  parentGroupId?: string;
-}
-
-interface UpdateTaskGroupPayload {
-  stream: StreamTabId;
-  groupId: string;
-  status: TaskGroupStatus;
-  endTime?: number;
-}
-
+// SetActiveStreamPayload and SetTaskStatePayload are defined inline
+// because they reference types from external modules (AgentSessionDescriptor, TaskState)
+// that don't have schemas yet. These can be migrated when those modules are updated.
 interface SetActiveStreamPayload {
   stream: StreamTabId | null;
   session?: AgentSessionDescriptor | null;
@@ -51,21 +41,8 @@ interface SetActiveStreamPayload {
 
 interface SetTaskStatePayload {
   streamTabId: StreamTabId;
-  executionId?: ExecutionId;
+  executionId?: string;
   taskState: TaskState;
-}
-
-/**
- * Payload for storage-scoped events (files, usage, etc.).
- *
- * storageKey is THE key for storage operations - required for all events.
- */
-interface RunScopedPayload {
-  stream: StreamTabId;
-  /** THE key for storage operations. Required. */
-  storageKey: StorageKey;
-  /** For metadata/audit purposes */
-  executionId?: ExecutionId;
 }
 
 export interface ProgressEventPayloads {

--- a/src/eventBus/schemas.ts
+++ b/src/eventBus/schemas.ts
@@ -17,7 +17,7 @@ export {
   type RetryRequestPrompt,
 } from './types';
 
-/** Task group status values (matches TaskGroup['status'] from LogTypes) */
+/** Task group status (matches TaskGroup['status'] from LogTypes) */
 export const TaskGroupStatusSchema = z.enum([
   'running',
   'error',
@@ -38,12 +38,12 @@ export const AddTaskGroupPayloadSchema = z.strictObject({
 });
 export type AddTaskGroupPayload = z.infer<typeof AddTaskGroupPayloadSchema>;
 
-/** Payload for updating an existing task group */
-export const UpdateTaskGroupPayloadSchema = z.strictObject({
-  stream: StreamTabIdSchema,
-  groupId: z.string().min(1),
-  status: TaskGroupStatusSchema,
-  endTime: z.number().optional(),
+/** Payload for updating a task group (subset of AddTaskGroupPayload) */
+export const UpdateTaskGroupPayloadSchema = AddTaskGroupPayloadSchema.pick({
+  stream: true,
+  groupId: true,
+  status: true,
+  endTime: true,
 });
 export type UpdateTaskGroupPayload = z.infer<
   typeof UpdateTaskGroupPayloadSchema

--- a/src/eventBus/schemas.ts
+++ b/src/eventBus/schemas.ts
@@ -18,23 +18,10 @@ export {
   type RetryRequestPrompt,
 } from './types';
 
-/** Task group status - derived from TaskGroup['status'] */
-export const TaskGroupStatusSchema = z.enum([
-  'running',
-  'error',
-  'stopped',
-  'ready',
-]);
+/** Task group status - must match TaskGroup['status'] from LogTypes */
+const TASK_GROUP_STATUSES = ['running', 'error', 'stopped', 'ready'] as const satisfies readonly TaskGroup['status'][];
+export const TaskGroupStatusSchema = z.enum(TASK_GROUP_STATUSES);
 export type TaskGroupStatus = z.infer<typeof TaskGroupStatusSchema>;
-
-// Compile-time assertion: ensures TaskGroupStatus stays in sync with LogTypes
-type _AssertStatusMatch = TaskGroupStatus extends TaskGroup['status']
-  ? TaskGroup['status'] extends TaskGroupStatus
-    ? true
-    : never
-  : never;
-const _assertStatusMatch: _AssertStatusMatch = true;
-void _assertStatusMatch;
 
 /** Payload for adding a new task group */
 export const AddTaskGroupPayloadSchema = z.strictObject({

--- a/src/eventBus/schemas.ts
+++ b/src/eventBus/schemas.ts
@@ -1,25 +1,15 @@
 /**
  * Zod schemas for ProgressEventBus payloads.
- *
- * These schemas provide runtime validation for event payloads.
  * Types are derived from schemas for single source of truth.
- *
- * Note: Some payloads (SetActiveStreamPayload, SetTaskStatePayload) are
- * defined inline in ProgressEventBus.ts because they reference types
- * (AgentSessionDescriptor, TaskState) that don't have schemas yet.
  */
-
-// Third-party imports
 import { z } from 'zod';
-
-// Local imports - schemas
 import {
   StreamTabIdSchema,
   ExecutionIdSchema,
   StorageKeySchema,
 } from '@agent/types/IdentifierTypes';
 
-// Re-export for convenience
+// Re-export from types.ts (breaking circular dependency with progressView)
 export {
   ToolEditApprovalPromptSchema,
   RetryRequestPromptSchema,
@@ -27,14 +17,7 @@ export {
   type RetryRequestPrompt,
 } from './types';
 
-// ============================================================================
-// TASK GROUP SCHEMAS
-// ============================================================================
-
-/**
- * Valid task group status values.
- * Matches TaskGroup['status'] from LogTypes.
- */
+/** Task group status values (matches TaskGroup['status'] from LogTypes) */
 export const TaskGroupStatusSchema = z.enum([
   'running',
   'error',
@@ -43,9 +26,7 @@ export const TaskGroupStatusSchema = z.enum([
 ]);
 export type TaskGroupStatus = z.infer<typeof TaskGroupStatusSchema>;
 
-/**
- * Payload for adding a new task group.
- */
+/** Payload for adding a new task group */
 export const AddTaskGroupPayloadSchema = z.strictObject({
   stream: StreamTabIdSchema,
   groupId: z.string().min(1),
@@ -57,9 +38,7 @@ export const AddTaskGroupPayloadSchema = z.strictObject({
 });
 export type AddTaskGroupPayload = z.infer<typeof AddTaskGroupPayloadSchema>;
 
-/**
- * Payload for updating an existing task group.
- */
+/** Payload for updating an existing task group */
 export const UpdateTaskGroupPayloadSchema = z.strictObject({
   stream: StreamTabIdSchema,
   groupId: z.string().min(1),
@@ -70,19 +49,10 @@ export type UpdateTaskGroupPayload = z.infer<
   typeof UpdateTaskGroupPayloadSchema
 >;
 
-// ============================================================================
-// RUN-SCOPED SCHEMAS
-// ============================================================================
-
-/**
- * Base payload for storage-scoped events (files, usage, etc.).
- * storageKey is THE key for storage operations - required for all events.
- */
+/** Base payload for storage-scoped events (files, usage, etc.) */
 export const RunScopedPayloadSchema = z.strictObject({
   stream: StreamTabIdSchema,
-  /** THE key for storage operations. Required. */
   storageKey: StorageKeySchema,
-  /** For metadata/audit purposes */
   executionId: ExecutionIdSchema.optional(),
 });
 export type RunScopedPayload = z.infer<typeof RunScopedPayloadSchema>;

--- a/src/eventBus/schemas.ts
+++ b/src/eventBus/schemas.ts
@@ -19,7 +19,12 @@ export {
 } from './types';
 
 /** Task group status - must match TaskGroup['status'] from LogTypes */
-const TASK_GROUP_STATUSES = ['running', 'error', 'stopped', 'ready'] as const satisfies readonly TaskGroup['status'][];
+const TASK_GROUP_STATUSES = [
+  'running',
+  'error',
+  'stopped',
+  'ready',
+] as const satisfies readonly TaskGroup['status'][];
 export const TaskGroupStatusSchema = z.enum(TASK_GROUP_STATUSES);
 export type TaskGroupStatus = z.infer<typeof TaskGroupStatusSchema>;
 

--- a/src/eventBus/schemas.ts
+++ b/src/eventBus/schemas.ts
@@ -3,6 +3,10 @@
  *
  * These schemas provide runtime validation for event payloads.
  * Types are derived from schemas for single source of truth.
+ *
+ * Note: Some payloads (SetActiveStreamPayload, SetTaskStatePayload) are
+ * defined inline in ProgressEventBus.ts because they reference types
+ * (AgentSessionDescriptor, TaskState) that don't have schemas yet.
  */
 
 // Third-party imports
@@ -14,7 +18,6 @@ import {
   ExecutionIdSchema,
   StorageKeySchema,
 } from '@agent/types/IdentifierTypes';
-import { StreamStatusSchema } from '@common/constants/streamStatus';
 
 // Re-export for convenience
 export {
@@ -68,48 +71,6 @@ export type UpdateTaskGroupPayload = z.infer<
 >;
 
 // ============================================================================
-// STREAM SCHEMAS
-// ============================================================================
-
-/**
- * Payload for setting the active stream.
- * session is typed loosely here; full validation happens in consumers.
- */
-export const SetActiveStreamPayloadSchema = z.strictObject({
-  stream: StreamTabIdSchema.nullable(),
-  session: z.unknown().nullish(),
-});
-export type SetActiveStreamPayload = z.infer<
-  typeof SetActiveStreamPayloadSchema
->;
-
-/**
- * Payload for updating stream status.
- */
-export const UpdateStreamStatusPayloadSchema = z.strictObject({
-  stream: StreamTabIdSchema,
-  status: StreamStatusSchema,
-});
-export type UpdateStreamStatusPayload = z.infer<
-  typeof UpdateStreamStatusPayloadSchema
->;
-
-// ============================================================================
-// TASK STATE SCHEMAS
-// ============================================================================
-
-/**
- * Payload for setting task state.
- * taskState is typed loosely here; full validation happens in consumers.
- */
-export const SetTaskStatePayloadSchema = z.strictObject({
-  streamTabId: StreamTabIdSchema,
-  executionId: ExecutionIdSchema.optional(),
-  taskState: z.unknown(),
-});
-export type SetTaskStatePayload = z.infer<typeof SetTaskStatePayloadSchema>;
-
-// ============================================================================
 // RUN-SCOPED SCHEMAS
 // ============================================================================
 
@@ -125,37 +86,3 @@ export const RunScopedPayloadSchema = z.strictObject({
   executionId: ExecutionIdSchema.optional(),
 });
 export type RunScopedPayload = z.infer<typeof RunScopedPayloadSchema>;
-
-// ============================================================================
-// SIMPLE EVENT SCHEMAS
-// ============================================================================
-
-/**
- * Payload for resolving retry requests.
- */
-export const ResolveRetryRequestPayloadSchema = z.strictObject({
-  streamId: StreamTabIdSchema,
-});
-export type ResolveRetryRequestPayload = z.infer<
-  typeof ResolveRetryRequestPayloadSchema
->;
-
-/**
- * Payload for resolving tool edit approval prompts.
- */
-export const ResolveToolEditApprovalPayloadSchema = z.strictObject({
-  requestId: z.string().min(1),
-});
-export type ResolveToolEditApprovalPayload = z.infer<
-  typeof ResolveToolEditApprovalPayloadSchema
->;
-
-/**
- * Payload for updating tool edit approval bypass state.
- */
-export const UpdateToolEditApprovalBypassPayloadSchema = z.strictObject({
-  bypassActive: z.boolean(),
-});
-export type UpdateToolEditApprovalBypassPayload = z.infer<
-  typeof UpdateToolEditApprovalBypassPayloadSchema
->;

--- a/src/eventBus/schemas.ts
+++ b/src/eventBus/schemas.ts
@@ -1,0 +1,161 @@
+/**
+ * Zod schemas for ProgressEventBus payloads.
+ *
+ * These schemas provide runtime validation for event payloads.
+ * Types are derived from schemas for single source of truth.
+ */
+
+// Third-party imports
+import { z } from 'zod';
+
+// Local imports - schemas
+import {
+  StreamTabIdSchema,
+  ExecutionIdSchema,
+  StorageKeySchema,
+} from '@agent/types/IdentifierTypes';
+import { StreamStatusSchema } from '@common/constants/streamStatus';
+
+// Re-export for convenience
+export {
+  ToolEditApprovalPromptSchema,
+  RetryRequestPromptSchema,
+  type ToolEditApprovalPrompt,
+  type RetryRequestPrompt,
+} from './types';
+
+// ============================================================================
+// TASK GROUP SCHEMAS
+// ============================================================================
+
+/**
+ * Valid task group status values.
+ * Matches TaskGroup['status'] from LogTypes.
+ */
+export const TaskGroupStatusSchema = z.enum([
+  'running',
+  'error',
+  'stopped',
+  'ready',
+]);
+export type TaskGroupStatus = z.infer<typeof TaskGroupStatusSchema>;
+
+/**
+ * Payload for adding a new task group.
+ */
+export const AddTaskGroupPayloadSchema = z.strictObject({
+  stream: StreamTabIdSchema,
+  groupId: z.string().min(1),
+  groupName: z.string(),
+  startTime: z.number(),
+  status: TaskGroupStatusSchema,
+  endTime: z.number().optional(),
+  parentGroupId: z.string().optional(),
+});
+export type AddTaskGroupPayload = z.infer<typeof AddTaskGroupPayloadSchema>;
+
+/**
+ * Payload for updating an existing task group.
+ */
+export const UpdateTaskGroupPayloadSchema = z.strictObject({
+  stream: StreamTabIdSchema,
+  groupId: z.string().min(1),
+  status: TaskGroupStatusSchema,
+  endTime: z.number().optional(),
+});
+export type UpdateTaskGroupPayload = z.infer<
+  typeof UpdateTaskGroupPayloadSchema
+>;
+
+// ============================================================================
+// STREAM SCHEMAS
+// ============================================================================
+
+/**
+ * Payload for setting the active stream.
+ * session is typed loosely here; full validation happens in consumers.
+ */
+export const SetActiveStreamPayloadSchema = z.strictObject({
+  stream: StreamTabIdSchema.nullable(),
+  session: z.unknown().nullish(),
+});
+export type SetActiveStreamPayload = z.infer<
+  typeof SetActiveStreamPayloadSchema
+>;
+
+/**
+ * Payload for updating stream status.
+ */
+export const UpdateStreamStatusPayloadSchema = z.strictObject({
+  stream: StreamTabIdSchema,
+  status: StreamStatusSchema,
+});
+export type UpdateStreamStatusPayload = z.infer<
+  typeof UpdateStreamStatusPayloadSchema
+>;
+
+// ============================================================================
+// TASK STATE SCHEMAS
+// ============================================================================
+
+/**
+ * Payload for setting task state.
+ * taskState is typed loosely here; full validation happens in consumers.
+ */
+export const SetTaskStatePayloadSchema = z.strictObject({
+  streamTabId: StreamTabIdSchema,
+  executionId: ExecutionIdSchema.optional(),
+  taskState: z.unknown(),
+});
+export type SetTaskStatePayload = z.infer<typeof SetTaskStatePayloadSchema>;
+
+// ============================================================================
+// RUN-SCOPED SCHEMAS
+// ============================================================================
+
+/**
+ * Base payload for storage-scoped events (files, usage, etc.).
+ * storageKey is THE key for storage operations - required for all events.
+ */
+export const RunScopedPayloadSchema = z.strictObject({
+  stream: StreamTabIdSchema,
+  /** THE key for storage operations. Required. */
+  storageKey: StorageKeySchema,
+  /** For metadata/audit purposes */
+  executionId: ExecutionIdSchema.optional(),
+});
+export type RunScopedPayload = z.infer<typeof RunScopedPayloadSchema>;
+
+// ============================================================================
+// SIMPLE EVENT SCHEMAS
+// ============================================================================
+
+/**
+ * Payload for resolving retry requests.
+ */
+export const ResolveRetryRequestPayloadSchema = z.strictObject({
+  streamId: StreamTabIdSchema,
+});
+export type ResolveRetryRequestPayload = z.infer<
+  typeof ResolveRetryRequestPayloadSchema
+>;
+
+/**
+ * Payload for resolving tool edit approval prompts.
+ */
+export const ResolveToolEditApprovalPayloadSchema = z.strictObject({
+  requestId: z.string().min(1),
+});
+export type ResolveToolEditApprovalPayload = z.infer<
+  typeof ResolveToolEditApprovalPayloadSchema
+>;
+
+/**
+ * Payload for updating tool edit approval bypass state.
+ */
+export const UpdateToolEditApprovalBypassPayloadSchema = z.strictObject({
+  bypassActive: z.boolean(),
+});
+export type UpdateToolEditApprovalBypassPayload = z.infer<
+  typeof UpdateToolEditApprovalBypassPayloadSchema
+>;

--- a/src/eventBus/schemas.ts
+++ b/src/eventBus/schemas.ts
@@ -8,6 +8,7 @@ import {
   ExecutionIdSchema,
   StorageKeySchema,
 } from '@agent/types/IdentifierTypes';
+import type { TaskGroup } from '@logger/LogTypes';
 
 // Re-export from types.ts (breaking circular dependency with progressView)
 export {
@@ -17,7 +18,7 @@ export {
   type RetryRequestPrompt,
 } from './types';
 
-/** Task group status (matches TaskGroup['status'] from LogTypes) */
+/** Task group status - derived from TaskGroup['status'] */
 export const TaskGroupStatusSchema = z.enum([
   'running',
   'error',
@@ -25,6 +26,15 @@ export const TaskGroupStatusSchema = z.enum([
   'ready',
 ]);
 export type TaskGroupStatus = z.infer<typeof TaskGroupStatusSchema>;
+
+// Compile-time assertion: ensures TaskGroupStatus stays in sync with LogTypes
+type _AssertStatusMatch = TaskGroupStatus extends TaskGroup['status']
+  ? TaskGroup['status'] extends TaskGroupStatus
+    ? true
+    : never
+  : never;
+const _assertStatusMatch: _AssertStatusMatch = true;
+void _assertStatusMatch;
 
 /** Payload for adding a new task group */
 export const AddTaskGroupPayloadSchema = z.strictObject({

--- a/src/eventBus/schemas.ts
+++ b/src/eventBus/schemas.ts
@@ -10,7 +10,11 @@ import {
 } from '@agent/types/IdentifierTypes';
 import type { TaskGroup } from '@logger/LogTypes';
 
-// Re-export from types.ts (breaking circular dependency with progressView)
+/**
+ * Re-export from types.ts to break circular dependency:
+ * progressView/events → eventBus/schemas → eventBus/types
+ * (progressView cannot import types.ts directly due to other deps)
+ */
 export {
   ToolEditApprovalPromptSchema,
   RetryRequestPromptSchema,

--- a/src/eventBus/types.ts
+++ b/src/eventBus/types.ts
@@ -1,25 +1,10 @@
 /**
- * Shared types for the progress event bus.
- *
- * These types are used by both the event bus and UI components.
- * They are defined here to break the circular dependency between
- * @eventBus and @progressView.
+ * Shared event bus types for breaking circular dependency with progressView.
  */
-
-// Third-party imports
 import { z } from 'zod';
-
-// Type imports
 import { StreamTabIdSchema } from '@agent/types/IdentifierTypes';
 
-// ============================================================================
-// EVENT PAYLOAD SCHEMAS (types derived via z.infer)
-// ============================================================================
-
-/**
- * Prompt data for tool edit approval requests.
- * Emitted via 'showToolEditApprovalPrompt' event.
- */
+/** Tool edit approval request prompt */
 export const ToolEditApprovalPromptSchema = z.strictObject({
   requestId: z.string(),
   path: z.string(),
@@ -34,10 +19,7 @@ export type ToolEditApprovalPrompt = z.infer<
   typeof ToolEditApprovalPromptSchema
 >;
 
-/**
- * Prompt data for manual retry requests.
- * Emitted via 'showRetryRequest' event.
- */
+/** Manual retry request prompt */
 export const RetryRequestPromptSchema = z.strictObject({
   streamId: StreamTabIdSchema,
   operation: z.string(),

--- a/src/eventBus/types.ts
+++ b/src/eventBus/types.ts
@@ -6,31 +6,42 @@
  * @eventBus and @progressView.
  */
 
+// Third-party imports
+import { z } from 'zod';
+
 // Type imports
-import type { StreamTabId } from '@agent/types/IdentifierTypes';
+import { StreamTabIdSchema } from '@agent/types/IdentifierTypes';
+
+// ============================================================================
+// EVENT PAYLOAD SCHEMAS (types derived via z.infer)
+// ============================================================================
 
 /**
  * Prompt data for tool edit approval requests.
  * Emitted via 'showToolEditApprovalPrompt' event.
  */
-export interface ToolEditApprovalPrompt {
-  requestId: string;
-  path: string;
-  relativePath: string;
-  sourceTool: string;
-  allowBypass: boolean;
-  streamId: StreamTabId | '';
-  addedLines: number;
-  removedLines: number;
-}
+export const ToolEditApprovalPromptSchema = z.strictObject({
+  requestId: z.string(),
+  path: z.string(),
+  relativePath: z.string(),
+  sourceTool: z.string(),
+  allowBypass: z.boolean(),
+  streamId: z.union([StreamTabIdSchema, z.literal('')]),
+  addedLines: z.number().int().nonnegative(),
+  removedLines: z.number().int().nonnegative(),
+});
+export type ToolEditApprovalPrompt = z.infer<
+  typeof ToolEditApprovalPromptSchema
+>;
 
 /**
  * Prompt data for manual retry requests.
  * Emitted via 'showRetryRequest' event.
  */
-export interface RetryRequestPrompt {
-  streamId: StreamTabId;
-  operation: string;
-  model?: string;
-  errorMessage?: string;
-}
+export const RetryRequestPromptSchema = z.strictObject({
+  streamId: StreamTabIdSchema,
+  operation: z.string(),
+  model: z.string().optional(),
+  errorMessage: z.string().optional(),
+});
+export type RetryRequestPrompt = z.infer<typeof RetryRequestPromptSchema>;

--- a/src/utils/files/taskRunStorage.ts
+++ b/src/utils/files/taskRunStorage.ts
@@ -5,8 +5,11 @@ import { promises as fs } from 'fs';
 // Third-party imports
 import { z } from 'zod';
 
-// Local imports - log
-import type { ExecutionId } from '@agent/types/IdentifierTypes';
+// Local imports - identifiers
+import {
+  ExecutionIdSchema,
+  type ExecutionId,
+} from '@agent/types/IdentifierTypes';
 
 // Local imports - common
 import { toErrorMessage } from '@common/errors';
@@ -38,7 +41,7 @@ export const RunStorageFileLocationSchema = z.strictObject({
   kind: z.literal('runStorage'),
   absolutePath: z.string(),
   relativePath: z.string(),
-  executionId: z.string(),
+  executionId: ExecutionIdSchema,
 });
 
 export const ExternalFileLocationSchema = z.strictObject({

--- a/src/utils/files/taskRunStorage.ts
+++ b/src/utils/files/taskRunStorage.ts
@@ -24,29 +24,16 @@ import { flexibleFS } from './flexibleFS';
 const CHANNEL = 'taskRunStorage';
 logger.initialize(CHANNEL);
 
-/**
- * Directory name for storing task run artifacts.
- * All task execution files (debug JSONs, logs, etc.) are organized
- * in subdirectories under this parent directory.
- */
+/** Directory for task run artifacts (debug JSONs, logs, etc.) */
 export const TASK_RUNS_DIR = 'taskRuns';
 
-// ============================================================================
-// FILE LOCATION SCHEMAS (types derived via z.infer)
-// ============================================================================
-
-/**
- * File location in workspace with relative path.
- */
+// File location schemas (types derived via z.infer)
 export const WorkspaceFileLocationSchema = z.strictObject({
   kind: z.literal('workspace'),
   absolutePath: z.string(),
   relativePath: z.string(),
 });
 
-/**
- * File location in run storage with execution context.
- */
 export const RunStorageFileLocationSchema = z.strictObject({
   kind: z.literal('runStorage'),
   absolutePath: z.string(),
@@ -54,34 +41,24 @@ export const RunStorageFileLocationSchema = z.strictObject({
   executionId: z.string(),
 });
 
-/**
- * File location outside workspace/storage (external).
- */
 export const ExternalFileLocationSchema = z.strictObject({
   kind: z.literal('external'),
   absolutePath: z.string(),
 });
 
-/**
- * Discriminated union of all file location types.
- * Uses the 'kind' field for discrimination.
- */
+/** Discriminated union of all file location types */
 export const FileLocationSchema = z.discriminatedUnion('kind', [
   WorkspaceFileLocationSchema,
   RunStorageFileLocationSchema,
   ExternalFileLocationSchema,
 ]);
 
-/**
- * Agent outputs are always workspace or runStorage, never external.
- * Use this schema for agent-created file locations.
- */
+/** Agent outputs are workspace or runStorage, never external */
 export const AgentFileLocationSchema = z.discriminatedUnion('kind', [
   WorkspaceFileLocationSchema,
   RunStorageFileLocationSchema,
 ]);
 
-// Derive types from schemas (Zod v4)
 export type WorkspaceFileLocation = z.infer<typeof WorkspaceFileLocationSchema>;
 export type RunStorageFileLocation = z.infer<
   typeof RunStorageFileLocationSchema

--- a/src/utils/files/taskRunStorage.ts
+++ b/src/utils/files/taskRunStorage.ts
@@ -2,6 +2,9 @@
 import * as path from 'path';
 import { promises as fs } from 'fs';
 
+// Third-party imports
+import { z } from 'zod';
+
 // Local imports - log
 import type { ExecutionId } from '@agent/types/IdentifierTypes';
 
@@ -28,46 +31,64 @@ logger.initialize(CHANNEL);
  */
 export const TASK_RUNS_DIR = 'taskRuns';
 
+// ============================================================================
+// FILE LOCATION SCHEMAS (types derived via z.infer)
+// ============================================================================
+
 /**
  * File location in workspace with relative path.
  */
-export interface WorkspaceFileLocation {
-  kind: 'workspace';
-  absolutePath: string;
-  relativePath: string;
-}
+export const WorkspaceFileLocationSchema = z.strictObject({
+  kind: z.literal('workspace'),
+  absolutePath: z.string(),
+  relativePath: z.string(),
+});
 
 /**
  * File location in run storage with execution context.
  */
-export interface RunStorageFileLocation {
-  kind: 'runStorage';
-  absolutePath: string;
-  relativePath: string;
-  executionId: string;
-}
+export const RunStorageFileLocationSchema = z.strictObject({
+  kind: z.literal('runStorage'),
+  absolutePath: z.string(),
+  relativePath: z.string(),
+  executionId: z.string(),
+});
 
 /**
  * File location outside workspace/storage (external).
  */
-export interface ExternalFileLocation {
-  kind: 'external';
-  absolutePath: string;
-}
+export const ExternalFileLocationSchema = z.strictObject({
+  kind: z.literal('external'),
+  absolutePath: z.string(),
+});
 
 /**
  * Discriminated union of all file location types.
+ * Uses the 'kind' field for discrimination.
  */
-export type FileLocation =
-  | WorkspaceFileLocation
-  | RunStorageFileLocation
-  | ExternalFileLocation;
+export const FileLocationSchema = z.discriminatedUnion('kind', [
+  WorkspaceFileLocationSchema,
+  RunStorageFileLocationSchema,
+  ExternalFileLocationSchema,
+]);
 
 /**
  * Agent outputs are always workspace or runStorage, never external.
- * Use this type for agent-created file locations.
+ * Use this schema for agent-created file locations.
  */
-export type AgentFileLocation = WorkspaceFileLocation | RunStorageFileLocation;
+export const AgentFileLocationSchema = z.discriminatedUnion('kind', [
+  WorkspaceFileLocationSchema,
+  RunStorageFileLocationSchema,
+]);
+
+// Derive types from schemas (Zod v4)
+export type WorkspaceFileLocation = z.infer<typeof WorkspaceFileLocationSchema>;
+export type RunStorageFileLocation = z.infer<
+  typeof RunStorageFileLocationSchema
+>;
+export type ExternalFileLocation = z.infer<typeof ExternalFileLocationSchema>;
+export type FileLocation = z.infer<typeof FileLocationSchema>;
+export type AgentFileLocation = z.infer<typeof AgentFileLocationSchema>;
 
 export function createWorkspaceLocation(
   absolutePath: string,

--- a/src/utils/files/taskRunStorage.ts
+++ b/src/utils/files/taskRunStorage.ts
@@ -84,7 +84,7 @@ export function createWorkspaceLocation(
 export function createRunStorageLocation(
   absolutePath: string,
   relativePath: string,
-  executionId: string,
+  executionId: ExecutionId,
 ): RunStorageFileLocation {
   return {
     kind: 'runStorage',


### PR DESCRIPTION
Replace z.custom<T>() usages with proper discriminated union schemas:

- FileLocation: Create FileLocationSchema with discriminated union
  replacing 7 z.custom<FileLocation>() calls in agent/output/types.ts

- Identifiers: Add schemas for StreamTabId, ExecutionId, StorageKey
  with proper validation (uuid, min length, branding)

- StreamStatus: Convert to z.enum() schema for type-safe validation

- EventBus: Create src/eventBus/schemas.ts with payload schemas for
  TaskGroup, RunScoped, and approval events

Benefits:
- Runtime validation for discriminated unions
- Single source of truth (types derived from schemas)
- Eliminates 7 z.custom<FileLocation>() usages
- Enables future schema composition and validation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Consolidates types around Zod schemas (discriminated unions/enums) across identifiers, file locations, usage, and event bus payloads, removing z.custom usages and centralizing validation.
> 
> - **Schemas/Types**:
>   - Introduce `StreamTabIdSchema`, `ExecutionIdSchema`, `StorageKeySchema` with validation; add `ExecutionIdentitySchema` (`src/agent/types/IdentifierTypes.ts`).
>   - Convert `STREAM_STATUS` to `StreamStatusSchema` enum (`src/common/constants/streamStatus.ts`).
>   - Add discriminated union `FileLocationSchema` and `AgentFileLocationSchema` with sub-schemas in `@utils/files` (`src/utils/files/taskRunStorage.ts`).
>   - Define usage schemas: `RunUsageTotalsSchema`, `NormalizedUsageSnapshotSchema`, `RunUsageAccumulatorJSONSchema` and use `NormalizedUsageSchema` (`src/agent/core/RunUsageAccumulator.ts`).
> - **Agent runtime**:
>   - Swap `z.custom` fields for schema-backed ones in `ConversationRoundStateSnapshotSchema` and `AgentRunStateSnapshotSchema` (`src/agent/core/AgentState.ts`).
> - **Event Bus**:
>   - Add `src/eventBus/schemas.ts` with `TaskGroupStatusSchema`, `AddTaskGroupPayloadSchema`, `UpdateTaskGroupPayloadSchema`, `RunScopedPayloadSchema`.
>   - Define prompt schemas in `src/eventBus/types.ts` (`ToolEditApprovalPromptSchema`, `RetryRequestPromptSchema`).
>   - Refactor `ProgressEventBus` to consume new payload/types and remove inline payload definitions.
> - **Outputs/Files**:
>   - Replace `z.custom<FileLocation>()` with `FileLocationSchema` across output types; compose `OutputFileInfoSchema` from `OutputFileSchema` (`src/agent/output/types.ts`).
> - **Docs**:
>   - Add Schema and Type Guidelines to `CLAUDE.md` promoting schema-first design.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cb2819661a8922da1c027f597cc12db4471dfe46. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->