### PR TITLE
Fix elapsed time display after refactoring

### DIFF
--- a/src/agent/core/flows/CommonCycleTypes.ts
+++ b/src/agent/core/flows/CommonCycleTypes.ts
@@ -33,7 +33,7 @@ export interface BaseCycleState {
   messages: ProviderMessage[];
   /** Whether the cycle should stop processing */
   shouldStop: boolean;
-  /** Time taken for response in seconds */
+  /** Time taken for response in milliseconds */
   responseTime?: number;
   /** Reason the model stopped generating */
   stopReason?: ProviderStopReason;
@@ -137,7 +137,7 @@ export interface BaseInvocationPrepResult {
 export interface BaseInvocationSuccessData {
   /** Raw response from the model */
   response: unknown;
-  /** Time taken for the response in seconds */
+  /** Time taken for the response in milliseconds */
   responseTime?: number;
 }
 

--- a/src/agent/core/flows/CommonCycleTypes.ts
+++ b/src/agent/core/flows/CommonCycleTypes.ts
@@ -34,7 +34,7 @@ export interface BaseCycleState {
   /** Whether the cycle should stop processing */
   shouldStop: boolean;
   /** Time taken for response in milliseconds */
-  responseTime?: number;
+  responseTimeMs?: number;
   /** Reason the model stopped generating */
   stopReason?: ProviderStopReason;
 }
@@ -86,7 +86,7 @@ export function resetCycleState<T extends BaseCycleState>(
 ): void {
   // Reset base cycle state fields
   state.shouldStop = false;
-  state.responseTime = undefined;
+  state.responseTimeMs = undefined;
   state.stopReason = undefined;
 
   // Reset additional optional fields to undefined
@@ -138,7 +138,7 @@ export interface BaseInvocationSuccessData {
   /** Raw response from the model */
   response: unknown;
   /** Time taken for the response in milliseconds */
-  responseTime?: number;
+  responseTimeMs?: number;
 }
 
 // ============================================================================

--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -464,7 +464,7 @@ class ResponseProcessNode<C> extends BaseNode<
 
       if (prepRes.responseTime !== undefined) {
         options.logger.debug(
-          `Response time: ${prepRes.responseTime.toFixed(2)}s`,
+          `Response time: ${(prepRes.responseTime / 1000).toFixed(2)}s`,
         );
       }
 

--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -278,7 +278,7 @@ class ResponseModelInvocationNode<C> extends RetryableInvocationNode<
 
     const start = Date.now();
     try {
-      const { response, responseTime } = await stage.run(async () => {
+      const { response, responseTimeMs } = await stage.run(async () => {
         const modelResponse = await options.modelHandler.createResponse({
           client: options.client,
           messages: prepRes.messages,
@@ -293,10 +293,10 @@ class ResponseModelInvocationNode<C> extends RetryableInvocationNode<
 
         const elapsedMs = Date.now() - start;
 
-        return { response: modelResponse, responseTime: elapsedMs };
+        return { response: modelResponse, responseTimeMs: elapsedMs };
       });
 
-      return { kind: 'success', response, responseTime };
+      return { kind: 'success', response, responseTimeMs };
     } finally {
       options.setAbortController(null);
     }
@@ -335,7 +335,7 @@ class ResponseModelInvocationNode<C> extends RetryableInvocationNode<
 
     // Apply success-specific side effects
     state.responseObject = successRes.response;
-    state.responseTime = successRes.responseTime;
+    state.responseTimeMs = successRes.responseTimeMs;
 
     if (state.debugContext && state.debugFileOptions) {
       await maybeSaveDebugObject({
@@ -357,7 +357,7 @@ class ResponseModelInvocationNode<C> extends RetryableInvocationNode<
 interface ProcessPrepResult {
   shouldStop: boolean;
   responseObject: unknown;
-  responseTime?: number;
+  responseTimeMs?: number;
   messages: ProviderMessage[];
   outputLocation: AgentFileLocation;
   outputExists: boolean;
@@ -378,8 +378,8 @@ interface ProcessResult {
   /** Normalized usage - single source of truth */
   normalizedUsage: NormalizedUsage;
   repetitionDetected: boolean;
-  /** Response time for store update in post() */
-  responseTime?: number;
+  /** Response time in ms for store update in post() */
+  responseTimeMs?: number;
   /** Updated last response for store update in post() */
   updatedLastResponse?: string;
   /** Updated accumulated output for store update in post() */
@@ -427,7 +427,7 @@ class ResponseProcessNode<C> extends BaseNode<
     return {
       shouldStop: state.shouldStop,
       responseObject: state.responseObject,
-      responseTime: state.responseTime,
+      responseTimeMs: state.responseTimeMs,
       messages: state.messages,
       outputLocation: state.outputLocation!,
       outputExists: state.outputExists,
@@ -462,9 +462,9 @@ class ResponseProcessNode<C> extends BaseNode<
         options.logger.debug(`Model response: ${newResponse.slice(0, 100)}`);
       }
 
-      if (prepRes.responseTime !== undefined) {
+      if (prepRes.responseTimeMs !== undefined) {
         options.logger.debug(
-          `Response time: ${(prepRes.responseTime / 1000).toFixed(2)}s`,
+          `Response time: ${(prepRes.responseTimeMs / 1000).toFixed(2)}s`,
         );
       }
 
@@ -499,7 +499,7 @@ class ResponseProcessNode<C> extends BaseNode<
       // Normalize usage once - this is the single source of truth
       const normalizedUsage = options.modelHandler.normalizeUsage(
         responseUsage,
-        prepRes.responseTime ?? 0,
+        prepRes.responseTimeMs ?? 0,
       );
 
       const repetitionResult = checkForMassiveRepetition(
@@ -556,7 +556,7 @@ class ResponseProcessNode<C> extends BaseNode<
           normalizedUsage,
           repetitionDetected: repetitionResult.massiveRepetitionDetected,
           // Pass data for post() to apply side effects
-          responseTime: prepRes.responseTime,
+          responseTimeMs: prepRes.responseTimeMs,
           updatedLastResponse,
           updatedAccumulatedOutput,
         },
@@ -585,8 +585,8 @@ class ResponseProcessNode<C> extends BaseNode<
 
     // Apply side effects that were computed in exec()
     // These updates are now in post() where they belong (PocketFlow compliance)
-    if (result.responseTime !== undefined) {
-      store.round.addResponseTime(result.responseTime);
+    if (result.responseTimeMs !== undefined) {
+      store.round.addResponseTime(result.responseTimeMs);
     }
 
     if (result.normalizedUsage) {

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -316,12 +316,12 @@ class ToolUseCallNode<C> extends RetryableInvocationNode<
         tools: options.agentSetting.tools as ToolDefinition[] | undefined,
       });
 
-      const responseTime = Date.now() - start;
+      const responseTimeMs = Date.now() - start;
 
       return {
         kind: 'success',
         response,
-        responseTime,
+        responseTimeMs,
         debugContext,
         debugFileOptions,
       };
@@ -363,7 +363,7 @@ class ToolUseCallNode<C> extends RetryableInvocationNode<
 
     // Apply success-specific side effects
     state.response = successRes.response;
-    state.responseTime = successRes.responseTime;
+    state.responseTimeMs = successRes.responseTimeMs;
 
     await maybeSaveDebugObject({
       context: successRes.debugContext,
@@ -383,7 +383,7 @@ class ToolUseCallNode<C> extends RetryableInvocationNode<
 interface ToolUseProcessPrepResult {
   shouldStop: boolean;
   response?: unknown;
-  responseTime?: number;
+  responseTimeMs?: number;
 }
 
 /**
@@ -403,7 +403,7 @@ type ToolUseProcessExecResult =
       serverToolContentBlocks?: ServerToolContentBlock[];
       lastAssistantContent?: unknown[];
       normalizedUsage?: NormalizedUsage;
-      responseTime?: number;
+      responseTimeMs?: number;
       // Message to create if endTurn
       createAssistantMessage?: boolean;
       lastResponseUpdate?: string;
@@ -432,7 +432,7 @@ class ToolUseProcessNode<C> extends BaseNode<
     return {
       shouldStop: state.shouldStop,
       response: state.response,
-      responseTime: state.responseTime,
+      responseTimeMs: state.responseTimeMs,
     };
   }
 
@@ -515,7 +515,7 @@ class ToolUseProcessNode<C> extends BaseNode<
     if (usage) {
       normalizedUsage = options.modelHandler.normalizeUsage(
         usage,
-        prepRes.responseTime ?? 0,
+        prepRes.responseTimeMs ?? 0,
       );
     }
 
@@ -530,7 +530,7 @@ class ToolUseProcessNode<C> extends BaseNode<
         serverToolContentBlocks: serverToolData.contentBlocks,
         lastAssistantContent,
         normalizedUsage,
-        responseTime: prepRes.responseTime,
+        responseTimeMs: prepRes.responseTimeMs,
         createAssistantMessage: Boolean(text),
         lastResponseUpdate: text ?? undefined,
       };
@@ -545,7 +545,7 @@ class ToolUseProcessNode<C> extends BaseNode<
       serverToolContentBlocks: serverToolData.contentBlocks,
       lastAssistantContent,
       normalizedUsage,
-      responseTime: prepRes.responseTime,
+      responseTimeMs: prepRes.responseTimeMs,
     };
   }
 
@@ -573,8 +573,8 @@ class ToolUseProcessNode<C> extends BaseNode<
       execRes.lastAssistantContent ?? [];
 
     // Apply side effects: response time
-    if (execRes.responseTime !== undefined) {
-      store.round.addResponseTime(execRes.responseTime);
+    if (execRes.responseTimeMs !== undefined) {
+      store.round.addResponseTime(execRes.responseTimeMs);
     }
 
     // Apply side effects: usage

--- a/src/agent/utils/UsageMonitor.ts
+++ b/src/agent/utils/UsageMonitor.ts
@@ -91,7 +91,7 @@ export class UsageMonitor {
 
       const payload: ExtendedTokenUsageStats = {
         ...baseStats,
-        elapsedTime: Number(stateGlobal.totalResponseTimeMs.toFixed(1)),
+        elapsedTime: Number((stateGlobal.totalResponseTimeMs / 1000).toFixed(1)),
         ...(cachingStats && {
           cacheReadInputTokens: totals.totalCacheReadInputTokens,
           ...(this.modelHandler.capabilities.supportsPromptCaching && {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Summary**
> 
> Standardizes response timing to milliseconds throughout agent cycles and fixes elapsed time presentation.
> 
> - Replace `responseTime` (seconds) with `responseTimeMs` (milliseconds) in `BaseCycleState` and `BaseInvocationSuccessData`
> - Update `ResponseCycleFlow` and `ToolUseCycleFlow` to compute, propagate, log, and store `responseTimeMs`; adjust `normalizeUsage` calls to use ms
> - Logging now converts ms → seconds only for display; store uses ms for `addResponseTime`
> - `UsageMonitor`: report `elapsedTime` in seconds by dividing `totalResponseTimeMs` by 1000
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e34c18e5cb9d3bb2f1a081d1acdb5ff187e0d9e2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->