### PR TITLE
Move include source outside tools loop

### DIFF
--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -603,12 +603,14 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       if (convertedTools.length > 0) {
         params.tools = convertedTools;
         params.tool_choice = 'auto';
-
-        // Include web search sources in response when native web search is enabled
-        if (this.capabilities.supportsNativeWebSearch) {
-          params.include = ['web_search_call.action.sources'];
-        }
       }
+    }
+
+    // Include web search sources in response when native web search is enabled.
+    // This is set outside the tools block because deep research models use
+    // native web search even when no explicit tools are passed.
+    if (this.capabilities.supportsNativeWebSearch) {
+      params.include = ['web_search_call.action.sources'];
     }
 
     if (this.capabilities.supportsReasoning) {


### PR DESCRIPTION
Deep research models use native web search even when no explicit tools are passed. The include parameter for web search sources should be set based on supportsNativeWebSearch capability, not dependent on whether tools exist after filtering.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Moves the `include` setting for web search sources outside the tools block so it’s applied whenever native web search is supported, regardless of provided tools.
> 
> - **OpenAI Responses handler (`src/agent/modelHandlers/modelHandlerOpenAIResponse.ts`)**:
>   - Always set `params.include = ['web_search_call.action.sources']` when `supportsNativeWebSearch` is true, independent of `tools`.
>   - Removed the previous `include` assignment from inside the tools block.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 543d70272b50ffcf1dcdadf77f88000df0850f5b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->