### PR TITLE
fix(google): use native ThinkingLevel.MEDIUM from SDK

### DIFF
--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -87,6 +87,16 @@ function isTextPart(part: Part): part is Part & { text: string } {
   return typeof (part as { text?: unknown }).text === 'string';
 }
 
+/** Extract concatenated text from parts, excluding thought parts */
+function extractNonThinkingText(parts: Part[], trim = false): string {
+  const text = parts
+    .filter((part): part is Part & { text: string } => isTextPart(part))
+    .filter((part) => !part.thought)
+    .map((part) => part.text)
+    .join('');
+  return trim ? text.trim() : text;
+}
+
 /**
  * Validates that messages have proper alternating user/model turns.
  * All message creation should enforce this natively, so this is a safety check.
@@ -577,11 +587,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
         const finalReasoning = this.processThinkingBlock(baseResponse);
         thinking.finalize(finalReasoning ?? undefined);
 
-        const nonThinkingText = aggregatedParts
-          .filter((part): part is Part & { text: string } => isTextPart(part))
-          .filter((part) => !part.thought)
-          .map((part) => part.text)
-          .join('');
+        const nonThinkingText = extractNonThinkingText(aggregatedParts);
 
         let finalOutputText = aggregatedText || nonThinkingText;
         if (!finalOutputText && baseResponse.text) {
@@ -796,12 +802,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
     // The getter may use cached values that don't reflect mutations we made
     // to the candidates array during streaming (lines 536-550, 577-584).
     // Filter out thought parts and concatenate text from remaining parts.
-    const rawResponseText = parts
-      .filter((part): part is Part & { text: string } => isTextPart(part))
-      .filter((part) => !part.thought)
-      .map((part) => part.text)
-      .join('')
-      .trim();
+    const rawResponseText = extractNonThinkingText(parts, true);
 
     // For TOOL CALL ONLY RESPONSE this happens sometimes, we don't want to log it
     let responseText = replacementEngine.applyAll(rawResponseText);

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -193,11 +193,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
     }
 
     if (requestedLevel === ReasoningEffort.MEDIUM) {
-      // SDK only exports LOW/HIGH; Gemini 3 Flash supports MEDIUM via API but SDK lacks enum
-      this.logger.warn(
-        "SDK ThinkingLevel enum doesn't include 'MEDIUM'. Falling back to 'HIGH'.",
-      );
-      return ThinkingLevel.HIGH;
+      return ThinkingLevel.MEDIUM;
     }
 
     if (requestedLevel === ReasoningEffort.LOW) {

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -766,7 +766,6 @@ export class ModelHandlerOpenAI<
       newResponse = choice.message.content.trim();
     } else if (
       stopReason === OPENAI_CHAT_FINISH.TOOL_CALLS ||
-      stopReason === OPENAI_CHAT_FINISH.TOOL_USE ||
       stopReason === OPENAI_CHAT_FINISH.FUNCTION_CALL ||
       Array.isArray(choice.message.tool_calls) ||
       choice.message.function_call

--- a/src/agent/modelHandlers/types/StopReasonTypes.ts
+++ b/src/agent/modelHandlers/types/StopReasonTypes.ts
@@ -10,7 +10,6 @@ export const OPENAI_CHAT_FINISH = {
   STOP: 'stop',
   LENGTH: 'length',
   TOOL_CALLS: 'tool_calls',
-  TOOL_USE: 'tool_use',
   CONTENT_FILTER: 'content_filter',
   FUNCTION_CALL: 'function_call',
 } as const;


### PR DESCRIPTION
Remove fallback to HIGH for medium reasoning effort now that
@google/genai SDK v1.34.0 exports ThinkingLevel.MEDIUM natively.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables correct reasoning config for Gemini 3 and simplifies text handling.
> 
> - **Google GenAI**: Map `ReasoningEffort.MEDIUM` to native `ThinkingLevel.MEDIUM` (remove fallback to `HIGH` and related warning)
> - **Refactor**: Add `extractNonThinkingText` to deduplicate extraction of non-`thought` text from `parts`; use it in streaming finalization and `extractResponse`
> - **OpenAI types**: Remove obsolete `OPENAI_CHAT_FINISH.TOOL_USE` usage and constant
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ea08f01f4cc463c7af0e0a0d108da2dbe45b476a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->