### PR TITLE
refactor: flatten buildBaseFlowServices abstraction layer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -236,7 +236,7 @@ Aim for code that looks like it was designed correctly from the start:
 Agent flows follow the PocketFlow pattern in `src/agent/implementations/flows/`:
 
 - **Flow types**: `ReflectionFlow` for multi-round reflection agents, `ToolUseRunFlow` for tool-use agents
-- **Services** are immutable dependencies injected via `flow.setServices()`. Nodes access them via `this.services`. Define service interfaces in flow-specific files (e.g., `ReflectionServices`, `ToolUseServices`) extending `BaseFlowServices`.
+- **Services** are immutable dependencies injected via `flow.setServices()`. Nodes access them via `this.services`. Define service interfaces in flow-specific files (e.g., `ReflectionServices`, `ToolUseServices`) extending `BaseFlowContextInit` with convenience accessors (`logger`, `context`) defined inline.
 - **Shared store** contains only mutable state (memories). Nodes read/write via `prep()` and `post()` methods.
 - **Flow transitions** - use named constants instead of magic values:
   - `FlowTransition.DEFAULT` - follow next() successor

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,7 @@ This project uses **Zod v4**. See AGENTS.md for idiomatic Zod v4 patterns includ
 When refactoring, eliminate unnecessary wrapper functions and indirection layers:
 
 **Anti-pattern (too many layers):**
+
 ```
 Node.exec()
   → wrapperFunction()
@@ -112,6 +113,7 @@ Node.exec()
 ```
 
 **Preferred (direct execution):**
+
 ```
 Node.exec()
   → createFlow()
@@ -119,6 +121,7 @@ Node.exec()
 ```
 
 **Guidelines:**
