### PR TITLE
Derive universal gate set appendix section

### DIFF
--- a/src/agent/modelHandlers/modelHandlerKimi.ts
+++ b/src/agent/modelHandlers/modelHandlerKimi.ts
@@ -36,13 +36,10 @@ export class ModelHandlerKimi extends ModelHandlerOpenAI {
       this.capabilities.supportsReasoning;
     return isThinkingModel ? new BaseReasoningStreamAggregator() : null;
   }
-  /**
-   * Get the base URL for the Moonshot API.
-   * The Moonshot API has a different base URL than OpenAI.
-   */
-  getBaseUrl(): string {
-    return 'https://api.moonshot.cn/v1';
-  }
+  // Note: getBaseUrl() is NOT overridden here.
+  // The base ModelHandler.getBaseUrl() correctly handles:
+  // - Server-side keys: routes through relay
+  // - Direct access: uses BASE_URLS[MOONSHOT] = 'https://api.moonshot.cn/v1'
 
   /**
    * Override createResponse to preprocess messages for Kimi models.

--- a/src/auth/serverKeys/ServerSideKeyService.ts
+++ b/src/auth/serverKeys/ServerSideKeyService.ts
@@ -31,6 +31,7 @@ const CHANNEL = 'ServerSideKeyService';
 const RELAY_PATH_SUFFIXES: Partial<Record<ServerSideProvider, string>> = {
   openai: '/v1',
   xai: '/v1',
+  deepseek: '/v1',
   moonshot: '/v1',
   dashscope: '/compatible-mode/v1',
 };


### PR DESCRIPTION
The ModelHandlerKimi override of getBaseUrl() was always returning the direct Moonshot URL, bypassing the relay routing logic. This caused 401 errors when using server-side keys because the JWT was sent directly to Moonshot instead of through the relay.

Removing the override allows the base ModelHandler.getBaseUrl() to correctly route through the relay when server-side keys are enabled.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Fix relay routing for Kimi models**
> 
> - Remove `getBaseUrl()` override in `modelHandlerKimi.ts` so base routing logic is used, ensuring server-side keys go through the relay instead of direct Moonshot URL
> 
> **Relay mapping update**
> 
> - Add `deepseek: '/v1'` to `RELAY_PATH_SUFFIXES` in `ServerSideKeyService.ts` to generate correct relay URLs for DeepSeek
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ba10d9c9c29f37c54e3f863922262bc39e43d582. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->