### PR TITLE
Investigate logging and streaming system architecture

### DIFF
--- a/src/logger/logUtils.ts
+++ b/src/logger/logUtils.ts
@@ -183,7 +183,10 @@ export function endGroup(
   isAgent = false,
 ): void {
   const transport = getTransport(channel, isAgent);
-  transport?.endGroup(groupId, status);
+  const context = getContext(channel, isAgent);
+  // Parent is second-to-last in stack (current group is last)
+  const parentGroupId = context?.stack.at(-2);
+  transport?.endGroup(groupId, status, parentGroupId);
   popGroupContext(channel, groupId, isAgent);
 }
 

--- a/src/logger/transports/VSCodeTransport.ts
+++ b/src/logger/transports/VSCodeTransport.ts
@@ -2,7 +2,6 @@
 import * as vscode from 'vscode';
 import Transport from 'winston-transport';
 
-import type { TaskGroupStatus } from '@common/constants/streamStatus';
 // Local imports - logger
 import { getColorForLevel, serializeLogData } from '@logger/utils';
 import type { EndGroupStatus } from '@logger/messageTypes';
@@ -22,22 +21,12 @@ interface VSCodeTransportOptions extends Transport.TransportStreamOptions {
   includeStructuredData?: () => boolean;
 }
 
-interface TransportGroup {
-  id: string;
-  name: string;
-  startTime: number;
-  status: TaskGroupStatus;
-  parentGroupId?: string;
-  endTime?: number;
-}
-
 export class VSCodeTransport extends Transport {
   private readonly channel: vscode.OutputChannel;
   private readonly streamName: string;
   private readonly sink?: LogEventSink;
   private readonly isAgentChannel: boolean;
   private readonly includeStructuredData?: () => boolean;
-  private readonly groups = new Map<string, TransportGroup>();
   private activeGroupId?: string;
 
   constructor(options: VSCodeTransportOptions) {
@@ -69,46 +58,26 @@ export class VSCodeTransport extends Transport {
   }
 
   startGroup(groupName: string, id: string, parentGroupId?: string): string {
-    const now = Date.now();
-    const group: TransportGroup = {
-      id,
-      name: groupName,
-      startTime: now,
-      status: 'running',
-      parentGroupId,
-    };
-    this.groups.set(id, group);
     this.activeGroupId = id;
-
     this.emitGroupStarted({
       stream: this.streamName,
       groupId: id,
       groupName,
-      startTime: now,
+      startTime: Date.now(),
       parentGroupId,
     });
-
     return id;
   }
 
-  endGroup(groupId: string, status: EndGroupStatus): void {
-    const group = this.groups.get(groupId);
-    if (!group) {
-      return;
-    }
-
-    group.endTime = Date.now();
-    group.status = status;
-
+  endGroup(groupId: string, status: EndGroupStatus, parentGroupId?: string): void {
     this.emitGroupFinished({
       stream: this.streamName,
       groupId,
       status,
-      endTime: group.endTime,
+      endTime: Date.now(),
     });
-
     if (this.activeGroupId === groupId) {
-      this.activeGroupId = group.parentGroupId;
+      this.activeGroupId = parentGroupId;
     }
   }
 
@@ -117,9 +86,7 @@ export class VSCodeTransport extends Transport {
   }
 
   setActiveGroupId(groupId: string | undefined): void {
-    if (groupId === undefined || this.groups.has(groupId)) {
-      this.activeGroupId = groupId;
-    }
+    this.activeGroupId = groupId;
   }
 
   private writeToChannel(

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -395,9 +395,11 @@ export class ProgressEventHandler {
     this.state.activeStream = stream;
 
     if (this.webviewUpdater.isAvailable()) {
-      // Force rebuild to clear any previous stream's content. The new task
-      // group must be added to state BEFORE this call (in TaskGroupEvents)
-      // so UPDATE_LOGS includes it and the frontend renders it correctly.
+      // Send UPDATE_STREAMS first to create the tab in frontend
+      this.webviewUpdater.updateAll(this.state, this._streamStatus);
+      // Then send UPDATE_LOGS with content. The new task group must be
+      // added to state BEFORE this call (in TaskGroupEvents) so UPDATE_LOGS
+      // includes it and the frontend renders it correctly.
       this.refreshStreamSurface(stream, {
         updateInstruction: false,
         forceRebuild: true,

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -79,6 +79,7 @@ export class ProgressEventHandler {
       withErrorBoundary: createErrorBoundary(this.logger, 'StreamStatusEvents'),
       streamStatus: this._streamStatus,
       setStreamStatus: this.setStreamStatus.bind(this),
+      updateStreamStatusWithUI: this.updateStreamStatusWithUI.bind(this),
       sendInstructionUpdate: this.sendInstructionUpdate.bind(this),
       refreshStreamSurface: this.refreshStreamSurface.bind(this),
       warnLog: this.logger.warn.bind(this.logger),
@@ -304,38 +305,42 @@ export class ProgressEventHandler {
   }
 
   /**
-   * Set the status for a specific stream synchronously.
+   * Set the status for a specific stream. Only updates the map.
+   * Callers are responsible for triggering any needed UI updates.
    */
   setStreamStatus(stream: string, status: StreamStatus): void {
-    // Update the persistent status map first
     if (status === STREAM_STATUS.READY) {
       this._streamStatus.delete(stream);
     } else {
       this._streamStatus.set(stream, status);
     }
+  }
 
-    if (this.webviewUpdater.isAvailable()) {
-      // When sorted by time, status changes may affect tab order (due to new log entries),
-      // so we need a full refresh. Otherwise use efficient targeted update.
-      const needsFullRefresh =
-        !this.state.streamTabs.has(stream) ||
-        this.state.streamSortOrder === 'time';
+  /**
+   * Update stream status and send targeted UI update.
+   * Use this for status-only changes (not full stream switches).
+   */
+  updateStreamStatusWithUI(stream: string, status: StreamStatus): void {
+    this.setStreamStatus(stream, status);
 
-      if (needsFullRefresh) {
-        // Include current status in refresh map so frontend displays it correctly.
-        // READY is deleted from _streamStatus but should still be shown to user.
-        const statusesForRefresh = new Map(this._streamStatus);
-        statusesForRefresh.set(stream, status);
-        this.webviewUpdater.updateAll(this.state, statusesForRefresh);
-      } else {
-        // Targeted update - frontend handles main status update via handleUpdateStreamStatus
-        const logs = this.state.streamTabs.getMessages(stream);
-        // Note: lastTimestamp may be undefined if logs exist but last entry has no timestamp.
-        // Frontend guards against invalid timestamps (0, undefined) with lastTimestamp > 0 check.
-        const lastTimestamp =
-          logs.length > 0 ? logs.at(-1)?.timestamp : undefined;
-        this.webviewUpdater.updateStreamStatus(stream, status, lastTimestamp);
-      }
+    if (!this.webviewUpdater.isAvailable()) {
+      return;
+    }
+
+    // When sorted by time, status changes may affect tab order,
+    // so we need a full refresh. Otherwise use targeted update.
+    if (
+      !this.state.streamTabs.has(stream) ||
+      this.state.streamSortOrder === 'time'
+    ) {
+      const statusesForRefresh = new Map(this._streamStatus);
+      statusesForRefresh.set(stream, status);
+      this.webviewUpdater.updateAll(this.state, statusesForRefresh);
+    } else {
+      const logs = this.state.streamTabs.getMessages(stream);
+      const lastTimestamp =
+        logs.length > 0 ? logs.at(-1)?.timestamp : undefined;
+      this.webviewUpdater.updateStreamStatus(stream, status, lastTimestamp);
     }
   }
 
@@ -371,11 +376,10 @@ export class ProgressEventHandler {
    * status or activation events, preserving any existing status metadata.
    */
   private async initializeStreamForTaskGroup(stream: string): Promise<void> {
-    const existingStatus = this._streamStatus.get(stream);
-
     await this.state.streamTabs.ensureStream(stream);
 
-    if (!existingStatus) {
+    // Set status if not already set
+    if (!this._streamStatus.has(stream)) {
       this.setStreamStatus(stream, STREAM_STATUS.RUNNING);
     }
 
@@ -389,9 +393,6 @@ export class ProgressEventHandler {
     }
 
     this.state.activeStream = stream;
-
-    const status = this._streamStatus.get(stream) ?? STREAM_STATUS.RUNNING;
-    this.setStreamStatus(stream, status);
 
     if (this.webviewUpdater.isAvailable()) {
       // Force rebuild to clear any previous stream's content. The new task

--- a/src/progressView/events/StreamStatusEvents.ts
+++ b/src/progressView/events/StreamStatusEvents.ts
@@ -27,7 +27,10 @@ import type {
  */
 export interface StreamStatusEventShared extends BaseEventShared {
   streamStatus: Map<string, StreamStatus>;
+  /** Updates status map only. Use for complex flows that handle their own UI updates. */
   setStreamStatus(stream: string, status: StreamStatus): void;
+  /** Updates status map AND sends UI update. Use for standalone status changes. */
+  updateStreamStatusWithUI(stream: string, status: StreamStatus): void;
   sendInstructionUpdate(stream: StreamTabId | '', runId?: string | null): void;
   refreshStreamSurface(
     stream: string,
@@ -180,7 +183,7 @@ export function createStreamStatusEvents(
         new vscode.Disposable(
           bus.on('updateStreamStatus', (payload) =>
             withErrorBoundary('failed to handle updateStreamStatus', () =>
-              shared.setStreamStatus(payload.stream, payload.status),
+              shared.updateStreamStatusWithUI(payload.stream, payload.status),
             ),
           ),
         ),

--- a/src/progressView/events/StreamStatusEvents.ts
+++ b/src/progressView/events/StreamStatusEvents.ts
@@ -90,22 +90,12 @@ export function createStreamStatusEvents(
     const status: StreamStatus =
       shared.streamStatus.get(stream) ?? STREAM_STATUS.RUNNING;
 
-    if (updater.isAvailable()) {
-      // ORDERING REQUIREMENTS:
-      // 1. ensureStream (line 70) must be awaited BEFORE this block to ensure
-      //    backend state.streamTabs.has(stream) returns true in setStreamStatus.
-      // 2. updateAll sends UPDATE_STREAMS which creates the frontend tab.
-      // 3. setStreamStatus sends UPDATE_STREAM_STATUS to update the existing tab.
-      // Frontend processes messages FIFO, so tab exists before status update.
-      // If setStreamStatus is called before stream is in backend state, it will
-      // trigger another full updateAll, which is inefficient but safe.
-      updater.updateAll(state, shared.streamStatus);
-    }
-
+    // Update status map (no UI side effects)
     shared.setStreamStatus(stream, status);
 
     if (updater.isAvailable()) {
-      // Only force rebuild when actually switching streams
+      // Update tab list, then content
+      updater.updateAll(state, shared.streamStatus);
       shared.refreshStreamSurface(stream, {
         updateInstruction: false,
         forceRebuild: isStreamSwitch,

--- a/src/progressView/events/TaskGroupEvents.ts
+++ b/src/progressView/events/TaskGroupEvents.ts
@@ -81,16 +81,13 @@ export function createTaskGroupEvents(
       if (!hasStream) {
         debugLog(`Creating stream from addTaskGroup: ${stream}`);
         // Initialize stream after group is in state. This sends UPDATE_LOGS
-        // with forceRebuild: true, which will include the new group.
+        // with forceRebuild: true, which includes the new group.
         await shared.initializeStreamForTaskGroup(stream);
-      }
-
-      // Send ADD_TASK_GROUP to frontend for immediate rendering.
-      // Always send when updater is available - the frontend will handle
-      // the message correctly once activeStream is set by UPDATE_STREAMS.
-      // This fixes a race condition where setActiveStream creates the stream
-      // but hasn't set activeStream yet when addTaskGroup is processed.
-      if (updater.isAvailable()) {
+        // No separate addTaskGroup needed - group is in UPDATE_LOGS
+      } else if (updater.isAvailable()) {
+        // Stream exists - send incremental update.
+        // Handles race where setActiveStream created stream but addTaskGroup
+        // arrives before activeStream is set.
         updater.addTaskGroup(stream, group);
       }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> - **Logger/transport changes**: `endGroup` now passes `parentGroupId` from context; `VSCodeTransport` drops internal group map/state, emits start/end with `Date.now()` and updates `activeGroupId` via provided `parentGroupId`.
> - **Progress view status handling**: Split `setStreamStatus` (map-only) from `updateStreamStatusWithUI` (map + targeted UI). `StreamStatusEvents` uses map-only on activation and UI update on `updateStreamStatus`.
> - **Stream/task group init**: `initializeStreamForTaskGroup` ensures stream, sets default RUNNING if missing, then `updateAll` before `refreshStreamSurface`. `TaskGroupEvents` now relies on `UPDATE_LOGS` to include newly added groups on first creation; otherwise sends incremental `addTaskGroup`. Addresses ordering/race issues when creating streams and updating tabs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ad0c49e6552e9c3796dcd2523adf0c2d4b60a20e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->