### PR TITLE
refactor: remove duplicate CycleStateSlices interface

### DIFF
--- a/src/agent/implementations/flows/reflection/nodes/ResponseCycleCompositionNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/ResponseCycleCompositionNode.ts
@@ -26,8 +26,7 @@ import {
   NODE_NO_WAIT,
   buildBaseCycleOptions,
 } from '@agent/implementations/flows/common';
-import { ConversationRoundState, AgentRunState } from '@agent/core/AgentState';
-import type { AgentWorkspaceState } from '@agent/core/AgentWorkspaceState';
+import { ConversationRoundState } from '@agent/core/AgentState';
 import {
   createResponseCycleFlow,
   type ResponseCycleShared,
@@ -37,6 +36,7 @@ import { createRetryState } from '@agent/core/flows/RetryState';
 import { interpretCycleCompletion } from '@agent/core/flows/CommonCycleTypes';
 import {
   finalizeRound,
+  type CycleStateSlices,
   type ResponseCycleOptions,
   type ResponseCycleParams,
 } from '@agent/core/flows/CycleServices';
@@ -60,16 +60,12 @@ import type {
 // ============================================================================
 
 /**
- * State slices for cycle execution.
- * Using slices directly instead of AgentSharedStore wrapper.
+ * Core state slices for cycle prep input.
+ * Uses CycleStateSlices from CycleServices (single source of truth).
  */
-interface CycleStateSlices {
-  round: ConversationRoundState;
-  run: AgentRunState;
-  workspace: AgentWorkspaceState;
-}
+type CoreStateSlices = Pick<CycleStateSlices, 'round' | 'run' | 'workspace'>;
 
-interface CyclePrepInput extends CycleStateSlices {
+interface CyclePrepInput extends CoreStateSlices {
   context: RoundContext;
   currentRound: number;
   outputLocation: AgentFileLocation;
@@ -82,7 +78,7 @@ type CycleExecResult =
       failedWithError: boolean;
       errorMessage?: string;
       userCancelled: boolean;
-    } & CycleStateSlices)
+    } & CoreStateSlices)
   | { kind: 'error'; error: Error };
 
 // ============================================================================


### PR DESCRIPTION
Use CycleStateSlices from CycleServices as single source of truth
instead of redefining locally. This reduces change amplification
when modifying state slices.

- Import CycleStateSlices from @agent/core/flows/CycleServices
- Create CoreStateSlices type alias using Pick<> for clarity
- Remove unused AgentRunState, AgentWorkspaceState imports

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Consolidates state slice typing to reduce duplication and align with shared flow services.
> 
> - Import `CycleStateSlices` from `@agent/core/flows/CycleServices` and define `CoreStateSlices = Pick<CycleStateSlices, 'round' | 'run' | 'workspace'>`
> - Update `CyclePrepInput` and `CycleExecResult` to use `CoreStateSlices`; delete locally defined `CycleStateSlices` interface
> - Remove unused `AgentRunState` and `AgentWorkspaceState` imports
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 00ef66034ecf62de55630bec456949839683cbd1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->