### PR TITLE
refactor(remote): use shared sleep utility instead of local delay function

### DIFF
--- a/src/agent/node/index.ts
+++ b/src/agent/node/index.ts
@@ -1,3 +1,5 @@
+import { sleep } from '@utils/helpers';
+
 type NonIterableObject = Partial<Record<string, unknown>> & {
   [Symbol.iterator]?: never;
 };
@@ -108,8 +110,7 @@ class Node<
         const isAborted = this.signal?.aborted === true;
         if (this.currentRetry === this.maxRetries - 1 || isAborted)
           return await this.execFallback(prepRes, e as Error);
-        if (this.wait > 0)
-          await new Promise((resolve) => setTimeout(resolve, this.wait * 1000));
+        if (this.wait > 0) await sleep(this.wait * 1000);
       }
     }
     return undefined;

--- a/src/agent/remote/remoteAgentUtils.ts
+++ b/src/agent/remote/remoteAgentUtils.ts
@@ -11,6 +11,9 @@ import { MAIN_VIEW_COMMANDS } from '@common/webview';
 // Local imports - logger
 import * as logger from '@logger/logUtils';
 
+// Local imports - utils
+import { sleep } from '@utils/helpers';
+
 const CHANNEL = 'RemoteAgentUtils';
 logger.initialize(CHANNEL);
 
@@ -57,14 +60,6 @@ async function handleSelectionFallback(
 }
 
 /**
- * Small delay to allow webview to initialize after focus.
- * This helps ensure the webview's message handlers are ready.
- */
-function delay(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-/**
  * Select an agent in the main webview's dropdown.
  * This is the single source of truth for agent selection across the extension.
  *
@@ -94,7 +89,7 @@ export async function selectAgentInMainView(
 
   // Small delay to ensure webview has time to initialize if it was just revealed
   // This helps prevent race conditions where the message arrives before handlers are ready
-  await delay(100);
+  await sleep(100);
 
   try {
     const webviewView = await vscode.commands.executeCommand<

--- a/src/frontend/media/audio.ts
+++ b/src/frontend/media/audio.ts
@@ -11,6 +11,7 @@ import { getSdkErrorMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
 import { MODEL_CONFIGS } from '@model/ModelRegistry';
 import { AbsoluteFS, StorageFS } from '@utils/files';
+import { sleep } from '@utils/helpers';
 import { THREE_DAYS_MS } from '@utils/config';
 import { getConfig } from '@utils/config/configUtils';
 import { checkToolInstalled } from '@utils/system/toolUtils';
@@ -164,7 +165,7 @@ export async function stopRecordingAndTranscribe(
     activeRecordingPath = null;
 
     // Wait a bit for the file to be properly written
-    await new Promise((resolve) => setTimeout(resolve, 500));
+    await sleep(500);
 
     // Check if the file exists and has content
     if (!AbsoluteFS.existsSync(recordingPath)) {

--- a/src/tools/citation/rateLimiter.ts
+++ b/src/tools/citation/rateLimiter.ts
@@ -1,3 +1,5 @@
+import { sleep } from '@utils/helpers';
+
 /**
  * Simple rate limiter to respect API rate limits for academic metadata services.
  * Ensures minimum delay between consecutive requests to the same API.
@@ -26,7 +28,7 @@ export async function waitForRateLimit(
 
   if (timeSinceLastRequest < minDelayMs) {
     const waitTime = minDelayMs - timeSinceLastRequest;
-    await new Promise((resolve) => setTimeout(resolve, waitTime));
+    await sleep(waitTime);
     // Use calculated time to avoid drift from async operations
     state.lastRequestTime = now + waitTime;
   } else {


### PR DESCRIPTION
Replace the local delay() function with the existing sleep() utility from
@utils/helpers to follow the Single Source of Truth principle and avoid
code duplication.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace setTimeout/delay usages with shared `sleep()` in retry logic, webview init, audio finalization, and API rate limiting.
> 
> - **Refactor: unify delays via `@utils/helpers#sleep`**
>   - `src/agent/node/index.ts`: Retry backoff in `Node._exec` now uses `sleep`.
>   - `src/agent/remote/remoteAgentUtils.ts`: Remove local `delay()`; webview init wait uses `sleep`.
>   - `src/frontend/media/audio.ts`: Post-stop recording wait uses `sleep`.
>   - `src/tools/citation/rateLimiter.ts`: Rate limiter wait uses `sleep`.
>   - Added corresponding `sleep` imports where used.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 188418463350ea894b8274b3f8758341701d86b9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->