### PR TITLE
Add manual retry for background mode

### DIFF
--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -245,6 +245,14 @@ class ResponseModelInvocationNode<C> extends RetryableInvocationNode<
   }
 
   /**
+   * Check if background mode is active via the model handler.
+   * This enables the base class to enforce minimum retry count for background jobs.
+   */
+  protected override isBackgroundModeActive(): boolean {
+    return this.services.modelHandler.isBackgroundModeActive();
+  }
+
+  /**
    * Extract data from shared for exec().
    * PocketFlow compliance: exec() should only use prepRes, not shared.
    */

--- a/src/agent/core/flows/RetryState.ts
+++ b/src/agent/core/flows/RetryState.ts
@@ -31,6 +31,13 @@ import { bus } from '@eventBus/ProgressEventBus';
 /** Timeout for manual retry wait (5 minutes) - used by retryPrompt implementations */
 const MANUAL_RETRY_TIMEOUT_MS = 5 * 60 * 1000;
 
+/**
+ * Minimum manual retries for background mode.
+ * Background jobs can take longer and may fail due to timeout, so we ensure
+ * users have at least 3 opportunities to retry before giving up.
+ */
+export const BACKGROUND_MODE_MIN_MANUAL_RETRIES = 3;
+
 // ============================================================================
 // Schemas (Single Source of Truth)
 // ============================================================================

--- a/src/agent/core/flows/RetryState.ts
+++ b/src/agent/core/flows/RetryState.ts
@@ -32,11 +32,12 @@ import { bus } from '@eventBus/ProgressEventBus';
 const MANUAL_RETRY_TIMEOUT_MS = 5 * 60 * 1000;
 
 /**
- * Minimum manual retries for background mode.
+ * Minimum retry count for background mode.
+ * This is the minimum value for maxRetries (total attempts = 1 initial + N-1 retries).
  * Background jobs can take longer and may fail due to timeout, so we ensure
- * users have at least 3 opportunities to retry before giving up.
+ * at least 3 total attempts before surfacing the manual retry UI.
  */
-export const BACKGROUND_MODE_MIN_MANUAL_RETRIES = 3;
+export const BACKGROUND_MODE_MIN_RETRIES = 3;
 
 // ============================================================================
 // Schemas (Single Source of Truth)
@@ -300,6 +301,16 @@ export abstract class RetryableInvocationNode<
   }
 
   /**
+   * Check if background mode is active for this node.
+   * Override in subclasses that have access to model handler.
+   *
+   * @returns false by default, subclasses can override to check modelHandler
+   */
+  protected isBackgroundModeActive(): boolean {
+    return false;
+  }
+
+  /**
    * Read fresh retry config before starting the retry loop.
    *
    * This enables config changes (e.g., user adjusting retry settings)
@@ -313,10 +324,22 @@ export abstract class RetryableInvocationNode<
    *
    * The mutation pattern is intentional: it allows dynamic config while
    * keeping the Node API simple (maxRetries/wait are base class fields).
+   *
+   * ## Background mode minimum retries
+   * When background mode is active, we enforce a minimum retry count
+   * (BACKGROUND_MODE_MIN_RETRIES) to give users more chances to recover
+   * from transient failures common in long-running background jobs.
    */
   async _exec(prepRes: unknown): Promise<unknown> {
     const config = getNodeRetryConfig();
-    this.maxRetries = config.maxRetries;
+    let maxRetries = config.maxRetries;
+
+    // Enforce minimum retries for background mode
+    if (this.isBackgroundModeActive()) {
+      maxRetries = Math.max(maxRetries, BACKGROUND_MODE_MIN_RETRIES);
+    }
+
+    this.maxRetries = maxRetries;
     this.wait = config.wait;
     return super._exec(prepRes);
   }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces a background-mode-aware retry floor to improve robustness of long-running jobs.
> 
> - Adds `BACKGROUND_MODE_MIN_RETRIES=3` and enforces it in `RetryableInvocationNode._exec()` when `isBackgroundModeActive()` is true
> - Implements `isBackgroundModeActive()` hook (default false) and overrides it in `ResponseModelInvocationNode` to use `services.modelHandler.isBackgroundModeActive()`
> - Keeps dynamic retry config refresh; no changes to non-background behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 19bab83ded63d1b5961591ea3350626c34bb3c73. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->