### PR TITLE
Fix dropdown jumping back to default value

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "node-pandoc": "^0.3.0",
         "openai": "^6.15.0",
         "pdf2pic": "^3.2.0",
+        "perfect-debounce": "^2.0.0",
         "shell-quote": "^1.8.3",
         "sortablejs": "^1.15.6",
         "tar": "^7.5.2",
@@ -7145,6 +7146,12 @@
         "type": "paypal",
         "url": "https://www.paypal.me/yakovmeister"
       }
+    },
+    "node_modules/perfect-debounce": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-2.0.0.tgz",
+      "integrity": "sha512-fkEH/OBiKrqqI/yIgjR92lMfs2K8105zt/VT6+7eTjNwisrsh47CeIED9z58zI7DfKdH3uHAn25ziRZn3kgAow==",
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -1672,6 +1672,7 @@
     "node-pandoc": "^0.3.0",
     "openai": "^6.15.0",
     "pdf2pic": "^3.2.0",
+    "perfect-debounce": "^2.0.0",
     "shell-quote": "^1.8.3",
     "sortablejs": "^1.15.6",
     "tar": "^7.5.2",

--- a/src/MainViewProvider.ts
+++ b/src/MainViewProvider.ts
@@ -9,7 +9,12 @@ import { BaseWebviewProvider } from '@common/webview';
 import { getSharedLocalResourceRoots } from '@common/webview';
 import { MAIN_VIEW_COMMANDS } from '@common/webview';
 import { agentDirectories } from '@frontend/agents';
-import { watchConfig, getConfig } from '@utils/config';
+import {
+  watchConfig,
+  getConfig,
+  DEBOUNCE_OPTIONS_MS,
+  DEBOUNCE_STATE_SAVE_MS,
+} from '@utils/config';
 import { debounce } from '@utils/core';
 import { consumePendingState } from '@common/state';
 import { checkCoreDependencies } from '@utils/system/toolUtils';
