### PR TITLE
fix(auth): improve GitHub token exchange error logging

### DIFF
--- a/src/auth/SupabaseAuthProvider.ts
+++ b/src/auth/SupabaseAuthProvider.ts
@@ -479,7 +479,11 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
 
       logger.info(
         'SupabaseAuthProvider',
-        `Got VS Code GitHub session for ${githubSession.account.label}`,
+        `Got VS Code GitHub session for ${githubSession.account.label} (scopes: ${githubSession.scopes.join(', ') || 'default'})`,
+      );
+      logger.debug(
+        'SupabaseAuthProvider',
+        `GitHub token preview: ${githubSession.accessToken.substring(0, 10)}...`,
       );
 
       // Exchange GitHub token for Supabase session via Edge Function
@@ -509,9 +513,13 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
 
       if (!response.ok) {
         const errorData = await response.json().catch(() => ({}));
-        throw new Error(
-          errorData.error || `Token exchange failed: ${response.status}`,
+        const errorMsg =
+          errorData.error || `Token exchange failed: ${response.status}`;
+        logger.error(
+          'SupabaseAuthProvider',
+          `GitHub token exchange failed (${response.status}): ${errorMsg}`,
         );
+        throw new Error(errorMsg);
       }
 
       // Parse and validate response with Zod schema

--- a/supabase/functions/auth-github/index.ts
+++ b/supabase/functions/auth-github/index.ts
@@ -112,7 +112,7 @@ function jsonResponse(
 
 async function validateGitHubToken(
   token: string,
-): Promise<{ user: GitHubUser; email: string } | null> {
+): Promise<{ user: GitHubUser; email: string } | { error: string }> {
   const headers = {
     Authorization: `Bearer ${token}`,
     Accept: 'application/vnd.github+json',
@@ -120,7 +120,13 @@ async function validateGitHubToken(
   };
 
   const userRes = await fetch('https://api.github.com/user', { headers });
-  if (!userRes.ok) return null;
+  if (!userRes.ok) {
+    const errorText = await userRes.text().catch(() => 'unknown');
+    console.error(
+      `[AUTH] GitHub /user API failed: ${userRes.status} - ${errorText}`,
+    );
+    return { error: `GitHub API rejected token (${userRes.status})` };
+  }
 
   const user: GitHubUser = await userRes.json();
   let primaryEmail = user.email;
@@ -135,9 +141,19 @@ async function validateGitHubToken(
         e.primary && e.verified,
     );
     if (primary) primaryEmail = primary.email;
+  } else {
+    console.warn(
+      `[AUTH] GitHub /user/emails API failed: ${emailsRes.status}, using profile email`,
+    );
   }
 
-  if (!primaryEmail) return null;
+  if (!primaryEmail) {
+    console.error(
+      `[AUTH] No verified email for GitHub user ${user.login} (id: ${user.id})`,
+    );
+    return { error: 'No verified email on GitHub account' };
+  }
+
   return { user, email: primaryEmail };
 }
 
@@ -191,16 +207,12 @@ app.post('/exchange', async (c) => {
       return jsonResponse(c, { error: 'github_token required' }, 400);
     }
 
-    const githubData = await validateGitHubToken(body.github_token);
-    if (!githubData) {
-      return jsonResponse(
-        c,
-        { error: 'Invalid GitHub token or missing verified email' },
-        401,
-      );
+    const githubResult = await validateGitHubToken(body.github_token);
+    if ('error' in githubResult) {
+      return jsonResponse(c, { error: githubResult.error }, 401);
     }
 
-    const { user: githubUser, email } = githubData;
+    const { user: githubUser, email } = githubResult;
     const githubProviderId = githubUser.id.toString();
     const supabase = c.get('supabase');
 


### PR DESCRIPTION
Add detailed error logging to help debug token exchange 401 failures:
- Edge Function now returns specific error messages instead of generic
  "Invalid GitHub token or missing verified email"
- Log GitHub API status codes when /user or /user/emails calls fail
- Client-side now logs the actual error from the Edge Function response
- Add debug logging for GitHub session scopes and token preview

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves visibility and diagnostics for GitHub-based auth flows.
> 
> - Client: logs GitHub session scopes and a short token preview; on token exchange failure, logs status and server-provided error before throwing it
> - Edge Function: `validateGitHubToken` now returns structured `{ error }` with detailed reasons (GitHub `/user` status, `/user/emails` fallback, missing verified email) and logs failures; `/exchange` propagates specific 401 errors instead of a generic message
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bb0dca6955e59a2241f8e2781c1fa135c0a5a449. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->