### PR TITLE
feat: add workflow-to-tool-use agent chaining

### DIFF
--- a/resources/tool_use_agents/chat.yaml
+++ b/resources/tool_use_agents/chat.yaml
@@ -42,4 +42,12 @@ prompts:
 
     Guidelines on using Tools: (1) For bash operations, distinguish between safe and potentially risky commands. Safe commands (execute without confirmation): ls, pwd, cat, echo, grep, find, which, date, whoami. Potentially complicated operations: Ask for confirmation before executing (e.g., rm, mv, cp with wildcards, curl/wget, npm/pip install, git operations beyond status/log). (2) Clearly explain what any command will do before executing it. (3) Use `extract_figures` to gather image assets referenced in LaTeX documents, `extract_bib_entries` to pull BibTeX records for cited references, and `extract_tikz_figures` to compile TikZ diagrams when the user needs visual outputs. (4) For some tool use users have the options to reject or edit the changes before they are applied. Pay attention to the user's feedback and adjust your behavior accordingly.
   userRequest: |
+    {% if WORKFLOW_CONTEXT %}
+    <workflow_output>
+    The following content was produced by a previous workflow agent. The user would like to refine or continue working on this output:
+
+    {{ WORKFLOW_CONTEXT }}
+    </workflow_output>
+
+    {% endif %}
     {{ INSTRUCTION }}

--- a/resources/tool_use_agents/discuss.yaml
+++ b/resources/tool_use_agents/discuss.yaml
@@ -61,4 +61,12 @@ prompts:
     (4) Be willing to revise your position based on new arguments or evidence.
     (5) Distinguish between established knowledge and your own interpretations.
   userRequest: |
+    {% if WORKFLOW_CONTEXT %}
+    <workflow_output>
+    The following content was produced by a previous workflow agent. The user would like to discuss or refine this output:
+
+    {{ WORKFLOW_CONTEXT }}
+    </workflow_output>
+
+    {% endif %}
     {{ INSTRUCTION }}

--- a/src/agent/core/AgentConfig.ts
+++ b/src/agent/core/AgentConfig.ts
@@ -41,6 +41,10 @@ const AgentConfigBaseSchema = z
     instruction: z.string().prefault(''),
     useMultipleOutputs: z.boolean().prefault(false),
 
+    // Optional context from a prior workflow agent execution
+    // Used when chaining workflow output into a tool-use agent for refinement
+    workflowContext: z.string().nullable().prefault(null),
+
     // Legacy field for backward compatibility - prefer session.agentType
     agentType: z.enum(AgentType).optional(),
     // Canonical session descriptor - single source of truth

