### PR TITLE
docs: add logging and streaming architecture investigation

### DIFF
--- a/docs/LOGGING_STREAMING_ARCHITECTURE.md
+++ b/docs/LOGGING_STREAMING_ARCHITECTURE.md
@@ -155,10 +155,29 @@ const todos = state.getTodos(stream);
 | Stream not activated first | `59d84b5` | setActiveStream after Init |
 | Race in ensureStream | `da11dda` | Async timing with activeStream check |
 | Stale groups on session switch | `509592a` | Groups not cleared |
+| Groups dropped before activation | `87679a4` | addTaskGroup arrives before setActiveStream |
 
 ### Current Session Kind Switching
 
 Commit `509592a` clears task groups when switching between session kinds (workflow ↔ tool-use). This prevents stale groups but may cause Init groups from previous sessions to disappear when switching contexts.
+
+### Backend Buffering Solution (87679a4)
+
+When `addTaskGroup` arrives before `setActiveStream` for a stream, the group is now buffered in `ProgressEventHandler.pendingTaskGroups`. When `setActiveStream` is processed and `state.activeStream` is set, buffered groups are replayed via `replayPendingTaskGroups()`.
+
+```
+TaskGroupEvents.handleAddTaskGroup()
+    │
+    ├─ stream === state.activeStream?
+    │     ├─ YES: updater.addTaskGroup() immediately
+    │     └─ NO:  bufferTaskGroupForReplay(stream, group)
+    │
+StreamStatusEvents.handleSetActiveStream()
+    │
+    ├─ state.activeStream = stream
+    └─ replayPendingTaskGroups(stream, updater)
+          └─ sends buffered groups via updater.addTaskGroup()
+```
 
 ## Round Trip Analysis
 

--- a/docs/LOGGING_STREAMING_ARCHITECTURE.md
+++ b/docs/LOGGING_STREAMING_ARCHITECTURE.md
@@ -143,27 +143,43 @@ const todos = state.getTodos(stream);
 ### Init Group Creation
 
 1. `executeAgent()` starts agent execution
-2. `prepareFlowExecution()` emits `setActiveStream` (critical timing)
-3. `logger.stage('Init')` creates the Init group
+2. `prepareFlowExecution()` emits `setActiveStream` **BEFORE** Init stage
+3. `logger.stage('Init')` creates the Init group (now after setActiveStream)
 4. `ProgressViewSink.handleGroupStarted()` emits `addTaskGroup`
 5. `TaskGroupEvents` adds to state and sends to frontend
 
+The correct ordering is enforced in `prepareFlowExecution()` which emits
+`setActiveStream` before calling `logger.stage('Init')`. This ensures
+the frontend has `state.activeStream` set when `addTaskGroup` arrives.
+
 ### Historical Init Group Issues (FIXED)
 
-| Issue | Commit | Root Cause |
-|-------|--------|------------|
-| Stream not activated first | `59d84b5` | setActiveStream after Init |
-| Race in ensureStream | `da11dda` | Async timing with activeStream check |
-| Stale groups on session switch | `509592a` | Groups not cleared |
-| Groups dropped before activation | `87679a4` | addTaskGroup arrives before setActiveStream |
+| Issue | Commit | Root Cause | Fix |
+|-------|--------|------------|-----|
+| Stream not activated first | `59d84b5` | setActiveStream after Init | Moved emission order |
+| Race in ensureStream | `da11dda` | Async timing with activeStream check | Await ensureStream |
+| Stale groups on session switch | `509592a` | Groups not cleared | Clear on switch |
+| Groups dropped before activation | `87679a4` | addTaskGroup before setActiveStream | Backend buffering |
+| Source ordering incorrect | (latest) | prepareFlowExecution order | Emit before Init |
 
 ### Current Session Kind Switching
 
 Commit `509592a` clears task groups when switching between session kinds (workflow ↔ tool-use). This prevents stale groups but may cause Init groups from previous sessions to disappear when switching contexts.
 
-### Backend Buffering Solution (87679a4)
+### Source Order Fix (executeAgent.ts)
 
