### PR TITLE
Make user group system more flexible

### DIFF
--- a/docs/guide/remote-agents.md
+++ b/docs/guide/remote-agents.md
@@ -50,40 +50,43 @@ Remote agents work just like built-in agents:
 Remote agents are marked with a cloud icon (☁️) in the agent selector to distinguish them from local agents.
 :::
 
-## Researcher Access Program
+## Research Access Program
 
-The **Researcher Access Program** provides access to advanced remote agents specifically designed for academic research and professional writing. These agents include:
+The **Research Access Program** provides access to specialized remote agents designed for academic research and professional writing. Program members get access to:
 
-- **Specialized domain agents**: Agents fine-tuned for specific research fields
+- **Specialized domain agents**: Agents tailored for specific research fields (mathematics, computer science, physics, etc.)
 - **Advanced reasoning capabilities**: Multi-step analysis and complex document processing
 - **Beta features**: Early access to experimental agents and capabilities
 - **Priority improvements**: Your feedback directly influences agent development
 
+Different agents may be available to different research groups based on their domain and needs.
+
 ### Joining the Program
 
-The Researcher Access Program is available to active researchers, academics, and technical writers. To join:
+The Research Access Program is available to active researchers, academics, and technical writers. To join:
 
 1. **Sign in** to TeXRA using your institutional or professional email
 2. **Contact us** at [contact@texra.ai](mailto:contact@texra.ai) with:
    - Your name and affiliation
-   - Brief description of your research or writing needs
+   - Brief description of your research area
    - How you plan to use remote agents
 
-We'll review your application and grant access within 1-2 business days.
+We'll review your application and grant appropriate access within 1-2 business days.
 
-::: tip Free Access
-TeXRA is committed to supporting academic research. The Researcher Access Program is **free for qualifying researchers and students**. We do not charge for remote agent access.
+::: tip Free for Researchers
+TeXRA is committed to supporting academic research. The Research Access Program is **free for qualifying researchers and students**. We do not charge for remote agent access.
 :::
 
 ## Managing Your Account
 
 ### View Your Profile
 
-Check your account status and tier:
+Check your account status and available agents:
 
 1. Open Command Palette
 2. Run: **TeXRA: View Profile**
-3. View your email, user ID, and access tier
+3. View your email, user ID, and access level
+4. Browse remote agents available to you
 
 ### Sign Out
 

--- a/docs/supabase/MIGRATION_FLEXIBLE_USER_GROUPS.sql
+++ b/docs/supabase/MIGRATION_FLEXIBLE_USER_GROUPS.sql
@@ -13,7 +13,20 @@ ALTER TABLE profiles
 ADD COLUMN IF NOT EXISTS permissions TEXT[] DEFAULT '{}';
 
 -- ============================================================================
--- STEP 2: Update tier to support free/Max/Ultra
+-- STEP 2: Migrate existing tier='researcher' to permissions FIRST
+-- ============================================================================
+-- Before changing tier constraint, migrate researcher users to have 'researcher' permission
+UPDATE profiles
+SET permissions = ARRAY['researcher']
+WHERE tier = 'researcher' AND (permissions IS NULL OR permissions = '{}');
+
+-- Now reset tier to 'free' for all researcher users (permission is what matters now)
+UPDATE profiles
+SET tier = 'free'
+WHERE tier = 'researcher';
+
+-- ============================================================================
+-- STEP 3: Update tier constraint to support free/Max/Ultra
 -- ============================================================================
 -- Tier is for future server-side API key access levels
 ALTER TABLE profiles DROP CONSTRAINT IF EXISTS profiles_tier_check;
@@ -21,13 +34,13 @@ ALTER TABLE profiles
 ADD CONSTRAINT profiles_tier_check CHECK (tier IN ('free', 'Max', 'Ultra'));
 
 -- ============================================================================
--- STEP 3: Drop old constraints for extensibility
+-- STEP 4: Drop old constraints for extensibility
 -- ============================================================================
 ALTER TABLE remote_agents DROP CONSTRAINT IF EXISTS remote_agents_visibility_check;
 ALTER TABLE remote_agents DROP CONSTRAINT IF EXISTS remote_agents_agent_type_check;
 
 -- ============================================================================
--- STEP 4: Convert visibility from TEXT to TEXT[] (array)
+-- STEP 5: Convert visibility from TEXT to TEXT[] (array)
 -- ============================================================================
 -- This allows agents to be visible to multiple user groups
 -- First, rename old column
@@ -46,7 +59,7 @@ WHERE visibility_old IS NOT NULL;
 ALTER TABLE remote_agents DROP COLUMN visibility_old;
 
 -- ============================================================================
--- STEP 5: Add agent_category column
+-- STEP 6: Add agent_category column
 -- ============================================================================
 ALTER TABLE remote_agents
 ADD COLUMN IF NOT EXISTS agent_category TEXT DEFAULT 'workflow'
@@ -56,13 +69,6 @@ CHECK (agent_category IN ('workflow', 'toolUse'));
 UPDATE remote_agents
 SET agent_category = 'toolUse'
 WHERE agent_type = 'toolUse';
-
--- ============================================================================
--- STEP 6: Migrate existing tier='researcher' to permissions
--- ============================================================================
-UPDATE profiles
-SET permissions = ARRAY['researcher']
-WHERE tier = 'researcher' AND (permissions IS NULL OR permissions = '{}');
 
 -- ============================================================================
 -- STEP 7: Create helper function for permission checks