--- a/src/agent/utils/userVars.ts
+++ b/src/agent/utils/userVars.ts
@@ -86,6 +86,8 @@ function getBasicVars(
   return {
     MODEL: agentConfig.model,
     INSTRUCTION: agentConfig.instruction,
+    // Context from prior workflow agent execution (for chaining agents)
+    WORKFLOW_CONTEXT: agentConfig.workflowContext,
     IS_OPENAI_MODEL: modelHandler.isOpenai,
     IS_ANTHROPIC_MODEL: modelHandler.isAnthropic,
     IS_GOOGLE_MODEL: modelHandler.isGoogle,

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -27,6 +27,7 @@ import {
   registerAgentCreatorCommands,
   registerFollowUpCommand,
   registerResumeAgentCommand,
+  registerContinueWithChatCommand,
 } from '@commands/agent';
 import {
   registerTestCommands,
@@ -101,6 +102,7 @@ export function registerCommands(context: vscode.ExtensionContext) {
     progressView: registerProgressViewCommands(context),
     followUp: registerFollowUpCommand(context),
     resumeAgent: registerResumeAgentCommand(context),
+    continueWithChat: registerContinueWithChatCommand(context),
     openFile: registerOpenFileCommands(context),
     help: registerHelpCommands(context),
     mainView: registerMainViewCommands(context),

--- a/src/commands/agent/continueWithChatCommand.ts
+++ b/src/commands/agent/continueWithChatCommand.ts
@@ -1,0 +1,209 @@
+/**
+ * Command to continue a workflow agent's output with an interactive tool-use (chat) agent.
+ *
+ * This enables graceful chaining: when a workflow agent gets you 90% of the way there,
+ * you can hand off to a chat agent for fine-tuning and interactive refinement.
+ */
+
+// Standard library imports
+import { randomUUID } from 'crypto';
+
+// Third-party imports
+import * as vscode from 'vscode';
+
+// Local imports
+import { parseAgentConfig, type AgentConfig } from '@agent/core/AgentConfig';
+import { executeAgent } from '@agent/runtime/executeAgent';
+import type { ExecutionId } from '@agent/types/IdentifierTypes';
+import { AgentHistoryManager } from '@common/history';
+import * as logger from '@logger/logUtils';
+import { WorkspaceFS } from '@utils/files';
+
+const CHANNEL = 'ContinueWithChatCommand';
+
+/**
+ * Payload for the continueWithChat command.
+ */
+export interface ContinueWithChatPayload {
+  /** The workflow context to pass to the chat agent (document content) */
+  workflowContext: string;
+
+  /** Optional instruction for what to do with the workflow output */
+  instruction?: string;
+
+  /** Optional model to use (defaults to config's default) */
+  model?: string;
+
+  /** Optional: input file path for the chat agent to work with */
+  inputFile?: string;
+
+  /** Optional: additional input files */
+  inputFiles?: string[];
+
+  /** Optional: reference files for context */
+  referenceFiles?: string[];
+}
+
+/**
+ * Builds the workflow context from a file path.
+ * Reads the file content and returns it as a string.
+ */
+export async function buildWorkflowContextFromFile(
+  filePath: string,
+): Promise<string> {
+  try {
+    const content = await WorkspaceFS.read(filePath);
+    return content;
+  } catch (error) {
+    logger.warn(CHANNEL, `Failed to read workflow output file: ${filePath}`, {
+      data: error,
+    });
+    return '';
+  }
+}
+
+/**
+ * Builds the workflow context from multiple file paths.
+ * Combines file contents with XML-style wrappers.
+ */
+export async function buildWorkflowContextFromFiles(
+  filePaths: string[],
+): Promise<string> {
+  const contents = await Promise.all(
+    filePaths.map(async (filePath) => {
+      try {
+        const content = await WorkspaceFS.read(filePath);
+        const fileName = filePath.split('/').pop() || filePath;
+        return `<document name="${fileName}">\n${content}\n</document>`;
+      } catch {
+        return null;
+      }
+    }),
+  );
+
+  return contents.filter(Boolean).join('\n\n');
+}
+
+/**
+ * Continues with a chat agent using the provided workflow context.
+ */
+export async function continueWithChat(
+  payload: ContinueWithChatPayload,
+): Promise<void> {
+  const {
+    workflowContext,
+    instruction = 'Please review the workflow output above and help me refine it.',
+    model,
+    inputFile,
+    inputFiles = [],
+    referenceFiles = [],
+  } = payload;
+
+  if (!workflowContext || workflowContext.trim().length === 0) {
+    void vscode.window.showWarningMessage(
+      'No workflow context provided. Please run a workflow agent first.',
+    );
+    return;
+  }
+
+  // Build the agent configuration for the chat agent
+  const chatConfig: Partial<AgentConfig> = {
+    agent: 'chat',
+    instruction,
+    workflowContext,
+    inputFile: inputFile || '',
+    inputFiles,
+    referenceFiles,
+  };
+
+  if (model) {
+    chatConfig.model = model;
+  }
+
+  try {
+    const normalizedConfig = parseAgentConfig(chatConfig);
+    const executionId = randomUUID() as ExecutionId;
+
+    await AgentHistoryManager.addToHistory(executionId, normalizedConfig);
+    await executeAgent(normalizedConfig, executionId);
+
+    logger.info(
+      CHANNEL,
+      `Started chat agent with workflow context (${workflowContext.length} chars)`,
+    );
+  } catch (error) {
+    logger.error(CHANNEL, 'Failed to start chat agent', { data: error });
+    void vscode.window.showErrorMessage(
+      `Failed to continue with chat: ${error instanceof Error ? error.message : 'Unknown error'}`,
+    );
+  }
+}
+
+/**
+ * Registers the continueWithChat command.
+ */
+export function registerContinueWithChatCommand(
+  context: vscode.ExtensionContext,
+): void {
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      'texra.continueWithChat',
+      async (payload: ContinueWithChatPayload) => {
+        await continueWithChat(payload);
+      },
+    ),
+  );
+
+  // Also register a convenience command that prompts for input
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      'texra.continueWithChatFromFile',
+      async (fileUri?: vscode.Uri) => {
+        let filePath: string | undefined;
+
+        if (fileUri) {
+          filePath = fileUri.fsPath;
+        } else {
+          // Prompt user to select a file
+          const selectedFiles = await vscode.window.showOpenDialog({
+            canSelectMany: false,
+            openLabel: 'Select Workflow Output',
+            filters: {
+              'Text files': ['tex', 'txt', 'md', 'xml'],
+              'All files': ['*'],
+            },
+          });
+
+          if (!selectedFiles || selectedFiles.length === 0) {
+            return;
+          }
+          filePath = selectedFiles[0].fsPath;
+        }
+
+        const workflowContext = await buildWorkflowContextFromFile(filePath);
+        if (!workflowContext) {
+          void vscode.window.showWarningMessage('Could not read the file.');
+          return;
+        }
+
+        // Prompt for instruction
+        const instruction = await vscode.window.showInputBox({
+          prompt: 'What would you like to refine or change?',
+          placeHolder:
+            'e.g., "Polish the introduction" or "Fix the mathematical notation"',
+          value: 'Please help me refine this document.',
+        });
+
+        if (instruction === undefined) {
+          return; // User cancelled
+        }
+
+        await continueWithChat({
+          workflowContext,
+          instruction: instruction || 'Please help me refine this document.',
+          inputFile: filePath,
+        });
+      },
+    ),
+  );
+}

