### PR TITLE
Add VS Code messages for file loading display

### DIFF
--- a/src/agent/utils/userVars.ts
+++ b/src/agent/utils/userVars.ts
@@ -115,12 +115,12 @@ async function getFileVars(
     ...agentConfig.mediaFiles,
   ].filter(Boolean) as string[];
 
-  // Log file categories being loaded
+  // Log file categories being loaded (processed sequentially to preserve UI display order)
   await logFileCategoriesWithExistence(logger, {
-    'input files': allInputFiles,
-    'reference files': allReferenceFiles,
-    'auxiliary files': allAuxiliaryFiles,
-    'media files': allMediaFiles,
+    'Input Files': allInputFiles,
+    'Reference Files': allReferenceFiles,
+    'Auxiliary Files': allAuxiliaryFiles,
+    'Media Files': allMediaFiles,
   });
 
   const singleFileMappings = {

--- a/src/agent/utils/userVars.ts
+++ b/src/agent/utils/userVars.ts
@@ -172,25 +172,42 @@ async function getFileVars(
  * Log file categories with existence checking.
  * Each category is logged separately with a VS Code native file list message.
  * Uses tuple array for explicit ordering guarantee.
+ *
+ * Processes all categories in parallel for better performance, but logs
+ * them sequentially to preserve the expected UI display order.
  */
 async function logFileCategoriesWithExistence(
   logger: AgentLogger,
   categories: Array<[category: string, files: string[]]>,
 ): Promise<void> {
-  for (const [category, files] of categories) {
-    if (files.length === 0) {
-      continue;
+  // Process all categories in parallel for better performance
+  const results = await Promise.all(
+    categories.map(async ([category, files]) => {
+      if (files.length === 0) {
+        return { category, entries: [] };
+      }
+
+      // Explicit type annotation prevents type widening if WorkspaceFS.exists changes
+      const entries: Array<{ path: string; ok: boolean }> = await Promise.all(
+        files.map(async (filePath) => {
+          try {
+            return { path: filePath, ok: await WorkspaceFS.exists(filePath) };
+          } catch {
+            // Treat permission/access errors as non-existent
+            return { path: filePath, ok: false };
+          }
+        }),
+      );
+
+      return { category, entries };
+    }),
+  );
+
+  // Log sequentially to preserve UI display order
+  for (const { category, entries } of results) {
+    if (entries.length > 0) {
+      logger.logFileCategory(category, entries);
     }
-
-    // Explicit type annotation prevents type widening if WorkspaceFS.exists changes
-    const fileEntries: Array<{ path: string; ok: boolean }> = await Promise.all(
-      files.map(async (filePath) => ({
-        path: filePath,
-        ok: await WorkspaceFS.exists(filePath),
-      })),
-    );
-
-    logger.logFileCategory(category, fileEntries);
   }
 }
 

--- a/src/agent/utils/userVars.ts
+++ b/src/agent/utils/userVars.ts
@@ -12,6 +12,7 @@ import {
 } from '@agent/core/AgentDataclass';
 import { setVarFromFile } from '@frontend/files/vars';
 import { AgentLogger } from '@logger/AgentLogger';
+import type { FileListEntry } from '@logger/messageTypes';
 import { getXmlFormatFromFiles, getListOfFiles } from '@utils/prompt';
 import { getConfig } from '@utils/config';
 import { WorkspaceFS } from '@utils/files';
@@ -22,14 +23,13 @@ import { WorkspaceFS } from '@utils/files';
 export type UserVars = Record<string, unknown>;
 
 /**
- * Information about a loaded file
+ * Information about a loaded file for prompt variable substitution.
+ * Extends FileListEntry with required source and varName fields.
+ * Compatible with FileListEntry (can be passed to AgentLogger.fileList).
  */
-export type LoadedFileEntry = {
-  path: string;
-  ok: boolean;
-  varName: string;
+export type LoadedFileEntry = FileListEntry & {
   source: string;
-  internal?: boolean;
+  varName: string;
 };
 
 /**

--- a/src/agent/utils/userVars.ts
+++ b/src/agent/utils/userVars.ts
@@ -116,12 +116,13 @@ async function getFileVars(
   ].filter(Boolean) as string[];
 
   // Log file categories being loaded (processed sequentially to preserve UI display order)
-  await logFileCategoriesWithExistence(logger, {
-    'Input Files': allInputFiles,
-    'Reference Files': allReferenceFiles,
-    'Auxiliary Files': allAuxiliaryFiles,
-    'Media Files': allMediaFiles,
-  });
+  // Using tuple array for explicit ordering guarantee
+  await logFileCategoriesWithExistence(logger, [
+    ['Input Files', allInputFiles],
+    ['Reference Files', allReferenceFiles],
+    ['Auxiliary Files', allAuxiliaryFiles],
+    ['Media Files', allMediaFiles],
+  ]);
 
   const singleFileMappings = {
     INPUT: agentConfig.inputFile,
@@ -170,17 +171,19 @@ async function getFileVars(
 /**
  * Log file categories with existence checking.
  * Each category is logged separately with a VS Code native file list message.
+ * Uses tuple array for explicit ordering guarantee.
  */
 async function logFileCategoriesWithExistence(
   logger: AgentLogger,
-  categories: Record<string, string[]>,
+  categories: Array<[category: string, files: string[]]>,
 ): Promise<void> {
-  for (const [category, files] of Object.entries(categories)) {
+  for (const [category, files] of categories) {
     if (files.length === 0) {
       continue;
     }
 
-    const fileEntries = await Promise.all(
+    // Explicit type annotation prevents type widening if WorkspaceFS.exists changes
+    const fileEntries: Array<{ path: string; ok: boolean }> = await Promise.all(
       files.map(async (filePath) => ({
         path: filePath,
         ok: await WorkspaceFS.exists(filePath),

--- a/src/agent/utils/userVars.ts
+++ b/src/agent/utils/userVars.ts
@@ -64,7 +64,7 @@ export async function buildUserVars(
   // Merge all variable sources using spread operator
   const userVars: UserVars = {
     ...getBasicVars(agentConfig, modelHandler),
-    ...(await getFileVars(agentConfig)),
+    ...(await getFileVars(agentConfig, logger)),
     ...requiredVars,
     ...patternVars,
     ...getOutputFilesOrder(agentConfig, agentSetting),
@@ -92,7 +92,10 @@ function getBasicVars(
   };
 }
 
-async function getFileVars(agentConfig: AgentConfig): Promise<UserVars> {
+async function getFileVars(
+  agentConfig: AgentConfig,
+  logger: AgentLogger,
+): Promise<UserVars> {
   const userVars: UserVars = {};
 
   const allInputFiles = [
@@ -107,6 +110,18 @@ async function getFileVars(agentConfig: AgentConfig): Promise<UserVars> {
     agentConfig.auxiliaryFile,
     ...agentConfig.auxiliaryFiles,
   ].filter(Boolean) as string[];
+  const allMediaFiles = [
+    agentConfig.mediaFile,
+    ...agentConfig.mediaFiles,
+  ].filter(Boolean) as string[];
+
+  // Log file categories being loaded
+  await logFileCategoriesWithExistence(logger, {
+    'input files': allInputFiles,
+    'reference files': allReferenceFiles,
+    'auxiliary files': allAuxiliaryFiles,
+    'media files': allMediaFiles,
+  });
 
   const singleFileMappings = {
     INPUT: agentConfig.inputFile,
@@ -150,6 +165,30 @@ async function getFileVars(agentConfig: AgentConfig): Promise<UserVars> {
   }
 
   return userVars;
+}
+
+/**
+ * Log file categories with existence checking.
+ * Each category is logged separately with a VS Code native file list message.
+ */
+async function logFileCategoriesWithExistence(
+  logger: AgentLogger,
+  categories: Record<string, string[]>,
+): Promise<void> {
+  for (const [category, files] of Object.entries(categories)) {
+    if (files.length === 0) {
+      continue;
+    }
+
+    const fileEntries = await Promise.all(
+      files.map(async (filePath) => ({
+        path: filePath,
+        ok: await WorkspaceFS.exists(filePath),
+      })),
+    );
+
+    logger.logFileCategory(category, fileEntries);
+  }
 }
 
 async function getRequiredFileVars(

--- a/src/logger/AgentLogger.ts
+++ b/src/logger/AgentLogger.ts
@@ -334,7 +334,7 @@ export class AgentLogger {
    */
   logFileCategory(
     category: string,
-    files: Array<{ path: string; ok?: boolean }>,
+    files: Array<Pick<FileListEntry, 'path'> & { ok?: boolean }>,
     groupId?: string,
   ): void {
     if (files.length === 0) {

--- a/src/logger/AgentLogger.ts
+++ b/src/logger/AgentLogger.ts
@@ -323,6 +323,36 @@ export class AgentLogger {
   }
 
   /**
+   * Log files being loaded for a specific category (input, reference, auxiliary, media).
+   * Creates a FILE_LIST entry with a descriptive category label.
+   */
+  logFileCategory(
+    category: string,
+    files: Array<{ path: string; ok?: boolean }>,
+    groupId?: string,
+  ): void {
+    if (files.length === 0) {
+      return;
+    }
+
+    const loadedCount = files.filter((f) => f.ok !== false).length;
+    const summary = `Loading ${category} (${loadedCount}/${files.length})`;
+
+    const entries = files.map((f) => ({
+      path: f.path,
+      ok: f.ok !== false,
+      source: category,
+      sourceDisplay: category,
+    }));
+
+    this.info(summary, {
+      groupId,
+      messageType: MESSAGE_TYPES.FILE_LIST,
+      data: entries,
+    });
+  }
+
+  /**
    * Log missing output information.
    */
   missingOutputs(info: unknown, groupId?: string): void {

--- a/src/logger/AgentLogger.ts
+++ b/src/logger/AgentLogger.ts
@@ -18,7 +18,11 @@ import * as logger from './logUtils';
 import { END_GROUP_STATUS, MESSAGE_TYPES } from './messageTypes';
 
 // Type imports
-import type { EndGroupStatus, MessageType } from './messageTypes';
+import type {
+  EndGroupStatus,
+  FileListEntry,
+  MessageType,
+} from './messageTypes';
 import type { LogOptions } from './logOptions';
 
 export interface LoggerScopeOptions {
@@ -312,8 +316,9 @@ export class AgentLogger {
 
   /**
    * Log a list of files that were processed.
+   * @param files - Array of FileListEntry objects conforming to FileListEntrySchema
    */
-  fileList(files: unknown[], groupId?: string): void {
+  fileList(files: FileListEntry[], groupId?: string): void {
     const summary = `Loaded ${files.length} file${files.length === 1 ? '' : 's'}`;
     this.info(summary, {
       groupId,
@@ -340,7 +345,7 @@ export class AgentLogger {
     const loadedCount = files.filter((f) => f.ok === true).length;
     const summary = `Loading ${category} (${loadedCount}/${files.length})`;
 
-    const entries = files.map((f) => ({
+    const entries: FileListEntry[] = files.map((f) => ({
       path: f.path,
       ok: f.ok === true,
       source: category,

--- a/src/logger/AgentLogger.ts
+++ b/src/logger/AgentLogger.ts
@@ -325,6 +325,7 @@ export class AgentLogger {
   /**
    * Log files being loaded for a specific category (input, reference, auxiliary, media).
    * Creates a FILE_LIST entry with a descriptive category label.
+   * Empty arrays are handled gracefully (no-op).
    */
   logFileCategory(
     category: string,
@@ -335,12 +336,13 @@ export class AgentLogger {
       return;
     }
 
-    const loadedCount = files.filter((f) => f.ok !== false).length;
+    // Use explicit === true check: only count files where existence was confirmed
+    const loadedCount = files.filter((f) => f.ok === true).length;
     const summary = `Loading ${category} (${loadedCount}/${files.length})`;
 
     const entries = files.map((f) => ({
       path: f.path,
-      ok: f.ok !== false,
+      ok: f.ok === true,
       source: category,
       sourceDisplay: category,
     }));

--- a/src/logger/messageTypes.ts
+++ b/src/logger/messageTypes.ts
@@ -89,3 +89,29 @@ export const MessageTypeSchema = z.enum([
 ]);
 
 export type MessageType = z.infer<typeof MessageTypeSchema>;
+
+/**
+ * Schema for FILE_LIST message data entries.
+ * Single source of truth for file list entry structure used by:
+ * - AgentLogger.fileList() and logFileCategory()
+ * - Progress view normalizers (normalizeFileListEntries)
+ * - userVars.ts LoadedFileEntry type
+ *
+ * Note: The normalizer defaults missing `source` to 'unknown', so it's optional here.
+ */
+export const FileListEntrySchema = z.object({
+  /** File path (absolute or relative) */
+  path: z.string(),
+  /** Whether the file was successfully loaded/found */
+  ok: z.boolean(),
+  /** Category source identifier (e.g., 'requiredFiles', 'Input Files'). Defaults to 'unknown' in normalizer. */
+  source: z.string().optional(),
+  /** Display label for the source (defaults to source if not provided) */
+  sourceDisplay: z.string().optional(),
+  /** Variable name if loaded for prompt variable substitution */
+  varName: z.string().optional(),
+  /** Whether this is an internal/bundled file */
+  internal: z.boolean().optional(),
+});
+
+export type FileListEntry = z.infer<typeof FileListEntrySchema>;

--- a/src/test/logger/AgentLoggerFileList.test.ts
+++ b/src/test/logger/AgentLoggerFileList.test.ts
@@ -1,0 +1,99 @@
+// Standard library imports
+import { strict as assert } from 'assert';
+
+// Local imports
+import { AgentLogger } from '@logger/AgentLogger';
+import { MESSAGE_TYPES } from '@logger/messageTypes';
+import { bus } from '@eventBus/ProgressEventBus';
+
+describe('AgentLogger.logFileCategory', () => {
+  let logger: AgentLogger;
+  let capturedMessages: any[];
+  let unsubscribe: () => void;
+
+  beforeEach(() => {
+    logger = new AgentLogger('TestFileListLogger');
+    capturedMessages = [];
+    unsubscribe = bus.on('addLogMessage', (payload) => {
+      if (payload.stream === 'TestFileListLogger') {
+        capturedMessages.push(payload.logMessage);
+      }
+    });
+  });
+
+  afterEach(() => {
+    unsubscribe();
+  });
+
+  it('handles empty file array gracefully (no-op)', () => {
+    logger.logFileCategory('Input Files', []);
+    assert.equal(capturedMessages.length, 0);
+  });
+
+  it('logs files with correct category label', () => {
+    logger.logFileCategory('Input Files', [
+      { path: '/path/to/file.tex', ok: true },
+    ]);
+
+    assert.equal(capturedMessages.length, 1);
+    assert.equal(capturedMessages[0].messageType, MESSAGE_TYPES.FILE_LIST);
+    assert.equal(capturedMessages[0].text, 'Loading Input Files (1/1)');
+  });
+
+  it('counts only files with ok === true as loaded', () => {
+    logger.logFileCategory('Reference Files', [
+      { path: '/path/exists.tex', ok: true },
+      { path: '/path/missing.tex', ok: false },
+      { path: '/path/also-exists.tex', ok: true },
+    ]);
+
+    assert.equal(capturedMessages.length, 1);
+    assert.equal(capturedMessages[0].text, 'Loading Reference Files (2/3)');
+  });
+
+  it('treats undefined ok as false (not loaded)', () => {
+    logger.logFileCategory('Auxiliary Files', [
+      { path: '/path/exists.tex', ok: true },
+      { path: '/path/unknown.tex' }, // ok is undefined
+    ]);
+
+    assert.equal(capturedMessages.length, 1);
+    assert.equal(capturedMessages[0].text, 'Loading Auxiliary Files (1/2)');
+  });
+
+  it('handles all files missing (none exist)', () => {
+    logger.logFileCategory('Media Files', [
+      { path: '/path/missing1.png', ok: false },
+      { path: '/path/missing2.png', ok: false },
+    ]);
+
+    assert.equal(capturedMessages.length, 1);
+    assert.equal(capturedMessages[0].text, 'Loading Media Files (0/2)');
+  });
+
+  it('includes source and sourceDisplay in entry data', () => {
+    logger.logFileCategory('Input Files', [
+      { path: '/path/file.tex', ok: true },
+    ]);
+
+    const entries = capturedMessages[0].data;
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].source, 'Input Files');
+    assert.equal(entries[0].sourceDisplay, 'Input Files');
+    assert.equal(entries[0].path, '/path/file.tex');
+    assert.equal(entries[0].ok, true);
+  });
+
+  it('maps ok properly in entries (undefined becomes false)', () => {
+    logger.logFileCategory('Test', [
+      { path: '/a', ok: true },
+      { path: '/b', ok: false },
+      { path: '/c' }, // undefined
+    ]);
+
+    const entries = capturedMessages[0].data;
+    assert.equal(entries[0].ok, true);
+    assert.equal(entries[1].ok, false);
+    assert.equal(entries[2].ok, false);
+  });
+});


### PR DESCRIPTION
Add VS Code native messages showing files being loaded during initialization:
- Input files, reference files, auxiliary files, and media files are now displayed with categorized file list messages
- Each category shows the file count and existence status
- Uses the existing FILE_LIST message type for consistent styling

Changes:
- Add logFileCategory method to AgentLogger for categorized file logging
- Update userVars.ts to log file categories with existence checking

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce categorized file loading logs with existence counts, a shared FileListEntry schema, and integrate logging into userVars (including media files), with tests.
> 
> - **Logging**:
>   - Add `AgentLogger.logFileCategory` to emit categorized `FILE_LIST` messages with loaded/total counts; update `fileList` to use typed `FileListEntry`.
>   - Introduce `FileListEntrySchema`/`FileListEntry` in `@logger/messageTypes` for consistent file list entry structure.
> - **Agent utils (`userVars.ts`)**:
>   - `getFileVars` now accepts `logger`, adds media file category, and logs file categories via `logFileCategoriesWithExistence` (existence checked in parallel, logged sequentially).
>   - `LoadedFileEntry` now extends `FileListEntry`; aggregated loaded files still emitted via `logger.fileList`.
> - **Tests**:
>   - Add `AgentLoggerFileList.test.ts` covering category logging, counts, and entry mapping.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f610f1b2a0b20afa82286c57c304710125558ea6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->