### PR TITLE
Fix button hover tooltips and aux tips

### DIFF
--- a/src/historyView/index.html
+++ b/src/historyView/index.html
@@ -69,12 +69,14 @@
             class="search-nav-btn"
             icon="chevron-up"
             label="Previous match"
+            title="Previous match"
           ></vscode-toolbar-button>
           <vscode-toolbar-button
             id="nextMatch"
             class="search-nav-btn"
             icon="chevron-down"
             label="Next match"
+            title="Next match"
           ></vscode-toolbar-button>
           <span id="matchCount" class="match-count"></span>
         </vscode-toolbar-container>
@@ -97,16 +99,19 @@
               class="delete-btn"
               icon="trash"
               label="Delete"
+              title="Delete"
             ></vscode-toolbar-button>
             <vscode-toolbar-button
               class="restore-btn"
               icon="reply"
               label="Restore"
+              title="Restore"
             ></vscode-toolbar-button>
             <vscode-toolbar-button
               class="rerun-btn"
               icon="debug-rerun"
               label="Rerun"
+              title="Rerun"
             ></vscode-toolbar-button>
           </vscode-toolbar-container>
         </div>

--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -206,7 +206,8 @@
               <vscode-toolbar-button
                 id="polishFollowUpBtn"
                 icon="sparkle"
-                label="Polish follow-up with AI"
+                label="Polish follow-up"
+                title="Polish follow-up with AI"
               ></vscode-toolbar-button>
               <vscode-progress-ring
                 id="polishFollowUpProgressContainer"
@@ -216,22 +217,26 @@
                 id="resetApprovalBypassBtn"
                 icon="shield"
                 label="Resume approval prompts"
+                title="Resume approval prompts"
                 hidden
               ></vscode-toolbar-button>
               <vscode-toolbar-button
                 id="recordFollowUpBtn"
                 icon="mic"
-                label="Record follow-up with microphone"
+                label="Record follow-up"
+                title="Record follow-up with microphone"
               ></vscode-toolbar-button>
               <vscode-toolbar-button
                 id="clearFollowUpBtn"
                 icon="clear-all"
                 label="Clear input"
+                title="Clear input"
               ></vscode-toolbar-button>
               <vscode-toolbar-button
                 id="sendFollowUpBtn"
                 icon="send"
                 label="Send"
+                title="Send follow-up message"
               ></vscode-toolbar-button>
             </div>
           </div>
@@ -249,26 +254,31 @@
                   class="compare-btn"
                   icon="diff"
                   label="Compare with base"
+                  title="Compare with base"
                 ></vscode-toolbar-button>
                 <vscode-toolbar-button
                   class="accept-btn"
                   icon="check"
                   label="Accept edits"
+                  title="Accept edits"
                 ></vscode-toolbar-button>
                 <vscode-toolbar-button
                   class="merge-btn"
                   icon="git-merge"
                   label="Merge edits"
+                  title="Merge edits"
                 ></vscode-toolbar-button>
                 <vscode-toolbar-button
                   class="diff-btn"
                   icon="diff-single"
                   label="LaTeXdiff"
+                  title="LaTeXdiff"
                 ></vscode-toolbar-button>
                 <vscode-toolbar-button
                   class="prev-btn"
                   icon="diff-added"
                   label="Compare with previous round"
+                  title="Compare with previous round"
                 ></vscode-toolbar-button>
               </vscode-toolbar-container>
             </div>
@@ -306,6 +316,7 @@
                 data-stream=""
                 icon="close"
                 label="Delete stream"
+                title="Delete stream"
               ></vscode-toolbar-button>
             </div>
           </template>
@@ -432,12 +443,14 @@
                 <vscode-toolbar-button
                   icon="refresh"
                   label="Retry"
+                  title="Retry"
                   data-action="retry"
                   >Retry</vscode-toolbar-button
                 >
                 <vscode-toolbar-button
                   icon="close"
                   label="Dismiss"
+                  title="Dismiss"
                   data-action="dismiss"
                   >Dismiss</vscode-toolbar-button
                 >
@@ -454,24 +467,28 @@
                 <vscode-toolbar-button
                   icon="diff"
                   label="Open diff"
+                  title="Open diff"
                   data-action="open"
                   >Open diff</vscode-toolbar-button
                 >
                 <vscode-toolbar-button
                   icon="check"
                   label="Approve"
+                  title="Approve"
                   data-action="approve"
                   >Approve</vscode-toolbar-button
                 >
                 <vscode-toolbar-button
                   icon="close"
                   label="Reject"
+                  title="Reject"
                   data-action="reject"
                   >Reject</vscode-toolbar-button
                 >
                 <vscode-toolbar-button
                   icon="shield"