--- a/src/commands/agent/index.ts
+++ b/src/commands/agent/index.ts
@@ -4,6 +4,13 @@ export {
   agentCreatorCommands,
   registerAgentCreatorCommands,
 } from './agentCreatorCommands';
+export {
+  continueWithChat,
+  registerContinueWithChatCommand,
+  buildWorkflowContextFromFile,
+  buildWorkflowContextFromFiles,
+  type ContinueWithChatPayload,
+} from './continueWithChatCommand';
 export { executeCommand, registerExecuteCommand } from './executeCommand';
 export { registerFollowUpCommand } from './followUpCommand';
 export { mergeCommands, registerMergeCommands } from './mergeCommands';

--- a/src/webview/managers/ExecutionManager.ts
+++ b/src/webview/managers/ExecutionManager.ts
@@ -141,6 +141,7 @@ export class ExecutionManager {
           .filter((f: string | null): f is string => f !== null),
       ),
       editedFile: null,
+      workflowContext: null,
       toolConfig,
       agentType: session.agentType,
       session,


### PR DESCRIPTION
Enable graceful handoff from workflow agents to tool-use agents for
refinement. When a workflow agent gets 90% of the way there, users can
now continue with a chat agent for fine-tuning and interactive changes.

Changes:
- Add `workflowContext` field to AgentConfig for passing prior output
- Add WORKFLOW_CONTEXT user variable in prompt rendering
- Create `texra.continueWithChat` command for chaining agents
- Update chat.yaml and discuss.yaml to use workflow context
- Add `texra.continueWithChatFromFile` convenience command with UI

The workflow context is wrapped in XML tags and injected into the
tool-use agent's initial prompt, giving full context of prior work.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds workflow-to-chat handoff using a new workflowContext field, prompt support, and continueWithChat commands.
> 
> - **Agent prompts (tool-use)**:
>   - `resources/tool_use_agents/chat.yaml` and `discuss.yaml`: conditionally inject prior workflow output via `WORKFLOW_CONTEXT` wrapped in `<workflow_output>`.
> - **Core config & vars**:
>   - `AgentConfig`: add nullable `workflowContext` field; propagate through schema.
>   - `userVars`: expose `WORKFLOW_CONTEXT` from `agentConfig.workflowContext`.
> - **Commands**:
>   - New `texra.continueWithChat` and `texra.continueWithChatFromFile` with helpers to build context from file(s); execute chat agent with provided context.
>   - Registered in `src/commands.ts` and exported via `commands/agent/index.ts`.
> - **Webview**:
>   - `ExecutionManager`: include `workflowContext` (default `null`) in composed tool-use configs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0e78b8f2b9f0e048cc08d14c344dac95aa7392b2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->