### PR TITLE
Fix profile view agent selection switching

### DIFF
--- a/src/webview/modules/mainViewState.js
+++ b/src/webview/modules/mainViewState.js
@@ -352,11 +352,24 @@ export class MainViewState {
       selectEl.setAttribute('aria-hidden', isActive ? 'false' : 'true');
       selectEl.tabIndex = isActive ? 0 : -1;
       if (isActive && !selectEl.value) {
-        const fallback = getSelectDefaultValue(
-          selectId,
-          getSessionDefaultAgent(normalized),
-        );
-        safeSetElementValue(selectId, fallback);
+        // Check stored state first - DOM might not be updated yet for custom elements
+        // (vscode-single-select may not synchronously update .value)
+        const storedState = this.stateManager.getState() || {};
+        const stateKey =
+          normalized === SESSION_TYPES.TOOL_USE ? 'toolUseAgent' : 'workflowAgent';
+        const storedValue = storedState[stateKey];
+
+        if (storedValue) {
+          // DOM is stale but we have a stored value - use it
+          safeSetElementValue(selectId, storedValue);
+        } else {
+          // Truly empty - apply default
+          const fallback = getSelectDefaultValue(
+            selectId,
+            getSessionDefaultAgent(normalized),
+          );
+          safeSetElementValue(selectId, fallback);
+        }
       }
     });
 

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -279,8 +279,9 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
         mainViewState.update({ [stateKey]: targetValue });
 
         // NOW switch session type UI (shows correct dropdown, updates radio buttons)
-        // The value is already set, so applySessionType won't override with default
-        mainViewState.applySessionType(targetSessionType);
+        // Pass skipSave: true since we already updated state via mainViewState.update()
+        // This prevents save() from reading stale DOM values for custom elements
+        mainViewState.applySessionType(targetSessionType, { skipSave: true });
 
         // Decorate the placeholder option if it was just created
         // Re-query options since _setAgentValue may have added a new option


### PR DESCRIPTION
…switch

The issue was a race condition between DOM updates and state checks when switching agents from the profile view:

1. `_setAgentValue()` sets DOM value, but vscode-single-select custom elements may not synchronously update their `.value` property
2. `applySessionType()` checks `selectEl.value` which could still be empty, causing it to override with the default agent

The fix:
- In `applySessionType()`: Check stored state before applying defaults when DOM value appears empty (DOM might be stale for custom elements)
- In `SET_SELECTED_AGENT` handler: Pass `skipSave: true` to prevent `save()` from reading stale DOM values immediately after setting

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensure agent dropdown retains the selected value when switching sessions by preferring stored state over empty DOM values and skipping save to avoid stale reads.
> 
> - **Webview state/UI**:
>   - `mainViewState.applySessionType(...)`: When activating an agent select, prefer stored state (`workflowAgent`/`toolUseAgent`) if the DOM value is empty; only then fall back to default.
>   - `SET_SELECTED_AGENT` handler: After setting the agent and updating state, call `applySessionType(..., { skipSave: true })` to prevent `save()` from reading stale values from custom elements.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4eddfecd36ae3e86059c9947e4d924ab79489e93. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->