### PR TITLE
Show multiple output support in agent profile

### DIFF
--- a/src/agent/index/agentRegistry.ts
+++ b/src/agent/index/agentRegistry.ts
@@ -452,9 +452,9 @@ async function loadRemoteAgents(): Promise<AgentEntry[]> {
         name: entryName,
         source: 'remote' as AgentSource,
         path: '',
-        // Set multiplePath to indicate _multiple variant exists (for UI indicator)
-        // Use the multiple variant's name as a truthy marker
-        multiplePath: base && multiple ? multiple.name : undefined,
+        // Set multiplePath to indicate multiple output support (for UI indicator)
+        // True if _multiple variant exists, or if this IS a _multiple-only agent
+        multiplePath: multiple ? multiple.name : undefined,
         category,
         agentType,
         description: primary.description,

--- a/src/profileView/ProfileViewMessageHandler.ts
+++ b/src/profileView/ProfileViewMessageHandler.ts
@@ -67,6 +67,7 @@ export class ProfileViewMessageHandler extends BaseViewMessageHandler<
       description: entry.description || '',
       visibility: entry.visibility || ['public'],
       category: entry.category || 'workflow',
+      supportsMultipleOutput: !!entry.multiplePath,
     }));
 
     await webview.postMessage({

--- a/src/profileView/ProfileViewMessageHandler.ts
+++ b/src/profileView/ProfileViewMessageHandler.ts
@@ -20,6 +20,16 @@ import { AUTH_COMMANDS } from '@/auth/authCommands';
 // --- Message Schemas ---
 const SelectAgentMessage = z.object({ agentName: z.string().min(1) });
 
+/** Schema for remote agent data sent to webview */
+const RemoteAgentPayloadSchema = z.object({
+  name: z.string(),
+  description: z.string(),
+  visibility: z.array(z.string()),
+  category: z.string(),
+  supportsMultipleOutput: z.boolean(),
+});
+type RemoteAgentPayload = z.infer<typeof RemoteAgentPayloadSchema>;
+
 export class ProfileViewMessageHandler extends BaseViewMessageHandler<
   vscode.WebviewView | vscode.WebviewPanel
 > {
@@ -62,7 +72,7 @@ export class ProfileViewMessageHandler extends BaseViewMessageHandler<
     // All authenticated users can see agents matching their visibility access
     await loadAgents();
     const entries = getAgentsBySource('remote' as AgentSource);
-    const remoteAgents = entries.map((entry) => ({
+    const remoteAgents: RemoteAgentPayload[] = entries.map((entry) => ({
       name: entry.name,
       description: entry.description || '',
       visibility: entry.visibility || ['public'],

--- a/src/profileView/ProfileViewMessageHandler.ts
+++ b/src/profileView/ProfileViewMessageHandler.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 
 // Local imports - agent
 import { getAgentsBySource, loadAgents, type AgentSource } from '@agent/index';
+import { AgentCategory } from '@agent/core/AgentDataclass';
 import { selectAgentInMainView } from '@agent/remote/remoteAgentUtils';
 
 // Local imports - common
@@ -20,12 +21,12 @@ import { AUTH_COMMANDS } from '@/auth/authCommands';
 // --- Message Schemas ---
 const SelectAgentMessage = z.object({ agentName: z.string().min(1) });
 
-/** Schema for remote agent data sent to webview */
+/** Schema for remote agent data sent to webview (used for type inference only) */
 const RemoteAgentPayloadSchema = z.object({
   name: z.string(),
   description: z.string(),
   visibility: z.array(z.string()),
-  category: z.string(),
+  category: z.nativeEnum(AgentCategory),
   supportsMultipleOutput: z.boolean(),
 });
 type RemoteAgentPayload = z.infer<typeof RemoteAgentPayloadSchema>;
@@ -76,7 +77,7 @@ export class ProfileViewMessageHandler extends BaseViewMessageHandler<
       name: entry.name,
       description: entry.description || '',
       visibility: entry.visibility || ['public'],
-      category: entry.category || 'workflow',
+      category: entry.category || AgentCategory.Workflow,
       supportsMultipleOutput: !!entry.multiplePath,
     }));
 

--- a/src/profileView/index.html
+++ b/src/profileView/index.html
@@ -99,6 +99,9 @@
         <td class="agent-type">
           <span class="type-badge"></span>
         </td>
+        <td class="agent-multi-output">
+          <span class="multi-output-badge"></span>
+        </td>
         <td class="agent-description"></td>
         <td class="agent-visibility">
           <span class="visibility-badge"></span>

--- a/src/profileView/index.html
+++ b/src/profileView/index.html
@@ -96,8 +96,8 @@
     <template id="agentRowTemplate">
       <tr class="agent-row">
         <td class="agent-name"></td>
-        <td class="agent-type">
-          <span class="type-badge"></span>
+        <td class="agent-category">
+          <span class="category-badge"></span>
         </td>
         <td class="agent-multi-output">
           <span class="multi-output-badge"></span>

--- a/src/profileView/modules/uiManagers/AgentsTable.js
+++ b/src/profileView/modules/uiManagers/AgentsTable.js
@@ -1,6 +1,6 @@
 /* global document, console */
 // Local imports - profile view
-import { ELEMENT_IDS, LABELS, CLASS_NAMES, DEFAULTS } from '../constants.js';
+import { ELEMENT_IDS, LABELS, CLASS_NAMES } from '../constants.js';
 import { PROFILE_VIEW_COMMANDS } from '@common/webview/commands.js';
 import { vscode } from '@common/webviewContext.js';
 import { safeGetElementById } from '@common/domUtils.js';
@@ -169,7 +169,7 @@ export class AgentsTable {
     // Set agent category badge (workflow or toolUse)
     const categoryBadge = row.querySelector('.category-badge');
     if (categoryBadge) {
-      categoryBadge.textContent = agent.category || DEFAULTS.AGENT_CATEGORY;
+      categoryBadge.textContent = agent.category;
     }
 
     // Set multi-output badge with codicon and aria-label for accessibility

--- a/src/profileView/modules/uiManagers/AgentsTable.js
+++ b/src/profileView/modules/uiManagers/AgentsTable.js
@@ -172,7 +172,7 @@ export class AgentsTable {
       typeBadge.textContent = agent.category || DEFAULTS.AGENT_CATEGORY;
     }
 
-    // Set multi-output badge with codicon
+    // Set multi-output badge with codicon and aria-label for accessibility
     const multiOutputBadge = row.querySelector('.multi-output-badge');
     if (multiOutputBadge) {
       const icon = document.createElement('span');
@@ -180,9 +180,11 @@ export class AgentsTable {
       if (agent.supportsMultipleOutput) {
         icon.classList.add('codicon-check');
         multiOutputBadge.classList.add('supported');
+        multiOutputBadge.setAttribute('aria-label', 'Supports multiple outputs');
       } else {
         icon.classList.add('codicon-close');
         multiOutputBadge.classList.add('not-supported');
+        multiOutputBadge.setAttribute('aria-label', 'Single output only');
       }
       multiOutputBadge.appendChild(icon);
     }

--- a/src/profileView/modules/uiManagers/AgentsTable.js
+++ b/src/profileView/modules/uiManagers/AgentsTable.js
@@ -172,16 +172,19 @@ export class AgentsTable {
       typeBadge.textContent = agent.category || DEFAULTS.AGENT_CATEGORY;
     }
 
-    // Set multi-output badge
+    // Set multi-output badge with codicon
     const multiOutputBadge = row.querySelector('.multi-output-badge');
     if (multiOutputBadge) {
+      const icon = document.createElement('span');
+      icon.className = 'codicon';
       if (agent.supportsMultipleOutput) {
-        multiOutputBadge.textContent = 'Yes';
+        icon.classList.add('codicon-check');
         multiOutputBadge.classList.add('supported');
       } else {
-        multiOutputBadge.textContent = 'No';
+        icon.classList.add('codicon-close');
         multiOutputBadge.classList.add('not-supported');
       }
+      multiOutputBadge.appendChild(icon);
     }
 
     // Set description

--- a/src/profileView/modules/uiManagers/AgentsTable.js
+++ b/src/profileView/modules/uiManagers/AgentsTable.js
@@ -167,9 +167,9 @@ export class AgentsTable {
     if (agentName) agentName.textContent = agent.name;
 
     // Set agent category badge (workflow or toolUse)
-    const typeBadge = row.querySelector('.type-badge');
-    if (typeBadge) {
-      typeBadge.textContent = agent.category || DEFAULTS.AGENT_CATEGORY;
+    const categoryBadge = row.querySelector('.category-badge');
+    if (categoryBadge) {
+      categoryBadge.textContent = agent.category || DEFAULTS.AGENT_CATEGORY;
     }
 
     // Set multi-output badge with codicon and aria-label for accessibility

--- a/src/profileView/modules/uiManagers/AgentsTable.js
+++ b/src/profileView/modules/uiManagers/AgentsTable.js
@@ -121,7 +121,8 @@ export class AgentsTable {
     thead.innerHTML = `
       <tr>
         <th>Agent</th>
-        <th>Type</th>
+        <th>Category</th>
+        <th>Multi-Output</th>
         <th>Description</th>
         <th>Visibility</th>
         <th>Action</th>
@@ -169,6 +170,18 @@ export class AgentsTable {
     const typeBadge = row.querySelector('.type-badge');
     if (typeBadge) {
       typeBadge.textContent = agent.category || DEFAULTS.AGENT_CATEGORY;
+    }
+
+    // Set multi-output badge
+    const multiOutputBadge = row.querySelector('.multi-output-badge');
+    if (multiOutputBadge) {
+      if (agent.supportsMultipleOutput) {
+        multiOutputBadge.textContent = 'Yes';
+        multiOutputBadge.classList.add('supported');
+      } else {
+        multiOutputBadge.textContent = 'No';
+        multiOutputBadge.classList.add('not-supported');
+      }
     }
 
     // Set description

--- a/src/profileView/styles/index.css
+++ b/src/profileView/styles/index.css
@@ -190,7 +190,7 @@ h2 {
 
 .multi-output-badge.supported {
   background: var(--vscode-testing-iconPassed);
-  color: white;
+  color: var(--vscode-button-foreground);
 }
 
 .multi-output-badge.not-supported {

--- a/src/profileView/styles/index.css
+++ b/src/profileView/styles/index.css
@@ -194,9 +194,9 @@ h2 {
 }
 
 .multi-output-badge.not-supported {
-  background: var(--vscode-descriptionForeground);
-  color: var(--vscode-editor-background);
-  opacity: 0.6;
+  background: var(--vscode-input-background);
+  color: var(--vscode-descriptionForeground);
+  border: 1px solid var(--vscode-panel-border);
 }
 
 /* Select button */

--- a/src/profileView/styles/index.css
+++ b/src/profileView/styles/index.css
@@ -168,8 +168,8 @@ h2 {
   color: var(--vscode-badge-foreground);
 }
 
-/* Type badges */
-.type-badge {
+/* Category badges */
+.category-badge {
   display: inline-block;
   padding: 2px var(--spacing-small);
   border-radius: var(--border-radius-small);

--- a/src/profileView/styles/index.css
+++ b/src/profileView/styles/index.css
@@ -179,6 +179,26 @@ h2 {
   color: var(--vscode-badge-foreground);
 }
 
+/* Multi-output badges */
+.multi-output-badge {
+  display: inline-block;
+  padding: 2px var(--spacing-small);
+  border-radius: var(--border-radius-small);
+  font-size: var(--font-size-sm);
+  font-weight: 500;
+}
+
+.multi-output-badge.supported {
+  background: var(--vscode-testing-iconPassed);
+  color: white;
+}
+
+.multi-output-badge.not-supported {
+  background: var(--vscode-descriptionForeground);
+  color: var(--vscode-editor-background);
+  opacity: 0.6;
+}
+
 /* Select button */
 .select-btn {
   white-space: nowrap;


### PR DESCRIPTION
Add a new "Multi-Output" column to the agents table in the profile view that shows whether each agent supports processing multiple documents.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Category and Multi-Output columns to the Profile view, wiring a new supportsMultipleOutput flag from the backend and refining remote agent multiplePath detection.
> 
> - **Frontend (Profile View)**:
>   - **Agents table**: Add `Category` and `Multi-Output` columns; update row template and header.
>   - **Badges/UI**: Render `category-badge` and `multi-output-badge` (check/close icons, ARIA labels); add corresponding CSS styles.
> - **Backend**:
>   - **Profile data**: Include `supportsMultipleOutput` (derived from `entry.multiplePath`) and use `AgentCategory` enum in payload.
>   - **Agent registry**: For remote agents, set `multiplePath` when a `_multiple` variant exists or when the agent is `_multiple`-only; minor comment clarifications.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9c91e3e7855a12c0d58e7ac755907d4f18d91cf3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->