### PR TITLE
Debug continue logic skipping first round

### DIFF
--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -268,28 +268,10 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
       this.outputHandler.setActiveRun(params.storageKey);
     }
 
-    // Sort rounds for consistent ordering
+    // Track how many rounds were completed in the previous run.
+    // The actual roundOutputs and outputHandler.rounds will be repopulated
+    // during replay as each round goes through OutputNode.
     const sortedRounds = Array.from(params.rounds.keys()).sort((a, b) => a - b);
-
-    // Create RoundOutput objects directly in agent.roundOutputs[] (canonical storage)
-    // Also hydrate OutputHandler's rounds map for latexdiff to work after resume
-    for (const round of sortedRounds) {
-      const savedOutputs = params.rounds.get(round) ?? [];
-      this.roundOutputs[round] = {
-        round,
-        rawOutput: null, // Not available from saved state
-        outputs: savedOutputs,
-        xmlSummary: {
-          tagContents: {},
-          documents: [],
-          singleOutputFile: null,
-          sourceLocation: null,
-        },
-      };
-      // Hydrate OutputHandler so getRoundMapping works for latexdiff
-      this.outputHandler.hydrateRound(round, savedOutputs);
-    }
-
     this.hydratedRoundCount = sortedRounds.length;
   }
 
@@ -411,11 +393,11 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
       // Check hydration state AFTER startAndInitRun (which calls hydrateFromResume)
       previousHydratedRounds = this.hydratedRoundCount;
       const hadHydratedRounds = previousHydratedRounds > 0;
