### PR TITLE
fix(pricing): update GPT-5 family cache discount factors to 90%

### DIFF
--- a/src/model/providers/openaiReasoningModels.ts
+++ b/src/model/providers/openaiReasoningModels.ts
@@ -201,7 +201,7 @@ export const OPENAI_REASONING_MODELS: Record<string, ModelConfig> = {
     outputPrice: 120.0,
     capabilities: {
       ...OPENAI_REASONING_DEFAULT_CAPABILITIES,
-      cacheDiscountFactor: 0.25,
+      supportsAutoPromptCaching: false,
       supportsNativeMCPServer: true,
       supportsNativeWebSearch: true,
       supportsNativeCodeExecution: true,
@@ -222,7 +222,7 @@ export const OPENAI_REASONING_MODELS: Record<string, ModelConfig> = {
     outputPrice: 10.0,
     capabilities: {
       ...OPENAI_REASONING_DEFAULT_CAPABILITIES,
-      cacheDiscountFactor: 0.25,
+      cacheDiscountFactor: 0.1,
       supportsNativeMCPServer: true,
       supportsNativeWebSearch: true,
       supportsNativeCodeExecution: true,
@@ -243,7 +243,7 @@ export const OPENAI_REASONING_MODELS: Record<string, ModelConfig> = {
     outputPrice: 10.0,
     capabilities: {
       ...OPENAI_REASONING_DEFAULT_CAPABILITIES,
-      cacheDiscountFactor: 0.25,
+      cacheDiscountFactor: 0.1,
       reasoningEffort: ReasoningEffort.NONE,
       supportsNativeMCPServer: true,
       supportsNativeWebSearch: true,
@@ -265,7 +265,7 @@ export const OPENAI_REASONING_MODELS: Record<string, ModelConfig> = {
     outputPrice: 168.0,
     capabilities: {
       ...OPENAI_REASONING_DEFAULT_CAPABILITIES,
-      cacheDiscountFactor: 0.1,
+      supportsAutoPromptCaching: false,
       supportsNativeMCPServer: true,
       supportsNativeWebSearch: true,
       supportsNativeCodeExecution: true,
@@ -307,7 +307,7 @@ export const OPENAI_REASONING_MODELS: Record<string, ModelConfig> = {
     outputPrice: 2.0,
     capabilities: {
       ...OPENAI_REASONING_DEFAULT_CAPABILITIES,
-      cacheDiscountFactor: 0.25,
+      cacheDiscountFactor: 0.1,
       supportsNativeMCPServer: true,
       supportsNativeWebSearch: true,
       supportsNativeCodeExecution: true,
@@ -328,7 +328,7 @@ export const OPENAI_REASONING_MODELS: Record<string, ModelConfig> = {
     outputPrice: 0.4,
     capabilities: {
       ...OPENAI_REASONING_DEFAULT_CAPABILITIES,
-      cacheDiscountFactor: 0.25,
+      cacheDiscountFactor: 0.1,
       supportsNativeMCPServer: true,
       supportsNativeWebSearch: true,
       supportsNativeCodeExecution: true,


### PR DESCRIPTION
- GPT-5, GPT-5.1, GPT-5-mini, GPT-5-nano: change cacheDiscountFactor from 0.25 to 0.1
- GPT-5-pro, GPT-5.2-pro: disable prompt caching (no cached pricing available)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reduce cache discount to 0.1 for GPT‑5 non‑pro models and disable auto prompt caching for GPT‑5 Pro variants.
> 
> - **OpenAI reasoning models (`src/model/providers/openaiReasoningModels.ts`)**
>   - Set `cacheDiscountFactor` to `0.1` for `gpt5`, `gpt51`, `gpt5-` (mini), and `gpt5--` (nano).
>   - Disable `supportsAutoPromptCaching` for `gpt5pro` and `gpt52pro` (replace prior cache discount setting).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 89ce27f9d035af374502cbdbcb068bf86c59ad7c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->