-                  label="Approve &amp; Yolo this session"
+                  label="Approve & Yolo this session"
+                  title="Approve & Yolo this session"
                   data-action="approveAll"
                   data-toggle-action="resumeApprovals"
                   toggleable

--- a/src/webview/index.html
+++ b/src/webview/index.html
@@ -173,7 +173,7 @@
                 ></vscode-toolbar-button>
                 <label
                   for="referenceFile"
-                  title="Example or context files that guide the agent's output"
+                  title="Context files such as .bib/.bbl or other papers that guide output but won't be modified"
                   >Reference</label
                 >
               </div>

--- a/src/webview/index.html
+++ b/src/webview/index.html
@@ -243,7 +243,7 @@
                 ></vscode-toolbar-button>
                 <label
                   for="auxiliaryFile"
-                  title="Supporting files required for correct processing, including .cls and .sty"
+                  title="Supporting files such as preamble.tex, .cls, and .sty"
                   >Auxiliary</label
                 >
               </div>

--- a/src/webview/index.html
+++ b/src/webview/index.html
@@ -74,6 +74,7 @@
                   id="refreshInputFileButton"
                   icon="file-code"
                   label="Refresh input files"
+                  title="Refresh input files"
                 ></vscode-toolbar-button>
                 <label
                   for="inputFile"
@@ -111,11 +112,13 @@
                   id="currentInputFileButton"
                   icon="file-code"
                   label="Set current file as input"
+                  title="Set current file as input"
                 ></vscode-toolbar-button>
                 <vscode-toolbar-button
                   id="emptyInputFileButton"
                   icon="close"
-                  label="Empty"
+                  label="Clear input file"
+                  title="Clear input file"
                 ></vscode-toolbar-button>
                 <span
                   id="toggleInputFiles"
@@ -128,18 +131,21 @@
                   class="file-action-button"
                   icon="folder-opened"
                   label="Add opened files as input"
+                  title="Add opened files as input"
                 ></vscode-toolbar-button>
                 <vscode-toolbar-button
                   id="emptyInputFilesButton"
                   class="file-action-button"
                   icon="trash"
-                  label="Empty"
+                  label="Clear all input files"
+                  title="Clear all input files"
                 ></vscode-toolbar-button>
                 <vscode-toolbar-button
                   id="selectInputFilesButton"
                   class="file-action-button"
                   icon="add"
-                  label="Add"
+                  label="Add input files"
+                  title="Add input files"
                 ></vscode-toolbar-button>
               </vscode-toolbar-container>
             </div>
@@ -163,6 +169,7 @@
                   id="refreshReferenceFileButton"
                   icon="book"
                   label="Refresh reference files"
+                  title="Refresh reference files"
                 ></vscode-toolbar-button>
                 <label
                   for="referenceFile"
@@ -175,11 +182,13 @@
                   id="currentReferenceFileButton"
                   icon="file-code"
                   label="Set current file as reference"
+                  title="Set current file as reference"
                 ></vscode-toolbar-button>
                 <vscode-toolbar-button
                   id="emptyReferenceFileButton"
                   icon="close"
-                  label="Empty"
+                  label="Clear reference file"
+                  title="Clear reference file"
                 ></vscode-toolbar-button>
                 <span
                   id="toggleReferenceFiles"
@@ -192,18 +201,21 @@
                   class="file-action-button"
                   icon="folder-opened"
                   label="Add opened files as reference"
+                  title="Add opened files as reference"
                 ></vscode-toolbar-button>
                 <vscode-toolbar-button
                   id="emptyReferenceFilesButton"
                   class="file-action-button"
                   icon="trash"
-                  label="Empty"
+                  label="Clear all reference files"
+                  title="Clear all reference files"
                 ></vscode-toolbar-button>
                 <vscode-toolbar-button
                   id="selectReferenceFilesButton"
                   class="file-action-button"
                   icon="add"
-                  label="Add"
+                  label="Add reference files"
+                  title="Add reference files"
                 ></vscode-toolbar-button>
               </vscode-toolbar-container>
             </div>
@@ -227,10 +239,11 @@
                   id="refreshAuxiliaryFileButton"
                   icon="file-add"
                   label="Refresh auxiliary files"
+                  title="Refresh auxiliary files"
                 ></vscode-toolbar-button>
                 <label
                   for="auxiliaryFile"
-                  title="Supporting files required for correct processing, including .cls, .sty, .bib"
+                  title="Supporting files required for correct processing, including .cls and .sty"
                   >Auxiliary</label
                 >
               </div>
@@ -239,11 +252,13 @@
                   id="currentAuxiliaryFileButton"
                   icon="file-code"
                   label="Set current file as auxiliary"
