### PR TITLE
Add getting started guidance for new sessions

### DIFF
--- a/src/MainViewProvider.ts
+++ b/src/MainViewProvider.ts
@@ -166,6 +166,7 @@ export class MainViewProvider
   resolveWebviewView(webviewView: vscode.WebviewView) {
     webviewView.webview.options = {
       enableScripts: true,
+      enableCommandUris: true,
       localResourceRoots: getSharedLocalResourceRoots(this.context, 'webview'),
     };
 

--- a/src/common/webview/commands.js
+++ b/src/common/webview/commands.js
@@ -89,6 +89,8 @@ export const MAIN_VIEW_COMMANDS = {
   SHOW_DEPENDENCY_BANNER: 'showDependencyBanner',
   HIDE_DEPENDENCY_BANNER: 'hideDependencyBanner',
   UPDATE_DEPENDENCY_REMINDER_SETTING: 'updateDependencyReminderSetting',
+  SHOW_GETTING_STARTED_BANNER: 'showGettingStartedBanner',
+  HIDE_GETTING_STARTED_BANNER: 'hideGettingStartedBanner',
 
   // Extension response events
   CHECK_RESTORED_BASE_FILE: 'checkRestoredBaseFile',

--- a/src/common/webview/commands.ts
+++ b/src/common/webview/commands.ts
@@ -89,6 +89,8 @@ export const MAIN_VIEW_COMMANDS = {
   SHOW_DEPENDENCY_BANNER: 'showDependencyBanner',
   HIDE_DEPENDENCY_BANNER: 'hideDependencyBanner',
   UPDATE_DEPENDENCY_REMINDER_SETTING: 'updateDependencyReminderSetting',
+  SHOW_GETTING_STARTED_BANNER: 'showGettingStartedBanner',
+  HIDE_GETTING_STARTED_BANNER: 'hideGettingStartedBanner',
 
   // Extension response events
   CHECK_RESTORED_BASE_FILE: 'checkRestoredBaseFile',

--- a/src/webview/index.html
+++ b/src/webview/index.html
@@ -576,6 +576,15 @@
             >
           </div>
         </div>
+
+        <!-- Getting Started Banner -->
+        <div
+          id="gettingStartedBanner"
+          class="getting-started-banner"
+          style="display: none"
+        >
+          <span class="getting-started-text"></span>
+        </div>
       </div>
 
       <div class="latexdiffs-section">

--- a/src/webview/managers/FileManager.ts
+++ b/src/webview/managers/FileManager.ts
@@ -166,7 +166,6 @@ export class FileManager {
   }
 
   async handleRequestBaseFile(message: RequestBaseFileMessage): Promise<void> {
-    const webviewView = this.getWebview();
     const files = await fileLister.list('input');
     await this.postFileUpdate('Base', files, {
       notifyWhenEmpty: !!message.notifyWhenEmpty,
@@ -175,15 +174,7 @@ export class FileManager {
         : undefined,
     });
 
-    // Show getting started banner when workspace has no input files
-    if (webviewView) {
-      webviewView.webview.postMessage({
-        command:
-          files.length === 0
-            ? MAIN_VIEW_COMMANDS.SHOW_GETTING_STARTED_BANNER
-            : MAIN_VIEW_COMMANDS.HIDE_GETTING_STARTED_BANNER,
-      });
-    }
+    this.updateGettingStartedBanner(files.length === 0);
   }
 
   async handleRequestDefaultOutputFiles(
@@ -281,8 +272,6 @@ export class FileManager {
   }
 
   async handleRefreshAllFiles(): Promise<void> {
-    const webviewView = this.getWebview();
-
     const refreshedFiles = {
       input: await fileLister.list('input'),
       reference: await fileLister.list('reference'),
@@ -296,15 +285,7 @@ export class FileManager {
 
     await this.updateBaseFileSelect();
 
-    // Check if workspace is empty (no input files) and show getting started banner
-    if (webviewView) {
-      const isEmpty = refreshedFiles.input.length === 0;
-      webviewView.webview.postMessage({
-        command: isEmpty
-          ? MAIN_VIEW_COMMANDS.SHOW_GETTING_STARTED_BANNER
-          : MAIN_VIEW_COMMANDS.HIDE_GETTING_STARTED_BANNER,
-      });
-    }
+    this.updateGettingStartedBanner(refreshedFiles.input.length === 0);
   }
 
   async handleGetCurrentFile(message: GetCurrentFileMessage): Promise<void> {
@@ -561,6 +542,18 @@ export class FileManager {
       command: MAIN_VIEW_COMMANDS.SET_BASE_FILE,
       files: baseFiles,
       preserveBaseFile: true,
+    });
+  }
+
+  private updateGettingStartedBanner(isEmpty: boolean): void {
+    const webviewView = this.getWebview();
+    if (!webviewView) {
+      return;
+    }
+    webviewView.webview.postMessage({
+      command: isEmpty
+        ? MAIN_VIEW_COMMANDS.SHOW_GETTING_STARTED_BANNER
+        : MAIN_VIEW_COMMANDS.HIDE_GETTING_STARTED_BANNER,
     });
   }
 

--- a/src/webview/managers/FileManager.ts
+++ b/src/webview/managers/FileManager.ts
@@ -166,6 +166,7 @@ export class FileManager {
   }
 
   async handleRequestBaseFile(message: RequestBaseFileMessage): Promise<void> {
+    const webviewView = this.getWebview();
     const files = await fileLister.list('input');
     await this.postFileUpdate('Base', files, {
       notifyWhenEmpty: !!message.notifyWhenEmpty,
@@ -173,6 +174,16 @@ export class FileManager {
         ? { preserveBaseFile: true }
         : undefined,
     });
+
+    // Show getting started banner when workspace has no input files
+    if (webviewView) {
+      webviewView.webview.postMessage({
+        command:
+          files.length === 0
+            ? MAIN_VIEW_COMMANDS.SHOW_GETTING_STARTED_BANNER
+            : MAIN_VIEW_COMMANDS.HIDE_GETTING_STARTED_BANNER,
+      });
+    }
   }
 
   async handleRequestDefaultOutputFiles(
@@ -270,6 +281,8 @@ export class FileManager {
   }
 
   async handleRefreshAllFiles(): Promise<void> {
+    const webviewView = this.getWebview();
+
     const refreshedFiles = {
       input: await fileLister.list('input'),
       reference: await fileLister.list('reference'),
@@ -282,6 +295,16 @@ export class FileManager {
     });
 
     await this.updateBaseFileSelect();
+
+    // Check if workspace is empty (no input files) and show getting started banner
+    if (webviewView) {
+      const isEmpty = refreshedFiles.input.length === 0;
+      webviewView.webview.postMessage({
+        command: isEmpty
+          ? MAIN_VIEW_COMMANDS.SHOW_GETTING_STARTED_BANNER
+          : MAIN_VIEW_COMMANDS.HIDE_GETTING_STARTED_BANNER,
+      });
+    }
   }
 
   async handleGetCurrentFile(message: GetCurrentFileMessage): Promise<void> {

--- a/src/webview/managers/FileManager.ts
+++ b/src/webview/managers/FileManager.ts
@@ -117,10 +117,6 @@ export class FileManager {
   async handleRequestInputFile(
     message: RequestInputFileMessage,
   ): Promise<void> {
-    const webviewView = this.getWebview();
-    if (!webviewView) {
-      return;
-    }
     const refreshedInputFiles =
       (await vscode.commands.executeCommand<string[]>(
         'texra.refreshInputFiles',
@@ -128,6 +124,8 @@ export class FileManager {
     await this.postFileUpdate('Input', refreshedInputFiles, {
       notifyWhenEmpty: !!message.notifyWhenEmpty,
     });
+
+    this.updateGettingStartedBanner(refreshedInputFiles.length === 0);
   }
 
   async handleRequestFile(message: RequestFileMessage): Promise<void> {

--- a/src/webview/managers/FileManager.ts
+++ b/src/webview/managers/FileManager.ts
@@ -117,6 +117,9 @@ export class FileManager {
   async handleRequestInputFile(
     message: RequestInputFileMessage,
   ): Promise<void> {
+    if (!this.getWebview()) {
+      return;
+    }
     const refreshedInputFiles =
       (await vscode.commands.executeCommand<string[]>(
         'texra.refreshInputFiles',

--- a/src/webview/modules/constants.js
+++ b/src/webview/modules/constants.js
@@ -106,6 +106,7 @@ export const ELEMENT_IDS = {
   DEPENDENCY_BANNER: 'dependencyBanner',
   DEPENDENCY_RECHECK_BUTTON: 'dependencyRecheckButton',
   DEPENDENCY_DISMISS_BUTTON: 'dependencyDismissButton',
+  GETTING_STARTED_BANNER: 'gettingStartedBanner',
   SESSION_TYPE_TOGGLE: 'sessionTypeToggle',
   WORKFLOW_AGENT_SELECT: 'workflowAgent',
   TOOL_USE_AGENT_SELECT: 'toolUseAgent',

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -99,6 +99,10 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
         ),
       [MAIN_VIEW_COMMANDS.HIDE_DEPENDENCY_BANNER]: () =>
         webviewEventBus.dispatchEvent(new CustomEvent('hideDependencyBanner')),
+      [MAIN_VIEW_COMMANDS.SHOW_GETTING_STARTED_BANNER]: () =>
+        bannerManager.showBanner(ELEMENT_IDS.GETTING_STARTED_BANNER),
+      [MAIN_VIEW_COMMANDS.HIDE_GETTING_STARTED_BANNER]: () =>
+        bannerManager.hideBanner(ELEMENT_IDS.GETTING_STARTED_BANNER),
       /**
        * Handles SET_MODEL_OPTIONS command to update the model dropdown.
        *

--- a/src/webview/modules/uiManagers/BannerManager.js
+++ b/src/webview/modules/uiManagers/BannerManager.js
@@ -36,7 +36,10 @@ export class BannerManager extends BaseUIManager {
         break;
     }
 
-    element.style.setProperty('display', 'block');
+    // Getting started banner uses block layout; others use flex for button alignment
+    const displayStyle =
+      id === ELEMENT_IDS.GETTING_STARTED_BANNER ? 'block' : 'flex';
+    element.style.setProperty('display', displayStyle);
   }
 
   /**

--- a/src/webview/modules/uiManagers/BannerManager.js
+++ b/src/webview/modules/uiManagers/BannerManager.js
@@ -272,8 +272,8 @@ export class BannerManager extends BaseUIManager {
       return;
     }
 
-    // Clear existing content
-    textContainer.innerHTML = '';
+    // Clear existing content safely
+    textContainer.replaceChildren();
 
     // Build the message with command links
     const introText = document.createTextNode(

--- a/src/webview/modules/uiManagers/BannerManager.js
+++ b/src/webview/modules/uiManagers/BannerManager.js
@@ -29,11 +29,14 @@ export class BannerManager extends BaseUIManager {
       case ELEMENT_IDS.DEPENDENCY_BANNER:
         this._setupDependencyBanner(element, config);
         break;
+      case ELEMENT_IDS.GETTING_STARTED_BANNER:
+        this._setupGettingStartedBanner(element);
+        break;
       default:
         break;
     }
 
-    element.style.setProperty('display', 'flex');
+    element.style.setProperty('display', 'block');
   }
 
   /**
@@ -250,6 +253,58 @@ export class BannerManager extends BaseUIManager {
     item.appendChild(nameSpan);
     item.appendChild(button);
     container.appendChild(item);
+  }
+
+  /**
+   * Configure getting started banner with helpful links.
+   * @private
+   * @param {HTMLElement} element - The banner element
+   */
+  _setupGettingStartedBanner(element) {
+    const textContainer = element.querySelector('.getting-started-text');
+    if (!textContainer) {
+      console.warn(
+        '[BannerManager] Getting started banner missing text container',
+      );
+      return;
+    }
+
+    // Clear existing content
+    textContainer.innerHTML = '';
+
+    // Build the message with command links
+    const introText = document.createTextNode(
+      'No files found in workspace. Try ',
+    );
+    textContainer.appendChild(introText);
+
+    // Create links
+    const links = [
+      {
+        command: 'texra.openGettingStarted',
+        text: 'opening the getting started walkthrough',
+      },
+      { command: 'texra.createSampleProject', text: 'creating a sample project' },
+      { command: 'texra.cloneOverleafProject', text: 'cloning an Overleaf project' },
+      { command: 'texra.downloadArXivSource', text: 'downloading an arXiv source' },
+    ];
+
+    links.forEach((link, index) => {
+      const anchor = document.createElement('a');
+      anchor.href = `command:${link.command}`;
+      anchor.textContent = link.text;
+      textContainer.appendChild(anchor);
+
+      if (index < links.length - 1) {
+        const separator =
+          index === links.length - 2
+            ? document.createTextNode(', or ')
+            : document.createTextNode(', ');
+        textContainer.appendChild(separator);
+      }
+    });
+
+    textContainer.appendChild(document.createTextNode('.'));
   }
 }
 

--- a/src/webview/styles/containers.css
+++ b/src/webview/styles/containers.css
@@ -122,3 +122,23 @@
   justify-content: space-between;
   align-items: center;
 }
+
+/* Getting started banner - informational style */
+.getting-started-banner {
+  background-color: var(--vscode-inputValidation-infoBackground);
+  color: var(--vscode-inputValidation-infoForeground);
+  border: 1px solid var(--vscode-inputValidation-infoBorder);
+  border-radius: var(--border-radius);
+  padding: var(--spacing-small) var(--spacing-medium);
+  margin-bottom: var(--spacing-large);
+  line-height: 1.5;
+}
+
+.getting-started-banner a {
+  color: var(--vscode-textLink-foreground);
+  text-decoration: none;
+}
+
+.getting-started-banner a:hover {
+  text-decoration: underline;
+}


### PR DESCRIPTION
Add a new informational banner that appears when the workspace has no input files, helping new users discover how to get started with TeXRA. The banner provides links to the getting started walkthrough, creating a sample project, cloning an Overleaf project, or downloading arXiv source.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds an informational banner shown when no input files are found, with command links to onboarding actions, plus wiring, commands, and styles to support it.
> 
> - **Webview/Commands**
>   - Add `MAIN_VIEW_COMMANDS.SHOW_GETTING_STARTED_BANNER` / `HIDE_GETTING_STARTED_BANNER` in `src/common/webview/commands.{ts,js}`.
>   - Enable command URIs in webview via `webview.options.enableCommandUris = true` in `src/MainViewProvider.ts`.
> - **UI**
>   - Insert `#gettingStartedBanner` container in `src/webview/index.html` and style it in `src/webview/styles/containers.css`.
>   - Extend `BannerManager` to render getting-started text with command links (`texra.openGettingStarted`, `texra.createSampleProject`, `texra.cloneOverleafProject`, `texra.downloadArXivSource`).
>   - Wire message handlers to show/hide the banner in `src/webview/modules/messageHandlers.js`; add ID in `src/webview/modules/constants.js`.
> - **File logic**
>   - Update `FileManager` to post show/hide banner commands based on empty input/base file lists and on full refresh (`handleRequestInputFile`, `handleRequestBaseFile`, `handleRefreshAllFiles`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c3cf92b77806a928c7fbc7f888f180c47e9dde08. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->