### PR TITLE
feat: display native web search tool results in progress view

### DIFF
--- a/resources/tool_use_agents/search.yaml
+++ b/resources/tool_use_agents/search.yaml
@@ -1,0 +1,50 @@
+name: search
+description: Research assistant with web search and literature discovery tools.
+
+settings:
+  agentType: toolUse
+  tools:
+    - bash
+    - read_file
+    - glob
+    - grep
+    - ls
+    - extract_figures
+    - extract_bib_entries
+    - extract_tikz_figures
+    - arxiv_search
+    - arxiv_metadata
+    - crossref_search
+    - crossref_doi
+    - web_search
+    - web_fetch
+prompts:
+  systemPrompt: |
+    You are a research assistant helping the user discover and synthesize information from the web and academic literature. Reason deeply.
+
+    Mathematical Communication: (1) Use $...$ for inline math expressions. (2) Define all notation before use. (3) Show reasoning step-by-step, not just final results. (4) For complex problems, outline your approach before diving into details.
+
+    Research Workflow:
+    (1) Use web_search and web_fetch to find current information, news, and general resources.
+    (2) Use arxiv_search and arxiv_metadata for preprints and recent academic work.
+    (3) Use crossref_search and crossref_doi for published literature and citations.
+    (4) Cross-reference multiple sources to verify information.
+    (5) Synthesize findings into coherent summaries with proper citations.
+
+    Source Handling:
+    (1) Always cite sources with URLs, DOIs, or arXiv IDs.
+    (2) Distinguish between peer-reviewed publications, preprints, and web sources.
+    (3) Note publication dates to assess recency of information.
+    (4) When conflicting information is found, present multiple perspectives.
+
+    File Operations:
+    (1) You can read files to understand context but cannot edit or create files.
+    (2) Use read_file, glob, grep, and ls to explore the user's workspace.
+    (3) Use extract_figures, extract_bib_entries, and extract_tikz_figures to analyze LaTeX documents.
+
+    Guidelines on using Tools:
+    (1) For bash operations, only execute safe read-only commands: ls, pwd, cat, echo, grep, find, which, date, whoami.
+    (2) Do not execute commands that modify files or system state.
+    (3) Clearly explain what any command will do before executing it.
+  userRequest: |
+    {{ INSTRUCTION }}

--- a/src/agent/core/AgentWorkspaceState.ts
+++ b/src/agent/core/AgentWorkspaceState.ts
@@ -200,15 +200,12 @@ export class ServerToolContentState {
    * Server tool content blocks extracted from the model response.
    * These include server_tool_use, web_search_tool_result (Anthropic),
    * and web_search_call (OpenAI) blocks.
+   * Cleared after being consumed by createToolUseFollowUpMessages().
    */
   public contentBlocks: ServerToolContentBlock[] = [];
 
-  /** Whether content has been added to messages (prevents duplicates) */
-  public contentAdded = false;
-
   reset(): void {
     this.contentBlocks = [];
-    this.contentAdded = false;
   }
 }
 

--- a/src/agent/core/AgentWorkspaceState.ts
+++ b/src/agent/core/AgentWorkspaceState.ts
@@ -181,6 +181,39 @@ export class ReasoningCacheState {
   }
 }
 
