### PR TITLE
Remove summary from tool output section

### DIFF
--- a/src/progressView/modules/formatters/normalizers.js
+++ b/src/progressView/modules/formatters/normalizers.js
@@ -174,11 +174,25 @@ export const normalizeToolUseLog = (structured) => {
 
   const outputCandidate =
     parsed.output !== undefined ? parsed.output : outputDetails.output;
+
+  // Extract the actual output content, avoiding redundant nesting
+  // If outputCandidate is an object with an 'output' field, use that directly
+  let outputContent = outputCandidate;
+  if (
+    outputCandidate !== null &&
+    typeof outputCandidate === 'object' &&
+    !Array.isArray(outputCandidate)
+  ) {
+    const { summary: _unusedSummary, output, ...rest } = outputCandidate;
+    // Prefer the nested output field if it exists, otherwise use remaining fields
+    outputContent = output !== undefined ? output : rest;
+  }
+
   const outputText =
-    typeof outputCandidate === 'string'
-      ? outputCandidate
-      : outputCandidate !== undefined
-        ? stringifyForDisplay(outputCandidate)
+    typeof outputContent === 'string'
+      ? outputContent
+      : outputContent !== undefined
+        ? stringifyForDisplay(outputContent)
         : '';
 
   const toolName =


### PR DESCRIPTION
The summary field was being shown twice - once in the header and again in the stringified output YAML. Now the summary is stripped from the output object before stringification since it's already displayed in the header.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Fixes duplicate summary and redundant nesting in tool output display**
> 
> - Updates `normalizeToolUseLog` in `normalizers.js` to extract actual `output` content from nested objects, discard `summary`, and stringify the remaining output reliably
> - Continues deriving `headerSummary` from `summary` or `error`, while `outputText` now excludes `summary` to avoid duplication
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 994320b2d099cc252c59d60a69155792624abc5f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->