### PR TITLE
fix(types): improve type resolution and eliminate unsafe casts

### DIFF
--- a/src/agent/core/AgentState.ts
+++ b/src/agent/core/AgentState.ts
@@ -14,6 +14,12 @@ import {
   type UsageSummary,
   type NativeUsagePayload,
 } from './RunUsageAccumulator';
+import {
+  UsageSummarySchema,
+  NativeUsagePayloadSchema,
+  isOpenAIUsageFormat,
+  isAnthropicUsageFormat,
+} from './ResponseUsage';
 
 // Type imports
 import type {
@@ -93,11 +99,11 @@ function migrateLegacyUsageSummary(
 function isAnthropicUsage(
   usage: UsageSummary,
 ): usage is AnthropicAPIResponseUsage {
-  return usage !== null && 'input_tokens' in usage;
+  return isAnthropicUsageFormat(usage);
 }
 
 function isOpenAIUsage(usage: UsageSummary): usage is OpenAIAPIResponseUsage {
-  return usage !== null && 'prompt_tokens' in usage;
+  return isOpenAIUsageFormat(usage);
 }
 
 export const ConversationRoundStateSnapshotSchema = z.object({
@@ -108,8 +114,9 @@ export const ConversationRoundStateSnapshotSchema = z.object({
   // New: store normalized usage directly (nullish for backward compat with old saved states)
   normalizedUsage: NormalizedUsageSchema.nullish(),
   // Legacy fields for backward compatibility (deprecated)
-  usageSummary: z.custom<UsageSummary>().nullable().optional(),
-  nativeUsage: z.custom<NativeUsagePayload>().nullable().optional(),
+  // Using proper schemas instead of z.custom<T>() for runtime validation
+  usageSummary: UsageSummarySchema.optional(),
+  nativeUsage: NativeUsagePayloadSchema.nullable().optional(),
   provider: UsageProviderSchema.nullable().optional(),
 });
 

--- a/src/agent/core/AgentWorkspaceState.ts
+++ b/src/agent/core/AgentWorkspaceState.ts
@@ -141,17 +141,31 @@ export class FileInteractionState {
     edits?: { path?: string; added?: number; removed?: number }[];
   }): FileInteractionState {
     const state = new FileInteractionState();
+    state.restoreFrom(data);
+    return state;
+  }
+
+  /**
+   * Restores state from serialized data, clearing existing state first.
+   * Used for in-place restoration without creating a new instance.
+   */
+  restoreFrom(data: {
+    readFiles?: string[];
+    edits?: { path?: string; added?: number; removed?: number }[];
+  }): void {
+    // Clear existing state
+    this.readFiles.clear();
+    this.edits.clear();
     // Restore read files
-    (data.readFiles ?? []).forEach((path) => state.recordRead(path));
+    (data.readFiles ?? []).forEach((path) => this.recordRead(path));
     // Restore edits directly (absolute values, not deltas)
     (data.edits ?? []).forEach((entry) => {
       if (!entry?.path) return;
-      state.edits.set(entry.path, {
+      this.edits.set(entry.path, {
         added: entry.added ?? 0,
         removed: entry.removed ?? 0,
       });
     });
-    return state;
   }
 }
 
@@ -278,16 +292,14 @@ export class AgentWorkspaceState {
     state.reasoning.thinkingBlocks.push(...snapshot.reasoning.thinkingBlocks);
     state.reasoning.thinkingAdded = snapshot.reasoning.thinkingAdded;
     state.document.texcountStats = snapshot.document.texcountStats;
-    // Restore file interactions directly using fromJSON (single source of truth)
+    // Restore file interactions in-place using restoreFrom
     const interactions =
       snapshot.interactions ??
       ({
         readFiles: [],
         edits: [],
       } satisfies AgentWorkspaceSnapshot['interactions']);
-    const restored = FileInteractionState.fromJSON(interactions);
-    // Replace the default instance with the restored state
-    (state as any).interactions = restored;
+    state.interactions.restoreFrom(interactions);
     return state;
   }
 }

--- a/src/agent/core/ResponseUsage.ts
+++ b/src/agent/core/ResponseUsage.ts
@@ -1,4 +1,5 @@
 // Third-party imports
+import { z } from 'zod';
 import type {
   Usage as AnthropicUsage,
   CacheCreation,
@@ -99,4 +100,198 @@ export interface AnthropicAPIResponseUsage extends ResponseUsageBase {
   service_tier: 'standard' | 'priority' | 'batch' | null;
   // Optional field surfaced by compatibility layers that expose tool-use costs.
   tool_use_tokens?: number;
+}
+
+// ============================================================================
+// Zod Schemas for Runtime Validation
+// ============================================================================
+
+/** Schema for base response usage metrics. */
+export const ResponseUsageBaseSchema = z.object({
+  totalInputTokens: z.number(),
+  totalOutputTokens: z.number(),
+  percentageCached: z.number(),
+  cost: z.number(),
+  responseTime: z.number(),
+});
+
+/** Schema for prompt token details (OpenAI). */
+const PromptTokensDetailsSchema = z
+  .object({
+    cached_tokens: z.number().optional(),
+  })
+  .passthrough()
+  .optional();
+
+/** Schema for completion token details (OpenAI). */
+const CompletionTokensDetailsSchema = z
+  .object({
+    reasoning_tokens: z.number().optional(),
+    accepted_prediction_tokens: z.number().nullable().optional(),
+    rejected_prediction_tokens: z.number().nullable().optional(),
+  })
+  .passthrough()
+  .optional();
+
+/** Schema for cache creation (Anthropic). */
+const CacheCreationSchema = z
+  .object({
+    ephemeral_1m_input_tokens: z.number().optional(),
+    ephemeral_5m_input_tokens: z.number().optional(),
+  })
+  .passthrough()
+  .nullable();
+
+/** Schema for server tool usage (Anthropic). */
+const ServerToolUsageSchema = z
+  .object({
+    web_search_requests: z.number().optional(),
+  })
+  .passthrough()
+  .nullable();
+
+/**
+ * Schema for UsageSummary (legacy format).
+ * Uses type guards for validation to match the interface types exactly.
+ * More permissive than strict schema validation for backward compatibility.
+ */
+export const UsageSummarySchema = z.custom<
+  OpenAIAPIResponseUsage | AnthropicAPIResponseUsage | null
+>(
+  (value): value is OpenAIAPIResponseUsage | AnthropicAPIResponseUsage | null => {
+    if (value === null) return true;
+    if (typeof value !== 'object') return false;
+    // Check for discriminating fields
+    const obj = value as Record<string, unknown>;
+    // OpenAI format has prompt_tokens
+    if ('prompt_tokens' in obj && typeof obj.prompt_tokens === 'number') {
+      return true;
+    }
+    // Anthropic format has input_tokens
+    if ('input_tokens' in obj && typeof obj.input_tokens === 'number') {
+      return true;
+    }
+    return false;
+  },
+  {
+    message: 'Invalid UsageSummary format: expected OpenAI or Anthropic usage object or null',
+  },
+);
+
+/**
+ * Type guard to check if usage is OpenAI format.
+ */
+export function isOpenAIUsageFormat(
+  usage: unknown,
+): usage is OpenAIAPIResponseUsage {
+  return (
+    typeof usage === 'object' &&
+    usage !== null &&
+    'prompt_tokens' in usage &&
+    typeof (usage as Record<string, unknown>).prompt_tokens === 'number'
+  );
+}
+
+/**
+ * Type guard to check if usage is Anthropic format.
+ */
+export function isAnthropicUsageFormat(
+  usage: unknown,
+): usage is AnthropicAPIResponseUsage {
+  return (
+    typeof usage === 'object' &&
+    usage !== null &&
+    'input_tokens' in usage &&
+    typeof (usage as Record<string, unknown>).input_tokens === 'number'
+  );
+}
+
+// ----------------------------------------------------------------------------
+// Native Usage Payload Schemas (raw API responses)
+// ----------------------------------------------------------------------------
+
+/**
+ * Schema for NativeUsagePayload union.
+ * Uses type guard validation to match the interface types exactly.
+ * More permissive than strict schema validation for backward compatibility.
+ */
+export const NativeUsagePayloadSchema = z.custom<NativeUsagePayload>(
+  (value): value is NativeUsagePayload => {
+    if (typeof value !== 'object' || value === null) return false;
+    const obj = value as Record<string, unknown>;
+
+    // OpenAI Chat Completions (has prompt_tokens and completion_tokens)
+    if (
+      'prompt_tokens' in obj &&
+      typeof obj.prompt_tokens === 'number' &&
+      'completion_tokens' in obj &&
+      typeof obj.completion_tokens === 'number'
+    ) {
+      return true;
+    }
+
+    // OpenAI Responses API or Anthropic (has input_tokens and output_tokens)
+    if (
+      'input_tokens' in obj &&
+      typeof obj.input_tokens === 'number' &&
+      'output_tokens' in obj &&
+      typeof obj.output_tokens === 'number'
+    ) {
+      return true;
+    }
+
+    // Google Gemini (has promptTokenCount or candidatesTokenCount)
+    if (
+      ('promptTokenCount' in obj && typeof obj.promptTokenCount === 'number') ||
+      ('candidatesTokenCount' in obj &&
+        typeof obj.candidatesTokenCount === 'number') ||
+      ('totalTokenCount' in obj && typeof obj.totalTokenCount === 'number')
+    ) {
+      return true;
+    }
+
+    return false;
+  },
+  {
+    message:
+      'Invalid NativeUsagePayload format: expected usage object from OpenAI, Anthropic, or Google',
+  },
+);
+
+/**
+ * Identifies which provider a native usage payload belongs to.
+ */
+export function identifyNativeUsageProvider(
+  usage: unknown,
+): 'openai-chat' | 'openai-response' | 'anthropic' | 'google' | null {
+  if (typeof usage !== 'object' || usage === null) return null;
+
+  const obj = usage as Record<string, unknown>;
+
+  // Check for Google (has promptTokenCount)
+  if ('promptTokenCount' in obj || 'candidatesTokenCount' in obj) {
+    return 'google';
+  }
+
+  // Check for OpenAI Responses API (has input_tokens but no prompt_tokens)
+  if (
+    'input_tokens' in obj &&
+    'output_tokens' in obj &&
+    !('prompt_tokens' in obj) &&
+    !('cache_read_input_tokens' in obj)
+  ) {
+    return 'openai-response';
+  }
+
+  // Check for Anthropic (has input_tokens and potentially cache fields)
+  if ('input_tokens' in obj && 'output_tokens' in obj) {
+    return 'anthropic';
+  }
+
+  // Check for OpenAI Chat (has prompt_tokens and completion_tokens)
+  if ('prompt_tokens' in obj && 'completion_tokens' in obj) {
+    return 'openai-chat';
+  }
+
+  return null;
 }

--- a/src/agent/modelHandlers/types/ProviderMessageSchema.ts
+++ b/src/agent/modelHandlers/types/ProviderMessageSchema.ts
@@ -1,0 +1,237 @@
+/**
+ * Zod schemas and type guards for provider message validation.
+ *
+ * This module provides proper runtime validation for the ProviderMessage union type,
+ * which represents messages from different AI providers (OpenAI, Anthropic, Google).
+ *
+ * The schemas here are intentionally permissive for the message content to allow
+ * provider-specific extensions, but they validate the discriminating fields that
+ * identify which provider format a message belongs to.
+ */
+
+// Third-party imports
+import { z } from 'zod';
+
+// Type imports
+import type { ProviderMessage } from './ProviderMessage';
+
+/**
+ * OpenAI Chat Completion message roles.
+ * @see https://platform.openai.com/docs/api-reference/chat/create
+ */
+const OPENAI_CHAT_ROLES = ['system', 'user', 'assistant', 'tool', 'function', 'developer'] as const;
+
+/**
+ * Anthropic message roles.
+ * @see https://docs.anthropic.com/en/api/messages
+ */
+const ANTHROPIC_ROLES = ['user', 'assistant'] as const;
+
+/**
+ * Google Gemini content roles.
+ * @see https://ai.google.dev/api/generate-content
+ */
+const GOOGLE_ROLES = ['user', 'model', 'function', 'system'] as const;
+
+/**
+ * OpenAI Responses API item types.
+ * @see https://platform.openai.com/docs/api-reference/responses
+ */
+const OPENAI_RESPONSE_ITEM_TYPES = [
+  'message',
+  'function_call',
+  'function_call_output',
+  'item_reference',
+  'file_search_call',
+  'computer_call',
+  'computer_call_output',
+  'reasoning',
+  'image_generation_call',
+  'code_interpreter_call',
+  'local_shell_call',
+  'local_shell_call_output',
+  'mcp_list_tools',
+  'mcp_call_tool',
+  'mcp_call_tool_result',
+  'mcp_list_resources',
+  'mcp_read_resource',
+  'web_search_call',
+] as const;
+
+/**
+ * Schema for OpenAI Chat Completion messages.
+ * Validates the structure of ChatCompletionMessageParam.
+ */
+export const OpenAIChatMessageSchema = z.object({
+  role: z.enum(OPENAI_CHAT_ROLES),
+  content: z.unknown(), // Content varies by role
+  name: z.string().optional(),
+  tool_calls: z.array(z.unknown()).optional(),
+  tool_call_id: z.string().optional(),
+  function_call: z.unknown().optional(),
+});
+
+/**
+ * Schema for OpenAI Responses API items.
+ * Validates the structure of ResponseInputItem.
+ */
+export const OpenAIResponseItemSchema = z.object({
+  type: z.enum(OPENAI_RESPONSE_ITEM_TYPES),
+  id: z.string().optional(),
+  // Other fields vary by type
+}).passthrough();
+
+/**
+ * Schema for Anthropic messages.
+ * Validates the structure of MessageParam.
+ */
+export const AnthropicMessageSchema = z.object({
+  role: z.enum(ANTHROPIC_ROLES),
+  content: z.union([
+    z.string(),
+    z.array(z.object({
+      type: z.string(),
+    }).passthrough()),
+  ]),
+});
+
+/**
+ * Schema for Google Gemini content.
+ * Validates the structure of Content.
+ */
+export const GoogleContentSchema = z.object({
+  role: z.enum(GOOGLE_ROLES).optional(),
+  parts: z.array(z.object({}).passthrough()),
+});
+
+/**
+ * Type guard to check if a message is an OpenAI Responses API item.
+ * ResponseInputItem is distinguished by having a `type` field.
+ */
+export function isOpenAIResponseItem(value: unknown): boolean {
+  if (typeof value !== 'object' || value === null) return false;
+  const obj = value as Record<string, unknown>;
+  return (
+    typeof obj.type === 'string' &&
+    OPENAI_RESPONSE_ITEM_TYPES.includes(obj.type as typeof OPENAI_RESPONSE_ITEM_TYPES[number])
+  );
+}
+
+/**
+ * Type guard to check if a message is an OpenAI Chat Completion message.
+ * ChatCompletionMessageParam has `role` but NOT `type` or `parts`.
+ */
+export function isOpenAIChatMessage(value: unknown): boolean {
+  if (typeof value !== 'object' || value === null) return false;
+  const obj = value as Record<string, unknown>;
+  return (
+    typeof obj.role === 'string' &&
+    OPENAI_CHAT_ROLES.includes(obj.role as typeof OPENAI_CHAT_ROLES[number]) &&
+    !('type' in obj) && // Not a ResponseInputItem
+    !('parts' in obj) // Not Google Content
+  );
+}
+
+/**
+ * Type guard to check if a message is an Anthropic message.
+ * MessageParam has `role` (user/assistant only) and `content` (string or array of blocks).
+ */
+export function isAnthropicMessage(value: unknown): boolean {
+  if (typeof value !== 'object' || value === null) return false;
+  const obj = value as Record<string, unknown>;
+  return (
+    typeof obj.role === 'string' &&
+    ANTHROPIC_ROLES.includes(obj.role as typeof ANTHROPIC_ROLES[number]) &&
+    'content' in obj &&
+    !('parts' in obj) && // Not Google Content
+    !('type' in obj) // Not ResponseInputItem
+  );
+}
+
+/**
+ * Type guard to check if a message is Google Gemini content.
+ * Content is distinguished by having a `parts` array.
+ */
+export function isGoogleContent(value: unknown): boolean {
+  if (typeof value !== 'object' || value === null) return false;
+  const obj = value as Record<string, unknown>;
+  return (
+    Array.isArray(obj.parts) &&
+    (obj.role === undefined ||
+      (typeof obj.role === 'string' &&
+        GOOGLE_ROLES.includes(obj.role as typeof GOOGLE_ROLES[number])))
+  );
+}
+
+/**
+ * Validates that a value is a valid ProviderMessage.
+ * Checks against all supported provider message formats.
+ */
+export function isValidProviderMessage(value: unknown): value is ProviderMessage {
+  return (
+    isOpenAIResponseItem(value) ||
+    isOpenAIChatMessage(value) ||
+    isAnthropicMessage(value) ||
+    isGoogleContent(value)
+  );
+}
+
+/**
+ * Identifies which provider format a message belongs to.
+ * Returns null if the message format is not recognized.
+ */
+export function identifyMessageProvider(
+  value: unknown,
+): 'openai-chat' | 'openai-response' | 'anthropic' | 'google' | null {
+  if (isOpenAIResponseItem(value)) return 'openai-response';
+  if (isOpenAIChatMessage(value)) return 'openai-chat';
+  if (isAnthropicMessage(value)) return 'anthropic';
+  if (isGoogleContent(value)) return 'google';
+  return null;
+}
+
+/**
+ * Zod schema for ProviderMessage with proper validation.
+ *
+ * This schema validates that the value matches one of the supported provider
+ * message formats, providing better error messages than a simple type check.
+ */
+export const ProviderMessageSchema = z.custom<ProviderMessage>(
+  (value): value is ProviderMessage => {
+    if (typeof value !== 'object' || value === null) {
+      return false;
+    }
+    return isValidProviderMessage(value);
+  },
+  {
+    message:
+      'Invalid provider message format. Expected OpenAI ChatCompletionMessageParam, ' +
+      'OpenAI ResponseInputItem, Anthropic MessageParam, or Google Content.',
+  },
+);
+
+/**
+ * Parses and validates a provider message, returning detailed error info on failure.
+ */
+export function parseProviderMessage(value: unknown): {
+  success: true;
+  data: ProviderMessage;
+  provider: ReturnType<typeof identifyMessageProvider>;
+} | {
+  success: false;
+  error: string;
+} {
+  const provider = identifyMessageProvider(value);
+  if (provider === null) {
+    const preview = JSON.stringify(value)?.slice(0, 100) ?? 'unknown';
+    return {
+      success: false,
+      error: `Unrecognized message format: ${preview}...`,
+    };
+  }
+  return {
+    success: true,
+    data: value as ProviderMessage,
+    provider,
+  };
+}

--- a/src/agent/remote/RemoteAgentLoader.ts
+++ b/src/agent/remote/RemoteAgentLoader.ts
@@ -8,8 +8,8 @@ import {
   AgentDefinitionSchema,
 } from '@agent/core/AgentDataclass';
 import { isMultipleVariant, getMultipleName } from '@agent/index/agentRegistry';
+import { resolveToolDefinitionsAsync } from '@agent/utils/toolResolution';
 import * as logger from '@logger/logUtils';
-import type { ToolDefinition } from '@model';
 import { SupabaseClient } from '@/auth/SupabaseClient';
 import { SUPABASE_CONFIG } from '@/auth/config';
 
@@ -156,20 +156,8 @@ export class RemoteAgentLoader {
 
         // Resolve tool names to definitions
         if (Array.isArray(settings.tools)) {
-          const { DEFAULT_TOOL_REGISTRY } = await import('@tools/registry');
-          settings.tools = (settings.tools as any[]).map((item) => {
-            if (typeof item === 'string') {
-              const tool = DEFAULT_TOOL_REGISTRY[item];
-              if (!tool) {
-                logger.warn(CHANNEL, `Tool "${item}" not found in registry`);
-                return { name: item } as ToolDefinition;
-              }
-              return tool.definition;
-            }
-            if (!DEFAULT_TOOL_REGISTRY[item.name]) {
-              logger.warn(CHANNEL, `Tool "${item.name}" not found in registry`);
-            }
-            return item as ToolDefinition;
+          settings.tools = await resolveToolDefinitionsAsync(settings.tools, {
+            warn: logger.warn,
           });
         }
 

--- a/src/agent/runtime/agentLoad.ts
+++ b/src/agent/runtime/agentLoad.ts
@@ -21,11 +21,9 @@ import {
   AgentType,
   parseAgentSetting,
 } from '@agent/core/AgentDataclass';
+import { resolveToolDefinitionsAsync } from '@agent/utils/toolResolution';
 import { toErrorMessage } from '@common/errors/errorHandlingUtils';
 import * as logger from '@logger/logUtils';
-
-// Type imports
-import type { ToolDefinition } from '@model';
 
 // Internal imports
 import { AbsoluteFS } from '@utils/files';
@@ -167,20 +165,8 @@ export async function loadAgentSettingAndPrompts(
 
     // Resolve tool names to definitions
     if (Array.isArray(settings.tools)) {
-      const { DEFAULT_TOOL_REGISTRY } = await import('@tools/registry');
-      settings.tools = (settings.tools as any[]).map((item) => {
-        if (typeof item === 'string') {
-          const tool = DEFAULT_TOOL_REGISTRY[item];
-          if (!tool) {
-            logger.warn(CHANNEL, `Tool "${item}" not found in registry`);
-            return { name: item } as ToolDefinition;
-          }
-          return tool.definition;
-        }
-        if (!DEFAULT_TOOL_REGISTRY[item.name]) {
-          logger.warn(CHANNEL, `Tool "${item.name}" not found in registry`);
-        }
-        return item as ToolDefinition;
+      settings.tools = await resolveToolDefinitionsAsync(settings.tools, {
+        warn: logger.warn,
       });
     }
 

--- a/src/agent/toolUse/ToolUseSnapshotTypes.ts
+++ b/src/agent/toolUse/ToolUseSnapshotTypes.ts
@@ -4,20 +4,13 @@ import { z } from 'zod';
 // Local imports - agent
 import { AgentConfigSchema, type AgentConfig } from '@agent/core/AgentConfig';
 import { AgentSharedStoreSnapshotSchema } from '@agent/core/AgentSharedStore';
+import { ProviderMessageSchema } from '@agent/modelHandlers/types/ProviderMessageSchema';
 // Type imports
 import type { AgentSharedStore } from '@agent/core/AgentSharedStore';
 import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
 import type { ExecutionId, StreamTabId } from '@agent/types/IdentifierTypes';
 
 export const TOOL_USE_SNAPSHOT_VERSION = 1;
-
-const ProviderMessageSchema = z.custom<ProviderMessage>(
-  (value): value is ProviderMessage =>
-    typeof value === 'object' && value !== null,
-  {
-    error: 'messages must contain provider message objects',
-  },
-);
 
 /**
  * We use z.object() instead of z.strictObject() to remain backward compatible

--- a/src/agent/utils/messageSkeletonUtils.ts
+++ b/src/agent/utils/messageSkeletonUtils.ts
@@ -7,6 +7,9 @@ import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage
 // Local imports
 import { MESSAGE_PREVIEW_LENGTH } from '@utils/config';
 
+/** Skeleton output type - simplified representation of message structure */
+type MessageSkeleton = Record<string, unknown> | null | string;
+
 /**
  * Creates a skeleton representation of a message object for debugging.
  * Preserves structure while truncating content to avoid cluttering logs.
@@ -17,53 +20,62 @@ import { MESSAGE_PREVIEW_LENGTH } from '@utils/config';
 export function messageToSkeleton(
   message: ProviderMessage | ProviderMessage[],
   maxContentLength: number = MESSAGE_PREVIEW_LENGTH,
-): any {
+): MessageSkeleton | MessageSkeleton[] {
   if (!message) {
     return null;
   }
 
   if (Array.isArray(message)) {
-    return message.map((item) => messageToSkeleton(item, maxContentLength));
+    // Each item in the array produces a single MessageSkeleton (not nested arrays)
+    return message.map(
+      (item) => messageToSkeleton(item, maxContentLength) as MessageSkeleton,
+    );
   }
 
   if (typeof message !== 'object') {
     return typeof message;
   }
 
-  const result: any = {};
+  const result: Record<string, unknown> = {};
 
   for (const [key, value] of Object.entries(message)) {
     if (key === 'content') {
       if (Array.isArray(value)) {
         // Handle content arrays (common in Anthropic responses)
-        result[key] = value.map((item: any) => {
-          if (typeof item === 'object') {
-            const itemSkeleton: any = { type: item.type };
+        result[key] = value.map((item: unknown) => {
+          if (typeof item === 'object' && item !== null) {
+            const itemObj = item as Record<string, unknown>;
+            const itemSkeleton: Record<string, unknown> = { type: itemObj.type };
 
-            if (item.text) {
+            const text = itemObj.text;
+            if (typeof text === 'string') {
               const truncatedText =
-                item.text.length > maxContentLength
-                  ? `${item.text.substring(0, maxContentLength)}... (${item.text.length} chars)`
-                  : item.text;
+                text.length > maxContentLength
+                  ? `${text.substring(0, maxContentLength)}... (${text.length} chars)`
+                  : text;
               itemSkeleton.text = truncatedText;
             }
 
-            if (item.source) {
-              itemSkeleton.source = { type: item.source.type };
-              if (item.source.media_type) {
-                itemSkeleton.source.media_type = item.source.media_type;
+            const source = itemObj.source as Record<string, unknown> | undefined;
+            if (source && typeof source === 'object') {
+              const sourceInfo: Record<string, unknown> = { type: source.type };
+              if (source.media_type) {
+                sourceInfo.media_type = source.media_type;
               }
-              if (item.source.data) {
-                itemSkeleton.source.data = `[base64 data: ${item.source.data.length} chars]`;
+              const data = source.data;
+              if (typeof data === 'string') {
+                sourceInfo.data = `[base64 data: ${data.length} chars]`;
               }
+              itemSkeleton.source = sourceInfo;
             }
 
-            if (item.cache_control) {
-              itemSkeleton.cache_control = item.cache_control;
+            if (itemObj.cache_control) {
+              itemSkeleton.cache_control = itemObj.cache_control;
             }
 
-            if (item.thinking) {
-              itemSkeleton.thinking = `[thinking data: ${item.thinking.length} chars]`;
+            const thinking = itemObj.thinking;
+            if (typeof thinking === 'string') {
+              itemSkeleton.thinking = `[thinking data: ${thinking.length} chars]`;
             }
 
             return itemSkeleton;
@@ -93,9 +105,11 @@ export function messageToSkeleton(
       value !== undefined
     ) {
       // Recursively process nested objects
-      // Note: We pass 'any' here since nested properties within a message
-      // are not necessarily ProviderMessage instances themselves
-      result[key] = messageToSkeleton(value as any, maxContentLength);
+      // Cast to ProviderMessage for recursive call - safe because we're creating skeletons
+      result[key] = messageToSkeleton(
+        value as ProviderMessage,
+        maxContentLength,
+      );
     } else {
       // Pass through primitive values
       result[key] = value;

--- a/src/agent/utils/toolResolution.ts
+++ b/src/agent/utils/toolResolution.ts
@@ -1,0 +1,88 @@
+/**
+ * Shared utility for resolving tool names to tool definitions.
+ *
+ * This module provides a single source of truth for tool resolution logic,
+ * used by both local agent loading and remote agent loading.
+ */
+
+// Type imports
+import type { ToolDefinition } from '@model';
+import type { ITool } from '@agent/core/ToolTypes';
+
+/** Logger channel for tool resolution */
+const CHANNEL = 'toolResolution';
+
+/** Options for tool resolution */
+export interface ResolveToolsOptions {
+  /** Logger function for warnings (optional, defaults to console.warn) */
+  warn?: (channel: string, message: string) => void;
+}
+
+/**
+ * Represents a tool reference in agent configuration.
+ * Can be either a string name or an inline tool definition.
+ */
+export type ToolReference = string | ToolDefinition;
+
+/**
+ * Simple tool lookup interface - accepts plain Record<string, ITool>.
+ */
+type ToolLookup = Record<string, ITool | undefined>;
+
+/**
+ * Resolves an array of tool references to tool definitions.
+ *
+ * Tool references can be:
+ * - String names that map to registered tools
+ * - Inline tool definitions
+ *
+ * @param tools - Array of tool references (strings or definitions)
+ * @param registry - Tool registry record to look up tool definitions
+ * @param options - Optional configuration for logging
+ * @returns Array of resolved tool definitions
+ */
+export function resolveToolDefinitions(
+  tools: ToolReference[],
+  registry: ToolLookup,
+  options?: ResolveToolsOptions,
+): ToolDefinition[] {
+  const warn = options?.warn ?? ((_ch, msg) => console.warn(msg));
+
+  return tools.map((item): ToolDefinition => {
+    if (typeof item === 'string') {
+      const tool = registry[item];
+      if (!tool) {
+        warn(CHANNEL, `Tool "${item}" not found in registry`);
+        // Return a stub definition for unknown tools
+        // This preserves the tool name so errors are clear downstream
+        return { name: item };
+      }
+      return tool.definition;
+    }
+
+    // Item is already a tool definition object
+    const toolDef = item as ToolDefinition;
+    if (!registry[toolDef.name]) {
+      warn(CHANNEL, `Tool "${toolDef.name}" not found in registry`);
+    }
+    return toolDef;
+  });
+}
+
+/**
+ * Lazily loads the default tool registry and resolves tools.
+ *
+ * This is a convenience function that handles the dynamic import of the
+ * tool registry, useful for avoiding circular dependencies.
+ *
+ * @param tools - Array of tool references (strings or definitions)
+ * @param options - Optional configuration for logging
+ * @returns Promise resolving to array of tool definitions
+ */
+export async function resolveToolDefinitionsAsync(
+  tools: ToolReference[],
+  options?: ResolveToolsOptions,
+): Promise<ToolDefinition[]> {
+  const { DEFAULT_TOOL_REGISTRY } = await import('@tools/registry');
+  return resolveToolDefinitions(tools, DEFAULT_TOOL_REGISTRY, options);
+}

--- a/src/commands/files/fileSelectionCommands.ts
+++ b/src/commands/files/fileSelectionCommands.ts
@@ -19,10 +19,13 @@ interface PickerOptions<Many extends boolean> {
   filters: () => { [name: string]: string[] };
 }
 
+/** Return type for the file picker based on the allowMany option */
+type PickerResult<Many extends boolean> = Many extends true
+  ? string[] | null
+  : string | null;
+
 function createPicker<Many extends boolean>(options: PickerOptions<Many>) {
-  return async (
-    currentFile?: string,
-  ): Promise<Many extends true ? string[] | null : string | null> => {
+  return async (currentFile?: string): Promise<PickerResult<Many>> => {
     try {
       const baseOpts = {
         currentFile,
@@ -35,7 +38,9 @@ function createPicker<Many extends boolean>(options: PickerOptions<Many>) {
         : await selectFile(baseOpts);
 
       if (!result) {
-        return null as any;
+        // TypeScript can't narrow conditional types, so we use a type assertion
+        // This is safe because null is valid for both branches of PickerResult
+        return null as PickerResult<Many>;
       }
 
       const message = Array.isArray(result)
@@ -43,10 +48,11 @@ function createPicker<Many extends boolean>(options: PickerOptions<Many>) {
         : `Selected file: ${result}`;
       showInfoMessage(message);
       logger.info(CHANNEL, message);
-      return result as any;
+      // Type assertion is safe because selectFiles returns string[] and selectFile returns string
+      return result as PickerResult<Many>;
     } catch (err) {
       await showLoggedErrorMessage(CHANNEL, 'Error selecting files', err);
-      return null as any;
+      return null as PickerResult<Many>;
     }
   };
 }


### PR DESCRIPTION
- Add ProviderMessageSchema with proper discriminated union validation
  for OpenAI, Anthropic, and Google message formats
- Extract shared toolResolution utility to eliminate code duplication
  between agentLoad.ts and RemoteAgentLoader.ts
- Add proper schemas for UsageSummary and NativeUsagePayload with
  type guards for backward compatibility
- Replace `as any` casts with proper type assertions in:
  - AgentWorkspaceState (added restoreFrom method)
  - fileSelectionCommands (added PickerResult type)
  - messageSkeletonUtils (fixed recursive typing)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Zod schemas and type guards for provider messages and usage, extracts shared tool resolution, and tightens typing across state and file picker to eliminate unsafe casts.
> 
> - **Types/Validation**:
>   - **Provider Messages**: Add `ProviderMessageSchema` with guards (`isOpenAIResponseItem`, `isOpenAIChatMessage`, `isAnthropicMessage`, `isGoogleContent`) and `identifyMessageProvider`.
>   - **Usage**: Add `UsageSummarySchema`, `NativeUsagePayloadSchema`, base schemas, and guards (`isOpenAIUsageFormat`, `isAnthropicUsageFormat`, `identifyNativeUsageProvider`). Update `AgentState` to use these schemas/guards.
> - **Tool Resolution**:
>   - Extract `resolveToolDefinitions`/`resolveToolDefinitionsAsync` to `@agent/utils/toolResolution` and integrate in `agentLoad.ts` and `RemoteAgentLoader.ts`.
> - **State/Snapshots**:
>   - `FileInteractionState`: add `restoreFrom()`; `AgentWorkspaceState.fromJSON` restores interactions in-place.
>   - `ToolUseSnapshotTypes`: use `ProviderMessageSchema` for `messages`.
> - **Utilities**:
>   - `messageSkeletonUtils`: define `MessageSkeleton` type and fix recursive typing/truncation.
>   - `fileSelectionCommands`: add `PickerResult` conditional type and precise casts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 788b06e5b7ed89d5f9cfd12d48fb0b6598e23bd8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->