### PR TITLE
Remove duplicate code

### DIFF
--- a/src/agent/core/flows/RetryState.ts
+++ b/src/agent/core/flows/RetryState.ts
@@ -192,11 +192,23 @@ function formatErrorMessage(
 }
 
 /**
+ * Generates a stable ID for retry error deduplication.
+ * Uses logger's channel ID and operation name to create a consistent identifier
+ * that will cause subsequent retry errors to replace the previous one in the UI.
+ */
+function getRetryErrorId(logger: AgentLogger, operationName: string): string {
+  return `retry-error:${logger.channelId}:${operationName}`;
+}
+
+/**
  * Applies fallback result: records error, logs, and returns flow transition.
  * Called from post() after receiving FallbackResult from execFallback.
  *
  * This is the single source of truth for error logging (log at boundary principle).
  * The error context from enrichError() is included in the log message.
+ *
+ * Uses a stable messageId for retry errors so subsequent retry failures replace
+ * the previous error entry in the UI instead of accumulating duplicates.
  *
  * @param result - The fallback result from determineFallbackAction
  * @param state - The retry state to update
@@ -213,11 +225,15 @@ export function applyFallbackResult(
   // Record error in state for caller/UI access
   recordRetryError(state, result.error);
 
+  // Use a stable ID so subsequent retry errors replace the previous one
+  const messageId = getRetryErrorId(logger, operationName);
+
   switch (result.outcome) {
     case 'manual_retry':
       logger.logErrorData(
         formatErrorMessage(operationName, result.error),
         result.error,
+        { messageId },
       );
       return FlowTransition.AWAIT_RETRY;
 
@@ -225,6 +241,7 @@ export function applyFallbackResult(
       logger.logErrorData(
         formatErrorMessage(operationName, result.error, '(not retryable)'),
         result.error,
+        { messageId },
       );
       return FlowTransition.COMPLETE;
 

--- a/src/logger/AgentLogger.ts
+++ b/src/logger/AgentLogger.ts
@@ -214,6 +214,7 @@ export class AgentLogger {
       messageType: options.messageType,
       isAgent: this.isAgentLogger,
       data: options.data,
+      messageId: options.messageId,
     });
   }
 
@@ -267,13 +268,21 @@ export class AgentLogger {
    *
    * @param message - Human-readable error description
    * @param errorData - Pre-structured error data
-   * @param groupId - Optional group ID for progress view
+   * @param options - Optional settings: groupId for progress view, messageId for deduplication
    */
-  logErrorData(message: string, errorData: unknown, groupId?: string): void {
+  logErrorData(
+    message: string,
+    errorData: unknown,
+    options?: { groupId?: string; messageId?: string } | string,
+  ): void {
+    // Support both old signature (groupId as string) and new signature (options object)
+    const opts =
+      typeof options === 'string' ? { groupId: options } : (options ?? {});
     this.error(message, {
-      groupId,
+      groupId: opts.groupId,
       messageType: MESSAGE_TYPES.ERROR,
       data: errorData,
+      messageId: opts.messageId,
     });
   }
 

--- a/src/logger/logOptions.ts
+++ b/src/logger/logOptions.ts
@@ -21,6 +21,8 @@ export interface LogOptions {
   messageType?: MessageType;
   /** Structured data for debug mode display */
   data?: unknown;
+  /** Stable ID for deduplication. If provided, replaces existing message with same ID. */
+  messageId?: string;
 }
 
 /**

--- a/src/logger/logUtils.ts
+++ b/src/logger/logUtils.ts
@@ -156,6 +156,7 @@ function logWithGroup(
     groupId: activeGroupId,
     messageType: options.messageType,
     data: options.data,
+    messageId: options.messageId,
   });
 }
 

--- a/src/logger/sinks/ProgressViewSink.ts
+++ b/src/logger/sinks/ProgressViewSink.ts
@@ -36,7 +36,8 @@ export class ProgressViewSink implements LogEventSink {
     if (messageType === MESSAGE_TYPES.INTERNAL) {
       return;
     }
-    const id = randomUUID();
+    // Use provided messageId for deduplication, or generate a new UUID
+    const id = event.messageId ?? randomUUID();
     const timestamp = new Date(event.timestamp).getTime();
     const logMessage: LogMessageData = {
       id,

--- a/src/logger/transports/VSCodeTransport.ts
+++ b/src/logger/transports/VSCodeTransport.ts
@@ -50,7 +50,7 @@ export class VSCodeTransport extends Transport {
   }
 
   log(info: any, callback: () => void): void {
-    const { level, message, timestamp, messageType } = info;
+    const { level, message, timestamp, messageType, messageId } = info;
     const structuredData = serializeLogData(info.data);
     const groupId = info.groupId ?? this.activeGroupId;
 
@@ -63,6 +63,7 @@ export class VSCodeTransport extends Transport {
       groupId,
       messageType,
       data: structuredData,
+      messageId,
     });
 
     callback();

--- a/src/logger/types/LogEventSink.ts
+++ b/src/logger/types/LogEventSink.ts
@@ -11,6 +11,8 @@ export interface LogMessageEvent {
   groupId?: string;
   messageType?: MessageType;
   data?: unknown;
+  /** Optional stable ID for deduplication. If provided, replaces existing message with same ID. */
+  messageId?: string;
 }
 
 export interface LogGroupStartedEvent {


### PR DESCRIPTION
When model invocations fail and are retried, the previous error message in the progress view is now replaced instead of accumulating duplicate entries. This is achieved by:

- Adding optional messageId field to LogMessageEvent interface
- Passing messageId through the logging pipeline
- Generating a stable retry error ID based on stream ID and operation name
- Using the stable ID when logging retry errors so subsequent errors replace the previous one in the UI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a `messageId` to the logging pipeline and uses stable IDs so retry error logs replace previous entries in the progress view.
> 
> - **Logging pipeline**:
>   - Add optional `messageId` to `LogOptions`, `LogMessageEvent`, and propagate via `logUtils`, `AgentLogger.error`, and `VSCodeTransport` to sinks.
>   - Update `ProgressViewSink` to use provided `messageId` (or fallback UUID) for log entry IDs, enabling deduplication.
>   - Adjust `AgentLogger.logErrorData` to accept an options object (`{ groupId?, messageId? }`) while preserving backward-compatible string `groupId`.
> - **Retry flow**:
>   - Introduce `getRetryErrorId(logger, operationName)` to generate stable retry error IDs.
>   - Use stable `messageId` in `applyFallbackResult` when logging retry errors so subsequent failures replace prior entries in the UI.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1f41de0a92b34c55afab28fc32ba30a5dea23eaa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->