### PR TITLE
Fix commutation relation replacement engine bug

### DIFF
--- a/src/replacement/rules/spacing.ts
+++ b/src/replacement/rules/spacing.ts
@@ -28,7 +28,9 @@ export const LATEX_SPACING_REPLACEMENTS: ReplacementCategory = {
     '.  ': '. ',
 
     // ===== Comma spacing fixes =====
-    ',\\,\\': ', ',
+    // Note: ',\,\' -> ', \' preserves the trailing backslash (start of next command)
+    // Bug fix: previously this was ', ' which stripped backslashes from commands like \phi
+    ',\\,\\': ', \\',
     ')\\,\\': ') \\',
     '}\\,\\': '} \\',
     '|\\,\\': '| \\',


### PR DESCRIPTION
The pattern ',\,\' was incorrectly replacing with ', ' which stripped the trailing backslash. This caused Greek letters like \phi and \pi to lose their backslash when they appeared after comma-thinspace sequences (e.g., ',\,\phi' became ', phi' instead of ', \phi').

The fix changes the replacement to ', \' to preserve the trailing backslash, matching the behavior of similar patterns like ')\,\' and '}\,\' which already preserved the backslash.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjust `',\\,\\'` replacement to `', \\'` in LaTeX spacing rules to preserve the trailing backslash.
> 
> - **Spacing rules (`src/replacement/rules/spacing.ts`)**:
>   - **Comma spacing**: Change `',\\,\\'` mapping from `', '` to `', \\'` to preserve trailing backslash in subsequent commands.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aaeec15a358b234c7531fab664a3b4c2570b50e3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->