### PR TITLE
docs: add comprehensive state management architecture analysis

### DIFF
--- a/docs/architecture/STATE_CONSOLIDATION_ANALYSIS.md
+++ b/docs/architecture/STATE_CONSOLIDATION_ANALYSIS.md
@@ -1,0 +1,528 @@
+# State Management Architecture Analysis
+
+## Executive Summary
+
+After deep analysis of the agent state management system, I've identified **critical architectural issues** that lead to code duplication, confusion, and unnecessary complexity. The core problems are:
+
+1. **`AgentRunState.totalRounds` naming/usage confusion** - It's called "totalRounds" but tracks "completed cycles" and is ONLY used by tool-use agents
+2. **Parallel metrics tracking systems** - Tool-use duplicates what reflection already has with `ConversationRoundState`
+3. **Two finalization paths** that do nearly identical work
+4. **`AgentSharedStore` is used inconsistently** - reflection flows don't use it, tool-use flows do
+
+---
+
+## Current State Architecture Diagram
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                        CURRENT STATE HIERARCHY                              │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                             │
+│  ┌──────────────────────────────────────┐                                  │
+│  │         AgentRunState                │  ← Aggregate run statistics      │
+│  ├──────────────────────────────────────┤                                  │
+│  │ • totalRounds: number        ⚠️       │  ← CONFUSING: only tool-use uses │
+│  │ • totalResponseTimeMs: number        │                                  │
+│  │ • usageAccumulator: RunUsageAccum    │                                  │
+│  └──────────────────────────────────────┘                                  │
+│                    │                                                        │
+│     ┌──────────────┴──────────────┐                                        │
+│     ▼                              ▼                                        │
+│  ┌─────────────────────┐    ┌─────────────────────────────────────┐        │
+│  │  REFLECTION FLOW    │    │         TOOL-USE FLOW               │        │
+│  │  (multi-round)      │    │         (session-based)             │        │
+│  ├─────────────────────┤    ├─────────────────────────────────────┤        │
+│  │                     │    │                                     │        │
+│  │ ReflectionFlowState │    │ ToolUseRunState                     │        │
+│  │ ├─ currentRound     │    │ ├─ conversation                     │        │
+│  │ ├─ totalRounds      │    │ ├─ shouldSkipCycle                  │        │
+│  │ ├─ runStateSnapshot │    │ └─ storeSnapshot ──────────┐        │        │
+│  │ └─ workspaceSnapshot│    │                            │        │        │
+│  │                     │    │                            ▼        │        │
+│  │         ⬇️           │    │              AgentSharedStore       │        │
+│  │                     │    │              ├─ round (unused!) ⚠️   │        │
+│  │ ConversationRound   │    │              ├─ run                 │        │
+│  │ State (via services)│    │              ├─ workspace           │        │
+│  │ ├─ roundIndex       │    │              └─ user                │        │
+│  │ ├─ continuationCount│    │                                     │        │
+│  │ ├─ responseTimeMs   │    │ ToolUseCycleState (DUPLICATES!) ⚠️   │        │
+│  │ └─ normalizedUsage  │    │ ├─ cycleIndex       ≈ roundIndex    │        │
+│  │                     │    │ ├─ cycleResponseTimeMs ≈ responseMs │        │
+│  │                     │    │ └─ cycleNormalizedUsage ≈ normUsage │        │
+│  └─────────────────────┘    └─────────────────────────────────────┘        │
+│                                                                             │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Issue #1: `AgentRunState.totalRounds` - Misnamed and Misused
+
+### The Problem
+
+```typescript
+// AgentState.ts:142-176
+export class AgentRunState {
+  public totalRounds: number;  // ⚠️ CONFUSING NAME
+
+  incrementRounds(): void {
+    this.totalRounds += 1;  // Only called by tool-use!
+  }
+}
+```
+
+**What it's called**: `totalRounds`
+**What it actually tracks**: Number of completed CYCLES (only in tool-use flows)
+**Who uses it**:
+- Tool-use: YES - incremented after each cycle completion
+- Reflection: NO - stays at 0 the entire run
+
+### Evidence
+
+| Flow Type | Uses `incrementRounds()`? | Value at end of run |
+|-----------|---------------------------|---------------------|
+| Reflection | ❌ Never | 0 |
+| Tool-Use | ✅ After each cycle | N (number of cycles) |
+
+### Impact
+
+1. **Confusion**: Developers expect "totalRounds" to track rounds, but it tracks cycles
+2. **Asymmetry**: Different tracking between flow types
+3. **Dead Code**: Reflection flows carry this field but never use it
+
+### Recommendation
+
+**Rename to `completedCycles`** and only use in tool-use flows, OR eliminate entirely.
+
+---
+
+## Issue #2: Parallel Metrics Tracking Systems
+
+### The Problem
+
+Tool-use cycles duplicate the exact same metrics that `ConversationRoundState` already tracks:
+
+```
+┌─────────────────────────────────┐     ┌─────────────────────────────────┐
+│   ConversationRoundState        │     │   ToolUseCycleState             │
+│   (Reflection flows)            │     │   (Tool-use flows)              │
+├─────────────────────────────────┤     ├─────────────────────────────────┤
+│ roundIndex: number              │ ≡   │ cycleIndex: number              │
+│ responseTimeMs: number          │ ≡   │ cycleResponseTimeMs: number     │
+│ normalizedUsage: NormalizedUsage│ ≡   │ cycleNormalizedUsage: NormUsage │
+│ continuationCount: number       │     │ (not tracked)                   │
+│ outputFile: string              │     │ (not tracked)                   │
+└─────────────────────────────────┘     └─────────────────────────────────┘
+         │                                        │
+         ▼                                        ▼
+    finalizeRound()                    finalizeToolUseCycle()
+         │                                        │
+         ▼                                        ▼
+  run.recordRound(round)              run.usageAccumulator.record(...)
+                                      run.addResponseTime(...)
+```
+
+### The Duplication
+
+1. **Two state types** tracking the same metrics
+2. **Two finalization functions** doing nearly identical work
+3. **Two code paths** to maintain
+
+### CycleServices.ts Evidence
+
+```typescript
+// finalizeRound() - for reflection
+export async function finalizeRound(slices: CycleStateSlices): Promise<void> {
+  const { round, run, onRoundFinalized } = slices;
+  run.recordRound(round);  // Uses round object
+  if (onRoundFinalized) await onRoundFinalized(run);
+}
+
+// finalizeToolUseCycle() - for tool-use
+export async function finalizeToolUseCycle(input: ToolUseCycleFinalizeInput): Promise<void> {
+  const { cycleIndex, responseTimeMs, normalizedUsage, run } = input;
+  if (normalizedUsage) {
+    run.usageAccumulator.recordNormalizedUsage(cycleIndex, normalizedUsage);  // Direct values!
+  }
+  run.addResponseTime(responseTimeMs);  // Direct values!
+  if (input.onRoundFinalized) await input.onRoundFinalized(run);
+}
+```
+
+### Why This Happened
+
+Tool-use was designed to NOT need `ConversationRoundState` because:
+1. Tool-use doesn't have explicit "rounds" (it's session-based)
+2. Wanted to avoid passing round object through services
+
+But the result is: **we duplicated the metrics tracking logic**.
+
+### Recommendation
+
+**Unify into ConversationRoundState** (or rename to `CycleMetricsState`) and use it for both flow types.
+
+---
+
+## Issue #3: AgentSharedStore Inconsistency
+
+### The Problem
+
+```
+REFLECTION FLOWS:
+  ├─ ReflectionFlowState (flat state, snapshots)
+  ├─ Does NOT use AgentSharedStore during flow
+  └─ Passes slices directly via services
+
+TOOL-USE FLOWS:
+  ├─ ToolUseRunState.storeSnapshot → AgentSharedStore
+  ├─ Reconstructs store every cycle
+  └─ But store.round is NEVER USED ⚠️
+```
+
+### Evidence
+
+In `ToolUseFlowContext.ts:164-166`:
+```typescript
+const store = createSharedStore({
+  roundIndex: currentRunState.totalRounds,  // Creates round object
+  runState: currentRunState,
+  // ...
+});
+```
+
+But then in `ToolUseCycleFlow.ts`, the `round` object is NEVER accessed:
+- Services only include: `run`, `workspace`, `onRoundFinalized`
+- NO `round` in `BaseCycleStateSlices` for tool-use
+
+**The round object exists in the store but is never used by tool-use flows.**
+
+### Impact
+
+1. **Wasted memory**: Creating unused ConversationRoundState objects
+2. **Confusion**: Store has `round` but tool-use ignores it
+3. **Serialization overhead**: Round snapshots saved but never read
+
+### Recommendation
+
+Either:
+1. **Remove round from AgentSharedStore for tool-use**, OR
+2. **Use the round object in tool-use** (eliminating the duplicate cycleIndex/cycleResponseTimeMs/cycleNormalizedUsage)
+
+---
+
+## Issue #4: Snapshot Round-Trip Overhead
+
+### The Pattern
+
+Every tool-use cycle:
+```typescript
+// In ToolUseCycleNode.prep()
+const store = createSharedStore({ snapshot: shared.state.storeSnapshot });
+// ... cycle runs ...
+
+// In ToolUseCycleNode.post()
+shared.state.storeSnapshot = prepRes.store.toSnapshot();
+```
+
+This means:
+1. **Deserialize** store from JSON → class instances
+2. Run cycle
+3. **Serialize** store back to JSON
+
+For EVERY cycle, even if store wasn't modified.
+
+### Impact
+
+- Extra CPU for JSON serialization/deserialization
+- Memory churn creating temporary class instances
+
+### Recommendation
+
+This is necessary for PersistedFlow but could be optimized with dirty tracking.
+
+---
+
+## Proposed Consolidated Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                      PROPOSED STATE HIERARCHY                               │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                             │
+│  ┌──────────────────────────────────────┐                                  │
+│  │         AgentRunState                │  ← Keep as aggregate             │
+│  ├──────────────────────────────────────┤                                  │
+│  │ • totalResponseTimeMs: number        │                                  │
+│  │ • usageAccumulator: RunUsageAccum    │                                  │
+│  │ ✅ REMOVE: totalRounds (unused/confusing)                               │
+│  └──────────────────────────────────────┘                                  │
+│                    │                                                        │
+│                    ▼                                                        │
+│  ┌──────────────────────────────────────┐                                  │
+│  │     CycleMetrics (renamed)           │  ← SINGLE source for metrics     │
+│  ├──────────────────────────────────────┤                                  │
+│  │ • cycleIndex: number                 │                                  │
+│  │ • responseTimeMs: number             │                                  │
+│  │ • normalizedUsage: NormalizedUsage   │                                  │
+│  │ • continuationCount?: number         │  ← Optional, only for reflection │
+│  │ • outputFile?: string                │  ← Optional, only for reflection │
+│  └──────────────────────────────────────┘                                  │
+│                    │                                                        │
+│     ┌──────────────┴──────────────┐                                        │
+│     ▼                              ▼                                        │
+│  ┌─────────────────────┐    ┌─────────────────────────────────────┐        │
+│  │  REFLECTION FLOW    │    │         TOOL-USE FLOW               │        │
+│  ├─────────────────────┤    ├─────────────────────────────────────┤        │
+│  │                     │    │                                     │        │
+│  │ Uses CycleMetrics   │    │ Uses CycleMetrics                   │        │
+│  │ via services        │    │ via services                        │        │
+│  │                     │    │                                     │        │
+│  │ ✅ SAME finalization│    │ ✅ SAME finalization                 │        │
+│  │    path             │    │    path                             │        │
+│  └─────────────────────┘    └─────────────────────────────────────┘        │
+│                                                                             │
+│  SINGLE finalizeCycle(slices: CycleSlices): Promise<void>                  │
+│                                                                             │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Concrete Refactoring Steps
+
+### Phase 1: Eliminate `AgentRunState.totalRounds`
+
+**Files to modify:**
+- `src/agent/core/AgentState.ts` - Remove `totalRounds` field and `incrementRounds()`
+- `src/agent/core/flows/ToolUseCycleFlow.ts:616` - Remove `run.incrementRounds()` call
+- `src/agent/implementations/flows/tooluse/ToolUseFlowContext.ts:165` - Don't use `currentRunState.totalRounds`
+- `src/agent/implementations/flows/ToolUseRunFlow.ts:305` - Use different source for cycleIndex
+
+**Alternative for cycleIndex**: Track in ToolUseRunState or derive from usageAccumulator.length
+
+### Phase 2: Unify Metrics Tracking
+
+**Option A: Use ConversationRoundState everywhere**
+- Rename to `CycleMetricsState` for clarity
+- Tool-use flows pass it via services (like reflection does)
+- Delete duplicate fields from ToolUseCycleState
+- Merge `finalizeToolUseCycle()` into `finalizeRound()`
+
+**Option B: Create minimal CycleMetrics interface**
+- Extract common metrics to new interface
+- Both ConversationRoundState and ToolUseCycleState implement it
+- Single finalization function accepts the interface
+
+### Phase 3: Clean Up AgentSharedStore
+
+**If using ConversationRoundState for tool-use:**
+- Tool-use can actually use `store.round`
+- Remove duplicate metrics from ToolUseCycleState
+
+**If NOT using ConversationRoundState:**
+- Create `ToolUseSharedStore` without round field
+- Or keep AgentSharedStore but make round optional
+
+### Phase 4: Simplify Service Injection
+
+Current complexity:
+```
+BaseFlowContextInit
+  → buildBaseFlowServices()
+    → ReflectionFlowContext / ToolUseFlowContext
+      → buildBaseCycleOptions()
+        → ResponseCycleServices / ToolUseCycleServices
+```
+
+Could be simplified to fewer layers.
+
+---
+
+## Impact Assessment
+
+| Issue | Complexity | Impact | Priority |
+|-------|------------|--------|----------|
+| #1 Rename/remove totalRounds | Low | Medium | High |
+| #2 Unify metrics tracking | Medium | High | High |
+| #3 AgentSharedStore consistency | Medium | Medium | Medium |
+| #4 Snapshot overhead | High | Low | Low |
+
+---
+
+## Recommended Order of Operations
+
+1. **First**: Remove `AgentRunState.totalRounds` - minimal risk, high clarity gain
+2. **Second**: Unify finalization paths - reduces code duplication
+3. **Third**: Decide on AgentSharedStore strategy for tool-use
+4. **Later**: Consider snapshot optimization (dirty tracking)
+
+---
+
+## Summary: What to Delete
+
+| Item | Location | Reason |
+|------|----------|--------|
+| `totalRounds` field | AgentRunState | Only used by tool-use, confusing name |
+| `incrementRounds()` | AgentRunState | Only caller is tool-use, removes with field |
+| `cycleIndex` in state | ToolUseCycleState | Use CycleMetrics.cycleIndex instead |
+| `cycleResponseTimeMs` | ToolUseCycleState | Use CycleMetrics.responseTimeMs instead |
+| `cycleNormalizedUsage` | ToolUseCycleState | Use CycleMetrics.normalizedUsage instead |
+| `finalizeToolUseCycle()` | CycleServices.ts | Merge into unified `finalizeCycle()` |
+| Unused `round` in tool-use store | AgentSharedStore | Either use it or remove it |
+
+---
+
+## Issue #5: Factory Function Overhead
+
+### The Problem
+
+There are **7 factory functions** in the critical path from agent execution to model invocation:
+
+```
+executeAgent()
+  → prepareFlowExecution()         ← Factory #1
+    → createReflectionFlowContext() ← Factory #2 (wrapper)
+      → buildReflectionServices()   ← Factory #3
+        → buildBaseFlowServices()   ← Factory #4 (pass-through!)
+          → createResponseCycleFlow() ← Factory #5
+            → buildBaseCycleOptions()  ← Factory #6 (field mapper!)
+```
+
+### Pass-Through Wrappers Identified
+
+**`buildBaseFlowServices()` - Just spreads + adds 2 aliases**
+```typescript
+// BaseFlowServices.ts:128
+export function buildBaseFlowServices<C>(init: BaseFlowContextInit<C>): BaseFlowServices<C> {
+  return {
+    ...init,                           // ← Just spread
+    logger: init.executionContext.logger,  // ← Alias #1
+    context: init.executionContext,        // ← Alias #2
+  };
+}
+```
+
+**`buildBaseCycleOptions()` - Just field mapping**
+```typescript
+// BaseFlowServices.ts:157
+export function buildBaseCycleOptions<C>(services): AgentCycleBaseOptions<C> {
+  return {
+    modelHandler: services.modelHandler,
+    agentSetting: services.setting,      // ← Field rename
+    agentPrompt: services.prompt,         // ← Field rename
+    // ... more mapping ...
+  };
+}
+```
+
+### ReflectionFlowContext - Unnecessary Wrapper Object
+
+```typescript
+// Creates wrapper just to hold services + 2 lifecycle methods
+export function createReflectionFlowContext<C>(init): ReflectionFlowContext<C> {
+  const services = buildReflectionServices(init);
+  return {
+    services,     // ← Services wrapped in context object
+    setActiveRun(storageKey) { ... },  // ← 1 line of code
+    dispose() { ... },                  // ← 1 line of code
+    interrupt() { ... },                // ← 2 lines of code
+  };
+}
+```
+
+**Usage in runReflectionFlow.ts**:
+```typescript
+const flowContext = createReflectionFlowContext({...});
+flowContext.setActiveRun(storageKey);  // ← Just calls outputHandler.setActiveRun()
+// ... later unwraps services anyway ...
+services = { ...flowContext.services, runStage };
+// ... finally ...
+flowContext?.dispose();  // ← Just calls retryCoordinator.clearRequest()
+```
+
+### Recommendation
+
+**Eliminate 2-3 factory functions:**
+1. **Inline `buildBaseFlowServices()`** - It only spreads + adds 2 aliases
+2. **Inline `buildBaseCycleOptions()`** - Or standardize field names to avoid mapping
+3. **Eliminate `ReflectionFlowContext`** - Call `buildReflectionServices()` directly, inline lifecycle calls
+
+---
+
+## Issue #6: UserVariableChannels Inconsistent Access
+
+### The Pattern
+
+UserVariableChannels has two channels:
+- `input`: Frozen, immutable base variables
+- `transient`: Mutable copy for runtime modifications
+
+### The Inconsistency
+
+**Path A** - Some code uses only `.transient`:
+```typescript
+// buildBaseCycleOptions()
+userVars: services.userVarChannels.transient
+
+// PromptBuilder constructor
+new PromptBuilder(prompt, setting, userVarChannels.transient, logger);
+```
+
+**Path B** - Some code merges both:
+```typescript
+// ResponseCycleNode.getUserVars()
+return { ...channels.input, ...channels.transient };
+```
+
+### Impact
+
+- Cognitive overhead understanding which path to use
+- Possible bugs if code expects merged form but gets only transient
+- The frozen `.input` is accessed through two different patterns
+
+### Recommendation
+
+**Standardize on one approach:**
+- Either always merge both channels once at the top level
+- Or document clearly when to use which pattern
+
+---
+
+## Complete Refactoring Priority Matrix
+
+| Issue | Complexity | Impact | Risk | Priority |
+|-------|------------|--------|------|----------|
+| #1 Remove `totalRounds` from AgentRunState | Low | Medium | Low | **P1** |
+| #2 Unify metrics tracking (eliminate ToolUseCycleState duplicates) | Medium | High | Medium | **P1** |
+| #5 Inline `buildBaseFlowServices()` | Low | Low | Low | **P2** |
+| #5 Eliminate `ReflectionFlowContext` wrapper | Medium | Medium | Low | **P2** |
+| #3 AgentSharedStore round consistency | Medium | Medium | Medium | **P2** |
+| #6 Standardize UserVariableChannels access | Low | Low | Low | **P3** |
+| #4 Snapshot optimization | High | Low | Medium | **P4** |
+
+---
+
+## Recommended Surgical Operation Order
+
+### Phase 1: Quick Wins (Low Risk, High Clarity)
+
+1. **Rename `AgentRunState.totalRounds` → `completedCycles`** or eliminate
+2. **Inline `buildBaseFlowServices()`** into callers
+
+### Phase 2: Unify Metrics (Medium Risk, High Impact)
+
+1. **Rename `ConversationRoundState` → `CycleMetricsState`**
+2. **Make tool-use flows use CycleMetricsState** via services
+3. **Delete duplicate fields** from ToolUseCycleState
+4. **Merge finalization functions** into single `finalizeCycle()`
+
+### Phase 3: Clean Up Wrappers (Medium Risk, Medium Impact)
+
+1. **Eliminate `ReflectionFlowContext`** wrapper object
+2. **Inline `buildBaseCycleOptions()`** or standardize field names
+3. **Decide on AgentSharedStore** for tool-use (use round or remove it)
+
+### Phase 4: Polish (Low Priority)
+
+1. **Standardize UserVariableChannels** access pattern
+2. **Consider snapshot dirty tracking** for performance

