### PR TITLE
Fix inconsistent component sizing issue

### DIFF
--- a/src/webview/styles/base.css
+++ b/src/webview/styles/base.css
@@ -116,7 +116,7 @@ vscode-option[data-requires-key='true'] {
   font-style: normal;
 }
 
-vscode-option[data-multiple='true'] {
+vscode-option {
   font-family: codicon, var(--vscode-font-family);
 }
 


### PR DESCRIPTION
Apply codicon font to all vscode-option elements, not just those with data-multiple attribute, so Unicode icons render consistently.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Apply codicon font to all vscode-option elements (not just [data-multiple='true']) to standardize icon rendering/sizing.
> 
> - **Styles**:
>   - Broaden selector in `src/webview/styles/base.css` to apply `font-family: codicon, var(--vscode-font-family)` to all `vscode-option` (was only `vscode-option[data-multiple='true']`) for consistent icon rendering/sizing.
>   - Preserve italic styling for `vscode-option[data-tool-use='true']`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2ef0e0199af91e33cf0740723061020baa674fe2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->