### PR TITLE
Fix collapsed todo lists and missing usage panel

### DIFF
--- a/src/progressView/styles/file-list.css
+++ b/src/progressView/styles/file-list.css
@@ -11,6 +11,11 @@
   border-bottom: 1px solid var(--color-border);
 }
 
+.files-collapsible[hidden] {
+  display: none;
+}
+
+/* Override vscode-collapsible header padding */
 .files-collapsible::part(header) {
   padding: var(--spacing-small) var(--spacing-medium);
 }

--- a/src/progressView/styles/logs.css
+++ b/src/progressView/styles/logs.css
@@ -279,6 +279,10 @@
   color: var(--color-text-secondary);
 }
 
+.usage-summary-footer[hidden] {
+  display: none;
+}
+
 .usage-summary-footer .run-summary {
   margin-left: auto;
 }

--- a/src/progressView/styles/logs.css
+++ b/src/progressView/styles/logs.css
@@ -259,10 +259,9 @@
   animation: pulse-scale 1.5s infinite;
 }
 
-/* Generated files list */
+/* Generated files list - inside vscode-collapsible body */
 .files-container {
   padding: var(--spacing-small);
-  border-top: 1px solid var(--color-border);
   font-size: var(--vscode-editor-font-size);
   overflow-y: auto;
   max-height: var(--height-large);


### PR DESCRIPTION
The .usage-summary-footer had display: flex set, which could override the HTML hidden attribute's default display: none behavior. This caused inconsistent visibility behavior depending on browser implementation.

Adding an explicit [hidden] selector ensures the element is properly hidden when the hidden attribute is present, fixing the disappeared usage panel issue after the todo list collapsible refactoring.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures correct visibility handling after collapsible refactor and tidies files list styling.
> 
> - Add `[hidden]` rules for `files-collapsible` and `usage-summary-footer` so elements are truly hidden when the `hidden` attribute is present
> - Refine generated files list styling: clarify it’s inside the `vscode-collapsible` body and remove the `.files-container` top border
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2923091038c1c3a4ecf4200c39f6c0c8ff4d3d96. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->