--- a/docs/architecture/STATE_CONSOLIDATION_ANALYSIS.md
+++ b/docs/architecture/STATE_CONSOLIDATION_ANALYSIS.md
@@ -2,20 +2,41 @@
 
 ## ✅ Completed Refactoring
 
-The following issues have been **FIXED** in commit `bbd9b7a`:
+The following issues have been **FIXED**:
 
-| Issue | Status | Changes Made |
+| Issue | Commit | Changes Made |
 |-------|--------|--------------|
-| #1 `AgentRunState.totalRounds` | ✅ FIXED | Removed field, added `getCompletedCycles()` derived from usageAccumulator |
-| #3 AgentSharedStore unused round | ✅ FIXED | Created `ToolUseStore` without round field for tool-use flows |
+| #1 `AgentRunState.totalRounds` | `bbd9b7a` | Removed field, added `getCompletedCycles()` derived from usageAccumulator |
+| #3 AgentSharedStore unused round | `fd6bf00` | Made round optional in single class (DRY approach) |
 
 **Files Changed:**
 - `AgentState.ts` - Removed `totalRounds` and `incrementRounds()`
 - `RunUsageAccumulator.ts` - Added `getCompletedCycles()`
-- `AgentSharedStore.ts` - Added `ToolUseStore`, `ToolUseStoreSnapshot`, `createToolUseStore()`
+- `AgentSharedStore.ts` - Made round optional, `ToolUseStore` is type alias, `createToolUseStore()` creates with `round=null`
 - `ToolUseCycleFlow.ts` - Removed `run.incrementRounds()` call
 - `ToolUseRunFlow.ts` - Uses `ToolUseStore` and `getCompletedCycles()`
 - Tool-use flow files updated to use `ToolUseStore`
