### PR TITLE
Fix agent recovery from history streams

### DIFF
--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -785,105 +785,143 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
     }
   }
 
+  /**
+   * Restore the main view state from a TaskState object.
+   *
+   * Flow:
+   * 1. Extract session type from canonical session descriptor
+   * 2. Set all form field values directly in DOM
+   * 3. Set file arrays in DOM
+   * 4. Store state for persistence
+   * 5. Apply session type UI changes (visibility, disabled states)
+   *
+   * Note: We intentionally do NOT call mainViewState.restore() here because
+   * we already set all DOM values directly. Calling restore() would redundantly
+   * re-read state and re-apply to DOM, plus clear and rebuild file lists twice.
+   */
   _handleStateRestoration(state) {
     const config = state.agentConfig || state;
     const activeFiles = state.activeFiles || {};
-    // TaskState has session at top level - this is the canonical source of truth
-    // agentConfig.session should match, but may be missing in legacy data
+    // TaskState.session is the canonical source of truth for session metadata
     const canonicalSession = state.session || config.session;
 
     const savedState = {};
-    this._restoreFormFields(config, savedState, canonicalSession);
+    const sessionType = this._restoreFormFields(config, savedState, canonicalSession);
     this._restoreFileArrays(config, savedState, activeFiles);
+
+    // Store state for persistence and future restoration
     mainViewState.set(savedState);
-    mainViewState.restore();
+
+    // Apply session type UI changes (visibility, disabled states) without re-setting values.
+    // skipSave: true because we already have the correct state stored above.
+    mainViewState.applySessionType(sessionType, { skipSave: true });
+
+    // Prevent _postHandle from calling mainViewState.restore()
     this._skipNextRestoreState = true;
   }
 
