### PR TITLE
feat(tools): add native Zod schema support for SDK tool conversions

### DIFF
--- a/src/agent/modelHandlers/toolConversion.ts
+++ b/src/agent/modelHandlers/toolConversion.ts
@@ -1,4 +1,8 @@
 // Third-party imports
+import { toJSONSchema } from 'zod';
+import { zodFunction, zodResponsesFunction } from 'openai/helpers/zod';
+
+// Type imports
 import type { ToolDefinition } from '@model';
 import type {
   Tool as AnthropicTool,
@@ -45,16 +49,34 @@ const ANTHROPIC_TOOL_TYPE_MAP: Record<string, string> = {
   web_search: 'web_search_20250305',
 } as const;
 
-/** Convert generic ToolDefinition objects to OpenAI ChatCompletionTool format. */
+/**
+ * Convert generic ToolDefinition objects to OpenAI ChatCompletionTool format.
+ *
+ * When a tool has a zodSchema, uses OpenAI's native zodFunction() helper which:
+ * - Converts Zod schema to JSON Schema using SDK's optimized conversion
+ * - Enables strict mode for better type safety
+ */
 export function toOpenAITools(defs: ToolDefinition[]): ChatCompletionTool[] {
-  return defs.map((d) => ({
-    type: 'function',
-    function: {
-      name: d.name,
-      description: d.description,
-      parameters: d.parameters,
-    },
-  }));
+  return defs.map((d) => {
+    // Use native SDK Zod conversion when schema is available
+    if (d.zodSchema) {
+      return zodFunction({
+        name: d.name,
+        description: d.description,
+        parameters: d.zodSchema,
+      }) as unknown as ChatCompletionTool;
+    }
+
+    // Fallback to manual conversion for legacy definitions
+    return {
+      type: 'function',
+      function: {
+        name: d.name,
+        description: d.description,
+        parameters: d.parameters,
+      },
+    };
+  });
 }
 
 /**
@@ -67,7 +89,13 @@ export interface OpenAIResponseToolOptions {
   supportsFunctionCalling?: boolean;
 }
 
-/** Convert generic ToolDefinition objects to OpenAI Responses API tool format. */
+/**
+ * Convert generic ToolDefinition objects to OpenAI Responses API tool format.
+ *
+ * When a tool has a zodSchema, uses OpenAI's native zodResponsesFunction() helper which:
+ * - Converts Zod schema to JSON Schema using SDK's optimized conversion
+ * - Enables strict mode for better type safety
+ */
 export function toOpenAIResponseTools(
   defs: ToolDefinition[],
   options: OpenAIResponseToolOptions = {},
@@ -94,7 +122,19 @@ export function toOpenAIResponseTools(
       continue;
     }
 
-    // Standard function tools
+    // Use native SDK Zod conversion when schema is available
+    if (d.zodSchema) {
+      tools.push(
+        zodResponsesFunction({
+          name: d.name,
+          description: d.description,
+          parameters: d.zodSchema,
+        }) as unknown as OpenAIResponseTool,
+      );
+      continue;
+    }
+
+    // Fallback to manual conversion for legacy definitions
     const params = (d.parameters ?? null) as Record<string, unknown> | null;
     tools.push({
       type: 'function',
@@ -119,7 +159,13 @@ export interface AnthropicToolOptions {
   supportsNativeWebSearch?: boolean;
 }
 
-/** Convert generic ToolDefinition objects to Anthropic Tool format. */
+/**
+ * Convert generic ToolDefinition objects to Anthropic Tool format.
+ *
+ * When a tool has a zodSchema, uses Zod's native toJSONSchema() which:
+ * - Converts Zod schema directly to JSON Schema
+ * - Uses the same conversion pattern as Anthropic's betaZodTool() helper
+ */
 export function toAnthropicTools(
   defs: ToolDefinition[],
   options: AnthropicToolOptions = {},
@@ -141,6 +187,18 @@ export function toAnthropicTools(
       }
     }
 
+    // Use native Zod conversion when schema is available
+    // This mirrors the Anthropic SDK's betaZodTool() implementation
+    if (d.zodSchema) {
+      const jsonSchema = toJSONSchema(d.zodSchema, { reused: 'ref' });
+      return {
+        name: d.name,
+        description: d.description,
+        input_schema: jsonSchema as AnthropicTool['input_schema'],
+      } as ToolUnion;
+    }
+
+    // Fallback to pre-converted parameters for legacy definitions
     const params = d.parameters as AnthropicTool['input_schema'] | undefined;
     return {
       name: d.name,
@@ -158,6 +216,7 @@ export function toAnthropicTools(
  * functionDeclarations - this is a Live API only feature.
  * See: https://ai.google.dev/gemini-api/docs/live-tools
  *
+ * When a tool has a zodSchema, uses Zod's native toJSONSchema() for conversion.
  * All tools (including web_search) are converted to function declarations.
  *
  * @param defs Tool definitions to convert
@@ -169,11 +228,23 @@ export function toGoogleTools(defs: ToolDefinition[]): GeminiTool[] {
 
   // Convert all tools to function declarations
   // Native googleSearch is disabled until Live API support is added
-  const declarations: FunctionDeclaration[] = defs.map((d) => ({
-    name: d.name,
-    description: d.description,
-    parameters: d.parameters as Schema | undefined,
-  }));
+  const declarations: FunctionDeclaration[] = defs.map((d) => {
+    // Use native Zod conversion when schema is available
+    if (d.zodSchema) {
+      return {
+        name: d.name,
+        description: d.description,
+        parameters: toJSONSchema(d.zodSchema) as Schema | undefined,
+      };
+    }
+
+    // Fallback to pre-converted parameters for legacy definitions
+    return {
+      name: d.name,
+      description: d.description,
+      parameters: d.parameters as Schema | undefined,
+    };
+  });
 
   return [{ functionDeclarations: declarations }];
 }

--- a/src/agent/modelHandlers/toolConversion.ts
+++ b/src/agent/modelHandlers/toolConversion.ts
@@ -1,6 +1,6 @@
 // Third-party imports
 import { toJSONSchema } from 'zod';
-import { zodFunction, zodResponsesFunction } from 'openai/helpers/zod';
+import { zodFunction } from 'openai/helpers/zod';
 
 // Type imports
 import type { ToolDefinition } from '@model';
@@ -55,6 +55,9 @@ const ANTHROPIC_TOOL_TYPE_MAP: Record<string, string> = {
  * When a tool has a zodSchema, uses OpenAI's native zodFunction() helper which:
  * - Converts Zod schema to JSON Schema using SDK's optimized conversion
  * - Enables strict mode for better type safety
+ *
+ * Note: zodFunction() may throw for invalid schemas - this is intentional fail-fast
+ * behavior since invalid tool schemas are programming errors caught during development.
  */
 export function toOpenAITools(defs: ToolDefinition[]): ChatCompletionTool[] {
   return defs.map((d) => {
@@ -94,9 +97,12 @@ export interface OpenAIResponseToolOptions {
 /**
  * Convert generic ToolDefinition objects to OpenAI Responses API tool format.
  *
- * When a tool has a zodSchema, uses OpenAI's native zodResponsesFunction() helper which:
- * - Converts Zod schema to JSON Schema using SDK's optimized conversion
- * - Enables strict mode for better type safety
+ * NOTE: We intentionally don't use zodResponsesFunction() here because it enables
+ * strict mode, which requires all parameters to be required. Tools like Wolfram
+ * have optional fields, so we must use strict: false for the Responses API.
+ *
+ * When a tool has a zodSchema, we use Zod's native toJSONSchema() for conversion
+ * while keeping strict: false for compatibility with optional parameters.
  */
 export function toOpenAIResponseTools(
   defs: ToolDefinition[],
@@ -124,30 +130,20 @@ export function toOpenAIResponseTools(
       continue;
     }
 
-    // Use native SDK Zod conversion when schema is available
-    // zodResponsesFunction() returns AutoParseableResponseTool which extends FunctionTool
-    // with additional parsing metadata - structurally compatible with OpenAIResponseTool
-    if (d.zodSchema) {
-      tools.push(
-        zodResponsesFunction({
-          name: d.name,
-          description: d.description,
-          parameters: d.zodSchema,
-        }) as OpenAIResponseTool,
-      );
-      continue;
-    }
+    // Use native Zod conversion when schema is available, but keep strict: false
+    // to support tools with optional parameters (e.g., Wolfram timeout field)
+    const params = d.zodSchema
+      ? (toJSONSchema(d.zodSchema) as Record<string, unknown> | null)
+      : ((d.parameters ?? null) as Record<string, unknown> | null);
 
-    // Fallback to manual conversion for legacy definitions
-    const params = (d.parameters ?? null) as Record<string, unknown> | null;
     tools.push({
       type: 'function',
       name: d.name,
       description: d.description,
       parameters: params,
       // Setting strict=true requires an explicit `required` array covering all
-      // parameters. The Wolfram tool uses optional fields, so disable strict
-      // validation to avoid schema errors from the OpenAI Responses API.
+      // parameters. Tools with optional fields need strict: false to avoid
+      // OpenAI Responses API schema errors.
       strict: false,
     } as FunctionTool);
   }

--- a/src/agent/modelHandlers/toolConversion.ts
+++ b/src/agent/modelHandlers/toolConversion.ts
@@ -59,12 +59,14 @@ const ANTHROPIC_TOOL_TYPE_MAP: Record<string, string> = {
 export function toOpenAITools(defs: ToolDefinition[]): ChatCompletionTool[] {
   return defs.map((d) => {
     // Use native SDK Zod conversion when schema is available
+    // zodFunction() returns AutoParseableTool which extends ChatCompletionFunctionTool
+    // with additional parsing metadata - structurally compatible with ChatCompletionTool
     if (d.zodSchema) {
       return zodFunction({
         name: d.name,
         description: d.description,
         parameters: d.zodSchema,
-      }) as unknown as ChatCompletionTool;
+      }) as ChatCompletionTool;
     }
 
     // Fallback to manual conversion for legacy definitions
@@ -123,13 +125,15 @@ export function toOpenAIResponseTools(
     }
 
     // Use native SDK Zod conversion when schema is available
+    // zodResponsesFunction() returns AutoParseableResponseTool which extends FunctionTool
+    // with additional parsing metadata - structurally compatible with OpenAIResponseTool
     if (d.zodSchema) {
       tools.push(
         zodResponsesFunction({
           name: d.name,
           description: d.description,
           parameters: d.zodSchema,
-        }) as unknown as OpenAIResponseTool,
+        }) as OpenAIResponseTool,
       );
       continue;
     }

--- a/src/model/ToolDefinition.ts
+++ b/src/model/ToolDefinition.ts
@@ -7,28 +7,27 @@ import type { Tool as AnthropicTool } from '@anthropic-ai/sdk/resources/messages
 import type { Schema as GeminiSchema } from '@google/genai/dist/genai';
 
 /**
- * Zod schema describing a tool/function that a provider can execute.
+ * Zod schema for validating tool definitions from YAML configs and external sources.
  *
- * Uses passthrough() to allow runtime-only fields like zodSchema which are
- * not part of the serialized schema but are added to tool definitions at runtime.
+ * Note: The zodSchema field is a runtime-only property added by defineTool() and
+ * is not part of this validation schema. It's only present on the TypeScript type.
  */
-export const ToolDefinitionSchema = z
-  .object({
-    /** Name of the tool or function */
-    name: z.string(),
-    /** Optional description for the model */
-    description: z.string().optional(),
-    /** Parameter schema or provider specific metadata */
-    parameters: z.record(z.string(), z.unknown()).optional(),
-  })
-  .passthrough();
+export const ToolDefinitionSchema = z.strictObject({
+  /** Name of the tool or function */
+  name: z.string(),
+  /** Optional description for the model */
+  description: z.string().optional(),
+  /** Parameter schema or provider specific metadata */
+  parameters: z.record(z.string(), z.unknown()).optional(),
+});
 
 /**
  * Generic tool definition used across model providers. The parameters field
  * aligns with OpenAI, Anthropic and Google Gemini function schemas.
  *
- * When zodSchema is provided, SDK-native Zod helpers can be used for conversion,
- * avoiding manual JSON Schema transformation and enabling SDK-specific optimizations.
+ * This type extends the validated schema with:
+ * - Provider-specific parameter types for better type inference
+ * - Runtime-only zodSchema field (added by defineTool(), not from YAML)
  */
 export type ToolDefinition = z.infer<typeof ToolDefinitionSchema> & {
   parameters?:
@@ -36,10 +35,9 @@ export type ToolDefinition = z.infer<typeof ToolDefinitionSchema> & {
     | AnthropicTool['input_schema']
     | GeminiSchema;
   /**
-   * Original Zod schema for SDK-native Zod support.
-   * When present, conversion functions can use SDK helpers like:
-   * - OpenAI: zodFunction() / zodResponsesFunction()
-   * - Anthropic: betaZodTool() pattern (z.toJSONSchema)
+   * Original Zod schema for SDK-native Zod support (runtime-only, not serialized).
+   * When present, conversion functions use native toJSONSchema() for conversion.
+   * Added by defineTool() - not present in YAML configs or validated by schema.
    */
   zodSchema?: ZodType;
 };

--- a/src/model/ToolDefinition.ts
+++ b/src/model/ToolDefinition.ts
@@ -1,5 +1,5 @@
 // Third-party imports
-import { z } from 'zod';
+import { z, type ZodType } from 'zod';
 
 // Third-party imports - provider tool definitions
 import type { FunctionDefinition } from 'openai/resources/shared';
@@ -19,10 +19,20 @@ export const ToolDefinitionSchema = z.strictObject({
 /**
  * Generic tool definition used across model providers. The parameters field
  * aligns with OpenAI, Anthropic and Google Gemini function schemas.
+ *
+ * When zodSchema is provided, SDK-native Zod helpers can be used for conversion,
+ * avoiding manual JSON Schema transformation and enabling SDK-specific optimizations.
  */
 export type ToolDefinition = z.infer<typeof ToolDefinitionSchema> & {
   parameters?:
     | FunctionDefinition['parameters']
     | AnthropicTool['input_schema']
     | GeminiSchema;
+  /**
+   * Original Zod schema for SDK-native Zod support.
+   * When present, conversion functions can use SDK helpers like:
+   * - OpenAI: zodFunction() / zodResponsesFunction()
+   * - Anthropic: betaZodTool() pattern (z.toJSONSchema)
+   */
+  zodSchema?: ZodType;
 };

--- a/src/model/ToolDefinition.ts
+++ b/src/model/ToolDefinition.ts
@@ -6,15 +6,22 @@ import type { FunctionDefinition } from 'openai/resources/shared';
 import type { Tool as AnthropicTool } from '@anthropic-ai/sdk/resources/messages/messages';
 import type { Schema as GeminiSchema } from '@google/genai/dist/genai';
 
-/** Zod schema describing a tool/function that a provider can execute. */
-export const ToolDefinitionSchema = z.strictObject({
-  /** Name of the tool or function */
-  name: z.string(),
-  /** Optional description for the model */
-  description: z.string().optional(),
-  /** Parameter schema or provider specific metadata */
-  parameters: z.record(z.string(), z.unknown()).optional(),
-});
+/**
+ * Zod schema describing a tool/function that a provider can execute.
+ *
+ * Uses passthrough() to allow runtime-only fields like zodSchema which are
+ * not part of the serialized schema but are added to tool definitions at runtime.
+ */
+export const ToolDefinitionSchema = z
+  .object({
+    /** Name of the tool or function */
+    name: z.string(),
+    /** Optional description for the model */
+    description: z.string().optional(),
+    /** Parameter schema or provider specific metadata */
+    parameters: z.record(z.string(), z.unknown()).optional(),
+  })
+  .passthrough();
 
 /**
  * Generic tool definition used across model providers. The parameters field

--- a/src/tools/core/define.ts
+++ b/src/tools/core/define.ts
@@ -20,6 +20,8 @@ export function defineTool<T>(def: {
       unrepresentable: 'any',
       io: 'input',
     }) as Record<string, unknown>,
+    // Include original Zod schema for SDK-native conversions (OpenAI, Anthropic)
+    zodSchema: def.schema,
   };
 
   abstract class GeneratedTool extends BaseTool<T> {


### PR DESCRIPTION
Add zodSchema field to ToolDefinition for SDK-native Zod support:
- OpenAI: Use zodFunction() and zodResponsesFunction() helpers
- Anthropic: Use Zod's native toJSONSchema() (same as betaZodTool)
- Google: Use Zod's native toJSONSchema() for Gemini tools

This enables SDK-optimized conversions (e.g., strict mode for OpenAI)
while maintaining backward compatibility with legacy definitions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `zodSchema` to `ToolDefinition` and updates OpenAI/Anthropic/Google tool conversions to use native Zod helpers with legacy fallback and appropriate strictness.
> 
> - **Core type & tooling**
>   - Add runtime-only `zodSchema` to `ToolDefinition` (`src/model/ToolDefinition.ts`).
>   - `defineTool()` now preserves original Zod schema and JSON Schema params (`src/tools/core/define.ts`).
> - **Provider conversions** (`src/agent/modelHandlers/toolConversion.ts`):
>   - **OpenAI (Chat Completions)**: Use `zodFunction()` when `zodSchema` is present; fallback to existing `parameters`.
>   - **OpenAI (Responses API)**: Convert via `toJSONSchema()` when `zodSchema` exists; keep `strict: false`; support native `web_search` toggle.
>   - **Anthropic**: Use `toJSONSchema()` (with `{ reused: 'ref' }`) for `input_schema`; respect native tool types (e.g., `web_search`) when enabled.
>   - **Google Gemini**: Convert to function declarations using `toJSONSchema()` when available; otherwise use legacy `parameters`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c5ab028adc0a05aa0cbe26626ac62c3fb3f8663f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->