+
+### DRY Architecture for Store
+
+```typescript
+// Single class supports both modes:
+export class AgentSharedStore {
+  private roundState: ConversationRoundState | null;
+  // ... other fields
+
+  hasRound(): boolean { return this.roundState !== null; }
+}
+
+// Type alias (not duplicate class)
+export type ToolUseStore = AgentSharedStore;
+
+// Factory for tool-use (round=null)
+export function createToolUseStore(args): AgentSharedStore { ... }
+
+// Factory for reflection (round provided)
+export function createSharedStore(args): AgentSharedStore { ... }
+```
 
 ---
 
@@ -40,7 +61,7 @@ After deep analysis of the agent state management system, I've identified **crit
 
 ---
 
-## Current State Architecture Diagram
+## Current State Architecture Diagram (After Fix)
 
 ```
 ┌─────────────────────────────────────────────────────────────────────────────┐
@@ -50,9 +71,9 @@ After deep analysis of the agent state management system, I've identified **crit
 │  ┌──────────────────────────────────────┐                                  │
 │  │         AgentRunState                │  ← Aggregate run statistics      │
 │  ├──────────────────────────────────────┤                                  │
-│  │ • totalRounds: number        ⚠️       │  ← CONFUSING: only tool-use uses │
 │  │ • totalResponseTimeMs: number        │                                  │
 │  │ • usageAccumulator: RunUsageAccum    │                                  │
+│  │ • getCompletedCycles() ✅            │  ← Derived from accumulator      │
 │  └──────────────────────────────────────┘                                  │
 │                    │                                                        │
 │     ┌──────────────┴──────────────┐                                        │
@@ -69,7 +90,7 @@ After deep analysis of the agent state management system, I've identified **crit
 │  │ └─ workspaceSnapshot│    │                            │        │        │
 │  │                     │    │                            ▼        │        │
 │  │         ⬇️           │    │              AgentSharedStore       │        │
-│  │                     │    │              ├─ round (unused!) ⚠️   │        │
+│  │                     │    │              ├─ round: null ✅       │        │
 │  │ ConversationRound   │    │              ├─ run                 │        │
 │  │ State (via services)│    │              ├─ workspace           │        │
 │  │ ├─ roundIndex       │    │              └─ user                │        │
@@ -79,6 +100,9 @@ After deep analysis of the agent state management system, I've identified **crit
 │  │                     │    │ ├─ cycleResponseTimeMs ≈ responseMs │        │
 │  │                     │    │ └─ cycleNormalizedUsage ≈ normUsage │        │
 │  └─────────────────────┘    └─────────────────────────────────────┘        │
+│                                                                             │
+│  ✅ FIXED: AgentSharedStore now has optional round (null for tool-use)     │
+│  ✅ FIXED: AgentRunState.totalRounds removed, use getCompletedCycles()     │
 │                                                                             │
 └─────────────────────────────────────────────────────────────────────────────┘
 ```

