### PR TITLE
Add gemini3f to default package.json list

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,6 +128,7 @@
             },
             "default": [
               "gemini3p",
+              "gemini3f",
               "sonnet45T",
               "opus45T",
               "gpt52",


### PR DESCRIPTION
Include Gemini 3 Flash in the default texra.models array alongside Gemini 3 Pro for consistency with the merge model configuration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `gemini3f` (Gemini 3 Flash) to the default `texra.models` list in `package.json`.
> 
> - **Configuration**:
>   - Add `gemini3f` to default `texra.models` in `package.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 883b7744c3f39870e91642bb75957b837b03ce74. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->