### PR TITLE
Reduce reasoning effort for tool use agent

### DIFF
--- a/src/agent/core/AgentCycleOptions.ts
+++ b/src/agent/core/AgentCycleOptions.ts
@@ -5,6 +5,7 @@ import { z } from 'zod';
 import type { IModelHandler } from '@agent/modelHandlers';
 import type { AgentExecutionContext } from '@agent/runtime/AgentExecutionContext';
 import type { AgentLogger } from '@logger/AgentLogger';
+import type { ReasoningEffort } from '@model/ModelConfig';
 import type { AgentPrompt, AgentSetting } from './AgentDataclass';
 
 export interface UserVariableChannels {
@@ -34,4 +35,6 @@ export interface AgentCycleBaseOptions<C = unknown> {
   client: C;
   checkInterruption: () => Promise<boolean> | boolean;
   setAbortController: (ctrl: AbortController | null) => void;
+  /** Optional override for reasoning effort (used by tool-use agents) */
+  reasoningEffortOverride?: ReasoningEffort;
 }

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -335,6 +335,7 @@ class ToolUseCallNode<C> extends Node<
         temperature: options.agentSetting.temperature ?? 0,
         signal: abortController.signal,
         tools: options.agentSetting.tools as ToolDefinition[] | undefined,
+        reasoningEffortOverride: options.reasoningEffortOverride,
       });
 
       const responseTime = (Date.now() - start) / 1000;

--- a/src/agent/implementations/BaseToolUseAgent.ts
+++ b/src/agent/implementations/BaseToolUseAgent.ts
@@ -3,6 +3,7 @@ import type { IModelHandler } from '@agent/modelHandlers';
 
 // Internal imports
 import { runToolUseCycle } from '@agent/core/ToolUseCycle';
+import { ModelProvider, ReasoningEffort } from '@model/ModelConfig';
 // Type imports
 import type { ToolUseCycleOptions } from '@agent/core/ToolUseCycle';
 // Internal imports
@@ -290,12 +291,23 @@ export class BaseToolUseAgent<C = unknown> extends BaseAgent<C> {
       client,
     });
 
+    // Use medium reasoning effort for OpenAI models in tool-use mode
+    // to reduce latency and cost while maintaining quality
+    const capabilities = this.modelHandler.config.capabilities;
+    const isOpenAIReasoning =
+      this.modelHandler.config.provider === ModelProvider.OPENAI &&
+      capabilities.supportsReasoning &&
+      capabilities.supportsReasoningEffort;
+
     return {
       ...baseOptions,
       toolRegistry: this.toolRegistry,
       workspaceState: store.workspace,
       modelName: this.agentConfig.model,
       agentName: this.agentConfig.agent,
+      reasoningEffortOverride: isOpenAIReasoning
+        ? ReasoningEffort.MEDIUM
+        : undefined,
     };
   }
 

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -155,6 +155,7 @@ export class ModelHandlerOpenAI<
     systemPrompt?: string,
     endTag?: string,
     tools?: ToolDefinition[],
+    reasoningEffortOverride?: string,
   ): ChatCompletionRequestBase {
     const baseParams: ChatCompletionRequestBase = {
       model: this.config.fullName,
@@ -171,13 +172,17 @@ export class ModelHandlerOpenAI<
       baseParams.temperature = temperature;
     }
 
+    // Use override if provided, otherwise fall back to config
+    const effectiveReasoningEffort =
+      reasoningEffortOverride ?? this.config.capabilities.reasoningEffort;
+
     if (
       this.config.capabilities.supportsReasoning &&
       this.config.capabilities.supportsReasoningEffort &&
-      this.config.capabilities.reasoningEffort
+      effectiveReasoningEffort
     ) {
       baseParams.reasoning_effort = this.validateReasoningEffort(
-        this.config.capabilities.reasoningEffort,
+        effectiveReasoningEffort,
       ) as ChatCompletionRequestBase['reasoning_effort'];
     }
 
@@ -418,6 +423,7 @@ export class ModelHandlerOpenAI<
       endTag,
       signal,
       tools,
+      reasoningEffortOverride,
     } = options;
 
     // Apply message normalization if subclass specifies options
@@ -433,6 +439,7 @@ export class ModelHandlerOpenAI<
       systemPrompt,
       endTag,
       tools,
