### PR TITLE
refactor: remove dead code (unused exports)

### DIFF
--- a/src/agent/modelHandlers/toolConversion.ts
+++ b/src/agent/modelHandlers/toolConversion.ts
@@ -37,13 +37,6 @@ import type {
  */
 export const NATIVE_TOOL_NAMES = new Set(['web_search']);
 
-/**
- * Check if a tool is a native/server-side tool.
- */
-export function isNativeTool(name: string): boolean {
-  return NATIVE_TOOL_NAMES.has(name);
-}
-
 // Map local tool names to Anthropic remote tool types
 const ANTHROPIC_TOOL_TYPE_MAP: Record<string, string> = {
   bash: 'bash_20250124',

--- a/src/agent/modelHandlers/types/ServerToolTypes.ts
+++ b/src/agent/modelHandlers/types/ServerToolTypes.ts
@@ -360,27 +360,3 @@ export function extractDomain(url: string): string {
   }
 }
 
-/**
- * Format web search results for display/logging.
- */
-export function formatWebSearchResults(result: WebSearchResult): string {
-  const lines: string[] = [];
-
-  if (result.query) {
-    lines.push(`Search: "${result.query}"`);
-  }
-
-  lines.push(`Provider: ${result.provider}`);
-  lines.push(`Results: ${result.results.length}`);
-  lines.push('');
-
-  for (const entry of result.results) {
-    lines.push(`• ${entry.title || entry.domain || 'Untitled'}`);
-    lines.push(`  ${entry.url}`);
-    if (entry.snippet) {
-      lines.push(`  ${entry.snippet.slice(0, 100)}...`);
-    }
-  }
-
-  return lines.join('\n');
-}

--- a/src/agent/modelHandlers/types/StopReasonTypes.ts
+++ b/src/agent/modelHandlers/types/StopReasonTypes.ts
@@ -34,25 +34,6 @@ export const OPENAI_COMPLETION_FINISH_REASONS = Object.values(
 export type OpenAICompletionFinishReason =
   (typeof OPENAI_COMPLETION_FINISH_REASONS)[number];
 
-/**
- * Status values used by the OpenAI Responses API.
- * Re-exported from the SDK for convenience; the SDK's ResponseStatus type
- * is the single source of truth.
- */
-export { type ResponseStatus as OpenAIResponseStatus } from 'openai/resources/responses/responses';
-
-/** Constants matching SDK's ResponseStatus for runtime checks. */
-export const OPENAI_RESPONSE_STATUS = {
-  COMPLETED: 'completed',
-  FAILED: 'failed',
-  IN_PROGRESS: 'in_progress',
-  CANCELLED: 'cancelled',
-  QUEUED: 'queued',
-  INCOMPLETE: 'incomplete',
-} as const satisfies Record<
-  string,
-  import('openai/resources/responses/responses').ResponseStatus
->;
 
 /** Stop reasons defined in the Model Context Protocol SDK. */
 export const MCP_STOP = {
@@ -75,7 +56,6 @@ export const ANTHROPIC_STOP = {
   PAUSE_TURN: 'pause_turn',
   REFUSAL: 'refusal',
 } as const satisfies Record<string, AnthropicSDKStopReason>;
-export const ANTHROPIC_STOP_REASONS = Object.values(ANTHROPIC_STOP);
 /** Anthropic stop reason type - derived from SDK's StopReason */
 export type AnthropicStopReason = AnthropicSDKStopReason;
 

--- a/src/agent/modelHandlers/utils/toolAttachmentUtils.ts
+++ b/src/agent/modelHandlers/utils/toolAttachmentUtils.ts
@@ -45,8 +45,6 @@ export const EditedFileRecordSchema = z.object({
   sourceDisplay: z.string(),
 });
 
-export type EditedFileRecord = z.infer<typeof EditedFileRecordSchema>;
-
 /**
  * Schema for strongly-typed tool result payloads sent to model handlers.
  * This is what gets passed to handlers - no binary data, properly typed fields.

--- a/src/logger/messageTypes.ts
+++ b/src/logger/messageTypes.ts
@@ -20,8 +20,6 @@ export const LogLevelSchema = z.enum([
   LOG_LEVELS.DEBUG,
 ]);
 
-export type LogLevel = z.infer<typeof LogLevelSchema>;
-
 /**
  * End group status - terminal states used when finalizing log groups.
  * Single source of truth for end status in AgentLogger, LogEventSink, and transports.

--- a/src/progressView/types.ts
+++ b/src/progressView/types.ts
@@ -1,8 +1,7 @@
 // Local imports - agent types
 import type { AgentCategory, AgentType } from '@agent/core/AgentDataclass';
-import type { ExecutionId, StreamTabId } from '@agent/types/IdentifierTypes';
+import type { ExecutionId } from '@agent/types/IdentifierTypes';
 import type { AgentTypeFilter } from '@agent/types/AgentStreamTypes';
-import type { StreamStatus } from '@common/constants/streamStatus';
 
 export interface StreamUITraits {
   /** Canonical session grouping for the stream. */
@@ -40,16 +39,4 @@ export interface InstructionMetadata {
 export interface InstructionUpdate {
   text: string;
   metadata?: InstructionMetadata;
-}
-
-/**
- * Message payload for UPDATE_STREAM_STATUS command.
- * Used for efficient single-stream status updates without full list refresh.
- */
-export interface UpdateStreamStatusMessage {
-  command: 'updateStreamStatus';
-  stream: StreamTabId;
-  status: StreamStatus;
-  /** Optional timestamp for updating "last activity" display */
-  lastTimestamp?: number;
 }

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -14,24 +14,6 @@ import { ToolError, type ToolFileAttachment } from '@tools/result';
 import { getPathSegments, isNonEmptyString, toPosixPath } from '@utils/core';
 import { WorkspaceFS, getMimeType } from '@utils/files';
 
-/**
- * Helper function to truncate long output for logging
- *
- * @param text Text to truncate
- * @param maxLength Maximum length before truncation
- * @returns Truncated text if needed
- */
-export function maybe_truncate(text: string, maxLength: number = 5000): string {
-  if (text.length <= maxLength) {
-    return text;
-  }
-
-  const truncatedText =
-    text.substring(0, maxLength) +
-    `\n...(truncated, ${text.length - maxLength} more characters)`;
-  return truncatedText;
-}
-
 export interface WorkspacePathResolution {
   relative: string;
   absolute: string;

--- a/src/utils/pendingStateManager.ts
+++ b/src/utils/pendingStateManager.ts
@@ -25,9 +25,3 @@ export function consumePendingState(): TaskState | undefined {
   return state;
 }
 
-/**
- * Check if there is pending state.
- */
-export function hasPendingState(): boolean {
-  return pendingState !== undefined;
-}

--- a/src/utils/system/constants.ts
+++ b/src/utils/system/constants.ts
@@ -1,4 +1,2 @@
 // Common LaTeX tool names used across the system
 export const TEX_TOOLS = ['latexdiff', 'latexindent', 'latexmk'] as const;
-
-export type TexTool = (typeof TEX_TOOLS)[number];

--- a/src/webview/managers/FileManager.ts
+++ b/src/webview/managers/FileManager.ts
@@ -17,8 +17,7 @@ import { WorkspaceFS } from '@utils/files';
 // Local imports - types
 import type {
   FileSelectionMessage,
-  InputFileSelectedMessage,
-  GenericFileSelectedMessage,
+  FileSelectedMessage,
   RequestInputFileMessage,
   RequestFileMessage,
   RequestEditedFileMessage,
@@ -95,7 +94,7 @@ export class FileManager {
   }
 
   async handleInputFileSelected(
-    message: InputFileSelectedMessage,
+    message: FileSelectedMessage,
   ): Promise<void> {
     const webviewView = this.getWebview();
     if (!webviewView) {
@@ -110,7 +109,7 @@ export class FileManager {
     this.postFileUpdate('Edited', filteredEditedFiles);
   }
 
-  handleGenericFileSelected(message: GenericFileSelectedMessage): void {
+  handleGenericFileSelected(message: FileSelectedMessage): void {
     logger.debug(CHANNEL, `${message.command}: ${message.filePath}`);
   }
 

--- a/src/webview/types/messages.ts
+++ b/src/webview/types/messages.ts
@@ -87,20 +87,6 @@ export const FileSelectedMessageSchema = BaseMessageSchema.extend(
 export type FileSelectedMessage = z.infer<typeof FileSelectedMessageSchema>;
 
 /**
- * Input file selected message from webview.
- * Alias for FileSelectedMessageSchema for semantic clarity.
- */
-export const InputFileSelectedMessageSchema = FileSelectedMessageSchema;
-export type InputFileSelectedMessage = FileSelectedMessage;
-
-/**
- * Generic file selected message from webview.
- * Alias for FileSelectedMessageSchema for semantic clarity.
- */
-export const GenericFileSelectedMessageSchema = FileSelectedMessageSchema;
-export type GenericFileSelectedMessage = FileSelectedMessage;
-
-/**
  * Request input file message from webview
  */
 export const RequestInputFileMessageSchema = BaseMessageSchema.extend(


### PR DESCRIPTION
Remove unused exports identified by ts-prune analysis:

- `maybe_truncate` from src/tools/utils.ts
- `hasPendingState` from src/utils/pendingStateManager.ts
- `isNativeTool` from src/agent/modelHandlers/toolConversion.ts
- `formatWebSearchResults` from src/agent/modelHandlers/types/ServerToolTypes.ts
- `OPENAI_RESPONSE_STATUS`, `ANTHROPIC_STOP_REASONS` from src/agent/modelHandlers/types/StopReasonTypes.ts
- `UpdateStreamStatusMessage` from src/progressView/types.ts
- `TexTool` from src/utils/system/constants.ts
- `InputFileSelectedMessageSchema`, `GenericFileSelectedMessageSchema` from src/webview/types/messages.ts
- `EditedFileRecord` from src/agent/modelHandlers/utils/toolAttachmentUtils.ts
- `LogLevel` from src/logger/messageTypes.ts

Update FileManager.ts to use FileSelectedMessage directly instead of
the removed type aliases.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Remove unused exports and redundant type aliases across agent, tools, utils, and webview; switch FileManager to use the unified FileSelectedMessage.
> 
> - **Types/Utils cleanup**:
>   - Remove unused exports: `maybe_truncate`, `hasPendingState`, `isNativeTool`, `formatWebSearchResults`, `OPENAI_RESPONSE_STATUS`, `ANTHROPIC_STOP_REASONS`, `UpdateStreamStatusMessage`, `TexTool`, `EditedFileRecord`, `LogLevel`.
>   - Drop redundant alias schemas/types in `webview/types/messages.ts` in favor of `FileSelectedMessage`.
> - **Webview**:
>   - Update `FileManager` to use `FileSelectedMessage` for `handleInputFileSelected` and `handleGenericFileSelected`.
> - **No functional changes to tool conversion or stop reason logic aside from removing unused exports.**
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 09eedd77a0b3aea3dfcfe2e850c8276fbbba5807. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->