### PR TITLE
Fix agent icon button navigation in webview

### DIFF
--- a/src/utils/settingsQueries.ts
+++ b/src/utils/settingsQueries.ts
@@ -1,6 +1,7 @@
 export const SETTINGS_QUERY = {
   EXTENSION: '@ext:texra-ai.texra',
-  AGENTS: '@ext:texra-ai.texra agents',
+  WORKFLOW_AGENTS: '@ext:texra-ai.texra texra.agents',
+  TOOL_USE_AGENTS: '@ext:texra-ai.texra texra.toolUseAgents',
   MODELS: '@ext:texra-ai.texra models',
   AGENT_DIRECTORY: '@ext:texra-ai.texra explorer.agentsDirectory',
 } as const;

--- a/src/webview/MainViewMessageHandler.ts
+++ b/src/webview/MainViewMessageHandler.ts
@@ -160,8 +160,13 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
       // Settings commands
       [MAIN_VIEW_COMMANDS.SETTINGS_OPEN]: async () =>
         this.settingsManager.openSettings(),
-      [MAIN_VIEW_COMMANDS.OPEN_AGENT_SETTINGS]: async () =>
-        this.settingsManager.openSettings(SETTINGS_QUERY.AGENTS),
+      [MAIN_VIEW_COMMANDS.OPEN_AGENT_SETTINGS]: async (m) => {
+        const query =
+          m?.sessionType === 'toolUse'
+            ? SETTINGS_QUERY.TOOL_USE_AGENTS
+            : SETTINGS_QUERY.WORKFLOW_AGENTS;
+        return this.settingsManager.openSettings(query);
+      },
       [MAIN_VIEW_COMMANDS.OPEN_MODEL_SETTINGS]: async () =>
         this.settingsManager.openSettings(SETTINGS_QUERY.MODELS),
       [MAIN_VIEW_COMMANDS.OPEN_AGENT_DIRECTORY]: async (m) => {

--- a/src/webview/modules/domHandlers.js
+++ b/src/webview/modules/domHandlers.js
@@ -1,5 +1,5 @@
 // Local imports - webview
-import { ELEMENT_IDS } from './constants.js';
+import { ELEMENT_IDS, normalizeSessionType } from './constants.js';
 import { webviewEventBus } from './eventBus.js';
 import { mainViewState } from './mainViewState.js';
 import { ActionButtonManager } from './uiManagers/ActionButtonManager.js';
@@ -115,8 +115,10 @@ class MainViewDomHandler extends BaseDomHandler {
     });
 
     this.addListener(ELEMENT_IDS.AGENT_CONFIG_EDIT_BUTTON, 'click', () => {
+      const sessionType = normalizeSessionType(mainViewState.get()?.sessionType);
       vscode.postMessage({
         command: MAIN_VIEW_COMMANDS.OPEN_AGENT_SETTINGS,
+        sessionType,
       });
     });
 

--- a/src/webview/modules/uiManagers/SettingsButtonManager.js
+++ b/src/webview/modules/uiManagers/SettingsButtonManager.js
@@ -165,8 +165,10 @@ export class SettingsButtonManager extends BaseUIManager {
 
   _setupSettingsButtons() {
     this.addListener(ELEMENT_IDS.AGENT_SETTINGS_BUTTON, 'click', () => {
+      const sessionType = normalizeSessionType(this.state.get()?.sessionType);
       this.vscode.postMessage({
         command: MAIN_VIEW_COMMANDS.OPEN_AGENT_SETTINGS,
+        sessionType,
       });
     });
 


### PR DESCRIPTION
…utton

When clicking the agent icon button in the webview, the settings page now opens filtered to the correct agent list based on the current session type:
- Workflow mode opens workflow agents settings (texra.agents)
- Tool use mode opens tool use agents settings (texra.toolUseAgents)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Agent settings buttons now open the correct filtered settings view (`texra.agents` or `texra.toolUseAgents`) based on the current session type.
> 
> - **Webview**:
>   - Pass normalized `sessionType` when opening agent settings from `domHandlers` and `SettingsButtonManager`.
>   - `MainViewMessageHandler` routes `OPEN_AGENT_SETTINGS` to `SETTINGS_QUERY.WORKFLOW_AGENTS` or `SETTINGS_QUERY.TOOL_USE_AGENTS` accordingly.
> - **Utils**:
>   - Replace `SETTINGS_QUERY.AGENTS` with `SETTINGS_QUERY.WORKFLOW_AGENTS` and `SETTINGS_QUERY.TOOL_USE_AGENTS`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3a0b9927d63dc24ab59bbe692ffae74440a31b10. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->