### PR TITLE
fix: improve flow architecture consistency and configurability

### DIFF
--- a/src/agent/core/flows/RetryState.ts
+++ b/src/agent/core/flows/RetryState.ts
@@ -25,11 +25,9 @@ import { MESSAGE_TYPES } from '@logger/messageTypes';
 import {
   getModelRetryBackoffMs,
   getModelRetryMaxAttempts,
+  getManualRetryTimeoutMs,
 } from '@utils/config';
 import { bus } from '@eventBus/ProgressEventBus';
-
-/** Timeout for manual retry wait (5 minutes) - used by retryPrompt implementations */
-const MANUAL_RETRY_TIMEOUT_MS = 5 * 60 * 1000;
 
 // ============================================================================
 // Schemas (Single Source of Truth)
@@ -383,7 +381,7 @@ export abstract class RetryableInvocationNode<
         operation: operationName,
         errorMessage: formatted.message,
         logger,
-        timeoutMs: MANUAL_RETRY_TIMEOUT_MS,
+        timeoutMs: getManualRetryTimeoutMs(),
       },
     );
 

--- a/src/agent/implementations/flows/reflection/ReflectionFlowState.ts
+++ b/src/agent/implementations/flows/reflection/ReflectionFlowState.ts
@@ -342,3 +342,78 @@ export function updateRunStateSnapshot(
 export function createFreshWorkspaceSnapshot(): AgentWorkspaceSnapshot {
   return AgentWorkspaceState.create().toSnapshot();
 }
+
+// ============================================================================
+// Array Mutation Helpers
+// ============================================================================
+
+/**
+ * Append a round state snapshot to the accumulated snapshots array.
+ *
+ * ## Why this helper exists
+ *
+ * In-place array mutations (e.g., `shared.roundStateSnapshots.push(...)`) can cause
+ * issues with PersistedFlow's `structuredClone()` serialization. While the mutation
+ * itself works, it creates a pattern that's harder to audit for correctness.
+ *
+ * This helper makes the mutation explicit and provides a clear audit point for
+ * state changes. It also allows for future optimization (e.g., immutable updates)
+ * without changing call sites.
+ *
+ * @param shared - The reflection flow shared state
+ * @param snapshot - The round state snapshot to append
+ *
+ * @example
+ * // In ResponseCycleCompositionNode.post()
+ * appendRoundStateSnapshot(shared, prepRes.context.stateRoundSnapshot);
+ */
+export function appendRoundStateSnapshot(
+  shared: ReflectionFlowShared,
+  snapshot: ConversationRoundStateSnapshot,
+): void {
+  shared.roundStateSnapshots = [...shared.roundStateSnapshots, snapshot];
+}
+
+/**
+ * Set a round output at the specified round index.
+ *
+ * ## Why this helper exists
+ *
+ * Direct array index assignment (e.g., `shared.roundOutputs[index] = output`) can
+ * be error-prone and harder to audit. This helper provides:
+ * - Bounds checking (auto-expands array if needed)
+ * - Clear mutation point for debugging
+ * - Consistent pattern across the codebase
+ *
+ * @param shared - The reflection flow shared state
+ * @param roundIndex - The round index to set
+ * @param output - The round output to set
+ *
+ * @example
+ * // In OutputNode.post()
+ * setRoundOutput(shared, shared.currentRound, execRes);
+ */
+export function setRoundOutput(
+  shared: ReflectionFlowShared,
+  roundIndex: number,
+  output: z.infer<typeof RoundOutputSchema>,
+): void {
+  // Create a new array to ensure clean serialization
+  const newOutputs = [...shared.roundOutputs];
+  // Expand array if needed (shouldn't happen in normal flow, but defensive)
+  while (newOutputs.length <= roundIndex) {
+    newOutputs.push({
+      round: newOutputs.length,
+      rawOutput: null,
+      outputs: [],
+      xmlSummary: {
+        tagContents: {},
+        documents: [],
+        singleOutputFile: null,
+        sourceLocation: null,
+      },
+    });
+  }
+  newOutputs[roundIndex] = output;
+  shared.roundOutputs = newOutputs;
+}

--- a/src/agent/implementations/flows/reflection/nodes/OutputNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/OutputNode.ts
@@ -36,7 +36,10 @@ import type { AgentFileLocation, FileLocation } from '@utils/files';
 import { flexibleFS } from '@utils/files';
 
 import { createBaseFileLocations } from '../helpers';
-import type { ReflectionFlowShared } from '../ReflectionFlowState';
+import {
+  setRoundOutput,
+  type ReflectionFlowShared,
+} from '../ReflectionFlowState';
 import type {
   ReflectionFlowParams,
   ReflectionServices,
@@ -190,8 +193,8 @@ export class OutputNode<C = unknown> extends Node<
     _prepRes: OutputPrepInput,
     execRes: OutputExecResult,
   ): Promise<string | undefined> {
-    // Store round output
-    shared.roundOutputs[shared.currentRound] = execRes;
+    // Store round output using explicit helper (ensures clean serialization)
+    setRoundOutput(shared, shared.currentRound, execRes);
 
     // Continue to RoundCompleteNode
     return FlowTransition.DEFAULT;

--- a/src/agent/implementations/flows/reflection/nodes/ResponseCycleCompositionNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/ResponseCycleCompositionNode.ts
@@ -47,6 +47,7 @@ import {
   getRunState,
   updateRunStateSnapshot,
   updateWorkspaceSnapshot,
+  appendRoundStateSnapshot,
   type ReflectionFlowShared,
   type RoundContext,
 } from '../ReflectionFlowState';
@@ -319,8 +320,8 @@ export class ResponseCycleCompositionNode<C = unknown> extends Node<
     // (via updateMessageContentWithPrefill) and must be propagated for multi-round flows
     shared.conversation = prepRes.context.messages;
 
-    // Store round state snapshot for later (already a snapshot, just push directly)
-    shared.roundStateSnapshots.push(prepRes.context.stateRoundSnapshot);
+    // Store round state snapshot for later using explicit helper (ensures clean serialization)
+    appendRoundStateSnapshot(shared, prepRes.context.stateRoundSnapshot);
 
     // Continue to OutputNode
     return FlowTransition.DEFAULT;

--- a/src/agent/implementations/flows/reflection/nodes/index.ts
+++ b/src/agent/implementations/flows/reflection/nodes/index.ts
@@ -7,10 +7,13 @@
  * - ResponseCycleFlow is composed as a sub-flow
  *
  * Node flow:
- * TeXCountNode → MediaPreparationNode → PrepareContextNode
+ * PrepareContextNode → TeXCountNode → MediaPreparationNode
  *   → ResponseCycleCompositionNode → OutputNode → RoundCompleteNode
  *
- * TeXCountNode is the first node in each round - it creates workspace state.
+ * PrepareContextNode is the first node in each round - it builds base messages.
+ * Each subsequent node enriches the context:
+ * - TeXCountNode: prepends LaTeX word count stats
+ * - MediaPreparationNode: adds media files (figures, TikZ, PDFs)
  */
 
 export { TeXCountNode } from './TeXCountNode';

--- a/src/utils/config/constants.ts
+++ b/src/utils/config/constants.ts
@@ -72,6 +72,9 @@ export const DEFAULT_TOOL_USE_PERSISTENCE_TTL_HOURS = 72;
 export const DEFAULT_MODEL_RETRY_MAX_ATTEMPTS = 0;
 export const DEFAULT_MODEL_RETRY_BACKOFF_MS = 1000;
 
+// Manual retry UI timeout (5 minutes default)
+export const DEFAULT_MANUAL_RETRY_TIMEOUT_MS = 5 * 60 * 1000;
+
 /** Determine whether tool-use session persistence is enabled. */
 export function getToolUsePersistenceEnabled(): boolean {
   return getConfig<boolean>('texra.toolUse.persistence.enabled', true);
@@ -106,5 +109,12 @@ export function getModelRetryBackoffMs(): number {
   return getConfig<number>(
     'texra.model.retry.backoffMs',
     DEFAULT_MODEL_RETRY_BACKOFF_MS,
+  );
+}
+
+export function getManualRetryTimeoutMs(): number {
+  return getConfig<number>(
+    'texra.model.retry.manualTimeoutMs',
+    DEFAULT_MANUAL_RETRY_TIMEOUT_MS,
   );
 }


### PR DESCRIPTION
- Move hard-coded manual retry timeout to configuration
  - Add DEFAULT_MANUAL_RETRY_TIMEOUT_MS constant (5 minutes)
  - Add getManualRetryTimeoutMs() getter function
  - Update RetryState.ts to use configurable timeout

- Fix misleading documentation in reflection nodes
  - Correct node order: PrepareContextNode runs first, not TeXCountNode
  - Document that each node enriches context (stats, media)

- Add explicit array mutation helpers for ReflectionFlowState
  - Add appendRoundStateSnapshot() for clean array appends
  - Add setRoundOutput() with bounds checking
  - Update ResponseCycleCompositionNode and OutputNode to use helpers
  - Ensures clean serialization via PersistedFlow's structuredClone()

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> - **Configurable manual retry timeout**: Adds `DEFAULT_MANUAL_RETRY_TIMEOUT_MS` and `getManualRetryTimeoutMs()` in `utils/config/constants.ts`; `RetryState.ts` now uses `getManualRetryTimeoutMs()` for `retryCoordinator.waitForUserAction`.
> - **Serialization-safe state updates**: Introduces `appendRoundStateSnapshot()` and `setRoundOutput()` in `ReflectionFlowState.ts` and updates `ResponseCycleCompositionNode` and `OutputNode` to use them instead of in-place mutations.
> - **Docs/flow order fix**: Corrects reflection node order in `nodes/index.ts` and clarifies each node’s role in enriching context.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 038e9bf1bc20b6b233edff1f816eb1edcc515cf5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->