### PR TITLE
Set up agent configuration for code review

### DIFF
--- a/src/agent/modelHandlers/modelHandlerKimi.ts
+++ b/src/agent/modelHandlers/modelHandlerKimi.ts
@@ -1,10 +1,9 @@
-// (none needed)
-
 // Third-party imports
 import OpenAI from 'openai';
 
 // Local imports - agent
 import type { NormalizedUsage } from '@agent/types/NormalizedUsage';
+import { isMissingFinishReasonError } from '@common/errors/sdkErrorUtils';
 import { BaseReasoningStreamAggregator } from './BaseReasoningStreamAggregator';
 import { ModelHandlerOpenAI } from './modelHandlerOpenAI';
 import { executeRequest } from './utils/requestExecutor';
@@ -16,10 +15,6 @@ import type {
   ChatCompletionMessageParam,
 } from 'openai/resources/chat/completions';
 import type { ContentDeltaEvent } from 'openai/lib/ChatCompletionStream';
-
-// Internal imports
-
-// Local file imports
 
 /**
  * Handler for Moonshot Kimi models using OpenAI-compatible API.
@@ -154,10 +149,25 @@ export class ModelHandlerKimi extends ModelHandlerOpenAI {
         stream.on('chunk', onChunk);
 
         try {
-          const sdkFinalResponse = await stream.finalChatCompletion();
+          let finalResponse: ChatCompletion;
 
-          // Use aggregator to build the final response with all content
-          const finalResponse = streamingAggregator.finalize(sdkFinalResponse);
+          try {
+            const sdkFinalResponse = await stream.finalChatCompletion();
+            // Use aggregator to build the final response with all content
+            finalResponse = streamingAggregator.finalize(sdkFinalResponse);
+          } catch (err) {
+            // Handle missing finish_reason error from OpenAI SDK
+            // @see https://github.com/openai/openai-node/issues/499
+            if (isMissingFinishReasonError(err)) {
+              this.logger.warn(
+                'Stream missing finish_reason - using aggregator fallback',
+              );
+              // Use aggregator without SDK response - it defaults finish_reason to 'stop'
+              finalResponse = streamingAggregator.finalize();
+            } else {
+              throw err;
+            }
+          }
 
           const finalReasoning = this.processThinkingBlock(finalResponse);
           if (finalReasoning === null) {

--- a/src/agent/modelHandlers/modelHandlerKimi.ts
+++ b/src/agent/modelHandlers/modelHandlerKimi.ts
@@ -3,7 +3,6 @@ import OpenAI from 'openai';
 
 // Local imports - agent
 import type { NormalizedUsage } from '@agent/types/NormalizedUsage';
-import { isMissingFinishReasonError } from '@common/errors/sdkErrorUtils';
 import { BaseReasoningStreamAggregator } from './BaseReasoningStreamAggregator';
 import { ModelHandlerOpenAI } from './modelHandlerOpenAI';
 import { executeRequest } from './utils/requestExecutor';
@@ -149,25 +148,10 @@ export class ModelHandlerKimi extends ModelHandlerOpenAI {
         stream.on('chunk', onChunk);
 
         try {
-          let finalResponse: ChatCompletion;
-
-          try {
-            const sdkFinalResponse = await stream.finalChatCompletion();
-            // Use aggregator to build the final response with all content
-            finalResponse = streamingAggregator.finalize(sdkFinalResponse);
-          } catch (err) {
-            // Handle missing finish_reason error from OpenAI SDK
-            // @see https://github.com/openai/openai-node/issues/499
-            if (isMissingFinishReasonError(err)) {
-              this.logger.warn(
-                'Stream missing finish_reason - using aggregator fallback',
-              );
-              // Use aggregator without SDK response - it defaults finish_reason to 'stop'
-              finalResponse = streamingAggregator.finalize();
-            } else {
-              throw err;
-            }
-          }
+          const finalResponse = await this.awaitFinalResponse(
+            stream,
+            streamingAggregator,
+          );
 
           const finalReasoning = this.processThinkingBlock(finalResponse);
           if (finalReasoning === null) {

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -34,6 +34,7 @@ import { calculateTokenPrice } from '@agent/utils/priceUtils';
 import {
   getSdkErrorMessage,
   isContextWindowError,
+  isMissingFinishReasonError,
 } from '@common/errors/sdkErrorUtils';
 
 // Type imports
@@ -345,10 +346,28 @@ export class ModelHandlerOpenAI<
         };
 
         try {
-          const sdkFinalResponse = await stream.finalChatCompletion();
-          let finalResponse = streamingAggregator
-            ? streamingAggregator.finalize(sdkFinalResponse)
-            : sdkFinalResponse;
+          let finalResponse: ChatCompletion;
+
+          try {
+            const sdkFinalResponse = await stream.finalChatCompletion();
+            finalResponse = streamingAggregator
+              ? streamingAggregator.finalize(sdkFinalResponse)
+              : sdkFinalResponse;
+          } catch (err) {
+            // Handle missing finish_reason error from OpenAI SDK
+            // This can occur with DeepSeek reasoning models and other providers
+            // that don't properly send finish_reason in streaming responses
+            // @see https://github.com/openai/openai-node/issues/499
+            if (streamingAggregator && isMissingFinishReasonError(err)) {
+              this.logger.warn(
+                'Stream missing finish_reason - using aggregator fallback',
+              );
+              // Use aggregator without SDK response - it defaults finish_reason to 'stop'
+              finalResponse = streamingAggregator.finalize();
+            } else {
+              throw err;
+            }
+          }
 
           // Ensure usage is captured - use SDK's totalUsage() as fallback
           if (!finalResponse.usage) {

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -346,28 +346,10 @@ export class ModelHandlerOpenAI<
         };
 
         try {
-          let finalResponse: ChatCompletion;
-
-          try {
-            const sdkFinalResponse = await stream.finalChatCompletion();
-            finalResponse = streamingAggregator
-              ? streamingAggregator.finalize(sdkFinalResponse)
-              : sdkFinalResponse;
-          } catch (err) {
-            // Handle missing finish_reason error from OpenAI SDK
-            // This can occur with DeepSeek reasoning models and other providers
-            // that don't properly send finish_reason in streaming responses
-            // @see https://github.com/openai/openai-node/issues/499
-            if (streamingAggregator && isMissingFinishReasonError(err)) {
-              this.logger.warn(
-                'Stream missing finish_reason - using aggregator fallback',
-              );
-              // Use aggregator without SDK response - it defaults finish_reason to 'stop'
-              finalResponse = streamingAggregator.finalize();
-            } else {
-              throw err;
-            }
-          }
+          let finalResponse = await this.awaitFinalResponse(
+            stream,
+            streamingAggregator,
+          );
 
           // Ensure usage is captured - use SDK's totalUsage() as fallback
           if (!finalResponse.usage) {
@@ -408,6 +390,42 @@ export class ModelHandlerOpenAI<
           { signal },
         ),
     );
+  }
+
+  /**
+   * Awaits the final chat completion from a stream, with fallback handling
+   * for providers that don't send finish_reason (e.g., DeepSeek, Kimi).
+   *
+   * When the SDK throws "missing finish_reason", falls back to using the
+   * streaming aggregator to build a valid response from accumulated chunks.
+   *
+   * @param stream - The OpenAI chat completion stream
+   * @param aggregator - Optional streaming aggregator for fallback
+   * @returns The final ChatCompletion response
+   */
+  protected async awaitFinalResponse(
+    stream: ReturnType<typeof OpenAI.prototype.chat.completions.stream>,
+    aggregator: StreamingAggregator | null,
+  ): Promise<ChatCompletion> {
+    try {
+      const sdkFinalResponse = await stream.finalChatCompletion();
+      return aggregator
+        ? aggregator.finalize(sdkFinalResponse)
+        : sdkFinalResponse;
+    } catch (err) {
+      // Handle missing finish_reason error from OpenAI SDK
+      // This can occur with DeepSeek reasoning models and other providers
+      // that don't properly send finish_reason in streaming responses
+      // @see https://github.com/openai/openai-node/issues/499
+      if (aggregator && isMissingFinishReasonError(err)) {
+        this.logger.warn(
+          'Stream missing finish_reason - using aggregator fallback',
+        );
+        // Use aggregator without SDK response - it defaults finish_reason to 'stop'
+        return aggregator.finalize();
+      }
+      throw err;
+    }
   }
 
   /**

--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -532,6 +532,26 @@ export function isContextWindowError(err: unknown): boolean {
 }
 
 /**
+ * Checks if an error is the OpenAI SDK "missing finish_reason" error.
+ * This error occurs when the streaming response doesn't include a finish_reason
+ * in the final chunk, which can happen with:
+ * - DeepSeek reasoning models
+ * - Other OpenAI-compatible APIs that don't properly send finish_reason
+ *
+ * When detected, the streaming aggregator should be used to build a fallback
+ * response with a default finish_reason of 'stop'.
+ *
+ * @see https://github.com/openai/openai-node/issues/499
+ * @see https://github.com/openai/openai-node/issues/1206
+ */
+export function isMissingFinishReasonError(err: unknown): boolean {
+  if (!(err instanceof Error)) {
+    return false;
+  }
+  return err.message.includes('missing finish_reason');
+}
+
+/**
  * Context for building error log data.
  */
 export interface ErrorLogContext {


### PR DESCRIPTION
Add fallback handling for the OpenAI SDK "missing finish_reason" error that can occur with DeepSeek reasoning models and other OpenAI-compatible APIs that don't properly send finish_reason in streaming responses.

When this error occurs, the streaming aggregator's finalize() method is used without the SDK response - it defaults finish_reason to 'stop'.

Affected model handlers: OpenAI, Kimi

References:
- https://github.com/openai/openai-node/issues/499
- https://github.com/openai/openai-node/issues/1206

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Robust streaming fallback for OpenAI-compatible APIs**
> 
> - Introduces `awaitFinalResponse()` in `modelHandlerOpenAI` to catch "missing finish_reason" errors and finalize via the streaming aggregator
> - Wires the fallback into both OpenAI and Kimi streaming paths (Kimi reasoning models use `BaseReasoningStreamAggregator`)
> - Adds `isMissingFinishReasonError()` in `sdkErrorUtils` to detect the SDK error and log a warning before falling back
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4ebce91ae7e8ba43c900489b5e84cf3e51ba064d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->