+                  title="Set current file as auxiliary"
                 ></vscode-toolbar-button>
                 <vscode-toolbar-button
                   id="emptyAuxiliaryFileButton"
                   icon="close"
-                  label="Empty"
+                  label="Clear auxiliary file"
+                  title="Clear auxiliary file"
                 ></vscode-toolbar-button>
                 <span
                   id="toggleAuxiliaryFiles"
@@ -256,18 +271,21 @@
                   class="file-action-button"
                   icon="folder-opened"
                   label="Add opened files as auxiliary"
+                  title="Add opened files as auxiliary"
                 ></vscode-toolbar-button>
                 <vscode-toolbar-button
                   id="emptyAuxiliaryFilesButton"
                   class="file-action-button"
                   icon="trash"
-                  label="Empty"
+                  label="Clear all auxiliary files"
+                  title="Clear all auxiliary files"
                 ></vscode-toolbar-button>
                 <vscode-toolbar-button
                   id="selectAuxiliaryFilesButton"
                   class="file-action-button"
                   icon="add"
-                  label="Add"
+                  label="Add auxiliary files"
+                  title="Add auxiliary files"
                 ></vscode-toolbar-button>
               </vscode-toolbar-container>
             </div>
@@ -291,6 +309,7 @@
                   id="refreshMediaFileButton"
                   icon="file-media"
                   label="Refresh media files"
+                  title="Refresh media files"
                 ></vscode-toolbar-button>
                 <label
                   for="mediaFile"
@@ -330,7 +349,8 @@
                 <vscode-toolbar-button
                   id="emptyMediaFileButton"
                   icon="close"
-                  label="Empty"
+                  label="Clear media file"
+                  title="Clear media file"
                 ></vscode-toolbar-button>
                 <span
                   id="toggleMediaFiles"
@@ -342,13 +362,15 @@
                   id="emptyMediaFilesButton"
                   class="file-action-button"
                   icon="trash"
-                  label="Empty"
+                  label="Clear all media files"
+                  title="Clear all media files"
                 ></vscode-toolbar-button>
                 <vscode-toolbar-button
                   id="selectMediaFilesButton"
                   class="file-action-button"
                   icon="add"
-                  label="Add"
+                  label="Add media files"
+                  title="Add media files"
                 ></vscode-toolbar-button>
               </vscode-toolbar-container>
             </div>
@@ -385,13 +407,15 @@
                   id="emptyOutputFilesButton"
                   class="file-action-button"
                   icon="trash"
-                  label="Empty"
+                  label="Clear all output files"
+                  title="Clear all output files"
                 ></vscode-toolbar-button>
                 <vscode-toolbar-button
                   id="selectOutputFilesButton"
                   class="file-action-button"
                   icon="add"
-                  label="Add"
+                  label="Add output files"
+                  title="Add output files"
                 ></vscode-toolbar-button>
               </vscode-toolbar-container>
             </div>
@@ -439,19 +463,22 @@
               <vscode-toolbar-button
                 id="packButton"
                 icon="archive"
-                label="Pack the output for this agent into the History folder"
+                label="Pack output to History"
+                title="Pack the output for this agent into the History folder"
                 style="display: none"
               ></vscode-toolbar-button>
               <vscode-toolbar-button
                 id="cleanButton"
                 icon="trash"
-                label="Clean the output for this agent"
+                label="Clean output"
+                title="Clean the output for this agent"
                 style="display: none"
               ></vscode-toolbar-button>
               <vscode-toolbar-button
                 id="magicPolishButton"
                 icon="sparkle"
-                label="Polish instruction text with AI"
+                label="Polish instruction"
+                title="Polish instruction text with AI"
               ></vscode-toolbar-button>
               <vscode-progress-ring
                 id="polishProgressContainer"
@@ -460,12 +487,14 @@
               <vscode-toolbar-button
                 id="recordInstructionButton"
                 icon="mic"
-                label="Record instruction with microphone"
+                label="Record instruction"
+                title="Record instruction with microphone"
               ></vscode-toolbar-button>
               <vscode-toolbar-button
                 id="eraseInstructionButton"
                 icon="clear-all"
-                label="Erase Instruction"
+                label="Erase instruction"
+                title="Erase instruction"
               ></vscode-toolbar-button>
             </vscode-toolbar-container>
           </div>
@@ -653,11 +682,13 @@
                   id="currentBaseFileButton"
                   icon="file-code"
                   label="Set current file as base"
+                  title="Set current file as base"
                 ></vscode-toolbar-button>
                 <vscode-toolbar-button
                   id="emptyBaseFileButton"
                   icon="close"
-                  label="Empty"
+                  label="Clear base file"
+                  title="Clear base file"
                 ></vscode-toolbar-button>
               </vscode-toolbar-container>
             </div>
