### PR TITLE
Load bib/bbl files in reference file selector

### DIFF
--- a/package.json
+++ b/package.json
@@ -402,6 +402,7 @@
               ".txt",
               ".tex",
               ".md",
+              ".bib",
               ".bbl"
             ],
             "description": "File extensions to include when searching for reference files",
@@ -445,7 +446,6 @@
             "default": [
               ".pdf",
               ".bst",
-              ".bib",
               ".json",
               ".py",
               ".ipynb",

--- a/src/webview/index.html
+++ b/src/webview/index.html
@@ -243,7 +243,7 @@
                 ></vscode-toolbar-button>
                 <label
                   for="auxiliaryFile"
-                  title="Supporting files such as preamble.tex, .cls, and .sty"
+                  title="Supporting files such as preamble.tex, .cls, and .sty. Extract preamble from large input files to avoid duplicate output."
                   >Auxiliary</label
                 >
               </div>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Reference file selection**
> 
> - Adds `.bib` to `texra.files.included.referenceExtensions` and removes `.bib` from `texra.files.ignored.fileExtensions` so BibTeX files are selectable alongside `.bbl`.
> 
> **UI copy**
> 
> - Updates the Auxiliary label tooltip in `src/webview/index.html` to suggest extracting preambles from large input files to avoid duplicate output.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3ffd65f1be13a7c249461b9c65c943c25da8df5f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->