### PR TITLE
Analyze data structure resolution in TeXRA

### DIFF
--- a/docs/data-structure-simplification-plan.md
+++ b/docs/data-structure-simplification-plan.md
@@ -1,0 +1,266 @@
+# Data Structure Simplification Plan
+
+This document outlines the implementation plan for simplifying and unifying data structures in the TeXRA codebase, based on the analysis in the Data Structure Resolution Analysis.
+
+## Current State Analysis
+
+### Usage Type Hierarchy
+
+```
+Provider SDK Types (Raw)
+    │
+    ▼ modelHandler.normalizeUsage()
+NormalizedUsage (per-request, canonical)
+    │
+    ▼ RunUsageAccumulator.recordNormalizedUsage()
+RunUsageTotals (accumulated totals)
+    │
+    ▼ UsageMonitor.recordUsage()
+ExtendedTokenUsageStats (for logging/reporting)
+    │
+    ▼ AgentUsageReporter.report() - TRUNCATION HAPPENS HERE
+TokenUsageStats (3 fields only for Progress View)
+```
+
+### Field Naming Inconsistencies
+
+| Concept | NormalizedUsage | ExtendedTokenUsageStats | RunUsageTotals |
+|---------|-----------------|------------------------|----------------|
+| Cached input tokens | `cachedInputTokens` | `cacheReadInputTokens` | `totalCacheReadInputTokens` |
+| Cache creation tokens | `cacheCreationTokens` | `cacheCreationInputTokens` | `totalCacheCreationInputTokens` |
+| Time measurement | `responseTimeMs` (ms) | `elapsedTime` (seconds) | N/A |
+| Tool usage tokens | `toolUsePromptTokens` | `toolUseTokens` | `totalToolUsePromptTokens` |
+| Reasoning tokens | `reasoningTokens` | `reasoningTokens` | `totalReasoningTokens` |
+
+---
+
+## Priority 2: Unify ExtendedTokenUsageStats → NormalizedUsage ✅ IMPLEMENTED
+
+### Problem
+Two nearly-identical schemas exist with different field names, causing confusion and requiring manual mapping.
+
+### Solution: Rename ExtendedTokenUsageStats fields to match NormalizedUsage
+
+This is the minimal-change approach that preserves the distinct purposes (totals vs per-request) while fixing naming inconsistencies.
+
+#### Files Modified
+
+1. **`src/agent/types/UsageTypes.ts`** ✅
+   - Renamed fields in `ExtendedTokenUsageStatsSchema`:
+     - `cacheReadInputTokens` → `cachedInputTokens`
+     - `cacheCreationInputTokens` → `cacheCreationTokens`
+     - `elapsedTime` → `responseTimeMs` (unit changed from seconds to milliseconds)
+     - `toolUseTokens` → `toolUsePromptTokens`
+
+2. **`src/agent/utils/UsageMonitor.ts`** ✅
+   - Updated payload construction to use new field names
+   - Changed `elapsedTime` to `responseTimeMs` (value was already in ms!)
+
+3. **`src/progressView/modules/formatters.js`** ✅
+   - Added backward compatibility for both old and new field names
+   - Converts `responseTimeMs` to seconds for display
+
+4. **`src/test/logger/AgentUsageReporter.test.ts`** ✅
+   - Updated test fixtures to use new field names
+
+---
+
+## Priority 3: Preserve NormalizedUsage in Progress View ✅ IMPLEMENTED
+
+### Problem
+The Progress View only receives `TokenUsageStats` (3 fields), losing all extended metrics like cached tokens, reasoning tokens, etc.
+
+### Solution: Pass NormalizedUsage-like data to Progress View
+
+Created a new `DisplayUsageStats` type that extends `TokenUsageStats` with optional extended fields. This type flows through the entire event chain from agent execution to the Progress View.
+
+#### Files Modified
+
+1. **`src/agent/types/UsageTypes.ts`** ✅
+   - Created `DisplayUsageStatsSchema` with optional extended fields:
+     - `cachedInputTokens`
+     - `cacheCreationTokens`
+     - `percentageCached`
+     - `reasoningTokens`
+
+2. **`src/eventBus/ProgressEventBus.ts`** ✅
+   - Changed `updateStreamUsage` event type from `TokenUsageStats` to `DisplayUsageStats`
+
+3. **`src/logger/AgentUsageReporter.ts`** ✅
+   - Updated to pass extended fields in the event payload
+
+4. **`src/progressView/events/UsageEvents.ts`** ✅
+   - Updated to preserve and pass through extended fields
+
+5. **`src/progressView/managers/UsageStatsManager.ts`** ✅
+   - Updated to store `DisplayUsageStats` (now stores extended metrics)
+   - Created `DisplayUsageStatsParsingSchema` with safe coercion for optional fields
+
+6. **`src/progressView/managers/WebviewUpdater.ts`** ✅
+   - Updated `updateRunUsage` method signature to use `DisplayUsageStats`
+
+---
+
+## Priority 4: Centralize Legacy Migration (FUTURE WORK)
+
+### Problem
+Migration logic is scattered across multiple files:
+- `UsageStatsManager.ts:257` - `migrateLegacyRunUsage()`
+- `OutputFilesManager.ts:495` - `migrateLegacyMissingOutputs()`
+
+### Solution: Create MigrationService
+
+> **Note:** This is documented for future work. The current migration logic works correctly.
+
+#### New File: `src/progressView/persistence/MigrationService.ts`
+
+```typescript
+import { AgentLogger } from '@logger/AgentLogger';
+import type { StateStorage } from './PersistentMapManager';
+
+export interface MigrationResult {
+  key: string;
+  success: boolean;
+  itemsMigrated: number;
+}
+
+export class MigrationService {
+  private readonly logger: AgentLogger;
+
+  constructor(private readonly storage: StateStorage) {
+    this.logger = new AgentLogger('MigrationService');
+  }
+
+  /**
+   * Run all migrations. Should be called once on extension activation.
+   */
+  async runAll(): Promise<MigrationResult[]> {
+    const results: MigrationResult[] = [];
+
+    results.push(await this.migrateRunUsage());
+    results.push(await this.migrateMissingOutputs());
+    // Add future migrations here
+
+    return results;
+  }
+
+  private async migrateRunUsage(): Promise<MigrationResult> {
+    // Move logic from UsageStatsManager.migrateLegacyRunUsage()
+  }
+
+  private async migrateMissingOutputs(): Promise<MigrationResult> {
+    // Move logic from OutputFilesManager.migrateLegacyMissingOutputs()
+  }
+}
+```
+
+#### Files to Modify
+
+1. **`src/progressView/managers/UsageStatsManager.ts`**:
+   - Remove `migrateLegacyRunUsage()` method
+   - Remove migration call from `load()`
+
+2. **`src/progressView/managers/OutputFilesManager.ts`**:
+   - Remove `migrateLegacyMissingOutputs()` method
+   - Remove migration call from loading logic
+
+3. **`src/extension.ts`** (or appropriate activation point):
+   - Call `migrationService.runAll()` on activation
+
+---
+
+## Priority 5: Schema-Driven Serialization (DOCUMENTATION ONLY)
+
+> **Note:** This section provides guidelines for future development. No code changes were made.
+
+### Current Pattern
+
+Each stateful class has:
+1. A `*SnapshotSchema` defining serialization format
+2. A `toJSON()` method that manually constructs the snapshot
+3. A `fromJSON()` static method that manually parses
+
+This leads to field duplication between schema and `toJSON()`.
+
+### Recommended Pattern
+
+For classes with simple field mappings, consider:
+
+```typescript
+// Schema defines the serialization format
+export const MyStateSnapshotSchema = z.object({
+  field1: z.string(),
+  field2: z.number(),
+});
+
+export class MyState {
+  field1: string;
+  field2: number;
+
+  // Derive toJSON from class properties
+  toJSON(): z.infer<typeof MyStateSnapshotSchema> {
+    // Use schema to validate output (catches missing fields at runtime)
+    return MyStateSnapshotSchema.parse({
+      field1: this.field1,
+      field2: this.field2,
+    });
+  }
+
+  static fromJSON(json: unknown): MyState {
+    const parsed = MyStateSnapshotSchema.parse(json);
+    const state = new MyState();
+    state.field1 = parsed.field1;
+    state.field2 = parsed.field2;
+    return state;
+  }
+}
+```
+
+### When NOT to Use
+
+- When performance is critical (parsing adds overhead)
+- When class has computed/derived properties not in schema
+- When class needs complex initialization logic
+
+### Classes to Consider for This Pattern
+
+| Class | Complexity | Recommendation |
+|-------|------------|----------------|
+| `ConversationRoundState` | Simple | Could benefit |
+| `AgentRunState` | Contains nested object | Keep current |
+| `RunUsageAccumulator` | Simple + nested array | Could benefit |
+| `AgentSharedStore` | Complex composition | Keep current |
+| `AgentWorkspaceState` | Complex nested | Keep current |
+
+---
+
+## Implementation Summary
+
+| Priority | Status | Description |
+|----------|--------|-------------|
+| 2 | ✅ DONE | Unified field naming in `ExtendedTokenUsageStats` |
+| 3 | ✅ DONE | Created `DisplayUsageStats`, extended event chain to preserve metrics |
+| 4 | ⏳ Future | Centralize legacy migrations (documented for future work) |
+| 5 | 📄 Docs | Schema-driven serialization pattern (documentation only) |
+
+### Files Changed
+
+- `src/agent/types/UsageTypes.ts` - New `DisplayUsageStats`, renamed fields
+- `src/agent/utils/UsageMonitor.ts` - Use new field names
+- `src/eventBus/ProgressEventBus.ts` - Use `DisplayUsageStats` in event
+- `src/logger/AgentUsageReporter.ts` - Pass extended fields
+- `src/progressView/events/UsageEvents.ts` - Preserve extended fields
+- `src/progressView/managers/UsageStatsManager.ts` - Store `DisplayUsageStats`
+- `src/progressView/managers/WebviewUpdater.ts` - Accept `DisplayUsageStats`
+- `src/progressView/modules/formatters.js` - Backward compatible field handling
+- `src/test/logger/AgentUsageReporter.test.ts` - Updated test fixtures
+
+---
+
+## Validation Checklist
+
+- [x] TypeScript compiles without errors
+- [x] Webpack build succeeds
+- [x] Backward compatibility maintained in formatters.js
+- [ ] Manual testing: verify usage statistics display correctly in Progress View
+- [ ] Manual testing: verify logging output shows correct field names

