### PR TITLE
fix(ui): make API key missing indicator red in model selector

### DIFF
--- a/src/model/computeModelOptions.ts
+++ b/src/model/computeModelOptions.ts
@@ -31,8 +31,8 @@ function formatCost(inputPrice?: number, outputPrice?: number): string {
 
 /**
  * Compute model <vscode-option> tags based on available API keys.
- * Models missing a required key receive a "✗" label and attributes so the
- * webview can handle API key setup prompts.
+ * Models missing a required key receive data-requires-key="true" so the
+ * webview can handle API key setup prompts and display a red ✗ indicator.
  */
 export async function computeModelOptions(): Promise<string> {
   const models = getConfig<string[]>('texra.models', []);
@@ -66,7 +66,8 @@ export async function computeModelOptions(): Promise<string> {
         available = true;
       }
 
-      const label = available ? model : `${model} ✗`;
+      // Client-side adds the ✗ indicator based on data-requires-key attribute
+      const label = model;
       const requiresKeyAttr = available
         ? ''
         : ' data-requires-key="true" class="disabled-option disabled-model"';

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -327,13 +327,12 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
   }
 
   _decorateModelOption(opt) {
-    const { provider, context, cost } = opt.dataset;
+    const { provider, context, cost, requiresKey } = opt.dataset;
     const modelName =
       opt.textContent?.trim() ?? opt.getAttribute('value') ?? '';
 
     // Get provider decorator for the icon
     const decorator = getModelProviderDecorator(provider);
-    const displayLabel = `${decorator.unicode} ${modelName}`;
 
     // Build tooltip with provider info
     const hints = [];
@@ -341,8 +340,14 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
     if (context) hints.push(`Context: ${context}`);
     if (cost) hints.push(`Cost: ${cost}`);
 
-    // Set text content with provider icon
-    opt.textContent = displayLabel;
+    // Set content with provider icon, adding red ✗ via DOM if key is missing
+    opt.textContent = `${decorator.unicode} ${modelName}`;
+    if (requiresKey === 'true') {
+      const span = document.createElement('span');
+      span.className = 'api-key-missing';
+      span.textContent = ' ✗';
+      opt.appendChild(span);
+    }
 
     if (hints.length > 0) {
       opt.title = hints.join(' | ');

--- a/src/webview/styles/base.css
+++ b/src/webview/styles/base.css
@@ -128,6 +128,14 @@ vscode-option[data-requires-key='true'] {
   background-color: var(--vscode-input-background);
 }
 
+/* Red × indicator for missing API keys.
+   Overrides parent opacity/font-style so the ✗ stands out clearly. */
+.api-key-missing {
+  color: var(--vscode-errorForeground);
+  opacity: 1;
+  font-style: normal;
+}
+
 vscode-option[data-multiple='true'] {
   font-family: codicon, var(--vscode-font-family);
 }


### PR DESCRIPTION
Display the ✗ symbol in red (using --vscode-errorForeground) for models
that require an API key but don't have one configured. This makes it
more visually clear which models are unavailable due to missing keys.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Models lacking required API keys now display a red ✗ in the model dropdown via a data attribute and DOM decoration, with supporting CSS.
> 
> - **Model selector UI**:
>   - Client adds a red `✗` for models missing API keys based on `data-requires-key="true"`.
>   - `src/model/computeModelOptions.ts`: stops embedding `✗` in labels; emits `data-requires-key` and disabled classes when keys are missing; preserves provider/context/cost data.
>   - `src/webview/modules/messageHandlers.js`: `_decorateModelOption` reads `requiresKey`, sets provider icon, and appends `span.api-key-missing` for the red `✗`; updates tooltips/ARIA.
> - **Styles**:
>   - `src/webview/styles/base.css`: adds `.api-key-missing` using `--vscode-errorForeground` and ensures visibility over disabled styling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7be8b667d6013e0a9a27c6bbde35d72125b84970. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->