-      // For new runs: clear roundOutputs to start fresh
-      // For resumed runs: preserve hydrated roundOutputs for latexdiff comparisons
-      if (!hadHydratedRounds) {
-        this.roundOutputs = [];
-      } else {
+
+      // Always start fresh - roundOutputs will be repopulated during replay
+      this.roundOutputs = [];
+
+      if (hadHydratedRounds) {
         // Inform user that previous rounds will be replayed from saved outputs
         this.logger.info(
           `Resuming from previous run - replaying ${previousHydratedRounds} completed round(s)`,
@@ -437,13 +419,11 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
       });
 
       // Create shared state for the flow (no lifecycle - errors thrown directly)
-      // Pass hydrated outputs to preserve them during resume
       shared = {
         agent: this,
         state: createInitialReflectionState(
           totalRounds,
           AgentWorkspaceState.create(),
-          hadHydratedRounds ? this.roundOutputs : undefined,
         ),
         retryState: createRetryState(),
         runStage: this.runStage,

--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -411,6 +411,8 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
       // Check hydration state AFTER startAndInitRun (which calls hydrateFromResume)
       previousHydratedRounds = this.hydratedRoundCount;
       const hadHydratedRounds = previousHydratedRounds > 0;
+      // For new runs: clear roundOutputs to start fresh
+      // For resumed runs: preserve hydrated roundOutputs for latexdiff comparisons
       if (!hadHydratedRounds) {
         this.roundOutputs = [];
       }
@@ -422,12 +424,10 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
         throw new Error('Run stage required for reflection agent.');
       }
 
-      // Determine starting round from hydrated outputs (for resume)
-      const startingRound = hadHydratedRounds ? this.roundOutputs.length : 0;
-
-      // Create initial round stage for UI grouping (r0, r1, etc.)
-      const roundStageName = `r${startingRound}`;
-      const roundStage = await this.logger.stage(roundStageName, {
+      // Always start from round 0, even on resume.
+      // Completed rounds are "replayed" via initializeOutputAndPrefill()
+      // which reads existing output files instead of calling the model.
+      const roundStage = await this.logger.stage('r0', {
         parent: this.runStage,
       });
 

--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -40,13 +40,8 @@ import { AgentExecutionContext } from '@agent/runtime/AgentExecutionContext';
 import { normalizeRunId } from '@common/constants/runIds';
 import { END_GROUP_STATUS, type EndGroupStatus } from '@logger/messageTypes';
 import { PromptBuilder } from '@utils/prompt';
-import {
-  TaskRunFileService,
-  flexibleFS,
-  type AgentFileLocation,
-} from '@utils/files';
+import { TaskRunFileService, type AgentFileLocation } from '@utils/files';
 import { LatexMediaManager } from '@latex';
-import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
 
 /**
  * Parameters for resuming a reflection agent from saved state.
@@ -280,12 +275,9 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
     // Also hydrate OutputHandler's rounds map for latexdiff to work after resume
     for (const round of sortedRounds) {
       const savedOutputs = params.rounds.get(round) ?? [];
-      // Reconstruct raw output location - the file should still exist on disk
-      // Use the same logic as getOutputFileLocation() to get the path
-      const rawOutputLocation = this.getOutputFileLocation(round);
       this.roundOutputs[round] = {
         round,
-        rawOutput: rawOutputLocation,
+        rawOutput: null, // Not available from saved state
         outputs: savedOutputs,
         xmlSummary: {
           tagContents: {},
@@ -299,92 +291,6 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
     }
 
     this.hydratedRoundCount = sortedRounds.length;
-  }
-
-  /**
-   * Reconstruct conversation history from hydrated round outputs.
-   *
-   * On resume, the conversation array is empty but we have completed round outputs.
-   * This method rebuilds the conversation by:
-   * 1. Reading assistant responses from raw output files
-   * 2. Building user messages via promptBuilder
-   *
-   * This enables multi-round agents to continue from where they left off with
-   * full context of previous rounds.
-   *
-   * @returns The reconstructed conversation messages, or empty array if reconstruction fails
-   */
-  private async reconstructConversation(): Promise<ProviderMessage[]> {
-    if (this.roundOutputs.length === 0) {
-      return [];
-    }
-
-    const promptBuilder = this.getPromptBuilder();
-    const conversation: ProviderMessage[] = [];
-
-    for (let round = 0; round < this.roundOutputs.length; round++) {
-      const roundOutput = this.roundOutputs[round];
-      if (!roundOutput?.rawOutput) {
-        this.logger.warn(
-          `Cannot reconstruct conversation: missing rawOutput for round ${round}`,
-        );
-        return [];
-      }
-
-      try {
-        // Read assistant response from raw output file
-        const rawOutputPath = roundOutput.rawOutput.absolutePath;
-        const fileExists = await flexibleFS.exists(roundOutput.rawOutput);
-        if (!fileExists) {
-          this.logger.warn(
-            `Cannot reconstruct conversation: raw output file not found for round ${round}: ${rawOutputPath}`,
-          );
-          return [];
-        }
-
-        const assistantResponse = await flexibleFS.read(roundOutput.rawOutput);
-
-        if (round === 0) {
-          // First round: build initial prompts and add user message
-          const { systemPrompt, userRequest, userPrefix } =
-            await promptBuilder.buildInitialPrompts();
-
-          // Initialize messages with user message (similar to PrepareContextNode)
-          const messages = await this.modelHandler.initializeMessages(
-            userPrefix,
-            userRequest,
-            undefined,
-            systemPrompt,
-          );
-          conversation.push(...messages);
-        } else {
-          // Subsequent rounds: build user request only
-          const userRequest = await promptBuilder.buildUserRequest(round);
-          if (userRequest?.trim()) {
-            await this.modelHandler.createRoundMessages(
-              conversation,
-              userRequest,
-              undefined,
-            );
-          }
-        }
-
-        // Add assistant response
-        const assistantMessage =
-          this.modelHandler.createAssistantMessage(assistantResponse);
-        conversation.push(assistantMessage);
-      } catch (error) {
-        this.logger.warn(
-          `Failed to reconstruct conversation for round ${round}: ${error}`,
-        );
-        return [];
-      }
-    }
-
-    this.logger.debug(
-      `Reconstructed conversation with ${conversation.length} messages from ${this.roundOutputs.length} rounds`,
-    );
-    return conversation;
   }
 
   protected getPromptBuilder(): PromptBuilder {
@@ -509,13 +415,6 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
         this.roundOutputs = [];
       }
 
-      // Reconstruct conversation from hydrated rounds if resuming
-      // This enables multi-round agents to continue with full context
-      let initialConversation: ProviderMessage[] | undefined;
-      if (hadHydratedRounds) {
-        initialConversation = await this.reconstructConversation();
-      }
-
       const totalRounds = this.getTotalRounds();
 
       // Ensure we have a run stage for round grouping
@@ -533,15 +432,14 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
       });
 
       // Create shared state for the flow (no lifecycle - errors thrown directly)
-      // Pass hydrated outputs and reconstructed conversation to preserve context during resume
+      // Pass hydrated outputs to preserve them during resume
       shared = {
         agent: this,
-        state: createInitialReflectionState({
+        state: createInitialReflectionState(
           totalRounds,
-          initialWorkspaceState: AgentWorkspaceState.create(),
-          hydratedOutputs: hadHydratedRounds ? this.roundOutputs : undefined,
-          initialConversation,
-        }),
+          AgentWorkspaceState.create(),
+          hadHydratedRounds ? this.roundOutputs : undefined,
+        ),
         retryState: createRetryState(),
         runStage: this.runStage,
       };

--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -415,6 +415,11 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
       // For resumed runs: preserve hydrated roundOutputs for latexdiff comparisons
       if (!hadHydratedRounds) {
         this.roundOutputs = [];
+      } else {
+        // Inform user that previous rounds will be replayed from saved outputs
+        this.logger.info(
+          `Resuming from previous run - replaying ${previousHydratedRounds} completed round(s)`,
+        );
       }
 
       const totalRounds = this.getTotalRounds();

--- a/src/agent/implementations/BaseReflectionAgent.ts
+++ b/src/agent/implementations/BaseReflectionAgent.ts
@@ -40,8 +40,13 @@ import { AgentExecutionContext } from '@agent/runtime/AgentExecutionContext';
 import { normalizeRunId } from '@common/constants/runIds';
 import { END_GROUP_STATUS, type EndGroupStatus } from '@logger/messageTypes';
 import { PromptBuilder } from '@utils/prompt';
-import { TaskRunFileService, type AgentFileLocation } from '@utils/files';
+import {
+  TaskRunFileService,
+  flexibleFS,
+  type AgentFileLocation,
+} from '@utils/files';
 import { LatexMediaManager } from '@latex';
+import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
 
 /**
  * Parameters for resuming a reflection agent from saved state.
@@ -275,9 +280,12 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
     // Also hydrate OutputHandler's rounds map for latexdiff to work after resume
     for (const round of sortedRounds) {
       const savedOutputs = params.rounds.get(round) ?? [];
+      // Reconstruct raw output location - the file should still exist on disk
+      // Use the same logic as getOutputFileLocation() to get the path
+      const rawOutputLocation = this.getOutputFileLocation(round);
       this.roundOutputs[round] = {
         round,
-        rawOutput: null, // Not available from saved state
+        rawOutput: rawOutputLocation,
         outputs: savedOutputs,
         xmlSummary: {
           tagContents: {},
@@ -291,6 +299,92 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
     }
 
     this.hydratedRoundCount = sortedRounds.length;
+  }
+
+  /**
+   * Reconstruct conversation history from hydrated round outputs.
+   *
+   * On resume, the conversation array is empty but we have completed round outputs.
+   * This method rebuilds the conversation by:
+   * 1. Reading assistant responses from raw output files
+   * 2. Building user messages via promptBuilder
+   *
+   * This enables multi-round agents to continue from where they left off with
+   * full context of previous rounds.
+   *
+   * @returns The reconstructed conversation messages, or empty array if reconstruction fails
+   */
+  private async reconstructConversation(): Promise<ProviderMessage[]> {
+    if (this.roundOutputs.length === 0) {
+      return [];
+    }
+
+    const promptBuilder = this.getPromptBuilder();
+    const conversation: ProviderMessage[] = [];
+
+    for (let round = 0; round < this.roundOutputs.length; round++) {
+      const roundOutput = this.roundOutputs[round];
+      if (!roundOutput?.rawOutput) {
+        this.logger.warn(
+          `Cannot reconstruct conversation: missing rawOutput for round ${round}`,
+        );
+        return [];
+      }
+
+      try {
+        // Read assistant response from raw output file
+        const rawOutputPath = roundOutput.rawOutput.absolutePath;
+        const fileExists = await flexibleFS.exists(roundOutput.rawOutput);
+        if (!fileExists) {
+          this.logger.warn(
+            `Cannot reconstruct conversation: raw output file not found for round ${round}: ${rawOutputPath}`,
+          );
+          return [];
+        }
+
+        const assistantResponse = await flexibleFS.read(roundOutput.rawOutput);
+
+        if (round === 0) {
+          // First round: build initial prompts and add user message
+          const { systemPrompt, userRequest, userPrefix } =
+            await promptBuilder.buildInitialPrompts();
+
+          // Initialize messages with user message (similar to PrepareContextNode)
+          const messages = await this.modelHandler.initializeMessages(
+            userPrefix,
+            userRequest,
+            undefined,
+            systemPrompt,
+          );
+          conversation.push(...messages);
+        } else {
+          // Subsequent rounds: build user request only
+          const userRequest = await promptBuilder.buildUserRequest(round);
+          if (userRequest?.trim()) {
+            await this.modelHandler.createRoundMessages(
+              conversation,
+              userRequest,
+              undefined,
+            );
+          }
+        }
+
+        // Add assistant response
+        const assistantMessage =
+          this.modelHandler.createAssistantMessage(assistantResponse);
+        conversation.push(assistantMessage);
+      } catch (error) {
+        this.logger.warn(
+          `Failed to reconstruct conversation for round ${round}: ${error}`,
+        );
+        return [];
+      }
+    }
+
+    this.logger.debug(
+      `Reconstructed conversation with ${conversation.length} messages from ${this.roundOutputs.length} rounds`,
+    );
+    return conversation;
   }
 
   protected getPromptBuilder(): PromptBuilder {
@@ -415,6 +509,13 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
         this.roundOutputs = [];
       }
 
+      // Reconstruct conversation from hydrated rounds if resuming
+      // This enables multi-round agents to continue with full context
+      let initialConversation: ProviderMessage[] | undefined;
+      if (hadHydratedRounds) {
+        initialConversation = await this.reconstructConversation();
+      }
+
       const totalRounds = this.getTotalRounds();
 
       // Ensure we have a run stage for round grouping
@@ -432,14 +533,15 @@ export abstract class BaseReflectionAgent<C = unknown> extends BaseAgent<C> {
       });
 
       // Create shared state for the flow (no lifecycle - errors thrown directly)
