### PR TITLE
feat(context-editing): implement context editing support for Anthropic API

### DIFF
--- a/src/agent/core/AgentDataclass.ts
+++ b/src/agent/core/AgentDataclass.ts
@@ -121,12 +121,37 @@ export const AgentWorkflowSettingSchema = AgentSettingBaseSchema.extend({
   }
 });
 
+/**
+ * Schema for context editing configuration in tool-use agents.
+ * Controls how conversation context is managed as it grows.
+ */
+export const ContextEditingConfigSchema = z
+  .object({
+    /** Input token threshold that triggers context clearing (default: 100000) */
+    triggerThreshold: z.number().positive().optional(),
+    /** Number of recent tool uses to keep after clearing (default: 3) */
+    toolUsesToKeep: z.number().min(1).optional(),
+    /** Minimum tokens to clear each time (helps with cache invalidation cost) */
+    clearAtLeast: z.number().positive().optional(),
+    /** Tool names whose results should never be cleared */
+    excludeTools: z.array(z.string()).optional(),
+    /** Also clear tool input parameters (not just results) */
+    clearToolInputs: z.boolean().optional(),
+    /** Number of thinking turns to keep (default: 2, only when extended thinking enabled) */
+    thinkingTurnsToKeep: z.number().min(1).optional(),
+  })
+  .optional();
+
+export type ContextEditingConfig = z.infer<typeof ContextEditingConfigSchema>;
+
 /** Tool-use agents never expose workflow-specific flags. */
 export const AgentToolUseSettingSchema = AgentSettingBaseSchema.extend({
   agentType: z.literal(AgentType.ToolUse).prefault(AgentType.ToolUse),
   agentCategory: z
     .literal(AgentCategory.ToolUse)
     .prefault(AgentCategory.ToolUse),
+  /** Context editing configuration for managing conversation context size */
+  contextEditing: ContextEditingConfigSchema,
 });
 
 /**

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -12,6 +12,7 @@ import {
 } from '@agent/core/flows/CommonCycleTypes';
 import type { SdkToolCall } from '@agent/modelHandlers/types/IModelHandler';
 import type { ProviderStopReason } from '@agent/modelHandlers/types/StopReasonTypes';
+import type { ContextEditsInfo } from '@agent/types/NormalizedUsage';
 
 // Local imports - utilities
 import { maybeSaveDebugObject } from '@agent/utils/debugMessageSaver';
@@ -325,12 +326,18 @@ class ToolUseCallNode<C> extends Node<
     const start = Date.now();
     try {
       options.modelHandler.setOutputStreaming(true);
+      // Extract context editing config for tool-use agents
+      const contextEditingConfig =
+        'contextEditing' in options.agentSetting
+          ? options.agentSetting.contextEditing
+          : undefined;
       const response = await options.modelHandler.createResponse({
         client: options.client,
         messages: prepRes.messages,
         temperature: options.agentSetting.temperature ?? 0,
         signal: abortController.signal,
         tools: options.agentSetting.tools as ToolDefinition[] | undefined,
+        contextEditingConfig,
       });
 
       const responseTime = (Date.now() - start) / 1000;
@@ -473,6 +480,7 @@ class ToolUseProcessNode<C> extends BaseNode<
       response: text,
       usage,
       stopReason,
+      contextEdits,
     } = options.modelHandler.extractResponse(state.response, '');
 
     if (text) {
@@ -498,6 +506,12 @@ class ToolUseProcessNode<C> extends BaseNode<
         usage,
         state.responseTime ?? 0,
       );
+      // Add context editing information if available
+      if (contextEdits) {
+        normalizedUsage.contextEdits = contextEdits;
+        // Log context editing feedback
+        this.logContextEditingFeedback(options.logger, contextEdits, groupId);
+      }
       store.round.setNormalizedUsage(normalizedUsage);
     } else {
       store.round.clearUsage();
@@ -566,6 +580,45 @@ class ToolUseProcessNode<C> extends BaseNode<
 
     store.resetRound(nextRoundIndex);
     return undefined;
+  }
+
+  /**
+   * Logs context editing feedback when the API clears context.
+   */
+  private logContextEditingFeedback(
+    logger: AgentLogger,
+    contextEdits: ContextEditsInfo,
+    groupId: string | undefined,
+  ): void {
+    const parts: string[] = [];
+
+    for (const edit of contextEdits.appliedEdits) {
+      if (edit.type === 'clear_tool_uses_20250919') {
+        const tokensCleared = edit.clearedInputTokens
+          ? ` (${(edit.clearedInputTokens / 1000).toFixed(1)}k tokens)`
+          : '';
+        parts.push(
+          `Cleared ${edit.clearedToolUses ?? 'some'} tool results${tokensCleared}`,
+        );
+      } else if (edit.type === 'clear_thinking_20251015') {
+        const tokensCleared = edit.clearedInputTokens
+          ? ` (${(edit.clearedInputTokens / 1000).toFixed(1)}k tokens)`
+          : '';
+        parts.push(
+          `Cleared ${edit.clearedThinkingTurns ?? 'some'} thinking turns${tokensCleared}`,
+        );
+      }
+    }
+
+    if (parts.length > 0) {
+      const totalCleared = contextEdits.totalClearedTokens
+        ? ` Total: ${(contextEdits.totalClearedTokens / 1000).toFixed(1)}k tokens cleared`
+        : '';
+      logger.info(`Context edited: ${parts.join(', ')}${totalCleared}`, {
+        groupId,
+        messageType: MESSAGE_TYPES.INTERNAL,
+      });
+    }
   }
 }
 

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -47,7 +47,10 @@ import {
   ThinkingBlock,
 } from '@agent/core/AgentWorkspaceState';
 import { ModelHandler } from '@agent/modelHandlers/ModelHandler';
