### PR TITLE
Investigate project purpose and scope

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,6 +109,28 @@ const value = Schema.catch(defaultValue).parse(data);
 description: z.string().nullish(),  // null | undefined → undefined
 ```
 
+**Tool input schemas (IMPORTANT)**
+
+Use `.nullish()` instead of `.optional()` for optional fields in tool input schemas. OpenAI-compatible APIs (DeepSeek, Kimi, etc.) require optional fields to also be nullable for structured output compatibility.
+
+```typescript
+// Tool schemas - use .nullish() for API compatibility
+const ToolInputSchema = z.strictObject({
+  required: z.string(),
+  optional: z.string().nullish(),  // NOT .optional()
+});
+```
+
+When checking for missing optional values, use `== null` (not `=== undefined`) to handle both null and undefined:
+
+```typescript
+if (input.optional == null) {
+  // handles both null and undefined
+}
+```
+
+See: https://platform.openai.com/docs/guides/structured-outputs
+
 ### Refactoring for simplicity
 
 Aim for code that looks like it was designed correctly from the start:

--- a/src/tools/EditTool.ts
+++ b/src/tools/EditTool.ts
@@ -20,7 +20,7 @@ const EditInputSchema = z.strictObject({
   path: z.string(),
   old_string: z.string(),
   new_string: z.string(),
-  replace_all: z.boolean().optional(),
+  replace_all: z.boolean().nullish(),
 });
 
 export type EditInput = z.infer<typeof EditInputSchema>;

--- a/src/tools/ReadTool.ts
+++ b/src/tools/ReadTool.ts
@@ -20,13 +20,13 @@ const ReadInputSchema = z.strictObject({
   range: z
     .strictObject({
       start: z.int().min(1),
-      end: z.int().min(1).optional(),
+      end: z.int().min(1).nullish(),
     })
-    .refine((value) => value.end === undefined || value.end >= value.start, {
+    .refine((value) => value.end == null || value.end >= value.start, {
       path: ['end'],
       error: 'range.end must be greater than or equal to range.start',
     })
-    .optional(),
+    .nullish(),
 });
 
 export type ReadInput = z.infer<typeof ReadInputSchema>;

--- a/src/tools/TextEditorTool.ts
+++ b/src/tools/TextEditorTool.ts
@@ -40,11 +40,11 @@ const SNIPPET_LINES = 4;
 export const TextEditorInputSchema = z.strictObject({
   command: z.enum(['view', 'create', 'str_replace', 'insert', 'undo_edit']),
   path: z.string(),
-  file_text: z.string().optional(),
-  view_range: z.tuple([z.number(), z.number()]).optional(),
-  old_str: z.string().optional(),
-  new_str: z.string().optional(),
-  insert_line: z.number().optional(),
+  file_text: z.string().nullish(),
+  view_range: z.tuple([z.number(), z.number()]).nullish(),
+  old_str: z.string().nullish(),
+  new_str: z.string().nullish(),
+  insert_line: z.number().nullish(),
 });
 
 /** Derived from TextEditorInputSchema - single source of truth */

--- a/src/tools/TextEditorTool.ts
+++ b/src/tools/TextEditorTool.ts
@@ -129,7 +129,7 @@ export class TextEditorTool extends defineTool({
         );
 
       case 'insert':
-        if (input.insert_line === undefined) {
+        if (input.insert_line == null) {
           throw new ToolError(
             'Parameter `insert_line` is required for command: insert',
           );

--- a/src/tools/arxiv/ArxivDownloadTool.ts
+++ b/src/tools/arxiv/ArxivDownloadTool.ts
@@ -13,7 +13,7 @@ import { arxivProcessor } from '@latex/arxivProcessor';
 
 const ArxivDownloadInputSchema = z.strictObject({
   id: z.string(),
-  autoIndent: z.boolean().optional(),
+  autoIndent: z.boolean().nullish(),
 });
 
 export type ArxivDownloadInput = z.infer<typeof ArxivDownloadInputSchema>;

--- a/src/tools/arxiv/ArxivMetadataTool.ts
+++ b/src/tools/arxiv/ArxivMetadataTool.ts
@@ -18,8 +18,8 @@ import { arxivProcessor } from '@latex/arxivProcessor';
 
 const ArxivMetadataInputSchema = z.strictObject({
   id: z.string(),
-  includeAbstract: z.boolean().optional(),
-  maxAuthors: z.int().positive().max(ARXIV_CONSTANTS.MAX_AUTHORS).optional(),
+  includeAbstract: z.boolean().nullish(),
+  maxAuthors: z.int().positive().max(ARXIV_CONSTANTS.MAX_AUTHORS).nullish(),
 });
 
 export type ArxivMetadataInput = z.infer<typeof ArxivMetadataInputSchema>;

--- a/src/tools/arxiv/ArxivSearchTool.ts
+++ b/src/tools/arxiv/ArxivSearchTool.ts
@@ -29,14 +29,14 @@ const SearchFieldSchema = z.enum(['all', 'author', 'title', 'abstract']);
 
 const ArxivSearchInputSchema = z.strictObject({
   query: z.string(),
-  field: SearchFieldSchema.optional().describe(
+  field: SearchFieldSchema.nullish().describe(
     'Search field: "author" for author names, "title" for paper titles, "abstract" for abstracts, "all" (default) for all fields',
   ),
-  categories: z.array(z.string()).optional(),
-  maxResults: z.int().positive().max(ARXIV_CONSTANTS.MAX_RESULTS).optional(),
-  start: z.int().min(0).optional(),
-  sortBy: SortBySchema.optional(),
-  sortOrder: SortOrderSchema.optional(),
+  categories: z.array(z.string()).nullish(),
+  maxResults: z.int().positive().max(ARXIV_CONSTANTS.MAX_RESULTS).nullish(),
+  start: z.int().min(0).nullish(),
+  sortBy: SortBySchema.nullish(),
+  sortOrder: SortOrderSchema.nullish(),
 });
 
 export type ArxivSearchInput = z.infer<typeof ArxivSearchInputSchema>;

--- a/src/tools/citation/CrossrefSearchTool.ts
+++ b/src/tools/citation/CrossrefSearchTool.ts
@@ -19,16 +19,16 @@ import { waitForRateLimit } from './rateLimiter';
 
 const CrossrefSearchInputSchema = z.strictObject({
   query: z.string(),
-  rows: z.int().positive().max(CROSSREF_CONSTANTS.MAX_ROWS).optional(),
-  offset: z.int().min(0).optional(),
-  sort: z.string().optional(),
-  order: z.enum(['asc', 'desc']).optional(),
+  rows: z.int().positive().max(CROSSREF_CONSTANTS.MAX_ROWS).nullish(),
+  offset: z.int().min(0).nullish(),
+  sort: z.string().nullish(),
+  order: z.enum(['asc', 'desc']).nullish(),
   filter: z
     .union([
       z.string(),
       z.record(z.string(), z.union([z.string(), z.array(z.string())])),
     ])
-    .optional(),
+    .nullish(),
 });
 
 export type CrossrefSearchInput = z.infer<typeof CrossrefSearchInputSchema>;

--- a/src/tools/fileOp.ts
+++ b/src/tools/fileOp.ts
@@ -26,7 +26,7 @@ import { defineTool } from './core/define';
 const FileOpInputSchema = z.strictObject({
   command: z.enum(['read', 'write', 'append']),
   path: z.string(),
-  content: z.string().optional(),
+  content: z.string().nullish(),
 });
 
 export type FileOpInput = z.infer<typeof FileOpInputSchema>;

--- a/src/tools/fileOp.ts
+++ b/src/tools/fileOp.ts
@@ -48,7 +48,7 @@ export class FileOpTool extends defineTool({
         });
       }
       case 'write': {
-        if (content === undefined) {
+        if (content == null) {
           return toolResult({
             error: 'content parameter is required for write',
             isError: true,
@@ -100,7 +100,7 @@ export class FileOpTool extends defineTool({
         });
       }
       case 'append': {
-        if (content === undefined) {
+        if (content == null) {
           return toolResult({
             error: 'content parameter is required for append',
             isError: true,

--- a/src/tools/glob.ts
+++ b/src/tools/glob.ts
@@ -19,7 +19,7 @@ import { defineTool } from './core/define';
 
 const GlobInputSchema = z.strictObject({
   pattern: z.string().min(1, 'pattern is required'),
-  path: z.string().optional(),
+  path: z.string().nullish(),
 });
 
 export type GlobInput = z.infer<typeof GlobInputSchema>;

--- a/src/tools/grep.ts
+++ b/src/tools/grep.ts
@@ -16,17 +16,17 @@ type OutputMode = (typeof OUTPUT_MODES)[number];
 
 const GrepInputSchema = z.strictObject({
   pattern: z.string().min(1, 'pattern is required'),
-  path: z.string().optional(),
-  glob: z.string().optional(),
-  output_mode: z.enum(OUTPUT_MODES).optional(),
-  '-B': z.int().min(0).optional(),
-  '-A': z.int().min(0).optional(),
-  '-C': z.int().min(0).optional(),
-  '-n': z.boolean().optional(),
-  '-i': z.boolean().optional(),
-  type: z.string().optional(),
-  head_limit: z.int().min(1).optional(),
-  multiline: z.boolean().optional(),
+  path: z.string().nullish(),
+  glob: z.string().nullish(),
+  output_mode: z.enum(OUTPUT_MODES).nullish(),
+  '-B': z.int().min(0).nullish(),
+  '-A': z.int().min(0).nullish(),
+  '-C': z.int().min(0).nullish(),
+  '-n': z.boolean().nullish(),
+  '-i': z.boolean().nullish(),
+  type: z.string().nullish(),
+  head_limit: z.int().min(1).nullish(),
+  multiline: z.boolean().nullish(),
 });
 
 export type GrepInput = z.infer<typeof GrepInputSchema>;

--- a/src/tools/latex/ExtractBibliographyTool.ts
+++ b/src/tools/latex/ExtractBibliographyTool.ts
@@ -23,7 +23,7 @@ const ExtractBibliographyInputSchema = z.strictObject({
     .describe(
       'Optional path to a BibTeX file to include when resolving citations.',
     )
-    .optional(),
+    .nullish(),
 });
 
 export type ExtractBibliographyInput = z.infer<

--- a/src/tools/latex/ExtractTikzFiguresTool.ts
+++ b/src/tools/latex/ExtractTikzFiguresTool.ts
@@ -20,7 +20,7 @@ const ExtractTikzInputSchema = z.strictObject({
   compile: z
     .boolean()
     .describe('Compile extracted TikZ pictures into standalone PDFs.')
-    .optional(),
+    .nullish(),
 });
 
 export type ExtractTikzInput = z.infer<typeof ExtractTikzInputSchema>;

--- a/src/tools/texcount/TexcountTool.ts
+++ b/src/tools/texcount/TexcountTool.ts
@@ -14,8 +14,8 @@ import {
 
 const TexcountInputSchema = z.strictObject({
   files: z.union([z.string(), z.array(z.string()).min(1)]),
-  mode: z.enum(['separate', 'include', 'sum']).optional(),
-  format: z.enum(['raw', 'stats']).optional(),
+  mode: z.enum(['separate', 'include', 'sum']).nullish(),
+  format: z.enum(['raw', 'stats']).nullish(),
 });
 
 type TexcountInput = z.infer<typeof TexcountInputSchema>;

--- a/src/tools/web/WebFetchTool.ts
+++ b/src/tools/web/WebFetchTool.ts
@@ -19,7 +19,7 @@ const WebFetchInputSchema = z.strictObject({
       (value) => value.startsWith('http://') || value.startsWith('https://'),
       'URL must use HTTP or HTTPS protocol',
     ),
-  prompt: z.string().min(1).optional(),
+  prompt: z.string().min(1).nullish(),
 });
 
 export type WebFetchInput = z.infer<typeof WebFetchInputSchema>;

--- a/src/tools/web/WebSearchTool.ts
+++ b/src/tools/web/WebSearchTool.ts
@@ -9,7 +9,7 @@ import { defineTool } from '@tools/core/define';
 
 const WebSearchInputSchema = z.strictObject({
   query: z.string(),
-  max_results: z.number().min(1).max(5).optional(),
+  max_results: z.number().min(1).max(5).nullish(),
 });
 
 export type WebSearchInput = z.infer<typeof WebSearchInputSchema>;

--- a/src/tools/wolfram/WolframTool.ts
+++ b/src/tools/wolfram/WolframTool.ts
@@ -10,7 +10,7 @@ import { executeWolframCode } from './wolframScriptUtils';
 
 const WolframInputSchema = z.strictObject({
   code: z.string(),
-  timeout: z.number().optional(),
+  timeout: z.number().nullish(),
 });
 
 export type WolframInput = z.infer<typeof WolframInputSchema>;


### PR DESCRIPTION
OpenAI-compatible APIs (DeepSeek, etc.) require optional fields to also be nullable. Change all tool input schema fields from .optional() to .nullish() to ensure compatibility with structured output APIs.

Fixes error: "Zod field uses .optional() without .nullable() which is not supported by the API"

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns all tool input schemas with OpenAI-compatible structured outputs by treating optional fields as nullable and updating null checks.
> 
> - Replace `.optional()` with `.nullish()` across tool schemas (Edit, Read, TextEditor, Arxiv*, Crossref, file_op, glob, grep, LaTeX tools, texcount, web_fetch, web_search, wolfram)
> - Adjust validations and guards to use `== null` and refine conditions accordingly (e.g., range/end checks, required param checks)
> - Update `AGENTS.md` with guidance, examples, and rationale for using `.nullish()` in tool schemas
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit be2a1ae70176627e47d4e25173628d44d777c4e3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->