### PR TITLE
feat(auth): add browser-based GitHub login as alternative to native auth

### DIFF
--- a/src/auth/SupabaseAuthProvider.ts
+++ b/src/auth/SupabaseAuthProvider.ts
@@ -431,17 +431,30 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
    * and avoids OAuth callback complexity. The GitHub token is exchanged for a
    * Supabase session via Edge Function.
    *
+   * For GitHub (Browser): Uses traditional Supabase OAuth flow via web browser.
+   * This is an alternative when VS Code's built-in auth is not preferred.
+   *
    * For other providers (Google): Uses traditional Supabase OAuth flow with
    * environment-appropriate callback URIs.
    *
-   * @param scopes - Scopes array, may contain provider hint as "provider:github"
+   * @param scopes - Scopes array, may contain provider hint as "provider:github", "provider:github-browser", or "provider:google"
    */
   async createSession(
     scopes: readonly string[],
   ): Promise<vscode.AuthenticationSession> {
-    // Extract provider from scopes (format: "provider:github" or "provider:google")
+    // Extract provider from scopes (format: "provider:github", "provider:github-browser", or "provider:google")
     const providerScope = scopes.find((s) => s.startsWith('provider:'));
     const requestedProvider = providerScope?.split(':')[1];
+
+    // Handle github-browser as a special case - use browser OAuth flow for GitHub
+    if (requestedProvider === 'github-browser') {
+      logger.info(
+        'SupabaseAuthProvider',
+        'Using browser-based GitHub auth (Supabase OAuth flow)',
+      );
+      return this.createSessionViaSupabaseOAuth('github');
+    }
+
     const provider = isOAuthProvider(requestedProvider)
       ? requestedProvider
       : DEFAULT_OAUTH_PROVIDER;

--- a/src/auth/authCommands.ts
+++ b/src/auth/authCommands.ts
@@ -35,8 +35,8 @@ export function initializeProfileViewProvider(
   return profileViewProvider;
 }
 
-/** Auth method type including OAuth providers and email */
-type AuthMethod = OAuthProvider | 'email';
+/** Auth method type including OAuth providers, browser variants, and email */
+type AuthMethod = OAuthProvider | 'github-browser' | 'email';
 
 /** Email login is disabled due to remote configuration issues */
 const EMAIL_LOGIN_ENABLED = false;
@@ -77,6 +77,12 @@ export async function signIn(): Promise<void> {
         description: `Sign in with ${OAUTH_PROVIDER_LABELS[provider].label}`,
         method: provider as AuthMethod,
       })),
