### PR TITLE
fix: enforce schema as single source of truth for UserVariableChannels

### DIFF
--- a/src/agent/core/AgentCycleOptions.ts
+++ b/src/agent/core/AgentCycleOptions.ts
@@ -7,21 +7,18 @@ import type { AgentExecutionContext } from '@agent/runtime/AgentExecutionContext
 import type { AgentLogger } from '@logger/AgentLogger';
 import type { AgentPrompt, AgentSetting } from './AgentDataclass';
 
-export interface UserVariableChannels {
-  input: Readonly<Record<string, any>>;
-  transient: Record<string, any>;
-  output: Record<string, any>;
-}
-
 /**
  * We use z.object() instead of z.strictObject() to remain backward compatible
  * with legacy user variable channels that may contain removed or renamed fields.
  */
 export const UserVariableChannelsSchema = z.object({
-  input: z.record(z.string(), z.unknown()),
+  input: z.record(z.string(), z.unknown()).readonly(),
   transient: z.record(z.string(), z.unknown()),
   output: z.record(z.string(), z.unknown()),
 });
+
+/** Derived from UserVariableChannelsSchema - single source of truth */
+export type UserVariableChannels = z.infer<typeof UserVariableChannelsSchema>;
 
 export interface AgentCycleBaseOptions<C = unknown> {
   modelHandler: IModelHandler<any, any, any, any, C>;

--- a/src/agent/remote/types.ts
+++ b/src/agent/remote/types.ts
@@ -8,8 +8,11 @@
 import { z } from 'zod';
 
 // Local imports - agent core
-import { AgentCategory } from '@agent/core/AgentDataclass';
-import type { AgentSetting, AgentPrompt } from '@agent/core/AgentDataclass';
+import {
+  AgentCategory,
+  AgentSettingSchema,
+  AgentPromptSchema,
+} from '@agent/core/AgentDataclass';
 
 // Re-export LoadAgentOptions as RemoteAgentLoadOptions for API consistency
 export type { LoadAgentOptions as RemoteAgentLoadOptions } from '@agent/runtime/agentLoad';
@@ -42,11 +45,15 @@ export const RemoteAgentMetadataSchema = z.object({
 export type RemoteAgentMetadata = z.infer<typeof RemoteAgentMetadataSchema>;
 
 /**
- * Configuration loaded from a remote agent source.
+ * Schema for configuration loaded from a remote agent source.
+ * Composed from existing schemas - single source of truth.
  */
-export interface RemoteAgentConfig {
-  name: string;
-  settings: AgentSetting;
-  prompts: AgentPrompt;
-  metadata: RemoteAgentMetadata;
-}
+export const RemoteAgentConfigSchema = z.strictObject({
+  name: z.string(),
+  settings: AgentSettingSchema,
+  prompts: AgentPromptSchema,
+  metadata: RemoteAgentMetadataSchema,
+});
+
+/** Derived from RemoteAgentConfigSchema - single source of truth */
+export type RemoteAgentConfig = z.infer<typeof RemoteAgentConfigSchema>;

--- a/src/agent/toolUse/ToolUseSnapshotTypes.ts
+++ b/src/agent/toolUse/ToolUseSnapshotTypes.ts
@@ -26,10 +26,19 @@ export const ToolUseSessionSnapshotSchema = z.object({
   lastUpdated: z.number(),
 });
 
+/** Derived from ToolUseSessionSnapshotSchema - single source of truth */
 export type ToolUseSessionSnapshot = z.infer<
   typeof ToolUseSessionSnapshotSchema
 >;
 
+/**
+ * Input payload for saving a tool-use session snapshot.
+ *
+ * NOTE: This is a manual interface (not schema-derived) because `store` is an
+ * AgentSharedStore class instance with methods (e.g., toSnapshot()), not a plain
+ * data structure. Zod schemas cannot validate class instances with private fields.
+ * The store is serialized to AgentSharedStoreSnapshot during the save operation.
+ */
 export interface SaveToolUseSnapshotPayload {
   executionId: ExecutionId;
   streamId: StreamTabId;

--- a/src/tools/TextEditorTool.ts
+++ b/src/tools/TextEditorTool.ts
@@ -25,7 +25,7 @@ import { WorkspaceFS, AbsoluteFS } from '@utils/files';
 // Local file imports
 import { defineTool } from './core/define';
 import { ToolResult, ToolError, cliResult, toolResult } from './result';
-import { ToolCallInput, EditorCommand, FileHistoryEntry } from './types';
+import { FileHistoryEntry } from './types';
 
 // Local imports - approval helpers
 
@@ -47,7 +47,11 @@ export const TextEditorInputSchema = z.strictObject({
   insert_line: z.number().optional(),
 });
 
+/** Derived from TextEditorInputSchema - single source of truth */
 export type TextEditorInput = z.infer<typeof TextEditorInputSchema>;
+
+/** Command type derived from TextEditorInputSchema */
+export type EditorCommand = TextEditorInput['command'];
 
 /**
  * Implementation of Anthropic's text editor tool for VS Code

--- a/src/tools/types.ts
+++ b/src/tools/types.ts
@@ -28,28 +28,12 @@ export interface TextEditorToolParams extends BetaToolUnionParam {
     | 'text_editor_20250429';
 }
 
-/**
- * Command types for the text editor tool
- */
-export type EditorCommand =
-  | 'view'
-  | 'create'
-  | 'str_replace'
-  | 'insert'
-  | 'undo_edit';
-
-/**
- * Interface for the tool call input
- */
-export interface ToolCallInput {
-  command: EditorCommand;
-  path: string;
-  file_text?: string;
-  view_range?: [number, number];
-  old_str?: string;
-  new_str?: string;
-  insert_line?: number;
-}
+// Re-export schema-derived types from TextEditorTool (single source of truth)
+export {
+  EditorCommand,
+  TextEditorInput,
+  TextEditorInput as ToolCallInput, // Alias for backward compatibility
+} from './TextEditorTool';
 
 /**
  * Interface for file history entries


### PR DESCRIPTION
- Derive UserVariableChannels type from UserVariableChannelsSchema instead
  of duplicating field definitions in both interface and schema
- Add .readonly() to input field in schema to match original interface
- Document SaveToolUseSnapshotPayload interface explaining why it's manual
  (accepts class instance with methods, not plain data structure)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Derives types from Zod schemas (including readonly `input`), introduces strict `RemoteAgentConfigSchema`, centralizes text editor input/command types, and documents the manual snapshot save payload.
> 
> - **Core**
>   - Derive `UserVariableChannels` from `UserVariableChannelsSchema`; make `input` channel `readonly`.
> - **Remote Agent**
>   - Add strict `RemoteAgentConfigSchema` composed of `AgentSettingSchema` and `AgentPromptSchema`; export `RemoteAgentConfig` from schema inference.
> - **Tool Use**
>   - Add documented `SaveToolUseSnapshotPayload` interface (manual, not schema-derived); keep `ToolUseSessionSnapshot` type from schema.
> - **Tools (Text Editor)**
>   - Define `TextEditorInputSchema` and infer `TextEditorInput`; derive `EditorCommand` from schema.
>   - Remove duplicated editor types from `types.ts` and re-export schema-derived types (alias `ToolCallInput` for backward compatibility).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 60470600f5c30528b1363aad001d1810e5714f2f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->