### PR TITLE
Fix execution ID storage location for agent sessions

### DIFF
--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -268,9 +268,9 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
     await this.withToolbarTaskState(message.stream, async (taskState) => {
       const executionId = this.provider.state.getExecutionId(message.stream);
       const activeRunId = this.provider.state.getActiveRunId(message.stream);
-      // Priority: activeRunId (task group ID for workflow agents) ?? executionId (for tool-use)
-      // Workflow agents store files under task group ID, NOT executionId
-      // Use normalizeRunId to brand as StorageKey at this boundary
+      // storageKey is for logical indexing (finding file metadata in progress view state).
+      // For workflow agents: activeRunId = task group ID; for tool-use: executionId.
+      // Note: Physical file paths use executionId (see runId below), not storageKey.
       const storageKey = normalizeRunId(activeRunId ?? executionId);
       const runOutputs = this.provider.state.getRunOutputFiles(message.stream, {
         storageKey,
@@ -436,9 +436,9 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
       ? this.provider.state.getRunOutputFiles(stream, { storageKey })
       : undefined;
 
-    // The stored executionId is the actual directory name in taskRuns/
-    // For workflow agents, storageKey differs from executionId (storageKey = task group ID)
-    // but files are always written to taskRuns/<executionId>/
+    // executionId is the physical directory name: taskRuns/<executionId>/
+    // For workflow agents, storageKey (task group ID) differs from executionId,
+    // but files are always written to the executionId directory.
     const executionId = this.provider.state.getExecutionId(stream);
 
     try {
@@ -448,7 +448,9 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
         await ensureRunDir(executionId);
         directoryToReveal = getRunDir(executionId);
       } else if (runOutputs) {
-        // Fallback: find any output directory
+        // Defensive fallback: executionId and outputFiles are persisted independently,
+        // so edge cases (data migration, partial state) could leave files without executionId.
+        // Extract directory from actual file paths.
         for (const infos of runOutputs.values()) {
           for (const info of infos) {
             if (

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -436,9 +436,10 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
       ? this.provider.state.getRunOutputFiles(stream, { storageKey })
       : undefined;
 
-    // Trust stored executionId, don't extract from paths
-    const executionId =
-      resolvedRunId ?? this.provider.state.getExecutionId(stream);
+    // The stored executionId is the actual directory name in taskRuns/
+    // For workflow agents, storageKey differs from executionId (storageKey = task group ID)
+    // but files are always written to taskRuns/<executionId>/
+    const executionId = this.provider.state.getExecutionId(stream);
 
     try {
       let directoryToReveal: string | undefined;


### PR DESCRIPTION
For workflow agents, the storageKey (task group ID) differs from the executionId (original UUID). Files are always written to taskRuns/<executionId>/, but the progress view was incorrectly using storageKey when constructing the directory path, causing "open task run storage" to open the wrong (empty) directory.

Now correctly uses getExecutionId(stream) which returns the actual directory name where files are stored.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use executionId for physical task run directories and add a fallback to derive the directory from output file paths; clarify separation of storageKey (logical) vs executionId (physical) in diff handling.
> 
> - **Progress View**
>   - **Open Task Storage (`handleOpenTaskStorage`)**:
>     - Use `getExecutionId(stream)` as the physical directory (`taskRuns/<executionId>/`).
>     - Ensure and reveal the execution directory; improve error handling.
>     - Add defensive fallback to derive the directory from persisted output file paths when `executionId` is missing.
>   - **Diff Handling (`handleDiffStream`)**:
>     - Compute `storageKey` from `activeRunId ?? executionId` for logical indexing.
>     - Pass `executionId` as `runId` for file-system paths, clearly separating logical vs physical identifiers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d69e3014bd4ea9a18d86be03374ee48b363481a3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->