### PR TITLE
refactor: consolidate tool attachment schemas using Zod composition

### DIFF
--- a/src/agent/modelHandlers/utils/toolAttachmentUtils.ts
+++ b/src/agent/modelHandlers/utils/toolAttachmentUtils.ts
@@ -1,34 +1,38 @@
 // Third-party imports
 import { z } from 'zod';
 
-// Local imports - tools
-import type { ToolFileAttachment, ToolResult } from '@tools/result';
+// Local imports - tools (single source of truth for file/attachment schemas)
+import {
+  type ToolFileAttachment,
+  type ToolResult,
+  type FileReference,
+  ToolFileAttachmentSchema,
+  FileReferenceSchema,
+  LineChangesSchema,
+  EditRecordSchema,
+} from '@tools/result';
 
 // Local imports - utils
 import { WorkspaceFS } from '@utils/files';
 
+// Re-export schemas from result.ts for backwards compatibility
+export {
+  ToolFileAttachmentSchema,
+  FileReferenceSchema,
+  LineChangesSchema,
+  EditRecordSchema,
+  type FileReference,
+} from '@tools/result';
+
 export const DEFAULT_ATTACHMENT_MIME_TYPE = 'application/octet-stream';
 
 // ============================================================================
-// Zod Schemas
+// Additional Schemas (specific to tool attachment handling)
 // ============================================================================
 
 /**
- * Schema for file references in tool result payloads (binary data stripped).
- */
-export const FileReferenceSchema = z.object({
-  /** Workspace-relative or descriptive path for the file */
-  path: z.string(),
-  /** MIME type for the file */
-  mimeType: z.string(),
-  /** Optional human readable description */
-  description: z.string().optional(),
-});
-
-export type FileReference = z.infer<typeof FileReferenceSchema>;
-
-/**
  * Schema for records of files edited during tool execution.
+ * Specific to logging/tracking edited files in handler context.
  */
 export const EditedFileRecordSchema = z.object({
   /** Path to the edited file */
@@ -44,25 +48,9 @@ export const EditedFileRecordSchema = z.object({
 export type EditedFileRecord = z.infer<typeof EditedFileRecordSchema>;
 
 /**
- * Schema for line change statistics.
- */
-export const LineChangesSchema = z.object({
-  added: z.number(),
-  removed: z.number(),
-});
-
-/**
- * Schema for edit records in tool results.
- */
-export const EditRecordSchema = z.object({
-  path: z.string(),
-  lineChanges: LineChangesSchema.optional(),
-});
-
-/**
  * Schema for strongly-typed tool result payloads sent to model handlers.
  * This is what gets passed to handlers - no binary data, properly typed fields.
- * Uses passthrough() to allow additional properties for forward compatibility.
+ * Uses looseObject to allow additional properties for forward compatibility.
  */
 export const ToolResultPayloadSchema = z.looseObject({
   /** Brief summary of the tool execution result */
@@ -89,26 +77,9 @@ export const ToolResultPayloadSchema = z.looseObject({
   editedFiles: z.array(EditedFileRecordSchema).optional(),
   /** Summary added by handlers when attachments are available */
   attachmentSummary: z.string().optional(),
-}); // Allow additional properties for forward compatibility
+});
 
 export type ToolResultPayload = z.infer<typeof ToolResultPayloadSchema>;
-
-/**
- * Schema for file attachments with optional binary data.
- * Used for validation when processing tool results.
- */
-export const ToolFileAttachmentSchema = z.object({
-  /** Workspace-relative or descriptive path for the attachment */
-  path: z.string().min(1),
-  /** MIME type for the attachment payload */
-  mimeType: z.string().min(1),
-  /** Optional human readable description */
-  description: z.string().optional(),
-  /** Base64 encoded payload when inline transport is supported */
-  base64Data: z.string().optional(),
-  /** Raw bytes for providers that require binary uploads */
-  bytes: z.custom<Uint8Array>((val) => val instanceof Uint8Array).optional(),
-});
 
 /**
  * Result from extracting attachments from a tool result.

--- a/src/common/webview/BaseViewMessageHandler.ts
+++ b/src/common/webview/BaseViewMessageHandler.ts
@@ -14,6 +14,23 @@ export type MessageHandler<
 > = (message: any, webviewView: T) => Promise<void> | void;
 
 /**
+ * Configuration options for BaseViewMessageHandler.
+ */
+export interface MessageHandlerOptions {
+  /**
+   * When true, the handler automatically tracks the active webview reference
+   * and provides getActiveView() for handlers that need webview access outside
+   * the handler callback context.
+   *
+   * Enable this when handlers need to post messages to the webview from methods
+   * that don't receive the webview as a parameter.
+   *
+   * @default false
+   */
+  trackActiveView?: boolean;
+}
+
+/**
  * Base class for all webview message handlers.
  * Provides consistent error handling, logging, and common patterns.
  * @template T - The webview type (WebviewView or WebviewPanel)
@@ -24,12 +41,45 @@ export abstract class BaseViewMessageHandler<
   protected readonly logger: any;
   protected readonly channel: string;
   protected readonly handlers: Record<string, MessageHandler<T>>;
+  private readonly _options: MessageHandlerOptions;
 
-  constructor(protected readonly viewName: string) {
+  /**
+   * Active webview reference, tracked when trackActiveView option is enabled.
+   * Subclasses can access via getActiveView().
+   */
+  private _activeView: T | undefined;
+
+  constructor(
+    protected readonly viewName: string,
+    options?: MessageHandlerOptions,
+  ) {
     this.logger = logger;
     this.channel = `${viewName}MessageHandler`;
+    this._options = options ?? {};
     logger.initialize(this.channel);
     this.handlers = this.createHandlers();
+  }
+
+  /**
+   * Get the currently active webview.
+   * Only available when trackActiveView option is enabled.
+   * @returns The active webview or undefined if not available/not tracking
+   */
+  protected getActiveView(): T | undefined {
+    if (!this._options.trackActiveView) {
+      this.logger.warn(
+        this.channel,
+        'getActiveView called but trackActiveView is not enabled',
+      );
+      return undefined;
+    }
+
+    if (!this._activeView) {
+      this.logger.warn(this.channel, 'No active webview available');
+      return undefined;
+    }
+
+    return this._activeView;
   }
 
   /**
@@ -38,9 +88,15 @@ export abstract class BaseViewMessageHandler<
   protected abstract createHandlers(): Record<string, MessageHandler<T>>;
 
   /**
-   * Standard message handling with consistent error handling and logging
+   * Standard message handling with consistent error handling and logging.
+   * When trackActiveView is enabled, automatically updates the active view reference.
    */
   public async handleMessage(message: any, webviewView: T): Promise<void> {
+    // Track active view when option is enabled
+    if (this._options.trackActiveView) {
+      this._activeView = webviewView;
+    }
+
     if (!message?.command) {
       this.logger.warn(
         this.channel,

--- a/src/common/webview/index.ts
+++ b/src/common/webview/index.ts
@@ -6,6 +6,7 @@ export {
 export {
   MessageHandler,
   BaseViewMessageHandler,
+  type MessageHandlerOptions,
 } from './BaseViewMessageHandler';
 export { BaseWebviewProvider } from './BaseWebviewProvider';
 export {

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -74,13 +74,13 @@ const ApprovalAction = z.object({
 
 export class ProgressViewMessageHandler extends BaseViewMessageHandler {
   private readonly recordingManager: RecordingManager;
-  private activeView: vscode.WebviewView | undefined;
 
   constructor(
     private readonly provider: ProgressViewProvider,
     context: vscode.ExtensionContext,
   ) {
-    super('ProgressView');
+    // Enable activeView tracking - getActiveView() is inherited from base class
+    super('ProgressView', { trackActiveView: true });
     this.recordingManager = new RecordingManager(context, {
       recordingStartedCommand: PROGRESS_VIEW_COMMANDS.RECORDING_STARTED,
       recordingStoppedCommand: PROGRESS_VIEW_COMMANDS.RECORDING_STOPPED,
@@ -88,23 +88,6 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
       transcriptionCommand: PROGRESS_VIEW_COMMANDS.FOLLOW_UP_TEXT_TRANSCRIBED,
       progressTitle: 'Transcribing follow-up message',
     });
-  }
-
-  public override async handleMessage(
-    message: any,
-    webviewView: vscode.WebviewView,
-  ): Promise<void> {
-    this.activeView = webviewView;
-    await super.handleMessage(message, webviewView);
-  }
-
-  private getActiveView(): vscode.WebviewView | undefined {
-    if (!this.activeView) {
-      this.logger.warn(this.channel, 'No active progress view available');
-      return undefined;
-    }
-
-    return this.activeView;
   }
 
   private async deleteSessionSnapshot(stream: StreamTabId): Promise<void> {

--- a/src/progressView/events/ApprovalEvents.ts
+++ b/src/progressView/events/ApprovalEvents.ts
@@ -5,7 +5,6 @@ import * as vscode from 'vscode';
 import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
 
 // Local file imports
-import { createErrorBoundary } from './errorHandling';
 import type {
   BaseEventShared,
   EventModuleBase,
@@ -37,10 +36,7 @@ export type ApprovalEventsModule = EventModuleBase;
 export function createApprovalEventsModule(
   shared: ApprovalEventsShared,
 ): ApprovalEventsModule {
-  const withErrorBoundary = createErrorBoundary(
-    shared.logger,
-    'ApprovalEvents',
-  );
+  const { withErrorBoundary } = shared;
 
   return {
     register(bus: ProgressEventBusLike): vscode.Disposable[] {

--- a/src/progressView/events/ApprovalEvents.ts
+++ b/src/progressView/events/ApprovalEvents.ts
@@ -1,16 +1,22 @@
 // Third-party imports
 import * as vscode from 'vscode';
 
-// Local imports
-import type { AgentLogger } from '@logger/AgentLogger';
+// Type imports
 import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
 
 // Local file imports
 import { createErrorBoundary } from './errorHandling';
-import type { ProgressEventBusLike } from './types';
+import type {
+  BaseEventShared,
+  EventModuleBase,
+  ProgressEventBusLike,
+} from './types';
 
-export interface ApprovalEventsShared {
-  logger: AgentLogger;
+/**
+ * Shared context for ApprovalEvents module.
+ * Extends BaseEventShared with approval-specific callbacks.
+ */
+export interface ApprovalEventsShared extends BaseEventShared {
   showToolEditApprovalPrompt: (
     payload: ProgressEventPayloads['showToolEditApprovalPrompt'],
   ) => void;
@@ -18,9 +24,11 @@ export interface ApprovalEventsShared {
   updateToolEditApprovalBypassState: (bypassActive: boolean) => void;
 }
 
-export interface ApprovalEventsModule {
-  register(bus: ProgressEventBusLike): vscode.Disposable[];
-}
+/**
+ * ApprovalEvents module interface.
+ * Uses EventModuleBase pattern (bus only, no state/updater).
+ */
+export type ApprovalEventsModule = EventModuleBase;
 
 /**
  * Creates a module for handling tool edit approval events.

--- a/src/progressView/events/LogEvents.ts
+++ b/src/progressView/events/LogEvents.ts
@@ -9,9 +9,6 @@ import type { ProgressViewState } from '@progressView/state/ProgressViewState';
 // Local imports
 import { getConfig } from '@utils/config';
 import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
-
-// Local file imports
-import { createErrorBoundary } from './errorHandling';
 import type {
   BaseEventShared,
   ProgressEventBusLike,
@@ -20,7 +17,7 @@ import type {
 
 /**
  * Shared context for LogEvents module.
- * Uses BaseEventShared which provides logger for error boundary.
+ * Uses BaseEventShared which provides withErrorBoundary.
  */
 type LogEventsShared = BaseEventShared;
 
@@ -31,7 +28,7 @@ type LogEventsShared = BaseEventShared;
 export type LogEventsModule = StatefulEventModule;
 
 export function createLogEvents(shared: LogEventsShared): LogEventsModule {
-  const withErrorBoundary = createErrorBoundary(shared.logger, 'LogEvents');
+  const { withErrorBoundary } = shared;
 
   const handleAddLogMessage = (
     data: ProgressEventPayloads['addLogMessage'],

--- a/src/progressView/events/LogEvents.ts
+++ b/src/progressView/events/LogEvents.ts
@@ -1,36 +1,34 @@
 // Third-party imports
 import * as vscode from 'vscode';
 
-// Local imports - progress view
 // Type imports
-import type { AgentLogger } from '@logger/AgentLogger';
 import { MESSAGE_TYPES } from '@logger/messageTypes';
 import type { WebviewUpdater } from '@progressView/managers';
 import type { ProgressViewState } from '@progressView/state/ProgressViewState';
 
-// Local imports - events
+// Local imports
 import { getConfig } from '@utils/config';
-
-// Type imports
 import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
 
 // Local file imports
 import { createErrorBoundary } from './errorHandling';
+import type {
+  BaseEventShared,
+  ProgressEventBusLike,
+  StatefulEventModule,
+} from './types';
 
-// Type imports
-import type { ProgressEventBusLike } from './types';
+/**
+ * Shared context for LogEvents module.
+ * Uses BaseEventShared which provides logger for error boundary.
+ */
+type LogEventsShared = BaseEventShared;
 
-interface LogEventsShared {
-  logger: AgentLogger;
-}
-
-export interface LogEventsModule {
-  register(
-    bus: ProgressEventBusLike,
-    state: ProgressViewState,
-    updater: WebviewUpdater,
-  ): vscode.Disposable[];
-}
+/**
+ * LogEvents module interface.
+ * Uses StatefulEventModule pattern for state/updater access.
+ */
+export type LogEventsModule = StatefulEventModule;
 
 export function createLogEvents(shared: LogEventsShared): LogEventsModule {
   const withErrorBoundary = createErrorBoundary(shared.logger, 'LogEvents');

--- a/src/progressView/events/OutputEvents.ts
+++ b/src/progressView/events/OutputEvents.ts
@@ -1,28 +1,29 @@
 // Third-party imports
 import * as vscode from 'vscode';
 
-// Local imports - progress view
-import type { AgentLogger } from '@logger/AgentLogger';
+// Type imports
 import type { WebviewUpdater } from '@progressView/managers';
 import type { ProgressViewState } from '@progressView/state/ProgressViewState';
 
 // Local file imports
 import { createErrorBoundary } from './errorHandling';
+import type {
+  BaseEventShared,
+  ProgressEventBusLike,
+  StatefulEventModule,
+} from './types';
 
-// Type imports
-import type { ProgressEventBusLike } from './types';
+/**
+ * OutputEvents module interface.
+ * Uses StatefulEventModule pattern for state/updater access.
+ */
+export type OutputEventsModule = StatefulEventModule;
 
-export interface OutputEventsModule {
-  register(
-    bus: ProgressEventBusLike,
-    state: ProgressViewState,
-    updater: WebviewUpdater,
-  ): vscode.Disposable[];
-}
-
-interface OutputEventsShared {
-  logger: AgentLogger;
-}
+/**
+ * Shared context for OutputEvents module.
+ * Uses BaseEventShared which provides logger for error boundary.
+ */
+type OutputEventsShared = BaseEventShared;
 
 const toRoundRecord = <T>(
   rounds?: Map<number, T[]>,

--- a/src/progressView/events/OutputEvents.ts
+++ b/src/progressView/events/OutputEvents.ts
@@ -6,7 +6,7 @@ import type { WebviewUpdater } from '@progressView/managers';
 import type { ProgressViewState } from '@progressView/state/ProgressViewState';
 
 // Local file imports
-import { createErrorBoundary } from './errorHandling';
+import type { ErrorBoundaryFn } from './errorHandling';
 import type {
   BaseEventShared,
   ProgressEventBusLike,
@@ -21,7 +21,7 @@ export type OutputEventsModule = StatefulEventModule;
 
 /**
  * Shared context for OutputEvents module.
- * Uses BaseEventShared which provides logger for error boundary.
+ * Uses BaseEventShared which provides withErrorBoundary.
  */
 type OutputEventsShared = BaseEventShared;
 
@@ -83,7 +83,7 @@ const registerOutputFileListeners = (
   bus: ProgressEventBusLike,
   state: ProgressViewState,
   updater: WebviewUpdater,
-  withErrorBoundary: ReturnType<typeof createErrorBoundary>,
+  withErrorBoundary: ErrorBoundaryFn,
 ): vscode.Disposable[] => {
   const addFiles = bus.on(
     'addOutputFiles',
@@ -126,7 +126,7 @@ const registerOutputFileListeners = (
 export function createOutputEvents(
   shared: OutputEventsShared,
 ): OutputEventsModule {
-  const withErrorBoundary = createErrorBoundary(shared.logger, 'OutputEvents');
+  const { withErrorBoundary } = shared;
 
   return {
     register(

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -5,6 +5,7 @@ import * as vscode from 'vscode';
 import type { StreamTabId } from '@agent/types/IdentifierTypes';
 import type { OutputFileInfo } from '@agent/output/types';
 import type { TokenUsageStats } from '@agent/types/UsageTypes';
+
 // Internal imports
 import { AgentCategory } from '@agent/core/AgentDataclass';
 import { normalizeRunId } from '@common/constants/runIds';
@@ -16,6 +17,7 @@ import { bus } from '@eventBus/ProgressEventBus';
 
 // Local file imports
 import type { StreamStatus } from '@eventBus/ProgressEventBus';
+import { createErrorBoundary } from './errorHandling';
 import {
   createStreamStatusEvents,
   type StreamStatusEventModule,
@@ -37,8 +39,6 @@ import {
   type ApprovalEventsModule,
   type ApprovalEventsShared,
 } from './ApprovalEvents';
-
-// Local imports - events
 
 /**
  * Handles progress event bus subscriptions for the progress view.
@@ -71,35 +71,40 @@ export class ProgressEventHandler {
       >,
   ) {
     this.logger = new AgentLogger('ProgressEventHandler');
+
+    // Create error boundaries centrally - modules receive pre-configured boundaries
     this.streamStatusEvents = createStreamStatusEvents({
-      logger: this.logger,
+      withErrorBoundary: createErrorBoundary(this.logger, 'StreamStatusEvents'),
       streamStatus: this._streamStatus,
       setStreamStatus: (stream, status) => this.setStreamStatus(stream, status),
       sendInstructionUpdate: (stream) => this.sendInstructionUpdate(stream),
       refreshStreamSurface: (stream, options) =>
         this.refreshStreamSurface(stream, options),
+      warnLog: (message) => this.logger.warn(message),
+      debugLog: (message) => this.logger.debug(message),
     });
     this.outputEvents = createOutputEvents({
-      logger: this.logger,
+      withErrorBoundary: createErrorBoundary(this.logger, 'OutputEvents'),
     });
     this.usageEvents = createUsageEvents({
-      logger: this.logger,
+      withErrorBoundary: createErrorBoundary(this.logger, 'UsageEvents'),
     });
     this.logEvents = createLogEvents({
-      logger: this.logger,
+      withErrorBoundary: createErrorBoundary(this.logger, 'LogEvents'),
     });
     this.taskGroupEvents = createTaskGroupEvents({
-      logger: this.logger,
+      withErrorBoundary: createErrorBoundary(this.logger, 'TaskGroupEvents'),
       initializeStreamForTaskGroup: (stream) =>
         this.initializeStreamForTaskGroup(stream),
+      debugLog: (message) => this.logger.debug(message),
     });
     this.retryEvents = createRetryEventsModule({
-      logger: this.logger,
+      withErrorBoundary: createErrorBoundary(this.logger, 'RetryEvents'),
       showRetryRequest: callbacks.showRetryRequest,
       resolveRetryRequest: callbacks.resolveRetryRequest,
     });
     this.approvalEvents = createApprovalEventsModule({
-      logger: this.logger,
+      withErrorBoundary: createErrorBoundary(this.logger, 'ApprovalEvents'),
       showToolEditApprovalPrompt: callbacks.showToolEditApprovalPrompt,
       resolveToolEditApprovalPrompt: callbacks.resolveToolEditApprovalPrompt,
       updateToolEditApprovalBypassState:

--- a/src/progressView/events/RetryEvents.ts
+++ b/src/progressView/events/RetryEvents.ts
@@ -5,7 +5,6 @@ import * as vscode from 'vscode';
 import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
 
 // Local file imports
-import { createErrorBoundary } from './errorHandling';
 import type {
   BaseEventShared,
   EventModuleBase,
@@ -38,7 +37,7 @@ export type RetryEventsModule = EventModuleBase;
 export function createRetryEventsModule(
   shared: RetryEventsShared,
 ): RetryEventsModule {
-  const withErrorBoundary = createErrorBoundary(shared.logger, 'RetryEvents');
+  const { withErrorBoundary } = shared;
 
   return {
     register(bus: ProgressEventBusLike): vscode.Disposable[] {

--- a/src/progressView/events/RetryEvents.ts
+++ b/src/progressView/events/RetryEvents.ts
@@ -1,16 +1,22 @@
 // Third-party imports
 import * as vscode from 'vscode';
 
-// Local imports
-import type { AgentLogger } from '@logger/AgentLogger';
+// Type imports
 import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
 
 // Local file imports
 import { createErrorBoundary } from './errorHandling';
-import type { ProgressEventBusLike } from './types';
+import type {
+  BaseEventShared,
+  EventModuleBase,
+  ProgressEventBusLike,
+} from './types';
 
-export interface RetryEventsShared {
-  logger: AgentLogger;
+/**
+ * Shared context for RetryEvents module.
+ * Extends BaseEventShared with retry-specific callbacks.
+ */
+export interface RetryEventsShared extends BaseEventShared {
   /** Callback to show retry request (routes through provider for queueing) */
   showRetryRequest: (
     payload: ProgressEventPayloads['showRetryRequest'],
@@ -19,9 +25,11 @@ export interface RetryEventsShared {
   resolveRetryRequest: (streamId: string) => void;
 }
 
-export interface RetryEventsModule {
-  register(bus: ProgressEventBusLike): vscode.Disposable[];
-}
+/**
+ * RetryEvents module interface.
+ * Uses EventModuleBase pattern (bus only, no state/updater).
+ */
+export type RetryEventsModule = EventModuleBase;
 
 /**
  * Creates a module for handling retry request events.

--- a/src/progressView/events/StreamStatusEvents.ts
+++ b/src/progressView/events/StreamStatusEvents.ts
@@ -1,29 +1,28 @@
 // Third-party imports
 import * as vscode from 'vscode';
 
-// Local imports - identifiers
+// Type imports
 import type { StreamTabId } from '@agent/types/IdentifierTypes';
 import { STREAM_STATUS } from '@common/constants/streamStatus';
-import type { AgentLogger } from '@logger/AgentLogger';
 import type { WebviewUpdater } from '@progressView/managers';
 import type { StreamTabInfo } from '@progressView/types';
-// Internal imports
+
+// Local imports
 import { buildStreamInfos } from '@progressView/streamInfoUtils';
-// Type imports
 import type { ProgressViewState } from '@progressView/state/ProgressViewState';
-import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
-
-// Internal imports
-
-// Local file imports
-import type { StreamStatus } from '@eventBus/ProgressEventBus';
+import type { ProgressEventPayloads, StreamStatus } from '@eventBus/ProgressEventBus';
 import { createErrorBoundary } from './errorHandling';
+import type {
+  BaseEventShared,
+  ProgressEventBusLike,
+  StatefulEventModule,
+} from './types';
 
-// Type imports
-import type { ProgressEventBusLike } from './types';
-
-export interface StreamStatusEventShared {
-  logger: AgentLogger;
+/**
+ * Shared context for StreamStatusEvents module.
+ * Extends BaseEventShared with stream status management callbacks.
+ */
+export interface StreamStatusEventShared extends BaseEventShared {
   streamStatus: Map<string, StreamStatus>;
   setStreamStatus(stream: string, status: StreamStatus): void;
   sendInstructionUpdate(stream: StreamTabId | '', runId?: string | null): void;
@@ -33,13 +32,11 @@ export interface StreamStatusEventShared {
   ): void;
 }
 
-export interface StreamStatusEventModule {
-  register(
-    bus: ProgressEventBusLike,
-    state: ProgressViewState,
-    updater: WebviewUpdater,
-  ): vscode.Disposable[];
-}
+/**
+ * StreamStatusEvents module interface.
+ * Uses StatefulEventModule pattern for state/updater access.
+ */
+export type StreamStatusEventModule = StatefulEventModule;
 
 export function createStreamStatusEvents(
   shared: StreamStatusEventShared,

--- a/src/progressView/events/StreamStatusEvents.ts
+++ b/src/progressView/events/StreamStatusEvents.ts
@@ -8,7 +8,10 @@ import type { WebviewUpdater } from '@progressView/managers';
 import type { StreamTabInfo } from '@progressView/types';
 import { buildStreamInfos } from '@progressView/streamInfoUtils';
 import type { ProgressViewState } from '@progressView/state/ProgressViewState';
-import type { ProgressEventPayloads, StreamStatus } from '@eventBus/ProgressEventBus';
+import type {
+  ProgressEventPayloads,
+  StreamStatus,
+} from '@eventBus/ProgressEventBus';
 
 // Local imports
 import type {

--- a/src/progressView/events/StreamStatusEvents.ts
+++ b/src/progressView/events/StreamStatusEvents.ts
@@ -6,12 +6,11 @@ import type { StreamTabId } from '@agent/types/IdentifierTypes';
 import { STREAM_STATUS } from '@common/constants/streamStatus';
 import type { WebviewUpdater } from '@progressView/managers';
 import type { StreamTabInfo } from '@progressView/types';
-
-// Local imports
 import { buildStreamInfos } from '@progressView/streamInfoUtils';
 import type { ProgressViewState } from '@progressView/state/ProgressViewState';
 import type { ProgressEventPayloads, StreamStatus } from '@eventBus/ProgressEventBus';
-import { createErrorBoundary } from './errorHandling';
+
+// Local imports
 import type {
   BaseEventShared,
   ProgressEventBusLike,
@@ -21,6 +20,7 @@ import type {
 /**
  * Shared context for StreamStatusEvents module.
  * Extends BaseEventShared with stream status management callbacks.
+ * Also requires logging callbacks for warn/debug messages.
  */
 export interface StreamStatusEventShared extends BaseEventShared {
   streamStatus: Map<string, StreamStatus>;
@@ -30,6 +30,8 @@ export interface StreamStatusEventShared extends BaseEventShared {
     stream: string,
     options?: { updateInstruction?: boolean; forceRebuild?: boolean },
   ): void;
+  warnLog(message: string): void;
+  debugLog(message: string): void;
 }
 
 /**
@@ -41,10 +43,7 @@ export type StreamStatusEventModule = StatefulEventModule;
 export function createStreamStatusEvents(
   shared: StreamStatusEventShared,
 ): StreamStatusEventModule {
-  const withErrorBoundary = createErrorBoundary(
-    shared.logger,
-    'StreamStatusEvents',
-  );
+  const { withErrorBoundary, warnLog, debugLog } = shared;
 
   const handleSetActiveStream = async (
     payload: ProgressEventPayloads['setActiveStream'],
@@ -119,7 +118,7 @@ export function createStreamStatusEvents(
     const normalizedState = state.getTaskState(streamTabId);
 
     if (!normalizedState) {
-      shared.logger.warn(
+      warnLog(
         `Received setTaskState for ${streamTabId} but no state was stored`,
       );
     } else {
@@ -133,7 +132,7 @@ export function createStreamStatusEvents(
         currentFilter !== 'all' &&
         currentFilter !== sessionKind
       ) {
-        shared.logger.debug(
+        debugLog(
           `Adjusting agent filter from ${currentFilter} to ${sessionKind} for stream ${streamTabId}`,
         );
         state.agentTypeFilter = sessionKind;

--- a/src/progressView/events/TaskGroupEvents.ts
+++ b/src/progressView/events/TaskGroupEvents.ts
@@ -11,7 +11,6 @@ import type { ProgressViewState } from '@progressView/state/ProgressViewState';
 import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
 
 // Local file imports
-import { createErrorBoundary } from './errorHandling';
 import type {
   BaseEventShared,
   ProgressEventBusLike,
@@ -21,9 +20,11 @@ import type {
 /**
  * Shared context for TaskGroupEvents module.
  * Extends BaseEventShared with task group initialization callback.
+ * Also requires debugLog for verbose logging during stream creation.
  */
 interface TaskGroupEventsShared extends BaseEventShared {
   initializeStreamForTaskGroup(stream: string): Promise<void>;
+  debugLog(message: string): void;
 }
 
 /**
@@ -35,10 +36,7 @@ export type TaskGroupEventsModule = StatefulEventModule;
 export function createTaskGroupEvents(
   shared: TaskGroupEventsShared,
 ): TaskGroupEventsModule {
-  const withErrorBoundary = createErrorBoundary(
-    shared.logger,
-    'TaskGroupEvents',
-  );
+  const { withErrorBoundary, debugLog } = shared;
 
   const handleAddTaskGroup = (
     data: ProgressEventPayloads['addTaskGroup'],
@@ -58,7 +56,7 @@ export function createTaskGroupEvents(
 
       const hasStream = state.streamTabs.has(stream);
       if (!hasStream) {
-        shared.logger.debug(`Creating stream from addTaskGroup: ${stream}`);
+        debugLog(`Creating stream from addTaskGroup: ${stream}`);
         await shared.initializeStreamForTaskGroup(stream);
       }
 

--- a/src/progressView/events/TaskGroupEvents.ts
+++ b/src/progressView/events/TaskGroupEvents.ts
@@ -1,8 +1,7 @@
 // Third-party imports
 import * as vscode from 'vscode';
 
-// Local imports - progress view
-import type { AgentLogger } from '@logger/AgentLogger';
+// Type imports
 import type { TaskGroup } from '@logger/LogTypes';
 import type {
   TaskGroupUpdatePayload,
@@ -13,22 +12,25 @@ import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
 
 // Local file imports
 import { createErrorBoundary } from './errorHandling';
+import type {
+  BaseEventShared,
+  ProgressEventBusLike,
+  StatefulEventModule,
+} from './types';
 
-// Type imports
-import type { ProgressEventBusLike } from './types';
-
-interface TaskGroupEventsShared {
-  logger: AgentLogger;
+/**
+ * Shared context for TaskGroupEvents module.
+ * Extends BaseEventShared with task group initialization callback.
+ */
+interface TaskGroupEventsShared extends BaseEventShared {
   initializeStreamForTaskGroup(stream: string): Promise<void>;
 }
 
-export interface TaskGroupEventsModule {
-  register(
-    bus: ProgressEventBusLike,
-    state: ProgressViewState,
-    updater: WebviewUpdater,
-  ): vscode.Disposable[];
-}
+/**
+ * TaskGroupEvents module interface.
+ * Uses StatefulEventModule pattern for state/updater access.
+ */
+export type TaskGroupEventsModule = StatefulEventModule;
 
 export function createTaskGroupEvents(
   shared: TaskGroupEventsShared,

--- a/src/progressView/events/UsageEvents.ts
+++ b/src/progressView/events/UsageEvents.ts
@@ -7,7 +7,6 @@ import type { WebviewUpdater } from '@progressView/managers';
 import type { ProgressViewState } from '@progressView/state/ProgressViewState';
 
 // Local file imports
-import { createErrorBoundary } from './errorHandling';
 import type {
   BaseEventShared,
   ProgressEventBusLike,
@@ -22,14 +21,14 @@ export type UsageEventsModule = StatefulEventModule;
 
 /**
  * Shared context for UsageEvents module.
- * Uses BaseEventShared which provides logger for error boundary.
+ * Uses BaseEventShared which provides withErrorBoundary.
  */
 type UsageEventsShared = BaseEventShared;
 
 export function createUsageEvents(
   shared: UsageEventsShared,
 ): UsageEventsModule {
-  const withErrorBoundary = createErrorBoundary(shared.logger, 'UsageEvents');
+  const { withErrorBoundary } = shared;
 
   return {
     register(

--- a/src/progressView/events/UsageEvents.ts
+++ b/src/progressView/events/UsageEvents.ts
@@ -1,29 +1,30 @@
 // Third-party imports
 import * as vscode from 'vscode';
 
-// Local imports - progress view
+// Type imports
 import type { TokenUsageStats } from '@agent/types/UsageTypes';
-import type { AgentLogger } from '@logger/AgentLogger';
 import type { WebviewUpdater } from '@progressView/managers';
 import type { ProgressViewState } from '@progressView/state/ProgressViewState';
 
 // Local file imports
 import { createErrorBoundary } from './errorHandling';
+import type {
+  BaseEventShared,
+  ProgressEventBusLike,
+  StatefulEventModule,
+} from './types';
 
-// Type imports
-import type { ProgressEventBusLike } from './types';
+/**
+ * UsageEvents module interface.
+ * Uses StatefulEventModule pattern for state/updater access.
+ */
+export type UsageEventsModule = StatefulEventModule;
 
-export interface UsageEventsModule {
-  register(
-    bus: ProgressEventBusLike,
-    state: ProgressViewState,
-    updater: WebviewUpdater,
-  ): vscode.Disposable[];
-}
-
-interface UsageEventsShared {
-  logger: AgentLogger;
-}
+/**
+ * Shared context for UsageEvents module.
+ * Uses BaseEventShared which provides logger for error boundary.
+ */
+type UsageEventsShared = BaseEventShared;
 
 export function createUsageEvents(
   shared: UsageEventsShared,

--- a/src/progressView/events/errorHandling.ts
+++ b/src/progressView/events/errorHandling.ts
@@ -1,10 +1,19 @@
 // Local imports - logger
 import type { AgentLogger } from '@logger/AgentLogger';
 
+/**
+ * Type for error boundary functions created by createErrorBoundary.
+ * Wraps async handlers to catch and log errors.
+ */
+export type ErrorBoundaryFn = (
+  context: string,
+  fn: () => unknown | Promise<unknown>,
+) => void;
+
 export function createErrorBoundary(
   logger: AgentLogger,
   moduleName: string,
-): (context: string, fn: () => unknown | Promise<unknown>) => void {
+): ErrorBoundaryFn {
   return (context: string, fn: () => unknown | Promise<unknown>): void => {
     try {
       const result = fn();

--- a/src/progressView/events/types.ts
+++ b/src/progressView/events/types.ts
@@ -1,5 +1,4 @@
 // Type imports
-import type { AgentLogger } from '@logger/AgentLogger';
 import type { WebviewUpdater } from '@progressView/managers';
 import type { ProgressViewState } from '@progressView/state/ProgressViewState';
 import type {
@@ -7,6 +6,9 @@ import type {
   ProgressEventPayloads,
 } from '@eventBus/ProgressEventBus';
 import type * as vscode from 'vscode';
+
+// Local imports
+import type { ErrorBoundaryFn } from './errorHandling';
 
 // ============================================================================
 // Event Bus Interface
@@ -29,10 +31,10 @@ export interface ProgressEventBusLike {
 
 /**
  * Base shared context for all event modules.
- * All event modules require a logger for error boundary handling.
+ * Provides pre-configured error boundary - modules don't need to create their own.
  */
 export interface BaseEventShared {
-  logger: AgentLogger;
+  withErrorBoundary: ErrorBoundaryFn;
 }
 
 /**

--- a/src/progressView/events/types.ts
+++ b/src/progressView/events/types.ts
@@ -1,8 +1,16 @@
-// Local imports - event bus
+// Type imports
+import type { AgentLogger } from '@logger/AgentLogger';
+import type { WebviewUpdater } from '@progressView/managers';
+import type { ProgressViewState } from '@progressView/state/ProgressViewState';
 import type {
   ProgressEvent,
   ProgressEventPayloads,
 } from '@eventBus/ProgressEventBus';
+import type * as vscode from 'vscode';
+
+// ============================================================================
+// Event Bus Interface
+// ============================================================================
 
 export interface ProgressEventBusLike {
   on<K extends ProgressEvent>(
@@ -13,4 +21,36 @@ export interface ProgressEventBusLike {
     event: K,
     payload: ProgressEventPayloads[K],
   ): void;
+}
+
+// ============================================================================
+// Base Interfaces for Event Modules
+// ============================================================================
+
+/**
+ * Base shared context for all event modules.
+ * All event modules require a logger for error boundary handling.
+ */
+export interface BaseEventShared {
+  logger: AgentLogger;
+}
+
+/**
+ * Base event module interface for simple event handlers (bus only).
+ * Used by modules like ApprovalEvents, RetryEvents that don't need state/updater.
+ */
+export interface EventModuleBase {
+  register(bus: ProgressEventBusLike): vscode.Disposable[];
+}
+
+/**
+ * Stateful event module interface for handlers needing state and updater.
+ * Used by modules like LogEvents, OutputEvents, UsageEvents, etc.
+ */
+export interface StatefulEventModule {
+  register(
+    bus: ProgressEventBusLike,
+    state: ProgressViewState,
+    updater: WebviewUpdater,
+  ): vscode.Disposable[];
 }

--- a/src/progressView/managers/UsageStatsManager.ts
+++ b/src/progressView/managers/UsageStatsManager.ts
@@ -33,10 +33,12 @@ const TokenUsageStatsParsingSchema = z
   })
   .catch({ inputTokens: 0, outputTokens: 0, cost: 0 });
 
-// Compile-time assertion: ensure parsing schema produces compatible type
-const _typeCheck: z.infer<typeof TokenUsageStatsParsingSchema> =
-  {} as TokenUsageStats;
-void _typeCheck;
+// Compile-time assertion: ensure parsing schema produces type compatible with TokenUsageStats
+type _AssertSchemaCompatible =
+  z.infer<typeof TokenUsageStatsParsingSchema> extends TokenUsageStats
+    ? true
+    : never;
+const _assertCompatible: _AssertSchemaCompatible = true;
 
 /** Checks if usage stats are all zeros (effectively empty) */
 function isEmptyUsage(usage: TokenUsageStats): boolean {

--- a/src/progressView/managers/UsageStatsManager.ts
+++ b/src/progressView/managers/UsageStatsManager.ts
@@ -46,9 +46,12 @@ function isEmptyUsage(usage: TokenUsageStats): boolean {
 }
 
 /** Schema for run map format: { runId: { inputTokens, outputTokens, cost } } */
-const UsageDataSchema = createSingleValueRunMapSchema(TokenUsageStatsParsingSchema, {
-  isEmpty: isEmptyUsage,
-});
+const UsageDataSchema = createSingleValueRunMapSchema(
+  TokenUsageStatsParsingSchema,
+  {
+    isEmpty: isEmptyUsage,
+  },
+);
 
 /**
  * Manages usage statistics collection with persistence.

--- a/src/progressView/managers/UsageStatsManager.ts
+++ b/src/progressView/managers/UsageStatsManager.ts
@@ -3,8 +3,8 @@ import { z } from 'zod';
 
 // Local imports - identifiers
 import type { StorageKey, StreamTabId } from '@agent/types/IdentifierTypes';
-// Types
-import type { TokenUsageStats } from '@agent/types/UsageTypes';
+// Types - import canonical type (schema defines structure)
+import { type TokenUsageStats } from '@agent/types/UsageTypes';
 import { normalizeRunId } from '@common/constants/runIds';
 import { WorkspaceStateKey } from '@common/state/stateManager';
 import { AgentLogger } from '@logger/AgentLogger';
@@ -21,14 +21,22 @@ const FiniteNumber = z.coerce
   .number()
   .transform((n) => (Number.isFinite(n) ? n : 0));
 
-/** Schema for TokenUsageStats with safe number coercion */
-const TokenUsageStatsSchema = z
+/**
+ * Schema for parsing TokenUsageStats with safe number coercion.
+ * Extends the canonical schema shape with coercion for persistence resilience.
+ */
+const TokenUsageStatsParsingSchema = z
   .object({
     inputTokens: FiniteNumber,
     outputTokens: FiniteNumber,
     cost: FiniteNumber,
   })
   .catch({ inputTokens: 0, outputTokens: 0, cost: 0 });
+
+// Compile-time assertion: ensure parsing schema produces compatible type
+const _typeCheck: z.infer<typeof TokenUsageStatsParsingSchema> =
+  {} as TokenUsageStats;
+void _typeCheck;
 
 /** Checks if usage stats are all zeros (effectively empty) */
 function isEmptyUsage(usage: TokenUsageStats): boolean {
@@ -38,7 +46,7 @@ function isEmptyUsage(usage: TokenUsageStats): boolean {
 }
 
 /** Schema for run map format: { runId: { inputTokens, outputTokens, cost } } */
-const UsageDataSchema = createSingleValueRunMapSchema(TokenUsageStatsSchema, {
+const UsageDataSchema = createSingleValueRunMapSchema(TokenUsageStatsParsingSchema, {
   isEmpty: isEmptyUsage,
 });
 
@@ -73,7 +81,7 @@ export class UsageStatsManager extends PersistentMapManager<
     storageKey: StorageKey,
     usage: TokenUsageStats,
   ): Promise<void> {
-    const normalized = TokenUsageStatsSchema.parse(usage);
+    const normalized = TokenUsageStatsParsingSchema.parse(usage);
     const current =
       this.items.get(stream) ?? new Map<string, TokenUsageStats>();
     if (
@@ -170,7 +178,7 @@ export class UsageStatsManager extends PersistentMapManager<
         continue;
       }
 
-      const usage = TokenUsageStatsSchema.parse(value);
+      const usage = TokenUsageStatsParsingSchema.parse(value);
       if (
         usage.inputTokens === 0 &&
         usage.outputTokens === 0 &&
@@ -262,7 +270,7 @@ export class UsageStatsManager extends PersistentMapManager<
     }
 
     const totals = legacy.usageAccumulator.totals;
-    const usage: TokenUsageStats = TokenUsageStatsSchema.parse({
+    const usage: TokenUsageStats = TokenUsageStatsParsingSchema.parse({
       inputTokens: totals.totalInputTokens ?? 0,
       outputTokens: totals.totalOutputTokens ?? 0,
       cost: totals.totalCost ?? 0,

--- a/src/test/progressView/events/LogEvents.test.ts
+++ b/src/test/progressView/events/LogEvents.test.ts
@@ -7,6 +7,7 @@ import type { LogMessageData } from '@logger/LogTypes';
 import { MESSAGE_TYPES } from '@logger/messageTypes';
 
 // Local imports - progress view
+import { createErrorBoundary } from '@progressView/events/errorHandling';
 import { createLogEvents } from '@progressView/events/LogEvents';
 import type { ProgressEventBusLike } from '@progressView/events/types';
 import { StreamTabsManager } from '@progressView/managers/StreamTabsManager';
@@ -80,7 +81,8 @@ describe('LogEvents', () => {
 
     const bus = new TestBus();
     const logger = new AgentLogger('LogEventsTest');
-    const { register } = createLogEvents({ logger });
+    const withErrorBoundary = createErrorBoundary(logger, 'LogEventsTest');
+    const { register } = createLogEvents({ withErrorBoundary });
     const disposables = register(bus, state, updater);
 
     const thinkingMessage: LogMessageData = {

--- a/src/tools/result.ts
+++ b/src/tools/result.ts
@@ -1,6 +1,62 @@
+// Third-party imports
+import { z } from 'zod';
+
 // Type imports
 import type { Diagnostic } from 'vscode';
 import type { ZodIssue } from 'zod';
+
+// ============================================================================
+// Zod Schemas - Single Source of Truth
+// ============================================================================
+
+/**
+ * Schema for line change statistics.
+ * Single source of truth - used by ToolResult, edits, and model handlers.
+ */
+export const LineChangesSchema = z.object({
+  added: z.number(),
+  removed: z.number(),
+});
+export type LineChanges = z.infer<typeof LineChangesSchema>;
+
+/**
+ * Base schema for file references (metadata only, no binary data).
+ * Used when binary data has been stripped for serialization/logging.
+ */
+export const FileReferenceSchema = z.object({
+  /** Workspace-relative or descriptive path for the file */
+  path: z.string(),
+  /** MIME type for the file */
+  mimeType: z.string(),
+  /** Optional human readable description */
+  description: z.string().optional(),
+});
+export type FileReference = z.infer<typeof FileReferenceSchema>;
+
+/**
+ * Schema for file attachments with optional binary data.
+ * Extends FileReferenceSchema with binary payload fields.
+ */
+export const ToolFileAttachmentSchema = FileReferenceSchema.extend({
+  /** Base64 encoded payload when inline transport is supported */
+  base64Data: z.string().optional(),
+  /** Raw bytes for providers that require binary uploads */
+  bytes: z.custom<Uint8Array>((val) => val instanceof Uint8Array).optional(),
+});
+export type ToolFileAttachment = z.infer<typeof ToolFileAttachmentSchema>;
+
+/**
+ * Schema for edit records in tool results.
+ */
+export const EditRecordSchema = z.object({
+  path: z.string(),
+  lineChanges: LineChangesSchema.optional(),
+});
+export type EditRecord = z.infer<typeof EditRecordSchema>;
+
+// ============================================================================
+// Diagnostics Types (not Zod - these are complex unions with external types)
+// ============================================================================
 
 export interface DiagnosticsPayload {
   path: string;
@@ -16,34 +72,37 @@ export type ErrorDiagnostics =
   | DiagnosticsPayload // For diagnostics payloads returned by tools
   | unknown; // For other types of diagnostics
 
-export interface ToolFileAttachment {
-  /** Workspace-relative or descriptive path for the attachment */
-  path: string;
-  /** MIME type for the attachment payload */
-  mimeType: string;
-  /** Optional human readable description */
-  description?: string;
-  /** Base64 encoded payload when inline transport is supported */
-  base64Data?: string;
-  /** Raw bytes for providers that require binary uploads */
-  bytes?: Uint8Array;
-}
+// ============================================================================
+// ToolResult Schema
+// ============================================================================
 
-export interface ToolResult {
-  output?: string;
-  summary?: string;
-  error?: string;
-  userInstruction?: string;
-  userPatch?: string;
-  lineChanges?: { added: number; removed: number };
-  edits?: {
-    path: string;
-    lineChanges?: { added: number; removed: number };
-  }[];
-  isError?: boolean;
-  diagnostics?: ErrorDiagnostics; // Additional error details like validation issues
-  files?: ToolFileAttachment[];
-}
+/**
+ * Schema for tool execution results.
+ * Uses looseObject to allow additional properties for forward compatibility.
+ */
+export const ToolResultSchema = z.looseObject({
+  /** Detailed output from the tool */
+  output: z.string().optional(),
+  /** Brief summary of the tool execution result */
+  summary: z.string().optional(),
+  /** Error message if tool execution failed */
+  error: z.string().optional(),
+  /** User instruction that was processed */
+  userInstruction: z.string().optional(),
+  /** User-provided patch content */
+  userPatch: z.string().optional(),
+  /** Statistics about line changes made */
+  lineChanges: LineChangesSchema.optional(),
+  /** Records of edits made during tool execution */
+  edits: z.array(EditRecordSchema).optional(),
+  /** Whether this result represents an error */
+  isError: z.boolean().optional(),
+  /** Additional diagnostic information */
+  diagnostics: z.unknown().optional(),
+  /** File attachments (may contain binary data) */
+  files: z.array(ToolFileAttachmentSchema).optional(),
+});
+export type ToolResult = z.infer<typeof ToolResultSchema>;
 
 export function toolResult(result: ToolResult): ToolResult {
   return result;

--- a/src/webview/MainViewMessageHandler.ts
+++ b/src/webview/MainViewMessageHandler.ts
@@ -39,10 +39,9 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
   private readonly executionManager: ExecutionManager;
   private readonly diffManager: DiffManager;
   private readonly instructionManager: InstructionManager;
-  private activeView: vscode.WebviewView | undefined;
 
   constructor(private readonly context: vscode.ExtensionContext) {
-    super('MainView');
+    super('MainView', { trackActiveView: true });
     this.settingsManager = new SettingsManager();
     this.recordingManager = new RecordingManager(context, {
       recordingStartedCommand: MAIN_VIEW_COMMANDS.RECORDING_STARTED,
@@ -61,20 +60,12 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
     message: any,
     webviewView: vscode.WebviewView,
   ): Promise<void> {
-    this.activeView = webviewView;
+    // Attach webview to managers that need it for message posting
     this.fileManager.attachWebview(webviewView);
     this.instructionManager.attachWebview(webviewView);
 
+    // Base class handles activeView tracking when trackActiveView is enabled
     await super.handleMessage(message, webviewView);
-  }
-
-  private getActiveView(): vscode.WebviewView | undefined {
-    if (!this.activeView) {
-      this.logger.warn(this.channel, 'No active webview available');
-      return undefined;
-    }
-
-    return this.activeView;
   }
 
   protected createHandlers(): Record<

--- a/src/webview/types/messages.ts
+++ b/src/webview/types/messages.ts
@@ -77,26 +77,28 @@ export const FileSelectionMessageSchema = BaseMessageSchema;
 export type FileSelectionMessage = z.infer<typeof FileSelectionMessageSchema>;
 
 /**
- * Input file selected message from webview
+ * Base schema for file selected messages.
+ * Shared structure for InputFileSelected and GenericFileSelected.
  */
-export const InputFileSelectedMessageSchema = BaseMessageSchema.extend(
+export const FileSelectedMessageSchema = BaseMessageSchema.extend(
   WithFilePath.shape,
 );
 
-export type InputFileSelectedMessage = z.infer<
-  typeof InputFileSelectedMessageSchema
->;
+export type FileSelectedMessage = z.infer<typeof FileSelectedMessageSchema>;
 
 /**
- * Generic file selected message from webview
+ * Input file selected message from webview.
+ * Alias for FileSelectedMessageSchema for semantic clarity.
  */
-export const GenericFileSelectedMessageSchema = BaseMessageSchema.extend(
-  WithFilePath.shape,
-);
+export const InputFileSelectedMessageSchema = FileSelectedMessageSchema;
+export type InputFileSelectedMessage = FileSelectedMessage;
 
-export type GenericFileSelectedMessage = z.infer<
-  typeof GenericFileSelectedMessageSchema
->;
+/**
+ * Generic file selected message from webview.
+ * Alias for FileSelectedMessageSchema for semantic clarity.
+ */
+export const GenericFileSelectedMessageSchema = FileSelectedMessageSchema;
+export type GenericFileSelectedMessage = FileSelectedMessage;
 
 /**
  * Request input file message from webview


### PR DESCRIPTION
Establish single source of truth for file attachment schemas in result.ts:
- Move LineChangesSchema, FileReferenceSchema, ToolFileAttachmentSchema to result.ts
- Use .extend() for schema inheritance (FileReference → ToolFileAttachment)
- Derive all types from schemas using z.infer<>
- Add EditRecordSchema and ToolResultSchema for full type coverage
- Re-export schemas from toolAttachmentUtils.ts for backwards compatibility

This eliminates duplicate definitions and ensures types can never drift
from their schema definitions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Centralizes tool/file schemas in `@tools/result`, adds `ToolResult` schema, refactors webview handlers to track active views, and unifies progress-view event modules with shared error boundaries and cleaner types.
> 
> - **Schemas/Types**:
>   - Consolidate `LineChangesSchema`, `FileReferenceSchema`, `ToolFileAttachmentSchema`, `EditRecordSchema`, and new `ToolResultSchema` in `src/tools/result.ts` as single source of truth; re-export in `toolAttachmentUtils.ts`.
>   - Update `toolAttachmentUtils.ts` to consume shared schemas, add `EditedFileRecordSchema`, and define `ToolResultPayloadSchema` using `z.looseObject`.
> - **Webview Framework**:
>   - Add `MessageHandlerOptions.trackActiveView` and active view tracking to `BaseViewMessageHandler` with `getActiveView()`; export options in barrel.
>   - Refactor `MainViewMessageHandler` and `ProgressViewMessageHandler` to use base active-view tracking and remove local tracking.
>   - Unify file-selected message schemas via `FileSelectedMessageSchema` with aliases for input/generic variants.
> - **Progress View Events**:
>   - Introduce `BaseEventShared` with pre-configured `withErrorBoundary` and new module interfaces (`EventModuleBase`, `StatefulEventModule`).
>   - Refactor event modules (`StreamStatusEvents`, `LogEvents`, `OutputEvents`, `UsageEvents`, `TaskGroupEvents`, `RetryEvents`, `ApprovalEvents`) to use shared error boundary and cleaner shared types; inject warn/debug callbacks where needed.
>   - Wire centralized error boundaries in `ProgressEventHandler` and pass logging callbacks; minor status/stream initialization tweaks.
> - **Usage Stats**:
>   - Harden parsing with `TokenUsageStatsParsingSchema` (number coercion, defaults) in `UsageStatsManager`; apply across set/load/migration.
> - **Tests**:
>   - Update `LogEvents` test to use `createErrorBoundary` and new factory signature.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9428d60e744d63e2d75e2c031a184e5e339cea94. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->