### PR TITLE
refactor(agent): replace toJSON/fromJSON with Zod codecs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -283,7 +283,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -330,7 +329,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -781,7 +779,6 @@
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.24.3.tgz",
       "integrity": "sha512-YgSHW29fuzKKAHTGe9zjNoo+yF8KaQPzDC2W9Pv41E7/57IfY+AMGJ/aDFlgTLcVVELoggKE4syABCE75u3NCw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
@@ -1276,7 +1273,6 @@
       "integrity": "sha512-N9lBGA9o9aqb1hVMc9hzySbhKibHmB+N3IpoShyV6HyQYRGIhlrO5rQgttypi+yEeKsKI4idxC8Jw6gXKD4THA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.49.0",
         "@typescript-eslint/types": "8.49.0",
@@ -1889,7 +1885,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2457,7 +2452,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.9",
         "caniuse-lite": "^1.0.30001746",
@@ -3544,7 +3538,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3943,7 +3936,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
       "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.0",
@@ -7244,6 +7236,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -7265,6 +7258,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -7784,7 +7778,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -8907,7 +8900,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9124,7 +9116,6 @@
       "integrity": "sha512-HU1JOuV1OavsZ+mfigY0j8d1TgQgbZ6M+J75zDkpEAwYeXjWSqrGJtgnPblJjd/mAyTNQ7ygw0MiKOn6etz8yw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -9174,7 +9165,6 @@
       "integrity": "sha512-MfwFQ6SfwinsUVi0rNJm7rHZ31GyTcpVE5pgVA3hwFRb7COD4TzjUUwhGWKfO50+xdc2MQPuEBBJoqIMGt3JDw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.6.1",
         "@webpack-cli/configtest": "^3.0.1",
@@ -9867,7 +9857,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.2.0.tgz",
       "integrity": "sha512-Bd5fw9wlIhtqCCxotZgdTOMwGm1a0u75wARVEY9HMs1X17trvA/lMi4+MGK5EUfYkXVTbX8UDiDKW4OgzHVUZw==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/agent/core/AgentSharedStore.ts
