### PR TITLE
feat: use native vscode-collapsible for progress view panels

### DIFF
--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -180,19 +180,24 @@
             id="logContent"
             class="log-container"
           ></vscode-scrollable>
-          <div id="generatedFiles" class="files-container"></div>
-          <div
-            id="todoListContainer"
-            class="todo-list-container"
+          <vscode-collapsible
+            id="generatedFilesCollapsible"
+            title="Generated Files"
+            class="progress-collapsible files-collapsible"
+            open
             hidden
-            aria-hidden="true"
           >
-            <div class="todo-list__header">
-              <i class="codicon codicon-tasklist"></i>
-              <span>Task Progress</span>
-            </div>
+            <div id="generatedFiles" class="files-container"></div>
+          </vscode-collapsible>
+          <vscode-collapsible
+            id="todoListContainer"
+            title="Task Progress"
+            class="progress-collapsible todo-collapsible"
+            open
+            hidden
+          >
             <div id="todoList" class="todo-list"></div>
-          </div>
+          </vscode-collapsible>
           <div class="usage-summary-footer" hidden>
             <span id="runSummary" class="run-summary"></span>
           </div>

--- a/src/progressView/modules/constants.js
+++ b/src/progressView/modules/constants.js
@@ -18,6 +18,7 @@ export const ELEMENT_IDS = {
   LOG_CONTENT: 'logContent',
   LOG_PLACEHOLDER: 'logPlaceholder',
   GENERATED_FILES: 'generatedFiles',
+  GENERATED_FILES_COLLAPSIBLE: 'generatedFilesCollapsible',
   STREAM_TABS: 'streamTabs',
   ACTIVE_STREAM_NAME: 'activeStreamName',
   RUN_SELECTOR: 'runSelector',

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -311,6 +311,7 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       dom.instructionPanel.hide();
       dom.runSelector.clear();
       dom.todoList.clear();
+      dom.fileList.clear();
       state.clearRunInstructions();
       state.clearAllActiveRuns();
       state.clearAllPendingInstructions();
@@ -877,6 +878,7 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
         dom.instructionPanel.hide();
         dom.runSelector.clear();
         dom.todoList.clear();
+        dom.fileList.clear();
       }
     }
 
@@ -897,6 +899,7 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     state.clearAllTodos();
     dom.runSelector.clear();
     dom.todoList.clear();
+    dom.fileList.clear();
     this._updatePlaceholderVisibility();
   }
 

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -327,6 +327,7 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
 
     this._refreshInstructionForActiveRun();
     this._refreshUsageForActiveRun();
