### PR TITLE
fix: enable resume and run-new for tool-use sessions

### DIFF
--- a/src/agent/toolUse/ToolUseFollowUp.ts
+++ b/src/agent/toolUse/ToolUseFollowUp.ts
@@ -37,11 +37,15 @@ export async function sendFollowUp(
   streamId: StreamTabId,
   text: string,
 ): Promise<void> {
+  logger.debug(`sendFollowUp called for stream: ${streamId}`);
+
   // Try active flow context first
   const flowContext = getToolUseFlowContext(streamId);
   if (flowContext) {
+    logger.debug(`Found active flow context for stream: ${streamId}`);
     try {
       flowContext.session.appendFollowUp(text);
+      logger.debug(`Follow-up appended successfully to stream: ${streamId}`);
     } catch (error) {
       logger.error('Failed to send follow-up to active session.', {
         data: error,
@@ -53,6 +57,8 @@ export async function sendFollowUp(
     return;
   }
 
+  logger.debug(`No active flow context found for stream: ${streamId}`);
+
   // Queue if session is resuming
   if (ToolUseFollowUpQueue.isResuming(streamId)) {
     if (ToolUseFollowUpQueue.enqueue(streamId, text)) {
@@ -63,6 +69,9 @@ export async function sendFollowUp(
 
   // Queue if session is waiting (paused, can be resumed)
   const status = StreamStatusService.get(streamId);
+  logger.debug(
+    `StreamStatusService status for ${streamId}: ${status ?? 'undefined'}`,
+  );
   if (status === STREAM_STATUS.WAITING) {
     // Ensure queue exists and enqueue
     ToolUseFollowUpQueue.acquire(streamId);
@@ -75,7 +84,9 @@ export async function sendFollowUp(
   }
 
   // No active/waiting session found - user can resume via UI command
-  logger.debug(`No active session found for follow-up on stream ${streamId}.`);
+  logger.warn(
+    `No active/waiting session found for follow-up on stream ${streamId}. Status: ${status ?? 'undefined'}`,
+  );
   void vscode.window.showWarningMessage(
     'No active tool-use session found. Use the Resume button to continue.',
   );

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -23,6 +23,7 @@ import { normalizeRunId } from '@common/constants/runIds';
 import { safeExecuteCommand } from '@frontend/system/commandUtils';
 import {
   isWorkflowTaskState,
+  isToolUseTaskState,
   type WorkflowTaskState,
   type TaskState,
 } from '@logger/TaskState';
@@ -206,31 +207,41 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
   }
 
   private async handleRunAgain(message: any): Promise<void> {
-    await this.withToolbarTaskState(message.stream, async (taskState) => {
-      const executionId = this.provider.state.getExecutionId(message.stream);
-      if (!executionId) {
-        this.logger.warn(
-          this.channel,
-          `Resume requested for ${message.stream} without an execution ID`,
-        );
-        return;
-      }
+    const taskState = this.provider.state.getTaskState(message.stream);
+    if (!taskState) {
+      return;
+    }
 
-      await safeExecuteCommand('texra.execute', [
-        {
-          config: taskState.agentConfig,
-          executionId,
-          stream: message.stream,
-          resume: true,
-        },
-      ]);
-    });
+    const executionId = this.provider.state.getExecutionId(message.stream);
+    if (!executionId) {
+      this.logger.warn(
+        this.channel,
+        `Resume requested for ${message.stream} without an execution ID`,
+      );
+      return;
+    }
+
+    // Handle both workflow and tool-use sessions
+    // Both task state types have agentConfig which is all we need for resume
+    await safeExecuteCommand('texra.execute', [
+      {
+        config: taskState.agentConfig,
+        executionId,
+        stream: message.stream,
+        resume: true,
+      },
+    ]);
   }
 
   private async handleRunNew(message: any): Promise<void> {
-    await this.withToolbarTaskState(message.stream, async (taskState) => {
-      await safeExecuteCommand('texra.execute', [taskState.agentConfig]);
-    });
+    const taskState = this.provider.state.getTaskState(message.stream);
+    if (!taskState) {
+      return;
+    }
+
+    // Handle both workflow and tool-use sessions
+    // Both task state types have agentConfig which is all we need to start new run
+    await safeExecuteCommand('texra.execute', [taskState.agentConfig]);
   }
 
   private async handleRetryStreamRequest(message: any): Promise<void> {

--- a/src/progressView/modules/uiManagers/FollowUpInputManager.js
+++ b/src/progressView/modules/uiManagers/FollowUpInputManager.js
@@ -89,7 +89,13 @@ export class FollowUpInputManager {
 
     const text = this.textarea.value.trim();
     const stream = progressViewState.activeStream;
-    if (!text || !stream) {
+    if (!text) {
+      return;
+    }
+    if (!stream) {
+      console.warn(
+        '[FollowUpInputManager] Cannot send follow-up: no active stream',
+      );
       return;
     }
 


### PR DESCRIPTION
The handleRunAgain and handleRunNew handlers were using
withToolbarTaskState which only accepted WorkflowTaskState.
This caused these handlers to silently return early for
tool-use sessions, preventing users from resuming or
re-running tool-use agents.

Changed both handlers to directly get the task state and
check for null, allowing them to work with both workflow
and tool-use task states (both have the required
agentConfig field).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> - **Fix resume/run-new for tool-use sessions**: `handleRunAgain` and `handleRunNew` now fetch the generic `taskState` and execute with `agentConfig`/`executionId`, enabling both workflow and tool-use streams to resume or start new runs.
> - **Better diagnostics for follow-ups**: `sendFollowUp` adds detailed debug/warn logs for active/queue/wait paths and logs stream status when no session is found.
> - **UI robustness**: `FollowUpInputManager` prevents sending empty messages and logs a warning when no active stream is present.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a20d37c9bc1db8fff7869779295725b4847c482e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->