### PR TITLE
refactor: flatten two-layer factory patterns in flow contexts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,6 +134,46 @@ Node.exec()
 - `ToolUseCycle.ts` deleted → `ToolUseCycleNode` creates flow directly
 - Tests updated to use `createResponseCycleFlow()` / `createToolUseCycleFlow()` directly
 
+### Discouraged Factory Patterns
+
+Avoid these patterns that add indirection without value:
+
+**Two-layer factories (called once):**
+
+```typescript
+// ❌ Anti-pattern: buildX only called from createX
+export function createContext(init) {
+  const services = buildServices(init);  // ← Extra layer
+  return { services, ... };
+}
+function buildServices(init) { ... }
+
+// ✅ Preferred: Inline if only called once
+export function createContext(init) {
+  const services = { ... };  // ← Direct
+  return { services, ... };
+}
+```
+
+**Trivial identity factories:**
+
+```typescript
+// ❌ Anti-pattern: Just spreads into new object
+function createOptions(options: Options): Options {
+  return { ...options };
+}
+
+// ✅ Preferred: Use object literal directly
+const options: Options = { ... };
+```
+
+**When factories ARE justified:**
+
+- Called from multiple locations (DRY)
+- Contain meaningful logic (validation, defaults, transforms)
+- Create class instances or complex objects
+- Need to capture closures with initialization context
+
 ### Path Aliases
 
 Common aliases (full list in `tsconfig.json`):

--- a/src/agent/core/flows/CommonCycleTypes.ts
+++ b/src/agent/core/flows/CommonCycleTypes.ts
@@ -194,33 +194,3 @@ export function interpretCycleCompletion(
   };
 }
 
-// ============================================================================
-// Debug Context Factory
-// ============================================================================
-
-/**
- * Creates a debug context for cycle operations.
- *
- * Note: The caller should pass isRemote (computed via isRemoteAgent from @agent/index)
- * to avoid circular dependency issues.
- */
-export function createDebugContext(
-  options: CycleDebugContext,
-): CycleDebugContext {
-  return { ...options };
-}
-
-/**
- * Creates debug file options for a cycle.
- */
-export function createDebugFileOptions(
-  roundIndex: number,
-  baseName: string,
-  outputFile?: string,
-): CycleDebugFileOptions {
-  return {
-    continuationCount: roundIndex,
-    baseName,
-    outputFile,
-  };
-}

--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -12,11 +12,9 @@ import {
   BaseInvocationPrepResult,
   BaseInvocationSuccessData,
   resetCycleState,
-  CycleDebugContext,
-  CycleDebugFileOptions,
+  type CycleDebugContext,
+  type CycleDebugFileOptions,
   SkippableNodeResult,
-  createDebugContext,
-  createDebugFileOptions,
 } from '@agent/core/flows/CommonCycleTypes';
 // Type imports
 import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
@@ -150,17 +148,17 @@ class ResponsePrepNode<C> extends BaseNode<
     const debug: CycleDebugOptions | undefined = interrupted
       ? undefined
       : {
-          context: createDebugContext({
+          context: {
             logger,
             modelName: agentConfig.model,
             executionId: services.context.executionId,
             isRemote: isRemoteAgent(agentConfig.agent),
-          }),
-          fileOptions: createDebugFileOptions(
-            round.continuationCount,
-            'response',
-            state.outputLocation.relativePath,
-          ),
+          },
+          fileOptions: {
+            continuationCount: round.continuationCount,
+            baseName: 'response',
+            outputFile: state.outputLocation.relativePath,
+          },
         };
 
     return {

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -9,10 +9,8 @@ import {
   BaseInvocationPrepResult,
   BaseInvocationSuccessData,
   resetCycleState,
-  CycleDebugContext,
-  CycleDebugFileOptions,
-  createDebugContext,
-  createDebugFileOptions,
+  type CycleDebugContext,
+  type CycleDebugFileOptions,
 } from '@agent/core/flows/CommonCycleTypes';
 import type { SdkToolCall } from '@agent/modelHandlers/types/IModelHandler';
 import type { ServerToolContentBlock } from '@agent/modelHandlers/types/ServerToolTypes';
@@ -209,17 +207,16 @@ class ToolUsePrepNode<C> extends BaseNode<
   }> {
     const services = this.services;
     const interrupted = Boolean(await services.checkInterruption());
-    const debugContext = createDebugContext({
+    const debugContext: CycleDebugContext = {
       logger: services.logger,
       modelName: services.modelName,
       executionId: services.context.executionId,
       isRemote: isRemoteAgent(services.agentName),
-    });
-    // Use cycleIndex from state instead of round.roundIndex
-    const debugFileOptions = createDebugFileOptions(
-      shared.state.cycleIndex,
-      'tooluse',
-    );
+    };
+    const debugFileOptions: CycleDebugFileOptions = {
+      continuationCount: shared.state.cycleIndex,
+      baseName: 'tooluse',
+    };
     return { interrupted, debugContext, debugFileOptions };
   }
 
