### PR TITLE
Fix missing text module import error

### DIFF
--- a/src/agent/modelHandlers/support/MediaAttachmentProcessor.ts
+++ b/src/agent/modelHandlers/support/MediaAttachmentProcessor.ts
@@ -20,7 +20,7 @@ import type { ModelCapabilities } from '@model/ModelConfig';
 import {
   AbsoluteFS,
   getMimeType,
-  getDisplayPath,
+  getShortDisplayPath,
   type FileLocation,
 } from '@utils/files';
 
@@ -180,7 +180,7 @@ export class MediaAttachmentProcessor {
       } else {
         const reason = settledResult.reason;
         const location = mediaFiles[index];
-        const displayPath = getDisplayPath(location);
+        const displayPath = getShortDisplayPath(location);
         this.logger.error(
           `Failed to load media entry for ${displayPath}: ${getSdkErrorMessage(reason)}`,
           { data: reason },
@@ -208,7 +208,7 @@ export class MediaAttachmentProcessor {
     location: FileLocation,
   ): Promise<{ entry?: MediaEntry | MediaEntry[]; result: MediaFileResult }> {
     const absolutePath = location.absolutePath;
-    const displayPath = getDisplayPath(location);
+    const displayPath = getShortDisplayPath(location);
     const fileExistsResult = await AbsoluteFS.exists(absolutePath);
 
     if (!fileExistsResult) {

--- a/src/agent/utils/text/index.ts
+++ b/src/agent/utils/text/index.ts
@@ -1,0 +1,1 @@
+export * from './repetitionUtils';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -258,7 +258,10 @@ export async function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(apiKeyStatusBarItem);
   // Non-blocking refresh to avoid delaying extension activation
   void refreshApiKeyStatus().catch((err) =>
-    logger.error('extension', `API key status refresh failed: ${toErrorMessage(err)}`),
+    logger.error(
+      'extension',
+      `API key status refresh failed: ${toErrorMessage(err)}`,
+    ),
   );
 
   const runningStreams = new Set<string>();
@@ -343,7 +346,10 @@ export async function activate(context: vscode.ExtensionContext) {
     )
       .then(() => context.globalState.update(welcomeKey, true))
       .catch((err) =>
-        logger.error('extension', `Welcome instruction failed: ${toErrorMessage(err)}`),
+        logger.error(
+          'extension',
+          `Welcome instruction failed: ${toErrorMessage(err)}`,
+        ),
       );
   }
 }

--- a/src/frontend/latex/openBuild.ts
+++ b/src/frontend/latex/openBuild.ts
@@ -52,7 +52,10 @@ export async function openAndBuildIfTex(
       try {
         await vscode.commands.executeCommand('latex-workshop.build', uri);
       } catch (err) {
-        logger.warn(CHANNEL, `LaTeX Workshop build failed: ${toErrorMessage(err)}`);
+        logger.warn(
+          CHANNEL,
+          `LaTeX Workshop build failed: ${toErrorMessage(err)}`,
+        );
       }
     } else {
       await vscode.commands.executeCommand('vscode.open', uri);
@@ -81,7 +84,10 @@ export async function openBuildDisplayIfTex(
       setTimeout(async () => {
         await vscode.commands.executeCommand('latex-workshop.view');
         setTimeout(
-          () => void vscode.commands.executeCommand('latex-workshop.refresh-viewer'),
+          () =>
+            void vscode.commands.executeCommand(
+              'latex-workshop.refresh-viewer',
+            ),
           LATEX_VIEWER_REFRESH_DELAY_MS,
         );
       }, LATEX_VIEWER_OPEN_DELAY_MS);

--- a/src/frontend/setup.ts
+++ b/src/frontend/setup.ts
@@ -90,7 +90,10 @@ export async function copyDefaultAgents(context: vscode.ExtensionContext) {
     // Update the stored version after successful copy
     await globalSM.update(GlobalStateKey.LAST_KNOWN_VERSION, currentVersion);
   } catch (err) {
-    logger.error('extension', `Error copying default agents: ${toErrorMessage(err)}`);
+    logger.error(
+      'extension',
+      `Error copying default agents: ${toErrorMessage(err)}`,
+    );
   }
 }
 
@@ -341,6 +344,9 @@ export async function configureLatexSettings() {
       );
     }
   } catch (err) {
-    logger.error('extension', `Error configuring LaTeX settings: ${toErrorMessage(err)}`);
+    logger.error(
+      'extension',
+      `Error configuring LaTeX settings: ${toErrorMessage(err)}`,
+    );
   }
 }

--- a/src/utils/files/pathUtils.ts
+++ b/src/utils/files/pathUtils.ts
@@ -2,25 +2,9 @@
 import * as path from 'path';
 
 // Local imports - utils
