### PR TITLE
refactor: reduce abstraction overhead in flow contexts

### DIFF
--- a/src/agent/implementations/flows/reflection/ReflectionFlowContext.ts
+++ b/src/agent/implementations/flows/reflection/ReflectionFlowContext.ts
@@ -269,7 +269,7 @@ export function createReflectionFlowContext<C = unknown>(
     promptBuilder,
     fileService,
     getOutputFileLocation,
-    shouldEnsureXmlStructure: () => shouldEnsureXmlStructure,
+    shouldEnsureXmlStructure,
     getUsageRecorder,
   };
 

--- a/src/agent/implementations/flows/reflection/ReflectionFlowContext.ts
+++ b/src/agent/implementations/flows/reflection/ReflectionFlowContext.ts
@@ -61,118 +61,6 @@ export interface ReflectionFlowContextInit<
 }
 
 // ============================================================================
-// Behavior Computation
-// ============================================================================
-
-/**
- * Compute whether XML structure should be ensured based on configuration.
- *
- * Priority order:
- * 1. `setting.xmlStructureMode` - explicit YAML configuration
- * 2. `agentType: 'CoT'` - implies always ensure XML structure
- * 3. `agentType: 'direct'` - implies scratchpadOnly mode
- * 4. Default: false (no XML structure enforcement)
- */
-function computeShouldEnsureXmlStructure(
-  setting: AgentWorkflowSetting,
-): boolean {
-  const useScratchpad = setting.prefills?.includes('<scratchpad>') ?? false;
-
-  // 1. Explicit xmlStructureMode takes highest precedence
-  if (setting.xmlStructureMode !== undefined) {
-    switch (setting.xmlStructureMode) {
-      case 'always':
-        return true;
-      case 'scratchpadOnly':
-        return useScratchpad;
-      case 'never':
-      default:
-        return false;
-    }
-  }
-
-  // 2. agentType-driven: 'CoT' implies always ensure XML structure
-  if (setting.agentType === 'CoT') {
-    return true;
-  }
-
-  // 3. agentType-driven: 'direct' implies scratchpadOnly mode
-  if (setting.agentType === 'direct') {
-    return useScratchpad;
-  }
-
-  // 4. Default behavior (no explicit type or config)
-  return false;
-}
-
-/**
- * Compute total rounds based on configuration.
- *
- * Priority order:
- * 1. `setting.maxRounds` - explicit YAML configuration
- * 2. `agentType: 'direct'` - implies single-round execution (maxRounds=1)
- * 3. Default calculation - max(configured rounds, userRequest array length)
- */
-function computeTotalRounds(
-  setting: AgentWorkflowSetting,
-  prompt: AgentPrompt,
-): number {
-  // 1. Explicit maxRounds config takes highest precedence
-  if (setting.maxRounds !== undefined) {
-    return setting.maxRounds;
-  }
-
-  // 2. agentType-driven: 'direct' implies single-round execution
-  if (setting.agentType === 'direct') {
-    return 1;
-  }
-
-  // 3. Default behavior for CoT and other types
-  const requestArray = Array.isArray(prompt.userRequest)
-    ? prompt.userRequest
-    : prompt.userRequest
-      ? [prompt.userRequest]
-      : [];
-  return Math.max(setting.rounds ?? 2, requestArray.length);
-}
-
-/**
- * Compute output file location for a given round.
- *
- * This replaces the polymorphic getOutputFileLocation() method.
- * MergeAgent has special logic that would need a separate strategy.
- */
-function createOutputFileLocationGetter(
-  config: AgentConfig,
-  setting: AgentWorkflowSetting,
-  modelHandler: IModelHandler<any, any, any, any, any>,
-  fileService: TaskRunFileService,
-): (round: number) => AgentFileLocation {
-  const useScratchpad = setting.prefills?.includes('<scratchpad>') ?? false;
-
-  return (currRound: number): AgentFileLocation => {
-    const baseOutputFile = config.inputFile;
-    const fileExtension = useScratchpad ? 'xml' : setting.outputExt;
-
-    const fileName = getOutputFileName(
-      baseOutputFile,
-      config.agent,
-      modelHandler.config.name,
-      fileExtension,
-      currRound,
-      config.editedFile || undefined,
-    );
-
-    // Route raw XML to isolated storage, direct outputs respect user preference
-    return (
-      useScratchpad
-        ? fileService.createRawOutputLocation(fileName)
-        : fileService.createLocation(fileName)
-    ) as AgentFileLocation;
-  };
-}
-
-// ============================================================================
 // Context Object (simple object, not a class)
 // ============================================================================
 
