### PR TITLE
Fix remote agent cloud size and stream display

### DIFF
--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -15,6 +15,7 @@ import {
 import {
   resolveAgent,
   getMultipleName,
+  isRemoteAgent,
   type ResolvedAgent,
 } from '@agent/index';
 import { parseAgentConfig, type AgentConfig } from '@agent/core/AgentConfig';
@@ -411,6 +412,7 @@ export async function executeAgentWithLogging<T extends IAgent>(
               bus.emit('setActiveStream', {
                 stream: activeStreamId,
                 session: metadata,
+                isRemote: isRemoteAgent(config.agent),
               });
               StreamStatusService.set(activeStreamId, STREAM_STATUS.RUNNING);
 

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -413,9 +413,9 @@ export async function executeAgentWithLogging<T extends IAgent>(
                 stream: activeStreamId,
                 session: metadata,
                 isRemote: isRemoteAgent(config.agent),
-                hasMultipleOutputs:
-                  config.useMultipleOutputs ||
-                  (config.outputFiles?.length ?? 0) > 1,
+                // useMultipleOutputs is the single source of truth, already computed
+                // at config creation time (see ExecutionManager). Workflow-only concept.
+                hasMultipleOutputs: config.useMultipleOutputs,
               });
               StreamStatusService.set(activeStreamId, STREAM_STATUS.RUNNING);
 

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -413,6 +413,9 @@ export async function executeAgentWithLogging<T extends IAgent>(
                 stream: activeStreamId,
                 session: metadata,
                 isRemote: isRemoteAgent(config.agent),
+                hasMultipleOutputs:
+                  config.useMultipleOutputs ||
+                  (config.outputFiles?.length ?? 0) > 1,
               });
               StreamStatusService.set(activeStreamId, STREAM_STATUS.RUNNING);
 

