### PR TITLE
Fix LaTeX formatting in centered text block

### DIFF
--- a/src/replacement/rulesRegex.ts
+++ b/src/replacement/rulesRegex.ts
@@ -375,10 +375,6 @@ export const EQUATION_STYLE_REPLACEMENTS: ReplacementCategory = {
     '(\\\\end\\{(equation|align|figure|table|itemize|enumerate|description)\\})([A-Za-z])':
       '$1\n\n$3',
 
-    // Remove spaces inside formatting
-    '\\\\(?:textbf|textit|emph|underline|overbrace|underbrace|label)\\{\\s+([^}]*)\\s+\\}':
-      '\\$1{$2}',
-
     // Fix space before closing braces in commands (nearly universal style)
     // '\\\\(textbf|textit|emph|underline)\\{([^{}]*)\\s+\\}': '\\\\$1{$2}', // might not working now
 


### PR DESCRIPTION
…ar commands

The consolidated replacement rule used a non-capturing group for command names but referenced $2 in the replacement, which doesn't exist. This caused \emph{...} to be incorrectly transformed to \...content{$2}.

The individual rules below (textbf, textit, emph, etc.) already handle each command correctly, so the broken consolidated rule is redundant.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the broken consolidated regex that trimmed spaces inside multiple LaTeX commands, relying on existing per-command rules instead.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bcacd479708c9413d0c872cca52667db947c3a7e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->