### PR TITLE
Use bind to reduce code complexity

### DIFF
--- a/src/MainViewProvider.ts
+++ b/src/MainViewProvider.ts
@@ -40,11 +40,11 @@ export class MainViewProvider
 
   // Debounced refresh methods using perfect-debounce
   private debouncedRefreshAgentOptions = debounce(
-    () => this.refreshAgentOptions(),
+    this.refreshAgentOptions.bind(this),
     DEBOUNCE_OPTIONS_MS,
   );
   private debouncedRefreshModelOptions = debounce(
-    () => this.refreshModelOptions(),
+    this.refreshModelOptions.bind(this),
     DEBOUNCE_OPTIONS_MS,
   );
 
@@ -83,17 +83,13 @@ export class MainViewProvider
 
   private setupConfigurationWatcher() {
     // Watch for agent configuration changes - only refresh agent options
-    watchConfig(this.context, ['texra.agents', 'texra.toolUseAgents'], () =>
-      this.debouncedRefreshAgentOptions(),
-    );
+    watchConfig(this.context, ['texra.agents', 'texra.toolUseAgents'], this.debouncedRefreshAgentOptions);
 
     // Watch for model configuration changes - only refresh model options
-    watchConfig(this.context, ['texra.models'], () =>
-      this.debouncedRefreshModelOptions(),
-    );
+    watchConfig(this.context, ['texra.models'], this.debouncedRefreshModelOptions);
 
     // Watch for file configuration changes - only refresh file list
-    watchConfig(this.context, ['texra.files'], () => this.refreshFiles());
+    watchConfig(this.context, ['texra.files'], this.refreshFiles.bind(this));
   }
 
   private setupAuthListener() {
@@ -175,8 +171,8 @@ export class MainViewProvider
     this.fileWatcher = vscode.workspace.createFileSystemWatcher(filePattern);
 
     // Handle file changes
-    this.fileWatcher.onDidCreate(() => this.refreshFiles());
-    this.fileWatcher.onDidDelete(() => this.refreshFiles());
+    this.fileWatcher.onDidCreate(this.refreshFiles.bind(this));
+    this.fileWatcher.onDidDelete(this.refreshFiles.bind(this));
 
     // Dispose watcher when extension is deactivated
     this.context.subscriptions.push(this.fileWatcher);

--- a/src/agent/output/OutputHandler.ts
+++ b/src/agent/output/OutputHandler.ts
@@ -114,8 +114,8 @@ export class OutputHandler implements IOutputHandler {
       channel: this.channel,
       logger: this.logger,
       xmlManager: this.xmlManager,
-      setRoundOutputs: (round, outputs) => this.setRoundOutputs(round, outputs),
-      ensureRoundData: (round) => this.ensureRoundData(round),
+      setRoundOutputs: this.setRoundOutputs.bind(this),
+      ensureRoundData: this.ensureRoundData.bind(this),
     });
   }
 

--- a/src/common/webview/BaseWebviewProvider.ts
+++ b/src/common/webview/BaseWebviewProvider.ts
@@ -44,7 +44,7 @@ export abstract class BaseWebviewProvider {
       webviewView.webview.onDidReceiveMessage((message) =>
         this.messageHandler.handleMessage(message, webviewView),
       ),
-      webviewView.onDidDispose(() => this.cleanupView()),
+      webviewView.onDidDispose(this.cleanupView.bind(this)),
     );
   }
 

--- a/src/explorer/WatcherManager.ts
+++ b/src/explorer/WatcherManager.ts
@@ -90,7 +90,7 @@ export class WatcherManager {
             this.validationHandles.push(handle);
           }
         });
-        watcher.onDidDelete(() => this.triggerRefresh());
+        watcher.onDidDelete(this.triggerRefresh);
 
         if (path.resolve(watchPath) === path.resolve(customAgentsPath ?? '')) {
           watcher.onDidChange(async (uri) => {
@@ -100,7 +100,7 @@ export class WatcherManager {
             }
           });
         } else {
-          watcher.onDidChange(() => this.triggerRefresh());
+          watcher.onDidChange(this.triggerRefresh);
         }
       }
 

