### PR TITLE
fix: use tabGroups instead of textDocuments for opened files

### DIFF
--- a/src/webview/index.html
+++ b/src/webview/index.html
@@ -359,6 +359,13 @@
                   ><i class="codicon codicon-chevron-down"></i
                 ></span>
                 <vscode-toolbar-button
+                  id="addOpenedMediaFilesButton"
+                  class="file-action-button"
+                  icon="folder-opened"
+                  label="Add opened files as media"
+                  title="Add opened files as media"
+                ></vscode-toolbar-button>
+                <vscode-toolbar-button
                   id="emptyMediaFilesButton"
                   class="file-action-button"
                   icon="trash"

--- a/src/webview/managers/FileManager.ts
+++ b/src/webview/managers/FileManager.ts
@@ -12,6 +12,10 @@ import {
   showLoggedMessage,
   toErrorMessage,
 } from '@common/errors';
+import {
+  getIncludedExtensions,
+  ExtensionCategory,
+} from '@common/files/fileTypeUtils';
 import { MAIN_VIEW_COMMANDS } from '@common/webview';
 import { selectFiles } from '@frontend/ui/dialogs';
 import { fileLister } from '@frontend/files';
@@ -414,9 +418,24 @@ export class FileManager extends BaseWebviewManager {
       return;
     }
     const openedFiles = await this.getOpenedFiles();
+
+    // Filter files by allowed extensions for the target file type
+    // Extensions from config have leading dots (e.g., '.tex'), strip them for comparison
+    // Lowercase both sides for case-insensitive matching
+    const allowedExtensions = getIncludedExtensions(
+      fileType as ExtensionCategory,
+    ).map((ext) => ext.replace('.', '').toLowerCase());
+    const filteredFiles =
+      allowedExtensions.length > 0
+        ? openedFiles.filter((file) => {
+            const ext = path.extname(file).toLowerCase().replace('.', '');
+            return allowedExtensions.includes(ext);
+          })
+        : openedFiles;
+
     webviewView.webview.postMessage({
       command: MAIN_VIEW_COMMANDS.SET_OPENED_FILES,
-      files: openedFiles,
+      files: filteredFiles,
       fileType,
       shouldFilter: true,
     });
@@ -546,10 +565,28 @@ export class FileManager extends BaseWebviewManager {
       return [];
     }
 
-    const openedDocuments = workspace.textDocuments;
-    const relevantFiles = openedDocuments
-      .filter((doc) => doc.uri.scheme === 'file')
-      .map((doc) => workspace.asRelativePath(doc.uri.fsPath, false));
+    // Use tabGroups to get only files actually open in tabs
+    // (workspace.textDocuments includes closed files still in memory)
+    const openedFiles: string[] = [];
+    for (const tabGroup of vscode.window.tabGroups.all) {
+      for (const tab of tabGroup.tabs) {
+        // TabInputText: regular text files (.tex, .md, etc.)
+        // TabInputCustom: media files opened in custom editors (images, PDFs)
+        const input = tab.input;
+        if (
+          input instanceof vscode.TabInputText ||
+          input instanceof vscode.TabInputCustom
+        ) {
+          const uri = input.uri;
+          if (uri.scheme === 'file') {
+            openedFiles.push(workspace.asRelativePath(uri.fsPath, false));
+          }
+        }
+      }
+    }
+
+    // Remove duplicates (same file can be open in multiple tab groups)
+    const relevantFiles = [...new Set(openedFiles)];
 
     logger.debug(CHANNEL, `Found opened files: ${relevantFiles.join(', ')}`);
     return relevantFiles;

--- a/src/webview/modules/uiManagers/FileInputManager.js
+++ b/src/webview/modules/uiManagers/FileInputManager.js
@@ -161,7 +161,7 @@ export class FileInputManager extends BaseUIManager {
         prefix: 'addOpened',
         suffix: 'FilesButton',
         command: MAIN_VIEW_COMMANDS.ADD_OPENED_FILES,
-        types: baseTypes,
+        types: [...baseTypes, 'media'],
       },
       {
         prefix: 'current',


### PR DESCRIPTION
workspace.textDocuments includes documents that are still in memory
even after being closed from the UI. Switch to vscode.window.tabGroups
to get only files actually visible in editor tabs.

Also adds support for media files (images, PDFs) via TabInputCustom,
and adds the "Add opened files as media" button to the UI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Scope**: Improve accuracy of opened-file detection and extend media handling in the webview.
> 
> - Switch `FileManager.getOpenedFiles` to `vscode.window.tabGroups` (supports `TabInputText` and `TabInputCustom`), deduplicate results, and exclude non-file URIs
> - Filter files in `handleAddOpenedFiles` by allowed extensions for the target `fileType` using `getIncludedExtensions`, and send filtered list via `SET_OPENED_FILES`
> - Add UI control in `index.html` and wiring in `FileInputManager.js` to support `ADD_OPENED_FILES` for `media` ("Add opened files as media" button)
> - Maintain existing multi-file and current-file behaviors; internal messaging unchanged aside from filtered results and `shouldFilter: true`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3bb6f95b582722403f7b50f15a5d501769d56f3b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->