### PR TITLE
Literature review of Ignacio Cirac's 2025 work

### DIFF
--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -52,6 +52,7 @@ import {
   buildOpenAIWebSearchResult,
   extractOpenAIWebSearchResults,
   hasOpenAIWebSearchData,
+  isOpenAIReasoningItem,
   isOpenAIServerToolContent,
   isOpenAIWebSearchCall,
   type ServerToolExtractionResult,
@@ -1339,10 +1340,13 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
    * Returns both normalized results for display and raw content blocks for context.
    * Single source of truth for OpenAI Responses API server tool extraction.
    *
-   * Note: We include both reasoning items AND web_search_call items because
-   * OpenAI's API requires reasoning items when web_search_call references them.
-   * Error: "Item 'ws_...' of type 'web_search_call' was provided without its
-   * required 'reasoning' item: 'rs_...'."
+   * Note: We include reasoning items ONLY when they immediately precede a
+   * web_search_call item. This satisfies two API requirements:
+   * - "web_search_call was provided without its required 'reasoning' item"
+   * - "reasoning was provided without its required following item"
+   *
+   * Reasoning items followed by function_call are NOT included here because
+   * function_call items are handled separately by the tool use flow.
    */
   override extractServerToolData(
     response: Response,
@@ -1353,9 +1357,20 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     }
 
     // Extract content blocks that need to be preserved
-    // Includes both reasoning items and web_search_call items because
-    // web_search_call may depend on preceding reasoning items
-    const contentBlocks = output.filter(isOpenAIServerToolContent);
+    // Only include reasoning items that are immediately followed by web_search_call
+    // to satisfy both API requirements (reasoning needs following item, web_search needs preceding reasoning)
+    const contentBlocks: (ResponseFunctionWebSearch | ResponseReasoningItem)[] =
+      [];
+    for (let i = 0; i < output.length; i++) {
+      const item = output[i];
+      if (isOpenAIWebSearchCall(item)) {
+        // Check if there's a reasoning item immediately before this web_search_call
+        if (i > 0 && isOpenAIReasoningItem(output[i - 1])) {
+          contentBlocks.push(output[i - 1] as ResponseReasoningItem);
+        }
+        contentBlocks.push(item);
+      }
+    }
 
     // Extract normalized web search results for display
     const webSearchResults = extractOpenAIWebSearchResults(output);

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -52,6 +52,7 @@ import {
   buildOpenAIWebSearchResult,
   extractOpenAIWebSearchResults,
   hasOpenAIWebSearchData,
+  isOpenAIServerToolContent,
   isOpenAIWebSearchCall,
   type ServerToolExtractionResult,
 } from './types/ServerToolTypes';
@@ -1337,6 +1338,11 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
    * Extract all server tool data in a single pass.
    * Returns both normalized results for display and raw content blocks for context.
    * Single source of truth for OpenAI Responses API server tool extraction.
+   *
+   * Note: We include both reasoning items AND web_search_call items because
+   * OpenAI's API requires reasoning items when web_search_call references them.
+   * Error: "Item 'ws_...' of type 'web_search_call' was provided without its
+   * required 'reasoning' item: 'rs_...'."
    */
   override extractServerToolData(
     response: Response,
@@ -1347,7 +1353,9 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     }
 
     // Extract content blocks that need to be preserved
-    const contentBlocks = output.filter(isOpenAIWebSearchCall);
+    // Includes both reasoning items and web_search_call items because
+    // web_search_call may depend on preceding reasoning items
+    const contentBlocks = output.filter(isOpenAIServerToolContent);
 
     // Extract normalized web search results for display
     const webSearchResults = extractOpenAIWebSearchResults(output);
@@ -1368,12 +1376,13 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       messages.push(this.createAssistantMessage(text));
     }
 
