### PR TITLE
refactor(usage): preserve extended metrics in progress view persistence

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -282,7 +282,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -329,7 +328,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -780,7 +778,6 @@
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.24.3.tgz",
       "integrity": "sha512-YgSHW29fuzKKAHTGe9zjNoo+yF8KaQPzDC2W9Pv41E7/57IfY+AMGJ/aDFlgTLcVVELoggKE4syABCE75u3NCw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
@@ -1276,7 +1273,6 @@
       "integrity": "sha512-PC0PDZfJg8sP7cmKe6L3QIL8GZwU5aRvUFedqSIpw3B+QjRSUZeeITC2M5XKeMXEzL6wccN196iy3JLwKNvDVA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.48.1",
         "@typescript-eslint/types": "8.48.1",
@@ -1889,7 +1885,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2437,7 +2432,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.9",
         "caniuse-lite": "^1.0.30001746",
@@ -3524,7 +3518,6 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3923,7 +3916,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
       "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.0",
@@ -7224,6 +7216,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -7245,6 +7238,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -7764,7 +7758,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -8887,7 +8880,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9104,7 +9096,6 @@
       "integrity": "sha512-HU1JOuV1OavsZ+mfigY0j8d1TgQgbZ6M+J75zDkpEAwYeXjWSqrGJtgnPblJjd/mAyTNQ7ygw0MiKOn6etz8yw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -9154,7 +9145,6 @@
       "integrity": "sha512-MfwFQ6SfwinsUVi0rNJm7rHZ31GyTcpVE5pgVA3hwFRb7COD4TzjUUwhGWKfO50+xdc2MQPuEBBJoqIMGt3JDw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.6.1",
         "@webpack-cli/configtest": "^3.0.1",
@@ -9847,7 +9837,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.13.tgz",
       "integrity": "sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/agent/types/UsageTypes.ts
