### PR TITLE
fix(streamtabs): use full file path for stream tab deduplication

### DIFF
--- a/src/logger/streamUtils.ts
+++ b/src/logger/streamUtils.ts
@@ -44,6 +44,7 @@ export function getStreamTabId(
   const agentName = options.useMultipleOutputs
     ? getMultipleName(cleanAgent)
     : cleanAgent;
-  const baseName = inputFile ? path.basename(inputFile) : '';
-  return `${agentName}@${model}: ${baseName}`;
+  // Use full path for deduplication to distinguish files with same name in different directories
+  const filePath = inputFile ?? '';
+  return `${agentName}@${model}: ${filePath}`;
 }

--- a/src/logger/streamUtils.ts
+++ b/src/logger/streamUtils.ts
@@ -1,6 +1,5 @@
 // Standard library imports
 import { randomUUID } from 'crypto';
-import * as path from 'path';
 
 // Local imports
 import { getCleanAgentName, getMultipleName } from '@agent/index';
@@ -44,7 +43,9 @@ export function getStreamTabId(
   const agentName = options.useMultipleOutputs
     ? getMultipleName(cleanAgent)
     : cleanAgent;
-  // Use full path for deduplication to distinguish files with same name in different directories
-  const filePath = inputFile ?? '';
+  // Use full path for deduplication to distinguish files with same name in different directories.
+  // Normalize backslashes to forward slashes for consistent IDs across platforms and to avoid
+  // issues with CSS attribute selectors where backslashes are treated as escape characters.
+  const filePath = (inputFile ?? '').replace(/\\/g, '/');
   return `${agentName}@${model}: ${filePath}`;
 }

--- a/src/logger/streamUtils.ts
+++ b/src/logger/streamUtils.ts
@@ -43,9 +43,10 @@ export function getStreamTabId(
   const agentName = options.useMultipleOutputs
     ? getMultipleName(cleanAgent)
     : cleanAgent;
-  // Use full path for deduplication to distinguish files with same name in different directories.
-  // Normalize backslashes to forward slashes for consistent IDs across platforms and to avoid
-  // issues with CSS attribute selectors where backslashes are treated as escape characters.
+  // Use full workspace-relative path for deduplication to distinguish files with same name
+  // in different directories. Normalize backslashes to forward slashes for consistent IDs
+  // across platforms and to avoid issues with CSS attribute selectors where backslashes
+  // are treated as escape characters.
   const filePath = (inputFile ?? '').replace(/\\/g, '/');
   return `${agentName}@${model}: ${filePath}`;
 }

