### PR TITLE
Implement Kimi model support

### DIFF
--- a/src/agent/modelHandlers/modelHandlerKimi.ts
+++ b/src/agent/modelHandlers/modelHandlerKimi.ts
@@ -46,7 +46,7 @@ export class ModelHandlerKimi extends ModelHandlerOpenAI {
    *
    * Note: This handler does NOT use the getMessageNormalizationOptions() hook
    * because Kimi thinking models require additional custom logic:
-   * - Conditional `thinking: true` parameter
+   * - Reasoning auto-enabled via model name (no explicit parameter needed)
    * - Custom streaming aggregation for reasoning_content
    * - Different request structure for thinking vs regular models
    *

--- a/src/agent/modelHandlers/modelHandlerKimi.ts
+++ b/src/agent/modelHandlers/modelHandlerKimi.ts
@@ -73,18 +73,20 @@ export class ModelHandlerKimi extends ModelHandlerOpenAI {
 
     if (isThinkingModel) {
       this.logger.debug(
-        'Using Kimi thinking model - adding thinking parameter',
+        'Using Kimi thinking model - reasoning enabled via model name',
       );
 
       // Check if streaming is enabled
       const useStreaming = this.getStreamingConfig();
 
+      // Kimi K2 Thinking models automatically enable reasoning based on model name.
+      // No `thinking` parameter is needed - the API returns reasoning_content automatically.
+      // Recommended: temperature=1.0, max_tokens >= 16000, stream=true
       const kwargs: any = {
         model: this.config.fullName,
         messages: processedMessages,
         temperature: temperature,
         max_tokens: this.config.maxOutputTokens,
-        thinking: true,
       };
 
       if (endTag) {


### PR DESCRIPTION
Kimi K2 Thinking models automatically enable reasoning based on the model name (kimi-k2-thinking). The API was rejecting the boolean `thinking: true` parameter with error: "the thinking field in the request (expected type object) is illegal, and bool is not acceptable".

Per official Moonshot documentation, no thinking parameter is needed. The reasoning_content field is returned automatically in responses.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns Kimi handler with Moonshot API expectations for K2 Thinking models.
> 
> - Removes `thinking: true` from request `kwargs`; reasoning is auto-enabled by model name and `reasoning_content` is returned by the API
> - Updates debug log to reflect auto reasoning; adds guidance comments (recommended params)
> - Leaves streaming aggregation intact to collect `reasoning_content`; preserves `tools`, `stop`, and streaming options behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 600e8eabea3c441816cc69eca2d554878fbdcf24. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->