### PR TITLE
fix: handle missing usage info in OpenAI Responses API streaming

### DIFF
--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -724,16 +724,29 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
 
   /**
    * Extract plain text and usage information from the Responses API result.
+   *
+   * Note: OpenAI's Responses API streaming can sometimes return missing or null
+   * usage data, especially with thinking models through relay proxies. We handle
+   * this gracefully by using zero defaults rather than failing.
+   * See: https://github.com/openai/openai-agents-python/issues/1179
    */
   extractResponse(
     responseObject: Response,
     endTag: string,
   ): ExtractResponseResult {
+    // Handle missing usage gracefully - OpenAI streaming may not always include it
+    const usage: ResponseUsage = responseObject.usage ?? {
+      input_tokens: 0,
+      output_tokens: 0,
+      total_tokens: 0,
+      input_tokens_details: { cached_tokens: 0 },
+      output_tokens_details: { reasoning_tokens: 0 },
+    };
     if (!responseObject.usage) {
-      throw new Error('Response object missing required usage information');
+      this.logger.warn(
+        'Response missing usage information - token counts will show as 0',
+      );
     }
-
-    const usage = responseObject.usage;
     let newResponse = responseObject.output_text?.trim() ?? '';
 
     if (!newResponse && responseObject.output) {


### PR DESCRIPTION
OpenAI's Responses API streaming can sometimes return missing or null
usage data, especially with thinking models through relay proxies.
Instead of throwing an error, we now gracefully use zero defaults for
token counts and log a warning.

Fixes agent failures with "Response object missing required usage
information" error when using server-side API keys via relay.

See: https://github.com/openai/openai-agents-python/issues/1179

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents crashes when OpenAI Responses streaming omits `usage` (notably with reasoning models over relays).
> 
> - Updates `extractResponse` to use zeroed defaults for `Response.usage` when missing and emits a warning instead of throwing
> - Leaves response text extraction and stop-reason logic unchanged
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ea8f3fd2758a9ce5aea4d2b2ab8c552a498464d8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->