### PR TITLE
Fix TypeScript error in ProgressViewState

### DIFF
--- a/src/progressView/state/ProgressViewState.ts
+++ b/src/progressView/state/ProgressViewState.ts
@@ -644,7 +644,12 @@ export class ProgressViewState {
           continue;
         }
 
-        this.taskStates.set(stream as StreamTabId, parseResult.data);
+        // Cast is safe: schema uses passthrough() for efficiency but data
+        // originated from a validated TaskState with full AgentConfig
+        this.taskStates.set(
+          stream as StreamTabId,
+          parseResult.data as TaskState,
+        );
         loaded += 1;
       }
     }


### PR DESCRIPTION
The TaskStateSchema uses passthrough() for efficiency to avoid re-validating already-validated agentConfig, but this causes the inferred type from safeParse() to be the minimal validated shape rather than the full TaskState type. Add explicit cast since the data originated from a validated TaskState.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Type-only fix to ensure persisted task states are stored with the correct type.
> 
> - In `ProgressViewState.loadTaskStates`, cast `parseResult.data` to `TaskState` before storing, addressing the narrower inference from `TaskStateSchema.passthrough()`
> - No runtime behavior changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 73da25965356b18963d4136e26c034b9f58067ee. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->