### PR TITLE
refactor: apply DRY principles across model handlers and view providers

### DIFF
--- a/src/agent/modelHandlers/modelHandlerDashScope.ts
+++ b/src/agent/modelHandlers/modelHandlerDashScope.ts
@@ -1,62 +1,21 @@
 // (none needed)
 
-// Third-party imports
-import OpenAI from 'openai';
-
-// Local imports - agent components
-import { MediaEntry } from '@agent/utils/mediaTypes';
-
 // Local file imports
 import { ModelHandlerOpenAI } from './modelHandlerOpenAI';
-import type { CreateResponseOptions } from './types/IModelHandler';
-import type {
-  ChatCompletion,
-  ChatCompletionMessageParam,
-} from 'openai/resources/chat/completions';
+import type { NormalizeOpenAIMessageContentOptions } from './openAIMessageUtils';
 
 /**
  * Handler for DashScope Qwen models using OpenAI-compatible API.
  * usageProvider and toolCallProvider inherit from base class via config.provider.
+ *
+ * Note: Thinking blocks are handled by the base OpenAI handler.
+ * createMediaContent is inherited from ModelHandlerOpenAI.
  */
 export class ModelHandlerDashScope extends ModelHandlerOpenAI {
-  /** Thinking blocks are handled by the base OpenAI handler. */
   /**
-   * Override createResponse to preprocess messages for DashScope models
+   * DashScope requires content to be converted to strings.
    */
-  async createResponse(
-    options: CreateResponseOptions<ChatCompletionMessageParam, OpenAI>,
-  ): Promise<ChatCompletion> {
-    const { messages } = options;
-    // Preprocess messages for DashScope compatibility
-    const processedMessages = this.prepareNormalizedMessages(
-      messages,
-      {
-        convertContentToString: true,
-      },
-      'DashScope',
-    );
-
-    // Call the parent implementation with the processed messages
-    return super.createResponse({
-      ...options,
-      messages: processedMessages,
-    });
-  }
-
-  /**
-   * Creates media content formatted for DashScope Qwen-VL models
-   * Overrides the parent method to handle DashScope-specific formatting
-   */
-  createMediaContent(mediaMessage: MediaEntry[]): any[] {
-    return mediaMessage.flatMap((media): any[] => {
-      if (media.media_category === 'image') {
-        return this.buildStandardVisionParts(media);
-      } else {
-        this.logger.warn(
-          `Unsupported media category for DashScope: ${media.media_category}`,
-        );
-        return [];
-      }
-    });
+  protected override getMessageNormalizationOptions(): NormalizeOpenAIMessageContentOptions {
+    return { convertContentToString: true };
   }
 }

--- a/src/agent/modelHandlers/modelHandlerDeepSeek.ts
+++ b/src/agent/modelHandlers/modelHandlerDeepSeek.ts
@@ -6,15 +6,12 @@ import type { AgentWorkspaceState } from '@agent/core/AgentWorkspaceState';
 import type { ToolFileAttachment } from '@tools/result';
 import { ModelHandlerOpenAI } from './modelHandlerOpenAI';
 import { BaseReasoningStreamAggregator } from './BaseReasoningStreamAggregator';
+import type { NormalizeOpenAIMessageContentOptions } from './openAIMessageUtils';
 import type { ToolResultPayload } from './utils/toolAttachmentUtils';
 
 // Type imports
+import type { DeepSeekToolCall } from './types/IModelHandler';
 import type {
-  CreateResponseOptions,
-  DeepSeekToolCall,
-} from './types/IModelHandler';
-import type {
-  ChatCompletion,
   ChatCompletionMessageParam,
   ChatCompletionAssistantMessageParam,
 } from 'openai/resources/chat/completions';
@@ -240,26 +237,12 @@ export class ModelHandlerDeepSeek extends ModelHandlerOpenAI<DeepSeekToolCall> {
   }
 
   /**
-   * Override createResponse to preprocess messages for Deepseek models
+   * DeepSeek requires merging consecutive roles and converting content to strings.
    */
-  async createResponse(
-    options: CreateResponseOptions<ChatCompletionMessageParam, OpenAI>,
-  ): Promise<ChatCompletion> {
-    const { messages } = options;
-    // Preprocess messages to merge consecutive messages and convert content to strings
-    const processedMessages = this.prepareNormalizedMessages(
-      messages,
-      {
-        mergeConsecutiveRoles: true,
-        convertContentToString: true,
-      },
-      'Deepseek',
-    );
-
-    // Call the parent implementation with the processed messages
-    return super.createResponse({
-      ...options,
-      messages: processedMessages,
-    });
+  protected override getMessageNormalizationOptions(): NormalizeOpenAIMessageContentOptions {
+    return {
+      mergeConsecutiveRoles: true,
+      convertContentToString: true,
+    };
   }
 }

--- a/src/agent/modelHandlers/modelHandlerKimi.ts
+++ b/src/agent/modelHandlers/modelHandlerKimi.ts
@@ -46,7 +46,14 @@ export class ModelHandlerKimi extends ModelHandlerOpenAI {
 
   /**
    * Override createResponse to preprocess messages for Kimi models.
-   * Note: processThinkingBlock is inherited from ModelHandlerOpenAI which
+   *
+   * Note: This handler does NOT use the getMessageNormalizationOptions() hook
+   * because Kimi thinking models require additional custom logic:
+   * - Conditional `thinking: true` parameter
+   * - Custom streaming aggregation for reasoning_content
+   * - Different request structure for thinking vs regular models
+   *
+   * processThinkingBlock is inherited from ModelHandlerOpenAI which
    * already handles reasoning_content extraction via extractReasoningFromMessage().
    */
   async createResponse(

--- a/src/agent/modelHandlers/modelHandlerKimi.ts
+++ b/src/agent/modelHandlers/modelHandlerKimi.ts
@@ -4,10 +4,7 @@
 import OpenAI from 'openai';
 
 // Local imports - agent
-import { AgentWorkspaceState } from '@agent/core/AgentWorkspaceState';
 import type { NormalizedUsage } from '@agent/types/NormalizedUsage';
-import { MediaEntry } from '@agent/utils/mediaTypes';
-import { K_SLICE } from '@utils/config';
 import { BaseReasoningStreamAggregator } from './BaseReasoningStreamAggregator';
 import { ModelHandlerOpenAI } from './modelHandlerOpenAI';
 import { executeRequest } from './utils/requestExecutor';
@@ -48,64 +45,9 @@ export class ModelHandlerKimi extends ModelHandlerOpenAI {
   }
 
   /**
-   * Process thinking blocks for Moonshot models
-   * @param responseObject The raw response object from the model
-   * @param workspaceState Optional workspaceState to update with the thinking block
-   * @returns The extracted reasoning_content or null if none
-   */
-  processThinkingBlock(
-    responseObject: any,
-    workspaceState?: AgentWorkspaceState,
-  ): string | null {
-    if (!responseObject) {
-      return null;
-    }
-
-    // Extract reasoning content from Moonshot Kimi thinking model response
-    let reasoningContent = null;
-
-    if (
-      responseObject.choices &&
-      responseObject.choices.length > 0 &&
-      responseObject.choices[0].message
-    ) {
-      const message = responseObject.choices[0].message;
-
-      if (message.reasoning_content) {
-        reasoningContent = message.reasoning_content;
-        this.logger.debug(
-          'Found reasoning_content in choices[0].message.reasoning_content',
-        );
-
-        // If workspaceState is provided and we have reasoning content,
-        // store it in the workspaceState for future use (similar to Anthropic thinking blocks)
-        if (workspaceState && !workspaceState.reasoning.thinkingAdded) {
-          // Create a thinking block in the same format as Anthropic for consistency
-          const thinkingBlock = {
-            type: 'thinking',
-            thinking: reasoningContent,
-          };
-
-          workspaceState.reasoning.thinkingBlocks = [thinkingBlock];
-          workspaceState.reasoning.thinkingAdded = true;
-        }
-      }
-    }
-
-    if (!reasoningContent) {
-      return null;
-    }
-
-    // Log preview of thinking content
-    this.logger.debug(
-      `Kimi thinking content preview: ${reasoningContent.substring(0, K_SLICE)}...`,
-    );
-
-    return reasoningContent;
-  }
-
-  /**
-   * Override createResponse to preprocess messages for Kimi models
+   * Override createResponse to preprocess messages for Kimi models.
+   * Note: processThinkingBlock is inherited from ModelHandlerOpenAI which
+   * already handles reasoning_content extraction via extractReasoningFromMessage().
    */
   async createResponse(
     options: CreateResponseOptions<ChatCompletionMessageParam, OpenAI>,
@@ -247,20 +189,7 @@ export class ModelHandlerKimi extends ModelHandlerOpenAI {
     });
   }
 
-  /**
-   * Creates media content formatted for Kimi models
-   * Overrides the parent method to handle Kimi-specific formatting
-   */
-  createMediaContent(mediaMessage: MediaEntry[]): any[] {
-    return mediaMessage.flatMap((media): any[] => {
-      if (media.media_category === 'image') {
-        return this.buildStandardVisionParts(media);
-      } else {
-        this.logger.warn(
-          `Unsupported media category for Kimi: ${media.media_category}`,
-        );
-        return [];
-      }
-    });
-  }
+  // Note: createMediaContent is inherited from ModelHandlerOpenAI which
+  // already handles images via buildStandardVisionParts() and logs
+  // appropriate warnings for unsupported media categories.
 }

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -389,19 +389,38 @@ export class ModelHandlerOpenAI<
     );
   }
 
