### PR TITLE
fix(api-key): pass provider as array to safeExecuteCommand

### DIFF
--- a/src/webview/MainViewMessageHandler.ts
+++ b/src/webview/MainViewMessageHandler.ts
@@ -203,7 +203,7 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
       [MAIN_VIEW_COMMANDS.OPEN_SET_PROVIDER_API_KEY]: async (m) => {
         // Reuse existing setApiKey command with provider parameter
         if (m?.provider) {
-          await safeExecuteCommand('texra.setApiKey', m.provider);
+          await safeExecuteCommand('texra.setApiKey', [m.provider]);
         }
       },
       [MAIN_VIEW_COMMANDS.OPEN_PROVIDER_API_KEY_URL]: async (m) => {


### PR DESCRIPTION
The safeExecuteCommand function expects args to be an array and spreads it.
Passing a string directly caused it to be spread into individual characters,
so "deepseek" became "d" (the first character) instead of the full provider name.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensure `OPEN_SET_PROVIDER_API_KEY` passes provider as an array to `safeExecuteCommand('texra.setApiKey', ...)` to avoid string spreading.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f925a0bbe3141545cea58eda221a5d22bfa45b9f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->