+    this._refreshOutputsForActiveRun();
   }
 
   handleUpdateLogs(message) {

--- a/src/progressView/modules/uiManagers/FileList.js
+++ b/src/progressView/modules/uiManagers/FileList.js
@@ -38,9 +38,6 @@ export class FileList {
       return;
     }
 
-    // Show the collapsible when there are files
-    setVisibilityState(collapsible, true);
-
     const rounds = Object.keys(filesByRound)
       .map((r) => parseInt(r, 10))
       .sort((a, b) => a - b);
@@ -100,6 +97,9 @@ export class FileList {
     if (!showRoundHeaders && flatGroup && hasFiles) {
       container.appendChild(flatGroup);
     }
+
+    // Show/hide collapsible based on whether files were actually rendered
+    setVisibilityState(collapsible, hasFiles);
   }
 
   /**

--- a/src/progressView/modules/uiManagers/FileList.js
+++ b/src/progressView/modules/uiManagers/FileList.js
@@ -2,6 +2,7 @@
 import { COMMANDS, ELEMENT_IDS } from '../constants.js';
 // Local imports
 import { createFromTemplate } from '@common/templateUtils.js';
+import { setVisibilityState } from '@common/domUtils.js';
 
 /**
  * Manages file list rendering.
@@ -33,16 +34,12 @@ export class FileList {
 
     if (!filesByRound || Object.keys(filesByRound).length === 0) {
       // Hide the collapsible when there are no files
-      if (collapsible) {
-        collapsible.hidden = true;
-      }
+      setVisibilityState(collapsible, false);
       return;
     }
 
     // Show the collapsible when there are files
-    if (collapsible) {
-      collapsible.hidden = false;
-    }
+    setVisibilityState(collapsible, true);
 
     const rounds = Object.keys(filesByRound)
       .map((r) => parseInt(r, 10))
@@ -254,8 +251,6 @@ export class FileList {
     if (container) {
       container.innerHTML = '';
     }
-    if (collapsible) {
-      collapsible.hidden = true;
-    }
+    setVisibilityState(collapsible, false);
   }
 }

--- a/src/progressView/modules/uiManagers/FileList.js
+++ b/src/progressView/modules/uiManagers/FileList.js
@@ -5,7 +5,7 @@ import { createFromTemplate } from '@common/templateUtils.js';
 
 /**
  * Manages file list rendering.
- * Updated to use new OutputFileInfo structure (no duplicate path fields).
+ * Uses native VS Code collapsible for the container.
  */
 export class FileList {
   /**
@@ -18,6 +18,9 @@ export class FileList {
   update(filesByRound, options = {}) {
     const { showRoundHeaders = true } = options;
     const container = document.getElementById(ELEMENT_IDS.GENERATED_FILES);
+    const collapsible = document.getElementById(
+      ELEMENT_IDS.GENERATED_FILES_COLLAPSIBLE,
+    );
     if (!container) return;
 
     container.innerHTML = '';
@@ -29,8 +32,16 @@ export class FileList {
     }
 
     if (!filesByRound || Object.keys(filesByRound).length === 0) {
-      container.textContent = 'No generated files';
+      // Hide the collapsible when there are no files
+      if (collapsible) {
+        collapsible.hidden = true;
+      }
       return;
+    }
+
+    // Show the collapsible when there are files
+    if (collapsible) {
+      collapsible.hidden = false;
     }
 
     const rounds = Object.keys(filesByRound)
@@ -229,6 +240,22 @@ export class FileList {
       filePathSpan.classList.add('clickable-link');
       filePathSpan.dataset.command = COMMANDS.OPEN_FILE;
       filePathSpan.dataset.file = file.location.absolutePath;
+    }
+  }
+
+  /**
+   * Clear the file list and hide the collapsible container.
+   */
+  clear() {
+    const container = document.getElementById(ELEMENT_IDS.GENERATED_FILES);
+    const collapsible = document.getElementById(
+      ELEMENT_IDS.GENERATED_FILES_COLLAPSIBLE,
+    );
+    if (container) {
+      container.innerHTML = '';
+    }
+    if (collapsible) {
+      collapsible.hidden = true;
     }
   }
 }

--- a/src/progressView/modules/uiManagers/TodoList.js
+++ b/src/progressView/modules/uiManagers/TodoList.js
@@ -2,7 +2,7 @@
 import { ELEMENT_IDS } from '../constants.js';
 
 // Local imports - shared helpers
-import { safeGetElementById } from '@common/domUtils.js';
+import { safeGetElementById, setVisibilityState } from '@common/domUtils.js';
 import { TODO_STATUS } from '@common/constants/todoStatus';
 
 /**
@@ -120,7 +120,7 @@ export class TodoList {
       return;
     }
 
-    elements.container.hidden = false;
+    setVisibilityState(elements.container, true);
   }
 
   /**
@@ -132,7 +132,7 @@ export class TodoList {
       return;
     }
 
-    elements.container.hidden = true;
+    setVisibilityState(elements.container, false);
   }
 
   /**

--- a/src/progressView/modules/uiManagers/TodoList.js
+++ b/src/progressView/modules/uiManagers/TodoList.js
@@ -2,7 +2,7 @@
 import { ELEMENT_IDS } from '../constants.js';
 
 // Local imports - shared helpers
-import { safeGetElementById, setVisibilityState } from '@common/domUtils.js';
+import { safeGetElementById } from '@common/domUtils.js';
 import { TODO_STATUS } from '@common/constants/todoStatus';
 
 /**
@@ -25,7 +25,7 @@ const STATUS_CLASSES = {
 
 /**
  * Manages the todo list display in the progress view.
- * Shows task progress for tool-use agents.
+ * Shows task progress for tool-use agents using native VS Code collapsible.
  */
 export class TodoList {
   constructor() {
@@ -112,7 +112,7 @@ export class TodoList {
   }
 
   /**
-   * Show the todo list container.
+   * Show the todo list container (vscode-collapsible).
    */
   show() {
     const elements = this._getElements();
@@ -120,11 +120,11 @@ export class TodoList {
       return;
     }
 
-    setVisibilityState(elements.container, true);
+    elements.container.hidden = false;
   }
 
   /**
-   * Hide the todo list container.
+   * Hide the todo list container (vscode-collapsible).
    */
   hide() {
     const elements = this._getElements();
@@ -132,7 +132,7 @@ export class TodoList {
       return;
     }
 
-    setVisibilityState(elements.container, false);
+    elements.container.hidden = true;
   }
 
   /**

--- a/src/progressView/styles/base.css
+++ b/src/progressView/styles/base.css
@@ -35,3 +35,12 @@ vscode-split-layout {
 }
 
 /* Animations moved to common.css as pulse-scale, pulse-fade, and spin */
+
+/* Shared progress collapsible styles */
+.progress-collapsible {
+  background-color: transparent;
+}
+
+.progress-collapsible[hidden] {
+  display: none;
+}

--- a/src/progressView/styles/file-list.css
+++ b/src/progressView/styles/file-list.css
@@ -1,7 +1,23 @@
 /**
  * File list styles for ProgressView
  * Styling for file list entries and file tree display
+ * Uses native VS Code collapsible component
  */
+
+/* Collapsible container styling */
+.files-collapsible {
+  margin: var(--spacing-small) 0;
+  border-top: 1px solid var(--color-border);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.files-collapsible::part(header) {
+  padding: var(--spacing-small) var(--spacing-medium);
+}
+
+.files-collapsible::part(body) {
+  padding: 0 var(--spacing-medium) var(--spacing-small);
+}
 
 /* File metadata styling */
 .file-list-content .file-var {

--- a/src/progressView/styles/todo-list.css
+++ b/src/progressView/styles/todo-list.css
@@ -1,32 +1,22 @@
 /**
  * Todo list styles for the ProgressView
- * Displays task progress for tool-use agents
+ * Uses native VS Code collapsible component
  */
 
-.todo-list-container {
-  display: none;
+/* Collapsible container styling */
+.todo-collapsible {
+  margin: var(--spacing-small) 0;
   border-top: 1px solid var(--color-border);
   border-bottom: 1px solid var(--color-border);
-  background-color: transparent;
+}
+
+/* Override vscode-collapsible header padding */
+.todo-collapsible::part(header) {
   padding: var(--spacing-small) var(--spacing-medium);
 }
 
-.todo-list-container.is-visible {
-  display: block;
-}
-
-.todo-list__header {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--spacing-tiny);
-  font-weight: 500;
-  color: var(--color-text-secondary);
-  margin-bottom: var(--spacing-small);
-}
-
-.todo-list__header .codicon {
-  font-size: var(--font-size-icon);
-  line-height: 1;
+.todo-collapsible::part(body) {
+  padding: 0 var(--spacing-medium) var(--spacing-small);
 }
 
 .todo-list {


### PR DESCRIPTION
Replace custom collapsible implementation with native vscode-collapsible
component for the Task Progress (todo list) and Generated Files panels.

Changes:
- Wrap both panels in vscode-collapsible elements
- Update TodoList.js and FileList.js to show/hide collapsibles via hidden attribute
- Add clear() method to FileList for proper cleanup
- Update CSS styles to use ::part selectors for collapsible styling
- Remove old custom header styling in favor of native component

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Migrates progress panels to native collapsibles and streamlines visibility and cleanup.
> 
> - Wrap `generatedFiles` and `todoList` in `vscode-collapsible` with shared `progress-collapsible` styles; add `GENERATED_FILES_COLLAPSIBLE` id
> - Update `FileList` and `TodoList` to toggle visibility via `setVisibilityState`, hide when empty, and add `fileList.clear()` for proper cleanup
> - Message handlers now clear file list on stream switch/delete and refresh outputs via `_refreshOutputsForActiveRun()`; todo updates unchanged but use collapsible container
> - New CSS using `::part(header|body)` for `files-collapsible` and `todo-collapsible`; remove old custom header/layout styles
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3a42319636f7d9810bcf702711b218cc7dc39fda. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->