### PR TITLE
Handle file replacement with extension validation

### DIFF
--- a/src/agent/utils/mergeFileUtils.ts
+++ b/src/agent/utils/mergeFileUtils.ts
@@ -76,3 +76,29 @@ export function parseFilenameParts(editedBase: string): FilenameParts {
 
   return { base, agent, roundNum, model };
 }
+
+/**
+ * Extracts agent suffix by comparing base and edited filenames.
+ * Use when the base filename contains underscores and simple parsing won't work.
+ *
+ * @example
+ * extractAgentSuffix(
+ *   "20251018_meeting_notes",
+ *   "20251018_meeting_notes_transcribe_r1_gemini"
+ * ) // returns "transcribe"
+ */
+export function extractAgentSuffix(
+  baseNameWithoutExt: string,
+  editedNameWithoutExt: string,
+): string | null {
+  if (!editedNameWithoutExt.startsWith(baseNameWithoutExt)) {
+    return null;
+  }
+
+  // Get suffix after base name, e.g., "_transcribe_r1_gemini3p"
+  const suffix = editedNameWithoutExt.slice(baseNameWithoutExt.length);
+
+  // Extract agent: everything between leading underscore and _r{digits}
+  const match = suffix.match(/^_(.+?)_r\d+/);
+  return match?.[1] ?? null;
+}

--- a/src/commands/latex/compareCommands.ts
+++ b/src/commands/latex/compareCommands.ts
@@ -4,11 +4,17 @@ import * as path from 'path';
 // Third-party imports
 import * as vscode from 'vscode';
 
-// Local imports - log
+// Local imports
+import { extractAgentSuffix } from '@agent/utils';
 import { toErrorMessage } from '@common/errors';
 import { registerDiffRefresh } from '@frontend/ui/diffView';
 import * as logger from '@logger/logUtils';
-import { flexibleFS } from '@utils/files';
+import {
+  flexibleFS,
+  createWorkspaceLocation,
+  createRunStorageLocation,
+  createExternalLocation,
+} from '@utils/files';
 import type { FileLocation } from '@utils/files';
 import { DIFF_REGISTRATION_DELAY_MS } from '@utils/config';
 
