### PR TITLE
Fix Max account model list sync issue

### DIFF
--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -274,17 +274,21 @@ export abstract class ModelHandler<
         );
         return accessToken;
       }
-      // This should not happen if shouldUseServerSideKeys returned true,
-      // but fall through to normal API key retrieval just in case
-      this.logger.warn(
-        'Server-side keys check passed but no access token available, falling back to local keys',
+      // No access token available - this shouldn't happen if shouldUseServerSideKeys returned true
+      // Since useIncludedAccess must be true here (checked in shouldUseServerSideKeys),
+      // throw an error instead of falling back to personal keys
+      throw new Error(
+        'Unable to authenticate with server. Please sign out and sign back in, or switch to "Use My Own Keys" mode.',
       );
     } else if (useIncludedAccess) {
       // User selected "Use Included Access" but model is not available for their tier
       // Don't fall back to personal API keys - throw an error to match dropdown behavior
+      this.logger.debug(
+        `Model "${this.config.name}" not available for tier, useIncludedAccess=true`,
+      );
       throw new Error(
         `Model "${this.config.name}" is not available with your current subscription tier. ` +
-          `Switch to "Use My Own Keys" in the profile settings, or select a model included in your tier.`,
+          `Switch to "Use My Own Keys" via the TeXRA Profile panel, or select a model included in your tier.`,
       );
     }
 

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -279,7 +279,21 @@ export abstract class ModelHandler<
       throw new Error(
         'Unable to authenticate with server. Please sign out and sign back in, or switch to "Use My Own Keys" mode.',
       );