--- a/docs/architecture/STATE_CONSOLIDATION_ANALYSIS.md
+++ b/docs/architecture/STATE_CONSOLIDATION_ANALYSIS.md
@@ -1,13 +1,42 @@
 # State Management Architecture Analysis
 
+## ✅ Completed Refactoring
+
+The following issues have been **FIXED** in commit `bbd9b7a`:
+
+| Issue | Status | Changes Made |
+|-------|--------|--------------|
+| #1 `AgentRunState.totalRounds` | ✅ FIXED | Removed field, added `getCompletedCycles()` derived from usageAccumulator |
+| #3 AgentSharedStore unused round | ✅ FIXED | Created `ToolUseStore` without round field for tool-use flows |
+
+**Files Changed:**
+- `AgentState.ts` - Removed `totalRounds` and `incrementRounds()`
+- `RunUsageAccumulator.ts` - Added `getCompletedCycles()`
+- `AgentSharedStore.ts` - Added `ToolUseStore`, `ToolUseStoreSnapshot`, `createToolUseStore()`
+- `ToolUseCycleFlow.ts` - Removed `run.incrementRounds()` call
+- `ToolUseRunFlow.ts` - Uses `ToolUseStore` and `getCompletedCycles()`
+- Tool-use flow files updated to use `ToolUseStore`
+
+---
+
+## Remaining Issues (Not Yet Fixed)
+
+The following issues are documented but not yet addressed:
+
+1. **Parallel metrics tracking systems** - Tool-use still duplicates `ConversationRoundState` fields in `ToolUseCycleState`
+2. **Two finalization paths** - `finalizeRound()` vs `finalizeToolUseCycle()` still exist
+3. **Factory function overhead** - Pass-through wrappers not yet inlined
+
+---
+
 ## Executive Summary
 
 After deep analysis of the agent state management system, I've identified **critical architectural issues** that lead to code duplication, confusion, and unnecessary complexity. The core problems are:
 
-1. **`AgentRunState.totalRounds` naming/usage confusion** - It's called "totalRounds" but tracks "completed cycles" and is ONLY used by tool-use agents
+1. ~~**`AgentRunState.totalRounds` naming/usage confusion**~~ ✅ FIXED
 2. **Parallel metrics tracking systems** - Tool-use duplicates what reflection already has with `ConversationRoundState`
-3. **Two finalization paths** that do nearly identical work
-4. **`AgentSharedStore` is used inconsistently** - reflection flows don't use it, tool-use flows do
+3. ~~**`AgentSharedStore` is used inconsistently**~~ ✅ FIXED - Created separate `ToolUseStore`
+4. **Two finalization paths** that do nearly identical work
 
 ---
 

--- a/src/agent/core/AgentSharedStore.ts
+++ b/src/agent/core/AgentSharedStore.ts
@@ -24,6 +24,124 @@ export interface AgentSharedStoreSlices {
   user: UserVariableChannels;
 }
 
