### PR TITLE
feat: add openrouter sdk handler

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@google/genai": "^1.34.0",
         "@jamesgopsill/crossref-client": "^1.1.0",
         "@modelcontextprotocol/sdk": "^1.25.1",
+        "@openrouter/sdk": "^0.3.7",
         "@supabase/supabase-js": "^2.88.0",
         "@vscode-elements/elements": "^2.3.1",
         "@vscode/codicons": "^0.0.44",
@@ -863,6 +864,15 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
+    },
+    "node_modules/@openrouter/sdk": {
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/@openrouter/sdk/-/sdk-0.3.7.tgz",
+      "integrity": "sha512-jHR7ive7s17kwnE/9+PHXkwKwObEn+hEuW52v8bBkn76insdF3nCcN1xkotHR4i87zLJc8SwE0/2vQsPIAkvnA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      }
     },
     "node_modules/@pdf-lib/standard-fonts": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -1642,6 +1642,7 @@
     "@google/genai": "^1.34.0",
     "@jamesgopsill/crossref-client": "^1.1.0",
     "@modelcontextprotocol/sdk": "^1.25.1",
+    "@openrouter/sdk": "^0.3.7",
     "@supabase/supabase-js": "^2.88.0",
     "@vscode-elements/elements": "^2.3.1",
     "@vscode/codicons": "^0.0.44",