+      reasoningEffortOverride,
     );
 
     if (useStreaming) {

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -537,8 +537,15 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
   async createResponse(
     options: CreateResponseOptions<ResponseInputItem, OpenAI>,
   ): Promise<Response> {
-    const { client, messages, temperature, systemPrompt, signal, tools } =
-      options;
+    const {
+      client,
+      messages,
+      temperature,
+      systemPrompt,
+      signal,
+      tools,
+      reasoningEffortOverride,
+    } = options;
     const _endTag = options.endTag; // Unused but kept for compatibility
     const streamingToggleEnabled = this.getStreamingConfig();
     const backgroundToggleEnabled = getConfig<boolean>(
@@ -634,12 +641,15 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       if (includeSummary) {
         reasoning.summary = 'auto';
       }
+      // Use override if provided, otherwise fall back to config
+      const effectiveReasoningEffort =
+        reasoningEffortOverride ?? this.capabilities.reasoningEffort;
       if (
         this.capabilities.supportsReasoningEffort &&
-        this.capabilities.reasoningEffort &&
-        this.capabilities.reasoningEffort !== 'none'
+        effectiveReasoningEffort &&
+        effectiveReasoningEffort !== 'none'
       ) {
-        reasoning.effort = this.capabilities.reasoningEffort;
+        reasoning.effort = effectiveReasoningEffort;
       }
       params.reasoning = reasoning;
     }

--- a/src/agent/modelHandlers/modelHandlerOpenRouter.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenRouter.ts
@@ -110,7 +110,15 @@ export class ModelHandlerOpenRouter extends ModelHandlerOpenAI {
   async createResponse(
     options: CreateResponseOptions<ChatCompletionMessageParam, OpenAI>,
   ): Promise<ChatCompletion> {
-    const { client, messages, temperature, endTag, signal, tools } = options;
+    const {
+      client,
+      messages,
+      temperature,
+      endTag,
+      signal,
+      tools,
+      reasoningEffortOverride,
+    } = options;
     // Get streaming config
     const useStreaming = this.getStreamingConfig();
 
@@ -122,6 +130,10 @@ export class ModelHandlerOpenRouter extends ModelHandlerOpenAI {
       extra_headers: { 'X-Title': 'TeXRA.ai' },
     };
 
+    // Use override if provided, otherwise fall back to config
+    const effectiveReasoningEffort =
+      reasoningEffortOverride ?? this.config.capabilities.reasoningEffort;
+
     // Reasoning parameters vary by model via OpenRouter:
     // - O1-style models: use reasoning.effort + include_reasoning
     // - DeepSeek V3.2: use reasoning.enabled (no include_reasoning needed,
@@ -129,13 +141,11 @@ export class ModelHandlerOpenRouter extends ModelHandlerOpenAI {
     if (this.config.capabilities.supportsReasoning) {
       if (
         this.config.capabilities.supportsReasoningEffort &&
-        this.config.capabilities.reasoningEffort
+        effectiveReasoningEffort
       ) {
         // O1-style models with effort levels
         kwargs.reasoning = {
-          effort: this.validateReasoningEffort(
-            this.config.capabilities.reasoningEffort,
-          ),
+          effort: this.validateReasoningEffort(effectiveReasoningEffort),
         };
         kwargs.include_reasoning = true;
       } else {

--- a/src/agent/modelHandlers/types/IModelHandler.ts
+++ b/src/agent/modelHandlers/types/IModelHandler.ts
@@ -9,7 +9,12 @@ import type { NormalizedUsage } from '@agent/types/NormalizedUsage';
 // Type imports
 import type { MediaEntry } from '@agent/utils/mediaTypes';
 import type { AgentLogger } from '@logger/AgentLogger';
-import type { ModelConfig, ModelCapabilities, ToolDefinition } from '@model';
+import type {
+  ModelConfig,
+  ModelCapabilities,
+  ReasoningEffort,
+  ToolDefinition,
+} from '@model';
 import type { ToolFileAttachment } from '@tools/result';
 import type { FileLocation } from '@utils/files';
 import type { ToolResultPayload } from '../utils/toolAttachmentUtils';
@@ -49,6 +54,8 @@ export interface CreateResponseOptions<
   signal?: AbortSignal;
   /** Optional tool definitions for function calling */
   tools?: ToolDefinition[];
+  /** Optional override for reasoning effort (used by tool-use agents) */
+  reasoningEffortOverride?: ReasoningEffort;
 }
 
 /**


### PR DESCRIPTION
… OpenAI models

Add reasoningEffortOverride mechanism to allow agents to customize reasoning effort per-session. BaseToolUseAgent sets MEDIUM reasoning effort for OpenAI reasoning models to reduce latency and cost while maintaining quality for tool-use interactions.

Changes:
- Add reasoningEffortOverride to AgentCycleBaseOptions and CreateResponseOptions
- Update OpenAI, OpenRouter, and OpenAI Response handlers to use override
- Set MEDIUM reasoning effort in BaseToolUseAgent for OpenAI reasoning models

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a `reasoningEffortOverride` plumbed through agent cycle and model handlers, setting MEDIUM effort for OpenAI reasoning models in tool-use mode.
> 
> - **Core/Options**
>   - Add `reasoningEffortOverride?: ReasoningEffort` to `AgentCycleBaseOptions` and pass through `ToolUseCycleFlow` to model handler `createResponse`.
> - **Agent**
>   - `BaseToolUseAgent`: sets `reasoningEffortOverride` to `ReasoningEffort.MEDIUM` when provider is OpenAI and supports reasoning/effort.
> - **Model Handlers**
>   - `modelHandlerOpenAI`, `modelHandlerOpenAIResponse`, `modelHandlerOpenRouter`: accept `reasoningEffortOverride` in `createResponse` and use it when building params (`reasoning_effort`/`reasoning.effort`).
> - **Types**
>   - Extend `CreateResponseOptions` and imports to include `ReasoningEffort`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e6b918ee326740418d2210bdf0953e30f67e3fb5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->