-import type { NormalizedUsage } from '@agent/types/NormalizedUsage';
+import type {
+  ContextEditsInfo,
+  NormalizedUsage,
+} from '@agent/types/NormalizedUsage';
 import { createContinuationMessage } from '@agent/utils/continuationMessage';
 import { MediaEntry } from '@agent/utils/mediaTypes';
 import { calculateTokenPrice } from '@agent/utils/priceUtils';
@@ -337,6 +340,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
       endTag,
       signal,
       tools,
+      contextEditingConfig,
     } = requestOptions;
     // Get streaming config
     const useStreaming = this.getStreamingConfig();
@@ -541,12 +545,63 @@ export class ModelHandlerAnthropic extends ModelHandler<
         ...(options.context_management?.edits ?? []),
       ];
 
+      // Add thinking block clearing when extended thinking is enabled
+      // Must be listed before tool result clearing per API requirements
+      const hasThinkingEnabled =
+        options.thinking && options.thinking.type === 'enabled';
+      if (
+        hasThinkingEnabled &&
+        !contextManagementEdits.some(
+          (edit) => edit.type === 'clear_thinking_20251015',
+        )
+      ) {
+        // Use configured thinking turns to keep, default to 2
+        const thinkingTurnsToKeep =
+          contextEditingConfig?.thinkingTurnsToKeep ?? 2;
+        contextManagementEdits.unshift({
+          type: 'clear_thinking_20251015',
+          keep: { type: 'thinking_turns', value: thinkingTurnsToKeep },
+        });
+      }
+
+      // Add tool result clearing with configurable options
       if (
         !contextManagementEdits.some(
           (edit) => edit.type === 'clear_tool_uses_20250919',
         )
       ) {
-        contextManagementEdits.push({ type: 'clear_tool_uses_20250919' });
+        // Build the tool clearing config with optional parameters
+        // Using type assertion since SDK types may not include all configurable fields
+        const toolClearingConfig = {
+          type: 'clear_tool_uses_20250919' as const,
+          ...(contextEditingConfig?.triggerThreshold && {
+            trigger: {
+              type: 'input_tokens' as const,
+              value: contextEditingConfig.triggerThreshold,
+            },
+          }),
+          ...(contextEditingConfig?.toolUsesToKeep && {
+            keep: {
+              type: 'tool_uses' as const,
+              value: contextEditingConfig.toolUsesToKeep,
+            },
+          }),
+          ...(contextEditingConfig?.clearAtLeast && {
+            clear_at_least: {
+              type: 'input_tokens' as const,
+              value: contextEditingConfig.clearAtLeast,
+            },
+          }),
+          ...(contextEditingConfig?.excludeTools &&
+            contextEditingConfig.excludeTools.length > 0 && {
+              exclude_tools: contextEditingConfig.excludeTools,
+            }),
+          ...(contextEditingConfig?.clearToolInputs !== undefined && {
+            clear_tool_inputs: contextEditingConfig.clearToolInputs,
+          }),
+        };
+
+        contextManagementEdits.push(toolClearingConfig);
       }
 
       options.context_management = {
@@ -1152,10 +1207,73 @@ export class ModelHandlerAnthropic extends ModelHandler<
 
     newResponse = replacementEngine.applyAll(newResponse);
 
+    // Extract context editing information if available
+    const contextEdits = this.extractContextEdits(responseObject);
+
     return {
       response: newResponse,
       usage: responseObject.usage,
       stopReason: stopReason ?? 'stop',
+      contextEdits,
+    };
+  }
+
+  /**
+   * Extracts context editing information from the API response.
+   * This captures which context management strategies were applied.
+   */
+  private extractContextEdits(
+    responseObject: BetaMessage,
+  ): ContextEditsInfo | undefined {
+    // Access context_management from the response
+    // The SDK types may not include this yet, so we use a type assertion
+    const contextManagement = (
+      responseObject as BetaMessage & {
+        context_management?: {
+          applied_edits?: Array<{
+            type: string;
+            cleared_tool_uses?: number;
+            cleared_thinking_turns?: number;
+            cleared_input_tokens?: number;
+          }>;
+        };
+      }
+    ).context_management;
+
+    if (!contextManagement?.applied_edits?.length) {
+      return undefined;
+    }
+
+    let totalClearedTokens = 0;
+    const appliedEdits: ContextEditsInfo['appliedEdits'] = [];
+
+    for (const edit of contextManagement.applied_edits) {
+      if (edit.cleared_input_tokens) {
+        totalClearedTokens += edit.cleared_input_tokens;
+      }
+
+      if (edit.type === 'clear_tool_uses_20250919') {
+        appliedEdits.push({
+          type: 'clear_tool_uses_20250919',
+          clearedToolUses: edit.cleared_tool_uses,
+          clearedInputTokens: edit.cleared_input_tokens,
+        });
+      } else if (edit.type === 'clear_thinking_20251015') {
+        appliedEdits.push({
+          type: 'clear_thinking_20251015',
+          clearedThinkingTurns: edit.cleared_thinking_turns,
+          clearedInputTokens: edit.cleared_input_tokens,
+        });
+      }
+    }
+
+    if (appliedEdits.length === 0) {
+      return undefined;
+    }
+
+    return {
+      appliedEdits,
+      totalClearedTokens: totalClearedTokens > 0 ? totalClearedTokens : undefined,
     };
   }
 

