### PR TITLE
fix: enable output streaming in ResponseCycleFlow

### DIFF
--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -272,7 +272,7 @@ class ResponseModelInvocationNode<C> extends RetryableInvocationNode<
       return { kind: 'skipped' };
     }
 
-    services.modelHandler.setOutputStreaming(true);
+    services.modelHandler.setOutputStreaming(false);
 
     const stage = await services.logger.stage('Model invocation', {
       skip: true,

--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -447,6 +447,9 @@ class ResponseProcessNode<C> extends BaseNode<
       return { kind: 'skipped' };
     }
 
+    // Capture the current group ID for logging (matches ToolUseCycleFlow pattern)
+    const groupId = logger.withCurrentGroup((id) => id);
+
     const stage = await logger.stage('Process response', {
       skip: true,
     });
@@ -484,6 +487,7 @@ class ResponseProcessNode<C> extends BaseNode<
       // (streaming mode already shows it progressively via streams)
       if (thinkingContent && !useStreaming) {
         logger.info(thinkingContent, {
+          groupId,
           messageType: MESSAGE_TYPES.THINKING,
         });
       }
@@ -492,6 +496,7 @@ class ResponseProcessNode<C> extends BaseNode<
       const scratchpad = await extractScratchpad(newResponse, 'scratchpad');
       if (scratchpad) {
         logger.info(scratchpad, {
+          groupId,
           messageType: MESSAGE_TYPES.SCRATCHPAD,
         });
       }

--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -272,7 +272,7 @@ class ResponseModelInvocationNode<C> extends RetryableInvocationNode<
       return { kind: 'skipped' };
     }
 