--- a/src/agent/core/AgentState.ts
+++ b/src/agent/core/AgentState.ts
@@ -131,7 +131,9 @@ export const AgentRunStateSnapshotSchema = z.object({
  * Single source of truth for AgentRunState serialization format.
  * Uses z.output<> to get the type after parsing (all fields required).
  */
-export type AgentRunStateSnapshot = z.output<typeof AgentRunStateSnapshotSchema>;
+export type AgentRunStateSnapshot = z.output<
+  typeof AgentRunStateSnapshotSchema
+>;
 
 export class AgentRunState {
   public totalRounds: number;
@@ -147,7 +149,9 @@ export class AgentRunState {
   /** Deserialize from a snapshot. Validates and applies schema defaults. */
   static fromSnapshot(snapshot: unknown): AgentRunState {
     const parsed = AgentRunStateSnapshotSchema.parse(snapshot);
-    const usageAccumulator = RunUsageAccumulator.fromSnapshot(parsed.usageAccumulator);
+    const usageAccumulator = RunUsageAccumulator.fromSnapshot(
+      parsed.usageAccumulator,
+    );
     const state = new AgentRunState(usageAccumulator);
     state.totalRounds = parsed.totalRounds;
     state.totalResponseTimeMs = parsed.totalResponseTimeMs;

--- a/src/agent/core/AgentWorkspaceState.ts
+++ b/src/agent/core/AgentWorkspaceState.ts
@@ -28,7 +28,9 @@ export const ResponseAssemblyStateSnapshotSchema = z.object({
   lastResponse: z.string().default(''),
   accumulatedOutput: z.string().default(''),
 });
-export type ResponseAssemblyStateSnapshot = z.output<typeof ResponseAssemblyStateSnapshotSchema>;
+export type ResponseAssemblyStateSnapshot = z.output<
+  typeof ResponseAssemblyStateSnapshotSchema
+>;
 
 /**
  * Workspace assembly state keeps track of the model's textual output so the
@@ -114,7 +116,10 @@ export class FileInteractionState {
     const state = new FileInteractionState();
     parsed.readFiles.forEach((path) => state.readFiles.add(path));
     for (const entry of parsed.edits) {
-      state.edits.set(entry.path, { added: entry.added, removed: entry.removed });
+      state.edits.set(entry.path, {
+        added: entry.added,
+        removed: entry.removed,
+      });
     }
     return state;
   }
@@ -202,15 +207,20 @@ export class FileInteractionState {
  * Legacy snapshots stored plain strings; new snapshots store FileLocation objects.
  * Transform normalizes legacy strings to FileLocation on parse.
  */
-const MediaFileEntrySchema = z.union([z.string(), FileLocationSchema]).transform(
-  (entry): FileLocation => (typeof entry === 'string' ? pathToLocation(entry) : entry),
-);
+const MediaFileEntrySchema = z
+  .union([z.string(), FileLocationSchema])
+  .transform(
+    (entry): FileLocation =>
+      typeof entry === 'string' ? pathToLocation(entry) : entry,
+  );
 
 /** Schema for MediaAttachmentState serialization */
 export const MediaAttachmentStateSnapshotSchema = z.object({
   files: z.array(MediaFileEntrySchema).default([]),
 });
-export type MediaAttachmentStateSnapshot = z.output<typeof MediaAttachmentStateSnapshotSchema>;
+export type MediaAttachmentStateSnapshot = z.output<
+  typeof MediaAttachmentStateSnapshotSchema
+>;
 
 export class MediaAttachmentState {
   public readonly files: FileLocation[] = [];
@@ -265,7 +275,9 @@ export const ReasoningCacheStateSnapshotSchema = z.object({
   thinkingBlocks: z.array(ThinkingBlockSchema).default([]),
   thinkingAdded: z.boolean().default(false),
 });
-export type ReasoningCacheStateSnapshot = z.output<typeof ReasoningCacheStateSnapshotSchema>;
+export type ReasoningCacheStateSnapshot = z.output<
+  typeof ReasoningCacheStateSnapshotSchema
+>;
 
 export class ReasoningCacheState {
   public thinkingBlocks: ThinkingBlock[] = [];
@@ -342,7 +354,9 @@ export class ServerToolContentState {
 export const DocumentStatsStateSnapshotSchema = z.object({
   texcountStats: z.string().nullable().default(null),
 });
-export type DocumentStatsStateSnapshot = z.output<typeof DocumentStatsStateSnapshotSchema>;
+export type DocumentStatsStateSnapshot = z.output<
+  typeof DocumentStatsStateSnapshotSchema
+>;
 
 export class DocumentStatsState {
   public texcountStats: string | null = null;
@@ -442,11 +456,20 @@ export class TodoState {
  * with legacy workspace snapshots that may contain removed or renamed fields.
  */
 export const AgentWorkspaceStateSnapshotSchema = z.object({
-  assembly: ResponseAssemblyStateSnapshotSchema.default({ lastResponse: '', accumulatedOutput: '' }),
+  assembly: ResponseAssemblyStateSnapshotSchema.default({
+    lastResponse: '',
+    accumulatedOutput: '',
+  }),
   media: MediaAttachmentStateSnapshotSchema.default({ files: [] }),
-  reasoning: ReasoningCacheStateSnapshotSchema.default({ thinkingBlocks: [], thinkingAdded: false }),
+  reasoning: ReasoningCacheStateSnapshotSchema.default({
+    thinkingBlocks: [],
+    thinkingAdded: false,
+  }),
   document: DocumentStatsStateSnapshotSchema.default({ texcountStats: null }),
-  interactions: FileInteractionStateSnapshotSchema.default({ readFiles: [], edits: [] }),
+  interactions: FileInteractionStateSnapshotSchema.default({
+    readFiles: [],
+    edits: [],
+  }),
   todos: TodoStateSnapshotSchema.default({ todos: [] }),
 });
 
@@ -532,4 +555,3 @@ export class AgentWorkspaceState {
     this.serverToolContent.reset();
   }
 }
-

--- a/src/agent/core/ToolUseCycle.ts
+++ b/src/agent/core/ToolUseCycle.ts
@@ -118,7 +118,8 @@ export async function runToolUseCycle<C = unknown>(
  */
 function emitEditedFiles<C>(input: ToolUseCycleInput<C>): void {
   const { options, store } = input;
-  const interactions: FileInteractionStateSnapshot = store.workspace.interactions.toSnapshot();
+  const interactions: FileInteractionStateSnapshot =
+    store.workspace.interactions.toSnapshot();
 
   if (interactions.edits.length === 0) {
     return;

--- a/src/agent/modelHandlers/modelHandlerOpenRouter.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenRouter.ts
@@ -1,24 +1,41 @@
 // Third-party imports
-import OpenAI from 'openai';
+import { OpenRouter } from '@openrouter/sdk';
 import { isAssistantMessage } from 'openai/lib/chatCompletionUtils';
 
-// Local imports - core utilities
-
-// Local imports - agent
-import { AgentWorkspaceState } from '@agent/core/AgentWorkspaceState';
+// Local imports - agent components
+import type { ExtendedCompletionUsage } from '@agent/core/ResponseUsage';
 import type { NormalizedUsage } from '@agent/types/NormalizedUsage';
+import { AgentWorkspaceState } from '@agent/core/AgentWorkspaceState';
 import { isNonEmptyString } from '@utils/core';
 
 // Local file imports
 import { ModelHandlerOpenAI } from './modelHandlerOpenAI';
-import { toOpenAITools } from './toolConversion';
+import { OPENAI_CHAT_FINISH } from './types/StopReasonTypes';
 import { executeRequest } from './utils/requestExecutor';
 import type { CreateResponseOptions } from './types/IModelHandler';
+
+// Third-party type imports
+import type {
+  ChatGenerationParams,
+  ChatGenerationTokenUsage,
+  ChatResponse,
+  ChatStreamingResponseChunkData,
+  Effort,
+  Message,
+  Schema3,
+} from '@openrouter/sdk/esm/models/index.js';
+import type OpenAI from 'openai';
 import type {
   ChatCompletion,
-  ChatCompletionChunk,
+  ChatCompletionCreateParamsStreaming,
   ChatCompletionMessageParam,
+  ChatCompletionMessageToolCall,
 } from 'openai/resources/chat/completions';
+
+type ChatCompletionRequestBase = Omit<
+  ChatCompletionCreateParamsStreaming,
+  'stream' | 'stream_options'
+>;
 
 /**
  * OpenRouter reasoning_details array item types.
@@ -35,15 +52,10 @@ interface ReasoningDetailItem {
   signature?: string | null; // for reasoning.text
 }
 
-/**
- * Extracts text content from OpenRouter reasoning_details array.
- * Handles the structured format with type-specific fields.
- */
 const extractTextFromReasoningDetails = (
-  details: ReasoningDetailItem[] | unknown,
+  details: ReasoningDetailItem[] | Schema3[] | unknown,
 ): string => {
   if (!Array.isArray(details)) {
-    // Fallback: if it's a string, return it directly
     if (typeof details === 'string') return details;
     return '';
   }
@@ -52,15 +64,14 @@ const extractTextFromReasoningDetails = (
   for (const item of details) {
     if (!item || typeof item !== 'object') continue;
 
-    switch (item.type) {
+    switch ((item as ReasoningDetailItem).type) {
       case 'reasoning.text':
-        if (item.text) textParts.push(item.text);
+        if ('text' in item && item.text) textParts.push(item.text);
         break;
       case 'reasoning.summary':
-        if (item.summary) textParts.push(item.summary);
+        if ('summary' in item && item.summary) textParts.push(item.summary);
         break;
       case 'reasoning.encrypted':
-        // Encrypted content is not useful for display, skip it
         break;
     }
   }
@@ -68,35 +79,259 @@ const extractTextFromReasoningDetails = (
   return textParts.join('');
 };
 
-/**
- * Extracts reasoning delta from streaming chunks for OpenRouter.
- * Handles both:
- * - reasoning_details: array of objects (OpenRouter normalized format)
- * - reasoning_content: string (native DeepSeek/other models)
- */
 const extractOpenRouterReasoningDelta = (
-  chunk: ChatCompletionChunk,
+  chunk: ChatStreamingResponseChunkData,
 ): string => {
   const choice = chunk.choices[0];
   if (!choice) return '';
 
-  const delta = choice.delta as {
-    reasoning_details?: ReasoningDetailItem[] | string;
-    reasoning_content?: string;
-  };
+  const delta = choice.delta;
 
-  // Try reasoning_details first (OpenRouter normalized format)
-  if ('reasoning_details' in delta && delta.reasoning_details) {
-    return extractTextFromReasoningDetails(delta.reasoning_details);
+  if (delta.reasoningDetails && delta.reasoningDetails.length > 0) {
+    return extractTextFromReasoningDetails(delta.reasoningDetails);
   }
 
-  // Fall back to reasoning_content (native format for some models)
-  if ('reasoning_content' in delta && delta.reasoning_content) {
-    return delta.reasoning_content;
+  if (delta.reasoning) {
+    return delta.reasoning;
   }
 
   return '';
 };
+
+const toOpenRouterContent = (
+  content: ChatCompletionMessageParam['content'],
+): Message['content'] => {
+  if (
+    typeof content === 'string' ||
+    content === undefined ||
+    content === null
+  ) {
+    return content ?? '';
+  }
+
+  if (Array.isArray(content)) {
+    return content.map((part) => {
+      if (!part || typeof part !== 'object' || !('type' in part)) {
+        return part as unknown;
+      }
+
+      if (part.type === 'image_url' && 'image_url' in part) {
+        return {
+          type: part.type,
+          imageUrl: part.image_url,
+        } as unknown;
+      }
+
+      if (part.type === 'input_audio' && 'input_audio' in part) {
+        return {
+          type: part.type,
+          inputAudio: part.input_audio,
+        } as unknown;
+      }
+
+      return part as unknown;
+    }) as Message['content'];
+  }
+
+  return content as Message['content'];
+};
+
+const mapToolCallsForRequest = (toolCalls?: ChatCompletionMessageToolCall[]) =>
+  toolCalls
+    ?.filter(
+      (
+        toolCall,
+      ): toolCall is ChatCompletionMessageToolCall & { type: 'function' } =>
+        toolCall.type === 'function',
+    )
+    .map((toolCall) => {
+      const toolFunction = (
+        toolCall as { function?: { name?: string; arguments?: string } }
+      ).function;
+
+      return {
+        id: toolCall.id,
+        type: 'function' as const,
+        function: toolFunction,
+      };
+    });
+
+const toOpenRouterMessages = (
+  messages: ChatCompletionMessageParam[],
+): Message[] => {
+  const mappedMessages = messages.map((message) => {
+    if (message.role === 'assistant') {
+      const assistantMessage = message as {
+        tool_calls?: ChatCompletionMessageToolCall[];
+        content?: ChatCompletionMessageParam['content'];
+      };
+      return {
+        role: 'assistant',
+        content: toOpenRouterContent(assistantMessage.content),
+        toolCalls: mapToolCallsForRequest(assistantMessage.tool_calls),
+      };
+    }
+
+    if (message.role === 'tool') {
+      const toolMessage = message as {
+        tool_call_id?: string;
+        content?: ChatCompletionMessageParam['content'];
+      };
+      return {
+        role: 'tool',
+        content: toOpenRouterContent(toolMessage.content),
+        toolCallId: toolMessage.tool_call_id,
+      };
+    }
+
+    return {
+      role: message.role,
+      content: toOpenRouterContent(message.content),
+    } as Message;
+  });
+
+  return mappedMessages as Message[];
+};
+
+const toOpenAIToolCalls = (
+  toolCalls?: Array<{
+    id?: string;
+    type?: string;
+    function?: { name?: string; arguments?: string };
+  }> | null,
+): ChatCompletionMessageToolCall[] =>
+  (toolCalls ?? []).map((call, index) => ({
+    id: call.id ?? `call_${index}`,
+    type: 'function',
+    function: {
+      name: call.function?.name ?? '',
+      arguments: call.function?.arguments ?? '',
+    },
+  }));
+
+const toOpenAIUsage = (
+  usage?: ChatGenerationTokenUsage | null,
+): ExtendedCompletionUsage | null => {
+  if (!usage) return null;
+
+  const promptTokens = usage.promptTokens ?? 0;
+  const completionTokens = usage.completionTokens ?? 0;
+
+  return {
+    prompt_tokens: promptTokens,
+    completion_tokens: completionTokens,
+    total_tokens: usage.totalTokens ?? promptTokens + completionTokens,
+    prompt_tokens_details: usage.promptTokensDetails?.cachedTokens
+      ? { cached_tokens: usage.promptTokensDetails.cachedTokens }
+      : undefined,
+    completion_tokens_details: usage.completionTokensDetails?.reasoningTokens
+      ? { reasoning_tokens: usage.completionTokensDetails.reasoningTokens }
+      : undefined,
+    prompt_cache_hit_tokens: usage.promptTokensDetails?.cachedTokens,
+  };
+};
+
+const extractContentText = (
+  content: string | Array<{ type?: string; text?: string }> | null | undefined,
+): string => {
+  if (!content) return '';
+  if (typeof content === 'string') return content;
+  return content
+    .map((item) => ('text' in item ? (item.text ?? '') : ''))
+    .join('');
+};
+
+interface CompletionBuildOptions {
+  id: string;
+  created: number;
+  model: string;
+  finishReason: string | null | undefined;
+  content: string;
+  systemFingerprint?: string | null;
+  toolCalls?: ChatCompletionMessageToolCall[];
+  usage?: ExtendedCompletionUsage | null;
+  reasoning?: string;
+  reasoningDetails?: ReasoningDetailItem[] | Schema3[];
+}
+
+const buildChatCompletion = (
+  options: CompletionBuildOptions,
+): ChatCompletion => ({
+  id: options.id,
+  choices: [
+    {
+      index: 0,
+      message: {
+        role: 'assistant',
+        content: options.content,
+        tool_calls:
+          options.toolCalls && options.toolCalls.length > 0
+            ? options.toolCalls
+            : undefined,
+        reasoning: options.reasoning || undefined,
+        reasoning_details:
+          options.reasoningDetails && options.reasoningDetails.length > 0
+            ? (options.reasoningDetails as ReasoningDetailItem[])
+            : undefined,
+      } as any,
+      finish_reason: (options.finishReason ??
+        OPENAI_CHAT_FINISH.STOP) as ChatCompletion['choices'][number]['finish_reason'],
+      logprobs: null,
+    },
+  ],
+  created: options.created,
+  model: options.model,
+  object: 'chat.completion',
+  system_fingerprint: options.systemFingerprint ?? undefined,
+  usage: options.usage ?? undefined,
+});
+
+const convertChatResponseToCompletion = (
+  response: ChatResponse,
+  modelFallback: string,
+): ChatCompletion => {
+  const choice = response.choices[0];
+  if (!choice) {
+    throw new Error('Invalid OpenRouter response: missing choices');
+  }
+
+  const assistantMessage = choice.message;
+  const content = extractContentText(assistantMessage.content);
+  const toolCalls = toOpenAIToolCalls(assistantMessage.toolCalls);
+  const usage = toOpenAIUsage(response.usage);
+
+  const reasoningDetails =
+    choice.reasoningDetails && choice.reasoningDetails.length > 0
+      ? choice.reasoningDetails
+      : undefined;
+
+  return buildChatCompletion({
+    id: response.id,
+    created: response.created,
+    model: response.model ?? modelFallback,
+    finishReason: choice.finishReason ?? OPENAI_CHAT_FINISH.STOP,
+    content,
+    toolCalls,
+    systemFingerprint: response.systemFingerprint,
+    usage,
+    reasoning: assistantMessage.reasoning ?? undefined,
+    reasoningDetails,
+  });
+};
+
+const finalizeToolCallsFromStream = (
+  buffer: Map<number, { id?: string; name?: string; args: string }>,
+): ChatCompletionMessageToolCall[] =>
+  Array.from(buffer.entries())
+    .sort(([left], [right]) => left - right)
+    .map(([index, call]) => ({
+      id: call.id ?? `call_${index}`,
+      type: 'function',
+      function: {
+        name: call.name ?? '',
+        arguments: call.args,
+      },
+    }));
 
 /**
  * Handler for models accessed through OpenRouter.
@@ -106,108 +341,229 @@ export class ModelHandlerOpenRouter extends ModelHandlerOpenAI {
     return 'openrouter';
   }
 
-  /** Creates a response using OpenRouter's API with model-specific configuration. */
-  async createResponse(
+  /** Uses the native OpenRouter SDK client. */
+  override async getClient(): Promise<OpenAI> {
+    const apiKey = await this.getApiKey();
+    const baseURL = this.getBaseUrl() ?? undefined;
+    this.logger.debug(`Using OpenRouter API key. Base URL: ${baseURL}`);
+
+    const client = new OpenRouter({
+      apiKey,
+      serverURL: baseURL,
+      xTitle: 'TeXRA.ai',
+    });
+
+    return client as unknown as OpenAI;
+  }
+
+  /** Creates a response using OpenRouter's native SDK. */
+  override async createResponse(
     options: CreateResponseOptions<ChatCompletionMessageParam, OpenAI>,
   ): Promise<ChatCompletion> {
-    const { client, messages, temperature, endTag, signal, tools } = options;
-    // Get streaming config
-    const useStreaming = this.getStreamingConfig();
-
-    const kwargs: any = {
-      model: this.config.openrouterFullName, // Use OpenRouter model name
-      messages,
-      max_tokens: this.config.maxOutputTokens,
+    const {
+      client,
+      messages: rawMessages,
       temperature,
-      extra_headers: { 'X-Title': 'TeXRA.ai' },
-    };
+      systemPrompt,
+      endTag,
+      signal,
+      tools,
+    } = options;
+    const useStreaming = this.getStreamingConfig();
+    const normalizationOptions = this.getMessageNormalizationOptions();
+    const messages = normalizationOptions
+      ? this.prepareNormalizedMessages(
+          rawMessages,
+          normalizationOptions,
+          'openrouter',
+        )
+      : rawMessages;
 
-    // Reasoning parameters vary by model via OpenRouter:
-    // - O1-style models: use reasoning.effort + include_reasoning
-    // - DeepSeek V3.2: use reasoning.enabled (no include_reasoning needed,
-    //   reasoning_details is returned automatically when enabled)
-    if (this.config.capabilities.supportsReasoning) {
-      if (
-        this.config.capabilities.supportsReasoningEffort &&
-        this.config.capabilities.reasoningEffort
-      ) {
-        // O1-style models with effort levels
-        kwargs.reasoning = {
-          effort: this.validateReasoningEffort(
-            this.config.capabilities.reasoningEffort,
-          ),
-        };
-        kwargs.include_reasoning = true;
-      } else {
-        // DeepSeek V3.2 and similar models - just enable reasoning
-        kwargs.reasoning = { enabled: true };
-      }
-    }
-
-    if (tools && tools.length > 0) {
-      kwargs.tools = toOpenAITools(tools);
-      kwargs.tool_choice = 'auto';
-    }
-
-    if (endTag) {
-      kwargs.stop = [endTag];
-    }
+    const baseParams = this.buildChatBaseParams(
+      messages,
+      temperature,
+      systemPrompt,
+      endTag,
+      tools,
+    );
+    const chatParams = this.buildChatParams(baseParams, useStreaming);
+    const openRouterClient = client as unknown as OpenRouter;
 
     if (useStreaming) {
-      kwargs.stream_options = { include_usage: true }; // Assuming OpenRouter passes this through
-      const stream = await executeRequest(
+      const streamParams = { ...chatParams, stream: true as const };
+      const stream = (await executeRequest(
         {
           model: this.config.name,
-          operation: 'openrouter.chat.completions.stream',
+          operation: 'openrouter.chat.send.stream',
           signal,
         },
-        () => client.chat.completions.stream(kwargs, { signal }),
+        () => openRouterClient.chat.send(streamParams, { signal }),
+      )) as AsyncIterable<ChatStreamingResponseChunkData>;
+
+      return this.consumeStreamingResponse(
+        stream,
+        streamParams,
+        this.config.openrouterFullName ?? this.config.fullName,
       );
-      const thinking = this.createThinkingStream();
-      const output = this.isOutputStreamingEnabled()
-        ? this.createOutputStream()
-        : undefined;
-      for await (const chunk of stream) {
-        const reasoningDelta = extractOpenRouterReasoningDelta(chunk);
-        const contentDelta = chunk.choices[0]?.delta?.content ?? '';
-        if (reasoningDelta) thinking.append(reasoningDelta);
-        if (contentDelta) output?.append(contentDelta);
+    }
+
+    const response = await executeRequest(
+      {
+        model: this.config.name,
+        operation: 'openrouter.chat.send',
+        signal,
+      },
+      () =>
+        openRouterClient.chat.send(
+          { ...chatParams, stream: false as const },
+          { signal },
+        ),
+    );
+
+    return convertChatResponseToCompletion(
+      response as ChatResponse,
+      this.config.openrouterFullName ?? this.config.fullName,
+    );
+  }
+
+  private buildChatParams(
+    baseParams: ChatCompletionRequestBase,
+    useStreaming: boolean,
+  ): ChatGenerationParams {
+    const maxTokens =
+      (baseParams as { max_tokens?: number }).max_tokens ??
+      (baseParams as { max_completion_tokens?: number })
+        .max_completion_tokens ??
+      this.config.maxOutputTokens;
+
+    const reasoningEffort =
+      (baseParams as { reasoning_effort?: string }).reasoning_effort ??
+      this.capabilities.reasoningEffort;
+
+    const effortValue = reasoningEffort
+      ? (this.validateReasoningEffort(reasoningEffort) as Effort)
+      : undefined;
+
+    const params: ChatGenerationParams = {
+      model: this.config.openrouterFullName ?? this.config.fullName,
+      messages: toOpenRouterMessages(baseParams.messages ?? []),
+      temperature: baseParams.temperature ?? undefined,
+      stop: baseParams.stop,
+      tools: baseParams.tools as ChatGenerationParams['tools'],
+      toolChoice: (baseParams as { tool_choice?: unknown }).tool_choice,
+      reasoning:
+        this.capabilities.supportsReasoning && effortValue !== undefined
+          ? { effort: effortValue }
+          : this.capabilities.supportsReasoning
+            ? { effort: undefined }
+            : undefined,
+      stream: useStreaming ? true : undefined,
+      streamOptions: useStreaming ? { includeUsage: true } : undefined,
+    };
+
+    if (typeof maxTokens === 'number') {
+      params.maxTokens = maxTokens;
+      params.maxCompletionTokens = maxTokens;
+    }
+
+    return params;
+  }
+
+  private async consumeStreamingResponse(
+    stream: AsyncIterable<ChatStreamingResponseChunkData>,
+    params: ChatGenerationParams,
+    modelFallback: string,
+  ): Promise<ChatCompletion> {
+    const thinkingStream = this.createThinkingStream();
+    const outputStream = this.isOutputStreamingEnabled()
+      ? this.createOutputStream()
+      : undefined;
+
+    let aggregatedContent = '';
+    let aggregatedReasoning = '';
+    let aggregatedUsage: ChatGenerationTokenUsage | null = null;
+    let finishReason: string | null | undefined;
+    let systemFingerprint: string | null | undefined;
+    let responseId: string | undefined;
+    let responseCreated: number | undefined;
+    let responseModel: string | undefined;
+    let reasoningDetails: ReasoningDetailItem[] | Schema3[] | undefined;
+
+    const toolCallBuffer = new Map<
+      number,
+      { id?: string; name?: string; args: string }
+    >();
+
+    for await (const chunk of stream) {
+      responseId = chunk.id ?? responseId;
+      responseCreated = chunk.created ?? responseCreated;
+      responseModel = chunk.model ?? responseModel;
+      systemFingerprint = chunk.systemFingerprint ?? systemFingerprint;
+      if (chunk.usage) {
+        aggregatedUsage = chunk.usage;
       }
 
-      // Note that there is no second consumption problem
-      // But i am not sure about openrouter's stream api, whether it works for every model.
-      let response = await stream.finalChatCompletion();
+      const choice = chunk.choices[0];
+      if (!choice) continue;
 
-      // Ensure usage is captured - use SDK's totalUsage() as fallback
-      if (!response.usage) {
-        try {
-          const totalUsage = await stream.totalUsage();
-          response = { ...response, usage: totalUsage };
-        } catch {
-          // totalUsage() may fail if stream ended abnormally
+      const delta = choice.delta;
+      if (typeof delta.content === 'string') {
+        aggregatedContent += delta.content;
+        outputStream?.append(delta.content);
+      }
+
+      const reasoningDelta = extractOpenRouterReasoningDelta(chunk);
+      if (reasoningDelta) {
+        aggregatedReasoning += reasoningDelta;
+        thinkingStream.append(reasoningDelta);
+      }
+
+      if (delta.reasoningDetails && delta.reasoningDetails.length > 0) {
+        reasoningDetails = delta.reasoningDetails as ReasoningDetailItem[];
+      }
+
+      if (Array.isArray(delta.toolCalls)) {
+        for (const toolCall of delta.toolCalls) {
+          const existing = toolCallBuffer.get(toolCall.index) ?? {
+            args: '',
+          };
+          if (toolCall.id) existing.id = toolCall.id;
+          if (toolCall.function?.name) existing.name = toolCall.function.name;
+          if (toolCall.function?.arguments) {
+            existing.args += toolCall.function.arguments;
+          }
+          toolCallBuffer.set(toolCall.index, existing);
         }
       }
 
-      const finalReasoning = this.processThinkingBlock(response);
-      thinking.finalize(finalReasoning ?? undefined);
-      const finalOutput = response.choices?.[0]?.message?.content ?? '';
-      if (output) output.finalize(finalOutput);
-      return response;
-    } else {
-      return executeRequest(
-        {
-          model: this.config.name,
-          operation: 'openrouter.chat.completions.create',
-          signal,
-        },
-        () => client.chat.completions.create(kwargs, { signal }),
-      );
+      finishReason = choice.finishReason ?? finishReason;
     }
+
+    thinkingStream.finalize(aggregatedReasoning || undefined);
+    if (outputStream) {
+      outputStream.finalize(aggregatedContent);
+    }
+
+    const usage = toOpenAIUsage(aggregatedUsage);
+    const toolCalls = finalizeToolCallsFromStream(toolCallBuffer);
+
+    return buildChatCompletion({
+      id: responseId ?? `openrouter-${Date.now()}`,
+      created: responseCreated ?? Math.floor(Date.now() / 1000),
+      model: responseModel ?? params.model ?? modelFallback,
+      finishReason: finishReason ?? OPENAI_CHAT_FINISH.STOP,
+      content: aggregatedContent,
+      systemFingerprint,
+      toolCalls,
+      usage,
+      reasoning: aggregatedReasoning || undefined,
+      reasoningDetails,
+    });
   }
 
   /**
    * OpenRouter returns reasoning in different formats:
-   * - reasoning_details: array of objects (normalized format, see ReasoningDetailItem)
+   * - reasoning_details: array of objects (OpenRouter normalized format, see ReasoningDetailItem)
    * - reasoning: string (simple format)
    *
    * @see https://openrouter.ai/docs/guides/best-practices/reasoning-tokens
@@ -215,14 +571,12 @@ export class ModelHandlerOpenRouter extends ModelHandlerOpenAI {
   protected override extractReasoningFromMessage(
     message: Record<string, unknown> | undefined,
   ): string | null {
-    // Try reasoning_details first (OpenRouter normalized format - array of objects)
     const reasoningDetails = message?.reasoning_details;
     if (reasoningDetails) {
       const extracted = extractTextFromReasoningDetails(reasoningDetails);
       if (extracted) return extracted;
     }
 
-    // Fall back to simple reasoning field (string)
     const reasoning = message?.reasoning;
     if (!reasoning) {
       return null;
@@ -246,10 +600,8 @@ export class ModelHandlerAnthropicViaOpenRouter extends ModelHandlerOpenRouter {
     workspaceState: AgentWorkspaceState,
   ): void {
     const lastMessage = messages.at(-1);
-    // although OpenAI models do not support assistant prefill, some models (such as Anthropic/DeepSeek perhaps?) via OpenRouter might do
     if (isAssistantMessage(lastMessage)) {
       if (Array.isArray(lastMessage.content)) {
-        // is this correct? it looks like we should attach previous response too.
         const lastPart = lastMessage.content.at(-1);
         if (lastPart && 'text' in lastPart) {
           lastPart.text = bestConnector + newResponse;


### PR DESCRIPTION
## Summary
- add a native OpenRouter SDK client with request/response conversion, tool handling, and streaming aggregation
- depend on the official `@openrouter/sdk` package and refresh formatter output in agent state files

## Testing
- npm run format
- npm run compile *(warning about nunjucks dynamic require in webpack output)*
- npm run lint *(warning about existing /* eslint-env */ usage in tests)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943bbad89c4832485fb4650e1e0c67e)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce a native OpenRouter SDK client with full chat, streaming, tool-calls, and reasoning support, plus minor state formatting updates and dependency addition.
> 
> - **Model Handling (OpenRouter)**:
>   - Implement native `@openrouter/sdk` integration in `modelHandlerOpenRouter.ts` with request/response mapping, tool-call conversion, reasoning extraction, and streaming aggregation.
>   - Add client factory using `OpenRouter`, unified param building, and conversion back to OpenAI-compatible `ChatCompletion` shape.
>   - Introduce Anthropic-via-OpenRouter helpers for assistant prefill and non-prefill flows.
> - **Core State**:
>   - Minor formatting/refactors in `AgentState.ts`, `AgentWorkspaceState.ts`, and `ToolUseCycle.ts` (type exports, snapshot building, line-wrapping; no logic changes).
> - **Config/Deps**:
>   - Add `@openrouter/sdk` to `package.json` (and lockfile).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 68fa13662bcca6dbaf197d88011c38535561aeb9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->