### PR TITLE
fix(agent): hide input file messages for tool use agents

### DIFF
--- a/src/agent/utils/userVars.ts
+++ b/src/agent/utils/userVars.ts
@@ -8,7 +8,7 @@ import type { AgentConfig } from '@agent/core/AgentConfig';
 import {
   AgentSetting,
   AgentPrompt,
-  AgentType,
+  AgentCategory,
 } from '@agent/core/AgentDataclass';
 import { setVarFromFile } from '@frontend/files/vars';
 import { AgentLogger } from '@logger/AgentLogger';
@@ -64,7 +64,7 @@ export async function buildUserVars(
   // Merge all variable sources using spread operator
   const userVars: UserVars = {
     ...getBasicVars(agentConfig, modelHandler),
-    ...(await getFileVars(agentConfig, logger)),
+    ...(await getFileVars(agentConfig, agentSetting, logger)),
     ...requiredVars,
     ...patternVars,
     ...getOutputFilesOrder(agentConfig, agentSetting),
@@ -94,6 +94,7 @@ function getBasicVars(
 
 async function getFileVars(
   agentConfig: AgentConfig,
+  agentSetting: AgentSetting,
   logger: AgentLogger,
 ): Promise<UserVars> {
   const userVars: UserVars = {};
@@ -116,13 +117,15 @@ async function getFileVars(
   ].filter(Boolean) as string[];
 
   // Log file categories being loaded (processed sequentially to preserve UI display order)
-  // Using tuple array for explicit ordering guarantee
-  await logFileCategoriesWithExistence(logger, [
-    ['Input Files', allInputFiles],
-    ['Reference Files', allReferenceFiles],
-    ['Auxiliary Files', allAuxiliaryFiles],
-    ['Media Files', allMediaFiles],
-  ]);
+  // Skip for tool-use agents as they don't need this UI feedback
+  if (agentSetting.agentCategory !== AgentCategory.ToolUse) {
+    await logFileCategoriesWithExistence(logger, [
+      ['Input Files', allInputFiles],
+      ['Reference Files', allReferenceFiles],
+      ['Auxiliary Files', allAuxiliaryFiles],
+      ['Media Files', allMediaFiles],
+    ]);
+  }
 
   const singleFileMappings = {
     INPUT: agentConfig.inputFile,
@@ -374,7 +377,7 @@ export function getToolFlags(
   };
 
   // Only compute ROUNDS for workflow agents, not tool-use agents
-  if (agentSetting.agentType !== AgentType.ToolUse) {
+  if (agentSetting.agentCategory !== AgentCategory.ToolUse) {
     const requestArray = Array.isArray(agentPrompt.userRequest)
       ? agentPrompt.userRequest
       : agentPrompt.userRequest


### PR DESCRIPTION
Tool use agents don't need the "Files (x/y loaded)" UI feedback since
they don't use input files in the same way as workflow agents. Skip
logging file categories in getFileVars when the agent type is ToolUse.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Skips input/reference file logging and ROUNDS computation for tool-use agents by using AgentCategory; updates getFileVars to accept agentSetting and adjusts imports/callers.
> 
> - **Agent utils (`src/agent/utils/userVars.ts`)**:
>   - Suppress file category logging in `getFileVars` when `agentSetting.agentCategory === AgentCategory.ToolUse`.
>   - Use `agentCategory` (via `AgentCategory`) instead of `agentType` for ROUNDS computation in `getToolFlags`.
>   - Update `getFileVars` signature to accept `agentSetting` and adjust its call in `buildUserVars`.
>   - Replace `AgentType` import with `AgentCategory`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 748c63818191b62b38531e7c220e461e588978f1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->