### PR TITLE
refactor(agent): use Zod discriminated unions for agent schemas

### DIFF
--- a/src/agent/core/AgentDataclass.ts
+++ b/src/agent/core/AgentDataclass.ts
@@ -58,13 +58,9 @@ export function resolveAgentSessionDescriptor(
   };
 }
 
-/**
- * Base schema shared by workflow and tool-use agent settings. Individual
- * variants extend this schema to add variant-specific constraints.
- */
+/** Shared fields for all agent settings (discriminator added per-variant). */
 export const AgentSettingBaseSchema = z.strictObject({
   agentType: z.enum(AgentType).prefault(AgentType.CoT),
-  agentCategory: z.enum(AgentCategory).prefault(AgentCategory.Workflow),
   documentTag: z
     .string()
     .min(1, 'documentTag cannot be empty')
@@ -92,54 +88,32 @@ export const AgentSettingBaseSchema = z.strictObject({
   tools: z.array(ToolDefinitionSchema).prefault([]),
 });
 
-/**
- * Workflow agent settings support multiple-output workflows and therefore
- * expose the {@code isMultipleOutput} toggle.
- */
+/** Workflow agents: literal discriminator + workflow-specific fields. */
 export const AgentWorkflowSettingSchema = AgentSettingBaseSchema.extend({
+  agentCategory: z.literal(AgentCategory.Workflow).prefault(AgentCategory.Workflow),
   isRewrite: z.boolean().prefault(true),
   rounds: z.number().prefault(2),
   prefills: z.array(z.string()).prefault([]),
   outputExt: z.string().prefault('txt'),
   isMultipleOutput: z.boolean().prefault(false),
-}).superRefine((data, ctx) => {
-  if (data.agentType === AgentType.ToolUse) {
-    ctx.addIssue({
-      code: 'custom',
-      path: ['agentType'],
-      message:
-        'Workflow agent settings cannot use the toolUse agent type. Use the tool-use schema instead.',
-    });
-  }
-  if (data.agentCategory === AgentCategory.ToolUse) {
-    ctx.addIssue({
-      code: 'custom',
-      path: ['agentCategory'],
-      message:
-        'Workflow agent settings must use the workflow category. Use the tool-use schema instead.',
-    });
-  }
 });
 
-/** Tool-use agents never expose workflow-specific flags. */
+/** Tool-use agents: literal discriminator, no workflow fields. */
 export const AgentToolUseSettingSchema = AgentSettingBaseSchema.extend({
+  agentCategory: z.literal(AgentCategory.ToolUse).prefault(AgentCategory.ToolUse),
   agentType: z.literal(AgentType.ToolUse).prefault(AgentType.ToolUse),
-  agentCategory: z
-    .literal(AgentCategory.ToolUse)
-    .prefault(AgentCategory.ToolUse),
 });
 
-/**
- * Canonical agent settings schema combining workflow and tool-use variants.
- */
-export const AgentSettingSchema = z.union([
+/** Discriminated union for O(1) type lookup by agentCategory. */
+export const AgentSettingSchema = z.discriminatedUnion('agentCategory', [
   AgentWorkflowSettingSchema,
   AgentToolUseSettingSchema,
 ]);
 
-export type AgentWorkflowSetting = z.infer<typeof AgentWorkflowSettingSchema>;
-export type AgentToolUseSetting = z.infer<typeof AgentToolUseSettingSchema>;
+/** Canonical union type - derive subtypes from this. */
 export type AgentSetting = z.infer<typeof AgentSettingSchema>;
+export type AgentWorkflowSetting = Extract<AgentSetting, { agentCategory: AgentCategory.Workflow }>;
+export type AgentToolUseSetting = Extract<AgentSetting, { agentCategory: AgentCategory.ToolUse }>;
 
 /**
  * Return the canonical session descriptor for a fully-materialized agent setting.

--- a/src/agent/core/AgentDataclass.ts
+++ b/src/agent/core/AgentDataclass.ts
@@ -88,8 +88,9 @@ export const AgentSettingBaseSchema = z.strictObject({
   tools: z.array(ToolDefinitionSchema).prefault([]),
 });
 
-/** Workflow agents: literal discriminator + workflow-specific fields. */
+/** Workflow agents: only CoT/Direct types, adds workflow-specific fields. */
 export const AgentWorkflowSettingSchema = AgentSettingBaseSchema.extend({
+  agentType: z.enum([AgentType.CoT, AgentType.Direct]).prefault(AgentType.CoT),
   agentCategory: z.literal(AgentCategory.Workflow).prefault(AgentCategory.Workflow),
   isRewrite: z.boolean().prefault(true),
   rounds: z.number().prefault(2),
@@ -98,19 +99,22 @@ export const AgentWorkflowSettingSchema = AgentSettingBaseSchema.extend({
   isMultipleOutput: z.boolean().prefault(false),
 });
 
-/** Tool-use agents: literal discriminator, no workflow fields. */
+/** Tool-use agents: forces ToolUse type, no workflow fields. */
 export const AgentToolUseSettingSchema = AgentSettingBaseSchema.extend({
-  agentCategory: z.literal(AgentCategory.ToolUse).prefault(AgentCategory.ToolUse),
   agentType: z.literal(AgentType.ToolUse).prefault(AgentType.ToolUse),
+  agentCategory: z.literal(AgentCategory.ToolUse).prefault(AgentCategory.ToolUse),
 });
 
-/** Discriminated union for O(1) type lookup by agentCategory. */
-export const AgentSettingSchema = z.discriminatedUnion('agentCategory', [
+/**
+ * Union schema - tries workflow first, then tool-use.
+ * Note: z.union (not discriminatedUnion) because input may lack agentCategory.
+ */
+export const AgentSettingSchema = z.union([
   AgentWorkflowSettingSchema,
   AgentToolUseSettingSchema,
 ]);
 
-/** Canonical union type - derive subtypes from this. */
+/** Canonical union type - derive subtypes via Extract for type safety. */
 export type AgentSetting = z.infer<typeof AgentSettingSchema>;
 export type AgentWorkflowSetting = Extract<AgentSetting, { agentCategory: AgentCategory.Workflow }>;
 export type AgentToolUseSetting = Extract<AgentSetting, { agentCategory: AgentCategory.ToolUse }>;


### PR DESCRIPTION
Implement better separation of concerns between workflow and tool-use
agents using Zod v4 patterns:

- Add AgentSchemas.ts with discriminatedUnion for AgentSettingSchema
- Extract types from union (WorkflowSetting, ToolUseSetting) via Extract<>
- Auto-derive agentCategory from agentType to eliminate redundancy
- Add CycleOptionsSchemas.ts with Zod schemas for cycle options
- Update CycleServices.ts to re-export from new schema modules
- Refactor AgentDataclass.ts to re-export from AgentSchemas.ts

Benefits:
- O(1) discriminator lookup vs O(n) schema attempts
- Better type narrowing with type guards
- Single source of truth for agent type derivation
- Cleaner separation between workflow and tool-use specific fields

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors agent setting schemas to remove base agentCategory, enforce agentType/agentCategory per variant, simplify validation, and derive subtypes via Extract<>.
> 
> - **Agent schemas**:
>   - **Base**: Remove `agentCategory` from `AgentSettingBaseSchema` and clarify shared-field intent.
>   - **Workflow variant**: Restrict `agentType` to `CoT|direct`; set `agentCategory` to `workflow`; keep workflow-only fields; remove custom `superRefine` validations replaced by literal constraints.
>   - **Tool-use variant**: Force `agentType` to `toolUse`; set `agentCategory` to `toolUse`.
>   - **Union**: Keep `AgentSettingSchema` as `z.union([Workflow, ToolUse])` (tries workflow first); comments updated to explain non-discriminated use.
>   - **Types**: Export `AgentSetting` and derive `AgentWorkflowSetting`/`AgentToolUseSetting` via `Extract<>` on `agentCategory`.
> - **Session helpers**: `getAgentSessionDescriptor` returns `agentType` and `agentCategory` from a parsed setting; minor comment/typing cleanups.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b94094d87646a1437edaced1747861a3a6c24f36. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->