--- a/docs/supabase/MIGRATION_FLEXIBLE_USER_GROUPS.sql
+++ b/docs/supabase/MIGRATION_FLEXIBLE_USER_GROUPS.sql
@@ -151,19 +151,18 @@ USING (
 -- STEP 11: Fix nested visibility arrays (if migration ran incorrectly)
 -- ============================================================================
 -- If visibility shows [[["public"]]] instead of ["public"], fix it.
--- NOTE: These fixes extract the inner array to preserve all elements.
--- For 3D arrays like [[['math', 'cs']]], visibility[1][1] gives ['math', 'cs']
--- For 2D arrays like [['math', 'cs']], visibility[1] gives ['math', 'cs']
+-- NOTE: PostgreSQL array subscripts return scalars, so we use unnest/array_agg
+-- to properly flatten nested arrays while preserving all elements.
 
--- Fix 3D arrays: [[['a', 'b']]] -> ['a', 'b']
-UPDATE remote_agents
-SET visibility = visibility[1][1]
-WHERE array_ndims(visibility) = 3;
-
--- Fix 2D arrays: [['a', 'b']] -> ['a', 'b']
-UPDATE remote_agents
-SET visibility = visibility[1]
-WHERE array_ndims(visibility) = 2;
+-- Fix any nested arrays (2D or 3D) by flattening with unnest
+-- This handles both [['a', 'b']] and [[['a', 'b']]] cases
+UPDATE remote_agents ra
+SET visibility = (
+  SELECT array_agg(elem)
+  FROM unnest(ra.visibility) AS elem
+  WHERE elem IS NOT NULL
+)
+WHERE array_ndims(visibility) > 1;
 
 -- ============================================================================
 -- STEP 12: Verify

--- a/docs/supabase/MIGRATION_FLEXIBLE_USER_GROUPS.sql
+++ b/docs/supabase/MIGRATION_FLEXIBLE_USER_GROUPS.sql
@@ -1,0 +1,244 @@
+-- Migration: Flexible User Groups
+-- This script migrates from hardcoded tiers to a permission-based user groups system
+-- Run in Supabase SQL Editor
+
+-- ============================================================================
+-- STEP 1: Create user_groups table
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS user_groups (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  name TEXT UNIQUE NOT NULL,           -- Internal name: 'free', 'researcher', 'enterprise'
+  display_name TEXT NOT NULL,          -- User-facing: 'Free Tier', 'Researcher Access'
+  description TEXT,                    -- Optional description
+  permissions TEXT[] DEFAULT '{}',     -- Array of permission strings
+  priority INT DEFAULT 0,              -- Higher = more privileges (used for display/ordering)
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+-- ============================================================================
+-- STEP 2: Create user_group_memberships table (many-to-many)
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS user_group_memberships (
+  user_id UUID REFERENCES auth.users ON DELETE CASCADE,
+  group_id UUID REFERENCES user_groups ON DELETE CASCADE,
+  granted_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  granted_by UUID REFERENCES auth.users,  -- Optional: who granted the membership
+  expires_at TIMESTAMP WITH TIME ZONE,    -- Optional: for time-limited access
+  PRIMARY KEY (user_id, group_id)
+);
+
+-- Create index for faster lookups
+CREATE INDEX IF NOT EXISTS idx_user_group_memberships_user ON user_group_memberships(user_id);
+CREATE INDEX IF NOT EXISTS idx_user_group_memberships_group ON user_group_memberships(group_id);
+
+-- ============================================================================
+-- STEP 3: Create helper functions for permission checks
+-- ============================================================================
+
+-- Check if current user has a specific permission
+CREATE OR REPLACE FUNCTION user_has_permission(required_permission TEXT)
+RETURNS BOOLEAN AS $$
+  SELECT EXISTS (
+    SELECT 1 FROM user_group_memberships ugm
+    JOIN user_groups ug ON ugm.group_id = ug.id
+    WHERE ugm.user_id = auth.uid()
+      AND (ugm.expires_at IS NULL OR ugm.expires_at > NOW())
+      AND required_permission = ANY(ug.permissions)
+  );
+$$ LANGUAGE sql SECURITY DEFINER STABLE;
+
+-- Check if current user is member of a specific group (by name)
+CREATE OR REPLACE FUNCTION user_in_group(group_name TEXT)
+RETURNS BOOLEAN AS $$
+  SELECT EXISTS (
+    SELECT 1 FROM user_group_memberships ugm
+    JOIN user_groups ug ON ugm.group_id = ug.id
+    WHERE ugm.user_id = auth.uid()
+      AND (ugm.expires_at IS NULL OR ugm.expires_at > NOW())
+      AND ug.name = group_name
+  );
+$$ LANGUAGE sql SECURITY DEFINER STABLE;
+
+-- Get all permissions for current user (flattened)
+CREATE OR REPLACE FUNCTION get_user_permissions()
+RETURNS TEXT[] AS $$
+  SELECT COALESCE(
+    array_agg(DISTINCT perm),
+    '{}'::TEXT[]
+  )
+  FROM user_group_memberships ugm
+  JOIN user_groups ug ON ugm.group_id = ug.id
+  CROSS JOIN LATERAL unnest(ug.permissions) AS perm
+  WHERE ugm.user_id = auth.uid()
+    AND (ugm.expires_at IS NULL OR ugm.expires_at > NOW());
+$$ LANGUAGE sql SECURITY DEFINER STABLE;
+
+-- Get highest priority group for current user (for backwards compatibility)
+CREATE OR REPLACE FUNCTION get_user_primary_group()
+RETURNS TEXT AS $$
+  SELECT ug.name
+  FROM user_group_memberships ugm
+  JOIN user_groups ug ON ugm.group_id = ug.id
+  WHERE ugm.user_id = auth.uid()
+    AND (ugm.expires_at IS NULL OR ugm.expires_at > NOW())
+  ORDER BY ug.priority DESC
+  LIMIT 1;
+$$ LANGUAGE sql SECURITY DEFINER STABLE;
+
+-- ============================================================================
+-- STEP 4: Seed default user groups
+-- ============================================================================
+INSERT INTO user_groups (name, display_name, description, permissions, priority) VALUES
+  ('free', 'Free', 'Default tier for all users', '{}', 0),
+  ('researcher', 'Researcher Access', 'Access to premium remote agents',
+   '{"access_remote_agents", "access_researcher_visibility"}', 10)
+ON CONFLICT (name) DO UPDATE SET
+  display_name = EXCLUDED.display_name,
+  description = EXCLUDED.description,
+  permissions = EXCLUDED.permissions,
+  priority = EXCLUDED.priority;
+
+-- ============================================================================
+-- STEP 5: Migrate existing users from profiles.tier to group memberships
+-- ============================================================================
+INSERT INTO user_group_memberships (user_id, group_id)
+SELECT p.user_id, ug.id
+FROM profiles p
+JOIN user_groups ug ON ug.name = p.tier
+WHERE p.tier IS NOT NULL
+ON CONFLICT (user_id, group_id) DO NOTHING;
+
+-- Also add 'free' group membership for all users (everyone starts with free)
+INSERT INTO user_group_memberships (user_id, group_id)
+SELECT p.user_id, ug.id
+FROM profiles p
+CROSS JOIN user_groups ug
+WHERE ug.name = 'free'
+ON CONFLICT (user_id, group_id) DO NOTHING;
+
+-- ============================================================================
+-- STEP 6: Enable RLS on new tables
+-- ============================================================================
+ALTER TABLE user_groups ENABLE ROW LEVEL SECURITY;
+ALTER TABLE user_group_memberships ENABLE ROW LEVEL SECURITY;
+
+-- Everyone can view user groups (they're public metadata)
+CREATE POLICY "Anyone can view user groups"
+  ON user_groups FOR SELECT
+  USING (true);
+
+-- Users can view their own memberships
+CREATE POLICY "Users can view own memberships"
+  ON user_group_memberships FOR SELECT
+  USING (auth.uid() = user_id);
+
+-- ============================================================================
+-- STEP 7: Update remote_agents RLS policy to use permissions
+-- ============================================================================
+
+-- Drop old policy
+DROP POLICY IF EXISTS "Users can view allowed agents" ON remote_agents;
+
+-- Create new permission-based policy
+-- visibility values map to permissions: 'researcher' -> 'access_researcher_visibility'
+CREATE POLICY "Users can view allowed agents"
+  ON remote_agents FOR SELECT
+  USING (
+    visibility = 'public' OR
+    user_has_permission('access_' || visibility || '_visibility') OR
+    EXISTS (
+      SELECT 1 FROM agent_whitelist
+      WHERE agent_id = id AND user_id = auth.uid()
+    )
+  );
+
+-- ============================================================================
+-- STEP 8: Update storage RLS policy
+-- ============================================================================
+DROP POLICY IF EXISTS "Researcher access users can read agent configs" ON storage.objects;
+
+CREATE POLICY "Users can read allowed agent configs"
+ON storage.objects FOR SELECT
+USING (
+  bucket_id = 'agent-configs' AND
+  (
+    -- Public agents (in public/ folder)
+    (storage.foldername(name))[1] = 'public' OR
+    -- Permission-based access (folder name maps to permission)
+    user_has_permission('access_' || (storage.foldername(name))[1] || '_visibility') OR
+    -- Whitelisted agents
+    EXISTS (
+      SELECT 1 FROM agent_whitelist aw
+      JOIN remote_agents ra ON aw.agent_id = ra.id
+      WHERE aw.user_id = auth.uid()
+        AND ra.storage_path = name
+    )
+  )
+);
+
+-- ============================================================================
+-- STEP 9: Update trigger to auto-add free group to new users
+-- ============================================================================
+CREATE OR REPLACE FUNCTION handle_new_user()
+RETURNS TRIGGER AS $$
+DECLARE
+  free_group_id UUID;
+BEGIN
+  -- Create profile
+  INSERT INTO public.profiles (user_id, email)
+  VALUES (new.id, new.email);
+
+  -- Add to 'free' group
+  SELECT id INTO free_group_id FROM user_groups WHERE name = 'free';
+  IF free_group_id IS NOT NULL THEN
+    INSERT INTO user_group_memberships (user_id, group_id)
+    VALUES (new.id, free_group_id)
+    ON CONFLICT DO NOTHING;
+  END IF;
+
+  RETURN new;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- ============================================================================
+-- STEP 10: Verification queries
+-- ============================================================================
+-- Run these to verify the migration worked:
+
+-- Check user groups exist
+SELECT name, display_name, permissions, priority FROM user_groups ORDER BY priority;
+
+-- Check memberships were migrated
+SELECT
+  p.email,
+  p.tier as old_tier,
+  array_agg(ug.name) as new_groups
+FROM profiles p
+LEFT JOIN user_group_memberships ugm ON p.user_id = ugm.user_id
+LEFT JOIN user_groups ug ON ugm.group_id = ug.id
+GROUP BY p.user_id, p.email, p.tier;
+
+-- Test permission function
+SELECT get_user_permissions();
+SELECT get_user_primary_group();
+
+-- ============================================================================
+-- OPTIONAL: Remove tier column from profiles (run after verifying migration)
+-- ============================================================================
+-- WARNING: Only run this after confirming the migration worked!
+-- ALTER TABLE profiles DROP COLUMN tier;
+-- DROP CONSTRAINT IF EXISTS profiles_tier_check ON profiles;
+
+-- ============================================================================
+-- ADDING NEW GROUPS (Example)
+-- ============================================================================
+-- To add a new group, just INSERT:
+-- INSERT INTO user_groups (name, display_name, permissions, priority) VALUES
+--   ('enterprise', 'Enterprise', '{"access_remote_agents", "access_researcher_visibility", "access_enterprise_visibility", "priority_support"}', 20);
+--
+-- To grant a user access:
+-- INSERT INTO user_group_memberships (user_id, group_id)
+-- SELECT p.user_id, ug.id
+-- FROM profiles p, user_groups ug
+-- WHERE p.email = 'user@example.com' AND ug.name = 'enterprise';

--- a/docs/supabase/MIGRATION_FLEXIBLE_USER_GROUPS.sql
+++ b/docs/supabase/MIGRATION_FLEXIBLE_USER_GROUPS.sql
@@ -137,10 +137,22 @@ USING (
 );
 
 -- ============================================================================
--- STEP 11: Verify
+-- STEP 11: Fix nested visibility arrays (if migration ran incorrectly)
+-- ============================================================================
+-- If visibility shows [[["public"]]] instead of ["public"], fix it:
+UPDATE remote_agents
+SET visibility = ARRAY[visibility[1][1][1]]
+WHERE array_ndims(visibility) = 3;
+
+UPDATE remote_agents
+SET visibility = ARRAY[visibility[1][1]]
+WHERE array_ndims(visibility) = 2;
+
+-- ============================================================================
+-- STEP 12: Verify
 -- ============================================================================
 SELECT email, tier, permissions FROM profiles LIMIT 10;
-SELECT name, visibility, agent_category FROM remote_agents LIMIT 10;
+SELECT name, visibility, array_ndims(visibility) as dims, agent_category FROM remote_agents LIMIT 10;
 
 -- ============================================================================
 -- USAGE EXAMPLES

--- a/docs/supabase/MIGRATION_FLEXIBLE_USER_GROUPS.sql
+++ b/docs/supabase/MIGRATION_FLEXIBLE_USER_GROUPS.sql
@@ -13,16 +13,16 @@ ALTER TABLE profiles
 ADD COLUMN IF NOT EXISTS permissions TEXT[] DEFAULT '{}';
 
 -- ============================================================================
--- STEP 2: Migrate existing tier='researcher' to permissions FIRST
+-- STEP 2: Migrate existing tier='researcher' to permissions and Max tier
 -- ============================================================================
 -- Before changing tier constraint, migrate researcher users to have 'researcher' permission
 UPDATE profiles
 SET permissions = ARRAY['researcher']
 WHERE tier = 'researcher' AND (permissions IS NULL OR permissions = '{}');
 
--- Now reset tier to 'free' for all researcher users (permission is what matters now)
+-- Upgrade researcher users to Max tier (they get API key access)
 UPDATE profiles
-SET tier = 'free'
+SET tier = 'Max'
 WHERE tier = 'researcher';
 
 -- ============================================================================
@@ -34,10 +34,15 @@ ALTER TABLE profiles
 ADD CONSTRAINT profiles_tier_check CHECK (tier IN ('free', 'Max', 'Ultra'));
 
 -- ============================================================================
--- STEP 4: Drop old constraints for extensibility
+-- STEP 4: Drop old constraints and policies BEFORE modifying columns
 -- ============================================================================
 ALTER TABLE remote_agents DROP CONSTRAINT IF EXISTS remote_agents_visibility_check;
 ALTER TABLE remote_agents DROP CONSTRAINT IF EXISTS remote_agents_agent_type_check;
+
+-- Drop ALL existing RLS policies that depend on visibility column
+DROP POLICY IF EXISTS "Users can view allowed agents" ON remote_agents;
+DROP POLICY IF EXISTS "Users can view public agents" ON remote_agents;
+DROP POLICY IF EXISTS "Researchers can view researcher agents" ON remote_agents;
 
 -- ============================================================================
 -- STEP 5: Convert visibility from TEXT to TEXT[] (array)
@@ -83,13 +88,8 @@ RETURNS BOOLEAN AS $$
 $$ LANGUAGE sql SECURITY DEFINER STABLE;
 
 -- ============================================================================
--- STEP 8: Update remote_agents RLS policy
+-- STEP 8: Create new remote_agents RLS policy
 -- ============================================================================
--- Drop ALL existing policies to ensure clean state
-DROP POLICY IF EXISTS "Users can view allowed agents" ON remote_agents;
-DROP POLICY IF EXISTS "Users can view public agents" ON remote_agents;
-DROP POLICY IF EXISTS "Researchers can view researcher agents" ON remote_agents;
-
 CREATE POLICY "Users can view allowed agents"
   ON remote_agents FOR SELECT
   USING (
@@ -159,6 +159,6 @@ SELECT name, visibility, agent_category FROM remote_agents LIMIT 10;
 
 -- Tier values (for future API key access):
 -- 'free' - default, no API key access
--- 'Max' - mid-tier API key access
+-- 'Max' - mid-tier API key access (former researchers)
 -- 'Ultra' - full API key access
 -- UPDATE profiles SET tier = 'Max' WHERE email = 'user@example.com';

--- a/docs/supabase/MIGRATION_FLEXIBLE_USER_GROUPS.sql
+++ b/docs/supabase/MIGRATION_FLEXIBLE_USER_GROUPS.sql
@@ -1,12 +1,21 @@
--- Migration: Flexible Permissions (Simplified)
--- Adds permissions array directly to profiles table
--- No new tables needed - just one column addition
+-- Migration: Flexible Permissions & Agent Categories
+-- 1. Adds permissions array to profiles table
+-- 2. Adds agent_category to remote_agents table
 
 -- ============================================================================
 -- STEP 1: Add permissions column to profiles
 -- ============================================================================
 ALTER TABLE profiles
 ADD COLUMN IF NOT EXISTS permissions TEXT[] DEFAULT '{}';
+
+-- ============================================================================
+-- STEP 1b: Add agent_category column to remote_agents
+-- ============================================================================
+-- Values: 'workflow' (default) or 'toolUse'
+-- This is the user-facing category, not the implementation detail (CoT/direct)
+ALTER TABLE remote_agents
+ADD COLUMN IF NOT EXISTS agent_category TEXT DEFAULT 'workflow'
+CHECK (agent_category IN ('workflow', 'toolUse'));
 
 -- ============================================================================
 -- STEP 2: Migrate existing tiers to permissions

--- a/docs/supabase/MIGRATION_FLEXIBLE_USER_GROUPS.sql
+++ b/docs/supabase/MIGRATION_FLEXIBLE_USER_GROUPS.sql
@@ -124,8 +124,8 @@ USING (
   (
     -- Public folder
     (storage.foldername(name))[1] = 'public' OR
-    -- Folder matches any of user's permissions
-    (storage.foldername(name))[1] = ANY((SELECT permissions FROM profiles WHERE user_id = auth.uid())) OR
+    -- Folder matches any of user's permissions (use @> contains operator)
+    (SELECT permissions FROM profiles WHERE user_id = auth.uid()) @> ARRAY[(storage.foldername(name))[1]] OR
     -- Whitelist access
     EXISTS (
       SELECT 1 FROM agent_whitelist aw

--- a/docs/supabase/MIGRATION_FLEXIBLE_USER_GROUPS.sql
+++ b/docs/supabase/MIGRATION_FLEXIBLE_USER_GROUPS.sql
@@ -1,68 +1,66 @@
 -- Migration: Flexible Permissions & Agent Categories
--- 1. Adds permissions array to profiles table
--- 2. Adds agent_category to remote_agents table
--- 3. Drops visibility CHECK constraint for extensibility
+-- 1. Adds permissions array to profiles (visibility values user can access)
+-- 2. Adds agent_category to remote_agents (workflow/toolUse)
+-- 3. Removes agent_type, drops visibility CHECK constraint
 
 -- ============================================================================
 -- STEP 1: Add permissions column to profiles
 -- ============================================================================
+-- Permissions are just visibility values: 'researcher', 'math', 'cs', etc.
+-- User can see agents where visibility = ANY(permissions)
 ALTER TABLE profiles
 ADD COLUMN IF NOT EXISTS permissions TEXT[] DEFAULT '{}';
 
 -- ============================================================================
--- STEP 1b: Drop visibility CHECK constraint to allow extensible values
+-- STEP 2: Drop constraints for extensibility
 -- ============================================================================
--- This enables adding new visibility levels (e.g., 'enterprise') without schema changes
 ALTER TABLE remote_agents DROP CONSTRAINT IF EXISTS remote_agents_visibility_check;
+ALTER TABLE remote_agents DROP CONSTRAINT IF EXISTS remote_agents_agent_type_check;
 
 -- ============================================================================
--- STEP 1c: Add agent_category column to remote_agents
+-- STEP 3: Add agent_category, drop agent_type
 -- ============================================================================
--- Values: 'workflow' (default) or 'toolUse'
--- This is the user-facing category, not the implementation detail (CoT/direct)
 ALTER TABLE remote_agents
 ADD COLUMN IF NOT EXISTS agent_category TEXT DEFAULT 'workflow'
 CHECK (agent_category IN ('workflow', 'toolUse'));
 
--- ============================================================================
--- STEP 1d: Migrate existing agent_type values to agent_category
--- ============================================================================
--- toolUse agent_type -> toolUse category
--- CoT/direct agent_type -> workflow category (default)
+-- Migrate existing agent_type='toolUse' to agent_category='toolUse'
 UPDATE remote_agents
 SET agent_category = 'toolUse'
-WHERE agent_type = 'toolUse' AND (agent_category IS NULL OR agent_category = 'workflow');
+WHERE agent_type = 'toolUse';
+
+-- Drop agent_type column (optional - can keep for backwards compat)
+-- ALTER TABLE remote_agents DROP COLUMN IF EXISTS agent_type;
 
 -- ============================================================================
--- STEP 2: Migrate existing tiers to permissions
+-- STEP 4: Migrate existing tier='researcher' to permissions
 -- ============================================================================
 UPDATE profiles
-SET permissions = ARRAY['access_remote_agents', 'access_researcher_visibility']
+SET permissions = ARRAY['researcher']
 WHERE tier = 'researcher' AND (permissions IS NULL OR permissions = '{}');
 
 -- ============================================================================
--- STEP 3: Create helper function for permission checks
+-- STEP 5: Create helper function for permission checks
 -- ============================================================================
-CREATE OR REPLACE FUNCTION user_has_permission(required_permission TEXT)
+CREATE OR REPLACE FUNCTION user_has_visibility_access(required_visibility TEXT)
 RETURNS BOOLEAN AS $$
-  SELECT EXISTS (
+  SELECT required_visibility = 'public' OR EXISTS (
     SELECT 1 FROM profiles
     WHERE user_id = auth.uid()
-      AND required_permission = ANY(permissions)
+      AND required_visibility = ANY(permissions)
   );
 $$ LANGUAGE sql SECURITY DEFINER STABLE;
 
 -- ============================================================================
--- STEP 4: Update remote_agents RLS policy
+-- STEP 6: Update remote_agents RLS policy
 -- ============================================================================
 DROP POLICY IF EXISTS "Users can view allowed agents" ON remote_agents;
 
--- Dynamic permission check: visibility -> 'access_{visibility}_visibility'
 CREATE POLICY "Users can view allowed agents"
   ON remote_agents FOR SELECT
   USING (
     visibility = 'public' OR
-    user_has_permission('access_' || visibility || '_visibility') OR
+    visibility = ANY((SELECT permissions FROM profiles WHERE user_id = auth.uid())) OR
     EXISTS (
       SELECT 1 FROM agent_whitelist
       WHERE agent_id = id AND user_id = auth.uid()
@@ -70,7 +68,7 @@ CREATE POLICY "Users can view allowed agents"
   );
 
 -- ============================================================================
--- STEP 5: Update storage RLS policy
+-- STEP 7: Update storage RLS policy
 -- ============================================================================
 DROP POLICY IF EXISTS "Researcher access users can read agent configs" ON storage.objects;
 DROP POLICY IF EXISTS "Users can read allowed agent configs" ON storage.objects;
@@ -81,7 +79,7 @@ USING (
   bucket_id = 'agent-configs' AND
   (
     (storage.foldername(name))[1] = 'public' OR
-    user_has_permission('access_' || (storage.foldername(name))[1] || '_visibility') OR
+    (storage.foldername(name))[1] = ANY((SELECT permissions FROM profiles WHERE user_id = auth.uid())) OR
     EXISTS (
       SELECT 1 FROM agent_whitelist aw
       JOIN remote_agents ra ON aw.agent_id = ra.id
@@ -92,28 +90,26 @@ USING (
 );
 
 -- ============================================================================
--- STEP 6: Verify
+-- STEP 8: Verify
 -- ============================================================================
 SELECT email, tier, permissions FROM profiles LIMIT 10;
+SELECT name, visibility, agent_category FROM remote_agents LIMIT 10;
 
 -- ============================================================================
 -- USAGE EXAMPLES
 -- ============================================================================
 
--- Grant a user access to remote agents:
--- UPDATE profiles SET permissions = array_append(permissions, 'access_remote_agents')
+-- Grant user access to 'researcher' visibility agents:
+-- UPDATE profiles SET permissions = array_append(permissions, 'researcher')
 -- WHERE email = 'user@example.com';
 
--- Grant multiple permissions:
--- UPDATE profiles SET permissions = permissions || ARRAY['access_remote_agents', 'access_researcher_visibility']
+-- Grant access to multiple visibility levels:
+-- UPDATE profiles SET permissions = ARRAY['researcher', 'math', 'cs']
 -- WHERE email = 'user@example.com';
 
--- Revoke a permission:
--- UPDATE profiles SET permissions = array_remove(permissions, 'access_remote_agents')
--- WHERE email = 'user@example.com';
+-- Add a new agent for mathematicians:
+-- INSERT INTO remote_agents (name, description, storage_path, visibility, agent_category)
+-- VALUES ('proof-assistant', 'Helps with proofs', 'math/proof.yaml', 'math', 'workflow');
+-- Then grant users: UPDATE profiles SET permissions = array_append(permissions, 'math') WHERE ...
 
--- Add a new visibility level (e.g., 'enterprise'):
--- 1. Set agent visibility: UPDATE remote_agents SET visibility = 'enterprise' WHERE name = 'my-agent';
--- 2. Grant permission: UPDATE profiles SET permissions = array_append(permissions, 'access_enterprise_visibility')
---    WHERE email = 'user@example.com';
--- No code changes needed!
+-- Note: 'tier' column is reserved for future server-side API key access

--- a/docs/supabase/MIGRATION_FLEXIBLE_USER_GROUPS.sql
+++ b/docs/supabase/MIGRATION_FLEXIBLE_USER_GROUPS.sql
@@ -1,24 +1,52 @@
 -- Migration: Flexible Permissions & Agent Categories
 -- 1. Adds permissions array to profiles (visibility values user can access)
--- 2. Adds agent_category to remote_agents (workflow/toolUse)
--- 3. Removes agent_type, drops visibility CHECK constraint
+-- 2. Changes visibility to array (agent can be visible to multiple groups)
+-- 3. Adds agent_category to remote_agents (workflow/toolUse)
+-- 4. Adds tier constraint (free/Max/Ultra) for future API key access
 
 -- ============================================================================
 -- STEP 1: Add permissions column to profiles
 -- ============================================================================
--- Permissions are just visibility values: 'researcher', 'math', 'cs', etc.
--- User can see agents where visibility = ANY(permissions)
+-- Permissions are visibility values: 'researcher', 'math', 'cs', etc.
+-- User can see agents where visibility && permissions (array overlap)
 ALTER TABLE profiles
 ADD COLUMN IF NOT EXISTS permissions TEXT[] DEFAULT '{}';
 
 -- ============================================================================
--- STEP 2: Drop constraints for extensibility
+-- STEP 2: Update tier to support free/Max/Ultra
+-- ============================================================================
+-- Tier is for future server-side API key access levels
+ALTER TABLE profiles DROP CONSTRAINT IF EXISTS profiles_tier_check;
+ALTER TABLE profiles
+ADD CONSTRAINT profiles_tier_check CHECK (tier IN ('free', 'Max', 'Ultra'));
+
+-- ============================================================================
+-- STEP 3: Drop old constraints for extensibility
 -- ============================================================================
 ALTER TABLE remote_agents DROP CONSTRAINT IF EXISTS remote_agents_visibility_check;
 ALTER TABLE remote_agents DROP CONSTRAINT IF EXISTS remote_agents_agent_type_check;
 
 -- ============================================================================
--- STEP 3: Add agent_category, drop agent_type
+-- STEP 4: Convert visibility from TEXT to TEXT[] (array)
+-- ============================================================================
+-- This allows agents to be visible to multiple user groups
+-- First, rename old column
+ALTER TABLE remote_agents RENAME COLUMN visibility TO visibility_old;
+
+-- Add new array column
+ALTER TABLE remote_agents
+ADD COLUMN visibility TEXT[] DEFAULT ARRAY['public'];
+
+-- Migrate existing values (single value to array)
+UPDATE remote_agents
+SET visibility = ARRAY[visibility_old]
+WHERE visibility_old IS NOT NULL;
+
+-- Drop old column
+ALTER TABLE remote_agents DROP COLUMN visibility_old;
+
+-- ============================================================================
+-- STEP 5: Add agent_category column
 -- ============================================================================
 ALTER TABLE remote_agents
 ADD COLUMN IF NOT EXISTS agent_category TEXT DEFAULT 'workflow'
@@ -29,38 +57,41 @@ UPDATE remote_agents
 SET agent_category = 'toolUse'
 WHERE agent_type = 'toolUse';
 
--- Drop agent_type column (optional - can keep for backwards compat)
--- ALTER TABLE remote_agents DROP COLUMN IF EXISTS agent_type;
-
 -- ============================================================================
--- STEP 4: Migrate existing tier='researcher' to permissions
+-- STEP 6: Migrate existing tier='researcher' to permissions
 -- ============================================================================
 UPDATE profiles
 SET permissions = ARRAY['researcher']
 WHERE tier = 'researcher' AND (permissions IS NULL OR permissions = '{}');
 
 -- ============================================================================
--- STEP 5: Create helper function for permission checks
+-- STEP 7: Create helper function for permission checks
 -- ============================================================================
-CREATE OR REPLACE FUNCTION user_has_visibility_access(required_visibility TEXT)
+CREATE OR REPLACE FUNCTION user_has_visibility_access(required_visibility TEXT[])
 RETURNS BOOLEAN AS $$
-  SELECT required_visibility = 'public' OR EXISTS (
+  SELECT 'public' = ANY(required_visibility) OR EXISTS (
     SELECT 1 FROM profiles
     WHERE user_id = auth.uid()
-      AND required_visibility = ANY(permissions)
+      AND required_visibility && permissions  -- array overlap
   );
 $$ LANGUAGE sql SECURITY DEFINER STABLE;
 
 -- ============================================================================
--- STEP 6: Update remote_agents RLS policy
+-- STEP 8: Update remote_agents RLS policy
 -- ============================================================================
+-- Drop ALL existing policies to ensure clean state
 DROP POLICY IF EXISTS "Users can view allowed agents" ON remote_agents;
+DROP POLICY IF EXISTS "Users can view public agents" ON remote_agents;
+DROP POLICY IF EXISTS "Researchers can view researcher agents" ON remote_agents;
 
 CREATE POLICY "Users can view allowed agents"
   ON remote_agents FOR SELECT
   USING (
-    visibility = 'public' OR
-    visibility = ANY((SELECT permissions FROM profiles WHERE user_id = auth.uid())) OR
+    -- Public agents (visibility array contains 'public')
+    'public' = ANY(visibility) OR
+    -- Permission-based access (visibility overlaps with user's permissions)
+    visibility && (SELECT permissions FROM profiles WHERE user_id = auth.uid()) OR
+    -- Whitelist access
     EXISTS (
       SELECT 1 FROM agent_whitelist
       WHERE agent_id = id AND user_id = auth.uid()
@@ -68,18 +99,23 @@ CREATE POLICY "Users can view allowed agents"
   );
 
 -- ============================================================================
--- STEP 7: Update storage RLS policy
+-- STEP 9: Update storage RLS policy
 -- ============================================================================
+-- Drop ALL existing storage policies
 DROP POLICY IF EXISTS "Researcher access users can read agent configs" ON storage.objects;
 DROP POLICY IF EXISTS "Users can read allowed agent configs" ON storage.objects;
+DROP POLICY IF EXISTS "Users can read public agent configs" ON storage.objects;
 
 CREATE POLICY "Users can read allowed agent configs"
 ON storage.objects FOR SELECT
 USING (
   bucket_id = 'agent-configs' AND
   (
+    -- Public folder
     (storage.foldername(name))[1] = 'public' OR
+    -- Folder matches any of user's permissions
     (storage.foldername(name))[1] = ANY((SELECT permissions FROM profiles WHERE user_id = auth.uid())) OR
+    -- Whitelist access
     EXISTS (
       SELECT 1 FROM agent_whitelist aw
       JOIN remote_agents ra ON aw.agent_id = ra.id
@@ -90,7 +126,7 @@ USING (
 );
 
 -- ============================================================================
--- STEP 8: Verify
+-- STEP 10: Verify
 -- ============================================================================
 SELECT email, tier, permissions FROM profiles LIMIT 10;
 SELECT name, visibility, agent_category FROM remote_agents LIMIT 10;
@@ -107,9 +143,16 @@ SELECT name, visibility, agent_category FROM remote_agents LIMIT 10;
 -- UPDATE profiles SET permissions = ARRAY['researcher', 'math', 'cs']
 -- WHERE email = 'user@example.com';
 
--- Add a new agent for mathematicians:
+-- Add agent visible to BOTH math and cs groups:
 -- INSERT INTO remote_agents (name, description, storage_path, visibility, agent_category)
--- VALUES ('proof-assistant', 'Helps with proofs', 'math/proof.yaml', 'math', 'workflow');
--- Then grant users: UPDATE profiles SET permissions = array_append(permissions, 'math') WHERE ...
+-- VALUES ('proof-assistant', 'Helps with proofs', 'math/proof.yaml', ARRAY['math', 'cs'], 'workflow');
 
--- Note: 'tier' column is reserved for future server-side API key access
+-- Add agent visible to everyone (public):
+-- INSERT INTO remote_agents (name, description, storage_path, visibility, agent_category)
+-- VALUES ('basic-assistant', 'Basic help', 'public/basic.yaml', ARRAY['public'], 'workflow');
+
+-- Tier values (for future API key access):
+-- 'free' - default, no API key access
+-- 'Max' - mid-tier API key access
+-- 'Ultra' - full API key access
+-- UPDATE profiles SET tier = 'Max' WHERE email = 'user@example.com';

--- a/docs/supabase/MIGRATION_FLEXIBLE_USER_GROUPS.sql
+++ b/docs/supabase/MIGRATION_FLEXIBLE_USER_GROUPS.sql
@@ -68,6 +68,10 @@ WHERE visibility_old IS NOT NULL;
 -- Drop old column
 ALTER TABLE remote_agents DROP COLUMN visibility_old;
 
+-- Add GIN indexes for array overlap performance
+CREATE INDEX IF NOT EXISTS idx_remote_agents_visibility ON remote_agents USING GIN(visibility);
+CREATE INDEX IF NOT EXISTS idx_profiles_permissions ON profiles USING GIN(permissions);
+
 -- ============================================================================
 -- STEP 7: Add agent_category column
 -- ============================================================================
@@ -146,13 +150,19 @@ USING (
 -- ============================================================================
 -- STEP 11: Fix nested visibility arrays (if migration ran incorrectly)
 -- ============================================================================
--- If visibility shows [[["public"]]] instead of ["public"], fix it:
+-- If visibility shows [[["public"]]] instead of ["public"], fix it.
+-- NOTE: These fixes extract the inner array to preserve all elements.
+-- For 3D arrays like [[['math', 'cs']]], visibility[1][1] gives ['math', 'cs']
+-- For 2D arrays like [['math', 'cs']], visibility[1] gives ['math', 'cs']
+
+-- Fix 3D arrays: [[['a', 'b']]] -> ['a', 'b']
 UPDATE remote_agents
-SET visibility = ARRAY[visibility[1][1][1]]
+SET visibility = visibility[1][1]
 WHERE array_ndims(visibility) = 3;
 
+-- Fix 2D arrays: [['a', 'b']] -> ['a', 'b']
 UPDATE remote_agents
-SET visibility = ARRAY[visibility[1][1]]
+SET visibility = visibility[1]
 WHERE array_ndims(visibility) = 2;
 
 -- ============================================================================

--- a/docs/supabase/MIGRATION_FLEXIBLE_USER_GROUPS.sql
+++ b/docs/supabase/MIGRATION_FLEXIBLE_USER_GROUPS.sql
@@ -1,6 +1,7 @@
 -- Migration: Flexible Permissions & Agent Categories
 -- 1. Adds permissions array to profiles table
 -- 2. Adds agent_category to remote_agents table
+-- 3. Drops visibility CHECK constraint for extensibility
 
 -- ============================================================================
 -- STEP 1: Add permissions column to profiles
@@ -9,13 +10,28 @@ ALTER TABLE profiles
 ADD COLUMN IF NOT EXISTS permissions TEXT[] DEFAULT '{}';
 
 -- ============================================================================
--- STEP 1b: Add agent_category column to remote_agents
+-- STEP 1b: Drop visibility CHECK constraint to allow extensible values
+-- ============================================================================
+-- This enables adding new visibility levels (e.g., 'enterprise') without schema changes
+ALTER TABLE remote_agents DROP CONSTRAINT IF EXISTS remote_agents_visibility_check;
+
+-- ============================================================================
+-- STEP 1c: Add agent_category column to remote_agents
 -- ============================================================================
 -- Values: 'workflow' (default) or 'toolUse'
 -- This is the user-facing category, not the implementation detail (CoT/direct)
 ALTER TABLE remote_agents
 ADD COLUMN IF NOT EXISTS agent_category TEXT DEFAULT 'workflow'
 CHECK (agent_category IN ('workflow', 'toolUse'));
+
+-- ============================================================================
+-- STEP 1d: Migrate existing agent_type values to agent_category
+-- ============================================================================
+-- toolUse agent_type -> toolUse category
+-- CoT/direct agent_type -> workflow category (default)
+UPDATE remote_agents
+SET agent_category = 'toolUse'
+WHERE agent_type = 'toolUse' AND (agent_category IS NULL OR agent_category = 'workflow');
 
 -- ============================================================================
 -- STEP 2: Migrate existing tiers to permissions

--- a/docs/supabase/MIGRATION_FLEXIBLE_USER_GROUPS.sql
+++ b/docs/supabase/MIGRATION_FLEXIBLE_USER_GROUPS.sql
@@ -3,6 +3,10 @@
 -- 2. Changes visibility to array (agent can be visible to multiple groups)
 -- 3. Adds agent_category to remote_agents (workflow/toolUse)
 -- 4. Adds tier constraint (free/Max/Ultra) for future API key access
+--
+-- NOTE: Tier names (Max/Ultra) are internal. In the UI, users see:
+-- - "research access program" for Max tier (researchers, academics)
+-- - Ultra is reserved for sponsors who engaged with TeXRA development
 
 -- ============================================================================
 -- STEP 1: Add permissions column to profiles
@@ -190,8 +194,8 @@ SELECT name, visibility, array_ndims(visibility) as dims, agent_category FROM re
 -- INSERT INTO remote_agents (name, description, storage_path, visibility, agent_category)
 -- VALUES ('basic-assistant', 'Basic help', 'public/basic.yaml', ARRAY['public'], 'workflow');
 
--- Tier values (for future API key access):
+-- Tier values (internal names, for future API key access):
 -- 'free' - default, no API key access
--- 'Max' - mid-tier API key access (former researchers)
--- 'Ultra' - full API key access
+-- 'Max' - research access program members (researchers, academics)
+-- 'Ultra' - special sponsors who engaged with TeXRA development
 -- UPDATE profiles SET tier = 'Max' WHERE email = 'user@example.com';

--- a/docs/supabase/MIGRATION_FLEXIBLE_USER_GROUPS.sql
+++ b/docs/supabase/MIGRATION_FLEXIBLE_USER_GROUPS.sql
@@ -112,6 +112,13 @@ CREATE POLICY "Users can view allowed agents"
 -- ============================================================================
 -- STEP 10: Update storage RLS policy
 -- ============================================================================
+-- NOTE: This storage policy is defense-in-depth only.
+-- Primary access control is on remote_agents table (using array overlap &&).
+-- The Edge Function verifies access via remote_agents RLS first, then uses
+-- an admin client to bypass storage RLS. Store agents in a folder matching
+-- their primary visibility level (e.g., researcher/agent.yaml for an agent
+-- with visibility = ['researcher', 'math']).
+
 -- Drop ALL existing storage policies
 DROP POLICY IF EXISTS "Researcher access users can read agent configs" ON storage.objects;
 DROP POLICY IF EXISTS "Users can read allowed agent configs" ON storage.objects;
@@ -124,7 +131,7 @@ USING (
   (
     -- Public folder
     (storage.foldername(name))[1] = 'public' OR
-    -- Folder matches any of user's permissions (use @> contains operator)
+    -- Defense-in-depth: check if user has permission for folder
     (SELECT permissions FROM profiles WHERE user_id = auth.uid()) @> ARRAY[(storage.foldername(name))[1]] OR
     -- Whitelist access
     EXISTS (

--- a/docs/supabase/MIGRATION_FLEXIBLE_USER_GROUPS.sql
+++ b/docs/supabase/MIGRATION_FLEXIBLE_USER_GROUPS.sql
@@ -13,9 +13,15 @@ ALTER TABLE profiles
 ADD COLUMN IF NOT EXISTS permissions TEXT[] DEFAULT '{}';
 
 -- ============================================================================
--- STEP 2: Migrate existing tier='researcher' to permissions and Max tier
+-- STEP 2: Drop old tier constraint FIRST
 -- ============================================================================
--- Before changing tier constraint, migrate researcher users to have 'researcher' permission
+-- Must drop before changing tier values, as old constraint only allows ('free', 'researcher')
+ALTER TABLE profiles DROP CONSTRAINT IF EXISTS profiles_tier_check;
+
+-- ============================================================================
+-- STEP 3: Migrate existing tier='researcher' to permissions and Max tier
+-- ============================================================================
+-- Migrate researcher users to have 'researcher' permission
 UPDATE profiles
 SET permissions = ARRAY['researcher']
 WHERE tier = 'researcher' AND (permissions IS NULL OR permissions = '{}');
@@ -26,15 +32,14 @@ SET tier = 'Max'
 WHERE tier = 'researcher';
 
 -- ============================================================================
--- STEP 3: Update tier constraint to support free/Max/Ultra
+-- STEP 4: Add new tier constraint (free/Max/Ultra)
 -- ============================================================================
 -- Tier is for future server-side API key access levels
-ALTER TABLE profiles DROP CONSTRAINT IF EXISTS profiles_tier_check;
 ALTER TABLE profiles
 ADD CONSTRAINT profiles_tier_check CHECK (tier IN ('free', 'Max', 'Ultra'));
 
 -- ============================================================================
--- STEP 4: Drop old constraints and policies BEFORE modifying columns
+-- STEP 5: Drop old constraints and policies BEFORE modifying columns
 -- ============================================================================
 ALTER TABLE remote_agents DROP CONSTRAINT IF EXISTS remote_agents_visibility_check;
 ALTER TABLE remote_agents DROP CONSTRAINT IF EXISTS remote_agents_agent_type_check;
@@ -45,7 +50,7 @@ DROP POLICY IF EXISTS "Users can view public agents" ON remote_agents;
 DROP POLICY IF EXISTS "Researchers can view researcher agents" ON remote_agents;
 
 -- ============================================================================
--- STEP 5: Convert visibility from TEXT to TEXT[] (array)
+-- STEP 6: Convert visibility from TEXT to TEXT[] (array)
 -- ============================================================================
 -- This allows agents to be visible to multiple user groups
 -- First, rename old column
@@ -64,7 +69,7 @@ WHERE visibility_old IS NOT NULL;
 ALTER TABLE remote_agents DROP COLUMN visibility_old;
 
 -- ============================================================================
--- STEP 6: Add agent_category column
+-- STEP 7: Add agent_category column
 -- ============================================================================
 ALTER TABLE remote_agents
 ADD COLUMN IF NOT EXISTS agent_category TEXT DEFAULT 'workflow'
@@ -76,7 +81,7 @@ SET agent_category = 'toolUse'
 WHERE agent_type = 'toolUse';
 
 -- ============================================================================
--- STEP 7: Create helper function for permission checks
+-- STEP 8: Create helper function for permission checks
 -- ============================================================================
 CREATE OR REPLACE FUNCTION user_has_visibility_access(required_visibility TEXT[])
 RETURNS BOOLEAN AS $$
@@ -88,7 +93,7 @@ RETURNS BOOLEAN AS $$
 $$ LANGUAGE sql SECURITY DEFINER STABLE;
 
 -- ============================================================================
--- STEP 8: Create new remote_agents RLS policy
+-- STEP 9: Create new remote_agents RLS policy
 -- ============================================================================
 CREATE POLICY "Users can view allowed agents"
   ON remote_agents FOR SELECT
@@ -105,7 +110,7 @@ CREATE POLICY "Users can view allowed agents"
   );
 
 -- ============================================================================
--- STEP 9: Update storage RLS policy
+-- STEP 10: Update storage RLS policy
 -- ============================================================================
 -- Drop ALL existing storage policies
 DROP POLICY IF EXISTS "Researcher access users can read agent configs" ON storage.objects;
@@ -132,7 +137,7 @@ USING (
 );
 
 -- ============================================================================
--- STEP 10: Verify
+-- STEP 11: Verify
 -- ============================================================================
 SELECT email, tier, permissions FROM profiles LIMIT 10;
 SELECT name, visibility, agent_category FROM remote_agents LIMIT 10;

--- a/docs/supabase/MIGRATION_FLEXIBLE_USER_GROUPS.sql
+++ b/docs/supabase/MIGRATION_FLEXIBLE_USER_GROUPS.sql
@@ -1,147 +1,38 @@
--- Migration: Flexible User Groups
--- This script migrates from hardcoded tiers to a permission-based user groups system
--- Run in Supabase SQL Editor
+-- Migration: Flexible Permissions (Simplified)
+-- Adds permissions array directly to profiles table
+-- No new tables needed - just one column addition
 
 -- ============================================================================
--- STEP 1: Create user_groups table
+-- STEP 1: Add permissions column to profiles
 -- ============================================================================
-CREATE TABLE IF NOT EXISTS user_groups (
-  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
-  name TEXT UNIQUE NOT NULL,           -- Internal name: 'free', 'researcher', 'enterprise'
-  display_name TEXT NOT NULL,          -- User-facing: 'Free Tier', 'Researcher Access'
-  description TEXT,                    -- Optional description
-  permissions TEXT[] DEFAULT '{}',     -- Array of permission strings
-  priority INT DEFAULT 0,              -- Higher = more privileges (used for display/ordering)
-  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
-  updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
-);
+ALTER TABLE profiles
+ADD COLUMN IF NOT EXISTS permissions TEXT[] DEFAULT '{}';
 
 -- ============================================================================
--- STEP 2: Create user_group_memberships table (many-to-many)
+-- STEP 2: Migrate existing tiers to permissions
 -- ============================================================================
-CREATE TABLE IF NOT EXISTS user_group_memberships (
-  user_id UUID REFERENCES auth.users ON DELETE CASCADE,
-  group_id UUID REFERENCES user_groups ON DELETE CASCADE,
-  granted_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
-  granted_by UUID REFERENCES auth.users,  -- Optional: who granted the membership
-  expires_at TIMESTAMP WITH TIME ZONE,    -- Optional: for time-limited access
-  PRIMARY KEY (user_id, group_id)
-);
-
--- Create index for faster lookups
-CREATE INDEX IF NOT EXISTS idx_user_group_memberships_user ON user_group_memberships(user_id);
-CREATE INDEX IF NOT EXISTS idx_user_group_memberships_group ON user_group_memberships(group_id);
+UPDATE profiles
+SET permissions = ARRAY['access_remote_agents', 'access_researcher_visibility']
+WHERE tier = 'researcher' AND (permissions IS NULL OR permissions = '{}');
 
 -- ============================================================================
--- STEP 3: Create helper functions for permission checks
+-- STEP 3: Create helper function for permission checks
 -- ============================================================================
-
--- Check if current user has a specific permission
 CREATE OR REPLACE FUNCTION user_has_permission(required_permission TEXT)
 RETURNS BOOLEAN AS $$
   SELECT EXISTS (
-    SELECT 1 FROM user_group_memberships ugm
-    JOIN user_groups ug ON ugm.group_id = ug.id
-    WHERE ugm.user_id = auth.uid()
-      AND (ugm.expires_at IS NULL OR ugm.expires_at > NOW())
-      AND required_permission = ANY(ug.permissions)
+    SELECT 1 FROM profiles
+    WHERE user_id = auth.uid()
+      AND required_permission = ANY(permissions)
   );
 $$ LANGUAGE sql SECURITY DEFINER STABLE;
 
--- Check if current user is member of a specific group (by name)
-CREATE OR REPLACE FUNCTION user_in_group(group_name TEXT)
-RETURNS BOOLEAN AS $$
-  SELECT EXISTS (
-    SELECT 1 FROM user_group_memberships ugm
-    JOIN user_groups ug ON ugm.group_id = ug.id
-    WHERE ugm.user_id = auth.uid()
-      AND (ugm.expires_at IS NULL OR ugm.expires_at > NOW())
-      AND ug.name = group_name
-  );
-$$ LANGUAGE sql SECURITY DEFINER STABLE;
-
--- Get all permissions for current user (flattened)
-CREATE OR REPLACE FUNCTION get_user_permissions()
-RETURNS TEXT[] AS $$
-  SELECT COALESCE(
-    array_agg(DISTINCT perm),
-    '{}'::TEXT[]
-  )
-  FROM user_group_memberships ugm
-  JOIN user_groups ug ON ugm.group_id = ug.id
-  CROSS JOIN LATERAL unnest(ug.permissions) AS perm
-  WHERE ugm.user_id = auth.uid()
-    AND (ugm.expires_at IS NULL OR ugm.expires_at > NOW());
-$$ LANGUAGE sql SECURITY DEFINER STABLE;
-
--- Get highest priority group for current user (for backwards compatibility)
-CREATE OR REPLACE FUNCTION get_user_primary_group()
-RETURNS TEXT AS $$
-  SELECT ug.name
-  FROM user_group_memberships ugm
-  JOIN user_groups ug ON ugm.group_id = ug.id
-  WHERE ugm.user_id = auth.uid()
-    AND (ugm.expires_at IS NULL OR ugm.expires_at > NOW())
-  ORDER BY ug.priority DESC
-  LIMIT 1;
-$$ LANGUAGE sql SECURITY DEFINER STABLE;
-
 -- ============================================================================
--- STEP 4: Seed default user groups
+-- STEP 4: Update remote_agents RLS policy
 -- ============================================================================
-INSERT INTO user_groups (name, display_name, description, permissions, priority) VALUES
-  ('free', 'Free', 'Default tier for all users', '{}', 0),
-  ('researcher', 'Researcher Access', 'Access to premium remote agents',
-   '{"access_remote_agents", "access_researcher_visibility"}', 10)
-ON CONFLICT (name) DO UPDATE SET
-  display_name = EXCLUDED.display_name,
-  description = EXCLUDED.description,
-  permissions = EXCLUDED.permissions,
-  priority = EXCLUDED.priority;
-
--- ============================================================================
--- STEP 5: Migrate existing users from profiles.tier to group memberships
--- ============================================================================
-INSERT INTO user_group_memberships (user_id, group_id)
-SELECT p.user_id, ug.id
-FROM profiles p
-JOIN user_groups ug ON ug.name = p.tier
-WHERE p.tier IS NOT NULL
-ON CONFLICT (user_id, group_id) DO NOTHING;
-
--- Also add 'free' group membership for all users (everyone starts with free)
-INSERT INTO user_group_memberships (user_id, group_id)
-SELECT p.user_id, ug.id
-FROM profiles p
-CROSS JOIN user_groups ug
-WHERE ug.name = 'free'
-ON CONFLICT (user_id, group_id) DO NOTHING;
-
--- ============================================================================
--- STEP 6: Enable RLS on new tables
--- ============================================================================
-ALTER TABLE user_groups ENABLE ROW LEVEL SECURITY;
-ALTER TABLE user_group_memberships ENABLE ROW LEVEL SECURITY;
-
--- Everyone can view user groups (they're public metadata)
-CREATE POLICY "Anyone can view user groups"
-  ON user_groups FOR SELECT
-  USING (true);
-
--- Users can view their own memberships
-CREATE POLICY "Users can view own memberships"
-  ON user_group_memberships FOR SELECT
-  USING (auth.uid() = user_id);
-
--- ============================================================================
--- STEP 7: Update remote_agents RLS policy to use permissions
--- ============================================================================
-
--- Drop old policy
 DROP POLICY IF EXISTS "Users can view allowed agents" ON remote_agents;
 
--- Create new permission-based policy
--- visibility values map to permissions: 'researcher' -> 'access_researcher_visibility'
+-- Dynamic permission check: visibility -> 'access_{visibility}_visibility'
 CREATE POLICY "Users can view allowed agents"
   ON remote_agents FOR SELECT
   USING (
@@ -154,20 +45,18 @@ CREATE POLICY "Users can view allowed agents"
   );
 
 -- ============================================================================
--- STEP 8: Update storage RLS policy
+-- STEP 5: Update storage RLS policy
 -- ============================================================================
 DROP POLICY IF EXISTS "Researcher access users can read agent configs" ON storage.objects;
+DROP POLICY IF EXISTS "Users can read allowed agent configs" ON storage.objects;
 
 CREATE POLICY "Users can read allowed agent configs"
 ON storage.objects FOR SELECT
 USING (
   bucket_id = 'agent-configs' AND
   (
-    -- Public agents (in public/ folder)
     (storage.foldername(name))[1] = 'public' OR
-    -- Permission-based access (folder name maps to permission)
     user_has_permission('access_' || (storage.foldername(name))[1] || '_visibility') OR
-    -- Whitelisted agents
     EXISTS (
       SELECT 1 FROM agent_whitelist aw
       JOIN remote_agents ra ON aw.agent_id = ra.id
@@ -178,67 +67,28 @@ USING (
 );
 
 -- ============================================================================
--- STEP 9: Update trigger to auto-add free group to new users
+-- STEP 6: Verify
 -- ============================================================================
-CREATE OR REPLACE FUNCTION handle_new_user()
-RETURNS TRIGGER AS $$
-DECLARE
-  free_group_id UUID;
-BEGIN
-  -- Create profile
-  INSERT INTO public.profiles (user_id, email)
-  VALUES (new.id, new.email);
-
-  -- Add to 'free' group
-  SELECT id INTO free_group_id FROM user_groups WHERE name = 'free';
-  IF free_group_id IS NOT NULL THEN
-    INSERT INTO user_group_memberships (user_id, group_id)
-    VALUES (new.id, free_group_id)
-    ON CONFLICT DO NOTHING;
-  END IF;
-
-  RETURN new;
-END;
-$$ LANGUAGE plpgsql SECURITY DEFINER;
+SELECT email, tier, permissions FROM profiles LIMIT 10;
 
 -- ============================================================================
--- STEP 10: Verification queries
+-- USAGE EXAMPLES
 -- ============================================================================
--- Run these to verify the migration worked:
 
--- Check user groups exist
-SELECT name, display_name, permissions, priority FROM user_groups ORDER BY priority;
+-- Grant a user access to remote agents:
+-- UPDATE profiles SET permissions = array_append(permissions, 'access_remote_agents')
+-- WHERE email = 'user@example.com';
 
--- Check memberships were migrated
-SELECT
-  p.email,
-  p.tier as old_tier,
-  array_agg(ug.name) as new_groups
-FROM profiles p
-LEFT JOIN user_group_memberships ugm ON p.user_id = ugm.user_id
-LEFT JOIN user_groups ug ON ugm.group_id = ug.id
-GROUP BY p.user_id, p.email, p.tier;
+-- Grant multiple permissions:
+-- UPDATE profiles SET permissions = permissions || ARRAY['access_remote_agents', 'access_researcher_visibility']
+-- WHERE email = 'user@example.com';
 
--- Test permission function
-SELECT get_user_permissions();
-SELECT get_user_primary_group();
+-- Revoke a permission:
+-- UPDATE profiles SET permissions = array_remove(permissions, 'access_remote_agents')
+-- WHERE email = 'user@example.com';
 
--- ============================================================================
--- OPTIONAL: Remove tier column from profiles (run after verifying migration)
--- ============================================================================
--- WARNING: Only run this after confirming the migration worked!
--- ALTER TABLE profiles DROP COLUMN tier;
--- DROP CONSTRAINT IF EXISTS profiles_tier_check ON profiles;
-
--- ============================================================================
--- ADDING NEW GROUPS (Example)
--- ============================================================================
--- To add a new group, just INSERT:
--- INSERT INTO user_groups (name, display_name, permissions, priority) VALUES
---   ('enterprise', 'Enterprise', '{"access_remote_agents", "access_researcher_visibility", "access_enterprise_visibility", "priority_support"}', 20);
---
--- To grant a user access:
--- INSERT INTO user_group_memberships (user_id, group_id)
--- SELECT p.user_id, ug.id
--- FROM profiles p, user_groups ug
--- WHERE p.email = 'user@example.com' AND ug.name = 'enterprise';
+-- Add a new visibility level (e.g., 'enterprise'):
+-- 1. Set agent visibility: UPDATE remote_agents SET visibility = 'enterprise' WHERE name = 'my-agent';
+-- 2. Grant permission: UPDATE profiles SET permissions = array_append(permissions, 'access_enterprise_visibility')
+--    WHERE email = 'user@example.com';
+-- No code changes needed!

--- a/docs/supabase/SUPABASE_SETUP.md
+++ b/docs/supabase/SUPABASE_SETUP.md
@@ -184,7 +184,10 @@ Go to **SQL Editor** in Supabase dashboard and run this SQL:
 CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 
 -- Profiles table (user metadata)
--- tier: reserved for future API key access levels (free/Max/Ultra)
+-- tier: internal tier names for future API key access
+--   'free' - default, no API key access
+--   'Max' - research access program members (researchers, academics)
+--   'Ultra' - special sponsors who engaged with TeXRA development
 -- permissions: array of visibility values user can access (e.g., 'researcher', 'math', 'cs')
 CREATE TABLE profiles (
   user_id UUID REFERENCES auth.users ON DELETE CASCADE PRIMARY KEY,

--- a/docs/supabase/SUPABASE_SETUP.md
+++ b/docs/supabase/SUPABASE_SETUP.md
@@ -189,7 +189,7 @@ CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 CREATE TABLE profiles (
   user_id UUID REFERENCES auth.users ON DELETE CASCADE PRIMARY KEY,
   email TEXT,
-  tier TEXT DEFAULT 'free',
+  tier TEXT DEFAULT 'free' CHECK (tier IN ('free', 'Max', 'Ultra')),
   permissions TEXT[] DEFAULT '{}',
   created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
   updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
@@ -232,7 +232,8 @@ CREATE TABLE usage_logs (
 -- Create indexes for performance
 CREATE INDEX idx_usage_logs_user ON usage_logs(user_id);
 CREATE INDEX idx_usage_logs_response ON usage_logs(response_id);
-CREATE INDEX idx_remote_agents_visibility ON remote_agents(visibility);
+CREATE INDEX idx_remote_agents_visibility ON remote_agents USING GIN(visibility);
+CREATE INDEX idx_profiles_permissions ON profiles USING GIN(permissions);
 
 -- Enable Row Level Security (RLS)
 ALTER TABLE profiles ENABLE ROW LEVEL SECURITY;

--- a/docs/supabase/SUPABASE_SETUP.md
+++ b/docs/supabase/SUPABASE_SETUP.md
@@ -329,8 +329,8 @@ USING (
   (
     -- Public agents (in public/ folder)
     (storage.foldername(name))[1] = 'public' OR
-    -- Visibility-based access (folder name matches a permission)
-    (storage.foldername(name))[1] = ANY((SELECT permissions FROM profiles WHERE user_id = auth.uid())) OR
+    -- Visibility-based access (permissions array contains folder name)
+    (SELECT permissions FROM profiles WHERE user_id = auth.uid()) @> ARRAY[(storage.foldername(name))[1]] OR
     -- Whitelisted agents
     EXISTS (
       SELECT 1 FROM agent_whitelist aw

--- a/docs/supabase/SUPABASE_SETUP.md
+++ b/docs/supabase/SUPABASE_SETUP.md
@@ -196,14 +196,14 @@ CREATE TABLE profiles (
 );
 
 -- Remote agents metadata table
--- visibility: any string value (e.g., 'public', 'researcher', 'math', 'cs')
+-- visibility: array of group names that can access the agent (e.g., ARRAY['math', 'cs'])
 -- agent_category: 'workflow' (multi-turn) or 'toolUse' (single-turn with tools)
 CREATE TABLE remote_agents (
   id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
   name TEXT UNIQUE NOT NULL,
   description TEXT,
   storage_path TEXT NOT NULL,
-  visibility TEXT DEFAULT 'public',
+  visibility TEXT[] DEFAULT ARRAY['public'],
   agent_category TEXT DEFAULT 'workflow' CHECK (agent_category IN ('workflow', 'toolUse')),
   created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
   updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
@@ -253,11 +253,12 @@ CREATE POLICY "Users can update own profile"
   USING (auth.uid() = user_id);
 
 -- Users can view agents based on visibility and permissions
+-- Uses array overlap (&&) to check if any visibility matches any permission
 CREATE POLICY "Users can view allowed agents"
   ON remote_agents FOR SELECT
   USING (
-    visibility = 'public' OR
-    visibility = ANY((SELECT permissions FROM profiles WHERE user_id = auth.uid())) OR
+    'public' = ANY(visibility) OR
+    visibility && (SELECT permissions FROM profiles WHERE user_id = auth.uid()) OR
     EXISTS (
       SELECT 1 FROM agent_whitelist
       WHERE agent_id = id AND user_id = auth.uid()
@@ -541,17 +542,40 @@ The extension will now use the configured credentials. Users don't need to confi
 In **SQL Editor**, run:
 
 ```sql
+-- Agent visible to 'researcher' group only
 INSERT INTO remote_agents (name, description, storage_path, visibility, agent_category)
 VALUES (
   'advanced-researcher',
   'AI-powered research assistant for academic papers',
   'researcher/advanced-researcher.yaml',
-  'researcher',
+  ARRAY['researcher'],
+  'workflow'
+);
+
+-- Agent visible to BOTH math and cs groups
+INSERT INTO remote_agents (name, description, storage_path, visibility, agent_category)
+VALUES (
+  'proof-assistant',
+  'Helps with mathematical proofs and algorithms',
+  'math/proof-assistant.yaml',
+  ARRAY['math', 'cs'],
+  'workflow'
+);
+
+-- Public agent (visible to all authenticated users)
+INSERT INTO remote_agents (name, description, storage_path, visibility, agent_category)
+VALUES (
+  'basic-assistant',
+  'General purpose assistant',
+  'public/basic-assistant.yaml',
+  ARRAY['public'],
   'workflow'
 );
 ```
 
-Note: `agent_category` can be `'workflow'` (multi-turn agents) or `'toolUse'` (single-turn with tools).
+Notes:
+- `visibility` is an array - agents can be visible to multiple groups
+- `agent_category` can be `'workflow'` (multi-turn) or `'toolUse'` (single-turn with tools)
 
 ---
 

--- a/docs/supabase/SUPABASE_SETUP.md
+++ b/docs/supabase/SUPABASE_SETUP.md
@@ -419,10 +419,10 @@ serve(async (req) => {
     }
 
     // Fetch agent metadata using userClient (RLS enforces access control)
-    // RLS policies check user tier/whitelist - unauthorized users won't see the agent
+    // RLS policies check user permissions/whitelist - unauthorized users won't see the agent
     const { data: agent, error: agentError } = await userClient
       .from('remote_agents')
-      .select('id, name, description, storage_path')
+      .select('id, name, description, storage_path, visibility, agent_category')
       .eq('name', agentName)
       .single();
 
@@ -465,6 +465,8 @@ serve(async (req) => {
         config: yamlContent,
         name: agent.name,
         description: agent.description,
+        visibility: agent.visibility,        // string[] - array of groups
+        agentCategory: agent.agent_category,  // 'workflow' or 'toolUse'
       }),
       {
         status: 200,

--- a/docs/supabase/SUPABASE_SETUP.md
+++ b/docs/supabase/SUPABASE_SETUP.md
@@ -465,8 +465,8 @@ serve(async (req) => {
         config: yamlContent,
         name: agent.name,
         description: agent.description,
-        visibility: agent.visibility,        // string[] - array of groups
-        agentCategory: agent.agent_category,  // 'workflow' or 'toolUse'
+        visibility: agent.visibility, // string[] - array of groups
+        agentCategory: agent.agent_category, // 'workflow' or 'toolUse'
       }),
       {
         status: 200,
@@ -577,6 +577,7 @@ VALUES (
 ```
 
 Notes:
+
 - `visibility` is an array - agents can be visible to multiple groups
 - `agent_category` can be `'workflow'` (multi-turn) or `'toolUse'` (single-turn with tools)
 

--- a/docs/supabase/SUPABASE_SETUP.md
+++ b/docs/supabase/SUPABASE_SETUP.md
@@ -316,6 +316,12 @@ CREATE TRIGGER on_auth_user_created
 
 ### 2. Configure Storage RLS Policies
 
+> **Note:** This storage policy is defense-in-depth only. Primary access control is on the
+> `remote_agents` table (using array overlap `&&`). The Edge Function verifies access via
+> remote_agents RLS first, then uses an admin client to bypass storage RLS. Store agents
+> in a folder matching their primary visibility level (e.g., `researcher/agent.yaml` for
+> an agent with `visibility = ['researcher', 'math']`).
+
 1. Click on the `agent-configs` bucket
 2. Go to **Policies** tab
 3. Click "New Policy"
@@ -330,7 +336,8 @@ USING (
   (
     -- Public agents (in public/ folder)
     (storage.foldername(name))[1] = 'public' OR
-    -- Visibility-based access (permissions array contains folder name)
+    -- Defense-in-depth: check if user has permission for folder
+    -- Primary access control is on remote_agents table via Edge Function
     (SELECT permissions FROM profiles WHERE user_id = auth.uid()) @> ARRAY[(storage.foldername(name))[1]] OR
     -- Whitelisted agents
     EXISTS (

--- a/docs/supabase/SUPABASE_SETUP.md
+++ b/docs/supabase/SUPABASE_SETUP.md
@@ -8,7 +8,7 @@ TeXRA uses Supabase for:
 
 - **User Authentication** - OAuth login (GitHub, Google, GitLab)
 - **Remote Agents** - Secure storage and access control for agent configurations
-- **Permissions** - Tier-based access (free vs researcher access program)
+- **Permissions** - Flexible visibility-based access (users see agents matching their permissions)
 
 **Important**: Users authenticate to **TeXRA's official Supabase service**, not their own. This guide is for **extension maintainers** who need to set up the TeXRA backend.
 
@@ -184,22 +184,27 @@ Go to **SQL Editor** in Supabase dashboard and run this SQL:
 CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 
 -- Profiles table (user metadata)
+-- tier: reserved for future API key access levels (free/Max/Ultra)
+-- permissions: array of visibility values user can access (e.g., 'researcher', 'math', 'cs')
 CREATE TABLE profiles (
   user_id UUID REFERENCES auth.users ON DELETE CASCADE PRIMARY KEY,
   email TEXT,
-  tier TEXT DEFAULT 'free' CHECK (tier IN ('free', 'researcher')),
+  tier TEXT DEFAULT 'free',
+  permissions TEXT[] DEFAULT '{}',
   created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
   updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );
 
 -- Remote agents metadata table
+-- visibility: any string value (e.g., 'public', 'researcher', 'math', 'cs')
+-- agent_category: 'workflow' (multi-turn) or 'toolUse' (single-turn with tools)
 CREATE TABLE remote_agents (
   id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
   name TEXT UNIQUE NOT NULL,
   description TEXT,
   storage_path TEXT NOT NULL,
-  visibility TEXT DEFAULT 'researcher' CHECK (visibility IN ('public', 'researcher', 'whitelist')),
-  agent_type TEXT DEFAULT 'CoT' CHECK (agent_type IN ('CoT', 'direct', 'toolUse')),
+  visibility TEXT DEFAULT 'public',
+  agent_category TEXT DEFAULT 'workflow' CHECK (agent_category IN ('workflow', 'toolUse')),
   created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
   updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );
@@ -247,15 +252,12 @@ CREATE POLICY "Users can update own profile"
   ON profiles FOR UPDATE
   USING (auth.uid() = user_id);
 
--- Users can view agents based on visibility and tier
+-- Users can view agents based on visibility and permissions
 CREATE POLICY "Users can view allowed agents"
   ON remote_agents FOR SELECT
   USING (
     visibility = 'public' OR
-    (visibility = 'researcher' AND EXISTS (
-      SELECT 1 FROM profiles
-      WHERE user_id = auth.uid() AND tier = 'researcher'
-    )) OR
+    visibility = ANY((SELECT permissions FROM profiles WHERE user_id = auth.uid())) OR
     EXISTS (
       SELECT 1 FROM agent_whitelist
       WHERE agent_id = id AND user_id = auth.uid()
@@ -319,21 +321,15 @@ CREATE TRIGGER on_auth_user_created
 5. Paste this policy:
 
 ```sql
-CREATE POLICY "Researcher access users can read agent configs"
+CREATE POLICY "Users can read allowed agent configs"
 ON storage.objects FOR SELECT
 USING (
   bucket_id = 'agent-configs' AND
   (
     -- Public agents (in public/ folder)
     (storage.foldername(name))[1] = 'public' OR
-    -- Researcher access agents (requires researcher tier)
-    (
-      (storage.foldername(name))[1] = 'researcher' AND
-      EXISTS (
-        SELECT 1 FROM profiles
-        WHERE user_id = auth.uid() AND tier = 'researcher'
-      )
-    ) OR
+    -- Visibility-based access (folder name matches a permission)
+    (storage.foldername(name))[1] = ANY((SELECT permissions FROM profiles WHERE user_id = auth.uid())) OR
     -- Whitelisted agents
     EXISTS (
       SELECT 1 FROM agent_whitelist aw
@@ -532,10 +528,12 @@ The extension will now use the configured credentials. Users don't need to confi
 
 1. Create your agent YAML file locally (e.g., `advanced-researcher.yaml`)
 2. In Supabase dashboard, go to **Storage** → `agent-configs`
-3. Create folder structure:
-   - `public/` - for free agents
+3. Create folder structure matching visibility values:
+   - `public/` - for agents visible to all authenticated users
    - `researcher/` - for researcher access program agents
-   - `whitelist/` - for whitelisted agents
+   - `math/` - for mathematicians (custom visibility group)
+   - `cs/` - for computer scientists (custom visibility group)
+   - etc. (folder names should match the visibility value in the database)
 4. Upload your YAML file to the appropriate folder (e.g., `researcher/advanced-researcher.yaml`)
 
 ### 2. Add Agent Metadata to Database
@@ -543,31 +541,40 @@ The extension will now use the configured credentials. Users don't need to confi
 In **SQL Editor**, run:
 
 ```sql
-INSERT INTO remote_agents (name, description, storage_path, visibility, agent_type)
+INSERT INTO remote_agents (name, description, storage_path, visibility, agent_category)
 VALUES (
   'advanced-researcher',
   'AI-powered research assistant for academic papers',
   'researcher/advanced-researcher.yaml',
   'researcher',
-  'CoT'
+  'workflow'
 );
 ```
+
+Note: `agent_category` can be `'workflow'` (multi-turn agents) or `'toolUse'` (single-turn with tools).
 
 ---
 
 ## Part 8: User Management
 
-### 1. Grant User Researcher Access
+### 1. Grant User Access to Visibility Groups
+
+Users can see agents where `visibility` matches any value in their `permissions` array.
 
 In **SQL Editor**:
 
 ```sql
--- Get user's ID first
-SELECT user_id, email FROM profiles;
+-- View all users
+SELECT user_id, email, permissions FROM profiles;
 
--- Grant specific user researcher access
+-- Grant user access to 'researcher' visibility agents
 UPDATE profiles
-SET tier = 'researcher'
+SET permissions = array_append(permissions, 'researcher')
+WHERE email = 'user@example.com';
+
+-- Grant multiple visibility levels at once
+UPDATE profiles
+SET permissions = ARRAY['researcher', 'math', 'cs']
 WHERE email = 'user@example.com';
 ```
 

--- a/src/agent/index/agentRegistry.ts
+++ b/src/agent/index/agentRegistry.ts
@@ -444,7 +444,9 @@ async function loadRemoteAgents(): Promise<AgentEntry[]> {
       const isToolUse =
         primary.agentCategory === 'toolUse' ||
         primary.agentCategory === AgentCategory.ToolUse;
-      const category = isToolUse ? AgentCategory.ToolUse : AgentCategory.Workflow;
+      const category = isToolUse
+        ? AgentCategory.ToolUse
+        : AgentCategory.Workflow;
       // Derive agentType from category (toolUse category -> ToolUse type, otherwise CoT)
       const agentType = isToolUse ? AgentType.ToolUse : AgentType.CoT;
 

--- a/src/agent/index/agentRegistry.ts
+++ b/src/agent/index/agentRegistry.ts
@@ -442,6 +442,14 @@ async function loadRemoteAgents(): Promise<AgentEntry[]> {
       // If only _multiple exists without a base, use full name as the entry name
       const entryName = base ? baseName : primary.name;
 
+      // Determine category from agentCategory (new) or agentType (legacy)
+      const isToolUse =
+        primary.agentCategory === 'toolUse' ||
+        primary.agentCategory === AgentCategory.ToolUse;
+      const category = isToolUse ? AgentCategory.ToolUse : AgentCategory.Workflow;
+      // Derive agentType from category (toolUse category -> ToolUse type, otherwise CoT)
+      const agentType = isToolUse ? AgentType.ToolUse : AgentType.CoT;
+
       entries.push({
         name: entryName,
         source: 'remote' as AgentSource,
@@ -449,11 +457,8 @@ async function loadRemoteAgents(): Promise<AgentEntry[]> {
         // Set multiplePath to indicate _multiple variant exists (for UI indicator)
         // Use the multiple variant's name as a truthy marker
         multiplePath: base && multiple ? multiple.name : undefined,
-        category:
-          primary.agentType === 'toolUse'
-            ? AgentCategory.ToolUse
-            : AgentCategory.Workflow,
-        agentType: mapAgentType(primary.agentType),
+        category,
+        agentType,
         description: primary.description,
         visibility: primary.visibility,
       });

--- a/src/agent/index/agentRegistry.ts
+++ b/src/agent/index/agentRegistry.ts
@@ -44,8 +44,22 @@ export const AgentSource = z.enum([
 ]);
 export type AgentSource = z.infer<typeof AgentSource>;
 
-/** Remote agent visibility levels. */
-export type RemoteVisibility = 'public' | 'researcher' | 'whitelist';
+/**
+ * Remote agent visibility levels.
+ *
+ * Visibility determines who can access an agent. The permission required to access
+ * an agent is derived from the visibility: 'access_{visibility}_visibility'
+ * (e.g., visibility='researcher' requires 'access_researcher_visibility' permission).
+ *
+ * Common values:
+ * - 'public': Available to all authenticated users
+ * - 'researcher': Requires 'access_researcher_visibility' permission
+ * - 'whitelist': Requires explicit whitelist entry (checked separately)
+ *
+ * New visibility levels can be added in the database without code changes.
+ * Just ensure the corresponding permission exists in user_groups.
+ */
+export type RemoteVisibility = string;
 
 /**
  * Minimal agent metadata for dropdown display and path resolution.

--- a/src/agent/index/agentRegistry.ts
+++ b/src/agent/index/agentRegistry.ts
@@ -441,9 +441,7 @@ async function loadRemoteAgents(): Promise<AgentEntry[]> {
       const entryName = base ? baseName : primary.name;
 
       // Determine category from agentCategory (new) or agentType (legacy)
-      const isToolUse =
-        primary.agentCategory === 'toolUse' ||
-        primary.agentCategory === AgentCategory.ToolUse;
+      const isToolUse = primary.agentCategory === AgentCategory.ToolUse;
       const category = isToolUse
         ? AgentCategory.ToolUse
         : AgentCategory.Workflow;

--- a/src/agent/index/agentRegistry.ts
+++ b/src/agent/index/agentRegistry.ts
@@ -47,19 +47,17 @@ export type AgentSource = z.infer<typeof AgentSource>;
 /**
  * Remote agent visibility levels.
  *
- * Visibility determines who can access an agent. The permission required to access
- * an agent is derived from the visibility: 'access_{visibility}_visibility'
- * (e.g., visibility='researcher' requires 'access_researcher_visibility' permission).
+ * Visibility is an array of group names that can access the agent.
+ * User can access the agent if their permissions overlap with visibility.
  *
  * Common values:
- * - 'public': Available to all authenticated users
- * - 'researcher': Requires 'access_researcher_visibility' permission
- * - 'whitelist': Requires explicit whitelist entry (checked separately)
+ * - ['public']: Available to all authenticated users
+ * - ['researcher']: Requires 'researcher' in user's permissions
+ * - ['math', 'cs']: Available to users with 'math' OR 'cs' permission
  *
  * New visibility levels can be added in the database without code changes.
- * Just ensure the corresponding permission exists in user_groups.
  */
-export type RemoteVisibility = string;
+export type RemoteVisibility = string[];
 
 /**
  * Minimal agent metadata for dropdown display and path resolution.

--- a/src/agent/remote/RemoteAgentLoader.ts
+++ b/src/agent/remote/RemoteAgentLoader.ts
@@ -21,8 +21,8 @@ export interface RemoteAgentMetadata {
   id: string;
   name: string;
   description: string;
-  /** Visibility level - determines required permission for access */
-  visibility: string;
+  /** Visibility levels - array of groups that can access this agent */
+  visibility: string[];
   /** Agent category: 'workflow' or 'toolUse' */
   agentCategory?: string;
 }
@@ -220,7 +220,7 @@ export class RemoteAgentLoader {
             id: '',
             name: agentName,
             description: description || '',
-            visibility: 'researcher',
+            visibility: ['public'],
           },
         };
       } catch (error) {

--- a/src/agent/remote/RemoteAgentLoader.ts
+++ b/src/agent/remote/RemoteAgentLoader.ts
@@ -21,7 +21,8 @@ export interface RemoteAgentMetadata {
   id: string;
   name: string;
   description: string;
-  visibility: 'public' | 'researcher' | 'whitelist';
+  /** Visibility level - determines required permission for access */
+  visibility: string;
   agentType?: string;
 }
 

--- a/src/agent/remote/RemoteAgentLoader.ts
+++ b/src/agent/remote/RemoteAgentLoader.ts
@@ -23,7 +23,8 @@ export interface RemoteAgentMetadata {
   description: string;
   /** Visibility level - determines required permission for access */
   visibility: string;
-  agentType?: string;
+  /** Agent category: 'workflow' or 'toolUse' */
+  agentCategory?: string;
 }
 
 export interface RemoteAgentConfig {
@@ -275,7 +276,7 @@ export class RemoteAgentLoader {
       // RLS will automatically filter based on user's permissions
       const { data, error } = await supabase
         .from('remote_agents')
-        .select('id, name, description, visibility, agent_type')
+        .select('id, name, description, visibility, agent_category')
         .order('name');
 
       if (error) {
@@ -289,7 +290,7 @@ export class RemoteAgentLoader {
         name: row.name,
         description: row.description,
         visibility: row.visibility,
-        agentType: row.agent_type,
+        agentCategory: row.agent_category,
       })) as RemoteAgentMetadata[];
     } catch (error) {
       const errorMessage =
@@ -321,7 +322,7 @@ export class RemoteAgentLoader {
 
       const { data, error } = await supabase
         .from('remote_agents')
-        .select('id, name, description, visibility')
+        .select('id, name, description, visibility, agent_category')
         .eq('name', agentName)
         .single();
 
@@ -333,7 +334,13 @@ export class RemoteAgentLoader {
         return null;
       }
 
-      return data as RemoteAgentMetadata;
+      return {
+        id: data.id,
+        name: data.name,
+        description: data.description,
+        visibility: data.visibility,
+        agentCategory: data.agent_category,
+      } as RemoteAgentMetadata;
     } catch (error) {
       const errorMessage =
         error instanceof Error ? error.message : String(error);

--- a/src/auth/SupabaseClient.ts
+++ b/src/auth/SupabaseClient.ts
@@ -5,7 +5,7 @@ import {
 } from '@supabase/supabase-js';
 import * as vscode from 'vscode';
 import * as logger from '@logger/logUtils';
-import type { UserGroup, UserAuthContext } from './config';
+import type { UserAuthContext } from './config';
 
 /**
  * Singleton Supabase client with authentication helpers.
@@ -153,8 +153,8 @@ export class SupabaseClient {
   }
 
   /**
-   * Get the user's full authorization context including groups and permissions.
-   * This is the preferred method for permission checks.
+   * Get the user's authorization context including permissions.
+   * Fetches permissions directly from profiles table.
    */
   static async getUserAuthContext(): Promise<UserAuthContext> {
     const defaultContext: UserAuthContext = {
@@ -175,67 +175,33 @@ export class SupabaseClient {
         refresh_token: tokens.refreshToken,
       });
 
-      // Fetch user's group memberships with group details
+      // Fetch tier and permissions from profiles
       const { data, error } = await client
-        .from('user_group_memberships')
-        .select(
-          `
-          user_groups (
-            id,
-            name,
-            display_name,
-            permissions,
-            priority
-          )
-        `,
-        )
-        .order('user_groups(priority)', { ascending: false });
+        .from('profiles')
+        .select('tier, permissions')
+        .single();
 
-      if (error) {
+      if (error || !data) {
         logger.error(
           'SupabaseClient',
-          `Error fetching user groups: ${error.message}`,
+          `Error fetching profile: ${error?.message || 'No data'}`,
         );
-        // Fall back to legacy tier check
-        return this.getLegacyAuthContext();
+        return defaultContext;
       }
 
-      if (!data || data.length === 0) {
-        // No group memberships found, try legacy tier
-        return this.getLegacyAuthContext();
+      const tier = (data.tier as string) || 'free';
+      let permissions = (data.permissions as string[]) || [];
+
+      // If permissions column is empty, fall back to tier-based permissions
+      if (permissions.length === 0 && tier === 'researcher') {
+        permissions = ['access_remote_agents', 'access_researcher_visibility'];
       }
 
-      // Transform data to UserGroup format
-      const groups: UserGroup[] = data
-        .map((membership) => {
-          const group = membership.user_groups as unknown as {
-            id: string;
-            name: string;
-            display_name: string;
-            permissions: string[];
-            priority: number;
-          };
-          if (!group) return null;
-          return {
-            id: group.id,
-            name: group.name,
-            displayName: group.display_name,
-            permissions: group.permissions || [],
-            priority: group.priority || 0,
-          };
-        })
-        .filter((g): g is UserGroup => g !== null);
-
-      // Flatten all permissions (deduplicated)
-      const permissions = [
-        ...new Set(groups.flatMap((g) => g.permissions)),
-      ];
-
-      // Primary group is the one with highest priority
-      const primaryGroup =
-        groups.length > 0 ? groups[0].name : 'free';
-
-      return { groups, permissions, primaryGroup };
+      return {
+        groups: [], // Simplified - no groups table
+        permissions,
+        primaryGroup: tier,
+      };
     } catch (error) {
       const errorMsg = error instanceof Error ? error.message : String(error);
       logger.error(
@@ -248,7 +214,6 @@ export class SupabaseClient {
 
   /**
    * Get user's permissions as a flat array.
-   * Convenience method for simple permission checks.
    */
   static async getUserPermissions(): Promise<string[]> {
     const context = await this.getUserAuthContext();
@@ -261,56 +226,6 @@ export class SupabaseClient {
   static async hasPermission(permission: string): Promise<boolean> {
     const permissions = await this.getUserPermissions();
     return permissions.includes(permission);
-  }
-
-  /**
-   * Legacy fallback: get auth context from profiles.tier column.
-   * Used when user_groups tables don't exist yet.
-   */
-  private static async getLegacyAuthContext(): Promise<UserAuthContext> {
-    const defaultContext: UserAuthContext = {
-      groups: [],
-      permissions: [],
-      primaryGroup: 'free',
-    };
-
-    try {
-      const client = this.getClient();
-      const { data, error } = await client
-        .from('profiles')
-        .select('tier')
-        .single();
-
-      if (error || !data) {
-        return defaultContext;
-      }
-
-      const tier = (data.tier as string) || 'free';
-
-      // Map legacy tiers to permissions
-      if (tier === 'researcher') {
-        return {
-          groups: [
-            {
-              id: 'legacy-researcher',
-              name: 'researcher',
-              displayName: 'Researcher Access',
-              permissions: [
-                'access_remote_agents',
-                'access_researcher_visibility',
-              ],
-              priority: 10,
-            },
-          ],
-          permissions: ['access_remote_agents', 'access_researcher_visibility'],
-          primaryGroup: 'researcher',
-        };
-      }
-
-      return defaultContext;
-    } catch {
-      return defaultContext;
-    }
   }
 
   /**

--- a/src/auth/SupabaseClient.ts
+++ b/src/auth/SupabaseClient.ts
@@ -5,7 +5,7 @@ import {
 } from '@supabase/supabase-js';
 import * as vscode from 'vscode';
 import * as logger from '@logger/logUtils';
-import type { UserAuthContext } from './config';
+import type { UserAuthContext, UserTier } from './config';
 
 /**
  * Singleton Supabase client with authentication helpers.
@@ -141,9 +141,14 @@ export class SupabaseClient {
    * Get user tier from the database.
    * Returns the actual tier value: 'free', 'Max', or 'Ultra'.
    */
-  static async getUserTier(): Promise<string> {
+  static async getUserTier(): Promise<UserTier> {
     const authContext = await this.getUserAuthContext();
-    return authContext.tier;
+    const tier = authContext.tier;
+    // Validate tier is a known value, default to 'free'
+    if (tier === 'free' || tier === 'Max' || tier === 'Ultra') {
+      return tier;
+    }
+    return 'free';
   }
 
   /**

--- a/src/auth/SupabaseClient.ts
+++ b/src/auth/SupabaseClient.ts
@@ -138,17 +138,12 @@ export class SupabaseClient {
   }
 
   /**
-   * Get user tier (free or researcher).
-   * @deprecated Use getUserAuthContext() instead.
-   * This method is kept for backwards compatibility.
+   * Get user tier from the database.
+   * Returns the actual tier value: 'free', 'Max', or 'Ultra'.
    */
-  static async getUserTier(): Promise<'free' | 'researcher'> {
+  static async getUserTier(): Promise<string> {
     const authContext = await this.getUserAuthContext();
-    // Map tier to legacy values for backwards compatibility
-    if (authContext.tier === 'researcher') {
-      return 'researcher';
-    }
-    return 'free';
+    return authContext.tier;
   }
 
   /**

--- a/src/auth/SupabaseClient.ts
+++ b/src/auth/SupabaseClient.ts
@@ -139,14 +139,13 @@ export class SupabaseClient {
 
   /**
    * Get user tier (free or researcher).
-   * @deprecated Use getUserAuthContext() or getUserPermissions() instead for flexible permission checks.
+   * @deprecated Use getUserAuthContext() instead.
    * This method is kept for backwards compatibility.
    */
   static async getUserTier(): Promise<'free' | 'researcher'> {
     const authContext = await this.getUserAuthContext();
-    // Map primary group to legacy tier values
-    const tier = authContext.primaryGroup;
-    if (tier === 'researcher') {
+    // Map tier to legacy values for backwards compatibility
+    if (authContext.tier === 'researcher') {
       return 'researcher';
     }
     return 'free';
@@ -154,13 +153,13 @@ export class SupabaseClient {
 
   /**
    * Get the user's authorization context including permissions.
-   * Fetches permissions directly from profiles table.
+   * Permissions are visibility values the user can access.
+   * Tier is reserved for future API key access levels.
    */
   static async getUserAuthContext(): Promise<UserAuthContext> {
     const defaultContext: UserAuthContext = {
-      groups: [],
       permissions: [],
-      primaryGroup: 'free',
+      tier: 'free',
     };
 
     const tokens = await this.getSessionTokens();
@@ -192,15 +191,14 @@ export class SupabaseClient {
       const tier = (data.tier as string) || 'free';
       let permissions = (data.permissions as string[]) || [];
 
-      // If permissions column is empty, fall back to tier-based permissions
+      // Legacy fallback: if permissions empty and tier='researcher', grant 'researcher' visibility
       if (permissions.length === 0 && tier === 'researcher') {
-        permissions = ['access_remote_agents', 'access_researcher_visibility'];
+        permissions = ['researcher'];
       }
 
       return {
-        groups: [], // Simplified - no groups table
         permissions,
-        primaryGroup: tier,
+        tier,
       };
     } catch (error) {
       const errorMsg = error instanceof Error ? error.message : String(error);

--- a/src/auth/SupabaseClient.ts
+++ b/src/auth/SupabaseClient.ts
@@ -5,6 +5,7 @@ import {
 } from '@supabase/supabase-js';
 import * as vscode from 'vscode';
 import * as logger from '@logger/logUtils';
+import type { UserGroup, UserAuthContext } from './config';
 
 /**
  * Singleton Supabase client with authentication helpers.
@@ -138,11 +139,33 @@ export class SupabaseClient {
 
   /**
    * Get user tier (free or researcher).
+   * @deprecated Use getUserAuthContext() or getUserPermissions() instead for flexible permission checks.
+   * This method is kept for backwards compatibility.
    */
   static async getUserTier(): Promise<'free' | 'researcher'> {
+    const authContext = await this.getUserAuthContext();
+    // Map primary group to legacy tier values
+    const tier = authContext.primaryGroup;
+    if (tier === 'researcher') {
+      return 'researcher';
+    }
+    return 'free';
+  }
+
+  /**
+   * Get the user's full authorization context including groups and permissions.
+   * This is the preferred method for permission checks.
+   */
+  static async getUserAuthContext(): Promise<UserAuthContext> {
+    const defaultContext: UserAuthContext = {
+      groups: [],
+      permissions: [],
+      primaryGroup: 'free',
+    };
+
     const tokens = await this.getSessionTokens();
     if (!tokens) {
-      return 'free';
+      return defaultContext;
     }
 
     try {
@@ -152,21 +175,141 @@ export class SupabaseClient {
         refresh_token: tokens.refreshToken,
       });
 
+      // Fetch user's group memberships with group details
+      const { data, error } = await client
+        .from('user_group_memberships')
+        .select(
+          `
+          user_groups (
+            id,
+            name,
+            display_name,
+            permissions,
+            priority
+          )
+        `,
+        )
+        .order('user_groups(priority)', { ascending: false });
+
+      if (error) {
+        logger.error(
+          'SupabaseClient',
+          `Error fetching user groups: ${error.message}`,
+        );
+        // Fall back to legacy tier check
+        return this.getLegacyAuthContext();
+      }
+
+      if (!data || data.length === 0) {
+        // No group memberships found, try legacy tier
+        return this.getLegacyAuthContext();
+      }
+
+      // Transform data to UserGroup format
+      const groups: UserGroup[] = data
+        .map((membership) => {
+          const group = membership.user_groups as unknown as {
+            id: string;
+            name: string;
+            display_name: string;
+            permissions: string[];
+            priority: number;
+          };
+          if (!group) return null;
+          return {
+            id: group.id,
+            name: group.name,
+            displayName: group.display_name,
+            permissions: group.permissions || [],
+            priority: group.priority || 0,
+          };
+        })
+        .filter((g): g is UserGroup => g !== null);
+
+      // Flatten all permissions (deduplicated)
+      const permissions = [
+        ...new Set(groups.flatMap((g) => g.permissions)),
+      ];
+
+      // Primary group is the one with highest priority
+      const primaryGroup =
+        groups.length > 0 ? groups[0].name : 'free';
+
+      return { groups, permissions, primaryGroup };
+    } catch (error) {
+      const errorMsg = error instanceof Error ? error.message : String(error);
+      logger.error(
+        'SupabaseClient',
+        `Error getting user auth context: ${errorMsg}`,
+      );
+      return defaultContext;
+    }
+  }
+
+  /**
+   * Get user's permissions as a flat array.
+   * Convenience method for simple permission checks.
+   */
+  static async getUserPermissions(): Promise<string[]> {
+    const context = await this.getUserAuthContext();
+    return context.permissions;
+  }
+
+  /**
+   * Check if user has a specific permission.
+   */
+  static async hasPermission(permission: string): Promise<boolean> {
+    const permissions = await this.getUserPermissions();
+    return permissions.includes(permission);
+  }
+
+  /**
+   * Legacy fallback: get auth context from profiles.tier column.
+   * Used when user_groups tables don't exist yet.
+   */
+  private static async getLegacyAuthContext(): Promise<UserAuthContext> {
+    const defaultContext: UserAuthContext = {
+      groups: [],
+      permissions: [],
+      primaryGroup: 'free',
+    };
+
+    try {
+      const client = this.getClient();
       const { data, error } = await client
         .from('profiles')
         .select('tier')
         .single();
 
       if (error || !data) {
-        const errorMsg = error?.message || 'Unknown error';
-        logger.error('SupabaseClient', `Error fetching user tier: ${errorMsg}`);
-        return 'free';
+        return defaultContext;
       }
-      return (data.tier as 'free' | 'researcher') || 'free';
-    } catch (error) {
-      const errorMsg = error instanceof Error ? error.message : String(error);
-      logger.error('SupabaseClient', `Error getting user tier: ${errorMsg}`);
-      return 'free';
+
+      const tier = (data.tier as string) || 'free';
+
+      // Map legacy tiers to permissions
+      if (tier === 'researcher') {
+        return {
+          groups: [
+            {
+              id: 'legacy-researcher',
+              name: 'researcher',
+              displayName: 'Researcher Access',
+              permissions: [
+                'access_remote_agents',
+                'access_researcher_visibility',
+              ],
+              priority: 10,
+            },
+          ],
+          permissions: ['access_remote_agents', 'access_researcher_visibility'],
+          primaryGroup: 'researcher',
+        };
+      }
+
+      return defaultContext;
+    } catch {
+      return defaultContext;
     }
   }
 

--- a/src/auth/SupabaseClient.ts
+++ b/src/auth/SupabaseClient.ts
@@ -5,7 +5,11 @@ import {
 } from '@supabase/supabase-js';
 import * as vscode from 'vscode';
 import * as logger from '@logger/logUtils';
-import type { UserAuthContext, UserTier } from './config';
+import {
+  type UserAuthContext,
+  type UserTier,
+  UserAuthContextSchema,
+} from './config';
 
 /**
  * Singleton Supabase client with authentication helpers.
@@ -143,12 +147,7 @@ export class SupabaseClient {
    */
   static async getUserTier(): Promise<UserTier> {
     const authContext = await this.getUserAuthContext();
-    const tier = authContext.tier;
-    // Validate tier is a known value, default to 'free'
-    if (tier === 'free' || tier === 'Max' || tier === 'Ultra') {
-      return tier;
-    }
-    return 'free';
+    return authContext.tier;
   }
 
   /**
@@ -188,15 +187,21 @@ export class SupabaseClient {
         return defaultContext;
       }
 
-      const tier = typeof data.tier === 'string' ? data.tier : 'free';
-      const permissions = Array.isArray(data.permissions)
-        ? data.permissions
-        : [];
+      // Validate and parse with Zod schema, fallback to defaults for invalid fields
+      const result = UserAuthContextSchema.safeParse({
+        tier: data.tier ?? 'free',
+        permissions: data.permissions ?? [],
+      });
 
-      return {
-        permissions,
-        tier,
-      };
+      if (!result.success) {
+        logger.warn(
+          'SupabaseClient',
+          `Invalid profile data: ${result.error.message}`,
+        );
+        return defaultContext;
+      }
+
+      return result.data;
     } catch (error) {
       const errorMsg = error instanceof Error ? error.message : String(error);
       logger.error(
@@ -213,14 +218,6 @@ export class SupabaseClient {
   static async getUserPermissions(): Promise<string[]> {
     const context = await this.getUserAuthContext();
     return context.permissions;
-  }
-
-  /**
-   * Check if user has a specific permission.
-   */
-  static async hasPermission(permission: string): Promise<boolean> {
-    const permissions = await this.getUserPermissions();
-    return permissions.includes(permission);
   }
 
   /**

--- a/src/auth/SupabaseClient.ts
+++ b/src/auth/SupabaseClient.ts
@@ -184,12 +184,7 @@ export class SupabaseClient {
       }
 
       const tier = (data.tier as string) || 'free';
-      let permissions = (data.permissions as string[]) || [];
-
-      // Legacy fallback: if permissions empty and tier='researcher', grant 'researcher' visibility
-      if (permissions.length === 0 && tier === 'researcher') {
-        permissions = ['researcher'];
-      }
+      const permissions = (data.permissions as string[]) || [];
 
       return {
         permissions,

--- a/src/auth/SupabaseClient.ts
+++ b/src/auth/SupabaseClient.ts
@@ -183,8 +183,10 @@ export class SupabaseClient {
         return defaultContext;
       }
 
-      const tier = (data.tier as string) || 'free';
-      const permissions = (data.permissions as string[]) || [];
+      const tier = typeof data.tier === 'string' ? data.tier : 'free';
+      const permissions = Array.isArray(data.permissions)
+        ? data.permissions
+        : [];
 
       return {
         permissions,

--- a/src/auth/authCommands.ts
+++ b/src/auth/authCommands.ts
@@ -273,7 +273,7 @@ export async function showAccountMenu(): Promise<void> {
         {
           label: '$(sign-in) Sign In',
           description:
-            'Sign in to access remote agents via the researcher access program',
+            'Sign in to access remote agents via the research access program',
           action: 'signIn' as const,
         },
       ];

--- a/src/auth/authCommands.ts
+++ b/src/auth/authCommands.ts
@@ -242,7 +242,7 @@ export async function viewProfile(): Promise<void> {
 export async function getAuthStatus(): Promise<{
   authenticated: boolean;
   email?: string;
-  tier?: 'free' | 'researcher';
+  tier?: string;
 }> {
   const isAuth = await SupabaseClient.isAuthenticated();
   if (!isAuth) {

--- a/src/auth/config.ts
+++ b/src/auth/config.ts
@@ -84,26 +84,16 @@ export const PERMISSIONS = {
 export type Permission = (typeof PERMISSIONS)[keyof typeof PERMISSIONS];
 
 /**
- * User group information returned from the database.
- */
-export interface UserGroup {
-  id: string;
-  name: string;
-  displayName: string;
-  permissions: string[];
-  priority: number;
-}
-
-/**
- * User's authorization context including groups and permissions.
+ * User's authorization context.
+ * Permissions are stored directly in the profiles table.
  */
 export interface UserAuthContext {
-  /** All groups the user belongs to */
-  groups: UserGroup[];
-  /** Flattened list of all permissions from all groups */
+  /** User's permissions from profiles.permissions column */
   permissions: string[];
-  /** Primary group (highest priority) - for backwards compatibility */
+  /** User's tier from profiles.tier column (for display) */
   primaryGroup: string;
+  /** @deprecated Kept for compatibility, always empty in simplified model */
+  groups: never[];
 }
 
 /**

--- a/src/auth/config.ts
+++ b/src/auth/config.ts
@@ -106,15 +106,27 @@ export type UserTier = 'free' | 'Max' | 'Ultra';
  */
 export function hasVisibilityAccess(
   permissions: string[],
-  visibility: string | string[],
+  visibility: string | string[] | undefined | null,
 ): boolean {
+  // Handle undefined/null visibility - treat as public
+  if (!visibility) {
+    return true;
+  }
   const visibilityArray = Array.isArray(visibility) ? visibility : [visibility];
+  // Filter out any undefined/null elements
+  const cleanedVisibility = visibilityArray.filter(
+    (v): v is string => typeof v === 'string',
+  );
+  // Empty visibility array is treated as public
+  if (cleanedVisibility.length === 0) {
+    return true;
+  }
   // Public agents are always accessible
-  if (visibilityArray.includes('public')) {
+  if (cleanedVisibility.includes('public')) {
     return true;
   }
   // Check for any overlap between visibility and permissions
-  return visibilityArray.some((v) => permissions.includes(v));
+  return cleanedVisibility.some((v) => permissions.includes(v));
 }
 
 /**

--- a/src/auth/config.ts
+++ b/src/auth/config.ts
@@ -98,6 +98,11 @@ export type UserTier = 'free' | 'Max' | 'Ultra';
  * Returns true if:
  * - Agent visibility includes 'public', OR
  * - There's any overlap between agent visibility and user permissions
+ *
+ * Note: Server-side RLS handles primary access control. This function is for:
+ * - Client-side pre-filtering (e.g., UI hints before server roundtrip)
+ * - Testing and validation
+ * - Future use cases where client-side access checks are needed
  */
 export function hasVisibilityAccess(
   permissions: string[],

--- a/src/auth/config.ts
+++ b/src/auth/config.ts
@@ -89,13 +89,27 @@ export interface UserAuthContext {
 }
 
 /**
- * Check if user has access to a specific visibility level.
+ * Tier values for future server-side API key access.
+ */
+export type UserTier = 'free' | 'Max' | 'Ultra';
+
+/**
+ * Check if user has access to an agent's visibility levels.
+ * Returns true if:
+ * - Agent visibility includes 'public', OR
+ * - There's any overlap between agent visibility and user permissions
  */
 export function hasVisibilityAccess(
   permissions: string[],
-  visibility: string,
+  visibility: string | string[],
 ): boolean {
-  return visibility === 'public' || permissions.includes(visibility);
+  const visibilityArray = Array.isArray(visibility) ? visibility : [visibility];
+  // Public agents are always accessible
+  if (visibilityArray.includes('public')) {
+    return true;
+  }
+  // Check for any overlap between visibility and permissions
+  return visibilityArray.some((v) => permissions.includes(v));
 }
 
 /**

--- a/src/auth/config.ts
+++ b/src/auth/config.ts
@@ -65,6 +65,77 @@ export function isSupabaseConfigured(): boolean {
 export const OAUTH_PROVIDERS = ['github', 'google', 'gitlab'] as const;
 export type OAuthProvider = (typeof OAUTH_PROVIDERS)[number];
 
+// ============================================================================
+// User Groups & Permissions
+// ============================================================================
+
+/**
+ * Known permissions used in the system.
+ * New permissions can be added to the database without code changes,
+ * but these constants provide type safety for common checks.
+ */
+export const PERMISSIONS = {
+  /** Access to remote agents feature */
+  ACCESS_REMOTE_AGENTS: 'access_remote_agents',
+  /** Access to agents with 'researcher' visibility */
+  ACCESS_RESEARCHER_VISIBILITY: 'access_researcher_visibility',
+} as const;
+
+export type Permission = (typeof PERMISSIONS)[keyof typeof PERMISSIONS];
+
+/**
+ * User group information returned from the database.
+ */
+export interface UserGroup {
+  id: string;
+  name: string;
+  displayName: string;
+  permissions: string[];
+  priority: number;
+}
+
+/**
+ * User's authorization context including groups and permissions.
+ */
+export interface UserAuthContext {
+  /** All groups the user belongs to */
+  groups: UserGroup[];
+  /** Flattened list of all permissions from all groups */
+  permissions: string[];
+  /** Primary group (highest priority) - for backwards compatibility */
+  primaryGroup: string;
+}
+
+/**
+ * Check if a permission array includes a specific permission.
+ */
+export function hasPermission(
+  permissions: string[],
+  permission: string,
+): boolean {
+  return permissions.includes(permission);
+}
+
+/**
+ * Check if a permission array includes any of the specified permissions.
+ */
+export function hasAnyPermission(
+  permissions: string[],
+  requiredPermissions: string[],
+): boolean {
+  return requiredPermissions.some((p) => permissions.includes(p));
+}
+
+/**
+ * Check if a permission array includes all of the specified permissions.
+ */
+export function hasAllPermissions(
+  permissions: string[],
+  requiredPermissions: string[],
+): boolean {
+  return requiredPermissions.every((p) => permissions.includes(p));
+}
+
 /**
  * Default OAuth provider to use.
  * Users can choose during sign-in if multiple are configured in Supabase.

--- a/src/auth/config.ts
+++ b/src/auth/config.ts
@@ -70,60 +70,32 @@ export type OAuthProvider = (typeof OAUTH_PROVIDERS)[number];
 // ============================================================================
 
 /**
- * Known permissions used in the system.
- * New permissions can be added to the database without code changes,
- * but these constants provide type safety for common checks.
+ * Permissions are just visibility values that the user can access.
+ * E.g., ['researcher', 'math', 'cs'] means user can see agents with those visibility levels.
+ * 'public' agents are always visible to authenticated users.
+ *
+ * Note: 'tier' column is reserved for future server-side API key access.
  */
-export const PERMISSIONS = {
-  /** Access to remote agents feature */
-  ACCESS_REMOTE_AGENTS: 'access_remote_agents',
-  /** Access to agents with 'researcher' visibility */
-  ACCESS_RESEARCHER_VISIBILITY: 'access_researcher_visibility',
-} as const;
-
-export type Permission = (typeof PERMISSIONS)[keyof typeof PERMISSIONS];
 
 /**
  * User's authorization context.
- * Permissions are stored directly in the profiles table.
+ * Permissions are visibility values stored in profiles.permissions column.
  */
 export interface UserAuthContext {
-  /** User's permissions from profiles.permissions column */
+  /** Visibility values user can access: ['researcher', 'math', etc.] */
   permissions: string[];
-  /** User's tier from profiles.tier column (for display) */
-  primaryGroup: string;
-  /** @deprecated Kept for compatibility, always empty in simplified model */
-  groups: never[];
+  /** User's tier (reserved for future API key access) */
+  tier: string;
 }
 
 /**
- * Check if a permission array includes a specific permission.
+ * Check if user has access to a specific visibility level.
  */
-export function hasPermission(
+export function hasVisibilityAccess(
   permissions: string[],
-  permission: string,
+  visibility: string,
 ): boolean {
-  return permissions.includes(permission);
-}
-
-/**
- * Check if a permission array includes any of the specified permissions.
- */
-export function hasAnyPermission(
-  permissions: string[],
-  requiredPermissions: string[],
-): boolean {
-  return requiredPermissions.some((p) => permissions.includes(p));
-}
-
-/**
- * Check if a permission array includes all of the specified permissions.
- */
-export function hasAllPermissions(
-  permissions: string[],
-  requiredPermissions: string[],
-): boolean {
-  return requiredPermissions.every((p) => permissions.includes(p));
+  return visibility === 'public' || permissions.includes(visibility);
 }
 
 /**

--- a/src/auth/config.ts
+++ b/src/auth/config.ts
@@ -6,6 +6,7 @@
  *
  * Similar to how GitHub Copilot works - users sign in to the official service.
  */
+import { z } from 'zod';
 
 /**
  * Supabase configuration interface
@@ -78,20 +79,22 @@ export type OAuthProvider = (typeof OAUTH_PROVIDERS)[number];
  */
 
 /**
+ * Tier values for server-side API key access.
+ */
+export const UserTierSchema = z.enum(['free', 'Max', 'Ultra']);
+export type UserTier = z.infer<typeof UserTierSchema>;
+
+/**
  * User's authorization context.
  * Permissions are visibility values stored in profiles.permissions column.
  */
-export interface UserAuthContext {
+export const UserAuthContextSchema = z.object({
   /** Visibility values user can access: ['researcher', 'math', etc.] */
-  permissions: string[];
+  permissions: z.array(z.string()),
   /** User's tier (reserved for future API key access) */
-  tier: string;
-}
-
-/**
- * Tier values for future server-side API key access.
- */
-export type UserTier = 'free' | 'Max' | 'Ultra';
+  tier: UserTierSchema,
+});
+export type UserAuthContext = z.infer<typeof UserAuthContextSchema>;
 
 /**
  * Check if user has access to an agent's visibility levels.

--- a/src/profileView/ProfileViewMessageHandler.ts
+++ b/src/profileView/ProfileViewMessageHandler.ts
@@ -65,7 +65,7 @@ export class ProfileViewMessageHandler extends BaseViewMessageHandler<
     const remoteAgents = entries.map((entry) => ({
       name: entry.name,
       description: entry.description || '',
-      visibility: entry.visibility || 'public',
+      visibility: entry.visibility || ['public'],
       category: entry.category || 'workflow',
     }));
 

--- a/src/profileView/ProfileViewMessageHandler.ts
+++ b/src/profileView/ProfileViewMessageHandler.ts
@@ -64,7 +64,7 @@ export class ProfileViewMessageHandler extends BaseViewMessageHandler<
       name: string;
       description: string;
       visibility: string;
-      agentType?: string;
+      category?: string;
     }> = [];
 
     const canAccessRemoteAgents = hasPermission(
@@ -80,7 +80,7 @@ export class ProfileViewMessageHandler extends BaseViewMessageHandler<
         name: entry.name,
         description: entry.description || '',
         visibility: entry.visibility || 'researcher',
-        agentType: entry.agentType || 'CoT',
+        category: entry.category || 'workflow',
       }));
     }
 

--- a/src/profileView/ProfileViewMessageHandler.ts
+++ b/src/profileView/ProfileViewMessageHandler.ts
@@ -16,7 +16,6 @@ import {
 // Local imports - auth
 import { SupabaseClient } from '@/auth/SupabaseClient';
 import { AUTH_COMMANDS } from '@/auth/authCommands';
-import { PERMISSIONS, hasPermission } from '@/auth/config';
 
 // --- Message Schemas ---
 const SelectAgentMessage = z.object({ agentName: z.string().min(1) });
@@ -59,30 +58,16 @@ export class ProfileViewMessageHandler extends BaseViewMessageHandler<
     const user = await SupabaseClient.getUser();
     const authContext = await SupabaseClient.getUserAuthContext();
 
-    // Fetch remote agents if user has permission
-    let remoteAgents: Array<{
-      name: string;
-      description: string;
-      visibility: string;
-      category?: string;
-    }> = [];
-
-    const canAccessRemoteAgents = hasPermission(
-      authContext.permissions,
-      PERMISSIONS.ACCESS_REMOTE_AGENTS,
-    );
-
-    if (canAccessRemoteAgents) {
-      // Refresh agent cache to ensure remote agents are loaded after authentication
-      await loadAgents();
-      const entries = getAgentsBySource('remote' as AgentSource);
-      remoteAgents = entries.map((entry) => ({
-        name: entry.name,
-        description: entry.description || '',
-        visibility: entry.visibility || 'researcher',
-        category: entry.category || 'workflow',
-      }));
-    }
+    // Fetch remote agents - RLS filters based on user's permissions
+    // All authenticated users can see agents matching their visibility access
+    await loadAgents();
+    const entries = getAgentsBySource('remote' as AgentSource);
+    const remoteAgents = entries.map((entry) => ({
+      name: entry.name,
+      description: entry.description || '',
+      visibility: entry.visibility || 'public',
+      category: entry.category || 'workflow',
+    }));
 
     await webview.postMessage({
       command: PROFILE_VIEW_COMMANDS.UPDATE_PROFILE,
@@ -91,7 +76,7 @@ export class ProfileViewMessageHandler extends BaseViewMessageHandler<
         email: user?.email || 'N/A',
         id: user?.id || '',
       },
-      tier: authContext.primaryGroup, // Backwards compatibility
+      tier: authContext.tier,
       permissions: authContext.permissions,
       remoteAgents,
     });

--- a/src/profileView/ProfileViewMessageHandler.ts
+++ b/src/profileView/ProfileViewMessageHandler.ts
@@ -16,6 +16,7 @@ import {
 // Local imports - auth
 import { SupabaseClient } from '@/auth/SupabaseClient';
 import { AUTH_COMMANDS } from '@/auth/authCommands';
+import { PERMISSIONS, hasPermission } from '@/auth/config';
 
 // --- Message Schemas ---
 const SelectAgentMessage = z.object({ agentName: z.string().min(1) });
@@ -49,15 +50,16 @@ export class ProfileViewMessageHandler extends BaseViewMessageHandler<
         authenticated: false,
         user: null,
         tier: 'free',
+        permissions: [],
         remoteAgents: [],
       });
       return;
     }
 
     const user = await SupabaseClient.getUser();
-    const tier = await SupabaseClient.getUserTier();
+    const authContext = await SupabaseClient.getUserAuthContext();
 
-    // Fetch remote agents if user has researcher tier
+    // Fetch remote agents if user has permission
     let remoteAgents: Array<{
       name: string;
       description: string;
@@ -65,7 +67,12 @@ export class ProfileViewMessageHandler extends BaseViewMessageHandler<
       agentType?: string;
     }> = [];
 
-    if (tier === 'researcher') {
+    const canAccessRemoteAgents = hasPermission(
+      authContext.permissions,
+      PERMISSIONS.ACCESS_REMOTE_AGENTS,
+    );
+
+    if (canAccessRemoteAgents) {
       // Refresh agent cache to ensure remote agents are loaded after authentication
       await loadAgents();
       const entries = getAgentsBySource('remote' as AgentSource);
@@ -84,7 +91,8 @@ export class ProfileViewMessageHandler extends BaseViewMessageHandler<
         email: user?.email || 'N/A',
         id: user?.id || '',
       },
-      tier,
+      tier: authContext.primaryGroup, // Backwards compatibility
+      permissions: authContext.permissions,
       remoteAgents,
     });
   }

--- a/src/profileView/modules/constants.js
+++ b/src/profileView/modules/constants.js
@@ -34,8 +34,8 @@ export const CLASS_NAMES = {
 // Text labels and messages
 export const LABELS = {
   TIER_FREE_MESSAGE:
-    'Join the research access program to access premium remote agents.',
-  TIER_PREMIUM_MESSAGE: 'You have access to premium remote agents.',
+    'Join the research access program to access more remote agents.',
+  TIER_PREMIUM_MESSAGE: 'You have access to remote agents.',
   NO_AGENTS_MESSAGE:
     'No remote agents available. Contact support@texra.ai for assistance.',
   NOT_AUTHENTICATED_MESSAGE: 'You are not signed in to TeXRA.',

--- a/src/profileView/modules/constants.js
+++ b/src/profileView/modules/constants.js
@@ -34,7 +34,7 @@ export const CLASS_NAMES = {
 // Text labels and messages
 export const LABELS = {
   TIER_FREE_MESSAGE:
-    'Upgrade to Max or Ultra tier to access premium remote agents.',
+    'Join the research access program to access premium remote agents.',
   TIER_PREMIUM_MESSAGE: 'You have access to premium remote agents.',
   NO_AGENTS_MESSAGE:
     'No remote agents available. Contact support@texra.ai for assistance.',

--- a/src/profileView/modules/constants.js
+++ b/src/profileView/modules/constants.js
@@ -34,8 +34,8 @@ export const CLASS_NAMES = {
 // Text labels and messages
 export const LABELS = {
   TIER_FREE_MESSAGE:
-    'Join the researcher access program to access premium remote agents.',
-  TIER_RESEARCHER_MESSAGE: 'You have access to premium remote agents.',
+    'Upgrade to Max or Ultra tier to access premium remote agents.',
+  TIER_PREMIUM_MESSAGE: 'You have access to premium remote agents.',
   NO_AGENTS_MESSAGE:
     'No remote agents available. Contact support@texra.ai for assistance.',
   NOT_AUTHENTICATED_MESSAGE: 'You are not signed in to TeXRA.',

--- a/src/profileView/modules/constants.js
+++ b/src/profileView/modules/constants.js
@@ -43,5 +43,5 @@ export const LABELS = {
 
 // Default values
 export const DEFAULTS = {
-  AGENT_TYPE: 'CoT',
+  AGENT_CATEGORY: 'workflow',
 };

--- a/src/profileView/modules/messageHandlers.js
+++ b/src/profileView/modules/messageHandlers.js
@@ -27,13 +27,13 @@ export class ProfileViewMessageHandler extends BaseWebviewMessageHandler {
     });
 
     // Update UI
-    profileViewDomHandler.agentsTable.render(
-      message.authenticated,
-      message.user,
-      message.tier,
-      message.permissions || [],
-      message.remoteAgents,
-    );
+    profileViewDomHandler.agentsTable.render({
+      authenticated: message.authenticated,
+      user: message.user,
+      tier: message.tier,
+      permissions: message.permissions || [],
+      remoteAgents: message.remoteAgents,
+    });
   }
 }
 

--- a/src/profileView/modules/messageHandlers.js
+++ b/src/profileView/modules/messageHandlers.js
@@ -22,6 +22,7 @@ export class ProfileViewMessageHandler extends BaseWebviewMessageHandler {
       authenticated: message.authenticated,
       user: message.user,
       tier: message.tier,
+      permissions: message.permissions || [],
       remoteAgents: message.remoteAgents,
     });
 
@@ -30,6 +31,7 @@ export class ProfileViewMessageHandler extends BaseWebviewMessageHandler {
       message.authenticated,
       message.user,
       message.tier,
+      message.permissions || [],
       message.remoteAgents,
     );
   }

--- a/src/profileView/modules/profileViewState.js
+++ b/src/profileView/modules/profileViewState.js
@@ -11,6 +11,7 @@ class ProfileViewState {
     this._authenticated = false;
     this._user = null;
     this._tier = 'free';
+    this._permissions = [];
     this._remoteAgents = [];
   }
 
@@ -23,6 +24,7 @@ class ProfileViewState {
     this._authenticated = saved.authenticated ?? false;
     this._user = saved.user ?? null;
     this._tier = saved.tier ?? 'free';
+    this._permissions = saved.permissions ?? [];
     this._remoteAgents = saved.remoteAgents ?? [];
   }
 
@@ -34,6 +36,7 @@ class ProfileViewState {
       authenticated: this._authenticated,
       user: this._user,
       tier: this._tier,
+      permissions: this._permissions,
       remoteAgents: this._remoteAgents,
     });
   }
@@ -65,6 +68,15 @@ class ProfileViewState {
     this.save();
   }
 
+  get permissions() {
+    return this._permissions;
+  }
+
+  set permissions(value) {
+    this._permissions = value;
+    this.save();
+  }
+
   get remoteAgents() {
     return this._remoteAgents;
   }
@@ -81,6 +93,7 @@ class ProfileViewState {
     this._authenticated = data.authenticated;
     this._user = data.user;
     this._tier = data.tier;
+    this._permissions = data.permissions || [];
     this._remoteAgents = data.remoteAgents || [];
     this.save();
   }

--- a/src/profileView/modules/uiManagers/AgentsTable.js
+++ b/src/profileView/modules/uiManagers/AgentsTable.js
@@ -180,8 +180,10 @@ export class AgentsTable {
         ? agent.visibility
         : [agent.visibility];
       visibilityBadge.textContent = visibilityArray.join(', ');
-      // Use first visibility value for CSS class
-      visibilityBadge.classList.add(visibilityArray[0] || 'public');
+      // Use first visibility value for CSS class, or 'custom' for non-public values
+      const firstVisibility = visibilityArray[0] || 'public';
+      const cssClass = firstVisibility === 'public' ? 'public' : 'custom';
+      visibilityBadge.classList.add(cssClass);
     }
 
     // Set up select button

--- a/src/profileView/modules/uiManagers/AgentsTable.js
+++ b/src/profileView/modules/uiManagers/AgentsTable.js
@@ -189,10 +189,10 @@ export class AgentsTable {
     const agentName = row.querySelector('.agent-name');
     if (agentName) agentName.textContent = agent.name;
 
-    // Set agent type badge
+    // Set agent category badge (workflow or toolUse)
     const typeBadge = row.querySelector('.type-badge');
     if (typeBadge) {
-      typeBadge.textContent = agent.agentType || DEFAULTS.AGENT_TYPE;
+      typeBadge.textContent = agent.category || DEFAULTS.AGENT_CATEGORY;
     }
 
     // Set description

--- a/src/profileView/modules/uiManagers/AgentsTable.js
+++ b/src/profileView/modules/uiManagers/AgentsTable.js
@@ -90,7 +90,7 @@ export class AgentsTable {
       const hasAnyPermissions =
         Array.isArray(permissions) && permissions.length > 0;
       tierMessage.textContent = hasAnyPermissions
-        ? LABELS.TIER_RESEARCHER_MESSAGE
+        ? LABELS.TIER_PREMIUM_MESSAGE
         : LABELS.TIER_FREE_MESSAGE;
     }
 

--- a/src/profileView/modules/uiManagers/AgentsTable.js
+++ b/src/profileView/modules/uiManagers/AgentsTable.js
@@ -6,6 +6,22 @@ import { vscode } from '@common/webviewContext.js';
 import { safeGetElementById } from '@common/domUtils.js';
 
 /**
+ * Permission constant for accessing remote agents.
+ * Matches PERMISSIONS.ACCESS_REMOTE_AGENTS from config.ts
+ */
+const PERMISSION_ACCESS_REMOTE_AGENTS = 'access_remote_agents';
+
+/**
+ * Check if a permission array includes a specific permission.
+ * @param {string[]} permissions - Array of permission strings
+ * @param {string} permission - Permission to check for
+ * @returns {boolean}
+ */
+function hasPermission(permissions, permission) {
+  return Array.isArray(permissions) && permissions.includes(permission);
+}
+
+/**
  * Manages the agents table rendering and interactions.
  */
 export class AgentsTable {
@@ -31,8 +47,13 @@ export class AgentsTable {
 
   /**
    * Render the profile view with the given data.
+   * @param {boolean} authenticated - Whether the user is authenticated
+   * @param {object} user - User object with email and id
+   * @param {string} tier - Primary group name (for backwards compatibility / display)
+   * @param {string[]} permissions - Array of permission strings
+   * @param {Array} remoteAgents - Array of remote agent objects
    */
-  render(authenticated, user, tier, remoteAgents) {
+  render(authenticated, user, tier, permissions, remoteAgents) {
     const profileInfo = safeGetElementById(ELEMENT_IDS.PROFILE_INFO);
     const tierInfo = safeGetElementById(ELEMENT_IDS.TIER_INFO);
     const notAuthenticated = safeGetElementById(ELEMENT_IDS.NOT_AUTHENTICATED);
@@ -71,24 +92,32 @@ export class AgentsTable {
     if (userEmail) userEmail.textContent = user?.email || 'N/A';
     if (userId) userId.textContent = user?.id || '';
 
-    // Update tier badge
+    // Update tier badge (shows primary group for display)
     const tierBadge = safeGetElementById(ELEMENT_IDS.USER_TIER);
     if (tierBadge) {
       tierBadge.textContent = tier;
       tierBadge.className = `${CLASS_NAMES.TIER_BADGE} ${tier}`;
     }
 
-    // Update tier message
+    // Update tier message based on permissions (not hardcoded tier check)
     const tierMessage = safeGetElementById(ELEMENT_IDS.TIER_MESSAGE);
     if (tierMessage) {
-      tierMessage.textContent =
-        tier === 'researcher'
-          ? LABELS.TIER_RESEARCHER_MESSAGE
-          : LABELS.TIER_FREE_MESSAGE;
+      const canAccessRemote = hasPermission(
+        permissions,
+        PERMISSION_ACCESS_REMOTE_AGENTS,
+      );
+      tierMessage.textContent = canAccessRemote
+        ? LABELS.TIER_RESEARCHER_MESSAGE
+        : LABELS.TIER_FREE_MESSAGE;
     }
 
-    // Show/hide remote agents section based on tier
-    if (tier === 'researcher') {
+    // Show/hide remote agents section based on permission (not tier)
+    const canAccessRemoteAgents = hasPermission(
+      permissions,
+      PERMISSION_ACCESS_REMOTE_AGENTS,
+    );
+
+    if (canAccessRemoteAgents) {
       remoteAgentsSection.style.display = 'block';
 
       if (remoteAgents && remoteAgents.length > 0) {

--- a/src/profileView/modules/uiManagers/AgentsTable.js
+++ b/src/profileView/modules/uiManagers/AgentsTable.js
@@ -31,13 +31,14 @@ export class AgentsTable {
 
   /**
    * Render the profile view with the given data.
-   * @param {boolean} authenticated - Whether the user is authenticated
-   * @param {object} user - User object with email and id
-   * @param {string} tier - Primary group name (for backwards compatibility / display)
-   * @param {string[]} permissions - Array of permission strings
-   * @param {Array} remoteAgents - Array of remote agent objects
+   * @param {Object} options - Render options
+   * @param {boolean} options.authenticated - Whether the user is authenticated
+   * @param {object} options.user - User object with email and id
+   * @param {string} options.tier - Primary group name (for backwards compatibility / display)
+   * @param {string[]} options.permissions - Array of permission strings
+   * @param {Array} options.remoteAgents - Array of remote agent objects
    */
-  render(authenticated, user, tier, permissions, remoteAgents) {
+  render({ authenticated, user, tier, permissions, remoteAgents }) {
     const profileInfo = safeGetElementById(ELEMENT_IDS.PROFILE_INFO);
     const tierInfo = safeGetElementById(ELEMENT_IDS.TIER_INFO);
     const notAuthenticated = safeGetElementById(ELEMENT_IDS.NOT_AUTHENTICATED);

--- a/src/profileView/modules/uiManagers/AgentsTable.js
+++ b/src/profileView/modules/uiManagers/AgentsTable.js
@@ -5,7 +5,6 @@ import { PROFILE_VIEW_COMMANDS } from '@common/webview/commands.js';
 import { vscode } from '@common/webviewContext.js';
 import { safeGetElementById } from '@common/domUtils.js';
 
-
 /**
  * Manages the agents table rendering and interactions.
  */

--- a/src/profileView/modules/uiManagers/AgentsTable.js
+++ b/src/profileView/modules/uiManagers/AgentsTable.js
@@ -80,7 +80,8 @@ export class AgentsTable {
     const tierBadge = safeGetElementById(ELEMENT_IDS.USER_TIER);
     if (tierBadge) {
       tierBadge.textContent = tier;
-      tierBadge.className = `${CLASS_NAMES.TIER_BADGE} ${tier}`;
+      // Normalize tier to lowercase for CSS class consistency
+      tierBadge.className = `${CLASS_NAMES.TIER_BADGE} ${tier.toLowerCase()}`;
     }
 
     // Update tier message based on whether user has any permissions

--- a/src/profileView/modules/uiManagers/AgentsTable.js
+++ b/src/profileView/modules/uiManagers/AgentsTable.js
@@ -5,21 +5,6 @@ import { PROFILE_VIEW_COMMANDS } from '@common/webview/commands.js';
 import { vscode } from '@common/webviewContext.js';
 import { safeGetElementById } from '@common/domUtils.js';
 
-/**
- * Permission constant for accessing remote agents.
- * Matches PERMISSIONS.ACCESS_REMOTE_AGENTS from config.ts
- */
-const PERMISSION_ACCESS_REMOTE_AGENTS = 'access_remote_agents';
-
-/**
- * Check if a permission array includes a specific permission.
- * @param {string[]} permissions - Array of permission strings
- * @param {string} permission - Permission to check for
- * @returns {boolean}
- */
-function hasPermission(permissions, permission) {
-  return Array.isArray(permissions) && permissions.includes(permission);
-}
 
 /**
  * Manages the agents table rendering and interactions.
@@ -99,36 +84,26 @@ export class AgentsTable {
       tierBadge.className = `${CLASS_NAMES.TIER_BADGE} ${tier}`;
     }
 
-    // Update tier message based on permissions (not hardcoded tier check)
+    // Update tier message based on whether user has any permissions
     const tierMessage = safeGetElementById(ELEMENT_IDS.TIER_MESSAGE);
     if (tierMessage) {
-      const canAccessRemote = hasPermission(
-        permissions,
-        PERMISSION_ACCESS_REMOTE_AGENTS,
-      );
-      tierMessage.textContent = canAccessRemote
+      const hasAnyPermissions =
+        Array.isArray(permissions) && permissions.length > 0;
+      tierMessage.textContent = hasAnyPermissions
         ? LABELS.TIER_RESEARCHER_MESSAGE
         : LABELS.TIER_FREE_MESSAGE;
     }
 
-    // Show/hide remote agents section based on permission (not tier)
-    const canAccessRemoteAgents = hasPermission(
-      permissions,
-      PERMISSION_ACCESS_REMOTE_AGENTS,
-    );
+    // Show remote agents section for all authenticated users
+    // RLS filters which agents they can see based on permissions
+    remoteAgentsSection.style.display = 'block';
 
-    if (canAccessRemoteAgents) {
-      remoteAgentsSection.style.display = 'block';
-
-      if (remoteAgents && remoteAgents.length > 0) {
-        this.renderAgentsTable(remoteAgents);
-        noAgentsMessage.style.display = 'none';
-      } else {
-        if (this.container) this.container.innerHTML = '';
-        noAgentsMessage.style.display = 'block';
-      }
+    if (remoteAgents && remoteAgents.length > 0) {
+      this.renderAgentsTable(remoteAgents);
+      noAgentsMessage.style.display = 'none';
     } else {
-      remoteAgentsSection.style.display = 'none';
+      if (this.container) this.container.innerHTML = '';
+      noAgentsMessage.style.display = 'block';
     }
   }
 

--- a/src/profileView/modules/uiManagers/AgentsTable.js
+++ b/src/profileView/modules/uiManagers/AgentsTable.js
@@ -174,11 +174,15 @@ export class AgentsTable {
     const description = row.querySelector('.agent-description');
     if (description) description.textContent = agent.description;
 
-    // Set visibility badge
+    // Set visibility badge (handles both string and array)
     const visibilityBadge = row.querySelector('.visibility-badge');
     if (visibilityBadge) {
-      visibilityBadge.textContent = agent.visibility;
-      visibilityBadge.classList.add(agent.visibility);
+      const visibilityArray = Array.isArray(agent.visibility)
+        ? agent.visibility
+        : [agent.visibility];
+      visibilityBadge.textContent = visibilityArray.join(', ');
+      // Use first visibility value for CSS class
+      visibilityBadge.classList.add(visibilityArray[0] || 'public');
     }
 
     // Set up select button

--- a/src/profileView/styles/index.css
+++ b/src/profileView/styles/index.css
@@ -67,12 +67,12 @@ h2 {
   color: var(--vscode-inputValidation-warningForeground);
 }
 
-.tier-badge.Max {
+.tier-badge.max {
   background: var(--vscode-badge-background);
   color: var(--vscode-badge-foreground);
 }
 
-.tier-badge.Ultra {
+.tier-badge.ultra {
   background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
   color: #ffffff;
 }
@@ -161,16 +161,6 @@ h2 {
 .visibility-badge.public {
   background: var(--vscode-testing-iconPassed);
   color: white;
-}
-
-.visibility-badge.researcher {
-  background: var(--vscode-badge-background);
-  color: var(--vscode-badge-foreground);
-}
-
-.visibility-badge.whitelist {
-  background: var(--vscode-inputValidation-warningBackground);
-  color: var(--vscode-inputValidation-warningForeground);
 }
 
 .visibility-badge.custom {

--- a/src/profileView/styles/index.css
+++ b/src/profileView/styles/index.css
@@ -173,6 +173,11 @@ h2 {
   color: var(--vscode-inputValidation-warningForeground);
 }
 
+.visibility-badge.custom {
+  background: var(--vscode-badge-background);
+  color: var(--vscode-badge-foreground);
+}
+
 /* Type badges */
 .type-badge {
   display: inline-block;

--- a/src/profileView/styles/index.css
+++ b/src/profileView/styles/index.css
@@ -67,6 +67,17 @@ h2 {
   color: var(--vscode-inputValidation-warningForeground);
 }
 
+.tier-badge.Max {
+  background: var(--vscode-badge-background);
+  color: var(--vscode-badge-foreground);
+}
+
+.tier-badge.Ultra {
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  color: #ffffff;
+}
+
+/* Legacy: keep researcher for backwards compat */
 .tier-badge.researcher {
   background: var(--vscode-badge-background);
   color: var(--vscode-badge-foreground);


### PR DESCRIPTION
Replace hardcoded tier checks ('free' | 'researcher') with a flexible permission-based system:

- Add SQL migration for user_groups and user_group_memberships tables
- Add permission helper functions (user_has_permission, get_user_permissions)
- Update SupabaseClient with getUserAuthContext() and getUserPermissions()
- Add permission constants and helper functions in config.ts
- Update ProfileViewMessageHandler to check permissions not tiers
- Update AgentsTable.js UI to use permission checks
- Make RemoteVisibility type extensible (string instead of union)

Benefits:
- New groups can be added via database INSERT (no code changes)
- Permissions are stored in user_groups.permissions array
- RLS policies use dynamic permission checks
- Backwards compatible with existing 'free'/'researcher' users

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces tier-based checks with permission-driven visibility arrays, adds agent categories, updates DB/RLS, client APIs, UI, and docs accordingly.
> 
> - **Backend/DB**
>   - Add `profiles.permissions` (TEXT[]) and new tier constraint (`'free'|'Max'|'Ultra'`).
>   - Convert `remote_agents.visibility` to `TEXT[]`, add GIN indexes, and introduce `agent_category` (`'workflow'|'toolUse'`).
>   - Migrate data (researcher → permissions/tier), add helper `user_has_visibility_access()`, and replace RLS policies to use array overlap (`visibility && permissions`).
>   - Update storage RLS to defense-in-depth using folder-based checks; add fix-up for nested arrays.
> - **Edge Function** (`get-agent-config`)
>   - Return `visibility` (string[]) and `agent_category`; queries align with new schema.
> - **Auth/Client**
>   - Add `UserTier` (`'free'|'Max'|'Ultra'`) and `UserAuthContext` with Zod validation.
>   - Implement `getUserAuthContext()`, `getUserPermissions()`, and refactor `getUserTier()` to use DB profile.
>   - Add `hasVisibilityAccess()` helper.
> - **Agent Loading/Registry**
>   - Update remote metadata to `visibility: string[]` and `agentCategory`.
>   - Map `agent_category` → `AgentCategory`/`AgentType`; default visibility fallback to `['public']`.
> - **Profile View UI**
>   - Show permissions and tier; always render Remote Agents section (RLS filters results).
>   - Update table to display category and multi-value visibility; adjust badges/CSS and messages.
> - **Docs**
>   - Revise guides and Supabase setup to reflect permission-based visibility, agent categories, policies, and examples; rename to “Research Access Program.”
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 56df76b4d6a634c2b994d80b8090e4c3e2a63eef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->