@@ -672,6 +703,7 @@
                   id="refreshEditedFileButton"
                   icon="edit"
                   label="Refresh edited files"
+                  title="Refresh edited files"
                 ></vscode-toolbar-button>
                 <label
                   for="editedFile"
@@ -683,32 +715,38 @@
                 <vscode-toolbar-button
                   id="acceptButton"
                   icon="check"
-                  label="Accept changes from edited file and overwrite base file"
+                  label="Accept changes"
+                  title="Accept changes from edited file and overwrite base file"
                 ></vscode-toolbar-button>
                 <vscode-toolbar-button
                   id="compareButton"
                   icon="diff"
-                  label="Compare the selected edited file with the selected base file"
+                  label="Compare files"
+                  title="Compare the selected edited file with the selected base file"
                 ></vscode-toolbar-button>
                 <vscode-toolbar-button
                   id="mergeButton"
                   icon="merge"
-                  label="Create a new verion of the base file by merging the edits suggested by the edited file"
+                  label="Merge edits"
+                  title="Create a new version of the base file by merging the edits suggested by the edited file"
                 ></vscode-toolbar-button>
                 <vscode-toolbar-button
                   id="latexdiffButton"
                   icon="diff-single"
-                  label="LaTeXdiff the selected edited file with the selected base file"
+                  label="LaTeXdiff"
+                  title="LaTeXdiff the selected edited file with the selected base file"
                 ></vscode-toolbar-button>
                 <vscode-toolbar-button
                   id="currentEditedFileButton"
                   icon="file-code"
                   label="Set current file as edited"
+                  title="Set current file as edited"
                 ></vscode-toolbar-button>
                 <vscode-toolbar-button
                   id="emptyEditedFileButton"
                   icon="close"
-                  label="Empty"
+                  label="Clear edited file"
+                  title="Clear edited file"
                 ></vscode-toolbar-button>
               </vscode-toolbar-container>
             </div>
@@ -723,6 +761,7 @@
                   id="refreshCommitButton"
                   icon="git-commit"
                   label="Refresh commit list"
+                  title="Refresh commit list"
                 ></vscode-toolbar-button>
                 <label for="commit">Commit</label>
               </div>
@@ -730,17 +769,20 @@
                 <vscode-toolbar-button
                   id="latexdiffvcButton"
                   icon="diff-single"
-                  label="LaTeXdiff the selected base file with another git commit"
+                  label="LaTeXdiff with commit"
+                  title="LaTeXdiff the selected base file with another git commit"
                 ></vscode-toolbar-button>
                 <vscode-toolbar-button
                   id="packLatexdiffvcButton"
                   icon="archive"
-                  label="Pack the latexdiff-vc output into the History folder"
+                  label="Pack latexdiff output"
+                  title="Pack the latexdiff-vc output into the History folder"
                 ></vscode-toolbar-button>
                 <vscode-toolbar-button
                   id="cleanLatexdiffvcButton"
                   icon="trash"
-                  label="Clean the latexdiff-vc output"
+                  label="Clean latexdiff output"
+                  title="Clean the latexdiff-vc output"
                 ></vscode-toolbar-button>
               </vscode-toolbar-container>
             </div>
@@ -754,7 +796,7 @@
     <template id="fileListEntryTemplate">
       <div class="file-item" data-path="">
         <span class="file-name"></span>
-        <span class="remove-button">-</span>
+        <span class="remove-button" title="Remove file">-</span>
       </div>
     </template>
     <template id="codiconTemplate">


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Add consistent title tooltips and streamline labels for buttons across History, Progress, and Main webviews.
> 
> - **Frontend Webviews**:
>   - **History View (`src/historyView/index.html`)**:
>     - Add `title` tooltips to search navigation (`prevMatch`, `nextMatch`) and history action buttons (`Delete`, `Restore`, `Rerun`).
>   - **Progress View (`src/progressView/index.html`)**:
>     - Add `title` tooltips to follow-up controls, file action buttons, stream tab delete, retry/approval actions.
>     - Shorten/clarify labels (e.g., "Polish follow-up", "Record follow-up", "Approve & Yolo this session").
>   - **Main Webview (`src/webview/index.html`)**:
>     - Add `title` tooltips to file selection/action buttons and instruction actions.
>     - Replace generic "Empty" labels with explicit "Clear …" variants and clarify add/refresh labels.
>     - Update helper text/tooltips for `Reference` and `Auxiliary` selectors; add remove-file button tooltip.
>     - Add titles and clearer labels in LaTeXdiff section (accept/compare/merge/latexdiff, commit actions).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3563e2605dc629881fa7ec5b5fa03b9b48bfad3c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->