@@ -36,11 +41,11 @@ export class MainViewProvider
   // Debounced refresh methods using perfect-debounce
   private debouncedRefreshAgentOptions = debounce(
     () => this.refreshAgentOptions(),
-    300,
+    DEBOUNCE_OPTIONS_MS,
   );
   private debouncedRefreshModelOptions = debounce(
     () => this.refreshModelOptions(),
-    300,
+    DEBOUNCE_OPTIONS_MS,
   );
 
   constructor(protected readonly context: vscode.ExtensionContext) {
@@ -204,7 +209,7 @@ export class MainViewProvider
     const debouncedAgentFileRefresh = debounce(async () => {
       await updateAgentDirs();
       await this.refreshAgentOptions();
-    }, 500);
+    }, DEBOUNCE_STATE_SAVE_MS);
 
     // Filter and debounce agent file changes
     const onAgentFileChange = (uri: vscode.Uri) => {

--- a/src/MainViewProvider.ts
+++ b/src/MainViewProvider.ts
@@ -31,6 +31,9 @@ export class MainViewProvider
   // Static flag to track if commands have been registered
   private static commandsRegistered = false;
 
+  // Debounce timeout for config change refreshes
+  private configRefreshTimeout: ReturnType<typeof setTimeout> | undefined;
+
   constructor(protected readonly context: vscode.ExtensionContext) {
     super(context);
     this.messageHandler = new MainViewMessageHandler(context);
@@ -65,12 +68,31 @@ export class MainViewProvider
   }
 
   private setupConfigurationWatcher() {
-    // Watch for configuration changes that affect agent/model options
+    // Watch for agent/model configuration changes with debounce
+    // These trigger a full options refresh which is more expensive
     watchConfig(
       this.context,
-      ['texra.agents', 'texra.toolUseAgents', 'texra.models', 'texra.files'],
-      () => this.refreshOptionsAndView(),
+      ['texra.agents', 'texra.toolUseAgents', 'texra.models'],
+      () => this.debouncedRefreshOptionsAndView(),
     );
+
+    // Watch for file configuration changes separately
+    // These only need to refresh the file list, not agent/model options
+    watchConfig(this.context, ['texra.files'], () => this.refreshFiles());
+  }
+
+  /**
+   * Debounced version of refreshOptionsAndView to prevent rapid re-sends
+   * when multiple config changes happen in quick succession.
+   */
+  private debouncedRefreshOptionsAndView() {
+    if (this.configRefreshTimeout) {
+      clearTimeout(this.configRefreshTimeout);
+    }
+    this.configRefreshTimeout = setTimeout(() => {
+      void this.refreshOptionsAndView();
+      this.configRefreshTimeout = undefined;
+    }, 300); // 300ms debounce for config changes
   }
 
   private setupAuthListener() {

--- a/src/MainViewProvider.ts
+++ b/src/MainViewProvider.ts
@@ -83,10 +83,8 @@ export class MainViewProvider
 
   private setupConfigurationWatcher() {
     // Watch for agent configuration changes - only refresh agent options
-    watchConfig(
-      this.context,
-      ['texra.agents', 'texra.toolUseAgents'],
-      () => this.debouncedRefreshAgentOptions(),
+    watchConfig(this.context, ['texra.agents', 'texra.toolUseAgents'], () =>
+      this.debouncedRefreshAgentOptions(),
     );
 
     // Watch for model configuration changes - only refresh model options

--- a/src/MainViewProvider.ts
+++ b/src/MainViewProvider.ts
@@ -2,7 +2,7 @@
 import * as vscode from 'vscode';
 
 // Local imports - agent
-import { refresh } from '@agent/index';
+import { refresh, computeAgentOptions } from '@agent/index';
 
 // Local imports - common
 import { BaseWebviewProvider } from '@common/webview';
@@ -13,6 +13,7 @@ import { watchConfig, getConfig } from '@utils/config';
 import { consumePendingState } from '@common/state';
 import { checkCoreDependencies } from '@utils/system/toolUtils';
 import { getServerSideKeyService } from '@/auth/serverKeys';
+import { computeModelOptions } from '@model/computeModelOptions';
 
 // Local file imports
 import { MainViewMessageHandler } from './webview/MainViewMessageHandler';
@@ -31,8 +32,9 @@ export class MainViewProvider
   // Static flag to track if commands have been registered
   private static commandsRegistered = false;
 
-  // Debounce timeout for config change refreshes
-  private configRefreshTimeout: ReturnType<typeof setTimeout> | undefined;
+  // Debounce timeouts for config change refreshes (separate for agents vs models)
+  private agentRefreshTimeout: ReturnType<typeof setTimeout> | undefined;
+  private modelRefreshTimeout: ReturnType<typeof setTimeout> | undefined;
 
   constructor(protected readonly context: vscode.ExtensionContext) {
     super(context);
@@ -68,31 +70,46 @@ export class MainViewProvider
   }
 
   private setupConfigurationWatcher() {
-    // Watch for agent/model configuration changes with debounce
-    // These trigger a full options refresh which is more expensive
+    // Watch for agent configuration changes - only refresh agent options
     watchConfig(
       this.context,
-      ['texra.agents', 'texra.toolUseAgents', 'texra.models'],
-      () => this.debouncedRefreshOptionsAndView(),
+      ['texra.agents', 'texra.toolUseAgents'],
+      () => this.debouncedRefreshAgentOptions(),
     );
 
-    // Watch for file configuration changes separately
-    // These only need to refresh the file list, not agent/model options
+    // Watch for model configuration changes - only refresh model options
+    watchConfig(this.context, ['texra.models'], () =>
+      this.debouncedRefreshModelOptions(),
+    );
+
+    // Watch for file configuration changes - only refresh file list
     watchConfig(this.context, ['texra.files'], () => this.refreshFiles());
   }
 
   /**
-   * Debounced version of refreshOptionsAndView to prevent rapid re-sends
-   * when multiple config changes happen in quick succession.
+   * Debounced refresh of agent options only.
    */
-  private debouncedRefreshOptionsAndView() {
-    if (this.configRefreshTimeout) {
-      clearTimeout(this.configRefreshTimeout);
+  private debouncedRefreshAgentOptions() {
+    if (this.agentRefreshTimeout) {
+      clearTimeout(this.agentRefreshTimeout);
     }
-    this.configRefreshTimeout = setTimeout(() => {
-      void this.refreshOptionsAndView();
-      this.configRefreshTimeout = undefined;
-    }, 300); // 300ms debounce for config changes
+    this.agentRefreshTimeout = setTimeout(() => {
+      void this.refreshAgentOptions();
+      this.agentRefreshTimeout = undefined;
+    }, 300);
+  }
+
+  /**
+   * Debounced refresh of model options only.
+   */
+  private debouncedRefreshModelOptions() {
+    if (this.modelRefreshTimeout) {
+      clearTimeout(this.modelRefreshTimeout);
+    }
+    this.modelRefreshTimeout = setTimeout(() => {
+      void this.refreshModelOptions();
+      this.modelRefreshTimeout = undefined;
+    }, 300);
   }
 
   private setupAuthListener() {
@@ -115,8 +132,8 @@ export class MainViewProvider
   }
 
   /**
-   * Refresh agent options and update the webview.
-   * Called when agents change (file watcher) or auth state changes (login/logout).
+   * Refresh both agent and model options.
+   * Called when auth state changes (login/logout affects both).
    */
   async refreshOptionsAndView() {
     if (!this._view) {
@@ -132,6 +149,39 @@ export class MainViewProvider
       { command: MAIN_VIEW_COMMANDS.WEBVIEW_READY },
       this._view as vscode.WebviewView,
     );
+  }
+
+  /**
+   * Refresh agent options only.
+   * Called when agent config changes (texra.agents, texra.toolUseAgents).
+   */
+  async refreshAgentOptions() {
+    if (!this._view) {
+      return;
+    }
+    // Refresh the agent index to pick up configuration changes
+    await refresh();
+
+    const agentOptions = await computeAgentOptions();
+    this._view.webview.postMessage({
+      command: MAIN_VIEW_COMMANDS.SET_AGENT_OPTIONS,
+      options: agentOptions,
+    });
+  }
+
+  /**
+   * Refresh model options only.
+   * Called when model config changes (texra.models).
+   */
+  async refreshModelOptions() {
+    if (!this._view) {
+      return;
+    }
+    const modelOptions = await computeModelOptions();
+    this._view.webview.postMessage({
+      command: MAIN_VIEW_COMMANDS.SET_MODEL_OPTIONS,
+      options: modelOptions,
+    });
   }
 
   private setupFileWatcher() {
@@ -183,8 +233,8 @@ export class MainViewProvider
       refreshTimeout = setTimeout(() => {
         // Also update agent dirs in case they changed
         void updateAgentDirs();
-        // refreshOptionsAndView already calls refresh()
-        void this.refreshOptionsAndView();
+        // Only refresh agent options when agent files change
+        void this.refreshAgentOptions();
         refreshTimeout = undefined;
       }, 500);
     };

--- a/src/MainViewProvider.ts
+++ b/src/MainViewProvider.ts
@@ -10,6 +10,7 @@ import { getSharedLocalResourceRoots } from '@common/webview';
 import { MAIN_VIEW_COMMANDS } from '@common/webview';
 import { agentDirectories } from '@frontend/agents';
 import { watchConfig, getConfig } from '@utils/config';
+import { debounce } from '@utils/core';
 import { consumePendingState } from '@common/state';
 import { checkCoreDependencies } from '@utils/system/toolUtils';
 import { getServerSideKeyService } from '@/auth/serverKeys';
@@ -32,9 +33,15 @@ export class MainViewProvider
   // Static flag to track if commands have been registered
   private static commandsRegistered = false;
 
-  // Debounce timeouts for config change refreshes (separate for agents vs models)
-  private agentRefreshTimeout: ReturnType<typeof setTimeout> | undefined;
-  private modelRefreshTimeout: ReturnType<typeof setTimeout> | undefined;
+  // Debounced refresh methods using perfect-debounce
+  private debouncedRefreshAgentOptions = debounce(
+    () => this.refreshAgentOptions(),
+    300,
+  );
+  private debouncedRefreshModelOptions = debounce(
+    () => this.refreshModelOptions(),
+    300,
+  );
 
   constructor(protected readonly context: vscode.ExtensionContext) {
     super(context);
@@ -84,32 +91,6 @@ export class MainViewProvider
 
     // Watch for file configuration changes - only refresh file list
     watchConfig(this.context, ['texra.files'], () => this.refreshFiles());
-  }
-
-  /**
-   * Debounced refresh of agent options only.
-   */
-  private debouncedRefreshAgentOptions() {
-    if (this.agentRefreshTimeout) {
-      clearTimeout(this.agentRefreshTimeout);
-    }
-    this.agentRefreshTimeout = setTimeout(() => {
-      void this.refreshAgentOptions();
-      this.agentRefreshTimeout = undefined;
-    }, 300);
-  }
-
-  /**
-   * Debounced refresh of model options only.
-   */
-  private debouncedRefreshModelOptions() {
-    if (this.modelRefreshTimeout) {
-      clearTimeout(this.modelRefreshTimeout);
-    }
-    this.modelRefreshTimeout = setTimeout(() => {
-      void this.refreshModelOptions();
-      this.modelRefreshTimeout = undefined;
-    }, 300);
   }
 
   private setupAuthListener() {
@@ -219,29 +200,22 @@ export class MainViewProvider
       return agentDirPaths.some((dir) => filePath.startsWith(dir));
     };
 
-    // Debounce agent refresh to avoid rapid reloads during file saves
-    let refreshTimeout: ReturnType<typeof setTimeout> | undefined;
-    const debouncedRefresh = (uri: vscode.Uri) => {
-      // Only refresh if the changed file is in an agent directory
-      if (!isAgentFile(uri)) {
-        return;
-      }
+    // Debounced refresh - updates agent dirs and options
+    const debouncedAgentFileRefresh = debounce(async () => {
+      await updateAgentDirs();
+      await this.refreshAgentOptions();
+    }, 500);
 
-      if (refreshTimeout) {
-        clearTimeout(refreshTimeout);
+    // Filter and debounce agent file changes
+    const onAgentFileChange = (uri: vscode.Uri) => {
+      if (isAgentFile(uri)) {
+        void debouncedAgentFileRefresh();
       }
-      refreshTimeout = setTimeout(() => {
-        // Also update agent dirs in case they changed
-        void updateAgentDirs();
-        // Only refresh agent options when agent files change
-        void this.refreshAgentOptions();
-        refreshTimeout = undefined;
-      }, 500);
     };
 
-    this.agentWatcher.onDidCreate(debouncedRefresh);
-    this.agentWatcher.onDidChange(debouncedRefresh);
-    this.agentWatcher.onDidDelete(debouncedRefresh);
+    this.agentWatcher.onDidCreate(onAgentFileChange);
+    this.agentWatcher.onDidChange(onAgentFileChange);
+    this.agentWatcher.onDidDelete(onAgentFileChange);
 
     this.context.subscriptions.push(this.agentWatcher);
   }

--- a/src/agent/index/agentRegistry.ts
+++ b/src/agent/index/agentRegistry.ts
@@ -532,10 +532,19 @@ export interface AgentOptionsPayload {
   toolUse: string;
 }
 
+/** Optional selected values for preserving current selection */
+export interface AgentSelectedValues {
+  workflow?: string;
+  toolUse?: string;
+}
+
 /**
  * Build dropdown HTML options from cached agents.
+ * @param selected - Optional current selection to preserve
  */
-export function buildAgentOptions(): AgentOptionsPayload {
+export function buildAgentOptions(
+  selected?: AgentSelectedValues,
+): AgentOptionsPayload {
   const workflowEntries = getWorkflowAgents();
   const toolUseEntries = getToolUseAgents();
 
@@ -558,11 +567,13 @@ export function buildAgentOptions(): AgentOptionsPayload {
       visibleWorkflow,
       DEFAULT_WORKFLOW_AGENT,
       'No workflow agents',
+      selected?.workflow,
     ),
     toolUse: renderOptions(
       visibleToolUse,
       DEFAULT_TOOL_USE_AGENT,
       'No tool-use agents',
+      selected?.toolUse,
     ),
   };
 }
@@ -634,23 +645,30 @@ function renderOptions(
   entries: AgentEntry[],
   defaultName: string,
   emptyMsg: string,
+  selectedValue?: string,
 ): string {
   if (entries.length === 0) {
     return `<vscode-option value="">${emptyMsg}</vscode-option>`;
   }
 
-  // After deduplication, each name appears only once - simple name match
-  const defaultEntry = entries.find((e) => e.name === defaultName);
+  // Determine which entry should be selected:
+  // 1. If selectedValue is provided and exists in entries, use it
+  // 2. Otherwise fall back to default
+  const selectedEntry = selectedValue
+    ? entries.find((e) => createKey(e.source, e.name) === selectedValue)
+    : undefined;
+  const effectiveSelectedEntry =
+    selectedEntry ?? entries.find((e) => e.name === defaultName);
 
   // Sort: selected first, then alphabetically by name
   const sorted = [...entries].sort((a, b) => {
-    if (a.name === defaultName) return -1;
-    if (b.name === defaultName) return 1;
+    if (a === effectiveSelectedEntry) return -1;
+    if (b === effectiveSelectedEntry) return 1;
     return a.name.localeCompare(b.name);
   });
 
   return sorted
-    .map((entry) => renderOption(entry, entry === defaultEntry))
+    .map((entry) => renderOption(entry, entry === effectiveSelectedEntry))
     .join('\n');
 }
 
@@ -680,14 +698,17 @@ function renderOption(entry: AgentEntry, selected: boolean): string {
 
 /**
  * Async version - ensures cache is loaded first.
+ * @param selected - Optional current selection to preserve
  */
-export async function computeAgentOptions(): Promise<AgentOptionsPayload> {
+export async function computeAgentOptions(
+  selected?: AgentSelectedValues,
+): Promise<AgentOptionsPayload> {
   if (!initialized) {
     await loadAgents();
   } else if (initPromise) {
     await initPromise;
   }
-  return buildAgentOptions();
+  return buildAgentOptions(selected);
 }
 
 /**

--- a/src/agent/index/agentRegistry.ts
+++ b/src/agent/index/agentRegistry.ts
@@ -532,19 +532,14 @@ export interface AgentOptionsPayload {
   toolUse: string;
 }
 
-/** Optional selected values for preserving current selection */
-export interface AgentSelectedValues {
-  workflow?: string;
-  toolUse?: string;
-}
-
 /**
  * Build dropdown HTML options from cached agents.
- * @param selected - Optional current selection to preserve
+ *
+ * Note: Selection preservation is handled client-side via _markOptionAsSelected
+ * in the webview, which uses DOMParser to add the 'selected' attribute based
+ * on the current dropdown value before setting innerHTML.
  */
-export function buildAgentOptions(
-  selected?: AgentSelectedValues,
-): AgentOptionsPayload {
+export function buildAgentOptions(): AgentOptionsPayload {
   const workflowEntries = getWorkflowAgents();
   const toolUseEntries = getToolUseAgents();
 
@@ -567,13 +562,11 @@ export function buildAgentOptions(
       visibleWorkflow,
       DEFAULT_WORKFLOW_AGENT,
       'No workflow agents',
-      selected?.workflow,
     ),
     toolUse: renderOptions(
       visibleToolUse,
       DEFAULT_TOOL_USE_AGENT,
       'No tool-use agents',
-      selected?.toolUse,
     ),
   };
 }
@@ -645,34 +638,23 @@ function renderOptions(
   entries: AgentEntry[],
   defaultName: string,
   emptyMsg: string,
-  selectedValue?: string,
 ): string {
   if (entries.length === 0) {
     return `<vscode-option value="">${emptyMsg}</vscode-option>`;
   }
 
-  // Determine which entry should be selected:
-  // 1. If selectedValue is provided and exists in entries, use it
-  // 2. Otherwise fall back to default
-  const selectedEntry = selectedValue
-    ? entries.find((e) => createKey(e.source, e.name) === selectedValue)
-    : undefined;
-  const effectiveSelectedEntry =
-    selectedEntry ?? entries.find((e) => e.name === defaultName);
-
-  // Sort: selected first, then alphabetically by name
+  // Sort: default agent first, then alphabetically by name
+  const defaultEntry = entries.find((e) => e.name === defaultName);
   const sorted = [...entries].sort((a, b) => {
-    if (a === effectiveSelectedEntry) return -1;
-    if (b === effectiveSelectedEntry) return 1;
+    if (a === defaultEntry) return -1;
+    if (b === defaultEntry) return 1;
     return a.name.localeCompare(b.name);
   });
 
-  return sorted
-    .map((entry) => renderOption(entry, entry === effectiveSelectedEntry))
-    .join('\n');
+  return sorted.map((entry) => renderOption(entry)).join('\n');
 }
 
-function renderOption(entry: AgentEntry, selected: boolean): string {
+function renderOption(entry: AgentEntry): string {
   const key = `${entry.source}:${entry.name}`;
   const attrs: string[] = [
     `value="${encodeHtml(key)}"`,
@@ -691,24 +673,24 @@ function renderOption(entry: AgentEntry, selected: boolean): string {
     attrs.push(`data-description="${encodeHtml(entry.description)}"`);
   if (entry.agentType)
     attrs.push(`data-agent-type="${encodeHtml(entry.agentType)}"`);
-  if (selected) attrs.push('selected');
 
   return `<vscode-option ${attrs.join(' ')}>${encodeHtml(entry.name)}</vscode-option>`;
 }
 
 /**
  * Async version - ensures cache is loaded first.
- * @param selected - Optional current selection to preserve
+ *
+ * Note: Selection preservation is handled client-side via _markOptionAsSelected
+ * in the webview, which uses DOMParser to add the 'selected' attribute based
+ * on the current dropdown value before setting innerHTML.
  */
-export async function computeAgentOptions(
-  selected?: AgentSelectedValues,
-): Promise<AgentOptionsPayload> {
+export async function computeAgentOptions(): Promise<AgentOptionsPayload> {
   if (!initialized) {
     await loadAgents();
   } else if (initPromise) {
     await initPromise;
   }
-  return buildAgentOptions(selected);
+  return buildAgentOptions();
 }
 
 /**

--- a/src/agent/index/index.ts
+++ b/src/agent/index/index.ts
@@ -11,7 +11,6 @@ export {
   type ResolvedAgent,
   type RemoteVisibility,
   type AgentOptionsPayload,
-  type AgentSelectedValues,
   // Core functions
   loadAgents,
   getAgent,

--- a/src/agent/index/index.ts
+++ b/src/agent/index/index.ts
@@ -11,6 +11,7 @@ export {
   type ResolvedAgent,
   type RemoteVisibility,
   type AgentOptionsPayload,
+  type AgentSelectedValues,
   // Core functions
   loadAgents,
   getAgent,

--- a/src/commands/api/apiKeyCommands.ts
+++ b/src/commands/api/apiKeyCommands.ts
@@ -64,7 +64,8 @@ async function setApiKeyForProvider(
     );
     vscode.window.showInformationMessage(`${provider} API key has been set`);
     await vscode.commands.executeCommand('texra.refreshApiKeyStatus');
-    void vscode.commands.executeCommand('texra.refreshModelOptions');
+    // Refresh both model and agent options (model availability may change)
+    void vscode.commands.executeCommand('texra.refreshAllOptions');
     const view = await vscode.commands.executeCommand<vscode.WebviewView>(
       'texra.getWebviewView',
     );
@@ -125,7 +126,8 @@ export function registerApiKeyCommands(context: vscode.ExtensionContext) {
           `${provider} API key has been removed`,
         );
         await vscode.commands.executeCommand('texra.refreshApiKeyStatus');
-        void vscode.commands.executeCommand('texra.refreshModelOptions');
+        // Refresh both model and agent options (model availability may change)
+        void vscode.commands.executeCommand('texra.refreshAllOptions');
         const any = await SecretManager.anyApiKeyExists();
         const view = await vscode.commands.executeCommand<vscode.WebviewView>(
           'texra.getWebviewView',

--- a/src/commands/system/mainViewCommands.ts
+++ b/src/commands/system/mainViewCommands.ts
@@ -29,11 +29,12 @@ async function getMainWebview(): Promise<vscode.WebviewView | undefined> {
 }
 
 /**
- * Log a refresh error.
+ * Log a refresh error and notify the user.
  */
 function logRefreshError(error: unknown, context: string): void {
   const message = error instanceof Error ? error.message : String(error);
   logger.error(CHANNEL, `Failed to ${context}: ${message}`);
+  vscode.window.showErrorMessage(`Failed to ${context}: ${message}`);
 }
 
 /**

--- a/src/commands/system/mainViewCommands.ts
+++ b/src/commands/system/mainViewCommands.ts
@@ -13,6 +13,7 @@ const CHANNEL = 'mainViewCommands';
 export const mainViewCommands = {
   reset: 'texra.mainView.reset',
   refreshModelOptions: 'texra.refreshModelOptions',
+  refreshAgentOptions: 'texra.refreshAgentOptions',
   refreshAllOptions: 'texra.refreshAllOptions',
 };
 
@@ -46,8 +47,62 @@ export function registerMainViewCommands(context: vscode.ExtensionContext) {
   );
 
   /**
+   * Refresh model options only in the webview.
+   */
+  const refreshModelOptionsCommand = vscode.commands.registerCommand(
+    mainViewCommands.refreshModelOptions,
+    async () => {
+      const webviewView = await safeExecuteCommand<vscode.WebviewView>(
+        'texra.getWebviewView',
+        [],
+        'mainViewCommands',
+      );
+      if (webviewView) {
+        try {
+          const modelOptions = await computeModelOptions();
+          webviewView.webview.postMessage({
+            command: MAIN_VIEW_COMMANDS.SET_MODEL_OPTIONS,
+            options: modelOptions,
+          });
+        } catch (error) {
+          const message =
+            error instanceof Error ? error.message : String(error);
+          logger.error(CHANNEL, `Failed to refresh model options: ${message}`);
+        }
+      }
+    },
+  );
+
+  /**
+   * Refresh agent options only in the webview.
+   */
+  const refreshAgentOptionsCommand = vscode.commands.registerCommand(
+    mainViewCommands.refreshAgentOptions,
+    async () => {
+      const webviewView = await safeExecuteCommand<vscode.WebviewView>(
+        'texra.getWebviewView',
+        [],
+        'mainViewCommands',
+      );
+      if (webviewView) {
+        try {
+          const agentOptions = await computeAgentOptions();
+          webviewView.webview.postMessage({
+            command: MAIN_VIEW_COMMANDS.SET_AGENT_OPTIONS,
+            options: agentOptions,
+          });
+        } catch (error) {
+          const message =
+            error instanceof Error ? error.message : String(error);
+          logger.error(CHANNEL, `Failed to refresh agent options: ${message}`);
+        }
+      }
+    },
+  );
+
+  /**
    * Refresh both model and agent options in the webview.
-   * This is the primary command for refreshing dropdown options.
+   * Used when both need to be updated together (e.g., API key changes, auth changes).
    */
   const refreshAllOptionsCommand = vscode.commands.registerCommand(
     mainViewCommands.refreshAllOptions,
@@ -78,32 +133,22 @@ export function registerMainViewCommands(context: vscode.ExtensionContext) {
           const message =
             error instanceof Error ? error.message : String(error);
           logger.error(CHANNEL, `Failed to refresh options: ${message}`);
-          vscode.window.showErrorMessage(
-            'Failed to refresh options. Please check the output console for details.',
-          );
         }
       }
     },
   );
 
-  /**
-   * Legacy command for refreshing model options only.
-   * Now delegates to refreshAllOptions for consistency.
-   * @deprecated Use refreshAllOptions instead
-   */
-  const refreshModelOptionsCommand = vscode.commands.registerCommand(
-    mainViewCommands.refreshModelOptions,
-    async () => {
-      // Delegate to refreshAllOptions for consistent behavior
-      await vscode.commands.executeCommand(mainViewCommands.refreshAllOptions);
-    },
-  );
-
   context.subscriptions.push(
     resetCommand,
-    refreshAllOptionsCommand,
     refreshModelOptionsCommand,
+    refreshAgentOptionsCommand,
+    refreshAllOptionsCommand,
   );
 
-  return { resetCommand, refreshAllOptionsCommand, refreshModelOptionsCommand };
+  return {
+    resetCommand,
+    refreshModelOptionsCommand,
+    refreshAgentOptionsCommand,
+    refreshAllOptionsCommand,
+  };
 }

--- a/src/commands/system/mainViewCommands.ts
+++ b/src/commands/system/mainViewCommands.ts
@@ -2,7 +2,7 @@
 import * as vscode from 'vscode';
 
 // Local imports
-import { computeAgentOptions } from '@agent/index';
+import { computeAgentOptions, refresh } from '@agent/index';
 import { MAIN_VIEW_COMMANDS } from '@common/webview';
 import { safeExecuteCommand } from '@frontend/system/commandUtils';
 import * as logger from '@logger/logUtils';
@@ -16,6 +16,25 @@ export const mainViewCommands = {
   refreshAgentOptions: 'texra.refreshAgentOptions',
   refreshAllOptions: 'texra.refreshAllOptions',
 };
+
+/**
+ * Get the main webview view instance.
+ */
+async function getMainWebview(): Promise<vscode.WebviewView | undefined> {
+  return safeExecuteCommand<vscode.WebviewView>(
+    'texra.getWebviewView',
+    [],
+    CHANNEL,
+  );
+}
+
+/**
+ * Log a refresh error.
+ */
+function logRefreshError(error: unknown, context: string): void {
+  const message = error instanceof Error ? error.message : String(error);
+  logger.error(CHANNEL, `Failed to ${context}: ${message}`);
+}
 
 /**
  * Registers main view commands for the extension
@@ -52,23 +71,17 @@ export function registerMainViewCommands(context: vscode.ExtensionContext) {
   const refreshModelOptionsCommand = vscode.commands.registerCommand(
     mainViewCommands.refreshModelOptions,
     async () => {
-      const webviewView = await safeExecuteCommand<vscode.WebviewView>(
-        'texra.getWebviewView',
-        [],
-        'mainViewCommands',
-      );
-      if (webviewView) {
-        try {
-          const modelOptions = await computeModelOptions();
-          webviewView.webview.postMessage({
-            command: MAIN_VIEW_COMMANDS.SET_MODEL_OPTIONS,
-            options: modelOptions,
-          });
-        } catch (error) {
-          const message =
-            error instanceof Error ? error.message : String(error);
-          logger.error(CHANNEL, `Failed to refresh model options: ${message}`);
-        }
+      const webview = await getMainWebview();
+      if (!webview) return;
+
+      try {
+        const options = await computeModelOptions();
+        webview.webview.postMessage({
+          command: MAIN_VIEW_COMMANDS.SET_MODEL_OPTIONS,
+          options,
+        });
+      } catch (error) {
+        logRefreshError(error, 'refresh model options');
       }
     },
   );
@@ -79,23 +92,19 @@ export function registerMainViewCommands(context: vscode.ExtensionContext) {
   const refreshAgentOptionsCommand = vscode.commands.registerCommand(
     mainViewCommands.refreshAgentOptions,
     async () => {
-      const webviewView = await safeExecuteCommand<vscode.WebviewView>(
-        'texra.getWebviewView',
-        [],
-        'mainViewCommands',
-      );
-      if (webviewView) {
-        try {
-          const agentOptions = await computeAgentOptions();
-          webviewView.webview.postMessage({
-            command: MAIN_VIEW_COMMANDS.SET_AGENT_OPTIONS,
-            options: agentOptions,
-          });
-        } catch (error) {
-          const message =
-            error instanceof Error ? error.message : String(error);
-          logger.error(CHANNEL, `Failed to refresh agent options: ${message}`);
-        }
+      const webview = await getMainWebview();
+      if (!webview) return;
+
+      try {
+        // Reload agent index to pick up config changes
+        await refresh();
+        const options = await computeAgentOptions();
+        webview.webview.postMessage({
+          command: MAIN_VIEW_COMMANDS.SET_AGENT_OPTIONS,
+          options,
+        });
+      } catch (error) {
+        logRefreshError(error, 'refresh agent options');
       }
     },
   );
@@ -107,33 +116,27 @@ export function registerMainViewCommands(context: vscode.ExtensionContext) {
   const refreshAllOptionsCommand = vscode.commands.registerCommand(
     mainViewCommands.refreshAllOptions,
     async () => {
-      const webviewView = await safeExecuteCommand<vscode.WebviewView>(
-        'texra.getWebviewView',
-        [],
-        'mainViewCommands',
-      );
-      if (webviewView) {
-        try {
-          // Refresh both model and agent options in parallel
-          const [modelOptions, agentOptions] = await Promise.all([
-            computeModelOptions(),
-            computeAgentOptions(),
-          ]);
+      const webview = await getMainWebview();
+      if (!webview) return;
 
-          webviewView.webview.postMessage({
-            command: MAIN_VIEW_COMMANDS.SET_MODEL_OPTIONS,
-            options: modelOptions,
-          });
+      try {
+        // Reload agent index first, then compute both in parallel
+        await refresh();
+        const [modelOptions, agentOptions] = await Promise.all([
+          computeModelOptions(),
+          computeAgentOptions(),
+        ]);
 
-          webviewView.webview.postMessage({
-            command: MAIN_VIEW_COMMANDS.SET_AGENT_OPTIONS,
-            options: agentOptions,
-          });
-        } catch (error) {
-          const message =
-            error instanceof Error ? error.message : String(error);
-          logger.error(CHANNEL, `Failed to refresh options: ${message}`);
-        }
+        webview.webview.postMessage({
+          command: MAIN_VIEW_COMMANDS.SET_MODEL_OPTIONS,
+          options: modelOptions,
+        });
+        webview.webview.postMessage({
+          command: MAIN_VIEW_COMMANDS.SET_AGENT_OPTIONS,
+          options: agentOptions,
+        });
+      } catch (error) {
+        logRefreshError(error, 'refresh options');
       }
     },
   );

--- a/src/commands/system/mainViewCommands.ts
+++ b/src/commands/system/mainViewCommands.ts
@@ -1,17 +1,19 @@
 // Third-party imports
 import * as vscode from 'vscode';
 
-// Local imports - webview commands
+// Local imports
+import { computeAgentOptions } from '@agent/index';
 import { MAIN_VIEW_COMMANDS } from '@common/webview';
-import { computeModelOptions } from '@model/computeModelOptions';
 import { safeExecuteCommand } from '@frontend/system/commandUtils';
 import * as logger from '@logger/logUtils';
+import { computeModelOptions } from '@model/computeModelOptions';
 
 const CHANNEL = 'mainViewCommands';
 
 export const mainViewCommands = {
   reset: 'texra.mainView.reset',
   refreshModelOptions: 'texra.refreshModelOptions',
+  refreshAllOptions: 'texra.refreshAllOptions',
 };
 
 /**
@@ -43,8 +45,12 @@ export function registerMainViewCommands(context: vscode.ExtensionContext) {
     },
   );
 
-  const refreshModelOptionsCommand = vscode.commands.registerCommand(
-    mainViewCommands.refreshModelOptions,
+  /**
+   * Refresh both model and agent options in the webview.
+   * This is the primary command for refreshing dropdown options.
+   */
+  const refreshAllOptionsCommand = vscode.commands.registerCommand(
+    mainViewCommands.refreshAllOptions,
     async () => {
       const webviewView = await safeExecuteCommand<vscode.WebviewView>(
         'texra.getWebviewView',
@@ -53,24 +59,51 @@ export function registerMainViewCommands(context: vscode.ExtensionContext) {
       );
       if (webviewView) {
         try {
-          const options = await computeModelOptions();
+          // Refresh both model and agent options in parallel
+          const [modelOptions, agentOptions] = await Promise.all([
+            computeModelOptions(),
+            computeAgentOptions(),
+          ]);
+
           webviewView.webview.postMessage({
             command: MAIN_VIEW_COMMANDS.SET_MODEL_OPTIONS,
-            options,
+            options: modelOptions,
+          });
+
+          webviewView.webview.postMessage({
+            command: MAIN_VIEW_COMMANDS.SET_AGENT_OPTIONS,
+            options: agentOptions,
           });
         } catch (error) {
           const message =
             error instanceof Error ? error.message : String(error);
-          logger.error(CHANNEL, `Failed to refresh model options: ${message}`);
+          logger.error(CHANNEL, `Failed to refresh options: ${message}`);
           vscode.window.showErrorMessage(
-            'Failed to refresh model options. Please check the output console for details.',
+            'Failed to refresh options. Please check the output console for details.',
           );
         }
       }
     },
   );
 
-  context.subscriptions.push(resetCommand, refreshModelOptionsCommand);
+  /**
+   * Legacy command for refreshing model options only.
+   * Now delegates to refreshAllOptions for consistency.
+   * @deprecated Use refreshAllOptions instead
+   */
+  const refreshModelOptionsCommand = vscode.commands.registerCommand(
+    mainViewCommands.refreshModelOptions,
+    async () => {
+      // Delegate to refreshAllOptions for consistent behavior
+      await vscode.commands.executeCommand(mainViewCommands.refreshAllOptions);
+    },
+  );
 
-  return { resetCommand, refreshModelOptionsCommand };
+  context.subscriptions.push(
+    resetCommand,
+    refreshAllOptionsCommand,
+    refreshModelOptionsCommand,
+  );
+
+  return { resetCommand, refreshAllOptionsCommand, refreshModelOptionsCommand };
 }

--- a/src/common/debounce.js
+++ b/src/common/debounce.js
@@ -1,0 +1,19 @@
+/**
+ * Creates a debounced function that delays invoking fn until after delay ms
+ * have elapsed since the last time the debounced function was invoked.
+ *
+ * This implementation mirrors the behavior of perfect-debounce for consistency
+ * with the Node.js codebase.
+ *
+ * @template {(...args: any[]) => any} T
+ * @param {T} fn - The function to debounce
+ * @param {number} delay - The delay in milliseconds
+ * @returns {(...args: Parameters<T>) => void}
+ */
+export function debounce(fn, delay) {
+  let timeout;
+  return (...args) => {
+    clearTimeout(timeout);
+    timeout = setTimeout(() => fn(...args), delay);
+  };
+}

--- a/src/explorer/WatcherManager.ts
+++ b/src/explorer/WatcherManager.ts
@@ -46,8 +46,9 @@ export class WatcherManager {
         return;
       }
 
+      // Clean up any existing watchers before setting up new ones
       this.dispose();
-      // Reset disposed flag for re-setup
+      // Re-enable after dispose() set it to true - allows new watchers to trigger refresh
       this.disposed = false;
 
       const builtInAgentsPath = await agentDirectories.builtIn();

--- a/src/explorer/WatcherManager.ts
+++ b/src/explorer/WatcherManager.ts
@@ -17,15 +17,22 @@ export class WatcherManager {
   private disposables: vscode.FileSystemWatcher[] = [];
   private validationHandles: NodeJS.Timeout[] = [];
   private static readonly VALIDATION_DELAY = 300;
+  private disposed = false;
 
   // Debounced refresh using perfect-debounce
+  // Wrapped with disposed check since perfect-debounce doesn't expose cancel
   private triggerRefresh: () => void;
 
   constructor(
     private context: vscode.ExtensionContext | undefined,
     private refresh: () => void,
   ) {
-    this.triggerRefresh = debounce(() => this.refresh(), 200);
+    // Wrap callback with disposed check to prevent execution after dispose
+    this.triggerRefresh = debounce(() => {
+      if (!this.disposed) {
+        this.refresh();
+      }
+    }, 200);
   }
 
   async setup() {
@@ -39,6 +46,8 @@ export class WatcherManager {
       }
 
       this.dispose();
+      // Reset disposed flag for re-setup
+      this.disposed = false;
 
       const builtInAgentsPath = await agentDirectories.builtIn();
       const builtInToolUsePath = await agentDirectories.builtInToolUse();
@@ -103,7 +112,8 @@ export class WatcherManager {
   }
 
   dispose() {
-    // Note: debounced refresh will naturally stop when refresh is no longer needed
+    // Set disposed flag to prevent debounced refresh from executing
+    this.disposed = true;
     this.validationHandles.forEach((h) => clearTimeout(h));
     this.validationHandles = [];
     this.disposables.forEach((d) => d.dispose());

--- a/src/explorer/WatcherManager.ts
+++ b/src/explorer/WatcherManager.ts
@@ -9,6 +9,7 @@ import { agentDirectories } from '@frontend/agents';
 import { validateYamlAndPromptAdd } from '@frontend/agents';
 import * as logger from '@logger/logUtils';
 import { debounce } from '@utils/core';
+import { DEBOUNCE_WATCHER_MS } from '@utils/config';
 
 const CHANNEL = 'Webview';
 logger.initialize(CHANNEL);
@@ -32,7 +33,7 @@ export class WatcherManager {
       if (!this.disposed) {
         this.refresh();
       }
-    }, 200);
+    }, DEBOUNCE_WATCHER_MS);
   }
 
   async setup() {

--- a/src/explorer/WatcherManager.ts
+++ b/src/explorer/WatcherManager.ts
@@ -8,26 +8,24 @@ import * as vscode from 'vscode';
 import { agentDirectories } from '@frontend/agents';
 import { validateYamlAndPromptAdd } from '@frontend/agents';
 import * as logger from '@logger/logUtils';
+import { debounce } from '@utils/core';
 
 const CHANNEL = 'Webview';
 logger.initialize(CHANNEL);
 
 export class WatcherManager {
   private disposables: vscode.FileSystemWatcher[] = [];
-  private refreshHandle: NodeJS.Timeout | undefined;
   private validationHandles: NodeJS.Timeout[] = [];
   private static readonly VALIDATION_DELAY = 300;
+
+  // Debounced refresh using perfect-debounce
+  private triggerRefresh: () => void;
 
   constructor(
     private context: vscode.ExtensionContext | undefined,
     private refresh: () => void,
-  ) {}
-
-  private triggerRefresh() {
-    if (this.refreshHandle) {
-      clearTimeout(this.refreshHandle);
-    }
-    this.refreshHandle = setTimeout(() => this.refresh(), 200);
+  ) {
+    this.triggerRefresh = debounce(() => this.refresh(), 200);
   }
 
   async setup() {
@@ -105,10 +103,7 @@ export class WatcherManager {
   }
 
   dispose() {
-    if (this.refreshHandle) {
-      clearTimeout(this.refreshHandle);
-      this.refreshHandle = undefined;
-    }
+    // Note: debounced refresh will naturally stop when refresh is no longer needed
     this.validationHandles.forEach((h) => clearTimeout(h));
     this.validationHandles = [];
     this.disposables.forEach((d) => d.dispose());

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -175,21 +175,8 @@ export async function activate(context: vscode.ExtensionContext) {
         // Connect URI handler to auth provider
         authProvider.setUriHandler(uriHandler);
 
-        // Subscribe to auth state changes to refresh agent list on login/logout
-        context.subscriptions.push(
-          authProvider.onDidChangeSessions(async (event) => {
-            // Refresh agent options when user logs in or out
-            // This will fetch/clear remote agents and update dropdown
-            const mainView = getMainViewProvider();
-            if (mainView) {
-              logger.info(
-                'extension',
-                `Auth state changed (added: ${event.added?.length ?? 0}, removed: ${event.removed?.length ?? 0}), refreshing agents`,
-              );
-              await mainView.refreshOptionsAndView();
-            }
-          }),
-        );
+        // Note: Auth state change listener is handled in MainViewProvider.setupAuthListener()
+        // to avoid duplicate refresh calls when user logs in/out.
 
         // Initialize usage logging service for backend analytics (only when auth is available)
         const extensionVersion =

--- a/src/historyView/modules/uiManagers/HistoryEventsManager.js
+++ b/src/historyView/modules/uiManagers/HistoryEventsManager.js
@@ -1,6 +1,7 @@
 // Local imports - history view
 import { ELEMENT_IDS } from '../constants.js';
 import { addEventListenerSafely } from '@common/domUtils.js';
+import { debounce } from '@common/debounce.js';
 
 /**
  * Registers global event listeners for the history view.
@@ -11,17 +12,9 @@ export class HistoryEventsManager {
     this.handlers = [];
   }
 
-  _debounce(fn, delay) {
-    let timeout;
-    return (...args) => {
-      clearTimeout(timeout);
-      timeout = setTimeout(() => fn(...args), delay);
-    };
-  }
-
   setupEventListeners() {
     const searchInput = document.getElementById(ELEMENT_IDS.SEARCH_INPUT);
-    const searchHandler = this._debounce((e) => {
+    const searchHandler = debounce((e) => {
       const term = e.target.value.trim();
       this.searchManager.search(term);
     }, 300);

--- a/src/model/computeModelOptions.ts
+++ b/src/model/computeModelOptions.ts
@@ -37,7 +37,11 @@ function formatCost(inputPrice?: number, outputPrice?: number): string {
  * @returns Whether the model is available via personal keys
  */
 async function checkPersonalKeyAvailability(
-  config: { openRouterOnly?: boolean; openrouterFullName?: string; provider: string },
+  config: {
+    openRouterOnly?: boolean;
+    openrouterFullName?: string;
+    provider: string;
+  },
   hasOpenRouter: boolean,
 ): Promise<boolean> {
   // openRouterOnly models can ONLY use OpenRouter
@@ -50,7 +54,9 @@ async function checkPersonalKeyAvailability(
   // Check provider-specific API key
   if (SecretManager.API_PROVIDERS.includes(provider as ApiProvider)) {
     try {
-      const hasProviderKey = await SecretManager.apiKeyExists(provider as ApiProvider);
+      const hasProviderKey = await SecretManager.apiKeyExists(
+        provider as ApiProvider,
+      );
       if (hasProviderKey) {
         return true;
       }

--- a/src/model/computeModelOptions.ts
+++ b/src/model/computeModelOptions.ts
@@ -78,6 +78,10 @@ async function checkPersonalKeyAvailability(
  *
  * When "Use Included Access" is enabled, only server-side availability is checked.
  * When "Use My Own Keys" is selected, personal API keys are checked as fallback.
+ *
+ * Note: Selection preservation is handled client-side via _markOptionAsSelected
+ * in the webview, which uses DOMParser to add the 'selected' attribute based
+ * on the current dropdown value before setting innerHTML.
  */
 export async function computeModelOptions(): Promise<string> {
   const models = getConfig<string[]>('texra.models', []);

--- a/src/utils/config/constants.ts
+++ b/src/utils/config/constants.ts
@@ -59,6 +59,11 @@ export const LATEX_VIEWER_OPEN_DELAY_MS = 5000;
 export const LATEX_VIEWER_REFRESH_DELAY_MS = 5000;
 export const THREE_DAYS_MS = 3 * 24 * 60 * 60 * 1000;
 
+// Debounce delay constants for UI responsiveness
+export const DEBOUNCE_WATCHER_MS = 200; // File system watchers (fast response)
+export const DEBOUNCE_OPTIONS_MS = 300; // Dropdown options refresh
+export const DEBOUNCE_STATE_SAVE_MS = 500; // State persistence (slower, batched)
+
 // Tool-use persistence defaults
 export const DEFAULT_TOOL_USE_PERSISTENCE_TTL_HOURS = 72;
 

--- a/src/utils/core/async.ts
+++ b/src/utils/core/async.ts
@@ -2,6 +2,9 @@
  * Async utilities - pure async helper functions.
  */
 
+// Re-export debounce from perfect-debounce for consistent usage across codebase
+export { debounce } from 'perfect-debounce';
+
 /**
  * Asynchronously wait for the specified number of milliseconds.
  * @param ms Number of milliseconds to sleep

--- a/src/utils/core/index.ts
+++ b/src/utils/core/index.ts
@@ -17,4 +17,4 @@ export {
   type SerializedError,
 } from './stringCore';
 export { contentToString, isObject, type MessageContent } from './typeGuards';
-export { sleep, sleepWithAbort } from './async';
+export { debounce, sleep, sleepWithAbort } from './async';

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -391,7 +391,12 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
     // Caller must wrap in blockSave()/unblockSave() - vscode-single-select
     // fires change events during innerHTML replacement which would trigger save()
     const previous = selectElement.value;
-    selectElement.innerHTML = optionsHtml;
+    // Add 'selected' attribute to the correct option in HTML before setting innerHTML.
+    // This is necessary because vscode-single-select's slotchange handler defaults to
+    // the first option if no option has selected=true. By the time we call
+    // _restoreModelSelection, slotchange has already fired and reset the selection.
+    const htmlWithSelected = this._markOptionAsSelected(optionsHtml, previous);
+    selectElement.innerHTML = htmlWithSelected;
     this._restoreModelSelection(selectElement, previous);
     getSelectOptionElements(selectElement).forEach((opt) => {
       this._decorateModelOption(opt);
@@ -435,7 +440,12 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
     // Caller must wrap in blockSave()/unblockSave() - vscode-single-select
     // fires change events during innerHTML replacement which would trigger save()
     const previous = selectElement.value;
-    selectElement.innerHTML = optionsHtml ?? '';
+    // Add 'selected' attribute to the correct option in HTML before setting innerHTML.
+    // This is necessary because vscode-single-select's slotchange handler defaults to
+    // the first option if no option has selected=true. By the time we call
+    // _restoreAgentSelection, slotchange has already fired and reset the selection.
+    const htmlWithSelected = this._markOptionAsSelected(optionsHtml ?? '', previous);
+    selectElement.innerHTML = htmlWithSelected;
     this._restoreAgentSelection(selectElement, previous);
     getSelectOptionElements(selectElement).forEach((opt) => {
       this._decorateAgentOption(opt);
@@ -821,6 +831,54 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
     // If matchedCandidate !== savedValue, previousValue was used.
     // Keep savedValue in state - user's preference is preserved for when
     // the model becomes available again (e.g., API key re-added).
+  }
+
+  /**
+   * Mark an option as selected in HTML string by adding the 'selected' attribute.
+   *
+   * This is necessary to work around a timing issue in vscode-single-select:
+   * When innerHTML is replaced, slotchange fires asynchronously. The component's
+   * _setStateFromSlottedElements() reads el.selected from each option, and if none
+   * are selected, it defaults to index 0. By the time we set selectElement.value,
+   * the slotchange handler has already run and reset the selection.
+   *
+   * By adding 'selected' attribute to the correct option in HTML before setting
+   * innerHTML, slotchange will read selected=true and preserve the selection.
+   *
+   * @param {string} html - The options HTML string
+   * @param {string} value - The value to mark as selected
+   * @returns {string} The HTML with 'selected' attribute added to matching option
+   */
+  _markOptionAsSelected(html, value) {
+    if (!value || !html) {
+      return html || '';
+    }
+
+    // Escape special regex characters in the value
+    const escapedValue = value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+    // Match <vscode-option with value="..." and add selected attribute
+    // Handle both value="..." and value='...' formats
+    // The regex captures everything up to the closing > to insert 'selected' before it
+    const doubleQuoteRegex = new RegExp(
+      `(<vscode-option\\s+[^>]*value="${escapedValue}"[^>]*)>`,
+      'i',
+    );
+    const singleQuoteRegex = new RegExp(
+      `(<vscode-option\\s+[^>]*value='${escapedValue}'[^>]*)>`,
+      'i',
+    );
+
+    // Try double quotes first, then single quotes
+    if (doubleQuoteRegex.test(html)) {
+      return html.replace(doubleQuoteRegex, '$1 selected>');
+    }
+    if (singleQuoteRegex.test(html)) {
+      return html.replace(singleQuoteRegex, '$1 selected>');
+    }
+
+    // Value not found in options - return original HTML
+    return html;
   }
 
   _getActiveAgentSelection() {

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -449,7 +449,10 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
     // Two-phase selection restoration (see _applyModelOptions for details):
     // 1. _markOptionAsSelected: Prevents slotchange from defaulting to first option
     // 2. _restoreAgentSelection: Handles fallbacks (value migration, placeholder creation)
-    const htmlWithSelected = this._markOptionAsSelected(optionsHtml ?? '', previous);
+    const htmlWithSelected = this._markOptionAsSelected(
+      optionsHtml ?? '',
+      previous,
+    );
     selectElement.innerHTML = htmlWithSelected;
     this._restoreAgentSelection(selectElement, previous);
 

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -391,13 +391,18 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
     // Caller must wrap in blockSave()/unblockSave() - vscode-single-select
     // fires change events during innerHTML replacement which would trigger save()
     const previous = selectElement.value;
-    // Add 'selected' attribute to the correct option in HTML before setting innerHTML.
-    // This is necessary because vscode-single-select's slotchange handler defaults to
-    // the first option if no option has selected=true. By the time we call
-    // _restoreModelSelection, slotchange has already fired and reset the selection.
+
+    // Two-phase selection restoration:
+    // 1. _markOptionAsSelected: Add 'selected' attribute to HTML BEFORE innerHTML assignment.
+    //    This prevents vscode-single-select's slotchange from defaulting to first option.
+    // 2. _restoreModelSelection: Handles fallback cases after innerHTML is set:
+    //    - Value not found in options (preserves user preference in state)
+    //    - Sets selectElement.value for programmatic access
+    //    Both are needed because slotchange fires asynchronously after innerHTML.
     const htmlWithSelected = this._markOptionAsSelected(optionsHtml, previous);
     selectElement.innerHTML = htmlWithSelected;
     this._restoreModelSelection(selectElement, previous);
+
     getSelectOptionElements(selectElement).forEach((opt) => {
       this._decorateModelOption(opt);
     });
@@ -440,13 +445,14 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
     // Caller must wrap in blockSave()/unblockSave() - vscode-single-select
     // fires change events during innerHTML replacement which would trigger save()
     const previous = selectElement.value;
-    // Add 'selected' attribute to the correct option in HTML before setting innerHTML.
-    // This is necessary because vscode-single-select's slotchange handler defaults to
-    // the first option if no option has selected=true. By the time we call
-    // _restoreAgentSelection, slotchange has already fired and reset the selection.
+
+    // Two-phase selection restoration (see _applyModelOptions for details):
+    // 1. _markOptionAsSelected: Prevents slotchange from defaulting to first option
+    // 2. _restoreAgentSelection: Handles fallbacks (value migration, placeholder creation)
     const htmlWithSelected = this._markOptionAsSelected(optionsHtml ?? '', previous);
     selectElement.innerHTML = htmlWithSelected;
     this._restoreAgentSelection(selectElement, previous);
+
     getSelectOptionElements(selectElement).forEach((opt) => {
       this._decorateAgentOption(opt);
     });

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -881,8 +881,8 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
       return html;
     }
 
-    // Return the modified HTML
-    return doc.querySelector('div').innerHTML;
+    // Return the modified HTML (with null-safety fallback)
+    return doc.querySelector('div')?.innerHTML ?? html;
   }
 
   _getActiveAgentSelection() {

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -43,6 +43,7 @@ import {
   getSelectedOptionElement,
 } from '@common/domUtils.js';
 import { capitalize, uncapitalize } from '@common/stringUtils.js';
+import { encodeHtml } from '@common/htmlEncoding.js';
 import {
   AGENT_DECORATORS,
   getAgentTypeDecorator,
@@ -854,18 +855,23 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
       return html || '';
     }
 
-    // Escape special regex characters in the value
-    const escapedValue = value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    // HTML-encode the value to match how it appears in the HTML
+    // (agent values are encoded with he.encode() when generating options)
+    const encodedValue = encodeHtml(value);
+
+    // Escape special regex characters in the encoded value
+    const escapedValue = encodedValue.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
     // Match <vscode-option with value="..." and add selected attribute
     // Handle both value="..." and value='...' formats
-    // The regex captures everything up to the closing > to insert 'selected' before it
+    // Use word boundary after value= to avoid matching data-value or similar
+    // Check that 'selected' isn't already present to avoid duplicates
     const doubleQuoteRegex = new RegExp(
-      `(<vscode-option\\s+[^>]*value="${escapedValue}"[^>]*)>`,
+      `(<vscode-option\\s+(?![^>]*\\bselected\\b)[^>]*\\bvalue="${escapedValue}"[^>]*)>`,
       'i',
     );
     const singleQuoteRegex = new RegExp(
-      `(<vscode-option\\s+[^>]*value='${escapedValue}'[^>]*)>`,
+      `(<vscode-option\\s+(?![^>]*\\bselected\\b)[^>]*\\bvalue='${escapedValue}'[^>]*)>`,
       'i',
     );
 

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -43,7 +43,6 @@ import {
   getSelectedOptionElement,
 } from '@common/domUtils.js';
 import { capitalize, uncapitalize } from '@common/stringUtils.js';
-import { encodeHtml } from '@common/htmlEncoding.js';
 import {
   AGENT_DECORATORS,
   getAgentTypeDecorator,
@@ -846,6 +845,8 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
    * By adding 'selected' attribute to the correct option in HTML before setting
    * innerHTML, slotchange will read selected=true and preserve the selection.
    *
+   * Uses DOMParser for safe, encoding-aware HTML manipulation instead of regex.
+   *
    * @param {string} html - The options HTML string
    * @param {string} value - The value to mark as selected
    * @returns {string} The HTML with 'selected' attribute added to matching option
@@ -855,36 +856,27 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
       return html || '';
     }
 
-    // HTML-encode the value to match how it appears in the HTML
-    // (agent values are encoded with he.encode() when generating options)
-    const encodedValue = encodeHtml(value);
+    // Use DOMParser for safe, encoding-aware manipulation
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(`<div>${html}</div>`, 'text/html');
+    const options = doc.querySelectorAll('vscode-option');
 
-    // Escape special regex characters in the encoded value
-    const escapedValue = encodedValue.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    let found = false;
+    options.forEach((opt) => {
+      // getAttribute returns decoded value, so we compare directly with value
+      if (opt.getAttribute('value') === value) {
+        opt.setAttribute('selected', '');
+        found = true;
+      }
+    });
 
-    // Match <vscode-option with value="..." and add selected attribute
-    // Handle both value="..." and value='...' formats
-    // Use word boundary after value= to avoid matching data-value or similar
-    // Check that 'selected' isn't already present to avoid duplicates
-    const doubleQuoteRegex = new RegExp(
-      `(<vscode-option\\s+(?![^>]*\\bselected\\b)[^>]*\\bvalue="${escapedValue}"[^>]*)>`,
-      'i',
-    );
-    const singleQuoteRegex = new RegExp(
-      `(<vscode-option\\s+(?![^>]*\\bselected\\b)[^>]*\\bvalue='${escapedValue}'[^>]*)>`,
-      'i',
-    );
-
-    // Try double quotes first, then single quotes
-    if (doubleQuoteRegex.test(html)) {
-      return html.replace(doubleQuoteRegex, '$1 selected>');
-    }
-    if (singleQuoteRegex.test(html)) {
-      return html.replace(singleQuoteRegex, '$1 selected>');
+    if (!found) {
+      // Value not found in options - return original HTML
+      return html;
     }
 
-    // Value not found in options - return original HTML
-    return html;
+    // Return the modified HTML
+    return doc.querySelector('div').innerHTML;
   }
 
   _getActiveAgentSelection() {

--- a/src/webview/modules/uiManagers/FileInputManager.js
+++ b/src/webview/modules/uiManagers/FileInputManager.js
@@ -20,6 +20,7 @@ import { fileSelect } from './FileSelect.js';
 import { outputFilesManager } from './OutputFilesManager.js';
 import { safeGetElementById, safeGetElementValue } from '@common/domUtils.js';
 import { capitalize } from '@common/stringUtils.js';
+import { debounce } from '@common/debounce.js';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
 import { vscode } from '@common/webviewContext.js';
 
@@ -345,7 +346,9 @@ export class FileInputManager extends BaseUIManager {
         this.addListener(id, 'change', () => this.state.save());
       }
     });
-    this.addListener('instruction', 'input', () => this.state.save());
+    // Debounce instruction input to avoid saving on every keystroke
+    const debouncedSave = debounce(() => this.state.save(), 500);
+    this.addListener('instruction', 'input', debouncedSave);
   }
 
   setup() {

--- a/src/webview/modules/uiManagers/InstructionManager.js
+++ b/src/webview/modules/uiManagers/InstructionManager.js
@@ -1,6 +1,7 @@
 // Local imports - webview
 import { setupPasteListener } from '../pasteHandler.js';
 import { safeGetElementById } from '@common/domUtils.js';
+import { debounce } from '@common/debounce.js';
 import {
   awaitTextareaUpgrade,
   insertTextAtCursor,
@@ -29,9 +30,9 @@ export class InstructionManager {
         return;
       }
 
-      target.addEventListener('input', () => {
-        this.state?.save();
-      });
+      // Debounce state saves to avoid saving on every keystroke
+      const debouncedSave = debounce(() => this.state?.save(), 500);
+      target.addEventListener('input', debouncedSave);
 
       setupPasteListener(
         target,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Focuses on stopping dropdowns from jumping to defaults and reducing UI churn.
> 
> - Preserve selection in webview dropdowns by marking the current option as `selected` before `innerHTML` updates and restoring afterward (models and agents); server-side option builders no longer set `selected` themselves
> - Split option updates and commands: `texra.refreshAgentOptions`, `texra.refreshModelOptions`, and `texra.refreshAllOptions`; API key set/remove now triggers `refreshAllOptions`
> - Debounce throughout: agent/model option recompute, agent directory file watcher updates, explorer watchers, history search, and instruction input/state saves; add shared debounce helpers and constants; add `perfect-debounce` dependency
> - Refactor MainViewProvider/config watchers to refresh only what changed (agents/models/files) and centralize auth-driven refreshes; minor sorting tweak for agent options (default-first)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5a3ef91ea189e15626118c111d71983d62883330. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->