### PR TITLE
Remove remote agent tags

### DIFF
--- a/docs/supabase/SUPABASE_SETUP.md
+++ b/docs/supabase/SUPABASE_SETUP.md
@@ -199,7 +199,6 @@ CREATE TABLE remote_agents (
   description TEXT,
   storage_path TEXT NOT NULL,
   visibility TEXT DEFAULT 'researcher' CHECK (visibility IN ('public', 'researcher', 'whitelist')),
-  tags TEXT[],
   created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
   updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );
@@ -534,13 +533,12 @@ The extension will now use the configured credentials. Users don't need to confi
 In **SQL Editor**, run:
 
 ```sql
-INSERT INTO remote_agents (name, description, storage_path, visibility, tags)
+INSERT INTO remote_agents (name, description, storage_path, visibility)
 VALUES (
   'advanced-researcher',
   'AI-powered research assistant for academic papers',
   'researcher/advanced-researcher.yaml',
-  'researcher',
-  ARRAY['research', 'academic', 'writing']
+  'researcher'
 );
 ```
 


### PR DESCRIPTION
The tags field was defined in the database schema but never actually used in the codebase. Removing it simplifies the schema without any functional impact.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Remove unused `tags` column from `remote_agents` schema and update INSERT example accordingly in the Supabase setup guide.
> 
> - **Docs — Supabase Setup**:
>   - **Database schema**: Remove `tags` column from `remote_agents` table definition.
>   - **Examples**: Update `INSERT INTO remote_agents` example to omit `tags` field and values.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a5e83e747068ee619855dcea43908c89c60d84c8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->