### PR TITLE
Fix single select fields resetting to None

### DIFF
--- a/src/webview/modules/mainViewState.js
+++ b/src/webview/modules/mainViewState.js
@@ -115,6 +115,15 @@ export class MainViewState {
     }
   }
 
+  /**
+   * Check if save() calls are currently blocked.
+   * Useful for change handlers that should not post messages during programmatic updates.
+   * @returns {boolean} True if save() calls are blocked
+   */
+  isBlocked() {
+    return this._saveBlockCount > 0;
+  }
+
   get() {
     return this.stateManager.getState();
   }

--- a/src/webview/modules/uiManagers/FileInputManager.js
+++ b/src/webview/modules/uiManagers/FileInputManager.js
@@ -87,7 +87,13 @@ export class FileInputManager extends BaseUIManager {
       });
     });
 
+    // Guard change handlers during programmatic updates (e.g., file refresh).
+    // vscode-single-select fires change events when innerHTML is cleared,
+    // which would send empty values to the extension and corrupt state.
     this.addListener(INPUT_FILE, 'change', (e) => {
+      if (this.state.isBlocked()) {
+        return;
+      }
       const inputFile = e.target.value;
       this.vscode.postMessage({
         command: MAIN_VIEW_COMMANDS.INPUT_FILE_SELECTED,
@@ -96,6 +102,9 @@ export class FileInputManager extends BaseUIManager {
     });
 
     this.addListener(REFERENCE_FILE, 'change', (e) => {
+      if (this.state.isBlocked()) {
+        return;
+      }
       const referenceFile = e.target.value;
       this.vscode.postMessage({
         command: MAIN_VIEW_COMMANDS.REFERENCE_FILE_SELECTED,
@@ -104,6 +113,9 @@ export class FileInputManager extends BaseUIManager {
     });
 
     this.addListener(BASE_FILE, 'change', () => {
+      if (this.state.isBlocked()) {
+        return;
+      }
       const baseFile = safeGetElementValue(BASE_FILE);
       this.vscode.postMessage({
         command: MAIN_VIEW_COMMANDS.REQUEST_EDITED_FILE,

--- a/src/webview/modules/uiManagers/FileInputManager.js
+++ b/src/webview/modules/uiManagers/FileInputManager.js
@@ -112,11 +112,11 @@ export class FileInputManager extends BaseUIManager {
       });
     });
 
-    this.addListener(BASE_FILE, 'change', () => {
+    this.addListener(BASE_FILE, 'change', (e) => {
       if (this.state.isBlocked()) {
         return;
       }
-      const baseFile = safeGetElementValue(BASE_FILE);
+      const baseFile = e.target.value;
       this.vscode.postMessage({
         command: MAIN_VIEW_COMMANDS.REQUEST_EDITED_FILE,
         baseFile,


### PR DESCRIPTION
When file watcher triggers a refresh, vscode-single-select components fire change events as innerHTML is cleared. The change handlers in FileInputManager were posting INPUT_FILE_SELECTED/REFERENCE_FILE_SELECTED messages with empty values, which then updated mainViewState via update()
- bypassing the blockSave mechanism and corrupting the persisted state.

Changes:
- Add isBlocked() method to MainViewState to expose save block status
- Guard INPUT_FILE, REFERENCE_FILE, and BASE_FILE change handlers to skip posting messages during programmatic updates (when isBlocked)

This ensures that spurious change events during file list refresh don't corrupt the saved selection state.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents programmatic refreshes from corrupting saved file selections in the webview.
> 
> - Add `isBlocked()` to `MainViewState` to expose the active save-block state
> - Guard `INPUT_FILE`, `REFERENCE_FILE`, and `BASE_FILE` change handlers in `FileInputManager` to no-op when `isBlocked()` (avoids posting empty values from `vscode-single-select` during refresh)
> - Minor: use event target value in `BASE_FILE` change handler
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 06c89fef97740578ad4e641bec58ed4cb26b506c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->