### PR TITLE
fix: set default retry attempts to 0 for no automatic retries

### DIFF
--- a/package.json
+++ b/package.json
@@ -974,9 +974,9 @@
         "properties": {
           "texra.model.retry.maxAttempts": {
             "type": "number",
-            "default": 1,
-            "minimum": 1,
-            "description": "Number of automatic retry attempts before surfacing a manual retry option for model calls. Default is 1 (no automatic retries, requires manual retry button click).",
+            "default": 0,
+            "minimum": 0,
+            "description": "Number of automatic retry attempts before surfacing a manual retry option for model calls. Set to 0 for no automatic retries (manual retry button only).",
             "scope": "resource"
           },
           "texra.model.retry.backoffMs": {

--- a/src/utils/config/constants.ts
+++ b/src/utils/config/constants.ts
@@ -52,7 +52,7 @@ export const DEFAULT_TOOL_USE_PERSISTENCE_TTL_HOURS = 72;
 
 // Retry defaults
 // Default to 0 automatic retries - users must click retry button
-export const DEFAULT_MODEL_RETRY_ATTEMPTS = 0;
+export const DEFAULT_MODEL_RETRY_MAX_ATTEMPTS = 0;
 export const DEFAULT_MODEL_RETRY_BACKOFF_MS = 1000;
 
 /** Determine whether tool-use session persistence is enabled. */
@@ -80,7 +80,7 @@ export function getToolUsePersistenceTtlHours(): number {
 export function getModelRetryMaxAttempts(): number {
   return getConfig<number>(
     'texra.model.retry.maxAttempts',
-    DEFAULT_MODEL_RETRY_ATTEMPTS,
+    DEFAULT_MODEL_RETRY_MAX_ATTEMPTS,
   );
 }
 


### PR DESCRIPTION
The package.json default (1) was inconsistent with the code fallback (0),
causing automatic retries to occur unexpectedly. This led to doubled
thinking blocks in streaming output when requests failed mid-stream and
were automatically retried.

- Change default from 1 to 0 (no automatic retries)
- Change minimum from 1 to 0 (allow zero retries)
- Fix misleading description that said "1 = no automatic retries"

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures no automatic retries by default and aligns code with configuration.
> 
> - In `package.json`, sets `texra.model.retry.maxAttempts` `default` from `1` to `0`, lowers `minimum` to `0`, and clarifies description
> - In `src/utils/config/constants.ts`, renames `DEFAULT_MODEL_RETRY_ATTEMPTS` to `DEFAULT_MODEL_RETRY_MAX_ATTEMPTS` and updates `getModelRetryMaxAttempts` to use it; retry backoff unchanged
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f0d594cdec9d7adbb71158fc9c07b1402b15d876. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->