### PR TITLE
refactor(types): modernize message handlers with TypeScript and Zod v4 best practices

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -115,7 +115,11 @@ export default tseslint.config(
 
       // --- Adjustments for ESLint v9 ---
 
-      // Temporarily disable strict any checks - REVISIT LATER
+      // @typescript-eslint/no-explicit-any enforcement roadmap:
+      // 1. Message handlers now use 'unknown' with Zod schema validation
+      // 2. Consider setting to 'warn' once major handler migrations complete
+      // 3. Target full 'error' enforcement after all `any` types are removed
+      // See: src/common/webview/BaseViewMessageHandler.ts for validation pattern
       '@typescript-eslint/no-explicit-any': 'off',
 
       // Disable rules causing many errors after upgrade - REVISIT LATER

--- a/package-lock.json
+++ b/package-lock.json
@@ -283,7 +283,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -330,7 +329,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -781,7 +779,6 @@
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.24.3.tgz",
       "integrity": "sha512-YgSHW29fuzKKAHTGe9zjNoo+yF8KaQPzDC2W9Pv41E7/57IfY+AMGJ/aDFlgTLcVVELoggKE4syABCE75u3NCw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
@@ -1276,7 +1273,6 @@
       "integrity": "sha512-N9lBGA9o9aqb1hVMc9hzySbhKibHmB+N3IpoShyV6HyQYRGIhlrO5rQgttypi+yEeKsKI4idxC8Jw6gXKD4THA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.49.0",
         "@typescript-eslint/types": "8.49.0",
@@ -1889,7 +1885,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2457,7 +2452,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.9",
         "caniuse-lite": "^1.0.30001746",
@@ -3544,7 +3538,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3943,7 +3936,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
       "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.0",
@@ -7244,6 +7236,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -7265,6 +7258,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -7784,7 +7778,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -8907,7 +8900,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9124,7 +9116,6 @@
       "integrity": "sha512-HU1JOuV1OavsZ+mfigY0j8d1TgQgbZ6M+J75zDkpEAwYeXjWSqrGJtgnPblJjd/mAyTNQ7ygw0MiKOn6etz8yw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -9174,7 +9165,6 @@
       "integrity": "sha512-MfwFQ6SfwinsUVi0rNJm7rHZ31GyTcpVE5pgVA3hwFRb7COD4TzjUUwhGWKfO50+xdc2MQPuEBBJoqIMGt3JDw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.6.1",
         "@webpack-cli/configtest": "^3.0.1",
@@ -9867,7 +9857,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.2.0.tgz",
       "integrity": "sha512-Bd5fw9wlIhtqCCxotZgdTOMwGm1a0u75wARVEY9HMs1X17trvA/lMi4+MGK5EUfYkXVTbX8UDiDKW4OgzHVUZw==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/common/webview/BaseViewMessageHandler.ts
+++ b/src/common/webview/BaseViewMessageHandler.ts
@@ -9,9 +9,14 @@ import * as logger from '@logger/logUtils';
 import { COMMON_COMMANDS } from './commands';
 import type { z } from 'zod';
 
+/**
+ * Message handler function type.
+ * Uses `unknown` instead of `any` to encourage proper validation.
+ * Use withValidatedMessage() for type-safe message handling.
+ */
 export type MessageHandler<
   T extends vscode.WebviewView | vscode.WebviewPanel = vscode.WebviewView,
-> = (message: any, webviewView: T) => Promise<void> | void;
+> = (message: unknown, webviewView: T) => Promise<void> | void;
 
 /**
  * Configuration options for BaseViewMessageHandler.
@@ -91,13 +96,15 @@ export abstract class BaseViewMessageHandler<
    * Standard message handling with consistent error handling and logging.
    * When trackActiveView is enabled, automatically updates the active view reference.
    */
-  public async handleMessage(message: any, webviewView: T): Promise<void> {
+  public async handleMessage(message: unknown, webviewView: T): Promise<void> {
     // Track active view when option is enabled
     if (this._options.trackActiveView) {
       this._activeView = webviewView;
     }
 
-    if (!message?.command) {
+    // Type guard for message structure
+    const msg = message as { command?: string } | null | undefined;
+    if (!msg?.command) {
       this.logger.warn(
         this.channel,
         `Received message without command. Message: ${JSON.stringify(message)}`,
@@ -105,11 +112,11 @@ export abstract class BaseViewMessageHandler<
       return;
     }
 
-    this.logger.debug(this.channel, `Received message: ${message.command}`);
+    this.logger.debug(this.channel, `Received message: ${msg.command}`);
 
-    const handler = this.handlers[message.command];
+    const handler = this.handlers[msg.command];
     if (!handler) {
-      this.logger.warn(this.channel, `Unknown command: ${message.command}`);
+      this.logger.warn(this.channel, `Unknown command: ${msg.command}`);
       return;
     }
 
@@ -118,13 +125,13 @@ export abstract class BaseViewMessageHandler<
     } catch (error) {
       this.logger.error(
         this.channel,
-        `Error handling command ${message.command}: ${toErrorMessage(error)}`,
+        `Error handling command ${msg.command}: ${toErrorMessage(error)}`,
       );
 
       // Optionally notify the webview of the error
       webviewView.webview.postMessage({
         command: 'error',
-        message: `Failed to handle command: ${message.command}`,
+        message: `Failed to handle command: ${msg.command}`,
       });
     }
   }
@@ -132,8 +139,12 @@ export abstract class BaseViewMessageHandler<
   /**
    * Helper method for common theme handling
    */
-  protected async handleTheme(message: any, webviewView: T): Promise<void> {
-    if (!message?.theme) {
+  protected async handleTheme(
+    message: unknown,
+    webviewView: T,
+  ): Promise<void> {
+    const msg = message as { theme?: string } | null | undefined;
+    if (!msg?.theme) {
       this.logger.warn(this.channel, 'Invalid theme message', {
         data: message,
       });
@@ -142,17 +153,21 @@ export abstract class BaseViewMessageHandler<
 
     webviewView.webview.postMessage({
       command: COMMON_COMMANDS.THEME_SET,
-      theme: message.theme,
+      theme: msg.theme,
     });
   }
 
   /**
    * Helper method for common debug mode handling
    */
-  protected async handleDebugMode(message: any, webviewView: T): Promise<void> {
+  protected async handleDebugMode(
+    message: unknown,
+    webviewView: T,
+  ): Promise<void> {
+    const msg = message as { debugMode?: boolean } | null | undefined;
     webviewView.webview.postMessage({
       command: COMMON_COMMANDS.DEBUG_MODE_SET,
-      debugMode: message.debugMode,
+      debugMode: msg?.debugMode,
     });
   }
 
@@ -162,8 +177,8 @@ export abstract class BaseViewMessageHandler<
    * when the webview signals it is ready.
    */
   protected async handleWebviewReady(
-    message: any,
-    webviewView: T,
+    _message: unknown,
+    _webviewView: T,
   ): Promise<void> {
     this.logger.debug(this.channel, 'Webview ready signal received');
     // Subclasses can override for custom ready handling

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -3,9 +3,6 @@ import * as path from 'path';
 
 // Third-party imports
 import * as vscode from 'vscode';
-import { z } from 'zod';
-
-// Local imports - common
 
 // Local imports - progress view
 import {
@@ -30,7 +27,6 @@ import {
 import {
   handleProgressViewToolEditApprovalAction,
   resetToolEditApprovalSessionBypass,
-  ProgressViewApprovalActions,
 } from '@tools/approval/toolEditApproval';
 import { pathToLocation } from '@utils/files';
 import { isNonEmptyString } from '@utils/core';
@@ -41,37 +37,24 @@ import {
   polishTextWithAI,
 } from '@utils/text/textEnhancementUtils';
 
+// Message schemas - single source of truth for message validation
+import {
+  StreamMessageSchema,
+  SortStreamsMessageSchema,
+  FilterStreamsMessageSchema,
+  SendFollowUpMessageSchema,
+  PolishFollowUpMessageSchema,
+  ShowInformationMessageSchema,
+  ToolEditApprovalActionMessageSchema,
+  OpenTaskStorageMessageSchema,
+  OpenLabelMessageSchema,
+  type FileCommandMessage,
+  type BaseFileCommandMessage,
+  type CompareMessage,
+} from './messages';
+
 // Type imports
 import type { ProgressViewProvider } from './ProgressViewProvider';
-
-interface FileCommandMessage {
-  file: string;
-}
-
-interface BaseFileCommandMessage extends FileCommandMessage {
-  base?: string;
-}
-
-interface CompareMessage extends BaseFileCommandMessage {
-  prev?: string;
-}
-
-// --- Message Schemas ---
-
-const TrimmedString = z
-  .string()
-  .transform((s) => s.trim())
-  .pipe(z.string().min(1));
-const PolishFollowUp = z.object({
-  stream: z.string().min(1),
-  text: TrimmedString,
-});
-const InfoMessage = z.object({ text: TrimmedString });
-const ApprovalAction = z.object({
-  requestId: z.string().min(1),
-  action: z.enum(ProgressViewApprovalActions),
-  note: z.string().optional(),
-});
 
 export class ProgressViewMessageHandler extends BaseViewMessageHandler {
   private readonly recordingManager: RecordingManager;
@@ -174,7 +157,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
    * This allows the provider to process any pending updates that
    * were queued while the webview was initializing.
    */
-  protected override async handleWebviewReady(message: any): Promise<void> {
+  protected override async handleWebviewReady(message: unknown): Promise<void> {
     const webviewView = this.getActiveView();
     if (webviewView) {
       await super.handleWebviewReady(message, webviewView);
@@ -182,19 +165,33 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
     this.provider.markWebviewReady();
   }
 
-  private async handleSwitchStream(message: any): Promise<void> {
-    this.provider.setActiveStream(message.stream);
+  private async handleSwitchStream(message: unknown): Promise<void> {
+    await this.withValidatedMessage(
+      StreamMessageSchema,
+      message,
+      'switchStream',
+      ({ stream }) => {
+        this.provider.setActiveStream(stream);
+      },
+    );
   }
 
-  private async handleDeleteStream(message: any): Promise<void> {
-    // Delete persisted session data if any
-    await this.deleteSessionSnapshot(message.stream);
-    await this.provider.state.clearStream(message.stream);
-    // Force rebuild since we deleted a stream
-    this.provider.updateWebview({ forceRebuild: true });
+  private async handleDeleteStream(message: unknown): Promise<void> {
+    await this.withValidatedMessage(
+      StreamMessageSchema,
+      message,
+      'deleteStream',
+      async ({ stream }) => {
+        // Delete persisted session data if any
+        await this.deleteSessionSnapshot(stream as StreamTabId);
+        await this.provider.state.clearStream(stream);
+        // Force rebuild since we deleted a stream
+        this.provider.updateWebview({ forceRebuild: true });
+      },
+    );
   }
 
-  private async handleDeleteAll(_message: any): Promise<void> {
+  private async handleDeleteAll(_message: unknown): Promise<void> {
     // Show confirmation dialog
     const confirmation = await vscode.window.showWarningMessage(
       'Are you sure you want to delete all streams? This action cannot be undone.',
@@ -218,125 +215,208 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
     this.provider.updateWebview({ forceRebuild: true });
   }
 
-  private async handleStopStream(message: any): Promise<void> {
-    await vscode.commands.executeCommand('texra.stopAgent', message.stream);
+  private async handleStopStream(message: unknown): Promise<void> {
+    await this.withValidatedMessage(
+      StreamMessageSchema,
+      message,
+      'stopStream',
+      async ({ stream }) => {
+        await vscode.commands.executeCommand('texra.stopAgent', stream);
+      },
+    );
   }
 
-  private async handleRunAgain(message: any): Promise<void> {
-    await this.withToolbarTaskState(message.stream, async (taskState) => {
-      const executionId = this.provider.state.getExecutionId(message.stream);
-      if (!executionId) {
-        this.logger.warn(
-          this.channel,
-          `Resume requested for ${message.stream} without an execution ID`,
-        );
-        return;
-      }
+  private async handleRunAgain(message: unknown): Promise<void> {
+    await this.withValidatedMessage(
+      StreamMessageSchema,
+      message,
+      'runAgain',
+      async ({ stream }) => {
+        await this.withToolbarTaskState(stream, async (taskState) => {
+          const executionId = this.provider.state.getExecutionId(stream);
+          if (!executionId) {
+            this.logger.warn(
+              this.channel,
+              `Resume requested for ${stream} without an execution ID`,
+            );
+            return;
+          }
 
-      await safeExecuteCommand('texra.execute', [
-        {
-          config: taskState.agentConfig,
-          executionId,
-          stream: message.stream,
-          resume: true,
-        },
-      ]);
-    });
+          await safeExecuteCommand('texra.execute', [
+            {
+              config: taskState.agentConfig,
+              executionId,
+              stream,
+              resume: true,
+            },
+          ]);
+        });
+      },
+    );
   }
 
-  private async handleRunNew(message: any): Promise<void> {
-    await this.withToolbarTaskState(message.stream, async (taskState) => {
-      await safeExecuteCommand('texra.execute', [taskState.agentConfig]);
-    });
+  private async handleRunNew(message: unknown): Promise<void> {
+    await this.withValidatedMessage(
+      StreamMessageSchema,
+      message,
+      'runNew',
+      async ({ stream }) => {
+        await this.withToolbarTaskState(stream, async (taskState) => {
+          await safeExecuteCommand('texra.execute', [taskState.agentConfig]);
+        });
+      },
+    );
   }
 
-  private async handleRetryStreamRequest(message: any): Promise<void> {
-    // triggerRetry is synchronous, no await needed
-    const success = retryCoordinator.triggerRetry(message.stream);
-    if (!success) {
-      await vscode.window.showInformationMessage(
-        'No retryable request is available for this stream yet.',
-      );
-    }
+  private async handleRetryStreamRequest(message: unknown): Promise<void> {
+    await this.withValidatedMessage(
+      StreamMessageSchema,
+      message,
+      'retryStreamRequest',
+      async ({ stream }) => {
+        // triggerRetry is synchronous, no await needed
+        const success = retryCoordinator.triggerRetry(stream);
+        if (!success) {
+          await vscode.window.showInformationMessage(
+            'No retryable request is available for this stream yet.',
+          );
+        }
+      },
+    );
   }
 
-  private async handleCancelRetryRequest(message: any): Promise<void> {
-    retryCoordinator.cancelRetry(message.stream);
+  private async handleCancelRetryRequest(message: unknown): Promise<void> {
+    await this.withValidatedMessage(
+      StreamMessageSchema,
+      message,
+      'cancelRetryRequest',
+      ({ stream }) => {
+        retryCoordinator.cancelRetry(stream);
+      },
+    );
   }
 
-  private async handleDiffStream(message: any): Promise<void> {
-    await this.withToolbarTaskState(message.stream, async (taskState) => {
-      const executionId = this.provider.state.getExecutionId(message.stream);
-      const activeRunId = this.provider.state.getActiveRunId(message.stream);
-      // storageKey is for logical indexing (finding file metadata in progress view state).
-      // For workflow agents: activeRunId = task group ID; for tool-use: executionId.
-      // Note: Physical file paths use executionId (see runId below), not storageKey.
-      const storageKey = normalizeRunId(activeRunId ?? executionId);
-      const runOutputs = this.provider.state.getRunOutputFiles(message.stream, {
-        storageKey,
-      });
-      const outputsByRound = runOutputs
-        ? Object.fromEntries(runOutputs.entries())
-        : undefined;
+  private async handleDiffStream(message: unknown): Promise<void> {
+    await this.withValidatedMessage(
+      StreamMessageSchema,
+      message,
+      'diffStream',
+      async ({ stream }) => {
+        await this.withToolbarTaskState(stream, async (taskState) => {
+          const executionId = this.provider.state.getExecutionId(stream);
+          const activeRunId = this.provider.state.getActiveRunId(stream);
+          // storageKey is for logical indexing (finding file metadata in progress view state).
+          // For workflow agents: activeRunId = task group ID; for tool-use: executionId.
+          // Note: Physical file paths use executionId (see runId below), not storageKey.
+          const storageKey = normalizeRunId(activeRunId ?? executionId);
+          const runOutputs = this.provider.state.getRunOutputFiles(stream, {
+            storageKey,
+          });
+          const outputsByRound = runOutputs
+            ? Object.fromEntries(runOutputs.entries())
+            : undefined;
 
-      await vscode.commands.executeCommand('texra.runLatexdiff', {
-        agent: taskState.agentConfig.agent,
-        model: taskState.agentConfig.model,
-        inputFile: taskState.agentConfig.inputFile,
-        outputFiles: taskState.agentConfig.outputFiles,
-        outputFilesActive: taskState.activeFiles.output,
-        streamId: message.stream,
-        // executionId is for file system paths (taskRuns/<executionId>/...)
-        // storageKey is for logical storage indexing - different concepts
-        runId: executionId,
-        outputsByRound,
-      });
-    });
+          await vscode.commands.executeCommand('texra.runLatexdiff', {
+            agent: taskState.agentConfig.agent,
+            model: taskState.agentConfig.model,
+            inputFile: taskState.agentConfig.inputFile,
+            outputFiles: taskState.agentConfig.outputFiles,
+            outputFilesActive: taskState.activeFiles.output,
+            streamId: stream,
+            // executionId is for file system paths (taskRuns/<executionId>/...)
+            // storageKey is for logical storage indexing - different concepts
+            runId: executionId,
+            outputsByRound,
+          });
+        });
+      },
+    );
   }
 
-  private async handlePackStream(message: any): Promise<void> {
-    await this.withToolbarTaskState(message.stream, async (taskState) => {
-      await this.handleFileOperation(message.stream, taskState, 'texra.pack');
-    });
+  private async handlePackStream(message: unknown): Promise<void> {
+    await this.withValidatedMessage(
+      StreamMessageSchema,
+      message,
+      'packStream',
+      async ({ stream }) => {
+        await this.withToolbarTaskState(stream, async (taskState) => {
+          await this.handleFileOperation(stream, taskState, 'texra.pack');
+        });
+      },
+    );
   }
 
-  private async handleCleanStream(message: any): Promise<void> {
-    await this.withToolbarTaskState(message.stream, async (taskState) => {
-      await this.handleFileOperation(message.stream, taskState, 'texra.clean');
-    });
+  private async handleCleanStream(message: unknown): Promise<void> {
+    await this.withValidatedMessage(
+      StreamMessageSchema,
+      message,
+      'cleanStream',
+      async ({ stream }) => {
+        await this.withToolbarTaskState(stream, async (taskState) => {
+          await this.handleFileOperation(stream, taskState, 'texra.clean');
+        });
+      },
+    );
   }
 
-  private async handleSortStreams(message: any): Promise<void> {
-    this.provider.state.streamSortOrder = message.sortBy ?? 'time';
-    this.provider.updateWebview();
+  private async handleSortStreams(message: unknown): Promise<void> {
+    await this.withValidatedMessage(
+      SortStreamsMessageSchema,
+      message,
+      'sortStreams',
+      ({ sortBy }) => {
+        this.provider.state.streamSortOrder = sortBy ?? 'time';
+        this.provider.updateWebview();
+      },
+    );
   }
 
-  private async handleFilterStreams(message: any): Promise<void> {
-    const requestedFilter = message.filter;
-    const filter: AgentTypeFilter = isAgentTypeFilter(requestedFilter)
-      ? requestedFilter
-      : 'all';
-    this.provider.state.agentTypeFilter = filter;
-    this.provider.updateWebview();
+  private async handleFilterStreams(message: unknown): Promise<void> {
+    await this.withValidatedMessage(
+      FilterStreamsMessageSchema,
+      message,
+      'filterStreams',
+      ({ filter }) => {
+        const validFilter: AgentTypeFilter = isAgentTypeFilter(filter)
+          ? filter
+          : 'all';
+        this.provider.state.agentTypeFilter = validFilter;
+        this.provider.updateWebview();
+      },
+    );
   }
 
-  private async handleRestoreState(message: any): Promise<void> {
-    const taskState = this.provider.state.getTaskState(message.stream);
-    if (taskState) {
-      await vscode.commands.executeCommand('texra.restoreState', taskState);
-    }
+  private async handleRestoreState(message: unknown): Promise<void> {
+    await this.withValidatedMessage(
+      StreamMessageSchema,
+      message,
+      'restoreState',
+      async ({ stream }) => {
+        const taskState = this.provider.state.getTaskState(stream);
+        if (taskState) {
+          await vscode.commands.executeCommand('texra.restoreState', taskState);
+        }
+      },
+    );
   }
 
-  private async handleSendFollowUp(message: any): Promise<void> {
-    await vscode.commands.executeCommand('texra.sendFollowUp', {
-      stream: message.stream,
-      text: message.text,
-    });
+  private async handleSendFollowUp(message: unknown): Promise<void> {
+    await this.withValidatedMessage(
+      SendFollowUpMessageSchema,
+      message,
+      'sendFollowUp',
+      async ({ stream, text }) => {
+        await vscode.commands.executeCommand('texra.sendFollowUp', {
+          stream,
+          text,
+        });
+      },
+    );
   }
 
   private async handlePolishFollowUp(message: unknown): Promise<void> {
     await this.withValidatedMessage(
-      PolishFollowUp,
+      PolishFollowUpMessageSchema,
       message,
       'polishFollowUp',
       async ({ stream, text }) => {
@@ -393,7 +473,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
 
   private async handleShowInformationMessage(message: unknown): Promise<void> {
     await this.withValidatedMessage(
-      InfoMessage,
+      ShowInformationMessageSchema,
       message,
       'infoMessage',
       async (data) => {
@@ -404,7 +484,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
 
   private async handleToolEditApprovalAction(message: unknown): Promise<void> {
     await this.withValidatedMessage(
-      ApprovalAction,
+      ToolEditApprovalActionMessageSchema,
       message,
       'approvalAction',
       handleProgressViewToolEditApprovalAction,
@@ -418,8 +498,11 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
     );
   }
 
-  private async handleOpenTaskStorage(message: any): Promise<void> {
-    const stream = message.stream as StreamTabId | undefined;
+  private async handleOpenTaskStorage(message: unknown): Promise<void> {
+    const parsed = OpenTaskStorageMessageSchema.safeParse(message);
+    const stream = (parsed.success ? parsed.data.stream : undefined) as
+      | StreamTabId
+      | undefined;
     if (!stream) {
       await vscode.window.showInformationMessage(
         'No workspace storage folder is available for this run yet.',
@@ -600,8 +683,15 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
     );
   }
 
-  private async handleOpenLabel(message: any): Promise<void> {
-    await vscode.commands.executeCommand('texra.openLabel', message.label);
+  private async handleOpenLabel(message: unknown): Promise<void> {
+    await this.withValidatedMessage(
+      OpenLabelMessageSchema,
+      message,
+      'openLabel',
+      async ({ label }) => {
+        await vscode.commands.executeCommand('texra.openLabel', label);
+      },
+    );
   }
 
   private async handleOpenProfile(): Promise<void> {

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -499,82 +499,90 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
   }
 
   private async handleOpenTaskStorage(message: unknown): Promise<void> {
-    const parsed = OpenTaskStorageMessageSchema.safeParse(message);
-    const stream = (parsed.success ? parsed.data.stream : undefined) as
-      | StreamTabId
-      | undefined;
-    if (!stream) {
-      await vscode.window.showInformationMessage(
-        'No workspace storage folder is available for this run yet.',
-      );
-      return;
-    }
+    await this.withValidatedMessage(
+      OpenTaskStorageMessageSchema,
+      message,
+      'openTaskStorage',
+      async ({ stream: streamOrUndefined }) => {
+        const stream = streamOrUndefined as StreamTabId | undefined;
+        if (!stream) {
+          await vscode.window.showInformationMessage(
+            'No workspace storage folder is available for this run yet.',
+          );
+          return;
+        }
 
-    const resolvedRunId = this.provider.state.resolveRunId(stream, undefined, {
-      persist: false,
-    });
-    // Only fetch output files if we have a resolved run ID
-    const storageKey = resolvedRunId ? normalizeRunId(resolvedRunId) : null;
-    const runOutputs = storageKey
-      ? this.provider.state.getRunOutputFiles(stream, { storageKey })
-      : undefined;
+        const resolvedRunId = this.provider.state.resolveRunId(
+          stream,
+          undefined,
+          {
+            persist: false,
+          },
+        );
+        // Only fetch output files if we have a resolved run ID
+        const storageKey = resolvedRunId ? normalizeRunId(resolvedRunId) : null;
+        const runOutputs = storageKey
+          ? this.provider.state.getRunOutputFiles(stream, { storageKey })
+          : undefined;
 
-    // executionId is the physical directory name: taskRuns/<executionId>/
-    // For workflow agents, storageKey (task group ID) differs from executionId,
-    // but files are always written to the executionId directory.
-    const executionId = this.provider.state.getExecutionId(stream);
+        // executionId is the physical directory name: taskRuns/<executionId>/
+        // For workflow agents, storageKey (task group ID) differs from executionId,
+        // but files are always written to the executionId directory.
+        const executionId = this.provider.state.getExecutionId(stream);
 
-    try {
-      let directoryToReveal: string | undefined;
+        try {
+          let directoryToReveal: string | undefined;
 
-      if (executionId) {
-        await ensureRunDir(executionId);
-        directoryToReveal = getRunDir(executionId);
-      } else if (runOutputs) {
-        // Defensive fallback: executionId and outputFiles are persisted independently,
-        // so edge cases (data migration, partial state) could leave files without executionId.
-        // Extract directory from actual file paths.
-        for (const infos of runOutputs.values()) {
-          for (const info of infos) {
-            if (
-              info.location.kind === 'runStorage' ||
-              info.location.kind === 'workspace'
-            ) {
-              directoryToReveal = path.dirname(info.location.absolutePath);
-              break;
+          if (executionId) {
+            await ensureRunDir(executionId);
+            directoryToReveal = getRunDir(executionId);
+          } else if (runOutputs) {
+            // Defensive fallback: executionId and outputFiles are persisted independently,
+            // so edge cases (data migration, partial state) could leave files without executionId.
+            // Extract directory from actual file paths.
+            for (const infos of runOutputs.values()) {
+              for (const info of infos) {
+                if (
+                  info.location.kind === 'runStorage' ||
+                  info.location.kind === 'workspace'
+                ) {
+                  directoryToReveal = path.dirname(info.location.absolutePath);
+                  break;
+                }
+              }
+              if (directoryToReveal) break;
             }
           }
-          if (directoryToReveal) break;
+
+          if (!directoryToReveal) {
+            await vscode.window.showInformationMessage(
+              'No workspace storage folder is available for this run yet.',
+            );
+            return;
+          }
+
+          await safeExecuteCommand('revealFileInOS', [
+            vscode.Uri.file(directoryToReveal),
+          ]);
+        } catch (error) {
+          const errorMessage = toErrorMessage(error);
+          this.logger.error(
+            this.channel,
+            `Failed to open task storage for stream ${stream}, executionId ${executionId ?? 'unknown'}: ${errorMessage}`,
+            {
+              data: {
+                error: error instanceof Error ? error : undefined,
+                stream,
+                executionId,
+              },
+            },
+          );
+          await vscode.window.showErrorMessage(
+            'Unable to open the workspace storage folder for this run.',
+          );
         }
-      }
-
-      if (!directoryToReveal) {
-        await vscode.window.showInformationMessage(
-          'No workspace storage folder is available for this run yet.',
-        );
-        return;
-      }
-
-      await safeExecuteCommand('revealFileInOS', [
-        vscode.Uri.file(directoryToReveal),
-      ]);
-    } catch (error) {
-      const errorMessage = toErrorMessage(error);
-      this.logger.error(
-        this.channel,
-        `Failed to open task storage for stream ${stream}, executionId ${executionId ?? 'unknown'}: ${errorMessage}`,
-        {
-          data: {
-            error: error instanceof Error ? error : undefined,
-            stream,
-            executionId,
-          },
-        },
-      );
-      await vscode.window.showErrorMessage(
-        'Unable to open the workspace storage folder for this run.',
-      );
-    }
+      },
+    );
   }
 
   private async handleOpenFile(message: FileCommandMessage): Promise<void> {

--- a/src/progressView/messages.ts
+++ b/src/progressView/messages.ts
@@ -1,0 +1,171 @@
+/**
+ * Zod schemas for progress view message types.
+ * Types are derived from schemas using z.infer<> for single source of truth.
+ *
+ * @module progressView/messages
+ */
+import { z } from 'zod';
+
+import { ProgressViewApprovalActions } from '@tools/approval/toolEditApproval';
+
+// --- Base Schemas (composable building blocks) ---
+
+/** Trimmed non-empty string for text inputs */
+const TrimmedString = z
+  .string()
+  .transform((s) => s.trim())
+  .pipe(z.string().min(1));
+
+/** Stream identifier schema - used by most stream-related messages */
+export const StreamIdSchema = z.string().min(1);
+
+// --- Stream Management Messages ---
+
+/** Message with a stream identifier */
+export const StreamMessageSchema = z.object({
+  stream: StreamIdSchema,
+});
+export type StreamMessage = z.infer<typeof StreamMessageSchema>;
+
+/** Message for switch stream command */
+export const SwitchStreamMessageSchema = StreamMessageSchema;
+export type SwitchStreamMessage = z.infer<typeof SwitchStreamMessageSchema>;
+
+/** Message for delete stream command */
+export const DeleteStreamMessageSchema = StreamMessageSchema;
+export type DeleteStreamMessage = z.infer<typeof DeleteStreamMessageSchema>;
+
+/** Message for stop stream command */
+export const StopStreamMessageSchema = StreamMessageSchema;
+export type StopStreamMessage = z.infer<typeof StopStreamMessageSchema>;
+
+/** Message for run again command */
+export const RunAgainMessageSchema = StreamMessageSchema;
+export type RunAgainMessage = z.infer<typeof RunAgainMessageSchema>;
+
+/** Message for run new command */
+export const RunNewMessageSchema = StreamMessageSchema;
+export type RunNewMessage = z.infer<typeof RunNewMessageSchema>;
+
+/** Message for retry stream request */
+export const RetryStreamRequestMessageSchema = StreamMessageSchema;
+export type RetryStreamRequestMessage = z.infer<
+  typeof RetryStreamRequestMessageSchema
+>;
+
+/** Message for cancel retry request */
+export const CancelRetryRequestMessageSchema = StreamMessageSchema;
+export type CancelRetryRequestMessage = z.infer<
+  typeof CancelRetryRequestMessageSchema
+>;
+
+/** Message for diff stream command */
+export const DiffStreamMessageSchema = StreamMessageSchema;
+export type DiffStreamMessage = z.infer<typeof DiffStreamMessageSchema>;
+
+/** Message for pack stream command */
+export const PackStreamMessageSchema = StreamMessageSchema;
+export type PackStreamMessage = z.infer<typeof PackStreamMessageSchema>;
+
+/** Message for clean stream command */
+export const CleanStreamMessageSchema = StreamMessageSchema;
+export type CleanStreamMessage = z.infer<typeof CleanStreamMessageSchema>;
+
+/** Message for restore state command */
+export const RestoreStateMessageSchema = StreamMessageSchema;
+export type RestoreStateMessage = z.infer<typeof RestoreStateMessageSchema>;
+
+/** Message for open task storage command */
+export const OpenTaskStorageMessageSchema = z.object({
+  stream: StreamIdSchema.optional(),
+});
+export type OpenTaskStorageMessage = z.infer<
+  typeof OpenTaskStorageMessageSchema
+>;
+
+// --- Sort and Filter Messages ---
+
+/** Valid sort options for streams */
+export const StreamSortOrderSchema = z
+  .enum(['time', 'name', 'status'])
+  .prefault('time');
+
+/** Message for sort streams command */
+export const SortStreamsMessageSchema = z.object({
+  sortBy: StreamSortOrderSchema.optional(),
+});
+export type SortStreamsMessage = z.infer<typeof SortStreamsMessageSchema>;
+
+/** Message for filter streams command */
+export const FilterStreamsMessageSchema = z.object({
+  filter: z.string().optional(),
+});
+export type FilterStreamsMessage = z.infer<typeof FilterStreamsMessageSchema>;
+
+// --- Follow-Up Messages ---
+
+/** Message for send follow-up command */
+export const SendFollowUpMessageSchema = z.object({
+  stream: StreamIdSchema,
+  text: z.string(),
+});
+export type SendFollowUpMessage = z.infer<typeof SendFollowUpMessageSchema>;
+
+/** Message for polish follow-up command */
+export const PolishFollowUpMessageSchema = z.object({
+  stream: StreamIdSchema,
+  text: TrimmedString,
+});
+export type PolishFollowUpMessage = z.infer<typeof PolishFollowUpMessageSchema>;
+
+// --- Information Messages ---
+
+/** Message for show information message command */
+export const ShowInformationMessageSchema = z.object({
+  text: TrimmedString,
+});
+export type ShowInformationMessage = z.infer<
+  typeof ShowInformationMessageSchema
+>;
+
+// --- Approval Action Messages ---
+
+/** Message for tool edit approval action */
+export const ToolEditApprovalActionMessageSchema = z.object({
+  requestId: z.string().min(1),
+  action: z.enum(ProgressViewApprovalActions),
+  note: z.string().optional(),
+});
+export type ToolEditApprovalActionMessage = z.infer<
+  typeof ToolEditApprovalActionMessageSchema
+>;
+
+// --- File Operation Messages ---
+
+/** Base message with file path */
+export const FileCommandMessageSchema = z.object({
+  file: z.string(),
+});
+export type FileCommandMessage = z.infer<typeof FileCommandMessageSchema>;
+
+/** Message with file and optional base path */
+export const BaseFileCommandMessageSchema = FileCommandMessageSchema.extend({
+  base: z.string().optional(),
+});
+export type BaseFileCommandMessage = z.infer<
+  typeof BaseFileCommandMessageSchema
+>;
+
+/** Message for compare operations with optional previous file */
+export const CompareMessageSchema = BaseFileCommandMessageSchema.extend({
+  prev: z.string().optional(),
+});
+export type CompareMessage = z.infer<typeof CompareMessageSchema>;
+
+// --- Label Messages ---
+
+/** Message for open label command */
+export const OpenLabelMessageSchema = z.object({
+  label: z.string(),
+});
+export type OpenLabelMessage = z.infer<typeof OpenLabelMessageSchema>;

--- a/src/progressView/messages.ts
+++ b/src/progressView/messages.ts
@@ -107,7 +107,7 @@ export type FilterStreamsMessage = z.infer<typeof FilterStreamsMessageSchema>;
 /** Message for send follow-up command */
 export const SendFollowUpMessageSchema = z.object({
   stream: StreamIdSchema,
-  text: z.string(),
+  text: TrimmedString,
 });
 export type SendFollowUpMessage = z.infer<typeof SendFollowUpMessageSchema>;
 

--- a/src/webview/MainViewMessageHandler.ts
+++ b/src/webview/MainViewMessageHandler.ts
@@ -33,6 +33,29 @@ import {
   InstructionManager,
 } from './managers';
 
+// Type imports for message type assertions
+import type {
+  FileSelectionMessage,
+  FileSelectedMessage,
+  RequestInputFileMessage,
+  RequestFileMessage,
+  RequestEditedFileMessage,
+  RequestBaseFileMessage,
+  RequestDefaultOutputFilesMessage,
+  SetMultipleFilesMessage,
+  SelectMultipleFilesMessage,
+  GetCurrentFileMessage,
+  UpdateFilesMessage,
+  PolishInstructionMessage,
+  ClipboardImageMessage,
+} from './types/messages';
+
+/**
+ * Type guard helper for message properties.
+ * Used for inline handlers that need to access optional message fields.
+ */
+type MessageWith<T> = { command: string } & T;
+
 export class MainViewMessageHandler extends BaseViewMessageHandler {
   private readonly settingsManager: SettingsManager;
   private readonly recordingManager: RecordingManager;
@@ -58,7 +81,7 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
   }
 
   public override async handleMessage(
-    message: any,
+    message: unknown,
     webviewView: vscode.WebviewView,
   ): Promise<void> {
     // Attach webview to managers that need it for message posting
@@ -73,6 +96,9 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
     string,
     MessageHandler<vscode.WebviewView>
   > {
+    // Type assertion helper for cleaner handler definitions
+    const asMsg = <T>(m: unknown): T => m as T;
+
     return {
       // Common handlers
       [MAIN_VIEW_COMMANDS.THEME_SET]: this.handleTheme.bind(this),
@@ -82,8 +108,10 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
       // Core functionality
       [MAIN_VIEW_COMMANDS.SHOW_INFORMATION_MESSAGE]:
         this.handleInfoMessage.bind(this),
-      [MAIN_VIEW_COMMANDS.SHOW_INSTRUCTION]: async (m) =>
-        showInstructionWithSuppress(m.key, m.text),
+      [MAIN_VIEW_COMMANDS.SHOW_INSTRUCTION]: async (m) => {
+        const msg = asMsg<MessageWith<{ key: string; text: string }>>(m);
+        return showInstructionWithSuppress(msg.key, msg.text);
+      },
       [MAIN_VIEW_COMMANDS.GET_THEME]: this.handleThemeRequest.bind(this),
       [MAIN_VIEW_COMMANDS.GET_DEBUG_MODE]:
         this.handleDebugModeRequest.bind(this),
@@ -96,61 +124,89 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
       // Delegate to managers for specific functionality
       // File selection commands
       [MAIN_VIEW_COMMANDS.SELECT_INPUT_FILE]: async (m) =>
-        this.fileManager.handleFileSelection(m),
+        this.fileManager.handleFileSelection(asMsg<FileSelectionMessage>(m)),
       [MAIN_VIEW_COMMANDS.SELECT_REFERENCE_FILE]: async (m) =>
-        this.fileManager.handleFileSelection(m),
+        this.fileManager.handleFileSelection(asMsg<FileSelectionMessage>(m)),
       [MAIN_VIEW_COMMANDS.SELECT_AUXILIARY_FILE]: async (m) =>
-        this.fileManager.handleFileSelection(m),
+        this.fileManager.handleFileSelection(asMsg<FileSelectionMessage>(m)),
       [MAIN_VIEW_COMMANDS.SELECT_MEDIA_FILE]: async (m) =>
-        this.fileManager.handleFileSelection(m),
+        this.fileManager.handleFileSelection(asMsg<FileSelectionMessage>(m)),
       [MAIN_VIEW_COMMANDS.SELECT_EDITED_FILE]: async () =>
         this.fileManager.handleEditedFileSelection(),
 
       // File selected commands
       [MAIN_VIEW_COMMANDS.INPUT_FILE_SELECTED]: async (m) =>
-        this.fileManager.handleInputFileSelected(m),
+        this.fileManager.handleInputFileSelected(asMsg<FileSelectedMessage>(m)),
       [MAIN_VIEW_COMMANDS.REFERENCE_FILE_SELECTED]: async (m) =>
-        this.fileManager.handleGenericFileSelected(m),
+        this.fileManager.handleGenericFileSelected(
+          asMsg<FileSelectedMessage>(m),
+        ),
       [MAIN_VIEW_COMMANDS.AUXILIARY_FILE_SELECTED]: async (m) =>
-        this.fileManager.handleGenericFileSelected(m),
+        this.fileManager.handleGenericFileSelected(
+          asMsg<FileSelectedMessage>(m),
+        ),
       [MAIN_VIEW_COMMANDS.MEDIA_FILE_SELECTED]: async (m) =>
-        this.fileManager.handleGenericFileSelected(m),
+        this.fileManager.handleGenericFileSelected(
+          asMsg<FileSelectedMessage>(m),
+        ),
       [MAIN_VIEW_COMMANDS.EDITED_FILE_SELECTED]: async (m) =>
-        this.fileManager.handleGenericFileSelected(m),
+        this.fileManager.handleGenericFileSelected(
+          asMsg<FileSelectedMessage>(m),
+        ),
 
       // Request file commands
       [MAIN_VIEW_COMMANDS.REQUEST_INPUT_FILE]: async (m) =>
-        this.fileManager.handleRequestInputFile(m),
+        this.fileManager.handleRequestInputFile(
+          asMsg<RequestInputFileMessage>(m),
+        ),
       [MAIN_VIEW_COMMANDS.REQUEST_REFERENCE_FILE]: async (m) =>
-        this.fileManager.handleRequestFile(m),
+        this.fileManager.handleRequestFile(asMsg<RequestFileMessage>(m)),
       [MAIN_VIEW_COMMANDS.REQUEST_AUXILIARY_FILE]: async (m) =>
-        this.fileManager.handleRequestFile(m),
+        this.fileManager.handleRequestFile(asMsg<RequestFileMessage>(m)),
       [MAIN_VIEW_COMMANDS.REQUEST_MEDIA_FILE]: async (m) =>
-        this.fileManager.handleRequestFile(m),
+        this.fileManager.handleRequestFile(asMsg<RequestFileMessage>(m)),
       [MAIN_VIEW_COMMANDS.REQUEST_EDITED_FILE]: async (m) =>
-        this.fileManager.handleRequestEditedFile(m),
+        this.fileManager.handleRequestEditedFile(
+          asMsg<RequestEditedFileMessage>(m),
+        ),
       [MAIN_VIEW_COMMANDS.REQUEST_BASE_FILE]: async (m) =>
-        this.fileManager.handleRequestBaseFile(m),
+        this.fileManager.handleRequestBaseFile(
+          asMsg<RequestBaseFileMessage>(m),
+        ),
       [MAIN_VIEW_COMMANDS.REQUEST_DEFAULT_OUTPUT_FILES]: async (m) =>
-        this.fileManager.handleRequestDefaultOutputFiles(m),
+        this.fileManager.handleRequestDefaultOutputFiles(
+          asMsg<RequestDefaultOutputFilesMessage>(m),
+        ),
 
       // Multiple file operations
       [MAIN_VIEW_COMMANDS.SET_INPUT_FILES]: async (m) =>
-        this.fileManager.handleSetMultipleFiles(m),
+        this.fileManager.handleSetMultipleFiles(
+          asMsg<SetMultipleFilesMessage>(m),
+        ),
       [MAIN_VIEW_COMMANDS.SET_REFERENCE_FILES]: async (m) =>
-        this.fileManager.handleSetMultipleFiles(m),
+        this.fileManager.handleSetMultipleFiles(
+          asMsg<SetMultipleFilesMessage>(m),
+        ),
       [MAIN_VIEW_COMMANDS.SET_AUXILIARY_FILES]: async (m) =>
-        this.fileManager.handleSetMultipleFiles(m),
+        this.fileManager.handleSetMultipleFiles(
+          asMsg<SetMultipleFilesMessage>(m),
+        ),
       [MAIN_VIEW_COMMANDS.SET_MEDIA_FILES]: async (m) =>
-        this.fileManager.handleSetMultipleFiles(m),
+        this.fileManager.handleSetMultipleFiles(
+          asMsg<SetMultipleFilesMessage>(m),
+        ),
       [MAIN_VIEW_COMMANDS.SELECT_MULTIPLE_FILES]: async (m) =>
-        this.fileManager.handleSelectMultipleFiles(m),
+        this.fileManager.handleSelectMultipleFiles(
+          asMsg<SelectMultipleFilesMessage>(m),
+        ),
 
       // Other file operations
       [MAIN_VIEW_COMMANDS.GET_CURRENT_FILE]: async (m) =>
-        this.fileManager.handleGetCurrentFile(m),
-      [MAIN_VIEW_COMMANDS.ADD_OPENED_FILES]: async (m) =>
-        this.fileManager.handleAddOpenedFiles(m.fileType),
+        this.fileManager.handleGetCurrentFile(asMsg<GetCurrentFileMessage>(m)),
+      [MAIN_VIEW_COMMANDS.ADD_OPENED_FILES]: async (m) => {
+        const msg = asMsg<MessageWith<{ fileType: string }>>(m);
+        return this.fileManager.handleAddOpenedFiles(msg.fileType);
+      },
 
       // Execution commands
       [MAIN_VIEW_COMMANDS.MERGE]: async (m) =>
@@ -162,8 +218,9 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
       [MAIN_VIEW_COMMANDS.SETTINGS_OPEN]: async () =>
         this.settingsManager.openSettings(),
       [MAIN_VIEW_COMMANDS.OPEN_AGENT_SETTINGS]: async (m) => {
+        const msg = asMsg<MessageWith<{ sessionType?: string }>>(m);
         const query =
-          m?.sessionType === 'toolUse'
+          msg.sessionType === 'toolUse'
             ? SETTINGS_QUERY.TOOL_USE_AGENTS
             : SETTINGS_QUERY.WORKFLOW_AGENTS;
         return this.settingsManager.openSettings(query);
@@ -171,7 +228,8 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
       [MAIN_VIEW_COMMANDS.OPEN_MODEL_SETTINGS]: async () =>
         this.settingsManager.openSettings(SETTINGS_QUERY.MODELS),
       [MAIN_VIEW_COMMANDS.OPEN_AGENT_DIRECTORY]: async (m) => {
-        if (m?.customDirSet) {
+        const msg = asMsg<MessageWith<{ customDirSet?: boolean }>>(m);
+        if (msg.customDirSet) {
           const dir = await agentDirectories.custom();
           if (dir) {
             await vscode.commands.executeCommand(
@@ -194,23 +252,29 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
 
       // Instruction commands
       [MAIN_VIEW_COMMANDS.POLISH_INSTRUCTION_TEXT]: async (m) =>
-        this.instructionManager.handlePolishInstructionText(m),
+        this.instructionManager.handlePolishInstructionText(
+          asMsg<PolishInstructionMessage>(m),
+        ),
       [MAIN_VIEW_COMMANDS.TRANSCRIBE_INSTRUCTION]: async () =>
         this.instructionManager.handleTranscribeInstruction(),
       [MAIN_VIEW_COMMANDS.CLIPBOARD_IMAGE]: async (m) =>
-        this.instructionManager.handleClipboardImage(m),
+        this.instructionManager.handleClipboardImage(
+          asMsg<ClipboardImageMessage>(m),
+        ),
       [MAIN_VIEW_COMMANDS.OPEN_SET_API_KEY]: async () =>
         safeExecuteCommand('texra.setApiKey'),
       [MAIN_VIEW_COMMANDS.OPEN_SET_PROVIDER_API_KEY]: async (m) => {
         // Reuse existing setApiKey command with provider parameter
-        if (m?.provider) {
-          await safeExecuteCommand('texra.setApiKey', [m.provider]);
+        const msg = asMsg<MessageWith<{ provider?: string }>>(m);
+        if (msg.provider) {
+          await safeExecuteCommand('texra.setApiKey', [msg.provider]);
         }
       },
       [MAIN_VIEW_COMMANDS.OPEN_PROVIDER_API_KEY_URL]: async (m) => {
         // Open provider-specific API key page
-        if (m?.provider) {
-          const url = PROVIDER_URLS[m.provider as keyof typeof PROVIDER_URLS];
+        const msg = asMsg<MessageWith<{ provider?: string }>>(m);
+        if (msg.provider) {
+          const url = PROVIDER_URLS[msg.provider as keyof typeof PROVIDER_URLS];
           if (url) {
             await vscode.env.openExternal(vscode.Uri.parse(url));
           }
@@ -254,10 +318,12 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
         view?.webview.postMessage(m);
       },
       [MAIN_VIEW_COMMANDS.UPDATE_DEPENDENCY_REMINDER_SETTING]: async (m) => {
-        await setConfig('ui.showDependencyReminders', m.value);
+        const msg = asMsg<MessageWith<{ value: boolean }>>(m);
+        await setConfig('ui.showDependencyReminders', msg.value);
       },
       [MAIN_VIEW_COMMANDS.OPEN_INSTALL_GUIDE]: async (m) => {
-        const cmd = getToolDocsCommand(m.tool);
+        const msg = asMsg<MessageWith<{ tool: string }>>(m);
+        const cmd = getToolDocsCommand(msg.tool);
         if (cmd) {
           const [command, ...args] = cmd.split(',');
           await safeExecuteCommand(command, args);
@@ -330,15 +396,15 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
       [MAIN_VIEW_COMMANDS.REFRESH_ALL_FILES]: async () =>
         this.fileManager.handleRefreshAllFiles(),
       [MAIN_VIEW_COMMANDS.UPDATE_INPUT_FILES]: async (m) =>
-        this.fileManager.handleUpdateFiles(m),
+        this.fileManager.handleUpdateFiles(asMsg<UpdateFilesMessage>(m)),
       [MAIN_VIEW_COMMANDS.UPDATE_REFERENCE_FILES]: async (m) =>
-        this.fileManager.handleUpdateFiles(m),
+        this.fileManager.handleUpdateFiles(asMsg<UpdateFilesMessage>(m)),
       [MAIN_VIEW_COMMANDS.UPDATE_AUXILIARY_FILES]: async (m) =>
-        this.fileManager.handleUpdateFiles(m),
+        this.fileManager.handleUpdateFiles(asMsg<UpdateFilesMessage>(m)),
       [MAIN_VIEW_COMMANDS.UPDATE_MEDIA_FILES]: async (m) =>
-        this.fileManager.handleUpdateFiles(m),
+        this.fileManager.handleUpdateFiles(asMsg<UpdateFilesMessage>(m)),
       [MAIN_VIEW_COMMANDS.UPDATE_OUTPUT_FILES]: async (m) =>
-        this.fileManager.handleUpdateFiles(m),
+        this.fileManager.handleUpdateFiles(asMsg<UpdateFilesMessage>(m)),
 
       // Git/diff operations
       [MAIN_VIEW_COMMANDS.REQUEST_RECENT_COMMITS]: async (m) => {
@@ -387,12 +453,15 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
   }
 
   // Implement handler methods
-  private async handleInfoMessage(message: any): Promise<void> {
-    vscode.window.showInformationMessage(message.text);
-    this.logger.debug(this.channel, `Information message: ${message.text}`);
+  private async handleInfoMessage(message: unknown): Promise<void> {
+    const msg = message as { text?: string } | null | undefined;
+    if (msg?.text) {
+      vscode.window.showInformationMessage(msg.text);
+      this.logger.debug(this.channel, `Information message: ${msg.text}`);
+    }
   }
 
-  private async handleThemeRequest(message: any): Promise<void> {
+  private async handleThemeRequest(_message: unknown): Promise<void> {
     const webviewView = this.getActiveView();
     if (!webviewView) {
       return;
@@ -407,7 +476,7 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
     });
   }
 
-  private async handleDebugModeRequest(message: any): Promise<void> {
+  private async handleDebugModeRequest(_message: unknown): Promise<void> {
     const webviewView = this.getActiveView();
     if (!webviewView) {
       return;
@@ -419,24 +488,25 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
     });
   }
 
-  private async handleModelSelection(message: any): Promise<void> {
+  private async handleModelSelection(message: unknown): Promise<void> {
     const webviewView = this.getActiveView();
     if (!webviewView) {
       return;
     }
-    if (message.model) {
+    const msg = message as { model?: string } | null | undefined;
+    if (msg?.model) {
       webviewView.webview.postMessage({
         command: MAIN_VIEW_COMMANDS.MODEL_SELECTED,
-        model: message.model,
+        model: msg.model,
       });
     }
   }
 
-  private async handleShowAgentHistory(message: any): Promise<void> {
+  private async handleShowAgentHistory(_message: unknown): Promise<void> {
     await safeExecuteCommand('texra.showAgentHistory', [], this.viewName);
   }
 
-  protected async handleWebviewReady(_message: any): Promise<void> {
+  protected async handleWebviewReady(_message: unknown): Promise<void> {
     const webviewView = this.getActiveView();
     if (!webviewView) {
       return;

--- a/src/webview/MainViewMessageHandler.ts
+++ b/src/webview/MainViewMessageHandler.ts
@@ -33,28 +33,11 @@ import {
   InstructionManager,
 } from './managers';
 
-// Type imports for message type assertions
-import type {
-  FileSelectionMessage,
-  FileSelectedMessage,
-  RequestInputFileMessage,
-  RequestFileMessage,
-  RequestEditedFileMessage,
-  RequestBaseFileMessage,
-  RequestDefaultOutputFilesMessage,
-  SetMultipleFilesMessage,
-  SelectMultipleFilesMessage,
-  GetCurrentFileMessage,
-  UpdateFilesMessage,
-  PolishInstructionMessage,
-  ClipboardImageMessage,
-} from './types/messages';
-
 /**
- * Type guard helper for message properties.
- * Used for inline handlers that need to access optional message fields.
+ * Type helper for accessing message properties inline.
+ * Use sparingly - prefer manager-level validation for complex messages.
  */
-type MessageWith<T> = { command: string } & T;
+type AnyMessage = Record<string, unknown>;
 
 export class MainViewMessageHandler extends BaseViewMessageHandler {
   private readonly settingsManager: SettingsManager;
@@ -96,8 +79,8 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
     string,
     MessageHandler<vscode.WebviewView>
   > {
-    // Type assertion helper for cleaner handler definitions
-    const asMsg = <T>(m: unknown): T => m as T;
+    // Helper to access message properties for simple inline handlers
+    const msg = (m: unknown) => m as AnyMessage;
 
     return {
       // Common handlers
@@ -108,10 +91,11 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
       // Core functionality
       [MAIN_VIEW_COMMANDS.SHOW_INFORMATION_MESSAGE]:
         this.handleInfoMessage.bind(this),
-      [MAIN_VIEW_COMMANDS.SHOW_INSTRUCTION]: async (m) => {
-        const msg = asMsg<MessageWith<{ key: string; text: string }>>(m);
-        return showInstructionWithSuppress(msg.key, msg.text);
-      },
+      [MAIN_VIEW_COMMANDS.SHOW_INSTRUCTION]: async (m) =>
+        showInstructionWithSuppress(
+          msg(m).key as string,
+          msg(m).text as string,
+        ),
       [MAIN_VIEW_COMMANDS.GET_THEME]: this.handleThemeRequest.bind(this),
       [MAIN_VIEW_COMMANDS.GET_DEBUG_MODE]:
         this.handleDebugModeRequest.bind(this),
@@ -121,94 +105,65 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
       [MAIN_VIEW_COMMANDS.SHOW_AGENT_HISTORY]:
         this.handleShowAgentHistory.bind(this),
 
-      // Delegate to managers for specific functionality
-      // File selection commands
+      // File selection commands - managers validate internally
       [MAIN_VIEW_COMMANDS.SELECT_INPUT_FILE]: async (m) =>
-        this.fileManager.handleFileSelection(asMsg<FileSelectionMessage>(m)),
+        this.fileManager.handleFileSelection(m),
       [MAIN_VIEW_COMMANDS.SELECT_REFERENCE_FILE]: async (m) =>
-        this.fileManager.handleFileSelection(asMsg<FileSelectionMessage>(m)),
+        this.fileManager.handleFileSelection(m),
       [MAIN_VIEW_COMMANDS.SELECT_AUXILIARY_FILE]: async (m) =>
-        this.fileManager.handleFileSelection(asMsg<FileSelectionMessage>(m)),
+        this.fileManager.handleFileSelection(m),
       [MAIN_VIEW_COMMANDS.SELECT_MEDIA_FILE]: async (m) =>
-        this.fileManager.handleFileSelection(asMsg<FileSelectionMessage>(m)),
+        this.fileManager.handleFileSelection(m),
       [MAIN_VIEW_COMMANDS.SELECT_EDITED_FILE]: async () =>
         this.fileManager.handleEditedFileSelection(),
 
-      // File selected commands
+      // File selected commands - managers validate internally
       [MAIN_VIEW_COMMANDS.INPUT_FILE_SELECTED]: async (m) =>
-        this.fileManager.handleInputFileSelected(asMsg<FileSelectedMessage>(m)),
+        this.fileManager.handleInputFileSelected(m),
       [MAIN_VIEW_COMMANDS.REFERENCE_FILE_SELECTED]: async (m) =>
-        this.fileManager.handleGenericFileSelected(
-          asMsg<FileSelectedMessage>(m),
-        ),
+        this.fileManager.handleGenericFileSelected(m),
       [MAIN_VIEW_COMMANDS.AUXILIARY_FILE_SELECTED]: async (m) =>
-        this.fileManager.handleGenericFileSelected(
-          asMsg<FileSelectedMessage>(m),
-        ),
+        this.fileManager.handleGenericFileSelected(m),
       [MAIN_VIEW_COMMANDS.MEDIA_FILE_SELECTED]: async (m) =>
-        this.fileManager.handleGenericFileSelected(
-          asMsg<FileSelectedMessage>(m),
-        ),
+        this.fileManager.handleGenericFileSelected(m),
       [MAIN_VIEW_COMMANDS.EDITED_FILE_SELECTED]: async (m) =>
-        this.fileManager.handleGenericFileSelected(
-          asMsg<FileSelectedMessage>(m),
-        ),
+        this.fileManager.handleGenericFileSelected(m),
 
-      // Request file commands
+      // Request file commands - managers validate internally
       [MAIN_VIEW_COMMANDS.REQUEST_INPUT_FILE]: async (m) =>
-        this.fileManager.handleRequestInputFile(
-          asMsg<RequestInputFileMessage>(m),
-        ),
+        this.fileManager.handleRequestInputFile(m),
       [MAIN_VIEW_COMMANDS.REQUEST_REFERENCE_FILE]: async (m) =>
-        this.fileManager.handleRequestFile(asMsg<RequestFileMessage>(m)),
+        this.fileManager.handleRequestFile(m),
       [MAIN_VIEW_COMMANDS.REQUEST_AUXILIARY_FILE]: async (m) =>
-        this.fileManager.handleRequestFile(asMsg<RequestFileMessage>(m)),
+        this.fileManager.handleRequestFile(m),
       [MAIN_VIEW_COMMANDS.REQUEST_MEDIA_FILE]: async (m) =>
-        this.fileManager.handleRequestFile(asMsg<RequestFileMessage>(m)),
+        this.fileManager.handleRequestFile(m),
       [MAIN_VIEW_COMMANDS.REQUEST_EDITED_FILE]: async (m) =>
-        this.fileManager.handleRequestEditedFile(
-          asMsg<RequestEditedFileMessage>(m),
-        ),
+        this.fileManager.handleRequestEditedFile(m),
       [MAIN_VIEW_COMMANDS.REQUEST_BASE_FILE]: async (m) =>
-        this.fileManager.handleRequestBaseFile(
-          asMsg<RequestBaseFileMessage>(m),
-        ),
+        this.fileManager.handleRequestBaseFile(m),
       [MAIN_VIEW_COMMANDS.REQUEST_DEFAULT_OUTPUT_FILES]: async (m) =>
-        this.fileManager.handleRequestDefaultOutputFiles(
-          asMsg<RequestDefaultOutputFilesMessage>(m),
-        ),
+        this.fileManager.handleRequestDefaultOutputFiles(m),
 
-      // Multiple file operations
+      // Multiple file operations - managers validate internally
       [MAIN_VIEW_COMMANDS.SET_INPUT_FILES]: async (m) =>
-        this.fileManager.handleSetMultipleFiles(
-          asMsg<SetMultipleFilesMessage>(m),
-        ),
+        this.fileManager.handleSetMultipleFiles(m),
       [MAIN_VIEW_COMMANDS.SET_REFERENCE_FILES]: async (m) =>
-        this.fileManager.handleSetMultipleFiles(
-          asMsg<SetMultipleFilesMessage>(m),
-        ),
+        this.fileManager.handleSetMultipleFiles(m),
       [MAIN_VIEW_COMMANDS.SET_AUXILIARY_FILES]: async (m) =>
-        this.fileManager.handleSetMultipleFiles(
-          asMsg<SetMultipleFilesMessage>(m),
-        ),
+        this.fileManager.handleSetMultipleFiles(m),
       [MAIN_VIEW_COMMANDS.SET_MEDIA_FILES]: async (m) =>
-        this.fileManager.handleSetMultipleFiles(
-          asMsg<SetMultipleFilesMessage>(m),
-        ),
+        this.fileManager.handleSetMultipleFiles(m),
       [MAIN_VIEW_COMMANDS.SELECT_MULTIPLE_FILES]: async (m) =>
-        this.fileManager.handleSelectMultipleFiles(
-          asMsg<SelectMultipleFilesMessage>(m),
-        ),
+        this.fileManager.handleSelectMultipleFiles(m),
 
-      // Other file operations
+      // Other file operations - managers validate internally
       [MAIN_VIEW_COMMANDS.GET_CURRENT_FILE]: async (m) =>
-        this.fileManager.handleGetCurrentFile(asMsg<GetCurrentFileMessage>(m)),
-      [MAIN_VIEW_COMMANDS.ADD_OPENED_FILES]: async (m) => {
-        const msg = asMsg<MessageWith<{ fileType: string }>>(m);
-        return this.fileManager.handleAddOpenedFiles(msg.fileType);
-      },
+        this.fileManager.handleGetCurrentFile(m),
+      [MAIN_VIEW_COMMANDS.ADD_OPENED_FILES]: async (m) =>
+        this.fileManager.handleAddOpenedFiles(msg(m).fileType as string),
 
-      // Execution commands
+      // Execution commands - managers validate internally
       [MAIN_VIEW_COMMANDS.MERGE]: async (m) =>
         this.executionManager.handleMerge(m),
       [MAIN_VIEW_COMMANDS.COMPARE]: async (m) =>
@@ -218,9 +173,8 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
       [MAIN_VIEW_COMMANDS.SETTINGS_OPEN]: async () =>
         this.settingsManager.openSettings(),
       [MAIN_VIEW_COMMANDS.OPEN_AGENT_SETTINGS]: async (m) => {
-        const msg = asMsg<MessageWith<{ sessionType?: string }>>(m);
         const query =
-          msg.sessionType === 'toolUse'
+          msg(m).sessionType === 'toolUse'
             ? SETTINGS_QUERY.TOOL_USE_AGENTS
             : SETTINGS_QUERY.WORKFLOW_AGENTS;
         return this.settingsManager.openSettings(query);
@@ -228,8 +182,7 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
       [MAIN_VIEW_COMMANDS.OPEN_MODEL_SETTINGS]: async () =>
         this.settingsManager.openSettings(SETTINGS_QUERY.MODELS),
       [MAIN_VIEW_COMMANDS.OPEN_AGENT_DIRECTORY]: async (m) => {
-        const msg = asMsg<MessageWith<{ customDirSet?: boolean }>>(m);
-        if (msg.customDirSet) {
+        if (msg(m).customDirSet) {
           const dir = await agentDirectories.custom();
           if (dir) {
             await vscode.commands.executeCommand(
@@ -250,31 +203,25 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
       [MAIN_VIEW_COMMANDS.OPEN_INSTALLATION_DOCS]: async () =>
         safeExecuteCommand('texra.openDoc', ['installation'], this.viewName),
 
-      // Instruction commands
+      // Instruction commands - managers validate internally
       [MAIN_VIEW_COMMANDS.POLISH_INSTRUCTION_TEXT]: async (m) =>
-        this.instructionManager.handlePolishInstructionText(
-          asMsg<PolishInstructionMessage>(m),
-        ),
+        this.instructionManager.handlePolishInstructionText(m),
       [MAIN_VIEW_COMMANDS.TRANSCRIBE_INSTRUCTION]: async () =>
         this.instructionManager.handleTranscribeInstruction(),
       [MAIN_VIEW_COMMANDS.CLIPBOARD_IMAGE]: async (m) =>
-        this.instructionManager.handleClipboardImage(
-          asMsg<ClipboardImageMessage>(m),
-        ),
+        this.instructionManager.handleClipboardImage(m),
       [MAIN_VIEW_COMMANDS.OPEN_SET_API_KEY]: async () =>
         safeExecuteCommand('texra.setApiKey'),
       [MAIN_VIEW_COMMANDS.OPEN_SET_PROVIDER_API_KEY]: async (m) => {
-        // Reuse existing setApiKey command with provider parameter
-        const msg = asMsg<MessageWith<{ provider?: string }>>(m);
-        if (msg.provider) {
-          await safeExecuteCommand('texra.setApiKey', [msg.provider]);
+        const provider = msg(m).provider as string | undefined;
+        if (provider) {
+          await safeExecuteCommand('texra.setApiKey', [provider]);
         }
       },
       [MAIN_VIEW_COMMANDS.OPEN_PROVIDER_API_KEY_URL]: async (m) => {
-        // Open provider-specific API key page
-        const msg = asMsg<MessageWith<{ provider?: string }>>(m);
-        if (msg.provider) {
-          const url = PROVIDER_URLS[msg.provider as keyof typeof PROVIDER_URLS];
+        const provider = msg(m).provider as string | undefined;
+        if (provider) {
+          const url = PROVIDER_URLS[provider as keyof typeof PROVIDER_URLS];
           if (url) {
             await vscode.env.openExternal(vscode.Uri.parse(url));
           }
@@ -318,12 +265,12 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
         view?.webview.postMessage(m);
       },
       [MAIN_VIEW_COMMANDS.UPDATE_DEPENDENCY_REMINDER_SETTING]: async (m) => {
-        const msg = asMsg<MessageWith<{ value: boolean }>>(m);
-        await setConfig('ui.showDependencyReminders', msg.value);
+        const data = msg(m);
+        await setConfig('ui.showDependencyReminders', data.value as boolean);
       },
       [MAIN_VIEW_COMMANDS.OPEN_INSTALL_GUIDE]: async (m) => {
-        const msg = asMsg<MessageWith<{ tool: string }>>(m);
-        const cmd = getToolDocsCommand(msg.tool);
+        const data = msg(m);
+        const cmd = getToolDocsCommand(data.tool as string);
         if (cmd) {
           const [command, ...args] = cmd.split(',');
           await safeExecuteCommand(command, args);
@@ -392,19 +339,19 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
       [MAIN_VIEW_COMMANDS.STOP_RECORDING]: async (_m, w) =>
         this.recordingManager.stop(w),
 
-      // File refresh and update operations
+      // File refresh and update operations - manager validates internally
       [MAIN_VIEW_COMMANDS.REFRESH_ALL_FILES]: async () =>
         this.fileManager.handleRefreshAllFiles(),
       [MAIN_VIEW_COMMANDS.UPDATE_INPUT_FILES]: async (m) =>
-        this.fileManager.handleUpdateFiles(asMsg<UpdateFilesMessage>(m)),
+        this.fileManager.handleUpdateFiles(m),
       [MAIN_VIEW_COMMANDS.UPDATE_REFERENCE_FILES]: async (m) =>
-        this.fileManager.handleUpdateFiles(asMsg<UpdateFilesMessage>(m)),
+        this.fileManager.handleUpdateFiles(m),
       [MAIN_VIEW_COMMANDS.UPDATE_AUXILIARY_FILES]: async (m) =>
-        this.fileManager.handleUpdateFiles(asMsg<UpdateFilesMessage>(m)),
+        this.fileManager.handleUpdateFiles(m),
       [MAIN_VIEW_COMMANDS.UPDATE_MEDIA_FILES]: async (m) =>
-        this.fileManager.handleUpdateFiles(asMsg<UpdateFilesMessage>(m)),
+        this.fileManager.handleUpdateFiles(m),
       [MAIN_VIEW_COMMANDS.UPDATE_OUTPUT_FILES]: async (m) =>
-        this.fileManager.handleUpdateFiles(asMsg<UpdateFilesMessage>(m)),
+        this.fileManager.handleUpdateFiles(m),
 
       // Git/diff operations
       [MAIN_VIEW_COMMANDS.REQUEST_RECENT_COMMITS]: async (m) => {

--- a/src/webview/managers/ExecutionManager.ts
+++ b/src/webview/managers/ExecutionManager.ts
@@ -9,13 +9,27 @@ import {
   AgentType,
   type AgentSessionDescriptor,
 } from '@agent/core/AgentDataclass';
-import { ToolConfig } from '@agent/core/ToolConfig';
+import { ToolConfig, DEFAULT_TOOL_CONFIG } from '@agent/core/ToolConfig';
 import { capitalize } from '@frontend/ui/messageUtils';
 import * as logger from '@logger/logUtils';
 import {
   isPastedImage,
   getPastedImageFullPath,
 } from '@utils/files/pastedImageUtils';
+
+// Message schemas - single source of truth
+import {
+  ExecuteMessageSchema,
+  FileOperationMessageSchema,
+  HousekeepingMessageSchema,
+  SingleOperationMessageSchema,
+  MultipleOperationMessageSchema,
+  type ExecuteMessage,
+  type FileOperationMessage,
+  type HousekeepingMessage,
+  type SingleOperationMessage,
+  type MultipleOperationMessage,
+} from '../types/messages';
 
 const CHANNEL = 'ExecutionManager';
 logger.initialize(CHANNEL);
@@ -31,11 +45,24 @@ function getFilesIfNotEmpty<T>(files: T[] | undefined | null): T[] {
 export class ExecutionManager {
   constructor() {}
 
-  async handleExecute(message: any): Promise<void> {
-    const isToolUseAgent = !!message.isToolUseAgent;
+  /**
+   * Handle execute command from webview.
+   * Validates the message and routes to workflow or tool-use handler.
+   */
+  async handleExecute(message: unknown): Promise<void> {
+    const parsed = ExecuteMessageSchema.safeParse(message);
+    if (!parsed.success) {
+      logger.warn(CHANNEL, 'Invalid execute message', {
+        data: { errors: parsed.error.issues },
+      });
+      return;
+    }
+
+    const msg = parsed.data;
+    const isToolUseAgent = !!msg.isToolUseAgent;
     const config = isToolUseAgent
-      ? this.buildToolUseCommandPayload(message)
-      : await this.buildWorkflowCommandPayload(message);
+      ? this.buildToolUseCommandPayload(msg)
+      : await this.buildWorkflowCommandPayload(msg);
 
     if (!config) {
       return;
@@ -45,7 +72,7 @@ export class ExecutionManager {
   }
 
   private async buildWorkflowCommandPayload(
-    message: any,
+    message: ExecuteMessage,
   ): Promise<AgentConfig | null> {
     if (!message.inputFile) {
       const openDocs = 'File Management Guide';
@@ -64,7 +91,7 @@ export class ExecutionManager {
     });
   }
 
-  private buildToolUseCommandPayload(message: any): AgentConfig {
+  private buildToolUseCommandPayload(message: ExecuteMessage): AgentConfig {
     return this.composeToolUseAgentConfig(message, {
       agentType: AgentType.ToolUse,
       agentCategory: AgentCategory.ToolUse,
@@ -72,7 +99,7 @@ export class ExecutionManager {
   }
 
   private composeWorkflowAgentConfig(
-    message: any,
+    message: ExecuteMessage,
     session: AgentSessionDescriptor,
   ): AgentConfig {
     const baseConfig = this.composeBaseAgentConfig(message, session);
@@ -89,7 +116,7 @@ export class ExecutionManager {
   }
 
   private composeToolUseAgentConfig(
-    message: any,
+    message: ExecuteMessage,
     session: AgentSessionDescriptor,
   ): AgentConfig {
     const baseConfig = this.composeBaseAgentConfig(message, session);
@@ -105,15 +132,27 @@ export class ExecutionManager {
   }
 
   private composeBaseAgentConfig(
-    message: any,
+    message: ExecuteMessage,
     session: AgentSessionDescriptor,
   ): Omit<AgentConfig, 'useMultipleOutputs' | 'outputFiles'> {
+    // Apply tool configuration - start with defaults and override with provided values
     const toolConfig: ToolConfig = {
-      autoExtractFigure: message.autoExtractFigure,
-      autoExtractTikzFigure: message.autoExtractTikzFigure,
-      attachTeXCount: message.attachTeXCount,
-      attachDiagnostics: message.attachDiagnostics,
-      autoCompileInputPdf: message.autoCompileInputPdf,
+      ...DEFAULT_TOOL_CONFIG,
+      ...(message.autoExtractFigure !== undefined && {
+        autoExtractFigure: message.autoExtractFigure,
+      }),
+      ...(message.autoExtractTikzFigure !== undefined && {
+        autoExtractTikzFigure: message.autoExtractTikzFigure,
+      }),
+      ...(message.attachTeXCount !== undefined && {
+        attachTeXCount: message.attachTeXCount,
+      }),
+      ...(message.attachDiagnostics !== undefined && {
+        attachDiagnostics: message.attachDiagnostics,
+      }),
+      ...(message.autoCompileInputPdf !== undefined && {
+        autoCompileInputPdf: message.autoCompileInputPdf,
+      }),
     };
 
     const mapMediaPath = (f: string | null): string | null => {
@@ -125,9 +164,9 @@ export class ExecutionManager {
     };
 
     return {
-      agent: message.agent,
-      model: message.model,
-      instruction: message.instruction,
+      agent: message.agent ?? 'correct',
+      model: message.model ?? 'gemini3p',
+      instruction: message.instruction ?? '',
       inputFile: message.inputFile ?? '',
       inputFiles: getFilesIfNotEmpty<string>(message.inputFiles),
       referenceFile: message.referenceFile ?? null,
@@ -147,7 +186,7 @@ export class ExecutionManager {
     };
   }
 
-  private handleFileOperation(message: any): void {
+  private handleFileOperationInternal(message: FileOperationMessage): void {
     vscode.commands.executeCommand(
       `texra.${message.command}`,
       message.inputFile,
@@ -156,50 +195,88 @@ export class ExecutionManager {
     );
   }
 
-  handleMerge(message: any): void {
-    this.handleFileOperation(message);
+  /**
+   * Handle merge command from webview.
+   */
+  handleMerge(message: unknown): void {
+    const parsed = FileOperationMessageSchema.safeParse(message);
+    if (parsed.success) {
+      this.handleFileOperationInternal(parsed.data);
+    }
   }
 
-  handleCompare(message: any): void {
-    this.handleFileOperation(message);
+  /**
+   * Handle compare command from webview.
+   */
+  handleCompare(message: unknown): void {
+    const parsed = FileOperationMessageSchema.safeParse(message);
+    if (parsed.success) {
+      this.handleFileOperationInternal(parsed.data);
+    }
   }
 
-  handleAcceptEdited(message: any): void {
-    this.handleFileOperation(message);
+  /**
+   * Handle accept edited command from webview.
+   */
+  handleAcceptEdited(message: unknown): void {
+    const parsed = FileOperationMessageSchema.safeParse(message);
+    if (parsed.success) {
+      this.handleFileOperationInternal(parsed.data);
+    }
   }
 
-  handleHousekeeping(message: any): void {
-    vscode.commands.executeCommand(`texra.${message.command}`);
+  /**
+   * Handle housekeeping command from webview.
+   */
+  handleHousekeeping(message: unknown): void {
+    const parsed = HousekeepingMessageSchema.safeParse(message);
+    if (parsed.success) {
+      vscode.commands.executeCommand(`texra.${parsed.data.command}`);
+    }
   }
 
-  handleSingleOperation(message: any): void {
-    vscode.commands.executeCommand(
-      `texra.${message.command}`,
-      message.inputFile,
-      message.agent,
-      message.model,
-    );
+  /**
+   * Handle single file operation command from webview.
+   */
+  handleSingleOperation(message: unknown): void {
+    const parsed = SingleOperationMessageSchema.safeParse(message);
+    if (parsed.success) {
+      const { command, inputFile, agent, model } = parsed.data;
+      vscode.commands.executeCommand(
+        `texra.${command}`,
+        inputFile,
+        agent,
+        model,
+      );
+    }
   }
 
-  async handleMultipleOperation(message: any): Promise<void> {
-    const operation = message.command.startsWith('pack')
-      ? 'Packing'
-      : 'Cleaning';
-    const outputFilesStr = Array.isArray(message.outputFiles)
-      ? message.outputFiles.join(', ')
+  /**
+   * Handle multiple file operation command from webview.
+   */
+  async handleMultipleOperation(message: unknown): Promise<void> {
+    const parsed = MultipleOperationMessageSchema.safeParse(message);
+    if (!parsed.success) {
+      return;
+    }
+
+    const { command, inputFile, agent, model, outputFiles } = parsed.data;
+    const operation = command.startsWith('pack') ? 'Packing' : 'Cleaning';
+    const outputFilesStr = Array.isArray(outputFiles)
+      ? outputFiles.join(', ')
       : '';
 
     logger.info(
       CHANNEL,
-      `${capitalize(operation)} multiple files: ${message.inputFile}, ${outputFilesStr}`,
+      `${capitalize(operation)} multiple files: ${inputFile}, ${outputFilesStr}`,
     );
 
     vscode.commands.executeCommand(
-      `texra.${message.command}`,
-      message.inputFile,
-      message.agent,
-      message.model,
-      message.outputFiles,
+      `texra.${command}`,
+      inputFile,
+      agent,
+      model,
+      outputFiles,
     );
   }
 }

--- a/src/webview/managers/FileManager.ts
+++ b/src/webview/managers/FileManager.ts
@@ -14,20 +14,19 @@ import { uncapitalize } from '@frontend/ui/messageUtils';
 import * as logger from '@logger/logUtils';
 import { WorkspaceFS } from '@utils/files';
 
-// Local imports - types
-import type {
-  FileSelectionMessage,
-  InputFileSelectedMessage,
-  GenericFileSelectedMessage,
-  RequestInputFileMessage,
-  RequestFileMessage,
-  RequestEditedFileMessage,
-  RequestBaseFileMessage,
-  RequestDefaultOutputFilesMessage,
-  SetMultipleFilesMessage,
-  SelectMultipleFilesMessage,
-  GetCurrentFileMessage,
-  UpdateFilesMessage,
+// Local imports - schemas (single source of truth)
+import {
+  FileSelectionMessageSchema,
+  FileSelectedMessageSchema,
+  RequestInputFileMessageSchema,
+  RequestFileMessageSchema,
+  RequestEditedFileMessageSchema,
+  RequestBaseFileMessageSchema,
+  RequestDefaultOutputFilesMessageSchema,
+  SetMultipleFilesMessageSchema,
+  SelectMultipleFilesMessageSchema,
+  GetCurrentFileMessageSchema,
+  UpdateFilesMessageSchema,
 } from '../types/messages';
 
 const CHANNEL = 'FileManager';
@@ -58,16 +57,25 @@ export class FileManager {
     return this.webview;
   }
 
-  async handleFileSelection(message: FileSelectionMessage): Promise<void> {
+  async handleFileSelection(message: unknown): Promise<void> {
+    const parsed = FileSelectionMessageSchema.safeParse(message);
+    if (!parsed.success) {
+      logger.debug(CHANNEL, 'Invalid file selection message', {
+        data: parsed.error,
+      });
+      return;
+    }
+
     const webviewView = this.getWebview();
     if (!webviewView) {
       return;
     }
-    const singleFileType = message.command.replace('select', '');
+
+    const singleFileType = parsed.data.command.replace('select', '');
     logger.debug(CHANNEL, `Selecting ${singleFileType}`);
 
     const file = await vscode.commands.executeCommand<string>(
-      `texra.${message.command}`,
+      `texra.${parsed.data.command}`,
     );
     if (file) {
       logger.debug(CHANNEL, `Selected ${singleFileType}: ${file}`);
@@ -94,45 +102,78 @@ export class FileManager {
     }
   }
 
-  async handleInputFileSelected(
-    message: InputFileSelectedMessage,
-  ): Promise<void> {
+  async handleInputFileSelected(message: unknown): Promise<void> {
+    const parsed = FileSelectedMessageSchema.safeParse(message);
+    if (!parsed.success) {
+      logger.debug(CHANNEL, 'Invalid input file selected message', {
+        data: parsed.error,
+      });
+      return;
+    }
+
     const webviewView = this.getWebview();
     if (!webviewView) {
       return;
     }
+
     const baseFileNameForInput = path.basename(
-      message.filePath,
-      path.extname(message.filePath),
+      parsed.data.filePath,
+      path.extname(parsed.data.filePath),
     );
     const filteredEditedFiles =
       await fileLister.listEditedFiles(baseFileNameForInput);
     this.postFileUpdate('Edited', filteredEditedFiles);
   }
 
-  handleGenericFileSelected(message: GenericFileSelectedMessage): void {
-    logger.debug(CHANNEL, `${message.command}: ${message.filePath}`);
+  handleGenericFileSelected(message: unknown): void {
+    const parsed = FileSelectedMessageSchema.safeParse(message);
+    if (!parsed.success) {
+      logger.debug(CHANNEL, 'Invalid generic file selected message', {
+        data: parsed.error,
+      });
+      return;
+    }
+
+    logger.debug(
+      CHANNEL,
+      `${parsed.data.command}: ${parsed.data.filePath}`,
+    );
   }
 
-  async handleRequestInputFile(
-    message: RequestInputFileMessage,
-  ): Promise<void> {
+  async handleRequestInputFile(message: unknown): Promise<void> {
+    const parsed = RequestInputFileMessageSchema.safeParse(message);
+    if (!parsed.success) {
+      logger.debug(CHANNEL, 'Invalid request input file message', {
+        data: parsed.error,
+      });
+      return;
+    }
+
     if (!this.getWebview()) {
       return;
     }
+
     const refreshedInputFiles =
       (await vscode.commands.executeCommand<string[]>(
         'texra.refreshInputFiles',
       )) ?? [];
     await this.postFileUpdate('Input', refreshedInputFiles, {
-      notifyWhenEmpty: !!message.notifyWhenEmpty,
+      notifyWhenEmpty: !!parsed.data.notifyWhenEmpty,
     });
 
     this.updateGettingStartedBanner(refreshedInputFiles.length === 0);
   }
 
-  async handleRequestFile(message: RequestFileMessage): Promise<void> {
-    const fileType = message.command.replace('request', '').replace('File', '');
+  async handleRequestFile(message: unknown): Promise<void> {
+    const parsed = RequestFileMessageSchema.safeParse(message);
+    if (!parsed.success) {
+      logger.debug(CHANNEL, 'Invalid request file message', {
+        data: parsed.error,
+      });
+      return;
+    }
+
+    const fileType = parsed.data.command.replace('request', '').replace('File', '');
     const files = await (async () => {
       switch (fileType) {
         case 'Reference':
@@ -146,31 +187,45 @@ export class FileManager {
       }
     })();
     await this.postFileUpdate(fileType, files, {
-      notifyWhenEmpty: !!message.notifyWhenEmpty,
+      notifyWhenEmpty: !!parsed.data.notifyWhenEmpty,
     });
   }
 
-  async handleRequestEditedFile(
-    message: RequestEditedFileMessage,
-  ): Promise<void> {
+  async handleRequestEditedFile(message: unknown): Promise<void> {
+    const parsed = RequestEditedFileMessageSchema.safeParse(message);
+    if (!parsed.success) {
+      logger.debug(CHANNEL, 'Invalid request edited file message', {
+        data: parsed.error,
+      });
+      return;
+    }
+
     let allEditedFiles: string[] = [];
-    if (message.baseFile) {
+    if (parsed.data.baseFile) {
       const baseFileNameForEdited = path.basename(
-        message.baseFile,
-        path.extname(message.baseFile),
+        parsed.data.baseFile,
+        path.extname(parsed.data.baseFile),
       );
       allEditedFiles = await fileLister.listEditedFiles(baseFileNameForEdited);
     }
     await this.postFileUpdate('Edited', allEditedFiles, {
-      notifyWhenEmpty: !!message.notifyWhenEmpty,
+      notifyWhenEmpty: !!parsed.data.notifyWhenEmpty,
     });
   }
 
-  async handleRequestBaseFile(message: RequestBaseFileMessage): Promise<void> {
+  async handleRequestBaseFile(message: unknown): Promise<void> {
+    const parsed = RequestBaseFileMessageSchema.safeParse(message);
+    if (!parsed.success) {
+      logger.debug(CHANNEL, 'Invalid request base file message', {
+        data: parsed.error,
+      });
+      return;
+    }
+
     const files = await fileLister.list('input');
     await this.postFileUpdate('Base', files, {
-      notifyWhenEmpty: !!message.notifyWhenEmpty,
-      additionalPayload: message.preserveBaseFile
+      notifyWhenEmpty: !!parsed.data.notifyWhenEmpty,
+      additionalPayload: parsed.data.preserveBaseFile
         ? { preserveBaseFile: true }
         : undefined,
     });
@@ -178,14 +233,21 @@ export class FileManager {
     this.updateGettingStartedBanner(files.length === 0);
   }
 
-  async handleRequestDefaultOutputFiles(
-    message: RequestDefaultOutputFilesMessage,
-  ): Promise<void> {
+  async handleRequestDefaultOutputFiles(message: unknown): Promise<void> {
+    const parsed = RequestDefaultOutputFilesMessageSchema.safeParse(message);
+    if (!parsed.success) {
+      logger.debug(CHANNEL, 'Invalid request default output files message', {
+        data: parsed.error,
+      });
+      return;
+    }
+
     const webviewView = this.getWebview();
     if (!webviewView) {
       return;
     }
-    const agentIdentifier = message.agent;
+
+    const agentIdentifier = parsed.data.agent;
     if (!agentIdentifier) {
       webviewView.webview.postMessage({
         command: MAIN_VIEW_COMMANDS.SET_DEFAULT_OUTPUT_FILES,
@@ -213,34 +275,50 @@ export class FileManager {
     }
   }
 
-  handleSetMultipleFiles(message: SetMultipleFilesMessage): void {
+  handleSetMultipleFiles(message: unknown): void {
+    const parsed = SetMultipleFilesMessageSchema.safeParse(message);
+    if (!parsed.success) {
+      logger.debug(CHANNEL, 'Invalid set multiple files message', {
+        data: parsed.error,
+      });
+      return;
+    }
+
     const webviewView = this.getWebview();
     if (!webviewView) {
       return;
     }
-    if (message.files && message.files.length > 0) {
+
+    if (parsed.data.files && parsed.data.files.length > 0) {
       webviewView.webview.postMessage({
-        command: message.command,
-        files: message.files,
+        command: parsed.data.command,
+        files: parsed.data.files,
       });
     }
   }
 
-  async handleSelectMultipleFiles(
-    message: SelectMultipleFilesMessage,
-  ): Promise<void> {
+  async handleSelectMultipleFiles(message: unknown): Promise<void> {
+    const parsed = SelectMultipleFilesMessageSchema.safeParse(message);
+    if (!parsed.success) {
+      logger.debug(CHANNEL, 'Invalid select multiple files message', {
+        data: parsed.error,
+      });
+      return;
+    }
+
     const webviewView = this.getWebview();
     if (!webviewView) {
       return;
     }
-    const fileType = message.fileType;
+
+    const fileType = parsed.data.fileType;
     let selectedFiles: string[] | null = null;
 
     try {
       if (fileType === 'OutputFiles') {
-        selectedFiles = await this.selectOutputFiles(message.currentFile);
+        selectedFiles = await this.selectOutputFiles(parsed.data.currentFile);
       } else {
-        const currentFileForMultiple = message.currentFile;
+        const currentFileForMultiple = parsed.data.currentFile;
         const baseType = fileType.replace('Files', '');
         selectedFiles = await vscode.commands.executeCommand<string[]>(
           `texra.select${baseType}Files`,
@@ -289,19 +367,28 @@ export class FileManager {
     this.updateGettingStartedBanner(refreshedFiles.input.length === 0);
   }
 
-  async handleGetCurrentFile(message: GetCurrentFileMessage): Promise<void> {
+  async handleGetCurrentFile(message: unknown): Promise<void> {
+    const parsed = GetCurrentFileMessageSchema.safeParse(message);
+    if (!parsed.success) {
+      logger.debug(CHANNEL, 'Invalid get current file message', {
+        data: parsed.error,
+      });
+      return;
+    }
+
     const webviewView = this.getWebview();
     if (!webviewView) {
       return;
     }
-    const fileType = message.fileType ?? 'input';
+
+    const fileType = parsed.data.fileType ?? 'input';
     const currentOpenFile = await vscode.commands.executeCommand<string>(
       'texra.getCurrentFile',
     );
     if (currentOpenFile) {
       let commitCheckFile: string | null = null;
       if (fileType === 'edited') {
-        const baseFile = message.baseFile;
+        const baseFile = parsed.data.baseFile;
         if (baseFile) {
           const baseFileName = path.basename(baseFile, path.extname(baseFile));
           const currentFileName = path.basename(
@@ -420,14 +507,23 @@ export class FileManager {
     });
   }
 
-  async handleUpdateFiles(message: UpdateFilesMessage): Promise<void> {
+  async handleUpdateFiles(message: unknown): Promise<void> {
+    const parsed = UpdateFilesMessageSchema.safeParse(message);
+    if (!parsed.success) {
+      logger.debug(CHANNEL, 'Invalid update files message', {
+        data: parsed.error,
+      });
+      return;
+    }
+
     const webviewView = this.getWebview();
     if (!webviewView) {
       return;
     }
-    const command = message.command;
+
+    const command = parsed.data.command;
     const fileType = command.replace('update', '');
-    const files = message.files ?? [];
+    const files = parsed.data.files ?? [];
 
     logger.debug(CHANNEL, `Updating ${fileType} with ${files.length} files`);
     webviewView.webview.postMessage({ command: `set${fileType}`, files });

--- a/src/webview/managers/InstructionManager.ts
+++ b/src/webview/managers/InstructionManager.ts
@@ -12,17 +12,16 @@ import { MAIN_VIEW_COMMANDS } from '@common/webview';
 import * as logger from '@logger/logUtils';
 import { StorageFS } from '@utils/files';
 import { THREE_DAYS_MS } from '@utils/config';
-import { sleep } from '@utils/helpers';
 import { PASTED_DIR } from '@utils/files/pastedImageUtils';
 import {
   polishTextWithAI,
   FileContext,
 } from '@utils/text/textEnhancementUtils';
 
-// Local imports - types
-import type {
-  PolishInstructionMessage,
-  ClipboardImageMessage,
+// Local imports - schemas (single source of truth)
+import {
+  PolishInstructionMessageSchema,
+  ClipboardImageMessageSchema,
 } from '../types/messages';
 
 const CHANNEL = 'InstructionManager';
@@ -98,64 +97,72 @@ export class InstructionManager {
     }
   }
 
-  async handlePolishInstructionText(
-    message: PolishInstructionMessage,
-  ): Promise<void> {
+  async handlePolishInstructionText(message: unknown): Promise<void> {
+    const parsed = PolishInstructionMessageSchema.safeParse(message);
+    if (!parsed.success) {
+      logger.debug(CHANNEL, 'Invalid polish instruction message', {
+        data: parsed.error,
+      });
+      return;
+    }
+
     const webviewView = this.getWebview();
     if (!webviewView) {
       return;
     }
+
+    const msg = parsed.data;
     try {
-      const fileContext: FileContext = { agent: message.agent };
+      const fileContext: FileContext = { agent: msg.agent };
 
       // Add single files
-      this.addSingleFileIfValid(fileContext, 'inputFile', message.inputFile);
+      this.addSingleFileIfValid(fileContext, 'inputFile', msg.inputFile);
       this.addSingleFileIfValid(
         fileContext,
         'referenceFile',
-        message.referenceFile,
+        msg.referenceFile,
       );
       this.addSingleFileIfValid(
         fileContext,
         'auxiliaryFile',
-        message.auxiliaryFile,
+        msg.auxiliaryFile,
       );
-      this.addSingleFileIfValid(fileContext, 'mediaFile', message.mediaFile);
+      this.addSingleFileIfValid(fileContext, 'mediaFile', msg.mediaFile);
 
       // Add multiple files
       this.addMultipleFilesIfValid(
         fileContext,
         'inputFiles',
-        !!message.inputFilesActive,
-        message.inputFiles,
+        !!msg.inputFilesActive,
+        msg.inputFiles,
       );
       this.addMultipleFilesIfValid(
         fileContext,
         'referenceFiles',
-        !!message.referenceFilesActive,
-        message.referenceFiles,
+        !!msg.referenceFilesActive,
+        msg.referenceFiles,
       );
       this.addMultipleFilesIfValid(
         fileContext,
         'auxiliaryFiles',
-        !!message.auxiliaryFilesActive,
-        message.auxiliaryFiles,
+        !!msg.auxiliaryFilesActive,
+        msg.auxiliaryFiles,
       );
       this.addMultipleFilesIfValid(
         fileContext,
         'mediaFiles',
-        !!message.mediaFilesActive,
-        message.mediaFiles,
+        !!msg.mediaFilesActive,
+        msg.mediaFiles,
       );
       this.addMultipleFilesIfValid(
         fileContext,
         'outputFiles',
-        !!message.outputFilesActive,
-        message.outputFiles,
+        !!msg.outputFilesActive,
+        msg.outputFiles,
       );
 
       try {
-        const result = await polishTextWithAI(message.text, fileContext);
+        const result = await polishTextWithAI(msg.text, fileContext);
         if (result.success) {
           webviewView.webview.postMessage({
             command: MAIN_VIEW_COMMANDS.INSTRUCTION_TEXT_POLISHED,
@@ -195,13 +202,22 @@ export class InstructionManager {
     );
   }
 
-  async handleClipboardImage(message: ClipboardImageMessage): Promise<void> {
+  async handleClipboardImage(message: unknown): Promise<void> {
+    const parsed = ClipboardImageMessageSchema.safeParse(message);
+    if (!parsed.success) {
+      logger.debug(CHANNEL, 'Invalid clipboard image message', {
+        data: parsed.error,
+      });
+      return;
+    }
+
     const webviewView = this.getWebview();
     if (!webviewView) {
       return;
     }
+
     try {
-      const { base64, mediaType, fileName } = message;
+      const { base64, mediaType, fileName } = parsed.data;
       if (!base64 || !mediaType || !fileName) {
         return;
       }

--- a/src/webview/types/messages.ts
+++ b/src/webview/types/messages.ts
@@ -198,3 +198,95 @@ export const UpdateFilesMessageSchema = BaseMessageSchema.extend(
 );
 
 export type UpdateFilesMessage = z.infer<typeof UpdateFilesMessageSchema>;
+
+// --- Execution Manager Message Schemas ---
+
+/** Tool configuration options */
+const ToolConfigSchema = z.object({
+  autoExtractFigure: z.boolean().optional(),
+  autoExtractTikzFigure: z.boolean().optional(),
+  attachTeXCount: z.boolean().optional(),
+  attachDiagnostics: z.boolean().optional(),
+  autoCompileInputPdf: z.boolean().optional(),
+});
+
+/**
+ * Execute agent message from webview.
+ * Contains all fields needed to run a workflow or tool-use agent.
+ */
+export const ExecuteMessageSchema = z.object({
+  // Agent identification
+  agent: z.string().optional(),
+  model: z.string().optional(),
+  instruction: z.string().optional(),
+  isToolUseAgent: z.boolean().optional(),
+
+  // File inputs
+  inputFile: z.string().optional(),
+  inputFiles: z.array(z.string()).optional(),
+  referenceFile: z.string().nullable().optional(),
+  referenceFiles: z.array(z.string()).optional(),
+  auxiliaryFile: z.string().nullable().optional(),
+  auxiliaryFiles: z.array(z.string()).optional(),
+  mediaFile: z.string().nullable().optional(),
+  mediaFiles: z.array(z.string()).optional(),
+
+  // Output configuration
+  outputFiles: z.array(z.string()).optional(),
+  outputFilesActive: z.boolean().optional(),
+
+  // Tool config
+  ...ToolConfigSchema.shape,
+});
+
+export type ExecuteMessage = z.infer<typeof ExecuteMessageSchema>;
+
+/**
+ * File operation message for merge/compare/accept operations
+ */
+export const FileOperationMessageSchema = z.object({
+  command: z.string(),
+  inputFile: z.string().optional(),
+  baseFile: z.string().optional(),
+  editedFile: z.string().optional(),
+});
+
+export type FileOperationMessage = z.infer<typeof FileOperationMessageSchema>;
+
+/**
+ * Housekeeping command message (clean, indent, etc.)
+ */
+export const HousekeepingMessageSchema = z.object({
+  command: z.string(),
+});
+
+export type HousekeepingMessage = z.infer<typeof HousekeepingMessageSchema>;
+
+/**
+ * Single file operation message (pack/clean single file)
+ */
+export const SingleOperationMessageSchema = z.object({
+  command: z.string(),
+  inputFile: z.string().optional(),
+  agent: z.string().optional(),
+  model: z.string().optional(),
+});
+
+export type SingleOperationMessage = z.infer<
+  typeof SingleOperationMessageSchema
+>;
+
+/**
+ * Multiple file operation message (pack/clean multiple files)
+ */
+export const MultipleOperationMessageSchema = z.object({
+  command: z.string(),
+  inputFile: z.string().optional(),
+  agent: z.string().optional(),
+  model: z.string().optional(),
+  outputFiles: z.array(z.string()).optional(),
+});
+
+export type MultipleOperationMessage = z.infer<
+  typeof MultipleOperationMessageSchema
+>;


### PR DESCRIPTION
- Update MessageHandler type to use `unknown` instead of `any` to encourage proper validation
- Create comprehensive Zod schemas for progress view messages (messages.ts)
- Add execution manager message schemas to webview/types/messages.ts
- Refactor ProgressViewMessageHandler to use withValidatedMessage() pattern
- Update ExecutionManager with typed message handling and schema validation
- Add type assertions in MainViewMessageHandler for cleaner handler definitions
- Update ESLint config with roadmap comment for future no-explicit-any enforcement

This modernization:
- Improves type safety across webview message handling
- Leverages existing Zod v4 features like .prefault() and schema composition
- Provides a pattern for gradually eliminating `any` types
- Maintains backward compatibility while improving validation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces any-based handlers with unknown + Zod-validated message handling, adds centralized schemas, and refactors webview managers and progress view to use typed validation patterns.
> 
> - **Webview Message Handling (core)**:
>   - Update `BaseViewMessageHandler` to accept `unknown`, add `withValidatedMessage()` helper, and tighten theme/debug handling.
>   - Add inline type assertions in `MainViewMessageHandler`; route all commands to managers while keeping messages as `unknown`.
> - **Schema Centralization**:
>   - Introduce comprehensive Zod schemas in `src/progressView/messages.ts` and extend `src/webview/types/messages.ts` with execution and file op message schemas.
> - **Progress View**:
>   - Refactor `ProgressViewMessageHandler` to validate all incoming messages via schemas (stream actions, sorting/filtering, follow-up polish, tool-approval, storage/label ops) and to use `getActiveView()` pattern.
> - **Execution Manager**:
>   - Validate execute/ops messages with schemas; split workflow vs tool-use payload building; apply `DEFAULT_TOOL_CONFIG` with selective overrides.
> - **File & Instruction Managers**:
>   - Validate all request/selection/update and clipboard/polish messages via schemas; adjust postings and helpers accordingly.
> - **ESLint**:
>   - Add roadmap comments for `@typescript-eslint/no-explicit-any` enforcement.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ee74cbd5f6218f56e8ceeab9e85d7edb06cac46e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->