### PR TITLE
docs: update CLAUDE.md and AGENTS.md with latest codebase standards

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,8 +48,14 @@ When updating CHANGELOG.md:
 ### Directory organization
 
 - `src/frontend/` contains extension-host utilities that power shared UI flows (agent directories, file listers, instruction banners, tool workflows). Prefer these helpers over duplicating logic in commands or webviews.
+  - `frontend/system/` - VS Code command utilities (`safeExecuteCommand`)
+  - `frontend/ui/` - Dialog helpers, diff views, message utilities
+  - `frontend/editor/` - Active file guards and editor utilities
 - `src/common/` holds backend-only helpers (errors, state, files, base webview classes). Import them through the `@common/*` alias for clarity.
+  - `common/state/` - State managers including `pendingStateManager`
 - `src/utils/` is reserved for utilities used by both the extension host and webviews. If a helper is specific to one side, place it under `frontend/` or `common/` instead of `utils/`.
+  - `utils/core/` - Async utilities (`debounce`, `withTimeout`, `delay`)
+  - `utils/files/` - Filesystem utilities, rules, and vars
 
 ### Pragmatic implementations
 
@@ -134,7 +140,36 @@ if (input.optional == null) {
 }
 ```
 
+When passing nullish tool values to functions expecting `T | undefined` (not `T | null | undefined`), coalesce to undefined:
+
+```typescript
+// Function expects string | undefined, but .nullish() gives string | null | undefined
+const result = processPath(input.path ?? undefined);
+```
+
 See: https://platform.openai.com/docs/guides/structured-outputs
+
+### ES2023+ Patterns
+
+Use modern JavaScript features available with ES2022+ target:
+
+```typescript
+// Use findLast() for reverse array search
+const lastMessage = messages.findLast((m) => m.role === 'assistant');
+
+// Use ??= for lazy initialization
+this._builder ??= new PromptBuilder();
+
+// Use optional chaining consistently
+abortController?.abort();
+if (!runStage?.id) return;
+
+// Use ?? false for boolean coercion (not || false)
+const isEnabled = config.enabled ?? false;
+
+// Iterate Sets directly without Array.from()
+for (const item of mySet) { ... }
+```
 
 ### Refactoring for simplicity
 
@@ -164,6 +199,17 @@ Aim for code that looks like it was designed correctly from the start:
 - Implement new agents against `IAgent` (`src/agent/core/IAgent.ts`) and compose them via the factories in `src/agent/runtime`.
 - Persist interactive runs with `ToolUseSessionManager` (`src/agent/toolUse/ToolUseSessionManager.ts`) and launch/resume executions via `executeAgent` or `runPreparedAgent` (`src/agent/runtime/executeAgent.ts`) so session filters, run directories, and resume actions stay synchronized.
 - Add new model handlers under `src/agent/modelHandlers/`, export them through the index, and register capabilities/pricing in `src/model/ModelRegistry.ts`.
+
+**PocketFlow architecture**
+
+Agent flows follow the PocketFlow pattern in `src/agent/implementations/flows/`:
+
+- **Services** are immutable dependencies injected via `flow.setServices()`. Nodes access them via `this.services`. Define service interfaces in flow-specific files (e.g., `ReflectionServices`, `ToolUseServices`) extending `BaseFlowServices`.
+- **Shared store** contains only mutable state (memories). Nodes read/write via `prep()` and `post()` methods.
+- **Flow transitions** use `FlowTransition.DEFAULT` instead of magic `undefined` for clarity.
+- Node lifecycle: `prep(shared) → exec(prepRes) → post(shared, prepRes, execRes)`. Use constants `NODE_NO_RETRY` and `NODE_NO_WAIT` for node configuration.
+
+See `docs/pocketflow/` for full framework documentation.
 
 **Webviews and UI**
 
@@ -197,7 +243,7 @@ Aim for code that looks like it was designed correctly from the start:
 
 ### Webview Consistency Patterns
 
-- **Base Classes**: All webviews extend `BaseViewContentProvider`, `BaseViewMessageHandler`, and use DOM managers built on `BaseDomHandler` for consistent error handling, logging, URI generation, and cleanup
+- **Base Classes**: All webviews extend `BaseViewContentProvider`, `BaseViewMessageHandler`, and use DOM managers built on `BaseDomHandler` for consistent error handling, logging, URI generation, and cleanup. UI managers extend `BaseUIManager` from `src/common/modules/BaseUIManager.js`.
 - **Naming Convention**: Follow `[Domain]View[Component]` pattern (e.g., `MainViewContentProvider`, `HistoryViewMessageHandler`)
 - **Command Constants**: Define all commands in `src/common/webview/commands.js` and `.ts` - use constants, not string literals
 - **Message Handlers**: Delegate to domain-specific manager classes (FileManager, SettingsManager, etc.) for separation of concerns
@@ -206,6 +252,7 @@ Aim for code that looks like it was designed correctly from the start:
 - **Module Structure**: Keep UI managers focused on a single responsibility
 - **Trust Dependencies**: Use APIs as documented. When behavior is unclear, check the source in `node_modules/` first. Add a workaround only for a documented quirk, with a comment explaining it
 - **Dropdown Menus**: Should close when clicking outside, not just on toggle
+- **CSS Organization**: Keep per-component styles in view-specific `styles/` directories, shared tokens in `src/common/styles/common.css`
 
 ### Source Organization
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,11 +51,24 @@ When updating CHANGELOG.md:
   - `frontend/system/` - VS Code command utilities (`safeExecuteCommand`)
   - `frontend/ui/` - Dialog helpers, diff views, message utilities
   - `frontend/editor/` - Active file guards and editor utilities
+  - `frontend/agents/` - Agent directory management (`AgentDirectoryManager`)
+  - `frontend/files/` - File lister and discovery utilities
+  - `frontend/webview/` - Webview HTML builder (`buildWebviewHtml`)
+  - `frontend/latex/` - LaTeX build integration, linting
+  - `frontend/media/` - Image and audio handling
 - `src/common/` holds backend-only helpers (errors, state, files, base webview classes). Import them through the `@common/*` alias for clarity.
   - `common/state/` - State managers including `pendingStateManager`
+  - `common/modules/` - Shared webview modules (`BaseUIManager`, `domUtils`, `templateUtils`)
+  - `common/webview/` - Base classes (`BaseViewContentProvider`, `BaseViewMessageHandler`), theme handlers
 - `src/utils/` is reserved for utilities used by both the extension host and webviews. If a helper is specific to one side, place it under `frontend/` or `common/` instead of `utils/`.
   - `utils/core/` - Async utilities (`debounce`, `withTimeout`, `delay`)
   - `utils/files/` - Filesystem utilities, rules, and vars
+  - `utils/config/` - Settings helpers (`getConfig`, `updateConfig`, `watchConfig`)
+  - `utils/system/` - Shell command execution (`execUtils`)
+  - `utils/text/` - Text and XML processing utilities
+  - `utils/prompt/` - Prompt builder utilities
+- `src/explorer/` - VS Code file explorer integration and watchers
+- `src/profileView/` - Agent profile/settings webview (follows same pattern as progressView/historyView)
 
 ### Pragmatic implementations
 
@@ -76,6 +89,18 @@ This project uses Zod v4. Follow these idiomatic patterns:
 - `.iso.datetime()` instead of `.string().datetime()` - ISO datetime validator
 - `.enum(MyEnum)` instead of `.nativeEnum(MyEnum)` - works with TS enums
 - `.looseObject({...})` instead of `.object({...}).passthrough()` - allows extra keys
+- `.strictObject({...})` - disallows extra keys (use for tool input schemas)
+
+**Validation and refinement**
+
+- `.describe('...')` - add field documentation for tool schemas and types
+- `.refine()` / `.superRefine()` - custom validation logic
+- `.nullable()` - accept null (distinct from `.nullish()` which accepts null OR undefined)
+- `.nonnegative()` / `.positive()` - numeric constraints
+- `.regex()` - pattern matching for strings
+- `.url()` - URL validation
+- `.transform()` - value transformation after validation
+- `.custom<T>()` - use sparingly for external SDK types with explanatory comments
 
 **Default values**
 
@@ -154,11 +179,17 @@ See: https://platform.openai.com/docs/guides/structured-outputs
 Use modern JavaScript features available with ES2022+ target:
 
 ```typescript
-// Use findLast() for reverse array search
-const lastMessage = messages.findLast((m) => m.role === 'assistant');
+// Use .at() for negative array indexing
+const lastItem = items.at(-1);
 
-// Use ??= for lazy initialization
-this._builder ??= new PromptBuilder();
+// Use Object.hasOwn() instead of hasOwnProperty
+if (Object.hasOwn(obj, 'key')) { ... }
+
+// Use .flatMap() for map+flatten
+const allItems = groups.flatMap((g) => g.items);
+
+// Use .replaceAll() for global string replacement
+const cleaned = text.replaceAll('\r\n', '\n');
 
 // Use optional chaining consistently
 abortController?.abort();
@@ -204,10 +235,16 @@ Aim for code that looks like it was designed correctly from the start:
 
 Agent flows follow the PocketFlow pattern in `src/agent/implementations/flows/`:
 
+- **Flow types**: `ReflectionFlow` for multi-round reflection agents, `ToolUseRunFlow` for tool-use agents
 - **Services** are immutable dependencies injected via `flow.setServices()`. Nodes access them via `this.services`. Define service interfaces in flow-specific files (e.g., `ReflectionServices`, `ToolUseServices`) extending `BaseFlowServices`.
 - **Shared store** contains only mutable state (memories). Nodes read/write via `prep()` and `post()` methods.
-- **Flow transitions** use `FlowTransition.DEFAULT` instead of magic `undefined` for clarity.
-- Node lifecycle: `prep(shared) → exec(prepRes) → post(shared, prepRes, execRes)`. Use constants `NODE_NO_RETRY` and `NODE_NO_WAIT` for node configuration.
+- **Flow transitions** - use named constants instead of magic values:
+  - `FlowTransition.DEFAULT` - follow next() successor
+  - `FlowTransition.CONTINUE` - loop back to flow entry
+  - `FlowTransition.FINALIZE` - exit flow after finalization
+  - `FlowTransition.COMPLETE` - return control to caller
+- **Node lifecycle**: `prep(shared) → exec(prepRes) → post(shared, prepRes, execRes)`. Use constants `NODE_NO_RETRY` and `NODE_NO_WAIT` for node configuration.
+- **Agent owns lifecycle**: Agents handle init/finalize; flows handle only execution logic. Nodes should throw errors directly (agent.run() catches).
 
 See `docs/pocketflow/` for full framework documentation.
 
@@ -215,7 +252,7 @@ See `docs/pocketflow/` for full framework documentation.
 
 - Generate HTML through `BaseViewContentProvider` (`src/common/webview/BaseViewContentProvider.ts`) and `buildWebviewHtml` (`src/frontend/webview/html.ts`). Extend `BaseViewMessageHandler` and `BaseDomHandler` for consistent lifecycle management across views.
 - Register webview message handlers with `registerMessageHandlers` (`src/common/modules/webviewContext.js`). When adding UI managers (e.g., under `src/webview/modules/uiManagers/` or `src/progressView/modules/uiManagers/`), expose their URIs in the relevant content provider and import map.
-- Use codicon-based controls and the shared helpers in `src/common/modules/` (`iconButtonInitializer`, `templateUtils`, `domUtils`, `stringUtils`, `pathUtils`, `webviewState`, `themeHandlers`) alongside `src/webview/modules/pasteHandler.js` for consistent interactions.
+- Use codicon-based controls and the shared helpers in `src/common/modules/` (`iconConstants`, `templateUtils`, `domUtils`, `stringUtils`, `pathUtils`, `webviewState`) and `src/common/webview/themeHandlers.js` alongside `src/webview/modules/pasteHandler.js` for consistent interactions.
 - Map every module dependency in the import map, including transitives, and generate URIs via helper methods (`getHistoryViewUri`, `getCommonUri`, etc.). Missing entries will prevent modules from loading in the sandboxed webview.
 - For webview dependencies, prefer CDN builds (jsdelivr for static assets, esm.sh for ES modules) for complex packages like markdown-it, KaTeX, or highlight.js, while keeping lightweight bundles (split.js, `@vscode/codicons`) local to reduce extension size.
 - Keep CSS modular (per-component styles in `src/progressView/styles`, shared tokens in `src/common/styles/common.css`) and use codicon chevrons (e.g., `<i class="codicon codicon-chevron-down"></i>`) for toggle affordances.
@@ -243,8 +280,8 @@ See `docs/pocketflow/` for full framework documentation.
 
 ### Webview Consistency Patterns
 
-- **Base Classes**: All webviews extend `BaseViewContentProvider`, `BaseViewMessageHandler`, and use DOM managers built on `BaseDomHandler` for consistent error handling, logging, URI generation, and cleanup. UI managers extend `BaseUIManager` from `src/common/modules/BaseUIManager.js`.
-- **Naming Convention**: Follow `[Domain]View[Component]` pattern (e.g., `MainViewContentProvider`, `HistoryViewMessageHandler`)
+- **Base Classes**: All webviews (webview, progressView, historyView, profileView) extend `BaseViewContentProvider`, `BaseViewMessageHandler`, and use DOM managers built on `BaseDomHandler` for consistent error handling, logging, URI generation, and cleanup. Complex UI managers can extend `BaseUIManager` from `src/common/modules/BaseUIManager.js`.
+- **Naming Convention**: Follow `[Domain]View[Component]` pattern (e.g., `MainViewContentProvider`, `HistoryViewMessageHandler`, `ProfileViewDomHandler`)
 - **Command Constants**: Define all commands in `src/common/webview/commands.js` and `.ts` - use constants, not string literals
 - **Message Handlers**: Delegate to domain-specific manager classes (FileManager, SettingsManager, etc.) for separation of concerns
 - **Client-Side State**: Add empty handlers with `/* State saved client-side */` comment for checkbox/toggle operations

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,8 @@ Key directories in `src/`:
 - `webview/` - Main agent interaction interface
 - `progressView/` - Task tracking board
 - `historyView/` - Execution history browser
+- `profileView/` - Agent profile/settings view
+- `explorer/` - VS Code file explorer integration
 - `logger/` - Logging infrastructure
 - `eventBus/` - Progress event system
 - `replacement/` - Text cleanup rules

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,7 @@ The core of TeXRA is its agent architecture in `src/agent/`:
 Key directories in `src/`:
 
 - `agent/` - Agent core, implementations, model handlers, runtime, tool-use
+  - `implementations/flows/` - PocketFlow-based flow implementations (reflection, tool-use)
 - `commands/` - Commands organized by domain (see below)
 - `common/` - Backend-only helpers (errors, state, files, webview base classes)
 - `frontend/` - Extension-host utilities for shared UI flows
@@ -63,6 +64,10 @@ Key directories in `src/`:
 - `logger/` - Logging infrastructure
 - `eventBus/` - Progress event system
 - `replacement/` - Text cleanup rules
+
+Key documentation in `docs/`:
+
+- `pocketflow/` - PocketFlow framework documentation (core abstractions, design patterns, utility functions)
 
 ### Commands (`src/commands/`)
 
@@ -88,6 +93,8 @@ Use Zod schemas as the single source of truth for data structures:
 - **Avoid `z.custom<T>()`** when a proper schema exists—prefer `z.discriminatedUnion()` for union types
 - **Co-locate types with schemas** in the same file for maintainability
 - **Add compile-time assertions** (using `satisfies`) when schemas must stay synchronized with external types
+
+This project uses **Zod v4**. See AGENTS.md for idiomatic Zod v4 patterns including `.prefault()`, `.catch()`, and `.nullish()` for tool schemas.
 
 ### Path Aliases
 

--- a/src/agent/remote/RemoteAgentLoader.ts
+++ b/src/agent/remote/RemoteAgentLoader.ts
@@ -110,7 +110,7 @@ export class RemoteAgentLoader {
             throw new Error('Session expired. Sign in again to continue.');
           } else if (response.status === StatusCodes.NOT_FOUND) {
             // If not found and we have more candidates to try, continue to next
-            if (candidateName !== candidateNames[candidateNames.length - 1]) {
+            if (candidateName !== candidateNames.at(-1)) {
               logger.debug(
                 CHANNEL,
                 `Agent variant "${candidateName}" not found, trying next candidate`,
@@ -213,7 +213,7 @@ export class RemoteAgentLoader {
         };
       } catch (error) {
         // If this is the last candidate, throw the error
-        if (candidateName === candidateNames[candidateNames.length - 1]) {
+        if (candidateName === candidateNames.at(-1)) {
           logger.error(
             CHANNEL,
             `Failed to load remote agent "${agentName}": ${toErrorMessage(error)}`,

--- a/src/auth/serverKeys/ServerSideKeyService.ts
+++ b/src/auth/serverKeys/ServerSideKeyService.ts
@@ -23,6 +23,7 @@ import {
 } from '../config';
 import type { TierService } from '../tier/TierService';
 import type { ServerSideProvider } from './types';
+import { logger } from '@logger/logUtils';
 
 const LOG_PREFIX = '[ServerSideKeyService]';
 
@@ -303,7 +304,7 @@ export class ServerSideKeyService {
 
       // Check if access has expired
       if (this.tierService.isAccessExpired()) {
-        console.log(`${LOG_PREFIX} User access has expired`);
+        logger.info(`${LOG_PREFIX} User access has expired`);
         this.accessResult = false;
         return false;
       }
@@ -312,7 +313,7 @@ export class ServerSideKeyService {
       // If tier config failed, report no access so UI shows API key banner
       const tierConfigRequired = !this.hasFullAccess();
       if (tierConfigRequired && tierConfig === null) {
-        console.log(
+        logger.info(
           `${LOG_PREFIX} Tier config unavailable for non-Ultra user, denying access`,
         );
         this.accessResult = false;

--- a/src/auth/tier/TierService.ts
+++ b/src/auth/tier/TierService.ts
@@ -20,6 +20,7 @@ import {
   type TierModelConfig,
   type UserAccessStatus,
 } from './types';
+import { logger } from '@logger/logUtils';
 
 const LOG_PREFIX = '[TierService]';
 
@@ -85,12 +86,12 @@ export class TierService {
 
       if (!response.ok) {
         if (response.status === 404) {
-          console.log(
+          logger.info(
             `${LOG_PREFIX} tier-config endpoint not available, using defaults`,
           );
           return null;
         }
-        console.error(
+        logger.error(
           `${LOG_PREFIX} Failed to fetch tier config: ${response.status}`,
         );
         return null;
@@ -109,7 +110,7 @@ export class TierService {
       const parsed = TierModelConfigSchema.safeParse(data);
 
       if (!parsed.success) {
-        console.error(
+        logger.error(
           `${LOG_PREFIX} Invalid tier config response:`,
           parsed.error,
         );
@@ -118,7 +119,7 @@ export class TierService {
 
       return parsed.data;
     } catch (error) {
-      console.error(`${LOG_PREFIX} Error fetching tier config:`, error);
+      logger.error(`${LOG_PREFIX} Error fetching tier config:`, error);
       return null;
     }
   }

--- a/src/commands/files/openFileCommands.ts
+++ b/src/commands/files/openFileCommands.ts
@@ -4,6 +4,9 @@ import * as vscode from 'vscode';
 // Local imports - common
 import { toErrorMessage } from '@common/errors';
 
+// Local imports - logging
+import { logger } from '@logger/logUtils';
+
 // Local imports - utilities
 import { fileLister } from '@frontend/files';
 import { openBuildDisplayIfTex } from '@frontend/latex/openBuild';
@@ -41,7 +44,7 @@ export async function openLabel(label: string): Promise<void> {
       }
     } catch (error) {
       // Log but continue search - file might be inaccessible
-      console.debug(`Could not read file ${file}: ${toErrorMessage(error)}`);
+      logger.debug(`Could not read file ${file}: ${toErrorMessage(error)}`);
     }
   }
 

--- a/src/commands/git/gitCommands.ts
+++ b/src/commands/git/gitCommands.ts
@@ -8,6 +8,7 @@ import * as vscode from 'vscode';
 // Local imports - utilities
 import { getConfig } from '@utils/config';
 import { WorkspaceFS } from '@utils/files';
+import { logger } from '@logger/logUtils';
 
 // Type imports
 import type { Dirent } from 'fs';
@@ -209,7 +210,7 @@ async function cloneOverleafProject(
     vscode.window.showErrorMessage(
       'Unable to inspect the workspace folder before cloning the Overleaf project.',
     );
-    console.error('Failed to read workspace contents:', error);
+    logger.error('Failed to read workspace contents:', error);
     return;
   }
 
@@ -250,9 +251,9 @@ async function cloneOverleafProject(
       const sanitizedMessage = error.message
         .replaceAll(token, '********')
         .replaceAll(encodedToken, '********');
-      console.error('Overleaf clone failed:', sanitizedMessage);
+      logger.error('Overleaf clone failed:', sanitizedMessage);
     } else {
-      console.error('Overleaf clone failed with non-error value:', error);
+      logger.error('Overleaf clone failed with non-error value:', error);
     }
   }
 }

--- a/src/commands/system/mainViewCommands.ts
+++ b/src/commands/system/mainViewCommands.ts
@@ -5,6 +5,7 @@ import * as vscode from 'vscode';
 import { MAIN_VIEW_COMMANDS } from '@common/webview';
 import { computeModelOptions } from '@model/computeModelOptions';
 import { safeExecuteCommand } from '@frontend/system/commandUtils';
+import { logger } from '@logger/logUtils';
 
 export const mainViewCommands = {
   reset: 'texra.mainView.reset',
@@ -56,7 +57,7 @@ export function registerMainViewCommands(context: vscode.ExtensionContext) {
             options,
           });
         } catch (error) {
-          console.error('Failed to refresh model options:', error);
+          logger.error('Failed to refresh model options:', error);
           vscode.window.showErrorMessage(
             'Failed to refresh model options. Please check the output console for details.',
           );

--- a/src/progressView/persistence/schemaUtils.ts
+++ b/src/progressView/persistence/schemaUtils.ts
@@ -4,7 +4,7 @@ import { z } from 'zod';
 /**
  * Coerces and validates integer round keys from string record keys.
  */
-export const RoundKeySchema = z.coerce.number().int();
+export const RoundKeySchema = z.coerce.int();
 
 /**
  * Factory for creating round map schemas that transform { roundNum: items[] } to Map<number, T[]>.

--- a/src/tools/EditTool.ts
+++ b/src/tools/EditTool.ts
@@ -72,13 +72,13 @@ export class EditFileTool extends defineTool({
       );
     }
 
-    if (!replace_all && occurrences > 1) {
+    if (replace_all !== true && occurrences > 1) {
       throw new ToolError(
         `old_string is not unique within ${targetPath}. Include more surrounding context or set replace_all to true.`,
       );
     }
 
-    const updatedContent = replace_all
+    const updatedContent = replace_all === true
       ? currentContent.replaceAll(old_string, new_string)
       : currentContent.replace(old_string, new_string);
 
@@ -104,10 +104,10 @@ export class EditFileTool extends defineTool({
       finalContent,
     );
 
-    const replacementSummary = replace_all
+    const replacementSummary = replace_all === true
       ? `Replaced ${occurrences} occurrence${occurrences === 1 ? '' : 's'}.`
       : 'Replaced 1 occurrence.';
-    const summary = replace_all
+    const summary = replace_all === true
       ? `Edited ${targetPath}: replaced ${occurrences} occurrence${
           occurrences === 1 ? '' : 's'
         }`

--- a/src/tools/TextEditorTool.ts
+++ b/src/tools/TextEditorTool.ts
@@ -395,9 +395,9 @@ export class TextEditorTool extends defineTool({
       const fileContent = await WorkspaceFS.read(filePath);
 
       // Expand tabs in content and search string
-      const expandedFileContent = fileContent.replace(/\t/g, '    ');
-      const expandedOldStr = oldStr.replace(/\t/g, '    ');
-      const expandedNewStr = newStr.replace(/\t/g, '    ');
+      const expandedFileContent = fileContent.replaceAll('\t', '    ');
+      const expandedOldStr = oldStr.replaceAll('\t', '    ');
+      const expandedNewStr = newStr.replaceAll('\t', '    ');
 
       // Check for occurrences of oldStr
       const occurrences = expandedFileContent.split(expandedOldStr).length - 1;
@@ -520,8 +520,8 @@ export class TextEditorTool extends defineTool({
       const fileContent = await WorkspaceFS.read(filePath);
 
       // Expand tabs in content and new string
-      const expandedFileContent = fileContent.replace(/\t/g, '    ');
-      const expandedNewStr = newStr.replace(/\t/g, '    ');
+      const expandedFileContent = fileContent.replaceAll('\t', '    ');
+      const expandedNewStr = newStr.replaceAll('\t', '    ');
 
       // Split content into lines
       const fileLines = expandedFileContent.split('\n');

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -59,7 +59,7 @@ interface PendingApprovalEntry {
 }
 
 /** All valid approval actions for tool edit prompts */
-export const ProgressViewApprovalActions = [
+export const PROGRESS_VIEW_APPROVAL_ACTIONS = [
   'approve',
   'reject',
   'openDiff',
@@ -68,7 +68,7 @@ export const ProgressViewApprovalActions = [
 ] as const;
 
 export type ProgressViewApprovalAction =
-  (typeof ProgressViewApprovalActions)[number];
+  (typeof PROGRESS_VIEW_APPROVAL_ACTIONS)[number];
 
 interface ProgressViewApprovalActionPayload {
   requestId: string;
@@ -217,7 +217,7 @@ function countChangedLines(text: string): number {
     return 0;
   }
 
-  const normalized = text.replace(/\r\n/g, '\n');
+  const normalized = text.replaceAll('\r\n', '\n');
   const segments = normalized.split('\n');
   if (normalized.endsWith('\n')) {
     return Math.max(segments.length - 1, 0);

--- a/src/tools/arxiv/ArxivMetadataTool.ts
+++ b/src/tools/arxiv/ArxivMetadataTool.ts
@@ -61,7 +61,7 @@ export class ArxivMetadataTool extends defineTool({
       targetEntry.authors,
       input.maxAuthors ?? undefined,
     );
-    const includeAbstract = input.includeAbstract !== false;
+    const includeAbstract = input.includeAbstract ?? true;
 
     const metadata: ArxivPaperMetadata = {
       id: extractEntryIdentifier(targetEntry.id) ?? requestId,

--- a/src/utils/config/constants.ts
+++ b/src/utils/config/constants.ts
@@ -1,5 +1,6 @@
 // Local imports - config utils
 import { getConfig } from './configUtils';
+import { logger } from '@logger/logUtils';
 
 // Settings query constants for VS Code settings UI
 export const SETTINGS_QUERY = {
@@ -78,7 +79,7 @@ export function getToolUsePersistenceTtlHours(): number {
   const hours = Number(value);
   if (!Number.isFinite(hours) || hours < 1) {
     // Log a warning when invalid configuration is detected
-    console.warn(
+    logger.warn(
       `Invalid tool-use persistence TTL value: ${value}. Using default of ${DEFAULT_TOOL_USE_PERSISTENCE_TTL_HOURS} hours.`,
     );
     return DEFAULT_TOOL_USE_PERSISTENCE_TTL_HOURS;

--- a/src/utils/system/toolUtils.ts
+++ b/src/utils/system/toolUtils.ts
@@ -8,6 +8,7 @@ import * as vscode from 'vscode';
 
 // Local imports
 import type { ExecResult } from '@agent/types/ResultTypes';
+import { logger } from '@logger/logUtils';
 
 // Local file imports
 import { extendEnvPath, findToolInCommonPaths } from './platformPaths';
@@ -403,7 +404,7 @@ export async function checkCoreDependencies(
   } catch (error) {
     // If checking fails, assume all tools are missing to prompt user to check
     // This is safer than silently ignoring the error
-    console.error('Failed to check core dependencies:', error);
+    logger.error('Failed to check core dependencies:', error);
     return ['latexindent', 'perl', 'gs', 'gm/magick'];
   }
 }

--- a/src/webview/types/messages.ts
+++ b/src/webview/types/messages.ts
@@ -4,7 +4,7 @@
  */
 import { z } from 'zod';
 
-import { ProgressViewApprovalActions } from '@tools/approval/toolEditApproval';
+import { PROGRESS_VIEW_APPROVAL_ACTIONS } from '@tools/approval/toolEditApproval';
 
 // --- Base Schemas (composable building blocks) ---
 
@@ -213,7 +213,7 @@ export type InfoMessage = z.infer<typeof InfoMessageSchema>;
 /** Approval action message from progress view */
 export const ApprovalActionMessageSchema = z.object({
   requestId: z.string().min(1),
-  action: z.enum(ProgressViewApprovalActions),
+  action: z.enum(PROGRESS_VIEW_APPROVAL_ACTIONS),
   note: z.string().optional(),
 });
 


### PR DESCRIPTION
- Add PocketFlow documentation reference and flows directory to CLAUDE.md
- Add Zod v4 reference note to CLAUDE.md
- Document ES2023+ patterns (findLast, ??=, optional chaining)
- Add nullish coalescing pattern for tool implementations
- Document PocketFlow architecture and services pattern
- Expand directory organization with frontend/common/utils subdirectories
- Add BaseUIManager and CSS organization to webview patterns

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refreshes repository standards and modernizes implementation details across tools, auth, commands, and webview types.
> 
> - **Docs**: Expand `AGENTS.md` and `CLAUDE.md` with PocketFlow overview, directory maps, Zod v4 idioms, and ES2023+ patterns; add webview/CSS patterns and Profile/Explorer directories
> - **Logging**: Replace `console.*` with `logger` across auth (`TierService`, `ServerSideKeyService`), git/system/file commands, config constants, and tool utils for consistent telemetry
> - **ES2023 APIs**: Use `.at(-1)`, `.replaceAll()`, optional chaining, and nullish coalescing where appropriate (e.g., RemoteAgentLoader, TextEditorTool, approval utils)
> - **Zod v4 alignment**: Use `z.coerce.int()` and stricter schemas in persistence and webview message types
> - **Tool behavior**: Make `replace_all` strictly `=== true` in `EditTool`; normalize tab expansion via `replaceAll` in `TextEditorTool`; default `includeAbstract` via `?? true` in `ArxivMetadataTool`
> - **Approval constants**: Rename `ProgressViewApprovalActions` → `PROGRESS_VIEW_APPROVAL_ACTIONS` and update webview message schema accordingly
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d423eb1e4f5c93c06330ff2f82aaf89a42c34eef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->