### PR TITLE
Fix round group display separation issue

### DIFF
--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -35,7 +35,6 @@ import { getSystemPromptWithRules } from '@utils/prompt';
 import type { AgentFileLocation } from '@utils/files';
 import { K_SLICE, REPETITION_DETECTION_THRESHOLD } from '@utils/config';
 import { AbsoluteFS, flexibleFS } from '@utils/files';
-import { isNonEmptyString } from '@utils/core';
 import xmlUtils from '@utils/text/xmlUtils';
 import { bestConnectionMethod } from '@latex';
 
@@ -485,30 +484,23 @@ class ResponseProcessNode<C> extends BaseNode<
         store.workspace,
       );
       const useStreaming = options.modelHandler.getStreamingConfig();
+      const isBackgroundMode = options.modelHandler.isBackgroundModeActive();
 
-      if (thinkingContent && !useStreaming) {
-        const formatted = await xmlUtils.formatContent(thinkingContent);
-        if (isNonEmptyString(formatted)) {
-          options.logger.info(formatted, {
-            messageType: MESSAGE_TYPES.THINKING,
-          });
-        }
+      // For non-streaming mode, emit thinking/scratchpad to progress view
+      // Skip for background mode - content arrives all at once after polling
+      if (thinkingContent && !useStreaming && !isBackgroundMode) {
+        options.logger.info(thinkingContent, {
+          messageType: MESSAGE_TYPES.THINKING,
+        });
       }
 
       const scratchpad = await xmlUtils.extractScratchpad(
         newResponse,
         'scratchpad',
       );
-      if (scratchpad) {
+      if (scratchpad && !isBackgroundMode) {
         options.logger.info(scratchpad, {
           messageType: MESSAGE_TYPES.SCRATCHPAD,
-        });
-      }
-
-      if (newResponse && !useStreaming) {
-        const formattedResponse = await xmlUtils.formatContent(newResponse);
-        options.logger.info(formattedResponse, {
-          messageType: MESSAGE_TYPES.INTERNAL,
         });
       }
 

--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -484,21 +484,21 @@ class ResponseProcessNode<C> extends BaseNode<
         store.workspace,
       );
       const useStreaming = options.modelHandler.getStreamingConfig();
-      const isBackgroundMode = options.modelHandler.isBackgroundModeActive();
 
-      // For non-streaming mode, emit thinking/scratchpad to progress view
-      // Skip for background mode - content arrives all at once after polling
-      if (thinkingContent && !useStreaming && !isBackgroundMode) {
+      // For non-streaming mode, emit thinking to progress view
+      // (streaming mode already shows it progressively via streams)
+      if (thinkingContent && !useStreaming) {
         options.logger.info(thinkingContent, {
           messageType: MESSAGE_TYPES.THINKING,
         });
       }
 
+      // Scratchpad is always extracted from final response, not streamed
       const scratchpad = await xmlUtils.extractScratchpad(
         newResponse,
         'scratchpad',
       );
-      if (scratchpad && !isBackgroundMode) {
+      if (scratchpad) {
         options.logger.info(scratchpad, {
           messageType: MESSAGE_TYPES.SCRATCHPAD,
         });

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -167,6 +167,15 @@ export abstract class ModelHandler<
   }
 
   /**
+   * Indicates whether background mode is active for this handler.
+   * Background mode runs requests asynchronously and polls for completion.
+   * Override in handlers that support background execution.
+   */
+  public isBackgroundModeActive(): boolean {
+    return false;
+  }
+
+  /**
    * Enables or disables Progress view updates.
    */
   public setProgressViewEnabled(enabled: boolean): void {

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -135,14 +135,23 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
    * @returns false if background mode is enabled, otherwise delegates to base
    */
   public override getStreamingConfig(): boolean {
+    if (this.isBackgroundModeActive()) {
+      return false;
+    }
+    return super.getStreamingConfig();
+  }
+
+  /**
+   * Check if background mode is active for this handler.
+   * Background mode is enabled when the config toggle is on AND
+   * this model/agent is eligible for background execution.
+   */
+  public override isBackgroundModeActive(): boolean {
     const useBackgroundResponses = getConfig<boolean>(
       'texra.model.useBackgroundResponses',
       false,
     );
-    if (useBackgroundResponses && this.isBackgroundModeEligible()) {
-      return false;
-    }
-    return super.getStreamingConfig();
+    return useBackgroundResponses && this.isBackgroundModeEligible();
   }
 
   protected override backgroundModeSupported = true;

--- a/src/agent/modelHandlers/types/IModelHandler.ts
+++ b/src/agent/modelHandlers/types/IModelHandler.ts
@@ -164,6 +164,9 @@ export interface IModelHandler<
   /** Check if output streaming is enabled. */
   isOutputStreamingEnabled(): boolean;
 
+  /** Check if background mode is active for this handler. */
+  isBackgroundModeActive(): boolean;
+
   /** Indicates if the model is served by Google. */
   readonly isGoogle: boolean;
 

--- a/src/logger/transports/VSCodeTransport.ts
+++ b/src/logger/transports/VSCodeTransport.ts
@@ -99,6 +99,7 @@ export class VSCodeTransport extends Transport {
 
     group.endTime = Date.now();
     group.status = status;
+
     this.emitGroupFinished({
       stream: this.streamName,
       groupId,

--- a/src/progressView/events/TaskGroupEvents.ts
+++ b/src/progressView/events/TaskGroupEvents.ts
@@ -43,6 +43,10 @@ export function createTaskGroupEvents(
     state: ProgressViewState,
     updater: WebviewUpdater,
   ): void => {
+    debugLog(
+      `addTaskGroup: groupId=${data.groupId}, name=${data.groupName}, parentGroupId=${data.parentGroupId ?? 'none'}, stream=${data.stream}`,
+    );
+
     withErrorBoundary('failed to handle addTaskGroup', async () => {
       const {
         stream,
@@ -90,6 +94,10 @@ export function createTaskGroupEvents(
     state: ProgressViewState,
     updater: WebviewUpdater,
   ): void => {
+    debugLog(
+      `updateTaskGroup: groupId=${data.groupId}, status=${data.status}, stream=${data.stream}`,
+    );
+
     withErrorBoundary('failed to handle updateTaskGroup', async () => {
       const update: TaskGroupUpdatePayload = {
         stream: data.stream,
@@ -102,7 +110,13 @@ export function createTaskGroupEvents(
 
       await state.taskGroups.updateGroup(update);
 
-      if (updater.isAvailable() && data.stream === state.activeStream) {
+      const shouldSendToWebview =
+        updater.isAvailable() && data.stream === state.activeStream;
+      debugLog(
+        `updateTaskGroup: shouldSendToWebview=${shouldSendToWebview}, activeStream=${state.activeStream}`,
+      );
+
+      if (shouldSendToWebview) {
         updater.updateTaskGroup(update);
       }
     });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Enable background-mode-aware streaming for OpenAI Responses, simplify non-streaming thinking emission, and add task group debug logging in the progress view.
> 
> - **Model handling**:
>   - Add `isBackgroundModeActive()` to `ModelHandler` and `IModelHandler`.
>   - OpenAI Responses handler: disable streaming when background mode is active; determine eligibility (GPT‑5 workflow agents) and use background polling.
> - **Response processing** (`src/agent/core/flows/ResponseCycleFlow.ts`):
>   - Emit `THINKING` content only in non-streaming mode (no XML reformatting); always extract and emit `SCRATCHPAD` from final response.
>   - Remove non-streaming internal formatted-response log; keep normalized usage as single source of truth.
> - **Progress view**:
>   - Add verbose debug logs for `addTaskGroup`/`updateTaskGroup`; conditionally send updates to webview only for the active stream with debug tracing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e1fef8c832c66043b43cd227794472c0099d57de. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->