### PR TITLE
Research AI4Science and Max Welling's work

### DIFF
--- a/src/tools/arxiv/ArxivSearchTool.ts
+++ b/src/tools/arxiv/ArxivSearchTool.ts
@@ -1,5 +1,12 @@
 // Third-party imports
-import { all, and, category as catQuery } from 'arxiv-client';
+import {
+  all,
+  and,
+  author as authorQuery,
+  title as titleQuery,
+  abstract as abstractQuery,
+  category as catQuery,
+} from 'arxiv-client';
 import { z } from 'zod';
 
 // Local imports - latex
@@ -18,9 +25,13 @@ import { defineTool } from '@tools/core/define';
 
 const SortBySchema = z.enum(['relevance', 'lastUpdatedDate', 'submittedDate']);
 const SortOrderSchema = z.enum(['ascending', 'descending']);
+const SearchFieldSchema = z.enum(['all', 'author', 'title', 'abstract']);
 
 const ArxivSearchInputSchema = z.strictObject({
   query: z.string(),
+  field: SearchFieldSchema.optional().describe(
+    'Search field: "author" for author names, "title" for paper titles, "abstract" for abstracts, "all" (default) for all fields',
+  ),
   categories: z.array(z.string()).optional(),
   maxResults: z.int().positive().max(ARXIV_CONSTANTS.MAX_RESULTS).optional(),
   start: z.int().min(0).optional(),
@@ -33,7 +44,7 @@ export type ArxivSearchInput = z.infer<typeof ArxivSearchInputSchema>;
 export class ArxivSearchTool extends defineTool({
   name: 'arxiv_search',
   description:
-    'Search arXiv for papers and return basic metadata for each hit.',
+    'Search arXiv for papers and return basic metadata for each hit. Use field="author" for author name searches.',
   schema: ArxivSearchInputSchema,
 }) {
   protected async execute(input: ArxivSearchInput) {
@@ -42,13 +53,28 @@ export class ArxivSearchTool extends defineTool({
       throw new ToolError('Search query cannot be empty.');
     }
 
+    // Select the query function based on the field parameter
+    const searchField = input.field ?? 'all';
+    const fieldQueryFn = (term: string) => {
+      switch (searchField) {
+        case 'author':
+          return authorQuery(term);
+        case 'title':
+          return titleQuery(term);
+        case 'abstract':
+          return abstractQuery(term);
+        default:
+          return all(term);
+      }
+    };
+
     // Build query using arxiv-client query builder
     const terms = Array.from(
       trimmedQuery.matchAll(/"([^"]+)"|\S+/g),
       (match) => match[1] ?? match[0],
     );
 
-    const termQueries = terms.map((term) => all(term));
+    const termQueries = terms.map((term) => fieldQueryFn(term));
     let query = termQueries.length === 1 ? termQueries[0] : and(...termQueries);
 
     // Add category filters if provided
@@ -117,14 +143,16 @@ export class ArxivSearchTool extends defineTool({
 
     const payload = {
       query: trimmedQuery,
+      field: searchField,
       start: input.start ?? 0,
       count: results.length,
       totalResults: null, // arxiv-client doesn't expose totalResults
       results,
     };
 
+    const fieldLabel = searchField !== 'all' ? ` (${searchField})` : '';
     return toolResult({
-      summary: `Found ${results.length} arXiv result${results.length === 1 ? '' : 's'} for "${trimmedQuery}"`,
+      summary: `Found ${results.length} arXiv result${results.length === 1 ? '' : 's'} for "${trimmedQuery}"${fieldLabel}`,
       output: JSON.stringify(payload, null, 2),
     });
   }

--- a/src/tools/web/WebSearchTool.ts
+++ b/src/tools/web/WebSearchTool.ts
@@ -14,6 +14,24 @@ const WebSearchInputSchema = z.strictObject({
 
 export type WebSearchInput = z.infer<typeof WebSearchInputSchema>;
 
+interface DuckDuckGoResult {
+  Text?: string;
+  FirstURL?: string;
+  Topics?: DuckDuckGoResult[];
+}
+
+interface DuckDuckGoResponse {
+  Abstract?: string;
+  AbstractText?: string;
+  AbstractURL?: string;
+  AbstractSource?: string;
+  Heading?: string;
+  RelatedTopics?: DuckDuckGoResult[];
+  Infobox?: {
+    content?: Array<{ label?: string; value?: string }>;
+  };
+}
+
 export class WebSearchTool extends defineTool({
   name: 'web_search',
   description: 'Search the web and return top results',
@@ -23,33 +41,68 @@ export class WebSearchTool extends defineTool({
     const { query, max_results = 3 } = input;
     let response;
     try {
-      response = await axios.get('https://api.duckduckgo.com/', {
-        params: { q: query, format: 'json', no_redirect: 1, no_html: 1 },
-      });
+      response = await axios.get<DuckDuckGoResponse>(
+        'https://api.duckduckgo.com/',
+        {
+          params: { q: query, format: 'json', no_redirect: 1, no_html: 1 },
+        },
+      );
     } catch (error) {
       throw new ToolError(`Web search failed: ${toErrorMessage(error)}`);
     }
     const data = response.data;
     const results: string[] = [];
-    if (Array.isArray(data.RelatedTopics)) {
-      for (const item of data.RelatedTopics.slice(0, max_results)) {
-        if (
-          typeof item.Text === 'string' &&
-          typeof item.FirstURL === 'string'
-        ) {
+
+    // Extract abstract/summary if available (direct answers)
+    if (data.AbstractText && data.AbstractURL) {
+      const source = data.AbstractSource ? ` [${data.AbstractSource}]` : '';
+      results.push(`${data.AbstractText}${source} (${data.AbstractURL})`);
+    } else if (data.Abstract && data.AbstractURL) {
+      results.push(`${data.Abstract} (${data.AbstractURL})`);
+    }
+
+    // Extract from RelatedTopics (including nested Topics)
+    const extractTopics = (
+      topics: DuckDuckGoResult[],
+      limit: number,
+    ): void => {
+      for (const item of topics) {
+        if (results.length >= limit) break;
+        if (typeof item.Text === 'string' && typeof item.FirstURL === 'string') {
           results.push(`${item.Text} (${item.FirstURL})`);
         }
+        // Handle nested topic groups
+        if (Array.isArray(item.Topics)) {
+          extractTopics(item.Topics, limit);
+        }
+      }
+    };
+
+    if (Array.isArray(data.RelatedTopics)) {
+      extractTopics(data.RelatedTopics, max_results);
+    }
+
+    // Extract key facts from Infobox if available
+    if (data.Infobox?.content && results.length < max_results) {
+      const facts = data.Infobox.content
+        .filter((c) => c.label && c.value)
+        .slice(0, max_results - results.length)
+        .map((c) => `${c.label}: ${c.value}`);
+      if (facts.length > 0) {
+        results.push(`Key facts: ${facts.join('; ')}`);
       }
     }
+
     if (results.length === 0) {
       return toolResult({
         summary: `Search "${query}" (no results)`,
-        output: 'No results found.',
+        output:
+          'No results found. Note: This search uses DuckDuckGo Instant Answers API which works best for factual/entity queries. For general web searches, try rephrasing the query or use more specific terms.',
       });
     }
     return toolResult({
       summary: `Search "${query}"`,
-      output: results.join('\n'),
+      output: results.slice(0, max_results).join('\n\n'),
     });
   }
 }


### PR DESCRIPTION
- WebSearchTool: Extract Abstract, AbstractText, Infobox fields from DuckDuckGo in addition to RelatedTopics; handle nested topic groups; provide clearer error message when no results found

- ArxivSearchTool: Add 'field' parameter to support author-specific, title-specific, and abstract-specific searches (fixes issue where author name queries returned no results with all-field search)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds field-specific arXiv queries and expands DuckDuckGo parsing (abstracts, nested topics, infobox) with clearer results and messaging.
> 
> - **ArXiv Search (`src/tools/arxiv/ArxivSearchTool.ts`)**
>   - Add `field` parameter (`all`/`author`/`title`/`abstract`) and route terms to corresponding query (`authorQuery`, `titleQuery`, `abstractQuery`, `all`).
>   - Include `field` in output payload and summary; clarify tool description.
>   - Preserve category filters, sorting, and rate-limited execution.
> - **Web Search (`src/tools/web/WebSearchTool.ts`)**
>   - Strongly type DuckDuckGo response and parse direct answers (`AbstractText`/`Abstract`) with source/URL.
>   - Recursively extract `RelatedTopics` (including nested `Topics`) and limit results.
>   - Parse `Infobox` key facts; improve no-results guidance.
>   - Return formatted output with separated entries and respect `max_results`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f01504c4e40cf25f7fa51a026c5387cc12306370. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->