-    // Include server tool content blocks (web_search_call) from workspace state
-    // These need to be preserved when both server and local tools are in the same response
+    // Include server tool content blocks (reasoning, web_search_call) from workspace state
+    // These need to be preserved when both server and local tools are in the same response.
+    // Reasoning items must be included when web_search_call references them.
     if (workspaceState?.serverToolContent.contentBlocks.length) {
-      // Filter to only OpenAI web search blocks for type safety
+      // Filter to only OpenAI server tool content (reasoning + web_search_call)
       const openaiBlocks = workspaceState.serverToolContent.contentBlocks
-        .filter(isOpenAIWebSearchCall)
+        .filter(isOpenAIServerToolContent)
         .map((block) => block as ResponseInputItem);
       messages.push(...openaiBlocks);
       // Clear after consuming to prevent duplicates - use reset method for consistency

--- a/src/agent/modelHandlers/types/ServerToolTypes.ts
+++ b/src/agent/modelHandlers/types/ServerToolTypes.ts
@@ -16,7 +16,10 @@ import type {
   WebSearchToolResultBlock,
   WebSearchResultBlock,
 } from '@anthropic-ai/sdk/resources/messages';
-import type { ResponseFunctionWebSearch } from 'openai/resources/responses/responses';
+import type {
+  ResponseFunctionWebSearch,
+  ResponseReasoningItem,
+} from 'openai/resources/responses/responses';
 
 // ============================================================================
 // Web Search Result Types
@@ -64,12 +67,14 @@ export interface WebSearchResult {
  * These blocks need to be preserved in conversation context for follow-up messages.
  *
  * - Anthropic: ServerToolUseBlock (the call) and WebSearchToolResultBlock (the result)
- * - OpenAI: ResponseFunctionWebSearch (combined call/result)
+ * - OpenAI: ResponseFunctionWebSearch (combined call/result) and ResponseReasoningItem
+ *   (reasoning items must be included when web_search_call references them)
  */
 export type ServerToolContentBlock =
   | ServerToolUseBlock
   | WebSearchToolResultBlock
-  | ResponseFunctionWebSearch;
+  | ResponseFunctionWebSearch
+  | ResponseReasoningItem;
 
 /**
  * Combined result from server tool extraction.
@@ -126,6 +131,33 @@ export function isOpenAIWebSearchCall(
     item !== null &&
     (item as { type?: string }).type === 'web_search_call'
   );
+}
+
+/**
+ * Type guard for OpenAI reasoning item.
+ * Uses SDK's ResponseReasoningItem type for proper typing.
+ * Reasoning items must be preserved when web_search_call references them.
+ */
+export function isOpenAIReasoningItem(
+  item: unknown,
+): item is ResponseReasoningItem {
+  return (
+    typeof item === 'object' &&
+    item !== null &&
+    (item as { type?: string }).type === 'reasoning'
+  );
+}
+
+/**
+ * Type guard for OpenAI server tool content blocks.
+ * Checks if an item is either a web search call or reasoning item.
+ * Used to identify content that needs to be preserved in conversation context.
+ * Reasoning items must be included when web_search_call references them.
+ */
+export function isOpenAIServerToolContent(
+  item: unknown,
+): item is ResponseFunctionWebSearch | ResponseReasoningItem {
+  return isOpenAIWebSearchCall(item) || isOpenAIReasoningItem(item);
 }
 
 /**


### PR DESCRIPTION
…them

OpenAI's Responses API requires reasoning items to be included when web_search_call items reference them. When the model produces a response with both reasoning and web_search_call, the API fails with: "Item 'ws_...' of type 'web_search_call' was provided without its required 'reasoning' item: 'rs_...'."

This fix:
- Adds ResponseReasoningItem to ServerToolContentBlock type union
- Adds isOpenAIReasoningItem and isOpenAIServerToolContent type guards
- Updates extractServerToolData to include reasoning items
- Updates createToolUseFollowUpMessages to preserve reasoning context

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures OpenAI Responses pairs required reasoning items with web_search_call and preserves them during follow-up tool calls.
> 
> - **Types**:
>   - Add `ResponseReasoningItem` to `ServerToolContentBlock` union in `types/ServerToolTypes.ts`.
>   - Introduce type guards `isOpenAIReasoningItem` and `isOpenAIServerToolContent`.
> - **Server tool extraction** (`modelHandlerOpenAIResponse.ts`):
>   - Update `extractServerToolData` to include reasoning items only when immediately preceding a `web_search_call` and return them in `contentBlocks`.
>   - Continue normalizing web search results via `extractOpenAIWebSearchResults`.
> - **Follow-up messaging** (`modelHandlerOpenAIResponse.ts`):
>   - Update `createToolUseFollowUpMessages` to preserve and resend OpenAI server tool content (`reasoning`, `web_search_call`) from workspace state and clear after use.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 13d68a1e18694fffc65ca802fe1b85f3f3147269. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->