+// ============================================================================
+// ToolUseStore - Simplified store for tool-use agents (no round tracking)
+// ============================================================================
+
+/**
+ * Store slices for tool-use agents.
+ * Unlike AgentSharedStoreSlices, this doesn't include round since tool-use
+ * agents track cycle metrics directly in flow state, not via round objects.
+ */
+export interface ToolUseStoreSlices {
+  run: AgentRunState;
+  workspace: AgentWorkspaceState;
+  user: UserVariableChannels;
+}
+
+/**
+ * Snapshot schema for ToolUseStore.
+ * Uses z.object() for backward compatibility with legacy snapshots.
+ */
+export const ToolUseStoreSnapshotSchema = z.object({
+  run: AgentRunStateSnapshotSchema,
+  workspace: AgentWorkspaceStateSnapshotSchema,
+  user: UserVariableChannelsSchema,
+});
+
+/**
+ * Output type for ToolUseStore serialization.
+ */
+export type ToolUseStoreSnapshot = z.output<typeof ToolUseStoreSnapshotSchema>;
+
+/**
+ * Simplified store for tool-use agents.
+ *
+ * Unlike AgentSharedStore, this doesn't include a round object since tool-use
+ * agents track cycle metrics (cycleIndex, cycleResponseTimeMs, etc.) directly
+ * in ToolUseCycleState, not via ConversationRoundState.
+ */
+export class ToolUseStore {
+  private readonly runState: AgentRunState;
+  private readonly workspaceState: AgentWorkspaceState;
+  private readonly userChannels: UserVariableChannels;
+
+  constructor(config: ToolUseStoreSlices) {
+    this.runState = config.run;
+    this.workspaceState = config.workspace;
+    this.userChannels = config.user;
+  }
+
+  /** Deserialize from a snapshot. Validates and applies schema defaults. */
+  static fromSnapshot(snapshot: unknown): ToolUseStore {
+    const parsed = ToolUseStoreSnapshotSchema.parse(snapshot);
+    return new ToolUseStore({
+      run: AgentRunState.fromSnapshot(parsed.run),
+      workspace: AgentWorkspaceState.fromSnapshot(parsed.workspace),
+      user: {
+        input: Object.freeze({ ...parsed.user.input }),
+        transient: { ...parsed.user.transient },
+      },
+    });
+  }
+
+  /** Serialize to a snapshot. */
+  toSnapshot(): ToolUseStoreSnapshot {
+    return {
+      run: this.runState.toSnapshot(),
+      workspace: this.workspaceState.toSnapshot(),
+      user: {
+        input: { ...this.userChannels.input },
+        transient: { ...this.userChannels.transient },
+      },
+    };
+  }
+
+  get run(): AgentRunState {
+    return this.runState;
+  }
+
+  get workspace(): AgentWorkspaceState {
+    return this.workspaceState;
+  }
+
+  get user(): UserVariableChannels {
+    return this.userChannels;
+  }
+}
+
+/**
+ * Factory params for creating a new ToolUseStore.
+ */
+interface ToolUseStoreFactoryParams {
+  runState: AgentRunState;
+  workspaceState: AgentWorkspaceState;
+  userChannels: UserVariableChannels;
+}
+
+/**
+ * Factory args - either create from params or restore from snapshot.
+ */
+type ToolUseStoreFactoryArgs =
+  | (ToolUseStoreFactoryParams & { snapshot?: undefined })
+  | { snapshot: ToolUseStoreSnapshot };
+
+/**
+ * Create a ToolUseStore from params or snapshot.
+ */
+export function createToolUseStore(args: ToolUseStoreFactoryArgs): ToolUseStore {
+  if ('snapshot' in args && args.snapshot) {
+    return ToolUseStore.fromSnapshot(args.snapshot);
+  }
+
+  const params = args as ToolUseStoreFactoryParams;
+  return new ToolUseStore({
+    run: params.runState,
+    workspace: params.workspaceState,
+    user: params.userChannels,
+  });
+}
+
 /**
  * We use z.object() instead of z.strictObject() to remain backward compatible
  * with legacy store snapshots that may contain removed or renamed fields.

--- a/src/agent/core/AgentSharedStore.ts
+++ b/src/agent/core/AgentSharedStore.ts
@@ -17,164 +17,90 @@ import {
   type UserVariableChannels,
 } from './AgentCycleOptions';
 
-export interface AgentSharedStoreSlices {
+// ============================================================================
+// Store Slices
+// ============================================================================
+
+/**
+ * Required slices for all stores.
+ */
+export interface BaseStoreSlices {
+  run: AgentRunState;
+  workspace: AgentWorkspaceState;
+  user: UserVariableChannels;
+}
+
+/**
+ * Full store slices including round (for reflection agents).
+ */
+export interface AgentSharedStoreSlices extends BaseStoreSlices {
   round: ConversationRoundState;
-  run: AgentRunState;
-  workspace: AgentWorkspaceState;
-  user: UserVariableChannels;
 }
 
 // ============================================================================
-// ToolUseStore - Simplified store for tool-use agents (no round tracking)
+// Snapshot Schemas
 // ============================================================================
 
 /**
- * Store slices for tool-use agents.
- * Unlike AgentSharedStoreSlices, this doesn't include round since tool-use
- * agents track cycle metrics directly in flow state, not via round objects.
+ * Base snapshot schema without round.
+ * Used by tool-use agents which don't track rounds.
  */
-export interface ToolUseStoreSlices {
-  run: AgentRunState;
-  workspace: AgentWorkspaceState;
-  user: UserVariableChannels;
-}
+export const BaseStoreSnapshotSchema = z.object({
+  run: AgentRunStateSnapshotSchema,
+  workspace: AgentWorkspaceStateSnapshotSchema,
+  user: UserVariableChannelsSchema,
+});
 
 /**
- * Snapshot schema for ToolUseStore.
+ * Full snapshot schema with optional round.
  * Uses z.object() for backward compatibility with legacy snapshots.
+ * Round is optional to support both reflection (with round) and tool-use (without).
  */