--- a/src/eventBus/ProgressEventBus.ts
+++ b/src/eventBus/ProgressEventBus.ts
@@ -34,6 +34,8 @@ interface SetActiveStreamPayload {
   session?: AgentSessionDescriptor | null;
   /** Hint whether this is a remote agent (for UI display before TaskState is set) */
   isRemote?: boolean;
+  /** Hint whether this agent uses multiple outputs (for UI display before TaskState is set) */
+  hasMultipleOutputs?: boolean;
 }
 
 interface SetTaskStatePayload {

--- a/src/eventBus/ProgressEventBus.ts
+++ b/src/eventBus/ProgressEventBus.ts
@@ -32,6 +32,8 @@ const MAX_BUFFER_SIZE = 1000;
 interface SetActiveStreamPayload {
   stream: StreamTabId | null;
   session?: AgentSessionDescriptor | null;
+  /** Hint whether this is a remote agent (for UI display before TaskState is set) */
+  isRemote?: boolean;
 }
 
 interface SetTaskStatePayload {

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -175,7 +175,7 @@ export class ProgressEventHandler {
 
     const taskState = this.state.getTaskState(stream);
     const instructionUpdate = WebviewUpdater.createInstructionUpdate(taskState);
-    const sessionKindHint = this.state.getSessionKindHint(stream);
+    const { sessionCategory: sessionKindHint } = this.state.getStreamHints(stream);
     const sessionKind = taskState?.session?.agentCategory ?? sessionKindHint;
     const runId =
       runIdHint === undefined
@@ -378,7 +378,7 @@ export class ProgressEventHandler {
       this.setStreamStatus(stream, STREAM_STATUS.RUNNING);
     }
 
-    this.state.setSessionKindHint(stream, AgentCategory.Workflow);
+    this.state.updateStreamHints(stream, { sessionCategory: AgentCategory.Workflow });
 
     const currentFilter = this.state.agentTypeFilter;
     if (currentFilter !== 'all' && currentFilter !== AgentCategory.Workflow) {

--- a/src/progressView/events/StreamStatusEvents.ts
+++ b/src/progressView/events/StreamStatusEvents.ts
@@ -53,7 +53,7 @@ export function createStreamStatusEvents(
     state: ProgressViewState,
     updater: WebviewUpdater,
   ): Promise<void> => {
-    const { stream, session } = payload;
+    const { stream, session, isRemote } = payload;
 
     if (!stream) {
       return;
@@ -67,6 +67,12 @@ export function createStreamStatusEvents(
 
     if (session) {
       state.setSessionKindHint(stream, session.agentCategory);
+    }
+
+    // Store isRemote hint so the UI can show the remote indicator
+    // before the full TaskState is set
+    if (isRemote !== undefined) {
+      state.setIsRemoteHint(stream, isRemote);
     }
 
     const currentFilter = state.agentTypeFilter;

--- a/src/progressView/events/StreamStatusEvents.ts
+++ b/src/progressView/events/StreamStatusEvents.ts
@@ -53,7 +53,7 @@ export function createStreamStatusEvents(
     state: ProgressViewState,
     updater: WebviewUpdater,
   ): Promise<void> => {
-    const { stream, session, isRemote } = payload;
+    const { stream, session, isRemote, hasMultipleOutputs } = payload;
 
     if (!stream) {
       return;
@@ -65,15 +65,12 @@ export function createStreamStatusEvents(
 
     await state.streamTabs.ensureStream(stream);
 
-    if (session) {
-      state.setSessionKindHint(stream, session.agentCategory);
-    }
-
-    // Store isRemote hint so the UI can show the remote indicator
-    // before the full TaskState is set
-    if (isRemote !== undefined) {
-      state.setIsRemoteHint(stream, isRemote);
-    }
+    // Store hints so the UI can show indicators before the full TaskState is set
+    state.updateStreamHints(stream, {
+      sessionCategory: session?.agentCategory,
+      isRemote,
+      hasMultipleOutputs,
+    });
 
     const currentFilter = state.agentTypeFilter;
     const targetCategory = session?.agentCategory;
@@ -122,7 +119,7 @@ export function createStreamStatusEvents(
     const { streamTabId, executionId, taskState } = data;
 
     state.setTaskState(streamTabId, taskState);
-    state.clearSessionKindHint(streamTabId);
+    // Note: setTaskState already clears stream hints
 
     const normalizedState = state.getTaskState(streamTabId);
 

--- a/src/progressView/state/ProgressViewState.ts
+++ b/src/progressView/state/ProgressViewState.ts
@@ -80,6 +80,14 @@ export class ProgressViewState {
    * is cleared, so there is no need to persist these hints across sessions.
    */
   private _sessionCategoryHints: Map<StreamTabId, AgentCategory> = new Map();
+  /**
+   * Ephemeral remote-agent hints keyed by stream ID.
+   *
+   * When a stream becomes active before its {@link TaskState} is persisted,
+   * progress events populate this map so the UI can immediately show the
+   * remote indicator. Once canonical metadata is stored the entry is cleared.
+   */
+  private _isRemoteHints: Map<StreamTabId, boolean> = new Map();
   private _activeRunIds: Map<StreamTabId, StorageKey | null> = new Map();
   /**
    * Ephemeral todos storage keyed by stream ID.
@@ -203,6 +211,19 @@ export class ProgressViewState {
 
   clearSessionKindHint(streamTabId: StreamTabId): void {
     this._sessionCategoryHints.delete(streamTabId);
+  }
+
+  // Remote agent hint management (non-persistent)
+  setIsRemoteHint(streamTabId: StreamTabId, isRemote: boolean): void {
+    this._isRemoteHints.set(streamTabId, isRemote);
+  }
+
+  getIsRemoteHint(streamTabId: StreamTabId): boolean | undefined {
+    return this._isRemoteHints.get(streamTabId);
+  }
+
+  clearIsRemoteHint(streamTabId: StreamTabId): void {
+    this._isRemoteHints.delete(streamTabId);
   }
 
   // Todo management (ephemeral, non-persistent)
@@ -458,6 +479,7 @@ export class ProgressViewState {
   setTaskState(streamTabId: StreamTabId, taskState: TaskState): void {
     this.taskStates.set(streamTabId, cloneTaskState(taskState));
     this.clearSessionKindHint(streamTabId);
+    this.clearIsRemoteHint(streamTabId);
     this.saveTaskStates();
     this.cleanupToolUseAgentRegistry();
   }

--- a/src/progressView/state/ProgressViewState.ts
+++ b/src/progressView/state/ProgressViewState.ts
@@ -1,10 +1,14 @@
 // Third-party imports
 import * as vscode from 'vscode';
+import { z } from 'zod';
 
 // Local imports - agent metadata
-import { resolveAgentSessionDescriptor } from '@agent/core/AgentDataclass';
+import {
+  AgentCategory,
+  resolveAgentSessionDescriptor,
+} from '@agent/core/AgentDataclass';
 // Type imports
-import type { AgentCategory, AgentType } from '@agent/core/AgentDataclass';
+import type { AgentType } from '@agent/core/AgentDataclass';
 // Internal imports
 import { isAgentTypeFilter } from '@agent/types/AgentStreamTypes';
 // Type imports
@@ -36,6 +40,18 @@ import {
 import type { StateStorage } from '@progressView/persistence/PersistentMapManager';
 import { getConfig } from '@utils/config';
 import type { TodoItem } from '@eventBus/schemas';
+
+/**
+ * Schema for ephemeral stream metadata hints.
+ * Used to display UI indicators before TaskState is fully populated.
+ */
+export const StreamHintsSchema = z.object({
+  sessionCategory: z.nativeEnum(AgentCategory).optional(),
+  isRemote: z.boolean().optional(),
+  hasMultipleOutputs: z.boolean().optional(),
+});
+
+export type StreamHints = z.infer<typeof StreamHintsSchema>;
 
 /**
  * Core state management for the progress view.
@@ -79,14 +95,7 @@ export class ProgressViewState {
    * indicators (session category, remote status, multiple outputs).
    * Once canonical metadata is stored via setTaskState, the entry is cleared.
    */
-  private _streamHints: Map<
-    StreamTabId,
-    {
-      sessionCategory?: AgentCategory;
-      isRemote?: boolean;
-      hasMultipleOutputs?: boolean;
-    }
-  > = new Map();
+  private _streamHints = new Map<StreamTabId, StreamHints>();
   private _activeRunIds: Map<StreamTabId, StorageKey | null> = new Map();
   /**
    * Ephemeral todos storage keyed by stream ID.
@@ -198,48 +207,17 @@ export class ProgressViewState {
 
   // Stream metadata hint management (ephemeral, non-persistent)
   // Provides UI hints before TaskState is fully populated
-  updateStreamHints(
-    streamTabId: StreamTabId,
-    hints: {
-      sessionCategory?: AgentCategory;
-      isRemote?: boolean;
-      hasMultipleOutputs?: boolean;
-    },
-  ): void {
+  updateStreamHints(streamTabId: StreamTabId, hints: StreamHints): void {
     const existing = this._streamHints.get(streamTabId) ?? {};
     this._streamHints.set(streamTabId, { ...existing, ...hints });
   }
 
-  getStreamHints(streamTabId: StreamTabId): {
-    sessionCategory?: AgentCategory;
-    isRemote?: boolean;
-    hasMultipleOutputs?: boolean;
-  } {
+  getStreamHints(streamTabId: StreamTabId): StreamHints {
     return this._streamHints.get(streamTabId) ?? {};
   }
 
   clearStreamHints(streamTabId: StreamTabId): void {
     this._streamHints.delete(streamTabId);
-  }
-
-  // Legacy accessors for backward compatibility with existing code
-  setSessionKindHint(
-    streamTabId: StreamTabId,
-    sessionCategory: AgentCategory,
-  ): void {
-    this.updateStreamHints(streamTabId, { sessionCategory });
-  }
-
-  getSessionKindHint(streamTabId: StreamTabId): AgentCategory | undefined {
-    return this.getStreamHints(streamTabId).sessionCategory;
-  }
-
-  getIsRemoteHint(streamTabId: StreamTabId): boolean | undefined {
-    return this.getStreamHints(streamTabId).isRemote;
-  }
-
-  getHasMultipleOutputsHint(streamTabId: StreamTabId): boolean | undefined {
-    return this.getStreamHints(streamTabId).hasMultipleOutputs;
   }
 
   // Todo management (ephemeral, non-persistent)

--- a/src/progressView/state/ProgressViewState.ts
+++ b/src/progressView/state/ProgressViewState.ts
@@ -72,22 +72,21 @@ export class ProgressViewState {
   private readonly taskStates = new Map<StreamTabId, TaskState>();
   private _executionIds: Map<StreamTabId, ExecutionId> = new Map();
   /**
-   * Ephemeral session-kind hints keyed by stream ID.
+   * Ephemeral stream metadata hints keyed by stream ID.
    *
    * When a stream becomes active before its {@link TaskState} is persisted,
-   * progress events populate this map so the UI can immediately classify the
-   * tab as workflow vs. tool-use. Once canonical metadata is stored the entry
-   * is cleared, so there is no need to persist these hints across sessions.
+   * progress events populate this map so the UI can immediately show correct
+   * indicators (session category, remote status, multiple outputs).
+   * Once canonical metadata is stored via setTaskState, the entry is cleared.
    */
-  private _sessionCategoryHints: Map<StreamTabId, AgentCategory> = new Map();
-  /**
-   * Ephemeral remote-agent hints keyed by stream ID.
-   *
-   * When a stream becomes active before its {@link TaskState} is persisted,
-   * progress events populate this map so the UI can immediately show the
-   * remote indicator. Once canonical metadata is stored the entry is cleared.
-   */
-  private _isRemoteHints: Map<StreamTabId, boolean> = new Map();
+  private _streamHints: Map<
+    StreamTabId,
+    {
+      sessionCategory?: AgentCategory;
+      isRemote?: boolean;
+      hasMultipleOutputs?: boolean;
+    }
+  > = new Map();
   private _activeRunIds: Map<StreamTabId, StorageKey | null> = new Map();
   /**
    * Ephemeral todos storage keyed by stream ID.
@@ -197,33 +196,50 @@ export class ProgressViewState {
     this.saveAgentTypeFilter();
   }
 
-  // Session kind hint management (non-persistent)
+  // Stream metadata hint management (ephemeral, non-persistent)
+  // Provides UI hints before TaskState is fully populated
+  updateStreamHints(
+    streamTabId: StreamTabId,
+    hints: {
+      sessionCategory?: AgentCategory;
+      isRemote?: boolean;
+      hasMultipleOutputs?: boolean;
+    },
+  ): void {
+    const existing = this._streamHints.get(streamTabId) ?? {};
+    this._streamHints.set(streamTabId, { ...existing, ...hints });
+  }
+
+  getStreamHints(streamTabId: StreamTabId): {
+    sessionCategory?: AgentCategory;
+    isRemote?: boolean;
+    hasMultipleOutputs?: boolean;
+  } {
+    return this._streamHints.get(streamTabId) ?? {};
+  }
+
+  clearStreamHints(streamTabId: StreamTabId): void {
+    this._streamHints.delete(streamTabId);
+  }
+
+  // Legacy accessors for backward compatibility with existing code
   setSessionKindHint(
     streamTabId: StreamTabId,
     sessionCategory: AgentCategory,
   ): void {
-    this._sessionCategoryHints.set(streamTabId, sessionCategory);
+    this.updateStreamHints(streamTabId, { sessionCategory });
   }
 
   getSessionKindHint(streamTabId: StreamTabId): AgentCategory | undefined {
-    return this._sessionCategoryHints.get(streamTabId);
-  }
-
-  clearSessionKindHint(streamTabId: StreamTabId): void {
-    this._sessionCategoryHints.delete(streamTabId);
-  }
-
-  // Remote agent hint management (non-persistent)
-  setIsRemoteHint(streamTabId: StreamTabId, isRemote: boolean): void {
-    this._isRemoteHints.set(streamTabId, isRemote);
+    return this.getStreamHints(streamTabId).sessionCategory;
   }
 
   getIsRemoteHint(streamTabId: StreamTabId): boolean | undefined {
-    return this._isRemoteHints.get(streamTabId);
+    return this.getStreamHints(streamTabId).isRemote;
   }
 
-  clearIsRemoteHint(streamTabId: StreamTabId): void {
-    this._isRemoteHints.delete(streamTabId);
+  getHasMultipleOutputsHint(streamTabId: StreamTabId): boolean | undefined {
+    return this.getStreamHints(streamTabId).hasMultipleOutputs;
   }
 
   // Todo management (ephemeral, non-persistent)
@@ -478,8 +494,7 @@ export class ProgressViewState {
   // Task state management
   setTaskState(streamTabId: StreamTabId, taskState: TaskState): void {
     this.taskStates.set(streamTabId, cloneTaskState(taskState));
-    this.clearSessionKindHint(streamTabId);
-    this.clearIsRemoteHint(streamTabId);
+    this.clearStreamHints(streamTabId);
     this.saveTaskStates();
     this.cleanupToolUseAgentRegistry();
   }
@@ -491,7 +506,7 @@ export class ProgressViewState {
 
   clearTaskState(streamTabId: StreamTabId): void {
     const didDelete = this.taskStates.delete(streamTabId);
-    this.clearSessionKindHint(streamTabId);
+    this.clearStreamHints(streamTabId);
     if (didDelete) {
       this.saveTaskStates();
       this.cleanupToolUseAgentRegistry();
@@ -551,7 +566,7 @@ export class ProgressViewState {
     ]);
     const removedState = this.taskStates.delete(stream);
     this._executionIds.delete(stream);
-    this.clearSessionKindHint(stream);
+    this.clearStreamHints(stream);
     this.clearActiveRun(stream);
     this.clearTodos(stream);
 
@@ -579,7 +594,7 @@ export class ProgressViewState {
     ]);
     this.taskStates.clear();
     this._executionIds.clear();
-    this._sessionCategoryHints.clear();
+    this._streamHints.clear();
     this._todos.clear();
     this._activeRunIds.clear();
     this._activeStream = '';

--- a/src/progressView/streamInfoUtils.ts
+++ b/src/progressView/streamInfoUtils.ts
@@ -63,7 +63,6 @@ export function buildStreamInfos(
     const logs = state.streamTabs.getMessages(id);
     const lastTimestamp = logs.length > 0 ? logs.at(-1)?.timestamp : undefined;
     const creationTimestamp = logs.length > 0 ? logs[0].timestamp : undefined;
-    const outputs = taskState?.agentConfig.outputFiles ?? [];
     const inputFile = taskState?.agentConfig.inputFile ?? '';
     // Extract clean agent name (strip source: prefix if present)
     const rawAgentName = taskState?.agentConfig.agent ?? id.split('@')[0];
@@ -104,11 +103,10 @@ export function buildStreamInfos(
         sessionKind: sessionCategory,
         isToolAgent,
       },
-      // When taskState is available, check useMultipleOutputs flag OR actual output files count.
+      // useMultipleOutputs is the single source of truth (workflow-only concept).
       // When taskState is null, fall back to the hint from setActiveStream event.
-      // This mirrors the hint calculation in executeAgent.ts for consistent UI behavior.
       hasMultipleOutputs: taskState
-        ? (taskState.agentConfig.useMultipleOutputs || outputs.length > 1)
+        ? taskState.agentConfig.useMultipleOutputs
         : (hints.hasMultipleOutputs ?? false),
       isRemote,
       lastTimestamp,

--- a/src/progressView/streamInfoUtils.ts
+++ b/src/progressView/streamInfoUtils.ts
@@ -59,7 +59,7 @@ export function buildStreamInfos(
 ): StreamTabInfo[] {
   const infos = state.streamTabs.keys().reduce<StreamTabInfo[]>((acc, id) => {
     const taskState = state.getTaskState(id);
-    const sessionKindHint = state.getSessionKindHint(id);
+    const hints = state.getStreamHints(id);
     const logs = state.streamTabs.getMessages(id);
     const lastTimestamp = logs.length > 0 ? logs.at(-1)?.timestamp : undefined;
     const creationTimestamp = logs.length > 0 ? logs[0].timestamp : undefined;
@@ -68,7 +68,8 @@ export function buildStreamInfos(
     // Extract clean agent name (strip source: prefix if present)
     const rawAgentName = taskState?.agentConfig.agent ?? id.split('@')[0];
     const agentName = getCleanAgentName(rawAgentName);
-    let sessionCategory = taskState?.session?.agentCategory ?? sessionKindHint;
+    let sessionCategory =
+      taskState?.session?.agentCategory ?? hints.sessionCategory;
 
     // Filter logic: streams without category only show when filter is "all"
     if (!sessionCategory) {
@@ -89,7 +90,7 @@ export function buildStreamInfos(
     // rawAgentName is just the clean name from the stream ID, so fall back to the hint.
     const isRemote = taskState
       ? isRemoteAgent(rawAgentName)
-      : (state.getIsRemoteHint(id) ?? false);
+      : (hints.isRemote ?? false);
     const executionId = state.getExecutionId(id);
     const label = buildStreamLabel(agentName, inputFile, sessionCategory);
     acc.push({
@@ -107,7 +108,7 @@ export function buildStreamInfos(
       // When taskState is null, fall back to the hint from setActiveStream event.
       hasMultipleOutputs: taskState
         ? outputs.length > 1
-        : (state.getHasMultipleOutputsHint(id) ?? false),
+        : (hints.hasMultipleOutputs ?? false),
       isRemote,
       lastTimestamp,
       inputFile,

--- a/src/progressView/streamInfoUtils.ts
+++ b/src/progressView/streamInfoUtils.ts
@@ -104,10 +104,11 @@ export function buildStreamInfos(
         sessionKind: sessionCategory,
         isToolAgent,
       },
-      // When taskState is available, use actual output files count.
+      // When taskState is available, check useMultipleOutputs flag OR actual output files count.
       // When taskState is null, fall back to the hint from setActiveStream event.
+      // This mirrors the hint calculation in executeAgent.ts for consistent UI behavior.
       hasMultipleOutputs: taskState
-        ? outputs.length > 1
+        ? (taskState.agentConfig.useMultipleOutputs || outputs.length > 1)
         : (hints.hasMultipleOutputs ?? false),
       isRemote,
       lastTimestamp,

--- a/src/progressView/streamInfoUtils.ts
+++ b/src/progressView/streamInfoUtils.ts
@@ -103,7 +103,11 @@ export function buildStreamInfos(
         sessionKind: sessionCategory,
         isToolAgent,
       },
-      hasMultipleOutputs: outputs.length > 1,
+      // When taskState is available, use actual output files count.
+      // When taskState is null, fall back to the hint from setActiveStream event.
+      hasMultipleOutputs: taskState
+        ? outputs.length > 1
+        : (state.getHasMultipleOutputsHint(id) ?? false),
       isRemote,
       lastTimestamp,
       inputFile,

--- a/src/progressView/streamInfoUtils.ts
+++ b/src/progressView/streamInfoUtils.ts
@@ -84,7 +84,12 @@ export function buildStreamInfos(
     const agentType =
       taskState?.session?.agentType ?? taskState?.agentConfig.agentType;
     const isToolAgent = sessionCategory === AgentCategory.ToolUse;
-    const isRemote = isRemoteAgent(rawAgentName);
+    // When taskState is available, rawAgentName has the full key (e.g., "remote:generic")
+    // and isRemoteAgent can reliably determine the source. When taskState is null,
+    // rawAgentName is just the clean name from the stream ID, so fall back to the hint.
+    const isRemote = taskState
+      ? isRemoteAgent(rawAgentName)
+      : (state.getIsRemoteHint(id) ?? false);
     const executionId = state.getExecutionId(id);
     const label = buildStreamLabel(agentName, inputFile, sessionCategory);
     acc.push({

--- a/src/webview/styles/base.css
+++ b/src/webview/styles/base.css
@@ -117,7 +117,10 @@ vscode-option[data-requires-key='true'] {
 }
 
 vscode-option {
-  font-family: codicon, var(--vscode-font-family);
+  /* Use only vscode-font-family to ensure consistent Unicode character sizing.
+     Codicon font doesn't include characters like ☁ (U+2601), causing
+     inconsistent fallback rendering when listed as primary font. */
+  font-family: var(--vscode-font-family);
 }
 
 vscode-option[data-tool-use='true'] {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Improves stream tab rendering and metadata by providing early UI hints and refining state flow.
> 
> - `setActiveStream` now carries `isRemote` and `hasMultipleOutputs`; `executeAgent` emits both using `isRemoteAgent(...)` and `config.useMultipleOutputs`
> - Introduces ephemeral `StreamHints` (zod-validated) in `ProgressViewState` replacing session-kind hint; cleared once `setTaskState` persists canonical data
> - Updates consumers to use hints: `StreamStatusEvents`, `ProgressEventHandler`, and `buildStreamInfos` (falls back to hints when `TaskState` is absent; derives `isRemote` reliably; uses `useMultipleOutputs` as source of truth)
> - Initializes workflow streams with `sessionCategory` via `updateStreamHints`
> - CSS: remove `codicon` from `vscode-option` font-family to render Unicode (e.g., ☁) consistently
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 97d6d9bb64f469a6cd6dc1210941ef45d0dc8c41. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->