### PR TITLE
Replace type casts with native SDK helpers

### DIFF
--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -616,6 +616,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
         output?.finalize(finalOutputText);
 
         // Ensure text field excludes thinking content
+        // Part.thought is a native property of the Google GenAI SDK Part interface
         const candidateContent = baseResponse.candidates?.[0]?.content;
         if (candidateContent?.parts) {
           const filteredParts = candidateContent.parts.filter(

--- a/src/agent/remote/RemoteAgentLoader.ts
+++ b/src/agent/remote/RemoteAgentLoader.ts
@@ -183,9 +183,11 @@ export class RemoteAgentLoader {
         const prompts: Partial<AgentPrompt> = validated.prompts || {};
 
         // Resolve tool names to definitions
+        // tools can be strings (tool names) or partial ToolDefinitions from YAML
         if (Array.isArray(settings.tools)) {
           const { DEFAULT_TOOL_REGISTRY } = await import('@tools/registry');
-          settings.tools = (settings.tools as any[]).map((item) => {
+          const rawTools = settings.tools as (string | { name: string })[];
+          settings.tools = rawTools.map((item) => {
             if (typeof item === 'string') {
               const tool = DEFAULT_TOOL_REGISTRY[item];
               if (!tool) {

--- a/src/agent/remote/RemoteAgentLoader.ts
+++ b/src/agent/remote/RemoteAgentLoader.ts
@@ -10,7 +10,6 @@ import {
 } from '@agent/core/AgentDataclass';
 import { getMultipleName, getBaseName } from '@agent/index/agentRegistry';
 import * as logger from '@logger/logUtils';
-import type { ToolDefinition } from '@model';
 import { SupabaseClient } from '@/auth/SupabaseClient';
 import { SUPABASE_CONFIG } from '@/auth/config';
 
@@ -182,25 +181,14 @@ export class RemoteAgentLoader {
         const settings: Partial<AgentSetting> = validated.settings || {};
         const prompts: Partial<AgentPrompt> = validated.prompts || {};
 
-        // Resolve tool names to definitions
-        // tools can be strings (tool names) or partial ToolDefinitions from YAML
+        // Resolve tool names to definitions using shared utility
         if (Array.isArray(settings.tools)) {
-          const { DEFAULT_TOOL_REGISTRY } = await import('@tools/registry');
-          const rawTools = settings.tools as (string | { name: string })[];
-          settings.tools = rawTools.map((item) => {
-            if (typeof item === 'string') {
-              const tool = DEFAULT_TOOL_REGISTRY[item];
-              if (!tool) {
-                logger.warn(CHANNEL, `Tool "${item}" not found in registry`);
-                return { name: item } as ToolDefinition;
-              }
-              return tool.definition;
-            }
-            if (!DEFAULT_TOOL_REGISTRY[item.name]) {
-              logger.warn(CHANNEL, `Tool "${item.name}" not found in registry`);
-            }
-            return item as ToolDefinition;
-          });
+          const { resolveToolDefinitions } = await import('@tools/registry');
+          settings.tools = resolveToolDefinitions(
+            settings.tools as (string | { name: string })[],
+            (name) =>
+              logger.warn(CHANNEL, `Tool "${name}" not found in registry`),
+          );
         }
 
         const validatedSettings = parseAgentSetting(settings);

--- a/src/agent/runtime/agentLoad.ts
+++ b/src/agent/runtime/agentLoad.ts
@@ -166,9 +166,11 @@ export async function loadAgentSettingAndPrompts(
     ensureAgentTypeForSource(settings, entry.source);
 
     // Resolve tool names to definitions
+    // tools can be strings (tool names) or partial ToolDefinitions from YAML
     if (Array.isArray(settings.tools)) {
       const { DEFAULT_TOOL_REGISTRY } = await import('@tools/registry');
-      settings.tools = (settings.tools as any[]).map((item) => {
+      const rawTools = settings.tools as (string | { name: string })[];
+      settings.tools = rawTools.map((item) => {
         if (typeof item === 'string') {
           const tool = DEFAULT_TOOL_REGISTRY[item];
           if (!tool) {

--- a/src/agent/runtime/agentLoad.ts
+++ b/src/agent/runtime/agentLoad.ts
@@ -24,9 +24,6 @@ import {
 import { toErrorMessage } from '@common/errors/errorHandlingUtils';
 import * as logger from '@logger/logUtils';
 
-// Type imports
-import type { ToolDefinition } from '@model';
-
 // Internal imports
 import { AbsoluteFS } from '@utils/files';
 
@@ -165,25 +162,13 @@ export async function loadAgentSettingAndPrompts(
 
     ensureAgentTypeForSource(settings, entry.source);
 
-    // Resolve tool names to definitions
-    // tools can be strings (tool names) or partial ToolDefinitions from YAML
+    // Resolve tool names to definitions using shared utility
     if (Array.isArray(settings.tools)) {
-      const { DEFAULT_TOOL_REGISTRY } = await import('@tools/registry');
-      const rawTools = settings.tools as (string | { name: string })[];
-      settings.tools = rawTools.map((item) => {
-        if (typeof item === 'string') {
-          const tool = DEFAULT_TOOL_REGISTRY[item];
-          if (!tool) {
-            logger.warn(CHANNEL, `Tool "${item}" not found in registry`);
-            return { name: item } as ToolDefinition;
-          }
-          return tool.definition;
-        }
-        if (!DEFAULT_TOOL_REGISTRY[item.name]) {
-          logger.warn(CHANNEL, `Tool "${item.name}" not found in registry`);
-        }
-        return item as ToolDefinition;
-      });
+      const { resolveToolDefinitions } = await import('@tools/registry');
+      settings.tools = resolveToolDefinitions(
+        settings.tools as (string | { name: string })[],
+        (name) => logger.warn(CHANNEL, `Tool "${name}" not found in registry`),
+      );
     }
 
     // Apply defaults and validate the final settings and prompts

--- a/src/agent/utils/messageSkeletonUtils.ts
+++ b/src/agent/utils/messageSkeletonUtils.ts
@@ -93,9 +93,12 @@ export function messageToSkeleton(
       value !== undefined
     ) {
       // Recursively process nested objects
-      // Note: We pass 'any' here since nested properties within a message
-      // are not necessarily ProviderMessage instances themselves
-      result[key] = messageToSkeleton(value as any, maxContentLength);
+      // Nested properties are typed as ProviderMessage for the recursive call
+      // though they may not strictly conform - the function handles this gracefully
+      result[key] = messageToSkeleton(
+        value as ProviderMessage,
+        maxContentLength,
+      );
     } else {
       // Pass through primitive values
       result[key] = value;

--- a/src/agent/utils/messageSkeletonUtils.ts
+++ b/src/agent/utils/messageSkeletonUtils.ts
@@ -16,8 +16,16 @@ import { MESSAGE_PREVIEW_LENGTH } from '@utils/config';
  */
 export function messageToSkeleton(
   message: ProviderMessage | ProviderMessage[],
+  maxContentLength?: number,
+): unknown;
+export function messageToSkeleton(
+  message: Record<string, unknown>,
+  maxContentLength?: number,
+): unknown;
+export function messageToSkeleton(
+  message: ProviderMessage | ProviderMessage[] | Record<string, unknown>,
   maxContentLength: number = MESSAGE_PREVIEW_LENGTH,
-): any {
+): unknown {
   if (!message) {
     return null;
   }
@@ -30,40 +38,54 @@ export function messageToSkeleton(
     return typeof message;
   }
 
-  const result: any = {};
+  const result: Record<string, unknown> = {};
 
   for (const [key, value] of Object.entries(message)) {
     if (key === 'content') {
       if (Array.isArray(value)) {
         // Handle content arrays (common in Anthropic responses)
-        result[key] = value.map((item: any) => {
-          if (typeof item === 'object') {
-            const itemSkeleton: any = { type: item.type };
+        result[key] = value.map((item: unknown) => {
+          if (typeof item === 'object' && item !== null) {
+            const typedItem = item as Record<string, unknown>;
+            const itemSkeleton: Record<string, unknown> = {
+              type: typedItem.type,
+            };
 
-            if (item.text) {
+            if (
+              typeof typedItem.text === 'string' &&
+              typedItem.text.length > 0
+            ) {
+              const text = typedItem.text;
               const truncatedText =
-                item.text.length > maxContentLength
-                  ? `${item.text.substring(0, maxContentLength)}... (${item.text.length} chars)`
-                  : item.text;
+                text.length > maxContentLength
+                  ? `${text.substring(0, maxContentLength)}... (${text.length} chars)`
+                  : text;
               itemSkeleton.text = truncatedText;
             }
 
-            if (item.source) {
-              itemSkeleton.source = { type: item.source.type };
-              if (item.source.media_type) {
-                itemSkeleton.source.media_type = item.source.media_type;
+            if (
+              typeof typedItem.source === 'object' &&
+              typedItem.source !== null
+            ) {
+              const source = typedItem.source as Record<string, unknown>;
+              const sourceSkeleton: Record<string, unknown> = {
+                type: source.type,
+              };
+              if (source.media_type) {
+                sourceSkeleton.media_type = source.media_type;
               }
-              if (item.source.data) {
-                itemSkeleton.source.data = `[base64 data: ${item.source.data.length} chars]`;
+              if (typeof source.data === 'string') {
+                sourceSkeleton.data = `[base64 data: ${source.data.length} chars]`;
               }
+              itemSkeleton.source = sourceSkeleton;
             }
 
-            if (item.cache_control) {
-              itemSkeleton.cache_control = item.cache_control;
+            if (typedItem.cache_control) {
+              itemSkeleton.cache_control = typedItem.cache_control;
             }
 
-            if (item.thinking) {
-              itemSkeleton.thinking = `[thinking data: ${item.thinking.length} chars]`;
+            if (typeof typedItem.thinking === 'string') {
+              itemSkeleton.thinking = `[thinking data: ${typedItem.thinking.length} chars]`;
             }
 
             return itemSkeleton;
@@ -92,9 +114,11 @@ export function messageToSkeleton(
       value !== null &&
       value !== undefined
     ) {
-      // Recursively process nested objects - function handles arbitrary structures
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      result[key] = messageToSkeleton(value as any, maxContentLength);
+      // Recursively process nested objects using Record<string, unknown> overload
+      result[key] = messageToSkeleton(
+        value as Record<string, unknown>,
+        maxContentLength,
+      );
     } else {
       // Pass through primitive values
       result[key] = value;

--- a/src/agent/utils/messageSkeletonUtils.ts
+++ b/src/agent/utils/messageSkeletonUtils.ts
@@ -92,13 +92,9 @@ export function messageToSkeleton(
       value !== null &&
       value !== undefined
     ) {
-      // Recursively process nested objects
-      // Nested properties are typed as ProviderMessage for the recursive call
-      // though they may not strictly conform - the function handles this gracefully
-      result[key] = messageToSkeleton(
-        value as ProviderMessage,
-        maxContentLength,
-      );
+      // Recursively process nested objects - function handles arbitrary structures
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      result[key] = messageToSkeleton(value as any, maxContentLength);
     } else {
       // Pass through primitive values
       result[key] = value;

--- a/src/commands/files/fileSelectionCommands.ts
+++ b/src/commands/files/fileSelectionCommands.ts
@@ -19,10 +19,13 @@ interface PickerOptions<Many extends boolean> {
   filters: () => { [name: string]: string[] };
 }
 
+/** Conditional return type for file picker functions */
+type PickerResult<Many extends boolean> = Many extends true
+  ? string[] | null
+  : string | null;
+
 function createPicker<Many extends boolean>(options: PickerOptions<Many>) {
-  return async (
-    currentFile?: string,
-  ): Promise<Many extends true ? string[] | null : string | null> => {
+  return async (currentFile?: string): Promise<PickerResult<Many>> => {
     try {
       const baseOpts = {
         currentFile,
@@ -35,7 +38,8 @@ function createPicker<Many extends boolean>(options: PickerOptions<Many>) {
         : await selectFile(baseOpts);
 
       if (!result) {
-        return null as any;
+        // TypeScript cannot narrow conditional types at runtime
+        return null as PickerResult<Many>;
       }
 
       const message = Array.isArray(result)
@@ -43,10 +47,10 @@ function createPicker<Many extends boolean>(options: PickerOptions<Many>) {
         : `Selected file: ${result}`;
       showInfoMessage(message);
       logger.info(CHANNEL, message);
-      return result as any;
+      return result as PickerResult<Many>;
     } catch (err) {
       await showLoggedErrorMessage(CHANNEL, 'Error selecting files', err);
-      return null as any;
+      return null as PickerResult<Many>;
     }
   };
 }

--- a/src/commands/files/fileSelectionCommands.ts
+++ b/src/commands/files/fileSelectionCommands.ts
@@ -26,6 +26,9 @@ type PickerResult<Many extends boolean> = Many extends true
 
 function createPicker<Many extends boolean>(options: PickerOptions<Many>) {
   return async (currentFile?: string): Promise<PickerResult<Many>> => {
+    // TypeScript cannot narrow conditional types at runtime, so we need this cast
+    const nullResult = null as PickerResult<Many>;
+
     try {
       const baseOpts = {
         currentFile,
@@ -38,8 +41,7 @@ function createPicker<Many extends boolean>(options: PickerOptions<Many>) {
         : await selectFile(baseOpts);
 
       if (!result) {
-        // TypeScript cannot narrow conditional types at runtime
-        return null as PickerResult<Many>;
+        return nullResult;
       }
 
       const message = Array.isArray(result)
@@ -50,7 +52,7 @@ function createPicker<Many extends boolean>(options: PickerOptions<Many>) {
       return result as PickerResult<Many>;
     } catch (err) {
       await showLoggedErrorMessage(CHANNEL, 'Error selecting files', err);
-      return null as PickerResult<Many>;
+      return nullResult;
     }
   };
 }

--- a/src/commands/system/textEditorCommands.ts
+++ b/src/commands/system/textEditorCommands.ts
@@ -2,7 +2,11 @@
 import * as vscode from 'vscode';
 
 // Local imports - Anthropic Tool
-import { TextEditorTool, ToolCallInput, type EditorCommand } from '@agent/toolUse';
+import {
+  TextEditorTool,
+  ToolCallInput,
+  type EditorCommand,
+} from '@agent/toolUse';
 import { showLoggedErrorMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
 import { WorkspaceFS } from '@utils/files';
@@ -59,7 +63,10 @@ async function handleTestTextEditor(): Promise<void> {
 
     // Prepare input based on selected command
     // Type assertion is safe because showQuickPick options match EditorCommand values
-    const input: ToolCallInput = { command: command as EditorCommand, path: filePath };
+    const input: ToolCallInput = {
+      command: command as EditorCommand,
+      path: filePath,
+    };
 
     switch (command) {
       case 'view':

--- a/src/commands/system/textEditorCommands.ts
+++ b/src/commands/system/textEditorCommands.ts
@@ -2,7 +2,7 @@
 import * as vscode from 'vscode';
 
 // Local imports - Anthropic Tool
-import { TextEditorTool, ToolCallInput } from '@agent/toolUse';
+import { TextEditorTool, ToolCallInput, type EditorCommand } from '@agent/toolUse';
 import { showLoggedErrorMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
 import { WorkspaceFS } from '@utils/files';
@@ -58,7 +58,8 @@ async function handleTestTextEditor(): Promise<void> {
     );
 
     // Prepare input based on selected command
-    const input: ToolCallInput = { command: command as any, path: filePath };
+    // Type assertion is safe because showQuickPick options match EditorCommand values
+    const input: ToolCallInput = { command: command as EditorCommand, path: filePath };
 
     switch (command) {
       case 'view':

--- a/src/logger/AgentLogger.ts
+++ b/src/logger/AgentLogger.ts
@@ -362,8 +362,14 @@ export class AgentLogger {
   /**
    * Log missing output information.
    */
-  missingOutputs(info: unknown, groupId?: string): void {
-    const missing = (info as any).missing as unknown[] | undefined;
+  missingOutputs(
+    info: { missing?: unknown[] } | unknown,
+    groupId?: string,
+  ): void {
+    const missing =
+      typeof info === 'object' && info !== null && 'missing' in info
+        ? (info as { missing?: unknown[] }).missing
+        : undefined;
     const count = missing?.length ?? 0;
     const summary = `${count} output file${count === 1 ? '' : 's'} missing`;
     this.info(summary, {

--- a/src/logger/AgentLogger.ts
+++ b/src/logger/AgentLogger.ts
@@ -362,10 +362,7 @@ export class AgentLogger {
   /**
    * Log missing output information.
    */
-  missingOutputs(
-    info: { missing?: unknown[] } | unknown,
-    groupId?: string,
-  ): void {
+  missingOutputs(info: unknown, groupId?: string): void {
     const missing =
       typeof info === 'object' && info !== null && 'missing' in info
         ? (info as { missing?: unknown[] }).missing

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -118,7 +118,7 @@ export type RawToolConfig =
  * Handles both string names (resolved from registry) and partial definitions.
  *
  * @param tools - Array of raw tool configs (strings or objects with name)
- * @param warnOnMissing - Optional callback for logging warnings about missing tools
+ * @param warnOnMissing - Optional callback for logging warnings about missing/invalid tools
  * @returns Array of resolved ToolDefinition objects
  */
 export function resolveToolDefinitions(
@@ -127,10 +127,10 @@ export function resolveToolDefinitions(
 ): ToolDefinition[] {
   return tools.map((item): ToolDefinition => {
     if (typeof item === 'string') {
-      // Validate tool name format
+      // Validate tool name format - warn but preserve original name for debugging
       if (!isValidToolName(item)) {
-        warnOnMissing?.(`Invalid tool name format: "${item}"`);
-        return { name: 'invalid_tool' };
+        warnOnMissing?.(item);
+        return { name: item };
       }
       const tool = DEFAULT_TOOL_REGISTRY[item];
       if (!tool) {
@@ -139,10 +139,10 @@ export function resolveToolDefinitions(
       }
       return tool.definition;
     }
-    // Validate tool name format for object form
+    // Validate tool name format for object form - warn but preserve original name
     if (!isValidToolName(item.name)) {
-      warnOnMissing?.(`Invalid tool name format: "${item.name}"`);
-      return { name: 'invalid_tool' };
+      warnOnMissing?.(item.name);
+      return { name: item.name };
     }
     if (!DEFAULT_TOOL_REGISTRY[item.name]) {
       warnOnMissing?.(item.name);

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -3,7 +3,10 @@ import type { ITool, IToolRegistry } from '@agent/core/ToolTypes';
 import { createToolRegistry } from '@agent/core/ToolTypes';
 
 // Local imports - model types
-import type { ToolDefinition } from '@model/ToolDefinition';
+import {
+  ToolDefinitionSchema,
+  type ToolDefinition,
+} from '@model/ToolDefinition';
 
 // Local imports - tools
 import { BashTool } from './bash';
@@ -91,8 +94,11 @@ export const DEFAULT_TOOL_REGISTRY: Record<string, ITool> = DEFAULT_TOOLS;
 
 /**
  * Raw tool configuration from YAML - can be a string name or partial definition.
+ * Object form must have a name and can include optional description/parameters.
  */
-export type RawToolConfig = string | { name: string; [key: string]: unknown };
+export type RawToolConfig =
+  | string
+  | (Partial<ToolDefinition> & { name: string });
 
 /**
  * Resolve raw tool configurations to ToolDefinition objects.
@@ -118,6 +124,12 @@ export function resolveToolDefinitions(
     if (!DEFAULT_TOOL_REGISTRY[item.name]) {
       warnOnMissing?.(item.name);
     }
-    return item as ToolDefinition;
+    // Validate against schema - if invalid, return minimal definition
+    const parsed = ToolDefinitionSchema.safeParse(item);
+    if (parsed.success) {
+      return parsed.data as ToolDefinition;
+    }
+    // Fallback: return just the name if validation fails
+    return { name: item.name };
   });
 }

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -2,6 +2,9 @@
 import type { ITool, IToolRegistry } from '@agent/core/ToolTypes';
 import { createToolRegistry } from '@agent/core/ToolTypes';
 
+// Local imports - model types
+import type { ToolDefinition } from '@model/ToolDefinition';
+
 // Local imports - tools
 import { BashTool } from './bash';
 import { DiagnosticsTool } from './DiagnosticsTool';
@@ -85,3 +88,36 @@ export function resetDefaultToolRegistry(): void {
  * @deprecated Prefer getDefaultToolRegistry() for IToolRegistry interface.
  */
 export const DEFAULT_TOOL_REGISTRY: Record<string, ITool> = DEFAULT_TOOLS;
+
+/**
+ * Raw tool configuration from YAML - can be a string name or partial definition.
+ */
+export type RawToolConfig = string | { name: string; [key: string]: unknown };
+
+/**
+ * Resolve raw tool configurations to ToolDefinition objects.
+ * Handles both string names (resolved from registry) and partial definitions.
+ *
+ * @param tools - Array of raw tool configs (strings or objects with name)
+ * @param warnOnMissing - Optional callback for logging warnings about missing tools
+ * @returns Array of resolved ToolDefinition objects
+ */
+export function resolveToolDefinitions(
+  tools: RawToolConfig[],
+  warnOnMissing?: (toolName: string) => void,
+): ToolDefinition[] {
+  return tools.map((item): ToolDefinition => {
+    if (typeof item === 'string') {
+      const tool = DEFAULT_TOOL_REGISTRY[item];
+      if (!tool) {
+        warnOnMissing?.(item);
+        return { name: item };
+      }
+      return tool.definition;
+    }
+    if (!DEFAULT_TOOL_REGISTRY[item.name]) {
+      warnOnMissing?.(item.name);
+    }
+    return item as ToolDefinition;
+  });
+}

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -93,6 +93,19 @@ export function resetDefaultToolRegistry(): void {
 export const DEFAULT_TOOL_REGISTRY: Record<string, ITool> = DEFAULT_TOOLS;
 
 /**
+ * Valid tool name pattern: starts with letter/underscore, followed by alphanumeric/underscores.
+ */
+const VALID_TOOL_NAME_PATTERN = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
+
+/**
+ * Validates a tool name contains only allowed characters.
+ * @returns true if valid, false otherwise
+ */
+function isValidToolName(name: string): boolean {
+  return VALID_TOOL_NAME_PATTERN.test(name);
+}
+
+/**
  * Raw tool configuration from YAML - can be a string name or partial definition.
  * Object form must have a name and can include optional description/parameters.
  */
@@ -114,6 +127,11 @@ export function resolveToolDefinitions(
 ): ToolDefinition[] {
   return tools.map((item): ToolDefinition => {
     if (typeof item === 'string') {
+      // Validate tool name format
+      if (!isValidToolName(item)) {
+        warnOnMissing?.(`Invalid tool name format: "${item}"`);
+        return { name: 'invalid_tool' };
+      }
       const tool = DEFAULT_TOOL_REGISTRY[item];
       if (!tool) {
         warnOnMissing?.(item);
@@ -121,10 +139,17 @@ export function resolveToolDefinitions(
       }
       return tool.definition;
     }
+    // Validate tool name format for object form
+    if (!isValidToolName(item.name)) {
+      warnOnMissing?.(`Invalid tool name format: "${item.name}"`);
+      return { name: 'invalid_tool' };
+    }
     if (!DEFAULT_TOOL_REGISTRY[item.name]) {
       warnOnMissing?.(item.name);
     }
     // Validate against schema - if invalid, return minimal definition
+    // Note: Cast is safe because ToolDefinitionSchema validates structure;
+    // ToolDefinition type adds provider-specific param types that are additive.
     const parsed = ToolDefinitionSchema.safeParse(item);
     if (parsed.success) {
       return parsed.data as ToolDefinition;

--- a/src/utils/system/execUtils.ts
+++ b/src/utils/system/execUtils.ts
@@ -2,6 +2,20 @@
 import { execa, type Options, ExecaError } from 'execa';
 import { quote as shellQuote } from 'shell-quote';
 
+/**
+ * Encoding options compatible with execa v9.
+ * execa uses a stricter encoding type than Node's BufferEncoding.
+ */
+type ExecaEncodingOption =
+  | 'utf8'
+  | 'utf16le'
+  | 'buffer'
+  | 'hex'
+  | 'base64'
+  | 'base64url'
+  | 'latin1'
+  | 'ascii';
+
 // Local imports - log
 import type { ExecResult } from '@agent/types/ResultTypes';
 
@@ -66,15 +80,16 @@ export async function executeCommand(
       : { ...process.env };
     env.PATH = extendEnvPath(env.PATH);
 
-    const encodingOption: BufferEncoding =
+    // Normalize 'utf-8' to 'utf8' for execa compatibility
+    const encodingOption: ExecaEncodingOption =
       options.encoding && options.encoding.toLowerCase() === 'utf-8'
         ? 'utf8'
-        : (options.encoding ?? 'utf8');
+        : ((options.encoding ?? 'utf8') as ExecaEncodingOption);
 
     const execaOptions: Options = {
       cwd: workspacePath,
       env,
-      encoding: encodingOption as any, // execa v9 type compatibility
+      encoding: encodingOption,
       timeout: options.timeout,
       reject: false,
       input: options.stdin,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Centralizes tool resolution via a shared validator, filters Gemini thought parts from Google responses, improves typings and safety, and aligns exec encoding with execa.
> 
> - **Google GenAI handler**:
>   - Filters out `Part.thought` from `candidates[0].content.parts` to ensure `text` excludes thinking content.
>   - Streams aggregate parts/text and preserves usage; logs and finalizes clean output.
> - **Tools registry**:
>   - Adds `resolveToolDefinitions()` with `ToolDefinitionSchema` validation and tool-name format checks.
>   - Exposes `RawToolConfig` and validates/normalizes unknown tools; keeps `DEFAULT_TOOL_REGISTRY` for backward-compat.
>   - Migrates tool resolution in `@agent/runtime/agentLoad` and `@agent/remote/RemoteAgentLoader` to shared helper.
> - **Typing and safety**:
>   - Strengthens types in `messageSkeletonUtils` (overloads, `Record<string, unknown>` usage).
>   - Improves `fileSelectionCommands` with conditional return type (`PickerResult`) and safer null handling.
>   - Narrows types in `textEditorCommands` (`EditorCommand` cast) and `AgentLogger.missingOutputs` safe access.
> - **System utils**:
>   - Introduces `ExecaEncodingOption` and normalizes `'utf-8'` to `'utf8'` for execa v9 compatibility.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9a62d063fb6ccfc0cbc1a02dec0df27943581b9a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->