### PR TITLE
refactor: remove closure wrappers from tool-use flow services

### DIFF
--- a/src/agent/implementations/flows/ToolUseRunFlow.ts
+++ b/src/agent/implementations/flows/ToolUseRunFlow.ts
@@ -11,6 +11,10 @@
  * - Flow propagates services to all nodes automatically
  * - Nodes access via this.services getter
  *
+ * Refactored (no closure wrappers):
+ * - Nodes call helper functions directly with services context
+ * - Eliminates closure indirection for cleaner call stacks
+ *
  * This follows the same pattern as ReflectionFlow for consistency.
  */
 
@@ -44,8 +48,14 @@ import {
   NODE_NO_WAIT,
 } from '@agent/implementations/flows/common';
 
-// Service types
-import type { ToolUseServices, ToolUseFlowParams } from './tooluse';
+// Service types and helper functions (direct calls, no closures)
+import {
+  prepareInitialState,
+  buildCycleOptions,
+  applyFollowUpMessage,
+  type ToolUseServices,
+  type ToolUseFlowParams,
+} from './tooluse';
 
 // ============================================================================
 // State Types
@@ -185,11 +195,11 @@ function assertPreparedState(
 /**
  * Prepares state for tool-use cycle.
  *
- * Uses native services pattern:
- * - this.services.prepareState() instead of shared.hooks.prepareState()
+ * Calls helper functions directly with services context (no closure wrappers).
+ * This eliminates closure indirection for cleaner call stacks.
  *
  * Note: cycleOptions is NOT stored in state (non-serializable). It's rebuilt
- * by CycleNode using this.services.buildCycleOptions().
+ * by CycleNode using buildCycleOptions().
  */
 class ToolUsePrepareNode<C> extends Node<
   ToolUseRunShared,
@@ -207,9 +217,9 @@ class ToolUsePrepareNode<C> extends Node<
   async exec(
     _prepRes: void,
   ): Promise<{ kind: 'success'; result: ToolUsePrepareResult<C> }> {
-    // Use native services pattern
-    const prepared = await this.services.prepareState();
-    const cycleOptions = this.services.buildCycleOptions(prepared.store);
+    // Call helper functions directly (no closure wrappers)
+    const prepared = await prepareInitialState(this.services);
+    const cycleOptions = buildCycleOptions(this.services, prepared.store);
     return {
       kind: 'success',
       result: {
@@ -273,8 +283,8 @@ class ToolUseCycleNode<C> extends Node<
     // Reconstruct store from snapshot (koala-code-reader pattern)
     const store = createSharedStore({ snapshot: shared.state.storeSnapshot });
 
-    // Rebuild cycleOptions from services (NOT stored in state - non-serializable)
-    const cycleOptions = this.services.buildCycleOptions(store);
+    // Rebuild cycleOptions directly (no closure wrapper)
+    const cycleOptions = buildCycleOptions(this.services, store);
 
     return {
       shouldSkip: shared.state.shouldSkipCycle,
@@ -404,9 +414,8 @@ class ToolUseCycleNode<C> extends Node<
 /**
  * Waits for user follow-up message between cycles.
  *
- * Uses native services pattern:
- * - this.services.applyFollowUpMessage() instead of shared.agent.applyFollowUpMessage()
- * - Session operations via this.services.session
+ * Calls helper functions directly with services context (no closure wrappers).
+ * Session operations via this.services.session.
  */
 class ToolUseWaitNode<C> extends Node<
   ToolUseRunShared,
@@ -472,10 +481,11 @@ class ToolUseWaitNode<C> extends Node<
       return FlowTransition.DEFAULT;
     }
 
-    // Apply follow-up via services
+    // Apply follow-up directly (no closure wrapper)
     const session = this.services.session;
     await session.markRunning();
-    shared.state.conversation = await this.services.applyFollowUpMessage(
+    shared.state.conversation = await applyFollowUpMessage(
+      this.services,
       execRes.followUp,
       shared.state.conversation,
     );
@@ -524,6 +534,3 @@ export function createToolUseRunFlow<C = unknown>(): Flow<
     prepareNode,
   );
 }
-
-// Re-export types for convenience
-export type { ToolUseServices, ToolUseFlowParams } from './tooluse';

--- a/src/agent/implementations/flows/tooluse/ToolUseFlowContext.ts
+++ b/src/agent/implementations/flows/tooluse/ToolUseFlowContext.ts
@@ -1,15 +1,8 @@
 /**
- * ToolUseFlowContext - Simple factory function for tool-use flow services.
- *
- * Creates all services needed by ToolUseRunFlow:
- * - Session lifecycle management (follow-ups, status)
- * - Tool registry and resolution
- * - Cycle execution options
- *
- * Note: Persistence is handled automatically by PersistedFlow.
+ * ToolUseFlowContext - Factory and helpers for tool-use flow services.
+ * Services pass context values directly; nodes call helpers without closures.
  */
 
-import type { IModelHandler } from '@agent/modelHandlers';
 import type { AgentToolUseSetting } from '@agent/core/AgentDataclass';
 import type { IToolRegistry } from '@agent/core/ToolTypes';
 import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
@@ -26,7 +19,10 @@ import type { RoundFinalizedCallback } from '@agent/core/flows/CycleServices';
 import type { ToolDefinition } from '@model';
 import { getDefaultToolRegistry } from '@tools/registry';
 import { buildInitialToolUsePrompts } from '@utils/prompt';
-import { ToolUseSessionLifecycle } from './ToolUseSessionLifecycle';
+import {
+  ToolUseSessionLifecycle,
+  type IToolUseSession,
+} from './ToolUseSessionLifecycle';
 
 import { buildBaseCycleOptions } from '../common';
 import type { ToolUseServices, PrepareStateResult } from './ToolUseServices';
@@ -86,27 +82,15 @@ export interface ToolUseFlowContext<C = unknown> {
 }
 
 // ============================================================================
-// Helper Functions
+// Helper Functions (called directly by nodes, no closure wrappers)
 // ============================================================================
 
-/**
- * Prepare initial state for the tool-use session.
- * Handles both new sessions and resumed sessions from snapshots.
- */
-async function prepareInitialState<C>(
-  init: ToolUseFlowContextInit<C>,
-  sessionLifecycle: ToolUseSessionLifecycle,
-  snapshot: ToolUseSessionSnapshot | null,
+/** Prepare initial state for tool-use session (new or resumed from snapshot). */
+export async function prepareInitialState<C>(
+  services: ToolUseServices<C>,
 ): Promise<PrepareStateResult> {
-  const {
-    modelHandler,
-    prompt,
-    userVarChannels,
-    executionContext,
-    getUsageRecorder,
-  } = init;
-  const logger = executionContext.logger;
-  const onRoundFinalized = getUsageRecorder?.();
+  const { modelHandler, prompt, userVarChannels, logger, snapshot, session } =
+    services;
 
   if (snapshot) {
     logger.debug('Resuming tool-use session from saved state.');
@@ -115,7 +99,7 @@ async function prepareInitialState<C>(
     // Store is a pure data holder; onRoundFinalized is passed to flow services separately
     const store = createSharedStore({ snapshot: snapshot.store });
 
-    sessionLifecycle.setStore(store);
+    session.setStore(store);
 
     return {
       messages,
@@ -146,7 +130,7 @@ async function prepareInitialState<C>(
     userChannels: userVarChannels,
   });
 
-  sessionLifecycle.setStore(store);
+  session.setStore(store);
 
   return {
     messages,
@@ -156,61 +140,51 @@ async function prepareInitialState<C>(
   };
 }
 
-/**
- * Create cycle options for tool-use execution.
- */
-function createCycleOptions<C>(
-  init: ToolUseFlowContextInit<C>,
-  toolRegistry: IToolRegistry,
-  resolvedTools: ToolDefinition[],
+/** Build cycle options for tool-use execution. */
+export function buildCycleOptions<C>(
+  services: ToolUseServices<C>,
   store: AgentSharedStore,
 ): ToolUseCycleOptions<C> {
-  // Use pre-resolved tools (computed at construction time)
-  const resolvedSetting = {
-    ...init.setting,
-    tools: resolvedTools,
-  };
+  const { setting, toolRegistry, resolvedTools, config } = services;
+  const resolvedSetting = { ...setting, tools: resolvedTools };
 
-  // Build base cycle options using helper (eliminates manual field copying)
-  // Then extend with tool-use specific fields
-  // Note: workspace is passed via CycleStateSlices, not duplicated in options
   return {
-    ...buildBaseCycleOptions(init),
-    // Override with resolved setting (includes pre-resolved tools)
+    ...buildBaseCycleOptions(services),
     agentSetting: resolvedSetting,
-    // ToolUseCycleOptions specific fields
-    toolRegistry: toolRegistry,
-    modelName: init.config.model,
-    agentName: init.config.agent,
+    toolRegistry,
+    modelName: config.model,
+    agentName: config.agent,
   };
+}
+
+/** Apply a follow-up message to the conversation. */
+export async function applyFollowUpMessage<C>(
+  services: ToolUseServices<C>,
+  followUp: string,
+  messages: ProviderMessage[],
+): Promise<ProviderMessage[]> {
+  services.logger.userMessage(followUp);
+  return await services.modelHandler.createUserFollowUpMessages(
+    messages,
+    followUp,
+  );
 }
 
 // ============================================================================
 // Factory Function
 // ============================================================================
 
-/**
- * Creates a ToolUseFlowContext with all services and behaviors configured.
- *
- * This is the primary entry point for setting up flow execution.
- * Returns a simple object with services and lifecycle methods.
- */
+/** Creates a ToolUseFlowContext with services and lifecycle methods. */
 export function createToolUseFlowContext<C = unknown>(
   init: ToolUseFlowContextInit<C>,
 ): ToolUseFlowContext<C> {
-  const {
-    setting,
-    streamTabId,
-    toolRegistry: customRegistry,
-    resumeSnapshot,
-  } = init;
+  const { setting, streamTabId, toolRegistry: customRegistry, resumeSnapshot } = init;
 
-  // Create services eagerly (no lazy initialization)
   const toolRegistry = customRegistry ?? getDefaultToolRegistry();
   const sessionLifecycle = new ToolUseSessionLifecycle(streamTabId);
   const logger = init.executionContext.logger;
 
-  // Resolve tools once at construction time instead of on every cycle
+  // Resolve tools once at construction time
   const toolConfigs = Array.isArray(setting.tools) ? setting.tools : [];
   const resolvedTools: ToolDefinition[] = [];
   for (const t of toolConfigs) {
@@ -222,10 +196,6 @@ export function createToolUseFlowContext<C = unknown>(
     resolvedTools.push(def);
   }
 
-  // Capture snapshot in closure for prepareState
-  const snapshot = resumeSnapshot ?? null;
-
-  // Build complete services object
   const services: ToolUseServices<C> = {
     ...init,
     logger: init.executionContext.logger,
@@ -233,16 +203,8 @@ export function createToolUseFlowContext<C = unknown>(
     setting,
     toolRegistry,
     session: sessionLifecycle,
-    prepareState: () => prepareInitialState(init, sessionLifecycle, snapshot),
-    buildCycleOptions: (store) =>
-      createCycleOptions(init, toolRegistry, resolvedTools, store),
-    applyFollowUpMessage: async (message, conversation) => {
-      init.executionContext.logger.userMessage(message);
-      return init.modelHandler.createUserFollowUpMessages(
-        conversation,
-        message,
-      );
-    },
+    resolvedTools,
+    snapshot: resumeSnapshot ?? null,
     getUsageRecorder: init.getUsageRecorder ?? (() => async () => {}),
   };
 

--- a/src/agent/implementations/flows/tooluse/ToolUseServices.ts
+++ b/src/agent/implementations/flows/tooluse/ToolUseServices.ts
@@ -6,24 +6,25 @@
  * - Nodes access services via this.services
  * - shared contains mutable runtime state only
  *
- * ToolUseServices extends BaseFlowContextInit and FlowServiceAccessors
- * with tool-use specific dependencies (tool registry, session, cycle operations).
+ * Architecture (refactored - no closure wrappers):
+ * - Services pass context values directly (resolvedTools, snapshot, etc.)
+ * - Nodes call helper functions directly with services context
+ * - Eliminates closure indirection for cleaner call stacks
  */
 
-import type { ToolUseCycleOptions } from '@agent/core/flows/CycleServices';
 import type { AgentSharedStore } from '@agent/core/AgentSharedStore';
 import type { AgentRunState } from '@agent/core/AgentState';
 import type { AgentToolUseSetting } from '@agent/core/AgentDataclass';
 import type { RoundFinalizedCallback } from '@agent/core/flows/CycleServices';
 import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
 import type { IToolRegistry } from '@agent/core/ToolTypes';
+import type { ToolDefinition } from '@model';
 import type {
   BaseFlowContextInit,
   FlowServiceAccessors,
 } from '../common/BaseFlowServices';
 import type { IToolUseSession } from './ToolUseSessionLifecycle';
-
-// Note: RunCycleResult was removed - ToolUseCycleNode now directly runs ToolUseCycleFlow
+import type { ToolUseSessionSnapshot } from './ToolUseSessionTypes';
 
 /**
  * Result of preparing initial state for a tool-use session.
@@ -38,10 +39,13 @@ export interface PrepareStateResult {
 /**
  * Services for tool-use flow nodes.
  *
- * Extends BaseFlowContextInit directly with tool-use specific dependencies:
- * - toolRegistry: Available tools for the agent
- * - session: Session lifecycle management (follow-ups, status)
- * - Operations: prepareState, buildCycleOptions, applyFollowUpMessage
+ * Extends BaseFlowContextInit directly with tool-use specific dependencies.
+ * Nodes call helper functions directly with these context values (no closures).
+ *
+ * Refactored architecture:
+ * - resolvedTools: Pre-resolved tool definitions (computed once at creation)
+ * - snapshot: Resume snapshot for session recovery (null for fresh start)
+ * - Nodes import and call helper functions directly
  *
  * Note: ToolUseCycleNode directly instantiates ToolUseCycleFlow (no runCycle indirection).
  * Persistence is handled automatically by PersistedFlow after each node.
@@ -57,31 +61,11 @@ export interface ToolUseServices<C = unknown>
   /** Session lifecycle for follow-ups and status management */
   readonly session: IToolUseSession;
 
-  // =========================================================================
-  // Cycle Operations
-  // These are agent-specific operations that nodes invoke via services.
-  // =========================================================================
+  /** Pre-resolved tool definitions (computed once at context creation) */
+  readonly resolvedTools: ToolDefinition[];
 
-  /**
-   * Prepare initial state for the tool-use session.
-   * Handles both new sessions and resumed sessions from snapshots.
-   */
-  readonly prepareState: () => Promise<PrepareStateResult>;
-
-  /**
-   * Build cycle options for tool-use execution.
-   */
-  readonly buildCycleOptions: (
-    store: AgentSharedStore,
-  ) => ToolUseCycleOptions<C>;
-
-  /**
-   * Apply a follow-up message to the conversation.
-   */
-  readonly applyFollowUpMessage: (
-    message: string,
-    conversation: ProviderMessage[],
-  ) => Promise<ProviderMessage[]>;
+  /** Resume snapshot for session recovery (null for fresh start) */
+  readonly snapshot: ToolUseSessionSnapshot | null;
 
   /**
    * Get usage recorder callback for tracking round statistics.

--- a/src/agent/implementations/flows/tooluse/ToolUseSessionLifecycle.ts
+++ b/src/agent/implementations/flows/tooluse/ToolUseSessionLifecycle.ts
@@ -20,6 +20,9 @@ import { STREAM_STATUS } from '@common/constants/streamStatus';
  * This interface focuses on session-specific operations (follow-ups, status).
  */
 export interface IToolUseSession {
+  /** Set the shared store for session state management. */
+  setStore(store: AgentSharedStore | null): void;
+
   /** Append a follow-up message to the session queue. */
   appendFollowUp(text: string): void;
 

--- a/src/agent/implementations/flows/tooluse/index.ts
+++ b/src/agent/implementations/flows/tooluse/index.ts
@@ -3,6 +3,11 @@
  *
  * Service interfaces and flow-first execution for tool-use agents.
  * The flow itself is in ToolUseRunFlow.ts (parent directory).
+ *
+ * Architecture (refactored - no closure wrappers):
+ * - Helper functions are exported for direct use by nodes
+ * - Services pass context values directly (resolvedTools, snapshot, etc.)
+ * - Eliminates closure indirection for cleaner call stacks
  */
 
 export type {
@@ -14,6 +19,10 @@ export type {
 export {
   ToolUseFlowContext,
   type ToolUseFlowContextInit,
+  // Helper functions for direct use by nodes (no closure wrappers)
+  prepareInitialState,
+  buildCycleOptions,
+  applyFollowUpMessage,
 } from './ToolUseFlowContext';
 
 export {


### PR DESCRIPTION
Eliminates abstraction overhead by removing closure wrapper pattern:

- ToolUseServices no longer contains closure functions (prepareState,
  buildCycleOptions, applyFollowUpMessage)
- Helper functions are now exported and called directly by nodes
- Services pass context values directly (resolvedTools, snapshot)
- Reduces call stack depth by 3 function calls

Before: node.exec() → closure → helper function
After:  node.exec() → helper function (direct call)

This aligns tool-use flow with reflection flow patterns where nodes
create flows directly in exec() without closure indirection.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Unifies tool-use flow with reflection patterns by removing service closure wrappers and simplifying call stacks.
> 
> - Nodes in `ToolUseRunFlow.ts` now call `prepareInitialState`, `buildCycleOptions`, and `applyFollowUpMessage` directly; `cycleOptions` rebuilt per cycle from services
> - `ToolUseServices` interface drops callable fields and adds direct context (`resolvedTools`, `snapshot`); session exposed via `IToolUseSession`
> - `ToolUseFlowContext` now exports helper functions, resolves tools once, and passes context values directly; session lifecycle gains `setStore`
> - `tooluse/index.ts` updates exports to surface helpers and session types
> 
> Scope: structural refactor only; no feature changes, reduced indirection and cleaner stacks
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1030db1d8411acdffb8b878dab4b98b848257c9e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->