-    } else if (useIncludedAccess) {
+    }
+
+    // openRouterOnly models can NEVER use server-side relay - they always need OpenRouter key.
+    // Allow these even in "Use Included Access" mode since included access is never possible.
+    if (this.config.openRouterOnly) {
+      try {
+        return await SecretManager.getApiKey('openRouter');
+      } catch (err) {
+        throw new Error(
+          `Model "${this.config.name}" requires an OpenRouter API key. Please set it using the "Set API Key" command.`,
+        );
+      }
+    }
+
+    if (useIncludedAccess) {
       // User selected "Use Included Access" but model is not available for their tier
       // Don't fall back to personal API keys - throw an error to match dropdown behavior
       this.logger.debug(

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -255,9 +255,16 @@ export abstract class ModelHandler<
    * Retrieves API key from environment variables based on provider and OpenRouter configuration.
    * When server-side keys are enabled (experimental), returns the user's JWT token instead,
    * which the relay Edge Function will use for authentication.
+   *
+   * When "Use Included Access" is enabled, only server-side keys are used - no fallback
+   * to personal API keys. This ensures runtime behavior matches dropdown availability.
+   *
    * @throws Error if required API key is missing from environment
    */
   public async getApiKey(): Promise<string> {
+    const serverSideKeyService = getServerSideKeyService();
+    const useIncludedAccess = serverSideKeyService.getUseIncludedModelAccess();
+
     // Use centralized check to ensure consistency with getBaseUrl()
     if (this.shouldUseServerSideKeys()) {
       const accessToken = await SupabaseClient.getAccessToken();
@@ -271,6 +278,13 @@ export abstract class ModelHandler<
       // but fall through to normal API key retrieval just in case
       this.logger.warn(
         'Server-side keys check passed but no access token available, falling back to local keys',
+      );
+    } else if (useIncludedAccess) {
+      // User selected "Use Included Access" but model is not available for their tier
+      // Don't fall back to personal API keys - throw an error to match dropdown behavior
+      throw new Error(
+        `Model "${this.config.name}" is not available with your current subscription tier. ` +
+          `Switch to "Use My Own Keys" in the profile settings, or select a model included in your tier.`,
       );
     }
 

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -274,9 +274,8 @@ export abstract class ModelHandler<
         );
         return accessToken;
       }
-      // No access token available - this shouldn't happen if shouldUseServerSideKeys returned true
-      // Since useIncludedAccess must be true here (checked in shouldUseServerSideKeys),
-      // throw an error instead of falling back to personal keys
+      // No access token available - shouldUseServerSideKeys() returned true, meaning isEnabled()
+      // returned true. Don't fall back to personal keys - throw an actionable error.
       throw new Error(
         'Unable to authenticate with server. Please sign out and sign back in, or switch to "Use My Own Keys" mode.',
       );

--- a/src/auth/serverKeys/ServerSideKeyService.ts
+++ b/src/auth/serverKeys/ServerSideKeyService.ts
@@ -24,6 +24,7 @@ import {
 import type { TierService } from '../tier/TierService';
 import type { ServerSideProvider } from './types';
 import * as logger from '@logger/logUtils';
+import { getConfig, updateConfig } from '@utils/config';
 
 const CHANNEL = 'ServerSideKeyService';
 
@@ -167,7 +168,7 @@ export class ServerSideKeyService {
 
   /**
    * Set the "use included model access" preference.
-   * When enabling, pre-fetches providers and tier config.
+   * When enabling, pre-fetches providers and tier config, and syncs allowed models.
    */
   async setUseIncludedModelAccess(value: boolean): Promise<void> {
     const changed = this.useIncludedModelAccess !== value;
@@ -183,6 +184,8 @@ export class ServerSideKeyService {
       // Pre-fetch tier config (which includes providers) when enabling
       if (value) {
         await this.tierService.getConfig();
+        // Sync allowed models to user's config so dropdown shows tier models
+        await this.canUseServerSideKeys();
       }
 
       this._onDidChangeModelAccess.fire(value);
@@ -328,6 +331,9 @@ export class ServerSideKeyService {
       if (hasAccess && providers.length > 0) {
         this.accessTimestamp = Date.now();
         this._isCachePrimed = true;
+
+        // Sync allowed models to user's texra.models config (fire-and-forget)
+        void this.syncAllowedModelsToConfig();
       }
 
       return hasAccess && providers.length > 0;
@@ -451,6 +457,48 @@ export class ServerSideKeyService {
    */
   getAccessExpirationDate(): Date | null {
     return this.tierService.getExpirationDate();
+  }
+
+  // ==========================================================================
+  // Model List Sync
+  // ==========================================================================
+
+  /**
+   * Sync allowed models from tier config into the user's texra.models list.
+   * This ensures the model dropdown includes all models available in the user's tier.
+   *
+   * Only adds missing models - never removes user's existing selections.
+   * Call canUseServerSideKeys() first to prime caches.
+   */
+  async syncAllowedModelsToConfig(): Promise<void> {
+    // Only sync when using included access
+    if (!this.isEnabled()) {
+      return;
+    }
+
+    const allowedModels = this.getAllowedModelsForCurrentUser();
+
+    // null means all models (Ultra tier) - no sync needed
+    // empty array means error or no access - don't modify user's list
+    if (allowedModels === null || allowedModels.length === 0) {
+      return;
+    }
+
+    const currentModels = getConfig<string[]>('texra.models', []);
+    const modelsToAdd = allowedModels.filter(
+      (model) => !currentModels.includes(model),
+    );
+
+    if (modelsToAdd.length > 0) {
+      const mergedModels = [...currentModels, ...modelsToAdd];
+      await updateConfig('texra.models', mergedModels, {
+        target: vscode.ConfigurationTarget.Global,
+      });
+      logger.info(
+        CHANNEL,
+        `Synced ${modelsToAdd.length} tier-allowed models to config: ${modelsToAdd.join(', ')}`,
+      );
+    }
   }
 
   // ==========================================================================

--- a/src/auth/serverKeys/ServerSideKeyService.ts
+++ b/src/auth/serverKeys/ServerSideKeyService.ts
@@ -24,7 +24,6 @@ import {
 import type { TierService } from '../tier/TierService';
 import type { ServerSideProvider } from './types';
 import * as logger from '@logger/logUtils';
-import { getConfig, updateConfig } from '@utils/config';
 
 const CHANNEL = 'ServerSideKeyService';
 
@@ -168,7 +167,7 @@ export class ServerSideKeyService {
 
   /**
    * Set the "use included model access" preference.
-   * When enabling, pre-fetches providers and tier config, and syncs allowed models.
+   * When enabling, pre-fetches providers and tier config.
    */
   async setUseIncludedModelAccess(value: boolean): Promise<void> {
     const changed = this.useIncludedModelAccess !== value;
@@ -184,8 +183,6 @@ export class ServerSideKeyService {
       // Pre-fetch tier config (which includes providers) when enabling
       if (value) {
         await this.tierService.getConfig();
-        // Sync allowed models to user's config so dropdown shows tier models
-        await this.canUseServerSideKeys();
       }
 
       this._onDidChangeModelAccess.fire(value);
@@ -331,9 +328,6 @@ export class ServerSideKeyService {
       if (hasAccess && providers.length > 0) {
         this.accessTimestamp = Date.now();
         this._isCachePrimed = true;
-
-        // Sync allowed models to user's texra.models config (fire-and-forget)
-        void this.syncAllowedModelsToConfig();
       }
 
       return hasAccess && providers.length > 0;
@@ -457,48 +451,6 @@ export class ServerSideKeyService {
    */
   getAccessExpirationDate(): Date | null {
     return this.tierService.getExpirationDate();
-  }
-
-  // ==========================================================================
-  // Model List Sync
-  // ==========================================================================
-
-  /**
-   * Sync allowed models from tier config into the user's texra.models list.
-   * This ensures the model dropdown includes all models available in the user's tier.
-   *
-   * Only adds missing models - never removes user's existing selections.
-   * Call canUseServerSideKeys() first to prime caches.
-   */
-  async syncAllowedModelsToConfig(): Promise<void> {
-    // Only sync when using included access
-    if (!this.isEnabled()) {
-      return;
-    }
-
-    const allowedModels = this.getAllowedModelsForCurrentUser();
-
-    // null means all models (Ultra tier) - no sync needed
-    // empty array means error or no access - don't modify user's list
-    if (allowedModels === null || allowedModels.length === 0) {
-      return;
-    }
-
-    const currentModels = getConfig<string[]>('texra.models', []);
-    const modelsToAdd = allowedModels.filter(
-      (model) => !currentModels.includes(model),
-    );
-
-    if (modelsToAdd.length > 0) {
-      const mergedModels = [...currentModels, ...modelsToAdd];
-      await updateConfig('texra.models', mergedModels, {
-        target: vscode.ConfigurationTarget.Global,
-      });
-      logger.info(
-        CHANNEL,
-        `Synced ${modelsToAdd.length} tier-allowed models to config: ${modelsToAdd.join(', ')}`,
-      );
-    }
   }
 
   // ==========================================================================

--- a/src/model/computeModelOptions.ts
+++ b/src/model/computeModelOptions.ts
@@ -113,10 +113,16 @@ export async function computeModelOptions(): Promise<string> {
 
       let available = hasServerSideForModel;
 
-      // Only check personal keys if:
+      // openRouterOnly models can NEVER use server-side relay - they always need OpenRouter key.
+      // Allow these even in "Use Included Access" mode since included access is never possible.
+      if (!available && config.openRouterOnly) {
+        available = hasOpenRouter;
+      }
+
+      // For other models, only check personal keys if:
       // 1. Not available via server-side, AND
       // 2. User has NOT selected "Use Included Access" (i.e., using personal keys mode)
-      if (!available && !useIncludedAccess) {
+      if (!available && !useIncludedAccess && !config.openRouterOnly) {
         available = await checkPersonalKeyAvailability(config, hasOpenRouter);
       }
 

--- a/src/model/computeModelOptions.ts
+++ b/src/model/computeModelOptions.ts
@@ -29,6 +29,44 @@ function formatCost(inputPrice?: number, outputPrice?: number): string {
 }
 
 /**
+ * Check if a model is available via personal API keys.
+ * Called only when server-side access is not available and user is in "Use My Own Keys" mode.
+ *
+ * @param config - Model configuration
+ * @param hasOpenRouter - Whether user has OpenRouter API key
+ * @returns Whether the model is available via personal keys
+ */
+async function checkPersonalKeyAvailability(
+  config: { openRouterOnly?: boolean; openrouterFullName?: string; provider: string },
+  hasOpenRouter: boolean,
+): Promise<boolean> {
+  // openRouterOnly models can ONLY use OpenRouter
+  if (config.openRouterOnly) {
+    return hasOpenRouter;
+  }
+
+  const provider = config.provider;
+
+  // Check provider-specific API key
+  if (SecretManager.API_PROVIDERS.includes(provider as ApiProvider)) {
+    try {
+      const hasProviderKey = await SecretManager.apiKeyExists(provider as ApiProvider);
+      if (hasProviderKey) {
+        return true;
+      }
+      // Check OpenRouter as fallback for models that support it
+      return !!(config.openrouterFullName && hasOpenRouter);
+    } catch (error) {
+      console.warn(`Failed to check API key for ${provider}:`, error);
+      return false;
+    }
+  }
+
+  // Providers not in API_PROVIDERS don't require keys (e.g., COPILOT)
+  return true;
+}
+
+/**
  * Compute model <vscode-option> tags based on available API keys.
  * Models missing a required key receive data-requires-key="true" so the
  * webview can handle API key setup prompts and display a red ✗ indicator.
@@ -79,27 +117,7 @@ export async function computeModelOptions(): Promise<string> {
       // 1. Not available via server-side, AND
       // 2. User has NOT selected "Use Included Access" (i.e., using personal keys mode)
       if (!available && !useIncludedAccess) {
-        if (config.openRouterOnly) {
-          // openRouterOnly models can ONLY use OpenRouter - check that key exists
-          available = hasOpenRouter;
-        } else if (SecretManager.API_PROVIDERS.includes(provider as ApiProvider)) {
-          // Check provider-specific API key
-          try {
-            available = await SecretManager.apiKeyExists(
-              provider as ApiProvider,
-            );
-          } catch (error) {
-            console.warn(`Failed to check API key for ${provider}:`, error);
-          }
-
-          // Check OpenRouter as fallback for models that support it
-          if (!available && config.openrouterFullName && hasOpenRouter) {
-            available = true;
-          }
-        } else {
-          // Providers not in API_PROVIDERS don't require keys (e.g., COPILOT)
-          available = true;
-        }
+        available = await checkPersonalKeyAvailability(config, hasOpenRouter);
       }
 
       // Build option tag with data attributes

--- a/src/model/computeModelOptions.ts
+++ b/src/model/computeModelOptions.ts
@@ -66,8 +66,10 @@ export async function computeModelOptions(): Promise<string> {
       const provider = config.provider;
 
       // Determine availability - server-side checks are sync after priming
+      // Note: openRouterOnly models can't use server-side relay (they need OpenRouter API)
       const hasServerSideForModel =
         hasAnyServerSideAccess &&
+        !config.openRouterOnly &&
         serverSideKeyService.isProviderOnServer(provider) &&
         serverSideKeyService.canUseModelSync(model);
 
@@ -77,7 +79,11 @@ export async function computeModelOptions(): Promise<string> {
       // 1. Not available via server-side, AND
       // 2. User has NOT selected "Use Included Access" (i.e., using personal keys mode)
       if (!available && !useIncludedAccess) {
-        if (SecretManager.API_PROVIDERS.includes(provider as ApiProvider)) {
+        if (config.openRouterOnly) {
+          // openRouterOnly models can ONLY use OpenRouter - check that key exists
+          available = hasOpenRouter;
+        } else if (SecretManager.API_PROVIDERS.includes(provider as ApiProvider)) {
+          // Check provider-specific API key
           try {
             available = await SecretManager.apiKeyExists(
               provider as ApiProvider,
@@ -85,13 +91,13 @@ export async function computeModelOptions(): Promise<string> {
           } catch (error) {
             console.warn(`Failed to check API key for ${provider}:`, error);
           }
-        } else {
-          // Providers not in API_PROVIDERS don't require keys (e.g., OTHERS, COPILOT)
-          available = true;
-        }
 
-        // Check OpenRouter as fallback
-        if (!available && config.openrouterFullName && hasOpenRouter) {
+          // Check OpenRouter as fallback for models that support it
+          if (!available && config.openrouterFullName && hasOpenRouter) {
+            available = true;
+          }
+        } else {
+          // Providers not in API_PROVIDERS don't require keys (e.g., COPILOT)
           available = true;
         }
       }

--- a/src/model/computeModelOptions.ts
+++ b/src/model/computeModelOptions.ts
@@ -37,6 +37,9 @@ function formatCost(inputPrice?: number, outputPrice?: number): string {
  * - Ultra tier: All models available via relay (if provider enabled)
  * - Max tier: Only specific cheaper models available via relay (configured remotely)
  * - Free tier: Must bring own API keys
+ *
+ * When "Use Included Access" is enabled, only server-side availability is checked.
+ * When "Use My Own Keys" is selected, personal API keys are checked as fallback.
  */
 export async function computeModelOptions(): Promise<string> {
   const models = getConfig<string[]>('texra.models', []);
@@ -47,6 +50,9 @@ export async function computeModelOptions(): Promise<string> {
   const serverSideKeyService = getServerSideKeyService();
   const hasAnyServerSideAccess =
     await serverSideKeyService.canUseServerSideKeys();
+
+  // Check if user wants to use included access (no personal key fallback)
+  const useIncludedAccess = serverSideKeyService.getUseIncludedModelAccess();
 
   // Build option tags for each model
   // Server-side checks are sync (caches primed above), personal key checks are async
@@ -67,8 +73,10 @@ export async function computeModelOptions(): Promise<string> {
 
       let available = hasServerSideForModel;
 
-      // Only check personal keys if not available via server-side
-      if (!available) {
+      // Only check personal keys if:
+      // 1. Not available via server-side, AND
+      // 2. User has NOT selected "Use Included Access" (i.e., using personal keys mode)
+      if (!available && !useIncludedAccess) {
         if (SecretManager.API_PROVIDERS.includes(provider as ApiProvider)) {
           try {
             available = await SecretManager.apiKeyExists(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Align runtime behavior with model availability**
> 
> - Enforces "Use Included Access" mode in `ModelHandler.getApiKey()`: uses server-side relay only, throws if access token missing, and does not fall back to personal API keys
> - Adds explicit handling for `openRouterOnly` models: always require OpenRouter key (allowed even in included-access mode)
> - Updates `computeModelOptions()` to respect `useIncludedAccess`, exclude server-side for `openRouterOnly`, and use a new `checkPersonalKeyAvailability` helper to gate personal-key fallback only when appropriate
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ac584df4711e1af8ae15a858646bf1a40c937538. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->