-import type { FileLocation } from './taskRunStorage';
 import { WorkspaceFS } from './workspaceFS';
 
 /** Resolve a file path relative to the workspace if not already absolute. */
 export function resolveFilePath(file: string): string {
   return path.isAbsolute(file) ? file : WorkspaceFS.fullPath(file);
-}
-
-/**
- * Get a display-friendly path for a file location.
- * For workspace/runStorage files, returns the relative path.
- * For external files, returns the full absolute path for clarity.
- *
- * Use this for logging and user-facing messages where the full path
- * of external files is helpful for identification.
- */
-export function getDisplayPath(location: FileLocation): string {
-  if (location.kind === 'workspace' || location.kind === 'runStorage') {
-    return location.relativePath;
-  }
-  return location.absolutePath;
 }

--- a/src/utils/files/pathUtils.ts
+++ b/src/utils/files/pathUtils.ts
@@ -2,9 +2,25 @@
 import * as path from 'path';
 
 // Local imports - utils
+import type { FileLocation } from './taskRunStorage';
 import { WorkspaceFS } from './workspaceFS';
 
 /** Resolve a file path relative to the workspace if not already absolute. */
 export function resolveFilePath(file: string): string {
   return path.isAbsolute(file) ? file : WorkspaceFS.fullPath(file);
+}
+
+/**
+ * Get a display-friendly path for a file location.
+ * For workspace/runStorage files, returns the relative path.
+ * For external files, returns the full absolute path for clarity.
+ *
+ * Use this for logging and user-facing messages where the full path
+ * of external files is helpful for identification.
+ */
+export function getDisplayPath(location: FileLocation): string {
+  if (location.kind === 'workspace' || location.kind === 'runStorage') {
+    return location.relativePath;
+  }
+  return location.absolutePath;
 }

--- a/src/utils/files/rulesUtils.ts
+++ b/src/utils/files/rulesUtils.ts
@@ -38,7 +38,10 @@ export async function loadTexraRules(): Promise<string> {
       }
     }
   } catch (err) {
-    logger.warn(CHANNEL, `Failed to load ${'.texrarules'}: ${toErrorMessage(err)}`);
+    logger.warn(
+      CHANNEL,
+      `Failed to load ${'.texrarules'}: ${toErrorMessage(err)}`,
+    );
   }
   return '';
 }

--- a/src/utils/files/taskRunStorage.ts
+++ b/src/utils/files/taskRunStorage.ts
@@ -635,8 +635,6 @@ export function pathToLocation(target: string): FileLocation {
  *
  * This provides a concise human-readable path suitable for showing to users or models,
  * while absolutePath should be used for actual file operations.
- *
- * Note: For full path display of external files, use getDisplayPath from @agent/output.
  */
 export function getShortDisplayPath(location: FileLocation): string {
   if (location.kind === 'workspace' || location.kind === 'runStorage') {

--- a/src/utils/text/xmlUtils.ts
+++ b/src/utils/text/xmlUtils.ts
@@ -31,7 +31,11 @@ import {
 } from './xmlExtraction';
 
 // Re-export from CDATA module
-export { removeCDATA, addCdataToTags, addCdataToTagsMultiple } from './xmlCdata';
+export {
+  removeCDATA,
+  addCdataToTags,
+  addCdataToTagsMultiple,
+} from './xmlCdata';
 
 // Re-export from format detection module
 export {

--- a/src/webview/managers/FileManager.ts
+++ b/src/webview/managers/FileManager.ts
@@ -13,7 +13,7 @@ import {
   toErrorMessage,
 } from '@common/errors';
 import { MAIN_VIEW_COMMANDS } from '@common/webview';
-import { selectFiles } from '@utils/dialogs';
+import { selectFiles } from '@frontend/ui/dialogs';
 import { fileLister } from '@frontend/files';
 import { uncapitalize } from '@frontend/ui/messageUtils';
 import * as logger from '@logger/logUtils';


### PR DESCRIPTION
- Create src/agent/utils/text/index.ts to export repetitionUtils
- Fix FileManager.ts import path for selectFiles (use @frontend/ui/dialogs)
- Add getDisplayPath function to pathUtils.ts for FileLocation display

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> - **Text utils export:** Adds `src/agent/utils/text/index.ts` to re-export `repetitionUtils` to resolve missing imports
> - **Media logging path display:** `MediaAttachmentProcessor` now uses `getShortDisplayPath` for user-facing paths on errors and processing logs
> - **Path utility:** Provides `getShortDisplayPath(location)` in `taskRunStorage.ts` for concise display paths
> - **Webview import fix:** Updates `FileManager` to import `selectFiles` from `@frontend/ui/dialogs`
> - *Minor:* Reformats multiline logger calls in `extension.ts`, LaTeX open/build helpers, setup, rules loading, and XML utils
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 487029aaf3b9cba7de145f5eb0c4b7b7de6032ef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->