@@ -316,17 +313,16 @@ class ToolUseCallNode<C> extends RetryableInvocationNode<
       return { kind: 'skipped' };
     }
 
-    const debugContext = createDebugContext({
+    const debugContext: CycleDebugContext = {
       logger: services.logger,
       modelName: services.modelName,
       executionId: services.context.executionId,
       isRemote: isRemoteAgent(services.agentName),
-    });
-    // Use cycleIndex from prepRes instead of round.roundIndex
-    const debugFileOptions = createDebugFileOptions(
-      prepRes.cycleIndex,
-      'tooluse_response',
-    );
+    };
+    const debugFileOptions: CycleDebugFileOptions = {
+      continuationCount: prepRes.cycleIndex,
+      baseName: 'tooluse_response',
+    };
 
     const start = Date.now();
 

--- a/src/agent/implementations/flows/reflection/ReflectionFlowContext.ts
+++ b/src/agent/implementations/flows/reflection/ReflectionFlowContext.ts
@@ -198,21 +198,21 @@ export interface ReflectionFlowContext<C = unknown> {
 }
 
 // ============================================================================
-// Factory Functions
+// Factory Function
 // ============================================================================
 
 /**
- * Build reflection flow services from initialization config.
+ * Creates a ReflectionFlowContext with all services and behaviors configured.
  *
- * This is the PocketFlow-native way: simple factory function that creates
- * all services eagerly and returns them as a plain object.
+ * This is the primary entry point for setting up flow execution.
+ * Returns a simple object with services and lifecycle methods.
  *
  * Note: Returns partial services (missing runStage). The runStage is added
  * by runReflectionFlow after the run stage is created/provided.
  */
