### PR TITLE
Continue work from previous pull request

### DIFF
--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -150,7 +150,10 @@ async function prepareFlowExecution(
   executionId?: ExecutionId,
 ): Promise<FlowExecutionContext> {
   // 1. Resolve agent definition
-  const fullConfig = AgentConfigSchema.parse({ agent: agentName, ...configPayload });
+  const fullConfig = AgentConfigSchema.parse({
+    agent: agentName,
+    ...configPayload,
+  });
   const resolution = await getAgentPath(fullConfig.agent, {
     preferMultiple: fullConfig.useMultipleOutputs,
   });

--- a/src/logger/TaskState.ts
+++ b/src/logger/TaskState.ts
@@ -59,29 +59,42 @@ export const TaskStateSchema = z.union([
 ]);
 
 // -----------------------------------------------------------------------------
-// Types - Derived from Schemas
+// Types - Derived from Schemas (Single Source of Truth)
 // -----------------------------------------------------------------------------
 
-export interface ToolSessionState {
-  lastFollowUpAt?: number;
-}
-
+export type ToolSessionState = z.infer<typeof ToolSessionStateSchema>;
 export type WorkflowTaskState = z.infer<typeof WorkflowTaskStateSchema>;
 export type ToolUseTaskState = z.infer<typeof ToolUseTaskStateSchema>;
 export type TaskState = z.infer<typeof TaskStateSchema>;
 
 // -----------------------------------------------------------------------------
-// Type Guards
+// Type Guards - Shared predicates for category narrowing
 // -----------------------------------------------------------------------------
 
+/** Check if agentCategory is ToolUse (works on any object with session) */
+export function isToolUseCategory(obj: {
+  session?: { agentCategory?: AgentCategory };
+}): boolean {
+  return obj.session?.agentCategory === AgentCategory.ToolUse;
+}
+
+/** Check if agentCategory is Workflow (works on any object with session) */
+export function isWorkflowCategory(obj: {
+  session?: { agentCategory?: AgentCategory };
+}): boolean {
+  return obj.session?.agentCategory === AgentCategory.Workflow;
+}
+
+/** Type guard for TaskState narrowing to WorkflowTaskState */
 export function isWorkflowTaskState(
   taskState: TaskState,
 ): taskState is WorkflowTaskState {
-  return taskState.agentConfig.session.agentCategory === AgentCategory.Workflow;
+  return isWorkflowCategory(taskState.agentConfig);
 }
 
+/** Type guard for TaskState narrowing to ToolUseTaskState */
 export function isToolUseTaskState(
   taskState: TaskState,
 ): taskState is ToolUseTaskState {
-  return taskState.agentConfig.session.agentCategory === AgentCategory.ToolUse;
+  return isToolUseCategory(taskState.agentConfig);
 }

--- a/src/logger/TaskState.ts
+++ b/src/logger/TaskState.ts
@@ -1,44 +1,78 @@
+// Third-party imports
+import { z } from 'zod';
+
 // Local imports
-import type { AgentConfig } from '@agent/core/AgentConfig';
+import { AgentConfigSchema } from '@agent/core/AgentConfig';
 // Internal imports
-import {
-  AgentCategory,
-  type AgentSessionDescriptor,
-} from '@agent/core/AgentDataclass';
+import { AgentCategory } from '@agent/core/AgentDataclass';
+import { AgentSessionDescriptorSchema } from '@agent/core/AgentSessionSchema';
 
 // Type imports
-import type { FileType } from '@utils/config';
+import { FILE_TYPES, type FileType } from '@utils/config';
 
-/** Shared properties for all task state variants. */
-interface BaseTaskState {
-  agentConfig: AgentConfig;
-}
+// -----------------------------------------------------------------------------
+// Zod Schemas - Single Source of Truth
+// -----------------------------------------------------------------------------
+
+/** Schema for tool session state */
+const ToolSessionStateSchema = z.object({
+  lastFollowUpAt: z.number().optional(),
+});
+
+/** Active files record schema */
+const ActiveFilesSchema = z.record(
+  z.enum(FILE_TYPES),
+  z.boolean(),
+) as z.ZodType<Record<FileType, boolean>>;
+
+/** Schema for workflow task state with category discriminator */
+const WorkflowTaskStateSchema = z.object({
+  agentConfig: AgentConfigSchema.and(
+    z.object({
+      session: AgentSessionDescriptorSchema.and(
+        z.object({ agentCategory: z.literal(AgentCategory.Workflow) }),
+      ),
+    }),
+  ),
+  activeFiles: ActiveFilesSchema,
+});
+
+/** Schema for tool-use task state with category discriminator */
+const ToolUseTaskStateSchema = z.object({
+  agentConfig: AgentConfigSchema.and(
+    z.object({
+      session: AgentSessionDescriptorSchema.and(
+        z.object({ agentCategory: z.literal(AgentCategory.ToolUse) }),
+      ),
+    }),
+  ),
+  toolSessionState: ToolSessionStateSchema.optional(),
+});
 
 /**
- * Workflow task state stores file visibility information for toolbar actions.
+ * TaskState schema using discriminated union on agentConfig.session.agentCategory.
+ * Use safeParse for validation when loading persisted state.
  */
-export interface WorkflowTaskState extends BaseTaskState {
-  agentConfig: AgentConfig & {
-    session: AgentSessionDescriptor & { agentCategory: AgentCategory.Workflow };
-  };
-  activeFiles: Record<FileType, boolean>;
-}
+export const TaskStateSchema = z.union([
+  WorkflowTaskStateSchema,
+  ToolUseTaskStateSchema,
+]);
 
-/**
- * Tool-use task state reserves space for persisting interactive session data.
- */
+// -----------------------------------------------------------------------------
+// Types - Derived from Schemas
+// -----------------------------------------------------------------------------
+
 export interface ToolSessionState {
   lastFollowUpAt?: number;
 }
 
-export interface ToolUseTaskState extends BaseTaskState {
-  agentConfig: AgentConfig & {
-    session: AgentSessionDescriptor & { agentCategory: AgentCategory.ToolUse };
-  };
-  toolSessionState?: ToolSessionState;
-}
+export type WorkflowTaskState = z.infer<typeof WorkflowTaskStateSchema>;
+export type ToolUseTaskState = z.infer<typeof ToolUseTaskStateSchema>;
+export type TaskState = z.infer<typeof TaskStateSchema>;
 
-export type TaskState = WorkflowTaskState | ToolUseTaskState;
+// -----------------------------------------------------------------------------
+// Type Guards
+// -----------------------------------------------------------------------------
 
 export function isWorkflowTaskState(
   taskState: TaskState,

--- a/src/logger/TaskState.ts
+++ b/src/logger/TaskState.ts
@@ -2,17 +2,20 @@
 import { z } from 'zod';
 
 // Local imports
-import { AgentConfigSchema } from '@agent/core/AgentConfig';
+import type { AgentConfig } from '@agent/core/AgentConfig';
 // Internal imports
 import { AgentCategory } from '@agent/core/AgentDataclass';
-import { AgentSessionDescriptorSchema } from '@agent/core/AgentSessionSchema';
+import type { AgentSessionDescriptor } from '@agent/core/AgentSessionSchema';
 
 // Type imports
 import { FILE_TYPES, type FileType } from '@utils/config';
 
 // -----------------------------------------------------------------------------
-// Zod Schemas - Single Source of Truth
+// Zod Schemas for Persisted State Validation
 // -----------------------------------------------------------------------------
+// These schemas validate persisted TaskState data. The agentConfig was already
+// validated when created, so we use passthrough() to avoid re-validation and
+// only check the discriminator and variant-specific fields.
 
 /** Schema for tool session state */
 const ToolSessionStateSchema = z.object({
@@ -25,33 +28,36 @@ const ActiveFilesSchema = z.record(
   z.boolean(),
 ) as z.ZodType<Record<FileType, boolean>>;
 
-/** Schema for workflow task state with category discriminator */
-const WorkflowTaskStateSchema = z.object({
-  agentConfig: AgentConfigSchema.and(
-    z.object({
-      session: AgentSessionDescriptorSchema.and(
-        z.object({ agentCategory: z.literal(AgentCategory.Workflow) }),
-      ),
+/** Minimal agentConfig schema - just validates the discriminator exists */
+const AgentConfigWithSessionSchema = z
+  .object({
+    session: z.object({
+      agentCategory: z.enum(AgentCategory),
     }),
+  })
+  .passthrough();
+
+/** Schema for workflow task state */
+const WorkflowTaskStateSchema = z.object({
+  agentConfig: AgentConfigWithSessionSchema.refine(
+    (c) => c.session.agentCategory === AgentCategory.Workflow,
+    { message: 'Expected Workflow category' },
   ),
   activeFiles: ActiveFilesSchema,
 });
 
-/** Schema for tool-use task state with category discriminator */
+/** Schema for tool-use task state */
 const ToolUseTaskStateSchema = z.object({
-  agentConfig: AgentConfigSchema.and(
-    z.object({
-      session: AgentSessionDescriptorSchema.and(
-        z.object({ agentCategory: z.literal(AgentCategory.ToolUse) }),
-      ),
-    }),
+  agentConfig: AgentConfigWithSessionSchema.refine(
+    (c) => c.session.agentCategory === AgentCategory.ToolUse,
+    { message: 'Expected ToolUse category' },
   ),
   toolSessionState: ToolSessionStateSchema.optional(),
 });
 
 /**
- * TaskState schema using discriminated union on agentConfig.session.agentCategory.
- * Use safeParse for validation when loading persisted state.
+ * TaskState schema for validating persisted state.
+ * Uses passthrough on agentConfig since it was validated when created.
  */
 export const TaskStateSchema = z.union([
   WorkflowTaskStateSchema,
@@ -59,42 +65,43 @@ export const TaskStateSchema = z.union([
 ]);
 
 // -----------------------------------------------------------------------------
-// Types - Derived from Schemas (Single Source of Truth)
+// Types - Explicitly defined with proper AgentConfig structure
 // -----------------------------------------------------------------------------
+// Types are defined explicitly (not inferred from validation schemas) because
+// the validation schemas use passthrough() for efficiency.
 
 export type ToolSessionState = z.infer<typeof ToolSessionStateSchema>;
-export type WorkflowTaskState = z.infer<typeof WorkflowTaskStateSchema>;
-export type ToolUseTaskState = z.infer<typeof ToolUseTaskStateSchema>;
-export type TaskState = z.infer<typeof TaskStateSchema>;
 
-// -----------------------------------------------------------------------------
-// Type Guards - Shared predicates for category narrowing
-// -----------------------------------------------------------------------------
-
-/** Check if agentCategory is ToolUse (works on any object with session) */
-export function isToolUseCategory(obj: {
-  session?: { agentCategory?: AgentCategory };
-}): boolean {
-  return obj.session?.agentCategory === AgentCategory.ToolUse;
+export interface WorkflowTaskState {
+  agentConfig: AgentConfig & {
+    session: AgentSessionDescriptor & { agentCategory: AgentCategory.Workflow };
+  };
+  activeFiles: Record<FileType, boolean>;
 }
 
-/** Check if agentCategory is Workflow (works on any object with session) */
-export function isWorkflowCategory(obj: {
-  session?: { agentCategory?: AgentCategory };
-}): boolean {
-  return obj.session?.agentCategory === AgentCategory.Workflow;
+export interface ToolUseTaskState {
+  agentConfig: AgentConfig & {
+    session: AgentSessionDescriptor & { agentCategory: AgentCategory.ToolUse };
+  };
+  toolSessionState?: ToolSessionState;
 }
+
+export type TaskState = WorkflowTaskState | ToolUseTaskState;
+
+// -----------------------------------------------------------------------------
+// Type Guards
+// -----------------------------------------------------------------------------
 
 /** Type guard for TaskState narrowing to WorkflowTaskState */
 export function isWorkflowTaskState(
   taskState: TaskState,
 ): taskState is WorkflowTaskState {
-  return isWorkflowCategory(taskState.agentConfig);
+  return taskState.agentConfig.session.agentCategory === AgentCategory.Workflow;
 }
 
 /** Type guard for TaskState narrowing to ToolUseTaskState */
 export function isToolUseTaskState(
   taskState: TaskState,
 ): taskState is ToolUseTaskState {
-  return isToolUseCategory(taskState.agentConfig);
+  return taskState.agentConfig.session.agentCategory === AgentCategory.ToolUse;
 }

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -176,7 +176,8 @@ export class ProgressEventHandler {
     const instructionUpdate = WebviewUpdater.createInstructionUpdate(taskState);
     const { sessionCategory: sessionKindHint } =
       this.state.getStreamHints(stream);
-    const sessionKind = taskState?.session?.agentCategory ?? sessionKindHint;
+    const sessionKind =
+      taskState?.agentConfig?.session?.agentCategory ?? sessionKindHint;
     const runId =
       runIdHint === undefined
         ? this.state.resolveRunId(stream, undefined, {

--- a/src/progressView/state/ProgressViewState.ts
+++ b/src/progressView/state/ProgressViewState.ts
@@ -21,6 +21,7 @@ import { AgentLogger } from '@logger/AgentLogger';
 import type { TaskGroup } from '@logger/LogTypes';
 import {
   TaskState,
+  TaskStateSchema,
   isToolUseTaskState,
   isWorkflowTaskState,
 } from '@logger/TaskState';
@@ -53,22 +54,37 @@ export type StreamHints = z.infer<typeof StreamHintsSchema>;
  * Composes focused manager classes and provides a clean interface
  * for state operations while hiding implementation details.
  */
+/**
+ * Deep clones a TaskState to prevent shared-state mutations.
+ * Clones nested objects (session, toolConfig) that could cause bugs if mutated.
+ */
 const cloneTaskState = (state: TaskState): TaskState => {
+  // Deep clone agentConfig including nested objects
+  const clonedAgentConfig = {
+    ...state.agentConfig,
+    session: { ...state.agentConfig.session },
+    toolConfig: { ...state.agentConfig.toolConfig },
+    // Clone arrays to prevent mutation
+    inputFiles: [...state.agentConfig.inputFiles],
+    referenceFiles: [...state.agentConfig.referenceFiles],
+    auxiliaryFiles: [...state.agentConfig.auxiliaryFiles],
+    mediaFiles: [...state.agentConfig.mediaFiles],
+    outputFiles: [...state.agentConfig.outputFiles],
+  };
+
   if (isWorkflowTaskState(state)) {
     return {
-      ...state,
-      agentConfig: { ...state.agentConfig },
+      agentConfig: clonedAgentConfig,
       activeFiles: { ...state.activeFiles },
-    };
+    } as TaskState;
   }
 
   return {
-    ...state,
-    agentConfig: { ...state.agentConfig },
+    agentConfig: clonedAgentConfig,
     toolSessionState: state.toolSessionState
       ? { ...state.toolSessionState }
       : undefined,
-  };
+  } as TaskState;
 };
 
 export class ProgressViewState {
@@ -658,20 +674,18 @@ export class ProgressViewState {
           continue;
         }
 
-        const raw = rawState as Record<string, unknown>;
-        const agentConfig = raw.agentConfig as Record<string, unknown>;
-        if (!agentConfig || typeof agentConfig !== 'object') {
-          continue;
-        }
-
-        // Skip entries without session metadata
-        if (!agentConfig.session) {
+        // Validate against TaskState schema to catch corrupted/malformed state
+        const parseResult = TaskStateSchema.safeParse(rawState);
+        if (!parseResult.success) {
+          this.logger.debug(
+            `Skipping invalid task state for stream ${stream}: ${parseResult.error.message}`,
+          );
           continue;
         }
 
         this.taskStates.set(
           stream as StreamTabId,
-          cloneTaskState(raw as unknown as TaskState),
+          cloneTaskState(parseResult.data),
         );
         loaded += 1;
       }

--- a/src/progressView/state/ProgressViewState.ts
+++ b/src/progressView/state/ProgressViewState.ts
@@ -669,7 +669,10 @@ export class ProgressViewState {
           continue;
         }
 
-        this.taskStates.set(stream as StreamTabId, cloneTaskState(raw as TaskState));
+        this.taskStates.set(
+          stream as StreamTabId,
+          cloneTaskState(raw as unknown as TaskState),
+        );
         loaded += 1;
       }
     }

--- a/src/progressView/state/ProgressViewState.ts
+++ b/src/progressView/state/ProgressViewState.ts
@@ -54,39 +54,6 @@ export type StreamHints = z.infer<typeof StreamHintsSchema>;
  * Composes focused manager classes and provides a clean interface
  * for state operations while hiding implementation details.
  */
-/**
- * Deep clones a TaskState to prevent shared-state mutations.
- * Clones nested objects (session, toolConfig) that could cause bugs if mutated.
- */
-const cloneTaskState = (state: TaskState): TaskState => {
-  // Deep clone agentConfig including nested objects
-  const clonedAgentConfig = {
-    ...state.agentConfig,
-    session: { ...state.agentConfig.session },
-    toolConfig: { ...state.agentConfig.toolConfig },
-    // Clone arrays to prevent mutation
-    inputFiles: [...state.agentConfig.inputFiles],
-    referenceFiles: [...state.agentConfig.referenceFiles],
-    auxiliaryFiles: [...state.agentConfig.auxiliaryFiles],
-    mediaFiles: [...state.agentConfig.mediaFiles],
-    outputFiles: [...state.agentConfig.outputFiles],
-  };
-
-  if (isWorkflowTaskState(state)) {
-    return {
-      agentConfig: clonedAgentConfig,
-      activeFiles: { ...state.activeFiles },
-    } as TaskState;
-  }
-
-  return {
-    agentConfig: clonedAgentConfig,
-    toolSessionState: state.toolSessionState
-      ? { ...state.toolSessionState }
-      : undefined,
-  } as TaskState;
-};
-
 export class ProgressViewState {
   private _streamTabs: StreamTabsManager;
   private _taskGroups: TaskGroupManager;
@@ -482,15 +449,14 @@ export class ProgressViewState {
 
   // Task state management
   setTaskState(streamTabId: StreamTabId, taskState: TaskState): void {
-    this.taskStates.set(streamTabId, cloneTaskState(taskState));
+    this.taskStates.set(streamTabId, taskState);
     this.clearStreamHints(streamTabId);
     this.saveTaskStates();
     this.cleanupToolUseAgentRegistry();
   }
 
   getTaskState(streamTabId: StreamTabId): TaskState | undefined {
-    const stored = this.taskStates.get(streamTabId);
-    return stored ? cloneTaskState(stored) : undefined;
+    return this.taskStates.get(streamTabId);
   }
 
   clearTaskState(streamTabId: StreamTabId): void {
@@ -503,12 +469,7 @@ export class ProgressViewState {
   }
 
   getAllTaskStates(): Map<StreamTabId, TaskState> {
-    return new Map(
-      Array.from(this.taskStates.entries(), ([stream, state]) => [
-        stream,
-        cloneTaskState(state),
-      ]),
-    );
+    return new Map(this.taskStates);
   }
 
   /**
@@ -683,10 +644,7 @@ export class ProgressViewState {
           continue;
         }
 
-        this.taskStates.set(
-          stream as StreamTabId,
-          cloneTaskState(parseResult.data),
-        );
+        this.taskStates.set(stream as StreamTabId, parseResult.data);
         loaded += 1;
       }
     }
@@ -772,13 +730,7 @@ export class ProgressViewState {
    * Save task states to persistence
    */
   private saveTaskStates(): void {
-    const serialized = Object.fromEntries(
-      Array.from(this.taskStates.entries(), ([stream, state]) => [
-        stream,
-        cloneTaskState(state),
-      ]),
-    );
-
+    const serialized = Object.fromEntries(this.taskStates);
     void this.storage.update(WorkspaceStateKey.TASK_STATES, serialized);
   }
 

--- a/src/progressView/streamInfoUtils.ts
+++ b/src/progressView/streamInfoUtils.ts
@@ -82,7 +82,8 @@ export function buildStreamInfos(
     }
 
     const agentType =
-      taskState?.agentConfig.session?.agentType ?? taskState?.agentConfig.agentType;
+      taskState?.agentConfig.session?.agentType ??
+      taskState?.agentConfig.agentType;
     const isToolAgent = sessionCategory === AgentCategory.ToolUse;
     // When taskState is available, rawAgentName has the full key (e.g., "remote:generic")
     // and isRemoteAgent can reliably determine the source. When taskState is null,

--- a/src/utils/config/configConversion.ts
+++ b/src/utils/config/configConversion.ts
@@ -33,6 +33,23 @@ function createActiveFilesFromArrays(
 }
 
 /**
+ * Type predicates for AgentConfig category narrowing.
+ * TypeScript's control flow analysis doesn't narrow nested properties,
+ * so we use these predicates to enable proper type narrowing without casts.
+ */
+function isToolUseAgentConfig(
+  config: AgentConfig,
+): config is ToolUseTaskState['agentConfig'] {
+  return config.session?.agentCategory === AgentCategory.ToolUse;
+}
+
+function isWorkflowAgentConfig(
+  config: AgentConfig,
+): config is WorkflowTaskState['agentConfig'] {
+  return config.session?.agentCategory === AgentCategory.Workflow;
+}
+
+/**
  * Converts an AgentConfig object to a TaskState object.
  * Session metadata comes from config.session (single source of truth).
  *
@@ -40,20 +57,26 @@ function createActiveFilesFromArrays(
  * @returns A TaskState representing the same configuration
  */
 export function agentConfigToTaskState(config: AgentConfig): TaskState {
-  const session = config.session;
-  if (!session) {
+  if (!config.session) {
     throw new Error('AgentConfig is missing canonical session metadata.');
   }
 
-  if (session.agentCategory === AgentCategory.ToolUse) {
+  if (isToolUseAgentConfig(config)) {
     return {
-      agentConfig: config as ToolUseTaskState['agentConfig'],
+      agentConfig: config,
       toolSessionState: {},
     };
   }
 
-  return {
-    agentConfig: config as WorkflowTaskState['agentConfig'],
-    activeFiles: createActiveFilesFromArrays(config),
-  };
+  if (isWorkflowAgentConfig(config)) {
+    return {
+      agentConfig: config,
+      activeFiles: createActiveFilesFromArrays(config),
+    };
+  }
+
+  // Should be unreachable - all AgentCategory values are handled
+  throw new Error(
+    `Unknown agent category: ${(config.session as { agentCategory: string }).agentCategory}`,
+  );
 }

--- a/src/utils/config/configConversion.ts
+++ b/src/utils/config/configConversion.ts
@@ -4,7 +4,11 @@ import { type AgentConfig } from '@agent/core/AgentConfig';
 import { AgentCategory } from '@agent/core/AgentDataclass';
 
 // Type imports
-import { type TaskState } from '@logger/TaskState';
+import {
+  type TaskState,
+  type ToolUseTaskState,
+  type WorkflowTaskState,
+} from '@logger/TaskState';
 
 // Local file imports
 import { FILE_TYPES, type FileType } from './constants';
@@ -43,13 +47,13 @@ export function agentConfigToTaskState(config: AgentConfig): TaskState {
 
   if (session.agentCategory === AgentCategory.ToolUse) {
     return {
-      agentConfig: config as TaskState['agentConfig'],
+      agentConfig: config as ToolUseTaskState['agentConfig'],
       toolSessionState: {},
     };
   }
 
   return {
-    agentConfig: config as TaskState['agentConfig'],
+    agentConfig: config as WorkflowTaskState['agentConfig'],
     activeFiles: createActiveFilesFromArrays(config),
   };
 }

--- a/src/utils/config/configConversion.ts
+++ b/src/utils/config/configConversion.ts
@@ -1,13 +1,13 @@
 // Local imports - models
 import { type AgentConfig } from '@agent/core/AgentConfig';
-// Internal imports
-import { AgentCategory } from '@agent/core/AgentDataclass';
 
 // Type imports
 import {
   type TaskState,
   type ToolUseTaskState,
   type WorkflowTaskState,
+  isToolUseCategory,
+  isWorkflowCategory,
 } from '@logger/TaskState';
 
 // Local file imports
@@ -33,25 +33,10 @@ function createActiveFilesFromArrays(
 }
 
 /**
- * Type predicates for AgentConfig category narrowing.
- * TypeScript's control flow analysis doesn't narrow nested properties,
- * so we use these predicates to enable proper type narrowing without casts.
- */
-function isToolUseAgentConfig(
-  config: AgentConfig,
-): config is ToolUseTaskState['agentConfig'] {
-  return config.session?.agentCategory === AgentCategory.ToolUse;
-}
-
-function isWorkflowAgentConfig(
-  config: AgentConfig,
-): config is WorkflowTaskState['agentConfig'] {
-  return config.session?.agentCategory === AgentCategory.Workflow;
-}
-
-/**
  * Converts an AgentConfig object to a TaskState object.
  * Session metadata comes from config.session (single source of truth).
+ *
+ * Uses shared category predicates from TaskState for DRY code.
  *
  * @param config The AgentConfig to convert
  * @returns A TaskState representing the same configuration
@@ -61,22 +46,20 @@ export function agentConfigToTaskState(config: AgentConfig): TaskState {
     throw new Error('AgentConfig is missing canonical session metadata.');
   }
 
-  if (isToolUseAgentConfig(config)) {
+  if (isToolUseCategory(config)) {
     return {
-      agentConfig: config,
+      agentConfig: config as ToolUseTaskState['agentConfig'],
       toolSessionState: {},
     };
   }
 
-  if (isWorkflowAgentConfig(config)) {
+  if (isWorkflowCategory(config)) {
     return {
-      agentConfig: config,
+      agentConfig: config as WorkflowTaskState['agentConfig'],
       activeFiles: createActiveFilesFromArrays(config),
     };
   }
 
   // Should be unreachable - all AgentCategory values are handled
-  throw new Error(
-    `Unknown agent category: ${(config.session as { agentCategory: string }).agentCategory}`,
-  );
+  throw new Error(`Unknown agent category: ${config.session.agentCategory}`);
 }

--- a/src/utils/config/configConversion.ts
+++ b/src/utils/config/configConversion.ts
@@ -1,13 +1,12 @@
 // Local imports - models
 import { type AgentConfig } from '@agent/core/AgentConfig';
+import { AgentCategory } from '@agent/core/AgentDataclass';
 
 // Type imports
 import {
   type TaskState,
   type ToolUseTaskState,
   type WorkflowTaskState,
-  isToolUseCategory,
-  isWorkflowCategory,
 } from '@logger/TaskState';
 
 // Local file imports
@@ -36,30 +35,29 @@ function createActiveFilesFromArrays(
  * Converts an AgentConfig object to a TaskState object.
  * Session metadata comes from config.session (single source of truth).
  *
- * Uses shared category predicates from TaskState for DRY code.
- *
  * @param config The AgentConfig to convert
  * @returns A TaskState representing the same configuration
  */
 export function agentConfigToTaskState(config: AgentConfig): TaskState {
-  if (!config.session) {
+  const { session } = config;
+  if (!session) {
     throw new Error('AgentConfig is missing canonical session metadata.');
   }
 
-  if (isToolUseCategory(config)) {
-    return {
-      agentConfig: config as ToolUseTaskState['agentConfig'],
-      toolSessionState: {},
-    };
+  switch (session.agentCategory) {
+    case AgentCategory.ToolUse:
+      return {
+        agentConfig: config as ToolUseTaskState['agentConfig'],
+        toolSessionState: {},
+      };
+    case AgentCategory.Workflow:
+      return {
+        agentConfig: config as WorkflowTaskState['agentConfig'],
+        activeFiles: createActiveFilesFromArrays(config),
+      };
+    default: {
+      const _exhaustive: never = session.agentCategory;
+      throw new Error(`Unknown agent category: ${_exhaustive}`);
+    }
   }
-
-  if (isWorkflowCategory(config)) {
-    return {
-      agentConfig: config as WorkflowTaskState['agentConfig'],
-      activeFiles: createActiveFilesFromArrays(config),
-    };
-  }
-
-  // Should be unreachable - all AgentCategory values are handled
-  throw new Error(`Unknown agent category: ${config.session.agentCategory}`);
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces schema-driven validation and simplifies task state persistence/consumption.
> 
> - **Validation:** New `TaskStateSchema` with zod validates persisted `TaskState` variants (`WorkflowTaskState`, `ToolUseTaskState`) using a minimal passthrough `agentConfig` discriminator; adds `ToolSessionState` and `ActiveFiles` schemas.
> - **State management:** `ProgressViewState` removes deep-clone utility, stores `TaskState` directly, validates on load, and simplifies serialization; cleans up tool-use agent registry based on validated states.
> - **Consumers updated:** `ProgressEventHandler` and `streamInfoUtils` now read session details via `taskState.agentConfig.session.*`.
> - **Conversion:** `agentConfigToTaskState` refactored to a typed switch on `AgentCategory`, producing category-specific state.
> - **Misc:** Minor formatting/typing adjustments in `executeAgent` config parsing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c1ad5eaaa2f10b5b572f2d8bb680c90e30554251. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->