### PR TITLE
fix: proactively refresh auth token before expiration

### DIFF
--- a/src/agent/utils/UsageMonitor.ts
+++ b/src/agent/utils/UsageMonitor.ts
@@ -91,7 +91,9 @@ export class UsageMonitor {
 
       const payload: ExtendedTokenUsageStats = {
         ...baseStats,
-        elapsedTime: Number((stateGlobal.totalResponseTimeMs / 1000).toFixed(1)),
+        elapsedTime: Number(
+          (stateGlobal.totalResponseTimeMs / 1000).toFixed(1),
+        ),
         ...(cachingStats && {
           cacheReadInputTokens: totals.totalCacheReadInputTokens,
           ...(this.modelHandler.capabilities.supportsPromptCaching && {

--- a/src/auth/SupabaseAuthProvider.ts
+++ b/src/auth/SupabaseAuthProvider.ts
@@ -75,6 +75,7 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
       context,
     );
     SupabaseAuthProvider.instance = this;
+    SupabaseClient.setAuthProvider(this);
   }
 
   /** Get singleton instance for sign out operations. */

--- a/src/auth/SupabaseAuthProvider.ts
+++ b/src/auth/SupabaseAuthProvider.ts
@@ -8,6 +8,7 @@ import {
   OAUTH_PROVIDERS,
   getAuthCallbackUri,
   AUTH_CALLBACK_TIMEOUT_MS,
+  TOKEN_REFRESH_THRESHOLD_MS,
   type OAuthProvider,
 } from './config';
 import { getServerSideKeyService } from './serverKeys';
@@ -81,6 +82,48 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
   /** Get singleton instance for sign out operations. */
   static getInstance(): SupabaseAuthProvider | null {
     return this.instance;
+  }
+
+  /**
+   * Ensure the access token is fresh, refreshing proactively if near expiry.
+   * Called by SupabaseClient.getAccessToken() to avoid token expiration during
+   * long-running operations (e.g., GPT-5 background mode).
+   *
+   * @returns Fresh access token, or null if no session or refresh failed
+   */
+  async ensureFreshToken(): Promise<string | null> {
+    try {
+      const sessionData = await this.context.secrets.get(
+        SupabaseAuthProvider.SESSION_KEY,
+      );
+      if (!sessionData) {
+        return null;
+      }
+
+      const session: SupabaseSession = JSON.parse(sessionData);
+      const timeUntilExpiry = session.expiresAt - Date.now();
+
+      // Refresh proactively if token expires within threshold
+      if (timeUntilExpiry < TOKEN_REFRESH_THRESHOLD_MS) {
+        logger.info(
+          'SupabaseAuthProvider',
+          `Token expires in ${Math.round(timeUntilExpiry / 1000)}s, refreshing proactively`,
+        );
+        const refreshed = await this.refreshSession(session);
+        if (refreshed) {
+          return refreshed.accessToken;
+        }
+        // Fall through to return existing token if refresh fails
+      }
+
+      return session.accessToken;
+    } catch (error) {
+      logger.error(
+        'SupabaseAuthProvider',
+        `Error ensuring fresh token: ${toErrorMessage(error)}`,
+      );
+      return null;
+    }
   }
 
   /**

--- a/src/auth/SupabaseAuthProvider.ts
+++ b/src/auth/SupabaseAuthProvider.ts
@@ -9,13 +9,12 @@ import {
   getAuthCallbackUri,
   AUTH_CALLBACK_TIMEOUT_MS,
   TOKEN_REFRESH_THRESHOLD_MS,
+  DEFAULT_SESSION_EXPIRY_MS,
+  SUPABASE_SESSION_KEY,
   type OAuthProvider,
 } from './config';
 import { getServerSideKeyService } from './serverKeys';
 import type { SupabaseUriHandler } from './UriHandler';
-
-/** Default session expiry time in milliseconds (1 hour) */
-const DEFAULT_SESSION_EXPIRY_MS = 60 * 60 * 1000;
 
 /** Session data stored in VS Code SecretStorage. */
 interface SupabaseSession {
@@ -57,7 +56,6 @@ function isOAuthProvider(value: string | undefined): value is OAuthProvider {
  * Manages user sessions for remote agent access.
  */
 export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
-  private static readonly SESSION_KEY = 'texra.supabase.session';
   private static instance: SupabaseAuthProvider | null = null;
 
   private _onDidChangeSessions =
@@ -94,7 +92,7 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
   async ensureFreshToken(): Promise<string | null> {
     try {
       const sessionData = await this.context.secrets.get(
-        SupabaseAuthProvider.SESSION_KEY,
+        SUPABASE_SESSION_KEY,
       );
       if (!sessionData) {
         return null;
@@ -166,7 +164,7 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
     try {
       // Check if we already have a session (after claiming the lock)
       const existingSession = await this.context.secrets.get(
-        SupabaseAuthProvider.SESSION_KEY,
+        SUPABASE_SESSION_KEY,
       );
       if (existingSession) {
         return;
@@ -192,7 +190,7 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
       // Store session and notify - wrapped in try to ensure cleanup on partial failure
       try {
         await this.context.secrets.store(
-          SupabaseAuthProvider.SESSION_KEY,
+          SUPABASE_SESSION_KEY,
           JSON.stringify(result.session),
         );
         // Clear server-side key access cache so it refetches with new auth state
@@ -299,7 +297,7 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
     _options?: vscode.AuthenticationProviderSessionOptions,
   ): Promise<vscode.AuthenticationSession[]> {
     const sessionData = await this.context.secrets.get(
-      SupabaseAuthProvider.SESSION_KEY,
+      SUPABASE_SESSION_KEY,
     );
     if (!sessionData) {
       return [];
@@ -413,7 +411,7 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
             );
           }
           await this.context.secrets.store(
-            SupabaseAuthProvider.SESSION_KEY,
+            SUPABASE_SESSION_KEY,
             JSON.stringify(session),
           );
           // Clear server-side key access cache so it refetches with new auth state
@@ -447,7 +445,7 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
   async removeSession(sessionId: string): Promise<void> {
     try {
       await SupabaseClient.getClient().auth.signOut();
-      await this.context.secrets.delete(SupabaseAuthProvider.SESSION_KEY);
+      await this.context.secrets.delete(SUPABASE_SESSION_KEY);
       // Clear server-side key cache when session is removed (handles automatic invalidation)
       getServerSideKeyService().clearAllCaches();
       this._onDidChangeSessions.fire({
@@ -584,7 +582,7 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
 
       // Update stored session
       await this.context.secrets.store(
-        SupabaseAuthProvider.SESSION_KEY,
+        SUPABASE_SESSION_KEY,
         JSON.stringify(refreshed),
       );
 

--- a/src/auth/SupabaseAuthProvider.ts
+++ b/src/auth/SupabaseAuthProvider.ts
@@ -92,9 +92,7 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
    */
   async ensureFreshToken(): Promise<string | null> {
     try {
-      const sessionData = await this.context.secrets.get(
-        SUPABASE_SESSION_KEY,
-      );
+      const sessionData = await this.context.secrets.get(SUPABASE_SESSION_KEY);
       if (!sessionData) {
         return null;
       }
@@ -173,9 +171,8 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
 
     try {
       // Check if we already have a session (after claiming the lock)
-      const existingSession = await this.context.secrets.get(
-        SUPABASE_SESSION_KEY,
-      );
+      const existingSession =
+        await this.context.secrets.get(SUPABASE_SESSION_KEY);
       if (existingSession) {
         return;
       }
@@ -306,9 +303,7 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
     _scopes?: readonly string[],
     _options?: vscode.AuthenticationProviderSessionOptions,
   ): Promise<vscode.AuthenticationSession[]> {
-    const sessionData = await this.context.secrets.get(
-      SUPABASE_SESSION_KEY,
-    );
+    const sessionData = await this.context.secrets.get(SUPABASE_SESSION_KEY);
     if (!sessionData) {
       return [];
     }

--- a/src/auth/SupabaseAuthProvider.ts
+++ b/src/auth/SupabaseAuthProvider.ts
@@ -111,7 +111,16 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
         if (refreshed) {
           return refreshed.accessToken;
         }
-        // Fall through to return existing token if refresh fails
+        // If token is already expired and refresh failed, return null
+        // to trigger VS Code auth fallback instead of returning expired token
+        if (timeUntilExpiry <= 0) {
+          logger.warn(
+            'SupabaseAuthProvider',
+            'Token expired and refresh failed, returning null',
+          );
+          return null;
+        }
+        // Token still valid but refresh failed - return existing token
       }
 
       return session.accessToken;

--- a/src/auth/SupabaseClient.ts
+++ b/src/auth/SupabaseClient.ts
@@ -13,6 +13,11 @@ import {
   SUPABASE_SESSION_KEY,
 } from './config';
 
+/** Interface for auth provider to avoid circular imports. */
+interface AuthTokenProvider {
+  ensureFreshToken(): Promise<string | null>;
+}
+
 /**
  * Singleton Supabase client with authentication helpers.
  */
@@ -20,6 +25,15 @@ export class SupabaseClient {
   private static instance: Client | null = null;
   private static config: { url: string; publicKey: string } | null = null;
   private static context: vscode.ExtensionContext | null = null;
+  private static authProvider: AuthTokenProvider | null = null;
+
+  /**
+   * Register an auth provider for token refresh.
+   * Called by SupabaseAuthProvider on initialization.
+   */
+  static setAuthProvider(provider: AuthTokenProvider): void {
+    this.authProvider = provider;
+  }
 
   /**
    * Initialize the Supabase client with project credentials.
@@ -60,17 +74,13 @@ export class SupabaseClient {
 
   /**
    * Get the current user's access token from VS Code authentication.
-   * Automatically refreshes the token if it's about to expire via SupabaseAuthProvider.
+   * Automatically refreshes the token if it's about to expire via the registered auth provider.
    */
   static async getAccessToken(): Promise<string | null> {
     try {
-      // Import dynamically to avoid circular dependency
-      const { SupabaseAuthProvider } = await import('./SupabaseAuthProvider');
-      const authProvider = SupabaseAuthProvider.getInstance();
-
-      // Use auth provider's ensureFreshToken() which handles proactive refresh
-      if (authProvider) {
-        const token = await authProvider.ensureFreshToken();
+      // Use registered auth provider for proactive token refresh
+      if (this.authProvider) {
+        const token = await this.authProvider.ensureFreshToken();
         if (token) {
           return token;
         }
@@ -81,7 +91,7 @@ export class SupabaseClient {
       } else {
         logger.debug(
           'SupabaseClient',
-          'Auth provider not initialized, using VS Code auth fallback',
+          'Auth provider not registered, using VS Code auth fallback',
         );
       }
 
@@ -89,9 +99,7 @@ export class SupabaseClient {
       const session = await vscode.authentication.getSession(
         'texra-supabase',
         [],
-        {
-          silent: true,
-        },
+        { silent: true },
       );
       return session?.accessToken || null;
     } catch (error) {

--- a/src/auth/SupabaseClient.ts
+++ b/src/auth/SupabaseClient.ts
@@ -74,6 +74,15 @@ export class SupabaseClient {
         if (token) {
           return token;
         }
+        logger.debug(
+          'SupabaseClient',
+          'ensureFreshToken returned null, falling back to VS Code auth',
+        );
+      } else {
+        logger.debug(
+          'SupabaseClient',
+          'Auth provider not initialized, using VS Code auth fallback',
+        );
       }
 
       // Fallback to VS Code's authentication API

--- a/src/auth/SupabaseClient.ts
+++ b/src/auth/SupabaseClient.ts
@@ -12,6 +12,9 @@ import {
   UserAuthContextSchema,
 } from './config';
 
+/** Refresh token if it expires within this threshold (5 minutes) */
+const TOKEN_REFRESH_THRESHOLD_MS = 5 * 60 * 1000;
+
 /**
  * Singleton Supabase client with authentication helpers.
  */
@@ -20,6 +23,7 @@ export class SupabaseClient {
   private static config: { url: string; publicKey: string } | null = null;
   private static context: vscode.ExtensionContext | null = null;
   private static readonly SESSION_KEY = 'texra.supabase.session';
+  private static refreshPromise: Promise<string | null> | null = null;
 
   /**
    * Initialize the Supabase client with project credentials.
@@ -60,9 +64,38 @@ export class SupabaseClient {
 
   /**
    * Get the current user's access token from VS Code authentication.
+   * Automatically refreshes the token if it's about to expire.
    */
   static async getAccessToken(): Promise<string | null> {
     try {
+      // First check if we have a stored session that needs refresh
+      if (this.context) {
+        const sessionData = await this.context.secrets.get(this.SESSION_KEY);
+        if (sessionData) {
+          const stored = JSON.parse(sessionData) as {
+            accessToken: string;
+            refreshToken: string;
+            expiresAt: number;
+          };
+
+          // Check if token is expired or about to expire
+          const timeUntilExpiry = stored.expiresAt - Date.now();
+          if (timeUntilExpiry < TOKEN_REFRESH_THRESHOLD_MS) {
+            logger.info(
+              'SupabaseClient',
+              `Token expires in ${Math.round(timeUntilExpiry / 1000)}s, refreshing proactively`,
+            );
+            const refreshed = await this.refreshTokenIfNeeded(stored);
+            if (refreshed) {
+              return refreshed;
+            }
+            // If refresh failed, fall through to try the existing token
+            // (it might still be valid for a few more seconds)
+          }
+        }
+      }
+
+      // Use VS Code's authentication API as fallback
       const session = await vscode.authentication.getSession(
         'texra-supabase',
         [],
@@ -75,6 +108,79 @@ export class SupabaseClient {
       logger.error(
         'SupabaseClient',
         `Error getting access token: ${toErrorMessage(error)}`,
+      );
+      return null;
+    }
+  }
+
+  /**
+   * Refresh the access token if needed, with concurrency protection.
+   */
+  private static async refreshTokenIfNeeded(session: {
+    accessToken: string;
+    refreshToken: string;
+    expiresAt: number;
+  }): Promise<string | null> {
+    // Prevent concurrent refresh attempts
+    if (this.refreshPromise) {
+      return this.refreshPromise;
+    }
+
+    this.refreshPromise = this.doRefreshToken(session).finally(() => {
+      this.refreshPromise = null;
+    });
+
+    return this.refreshPromise;
+  }
+
+  /**
+   * Perform the actual token refresh.
+   */
+  private static async doRefreshToken(session: {
+    accessToken: string;
+    refreshToken: string;
+    expiresAt: number;
+  }): Promise<string | null> {
+    try {
+      const { data, error } = await this.getClient().auth.refreshSession({
+        refresh_token: session.refreshToken,
+      });
+
+      if (error || !data.session) {
+        logger.warn(
+          'SupabaseClient',
+          `Token refresh failed: ${error?.message || 'No session returned'}`,
+        );
+        return null;
+      }
+
+      // Update stored session with new tokens
+      const refreshed = {
+        id: data.session.user.id,
+        accessToken: data.session.access_token,
+        refreshToken: data.session.refresh_token,
+        account: {
+          id: data.session.user.id,
+          label: data.session.user.email || data.session.user.id,
+        },
+        expiresAt: data.session.expires_at
+          ? data.session.expires_at * 1000
+          : Date.now() + 60 * 60 * 1000, // Default 1 hour
+      };
+
+      if (this.context) {
+        await this.context.secrets.store(
+          this.SESSION_KEY,
+          JSON.stringify(refreshed),
+        );
+        logger.info('SupabaseClient', 'Token refreshed successfully');
+      }
+
+      return refreshed.accessToken;
+    } catch (error) {
+      logger.error(
+        'SupabaseClient',
+        `Error refreshing token: ${toErrorMessage(error)}`,
       );
       return null;
     }

--- a/src/auth/SupabaseClient.ts
+++ b/src/auth/SupabaseClient.ts
@@ -12,9 +12,6 @@ import {
   UserAuthContextSchema,
 } from './config';
 
-/** Refresh token if it expires within this threshold (5 minutes) */
-const TOKEN_REFRESH_THRESHOLD_MS = 5 * 60 * 1000;
-
 /**
  * Singleton Supabase client with authentication helpers.
  */
@@ -23,7 +20,6 @@ export class SupabaseClient {
   private static config: { url: string; publicKey: string } | null = null;
   private static context: vscode.ExtensionContext | null = null;
   private static readonly SESSION_KEY = 'texra.supabase.session';
-  private static refreshPromise: Promise<string | null> | null = null;
 
   /**
    * Initialize the Supabase client with project credentials.
@@ -64,38 +60,23 @@ export class SupabaseClient {
 
   /**
    * Get the current user's access token from VS Code authentication.
-   * Automatically refreshes the token if it's about to expire.
+   * Automatically refreshes the token if it's about to expire via SupabaseAuthProvider.
    */
   static async getAccessToken(): Promise<string | null> {
     try {
-      // First check if we have a stored session that needs refresh
-      if (this.context) {
-        const sessionData = await this.context.secrets.get(this.SESSION_KEY);
-        if (sessionData) {
-          const stored = JSON.parse(sessionData) as {
-            accessToken: string;
-            refreshToken: string;
-            expiresAt: number;
-          };
+      // Import dynamically to avoid circular dependency
+      const { SupabaseAuthProvider } = await import('./SupabaseAuthProvider');
+      const authProvider = SupabaseAuthProvider.getInstance();
 
-          // Check if token is expired or about to expire
-          const timeUntilExpiry = stored.expiresAt - Date.now();
-          if (timeUntilExpiry < TOKEN_REFRESH_THRESHOLD_MS) {
-            logger.info(
-              'SupabaseClient',
-              `Token expires in ${Math.round(timeUntilExpiry / 1000)}s, refreshing proactively`,
-            );
-            const refreshed = await this.refreshTokenIfNeeded(stored);
-            if (refreshed) {
-              return refreshed;
-            }
-            // If refresh failed, fall through to try the existing token
-            // (it might still be valid for a few more seconds)
-          }
+      // Use auth provider's ensureFreshToken() which handles proactive refresh
+      if (authProvider) {
+        const token = await authProvider.ensureFreshToken();
+        if (token) {
+          return token;
         }
       }
 
-      // Use VS Code's authentication API as fallback
+      // Fallback to VS Code's authentication API
       const session = await vscode.authentication.getSession(
         'texra-supabase',
         [],
@@ -108,79 +89,6 @@ export class SupabaseClient {
       logger.error(
         'SupabaseClient',
         `Error getting access token: ${toErrorMessage(error)}`,
-      );
-      return null;
-    }
-  }
-
-  /**
-   * Refresh the access token if needed, with concurrency protection.
-   */
-  private static async refreshTokenIfNeeded(session: {
-    accessToken: string;
-    refreshToken: string;
-    expiresAt: number;
-  }): Promise<string | null> {
-    // Prevent concurrent refresh attempts
-    if (this.refreshPromise) {
-      return this.refreshPromise;
-    }
-
-    this.refreshPromise = this.doRefreshToken(session).finally(() => {
-      this.refreshPromise = null;
-    });
-
-    return this.refreshPromise;
-  }
-
-  /**
-   * Perform the actual token refresh.
-   */
-  private static async doRefreshToken(session: {
-    accessToken: string;
-    refreshToken: string;
-    expiresAt: number;
-  }): Promise<string | null> {
-    try {
-      const { data, error } = await this.getClient().auth.refreshSession({
-        refresh_token: session.refreshToken,
-      });
-
-      if (error || !data.session) {
-        logger.warn(
-          'SupabaseClient',
-          `Token refresh failed: ${error?.message || 'No session returned'}`,
-        );
-        return null;
-      }
-
-      // Update stored session with new tokens
-      const refreshed = {
-        id: data.session.user.id,
-        accessToken: data.session.access_token,
-        refreshToken: data.session.refresh_token,
-        account: {
-          id: data.session.user.id,
-          label: data.session.user.email || data.session.user.id,
-        },
-        expiresAt: data.session.expires_at
-          ? data.session.expires_at * 1000
-          : Date.now() + 60 * 60 * 1000, // Default 1 hour
-      };
-
-      if (this.context) {
-        await this.context.secrets.store(
-          this.SESSION_KEY,
-          JSON.stringify(refreshed),
-        );
-        logger.info('SupabaseClient', 'Token refreshed successfully');
-      }
-
-      return refreshed.accessToken;
-    } catch (error) {
-      logger.error(
-        'SupabaseClient',
-        `Error refreshing token: ${toErrorMessage(error)}`,
       );
       return null;
     }

--- a/src/auth/SupabaseClient.ts
+++ b/src/auth/SupabaseClient.ts
@@ -113,11 +113,17 @@ export class SupabaseClient {
 
   /**
    * Get access and refresh tokens from secure storage.
+   * Ensures tokens are fresh before returning.
    */
   static async getSessionTokens(): Promise<{
     accessToken: string;
     refreshToken: string;
   } | null> {
+    // Ensure token is fresh before reading from storage
+    if (this.authProvider) {
+      await this.authProvider.ensureFreshToken();
+    }
+
     if (!this.context) {
       logger.warn('SupabaseClient', 'Extension context not set');
       const accessToken = await this.getAccessToken();

--- a/src/auth/SupabaseClient.ts
+++ b/src/auth/SupabaseClient.ts
@@ -10,6 +10,7 @@ import {
   type UserAuthContext,
   type UserTier,
   UserAuthContextSchema,
+  SUPABASE_SESSION_KEY,
 } from './config';
 
 /**
@@ -19,7 +20,6 @@ export class SupabaseClient {
   private static instance: Client | null = null;
   private static config: { url: string; publicKey: string } | null = null;
   private static context: vscode.ExtensionContext | null = null;
-  private static readonly SESSION_KEY = 'texra.supabase.session';
 
   /**
    * Initialize the Supabase client with project credentials.
@@ -111,7 +111,7 @@ export class SupabaseClient {
     }
 
     try {
-      const sessionData = await this.context.secrets.get(this.SESSION_KEY);
+      const sessionData = await this.context.secrets.get(SUPABASE_SESSION_KEY);
       if (!sessionData) {
         return null;
       }

--- a/src/auth/config.ts
+++ b/src/auth/config.ts
@@ -222,3 +222,6 @@ export const AUTH_CALLBACK_TIMEOUT_MS = 2 * 60 * 1000;
 
 /** Cache TTL for server-side key access and tier config (5 minutes). */
 export const SERVER_SIDE_CACHE_TTL_MS = 5 * 60 * 1000;
+
+/** Refresh token proactively if it expires within this threshold (5 minutes). */
+export const TOKEN_REFRESH_THRESHOLD_MS = 5 * 60 * 1000;

--- a/src/auth/config.ts
+++ b/src/auth/config.ts
@@ -223,5 +223,11 @@ export const AUTH_CALLBACK_TIMEOUT_MS = 2 * 60 * 1000;
 /** Cache TTL for server-side key access and tier config (5 minutes). */
 export const SERVER_SIDE_CACHE_TTL_MS = 5 * 60 * 1000;
 
-/** Refresh token proactively if it expires within this threshold (5 minutes). */
-export const TOKEN_REFRESH_THRESHOLD_MS = 5 * 60 * 1000;
+/** Refresh token proactively if it expires within this threshold (15 minutes). */
+export const TOKEN_REFRESH_THRESHOLD_MS = 15 * 60 * 1000;
+
+/** Default session expiry time (1 hour). */
+export const DEFAULT_SESSION_EXPIRY_MS = 60 * 60 * 1000;
+
+/** Storage key for Supabase session in VS Code SecretStorage. */
+export const SUPABASE_SESSION_KEY = 'texra.supabase.session';

--- a/src/auth/config.ts
+++ b/src/auth/config.ts
@@ -223,8 +223,8 @@ export const AUTH_CALLBACK_TIMEOUT_MS = 2 * 60 * 1000;
 /** Cache TTL for server-side key access and tier config (5 minutes). */
 export const SERVER_SIDE_CACHE_TTL_MS = 5 * 60 * 1000;
 
-/** Refresh token proactively if it expires within this threshold (15 minutes). */
-export const TOKEN_REFRESH_THRESHOLD_MS = 15 * 60 * 1000;
+/** Refresh token proactively if it expires within this threshold (30 minutes). */
+export const TOKEN_REFRESH_THRESHOLD_MS = 30 * 60 * 1000;
 
 /** Default session expiry time (1 hour). */
 export const DEFAULT_SESSION_EXPIRY_MS = 60 * 60 * 1000;


### PR DESCRIPTION
The relay was returning "Invalid or expired token" (HTTP 401) during
multi-round agent executions because:

1. Token lifecycle: Supabase JWTs have a default 1-hour expiry
2. Long-running requests: GPT-5.2 background mode takes 10-15 minutes
3. No proactive refresh: getAccessToken() just returned stored token

When Round 0 took 12+ minutes and Round 1 started, the token had expired.

This fix adds proactive token refresh in SupabaseClient.getAccessToken():
- Checks stored session's expiresAt timestamp
- If within 5 minutes of expiry, refresh proactively
- Includes concurrency protection to prevent duplicate refresh calls
- Falls back to existing token if refresh fails

This ensures long-running agent sessions don't fail mid-execution due
to token expiration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Auth token refresh and config centralization**
> 
> - Adds `ensureFreshToken()` in `SupabaseAuthProvider` to proactively refresh tokens when nearing expiry (`TOKEN_REFRESH_THRESHOLD_MS`), with concurrency protection via `refreshSession`
> - `SupabaseClient.getAccessToken()` now consults the auth provider for a fresh token, falling back to VS Code auth; `getSessionTokens()` ensures freshness before reading
> - Registers the auth provider with `SupabaseClient.setAuthProvider()` and replaces hardcoded session key with `SUPABASE_SESSION_KEY`
> - Moves session-related constants to `auth/config.ts` (`TOKEN_REFRESH_THRESHOLD_MS`, `DEFAULT_SESSION_EXPIRY_MS`, `SUPABASE_SESSION_KEY`)
> - Minor formatting change in `UsageMonitor.ts`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2a90ee29e7c631232d356310796dbeac4a2ac638. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->