### PR TITLE
refactor(tools): improve separation of concerns for tool definitions

### DIFF
--- a/src/agent/core/AgentDataclass.ts
+++ b/src/agent/core/AgentDataclass.ts
@@ -2,7 +2,7 @@
 import { z } from 'zod';
 
 // Local imports - model types
-import { ToolDefinitionSchema } from '@model';
+import { ToolDefinitionSchema, type ToolDefinition } from '@model';
 
 // Local imports - session schema (imported for local use, re-exported below)
 import type { AgentSessionDescriptor } from './AgentSessionSchema';
@@ -89,7 +89,11 @@ export const AgentSettingBaseSchema = z.strictObject({
     )
     .prefault([]),
 
-  tools: z.array(ToolDefinitionSchema).prefault([]),
+  // Use custom validator that validates via schema but preserves ToolDefinition type
+  // This bridges the gap between schema validation and TypeScript typing
+  tools: z
+    .array(z.custom<ToolDefinition>((val) => ToolDefinitionSchema.safeParse(val).success))
+    .prefault([]),
 });
 
 /**

--- a/src/agent/modelHandlers/toolConversion.ts
+++ b/src/agent/modelHandlers/toolConversion.ts
@@ -14,7 +14,10 @@ import type {
   Schema,
   GoogleSearch,
 } from '@google/genai/dist/genai';
-import type { ChatCompletionTool } from 'openai/resources/chat/completions';
+import type {
+  ChatCompletionTool,
+  ChatCompletionFunctionTool,
+} from 'openai/resources/chat/completions';
 import type {
   FunctionTool,
   WebSearchTool,
@@ -73,6 +76,8 @@ export function toOpenAITools(defs: ToolDefinition[]): ChatCompletionTool[] {
     }
 
     // Fallback to manual conversion for legacy definitions
+    // Cast to ChatCompletionFunctionTool since ToolDefinition.parameters
+    // is a union type that includes provider-specific schemas
     return {
       type: 'function',
       function: {
@@ -80,7 +85,7 @@ export function toOpenAITools(defs: ToolDefinition[]): ChatCompletionTool[] {
         description: d.description,
         parameters: d.parameters,
       },
-    };
+    } as ChatCompletionFunctionTool;
   });
 }
 

--- a/src/model/ToolDefinition.ts
+++ b/src/model/ToolDefinition.ts
@@ -10,16 +10,19 @@ import type { Schema as GeminiSchema } from '@google/genai/dist/genai';
  * Zod schema for validating tool definitions from YAML configs and external sources.
  *
  * Note: The zodSchema field is a runtime-only property added by defineTool() and
- * is not part of this validation schema. It's only present on the TypeScript type.
+ * is not part of this validation schema. Using passthrough() allows runtime-only
+ * properties like zodSchema to pass validation without being stripped.
  */
-export const ToolDefinitionSchema = z.strictObject({
-  /** Name of the tool or function */
-  name: z.string(),
-  /** Optional description for the model */
-  description: z.string().optional(),
-  /** Parameter schema or provider specific metadata */
-  parameters: z.record(z.string(), z.unknown()).optional(),
-});
+export const ToolDefinitionSchema = z
+  .object({
+    /** Name of the tool or function */
+    name: z.string(),
+    /** Optional description for the model */
+    description: z.string().optional(),
+    /** Parameter schema or provider specific metadata */
+    parameters: z.record(z.string(), z.unknown()).optional(),
+  })
+  .passthrough();
 
 /**
  * Generic tool definition used across model providers. The parameters field

--- a/src/model/ToolDefinition.ts
+++ b/src/model/ToolDefinition.ts
@@ -6,12 +6,22 @@ import type { FunctionDefinition } from 'openai/resources/shared';
 import type { Tool as AnthropicTool } from '@anthropic-ai/sdk/resources/messages/messages';
 import type { Schema as GeminiSchema } from '@google/genai/dist/genai';
 
+// ============================================================================
+// Tool Definition Schema
+// ============================================================================
+
 /**
- * Zod schema for validating tool definitions from YAML configs and external sources.
+ * Zod schema for validating tool definition structure.
  *
- * Note: The zodSchema field is a runtime-only property added by defineTool() and
- * is not part of this validation schema. Using passthrough() allows runtime-only
- * properties like zodSchema to pass validation without being stripped.
+ * Design notes:
+ * - Uses z.object() (not strictObject) with passthrough() to allow runtime-only
+ *   fields like `zodSchema` that are added by defineTool()
+ * - The schema validates the serializable fields (name, description, parameters)
+ * - The TypeScript `ToolDefinition` type provides full typing including runtime fields
+ *
+ * This separation is intentional:
+ * - Schema: validates data structure from YAML/JSON
+ * - Type: provides full TypeScript typing for runtime usage
  */
 export const ToolDefinitionSchema = z
   .object({
@@ -24,15 +34,25 @@ export const ToolDefinitionSchema = z
   })
   .passthrough();
 
