### PR TITLE
Fix TypeScript type error in agent registry

### DIFF
--- a/src/agent/index/agentRegistry.ts
+++ b/src/agent/index/agentRegistry.ts
@@ -439,8 +439,8 @@ async function loadRemoteAgents(): Promise<AgentEntry[]> {
         multiplePath: multiple ? multiple.name : undefined,
         category,
         agentType,
-        description: primary.description,
-        visibility: primary.visibility,
+        description: primary.description ?? undefined,
+        visibility: primary.visibility ?? undefined,
       });
     }
 


### PR DESCRIPTION
The RemoteAgentMetadataSchema uses .nullish() which produces T | null | undefined, but AgentEntry expects T | undefined. Use nullish coalescing (?? undefined) to convert null to undefined.

Fixes TS2322 type errors on lines 442-443.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures remote agent metadata matches `AgentEntry` optional types.
> 
> - In `agentRegistry.ts` (`loadRemoteAgents`), update entry construction to use `description: primary.description ?? undefined` and `visibility: primary.visibility ?? undefined` to handle `null` from Zod `.nullish()` outputs and fix TS2322.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b578cc96a7be5b36472e07bed9a6a44fd4b761aa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->