### PR TITLE
Fix module import path for debounce utility

### DIFF
--- a/src/common/webview/BaseViewContentProvider.ts
+++ b/src/common/webview/BaseViewContentProvider.ts
@@ -189,6 +189,7 @@ export abstract class BaseViewContentProvider {
       baseUIManagerUri: this.getCommonUri(webview, 'modules/BaseUIManager.js'),
       stringUtilsUri: this.getCommonUri(webview, 'modules/stringUtils.js'),
       pathUtilsUri: this.getCommonUri(webview, 'modules/pathUtils.js'),
+      debounceUri: this.getCommonUri(webview, 'debounce.js'),
       clipboardUtilsUri: this.getCommonUri(
         webview,
         'modules/clipboardUtils.js',

--- a/src/historyView/index.html
+++ b/src/historyView/index.html
@@ -33,6 +33,7 @@
           "@common/webview/commands.js": "${commandsUri}",
           "@common/webviewContext.js": "${webviewContextUri}",
           "@common/domUtils.js": "${domUtilsUri}",
+          "@common/debounce.js": "${debounceUri}",
           "@common/templateUtils.js": "${templateUtilsUri}",
           "@common/htmlEncoding.js": "${htmlEncodingUri}",
           "@common/iconConstants.js": "${iconConstantsUri}",

--- a/src/webview/index.html
+++ b/src/webview/index.html
@@ -46,6 +46,7 @@
           "@common/domUtils.js": "${domUtilsUri}",
           "@common/BaseDomHandler.js": "${baseDomHandlerUri}",
           "@common/stringUtils.js": "${stringUtilsUri}",
+          "@common/debounce.js": "${debounceUri}",
           "@common/iconConstants.js": "${iconConstantsUri}",
           "@common/BaseWebviewMessageHandler.js": "${baseWebviewMessageHandlerUri}",
           "@common/constants/agentTypes.js": "${agentTypesUri}",


### PR DESCRIPTION
The @common/debounce.js import was missing from the import maps in webview HTML files, causing a module resolution error in the browser where path aliases don't work.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures the debounce utility resolves in browser-based webviews.
> 
> - Exposes `debounceUri` in `BaseViewContentProvider` pointing to `@common/debounce.js`
> - Adds `@common/debounce.js` to import maps in `src/historyView/index.html` and `src/webview/index.html`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 79c1442d00a65588a6a0cd4a9049531f03e345bd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->