+// ============================================================================
+// Tool Definition Type
+// ============================================================================
+
 /**
- * Generic tool definition used across model providers. The parameters field
- * aligns with OpenAI, Anthropic and Google Gemini function schemas.
+ * Full tool definition type used across model providers.
  *
- * This type extends the validated schema with:
- * - Provider-specific parameter types for better type inference
- * - Runtime-only zodSchema field (added by defineTool(), not from YAML)
+ * Note: This type is NOT derived from ToolDefinitionSchema via z.infer because:
+ * 1. `parameters` needs provider-specific types (OpenAI, Anthropic, Gemini)
+ * 2. `zodSchema` is a runtime-only field (ZodType can't be validated by Zod)
+ *
+ * The schema validates structure; this type provides TypeScript typing.
  */
-export type ToolDefinition = z.infer<typeof ToolDefinitionSchema> & {
+export type ToolDefinition = {
+  /** Name of the tool or function */
+  name: string;
+  /** Optional description for the model */
+  description?: string;
+  /** Parameter schema - accepts provider-specific formats */
   parameters?:
     | FunctionDefinition['parameters']
     | AnthropicTool['input_schema']
@@ -40,7 +60,21 @@ export type ToolDefinition = z.infer<typeof ToolDefinitionSchema> & {
   /**
    * Original Zod schema for SDK-native Zod support (runtime-only, not serialized).
    * When present, conversion functions use native toJSONSchema() for conversion.
-   * Added by defineTool() - not present in YAML configs or validated by schema.
+   * Added by defineTool() - not present in YAML configs.
    */
   zodSchema?: ZodType;
 };
+
+// ============================================================================
+// Type Guards and Utilities
+// ============================================================================
+
+/**
+ * Check if a tool definition has a Zod schema attached.
+ * Tools created via defineTool() will have this, YAML-loaded tools won't.
+ */
+export function hasZodSchema(
+  def: ToolDefinition,
+): def is ToolDefinition & { zodSchema: ZodType } {
+  return def.zodSchema !== undefined;
+}


### PR DESCRIPTION
Changed ToolDefinitionSchema from strictObject to object with passthrough() to allow the runtime-only zodSchema property added by defineTool() to pass validation when tools are validated in AgentSettingBaseSchema.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Allow passthrough runtime tool fields, preserve ToolDefinition typing in agent settings, and align OpenAI tool conversion/types.
> 
> - **Model (`src/model/ToolDefinition.ts`)**:
>   - Change `ToolDefinitionSchema` from `strictObject` to `object().passthrough()` to accept runtime-only fields (e.g., `zodSchema`).
>   - Define explicit `ToolDefinition` type (provider-specific `parameters`, optional `zodSchema`) and add `hasZodSchema` type guard.
> - **Core (`src/agent/core/AgentDataclass.ts`)**:
>   - Update `AgentSettingBaseSchema.tools` to use `z.custom<ToolDefinition>(...)` validated via `ToolDefinitionSchema.safeParse` to preserve `ToolDefinition` typing.
> - **Model Handlers (`src/agent/modelHandlers/toolConversion.ts`)**:
>   - Adjust OpenAI tool conversion fallback to return `ChatCompletionFunctionTool`; add corresponding import; minor typing/comments cleanup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 309469cc8bfafd3f040960c2e5d1f80a2a289660. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->