### PR TITLE
fix(agent): improve profile view agent selection reliability

### DIFF
--- a/src/agent/remote/remoteAgentUtils.ts
+++ b/src/agent/remote/remoteAgentUtils.ts
@@ -57,6 +57,14 @@ async function handleSelectionFallback(
 }
 
 /**
+ * Small delay to allow webview to initialize after focus.
+ * This helps ensure the webview's message handlers are ready.
+ */
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
  * Select an agent in the main webview's dropdown.
  * This is the single source of truth for agent selection across the extension.
  *
@@ -81,8 +89,12 @@ export async function selectAgentInMainView(
   // Format agent value as source:name for dropdown selection
   const agentValue = createKey(source as AgentSource, agentName);
 
-  // Focus the main view first
+  // Focus the main view first - this reveals it and triggers initialization if needed
   await vscode.commands.executeCommand('texra.mainView.focus');
+
+  // Small delay to ensure webview has time to initialize if it was just revealed
+  // This helps prevent race conditions where the message arrives before handlers are ready
+  await delay(100);
 
   try {
     const webviewView = await vscode.commands.executeCommand<
@@ -95,6 +107,11 @@ export async function selectAgentInMainView(
       const sessionType =
         entry?.category === AgentCategory.ToolUse ? 'toolUse' : 'workflow';
 
+      logger.info(
+        CHANNEL,
+        `Selecting agent "${agentName}" (${agentValue}) in ${sessionType} dropdown`,
+      );
+
       // Send SET_SELECTED_AGENT message to set just the agent selector value
       // This avoids triggering full state restoration which would clear other fields
       webviewView.webview.postMessage({
@@ -105,7 +122,7 @@ export async function selectAgentInMainView(
 
       if (showSuccessMessage) {
         void vscode.window.showInformationMessage(
-          `Agent "${agentName}" is now selected.`,
+          `Agent "${agentName}" is now selected in the main view.`,
         );
       }
 


### PR DESCRIPTION
- Add small delay after main view focus to ensure webview is ready
- Add logging to help debug agent selection issues
- Update success message to clarify agent is selected in main view

The delay helps prevent race conditions where the SET_SELECTED_AGENT
message arrives before the webview's handlers are registered.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a short post-focus delay and logging to stabilize agent selection in the main webview, and clarifies the success message.
> 
> - **Remote agent selection (`src/agent/remote/remoteAgentUtils.ts`)**:
>   - **Stability**: Insert small delay (`delay(100)`) after `texra.mainView.focus` to allow webview initialization.
>   - **Logging**: Add `logger.info` detailing selected agent and session type.
>   - **UX**: Update success toast to specify selection is "in the main view".
>   - *Misc*: Clarify comments around view focusing and initialization.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0331f3a5723c2ee80537892d5e32262768b6e7fd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->