### PR TITLE
fix: show response usage for tool-use sessions

### DIFF
--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -360,13 +360,15 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     state.clearActiveRun(message.stream);
     logContent.innerHTML = '';
     const groups = message.groups || [];
+
+    // Always update run metadata (instructions, usage, files) regardless of groups
+    // Tool-use sessions don't create task groups but still have usage data
+    this._updateRunMetadata(message.stream, message);
+
     if (groups.length > 0) {
       const parentGroups = groups.filter((g) => !g.parentGroupId);
       dom.runSelector.setRuns(parentGroups);
       dom.taskGroups.renderInitial(groups);
-
-      // Update run metadata using shared helper
-      this._updateRunMetadata(message.stream, message);
 
       if (parentGroups.length > 0) {
         const runIds = parentGroups.map((group) => group.id);


### PR DESCRIPTION
The _updateRunMetadata call was only happening inside the
`if (groups.length > 0)` block. Since tool-use sessions don't
create task groups (no stages/rounds), this code path was skipped
and usage data from the message was never stored in frontend state.

Moved _updateRunMetadata outside the conditional so it's always
called regardless of whether there are task groups. This ensures
instructions, usage stats, and output files are properly stored
for all session types.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes missing response usage (and other run-scoped data) for tool-use sessions.
> 
> - Moves `this._updateRunMetadata(stream, message)` in `handleUpdateLogs` outside the `groups.length > 0` check so run metadata (`runInstructions`, `runUsage`, `runFiles`) is always stored during full rebuilds
> - No UI flow changes; subsequent refresh calls (`_refreshInstructionForActiveRun`, `_refreshOutputsForActiveRun`, `_refreshUsageForActiveRun`) remain the same
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5846183bff037afd79a220a4f0d2fc6d89fa33f2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->