### PR TITLE
Consolidate duplicate webview reference fetching

### DIFF
--- a/src/agent/remote/remoteAgentUtils.ts
+++ b/src/agent/remote/remoteAgentUtils.ts
@@ -8,6 +8,9 @@ import { AgentCategory } from '@agent/core/AgentDataclass';
 // Local imports - common
 import { MAIN_VIEW_COMMANDS } from '@common/webview';
 
+// Local imports - frontend
+import { getMainWebview } from '@frontend/system/commandUtils';
+
 // Local imports - logger
 import * as logger from '@logger/logUtils';
 
@@ -92,9 +95,7 @@ export async function selectAgentInMainView(
   await sleep(100);
 
   try {
-    const webviewView = await vscode.commands.executeCommand<
-      vscode.WebviewView | undefined
-    >('texra.getWebviewView');
+    const webviewView = await getMainWebview(CHANNEL);
 
     if (webviewView) {
       // Determine session type based on agent category

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -44,6 +44,7 @@ import { MAIN_VIEW_COMMANDS } from '@common/webview/commands';
 import { toErrorMessage } from '@common/errors/errorHandlingUtils';
 import { getSdkErrorMessage } from '@common/errors/sdkErrorUtils';
 import { showInstructionWithSuppress } from '@frontend/ui/instruction';
+import { getMainWebview } from '@frontend/system/commandUtils';
 import { AgentLogger } from '@logger/AgentLogger';
 import { MODEL_CONFIGS } from '@model/ModelRegistry';
 import { agentConfigToTaskState } from '@utils/config';
@@ -107,9 +108,7 @@ export async function getAgentPath(
   const result = resolveAgent(agentIdentifier, options?.preferMultiple);
   if (result) return result;
 
-  const view = await vscode.commands.executeCommand<vscode.WebviewView>(
-    'texra.getWebviewView',
-  );
+  const view = await getMainWebview(CHANNEL);
   view?.webview.postMessage({
     command: MAIN_VIEW_COMMANDS.SHOW_AGENT_CONFIG_BANNER,
     agentName: agentIdentifier,

--- a/src/commands/api/apiKeyCommands.ts
+++ b/src/commands/api/apiKeyCommands.ts
@@ -4,6 +4,7 @@ import * as vscode from 'vscode';
 // Local imports
 import { MAIN_VIEW_COMMANDS } from '@common/webview';
 import { SecretManager, ApiProvider } from '@frontend/secretManager';
+import { getMainWebview } from '@frontend/system/commandUtils';
 
 export const PROVIDER_URLS: Record<ApiProvider, string> = {
   openai: 'https://platform.openai.com/api-keys',
@@ -66,9 +67,7 @@ async function setApiKeyForProvider(
     await vscode.commands.executeCommand('texra.refreshApiKeyStatus');
     // Refresh both model and agent options (model availability may change)
     void vscode.commands.executeCommand('texra.refreshAllOptions');
-    const view = await vscode.commands.executeCommand<vscode.WebviewView>(
-      'texra.getWebviewView',
-    );
+    const view = await getMainWebview();
     view?.webview.postMessage({
       command: MAIN_VIEW_COMMANDS.HIDE_API_KEY_BANNER,
     });
@@ -129,9 +128,7 @@ export function registerApiKeyCommands(context: vscode.ExtensionContext) {
         // Refresh both model and agent options (model availability may change)
         void vscode.commands.executeCommand('texra.refreshAllOptions');
         const any = await SecretManager.anyApiKeyExists();
-        const view = await vscode.commands.executeCommand<vscode.WebviewView>(
-          'texra.getWebviewView',
-        );
+        const view = await getMainWebview();
         view?.webview.postMessage({
           command: any
             ? MAIN_VIEW_COMMANDS.HIDE_API_KEY_BANNER

--- a/src/commands/history/stateRestoreCommand.ts
+++ b/src/commands/history/stateRestoreCommand.ts
@@ -6,6 +6,7 @@ import { showLoggedErrorMessage, toErrorMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
 import type { TaskState } from '@logger/TaskState';
 import { setPendingState } from '@common/state';
+import { getMainWebview } from '@frontend/system/commandUtils';
 // Type imports
 
 const CHANNEL = 'stateRestoreCommand';
@@ -36,10 +37,7 @@ async function restoreState(state: TaskState) {
 
     // Try to get the webview directly using our safe command
     try {
-      const webviewView =
-        await vscode.commands.executeCommand<vscode.WebviewView>(
-          'texra.getWebviewView',
-        );
+      const webviewView = await getMainWebview(CHANNEL);
 
       if (webviewView) {
         // Send the state directly to the webview

--- a/src/commands/system/mainViewCommands.ts
+++ b/src/commands/system/mainViewCommands.ts
@@ -4,7 +4,7 @@ import * as vscode from 'vscode';
 // Local imports
 import { computeAgentOptions, refresh } from '@agent/index';
 import { MAIN_VIEW_COMMANDS } from '@common/webview';
-import { safeExecuteCommand } from '@frontend/system/commandUtils';
+import { getMainWebview } from '@frontend/system/commandUtils';
 import * as logger from '@logger/logUtils';
 import { computeModelOptions } from '@model/computeModelOptions';
 
@@ -16,17 +16,6 @@ export const mainViewCommands = {
   refreshAgentOptions: 'texra.refreshAgentOptions',
   refreshAllOptions: 'texra.refreshAllOptions',
 };
-
-/**
- * Get the main webview view instance.
- */
-async function getMainWebview(): Promise<vscode.WebviewView | undefined> {
-  return safeExecuteCommand<vscode.WebviewView>(
-    'texra.getWebviewView',
-    [],
-    CHANNEL,
-  );
-}
 
 /**
  * Log a refresh error and notify the user.
@@ -46,11 +35,7 @@ export function registerMainViewCommands(context: vscode.ExtensionContext) {
   const resetCommand = vscode.commands.registerCommand(
     mainViewCommands.reset,
     async () => {
-      const webviewView = await safeExecuteCommand<vscode.WebviewView>(
-        'texra.getWebviewView',
-        [],
-        'mainViewCommands',
-      );
+      const webviewView = await getMainWebview(CHANNEL);
 
       if (webviewView) {
         webviewView.webview.postMessage({
@@ -72,7 +57,7 @@ export function registerMainViewCommands(context: vscode.ExtensionContext) {
   const refreshModelOptionsCommand = vscode.commands.registerCommand(
     mainViewCommands.refreshModelOptions,
     async () => {
-      const webview = await getMainWebview();
+      const webview = await getMainWebview(CHANNEL);
       if (!webview) return;
 
       try {
@@ -93,7 +78,7 @@ export function registerMainViewCommands(context: vscode.ExtensionContext) {
   const refreshAgentOptionsCommand = vscode.commands.registerCommand(
     mainViewCommands.refreshAgentOptions,
     async () => {
-      const webview = await getMainWebview();
+      const webview = await getMainWebview(CHANNEL);
       if (!webview) return;
 
       try {
@@ -117,7 +102,7 @@ export function registerMainViewCommands(context: vscode.ExtensionContext) {
   const refreshAllOptionsCommand = vscode.commands.registerCommand(
     mainViewCommands.refreshAllOptions,
     async () => {
-      const webview = await getMainWebview();
+      const webview = await getMainWebview(CHANNEL);
       if (!webview) return;
 
       try {

--- a/src/frontend/system/commandUtils.ts
+++ b/src/frontend/system/commandUtils.ts
@@ -30,3 +30,18 @@ export async function safeExecuteCommand<T>(
     return undefined;
   }
 }
+
+/**
+ * Get the main webview view instance.
+ * @param channel Optional channel for logging errors
+ * @returns The webview view or undefined if not available
+ */
+export async function getMainWebview(
+  channel: string = CHANNEL,
+): Promise<vscode.WebviewView | undefined> {
+  return safeExecuteCommand<vscode.WebviewView>(
+    'texra.getWebviewView',
+    [],
+    channel,
+  );
+}


### PR DESCRIPTION
Extract duplicate webview fetching pattern into a single getMainWebview() helper function in commandUtils.ts. This reduces code duplication across 6 files and provides consistent error handling for webview access.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Centralizes main webview retrieval behind a single `getMainWebview()` helper with consistent error handling, and updates all call sites to use it.
> 
> - Adds `getMainWebview(channel?)` in `frontend/system/commandUtils.ts` built on `safeExecuteCommand`
> - Replaces direct `vscode.commands.executeCommand('texra.getWebviewView')` usages in `remoteAgentUtils.ts`, `executeAgent.ts`, `apiKeyCommands.ts`, `stateRestoreCommand.ts`, and `mainViewCommands.ts`
> - Removes a local duplicate getter in `mainViewCommands.ts` and switches to the shared helper
> - Minor: pass `CHANNEL` to helper where available for scoped logging
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4422f27ecbbf0b026956f0bfb00282a752551af4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->