### PR TITLE
Fix button not clearing single select fields

### DIFF
--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -1106,13 +1106,11 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
       instruction.dispatchEvent(new Event('input'));
     }
 
-    // Set single file selections
-    if (state.inputFile) safeSetElementValue(INPUT_FILE, state.inputFile);
-    if (state.referenceFile)
-      safeSetElementValue(REFERENCE_FILE, state.referenceFile);
-    if (state.auxiliaryFile)
-      safeSetElementValue(AUXILIARY_FILE, state.auxiliaryFile);
-    if (state.mediaFile) safeSetElementValue(MEDIA_FILE, state.mediaFile);
+    // Set single file selections (explicitly clear to '' if not in state)
+    safeSetElementValue(INPUT_FILE, state.inputFile || '');
+    safeSetElementValue(REFERENCE_FILE, state.referenceFile || '');
+    safeSetElementValue(AUXILIARY_FILE, state.auxiliaryFile || '');
+    safeSetElementValue(MEDIA_FILE, state.mediaFile || '');
 
     // Restore checkbox values
     const toolConfig = state.toolConfig || {};
@@ -1131,10 +1129,10 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
         (isToolUseSession ? toolUseAgentValue : workflowAgentValue),
       model: state.model,
       instruction: instructionContent,
-      inputFile: state.inputFile,
-      referenceFile: state.referenceFile,
-      auxiliaryFile: state.auxiliaryFile,
-      mediaFile: state.mediaFile,
+      inputFile: state.inputFile || '',
+      referenceFile: state.referenceFile || '',
+      auxiliaryFile: state.auxiliaryFile || '',
+      mediaFile: state.mediaFile || '',
       autoExtractFigure:
         state.autoExtractFigure ?? toolConfig.autoExtractFigure ?? false,
       autoExtractTikzFigure:

--- a/src/webview/modules/uiManagers/FileSelect.js
+++ b/src/webview/modules/uiManagers/FileSelect.js
@@ -46,38 +46,45 @@ export class FileSelect {
     const normalizedFiles = Array.isArray(files) ? files : [];
     const sortedFiles = [...normalizedFiles].sort((a, b) => a.localeCompare(b));
 
-    selectDiv.innerHTML = '';
-    this.addOption(selectDiv, '', 'None');
-    sortedFiles.forEach((f) => this.addOption(selectDiv, f, f));
+    // Block saves during option updates - vscode-single-select fires change events
+    // when innerHTML is cleared, which would trigger save() with temporary "None" state
+    mainViewState.blockSave();
+    try {
+      selectDiv.innerHTML = '';
+      this.addOption(selectDiv, '', 'None');
+      sortedFiles.forEach((f) => this.addOption(selectDiv, f, f));
 
-    // Restore selection if file still exists, prioritizing stored state
-    const { storedValue, currentValue } = options;
-    let restoredValue = null;
+      // Restore selection if file still exists, prioritizing stored state
+      const { storedValue, currentValue } = options;
+      let restoredValue = null;
 
-    if (storedValue && sortedFiles.includes(storedValue)) {
-      restoredValue = storedValue;
-    } else if (currentValue && sortedFiles.includes(currentValue)) {
-      restoredValue = currentValue;
-    }
+      if (storedValue && sortedFiles.includes(storedValue)) {
+        restoredValue = storedValue;
+      } else if (currentValue && sortedFiles.includes(currentValue)) {
+        restoredValue = currentValue;
+      }
 
-    if (restoredValue) {
-      safeSetElementValue(id, restoredValue);
-    }
+      if (restoredValue) {
+        safeSetElementValue(id, restoredValue);
+      }
 
-    // Only update state if we successfully restored a value.
-    // Do NOT clear state when file is not in list - the file may temporarily
-    // not appear during refresh cycles, and clearing would lose the user's selection.
-    //
-    // INTENTIONAL STATE/UI DIVERGENCE: If the selected file is not in the list,
-    // the UI shows "None" but state preserves the original selection. This allows:
-    // - Recovery when file temporarily disappears (e.g., during refresh)
-    // - Persistence across agent changes that don't affect file availability
-    //
-    // Consumers should be aware that state[id] may not match UI in edge cases.
-    // The execution flow reads from DOM, so a missing file will correctly result
-    // in no file being sent. The user can manually clear via the empty button.
-    if (restoredValue) {
-      mainViewState.update({ [id]: restoredValue });
+      // Only update state if we successfully restored a value.
+      // Do NOT clear state when file is not in list - the file may temporarily
+      // not appear during refresh cycles, and clearing would lose the user's selection.
+      //
+      // INTENTIONAL STATE/UI DIVERGENCE: If the selected file is not in the list,
+      // the UI shows "None" but state preserves the original selection. This allows:
+      // - Recovery when file temporarily disappears (e.g., during refresh)
+      // - Persistence across agent changes that don't affect file availability
+      //
+      // Consumers should be aware that state[id] may not match UI in edge cases.
+      // The execution flow reads from DOM, so a missing file will correctly result
+      // in no file being sent. The user can manually clear via the empty button.
+      if (restoredValue) {
+        mainViewState.update({ [id]: restoredValue });
+      }
+    } finally {
+      mainViewState.unblockSave();
     }
   }
 


### PR DESCRIPTION
1. New button now properly clears single selects (Input, Reference, Auxiliary, Media) by explicitly setting values to '' when state is empty, instead of only setting when state has truthy values.

2. Fixed race condition where single selects could mysteriously reset to "None" during file list refresh. Added blockSave()/unblockSave() around FileSelect.update() to prevent change events from triggering save() with temporary state while options are being rebuilt.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves reliability of single-file selects and prevents unintended resets.
> 
> - Explicitly clears `inputFile`, `referenceFile`, `auxiliaryFile`, and `mediaFile` to `''` in both DOM and persisted `savedState` during state restoration
> - Wraps `FileSelect.update` in `mainViewState.blockSave()/unblockSave()` to avoid change events while rebuilding options, fixing a race where selects briefly became "None" and were saved incorrectly
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6fcc52847df9befbd4ed51ea502c1589eb2a9cd6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->