### PR TITLE
Refactor CSS to reduce duplication

### DIFF
--- a/src/common/styles/common.css
+++ b/src/common/styles/common.css
@@ -6,6 +6,19 @@
  * and make the codebase more maintainable.
  */
 
+/* ==========================================================================
+   Body Reset - Base styling shared across all views
+   Each view can override with layout-specific properties
+   ========================================================================== */
+
+body {
+  margin: 0;
+  font-family: var(--vscode-font-family);
+  font-size: var(--vscode-font-size);
+  color: var(--vscode-editor-foreground);
+  box-sizing: border-box;
+}
+
 :root {
   /* Colors */
   --background-color: var(--vscode-sideBar-background);
@@ -144,7 +157,7 @@ vscode-toolbar-button {
    Utility Classes
    ========================================================================== */
 
-/* Visibility */
+/* Visibility - Single source of truth for show/hide patterns */
 .hidden {
   display: none;
 }
@@ -153,11 +166,114 @@ vscode-toolbar-button {
   display: flex;
 }
 
+/* Block-level visibility toggle (for containers that should be block when visible) */
+.hidden-block {
+  display: none;
+}
+
+.hidden-block.is-visible {
+  display: block;
+}
+
 /* Text utilities */
 .truncate {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+/* Meta/secondary text - description foreground with smaller font */
+.text-meta {
+  font-size: var(--font-size-sm);
+  color: var(--vscode-descriptionForeground);
+}
+
+/* ==========================================================================
+   Flex Layout Utilities
+   ========================================================================== */
+
+/* Flex row with centered alignment */
+.flex-row {
+  display: flex;
+  align-items: center;
+}
+
+/* Flex row with small gap */
+.flex-row-gap-sm {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-small);
+}
+
+/* Flex row with medium gap */
+.flex-row-gap-md {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-medium);
+}
+
+/* Flex column layout */
+.flex-col {
+  display: flex;
+  flex-direction: column;
+}
+
+/* Flex column with small gap */
+.flex-col-gap-sm {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-small);
+}
+
+/* Flex column with medium gap */
+.flex-col-gap-md {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-medium);
+}
+
+/* ==========================================================================
+   Badge Base Class
+   ========================================================================== */
+
+/* Base badge styling - extend with color variants */
+.badge {
+  display: inline-block;
+  padding: var(--spacing-tiny) var(--spacing-small);
+  border-radius: var(--border-radius-small);
+  font-size: var(--font-size-sm);
+  font-weight: 500;
+}
+
+/* Badge with flex alignment (for icons) */
+.badge-flex {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-small);
+  padding: var(--spacing-tiny) var(--spacing-small);
+  border-radius: var(--border-radius-small);
+  font-size: var(--font-size-sm);
+  font-weight: 500;
+}
+
+/* ==========================================================================
+   Panel/Box Container Base
+   ========================================================================== */
+
+/* Standard panel box with border */
+.panel-box {
+  background-color: var(--background-color);
+  border: 1px solid var(--vscode-widget-border, var(--dropdown-border));
+  border-radius: var(--border-radius);
+  padding: var(--spacing-medium);
+}
+
+/* Panel box with larger border radius */
+.panel-box-lg {
+  background-color: var(--background-color);
+  border: 1px solid var(--vscode-widget-border, var(--dropdown-border));
+  border-radius: var(--border-radius-large);
+  padding: var(--spacing-large);
 }
 
 /* ==========================================================================

--- a/src/common/styles/common.css
+++ b/src/common/styles/common.css
@@ -22,11 +22,15 @@ body {
 :root {
   /* ==========================================================================
      Semantic Color Aliases - Single source of truth for VS Code theme colors
+
+     TODO: Migrate remaining --vscode-* usages across CSS files to use these
+     aliases. Currently only todo-list.css and placeholder.css are migrated.
      ========================================================================== */
 
   /* Text colors */
   --color-text-secondary: var(--vscode-descriptionForeground);
   --color-text-link: var(--vscode-textLink-foreground);
+  --color-text-link-active: var(--vscode-textLink-activeForeground);
 
   /* Background colors */
   --color-bg-secondary: var(--vscode-sideBar-background);
@@ -112,15 +116,15 @@ vscode-toolbar-button {
   flex-shrink: 0;
 }
 
-/* Common clickable link style (actually used in progressView) */
+/* Common clickable link style (used in progressView) */
 .clickable-link {
   cursor: pointer;
-  color: var(--vscode-textLink-foreground);
+  color: var(--color-text-link);
   text-decoration: none;
 }
 
 .clickable-link:hover {
-  color: var(--vscode-textLink-activeForeground);
+  color: var(--color-text-link-active);
   text-decoration: underline;
 }
 