@@ -118,7 +124,8 @@ async function handleCompare(
 }
 
 /**
- * Handles accepting the content of the edited file and overwriting the base file
+ * Handles accepting the content of the edited file.
+ * If extensions differ, creates a new file instead of overwriting.
  */
 async function handleAcceptEdited(
   inputLocation: FileLocation,
@@ -149,15 +156,36 @@ async function handleAcceptEdited(
       return;
     }
 
-    // Read content from edited file
-    const editedContent = await flexibleFS.read(editedLocation);
+    const basePath = fileToUseLocation.absolutePath;
+    const editedPath = editedLocation.absolutePath;
+    const editedFileName = path.basename(editedPath);
+    const baseExt = path.extname(basePath).toLowerCase();
+    const editedExt = path.extname(editedPath).toLowerCase();
 
-    // Confirm with user
-    const baseFileName = path.basename(fileToUseLocation.absolutePath);
-    const editedFileName = path.basename(editedLocation.absolutePath);
+    // Determine target: new file if extensions differ, otherwise overwrite base
+    const { targetLocation, targetFileName, isNewFile } =
+      baseExt !== editedExt
+        ? getNewFileTarget(fileToUseLocation, editedPath)
+        : {
+            targetLocation: fileToUseLocation,
+            targetFileName: path.basename(basePath),
+            isNewFile: false,
+          };
+
+    // Check if new file would overwrite an existing file
+    const targetExists = isNewFile && (await flexibleFS.exists(targetLocation));
+
+    let confirmMessage: string;
+    if (isNewFile && targetExists) {
+      confirmMessage = `Extensions differ (${baseExt} vs ${editedExt}). This will overwrite existing '${targetFileName}' with content from '${editedFileName}'. Are you sure?`;
+    } else if (isNewFile) {
+      confirmMessage = `Extensions differ (${baseExt} vs ${editedExt}). This will create '${targetFileName}' with content from '${editedFileName}'. Are you sure?`;
+    } else {
+      confirmMessage = `This will overwrite '${targetFileName}' with content from '${editedFileName}'. Are you sure?`;
+    }
 
     const answer = await vscode.window.showWarningMessage(
-      `This will overwrite '${baseFileName}' with content from '${editedFileName}'. Are you sure?`,
+      confirmMessage,
       { modal: true },
       'Yes',
       'Cancel',
@@ -167,17 +195,16 @@ async function handleAcceptEdited(
       return;
     }
 
-    // Write content to base file
-    await flexibleFS.write(fileToUseLocation, editedContent);
+    const editedContent = await flexibleFS.read(editedLocation);
+    await flexibleFS.write(targetLocation, editedContent);
 
-    vscode.window.showInformationMessage(
-      `Successfully replaced '${baseFileName}' with content from '${editedFileName}'`,
-    );
+    const successMessage =
+      isNewFile && !targetExists
+        ? `Successfully created '${targetFileName}' with content from '${editedFileName}'`
+        : `Successfully replaced '${targetFileName}' with content from '${editedFileName}'`;
 
-    logger.info(
-      CHANNEL,
-      `Copied content from ${editedFileName} to ${baseFileName}`,
-    );
+    vscode.window.showInformationMessage(successMessage);
+    logger.info(CHANNEL, successMessage);
   } catch (err) {
     vscode.window.showErrorMessage(
       `Error accepting changes: ${toErrorMessage(err)}`,
@@ -187,6 +214,58 @@ async function handleAcceptEdited(
       `Error in handleAcceptEdited: ${toErrorMessage(err)}`,
     );
   }
+}
+
+/**
+ * Determines the target file when extensions differ.
+ * Creates filename: {baseName}_{agent}.{editedExt} or falls back to edited filename.
+ * Preserves the location kind (workspace/runStorage/external) from the base file.
+ */
+function getNewFileTarget(
+  baseLocation: FileLocation,
+  editedPath: string,
+): { targetLocation: FileLocation; targetFileName: string; isNewFile: true } {
+  const basePath = baseLocation.absolutePath;
+  const baseNameWithoutExt = path.parse(basePath).name;
+  const editedNameWithoutExt = path.parse(editedPath).name;
+  const editedExt = path.extname(editedPath);
+
+  const agentSuffix = extractAgentSuffix(baseNameWithoutExt, editedNameWithoutExt);
+  const targetFileName = agentSuffix
+    ? `${baseNameWithoutExt}_${agentSuffix}${editedExt}`
+    : path.basename(editedPath);
+
+  const targetAbsolutePath = path.join(path.dirname(basePath), targetFileName);
+
+  // Preserve location kind from base file
+  let targetLocation: FileLocation;
+  switch (baseLocation.kind) {
+    case 'workspace': {
+      const targetRelativePath = path.join(
+        path.dirname(baseLocation.relativePath),
+        targetFileName,
+      );
+      targetLocation = createWorkspaceLocation(targetAbsolutePath, targetRelativePath);
+      break;
+    }
+    case 'runStorage': {
+      const targetRelativePath = path.join(
+        path.dirname(baseLocation.relativePath),
+        targetFileName,
+      );
+      targetLocation = createRunStorageLocation(
+        targetAbsolutePath,
+        targetRelativePath,
+        baseLocation.executionId,
+      );
+      break;
+    }
+    case 'external':
+      targetLocation = createExternalLocation(targetAbsolutePath);
+      break;
+  }
+
+  return { targetLocation, targetFileName, isNewFile: true };
 }
 
 export const compareCommands = {


### PR DESCRIPTION
When accepting edited file content, if the base file and edited file have different extensions (e.g., .txt vs .tex), the system now creates a new file with the appropriate extension instead of overwriting the original.

- Added extractAgentSuffix() to mergeFileUtils for reusable filename parsing
- Refactored handleAcceptEdited to be DRY with getNewFileTarget helper

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Accepting edited content now creates an appropriately named new file when extensions differ, leveraging agent suffix parsing and preserving file location kind.
> 
> - **Compare/Accept Edited (`src/commands/latex/compareCommands.ts`)**:
>   - Creates a new file instead of overwriting when base and edited extensions differ, with confirmation messaging.
>   - Adds `getNewFileTarget()` to derive `{baseName}_{agent}{editedExt}` (via `extractAgentSuffix`) and preserve location kind (`workspace`/`runStorage`/`external`).
>   - Writes edited content to computed target and reports success.
> - **Utils (`src/agent/utils/mergeFileUtils.ts`)**:
>   - Adds `extractAgentSuffix(baseNameWithoutExt, editedNameWithoutExt)` to parse agent from edited filenames with underscores.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7e10806ac8f2666763fba9fe7caea1bdb0ce740f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->