### PR TITLE
Set up OpenAI API key relay server

### DIFF
--- a/src/tools/citation/CrossrefSearchTool.ts
+++ b/src/tools/citation/CrossrefSearchTool.ts
@@ -26,7 +26,9 @@ const CrossrefSearchInputSchema = z.strictObject({
   filter: z
     .union([
       z.string(),
-      z.record(z.string(), z.union([z.string(), z.array(z.string())])),
+      // Use z.record(valueSchema) without key type to avoid generating propertyNames
+      // in JSON Schema, which OpenAI's function calling doesn't support
+      z.record(z.union([z.string(), z.array(z.string())])),
     ])
     .nullish(),
 });


### PR DESCRIPTION
The z.record(z.string(), valueSchema) pattern in Zod v4 generates propertyNames in JSON Schema, which OpenAI's function calling API doesn't support. Using z.record(valueSchema) without the key type defaults to string keys without generating propertyNames.

Fixes: HTTP 400 "propertyNames is not permitted" error for crossref_search

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes OpenAI function-calling incompatibility by changing the Crossref search input schema.
> 
> - Updates `filter` in `CrossrefSearchTool.ts` from `z.record(z.string(), value)` to `z.record(value)` to avoid emitting JSON Schema `propertyNames`, preventing HTTP 400 errors for `crossref_search`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a6a6d6b2ae2d3518fff9dd4f8ba23c8976a6c74e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->