### PR TITLE
Fix progress view unit display issue

### DIFF
--- a/src/progressView/modules/usageManagers.js
+++ b/src/progressView/modules/usageManagers.js
@@ -44,20 +44,22 @@ export class UsageSummary {
       footer.hidden = false;
     }
 
-    const parts = [
-      `${formatTokens(inputTokens)}`,
-      `${formatTokens(outputTokens)}`,
-      `$${cost.toFixed(3)}`,
-    ];
+    const formattedInput = formatTokens(inputTokens);
+    const formattedOutput = formatTokens(outputTokens);
+    const formattedCost = `$${cost.toFixed(3)}`;
 
     this._summaryElem.innerHTML = `
       <i class="codicon codicon-meter"></i>
       <span class="run-summary__label">Total usage:</span>
-      <span class="run-summary__value">${parts.join(' · ')}</span>
+      <span class="run-summary__value">
+        <i class="codicon codicon-arrow-up" title="Input tokens"></i>${formattedInput} ·
+        <i class="codicon codicon-arrow-down" title="Output tokens"></i>${formattedOutput} ·
+        ${formattedCost}
+      </span>
     `;
     this._summaryElem.setAttribute(
       'aria-label',
-      `Total usage ${parts.join(', ')}`,
+      `Total usage: ${formattedInput} input tokens, ${formattedOutput} output tokens, ${formattedCost}`,
     );
   }
 


### PR DESCRIPTION
Add up/down arrow icons to Total usage display (matching statistics style) to make it clear which number is input vs output tokens.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Clarifies the Total usage display by adding directional icons for input/output tokens, refactoring formatting, and improving the aria-label.
> 
> - **Progress View UI**:
>   - Update `UsageSummary.update` to show input/output token counts with up/down icons and cost in the `run-summary__value`.
>   - Replace `parts.join(...)` with explicit `formattedInput`, `formattedOutput`, and `formattedCost` variables.
>   - Improve accessibility by setting a descriptive `aria-label` with labeled token types and cost.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 675ff249e4229b0744f781f3f8e516c77bf4b616. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->