--- a/src/agent/modelHandlers/types/IModelHandler.ts
+++ b/src/agent/modelHandlers/types/IModelHandler.ts
@@ -1,11 +1,18 @@
 // Local imports - agent components
 import type { AgentConfig } from '@agent/core/AgentConfig';
 // Internal imports
-import { AgentSetting, AgentType } from '@agent/core/AgentDataclass';
+import {
+  AgentSetting,
+  AgentType,
+  type ContextEditingConfig,
+} from '@agent/core/AgentDataclass';
 import { ConversationRoundState, AgentRunState } from '@agent/core/AgentState';
 import { AgentWorkspaceState } from '@agent/core/AgentWorkspaceState';
 import type { ProviderUsage } from '@agent/core/ResponseUsage';
-import type { NormalizedUsage } from '@agent/types/NormalizedUsage';
+import type {
+  ContextEditsInfo,
+  NormalizedUsage,
+} from '@agent/types/NormalizedUsage';
 // Type imports
 import type { MediaEntry } from '@agent/utils/mediaTypes';
 import type { AgentLogger } from '@logger/AgentLogger';
@@ -49,6 +56,8 @@ export interface CreateResponseOptions<
   signal?: AbortSignal;
   /** Optional tool definitions for function calling */
   tools?: ToolDefinition[];
