### PR TITLE
fix: coalesce nullish values to undefined in tool implementations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,7 @@ When updating CHANGELOG.md:
 This project uses Zod v4. Follow these idiomatic patterns:
 
 **Type definitions**
+
 - `.int()` instead of `.number().int()` - native integer type
 - `.uuid()` instead of `.string().uuid()` - native UUID type
 - `.iso.datetime()` instead of `.string().datetime()` - ISO datetime validator
@@ -71,21 +72,23 @@ This project uses Zod v4. Follow these idiomatic patterns:
 - `.looseObject({...})` instead of `.object({...}).passthrough()` - allows extra keys
 
 **Default values**
+
 - `.prefault(val)` - Normalizes input BEFORE validation (for deserialization/loading)
 - `.default(val)` - Provides fallback AFTER validation fails
 - `.catch(val)` - Provides fallback when validation throws (field-level or schema-level)
 
 **When to use each default pattern:**
+
 ```typescript
 // Deserialization (loading saved state) - use .prefault()
 const SnapshotSchema = z.object({
-  count: z.int().prefault(0),        // normalize missing fields
+  count: z.int().prefault(0), // normalize missing fields
   items: z.array(z.string()).prefault([]),
 });
 
 // Field-level fallback (preserve valid fields) - use .catch()
 const UserSchema = z.object({
-  tier: TierSchema.catch('free'),    // invalid tier → 'free', valid tier preserved
+  tier: TierSchema.catch('free'), // invalid tier → 'free', valid tier preserved
   perms: z.array(z.string()).catch([]),
 });
 
@@ -94,6 +97,7 @@ const config = ConfigSchema.catch(DEFAULT_CONFIG).parse(data);
 ```
 
 **Safe parsing with fallback**
+
 ```typescript
 // Old verbose pattern
 const result = Schema.safeParse(data);
@@ -104,6 +108,7 @@ const value = Schema.catch(defaultValue).parse(data);
 ```
 
 **Null handling from databases**
+
 ```typescript
 // Accept null from DB, normalize to undefined
 description: z.string().nullish(),  // null | undefined → undefined
@@ -117,7 +122,7 @@ Use `.nullish()` instead of `.optional()` for optional fields in tool input sche
 // Tool schemas - use .nullish() for API compatibility
 const ToolInputSchema = z.strictObject({
   required: z.string(),
-  optional: z.string().nullish(),  // NOT .optional()
+  optional: z.string().nullish(), // NOT .optional()
 });
 ```
 

--- a/src/agent/utils/UsageMonitor.ts
+++ b/src/agent/utils/UsageMonitor.ts
@@ -133,7 +133,8 @@ export class UsageMonitor {
 
       // Validate provider against schema, fallback to 'unknown' if invalid
       const providerLower = modelConfig.provider.toLowerCase();
-      const provider = UsageProviderSchema.catch('unknown').parse(providerLower);
+      const provider =
+        UsageProviderSchema.catch('unknown').parse(providerLower);
 
       // Check if server-side keys (relay) were used for this request
       const usedRelay = getServerSideKeyService().shouldUseServerSideKeysSync(

--- a/src/model/ToolDefinition.ts
+++ b/src/model/ToolDefinition.ts
@@ -17,15 +17,15 @@ import { z, type ZodType } from 'zod';
  * without breaking validation when tools flow through AgentSettingSchema.
  */
 export const ToolDefinitionSchema = z.looseObject({
-    /** Name of the tool or function */
-    name: z.string(),
-    /** Optional description for the model */
-    description: z.string().optional(),
-    /** Parameter schema (JSON Schema format) */
-    parameters: z.record(z.string(), z.unknown()).optional(),
-    /** Runtime-only: original Zod schema for SDK-native conversion */
-    zodSchema: z.custom<ZodType>().optional(),
-  });
+  /** Name of the tool or function */
+  name: z.string(),
+  /** Optional description for the model */
+  description: z.string().optional(),
+  /** Parameter schema (JSON Schema format) */
+  parameters: z.record(z.string(), z.unknown()).optional(),
+  /** Runtime-only: original Zod schema for SDK-native conversion */
+  zodSchema: z.custom<ZodType>().optional(),
+});
 
 /** Tool definition type - derived from schema */
 export type ToolDefinition = z.infer<typeof ToolDefinitionSchema>;

