### PR TITLE
fix: add batch file update to prevent race condition during refresh

### DIFF
--- a/src/common/webview/commands.js
+++ b/src/common/webview/commands.js
@@ -115,6 +115,7 @@ export const MAIN_VIEW_COMMANDS = {
   SET_CURRENT_FILE: 'setCurrentFile',
   SET_OPENED_FILES: 'setOpenedFiles',
   SET_BASE_FILE: 'setBaseFile',
+  SET_ALL_SINGLE_FILES: 'setAllSingleFiles',
   SET_SELECTED_COMMIT: 'setSelectedCommit',
   SET_MODEL_OPTIONS: 'setModelOptions',
   SET_AGENT_OPTIONS: 'setAgentOptions',

--- a/src/common/webview/commands.ts
+++ b/src/common/webview/commands.ts
@@ -116,6 +116,7 @@ export const MAIN_VIEW_COMMANDS = {
   SET_CURRENT_FILE: 'setCurrentFile',
   SET_OPENED_FILES: 'setOpenedFiles',
   SET_BASE_FILE: 'setBaseFile',
+  SET_ALL_SINGLE_FILES: 'setAllSingleFiles',
   SET_SELECTED_COMMIT: 'setSelectedCommit',
   SET_MODEL_OPTIONS: 'setModelOptions',
   SET_AGENT_OPTIONS: 'setAgentOptions',

--- a/src/webview/managers/FileManager.ts
+++ b/src/webview/managers/FileManager.ts
@@ -263,6 +263,11 @@ export class FileManager extends BaseWebviewManager {
   }
 
   async handleRefreshAllFiles(): Promise<void> {
+    const webviewView = this.getWebview();
+    if (!webviewView) {
+      return;
+    }
+
     const refreshedFiles = {
       input: await fileLister.list('input'),
       reference: await fileLister.list('reference'),
@@ -270,8 +275,15 @@ export class FileManager extends BaseWebviewManager {
       media: await fileLister.list('media'),
     };
 
-    Object.entries(refreshedFiles).forEach(([type, files]) => {
-      this.postFileUpdate(type.charAt(0).toUpperCase() + type.slice(1), files);
+    // Send all single file updates in a single batch message
+    // This allows the webview to wrap all updates in a single blockSave()
+    // preventing race conditions where change events fire between updates
+    webviewView.webview.postMessage({
+      command: MAIN_VIEW_COMMANDS.SET_ALL_SINGLE_FILES,
+      inputFiles: refreshedFiles.input,
+      referenceFiles: refreshedFiles.reference,
+      auxiliaryFiles: refreshedFiles.auxiliary,
+      mediaFiles: refreshedFiles.media,
     });
 
     await this.updateBaseFileSelect();

--- a/src/webview/modules/handlers/fileHandlers.js
+++ b/src/webview/modules/handlers/fileHandlers.js
@@ -165,6 +165,10 @@ export function createFileHandlers(ctx) {
    * Handle batch update of all single file selects.
    * Wraps all updates in a single blockSave() to prevent race conditions
    * where change events fire between individual file updates.
+   *
+   * Note: This results in nested blockSave() calls since fileSelect.update()
+   * also calls blockSave() internally. This is safe because blockSave uses
+   * a counter (_saveBlockCount) that supports nesting.
    */
   function handleSetAllSingleFiles(message) {
     const { inputFiles, referenceFiles, auxiliaryFiles, mediaFiles } = message;

--- a/src/webview/modules/handlers/fileHandlers.js
+++ b/src/webview/modules/handlers/fileHandlers.js
@@ -161,6 +161,42 @@ export function createFileHandlers(ctx) {
     // No postHandle needed - fileSelect.update handles state
   }
 
+  /**
+   * Handle batch update of all single file selects.
+   * Wraps all updates in a single blockSave() to prevent race conditions
+   * where change events fire between individual file updates.
+   */
+  function handleSetAllSingleFiles(message) {
+    const { inputFiles, referenceFiles, auxiliaryFiles, mediaFiles } = message;
+
+    // Block saves for the entire batch operation
+    // This prevents vscode-single-select change events from triggering save()
+    // with temporary "None" state while options are being rebuilt
+    mainViewState.blockSave();
+    try {
+      if (inputFiles !== undefined) {
+        const options = getRestorationOptions('inputFile');
+        fileSelect.update('inputFile', inputFiles, options);
+      }
+      if (referenceFiles !== undefined) {
+        const options = getRestorationOptions('referenceFile');
+        fileSelect.update('referenceFile', referenceFiles, options);
+      }
+      if (auxiliaryFiles !== undefined) {
+        const options = getRestorationOptions('auxiliaryFile');
+        fileSelect.update('auxiliaryFile', auxiliaryFiles, options);
+      }
+      if (mediaFiles !== undefined) {
+        const options = getRestorationOptions('mediaFile');
+        fileSelect.update('mediaFile', mediaFiles, options);
+      }
+    } finally {
+      mainViewState.unblockSave();
+    }
+    // No postHandle needed - fileSelect.update handles state within blockSave
+  }
+
+  handlers[MAIN_VIEW_COMMANDS.SET_ALL_SINGLE_FILES] = handleSetAllSingleFiles;
   handlers[MAIN_VIEW_COMMANDS.SET_DEFAULT_OUTPUT_FILES] =
     handleSetDefaultOutputFiles;
   handlers[MAIN_VIEW_COMMANDS.ADD_MEDIA_FILE] = handleAddMediaFile;

--- a/src/webview/types/messages.ts
+++ b/src/webview/types/messages.ts
@@ -187,6 +187,21 @@ export const UpdateFilesMessageSchema = BaseMessageSchema.extend(
 
 export type UpdateFilesMessage = z.infer<typeof UpdateFilesMessageSchema>;
 
+/**
+ * Batch update all single file selects message from extension.
+ * Used by REFRESH_ALL_FILES to prevent race conditions during file watcher updates.
+ */
+export const SetAllSingleFilesMessageSchema = BaseMessageSchema.extend({
+  inputFiles: z.array(z.string()).optional(),
+  referenceFiles: z.array(z.string()).optional(),
+  auxiliaryFiles: z.array(z.string()).optional(),
+  mediaFiles: z.array(z.string()).optional(),
+});
+
+export type SetAllSingleFilesMessage = z.infer<
+  typeof SetAllSingleFilesMessageSchema
+>;
+
 // --- Common Utilities ---
 
 /** Trims whitespace and requires non-empty result */


### PR DESCRIPTION
The file watcher was triggering REFRESH_ALL_FILES which sent 4 separate messages (setInputFile, setReferenceFile, etc.). Each FileSelect.update() had its own blockSave()/unblockSave(), but BETWEEN messages the counter dropped to 0, allowing async change events to trigger save() with corrupted "None" state.

Solution: Add SET_ALL_SINGLE_FILES command that sends all file lists in a single message. The webview handler wraps all updates in a single blockSave() scope, ensuring no saves can happen until ALL file updates are complete.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents save() races during file refresh by batching single-file select updates.
> 
> - Add `SET_ALL_SINGLE_FILES` command in `commands.(js|ts)` and Zod schema `SetAllSingleFilesMessageSchema` in `types/messages.ts`
> - Update `FileManager.handleRefreshAllFiles()` to post a single `SET_ALL_SINGLE_FILES` message containing `inputFiles`, `referenceFiles`, `auxiliaryFiles`, and `mediaFiles`
> - Implement handler in `webview/modules/handlers/fileHandlers.js` that wraps all fileSelect updates in `mainViewState.blockSave()/unblockSave()` to avoid intermediate change events
> - Keep `SET_BASE_FILE` update and getting-started banner logic after the batch update
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 285590b536f9af431a572911fd8c150520a2ecb6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->