### PR TITLE
Fix agent settings and prompts loading error

### DIFF
--- a/src/agent/remote/RemoteAgentLoader.ts
+++ b/src/agent/remote/RemoteAgentLoader.ts
@@ -127,6 +127,19 @@ export class RemoteAgentLoader {
             } catch (error) {
               logger.warn(CHANNEL, 'Failed to read error response body');
             }
+
+            // Provide more helpful error message for storage-related failures
+            if (
+              response.status === 500 &&
+              errorText.includes('Failed to load agent configuration')
+            ) {
+              throw new Error(
+                `Failed to load agent "${agentName}": The agent configuration file could not be retrieved from storage. ` +
+                  `This may indicate the agent's YAML file is missing or the storage path in the database is incorrect. ` +
+                  `Please contact the TeXRA team if this agent should be available.`,
+              );
+            }
+
             throw new Error(
               `Failed to load agent: ${response.statusText} - ${errorText}`,
             );


### PR DESCRIPTION
…failures

When the edge function returns 500 with "Failed to load agent configuration", provide a more actionable error message explaining that the agent's YAML file could not be retrieved from storage, rather than showing the raw server error.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds targeted handling for 500 responses containing "Failed to load agent configuration" to present an actionable storage-related error message.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cc53a92fc1a6cc610b8ccb793810911bc8bd81a2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->