### PR TITLE
Prevent retry after user cancellation

### DIFF
--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -334,8 +334,12 @@ class ResponseModelInvocationNode<C> extends Node<
     const formatted = formatProviderHttpError(error);
     // Extract enriched context attached by requestExecutor (operation name, model)
     const context = extractErrorContext(error);
+
+    // If abort signal was triggered, this was user cancellation - never offer retry
+    const retryable = this.signal?.aborted ? false : formatted.retryable;
+
     const fallbackResult = determineFallbackAction(
-      formatted.retryable,
+      retryable,
       formatted.message,
       formatted.statusCode,
       context,

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -360,8 +360,12 @@ class ToolUseCallNode<C> extends Node<
     const formatted = formatProviderHttpError(error);
     // Extract enriched context attached by requestExecutor (operation name, model)
     const context = extractErrorContext(error);
+
+    // If abort signal was triggered, this was user cancellation - never offer retry
+    const retryable = this.signal?.aborted ? false : formatted.retryable;
+
     const fallbackResult = determineFallbackAction(
-      formatted.retryable,
+      retryable,
       formatted.message,
       formatted.statusCode,
       context,

--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -419,13 +419,9 @@ function extractMessage(err: unknown): string | undefined {
 }
 
 /**
- * Detects if an error is an abort/cancellation error.
- * These are NOT retryable since the user intentionally cancelled.
- * Handles:
- * - DOM AbortError (from AbortController)
- * - Errors with 'abort' or 'cancel' in name/message
+ * Checks if an error object itself (not its cause chain) is an abort error.
  */
-function isAbortError(err: unknown): boolean {
+function isAbortErrorDirect(err: unknown): boolean {
   if (!err || typeof err !== 'object') {
     return false;
   }
@@ -437,9 +433,45 @@ function isAbortError(err: unknown): boolean {
     return true;
   }
 
-  // Check for abort-related patterns in error name
+  // Check for abort-related patterns in error name (handles various SDK types)
   const name = errorObj.name?.toLowerCase() ?? '';
   if (name.includes('abort') || name.includes('cancel')) {
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * Detects if an error is an abort/cancellation error.
+ * These are NOT retryable since the user intentionally cancelled.
+ * Handles:
+ * - Native SDK abort errors (OpenAI/Anthropic APIUserAbortError)
+ * - DOM AbortError (from AbortController)
+ * - Errors with 'abort' or 'cancel' in name
+ * - Wrapped errors with AbortError in cause chain (e.g., Google SDK)
+ * - Fallback: abort patterns in message for SDKs without typed abort errors
+ */
+function isAbortError(err: unknown): boolean {
+  // Check the error itself
+  if (isAbortErrorDirect(err)) {
+    return true;
+  }
+
+  // Check the error's cause chain (ES2022) - handles SDK wrappers like Google's
+  // that wrap the original AbortError in a generic ApiError
+  const errorObj = err as { cause?: unknown };
+  if (errorObj.cause && isAbortErrorDirect(errorObj.cause)) {
+    return true;
+  }
+
+  // Fallback: check message for abort patterns (for SDKs that stringify the error)
+  // e.g., Google's "exception AbortError: This operation was aborted sending request"
+  const message =
+    err && typeof err === 'object' && 'message' in err
+      ? String((err as { message: unknown }).message).toLowerCase()
+      : '';
+  if (message.includes('aborterror') || message.includes('aborted')) {
     return true;
   }
 

--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -419,72 +419,16 @@ function extractMessage(err: unknown): string | undefined {
 }
 
 /**
- * Checks if an error object itself (not its cause chain) is an abort error.
- */
-function isAbortErrorDirect(err: unknown): boolean {
-  if (!err || typeof err !== 'object') {
-    return false;
-  }
-
-  const errorObj = err as { name?: string; message?: string };
-
-  // Check for DOM AbortError (DOMException with name 'AbortError')
-  if (errorObj.name === 'AbortError') {
-    return true;
-  }
-
-  // Check for abort-related patterns in error name (handles various SDK types)
-  const name = errorObj.name?.toLowerCase() ?? '';
-  if (name.includes('abort') || name.includes('cancel')) {
-    return true;
-  }
-
-  return false;
-}
-
-/**
- * Detects if an error is an abort/cancellation error.
- * These are NOT retryable since the user intentionally cancelled.
- * Handles:
- * - Native SDK abort errors (OpenAI/Anthropic APIUserAbortError)
- * - DOM AbortError (from AbortController)
- * - Errors with 'abort' or 'cancel' in name
- * - Wrapped errors with AbortError in cause chain (e.g., Google SDK)
- * - Fallback: abort patterns in message for SDKs without typed abort errors
- */
-function isAbortError(err: unknown): boolean {
-  // Check the error itself
-  if (isAbortErrorDirect(err)) {
-    return true;
-  }
-
-  // Check the error's cause chain (ES2022) - handles SDK wrappers like Google's
-  // that wrap the original AbortError in a generic ApiError
-  const errorObj = err as { cause?: unknown };
-  if (errorObj.cause && isAbortErrorDirect(errorObj.cause)) {
-    return true;
-  }
-
-  // Fallback: check message for abort patterns (for SDKs that stringify the error)
-  // e.g., Google's "exception AbortError: This operation was aborted sending request"
-  const message =
-    err && typeof err === 'object' && 'message' in err
-      ? String((err as { message: unknown }).message).toLowerCase()
-      : '';
-  if (message.includes('aborterror') || message.includes('aborted')) {
-    return true;
-  }
-
-  return false;
-}
-
-/**
  * Formats SDK errors from model providers into a consistent message so agent logs
  * can surface status codes alongside concise descriptions.
  *
  * The helper prefers the native SDK error classes for OpenAI, Anthropic, and
  * Google responses. When the error is not a known class, it inspects common
  * HTTP-shaped fields and falls back to a best-effort summary.
+ *
+ * Note: Abort/cancellation detection is handled at the flow level by checking
+ * the AbortController signal directly (this.signal?.aborted). Native SDK abort
+ * errors (OpenAI/Anthropic APIUserAbortError) are detected by matchNativeMessageError().
  */
 export function formatProviderHttpError(
   err: unknown,
@@ -499,16 +443,6 @@ export function formatProviderHttpError(
   const nativeHttp = matchNativeHttpError(err);
   if (nativeHttp) {
     return nativeHttp;
-  }
-
-  // Check for abort/cancellation errors (e.g., DOM AbortError from cancelled fetch)
-  // These are NOT retryable since the user intentionally cancelled.
-  if (isAbortError(err)) {
-    return {
-      message: extractMessage(err) ?? 'Request aborted',
-      provider: detectProvider(err),
-      retryable: false,
-    };
   }
 
   const statusCode = detectStatusCode(err);


### PR DESCRIPTION
Extended isAbortError() to detect abort patterns in error messages, not just error names. This fixes cases where SDK wrappers (like Google's) include "AbortError" in the message but use a different error name.

The fix catches patterns like:
- "exception AbortError: This operation was aborted sending request"
- "operation was aborted"
- "request aborted"
- "user aborted"
- "signal is aborted"

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensure user-initiated aborts never trigger manual retry by checking `AbortController` signal in flows and removing abort heuristics from `sdkErrorUtils`.
> 
> - **Flows**:
>   - `src/agent/core/flows/ResponseCycleFlow.ts` and `src/agent/core/flows/ToolUseCycleFlow.ts`:
>     - In `execFallback`, derive `retryable` from `this.signal?.aborted` (forces non-retry on user cancellation) instead of relying solely on formatted error.
> - **Error handling**:
>   - `src/common/errors/sdkErrorUtils.ts`:
>     - Remove abort/cancellation heuristics and `isAbortError`; rely on flow-level signal checks and native SDK abort classes via `matchNativeMessageError()`.
>     - Keep HTTP error formatting; update comments and fallback behavior accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit da64c761dfc187ae8361e4e2733d8f8c5f7a232d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->