+/**
+ * Cache for server tool content blocks (e.g., web_search results from Anthropic).
+ * These blocks need to be preserved in the assistant message when local tools are also present.
+ */
+export class ServerToolContentState {
+  /**
+   * Server tool content blocks extracted from the model response.
+   * These include server_tool_use and web_search_tool_result blocks.
+   */
+  public contentBlocks: unknown[] = [];
+
+  /**
+   * Store server tool content blocks to be included in follow-up messages.
+   */
+  setContentBlocks(blocks: unknown[]): void {
+    this.contentBlocks = blocks;
+  }
+
+  /**
+   * Clear stored content blocks (call after they've been added to messages).
+   */
+  reset(): void {
+    this.contentBlocks = [];
+  }
+
+  /**
+   * Check if there are server tool content blocks to include.
+   */
+  hasContent(): boolean {
+    return this.contentBlocks.length > 0;
+  }
+}
+
 export class DocumentStatsState {
   public texcountStats: string | null = null;
 
@@ -239,9 +272,14 @@ export class AgentWorkspaceState {
   public readonly reasoning = new ReasoningCacheState();
   public readonly document = new DocumentStatsState();
   public readonly interactions = new FileInteractionState();
+  public readonly serverToolContent = new ServerToolContentState();
 
   resetReasoning(): void {
     this.reasoning.reset();
+  }
+
+  resetServerToolContent(): void {
+    this.serverToolContent.reset();
   }
 
   toJSON(): AgentWorkspaceSnapshot {

--- a/src/agent/core/AgentWorkspaceState.ts
+++ b/src/agent/core/AgentWorkspaceState.ts
@@ -201,25 +201,12 @@ export class ServerToolContentState {
    */
   public contentBlocks: unknown[] = [];
 
-  /**
-   * Store server tool content blocks to be included in follow-up messages.
-   */
-  setContentBlocks(blocks: unknown[]): void {
-    this.contentBlocks = blocks;
-  }
+  /** Whether content has been added to messages (prevents duplicates) */
+  public contentAdded = false;
 
-  /**
-   * Clear stored content blocks (call after they've been added to messages).
-   */
   reset(): void {
     this.contentBlocks = [];
-  }
-
-  /**
-   * Check if there are server tool content blocks to include.
-   */
-  hasContent(): boolean {
-    return this.contentBlocks.length > 0;
+    this.contentAdded = false;
   }
 }
 

--- a/src/agent/core/AgentWorkspaceState.ts
+++ b/src/agent/core/AgentWorkspaceState.ts
@@ -204,8 +204,17 @@ export class ServerToolContentState {
    */
   public contentBlocks: ServerToolContentBlock[] = [];
 
+  /**
+   * Full assistant content blocks from the last response, excluding tool_use.
+   * Preserves original order for building correct follow-up messages.
+   * Includes: thinking, text, server_tool_use, web_search_tool_result blocks.
+   * Cleared after being consumed by createToolUseFollowUpMessages().
+   */
+  public lastAssistantContent: unknown[] = [];
+
   reset(): void {
     this.contentBlocks = [];
+    this.lastAssistantContent = [];
   }
 }
 

--- a/src/agent/core/AgentWorkspaceState.ts
+++ b/src/agent/core/AgentWorkspaceState.ts
@@ -209,6 +209,11 @@ export class ServerToolContentState {
    * Preserves original order for building correct follow-up messages.
    * Includes: thinking, text, server_tool_use, web_search_tool_result blocks.
    * Cleared after being consumed by createToolUseFollowUpMessages().
+   *
+   * Typed as unknown[] because content block types differ across providers:
+   * - Anthropic: ContentBlockParam (thinking, text, server_tool_use, etc.)
+   * - OpenAI: ResponseInputItem (message, function_call, web_search_call, etc.)
+   * Each handler casts to provider-specific types when consuming.
    */
   public lastAssistantContent: unknown[] = [];
 

--- a/src/agent/core/AgentWorkspaceState.ts
+++ b/src/agent/core/AgentWorkspaceState.ts
@@ -1,6 +1,8 @@
 // Third-party imports
 import { z } from 'zod';
 
+import type { ServerToolContentBlock } from '@agent/modelHandlers/types/ServerToolTypes';
+
 /**
  * Thinking block from reasoning models.
  * This represents the internal reasoning/thinking output from models like Claude Sonnet 4.
@@ -196,10 +198,10 @@ export class ReasoningCacheState {
 export class ServerToolContentState {
   /**
    * Server tool content blocks extracted from the model response.
-   * These include server_tool_use and web_search_tool_result blocks.
-   * Type is `unknown[]` because different providers have different block types.
+   * These include server_tool_use, web_search_tool_result (Anthropic),
+   * and web_search_call (OpenAI) blocks.
    */
-  public contentBlocks: unknown[] = [];
+  public contentBlocks: ServerToolContentBlock[] = [];
 
   /** Whether content has been added to messages (prevents duplicates) */
   public contentAdded = false;

--- a/src/agent/core/AgentWorkspaceState.ts
+++ b/src/agent/core/AgentWorkspaceState.ts
@@ -184,11 +184,20 @@ export class ReasoningCacheState {
 /**
  * Cache for server tool content blocks (e.g., web_search results from Anthropic).
  * These blocks need to be preserved in the assistant message when local tools are also present.
+ *
+ * **EPHEMERAL STATE**: This state is intentionally NOT serialized to snapshots.
+ * Server tool content is only relevant within a single tool use cycle and is automatically
+ * cleared after being consumed by `createToolUseFollowUpMessages()` or when the end-turn
+ * branch is taken. It does not need to survive state restoration since:
+ * 1. The response object containing the content is not persisted
+ * 2. Upon restoration, the model will generate fresh server tool content if needed
+ * 3. Stale content would cause duplicate blocks in conversation history
  */
 export class ServerToolContentState {
   /**
    * Server tool content blocks extracted from the model response.
    * These include server_tool_use and web_search_tool_result blocks.
+   * Type is `unknown[]` because different providers have different block types.
    */
   public contentBlocks: unknown[] = [];
 

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -497,6 +497,19 @@ class ToolUseProcessNode<C> extends BaseNode<
     store.workspace.serverToolContent.contentBlocks =
       serverToolData.contentBlocks;
 
+    // Store full assistant content (excluding tool_use) to preserve original order
+    // This is used in createToolUseFollowUpMessages for correct message building
+    // Works with Anthropic-style responses that have a content array
+    const responseContent = (state.response as { content?: unknown[] })?.content;
+    store.workspace.serverToolContent.lastAssistantContent = Array.isArray(
+      responseContent,
+    )
+      ? responseContent.filter((block) => {
+          const typed = block as { type?: string } | null | undefined;
+          return typed?.type !== 'tool_use';
+        })
+      : [];
+
     if (text) {
       options.logger.debug(`Model response: ${text.slice(0, 100)}`, {
         groupId,

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -491,9 +491,11 @@ class ToolUseProcessNode<C> extends BaseNode<
     }
 
     // Cache content blocks for use in follow-up messages
+    // Reset contentAdded flag when storing new blocks to ensure they get added
     if (serverToolData.contentBlocks.length > 0) {
       store.workspace.serverToolContent.contentBlocks =
         serverToolData.contentBlocks;
+      store.workspace.serverToolContent.contentAdded = false;
     }
 
     if (text) {

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -532,7 +532,9 @@ class ToolUseProcessNode<C> extends BaseNode<
         state.messages.push(options.modelHandler.createAssistantMessage(text));
         store.workspace.assembly.updateLastResponse(text);
       }
+      // Clear ephemeral state so stale data isn't used in subsequent requests
       store.workspace.resetServerToolContent();
+      store.workspace.resetReasoning();
       state.shouldStop = true;
       return {
         skipped: false,

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -12,7 +12,6 @@ import {
 } from '@agent/core/flows/CommonCycleTypes';
 import type { SdkToolCall } from '@agent/modelHandlers/types/IModelHandler';
 import type { ProviderStopReason } from '@agent/modelHandlers/types/StopReasonTypes';
-// WebSearchResult import removed - not needed with unified extraction
 
 // Local imports - utilities
 import { maybeSaveDebugObject } from '@agent/utils/debugMessageSaver';

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -499,17 +499,9 @@ class ToolUseProcessNode<C> extends BaseNode<
 
     // Store full assistant content (excluding tool_use) to preserve original order
     // This is used in createToolUseFollowUpMessages for correct message building
-    // Works with Anthropic-style responses that have a content array
-    const responseContent = (state.response as { content?: unknown[] })
-      ?.content;
-    store.workspace.serverToolContent.lastAssistantContent = Array.isArray(
-      responseContent,
-    )
-      ? responseContent.filter((block) => {
-          const typed = block as { type?: string } | null | undefined;
-          return typed?.type !== 'tool_use';
-        })
-      : [];
+    // Uses provider-agnostic extraction method
+    store.workspace.serverToolContent.lastAssistantContent =
+      options.modelHandler.extractAssistantContent(state.response);
 
     if (text) {
       options.logger.debug(`Model response: ${text.slice(0, 100)}`, {

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -491,10 +491,8 @@ class ToolUseProcessNode<C> extends BaseNode<
 
     // Cache content blocks for use in follow-up messages
     // Always assign to clear stale blocks from previous responses
-    // Reset contentAdded flag when storing new blocks to ensure they get added
     store.workspace.serverToolContent.contentBlocks =
       serverToolData.contentBlocks;
-    store.workspace.serverToolContent.contentAdded = false;
 
     if (text) {
       options.logger.debug(`Model response: ${text.slice(0, 100)}`, {

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -530,30 +530,12 @@ class ToolUseProcessNode<C> extends BaseNode<
 
     if (!toolCalls || toolCalls.length === 0 || endTurn) {
       state.toolCalls = undefined;
-      // Preserve response content if there's text OR server tool content (e.g., web_search)
-      // Server tool content can exist without text (model did a search but no text output)
-      const hasServerToolContent = serverToolData.contentBlocks.length > 0;
-      if (text || hasServerToolContent) {
-        // Use createAssistantMessageFromResponse to preserve server tool content
-        // (e.g., web_search results) in the conversation context
-        const assistantMessage =
-          options.modelHandler.createAssistantMessageFromResponse(
-            state.response,
-            text ?? '',
-          );
-        // Handle both single message and array returns (OpenAI may return array)
-        if (Array.isArray(assistantMessage)) {
-          state.messages.push(...assistantMessage);
-        } else {
-          state.messages.push(assistantMessage);
-        }
-        if (text) {
-          store.workspace.assembly.updateLastResponse(text);
-        }
+      // End turn - just preserve text. Server tool content (web_search) was already
+      // logged to progress view and is not needed in message history when stopping.
+      if (text) {
+        state.messages.push(options.modelHandler.createAssistantMessage(text));
+        store.workspace.assembly.updateLastResponse(text);
       }
-      // Clear server tool content state to prevent stale content in subsequent requests
-      // This is done here since createAssistantMessageFromResponse reads directly from response,
-      // not from workspace state cache
       store.workspace.resetServerToolContent();
       state.shouldStop = true;
       return {

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -530,12 +530,17 @@ class ToolUseProcessNode<C> extends BaseNode<
       if (text) {
         // Use createAssistantMessageFromResponse to preserve server tool content
         // (e.g., web_search results) in the conversation context
-        state.messages.push(
+        const assistantMessage =
           options.modelHandler.createAssistantMessageFromResponse(
             state.response,
             text,
-          ),
-        );
+          );
+        // Handle both single message and array returns (OpenAI may return array)
+        if (Array.isArray(assistantMessage)) {
+          state.messages.push(...assistantMessage);
+        } else {
+          state.messages.push(assistantMessage);
+        }
         store.workspace.assembly.updateLastResponse(text);
       }
       state.shouldStop = true;

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -490,12 +490,11 @@ class ToolUseProcessNode<C> extends BaseNode<
     }
 
     // Cache content blocks for use in follow-up messages
+    // Always assign to clear stale blocks from previous responses
     // Reset contentAdded flag when storing new blocks to ensure they get added
-    if (serverToolData.contentBlocks.length > 0) {
-      store.workspace.serverToolContent.contentBlocks =
-        serverToolData.contentBlocks;
-      store.workspace.serverToolContent.contentAdded = false;
-    }
+    store.workspace.serverToolContent.contentBlocks =
+      serverToolData.contentBlocks;
+    store.workspace.serverToolContent.contentAdded = false;
 
     if (text) {
       options.logger.debug(`Model response: ${text.slice(0, 100)}`, {

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -477,8 +477,9 @@ class ToolUseProcessNode<C> extends BaseNode<
     } = options.modelHandler.extractResponse(state.response, '');
 
     // Single extraction for all server tool data (single source of truth)
-    const serverToolData =
-      options.modelHandler.extractServerToolData(state.response);
+    const serverToolData = options.modelHandler.extractServerToolData(
+      state.response,
+    );
 
     // Log web search results to progress view
     for (const searchResult of serverToolData.webSearchResults) {

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -500,7 +500,8 @@ class ToolUseProcessNode<C> extends BaseNode<
     // Store full assistant content (excluding tool_use) to preserve original order
     // This is used in createToolUseFollowUpMessages for correct message building
     // Works with Anthropic-style responses that have a content array
-    const responseContent = (state.response as { content?: unknown[] })?.content;
+    const responseContent = (state.response as { content?: unknown[] })
+      ?.content;
     store.workspace.serverToolContent.lastAssistantContent = Array.isArray(
       responseContent,
     )

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -12,6 +12,7 @@ import {
 } from '@agent/core/flows/CommonCycleTypes';
 import type { SdkToolCall } from '@agent/modelHandlers/types/IModelHandler';
 import type { ProviderStopReason } from '@agent/modelHandlers/types/StopReasonTypes';
+import type { WebSearchResult } from '@agent/modelHandlers/types/ServerToolTypes';
 
 // Local imports - utilities
 import { maybeSaveDebugObject } from '@agent/utils/debugMessageSaver';
@@ -474,6 +475,17 @@ class ToolUseProcessNode<C> extends BaseNode<
       usage,
       stopReason,
     } = options.modelHandler.extractResponse(state.response, '');
+
+    // Extract and log web search results from native provider tools
+    const webSearchResults =
+      options.modelHandler.extractWebSearchResults(state.response);
+    for (const searchResult of webSearchResults) {
+      options.logger.info('', {
+        groupId,
+        messageType: MESSAGE_TYPES.WEB_SEARCH,
+        data: searchResult,
+      });
+    }
 
     if (text) {
       options.logger.debug(`Model response: ${text.slice(0, 100)}`, {

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -487,6 +487,14 @@ class ToolUseProcessNode<C> extends BaseNode<
       });
     }
 
+    // Store server tool content blocks (server_tool_use, web_search_tool_result)
+    // so they can be included when creating follow-up messages for local tools
+    const serverToolContent =
+      options.modelHandler.extractServerToolContent(state.response);
+    if (serverToolContent.length > 0) {
+      store.workspace.serverToolContent.setContentBlocks(serverToolContent);
+    }
+
     if (text) {
       options.logger.debug(`Model response: ${text.slice(0, 100)}`, {
         groupId,
@@ -520,7 +528,14 @@ class ToolUseProcessNode<C> extends BaseNode<
     if (!toolCalls || toolCalls.length === 0 || endTurn) {
       state.toolCalls = undefined;
       if (text) {
-        state.messages.push(options.modelHandler.createAssistantMessage(text));
+        // Use createAssistantMessageFromResponse to preserve server tool content
+        // (e.g., web_search results) in the conversation context
+        state.messages.push(
+          options.modelHandler.createAssistantMessageFromResponse(
+            state.response,
+            text,
+          ),
+        );
         store.workspace.assembly.updateLastResponse(text);
       }
       state.shouldStop = true;

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -481,12 +481,15 @@ class ToolUseProcessNode<C> extends BaseNode<
     );
 
     // Log web search results to progress view
-    for (const searchResult of serverToolData.webSearchResults) {
-      options.logger.info('', {
-        groupId,
-        messageType: MESSAGE_TYPES.WEB_SEARCH,
-        data: searchResult,
-      });
+    // Skip when streaming - Anthropic handler emits during streaming for correct order
+    if (!useStreaming) {
+      for (const searchResult of serverToolData.webSearchResults) {
+        options.logger.info('', {
+          groupId,
+          messageType: MESSAGE_TYPES.WEB_SEARCH,
+          data: searchResult,
+        });
+      }
     }
 
     // Cache content blocks for use in follow-up messages

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -12,7 +12,7 @@ import {
 } from '@agent/core/flows/CommonCycleTypes';
 import type { SdkToolCall } from '@agent/modelHandlers/types/IModelHandler';
 import type { ProviderStopReason } from '@agent/modelHandlers/types/StopReasonTypes';
-import type { WebSearchResult } from '@agent/modelHandlers/types/ServerToolTypes';
+// WebSearchResult import removed - not needed with unified extraction
 
 // Local imports - utilities
 import { maybeSaveDebugObject } from '@agent/utils/debugMessageSaver';
@@ -476,10 +476,12 @@ class ToolUseProcessNode<C> extends BaseNode<
       stopReason,
     } = options.modelHandler.extractResponse(state.response, '');
 
-    // Extract and log web search results from native provider tools
-    const webSearchResults =
-      options.modelHandler.extractWebSearchResults(state.response);
-    for (const searchResult of webSearchResults) {
+    // Single extraction for all server tool data (single source of truth)
+    const serverToolData =
+      options.modelHandler.extractServerToolData(state.response);
+
+    // Log web search results to progress view
+    for (const searchResult of serverToolData.webSearchResults) {
       options.logger.info('', {
         groupId,
         messageType: MESSAGE_TYPES.WEB_SEARCH,
@@ -487,12 +489,11 @@ class ToolUseProcessNode<C> extends BaseNode<
       });
     }
 
-    // Store server tool content blocks (server_tool_use, web_search_tool_result)
-    // so they can be included when creating follow-up messages for local tools
-    const serverToolContent =
-      options.modelHandler.extractServerToolContent(state.response);
-    if (serverToolContent.length > 0) {
-      store.workspace.serverToolContent.setContentBlocks(serverToolContent);
+    // Cache content blocks for use in follow-up messages
+    if (serverToolData.contentBlocks.length > 0) {
+      store.workspace.serverToolContent.setContentBlocks(
+        serverToolData.contentBlocks,
+      );
     }
 
     if (text) {
@@ -543,6 +544,10 @@ class ToolUseProcessNode<C> extends BaseNode<
         }
         store.workspace.assembly.updateLastResponse(text);
       }
+      // Clear server tool content state to prevent stale content in subsequent requests
+      // This is done here since createAssistantMessageFromResponse reads directly from response,
+      // not from workspace state cache
+      store.workspace.resetServerToolContent();
       state.shouldStop = true;
       return {
         skipped: false,

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -492,9 +492,8 @@ class ToolUseProcessNode<C> extends BaseNode<
 
     // Cache content blocks for use in follow-up messages
     if (serverToolData.contentBlocks.length > 0) {
-      store.workspace.serverToolContent.setContentBlocks(
-        serverToolData.contentBlocks,
-      );
+      store.workspace.serverToolContent.contentBlocks =
+        serverToolData.contentBlocks;
     }
 
     if (text) {
@@ -529,13 +528,16 @@ class ToolUseProcessNode<C> extends BaseNode<
 
     if (!toolCalls || toolCalls.length === 0 || endTurn) {
       state.toolCalls = undefined;
-      if (text) {
+      // Preserve response content if there's text OR server tool content (e.g., web_search)
+      // Server tool content can exist without text (model did a search but no text output)
+      const hasServerToolContent = serverToolData.contentBlocks.length > 0;
+      if (text || hasServerToolContent) {
         // Use createAssistantMessageFromResponse to preserve server tool content
         // (e.g., web_search results) in the conversation context
         const assistantMessage =
           options.modelHandler.createAssistantMessageFromResponse(
             state.response,
-            text,
+            text ?? '',
           );
         // Handle both single message and array returns (OpenAI may return array)
         if (Array.isArray(assistantMessage)) {
@@ -543,7 +545,9 @@ class ToolUseProcessNode<C> extends BaseNode<
         } else {
           state.messages.push(assistantMessage);
         }
-        store.workspace.assembly.updateLastResponse(text);
+        if (text) {
+          store.workspace.assembly.updateLastResponse(text);
+        }
       }
       // Clear server tool content state to prevent stale content in subsequent requests
       // This is done here since createAssistantMessageFromResponse reads directly from response,

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -481,7 +481,7 @@ class ToolUseProcessNode<C> extends BaseNode<
     );
 
     // Log web search results to progress view
-    // Skip when streaming - Anthropic handler emits during streaming for correct order
+    // Skip when streaming - handlers emit during streaming for correct order
     if (!useStreaming) {
       for (const searchResult of serverToolData.webSearchResults) {
         options.logger.info('', {

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -666,4 +666,13 @@ export abstract class ModelHandler<
       String(reason).toLowerCase() === 'endturn'
     );
   }
+
+  /**
+   * Extract assistant content blocks from a response, excluding tool_use blocks.
+   * Default implementation returns empty array for providers without this concept.
+   * Override in handlers that support structured content blocks (e.g., Anthropic).
+   */
+  extractAssistantContent(_responseObject: Resp): unknown[] {
+    return [];
+  }
 }

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -643,6 +643,24 @@ export abstract class ModelHandler<
   /** Build a simple assistant message from text. */
   abstract createAssistantMessage(text: string): M;
 
+  /**
+   * Create an assistant message from the raw API response, preserving all content blocks.
+   * Default implementation falls back to createAssistantMessage(text).
+   * Override in handlers that support server tools (like Anthropic's web_search).
+   */
+  createAssistantMessageFromResponse(_responseObject: Resp, text: string): M {
+    return this.createAssistantMessage(text);
+  }
+
+  /**
+   * Extract server tool content blocks from a provider response.
+   * Default implementation returns empty array.
+   * Override in handlers that support server tools (like Anthropic's web_search).
+   */
+  extractServerToolContent(_responseObject: Resp): unknown[] {
+    return [];
+  }
+
   /** Check if stop reason signals end-turn. */
   public isEndTurnStop(reason: ProviderStopReason): boolean {
     return (

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -631,18 +631,6 @@ export abstract class ModelHandler<
   abstract createAssistantMessage(text: string): M;
 
   /**
-   * Create an assistant message from the raw API response, preserving all content blocks.
-   * Default implementation falls back to createAssistantMessage(text).
-   * Override in handlers that support server tools (like Anthropic's web_search).
-   */
-  createAssistantMessageFromResponse(
-    _responseObject: Resp,
-    text: string,
-  ): M | M[] {
-    return this.createAssistantMessage(text);
-  }
-
-  /**
    * Extract all server tool data in a single pass.
    * Default implementation returns empty results.
    * Override in handlers that support server tools.

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -43,10 +43,7 @@ import type {
   SdkToolCall,
   StopConditionsResult,
 } from './types/IModelHandler';
-import type {
-  WebSearchResult,
-  ServerToolExtractionResult,
-} from './types/ServerToolTypes';
+import type { ServerToolExtractionResult } from './types/ServerToolTypes';
 
 // Default continuation limits
 const DEFAULT_CONTINUE_LIMIT = 10;
@@ -604,19 +601,6 @@ export abstract class ModelHandler<
   abstract extractToolUse(responseObject: Resp): T[];
 
   /**
-   * Extracts web search results from provider responses.
-   * Default implementation returns empty array (no native web search support).
-   * Override in handlers that support native/server-side web search.
-   *
-   * @param responseObject The raw response object from the model
-   * @returns Array of web search results (empty if none or not supported)
-   */
-  extractWebSearchResults(_responseObject: Resp): WebSearchResult[] {
-    // Default: no native web search support
-    return [];
-  }
-
-  /**
    * Build a provider-specific follow-up message containing a tool result.
    *
    * @param client - Provider client (for file uploads if supported)
@@ -656,16 +640,6 @@ export abstract class ModelHandler<
     text: string,
   ): M | M[] {
     return this.createAssistantMessage(text);
-  }
-
-  /**
-   * Extract server tool content blocks from a provider response.
-   * Default implementation returns empty array.
-   * Override in handlers that support server tools (like Anthropic's web_search).
-   * @deprecated Use extractServerToolData() for unified extraction
-   */
-  extractServerToolContent(_responseObject: Resp): unknown[] {
-    return [];
   }
 
   /**

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -43,7 +43,10 @@ import type {
   SdkToolCall,
   StopConditionsResult,
 } from './types/IModelHandler';
-import type { WebSearchResult } from './types/ServerToolTypes';
+import type {
+  WebSearchResult,
+  ServerToolExtractionResult,
+} from './types/ServerToolTypes';
 
 // Default continuation limits
 const DEFAULT_CONTINUE_LIMIT = 10;
@@ -659,9 +662,19 @@ export abstract class ModelHandler<
    * Extract server tool content blocks from a provider response.
    * Default implementation returns empty array.
    * Override in handlers that support server tools (like Anthropic's web_search).
+   * @deprecated Use extractServerToolData() for unified extraction
    */
   extractServerToolContent(_responseObject: Resp): unknown[] {
     return [];
+  }
+
+  /**
+   * Extract all server tool data in a single pass.
+   * Default implementation returns empty results.
+   * Override in handlers that support server tools.
+   */
+  extractServerToolData(_responseObject: Resp): ServerToolExtractionResult {
+    return { webSearchResults: [], contentBlocks: [] };
   }
 
   /** Check if stop reason signals end-turn. */

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -648,7 +648,10 @@ export abstract class ModelHandler<
    * Default implementation falls back to createAssistantMessage(text).
    * Override in handlers that support server tools (like Anthropic's web_search).
    */
-  createAssistantMessageFromResponse(_responseObject: Resp, text: string): M {
+  createAssistantMessageFromResponse(
+    _responseObject: Resp,
+    text: string,
+  ): M | M[] {
     return this.createAssistantMessage(text);
   }
 

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -43,7 +43,10 @@ import type {
   SdkToolCall,
   StopConditionsResult,
 } from './types/IModelHandler';
-import type { ServerToolExtractionResult } from './types/ServerToolTypes';
+import type {
+  ServerToolExtractionResult,
+  WebSearchResult,
+} from './types/ServerToolTypes';
 
 // Default continuation limits
 const DEFAULT_CONTINUE_LIMIT = 10;
@@ -182,6 +185,21 @@ export abstract class ModelHandler<
   protected createOutputStream() {
     return this.logger.createStream(MESSAGE_TYPES.MODEL_RESPONSE, {
       progressViewEnabled: this.progressViewEnabled,
+    });
+  }
+
+  /**
+   * Emit web search result to progress view during streaming.
+   * This allows search results to appear in correct order based on when
+   * they occurred in the response, rather than being logged after streaming.
+   */
+  protected emitWebSearchResult(result: WebSearchResult): void {
+    if (!this.progressViewEnabled) {
+      return;
+    }
+    this.logger.info('', {
+      messageType: MESSAGE_TYPES.WEB_SEARCH,
+      data: result,
     });
   }
 

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -600,55 +600,81 @@ export class ModelHandlerAnthropic extends ModelHandler<
       }
 
       try {
-        // Thinking blocks: separate stream per block (user wants to see each thinking phase)
-        // Text blocks: single shared stream (all text merges into one response)
-        // This distinction is important for server tools (web search) which produce
-        // multiple text blocks due to citations - we want one merged response, not fragments
+        // Streaming strategy for interleaved content blocks:
+        // - Thinking blocks: each gets its own stream entry (separate thinking phases)
+        // - Text blocks: consecutive text blocks merge, non-consecutive are separate
+        //
+        // Example: text_0 → thinking_1 → tool_2 → text_3 → text_4
+        //   → Output #1 (text_0), Thinking #1, Output #2 (text_3 + text_4 merged)
+        //
+        // This preserves order while merging citation-split text blocks.
         const outputEnabled = this.isOutputStreamingEnabled();
         const thinkingStreams = new Map<
           number,
           ReturnType<typeof this.createThinkingStream>
         >();
-        // Use object wrapper to avoid TypeScript narrowing issue with closure reassignment
-        const output = { stream: null as ReturnType<ModelHandler['createOutputStream']> | null };
+        // Track output stream and last block type for consecutive text detection
+        const state = {
+          outputStream: null as ReturnType<ModelHandler['createOutputStream']> | null,
+          lastBlockType: null as string | null,
+        };
 
         stream.on('streamEvent', (event: BetaRawMessageStreamEvent) => {
           if (event.type === 'content_block_start') {
-            if (event.content_block.type === 'thinking') {
+            const blockType = event.content_block.type;
+
+            if (blockType === 'thinking') {
+              // Finalize any pending text stream before starting thinking
+              if (state.outputStream) {
+                state.outputStream.finalize();
+                state.outputStream = null;
+              }
               thinkingStreams.set(event.index, this.createThinkingStream());
-            } else if (event.content_block.type === 'text' && outputEnabled) {
-              // Create output stream only once - all text blocks share it
-              if (!output.stream) {
-                output.stream = this.createOutputStream();
+            } else if (blockType === 'text' && outputEnabled) {
+              // Consecutive text blocks share a stream, non-consecutive get new stream
+              if (state.lastBlockType !== 'text') {
+                // Previous block wasn't text - finalize old stream, create new one
+                if (state.outputStream) {
+                  state.outputStream.finalize();
+                }
+                state.outputStream = this.createOutputStream();
+              }
+              // If lastBlockType was 'text', reuse existing outputStream
+            } else {
+              // Non-text, non-thinking block (tool_use, server_tool_use, etc.)
+              // Finalize any pending text stream
+              if (state.outputStream) {
+                state.outputStream.finalize();
+                state.outputStream = null;
               }
             }
+
+            state.lastBlockType = blockType;
           } else if (event.type === 'content_block_delta') {
             if (event.delta.type === 'thinking_delta') {
               thinkingStreams.get(event.index)?.append(event.delta.thinking);
             } else if (event.delta.type === 'text_delta') {
-              // All text deltas go to the shared output stream
-              output.stream?.append(event.delta.text);
+              state.outputStream?.append(event.delta.text);
             }
           } else if (event.type === 'content_block_stop') {
-            // Only finalize thinking streams on block stop
+            // Finalize thinking streams immediately on block stop
             const thinking = thinkingStreams.get(event.index);
             if (thinking) {
               thinking.finalize();
               thinkingStreams.delete(event.index);
             }
-            // Don't finalize output stream here - it accumulates all text blocks
+            // Text streams: don't finalize here - wait for non-text block or end
           }
         });
 
         // Note that there is no second consumption problem as per anthropic sdk examples
         response = await stream.finalMessage();
 
-        // Finalize any remaining thinking streams (shouldn't normally happen)
+        // Finalize any remaining streams
         for (const s of thinkingStreams.values()) {
           s.finalize();
         }
-        // Finalize the shared output stream after all text blocks are done
-        output.stream?.finalize();
+        state.outputStream?.finalize();
 
         // Store thinking blocks for API conversation continuation
         this.processThinkingBlock(response);

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -779,6 +779,9 @@ export class ModelHandlerAnthropic extends ModelHandler<
           s.finalize();
         }
         state.outputStream?.finalize();
+        // Clear pendingSearches to prevent memory leaks
+        state.pendingSearches.clear();
+        state.emittedSearchIds.clear();
 
         // Store thinking blocks for API conversation continuation
         this.processThinkingBlock(response);

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -613,11 +613,12 @@ export class ModelHandlerAnthropic extends ModelHandler<
           number,
           ReturnType<typeof this.createThinkingStream>
         >();
-        // Track output stream and last text block index for consecutive detection
+        // Track output stream and block indices for consecutive text detection
         // Per Anthropic docs: each block has an index corresponding to final content array
+        // We track the index of ANY block, not just text, to properly detect gaps
         const state = {
           outputStream: null as ReturnType<ModelHandler['createOutputStream']> | null,
-          lastTextBlockIndex: -1, // Index of most recent text block (-1 = none yet)
+          lastBlockIndex: -1, // Index of most recent block (any type)
         };
 
         stream.on('streamEvent', (event: BetaRawMessageStreamEvent) => {
@@ -633,10 +634,13 @@ export class ModelHandlerAnthropic extends ModelHandler<
               }
               thinkingStreams.set(blockIndex, this.createThinkingStream());
             } else if (blockType === 'text' && outputEnabled) {
-              // Consecutive text blocks (by index) share a stream
+              // Consecutive text blocks share a stream
+              // Consecutive means: immediately following (by index) AND previous was text
+              // The outputStream !== null check ensures previous block was text
+              // (we null it for thinking/tool blocks)
               const isConsecutive =
                 state.outputStream !== null &&
-                blockIndex === state.lastTextBlockIndex + 1;
+                blockIndex === state.lastBlockIndex + 1;
 
               if (!isConsecutive) {
                 // First text block or non-consecutive - create new stream
@@ -645,8 +649,6 @@ export class ModelHandlerAnthropic extends ModelHandler<
                 }
                 state.outputStream = this.createOutputStream();
               }
-              // Update last text block index
-              state.lastTextBlockIndex = blockIndex;
             } else {
               // Non-text, non-thinking block (tool_use, server_tool_use, etc.)
               // Finalize any pending text stream
@@ -655,6 +657,9 @@ export class ModelHandlerAnthropic extends ModelHandler<
                 state.outputStream = null;
               }
             }
+
+            // Always update lastBlockIndex for ALL block types
+            state.lastBlockIndex = blockIndex;
           } else if (event.type === 'content_block_delta') {
             if (event.delta.type === 'thinking_delta') {
               thinkingStreams.get(event.index)?.append(event.delta.thinking);

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -1040,44 +1040,6 @@ export class ModelHandlerAnthropic extends ModelHandler<
     };
   }
 
-  /**
-   * Create an assistant message from the raw API response, preserving all content blocks.
-   * This preserves server_tool_use, web_search_tool_result, and thinking blocks for native web search
-   * and extended thinking models.
-   */
-  override createAssistantMessageFromResponse(
-    responseObject: BetaMessage,
-    text: string,
-  ): MessageParam {
-    if (!Array.isArray(responseObject?.content)) {
-      return this.createAssistantMessage(text);
-    }
-
-    // Check if response contains server tool use blocks that need to be preserved
-    const hasServerToolContent = responseObject.content.some(
-      isAnthropicServerToolContent,
-    );
-
-    if (!hasServerToolContent) {
-      return this.createAssistantMessage(text);
-    }
-
-    // Preserve the full content array including server tool use, results, and thinking blocks
-    // Filter to only include blocks that are valid for assistant messages
-    const preservedContent = responseObject.content.filter(
-      (block) =>
-        block.type === 'text' ||
-        block.type === 'thinking' ||
-        block.type === 'redacted_thinking' ||
-        isAnthropicServerToolContent(block),
-    );
-
-    return {
-      role: 'assistant',
-      content: preservedContent as ContentBlockParam[],
-    };
-  }
-
   /** Converts image/document content array into Anthropic-compatible message format with type and source metadata. */
   createMediaContent(mediaMessage: MediaEntry[]): ContentBlockParam[] {
     if (mediaMessage.length === 0) {

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -117,6 +117,8 @@ import type {
   DocumentBlockParam,
   ThinkingBlockParam,
   RedactedThinkingBlockParam,
+  ServerToolUseBlock,
+  WebSearchToolResultBlock,
 } from '@anthropic-ai/sdk/resources/messages';
 
 /**
@@ -1716,9 +1718,11 @@ export class ModelHandlerAnthropic extends ModelHandler<
     }
 
     // Extract content blocks that need to be preserved
+    // Filter for server tool content (server_tool_use, web_search_tool_result)
+    // Cast needed because BetaContentBlock has slightly different types than the regular API
     const contentBlocks = responseObject.content.filter(
       isAnthropicServerToolContent,
-    );
+    ) as (ServerToolUseBlock | WebSearchToolResultBlock)[];
 
     // Extract normalized web search results for display
     const webSearchResults = extractAnthropicWebSearchResults(

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -83,6 +83,7 @@ import { executeRequest } from './utils/requestExecutor';
 import {
   extractAnthropicWebSearchResults,
   type WebSearchResult,
+  type ServerToolExtractionResult,
 } from './types/ServerToolTypes';
 
 // Type imports
@@ -1041,7 +1042,8 @@ export class ModelHandlerAnthropic extends ModelHandler<
 
   /**
    * Create an assistant message from the raw API response, preserving all content blocks.
-   * This preserves server_tool_use and web_search_tool_result blocks for native web search.
+   * This preserves server_tool_use, web_search_tool_result, and thinking blocks for native web search
+   * and extended thinking models.
    */
   override createAssistantMessageFromResponse(
     responseObject: BetaMessage,
@@ -1052,29 +1054,38 @@ export class ModelHandlerAnthropic extends ModelHandler<
     }
 
     // Check if response contains server tool use blocks that need to be preserved
-    const hasServerToolContent = responseObject.content.some(
-      (block) =>
-        block.type === 'server_tool_use' ||
-        block.type === 'web_search_tool_result',
+    const hasServerToolContent = responseObject.content.some((block) =>
+      this.isServerToolContentBlock(block),
     );
 
     if (!hasServerToolContent) {
       return this.createAssistantMessage(text);
     }
 
-    // Preserve the full content array including server tool use and results
+    // Preserve the full content array including server tool use, results, and thinking blocks
     // Filter to only include blocks that are valid for assistant messages
     const preservedContent = responseObject.content.filter(
       (block) =>
         block.type === 'text' ||
-        block.type === 'server_tool_use' ||
-        block.type === 'web_search_tool_result',
+        block.type === 'thinking' ||
+        block.type === 'redacted_thinking' ||
+        this.isServerToolContentBlock(block),
     );
 
     return {
       role: 'assistant',
       content: preservedContent as ContentBlockParam[],
     };
+  }
+
+  /**
+   * Helper to check if a content block is a server tool content block.
+   * Used to avoid duplication across methods.
+   */
+  private isServerToolContentBlock(block: { type: string }): boolean {
+    return (
+      block.type === 'server_tool_use' || block.type === 'web_search_tool_result'
+    );
   }
 
   /** Converts image/document content array into Anthropic-compatible message format with type and source metadata. */
@@ -1757,17 +1768,41 @@ export class ModelHandlerAnthropic extends ModelHandler<
   /**
    * Extract server tool content blocks (server_tool_use, web_search_tool_result)
    * that need to be preserved in the assistant message when local tools are also present.
+   * @deprecated Use extractServerToolData() for unified extraction
    */
   override extractServerToolContent(responseObject: BetaMessage): unknown[] {
     if (!Array.isArray(responseObject?.content)) {
       return [];
     }
 
-    return responseObject.content.filter(
-      (block) =>
-        block.type === 'server_tool_use' ||
-        block.type === 'web_search_tool_result',
+    return responseObject.content.filter((block) =>
+      this.isServerToolContentBlock(block),
     );
+  }
+
+  /**
+   * Extract all server tool data in a single pass.
+   * Returns both normalized results for display and raw content blocks for context.
+   * Single source of truth for Anthropic server tool extraction.
+   */
+  override extractServerToolData(
+    responseObject: BetaMessage,
+  ): ServerToolExtractionResult {
+    if (!Array.isArray(responseObject?.content)) {
+      return { webSearchResults: [], contentBlocks: [] };
+    }
+
+    // Extract content blocks that need to be preserved
+    const contentBlocks = responseObject.content.filter((block) =>
+      this.isServerToolContentBlock(block),
+    );
+
+    // Extract normalized web search results for display
+    const webSearchResults = extractAnthropicWebSearchResults(
+      responseObject.content,
+    );
+
+    return { webSearchResults, contentBlocks };
   }
 
   async createToolUseFollowUpMessages(

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -622,7 +622,9 @@ export class ModelHandlerAnthropic extends ModelHandler<
         // Per Anthropic docs: each block has an index corresponding to final content array
         // We track the index of ANY block, not just text, to properly detect gaps
         const state = {
-          outputStream: null as ReturnType<ModelHandler['createOutputStream']> | null,
+          outputStream: null as ReturnType<
+            ModelHandler['createOutputStream']
+          > | null,
           lastBlockIndex: -1, // Index of most recent block (any type)
           // Track web search: tool_use_id → { index, accumulated input JSON }
           pendingSearches: new Map<string, { index: number; input: string }>(),
@@ -681,11 +683,15 @@ export class ModelHandlerAnthropic extends ModelHandler<
               let query = '';
               if (searchData?.input) {
                 try {
-                  const parsed = JSON.parse(searchData.input) as { query?: string };
+                  const parsed = JSON.parse(searchData.input) as {
+                    query?: string;
+                  };
                   query = parsed.query ?? '';
                 } catch {
                   // Partial JSON, try to extract query
-                  const match = searchData.input.match(/"query"\s*:\s*"([^"]+)"/);
+                  const match = searchData.input.match(
+                    /"query"\s*:\s*"([^"]+)"/,
+                  );
                   if (match) {
                     query = match[1];
                   }

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -1765,10 +1765,11 @@ export class ModelHandlerAnthropic extends ModelHandler<
       workspaceState.serverToolContent.contentBlocks.length > 0 &&
       !workspaceState.serverToolContent.contentAdded
     ) {
-      content.push(
-        ...(workspaceState.serverToolContent
-          .contentBlocks as ContentBlockParam[]),
-      );
+      // Filter to only Anthropic server tool blocks for type safety
+      const anthropicBlocks = workspaceState.serverToolContent.contentBlocks
+        .filter(isAnthropicServerToolContent)
+        .map((block) => block as ContentBlockParam);
+      content.push(...anthropicBlocks);
       workspaceState.serverToolContent.contentAdded = true;
     }
     const toolInput = call.raw.input ?? {};

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -99,6 +99,7 @@ import type {
   BetaContextManagementConfig,
   BetaImageBlockParam,
   BetaMessage,
+  BetaRawMessageStreamEvent,
   BetaRedactedThinkingBlock,
   BetaRequestDocumentBlock,
   BetaThinkingBlock,
@@ -599,25 +600,45 @@ export class ModelHandlerAnthropic extends ModelHandler<
       }
 
       try {
-        const thinking = this.createThinkingStream();
-        const output = this.isOutputStreamingEnabled()
-          ? this.createOutputStream()
-          : undefined;
-        stream.on('thinking', (delta: string) => {
-          thinking.append(delta);
-        });
-        stream.on('text', (delta: string) => {
-          output?.append(delta);
+        // Track streams by block index - allows proper handling of interleaved blocks
+        const outputEnabled = this.isOutputStreamingEnabled();
+        const streams = new Map<
+          number,
+          ReturnType<typeof this.createThinkingStream>
+        >();
+
+        // Use streamEvent for granular control over individual content blocks
+        // This allows us to create separate entries for each thinking/text block
+        stream.on('streamEvent', (event: BetaRawMessageStreamEvent) => {
+          if (event.type === 'content_block_start') {
+            const idx = event.index;
+            if (event.content_block.type === 'thinking') {
+              streams.set(idx, this.createThinkingStream());
+            } else if (event.content_block.type === 'text' && outputEnabled) {
+              streams.set(idx, this.createOutputStream());
+            }
+          } else if (event.type === 'content_block_delta') {
+            const s = streams.get(event.index);
+            if (event.delta.type === 'thinking_delta') {
+              s?.append(event.delta.thinking);
+            } else if (event.delta.type === 'text_delta') {
+              s?.append(event.delta.text);
+            }
+          } else if (event.type === 'content_block_stop') {
+            const s = streams.get(event.index);
+            s?.finalize();
+            streams.delete(event.index);
+          }
         });
 
         // Note that there is no second consumption problem as per anthropic sdk examples
         response = await stream.finalMessage();
-        const finalReasoning = this.processThinkingBlock(response);
-        thinking.finalize(finalReasoning ?? undefined);
-        // Extract text manually instead of using finalText() which throws
-        // when response contains only thinking + tool_use blocks with no text
-        const finalOutput = extractTextFromContent(response.content);
-        if (output) output.finalize(finalOutput);
+        // Finalize any remaining streams (shouldn't normally happen)
+        for (const s of streams.values()) {
+          s.finalize();
+        }
+        // Store thinking blocks for API conversation continuation
+        this.processThinkingBlock(response);
       } finally {
         cleanupAbortListener?.();
       }

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -1794,13 +1794,16 @@ export class ModelHandlerAnthropic extends ModelHandler<
     }
     // Include server tool content blocks (server_tool_use, web_search_tool_result)
     // These need to be preserved when both server and local tools are in the same response
-    if (workspaceState?.serverToolContent.hasContent()) {
+    if (
+      workspaceState?.serverToolContent.contentBlocks &&
+      workspaceState.serverToolContent.contentBlocks.length > 0 &&
+      !workspaceState.serverToolContent.contentAdded
+    ) {
       content.push(
         ...(workspaceState.serverToolContent
           .contentBlocks as ContentBlockParam[]),
       );
-      // Clear cached server tool content so it's not duplicated
-      workspaceState.resetServerToolContent();
+      workspaceState.serverToolContent.contentAdded = true;
     }
     const toolInput = call.raw.input ?? {};
     content.push({

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -82,6 +82,7 @@ import { toAnthropicTools } from './toolConversion';
 import { executeRequest } from './utils/requestExecutor';
 import {
   extractAnthropicWebSearchResults,
+  extractDomain,
   isAnthropicServerToolContent,
   type ServerToolExtractionResult,
   type WebSearchResult,
@@ -702,7 +703,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
                       title: r.title,
                       snippet: r.encrypted_content,
                       pageAge: r.page_age ?? undefined,
-                      domain: this.extractDomain(r.url),
+                      domain: extractDomain(r.url),
                     });
                   }
                 }
@@ -1058,15 +1059,6 @@ export class ModelHandlerAnthropic extends ModelHandler<
     // generating citations for assets or pictures that originally lived in nested
     // folders.
     return sanitized.slice(0, 255);
-  }
-
-  /** Extract domain from URL for web search result display */
-  private extractDomain(url: string): string {
-    try {
-      return new URL(url).hostname;
-    } catch {
-      return '';
-    }
   }
 
   /** Initializes the message array for Anthropic chat models with user prefix, request, and optional media. */

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -82,7 +82,6 @@ import { toAnthropicTools } from './toolConversion';
 import { executeRequest } from './utils/requestExecutor';
 import {
   extractAnthropicWebSearchResults,
-  type WebSearchResult,
   type ServerToolExtractionResult,
 } from './types/ServerToolTypes';
 
@@ -1749,35 +1748,6 @@ export class ModelHandlerAnthropic extends ModelHandler<
         } satisfies AnthropicToolCall;
       })
       .filter((call): call is AnthropicToolCall => call !== null);
-  }
-
-  /**
-   * Extract native web search results from Anthropic response.
-   * Anthropic's web_search server tool returns WebSearchToolResultBlock.
-   */
-  override extractWebSearchResults(
-    responseObject: BetaMessage,
-  ): WebSearchResult[] {
-    if (!Array.isArray(responseObject?.content)) {
-      return [];
-    }
-
-    return extractAnthropicWebSearchResults(responseObject.content);
-  }
-
-  /**
-   * Extract server tool content blocks (server_tool_use, web_search_tool_result)
-   * that need to be preserved in the assistant message when local tools are also present.
-   * @deprecated Use extractServerToolData() for unified extraction
-   */
-  override extractServerToolContent(responseObject: BetaMessage): unknown[] {
-    if (!Array.isArray(responseObject?.content)) {
-      return [];
-    }
-
-    return responseObject.content.filter((block) =>
-      this.isServerToolContentBlock(block),
-    );
   }
 
   /**

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -613,15 +613,17 @@ export class ModelHandlerAnthropic extends ModelHandler<
           number,
           ReturnType<typeof this.createThinkingStream>
         >();
-        // Track output stream and last block type for consecutive text detection
+        // Track output stream and last text block index for consecutive detection
+        // Per Anthropic docs: each block has an index corresponding to final content array
         const state = {
           outputStream: null as ReturnType<ModelHandler['createOutputStream']> | null,
-          lastBlockType: null as string | null,
+          lastTextBlockIndex: -1, // Index of most recent text block (-1 = none yet)
         };
 
         stream.on('streamEvent', (event: BetaRawMessageStreamEvent) => {
           if (event.type === 'content_block_start') {
             const blockType = event.content_block.type;
+            const blockIndex = event.index;
 
             if (blockType === 'thinking') {
               // Finalize any pending text stream before starting thinking
@@ -629,17 +631,22 @@ export class ModelHandlerAnthropic extends ModelHandler<
                 state.outputStream.finalize();
                 state.outputStream = null;
               }
-              thinkingStreams.set(event.index, this.createThinkingStream());
+              thinkingStreams.set(blockIndex, this.createThinkingStream());
             } else if (blockType === 'text' && outputEnabled) {
-              // Consecutive text blocks share a stream, non-consecutive get new stream
-              if (state.lastBlockType !== 'text') {
-                // Previous block wasn't text - finalize old stream, create new one
+              // Consecutive text blocks (by index) share a stream
+              const isConsecutive =
+                state.outputStream !== null &&
+                blockIndex === state.lastTextBlockIndex + 1;
+
+              if (!isConsecutive) {
+                // First text block or non-consecutive - create new stream
                 if (state.outputStream) {
                   state.outputStream.finalize();
                 }
                 state.outputStream = this.createOutputStream();
               }
-              // If lastBlockType was 'text', reuse existing outputStream
+              // Update last text block index
+              state.lastTextBlockIndex = blockIndex;
             } else {
               // Non-text, non-thinking block (tool_use, server_tool_use, etc.)
               // Finalize any pending text stream
@@ -648,8 +655,6 @@ export class ModelHandlerAnthropic extends ModelHandler<
                 state.outputStream = null;
               }
             }
-
-            state.lastBlockType = blockType;
           } else if (event.type === 'content_block_delta') {
             if (event.delta.type === 'thinking_delta') {
               thinkingStreams.get(event.index)?.append(event.delta.thinking);

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -82,12 +82,10 @@ import { toAnthropicTools } from './toolConversion';
 import { executeRequest } from './utils/requestExecutor';
 import {
   extractAnthropicWebSearchResults,
-  extractDomain,
   isAnthropicServerToolContent,
   type ServerToolExtractionResult,
-  type WebSearchResult,
-  type WebSearchResultEntry,
 } from './types/ServerToolTypes';
+import { AnthropicStreamHandler } from './support/AnthropicStreamHandler';
 
 // Type imports
 import type { ProviderStopReason } from './types/StopReasonTypes';
@@ -123,7 +121,6 @@ import type {
   RedactedThinkingBlockParam,
   ServerToolUseBlock,
   WebSearchToolResultBlock,
-  WebSearchResultBlock,
 } from '@anthropic-ai/sdk/resources/messages';
 
 /**
@@ -603,185 +600,26 @@ export class ModelHandlerAnthropic extends ModelHandler<
         };
       }
 
+      const streamHandler = new AnthropicStreamHandler(
+        this.logger,
+        {
+          outputEnabled: this.isOutputStreamingEnabled(),
+          progressViewEnabled: this.progressViewEnabled,
+        },
+        {
+          createThinkingStream: () => this.createThinkingStream(),
+          createOutputStream: () => this.createOutputStream(),
+        },
+      );
+
       try {
-        // Streaming strategy for interleaved content blocks:
-        // - Thinking blocks: each gets its own stream entry (separate thinking phases)
-        // - Text blocks: consecutive text blocks merge, non-consecutive are separate
-        // - Server tools (web_search): emit to progress view when results arrive
-        //
-        // Example: text_0 → server_tool_1 → result_2 → text_3 → text_4
-        //   → Output #1 (text_0), WebSearch, Output #2 (text_3 + text_4 merged)
-        //
-        // This preserves order while merging citation-split text blocks.
-        const outputEnabled = this.isOutputStreamingEnabled();
-        const thinkingStreams = new Map<
-          number,
-          ReturnType<typeof this.createThinkingStream>
-        >();
-        // Track output stream and block indices for consecutive text detection
-        // Per Anthropic docs: each block has an index corresponding to final content array
-        // We track the index of ANY block, not just text, to properly detect gaps
-        const state = {
-          outputStream: null as ReturnType<
-            ModelHandler['createOutputStream']
-          > | null,
-          lastBlockIndex: -1, // Index of most recent block (any type)
-          // Track web search: tool_use_id → { index, accumulated input JSON }
-          pendingSearches: new Map<string, { index: number; input: string }>(),
-          // Track emitted search IDs to prevent duplicate logging in flow
-          emittedSearchIds: new Set<string>(),
-        };
-
-        stream.on('streamEvent', (event: BetaRawMessageStreamEvent) => {
-          if (event.type === 'content_block_start') {
-            const blockType = event.content_block.type;
-            const blockIndex = event.index;
-
-            if (blockType === 'thinking') {
-              // Finalize any pending text stream before starting thinking
-              if (state.outputStream) {
-                state.outputStream.finalize();
-                state.outputStream = null;
-              }
-              thinkingStreams.set(blockIndex, this.createThinkingStream());
-            } else if (blockType === 'text' && outputEnabled) {
-              // Consecutive text blocks share a stream
-              // Consecutive means: immediately following (by index) AND previous was text
-              // The outputStream !== null check ensures previous block was text
-              // (we null it for thinking/tool blocks)
-              const isConsecutive =
-                state.outputStream !== null &&
-                blockIndex === state.lastBlockIndex + 1;
-
-              if (!isConsecutive) {
-                // First text block or non-consecutive - create new stream
-                if (state.outputStream) {
-                  state.outputStream.finalize();
-                }
-                state.outputStream = this.createOutputStream();
-              }
-            } else if (blockType === 'server_tool_use') {
-              // Track web search server tool use to get query
-              const block = event.content_block as ServerToolUseBlock;
-              if (block.name === 'web_search') {
-                state.pendingSearches.set(block.id, {
-                  index: blockIndex,
-                  input: '',
-                });
-              }
-              // Finalize any pending text stream
-              if (state.outputStream) {
-                state.outputStream.finalize();
-                state.outputStream = null;
-              }
-            } else if (blockType === 'web_search_tool_result') {
-              // Emit web search result to progress view at the correct time
-              const block = event.content_block as WebSearchToolResultBlock;
-              const searchData = state.pendingSearches.get(block.tool_use_id);
-
-              // Parse query from accumulated input JSON
-              let query = '';
-              if (searchData?.input) {
-                try {
-                  const parsed = JSON.parse(searchData.input) as {
-                    query?: string;
-                  };
-                  query = parsed.query ?? '';
-                } catch {
-                  // Partial JSON, try to extract query
-                  const match = searchData.input.match(
-                    /"query"\s*:\s*"([^"]+)"/,
-                  );
-                  if (match) {
-                    query = match[1];
-                  }
-                }
-              }
-
-              // Extract results from the block content
-              const entries: WebSearchResultEntry[] = [];
-              if (Array.isArray(block.content)) {
-                for (const item of block.content) {
-                  const r = item as WebSearchResultBlock;
-                  if (r.type === 'web_search_result' && r.url) {
-                    entries.push({
-                      url: r.url,
-                      title: r.title,
-                      snippet: r.encrypted_content,
-                      pageAge: r.page_age ?? undefined,
-                      domain: extractDomain(r.url),
-                    });
-                  }
-                }
-              }
-
-              // Emit to progress view
-              if (entries.length > 0 || query) {
-                this.emitWebSearchResult({
-                  query,
-                  results: entries,
-                  provider: 'anthropic',
-                  callId: block.tool_use_id,
-                  status: 'completed',
-                });
-                state.emittedSearchIds.add(block.tool_use_id);
-              }
-
-              // Clean up
-              state.pendingSearches.delete(block.tool_use_id);
-
-              // Finalize any pending text stream
-              if (state.outputStream) {
-                state.outputStream.finalize();
-                state.outputStream = null;
-              }
-            } else {
-              // Other non-text, non-thinking blocks (tool_use, etc.)
-              // Finalize any pending text stream
-              if (state.outputStream) {
-                state.outputStream.finalize();
-                state.outputStream = null;
-              }
-            }
-
-            // Always update lastBlockIndex for ALL block types
-            state.lastBlockIndex = blockIndex;
-          } else if (event.type === 'content_block_delta') {
-            if (event.delta.type === 'thinking_delta') {
-              thinkingStreams.get(event.index)?.append(event.delta.thinking);
-            } else if (event.delta.type === 'text_delta') {
-              state.outputStream?.append(event.delta.text);
-            } else if (event.delta.type === 'input_json_delta') {
-              // Accumulate input JSON for web search to get query
-              for (const [, searchData] of state.pendingSearches) {
-                if (searchData.index === event.index) {
-                  searchData.input += event.delta.partial_json;
-                  break;
-                }
-              }
-            }
-          } else if (event.type === 'content_block_stop') {
-            // Finalize thinking streams immediately on block stop
-            const thinking = thinkingStreams.get(event.index);
-            if (thinking) {
-              thinking.finalize();
-              thinkingStreams.delete(event.index);
-            }
-            // Text streams: don't finalize here - wait for non-text block or end
-          }
-        });
+        streamHandler.attachToStream(stream);
 
         // Note that there is no second consumption problem as per anthropic sdk examples
         response = await stream.finalMessage();
 
-        // Finalize any remaining streams
-        for (const s of thinkingStreams.values()) {
-          s.finalize();
-        }
-        state.outputStream?.finalize();
-        // Clear pendingSearches to prevent memory leaks
-        state.pendingSearches.clear();
-        state.emittedSearchIds.clear();
+        // Finalize all streams and clear state
+        streamHandler.finalize();
 
         // Store thinking blocks for API conversation continuation
         this.processThinkingBlock(response);
@@ -1899,6 +1737,18 @@ export class ModelHandlerAnthropic extends ModelHandler<
     return { webSearchResults, contentBlocks };
   }
 
+  /**
+   * Extract assistant content blocks from an Anthropic response, excluding tool_use blocks.
+   * Preserves thinking, text, server_tool_use, and web_search_tool_result blocks.
+   */
+  override extractAssistantContent(responseObject: BetaMessage): unknown[] {
+    if (!Array.isArray(responseObject?.content)) {
+      return [];
+    }
+
+    return responseObject.content.filter((block) => block.type !== 'tool_use');
+  }
+
   async createToolUseFollowUpMessages(
     client: Anthropic | undefined,
     call: AnthropicToolCall,
@@ -1917,8 +1767,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
           .lastAssistantContent as ContentBlockParam[]),
       );
       // Clear all stores after consuming to prevent duplicates
-      workspaceState.serverToolContent.lastAssistantContent = [];
-      workspaceState.serverToolContent.contentBlocks = [];
+      workspaceState.resetServerToolContent();
       workspaceState.resetReasoning();
     } else {
       // Fall back to reconstructing from separate stores (legacy/non-streaming path)
@@ -1938,7 +1787,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
           .filter(isAnthropicServerToolContent)
           .map((block) => block as ContentBlockParam);
         content.push(...anthropicBlocks);
-        workspaceState.serverToolContent.contentBlocks = [];
+        workspaceState.resetServerToolContent();
       }
       if (text) {
         content.push({ type: 'text', text });

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -84,6 +84,8 @@ import {
   extractAnthropicWebSearchResults,
   isAnthropicServerToolContent,
   type ServerToolExtractionResult,
+  type WebSearchResult,
+  type WebSearchResultEntry,
 } from './types/ServerToolTypes';
 
 // Type imports
@@ -120,6 +122,7 @@ import type {
   RedactedThinkingBlockParam,
   ServerToolUseBlock,
   WebSearchToolResultBlock,
+  WebSearchResultBlock,
 } from '@anthropic-ai/sdk/resources/messages';
 
 /**
@@ -603,9 +606,10 @@ export class ModelHandlerAnthropic extends ModelHandler<
         // Streaming strategy for interleaved content blocks:
         // - Thinking blocks: each gets its own stream entry (separate thinking phases)
         // - Text blocks: consecutive text blocks merge, non-consecutive are separate
+        // - Server tools (web_search): emit to progress view when results arrive
         //
-        // Example: text_0 → thinking_1 → tool_2 → text_3 → text_4
-        //   → Output #1 (text_0), Thinking #1, Output #2 (text_3 + text_4 merged)
+        // Example: text_0 → server_tool_1 → result_2 → text_3 → text_4
+        //   → Output #1 (text_0), WebSearch, Output #2 (text_3 + text_4 merged)
         //
         // This preserves order while merging citation-split text blocks.
         const outputEnabled = this.isOutputStreamingEnabled();
@@ -619,6 +623,10 @@ export class ModelHandlerAnthropic extends ModelHandler<
         const state = {
           outputStream: null as ReturnType<ModelHandler['createOutputStream']> | null,
           lastBlockIndex: -1, // Index of most recent block (any type)
+          // Track web search: tool_use_id → { index, accumulated input JSON }
+          pendingSearches: new Map<string, { index: number; input: string }>(),
+          // Track emitted search IDs to prevent duplicate logging in flow
+          emittedSearchIds: new Set<string>(),
         };
 
         stream.on('streamEvent', (event: BetaRawMessageStreamEvent) => {
@@ -649,8 +657,79 @@ export class ModelHandlerAnthropic extends ModelHandler<
                 }
                 state.outputStream = this.createOutputStream();
               }
+            } else if (blockType === 'server_tool_use') {
+              // Track web search server tool use to get query
+              const block = event.content_block as ServerToolUseBlock;
+              if (block.name === 'web_search') {
+                state.pendingSearches.set(block.id, {
+                  index: blockIndex,
+                  input: '',
+                });
+              }
+              // Finalize any pending text stream
+              if (state.outputStream) {
+                state.outputStream.finalize();
+                state.outputStream = null;
+              }
+            } else if (blockType === 'web_search_tool_result') {
+              // Emit web search result to progress view at the correct time
+              const block = event.content_block as WebSearchToolResultBlock;
+              const searchData = state.pendingSearches.get(block.tool_use_id);
+
+              // Parse query from accumulated input JSON
+              let query = '';
+              if (searchData?.input) {
+                try {
+                  const parsed = JSON.parse(searchData.input) as { query?: string };
+                  query = parsed.query ?? '';
+                } catch {
+                  // Partial JSON, try to extract query
+                  const match = searchData.input.match(/"query"\s*:\s*"([^"]+)"/);
+                  if (match) {
+                    query = match[1];
+                  }
+                }
+              }
+
+              // Extract results from the block content
+              const entries: WebSearchResultEntry[] = [];
+              if (Array.isArray(block.content)) {
+                for (const item of block.content) {
+                  const r = item as WebSearchResultBlock;
+                  if (r.type === 'web_search_result' && r.url) {
+                    entries.push({
+                      url: r.url,
+                      title: r.title,
+                      snippet: r.encrypted_content,
+                      pageAge: r.page_age ?? undefined,
+                      domain: this.extractDomain(r.url),
+                    });
+                  }
+                }
+              }
+
+              // Emit to progress view
+              if (entries.length > 0 || query) {
+                this.emitWebSearchResult({
+                  query,
+                  results: entries,
+                  provider: 'anthropic',
+                  callId: block.tool_use_id,
+                  status: 'completed',
+                });
+                state.emittedSearchIds.add(block.tool_use_id);
+              }
+
+              // Clean up
+              state.pendingSearches.delete(block.tool_use_id);
+
+              // Finalize any pending text stream
+              if (state.outputStream) {
+                state.outputStream.finalize();
+                state.outputStream = null;
+              }
             } else {
-              // Non-text, non-thinking block (tool_use, server_tool_use, etc.)
+              // Other non-text, non-thinking blocks (tool_use, etc.)
               // Finalize any pending text stream
               if (state.outputStream) {
                 state.outputStream.finalize();
@@ -665,6 +744,14 @@ export class ModelHandlerAnthropic extends ModelHandler<
               thinkingStreams.get(event.index)?.append(event.delta.thinking);
             } else if (event.delta.type === 'text_delta') {
               state.outputStream?.append(event.delta.text);
+            } else if (event.delta.type === 'input_json_delta') {
+              // Accumulate input JSON for web search to get query
+              for (const [, searchData] of state.pendingSearches) {
+                if (searchData.index === event.index) {
+                  searchData.input += event.delta.partial_json;
+                  break;
+                }
+              }
             }
           } else if (event.type === 'content_block_stop') {
             // Finalize thinking streams immediately on block stop
@@ -971,6 +1058,15 @@ export class ModelHandlerAnthropic extends ModelHandler<
     // generating citations for assets or pictures that originally lived in nested
     // folders.
     return sanitized.slice(0, 255);
+  }
+
+  /** Extract domain from URL for web search result display */
+  private extractDomain(url: string): string {
+    try {
+      return new URL(url).hostname;
+    } catch {
+      return '';
+    }
   }
 
   /** Initializes the message array for Anthropic chat models with user prefix, request, and optional media. */

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -600,43 +600,56 @@ export class ModelHandlerAnthropic extends ModelHandler<
       }
 
       try {
-        // Track streams by block index - allows proper handling of interleaved blocks
+        // Thinking blocks: separate stream per block (user wants to see each thinking phase)
+        // Text blocks: single shared stream (all text merges into one response)
+        // This distinction is important for server tools (web search) which produce
+        // multiple text blocks due to citations - we want one merged response, not fragments
         const outputEnabled = this.isOutputStreamingEnabled();
-        const streams = new Map<
+        const thinkingStreams = new Map<
           number,
           ReturnType<typeof this.createThinkingStream>
         >();
+        // Use object wrapper to avoid TypeScript narrowing issue with closure reassignment
+        const output = { stream: null as ReturnType<ModelHandler['createOutputStream']> | null };
 
-        // Use streamEvent for granular control over individual content blocks
-        // This allows us to create separate entries for each thinking/text block
         stream.on('streamEvent', (event: BetaRawMessageStreamEvent) => {
           if (event.type === 'content_block_start') {
-            const idx = event.index;
             if (event.content_block.type === 'thinking') {
-              streams.set(idx, this.createThinkingStream());
+              thinkingStreams.set(event.index, this.createThinkingStream());
             } else if (event.content_block.type === 'text' && outputEnabled) {
-              streams.set(idx, this.createOutputStream());
+              // Create output stream only once - all text blocks share it
+              if (!output.stream) {
+                output.stream = this.createOutputStream();
+              }
             }
           } else if (event.type === 'content_block_delta') {
-            const s = streams.get(event.index);
             if (event.delta.type === 'thinking_delta') {
-              s?.append(event.delta.thinking);
+              thinkingStreams.get(event.index)?.append(event.delta.thinking);
             } else if (event.delta.type === 'text_delta') {
-              s?.append(event.delta.text);
+              // All text deltas go to the shared output stream
+              output.stream?.append(event.delta.text);
             }
           } else if (event.type === 'content_block_stop') {
-            const s = streams.get(event.index);
-            s?.finalize();
-            streams.delete(event.index);
+            // Only finalize thinking streams on block stop
+            const thinking = thinkingStreams.get(event.index);
+            if (thinking) {
+              thinking.finalize();
+              thinkingStreams.delete(event.index);
+            }
+            // Don't finalize output stream here - it accumulates all text blocks
           }
         });
 
         // Note that there is no second consumption problem as per anthropic sdk examples
         response = await stream.finalMessage();
-        // Finalize any remaining streams (shouldn't normally happen)
-        for (const s of streams.values()) {
+
+        // Finalize any remaining thinking streams (shouldn't normally happen)
+        for (const s of thinkingStreams.values()) {
           s.finalize();
         }
+        // Finalize the shared output stream after all text blocks are done
+        output.stream?.finalize();
+
         // Store thinking blocks for API conversation continuation
         this.processThinkingBlock(response);
       } finally {

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -1758,17 +1758,14 @@ export class ModelHandlerAnthropic extends ModelHandler<
     // Include server tool content blocks (server_tool_use, web_search_tool_result)
     // These need to be preserved when both server and local tools are in the same response
     // Order: thinking → server_tool_use → web_search_tool_result → text → tool_use
-    if (
-      workspaceState?.serverToolContent.contentBlocks &&
-      workspaceState.serverToolContent.contentBlocks.length > 0 &&
-      !workspaceState.serverToolContent.contentAdded
-    ) {
+    if (workspaceState?.serverToolContent.contentBlocks.length) {
       // Filter to only Anthropic server tool blocks for type safety
       const anthropicBlocks = workspaceState.serverToolContent.contentBlocks
         .filter(isAnthropicServerToolContent)
         .map((block) => block as ContentBlockParam);
       content.push(...anthropicBlocks);
-      workspaceState.serverToolContent.contentAdded = true;
+      // Clear after consuming to prevent duplicates
+      workspaceState.serverToolContent.contentBlocks = [];
     }
     // Text comes after server tool content (model generates text after seeing search results)
     if (text) {

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -1907,36 +1907,44 @@ export class ModelHandlerAnthropic extends ModelHandler<
     text?: string,
   ): Promise<MessageParam[]> {
     const content: ContentBlockParam[] = [];
-    if (
-      this.capabilities.supportsReasoning &&
-      workspaceState?.reasoning.thinkingBlocks &&
-      workspaceState.reasoning.thinkingBlocks.length > 0
-    ) {
-      // Anthropic models expect thinking blocks before text
-      // Include thinking blocks from workspace state as SDK thinking params
+
+    // Use stored assistant content if available - preserves original order from API
+    // This includes: thinking, text, server_tool_use, web_search_tool_result blocks
+    if (workspaceState?.serverToolContent.lastAssistantContent.length) {
       content.push(
-        ...(workspaceState.reasoning
-          .thinkingBlocks as AnthropicThinkingContentParam[]),
+        ...(workspaceState.serverToolContent
+          .lastAssistantContent as ContentBlockParam[]),
       );
-      // Clear cached thinking so the next response can store fresh blocks
-      workspaceState.resetReasoning();
-    }
-    // Include server tool content blocks (server_tool_use, web_search_tool_result)
-    // These need to be preserved when both server and local tools are in the same response
-    // Order: thinking → server_tool_use → web_search_tool_result → text → tool_use
-    if (workspaceState?.serverToolContent.contentBlocks.length) {
-      // Filter to only Anthropic server tool blocks for type safety
-      const anthropicBlocks = workspaceState.serverToolContent.contentBlocks
-        .filter(isAnthropicServerToolContent)
-        .map((block) => block as ContentBlockParam);
-      content.push(...anthropicBlocks);
-      // Clear after consuming to prevent duplicates
+      // Clear all stores after consuming to prevent duplicates
+      workspaceState.serverToolContent.lastAssistantContent = [];
       workspaceState.serverToolContent.contentBlocks = [];
+      workspaceState.resetReasoning();
+    } else {
+      // Fall back to reconstructing from separate stores (legacy/non-streaming path)
+      if (
+        this.capabilities.supportsReasoning &&
+        workspaceState?.reasoning.thinkingBlocks &&
+        workspaceState.reasoning.thinkingBlocks.length > 0
+      ) {
+        content.push(
+          ...(workspaceState.reasoning
+            .thinkingBlocks as AnthropicThinkingContentParam[]),
+        );
+        workspaceState.resetReasoning();
+      }
+      if (workspaceState?.serverToolContent.contentBlocks.length) {
+        const anthropicBlocks = workspaceState.serverToolContent.contentBlocks
+          .filter(isAnthropicServerToolContent)
+          .map((block) => block as ContentBlockParam);
+        content.push(...anthropicBlocks);
+        workspaceState.serverToolContent.contentBlocks = [];
+      }
+      if (text) {
+        content.push({ type: 'text', text });
+      }
     }
-    // Text comes after server tool content (model generates text after seeing search results)
-    if (text) {
-      content.push({ type: 'text', text });
-    }
+
+    // Add tool_use block at the end
     const toolInput = call.raw.input ?? {};
     content.push({
       type: 'tool_use',

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -1755,11 +1755,9 @@ export class ModelHandlerAnthropic extends ModelHandler<
       // Clear cached thinking so the next response can store fresh blocks
       workspaceState.resetReasoning();
     }
-    if (text) {
-      content.push({ type: 'text', text });
-    }
     // Include server tool content blocks (server_tool_use, web_search_tool_result)
     // These need to be preserved when both server and local tools are in the same response
+    // Order: thinking → server_tool_use → web_search_tool_result → text → tool_use
     if (
       workspaceState?.serverToolContent.contentBlocks &&
       workspaceState.serverToolContent.contentBlocks.length > 0 &&
@@ -1771,6 +1769,10 @@ export class ModelHandlerAnthropic extends ModelHandler<
         .map((block) => block as ContentBlockParam);
       content.push(...anthropicBlocks);
       workspaceState.serverToolContent.contentAdded = true;
+    }
+    // Text comes after server tool content (model generates text after seeing search results)
+    if (text) {
+      content.push({ type: 'text', text });
     }
     const toolInput = call.raw.input ?? {};
     content.push({

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -668,6 +668,14 @@ export class ModelHandlerAnthropic extends ModelHandler<
                   index: blockIndex,
                   input: '',
                 });
+                // Emit placeholder immediately to show search is starting
+                this.emitWebSearchResult({
+                  query: '',
+                  results: [],
+                  provider: 'anthropic',
+                  callId: block.id,
+                  status: 'in_progress',
+                });
               }
               // Finalize any pending text stream
               if (state.outputStream) {

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -618,12 +618,11 @@ export class ModelHandlerAnthropic extends ModelHandler<
         // Note that there is no second consumption problem as per anthropic sdk examples
         response = await stream.finalMessage();
 
-        // Finalize all streams and clear state
-        streamHandler.finalize();
-
         // Store thinking blocks for API conversation continuation
         this.processThinkingBlock(response);
       } finally {
+        // Always finalize stream handler to prevent memory leaks on error
+        streamHandler.finalize();
         cleanupAbortListener?.();
       }
     } else {

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -1039,6 +1039,44 @@ export class ModelHandlerAnthropic extends ModelHandler<
     };
   }
 
+  /**
+   * Create an assistant message from the raw API response, preserving all content blocks.
+   * This preserves server_tool_use and web_search_tool_result blocks for native web search.
+   */
+  override createAssistantMessageFromResponse(
+    responseObject: BetaMessage,
+    text: string,
+  ): MessageParam {
+    if (!Array.isArray(responseObject?.content)) {
+      return this.createAssistantMessage(text);
+    }
+
+    // Check if response contains server tool use blocks that need to be preserved
+    const hasServerToolContent = responseObject.content.some(
+      (block) =>
+        block.type === 'server_tool_use' ||
+        block.type === 'web_search_tool_result',
+    );
+
+    if (!hasServerToolContent) {
+      return this.createAssistantMessage(text);
+    }
+
+    // Preserve the full content array including server tool use and results
+    // Filter to only include blocks that are valid for assistant messages
+    const preservedContent = responseObject.content.filter(
+      (block) =>
+        block.type === 'text' ||
+        block.type === 'server_tool_use' ||
+        block.type === 'web_search_tool_result',
+    );
+
+    return {
+      role: 'assistant',
+      content: preservedContent as ContentBlockParam[],
+    };
+  }
+
   /** Converts image/document content array into Anthropic-compatible message format with type and source metadata. */
   createMediaContent(mediaMessage: MediaEntry[]): ContentBlockParam[] {
     if (mediaMessage.length === 0) {
@@ -1716,6 +1754,22 @@ export class ModelHandlerAnthropic extends ModelHandler<
     return extractAnthropicWebSearchResults(responseObject.content);
   }
 
+  /**
+   * Extract server tool content blocks (server_tool_use, web_search_tool_result)
+   * that need to be preserved in the assistant message when local tools are also present.
+   */
+  override extractServerToolContent(responseObject: BetaMessage): unknown[] {
+    if (!Array.isArray(responseObject?.content)) {
+      return [];
+    }
+
+    return responseObject.content.filter(
+      (block) =>
+        block.type === 'server_tool_use' ||
+        block.type === 'web_search_tool_result',
+    );
+  }
+
   async createToolUseFollowUpMessages(
     client: Anthropic | undefined,
     call: AnthropicToolCall,
@@ -1741,6 +1795,16 @@ export class ModelHandlerAnthropic extends ModelHandler<
     }
     if (text) {
       content.push({ type: 'text', text });
+    }
+    // Include server tool content blocks (server_tool_use, web_search_tool_result)
+    // These need to be preserved when both server and local tools are in the same response
+    if (workspaceState?.serverToolContent.hasContent()) {
+      content.push(
+        ...(workspaceState.serverToolContent
+          .contentBlocks as ContentBlockParam[]),
+      );
+      // Clear cached server tool content so it's not duplicated
+      workspaceState.resetServerToolContent();
     }
     const toolInput = call.raw.input ?? {};
     content.push({

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -668,14 +668,6 @@ export class ModelHandlerAnthropic extends ModelHandler<
                   index: blockIndex,
                   input: '',
                 });
-                // Emit placeholder immediately to show search is starting
-                this.emitWebSearchResult({
-                  query: '',
-                  results: [],
-                  provider: 'anthropic',
-                  callId: block.id,
-                  status: 'in_progress',
-                });
               }
               // Finalize any pending text stream
               if (state.outputStream) {

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -82,6 +82,7 @@ import { toAnthropicTools } from './toolConversion';
 import { executeRequest } from './utils/requestExecutor';
 import {
   extractAnthropicWebSearchResults,
+  isAnthropicServerToolContent,
   type ServerToolExtractionResult,
 } from './types/ServerToolTypes';
 
@@ -1053,8 +1054,8 @@ export class ModelHandlerAnthropic extends ModelHandler<
     }
 
     // Check if response contains server tool use blocks that need to be preserved
-    const hasServerToolContent = responseObject.content.some((block) =>
-      this.isServerToolContentBlock(block),
+    const hasServerToolContent = responseObject.content.some(
+      isAnthropicServerToolContent,
     );
 
     if (!hasServerToolContent) {
@@ -1068,23 +1069,13 @@ export class ModelHandlerAnthropic extends ModelHandler<
         block.type === 'text' ||
         block.type === 'thinking' ||
         block.type === 'redacted_thinking' ||
-        this.isServerToolContentBlock(block),
+        isAnthropicServerToolContent(block),
     );
 
     return {
       role: 'assistant',
       content: preservedContent as ContentBlockParam[],
     };
-  }
-
-  /**
-   * Helper to check if a content block is a server tool content block.
-   * Used to avoid duplication across methods.
-   */
-  private isServerToolContentBlock(block: { type: string }): boolean {
-    return (
-      block.type === 'server_tool_use' || block.type === 'web_search_tool_result'
-    );
   }
 
   /** Converts image/document content array into Anthropic-compatible message format with type and source metadata. */
@@ -1763,8 +1754,8 @@ export class ModelHandlerAnthropic extends ModelHandler<
     }
 
     // Extract content blocks that need to be preserved
-    const contentBlocks = responseObject.content.filter((block) =>
-      this.isServerToolContentBlock(block),
+    const contentBlocks = responseObject.content.filter(
+      isAnthropicServerToolContent,
     );
 
     // Extract normalized web search results for display

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -77,7 +77,7 @@ import { executeRequest } from './utils/requestExecutor';
 import { toGoogleTools } from './toolConversion';
 import {
   extractGoogleGroundingResults,
-  type WebSearchResult,
+  type ServerToolExtractionResult,
 } from './types/ServerToolTypes';
 
 // Type imports
@@ -1169,19 +1169,25 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
   }
 
   /**
-   * Extract grounding results from Google GenAI response.
+   * Extract server tool data from Google GenAI response.
    * Google uses groundingMetadata for search results when GoogleSearch tool is enabled.
+   * Note: Google doesn't have content blocks to preserve like Anthropic/OpenAI;
+   * grounding metadata is embedded in the response.
    */
-  override extractWebSearchResults(
+  override extractServerToolData(
     responseObject: GenerateContentResponse,
-  ): WebSearchResult[] {
+  ): ServerToolExtractionResult {
     const candidate = responseObject?.candidates?.[0];
     if (!candidate) {
-      return [];
+      return { webSearchResults: [], contentBlocks: [] };
     }
 
     const result = extractGoogleGroundingResults(candidate);
-    return result ? [result] : [];
+    return {
+      webSearchResults: result ? [result] : [],
+      // Google doesn't have explicit content blocks like Anthropic/OpenAI
+      contentBlocks: [],
+    };
   }
 
   /**

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -75,10 +75,6 @@ import {
 } from './utils/toolAttachmentUtils';
 import { executeRequest } from './utils/requestExecutor';
 import { toGoogleTools } from './toolConversion';
-import {
-  extractGoogleGroundingResults,
-  type ServerToolExtractionResult,
-} from './types/ServerToolTypes';
 
 // Type imports
 import type { MediaFileResult } from './support/MediaAttachmentProcessor';
@@ -1166,28 +1162,6 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
       raw: call,
       thoughtSignature,
     }));
-  }
-
-  /**
-   * Extract server tool data from Google GenAI response.
-   * Google uses groundingMetadata for search results when GoogleSearch tool is enabled.
-   * Note: Google doesn't have content blocks to preserve like Anthropic/OpenAI;
-   * grounding metadata is embedded in the response.
-   */
-  override extractServerToolData(
-    responseObject: GenerateContentResponse,
-  ): ServerToolExtractionResult {
-    const candidate = responseObject?.candidates?.[0];
-    if (!candidate) {
-      return { webSearchResults: [], contentBlocks: [] };
-    }
-
-    const result = extractGoogleGroundingResults(candidate);
-    return {
-      webSearchResults: result ? [result] : [],
-      // Google doesn't have explicit content blocks like Anthropic/OpenAI
-      contentBlocks: [],
-    };
   }
 
   /**

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -1277,17 +1277,46 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     return extractOpenAIWebSearchResults(output);
   }
 
+  /**
+   * Extract server tool content blocks (web_search_call) from OpenAI Responses API output.
+   * These need to be preserved in the conversation when local tools are also present.
+   */
+  override extractServerToolContent(response: Response): unknown[] {
+    const output = response?.output;
+    if (!Array.isArray(output)) {
+      return [];
+    }
+
+    return output.filter(
+      (item) =>
+        typeof item === 'object' &&
+        item !== null &&
+        (item as { type?: string }).type === 'web_search_call',
+    );
+  }
+
   async createToolUseFollowUpMessages(
     client: OpenAI | undefined,
     call: OpenAIResponseToolCall,
     result: ToolResultPayload,
     attachments: ToolFileAttachment[],
-    _workspaceState?: AgentWorkspaceState,
+    workspaceState?: AgentWorkspaceState,
     text?: string,
   ): Promise<ResponseInputItem[]> {
     const messages: ResponseInputItem[] = [];
     if (text) {
       messages.push(this.createAssistantMessage(text));
+    }
+
+    // Include server tool content blocks (web_search_call) from workspace state
+    // These need to be preserved when both server and local tools are in the same response
+    if (workspaceState?.serverToolContent.hasContent()) {
+      messages.push(
+        ...(workspaceState.serverToolContent
+          .contentBlocks as ResponseInputItem[]),
+      );
+      // Clear cached server tool content so it's not duplicated
+      workspaceState.resetServerToolContent();
     }
 
     const callMsg: ResponseFunctionToolCall = {
@@ -1453,6 +1482,41 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       role: 'assistant',
       content: text,
     } satisfies EasyInputMessage;
+  }
+
+  /**
+   * Create an assistant message from the raw API response, preserving web_search_call items.
+   * For OpenAI Responses API, web_search_call items are separate output items that need
+   * to be included in the conversation along with the text message.
+   */
+  override createAssistantMessageFromResponse(
+    response: Response,
+    text: string,
+  ): ResponseInputItem[] | EasyInputMessage {
+    const output = response?.output;
+    if (!Array.isArray(output)) {
+      return this.createAssistantMessage(text);
+    }
+
+    // Check if response contains web_search_call items
+    const webSearchCalls = output.filter(
+      (item) =>
+        typeof item === 'object' &&
+        item !== null &&
+        (item as { type?: string }).type === 'web_search_call',
+    );
+
+    if (webSearchCalls.length === 0) {
+      return this.createAssistantMessage(text);
+    }
+
+    // Return array with text message and web_search_call items
+    const items: ResponseInputItem[] = [];
+    if (text) {
+      items.push(this.createAssistantMessage(text));
+    }
+    items.push(...(webSearchCalls as ResponseInputItem[]));
+    return items;
   }
 
   private createInputText(text: string): ResponseInputContent {

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -1623,7 +1623,12 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       results: entries,
       provider: 'openai',
       callId: item.id,
-      status: item.status === 'completed' ? 'completed' : 'in_progress',
+      status:
+        item.status === 'completed'
+          ? 'completed'
+          : item.status === 'failed'
+            ? 'failed'
+            : 'in_progress',
     });
   }
 

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -80,10 +80,12 @@ import type {
   ResponseFunctionCallOutputItemList,
   ResponseOutputItem,
   ResponseOutputMessage,
+  ResponseFunctionWebSearch,
   // Streaming event types
   ResponseTextDeltaEvent,
   ResponseReasoningTextDeltaEvent,
   ResponseReasoningSummaryTextDeltaEvent,
+  ResponseOutputItemDoneEvent,
 } from 'openai/resources/responses/responses';
 
 interface UploadedOpenAIResponseAttachment {
@@ -631,11 +633,22 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       const output = this.isOutputStreamingEnabled()
         ? this.createOutputStream()
         : undefined;
+
+      // Track emitted web searches to avoid duplicates
+      const emittedWebSearchIds = new Set<string>();
+
       for await (const event of stream) {
         if (this.isReasoningDeltaEvent(event)) {
           thinking.append(event.delta);
         } else if (this.isTextDeltaEvent(event)) {
           output?.append(event.delta);
+        } else if (this.isOutputItemDoneEvent(event)) {
+          // Emit web search when the output item is complete
+          const item = event.item;
+          if (this.isWebSearchItem(item) && !emittedWebSearchIds.has(item.id)) {
+            this.emitOpenAIWebSearch(item);
+            emittedWebSearchIds.add(item.id);
+          }
         }
       }
 
@@ -1531,6 +1544,59 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     event: ResponseStreamEvent,
   ): event is ResponseTextDeltaEvent {
     return event.type === 'response.output_text.delta';
+  }
+
+  /** Type guard for output item done events. */
+  private isOutputItemDoneEvent(
+    event: ResponseStreamEvent,
+  ): event is ResponseOutputItemDoneEvent {
+    return event.type === 'response.output_item.done';
+  }
+
+  /** Type guard for web search output items. */
+  private isWebSearchItem(
+    item: ResponseOutputItem,
+  ): item is ResponseFunctionWebSearch {
+    return item.type === 'web_search_call';
+  }
+
+  /**
+   * Emit web search result to progress view during streaming.
+   * Extracts query and sources from the OpenAI web search item.
+   */
+  private emitOpenAIWebSearch(item: ResponseFunctionWebSearch): void {
+    // Extract action with query and sources if available
+    const action = (
+      item as ResponseFunctionWebSearch & {
+        action?: ResponseFunctionWebSearch.Search;
+      }
+    ).action;
+
+    const query = action?.query ?? '';
+    const sources = action?.sources ?? [];
+
+    const entries = sources.map((s) => ({
+      url: s.url,
+      title: '',
+      domain: this.extractDomain(s.url),
+    }));
+
+    this.emitWebSearchResult({
+      query,
+      results: entries,
+      provider: 'openai',
+      callId: item.id,
+      status: item.status === 'completed' ? 'completed' : 'in_progress',
+    });
+  }
+
+  /** Extract domain from URL. */
+  private extractDomain(url: string): string {
+    try {
+      return new URL(url).hostname;
+    } catch {
+      return '';
+    }
   }
 
   private getMessageContent(

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -593,6 +593,11 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         supportsNativeWebSearch: this.capabilities.supportsNativeWebSearch,
       });
       params.tool_choice = 'auto';
+
+      // Include web search sources in response when native web search is enabled
+      if (this.capabilities.supportsNativeWebSearch) {
+        params.include = ['web_search_call.action.sources'];
+      }
     }
 
     if (this.capabilities.supportsReasoning) {

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -87,6 +87,7 @@ import type {
   ResponseReasoningTextDeltaEvent,
   ResponseReasoningSummaryTextDeltaEvent,
   ResponseOutputItemDoneEvent,
+  ResponseWebSearchCallInProgressEvent,
 } from 'openai/resources/responses/responses';
 
 interface UploadedOpenAIResponseAttachment {
@@ -630,39 +631,68 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         },
         () => client.responses.stream(streamParams, { signal }),
       );
-      const thinking = this.createThinkingStream();
-      const output = this.isOutputStreamingEnabled()
-        ? this.createOutputStream()
-        : undefined;
 
-      // Track emitted web searches to avoid duplicates
-      const emittedWebSearchIds = new Set<string>();
+      // State for handling interleaved thinking and web search
+      // GPT can: think → web_search → think more → web_search → text
+      const state = {
+        thinkingStream: this.createThinkingStream(),
+        outputStream: this.isOutputStreamingEnabled()
+          ? this.createOutputStream()
+          : null,
+        emittedWebSearchIds: new Set<string>(),
+        hasThinkingContent: false,
+      };
 
       for await (const event of stream) {
         if (this.isReasoningDeltaEvent(event)) {
-          thinking.append(event.delta);
+          state.thinkingStream.append(event.delta);
+          state.hasThinkingContent = true;
         } else if (this.isTextDeltaEvent(event)) {
-          output?.append(event.delta);
+          state.outputStream?.append(event.delta);
+        } else if (this.isWebSearchInProgressEvent(event)) {
+          // Web search starting - finalize current thinking stream
+          if (state.hasThinkingContent) {
+            state.thinkingStream.finalize();
+            state.hasThinkingContent = false;
+          }
+          // Emit placeholder with status 'in_progress'
+          this.emitWebSearchResult({
+            query: '',
+            results: [],
+            provider: 'openai',
+            callId: event.item_id,
+            status: 'in_progress',
+          });
+          state.emittedWebSearchIds.add(event.item_id);
+          // Create new thinking stream for potential continuation
+          state.thinkingStream = this.createThinkingStream();
         } else if (this.isOutputItemDoneEvent(event)) {
-          // Emit web search when the output item is complete
+          // When output item is done, we can get the full web search data
           const item = event.item;
-          if (this.isWebSearchItem(item) && !emittedWebSearchIds.has(item.id)) {
+          if (
+            this.isWebSearchItem(item) &&
+            !state.emittedWebSearchIds.has(item.id)
+          ) {
+            // Finalize thinking if we have content (in case in_progress didn't fire)
+            if (state.hasThinkingContent) {
+              state.thinkingStream.finalize();
+              state.hasThinkingContent = false;
+              state.thinkingStream = this.createThinkingStream();
+            }
             this.emitOpenAIWebSearch(item);
-            emittedWebSearchIds.add(item.id);
+            state.emittedWebSearchIds.add(item.id);
           }
         }
       }
 
       const response = await stream.finalResponse();
-      // Don't pass reasoning to finalize - it would overwrite streamed content with shorter summary
-      // The streamed reasoning_text deltas already contain the full reasoning
-      thinking.finalize();
+      // Finalize any remaining thinking content
+      state.thinkingStream.finalize();
       const { response: finalText } = this.extractResponse(response, '');
-      if (output) output.finalize(finalText);
+      if (state.outputStream) state.outputStream.finalize(finalText);
 
-      // Emit web searches from final response since streaming events don't include action data
-      // The action field with query/sources is only populated in the final response
-      this.emitWebSearchesFromResponse(response, emittedWebSearchIds);
+      // Emit any web searches not yet emitted (fallback for edge cases)
+      this.emitWebSearchesFromResponse(response, state.emittedWebSearchIds);
 
       this.previousResponseId = response.id;
       this.sentMessages = messages.length;
@@ -1543,6 +1573,13 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       event.type === 'response.reasoning_text.delta' ||
       event.type === 'response.reasoning_summary_text.delta'
     );
+  }
+
+  /** Type guard for web search in_progress events. */
+  private isWebSearchInProgressEvent(
+    event: ResponseStreamEvent,
+  ): event is ResponseWebSearchCallInProgressEvent {
+    return event.type === 'response.web_search_call.in_progress';
   }
 
   /** Type guard for text output delta events. */

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -50,6 +50,7 @@ import { ModelHandler } from './ModelHandler';
 import {
   extractOpenAIWebSearchResults,
   type WebSearchResult,
+  type ServerToolExtractionResult,
 } from './types/ServerToolTypes';
 
 // Type imports
@@ -1281,6 +1282,9 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
    * Extract server tool content blocks (web_search_call) from OpenAI Responses API output.
    * These need to be preserved in the conversation when local tools are also present.
    */
+  /**
+   * @deprecated Use extractServerToolData() for unified extraction
+   */
   override extractServerToolContent(response: Response): unknown[] {
     const output = response?.output;
     if (!Array.isArray(output)) {
@@ -1293,6 +1297,31 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         item !== null &&
         (item as { type?: string }).type === 'web_search_call',
     );
+  }
+
+  /**
+   * Extract all server tool data in a single pass.
+   * Returns both normalized results for display and raw content blocks for context.
+   * Single source of truth for OpenAI Responses API server tool extraction.
+   */
+  override extractServerToolData(response: Response): ServerToolExtractionResult {
+    const output = response?.output;
+    if (!Array.isArray(output)) {
+      return { webSearchResults: [], contentBlocks: [] };
+    }
+
+    // Extract content blocks that need to be preserved
+    const contentBlocks = output.filter(
+      (item) =>
+        typeof item === 'object' &&
+        item !== null &&
+        (item as { type?: string }).type === 'web_search_call',
+    );
+
+    // Extract normalized web search results for display
+    const webSearchResults = extractOpenAIWebSearchResults(output);
+
+    return { webSearchResults, contentBlocks };
   }
 
   async createToolUseFollowUpMessages(

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -1356,8 +1356,8 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         .filter(isOpenAIWebSearchCall)
         .map((block) => block as ResponseInputItem);
       messages.push(...openaiBlocks);
-      // Clear after consuming to prevent duplicates
-      workspaceState.serverToolContent.contentBlocks = [];
+      // Clear after consuming to prevent duplicates - use reset method for consistency
+      workspaceState.resetServerToolContent();
     }
 
     const callMsg: ResponseFunctionToolCall = {
@@ -1628,8 +1628,15 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
   }
 
   /**
-   * Emit web search results from the final response.
-   * Called after streaming completes since streaming events don't include full action data.
+   * Emit web searches from the final response that weren't already emitted during streaming.
+   *
+   * This fallback ensures web searches are displayed even if streaming events are missed:
+   * - Network interruptions may cause output_item.done events to be lost
+   * - Some edge cases in the SDK may not emit all streaming events
+   * - Non-streaming responses need this path entirely
+   *
+   * The `alreadyEmitted` set prevents duplicates when streaming worked correctly.
+   * During normal streaming, this method typically does nothing (all IDs already emitted).
    */
   private emitWebSearchesFromResponse(
     response: Response,

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -49,7 +49,6 @@ import { toOpenAIResponseTools } from './toolConversion';
 import { ModelHandler } from './ModelHandler';
 import {
   extractOpenAIWebSearchResults,
-  type WebSearchResult,
   type ServerToolExtractionResult,
 } from './types/ServerToolTypes';
 
@@ -1263,40 +1262,6 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         input: this.parseArguments(call.arguments),
         raw: call,
       }));
-  }
-
-  /**
-   * Extract web search results from OpenAI Responses API output.
-   * OpenAI uses web_search_call items in the output array.
-   */
-  override extractWebSearchResults(response: Response): WebSearchResult[] {
-    const output = response?.output;
-    if (!Array.isArray(output)) {
-      return [];
-    }
-
-    return extractOpenAIWebSearchResults(output);
-  }
-
-  /**
-   * Extract server tool content blocks (web_search_call) from OpenAI Responses API output.
-   * These need to be preserved in the conversation when local tools are also present.
-   */
-  /**
-   * @deprecated Use extractServerToolData() for unified extraction
-   */
-  override extractServerToolContent(response: Response): unknown[] {
-    const output = response?.output;
-    if (!Array.isArray(output)) {
-      return [];
-    }
-
-    return output.filter(
-      (item) =>
-        typeof item === 'object' &&
-        item !== null &&
-        (item as { type?: string }).type === 'web_search_call',
-    );
   }
 
   /**

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -651,21 +651,13 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
           state.outputStream?.append(event.delta);
         } else if (this.isWebSearchInProgressEvent(event)) {
           // Web search starting - finalize current thinking stream
+          // Don't emit placeholder here - wait for output_item.done with full data
           if (state.hasThinkingContent) {
             state.thinkingStream.finalize();
             state.hasThinkingContent = false;
+            // Create new thinking stream for potential continuation after search
+            state.thinkingStream = this.createThinkingStream();
           }
-          // Emit placeholder with status 'in_progress'
-          this.emitWebSearchResult({
-            query: '',
-            results: [],
-            provider: 'openai',
-            callId: event.item_id,
-            status: 'in_progress',
-          });
-          state.emittedWebSearchIds.add(event.item_id);
-          // Create new thinking stream for potential continuation
-          state.thinkingStream = this.createThinkingStream();
         } else if (this.isOutputItemDoneEvent(event)) {
           // When output item is done, we can get the full web search data
           const item = event.item;

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -678,8 +678,10 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       }
 
       const response = await stream.finalResponse();
-      // Finalize any remaining thinking content
-      state.thinkingStream.finalize();
+      // Finalize any remaining thinking content (only if there's actual content)
+      if (state.hasThinkingContent) {
+        state.thinkingStream.finalize();
+      }
       const { response: finalText } = this.extractResponse(response, '');
       if (state.outputStream) state.outputStream.finalize(finalText);
 

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -1302,13 +1302,16 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
 
     // Include server tool content blocks (web_search_call) from workspace state
     // These need to be preserved when both server and local tools are in the same response
-    if (workspaceState?.serverToolContent.hasContent()) {
+    if (
+      workspaceState?.serverToolContent.contentBlocks &&
+      workspaceState.serverToolContent.contentBlocks.length > 0 &&
+      !workspaceState.serverToolContent.contentAdded
+    ) {
       messages.push(
         ...(workspaceState.serverToolContent
           .contentBlocks as ResponseInputItem[]),
       );
-      // Clear cached server tool content so it's not duplicated
-      workspaceState.resetServerToolContent();
+      workspaceState.serverToolContent.contentAdded = true;
     }
 
     const callMsg: ResponseFunctionToolCall = {

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -1307,17 +1307,14 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
 
     // Include server tool content blocks (web_search_call) from workspace state
     // These need to be preserved when both server and local tools are in the same response
-    if (
-      workspaceState?.serverToolContent.contentBlocks &&
-      workspaceState.serverToolContent.contentBlocks.length > 0 &&
-      !workspaceState.serverToolContent.contentAdded
-    ) {
+    if (workspaceState?.serverToolContent.contentBlocks.length) {
       // Filter to only OpenAI web search blocks for type safety
       const openaiBlocks = workspaceState.serverToolContent.contentBlocks
         .filter(isOpenAIWebSearchCall)
         .map((block) => block as ResponseInputItem);
       messages.push(...openaiBlocks);
-      workspaceState.serverToolContent.contentAdded = true;
+      // Clear after consuming to prevent duplicates
+      workspaceState.serverToolContent.contentBlocks = [];
     }
 
     const callMsg: ResponseFunctionToolCall = {

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -1312,10 +1312,11 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       workspaceState.serverToolContent.contentBlocks.length > 0 &&
       !workspaceState.serverToolContent.contentAdded
     ) {
-      messages.push(
-        ...(workspaceState.serverToolContent
-          .contentBlocks as ResponseInputItem[]),
-      );
+      // Filter to only OpenAI web search blocks for type safety
+      const openaiBlocks = workspaceState.serverToolContent.contentBlocks
+        .filter(isOpenAIWebSearchCall)
+        .map((block) => block as ResponseInputItem);
+      messages.push(...openaiBlocks);
       workspaceState.serverToolContent.contentAdded = true;
     }
 

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -48,6 +48,7 @@ import { OPENAI_CHAT_FINISH } from './types/StopReasonTypes';
 import { toOpenAIResponseTools } from './toolConversion';
 import { ModelHandler } from './ModelHandler';
 import {
+  extractDomain,
   extractOpenAIWebSearchResults,
   isOpenAIWebSearchCall,
   type ServerToolExtractionResult,
@@ -1578,7 +1579,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     const entries = sources.map((s) => ({
       url: s.url,
       title: '',
-      domain: this.extractDomain(s.url),
+      domain: extractDomain(s.url),
     }));
 
     this.emitWebSearchResult({
@@ -1588,15 +1589,6 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       callId: item.id,
       status: item.status === 'completed' ? 'completed' : 'in_progress',
     });
-  }
-
-  /** Extract domain from URL. */
-  private extractDomain(url: string): string {
-    try {
-      return new URL(url).hostname;
-    } catch {
-      return '';
-    }
   }
 
   private getMessageContent(

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -1479,36 +1479,6 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     } satisfies EasyInputMessage;
   }
 
-  /**
-   * Create an assistant message from the raw API response, preserving web_search_call items.
-   * For OpenAI Responses API, web_search_call items are separate output items that need
-   * to be included in the conversation along with the text message.
-   */
-  override createAssistantMessageFromResponse(
-    response: Response,
-    text: string,
-  ): ResponseInputItem[] | EasyInputMessage {
-    const output = response?.output;
-    if (!Array.isArray(output)) {
-      return this.createAssistantMessage(text);
-    }
-
-    // Check if response contains web_search_call items
-    const webSearchCalls = output.filter(isOpenAIWebSearchCall);
-
-    if (webSearchCalls.length === 0) {
-      return this.createAssistantMessage(text);
-    }
-
-    // Return array with text message and web_search_call items
-    const items: ResponseInputItem[] = [];
-    if (text) {
-      items.push(this.createAssistantMessage(text));
-    }
-    items.push(...(webSearchCalls as ResponseInputItem[]));
-    return items;
-  }
-
   private createInputText(text: string): ResponseInputContent {
     return { type: 'input_text', text };
   }

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -654,10 +654,15 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       }
 
       const response = await stream.finalResponse();
-      const finalReasoning = this.processThinkingBlock(response);
-      thinking.finalize(finalReasoning ?? undefined);
+      // Don't pass reasoning to finalize - it would overwrite streamed content with shorter summary
+      // The streamed reasoning_text deltas already contain the full reasoning
+      thinking.finalize();
       const { response: finalText } = this.extractResponse(response, '');
       if (output) output.finalize(finalText);
+
+      // Emit web searches from final response since streaming events don't include action data
+      // The action field with query/sources is only populated in the final response
+      this.emitWebSearchesFromResponse(response, emittedWebSearchIds);
 
       this.previousResponseId = response.id;
       this.sentMessages = messages.length;
@@ -1589,6 +1594,27 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       callId: item.id,
       status: item.status === 'completed' ? 'completed' : 'in_progress',
     });
+  }
+
+  /**
+   * Emit web search results from the final response.
+   * Called after streaming completes since streaming events don't include full action data.
+   */
+  private emitWebSearchesFromResponse(
+    response: Response,
+    alreadyEmitted: Set<string>,
+  ): void {
+    const output = response?.output;
+    if (!Array.isArray(output)) {
+      return;
+    }
+
+    for (const item of output) {
+      if (this.isWebSearchItem(item) && !alreadyEmitted.has(item.id)) {
+        this.emitOpenAIWebSearch(item);
+        alreadyEmitted.add(item.id);
+      }
+    }
   }
 
   private getMessageContent(

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -49,6 +49,7 @@ import { toOpenAIResponseTools } from './toolConversion';
 import { ModelHandler } from './ModelHandler';
 import {
   extractOpenAIWebSearchResults,
+  isOpenAIWebSearchCall,
   type ServerToolExtractionResult,
 } from './types/ServerToolTypes';
 
@@ -1269,19 +1270,16 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
    * Returns both normalized results for display and raw content blocks for context.
    * Single source of truth for OpenAI Responses API server tool extraction.
    */
-  override extractServerToolData(response: Response): ServerToolExtractionResult {
+  override extractServerToolData(
+    response: Response,
+  ): ServerToolExtractionResult {
     const output = response?.output;
     if (!Array.isArray(output)) {
       return { webSearchResults: [], contentBlocks: [] };
     }
 
     // Extract content blocks that need to be preserved
-    const contentBlocks = output.filter(
-      (item) =>
-        typeof item === 'object' &&
-        item !== null &&
-        (item as { type?: string }).type === 'web_search_call',
-    );
+    const contentBlocks = output.filter(isOpenAIWebSearchCall);
 
     // Extract normalized web search results for display
     const webSearchResults = extractOpenAIWebSearchResults(output);
@@ -1493,12 +1491,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     }
 
     // Check if response contains web_search_call items
-    const webSearchCalls = output.filter(
-      (item) =>
-        typeof item === 'object' &&
-        item !== null &&
-        (item as { type?: string }).type === 'web_search_call',
-    );
+    const webSearchCalls = output.filter(isOpenAIWebSearchCall);
 
     if (webSearchCalls.length === 0) {
       return this.createAssistantMessage(text);

--- a/src/agent/modelHandlers/support/AnthropicStreamHandler.ts
+++ b/src/agent/modelHandlers/support/AnthropicStreamHandler.ts
@@ -1,0 +1,338 @@
+/**
+ * Dedicated stream handler for Anthropic responses.
+ * Encapsulates the streaming event handling logic for improved testability and readability.
+ */
+import { MESSAGE_TYPES } from '@logger/messageTypes';
+import type { AgentLogger } from '@logger/AgentLogger';
+import {
+  extractDomain,
+  type WebSearchResult,
+  type WebSearchResultEntry,
+} from '../types/ServerToolTypes';
+
+import type { BetaRawMessageStreamEvent } from '@anthropic-ai/sdk/resources/beta/messages';
+import type {
+  ServerToolUseBlock,
+  WebSearchToolResultBlock,
+  WebSearchResultBlock,
+} from '@anthropic-ai/sdk/resources/messages';
+
+/**
+ * Duck-typed interface for Anthropic message streams.
+ * Allows us to work with the stream without importing SDK-internal types.
+ */
+interface AnthropicMessageStream {
+  on(
+    event: 'streamEvent',
+    callback: (event: BetaRawMessageStreamEvent) => void,
+  ): void;
+}
+
+/**
+ * Maximum size for accumulated search input JSON (64KB).
+ * Prevents memory growth for very long queries.
+ */
+const MAX_SEARCH_INPUT_SIZE = 65536;
+
+/**
+ * State tracked during Anthropic streaming.
+ */
+interface AnthropicStreamState {
+  /** Current output stream for text blocks */
+  outputStream: ReturnType<AgentLogger['createStream']> | null;
+  /** Index of most recent block (any type) */
+  lastBlockIndex: number;
+  /** Track web search: tool_use_id → { index, accumulated input JSON } */
+  pendingSearches: Map<string, { index: number; input: string }>;
+  /** Track emitted search IDs to prevent duplicate logging in flow */
+  emittedSearchIds: Set<string>;
+}
+
+/**
+ * Configuration for the stream handler.
+ */
+interface StreamHandlerConfig {
+  /** Whether output streaming is enabled */
+  outputEnabled: boolean;
+  /** Whether progress view is enabled */
+  progressViewEnabled: boolean;
+}
+
+/**
+ * Factory functions for creating streams.
+ */
+interface StreamFactories {
+  createThinkingStream: () => ReturnType<AgentLogger['createStream']>;
+  createOutputStream: () => ReturnType<AgentLogger['createStream']>;
+}
+
+/**
+ * Handles Anthropic streaming events with proper interleaved content block management.
+ *
+ * Streaming strategy for interleaved content blocks:
+ * - Thinking blocks: each gets its own stream entry (separate thinking phases)
+ * - Text blocks: consecutive text blocks merge, non-consecutive are separate
+ * - Server tools (web_search): emit to progress view when results arrive
+ *
+ * Example: text_0 → server_tool_1 → result_2 → text_3 → text_4
+ *   → Output #1 (text_0), WebSearch, Output #2 (text_3 + text_4 merged)
+ */
+export class AnthropicStreamHandler {
+  private readonly thinkingStreams = new Map<
+    number,
+    ReturnType<AgentLogger['createStream']>
+  >();
+  private readonly state: AnthropicStreamState = {
+    outputStream: null,
+    lastBlockIndex: -1,
+    pendingSearches: new Map(),
+    emittedSearchIds: new Set(),
+  };
+
+  constructor(
+    private readonly logger: AgentLogger,
+    private readonly config: StreamHandlerConfig,
+    private readonly factories: StreamFactories,
+  ) {}
+
+  /**
+   * Attaches event listeners to the stream and returns the handler for cleanup.
+   */
+  attachToStream(stream: AnthropicMessageStream): void {
+    stream.on('streamEvent', (event: BetaRawMessageStreamEvent) => {
+      this.handleStreamEvent(event);
+    });
+  }
+
+  /**
+   * Gets the set of emitted search IDs for duplicate prevention in flow.
+   */
+  getEmittedSearchIds(): Set<string> {
+    return this.state.emittedSearchIds;
+  }
+
+  /**
+   * Finalizes all remaining streams and clears state.
+   * Call this after stream.finalMessage() completes.
+   */
+  finalize(): void {
+    // Finalize any remaining thinking streams
+    for (const s of this.thinkingStreams.values()) {
+      s.finalize();
+    }
+    this.thinkingStreams.clear();
+
+    // Finalize output stream
+    this.state.outputStream?.finalize();
+    this.state.outputStream = null;
+
+    // Clear state to prevent memory leaks
+    this.state.pendingSearches.clear();
+    this.state.emittedSearchIds.clear();
+  }
+
+  /**
+   * Handles a single stream event.
+   */
+  private handleStreamEvent(event: BetaRawMessageStreamEvent): void {
+    if (event.type === 'content_block_start') {
+      this.handleBlockStart(event);
+    } else if (event.type === 'content_block_delta') {
+      this.handleBlockDelta(event);
+    } else if (event.type === 'content_block_stop') {
+      this.handleBlockStop(event);
+    }
+  }
+
+  /**
+   * Handles content_block_start events.
+   */
+  private handleBlockStart(
+    event: Extract<BetaRawMessageStreamEvent, { type: 'content_block_start' }>,
+  ): void {
+    const blockType = event.content_block.type;
+    const blockIndex = event.index;
+
+    if (blockType === 'thinking') {
+      // Finalize any pending text stream before starting thinking
+      this.finalizeOutputStream();
+      this.thinkingStreams.set(
+        blockIndex,
+        this.factories.createThinkingStream(),
+      );
+    } else if (blockType === 'text' && this.config.outputEnabled) {
+      // Consecutive text blocks share a stream
+      // Consecutive means: immediately following (by index) AND previous was text
+      // The outputStream !== null check ensures previous block was text
+      // (we null it for thinking/tool blocks)
+      const isConsecutive =
+        this.state.outputStream !== null &&
+        blockIndex === this.state.lastBlockIndex + 1;
+
+      if (!isConsecutive) {
+        // First text block or non-consecutive - create new stream
+        this.finalizeOutputStream();
+        this.state.outputStream = this.factories.createOutputStream();
+      }
+    } else if (blockType === 'server_tool_use') {
+      // Track web search server tool use to get query
+      const block = event.content_block as ServerToolUseBlock;
+      if (block.name === 'web_search') {
+        this.state.pendingSearches.set(block.id, {
+          index: blockIndex,
+          input: '',
+        });
+      }
+      // Finalize any pending text stream
+      this.finalizeOutputStream();
+    } else if (blockType === 'web_search_tool_result') {
+      this.handleWebSearchResult(
+        event.content_block as WebSearchToolResultBlock,
+      );
+      // Finalize any pending text stream
+      this.finalizeOutputStream();
+    } else {
+      // Other non-text, non-thinking blocks (tool_use, etc.)
+      // Finalize any pending text stream
+      this.finalizeOutputStream();
+    }
+
+    // Always update lastBlockIndex for ALL block types
+    this.state.lastBlockIndex = blockIndex;
+  }
+
+  /**
+   * Handles content_block_delta events.
+   */
+  private handleBlockDelta(
+    event: Extract<BetaRawMessageStreamEvent, { type: 'content_block_delta' }>,
+  ): void {
+    if (event.delta.type === 'thinking_delta') {
+      this.thinkingStreams.get(event.index)?.append(event.delta.thinking);
+    } else if (event.delta.type === 'text_delta') {
+      this.state.outputStream?.append(event.delta.text);
+    } else if (event.delta.type === 'input_json_delta') {
+      // Accumulate input JSON for web search to get query (with size limit)
+      for (const [, searchData] of this.state.pendingSearches) {
+        if (searchData.index === event.index) {
+          // Apply size limit to prevent memory growth
+          if (searchData.input.length < MAX_SEARCH_INPUT_SIZE) {
+            const remaining = MAX_SEARCH_INPUT_SIZE - searchData.input.length;
+            searchData.input += event.delta.partial_json.slice(0, remaining);
+          }
+          break;
+        }
+      }
+    }
+  }
+
+  /**
+   * Handles content_block_stop events.
+   */
+  private handleBlockStop(
+    event: Extract<BetaRawMessageStreamEvent, { type: 'content_block_stop' }>,
+  ): void {
+    // Finalize thinking streams immediately on block stop
+    const thinking = this.thinkingStreams.get(event.index);
+    if (thinking) {
+      thinking.finalize();
+      this.thinkingStreams.delete(event.index);
+    }
+    // Text streams: don't finalize here - wait for non-text block or end
+  }
+
+  /**
+   * Handles web_search_tool_result blocks.
+   */
+  private handleWebSearchResult(block: WebSearchToolResultBlock): void {
+    const searchData = this.state.pendingSearches.get(block.tool_use_id);
+
+    // Parse query from accumulated input JSON
+    const query = this.parseSearchQuery(searchData?.input);
+
+    // Extract results from the block content
+    const entries = this.extractSearchResults(block);
+
+    // Emit to progress view
+    if (entries.length > 0 || query) {
+      this.emitWebSearchResult({
+        query,
+        results: entries,
+        provider: 'anthropic',
+        callId: block.tool_use_id,
+        status: 'completed',
+      });
+      this.state.emittedSearchIds.add(block.tool_use_id);
+    }
+
+    // Clean up
+    this.state.pendingSearches.delete(block.tool_use_id);
+  }
+
+  /**
+   * Parses the search query from accumulated input JSON.
+   */
+  private parseSearchQuery(input: string | undefined): string {
+    if (!input) {
+      return '';
+    }
+
+    try {
+      const parsed = JSON.parse(input) as { query?: string };
+      return parsed.query ?? '';
+    } catch {
+      // Partial JSON, try to extract query with regex
+      const match = input.match(/"query"\s*:\s*"([^"]+)"/);
+      return match?.[1] ?? '';
+    }
+  }
+
+  /**
+   * Extracts search results from a web_search_tool_result block.
+   */
+  private extractSearchResults(
+    block: WebSearchToolResultBlock,
+  ): WebSearchResultEntry[] {
+    const entries: WebSearchResultEntry[] = [];
+
+    if (Array.isArray(block.content)) {
+      for (const item of block.content) {
+        const r = item as WebSearchResultBlock;
+        if (r.type === 'web_search_result' && r.url) {
+          entries.push({
+            url: r.url,
+            title: r.title,
+            snippet: r.encrypted_content,
+            pageAge: r.page_age ?? undefined,
+            domain: extractDomain(r.url),
+          });
+        }
+      }
+    }
+
+    return entries;
+  }
+
+  /**
+   * Finalizes the output stream if present and clears it.
+   */
+  private finalizeOutputStream(): void {
+    if (this.state.outputStream) {
+      this.state.outputStream.finalize();
+      this.state.outputStream = null;
+    }
+  }
+
+  /**
+   * Emits a web search result to the progress view.
+   */
+  private emitWebSearchResult(result: WebSearchResult): void {
+    if (!this.config.progressViewEnabled) {
+      return;
+    }
+    this.logger.info('', {
+      messageType: MESSAGE_TYPES.WEB_SEARCH,
+      data: result,
+    });
+  }
+}

--- a/src/agent/modelHandlers/support/AnthropicStreamHandler.ts
+++ b/src/agent/modelHandlers/support/AnthropicStreamHandler.ts
@@ -280,8 +280,11 @@ export class AnthropicStreamHandler {
     try {
       const parsed = JSON.parse(input) as { query?: string };
       return parsed.query ?? '';
-    } catch {
-      // Partial JSON, try to extract query with regex
+    } catch (error) {
+      // Partial JSON (common for streaming), try to extract query with regex
+      this.logger.debug(
+        `Anthropic search input JSON parse failed, using regex fallback: ${String(error)}`,
+      );
       const match = input.match(/"query"\s*:\s*"([^"]+)"/);
       return match?.[1] ?? '';
     }

--- a/src/agent/modelHandlers/types/IModelHandler.ts
+++ b/src/agent/modelHandlers/types/IModelHandler.ts
@@ -374,7 +374,10 @@ export interface IModelHandler<
    * @returns Assistant message(s) preserving full response content. May return array
    *          for providers like OpenAI where server tools are separate output items.
    */
-  createAssistantMessageFromResponse(responseObject: Resp, text: string): M | M[];
+  createAssistantMessageFromResponse(
+    responseObject: Resp,
+    text: string,
+  ): M | M[];
 
   /**
    * Determine if the stop reason represents an end-turn marker.

--- a/src/agent/modelHandlers/types/IModelHandler.ts
+++ b/src/agent/modelHandlers/types/IModelHandler.ts
@@ -305,6 +305,14 @@ export interface IModelHandler<
   extractWebSearchResults(responseObject: Resp): WebSearchResult[];
 
   /**
+   * Extract server tool content blocks from a provider response.
+   * These blocks (e.g., server_tool_use, web_search_tool_result for Anthropic)
+   * need to be preserved in the assistant message when local tools are also present.
+   * Returns empty array if no server tool content is present.
+   */
+  extractServerToolContent(responseObject: Resp): unknown[];
+
+  /**
    * Create provider-specific messages capturing the tool call and result.
    *
    * @param client - Provider client (for file uploads if supported)
@@ -358,6 +366,19 @@ export interface IModelHandler<
    * Build a simple assistant message from plain text.
    */
   createAssistantMessage(text: string): M;
+
+  /**
+   * Create an assistant message from the raw API response, preserving all content blocks.
+   * This is used when the response contains server tool use (like web_search) to ensure
+   * the full context including search results is preserved in the conversation.
+   *
+   * Default implementation falls back to createAssistantMessage(text).
+   *
+   * @param responseObject - The raw API response
+   * @param text - Extracted text content (fallback if no special handling needed)
+   * @returns Assistant message preserving full response content
+   */
+  createAssistantMessageFromResponse(responseObject: Resp, text: string): M;
 
   /**
    * Determine if the stop reason represents an end-turn marker.

--- a/src/agent/modelHandlers/types/IModelHandler.ts
+++ b/src/agent/modelHandlers/types/IModelHandler.ts
@@ -22,7 +22,10 @@ import type {
 import type { ResponseFunctionToolCallItem } from 'openai/resources/responses/responses';
 import type { FunctionCall } from '@google/genai';
 import type { ToolUseBlock } from '@anthropic-ai/sdk/resources/messages';
-import type { WebSearchResult } from './ServerToolTypes';
+import type {
+  WebSearchResult,
+  ServerToolExtractionResult,
+} from './ServerToolTypes';
 
 // Re-export for backwards compatibility
 export type { ProviderUsage };
@@ -301,6 +304,7 @@ export interface IModelHandler<
    * Extract web search results from a provider response.
    * Returns server-side web search results if the provider supports native search.
    * Returns empty array if no web search was performed or provider doesn't support it.
+   * @deprecated Use extractServerToolData() for unified extraction
    */
   extractWebSearchResults(responseObject: Resp): WebSearchResult[];
 
@@ -309,8 +313,19 @@ export interface IModelHandler<
    * These blocks (e.g., server_tool_use, web_search_tool_result for Anthropic)
    * need to be preserved in the assistant message when local tools are also present.
    * Returns empty array if no server tool content is present.
+   * @deprecated Use extractServerToolData() for unified extraction
    */
   extractServerToolContent(responseObject: Resp): unknown[];
+
+  /**
+   * Extract all server tool data from a provider response in a single pass.
+   * Returns both normalized results for display and raw content blocks for context.
+   * This is the single source of truth for server tool extraction.
+   *
+   * @param responseObject - The raw API response
+   * @returns Combined extraction result with webSearchResults and contentBlocks
+   */
+  extractServerToolData(responseObject: Resp): ServerToolExtractionResult;
 
   /**
    * Create provider-specific messages capturing the tool call and result.

--- a/src/agent/modelHandlers/types/IModelHandler.ts
+++ b/src/agent/modelHandlers/types/IModelHandler.ts
@@ -366,4 +366,13 @@ export interface IModelHandler<
    * Determine if the stop reason represents an end-turn marker.
    */
   isEndTurnStop(reason: ProviderStopReason): boolean;
+
+  /**
+   * Extract assistant content blocks from a response, excluding tool_use blocks.
+   * Used to preserve original order when building follow-up messages.
+   *
+   * @param responseObject - The raw API response
+   * @returns Array of content blocks suitable for message building, or empty array if not supported
+   */
+  extractAssistantContent(responseObject: Resp): unknown[];
 }

--- a/src/agent/modelHandlers/types/IModelHandler.ts
+++ b/src/agent/modelHandlers/types/IModelHandler.ts
@@ -376,9 +376,10 @@ export interface IModelHandler<
    *
    * @param responseObject - The raw API response
    * @param text - Extracted text content (fallback if no special handling needed)
-   * @returns Assistant message preserving full response content
+   * @returns Assistant message(s) preserving full response content. May return array
+   *          for providers like OpenAI where server tools are separate output items.
    */
-  createAssistantMessageFromResponse(responseObject: Resp, text: string): M;
+  createAssistantMessageFromResponse(responseObject: Resp, text: string): M | M[];
 
   /**
    * Determine if the stop reason represents an end-turn marker.

--- a/src/agent/modelHandlers/types/IModelHandler.ts
+++ b/src/agent/modelHandlers/types/IModelHandler.ts
@@ -22,10 +22,7 @@ import type {
 import type { ResponseFunctionToolCallItem } from 'openai/resources/responses/responses';
 import type { FunctionCall } from '@google/genai';
 import type { ToolUseBlock } from '@anthropic-ai/sdk/resources/messages';
-import type {
-  WebSearchResult,
-  ServerToolExtractionResult,
-} from './ServerToolTypes';
+import type { ServerToolExtractionResult } from './ServerToolTypes';
 
 // Re-export for backwards compatibility
 export type { ProviderUsage };
@@ -299,23 +296,6 @@ export interface IModelHandler<
 
   /** Extract tool-use details from a provider response. */
   extractToolUse(responseObject: Resp): T[];
-
-  /**
-   * Extract web search results from a provider response.
-   * Returns server-side web search results if the provider supports native search.
-   * Returns empty array if no web search was performed or provider doesn't support it.
-   * @deprecated Use extractServerToolData() for unified extraction
-   */
-  extractWebSearchResults(responseObject: Resp): WebSearchResult[];
-
-  /**
-   * Extract server tool content blocks from a provider response.
-   * These blocks (e.g., server_tool_use, web_search_tool_result for Anthropic)
-   * need to be preserved in the assistant message when local tools are also present.
-   * Returns empty array if no server tool content is present.
-   * @deprecated Use extractServerToolData() for unified extraction
-   */
-  extractServerToolContent(responseObject: Resp): unknown[];
 
   /**
    * Extract all server tool data from a provider response in a single pass.

--- a/src/agent/modelHandlers/types/IModelHandler.ts
+++ b/src/agent/modelHandlers/types/IModelHandler.ts
@@ -363,23 +363,6 @@ export interface IModelHandler<
   createAssistantMessage(text: string): M;
 
   /**
-   * Create an assistant message from the raw API response, preserving all content blocks.
-   * This is used when the response contains server tool use (like web_search) to ensure
-   * the full context including search results is preserved in the conversation.
-   *
-   * Default implementation falls back to createAssistantMessage(text).
-   *
-   * @param responseObject - The raw API response
-   * @param text - Extracted text content (fallback if no special handling needed)
-   * @returns Assistant message(s) preserving full response content. May return array
-   *          for providers like OpenAI where server tools are separate output items.
-   */
-  createAssistantMessageFromResponse(
-    responseObject: Resp,
-    text: string,
-  ): M | M[];
-
-  /**
    * Determine if the stop reason represents an end-turn marker.
    */
   isEndTurnStop(reason: ProviderStopReason): boolean;

--- a/src/agent/modelHandlers/types/ServerToolTypes.ts
+++ b/src/agent/modelHandlers/types/ServerToolTypes.ts
@@ -48,7 +48,7 @@ export interface WebSearchResult {
   /** Search result entries */
   results: WebSearchResultEntry[];
   /** Provider that executed the search */
-  provider: 'anthropic' | 'openai' | 'google';
+  provider: 'anthropic' | 'openai';
   /** Unique identifier for this search call */
   callId?: string;
   /** Status of the search */
@@ -56,42 +56,8 @@ export interface WebSearchResult {
 }
 
 // ============================================================================
-// Server Tool Call Types (Discriminated Union)
+// Server Tool Content Block Types
 // ============================================================================
-
-/**
- * Anthropic server tool use block.
- * Represents a tool executed by Anthropic's servers.
- */
-export interface AnthropicServerToolCall {
-  provider: 'anthropic';
-  type: 'web_search';
-  callId: string;
-  name: 'web_search';
-  /** Raw SDK block for reference */
-  raw: unknown;
-}
-
-/**
- * OpenAI web search call from Responses API.
- */
-export interface OpenAIWebSearchCall {
-  provider: 'openai';
-  type: 'web_search_call';
-  callId: string;
-  /** Search query */
-  query?: string;
-  /** Sources/URLs found */
-  sources?: Array<{ type: 'url'; url: string }>;
-  status: 'in_progress' | 'searching' | 'completed' | 'failed';
-  /** Raw SDK object for reference */
-  raw: unknown;
-}
-
-/**
- * Union of all server tool call types.
- */
-export type ServerToolCall = AnthropicServerToolCall | OpenAIWebSearchCall;
 
 /**
  * Union of all raw content block types that can be returned by server tools.

--- a/src/agent/modelHandlers/types/ServerToolTypes.ts
+++ b/src/agent/modelHandlers/types/ServerToolTypes.ts
@@ -333,7 +333,7 @@ export function extractOpenAIWebSearchResults(
 /**
  * Extract domain from URL.
  */
-function extractDomain(url: string): string {
+export function extractDomain(url: string): string {
   try {
     return new URL(url).hostname;
   } catch {

--- a/src/agent/modelHandlers/types/ServerToolTypes.ts
+++ b/src/agent/modelHandlers/types/ServerToolTypes.ts
@@ -3,7 +3,25 @@
  *
  * Server tools are executed by the provider (Anthropic, OpenAI, Google) rather
  * than locally. This module provides a unified abstraction layer.
+ *
+ * Uses native SDK types where available for better type safety and maintainability.
  */
+
+// SDK type imports - using native types for better type safety
+import type {
+  ServerToolUseBlock,
+  WebSearchToolResultBlock,
+  WebSearchResultBlock,
+} from '@anthropic-ai/sdk/resources/messages';
+import type { ResponseFunctionWebSearch } from 'openai/resources/responses/responses';
+
+// Re-export SDK types for external use
+export type {
+  ServerToolUseBlock,
+  WebSearchToolResultBlock,
+  WebSearchResultBlock,
+  ResponseFunctionWebSearch,
+};
 
 // ============================================================================
 // Web Search Result Types
@@ -113,7 +131,7 @@ export interface ServerToolExtractionResult {
 }
 
 // ============================================================================
-// Type Guards
+// Type Guards - Using SDK types for better type safety
 // ============================================================================
 
 /**
@@ -128,11 +146,12 @@ export function isWebSearchCall(call: ServerToolCall): boolean {
 }
 
 /**
- * Check if a content block is an Anthropic server tool use.
+ * Type guard for Anthropic server tool use block.
+ * Uses SDK's ServerToolUseBlock type for proper typing.
  */
 export function isAnthropicServerToolUse(
   block: unknown,
-): block is { type: 'server_tool_use'; id: string; name: string } {
+): block is ServerToolUseBlock {
   return (
     typeof block === 'object' &&
     block !== null &&
@@ -141,11 +160,12 @@ export function isAnthropicServerToolUse(
 }
 
 /**
- * Check if a content block is an Anthropic web search result.
+ * Type guard for Anthropic web search result block.
+ * Uses SDK's WebSearchToolResultBlock type for proper typing.
  */
 export function isAnthropicWebSearchResult(
   block: unknown,
-): block is { type: 'web_search_tool_result'; tool_use_id: string } {
+): block is WebSearchToolResultBlock {
   return (
     typeof block === 'object' &&
     block !== null &&
@@ -154,11 +174,12 @@ export function isAnthropicWebSearchResult(
 }
 
 /**
- * Check if an OpenAI response item is a web search call.
+ * Type guard for OpenAI web search call.
+ * Uses SDK's ResponseFunctionWebSearch type for proper typing.
  */
 export function isOpenAIWebSearchCall(
   item: unknown,
-): item is { type: 'web_search_call'; id: string } {
+): item is ResponseFunctionWebSearch {
   return (
     typeof item === 'object' &&
     item !== null &&
@@ -167,11 +188,22 @@ export function isOpenAIWebSearchCall(
 }
 
 // ============================================================================
-// Result Extraction Helpers
+// Result Extraction Helpers - Using SDK types for type safety
 // ============================================================================
 
 /**
+ * Type guard for WebSearchResultBlock array content.
+ * The SDK's WebSearchToolResultBlockContent is a union of error or results array.
+ */
+function isWebSearchResultArray(
+  content: WebSearchToolResultBlock['content'],
+): content is WebSearchResultBlock[] {
+  return Array.isArray(content);
+}
+
+/**
  * Extract web search results from Anthropic response content.
+ * Uses SDK's WebSearchToolResultBlock and WebSearchResultBlock types.
  */
 export function extractAnthropicWebSearchResults(
   content: unknown[],
@@ -183,30 +215,21 @@ export function extractAnthropicWebSearchResults(
       continue;
     }
 
-    const resultBlock = block as {
-      type: 'web_search_tool_result';
-      tool_use_id: string;
-      content?: Array<{
-        type: 'web_search_result';
-        url?: string;
-        title?: string;
-        encrypted_content?: string;
-        page_age?: string;
-      }>;
-    };
-
-    if (!Array.isArray(resultBlock.content)) {
+    // block is now properly typed as WebSearchToolResultBlock
+    if (!isWebSearchResultArray(block.content)) {
+      // Content is an error, not results
       continue;
     }
 
-    const entries: WebSearchResultEntry[] = resultBlock.content
-      .filter((r) => r.type === 'web_search_result' && r.url)
+    // block.content is now properly typed as WebSearchResultBlock[]
+    const entries: WebSearchResultEntry[] = block.content
+      .filter((r): r is WebSearchResultBlock => r.type === 'web_search_result' && !!r.url)
       .map((r) => ({
-        url: r.url!,
-        title: r.title ?? '',
+        url: r.url,
+        title: r.title,
         snippet: r.encrypted_content,
-        pageAge: r.page_age,
-        domain: extractDomain(r.url!),
+        pageAge: r.page_age ?? undefined,
+        domain: extractDomain(r.url),
       }));
 
     if (entries.length > 0) {
@@ -214,7 +237,7 @@ export function extractAnthropicWebSearchResults(
         query: '', // Anthropic doesn't expose query in result
         results: entries,
         provider: 'anthropic',
-        callId: resultBlock.tool_use_id,
+        callId: block.tool_use_id,
         status: 'completed',
       });
     }
@@ -224,7 +247,17 @@ export function extractAnthropicWebSearchResults(
 }
 
 /**
+ * Extended web search interface with optional action field.
+ * The action field is only populated when using include: ['web_search_call.action.sources'].
+ * Uses SDK's ResponseFunctionWebSearch.Search type for the action structure.
+ */
+interface ResponseFunctionWebSearchWithAction extends ResponseFunctionWebSearch {
+  action?: ResponseFunctionWebSearch.Search;
+}
+
+/**
  * Extract web search results from OpenAI Responses API output.
+ * Uses SDK's ResponseFunctionWebSearch type for proper typing.
  *
  * Note: The OpenAI Responses API returns web_search_call items with only
  * basic fields (id, status, type) by default. The action field with sources
@@ -241,19 +274,11 @@ export function extractOpenAIWebSearchResults(
       continue;
     }
 
-    const searchItem = item as {
-      type: 'web_search_call';
-      id: string;
-      status?: 'in_progress' | 'searching' | 'completed' | 'failed';
-      // action is only present when include: ['web_search_call.action.sources'] is used
-      action?: {
-        type: 'search';
-        query?: string;
-        sources?: Array<{ type: 'url'; url: string }>;
-      };
-    };
+    // item is now properly typed as ResponseFunctionWebSearch
+    // Cast to extended type that may include action field
+    const searchItem = item as ResponseFunctionWebSearchWithAction;
 
-    // Determine status
+    // Determine status using SDK's status type
     const status: WebSearchResult['status'] =
       searchItem.status === 'completed'
         ? 'completed'
@@ -277,10 +302,7 @@ export function extractOpenAIWebSearchResults(
     }
 
     // Handle case when action is present (include sources was used)
-    if (action.type !== 'search') {
-      continue;
-    }
-
+    // action.type is always 'search' per SDK's ResponseFunctionWebSearch.Search
     const entries: WebSearchResultEntry[] = (action.sources ?? []).map((s) => ({
       url: s.url,
       title: '', // OpenAI sources don't include titles in basic response

--- a/src/agent/modelHandlers/types/ServerToolTypes.ts
+++ b/src/agent/modelHandlers/types/ServerToolTypes.ts
@@ -187,6 +187,17 @@ export function isOpenAIWebSearchCall(
   );
 }
 
+/**
+ * Type guard for Anthropic server tool content blocks.
+ * Checks if a block is either a server tool use or web search result.
+ * Used to identify content that needs to be preserved in conversation context.
+ */
+export function isAnthropicServerToolContent(
+  block: unknown,
+): block is ServerToolUseBlock | WebSearchToolResultBlock {
+  return isAnthropicServerToolUse(block) || isAnthropicWebSearchResult(block);
+}
+
 // ============================================================================
 // Result Extraction Helpers - Using SDK types for type safety
 // ============================================================================

--- a/src/agent/modelHandlers/types/ServerToolTypes.ts
+++ b/src/agent/modelHandlers/types/ServerToolTypes.ts
@@ -89,30 +89,9 @@ export interface OpenAIWebSearchCall {
 }
 
 /**
- * Google grounding metadata from search.
- */
-export interface GoogleGroundingResult {
-  provider: 'google';
-  type: 'grounding';
-  /** Grounding chunks with web sources */
-  chunks: Array<{
-    title?: string;
-    uri?: string;
-    domain?: string;
-  }>;
-  /** Queries that were executed */
-  searchQueries?: string[];
-  /** Raw SDK metadata for reference */
-  raw: unknown;
-}
-
-/**
  * Union of all server tool call types.
  */
-export type ServerToolCall =
-  | AnthropicServerToolCall
-  | OpenAIWebSearchCall
-  | GoogleGroundingResult;
+export type ServerToolCall = AnthropicServerToolCall | OpenAIWebSearchCall;
 
 /**
  * Union of all raw content block types that can be returned by server tools.
@@ -140,17 +119,6 @@ export interface ServerToolExtractionResult {
 // ============================================================================
 // Type Guards - Using SDK types for better type safety
 // ============================================================================
-
-/**
- * Check if a server tool call is a web search (any provider).
- */
-export function isWebSearchCall(call: ServerToolCall): boolean {
-  return (
-    call.type === 'web_search' ||
-    call.type === 'web_search_call' ||
-    call.type === 'grounding'
-  );
-}
 
 /**
  * Type guard for Anthropic server tool use block.
@@ -356,49 +324,6 @@ export function extractOpenAIWebSearchResults(
   }
 
   return results;
-}
-
-/**
- * Extract grounding results from Google GenAI response.
- */
-export function extractGoogleGroundingResults(
-  candidate: unknown,
-): WebSearchResult | null {
-  const cand = candidate as {
-    groundingMetadata?: {
-      groundingChunks?: Array<{
-        web?: { title?: string; uri?: string; domain?: string };
-      }>;
-      webSearchQueries?: string[];
-      retrievalQueries?: string[];
-    };
-  };
-
-  const metadata = cand?.groundingMetadata;
-  if (!metadata?.groundingChunks?.length) {
-    return null;
-  }
-
-  const entries: WebSearchResultEntry[] = metadata.groundingChunks
-    .filter((chunk) => chunk.web?.uri)
-    .map((chunk) => ({
-      url: chunk.web!.uri!,
-      title: chunk.web!.title ?? '',
-      domain: chunk.web!.domain ?? extractDomain(chunk.web!.uri!),
-    }));
-
-  if (entries.length === 0) {
-    return null;
-  }
-
-  const queries = metadata.webSearchQueries ?? metadata.retrievalQueries ?? [];
-
-  return {
-    query: queries.join('; '),
-    results: entries,
-    provider: 'google',
-    status: 'completed',
-  };
 }
 
 // ============================================================================

--- a/src/agent/modelHandlers/types/ServerToolTypes.ts
+++ b/src/agent/modelHandlers/types/ServerToolTypes.ts
@@ -234,7 +234,10 @@ export function extractAnthropicWebSearchResults(
 
     // block.content is now properly typed as WebSearchResultBlock[]
     const entries: WebSearchResultEntry[] = block.content
-      .filter((r): r is WebSearchResultBlock => r.type === 'web_search_result' && !!r.url)
+      .filter(
+        (r): r is WebSearchResultBlock =>
+          r.type === 'web_search_result' && !!r.url,
+      )
       .map((r) => ({
         url: r.url,
         title: r.title,

--- a/src/agent/modelHandlers/types/ServerToolTypes.ts
+++ b/src/agent/modelHandlers/types/ServerToolTypes.ts
@@ -101,6 +101,17 @@ export type ServerToolCall =
   | OpenAIWebSearchCall
   | GoogleGroundingResult;
 
+/**
+ * Combined result from server tool extraction.
+ * Single source of truth for both display (webSearchResults) and context (contentBlocks).
+ */
+export interface ServerToolExtractionResult {
+  /** Normalized web search results for display in progress view */
+  webSearchResults: WebSearchResult[];
+  /** Raw content blocks to preserve in conversation context */
+  contentBlocks: unknown[];
+}
+
 // ============================================================================
 // Type Guards
 // ============================================================================

--- a/src/agent/modelHandlers/types/ServerToolTypes.ts
+++ b/src/agent/modelHandlers/types/ServerToolTypes.ts
@@ -115,6 +115,18 @@ export type ServerToolCall =
   | GoogleGroundingResult;
 
 /**
+ * Union of all raw content block types that can be returned by server tools.
+ * These blocks need to be preserved in conversation context for follow-up messages.
+ *
+ * - Anthropic: ServerToolUseBlock (the call) and WebSearchToolResultBlock (the result)
+ * - OpenAI: ResponseFunctionWebSearch (combined call/result)
+ */
+export type ServerToolContentBlock =
+  | ServerToolUseBlock
+  | WebSearchToolResultBlock
+  | ResponseFunctionWebSearch;
+
+/**
  * Combined result from server tool extraction.
  * Single source of truth for both display (webSearchResults) and context (contentBlocks).
  */
@@ -122,7 +134,7 @@ export interface ServerToolExtractionResult {
   /** Normalized web search results for display in progress view */
   webSearchResults: WebSearchResult[];
   /** Raw content blocks to preserve in conversation context */
-  contentBlocks: unknown[];
+  contentBlocks: ServerToolContentBlock[];
 }
 
 // ============================================================================

--- a/src/agent/modelHandlers/types/ServerToolTypes.ts
+++ b/src/agent/modelHandlers/types/ServerToolTypes.ts
@@ -8,20 +8,15 @@
  */
 
 // SDK type imports - using native types for better type safety
+// Consumers should import SDK types directly from the respective SDKs:
+// - Anthropic: '@anthropic-ai/sdk/resources/messages'
+// - OpenAI: 'openai/resources/responses/responses'
 import type {
   ServerToolUseBlock,
   WebSearchToolResultBlock,
   WebSearchResultBlock,
 } from '@anthropic-ai/sdk/resources/messages';
 import type { ResponseFunctionWebSearch } from 'openai/resources/responses/responses';
-
-// Re-export SDK types for external use
-export type {
-  ServerToolUseBlock,
-  WebSearchToolResultBlock,
-  WebSearchResultBlock,
-  ResponseFunctionWebSearch,
-};
 
 // ============================================================================
 // Web Search Result Types

--- a/src/agent/modelHandlers/types/ServerToolTypes.ts
+++ b/src/agent/modelHandlers/types/ServerToolTypes.ts
@@ -222,12 +222,26 @@ function isWebSearchResultArray(
 /**
  * Extract web search results from Anthropic response content.
  * Uses SDK's WebSearchToolResultBlock and WebSearchResultBlock types.
+ * Correlates server_tool_use blocks (which contain the query) with
+ * web_search_tool_result blocks (which contain the results).
  */
 export function extractAnthropicWebSearchResults(
   content: unknown[],
 ): WebSearchResult[] {
   const results: WebSearchResult[] = [];
 
+  // First pass: build a map of tool_use_id -> query from server_tool_use blocks
+  const queryMap = new Map<string, string>();
+  for (const block of content) {
+    if (isAnthropicServerToolUse(block) && block.name === 'web_search') {
+      const input = block.input as { query?: string } | undefined;
+      if (input?.query) {
+        queryMap.set(block.id, input.query);
+      }
+    }
+  }
+
+  // Second pass: extract results and match with queries
   for (const block of content) {
     if (!isAnthropicWebSearchResult(block)) {
       continue;
@@ -254,8 +268,10 @@ export function extractAnthropicWebSearchResults(
       }));
 
     if (entries.length > 0) {
+      // Look up the query from the corresponding server_tool_use block
+      const query = queryMap.get(block.tool_use_id) ?? '';
       results.push({
-        query: '', // Anthropic doesn't expose query in result
+        query,
         results: entries,
         provider: 'anthropic',
         callId: block.tool_use_id,

--- a/src/logger/LogTypes.ts
+++ b/src/logger/LogTypes.ts
@@ -42,6 +42,7 @@ export interface LogMessageData {
     | 'statistics'
     | 'modelResponse'
     | 'toolUse'
+    | 'webSearch'
     | 'userMessage'
     | 'progressStatus'
     | 'error'

--- a/src/logger/messageTypes.ts
+++ b/src/logger/messageTypes.ts
@@ -6,6 +6,8 @@ export const MESSAGE_TYPES = {
   LATEXDIFF: 'latexdiff',
   STATISTICS: 'statistics',
   TOOL_USE: 'toolUse',
+  /** Web search results from native provider tools (Anthropic, OpenAI, Google) */
+  WEB_SEARCH: 'webSearch',
   MODEL_RESPONSE: 'modelResponse',
   USER_MESSAGE: 'userMessage',
   PROGRESS_STATUS: 'progressStatus',

--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -876,15 +876,13 @@ export class LogEntryFormatter {
     const { query, results, provider, status } = structured;
     const resultCount = Array.isArray(results) ? results.length : 0;
 
-    // Build title
+    // Build title based on provider (anthropic or openai)
     const providerLabel =
       provider === 'anthropic'
         ? 'Anthropic'
         : provider === 'openai'
           ? 'OpenAI'
-          : provider === 'google'
-            ? 'Google'
-            : 'Web';
+          : 'Web';
     const queryPreview = query
       ? `: "${query.length > QUERY_PREVIEW_MAX_LENGTH ? query.slice(0, QUERY_PREVIEW_MAX_LENGTH) + '...' : query}"`
       : '';

--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -455,6 +455,17 @@ export class LogEntryFormatter {
             ),
           'tool use',
         ),
+      webSearch: (message) =>
+        this._safeFormat(
+          () =>
+            this._formatWebSearch(
+              message.normalizedPayload,
+              message.id,
+              message.groupId,
+              message.timestamp,
+            ),
+          'web search',
+        ),
       modelResponse: (message) =>
         this._safeFormat(
           () =>
@@ -822,6 +833,120 @@ export class LogEntryFormatter {
     contentElem.innerHTML =
       sections.length === 0
         ? wrapInPre(fallbackYaml || '')
+        : sections.join('<hr class="tool-use-separator">');
+
+    return element;
+  }
+
+  /**
+   * Format web search results from native provider tools (Anthropic, OpenAI, Google)
+   * @private
+   * @param {Object} normalizedPayload - Payload containing structured WebSearchResult
+   * @param {string} logId - Log entry ID
+   * @param {string} groupId - Group ID
+   * @param {string} timestamp - Timestamp
+   * @returns {HTMLElement|null} DOM element for web search results
+   */
+  _formatWebSearch(normalizedPayload, logId, groupId, timestamp) {
+    const element = createFromTemplate('toolUseTemplate');
+    if (!element) return null;
+
+    setElementDataset(element, { logId, groupId, timestamp });
+
+    const headerLabel = element.querySelector('.tool-use-title');
+    const iconElem = headerLabel ? headerLabel.previousElementSibling : null;
+    const toggleIcon = element.querySelector('.toggle-icon');
+    if (toggleIcon) toggleIcon.className = `${CHEVRON_RIGHT_CLASS} toggle-icon`;
+    if (iconElem) iconElem.className = 'codicon codicon-globe';
+    element.classList.remove('tool-use-error');
+
+    const contentElem = element.querySelector('.banner-content');
+    if (!contentElem) {
+      return element;
+    }
+
+    const { structured } = normalizedPayload || {};
+    if (!structured || typeof structured !== 'object') {
+      return null;
+    }
+
+    const { query, results, provider, status } = structured;
+    const resultCount = Array.isArray(results) ? results.length : 0;
+
+    // Build title
+    const providerLabel =
+      provider === 'anthropic'
+        ? 'Anthropic'
+        : provider === 'openai'
+          ? 'OpenAI'
+          : provider === 'google'
+            ? 'Google'
+            : 'Web';
+    const queryPreview = query
+      ? `: "${query.length > 40 ? query.slice(0, 40) + '...' : query}"`
+      : '';
+    const statusSuffix =
+      status === 'in_progress'
+        ? ' (searching...)'
+        : status === 'failed'
+          ? ' (failed)'
+          : '';
+    const titleText = `${providerLabel} Search${queryPreview}${statusSuffix}`;
+
+    if (headerLabel) headerLabel.textContent = titleText;
+    if (iconElem) {
+      iconElem.className =
+        status === 'failed'
+          ? 'codicon codicon-error'
+          : status === 'in_progress'
+            ? 'codicon codicon-sync spin'
+            : 'codicon codicon-globe';
+    }
+    element.classList.toggle('tool-use-error', status === 'failed');
+
+    // Build content sections
+    const sections = [];
+
+    if (query) {
+      sections.push(
+        buildToolUseSection('Query:', `<pre>${encodeHtml(query)}</pre>`),
+      );
+    }
+
+    if (resultCount > 0) {
+      const resultItems = results
+        .map((r) => {
+          const url = r.url || '';
+          const title = r.title || r.domain || url;
+          const domain = r.domain || '';
+          const urlEscaped = encodeHtml(url);
+          const titleEscaped = encodeHtml(title);
+          const domainDisplay = domain ? ` <span class="file-source">(${encodeHtml(domain)})</span>` : '';
+
+          return `<li class="detail-item">
+            <i class="codicon codicon-link"></i>
+            <a href="${urlEscaped}" class="web-search-link" target="_blank" rel="noopener noreferrer">${titleEscaped}</a>${domainDisplay}
+          </li>`;
+        })
+        .join('');
+
+      const resultsContent = `
+        <span class="file-list-summary">Results (${resultCount})</span>
+        <ul class="detail-list">${resultItems}</ul>
+      `;
+      sections.push(buildToolUseSection('Sources:', resultsContent));
+    } else if (status === 'completed') {
+      sections.push(
+        buildToolUseSection(
+          'Sources:',
+          '<span class="file-list-summary">No results found</span>',
+        ),
+      );
+    }
+
+    contentElem.innerHTML =
+      sections.length === 0
+        ? '<pre>Web search executed</pre>'
         : sections.join('<hr class="tool-use-separator">');
 
     return element;

--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -921,7 +921,9 @@ export class LogEntryFormatter {
           const domain = r.domain || '';
           const urlEscaped = encodeHtml(url);
           const titleEscaped = encodeHtml(title);
-          const domainDisplay = domain ? ` <span class="file-source">(${encodeHtml(domain)})</span>` : '';
+          const domainDisplay = domain
+            ? ` <span class="file-source">(${encodeHtml(domain)})</span>`
+            : '';
 
           return `<li class="detail-item">
             <i class="codicon codicon-link"></i>

--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -35,6 +35,9 @@ import { encodeHtml } from '@common/htmlEncoding.js';
 export const BULLET_MARKUP =
   '<i class="codicon codicon-circle-small-filled group-bullet"></i>';
 
+/** Maximum length for query preview in web search headers */
+const QUERY_PREVIEW_MAX_LENGTH = 40;
+
 export const EMOJI_BY_LEVEL = {
   error: '🔴',
   warn: '🟡',
@@ -883,7 +886,7 @@ export class LogEntryFormatter {
             ? 'Google'
             : 'Web';
     const queryPreview = query
-      ? `: "${query.length > 40 ? query.slice(0, 40) + '...' : query}"`
+      ? `: "${query.length > QUERY_PREVIEW_MAX_LENGTH ? query.slice(0, QUERY_PREVIEW_MAX_LENGTH) + '...' : query}"`
       : '';
     const statusSuffix =
       status === 'in_progress'

--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -842,9 +842,14 @@ export class LogEntryFormatter {
   }
 
   /**
-   * Format web search results from native provider tools (Anthropic, OpenAI, Google)
+   * Format web search results from native provider tools (Anthropic, OpenAI)
    * @private
    * @param {Object} normalizedPayload - Payload containing structured WebSearchResult
+   * @param {Object} normalizedPayload.structured - Structured web search data
+   * @param {string} [normalizedPayload.structured.query] - Search query
+   * @param {Array<{url?: string, title?: string, domain?: string, snippet?: string, pageAge?: string}>} [normalizedPayload.structured.results] - Search result entries
+   * @param {'anthropic'|'openai'} [normalizedPayload.structured.provider] - Provider that executed the search
+   * @param {'in_progress'|'completed'|'failed'} [normalizedPayload.structured.status] - Search status
    * @param {string} logId - Log entry ID
    * @param {string} groupId - Group ID
    * @param {string} timestamp - Timestamp

--- a/src/test/modelHandlers/ResponseToolConversion.test.ts
+++ b/src/test/modelHandlers/ResponseToolConversion.test.ts
@@ -56,7 +56,9 @@ describe('toOpenAIResponseTools', () => {
       },
     ];
 
-    const tools = toOpenAIResponseTools(defs, { supportsNativeWebSearch: true });
+    const tools = toOpenAIResponseTools(defs, {
+      supportsNativeWebSearch: true,
+    });
     assert.equal(tools.length, 1);
     assert.equal(tools[0].type, 'web_search');
   });
@@ -69,7 +71,9 @@ describe('toOpenAIResponseTools', () => {
       },
     ];
 
-    const tools = toOpenAIResponseTools(defs, { supportsNativeWebSearch: false });
+    const tools = toOpenAIResponseTools(defs, {
+      supportsNativeWebSearch: false,
+    });
     assert.equal(tools.length, 1);
     const tool = tools[0] as FunctionTool;
     assert.equal(tool.type, 'function');


### PR DESCRIPTION
Add support for displaying web search results from native provider tools
(Anthropic, OpenAI, Google) in the progress view:

- Add WEB_SEARCH message type for logging web search results
- Extract web search results in ToolUseProcessNode via extractWebSearchResults()
- Add _formatWebSearch() formatter in frontend for rich display
- Show provider, query, status, and clickable source links

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds unified server-tool web search extraction/logging with streaming support, preserves server tool content for follow-ups, and renders search results (provider/query/status/sources) in the progress view.
> 
> - **Agent/Backend**:
>   - Introduce `ServerToolContentState` and add `workspace.serverToolContent` with reset methods; preserve server tool content blocks and full assistant content between tool calls.
>   - Extend `ModelHandler` API: add `extractServerToolData()` and `extractAssistantContent()`, `emitWebSearchResult()`; remove per-provider `extractWebSearchResults()`; add end-turn cleanup.
>   - Implement server tool extraction and streaming emission:
>     - **Anthropic**: add `AnthropicStreamHandler` for interleaved thinking/text/search; implement `extractServerToolData()` and assistant content extraction; preserve server tool blocks in follow-ups.
>     - **OpenAI Responses**: include `web_search_call.action.sources`; emit web search during streaming; implement `extractServerToolData()`; include preserved `web_search_call` blocks in follow-ups.
>     - **Google**: remove grounding/web search extraction; keep tool handling unchanged.
>   - Update `ToolUseCycleFlow`: extract once, log `WEB_SEARCH`, cache `contentBlocks` and `lastAssistantContent`, clear on end-turn.
> - **UI/Logging**:
>   - Add `MESSAGE_TYPES.WEB_SEARCH` and formatter `_formatWebSearch` to render provider, query, status, and clickable sources.
> - **Config**:
>   - Add `resources/tool_use_agents/search.yaml` defining a research assistant with web tools.
> - **Tests**:
>   - Adjust tool conversion tests for native `web_search` tool support.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b8d6b9dcfe2aa308ca1d906bded521fe8c3bdda3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->