### PR TITLE
Test tools safely with Gemini model

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -282,7 +282,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -326,7 +325,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -777,7 +775,6 @@
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.24.3.tgz",
       "integrity": "sha512-YgSHW29fuzKKAHTGe9zjNoo+yF8KaQPzDC2W9Pv41E7/57IfY+AMGJ/aDFlgTLcVVELoggKE4syABCE75u3NCw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
@@ -1273,7 +1270,6 @@
       "integrity": "sha512-PC0PDZfJg8sP7cmKe6L3QIL8GZwU5aRvUFedqSIpw3B+QjRSUZeeITC2M5XKeMXEzL6wccN196iy3JLwKNvDVA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.48.1",
         "@typescript-eslint/types": "8.48.1",
@@ -1886,7 +1882,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2434,7 +2429,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.9",
         "caniuse-lite": "^1.0.30001746",
@@ -3521,7 +3515,6 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3920,7 +3913,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
       "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.0",
@@ -7713,7 +7705,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -8836,7 +8827,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9053,7 +9043,6 @@
       "integrity": "sha512-HU1JOuV1OavsZ+mfigY0j8d1TgQgbZ6M+J75zDkpEAwYeXjWSqrGJtgnPblJjd/mAyTNQ7ygw0MiKOn6etz8yw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -9103,7 +9092,6 @@
       "integrity": "sha512-MfwFQ6SfwinsUVi0rNJm7rHZ31GyTcpVE5pgVA3hwFRb7COD4TzjUUwhGWKfO50+xdc2MQPuEBBJoqIMGt3JDw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.6.1",
         "@webpack-cli/configtest": "^3.0.1",
@@ -9796,7 +9784,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.13.tgz",
       "integrity": "sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/agent/modelHandlers/toolConversion.ts
+++ b/src/agent/modelHandlers/toolConversion.ts
@@ -72,21 +72,51 @@ export function toAnthropicTools(defs: ToolDefinition[]): ToolUnion[] {
   });
 }
 
-/** Convert generic ToolDefinition objects to Google Gemini Tool format. */
+// Names of tools that should be converted to Google's native tool types
+// rather than function declarations
+const GOOGLE_NATIVE_TOOLS = new Set(['web_search', 'code_execution']);
+
+/** Convert generic ToolDefinition objects to Google Gemini Tool format.
+ *
+ * Google's API supports two categories of tools:
+ * 1. Function declarations - custom tools implemented by the application
+ * 2. Native tools - built-in tools like googleSearch and codeExecution
+ *
+ * Native tools must be configured separately and cannot be mixed with
+ * function declarations in the same Tool object. This function filters
+ * out native tools and configures them appropriately.
+ */
 export function toGoogleTools(defs: ToolDefinition[]): GeminiTool[] {
   if (defs.length === 0) {
     return [];
   }
 
-  const declarations: FunctionDeclaration[] = defs.map((d) => ({
-    name: d.name,
-    description: d.description,
-    parameters: d.parameters as Schema | undefined,
-  }));
+  // Separate native Google tools from custom function declarations
+  const customTools = defs.filter((d) => !GOOGLE_NATIVE_TOOLS.has(d.name));
+  const hasWebSearch = defs.some((d) => d.name === 'web_search');
+  const hasCodeExecution = defs.some((d) => d.name === 'code_execution');
 
-  return [
-    {
-      functionDeclarations: declarations,
-    },
-  ];
+  const result: GeminiTool[] = [];
+
+  // Add function declarations for custom tools
+  if (customTools.length > 0) {
+    const declarations: FunctionDeclaration[] = customTools.map((d) => ({
+      name: d.name,
+      description: d.description,
+      parameters: d.parameters as Schema | undefined,
+    }));
+    result.push({ functionDeclarations: declarations });
+  }
+
+  // Add native Google Search tool if web_search was requested
+  if (hasWebSearch) {
+    result.push({ googleSearch: {} });
+  }
+
+  // Add native Code Execution tool if code_execution was requested
+  if (hasCodeExecution) {
+    result.push({ codeExecution: {} });
+  }
+
+  return result;
 }

--- a/src/test/modelHandlers/ResponseToolConversion.test.ts
+++ b/src/test/modelHandlers/ResponseToolConversion.test.ts
@@ -2,7 +2,10 @@
 import { strict as assert } from 'assert';
 
 // Local imports - test