--- a/src/tools/ReadTool.ts
+++ b/src/tools/ReadTool.ts
@@ -116,7 +116,7 @@ export class ReadFileTool extends defineTool({
       truncated,
       rangeProvided: Boolean(input.range),
       rangeEndExceeded:
-        input.range?.end !== undefined && input.range.end > totalLines,
+        input.range?.end != null && input.range.end > totalLines,
     });
 
     return toolResult({

--- a/src/tools/TextEditorTool.ts
+++ b/src/tools/TextEditorTool.ts
@@ -103,7 +103,7 @@ export class TextEditorTool extends defineTool({
     // Execute the appropriate command
     switch (command) {
       case 'view':
-        return await this.view(filePath, input.view_range);
+        return await this.view(filePath, input.view_range ?? undefined);
       case 'create':
         if (!input.file_text) {
           throw new ToolError(

--- a/src/tools/arxiv/ArxivMetadataTool.ts
+++ b/src/tools/arxiv/ArxivMetadataTool.ts
@@ -57,7 +57,10 @@ export class ArxivMetadataTool extends defineTool({
     // Take the first result (should be the only one for ID lookup)
     const targetEntry = entries[0];
 
-    const authorNames = getAuthorNames(targetEntry.authors, input.maxAuthors);
+    const authorNames = getAuthorNames(
+      targetEntry.authors,
+      input.maxAuthors ?? undefined,
+    );
     const includeAbstract = input.includeAbstract !== false;
 
     const metadata: ArxivPaperMetadata = {

--- a/src/tools/glob.ts
+++ b/src/tools/glob.ts
@@ -36,7 +36,9 @@ export class GlobTool extends defineTool({
   schema: GlobInputSchema,
 }) {
   protected async execute(input: GlobInput): Promise<ToolResult> {
-    const { resolved: base, display } = resolveAndFormat(input.path);
+    const { resolved: base, display } = resolveAndFormat(
+      input.path ?? undefined,
+    );
     const gitignore = await getGitignoreMatcher();
 
     let matches: string[];

--- a/src/tools/grep.ts
+++ b/src/tools/grep.ts
@@ -100,7 +100,9 @@ export class GrepTool extends defineTool({
 }) {
   protected async execute(input: GrepInput): Promise<ToolResult> {
     const outputMode: OutputMode = input.output_mode ?? 'content';
-    const { resolved: searchPath, display } = resolveAndFormat(input.path);
+    const { resolved: searchPath, display } = resolveAndFormat(
+      input.path ?? undefined,
+    );
     const gitignore = await getGitignoreMatcher();
     const args = buildArguments(input, outputMode);
     const ignoreArgs = gitignore.ignoreFiles.flatMap((ignoreFile) => [
@@ -122,7 +124,10 @@ export class GrepTool extends defineTool({
       );
     }
 
-    const limitedOutput = applyHeadLimit(result.stdout, input.head_limit);
+    const limitedOutput = applyHeadLimit(
+      result.stdout,
+      input.head_limit ?? undefined,
+    );
     const outputText =
       limitedOutput || `No matches found for pattern in ${display}`;
     const summary = limitedOutput

--- a/src/tools/web/WebSearchTool.ts
+++ b/src/tools/web/WebSearchTool.ts
@@ -38,7 +38,8 @@ export class WebSearchTool extends defineTool({
   schema: WebSearchInputSchema,
 }) {
   protected async execute(input: WebSearchInput): Promise<ToolResult> {
-    const { query, max_results = 3 } = input;
+    const { query } = input;
+    const max_results = input.max_results ?? 3;
     let response;
     try {
       response = await axios.get<DuckDuckGoResponse>(

--- a/src/tools/wolfram/WolframTool.ts
+++ b/src/tools/wolfram/WolframTool.ts
@@ -22,7 +22,7 @@ export class WolframTool extends defineTool({
 }) {
   protected async execute(input: WolframInput): Promise<ToolResult> {
     const result = await executeWolframCode(input.code, {
-      timeout: input.timeout,
+      timeout: input.timeout ?? undefined,
       showErrorsToUser: false,
     });
     if (result.success) {


### PR DESCRIPTION
Fix TypeScript errors caused by .nullish() type (T | null | undefined) being passed to functions expecting (T | undefined). Use ?? undefined to convert null to undefined where needed.

Files fixed:
- ReadTool.ts: rangeEndExceeded check
- TextEditorTool.ts: view_range parameter
- glob.ts: input.path parameter
- grep.ts: input.path and input.head_limit
- ArxivMetadataTool.ts: input.maxAuthors
- WebSearchTool.ts: max_results with default value
- WolframTool.ts: timeout parameter

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Strengthens type-safety for optional fields by converting `null` to `undefined` where APIs expect `T | undefined`, and tidies schema/doc formatting.
> 
> - Tools: use `?? undefined` or `!= null` for optionals (`ReadTool` range check, `TextEditorTool` `view_range`, `glob`/`grep` `path`, `grep` `head_limit`, `arxiv_metadata` `maxAuthors`, `web_search` `max_results` default, `wolfram` `timeout`)
> - Maintains behavior while resolving TypeScript errors from `.nullish()` inputs
> - Minor formatting/consistency: `ToolDefinitionSchema` object layout, `UsageMonitor` provider parse wrap, docs in `AGENTS.md`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9fb54b21bc06c95763345cdc3db636306704c62b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->