-export function buildReflectionServices<C = unknown>(
+export function createReflectionFlowContext<C = unknown>(
   init: ReflectionFlowContextInit<C>,
-): ReflectionServicesPartial<C> {
+): ReflectionFlowContext<C> {
   const {
     config,
     setting,
@@ -251,21 +251,18 @@ export function buildReflectionServices<C = unknown>(
 
   // Compute behavior from configuration
   const shouldEnsureXmlStructure = computeShouldEnsureXmlStructure(setting);
+  const totalRounds = computeTotalRounds(setting, prompt);
 
   // Use custom getter if provided, otherwise create default
   const getOutputFileLocation =
     init.getOutputFileLocation ??
     createOutputFileLocationGetter(config, setting, modelHandler, fileService);
 
-  // Return partial services (missing runStage - added by runReflectionFlow)
-  // Round stages (r0, r1...) are managed by RoundPersistedFlow, not by services
-  return {
-    // Spread base init fields
+  // Build partial services (missing runStage - added by runReflectionFlow)
+  const services: ReflectionServicesPartial<C> = {
     ...init,
-    // Add convenience accessors
     logger: executionContext.logger,
     context: executionContext,
-    // Override with narrowed setting type
     setting,
     outputHandler,
     latexMediaManager,
@@ -275,35 +272,22 @@ export function buildReflectionServices<C = unknown>(
     shouldEnsureXmlStructure: () => shouldEnsureXmlStructure,
     getUsageRecorder,
   };
-}
-
-/**
- * Creates a ReflectionFlowContext with all services and behaviors configured.
- *
- * This is the primary entry point for setting up flow execution.
- * Returns a simple object with services and lifecycle methods.
- */
-export function createReflectionFlowContext<C = unknown>(
-  init: ReflectionFlowContextInit<C>,
-): ReflectionFlowContext<C> {
-  const services = buildReflectionServices(init);
-  const totalRounds = computeTotalRounds(init.setting, init.prompt);
 
   return {
     services,
     totalRounds,
 
     setActiveRun(storageKey: StorageKey): void {
-      services.outputHandler.setActiveRun(storageKey);
+      outputHandler.setActiveRun(storageKey);
     },
 
     interrupt(): void {
       init.onInterrupt?.();
-      retryCoordinator.clearRequest(init.executionContext.streamId);
+      retryCoordinator.clearRequest(executionContext.streamId);
     },
 
     dispose(): void {
-      retryCoordinator.clearRequest(init.executionContext.streamId);
+      retryCoordinator.clearRequest(executionContext.streamId);
     },
   };
 }

--- a/src/agent/implementations/flows/reflection/ReflectionServices.ts
+++ b/src/agent/implementations/flows/reflection/ReflectionServices.ts
@@ -86,7 +86,7 @@ export interface ReflectionServices<C = unknown>
 }
 
 /**
- * Partial services type for buildReflectionServices output.
+ * Partial services type for createReflectionFlowContext output.
  * Excludes runStage since it's set by runReflectionFlow after creation.
  */
 export type ReflectionServicesPartial<C = unknown> = Omit<

--- a/src/agent/implementations/flows/tooluse/ToolUseFlowContext.ts
+++ b/src/agent/implementations/flows/tooluse/ToolUseFlowContext.ts
@@ -220,22 +220,18 @@ async function applyFollowUpMessage<C>(
 }
 
 // ============================================================================
-// Factory Functions
+// Factory Function
 // ============================================================================
 
 /**
- * Build tool-use flow services from initialization config.
+ * Creates a ToolUseFlowContext with all services and behaviors configured.
  *
- * This is the PocketFlow-native way: simple factory function that creates
- * all services eagerly and returns them as a plain object.
+ * This is the primary entry point for setting up flow execution.
+ * Returns a simple object with services and lifecycle methods.
  */
-export function buildToolUseServices<C = unknown>(
+export function createToolUseFlowContext<C = unknown>(
   init: ToolUseFlowContextInit<C>,
-): {
-  services: ToolUseServices<C>;
-  sessionLifecycle: ToolUseSessionLifecycle;
-  resolvedTools: ToolDefinition[];
-} {
+): ToolUseFlowContext<C> {
   const {
     setting,
     streamTabId,
@@ -257,14 +253,11 @@ export function buildToolUseServices<C = unknown>(
   // Capture snapshot in closure for prepareState
   const snapshot = resumeSnapshot ?? null;
 
-  // Return complete services object
+  // Build complete services object
   const services: ToolUseServices<C> = {
-    // Spread base init fields
     ...init,
-    // Add convenience accessors
     logger: init.executionContext.logger,
     context: init.executionContext,
-    // Override with narrowed setting type
     setting,
     toolRegistry,
     session: sessionLifecycle,
@@ -276,33 +269,14 @@ export function buildToolUseServices<C = unknown>(
     getUsageRecorder: init.getUsageRecorder ?? (() => async () => {}),
   };
 
-  return { services, sessionLifecycle, resolvedTools };
-}
-
-/**
- * Creates a ToolUseFlowContext with all services and behaviors configured.
- *
- * This is the primary entry point for setting up flow execution.
- * Returns a simple object with services and lifecycle methods.
- */
-export function createToolUseFlowContext<C = unknown>(
-  init: ToolUseFlowContextInit<C>,
-): ToolUseFlowContext<C> {
-  const { services, sessionLifecycle } = buildToolUseServices(init);
-
   return {
     services,
-    streamTabId: init.streamTabId,
+    streamTabId,
     session: sessionLifecycle,
 
     interrupt(): void {
-      // Notify runtime layer to update interrupt state
       init.onInterrupt?.();
-
-      // Clear any pending retry request to avoid memory leaks
-      retryCoordinator.clearRequest(init.streamTabId);
-
-      // Clean up session lifecycle (PersistedFlow handles state cleanup)
+      retryCoordinator.clearRequest(streamTabId);
       sessionLifecycle.interrupt();
       sessionLifecycle.setStore(null);
     },


### PR DESCRIPTION
Inline buildReflectionServices() into createReflectionFlowContext() and
buildToolUseServices() into createToolUseFlowContext() - each was only
called once and added unnecessary indirection.

Net reduction: 42 lines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Simplifies flow construction by removing unnecessary factory layers and trivial helpers.
> 
> - Inline services directly in `createReflectionFlowContext()` and `createToolUseFlowContext()`; delete separate `build*Services` layers
> - Remove `createDebugContext` and `createDebugFileOptions` from `CommonCycleTypes`; construct `CycleDebugContext`/`CycleDebugFileOptions` inline in `ResponseCycleFlow` and `ToolUseCycleFlow`
> - Adjust interrupt/dispose and accessors to use locally scoped variables; minor type-only import and comment/doc updates
> - Update `CLAUDE.md` with guidance discouraging two-layer and identity factories
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 09af722c70be0a1efc31e5a51973f933fb856066. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->