+      // Add browser-based GitHub option as alternative
+      {
+        label: '$(globe) GitHub (Browser)',
+        description: 'Sign in with GitHub via web browser',
+        method: 'github-browser' as AuthMethod,
+      },
       ...(EMAIL_LOGIN_ENABLED
         ? [
             {

--- a/src/auth/authCommands.ts
+++ b/src/auth/authCommands.ts
@@ -71,17 +71,17 @@ export async function signIn(): Promise<void> {
     }
 
     // Build sign-in options from enabled auth methods
+    // Browser-based OAuth options first (GitHub and Google), native GitHub option at the bottom
     const signInOptions: SignInOption[] = [
-      ...OAUTH_PROVIDERS.map((provider) => ({
-        label: `${OAUTH_PROVIDER_LABELS[provider].icon} ${OAUTH_PROVIDER_LABELS[provider].label}`,
-        description: `Sign in with ${OAUTH_PROVIDER_LABELS[provider].label}`,
-        method: provider as AuthMethod,
-      })),
-      // Add browser-based GitHub option as alternative
       {
-        label: '$(globe) GitHub (Browser)',
+        label: '$(github) GitHub',
         description: 'Sign in with GitHub via web browser',
         method: 'github-browser' as AuthMethod,
+      },
+      {
+        label: '$(globe) Google',
+        description: 'Sign in with Google',
+        method: 'google' as AuthMethod,
       },
       ...(EMAIL_LOGIN_ENABLED
         ? [
@@ -92,6 +92,12 @@ export async function signIn(): Promise<void> {
             },
           ]
         : []),
+      // Native GitHub auth at the bottom (still being tested)
+      {
+        label: '$(github) GitHub (Native)',
+        description: 'Sign in using VS Code GitHub authentication',
+        method: 'github' as AuthMethod,
+      },
     ];
 
     const selected = await vscode.window.showQuickPick(signInOptions, {

--- a/src/auth/authCommands.ts
+++ b/src/auth/authCommands.ts
@@ -70,18 +70,24 @@ export async function signIn(): Promise<void> {
       return;
     }
 
+    // Check if VS Code's native GitHub auth is available (user already logged in to GitHub in VS Code)
+    const hasNativeGitHubAuth = await vscode.authentication
+      .getSession('github', ['user:email'], { silent: true })
+      .then((session) => session !== undefined)
+      .catch(() => false);
+
     // Build sign-in options from enabled auth methods
-    // Browser-based OAuth options first (GitHub and Google), native GitHub option at the bottom
+    // Browser-based OAuth options first (Google, then GitHub), native GitHub option at the bottom if available
     const signInOptions: SignInOption[] = [
-      {
-        label: '$(github) GitHub',
-        description: 'Sign in with GitHub via web browser',
-        method: 'github-browser' as AuthMethod,
-      },
       {
         label: '$(globe) Google',
         description: 'Sign in with Google',
         method: 'google' as AuthMethod,
+      },
+      {
+        label: '$(github) GitHub',
+        description: 'Sign in with GitHub via web browser',
+        method: 'github-browser' as AuthMethod,
       },
       ...(EMAIL_LOGIN_ENABLED
         ? [
@@ -92,12 +98,16 @@ export async function signIn(): Promise<void> {
             },
           ]
         : []),
-      // Native GitHub auth at the bottom (still being tested)
-      {
-        label: '$(github) GitHub (Native)',
-        description: 'Sign in using VS Code GitHub authentication',
-        method: 'github' as AuthMethod,
-      },
+      // Native GitHub auth only shown if user has working VS Code GitHub authentication
+      ...(hasNativeGitHubAuth
+        ? [
+            {
+              label: '$(github) GitHub (Native)',
+              description: 'Sign in using VS Code GitHub authentication',
+              method: 'github' as AuthMethod,
+            },
+          ]
+        : []),
     ];
 
     const selected = await vscode.window.showQuickPick(signInOptions, {

--- a/src/auth/authCommands.ts
+++ b/src/auth/authCommands.ts
@@ -71,10 +71,17 @@ export async function signIn(): Promise<void> {
     }
 
     // Check if VS Code's native GitHub auth is available (user already logged in to GitHub in VS Code)
-    const hasNativeGitHubAuth = await vscode.authentication
-      .getSession('github', ['user:email'], { silent: true })
-      .then((session) => session !== undefined)
-      .catch(() => false);
+    let hasNativeGitHubAuth = false;
+    try {
+      const githubSession = await vscode.authentication.getSession(
+        'github',
+        ['user:email'],
+        { silent: true },
+      );
+      hasNativeGitHubAuth = githubSession !== undefined;
+    } catch {
+      // Native GitHub auth not available
+    }
 
     // Build sign-in options from enabled auth methods
     // Browser-based OAuth options first (Google, then GitHub), native GitHub option at the bottom if available

--- a/src/auth/authCommands.ts
+++ b/src/auth/authCommands.ts
@@ -2,12 +2,7 @@ import * as vscode from 'vscode';
 import { ProfileViewProvider } from '@profileView/ProfileViewProvider';
 import { SupabaseClient } from './SupabaseClient';
 import { SupabaseAuthProvider } from './SupabaseAuthProvider';
-import {
-  OAUTH_PROVIDERS,
-  OAUTH_PROVIDER_LABELS,
-  type OAuthProvider,
-  getExternalAuthCallbackUri,
-} from './config';
+import { type OAuthProvider, getExternalAuthCallbackUri } from './config';
 
 /**
  * Command identifiers for auth-related commands.
@@ -70,21 +65,7 @@ export async function signIn(): Promise<void> {
       return;
     }
 
-    // Check if VS Code's native GitHub auth is available (user already logged in to GitHub in VS Code)
-    let hasNativeGitHubAuth = false;
-    try {
-      const githubSession = await vscode.authentication.getSession(
-        'github',
-        ['user:email'],
-        { silent: true },
-      );
-      hasNativeGitHubAuth = githubSession !== undefined;
-    } catch {
-      // Native GitHub auth not available
-    }
-
     // Build sign-in options from enabled auth methods
-    // Browser-based OAuth options first (Google, then GitHub), native GitHub option at the bottom if available
     const signInOptions: SignInOption[] = [
       {
         label: '$(globe) Google',
@@ -105,16 +86,11 @@ export async function signIn(): Promise<void> {
             },
           ]
         : []),
-      // Native GitHub auth only shown if user has working VS Code GitHub authentication
-      ...(hasNativeGitHubAuth
-        ? [
-            {
-              label: '$(github) GitHub (Native)',
-              description: 'Sign in using VS Code GitHub authentication',
-              method: 'github' as AuthMethod,
-            },
-          ]
-        : []),
+      {
+        label: '$(github) GitHub (VS Code)',
+        description: 'Sign in using VS Code GitHub authentication',
+        method: 'github' as AuthMethod,
+      },
     ];
 
     const selected = await vscode.window.showQuickPick(signInOptions, {


### PR DESCRIPTION
Users can now choose between "GitHub" (VS Code native auth) and
"GitHub (Browser)" for web-based OAuth flow. This ensures users
have a fallback option if the native GitHub authentication doesn't
work or isn't preferred.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces an alternative GitHub auth path and clarifies sign-in choices.
> 
> - Adds `provider:github-browser` handling in `SupabaseAuthProvider` to use Supabase OAuth for GitHub; default `github` still uses VS Code's native provider
> - Updates sign-in QuickPick to list `Google`, `GitHub` (browser), and `GitHub (VS Code)`; extends `AuthMethod` to include `github-browser`
> - Refines JSDoc and logging around OAuth provider selection and callback handling
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b0907f49de0f5a27f9bc0642ca9d71fe07ad4a81. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->