### PR TITLE
Fix workspace-relative path handling

### DIFF
--- a/src/agent/implementations/flows/reflection/helpers.ts
+++ b/src/agent/implementations/flows/reflection/helpers.ts
@@ -72,5 +72,9 @@ export function createBaseFileLocations(
 ): WorkspaceFileLocation[] {
   const files =
     config.outputFiles.length > 0 ? config.outputFiles : [config.inputFile];
-  return files.map((f) => createWorkspaceLocation(WorkspaceFS.fullPath(f), f));
+  return files.map((f) => {
+    const absolutePath = WorkspaceFS.fullPath(f);
+    const relativePath = WorkspaceFS.relativePath(absolutePath);
+    return createWorkspaceLocation(absolutePath, relativePath);
+  });
 }

--- a/src/agent/implementations/flows/reflection/helpers.ts
+++ b/src/agent/implementations/flows/reflection/helpers.ts
@@ -75,11 +75,12 @@ export function createBaseFileLocations(
   const files =
     config.outputFiles.length > 0 ? config.outputFiles : [config.inputFile];
   return files.map((f) => {
-    const absolutePath = WorkspaceFS.fullPath(f);
-    // Avoid round-trip conversion when f is already a workspace-relative path.
-    // Only compute relativePath from absolutePath when f is absolute.
+    // Handle absolute paths correctly: path.join() incorrectly concatenates
+    // when the second arg is absolute, so we must check first.
+    // See resolveFilePath in pathUtils.ts for the canonical pattern.
+    const absolutePath = path.isAbsolute(f) ? f : WorkspaceFS.fullPath(f);
     const relativePath = path.isAbsolute(f)
-      ? WorkspaceFS.relativePath(absolutePath)
+      ? WorkspaceFS.relativePath(f)
       : f;
     return createWorkspaceLocation(absolutePath, relativePath);
   });

--- a/src/agent/implementations/flows/reflection/helpers.ts
+++ b/src/agent/implementations/flows/reflection/helpers.ts
@@ -5,6 +5,8 @@
  * across multiple nodes, following DRY principles.
  */
 
+import * as path from 'path';
+
 import type { RoundOutput } from '@agent/output';
 
 import type { AgentConfig } from '@agent/core/AgentConfig';
@@ -74,7 +76,11 @@ export function createBaseFileLocations(
     config.outputFiles.length > 0 ? config.outputFiles : [config.inputFile];
   return files.map((f) => {
     const absolutePath = WorkspaceFS.fullPath(f);
-    const relativePath = WorkspaceFS.relativePath(absolutePath);
+    // Avoid round-trip conversion when f is already a workspace-relative path.
+    // Only compute relativePath from absolutePath when f is absolute.
+    const relativePath = path.isAbsolute(f)
+      ? WorkspaceFS.relativePath(absolutePath)
+      : f;
     return createWorkspaceLocation(absolutePath, relativePath);
   });
 }

--- a/src/frontend/ui/dialogs.ts
+++ b/src/frontend/ui/dialogs.ts
@@ -56,7 +56,7 @@ export async function selectFiles(
   });
 
   return fileUris && fileUris.length > 0
-    ? fileUris.map((uri) => vscode.workspace.asRelativePath(uri.fsPath, false))
+    ? fileUris.map((uri) => WorkspaceFS.relativePath(uri.fsPath))
     : null;
 }
 

--- a/src/frontend/ui/dialogs.ts
+++ b/src/frontend/ui/dialogs.ts
@@ -56,7 +56,7 @@ export async function selectFiles(
   });
 
   return fileUris && fileUris.length > 0
-    ? fileUris.map((uri) => WorkspaceFS.relativePath(uri.fsPath))
+    ? fileUris.map((uri) => vscode.workspace.asRelativePath(uri.fsPath, false))
     : null;
 }
 

--- a/src/utils/files/relativeFS.ts
+++ b/src/utils/files/relativeFS.ts
@@ -13,7 +13,9 @@ export abstract class RelativeFS extends BaseFS {
   }
 
   protected static override resolvePath(target: string): string {
-    return path.join(this.getBasePath(), target);
+    // If target is already absolute, return it directly.
+    // path.join() incorrectly concatenates absolute paths instead of returning them.
+    return path.isAbsolute(target) ? target : path.join(this.getBasePath(), target);
   }
 
   public static override fullPath(target: string): string {

--- a/src/utils/files/taskRunStorage.ts
+++ b/src/utils/files/taskRunStorage.ts
@@ -136,9 +136,13 @@ function resolvePathAgainstWorkspace(
 
   if (path.isAbsolute(normalized)) {
     // Absolute path - check if within workspace
+    // Use WorkspaceFS.relativePath() which handles symlinks correctly via
+    // vscode.workspace.asRelativePath(). Direct path.relative() fails when
+    // the path is inside a symlinked directory.
     if (workspaceRoot) {
-      const relative = path.relative(workspaceRoot, normalized);
-      if (!relative.startsWith('..') && !path.isAbsolute(relative)) {
+      const relative = WorkspaceFS.relativePath(normalized);
+      // asRelativePath returns the original path if outside workspace
+      if (relative !== normalized && !relative.startsWith('..')) {
         return {
           kind: 'workspace',
           absolutePath: normalized,

--- a/src/utils/files/workspaceFS.ts
+++ b/src/utils/files/workspaceFS.ts
@@ -1,6 +1,3 @@
-// Standard library imports
-import * as path from 'path';
-
 // Third-party imports
 import * as vscode from 'vscode';
 
@@ -21,9 +18,16 @@ export class WorkspaceFS extends RelativeFS {
     return vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
   }
 
+  /**
+   * Convert an absolute path to a workspace-relative path.
+   * Uses VS Code's asRelativePath which properly handles symlinks.
+   * Returns the original path if no workspace is open.
+   */
   public static relativePath(filePath: string): string {
-    const base = this.getPath();
-    return base ? path.relative(base, filePath) : filePath;
+    if (!this.getPath()) {
+      return filePath;
+    }
+    return vscode.workspace.asRelativePath(filePath, false);
   }
 
   public static async existsAndNonTrivial(target: string): Promise<boolean> {


### PR DESCRIPTION
When inputFile contained an absolute path, it was incorrectly passed as the relativePath parameter to createWorkspaceLocation. This caused path duplication when the relative path was later joined with the workspace root (e.g., /workspace/root + /absolute/path resulted in /workspace/root/absolute/path).

Fix by using WorkspaceFS.relativePath() to properly compute the workspace-relative path from the absolute path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves path resolution to correctly handle absolute paths and symlinked workspaces.
> 
> - Use VS Code’s `vscode.workspace.asRelativePath()` in `WorkspaceFS.relativePath()` for symlink-aware workspace-relative paths
> - Update `RelativeFS.resolvePath()` to return absolute targets directly instead of `path.join()` concatenation
> - In `taskRunStorage`, make `resolvePathAgainstWorkspace()` use `WorkspaceFS.relativePath()` for absolute inputs and adjust workspace/external classification
> - In `reflection/helpers.ts`, compute both absolute and relative paths correctly in `createBaseFileLocations()` to avoid path duplication
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3e6ae2b27f140ef1a6a054caa0e2a6727db5210e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->