+++ b/src/agent/types/UsageTypes.ts
@@ -38,6 +38,58 @@ export type ExtendedTokenUsageStats = z.infer<
 >;
 
 /**
+ * Usage statistics for persistence in the progress view.
+ * Extends base stats with optional extended metrics.
+ *
+ * This schema bridges ExtendedTokenUsageStats (used during execution)
+ * and persistence storage, preserving valuable metrics like caching
+ * efficiency and reasoning token usage across sessions.
+ */
+export const PersistedUsageStatsSchema = TokenUsageStatsSchema.extend({
+  /** Response time in milliseconds */
+  responseTimeMs: z.number().optional(),
+  /** Tokens served from cache (reduces cost) */
+  cachedInputTokens: z.number().optional(),
+  /** Tokens written to cache (Anthropic only, increases cost by 1.25x) */
+  cacheCreationTokens: z.number().optional(),
+  /** Percentage of input tokens served from cache */
+  percentageCached: z.number().optional(),
+  /** Tokens used for reasoning (o1, DeepSeek-R1, Gemini thinking) */
+  reasoningTokens: z.number().optional(),
+  /** Tokens consumed by tool use prompts */
+  toolUsePromptTokens: z.number().optional(),
+  /** Number of server-side tool executions (Anthropic web search) */
+  serverToolRequests: z.number().optional(),
+});
+
+export type PersistedUsageStats = z.infer<typeof PersistedUsageStatsSchema>;
+
+/**
+ * Converts ExtendedTokenUsageStats to PersistedUsageStats format.
+ * Maps field names from the execution-time format to the persistence format.
+ */
+export function toPersistedUsageStats(
+  stats: ExtendedTokenUsageStats,
+): PersistedUsageStats {
+  return {
+    inputTokens: stats.inputTokens,
+    outputTokens: stats.outputTokens,
+    cost: stats.cost,
+    // Map elapsedTime (seconds) to responseTimeMs (milliseconds)
+    responseTimeMs:
+      stats.elapsedTime !== undefined
+        ? Math.round(stats.elapsedTime * 1000)
+        : undefined,
+    cachedInputTokens: stats.cacheReadInputTokens,
+    cacheCreationTokens: stats.cacheCreationInputTokens,
+    percentageCached: stats.percentageCached,
+    reasoningTokens: stats.reasoningTokens,
+    toolUsePromptTokens: stats.toolUseTokens,
+    // Note: serverToolRequests not available in ExtendedTokenUsageStats
+  };
+}
+
+/**
  * Message interface for updating usage stats in the progress view.
  */
 export const StreamUsageMessageSchema = z.strictObject({

--- a/src/eventBus/ProgressEventBus.ts
+++ b/src/eventBus/ProgressEventBus.ts
@@ -5,7 +5,7 @@ import { EventEmitter } from 'events';
 import type { AgentSessionDescriptor } from '@agent/core/AgentDataclass';
 import type { OutputFileInfo } from '@agent/output/types';
 import type { StreamTabId, ExecutionId } from '@agent/types/IdentifierTypes';
-import type { TokenUsageStats } from '@agent/types/UsageTypes';
+import type { PersistedUsageStats } from '@agent/types/UsageTypes';
 import type { StreamStatus } from '@common/constants/streamStatus';
 import type { LogMessageData, LogMessageUpdate } from '@logger/LogTypes';
 import type { TaskState } from '@logger/TaskState';
@@ -56,7 +56,7 @@ export interface ProgressEventPayloads {
   clearMissingOutputs: StreamTabId;
   setTaskState: SetTaskStatePayload;
   updateStreamUsage: RunScopedPayload & {
-    usage: TokenUsageStats;
+    usage: PersistedUsageStats;
   };
   showRetryRequest: RetryRequestPrompt;
   resolveRetryRequest: { streamId: StreamTabId };

--- a/src/logger/AgentUsageReporter.ts
+++ b/src/logger/AgentUsageReporter.ts
@@ -1,6 +1,9 @@
 // Local imports - agent types
 import type { StorageKey, StreamTabId } from '@agent/types/IdentifierTypes';
-import type { ExtendedTokenUsageStats } from '@agent/types/UsageTypes';
+import {
+  type ExtendedTokenUsageStats,
+  toPersistedUsageStats,
+} from '@agent/types/UsageTypes';
 import { AgentCategory } from '@agent/core/AgentDataclass';
 
 // Internal imports
@@ -40,12 +43,8 @@ export class AgentUsageReporter {
   public report(stats: ExtendedTokenUsageStats, storageKey: StorageKey): void {
     const logStatistics = this.agentCategory === AgentCategory.Workflow;
 
-    // Pass through usage without modification
-    const usage = {
-      inputTokens: stats.inputTokens,
-      outputTokens: stats.outputTokens,
-      cost: stats.cost,
-    };
+    // Convert to persisted format, preserving all extended metrics
+    const usage = toPersistedUsageStats(stats);
 
     // storageKey is THE single source of truth - no fallbacks, no round-trips
     bus.emit('updateStreamUsage', {

--- a/src/progressView/events/UsageEvents.ts
+++ b/src/progressView/events/UsageEvents.ts
@@ -40,45 +40,12 @@ export function createUsageEvents(
         'updateStreamUsage',
         ({ stream, usage, storageKey }) => {
           withErrorBoundary('failed to handle updateStreamUsage', async () => {
-            // Normalize required fields and preserve optional extended metrics
-            const normalizedUsage: PersistedUsageStats = {
-              inputTokens: Number(usage.inputTokens ?? 0),
-              outputTokens: Number(usage.outputTokens ?? 0),
-              cost: Number(usage.cost ?? 0),
-              // Preserve extended metrics when available
-              ...(usage.responseTimeMs !== undefined && {
-                responseTimeMs: Number(usage.responseTimeMs),
-              }),
-              ...(usage.cachedInputTokens !== undefined && {
-                cachedInputTokens: Number(usage.cachedInputTokens),
-              }),
-              ...(usage.cacheCreationTokens !== undefined && {
-                cacheCreationTokens: Number(usage.cacheCreationTokens),
-              }),
-              ...(usage.percentageCached !== undefined && {
-                percentageCached: Number(usage.percentageCached),
-              }),
-              ...(usage.reasoningTokens !== undefined && {
-                reasoningTokens: Number(usage.reasoningTokens),
-              }),
-              ...(usage.toolUsePromptTokens !== undefined && {
-                toolUsePromptTokens: Number(usage.toolUsePromptTokens),
-              }),
-              ...(usage.serverToolRequests !== undefined && {
-                serverToolRequests: Number(usage.serverToolRequests),
-              }),
-            };
-
-            // storageKey is THE single source of truth - no fallbacks
-            await state.usageStats.setRunUsage(
-              stream,
-              storageKey,
-              normalizedUsage,
-            );
+            // Usage is already PersistedUsageStats from AgentUsageReporter;
+            // UsageStatsManager.setRunUsage() handles parsing/normalization
+            await state.usageStats.setRunUsage(stream, storageKey, usage);
 
             if (state.activeStream === stream && updater.isAvailable()) {
-              // Send only the changed run's usage instead of all runs
-              updater.updateRunUsage(stream, storageKey, normalizedUsage);
+              updater.updateRunUsage(stream, storageKey, usage);
             }
           });
         },

--- a/src/progressView/events/UsageEvents.ts
+++ b/src/progressView/events/UsageEvents.ts
@@ -2,7 +2,7 @@
 import * as vscode from 'vscode';
 
 // Type imports
-import type { TokenUsageStats } from '@agent/types/UsageTypes';
+import type { PersistedUsageStats } from '@agent/types/UsageTypes';
 import type { WebviewUpdater } from '@progressView/managers';
 import type { ProgressViewState } from '@progressView/state/ProgressViewState';
 
@@ -40,10 +40,33 @@ export function createUsageEvents(
         'updateStreamUsage',
         ({ stream, usage, storageKey }) => {
           withErrorBoundary('failed to handle updateStreamUsage', async () => {
-            const normalizedUsage: TokenUsageStats = {
+            // Normalize required fields and preserve optional extended metrics
+            const normalizedUsage: PersistedUsageStats = {
               inputTokens: Number(usage.inputTokens ?? 0),
               outputTokens: Number(usage.outputTokens ?? 0),
               cost: Number(usage.cost ?? 0),
+              // Preserve extended metrics when available
+              ...(usage.responseTimeMs !== undefined && {
+                responseTimeMs: Number(usage.responseTimeMs),
+              }),
+              ...(usage.cachedInputTokens !== undefined && {
+                cachedInputTokens: Number(usage.cachedInputTokens),
+              }),
+              ...(usage.cacheCreationTokens !== undefined && {
+                cacheCreationTokens: Number(usage.cacheCreationTokens),
+              }),
+              ...(usage.percentageCached !== undefined && {
+                percentageCached: Number(usage.percentageCached),
+              }),
+              ...(usage.reasoningTokens !== undefined && {
+                reasoningTokens: Number(usage.reasoningTokens),
+              }),
+              ...(usage.toolUsePromptTokens !== undefined && {
+                toolUsePromptTokens: Number(usage.toolUsePromptTokens),
+              }),
+              ...(usage.serverToolRequests !== undefined && {
+                serverToolRequests: Number(usage.serverToolRequests),
+              }),
             };
 
             // storageKey is THE single source of truth - no fallbacks

--- a/src/progressView/managers/UsageStatsManager.ts
+++ b/src/progressView/managers/UsageStatsManager.ts
@@ -4,7 +4,10 @@ import { z } from 'zod';
 // Local imports - identifiers
 import type { StorageKey, StreamTabId } from '@agent/types/IdentifierTypes';
 // Types - import canonical type (schema defines structure)
-import { type TokenUsageStats } from '@agent/types/UsageTypes';
+import {
+  type PersistedUsageStats,
+  PersistedUsageStatsSchema,
+} from '@agent/types/UsageTypes';
 import { normalizeRunId } from '@common/constants/runIds';
 import { WorkspaceStateKey } from '@common/state/stateManager';
 import { AgentLogger } from '@logger/AgentLogger';
@@ -21,35 +24,61 @@ const FiniteNumber = z.coerce
   .number()
   .transform((n) => (Number.isFinite(n) ? n : 0));
 
+/** Coerces optional number, defaulting non-finite values to undefined */
+const OptionalFiniteNumber = z
+  .union([z.number(), z.undefined()])
+  .transform((n) => (n !== undefined && Number.isFinite(n) ? n : undefined));
+
 /**
- * Schema for parsing TokenUsageStats with safe number coercion.
+ * Schema for parsing PersistedUsageStats with safe number coercion.
  * Extends the canonical schema shape with coercion for persistence resilience.
+ * Supports both legacy (3-field) and extended (10-field) formats.
  */
-const TokenUsageStatsParsingSchema = z
+const PersistedUsageStatsParsingSchema = z
   .object({
+    // Required fields (always present)
     inputTokens: FiniteNumber,
     outputTokens: FiniteNumber,
     cost: FiniteNumber,
+    // Extended fields (optional, may not be present in legacy data)
+    responseTimeMs: OptionalFiniteNumber,
+    cachedInputTokens: OptionalFiniteNumber,
+    cacheCreationTokens: OptionalFiniteNumber,
+    percentageCached: OptionalFiniteNumber,
+    reasoningTokens: OptionalFiniteNumber,
+    toolUsePromptTokens: OptionalFiniteNumber,
+    serverToolRequests: OptionalFiniteNumber,
   })
-  .catch({ inputTokens: 0, outputTokens: 0, cost: 0 });
+  .catch({
+    inputTokens: 0,
+    outputTokens: 0,
+    cost: 0,
+    responseTimeMs: undefined,
+    cachedInputTokens: undefined,
+    cacheCreationTokens: undefined,
+    percentageCached: undefined,
+    reasoningTokens: undefined,
+    toolUsePromptTokens: undefined,
+    serverToolRequests: undefined,
+  });
 
-// Compile-time assertion: ensure parsing schema produces type compatible with TokenUsageStats
+// Compile-time assertion: ensure parsing schema produces type compatible with PersistedUsageStats
 type _AssertSchemaCompatible =
-  z.infer<typeof TokenUsageStatsParsingSchema> extends TokenUsageStats
+  z.infer<typeof PersistedUsageStatsParsingSchema> extends PersistedUsageStats
     ? true
     : never;
 const _assertCompatible: _AssertSchemaCompatible = true;
 
 /** Checks if usage stats are all zeros (effectively empty) */
-function isEmptyUsage(usage: TokenUsageStats): boolean {
+function isEmptyUsage(usage: PersistedUsageStats): boolean {
   return (
     usage.inputTokens === 0 && usage.outputTokens === 0 && usage.cost === 0
   );
 }
 
-/** Schema for run map format: { runId: { inputTokens, outputTokens, cost } } */
+/** Schema for run map format: { runId: PersistedUsageStats } */
 const UsageDataSchema = createSingleValueRunMapSchema(
-  TokenUsageStatsParsingSchema,
+  PersistedUsageStatsParsingSchema,
   {
     isEmpty: isEmptyUsage,
   },
@@ -59,7 +88,7 @@ const UsageDataSchema = createSingleValueRunMapSchema(
  * Manages usage statistics collection with persistence.
  * Handles tracking and updating token usage and costs for different streams.
  */
-type RunUsageMap = Map<string, TokenUsageStats>;
+type RunUsageMap = Map<string, PersistedUsageStats>;
 
 /** Stream ID used for migrated legacy data */
 const LEGACY_MIGRATION_STREAM = '_legacy_migrated_' as StreamTabId;
@@ -84,11 +113,11 @@ export class UsageStatsManager extends PersistentMapManager<
   async setRunUsage(
     stream: StreamTabId,
     storageKey: StorageKey,
-    usage: TokenUsageStats,
+    usage: PersistedUsageStats,
   ): Promise<void> {
-    const normalized = TokenUsageStatsParsingSchema.parse(usage);
+    const normalized = PersistedUsageStatsParsingSchema.parse(usage);
     const current =
-      this.items.get(stream) ?? new Map<string, TokenUsageStats>();
+      this.items.get(stream) ?? new Map<string, PersistedUsageStats>();
     if (
       normalized.inputTokens === 0 &&
       normalized.outputTokens === 0 &&
@@ -137,9 +166,10 @@ export class UsageStatsManager extends PersistentMapManager<
   }
 
   /**
-   * Get total usage across all runs for a stream
+   * Get total usage across all runs for a stream.
+   * Returns aggregate totals; extended metrics are summed where available.
    */
-  getStreamTotals(stream: StreamTabId): TokenUsageStats | undefined {
+  getStreamTotals(stream: StreamTabId): PersistedUsageStats | undefined {
     const runs = this.items.get(stream);
     if (!runs || runs.size === 0) {
       return undefined;
@@ -148,14 +178,65 @@ export class UsageStatsManager extends PersistentMapManager<
     let inputTokens = 0;
     let outputTokens = 0;
     let cost = 0;
+    let responseTimeMs = 0;
+    let cachedInputTokens = 0;
+    let cacheCreationTokens = 0;
+    let reasoningTokens = 0;
+    let toolUsePromptTokens = 0;
+    let serverToolRequests = 0;
+    let hasExtendedMetrics = false;
 
     for (const usage of runs.values()) {
       inputTokens += usage.inputTokens;
       outputTokens += usage.outputTokens;
       cost += usage.cost;
+      if (usage.responseTimeMs !== undefined) {
+        responseTimeMs += usage.responseTimeMs;
+        hasExtendedMetrics = true;
+      }
+      if (usage.cachedInputTokens !== undefined) {
+        cachedInputTokens += usage.cachedInputTokens;
+        hasExtendedMetrics = true;
+      }
+      if (usage.cacheCreationTokens !== undefined) {
+        cacheCreationTokens += usage.cacheCreationTokens;
+        hasExtendedMetrics = true;
+      }
+      if (usage.reasoningTokens !== undefined) {
+        reasoningTokens += usage.reasoningTokens;
+        hasExtendedMetrics = true;
+      }
+      if (usage.toolUsePromptTokens !== undefined) {
+        toolUsePromptTokens += usage.toolUsePromptTokens;
+        hasExtendedMetrics = true;
+      }
+      if (usage.serverToolRequests !== undefined) {
+        serverToolRequests += usage.serverToolRequests;
+        hasExtendedMetrics = true;
+      }
     }
 
-    return { inputTokens, outputTokens, cost };
+    // Calculate percentageCached from aggregated values
+    const totalCacheableTokens = cachedInputTokens + cacheCreationTokens;
+    const percentageCached =
+      hasExtendedMetrics && totalCacheableTokens > 0
+        ? (cachedInputTokens / totalCacheableTokens) * 100
+        : undefined;
+
+    return {
+      inputTokens,
+      outputTokens,
+      cost,
+      ...(hasExtendedMetrics && {
+        responseTimeMs: responseTimeMs || undefined,
+        cachedInputTokens: cachedInputTokens || undefined,
+        cacheCreationTokens: cacheCreationTokens || undefined,
+        percentageCached,
+        reasoningTokens: reasoningTokens || undefined,
+        toolUsePromptTokens: toolUsePromptTokens || undefined,
+        serverToolRequests: serverToolRequests || undefined,
+      }),
+    };
   }
 
   /**
@@ -169,7 +250,9 @@ export class UsageStatsManager extends PersistentMapManager<
    * Set all usage statistics (used during loading)
    */
   setAll(
-    stats: Map<StreamTabId, RunUsageMap> | Map<StreamTabId, TokenUsageStats>,
+    stats:
+      | Map<StreamTabId, RunUsageMap>
+      | Map<StreamTabId, PersistedUsageStats>,
   ): void {
     const normalized: Map<StreamTabId, RunUsageMap> = new Map();
 
@@ -183,7 +266,7 @@ export class UsageStatsManager extends PersistentMapManager<
         continue;
       }
 
-      const usage = TokenUsageStatsParsingSchema.parse(value);
+      const usage = PersistedUsageStatsParsingSchema.parse(value);
       if (
         usage.inputTokens === 0 &&
         usage.outputTokens === 0 &&
@@ -201,22 +284,74 @@ export class UsageStatsManager extends PersistentMapManager<
   }
 
   /**
-   * Calculate total usage across all streams
+   * Calculate total usage across all streams.
+   * Returns aggregate totals; extended metrics are summed where available.
    */
-  getTotalUsage(): TokenUsageStats {
+  getTotalUsage(): PersistedUsageStats {
     let inputTokens = 0;
     let outputTokens = 0;
     let cost = 0;
+    let responseTimeMs = 0;
+    let cachedInputTokens = 0;
+    let cacheCreationTokens = 0;
+    let reasoningTokens = 0;
+    let toolUsePromptTokens = 0;
+    let serverToolRequests = 0;
+    let hasExtendedMetrics = false;
 
     for (const usage of this.items.values()) {
       for (const runUsage of usage.values()) {
         inputTokens += runUsage.inputTokens;
         outputTokens += runUsage.outputTokens;
         cost += runUsage.cost;
+        if (runUsage.responseTimeMs !== undefined) {
+          responseTimeMs += runUsage.responseTimeMs;
+          hasExtendedMetrics = true;
+        }
+        if (runUsage.cachedInputTokens !== undefined) {
+          cachedInputTokens += runUsage.cachedInputTokens;
+          hasExtendedMetrics = true;
+        }
+        if (runUsage.cacheCreationTokens !== undefined) {
+          cacheCreationTokens += runUsage.cacheCreationTokens;
+          hasExtendedMetrics = true;
+        }
+        if (runUsage.reasoningTokens !== undefined) {
+          reasoningTokens += runUsage.reasoningTokens;
+          hasExtendedMetrics = true;
+        }
+        if (runUsage.toolUsePromptTokens !== undefined) {
+          toolUsePromptTokens += runUsage.toolUsePromptTokens;
+          hasExtendedMetrics = true;
+        }
+        if (runUsage.serverToolRequests !== undefined) {
+          serverToolRequests += runUsage.serverToolRequests;
+          hasExtendedMetrics = true;
+        }
       }
     }
 
-    return { inputTokens, outputTokens, cost };
+    // Calculate percentageCached from aggregated values
+    const totalCacheableTokens = cachedInputTokens + cacheCreationTokens;
+    const percentageCached =
+      hasExtendedMetrics && totalCacheableTokens > 0
+        ? (cachedInputTokens / totalCacheableTokens) * 100
+        : undefined;
+
+    return {
+      inputTokens,
+      outputTokens,
+      cost,
+      ...(hasExtendedMetrics && {
+        responseTimeMs: responseTimeMs || undefined,
+        cachedInputTokens: cachedInputTokens || undefined,
+        cacheCreationTokens: cacheCreationTokens || undefined,
+        percentageCached,
+        reasoningTokens: reasoningTokens || undefined,
+        toolUsePromptTokens: toolUsePromptTokens || undefined,
+        serverToolRequests: serverToolRequests || undefined,
+      }),
+    };
   }
 
   /**
@@ -275,7 +410,7 @@ export class UsageStatsManager extends PersistentMapManager<
     }
 
     const totals = legacy.usageAccumulator.totals;
-    const usage: TokenUsageStats = TokenUsageStatsParsingSchema.parse({
+    const usage: PersistedUsageStats = PersistedUsageStatsParsingSchema.parse({
       inputTokens: totals.totalInputTokens ?? 0,
       outputTokens: totals.totalOutputTokens ?? 0,
       cost: totals.totalCost ?? 0,
@@ -294,7 +429,7 @@ export class UsageStatsManager extends PersistentMapManager<
     // Store under legacy migration identifiers
     const existing =
       this.items.get(LEGACY_MIGRATION_STREAM) ??
-      new Map<string, TokenUsageStats>();
+      new Map<string, PersistedUsageStats>();
     existing.set(LEGACY_MIGRATION_RUN_ID, usage);
     this.items.set(LEGACY_MIGRATION_STREAM, existing);
 

--- a/src/progressView/managers/UsageStatsManager.ts
+++ b/src/progressView/managers/UsageStatsManager.ts
@@ -76,6 +76,76 @@ function isEmptyUsage(usage: PersistedUsageStats): boolean {
   );
 }
 
+/** Keys for optional extended metrics that get summed during aggregation */
+const EXTENDED_METRIC_KEYS = [
+  'responseTimeMs',
+  'cachedInputTokens',
+  'cacheCreationTokens',
+  'reasoningTokens',
+  'toolUsePromptTokens',
+  'serverToolRequests',
+] as const;
+
+type ExtendedMetricKey = (typeof EXTENDED_METRIC_KEYS)[number];
+
+/**
+ * Aggregates multiple usage stats into a single total.
+ * Sums all numeric fields; computes percentageCached from aggregated cache values.
+ */
+function aggregateUsageStats(
+  usageItems: Iterable<PersistedUsageStats>,
+): PersistedUsageStats {
+  let inputTokens = 0;
+  let outputTokens = 0;
+  let cost = 0;
+  const extendedTotals: Record<ExtendedMetricKey, number> = {
+    responseTimeMs: 0,
+    cachedInputTokens: 0,
+    cacheCreationTokens: 0,
+    reasoningTokens: 0,
+    toolUsePromptTokens: 0,
+    serverToolRequests: 0,
+  };
+  let hasExtendedMetrics = false;
+
+  for (const usage of usageItems) {
+    inputTokens += usage.inputTokens;
+    outputTokens += usage.outputTokens;
+    cost += usage.cost;
+
+    for (const key of EXTENDED_METRIC_KEYS) {
+      const value = usage[key];
+      if (value !== undefined) {
+        extendedTotals[key] += value;
+        hasExtendedMetrics = true;
+      }
+    }
+  }
+
+  // Calculate percentageCached from aggregated cache values
+  const totalCacheableTokens =
+    extendedTotals.cachedInputTokens + extendedTotals.cacheCreationTokens;
+  const percentageCached =
+    hasExtendedMetrics && totalCacheableTokens > 0
+      ? (extendedTotals.cachedInputTokens / totalCacheableTokens) * 100
+      : undefined;
+
+  return {
+    inputTokens,
+    outputTokens,
+    cost,
+    ...(hasExtendedMetrics && {
+      responseTimeMs: extendedTotals.responseTimeMs || undefined,
+      cachedInputTokens: extendedTotals.cachedInputTokens || undefined,
+      cacheCreationTokens: extendedTotals.cacheCreationTokens || undefined,
+      percentageCached,
+      reasoningTokens: extendedTotals.reasoningTokens || undefined,
+      toolUsePromptTokens: extendedTotals.toolUsePromptTokens || undefined,
+      serverToolRequests: extendedTotals.serverToolRequests || undefined,
+    }),
+  };
+}
+
 /** Schema for run map format: { runId: PersistedUsageStats } */
 const UsageDataSchema = createSingleValueRunMapSchema(
   PersistedUsageStatsParsingSchema,
@@ -174,69 +244,7 @@ export class UsageStatsManager extends PersistentMapManager<
     if (!runs || runs.size === 0) {
       return undefined;
     }
-
-    let inputTokens = 0;
-    let outputTokens = 0;
-    let cost = 0;
-    let responseTimeMs = 0;
-    let cachedInputTokens = 0;
-    let cacheCreationTokens = 0;
-    let reasoningTokens = 0;
-    let toolUsePromptTokens = 0;
-    let serverToolRequests = 0;
-    let hasExtendedMetrics = false;
-
-    for (const usage of runs.values()) {
-      inputTokens += usage.inputTokens;
-      outputTokens += usage.outputTokens;
-      cost += usage.cost;
-      if (usage.responseTimeMs !== undefined) {
-        responseTimeMs += usage.responseTimeMs;
-        hasExtendedMetrics = true;
-      }
-      if (usage.cachedInputTokens !== undefined) {
-        cachedInputTokens += usage.cachedInputTokens;
-        hasExtendedMetrics = true;
-      }
-      if (usage.cacheCreationTokens !== undefined) {
-        cacheCreationTokens += usage.cacheCreationTokens;
-        hasExtendedMetrics = true;
-      }
-      if (usage.reasoningTokens !== undefined) {
-        reasoningTokens += usage.reasoningTokens;
-        hasExtendedMetrics = true;
-      }
-      if (usage.toolUsePromptTokens !== undefined) {
-        toolUsePromptTokens += usage.toolUsePromptTokens;
-        hasExtendedMetrics = true;
-      }
-      if (usage.serverToolRequests !== undefined) {
-        serverToolRequests += usage.serverToolRequests;
-        hasExtendedMetrics = true;
-      }
-    }
-
-    // Calculate percentageCached from aggregated values
-    const totalCacheableTokens = cachedInputTokens + cacheCreationTokens;
-    const percentageCached =
-      hasExtendedMetrics && totalCacheableTokens > 0
-        ? (cachedInputTokens / totalCacheableTokens) * 100
-        : undefined;
-
-    return {
-      inputTokens,
-      outputTokens,
-      cost,
-      ...(hasExtendedMetrics && {
-        responseTimeMs: responseTimeMs || undefined,
-        cachedInputTokens: cachedInputTokens || undefined,
-        cacheCreationTokens: cacheCreationTokens || undefined,
-        percentageCached,
-        reasoningTokens: reasoningTokens || undefined,
-        toolUsePromptTokens: toolUsePromptTokens || undefined,
-        serverToolRequests: serverToolRequests || undefined,
-      }),
-    };
+    return aggregateUsageStats(runs.values());
   }
 
   /**
@@ -288,70 +296,14 @@ export class UsageStatsManager extends PersistentMapManager<
    * Returns aggregate totals; extended metrics are summed where available.
    */
   getTotalUsage(): PersistedUsageStats {
-    let inputTokens = 0;
-    let outputTokens = 0;
-    let cost = 0;
-    let responseTimeMs = 0;
-    let cachedInputTokens = 0;
-    let cacheCreationTokens = 0;
-    let reasoningTokens = 0;
-    let toolUsePromptTokens = 0;
-    let serverToolRequests = 0;
-    let hasExtendedMetrics = false;
-
-    for (const usage of this.items.values()) {
-      for (const runUsage of usage.values()) {
-        inputTokens += runUsage.inputTokens;
-        outputTokens += runUsage.outputTokens;
-        cost += runUsage.cost;
-        if (runUsage.responseTimeMs !== undefined) {
-          responseTimeMs += runUsage.responseTimeMs;
-          hasExtendedMetrics = true;
-        }
-        if (runUsage.cachedInputTokens !== undefined) {
-          cachedInputTokens += runUsage.cachedInputTokens;
-          hasExtendedMetrics = true;
-        }
-        if (runUsage.cacheCreationTokens !== undefined) {
-          cacheCreationTokens += runUsage.cacheCreationTokens;
-          hasExtendedMetrics = true;
-        }
-        if (runUsage.reasoningTokens !== undefined) {
-          reasoningTokens += runUsage.reasoningTokens;
-          hasExtendedMetrics = true;
-        }
-        if (runUsage.toolUsePromptTokens !== undefined) {
-          toolUsePromptTokens += runUsage.toolUsePromptTokens;
-          hasExtendedMetrics = true;
-        }
-        if (runUsage.serverToolRequests !== undefined) {
-          serverToolRequests += runUsage.serverToolRequests;
-          hasExtendedMetrics = true;
-        }
+    const items = this.items;
+    const allUsage = (function* () {
+      for (const runMap of items.values()) {
+        yield* runMap.values();
       }
-    }
+    })();
 
-    // Calculate percentageCached from aggregated values
-    const totalCacheableTokens = cachedInputTokens + cacheCreationTokens;
-    const percentageCached =
-      hasExtendedMetrics && totalCacheableTokens > 0
-        ? (cachedInputTokens / totalCacheableTokens) * 100
-        : undefined;
-
-    return {
-      inputTokens,
-      outputTokens,
-      cost,
-      ...(hasExtendedMetrics && {
-        responseTimeMs: responseTimeMs || undefined,
-        cachedInputTokens: cachedInputTokens || undefined,
-        cacheCreationTokens: cacheCreationTokens || undefined,
-        percentageCached,
-        reasoningTokens: reasoningTokens || undefined,
-        toolUsePromptTokens: toolUsePromptTokens || undefined,
-        serverToolRequests: serverToolRequests || undefined,
-      }),
-    };
+    return aggregateUsageStats(allUsage);
   }
 
   /**

--- a/src/progressView/managers/WebviewUpdater.ts
+++ b/src/progressView/managers/WebviewUpdater.ts
@@ -6,7 +6,7 @@ import type { OutputFileInfo } from '@agent/output/types';
 import type { StreamTabId } from '@agent/types/IdentifierTypes';
 import type { AgentTypeFilter } from '@agent/types/AgentStreamTypes';
 // Types
-import type { TokenUsageStats } from '@agent/types/UsageTypes';
+import type { PersistedUsageStats } from '@agent/types/UsageTypes';
 
 import {
   STREAM_STATUS,
@@ -115,7 +115,7 @@ export class WebviewUpdater {
     extras?: {
       runInstructions?: Record<string, InstructionUpdate>;
       activeRunId?: string | null;
-      runUsage?: Record<string, TokenUsageStats>;
+      runUsage?: Record<string, PersistedUsageStats>;
       runFiles?: Record<string, { [key: number]: OutputFileInfo[] }>;
     },
     options?: {
@@ -233,7 +233,7 @@ export class WebviewUpdater {
    */
   updateUsage(
     stream: StreamTabId,
-    usageByRun: Record<string, TokenUsageStats>,
+    usageByRun: Record<string, PersistedUsageStats>,
   ): void {
     this.sendMessage({
       command: COMMANDS.UPDATE_USAGE,
@@ -249,7 +249,7 @@ export class WebviewUpdater {
   updateRunUsage(
     stream: StreamTabId,
     runId: string,
-    usage: TokenUsageStats,
+    usage: PersistedUsageStats,
   ): void {
     this.sendMessage({
       command: COMMANDS.UPDATE_RUN_USAGE,


### PR DESCRIPTION
Introduce PersistedUsageStatsSchema as a unified format for storing
usage statistics that preserves valuable extended metrics across
sessions. Previously, only basic stats (inputTokens, outputTokens,
cost) were persisted, losing timing, caching, and reasoning data.

- Add PersistedUsageStatsSchema with optional extended fields
- Add toPersistedUsageStats() converter function
- Update UsageStatsManager to store and aggregate extended metrics
- Update event bus and reporters to pass through full stats
- Maintain backward compatibility with legacy 3-field format

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a unified PersistedUsageStats format and updates the progress view pipeline to store, normalize, and aggregate extended usage metrics across sessions.
> 
> - **Types/Schema**:
>   - Add `PersistedUsageStatsSchema` and `toPersistedUsageStats()`; map execution-time metrics to persisted fields.
> - **Event Pipeline**:
>   - Update bus payloads and progress events to use `PersistedUsageStats`.
>   - `AgentUsageReporter` converts `ExtendedTokenUsageStats` to persisted format before emitting.
>   - `UsageEvents` forwards persisted stats directly (drops ad-hoc normalization).
> - **Persistence/Aggregation**:
>   - `UsageStatsManager` now parses/normalizes persisted stats (legacy- and extended-compatible), aggregates extended metrics (incl. computed `percentageCached`), and exposes totals across runs/streams.
>   - Adds legacy data migration from `texra.runUsage`.
> - **Webview**:
>   - `WebviewUpdater` methods updated to send `PersistedUsageStats` for run and total usage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4608279141ce4d91f242947a253ef138bb7c4c69. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->