### PR TITLE
Fix TypeScript error in ServerSideKeyService

### DIFF
--- a/src/auth/serverKeys/ServerSideKeyService.ts
+++ b/src/auth/serverKeys/ServerSideKeyService.ts
@@ -23,9 +23,9 @@ import {
 } from '../config';
 import type { TierService } from '../tier/TierService';
 import type { ServerSideProvider } from './types';
-import { logger } from '@logger/logUtils';
+import * as logger from '@logger/logUtils';
 
-const LOG_PREFIX = '[ServerSideKeyService]';
+const CHANNEL = 'ServerSideKeyService';
 
 /** Path suffixes for relay URLs, matching SDK expectations. */
 const RELAY_PATH_SUFFIXES: Partial<Record<ServerSideProvider, string>> = {
@@ -304,7 +304,7 @@ export class ServerSideKeyService {
 
       // Check if access has expired
       if (this.tierService.isAccessExpired()) {
-        logger.info(`${LOG_PREFIX} User access has expired`);
+        logger.info(CHANNEL, 'User access has expired');
         this.accessResult = false;
         return false;
       }
@@ -314,7 +314,8 @@ export class ServerSideKeyService {
       const tierConfigRequired = !this.hasFullAccess();
       if (tierConfigRequired && tierConfig === null) {
         logger.info(
-          `${LOG_PREFIX} Tier config unavailable for non-Ultra user, denying access`,
+          CHANNEL,
+          'Tier config unavailable for non-Ultra user, denying access',
         );
         this.accessResult = false;
         return false;

--- a/src/auth/tier/TierService.ts
+++ b/src/auth/tier/TierService.ts
@@ -20,9 +20,9 @@ import {
   type TierModelConfig,
   type UserAccessStatus,
 } from './types';
-import { logger } from '@logger/logUtils';
+import * as logger from '@logger/logUtils';
 
-const LOG_PREFIX = '[TierService]';
+const CHANNEL = 'TierService';
 
 /**
  * Service for managing tier-based model access configuration.
@@ -87,12 +87,14 @@ export class TierService {
       if (!response.ok) {
         if (response.status === 404) {
           logger.info(
-            `${LOG_PREFIX} tier-config endpoint not available, using defaults`,
+            CHANNEL,
+            'Tier-config endpoint not available, using defaults',
           );
           return null;
         }
         logger.error(
-          `${LOG_PREFIX} Failed to fetch tier config: ${response.status}`,
+          CHANNEL,
+          `Failed to fetch tier config: ${response.status}`,
         );
         return null;
       }
@@ -111,15 +113,16 @@ export class TierService {
 
       if (!parsed.success) {
         logger.error(
-          `${LOG_PREFIX} Invalid tier config response:`,
-          parsed.error,
+          CHANNEL,
+          `Invalid tier config response: ${parsed.error.message}`,
         );
         return null;
       }
 
       return parsed.data;
     } catch (error) {
-      logger.error(`${LOG_PREFIX} Error fetching tier config:`, error);
+      const message = error instanceof Error ? error.message : String(error);
+      logger.error(CHANNEL, `Error fetching tier config: ${message}`);
       return null;
     }
   }

--- a/src/commands/files/openFileCommands.ts
+++ b/src/commands/files/openFileCommands.ts
@@ -5,7 +5,9 @@ import * as vscode from 'vscode';
 import { toErrorMessage } from '@common/errors';
 
 // Local imports - logging
-import { logger } from '@logger/logUtils';
+import * as logger from '@logger/logUtils';
+
+const CHANNEL = 'openFileCommands';
 
 // Local imports - utilities
 import { fileLister } from '@frontend/files';
@@ -44,7 +46,10 @@ export async function openLabel(label: string): Promise<void> {
       }
     } catch (error) {
       // Log but continue search - file might be inaccessible
-      logger.debug(`Could not read file ${file}: ${toErrorMessage(error)}`);
+      logger.debug(
+        CHANNEL,
+        `Could not read file ${file}: ${toErrorMessage(error)}`,
+      );
     }
   }
 

--- a/src/commands/git/gitCommands.ts
+++ b/src/commands/git/gitCommands.ts
@@ -8,11 +8,12 @@ import * as vscode from 'vscode';
 // Local imports - utilities
 import { getConfig } from '@utils/config';
 import { WorkspaceFS } from '@utils/files';
-import { logger } from '@logger/logUtils';
+import * as logger from '@logger/logUtils';
 
 // Type imports
 import type { Dirent } from 'fs';
 
+const CHANNEL = 'gitCommands';
 const COMMIT_LABEL_FORMAT = '%h: %s (%cr)';
 
 export function registerGitCommands(context: vscode.ExtensionContext) {
@@ -210,7 +211,8 @@ async function cloneOverleafProject(
     vscode.window.showErrorMessage(
       'Unable to inspect the workspace folder before cloning the Overleaf project.',
     );
-    logger.error('Failed to read workspace contents:', error);
+    const message = error instanceof Error ? error.message : String(error);
+    logger.error(CHANNEL, `Failed to read workspace contents: ${message}`);
     return;
   }
 
@@ -251,9 +253,12 @@ async function cloneOverleafProject(
       const sanitizedMessage = error.message
         .replaceAll(token, '********')
         .replaceAll(encodedToken, '********');
-      logger.error('Overleaf clone failed:', sanitizedMessage);
+      logger.error(CHANNEL, `Overleaf clone failed: ${sanitizedMessage}`);
     } else {
-      logger.error('Overleaf clone failed with non-error value:', error);
+      logger.error(
+        CHANNEL,
+        `Overleaf clone failed with non-error value: ${String(error)}`,
+      );
     }
   }
 }

--- a/src/commands/system/mainViewCommands.ts
+++ b/src/commands/system/mainViewCommands.ts
@@ -5,7 +5,9 @@ import * as vscode from 'vscode';
 import { MAIN_VIEW_COMMANDS } from '@common/webview';
 import { computeModelOptions } from '@model/computeModelOptions';
 import { safeExecuteCommand } from '@frontend/system/commandUtils';
-import { logger } from '@logger/logUtils';
+import * as logger from '@logger/logUtils';
+
+const CHANNEL = 'mainViewCommands';
 
 export const mainViewCommands = {
   reset: 'texra.mainView.reset',
@@ -57,7 +59,9 @@ export function registerMainViewCommands(context: vscode.ExtensionContext) {
             options,
           });
         } catch (error) {
-          logger.error('Failed to refresh model options:', error);
+          const message =
+            error instanceof Error ? error.message : String(error);
+          logger.error(CHANNEL, `Failed to refresh model options: ${message}`);
           vscode.window.showErrorMessage(
             'Failed to refresh model options. Please check the output console for details.',
           );

--- a/src/progressView/persistence/schemaUtils.ts
+++ b/src/progressView/persistence/schemaUtils.ts
@@ -4,7 +4,7 @@ import { z } from 'zod';
 /**
  * Coerces and validates integer round keys from string record keys.
  */
-export const RoundKeySchema = z.coerce.int();
+export const RoundKeySchema = z.coerce.number().int();
 
 /**
  * Factory for creating round map schemas that transform { roundNum: items[] } to Map<number, T[]>.

--- a/src/tools/EditTool.ts
+++ b/src/tools/EditTool.ts
@@ -78,9 +78,10 @@ export class EditFileTool extends defineTool({
       );
     }
 
-    const updatedContent = replace_all === true
-      ? currentContent.replaceAll(old_string, new_string)
-      : currentContent.replace(old_string, new_string);
+    const updatedContent =
+      replace_all === true
+        ? currentContent.replaceAll(old_string, new_string)
+        : currentContent.replace(old_string, new_string);
 
     const approval = await requestToolEditApproval({
       path: targetPath,
@@ -104,14 +105,16 @@ export class EditFileTool extends defineTool({
       finalContent,
     );
 
-    const replacementSummary = replace_all === true
-      ? `Replaced ${occurrences} occurrence${occurrences === 1 ? '' : 's'}.`
-      : 'Replaced 1 occurrence.';
-    const summary = replace_all === true
-      ? `Edited ${targetPath}: replaced ${occurrences} occurrence${
-          occurrences === 1 ? '' : 's'
-        }`
-      : `Edited ${targetPath}: replaced 1 occurrence`;
+    const replacementSummary =
+      replace_all === true
+        ? `Replaced ${occurrences} occurrence${occurrences === 1 ? '' : 's'}.`
+        : 'Replaced 1 occurrence.';
+    const summary =
+      replace_all === true
+        ? `Edited ${targetPath}: replaced ${occurrences} occurrence${
+            occurrences === 1 ? '' : 's'
+          }`
+        : `Edited ${targetPath}: replaced 1 occurrence`;
 
     const userDiffNote = formatUnifiedApprovalUserDiff(
       targetPath,

--- a/src/utils/config/constants.ts
+++ b/src/utils/config/constants.ts
@@ -1,6 +1,8 @@
 // Local imports - config utils
 import { getConfig } from './configUtils';
-import { logger } from '@logger/logUtils';
+import * as logger from '@logger/logUtils';
+
+const CHANNEL = 'config';
 
 // Settings query constants for VS Code settings UI
 export const SETTINGS_QUERY = {
@@ -80,6 +82,7 @@ export function getToolUsePersistenceTtlHours(): number {
   if (!Number.isFinite(hours) || hours < 1) {
     // Log a warning when invalid configuration is detected
     logger.warn(
+      CHANNEL,
       `Invalid tool-use persistence TTL value: ${value}. Using default of ${DEFAULT_TOOL_USE_PERSISTENCE_TTL_HOURS} hours.`,
     );
     return DEFAULT_TOOL_USE_PERSISTENCE_TTL_HOURS;

--- a/src/utils/system/toolUtils.ts
+++ b/src/utils/system/toolUtils.ts
@@ -8,11 +8,13 @@ import * as vscode from 'vscode';
 
 // Local imports
 import type { ExecResult } from '@agent/types/ResultTypes';
-import { logger } from '@logger/logUtils';
+import * as logger from '@logger/logUtils';
 
 // Local file imports
 import { extendEnvPath, findToolInCommonPaths } from './platformPaths';
 import { executeCommand } from './execUtils';
+
+const CHANNEL = 'toolUtils';
 
 // Interface for tool configuration
 export interface ToolConfig {
@@ -404,7 +406,8 @@ export async function checkCoreDependencies(
   } catch (error) {
     // If checking fails, assume all tools are missing to prompt user to check
     // This is safer than silently ignoring the error
-    logger.error('Failed to check core dependencies:', error);
+    const message = error instanceof Error ? error.message : String(error);
+    logger.error(CHANNEL, `Failed to check core dependencies: ${message}`);
     return ['latexindent', 'perl', 'gs', 'gm/magick'];
   }
 }


### PR DESCRIPTION
- Change `import { logger }` to `import * as logger` for namespace imports
- Add CHANNEL constant and use as first argument to logger functions
- Replace z.coerce.int() with z.coerce.number().int() for Zod v4 compatibility
- Remove redundant LOG_PREFIX (channel already identifies source)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Logging standardization and safer error handling**
> 
> - Switches `import { logger }` to `import * as logger` and adds `CHANNEL` constants, passing the channel as the first arg to all logger calls across `ServerSideKeyService`, `TierService`, `openFileCommands`, `gitCommands`, `mainViewCommands`, `config/constants`, and `toolUtils`.
> - Normalizes error logging to stringify error messages (avoid logging raw objects), and improves informational messages (e.g., expired access, missing endpoints, clone failures).
> 
> **Schema compatibility**
> 
> - Updates `RoundKeySchema` to `z.coerce.number().int()` for Zod v4 compatibility in `progressView/persistence/schemaUtils`.
> 
> **Misc**
> 
> - Minor formatting/refactor only in `EditTool` (no functional changes).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f7521f0db0b5712d537d3741ce7874a60fd37aad. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->