### PR TITLE
Fix TypeScript object literal type error

### DIFF
--- a/src/agent/core/ResponseCycle.ts
+++ b/src/agent/core/ResponseCycle.ts
@@ -75,7 +75,7 @@ export async function runResponseCycle<C = unknown>(
       debugFileOptions: undefined,
       startTime: undefined,
       responseObject: undefined,
-      responseTime: undefined,
+      responseTimeMs: undefined,
       stopReason: undefined,
       processedResponse: undefined,
       roundFinalized: false,

--- a/src/agent/core/ToolUseCycle.ts
+++ b/src/agent/core/ToolUseCycle.ts
@@ -84,7 +84,7 @@ export async function runToolUseCycle<C = unknown>(
       messages: input.messages,
       shouldStop: false,
       response: undefined,
-      responseTime: undefined,
+      responseTimeMs: undefined,
       toolCalls: undefined,
       text: undefined,
       stopReason: undefined,

--- a/src/agent/implementations/flows/reflection/nodes/ResponseCycleCompositionNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/ResponseCycleCompositionNode.ts
@@ -188,7 +188,7 @@ export class ResponseCycleCompositionNode<C = unknown> extends Node<
         debugFileOptions: undefined,
         startTime: undefined,
         responseObject: undefined,
-        responseTime: undefined,
+        responseTimeMs: undefined,
         stopReason: undefined,
         processedResponse: undefined,
         roundFinalized: false,


### PR DESCRIPTION
Complete the rename from responseTime to responseTimeMs that was missed in three files during the earlier refactoring.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Completes the `responseTime` → `responseTimeMs` rename across cycle shared state to align with `ResponseCycleState`/`ToolUseCycleState` types.
> 
> - Update shared `state` field to `responseTimeMs` in `ResponseCycle.ts`, `ToolUseCycle.ts`, and `ResponseCycleCompositionNode.ts`
> - Ensures type consistency to avoid TS object literal errors
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4c1959855df545f8d4572354393438e8a285a4fa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->