--- a/src/explorer/WatcherManager.ts
+++ b/src/explorer/WatcherManager.ts
@@ -90,6 +90,8 @@ export class WatcherManager {
             this.validationHandles.push(handle);
           }
         });
+        // triggerRefresh can be passed directly because it's a debounced closure
+        // that already captures `this` in its constructor initialization
         watcher.onDidDelete(this.triggerRefresh);
 
         if (path.resolve(watchPath) === path.resolve(customAgentsPath ?? '')) {

--- a/src/historyView/modules/historyViewState.js
+++ b/src/historyView/modules/historyViewState.js
@@ -7,7 +7,7 @@ export class HistoryViewState {
     this.stateManager = new WebviewStateManager();
     this.searchIndex = 0;
     this.totalMatches = 0;
-    this.toggleStates = new ToggleStateStore(() => this.save());
+    this.toggleStates = new ToggleStateStore(this.save.bind(this));
   }
 
   initialize() {

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -85,14 +85,11 @@ export class ProgressViewProvider
       this.state,
       this.webviewUpdater,
       {
-        showRetryRequest: (payload) => this.showRetryRequest(payload),
-        resolveRetryRequest: (streamId) => this.resolveRetryRequest(streamId),
-        showToolEditApprovalPrompt: (payload) =>
-          this.showToolEditApprovalPrompt(payload),
-        resolveToolEditApprovalPrompt: (requestId) =>
-          this.resolveToolEditApprovalPrompt(requestId),
-        updateToolEditApprovalBypassState: (bypassActive) =>
-          this.updateToolEditApprovalBypassState(bypassActive),
+        showRetryRequest: this.showRetryRequest.bind(this),
+        resolveRetryRequest: this.resolveRetryRequest.bind(this),
+        showToolEditApprovalPrompt: this.showToolEditApprovalPrompt.bind(this),
+        resolveToolEditApprovalPrompt: this.resolveToolEditApprovalPrompt.bind(this),
+        updateToolEditApprovalBypassState: this.updateToolEditApprovalBypassState.bind(this),
       },
     );
 

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -78,12 +78,11 @@ export class ProgressEventHandler {
     this.streamStatusEvents = createStreamStatusEvents({
       withErrorBoundary: createErrorBoundary(this.logger, 'StreamStatusEvents'),
       streamStatus: this._streamStatus,
-      setStreamStatus: (stream, status) => this.setStreamStatus(stream, status),
-      sendInstructionUpdate: (stream) => this.sendInstructionUpdate(stream),
-      refreshStreamSurface: (stream, options) =>
-        this.refreshStreamSurface(stream, options),
-      warnLog: (message) => this.logger.warn(message),
-      debugLog: (message) => this.logger.debug(message),
+      setStreamStatus: this.setStreamStatus.bind(this),
+      sendInstructionUpdate: this.sendInstructionUpdate.bind(this),
+      refreshStreamSurface: this.refreshStreamSurface.bind(this),
+      warnLog: this.logger.warn.bind(this.logger),
+      debugLog: this.logger.debug.bind(this.logger),
     });
     this.outputEvents = createOutputEvents({
       withErrorBoundary: createErrorBoundary(this.logger, 'OutputEvents'),
@@ -96,13 +95,12 @@ export class ProgressEventHandler {
     });
     this.taskGroupEvents = createTaskGroupEvents({
       withErrorBoundary: createErrorBoundary(this.logger, 'TaskGroupEvents'),
-      initializeStreamForTaskGroup: (stream) =>
-        this.initializeStreamForTaskGroup(stream),
-      debugLog: (message) => this.logger.debug(message),
+      initializeStreamForTaskGroup: this.initializeStreamForTaskGroup.bind(this),
+      debugLog: this.logger.debug.bind(this.logger),
     });
     this.todoEvents = createTodoEvents({
       withErrorBoundary: createErrorBoundary(this.logger, 'TodoEvents'),
-      debugLog: (message) => this.logger.debug(message),
+      debugLog: this.logger.debug.bind(this.logger),
     });
     this.retryEvents = createRetryEventsModule({
       withErrorBoundary: createErrorBoundary(this.logger, 'RetryEvents'),

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -183,39 +183,32 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
 
   _createHandlers() {
     return {
-      [COMMANDS.UPDATE_STREAMS]: (m) => this.handleUpdateStreams(m),
-      [COMMANDS.UPDATE_LOGS]: (m) => this.handleUpdateLogs(m),
-      [COMMANDS.APPEND_LOG]: (m) => this.handleAppendLog(m),
-      [COMMANDS.UPDATE_LOG]: (m) => this.handleUpdateLog(m),
-      [COMMANDS.ADD_TASK_GROUP]: (m) => this.handleAddTaskGroup(m),
-      [COMMANDS.UPDATE_TASK_GROUP]: (m) => this.handleUpdateTaskGroup(m),
-      [COMMANDS.UPDATE_STATUS]: (m) => this.handleUpdateStatus(m),
-      [COMMANDS.UPDATE_STREAM_STATUS]: (m) => this.handleUpdateStreamStatus(m),
-      [COMMANDS.UPDATE_USAGE]: (m) => this.handleUpdateUsage(m),
-      [COMMANDS.UPDATE_RUN_USAGE]: (m) => this.handleUpdateRunUsage(m),
-      [COMMANDS.UPDATE_FILES]: (m) => this.handleUpdateFiles(m),
-      [COMMANDS.UPDATE_MISSING_OUTPUTS]: (m) =>
-        this.handleUpdateMissingOutputs(m),
-      [COMMANDS.SHOW_TOOL_EDIT_APPROVAL]: (m) =>
-        this.handleShowToolEditApproval(m),
-      [COMMANDS.RESOLVE_TOOL_EDIT_APPROVAL]: (m) =>
-        this.handleResolveToolEditApproval(m),
-      [COMMANDS.UPDATE_TOOL_EDIT_APPROVAL_STATE]: (m) =>
-        this.handleUpdateToolEditApprovalState(m),
-      [COMMANDS.SHOW_RETRY_REQUEST]: (m) => this.handleShowRetryRequest(m),
-      [COMMANDS.RESOLVE_RETRY_REQUEST]: (m) =>
-        this.handleResolveRetryRequest(m),
-      [COMMANDS.UPDATE_INSTRUCTION]: (m) => this.handleUpdateInstruction(m),
-      [COMMANDS.DELETE_STREAM]: (m) => this.handleDeleteStream(m),
-      [COMMANDS.DELETE_ALL]: () => this.handleDeleteAll(),
-      [COMMANDS.FOLLOW_UP_TEXT_POLISHED]: (m) =>
-        this.handleFollowUpTextPolished(m),
-      [COMMANDS.FOLLOW_UP_TEXT_TRANSCRIBED]: (m) =>
-        this.handleFollowUpTextTranscribed(m),
-      [COMMANDS.RECORDING_STARTED]: () => this.handleRecordingStarted(),
-      [COMMANDS.RECORDING_STOPPED]: () => this.handleRecordingStopped(),
-      [COMMANDS.RECORDING_ERROR]: () => this.handleRecordingError(),
-      [COMMANDS.UPDATE_TODOS]: (m) => this.handleUpdateTodos(m),
+      [COMMANDS.UPDATE_STREAMS]: this.handleUpdateStreams.bind(this),
+      [COMMANDS.UPDATE_LOGS]: this.handleUpdateLogs.bind(this),
+      [COMMANDS.APPEND_LOG]: this.handleAppendLog.bind(this),
+      [COMMANDS.UPDATE_LOG]: this.handleUpdateLog.bind(this),
+      [COMMANDS.ADD_TASK_GROUP]: this.handleAddTaskGroup.bind(this),
+      [COMMANDS.UPDATE_TASK_GROUP]: this.handleUpdateTaskGroup.bind(this),
+      [COMMANDS.UPDATE_STATUS]: this.handleUpdateStatus.bind(this),
+      [COMMANDS.UPDATE_STREAM_STATUS]: this.handleUpdateStreamStatus.bind(this),
+      [COMMANDS.UPDATE_USAGE]: this.handleUpdateUsage.bind(this),
+      [COMMANDS.UPDATE_RUN_USAGE]: this.handleUpdateRunUsage.bind(this),
+      [COMMANDS.UPDATE_FILES]: this.handleUpdateFiles.bind(this),
+      [COMMANDS.UPDATE_MISSING_OUTPUTS]: this.handleUpdateMissingOutputs.bind(this),
+      [COMMANDS.SHOW_TOOL_EDIT_APPROVAL]: this.handleShowToolEditApproval.bind(this),
+      [COMMANDS.RESOLVE_TOOL_EDIT_APPROVAL]: this.handleResolveToolEditApproval.bind(this),
+      [COMMANDS.UPDATE_TOOL_EDIT_APPROVAL_STATE]: this.handleUpdateToolEditApprovalState.bind(this),
+      [COMMANDS.SHOW_RETRY_REQUEST]: this.handleShowRetryRequest.bind(this),
+      [COMMANDS.RESOLVE_RETRY_REQUEST]: this.handleResolveRetryRequest.bind(this),
+      [COMMANDS.UPDATE_INSTRUCTION]: this.handleUpdateInstruction.bind(this),
+      [COMMANDS.DELETE_STREAM]: this.handleDeleteStream.bind(this),
+      [COMMANDS.DELETE_ALL]: this.handleDeleteAll.bind(this),
+      [COMMANDS.FOLLOW_UP_TEXT_POLISHED]: this.handleFollowUpTextPolished.bind(this),
+      [COMMANDS.FOLLOW_UP_TEXT_TRANSCRIBED]: this.handleFollowUpTextTranscribed.bind(this),
+      [COMMANDS.RECORDING_STARTED]: this.handleRecordingStarted.bind(this),
+      [COMMANDS.RECORDING_STOPPED]: this.handleRecordingStopped.bind(this),
+      [COMMANDS.RECORDING_ERROR]: this.handleRecordingError.bind(this),
+      [COMMANDS.UPDATE_TODOS]: this.handleUpdateTodos.bind(this),
     };
   }
 

--- a/src/progressView/modules/progressViewState.js
+++ b/src/progressView/modules/progressViewState.js
@@ -287,7 +287,7 @@ export class ProgressViewState {
 
     // Initialize managers
     this.taskGroups = new TaskGroups();
-    this.toggleStates = new ToggleStateStore(() => this.saveToggleStates());
+    this.toggleStates = new ToggleStateStore(this.saveToggleStates.bind(this));
     this.streamStatuses = new StreamStatuses();
     this.executionIdAvailability = new ExecutionIdAvailability();
   }

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -367,20 +367,16 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
 
   _createStateHandlers() {
     return {
-      [MAIN_VIEW_COMMANDS.STATE_RESTORE]: (m) => this.handleRestoreState(m),
-      [MAIN_VIEW_COMMANDS.CHECK_RESTORED_BASE_FILE]: () =>
-        this.handleCheckRestoredBaseFile(),
+      [MAIN_VIEW_COMMANDS.STATE_RESTORE]: this.handleRestoreState.bind(this),
+      [MAIN_VIEW_COMMANDS.CHECK_RESTORED_BASE_FILE]: this.handleCheckRestoredBaseFile.bind(this),
     };
   }
 
   _createInstructionHandlers() {
     return {
-      [MAIN_VIEW_COMMANDS.INSTRUCTION_TEXT_POLISHED]: (m) =>
-        this.handleInstructionTextPolished(m),
-      [MAIN_VIEW_COMMANDS.INSTRUCTION_TEXT_POLISH_ERROR]: (m) =>
-        this.handleInstructionTextPolishError(m),
-      [MAIN_VIEW_COMMANDS.INSTRUCTION_TEXT_TRANSCRIBED]: (m) =>
-        this.handleInstructionTextTranscribed(m),
+      [MAIN_VIEW_COMMANDS.INSTRUCTION_TEXT_POLISHED]: this.handleInstructionTextPolished.bind(this),
+      [MAIN_VIEW_COMMANDS.INSTRUCTION_TEXT_POLISH_ERROR]: this.handleInstructionTextPolishError.bind(this),
+      [MAIN_VIEW_COMMANDS.INSTRUCTION_TEXT_TRANSCRIBED]: this.handleInstructionTextTranscribed.bind(this),
     };
   }
 

--- a/src/webview/modules/uiManagers/FileInputManager.js
+++ b/src/webview/modules/uiManagers/FileInputManager.js
@@ -71,7 +71,7 @@ export class FileInputManager extends BaseUIManager {
       if (element) {
         const sortable = new Sortable(element, {
           animation: 150,
-          onEnd: () => this.state.save(),
+          onEnd: this.state.save.bind(this.state),
         });
         this._sortables.push(sortable);
       }
@@ -343,11 +343,11 @@ export class FileInputManager extends BaseUIManager {
         return; // handled by SettingsButtonManager
       }
       if (id !== 'instruction') {
-        this.addListener(id, 'change', () => this.state.save());
+        this.addListener(id, 'change', this.state.save.bind(this.state));
       }
     });
     // Debounce instruction input to avoid saving on every keystroke
-    const debouncedSave = debounce(() => this.state.save(), 500);
+    const debouncedSave = debounce(this.state.save.bind(this.state), 500);
     this.addListener('instruction', 'input', debouncedSave);
   }
 


### PR DESCRIPTION
Replace ~50 arrow function callbacks that simply delegate to methods with Function.prototype.bind() calls. This reduces visual noise and makes handler registrations more direct.

Key changes:
- progressView/modules/messageHandlers.js: 21 handlers
- webview/modules/messageHandlers.js: 5 handlers
- progressView/ProgressViewProvider.ts: 5 callbacks
- progressView/events/ProgressEventHandler.ts: 6 callbacks
- MainViewProvider.ts: 7 callbacks (debounce + watchers)
- agent/output/OutputHandler.ts: 2 callbacks
- explorer/WatcherManager.ts: 2 callbacks
- common/webview/BaseWebviewProvider.ts: 1 callback
- historyView/modules/historyViewState.js: 1 callback
- progressView/modules/progressViewState.js: 1 callback
- webview/modules/uiManagers/FileInputManager.js: 3 callbacks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reduces callback boilerplate by binding instance methods directly and passing safe debounced closures, improving readability and consistency of handler registration.
> 
> - Bind debounced refreshers and config/file watchers in `MainViewProvider` and use `bind(this)` for `refreshFiles`
> - Pass bound methods to `OutputFileProcessor` in `agent/output/OutputHandler`
> - Use bound cleanup in `common/webview/BaseWebviewProvider`
> - Pass debounced `triggerRefresh` directly and bind-less change/delete handlers in `explorer/WatcherManager`
> - Bind `save` callback in `historyView/modules/historyViewState.js`
> - In `progressView`: bind callbacks in `ProgressViewProvider`, replace inline lambdas with bound methods/loggers in `events/ProgressEventHandler`, and bind all command handlers in `modules/messageHandlers.js`; bind `saveToggleStates` in `modules/progressViewState.js`
> - In main webview `modules/messageHandlers.js`, bind state/instruction handler maps
> - In `webview/modules/uiManagers/FileInputManager.js`, bind `state.save` for Sortable and change/input listeners and use a debounced bound save
> 
> No functional logic changed; only callback wiring/registrations were simplified.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a994bcaab48048493601c485f622c295e7458563. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->