### PR TITLE
fix: refresh auth keys for relay before each response round

### DIFF
--- a/src/agent/implementations/flows/ToolUseRunFlow.ts
+++ b/src/agent/implementations/flows/ToolUseRunFlow.ts
@@ -219,7 +219,7 @@ class ToolUsePrepareNode<C> extends Node<
   ): Promise<{ kind: 'success'; result: ToolUsePrepareResult<C> }> {
     // Call helper functions directly (no closure wrappers)
     const prepared = await prepareInitialState(this.services);
-    const cycleOptions = buildCycleOptions(this.services, prepared.store);
+    const cycleOptions = await buildCycleOptions(this.services, prepared.store);
     return {
       kind: 'success',
       result: {
@@ -284,7 +284,7 @@ class ToolUseCycleNode<C> extends Node<
     const store = createSharedStore({ snapshot: shared.state.storeSnapshot });
 
     // Rebuild cycleOptions directly (no closure wrapper)
-    const cycleOptions = buildCycleOptions(this.services, store);
+    const cycleOptions = await buildCycleOptions(this.services, store);
 
     return {
       shouldSkip: shared.state.shouldSkipCycle,

--- a/src/agent/implementations/flows/common/BaseFlowServices.ts
+++ b/src/agent/implementations/flows/common/BaseFlowServices.ts
@@ -74,8 +74,8 @@ export interface BaseFlowContextInit<C = unknown> {
   /** Set abort controller for cancellation */
   setAbortController: (ctrl: AbortController | null) => void;
 
-  /** Get the API client instance */
-  getClient: () => C;
+  /** Get the API client instance (async to allow auth token refresh) */
+  getClient: () => Promise<C>;
 
   /** Callback invoked when interrupt() is called on the flow context */
   onInterrupt?: () => void;
@@ -120,7 +120,7 @@ export interface FlowServiceAccessors {
  * - prompt -> agentPrompt
  * - userVarChannels.transient -> userVars
  * - executionContext -> context (via services.context if available)
- * - getClient() -> client
+ * - getClient() -> client (awaited to get fresh auth tokens)
  *
  * Accepts either:
  * - BaseFlowContextInit (raw config, uses executionContext.logger)
@@ -129,9 +129,9 @@ export interface FlowServiceAccessors {
  * @param services - Flow services or initialization config
  * @returns Base cycle options ready for extension
  */
-export function buildBaseCycleOptions<C>(
+export async function buildBaseCycleOptions<C>(
   services: BaseFlowContextInit<C> & Partial<FlowServiceAccessors>,
-): AgentCycleBaseOptions<C> {
+): Promise<AgentCycleBaseOptions<C>> {
   return {
     modelHandler: services.modelHandler,
     agentSetting: services.setting,
@@ -139,7 +139,7 @@ export function buildBaseCycleOptions<C>(
     userVars: services.userVarChannels.transient,
     logger: services.logger ?? services.executionContext.logger,
     context: services.context ?? services.executionContext,
-    client: services.getClient(),
+    client: await services.getClient(),
     checkInterruption: services.checkInterruption,
     setAbortController: services.setAbortController,
   };

--- a/src/agent/implementations/flows/reflection/nodes/ResponseCycleNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/ResponseCycleNode.ts
@@ -167,9 +167,10 @@ export class ResponseCycleNode<C = unknown> extends Node<
     }
 
     // Build ResponseCycleOptions from services using helper
+    // Await to get fresh client with refreshed auth tokens for each response round
     const { userVarChannels } = services;
     const cycleOptions = {
-      ...buildBaseCycleOptions(services),
+      ...(await buildBaseCycleOptions(services)),
       userVars: { ...userVarChannels.input, ...userVarChannels.transient },
       agentConfig: services.config,
       fileService: services.fileService,

--- a/src/agent/implementations/flows/tooluse/ToolUseFlowContext.ts
+++ b/src/agent/implementations/flows/tooluse/ToolUseFlowContext.ts
@@ -141,15 +141,16 @@ export async function prepareInitialState<C>(
 }
 
 /** Build cycle options for tool-use execution. */
-export function buildCycleOptions<C>(
+export async function buildCycleOptions<C>(
   services: ToolUseServices<C>,
   store: AgentSharedStore,
-): ToolUseCycleOptions<C> {
+): Promise<ToolUseCycleOptions<C>> {
   const { setting, toolRegistry, resolvedTools, config } = services;
   const resolvedSetting = { ...setting, tools: resolvedTools };
 
+  // Await to get fresh client with refreshed auth tokens for each response round
   return {
-    ...buildBaseCycleOptions(services),
+    ...(await buildBaseCycleOptions(services)),
     agentSetting: resolvedSetting,
     toolRegistry,
     modelName: config.model,

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -336,12 +336,29 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
   }
 
   async getClient(): Promise<GoogleGenAI> {
+    // When using server-side relay keys, always create a fresh client to ensure
+    // auth tokens are refreshed (tokens expire and need refresh every 30 mins).
+    // Personal API keys don't expire, so caching is safe for those.
+    if (this.shouldUseServerSideKeys()) {
+      const credential = await this.getApiKey();
+      const baseUrl = this.getBaseUrl();
+      this.logger.debug(
+        `Using Google GenAI Native SDK with relay auth. Base URL: ${baseUrl}`,
+      );
+      return new GoogleGenAI({
+        apiKey: credential,
+        httpOptions: {
+          baseUrl: baseUrl ?? undefined,
+        },
+      });
+    }
+
+    // For personal API keys, cache the client
     if (!this.googleClient) {
       const credential = await this.getApiKey();
       const baseUrl = this.getBaseUrl();
       this.logger.debug(`Using Google GenAI Native SDK. Base URL: ${baseUrl}`);
 
-      // For relay auth: credential is the user's JWT, SDK sends it via x-goog-api-key header
       this.googleClient = new GoogleGenAI({
         apiKey: credential,
         httpOptions: {

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -474,9 +474,6 @@ export async function executeAgent(
       async () => {
         logger.info(`Executing ${agentName} with model ${config.model}`);
 
-        // Initialize client for all flow types
-        const client = await ctx.modelHandler.getClient();
-
         // Create interrupt manager (replaces mutable interruptState object)
         const interruptManager = new InterruptManager();
 
@@ -495,7 +492,8 @@ export async function executeAgent(
               streamTabId: ctx.streamTabId,
               checkInterruption: interruptManager.checkInterruption,
               setAbortController: interruptManager.setAbortController,
-              getClient: () => client,
+              // Get fresh client each response round to ensure auth keys are refreshed
+              getClient: () => ctx.modelHandler.getClient(),
               getUsageRecorder: createUsageRecorder(
                 ctx.usageMonitor,
                 'tool-use',
@@ -524,7 +522,8 @@ export async function executeAgent(
               userVarChannels: ctx.userVarChannels,
               checkInterruption: interruptManager.checkInterruption,
               setAbortController: interruptManager.setAbortController,
-              getClient: () => client,
+              // Get fresh client each response round to ensure auth keys are refreshed
+              getClient: () => ctx.modelHandler.getClient(),
               getUsageRecorder: createUsageRecorder(
                 ctx.usageMonitor,
                 'workflow',
@@ -605,9 +604,6 @@ export async function executeMergeAgent(
     await logger.withScope(`Task: merge@${model}`, async () => {
       logger.info(`Executing merge with model ${model}`);
 
-      // Initialize client
-      const client = await ctx.modelHandler.getClient();
-
       // Create interrupt manager
       const interruptManager = new InterruptManager();
 
@@ -632,7 +628,8 @@ export async function executeMergeAgent(
           userVarChannels: ctx.userVarChannels,
           checkInterruption: interruptManager.checkInterruption,
           setAbortController: interruptManager.setAbortController,
-          getClient: () => client,
+          // Get fresh client each response round to ensure auth keys are refreshed
+          getClient: () => ctx.modelHandler.getClient(),
           getUsageRecorder: createUsageRecorder(ctx.usageMonitor, 'workflow'),
           getOutputFileLocation,
           onInterrupt: interruptManager.onInterrupt,
@@ -702,12 +699,8 @@ export async function resumeToolUseFromSnapshot(
 
   // Create interrupt manager
   const interruptManager = new InterruptManager();
-  let client: any = null;
 
   try {
-    // Initialize client
-    client = await modelHandler.getClient();
-
     // Setup UI state for resume
     bus.emit('setActiveStream', {
       stream: streamTabId,
@@ -729,7 +722,8 @@ export async function resumeToolUseFromSnapshot(
         streamTabId,
         checkInterruption: interruptManager.checkInterruption,
         setAbortController: interruptManager.setAbortController,
-        getClient: () => client,
+        // Get fresh client each response round to ensure auth keys are refreshed
+        getClient: () => modelHandler.getClient(),
         getUsageRecorder: createUsageRecorder(usageMonitor, 'tool-use'),
         resumeSnapshot: snapshot,
         onInterrupt: interruptManager.onInterrupt,


### PR DESCRIPTION
The authentication key for long-running sessions was timing out because:

1. In executeAgent.ts, the client was created once at the start and
   cached for all subsequent response rounds. Even though ensureFreshToken()
   would refresh tokens at the 30-minute mark, the cached client still had
   the old auth key baked in.

2. The Google GenAI handler cached clients at the instance level, so even
   calling getClient() again would return the stale client with expired auth.

This fix ensures fresh clients with refreshed auth tokens are obtained
before each response round when using server-side relay keys:

- executeAgent.ts: Changed from caching client to calling getClient() fresh
- modelHandlerGoogleGenAI.ts: Skip caching when using relay auth (personal
  API keys still cache since they don't expire)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures expiring relay auth tokens are refreshed per response round by avoiding cached clients and awaiting client acquisition in cycle setup.
> 
> - Make `getClient` async in flow services and await it in `buildBaseCycleOptions` (now async)
> - Update `ResponseCycleNode`, `ToolUseRunFlow`, and tool-use cycle builders to `await buildBaseCycleOptions` / `buildCycleOptions`
> - Change `executeAgent` and resume/merge paths to pass `getClient: () => modelHandler.getClient()` instead of pre-fetching/caching a client
> - In `modelHandlerGoogleGenAI`, return a new `GoogleGenAI` client when using server-side relay keys; continue caching for personal keys
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aa7f257c05d6058d541bef4460d2e02c4cac530e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->