### PR TITLE
Replace manual status codes with http-status-codes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "gpt-tokenizer": "^3.4.0",
         "he": "^1.2.0",
         "highlight.js": "^11.11.1",
+        "http-status-codes": "^2.3.0",
         "identifiers-arxiv": "^0.1.1",
         "katex": "^0.16.27",
         "markdown-it": "^14.1.0",
@@ -4870,6 +4871,12 @@
       "engines": {
         "node": ">= 14"
       }
+    },
+    "node_modules/http-status-codes": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.3.0.tgz",
+      "integrity": "sha512-RJ8XvFvpPM/Dmc5SV+dC4y5PCeOhT3x1Hq0NU3rjGeg5a/CqlhZ7uudknPwZFz4aeAXDcbAyaeP7GAo9lvngtA==",
+      "license": "MIT"
     },
     "node_modules/https-proxy-agent": {
       "version": "7.0.6",

--- a/package.json
+++ b/package.json
@@ -1634,6 +1634,7 @@
     "gpt-tokenizer": "^3.4.0",
     "he": "^1.2.0",
     "highlight.js": "^11.11.1",
+    "http-status-codes": "^2.3.0",
     "identifiers-arxiv": "^0.1.1",
     "katex": "^0.16.27",
     "markdown-it": "^14.1.0",

--- a/src/agent/remote/RemoteAgentLoader.ts
+++ b/src/agent/remote/RemoteAgentLoader.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import { StatusCodes } from 'http-status-codes';
 import yaml from 'yaml';
 import {
   AgentSetting,
@@ -99,9 +100,9 @@ export class RemoteAgentLoader {
         });
 
         if (!response.ok) {
-          if (response.status === 401) {
+          if (response.status === StatusCodes.UNAUTHORIZED) {
             throw new Error('Session expired. Sign in again to continue.');
-          } else if (response.status === 404) {
+          } else if (response.status === StatusCodes.NOT_FOUND) {
             // If not found and we have more candidates to try, continue to next
             if (candidateName !== candidateNames[candidateNames.length - 1]) {
               logger.debug(
@@ -116,7 +117,7 @@ export class RemoteAgentLoader {
             throw new Error(
               `Agent "${agentName}" not found or access denied. Verify the agent name and your permissions.`,
             );
-          } else if (response.status === 403) {
+          } else if (response.status === StatusCodes.FORBIDDEN) {
             throw new Error(
               `Access denied to agent "${agentName}". Upgrade your account for access.`,
             );
@@ -130,7 +131,7 @@ export class RemoteAgentLoader {
 
             // Provide more helpful error message for storage-related failures
             if (
-              response.status === 500 &&
+              response.status === StatusCodes.INTERNAL_SERVER_ERROR &&
               errorText.includes('Failed to load agent configuration')
             ) {
               throw new Error(

--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -57,25 +57,6 @@ export interface ProviderHttpErrorDetails {
 }
 
 /**
- * Custom descriptions for HTTP status codes used in error messages.
- * Status text/titles are obtained via getReasonPhrase() from http-status-codes.
- */
-const HTTP_STATUS_DESCRIPTIONS: Record<number, string> = {
-  [StatusCodes.BAD_REQUEST]: 'Invalid parameters',
-  [StatusCodes.UNAUTHORIZED]: 'Invalid API key',
-  [StatusCodes.PAYMENT_REQUIRED]: 'Insufficient credits',
-  [StatusCodes.FORBIDDEN]: 'Permission denied',
-  [StatusCodes.NOT_FOUND]: 'Resource not found',
-  [StatusCodes.CONFLICT]: 'Conflict error',
-  [StatusCodes.UNPROCESSABLE_ENTITY]: 'Unprocessable entity',
-  [StatusCodes.TOO_MANY_REQUESTS]: 'Rate limit exceeded',
-  [StatusCodes.INTERNAL_SERVER_ERROR]: 'Provider error',
-  [StatusCodes.BAD_GATEWAY]: 'Provider error',
-  [StatusCodes.SERVICE_UNAVAILABLE]: 'No available providers',
-  [StatusCodes.GATEWAY_TIMEOUT]: 'Provider timeout',
-};
-
-/**
  * Safely get the reason phrase for a status code.
  * Returns undefined if the status code is not recognized.
  */
@@ -278,7 +259,7 @@ function matchNativeHttpError(
   const statusText = detectStatusText(err, statusCode);
   const requestId = detectRequestId(err);
   const fallbackMessage = statusCode
-    ? HTTP_STATUS_DESCRIPTIONS[statusCode]
+    ? safeGetReasonPhrase(statusCode)
     : undefined;
   const finalMessage =
     extractMessage(err) ?? fallbackMessage ?? 'Provider request failed';
@@ -476,7 +457,7 @@ export function formatProviderHttpError(
   const requestId = detectRequestId(err);
 
   const fallbackMessage = statusCode
-    ? HTTP_STATUS_DESCRIPTIONS[statusCode]
+    ? safeGetReasonPhrase(statusCode)
     : undefined;
   const finalMessage =
     extractMessage(err) ?? fallbackMessage ?? 'Provider request failed';

--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -1,5 +1,5 @@
 // Third-party imports
-import { ReasonPhrases, StatusCodes } from 'http-status-codes';
+import { getReasonPhrase, StatusCodes } from 'http-status-codes';
 import {
   APIConnectionError as AnthropicConnectionError,
   APIConnectionTimeoutError as AnthropicConnectionTimeoutError,
@@ -57,59 +57,35 @@ export interface ProviderHttpErrorDetails {
 }
 
 /**
- * HTTP status information - single source of truth for status titles and descriptions.
+ * Custom descriptions for HTTP status codes used in error messages.
+ * Status text/titles are obtained via getReasonPhrase() from http-status-codes.
  */
-const HTTP_STATUS_INFO: Record<number, { title: string; description: string }> =
-  {
-    [StatusCodes.BAD_REQUEST]: {
-      title: ReasonPhrases.BAD_REQUEST,
-      description: 'Invalid parameters',
-    },
-    [StatusCodes.UNAUTHORIZED]: {
-      title: ReasonPhrases.UNAUTHORIZED,
-      description: 'Invalid API key',
-    },
-    [StatusCodes.PAYMENT_REQUIRED]: {
-      title: ReasonPhrases.PAYMENT_REQUIRED,
-      description: 'Insufficient credits',
-    },
-    [StatusCodes.FORBIDDEN]: {
-      title: ReasonPhrases.FORBIDDEN,
-      description: 'Permission denied',
-    },
-    [StatusCodes.NOT_FOUND]: {
-      title: ReasonPhrases.NOT_FOUND,
-      description: 'Resource not found',
-    },
-    [StatusCodes.CONFLICT]: {
-      title: ReasonPhrases.CONFLICT,
-      description: 'Conflict error',
-    },
-    [StatusCodes.UNPROCESSABLE_ENTITY]: {
-      title: ReasonPhrases.UNPROCESSABLE_ENTITY,
-      description: 'Unprocessable entity',
-    },
-    [StatusCodes.TOO_MANY_REQUESTS]: {
-      title: ReasonPhrases.TOO_MANY_REQUESTS,
-      description: 'Rate limit exceeded',
-    },
-    [StatusCodes.INTERNAL_SERVER_ERROR]: {
-      title: ReasonPhrases.INTERNAL_SERVER_ERROR,
-      description: 'Provider error',
-    },
-    [StatusCodes.BAD_GATEWAY]: {
-      title: ReasonPhrases.BAD_GATEWAY,
-      description: 'Provider error',
-    },
-    [StatusCodes.SERVICE_UNAVAILABLE]: {
-      title: ReasonPhrases.SERVICE_UNAVAILABLE,
-      description: 'No available providers',
-    },
-    [StatusCodes.GATEWAY_TIMEOUT]: {
-      title: ReasonPhrases.GATEWAY_TIMEOUT,
-      description: 'Provider timeout',
-    },
-  };
+const HTTP_STATUS_DESCRIPTIONS: Record<number, string> = {
+  [StatusCodes.BAD_REQUEST]: 'Invalid parameters',
+  [StatusCodes.UNAUTHORIZED]: 'Invalid API key',
+  [StatusCodes.PAYMENT_REQUIRED]: 'Insufficient credits',
+  [StatusCodes.FORBIDDEN]: 'Permission denied',
+  [StatusCodes.NOT_FOUND]: 'Resource not found',
+  [StatusCodes.CONFLICT]: 'Conflict error',
+  [StatusCodes.UNPROCESSABLE_ENTITY]: 'Unprocessable entity',
+  [StatusCodes.TOO_MANY_REQUESTS]: 'Rate limit exceeded',
+  [StatusCodes.INTERNAL_SERVER_ERROR]: 'Provider error',
+  [StatusCodes.BAD_GATEWAY]: 'Provider error',
+  [StatusCodes.SERVICE_UNAVAILABLE]: 'No available providers',
+  [StatusCodes.GATEWAY_TIMEOUT]: 'Provider timeout',
+};
+
+/**
+ * Safely get the reason phrase for a status code.
+ * Returns undefined if the status code is not recognized.
+ */
+function safeGetReasonPhrase(statusCode: number): string | undefined {
+  try {
+    return getReasonPhrase(statusCode);
+  } catch {
+    return undefined;
+  }
+}
 
 type ErrorConstructor<T extends Error = Error> = abstract new (
   ...args: never[]
@@ -302,7 +278,7 @@ function matchNativeHttpError(
   const statusText = detectStatusText(err, statusCode);
   const requestId = detectRequestId(err);
   const fallbackMessage = statusCode
-    ? HTTP_STATUS_INFO[statusCode]?.description
+    ? HTTP_STATUS_DESCRIPTIONS[statusCode]
     : undefined;
   const finalMessage =
     extractMessage(err) ?? fallbackMessage ?? 'Provider request failed';
@@ -365,7 +341,7 @@ function detectStatusText(
   statusCode?: number,
 ): string | undefined {
   if (!err || typeof err !== 'object') {
-    return statusCode ? HTTP_STATUS_INFO[statusCode]?.title : undefined;
+    return statusCode ? safeGetReasonPhrase(statusCode) : undefined;
   }
 
   const candidate = err as {
@@ -378,7 +354,7 @@ function detectStatusText(
     candidate.statusText ??
     candidate.response?.statusText ??
     candidate.error?.statusText ??
-    (statusCode ? HTTP_STATUS_INFO[statusCode]?.title : undefined)
+    (statusCode ? safeGetReasonPhrase(statusCode) : undefined)
   );
 }
 
@@ -500,7 +476,7 @@ export function formatProviderHttpError(
   const requestId = detectRequestId(err);
 
   const fallbackMessage = statusCode
-    ? HTTP_STATUS_INFO[statusCode]?.description
+    ? HTTP_STATUS_DESCRIPTIONS[statusCode]
     : undefined;
   const finalMessage =
     extractMessage(err) ?? fallbackMessage ?? 'Provider request failed';

--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -1,4 +1,5 @@
 // Third-party imports
+import { ReasonPhrases, StatusCodes } from 'http-status-codes';
 import {
   APIConnectionError as AnthropicConnectionError,
   APIConnectionTimeoutError as AnthropicConnectionTimeoutError,
@@ -60,21 +61,54 @@ export interface ProviderHttpErrorDetails {
  */
 const HTTP_STATUS_INFO: Record<number, { title: string; description: string }> =
   {
-    400: { title: 'Bad Request', description: 'Invalid parameters' },
-    401: { title: 'Unauthorized', description: 'Invalid API key' },
-    402: { title: 'Payment Required', description: 'Insufficient credits' },
-    403: { title: 'Forbidden', description: 'Permission denied' },
-    404: { title: 'Not Found', description: 'Resource not found' },
-    409: { title: 'Conflict', description: 'Conflict error' },
-    422: { title: 'Unprocessable Entity', description: 'Unprocessable entity' },
-    429: { title: 'Too Many Requests', description: 'Rate limit exceeded' },
-    500: { title: 'Internal Server Error', description: 'Provider error' },
-    502: { title: 'Bad Gateway', description: 'Provider error' },
-    503: {
-      title: 'Service Unavailable',
+    [StatusCodes.BAD_REQUEST]: {
+      title: ReasonPhrases.BAD_REQUEST,
+      description: 'Invalid parameters',
+    },
+    [StatusCodes.UNAUTHORIZED]: {
+      title: ReasonPhrases.UNAUTHORIZED,
+      description: 'Invalid API key',
+    },
+    [StatusCodes.PAYMENT_REQUIRED]: {
+      title: ReasonPhrases.PAYMENT_REQUIRED,
+      description: 'Insufficient credits',
+    },
+    [StatusCodes.FORBIDDEN]: {
+      title: ReasonPhrases.FORBIDDEN,
+      description: 'Permission denied',
+    },
+    [StatusCodes.NOT_FOUND]: {
+      title: ReasonPhrases.NOT_FOUND,
+      description: 'Resource not found',
+    },
+    [StatusCodes.CONFLICT]: {
+      title: ReasonPhrases.CONFLICT,
+      description: 'Conflict error',
+    },
+    [StatusCodes.UNPROCESSABLE_ENTITY]: {
+      title: ReasonPhrases.UNPROCESSABLE_ENTITY,
+      description: 'Unprocessable entity',
+    },
+    [StatusCodes.TOO_MANY_REQUESTS]: {
+      title: ReasonPhrases.TOO_MANY_REQUESTS,
+      description: 'Rate limit exceeded',
+    },
+    [StatusCodes.INTERNAL_SERVER_ERROR]: {
+      title: ReasonPhrases.INTERNAL_SERVER_ERROR,
+      description: 'Provider error',
+    },
+    [StatusCodes.BAD_GATEWAY]: {
+      title: ReasonPhrases.BAD_GATEWAY,
+      description: 'Provider error',
+    },
+    [StatusCodes.SERVICE_UNAVAILABLE]: {
+      title: ReasonPhrases.SERVICE_UNAVAILABLE,
       description: 'No available providers',
     },
-    504: { title: 'Gateway Timeout', description: 'Provider timeout' },
+    [StatusCodes.GATEWAY_TIMEOUT]: {
+      title: ReasonPhrases.GATEWAY_TIMEOUT,
+      description: 'Provider timeout',
+    },
   };
 
 type ErrorConstructor<T extends Error = Error> = abstract new (
@@ -135,69 +169,85 @@ const NATIVE_MESSAGE_ERRORS: NativeMessageErrorEntry[] = [
 ];
 
 const NATIVE_HTTP_ERRORS: NativeHttpErrorEntry[] = [
-  { ctor: OpenAIBadRequestError, provider: 'openai', fallbackStatusCode: 400 },
+  {
+    ctor: OpenAIBadRequestError,
+    provider: 'openai',
+    fallbackStatusCode: StatusCodes.BAD_REQUEST,
+  },
   {
     ctor: AnthropicBadRequestError,
     provider: 'anthropic',
-    fallbackStatusCode: 400,
+    fallbackStatusCode: StatusCodes.BAD_REQUEST,
   },
   {
     ctor: OpenAIAuthenticationError,
     provider: 'openai',
-    fallbackStatusCode: 401,
+    fallbackStatusCode: StatusCodes.UNAUTHORIZED,
   },
   {
     ctor: AnthropicAuthenticationError,
     provider: 'anthropic',
-    fallbackStatusCode: 401,
+    fallbackStatusCode: StatusCodes.UNAUTHORIZED,
   },
   {
     ctor: OpenAIPermissionDeniedError,
     provider: 'openai',
-    fallbackStatusCode: 403,
+    fallbackStatusCode: StatusCodes.FORBIDDEN,
   },
   {
     ctor: AnthropicPermissionDeniedError,
     provider: 'anthropic',
-    fallbackStatusCode: 403,
+    fallbackStatusCode: StatusCodes.FORBIDDEN,
   },
-  { ctor: OpenAINotFoundError, provider: 'openai', fallbackStatusCode: 404 },
+  {
+    ctor: OpenAINotFoundError,
+    provider: 'openai',
+    fallbackStatusCode: StatusCodes.NOT_FOUND,
+  },
   {
     ctor: AnthropicNotFoundError,
     provider: 'anthropic',
-    fallbackStatusCode: 404,
+    fallbackStatusCode: StatusCodes.NOT_FOUND,
   },
-  { ctor: OpenAIConflictError, provider: 'openai', fallbackStatusCode: 409 },
+  {
+    ctor: OpenAIConflictError,
+    provider: 'openai',
+    fallbackStatusCode: StatusCodes.CONFLICT,
+  },
   {
     ctor: AnthropicConflictError,
     provider: 'anthropic',
-    fallbackStatusCode: 409,
+    fallbackStatusCode: StatusCodes.CONFLICT,
   },
   {
     ctor: OpenAIUnprocessableEntityError,
     provider: 'openai',
-    fallbackStatusCode: 422,
+    fallbackStatusCode: StatusCodes.UNPROCESSABLE_ENTITY,
   },
   {
     ctor: AnthropicUnprocessableEntityError,
     provider: 'anthropic',
-    fallbackStatusCode: 422,
+    fallbackStatusCode: StatusCodes.UNPROCESSABLE_ENTITY,
   },
-  { ctor: OpenAIRateLimitError, provider: 'openai', fallbackStatusCode: 429 },
+  {
+    ctor: OpenAIRateLimitError,
+    provider: 'openai',
+    fallbackStatusCode: StatusCodes.TOO_MANY_REQUESTS,
+  },
   {
     ctor: AnthropicRateLimitError,
     provider: 'anthropic',
-    fallbackStatusCode: 429,
+    fallbackStatusCode: StatusCodes.TOO_MANY_REQUESTS,
   },
   {
     ctor: OpenAIInternalServerError,
     provider: 'openai',
-    fallbackStatusCode: 500,
+    fallbackStatusCode: StatusCodes.INTERNAL_SERVER_ERROR,
   },
   {
     ctor: AnthropicInternalServerError,
     provider: 'anthropic',
-    fallbackStatusCode: 500,
+    fallbackStatusCode: StatusCodes.INTERNAL_SERVER_ERROR,
   },
   { ctor: OpenAIAPIError, provider: 'openai' },
   { ctor: AnthropicAPIError, provider: 'anthropic' },
@@ -220,14 +270,21 @@ function matchNativeMessageError(
 }
 
 /** Status codes that are retryable (5xx server errors, rate limits, timeouts) */
-const RETRYABLE_STATUS_CODES = new Set([408, 429, 500, 502, 503, 504]);
+const RETRYABLE_STATUS_CODES = new Set([
+  StatusCodes.REQUEST_TIMEOUT,
+  StatusCodes.TOO_MANY_REQUESTS,
+  StatusCodes.INTERNAL_SERVER_ERROR,
+  StatusCodes.BAD_GATEWAY,
+  StatusCodes.SERVICE_UNAVAILABLE,
+  StatusCodes.GATEWAY_TIMEOUT,
+]);
 
 function isRetryableStatusCode(statusCode?: number): boolean {
   if (statusCode === undefined) {
     return false;
   }
   // All 5xx errors are retryable
-  if (statusCode >= 500) {
+  if (statusCode >= StatusCodes.INTERNAL_SERVER_ERROR) {
     return true;
   }
   return RETRYABLE_STATUS_CODES.has(statusCode);

--- a/src/latex/arxivProcessor.ts
+++ b/src/latex/arxivProcessor.ts
@@ -4,6 +4,7 @@ import { pipeline } from 'node:stream/promises';
 
 // Third-party imports
 import axios from 'axios';
+import { StatusCodes } from 'http-status-codes';
 import * as arxivIdentifiers from 'identifiers-arxiv';
 import * as tar from 'tar';
 
@@ -58,11 +59,11 @@ export class ArxivSourceProcessor {
         timeout,
       });
 
-      if (response.status === 404) {
+      if (response.status === StatusCodes.NOT_FOUND) {
         throw new Error('Source not available for this arXiv ID');
       }
 
-      if (response.status !== 200) {
+      if (response.status !== StatusCodes.OK) {
         throw new Error(`Failed to download: HTTP ${response.status}`);
       }
 

--- a/src/tools/web/WebFetchTool.ts
+++ b/src/tools/web/WebFetchTool.ts
@@ -3,6 +3,7 @@ import { isIP } from 'node:net';
 
 // Third-party imports
 import axios from 'axios';
+import { StatusCodes } from 'http-status-codes';
 import TurndownService from 'turndown';
 import { z } from 'zod';
 
@@ -83,7 +84,8 @@ export class WebFetchTool extends defineTool({
         maxRedirects: 5,
         maxContentLength: 10 * 1024 * 1024,
         maxBodyLength: 10 * 1024 * 1024,
-        validateStatus: (status) => status >= 200 && status < 400,
+        validateStatus: (status) =>
+          status >= StatusCodes.OK && status < StatusCodes.BAD_REQUEST,
       });
     } catch (error) {
       if (axios.isAxiosError(error)) {


### PR DESCRIPTION
…kage

Replace hardcoded numeric HTTP status codes with constants from the http-status-codes npm package for better readability and maintainability.

- Add http-status-codes as a dependency
- Update sdkErrorUtils.ts to use StatusCodes and ReasonPhrases
- Update RemoteAgentLoader.ts to use StatusCodes for error handling
- Update arxivProcessor.ts to use StatusCodes for response checks
- Update WebFetchTool.ts to use StatusCodes for status validation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace numeric HTTP status codes with `http-status-codes` constants and reason phrases in error handling and fetch logic; add the package as a dependency.
> 
> - **Errors**:
>   - Replace hardcoded codes with `StatusCodes` and derive messages via `getReasonPhrase` in `src/common/errors/sdkErrorUtils.ts`.
>   - Remove custom `HTTP_STATUS_INFO`; add `safeGetReasonPhrase`; update retryable code set and comparisons to use constants.
>   - Expand `NATIVE_HTTP_ERRORS` fallback codes to use `StatusCodes`.
> - **Remote Agents**:
>   - Update HTTP checks in `src/agent/remote/RemoteAgentLoader.ts` to use `StatusCodes` (401/403/404/500).
> - **Web Tool**:
>   - Use `StatusCodes` in `validateStatus` range in `src/tools/web/WebFetchTool.ts`.
> - **LaTeX/arXiv**:
>   - Use `StatusCodes` for 200/404 checks in `src/latex/arxivProcessor.ts`.
> - **Dependencies**:
>   - Add `http-status-codes` to `package.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cad0503bfeed2e494bc4604288781de76668b3c6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->