### PR TITLE
refactor: fix memory leak and deduplicate OpenAI web search code

### DIFF
--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -48,7 +48,7 @@ import { OPENAI_CHAT_FINISH } from './types/StopReasonTypes';
 import { toOpenAIResponseTools } from './toolConversion';
 import { ModelHandler } from './ModelHandler';
 import {
-  extractDomain,
+  buildOpenAIWebSearchResult,
   extractOpenAIWebSearchResults,
   isOpenAIWebSearchCall,
   type ServerToolExtractionResult,
@@ -1599,37 +1599,10 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
 
   /**
    * Emit web search result to progress view during streaming.
-   * Extracts query and sources from the OpenAI web search item.
+   * Uses shared helper for consistent WebSearchResult construction.
    */
   private emitOpenAIWebSearch(item: ResponseFunctionWebSearch): void {
-    // Extract action with query and sources if available
-    const action = (
-      item as ResponseFunctionWebSearch & {
-        action?: ResponseFunctionWebSearch.Search;
-      }
-    ).action;
-
-    const query = action?.query ?? '';
-    const sources = action?.sources ?? [];
-
-    const entries = sources.map((s) => ({
-      url: s.url,
-      title: '',
-      domain: extractDomain(s.url),
-    }));
-
-    this.emitWebSearchResult({
-      query,
-      results: entries,
-      provider: 'openai',
-      callId: item.id,
-      status:
-        item.status === 'completed'
-          ? 'completed'
-          : item.status === 'failed'
-            ? 'failed'
-            : 'in_progress',
-    });
+    this.emitWebSearchResult(buildOpenAIWebSearchResult(item));
   }
 
   /**

--- a/src/agent/modelHandlers/support/AnthropicStreamHandler.ts
+++ b/src/agent/modelHandlers/support/AnthropicStreamHandler.ts
@@ -46,6 +46,8 @@ interface AnthropicStreamState {
   pendingSearches: Map<string, { index: number; input: string }>;
   /** Track emitted search IDs to prevent duplicate logging in flow */
   emittedSearchIds: Set<string>;
+  /** Flag to prevent processing events after finalize */
+  finalized: boolean;
 }
 
 /**
@@ -87,6 +89,7 @@ export class AnthropicStreamHandler {
     lastBlockIndex: -1,
     pendingSearches: new Map(),
     emittedSearchIds: new Set(),
+    finalized: false,
   };
 
   constructor(
@@ -114,8 +117,12 @@ export class AnthropicStreamHandler {
   /**
    * Finalizes all remaining streams and clears state.
    * Call this after stream.finalMessage() completes.
+   * Sets finalized flag to prevent processing any subsequent events.
    */
   finalize(): void {
+    // Set flag first to prevent processing any events that arrive during cleanup
+    this.state.finalized = true;
+
     // Finalize any remaining thinking streams
     for (const s of this.thinkingStreams.values()) {
       s.finalize();
@@ -133,8 +140,14 @@ export class AnthropicStreamHandler {
 
   /**
    * Handles a single stream event.
+   * Ignores events if handler has been finalized.
    */
   private handleStreamEvent(event: BetaRawMessageStreamEvent): void {
+    // Ignore events after finalization to prevent processing stale events
+    if (this.state.finalized) {
+      return;
+    }
+
     if (event.type === 'content_block_start') {
       this.handleBlockStart(event);
     } else if (event.type === 'content_block_delta') {

--- a/src/agent/modelHandlers/types/ServerToolTypes.ts
+++ b/src/agent/modelHandlers/types/ServerToolTypes.ts
@@ -227,6 +227,56 @@ interface ResponseFunctionWebSearchWithAction extends ResponseFunctionWebSearch 
 }
 
 /**
+ * Build a WebSearchResult from a single OpenAI web search item.
+ * Shared helper used by both streaming emission and final response extraction.
+ *
+ * Handles both cases:
+ * - Default API response: only id, status, type (no action/sources)
+ * - With include sources: action field contains query and sources
+ */
+export function buildOpenAIWebSearchResult(
+  item: ResponseFunctionWebSearch,
+): WebSearchResult {
+  const searchItem = item as ResponseFunctionWebSearchWithAction;
+
+  // Determine status using SDK's status type
+  const status: WebSearchResult['status'] =
+    searchItem.status === 'completed'
+      ? 'completed'
+      : searchItem.status === 'failed'
+        ? 'failed'
+        : 'in_progress';
+
+  const action = searchItem.action;
+
+  // Handle case when action is not present (default API response)
+  if (!action) {
+    return {
+      query: '',
+      results: [],
+      provider: 'openai',
+      callId: searchItem.id,
+      status,
+    };
+  }
+
+  // Handle case when action is present (include sources was used)
+  const entries: WebSearchResultEntry[] = (action.sources ?? []).map((s) => ({
+    url: s.url,
+    title: '', // OpenAI sources don't include titles in basic response
+    domain: extractDomain(s.url),
+  }));
+
+  return {
+    query: action.query ?? '',
+    results: entries,
+    provider: 'openai',
+    callId: searchItem.id,
+    status,
+  };
+}
+
+/**
  * Extract web search results from OpenAI Responses API output.
  * Uses SDK's ResponseFunctionWebSearch type for proper typing.
  *
@@ -245,48 +295,7 @@ export function extractOpenAIWebSearchResults(
       continue;
     }
 
-    // item is now properly typed as ResponseFunctionWebSearch
-    // Cast to extended type that may include action field
-    const searchItem = item as ResponseFunctionWebSearchWithAction;
-
-    // Determine status using SDK's status type
-    const status: WebSearchResult['status'] =
-      searchItem.status === 'completed'
-        ? 'completed'
-        : searchItem.status === 'failed'
-          ? 'failed'
-          : 'in_progress';
-
-    // Handle case when action is not present (default API response)
-    const action = searchItem.action;
-    if (!action) {
-      // Web search occurred but sources not included in response
-      // Return a result indicating the search happened
-      results.push({
-        query: '',
-        results: [],
-        provider: 'openai',
-        callId: searchItem.id,
-        status,
-      });
-      continue;
-    }
-
-    // Handle case when action is present (include sources was used)
-    // action.type is always 'search' per SDK's ResponseFunctionWebSearch.Search
-    const entries: WebSearchResultEntry[] = (action.sources ?? []).map((s) => ({
-      url: s.url,
-      title: '', // OpenAI sources don't include titles in basic response
-      domain: extractDomain(s.url),
-    }));
-
-    results.push({
-      query: action.query ?? '',
-      results: entries,
-      provider: 'openai',
-      callId: searchItem.id,
-      status,
-    });
+    results.push(buildOpenAIWebSearchResult(item));
   }
 
   return results;


### PR DESCRIPTION
AnthropicStreamHandler:
- Add finalized flag to prevent processing events after finalize()
- Check flag at start of handleStreamEvent() to ignore stale events

OpenAI web search:
- Extract shared buildOpenAIWebSearchResult() helper in ServerToolTypes
- Simplify emitOpenAIWebSearch() to use shared helper
- Simplify extractOpenAIWebSearchResults() to use shared helper
- Single source of truth for WebSearchResult construction