--- a/package-lock.json
+++ b/package-lock.json
@@ -282,7 +282,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -329,7 +328,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -780,7 +778,6 @@
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.24.3.tgz",
       "integrity": "sha512-YgSHW29fuzKKAHTGe9zjNoo+yF8KaQPzDC2W9Pv41E7/57IfY+AMGJ/aDFlgTLcVVELoggKE4syABCE75u3NCw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
@@ -1276,7 +1273,6 @@
       "integrity": "sha512-PC0PDZfJg8sP7cmKe6L3QIL8GZwU5aRvUFedqSIpw3B+QjRSUZeeITC2M5XKeMXEzL6wccN196iy3JLwKNvDVA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.48.1",
         "@typescript-eslint/types": "8.48.1",
@@ -1889,7 +1885,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2437,7 +2432,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.9",
         "caniuse-lite": "^1.0.30001746",
@@ -3524,7 +3518,6 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3923,7 +3916,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
       "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.0",
@@ -7224,6 +7216,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -7245,6 +7238,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -7764,7 +7758,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -8887,7 +8880,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9104,7 +9096,6 @@
       "integrity": "sha512-HU1JOuV1OavsZ+mfigY0j8d1TgQgbZ6M+J75zDkpEAwYeXjWSqrGJtgnPblJjd/mAyTNQ7ygw0MiKOn6etz8yw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -9154,7 +9145,6 @@
       "integrity": "sha512-MfwFQ6SfwinsUVi0rNJm7rHZ31GyTcpVE5pgVA3hwFRb7COD4TzjUUwhGWKfO50+xdc2MQPuEBBJoqIMGt3JDw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.6.1",
         "@webpack-cli/configtest": "^3.0.1",