+
 - Nodes should create and run flows directly in `exec()`, not delegate to wrapper functions
 - If a wrapper only creates state + runs flow + interprets results, inline it
 - Delete wrapper files entirely when they become unused (don't leave empty re-exports)
@@ -126,6 +129,7 @@ Node.exec()
 - Update imports to point to the source of truth (e.g., `CycleServices` not re-exporting files)
 
 **Example refactoring impact:**
+
 - `ResponseCycle.ts` deleted → `ResponseCycleNode` creates flow directly
 - `ToolUseCycle.ts` deleted → `ToolUseCycleNode` creates flow directly
 - Tests updated to use `createResponseCycleFlow()` / `createToolUseCycleFlow()` directly

--- a/src/agent/core/flows/CycleServices.ts
+++ b/src/agent/core/flows/CycleServices.ts
@@ -35,6 +35,7 @@ import type { AgentCycleBaseOptions } from '@agent/core/AgentCycleOptions';
 import type { AgentConfig } from '@agent/core/AgentConfig';
 import type { AgentWorkspaceState } from '@agent/core/AgentWorkspaceState';
 import type { IToolRegistry } from '@agent/core/ToolTypes';
+import type { NormalizedUsage } from '@agent/types/NormalizedUsage';
 import type { TaskRunFileService } from '@utils/files';
 
 // ============================================================================
@@ -191,9 +192,7 @@ export async function finalizeRound(slices: CycleStateSlices): Promise<void> {
 export interface ToolUseCycleFinalizeInput {
   cycleIndex: number;
   responseTimeMs: number;
-  normalizedUsage:
-    | import('@agent/types/NormalizedUsage').NormalizedUsage
-    | null;
+  normalizedUsage: NormalizedUsage | null;
   run: BaseCycleStateSlices['run'];
   onRoundFinalized?: RoundFinalizedCallback;
 }

--- a/src/agent/core/flows/CycleServices.ts
+++ b/src/agent/core/flows/CycleServices.ts
@@ -81,7 +81,6 @@ export interface CycleStateSlices extends BaseCycleStateSlices {
   round: ConversationRoundState;
 }
 
-
 // ============================================================================
 // CYCLE OPTIONS (single source of truth)
 // ============================================================================
@@ -192,7 +191,9 @@ export async function finalizeRound(slices: CycleStateSlices): Promise<void> {
 export interface ToolUseCycleFinalizeInput {
   cycleIndex: number;
   responseTimeMs: number;
-  normalizedUsage: import('@agent/types/NormalizedUsage').NormalizedUsage | null;
+  normalizedUsage:
+    | import('@agent/types/NormalizedUsage').NormalizedUsage
+    | null;
   run: BaseCycleStateSlices['run'];
   onRoundFinalized?: RoundFinalizedCallback;
 }

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -151,7 +151,7 @@ export interface ToolUseCycleState extends BaseCycleState {
    * Normalized usage for current cycle.
    * Reset after finalization when continuing to next cycle.
    */
-  cycleNormalizedUsage?: import('@agent/types/NormalizedUsage').NormalizedUsage;
+  cycleNormalizedUsage?: NormalizedUsage;
   /**
    * Whether the last cycle ended normally (model said end_turn).
    *

--- a/src/agent/implementations/flows/common/BaseFlowServices.ts
+++ b/src/agent/implementations/flows/common/BaseFlowServices.ts
@@ -81,30 +81,6 @@ export interface BaseFlowContextInit<C = unknown> {
   onInterrupt?: () => void;
 }
 
-// ============================================================================
-// Service Interfaces
-// ============================================================================
-
-/**
- * Convenience accessors added to services.
- *
- * These are convenience aliases that simplify access patterns:
- * - logger: Direct access to executionContext.logger
- * - context: Alias for executionContext (used by cycle options)
- *
- * Child service interfaces (ReflectionServices, ToolUseServices) extend
- * BaseFlowContextInit and include these accessors directly.
- *
- * @deprecated Use BaseFlowContextInit directly. Child services now define
- * logger and context fields inline. This type is kept for backward compatibility.
- */
-export type BaseFlowServices<C = unknown> = BaseFlowContextInit<C> & {
-  /** Logger for debugging and progress (convenience accessor) */
-  readonly logger: AgentLogger;
-  /** Alias for executionContext (used by AgentCycleOptions) */
-  readonly context: AgentExecutionContext;
-};
-
 /**
  * Base flow params type.
  *
@@ -117,22 +93,19 @@ export interface FlowParams {
 }
 
 // ============================================================================
-// Service Factory
+// Convenience Accessors
 // ============================================================================
 
 /**
- * Build base flow services from initialization config.
+ * Convenience accessors that child service interfaces define inline.
  *
- * Spreads init and adds convenience accessors (logger, context alias).
+ * ToolUseServices and ReflectionServices extend BaseFlowContextInit and add:
+ * - logger: Direct access to executionContext.logger
+ * - context: Alias for executionContext (used by cycle options)
  */
-export function buildBaseFlowServices<C>(
-  init: BaseFlowContextInit<C>,
-): BaseFlowServices<C> {
-  return {
-    ...init,
-    logger: init.executionContext.logger,
-    context: init.executionContext,
-  };
+export interface FlowServiceAccessors {
+  readonly logger: AgentLogger;
+  readonly context: AgentExecutionContext;
 }
 
 // ============================================================================
@@ -140,7 +113,7 @@ export function buildBaseFlowServices<C>(
 // ============================================================================
 
 /**
- * Build AgentCycleBaseOptions from BaseFlowServices or BaseFlowContextInit.
+ * Build AgentCycleBaseOptions from flow services or initialization config.
  *
  * Eliminates manual field copying by mapping service fields to cycle option fields:
  * - setting -> agentSetting
@@ -149,23 +122,23 @@ export function buildBaseFlowServices<C>(
  * - executionContext -> context (via services.context if available)
  * - getClient() -> client
  *
- * This helper enables inheritance-based option building instead of manual field copying.
+ * Accepts either:
+ * - BaseFlowContextInit (raw config, uses executionContext.logger)
+ * - Services with FlowServiceAccessors (uses .logger and .context directly)
  *
  * @param services - Flow services or initialization config
  * @returns Base cycle options ready for extension
  */
 export function buildBaseCycleOptions<C>(
-  services: BaseFlowServices<C> | BaseFlowContextInit<C>,
+  services: BaseFlowContextInit<C> & Partial<FlowServiceAccessors>,
 ): AgentCycleBaseOptions<C> {
   return {
     modelHandler: services.modelHandler,
     agentSetting: services.setting,
     agentPrompt: services.prompt,
     userVars: services.userVarChannels.transient,
-    logger:
-      'logger' in services ? services.logger : services.executionContext.logger,
-    context:
-      'context' in services ? services.context : services.executionContext,
+    logger: services.logger ?? services.executionContext.logger,
+    context: services.context ?? services.executionContext,
     client: services.getClient(),
     checkInterruption: services.checkInterruption,
     setAbortController: services.setAbortController,

--- a/src/agent/implementations/flows/common/index.ts
+++ b/src/agent/implementations/flows/common/index.ts
@@ -3,9 +3,10 @@
  *
  * Exports:
  * - NODE_NO_RETRY, NODE_NO_WAIT: Node configuration constants
- * - NodeExecResult: Shared result type for nodes
- * - BaseFlowServices: Base service interface for all flows
+ * - BaseFlowContextInit: Base initialization config for all flows
+ * - FlowServiceAccessors: Convenience accessors (logger, context) added by child services
  * - FlowParams: Base flow params type (aliased by flow-specific types)
+ * - buildBaseCycleOptions: Helper to build cycle options from services
  */
 
 export * from './AgentRunFlowRunner';

--- a/src/agent/implementations/flows/common/index.ts
+++ b/src/agent/implementations/flows/common/index.ts
@@ -1,12 +1,9 @@
 /**
  * Common agent flow infrastructure.
  *
- * Exports:
- * - NODE_NO_RETRY, NODE_NO_WAIT: Node configuration constants
- * - BaseFlowContextInit: Base initialization config for all flows
- * - FlowServiceAccessors: Convenience accessors (logger, context) added by child services
- * - FlowParams: Base flow params type (aliased by flow-specific types)
- * - buildBaseCycleOptions: Helper to build cycle options from services
+ * Re-exports from:
+ * - AgentRunFlowRunner: Flow runner utilities
+ * - BaseFlowServices: Base types, accessors, and cycle options builder
  */
 
 export * from './AgentRunFlowRunner';

--- a/src/agent/implementations/flows/reflection/ReflectionFlowContext.ts
+++ b/src/agent/implementations/flows/reflection/ReflectionFlowContext.ts
@@ -29,7 +29,6 @@ import { PromptBuilder } from '@utils/prompt';
 import { TaskRunFileService } from '@utils/files';
 import { LatexMediaManager } from '@latex';
 import { createBaseFileLocations } from './helpers';
-import { buildBaseFlowServices } from '../common';
 import type {
   ReflectionServices,
   ReflectionServicesPartial,
@@ -258,13 +257,15 @@ export function buildReflectionServices<C = unknown>(
     init.getOutputFileLocation ??
     createOutputFileLocationGetter(config, setting, modelHandler, fileService);
 
-  // Build base services
-  const baseServices = buildBaseFlowServices(init);
-
   // Return partial services (missing runStage - added by runReflectionFlow)
   // Round stages (r0, r1...) are managed by RoundPersistedFlow, not by services
   return {
-    ...baseServices,
+    // Spread base init fields
+    ...init,
+    // Add convenience accessors
+    logger: executionContext.logger,
+    context: executionContext,
+    // Override with narrowed setting type
     setting,
     outputHandler,
     latexMediaManager,

--- a/src/agent/implementations/flows/reflection/ReflectionServices.ts
+++ b/src/agent/implementations/flows/reflection/ReflectionServices.ts
@@ -13,9 +13,11 @@
 import type { IOutputHandler } from '@agent/output';
 import type { AgentWorkflowSetting } from '@agent/core/AgentDataclass';
 import type { RoundFinalizedCallback } from '@agent/core/flows/CycleServices';
-import type { BaseFlowContextInit } from '@agent/implementations/flows/common';
-import type { AgentLogStage, AgentLogger } from '@logger/AgentLogger';
-import type { AgentExecutionContext } from '@agent/runtime/AgentExecutionContext';
+import type {
+  BaseFlowContextInit,
+  FlowServiceAccessors,
+} from '../common/BaseFlowServices';
+import type { AgentLogStage } from '@logger/AgentLogger';
 import type { PromptBuilder } from '@utils/prompt';
 import type { AgentFileLocation, TaskRunFileService } from '@utils/files';
 import type { LatexMediaManager } from '@latex';
@@ -31,14 +33,9 @@ import type { LatexMediaManager } from '@latex';
  * - runStage: Parent logging stage for round stages (runtime-only)
  * - Configuration-driven behavior delegates
  */
-export interface ReflectionServices<
-  C = unknown,
-> extends BaseFlowContextInit<C> {
-  /** Logger for debugging and progress */
-  readonly logger: AgentLogger;
-
-  /** Execution context (IDs, storage key, etc.) */
-  readonly context: AgentExecutionContext;
+export interface ReflectionServices<C = unknown>
+  extends BaseFlowContextInit<C>,
+    FlowServiceAccessors {
   /** Narrow setting to workflow-specific type */
   readonly setting: AgentWorkflowSetting;
   /** Output handler for file processing and artifacts */

--- a/src/agent/implementations/flows/reflection/index.ts
+++ b/src/agent/implementations/flows/reflection/index.ts
@@ -55,6 +55,3 @@ export {
   ReflectionFlowStateSchema,
   RoundContextSchema,
 } from './ReflectionFlowState';
-
-// Individual nodes (for testing or extension)
-export * from './nodes';

--- a/src/agent/implementations/flows/reflection/nodes/ResponseCycleNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/ResponseCycleNode.ts
@@ -209,7 +209,10 @@ export class ResponseCycleNode<C = unknown> extends Node<
       await flow.run(shared);
 
       // Interpret completion from flow state
-      const completion = interpretCycleCompletion(shared.state, shared.retryState);
+      const completion = interpretCycleCompletion(
+        shared.state,
+        shared.retryState,
+      );
 
       return {
         kind: 'success',

--- a/src/agent/implementations/flows/tooluse/ToolUseFlowContext.ts
+++ b/src/agent/implementations/flows/tooluse/ToolUseFlowContext.ts
@@ -28,7 +28,7 @@ import { getDefaultToolRegistry } from '@tools/registry';
 import { buildInitialToolUsePrompts } from '@utils/prompt';
 import { ToolUseSessionLifecycle } from './ToolUseSessionLifecycle';
 
-import { buildBaseFlowServices, buildBaseCycleOptions } from '../common';
+import { buildBaseCycleOptions } from '../common';
 import type { ToolUseServices, PrepareStateResult } from './ToolUseServices';
 import type { ToolUseSessionSnapshot } from './ToolUseSessionTypes';
 
@@ -257,12 +257,14 @@ export function buildToolUseServices<C = unknown>(
   // Capture snapshot in closure for prepareState
   const snapshot = resumeSnapshot ?? null;
 
-  // Build base services
-  const baseServices = buildBaseFlowServices(init);
-
   // Return complete services object
   const services: ToolUseServices<C> = {
-    ...baseServices,
+    // Spread base init fields
+    ...init,
+    // Add convenience accessors
+    logger: init.executionContext.logger,
+    context: init.executionContext,
+    // Override with narrowed setting type
     setting,
     toolRegistry,
     session: sessionLifecycle,

--- a/src/agent/implementations/flows/tooluse/ToolUseServices.ts
+++ b/src/agent/implementations/flows/tooluse/ToolUseServices.ts
@@ -6,9 +6,8 @@
  * - Nodes access services via this.services
  * - shared contains mutable runtime state only
  *
- * ToolUseServices extends BaseFlowContextInit with tool-use specific
- * dependencies (tool registry, session, cycle operations), plus
- * convenience accessors (logger, context) defined inline.
+ * ToolUseServices extends BaseFlowContextInit and FlowServiceAccessors
+ * with tool-use specific dependencies (tool registry, session, cycle operations).
  */
 
 import type { ToolUseCycleOptions } from '@agent/core/flows/CycleServices';
@@ -18,9 +17,10 @@ import type { AgentToolUseSetting } from '@agent/core/AgentDataclass';
 import type { RoundFinalizedCallback } from '@agent/core/flows/CycleServices';
 import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
 import type { IToolRegistry } from '@agent/core/ToolTypes';
-import type { BaseFlowContextInit } from '@agent/implementations/flows/common';
-import type { AgentLogger } from '@logger/AgentLogger';
-import type { AgentExecutionContext } from '@agent/runtime/AgentExecutionContext';
+import type {
+  BaseFlowContextInit,
+  FlowServiceAccessors,
+} from '../common/BaseFlowServices';
 import type { IToolUseSession } from './ToolUseSessionLifecycle';
 
 // Note: RunCycleResult was removed - ToolUseCycleNode now directly runs ToolUseCycleFlow
@@ -46,12 +46,9 @@ export interface PrepareStateResult {
  * Note: ToolUseCycleNode directly instantiates ToolUseCycleFlow (no runCycle indirection).
  * Persistence is handled automatically by PersistedFlow after each node.
  */
-export interface ToolUseServices<C = unknown> extends BaseFlowContextInit<C> {
-  /** Logger for debugging and progress */
-  readonly logger: AgentLogger;
-
-  /** Execution context (IDs, storage key, etc.) */
-  readonly context: AgentExecutionContext;
+export interface ToolUseServices<C = unknown>
+  extends BaseFlowContextInit<C>,
+    FlowServiceAccessors {
   /** Narrow setting to tool-use specific type */
   readonly setting: AgentToolUseSetting;
 

--- a/src/agent/implementations/flows/tooluse/ToolUseServices.ts
+++ b/src/agent/implementations/flows/tooluse/ToolUseServices.ts
@@ -6,8 +6,9 @@
  * - Nodes access services via this.services
  * - shared contains mutable runtime state only
  *
- * ToolUseServices extends BaseFlowServices with tool-use specific
- * dependencies (tool registry, session, cycle operations).
+ * ToolUseServices extends BaseFlowContextInit with tool-use specific
+ * dependencies (tool registry, session, cycle operations), plus
+ * convenience accessors (logger, context) defined inline.
  */
 
 import type { ToolUseCycleOptions } from '@agent/core/flows/CycleServices';


### PR DESCRIPTION
- Remove deprecated BaseFlowServices type and buildBaseFlowServices() function
- Inline service building directly in ToolUseFlowContext and ReflectionFlowContext
- Simplify buildBaseCycleOptions() to use BaseFlowContextInit with optional accessors
- Remove internal node exports from reflection/index.ts (implementation detail)

This eliminates an unnecessary abstraction layer where buildBaseFlowServices()
was just spreading init + adding two convenience aliases.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Streamlines flow service construction and reduces indirection.
> 
> - Delete `BaseFlowServices` type and `buildBaseFlowServices()`; add `FlowServiceAccessors` with `logger`/`context`
> - Update `ReflectionServices` and `ToolUseServices` to extend `BaseFlowContextInit` + accessors; inline service creation in `ReflectionFlowContext` and `ToolUseFlowContext`
> - Simplify `buildBaseCycleOptions()` to accept `BaseFlowContextInit & Partial<FlowServiceAccessors>` and update callers
> - Tidy exports in `flows/common/index.ts`; remove internal node re-exports from `reflection/index.ts`
> - Normalize `NormalizedUsage` imports in cycle files; minor doc edits in `AGENTS.md` and `CLAUDE.md`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b50df081736e05156e838fa616649afde9dae6e9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->