+  /**
+   * Determine session type from state, with clear priority order.
+   * @returns {'workflow' | 'toolUse'} The normalized session type
+   */
+  _determineSessionType(canonicalSession, state) {
+    // Priority 1: Canonical session descriptor (single source of truth)
+    const category = canonicalSession?.agentCategory;
+    if (category === SESSION_TYPES.TOOL_USE || category === SESSION_TYPES.WORKFLOW) {
+      return category;
+    }
+
+    // Priority 2: Explicit sessionType property (for legacy/webview state)
+    if (state.sessionType === SESSION_TYPES.TOOL_USE || state.sessionType === SESSION_TYPES.WORKFLOW) {
+      return state.sessionType;
+    }
+
+    // Priority 3: Infer from agentType or isToolUseAgent flag (legacy support)
+    const agentType = canonicalSession?.agentType ?? state.agentType;
+    if (agentType === SESSION_TYPES.TOOL_USE || state.isToolUseAgent) {
+      return SESSION_TYPES.TOOL_USE;
+    }
+
+    // Default to workflow
+    return SESSION_TYPES.WORKFLOW;
+  }
+
+  /**
+   * Extract agent value for a session type from state.
+   * AgentConfig stores a single 'agent' field, but webview state may have
+   * separate workflowAgent/toolUseAgent fields for UI persistence.
+   */
+  _extractAgentValue(state, forToolUse, isCurrentlyToolUse) {
+    // Check for explicit session-specific agent value first (webview state format)
+    const explicitValue = forToolUse ? state.toolUseAgent : state.workflowAgent;
+    if (explicitValue) {
+      return explicitValue;
+    }
+
+    // Fall back to generic 'agent' field only if it matches the session type
+    // This prevents workflow agent from being assigned to tool-use dropdown and vice versa
+    if (state.agent && forToolUse === isCurrentlyToolUse) {
+      return state.agent;
+    }
+
+    return '';
+  }
+
+  /**
+   * Restore form field values from state to DOM.
+   * @returns {string} The normalized session type
+   */
   _restoreFormFields(state, savedState, canonicalSession) {
-    // Use the canonical session from TaskState (passed in), fallback to agentConfig.session
-    const sessionCategory =
-      canonicalSession?.agentCategory ?? state.session?.agentCategory;
+    const sessionType = this._determineSessionType(canonicalSession, state);
+    const isToolUseSession = sessionType === SESSION_TYPES.TOOL_USE;
 
-    let sessionType = state.sessionType;
-    if (sessionCategory === SESSION_TYPES.TOOL_USE) {
-      sessionType = SESSION_TYPES.TOOL_USE;
-    } else if (sessionCategory === SESSION_TYPES.WORKFLOW) {
-      sessionType = SESSION_TYPES.WORKFLOW;
+    // Extract agent values with clear logic
+    const workflowAgentValue = this._extractAgentValue(state, false, isToolUseSession);
+    const toolUseAgentValue = this._extractAgentValue(state, true, isToolUseSession);
+
+    // Set DOM values
+    safeSetElementValue(SESSION_TYPE_INPUT, sessionType);
+    this._setAgentValue(AGENT_SELECT_IDS[SESSION_TYPES.WORKFLOW], workflowAgentValue);
+    this._setAgentValue(AGENT_SELECT_IDS[SESSION_TYPES.TOOL_USE], toolUseAgentValue);
+
+    if (state.model) {
+      safeSetElementValue('model', state.model);
     }
-
-    if (!sessionType) {
-      // Final fallback: check agentType from canonical session, then isToolUseAgent flag
-      const agentType = canonicalSession?.agentType ?? state.agentType;
-      const isToolUse =
-        agentType === SESSION_TYPES.TOOL_USE || state.isToolUseAgent;
-      sessionType = isToolUse ? SESSION_TYPES.TOOL_USE : SESSION_TYPES.WORKFLOW;
-    }
-
-    const normalizedSessionType = normalizeSessionType(sessionType);
-    const isToolUseSession = normalizedSessionType === SESSION_TYPES.TOOL_USE;
-
-    const workflowAgentValue =
-      state.workflowAgent ??
-      (!isToolUseSession ? state.agent : undefined) ??
-      '';
-    const toolUseAgentValue =
-      state.toolUseAgent ?? (isToolUseSession ? state.agent : undefined) ?? '';
-
-    safeSetElementValue(SESSION_TYPE_INPUT, normalizedSessionType);
-    this._setAgentValue(
-      AGENT_SELECT_IDS[SESSION_TYPES.WORKFLOW],
-      workflowAgentValue,
-    );
-    this._setAgentValue(
-      AGENT_SELECT_IDS[SESSION_TYPES.TOOL_USE],
-      toolUseAgentValue,
-    );
-    if (state.model) safeSetElementValue('model', state.model);
 
     const instructionContent = state.instruction || '';
-    const instruction =
-      this._instructionEl ||
-      (this._instructionEl = this._getElement('instruction'));
+    const instruction = this._instructionEl || (this._instructionEl = this._getElement('instruction'));
     if (instruction) {
       instruction.value = instructionContent;
       instruction.dispatchEvent(new Event('input'));
     }
 
+    // Set single file selections
     if (state.inputFile) safeSetElementValue(INPUT_FILE, state.inputFile);
-    if (state.referenceFile)
-      safeSetElementValue(REFERENCE_FILE, state.referenceFile);
-    if (state.auxiliaryFile)
-      safeSetElementValue(AUXILIARY_FILE, state.auxiliaryFile);
+    if (state.referenceFile) safeSetElementValue(REFERENCE_FILE, state.referenceFile);
+    if (state.auxiliaryFile) safeSetElementValue(AUXILIARY_FILE, state.auxiliaryFile);
     if (state.mediaFile) safeSetElementValue(MEDIA_FILE, state.mediaFile);
 
+    // Build savedState object for persistence
     const toolConfig = state.toolConfig || {};
     Object.assign(savedState, {
-      sessionType: normalizedSessionType,
+      sessionType,
       workflowAgent: workflowAgentValue,
       toolUseAgent: toolUseAgentValue,
-      agent:
-        state.agent ??
-        (isToolUseSession ? toolUseAgentValue : workflowAgentValue),
+      agent: state.agent || (isToolUseSession ? toolUseAgentValue : workflowAgentValue),
       model: state.model,
       instruction: instructionContent,
       inputFile: state.inputFile,
       referenceFile: state.referenceFile,
       auxiliaryFile: state.auxiliaryFile,
       mediaFile: state.mediaFile,
-      autoExtractFigure:
-        state.autoExtractFigure ?? toolConfig.autoExtractFigure ?? false,
-      autoExtractTikzFigure:
-        state.autoExtractTikzFigure ??
-        toolConfig.autoExtractTikzFigure ??
-        false,
-      attachTeXCount:
-        state.attachTeXCount ?? toolConfig.attachTeXCount ?? false,
-      attachDiagnostics:
-        state.attachDiagnostics ?? toolConfig.attachDiagnostics ?? false,
-      autoCompileInputPdf:
-        state.autoCompileInputPdf ?? toolConfig.autoCompileInputPdf ?? false,
+      autoExtractFigure: state.autoExtractFigure ?? toolConfig.autoExtractFigure ?? false,
+      autoExtractTikzFigure: state.autoExtractTikzFigure ?? toolConfig.autoExtractTikzFigure ?? false,
+      attachTeXCount: state.attachTeXCount ?? toolConfig.attachTeXCount ?? false,
+      attachDiagnostics: state.attachDiagnostics ?? toolConfig.attachDiagnostics ?? false,
+      autoCompileInputPdf: state.autoCompileInputPdf ?? toolConfig.autoCompileInputPdf ?? false,
     });
+
+    return sessionType;
   }
 
   _restoreFileArrays(state, savedState, activeFiles = {}) {

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -12,6 +12,7 @@ import {
   SESSION_TYPE_INPUT,
   AGENT_SELECT_IDS,
   AGENT_SELECT_LIST,
+  CHECK_BOXES,
   normalizeSessionType,
 } from './constants.js';
 import { webviewEventBus } from './eventBus.js';
@@ -33,6 +34,7 @@ import {
 import { fileList } from './uiManagers/FileList.js';
 import {
   safeSetElementValue,
+  safeSetElementChecked,
   safeGetElementById,
   setChevronIcon,
   waitForElement,
@@ -901,8 +903,14 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
     if (state.auxiliaryFile) safeSetElementValue(AUXILIARY_FILE, state.auxiliaryFile);
     if (state.mediaFile) safeSetElementValue(MEDIA_FILE, state.mediaFile);
 
-    // Build savedState object for persistence
+    // Restore checkbox values
     const toolConfig = state.toolConfig || {};
+    CHECK_BOXES.forEach((id) => {
+      const value = state[id] ?? toolConfig[id] ?? false;
+      safeSetElementChecked(id, value);
+    });
+
+    // Build savedState object for persistence
     Object.assign(savedState, {
       sessionType,
       workflowAgent: workflowAgentValue,
@@ -942,30 +950,31 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
       savedState[visibilityName] = isVisible;
 
       const multipleFilesId = `${fileType}Files`;
+      const containerId = `${fileType}FilesContainer`;
+      const toggleId = `toggle${capitalize(fileType)}Files`;
+
       const multipleFiles = this._getElement(multipleFilesId);
-      if (filesArray.length > 0 || isVisible) {
-        const containerId = `${fileType}FilesContainer`;
-        const toggleId = `toggle${capitalize(fileType)}Files`;
+      const container = this._getElement(containerId);
+      const toggleElement = this._getElement(toggleId);
 
-        const container = this._getElement(containerId);
-        if (container) {
-          container.style.display = isVisible ? 'block' : 'none';
-        }
+      // Always clear existing files first to handle restoration to empty state
+      if (multipleFiles) {
+        multipleFiles.innerHTML = '';
+      }
 
-        const toggleElement = this._getElement(toggleId);
-        this._setToggleIcon(toggleElement, isVisible);
+      // Set container visibility and toggle icon
+      if (container) {
+        container.style.display = isVisible ? 'block' : 'none';
+      }
+      this._setToggleIcon(toggleElement, isVisible);
 
-        if (multipleFiles) {
-          multipleFiles.innerHTML = '';
-        }
-
-        if (filesArray.length > 0 && multipleFiles) {
-          fileList._batchMode = true;
-          filesArray.forEach((file) => {
-            fileList.add(multipleFilesId, file);
-          });
-          fileList._batchMode = false;
-        }
+      // Add files if any
+      if (filesArray.length > 0 && multipleFiles) {
+        fileList._batchMode = true;
+        filesArray.forEach((file) => {
+          fileList.add(multipleFilesId, file);
+        });
+        fileList._batchMode = false;
       }
     }
   }

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -601,6 +601,7 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
    *
    * @param {HTMLElement} selectElement - The select element to restore
    * @param {string[]} candidates - Array of candidate values to try, in priority order
+   * @returns {boolean} True if a candidate was matched, false if fell back to default
    */
   _restoreSelectValue(selectElement, candidates) {
     const filteredCandidates = candidates.filter(Boolean);
@@ -613,7 +614,7 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
 
     if (exactMatch) {
       selectElement.value = exactMatch;
-      return;
+      return true;
     }
 
     // Migration: try matching by name suffix for old format values
@@ -627,7 +628,7 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
       );
       if (suffixMatch) {
         selectElement.value = suffixMatch.value;
-        return;
+        return true;
       }
     }
 
@@ -636,13 +637,24 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
     if (fallbackOption) {
       selectElement.value = fallbackOption.value;
     }
+    return false;
   }
 
   _restoreAgentSelection(selectElement, previousValue) {
     const sessionType = this._getSessionTypeForSelect(selectElement);
     const savedValue = sessionType ? this._getSavedAgentValue(sessionType) : '';
     // Prioritize saved state over previous UI value for agents
-    this._restoreSelectValue(selectElement, [savedValue, previousValue]);
+    const restored = this._restoreSelectValue(selectElement, [
+      savedValue,
+      previousValue,
+    ]);
+
+    // If restoration failed and we have a saved value, recreate the placeholder
+    // This preserves the agent selection even when the agent isn't in the options
+    // (e.g., remote agent from another session, custom agent that was deleted)
+    if (!restored && savedValue) {
+      this._setAgentValue(selectElement.id, savedValue);
+    }
   }
 
   _restoreModelSelection(selectElement, previousValue) {

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -651,11 +651,14 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
       previousValue,
     ]);
 
-    // If restoration failed and we have a saved value, recreate the placeholder
-    // This preserves the agent selection even when the agent isn't in the options
-    // (e.g., remote agent from another session, custom agent that was deleted)
-    if (!restored && savedValue) {
-      this._setAgentValue(selectElement.id, savedValue);
+    // If restoration failed, recreate placeholder to preserve the agent selection
+    // even when the agent isn't in the options (e.g., remote agent from another
+    // session, custom agent that was deleted). Check savedValue first, then previousValue.
+    if (!restored) {
+      const valueToRestore = savedValue || previousValue;
+      if (valueToRestore) {
+        this._setAgentValue(selectElement.id, valueToRestore);
+      }
     }
   }
 
@@ -855,14 +858,15 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
    */
   _extractAgentValue(state, forToolUse, isCurrentlyToolUse) {
     // Check for explicit session-specific agent value first (webview state format)
+    // Use nullish check (!= null) to preserve empty string as an explicit value
     const explicitValue = forToolUse ? state.toolUseAgent : state.workflowAgent;
-    if (explicitValue) {
+    if (explicitValue != null) {
       return explicitValue;
     }
 
     // Fall back to generic 'agent' field only if it matches the session type
     // This prevents workflow agent from being assigned to tool-use dropdown and vice versa
-    if (state.agent && forToolUse === isCurrentlyToolUse) {
+    if (state.agent != null && forToolUse === isCurrentlyToolUse) {
       return state.agent;
     }
 


### PR DESCRIPTION
When SET_AGENT_OPTIONS arrives after STATE_RESTORE, if the saved agent value doesn't match any option in the dropdown (e.g., remote agent from another session, deleted custom agent), _restoreSelectValue would fall back to the first enabled option (default agent).

This fix:
- Makes _restoreSelectValue return boolean indicating if a match was found
- In _restoreAgentSelection, if no match was found but we have a saved value, recreate the placeholder option to preserve the selection

This ensures agent selection is properly preserved when restoring from history or streams, even when the agent isn't currently in the options.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Preserves agent selection when options are missing and refactors state restoration to set DOM directly, infer session type, restore checkboxes, and properly rebuild file lists.
> 
> - **State restoration**:
>   - New `_determineSessionType` and `_extractAgentValue` to reliably infer session type and agent values.
>   - `_handleStateRestoration` now sets DOM fields directly, saves state, and calls `applySessionType({... skipSave: true })` instead of `restore()`.
>   - `_restoreFormFields` returns `sessionType`, sets agents via `_setAgentValue`, restores `model`, instruction, single-file inputs, and checkbox values using `CHECK_BOXES` and `safeSetElementChecked`.
>   - `_restoreFileArrays` always clears lists, updates container visibility and toggle icon, then repopulates files.
> - **Agent selection recovery**:
>   - `_restoreSelectValue` now returns boolean; `_restoreAgentSelection` creates a placeholder option via `_setAgentValue` when no option matches saved/previous value.
> - **Imports**:
>   - Add `CHECK_BOXES` and `safeSetElementChecked`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1994630b6c6790c0c368e72f66d9869caf64b10f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->