@@ -9847,7 +9837,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.13.tgz",
       "integrity": "sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/agent/types/UsageTypes.ts
+++ b/src/agent/types/UsageTypes.ts
@@ -17,25 +17,51 @@ export type TokenUsageStats = z.infer<typeof TokenUsageStatsSchema>;
 
 /**
  * Extended statistics tracked during agent execution.
+ *
+ * Field names are aligned with NormalizedUsage for consistency:
+ * - cachedInputTokens (was cacheReadInputTokens)
+ * - cacheCreationTokens (was cacheCreationInputTokens)
+ * - responseTimeMs (was elapsedTime in seconds)
+ * - toolUsePromptTokens (was toolUseTokens)
  */
 export const ExtendedTokenUsageStatsSchema = TokenUsageStatsSchema.extend({
-  /** Total elapsed time in seconds */
-  elapsedTime: z.number().optional(),
-  /** Tokens read from cache */
-  cacheReadInputTokens: z.number().optional(),
-  /** Tokens written to cache */
-  cacheCreationInputTokens: z.number().optional(),
+  /** Response time in milliseconds */
+  responseTimeMs: z.number().optional(),
+  /** Tokens served from cache (reduces cost) */
+  cachedInputTokens: z.number().optional(),
+  /** Tokens written to cache (increases cost by 1.25x for Anthropic) */
+  cacheCreationTokens: z.number().optional(),
   /** Percentage of tokens served from cache */
   percentageCached: z.number().optional(),
   /** Tokens used for reasoning */
   reasoningTokens: z.number().optional(),
-  /** Tokens consumed by tool use */
-  toolUseTokens: z.number().optional(),
+  /** Tokens consumed by tool use prompts */
+  toolUsePromptTokens: z.number().optional(),
 });
 
 export type ExtendedTokenUsageStats = z.infer<
   typeof ExtendedTokenUsageStatsSchema
 >;
