### PR TITLE
Remove unsupported tools from deep research models

### DIFF
--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -594,10 +594,16 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     }
 
     if (tools && tools.length > 0) {
-      params.tools = toOpenAIResponseTools(tools, {
+      const convertedTools = toOpenAIResponseTools(tools, {
         supportsNativeWebSearch: this.capabilities.supportsNativeWebSearch,
+        supportsFunctionCalling: this.capabilities.supportsFunctionCalling,
       });
-      params.tool_choice = 'auto';
+      // Only set tools if there are any after filtering (deep research models
+      // strip unsupported function tools, potentially leaving an empty array)
+      if (convertedTools.length > 0) {
+        params.tools = convertedTools;
+        params.tool_choice = 'auto';
+      }
 
       // Include web search sources in response when native web search is enabled
       if (this.capabilities.supportsNativeWebSearch) {

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -603,11 +603,11 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       if (convertedTools.length > 0) {
         params.tools = convertedTools;
         params.tool_choice = 'auto';
-      }
 
-      // Include web search sources in response when native web search is enabled
-      if (this.capabilities.supportsNativeWebSearch) {
-        params.include = ['web_search_call.action.sources'];
+        // Include web search sources in response when native web search is enabled
+        if (this.capabilities.supportsNativeWebSearch) {
+          params.include = ['web_search_call.action.sources'];
+        }
       }
     }
 

--- a/src/agent/modelHandlers/toolConversion.ts
+++ b/src/agent/modelHandlers/toolConversion.ts
@@ -58,19 +58,6 @@ export function toOpenAITools(defs: ToolDefinition[]): ChatCompletionTool[] {
 }
 
 /**
- * Native tool types supported by OpenAI Responses API deep research models.
- * These models ONLY support these tools and reject function calling tools.
- * See: https://platform.openai.com/docs/guides/tools-deep-research
- */
-export const OPENAI_DEEP_RESEARCH_NATIVE_TOOLS = new Set([
-  'web_search',
-  'web_search_preview',
-  'code_interpreter',
-  'file_search',
-  'mcp',
-]);
-
-/**
  * Options for OpenAI Responses API tool conversion.
  */
 export interface OpenAIResponseToolOptions {
@@ -99,12 +86,12 @@ export function toOpenAIResponseTools(
     }
 
     // Deep research models only support native tools (web_search, code_interpreter,
-    // file_search, mcp). Skip function tools when function calling is not supported.
+    // file_search, mcp) and do NOT support function calling. When function calling
+    // is disabled, skip all remaining tools - they cannot be converted to function
+    // format, and native conversion for tools other than web_search is not yet
+    // implemented.
     if (!supportsFunctionCalling) {
-      // Skip tools that aren't in the native tools set for deep research models
-      if (!OPENAI_DEEP_RESEARCH_NATIVE_TOOLS.has(d.name)) {
-        continue;
-      }
+      continue;
     }
 
     // Standard function tools

--- a/src/agent/modelHandlers/toolConversion.ts
+++ b/src/agent/modelHandlers/toolConversion.ts
@@ -58,11 +58,26 @@ export function toOpenAITools(defs: ToolDefinition[]): ChatCompletionTool[] {
 }
 
 /**
+ * Native tool types supported by OpenAI Responses API deep research models.
+ * These models ONLY support these tools and reject function calling tools.
+ * See: https://platform.openai.com/docs/guides/tools-deep-research
+ */
+export const OPENAI_DEEP_RESEARCH_NATIVE_TOOLS = new Set([
+  'web_search',
+  'web_search_preview',
+  'code_interpreter',
+  'file_search',
+  'mcp',
+]);
+
+/**
  * Options for OpenAI Responses API tool conversion.
  */
 export interface OpenAIResponseToolOptions {
   /** Whether the model supports native web search. Defaults to false. */
   supportsNativeWebSearch?: boolean;
+  /** Whether the model supports function calling. Defaults to true. */
+  supportsFunctionCalling?: boolean;
 }
 
 /** Convert generic ToolDefinition objects to OpenAI Responses API tool format. */
@@ -70,7 +85,8 @@ export function toOpenAIResponseTools(
   defs: ToolDefinition[],
   options: OpenAIResponseToolOptions = {},
 ): OpenAIResponseTool[] {
-  const { supportsNativeWebSearch = false } = options;
+  const { supportsNativeWebSearch = false, supportsFunctionCalling = true } =
+    options;
   const tools: OpenAIResponseTool[] = [];
 
   for (const d of defs) {
@@ -80,6 +96,15 @@ export function toOpenAIResponseTools(
         type: 'web_search',
       } as WebSearchTool);
       continue;
+    }
+
+    // Deep research models only support native tools (web_search, code_interpreter,
+    // file_search, mcp). Skip function tools when function calling is not supported.
+    if (!supportsFunctionCalling) {
+      // Skip tools that aren't in the native tools set for deep research models
+      if (!OPENAI_DEEP_RESEARCH_NATIVE_TOOLS.has(d.name)) {
+        continue;
+      }
     }
 
     // Standard function tools

--- a/src/model/providers/openaiDeepResearchModels.ts
+++ b/src/model/providers/openaiDeepResearchModels.ts
@@ -6,9 +6,14 @@ import {
   ModelProvider,
 } from '@model/ModelConfig';
 
-// Common capabilities for OpenAI deep research models
-// Note: Deep research models only support web search, file search, MCP, and code interpreter.
-// Function calling is not supported.
+// Common capabilities for OpenAI deep research models.
+//
+// Tool capability combinations:
+// - Deep research: supportsFunctionCalling=false, supportsNativeWebSearch=true
+//   Only native tools (web_search, file_search, mcp, code_interpreter) are supported.
+//   Function calling tools are rejected with HTTP 400.
+// - Standard models: supportsFunctionCalling=true, supportsNativeWebSearch varies
+//   Function calling tools are converted normally. Native web_search used if supported.
 const OPENAI_DEEP_RESEARCH_DEFAULT_CAPABILITIES: ModelCapabilities = {
   ...DEFAULT_MODEL_CAPABILITIES,
   supportsFunctionCalling: false,

--- a/src/test/modelHandlers/ResponseToolConversion.test.ts
+++ b/src/test/modelHandlers/ResponseToolConversion.test.ts
@@ -95,6 +95,69 @@ describe('toOpenAIResponseTools', () => {
     assert.equal(tool.type, 'function');
     assert.equal(tool.name, 'web_search');
   });
+
+  it('filters out function tools when supportsFunctionCalling is false', () => {
+    const defs: ToolDefinition[] = [
+      {
+        name: 'read_file',
+        description: 'Read a file',
+        parameters: {
+          type: 'object',
+          properties: { path: { type: 'string' } },
+          required: ['path'],
+        },
+      },
+      {
+        name: 'write_file',
+        description: 'Write a file',
+      },
+    ];
+
+    // Deep research models don't support function calling
+    const tools = toOpenAIResponseTools(defs, {
+      supportsFunctionCalling: false,
+    });
+    // Both read_file and write_file should be filtered out
+    assert.equal(tools.length, 0);
+  });
+
+  it('keeps native web_search when supportsFunctionCalling is false and supportsNativeWebSearch is true', () => {
+    const defs: ToolDefinition[] = [
+      {
+        name: 'web_search',
+        description: 'Search the web',
+      },
+      {
+        name: 'read_file',
+        description: 'Read a file',
+      },
+    ];
+
+    // Deep research models support native web search but not function calling
+    const tools = toOpenAIResponseTools(defs, {
+      supportsFunctionCalling: false,
+      supportsNativeWebSearch: true,
+    });
+    // Only web_search should remain as native tool
+    assert.equal(tools.length, 1);
+    assert.equal(tools[0].type, 'web_search');
+  });
+
+  it('defaults supportsFunctionCalling to true', () => {
+    const defs: ToolDefinition[] = [
+      {
+        name: 'custom_tool',
+        description: 'A custom function tool',
+      },
+    ];
+
+    // No options passed - function calling should be allowed by default
+    const tools = toOpenAIResponseTools(defs);
+    assert.equal(tools.length, 1);
+    const tool = tools[0] as FunctionTool;
+    assert.equal(tool.type, 'function');
+    assert.equal(tool.name, 'custom_tool');
+  });
 });
 
 describe('toGoogleTools', () => {


### PR DESCRIPTION
Deep research models (o3-deep-research, o4-mini-deep-research) only support native tools: web_search, code_interpreter, file_search, and mcp. This change filters out function calling tools when the model's supportsFunctionCalling capability is false, preventing HTTP 400 errors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Filters out function-calling tools for deep-research models, only submits supported tools (native web_search), and adds options/tests to tool conversion.
> 
> - **Model handler (`src/agent/modelHandlers/modelHandlerOpenAIResponse.ts`)**
>   - Convert tools with `toOpenAIResponseTools` using capabilities `supportsNativeWebSearch` and `supportsFunctionCalling`.
>   - Only set `params.tools`/`tool_choice` (and `include` web search sources) if converted tools are non-empty.
> - **Tool conversion (`src/agent/modelHandlers/toolConversion.ts`)**
>   - Add `supportsFunctionCalling` option (default true) to `OpenAIResponseToolOptions`.
>   - Filter out non-native tools when `supportsFunctionCalling=false`; keep native `web_search` if allowed.
>   - Preserve standard function tool conversion when function calling is supported.
> - **Model capabilities (`src/model/providers/openaiDeepResearchModels.ts`)**
>   - Document/enforce deep-research capability mix (`supportsFunctionCalling=false`, `supportsNativeWebSearch=true`) and native tool support flags.
> - **Tests (`src/test/modelHandlers/ResponseToolConversion.test.ts`)**
>   - Add tests for filtering behavior, native `web_search` retention, and defaulting of `supportsFunctionCalling`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2b14129aec8f3cbabf267a04a5dd40ffb3af70a4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->