### PR TITLE
Fix select element functionality

### DIFF
--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -579,30 +579,52 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
       (opt) => opt.value === value,
     );
 
+    // Clear 'selected' attribute from all existing options first.
+    // vscode-single-select reads the 'selected' property during slotchange.
+    Array.from(selectElement.children).forEach((opt) => {
+      opt.removeAttribute('selected');
+      if ('selected' in opt) {
+        opt.selected = false;
+      }
+    });
+
+    // Determine the target option - either existing or newly created
+    let targetOption = existingOption;
+
     // If option doesn't exist, create a placeholder with clean display name.
     // SET_AGENT_OPTIONS will replace this with properly decorated options.
-    if (!existingOption) {
-      const option = document.createElement('vscode-option');
-      option.value = value;
+    if (!targetOption) {
+      targetOption = document.createElement('vscode-option');
+      targetOption.value = value;
 
       // Extract clean name from source:name format
       const parsed = this._parseAgentKey(value);
       const displayName = parsed ? parsed.name : value;
 
-      option.textContent = displayName;
-      option.dataset.label = displayName;
+      targetOption.textContent = displayName;
+      targetOption.dataset.label = displayName;
 
       // Set source-based data attributes for basic styling
       if (parsed) {
-        option.dataset.source = parsed.source;
+        targetOption.dataset.source = parsed.source;
         if (parsed.source === 'remote') {
-          option.dataset.remote = 'true';
+          targetOption.dataset.remote = 'true';
         } else if (parsed.source === 'custom') {
-          option.dataset.custom = 'true';
+          targetOption.dataset.custom = 'true';
         }
       }
 
-      selectElement.appendChild(option);
+      // Mark as selected BEFORE appending so slotchange picks it up
+      targetOption.setAttribute('selected', '');
+      targetOption.selected = true;
+
+      selectElement.appendChild(targetOption);
+    } else {
+      // For existing options, set selected attribute
+      targetOption.setAttribute('selected', '');
+      if ('selected' in targetOption) {
+        targetOption.selected = true;
+      }
     }
 
     // Set the value and dispatch change event to update the component's display


### PR DESCRIPTION
The vscode-single-select component doesn't update visually when setting element.value programmatically after dynamically adding an option. The fix explicitly sets the 'selected' attribute on the target option and clears it from all others, which triggers the component to update its visual display.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Explicitly clears existing selections and sets the selected state on the target option (existing or newly created) to make `vscode-single-select` reflect programmatic agent changes.
> 
> - **Webview**:
>   - **Agent select handling (`src/webview/modules/messageHandlers.js`)**:
>     - Clear `selected` from all existing options before updating.
>     - For target option (existing or new placeholder), set `selected` attribute and property; set before appending for new options to trigger `slotchange`.
>     - Preserve/derive display label and source metadata on placeholder options.
>     - Ensure value is set and `change` event dispatched to update component UI.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 87e68744a814c2b29c430e42a17bc1ddedaac977. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->