### PR TITLE
Fix webview sandbox security warnings

### DIFF
--- a/src/historyView/index.html
+++ b/src/historyView/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'none'; style-src ${cspSource} vscode-resource: 'unsafe-inline'; script-src 'nonce-${nonce}' https://cdnjs.cloudflare.com; font-src ${cspSource} vscode-resource:;"
+      content="default-src 'none'; style-src ${cspSource} vscode-resource: 'unsafe-inline'; script-src 'nonce-${nonce}' https://cdnjs.cloudflare.com https://esm.sh; connect-src https://cdnjs.cloudflare.com https://esm.sh; font-src ${cspSource} vscode-resource:;"
     />
     <link rel="stylesheet" href="${commonStyleUri}" />
     <link rel="stylesheet" href="${styleUri}" />

--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'none'; style-src ${cspSource} vscode-resource: 'unsafe-inline' https://cdn.jsdelivr.net; script-src 'nonce-${nonce}' https://esm.sh; font-src ${cspSource} vscode-resource: https://cdn.jsdelivr.net; img-src ${cspSource} data: https:;"
+      content="default-src 'none'; style-src ${cspSource} vscode-resource: 'unsafe-inline' https://cdn.jsdelivr.net; script-src 'nonce-${nonce}' https://esm.sh; connect-src https://esm.sh; font-src ${cspSource} vscode-resource: https://cdn.jsdelivr.net; img-src ${cspSource} data: https:;"
     />
     <link rel="stylesheet" href="${commonStyleUri}" />
     <link rel="stylesheet" href="${styleUri}" />

--- a/src/webview/index.html
+++ b/src/webview/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'none'; style-src ${cspSource} vscode-resource: 'unsafe-inline'; script-src 'nonce-${nonce}' https://cdnjs.cloudflare.com https://unpkg.com; img-src https: vscode-resource:; font-src ${cspSource} vscode-resource:;"
+      content="default-src 'none'; style-src ${cspSource} vscode-resource: 'unsafe-inline'; script-src 'nonce-${nonce}' https://cdnjs.cloudflare.com https://unpkg.com; connect-src https://cdnjs.cloudflare.com https://unpkg.com; img-src https: vscode-resource:; font-src ${cspSource} vscode-resource:;"
     />
     <link rel="stylesheet" href="${commonStyleUri}" />
     <link rel="stylesheet" href="${styleUri}" />


### PR DESCRIPTION
- Add connect-src https://esm.sh to progressView and historyView
- Add connect-src https://unpkg.com to mainView
- Add https://esm.sh to script-src in historyView (was missing but used in importmap for 'he' library)

These changes fix CSP violations that were causing console errors when loading source maps from external CDNs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update CSP in webviews to permit connections to esm.sh, unpkg, and cdnjs, and include esm.sh in historyView script-src to eliminate CSP console errors.
> 
> - **CSP updates**:
>   - `src/historyView/index.html`:
>     - Add `https://esm.sh` to `script-src`.
>     - Add `connect-src https://cdnjs.cloudflare.com https://esm.sh`.
>   - `src/progressView/index.html`:
>     - Add `connect-src https://esm.sh`.
>   - `src/webview/index.html`:
>     - Add `connect-src https://cdnjs.cloudflare.com https://unpkg.com`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ce5a47bf481d49a9b17e14e6b74a99e59b115f05. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->