### PR TITLE
Move transcribe_audio function to remote

### DIFF
--- a/docs/supabase/ADD_TRANSCRIBE_AUDIO_REMOTE.sql
+++ b/docs/supabase/ADD_TRANSCRIBE_AUDIO_REMOTE.sql
@@ -1,0 +1,23 @@
+-- Migration: Add transcribe_audio as a remote agent
+--
+-- Prerequisites:
+-- 1. Upload the transcribe_audio.yaml file to Supabase Storage:
+--    - Copy from: resources/agents/transcribe_audio.yaml
+--    - Upload to: Storage > agent-configs > researcher/transcribe_audio.yaml
+--
+-- Then run this SQL in Supabase SQL Editor:
+
+-- Insert the transcribe_audio agent metadata
+INSERT INTO remote_agents (name, description, storage_path, visibility, agent_type)
+VALUES (
+  'transcribe_audio',
+  'Transcribes audio with speaker identification and LaTeX math formatting',
+  'researcher/transcribe_audio.yaml',
+  'researcher',
+  'CoT'
+);
+
+-- Verify the insertion
+SELECT id, name, description, visibility, agent_type, storage_path
+FROM remote_agents
+WHERE name = 'transcribe_audio';

--- a/docs/supabase/SUPABASE_SETUP.md
+++ b/docs/supabase/SUPABASE_SETUP.md
@@ -199,6 +199,7 @@ CREATE TABLE remote_agents (
   description TEXT,
   storage_path TEXT NOT NULL,
   visibility TEXT DEFAULT 'researcher' CHECK (visibility IN ('public', 'researcher', 'whitelist')),
+  agent_type TEXT DEFAULT 'CoT' CHECK (agent_type IN ('CoT', 'direct', 'toolUse')),
   created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
   updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );
@@ -533,12 +534,13 @@ The extension will now use the configured credentials. Users don't need to confi
 In **SQL Editor**, run:
 
 ```sql
-INSERT INTO remote_agents (name, description, storage_path, visibility)
+INSERT INTO remote_agents (name, description, storage_path, visibility, agent_type)
 VALUES (
   'advanced-researcher',
   'AI-powered research assistant for academic papers',
   'researcher/advanced-researcher.yaml',
-  'researcher'
+  'researcher',
+  'CoT'
 );
 ```
 


### PR DESCRIPTION
Add SQL migration file for deploying transcribe_audio as a remote agent. Also document the agent_type column in remote_agents table schema.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a SQL migration to register `transcribe_audio` as a remote agent and updates setup docs to include the `agent_type` column and example insert.
> 
> - **Supabase**:
>   - **Migration**: Add `docs/supabase/ADD_TRANSCRIBE_AUDIO_REMOTE.sql` to insert `transcribe_audio` into `remote_agents` (with `agent_type='CoT'`) and a verification query.
>   - **Docs update** (`docs/supabase/SUPABASE_SETUP.md`):
>     - Add `agent_type` column to `remote_agents` schema (default `CoT`, check constraint).
>     - Update example `INSERT INTO remote_agents` to include `agent_type`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e78fa5b004436d363006adca29c5c91d427f142f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->