+  /** Optional context editing configuration (Anthropic tool-use only) */
+  contextEditingConfig?: ContextEditingConfig;
 }
 
 /**
@@ -61,6 +70,8 @@ export interface ExtractResponseResult {
   usage: ProviderUsage;
   /** Reason why the model stopped generating */
   stopReason: ProviderStopReason;
+  /** Context editing information (Anthropic only) */
+  contextEdits?: ContextEditsInfo;
 }
 
 /**

--- a/src/agent/types/NormalizedUsage.ts
+++ b/src/agent/types/NormalizedUsage.ts
@@ -25,6 +25,41 @@ export const UsageProviderSchema = z.enum([
 export type UsageProvider = z.infer<typeof UsageProviderSchema>;
 
 /**
+ * Schema for applied context edits from the API response.
+ * Captures details about which context editing strategies were applied.
+ */
+export const AppliedContextEditSchema = z.discriminatedUnion('type', [
+  z.object({
+    type: z.literal('clear_tool_uses_20250919'),
+    /** Number of tool use/result pairs that were cleared */
+    clearedToolUses: z.number().optional(),
+    /** Number of input tokens that were cleared */
+    clearedInputTokens: z.number().optional(),
+  }),
+  z.object({
+    type: z.literal('clear_thinking_20251015'),
+    /** Number of thinking turns that were cleared */
+    clearedThinkingTurns: z.number().optional(),
+    /** Number of input tokens that were cleared */
+    clearedInputTokens: z.number().optional(),
+  }),
+]);
+
+export type AppliedContextEdit = z.infer<typeof AppliedContextEditSchema>;
+
+/**
+ * Schema for context editing information in usage data.
+ */
+export const ContextEditsInfoSchema = z.object({
+  /** List of context edits that were applied */
+  appliedEdits: z.array(AppliedContextEditSchema),
+  /** Total tokens cleared across all strategies */
+  totalClearedTokens: z.number().optional(),
+});
+
+export type ContextEditsInfo = z.infer<typeof ContextEditsInfoSchema>;
+
+/**
  * Normalized usage statistics from any model provider.
  * Cost is computed once during normalization and never recomputed.
  */
@@ -53,6 +88,8 @@ export const NormalizedUsageSchema = z.object({
   toolUsePromptTokens: z.number().optional(),
   /** Number of server-side tool executions (Anthropic web search) */
   serverToolRequests: z.number().optional(),
+  /** Context editing information - edits applied to manage context size */
+  contextEdits: ContextEditsInfoSchema.optional(),
   /** Original API response payload (for debugging) */
   _native: z.unknown().optional(),
 });


### PR DESCRIPTION
Add comprehensive support for Anthropic's context editing beta feature:

- Add context editing types to NormalizedUsage (AppliedContextEdit,
  ContextEditsInfo) for tracking cleared tool uses and thinking blocks
- Extend ExtractResponseResult interface to capture context edits
- Extract context_management.applied_edits from API responses
- Add thinking block clearing (clear_thinking_20251015) when extended
  thinking is enabled, keeping last 2 turns by default
- Add configurable context editing settings via ContextEditingConfigSchema:
  - triggerThreshold: input token threshold for clearing
  - toolUsesToKeep: number of recent tool uses to preserve
  - clearAtLeast: minimum tokens to clear per operation
  - excludeTools: tools whose results should never be cleared
  - clearToolInputs: also clear tool input parameters
  - thinkingTurnsToKeep: thinking turns to preserve
- Display context editing feedback via logger when edits are applied

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 4cd9ec25fda25c194503476382b8883d68d28dc1. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->