### PR TITLE
Fix tilde character compilation errors

### DIFF
--- a/src/replacement/rulesRegex.ts
+++ b/src/replacement/rulesRegex.ts
@@ -310,6 +310,14 @@ export const LATEXDIFF_MARKUP_REPLACEMENTS: ReplacementCategory = {
     // Note: For commands like \bze that should not be split, use:
     // latexdiff --append-safecmd="bze,hbze" old.tex new.tex
     // This prevents latexdiff from splitting the command and its arguments
+
+    // === Fix escaped tildes in \DIFdel/\DIFadd commands ===
+    // The escaped tilde \~ is a tilde accent command that needs an argument.
+    // Inside \DIFdel{} it should be the non-breaking space character ~.
+    // Example: \DIFdel{\~}%DIFDELCMD → \DIFdel{~}%DIFDELCMD
+    '\\\\DIFdel\\{\\\\~\\}%DIFDELCMD': '\\DIFdel{~}%DIFDELCMD',
+    // Example: \DIFadd{\~}%DIFADDCMD → \DIFadd{~}%DIFADDCMD
+    '\\\\DIFadd\\{\\\\~\\}%DIFADDCMD': '\\DIFadd{~}%DIFADDCMD',
   },
 };
 


### PR DESCRIPTION
…rrors

The escaped tilde \~ is a tilde accent command that needs an argument. When latexdiff generates \DIFdel{\~} or \DIFadd{\~}, it causes LaTeX compilation errors. This fix converts these to the non-breaking space character ~ which compiles correctly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces `\DIFdel{\~}`/`\DIFadd{\~}` with `~` via new regex rules to avoid LaTeX compilation errors.
> 
> - **Latexdiff markup fixes (`src/replacement/rulesRegex.ts`)**:
>   - Add regex patterns converting `\DIFdel{\~}` → `\DIFdel{~}` and `\DIFadd{\~}` → `\DIFadd{~}` to ensure valid LaTeX.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9c278688e98a5e6c720d1543f5c8d69595327fd4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->