+
+/**
+ * Usage statistics for display in the Progress View.
+ * Extends TokenUsageStats with optional display-relevant fields.
+ *
+ * This is the type used when sending usage updates to the Progress View.
+ * It preserves key metrics that were previously lost (cached tokens, reasoning tokens).
+ */
+export const DisplayUsageStatsSchema = TokenUsageStatsSchema.extend({
+  /** Tokens served from cache (reduces cost) */
+  cachedInputTokens: z.number().optional(),
+  /** Tokens written to cache */
+  cacheCreationTokens: z.number().optional(),
+  /** Percentage of tokens served from cache */
+  percentageCached: z.number().optional(),
+  /** Tokens used for reasoning */
+  reasoningTokens: z.number().optional(),
+});
+
+export type DisplayUsageStats = z.infer<typeof DisplayUsageStatsSchema>;
 
 /**
  * Message interface for updating usage stats in the progress view.

--- a/src/agent/types/UsageTypes.ts
+++ b/src/agent/types/UsageTypes.ts
@@ -45,20 +45,16 @@ export type ExtendedTokenUsageStats = z.infer<
 
 /**
  * Usage statistics for display in the Progress View.
- * Extends TokenUsageStats with optional display-relevant fields.
- *
- * This is the type used when sending usage updates to the Progress View.
- * It preserves key metrics that were previously lost (cached tokens, reasoning tokens).
+ * Derived from ExtendedTokenUsageStats, picking only display-relevant fields.
  */
