### PR TITLE
Auto-refresh stream list on status change

### DIFF
--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -315,14 +315,11 @@ export class ProgressEventHandler {
     }
 
     if (this.webviewUpdater.isAvailable()) {
-      // Check if the stream tab exists before deciding update strategy
-      if (this.state.streamTabs.has(stream)) {
-        // Use targeted single-stream update for existing tabs
-        this.webviewUpdater.updateStreamStatus(stream, status);
-      } else {
-        // New stream: need full updateStreams to create the tab
-        this.webviewUpdater.updateAll(this.state, this._streamStatus);
-      }
+      // Always do full stream list refresh when status changes.
+      // This ensures timestamps and sorting are updated, not just the status dot.
+      // Previously only updateStreamStatus was called for existing tabs, which
+      // left the "last activity" timestamps stale until the user clicked.
+      this.webviewUpdater.updateAll(this.state, this._streamStatus);
 
       if (stream === this.state.activeStream) {
         this.webviewUpdater.updateStatus(status);

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -329,6 +329,8 @@ export class ProgressEventHandler {
       } else {
         // Targeted update - frontend handles main status update via handleUpdateStreamStatus
         const logs = this.state.streamTabs.getMessages(stream);
+        // Note: lastTimestamp may be undefined if logs exist but last entry has no timestamp.
+        // Frontend guards against invalid timestamps (0, undefined) with lastTimestamp > 0 check.
         const lastTimestamp =
           logs.length > 0 ? logs.at(-1)?.timestamp : undefined;
         this.webviewUpdater.updateStreamStatus(stream, status, lastTimestamp);

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -315,14 +315,20 @@ export class ProgressEventHandler {
     }
 
     if (this.webviewUpdater.isAvailable()) {
-      if (this.state.streamTabs.has(stream)) {
+      // When sorted by time, status changes may affect tab order (due to new log entries),
+      // so we need a full refresh. Otherwise use efficient targeted update.
+      const needsFullRefresh =
+        !this.state.streamTabs.has(stream) ||
+        this.state.streamSortOrder === 'time';
+
+      if (needsFullRefresh) {
+        this.webviewUpdater.updateAll(this.state, this._streamStatus);
+      } else {
         // Targeted update: send status and latest timestamp for efficient DOM update
         const logs = this.state.streamTabs.getMessages(stream);
-        const lastTimestamp = logs.length > 0 ? logs.at(-1)?.timestamp : undefined;
+        const lastTimestamp =
+          logs.length > 0 ? logs.at(-1)?.timestamp : undefined;
         this.webviewUpdater.updateStreamStatus(stream, status, lastTimestamp);
-      } else {
-        // New stream: need full updateStreams to create the tab
-        this.webviewUpdater.updateAll(this.state, this._streamStatus);
       }
 
       if (stream === this.state.activeStream) {

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -322,17 +322,14 @@ export class ProgressEventHandler {
         this.state.streamSortOrder === 'time';
 
       if (needsFullRefresh) {
+        // Full refresh - frontend handles main status update via handleUpdateStreams
         this.webviewUpdater.updateAll(this.state, this._streamStatus);
       } else {
-        // Targeted update: send status and latest timestamp for efficient DOM update
+        // Targeted update - frontend handles main status update via handleUpdateStreamStatus
         const logs = this.state.streamTabs.getMessages(stream);
         const lastTimestamp =
           logs.length > 0 ? logs.at(-1)?.timestamp : undefined;
         this.webviewUpdater.updateStreamStatus(stream, status, lastTimestamp);
-      }
-
-      if (stream === this.state.activeStream) {
-        this.webviewUpdater.updateStatus(status);
       }
     }
   }

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -306,12 +306,11 @@ export class ProgressEventHandler {
    * Set the status for a specific stream synchronously.
    */
   setStreamStatus(stream: string, status: StreamStatus): void {
+    // Update the persistent status map first
     if (status === STREAM_STATUS.READY) {
       this._streamStatus.delete(stream);
     } else {
-      // Status is not 'ready', so it's a valid active status
-      const nextStatus = status;
-      this._streamStatus.set(stream, nextStatus);
+      this._streamStatus.set(stream, status);
     }
 
     if (this.webviewUpdater.isAvailable()) {
@@ -322,8 +321,11 @@ export class ProgressEventHandler {
         this.state.streamSortOrder === 'time';
 
       if (needsFullRefresh) {
-        // Full refresh - frontend handles main status update via handleUpdateStreams
-        this.webviewUpdater.updateAll(this.state, this._streamStatus);
+        // Include current status in refresh map so frontend displays it correctly.
+        // READY is deleted from _streamStatus but should still be shown to user.
+        const statusesForRefresh = new Map(this._streamStatus);
+        statusesForRefresh.set(stream, status);
+        this.webviewUpdater.updateAll(this.state, statusesForRefresh);
       } else {
         // Targeted update - frontend handles main status update via handleUpdateStreamStatus
         const logs = this.state.streamTabs.getMessages(stream);

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -315,11 +315,15 @@ export class ProgressEventHandler {
     }
 
     if (this.webviewUpdater.isAvailable()) {
-      // Always do full stream list refresh when status changes.
-      // This ensures timestamps and sorting are updated, not just the status dot.
-      // Previously only updateStreamStatus was called for existing tabs, which
-      // left the "last activity" timestamps stale until the user clicked.
-      this.webviewUpdater.updateAll(this.state, this._streamStatus);
+      if (this.state.streamTabs.has(stream)) {
+        // Targeted update: send status and latest timestamp for efficient DOM update
+        const logs = this.state.streamTabs.getMessages(stream);
+        const lastTimestamp = logs.length > 0 ? logs.at(-1)?.timestamp : undefined;
+        this.webviewUpdater.updateStreamStatus(stream, status, lastTimestamp);
+      } else {
+        // New stream: need full updateStreams to create the tab
+        this.webviewUpdater.updateAll(this.state, this._streamStatus);
+      }
 
       if (stream === this.state.activeStream) {
         this.webviewUpdater.updateStatus(status);

--- a/src/progressView/managers/WebviewUpdater.ts
+++ b/src/progressView/managers/WebviewUpdater.ts
@@ -322,7 +322,7 @@ export class WebviewUpdater {
     lastTimestamp?: number,
   ): void {
     const message: UpdateStreamStatusMessage = {
-      command: 'UPDATE_STREAM_STATUS',
+      command: COMMANDS.UPDATE_STREAM_STATUS as 'updateStreamStatus',
       stream,
       status,
       lastTimestamp,

--- a/src/progressView/managers/WebviewUpdater.ts
+++ b/src/progressView/managers/WebviewUpdater.ts
@@ -321,13 +321,12 @@ export class WebviewUpdater {
     status: StreamStatus,
     lastTimestamp?: number,
   ): void {
-    const message: UpdateStreamStatusMessage = {
-      command: COMMANDS.UPDATE_STREAM_STATUS as 'updateStreamStatus',
+    this.sendMessage({
+      command: COMMANDS.UPDATE_STREAM_STATUS,
       stream,
       status,
       lastTimestamp,
-    };
-    this.sendMessage(message);
+    } satisfies Omit<UpdateStreamStatusMessage, 'command'> & { command: string });
   }
 
   /**

--- a/src/progressView/managers/WebviewUpdater.ts
+++ b/src/progressView/managers/WebviewUpdater.ts
@@ -15,7 +15,11 @@ import {
 import { AgentLogger } from '@logger/AgentLogger';
 import { LogMessageData } from '@logger/LogTypes';
 import type { TaskState } from '@logger/TaskState';
-import type { InstructionUpdate, StreamTabInfo } from '@progressView/types';
+import type {
+  InstructionUpdate,
+  StreamTabInfo,
+  UpdateStreamStatusMessage,
+} from '@progressView/types';
 // Internal imports
 import { buildStreamInfos } from '@progressView/streamInfoUtils';
 
@@ -317,12 +321,13 @@ export class WebviewUpdater {
     status: StreamStatus,
     lastTimestamp?: number,
   ): void {
-    this.sendMessage({
-      command: COMMANDS.UPDATE_STREAM_STATUS,
+    const message: UpdateStreamStatusMessage = {
+      command: 'UPDATE_STREAM_STATUS',
       stream,
       status,
       lastTimestamp,
-    });
+    };
+    this.sendMessage(message);
   }
 
   /**

--- a/src/progressView/managers/WebviewUpdater.ts
+++ b/src/progressView/managers/WebviewUpdater.ts
@@ -15,11 +15,7 @@ import {
 import { AgentLogger } from '@logger/AgentLogger';
 import { LogMessageData } from '@logger/LogTypes';
 import type { TaskState } from '@logger/TaskState';
-import type {
-  InstructionUpdate,
-  StreamTabInfo,
-  UpdateStreamStatusMessage,
-} from '@progressView/types';
+import type { InstructionUpdate, StreamTabInfo } from '@progressView/types';
 // Internal imports
 import { buildStreamInfos } from '@progressView/streamInfoUtils';
 
@@ -326,7 +322,7 @@ export class WebviewUpdater {
       stream,
       status,
       lastTimestamp,
-    } satisfies Omit<UpdateStreamStatusMessage, 'command'> & { command: string });
+    });
   }
 
   /**

--- a/src/progressView/managers/WebviewUpdater.ts
+++ b/src/progressView/managers/WebviewUpdater.ts
@@ -310,12 +310,18 @@ export class WebviewUpdater {
   /**
    * Update a single stream's status in the stream tabs.
    * More efficient than updateStreams when only status changed.
+   * @param lastTimestamp - Optional timestamp for updating "last activity" display
    */
-  updateStreamStatus(stream: StreamTabId, status: StreamStatus): void {
+  updateStreamStatus(
+    stream: StreamTabId,
+    status: StreamStatus,
+    lastTimestamp?: number,
+  ): void {
     this.sendMessage({
       command: COMMANDS.UPDATE_STREAM_STATUS,
       stream,
       status,
+      lastTimestamp,
     });
   }
 

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -566,7 +566,7 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
    * More efficient than UPDATE_STREAMS when only status changed.
    */
   handleUpdateStreamStatus(message) {
-    const { stream, status } = message;
+    const { stream, status, lastTimestamp } = message;
     if (!stream) {
       return;
     }
@@ -590,7 +590,7 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     }
 
     // Attempt DOM update (may fail if tab doesn't exist yet, which is OK)
-    dom.streamTabs.updateStreamStatus(stream, status);
+    dom.streamTabs.updateStreamStatus(stream, status, lastTimestamp);
   }
 
   handleUpdateUsage(message) {

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -591,6 +591,11 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
 
     // Attempt DOM update (may fail if tab doesn't exist yet, which is OK)
     dom.streamTabs.updateStreamStatus(stream, status, lastTimestamp);
+
+    // Also update main status indicator if this is the active stream
+    if (stream === state.activeStream) {
+      dom.status.update(status || STREAM_STATUS.STOPPED);
+    }
   }
 
   handleUpdateUsage(message) {

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -217,11 +217,17 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       state.pendingFilterUpdate = false;
     }
     state.resetExecutionIdAvailability();
-    // Preserve existing statuses when updates omit them so errored streams
-    // remain marked as error instead of reverting to stopped
+    // Preserve ERROR status when updates omit status, so errored streams
+    // remain marked as error instead of reverting to stopped. Other statuses
+    // (like RUNNING) should not be preserved when omitted, as undefined means
+    // the stream has completed (READY status is deleted from the status map).
     const streams = (message.streams || []).map((s) => {
-      const status =
-        s.status !== undefined ? s.status : state.streamStatuses.get(s.name);
+      let status = s.status;
+      if (status === undefined) {
+        const cachedStatus = state.streamStatuses.get(s.name);
+        // Only preserve ERROR status; other statuses should not persist
+        status = cachedStatus === STREAM_STATUS.ERROR ? cachedStatus : undefined;
+      }
       if (status) {
         state.streamStatuses.set(s.name, status);
       } else {
@@ -298,6 +304,11 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       // Refresh todos for the active stream
       const todos = state.getTodos(message.activeStream);
       dom.todoList.update(todos || []);
+
+      // Auto-focus follow-up input when active stream is waiting for user input
+      if (streamStatus === STREAM_STATUS.WAITING) {
+        dom.followUpInput.focus({ scrollIntoView: true });
+      }
     }
 
     this._refreshInstructionForActiveRun();
@@ -595,6 +606,11 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     // Also update main status indicator if this is the active stream
     if (stream === state.activeStream) {
       dom.status.update(status || STREAM_STATUS.STOPPED);
+
+      // Auto-focus follow-up input when waiting for user input
+      if (status === STREAM_STATUS.WAITING) {
+        dom.followUpInput.focus({ scrollIntoView: true });
+      }
     }
   }
 

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -134,6 +134,17 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
   }
 
   /**
+   * Auto-focus follow-up input when status is WAITING.
+   * Extracted to avoid duplication in handleUpdateStreams and handleUpdateStreamStatus.
+   * @param {string} status - The stream status to check
+   */
+  _focusFollowUpIfWaiting(status) {
+    if (status === STREAM_STATUS.WAITING) {
+      dom.followUpInput.focus({ scrollIntoView: true });
+    }
+  }
+
+  /**
    * Update run-scoped metadata (instructions, usage, files) from message.
    * Shared by handleUpdateLogs and _handleIncrementalUpdate to avoid duplication.
    * @param {string} stream - The stream to update
@@ -304,11 +315,7 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       // Refresh todos for the active stream
       const todos = state.getTodos(message.activeStream);
       dom.todoList.update(todos || []);
-
-      // Auto-focus follow-up input when active stream is waiting for user input
-      if (streamStatus === STREAM_STATUS.WAITING) {
-        dom.followUpInput.focus({ scrollIntoView: true });
-      }
+      this._focusFollowUpIfWaiting(streamStatus);
     }
 
     this._refreshInstructionForActiveRun();
@@ -606,11 +613,7 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     // Also update main status indicator if this is the active stream
     if (stream === state.activeStream) {
       dom.status.update(status || STREAM_STATUS.STOPPED);
-
-      // Auto-focus follow-up input when waiting for user input
-      if (status === STREAM_STATUS.WAITING) {
-        dom.followUpInput.focus({ scrollIntoView: true });
-      }
+      this._focusFollowUpIfWaiting(status);
     }
   }
 

--- a/src/progressView/modules/uiManagers/StreamTabs.js
+++ b/src/progressView/modules/uiManagers/StreamTabs.js
@@ -117,7 +117,7 @@ export class StreamTabs {
    * @param {string} streamName - The stream to update
    * @param {string} status - New status value
    * @param {number} [lastTimestamp] - Optional timestamp for "last activity" display
-   * @returns {boolean} True if tab was found and updated, false otherwise
+   * @returns {boolean} True if any DOM element was updated, false otherwise
    */
   updateStreamStatus(streamName, status, lastTimestamp) {
     if (!streamName) {
@@ -148,6 +148,8 @@ export class StreamTabs {
       return false;
     }
 
+    let updated = false;
+
     const statusEl = streamTab.querySelector('.tab-status');
     if (statusEl) {
       // Remove old status classes dynamically from STREAM_STATUS values
@@ -161,6 +163,7 @@ export class StreamTabs {
       statusEl.classList.add(normalizedStatus);
       statusEl.dataset.status =
         normalizedStatus.charAt(0).toUpperCase() + normalizedStatus.slice(1);
+      updated = true;
     }
 
     // Update timestamp display if provided
@@ -168,10 +171,11 @@ export class StreamTabs {
       const lastActiveEl = streamTab.querySelector('.last-active');
       if (lastActiveEl) {
         lastActiveEl.textContent = formatRelativeTime(lastTimestamp);
+        updated = true;
       }
     }
 
-    return true;
+    return updated;
   }
 
   /**

--- a/src/progressView/modules/uiManagers/StreamTabs.js
+++ b/src/progressView/modules/uiManagers/StreamTabs.js
@@ -166,8 +166,8 @@ export class StreamTabs {
       updated = true;
     }
 
-    // Update timestamp display if provided
-    if (lastTimestamp !== undefined) {
+    // Update timestamp display if provided and valid (> 0 to avoid 1970 dates)
+    if (lastTimestamp !== undefined && lastTimestamp > 0) {
       const lastActiveEl = streamTab.querySelector('.last-active');
       if (lastActiveEl) {
         lastActiveEl.textContent = formatRelativeTime(lastTimestamp);

--- a/src/progressView/modules/uiManagers/StreamTabs.js
+++ b/src/progressView/modules/uiManagers/StreamTabs.js
@@ -112,12 +112,12 @@ export class StreamTabs {
   }
 
   /**
-   * Update status for a single stream tab.
+   * Update status and/or timestamp for a single stream tab.
    * More efficient than full update() when only status changed.
    * @param {string} streamName - The stream to update
    * @param {string} status - New status value
    * @param {number} [lastTimestamp] - Optional timestamp for "last activity" display
-   * @returns {boolean} True if DOM was updated, false if tab not found
+   * @returns {boolean} True if tab was found and updated, false otherwise
    */
   updateStreamStatus(streamName, status, lastTimestamp) {
     if (!streamName) {

--- a/src/progressView/modules/uiManagers/StreamTabs.js
+++ b/src/progressView/modules/uiManagers/StreamTabs.js
@@ -116,9 +116,10 @@ export class StreamTabs {
    * More efficient than full update() when only status changed.
    * @param {string} streamName - The stream to update
    * @param {string} status - New status value
+   * @param {number} [lastTimestamp] - Optional timestamp for "last activity" display
    * @returns {boolean} True if DOM was updated, false if tab not found
    */
-  updateStreamStatus(streamName, status) {
+  updateStreamStatus(streamName, status, lastTimestamp) {
     if (!streamName) {
       return false;
     }
@@ -148,21 +149,28 @@ export class StreamTabs {
     }
 
     const statusEl = streamTab.querySelector('.tab-status');
-    if (!statusEl) {
-      return false;
+    if (statusEl) {
+      // Remove old status classes dynamically from STREAM_STATUS values
+      // This ensures the class list stays in sync with constants
+      Object.values(STREAM_STATUS).forEach((s) => statusEl.classList.remove(s));
+      // READY means execution completed - display as stopped (no active indicator)
+      const normalizedStatus =
+        status === STREAM_STATUS.READY
+          ? STREAM_STATUS.STOPPED
+          : status || STREAM_STATUS.STOPPED;
+      statusEl.classList.add(normalizedStatus);
+      statusEl.dataset.status =
+        normalizedStatus.charAt(0).toUpperCase() + normalizedStatus.slice(1);
     }
 
-    // Remove old status classes dynamically from STREAM_STATUS values
-    // This ensures the class list stays in sync with constants
-    Object.values(STREAM_STATUS).forEach((s) => statusEl.classList.remove(s));
-    // READY means execution completed - display as stopped (no active indicator)
-    const normalizedStatus =
-      status === STREAM_STATUS.READY
-        ? STREAM_STATUS.STOPPED
-        : status || STREAM_STATUS.STOPPED;
-    statusEl.classList.add(normalizedStatus);
-    statusEl.dataset.status =
-      normalizedStatus.charAt(0).toUpperCase() + normalizedStatus.slice(1);
+    // Update timestamp display if provided
+    if (lastTimestamp !== undefined) {
+      const lastActiveEl = streamTab.querySelector('.last-active');
+      if (lastActiveEl) {
+        lastActiveEl.textContent = formatRelativeTime(lastTimestamp);
+      }
+    }
+
     return true;
   }
 

--- a/src/progressView/types.ts
+++ b/src/progressView/types.ts
@@ -2,6 +2,7 @@
 import type { AgentCategory, AgentType } from '@agent/core/AgentDataclass';
 import type { ExecutionId, StreamTabId } from '@agent/types/IdentifierTypes';
 import type { AgentTypeFilter } from '@agent/types/AgentStreamTypes';
+import type { StreamStatus } from '@common/constants/streamStatus';
 
 export interface StreamUITraits {
   /** Canonical session grouping for the stream. */
@@ -39,4 +40,16 @@ export interface InstructionMetadata {
 export interface InstructionUpdate {
   text: string;
   metadata?: InstructionMetadata;
+}
+
+/**
+ * Message payload for UPDATE_STREAM_STATUS command.
+ * Used for efficient single-stream status updates without full list refresh.
+ */
+export interface UpdateStreamStatusMessage {
+  command: 'UPDATE_STREAM_STATUS';
+  stream: StreamTabId;
+  status: StreamStatus;
+  /** Optional timestamp for updating "last activity" display */
+  lastTimestamp?: number;
 }

--- a/src/progressView/types.ts
+++ b/src/progressView/types.ts
@@ -47,7 +47,7 @@ export interface InstructionUpdate {
  * Used for efficient single-stream status updates without full list refresh.
  */
 export interface UpdateStreamStatusMessage {
-  command: 'UPDATE_STREAM_STATUS';
+  command: 'updateStreamStatus';
   stream: StreamTabId;
   status: StreamStatus;
   /** Optional timestamp for updating "last activity" display */


### PR DESCRIPTION
Previously, the stream list only updated the status indicator (dot) when a stream's status changed, leaving timestamps and sorting stale until the user clicked. Now the full stream list is refreshed on every status change, ensuring the UI stays up-to-date automatically.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds conditional full refresh when status changes (time-sorted), and passes last-activity timestamps with targeted status updates; improves frontend status handling, focus, and ERROR-only status preservation.
> 
> - **Event handling (`ProgressEventHandler.setStreamStatus`)**:
>   - Chooses full refresh when stream tab missing or sort order is `time`; otherwise sends targeted update.
>   - Includes current status in full-refresh map and computes/passes `lastTimestamp` for targeted updates.
> - **Webview messaging (`WebviewUpdater.updateStreamStatus`)**:
>   - Extends payload to include optional `lastTimestamp`.
> - **Frontend handlers (`modules/messageHandlers.js`)**:
>   - Adds `_focusFollowUpIfWaiting` and uses it in `handleUpdateStreams` and `handleUpdateStreamStatus`.
>   - Preserves only `ERROR` status when status is omitted in `UPDATE_STREAMS`.
>   - `handleUpdateStreamStatus` accepts `lastTimestamp`, updates main status if active.
> - **UI tabs (`uiManagers/StreamTabs.updateStreamStatus`)**:
>   - Updates status classes safely, normalizes `READY` to `stopped`, and updates "last activity" when `lastTimestamp` provided; returns whether DOM changed.
> - **Types (`types.ts`)**:
>   - Adds `StreamStatus` import and `UpdateStreamStatusMessage` with optional `lastTimestamp`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0c9dd8cc6b2da648895ca8fed71fcfc15514edad. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->