### PR TITLE
refactor: DRY up executeAgent.ts with flow execution helpers

### DIFF
--- a/src/agent/implementations/flows/reflection/ReflectionFlowContext.ts
+++ b/src/agent/implementations/flows/reflection/ReflectionFlowContext.ts
@@ -23,6 +23,7 @@ import type { BaseFlowContextInit } from '@agent/implementations/flows/common';
 import { retryCoordinator } from '@agent/runtime/RetryRequestCoordinator';
 import type { StorageKey } from '@agent/types/IdentifierTypes';
 import { getOutputFileName } from '@agent/utils/outputFileUtils';
+import type { IInterruptible } from '@agent/toolUse/ToolUseAgentRegistry';
 import type { AgentFileLocation } from '@utils/files';
 
 import { PromptBuilder } from '@utils/prompt';
@@ -67,8 +68,10 @@ export interface ReflectionFlowContextInit<
 /**
  * Reflection flow context returned by factory function.
  * Contains services and lifecycle methods.
+ *
+ * Extends IInterruptible to allow registration with the interrupt registry.
  */
-export interface ReflectionFlowContext<C = unknown> {
+export interface ReflectionFlowContext<C = unknown> extends IInterruptible {
   /** Services for flow execution (missing runStage - set by runReflectionFlow) */
   services: ReflectionServicesPartial<C>;
 
@@ -77,9 +80,6 @@ export interface ReflectionFlowContext<C = unknown> {
 
   /** Set the active run storage key on the output handler */
   setActiveRun(storageKey: StorageKey): void;
-
-  /** Interrupt the flow execution */
-  interrupt(): void;
 
   /** Dispose context resources */
   dispose(): void;

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -277,17 +277,6 @@ function createUsageRecorder(
 }
 
 /**
- * Options for createToolUseCallbacks helper.
- */
-interface ToolUseCallbackOptions {
-  /**
-   * Optional setup callback invoked after registration.
-   * Used by resumeToolUseFromSnapshot to configure the session before flow starts.
-   */
-  onSetup?: (context: { session: IToolUseSession }) => void;
-}
-
-/**
  * Create standardized interruptible callbacks for tool-use flows.
  *
  * DRY helper for the register/unregister pattern used when running tool-use flows.
@@ -295,16 +284,17 @@ interface ToolUseCallbackOptions {
  * to ensure consistent stream ID usage throughout the flow lifecycle.
  *
  * @param streamTabId - Stream ID to use for registration
- * @param options - Optional callbacks for additional setup
+ * @param onSetup - Optional callback invoked after registration, used by
+ *                  resumeToolUseFromSnapshot to configure the session before flow starts
  */
 function createToolUseCallbacks(
   streamTabId: StreamTabId,
-  options?: ToolUseCallbackOptions,
+  onSetup?: (context: { session: IToolUseSession }) => void,
 ): RunToolUseFlowCallbacks {
   return {
     onContextReady: (_callbackStreamId, context) => {
       registerInterruptible(streamTabId, context);
-      options?.onSetup?.(context);
+      onSetup?.(context);
     },
     onFlowComplete: (_callbackStreamId) => {
       unregisterInterruptible(streamTabId);
@@ -773,11 +763,10 @@ export async function resumeToolUseFromSnapshot(
         streamTabId,
         resumeSnapshot: snapshot,
       },
-      createToolUseCallbacks(streamTabId, {
-        onSetup: setupSession
-          ? (context) => setupSession(context.session)
-          : undefined,
-      }),
+      createToolUseCallbacks(
+        streamTabId,
+        setupSession ? (context) => setupSession(context.session) : undefined,
+      ),
     );
 
     updateFlowStatus(streamTabId, result.status);

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -26,8 +26,12 @@ import type { ToolUseSessionSnapshot } from '@agent/implementations/flows/toolus
 import {
   runToolUseFlow,
   type IToolUseSession,
+  type RunToolUseFlowCallbacks,
 } from '@agent/implementations/flows/tooluse';
-import { runReflectionFlow } from '@agent/implementations/flows/reflection/runReflectionFlow';
+import {
+  runReflectionFlow,
+  type RunReflectionFlowCallbacks,
+} from '@agent/implementations/flows/reflection/runReflectionFlow';
 import { AgentConfigSchema, type AgentConfig } from '@agent/core/AgentConfig';
 import {
   AgentSetting,
@@ -51,6 +55,7 @@ import type { StreamTabId, ExecutionId } from '@agent/types/IdentifierTypes';
 import {
   registerInterruptible,
   unregisterInterruptible,
+  type IInterruptible,
 } from '@agent/toolUse/ToolUseAgentRegistry';
 import { STREAM_STATUS } from '@common/constants/streamStatus';
 import { normalizeRunId } from '@common/constants/runIds';
@@ -269,6 +274,103 @@ function createUsageRecorder(
   };
 }
 
+/**
+ * Create standardized interruptible callbacks for tool-use flows.
+ *
+ * DRY helper for the register/unregister pattern used when running tool-use flows.
+ */
+function createToolUseCallbacks(
+  streamTabId: StreamTabId,
+): RunToolUseFlowCallbacks {
+  return {
+    onContextReady: (_streamId, context) => {
+      registerInterruptible(streamTabId, context);
+    },
+    onFlowComplete: () => {
+      unregisterInterruptible(streamTabId);
+    },
+  };
+}
+
+/**
+ * Create standardized interruptible callbacks for reflection flows.
+ *
+ * DRY helper for the register/unregister pattern used when running reflection flows.
+ */
+function createReflectionCallbacks(
+  streamTabId: StreamTabId,
+): RunReflectionFlowCallbacks {
+  return {
+    onContextReady: (_storageKey, context) => {
+      registerInterruptible(streamTabId, context as IInterruptible);
+    },
+    onFlowComplete: () => {
+      unregisterInterruptible(streamTabId);
+    },
+  };
+}
+
+/**
+ * Build the common flow input fields shared by all flow types.
+ *
+ * DRY helper: Both tool-use and reflection flows share these fields.
+ * This extracts the common pattern instead of duplicating it 4+ times.
+ */
+function buildBaseFlowInput(
+  ctx: FlowExecutionContext,
+  interruptManager: InterruptManager,
+  runKind: 'workflow' | 'tool-use',
+) {
+  return {
+    modelHandler: ctx.modelHandler,
+    config: ctx.agentConfig,
+    prompt: ctx.agentPrompt,
+    executionContext: ctx.executionContext,
+    userVarChannels: ctx.userVarChannels,
+    checkInterruption: interruptManager.checkInterruption,
+    setAbortController: interruptManager.setAbortController,
+    onInterrupt: interruptManager.onInterrupt,
+    // Get fresh client each response round to ensure auth keys are refreshed
+    getClient: () => ctx.modelHandler.getClient(),
+    getUsageRecorder: createUsageRecorder(ctx.usageMonitor, runKind),
+  };
+}
+
+/**
+ * Setup UI state for flow execution.
+ *
+ * DRY helper: All three flow execution functions call setActiveStream
+ * and set stream status to RUNNING.
+ */
+function setupFlowUIState(ctx: FlowExecutionContext): void {
+  bus.emit('setActiveStream', {
+    stream: ctx.streamTabId,
+    session: ctx.agentConfig.session!,
+    isRemote: isRemoteAgent(ctx.agentConfig.agent),
+    hasMultipleOutputs: ctx.agentConfig.useMultipleOutputs,
+  });
+  StreamStatusService.set(ctx.streamTabId, STREAM_STATUS.RUNNING);
+}
+
+/**
+ * Update stream status based on flow result.
+ *
+ * DRY helper: All flow completions need to update status, but must
+ * preserve WAITING state for tool-use flows awaiting follow-up.
+ */
+function updateFlowStatus(
+  streamTabId: StreamTabId,
+  flowStatus: 'error' | 'stopped',
+): void {
+  const currentStatus = StreamStatusService.get(streamTabId);
+  if (currentStatus !== STREAM_STATUS.WAITING) {
+    StreamStatusService.set(
+      streamTabId,
+      flowStatus === 'error' ? STREAM_STATUS.ERROR : STREAM_STATUS.STOPPED,
+    );
+  }
+}
+
 // ============================================================================
 // UI and Error Handling
 // ============================================================================
@@ -424,13 +526,7 @@ export async function executeAgent(
     const runStorage = getRunStorageService();
 
     // Setup UI state
-    bus.emit('setActiveStream', {
-      stream: streamTabId,
-      session: config.session,
-      isRemote: isRemoteAgent(config.agent),
-      hasMultipleOutputs: config.useMultipleOutputs,
-    });
-    StreamStatusService.set(streamTabId, STREAM_STATUS.RUNNING);
+    setupFlowUIState(ctx);
 
     if (!isResume) {
       logger.info(`Starting task execution for ${streamTabId}`);
@@ -474,85 +570,33 @@ export async function executeAgent(
       async () => {
         logger.info(`Executing ${agentName} with model ${config.model}`);
 
-        // Create interrupt manager (replaces mutable interruptState object)
         const interruptManager = new InterruptManager();
-
         let flowStatus: 'error' | 'stopped';
 
         if (agentSetting.agentType === 'toolUse') {
           // Tool-use flow execution
           const result = await runToolUseFlow(
             {
-              modelHandler: ctx.modelHandler,
-              config: ctx.agentConfig,
+              ...buildBaseFlowInput(ctx, interruptManager, 'tool-use'),
               setting: ctx.agentSetting as AgentToolUseSetting,
-              prompt: ctx.agentPrompt,
-              executionContext: ctx.executionContext,
-              userVarChannels: ctx.userVarChannels,
               streamTabId: ctx.streamTabId,
-              checkInterruption: interruptManager.checkInterruption,
-              setAbortController: interruptManager.setAbortController,
-              // Get fresh client each response round to ensure auth keys are refreshed
-              getClient: () => ctx.modelHandler.getClient(),
-              getUsageRecorder: createUsageRecorder(
-                ctx.usageMonitor,
-                'tool-use',
-              ),
-              onInterrupt: interruptManager.onInterrupt,
             },
-            {
-              onContextReady: (streamId, context) => {
-                registerInterruptible(streamId, context);
-              },
-              onFlowComplete: (streamId) => {
-                unregisterInterruptible(streamId);
-              },
-            },
+            createToolUseCallbacks(streamTabId),
           );
           flowStatus = result.status;
         } else {
           // Reflection flow execution (direct/CoT/workflow)
           const result = await runReflectionFlow(
             {
-              modelHandler: ctx.modelHandler,
-              config: ctx.agentConfig,
+              ...buildBaseFlowInput(ctx, interruptManager, 'workflow'),
               setting: ctx.agentSetting as AgentWorkflowSetting,
-              prompt: ctx.agentPrompt,
-              executionContext: ctx.executionContext,
-              userVarChannels: ctx.userVarChannels,
-              checkInterruption: interruptManager.checkInterruption,
-              setAbortController: interruptManager.setAbortController,
-              // Get fresh client each response round to ensure auth keys are refreshed
-              getClient: () => ctx.modelHandler.getClient(),
-              getUsageRecorder: createUsageRecorder(
-                ctx.usageMonitor,
-                'workflow',
-              ),
-              onInterrupt: interruptManager.onInterrupt,
             },
-            {
-              onContextReady: (_storageKey, context) => {
-                registerInterruptible(streamTabId, context);
-              },
-              onFlowComplete: () => {
-                unregisterInterruptible(streamTabId);
-              },
-            },
+            createReflectionCallbacks(streamTabId),
           );
           flowStatus = result.status;
         }
 
-        // Update stream status based on flow result
-        // Tool-use flows can pause in WAITING state - don't override that
-        const currentStatus = StreamStatusService.get(streamTabId);
-        if (currentStatus !== STREAM_STATUS.WAITING) {
-          StreamStatusService.set(
-            streamTabId,
-            flowStatus === 'error'
-              ? STREAM_STATUS.ERROR
-              : STREAM_STATUS.STOPPED,
-          );
-        }
+        updateFlowStatus(streamTabId, flowStatus);
         logger.debug(`Task completed with status: ${flowStatus}`);
       },
       { skip: isResume },
@@ -592,25 +636,15 @@ export async function executeMergeAgent(
   }
 
   try {
-    // Setup UI state
-    bus.emit('setActiveStream', {
-      stream: streamTabId,
-      session: ctx.agentConfig.session!,
-      isRemote: isRemoteAgent(ctx.agentConfig.agent),
-      hasMultipleOutputs: ctx.agentConfig.useMultipleOutputs,
-    });
-    StreamStatusService.set(streamTabId, STREAM_STATUS.RUNNING);
+    setupFlowUIState(ctx);
 
     await logger.withScope(`Task: merge@${model}`, async () => {
       logger.info(`Executing merge with model ${model}`);
 
-      // Create interrupt manager
       const interruptManager = new InterruptManager();
 
-      // Create file service for merge-specific output location
-      const fileService = new TaskRunFileService(executionContext.executionId);
-
       // Create merge-specific output file location getter
+      const fileService = new TaskRunFileService(executionContext.executionId);
       const getOutputFileLocation = createMergeOutputFileLocationGetter(
         inputFile,
         editedFile,
@@ -620,35 +654,15 @@ export async function executeMergeAgent(
       // Run reflection flow with custom file naming
       const result = await runReflectionFlow(
         {
-          modelHandler: ctx.modelHandler,
-          config: ctx.agentConfig,
+          ...buildBaseFlowInput(ctx, interruptManager, 'workflow'),
           setting: ctx.agentSetting as AgentWorkflowSetting,
-          prompt: ctx.agentPrompt,
-          executionContext: ctx.executionContext,
-          userVarChannels: ctx.userVarChannels,
-          checkInterruption: interruptManager.checkInterruption,
-          setAbortController: interruptManager.setAbortController,
-          // Get fresh client each response round to ensure auth keys are refreshed
-          getClient: () => ctx.modelHandler.getClient(),
-          getUsageRecorder: createUsageRecorder(ctx.usageMonitor, 'workflow'),
           getOutputFileLocation,
-          onInterrupt: interruptManager.onInterrupt,
         },
-        {
-          onContextReady: (_storageKey, context) => {
-            registerInterruptible(streamTabId, context);
-          },
-          onFlowComplete: () => {
-            unregisterInterruptible(streamTabId);
-          },
-        },
+        createReflectionCallbacks(streamTabId),
       );
 
       logger.debug(`Task completed successfully`);
-      StreamStatusService.set(
-        streamTabId,
-        result.status === 'error' ? STREAM_STATUS.ERROR : STREAM_STATUS.STOPPED,
-      );
+      updateFlowStatus(streamTabId, result.status);
     });
   } catch (err) {
     StreamStatusService.set(streamTabId, STREAM_STATUS.ERROR);
@@ -680,15 +694,7 @@ export async function resumeToolUseFromSnapshot(
 
   // Prepare flow execution context
   const ctx = await prepareFlowExecution(config.agent, config, executionId);
-  const {
-    modelHandler,
-    agentConfig,
-    agentSetting,
-    agentPrompt,
-    executionContext,
-    userVarChannels,
-    usageMonitor,
-  } = ctx;
+  const { agentSetting, executionContext } = ctx;
 
   // Validate agent type
   if (agentSetting.agentType !== 'toolUse') {
@@ -697,60 +703,33 @@ export async function resumeToolUseFromSnapshot(
     );
   }
 
-  // Create interrupt manager
   const interruptManager = new InterruptManager();
 
   try {
-    // Setup UI state for resume
-    bus.emit('setActiveStream', {
-      stream: streamTabId,
-      session: agentConfig.session!,
-      isRemote: isRemoteAgent(agentConfig.agent),
-      hasMultipleOutputs: agentConfig.useMultipleOutputs,
-    });
-    StreamStatusService.set(streamTabId, STREAM_STATUS.RUNNING);
+    setupFlowUIState(ctx);
 
     // Run the flow with resume snapshot
+    // Note: Custom callbacks needed here because setupSession must run in onContextReady
     const result = await runToolUseFlow(
       {
-        modelHandler,
-        config: agentConfig,
+        ...buildBaseFlowInput(ctx, interruptManager, 'tool-use'),
         setting: agentSetting as AgentToolUseSetting,
-        prompt: agentPrompt,
-        executionContext,
-        userVarChannels,
         streamTabId,
-        checkInterruption: interruptManager.checkInterruption,
-        setAbortController: interruptManager.setAbortController,
-        // Get fresh client each response round to ensure auth keys are refreshed
-        getClient: () => modelHandler.getClient(),
-        getUsageRecorder: createUsageRecorder(usageMonitor, 'tool-use'),
         resumeSnapshot: snapshot,
-        onInterrupt: interruptManager.onInterrupt,
       },
       {
-        onContextReady: (streamId, context) => {
-          registerInterruptible(streamId, context);
-
+        onContextReady: (_streamId, context) => {
+          registerInterruptible(streamTabId, context);
           // Allow caller to configure session (e.g., append follow-ups)
-          if (setupSession) {
-            setupSession(context.session);
-          }
+          setupSession?.(context.session);
         },
-        onFlowComplete: (streamId) => {
-          unregisterInterruptible(streamId);
+        onFlowComplete: () => {
+          unregisterInterruptible(streamTabId);
         },
       },
     );
 
-    // Only set status if flow actually completed (not paused waiting for follow-up)
-    const finalStatus = StreamStatusService.get(streamTabId);
-    if (finalStatus !== STREAM_STATUS.WAITING) {
-      StreamStatusService.set(
-        streamTabId,
-        result.status === 'error' ? STREAM_STATUS.ERROR : STREAM_STATUS.STOPPED,
-      );
-    }
+    updateFlowStatus(streamTabId, result.status);
   } catch (error) {
     StreamStatusService.set(streamTabId, STREAM_STATUS.ERROR);
     await handleFlowError(error, config.agent, streamTabId, executionContext);

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -55,7 +55,6 @@ import type { StreamTabId, ExecutionId } from '@agent/types/IdentifierTypes';
 import {
   registerInterruptible,
   unregisterInterruptible,
-  type IInterruptible,
 } from '@agent/toolUse/ToolUseAgentRegistry';
 import { STREAM_STATUS } from '@common/constants/streamStatus';
 import { normalizeRunId } from '@common/constants/runIds';
@@ -300,17 +299,13 @@ function createToolUseCallbacks(
  * DRY helper for the register/unregister pattern used when running reflection flows.
  * Uses the captured streamTabId from the closure rather than the storageKey callback
  * parameter, since registerInterruptible expects a StreamTabId.
- *
- * Note: The cast to IInterruptible is safe because ReflectionFlowContext implements
- * the interrupt() method required by IInterruptible.
  */
 function createReflectionCallbacks(
   streamTabId: StreamTabId,
 ): RunReflectionFlowCallbacks {
   return {
     onContextReady: (_storageKey, context) => {
-      // Cast is safe: ReflectionFlowContext has interrupt() method
-      registerInterruptible(streamTabId, context as IInterruptible);
+      registerInterruptible(streamTabId, context);
     },
     onFlowComplete: (_storageKey) => {
       unregisterInterruptible(streamTabId);

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -274,18 +274,34 @@ function createUsageRecorder(
 }
 
 /**
+ * Options for createToolUseCallbacks helper.
+ */
+interface ToolUseCallbackOptions {
+  /**
+   * Optional setup callback invoked after registration.
+   * Used by resumeToolUseFromSnapshot to configure the session before flow starts.
+   */
+  onSetup?: (context: { session: IToolUseSession }) => void;
+}
+
+/**
  * Create standardized interruptible callbacks for tool-use flows.
  *
  * DRY helper for the register/unregister pattern used when running tool-use flows.
  * Uses the captured streamTabId from the closure rather than callback parameters
  * to ensure consistent stream ID usage throughout the flow lifecycle.
+ *
+ * @param streamTabId - Stream ID to use for registration
+ * @param options - Optional callbacks for additional setup
  */
 function createToolUseCallbacks(
   streamTabId: StreamTabId,
+  options?: ToolUseCallbackOptions,
 ): RunToolUseFlowCallbacks {
   return {
     onContextReady: (_callbackStreamId, context) => {
       registerInterruptible(streamTabId, context);
+      options?.onSetup?.(context);
     },
     onFlowComplete: (_callbackStreamId) => {
       unregisterInterruptible(streamTabId);
@@ -314,6 +330,23 @@ function createReflectionCallbacks(
 }
 
 /**
+ * Common flow input fields shared by all flow types.
+ * Returned by buildBaseFlowInput helper.
+ */
+interface BaseFlowInputFields {
+  modelHandler: FlowExecutionContext['modelHandler'];
+  config: FlowExecutionContext['agentConfig'];
+  prompt: FlowExecutionContext['agentPrompt'];
+  executionContext: FlowExecutionContext['executionContext'];
+  userVarChannels: FlowExecutionContext['userVarChannels'];
+  checkInterruption: InterruptManager['checkInterruption'];
+  setAbortController: InterruptManager['setAbortController'];
+  onInterrupt: InterruptManager['onInterrupt'];
+  getClient: () => ReturnType<FlowExecutionContext['modelHandler']['getClient']>;
+  getUsageRecorder: () => RoundFinalizedCallback;
+}
+
+/**
  * Build the common flow input fields shared by all flow types.
  *
  * DRY helper: Both tool-use and reflection flows share these fields.
@@ -323,7 +356,7 @@ function buildBaseFlowInput(
   ctx: FlowExecutionContext,
   interruptManager: InterruptManager,
   runKind: 'workflow' | 'tool-use',
-) {
+): BaseFlowInputFields {
   return {
     modelHandler: ctx.modelHandler,
     config: ctx.agentConfig,
@@ -637,7 +670,11 @@ export async function executeMergeAgent(
     editedFile,
   });
 
-  const { streamTabId, executionContext } = ctx;
+  const { streamTabId, executionContext, agentConfig } = ctx;
+
+  if (!agentConfig.session) {
+    throw new Error('Merge agent configuration is missing session metadata.');
+  }
 
   // Check if already running
   const currentStatus = StreamStatusService.get(streamTabId);
@@ -706,13 +743,17 @@ export async function resumeToolUseFromSnapshot(
 
   // Prepare flow execution context
   const ctx = await prepareFlowExecution(config.agent, config, executionId);
-  const { agentSetting, executionContext } = ctx;
+  const { agentSetting, executionContext, agentConfig } = ctx;
 
-  // Validate agent type
+  // Validate agent type and session
   if (agentSetting.agentType !== 'toolUse') {
     throw new Error(
       'Attempted to resume a non tool-use agent with resumeToolUseFromSnapshot.',
     );
+  }
+
+  if (!agentConfig.session) {
+    throw new Error('Resume agent configuration is missing session metadata.');
   }
 
   const interruptManager = new InterruptManager();
@@ -722,7 +763,6 @@ export async function resumeToolUseFromSnapshot(
     setupFlowUIState(ctx, streamTabId);
 
     // Run the flow with resume snapshot
-    // Note: Custom callbacks needed here because setupSession must run in onContextReady
     const result = await runToolUseFlow(
       {
         ...buildBaseFlowInput(ctx, interruptManager, 'tool-use'),
@@ -730,16 +770,11 @@ export async function resumeToolUseFromSnapshot(
         streamTabId,
         resumeSnapshot: snapshot,
       },
-      {
-        onContextReady: (_streamId, context) => {
-          registerInterruptible(streamTabId, context);
-          // Allow caller to configure session (e.g., append follow-ups)
-          setupSession?.(context.session);
-        },
-        onFlowComplete: () => {
-          unregisterInterruptible(streamTabId);
-        },
-      },
+      createToolUseCallbacks(streamTabId, {
+        onSetup: setupSession
+          ? (context) => setupSession(context.session)
+          : undefined,
+      }),
     );
 
     updateFlowStatus(streamTabId, result.status);

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -278,15 +278,17 @@ function createUsageRecorder(
  * Create standardized interruptible callbacks for tool-use flows.
  *
  * DRY helper for the register/unregister pattern used when running tool-use flows.
+ * Uses the captured streamTabId from the closure rather than callback parameters
+ * to ensure consistent stream ID usage throughout the flow lifecycle.
  */
 function createToolUseCallbacks(
   streamTabId: StreamTabId,
 ): RunToolUseFlowCallbacks {
   return {
-    onContextReady: (_streamId, context) => {
+    onContextReady: (_callbackStreamId, context) => {
       registerInterruptible(streamTabId, context);
     },
-    onFlowComplete: () => {
+    onFlowComplete: (_callbackStreamId) => {
       unregisterInterruptible(streamTabId);
     },
   };
@@ -296,15 +298,21 @@ function createToolUseCallbacks(
  * Create standardized interruptible callbacks for reflection flows.
  *
  * DRY helper for the register/unregister pattern used when running reflection flows.
+ * Uses the captured streamTabId from the closure rather than the storageKey callback
+ * parameter, since registerInterruptible expects a StreamTabId.
+ *
+ * Note: The cast to IInterruptible is safe because ReflectionFlowContext implements
+ * the interrupt() method required by IInterruptible.
  */
 function createReflectionCallbacks(
   streamTabId: StreamTabId,
 ): RunReflectionFlowCallbacks {
   return {
     onContextReady: (_storageKey, context) => {
+      // Cast is safe: ReflectionFlowContext has interrupt() method
       registerInterruptible(streamTabId, context as IInterruptible);
     },
-    onFlowComplete: () => {
+    onFlowComplete: (_storageKey) => {
       unregisterInterruptible(streamTabId);
     },
   };
@@ -341,15 +349,24 @@ function buildBaseFlowInput(
  *
  * DRY helper: All three flow execution functions call setActiveStream
  * and set stream status to RUNNING.
+ *
+ * @param ctx - Flow execution context
+ * @param streamTabIdOverride - Optional override for stream ID (used in resume scenarios
+ *                              where the snapshot's stream ID should be used instead of
+ *                              the regenerated one from ctx)
  */
-function setupFlowUIState(ctx: FlowExecutionContext): void {
+function setupFlowUIState(
+  ctx: FlowExecutionContext,
+  streamTabIdOverride?: StreamTabId,
+): void {
+  const streamTabId = streamTabIdOverride ?? ctx.streamTabId;
   bus.emit('setActiveStream', {
-    stream: ctx.streamTabId,
+    stream: streamTabId,
     session: ctx.agentConfig.session!,
     isRemote: isRemoteAgent(ctx.agentConfig.agent),
     hasMultipleOutputs: ctx.agentConfig.useMultipleOutputs,
   });
-  StreamStatusService.set(ctx.streamTabId, STREAM_STATUS.RUNNING);
+  StreamStatusService.set(streamTabId, STREAM_STATUS.RUNNING);
 }
 
 /**
@@ -706,7 +723,8 @@ export async function resumeToolUseFromSnapshot(
   const interruptManager = new InterruptManager();
 
   try {
-    setupFlowUIState(ctx);
+    // Use snapshot's stream ID for UI state to maintain consistency
+    setupFlowUIState(ctx, streamTabId);
 
     // Run the flow with resume snapshot
     // Note: Custom callbacks needed here because setupSession must run in onContextReady

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -335,7 +335,9 @@ interface BaseFlowInputFields {
   checkInterruption: InterruptManager['checkInterruption'];
   setAbortController: InterruptManager['setAbortController'];
   onInterrupt: InterruptManager['onInterrupt'];
-  getClient: () => ReturnType<FlowExecutionContext['modelHandler']['getClient']>;
+  getClient: () => ReturnType<
+    FlowExecutionContext['modelHandler']['getClient']
+  >;
   getUsageRecorder: () => RoundFinalizedCallback;
 }
 

--- a/src/agent/toolUse/ToolUseAgentRegistry.ts
+++ b/src/agent/toolUse/ToolUseAgentRegistry.ts
@@ -14,9 +14,20 @@ import type { StreamTabId } from '@agent/types/IdentifierTypes';
  * Common interface for anything that can be interrupted.
  * Implemented by:
  * - ToolUseFlowContext (via sessionLifecycle.interrupt())
+ * - ReflectionFlowContext (via onInterrupt callback and retry coordinator)
  * - BaseAgent (via isInterrupted flag)
  */
 export interface IInterruptible {
+  /**
+   * Request interruption of the execution.
+   *
+   * Implementations should:
+   * - Invoke any onInterrupt callbacks to signal the interrupt manager
+   * - Clear pending retry requests from the retry coordinator
+   * - Cancel any pending follow-up waits (for tool-use sessions)
+   *
+   * This method may be called from the UI thread when the user stops a task.
+   */
   interrupt(): void;
 }
 


### PR DESCRIPTION
Extract common patterns into reusable helpers:
- buildBaseFlowInput: Common flow input fields (modelHandler, config, etc.)
- setupFlowUIState: setActiveStream + setStreamStatus(RUNNING)
- updateFlowStatus: Status update preserving WAITING state
- createToolUseCallbacks/createReflectionCallbacks: Interruptible registration

This reduces code duplication across executeAgent, executeMergeAgent,
and resumeToolUseFromSnapshot functions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Consolidates repeated flow execution logic and standardizes interrupt handling.
> 
> - Adds helpers: `buildBaseFlowInput`, `setupFlowUIState`, `updateFlowStatus`, `createToolUseCallbacks`, `createReflectionCallbacks`; replaces duplicated code in `executeAgent`, `executeMergeAgent`, and `resumeToolUseFromSnapshot`
> - `ReflectionFlowContext` now implements `IInterruptible`; `interrupt()` forwards `onInterrupt` and clears retry requests; `dispose()` also clears retries
> - Introduces callback types (`RunToolUseFlowCallbacks`, `RunReflectionFlowCallbacks`) usage and centralizes register/unregister via `ToolUseAgentRegistry`
> - Ensures UI state setup and status updates are consistent; preserves WAITING state and uses snapshot stream ID on resume
> - Adds session validation checks for merge and resume paths
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d6b7325dda27ee5efd8857b19560b734cc6d4e08. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->