### PR TITLE
Debug empty search results in streaming mode

### DIFF
--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -51,6 +51,7 @@ import { ModelHandler } from './ModelHandler';
 import {
   buildOpenAIWebSearchResult,
   extractOpenAIWebSearchResults,
+  hasOpenAIWebSearchData,
   isOpenAIWebSearchCall,
   type ServerToolExtractionResult,
 } from './types/ServerToolTypes';
@@ -682,7 +683,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
           if (
             this.isWebSearchItem(item) &&
             !state.emittedWebSearchIds.has(item.id) &&
-            this.hasWebSearchData(item)
+            hasOpenAIWebSearchData(item)
           ) {
             // Finalize thinking if we have content (in case in_progress didn't fire)
             if (state.hasThinkingContent) {
@@ -1613,17 +1614,6 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     item: ResponseOutputItem,
   ): item is ResponseFunctionWebSearch {
     return item.type === 'web_search_call';
-  }
-
-  /**
-   * Check if a web search item has meaningful data (action field with query).
-   * During streaming, web search items may be emitted without the action field,
-   * which results in empty searches being displayed. We skip those and let the
-   * fallback from the final response handle them.
-   */
-  private hasWebSearchData(item: ResponseFunctionWebSearch): boolean {
-    const searchItem = item as { action?: { query?: string } };
-    return Boolean(searchItem.action?.query);
   }
 
   /**

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -1645,7 +1645,11 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     }
 
     for (const item of output) {
-      if (this.isWebSearchItem(item) && !alreadyEmitted.has(item.id)) {
+      if (
+        this.isWebSearchItem(item) &&
+        !alreadyEmitted.has(item.id) &&
+        hasOpenAIWebSearchData(item)
+      ) {
         this.emitOpenAIWebSearch(item);
         alreadyEmitted.add(item.id);
       }

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -681,7 +681,8 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
           const item = event.item;
           if (
             this.isWebSearchItem(item) &&
-            !state.emittedWebSearchIds.has(item.id)
+            !state.emittedWebSearchIds.has(item.id) &&
+            this.hasWebSearchData(item)
           ) {
             // Finalize thinking if we have content (in case in_progress didn't fire)
             if (state.hasThinkingContent) {
@@ -1612,6 +1613,17 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     item: ResponseOutputItem,
   ): item is ResponseFunctionWebSearch {
     return item.type === 'web_search_call';
+  }
+
+  /**
+   * Check if a web search item has meaningful data (action field with query).
+   * During streaming, web search items may be emitted without the action field,
+   * which results in empty searches being displayed. We skip those and let the
+   * fallback from the final response handle them.
+   */
+  private hasWebSearchData(item: ResponseFunctionWebSearch): boolean {
+    const searchItem = item as { action?: { query?: string } };
+    return Boolean(searchItem.action?.query);
   }
 
   /**

--- a/src/agent/modelHandlers/types/ServerToolTypes.ts
+++ b/src/agent/modelHandlers/types/ServerToolTypes.ts
@@ -277,6 +277,16 @@ export function buildOpenAIWebSearchResult(
 }
 
 /**
+ * Check if a web search item has meaningful data (action field with query).
+ * During streaming, web search items may be emitted without the action field,
+ * which results in empty searches being displayed. Use this to filter them out.
+ */
+export function hasOpenAIWebSearchData(item: ResponseFunctionWebSearch): boolean {
+  const searchItem = item as ResponseFunctionWebSearchWithAction;
+  return Boolean(searchItem.action?.query);
+}
+
+/**
  * Extract web search results from OpenAI Responses API output.
  * Uses SDK's ResponseFunctionWebSearch type for proper typing.
  *


### PR DESCRIPTION
…reaming

During streaming, web search items are emitted when output_item.done fires, but the action field (containing query and sources) is not yet populated. This caused empty "OpenAI Search" entries with "No results found" to appear.

The fix adds a hasWebSearchData check that skips emitting web searches during streaming if they lack meaningful data. The fallback mechanism at the end of streaming will emit proper results from the final response.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents empty OpenAI web searches by adding a helper to detect meaningful web_search data and using it to filter streaming and fallback emissions.
> 
> - **OpenAI Responses handler (`modelHandlerOpenAIResponse.ts`)**:
>   - On `output_item.done`, emit web searches only if `hasOpenAIWebSearchData(item)` and not previously emitted.
>   - In final fallback (`emitWebSearchesFromResponse`), also require `hasOpenAIWebSearchData(item)` to avoid empty entries.
> - **Server tool types (`ServerToolTypes.ts`)**:
>   - Add `hasOpenAIWebSearchData(item)` utility to detect web searches with an `action.query`.
>   - Documentation clarifies streaming may produce items without `action`, motivating the filter.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 47850eb83c2d0375995a659926f06241b9890704. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->