### PR TITLE
Fix agent selection clearing media selection

### DIFF
--- a/src/webview/modules/handlers/fileHandlers.js
+++ b/src/webview/modules/handlers/fileHandlers.js
@@ -16,12 +16,11 @@ import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
 /**
  * Create file related handlers.
  * @param {Object} ctx
- * @param {Function} ctx.postHandle
  * @param {Function} ctx.getElement
  * @param {Function} ctx.setToggleIcon
  */
 export function createFileHandlers(ctx) {
-  const { postHandle, getElement, setToggleIcon } = ctx;
+  const { getElement, setToggleIcon } = ctx;
 
   /**
    * Helper to get restoration options for a file select.
@@ -36,20 +35,22 @@ export function createFileHandlers(ctx) {
     };
   };
 
+  // Note: File handlers do NOT call postHandle() because:
+  // 1. fileSelect.update already handles state management
+  // 2. Calling restore() after would be redundant and could cause issues
+  //    if the state was modified during the async file list refresh
   const createSetFileHandler = (fileType, domId) => (message) => {
     const options = getRestorationOptions(domId);
     fileSelect.update(domId, message.files, options);
-    postHandle();
   };
 
   const createFileSelectedHandler = (fileType, domId) => (message) => {
     safeSetElementValue(domId, message.filePath);
-    postHandle();
+    mainViewState.update({ [domId]: message.filePath });
   };
 
   const createSetFilesHandler = (fileType, listId, toggleId) => (message) => {
     fileList.update(listId, toggleId, message.files);
-    postHandle();
   };
 
   const handlers = {};
@@ -96,18 +97,17 @@ export function createFileHandlers(ctx) {
       const toggleIcon = getElement('toggleMediaFiles');
       setToggleIcon(toggleIcon, true);
     }
-
-    postHandle();
+    // No postHandle needed - fileList.update handles state
   }
 
   function handleSetDefaultOutputFiles(message) {
     fileSelect.setAgentDefaultOutputFiles(message.files || []);
-    postHandle();
+    // No postHandle needed - just storing defaults
   }
 
   function handleSetRecentCommits(message) {
     fileSelect.handleRecentCommits(message);
-    postHandle();
+    // No postHandle needed - handleRecentCommits updates the dropdown
   }
 
   function handleSetCurrentFile(message) {
@@ -115,7 +115,7 @@ export function createFileHandlers(ctx) {
       fileType: message.fileType,
       filePath: message.filePath,
     });
-    postHandle();
+    // No postHandle needed - handleSetCurrentFile dispatches change event
   }
 
   function handleSetSelectedCommit(message) {
@@ -123,7 +123,7 @@ export function createFileHandlers(ctx) {
       commitHash: message.commitHash,
       commitLabel: message.commitLabel,
     });
-    postHandle();
+    // No postHandle needed - handleSetSelectedCommit dispatches change event
   }
 
   function handleSetOpenedFiles(message) {
@@ -143,7 +143,7 @@ export function createFileHandlers(ctx) {
 
       fileList.update(multipleFileId, toggleId, filesToAdd);
     }
-    postHandle();
+    // No postHandle needed - fileList.update handles state
   }
 
   function handleSetBaseFile(message) {
@@ -158,7 +158,7 @@ export function createFileHandlers(ctx) {
       // Read value after update to get the actual restored value
       fileSelect.updateEdited(currentBaseFileDiv.value);
     }
-    postHandle();
+    // No postHandle needed - fileSelect.update handles state
   }
 
   handlers[MAIN_VIEW_COMMANDS.SET_DEFAULT_OUTPUT_FILES] =

--- a/src/webview/modules/mainViewState.js
+++ b/src/webview/modules/mainViewState.js
@@ -310,14 +310,11 @@ export class MainViewState {
     const normalizedSessionType = normalizeSessionType(sessionTypeValue);
     const activeSelectId = AGENT_SELECT_IDS[normalizedSessionType];
     if (activeSelectId) {
-      const defaultAgent = getSessionDefaultAgent(normalizedSessionType);
       const agentValue = safeGetElementValue(activeSelectId) ?? '';
-      const resolvedAgent =
-        agentValue || getSelectDefaultValue(activeSelectId, defaultAgent);
-      if (!agentValue && resolvedAgent) {
-        safeSetElementValue(activeSelectId, resolvedAgent);
-      }
-      state.agent = resolvedAgent ?? '';
+      // Save the actual DOM value, not a computed default.
+      // DOM modification during save() can trigger unexpected change events.
+      // If agent is empty, restore() or applySessionType() will handle defaults.
+      state.agent = agentValue;
       state.isToolUseAgent = normalizedSessionType === SESSION_TYPES.TOOL_USE;
     }
 

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -174,11 +174,16 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
 
         this._applyModelOptions(select, m.options);
       },
-      [MAIN_VIEW_COMMANDS.SET_AGENT_OPTIONS]: (m) => {
+      /**
+       * Handles SET_AGENT_OPTIONS command to update agent dropdowns.
+       *
+       * Like SET_MODEL_OPTIONS, waits for select elements to appear before applying.
+       * Uses a disposer pattern to handle race conditions when multiple messages
+       * arrive before elements are ready.
+       */
+      [MAIN_VIEW_COMMANDS.SET_AGENT_OPTIONS]: async (m) => {
         const optionsPayload = m.options ?? {};
-        let applied = false;
-
-        [
+        const configs = [
           {
             id: AGENT_SELECT_IDS[SESSION_TYPES.WORKFLOW],
             html: optionsPayload.workflow ?? '',
@@ -187,20 +192,54 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
             id: AGENT_SELECT_IDS[SESSION_TYPES.TOOL_USE],
             html: optionsPayload.toolUse ?? '',
           },
-        ].forEach(({ id, html }) => {
-          if (!id) {
-            return;
-          }
-          const select = document.getElementById(id);
+        ];
+
+        let applied = false;
+
+        for (const { id, html } of configs) {
+          if (!id) continue;
+
+          let select = document.getElementById(id);
           if (!isSelectLikeElement(select)) {
-            return;
+            // Wait for element to appear, similar to SET_MODEL_OPTIONS
+            const waitHandle = waitForElement(`#${id}`);
+
+            // Cancel any previous waiter for this element
+            const waiterKey = `_disposeAgentWaiter_${id}`;
+            if (this[waiterKey]) {
+              this[waiterKey]();
+            }
+
+            const disposeHandle = () => {
+              waitHandle.dispose();
+              if (this[waiterKey] === disposeHandle) {
+                this[waiterKey] = null;
+              }
+            };
+            this[waiterKey] = disposeHandle;
+
+            select = await waitHandle.promise;
+
+            // Check if superseded or disposed
+            if (this[waiterKey] !== disposeHandle || this._isDisposed) {
+              continue;
+            }
+            this[waiterKey] = null;
+
+            if (!isSelectLikeElement(select)) {
+              console.warn(
+                `SET_AGENT_OPTIONS: Agent select '${id}' not found after waiting`,
+              );
+              continue;
+            }
           }
+
           this._applyAgentOptions(select, html);
           applied = true;
-        });
+        }
 
         if (!applied) {
-          console.warn('SET_AGENT_OPTIONS: Agent select elements not found');
+          console.warn('SET_AGENT_OPTIONS: No agent select elements found');
         }
       },
       /**
@@ -679,7 +718,15 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
   _restoreModelSelection(selectElement, previousValue) {
     const savedValue = mainViewState.get?.()?.model ?? '';
     // Prioritize saved state over previous UI value for consistency
-    this._restoreSelectValue(selectElement, [savedValue, previousValue]);
+    const restored = this._restoreSelectValue(selectElement, [savedValue, previousValue]);
+
+    // If restoration failed but we have a saved value, preserve it in state.
+    // The DOM will show the fallback, but state keeps the user's preference.
+    // This prevents losing the selection when options temporarily change
+    // (e.g., due to API key changes or provider availability).
+    if (!restored && savedValue) {
+      mainViewState.update({ model: savedValue });
+    }
   }
 
   _getActiveAgentSelection() {

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -179,7 +179,8 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
        *
        * Like SET_MODEL_OPTIONS, waits for select elements to appear before applying.
        * Uses a disposer pattern to handle race conditions when multiple messages
-       * arrive before elements are ready.
+       * arrive before elements are ready. Aborts entirely if superseded to prevent
+       * stale data from overwriting newer options.
        */
       [MAIN_VIEW_COMMANDS.SET_AGENT_OPTIONS]: async (m) => {
         const optionsPayload = m.options ?? {};
@@ -220,9 +221,10 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
 
             select = await waitHandle.promise;
 
-            // Check if superseded or disposed
+            // Check if superseded or disposed - abort entirely to prevent
+            // stale data from this message overwriting newer options
             if (this[waiterKey] !== disposeHandle || this._isDisposed) {
-              continue;
+              return;
             }
             this[waiterKey] = null;
 

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -744,6 +744,8 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
       this._disposeModelWaiter();
       this._disposeModelWaiter = null;
     }
+    // Clean up any pending agent waiters from previous setup
+    this._cleanupAgentWaiters();
     super.setup();
     this._setupAgentSelectListeners();
     if (requestData) {
@@ -777,12 +779,28 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
     this._tooltipListeners = [];
   }
 
+  /** Clean up any pending agent waiters to prevent dangling MutationObservers. */
+  _cleanupAgentWaiters() {
+    // Clean up waiters for both agent select types
+    [
+      AGENT_SELECT_IDS[SESSION_TYPES.WORKFLOW],
+      AGENT_SELECT_IDS[SESSION_TYPES.TOOL_USE],
+    ].forEach((id) => {
+      const waiterKey = `_disposeAgentWaiter_${id}`;
+      if (this[waiterKey]) {
+        this[waiterKey]();
+        this[waiterKey] = null;
+      }
+    });
+  }
+
   cleanup() {
     this._isDisposed = true;
     if (this._disposeModelWaiter) {
       this._disposeModelWaiter();
       this._disposeModelWaiter = null;
     }
+    this._cleanupAgentWaiters();
 
     this._cleanupTooltipListeners();
     super.cleanup();

--- a/src/webview/modules/uiManagers/FileSelect.js
+++ b/src/webview/modules/uiManagers/FileSelect.js
@@ -67,7 +67,15 @@ export class FileSelect {
     // Only update state if we successfully restored a value.
     // Do NOT clear state when file is not in list - the file may temporarily
     // not appear during refresh cycles, and clearing would lose the user's selection.
-    // The user can manually clear the selection if needed.
+    //
+    // INTENTIONAL STATE/UI DIVERGENCE: If the selected file is not in the list,
+    // the UI shows "None" but state preserves the original selection. This allows:
+    // - Recovery when file temporarily disappears (e.g., during refresh)
+    // - Persistence across agent changes that don't affect file availability
+    //
+    // Consumers should be aware that state[id] may not match UI in edge cases.
+    // The execution flow reads from DOM, so a missing file will correctly result
+    // in no file being sent. The user can manually clear via the empty button.
     if (restoredValue) {
       mainViewState.update({ [id]: restoredValue });
     }

--- a/src/webview/modules/uiManagers/FileSelect.js
+++ b/src/webview/modules/uiManagers/FileSelect.js
@@ -64,10 +64,12 @@ export class FileSelect {
       safeSetElementValue(id, restoredValue);
     }
 
-    // Sync state: update to restored value, or clear stale value if file no longer exists
-    const hasStaleState = storedValue && !sortedFiles.includes(storedValue);
-    if (restoredValue || hasStaleState) {
-      mainViewState.update({ [id]: restoredValue ?? '' });
+    // Only update state if we successfully restored a value.
+    // Do NOT clear state when file is not in list - the file may temporarily
+    // not appear during refresh cycles, and clearing would lose the user's selection.
+    // The user can manually clear the selection if needed.
+    if (restoredValue) {
+      mainViewState.update({ [id]: restoredValue });
     }
   }
 


### PR DESCRIPTION
The issue was that changing agents would reset the media file selection to "None". This was caused by two related problems:

1. FileSelect.update() was aggressively clearing state when a file was not found in the refreshed file list ("stale state" clearing). This would lose the user's selection even if the file was just temporarily missing during the refresh cycle.

2. File handlers were calling postHandle() which in turn called mainViewState.restore(), creating a potential race condition where state changes made by the file update could be overwritten.

Fixes:
- Remove aggressive stale state clearing in FileSelect.update() - only update state when successfully restoring a value
- Remove unnecessary postHandle()/restore() calls from file handlers since they already handle their own state management

The user's file selections now persist correctly when changing agents.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Stops clearing file selections during refresh and removes redundant restore calls; adds robust async handling for agent options and refines state saving/restoration.
> 
> - **File handling**:
>   - Remove `postHandle()` calls from file handlers; rely on `fileList`/`fileSelect` for state.
>   - On single-file select, also persist to `mainViewState`.
>   - `FileSelect.update(...)`: no longer clears state when file missing; only updates state on successful restore; keeps UI/state divergence intentionally during transient refreshes.
> - **State management**:
>   - `mainViewState.save()`: store raw agent select DOM value without computing defaults; avoid DOM mutations during save.
> - **Agent/model dropdowns**:
>   - `SET_AGENT_OPTIONS`: wait-for-element with per-select disposer keys, abort on supersede, warn if none found; add waiter cleanup on setup/cleanup.
>   - `_restoreModelSelection(...)`: if restore fails, keep saved model in state to preserve preference.
>   - Tooltip listeners added/cleaned for agent selects; initial tooltip update on setup.
> - **Misc**:
>   - Avoid redundant state restores in various file-related handlers (e.g., recent commits, current/selected files, opened/base file).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 655c4e9f0d45a2f3816701474a9070ea192bd2ca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->