-export const DisplayUsageStatsSchema = TokenUsageStatsSchema.extend({
-  /** Tokens served from cache (reduces cost) */
-  cachedInputTokens: z.number().optional(),
-  /** Tokens written to cache */
-  cacheCreationTokens: z.number().optional(),
-  /** Percentage of tokens served from cache */
-  percentageCached: z.number().optional(),
-  /** Tokens used for reasoning */
-  reasoningTokens: z.number().optional(),
+export const DisplayUsageStatsSchema = ExtendedTokenUsageStatsSchema.pick({
+  inputTokens: true,
+  outputTokens: true,
+  cost: true,
+  cachedInputTokens: true,
+  cacheCreationTokens: true,
+  percentageCached: true,
+  reasoningTokens: true,
 });
 
 export type DisplayUsageStats = z.infer<typeof DisplayUsageStatsSchema>;

--- a/src/agent/types/UsageTypes.ts
+++ b/src/agent/types/UsageTypes.ts
@@ -51,10 +51,12 @@ export const DisplayUsageStatsSchema = ExtendedTokenUsageStatsSchema.pick({
   inputTokens: true,
   outputTokens: true,
   cost: true,
+  responseTimeMs: true,
   cachedInputTokens: true,
   cacheCreationTokens: true,
   percentageCached: true,
   reasoningTokens: true,
+  toolUsePromptTokens: true,
 });
 
 export type DisplayUsageStats = z.infer<typeof DisplayUsageStatsSchema>;

--- a/src/agent/utils/UsageMonitor.ts
+++ b/src/agent/utils/UsageMonitor.ts
@@ -72,11 +72,11 @@ export class UsageMonitor {
 
       const payload: ExtendedTokenUsageStats = {
         ...baseStats,
-        elapsedTime: Number(stateGlobal.totalResponseTimeMs.toFixed(1)),
+        responseTimeMs: stateGlobal.totalResponseTimeMs,
         ...(cachingStats && {
-          cacheReadInputTokens: totals.totalCacheReadInputTokens,
+          cachedInputTokens: totals.totalCacheReadInputTokens,
           ...(this.modelHandler.capabilities.supportsPromptCaching && {
-            cacheCreationInputTokens: totals.totalCacheCreationInputTokens,
+            cacheCreationTokens: totals.totalCacheCreationInputTokens,
           }),
           percentageCached: Number((percentageCached ?? 0).toFixed(2)),
         }),
@@ -85,7 +85,7 @@ export class UsageMonitor {
         }),
         // Include tool usage if any is present
         ...(totals.totalToolUsePromptTokens > 0 && {
-          toolUseTokens: totals.totalToolUsePromptTokens,
+          toolUsePromptTokens: totals.totalToolUsePromptTokens,
         }),
       };
 

--- a/src/eventBus/ProgressEventBus.ts
+++ b/src/eventBus/ProgressEventBus.ts
@@ -5,7 +5,7 @@ import { EventEmitter } from 'events';
 import type { AgentSessionDescriptor } from '@agent/core/AgentDataclass';
 import type { OutputFileInfo } from '@agent/output/types';
 import type { StreamTabId, ExecutionId } from '@agent/types/IdentifierTypes';
-import type { TokenUsageStats } from '@agent/types/UsageTypes';
+import type { DisplayUsageStats } from '@agent/types/UsageTypes';
 import type { StreamStatus } from '@common/constants/streamStatus';
 import type { LogMessageData, LogMessageUpdate } from '@logger/LogTypes';
 import type { TaskState } from '@logger/TaskState';
@@ -56,7 +56,7 @@ export interface ProgressEventPayloads {
   clearMissingOutputs: StreamTabId;
   setTaskState: SetTaskStatePayload;
   updateStreamUsage: RunScopedPayload & {
-    usage: TokenUsageStats;
+    usage: DisplayUsageStats;
   };
   showRetryRequest: RetryRequestPrompt;
   resolveRetryRequest: { streamId: StreamTabId };

--- a/src/logger/AgentUsageReporter.ts
+++ b/src/logger/AgentUsageReporter.ts
@@ -40,11 +40,24 @@ export class AgentUsageReporter {
   public report(stats: ExtendedTokenUsageStats, storageKey: StorageKey): void {
     const logStatistics = this.agentCategory === AgentCategory.Workflow;
 
-    // Pass through usage without modification
+    // Pass through usage with extended fields preserved for Progress View
     const usage = {
       inputTokens: stats.inputTokens,
       outputTokens: stats.outputTokens,
       cost: stats.cost,
+      // Preserve extended metrics for display
+      ...(stats.cachedInputTokens !== undefined && {
+        cachedInputTokens: stats.cachedInputTokens,
+      }),
+      ...(stats.cacheCreationTokens !== undefined && {
+        cacheCreationTokens: stats.cacheCreationTokens,
+      }),
+      ...(stats.percentageCached !== undefined && {
+        percentageCached: stats.percentageCached,
+      }),
+      ...(stats.reasoningTokens !== undefined && {
+        reasoningTokens: stats.reasoningTokens,
+      }),
     };
 
     // storageKey is THE single source of truth - no fallbacks, no round-trips

--- a/src/logger/AgentUsageReporter.ts
+++ b/src/logger/AgentUsageReporter.ts
@@ -46,6 +46,9 @@ export class AgentUsageReporter {
       outputTokens: stats.outputTokens,
       cost: stats.cost,
       // Preserve extended metrics for display
+      ...(stats.responseTimeMs !== undefined && {
+        responseTimeMs: stats.responseTimeMs,
+      }),
       ...(stats.cachedInputTokens !== undefined && {
         cachedInputTokens: stats.cachedInputTokens,
       }),
@@ -57,6 +60,9 @@ export class AgentUsageReporter {
       }),
       ...(stats.reasoningTokens !== undefined && {
         reasoningTokens: stats.reasoningTokens,
+      }),
+      ...(stats.toolUsePromptTokens !== undefined && {
+        toolUsePromptTokens: stats.toolUsePromptTokens,
       }),
     };
 

--- a/src/progressView/events/UsageEvents.ts
+++ b/src/progressView/events/UsageEvents.ts
@@ -2,7 +2,7 @@
 import * as vscode from 'vscode';
 
 // Type imports
-import type { TokenUsageStats } from '@agent/types/UsageTypes';
+import type { DisplayUsageStats } from '@agent/types/UsageTypes';
 import type { WebviewUpdater } from '@progressView/managers';
 import type { ProgressViewState } from '@progressView/state/ProgressViewState';
 
@@ -40,10 +40,24 @@ export function createUsageEvents(
         'updateStreamUsage',
         ({ stream, usage, storageKey }) => {
           withErrorBoundary('failed to handle updateStreamUsage', async () => {
-            const normalizedUsage: TokenUsageStats = {
+            // Preserve extended fields for richer UI display
+            const normalizedUsage: DisplayUsageStats = {
               inputTokens: Number(usage.inputTokens ?? 0),
               outputTokens: Number(usage.outputTokens ?? 0),
               cost: Number(usage.cost ?? 0),
+              // Preserve extended metrics when present
+              ...(usage.cachedInputTokens !== undefined && {
+                cachedInputTokens: Number(usage.cachedInputTokens),
+              }),
+              ...(usage.cacheCreationTokens !== undefined && {
+                cacheCreationTokens: Number(usage.cacheCreationTokens),
+              }),
+              ...(usage.percentageCached !== undefined && {
+                percentageCached: Number(usage.percentageCached),
+              }),
+              ...(usage.reasoningTokens !== undefined && {
+                reasoningTokens: Number(usage.reasoningTokens),
+              }),
             };
 
             // storageKey is THE single source of truth - no fallbacks

--- a/src/progressView/events/UsageEvents.ts
+++ b/src/progressView/events/UsageEvents.ts
@@ -46,6 +46,9 @@ export function createUsageEvents(
               outputTokens: Number(usage.outputTokens ?? 0),
               cost: Number(usage.cost ?? 0),
               // Preserve extended metrics when present
+              ...(usage.responseTimeMs !== undefined && {
+                responseTimeMs: Number(usage.responseTimeMs),
+              }),
               ...(usage.cachedInputTokens !== undefined && {
                 cachedInputTokens: Number(usage.cachedInputTokens),
               }),
@@ -57,6 +60,9 @@ export function createUsageEvents(
               }),
               ...(usage.reasoningTokens !== undefined && {
                 reasoningTokens: Number(usage.reasoningTokens),
+              }),
+              ...(usage.toolUsePromptTokens !== undefined && {
+                toolUsePromptTokens: Number(usage.toolUsePromptTokens),
               }),
             };
 

--- a/src/progressView/managers/UsageStatsManager.ts
+++ b/src/progressView/managers/UsageStatsManager.ts
@@ -41,19 +41,23 @@ const DisplayUsageStatsParsingSchema = z
     outputTokens: FiniteNumber,
     cost: FiniteNumber,
     // Extended fields - preserved for display
+    responseTimeMs: OptionalFiniteNumber,
     cachedInputTokens: OptionalFiniteNumber,
     cacheCreationTokens: OptionalFiniteNumber,
     percentageCached: OptionalFiniteNumber,
     reasoningTokens: OptionalFiniteNumber,
+    toolUsePromptTokens: OptionalFiniteNumber,
   })
   .catch({
     inputTokens: 0,
     outputTokens: 0,
     cost: 0,
+    responseTimeMs: undefined,
     cachedInputTokens: undefined,
     cacheCreationTokens: undefined,
     percentageCached: undefined,
     reasoningTokens: undefined,
+    toolUsePromptTokens: undefined,
   });
 
 // Compile-time assertion: ensure parsing schema produces type compatible with DisplayUsageStats

--- a/src/progressView/managers/UsageStatsManager.ts
+++ b/src/progressView/managers/UsageStatsManager.ts
@@ -4,7 +4,10 @@ import { z } from 'zod';
 // Local imports - identifiers
 import type { StorageKey, StreamTabId } from '@agent/types/IdentifierTypes';
 // Types - import canonical type (schema defines structure)
-import { type TokenUsageStats } from '@agent/types/UsageTypes';
+import {
+  type TokenUsageStats,
+  type DisplayUsageStats,
+} from '@agent/types/UsageTypes';
 import { normalizeRunId } from '@common/constants/runIds';
 import { WorkspaceStateKey } from '@common/state/stateManager';
 import { AgentLogger } from '@logger/AgentLogger';
@@ -21,35 +24,55 @@ const FiniteNumber = z.coerce
   .number()
   .transform((n) => (Number.isFinite(n) ? n : 0));
 
+/** Coerces input to optional number, preserving undefined */
+const OptionalFiniteNumber = z.coerce
+  .number()
+  .optional()
+  .transform((n) => (n !== undefined && Number.isFinite(n) ? n : undefined));
+
 /**
- * Schema for parsing TokenUsageStats with safe number coercion.
+ * Schema for parsing DisplayUsageStats with safe number coercion.
  * Extends the canonical schema shape with coercion for persistence resilience.
+ * Includes optional extended fields for richer UI display.
  */
-const TokenUsageStatsParsingSchema = z
+const DisplayUsageStatsParsingSchema = z
   .object({
     inputTokens: FiniteNumber,
     outputTokens: FiniteNumber,
     cost: FiniteNumber,
+    // Extended fields - preserved for display
+    cachedInputTokens: OptionalFiniteNumber,
+    cacheCreationTokens: OptionalFiniteNumber,
+    percentageCached: OptionalFiniteNumber,
+    reasoningTokens: OptionalFiniteNumber,
   })
-  .catch({ inputTokens: 0, outputTokens: 0, cost: 0 });
+  .catch({
+    inputTokens: 0,
+    outputTokens: 0,
+    cost: 0,
+    cachedInputTokens: undefined,
+    cacheCreationTokens: undefined,
+    percentageCached: undefined,
+    reasoningTokens: undefined,
+  });
 
-// Compile-time assertion: ensure parsing schema produces type compatible with TokenUsageStats
+// Compile-time assertion: ensure parsing schema produces type compatible with DisplayUsageStats
 type _AssertSchemaCompatible =
-  z.infer<typeof TokenUsageStatsParsingSchema> extends TokenUsageStats
+  z.infer<typeof DisplayUsageStatsParsingSchema> extends DisplayUsageStats
     ? true
     : never;
 const _assertCompatible: _AssertSchemaCompatible = true;
 
 /** Checks if usage stats are all zeros (effectively empty) */
-function isEmptyUsage(usage: TokenUsageStats): boolean {
+function isEmptyUsage(usage: DisplayUsageStats): boolean {
   return (
     usage.inputTokens === 0 && usage.outputTokens === 0 && usage.cost === 0
   );
 }
 
-/** Schema for run map format: { runId: { inputTokens, outputTokens, cost } } */
+/** Schema for run map format: { runId: DisplayUsageStats } */
 const UsageDataSchema = createSingleValueRunMapSchema(
-  TokenUsageStatsParsingSchema,
+  DisplayUsageStatsParsingSchema,
   {
     isEmpty: isEmptyUsage,
   },
@@ -58,8 +81,9 @@ const UsageDataSchema = createSingleValueRunMapSchema(
 /**
  * Manages usage statistics collection with persistence.
  * Handles tracking and updating token usage and costs for different streams.
+ * Now stores DisplayUsageStats which includes extended metrics (cached tokens, reasoning tokens).
  */
-type RunUsageMap = Map<string, TokenUsageStats>;
+type RunUsageMap = Map<string, DisplayUsageStats>;
 
 /** Stream ID used for migrated legacy data */
 const LEGACY_MIGRATION_STREAM = '_legacy_migrated_' as StreamTabId;
@@ -84,11 +108,11 @@ export class UsageStatsManager extends PersistentMapManager<
   async setRunUsage(
     stream: StreamTabId,
     storageKey: StorageKey,
-    usage: TokenUsageStats,
+    usage: DisplayUsageStats,
   ): Promise<void> {
-    const normalized = TokenUsageStatsParsingSchema.parse(usage);
+    const normalized = DisplayUsageStatsParsingSchema.parse(usage);
     const current =
-      this.items.get(stream) ?? new Map<string, TokenUsageStats>();
+      this.items.get(stream) ?? new Map<string, DisplayUsageStats>();
     if (
       normalized.inputTokens === 0 &&
       normalized.outputTokens === 0 &&
@@ -169,7 +193,7 @@ export class UsageStatsManager extends PersistentMapManager<
    * Set all usage statistics (used during loading)
    */
   setAll(
-    stats: Map<StreamTabId, RunUsageMap> | Map<StreamTabId, TokenUsageStats>,
+    stats: Map<StreamTabId, RunUsageMap> | Map<StreamTabId, DisplayUsageStats>,
   ): void {
     const normalized: Map<StreamTabId, RunUsageMap> = new Map();
 
@@ -183,7 +207,7 @@ export class UsageStatsManager extends PersistentMapManager<
         continue;
       }
 
-      const usage = TokenUsageStatsParsingSchema.parse(value);
+      const usage = DisplayUsageStatsParsingSchema.parse(value);
       if (
         usage.inputTokens === 0 &&
         usage.outputTokens === 0 &&
@@ -275,7 +299,7 @@ export class UsageStatsManager extends PersistentMapManager<
     }
 
     const totals = legacy.usageAccumulator.totals;
-    const usage: TokenUsageStats = TokenUsageStatsParsingSchema.parse({
+    const usage: DisplayUsageStats = DisplayUsageStatsParsingSchema.parse({
       inputTokens: totals.totalInputTokens ?? 0,
       outputTokens: totals.totalOutputTokens ?? 0,
       cost: totals.totalCost ?? 0,
@@ -294,7 +318,7 @@ export class UsageStatsManager extends PersistentMapManager<
     // Store under legacy migration identifiers
     const existing =
       this.items.get(LEGACY_MIGRATION_STREAM) ??
-      new Map<string, TokenUsageStats>();
+      new Map<string, DisplayUsageStats>();
     existing.set(LEGACY_MIGRATION_RUN_ID, usage);
     this.items.set(LEGACY_MIGRATION_STREAM, existing);
 

--- a/src/progressView/managers/WebviewUpdater.ts
+++ b/src/progressView/managers/WebviewUpdater.ts
@@ -6,7 +6,10 @@ import type { OutputFileInfo } from '@agent/output/types';
 import type { StreamTabId } from '@agent/types/IdentifierTypes';
 import type { AgentTypeFilter } from '@agent/types/AgentStreamTypes';
 // Types
-import type { TokenUsageStats } from '@agent/types/UsageTypes';
+import type {
+  DisplayUsageStats,
+  TokenUsageStats,
+} from '@agent/types/UsageTypes';
 
 import {
   STREAM_STATUS,
@@ -245,11 +248,12 @@ export class WebviewUpdater {
   /**
    * Update usage for a single run (incremental).
    * More efficient than updateUsage when only one run's usage changed.
+   * Now passes extended usage stats (cached tokens, reasoning tokens) to UI.
    */
   updateRunUsage(
     stream: StreamTabId,
     runId: string,
-    usage: TokenUsageStats,
+    usage: DisplayUsageStats,
   ): void {
     this.sendMessage({
       command: COMMANDS.UPDATE_RUN_USAGE,

--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -1339,18 +1339,20 @@ export class LogEntryFormatter {
         formatTokens(parsed.outputTokens),
       );
     }
-    if (parsed.cacheReadInputTokens !== undefined) {
-      pushItem(
-        'codicon-history',
-        'Cache hits',
-        formatTokens(parsed.cacheReadInputTokens),
-      );
+    // Support both new field names (cachedInputTokens) and legacy (cacheReadInputTokens)
+    const cachedInputTokens =
+      parsed.cachedInputTokens ?? parsed.cacheReadInputTokens;
+    if (cachedInputTokens !== undefined) {
+      pushItem('codicon-history', 'Cache hits', formatTokens(cachedInputTokens));
     }
-    if (parsed.cacheCreationInputTokens !== undefined) {
+    // Support both new field names (cacheCreationTokens) and legacy (cacheCreationInputTokens)
+    const cacheCreationTokens =
+      parsed.cacheCreationTokens ?? parsed.cacheCreationInputTokens;
+    if (cacheCreationTokens !== undefined) {
       pushItem(
         'codicon-save',
         'Cache writes',
-        formatTokens(parsed.cacheCreationInputTokens),
+        formatTokens(cacheCreationTokens),
       );
     }
     if (parsed.percentageCached !== undefined) {
@@ -1367,15 +1369,23 @@ export class LogEntryFormatter {
         formatTokens(parsed.reasoningTokens),
       );
     }
-    if (parsed.toolUseTokens !== undefined) {
+    // Support both new field names (toolUsePromptTokens) and legacy (toolUseTokens)
+    const toolUsePromptTokens =
+      parsed.toolUsePromptTokens ?? parsed.toolUseTokens;
+    if (toolUsePromptTokens !== undefined) {
       pushItem(
         'codicon-tools',
         'Tool tokens',
-        formatTokens(parsed.toolUseTokens),
+        formatTokens(toolUsePromptTokens),
       );
     }
-    if (parsed.elapsedTime !== undefined) {
-      pushItem('codicon-clock', 'Elapsed time', parsed.elapsedTime, 's');
+    // Support both new field names (responseTimeMs) and legacy (elapsedTime in seconds)
+    const responseTimeMs =
+      parsed.responseTimeMs ?? (parsed.elapsedTime ? parsed.elapsedTime * 1000 : undefined);
+    if (responseTimeMs !== undefined) {
+      // Convert ms to seconds with 1 decimal for display
+      const seconds = (responseTimeMs / 1000).toFixed(1);
+      pushItem('codicon-clock', 'Elapsed time', seconds, 's');
     }
     if (parsed.cost !== undefined) {
       pushItem('codicon-rocket', 'Cost', `$${parsed.cost.toFixed(3)}`);

--- a/src/test/logger/AgentUsageReporter.test.ts
+++ b/src/test/logger/AgentUsageReporter.test.ts
@@ -46,7 +46,7 @@ describe('AgentUsageReporter', () => {
       inputTokens: 10,
       outputTokens: 5,
       cost: 0.25,
-      cacheCreationInputTokens: 4,
+      cacheCreationTokens: 4,
     };
 
     try {
@@ -98,7 +98,7 @@ describe('AgentUsageReporter', () => {
       inputTokens: 6,
       outputTokens: 2,
       cost: 0.1,
-      cacheCreationInputTokens: 1,
+      cacheCreationTokens: 1,
     };
 
     try {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Renames ExtendedTokenUsageStats to match NormalizedUsage and introduces DisplayUsageStats to propagate extended usage metrics (incl. responseTimeMs, caching, reasoning, tool use) to the Progress View with backward-compatible formatting.
> 
> - **Types/Usage schema**
>   - Rename `ExtendedTokenUsageStats` fields to match `NormalizedUsage` (`cacheReadInputTokens`→`cachedInputTokens`, `cacheCreationInputTokens`→`cacheCreationTokens`, `elapsedTime`→`responseTimeMs` ms, `toolUseTokens`→`toolUsePromptTokens`).
>   - Add `DisplayUsageStats` (extends `TokenUsageStats` with optional extended fields) and parsing schema.
> - **Event/reporting pipeline**
>   - `UsageMonitor`: build payload with new field names (`responseTimeMs`, caching/reasoning/tool tokens).
>   - `AgentUsageReporter`: forward extended fields; emit `updateStreamUsage` with `DisplayUsageStats`.
>   - `ProgressEventBus`/`UsageEvents`: update `updateStreamUsage` typing and preserve extended fields; coerce numbers.
> - **Progress View**
>   - `UsageStatsManager`: store `DisplayUsageStats`; totals and (legacy) migration updated to new schema.
>   - `WebviewUpdater`: `updateRunUsage` now accepts `DisplayUsageStats`.
>   - `formatters.js`: backward-compatible display for old/new field names; convert `responseTimeMs`→seconds for UI.
> - **Tests/Docs**
>   - Update `AgentUsageReporter.test.ts` fixtures to new fields.
>   - Add `docs/data-structure-simplification-plan.md` describing the plan and implemented steps.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d557ca13f82ed2b788a272e7f9ab84041ee2c64f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->