--- a/src/test/logger/streamUtils.test.ts
+++ b/src/test/logger/streamUtils.test.ts
@@ -6,23 +6,31 @@ import { AgentType } from '@agent/core/AgentDataclass';
 import { getStreamTabId } from '@/logger/streamUtils';
 
 describe('getStreamTabId', () => {
-  it('builds workflow identifiers using input file name', () => {
+  it('builds workflow identifiers using full input file path', () => {
     const id = getStreamTabId('polish', 'sonnet', '/tmp/paper.tex');
-    assert.equal(id, 'polish@sonnet: paper.tex');
+    assert.equal(id, 'polish@sonnet: /tmp/paper.tex');
   });
 
   it('appends multiple suffix for workflow streams with many outputs', () => {
     const id = getStreamTabId('polish', 'sonnet', '/tmp/paper.tex', {
       useMultipleOutputs: true,
     });
-    assert.equal(id, 'polish_multiple@sonnet: paper.tex');
+    assert.equal(id, 'polish_multiple@sonnet: /tmp/paper.tex');
   });
 
   it('avoids duplicating the multiple suffix when already present', () => {
     const id = getStreamTabId('polish_multiple', 'sonnet', '/tmp/paper.tex', {
       useMultipleOutputs: true,
     });
-    assert.equal(id, 'polish_multiple@sonnet: paper.tex');
+    assert.equal(id, 'polish_multiple@sonnet: /tmp/paper.tex');
+  });
+
+  it('distinguishes files with same name in different directories', () => {
+    const id1 = getStreamTabId('polish', 'sonnet', '/project1/paper.tex');
+    const id2 = getStreamTabId('polish', 'sonnet', '/project2/paper.tex');
+    assert.notEqual(id1, id2);
+    assert.equal(id1, 'polish@sonnet: /project1/paper.tex');
+    assert.equal(id2, 'polish@sonnet: /project2/paper.tex');
   });
 
   it('uses execution id prefix for tool use streams', () => {

--- a/src/test/logger/streamUtils.test.ts
+++ b/src/test/logger/streamUtils.test.ts
@@ -6,31 +6,31 @@ import { AgentType } from '@agent/core/AgentDataclass';
 import { getStreamTabId } from '@/logger/streamUtils';
 
 describe('getStreamTabId', () => {
-  it('builds workflow identifiers using full input file path', () => {
-    const id = getStreamTabId('polish', 'sonnet', '/tmp/paper.tex');
-    assert.equal(id, 'polish@sonnet: /tmp/paper.tex');
+  it('builds workflow identifiers using workspace-relative file path', () => {
+    const id = getStreamTabId('polish', 'sonnet', 'chapters/paper.tex');
+    assert.equal(id, 'polish@sonnet: chapters/paper.tex');
   });
 
   it('appends multiple suffix for workflow streams with many outputs', () => {
-    const id = getStreamTabId('polish', 'sonnet', '/tmp/paper.tex', {
+    const id = getStreamTabId('polish', 'sonnet', 'chapters/paper.tex', {
       useMultipleOutputs: true,
     });
-    assert.equal(id, 'polish_multiple@sonnet: /tmp/paper.tex');
+    assert.equal(id, 'polish_multiple@sonnet: chapters/paper.tex');
   });
 
   it('avoids duplicating the multiple suffix when already present', () => {
-    const id = getStreamTabId('polish_multiple', 'sonnet', '/tmp/paper.tex', {
+    const id = getStreamTabId('polish_multiple', 'sonnet', 'chapters/paper.tex', {
       useMultipleOutputs: true,
     });
-    assert.equal(id, 'polish_multiple@sonnet: /tmp/paper.tex');
+    assert.equal(id, 'polish_multiple@sonnet: chapters/paper.tex');
   });
 
   it('distinguishes files with same name in different directories', () => {
-    const id1 = getStreamTabId('polish', 'sonnet', '/project1/paper.tex');
-    const id2 = getStreamTabId('polish', 'sonnet', '/project2/paper.tex');
+    const id1 = getStreamTabId('polish', 'sonnet', 'project1/paper.tex');
+    const id2 = getStreamTabId('polish', 'sonnet', 'project2/paper.tex');
     assert.notEqual(id1, id2);
-    assert.equal(id1, 'polish@sonnet: /project1/paper.tex');
-    assert.equal(id2, 'polish@sonnet: /project2/paper.tex');
+    assert.equal(id1, 'polish@sonnet: project1/paper.tex');
+    assert.equal(id2, 'polish@sonnet: project2/paper.tex');
   });
 
   it('normalizes Windows backslashes to forward slashes', () => {

--- a/src/test/logger/streamUtils.test.ts
+++ b/src/test/logger/streamUtils.test.ts
@@ -33,6 +33,11 @@ describe('getStreamTabId', () => {
     assert.equal(id2, 'polish@sonnet: /project2/paper.tex');
   });
 
+  it('normalizes Windows backslashes to forward slashes', () => {
+    const id = getStreamTabId('polish', 'sonnet', 'C:\\Users\\test\\paper.tex');
+    assert.equal(id, 'polish@sonnet: C:/Users/test/paper.tex');
+  });
+
   it('uses execution id prefix for tool use streams', () => {
     const executionId = '12345678-9abc-def0-1234-56789abcdef0';
     const id = getStreamTabId('diagnostics', 'gpt4', '', {


### PR DESCRIPTION
Previously, stream tab IDs used only the file basename for identification,
causing collisions when files with the same name existed in different
directories (e.g., project1/paper.tex and project2/paper.tex). Now the
full file path is used, ensuring each file gets its own unique stream tab.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches stream tab IDs to use workspace-relative file paths (normalized to forward slashes) to avoid basename collisions, with updated tests.
> 
> - **Logger**:
>   - **`getStreamTabId`**: Use full workspace-relative `inputFile` path instead of basename for IDs to avoid collisions.
>     - Normalize Windows backslashes to forward slashes in returned IDs.
>     - Preserve multiple-output suffix handling via `getMultipleName`.
>     - Tool-use stream IDs unchanged (`agent@model#shortId`).
> - **Tests**:
>   - Update expectations to use full paths and verify multiple-output suffix behavior.
>   - Add cases to distinguish same filenames in different directories.
>   - Add case to verify Windows path normalization.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 08df8b713a49803d4d58b4f7f75e1c0f4b10a5cd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->