### PR TITLE
Update changelog since version 0.34

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ All notable changes to this project will be documented in this file.
   real-time search results displayed in the progress view during streaming.
 - Introduced a new **Web Search** tool-use agent optimized for research queries
   that leverage provider-native search capabilities.
+- Added **OpenAI deep research models** (`o3-deep-research`, `o4-mini-deep-research`)
+  for extended reasoning tasks.
+- Updated **DeepSeek models to V3.2** with streaming reasoning support via
+  OpenRouter.
 - Added **getting started guidance** that appears when opening an empty folder,
   helping new users bootstrap their first project.
 
@@ -23,6 +27,8 @@ All notable changes to this project will be documented in this file.
   agents.
 - Improved content block ordering in Anthropic streaming responses, fixing
   issues with interleaved thinking and text blocks.
+- Fixed figure path resolution for input files located in subdirectories.
+- Fixed `\input` path compatibility by normalizing leading `./` prefixes.
 - User-cancelled requests no longer trigger automatic retries.
 - Fixed banner display issues when refreshing the webview input.
 
@@ -31,7 +37,8 @@ All notable changes to this project will be documented in this file.
 - Refactored internal HTTP status handling using the `http-status-codes`
   package for better maintainability.
 - Consolidated prompt utilities and Zod schemas for improved type safety.
-- Updated core dependencies: Anthropic SDK 0.71.2, KaTeX 0.16.27, winston 3.19.0.
+- Updated core dependencies: Anthropic SDK 0.71.2, Google GenAI 1.32.0,
+  KaTeX 0.16.27, winston 3.19.0.
 
 ## [0.34.8] - 2025-12-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.34.9] - 2025-12-10
+
+### Features
+
+- Added **native web search** support for Anthropic and OpenAI models, with
+  real-time search results displayed in the progress view during streaming.
+- Introduced a new **Web Search** tool-use agent optimized for research queries
+  that leverage provider-native search capabilities.
+- Added **getting started guidance** that appears when opening an empty folder,
+  helping new users bootstrap their first project.
+
+### Bug Fixes
+
+- Fixed Windows path handling in progress view stream tabs, resolving duplicate
+  tab issues on Windows systems.
+- Agent selection now persists correctly when switching between sessions or when
+  the selected agent isn't in the current options list.
+- Remote agents with multiple output variants now group correctly like local
+  agents.
+- Improved content block ordering in Anthropic streaming responses, fixing
+  issues with interleaved thinking and text blocks.
+- User-cancelled requests no longer trigger automatic retries.
+- Fixed banner display issues when refreshing the webview input.
+
+### Improvements
+
+- Refactored internal HTTP status handling using the `http-status-codes`
+  package for better maintainability.
+- Consolidated prompt utilities and Zod schemas for improved type safety.
+- Updated core dependencies: Anthropic SDK 0.71.2, KaTeX 0.16.27, winston 3.19.0.
+
 ## [0.34.8] - 2025-12-04
 
 ### Features


### PR DESCRIPTION
Add entries for native web search support (Anthropic, OpenAI), web search agent, getting started guidance, and various bug fixes since 0.34.8.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates CHANGELOG with 0.34.9 features (native web search, web search agent, OpenAI deep research models, DeepSeek V3.2, onboarding), plus related fixes and improvements.
> 
> - **CHANGELOG (0.34.9)**:
>   - **Features**:
>     - Native web search for Anthropic/OpenAI with real-time results.
>     - New Web Search tool-use agent for research queries.
>     - OpenAI deep research models (`o3-deep-research`, `o4-mini-deep-research`).
>     - DeepSeek updated to V3.2 with streaming reasoning via OpenRouter.
>     - Getting-started guidance for empty folders.
>   - **Bug Fixes**:
>     - Windows path handling in stream tabs; persistent agent selection; correct grouping for multi-variant remote agents; Anthropic streaming content order; figure and `\input` path resolution; cancelation no longer retries; banner refresh issues.
>   - **Improvements**:
>     - HTTP status handling via `http-status-codes`; consolidated prompt utilities and Zod schemas; dependency bumps (Anthropic 0.71.2, Google GenAI 1.32.0, KaTeX 0.16.27, winston 3.19.0).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bcec85b5cd78b1920a7e15b1fafb646cf8790654. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->