### PR TITLE
Fix crossref_search function schema validation error

### DIFF
--- a/src/tools/citation/CrossrefSearchTool.ts
+++ b/src/tools/citation/CrossrefSearchTool.ts
@@ -23,14 +23,9 @@ const CrossrefSearchInputSchema = z.strictObject({
   offset: z.int().min(0).nullish(),
   sort: z.string().nullish(),
   order: z.enum(['asc', 'desc']).nullish(),
-  filter: z
-    .union([
-      z.string(),
-      // Use z.record(valueSchema) without key type to avoid generating propertyNames
-      // in JSON Schema, which OpenAI's function calling doesn't support
-      z.record(z.union([z.string(), z.array(z.string())])),
-    ])
-    .nullish(),
+  // Filter as Crossref filter string format (e.g., "from-pub-date:2023,has-orcid:true")
+  // Object format removed due to OpenAI JSON Schema limitations with z.record()
+  filter: z.string().nullish(),
 });
 
 export type CrossrefSearchInput = z.infer<typeof CrossrefSearchInputSchema>;
@@ -70,16 +65,7 @@ export class CrossrefSearchTool extends defineTool({
       options.order = input.order === 'asc' ? SortOrder.ASC : SortOrder.DESC;
     }
     if (input.filter) {
-      if (typeof input.filter === 'string') {
-        options.filter = input.filter;
-      } else {
-        const segments = Object.entries(input.filter).flatMap(([key, value]) =>
-          Array.isArray(value)
-            ? value.map((entry) => `${key}:${entry}`)
-            : [`${key}:${value}`],
-        );
-        options.filter = segments.join(',');
-      }
+      options.filter = input.filter;
     }
 
     let response: Awaited<ReturnType<typeof crossrefClient.works>>;


### PR DESCRIPTION
OpenAI's function calling API doesn't support propertyNames in JSON Schema, which is generated by z.record() in Zod v4. Additionally, z.record() in Zod v4 requires 2 arguments (key schema, value schema), but the code was only passing 1.

Simplify the filter to accept only string format since the object format was just a convenience that got converted to string anyway.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Simplifies Crossref search tool input and handling to avoid JSON Schema issues.
> 
> - Changes `CrossrefSearchInputSchema.filter` to a `string` (Crossref filter string format); removes prior object/record support due to OpenAI JSON Schema limitations
> - Updates execution to assign `options.filter` directly and drops object-to-string conversion logic
> - Introduces `ExtendedQueryWorksParams` to include `filter?: string` since library types omit it
> - Minor comments/docs updated; no behavioral changes beyond input format simplification
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aad92d695af7230747846bcb1dbd86703ebcab46. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->