### PR TITLE
Add DeepSeek model configuration details

### DIFF
--- a/src/agent/modelHandlers/modelHandlerOpenRouter.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenRouter.ts
@@ -43,19 +43,24 @@ export class ModelHandlerOpenRouter extends ModelHandlerOpenAI {
       extra_headers: { 'X-Title': 'TeXRA.ai' },
     };
 
-    // Reasoning parameters might vary depending on the underlying model via OpenRouter
-    // The `reasoning` and `include_reasoning` parameters are specific to some models like O1
+    // Reasoning parameters vary by model via OpenRouter:
+    // - O1-style models: use reasoning.effort parameter
+    // - DeepSeek V3.2: use reasoning.enabled parameter
     if (this.config.capabilities.supportsReasoning) {
       if (
         this.config.capabilities.supportsReasoningEffort &&
         this.config.capabilities.reasoningEffort
       ) {
+        // O1-style models with effort levels
         kwargs.reasoning = {
           effort: this.validateReasoningEffort(
             this.config.capabilities.reasoningEffort,
           ),
         };
         kwargs.include_reasoning = true;
+      } else {
+        // DeepSeek V3.2 and similar models - just enable reasoning
+        kwargs.reasoning = { enabled: true };
       }
     }
 
@@ -121,13 +126,15 @@ export class ModelHandlerOpenRouter extends ModelHandlerOpenAI {
   }
 
   /**
-   * OpenRouter uses 'reasoning' field instead of 'reasoning_content'.
+   * OpenRouter may use 'reasoning' or 'reasoning_details' field.
+   * DeepSeek V3.2 via OpenRouter returns 'reasoning_details'.
    * Also handles object values by converting to JSON.
    */
   protected override extractReasoningFromMessage(
     message: Record<string, unknown> | undefined,
   ): string | null {
-    const reasoning = message?.reasoning;
+    // Try both field names - reasoning_details (DeepSeek) and reasoning (others)
+    const reasoning = message?.reasoning_details ?? message?.reasoning;
     if (!reasoning) {
       return null;
     }

--- a/src/agent/modelHandlers/modelHandlerOpenRouter.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenRouter.ts
@@ -44,8 +44,9 @@ export class ModelHandlerOpenRouter extends ModelHandlerOpenAI {
     };
 
     // Reasoning parameters vary by model via OpenRouter:
-    // - O1-style models: use reasoning.effort parameter
-    // - DeepSeek V3.2: use reasoning.enabled parameter
+    // - O1-style models: use reasoning.effort + include_reasoning
+    // - DeepSeek V3.2: use reasoning.enabled (no include_reasoning needed,
+    //   reasoning_details is returned automatically when enabled)
     if (this.config.capabilities.supportsReasoning) {
       if (
         this.config.capabilities.supportsReasoningEffort &&
@@ -138,10 +139,16 @@ export class ModelHandlerOpenRouter extends ModelHandlerOpenAI {
     if (!reasoning) {
       return null;
     }
-    if (typeof reasoning === 'string' && reasoning.trim()) {
-      return reasoning;
+    if (typeof reasoning === 'string') {
+      return reasoning.trim() || null;
     }
-    // If reasoning is an object, convert to string
+    // If reasoning is an object, check if it's empty before converting
+    if (
+      typeof reasoning === 'object' &&
+      Object.keys(reasoning as object).length === 0
+    ) {
+      return null;
+    }
     const reasoningStr = JSON.stringify(reasoning);
     return reasoningStr.trim() || null;
   }

--- a/src/agent/modelHandlers/modelHandlerOpenRouter.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenRouter.ts
@@ -18,24 +18,74 @@ import type {
 } from 'openai/resources/chat/completions';
 
 /**
+ * OpenRouter reasoning_details array item types.
+ * @see https://openrouter.ai/docs/guides/best-practices/reasoning-tokens
+ */
+interface ReasoningDetailItem {
+  type: 'reasoning.text' | 'reasoning.summary' | 'reasoning.encrypted';
+  id?: string | null;
+  format?: string;
+  index?: number;
+  text?: string; // for reasoning.text
+  summary?: string; // for reasoning.summary
+  data?: string; // for reasoning.encrypted
+  signature?: string | null; // for reasoning.text
+}
+
+/**
+ * Extracts text content from OpenRouter reasoning_details array.
+ * Handles the structured format with type-specific fields.
+ */
+const extractTextFromReasoningDetails = (
+  details: ReasoningDetailItem[] | unknown,
+): string => {
+  if (!Array.isArray(details)) {
+    // Fallback: if it's a string, return it directly
+    if (typeof details === 'string') return details;
+    return '';
+  }
+
+  const textParts: string[] = [];
+  for (const item of details) {
+    if (!item || typeof item !== 'object') continue;
+
+    switch (item.type) {
+      case 'reasoning.text':
+        if (item.text) textParts.push(item.text);
+        break;
+      case 'reasoning.summary':
+        if (item.summary) textParts.push(item.summary);
+        break;
+      case 'reasoning.encrypted':
+        // Encrypted content is not useful for display, skip it
+        break;
+    }
+  }
+
+  return textParts.join('');
+};
+
+/**
  * Extracts reasoning delta from streaming chunks for OpenRouter.
- * Checks both reasoning_details (DeepSeek V3.2) and reasoning_content (others).
+ * Handles both:
+ * - reasoning_details: array of objects (OpenRouter normalized format)
+ * - reasoning_content: string (native DeepSeek/other models)
  */
 const extractOpenRouterReasoningDelta = (chunk: ChatCompletionChunk): string => {
   const choice = chunk.choices[0];
   if (!choice) return '';
 
   const delta = choice.delta as {
-    reasoning_details?: string;
+    reasoning_details?: ReasoningDetailItem[] | string;
     reasoning_content?: string;
   };
 
-  // Try reasoning_details first (DeepSeek V3.2 via OpenRouter)
+  // Try reasoning_details first (OpenRouter normalized format)
   if ('reasoning_details' in delta && delta.reasoning_details) {
-    return delta.reasoning_details;
+    return extractTextFromReasoningDetails(delta.reasoning_details);
   }
 
-  // Fall back to reasoning_content (other models)
+  // Fall back to reasoning_content (native format for some models)
   if ('reasoning_content' in delta && delta.reasoning_content) {
     return delta.reasoning_content;
   }
@@ -151,30 +201,32 @@ export class ModelHandlerOpenRouter extends ModelHandlerOpenAI {
   }
 
   /**
-   * OpenRouter may use 'reasoning' or 'reasoning_details' field.
-   * DeepSeek V3.2 via OpenRouter returns 'reasoning_details'.
-   * Also handles object values by converting to JSON.
+   * OpenRouter returns reasoning in different formats:
+   * - reasoning_details: array of objects (normalized format, see ReasoningDetailItem)
+   * - reasoning: string (simple format)
+   *
+   * @see https://openrouter.ai/docs/guides/best-practices/reasoning-tokens
    */
   protected override extractReasoningFromMessage(
     message: Record<string, unknown> | undefined,
   ): string | null {
-    // Try both field names - reasoning_details (DeepSeek) and reasoning (others)
-    const reasoning = message?.reasoning_details ?? message?.reasoning;
+    // Try reasoning_details first (OpenRouter normalized format - array of objects)
+    const reasoningDetails = message?.reasoning_details;
+    if (reasoningDetails) {
+      const extracted = extractTextFromReasoningDetails(reasoningDetails);
+      if (extracted) return extracted;
+    }
+
+    // Fall back to simple reasoning field (string)
+    const reasoning = message?.reasoning;
     if (!reasoning) {
       return null;
     }
     if (typeof reasoning === 'string') {
       return reasoning.trim() || null;
     }
-    // If reasoning is an object, check if it's empty before converting
-    if (
-      typeof reasoning === 'object' &&
-      Object.keys(reasoning as object).length === 0
-    ) {
-      return null;
-    }
-    const reasoningStr = JSON.stringify(reasoning);
-    return reasoningStr.trim() || null;
+
+    return null;
   }
 }
 

--- a/src/agent/modelHandlers/modelHandlerOpenRouter.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenRouter.ts
@@ -7,17 +7,41 @@ import { AgentWorkspaceState } from '@agent/core/AgentWorkspaceState';
 import type { NormalizedUsage } from '@agent/types/NormalizedUsage';
 
 // Local file imports
-import {
-  ModelHandlerOpenAI,
-  extractReasoningDelta,
-} from './modelHandlerOpenAI';
+import { ModelHandlerOpenAI } from './modelHandlerOpenAI';
 import { toOpenAITools } from './toolConversion';
 import { executeRequest } from './utils/requestExecutor';
 import type { CreateResponseOptions } from './types/IModelHandler';
 import type {
   ChatCompletion,
+  ChatCompletionChunk,
   ChatCompletionMessageParam,
 } from 'openai/resources/chat/completions';
+
+/**
+ * Extracts reasoning delta from streaming chunks for OpenRouter.
+ * Checks both reasoning_details (DeepSeek V3.2) and reasoning_content (others).
+ */
+const extractOpenRouterReasoningDelta = (chunk: ChatCompletionChunk): string => {
+  const choice = chunk.choices[0];
+  if (!choice) return '';
+
+  const delta = choice.delta as {
+    reasoning_details?: string;
+    reasoning_content?: string;
+  };
+
+  // Try reasoning_details first (DeepSeek V3.2 via OpenRouter)
+  if ('reasoning_details' in delta && delta.reasoning_details) {
+    return delta.reasoning_details;
+  }
+
+  // Fall back to reasoning_content (other models)
+  if ('reasoning_content' in delta && delta.reasoning_content) {
+    return delta.reasoning_content;
+  }
+
+  return '';
+};
 
 /**
  * Handler for models accessed through OpenRouter.
@@ -89,7 +113,7 @@ export class ModelHandlerOpenRouter extends ModelHandlerOpenAI {
         ? this.createOutputStream()
         : undefined;
       for await (const chunk of stream) {
-        const reasoningDelta = extractReasoningDelta(chunk);
+        const reasoningDelta = extractOpenRouterReasoningDelta(chunk);
         const contentDelta = chunk.choices[0]?.delta?.content ?? '';
         if (reasoningDelta) thinking.append(reasoningDelta);
         if (contentDelta) output?.append(contentDelta);

--- a/src/model/providers/deepseekModels.ts
+++ b/src/model/providers/deepseekModels.ts
@@ -51,6 +51,7 @@ export const DEEPSEEK_MODELS: Record<string, ModelConfig> = {
       supportsReasoning: true,
       supportsReasoningEffort: false,
       supportsFunctionCalling: true,
+      supportsAssistantPrefill: true,
     } satisfies ModelCapabilities,
     openRouterOnly: false,
   },

--- a/src/model/providers/deepseekModels.ts
+++ b/src/model/providers/deepseekModels.ts
@@ -6,24 +6,27 @@ import {
   ModelProvider,
 } from '@model/ModelConfig';
 
-// Common capabilities for DeepSeek models
+// Common capabilities for DeepSeek V3.2 models
+// Cache discount: $0.028 (cache hit) / $0.28 (cache miss) = 0.1
 const DEEPSEEK_DEFAULT_CAPABILITIES: ModelCapabilities = {
   ...DEFAULT_MODEL_CAPABILITIES,
   supportsAutoPromptCaching: true,
-  cacheDiscountFactor: 0.5,
+  cacheDiscountFactor: 0.1,
   supportsVision: false,
 };
 
 export const DEEPSEEK_MODELS: Record<string, ModelConfig> = {
+  // DeepSeek-V3.2 (Non-thinking Mode)
+  // Context: 128K, Max output: 8K, Supports: JSON Output, Tool Calls, Chat Prefix Completion, FIM
   deepseek: {
     name: 'deepseek',
     fullName: 'deepseek-chat',
     openrouterFullName: 'deepseek/deepseek-chat-v3.1',
     provider: ModelProvider.DEEPSEEK,
-    maxOutputTokens: 64000,
+    maxOutputTokens: 8192,
     contextWindow: 128000,
-    inputPrice: 0.56,
-    outputPrice: 1.68,
+    inputPrice: 0.28,
+    outputPrice: 0.42,
     capabilities: {
       ...DEEPSEEK_DEFAULT_CAPABILITIES,
       supportsAssistantPrefill: true,
@@ -31,6 +34,8 @@ export const DEEPSEEK_MODELS: Record<string, ModelConfig> = {
     } satisfies ModelCapabilities,
     openRouterOnly: false,
   },
+  // DeepSeek-V3.2 (Thinking Mode)
+  // Context: 128K, Max output: 64K, Supports: JSON Output, Tool Calls, Chat Prefix Completion
   deepseekT: {
     name: 'deepseekT',
     fullName: 'deepseek-reasoner',
@@ -38,30 +43,34 @@ export const DEEPSEEK_MODELS: Record<string, ModelConfig> = {
     provider: ModelProvider.DEEPSEEK,
     maxOutputTokens: 65536,
     contextWindow: 128000,
-    inputPrice: 0.56,
-    outputPrice: 1.68,
+    inputPrice: 0.28,
+    outputPrice: 0.42,
     capabilities: {
       ...DEEPSEEK_DEFAULT_CAPABILITIES,
       supportsReasoning: true,
       supportsReasoningEffort: false,
-      supportsFunctionCalling: false,
+      supportsFunctionCalling: true,
     } satisfies ModelCapabilities,
     openRouterOnly: false,
   },
+  // DeepSeek-V3.2-Speciale (Thinking Mode Only)
+  // Context: 128K, Max output: 128K, No Tool Calls, No JSON Output, No Chat Prefix Completion
+  // Available until December 15, 2025
   'deepseekT+': {
     name: 'deepseekT+',
     fullName: 'deepseek-reasoner',
     openrouterFullName: 'deepseek/deepseek-v3.2-speciale',
     provider: ModelProvider.DEEPSEEK,
-    maxOutputTokens: 65536,
-    contextWindow: 163840,
+    maxOutputTokens: 131072,
+    contextWindow: 128000,
     inputPrice: 0.28,
-    outputPrice: 0.4,
+    outputPrice: 0.42,
     capabilities: {
       ...DEEPSEEK_DEFAULT_CAPABILITIES,
       supportsReasoning: true,
       supportsReasoningEffort: false,
       supportsFunctionCalling: false,
+      supportsAssistantPrefill: false,
     } satisfies ModelCapabilities,
     openRouterOnly: false,
     baseUrl: 'https://api.deepseek.com/v3.2_speciale_expires_on_20251215',

--- a/src/model/providers/deepseekModels.ts
+++ b/src/model/providers/deepseekModels.ts
@@ -21,7 +21,7 @@ export const DEEPSEEK_MODELS: Record<string, ModelConfig> = {
   deepseek: {
     name: 'deepseek',
     fullName: 'deepseek-chat',
-    openrouterFullName: 'deepseek/deepseek-chat-v3.1',
+    openrouterFullName: 'deepseek/deepseek-v3.2',
     provider: ModelProvider.DEEPSEEK,
     maxOutputTokens: 8192,
     contextWindow: 128000,
@@ -36,10 +36,11 @@ export const DEEPSEEK_MODELS: Record<string, ModelConfig> = {
   },
   // DeepSeek-V3.2 (Thinking Mode)
   // Context: 128K, Max output: 64K, Supports: JSON Output, Tool Calls, Chat Prefix Completion
+  // OpenRouter: use reasoning: { enabled: true } parameter
   deepseekT: {
     name: 'deepseekT',
     fullName: 'deepseek-reasoner',
-    openrouterFullName: 'deepseek/deepseek-reasoner-v3.1',
+    openrouterFullName: 'deepseek/deepseek-v3.2',
     provider: ModelProvider.DEEPSEEK,
     maxOutputTokens: 65536,
     contextWindow: 128000,

--- a/src/model/providers/deepseekModels.ts
+++ b/src/model/providers/deepseekModels.ts
@@ -15,6 +15,17 @@ const DEEPSEEK_DEFAULT_CAPABILITIES: ModelCapabilities = {
   supportsVision: false,
 };
 
+/**
+ * DeepSeek model configurations.
+ *
+ * Model name conventions:
+ * - fullName: Model name for native DeepSeek API (e.g., 'deepseek-chat', 'deepseek-reasoner')
+ * - openrouterFullName: Model name for OpenRouter API (e.g., 'deepseek/deepseek-v3.2')
+ *
+ * For V3.2, both deepseek and deepseekT use the same OpenRouter model ('deepseek/deepseek-v3.2').
+ * The difference is that deepseekT has supportsReasoning: true, which triggers
+ * the reasoning: { enabled: true } parameter via OpenRouter.
+ */
 export const DEEPSEEK_MODELS: Record<string, ModelConfig> = {
   // DeepSeek-V3.2 (Non-thinking Mode)
   // Context: 128K, Max output: 8K, Supports: JSON Output, Tool Calls, Chat Prefix Completion, FIM


### PR DESCRIPTION
- Update deepseek-chat: max output 8K, pricing $0.28/$0.42 per 1M tokens
- Update deepseek-reasoner: enable function calling, pricing $0.28/$0.42
- Update deepseekT+ (V3.2-Speciale): max output 128K, context 128K
- Update cache discount factor to 0.1 (cache hit $0.028 / miss $0.28)
- Add documentation comments for model capabilities

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements OpenRouter reasoning_details/stream parsing and model-specific reasoning params, and updates DeepSeek V3.2 model configs (pricing, tokens, capabilities, cache discount).
> 
> - **Agent / OpenRouter handler (`src/agent/modelHandlers/modelHandlerOpenRouter.ts`)**:
>   - Parse reasoning from OpenRouter: add `ReasoningDetailItem`, `extractTextFromReasoningDetails`, and `extractOpenRouterReasoningDelta` for streaming `reasoning_details`/`reasoning_content`.
>   - Update `createResponse` to set model-specific `reasoning` params:
>     - O1-style: `reasoning.effort` + `include_reasoning`.
>     - DeepSeek V3.2: `reasoning: { enabled: true }`.
>   - Stream handling appends reasoning/output deltas and finalizes with usage fallback.
>   - `extractReasoningFromMessage` now prefers `reasoning_details` (array) then `reasoning` (string).
> - **Models (`src/model/providers/deepseekModels.ts`)**:
>   - Revise DeepSeek V3.2 configs:
>     - `deepseek`: `openrouterFullName` → `deepseek/deepseek-v3.2`, max output `8192`, pricing `0.28/0.42`, enable assistant prefill & function calling.
>     - `deepseekT`: `openrouterFullName` → `deepseek/deepseek-v3.2`, max output `65536`, pricing `0.28/0.42`, enable reasoning (no effort), function calling, assistant prefill.
>     - `deepseekT+`: `openrouterFullName` `deepseek/deepseek-v3.2-speciale`, max output `131072`, context `128000`, output price `0.42`, assistant prefill disabled, add `baseUrl`.
>   - Adjust DeepSeek default capabilities: enable auto prompt caching with `cacheDiscountFactor: 0.1`.
>   - Add/clarify documentation comments on model naming and capabilities.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f30338f3f8432e8e2ecb666fdcb143a77ef8ce12. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->