### PR TITLE
Fix total usage panel visibility in tool use

### DIFF
--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -128,6 +128,25 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
   }
 
   /**
+   * Clear stale state when switching between session kinds.
+   * Different session kinds have incompatible task group structures:
+   * - Workflow sessions create hierarchical task groups
+   * - Tool-use sessions don't create task groups at all
+   * Stale groups from previous sessions interfere with run ID resolution.
+   * @param {string} newSessionKind - The new session kind being switched to
+   */
+  _clearSessionKindState(newSessionKind) {
+    if (newSessionKind !== state.activeSessionKind && state.activeSessionKind) {
+      state.taskGroups.clear();
+      dom.taskGroups.clear();
+      const logContent = document.getElementById(ELEMENT_IDS.LOG_CONTENT);
+      if (logContent) {
+        logContent.innerHTML = '';
+      }
+    }
+  }
+
+  /**
    * Update run-scoped metadata (instructions, usage, files) from message.
    * Shared by handleUpdateLogs and _handleIncrementalUpdate to avoid duplication.
    * @param {string} stream - The stream to update
@@ -284,6 +303,7 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       'workflow'; // Default fallback
     const isToolAgent = sessionKind === 'toolUse';
 
+    this._clearSessionKindState(sessionKind);
     state.activeSessionKind = sessionKind;
 
     dom.runSelector.setDisplayEnabled(
@@ -777,6 +797,7 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       message.sessionKind || state.activeSessionKind || 'workflow';
     const isToolUseAgent = sessionKind === 'toolUse';
 
+    this._clearSessionKindState(sessionKind);
     state.activeSessionKind = sessionKind;
 
     let activeRunId = state.getActiveRunId(activeStream);


### PR DESCRIPTION
The usage panel was not visible in tool-use sessions because _collectRunCandidates and _findLatestRunId used the global taskGroups map which may contain stale groups from workflow sessions. Since tool-use sessions never create task groups, this caused incorrect run ID resolution when workflow groups existed from previous sessions.

The fix skips task group lookup when activeSessionKind is 'toolUse', allowing the functions to correctly fall back to usage runs for determining the active run ID.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures correct run resolution and UI updates when switching between workflow and tool-use sessions.
> 
> - Add `_clearSessionKindState(newSessionKind)` to purge `state.taskGroups`, `dom.taskGroups`, and `LOG_CONTENT` when the session kind changes
> - Invoke clearing in `handleUpdateStreams` and `handleUpdateInstruction` before setting `state.activeSessionKind`, preventing stale workflow groups from affecting tool-use sessions (restores usage panel and output refresh)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 509592af8091da08a55c148d88ab8c6ea9e0a3bb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->