+  /**
+   * Returns message normalization options for this handler.
+   * Subclasses can override to specify provider-specific normalization
+   * (e.g., convertContentToString, mergeConsecutiveRoles) without
+   * overriding the entire createResponse method.
+   *
+   * @returns Normalization options, or undefined to skip normalization
+   */
+  protected getMessageNormalizationOptions(): NormalizeOpenAIMessageContentOptions | undefined {
+    return undefined; // Default: no normalization
+  }
+
   /** Creates a chat completion with model-specific parameters. */
   async createResponse(
     options: CreateResponseOptions<ChatCompletionMessageParam, OpenAI>,
   ): Promise<ChatCompletion> {
     const {
       client,
-      messages,
+      messages: rawMessages,
       temperature,
       systemPrompt,
       endTag,
       signal,
       tools,
     } = options;
+
+    // Apply message normalization if subclass specifies options
+    const normOptions = this.getMessageNormalizationOptions();
+    const messages = normOptions
+      ? this.prepareNormalizedMessages(rawMessages, normOptions)
+      : rawMessages;
+
     const useStreaming = this.getStreamingConfig();
     const baseParams = this.buildChatBaseParams(
       messages,

--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -55,35 +55,24 @@ export interface ProviderHttpErrorDetails {
   requestId?: string;
 }
 
-const STATUS_TITLES: Record<number, string> = {
-  400: 'Bad Request',
-  401: 'Unauthorized',
-  402: 'Payment Required',
-  403: 'Forbidden',
-  404: 'Not Found',
-  409: 'Conflict',
-  422: 'Unprocessable Entity',
-  429: 'Too Many Requests',
-  500: 'Internal Server Error',
-  502: 'Bad Gateway',
-  503: 'Service Unavailable',
-  504: 'Gateway Timeout',
-};
-
-const STATUS_DESCRIPTIONS: Record<number, string> = {
-  400: 'Invalid parameters',
-  401: 'Invalid API key',
-  402: 'Insufficient credits',
-  403: 'Permission denied',
-  404: 'Resource not found',
-  409: 'Conflict error',
-  422: 'Unprocessable entity',
-  429: 'Rate limit exceeded',
-  500: 'Provider error',
-  502: 'Provider error',
-  503: 'No available providers',
-  504: 'Provider timeout',
-};
+/**
+ * HTTP status information - single source of truth for status titles and descriptions.
+ */
+const HTTP_STATUS_INFO: Record<number, { title: string; description: string }> =
+  {
+    400: { title: 'Bad Request', description: 'Invalid parameters' },
+    401: { title: 'Unauthorized', description: 'Invalid API key' },
+    402: { title: 'Payment Required', description: 'Insufficient credits' },
+    403: { title: 'Forbidden', description: 'Permission denied' },
+    404: { title: 'Not Found', description: 'Resource not found' },
+    409: { title: 'Conflict', description: 'Conflict error' },
+    422: { title: 'Unprocessable Entity', description: 'Unprocessable entity' },
+    429: { title: 'Too Many Requests', description: 'Rate limit exceeded' },
+    500: { title: 'Internal Server Error', description: 'Provider error' },
+    502: { title: 'Bad Gateway', description: 'Provider error' },
+    503: { title: 'Service Unavailable', description: 'No available providers' },
+    504: { title: 'Gateway Timeout', description: 'Provider timeout' },
+  };
 
 type ErrorConstructor<T extends Error = Error> = abstract new (
   ...args: never[]
@@ -253,7 +242,7 @@ function matchNativeHttpError(
   const statusText = detectStatusText(err, statusCode);
   const requestId = detectRequestId(err);
   const fallbackMessage = statusCode
-    ? STATUS_DESCRIPTIONS[statusCode]
+    ? HTTP_STATUS_INFO[statusCode]?.description
     : undefined;
   const finalMessage =
     extractMessage(err) ?? fallbackMessage ?? 'Provider request failed';
@@ -316,7 +305,7 @@ function detectStatusText(
   statusCode?: number,
 ): string | undefined {
   if (!err || typeof err !== 'object') {
-    return statusCode ? STATUS_TITLES[statusCode] : undefined;
+    return statusCode ? HTTP_STATUS_INFO[statusCode]?.title : undefined;
   }
 
   const candidate = err as {
@@ -329,7 +318,7 @@ function detectStatusText(
     candidate.statusText ??
     candidate.response?.statusText ??
     candidate.error?.statusText ??
-    (statusCode ? STATUS_TITLES[statusCode] : undefined)
+    (statusCode ? HTTP_STATUS_INFO[statusCode]?.title : undefined)
   );
 }
 
@@ -451,7 +440,7 @@ export function formatProviderHttpError(
   const requestId = detectRequestId(err);
 
   const fallbackMessage = statusCode
-    ? STATUS_DESCRIPTIONS[statusCode]
+    ? HTTP_STATUS_INFO[statusCode]?.description
     : undefined;
   const finalMessage =
     extractMessage(err) ?? fallbackMessage ?? 'Provider request failed';

--- a/src/common/webview/BaseViewContentProvider.ts
+++ b/src/common/webview/BaseViewContentProvider.ts
@@ -30,7 +30,7 @@ export abstract class BaseViewContentProvider {
   constructor(
     protected readonly context: vscode.ExtensionContext,
     protected readonly viewName: string,
-    private readonly moduleDescriptors: ModuleDescriptor[] = [],
+    private readonly moduleDescriptors: readonly ModuleDescriptor[] = [],
   ) {
     this.logger = logger;
     this.channel = `${viewName}ContentProvider`;

--- a/src/common/webview/BaseViewContentProvider.ts
+++ b/src/common/webview/BaseViewContentProvider.ts
@@ -20,9 +20,17 @@ export abstract class BaseViewContentProvider {
   protected readonly logger: any;
   protected readonly channel: string;
 
+  /**
+   * @param context - VS Code extension context
+   * @param viewName - Name of this view (used for logging)
+   * @param moduleDescriptors - Optional view-specific module descriptors.
+   *   If provided, getModuleUris() will automatically build URIs from these.
+   *   If not provided, subclasses must override getModuleUris().
+   */
   constructor(
     protected readonly context: vscode.ExtensionContext,
     protected readonly viewName: string,
+    private readonly moduleDescriptors: ModuleDescriptor[] = [],
   ) {
     this.logger = logger;
     this.channel = `${viewName}ContentProvider`;
@@ -35,11 +43,13 @@ export abstract class BaseViewContentProvider {
   protected abstract getViewPath(): string;
 
   /**
-   * Subclasses must provide their specific module URIs
+   * Returns view-specific module URIs. Default implementation uses
+   * moduleDescriptors passed to constructor. Subclasses can override
+   * for custom URI generation.
    */
-  protected abstract getModuleUris(
-    webview: vscode.Webview,
-  ): Record<string, vscode.Uri>;
+  protected getModuleUris(webview: vscode.Webview): Record<string, vscode.Uri> {
+    return this.buildUriRecord(webview, this.moduleDescriptors);
+  }
 
   /**
    * Optional: Override to provide additional template variables

--- a/src/historyView/HistoryViewContentProvider.ts
+++ b/src/historyView/HistoryViewContentProvider.ts
@@ -2,28 +2,22 @@
 import * as vscode from 'vscode';
 
 // Local imports - history view
-import { BaseViewContentProvider, ModuleDescriptor } from '@common/webview';
+import { BaseViewContentProvider } from '@common/webview';
+
+/** View-specific module descriptors for HistoryView */
+const HISTORY_VIEW_MODULES = [
+  { key: 'eventsUri', path: 'modules/uiManagers/HistoryEventsManager.js' },
+  { key: 'historyRendererUri', path: 'modules/uiManagers/HistoryRenderer.js' },
+  { key: 'historyViewStateUri', path: 'modules/historyViewState.js' },
+  { key: 'searchManagerUri', path: 'modules/uiManagers/SearchManager.js' },
+] as const;
 
 export class HistoryViewContentProvider extends BaseViewContentProvider {
   constructor(context: vscode.ExtensionContext) {
-    super(context, 'HistoryView');
+    super(context, 'HistoryView', [...HISTORY_VIEW_MODULES]);
   }
 
   protected getViewPath(): string {
     return 'historyView';
-  }
-
-  private readonly moduleDescriptors: ModuleDescriptor[] = [
-    { key: 'eventsUri', path: 'modules/uiManagers/HistoryEventsManager.js' },
-    {
-      key: 'historyRendererUri',
-      path: 'modules/uiManagers/HistoryRenderer.js',
-    },
-    { key: 'historyViewStateUri', path: 'modules/historyViewState.js' },
-    { key: 'searchManagerUri', path: 'modules/uiManagers/SearchManager.js' },
-  ];
-
-  protected getModuleUris(webview: vscode.Webview): Record<string, vscode.Uri> {
-    return this.buildUriRecord(webview, this.moduleDescriptors);
   }
 }

--- a/src/profileView/ProfileViewContentProvider.ts
+++ b/src/profileView/ProfileViewContentProvider.ts
@@ -2,27 +2,21 @@
 import * as vscode from 'vscode';
 
 // Local imports - profile view
-import { BaseViewContentProvider, ModuleDescriptor } from '@common/webview';
+import { BaseViewContentProvider } from '@common/webview';
+
+/** View-specific module descriptors for ProfileView */
+const PROFILE_VIEW_MODULES = [
+  { key: 'profileViewStateUri', path: 'modules/profileViewState.js' },
+  { key: 'agentsTableUri', path: 'modules/uiManagers/AgentsTable.js' },
+  { key: 'profileEventsUri', path: 'modules/uiManagers/ProfileEventsManager.js' },
+] as const;
 
 export class ProfileViewContentProvider extends BaseViewContentProvider {
   constructor(context: vscode.ExtensionContext) {
-    super(context, 'ProfileView');
+    super(context, 'ProfileView', [...PROFILE_VIEW_MODULES]);
   }
 
   protected getViewPath(): string {
     return 'profileView';
-  }
-
-  private readonly moduleDescriptors: ModuleDescriptor[] = [
-    { key: 'profileViewStateUri', path: 'modules/profileViewState.js' },
-    { key: 'agentsTableUri', path: 'modules/uiManagers/AgentsTable.js' },
-    {
-      key: 'profileEventsUri',
-      path: 'modules/uiManagers/ProfileEventsManager.js',
-    },
-  ];
-
-  protected getModuleUris(webview: vscode.Webview): Record<string, vscode.Uri> {
-    return this.buildUriRecord(webview, this.moduleDescriptors);
   }
 }

--- a/src/progressView/ProgressViewContentProvider.ts
+++ b/src/progressView/ProgressViewContentProvider.ts
@@ -2,59 +2,38 @@
 import * as vscode from 'vscode';
 
 // Local imports - progress view
-import { BaseViewContentProvider, ModuleDescriptor } from '@common/webview';
+import { BaseViewContentProvider } from '@common/webview';
+
+/** View-specific module descriptors for ProgressView */
+const PROGRESS_VIEW_MODULES = [
+  { key: 'progressViewStateUri', path: 'modules/progressViewState.js' },
+  { key: 'formattersUri', path: 'modules/formatters.js' },
+  { key: 'taskManagersUri', path: 'modules/taskManagers.js' },
+  { key: 'utilsUri', path: 'modules/utils.js' },
+  { key: 'usageManagersUri', path: 'modules/usageManagers.js' },
+  { key: 'katexMacrosUri', path: 'modules/katexMacros.js' },
+  { key: 'themeHandlersUri', path: 'modules/handlers/themeHandlers.js' },
+  // UI managers
+  { key: 'streamTabsUri', path: 'modules/uiManagers/StreamTabs.js' },
+  { key: 'toolbarUri', path: 'modules/uiManagers/Toolbar.js' },
+  { key: 'statusUri', path: 'modules/uiManagers/Status.js' },
+  { key: 'fileListUri', path: 'modules/uiManagers/FileList.js' },
+  { key: 'eventsUri', path: 'modules/uiManagers/EventsManager.js' },
+  { key: 'placeholderUri', path: 'modules/uiManagers/Placeholder.js' },
+  { key: 'runSelectorUri', path: 'modules/uiManagers/RunSelector.js' },
+  { key: 'instructionPanelUri', path: 'modules/uiManagers/InstructionPanel.js' },
+  { key: 'followUpInputManagerUri', path: 'modules/uiManagers/FollowUpInputManager.js' },
+  { key: 'approvalRequestsUri', path: 'modules/uiManagers/ApprovalRequests.js' },
+  { key: 'retryRequestsUri', path: 'modules/uiManagers/RetryRequests.js' },
+  { key: 'baseUIRequestManagerUri', path: 'modules/uiManagers/BaseUIRequestManager.js' },
+] as const;
 
 export class ProgressViewContentProvider extends BaseViewContentProvider {
   constructor(context: vscode.ExtensionContext) {
-    super(context, 'ProgressView');
+    super(context, 'ProgressView', [...PROGRESS_VIEW_MODULES]);
   }
 
   protected getViewPath(): string {
     return 'progressView';
-  }
-
-  private readonly moduleDescriptors: ModuleDescriptor[] = [
-    { key: 'progressViewStateUri', path: 'modules/progressViewState.js' },
-    { key: 'formattersUri', path: 'modules/formatters.js' },
-    { key: 'taskManagersUri', path: 'modules/taskManagers.js' },
-    { key: 'utilsUri', path: 'modules/utils.js' },
-    { key: 'usageManagersUri', path: 'modules/usageManagers.js' },
-    { key: 'katexMacrosUri', path: 'modules/katexMacros.js' },
-    { key: 'themeHandlersUri', path: 'modules/handlers/themeHandlers.js' },
-
-    // UI managers
-    { key: 'streamTabsUri', path: 'modules/uiManagers/StreamTabs.js' },
-    { key: 'toolbarUri', path: 'modules/uiManagers/Toolbar.js' },
-    { key: 'statusUri', path: 'modules/uiManagers/Status.js' },
-    { key: 'fileListUri', path: 'modules/uiManagers/FileList.js' },
-    { key: 'eventsUri', path: 'modules/uiManagers/EventsManager.js' },
-    { key: 'placeholderUri', path: 'modules/uiManagers/Placeholder.js' },
-    { key: 'runSelectorUri', path: 'modules/uiManagers/RunSelector.js' },
-    {
-      key: 'instructionPanelUri',
-      path: 'modules/uiManagers/InstructionPanel.js',
-    },
-    {
-      key: 'followUpInputManagerUri',
-      path: 'modules/uiManagers/FollowUpInputManager.js',
-    },
-    {
-      key: 'approvalRequestsUri',
-      path: 'modules/uiManagers/ApprovalRequests.js',
-    },
-    {
-      key: 'retryRequestsUri',
-      path: 'modules/uiManagers/RetryRequests.js',
-    },
-    {
-      key: 'baseUIRequestManagerUri',
-      path: 'modules/uiManagers/BaseUIRequestManager.js',
-    },
-  ];
-
-  protected getModuleUris(webview: vscode.Webview): Record<string, vscode.Uri> {
-    return {
-      ...this.buildUriRecord(webview, this.moduleDescriptors),
-    };
   }
 }

--- a/src/webview/MainViewContentProvider.ts
+++ b/src/webview/MainViewContentProvider.ts
@@ -5,66 +5,36 @@ import * as vscode from 'vscode';
 import { computeAgentOptionsSync } from '@agent/index';
 
 // Internal imports
-import { BaseViewContentProvider, ModuleDescriptor } from '@common/webview';
+import { BaseViewContentProvider } from '@common/webview';
 import { getConfig } from '@utils/config';
+
+/** View-specific module descriptors for MainView */
+const MAIN_VIEW_MODULES = [
+  { key: 'webviewStateModuleUri', path: 'modules/mainViewState.js' },
+  { key: 'themeHandlersUri', path: 'modules/handlers/themeHandlers.js' },
+  { key: 'fileMessageHandlersUri', path: 'modules/handlers/fileHandlers.js' },
+  { key: 'recordingHandlersUri', path: 'modules/handlers/recordingHandlers.js' },
+  { key: 'eventBusUri', path: 'modules/eventBus.js' },
+  { key: 'fileListUri', path: 'modules/uiManagers/FileList.js' },
+  { key: 'fileSelectUri', path: 'modules/uiManagers/FileSelect.js' },
+  { key: 'baseUIManagerUri', path: 'modules/uiManagers/BaseUIManager.js' },
+  { key: 'fileInputManagerUri', path: 'modules/uiManagers/FileInputManager.js' },
+  { key: 'actionButtonManagerUri', path: 'modules/uiManagers/ActionButtonManager.js' },
+  { key: 'settingsButtonManagerUri', path: 'modules/uiManagers/SettingsButtonManager.js' },
+  { key: 'bannerManagerUri', path: 'modules/uiManagers/BannerManager.js' },
+  { key: 'recordingManagerUri', path: 'modules/uiManagers/RecordingManager.js' },
+  { key: 'instructionManagerUri', path: 'modules/uiManagers/InstructionManager.js' },
+  { key: 'outputFilesManagerUri', path: 'modules/uiManagers/OutputFilesManager.js' },
+  { key: 'latexdiffManagerUri', path: 'modules/uiManagers/LatexdiffManager.js' },
+] as const;
 
 export class MainViewContentProvider extends BaseViewContentProvider {
   constructor(context: vscode.ExtensionContext) {
-    super(context, 'MainView');
+    super(context, 'MainView', [...MAIN_VIEW_MODULES]);
   }
 
   protected getViewPath(): string {
     return 'webview';
-  }
-
-  private readonly moduleDescriptors: ModuleDescriptor[] = [
-    { key: 'webviewStateModuleUri', path: 'modules/mainViewState.js' },
-    { key: 'themeHandlersUri', path: 'modules/handlers/themeHandlers.js' },
-    { key: 'fileMessageHandlersUri', path: 'modules/handlers/fileHandlers.js' },
-    {
-      key: 'recordingHandlersUri',
-      path: 'modules/handlers/recordingHandlers.js',
-    },
-    { key: 'eventBusUri', path: 'modules/eventBus.js' },
-    { key: 'fileListUri', path: 'modules/uiManagers/FileList.js' },
-    { key: 'fileSelectUri', path: 'modules/uiManagers/FileSelect.js' },
-    { key: 'baseUIManagerUri', path: 'modules/uiManagers/BaseUIManager.js' },
-    {
-      key: 'fileInputManagerUri',
-      path: 'modules/uiManagers/FileInputManager.js',
-    },
-    {
-      key: 'actionButtonManagerUri',
-      path: 'modules/uiManagers/ActionButtonManager.js',
-    },
-    {
-      key: 'settingsButtonManagerUri',
-      path: 'modules/uiManagers/SettingsButtonManager.js',
-    },
-    {
-      key: 'bannerManagerUri',
-      path: 'modules/uiManagers/BannerManager.js',
-    },
-    {
-      key: 'recordingManagerUri',
-      path: 'modules/uiManagers/RecordingManager.js',
-    },
-    {
-      key: 'instructionManagerUri',
-      path: 'modules/uiManagers/InstructionManager.js',
-    },
-    {
-      key: 'outputFilesManagerUri',
-      path: 'modules/uiManagers/OutputFilesManager.js',
-    },
-    {
-      key: 'latexdiffManagerUri',
-      path: 'modules/uiManagers/LatexdiffManager.js',
-    },
-  ];
-
-  protected getModuleUris(webview: vscode.Webview): Record<string, vscode.Uri> {
-    return this.buildUriRecord(webview, this.moduleDescriptors);
   }
 
   protected getTemplateVariables(): Record<string, any> {


### PR DESCRIPTION
- Remove duplicate processThinkingBlock override from Kimi handler
  (base class already handles reasoning_content extraction)

- Remove duplicate createMediaContent overrides from Kimi/DashScope
  (base class already handles images via buildStandardVisionParts)

- Consolidate HTTP_STATUS_TITLES and HTTP_STATUS_DESCRIPTIONS into
  single HTTP_STATUS_INFO map in sdkErrorUtils.ts

- Add getMessageNormalizationOptions() hook to ModelHandlerOpenAI
  allowing subclasses to specify normalization without overriding
  entire createResponse method (simplifies DeepSeek, DashScope)

- Refactor BaseViewContentProvider to accept moduleDescriptors in
  constructor, eliminating need for subclasses to declare separate
  properties and override getModuleUris()

Total reduction: ~150 lines with improved maintainability

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a normalization hook to `ModelHandlerOpenAI`, simplifies DeepSeek/DashScope/Kimi handlers, consolidates HTTP status metadata, and refactors webview providers to pass module descriptors via the base class.
> 
> - **Agent/Model Handlers**:
>   - **Normalization hook**: Add `getMessageNormalizationOptions()` to `ModelHandlerOpenAI` and apply automatically in `createResponse`.
>   - **Provider-specific**: 
>     - `ModelHandlerDeepSeek`: uses hook (`mergeConsecutiveRoles`, `convertContentToString`), adds reasoning-aware tool follow-ups and batching; enforces string assistant content; disables tool result attachments.
>     - `ModelHandlerDashScope`: uses hook (`convertContentToString`).
>     - `ModelHandlerKimi`: removes duplicate thinking/media logic; keeps custom `createResponse` for thinking mode, relies on base for reasoning extraction and media.
> - **Errors**:
>   - Replace separate `STATUS_TITLES`/`STATUS_DESCRIPTIONS` with unified `HTTP_STATUS_INFO`; update lookups in `sdkErrorUtils.ts`.
> - **Webview**:
>   - `BaseViewContentProvider`: accept `moduleDescriptors` via constructor and provide default `getModuleUris()`.
>   - Update `HistoryViewContentProvider`, `ProfileViewContentProvider`, `ProgressViewContentProvider`, and `MainViewContentProvider` to supply module descriptor arrays to base class and remove redundant overrides.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a1a4c58eb9762f8ad3492b4eab2e391ee1397fe9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->