### PR TITLE
Add deep research models documentation

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,8 @@
                 "o3-",
                 "o1pro",
                 "o1",
+                "o3-deep-research",
+                "o4-mini-deep-research",
                 "gptoss",
                 "gptoss-",
                 "gpt45",
@@ -132,7 +134,7 @@
               "qwen3max",
               "grok4"
             ],
-            "description": "List of available models. Model codes: opus45T/opus45 (Claude Opus 4.5 Thinking/Regular), opus41T/opus41 (Claude Opus 4.1 Thinking/Regular), opus4T/opus4 (Claude Opus 4 Thinking/Regular), sonnet45T/sonnet45 (Claude Sonnet 4.5 Thinking/Regular), haiku45T/haiku45 (Claude Haiku 4.5 Thinking/Regular), sonnet4T/sonnet4 (Claude Sonnet 4 Thinking/Regular), sonnet37T/sonnet37 (Claude Sonnet 3.7 Thinking/Regular), o4-/o3/o3pro/o3-/o1pro/o1/gptoss/gptoss- (OpenAI reasoning models), gpt51/gpt5/gpt5pro/gpt5-/gpt5--/gpt41/gpt4o (GPT-5.1/5/5 Pro/5 Mini/5 Nano/4.1/4O), gemini3p/gemini25p/gemini25f/gemini2fT (Gemini 3 Pro Preview, 2.5 Pro/Flash, 2.0 Flash Thinking), deepseek/deepseekT(DeepSeek V3.1 Regular/Thinking), dsv3/dsr1 (DeepSeek V3/R1), grok4 (Grok 4), grok3 (Grok 3), qwen3max (Qwen-Max latest), qwenplus (Qwen Plus latest), qwenturbo (Qwen Turbo), kimit/kimiv/kimi2/kimi2+/kimi2T/kimi2T+ (Kimi Thinking/Vision/K2/K2 Turbo/K2 Thinking/K2 Thinking Turbo)",
+            "description": "List of available models. Model codes: opus45T/opus45 (Claude Opus 4.5 Thinking/Regular), opus41T/opus41 (Claude Opus 4.1 Thinking/Regular), opus4T/opus4 (Claude Opus 4 Thinking/Regular), sonnet45T/sonnet45 (Claude Sonnet 4.5 Thinking/Regular), haiku45T/haiku45 (Claude Haiku 4.5 Thinking/Regular), sonnet4T/sonnet4 (Claude Sonnet 4 Thinking/Regular), sonnet37T/sonnet37 (Claude Sonnet 3.7 Thinking/Regular), o4-/o3/o3pro/o3-/o1pro/o1/gptoss/gptoss- (OpenAI reasoning models), o3-deep-research/o4-mini-deep-research (OpenAI Deep Research with web search), gpt51/gpt5/gpt5pro/gpt5-/gpt5--/gpt41/gpt4o (GPT-5.1/5/5 Pro/5 Mini/5 Nano/4.1/4O), gemini3p/gemini25p/gemini25f/gemini2fT (Gemini 3 Pro Preview, 2.5 Pro/Flash, 2.0 Flash Thinking), deepseek/deepseekT(DeepSeek V3.1 Regular/Thinking), dsv3/dsr1 (DeepSeek V3/R1), grok4 (Grok 4), grok3 (Grok 3), qwen3max (Qwen-Max latest), qwenplus (Qwen Plus latest), qwenturbo (Qwen Turbo), kimit/kimiv/kimi2/kimi2+/kimi2T/kimi2T+ (Kimi Thinking/Vision/K2/K2 Turbo/K2 Thinking/K2 Thinking Turbo)",
             "scope": "resource"
           },
           "texra.agentOutputs.storageMode": {

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -208,10 +208,11 @@ export abstract class ModelHandler<
    * @throws Error if required API key is missing from environment
    */
   public async getApiKey(): Promise<string> {
-    // Use OpenRouter if model requires it or if explicitly configured
+    // Models requiring direct API access (e.g., deep research) bypass OpenRouter
     const useOpenRouter =
-      this.config.openRouterOnly ||
-      getConfig<boolean>('texra.model.useOpenRouter', false);
+      !this.config.requiresResponsesAPI &&
+      (this.config.openRouterOnly ||
+        getConfig<boolean>('texra.model.useOpenRouter', false));
 
     if (useOpenRouter) {
       try {
@@ -242,6 +243,7 @@ export abstract class ModelHandler<
       provider: this.config.provider,
       openRouterOnly: this.config.openRouterOnly,
       customBaseUrl: this.config.baseUrl,
+      requiresResponsesAPI: this.config.requiresResponsesAPI,
       logger: this.logger,
     });
   }

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -25,7 +25,10 @@ import { getConfig } from '@utils/config';
 // Local file imports
 import type { FileLocation } from '@utils/files';
 import { MediaAttachmentProcessor } from './support/MediaAttachmentProcessor';
-import { resolveBaseUrl } from './support/ProxyConfigResolver';
+import {
+  resolveBaseUrl,
+  shouldUseOpenRouter,
+} from './support/ProxyConfigResolver';
 import {
   ANTHROPIC_STOP,
   OPENAI_CHAT_FINISH,
@@ -208,13 +211,7 @@ export abstract class ModelHandler<
    * @throws Error if required API key is missing from environment
    */
   public async getApiKey(): Promise<string> {
-    // Models requiring direct API access (e.g., deep research) bypass OpenRouter
-    const useOpenRouter =
-      !this.config.requiresResponsesAPI &&
-      (this.config.openRouterOnly ||
-        getConfig<boolean>('texra.model.useOpenRouter', false));
-
-    if (useOpenRouter) {
+    if (shouldUseOpenRouter(this.config)) {
       try {
         return await SecretManager.getApiKey('openRouter');
       } catch (err) {

--- a/src/agent/modelHandlers/support/ProxyConfigResolver.ts
+++ b/src/agent/modelHandlers/support/ProxyConfigResolver.ts
@@ -32,6 +32,21 @@ export interface ProxyConfig {
   logger?: { debug: (message: string) => void };
 }
 
+/**
+ * Determines whether OpenRouter should be used for API routing.
+ * Models with requiresResponsesAPI bypass OpenRouter even if globally enabled.
+ */
+export function shouldUseOpenRouter(config: {
+  requiresResponsesAPI?: boolean;
+  openRouterOnly: boolean;
+}): boolean {
+  return (
+    !config.requiresResponsesAPI &&
+    (config.openRouterOnly ||
+      getConfig<boolean>('texra.model.useOpenRouter', false))
+  );
+}
+
 export function resolveBaseUrl(config: ProxyConfig): string | null {
   // Per-model custom base URL takes highest precedence (e.g., temporary endpoints)
   if (config.customBaseUrl) {
@@ -41,11 +56,7 @@ export function resolveBaseUrl(config: ProxyConfig): string | null {
     return config.customBaseUrl;
   }
 
-  // Models requiring direct API access (e.g., deep research) bypass OpenRouter
-  const useOpenRouter =
-    !config.requiresResponsesAPI &&
-    (config.openRouterOnly ||
-      getConfig<boolean>('texra.model.useOpenRouter', false));
+  const useOpenRouter = shouldUseOpenRouter(config);
   const useImprovedConnection = getConfig<boolean>(
     'texra.model.useImprovedConnection',
     false,

--- a/src/agent/modelHandlers/support/ProxyConfigResolver.ts
+++ b/src/agent/modelHandlers/support/ProxyConfigResolver.ts
@@ -28,6 +28,7 @@ export interface ProxyConfig {
   provider: ModelProvider;
   openRouterOnly: boolean;
   customBaseUrl?: string; // Per-model custom base URL (overrides provider default)
+  requiresResponsesAPI?: boolean; // Models requiring direct API access (bypasses OpenRouter)
   logger?: { debug: (message: string) => void };
 }
 
@@ -40,9 +41,11 @@ export function resolveBaseUrl(config: ProxyConfig): string | null {
     return config.customBaseUrl;
   }
 
+  // Models requiring direct API access (e.g., deep research) bypass OpenRouter
   const useOpenRouter =
-    config.openRouterOnly ||
-    getConfig<boolean>('texra.model.useOpenRouter', false);
+    !config.requiresResponsesAPI &&
+    (config.openRouterOnly ||
+      getConfig<boolean>('texra.model.useOpenRouter', false));
   const useImprovedConnection = getConfig<boolean>(
     'texra.model.useImprovedConnection',
     false,

--- a/src/agent/runtime/ModelFactory.ts
+++ b/src/agent/runtime/ModelFactory.ts
@@ -53,13 +53,17 @@ export class ModelFactory {
     }
 
     // Check for OpenAI Responses API usage
+    // Deep research models only support the Responses API
     const useOpenAIResponsesAPI = getConfig<boolean>(
       'texra.model.useOpenAIResponsesAPI',
       false,
     );
+    const isDeepResearchModel = config.fullName.includes('deep-research');
     if (
       config.provider === ModelProvider.OPENAI &&
-      (useOpenAIResponsesAPI || config.fullName.startsWith('gpt-oss'))
+      (useOpenAIResponsesAPI ||
+        config.fullName.startsWith('gpt-oss') ||
+        isDeepResearchModel)
     ) {
       logger.debug(
         CHANNEL,

--- a/src/agent/runtime/ModelFactory.ts
+++ b/src/agent/runtime/ModelFactory.ts
@@ -34,6 +34,17 @@ export class ModelFactory {
    * @throws Error if provider is unsupported
    */
   static createHandler(config: ModelConfig): ModelHandler {
+    // Deep research models (names containing 'deep-research') only support the
+    // Responses API and must bypass OpenRouter even if configured
+    const isDeepResearchModel = config.fullName.includes('deep-research');
+    if (config.provider === ModelProvider.OPENAI && isDeepResearchModel) {
+      logger.debug(
+        CHANNEL,
+        'Using OpenAI Responses API Handler for deep research model',
+      );
+      return new ModelHandlerOpenAIResponse(config);
+    }
+
     // Use OpenRouter if model requires it or if explicitly configured in toolConfig
     const useOpenRouter =
       config.openRouterOnly ||
@@ -53,17 +64,13 @@ export class ModelFactory {
     }
 
     // Check for OpenAI Responses API usage
-    // Deep research models only support the Responses API
     const useOpenAIResponsesAPI = getConfig<boolean>(
       'texra.model.useOpenAIResponsesAPI',
       false,
     );
-    const isDeepResearchModel = config.fullName.includes('deep-research');
     if (
       config.provider === ModelProvider.OPENAI &&
-      (useOpenAIResponsesAPI ||
-        config.fullName.startsWith('gpt-oss') ||
-        isDeepResearchModel)
+      (useOpenAIResponsesAPI || config.fullName.startsWith('gpt-oss'))
     ) {
       logger.debug(
         CHANNEL,

--- a/src/agent/runtime/ModelFactory.ts
+++ b/src/agent/runtime/ModelFactory.ts
@@ -34,14 +34,12 @@ export class ModelFactory {
    * @throws Error if provider is unsupported
    */
   static createHandler(config: ModelConfig): ModelHandler {
-    // Deep research models (names containing 'deep-research') only support the
-    // Responses API and must bypass OpenRouter even if configured
-    const isDeepResearchModel = config.fullName.includes('deep-research');
-    if (config.provider === ModelProvider.OPENAI && isDeepResearchModel) {
-      logger.debug(
-        CHANNEL,
-        'Using OpenAI Responses API Handler for deep research model',
-      );
+    // Models requiring Responses API (e.g., deep research) must bypass OpenRouter
+    if (
+      config.provider === ModelProvider.OPENAI &&
+      config.requiresResponsesAPI
+    ) {
+      logger.debug(CHANNEL, 'Using OpenAI Responses API Handler (required)');
       return new ModelHandlerOpenAIResponse(config);
     }
 

--- a/src/model/ModelConfig.ts
+++ b/src/model/ModelConfig.ts
@@ -86,4 +86,5 @@ export interface ModelConfig {
   openRouterOnly: boolean; // Whether this model is only available through OpenRouter
   openrouterFullName?: string; // Full model name for OpenRouter (e.g., "anthropic/claude-3-opus-20240229")
   baseUrl?: string; // Custom base URL for this specific model (overrides provider default)
+  requiresResponsesAPI?: boolean; // Whether this model requires OpenAI Responses API (bypasses OpenRouter)
 }

--- a/src/model/ModelRegistry.ts
+++ b/src/model/ModelRegistry.ts
@@ -11,6 +11,7 @@
 import { ModelConfig } from './ModelConfig';
 import {
   ANTHROPIC_MODELS,
+  OPENAI_DEEP_RESEARCH_MODELS,
   OPENAI_REASONING_MODELS,
   OPENAI_MODELS,
   GOOGLE_MODELS,
@@ -28,6 +29,7 @@ import {
  */
 export const MODEL_CONFIGS: Record<string, ModelConfig> = {
   ...ANTHROPIC_MODELS,
+  ...OPENAI_DEEP_RESEARCH_MODELS,
   ...OPENAI_REASONING_MODELS,
   ...OPENAI_MODELS,
   ...GOOGLE_MODELS,

--- a/src/model/providers/openaiDeepResearchModels.ts
+++ b/src/model/providers/openaiDeepResearchModels.ts
@@ -6,12 +6,15 @@ import {
   ModelProvider,
 } from '@model/ModelConfig';
 
-// Common capabilities for OpenAI reasoning models
+// Common capabilities for OpenAI deep research models
+// Note: Deep research models only support web search, file search, MCP, and code interpreter.
+// Function calling is not supported.
 const OPENAI_DEEP_RESEARCH_DEFAULT_CAPABILITIES: ModelCapabilities = {
   ...DEFAULT_MODEL_CAPABILITIES,
+  supportsFunctionCalling: false,
   supportsAutoPromptCaching: true,
   cacheDiscountFactor: 0.25,
-  supportsReasoning: false,
+  supportsReasoning: true,
   supportsIntermDevMsgs: false,
   supportsVision: true,
   supportsNativeWebSearch: true,
@@ -34,6 +37,7 @@ export const OPENAI_DEEP_RESEARCH_MODELS: Record<string, ModelConfig> = {
       ...OPENAI_DEEP_RESEARCH_DEFAULT_CAPABILITIES,
     },
     openRouterOnly: false,
+    requiresResponsesAPI: true,
   },
   'o4-mini-deep-research': {
     name: 'o4-mini-deep-research',
@@ -48,5 +52,6 @@ export const OPENAI_DEEP_RESEARCH_MODELS: Record<string, ModelConfig> = {
       ...OPENAI_DEEP_RESEARCH_DEFAULT_CAPABILITIES,
     },
     openRouterOnly: false,
+    requiresResponsesAPI: true,
   },
 };


### PR DESCRIPTION
…-research)

Register the deep research models in the model registry and route them to the Responses API handler, which is required for these models that support native web search, MCP servers, and code execution.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Registers `o3-deep-research` and `o4-mini-deep-research` and ensures they bypass OpenRouter and use the OpenAI Responses API with appropriate capabilities.
> 
> - **Models**
>   - Add OpenAI deep research models: `o3-deep-research`, `o4-mini-deep-research` in `openaiDeepResearchModels.ts` with capabilities (reasoning, native web search/MCP/code exec/PDF; no function calling).
>   - Extend `MODEL_CONFIGS` to include deep research models; export consolidated `MODELS`.
>   - Add `requiresResponsesAPI` to `ModelConfig` for models needing the Responses API.
> - **Routing & Handlers**
>   - Introduce `shouldUseOpenRouter` and update `ProxyConfigResolver.resolveBaseUrl` to bypass OpenRouter when `requiresResponsesAPI` is set.
>   - Update `ModelHandler.getApiKey()` to honor `shouldUseOpenRouter`; pass `requiresResponsesAPI` into base URL resolution.
>   - Update `ModelFactory.createHandler()` to force `ModelHandlerOpenAIResponse` when `requiresResponsesAPI` is true (OpenAI) and maintain existing Responses API toggle logic.
> - **Configuration (package.json)**
>   - Add the two deep research models to `texra.models` enum and enhance description with Deep Research notes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 66380bcf820f4d4aba6426f8dea128dd915070b3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->