@@ -249,14 +137,55 @@ export function createReflectionFlowContext<C = unknown>(
     fileService,
   );
 
-  // Compute behavior from configuration
-  const shouldEnsureXmlStructure = computeShouldEnsureXmlStructure(setting);
-  const totalRounds = computeTotalRounds(setting, prompt);
+  // Compute shouldEnsureXmlStructure from configuration
+  // Priority: xmlStructureMode > agentType > default (false)
+  const useScratchpad = setting.prefills?.includes('<scratchpad>') ?? false;
+  let shouldEnsureXmlStructure = false;
+  if (setting.xmlStructureMode !== undefined) {
+    shouldEnsureXmlStructure =
+      setting.xmlStructureMode === 'always' ||
+      (setting.xmlStructureMode === 'scratchpadOnly' && useScratchpad);
+  } else if (setting.agentType === 'CoT') {
+    shouldEnsureXmlStructure = true;
+  } else if (setting.agentType === 'direct') {
+    shouldEnsureXmlStructure = useScratchpad;
+  }
 
-  // Use custom getter if provided, otherwise create default
+  // Compute totalRounds from configuration
+  // Priority: maxRounds > agentType=direct (1) > max(rounds, userRequest length)
+  let totalRounds: number;
+  if (setting.maxRounds !== undefined) {
+    totalRounds = setting.maxRounds;
+  } else if (setting.agentType === 'direct') {
+    totalRounds = 1;
+  } else {
+    const requestArray = Array.isArray(prompt.userRequest)
+      ? prompt.userRequest
+      : prompt.userRequest
+        ? [prompt.userRequest]
+        : [];
+    totalRounds = Math.max(setting.rounds ?? 2, requestArray.length);
+  }
+
+  // Use custom getter if provided, otherwise create default output file location getter
   const getOutputFileLocation =
     init.getOutputFileLocation ??