-export const ToolUseStoreSnapshotSchema = z.object({
-  run: AgentRunStateSnapshotSchema,
-  workspace: AgentWorkspaceStateSnapshotSchema,
-  user: UserVariableChannelsSchema,
+export const AgentSharedStoreSnapshotSchema = BaseStoreSnapshotSchema.extend({
+  round: ConversationRoundStateSnapshotSchema.optional(),
 });
 
 /**
- * Output type for ToolUseStore serialization.
+ * Output type for store serialization (without round).
  */
-export type ToolUseStoreSnapshot = z.output<typeof ToolUseStoreSnapshotSchema>;
+export type BaseStoreSnapshot = z.output<typeof BaseStoreSnapshotSchema>;
 
 /**
- * Simplified store for tool-use agents.
- *
- * Unlike AgentSharedStore, this doesn't include a round object since tool-use
- * agents track cycle metrics (cycleIndex, cycleResponseTimeMs, etc.) directly
- * in ToolUseCycleState, not via ConversationRoundState.
- */
-export class ToolUseStore {
-  private readonly runState: AgentRunState;
-  private readonly workspaceState: AgentWorkspaceState;
-  private readonly userChannels: UserVariableChannels;
-
-  constructor(config: ToolUseStoreSlices) {
-    this.runState = config.run;
-    this.workspaceState = config.workspace;
-    this.userChannels = config.user;
-  }
-
-  /** Deserialize from a snapshot. Validates and applies schema defaults. */
-  static fromSnapshot(snapshot: unknown): ToolUseStore {
-    const parsed = ToolUseStoreSnapshotSchema.parse(snapshot);
-    return new ToolUseStore({
-      run: AgentRunState.fromSnapshot(parsed.run),
-      workspace: AgentWorkspaceState.fromSnapshot(parsed.workspace),
-      user: {
-        input: Object.freeze({ ...parsed.user.input }),
-        transient: { ...parsed.user.transient },
-      },
-    });
-  }
-
-  /** Serialize to a snapshot. */
-  toSnapshot(): ToolUseStoreSnapshot {
-    return {
-      run: this.runState.toSnapshot(),
-      workspace: this.workspaceState.toSnapshot(),
-      user: {
-        input: { ...this.userChannels.input },
-        transient: { ...this.userChannels.transient },
-      },
-    };
-  }
-
-  get run(): AgentRunState {
-    return this.runState;
-  }
-
-  get workspace(): AgentWorkspaceState {
-    return this.workspaceState;
-  }
-
-  get user(): UserVariableChannels {
-    return this.userChannels;
-  }
-}
-
-/**
- * Factory params for creating a new ToolUseStore.
- */
-interface ToolUseStoreFactoryParams {
-  runState: AgentRunState;
-  workspaceState: AgentWorkspaceState;
-  userChannels: UserVariableChannels;
-}
-
-/**
- * Factory args - either create from params or restore from snapshot.
- */
-type ToolUseStoreFactoryArgs =
-  | (ToolUseStoreFactoryParams & { snapshot?: undefined })
-  | { snapshot: ToolUseStoreSnapshot };
-
-/**
- * Create a ToolUseStore from params or snapshot.
- */
-export function createToolUseStore(args: ToolUseStoreFactoryArgs): ToolUseStore {
-  if ('snapshot' in args && args.snapshot) {
-    return ToolUseStore.fromSnapshot(args.snapshot);
-  }
-
-  const params = args as ToolUseStoreFactoryParams;
-  return new ToolUseStore({
-    run: params.runState,
-    workspace: params.workspaceState,
-    user: params.userChannels,
-  });
-}
-
-/**
- * We use z.object() instead of z.strictObject() to remain backward compatible
- * with legacy store snapshots that may contain removed or renamed fields.
- */
-export const AgentSharedStoreSnapshotSchema = z.object({
-  round: ConversationRoundStateSnapshotSchema,
-  run: AgentRunStateSnapshotSchema,
-  workspace: AgentWorkspaceStateSnapshotSchema,
-  user: UserVariableChannelsSchema,
-});
-
-/**
- * Output type for AgentSharedStore serialization.
- * Uses z.output<> to get the type after parsing (all fields required).
+ * Output type for AgentSharedStore serialization (with optional round).
  */
 export type AgentSharedStoreSnapshot = z.output<
   typeof AgentSharedStoreSnapshotSchema
 >;
 
+// Alias for tool-use compatibility (same as BaseStoreSnapshot)
+export type ToolUseStoreSnapshot = BaseStoreSnapshot;
+export const ToolUseStoreSnapshotSchema = BaseStoreSnapshotSchema;
+
+// ============================================================================
+// Store Class
+// ============================================================================
+
 /**
- * Central store wiring agent run, round, workspace, and user-variable slices together.
+ * Central store wiring agent run, workspace, user, and optionally round slices.
  *
  * This is a pure data holder for snapshot serialization. Round finalization logic
  * lives in CycleServices.finalizeRound() as the single source of truth.
+ *
+ * ## Usage Modes
+ *
+ * - **Reflection agents**: Use with round for multi-turn tracking
+ * - **Tool-use agents**: Use without round (metrics tracked in flow state)
  */
 export class AgentSharedStore {
-  private roundState: ConversationRoundState;
+  private roundState: ConversationRoundState | null;
   private readonly runState: AgentRunState;
   private readonly workspaceState: AgentWorkspaceState;
   private readonly userChannels: UserVariableChannels;
 
-  constructor(config: AgentSharedStoreSlices) {
-    this.roundState = config.round;
+  constructor(
+    config: BaseStoreSlices & { round?: ConversationRoundState | null },
+  ) {
+    this.roundState = config.round ?? null;
     this.runState = config.run;
     this.workspaceState = config.workspace;
     this.userChannels = config.user;
@@ -184,7 +110,9 @@ export class AgentSharedStore {
   static fromSnapshot(snapshot: unknown): AgentSharedStore {
     const parsed = AgentSharedStoreSnapshotSchema.parse(snapshot);
     return new AgentSharedStore({
-      round: ConversationRoundState.fromSnapshot(parsed.round),
+      round: parsed.round
+        ? ConversationRoundState.fromSnapshot(parsed.round)
+        : null,
       run: AgentRunState.fromSnapshot(parsed.run),
       workspace: AgentWorkspaceState.fromSnapshot(parsed.workspace),
       user: {
@@ -194,10 +122,9 @@ export class AgentSharedStore {
     });
   }
 
-  /** Serialize to a snapshot. */
+  /** Serialize to a snapshot. Includes round only if present. */
   toSnapshot(): AgentSharedStoreSnapshot {
-    return {
-      round: this.roundState.toSnapshot(),
+    const base: BaseStoreSnapshot = {
       run: this.runState.toSnapshot(),
       workspace: this.workspaceState.toSnapshot(),
       user: {
@@ -205,10 +132,28 @@ export class AgentSharedStore {
         transient: { ...this.userChannels.transient },
       },
     };
+
+    if (this.roundState) {
+      return {
+        ...base,
+        round: this.roundState.toSnapshot(),
+      };
+    }
+
+    return base;
   }
 
-  get round(): ConversationRoundState {
+  /**
+   * Get round state. Returns null for tool-use agents.
+   * For reflection agents, use hasRound() to check before accessing.
+   */
+  get round(): ConversationRoundState | null {
     return this.roundState;
+  }
+
+  /** Check if this store has a round (reflection agent). */
+  hasRound(): boolean {
+    return this.roundState !== null;
   }
 
   get run(): AgentRunState {
@@ -224,10 +169,17 @@ export class AgentSharedStore {
   }
 }
 
+// Type alias for tool-use compatibility
+export type ToolUseStore = AgentSharedStore;
+
+// ============================================================================
+// Factory Functions
+// ============================================================================
+
 /**
- * Factory params for creating a new store from scratch.
+ * Factory params for creating a new store with round (reflection agents).
  */
-interface SharedStoreFactoryParams {
+interface SharedStoreWithRoundParams {
   roundIndex: number;
   runState: AgentRunState;
   workspaceState: AgentWorkspaceState;
@@ -236,17 +188,23 @@ interface SharedStoreFactoryParams {
 }
 
 /**
+ * Factory params for creating a new store without round (tool-use agents).
+ */
+interface SharedStoreWithoutRoundParams {
+  runState: AgentRunState;
+  workspaceState: AgentWorkspaceState;
+  userChannels: UserVariableChannels;
+}
+
+/**
  * Factory args - either create from params or restore from snapshot.
  */
 type SharedStoreFactoryArgs =
-  | (SharedStoreFactoryParams & { snapshot?: undefined })
+  | (SharedStoreWithRoundParams & { snapshot?: undefined })
   | { snapshot: AgentSharedStoreSnapshot };
 
 /**
- * Create an AgentSharedStore from params or snapshot.
- *
- * This is the preferred way to create stores as it handles both
- * fresh creation and snapshot restoration.
+ * Create an AgentSharedStore with round support (for reflection agents).
  */
 export function createSharedStore(
   args: SharedStoreFactoryArgs,
@@ -255,12 +213,38 @@ export function createSharedStore(
     return AgentSharedStore.fromSnapshot(args.snapshot);
   }
 
-  // Type narrowing: must be SharedStoreFactoryParams
-  const params = args as SharedStoreFactoryParams;
+  const params = args as SharedStoreWithRoundParams;
   const initialRound =
     params.roundState ?? new ConversationRoundState(params.roundIndex);
   return new AgentSharedStore({
     round: initialRound,
+    run: params.runState,
+    workspace: params.workspaceState,
+    user: params.userChannels,
+  });
+}
+
+/**
+ * Factory args for tool-use store.
+ */
+type ToolUseStoreFactoryArgs =
+  | (SharedStoreWithoutRoundParams & { snapshot?: undefined })
+  | { snapshot: BaseStoreSnapshot };
+
+/**
+ * Create an AgentSharedStore without round (for tool-use agents).
+ * This is a convenience function that creates a store with round=null.
+ */
+export function createToolUseStore(
+  args: ToolUseStoreFactoryArgs,
+): AgentSharedStore {
+  if ('snapshot' in args && args.snapshot) {
+    return AgentSharedStore.fromSnapshot(args.snapshot);
+  }
+
+  const params = args as SharedStoreWithoutRoundParams;
+  return new AgentSharedStore({
+    round: null,
     run: params.runState,
     workspace: params.workspaceState,
     user: params.userChannels,

--- a/src/agent/core/AgentState.ts
+++ b/src/agent/core/AgentState.ts
@@ -114,12 +114,10 @@ export class ConversationRoundState {
 
 /** Default values for AgentRunState */
 const RUN_STATE_DEFAULTS = {
-  totalRounds: 0,
   totalResponseTimeMs: 0,
 } as const;
 
 export const AgentRunStateSnapshotSchema = z.object({
-  totalRounds: z.int().nonnegative().prefault(RUN_STATE_DEFAULTS.totalRounds),
   totalResponseTimeMs: z
     .number()
     .nonnegative()
@@ -140,12 +138,10 @@ export type AgentRunStateSnapshot = z.output<
 >;
 
 export class AgentRunState {
-  public totalRounds: number;
   public totalResponseTimeMs: number;
   public readonly usageAccumulator: RunUsageAccumulator;
 
   constructor(accumulator?: RunUsageAccumulator) {
-    this.totalRounds = RUN_STATE_DEFAULTS.totalRounds;
     this.totalResponseTimeMs = RUN_STATE_DEFAULTS.totalResponseTimeMs;
     this.usageAccumulator = accumulator ?? new RunUsageAccumulator();
   }
@@ -157,7 +153,6 @@ export class AgentRunState {
       parsed.usageAccumulator,
     );
     const state = new AgentRunState(usageAccumulator);
-    state.totalRounds = parsed.totalRounds;
     state.totalResponseTimeMs = parsed.totalResponseTimeMs;
     return state;
   }
@@ -165,14 +160,17 @@ export class AgentRunState {
   /** Serialize to a snapshot. */
   toSnapshot(): AgentRunStateSnapshot {
     return {
-      totalRounds: this.totalRounds,
       totalResponseTimeMs: this.totalResponseTimeMs,
       usageAccumulator: this.usageAccumulator.toSnapshot(),
     };
   }
 
-  incrementRounds(): void {
-    this.totalRounds += 1;
+  /**
+   * Get the number of completed cycles.
+   * Derived from usageAccumulator which is the single source of truth.
+   */
+  getCompletedCycles(): number {
+    return this.usageAccumulator.getCompletedCycles();
   }
 
   addResponseTime(durationMs: number): void {

--- a/src/agent/core/RunUsageAccumulator.ts
+++ b/src/agent/core/RunUsageAccumulator.ts
@@ -139,4 +139,12 @@ export class RunUsageAccumulator {
   getNormalizedSnapshots(): readonly NormalizedUsageSnapshot[] {
     return this.normalizedSnapshots;
   }
+
+  /**
+   * Get the number of completed cycles.
+   * This is derived from the number of recorded usage snapshots.
+   */
+  getCompletedCycles(): number {
+    return this.normalizedSnapshots.length;
+  }
 }

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -606,6 +606,7 @@ class ToolUseProcessNode<C> extends BaseNode<
     }
 
     // Finalize cycle using direct values (no round object needed)
+    // Note: Recording to usageAccumulator automatically tracks completed cycles
     await finalizeToolUseCycle({
       cycleIndex: state.cycleIndex,
       responseTimeMs: state.cycleResponseTimeMs,
@@ -613,7 +614,6 @@ class ToolUseProcessNode<C> extends BaseNode<
       run,
       onRoundFinalized,
     });
-    run.incrementRounds();
 
     if (execRes.endTurn) {
       // Apply side effects for end turn

--- a/src/agent/implementations/flows/ToolUseRunFlow.ts
+++ b/src/agent/implementations/flows/ToolUseRunFlow.ts
@@ -18,9 +18,9 @@
 import { Node, Flow } from '@agent/node';
 import { FlowTransition } from '@agent/core/flows/FlowTransitions';
 import {
-  AgentSharedStore,
-  createSharedStore,
-  type AgentSharedStoreSnapshot,
+  ToolUseStore,
+  createToolUseStore,
+  type ToolUseStoreSnapshot,
 } from '@agent/core/AgentSharedStore';
 import {
   createToolUseCycleFlow,
@@ -67,8 +67,8 @@ import type { ToolUseServices, ToolUseFlowParams } from './tooluse';
 export interface ToolUseRunState {
   conversation: ProviderMessage[];
   shouldSkipCycle: boolean;
-  /** Store snapshot (natively serializable) - reconstruct via createSharedStore() */
-  storeSnapshot: AgentSharedStoreSnapshot | null;
+  /** Store snapshot (natively serializable) - reconstruct via createToolUseStore() */
+  storeSnapshot: ToolUseStoreSnapshot | null;
 }
 
 /**
@@ -111,7 +111,7 @@ export interface ToolUseRunShared {
  */
 interface ToolUsePrepareResult<C> {
   messages: ProviderMessage[];
-  store: AgentSharedStore;
+  store: ToolUseStore;
   shouldSkipCycle: boolean;
   cycleOptions: ToolUseCycleOptions<C>;
 }
@@ -142,7 +142,7 @@ interface CycleNodePrepResult<C> {
   shouldSkip: boolean;
   cycleOptions: ToolUseCycleOptions<C>;
   conversation: ProviderMessage[];
-  store: AgentSharedStore;
+  store: ToolUseStore;
 }
 
 /**
@@ -161,7 +161,7 @@ interface WaitNodePrepResult {
 
 /** Prepared state type with non-null storeSnapshot. */
 type PreparedState = ToolUseRunState & {
-  storeSnapshot: AgentSharedStoreSnapshot;
+  storeSnapshot: ToolUseStoreSnapshot;
 };
 
 /**
@@ -271,7 +271,7 @@ class ToolUseCycleNode<C> extends Node<
     assertPreparedState(shared.state);
 
     // Reconstruct store from snapshot (koala-code-reader pattern)
-    const store = createSharedStore({ snapshot: shared.state.storeSnapshot });
+    const store = createToolUseStore({ snapshot: shared.state.storeSnapshot });
 
     // Rebuild cycleOptions from services (NOT stored in state - non-serializable)
     const cycleOptions = this.services.buildCycleOptions(store);
@@ -292,7 +292,7 @@ class ToolUseCycleNode<C> extends Node<
 
     // Create cycle shared state (like ResponseCycleNode)
     // Tool-use cycles track metrics in state (cycleIndex, etc.) instead of round object
-    // cycleIndex starts from run.totalRounds to maintain continuity across user follow-ups
+    // cycleIndex starts from run.getCompletedCycles() to maintain continuity across user follow-ups
     const cycleShared: ToolUseCycleShared = {
       state: {
         messages: prepRes.conversation,
@@ -302,7 +302,7 @@ class ToolUseCycleNode<C> extends Node<
         toolCalls: undefined,
         text: undefined,
         stopReason: undefined,
-        cycleIndex: prepRes.store.run.totalRounds,
+        cycleIndex: prepRes.store.run.getCompletedCycles(),
         cycleResponseTimeMs: 0,
         cycleNormalizedUsage: undefined,
         endTurn: false,

--- a/src/agent/implementations/flows/tooluse/ToolUseFlowContext.ts
+++ b/src/agent/implementations/flows/tooluse/ToolUseFlowContext.ts
@@ -13,14 +13,14 @@ import type { IModelHandler } from '@agent/modelHandlers';
 import type { AgentToolUseSetting } from '@agent/core/AgentDataclass';
 import type { IToolRegistry } from '@agent/core/ToolTypes';
 import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
-import type { AgentSharedStore } from '@agent/core/AgentSharedStore';
+import type { ToolUseStore } from '@agent/core/AgentSharedStore';
 import type { StreamTabId } from '@agent/types/IdentifierTypes';
 import type { ToolUseCycleOptions } from '@agent/core/flows/CycleServices';
 import type { BaseFlowContextInit } from '@agent/implementations/flows/common';
 
 import { AgentWorkspaceState } from '@agent/core/AgentWorkspaceState';
 import { AgentRunState } from '@agent/core/AgentState';
-import { createSharedStore } from '@agent/core/AgentSharedStore';
+import { createToolUseStore } from '@agent/core/AgentSharedStore';
 import { retryCoordinator } from '@agent/runtime/RetryRequestCoordinator';
 import type { RoundFinalizedCallback } from '@agent/core/flows/CycleServices';
 import type { ToolDefinition } from '@model';
@@ -135,7 +135,7 @@ async function prepareInitialState<C>(
 
     const messages = snapshot.messages;
     // Store is a pure data holder; onRoundFinalized is passed to flow services separately
-    const store = createSharedStore({ snapshot: snapshot.store });
+    const store = createToolUseStore({ snapshot: snapshot.store });
 
     sessionLifecycle.setStore(store);
 
@@ -161,8 +161,8 @@ async function prepareInitialState<C>(
   );
 
   // Store is a pure data holder; onRoundFinalized is passed to flow services separately
-  const store = createSharedStore({
-    roundIndex: currentRunState.totalRounds,
+  // ToolUseStore doesn't include round since tool-use tracks metrics in flow state
+  const store = createToolUseStore({
     runState: currentRunState,
     workspaceState: AgentWorkspaceState.create(),
     userChannels: userVarChannels,
@@ -185,7 +185,7 @@ function createCycleOptions<C>(
   init: ToolUseFlowContextInit<C>,
   toolRegistry: IToolRegistry,
   resolvedTools: ToolDefinition[],
-  store: AgentSharedStore,
+  store: ToolUseStore,
 ): ToolUseCycleOptions<C> {
   // Use pre-resolved tools (computed at construction time)
   const resolvedSetting = {

--- a/src/agent/implementations/flows/tooluse/ToolUseFlowContext.ts
+++ b/src/agent/implementations/flows/tooluse/ToolUseFlowContext.ts
@@ -13,7 +13,7 @@ import type { IModelHandler } from '@agent/modelHandlers';
 import type { AgentToolUseSetting } from '@agent/core/AgentDataclass';
 import type { IToolRegistry } from '@agent/core/ToolTypes';
 import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
-import type { ToolUseStore } from '@agent/core/AgentSharedStore';
+import type { AgentSharedStore, ToolUseStore } from '@agent/core/AgentSharedStore';
 import type { StreamTabId } from '@agent/types/IdentifierTypes';
 import type { ToolUseCycleOptions } from '@agent/core/flows/CycleServices';
 import type { BaseFlowContextInit } from '@agent/implementations/flows/common';

--- a/src/agent/implementations/flows/tooluse/ToolUseServices.ts
+++ b/src/agent/implementations/flows/tooluse/ToolUseServices.ts
@@ -11,7 +11,7 @@
  */
 
 import type { ToolUseCycleOptions } from '@agent/core/flows/CycleServices';
-import type { AgentSharedStore } from '@agent/core/AgentSharedStore';
+import type { ToolUseStore } from '@agent/core/AgentSharedStore';
 import type { AgentRunState } from '@agent/core/AgentState';
 import type { AgentToolUseSetting } from '@agent/core/AgentDataclass';
 import type { RoundFinalizedCallback } from '@agent/core/flows/CycleServices';
@@ -29,7 +29,7 @@ import type { IToolUseSession } from './ToolUseSessionLifecycle';
  */
 export interface PrepareStateResult {
   messages: ProviderMessage[];
-  store: AgentSharedStore;
+  store: ToolUseStore;
   shouldSkipCycle: boolean;
   runState: AgentRunState;
 }
@@ -75,7 +75,7 @@ export interface ToolUseServices<C = unknown> extends BaseFlowContextInit<C> {
    * Build cycle options for tool-use execution.
    */
   readonly buildCycleOptions: (
-    store: AgentSharedStore,
+    store: ToolUseStore,
   ) => ToolUseCycleOptions<C>;
 
   /**

--- a/src/agent/implementations/flows/tooluse/ToolUseSessionLifecycle.ts
+++ b/src/agent/implementations/flows/tooluse/ToolUseSessionLifecycle.ts
@@ -4,7 +4,7 @@
  * Provides follow-up queue management and stream status updates.
  */
 
-import type { AgentSharedStore } from '@agent/core/AgentSharedStore';
+import type { ToolUseStore } from '@agent/core/AgentSharedStore';
 import type { StreamTabId } from '@agent/types/IdentifierTypes';
 
 import { FollowUpQueue } from '@agent/toolUse/FollowUpQueue';
@@ -44,17 +44,17 @@ export interface IToolUseSession {
  */
 export class ToolUseSessionLifecycle implements IToolUseSession {
   private readonly followUps: FollowUpQueue;
-  private store: AgentSharedStore | null = null;
+  private store: ToolUseStore | null = null;
 
   constructor(private readonly streamTabId: StreamTabId) {
     this.followUps = ToolUseFollowUpQueue.acquire(streamTabId);
   }
 
-  setStore(store: AgentSharedStore | null): void {
+  setStore(store: ToolUseStore | null): void {
     this.store = store;
   }
 
-  getStore(): AgentSharedStore | null {
+  getStore(): ToolUseStore | null {
     return this.store;
   }
 

--- a/src/agent/implementations/flows/tooluse/ToolUseSessionTypes.ts
+++ b/src/agent/implementations/flows/tooluse/ToolUseSessionTypes.ts
@@ -14,11 +14,11 @@ import { z } from 'zod';
 
 // Local imports - agent
 import { AgentConfigSchema, type AgentConfig } from '@agent/core/AgentConfig';
-import { AgentSharedStoreSnapshotSchema } from '@agent/core/AgentSharedStore';
+import { ToolUseStoreSnapshotSchema } from '@agent/core/AgentSharedStore';
 import { ProviderMessageSchema } from '@agent/modelHandlers/types/ProviderMessage';
 
 // Type imports
-import type { AgentSharedStore } from '@agent/core/AgentSharedStore';
+import type { ToolUseStore } from '@agent/core/AgentSharedStore';
 import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
 import type { ExecutionId, StreamTabId } from '@agent/types/IdentifierTypes';
 
@@ -38,7 +38,7 @@ export const ToolUseSessionSnapshotSchema = z.object({
   streamId: z.string(),
   agentConfig: AgentConfigSchema,
   messages: z.array(ProviderMessageSchema),
-  store: AgentSharedStoreSnapshotSchema,
+  store: ToolUseStoreSnapshotSchema,
   lastUpdated: z.number(),
 });
 
@@ -50,10 +50,10 @@ export type ToolUseSessionSnapshot = z.infer<
 /**
  * Input payload for saving a tool-use session snapshot.
  *
- * NOTE: This is a manual interface (not schema-derived) because `store` is an
- * AgentSharedStore class instance with methods (e.g., toSnapshot()), not a plain
+ * NOTE: This is a manual interface (not schema-derived) because `store` is a
+ * ToolUseStore class instance with methods (e.g., toSnapshot()), not a plain
  * data structure. Zod schemas cannot validate class instances with private fields.
- * The store is serialized to AgentSharedStoreSnapshot during the save operation.
+ * The store is serialized to ToolUseStoreSnapshot during the save operation.
  *
  * @see ToolUseSessionSnapshotSchema - SSOT for the serialized snapshot format
  */
@@ -62,5 +62,5 @@ export interface SaveToolUseSnapshotPayload {
   streamId: StreamTabId;
   agentConfig: AgentConfig;
   messages: ProviderMessage[];
-  store: AgentSharedStore;
+  store: ToolUseStore;
 }


### PR DESCRIPTION
Identifies 6 key architectural issues in the agent state management:

1. AgentRunState.totalRounds naming confusion - called "totalRounds" but
   tracks "completed cycles", only used by tool-use agents

2. Parallel metrics tracking - ToolUseCycleState duplicates exact same
   fields as ConversationRoundState (cycleIndex, responseTimeMs, usage)

3. AgentSharedStore inconsistency - tool-use creates round object but
   never uses it

4. Snapshot round-trip overhead - store reconstructed every cycle

5. Factory function overhead - 7 factories between executeAgent and
   model invocation, 2-3 are pass-through wrappers

6. UserVariableChannels inconsistent access patterns

Includes prioritized refactoring roadmap with concrete steps.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Modernizes state tracking and tool-use flow wiring with minimal surface changes.
> 
> - Removes `AgentRunState.totalRounds` and `incrementRounds()`; adds `RunUsageAccumulator.getCompletedCycles()` and `AgentRunState.getCompletedCycles()`
> - Refactors `AgentSharedStore` to have optional `round`; adds `BaseStoreSnapshot`, `ToolUseStore` (type alias), and `createToolUseStore()`
> - Updates tool-use flows (`ToolUseRunFlow`, `ToolUseFlowContext`, `ToolUseServices`, `ToolUseSession*`, `ToolUseCycleFlow`) to use `ToolUseStore` and derive `cycleIndex` from `run.getCompletedCycles()`; removes `run.incrementRounds()` call
> - Snapshot schemas updated to keep backward compatibility (optional `round`) and new `ToolUseStoreSnapshotSchema`
> - Adds architecture doc detailing completed refactors and remaining follow-ups
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cfdddd173e4905396ac95af3bfdf1a7240c2f586. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->