### PR TITLE
fix: force delete button visibility on stream tabs

### DIFF
--- a/src/progressView/styles/tabs.css
+++ b/src/progressView/styles/tabs.css
@@ -11,7 +11,7 @@
   font-size: var(--font-size-sm);
   border-left: var(--border-thin) solid var(--vscode-panel-border);
   height: 100%;
-  overflow: hidden;
+  overflow: visible;
   background-color: var(--background-color);
 }
 
@@ -103,10 +103,13 @@
 
 .tab-delete {
   flex-shrink: 0;
-  display: flex;
+  display: flex !important;
+  visibility: visible !important;
+  opacity: 1 !important;
   align-items: center;
   justify-content: center;
   width: var(--height-control);
+  min-width: var(--height-control);
   height: var(--height-control);
   margin: 0;
   margin-right: var(--spacing-small);


### PR DESCRIPTION
- Add !important rules to ensure button stays visible
- Set overflow: visible on tabs container to prevent clipping
- Add min-width to prevent button collapse

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures the stream tab delete button is always visible and not clipped by making the tabs container overflow visible and enforcing button visibility/min-width.
> 
> - **Styles (`src/progressView/styles/tabs.css`)**:
>   - Set `.tabs` `overflow: visible` to avoid clipping.
>   - Enforce `.tab-delete` visibility with `display/visibility/opacity: !important` and add `min-width` to prevent collapse.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f3869ed50bd7f0f09e56a258f19da0ece5dd516f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->