### PR TITLE
refactor: replace InterruptManager factory methods with arrow properties

### DIFF
--- a/src/agent/runtime/InterruptManager.ts
+++ b/src/agent/runtime/InterruptManager.ts
@@ -16,37 +16,34 @@
  * Manages interrupt state for a single flow execution.
  *
  * Created per-execution in executeAgent and passed to flow runners.
- * Provides callbacks compatible with BaseFlowContextInit interface.
+ * Arrow function properties are used for callbacks to automatically bind `this`.
  */
 export class InterruptManager {
   private _isInterrupted = false;
   private _abortController: AbortController | null = null;
 
-  /**
-   * Check if interruption has been requested.
-   * Used by cycles to check whether to stop.
-   */
-  isInterrupted(): boolean {
-    return this._isInterrupted;
-  }
+  // =========================================================================
+  // Callbacks - Arrow properties for BaseFlowContextInit compatibility
+  // =========================================================================
 
-  /**
-   * Request interruption.
-   * Called when user stops the agent or context.interrupt() is invoked.
-   */
-  requestInterrupt(): void {
+  /** Check if interruption has been requested. */
+  checkInterruption = (): boolean => this._isInterrupted;
+
+  /** Set the current abort controller for cancellation. */
+  setAbortController = (controller: AbortController | null): void => {
+    this._abortController = controller;
+  };
+
+  /** Request interruption - called when user stops the agent. */
+  onInterrupt = (): void => {
     if (this._isInterrupted) return;
     this._isInterrupted = true;
     this._abortController?.abort();
-  }
+  };
 
-  /**
-   * Set the current abort controller.
-   * Called by cycles when starting API requests.
-   */
-  setAbortController(controller: AbortController | null): void {
-    this._abortController = controller;
-  }
+  // =========================================================================
+  // Additional accessors (not passed to flows)
+  // =========================================================================
 
   /**
    * Get the current abort controller.
@@ -54,33 +51,5 @@ export class InterruptManager {
    */
   getAbortController(): AbortController | null {
     return this._abortController;
-  }
-
-  // =========================================================================
-  // Callback Factories - For BaseFlowContextInit compatibility
-  // =========================================================================
-
-  /**
-   * Create checkInterruption callback for flow context.
-   * Returns a bound function that checks this manager's state.
-   */
-  createCheckInterruption(): () => boolean {
-    return () => this._isInterrupted;
-  }
-
-  /**
-   * Create setAbortController callback for flow context.
-   * Returns a bound function that updates this manager.
-   */
-  createSetAbortController(): (ctrl: AbortController | null) => void {
-    return (ctrl) => this.setAbortController(ctrl);
-  }
-
-  /**
-   * Create onInterrupt callback for flow context.
-   * Returns a bound function that requests interruption on this manager.
-   */
-  createOnInterrupt(): () => void {
-    return () => this.requestInterrupt();
   }
 }

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -493,14 +493,14 @@ export async function executeAgent(
               executionContext: ctx.executionContext,
               userVarChannels: ctx.userVarChannels,
               streamTabId: ctx.streamTabId,
-              checkInterruption: interruptManager.createCheckInterruption(),
-              setAbortController: interruptManager.createSetAbortController(),
+              checkInterruption: interruptManager.checkInterruption,
+              setAbortController: interruptManager.setAbortController,
               getClient: () => client,
               getUsageRecorder: createUsageRecorder(
                 ctx.usageMonitor,
                 'tool-use',
               ),
-              onInterrupt: interruptManager.createOnInterrupt(),
+              onInterrupt: interruptManager.onInterrupt,
             },
             {
               onContextReady: (streamId, context) => {
@@ -522,14 +522,14 @@ export async function executeAgent(
               prompt: ctx.agentPrompt,
               executionContext: ctx.executionContext,
               userVarChannels: ctx.userVarChannels,
-              checkInterruption: interruptManager.createCheckInterruption(),
-              setAbortController: interruptManager.createSetAbortController(),
+              checkInterruption: interruptManager.checkInterruption,
+              setAbortController: interruptManager.setAbortController,
               getClient: () => client,
               getUsageRecorder: createUsageRecorder(
                 ctx.usageMonitor,
                 'workflow',
               ),
-              onInterrupt: interruptManager.createOnInterrupt(),
+              onInterrupt: interruptManager.onInterrupt,
             },
             {
               onContextReady: (_storageKey, context) => {
@@ -630,12 +630,12 @@ export async function executeMergeAgent(
           prompt: ctx.agentPrompt,
           executionContext: ctx.executionContext,
           userVarChannels: ctx.userVarChannels,
-          checkInterruption: interruptManager.createCheckInterruption(),
-          setAbortController: interruptManager.createSetAbortController(),
+          checkInterruption: interruptManager.checkInterruption,
+          setAbortController: interruptManager.setAbortController,
           getClient: () => client,
           getUsageRecorder: createUsageRecorder(ctx.usageMonitor, 'workflow'),
           getOutputFileLocation,
-          onInterrupt: interruptManager.createOnInterrupt(),
+          onInterrupt: interruptManager.onInterrupt,
         },
         {
           onContextReady: (_storageKey, context) => {
@@ -727,12 +727,12 @@ export async function resumeToolUseFromSnapshot(
         executionContext,
         userVarChannels,
         streamTabId,
-        checkInterruption: interruptManager.createCheckInterruption(),
-        setAbortController: interruptManager.createSetAbortController(),
+        checkInterruption: interruptManager.checkInterruption,
+        setAbortController: interruptManager.setAbortController,
         getClient: () => client,
         getUsageRecorder: createUsageRecorder(usageMonitor, 'tool-use'),
         resumeSnapshot: snapshot,
-        onInterrupt: interruptManager.createOnInterrupt(),
+        onInterrupt: interruptManager.onInterrupt,
       },
       {
         onContextReady: (streamId, context) => {


### PR DESCRIPTION
Use arrow function properties instead of factory methods that create
closures. This eliminates unnecessary indirection while preserving
the same behavior (automatic `this` binding).

Before: interruptManager.createCheckInterruption() → new closure
After:  interruptManager.checkInterruption → bound arrow property

- Removes 3 factory methods (createCheckInterruption, createSetAbortController, createOnInterrupt)
- Adds 3 arrow properties that auto-bind `this`
- Updates 4 call sites in executeAgent.ts to use direct property access
- Net reduction: 31 lines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors interrupt callback API to use arrow properties, removing closure factories while preserving behavior and automatic `this` binding.
> 
> - In `InterruptManager`, add arrow callbacks: `checkInterruption`, `setAbortController`, `onInterrupt`; remove factory methods `createCheckInterruption`, `createSetAbortController`, `createOnInterrupt`. Keep `getAbortController` accessor.
> - Update `executeAgent.ts` (including merge and resume paths) to pass these properties directly to `runToolUseFlow` and `runReflectionFlow`.
> - Simplifies code and reduces indirection/lines without changing runtime behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3ab14bec3466377011be835321a9b6e5bf9fb3e6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->