### PR TITLE
Fix softlink relative path resolution issue

### DIFF
--- a/src/frontend/files/listing.ts
+++ b/src/frontend/files/listing.ts
@@ -1,4 +1,5 @@
 // Standard library imports
+import * as fs from 'fs';
 import * as path from 'path';
 
 // Third-party imports
@@ -32,6 +33,23 @@ function containsHiddenSegment(relativePath: string): boolean {
   return relativePath
     .split(path.sep)
     .some((segment) => segment.startsWith('.') && segment.length > 1);
+}
+
+/**
+ * Compute relative path with symlink awareness.
+ * Uses real paths to avoid incorrect `../../../...` results when
+ * either path contains a symlink.
+ */
+function safeRelativePath(from: string, to: string): string {
+  try {
+    // Resolve symlinks in both paths before computing relative
+    const realFrom = fs.realpathSync(from);
+    const realTo = fs.realpathSync(to);
+    return path.relative(realFrom, realTo);
+  } catch {
+    // Fallback to direct comparison if realpath fails (e.g., file doesn't exist)
+    return path.relative(from, to);
+  }
 }
 
 function containsExcludedDirectory(
@@ -104,7 +122,7 @@ export async function getFilesInDirectory(
   return files
     .filter((uri) => {
       // Check if the file is inside an excluded directory (for symlinks, case-insensitive)
-      const relativePath = path.relative(dir, uri.fsPath);
+      const relativePath = safeRelativePath(dir, uri.fsPath);
       return !containsExcludedDirectory(relativePath, filters.excludeDirs);
     })
     .map((uri) => path.basename(uri.fsPath))
@@ -142,7 +160,7 @@ export async function getFilesRecursively(
   );
 
   return files
-    .map((uri) => path.relative(root, uri.fsPath))
+    .map((uri) => safeRelativePath(root, uri.fsPath))
     .filter((relativePath) => {
       if (!relativePath) {
         return false;

--- a/src/frontend/files/listing.ts
+++ b/src/frontend/files/listing.ts
@@ -1,5 +1,4 @@
 // Standard library imports
-import * as fs from 'fs';
 import * as path from 'path';
 
 // Third-party imports
@@ -36,20 +35,14 @@ function containsHiddenSegment(relativePath: string): boolean {
 }
 
 /**
- * Compute relative path with symlink awareness.
- * Uses real paths to avoid incorrect `../../../...` results when
- * either path contains a symlink.
+ * Get workspace-relative path, preserving symlink structure.
+ * Falls back to path.relative() for non-workspace paths.
  */
-function safeRelativePath(from: string, to: string): string {
-  try {
-    // Resolve symlinks in both paths before computing relative
-    const realFrom = fs.realpathSync(from);
-    const realTo = fs.realpathSync(to);
-    return path.relative(realFrom, realTo);
-  } catch {
-    // Fallback to direct comparison if realpath fails (e.g., file doesn't exist)
-    return path.relative(from, to);
-  }
+function getWorkspaceRelativePath(absolutePath: string): string {
+  // asRelativePath preserves symlink paths within workspace
+  const relative = vscode.workspace.asRelativePath(absolutePath, false);
+  // asRelativePath returns the original if outside workspace
+  return relative !== absolutePath ? relative : path.basename(absolutePath);
 }
 
 function containsExcludedDirectory(
@@ -122,7 +115,7 @@ export async function getFilesInDirectory(
   return files
     .filter((uri) => {
       // Check if the file is inside an excluded directory (for symlinks, case-insensitive)
-      const relativePath = safeRelativePath(dir, uri.fsPath);
+      const relativePath = getWorkspaceRelativePath(uri.fsPath);
       return !containsExcludedDirectory(relativePath, filters.excludeDirs);
     })
     .map((uri) => path.basename(uri.fsPath))
@@ -160,7 +153,7 @@ export async function getFilesRecursively(
   );
 
   return files
-    .map((uri) => safeRelativePath(root, uri.fsPath))
+    .map((uri) => getWorkspaceRelativePath(uri.fsPath))
     .filter((relativePath) => {
       if (!relativePath) {
         return false;

--- a/src/frontend/files/listing.ts
+++ b/src/frontend/files/listing.ts
@@ -29,27 +29,70 @@ function createExcludePattern(
 }
 
 function containsHiddenSegment(relativePath: string): boolean {
+  // Split on both separators for cross-platform compatibility
   return relativePath
-    .split(path.sep)
+    .split(/[/\\]/)
     .some((segment) => segment.startsWith('.') && segment.length > 1);
 }
 
 /**
- * Get workspace-relative path, preserving symlink structure.
- * Falls back to path.relative() for non-workspace paths.
+ * Get path relative to root, preserving symlink structure within workspace.
+ * Uses VS Code's asRelativePath for symlink awareness, then computes
+ * the path relative to the specified root.
+ *
+ * @param absolutePath - The absolute path to convert
+ * @param root - The base directory for relative path computation
+ * @returns Platform-native relative path
  */
-function getWorkspaceRelativePath(absolutePath: string): string {
-  // asRelativePath preserves symlink paths within workspace
-  const relative = vscode.workspace.asRelativePath(absolutePath, false);
-  // asRelativePath returns the original if outside workspace
-  return relative !== absolutePath ? relative : path.basename(absolutePath);
+function getRelativePathPreservingSymlinks(
+  absolutePath: string,
+  root: string,
+): string {
+  const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+
+  // Use asRelativePath for symlink awareness (returns forward slashes)
+  const wsRelative = vscode.workspace.asRelativePath(absolutePath, false);
+
+  // If outside workspace, asRelativePath returns the original absolute path
+  if (wsRelative === absolutePath) {
+    return path.relative(root, absolutePath);
+  }
+
+  // If root is the workspace root, return the workspace-relative path
+  if (workspaceRoot && path.normalize(root) === path.normalize(workspaceRoot)) {
+    // Normalize separators to platform-native
+    return wsRelative.split('/').join(path.sep);
+  }
+
+  // root is a subdirectory - compute path from workspace-relative path
+  // First get root relative to workspace
+  const rootRelative = vscode.workspace.asRelativePath(root, false);
+  if (rootRelative === root) {
+    // root is outside workspace, fall back to path.relative
+    return path.relative(root, absolutePath);
+  }
+
+  // Both paths are workspace-relative, compute relative path between them
+  // Normalize to forward slashes for consistent comparison
+  const wsRelativeNorm = wsRelative.split('\\').join('/');
+  const rootRelativeNorm = rootRelative.split('\\').join('/');
+
+  if (wsRelativeNorm.startsWith(rootRelativeNorm + '/')) {
+    // File is under root, strip the root prefix
+    const result = wsRelativeNorm.slice(rootRelativeNorm.length + 1);
+    return result.split('/').join(path.sep);
+  }
+
+  // File is not under root in workspace structure, use path.relative
+  return path.relative(root, absolutePath);
 }
 
 function containsExcludedDirectory(
   relativePath: string,
   normalizedExcludeDirs: string[],
 ): boolean {
-  const pathSegments = relativePath.split(path.sep).map((s) => s.toLowerCase());
+  // Split on both separators for cross-platform compatibility
+  const pathSegments = relativePath.split(/[/\\]/).map((s) => s.toLowerCase());
   return pathSegments.some((segment) =>
     normalizedExcludeDirs.includes(segment),
   );
@@ -114,8 +157,9 @@ export async function getFilesInDirectory(
 
   return files
     .filter((uri) => {
-      // Check if the file is inside an excluded directory (for symlinks, case-insensitive)
-      const relativePath = getWorkspaceRelativePath(uri.fsPath);
+      // For non-recursive search ('*'), relative path is just the filename.
+      // Use path.relative for filtering - symlink handling not needed here.
+      const relativePath = path.relative(dir, uri.fsPath);
       return !containsExcludedDirectory(relativePath, filters.excludeDirs);
     })
     .map((uri) => path.basename(uri.fsPath))
@@ -153,7 +197,7 @@ export async function getFilesRecursively(
   );
 
   return files
-    .map((uri) => getWorkspaceRelativePath(uri.fsPath))
+    .map((uri) => getRelativePathPreservingSymlinks(uri.fsPath, root))
     .filter((relativePath) => {
       if (!relativePath) {
         return false;


### PR DESCRIPTION
path.relative() produces incorrect `../../../...` results when paths contain symlinks because the resolved fsPath differs from the input directory. Use fs.realpathSync() on both paths before computing the relative path to handle symlinked workspaces correctly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves correctness of recursive file listing in symlinked workspaces and hardens path parsing across platforms.
> 
> - Add `getRelativePathPreservingSymlinks` using `vscode.workspace.asRelativePath` and fallback logic; apply it in `getFilesRecursively` instead of `path.relative(root, ...)` to maintain workspace/symlink structure
> - Make `containsHiddenSegment` and `containsExcludedDirectory` split on both `'/` and `\'` for cross-platform compatibility
> - Clarify non-recursive `getFilesInDirectory` filtering (filename-only) while continuing to use `path.relative`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 20a5c05471d8324d92ec39795d150ab4ebb4863a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->