### PR TITLE
fix: record files as read after write operations

### DIFF
--- a/src/tools/EditTool.ts
+++ b/src/tools/EditTool.ts
@@ -3,7 +3,10 @@ import { z } from 'zod';
 
 // Local imports - tools
 import { ToolError, ToolResult } from '@tools/result';
-import { requireFileReadForEdit } from '@tools/fileInteractions';
+import {
+  recordToolFileRead,
+  requireFileReadForEdit,
+} from '@tools/fileInteractions';
 import {
   buildApprovalRejectedResult,
   formatUnifiedApprovalUserDiff,
@@ -104,6 +107,10 @@ export class EditFileTool extends defineTool({
       currentContent,
       finalContent,
     );
+
+    // Record file as "read" after editing so subsequent edits don't require
+    // an explicit read again.
+    recordToolFileRead(targetPath);
 
     const replacementSummary =
       replace_all === true

--- a/src/tools/TextEditorTool.ts
+++ b/src/tools/TextEditorTool.ts
@@ -353,6 +353,10 @@ export class TextEditorTool extends defineTool({
         finalContent,
       );
 
+      // Record file as "read" after creation so subsequent edits don't require
+      // an explicit read - this is essential for newly created files.
+      recordToolFileRead(filePath);
+
       const userDiffNote = formatUnifiedApprovalUserDiff(
         filePath,
         finalContent,
@@ -453,6 +457,10 @@ export class TextEditorTool extends defineTool({
         this.addToHistory(filePath, baseContent);
       }
       const finalContent = appliedContent;
+
+      // Record file as "read" after editing so subsequent edits don't require
+      // an explicit read again.
+      recordToolFileRead(filePath);
 
       // Create a snippet of the edited section
       const textBeforeReplacement =
@@ -571,6 +579,10 @@ export class TextEditorTool extends defineTool({
       }
       const finalContent = appliedContent;
 
+      // Record file as "read" after editing so subsequent edits don't require
+      // an explicit read again.
+      recordToolFileRead(filePath);
+
       // Prepare success message
       const previewLines = finalContent.split('\n');
       const snippetStart = Math.max(0, insertLine - SNIPPET_LINES);
@@ -663,6 +675,10 @@ export class TextEditorTool extends defineTool({
       );
       history.pop();
       const finalContent = appliedContent;
+
+      // Record file as "read" after undo so subsequent edits don't require
+      // an explicit read again.
+      recordToolFileRead(filePath);
 
       // If the history is now empty, delete the entry
       if (history.length === 0) {

--- a/src/tools/WriteTool.ts
+++ b/src/tools/WriteTool.ts
@@ -5,7 +5,10 @@ import { z } from 'zod';
 import { isTexFile } from '@common/files/fileTypeUtils';
 import replacementEngine from '@replacement/engine';
 import { ToolResult } from '@tools/result';
-import { requireFileReadForEdit } from '@tools/fileInteractions';
+import {
+  recordToolFileRead,
+  requireFileReadForEdit,
+} from '@tools/fileInteractions';
 import {
   buildApprovalRejectedResult,
   formatUnifiedApprovalUserDiff,
@@ -69,6 +72,12 @@ export class WriteFileTool extends defineTool({
       originalContent,
       finalContent,
     );
+
+    // Record the file as "read" after writing so subsequent edits don't require
+    // an explicit read. This is especially important for new files that were
+    // just created - without this, any immediate edit would fail with
+    // "prior read required" even though the user just wrote the file.
+    recordToolFileRead(input.path);
 
     const userDiffNote = formatUnifiedApprovalUserDiff(
       input.path,

--- a/src/tools/fileInteractions.ts
+++ b/src/tools/fileInteractions.ts
@@ -25,7 +25,7 @@ export function requireFileReadForEdit(
   return {
     summary: `Read ${path} before editing`,
     output:
-      'Edits to existing files require a prior read in this session. Please call read_file first or write a new file instead.',
+      'Edits to existing files require a prior read in this session. Please call read_file first.',
     isError: true,
     diagnostics: { reason: 'unread-file', path },
   };

--- a/src/tools/fileOp.ts
+++ b/src/tools/fileOp.ts
@@ -86,6 +86,11 @@ export class FileOpTool extends defineTool({
           originalContent,
           finalContent,
         );
+
+        // Record file as "read" after writing so subsequent edits don't require
+        // an explicit read - especially important for newly created files.
+        recordToolFileRead(path);
+
         const userDiffNote = formatUnifiedApprovalUserDiff(
           path,
           finalContent,
@@ -150,6 +155,11 @@ export class FileOpTool extends defineTool({
         if (appendedSegment.length > 0) {
           await WorkspaceFS.appendFile(path, appendedSegment);
         }
+
+        // Record file as "read" after appending so subsequent edits don't require
+        // an explicit read - especially important for newly created files.
+        recordToolFileRead(path);
+
         // Report the actual applied content after append
         const appliedContent = await WorkspaceFS.read(path);
         const userDiffNote = formatUnifiedApprovalUserDiff(


### PR DESCRIPTION
When creating or editing files, the permission system would require
a prior read before subsequent edits. This was problematic for newly
created files - after writing a new file, any immediate edit would
fail with "prior read required" even though the user just wrote it.

Fix by calling recordToolFileRead() after successful write operations:
- WriteTool: record after write_file succeeds
- EditTool: record after edit_file succeeds
- TextEditorTool: record after create, str_replace, insert, undo_edit
- FileOpTool: record after write and append operations

Also simplified the error message by removing the confusing "write a
new file instead" suggestion.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures immediate follow-up edits don’t fail with "prior read required" by marking files as read after write-like operations.
> 
> - Call `recordToolFileRead` after successful operations in `WriteTool`, `EditTool`, `TextEditorTool` (create/`str_replace`/insert/undo), and `fileOp` (write/append)
> - Simplifies unread-file error in `requireFileReadForEdit` to: "Please call `read_file` first."
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7e8556d1f4a78041a101acded23c6f2c0e664a4d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->