### PR TITLE
refactor: replace forEach loops with native methods

### DIFF
--- a/src/agent/modelHandlers/modelHandlerDeepSeek.ts
+++ b/src/agent/modelHandlers/modelHandlerDeepSeek.ts
@@ -220,20 +220,14 @@ export class ModelHandlerDeepSeek extends ModelHandlerOpenAI<DeepSeekToolCall> {
 
     // Type assertion needed: DeepSeekAssistantMessage extends ChatCompletionAssistantMessageParam
     // with reasoning_content field that OpenAI's types don't know about
-    const messages: ChatCompletionMessageParam[] = [
-      callMsg as ChatCompletionMessageParam,
-    ];
+    // Build tool result messages (results are already sanitized by source)
+    const toolResultMessages = toolCalls.map((call, i) => ({
+      role: 'tool' as const,
+      tool_call_id: call.id,
+      content: JSON.stringify(results[i]),
+    }));
 
-    // Add individual tool result messages (results are already sanitized by source)
-    for (let i = 0; i < toolCalls.length; i++) {
-      messages.push({
-        role: 'tool' as const,
-        tool_call_id: toolCalls[i].id,
-        content: JSON.stringify(results[i]),
-      });
-    }
-
-    return messages;
+    return [callMsg as ChatCompletionMessageParam, ...toolResultMessages];
   }
 
   /**

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -1370,24 +1370,17 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
     }
 
     // Build all function call parts (preserving thought signature on first call)
-    const callParts: Part[] = [];
-    if (text) {
-      callParts.push(createPartFromText(text));
-    }
-    for (const call of calls) {
-      callParts.push(this.buildFunctionCallPart(call));
-    }
+    const callParts: Part[] = [
+      ...(text ? [createPartFromText(text)] : []),
+      ...calls.map((call) => this.buildFunctionCallPart(call)),
+    ];
 
-    // Build all function response parts
-    const responseParts: Part[] = [];
-    for (let i = 0; i < calls.length; i++) {
-      const part = await this.buildFunctionResponsePart(
-        calls[i],
-        results[i],
-        attachmentsPerCall[i],
-      );
-      responseParts.push(part);
-    }
+    // Build all function response parts in parallel
+    const responseParts = await Promise.all(
+      calls.map((call, i) =>
+        this.buildFunctionResponsePart(call, results[i], attachmentsPerCall[i]),
+      ),
+    );
 
     // Use SDK helpers for Content creation (single source of truth)
     const callMsg = createModelContent(callParts);

--- a/src/agent/utils/mergeFileUtils.ts
+++ b/src/agent/utils/mergeFileUtils.ts
@@ -32,16 +32,13 @@ export function extractAgentName(
     return parts[1];
   }
 
-  // Complex format - collect parts until round number
-  const agentParts: string[] = [];
-  for (let i = 1; i < parts.length; i++) {
-    const part = parts[i];
-    if (part.startsWith('r') && /^\d+$/.test(part.slice(1))) {
-      return agentParts.join('_');
-    }
-    agentParts.push(part);
-  }
-  return null;
+  // Complex format - find round number index and join parts before it
+  const partsAfterBase = parts.slice(1);
+  const roundIndex = partsAfterBase.findIndex(
+    (part) => part.startsWith('r') && /^\d+$/.test(part.slice(1)),
+  );
+
+  return roundIndex !== -1 ? partsAfterBase.slice(0, roundIndex).join('_') : null;
 }
 
 /**

--- a/src/latex/LatexMediaManager.ts
+++ b/src/latex/LatexMediaManager.ts
@@ -172,13 +172,9 @@ export class LatexMediaManager {
 
     const mirrorTasks: Promise<void>[] = [];
 
-    for (let idx = 0; idx < figureResults.length; idx++) {
-      const result = figureResults[idx];
-      if (
-        result.status !== 'fulfilled' ||
-        !result.value ||
-        result.value.length === 0
-      ) {
+    // Process fulfilled results with non-empty values
+    for (const [idx, result] of figureResults.entries()) {
+      if (result.status !== 'fulfilled' || !result.value?.length) {
         continue;
       }
 
@@ -207,14 +203,14 @@ export class LatexMediaManager {
         })),
       );
 
-      for (const { loc, exists } of existenceChecks) {
-        if (!exists) {
+      existenceChecks
+        .filter(({ exists }) => !exists)
+        .forEach(({ loc }) =>
           this.logger.debug(
             `Extracted figure path does not exist: ${loc.absolutePath} (from ${file.absolutePath})`,
             { groupId: activeGroupId },
-          );
-        }
-      }
+          ),
+        );
 
       workspaceState.media.addMediaFiles(fileLocations);
       mirrorTasks.push(
@@ -236,16 +232,13 @@ export class LatexMediaManager {
     const tikzResults = await Promise.allSettled(
       files.map((file) => tikzPictureManager.compile(file)),
     );
-    tikzResults.forEach((result) => {
-      if (
-        result.status === 'fulfilled' &&
-        result.value &&
-        result.value.length > 0
-      ) {
-        // TikZ compilation already returns FileLocation[]
-        workspaceState.media.addMediaFiles(result.value);
-      }
-    });
+    // Add successful TikZ compilation results (filter fulfilled with non-empty values)
+    tikzResults
+      .filter(
+        (r): r is PromiseFulfilledResult<FileLocation[]> =>
+          r.status === 'fulfilled' && (r.value?.length ?? 0) > 0,
+      )
+      .forEach((r) => workspaceState.media.addMediaFiles(r.value));
     if (logSummary) {
       this.logger.debug(`Extracted ${tikzResults.length} TikZ figures`, {
         groupId: activeGroupId,

--- a/src/latex/extractBibliography.ts
+++ b/src/latex/extractBibliography.ts
@@ -70,10 +70,9 @@ function normalizeBibPath(baseDir: string, target: string): string {
 
 function collectBibliographyPaths(baseDir: string, content: string): string[] {
   const paths = new Set<string>();
-  let match: RegExpExecArray | null;
   const directivePattern = createDirectivePattern();
 
-  while ((match = directivePattern.exec(content)) !== null) {
+  for (const match of content.matchAll(directivePattern)) {
     const block = match[1];
     for (const raw of block.split(',')) {
       const normalized = normalizeBibPath(baseDir, raw);
@@ -88,10 +87,9 @@ function collectBibliographyPaths(baseDir: string, content: string): string[] {
 
 function collectCitationKeys(content: string): string[] {
   const keys = new Set<string>();
-  let match: RegExpExecArray | null;
   const citationPattern = createCitationPattern();
 
-  while ((match = citationPattern.exec(content)) !== null) {
+  for (const match of content.matchAll(citationPattern)) {
     const block = match[1];
     for (const raw of block.split(',')) {
       const key = raw.trim();

--- a/src/latex/extractFigure.ts
+++ b/src/latex/extractFigure.ts
@@ -22,22 +22,22 @@ function parseGraphicspath(content: string): string[] {
   // Pattern to extract individual paths from nested braces
   const pathPattern = /\{([^{}]+)\}/g;
 
-  let outerMatch;
-  while ((outerMatch = graphicspathPattern.exec(content)) !== null) {
-    const outerContent = outerMatch[1];
-    let pathMatch;
-    while ((pathMatch = pathPattern.exec(outerContent)) !== null) {
-      let path = pathMatch[1].trim();
-      // Ensure path has trailing slash
-      if (path && !path.endsWith('/')) {
-        path += '/';
-      }
-      if (path) {
-        paths.push(path);
-      }
-    }
-  }
+  // Use flatMap to process outer matches and extract inner paths
+  const extractedPaths = Array.from(content.matchAll(graphicspathPattern)).flatMap(
+    (outerMatch) =>
+      Array.from(outerMatch[1].matchAll(pathPattern))
+        .map((pathMatch) => {
+          let p = pathMatch[1].trim();
+          // Ensure path has trailing slash
+          if (p && !p.endsWith('/')) {
+            p += '/';
+          }
+          return p;
+        })
+        .filter(Boolean),
+  );
 
+  paths.push(...extractedPaths);
   return paths;
 }
 
@@ -86,8 +86,7 @@ export async function extractFigurePathsFromLatex(
     const discovered = new Set<string>();
 
     for (const pattern of figurePatterns) {
-      let match;
-      while ((match = pattern.exec(processedLines)) !== null) {
+      for (const match of processedLines.matchAll(pattern)) {
         const figPath = match[1];
         let found = false;
         for (const basePath of graphicspaths) {

--- a/src/replacement/advanced.ts
+++ b/src/replacement/advanced.ts
@@ -77,13 +77,11 @@ export function applyLatexQuotesFormatting(text: string): string {
     totalReplacements += replacementCount;
 
     // Restore tikzpicture environments
-    let restoredContent = processedContent;
-    for (let i = 0; i < tikzEnvironments.length; i++) {
-      restoredContent = restoredContent.replace(
-        `__TIKZ_PLACEHOLDER_${i}__`,
-        tikzEnvironments[i],
-      );
-    }
+    const restoredContent = tikzEnvironments.reduce(
+      (content, env, i) =>
+        content.replace(`__TIKZ_PLACEHOLDER_${i}__`, env),
+      processedContent,
+    );
 
     // Replace the current document block with the processed one
     const processedDocumentBlock = `\\begin{document}${restoredContent}\\end{document}`;
@@ -338,21 +336,17 @@ export function replaceMathUnicode(text: string): string {
       const mathContent = text.substring(envStart, envEnd);
 
       // Apply Unicode replacements within the math content
-      let replacedContent = mathContent;
-
-      // Replace Unicode characters with LaTeX commands
-      for (const [unicode, latex] of Object.entries(mathUnicodeMap)) {
-        replacedContent = replacedContent.replace(
-          new RegExp(unicode, 'g'),
-          latex,
-        );
-      }
-
-      // Replace HTML subscript tags with LaTeX subscript syntax
-      replacedContent = replacedContent.replace(/<sub>(.*?)<\/sub>/g, '_{$1}');
-
-      // Replace HTML superscript tags with LaTeX superscript syntax
-      replacedContent = replacedContent.replace(/<sup>(.*?)<\/sup>/g, '^{$1}');
+      // Replace Unicode characters with LaTeX commands, then HTML sub/sup tags
+      const replacedContent = Object.entries(mathUnicodeMap)
+        .reduce(
+          (content, [unicode, latex]) =>
+            content.replace(new RegExp(unicode, 'g'), latex),
+          mathContent,
+        )
+        // Replace HTML subscript tags with LaTeX subscript syntax
+        .replace(/<sub>(.*?)<\/sub>/g, '_{$1}')
+        // Replace HTML superscript tags with LaTeX superscript syntax
+        .replace(/<sup>(.*?)<\/sup>/g, '^{$1}');
 
       // Replace the original math content with the processed one
       if (replacedContent !== mathContent) {
@@ -369,19 +363,17 @@ export function replaceMathUnicode(text: string): string {
 
   // Also handle inline math with $ ... $
   const inlineMathPattern = /\$(.*?)\$/g;
-  text = text.replace(inlineMathPattern, (match, p1) => {
-    let content = p1;
-
-    // Replace Unicode characters with LaTeX commands
-    for (const [unicode, latex] of Object.entries(mathUnicodeMap)) {
-      content = content.replace(new RegExp(unicode, 'g'), latex);
-    }
-
-    // Replace HTML subscript tags with LaTeX subscript syntax
-    content = content.replace(/<sub>(.*?)<\/sub>/g, '_{$1}');
-
-    // Replace HTML superscript tags with LaTeX superscript syntax
-    content = content.replace(/<sup>(.*?)<\/sup>/g, '^{$1}');
+  text = text.replace(inlineMathPattern, (_match, p1) => {
+    // Replace Unicode characters with LaTeX commands, then HTML sub/sup tags
+    const content = Object.entries(mathUnicodeMap)
+      .reduce(
+        (c, [unicode, latex]) => c.replace(new RegExp(unicode, 'g'), latex),
+        p1 as string,
+      )
+      // Replace HTML subscript tags with LaTeX subscript syntax
+      .replace(/<sub>(.*?)<\/sub>/g, '_{$1}')
+      // Replace HTML superscript tags with LaTeX superscript syntax
+      .replace(/<sup>(.*?)<\/sup>/g, '^{$1}');
 
     return `$${content}$`;
   });

--- a/src/replacement/helpers.ts
+++ b/src/replacement/helpers.ts
@@ -24,13 +24,9 @@ export {
 export function generateBackslashFixes(commands: string[]): {
   [key: string]: string;
 } {
-  const patterns: { [key: string]: string } = {};
-
-  commands.forEach((cmd) => {
-    patterns[`\\\\${cmd}`] = `\\${cmd}`;
-  });
-
-  return patterns;
+  return Object.fromEntries(
+    commands.map((cmd) => [`\\\\${cmd}`, `\\${cmd}`]),
+  );
 }
 
 /**
@@ -75,13 +71,9 @@ export function generateGroupedBackslashFixes(commandGroups: {
 export function generateTripleBackslashFixes(commands: string[]): {
   [key: string]: string;
 } {
-  const patterns: { [key: string]: string } = {};
-
-  commands.forEach((cmd) => {
-    patterns[`\\\\\\${cmd}`] = `\\${cmd}`;
-  });
-
-  return patterns;
+  return Object.fromEntries(
+    commands.map((cmd) => [`\\\\\\${cmd}`, `\\${cmd}`]),
+  );
 }
 
 /**
@@ -90,20 +82,17 @@ export function generateTripleBackslashFixes(commands: string[]): {
 export function generateBackslashFixesWithCase(commands: string[]): {
   [key: string]: string;
 } {
-  const patterns: { [key: string]: string } = {};
-
-  commands.forEach((cmd) => {
-    // Lowercase version
-    patterns[`\\\\${cmd}`] = `\\${cmd}`;
-
-    // Only capitalize the first letter if it makes sense for the command
-    if (/^[a-z]/.test(cmd)) {
-      const capitalizedCmd = capitalize(cmd);
-      patterns[`\\\\${capitalizedCmd}`] = `\\${capitalizedCmd}`;
-    }
-  });
-
-  return patterns;
+  return Object.fromEntries(
+    commands.flatMap((cmd) => {
+      const entries: [string, string][] = [[`\\\\${cmd}`, `\\${cmd}`]];
+      // Only capitalize the first letter if it makes sense for the command
+      if (/^[a-z]/.test(cmd)) {
+        const capitalizedCmd = capitalize(cmd);
+        entries.push([`\\\\${capitalizedCmd}`, `\\${capitalizedCmd}`]);
+      }
+      return entries;
+    }),
+  );
 }
 
 /**
@@ -112,58 +101,46 @@ export function generateBackslashFixesWithCase(commands: string[]): {
 export function generateXmlLatexConversions(environments: string[]): {
   [key: string]: string;
 } {
-  const patterns: { [key: string]: string } = {};
-
-  environments.forEach((env) => {
-    // XML to LaTeX
-    patterns[`<${env}>`] = `\\begin{${env}}`;
-    patterns[`</${env}>`] = `\\end{${env}}`;
-
-    // XML with begin to LaTeX
-    patterns[`<begin{${env}}>`] = `\\begin{${env}}`;
-    patterns[`</begin{${env}}>`] = `\\end{${env}}`;
-
-    // XML with end to LaTeX
-    patterns[`<end{${env}}>`] = `\\end{${env}}`;
-    patterns[`</end{${env}}>`] = `\\end{${env}}`;
-
-    // XML with braces to LaTeX
-    patterns[`<${env}}`] = `\\begin{${env}}`;
-    patterns[`</${env}}`] = `\\end{${env}}`;
-
-    patterns[`</${env}\n`] = `\\end{${env}}\n`;
-    patterns[`</${env}}\n`] = `\\end{${env}}\n`;
-
-    // XML begin tags incorrectly closed with leading slash
-    patterns[`</begin{${env}}`] = `\\begin{${env}}`;
-    patterns[`</begin{${env}}\n`] = `\\begin{${env}}\n`;
-    patterns[`</begin{${env}`] = `\\begin{${env}}`;
-
-    // LaTeX with incorrect XML ending
-    patterns[`\\end{${env}>}`] = `\\end{${env}}`;
-    patterns[`\\end{${env}>`] = `\\end{${env}}`;
-
-    // LaTeX with incorrect labels
-    patterns[`\\begin{-${env}}`] = `\\begin{${env}}`;
-    patterns[`\\end{-${env}}`] = `\\end{${env}}`;
-
-    // LaTeX with incorrect XML ending
-    patterns[`\\begin${env}`] = `\\begin{${env}}`;
-    patterns[`\\end${env}`] = `\\end{${env}}`;
-
-    // LaTeX with duplicated begin/end keywords
-    patterns[`\\begin{begin{${env}}`] = `\\begin{${env}}`;
-    patterns[`\\begin{begin{${env}}}`] = `\\begin{${env}}`;
-    patterns[`\\begin{\\begin{${env}}`] = `\\begin{${env}}`;
-    patterns[`\\begin{\\begin{${env}}}`] = `\\begin{${env}}`;
-
-    patterns[`\\end{end{${env}}`] = `\\end{${env}}`;
-    patterns[`\\end{end{${env}}}`] = `\\end{${env}}`;
-    patterns[`\\end{\\end{${env}}`] = `\\end{${env}}`;
-    patterns[`\\end{\\end{${env}}}`] = `\\end{${env}}`;
-  });
-
-  return patterns;
+  return Object.fromEntries(
+    environments.flatMap((env) => [
+      // XML to LaTeX
+      [`<${env}>`, `\\begin{${env}}`],
+      [`</${env}>`, `\\end{${env}}`],
+      // XML with begin to LaTeX
+      [`<begin{${env}}>`, `\\begin{${env}}`],
+      [`</begin{${env}}>`, `\\end{${env}}`],
+      // XML with end to LaTeX
+      [`<end{${env}}>`, `\\end{${env}}`],
+      [`</end{${env}}>`, `\\end{${env}}`],
+      // XML with braces to LaTeX
+      [`<${env}}`, `\\begin{${env}}`],
+      [`</${env}}`, `\\end{${env}}`],
+      [`</${env}\n`, `\\end{${env}}\n`],
+      [`</${env}}\n`, `\\end{${env}}\n`],
+      // XML begin tags incorrectly closed with leading slash
+      [`</begin{${env}}`, `\\begin{${env}}`],
+      [`</begin{${env}}\n`, `\\begin{${env}}\n`],
+      [`</begin{${env}`, `\\begin{${env}}`],
+      // LaTeX with incorrect XML ending
+      [`\\end{${env}>}`, `\\end{${env}}`],
+      [`\\end{${env}>`, `\\end{${env}}`],
+      // LaTeX with incorrect labels
+      [`\\begin{-${env}}`, `\\begin{${env}}`],
+      [`\\end{-${env}}`, `\\end{${env}}`],
+      // LaTeX with incorrect XML ending
+      [`\\begin${env}`, `\\begin{${env}}`],
+      [`\\end${env}`, `\\end{${env}}`],
+      // LaTeX with duplicated begin/end keywords
+      [`\\begin{begin{${env}}`, `\\begin{${env}}`],
+      [`\\begin{begin{${env}}}`, `\\begin{${env}}`],
+      [`\\begin{\\begin{${env}}`, `\\begin{${env}}`],
+      [`\\begin{\\begin{${env}}}`, `\\begin{${env}}`],
+      [`\\end{end{${env}}`, `\\end{${env}}`],
+      [`\\end{end{${env}}}`, `\\end{${env}}`],
+      [`\\end{\\end{${env}}`, `\\end{${env}}`],
+      [`\\end{\\end{${env}}}`, `\\end{${env}}`],
+    ]),
+  );
 }
 
 /**
@@ -172,21 +149,18 @@ export function generateXmlLatexConversions(environments: string[]): {
 export function generateLatexToXmlConversions(tags: string[]): {
   [key: string]: string;
 } {
-  const patterns: { [key: string]: string } = {};
-
-  tags.forEach((tag) => {
-    // LaTeX to XML
-    patterns[`\\begin{${tag}}`] = `<${tag}>`;
-    patterns[`\\end{${tag}}`] = `</${tag}>`;
-
-    // LaTeX with '>' at the end to XML
-    patterns[`\\begin{${tag}>}`] = `<${tag}>`;
-    patterns[`\\begin{${tag}>`] = `<${tag}>`;
-    patterns[`\\end{${tag}>}`] = `</${tag}>`;
-    patterns[`\\end{${tag}>`] = `</${tag}>`;
-  });
-
-  return patterns;
+  return Object.fromEntries(
+    tags.flatMap((tag) => [
+      // LaTeX to XML
+      [`\\begin{${tag}}`, `<${tag}>`],
+      [`\\end{${tag}}`, `</${tag}>`],
+      // LaTeX with '>' at the end to XML
+      [`\\begin{${tag}>}`, `<${tag}>`],
+      [`\\begin{${tag}>`, `<${tag}>`],
+      [`\\end{${tag}>}`, `</${tag}>`],
+      [`\\end{${tag}>`, `</${tag}>`],
+    ]),
+  );
 }
 
 /**
@@ -195,13 +169,9 @@ export function generateLatexToXmlConversions(tags: string[]): {
 export function generateEnvironmentBracesFixes(environments: string[]): {
   [key: string]: string;
 } {
-  const patterns: { [key: string]: string } = {};
-
-  environments.forEach((env) => {
-    patterns[`{\\${env}}`] = `{${env}}`;
-  });
-
-  return patterns;
+  return Object.fromEntries(
+    environments.map((env) => [`{\\${env}}`, `{${env}}`]),
+  );
 }
 
 /**
@@ -211,16 +181,14 @@ export function generateSectionSpacingFixes(
   environments: string[],
   sectionTypes: string[],
 ): { [key: string]: string } {
-  const patterns: { [key: string]: string } = {};
-
-  environments.forEach((env) => {
-    sectionTypes.forEach((sectionType) => {
-      patterns[`\\end{${env}}\n\\${sectionType}`] =
-        `\\end{${env}}\n\n\n\\${sectionType}`;
-    });
-  });
-
-  return patterns;
+  return Object.fromEntries(
+    environments.flatMap((env) =>
+      sectionTypes.map((sectionType) => [
+        `\\end{${env}}\n\\${sectionType}`,
+        `\\end{${env}}\n\n\n\\${sectionType}`,
+      ]),
+    ),
+  );
 }
 
 /**
@@ -230,10 +198,8 @@ export function generateSectionSpacingFixes(
 export function generateInvalidSectionEndingFixes(sectionTypes: string[]): {
   [key: string]: string;
 } {
-  const patterns: { [key: string]: string } = {};
-
-  sectionTypes.forEach((sectionType) => {
-    const invalidEndings = [
+  return Object.fromEntries(
+    sectionTypes.flatMap((sectionType) => [
       `\\end{${sectionType}}`,
       `\\end{${sectionType}*}`,
       `\\end {${sectionType}}`,
@@ -245,14 +211,8 @@ export function generateInvalidSectionEndingFixes(sectionTypes: string[]): {
       `\\end{${sectionType}* }`,
       `\\end { ${sectionType} }`,
       `\\end { ${sectionType}* }`,
-    ];
-
-    invalidEndings.forEach((ending) => {
-      patterns[ending] = '';
-    });
-  });
-
-  return patterns;
+    ].map((ending) => [ending, ''])),
+  );
 }
 
 /**
@@ -261,20 +221,20 @@ export function generateInvalidSectionEndingFixes(sectionTypes: string[]): {
 export function generateReferenceSpacing(referenceTypes: string[]): {
   [key: string]: string;
 } {
-  const patterns: { [key: string]: string } = {};
-
-  referenceTypes.forEach((type) => {
-    patterns[`${type} \\ref{`] = `${type}~\\ref{`;
-
-    // Also handle capitalized versions
-    if (/^[a-z]/.test(type)) {
-      const capitalizedType = capitalize(type);
-      patterns[`${capitalizedType} \\ref{`] = `${capitalizedType}~\\ref{`;
-      patterns[`${capitalizedType}\\ref{`] = `${capitalizedType}~\\ref{`;
-    }
-  });
-
-  return patterns;
+  return Object.fromEntries(
+    referenceTypes.flatMap((type) => {
+      const entries: [string, string][] = [[`${type} \\ref{`, `${type}~\\ref{`]];
+      // Also handle capitalized versions
+      if (/^[a-z]/.test(type)) {
+        const capitalizedType = capitalize(type);
+        entries.push(
+          [`${capitalizedType} \\ref{`, `${capitalizedType}~\\ref{`],
+          [`${capitalizedType}\\ref{`, `${capitalizedType}~\\ref{`],
+        );
+      }
+      return entries;
+    }),
+  );
 }
 
 /**
@@ -283,14 +243,12 @@ export function generateReferenceSpacing(referenceTypes: string[]): {
 export function generateEnvironmentSpacingFixes(environments: string[]): {
   [key: string]: string;
 } {
-  const patterns: { [key: string]: string } = {};
-
-  environments.forEach((env) => {
-    patterns[`\n\n\\begin{${env}}`] = `\n\\begin{${env}}`;
-    patterns[`\\end{${env}}\n\n`] = `\\end{${env}}\n`;
-  });
-
-  return patterns;
+  return Object.fromEntries(
+    environments.flatMap((env) => [
+      [`\n\n\\begin{${env}}`, `\n\\begin{${env}}`],
+      [`\\end{${env}}\n\n`, `\\end{${env}}\n`],
+    ]),
+  );
 }
 
 /**
@@ -299,15 +257,13 @@ export function generateEnvironmentSpacingFixes(environments: string[]): {
 export function generateEnvironmentLinebreakFixes(environments: string[]): {
   [key: string]: string;
 } {
-  const patterns: { [key: string]: string } = {};
-
-  environments.forEach((env) => {
-    patterns[`\n\n\\end{${env}}`] = `\n\\end{${env}}`;
-    patterns[`\n    \n\\end{${env}}`] = `\n\\end{${env}}`;
-    patterns[`\n\t\n\\end{${env}}`] = `\n\\end{${env}}`;
-  });
-
-  return patterns;
+  return Object.fromEntries(
+    environments.flatMap((env) => [
+      [`\n\n\\end{${env}}`, `\n\\end{${env}}`],
+      [`\n    \n\\end{${env}}`, `\n\\end{${env}}`],
+      [`\n\t\n\\end{${env}}`, `\n\\end{${env}}`],
+    ]),
+  );
 }
 
 /**
@@ -335,15 +291,14 @@ export function generateDecoratedMathShortcuts(
   symbols: string[],
   shortcutPrefix: string,
 ): { [key: string]: string } {
-  const patterns: { [key: string]: string } = {};
-
-  decorators.forEach((decorator) => {
-    symbols.forEach((symbol) => {
-      patterns[`\\${decorator}{\\${symbol}}`] = `\\${shortcutPrefix}${symbol}`;
-    });
-  });
-
-  return patterns;
+  return Object.fromEntries(
+    decorators.flatMap((decorator) =>
+      symbols.map((symbol) => [
+        `\\${decorator}{\\${symbol}}`,
+        `\\${shortcutPrefix}${symbol}`,
+      ]),
+    ),
+  );
 }
 
 /**
@@ -354,13 +309,12 @@ export function generateMathFontShortcuts(
   fontCmd: string,
   shortcutPrefix: string,
 ): { [key: string]: string } {
-  const patterns: { [key: string]: string } = {};
-
-  letters.forEach((letter) => {
-    patterns[`\\${fontCmd}{${letter}}`] = `\\${shortcutPrefix}${letter}`;
-  });
-
-  return patterns;
+  return Object.fromEntries(
+    letters.map((letter) => [
+      `\\${fontCmd}{${letter}}`,
+      `\\${shortcutPrefix}${letter}`,
+    ]),
+  );
 }
 
 /**
@@ -371,13 +325,12 @@ export function generateBoldBackslashFixes(
   prefix: string,
   letters: string[],
 ): { [key: string]: string } {
-  const patterns: { [key: string]: string } = {};
-
-  letters.forEach((letter) => {
-    patterns[`\\\\${prefix}${letter}`] = `\\${prefix}${letter}`;
-  });
-
-  return patterns;
+  return Object.fromEntries(
+    letters.map((letter) => [
+      `\\\\${prefix}${letter}`,
+      `\\${prefix}${letter}`,
+    ]),
+  );
 }
 
 /**
@@ -391,13 +344,12 @@ export function generateDecoratorShortcuts(
   letters: string[],
   prefix: string,
 ): { [key: string]: string } {
-  const patterns: { [key: string]: string } = {};
-
-  letters.forEach((letter) => {
-    patterns[`\\${decorator}{${letter}}`] = `\\${prefix}${letter}`;
-  });
-
-  return patterns;
+  return Object.fromEntries(
+    letters.map((letter) => [
+      `\\${decorator}{${letter}}`,
+      `\\${prefix}${letter}`,
+    ]),
+  );
 }
 
 /**
@@ -413,16 +365,18 @@ export function generateNestedDecoratorShortcuts(
   outerPrefix: string,
   innerPrefix: string,
 ): { [key: string]: string } {
-  const patterns: { [key: string]: string } = {};
-
-  letters.forEach((letter) => {
-    // Handle uppercase/lowercase differences
-    const displayLetter = /^[A-Z]/.test(letter) ? letter : letter.toLowerCase();
-    patterns[`\\${outerDecorator}{\\${innerCommand}{${displayLetter}}}`] =
-      `\\${outerPrefix}${innerPrefix}${displayLetter}`;
-  });
-
-  return patterns;
+  return Object.fromEntries(
+    letters.map((letter) => {
+      // Handle uppercase/lowercase differences
+      const displayLetter = /^[A-Z]/.test(letter)
+        ? letter
+        : letter.toLowerCase();
+      return [
+        `\\${outerDecorator}{\\${innerCommand}{${displayLetter}}}`,
+        `\\${outerPrefix}${innerPrefix}${displayLetter}`,
+      ];
+    }),
+  );
 }
 
 /**
@@ -453,13 +407,9 @@ export function generateVectorShortcuts(
   letters: string[],
   prefix: string = 'v',
 ): { [key: string]: string } {
-  const patterns: { [key: string]: string } = {};
-
-  letters.forEach((letter) => {
-    patterns[`\\vec{${letter}}`] = `\\${prefix}${letter}`;
-  });
-
-  return patterns;
+  return Object.fromEntries(
+    letters.map((letter) => [`\\vec{${letter}}`, `\\${prefix}${letter}`]),
+  );
 }
 
 /**
@@ -476,19 +426,18 @@ export function generateTextCommandNormalization(
   targetCommand: string = 'text',
   variant?: string,
 ): { [key: string]: string } {
-  const patterns: { [key: string]: string } = {};
-
   // Define all possible variants if none specified
   const allVariants = ['mathrm', 'mbox', 'textrm'];
   const variantsToUse = variant ? [variant] : allVariants;
 
-  variantsToUse.forEach((v) => {
-    terms.forEach((term) => {
-      patterns[`\\${v}{${term}}`] = `\\${targetCommand}{${term}}`;
-    });
-  });
-
-  return patterns;
+  return Object.fromEntries(
+    variantsToUse.flatMap((v) =>
+      terms.map((term) => [
+        `\\${v}{${term}}`,
+        `\\${targetCommand}{${term}}`,
+      ]),
+    ),
+  );
 }
 
 /**
@@ -500,20 +449,18 @@ export function generateLegacyTextCommandNormalization(
   targetCommand: string,
   variant?: string,
 ): { [key: string]: string } {
-  const patterns: { [key: string]: string } = {};
-
   const allVariants = ['rm', 'bf', 'cal'];
   const variantsToUse = variant ? [variant] : allVariants;
 
-  variantsToUse.forEach((v) => {
-    terms.forEach((term) => {
-      patterns[`{\\${v} ${term}}`] = `\\${targetCommand}{${term}}`;
-      // Handle {\rm{X}} style
-      patterns[`{\\${v}{${term}}}`] = `\\${targetCommand}{${term}}`;
-    });
-  });
-
-  return patterns;
+  return Object.fromEntries(
+    variantsToUse.flatMap((v) =>
+      terms.flatMap((term) => [
+        [`{\\${v} ${term}}`, `\\${targetCommand}{${term}}`],
+        // Handle {\rm{X}} style
+        [`{\\${v}{${term}}}`, `\\${targetCommand}{${term}}`],
+      ]),
+    ),
+  );
 }
 
 /**
@@ -541,19 +488,16 @@ export function generateDifferentialSpacing(
   variables: string[],
   spaceChar: string = '~',
 ): { [key: string]: string } {
-  const patterns: { [key: string]: string } = {};
-
-  // For each variable, generate spacing rules
-  variables.forEach((variable) => {
-    // Handle ' d\x ' case - adding space at end
-    patterns[` d\\${variable} `] = ` d\\${variable}${spaceChar}`;
-    // Handle with comma
-    patterns[`\\dd\\${variable}\\,`] = `\\dd\\${variable}${spaceChar}`;
-    // Handle differential replacement
-    patterns[`{d\\${variable}}`] = `{\\dd\\${variable}}`;
-  });
-
-  return patterns;
+  return Object.fromEntries(
+    variables.flatMap((variable) => [
+      // Handle ' d\x ' case - adding space at end
+      [` d\\${variable} `, ` d\\${variable}${spaceChar}`],
+      // Handle with comma
+      [`\\dd\\${variable}\\,`, `\\dd\\${variable}${spaceChar}`],
+      // Handle differential replacement
+      [`{d\\${variable}}`, `{\\dd\\${variable}}`],
+    ]),
+  );
 }
 
 /**

--- a/src/replacement/maxRules.ts
+++ b/src/replacement/maxRules.ts
@@ -95,16 +95,20 @@ export const MAX_AUTO_REPLACEMENTS: ReplacementCategory = {
     ];
 
     // Direct mapping: \mathrm{op} -> \op and \text{op} -> \op
-    mathOperators.forEach((op) => {
-      // Common variants
-      patterns[`\\mathrm{${op}}`] = `\\${op}`;
-      patterns[`\\text{${op}}`] = `\\${op}`;
-      patterns[`\\mbox{${op}}`] = `\\${op}`;
-      patterns[`\\textrm{${op}}`] = `\\${op}`;
-      patterns[`{\\rm ${op}}`] = `\\${op}`;
-      patterns[`_\\op`] = `_{\\${op}}`;
-      patterns[`^\\op`] = `^{\\${op}}`;
-    });
+    patterns = {
+      ...patterns,
+      ...Object.fromEntries(
+        mathOperators.flatMap((op) => [
+          [`\\mathrm{${op}}`, `\\${op}`],
+          [`\\text{${op}}`, `\\${op}`],
+          [`\\mbox{${op}}`, `\\${op}`],
+          [`\\textrm{${op}}`, `\\${op}`],
+          [`{\\rm ${op}}`, `\\${op}`],
+          [`_\\op`, `_{\\${op}}`],
+          [`^\\op`, `^{\\${op}}`],
+        ]),
+      ),
+    };
 
     // 2. Text Commands (defined with \newcommand{\cmd}{{\text{name}}})
     // These allow direct subscript/superscript like P_\cmd
@@ -112,18 +116,22 @@ export const MAX_AUTO_REPLACEMENTS: ReplacementCategory = {
     const textCommands = ['sys', 'bath', 'tot', 'const', 'discrete', 'decoder', 'encoder', 'pool', 'data', 'mar', 'model', 'prior', 'target', 'full', 'observed', 'accept', 'aux', 'eq', 'st', 'nc', 'irr', 'rev', 'hkp', 'adi', 'nadi', 'exc', 'pos', 'head', 'PE', 'class', 'window', 'Output', 'FFN', 'Strat', 'Ito', 'diss'];
 
     // Direct mapping: \text{cmd} -> \cmd
-    textCommands.forEach((cmd) => {
-      // Common variants
-      patterns[`\\text{${cmd}}`] = `\\${cmd}`;
-      patterns[`\\mathrm{${cmd}}`] = `\\${cmd}`;
-      patterns[`\\mbox{${cmd}}`] = `\\${cmd}`;
-      patterns[`\\textrm{${cmd}}`] = `\\${cmd}`;
-      patterns[`{\\rm ${cmd}}`] = `\\${cmd}`;
-      patterns[`_{\\${cmd}}`] = `_\\${cmd}`;
-      patterns[`^{\\${cmd}}`] = `^\\${cmd}`;
-      patterns[`_{${cmd}}`] = `_\\${cmd}`;
-      patterns[`^{${cmd}}`] = `^\\${cmd}`;
-    });
+    patterns = {
+      ...patterns,
+      ...Object.fromEntries(
+        textCommands.flatMap((cmd) => [
+          [`\\text{${cmd}}`, `\\${cmd}`],
+          [`\\mathrm{${cmd}}`, `\\${cmd}`],
+          [`\\mbox{${cmd}}`, `\\${cmd}`],
+          [`\\textrm{${cmd}}`, `\\${cmd}`],
+          [`{\\rm ${cmd}}`, `\\${cmd}`],
+          [`_{\\${cmd}}`, `_\\${cmd}`],
+          [`^{\\${cmd}}`, `^\\${cmd}`],
+          [`_{${cmd}}`, `_\\${cmd}`],
+          [`^{${cmd}}`, `^\\${cmd}`],
+        ]),
+      ),
+    };
 
     // prettier-ignore
     const symbolOperators = [
@@ -134,10 +142,15 @@ export const MAX_AUTO_REPLACEMENTS: ReplacementCategory = {
       'bu', 'ta'
     ];
     // these variables might occur as lower indices, but they do not need {..}
-    symbolOperators.forEach((op) => {
-      patterns[`_{\\${op}}`] = `_\\${op}`;
-      patterns[`^{\\${op}}`] = `^\\${op}`;
-    });
+    patterns = {
+      ...patterns,
+      ...Object.fromEntries(
+        symbolOperators.flatMap((op) => [
+          [`_{\\${op}}`, `_\\${op}`],
+          [`^{\\${op}}`, `^\\${op}`],
+        ]),
+      ),
+    };
 
     // ====================================================================
     // Auto-generated differential notation patterns
@@ -159,16 +172,19 @@ export const MAX_AUTO_REPLACEMENTS: ReplacementCategory = {
     const fractionDiffVariables = ['t', 'x', 'tau', 'ttau', 'beta', 'bx', 'bz', 'bze', 'bxi', 'S'];
 
     // Generate patterns for each variable
-    fractionDiffVariables.forEach((variable) => {
-      // Handle cases like {dx} -> {\\dd x}
-      patterns[`{d${variable}}`] = `{\\dd${variable}}`;
-
-      // Handle cases like \\frac{dx} -> \\frac{\\dd x}
-      patterns[`\\frac{d${variable}`] = `\\frac{\\dd${variable}`;
-
-      // Handle cases like \\frac{d}{dx} -> \\frac{\\dd}{\\dd x}
-      patterns[`\\frac{d}{d${variable}}`] = `\\frac{\\dd}{\\dd${variable}}`;
-    });
+    patterns = {
+      ...patterns,
+      ...Object.fromEntries(
+        fractionDiffVariables.flatMap((variable) => [
+          // Handle cases like {dx} -> {\\dd x}
+          [`{d${variable}}`, `{\\dd${variable}}`],
+          // Handle cases like \\frac{dx} -> \\frac{\\dd x}
+          [`\\frac{d${variable}`, `\\frac{\\dd${variable}`],
+          // Handle cases like \\frac{d}{dx} -> \\frac{\\dd}{\\dd x}
+          [`\\frac{d}{d${variable}}`, `\\frac{\\dd}{\\dd${variable}}`],
+        ]),
+      ),
+    };
 
     // Integration patterns
     patterns['\\int d\\'] = '\\int \\dd\\';
@@ -346,20 +362,30 @@ export const MAX_AUTO_REPLACEMENTS: ReplacementCategory = {
     const tildeGreekLetters = 'gamma lambda phi psi rho Sigma mu tau'.split(
       ' ',
     );
-    tildeGreekLetters.forEach((letter) => {
-      const shortcut = GREEK_LETTER_SHORTCUTS[letter] || letter;
-      patterns[`\\tilde{\\${letter}}`] = `\\t${shortcut}`;
-    });
+    patterns = {
+      ...patterns,
+      ...Object.fromEntries(
+        tildeGreekLetters.map((letter) => [
+          `\\tilde{\\${letter}}`,
+          `\\t${GREEK_LETTER_SHORTCUTS[letter] || letter}`,
+        ]),
+      ),
+    };
 
     // Tilde with boldsymbol+Greek
     // Example: \tilde{\boldsymbol{\zeta}} -> \tbze
     const tildeGreekBoldLetters = 'zeta gamma lambda pi xi eta Gamma'.split(
       ' ',
     );
-    tildeGreekBoldLetters.forEach((letter) => {
-      const shortcut = GREEK_LETTER_SHORTCUTS[letter] || letter;
-      patterns[`\\tilde{\\boldsymbol{\\${letter}}}`] = `\\tb${shortcut}`;
-    });
+    patterns = {
+      ...patterns,
+      ...Object.fromEntries(
+        tildeGreekBoldLetters.map((letter) => [
+          `\\tilde{\\boldsymbol{\\${letter}}}`,
+          `\\tb${GREEK_LETTER_SHORTCUTS[letter] || letter}`,
+        ]),
+      ),
+    };
 
     // Hat variables
     // Example: \hat{H} -> \hH
@@ -372,10 +398,15 @@ export const MAX_AUTO_REPLACEMENTS: ReplacementCategory = {
     // Hat with Greek letters
     // Example: \hat{\sigma} -> \hsg
     const hatGreekLetters = 'sigma Sigma pi rho'.split(' ');
-    hatGreekLetters.forEach((letter) => {
-      const shortcut = GREEK_LETTER_SHORTCUTS[letter] || letter;
-      patterns[`\\hat{\\${letter}}`] = `\\h${shortcut}`;
-    });
+    patterns = {
+      ...patterns,
+      ...Object.fromEntries(
+        hatGreekLetters.map((letter) => [
+          `\\hat{\\${letter}}`,
+          `\\h${GREEK_LETTER_SHORTCUTS[letter] || letter}`,
+        ]),
+      ),
+    };
 
     // Hat with mathbf
     // Example: \hat{\mathbf{n}} -> \hbn
@@ -394,10 +425,15 @@ export const MAX_AUTO_REPLACEMENTS: ReplacementCategory = {
     // Hat with boldsymbol+Greek
     // Example: \hat{\boldsymbol{\zeta}} -> \hbze
     const hatBoldsymbolLetters = 'zeta'.split(' ');
-    hatBoldsymbolLetters.forEach((letter) => {
-      const shortcut = GREEK_LETTER_SHORTCUTS[letter] || letter;
-      patterns[`\\hat{\\boldsymbol{\\${letter}}}`] = `\\hb${shortcut}`;
-    });
+    patterns = {
+      ...patterns,
+      ...Object.fromEntries(
+        hatBoldsymbolLetters.map((letter) => [
+          `\\hat{\\boldsymbol{\\${letter}}}`,
+          `\\hb${GREEK_LETTER_SHORTCUTS[letter] || letter}`,
+        ]),
+      ),
+    };
 
     // Fix for extra backslashes in bold symbols
     // Automatically generate fixes for lowercase bold letters (e.g., \\ba -> \ba)
@@ -415,18 +451,29 @@ export const MAX_AUTO_REPLACEMENTS: ReplacementCategory = {
     // Fix for double backslashes in custom commands
     // Examples: \\bet -> \bet, \\bbf -> \bbf
     const customShortcutFixes = ['bet', 'bze', 'cP', 'Om', 'bbf'];
-    customShortcutFixes.forEach((shortcut) => {
-      patterns[`\\\\${shortcut}`] = `\\${shortcut}`;
-    });
+    patterns = {
+      ...patterns,
+      ...Object.fromEntries(
+        customShortcutFixes.map((shortcut) => [
+          `\\\\${shortcut}`,
+          `\\${shortcut}`,
+        ]),
+      ),
+    };
 
     // Convert functions to simpler forms (e.g., F_/G_)
     // Examples: \F_ -> F_, \G( -> G(
     const functionNames = ['F', 'G'];
-    functionNames.forEach((name) => {
-      patterns[`\\${name}_`] = `${name}_`;
-      patterns[`\\${name}^`] = `${name}^`;
-      patterns[`\\${name}(`] = `${name}(`;
-    });
+    patterns = {
+      ...patterns,
+      ...Object.fromEntries(
+        functionNames.flatMap((name) => [
+          [`\\${name}_`, `${name}_`],
+          [`\\${name}^`, `${name}^`],
+          [`\\${name}(`, `${name}(`],
+        ]),
+      ),
+    };
 
     return patterns;
   })(),

--- a/src/utils/text/textEnhancementUtils.ts
+++ b/src/utils/text/textEnhancementUtils.ts
@@ -121,15 +121,15 @@ export async function polishTextWithAI(
 
       // Add files section header if there are any files
       const hasFiles =
-        fileContext.inputFile ||
-        (fileContext.inputFiles && fileContext.inputFiles.length > 0) ||
-        fileContext.referenceFile ||
-        (fileContext.referenceFiles && fileContext.referenceFiles.length > 0) ||
-        fileContext.auxiliaryFile ||
-        (fileContext.auxiliaryFiles && fileContext.auxiliaryFiles.length > 0) ||
-        fileContext.mediaFile ||
-        (fileContext.mediaFiles && fileContext.mediaFiles.length > 0) ||
-        (fileContext.outputFiles && fileContext.outputFiles.length > 0);
+        !!fileContext.inputFile ||
+        (fileContext.inputFiles?.length ?? 0) > 0 ||
+        !!fileContext.referenceFile ||
+        (fileContext.referenceFiles?.length ?? 0) > 0 ||
+        !!fileContext.auxiliaryFile ||
+        (fileContext.auxiliaryFiles?.length ?? 0) > 0 ||
+        !!fileContext.mediaFile ||
+        (fileContext.mediaFiles?.length ?? 0) > 0 ||
+        (fileContext.outputFiles?.length ?? 0) > 0;
 
       if (hasFiles) {
         fileContextString += '\nFiles in the task:\n';

--- a/src/utils/text/xmlUtils.ts
+++ b/src/utils/text/xmlUtils.ts
@@ -269,17 +269,10 @@ export function extractTextFromTag(
   inputContent: string,
   documentTag: string,
 ): string {
-  // This will find all matches of the tag
+  // Find all matches and get the last one using matchAll
   const regex = new RegExp(`<${documentTag}>(.*?)<\/${documentTag}>`, 'gs');
-
-  // Variables to track the last match
-  let lastContent = '';
-  let match;
-
-  // Find all matches and keep the last one
-  while ((match = regex.exec(inputContent)) !== null) {
-    lastContent = match[1];
-  }
+  const matches = Array.from(inputContent.matchAll(regex));
+  const lastContent = matches.at(-1)?.[1] ?? '';
 
   // Use centralized CDATA removal
   return removeCDATA(lastContent);


### PR DESCRIPTION
Replace imperative forEach/for loops with modern functional patterns:
- Use Object.fromEntries() + map()/flatMap() for pattern generation
- Use reduce() for sequential string replacements
- Use optional chaining (?.) and nullish coalescing (??) for cleaner checks
- Use findIndex() instead of manual loop with early return

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces imperative loops with map/flatMap/reduce, matchAll, Object.fromEntries, and Promise.all to streamline message construction, LaTeX processing, and replacement pattern generation.
> 
> - **Agent Model Handlers**
>   - **DeepSeek (`modelHandlerDeepSeek.ts`)**: Build tool result messages via `map` and return `[assistant, ...toolResults]` array.
>   - **Google GenAI (`modelHandlerGoogleGenAI.ts`)**: Construct call parts with spread + `map`; build response parts with `Promise.all`.
> - **LaTeX Processing**
>   - **Media Manager (`LatexMediaManager.ts`)**: Iterate settled results with `entries()`; filter `exists` via chaining; compact TikZ aggregation with `filter`/`forEach`.
>   - **Extractors**: Use `matchAll`/`flatMap` for parsing in `extractBibliography.ts` and `extractFigure.ts`.
> - **Replacement Engine**
>   - **Advanced rules (`advanced.ts`)**: Use `reduce` pipelines for Unicode/sub/sup replacements; restore TikZ via `reduce`.
>   - **Helpers (`helpers.ts`)**: Rewrite generators with `Object.fromEntries`, `map`/`flatMap` for concise pattern maps.
>   - **Max rules (`maxRules.ts`)**: Consolidate numerous pattern additions with `Object.fromEntries` and spreads; batch mappings via `flatMap`.
> - **Text/XML Utils**
>   - **Text enhancement (`textEnhancementUtils.ts`)**: Simplify file-context checks with optional chaining/nullish coalescing.
>   - **XML utils (`xmlUtils.ts`)**: Replace manual regex loops with `matchAll` for extracting last-tag content.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 190737273f6ce3026339f6a8d6af87442533deca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->