### PR TITLE
fix: restore waiting streams detection from ExecutionKVStore

### DIFF
--- a/src/agent/implementations/flows/reflection/runReflectionFlow.ts
+++ b/src/agent/implementations/flows/reflection/runReflectionFlow.ts
@@ -310,6 +310,16 @@ export async function runReflectionFlow<C = unknown>(
     status = END_GROUP_STATUS.ERROR;
     throw error;
   } finally {
+    // Clean up flow record on completion.
+    // When VS Code reloads mid-execution, this block never runs, preserving
+    // the record for sessions that were genuinely interrupted mid-wait.
+    try {
+      const kv = getExecutionStore(executionContext.executionId);
+      await kv.delete(`flow:${executionContext.executionId}`);
+    } catch {
+      // Ignore cleanup errors - non-critical
+    }
+
     // Round stages are finalized by RoundPersistedFlow - no need to end them here
 
     // Finalize run stage if we created it internally.

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -165,6 +165,16 @@ export async function runToolUseFlow<C = unknown>(
     status = END_GROUP_STATUS.ERROR;
     throw error;
   } finally {
+    // Clean up flow record on completion.
+    // When VS Code reloads mid-execution, this block never runs, preserving
+    // the record for sessions that were genuinely interrupted mid-wait.
+    try {
+      const kv = getExecutionStore(input.executionContext.executionId);
+      await kv.delete(`flow:${input.executionContext.executionId}`);
+    } catch {
+      // Ignore cleanup errors - non-critical
+    }
+
     // Cleanup (PersistedFlow handles state cleanup automatically)
     flowContext.dispose();
 

--- a/src/agent/storage/detectWaitingStreams.ts
+++ b/src/agent/storage/detectWaitingStreams.ts
@@ -1,0 +1,40 @@
+/**
+ * Detect waiting streams from persisted flow data.
+ *
+ * On extension startup, scans ExecutionKVStore for persisted tool-use flows
+ * that were interrupted mid-session. These streams should be marked as WAITING
+ * so users can send follow-ups and resume them.
+ */
+
+import type { ExecutionId, StreamTabId } from '@agent/types/IdentifierTypes';
+import type { FlowRecord } from '@agent/node/persisted-flow';
+
+import { getExecutionStore } from './ExecutionKVStore';
+
+/**
+ * Detect streams that have persisted flow state and should be marked as WAITING.
+ *
+ * @param executionIdMap - Map of streamTabId to executionId from ProgressViewState
+ * @returns Set of streamIds that have persisted flows (should be marked WAITING)
+ */
+export async function detectWaitingStreams(
+  executionIdMap: Map<StreamTabId, ExecutionId>,
+): Promise<Set<StreamTabId>> {
+  const waitingStreams = new Set<StreamTabId>();
+
+  for (const [streamId, executionId] of executionIdMap) {
+    try {
+      const kv = getExecutionStore(executionId);
+      const flowRecord = await kv.read<FlowRecord>(`flow:${executionId}`);
+
+      // If a flow record exists, this stream was mid-session and should be WAITING
+      if (flowRecord?.shared) {
+        waitingStreams.add(streamId);
+      }
+    } catch {
+      // Ignore errors - stream won't be marked as waiting
+    }
+  }
+
+  return waitingStreams;
+}

--- a/src/agent/storage/detectWaitingStreams.ts
+++ b/src/agent/storage/detectWaitingStreams.ts
@@ -14,11 +14,15 @@ import { getExecutionStore } from './ExecutionKVStore';
 /**
  * Detect streams that have persisted flow state and should be marked as WAITING.
  *
+ * A stream is considered "waiting" if it has a persisted flow record, which only
+ * happens when VS Code reloads mid-execution (the finally block in runToolUseFlow
+ * deletes the record on normal completion).
+ *
  * @param executionIdMap - Map of streamTabId to executionId from ProgressViewState
  * @returns Set of streamIds that have persisted flows (should be marked WAITING)
  */
 export async function detectWaitingStreams(
-  executionIdMap: Map<StreamTabId, ExecutionId>,
+  executionIdMap: ReadonlyMap<StreamTabId, ExecutionId>,
 ): Promise<Set<StreamTabId>> {
   const waitingStreams = new Set<StreamTabId>();
 

--- a/src/agent/storage/index.ts
+++ b/src/agent/storage/index.ts
@@ -5,3 +5,4 @@
  */
 
 export { type ExecutionKVStore, getExecutionStore } from './ExecutionKVStore';
+export { detectWaitingStreams } from './detectWaitingStreams';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,6 +6,9 @@ import * as vscode from 'vscode';
 import dotenv from 'dotenv';
 
 // Local imports - core
+import { detectWaitingStreams } from '@agent/storage';
+import { StreamStatusService } from '@agent/runtime/StreamStatusService';
+import { STREAM_STATUS } from '@common/constants/streamStatus';
 import { toErrorMessage } from '@common/errors/errorHandlingUtils';
 import { initializeStateManagers } from '@common/state/stateManager';
 import { SecretManager } from '@frontend/secretManager';
@@ -201,12 +204,27 @@ export async function activate(context: vscode.ExtensionContext) {
   const progressViewProvider = new ProgressViewProvider(context);
   await progressViewProvider.initialize();
 
-  // PersistedFlow handles state persistence automatically.
-  // Waiting streams detection will be restored from ExecutionKVStore in future.
-  const waitingStreams = new Set<string>();
+  // Detect streams with persisted flows that should be marked as WAITING.
+  // This allows users to send follow-ups and resume interrupted sessions.
+  const executionIdMap = progressViewProvider.state.getAllExecutionIds();
+  const waitingStreams = await detectWaitingStreams(
+    executionIdMap as Map<string, string>,
+  );
+
+  // Set StreamStatusService status for waiting streams.
+  // This enables the follow-up queuing mechanism in ToolUseFollowUp.
+  for (const streamId of waitingStreams) {
+    StreamStatusService.set(streamId, STREAM_STATUS.WAITING);
+  }
 
   // Log activation message to ensure the logger is working correctly
   logger.info('extension', 'TeXRA extension activated');
+  if (waitingStreams.size > 0) {
+    logger.debug(
+      'extension',
+      `Detected ${waitingStreams.size} waiting stream(s) with persisted flows`,
+    );
+  }
 
   // Clean up any tasks that were left in "running" state from previous session
   await progressViewProvider.cleanupTasksAfterRestart(waitingStreams);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -207,12 +207,12 @@ export async function activate(context: vscode.ExtensionContext) {
   // Detect streams with persisted flows that should be marked as WAITING.
   // This allows users to send follow-ups and resume interrupted sessions.
   const executionIdMap = progressViewProvider.state.getAllExecutionIds();
-  const waitingStreams = await detectWaitingStreams(
-    executionIdMap as Map<string, string>,
-  );
+  const waitingStreams = await detectWaitingStreams(executionIdMap);
 
-  // Set StreamStatusService status for waiting streams.
-  // This enables the follow-up queuing mechanism in ToolUseFollowUp.
+  // Set backend runtime status for waiting streams.
+  // StreamStatusService is used by ToolUseFollowUp to determine if follow-ups
+  // can be queued for a stream. This is separate from the UI state managed by
+  // ProgressEventHandler._streamStatus (updated via cleanupTasksAfterRestart).
   for (const streamId of waitingStreams) {
     StreamStatusService.set(streamId, STREAM_STATUS.WAITING);
   }
@@ -226,7 +226,10 @@ export async function activate(context: vscode.ExtensionContext) {
     );
   }
 
-  // Clean up any tasks that were left in "running" state from previous session
+  // Clean up UI state: mark running streams as ERROR (or WAITING if in waitingStreams).
+  // This only affects streams that were RUNNING in the UI state, which won't include
+  // any streams on a fresh restart. The StreamStatusService.set() above handles the
+  // backend status for all waiting streams regardless of prior UI state.
   await progressViewProvider.cleanupTasksAfterRestart(waitingStreams);
 
   // Configure LaTeX settings if LaTeX Workshop is installed

--- a/src/progressView/state/ProgressViewState.ts
+++ b/src/progressView/state/ProgressViewState.ts
@@ -500,6 +500,14 @@ export class ProgressViewState {
     return this._executionIds.get(streamTabId);
   }
 
+  /**
+   * Get all execution IDs as a read-only Map.
+   * Used for detecting waiting streams from persisted flows on startup.
+   */
+  getAllExecutionIds(): ReadonlyMap<StreamTabId, ExecutionId> {
+    return this._executionIds;
+  }
+
   clearExecutionId(streamTabId: StreamTabId): void {
     this._executionIds.delete(streamTabId);
     this.saveExecutionIds();


### PR DESCRIPTION
Fixes regression introduced in aa98b99 where the legacy tool-use
persistence layer was removed but waiting streams detection was not
restored from ExecutionKVStore as planned.

Changes:
- Add detectWaitingStreams() function to scan ExecutionKVStore for
  persisted tool-use flows on extension startup
- Export getAllExecutionIds() from ProgressViewState to provide
  stream → executionId mapping for detection
- Set StreamStatusService status to WAITING for detected streams,
  enabling the follow-up queuing mechanism in ToolUseFollowUp
- Pass detected waiting streams to cleanupTasksAfterRestart() so
  UI state is also correctly set to WAITING

This allows users to send follow-up messages to tool-use sessions
that were interrupted by VS Code reload/restart, which will be
queued and processed when the session is resumed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Restores waiting-stream recovery and ensures persisted flow cleanup.
> 
> - Add `detectWaitingStreams()` to scan `ExecutionKVStore` for `flow:<executionId>` records and export it from `@agent/storage`
> - Use detection in `extension.ts` to set `StreamStatusService` to `WAITING` and pass streams to `cleanupTasksAfterRestart`; add debug logging
> - Expose `getAllExecutionIds()` from `ProgressViewState` to provide stream → executionId mapping
> - Add `finally`-block cleanup in `runToolUseFlow` and `runReflectionFlow` to `delete` `flow:<executionId>` on normal completion (records persist only if VS Code reloads mid-execution)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 453235a36e3ca426ec51f9c75d907884e1fbcd10. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->