### PR TITLE
Disable email login temporarily

### DIFF
--- a/src/auth/authCommands.ts
+++ b/src/auth/authCommands.ts
@@ -67,7 +67,8 @@ export async function signIn(): Promise<void> {
       return;
     }
 
-    // Build sign-in options: OAuth providers + email
+    // Build sign-in options: OAuth providers only
+    // Note: Email magic link option is disabled due to remote configuration issues
     const signInOptions: SignInOption[] = [
       // OAuth providers
       ...OAUTH_PROVIDERS.map((provider) => ({
@@ -75,12 +76,12 @@ export async function signIn(): Promise<void> {
         description: `Sign in with ${OAUTH_PROVIDER_LABELS[provider].label}`,
         method: provider as AuthMethod,
       })),
-      // Email magic link option
-      {
-        label: '$(mail) Email',
-        description: 'Sign in with a magic link sent to your email',
-        method: 'email' as AuthMethod,
-      },
+      // Email magic link option - temporarily disabled
+      // {
+      //   label: '$(mail) Email',
+      //   description: 'Sign in with a magic link sent to your email',
+      //   method: 'email' as AuthMethod,
+      // },
     ];
 
     const selected = await vscode.window.showQuickPick(signInOptions, {

--- a/src/auth/authCommands.ts
+++ b/src/auth/authCommands.ts
@@ -38,6 +38,9 @@ export function initializeProfileViewProvider(
 /** Auth method type including OAuth providers and email */
 type AuthMethod = OAuthProvider | 'email';
 
+/** Email login is disabled due to remote configuration issues */
+const EMAIL_LOGIN_ENABLED = false;
+
 /** All sign-in options shown to users */
 interface SignInOption {
   label: string;
@@ -67,21 +70,22 @@ export async function signIn(): Promise<void> {
       return;
     }
 
-    // Build sign-in options: OAuth providers only
-    // Note: Email magic link option is disabled due to remote configuration issues
+    // Build sign-in options from enabled auth methods
     const signInOptions: SignInOption[] = [
-      // OAuth providers
       ...OAUTH_PROVIDERS.map((provider) => ({
         label: `${OAUTH_PROVIDER_LABELS[provider].icon} ${OAUTH_PROVIDER_LABELS[provider].label}`,
         description: `Sign in with ${OAUTH_PROVIDER_LABELS[provider].label}`,
         method: provider as AuthMethod,
       })),
-      // Email magic link option - temporarily disabled
-      // {
-      //   label: '$(mail) Email',
-      //   description: 'Sign in with a magic link sent to your email',
-      //   method: 'email' as AuthMethod,
-      // },
+      ...(EMAIL_LOGIN_ENABLED
+        ? [
+            {
+              label: '$(mail) Email',
+              description: 'Sign in with a magic link sent to your email',
+              method: 'email' as AuthMethod,
+            },
+          ]
+        : []),
     ];
 
     const selected = await vscode.window.showQuickPick(signInOptions, {


### PR DESCRIPTION
Hide email magic link sign-in from the selection menu due to remote configuration issues. The implementation code is preserved for future re-enablement.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Hide the email sign-in option by gating it behind `EMAIL_LOGIN_ENABLED=false`, keeping implementation intact.
> 
> - **Auth**:
>   - Gate email magic link option behind `EMAIL_LOGIN_ENABLED` (set to `false`).
>   - Build sign-in menu from enabled methods; only OAuth providers are shown.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 69cf2077302cb7d09fd17d768e31c0acee87fd59. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->