### PR TITLE
Make delete button always visible

### DIFF
--- a/src/progressView/styles/tabs.css
+++ b/src/progressView/styles/tabs.css
@@ -54,7 +54,7 @@
   flex-direction: column;
   align-items: flex-start;
   padding-top: var(--spacing-small);
-  padding-right: calc(var(--spacing-medium) + var(--height-control));
+  padding-right: var(--spacing-small);
   padding-bottom: var(--spacing-small);
   padding-left: var(--spacing-small);
   cursor: pointer;
@@ -102,16 +102,14 @@
 }
 
 .tab-delete {
-  position: absolute;
-  top: 50%;
-  right: var(--spacing-small);
-  transform: translateY(-50%);
+  flex-shrink: 0;
   display: flex;
   align-items: center;
   justify-content: center;
   width: var(--height-control);
   height: var(--height-control);
   margin: 0;
+  margin-right: var(--spacing-small);
   color: var(--vscode-icon-foreground, var(--vscode-foreground));
   transition: color 120ms ease;
 }


### PR DESCRIPTION
Changed tab delete button from absolute positioning to flex layout so it's always visible regardless of panel width.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches `.tab-delete` to a flex item and reduces `.tab` right padding to ensure the delete button remains visible across panel widths.
> 
> - **Styles (`src/progressView/styles/tabs.css`)**:
>   - Switch ``.tab-delete`` from absolute positioning to flex item (adds ``flex-shrink: 0``, fixed control size, right margin; removes absolute/top/right/transform).
>   - Reduce ``.tab`` right padding to ``var(--spacing-small)`` to accommodate the delete button within the layout.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bcaeed49ec363e8f1c5ef122861126a4670e0b37. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->