### PR TITLE
Add missing opened state for single select

### DIFF
--- a/src/commands/files/fileSelectionCommands.ts
+++ b/src/commands/files/fileSelectionCommands.ts
@@ -194,9 +194,22 @@ async function selectEditedFile(): Promise<string | null> {
 }
 
 async function getCurrentFile(): Promise<string | null> {
+  // Try activeTextEditor first (for text files)
   const currentFile = vscode.window.activeTextEditor?.document;
   if (currentFile && currentFile.uri.scheme === 'file') {
     return WorkspaceFS.relativePath(currentFile.uri.fsPath);
+  }
+  // Fallback to active tab (for media files like images, PDFs)
+  const activeTab = vscode.window.tabGroups.activeTabGroup.activeTab;
+  if (activeTab?.input) {
+    const input = activeTab.input;
+    if (
+      (input instanceof vscode.TabInputText ||
+        input instanceof vscode.TabInputCustom) &&
+      input.uri.scheme === 'file'
+    ) {
+      return WorkspaceFS.relativePath(input.uri.fsPath);
+    }
   }
   return null;
 }

--- a/src/webview/index.html
+++ b/src/webview/index.html
@@ -347,6 +347,12 @@
               </div>
               <vscode-toolbar-container class="file-select-actions">
                 <vscode-toolbar-button
+                  id="currentMediaFileButton"
+                  icon="file-code"
+                  label="Set current file as media"
+                  title="Set current file as media"
+                ></vscode-toolbar-button>
+                <vscode-toolbar-button
                   id="emptyMediaFileButton"
                   icon="close"
                   label="Clear media file"

--- a/src/webview/modules/uiManagers/FileInputManager.js
+++ b/src/webview/modules/uiManagers/FileInputManager.js
@@ -167,7 +167,7 @@ export class FileInputManager extends BaseUIManager {
         prefix: 'current',
         suffix: 'FileButton',
         command: MAIN_VIEW_COMMANDS.GET_CURRENT_FILE,
-        types: [...baseTypes, 'base', 'edited'],
+        types: [...baseTypes, 'media', 'base', 'edited'],
       },
     ];
 


### PR DESCRIPTION
Add currentMediaFileButton matching the pattern used by Input, Reference, and Auxiliary sections for quick single file selection.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds single-select support for the current media file and expands current-file detection beyond text editors.
> 
> - New `currentMediaFileButton` in `index.html` for “Set current file as media”
> - `FileInputManager`: includes `media` in `GET_CURRENT_FILE` button wiring to enable the new button
> - `fileSelectionCommands.getCurrentFile`: falls back to the active tab (`TabInputText`/`TabInputCustom`) to resolve file paths for non-text assets (e.g., images, PDFs)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ccf128959e7f74adc6406ceff414c4ed6ccab9d2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->