-import { toOpenAIResponseTools } from '@agent/modelHandlers/toolConversion';
+import {
+  toOpenAIResponseTools,
+  toGoogleTools,
+} from '@agent/modelHandlers/toolConversion';
 
 // Type imports
 import type { ToolDefinition } from '@model';
@@ -39,5 +42,97 @@ describe('toOpenAIResponseTools', () => {
 
     const tools = toOpenAIResponseTools(defs);
     assert.equal(tools[0].parameters, null);
+  });
+});
+
+describe('toGoogleTools', () => {
+  it('converts regular tools to function declarations', () => {
+    const defs: ToolDefinition[] = [
+      {
+        name: 'read_file',
+        description: 'Read a file',
+        parameters: {
+          type: 'object',
+          properties: { path: { type: 'string' } },
+          required: ['path'],
+        },
+      },
+    ];
+
+    const tools = toGoogleTools(defs);
+    assert.equal(tools.length, 1);
+    assert.ok(tools[0].functionDeclarations);
+    assert.equal(tools[0].functionDeclarations?.length, 1);
+    assert.equal(tools[0].functionDeclarations?.[0].name, 'read_file');
+  });
+
+  it('converts web_search to native googleSearch', () => {
+    const defs: ToolDefinition[] = [
+      {
+        name: 'web_search',
+        description: 'Search the web',
+        parameters: { type: 'object', properties: { query: { type: 'string' } } },
+      },
+    ];
+
+    const tools = toGoogleTools(defs);
+    assert.equal(tools.length, 1);
+    assert.ok(tools[0].googleSearch);
+    assert.ok(!tools[0].functionDeclarations);
+  });
+
+  it('converts code_execution to native codeExecution', () => {
+    const defs: ToolDefinition[] = [
+      {
+        name: 'code_execution',
+        description: 'Execute code',
+        parameters: { type: 'object', properties: {} },
+      },
+    ];
+
+    const tools = toGoogleTools(defs);
+    assert.equal(tools.length, 1);
+    assert.ok(tools[0].codeExecution);
+    assert.ok(!tools[0].functionDeclarations);
+  });
+
+  it('separates native tools from function declarations', () => {
+    const defs: ToolDefinition[] = [
+      {
+        name: 'read_file',
+        description: 'Read a file',
+        parameters: { type: 'object', properties: {} },
+      },
+      {
+        name: 'web_search',
+        description: 'Search the web',
+        parameters: { type: 'object', properties: {} },
+      },
+      {
+        name: 'code_execution',
+        description: 'Execute code',
+        parameters: { type: 'object', properties: {} },
+      },
+    ];
+
+    const tools = toGoogleTools(defs);
+    // Should produce 3 Tool objects: one with functionDeclarations, one with googleSearch, one with codeExecution
+    assert.equal(tools.length, 3);
+
+    const funcTool = tools.find((t) => t.functionDeclarations);
+    const searchTool = tools.find((t) => t.googleSearch);
+    const codeTool = tools.find((t) => t.codeExecution);
+
+    assert.ok(funcTool);
+    assert.equal(funcTool.functionDeclarations?.length, 1);
+    assert.equal(funcTool.functionDeclarations?.[0].name, 'read_file');
+
+    assert.ok(searchTool);
+    assert.ok(codeTool);
+  });
+
+  it('returns empty array for empty input', () => {
+    const tools = toGoogleTools([]);
+    assert.deepEqual(tools, []);
   });
 });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduce Gemini tool conversion that maps `web_search` and `code_execution` to native tools and separates custom function declarations, with comprehensive tests.
> 
> - **Agent Model Handling**:
>   - **Google Gemini tools**: Implement `toGoogleTools` to:
>     - Map `web_search` -> `googleSearch` and `code_execution` -> `codeExecution` as native tools.
>     - Separate native tools from custom `functionDeclarations` and return multiple `GeminiTool` entries as needed.
>     - Handle empty input by returning `[]`.
> - **Tests**:
>   - Add unit tests for `toGoogleTools` covering regular functions, native tool mapping, separation of tool types, and empty input.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 94cc82ce54dc70abb43160551beb86716a6874e7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->