-      // Pass hydrated outputs to preserve them during resume
+      // Pass hydrated outputs and reconstructed conversation to preserve context during resume
       shared = {
         agent: this,
-        state: createInitialReflectionState(
+        state: createInitialReflectionState({
           totalRounds,
-          AgentWorkspaceState.create(),
-          hadHydratedRounds ? this.roundOutputs : undefined,
-        ),
+          initialWorkspaceState: AgentWorkspaceState.create(),
+          hydratedOutputs: hadHydratedRounds ? this.roundOutputs : undefined,
+          initialConversation,
+        }),
         retryState: createRetryState(),
         runStage: this.runStage,
       };

--- a/src/agent/implementations/flows/reflection/ReflectionFlowState.ts
+++ b/src/agent/implementations/flows/reflection/ReflectionFlowState.ts
@@ -101,19 +101,26 @@ export interface ReflectionFlowShared {
 /**
  * Create initial state for a reflection flow run.
  *
+ * On resume, we always start from round 0 and "replay" all rounds.
+ * Completed rounds are detected by initializeOutputAndPrefill() which
+ * checks if output file exists - if so, it reads the existing response
+ * instead of calling the model, allowing conversation to build correctly.
+ *
  * @param totalRounds - Total rounds to execute
  * @param initialWorkspaceState - Initial workspace state
- * @param hydratedOutputs - Optional pre-hydrated round outputs from resume
+ * @param hydratedOutputs - Optional pre-hydrated round outputs from resume (for latexdiff)
  */
 export function createInitialReflectionState(
   totalRounds: number,
   initialWorkspaceState: AgentWorkspaceState,
   hydratedOutputs?: RoundOutput[],
 ): ReflectionFlowState {
-  // Calculate starting round from hydrated outputs (resume from next round)
-  const startingRound = hydratedOutputs?.length ?? 0;
+  // Always start from round 0, even on resume.
+  // Completed rounds are "replayed" - their output files already exist,
+  // so initializeOutputAndPrefill() will read them instead of calling the model.
+  // This ensures conversation is built correctly through the normal flow.
   return {
-    currentRound: startingRound,
+    currentRound: 0,
     totalRounds,
     workspaceState: initialWorkspaceState,
     context: null,

--- a/src/agent/implementations/flows/reflection/ReflectionFlowState.ts
+++ b/src/agent/implementations/flows/reflection/ReflectionFlowState.ts
@@ -99,17 +99,33 @@ export interface ReflectionFlowShared {
 }
 
 /**
+ * Options for creating initial reflection state.
+ */
+export interface CreateReflectionStateOptions {
+  /** Total rounds to execute */
+  totalRounds: number;
+  /** Initial workspace state */
+  initialWorkspaceState: AgentWorkspaceState;
+  /** Optional pre-hydrated round outputs from resume */
+  hydratedOutputs?: RoundOutput[];
+  /** Optional reconstructed conversation from resume */
+  initialConversation?: ProviderMessage[];
+}
+
+/**
  * Create initial state for a reflection flow run.
  *
- * @param totalRounds - Total rounds to execute
- * @param initialWorkspaceState - Initial workspace state
- * @param hydratedOutputs - Optional pre-hydrated round outputs from resume
+ * @param options - Configuration options for the initial state
  */
 export function createInitialReflectionState(
-  totalRounds: number,
-  initialWorkspaceState: AgentWorkspaceState,
-  hydratedOutputs?: RoundOutput[],
+  options: CreateReflectionStateOptions,
 ): ReflectionFlowState {
+  const {
+    totalRounds,
+    initialWorkspaceState,
+    hydratedOutputs,
+    initialConversation,
+  } = options;
   // Calculate starting round from hydrated outputs (resume from next round)
   const startingRound = hydratedOutputs?.length ?? 0;
   return {
@@ -118,7 +134,7 @@ export function createInitialReflectionState(
     workspaceState: initialWorkspaceState,
     context: null,
     outputLocation: null,
-    conversation: [],
+    conversation: initialConversation ?? [],
     runState: new AgentRunState(),
     roundStates: [],
     roundOutputs: hydratedOutputs ? [...hydratedOutputs] : [],

--- a/src/agent/implementations/flows/reflection/ReflectionFlowState.ts
+++ b/src/agent/implementations/flows/reflection/ReflectionFlowState.ts
@@ -99,33 +99,17 @@ export interface ReflectionFlowShared {
 }
 
 /**
- * Options for creating initial reflection state.
- */
-export interface CreateReflectionStateOptions {
-  /** Total rounds to execute */
-  totalRounds: number;
-  /** Initial workspace state */
-  initialWorkspaceState: AgentWorkspaceState;
-  /** Optional pre-hydrated round outputs from resume */
-  hydratedOutputs?: RoundOutput[];
-  /** Optional reconstructed conversation from resume */
-  initialConversation?: ProviderMessage[];
-}
-
-/**
  * Create initial state for a reflection flow run.
  *
- * @param options - Configuration options for the initial state
+ * @param totalRounds - Total rounds to execute
+ * @param initialWorkspaceState - Initial workspace state
+ * @param hydratedOutputs - Optional pre-hydrated round outputs from resume
  */
 export function createInitialReflectionState(
-  options: CreateReflectionStateOptions,
+  totalRounds: number,
+  initialWorkspaceState: AgentWorkspaceState,
+  hydratedOutputs?: RoundOutput[],
 ): ReflectionFlowState {
-  const {
-    totalRounds,
-    initialWorkspaceState,
-    hydratedOutputs,
-    initialConversation,
-  } = options;
   // Calculate starting round from hydrated outputs (resume from next round)
   const startingRound = hydratedOutputs?.length ?? 0;
   return {
@@ -134,7 +118,7 @@ export function createInitialReflectionState(
     workspaceState: initialWorkspaceState,
     context: null,
     outputLocation: null,
-    conversation: initialConversation ?? [],
+    conversation: [],
     runState: new AgentRunState(),
     roundStates: [],
     roundOutputs: hydratedOutputs ? [...hydratedOutputs] : [],

--- a/src/agent/implementations/flows/reflection/ReflectionFlowState.ts
+++ b/src/agent/implementations/flows/reflection/ReflectionFlowState.ts
@@ -108,17 +108,16 @@ export interface ReflectionFlowShared {
  *
  * @param totalRounds - Total rounds to execute
  * @param initialWorkspaceState - Initial workspace state
- * @param hydratedOutputs - Optional pre-hydrated round outputs from resume (for latexdiff)
  */
 export function createInitialReflectionState(
   totalRounds: number,
   initialWorkspaceState: AgentWorkspaceState,
-  hydratedOutputs?: RoundOutput[],
 ): ReflectionFlowState {
   // Always start from round 0, even on resume.
   // Completed rounds are "replayed" - their output files already exist,
   // so initializeOutputAndPrefill() will read them instead of calling the model.
   // This ensures conversation is built correctly through the normal flow.
+  // roundOutputs is populated by OutputNode as each round completes.
   return {
     currentRound: 0,
     totalRounds,
@@ -128,7 +127,7 @@ export function createInitialReflectionState(
     conversation: [],
     runState: new AgentRunState(),
     roundStates: [],
-    roundOutputs: hydratedOutputs ? [...hydratedOutputs] : [],
+    roundOutputs: [],
     continueRounds: true,
     endTurn: false,
     roundStage: null, // Set by agent.run() before flow starts

--- a/src/agent/implementations/flows/reflection/nodes/ResponseCycleCompositionNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/ResponseCycleCompositionNode.ts
@@ -149,6 +149,10 @@ export class ResponseCycleCompositionNode<C = unknown> extends Node<
       );
 
     // If prefill already completes the response, return success with endTurn=true
+    // This happens on resume when replaying completed rounds - the output file
+    // already contains the full response, so we skip the model call.
+    // Note: initializeOutputAndPrefill() modifies prepRes.context.messages in-place
+    // (adding the assistant response), so post() will sync this to shared.state.conversation.
     if (prefillEndsTurn) {
       return {
         kind: 'success',

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -1238,23 +1238,17 @@ export class ModelHandlerAnthropic extends ModelHandler<
     workspaceState.assembly.updateAccumulatedOutput(fileContent);
     workspaceState.assembly.updateLastResponse(fileContent);
 
-    const lastMessage = messages.at(-1);
     if (hasEndTag(agentSetting, fileContent)) {
-      this.logger.debug('End tag detected - skipping continuation');
-      // this is suspicious, because the two conflicts!!! we should check
-      if (lastMessage && Array.isArray(lastMessage.content)) {
-        const lastContent = lastMessage.content.at(-1);
-        if (lastContent && lastContent.type === 'text') {
-          lastContent.text = fileContent;
-        }
-      } else if (lastMessage) {
-        lastMessage.content = [
-          {
-            type: 'text',
-            text: fileContent,
-          } as ContentBlockParam,
-        ];
-      }
+      this.logger.debug(
+        'End tag detected - adding completed response and skipping model call',
+      );
+      // Add the completed assistant response to conversation
+      // This is critical for multi-round agents on resume - the conversation
+      // must include this round's response for subsequent rounds to have context
+      messages.push({
+        role: 'assistant',
+        content: [{ type: 'text', text: fileContent }],
+      });
 
       this.clearCacheControlTarget();
 

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -1078,8 +1078,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
     this.logger.debug(
       'Existing file content found without end tag - continuing generation.',
     );
-    workspaceState.assembly.updateAccumulatedOutput(fileContent);
-    workspaceState.assembly.lastResponse = fileContent;
+    // Note: workspace state already updated above (lines 1062-1063)
     const state = new ConversationRoundState(0);
     this.addContinueMessageWithoutPrefill(
       messages,

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -1056,6 +1056,12 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
     this.logger.debug(
       `Cleaned and saved existing content to ${outputLocation.absolutePath}.`,
     );
+
+    // Update workspace state - critical for multi-round agents on resume
+    // so that subsequent rounds have correct context
+    workspaceState.assembly.updateAccumulatedOutput(fileContent);
+    workspaceState.assembly.updateLastResponse(fileContent);
+
     messages.push(createModelContent(createPartFromText(fileContent)));
     this.logger.debug(
       `Added existing file content to messages as 'model' role.`,

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -890,23 +890,10 @@ export class ModelHandlerOpenAI<
       ],
     });
 
-    const lastMessage = messages.at(-1);
     if (hasEndTag(agentSetting, fileContent)) {
-      this.logger.debug('End tag detected - skipping continuation');
-      if (lastMessage && Array.isArray(lastMessage.content)) {
-        // this is suspicious, because the two conflicts!!!
-        const lastPart = lastMessage.content.at(-1);
-        if (lastPart && 'text' in lastPart) {
-          lastPart.text = fileContent;
-        }
-      } else if (lastMessage) {
-        lastMessage.content = [
-          {
-            type: 'text',
-            text: fileContent,
-          },
-        ];
-      }
+      this.logger.debug(
+        'End tag detected - skipping model call (response already added above)',
+      );
       endTurn = true;
       return [endTurn, messages];
     }

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -880,6 +880,11 @@ export class ModelHandlerOpenAI<
     // Write file content to output file
     await flexibleFS.write(outputLocation, fileContent);
 
+    // Update workspace state - critical for multi-round agents on resume
+    // so that subsequent rounds have correct context
+    workspaceState.assembly.updateAccumulatedOutput(fileContent);
+    workspaceState.assembly.updateLastResponse(fileContent);
+
     messages.push({
       role: 'assistant',
       content: [

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -906,9 +906,9 @@ export class ModelHandlerOpenAI<
     this.logger.warn(
       'Output file exists but no end tag found - continuing from file',
     );
-    if (fileContent.includes(prefill)) {
-      workspaceState.assembly.updateAccumulatedOutput(fileContent);
-    } else {
+    // Note: workspace state already updated above (lines 885-886)
+    // Only need to handle case where prefill needs to be prepended
+    if (!fileContent.includes(prefill)) {
       workspaceState.assembly.updateAccumulatedOutput(prefill + fileContent);
       await flexibleFS.write(
         outputLocation,
@@ -916,8 +916,6 @@ export class ModelHandlerOpenAI<
       );
     }
     const state = new ConversationRoundState(0);
-    workspaceState.assembly.lastResponse =
-      workspaceState.assembly.accumulatedOutput;
     this.addContinueMessageWithoutPrefill(
       messages,
       state,

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -1119,9 +1119,9 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     this.logger.warn(
       'Output file exists but no end tag found - continuing from file',
     );
-    if (fileContent.includes(prefill)) {
-      workspaceState.assembly.updateAccumulatedOutput(fileContent);
-    } else {
+    // Note: workspace state already updated above (lines 1108-1109)
+    // Only need to handle case where prefill needs to be prepended
+    if (!fileContent.includes(prefill)) {
       workspaceState.assembly.updateAccumulatedOutput(prefill + fileContent);
       await flexibleFS.write(
         outputLocation,
@@ -1130,8 +1130,6 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     }
 
     const state = new ConversationRoundState(0);
-    workspaceState.assembly.lastResponse =
-      workspaceState.assembly.accumulatedOutput;
     this.addContinueMessageWithoutPrefill(
       messages,
       state,

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -1103,6 +1103,11 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
 
     await flexibleFS.write(outputLocation, fileContent);
 
+    // Update workspace state - critical for multi-round agents on resume
+    // so that subsequent rounds have correct context
+    workspaceState.assembly.updateAccumulatedOutput(fileContent);
+    workspaceState.assembly.updateLastResponse(fileContent);
+
     messages.push(this.createAssistantMessage(fileContent));
 
     if (hasEndTag(agentSetting, fileContent)) {

--- a/src/agent/output/IOutputHandler.ts
+++ b/src/agent/output/IOutputHandler.ts
@@ -73,11 +73,4 @@ export interface IOutputHandler {
    */
   setActiveRun(storageKey: StorageKey): void;
 
-  /**
-   * Hydrate a round's outputs from previously saved state.
-   * Used during resume to populate the internal rounds map without reprocessing.
-   * @param round - Round number to hydrate
-   * @param outputs - Previously saved output file info
-   */
-  hydrateRound(round: number, outputs: OutputFileInfo[]): void;
 }

--- a/src/agent/output/OutputHandler.ts
+++ b/src/agent/output/OutputHandler.ts
@@ -161,21 +161,6 @@ export class OutputHandler implements IOutputHandler {
     );
   }
 
-  public hydrateRound(round: number, outputs: OutputFileInfo[]): void {
-    // Populate the internal rounds map from saved state
-    // This enables getRoundMapping to work correctly after resume
-    this.rounds.set(round, {
-      outputs,
-      rawOutput: null, // Not available from saved state
-      xmlSummary: {
-        tagContents: {},
-        documents: [],
-        singleOutputFile: null,
-        sourceLocation: null,
-      },
-    });
-  }
-
   private getStorageKey(): StorageKey {
     return this._storageKey ?? normalizeRunId(null);
   }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Improves resume behavior for reflection agents by replaying completed rounds from saved outputs to correctly rebuild conversation context.
> 
> - Always start at `r0` on resume; set `hydratedRoundCount` only and repopulate `roundOutputs` during replay
> - `createInitialReflectionState()` now starts at `currentRound: 0` with empty `roundOutputs`
> - `initializeOutputAndPrefill()` (Anthropic/Google/OpenAI) reads existing output files; when end tag is present, adds an assistant message and skips model call; updates `workspaceState.assembly` (`updateAccumulatedOutput`/`updateLastResponse`)
> - Logs replay info and resets `roundOutputs` before running; conversation is synced via `ResponseCycleCompositionNode.post()`
> - Removes `IOutputHandler.hydrateRound()` and related hydration in `OutputHandler` (no longer needed)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ff761a4da8a2e24550e30b24bea0fc628535f195. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->