--- a/src/common/styles/common.css
+++ b/src/common/styles/common.css
@@ -20,7 +20,47 @@ body {
 }
 
 :root {
-  /* Colors */
+  /* ==========================================================================
+     Semantic Color Aliases - Single source of truth for VS Code theme colors
+     Use these instead of --vscode-* variables directly
+     ========================================================================== */
+
+  /* Text colors */
+  --color-text-primary: var(--vscode-foreground);
+  --color-text-secondary: var(--vscode-descriptionForeground);
+  --color-text-link: var(--vscode-textLink-foreground);
+  --color-text-link-active: var(--vscode-textLink-activeForeground);
+  --color-text-editor: var(--vscode-editor-foreground);
+
+  /* Background colors */
+  --color-bg-primary: var(--vscode-editor-background);
+  --color-bg-secondary: var(--vscode-sideBar-background);
+  --color-bg-hover: var(--vscode-list-hoverBackground);
+  --color-bg-active: var(--vscode-list-activeSelectionBackground);
+  --color-bg-input: var(--vscode-input-background);
+  --color-bg-header: var(--vscode-sideBarSectionHeader-background);
+  --color-bg-code: var(--vscode-textCodeBlock-background);
+
+  /* Border colors */
+  --color-border: var(--vscode-panel-border);
+  --color-border-input: var(--vscode-input-border);
+  --color-border-widget: var(--vscode-widget-border);
+  --color-border-focus: var(--vscode-focusBorder);
+
+  /* Status colors */
+  --color-success: var(--vscode-testing-iconPassed);
+  --color-error: var(--vscode-errorForeground);
+  --color-warning: var(--vscode-editorWarning-foreground);
+  --color-info: var(--vscode-editorInfo-foreground);
+
+  /* Badge colors */
+  --color-badge-bg: var(--vscode-badge-background);
+  --color-badge-fg: var(--vscode-badge-foreground);
+
+  /* Accent color */
+  --color-accent: var(--vscode-activityBarBadge-background);
+
+  /* Legacy aliases (keep for backwards compatibility) */
   --background-color: var(--vscode-sideBar-background);
   --text-color: var(--vscode-sideBar-foreground);
   --button-hover-background: var(--vscode-button-hoverBackground);

--- a/src/common/styles/common.css
+++ b/src/common/styles/common.css
@@ -60,12 +60,11 @@ body {
   /* Accent color */
   --color-accent: var(--vscode-activityBarBadge-background);
 
-  /* Legacy aliases (keep for backwards compatibility) */
-  --background-color: var(--vscode-sideBar-background);
+  /* Additional semantic aliases (actively used) */
+  --background-color: var(--color-bg-secondary);
   --text-color: var(--vscode-sideBar-foreground);
   --button-hover-background: var(--vscode-button-hoverBackground);
   --dropdown-border: var(--vscode-dropdown-border);
-  --focus-border: var(--vscode-focusBorder);
 
   /* Typography */
   --font-size: var(--vscode-font-size);
@@ -204,13 +203,6 @@ vscode-toolbar-button {
 
 .hidden.is-visible {
   display: flex;
-}
-
-/* Text utilities */
-.truncate {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 /* ==========================================================================

--- a/src/common/styles/common.css
+++ b/src/common/styles/common.css
@@ -22,45 +22,22 @@ body {
 :root {
   /* ==========================================================================
      Semantic Color Aliases - Single source of truth for VS Code theme colors
-     Use these instead of --vscode-* variables directly
      ========================================================================== */
 
   /* Text colors */
-  --color-text-primary: var(--vscode-foreground);
   --color-text-secondary: var(--vscode-descriptionForeground);
   --color-text-link: var(--vscode-textLink-foreground);
-  --color-text-link-active: var(--vscode-textLink-activeForeground);
-  --color-text-editor: var(--vscode-editor-foreground);
 
   /* Background colors */
-  --color-bg-primary: var(--vscode-editor-background);
   --color-bg-secondary: var(--vscode-sideBar-background);
-  --color-bg-hover: var(--vscode-list-hoverBackground);
-  --color-bg-active: var(--vscode-list-activeSelectionBackground);
-  --color-bg-input: var(--vscode-input-background);
-  --color-bg-header: var(--vscode-sideBarSectionHeader-background);
-  --color-bg-code: var(--vscode-textCodeBlock-background);
 
   /* Border colors */
   --color-border: var(--vscode-panel-border);
-  --color-border-input: var(--vscode-input-border);
-  --color-border-widget: var(--vscode-widget-border);
-  --color-border-focus: var(--vscode-focusBorder);
 
   /* Status colors */
   --color-success: var(--vscode-testing-iconPassed);
-  --color-error: var(--vscode-errorForeground);
-  --color-warning: var(--vscode-editorWarning-foreground);
-  --color-info: var(--vscode-editorInfo-foreground);
 
-  /* Badge colors */
-  --color-badge-bg: var(--vscode-badge-background);
-  --color-badge-fg: var(--vscode-badge-foreground);
-
-  /* Accent color */
-  --color-accent: var(--vscode-activityBarBadge-background);
-
-  /* Additional semantic aliases (actively used) */
+  /* Aliases used by components */
   --background-color: var(--color-bg-secondary);
   --text-color: var(--vscode-sideBar-foreground);
   --button-hover-background: var(--vscode-button-hoverBackground);

--- a/src/common/styles/common.css
+++ b/src/common/styles/common.css
@@ -157,7 +157,7 @@ vscode-toolbar-button {
    Utility Classes
    ========================================================================== */
 
-/* Visibility - Single source of truth for show/hide patterns */
+/* Visibility */
 .hidden {
   display: none;
 }
@@ -166,114 +166,11 @@ vscode-toolbar-button {
   display: flex;
 }
 
-/* Block-level visibility toggle (for containers that should be block when visible) */
-.hidden-block {
-  display: none;
-}
-
-.hidden-block.is-visible {
-  display: block;
-}
-
 /* Text utilities */
 .truncate {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-}
-
-/* Meta/secondary text - description foreground with smaller font */
-.text-meta {
-  font-size: var(--font-size-sm);
-  color: var(--vscode-descriptionForeground);
-}
-
-/* ==========================================================================
-   Flex Layout Utilities
-   ========================================================================== */
-
-/* Flex row with centered alignment */
-.flex-row {
-  display: flex;
-  align-items: center;
-}
-
-/* Flex row with small gap */
-.flex-row-gap-sm {
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-small);
-}
-
-/* Flex row with medium gap */
-.flex-row-gap-md {
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-medium);
-}
-
-/* Flex column layout */
-.flex-col {
-  display: flex;
-  flex-direction: column;
-}
-
-/* Flex column with small gap */
-.flex-col-gap-sm {
-  display: flex;
-  flex-direction: column;
-  gap: var(--spacing-small);
-}
-
-/* Flex column with medium gap */
-.flex-col-gap-md {
-  display: flex;
-  flex-direction: column;
-  gap: var(--spacing-medium);
-}
-
-/* ==========================================================================
-   Badge Base Class
-   ========================================================================== */
-
-/* Base badge styling - extend with color variants */
-.badge {
-  display: inline-block;
-  padding: var(--spacing-tiny) var(--spacing-small);
-  border-radius: var(--border-radius-small);
-  font-size: var(--font-size-sm);
-  font-weight: 500;
-}
-
-/* Badge with flex alignment (for icons) */
-.badge-flex {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--spacing-small);
-  padding: var(--spacing-tiny) var(--spacing-small);
-  border-radius: var(--border-radius-small);
-  font-size: var(--font-size-sm);
-  font-weight: 500;
-}
-
-/* ==========================================================================
-   Panel/Box Container Base
-   ========================================================================== */
-
-/* Standard panel box with border */
-.panel-box {
-  background-color: var(--background-color);
-  border: 1px solid var(--vscode-widget-border, var(--dropdown-border));
-  border-radius: var(--border-radius);
-  padding: var(--spacing-medium);
-}
-
-/* Panel box with larger border radius */
-.panel-box-lg {
-  background-color: var(--background-color);
-  border: 1px solid var(--vscode-widget-border, var(--dropdown-border));
-  border-radius: var(--border-radius-large);
-  padding: var(--spacing-large);
 }
 
 /* ==========================================================================

--- a/src/common/styles/common.css
+++ b/src/common/styles/common.css
@@ -22,9 +22,6 @@ body {
 :root {
   /* ==========================================================================
      Semantic Color Aliases - Single source of truth for VS Code theme colors
-
-     TODO: Migrate remaining --vscode-* usages across CSS files to use these
-     aliases. Currently only todo-list.css and placeholder.css are migrated.
      ========================================================================== */
 
   /* Text colors */

--- a/src/historyView/styles/index.css
+++ b/src/historyView/styles/index.css
@@ -43,7 +43,7 @@ h2 {
 
 .match-count {
   font-size: var(--font-size-sm);
-  color: var(--vscode-descriptionForeground);
+  color: var(--color-text-secondary);
   min-width: calc(var(--height-button) * 2);
   text-align: center;
 }
@@ -87,7 +87,7 @@ mark.current-match {
 }
 
 .history-timestamp {
-  color: var(--vscode-descriptionForeground);
+  color: var(--color-text-secondary);
   font-size: var(--font-size-sm);
   margin-bottom: var(--spacing-small);
 }
@@ -126,7 +126,7 @@ mark.current-match {
 .empty-state {
   text-align: center;
   margin-top: calc(var(--spacing-xlarge) + var(--spacing-xlarge));
-  color: var(--vscode-descriptionForeground);
+  color: var(--color-text-secondary);
 }
 
 /* Collapsible content */
@@ -203,6 +203,6 @@ mark.current-match {
 
 /* Empty/unset value styling */
 .history-none {
-  color: var(--vscode-descriptionForeground);
+  color: var(--color-text-secondary);
   font-style: italic;
 }

--- a/src/historyView/styles/index.css
+++ b/src/historyView/styles/index.css
@@ -1,11 +1,10 @@
 /*
  * History view styles
+ * Note: Base body styles (margin, font-family, font-size, box-sizing, color) inherited from common.css
  */
 
 /* Base styles */
 body {
-  font-family: var(--font-family);
-  color: var(--vscode-editor-foreground);
   background-color: var(--vscode-editor-background);
   padding: var(--spacing-xlarge);
 }
@@ -171,15 +170,10 @@ mark.current-match {
   );
 }
 
-/* Session kind badge */
+/* Session kind badge - extends .badge-flex from common.css */
 .session-kind-badge {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--spacing-small);
-  padding: var(--spacing-xsmall) var(--spacing-medium);
+  padding: var(--spacing-tiny) var(--spacing-medium);
   border-radius: var(--border-radius);
-  font-size: var(--font-size-sm);
-  font-weight: 500;
 }
 
 .session-kind-badge .codicon {

--- a/src/historyView/styles/index.css
+++ b/src/historyView/styles/index.css
@@ -170,10 +170,15 @@ mark.current-match {
   );
 }
 
-/* Session kind badge - extends .badge-flex from common.css */
+/* Session kind badge */
 .session-kind-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-small);
   padding: var(--spacing-tiny) var(--spacing-medium);
   border-radius: var(--border-radius);
+  font-size: var(--font-size-sm);
+  font-weight: 500;
 }
 
 .session-kind-badge .codicon {

--- a/src/profileView/styles/index.css
+++ b/src/profileView/styles/index.css
@@ -51,11 +51,13 @@ h2 {
   color: var(--vscode-foreground);
 }
 
-/* Tier badge - extends .badge from common.css */
+/* Tier badge */
 .tier-badge {
+  display: inline-block;
   padding: var(--spacing-small) var(--spacing-medium);
   border-radius: var(--border-radius);
   text-transform: uppercase;
+  font-size: var(--font-size-sm);
   font-weight: 600;
 }
 
@@ -146,8 +148,12 @@ h2 {
   max-width: 300px;
 }
 
-/* Visibility badges - extends .badge from common.css */
+/* Visibility badges */
 .visibility-badge {
+  display: inline-block;
+  padding: 2px var(--spacing-small);
+  border-radius: var(--border-radius-small);
+  font-size: var(--font-size-sm);
   text-transform: lowercase;
 }
 
@@ -161,15 +167,24 @@ h2 {
   color: var(--vscode-badge-foreground);
 }
 
-/* Category badges - extends .badge from common.css */
+/* Category badges */
 .category-badge {
+  display: inline-block;
+  padding: 2px var(--spacing-small);
+  border-radius: var(--border-radius-small);
+  font-size: var(--font-size-sm);
+  font-weight: 500;
   background: var(--vscode-badge-background);
   color: var(--vscode-badge-foreground);
 }
 
-/* Multi-output badges - extends .badge from common.css */
+/* Multi-output badges */
 .multi-output-badge {
-  /* Badge styling from common.css */
+  display: inline-block;
+  padding: 2px var(--spacing-small);
+  border-radius: var(--border-radius-small);
+  font-size: var(--font-size-sm);
+  font-weight: 500;
 }
 
 .multi-output-badge.supported {

--- a/src/profileView/styles/index.css
+++ b/src/profileView/styles/index.css
@@ -10,7 +10,7 @@ body {
 }
 
 h1 {
-  color: var(--vscode-textLink-foreground);
+  color: var(--color-text-link);
   margin-bottom: var(--spacing-xlarge);
 }
 
@@ -19,7 +19,7 @@ h2 {
   margin-top: var(--spacing-xlarge);
   margin-bottom: var(--spacing-medium);
   font-size: 1.2em;
-  border-bottom: var(--border-thin) solid var(--vscode-panel-border);
+  border-bottom: var(--border-thin) solid var(--color-border);
   padding-bottom: var(--spacing-small);
 }
 
@@ -103,7 +103,7 @@ h2 {
 
 .not-authenticated p {
   margin-bottom: var(--spacing-xlarge);
-  color: var(--vscode-descriptionForeground);
+  color: var(--color-text-secondary);
 }
 
 /* Remote agents section */
@@ -122,7 +122,7 @@ h2 {
 .agents-table td {
   padding: var(--spacing-medium) var(--spacing-medium);
   text-align: left;
-  border-bottom: var(--border-thin) solid var(--vscode-panel-border);
+  border-bottom: var(--border-thin) solid var(--color-border);
 }
 
 .agents-table th {
@@ -139,7 +139,7 @@ h2 {
 
 .agent-name {
   font-weight: 500;
-  color: var(--vscode-textLink-foreground);
+  color: var(--color-text-link);
   white-space: nowrap;
 }
 
@@ -194,8 +194,8 @@ h2 {
 
 .multi-output-badge.not-supported {
   background: var(--vscode-input-background);
-  color: var(--vscode-descriptionForeground);
-  border: 1px solid var(--vscode-panel-border);
+  color: var(--color-text-secondary);
+  border: 1px solid var(--color-border);
 }
 
 /* Select button */
@@ -205,7 +205,7 @@ h2 {
 
 /* No agents message */
 .no-agents {
-  color: var(--vscode-descriptionForeground);
+  color: var(--color-text-secondary);
   font-style: italic;
   padding: var(--spacing-xlarge);
   text-align: center;
@@ -213,7 +213,7 @@ h2 {
 
 /* Loading state */
 .loading {
-  color: var(--vscode-descriptionForeground);
+  color: var(--color-text-secondary);
   font-style: italic;
 }
 
@@ -224,7 +224,7 @@ h2 {
 }
 
 .api-access-description {
-  color: var(--vscode-descriptionForeground);
+  color: var(--color-text-secondary);
   margin-bottom: var(--spacing-medium);
 }
 
@@ -240,7 +240,7 @@ h2 {
   gap: var(--spacing-medium);
   padding: var(--spacing-medium);
   background: var(--vscode-input-background);
-  border: var(--border-thin) solid var(--vscode-panel-border);
+  border: var(--border-thin) solid var(--color-border);
   border-radius: var(--border-radius);
   cursor: pointer;
   transition: border-color 0.2s ease;
@@ -273,7 +273,7 @@ h2 {
 
 .option-description {
   font-size: var(--font-size-sm);
-  color: var(--vscode-descriptionForeground);
+  color: var(--color-text-secondary);
 }
 
 .enabled-providers-info {
@@ -282,5 +282,5 @@ h2 {
   background: var(--vscode-textBlockQuote-background);
   border-radius: var(--border-radius);
   font-size: var(--font-size-sm);
-  color: var(--vscode-descriptionForeground);
+  color: var(--color-text-secondary);
 }

--- a/src/profileView/styles/index.css
+++ b/src/profileView/styles/index.css
@@ -1,11 +1,10 @@
 /*
  * Profile view styles
+ * Note: Base body styles (margin, font-family, font-size, box-sizing, color) inherited from common.css
  */
 
 /* Base styles */
 body {
-  font-family: var(--font-family);
-  color: var(--vscode-editor-foreground);
   background-color: var(--vscode-editor-background);
   padding: var(--spacing-xlarge);
 }
@@ -52,13 +51,11 @@ h2 {
   color: var(--vscode-foreground);
 }
 
-/* Tier badge */
+/* Tier badge - extends .badge from common.css */
 .tier-badge {
-  display: inline-block;
   padding: var(--spacing-small) var(--spacing-medium);
   border-radius: var(--border-radius);
   text-transform: uppercase;
-  font-size: var(--font-size-sm);
   font-weight: 600;
 }
 
@@ -149,12 +146,8 @@ h2 {
   max-width: 300px;
 }
 
-/* Visibility badges */
+/* Visibility badges - extends .badge from common.css */
 .visibility-badge {
-  display: inline-block;
-  padding: 2px var(--spacing-small);
-  border-radius: var(--border-radius-small);
-  font-size: var(--font-size-sm);
   text-transform: lowercase;
 }
 
@@ -168,24 +161,15 @@ h2 {
   color: var(--vscode-badge-foreground);
 }
 
-/* Category badges */
+/* Category badges - extends .badge from common.css */
 .category-badge {
-  display: inline-block;
-  padding: 2px var(--spacing-small);
-  border-radius: var(--border-radius-small);
-  font-size: var(--font-size-sm);
-  font-weight: 500;
   background: var(--vscode-badge-background);
   color: var(--vscode-badge-foreground);
 }
 
-/* Multi-output badges */
+/* Multi-output badges - extends .badge from common.css */
 .multi-output-badge {
-  display: inline-block;
-  padding: 2px var(--spacing-small);
-  border-radius: var(--border-radius-small);
-  font-size: var(--font-size-sm);
-  font-weight: 500;
+  /* Badge styling from common.css */
 }
 
 .multi-output-badge.supported {

--- a/src/progressView/styles/approval-requests.css
+++ b/src/progressView/styles/approval-requests.css
@@ -22,7 +22,7 @@
 .approval-request__path {
   font-family: var(--vscode-editor-font-family);
   font-size: 0.85rem;
-  color: var(--vscode-textLink-foreground);
+  color: var(--color-text-link);
   word-break: break-word;
 }
 
@@ -44,7 +44,7 @@
 }
 
 .approval-request__diff-label {
-  color: var(--vscode-descriptionForeground);
+  color: var(--color-text-secondary);
   font-size: 0.75rem;
   opacity: 0.9;
 }

--- a/src/progressView/styles/base.css
+++ b/src/progressView/styles/base.css
@@ -1,7 +1,7 @@
 /**
  * Base styles for ProgressView
  * Core layout and structure
- * Note: Base body styles (margin, font-family, font-size, box-sizing) inherited from common.css
+ * Note: Base body styles (margin, font-family, font-size, box-sizing, color) inherited from common.css
  */
 
 body {

--- a/src/progressView/styles/base.css
+++ b/src/progressView/styles/base.css
@@ -1,17 +1,14 @@
 /**
  * Base styles for ProgressView
  * Core layout and structure
+ * Note: Base body styles (margin, font-family, font-size, box-sizing) inherited from common.css
  */
 
 body {
   padding: 0;
-  margin: 0;
   display: flex;
   height: 100vh;
-  font-family: var(--font-family);
-  font-size: var(--font-size);
   background-color: var(--background-color);
-  color: var(--vscode-editor-foreground);
 }
 
 .main-container {

--- a/src/progressView/styles/file-list.css
+++ b/src/progressView/styles/file-list.css
@@ -5,14 +5,14 @@
 
 /* File metadata styling */
 .file-list-content .file-var {
-  color: var(--vscode-descriptionForeground);
+  color: var(--color-text-secondary);
   opacity: 0.8;
   font-size: 0.9em;
   margin-left: var(--spacing-tiny);
 }
 
 .file-list-content .file-source {
-  color: var(--vscode-descriptionForeground);
+  color: var(--color-text-secondary);
   opacity: 0.6;
   font-size: 0.85em;
   font-style: italic;
@@ -35,7 +35,7 @@
 
 /* Document tag info styling */
 .xml-link-container .document-tag {
-  color: var(--vscode-descriptionForeground);
+  color: var(--color-text-secondary);
   opacity: 0.8;
   font-style: italic;
 }
@@ -44,7 +44,7 @@
 .xml-link-container .xml-fix-hint {
   flex-basis: 100%;
   margin-top: var(--spacing-tiny);
-  color: var(--vscode-descriptionForeground);
+  color: var(--color-text-secondary);
   font-size: 0.9em;
   display: flex;
   align-items: center;
@@ -53,9 +53,9 @@
 
 .xml-link-container .xml-fix-hint .codicon {
   opacity: 1;
-  color: var(--vscode-textLink-foreground);
+  color: var(--color-text-link);
 }
 
 .xml-link-container .xml-fix-hint strong {
-  color: var(--vscode-textLink-foreground);
+  color: var(--color-text-link);
 }

--- a/src/progressView/styles/follow-up-input.css
+++ b/src/progressView/styles/follow-up-input.css
@@ -8,7 +8,7 @@
   display: none;
   align-items: flex-end;
   padding: var(--spacing-medium);
-  border-top: 1px solid var(--vscode-panel-border);
+  border-top: 1px solid var(--color-border);
   gap: var(--spacing-small);
 }
 

--- a/src/progressView/styles/groups.css
+++ b/src/progressView/styles/groups.css
@@ -12,7 +12,7 @@
   display: flex;
   align-items: center;
   background-color: transparent;
-  border-left: var(--border-medium) solid var(--vscode-panel-border);
+  border-left: var(--border-medium) solid var(--color-border);
 }
 
 /* Minimal styling for top-level task headers */
@@ -111,6 +111,6 @@
   top: 50%;
   width: var(--spacing-medium);
   height: var(--border-thin);
-  background-color: var(--vscode-panel-border);
+  background-color: var(--color-border);
   display: none; /* Start hidden, only show on advanced view option */
 }

--- a/src/progressView/styles/instruction-panel.css
+++ b/src/progressView/styles/instruction-panel.css
@@ -4,8 +4,8 @@
 
 .instruction-panel {
   display: none;
-  border-top: 1px solid var(--vscode-panel-border);
-  border-bottom: 1px solid var(--vscode-panel-border);
+  border-top: 1px solid var(--color-border);
+  border-bottom: 1px solid var(--color-border);
   background-color: transparent;
 }
 
@@ -26,7 +26,7 @@
   align-items: center;
   gap: var(--spacing-tiny);
   font-weight: 500;
-  color: var(--vscode-descriptionForeground);
+  color: var(--color-text-secondary);
 }
 
 .instruction-panel__title .codicon {

--- a/src/progressView/styles/logs.css
+++ b/src/progressView/styles/logs.css
@@ -43,7 +43,7 @@
 
 /* Timestamp color */
 .timestamp {
-  color: var(--vscode-descriptionForeground);
+  color: var(--color-text-secondary);
 }
 
 /* Level colors */
@@ -90,8 +90,8 @@
   display: flex;
   flex-direction: column;
   gap: var(--spacing-small);
-  color: var(--vscode-descriptionForeground);
-  border-bottom: 1px solid var(--vscode-panel-border);
+  color: var(--color-text-secondary);
+  border-bottom: 1px solid var(--color-border);
 }
 
 .log-header__primary {
@@ -139,7 +139,7 @@
   display: inline-flex;
   align-items: center;
   gap: var(--spacing-tiny);
-  color: var(--vscode-descriptionForeground);
+  color: var(--color-text-secondary);
   font-size: var(--font-size-sm);
   font-weight: 500;
   white-space: nowrap;
@@ -166,7 +166,7 @@
   display: inline-flex;
   align-items: center;
   gap: var(--spacing-tiny);
-  color: var(--vscode-descriptionForeground);
+  color: var(--color-text-secondary);
   font-size: var(--font-size-sm);
   opacity: 0.9;
 }
@@ -178,7 +178,7 @@
 
 .run-summary__label {
   font-weight: 500;
-  color: var(--vscode-descriptionForeground);
+  color: var(--color-text-secondary);
 }
 
 .run-summary__value {
@@ -210,7 +210,7 @@
   transform: translateX(-50%);
   padding: var(--spacing-small) var(--spacing-medium);
   background: var(--background-color);
-  border: var(--border-thin) solid var(--vscode-panel-border);
+  border: var(--border-thin) solid var(--color-border);
   border-radius: var(--border-radius-large);
   font-size: var(--font-size-sm);
   white-space: nowrap;
@@ -254,7 +254,7 @@
 /* Generated files list */
 .files-container {
   padding: var(--spacing-small);
-  border-top: 1px solid var(--vscode-panel-border);
+  border-top: 1px solid var(--color-border);
   font-size: var(--vscode-editor-font-size);
   overflow-y: auto;
   max-height: var(--height-large);
@@ -262,13 +262,13 @@
 }
 
 .usage-summary-footer {
-  border-top: 1px solid var(--vscode-panel-border);
+  border-top: 1px solid var(--color-border);
   background-color: var(--vscode-sideBarSectionHeader-background);
   padding: var(--spacing-small) var(--spacing-medium);
   display: flex;
   justify-content: flex-end;
   font-size: var(--font-size-sm);
-  color: var(--vscode-descriptionForeground);
+  color: var(--color-text-secondary);
 }
 
 .usage-summary-footer .run-summary {
@@ -298,7 +298,7 @@
   text-decoration: none;
   flex-shrink: 0;
   font-size: var(--font-size-sm);
-  color: var(--vscode-descriptionForeground);
+  color: var(--color-text-secondary);
 }
 /* Remove left spacing when only one stat is shown */
 .file-stats span:first-child {
@@ -355,7 +355,7 @@
 
 /* Group usage display styling */
 .group-usage {
-  color: var(--vscode-descriptionForeground);
+  color: var(--color-text-secondary);
   font-size: var(--font-size-sm);
   opacity: var(--opacity-subtle);
   font-weight: normal;
@@ -394,7 +394,7 @@
   .follow-up-container {
     display: none;
     padding: var(--spacing-small);
-    border-top: 1px solid var(--vscode-panel-border);
+    border-top: 1px solid var(--color-border);
     gap: var(--spacing-small);
   }
 

--- a/src/progressView/styles/markdown.css
+++ b/src/progressView/styles/markdown.css
@@ -43,7 +43,7 @@
 
 .markdown-content h1 {
   font-size: var(--font-size-lg);
-  border-bottom: var(--border-thin) solid var(--vscode-panel-border);
+  border-bottom: var(--border-thin) solid var(--color-border);
   padding-bottom: var(--spacing-small);
 }
 
@@ -54,10 +54,10 @@
   margin-bottom: var(--spacing-small);
   border-left: var(--border-thick) solid
     var(--vscode-activityBarBadge-background);
-  border-bottom: var(--border-thin) solid var(--vscode-panel-border);
+  border-bottom: var(--border-thin) solid var(--color-border);
   padding-bottom: var(--spacing-tiny);
   border-radius: var(--border-radius) 0 0 var(--border-radius);
-  color: var(--vscode-textLink-foreground);
+  color: var(--color-text-link);
 }
 
 .markdown-content h3 {
@@ -126,7 +126,7 @@
 }
 
 .markdown-content a {
-  color: var(--vscode-textLink-foreground);
+  color: var(--color-text-link);
   text-decoration: none;
 }
 
@@ -139,7 +139,7 @@
     var(--vscode-activityBarBadge-background);
   margin: var(--spacing-medium) 0;
   padding-left: var(--spacing-xlarge);
-  color: var(--vscode-descriptionForeground);
+  color: var(--color-text-secondary);
   font-style: italic;
 }
 
@@ -151,7 +151,7 @@
 
 .markdown-content table th,
 .markdown-content table td {
-  border: var(--border-thin) solid var(--vscode-panel-border);
+  border: var(--border-thin) solid var(--color-border);
   padding: var(--spacing-small) var(--spacing-large);
 }
 

--- a/src/progressView/styles/native-status.css
+++ b/src/progressView/styles/native-status.css
@@ -10,7 +10,7 @@
   gap: var(--spacing-small);
   padding: var(--spacing-small) var(--spacing-medium);
   margin: var(--spacing-small) 0;
-  border-left: var(--border-thin) solid var(--vscode-panel-border);
+  border-left: var(--border-thin) solid var(--color-border);
   border-radius: var(--border-radius-large);
   background-color: var(--vscode-sideBarSectionHeader-background, transparent);
   font-size: var(--font-size-sm);
@@ -27,7 +27,7 @@
 }
 
 .native-status-time {
-  color: var(--vscode-descriptionForeground);
+  color: var(--color-text-secondary);
   font-variant-numeric: tabular-nums;
   white-space: nowrap;
 }

--- a/src/progressView/styles/placeholder.css
+++ b/src/progressView/styles/placeholder.css
@@ -5,11 +5,11 @@
 
 .log-placeholder {
   text-align: center;
-  color: var(--vscode-descriptionForeground);
+  color: var(--color-text-secondary);
   padding: var(--spacing-large) var(--spacing-medium);
 }
 
 .log-placeholder a {
-  color: var(--vscode-textLink-foreground);
+  color: var(--color-text-link);
   text-decoration: underline;
 }

--- a/src/progressView/styles/requests-shared.css
+++ b/src/progressView/styles/requests-shared.css
@@ -76,7 +76,7 @@
 .approval-request__meta,
 .retry-request__meta {
   font-size: var(--font-size-sm);
-  color: var(--vscode-descriptionForeground);
+  color: var(--color-text-secondary);
   display: flex;
   align-items: center;
   gap: var(--spacing-small);

--- a/src/progressView/styles/scratchpad.css
+++ b/src/progressView/styles/scratchpad.css
@@ -15,7 +15,7 @@
 
 .tool-use-label {
   font-weight: 600;
-  color: var(--vscode-textLink-foreground);
+  color: var(--color-text-link);
   margin-bottom: var(--spacing-small);
 }
 
@@ -33,7 +33,7 @@
 .tool-use-separator {
   margin: var(--spacing-small) 0;
   border: none;
-  border-top: 1px solid var(--vscode-panel-border);
+  border-top: 1px solid var(--color-border);
   opacity: 0.3;
 }
 

--- a/src/progressView/styles/tabs.css
+++ b/src/progressView/styles/tabs.css
@@ -9,7 +9,7 @@
   flex: 1;
   min-width: 200px;
   font-size: var(--font-size-sm);
-  border-left: var(--border-thin) solid var(--vscode-panel-border);
+  border-left: var(--border-thin) solid var(--color-border);
   height: 100%;
   overflow: visible;
   background-color: var(--background-color);
@@ -23,7 +23,7 @@
 
 .clear-all-container {
   flex-shrink: 0;
-  border-top: var(--border-thin) solid var(--vscode-panel-border);
+  border-top: var(--border-thin) solid var(--color-border);
   padding: var(--spacing-small);
 }
 

--- a/src/progressView/styles/todo-list.css
+++ b/src/progressView/styles/todo-list.css
@@ -5,8 +5,8 @@
 
 .todo-list-container {
   display: none;
-  border-top: 1px solid var(--vscode-panel-border);
-  border-bottom: 1px solid var(--vscode-panel-border);
+  border-top: 1px solid var(--color-border);
+  border-bottom: 1px solid var(--color-border);
   background-color: transparent;
   padding: var(--spacing-small) var(--spacing-medium);
 }
@@ -20,7 +20,7 @@
   align-items: center;
   gap: var(--spacing-tiny);
   font-weight: 500;
-  color: var(--vscode-descriptionForeground);
+  color: var(--color-text-secondary);
   margin-bottom: var(--spacing-small);
 }
 
@@ -40,7 +40,7 @@
   align-items: flex-start;
   gap: var(--spacing-small);
   padding: var(--spacing-tiny) 0;
-  font-size: var(--vscode-font-size);
+  font-size: var(--font-size);
   line-height: 1.4;
 }
 
@@ -62,7 +62,7 @@
 }
 
 .todo-item--pending .todo-item__icon {
-  color: var(--vscode-descriptionForeground);
+  color: var(--color-text-secondary);
 }
 
 .todo-item--in-progress {
@@ -78,10 +78,10 @@
 }
 
 .todo-item--completed .todo-item__icon {
-  color: var(--vscode-testing-iconPassed);
+  color: var(--color-success);
 }
 
 .todo-item--completed .todo-item__content {
   text-decoration: line-through;
-  text-decoration-color: var(--vscode-descriptionForeground);
+  text-decoration-color: var(--color-text-secondary);
 }

--- a/src/progressView/styles/user-message.css
+++ b/src/progressView/styles/user-message.css
@@ -12,7 +12,7 @@
 
 .user-message {
   background-color: var(--vscode-editor-selectionBackground);
-  border-left: 3px solid var(--vscode-textLink-foreground);
+  border-left: 3px solid var(--color-text-link);
   padding: var(--spacing-small) var(--spacing-medium);
   max-width: 85%;
   margin-left: var(--spacing-xlarge);
@@ -27,7 +27,7 @@
 }
 
 .user-message-icon {
-  color: var(--vscode-textLink-foreground);
+  color: var(--color-text-link);
   font-size: var(--font-size-sm);
 }
 

--- a/src/webview/styles/base.css
+++ b/src/webview/styles/base.css
@@ -102,7 +102,7 @@ vscode-option.disabled-option,
 vscode-option.disabled-model,
 vscode-option.disabled-agent,
 vscode-option[data-requires-key='true'] {
-  color: var(--vscode-descriptionForeground);
+  color: var(--color-text-secondary);
   opacity: var(--opacity-subtle);
   font-style: italic;
   background-color: var(--vscode-input-background);

--- a/src/webview/styles/base.css
+++ b/src/webview/styles/base.css
@@ -1,18 +1,15 @@
 /**
  * Base styles for Webview
  * Core layout and structure
+ * Note: Base body styles (margin, font-family, font-size, box-sizing) inherited from common.css
  */
 
 body {
   background-color: transparent;
   color: var(--text-color);
-  font-family: var(--font-family);
-  font-size: var(--font-size);
   font-weight: var(--font-weight);
   min-height: 100vh;
-  margin: 0;
   padding: var(--spacing-medium);
-  box-sizing: border-box;
   display: flex;
   flex-direction: column;
 }

--- a/src/webview/styles/containers.css
+++ b/src/webview/styles/containers.css
@@ -130,7 +130,7 @@
 }
 
 .getting-started-banner a {
-  color: var(--vscode-textLink-foreground);
+  color: var(--color-text-link);
   text-decoration: none;
 }
 


### PR DESCRIPTION
…reset

- Add utility classes to common.css: flex layouts, text-meta, badge, panel-box
- Add common body reset with font-family, font-size, margin, color defaults
- Simplify view-specific body styles to only include layout overrides
- Refactor badge classes in profileView/historyView to extend base badge
- Fix undefined --spacing-xsmall variable (changed to --spacing-tiny)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Centralizes body reset and semantic color/border/link aliases in `common.css` and updates History/Profile/Progress/Webview styles to use them, simplifying and unifying styling.
> 
> - **Common CSS (`src/common/styles/common.css`)**:
>   - Add global body reset (margin, font, color, box-sizing).
>   - Introduce semantic aliases (`--color-text-secondary`, `--color-text-link`, `--color-border`, `--color-success`, etc.) and component aliases.
>   - Consolidate animations (`pulse-scale`, `pulse-fade`, `spin`).
>   - Remove unused `.truncate` utility.
> - **Views updated to use aliases and base reset**:
>   - `historyView`, `profileView`, `progressView`, `webview`: replace direct VS Code vars with `--color-*` aliases for text, links, borders; unify section borders and link colors; simplify `body` to layout-only overrides.
>   - ProgressView: standardize panels (`files-container`, `usage-summary-footer`, tabs, logs, instruction/todo panels) to `--color-border`/`--color-text-secondary`; use `--color-text-link` for user messages and paths; adopt shared animations.
>   - Profile/History: badges, tables, timestamps, empty states use new aliases; adjust session badge padding to `--spacing-tiny`.
>   - Misc: ensure font-size vars use shared `--font-size` (e.g., todo items).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fd7736e6746b88ad1ba316e16cef05e72ba391c8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->