### PR TITLE
refactor(types): consolidate redundant type definitions into single sources of truth

### DIFF
--- a/src/agent/types/DiffTypes.ts
+++ b/src/agent/types/DiffTypes.ts
@@ -1,14 +1,20 @@
 /**
  * Diff statistic schema used for file comparisons.
+ * Derives from LineChangesSchema (single source of truth) with optional fields.
  */
-// Third-party imports
-import { z } from 'zod';
+// Local imports - tools (single source of truth)
+import { LineChangesSchema } from '@tools/result';
 
-export const DiffStatsSchema = z.strictObject({
-  /** Number of added lines */
-  added: z.number().optional(),
-  /** Number of removed lines */
-  removed: z.number().optional(),
-});
+// Third-party imports
+import type { z } from 'zod';
+
+/**
+ * Schema for diff statistics - partial version of LineChanges.
+ * Used when computing diffs where fields may be absent (e.g., new file has only 'added').
+ */
+export const DiffStatsSchema = LineChangesSchema.partial();
 
 export type DiffStats = z.infer<typeof DiffStatsSchema>;
+
+// Re-export LineChanges for consumers that need the required version
+export { LineChangesSchema, type LineChanges } from '@tools/result';

--- a/src/agent/types/DiffTypes.ts
+++ b/src/agent/types/DiffTypes.ts
@@ -2,11 +2,11 @@
  * Diff statistic schema used for file comparisons.
  * Derives from LineChangesSchema (single source of truth) with optional fields.
  */
+// Third-party imports
+import { z } from 'zod';
+
 // Local imports - tools (single source of truth)
 import { LineChangesSchema } from '@tools/result';
-
-// Third-party imports
-import type { z } from 'zod';
 
 /**
  * Schema for diff statistics - partial version of LineChanges.

--- a/src/agent/types/NormalizedUsage.ts
+++ b/src/agent/types/NormalizedUsage.ts
@@ -6,6 +6,9 @@
  */
 import { z } from 'zod';
 
+// Local imports - single source of truth for base usage stats
+import { TokenUsageStatsSchema } from './UsageTypes';
+
 /**
  * Provider identifiers for usage tracking - single source of truth.
  */
@@ -26,15 +29,10 @@ export type UsageProvider = z.infer<typeof UsageProviderSchema>;
 
 /**
  * Normalized usage statistics from any model provider.
+ * Extends TokenUsageStatsSchema (single source of truth) with provider-specific fields.
  * Cost is computed once during normalization and never recomputed.
  */
