### PR TITLE
Set up Supabase authentication and stream management

### DIFF
--- a/docs/supabase/SUPABASE_SETUP.md
+++ b/docs/supabase/SUPABASE_SETUP.md
@@ -385,17 +385,24 @@ serve(async (req) => {
       });
     }
 
-    const supabase = createClient(
-      Deno.env.get('SUPABASE_URL')!,
-      Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!,
-      { global: { headers: { Authorization: authHeader } } },
-    );
+    const supabaseUrl = Deno.env.get('SUPABASE_URL')!;
+    const serviceRoleKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
 
-    // Verify user
+    // User client: uses user's JWT for auth verification and RLS-protected queries
+    // This ensures RLS policies on remote_agents table are enforced
+    const userClient = createClient(supabaseUrl, serviceRoleKey, {
+      global: { headers: { Authorization: authHeader } },
+    });
+
+    // Admin client: uses only SERVICE_ROLE_KEY for storage operations
+    // This bypasses bucket policies (safe because we already verify access via RLS)
+    const adminClient = createClient(supabaseUrl, serviceRoleKey);
+
+    // Verify user with their JWT
     const {
       data: { user },
       error: userError,
-    } = await supabase.auth.getUser();
+    } = await userClient.auth.getUser();
     if (userError || !user) {
       return new Response(JSON.stringify({ error: 'Invalid token' }), {
         status: 401,
@@ -412,8 +419,9 @@ serve(async (req) => {
       });
     }
 
-    // Fetch agent metadata (RLS enforces access control)
-    const { data: agent, error: agentError } = await supabase
+    // Fetch agent metadata using userClient (RLS enforces access control)
+    // RLS policies check user tier/whitelist - unauthorized users won't see the agent
+    const { data: agent, error: agentError } = await userClient
       .from('remote_agents')
       .select('id, name, description, storage_path')
       .eq('name', agentName)
@@ -431,8 +439,9 @@ serve(async (req) => {
       );
     }
 
-    // Fetch YAML from storage (RLS policy enforces access)
-    const { data: fileData, error: storageError } = await supabase.storage
+    // Fetch YAML from storage using adminClient (bypasses bucket policies)
+    // Safe because access was already verified via RLS on remote_agents table
+    const { data: fileData, error: storageError } = await adminClient.storage
       .from('agent-configs')
       .download(agent.storage_path);
 


### PR DESCRIPTION
…nction

The Edge Function was using a single Supabase client with the user's Authorization header passed globally, which caused storage downloads to fail. Storage bucket policies don't allow direct user access.

Fix by using two separate clients:
- userClient: for auth verification and RLS-protected table queries
- adminClient: for storage downloads (bypasses bucket policies)

This is safe because access is still verified via RLS on remote_agents table before the storage download is attempted.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors the documented Edge Function to use a user-authenticated client for RLS-guarded queries and a service-role admin client for storage downloads, resolving bucket policy access issues.
> 
> - **Docs (Supabase Setup)**:
>   - **Edge Function (`get-agent-config`)**:
>     - Split single `supabase` client into two:
>       - `userClient` (with `Authorization` header) for `auth.getUser()` and RLS-protected `remote_agents` queries.
>       - `adminClient` (service role only) for `storage.from('agent-configs').download(...)`.
>     - Extract `SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY` to variables and initialize clients explicitly.
>     - Clarify comments around RLS enforcement and bucket policy bypass for storage operations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a17ce60115e7f25de1edd7c9a2a5ec6ab2d9c9a0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->