-    createOutputFileLocationGetter(config, setting, modelHandler, fileService);
+    ((currRound: number): AgentFileLocation => {
+      const fileExtension = useScratchpad ? 'xml' : setting.outputExt;
+      const fileName = getOutputFileName(
+        config.inputFile,
+        config.agent,
+        modelHandler.config.name,
+        fileExtension,
+        currRound,
+        config.editedFile || undefined,
+      );
+      return (
+        useScratchpad
+          ? fileService.createRawOutputLocation(fileName)
+          : fileService.createLocation(fileName)
+      ) as AgentFileLocation;
+    });
 
   // Build partial services (missing runStage - added by runReflectionFlow)
   const services: ReflectionServicesPartial<C> = {

--- a/src/agent/implementations/flows/reflection/ReflectionServices.ts
+++ b/src/agent/implementations/flows/reflection/ReflectionServices.ts
@@ -73,10 +73,10 @@ export interface ReflectionServices<C = unknown>
   readonly getOutputFileLocation: (round: number) => AgentFileLocation;
 
   /**
-   * Check if XML structure should be ensured before processing.
-   * Based on xmlStructureMode config: 'never', 'scratchpadOnly', or 'always'.
+   * Whether XML structure should be ensured before processing.
+   * Computed from xmlStructureMode config: 'never', 'scratchpadOnly', or 'always'.
    */
-  readonly shouldEnsureXmlStructure: () => boolean;
+  readonly shouldEnsureXmlStructure: boolean;
 
   /**
    * Get usage recorder callback for tracking round statistics.

--- a/src/agent/implementations/flows/reflection/nodes/OutputNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/OutputNode.ts
@@ -86,7 +86,7 @@ export class OutputNode<C = unknown> extends Node<
     const baseFiles = createBaseFileLocations(config);
 
     // Determine if we should ensure XML structure (based on xmlStructureMode config)
-    const ensureXmlStructure = this.services.shouldEnsureXmlStructure();
+    const ensureXmlStructure = this.services.shouldEnsureXmlStructure;
 
     return {
       currentRound,

--- a/src/agent/implementations/flows/tooluse/ToolUseFlowContext.ts
+++ b/src/agent/implementations/flows/tooluse/ToolUseFlowContext.ts
@@ -185,18 +185,6 @@ function createCycleOptions<C>(
   };
 }
 
-/**
- * Apply a follow-up message to the conversation.
- */
-async function applyFollowUpMessage<C>(
-  init: ToolUseFlowContextInit<C>,
-  followUp: string,
-  messages: ProviderMessage[],
-): Promise<ProviderMessage[]> {
-  init.executionContext.logger.userMessage(followUp);
-  return await init.modelHandler.createUserFollowUpMessages(messages, followUp);
-}
-
 // ============================================================================
 // Factory Function
 // ============================================================================
@@ -248,8 +236,10 @@ export function createToolUseFlowContext<C = unknown>(
     prepareState: () => prepareInitialState(init, sessionLifecycle, snapshot),
     buildCycleOptions: (store) =>
       createCycleOptions(init, toolRegistry, resolvedTools, store),
-    applyFollowUpMessage: (message, conversation) =>
-      applyFollowUpMessage(init, message, conversation),
+    applyFollowUpMessage: async (message, conversation) => {
+      init.executionContext.logger.userMessage(message);
+      return init.modelHandler.createUserFollowUpMessages(conversation, message);
+    },
     getUsageRecorder: init.getUsageRecorder ?? (() => async () => {}),
   };
 

--- a/src/agent/implementations/flows/tooluse/ToolUseFlowContext.ts
+++ b/src/agent/implementations/flows/tooluse/ToolUseFlowContext.ts
@@ -90,28 +90,6 @@ export interface ToolUseFlowContext<C = unknown> {
 // ============================================================================
 
 /**
- * Resolves tool definitions from setting at construction time.
- * This is computed once and cached to avoid repeated registry lookups.
- */
-function resolveToolsFromSetting(
-  setting: AgentToolUseSetting,
-  toolRegistry: IToolRegistry,
-  logger: any,
-): ToolDefinition[] {
-  const cfg = Array.isArray(setting.tools) ? setting.tools : [];
-  const tools: ToolDefinition[] = [];
-  for (const t of cfg) {
-    const def = typeof t === 'string' ? { name: t } : t;
-    if (!toolRegistry.has(def.name)) {
-      logger.warn(`Tool "${def.name}" not found in registry`);
-      continue;
-    }
-    tools.push(def);
-  }
-  return tools;
-}
-
-/**
  * Prepare initial state for the tool-use session.
  * Handles both new sessions and resumed sessions from snapshots.
  */
@@ -242,13 +220,19 @@ export function createToolUseFlowContext<C = unknown>(
   // Create services eagerly (no lazy initialization)
   const toolRegistry = customRegistry ?? getDefaultToolRegistry();
   const sessionLifecycle = new ToolUseSessionLifecycle(streamTabId);
+  const logger = init.executionContext.logger;
 
   // Resolve tools once at construction time instead of on every cycle
-  const resolvedTools = resolveToolsFromSetting(
-    setting,
-    toolRegistry,
-    init.executionContext.logger,
-  );
+  const toolConfigs = Array.isArray(setting.tools) ? setting.tools : [];
+  const resolvedTools: ToolDefinition[] = [];
+  for (const t of toolConfigs) {
+    const def = typeof t === 'string' ? { name: t } : t;
+    if (!toolRegistry.has(def.name)) {
+      logger.warn(`Tool "${def.name}" not found in registry`);
+      continue;
+    }
+    resolvedTools.push(def);
+  }
 
   // Capture snapshot in closure for prepareState
   const snapshot = resumeSnapshot ?? null;


### PR DESCRIPTION
- Change shouldEnsureXmlStructure from function () => boolean to
  direct boolean property (computed once at context creation)
- Inline resolveToolsFromSetting() into createToolUseFlowContext()
  (single-use helper, 16 lines of code consolidated)

These changes eliminate unnecessary function wrapper overhead while
preserving the same runtime behavior. The closure-based service
methods (prepareState, buildCycleOptions, applyFollowUpMessage)
are retained as they provide legitimate deferred execution.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reduces abstraction in flow contexts while preserving behavior.
> 
> - **Reflection**: Inline computation of `shouldEnsureXmlStructure` and `totalRounds`; replace `shouldEnsureXmlStructure()` with boolean `shouldEnsureXmlStructure`; inline default `getOutputFileLocation` logic.
> - **OutputNode**: Read boolean `shouldEnsureXmlStructure` instead of calling a function.
> - **Tool-use**: Inline tool resolution (removes `resolveToolsFromSetting`) and inline `applyFollowUpMessage` logic; minor logger/local var cleanup; service wiring unchanged otherwise.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bc6b3db87f971cf36cb41fbad28f332ff84799e8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->