+++ b/src/agent/core/AgentSharedStore.ts
@@ -139,8 +139,9 @@ export const AgentSharedStoreCodec = z.codec(
   AgentSharedStoreSnapshotSchema,
   z.instanceof(AgentSharedStore),
   {
+    // Validation and defaults are applied by nested codecs (each parses its own schema).
+    // No top-level parse needed here since we delegate to specialized codecs.
     decode: (snapshot): AgentSharedStore => {
-      // Use nested codecs for each state slice
       const round = ConversationRoundStateCodec.decode(snapshot.round);
       const run = AgentRunStateCodec.decode(snapshot.run);
       const workspace = AgentWorkspaceStateCodec.decode(snapshot.workspace);

--- a/src/agent/core/AgentSharedStore.ts
+++ b/src/agent/core/AgentSharedStore.ts
@@ -52,7 +52,11 @@ export const AgentSharedStoreSnapshotSchema = z.object({
   user: UserVariableChannelsSchema,
 });
 
-export type AgentSharedStoreSnapshot = z.infer<
+/**
+ * Output type for AgentSharedStore serialization.
+ * Uses z.output<> to get the type after parsing (all fields required).
+ */
+export type AgentSharedStoreSnapshot = z.output<
   typeof AgentSharedStoreSnapshotSchema
 >;
 
@@ -68,14 +72,14 @@ export class AgentSharedStore {
   private readonly runState: AgentRunState;
   private readonly workspaceState: AgentWorkspaceState;
   private readonly userChannels: UserVariableChannels;
-  private readonly onRoundFinalized?: AgentRoundFinalizedCallback;
+  private _onRoundFinalized?: AgentRoundFinalizedCallback;
 
   constructor(config: AgentSharedStoreOptions) {
     this.roundState = config.round;
     this.runState = config.run;
     this.workspaceState = config.workspace;
     this.userChannels = config.user;
-    this.onRoundFinalized = config.onRoundFinalized;
+    this._onRoundFinalized = config.onRoundFinalized;
   }
 
   get round(): ConversationRoundState {
@@ -103,10 +107,19 @@ export class AgentSharedStore {
     return this.userChannels;
   }
 
+  /**
+   * Set the callback to be called when a round is finalized.
+   * Useful for attaching callbacks after deserialization since callbacks
+   * are not serialized.
+   */
+  setOnRoundFinalized(callback: AgentRoundFinalizedCallback | undefined): void {
+    this._onRoundFinalized = callback;
+  }
+
   async finalizeRound(): Promise<void> {
     this.runState.recordRound(this.roundState);
-    if (this.onRoundFinalized) {
-      await this.onRoundFinalized({
+    if (this._onRoundFinalized) {
+      await this._onRoundFinalized({
         round: this.roundState,
         run: this.runState,
         workspace: this.workspaceState,
@@ -126,7 +139,7 @@ export const AgentSharedStoreCodec = z.codec(
   AgentSharedStoreSnapshotSchema,
   z.instanceof(AgentSharedStore),
   {
-    decode: (snapshot: AgentSharedStoreSnapshot): AgentSharedStore => {
+    decode: (snapshot): AgentSharedStore => {
       // Use nested codecs for each state slice
       const round = ConversationRoundStateCodec.decode(snapshot.round);
       const run = AgentRunStateCodec.decode(snapshot.run);
@@ -144,10 +157,10 @@ export const AgentSharedStoreCodec = z.codec(
         user: storeUserChannels,
       });
     },
-    encode: (store: AgentSharedStore): AgentSharedStoreSnapshot => ({
-      round: ConversationRoundStateCodec.encode(store.round),
-      run: AgentRunStateCodec.encode(store.run),
-      workspace: AgentWorkspaceStateCodec.encode(store.workspace),
+    encode: (store): AgentSharedStoreSnapshot => ({
+      round: ConversationRoundStateCodec.encode(store.round) as AgentSharedStoreSnapshot['round'],
+      run: AgentRunStateCodec.encode(store.run) as AgentSharedStoreSnapshot['run'],
+      workspace: AgentWorkspaceStateCodec.encode(store.workspace) as AgentSharedStoreSnapshot['workspace'],
       user: {
         input: { ...store.user.input },
         transient: { ...store.user.transient },
@@ -184,15 +197,9 @@ export function createSharedStore(
     AgentSharedStoreSnapshotSchema.parse(snapshot);
     const store = AgentSharedStoreCodec.decode(snapshot);
 
-    // Re-create with callback if provided (callbacks are not serialized)
+    // Attach callback post-creation if provided (callbacks are not serialized)
     if (args.onRoundFinalized) {
-      return new AgentSharedStore({
-        round: store.round,
-        run: store.run,
-        workspace: store.workspace,
-        user: store.user,
-        onRoundFinalized: args.onRoundFinalized,
-      });
+      store.setOnRoundFinalized(args.onRoundFinalized);
     }
     return store;
   }

--- a/src/agent/core/AgentSharedStore.ts
+++ b/src/agent/core/AgentSharedStore.ts
@@ -4,15 +4,12 @@ import { z } from 'zod';
 // Local imports - state slices
 import {
   AgentRunState,
-  AgentRunStateCodec,
   ConversationRoundState,
-  ConversationRoundStateCodec,
   AgentRunStateSnapshotSchema,
   ConversationRoundStateSnapshotSchema,
 } from './AgentState';
 import {
   AgentWorkspaceState,
-  AgentWorkspaceStateCodec,
   AgentWorkspaceStateSnapshotSchema,
 } from './AgentWorkspaceState';
 import {
@@ -82,6 +79,35 @@ export class AgentSharedStore {
     this._onRoundFinalized = config.onRoundFinalized;
   }
 
+  /** Deserialize from a snapshot. Validates and applies schema defaults. */
+  static fromSnapshot(snapshot: unknown): AgentSharedStore {
+    const parsed = AgentSharedStoreSnapshotSchema.parse(snapshot);
+    return new AgentSharedStore({
+      round: ConversationRoundState.fromSnapshot(parsed.round),
+      run: AgentRunState.fromSnapshot(parsed.run),
+      workspace: AgentWorkspaceState.fromSnapshot(parsed.workspace),
+      user: {
+        input: Object.freeze({ ...parsed.user.input }),
+        transient: { ...parsed.user.transient },
+        output: { ...parsed.user.output },
+      },
+    });
+  }
+
+  /** Serialize to a snapshot. */
+  toSnapshot(): AgentSharedStoreSnapshot {
+    return {
+      round: this.roundState.toSnapshot(),
+      run: this.runState.toSnapshot(),
+      workspace: this.workspaceState.toSnapshot(),
+      user: {
+        input: { ...this.userChannels.input },
+        transient: { ...this.userChannels.transient },
+        output: { ...this.userChannels.output },
+      },
+    };
+  }
+
   get round(): ConversationRoundState {
     return this.roundState;
   }
@@ -128,49 +154,6 @@ export class AgentSharedStore {
   }
 }
 
-/**
- * Codec for bi-directional serialization of AgentSharedStore.
- * Use .encode() to serialize and .decode() to deserialize.
- *
- * Note: The onRoundFinalized callback is not serialized as it's runtime-only.
- * Use AgentSharedStoreCodec.decode() then set the callback separately if needed.
- */
-export const AgentSharedStoreCodec = z.codec(
-  AgentSharedStoreSnapshotSchema,
-  z.instanceof(AgentSharedStore),
-  {
-    // Validation and defaults are applied by nested codecs (each parses its own schema).
-    // No top-level parse needed here since we delegate to specialized codecs.
-    decode: (snapshot): AgentSharedStore => {
-      const round = ConversationRoundStateCodec.decode(snapshot.round);
-      const run = AgentRunStateCodec.decode(snapshot.run);
-      const workspace = AgentWorkspaceStateCodec.decode(snapshot.workspace);
-      const storeUserChannels: UserVariableChannels = {
-        input: Object.freeze({ ...snapshot.user.input }),
-        transient: { ...snapshot.user.transient },
-        output: { ...snapshot.user.output },
-      };
-
-      return new AgentSharedStore({
-        round,
-        run,
-        workspace,
-        user: storeUserChannels,
-      });
-    },
-    encode: (store): AgentSharedStoreSnapshot => ({
-      round: ConversationRoundStateCodec.encode(store.round) as AgentSharedStoreSnapshot['round'],
-      run: AgentRunStateCodec.encode(store.run) as AgentSharedStoreSnapshot['run'],
-      workspace: AgentWorkspaceStateCodec.encode(store.workspace) as AgentSharedStoreSnapshot['workspace'],
-      user: {
-        input: { ...store.user.input },
-        transient: { ...store.user.transient },
-        output: { ...store.user.output },
-      },
-    }),
-  },
-);
-
 interface SharedStoreFactoryParams {
   roundIndex: number;
   runState: AgentRunState;
@@ -194,8 +177,7 @@ export function createSharedStore(
     if (!snapshot) {
       throw new Error('Shared store snapshot is required.');
     }
-    // Codec decode handles validation via nested schema parses
-    const store = AgentSharedStoreCodec.decode(snapshot);
+    const store = AgentSharedStore.fromSnapshot(snapshot);
 
     // Attach callback post-creation if provided (callbacks are not serialized)
     if (args.onRoundFinalized) {

--- a/src/agent/core/AgentSharedStore.ts
+++ b/src/agent/core/AgentSharedStore.ts
@@ -4,12 +4,15 @@ import { z } from 'zod';
 // Local imports - state slices
 import {
   AgentRunState,
+  AgentRunStateCodec,
   ConversationRoundState,
+  ConversationRoundStateCodec,
   AgentRunStateSnapshotSchema,
   ConversationRoundStateSnapshotSchema,
 } from './AgentState';
 import {
   AgentWorkspaceState,
+  AgentWorkspaceStateCodec,
   AgentWorkspaceStateSnapshotSchema,
 } from './AgentWorkspaceState';
 import {
@@ -110,42 +113,49 @@ export class AgentSharedStore {
       });
     }
   }
-
-  toJSON(): AgentSharedStoreSnapshot {
-    return {
-      round: this.roundState.toJSON(),
-      run: this.runState.toJSON(),
-      workspace: this.workspaceState.toJSON(),
-      user: {
-        input: { ...this.userChannels.input },
-        transient: { ...this.userChannels.transient },
-        output: { ...this.userChannels.output },
-      },
-    };
-  }
-
-  static fromJSON(
-    snapshot: AgentSharedStoreSnapshot,
-    options?: { onRoundFinalized?: AgentRoundFinalizedCallback },
-  ): AgentSharedStore {
-    const round = ConversationRoundState.fromJSON(snapshot.round);
-    const run = AgentRunState.fromJSON(snapshot.run);
-    const workspace = AgentWorkspaceState.fromJSON(snapshot.workspace);
-    const storeUserChannels: UserVariableChannels = {
-      input: Object.freeze({ ...snapshot.user.input }),
-      transient: { ...snapshot.user.transient },
-      output: { ...snapshot.user.output },
-    };
-
-    return new AgentSharedStore({
-      round,
-      run,
-      workspace,
-      user: storeUserChannels,
-      onRoundFinalized: options?.onRoundFinalized,
-    });
-  }
 }
+
+/**
+ * Codec for bi-directional serialization of AgentSharedStore.
+ * Use .encode() to serialize and .decode() to deserialize.
+ *
+ * Note: The onRoundFinalized callback is not serialized as it's runtime-only.
+ * Use AgentSharedStoreCodec.decode() then set the callback separately if needed.
+ */
+export const AgentSharedStoreCodec = z.codec(
+  AgentSharedStoreSnapshotSchema,
+  z.instanceof(AgentSharedStore),
+  {
+    decode: (snapshot: AgentSharedStoreSnapshot): AgentSharedStore => {
+      // Use nested codecs for each state slice
+      const round = ConversationRoundStateCodec.decode(snapshot.round);
+      const run = AgentRunStateCodec.decode(snapshot.run);
+      const workspace = AgentWorkspaceStateCodec.decode(snapshot.workspace);
+      const storeUserChannels: UserVariableChannels = {
+        input: Object.freeze({ ...snapshot.user.input }),
+        transient: { ...snapshot.user.transient },
+        output: { ...snapshot.user.output },
+      };
+
+      return new AgentSharedStore({
+        round,
+        run,
+        workspace,
+        user: storeUserChannels,
+      });
+    },
+    encode: (store: AgentSharedStore): AgentSharedStoreSnapshot => ({
+      round: ConversationRoundStateCodec.encode(store.round),
+      run: AgentRunStateCodec.encode(store.run),
+      workspace: AgentWorkspaceStateCodec.encode(store.workspace),
+      user: {
+        input: { ...store.user.input },
+        transient: { ...store.user.transient },
+        output: { ...store.user.output },
+      },
+    }),
+  },
+);
 
 interface SharedStoreFactoryParams {
   roundIndex: number;
@@ -170,10 +180,21 @@ export function createSharedStore(
     if (!snapshot) {
       throw new Error('Shared store snapshot is required.');
     }
+    // Validate and decode using codec (handles nested state restoration)
     AgentSharedStoreSnapshotSchema.parse(snapshot);
-    return AgentSharedStore.fromJSON(snapshot, {
-      onRoundFinalized: args.onRoundFinalized,
-    });
+    const store = AgentSharedStoreCodec.decode(snapshot);
+
+    // Re-create with callback if provided (callbacks are not serialized)
+    if (args.onRoundFinalized) {
+      return new AgentSharedStore({
+        round: store.round,
+        run: store.run,
+        workspace: store.workspace,
+        user: store.user,
+        onRoundFinalized: args.onRoundFinalized,
+      });
+    }
+    return store;
   }
 
   const initialRound =

--- a/src/agent/core/AgentSharedStore.ts
+++ b/src/agent/core/AgentSharedStore.ts
@@ -193,8 +193,7 @@ export function createSharedStore(
     if (!snapshot) {
       throw new Error('Shared store snapshot is required.');
     }
-    // Validate and decode using codec (handles nested state restoration)
-    AgentSharedStoreSnapshotSchema.parse(snapshot);
+    // Codec decode handles validation via nested schema parses
     const store = AgentSharedStoreCodec.decode(snapshot);
 
     // Attach callback post-creation if provided (callbacks are not serialized)

--- a/src/agent/core/AgentState.ts
+++ b/src/agent/core/AgentState.ts
@@ -8,7 +8,6 @@ import {
 } from '@agent/types/NormalizedUsage';
 import {
   RunUsageAccumulator,
-  RunUsageAccumulatorCodec,
   RunUsageAccumulatorJSONSchema,
 } from './RunUsageAccumulator';
 
@@ -71,6 +70,28 @@ export class ConversationRoundState {
     this.normalizedUsage = ROUND_STATE_DEFAULTS.normalizedUsage;
   }
 
+  /** Deserialize from a snapshot. Validates and applies schema defaults. */
+  static fromSnapshot(snapshot: unknown): ConversationRoundState {
+    const parsed = ConversationRoundStateSnapshotSchema.parse(snapshot);
+    const state = new ConversationRoundState(parsed.roundIndex);
+    state.continuationCount = parsed.continuationCount;
+    state.responseTimeMs = parsed.responseTimeMs;
+    state.outputFile = parsed.outputFile;
+    state.normalizedUsage = parsed.normalizedUsage ?? null;
+    return state;
+  }
+
+  /** Serialize to a snapshot. */
+  toSnapshot(): ConversationRoundStateSnapshot {
+    return {
+      roundIndex: this.roundIndex,
+      continuationCount: this.continuationCount,
+      responseTimeMs: this.responseTimeMs,
+      outputFile: this.outputFile,
+      normalizedUsage: this.normalizedUsage,
+    };
+  }
+
   incrementContinuation(): void {
     this.continuationCount += 1;
   }
@@ -87,35 +108,6 @@ export class ConversationRoundState {
     this.normalizedUsage = null;
   }
 }
-
-/**
- * Codec for bi-directional serialization of ConversationRoundState.
- * Use .encode() to serialize and .decode() to deserialize.
- */
-export const ConversationRoundStateCodec = z.codec(
-  ConversationRoundStateSnapshotSchema,
-  z.instanceof(ConversationRoundState),
-  {
-    // Note: z.codec() does NOT auto-validate input before calling decode.
-    // We parse to apply schema defaults for legacy snapshots missing fields.
-    decode: (json): ConversationRoundState => {
-      const parsed = ConversationRoundStateSnapshotSchema.parse(json);
-      const state = new ConversationRoundState(parsed.roundIndex);
-      state.continuationCount = parsed.continuationCount;
-      state.responseTimeMs = parsed.responseTimeMs;
-      state.outputFile = parsed.outputFile;
-      state.normalizedUsage = parsed.normalizedUsage ?? null;
-      return state;
-    },
-    encode: (state): ConversationRoundStateSnapshot => ({
-      roundIndex: state.roundIndex,
-      continuationCount: state.continuationCount,
-      responseTimeMs: state.responseTimeMs,
-      outputFile: state.outputFile,
-      normalizedUsage: state.normalizedUsage,
-    }),
-  },
-);
 
 /** Default values for AgentRunState */
 const RUN_STATE_DEFAULTS = {
@@ -149,6 +141,25 @@ export class AgentRunState {
     this.usageAccumulator = accumulator ?? new RunUsageAccumulator();
   }
 
+  /** Deserialize from a snapshot. Validates and applies schema defaults. */
+  static fromSnapshot(snapshot: unknown): AgentRunState {
+    const parsed = AgentRunStateSnapshotSchema.parse(snapshot);
+    const usageAccumulator = RunUsageAccumulator.fromSnapshot(parsed.usageAccumulator);
+    const state = new AgentRunState(usageAccumulator);
+    state.totalRounds = parsed.totalRounds;
+    state.totalResponseTimeMs = parsed.totalResponseTimeMs;
+    return state;
+  }
+
+  /** Serialize to a snapshot. */
+  toSnapshot(): AgentRunStateSnapshot {
+    return {
+      totalRounds: this.totalRounds,
+      totalResponseTimeMs: this.totalResponseTimeMs,
+      usageAccumulator: this.usageAccumulator.toSnapshot(),
+    };
+  }
+
   incrementRounds(): void {
     this.totalRounds += 1;
   }
@@ -167,31 +178,3 @@ export class AgentRunState {
     this.addResponseTime(roundState.responseTimeMs);
   }
 }
-
-/**
- * Codec for bi-directional serialization of AgentRunState.
- * Use .encode() to serialize and .decode() to deserialize.
- */
-export const AgentRunStateCodec = z.codec(
-  AgentRunStateSnapshotSchema,
-  z.instanceof(AgentRunState),
-  {
-    // Note: z.codec() does NOT auto-validate input before calling decode.
-    // We parse to apply schema defaults for legacy snapshots missing fields.
-    decode: (json): AgentRunState => {
-      const parsed = AgentRunStateSnapshotSchema.parse(json);
-      const usageAccumulator = RunUsageAccumulatorCodec.decode(
-        parsed.usageAccumulator,
-      );
-      const state = new AgentRunState(usageAccumulator);
-      state.totalRounds = parsed.totalRounds;
-      state.totalResponseTimeMs = parsed.totalResponseTimeMs;
-      return state;
-    },
-    encode: (state): AgentRunStateSnapshot => ({
-      totalRounds: state.totalRounds,
-      totalResponseTimeMs: state.totalResponseTimeMs,
-      usageAccumulator: RunUsageAccumulatorCodec.encode(state.usageAccumulator) as AgentRunStateSnapshot['usageAccumulator'],
-    }),
-  },
-);

--- a/src/agent/core/AgentState.ts
+++ b/src/agent/core/AgentState.ts
@@ -99,7 +99,8 @@ export const ConversationRoundStateCodec = z.codec(
     decode: (
       json: ConversationRoundStateSnapshot,
     ): ConversationRoundState => {
-      // Schema handles defaults via .default()
+      // Intentional re-parse: validates untrusted input and applies schema defaults
+      // for legacy snapshots that may be missing fields like continuationCount
       const parsed = ConversationRoundStateSnapshotSchema.parse(json);
       const state = new ConversationRoundState(parsed.roundIndex);
       state.continuationCount = parsed.continuationCount;
@@ -178,13 +179,16 @@ export const AgentRunStateCodec = z.codec(
   z.instanceof(AgentRunState),
   {
     decode: (json): AgentRunState => {
+      // Intentional re-parse: validates untrusted input and applies schema defaults
+      // for legacy snapshots that may be missing fields like totalRounds
+      const parsed = AgentRunStateSnapshotSchema.parse(json);
       // Compose with nested codec
       const usageAccumulator = RunUsageAccumulatorCodec.decode(
-        json.usageAccumulator,
+        parsed.usageAccumulator,
       );
       const state = new AgentRunState(usageAccumulator);
-      state.totalRounds = json.totalRounds;
-      state.totalResponseTimeMs = json.totalResponseTimeMs;
+      state.totalRounds = parsed.totalRounds;
+      state.totalResponseTimeMs = parsed.totalResponseTimeMs;
       return state;
     },
     encode: (state): AgentRunStateSnapshot => ({

--- a/src/agent/core/AgentState.ts
+++ b/src/agent/core/AgentState.ts
@@ -50,9 +50,9 @@ export const ConversationRoundStateSnapshotSchema = z.object({
 
 /**
  * Single source of truth for ConversationRoundState serialization format.
- * Derived from the Zod schema - do not duplicate this definition.
+ * Uses z.output<> to get the type after parsing (all fields required).
  */
-export type ConversationRoundStateSnapshot = z.infer<
+export type ConversationRoundStateSnapshot = z.output<
   typeof ConversationRoundStateSnapshotSchema
 >;
 
@@ -135,9 +135,9 @@ export const AgentRunStateSnapshotSchema = z.object({
 
 /**
  * Single source of truth for AgentRunState serialization format.
- * Derived from the Zod schema - do not duplicate this definition.
+ * Uses z.output<> to get the type after parsing (all fields required).
  */
-export type AgentRunStateSnapshot = z.infer<typeof AgentRunStateSnapshotSchema>;
+export type AgentRunStateSnapshot = z.output<typeof AgentRunStateSnapshotSchema>;
 
 export class AgentRunState {
   public totalRounds: number;
@@ -177,7 +177,7 @@ export const AgentRunStateCodec = z.codec(
   AgentRunStateSnapshotSchema,
   z.instanceof(AgentRunState),
   {
-    decode: (json: AgentRunStateSnapshot): AgentRunState => {
+    decode: (json): AgentRunState => {
       // Compose with nested codec
       const usageAccumulator = RunUsageAccumulatorCodec.decode(
         json.usageAccumulator,
@@ -187,10 +187,10 @@ export const AgentRunStateCodec = z.codec(
       state.totalResponseTimeMs = json.totalResponseTimeMs;
       return state;
     },
-    encode: (state: AgentRunState): AgentRunStateSnapshot => ({
+    encode: (state): AgentRunStateSnapshot => ({
       totalRounds: state.totalRounds,
       totalResponseTimeMs: state.totalResponseTimeMs,
-      usageAccumulator: RunUsageAccumulatorCodec.encode(state.usageAccumulator),
+      usageAccumulator: RunUsageAccumulatorCodec.encode(state.usageAccumulator) as AgentRunStateSnapshot['usageAccumulator'],
     }),
   },
 );

--- a/src/agent/core/AgentState.ts
+++ b/src/agent/core/AgentState.ts
@@ -42,7 +42,7 @@ export const ConversationRoundStateSnapshotSchema = z.object({
     .nonnegative()
     .default(ROUND_STATE_DEFAULTS.responseTimeMs),
   outputFile: z.string().default(ROUND_STATE_DEFAULTS.outputFile),
-  normalizedUsage: NormalizedUsageSchema.nullish().default(
+  normalizedUsage: NormalizedUsageSchema.nullable().default(
     ROUND_STATE_DEFAULTS.normalizedUsage,
   ),
 });
@@ -77,7 +77,7 @@ export class ConversationRoundState {
     state.continuationCount = parsed.continuationCount;
     state.responseTimeMs = parsed.responseTimeMs;
     state.outputFile = parsed.outputFile;
-    state.normalizedUsage = parsed.normalizedUsage ?? null;
+    state.normalizedUsage = parsed.normalizedUsage;
     return state;
   }
 
@@ -121,7 +121,10 @@ export const AgentRunStateSnapshotSchema = z.object({
     .number()
     .nonnegative()
     .default(RUN_STATE_DEFAULTS.totalResponseTimeMs),
-  usageAccumulator: RunUsageAccumulatorJSONSchema,
+  usageAccumulator: RunUsageAccumulatorJSONSchema.default({
+    totals: {},
+    normalizedSnapshots: [],
+  }),
 });
 
 /**

--- a/src/agent/core/AgentState.ts
+++ b/src/agent/core/AgentState.ts
@@ -8,6 +8,7 @@ import {
 } from '@agent/types/NormalizedUsage';
 import {
   RunUsageAccumulator,
+  RunUsageAccumulatorCodec,
   RunUsageAccumulatorJSONSchema,
 } from './RunUsageAccumulator';
 
@@ -23,12 +24,28 @@ export type NativeResponseUsage =
   | AnthropicUsage
   | GenerateContentResponseUsageMetadata;
 
+/** Default values for ConversationRoundState */
+const ROUND_STATE_DEFAULTS = {
+  continuationCount: 0,
+  responseTimeMs: 0,
+  outputFile: '',
+  normalizedUsage: null,
+} as const;
+
 export const ConversationRoundStateSnapshotSchema = z.object({
   roundIndex: z.int().nonnegative(),
-  continuationCount: z.int().nonnegative(),
-  responseTimeMs: z.number().nonnegative(),
-  outputFile: z.string(),
-  normalizedUsage: NormalizedUsageSchema.nullish(),
+  continuationCount: z
+    .int()
+    .nonnegative()
+    .default(ROUND_STATE_DEFAULTS.continuationCount),
+  responseTimeMs: z
+    .number()
+    .nonnegative()
+    .default(ROUND_STATE_DEFAULTS.responseTimeMs),
+  outputFile: z.string().default(ROUND_STATE_DEFAULTS.outputFile),
+  normalizedUsage: NormalizedUsageSchema.nullish().default(
+    ROUND_STATE_DEFAULTS.normalizedUsage,
+  ),
 });
 
 /**
@@ -48,10 +65,10 @@ export class ConversationRoundState {
 
   constructor(roundIndex: number) {
     this.roundIndex = roundIndex;
-    this.continuationCount = 0;
-    this.responseTimeMs = 0;
-    this.outputFile = '';
-    this.normalizedUsage = null;
+    this.continuationCount = ROUND_STATE_DEFAULTS.continuationCount;
+    this.responseTimeMs = ROUND_STATE_DEFAULTS.responseTimeMs;
+    this.outputFile = ROUND_STATE_DEFAULTS.outputFile;
+    this.normalizedUsage = ROUND_STATE_DEFAULTS.normalizedUsage;
   }
 
   incrementContinuation(): void {
@@ -69,32 +86,50 @@ export class ConversationRoundState {
   clearUsage(): void {
     this.normalizedUsage = null;
   }
-
-  toJSON(): ConversationRoundStateSnapshot {
-    return {
-      roundIndex: this.roundIndex,
-      continuationCount: this.continuationCount,
-      responseTimeMs: this.responseTimeMs,
-      outputFile: this.outputFile,
-      normalizedUsage: this.normalizedUsage,
-    };
-  }
-
-  static fromJSON(
-    json: ConversationRoundStateSnapshot,
-  ): ConversationRoundState {
-    const state = new ConversationRoundState(json.roundIndex);
-    state.continuationCount = json.continuationCount;
-    state.responseTimeMs = json.responseTimeMs;
-    state.outputFile = json.outputFile;
-    state.normalizedUsage = json.normalizedUsage ?? null;
-    return state;
-  }
 }
 
+/**
+ * Codec for bi-directional serialization of ConversationRoundState.
+ * Use .encode() to serialize and .decode() to deserialize.
+ */
+export const ConversationRoundStateCodec = z.codec(
+  ConversationRoundStateSnapshotSchema,
+  z.instanceof(ConversationRoundState),
+  {
+    decode: (
+      json: ConversationRoundStateSnapshot,
+    ): ConversationRoundState => {
+      // Schema handles defaults via .default()
+      const parsed = ConversationRoundStateSnapshotSchema.parse(json);
+      const state = new ConversationRoundState(parsed.roundIndex);
+      state.continuationCount = parsed.continuationCount;
+      state.responseTimeMs = parsed.responseTimeMs;
+      state.outputFile = parsed.outputFile;
+      state.normalizedUsage = parsed.normalizedUsage ?? null;
+      return state;
+    },
+    encode: (state: ConversationRoundState): ConversationRoundStateSnapshot => ({
+      roundIndex: state.roundIndex,
+      continuationCount: state.continuationCount,
+      responseTimeMs: state.responseTimeMs,
+      outputFile: state.outputFile,
+      normalizedUsage: state.normalizedUsage,
+    }),
+  },
+);
+
+/** Default values for AgentRunState */
+const RUN_STATE_DEFAULTS = {
+  totalRounds: 0,
+  totalResponseTimeMs: 0,
+} as const;
+
 export const AgentRunStateSnapshotSchema = z.object({
-  totalRounds: z.int().nonnegative(),
-  totalResponseTimeMs: z.number().nonnegative(),
+  totalRounds: z.int().nonnegative().default(RUN_STATE_DEFAULTS.totalRounds),
+  totalResponseTimeMs: z
+    .number()
+    .nonnegative()
+    .default(RUN_STATE_DEFAULTS.totalResponseTimeMs),
   usageAccumulator: RunUsageAccumulatorJSONSchema,
 });
 
@@ -110,8 +145,8 @@ export class AgentRunState {
   public readonly usageAccumulator: RunUsageAccumulator;
 
   constructor(accumulator?: RunUsageAccumulator) {
-    this.totalRounds = 0;
-    this.totalResponseTimeMs = 0;
+    this.totalRounds = RUN_STATE_DEFAULTS.totalRounds;
+    this.totalResponseTimeMs = RUN_STATE_DEFAULTS.totalResponseTimeMs;
     this.usageAccumulator = accumulator ?? new RunUsageAccumulator();
   }
 
@@ -132,28 +167,30 @@ export class AgentRunState {
     }
     this.addResponseTime(roundState.responseTimeMs);
   }
-
-  toJSON(): AgentRunStateSnapshot {
-    return {
-      totalRounds: this.totalRounds,
-      totalResponseTimeMs: this.totalResponseTimeMs,
-      usageAccumulator: this.usageAccumulator.toJSON(),
-    };
-  }
-
-  static fromJSON(
-    json: AgentRunStateSnapshot | null | undefined,
-  ): AgentRunState {
-    if (!json) {
-      return new AgentRunState();
-    }
-
-    const usageAccumulator = RunUsageAccumulator.fromJSON(
-      json.usageAccumulator,
-    );
-    const state = new AgentRunState(usageAccumulator);
-    state.totalRounds = json.totalRounds;
-    state.totalResponseTimeMs = json.totalResponseTimeMs;
-    return state;
-  }
 }
+
+/**
+ * Codec for bi-directional serialization of AgentRunState.
+ * Use .encode() to serialize and .decode() to deserialize.
+ */
+export const AgentRunStateCodec = z.codec(
+  AgentRunStateSnapshotSchema,
+  z.instanceof(AgentRunState),
+  {
+    decode: (json: AgentRunStateSnapshot): AgentRunState => {
+      // Compose with nested codec
+      const usageAccumulator = RunUsageAccumulatorCodec.decode(
+        json.usageAccumulator,
+      );
+      const state = new AgentRunState(usageAccumulator);
+      state.totalRounds = json.totalRounds;
+      state.totalResponseTimeMs = json.totalResponseTimeMs;
+      return state;
+    },
+    encode: (state: AgentRunState): AgentRunStateSnapshot => ({
+      totalRounds: state.totalRounds,
+      totalResponseTimeMs: state.totalResponseTimeMs,
+      usageAccumulator: RunUsageAccumulatorCodec.encode(state.usageAccumulator),
+    }),
+  },
+);

--- a/src/agent/core/AgentState.ts
+++ b/src/agent/core/AgentState.ts
@@ -96,11 +96,9 @@ export const ConversationRoundStateCodec = z.codec(
   ConversationRoundStateSnapshotSchema,
   z.instanceof(ConversationRoundState),
   {
-    decode: (
-      json: ConversationRoundStateSnapshot,
-    ): ConversationRoundState => {
-      // Intentional re-parse: validates untrusted input and applies schema defaults
-      // for legacy snapshots that may be missing fields like continuationCount
+    // Note: z.codec() does NOT auto-validate input before calling decode.
+    // We parse to apply schema defaults for legacy snapshots missing fields.
+    decode: (json): ConversationRoundState => {
       const parsed = ConversationRoundStateSnapshotSchema.parse(json);
       const state = new ConversationRoundState(parsed.roundIndex);
       state.continuationCount = parsed.continuationCount;
@@ -109,7 +107,7 @@ export const ConversationRoundStateCodec = z.codec(
       state.normalizedUsage = parsed.normalizedUsage ?? null;
       return state;
     },
-    encode: (state: ConversationRoundState): ConversationRoundStateSnapshot => ({
+    encode: (state): ConversationRoundStateSnapshot => ({
       roundIndex: state.roundIndex,
       continuationCount: state.continuationCount,
       responseTimeMs: state.responseTimeMs,
@@ -178,11 +176,10 @@ export const AgentRunStateCodec = z.codec(
   AgentRunStateSnapshotSchema,
   z.instanceof(AgentRunState),
   {
+    // Note: z.codec() does NOT auto-validate input before calling decode.
+    // We parse to apply schema defaults for legacy snapshots missing fields.
     decode: (json): AgentRunState => {
-      // Intentional re-parse: validates untrusted input and applies schema defaults
-      // for legacy snapshots that may be missing fields like totalRounds
       const parsed = AgentRunStateSnapshotSchema.parse(json);
-      // Compose with nested codec
       const usageAccumulator = RunUsageAccumulatorCodec.decode(
         parsed.usageAccumulator,
       );

--- a/src/agent/core/AgentWorkspaceState.ts
+++ b/src/agent/core/AgentWorkspaceState.ts
@@ -70,7 +70,11 @@ export const FileInteractionStateSnapshotSchema = z.object({
     )
     .default([]),
 });
-export type FileInteractionStateSnapshot = z.infer<
+/**
+ * Output type for FileInteractionState serialization.
+ * Uses z.output<> to get the type after parsing (all fields required).
+ */
+export type FileInteractionStateSnapshot = z.output<
   typeof FileInteractionStateSnapshotSchema
 >;
 
@@ -296,7 +300,11 @@ import { TodoItemSchema, type TodoItem } from '@eventBus/schemas';
 export const TodoStateSnapshotSchema = z.object({
   todos: z.array(TodoItemSchema).default([]),
 });
-export type TodoStateSnapshot = z.infer<typeof TodoStateSnapshotSchema>;
+/**
+ * Output type for TodoState serialization.
+ * Uses z.output<> to get the type after parsing (all fields required).
+ */
+export type TodoStateSnapshot = z.output<typeof TodoStateSnapshotSchema>;
 
 /**
  * State for managing todo items during tool-use sessions.
@@ -420,9 +428,27 @@ export const AgentWorkspaceStateSnapshotSchema = z.object({
   todos: TodoStateSnapshotSchema.default({ todos: [] }),
 });
 
-export type AgentWorkspaceSnapshot = z.infer<
+/**
+ * Output type for AgentWorkspaceState serialization.
+ * Uses z.output<> to get the type after parsing (all fields required).
+ */
+export type AgentWorkspaceSnapshot = z.output<
   typeof AgentWorkspaceStateSnapshotSchema
 >;
+
+/** Symbol key for internal factory - only used by codec */
+const INTERNAL_FACTORY = Symbol('AgentWorkspaceState.internalFactory');
+
+/** Parameters for internal factory construction */
+interface AgentWorkspaceStateParams {
+  assembly: ResponseAssemblyState;
+  media: MediaAttachmentState;
+  reasoning: ReasoningCacheState;
+  document: DocumentStatsState;
+  interactions: FileInteractionState;
+  serverToolContent: ServerToolContentState;
+  todos: TodoState;
+}
 
 export class AgentWorkspaceState {
   public readonly assembly: ResponseAssemblyState;
@@ -434,35 +460,35 @@ export class AgentWorkspaceState {
   public readonly todos: TodoState;
 
   /** Use AgentWorkspaceState.create() for new instances */
-  private constructor(
-    assembly: ResponseAssemblyState,
-    media: MediaAttachmentState,
-    reasoning: ReasoningCacheState,
-    document: DocumentStatsState,
-    interactions: FileInteractionState,
-    serverToolContent: ServerToolContentState,
-    todos: TodoState,
-  ) {
-    this.assembly = assembly;
-    this.media = media;
-    this.reasoning = reasoning;
-    this.document = document;
-    this.interactions = interactions;
-    this.serverToolContent = serverToolContent;
-    this.todos = todos;
+  private constructor(params: AgentWorkspaceStateParams) {
+    this.assembly = params.assembly;
+    this.media = params.media;
+    this.reasoning = params.reasoning;
+    this.document = params.document;
+    this.interactions = params.interactions;
+    this.serverToolContent = params.serverToolContent;
+    this.todos = params.todos;
   }
 
   /** Factory method to create a fresh AgentWorkspaceState */
   static create(): AgentWorkspaceState {
-    return new AgentWorkspaceState(
-      new ResponseAssemblyState(),
-      new MediaAttachmentState(),
-      new ReasoningCacheState(),
-      new DocumentStatsState(),
-      new FileInteractionState(),
-      new ServerToolContentState(),
-      new TodoState(),
-    );
+    return new AgentWorkspaceState({
+      assembly: new ResponseAssemblyState(),
+      media: new MediaAttachmentState(),
+      reasoning: new ReasoningCacheState(),
+      document: new DocumentStatsState(),
+      interactions: new FileInteractionState(),
+      serverToolContent: new ServerToolContentState(),
+      todos: new TodoState(),
+    });
+  }
+
+  /**
+   * Internal factory for codec use only.
+   * @internal Do not use directly - use AgentWorkspaceStateCodec.decode() instead.
+   */
+  static [INTERNAL_FACTORY](params: AgentWorkspaceStateParams): AgentWorkspaceState {
+    return new AgentWorkspaceState(params);
   }
 
   resetReasoning(): void {
@@ -478,13 +504,16 @@ export class AgentWorkspaceState {
  * Codec for bi-directional serialization of AgentWorkspaceState.
  * Use .encode() to serialize and .decode() to deserialize.
  * Handles legacy format migration (e.g., media files string → FileLocation).
+ *
+ * Note: Uses z.custom() instead of z.instanceof() because the class has a private constructor.
  */
 export const AgentWorkspaceStateCodec = z.codec(
   AgentWorkspaceStateSnapshotSchema,
-  z.instanceof(AgentWorkspaceState),
+  z.custom<AgentWorkspaceState>((val) => val instanceof AgentWorkspaceState),
   {
-    decode: (json: AgentWorkspaceSnapshot): AgentWorkspaceState => {
-      // Schema handles defaults and legacy format conversion via MediaFileEntryCodec
+    decode: (json): AgentWorkspaceState => {
+      // Intentional re-parse: validates untrusted input and applies schema defaults
+      // for legacy snapshots that may be missing fields or have wrong types
       const parsed = AgentWorkspaceStateSnapshotSchema.parse(json);
 
       // Build component states
@@ -507,18 +536,18 @@ export const AgentWorkspaceStateCodec = z.codec(
       const interactions = FileInteractionStateCodec.decode(parsed.interactions);
       const todos = TodoStateCodec.decode(parsed.todos);
 
-      // Use private constructor via factory pattern workaround
-      return (AgentWorkspaceState as any).create_internal(
+      // Use Symbol-keyed factory for type-safe internal construction
+      return AgentWorkspaceState[INTERNAL_FACTORY]({
         assembly,
         media,
         reasoning,
         document,
         interactions,
-        new ServerToolContentState(),
+        serverToolContent: new ServerToolContentState(),
         todos,
-      );
+      });
     },
-    encode: (state: AgentWorkspaceState): AgentWorkspaceSnapshot => ({
+    encode: (state): AgentWorkspaceSnapshot => ({
       assembly: {
         lastResponse: state.assembly.lastResponse,
         accumulatedOutput: state.assembly.accumulatedOutput,
@@ -533,29 +562,8 @@ export const AgentWorkspaceStateCodec = z.codec(
       document: {
         texcountStats: state.document.texcountStats,
       },
-      interactions: FileInteractionStateCodec.encode(state.interactions),
-      todos: TodoStateCodec.encode(state.todos),
+      interactions: FileInteractionStateCodec.encode(state.interactions) as AgentWorkspaceSnapshot['interactions'],
+      todos: TodoStateCodec.encode(state.todos) as AgentWorkspaceSnapshot['todos'],
     }),
   },
 );
-
-// Internal factory for codec use - avoids exposing full constructor publicly
-(AgentWorkspaceState as any).create_internal = function (
-  assembly: ResponseAssemblyState,
-  media: MediaAttachmentState,
-  reasoning: ReasoningCacheState,
-  document: DocumentStatsState,
-  interactions: FileInteractionState,
-  serverToolContent: ServerToolContentState,
-  todos: TodoState,
-): AgentWorkspaceState {
-  return new (AgentWorkspaceState as any)(
-    assembly,
-    media,
-    reasoning,
-    document,
-    interactions,
-    serverToolContent,
-    todos,
-  );
-};

--- a/src/agent/core/AgentWorkspaceState.ts
+++ b/src/agent/core/AgentWorkspaceState.ts
@@ -8,21 +8,27 @@ import {
   type FileLocation,
 } from '@utils/files';
 
+/** Schema for ThinkingBlock */
+export const ThinkingBlockSchema = z.object({
+  type: z.string(),
+  thinking: z.string().optional(),
+  signature: z.string().optional(),
+  data: z.string().optional(),
+});
+
 /**
  * Thinking block from reasoning models.
  * This represents the internal reasoning/thinking output from models like Claude Sonnet 4.
  * Supports both regular thinking blocks and redacted thinking blocks from Anthropic.
  */
-export interface ThinkingBlock {
-  /** Block type: 'thinking' for regular, 'redacted_thinking' for redacted */
-  type: string;
-  /** Thinking content (for regular thinking blocks) */
-  thinking?: string;
-  /** Signature for verification (for regular thinking blocks from Anthropic) */
-  signature?: string;
-  /** Encrypted data (for redacted thinking blocks from Anthropic) */
-  data?: string;
-}
+export type ThinkingBlock = z.infer<typeof ThinkingBlockSchema>;
+
+/** Schema for ResponseAssemblyState serialization */
+export const ResponseAssemblyStateSnapshotSchema = z.object({
+  lastResponse: z.string().default(''),
+  accumulatedOutput: z.string().default(''),
+});
+export type ResponseAssemblyStateSnapshot = z.output<typeof ResponseAssemblyStateSnapshotSchema>;
 
 /**
  * Workspace assembly state keeps track of the model's textual output so the
@@ -31,6 +37,23 @@ export interface ThinkingBlock {
 export class ResponseAssemblyState {
   private _lastResponse = '';
   private _accumulatedOutput = '';
+
+  /** Deserialize from a snapshot. Validates and applies schema defaults. */
+  static fromSnapshot(snapshot: unknown): ResponseAssemblyState {
+    const parsed = ResponseAssemblyStateSnapshotSchema.parse(snapshot);
+    const state = new ResponseAssemblyState();
+    state._lastResponse = parsed.lastResponse;
+    state._accumulatedOutput = parsed.accumulatedOutput;
+    return state;
+  }
+
+  /** Serialize to a snapshot. */
+  toSnapshot(): ResponseAssemblyStateSnapshot {
+    return {
+      lastResponse: this._lastResponse,
+      accumulatedOutput: this._accumulatedOutput,
+    };
+  }
 
   get lastResponse(): string {
     return this._lastResponse;
@@ -84,6 +107,29 @@ export class FileInteractionState {
     string,
     { added: number; removed: number }
   >();
+
+  /** Deserialize from a snapshot. Validates and applies schema defaults. */
+  static fromSnapshot(snapshot: unknown): FileInteractionState {
+    const parsed = FileInteractionStateSnapshotSchema.parse(snapshot);
+    const state = new FileInteractionState();
+    parsed.readFiles.forEach((path) => state.readFiles.add(path));
+    for (const entry of parsed.edits) {
+      state.edits.set(entry.path, { added: entry.added, removed: entry.removed });
+    }
+    return state;
+  }
+
+  /** Serialize to a snapshot. */
+  toSnapshot(): FileInteractionStateSnapshot {
+    return {
+      readFiles: Array.from(this.readFiles),
+      edits: Array.from(this.edits.entries()).map(([path, diff]) => ({
+        path,
+        added: diff.added,
+        removed: diff.removed,
+      })),
+    };
+  }
 
   recordRead(path: string | undefined | null): void {
     if (!path) return;
@@ -149,57 +195,40 @@ export class FileInteractionState {
     const lineChanges = added || removed ? { added, removed } : undefined;
     return { edits: editsForCall, lineChanges };
   }
-
-  /** @internal Used by codec - prefer FileInteractionStateCodec */
-  _getReadFiles(): Set<string> {
-    return this.readFiles;
-  }
-
-  /** @internal Used by codec - prefer FileInteractionStateCodec */
-  _getEdits(): Map<string, { added: number; removed: number }> {
-    return this.edits;
-  }
 }
 
 /**
- * Codec for bi-directional serialization of FileInteractionState.
- * Use .encode() to serialize and .decode() to deserialize.
+ * Schema for legacy media file entries.
+ * Legacy snapshots stored plain strings; new snapshots store FileLocation objects.
+ * Transform normalizes legacy strings to FileLocation on parse.
  */
-export const FileInteractionStateCodec = z.codec(
-  FileInteractionStateSnapshotSchema,
-  z.instanceof(FileInteractionState),
-  {
-    // Note: z.codec() does NOT auto-validate input before calling decode.
-    // We parse to apply schema defaults for legacy snapshots missing fields.
-    decode: (json): FileInteractionState => {
-      const parsed = FileInteractionStateSnapshotSchema.parse(json);
-      const state = new FileInteractionState();
-      parsed.readFiles.forEach((path: string) => state.recordRead(path));
-      for (const entry of parsed.edits) {
-        state._getEdits().set(entry.path, {
-          added: entry.added,
-          removed: entry.removed,
-        });
-      }
-      return state;
-    },
-    encode: (state): FileInteractionStateSnapshot => ({
-      readFiles: Array.from(state._getReadFiles()),
-      edits: Array.from(state._getEdits().entries()).map(
-        ([path, diff]: [string, { added: number; removed: number }]) => ({
-          path,
-          added: diff.added,
-          removed: diff.removed,
-        }),
-      ),
-    }),
-  },
+const MediaFileEntrySchema = z.union([z.string(), FileLocationSchema]).transform(
+  (entry): FileLocation => (typeof entry === 'string' ? pathToLocation(entry) : entry),
 );
+
+/** Schema for MediaAttachmentState serialization */
+export const MediaAttachmentStateSnapshotSchema = z.object({
+  files: z.array(MediaFileEntrySchema).default([]),
+});
+export type MediaAttachmentStateSnapshot = z.output<typeof MediaAttachmentStateSnapshotSchema>;
 
 export class MediaAttachmentState {
   public readonly files: FileLocation[] = [];
   /** Set of absolute paths for O(1) deduplication lookups */
   private readonly pathSet = new Set<string>();
+
+  /** Deserialize from a snapshot. Validates, applies defaults, and normalizes legacy formats. */
+  static fromSnapshot(snapshot: unknown): MediaAttachmentState {
+    const parsed = MediaAttachmentStateSnapshotSchema.parse(snapshot);
+    const state = new MediaAttachmentState();
+    state.addMediaFiles(parsed.files);
+    return state;
+  }
+
+  /** Serialize to a snapshot. */
+  toSnapshot(): MediaAttachmentStateSnapshot {
+    return { files: [...this.files] };
+  }
 
   /**
    * Add a single media file to the attachment state.
@@ -231,9 +260,33 @@ export class MediaAttachmentState {
   }
 }
 
+/** Schema for ReasoningCacheState serialization */
+export const ReasoningCacheStateSnapshotSchema = z.object({
+  thinkingBlocks: z.array(ThinkingBlockSchema).default([]),
+  thinkingAdded: z.boolean().default(false),
+});
+export type ReasoningCacheStateSnapshot = z.output<typeof ReasoningCacheStateSnapshotSchema>;
+
 export class ReasoningCacheState {
   public thinkingBlocks: ThinkingBlock[] = [];
   public thinkingAdded = false;
+
+  /** Deserialize from a snapshot. Validates and applies schema defaults. */
+  static fromSnapshot(snapshot: unknown): ReasoningCacheState {
+    const parsed = ReasoningCacheStateSnapshotSchema.parse(snapshot);
+    const state = new ReasoningCacheState();
+    state.thinkingBlocks = [...parsed.thinkingBlocks];
+    state.thinkingAdded = parsed.thinkingAdded;
+    return state;
+  }
+
+  /** Serialize to a snapshot. */
+  toSnapshot(): ReasoningCacheStateSnapshot {
+    return {
+      thinkingBlocks: [...this.thinkingBlocks],
+      thinkingAdded: this.thinkingAdded,
+    };
+  }
 
   get primaryBlock(): ThinkingBlock | null {
     return this.thinkingBlocks.length > 0 ? this.thinkingBlocks[0] : null;
@@ -285,8 +338,27 @@ export class ServerToolContentState {
   }
 }
 
+/** Schema for DocumentStatsState serialization */
+export const DocumentStatsStateSnapshotSchema = z.object({
+  texcountStats: z.string().nullable().default(null),
+});
+export type DocumentStatsStateSnapshot = z.output<typeof DocumentStatsStateSnapshotSchema>;
+
 export class DocumentStatsState {
   public texcountStats: string | null = null;
+
+  /** Deserialize from a snapshot. Validates and applies schema defaults. */
+  static fromSnapshot(snapshot: unknown): DocumentStatsState {
+    const parsed = DocumentStatsStateSnapshotSchema.parse(snapshot);
+    const state = new DocumentStatsState();
+    state.texcountStats = parsed.texcountStats;
+    return state;
+  }
+
+  /** Serialize to a snapshot. */
+  toSnapshot(): DocumentStatsStateSnapshot {
+    return { texcountStats: this.texcountStats };
+  }
 
   updateTeXCountStats(stats: string | null): void {
     this.texcountStats = stats;
@@ -313,6 +385,19 @@ export type TodoStateSnapshot = z.output<typeof TodoStateSnapshotSchema>;
 export class TodoState {
   private _todos: TodoItem[] = [];
   private _onUpdate?: (todos: TodoItem[]) => void;
+
+  /** Deserialize from a snapshot. Validates and applies schema defaults. */
+  static fromSnapshot(snapshot: unknown): TodoState {
+    const parsed = TodoStateSnapshotSchema.parse(snapshot);
+    const state = new TodoState();
+    state._todos = [...parsed.todos];
+    return state;
+  }
+
+  /** Serialize to a snapshot. */
+  toSnapshot(): TodoStateSnapshot {
+    return { todos: [...this._todos] };
+  }
 
   get todos(): TodoItem[] {
     return this._todos;
@@ -349,84 +434,19 @@ export class TodoState {
   reset(): void {
     this._todos = [];
   }
-
-  /** @internal Used by codec */
-  _setTodos(todos: TodoItem[]): void {
-    this._todos = todos;
-  }
 }
 
 /**
- * Codec for bi-directional serialization of TodoState.
- * Use .encode() to serialize and .decode() to deserialize.
- */
-export const TodoStateCodec = z.codec(
-  TodoStateSnapshotSchema,
-  z.instanceof(TodoState),
-  {
-    // Note: z.codec() does NOT auto-validate input before calling decode.
-    // We parse to apply schema defaults for legacy snapshots missing fields.
-    decode: (json): TodoState => {
-      const parsed = TodoStateSnapshotSchema.parse(json);
-      const state = new TodoState();
-      state._setTodos([...parsed.todos]);
-      return state;
-    },
-    encode: (state): TodoStateSnapshot => ({
-      todos: [...state.todos],
-    }),
-  },
-);
-
-export const ThinkingBlockSchema = z.object({
-  type: z.string(),
-  thinking: z.string().optional(),
-  signature: z.string().optional(),
-  data: z.string().optional(),
-});
-
-/**
- * Codec for media files that handles both legacy (string[]) and new (FileLocation[]) formats.
- * Legacy snapshots stored plain strings; new snapshots store FileLocation objects.
- * Uses transform to normalize legacy strings to FileLocation on decode.
- */
-const MediaFileEntryCodec = z.codec(
-  z.union([z.string(), FileLocationSchema]),
-  FileLocationSchema,
-  {
-    decode: (entry: string | FileLocation): FileLocation =>
-      typeof entry === 'string' ? pathToLocation(entry) : entry,
-    encode: (location: FileLocation): FileLocation => location,
-  },
-);
-
-/**
- * We use z.object() instead of z.strictObject() to remain backward compatible
+ * Composite schema for AgentWorkspaceState serialization.
+ * Uses z.object() (not strictObject) to remain backward compatible
  * with legacy workspace snapshots that may contain removed or renamed fields.
  */
 export const AgentWorkspaceStateSnapshotSchema = z.object({
-  assembly: z
-    .object({
-      lastResponse: z.string().default(''),
-      accumulatedOutput: z.string().default(''),
-    })
-    .default({ lastResponse: '', accumulatedOutput: '' }),
-  media: z
-    .object({ files: z.array(MediaFileEntryCodec).default([]) })
-    .default({ files: [] }),
-  reasoning: z
-    .object({
-      thinkingBlocks: z.array(ThinkingBlockSchema).default([]),
-      thinkingAdded: z.boolean().default(false),
-    })
-    .default({ thinkingBlocks: [], thinkingAdded: false }),
-  document: z
-    .object({ texcountStats: z.string().nullable().default(null) })
-    .default({ texcountStats: null }),
-  interactions: FileInteractionStateSnapshotSchema.default({
-    readFiles: [],
-    edits: [],
-  }),
+  assembly: ResponseAssemblyStateSnapshotSchema.default({ lastResponse: '', accumulatedOutput: '' }),
+  media: MediaAttachmentStateSnapshotSchema.default({ files: [] }),
+  reasoning: ReasoningCacheStateSnapshotSchema.default({ thinkingBlocks: [], thinkingAdded: false }),
+  document: DocumentStatsStateSnapshotSchema.default({ texcountStats: null }),
+  interactions: FileInteractionStateSnapshotSchema.default({ readFiles: [], edits: [] }),
   todos: TodoStateSnapshotSchema.default({ todos: [] }),
 });
 
@@ -438,20 +458,6 @@ export type AgentWorkspaceSnapshot = z.output<
   typeof AgentWorkspaceStateSnapshotSchema
 >;
 
-/** Symbol key for internal factory - only used by codec */
-const INTERNAL_FACTORY = Symbol('AgentWorkspaceState.internalFactory');
-
-/** Parameters for internal factory construction */
-interface AgentWorkspaceStateParams {
-  assembly: ResponseAssemblyState;
-  media: MediaAttachmentState;
-  reasoning: ReasoningCacheState;
-  document: DocumentStatsState;
-  interactions: FileInteractionState;
-  serverToolContent: ServerToolContentState;
-  todos: TodoState;
-}
-
 export class AgentWorkspaceState {
   public readonly assembly: ResponseAssemblyState;
   public readonly media: MediaAttachmentState;
@@ -461,36 +467,61 @@ export class AgentWorkspaceState {
   public readonly serverToolContent: ServerToolContentState;
   public readonly todos: TodoState;
 
-  /** Use AgentWorkspaceState.create() for new instances */
-  private constructor(params: AgentWorkspaceStateParams) {
-    this.assembly = params.assembly;
-    this.media = params.media;
-    this.reasoning = params.reasoning;
-    this.document = params.document;
-    this.interactions = params.interactions;
-    this.serverToolContent = params.serverToolContent;
-    this.todos = params.todos;
+  private constructor(
+    assembly: ResponseAssemblyState,
+    media: MediaAttachmentState,
+    reasoning: ReasoningCacheState,
+    document: DocumentStatsState,
+    interactions: FileInteractionState,
+    serverToolContent: ServerToolContentState,
+    todos: TodoState,
+  ) {
+    this.assembly = assembly;
+    this.media = media;
+    this.reasoning = reasoning;
+    this.document = document;
+    this.interactions = interactions;
+    this.serverToolContent = serverToolContent;
+    this.todos = todos;
   }
 
   /** Factory method to create a fresh AgentWorkspaceState */
   static create(): AgentWorkspaceState {
-    return new AgentWorkspaceState({
-      assembly: new ResponseAssemblyState(),
-      media: new MediaAttachmentState(),
-      reasoning: new ReasoningCacheState(),
-      document: new DocumentStatsState(),
-      interactions: new FileInteractionState(),
-      serverToolContent: new ServerToolContentState(),
-      todos: new TodoState(),
-    });
+    return new AgentWorkspaceState(
+      new ResponseAssemblyState(),
+      new MediaAttachmentState(),
+      new ReasoningCacheState(),
+      new DocumentStatsState(),
+      new FileInteractionState(),
+      new ServerToolContentState(),
+      new TodoState(),
+    );
   }
 
-  /**
-   * Internal factory for codec use only.
-   * @internal Do not use directly - use AgentWorkspaceStateCodec.decode() instead.
-   */
-  static [INTERNAL_FACTORY](params: AgentWorkspaceStateParams): AgentWorkspaceState {
-    return new AgentWorkspaceState(params);
+  /** Deserialize from a snapshot. Validates, applies defaults, and handles legacy formats. */
+  static fromSnapshot(snapshot: unknown): AgentWorkspaceState {
+    const parsed = AgentWorkspaceStateSnapshotSchema.parse(snapshot);
+    return new AgentWorkspaceState(
+      ResponseAssemblyState.fromSnapshot(parsed.assembly),
+      MediaAttachmentState.fromSnapshot(parsed.media),
+      ReasoningCacheState.fromSnapshot(parsed.reasoning),
+      DocumentStatsState.fromSnapshot(parsed.document),
+      FileInteractionState.fromSnapshot(parsed.interactions),
+      new ServerToolContentState(), // Ephemeral - not serialized
+      TodoState.fromSnapshot(parsed.todos),
+    );
+  }
+
+  /** Serialize to a snapshot. */
+  toSnapshot(): AgentWorkspaceSnapshot {
+    return {
+      assembly: this.assembly.toSnapshot(),
+      media: this.media.toSnapshot(),
+      reasoning: this.reasoning.toSnapshot(),
+      document: this.document.toSnapshot(),
+      interactions: this.interactions.toSnapshot(),
+      todos: this.todos.toSnapshot(),
+    };
   }
 
   resetReasoning(): void {
@@ -502,70 +533,3 @@ export class AgentWorkspaceState {
   }
 }
 
-/**
- * Codec for bi-directional serialization of AgentWorkspaceState.
- * Use .encode() to serialize and .decode() to deserialize.
- * Handles legacy format migration (e.g., media files string → FileLocation).
- *
- * Note: Uses z.custom() instead of z.instanceof() because the class has a private constructor.
- */
-export const AgentWorkspaceStateCodec = z.codec(
-  AgentWorkspaceStateSnapshotSchema,
-  z.custom<AgentWorkspaceState>((val) => val instanceof AgentWorkspaceState),
-  {
-    // Note: z.codec() does NOT auto-validate input before calling decode.
-    // We parse to apply schema defaults for legacy snapshots missing fields.
-    decode: (json): AgentWorkspaceState => {
-      const parsed = AgentWorkspaceStateSnapshotSchema.parse(json);
-
-      // Build component states
-      const assembly = new ResponseAssemblyState();
-      assembly.lastResponse = parsed.assembly.lastResponse;
-      assembly.accumulatedOutput = parsed.assembly.accumulatedOutput;
-
-      const media = new MediaAttachmentState();
-      // Files are already normalized to FileLocation by MediaFileEntryCodec
-      media.addMediaFiles(parsed.media.files);
-
-      const reasoning = new ReasoningCacheState();
-      reasoning.thinkingBlocks.push(...parsed.reasoning.thinkingBlocks);
-      reasoning.thinkingAdded = parsed.reasoning.thinkingAdded;
-
-      const document = new DocumentStatsState();
-      document.texcountStats = parsed.document.texcountStats;
-
-      // Use nested codecs for complex state
-      const interactions = FileInteractionStateCodec.decode(parsed.interactions);
-      const todos = TodoStateCodec.decode(parsed.todos);
-
-      // Use Symbol-keyed factory for type-safe internal construction
-      return AgentWorkspaceState[INTERNAL_FACTORY]({
-        assembly,
-        media,
-        reasoning,
-        document,
-        interactions,
-        serverToolContent: new ServerToolContentState(),
-        todos,
-      });
-    },
-    encode: (state): AgentWorkspaceSnapshot => ({
-      assembly: {
-        lastResponse: state.assembly.lastResponse,
-        accumulatedOutput: state.assembly.accumulatedOutput,
-      },
-      media: {
-        files: [...state.media.files],
-      },
-      reasoning: {
-        thinkingBlocks: [...state.reasoning.thinkingBlocks],
-        thinkingAdded: state.reasoning.thinkingAdded,
-      },
-      document: {
-        texcountStats: state.document.texcountStats,
-      },
-      interactions: FileInteractionStateCodec.encode(state.interactions) as AgentWorkspaceSnapshot['interactions'],
-      todos: TodoStateCodec.encode(state.todos) as AgentWorkspaceSnapshot['todos'],
-    }),
-  },
-);

--- a/src/agent/core/AgentWorkspaceState.ts
+++ b/src/agent/core/AgentWorkspaceState.ts
@@ -57,6 +57,23 @@ export class ResponseAssemblyState {
   }
 }
 
+/** Schema for FileInteractionState serialization */
+export const FileInteractionStateSnapshotSchema = z.object({
+  readFiles: z.array(z.string()).default([]),
+  edits: z
+    .array(
+      z.object({
+        path: z.string(),
+        added: z.number().default(0),
+        removed: z.number().default(0),
+      }),
+    )
+    .default([]),
+});
+export type FileInteractionStateSnapshot = z.infer<
+  typeof FileInteractionStateSnapshotSchema
+>;
+
 export class FileInteractionState {
   private readonly readFiles = new Set<string>();
   private readonly edits = new Map<
@@ -129,38 +146,51 @@ export class FileInteractionState {
     return { edits: editsForCall, lineChanges };
   }
 
-  toJSON(): {
-    readFiles: string[];
-    edits: { path: string; added: number; removed: number }[];
-  } {
-    return {
-      readFiles: Array.from(this.readFiles),
-      edits: Array.from(this.edits.entries()).map(([path, diff]) => ({
-        path,
-        added: diff.added,
-        removed: diff.removed,
-      })),
-    };
+  /** @internal Used by codec - prefer FileInteractionStateCodec */
+  _getReadFiles(): Set<string> {
+    return this.readFiles;
   }
 
-  static fromJSON(data: {
-    readFiles?: string[];
-    edits?: { path?: string; added?: number; removed?: number }[];
-  }): FileInteractionState {
-    const state = new FileInteractionState();
-    // Restore read files
-    (data.readFiles ?? []).forEach((path) => state.recordRead(path));
-    // Restore edits directly (absolute values, not deltas)
-    (data.edits ?? []).forEach((entry) => {
-      if (!entry?.path) return;
-      state.edits.set(entry.path, {
-        added: entry.added ?? 0,
-        removed: entry.removed ?? 0,
-      });
-    });
-    return state;
+  /** @internal Used by codec - prefer FileInteractionStateCodec */
+  _getEdits(): Map<string, { added: number; removed: number }> {
+    return this.edits;
   }
 }
+
+/**
+ * Codec for bi-directional serialization of FileInteractionState.
+ * Use .encode() to serialize and .decode() to deserialize.
+ */
+export const FileInteractionStateCodec = z.codec(
+  FileInteractionStateSnapshotSchema,
+  z.instanceof(FileInteractionState),
+  {
+    decode: (json: FileInteractionStateSnapshot): FileInteractionState => {
+      const parsed = FileInteractionStateSnapshotSchema.parse(json);
+      const state = new FileInteractionState();
+      // Restore read files
+      parsed.readFiles.forEach((path: string) => state.recordRead(path));
+      // Restore edits directly (absolute values, not deltas)
+      for (const entry of parsed.edits) {
+        state._getEdits().set(entry.path, {
+          added: entry.added,
+          removed: entry.removed,
+        });
+      }
+      return state;
+    },
+    encode: (state: FileInteractionState): FileInteractionStateSnapshot => ({
+      readFiles: Array.from(state._getReadFiles()),
+      edits: Array.from(state._getEdits().entries()).map(
+        ([path, diff]: [string, { added: number; removed: number }]) => ({
+          path,
+          added: diff.added,
+          removed: diff.removed,
+        }),
+      ),
+    }),
+  },
+);
 
 export class MediaAttachmentState {
   public readonly files: FileLocation[] = [];
@@ -262,6 +292,12 @@ export class DocumentStatsState {
 // Import todo schemas from single source of truth (eventBus/schemas)
 import { TodoItemSchema, type TodoItem } from '@eventBus/schemas';
 
+/** Schema for TodoState serialization */
+export const TodoStateSnapshotSchema = z.object({
+  todos: z.array(TodoItemSchema).default([]),
+});
+export type TodoStateSnapshot = z.infer<typeof TodoStateSnapshotSchema>;
+
 /**
  * State for managing todo items during tool-use sessions.
  * Provides task tracking and progress visibility for agents.
@@ -306,18 +342,31 @@ export class TodoState {
     this._todos = [];
   }
 
-  toJSON(): { todos: TodoItem[] } {
-    return { todos: [...this._todos] };
-  }
-
-  static fromJSON(data: { todos?: TodoItem[] } | null): TodoState {
-    const state = new TodoState();
-    if (data?.todos) {
-      state._todos = [...data.todos];
-    }
-    return state;
+  /** @internal Used by codec */
+  _setTodos(todos: TodoItem[]): void {
+    this._todos = todos;
   }
 }
+
+/**
+ * Codec for bi-directional serialization of TodoState.
+ * Use .encode() to serialize and .decode() to deserialize.
+ */
+export const TodoStateCodec = z.codec(
+  TodoStateSnapshotSchema,
+  z.instanceof(TodoState),
+  {
+    decode: (json: TodoStateSnapshot): TodoState => {
+      const parsed = TodoStateSnapshotSchema.parse(json);
+      const state = new TodoState();
+      state._setTodos([...parsed.todos]);
+      return state;
+    },
+    encode: (state: TodoState): TodoStateSnapshot => ({
+      todos: [...state.todos],
+    }),
+  },
+);
 
 export const ThinkingBlockSchema = z.object({
   type: z.string(),
@@ -327,51 +376,48 @@ export const ThinkingBlockSchema = z.object({
 });
 
 /**
- * Schema for media files that handles both legacy (string[]) and new (FileLocation[]) formats.
+ * Codec for media files that handles both legacy (string[]) and new (FileLocation[]) formats.
  * Legacy snapshots stored plain strings; new snapshots store FileLocation objects.
+ * Uses transform to normalize legacy strings to FileLocation on decode.
  */
-const MediaFileEntrySchema = z.union([
-  z.string(), // Legacy format: plain path string
-  FileLocationSchema, // New format: FileLocation object
-]);
+const MediaFileEntryCodec = z.codec(
+  z.union([z.string(), FileLocationSchema]),
+  FileLocationSchema,
+  {
+    decode: (entry: string | FileLocation): FileLocation =>
+      typeof entry === 'string' ? pathToLocation(entry) : entry,
+    encode: (location: FileLocation): FileLocation => location,
+  },
+);
 
 /**
  * We use z.object() instead of z.strictObject() to remain backward compatible
  * with legacy workspace snapshots that may contain removed or renamed fields.
  */
 export const AgentWorkspaceStateSnapshotSchema = z.object({
-  assembly: z.object({
-    lastResponse: z.string(),
-    accumulatedOutput: z.string(),
-  }),
-  media: z.object({ files: z.array(MediaFileEntrySchema) }),
-  reasoning: z.object({
-    thinkingBlocks: z.array(ThinkingBlockSchema),
-    thinkingAdded: z.boolean(),
-  }),
-  document: z.object({ texcountStats: z.string().nullable() }),
-  interactions: z
+  assembly: z
     .object({
-      readFiles: z.array(z.string()),
-      edits: z.array(
-        z.object({
-          path: z.string(),
-          added: z.number().optional(),
-          removed: z.number().optional(),
-        }),
-      ),
+      lastResponse: z.string().default(''),
+      accumulatedOutput: z.string().default(''),
     })
-    .optional()
-    .prefault({
-      readFiles: [],
-      edits: [],
-    }),
-  todos: z
+    .default({ lastResponse: '', accumulatedOutput: '' }),
+  media: z
+    .object({ files: z.array(MediaFileEntryCodec).default([]) })
+    .default({ files: [] }),
+  reasoning: z
     .object({
-      todos: z.array(TodoItemSchema),
+      thinkingBlocks: z.array(ThinkingBlockSchema).default([]),
+      thinkingAdded: z.boolean().default(false),
     })
-    .optional()
-    .prefault({ todos: [] }),
+    .default({ thinkingBlocks: [], thinkingAdded: false }),
+  document: z
+    .object({ texcountStats: z.string().nullable().default(null) })
+    .default({ texcountStats: null }),
+  interactions: FileInteractionStateSnapshotSchema.default({
+    readFiles: [],
+    edits: [],
+  }),
+  todos: TodoStateSnapshotSchema.default({ todos: [] }),
 });
 
 export type AgentWorkspaceSnapshot = z.infer<
@@ -379,13 +425,45 @@ export type AgentWorkspaceSnapshot = z.infer<
 >;
 
 export class AgentWorkspaceState {
-  public readonly assembly = new ResponseAssemblyState();
-  public readonly media = new MediaAttachmentState();
-  public readonly reasoning = new ReasoningCacheState();
-  public readonly document = new DocumentStatsState();
-  public readonly interactions = new FileInteractionState();
-  public readonly serverToolContent = new ServerToolContentState();
-  public readonly todos = new TodoState();
+  public readonly assembly: ResponseAssemblyState;
+  public readonly media: MediaAttachmentState;
+  public readonly reasoning: ReasoningCacheState;
+  public readonly document: DocumentStatsState;
+  public readonly interactions: FileInteractionState;
+  public readonly serverToolContent: ServerToolContentState;
+  public readonly todos: TodoState;
+
+  /** Use AgentWorkspaceState.create() for new instances */
+  private constructor(
+    assembly: ResponseAssemblyState,
+    media: MediaAttachmentState,
+    reasoning: ReasoningCacheState,
+    document: DocumentStatsState,
+    interactions: FileInteractionState,
+    serverToolContent: ServerToolContentState,
+    todos: TodoState,
+  ) {
+    this.assembly = assembly;
+    this.media = media;
+    this.reasoning = reasoning;
+    this.document = document;
+    this.interactions = interactions;
+    this.serverToolContent = serverToolContent;
+    this.todos = todos;
+  }
+
+  /** Factory method to create a fresh AgentWorkspaceState */
+  static create(): AgentWorkspaceState {
+    return new AgentWorkspaceState(
+      new ResponseAssemblyState(),
+      new MediaAttachmentState(),
+      new ReasoningCacheState(),
+      new DocumentStatsState(),
+      new FileInteractionState(),
+      new ServerToolContentState(),
+      new TodoState(),
+    );
+  }
 
   resetReasoning(): void {
     this.reasoning.reset();
@@ -394,64 +472,90 @@ export class AgentWorkspaceState {
   resetServerToolContent(): void {
     this.serverToolContent.reset();
   }
+}
 
-  toJSON(): AgentWorkspaceSnapshot {
-    return {
+/**
+ * Codec for bi-directional serialization of AgentWorkspaceState.
+ * Use .encode() to serialize and .decode() to deserialize.
+ * Handles legacy format migration (e.g., media files string → FileLocation).
+ */
+export const AgentWorkspaceStateCodec = z.codec(
+  AgentWorkspaceStateSnapshotSchema,
+  z.instanceof(AgentWorkspaceState),
+  {
+    decode: (json: AgentWorkspaceSnapshot): AgentWorkspaceState => {
+      // Schema handles defaults and legacy format conversion via MediaFileEntryCodec
+      const parsed = AgentWorkspaceStateSnapshotSchema.parse(json);
+
+      // Build component states
+      const assembly = new ResponseAssemblyState();
+      assembly.lastResponse = parsed.assembly.lastResponse;
+      assembly.accumulatedOutput = parsed.assembly.accumulatedOutput;
+
+      const media = new MediaAttachmentState();
+      // Files are already normalized to FileLocation by MediaFileEntryCodec
+      media.addMediaFiles(parsed.media.files);
+
+      const reasoning = new ReasoningCacheState();
+      reasoning.thinkingBlocks.push(...parsed.reasoning.thinkingBlocks);
+      reasoning.thinkingAdded = parsed.reasoning.thinkingAdded;
+
+      const document = new DocumentStatsState();
+      document.texcountStats = parsed.document.texcountStats;
+
+      // Use nested codecs for complex state
+      const interactions = FileInteractionStateCodec.decode(parsed.interactions);
+      const todos = TodoStateCodec.decode(parsed.todos);
+
+      // Use private constructor via factory pattern workaround
+      return (AgentWorkspaceState as any).create_internal(
+        assembly,
+        media,
+        reasoning,
+        document,
+        interactions,
+        new ServerToolContentState(),
+        todos,
+      );
+    },
+    encode: (state: AgentWorkspaceState): AgentWorkspaceSnapshot => ({
       assembly: {
-        lastResponse: this.assembly.lastResponse,
-        accumulatedOutput: this.assembly.accumulatedOutput,
+        lastResponse: state.assembly.lastResponse,
+        accumulatedOutput: state.assembly.accumulatedOutput,
       },
       media: {
-        files: [...this.media.files],
+        files: [...state.media.files],
       },
       reasoning: {
-        thinkingBlocks: [...this.reasoning.thinkingBlocks],
-        thinkingAdded: this.reasoning.thinkingAdded,
+        thinkingBlocks: [...state.reasoning.thinkingBlocks],
+        thinkingAdded: state.reasoning.thinkingAdded,
       },
       document: {
-        texcountStats: this.document.texcountStats,
+        texcountStats: state.document.texcountStats,
       },
-      interactions: this.interactions.toJSON(),
-      todos: this.todos.toJSON(),
-    };
-  }
+      interactions: FileInteractionStateCodec.encode(state.interactions),
+      todos: TodoStateCodec.encode(state.todos),
+    }),
+  },
+);
 
-  static fromJSON(
-    snapshot: AgentWorkspaceSnapshot | null,
-  ): AgentWorkspaceState {
-    const state = new AgentWorkspaceState();
-    if (!snapshot) {
-      return state;
-    }
-
-    state.assembly.lastResponse = snapshot.assembly.lastResponse;
-    state.assembly.accumulatedOutput = snapshot.assembly.accumulatedOutput;
-
-    // Restore media files, converting legacy strings to FileLocation
-    const restoredMediaFiles: FileLocation[] = snapshot.media.files.map(
-      (entry) => (typeof entry === 'string' ? pathToLocation(entry) : entry),
-    );
-    state.media.addMediaFiles(restoredMediaFiles);
-
-    state.reasoning.thinkingBlocks.push(...snapshot.reasoning.thinkingBlocks);
-    state.reasoning.thinkingAdded = snapshot.reasoning.thinkingAdded;
-    state.document.texcountStats = snapshot.document.texcountStats;
-    // Restore file interactions directly using fromJSON (single source of truth)
-    const interactions =
-      snapshot.interactions ??
-      ({
-        readFiles: [],
-        edits: [],
-      } satisfies AgentWorkspaceSnapshot['interactions']);
-    const restored = FileInteractionState.fromJSON(interactions);
-    // Replace the default instance with the restored state
-    (state as any).interactions = restored;
-
-    // Restore todos
-    const todosData = snapshot.todos ?? { todos: [] };
-    const restoredTodos = TodoState.fromJSON(todosData);
-    (state as any).todos = restoredTodos;
-
-    return state;
-  }
-}
+// Internal factory for codec use - avoids exposing full constructor publicly
+(AgentWorkspaceState as any).create_internal = function (
+  assembly: ResponseAssemblyState,
+  media: MediaAttachmentState,
+  reasoning: ReasoningCacheState,
+  document: DocumentStatsState,
+  interactions: FileInteractionState,
+  serverToolContent: ServerToolContentState,
+  todos: TodoState,
+): AgentWorkspaceState {
+  return new (AgentWorkspaceState as any)(
+    assembly,
+    media,
+    reasoning,
+    document,
+    interactions,
+    serverToolContent,
+    todos,
+  );
+};

--- a/src/agent/core/AgentWorkspaceState.ts
+++ b/src/agent/core/AgentWorkspaceState.ts
@@ -169,12 +169,12 @@ export const FileInteractionStateCodec = z.codec(
   FileInteractionStateSnapshotSchema,
   z.instanceof(FileInteractionState),
   {
-    decode: (json: FileInteractionStateSnapshot): FileInteractionState => {
+    // Note: z.codec() does NOT auto-validate input before calling decode.
+    // We parse to apply schema defaults for legacy snapshots missing fields.
+    decode: (json): FileInteractionState => {
       const parsed = FileInteractionStateSnapshotSchema.parse(json);
       const state = new FileInteractionState();
-      // Restore read files
       parsed.readFiles.forEach((path: string) => state.recordRead(path));
-      // Restore edits directly (absolute values, not deltas)
       for (const entry of parsed.edits) {
         state._getEdits().set(entry.path, {
           added: entry.added,
@@ -183,7 +183,7 @@ export const FileInteractionStateCodec = z.codec(
       }
       return state;
     },
-    encode: (state: FileInteractionState): FileInteractionStateSnapshot => ({
+    encode: (state): FileInteractionStateSnapshot => ({
       readFiles: Array.from(state._getReadFiles()),
       edits: Array.from(state._getEdits().entries()).map(
         ([path, diff]: [string, { added: number; removed: number }]) => ({
@@ -364,13 +364,15 @@ export const TodoStateCodec = z.codec(
   TodoStateSnapshotSchema,
   z.instanceof(TodoState),
   {
-    decode: (json: TodoStateSnapshot): TodoState => {
+    // Note: z.codec() does NOT auto-validate input before calling decode.
+    // We parse to apply schema defaults for legacy snapshots missing fields.
+    decode: (json): TodoState => {
       const parsed = TodoStateSnapshotSchema.parse(json);
       const state = new TodoState();
       state._setTodos([...parsed.todos]);
       return state;
     },
-    encode: (state: TodoState): TodoStateSnapshot => ({
+    encode: (state): TodoStateSnapshot => ({
       todos: [...state.todos],
     }),
   },
@@ -511,9 +513,9 @@ export const AgentWorkspaceStateCodec = z.codec(
   AgentWorkspaceStateSnapshotSchema,
   z.custom<AgentWorkspaceState>((val) => val instanceof AgentWorkspaceState),
   {
+    // Note: z.codec() does NOT auto-validate input before calling decode.
+    // We parse to apply schema defaults for legacy snapshots missing fields.
     decode: (json): AgentWorkspaceState => {
-      // Intentional re-parse: validates untrusted input and applies schema defaults
-      // for legacy snapshots that may be missing fields or have wrong types
       const parsed = AgentWorkspaceStateSnapshotSchema.parse(json);
 
       // Build component states

--- a/src/agent/core/RunUsageAccumulator.ts
+++ b/src/agent/core/RunUsageAccumulator.ts
@@ -68,6 +68,24 @@ export class RunUsageAccumulator {
   private totals: RunUsageTotals = { ...DEFAULT_TOTALS };
   private readonly normalizedSnapshots: NormalizedUsageSnapshot[] = [];
 
+  /** Deserialize from a snapshot. Validates and applies schema defaults. */
+  static fromSnapshot(snapshot: unknown): RunUsageAccumulator {
+    const parsed = RunUsageAccumulatorJSONSchema.parse(snapshot);
+    const acc = new RunUsageAccumulator();
+    // parsed.totals already has defaults from parent schema, just needs field defaults
+    acc.totals = { ...DEFAULT_TOTALS, ...parsed.totals };
+    acc.normalizedSnapshots.push(...parsed.normalizedSnapshots);
+    return acc;
+  }
+
+  /** Serialize to a snapshot. */
+  toSnapshot(): RunUsageAccumulatorJSON {
+    return {
+      totals: this.totals,
+      normalizedSnapshots: [...this.normalizedSnapshots],
+    };
+  }
+
   recordNormalizedUsage(round: number, usage: NormalizedUsage): void {
     if (this.totals.firstInputTokens === 0) {
       this.totals.firstInputTokens =
@@ -116,39 +134,4 @@ export class RunUsageAccumulator {
   getNormalizedSnapshots(): readonly NormalizedUsageSnapshot[] {
     return this.normalizedSnapshots;
   }
-
-  /** @internal Used by codec - prefer RunUsageAccumulatorCodec.encode() */
-  _setTotals(totals: RunUsageTotals): void {
-    this.totals = totals;
-  }
-
-  /** @internal Used by codec - prefer RunUsageAccumulatorCodec.decode() */
-  _pushSnapshots(snapshots: NormalizedUsageSnapshot[]): void {
-    this.normalizedSnapshots.push(...snapshots);
-  }
 }
-
-/**
- * Codec for bi-directional serialization of RunUsageAccumulator.
- * Use .encode() to serialize and .decode() to deserialize.
- */
-export const RunUsageAccumulatorCodec = z.codec(
-  RunUsageAccumulatorJSONSchema,
-  z.instanceof(RunUsageAccumulator),
-  {
-    // Note: z.codec() does NOT auto-validate input before calling decode.
-    // We parse to apply schema defaults for legacy snapshots missing fields.
-    decode: (json): RunUsageAccumulator => {
-      const parsed = RunUsageAccumulatorJSONSchema.parse(json);
-      const acc = new RunUsageAccumulator();
-      const totals = RunUsageTotalsSchema.parse(parsed.totals);
-      acc._setTotals(totals);
-      acc._pushSnapshots(parsed.normalizedSnapshots);
-      return acc;
-    },
-    encode: (acc: RunUsageAccumulator): RunUsageAccumulatorJSON => ({
-      totals: acc.getTotals(),
-      normalizedSnapshots: [...acc.getNormalizedSnapshots()],
-    }),
-  },
-);

--- a/src/agent/core/RunUsageAccumulator.ts
+++ b/src/agent/core/RunUsageAccumulator.ts
@@ -7,17 +7,38 @@ import {
   type NormalizedUsage,
 } from '@agent/types/NormalizedUsage';
 
-/** Schema for run usage totals */
+/** Default values for run usage totals */
+const DEFAULT_TOTALS = {
+  firstInputTokens: 0,
+  totalInputTokens: 0,
+  totalOutputTokens: 0,
+  totalCost: 0,
+  totalCacheReadInputTokens: 0,
+  totalCacheCreationInputTokens: 0,
+  totalReasoningTokens: 0,
+  totalToolUsePromptTokens: 0,
+  totalServerToolRequests: 0,
+} as const;
+
+/** Schema for run usage totals with defaults */
 export const RunUsageTotalsSchema = z.object({
-  firstInputTokens: z.number(),
-  totalInputTokens: z.number(),
-  totalOutputTokens: z.number(),
-  totalCost: z.number(),
-  totalCacheReadInputTokens: z.number(),
-  totalCacheCreationInputTokens: z.number(),
-  totalReasoningTokens: z.number(),
-  totalToolUsePromptTokens: z.number(),
-  totalServerToolRequests: z.number(),
+  firstInputTokens: z.number().default(DEFAULT_TOTALS.firstInputTokens),
+  totalInputTokens: z.number().default(DEFAULT_TOTALS.totalInputTokens),
+  totalOutputTokens: z.number().default(DEFAULT_TOTALS.totalOutputTokens),
+  totalCost: z.number().default(DEFAULT_TOTALS.totalCost),
+  totalCacheReadInputTokens: z
+    .number()
+    .default(DEFAULT_TOTALS.totalCacheReadInputTokens),
+  totalCacheCreationInputTokens: z
+    .number()
+    .default(DEFAULT_TOTALS.totalCacheCreationInputTokens),
+  totalReasoningTokens: z.number().default(DEFAULT_TOTALS.totalReasoningTokens),
+  totalToolUsePromptTokens: z
+    .number()
+    .default(DEFAULT_TOTALS.totalToolUsePromptTokens),
+  totalServerToolRequests: z
+    .number()
+    .default(DEFAULT_TOTALS.totalServerToolRequests),
 });
 export type RunUsageTotals = z.infer<typeof RunUsageTotalsSchema>;
 
@@ -30,26 +51,14 @@ export type NormalizedUsageSnapshot = z.infer<
   typeof NormalizedUsageSnapshotSchema
 >;
 
-/** Schema for RunUsageAccumulator JSON serialization */
+/** Schema for RunUsageAccumulator JSON serialization (input accepts partial totals) */
 export const RunUsageAccumulatorJSONSchema = z.object({
-  totals: RunUsageTotalsSchema.partial(),
-  normalizedSnapshots: z.array(NormalizedUsageSnapshotSchema).optional(),
+  totals: RunUsageTotalsSchema.partial().default({}),
+  normalizedSnapshots: z.array(NormalizedUsageSnapshotSchema).default([]),
 });
 export type RunUsageAccumulatorJSON = z.infer<
   typeof RunUsageAccumulatorJSONSchema
 >;
-
-const DEFAULT_TOTALS: RunUsageTotals = {
-  firstInputTokens: 0,
-  totalInputTokens: 0,
-  totalOutputTokens: 0,
-  totalCost: 0,
-  totalCacheReadInputTokens: 0,
-  totalCacheCreationInputTokens: 0,
-  totalReasoningTokens: 0,
-  totalToolUsePromptTokens: 0,
-  totalServerToolRequests: 0,
-};
 
 export class RunUsageAccumulator {
   private totals: RunUsageTotals = { ...DEFAULT_TOTALS };
@@ -104,39 +113,36 @@ export class RunUsageAccumulator {
     return this.normalizedSnapshots;
   }
 
-  toJSON(): RunUsageAccumulatorJSON {
-    return {
-      totals: this.totals,
-      normalizedSnapshots:
-        this.normalizedSnapshots.length > 0
-          ? this.normalizedSnapshots
-          : undefined,
-    };
+  /** @internal Used by codec - prefer RunUsageAccumulatorCodec.encode() */
+  _setTotals(totals: RunUsageTotals): void {
+    this.totals = totals;
   }
 
-  static fromJSON(
-    json: RunUsageAccumulatorJSON | null | undefined,
-  ): RunUsageAccumulator {
-    const acc = new RunUsageAccumulator();
-    if (!json) return acc;
-
-    const t = json.totals;
-    acc.totals = {
-      firstInputTokens: t.firstInputTokens ?? 0,
-      totalInputTokens: t.totalInputTokens ?? 0,
-      totalOutputTokens: t.totalOutputTokens ?? 0,
-      totalCost: t.totalCost ?? 0,
-      totalCacheReadInputTokens: t.totalCacheReadInputTokens ?? 0,
-      totalCacheCreationInputTokens: t.totalCacheCreationInputTokens ?? 0,
-      totalReasoningTokens: t.totalReasoningTokens ?? 0,
-      totalToolUsePromptTokens: t.totalToolUsePromptTokens ?? 0,
-      totalServerToolRequests: t.totalServerToolRequests ?? 0,
-    };
-
-    if (json.normalizedSnapshots) {
-      acc.normalizedSnapshots.push(...json.normalizedSnapshots);
-    }
-
-    return acc;
+  /** @internal Used by codec - prefer RunUsageAccumulatorCodec.decode() */
+  _pushSnapshots(snapshots: NormalizedUsageSnapshot[]): void {
+    this.normalizedSnapshots.push(...snapshots);
   }
 }
+
+/**
+ * Codec for bi-directional serialization of RunUsageAccumulator.
+ * Use .encode() to serialize and .decode() to deserialize.
+ */
+export const RunUsageAccumulatorCodec = z.codec(
+  RunUsageAccumulatorJSONSchema,
+  z.instanceof(RunUsageAccumulator),
+  {
+    decode: (json: RunUsageAccumulatorJSON): RunUsageAccumulator => {
+      const acc = new RunUsageAccumulator();
+      // Schema handles defaults via .default() - parse partial totals to full totals
+      const totals = RunUsageTotalsSchema.parse(json.totals);
+      acc._setTotals(totals);
+      acc._pushSnapshots(json.normalizedSnapshots);
+      return acc;
+    },
+    encode: (acc: RunUsageAccumulator): RunUsageAccumulatorJSON => ({
+      totals: acc.getTotals(),
+      normalizedSnapshots: [...acc.getNormalizedSnapshots()],
+    }),
+  },
+);

--- a/src/agent/core/RunUsageAccumulator.ts
+++ b/src/agent/core/RunUsageAccumulator.ts
@@ -136,12 +136,11 @@ export const RunUsageAccumulatorCodec = z.codec(
   RunUsageAccumulatorJSONSchema,
   z.instanceof(RunUsageAccumulator),
   {
-    decode: (json: RunUsageAccumulatorJSON): RunUsageAccumulator => {
-      // Intentional re-parse: validates untrusted input and applies schema defaults
-      // for legacy snapshots that may be missing fields (e.g., normalizedSnapshots)
+    // Note: z.codec() does NOT auto-validate input before calling decode.
+    // We parse to apply schema defaults for legacy snapshots missing fields.
+    decode: (json): RunUsageAccumulator => {
       const parsed = RunUsageAccumulatorJSONSchema.parse(json);
       const acc = new RunUsageAccumulator();
-      // Schema handles defaults via .default() - parse partial totals to full totals
       const totals = RunUsageTotalsSchema.parse(parsed.totals);
       acc._setTotals(totals);
       acc._pushSnapshots(parsed.normalizedSnapshots);

--- a/src/agent/core/RunUsageAccumulator.ts
+++ b/src/agent/core/RunUsageAccumulator.ts
@@ -56,7 +56,11 @@ export const RunUsageAccumulatorJSONSchema = z.object({
   totals: RunUsageTotalsSchema.partial().default({}),
   normalizedSnapshots: z.array(NormalizedUsageSnapshotSchema).default([]),
 });
-export type RunUsageAccumulatorJSON = z.infer<
+/**
+ * Output type for RunUsageAccumulator serialization.
+ * Uses z.output<> to get the type after parsing (all fields required).
+ */
+export type RunUsageAccumulatorJSON = z.output<
   typeof RunUsageAccumulatorJSONSchema
 >;
 
@@ -133,11 +137,14 @@ export const RunUsageAccumulatorCodec = z.codec(
   z.instanceof(RunUsageAccumulator),
   {
     decode: (json: RunUsageAccumulatorJSON): RunUsageAccumulator => {
+      // Intentional re-parse: validates untrusted input and applies schema defaults
+      // for legacy snapshots that may be missing fields (e.g., normalizedSnapshots)
+      const parsed = RunUsageAccumulatorJSONSchema.parse(json);
       const acc = new RunUsageAccumulator();
       // Schema handles defaults via .default() - parse partial totals to full totals
-      const totals = RunUsageTotalsSchema.parse(json.totals);
+      const totals = RunUsageTotalsSchema.parse(parsed.totals);
       acc._setTotals(totals);
-      acc._pushSnapshots(json.normalizedSnapshots);
+      acc._pushSnapshots(parsed.normalizedSnapshots);
       return acc;
     },
     encode: (acc: RunUsageAccumulator): RunUsageAccumulatorJSON => ({

--- a/src/agent/core/RunUsageAccumulator.ts
+++ b/src/agent/core/RunUsageAccumulator.ts
@@ -72,7 +72,9 @@ export class RunUsageAccumulator {
   static fromSnapshot(snapshot: unknown): RunUsageAccumulator {
     const parsed = RunUsageAccumulatorJSONSchema.parse(snapshot);
     const acc = new RunUsageAccumulator();
-    // parsed.totals already has defaults from parent schema, just needs field defaults
+    // .partial().default({}) returns {} for missing totals, NOT the field defaults.
+    // Field-level defaults only apply when the field key is missing from a non-partial object.
+    // We need to spread DEFAULT_TOTALS to fill in any missing fields.
     acc.totals = { ...DEFAULT_TOTALS, ...parsed.totals };
     acc.normalizedSnapshots.push(...parsed.normalizedSnapshots);
     return acc;

--- a/src/agent/core/ToolUseCycle.ts
+++ b/src/agent/core/ToolUseCycle.ts
@@ -21,6 +21,7 @@ import { bus } from '@eventBus/ProgressEventBus';
 
 // Local file imports
 import { AgentSharedStore } from './AgentSharedStore';
+import { FileInteractionStateCodec } from './AgentWorkspaceState';
 import {
   createToolUseCycleFlow,
   type ToolUseCycleShared,
@@ -117,7 +118,7 @@ export async function runToolUseCycle<C = unknown>(
  */
 function emitEditedFiles<C>(input: ToolUseCycleInput<C>): void {
   const { options, store } = input;
-  const interactions = store.workspace.interactions.toJSON();
+  const interactions = FileInteractionStateCodec.encode(store.workspace.interactions);
 
   if (interactions.edits.length === 0) {
     return;

--- a/src/agent/core/ToolUseCycle.ts
+++ b/src/agent/core/ToolUseCycle.ts
@@ -21,13 +21,13 @@ import { bus } from '@eventBus/ProgressEventBus';
 
 // Local file imports
 import { AgentSharedStore } from './AgentSharedStore';
-import { FileInteractionStateCodec, type FileInteractionStateSnapshot } from './AgentWorkspaceState';
 import {
   createToolUseCycleFlow,
   type ToolUseCycleShared,
   type ToolUseCycleState,
 } from './flows/ToolUseCycleFlow';
 import { createRetryState } from './flows/RetryState';
+import type { FileInteractionStateSnapshot } from './AgentWorkspaceState';
 
 // Import and re-export from single source of truth
 import type { ToolUseCycleOptions } from './flows/CycleServices';
@@ -118,7 +118,7 @@ export async function runToolUseCycle<C = unknown>(
  */
 function emitEditedFiles<C>(input: ToolUseCycleInput<C>): void {
   const { options, store } = input;
-  const interactions = FileInteractionStateCodec.encode(store.workspace.interactions) as FileInteractionStateSnapshot;
+  const interactions: FileInteractionStateSnapshot = store.workspace.interactions.toSnapshot();
 
   if (interactions.edits.length === 0) {
     return;

--- a/src/agent/core/ToolUseCycle.ts
+++ b/src/agent/core/ToolUseCycle.ts
@@ -21,7 +21,7 @@ import { bus } from '@eventBus/ProgressEventBus';
 
 // Local file imports
 import { AgentSharedStore } from './AgentSharedStore';
-import { FileInteractionStateCodec } from './AgentWorkspaceState';
+import { FileInteractionStateCodec, type FileInteractionStateSnapshot } from './AgentWorkspaceState';
 import {
   createToolUseCycleFlow,
   type ToolUseCycleShared,
@@ -118,7 +118,7 @@ export async function runToolUseCycle<C = unknown>(
  */
 function emitEditedFiles<C>(input: ToolUseCycleInput<C>): void {
   const { options, store } = input;
-  const interactions = FileInteractionStateCodec.encode(store.workspace.interactions);
+  const interactions = FileInteractionStateCodec.encode(store.workspace.interactions) as FileInteractionStateSnapshot;
 
   if (interactions.edits.length === 0) {
     return;

--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -313,7 +313,7 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
     this.currentMessages = messages;
     this.currentRunState = runState;
     // Fresh workspace state per round - populated during execution
-    this.currentWorkspaceState = new AgentWorkspaceState();
+    this.currentWorkspaceState = AgentWorkspaceState.create();
     this.resetTransientUserVars({ CURRENT_ROUND: roundIndex });
   }
 

--- a/src/agent/implementations/BaseToolUseAgent.ts
+++ b/src/agent/implementations/BaseToolUseAgent.ts
@@ -259,7 +259,7 @@ export class BaseToolUseAgent<C = unknown> extends BaseAgent<C> {
     const store = createSharedStore({
       roundIndex: state.runState.totalRounds,
       runState: state.runState,
-      workspaceState: new AgentWorkspaceState(),
+      workspaceState: AgentWorkspaceState.create(),
       userChannels: this.getUserVarChannels(),
       onRoundFinalized: this.getUsageRecorder('tool-use'),
     });

--- a/src/agent/toolUse/ToolUseSnapshotStore.ts
+++ b/src/agent/toolUse/ToolUseSnapshotStore.ts
@@ -17,6 +17,7 @@ import {
 } from '@utils/config';
 
 // Local file imports
+import { AgentSharedStoreCodec } from '@agent/core/AgentSharedStore';
 import {
   TOOL_USE_SNAPSHOT_VERSION,
   ToolUseSessionSnapshotSchema,
@@ -100,7 +101,7 @@ export const ToolUseSnapshotStore = {
       streamId: payload.streamId,
       agentConfig: payload.agentConfig,
       messages: structuredClone(payload.messages),
-      store: payload.store.toJSON(),
+      store: AgentSharedStoreCodec.encode(payload.store),
       lastUpdated: Date.now(),
     } as const;
 

--- a/src/agent/toolUse/ToolUseSnapshotStore.ts
+++ b/src/agent/toolUse/ToolUseSnapshotStore.ts
@@ -6,7 +6,6 @@ import * as vscode from 'vscode';
 import { ZodError } from 'zod';
 
 // Local imports - agent
-import { AgentSharedStoreCodec } from '@agent/core/AgentSharedStore';
 import type { ExecutionId } from '@agent/types/IdentifierTypes';
 
 // Internal imports
@@ -99,7 +98,7 @@ export const ToolUseSnapshotStore = {
       streamId: payload.streamId,
       agentConfig: payload.agentConfig,
       messages: structuredClone(payload.messages),
-      store: AgentSharedStoreCodec.encode(payload.store),
+      store: payload.store.toSnapshot(),
       lastUpdated: Date.now(),
     } as const;
 

--- a/src/agent/toolUse/ToolUseSnapshotStore.ts
+++ b/src/agent/toolUse/ToolUseSnapshotStore.ts
@@ -5,7 +5,8 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import { ZodError } from 'zod';
 
-// Local imports - logging
+// Local imports - agent
+import { AgentSharedStoreCodec } from '@agent/core/AgentSharedStore';
 import type { ExecutionId } from '@agent/types/IdentifierTypes';
 
 // Internal imports
@@ -15,9 +16,6 @@ import {
   getToolUsePersistenceEnabled,
   getToolUsePersistenceTtlHours,
 } from '@utils/config';
-
-// Local file imports
-import { AgentSharedStoreCodec } from '@agent/core/AgentSharedStore';
 import {
   TOOL_USE_SNAPSHOT_VERSION,
   ToolUseSessionSnapshotSchema,

--- a/src/test/agent/core/ResponseCycleBackground.test.ts
+++ b/src/test/agent/core/ResponseCycleBackground.test.ts
@@ -323,7 +323,7 @@ describe('ResponseCycle background reasoning logs', () => {
     const messages: ProviderMessage[] = [];
     const stateRound = new ConversationRoundState(1);
     const stateGlobal = new AgentRunState();
-    const workspaceState = new AgentWorkspaceState();
+    const workspaceState = AgentWorkspaceState.create();
     const userVarChannels = {
       input: Object.freeze({}),
       transient: {} as Record<string, any>,

--- a/src/test/agent/toolUse/ToolUseFollowUpCoordinator.test.ts
+++ b/src/test/agent/toolUse/ToolUseFollowUpCoordinator.test.ts
@@ -7,7 +7,6 @@ import { AgentWorkspaceState } from '@agent/core/AgentWorkspaceState';
 import { AgentRunState } from '@agent/core/AgentState';
 import {
   createSharedStore,
-  AgentSharedStoreCodec,
   type AgentSharedStoreSnapshot,
 } from '@agent/core/AgentSharedStore';
 import {
@@ -45,7 +44,7 @@ describe('ToolUseFollowUpCoordinator', () => {
       session: { agentType: 'toolUse', agentCategory: 'toolUse' },
     }),
     messages: [],
-    store: AgentSharedStoreCodec.encode(store) as AgentSharedStoreSnapshot,
+    store: store.toSnapshot(),
     lastUpdated: Date.now(),
   };
 

--- a/src/test/agent/toolUse/ToolUseFollowUpCoordinator.test.ts
+++ b/src/test/agent/toolUse/ToolUseFollowUpCoordinator.test.ts
@@ -8,6 +8,7 @@ import { AgentRunState } from '@agent/core/AgentState';
 import {
   createSharedStore,
   AgentSharedStoreCodec,
+  type AgentSharedStoreSnapshot,
 } from '@agent/core/AgentSharedStore';
 import {
   resumeFromSnapshot,
@@ -44,7 +45,7 @@ describe('ToolUseFollowUpCoordinator', () => {
       session: { agentType: 'toolUse', agentCategory: 'toolUse' },
     }),
     messages: [],
-    store: AgentSharedStoreCodec.encode(store),
+    store: AgentSharedStoreCodec.encode(store) as AgentSharedStoreSnapshot,
     lastUpdated: Date.now(),
   };
 

--- a/src/test/agent/toolUse/ToolUseFollowUpCoordinator.test.ts
+++ b/src/test/agent/toolUse/ToolUseFollowUpCoordinator.test.ts
@@ -5,7 +5,10 @@ import { strict as assert } from 'assert';
 import { parseAgentConfig } from '@agent/core/AgentConfig';
 import { AgentWorkspaceState } from '@agent/core/AgentWorkspaceState';
 import { AgentRunState } from '@agent/core/AgentState';
-import { createSharedStore } from '@agent/core/AgentSharedStore';
+import {
+  createSharedStore,
+  AgentSharedStoreCodec,
+} from '@agent/core/AgentSharedStore';
 import {
   resumeFromSnapshot,
   sendFollowUp,
@@ -19,7 +22,7 @@ import { ToolUseSessionPersistence } from '@agent/toolUse/ToolUseSessionPersiste
 
 describe('ToolUseFollowUpCoordinator', () => {
   const streamId = 'stream-follow-up' as StreamTabId;
-  const workspace = new AgentWorkspaceState();
+  const workspace = AgentWorkspaceState.create();
   const store = createSharedStore({
     roundIndex: 0,
     runState: new AgentRunState(),
@@ -41,7 +44,7 @@ describe('ToolUseFollowUpCoordinator', () => {
       session: { agentType: 'toolUse', agentCategory: 'toolUse' },
     }),
     messages: [],
-    store: store.toJSON(),
+    store: AgentSharedStoreCodec.encode(store),
     lastUpdated: Date.now(),
   };
 

--- a/src/test/tools/BashTool.test.ts
+++ b/src/test/tools/BashTool.test.ts
@@ -142,7 +142,7 @@ describe('BashTool', () => {
       openRouterOnly: false,
     };
     const handler = new BashMockHandler(config);
-    const workspaceState = new AgentWorkspaceState();
+    const workspaceState = AgentWorkspaceState.create();
     const options: ToolUseCycleOptions<OpenAI> = {
       modelHandler: handler,
       agentSetting: {


### PR DESCRIPTION
Migrate all state serialization classes to use Zod 4.1 codecs for
bi-directional serialization. This provides a more native and graceful
approach that leverages Zod's built-in capabilities.

Changes:
- Add explicit codecs (RunUsageAccumulatorCodec, ConversationRoundStateCodec,
  AgentRunStateCodec, FileInteractionStateCodec, TodoStateCodec,
  AgentWorkspaceStateCodec, AgentSharedStoreCodec)
- Remove manual toJSON/fromJSON methods in favor of codec.encode()/decode()
- Use schema defaults instead of manual fallback values
- Handle legacy format migration (media files) via nested codecs
- Make AgentWorkspaceState constructor private, add factory method
- Update all consumers to use new codec API

Benefits:
- Single source of truth for serialization logic in schemas
- Automatic validation during decode
- Type-safe encode/decode with explicit type annotations
- Cleaner legacy format handling via codec composition

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace manual toJSON/fromJSON with Zod-based fromSnapshot/toSnapshot across agent state, add schema defaults and legacy media normalization, and update consumers/tests.
> 
> - **Core serialization**:
>   - Add `SnapshotSchema` + `fromSnapshot`/`toSnapshot` for `ConversationRoundState`, `AgentRunState`, `RunUsageAccumulator`, `AgentWorkspaceState` (and nested: assembly, interactions, media, reasoning, document, todos), and `AgentSharedStore`.
>   - Apply schema defaults; remove manual JSON serializers; normalize legacy media entries to `FileLocation`.
>   - Introduce `AgentWorkspaceState.create()` factory (constructor effectively internalized).
>   - Add `AgentSharedStore.setOnRoundFinalized()` and switch to private `_onRoundFinalized`.
> - **Consumers**:
>   - Update `ToolUseCycle` to use `interactions.toSnapshot()`; emit edited files via snapshot type.
>   - Persist sessions via `store.toSnapshot()` in `ToolUseSnapshotStore`.
>   - Use `AgentWorkspaceState.create()` in `BaseReflectionAgent` and `BaseToolUseAgent`; create shared stores from snapshots.
> - **Tests**:
>   - Migrate tests to `AgentWorkspaceState.create()` and `store.toSnapshot()`; adjust snapshots/types accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c9c3a73067b05ec790e10d81ea466c5d33e0007f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->