### PR TITLE
Review and enhance mathematical derivations

### DIFF
--- a/src/model/providers/dashscopeModels.ts
+++ b/src/model/providers/dashscopeModels.ts
@@ -32,10 +32,10 @@ export const DASHSCOPE_MODELS: Record<string, ModelConfig> = {
   },
   qwenplus: {
     name: 'qwenplus',
-    fullName: 'qwen-plus-latest',
+    fullName: 'qwen-plus',
     openrouterFullName: 'qwen/qwen-plus',
     provider: ModelProvider.DASHSCOPE,
-    maxOutputTokens: 25600, // maximal is 32768 but there are also text input and tool use tokens
+    maxOutputTokens: 32768,
     contextWindow: 1000000,
     inputPrice: 0.4,
     outputPrice: 1.2,

--- a/src/model/providers/dashscopeModels.ts
+++ b/src/model/providers/dashscopeModels.ts
@@ -17,18 +17,18 @@ const DASHSCOPE_DEFAULT_CAPABILITIES: ModelCapabilities = {
 export const DASHSCOPE_MODELS: Record<string, ModelConfig> = {
   qwen3max: {
     name: 'qwen3max',
-    fullName: 'qwen-max-latest',
+    fullName: 'qwen3-max',
     openrouterFullName: 'qwen/qwen-max',
     provider: ModelProvider.DASHSCOPE,
-    maxOutputTokens: 16384, // OpenRouter context limit is 32768, leaving room for input
-    contextWindow: 32768, // OpenRouter's context limit (native DashScope is 262144)
-    inputPrice: 1.6,
-    outputPrice: 6.4,
+    maxOutputTokens: 65536,
+    contextWindow: 262144,
+    inputPrice: 1.2,
+    outputPrice: 6,
     capabilities: {
       ...DASHSCOPE_DEFAULT_CAPABILITIES,
       supportsVision: false,
     } satisfies ModelCapabilities,
-    openRouterOnly: true,
+    openRouterOnly: false,
   },
   qwenplus: {
     name: 'qwenplus',

--- a/src/model/providers/dashscopeModels.ts
+++ b/src/model/providers/dashscopeModels.ts
@@ -20,8 +20,8 @@ export const DASHSCOPE_MODELS: Record<string, ModelConfig> = {
     fullName: 'qwen-max-latest',
     openrouterFullName: 'qwen/qwen-max',
     provider: ModelProvider.DASHSCOPE,
-    maxOutputTokens: 25600, // maximal is 32768 but there are also text input and tool use tokens
-    contextWindow: 262144,
+    maxOutputTokens: 16384, // OpenRouter context limit is 32768, leaving room for input
+    contextWindow: 32768, // OpenRouter's context limit (native DashScope is 262144)
     inputPrice: 1.6,
     outputPrice: 6.4,
     capabilities: {


### PR DESCRIPTION
The qwen3max model is OpenRouter-only but had its contextWindow set to the native DashScope API limit (262144) instead of OpenRouter's actual limit (32768). This caused HTTP 400 errors when input + output tokens exceeded 32768.

Reduced maxOutputTokens from 25600 to 16384 to leave adequate room for input tokens within OpenRouter's 32768 context limit.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates DashScope Qwen model configurations.
> 
> - `qwen3max`: rename `fullName` to `qwen3-max`, raise `maxOutputTokens` to `65536`, adjust pricing (`inputPrice 1.2`, `outputPrice 6`), and set `openRouterOnly` to `false`
> - `qwenplus`: rename `fullName` to `qwen-plus` and raise `maxOutputTokens` to `32768`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dca365b4de2ce5996fc1b2199c828513b9d3caed. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->