-    services.modelHandler.setOutputStreaming(false);
+    services.modelHandler.setOutputStreaming(true);
 
     const stage = await services.logger.stage('Model invocation', {
       skip: true,

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -362,29 +362,6 @@ export class ProgressViewProvider
   }
 
   /**
-   * Update log content for a stream (used by message handler)
-   * Now properly focused on just updating log content with groups
-   */
-  public updateLogContent(stream: string): void {
-    if (!this.webviewUpdater.isAvailable()) {
-      return;
-    }
-
-    const targetStream = this.state.streamTabs.has(stream)
-      ? stream
-      : (this.state.streamTabs.keys()[0] ?? '');
-
-    if (!targetStream) {
-      this.webviewUpdater.updateLogContent('', [], []);
-      return;
-    }
-
-    this.eventHandler.refreshStreamSurface(targetStream, {
-      updateInstruction: false,
-    });
-  }
-
-  /**
    * Set active stream (used by message handler)
    */
   public setActiveStream(stream: string): void {

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -312,6 +312,8 @@ export class ProgressEventHandler {
    * Set the status for a specific stream synchronously.
    */
   setStreamStatus(stream: string, status: StreamStatus): void {
+    const previousStatus = this._streamStatus.get(stream);
+
     // Update the persistent status map first
     if (status === STREAM_STATUS.READY) {
       this._streamStatus.delete(stream);
@@ -320,11 +322,15 @@ export class ProgressEventHandler {
     }
 
     if (this.webviewUpdater.isAvailable()) {
-      // When sorted by time, status changes may affect tab order (due to new log entries),
-      // so we need a full refresh. Otherwise use efficient targeted update.
+      const streamExists = this.state.streamTabs.has(stream);
+
+      // Determine if full refresh is needed:
+      // - New stream (not in tabs yet) always needs full refresh
+      // - When time-sorted, only refresh if status change might affect order
       const needsFullRefresh =
-        !this.state.streamTabs.has(stream) ||
-        this.state.streamSortOrder === 'time';
+        !streamExists ||
+        (this.state.streamSortOrder === 'time' &&
+          this.mightAffectTabOrder(previousStatus, status));
 
       if (needsFullRefresh) {
         // Include current status in refresh map so frontend displays it correctly.
@@ -342,6 +348,27 @@ export class ProgressEventHandler {
         this.webviewUpdater.updateStreamStatus(stream, status, lastTimestamp);
       }
     }
+  }
+
+  /**
+   * Determine if a status transition might affect stream tab ordering.
+   * Only transitions TO running state may result in new log activity that changes order.
+   * Other transitions (RUNNING→STOPPED, STOPPED→ERROR, etc.) don't add logs.
+   */
+  private mightAffectTabOrder(
+    previous: StreamStatus | undefined,
+    current: StreamStatus,
+  ): boolean {
+    // Transitioning TO running may result in new logs
+    if (
+      current === STREAM_STATUS.RUNNING &&
+      previous !== STREAM_STATUS.RUNNING
+    ) {
+      return true;
+    }
+
+    // Other transitions don't add new logs, so order is stable
+    return false;
   }
 
   /**

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -352,23 +352,24 @@ export class ProgressEventHandler {
 
   /**
    * Determine if a status transition might affect stream tab ordering.
-   * Only transitions TO running state may result in new log activity that changes order.
-   * Other transitions (RUNNING→STOPPED, STOPPED→ERROR, etc.) don't add logs.
+   * First status assignment or transitions TO running may result in new log
+   * activity that changes the stream's position in time-sorted order.
+   * Other transitions (RUNNING→STOPPED, etc.) don't require re-sorting because
+   * all log timestamps were already captured while the stream was RUNNING.
    */
   private mightAffectTabOrder(
     previous: StreamStatus | undefined,
     current: StreamStatus,
   ): boolean {
-    // Transitioning TO running may result in new logs
-    if (
-      current === STREAM_STATUS.RUNNING &&
-      previous !== STREAM_STATUS.RUNNING
-    ) {
+    // First status assignment should always trigger refresh
+    if (previous === undefined) {
       return true;
     }
 
-    // Other transitions don't add new logs, so order is stable
-    return false;
+    // Transitioning TO running may result in new log activity
+    return (
+      current === STREAM_STATUS.RUNNING && previous !== STREAM_STATUS.RUNNING
+    );
   }
 
   /**

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -212,12 +212,14 @@ export class ProgressEventHandler {
    * @param options.forceRebuild - If true, frontend will do full DOM rebuild.
    *   Required when switching streams or after data deletion. Defaults to false
    *   for incremental updates.
+   * @returns The resolved active run ID, useful for callers that need to pass it
+   *   to sendInstructionUpdate separately (when updateInstruction is false).
    */
   public refreshStreamSurface(
     stream: string,
     options: { updateInstruction?: boolean; forceRebuild?: boolean } = {},
-  ): void {
-    if (!this.webviewUpdater.isAvailable()) return;
+  ): string | null {
+    if (!this.webviewUpdater.isAvailable()) return null;
 
     const { updateInstruction = true, forceRebuild = false } = options;
 
@@ -230,7 +232,7 @@ export class ProgressEventHandler {
       if (updateInstruction) {
         this.webviewUpdater.clearInstruction('');
       }
-      return;
+      return null;
     }
 
     const messages = this.state.streamTabs.getMessages(stream);
@@ -295,6 +297,8 @@ export class ProgressEventHandler {
     if (updateInstruction) {
       this.sendInstructionUpdate(stream, activeRunId);
     }
+
+    return activeRunId;
   }
 
   /**
@@ -356,8 +360,10 @@ export class ProgressEventHandler {
 
     await this.state.streamTabs.ensureStream(stream);
 
+    // Set status directly without triggering webview update - we do a single
+    // coordinated updateAll below to avoid multiple redundant updates.
     if (!existingStatus) {
-      this.setStreamStatus(stream, STREAM_STATUS.RUNNING);
+      this._streamStatus.set(stream, STREAM_STATUS.RUNNING);
     }
 
     this.state.updateStreamHints(stream, {
@@ -371,22 +377,20 @@ export class ProgressEventHandler {
 
     this.state.activeStream = stream;
 
-    const status = this._streamStatus.get(stream) ?? STREAM_STATUS.RUNNING;
-    this.setStreamStatus(stream, status);
-
     if (this.webviewUpdater.isAvailable()) {
-      // Send UPDATE_STREAMS first so frontend sets state.activeStream.
-      // Without this, the subsequent UPDATE_LOGS fails _isActiveStream check.
+      // Single coordinated update - send UPDATE_STREAMS first so frontend
+      // sets state.activeStream. Without this, UPDATE_LOGS fails _isActiveStream check.
       this.webviewUpdater.updateAll(this.state, this._streamStatus);
 
       // Force rebuild to clear any previous stream's content. The new task
       // group must be added to state BEFORE this call (in TaskGroupEvents)
       // so UPDATE_LOGS includes it and the frontend renders it correctly.
-      this.refreshStreamSurface(stream, {
+      // Use the returned runId to avoid duplicate resolveRunId call.
+      const activeRunId = this.refreshStreamSurface(stream, {
         updateInstruction: false,
         forceRebuild: true,
       });
-      this.sendInstructionUpdate(stream);
+      this.sendInstructionUpdate(stream, activeRunId);
     }
   }
 

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -394,6 +394,10 @@ export class ProgressEventHandler {
     this.setStreamStatus(stream, status);
 
     if (this.webviewUpdater.isAvailable()) {
+      // Send UPDATE_STREAMS first so frontend sets state.activeStream.
+      // Without this, the subsequent UPDATE_LOGS fails _isActiveStream check.
+      this.webviewUpdater.updateAll(this.state, this._streamStatus);
+
       // Force rebuild to clear any previous stream's content. The new task
       // group must be added to state BEFORE this call (in TaskGroupEvents)
       // so UPDATE_LOGS includes it and the frontend renders it correctly.

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -13,6 +13,7 @@ import { STREAM_STATUS } from '@common/constants/streamStatus';
 import { AgentLogger } from '@logger/AgentLogger';
 import { WebviewUpdater } from '@progressView/managers';
 import { ProgressViewState } from '@progressView/state/ProgressViewState';
+import { nestedMapToRecord } from '@progressView/persistence/serializationUtils';
 import { bus } from '@eventBus/ProgressEventBus';
 
 // Local file imports
@@ -244,10 +245,10 @@ export class ProgressEventHandler {
       this.state.runInstructions.getInstructions(stream).entries(),
     );
 
-    const filesByRun = this.formatRunOutputs(
+    const filesByRun = nestedMapToRecord(
       this.state.outputFiles.getFiles(stream),
     );
-    const missingByRun = this.formatRunStringOutputs(
+    const missingByRun = nestedMapToRecord(
       this.state.outputFiles.getMissingOutputs(stream),
     );
     const usageByRun = Object.fromEntries(
@@ -337,26 +338,6 @@ export class ProgressEventHandler {
         this.webviewUpdater.updateStreamStatus(stream, status, lastTimestamp);
       }
     }
-  }
-
-  private formatRunOutputs(
-    runs: Map<string, Map<number, OutputFileInfo[]>>,
-  ): Record<string, { [key: number]: OutputFileInfo[] }> {
-    const payload: Record<string, { [key: number]: OutputFileInfo[] }> = {};
-    for (const [runId, rounds] of runs.entries()) {
-      payload[runId] = Object.fromEntries(rounds.entries());
-    }
-    return payload;
-  }
-
-  private formatRunStringOutputs(
-    runs: Map<string, Map<number, string[]>>,
-  ): Record<string, { [key: number]: string[] }> {
-    const payload: Record<string, { [key: number]: string[] }> = {};
-    for (const [runId, rounds] of runs.entries()) {
-      payload[runId] = Object.fromEntries(rounds.entries());
-    }
-    return payload;
   }
 
   /**

--- a/src/progressView/events/StreamStatusEvents.ts
+++ b/src/progressView/events/StreamStatusEvents.ts
@@ -32,7 +32,7 @@ export interface StreamStatusEventShared extends BaseEventShared {
   refreshStreamSurface(
     stream: string,
     options?: { updateInstruction?: boolean; forceRebuild?: boolean },
-  ): void;
+  ): string | null;
   warnLog(message: string): void;
   debugLog(message: string): void;
 }
@@ -102,12 +102,13 @@ export function createStreamStatusEvents(
     shared.setStreamStatus(stream, status);
 
     if (updater.isAvailable()) {
-      // Only force rebuild when actually switching streams
-      shared.refreshStreamSurface(stream, {
+      // Only force rebuild when actually switching streams.
+      // Use the returned runId to avoid duplicate resolveRunId call.
+      const activeRunId = shared.refreshStreamSurface(stream, {
         updateInstruction: false,
         forceRebuild: isStreamSwitch,
       });
-      shared.sendInstructionUpdate(stream);
+      shared.sendInstructionUpdate(stream, activeRunId);
     }
   };
 

--- a/src/progressView/events/StreamStatusEvents.ts
+++ b/src/progressView/events/StreamStatusEvents.ts
@@ -121,28 +121,21 @@ export function createStreamStatusEvents(
     state.setTaskState(streamTabId, taskState);
     // Note: setTaskState already clears stream hints
 
-    const normalizedState = state.getTaskState(streamTabId);
+    // Use taskState directly - no need to re-fetch what we just stored
+    const sessionKind = taskState.agentConfig.session.agentCategory;
+    const currentFilter = state.agentTypeFilter;
+    const activeStream = state.activeStream;
 
-    if (!normalizedState) {
-      warnLog(
-        `Received setTaskState for ${streamTabId} but no state was stored`,
+    if (
+      activeStream &&
+      activeStream === streamTabId &&
+      currentFilter !== 'all' &&
+      currentFilter !== sessionKind
+    ) {
+      debugLog(
+        `Adjusting agent filter from ${currentFilter} to ${sessionKind} for stream ${streamTabId}`,
       );
-    } else {
-      const sessionKind = normalizedState.agentConfig.session.agentCategory;
-      const currentFilter = state.agentTypeFilter;
-      const activeStream = state.activeStream;
-
-      if (
-        activeStream &&
-        activeStream === streamTabId &&
-        currentFilter !== 'all' &&
-        currentFilter !== sessionKind
-      ) {
-        debugLog(
-          `Adjusting agent filter from ${currentFilter} to ${sessionKind} for stream ${streamTabId}`,
-        );
-        state.agentTypeFilter = sessionKind;
-      }
+      state.agentTypeFilter = sessionKind;
     }
 
     if (executionId) {

--- a/src/progressView/managers/OutputFilesManager.ts
+++ b/src/progressView/managers/OutputFilesManager.ts
@@ -22,6 +22,10 @@ import {
   createRoundMapSchema,
   createRunMapSchema,
 } from '@progressView/persistence/schemaUtils';
+import {
+  nestedMapToRecord,
+  tripleNestedMapToRecord,
+} from '@progressView/persistence/serializationUtils';
 
 // --- Zod Schemas for Output Files ---
 
@@ -462,17 +466,7 @@ export class OutputFilesManager extends PersistentMapManager<
 
   /** Save missing outputs to persistence */
   async saveMissingOutputs(): Promise<void> {
-    const obj = Object.fromEntries(
-      Array.from(this._missingOutputs.entries(), ([stream, runs]) => [
-        stream,
-        Object.fromEntries(
-          Array.from(runs.entries(), ([runId, rounds]) => [
-            runId,
-            Object.fromEntries(rounds.entries()),
-          ]),
-        ),
-      ]),
-    );
+    const obj = tripleNestedMapToRecord(this._missingOutputs);
     await this.storage.update(WorkspaceStateKey.MISSING_OUTPUTS, obj);
   }
 
@@ -526,13 +520,7 @@ export class OutputFilesManager extends PersistentMapManager<
     value: Map<string, Map<number, OutputFileInfo[]>>,
     _key: StreamTabId,
   ): unknown {
-    const runs = Object.fromEntries(
-      Array.from(value.entries(), ([runId, rounds]) => [
-        runId,
-        Object.fromEntries(rounds.entries()),
-      ]),
-    );
-    return runs;
+    return nestedMapToRecord(value);
   }
 
   /** Validate and normalize loaded output files */

--- a/src/progressView/managers/RunInstructionManager.ts
+++ b/src/progressView/managers/RunInstructionManager.ts
@@ -13,6 +13,7 @@ import {
   PersistentMapManager,
   type StateStorage,
 } from '@progressView/persistence/PersistentMapManager';
+import { mapToRecord } from '@progressView/persistence/serializationUtils';
 
 type InstructionMap = Map<string, InstructionUpdate>;
 
@@ -82,7 +83,7 @@ export class RunInstructionManager extends PersistentMapManager<
     value: InstructionMap,
     _key: StreamTabId,
   ): unknown {
-    return Object.fromEntries(value.entries());
+    return mapToRecord(value);
   }
 
   protected override async deserialize(

--- a/src/progressView/managers/TaskGroupManager.ts
+++ b/src/progressView/managers/TaskGroupManager.ts
@@ -10,6 +10,7 @@ import {
   PersistentMapManager,
   type StateStorage,
 } from '@progressView/persistence/PersistentMapManager';
+import { mapToRecord } from '@progressView/persistence/serializationUtils';
 
 export interface TaskGroupUpdatePayload {
   stream: StreamTabId;
@@ -165,7 +166,7 @@ export class TaskGroupManager extends PersistentMapManager<
     value: Map<string, TaskGroup>,
     _key: StreamTabId,
   ): unknown {
-    return Object.fromEntries(value.entries());
+    return mapToRecord(value);
   }
 
   /** Normalize loaded groups */

--- a/src/progressView/managers/UsageStatsManager.ts
+++ b/src/progressView/managers/UsageStatsManager.ts
@@ -13,6 +13,7 @@ import {
   type StateStorage,
 } from '@progressView/persistence/PersistentMapManager';
 import { createSingleValueRunMapSchema } from '@progressView/persistence/schemaUtils';
+import { mapToRecord } from '@progressView/persistence/serializationUtils';
 
 // --- Zod Schemas for Usage Stats ---
 
@@ -243,7 +244,7 @@ export class UsageStatsManager extends PersistentMapManager<
 
   /** Normalize loaded usage records */
   protected override serialize(value: RunUsageMap, _key: StreamTabId): unknown {
-    return Object.fromEntries(value.entries());
+    return mapToRecord(value);
   }
 
   protected override async deserialize(

--- a/src/progressView/persistence/serializationUtils.ts
+++ b/src/progressView/persistence/serializationUtils.ts
@@ -1,0 +1,55 @@
+/**
+ * Shared serialization utilities for converting Map structures to plain objects.
+ * These are used throughout the progress view for persistence and webview messaging.
+ */
+
+/**
+ * Serialize a Map to a plain Record object.
+ * @example mapToRecord(new Map([['a', 1]])) // { a: 1 }
+ */
+export function mapToRecord<K extends string | number, V>(
+  map: Map<K, V>,
+): Record<string, V> {
+  return Object.fromEntries(map.entries()) as Record<string, V>;
+}
+
+/**
+ * Serialize a nested Map structure (outer → inner → value) to nested Records.
+ * Used for run-scoped data like output files by round, usage stats.
+ * @example nestedMapToRecord(new Map([['run1', new Map([[1, 'v']])]])) // { run1: { 1: 'v' } }
+ */
+export function nestedMapToRecord<K1 extends string, K2 extends string | number, V>(
+  outer: Map<K1, Map<K2, V>>,
+): Record<string, Record<string, V>> {
+  return Object.fromEntries(
+    Array.from(outer.entries(), ([key, inner]) => [
+      key,
+      Object.fromEntries(inner.entries()),
+    ]),
+  ) as Record<string, Record<string, V>>;
+}
+
+/**
+ * Serialize a deeply nested Map (stream → run → round → value).
+ * Used for missing outputs tracking which is keyed by stream, then run, then round.
+ */
+export function tripleNestedMapToRecord<
+  K1 extends string,
+  K2 extends string,
+  K3 extends string | number,
+  V,
+>(
+  outer: Map<K1, Map<K2, Map<K3, V>>>,
+): Record<string, Record<string, Record<string, V>>> {
+  return Object.fromEntries(
+    Array.from(outer.entries(), ([stream, runs]) => [
+      stream,
+      Object.fromEntries(
+        Array.from(runs.entries(), ([runId, rounds]) => [
+          runId,
+          Object.fromEntries(rounds.entries()),
+        ]),
+      ),
+    ]),
+  ) as Record<string, Record<string, Record<string, V>>>;
+}

--- a/src/progressView/state/ProgressViewState.ts
+++ b/src/progressView/state/ProgressViewState.ts
@@ -34,6 +34,7 @@ import {
   RunInstructionManager,
 } from '@progressView/managers';
 import type { StateStorage } from '@progressView/persistence/PersistentMapManager';
+import { mapToRecord } from '@progressView/persistence/serializationUtils';
 import { getConfig } from '@utils/config';
 import type { TodoItem } from '@eventBus/schemas';
 
@@ -405,7 +406,7 @@ export class ProgressViewState {
   }
 
   private saveActiveRunIds(): void {
-    const serialized = Object.fromEntries(this._activeRunIds.entries());
+    const serialized = mapToRecord(this._activeRunIds);
     void this.storage.update(WorkspaceStateKey.ACTIVE_RUN_IDS, serialized);
   }
 
@@ -753,7 +754,7 @@ export class ProgressViewState {
    * Save execution IDs to persistence
    */
   private saveExecutionIds(): void {
-    const executionIdsObj = Object.fromEntries(this._executionIds.entries());
+    const executionIdsObj = mapToRecord(this._executionIds);
     void this.storage.update(WorkspaceStateKey.EXECUTION_IDS, executionIdsObj);
   }
 


### PR DESCRIPTION
ResponseCycleFlow was hardcoded to disable output streaming (false),
while ToolUseCycleFlow had it enabled (true). This inconsistency
prevented streaming log updates from being emitted to the progress
view during normal response cycles, causing users to only see a
task group timer without real-time content updates.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Focuses on safer serialization and more efficient UI updates, plus clearer response logging.
> 
> - Adds `serializationUtils` (`mapToRecord`, `nestedMapToRecord`, `tripleNestedMapToRecord`) and replaces ad-hoc `Object.fromEntries` across managers (outputs, instructions, task groups, usage, state)
> - Refactors `ProgressEventHandler.refreshStreamSurface` to return `activeRunId`, avoids duplicate run resolution, and simplifies missing-output/file payload building
> - Improves stream status updates: targeted vs full refresh logic via `mightAffectTabOrder`; coordinated `updateAll` + `refreshStreamSurface` ordering; initialization path for early task-group events
> - Updates `StreamStatusEvents` to use returned run ID when sending instruction updates; cleans up filter handling in `setTaskState`
> - Removes unused `updateLogContent` from `ProgressViewProvider`; minor webview update flow tweaks
> - In `ResponseCycleFlow`, captures current `groupId` and includes it in THINKING/SCRATCHPAD logs for correct grouping
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c1b04942a27769a331e222a78b2c20777cc047bd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->