### PR TITLE
Fix model dropdown reverting selection to none

### DIFF
--- a/src/webview/modules/mainViewState.js
+++ b/src/webview/modules/mainViewState.js
@@ -91,6 +91,10 @@ function getSelectDefaultValue(selectId, fallback) {
 export class MainViewState {
   constructor() {
     this.stateManager = new WebviewStateManager();
+    // Guard flag to prevent save() during restore() - vscode-single-select
+    // fires 'change' events on programmatic value changes, which would trigger
+    // save() and capture partial/inconsistent DOM state
+    this._isRestoring = false;
   }
 
   get() {
@@ -150,6 +154,24 @@ export class MainViewState {
 
   /** Restore state from VS Code storage */
   restore() {
+    this._isRestoring = true;
+    let needsSaveAfter = false;
+    try {
+      needsSaveAfter = this._restoreImpl();
+    } finally {
+      this._isRestoring = false;
+    }
+    // If setDefaults() was called, its save() was skipped due to _isRestoring
+    // flag, so we need to save now after the flag is cleared
+    if (needsSaveAfter) {
+      this.save();
+    }
+  }
+
+  /**
+   * @returns {boolean} true if setDefaults() was called and needs a save after
+   */
+  _restoreImpl() {
     const previousState = this.stateManager.getState();
     if (previousState) {
       const defaults = {
@@ -238,15 +260,22 @@ export class MainViewState {
       }
 
       this.applySessionType(normalizedSessionType, { skipSave: true });
+      fileList.hideEmpty(MULTIPLE_SELECTIONS);
+      return false; // No save needed - state already exists
     } else {
       this.setDefaults();
+      fileList.hideEmpty(MULTIPLE_SELECTIONS);
+      return true; // setDefaults() save was skipped, needs save after
     }
-
-    fileList.hideEmpty(MULTIPLE_SELECTIONS);
   }
 
   /** Persist current UI state */
   save() {
+    // Skip save during restore to prevent capturing partial/inconsistent state
+    if (this._isRestoring) {
+      return;
+    }
+
     const state = {
       latexdiffsVisible:
         safeGetElementById(ELEMENT_IDS.LATEXDIFFS_CONTENT)?.style.display ===


### PR DESCRIPTION
The MODEL_SELECTED response handler was calling postHandle() which triggers restore(). During restore(), vscode-single-select fires 'change' events when values are set programmatically. This caused SettingsButtonManager's model change handler to call save() before mediaFile was restored, corrupting the saved state with stale values.

Fix: Remove the postHandle() call since it's unnecessary - the model was already set by user interaction and state was saved before posting.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents saving during restore to avoid inconsistent UI state, refactors restore logic with a deferred save after defaults, and ensures empty file lists are hidden.
> 
> - **Webview state management (`src/webview/modules/mainViewState.js`)**:
>   - Add `_isRestoring` flag to block `save()` during `restore()` to avoid capturing partial DOM state.
>   - Refactor `restore()` into `_restoreImpl()` that returns whether a post-restore save is needed; perform deferred save when defaults are applied.
>   - Ensure `fileList.hideEmpty(MULTIPLE_SELECTIONS)` is called after both existing-state and defaults paths.
>   - Call `applySessionType(..., { skipSave: true })` during restore to avoid unintended saves.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d44326a08975bb8a0c176d9f3cf31916edbf6aba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->