### PR TITLE
feat(agent): route raw XML output files to task run storage

### DIFF
--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -335,6 +335,14 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
    * Generates output file path for specified conversation round.
    * Default implementation uses scratchpad mode detection to determine file extension.
    * Override for specialized naming logic (e.g., MergeAgent).
+   *
+   * For scratchpad mode (XML output), uses createRawOutputLocation() which always
+   * routes to run storage when executionId is available. This keeps intermediate
+   * XML artifacts isolated from the user's workspace.
+   *
+   * For direct output mode, uses createLocation() which respects the user's
+   * storageMode preference.
+   *
    * @returns AgentFileLocation - always workspace or runStorage (never external)
    */
   public getOutputFileLocation(currRound: number): AgentFileLocation {
@@ -352,8 +360,12 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
       this.agentConfig.editedFile || undefined,
     );
 
-    // fileService.createLocation always returns workspace or runStorage for agent outputs
-    return this.fileService.createLocation(fileName) as AgentFileLocation;
+    // Route raw XML to isolated storage, direct outputs respect user preference
+    return (
+      this.useScratchpad
+        ? this.fileService.createRawOutputLocation(fileName)
+        : this.fileService.createLocation(fileName)
+    ) as AgentFileLocation;
   }
 
   /**

--- a/src/progressView/modules/formatters.js
+++ b/src/progressView/modules/formatters.js
@@ -1160,6 +1160,7 @@ export class LogEntryFormatter {
           <span>Open XML to check tag consistency:</span>
           <span class="file-link clickable-link" data-file="${xmlEscaped}">${xmlFileNameEscaped}</span>
           ${tagInfo}
+          <div class="xml-fix-hint">After fixing, click <i class="codicon codicon-debug-rerun"></i> <strong>Resume</strong> to re-process</div>
         </div>`;
     }
 

--- a/src/progressView/styles/file-list.css
+++ b/src/progressView/styles/file-list.css
@@ -24,6 +24,7 @@
   padding-top: var(--spacing-small);
   border-top: 1px solid var(--vscode-widget-border);
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   gap: var(--spacing-small);
 }
@@ -37,4 +38,24 @@
   color: var(--vscode-descriptionForeground);
   opacity: 0.8;
   font-style: italic;
+}
+
+/* Hint for fixing XML and resuming */
+.xml-link-container .xml-fix-hint {
+  flex-basis: 100%;
+  margin-top: var(--spacing-tiny);
+  color: var(--vscode-descriptionForeground);
+  font-size: 0.9em;
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-tiny);
+}
+
+.xml-link-container .xml-fix-hint .codicon {
+  opacity: 1;
+  color: var(--vscode-textLink-foreground);
+}
+
+.xml-link-container .xml-fix-hint strong {
+  color: var(--vscode-textLink-foreground);
 }

--- a/src/utils/files/taskRunStorage.ts
+++ b/src/utils/files/taskRunStorage.ts
@@ -408,6 +408,38 @@ export class TaskRunFileService {
   }
 
   /**
+   * Create a FileLocation for raw/intermediate output files (e.g., XML scratchpad).
+   * ALWAYS routes to run storage when executionId is available, regardless of
+   * the user's storageMode setting. This keeps intermediate artifacts isolated
+   * from the user's workspace.
+   *
+   * Falls back to workspace location only when no executionId is available.
+   *
+   * @param relativePath - Workspace-relative path (e.g., "paper__agent__r0_model.xml")
+   * @returns FileLocation (runStorage if executionId available, workspace otherwise)
+   */
+  public createRawOutputLocation(relativePath: string): FileLocation {
+    const workspaceRoot = this.workspaceRoot;
+    if (!workspaceRoot) {
+      return createExternalLocation(relativePath);
+    }
+
+    const normalized = relativePath ? path.normalize(relativePath) : '';
+
+    // Always route to run storage when executionId is available
+    const executionId = this.activeExecutionId;
+    if (executionId) {
+      const runDir = getRunDir(executionId);
+      const runAbsolute = path.join(runDir, normalized);
+      return createRunStorageLocation(runAbsolute, normalized, executionId);
+    }
+
+    // Fallback to workspace when no execution context
+    const workspaceAbsolute = path.join(workspaceRoot, normalized);
+    return createWorkspaceLocation(workspaceAbsolute, normalized);
+  }
+
+  /**
    * Create a FileLocation from a workspace-relative path, with run-storage awareness.
    * This is the preferred method for creating output file locations.
    *


### PR DESCRIPTION
Raw XML files are intermediate artifacts that clutter the user's workspace.
This change ensures XML output files always go to task run storage when an
executionId is available, regardless of the storageMode setting.

Changes:
- Add createRawOutputLocation() method to TaskRunFileService that always
  routes to run storage when executionId is available
- Use it in BaseReflectionAgent.getOutputFileLocation() for scratchpad mode
- Processed .tex files still respect user's storage mode preference
- DirectAgent outputs unchanged (no XML intermediate stage)

Also improves the XML extraction failure message to guide users:
- Add hint about clicking Resume button after fixing XML tags
- Style the hint to highlight the action visually

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Raw scratchpad XML now always saves to task run storage; UI shows a Resume hint when fixing XML, with supporting styles.
> 
> - **Agent/Workflow**:
>   - Update `BaseReflectionAgent.getOutputFileLocation()` to route scratchpad (XML) outputs via `fileService.createRawOutputLocation()`; direct outputs continue using `createLocation()` (respecting storageMode).
> - **Storage Utils**:
>   - Add `TaskRunFileService.createRawOutputLocation()` to always place intermediate/raw outputs in run storage when `executionId` exists; fallback to workspace otherwise.
> - **Progress View UI**:
>   - Enhance missing-outputs formatter to show a fix hint: “After fixing, click Resume to re-process,” with an XML link.
>   - Add/adjust CSS for `.xml-link-container` (wrap) and `.xml-fix-hint` styling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 215199d967a18fcdd8a37a3f6cfdd0655a717c52. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->