### PR TITLE
Disable auto-extract features in history tool agents

### DIFF
--- a/src/agent/core/AgentConfig.ts
+++ b/src/agent/core/AgentConfig.ts
@@ -57,7 +57,8 @@ const AgentConfigBaseSchema = z
     outputFiles: stringArrayField(),
     editedFile: z.string().nullable().prefault(null),
 
-    toolConfig: ToolConfigSchema.prefault(DEFAULT_TOOL_CONFIG),
+    // Defaults to all-false for tool-use agents; workflow agents populate from UI
+    toolConfig: ToolConfigSchema.default(DEFAULT_TOOL_CONFIG),
   })
   .superRefine((config, ctx) => {
     if (

--- a/src/agent/implementations/BaseToolUseAgent.ts
+++ b/src/agent/implementations/BaseToolUseAgent.ts
@@ -127,12 +127,6 @@ export class BaseToolUseAgent<C = unknown> extends BaseAgent<C> {
       }
       tools.push(def);
     }
-    if (
-      this.agentConfig.toolConfig.attachDiagnostics &&
-      !tools.some((t) => t.name === 'diagnostics')
-    ) {
-      tools.push({ name: 'diagnostics' });
-    }
     return tools;
   }
 

--- a/src/historyView/modules/uiManagers/HistoryRenderer.js
+++ b/src/historyView/modules/uiManagers/HistoryRenderer.js
@@ -192,7 +192,8 @@ export class HistoryRenderer {
         <span class="history-value">${encodedOutputs}</span>`;
     }
 
-    if (config.toolConfig) {
+    // Only show toolConfig for workflow agents - these options don't apply to tool-use agents
+    if (config.toolConfig && !isToolUse) {
       const toolsIcon = createCodicon('tools');
       detailsHTML += this._renderToolConfig(
         `${toolsIcon ? toolsIcon.outerHTML : ''} Config`,

--- a/src/test/agent/core/ConfigSchemas.test.ts
+++ b/src/test/agent/core/ConfigSchemas.test.ts
@@ -37,6 +37,7 @@ describe('AgentConfigSchema', () => {
       },
     } as Record<string, unknown>);
 
+    assert.ok(parsed.toolConfig, 'toolConfig should be defined when provided');
     assert.strictEqual('reflect' in parsed.toolConfig, false);
     assert.strictEqual(parsed.toolConfig.autoExtractFigure, false);
     assert.strictEqual('legacyFlag' in parsed, false);

--- a/src/webview/managers/ExecutionManager.ts
+++ b/src/webview/managers/ExecutionManager.ts
@@ -9,7 +9,7 @@ import {
   AgentType,
   type AgentSessionDescriptor,
 } from '@agent/core/AgentDataclass';
-import { ToolConfig } from '@agent/core/ToolConfig';
+import { DEFAULT_TOOL_CONFIG, ToolConfig } from '@agent/core/ToolConfig';
 import { capitalize } from '@frontend/ui/messageUtils';
 import * as logger from '@logger/logUtils';
 import {
@@ -81,8 +81,18 @@ export class ExecutionManager {
       message.outputFilesActive || outputFiles.length > 1
     );
 
+    // toolConfig only applies to workflow agents
+    const toolConfig: ToolConfig = {
+      autoExtractFigure: message.autoExtractFigure,
+      autoExtractTikzFigure: message.autoExtractTikzFigure,
+      attachTeXCount: message.attachTeXCount,
+      attachDiagnostics: message.attachDiagnostics,
+      autoCompileInputPdf: message.autoCompileInputPdf,
+    };
+
     return {
       ...baseConfig,
+      toolConfig,
       useMultipleOutputs,
       outputFiles,
     };
@@ -96,6 +106,8 @@ export class ExecutionManager {
 
     return {
       ...baseConfig,
+      // Tool-use agents use default (all-false) toolConfig
+      toolConfig: DEFAULT_TOOL_CONFIG,
       // Tool-use runs intentionally stay single-output so the execution
       // pipeline never attempts to resolve `_multiple` agent variants or
       // manage output file selections that the UI disables for this mode.
@@ -107,15 +119,7 @@ export class ExecutionManager {
   private composeBaseAgentConfig(
     message: any,
     session: AgentSessionDescriptor,
-  ): Omit<AgentConfig, 'useMultipleOutputs' | 'outputFiles'> {
-    const toolConfig: ToolConfig = {
-      autoExtractFigure: message.autoExtractFigure,
-      autoExtractTikzFigure: message.autoExtractTikzFigure,
-      attachTeXCount: message.attachTeXCount,
-      attachDiagnostics: message.attachDiagnostics,
-      autoCompileInputPdf: message.autoCompileInputPdf,
-    };
-
+  ): Omit<AgentConfig, 'useMultipleOutputs' | 'outputFiles' | 'toolConfig'> {
     const mapMediaPath = (f: string | null): string | null => {
       if (!f) return null;
       if (isPastedImage(f)) {
@@ -141,7 +145,6 @@ export class ExecutionManager {
           .filter((f: string | null): f is string => f !== null),
       ),
       editedFile: null,
-      toolConfig,
       agentType: session.agentType,
       session,
     };


### PR DESCRIPTION
The autoExtract and tool config options (autoExtractFigure, autoExtractTikzFigure, attachTeXCount, attachDiagnostics, autoCompileInputPdf) don't apply to tool-use agents - they're either disabled or irrelevant. Hide this section in history view for tool-use agents to improve separation of concerns.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Behavioral alignment of tool-use vs workflow configs**
> 
> - Agent schema: set `toolConfig` to `DEFAULT_TOOL_CONFIG` via `.default(...)` to ensure all-false by default; keeps output-file validation.
> - ExecutionManager: build `toolConfig` only for workflow runs; tool-use runs explicitly use `DEFAULT_TOOL_CONFIG`; base config no longer includes `toolConfig`.
> - Tool-use agent: remove auto-injection of `diagnostics` tool from `getTools()`.
> - History view: render `toolConfig` only for workflow items (hidden for tool-use).
> - Tests: update to assert `toolConfig` presence/cleaning and add session-derivation case.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d2b98640b7d4ac4402628ac0942d1559f177731f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->