### PR TITLE
refactor(css): consolidate styles and remove dead code

### DIFF
--- a/src/common/modules/domUtils.js
+++ b/src/common/modules/domUtils.js
@@ -290,3 +290,17 @@ export function waitForElement(selector, options = {}) {
 
   return { promise, dispose };
 }
+
+/**
+ * Set the data-expanded attribute on a parent element matching the selector.
+ * Used for CSS-based visibility toggling without fragile style attribute checks.
+ * @param {HTMLElement} element - The child element to start searching from.
+ * @param {string} selector - CSS selector for the parent element.
+ * @param {boolean} isExpanded - Whether the section is expanded.
+ */
+export function setExpandedState(element, selector, isExpanded) {
+  const parent = element?.closest(selector);
+  if (parent) {
+    parent.dataset.expanded = isExpanded ? 'true' : 'false';
+  }
+}

--- a/src/common/styles/common.css
+++ b/src/common/styles/common.css
@@ -208,10 +208,10 @@ vscode-toolbar-button {
    ========================================================================== */
 
 /* Secondary button style - less prominent than primary */
-.secondary {
+.btn-secondary {
   opacity: var(--opacity-normal);
 }
 
-.secondary:hover {
+.btn-secondary:hover {
   opacity: var(--opacity-full);
 }

--- a/src/common/styles/common.css
+++ b/src/common/styles/common.css
@@ -139,3 +139,79 @@ vscode-toolbar-button {
   opacity: var(--opacity-subtle);
   font-size: var(--font-size-sm);
 }
+
+/* ==========================================================================
+   Utility Classes
+   ========================================================================== */
+
+/* Visibility */
+.hidden {
+  display: none;
+}
+
+.hidden.is-visible {
+  display: flex;
+}
+
+/* Text utilities */
+.truncate {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* ==========================================================================
+   Animations
+   ========================================================================== */
+
+/* Pulse animation with scale - for status indicators */
+@keyframes pulse-scale {
+  0% {
+    transform: scale(1);
+    opacity: var(--opacity-subtle);
+  }
+  50% {
+    transform: scale(1.1);
+    opacity: var(--opacity-full);
+  }
+  100% {
+    transform: scale(1);
+    opacity: var(--opacity-subtle);
+  }
+}
+
+/* Pulse animation with fade - for recording indicators */
+@keyframes pulse-fade {
+  0% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.6;
+  }
+  100% {
+    opacity: 1;
+  }
+}
+
+/* Spin animation - for loading indicators */
+@keyframes spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* ==========================================================================
+   Button Variants
+   ========================================================================== */
+
+/* Secondary button style - less prominent than primary */
+.secondary {
+  opacity: var(--opacity-normal);
+}
+
+.secondary:hover {
+  opacity: var(--opacity-full);
+}

--- a/src/progressView/styles/base.css
+++ b/src/progressView/styles/base.css
@@ -37,29 +37,4 @@ vscode-split-layout {
   overflow: hidden;
 }
 
-/* Animations */
-/* Animation for status indicator */
-@keyframes pulse {
-  0% {
-    transform: scale(1);
-    opacity: var(--opacity-subtle);
-  }
-  50% {
-    transform: scale(1.1);
-    opacity: var(--opacity-full);
-  }
-  100% {
-    transform: scale(1);
-    opacity: var(--opacity-subtle);
-  }
-}
-
-/* Animation for running indicator */
-@keyframes spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
-}
+/* Animations moved to common.css as pulse-scale, pulse-fade, and spin */

--- a/src/progressView/styles/follow-up-input.css
+++ b/src/progressView/styles/follow-up-input.css
@@ -32,6 +32,7 @@
   overflow-y: auto;
 }
 
+/* !important needed to override vscode-toolbar-container's internal flex-direction: row */
 .follow-up-actions,
 vscode-toolbar-container.follow-up-actions {
   display: flex;

--- a/src/progressView/styles/logs.css
+++ b/src/progressView/styles/logs.css
@@ -232,7 +232,7 @@
 .status-indicator.running {
   background-color: var(--vscode-testing-runAction, #2ea043);
   box-shadow: 0 0 4px var(--vscode-testing-runAction, #2ea043);
-  animation: pulse 2s infinite;
+  animation: pulse-scale 2s infinite;
 }
 
 .status-indicator.error {
@@ -248,7 +248,7 @@
 .status-indicator.waiting {
   background-color: var(--vscode-textLink-foreground, #3794ff);
   box-shadow: 0 0 4px var(--vscode-textLink-foreground, #3794ff);
-  animation: pulse 3s infinite;
+  animation: pulse-scale 3s infinite;
 }
 
 /* Generated files list */

--- a/src/progressView/styles/utilities.css
+++ b/src/progressView/styles/utilities.css
@@ -9,54 +9,8 @@
  */
 
 /* ==========================================================================
-   Layout Utilities - structural only
+   Utilities moved to common.css - import from there
    ========================================================================== */
-
-.flex {
-  display: flex;
-}
-
-.flex-col {
-  display: flex;
-  flex-direction: column;
-}
-
-.flex-center {
-  display: flex;
-  align-items: center;
-}
-
-.flex-wrap {
-  display: flex;
-  flex-wrap: wrap;
-}
-
-/* ==========================================================================
-   Text Utilities - structural only
-   ========================================================================== */
-
-.truncate {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.pre-wrap {
-  white-space: pre-wrap;
-  word-break: break-word;
-}
-
-/* ==========================================================================
-   Visibility
-   ========================================================================== */
-
-.hidden {
-  display: none;
-}
-
-.hidden.is-visible {
-  display: flex;
-}
 
 /* ==========================================================================
    Interactive - Copy button base behavior

--- a/src/webview/index.html
+++ b/src/webview/index.html
@@ -66,7 +66,7 @@
     <div class="content-wrapper">
       <div class="main-content">
         <div class="file-selection-group">
-          <div class="file-select">
+          <div class="file-select" data-expanded="false">
             <div class="file-select-header">
               <div class="file-select-label-group">
                 <vscode-toolbar-button
@@ -155,7 +155,7 @@
               </div>
             </div>
           </div>
-          <div class="file-select">
+          <div class="file-select" data-expanded="false">
             <div class="file-select-header">
               <div class="file-select-label-group">
                 <vscode-toolbar-button
@@ -219,7 +219,7 @@
               </div>
             </div>
           </div>
-          <div class="file-select">
+          <div class="file-select" data-expanded="false">
             <div class="file-select-header">
               <div class="file-select-label-group">
                 <vscode-toolbar-button
@@ -283,7 +283,7 @@
               </div>
             </div>
           </div>
-          <div class="file-select">
+          <div class="file-select" data-expanded="false">
             <div class="file-select-header">
               <div class="file-select-label-group">
                 <vscode-toolbar-button
@@ -364,13 +364,13 @@
               </div>
             </div>
           </div>
-          <div class="file-select">
+          <div class="file-select" data-expanded="false">
             <div class="file-select-header">
               <div class="file-select-label-group">
                 <span
                   id="toggleOutputFiles"
                   class="toggle-icon"
-                  title="Show or hide additional files for the agent’s output"
+                  title="Show or hide additional files for the agent's output"
                   ><i class="codicon codicon-chevron-down"></i
                 ></span>
                 <span
@@ -600,7 +600,7 @@
         </div>
       </div>
 
-      <div class="latexdiffs-section">
+      <div class="latexdiffs-section" data-expanded="false">
         <div class="file-select-header">
           <div class="file-select-label-group">
             <span id="toggleLatexdiffs" class="toggle-icon" title="LaTeXDiffs">

--- a/src/webview/index.html
+++ b/src/webview/index.html
@@ -582,7 +582,7 @@
             >
             <vscode-toolbar-button
               id="dependencyDismissButton"
-              class="secondary"
+              class="btn-secondary"
               title="Dismiss (can be re-enabled in settings)"
               icon="close"
               >Dismiss</vscode-toolbar-button

--- a/src/webview/index.html
+++ b/src/webview/index.html
@@ -124,16 +124,19 @@
                 ></span>
                 <vscode-toolbar-button
                   id="addOpenedInputFilesButton"
+                  class="file-action-button"
                   icon="folder-opened"
                   label="Add opened files as input"
                 ></vscode-toolbar-button>
                 <vscode-toolbar-button
                   id="emptyInputFilesButton"
+                  class="file-action-button"
                   icon="trash"
                   label="Empty"
                 ></vscode-toolbar-button>
                 <vscode-toolbar-button
                   id="selectInputFilesButton"
+                  class="file-action-button"
                   icon="add"
                   label="Add"
                 ></vscode-toolbar-button>
@@ -185,16 +188,19 @@
                 ></span>
                 <vscode-toolbar-button
                   id="addOpenedReferenceFilesButton"
+                  class="file-action-button"
                   icon="folder-opened"
                   label="Add opened files as reference"
                 ></vscode-toolbar-button>
                 <vscode-toolbar-button
                   id="emptyReferenceFilesButton"
+                  class="file-action-button"
                   icon="trash"
                   label="Empty"
                 ></vscode-toolbar-button>
                 <vscode-toolbar-button
                   id="selectReferenceFilesButton"
+                  class="file-action-button"
                   icon="add"
                   label="Add"
                 ></vscode-toolbar-button>
@@ -246,16 +252,19 @@
                 ></span>
                 <vscode-toolbar-button
                   id="addOpenedAuxiliaryFilesButton"
+                  class="file-action-button"
                   icon="folder-opened"
                   label="Add opened files as auxiliary"
                 ></vscode-toolbar-button>
                 <vscode-toolbar-button
                   id="emptyAuxiliaryFilesButton"
+                  class="file-action-button"
                   icon="trash"
                   label="Empty"
                 ></vscode-toolbar-button>
                 <vscode-toolbar-button
                   id="selectAuxiliaryFilesButton"
+                  class="file-action-button"
                   icon="add"
                   label="Add"
                 ></vscode-toolbar-button>
@@ -330,11 +339,13 @@
                 ></span>
                 <vscode-toolbar-button
                   id="emptyMediaFilesButton"
+                  class="file-action-button"
                   icon="trash"
                   label="Empty"
                 ></vscode-toolbar-button>
                 <vscode-toolbar-button
                   id="selectMediaFilesButton"
+                  class="file-action-button"
                   icon="add"
                   label="Add"
                 ></vscode-toolbar-button>
@@ -371,11 +382,13 @@
               <vscode-toolbar-container class="file-select-actions">
                 <vscode-toolbar-button
                   id="emptyOutputFilesButton"
+                  class="file-action-button"
                   icon="trash"
                   label="Empty"
                 ></vscode-toolbar-button>
                 <vscode-toolbar-button
                   id="selectOutputFilesButton"
+                  class="file-action-button"
                   icon="add"
                   label="Add"
                 ></vscode-toolbar-button>

--- a/src/webview/modules/mainViewState.js
+++ b/src/webview/modules/mainViewState.js
@@ -23,6 +23,7 @@ import {
   setElementDisabled,
   isSelectLikeElement,
   getSelectOptionElements,
+  setExpandedState,
 } from '@common/domUtils.js';
 import { capitalize } from '@common/stringUtils.js';
 import { WebviewStateManager } from '@common/webviewState.js';
@@ -233,6 +234,7 @@ export class MainViewState {
         const visible = previousState.latexdiffsVisible ?? false;
         latexdiffsContent.style.display = visible ? 'block' : 'none';
         setChevronIcon(toggleLatexdiffs, visible);
+        setExpandedState(latexdiffsContent, '.latexdiffs-section', visible);
       }
 
       this.applySessionType(normalizedSessionType, { skipSave: true });

--- a/src/webview/modules/uiManagers/BannerManager.js
+++ b/src/webview/modules/uiManagers/BannerManager.js
@@ -248,7 +248,7 @@ export class BannerManager extends BaseUIManager {
     nameSpan.textContent = label;
 
     const button = document.createElement('vscode-toolbar-button');
-    button.className = 'secondary dependency-install-button';
+    button.className = 'btn-secondary dependency-install-button';
     button.textContent = 'Install';
     button.setAttribute('icon', 'cloud-download');
     button.dataset.tool = tool;

--- a/src/webview/modules/uiManagers/FileList.js
+++ b/src/webview/modules/uiManagers/FileList.js
@@ -3,6 +3,7 @@ import {
   addEventListenerSafely,
   safeGetElementById,
   setChevronIcon,
+  setExpandedState,
 } from '@common/domUtils.js';
 import { capitalize } from '@common/stringUtils.js';
 import { createFromTemplate } from '@common/templateUtils.js';
@@ -105,12 +106,7 @@ export class FileList {
       const container = safeGetElementById(`${listId}Container`);
       if (container) {
         container.style.display = 'block';
-
-        // Set data-expanded on parent .file-select for CSS styling
-        const fileSelect = container.closest('.file-select');
-        if (fileSelect) {
-          fileSelect.dataset.expanded = 'true';
-        }
+        setExpandedState(container, '.file-select', true);
       }
     }
     this._save();
@@ -129,12 +125,7 @@ export class FileList {
     if (!container || !toggleIcon) return;
     container.style.display = isVisible ? 'block' : 'none';
     setChevronIcon(toggleIcon, isVisible);
-
-    // Set data-expanded on parent .file-select for CSS styling
-    const fileSelect = container.closest('.file-select');
-    if (fileSelect) {
-      fileSelect.dataset.expanded = isVisible ? 'true' : 'false';
-    }
+    setExpandedState(container, '.file-select', isVisible);
   }
 
   /** Toggle visibility of a file list container */
@@ -158,12 +149,7 @@ export class FileList {
     if (toggleIconDiv) {
       setChevronIcon(toggleIconDiv, false);
     }
-
-    // Remove data-expanded from parent .file-select
-    const fileSelect = container.closest('.file-select');
-    if (fileSelect) {
-      fileSelect.dataset.expanded = 'false';
-    }
+    setExpandedState(container, '.file-select', false);
 
     if (shouldSave) {
       this._save();

--- a/src/webview/modules/uiManagers/FileList.js
+++ b/src/webview/modules/uiManagers/FileList.js
@@ -105,6 +105,12 @@ export class FileList {
       const container = safeGetElementById(`${listId}Container`);
       if (container) {
         container.style.display = 'block';
+
+        // Set data-expanded on parent .file-select for CSS styling
+        const fileSelect = container.closest('.file-select');
+        if (fileSelect) {
+          fileSelect.dataset.expanded = 'true';
+        }
       }
     }
     this._save();
@@ -123,6 +129,12 @@ export class FileList {
     if (!container || !toggleIcon) return;
     container.style.display = isVisible ? 'block' : 'none';
     setChevronIcon(toggleIcon, isVisible);
+
+    // Set data-expanded on parent .file-select for CSS styling
+    const fileSelect = container.closest('.file-select');
+    if (fileSelect) {
+      fileSelect.dataset.expanded = isVisible ? 'true' : 'false';
+    }
   }
 
   /** Toggle visibility of a file list container */
@@ -146,6 +158,13 @@ export class FileList {
     if (toggleIconDiv) {
       setChevronIcon(toggleIconDiv, false);
     }
+
+    // Remove data-expanded from parent .file-select
+    const fileSelect = container.closest('.file-select');
+    if (fileSelect) {
+      fileSelect.dataset.expanded = 'false';
+    }
+
     if (shouldSave) {
       this._save();
     }

--- a/src/webview/modules/uiManagers/LatexdiffManager.js
+++ b/src/webview/modules/uiManagers/LatexdiffManager.js
@@ -25,6 +25,12 @@ export class LatexdiffManager {
 
       container.style.display = shouldShow ? 'block' : 'none';
       setChevronIcon(toggleIcon, shouldShow);
+
+      // Set data-expanded on parent .latexdiffs-section for CSS styling
+      const section = container.closest('.latexdiffs-section');
+      if (section) {
+        section.dataset.expanded = shouldShow ? 'true' : 'false';
+      }
     }
   }
 
@@ -35,10 +41,17 @@ export class LatexdiffManager {
     if (!container || !toggleIcon) return;
 
     const isVisible = container.style.display !== 'none';
-    container.style.display = isVisible ? 'none' : 'block';
-    setChevronIcon(toggleIcon, !isVisible);
+    const newVisible = !isVisible;
+    container.style.display = newVisible ? 'block' : 'none';
+    setChevronIcon(toggleIcon, newVisible);
 
-    this.state.update({ latexdiffsVisible: !isVisible });
+    // Set data-expanded on parent .latexdiffs-section for CSS styling
+    const section = container.closest('.latexdiffs-section');
+    if (section) {
+      section.dataset.expanded = newVisible ? 'true' : 'false';
+    }
+
+    this.state.update({ latexdiffsVisible: newVisible });
     this.state.save();
   }
 }

--- a/src/webview/modules/uiManagers/LatexdiffManager.js
+++ b/src/webview/modules/uiManagers/LatexdiffManager.js
@@ -1,7 +1,11 @@
 // Local imports - webview
 import { ELEMENT_IDS } from '../constants.js';
 import { mainViewState } from '../mainViewState.js';
-import { safeGetElementById, setChevronIcon } from '@common/domUtils.js';
+import {
+  safeGetElementById,
+  setChevronIcon,
+  setExpandedState,
+} from '@common/domUtils.js';
 
 const LATEXDIFF_CONTENT_ID = ELEMENT_IDS.LATEXDIFFS_CONTENT;
 const TOGGLE_LATEXDIFFS_ID = ELEMENT_IDS.TOGGLE_LATEXDIFFS;
@@ -25,12 +29,7 @@ export class LatexdiffManager {
 
       container.style.display = shouldShow ? 'block' : 'none';
       setChevronIcon(toggleIcon, shouldShow);
-
-      // Set data-expanded on parent .latexdiffs-section for CSS styling
-      const section = container.closest('.latexdiffs-section');
-      if (section) {
-        section.dataset.expanded = shouldShow ? 'true' : 'false';
-      }
+      setExpandedState(container, '.latexdiffs-section', shouldShow);
     }
   }
 
@@ -44,12 +43,7 @@ export class LatexdiffManager {
     const newVisible = !isVisible;
     container.style.display = newVisible ? 'block' : 'none';
     setChevronIcon(toggleIcon, newVisible);
-
-    // Set data-expanded on parent .latexdiffs-section for CSS styling
-    const section = container.closest('.latexdiffs-section');
-    if (section) {
-      section.dataset.expanded = newVisible ? 'true' : 'false';
-    }
+    setExpandedState(container, '.latexdiffs-section', newVisible);
 
     this.state.update({ latexdiffsVisible: newVisible });
     this.state.save();

--- a/src/webview/modules/uiManagers/OutputFilesManager.js
+++ b/src/webview/modules/uiManagers/OutputFilesManager.js
@@ -95,6 +95,12 @@ export class OutputFilesManager {
 
       container.style.display = shouldShow ? 'block' : 'none';
       setChevronIcon(toggleIcon, shouldShow);
+
+      // Set data-expanded on parent .file-select for CSS styling
+      const fileSelect = container.closest('.file-select');
+      if (fileSelect) {
+        fileSelect.dataset.expanded = shouldShow ? 'true' : 'false';
+      }
     }
   }
 }

--- a/src/webview/modules/uiManagers/OutputFilesManager.js
+++ b/src/webview/modules/uiManagers/OutputFilesManager.js
@@ -3,7 +3,11 @@ import { INPUT_FILE, ELEMENT_IDS } from '../constants.js';
 import { mainViewState } from '../mainViewState.js';
 import { fileList } from './FileList.js';
 import { fileSelect } from './FileSelect.js';
-import { safeGetElementById, setChevronIcon } from '@common/domUtils.js';
+import {
+  safeGetElementById,
+  setChevronIcon,
+  setExpandedState,
+} from '@common/domUtils.js';
 
 const INPUT_FILE_ID = INPUT_FILE;
 const OUTPUT_FILES_ID = ELEMENT_IDS.OUTPUT_FILES;
@@ -95,12 +99,7 @@ export class OutputFilesManager {
 
       container.style.display = shouldShow ? 'block' : 'none';
       setChevronIcon(toggleIcon, shouldShow);
-
-      // Set data-expanded on parent .file-select for CSS styling
-      const fileSelect = container.closest('.file-select');
-      if (fileSelect) {
-        fileSelect.dataset.expanded = shouldShow ? 'true' : 'false';
-      }
+      setExpandedState(container, '.file-select', shouldShow);
     }
   }
 }

--- a/src/webview/styles/base.css
+++ b/src/webview/styles/base.css
@@ -50,23 +50,6 @@ body {
   height: var(--height-button);
 }
 
-/* Input field - uses common.css styles */
-
-/* Section header - extended from common.css */
-.section-header {
-  font-size: var(--font-size-lg);
-  font-weight: bold;
-  margin-top: var(--spacing-small);
-  padding-bottom: var(--spacing-small);
-  border-bottom: var(--border-thin) solid var(--vscode-panel-border);
-  line-height: 1.5;
-}
-
-.section-header .codicon {
-  margin-right: var(--spacing-small);
-  vertical-align: text-bottom;
-}
-
 /* Icon styling - extends common clickable */
 .codicon.clickable:hover {
   color: var(--button-hover-background);

--- a/src/webview/styles/containers.css
+++ b/src/webview/styles/containers.css
@@ -29,7 +29,7 @@
 }
 
 /* Only add background when expanded */
-.latexdiffs-section:has(#latexdiffsContent[style*='block']) {
+.latexdiffs-section[data-expanded='true'] {
   background-color: var(--background-color);
   border: 1px solid var(--vscode-widget-border, var(--dropdown-border));
   border-radius: var(--border-radius);
@@ -96,11 +96,6 @@
   align-items: center;
   justify-content: space-between;
   gap: var(--spacing-small);
-}
-
-.output-filename-override {
-  border-top: 1px solid var(--dropdown-border);
-  padding-top: var(--spacing-medium);
 }
 
 .remove-button {

--- a/src/webview/styles/file-selection.css
+++ b/src/webview/styles/file-selection.css
@@ -104,8 +104,6 @@ vscode-toolbar-container.file-select-actions {
 }
 
 /* When toggled (input is visible), make the label more prominent */
-.file-select-label-group[data-expanded='true'] .optional-label,
-.file-select-label-group[data-expanded='true'] .toggle-icon,
 .file-select[data-expanded='true'] .optional-label,
 .file-select[data-expanded='true'] .toggle-icon {
   color: var(--vscode-foreground);

--- a/src/webview/styles/file-selection.css
+++ b/src/webview/styles/file-selection.css
@@ -57,6 +57,7 @@
   margin-right: var(--spacing-small);
 }
 
+/* !important needed to override vscode-toolbar-container's internal flex-direction: row */
 .file-select-actions,
 vscode-toolbar-container.file-select-actions {
   flex-direction: column !important;
@@ -103,50 +104,15 @@ vscode-toolbar-container.file-select-actions {
 }
 
 /* When toggled (input is visible), make the label more prominent */
-.file-select-label-group:has(vscode-textfield[style*='inline-block'])
-  .optional-label,
-.file-select-label-group:has(vscode-textfield[style*='inline-block'])
-  .toggle-icon,
-.file-select:has(.multiple-files-container[style*='block']) .optional-label,
-.file-select:has(.multiple-files-container[style*='block']) .toggle-icon {
+.file-select-label-group[data-expanded='true'] .optional-label,
+.file-select-label-group[data-expanded='true'] .toggle-icon,
+.file-select[data-expanded='true'] .optional-label,
+.file-select[data-expanded='true'] .toggle-icon {
   color: var(--vscode-foreground);
 }
 
-/* Add this specific selector for Multiple Output Files section */
-.file-select:has(#outputFilesContainer[style*='none']) #emptyOutputFilesButton,
-.file-select:has(#outputFilesContainer[style*='none'])
-  #selectOutputFilesButton {
-  display: none;
-}
-
-/* Hide multiple file operation buttons when containers are not toggled */
-.file-select:has(#inputFilesContainer[style*='none']) #emptyInputFilesButton,
-.file-select:has(#inputFilesContainer[style*='none']) #selectInputFilesButton,
-.file-select:has(#inputFilesContainer[style*='none'])
-  #addOpenedInputFilesButton {
-  display: none;
-}
-
-.file-select:has(#referenceFilesContainer[style*='none'])
-  #emptyReferenceFilesButton,
-.file-select:has(#referenceFilesContainer[style*='none'])
-  #selectReferenceFilesButton,
-.file-select:has(#referenceFilesContainer[style*='none'])
-  #addOpenedReferenceFilesButton {
-  display: none;
-}
-
-.file-select:has(#auxiliaryFilesContainer[style*='none'])
-  #emptyAuxiliaryFilesButton,
-.file-select:has(#auxiliaryFilesContainer[style*='none'])
-  #selectAuxiliaryFilesButton,
-.file-select:has(#auxiliaryFilesContainer[style*='none'])
-  #addOpenedAuxiliaryFilesButton {
-  display: none;
-}
-
-.file-select:has(#mediaFilesContainer[style*='none']) #emptyMediaFilesButton,
-.file-select:has(#mediaFilesContainer[style*='none']) #selectMediaFilesButton {
+/* Hide multiple file operation buttons when containers are collapsed */
+.file-select:not([data-expanded='true']) .file-action-button {
   display: none;
 }
 
@@ -156,8 +122,8 @@ vscode-toolbar-container.file-select-actions {
 }
 
 /* Show/hide behavior for LaTeX diffs */
-.latexdiffs-section:has(#latexdiffsContent[style*='block']) .optional-label,
-.latexdiffs-section:has(#latexdiffsContent[style*='block']) .toggle-icon {
+.latexdiffs-section[data-expanded='true'] .optional-label,
+.latexdiffs-section[data-expanded='true'] .toggle-icon {
   color: var(--vscode-foreground);
 }
 

--- a/src/webview/styles/instruction-box.css
+++ b/src/webview/styles/instruction-box.css
@@ -68,17 +68,5 @@
 
 /* Recording button states - icon change is enough, no red background needed */
 #recordInstructionButton.recording .codicon-stop-circle {
-  animation: pulse 1.5s ease-in-out infinite;
-}
-
-@keyframes pulse {
-  0% {
-    opacity: 1;
-  }
-  50% {
-    opacity: 0.6;
-  }
-  100% {
-    opacity: 1;
-  }
+  animation: pulse-fade 1.5s ease-in-out infinite;
 }


### PR DESCRIPTION
- Remove 7 dead CSS classes (.section-header, .output-filename-override,
  .flex, .flex-col, .flex-center, .flex-wrap, .pre-wrap)
- Add missing .secondary button class
- Consolidate animations to common.css (pulse-scale, pulse-fade, spin)
- Move utility classes (.hidden, .truncate) to common.css
- Replace fragile :has([style*=...]) selectors with data-expanded attribute
- Update JS to set data-expanded on file containers for CSS styling
- Add explanatory comments for !important usage in toolbar overrides

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Consolidates animations/utilities into common styles and replaces fragile :has/style selectors with a `data-expanded` pattern wired via new `setExpandedState` across Webview and ProgressView.
> 
> - **Shared utilities/styles**:
>   - Add `setExpandedState` in `src/common/modules/domUtils.js` for setting `data-expanded` on parent containers.
>   - Centralize animations (`pulse-scale`, `pulse-fade`, `spin`) and utilities (`.hidden`, `.truncate`) in `src/common/styles/common.css`.
>   - Introduce `.btn-secondary` button variant and apply to dependency banner buttons.
> - **Webview UI**:
>   - Use `data-expanded` on `.file-select` and `.latexdiffs-section`; update HTML to initialize with `data-expanded="false"`.
>   - Update JS managers (`FileList`, `OutputFilesManager`, `LatexdiffManager`, `mainViewState`) to call `setExpandedState` when toggling sections.
>   - Simplify CSS to rely on `[data-expanded]` instead of `:has([style*=...])`; hide `.file-action-button` when collapsed.
>   - Minor text tweak: normalize apostrophe in tooltip text.
> - **ProgressView styles**:
>   - Remove duplicate keyframes; reference common animations in `logs.css` and recording button (`pulse-fade`).
>   - Trim unused utility classes; note imports now from `common.css`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a9b2fcd24af6566ece215bc0fd66b765f0892b27. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->