-export const NormalizedUsageSchema = z.object({
-  /** Total input tokens consumed */
-  inputTokens: z.number(),
-  /** Total output tokens generated */
-  outputTokens: z.number(),
-  /** Total cost in USD (computed once, never recomputed) */
-  cost: z.number(),
+export const NormalizedUsageSchema = TokenUsageStatsSchema.extend({
   /** Response time in milliseconds */
   responseTimeMs: z.number(),
   /** Provider that generated this usage data */

--- a/src/eventBus/schemas.ts
+++ b/src/eventBus/schemas.ts
@@ -12,6 +12,7 @@ import {
   TaskGroupStatusSchema,
   type TaskGroupStatus,
 } from '@common/constants/streamStatus';
+import { TaskGroupSchema } from '@logger/LogTypes';
 
 /**
  * Re-export from types.ts to break circular dependency:
@@ -28,15 +29,23 @@ export {
 // Re-export TaskGroupStatusSchema from single source of truth
 export { TaskGroupStatusSchema, type TaskGroupStatus };
 
-/** Payload for adding a new task group */
+/**
+ * Payload for adding a new task group.
+ * Uses TaskGroupSchema fields via composition (field names differ for API clarity).
+ */
 export const AddTaskGroupPayloadSchema = z.strictObject({
   stream: StreamTabIdSchema,
+  // Renamed from TaskGroup.id for payload clarity
   groupId: z.string().min(1),
+  // Renamed from TaskGroup.name for payload clarity
   groupName: z.string(),
-  startTime: z.number(),
-  status: TaskGroupStatusSchema,
-  endTime: z.number().optional(),
-  parentGroupId: z.string().optional(),
+  // Fields from TaskGroupSchema (same names)
+  ...TaskGroupSchema.pick({
+    startTime: true,
+    status: true,
+    endTime: true,
+    parentGroupId: true,
+  }).shape,
 });
 export type AddTaskGroupPayload = z.infer<typeof AddTaskGroupPayloadSchema>;
 

--- a/src/logger/LogTypes.ts
+++ b/src/logger/LogTypes.ts
@@ -1,54 +1,68 @@
 /**
  * Shared logging interfaces used by the logger and progress view.
+ * Defines Zod schemas as single source of truth, derives TypeScript types.
  */
+import { z } from 'zod';
 
-import type { TaskGroupStatus } from '@common/constants/streamStatus';
+import { TaskGroupStatusSchema } from '@common/constants/streamStatus';
 
-// Local imports
-import type { TaskGroupId, LogMessageId } from './types/EntityTypes';
-import type { LogLevel, MessageType } from './messageTypes';
+// Local imports - schemas for composition
+import { LogLevelSchema, MessageTypeSchema } from './messageTypes';
 
-export interface TaskGroup {
+/**
+ * Task group schema - single source of truth for task group structure.
+ * Used by logger and progress view for tracking execution groups.
+ */
+export const TaskGroupSchema = z.strictObject({
   /** Unique identifier for the group */
-  id: TaskGroupId;
+  id: z.string().min(1),
   /** Display name of the group */
-  name: string;
+  name: z.string(),
   /** Unix timestamp (ms) when the group started */
-  startTime: number;
+  startTime: z.number(),
   /** Unix timestamp (ms) when the group ended */
-  endTime?: number;
+  endTime: z.number().optional(),
   /** Current status of the group */
-  status: TaskGroupStatus;
+  status: TaskGroupStatusSchema,
   /** Parent group ID for nested groups */
-  parentGroupId?: TaskGroupId;
-}
+  parentGroupId: z.string().optional(),
+});
 
-export interface LogMessageData {
+export type TaskGroup = z.infer<typeof TaskGroupSchema>;
+
+/**
+ * Log message data schema - single source of truth for log entry structure.
+ */
+export const LogMessageDataSchema = z.strictObject({
   /** Unique identifier for this log entry */
-  id: LogMessageId;
+  id: z.string().min(1),
   /** Raw message text */
-  text: string;
+  text: z.string(),
   /** Severity level */
-  level: LogLevel;
+  level: LogLevelSchema,
   /** Unix timestamp (ms) */
-  timestamp: number;
+  timestamp: z.number(),
   /** Optional group association */
-  groupId?: TaskGroupId;
+  groupId: z.string().optional(),
   /** Optional message category */
-  messageType?: MessageType;
+  messageType: MessageTypeSchema.optional(),
   /** Whether verbose details should be displayed */
-  verbose?: boolean;
+  verbose: z.boolean().optional(),
   /** Optional structured data associated with the entry */
-  data?: unknown;
-}
+  data: z.unknown().optional(),
+});
 
-export interface LogMessageUpdate extends Partial<
-  Omit<LogMessageData, 'id' | 'level' | 'timestamp'>
-> {
-  /** Identifier of the log entry being updated */
-  id: LogMessageId;
-  /** Optional severity updates for completeness */
-  level?: LogMessageData['level'];
-  /** Optional timestamp override */
-  timestamp?: number;
-}
+export type LogMessageData = z.infer<typeof LogMessageDataSchema>;
+
+/**
+ * Log message update schema - partial update for existing log entries.
+ * Derives from LogMessageDataSchema using composition.
+ */
+export const LogMessageUpdateSchema = LogMessageDataSchema.pick({
+  id: true,
+}).extend({
+  // Optional fields that can be updated
+  ...LogMessageDataSchema.omit({ id: true }).partial().shape,
+});
+
+export type LogMessageUpdate = z.infer<typeof LogMessageUpdateSchema>;

--- a/src/logger/LogTypes.ts
+++ b/src/logger/LogTypes.ts
@@ -56,13 +56,10 @@ export type LogMessageData = z.infer<typeof LogMessageDataSchema>;
 
 /**
  * Log message update schema - partial update for existing log entries.
- * Derives from LogMessageDataSchema using composition.
+ * All fields optional except id (required for identifying the entry to update).
  */
-export const LogMessageUpdateSchema = LogMessageDataSchema.pick({
+export const LogMessageUpdateSchema = LogMessageDataSchema.partial().required({
   id: true,
-}).extend({
-  // Optional fields that can be updated
-  ...LogMessageDataSchema.omit({ id: true }).partial().shape,
 });
 
 export type LogMessageUpdate = z.infer<typeof LogMessageUpdateSchema>;

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -15,7 +15,7 @@ import * as difflib from 'difflib';
 import type { StreamTabId } from '@agent/types/IdentifierTypes';
 
 // Local imports - utils
-import { toolResult, type ToolResult } from '@tools/result';
+import { toolResult, type ToolResult, type LineChanges } from '@tools/result';
 import { WorkspaceFS } from '@utils/files';
 import { getConfig } from '@utils/config';
 import { safeExecuteCommand } from '@utils/system/commandUtils';
@@ -37,18 +37,13 @@ export interface ToolEditApprovalResult {
   userMessage?: string;
   appliedContent?: string;
   userPatch?: string;
-  lineChanges?: LineChangeSummary;
+  lineChanges?: LineChanges;
 }
 
 export const TOOL_EDIT_APPROVAL_CONFIG_KEY =
   'texra.toolUse.requireEditApproval';
 
 const REVEAL_TIMEOUT_MS = 1500;
-
-interface LineChangeSummary {
-  added: number;
-  removed: number;
-}
 
 interface PendingApprovalEntry {
   request: ToolEditApprovalRequest;
@@ -58,7 +53,7 @@ interface PendingApprovalEntry {
   proposedContent: string;
   title: string;
   streamId?: StreamTabId;
-  lineChanges: LineChangeSummary;
+  lineChanges: LineChanges;
   isSettled: () => boolean;
   settle: (result: ToolEditApprovalResult) => void;
 }
@@ -194,7 +189,7 @@ async function showProgressViewApprovalPrompt(
   requestId: string,
   request: ToolEditApprovalRequest,
   relativePath: string,
-  lineChanges: LineChangeSummary,
+  lineChanges: LineChanges,
 ): Promise<void> {
   await safeExecuteCommand('texra.showProgressView');
   bus.emit('showToolEditApprovalPrompt', {
@@ -233,7 +228,7 @@ function countChangedLines(text: string): number {
 function computeLineChangeSummary(
   original: string,
   proposed: string,
-): LineChangeSummary {
+): LineChanges {
   if (original === proposed) {
     return { added: 0, removed: 0 };
   }


### PR DESCRIPTION
- DiffStatsSchema now derives from LineChangesSchema using .partial()
- NormalizedUsageSchema now extends TokenUsageStatsSchema
- Created TaskGroupSchema and use composition in AddTaskGroupPayloadSchema
- Converted LogMessageData interface to Zod schema
- Replaced LineChangeSummary interface with LineChanges type

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Unifies type definitions into shared Zod schemas (TaskGroup, LogMessage, LineChanges, TokenUsageStats) and composes them across event bus and tool edit approval.
> 
> - **Types/Schemas**
>   - `DiffStatsSchema` now derives from `LineChangesSchema.partial()`; re-exports `LineChanges`.
>   - `NormalizedUsageSchema` extends `TokenUsageStatsSchema` and retains provider fields.
>   - Logger: introduce `TaskGroupSchema`, `LogMessageDataSchema`, and `LogMessageUpdateSchema`; derive TS types from schemas.
> - **Event Bus**
>   - `AddTaskGroupPayloadSchema` composes fields from `TaskGroupSchema` (with `groupId`/`groupName` for clarity).
> - **Tools**
>   - `toolEditApproval`: replace `LineChangeSummary` with shared `LineChanges`; update computation and prompt wiring to use the shared type.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2f9a2345266a0a9663dbd7cc824f6bceb08bbc59. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->