-When `addTaskGroup` arrives before `setActiveStream` for a stream, the group is now buffered in `ProgressEventHandler.pendingTaskGroups`. When `setActiveStream` is processed and `state.activeStream` is set, buffered groups are replayed via `replayPendingTaskGroups()`.
+The root cause fix: `prepareFlowExecution()` now emits `setActiveStream` before
+creating the Init stage. The `setupFlowUIState()` helper only sets stream status
+(no longer emits setActiveStream to avoid duplicate emissions).
+
+For resume scenarios, `streamTabIdOverride` option ensures the snapshot's stream
+ID is used instead of the regenerated one.
+
+### Backend Buffering Safety Net (87679a4)
+
+As a safety net for edge cases, when `addTaskGroup` arrives before `setActiveStream`
+for a stream, the group is buffered in `ProgressEventHandler.pendingTaskGroups`.
+When `setActiveStream` is processed, buffered groups are replayed.
 
 ```
 TaskGroupEvents.handleAddTaskGroup()

--- a/docs/LOGGING_STREAMING_ARCHITECTURE.md
+++ b/docs/LOGGING_STREAMING_ARCHITECTURE.md
@@ -1,0 +1,219 @@
+# Logging & Streaming Architecture Investigation
+
+> Investigation Date: 2026-01-03
+> Branch: claude/investigate-logging-streaming-cWNQJ
+
+## Overview
+
+This document captures the architecture analysis of TeXRA's logging and streaming systems, identifying complexity, round trips, and spaghetti patterns.
+
+## Key Components
+
+### Logging Pipeline
+
+```
+AgentLogger
+    │
+    ├─ createStream() ──────────────────────┐
+    │  (Direct bus.emit)                    │
+    │                                       │
+    └─ info/debug/warn/error                │
+           │                                │
+           ▼                                │
+       logUtils.ts                          │
+           │                                │
+           ▼                                │
+    LogChannelRegistry                      │
+           │                                │
+           ▼                                │
+    winston.Logger                          │
+           │                                │
+           ▼                                │
+    VSCodeTransport                         │
+    ├─ writeToChannel() ──► OutputChannel   │
+    └─ sink?.handleLogMessage()             │
+              │                             │
+              ▼                             │
+       ProgressViewSink                     │
+              │                             │
+              ▼                             │
+       bus.emit('addLogMessage') ◄──────────┘
+              │
+              ▼
+       ProgressEventBus
+              │
+              ▼
+       ProgressEventHandler
+              │
+              ▼
+       WebviewUpdater ──► Frontend
+```
+
+### Stream Status Flow
+
+```
+StreamStatusService.set()
+    │
+    ▼
+bus.emit('updateStreamStatus')
+    │
+    ▼
+StreamStatusEvents listener
+    │
+    ▼
+ProgressEventHandler.setStreamStatus()
+    │
+    ├─ _streamStatus Map (duplicate state!)
+    │
+    └─ WebviewUpdater
+           │
+           ├─ updateAll() (full refresh)
+           └─ updateStreamStatus() (targeted)
+```
+
+## Identified Issues
+
+### 1. Dual Logging Paths (HIGH)
+
+**Problem**: Two paths to progress view with different behavior.
+
+| Aspect | Path A: createStream() | Path B: logger methods |
+|--------|------------------------|----------------------|
+| Target | Progress view only | OutputChannel + Progress view |
+| Filtering | None | Debug/Internal filtered |
+| Type Validation | None | Validated |
+| ID Generation | Caller-provided | Sink generates UUID |
+
+**Files**:
+- `src/logger/AgentLogger.ts` (createStream: lines 509-596)
+- `src/logger/sinks/ProgressViewSink.ts` (filtering: lines 26-38)
+
+### 2. Duplicate Stream Status State (HIGH)
+
+**Problem**: Two separate Maps track stream status without synchronization.
+
+```typescript
+// In src/agent/runtime/StreamStatusService.ts
+const statusMemory = new Map<StreamTabId, StreamStatus>();
+
+// In src/progressView/events/ProgressEventHandler.ts
+private _streamStatus: Map<string, StreamStatus> = new Map();
+```
+
+**Issue**: `RetryState.ts` directly emits events, bypassing `StreamStatusService`, causing drift.
+
+### 3. Triple Update on Stream Switch (MEDIUM)
+
+**Problem**: `handleSetActiveStream()` triggers up to 3 overlapping updates.
+
+```typescript
+// In StreamStatusEvents.ts
+updater.updateAll(state, shared.streamStatus);      // [1] UPDATE_STREAMS
+shared.setStreamStatus(stream, status);             // [2] May updateAll() AGAIN
+shared.refreshStreamSurface(stream, {...});         // [3] UPDATE_LOGS
+shared.sendInstructionUpdate(stream, activeRunId);  // [4] UPDATE_INSTRUCTION
+```
+
+### 4. AsyncLocalStorage Context Management (LOW-MEDIUM)
+
+**Problem**: Group context uses `AsyncLocalStorage` with potential issues.
+
+- `previousStacks` Map can accumulate if groups aren't ended
+- Same Map object mutation with `enterWith()` may not isolate contexts
+- New async contexts lose group stack
+
+**File**: `src/logger/logUtils.ts` (lines 26-127)
+
+### 5. Complex State Resolution (LOW-MEDIUM)
+
+**Problem**: `refreshStreamSurface()` performs 7 separate state lookups.
+
+```typescript
+const messages = state.streamTabs.getMessages(stream);
+const groups = state.taskGroups.getStreamGroups(stream);
+const runInstructions = state.runInstructions.getInstructions(stream);
+const filesByRun = nestedMapToRecord(state.outputFiles.getFiles(stream));
+const missingByRun = nestedMapToRecord(state.outputFiles.getMissingOutputs(stream));
+const usageByRun = state.usageStats.getRunUsage(stream);
+const todos = state.getTodos(stream);
+```
+
+## Task Group Lifecycle
+
+### Init Group Creation
+
+1. `executeAgent()` starts agent execution
+2. `prepareFlowExecution()` emits `setActiveStream` (critical timing)
+3. `logger.stage('Init')` creates the Init group
+4. `ProgressViewSink.handleGroupStarted()` emits `addTaskGroup`
+5. `TaskGroupEvents` adds to state and sends to frontend
+
+### Historical Init Group Issues (FIXED)
+
+| Issue | Commit | Root Cause |
+|-------|--------|------------|
+| Stream not activated first | `59d84b5` | setActiveStream after Init |
+| Race in ensureStream | `da11dda` | Async timing with activeStream check |
+| Stale groups on session switch | `509592a` | Groups not cleared |
+
+### Current Session Kind Switching
+
+Commit `509592a` clears task groups when switching between session kinds (workflow ↔ tool-use). This prevents stale groups but may cause Init groups from previous sessions to disappear when switching contexts.
+
+## Round Trip Analysis
+
+| Operation | Layers | Events | Redundancy |
+|-----------|--------|--------|------------|
+| Log message (Path B) | 5 | 1-2 | None |
+| Log message (Path A) | 2 | 1 | Bypasses filters |
+| Stream status | 4 | 1-2 | Potential double updateAll |
+| Stream switch | 4 | 3-4 | Triple update possible |
+| Task group add | 4 | 1-3 | Full refresh if new stream |
+
+## Recommendations
+
+### Short-term Fixes
+
+1. **Unify logging paths**: Have `createStream()` use the same sink filtering as regular logging
+2. **Single status state**: Remove `StreamStatusService.statusMemory` or make `ProgressEventHandler` read from it
+3. **Avoid double updateAll**: Don't call `setStreamStatus()` after `updateAll()` in `handleSetActiveStream()`
+
+### Medium-term Refactoring
+
+1. **Batch webview messages**: Accumulate updates and send together
+2. **Cache resolved runIds**: Avoid repeated resolution in same operation
+3. **Consolidate state managers**: Reduce from 5 to 2-3 with clear boundaries
+
+### Long-term Architecture
+
+1. **Single source of truth**: Each piece of state owned by exactly one module
+2. **Explicit message flow**: Remove implicit callbacks and indirect updates
+3. **Typed event payloads**: Enforce schema validation on all bus events
+
+## Files Reference
+
+### Logging
+- `src/logger/AgentLogger.ts` - Main logger interface
+- `src/logger/logUtils.ts` - Low-level utilities + AsyncLocalStorage
+- `src/logger/LogChannelRegistry.ts` - Channel lifecycle
+- `src/logger/transports/VSCodeTransport.ts` - Transport to OutputChannel
+- `src/logger/sinks/ProgressViewSink.ts` - Progress view event emission
+
+### Event Bus
+- `src/eventBus/ProgressEventBus.ts` - Central event hub with buffering
+- `src/eventBus/schemas.ts` - Event payload schemas
+
+### Progress View
+- `src/progressView/events/ProgressEventHandler.ts` - Event orchestration
+- `src/progressView/events/StreamStatusEvents.ts` - Status event handling
+- `src/progressView/events/TaskGroupEvents.ts` - Task group handling
+- `src/progressView/events/LogEvents.ts` - Log message handling
+- `src/progressView/managers/WebviewUpdater.ts` - Webview messaging
+- `src/progressView/managers/StreamTabsManager.ts` - Stream state
+- `src/progressView/managers/TaskGroupManager.ts` - Task group state
+- `src/progressView/state/ProgressViewState.ts` - Combined state
+
+### Runtime
+- `src/agent/runtime/StreamStatusService.ts` - Status service (duplicate state!)
+- `src/agent/runtime/executeAgent.ts` - Agent execution entry point
+- `src/agent/core/flows/RetryState.ts` - Bypasses StreamStatusService

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -201,18 +201,7 @@ async function prepareFlowExecution(
   modelHandler.setAgentType(setting.agentType);
   modelHandler.setLogger(executionContext.logger);
 
-  // 4. Emit setActiveStream BEFORE creating Init stage
-  // This ensures the frontend has activeStream set before addTaskGroup arrives,
-  // preventing the race condition where handleAddTaskGroup's _isActiveStream check
-  // fails because state.activeStream isn't set yet.
-  bus.emit('setActiveStream', {
-    stream: streamTabId,
-    session: sessionDescriptor,
-    isRemote: isRemoteAgent(config.agent),
-    hasMultipleOutputs: config.useMultipleOutputs,
-  });
-
-  // 5. Build user variable channels (replaces agent.init() logic)
+  // 4. Build user variable channels (replaces agent.init() logic)
   // Wrap in "Init" stage so file loading logs are properly grouped
   const initStage = await executionContext.logger.stage('Init');
   let baseVars: Awaited<ReturnType<typeof buildUserVars>>;
@@ -235,7 +224,7 @@ async function prepareFlowExecution(
     transient: { ...baseVars },
   };
 
-  // 6. Create usage monitor for tracking API usage
+  // 5. Create usage monitor for tracking API usage
   const isMultipleOutput =
     setting.agentCategory === AgentCategory.Workflow
       ? (setting as AgentWorkflowSetting).isMultipleOutput

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -271,34 +271,25 @@ function createUsageRecorder(
 /**
  * Setup UI state for flow execution.
  *
- * Sets stream status to RUNNING and optionally emits setActiveStream.
- *
- * NOTE: setActiveStream is now emitted by prepareFlowExecution() before the Init
- * stage to fix the race condition where task groups arrived before activeStream
- * was set. This function only emits setActiveStream when:
- * - A streamTabIdOverride is provided (resume scenarios where snapshot stream ID
- *   differs from the regenerated one)
+ * DRY helper: All three flow execution functions call setActiveStream
+ * and set stream status to RUNNING.
  *
  * @param ctx - Flow execution context
- * @param streamTabIdOverride - Optional override for stream ID (resume scenarios)
+ * @param streamTabIdOverride - Optional override for stream ID (used in resume scenarios
+ *                              where the snapshot's stream ID should be used instead of
+ *                              the regenerated one from ctx)
  */
 function setupFlowUIState(
   ctx: FlowExecutionContext,
   streamTabIdOverride?: StreamTabId,
 ): void {
   const streamTabId = streamTabIdOverride ?? ctx.streamTabId;
-
-  // Only emit setActiveStream if we have an override (resume case)
-  // Normal flows already have setActiveStream emitted by prepareFlowExecution
-  if (streamTabIdOverride) {
-    bus.emit('setActiveStream', {
-      stream: streamTabId,
-      session: ctx.config.session!,
-      isRemote: isRemoteAgent(ctx.config.agent),
-      hasMultipleOutputs: ctx.config.useMultipleOutputs,
-    });
-  }
-
+  bus.emit('setActiveStream', {
+    stream: streamTabId,
+    session: ctx.config.session!,
+    isRemote: isRemoteAgent(ctx.config.agent),
+    hasMultipleOutputs: ctx.config.useMultipleOutputs,
+  });
   StreamStatusService.set(streamTabId, STREAM_STATUS.RUNNING);
 }
 

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -137,13 +137,28 @@ async function validateAndGetModelConfig(modelName: string): Promise<void> {
 }
 
 /**
+ * Options for prepareFlowExecution.
+ */
+interface PrepareFlowOptions {
+  /**
+   * Override the stream tab ID for UI state.
+   * Used in resume scenarios where the snapshot's stream ID should be used.
+   */
+  streamTabIdOverride?: StreamTabId;
+}
+
+/**
  * Prepare execution context for flow-first execution.
  * Creates all dependencies needed to run flows directly without agent classes.
+ *
+ * IMPORTANT: This function emits setActiveStream BEFORE creating the Init stage,
+ * ensuring task groups appear correctly in the progress board.
  */
 async function prepareFlowExecution(
   agentName: string,
   configPayload: Partial<AgentConfig>,
   executionId?: ExecutionId,
+  options?: PrepareFlowOptions,
 ): Promise<FlowExecutionContext> {
   // 1. Resolve agent definition
   const fullConfig = AgentConfigSchema.parse({
@@ -200,6 +215,19 @@ async function prepareFlowExecution(
   // for tool-use agents, OpenAI Response API background mode detection)
   modelHandler.setAgentType(setting.agentType);
   modelHandler.setLogger(executionContext.logger);
+
+  // Determine effective stream ID (may be overridden for resume scenarios)
+  const effectiveStreamTabId = options?.streamTabIdOverride ?? streamTabId;
+
+  // Emit setActiveStream BEFORE Init stage creation.
+  // This ensures the frontend has state.activeStream set when addTaskGroup arrives,
+  // preventing the race condition where Init groups are dropped.
+  bus.emit('setActiveStream', {
+    stream: effectiveStreamTabId,
+    session: sessionDescriptor,
+    isRemote: isRemoteAgent(fullConfig.agent),
+    hasMultipleOutputs: fullConfig.useMultipleOutputs,
+  });
 
   // 4. Build user variable channels (replaces agent.init() logic)
   // Wrap in "Init" stage so file loading logs are properly grouped
@@ -271,8 +299,9 @@ function createUsageRecorder(
 /**
  * Setup UI state for flow execution.
  *
- * DRY helper: All three flow execution functions call setActiveStream
- * and set stream status to RUNNING.
+ * Sets the stream status to RUNNING. Note: setActiveStream is emitted
+ * in prepareFlowExecution BEFORE Init stage creation to ensure correct
+ * ordering of task group events.
  *
  * @param ctx - Flow execution context
  * @param streamTabIdOverride - Optional override for stream ID (used in resume scenarios
@@ -284,12 +313,6 @@ function setupFlowUIState(
   streamTabIdOverride?: StreamTabId,
 ): void {
   const streamTabId = streamTabIdOverride ?? ctx.streamTabId;
-  bus.emit('setActiveStream', {
-    stream: streamTabId,
-    session: ctx.config.session!,
-    isRemote: isRemoteAgent(ctx.config.agent),
-    hasMultipleOutputs: ctx.config.useMultipleOutputs,
-  });
   StreamStatusService.set(streamTabId, STREAM_STATUS.RUNNING);
 }
 
@@ -635,11 +658,12 @@ export async function resumeToolUseFromSnapshot(
   const executionId = snapshot.executionId as ExecutionId;
   const streamTabId = snapshot.streamId as StreamTabId;
 
-  // Prepare flow execution context
+  // Prepare flow execution context with snapshot's stream ID for correct UI state
   const ctx = await prepareFlowExecution(
     snapshotConfig.agent,
     snapshotConfig,
     executionId,
+    { streamTabIdOverride: streamTabId },
   );
   const { setting, executionContext, config } = ctx;
 

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -201,7 +201,18 @@ async function prepareFlowExecution(
   modelHandler.setAgentType(setting.agentType);
   modelHandler.setLogger(executionContext.logger);
 
-  // 4. Build user variable channels (replaces agent.init() logic)
+  // 4. Emit setActiveStream BEFORE creating Init stage
+  // This ensures the frontend has activeStream set before addTaskGroup arrives,
+  // preventing the race condition where handleAddTaskGroup's _isActiveStream check
+  // fails because state.activeStream isn't set yet.
+  bus.emit('setActiveStream', {
+    stream: streamTabId,
+    session: sessionDescriptor,
+    isRemote: isRemoteAgent(config.agent),
+    hasMultipleOutputs: config.useMultipleOutputs,
+  });
+
+  // 5. Build user variable channels (replaces agent.init() logic)
   // Wrap in "Init" stage so file loading logs are properly grouped
   const initStage = await executionContext.logger.stage('Init');
   let baseVars: Awaited<ReturnType<typeof buildUserVars>>;
@@ -224,7 +235,7 @@ async function prepareFlowExecution(
     transient: { ...baseVars },
   };
 
-  // 5. Create usage monitor for tracking API usage
+  // 6. Create usage monitor for tracking API usage
   const isMultipleOutput =
     setting.agentCategory === AgentCategory.Workflow
       ? (setting as AgentWorkflowSetting).isMultipleOutput

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -282,25 +282,34 @@ function createUsageRecorder(
 /**
  * Setup UI state for flow execution.
  *
- * DRY helper: All three flow execution functions call setActiveStream
- * and set stream status to RUNNING.
+ * Sets stream status to RUNNING and optionally emits setActiveStream.
+ *
+ * NOTE: setActiveStream is now emitted by prepareFlowExecution() before the Init
+ * stage to fix the race condition where task groups arrived before activeStream
+ * was set. This function only emits setActiveStream when:
+ * - A streamTabIdOverride is provided (resume scenarios where snapshot stream ID
+ *   differs from the regenerated one)
  *
  * @param ctx - Flow execution context
- * @param streamTabIdOverride - Optional override for stream ID (used in resume scenarios
- *                              where the snapshot's stream ID should be used instead of
- *                              the regenerated one from ctx)
+ * @param streamTabIdOverride - Optional override for stream ID (resume scenarios)
  */
 function setupFlowUIState(
   ctx: FlowExecutionContext,
   streamTabIdOverride?: StreamTabId,
 ): void {
   const streamTabId = streamTabIdOverride ?? ctx.streamTabId;
-  bus.emit('setActiveStream', {
-    stream: streamTabId,
-    session: ctx.config.session!,
-    isRemote: isRemoteAgent(ctx.config.agent),
-    hasMultipleOutputs: ctx.config.useMultipleOutputs,
-  });
+
+  // Only emit setActiveStream if we have an override (resume case)
+  // Normal flows already have setActiveStream emitted by prepareFlowExecution
+  if (streamTabIdOverride) {
+    bus.emit('setActiveStream', {
+      stream: streamTabId,
+      session: ctx.config.session!,
+      isRemote: isRemoteAgent(ctx.config.agent),
+      hasMultipleOutputs: ctx.config.useMultipleOutputs,
+    });
+  }
+
   StreamStatusService.set(streamTabId, STREAM_STATUS.RUNNING);
 }
 

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -11,6 +11,7 @@ import { AgentCategory } from '@agent/core/AgentDataclass';
 import { normalizeRunId } from '@common/constants/runIds';
 import { STREAM_STATUS } from '@common/constants/streamStatus';
 import { AgentLogger } from '@logger/AgentLogger';
+import type { TaskGroup } from '@logger/LogTypes';
 import { WebviewUpdater } from '@progressView/managers';
 import { ProgressViewState } from '@progressView/state/ProgressViewState';
 import { nestedMapToRecord } from '@progressView/persistence/serializationUtils';
@@ -50,6 +51,12 @@ import { createTodoEvents, type TodoEventsModule } from './TodoEvents';
 export class ProgressEventHandler {
   private readonly logger: AgentLogger;
   private _streamStatus: Map<string, StreamStatus> = new Map();
+  /**
+   * Buffer for task groups that arrive before their stream is activated.
+   * Key: stream ID, Value: array of groups waiting to be sent to frontend.
+   * Groups are replayed when setActiveStream is processed for the stream.
+   */
+  private readonly pendingTaskGroups = new Map<string, TaskGroup[]>();
   private readonly streamStatusEvents: StreamStatusEventModule;
   private readonly outputEvents: OutputEventsModule;
   private readonly logEvents: LogEventsModule;
@@ -84,6 +91,7 @@ export class ProgressEventHandler {
       refreshStreamSurface: this.refreshStreamSurface.bind(this),
       warnLog: this.logger.warn.bind(this.logger),
       debugLog: this.logger.debug.bind(this.logger),
+      replayPendingTaskGroups: this.replayPendingTaskGroups.bind(this),
     });
     this.outputEvents = createOutputEvents({
       withErrorBoundary: createErrorBoundary(this.logger, 'OutputEvents'),
@@ -99,6 +107,7 @@ export class ProgressEventHandler {
       initializeStreamForTaskGroup:
         this.initializeStreamForTaskGroup.bind(this),
       debugLog: this.logger.debug.bind(this.logger),
+      bufferTaskGroupForReplay: this.bufferTaskGroupForReplay.bind(this),
     });
     this.todoEvents = createTodoEvents({
       withErrorBoundary: createErrorBoundary(this.logger, 'TodoEvents'),
@@ -377,6 +386,38 @@ export class ProgressEventHandler {
    */
   getAllStreamStatuses(): Map<string, StreamStatus> {
     return new Map(this._streamStatus);
+  }
+
+  /**
+   * Buffer a task group for later replay when the stream becomes active.
+   * Called by TaskGroupEvents when addTaskGroup arrives before setActiveStream.
+   */
+  private bufferTaskGroupForReplay(stream: string, group: TaskGroup): void {
+    const pending = this.pendingTaskGroups.get(stream) ?? [];
+    pending.push(group);
+    this.pendingTaskGroups.set(stream, pending);
+  }
+
+  /**
+   * Replay any buffered task groups for a stream after it becomes active.
+   * Called by StreamStatusEvents after setActiveStream sets state.activeStream.
+   */
+  private replayPendingTaskGroups(
+    stream: string,
+    updater: WebviewUpdater,
+  ): void {
+    const pending = this.pendingTaskGroups.get(stream);
+    if (!pending || pending.length === 0) {
+      return;
+    }
+
+    this.logger.debug(
+      `Replaying ${pending.length} buffered task groups for stream ${stream}`,
+    );
+    for (const group of pending) {
+      updater.addTaskGroup(stream, group);
+    }
+    this.pendingTaskGroups.delete(stream);
   }
 
   /**

--- a/src/progressView/events/StreamStatusEvents.ts
+++ b/src/progressView/events/StreamStatusEvents.ts
@@ -35,6 +35,11 @@ export interface StreamStatusEventShared extends BaseEventShared {
   ): string | null;
   warnLog(message: string): void;
   debugLog(message: string): void;
+  /**
+   * Replay any task groups that were buffered while waiting for this stream
+   * to become active. Called after state.activeStream is set.
+   */
+  replayPendingTaskGroups(stream: string, updater: WebviewUpdater): void;
 }
 
 /**
@@ -83,6 +88,12 @@ export function createStreamStatusEvents(
     }
 
     state.activeStream = stream;
+
+    // Replay any task groups that were buffered before this stream became active.
+    // Must be called AFTER setting state.activeStream so subsequent events see it.
+    if (updater.isAvailable()) {
+      shared.replayPendingTaskGroups(stream, updater);
+    }
 
     const status: StreamStatus =
       shared.streamStatus.get(stream) ?? STREAM_STATUS.RUNNING;

--- a/src/progressView/events/TaskGroupEvents.ts
+++ b/src/progressView/events/TaskGroupEvents.ts
@@ -25,6 +25,11 @@ import type {
 interface TaskGroupEventsShared extends BaseEventShared {
   initializeStreamForTaskGroup(stream: string): Promise<void>;
   debugLog(message: string): void;
+  /**
+   * Buffer a task group for later replay when the stream becomes active.
+   * Used when addTaskGroup arrives before setActiveStream for a stream.
+   */
+  bufferTaskGroupForReplay(stream: string, group: TaskGroup): void;
 }
 
 /**
@@ -85,13 +90,20 @@ export function createTaskGroupEvents(
         await shared.initializeStreamForTaskGroup(stream);
       }
 
-      // Send ADD_TASK_GROUP to frontend for immediate rendering.
-      // Always send when updater is available - the frontend will handle
-      // the message correctly once activeStream is set by UPDATE_STREAMS.
-      // This fixes a race condition where setActiveStream creates the stream
-      // but hasn't set activeStream yet when addTaskGroup is processed.
+      // Send ADD_TASK_GROUP to frontend only if this stream is currently active.
+      // If the stream isn't active yet (addTaskGroup arrived before setActiveStream),
+      // buffer the group for replay when setActiveStream is processed.
+      // This fixes the race condition where Init groups are dropped by the frontend
+      // because state.activeStream isn't set when the ADD_TASK_GROUP message arrives.
       if (updater.isAvailable()) {
-        updater.addTaskGroup(stream, group);
+        if (stream === state.activeStream) {
+          updater.addTaskGroup(stream, group);
+        } else {
+          debugLog(
+            `Buffering task group ${groupId} for stream ${stream} (activeStream=${state.activeStream})`,
+          );
+          shared.bufferTaskGroupForReplay(stream, group);
+        }
       }
 
       // Ensure group persistence completes


### PR DESCRIPTION
Document the spaghetti patterns and round trips in the logging/streaming
systems including:

- Dual logging paths (createStream vs logger methods) with inconsistent filtering
- Duplicate stream status state (StreamStatusService vs ProgressEventHandler)
- Triple update on stream switch with potential redundant refreshes
- AsyncLocalStorage context management issues
- Task group lifecycle and Init group disappearance root causes
- Round trip analysis for common operations
- Recommendations for short/medium/long-term fixes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves task group delivery ordering and resilience; documents current architecture and issues.
> 
> - Emit `setActiveStream` in `prepareFlowExecution()` before creating the `Init` stage; `setupFlowUIState()` now only sets `STREAM_STATUS.RUNNING`. `resumeToolUseFromSnapshot()` uses `streamTabIdOverride` to preserve snapshot stream IDs.
> - Add buffered task group handling: `ProgressEventHandler` stores pending groups and replays them on activation; `TaskGroupEvents` buffers when stream isn’t active and only sends `ADD_TASK_GROUP` for the active stream; `StreamStatusEvents` replays buffered groups after setting `state.activeStream` and before surface refresh/update.
> - Update wiring across `ProgressEventHandler`, `StreamStatusEvents`, and `TaskGroupEvents` to integrate buffering and maintain update ordering.
> - New doc `docs/LOGGING_STREAMING_ARCHITECTURE.md` detailing pipelines, identified issues, lifecycle, and recommendations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 315693028dff1b0c9342ab491f3be59c4e0c37ab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->