### PR TITLE
refactor: consolidate progress logging and reduce abstraction overhead

### DIFF
--- a/src/commands/housekeeping/cleanCommands.ts
+++ b/src/commands/housekeeping/cleanCommands.ts
@@ -87,7 +87,7 @@ async function handleCleanSingle(
   const streamId = getStreamTabId(agent, model, inputFile, {
     useMultipleOutputs: false,
   });
-  bus.emit('clearMissingOutputs', streamId);
+  bus.emit('clearMissingOutputs', { stream: streamId });
 }
 
 async function handleCleanMultiple(
@@ -107,7 +107,7 @@ async function handleCleanMultiple(
   const streamId = getStreamTabId(agent, model, inputFile, {
     useMultipleOutputs: true,
   });
-  bus.emit('clearMissingOutputs', streamId);
+  bus.emit('clearMissingOutputs', { stream: streamId });
 }
 
 export async function handleClean(config: {
@@ -162,7 +162,7 @@ export async function handleClean(config: {
     });
 
   if (!config.skipProgressViewClear) {
-    bus.emit('clearMissingOutputs', streamId);
+    bus.emit('clearMissingOutputs', { stream: streamId });
   }
 }
 

--- a/src/commands/housekeeping/packCommands.ts
+++ b/src/commands/housekeeping/packCommands.ts
@@ -133,11 +133,11 @@ async function handlePack(config: unknown) {
   showPackResult(result, inputFile);
 
   if (!skipProgressViewClear) {
-    bus.emit(
-      'clearMissingOutputs',
-      streamId ||
+    bus.emit('clearMissingOutputs', {
+      stream:
+        streamId ||
         getStreamTabId(agent, model, inputFile, { useMultipleOutputs }),
-    );
+    });
   }
 }
 
@@ -158,12 +158,11 @@ async function handlePackSingle(
   const data = parsed.data;
   const result = await runPackSingle(data.model, data.inputFile, data.agent);
   showPackResult(result, data.inputFile);
-  bus.emit(
-    'clearMissingOutputs',
-    getStreamTabId(data.agent, data.model, data.inputFile, {
+  bus.emit('clearMissingOutputs', {
+    stream: getStreamTabId(data.agent, data.model, data.inputFile, {
       useMultipleOutputs: false,
     }),
-  );
+  });
 }
 
 async function handlePackMultiple(
@@ -194,12 +193,11 @@ async function handlePackMultiple(
     data.outputFiles,
   );
   showPackResult(result, data.inputFile);
-  bus.emit(
-    'clearMissingOutputs',
-    getStreamTabId(data.agent, data.model, data.inputFile, {
+  bus.emit('clearMissingOutputs', {
+    stream: getStreamTabId(data.agent, data.model, data.inputFile, {
       useMultipleOutputs: true,
     }),
-  );
+  });
 }
 
 // --- Registration ---

--- a/src/eventBus/ProgressEventBus.ts
+++ b/src/eventBus/ProgressEventBus.ts
@@ -57,7 +57,7 @@ export interface ProgressEventPayloads {
   updateMissingOutputs: RunScopedPayload & {
     filesByRound: { [key: number]: string[] };
   };
-  clearMissingOutputs: StreamTabId;
+  clearMissingOutputs: { stream: StreamTabId };
   setTaskState: SetTaskStatePayload;
   updateStreamUsage: RunScopedPayload & {
     usage: TokenUsageStats;

--- a/src/logger/LogChannelRegistry.ts
+++ b/src/logger/LogChannelRegistry.ts
@@ -22,10 +22,6 @@ export class LogChannelRegistry {
   private mainOutputChannel: vscode.OutputChannel | null = null;
   private readonly channels = new Map<string, ChannelEntry>();
 
-  ensure(channel: string, options: ChannelOptions): ChannelEntry {
-    return this.getOrCreate(channel, options);
-  }
-
   getTransport(
     channel: string,
     options?: ChannelOptions,
@@ -34,7 +30,7 @@ export class LogChannelRegistry {
     return this.channels.get(key)?.transport;
   }
 
-  private getOrCreate(channel: string, options: ChannelOptions): ChannelEntry {
+  ensure(channel: string, options: ChannelOptions): ChannelEntry {
     const key = this.getKey(channel, options.isAgent);
     const existing = this.channels.get(key);
     if (existing) {

--- a/src/logger/filterUtils.ts
+++ b/src/logger/filterUtils.ts
@@ -2,35 +2,61 @@
 import { MESSAGE_TYPES, type MessageType } from './messageTypes';
 import { getConfig } from '@utils/config';
 
-interface FilterOptions {
+export interface FilterOptions {
   level: 'debug' | 'info' | 'warn' | 'error';
   messageType: MessageType;
+}
+
+export interface FilterResult {
+  /** Whether the message should be emitted to the progress view */
+  shouldEmit: boolean;
+  /** Current debug mode state (for setting verbose flag on emitted messages) */
+  debugMode: boolean;
+}
+
+/**
+ * Get the current debug mode setting.
+ * Single source of truth for debug mode configuration.
+ */
+export function getDebugMode(): boolean {
+  return getConfig<boolean>('texra.logger.debugMode', false);
+}
+
+/**
+ * Determines whether a log message should be emitted to the progress view
+ * and returns the debug mode state for setting the verbose flag.
+ *
+ * This filtering logic is shared between:
+ * - VSCodeTransport.emitLogEvent() (winston transport path)
+ * - AgentLogger.createStream() (stream-based logging path)
+ *
+ * @param options - The log level and message type to filter
+ * @returns Object with shouldEmit boolean and debugMode state
+ */
+export function getEmitFilter(options: FilterOptions): FilterResult {
+  const debugMode = getDebugMode();
+
+  // Always filter INTERNAL messages from progress view
+  // (these are implementation details, not user-facing content)
+  if (options.messageType === MESSAGE_TYPES.INTERNAL) {
+    return { shouldEmit: false, debugMode };
+  }
+
+  // Filter debug-level messages when not in debug mode
+  if (options.level === 'debug' && !debugMode) {
+    return { shouldEmit: false, debugMode };
+  }
+
+  return { shouldEmit: true, debugMode };
 }
 
 /**
  * Determines whether a log message should be emitted to the progress view
  * based on debug mode settings and message type.
  *
- * This filtering logic is shared between:
- * - ProgressViewSink.handleLogMessage() (normal logging path)
- * - AgentLogger.createStream() (stream-based logging path)
- *
  * @param options - The log level and message type to filter
  * @returns true if the message should be emitted to the progress view, false otherwise
  */
 export function shouldEmitToProgressView(options: FilterOptions): boolean {
-  const debugMode = getConfig<boolean>('texra.logger.debugMode', false);
-
-  // Filter debug-level messages when not in debug mode
-  if (options.level === 'debug' && !debugMode) {
-    return false;
-  }
-
-  // Always filter INTERNAL messages from progress view
-  // (these are implementation details, not user-facing content)
-  if (options.messageType === MESSAGE_TYPES.INTERNAL) {
-    return false;
-  }
-
-  return true;
+  return getEmitFilter(options).shouldEmit;
 }

--- a/src/logger/transports/VSCodeTransport.ts
+++ b/src/logger/transports/VSCodeTransport.ts
@@ -4,13 +4,12 @@ import * as vscode from 'vscode';
 import Transport from 'winston-transport';
 
 // Internal imports
-import type { TaskGroupStatus } from '@common/constants/streamStatus';
 import { bus } from '@eventBus/ProgressEventBus';
-import type { LogMessageData } from '@logger/LogTypes';
+import { getEmitFilter } from '@logger/filterUtils';
+import type { LogMessageData, TaskGroup } from '@logger/LogTypes';
 import { MESSAGE_TYPES, type MessageType } from '@logger/messageTypes';
 import type { EndGroupStatus } from '@logger/messageTypes';
 import { getColorForLevel, serializeLogData } from '@logger/utils';
-import { getConfig } from '@utils/config';
 
 interface VSCodeTransportOptions extends Transport.TransportStreamOptions {
   channel: vscode.OutputChannel;
@@ -19,21 +18,12 @@ interface VSCodeTransportOptions extends Transport.TransportStreamOptions {
   includeStructuredData?: () => boolean;
 }
 
-interface TransportGroup {
-  id: string;
-  name: string;
-  startTime: number;
-  status: TaskGroupStatus;
-  parentGroupId?: string;
-  endTime?: number;
-}
-
 export class VSCodeTransport extends Transport {
   private readonly channel: vscode.OutputChannel;
   private readonly streamName: string;
   private readonly isAgentChannel: boolean;
   private readonly includeStructuredData?: () => boolean;
-  private readonly groups = new Map<string, TransportGroup>();
+  private readonly groups = new Map<string, TaskGroup>();
   private activeGroupId?: string;
 
   constructor(options: VSCodeTransportOptions) {
@@ -68,7 +58,7 @@ export class VSCodeTransport extends Transport {
 
   startGroup(groupName: string, id: string, parentGroupId?: string): string {
     const now = Date.now();
-    const group: TransportGroup = {
+    const group: TaskGroup = {
       id,
       name: groupName,
       startTime: now,
@@ -125,7 +115,8 @@ export class VSCodeTransport extends Transport {
 
   /**
    * Emit log message to progress view event bus.
-   * Only emits for agent channels; filters debug and internal messages.
+   * Only emits for agent channels; filters debug and internal messages
+   * using shared filtering logic from filterUtils.
    */
   private emitLogEvent(event: {
     level: string;
@@ -137,21 +128,23 @@ export class VSCodeTransport extends Transport {
   }): void {
     if (!this.isAgentChannel) return;
 
-    const debugMode = getConfig<boolean>('texra.logger.debugMode', false);
-    if (event.level === 'debug' && !debugMode) return;
-
     const validatedMessageType: MessageType = this.isValidMessageType(
       event.messageType,
     )
       ? event.messageType
       : MESSAGE_TYPES.DEFAULT;
 
-    if (validatedMessageType === MESSAGE_TYPES.INTERNAL) return;
+    const level = event.level as 'debug' | 'info' | 'warn' | 'error';
+    const { shouldEmit, debugMode } = getEmitFilter({
+      level,
+      messageType: validatedMessageType,
+    });
+    if (!shouldEmit) return;
 
     const logMessage: LogMessageData = {
       id: randomUUID(),
       text: event.message,
-      level: event.level as LogMessageData['level'],
+      level,
       timestamp: new Date(event.timestamp).getTime(),
       groupId: event.groupId,
       messageType: validatedMessageType,

--- a/src/progressView/events/ApprovalEvents.ts
+++ b/src/progressView/events/ApprovalEvents.ts
@@ -44,13 +44,10 @@ export function createApprovalEvents(
             shared.showToolEditApprovalPrompt(payload),
           ),
         ),
-        createEventDisposable(
-          bus,
-          'resolveToolEditApprovalPrompt',
-          (payload) =>
-            withErrorBoundary('failed to resolve approval prompt', () =>
-              shared.resolveToolEditApprovalPrompt(payload.requestId),
-            ),
+        createEventDisposable(bus, 'resolveToolEditApprovalPrompt', (payload) =>
+          withErrorBoundary('failed to resolve approval prompt', () =>
+            shared.resolveToolEditApprovalPrompt(payload.requestId),
+          ),
         ),
         createEventDisposable(
           bus,

--- a/src/progressView/events/LogEvents.ts
+++ b/src/progressView/events/LogEvents.ts
@@ -5,23 +5,14 @@ import type { ProgressViewState } from '@progressView/state/ProgressViewState';
 import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
 import {
   createStatefulEventDisposable,
-  type ProgressEventBusLike,
+  sendIfActive,
+  type BaseEventShared,
+  type StatefulEventModule,
 } from './types';
-import type { BaseEventShared, StatefulEventModule } from './types';
 
-/**
- * Shared context for LogEvents module.
- * Uses BaseEventShared which provides withErrorBoundary.
- */
-type LogEventsShared = BaseEventShared;
-
-/**
- * LogEvents module interface.
- * Uses StatefulEventModule pattern for state/updater access.
- */
 export type LogEventsModule = StatefulEventModule;
 
-export function createLogEvents(shared: LogEventsShared): LogEventsModule {
+export function createLogEvents(shared: BaseEventShared): LogEventsModule {
   const { withErrorBoundary } = shared;
 
   const handleAddLogMessage = (
@@ -78,9 +69,9 @@ export function createLogEvents(shared: LogEventsShared): LogEventsModule {
 
       await state.streamTabs.save();
 
-      if (updater.isAvailable() && stream === state.activeStream) {
+      sendIfActive(stream, state, updater, () => {
         updater.updateLogMessage(stream, existing);
-      }
+      });
     });
   };
 

--- a/src/progressView/events/LogEvents.ts
+++ b/src/progressView/events/LogEvents.ts
@@ -2,9 +2,6 @@
 import { MESSAGE_TYPES } from '@logger/messageTypes';
 import type { WebviewUpdater } from '@progressView/managers';
 import type { ProgressViewState } from '@progressView/state/ProgressViewState';
-
-// Local imports
-import { getConfig } from '@utils/config';
 import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
 import {
   createStatefulEventDisposable,
@@ -32,19 +29,10 @@ export function createLogEvents(shared: LogEventsShared): LogEventsModule {
     state: ProgressViewState,
     updater: WebviewUpdater,
   ): void => {
+    // Note: Debug level and INTERNAL message filtering is done at the source
+    // in VSCodeTransport.emitLogEvent() before events reach this handler.
     withErrorBoundary('failed to handle addLogMessage', async () => {
       const { stream, logMessage } = data;
-
-      if (
-        logMessage.level === 'debug' &&
-        !getConfig<boolean>('texra.logger.debugMode', false)
-      ) {
-        return;
-      }
-
-      if (logMessage.messageType === MESSAGE_TYPES.INTERNAL) {
-        return;
-      }
 
       const isNew = await state.streamTabs.addMessage(stream, logMessage);
 

--- a/src/progressView/events/OutputEvents.ts
+++ b/src/progressView/events/OutputEvents.ts
@@ -1,25 +1,12 @@
-// Type imports
-import type { WebviewUpdater } from '@progressView/managers';
-import type { ProgressViewState } from '@progressView/state/ProgressViewState';
-
 // Local file imports
 import {
   createStatefulEventDisposable,
-  type ProgressEventBusLike,
+  sendIfActive,
+  type BaseEventShared,
+  type StatefulEventModule,
 } from './types';
-import type { BaseEventShared, StatefulEventModule } from './types';
 
-/**
- * OutputEvents module interface.
- * Uses StatefulEventModule pattern for state/updater access.
- */
 export type OutputEventsModule = StatefulEventModule;
-
-/**
- * Shared context for OutputEvents module.
- * Uses BaseEventShared which provides withErrorBoundary.
- */
-type OutputEventsShared = BaseEventShared;
 
 /** Convert Map<number, T[]> to Record<number, T[]> for webview. */
 const toRoundRecord = <T>(
@@ -27,9 +14,7 @@ const toRoundRecord = <T>(
 ): Record<number, T[]> | undefined =>
   rounds && rounds.size > 0 ? Object.fromEntries(rounds.entries()) : undefined;
 
-export function createOutputEvents(
-  shared: OutputEventsShared,
-): OutputEventsModule {
+export function createOutputEvents(shared: BaseEventShared): OutputEventsModule {
   const { withErrorBoundary } = shared;
 
   return {
@@ -94,15 +79,12 @@ export function createOutputEvents(
           state,
           updater,
           (stream) => {
-            withErrorBoundary(
-              'failed to handle clearMissingOutputs',
-              async () => {
-                await state.outputFiles.clearMissingOutputs(stream);
-                if (state.activeStream === stream && updater.isAvailable()) {
-                  updater.updateMissingOutputs(stream, { reset: true });
-                }
-              },
-            );
+            withErrorBoundary('failed to handle clearMissingOutputs', async () => {
+              await state.outputFiles.clearMissingOutputs(stream);
+              sendIfActive(stream, state, updater, () => {
+                updater.updateMissingOutputs(stream, { reset: true });
+              });
+            });
           },
         ),
       ];

--- a/src/progressView/events/OutputEvents.ts
+++ b/src/progressView/events/OutputEvents.ts
@@ -78,7 +78,7 @@ export function createOutputEvents(shared: BaseEventShared): OutputEventsModule 
           'clearMissingOutputs',
           state,
           updater,
-          (stream) => {
+          ({ stream }) => {
             withErrorBoundary('failed to handle clearMissingOutputs', async () => {
               await state.outputFiles.clearMissingOutputs(stream);
               sendIfActive(stream, state, updater, () => {

--- a/src/progressView/events/OutputEvents.ts
+++ b/src/progressView/events/OutputEvents.ts
@@ -14,7 +14,9 @@ const toRoundRecord = <T>(
 ): Record<number, T[]> | undefined =>
   rounds && rounds.size > 0 ? Object.fromEntries(rounds.entries()) : undefined;
 
-export function createOutputEvents(shared: BaseEventShared): OutputEventsModule {
+export function createOutputEvents(
+  shared: BaseEventShared,
+): OutputEventsModule {
   const { withErrorBoundary } = shared;
 
   return {
@@ -79,12 +81,15 @@ export function createOutputEvents(shared: BaseEventShared): OutputEventsModule 
           state,
           updater,
           ({ stream }) => {
-            withErrorBoundary('failed to handle clearMissingOutputs', async () => {
-              await state.outputFiles.clearMissingOutputs(stream);
-              sendIfActive(stream, state, updater, () => {
-                updater.updateMissingOutputs(stream, { reset: true });
-              });
-            });
+            withErrorBoundary(
+              'failed to handle clearMissingOutputs',
+              async () => {
+                await state.outputFiles.clearMissingOutputs(stream);
+                sendIfActive(stream, state, updater, () => {
+                  updater.updateMissingOutputs(stream, { reset: true });
+                });
+              },
+            );
           },
         ),
       ];

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -178,7 +178,7 @@ export class ProgressEventHandler {
     }
 
     if (!stream) {
-      this.webviewUpdater.clearInstruction('');
+      this.webviewUpdater.updateInstruction('', null);
       return;
     }
 
@@ -205,15 +205,11 @@ export class ProgressEventHandler {
       void this.state.runInstructions.deleteRun(stream, normalizeRunId(runId));
     }
 
-    if (instructionUpdate) {
-      this.webviewUpdater.updateInstruction(
-        stream,
-        instructionUpdate,
-        sessionKind,
-      );
-    } else {
-      this.webviewUpdater.clearInstruction(stream);
-    }
+    this.webviewUpdater.updateInstruction(
+      stream,
+      instructionUpdate ?? null,
+      sessionKind,
+    );
   }
 
   /**
@@ -239,7 +235,7 @@ export class ProgressEventHandler {
       this.webviewUpdater.updateUsage('', {});
       this.webviewUpdater.updateStatus(STREAM_STATUS.READY);
       if (updateInstruction) {
-        this.webviewUpdater.clearInstruction('');
+        this.webviewUpdater.updateInstruction('', null);
       }
       return null;
     }

--- a/src/progressView/events/TodoEvents.ts
+++ b/src/progressView/events/TodoEvents.ts
@@ -2,16 +2,15 @@
 import type { WebviewUpdater } from '@progressView/managers';
 import type { ProgressViewState } from '@progressView/state/ProgressViewState';
 import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
-
-// Local imports - constants
 import { TODO_STATUS } from '@eventBus/schemas';
 
 // Local file imports
 import {
   createStatefulEventDisposable,
-  type ProgressEventBusLike,
+  sendIfActive,
+  type BaseEventShared,
+  type StatefulEventModule,
 } from './types';
-import type { BaseEventShared, StatefulEventModule } from './types';
 
 /**
  * Shared context for TodoEvents module.
@@ -43,22 +42,12 @@ export function createTodoEvents(shared: TodoEventsShared): TodoEventsModule {
       `updateTodos: stream=${data.stream}, count=${todoCount}, inProgress=${inProgress}`,
     );
 
-    // Note: Unlike TaskGroupEvents which uses async handlers for stream initialization,
-    // TodoEvents uses sync handlers since there are no async operations needed.
-    // The error boundary still catches thrown errors synchronously.
     withErrorBoundary('failed to handle updateTodos', () => {
       const { stream, todos } = data;
-
-      // Always store todos in state for persistence across stream switches
       state.setTodos(stream, todos);
-
-      // Send to webview if it's the active stream and webview is available
-      const shouldSendToWebview =
-        updater.isAvailable() && stream === state.activeStream;
-
-      if (shouldSendToWebview) {
+      sendIfActive(stream, state, updater, () => {
         updater.updateTodos(stream, todos);
-      }
+      });
     });
   };
 

--- a/src/progressView/events/UsageEvents.ts
+++ b/src/progressView/events/UsageEvents.ts
@@ -1,30 +1,17 @@
 // Type imports
 import type { TokenUsageStats } from '@agent/types/UsageTypes';
-import type { WebviewUpdater } from '@progressView/managers';
-import type { ProgressViewState } from '@progressView/state/ProgressViewState';
 
 // Local file imports
 import {
   createStatefulEventDisposable,
-  type ProgressEventBusLike,
+  sendIfActive,
+  type BaseEventShared,
+  type StatefulEventModule,
 } from './types';
-import type { BaseEventShared, StatefulEventModule } from './types';
 
-/**
- * UsageEvents module interface.
- * Uses StatefulEventModule pattern for state/updater access.
- */
 export type UsageEventsModule = StatefulEventModule;
 
-/**
- * Shared context for UsageEvents module.
- * Uses BaseEventShared which provides withErrorBoundary.
- */
-type UsageEventsShared = BaseEventShared;
-
-export function createUsageEvents(
-  shared: UsageEventsShared,
-): UsageEventsModule {
+export function createUsageEvents(shared: BaseEventShared): UsageEventsModule {
   const { withErrorBoundary } = shared;
 
   return {
@@ -45,15 +32,11 @@ export function createUsageEvents(
                   cost: Number(usage.cost ?? 0),
                 };
 
-                await state.usageStats.setRunUsage(
-                  stream,
-                  storageKey,
-                  normalizedUsage,
-                );
+                await state.usageStats.setRunUsage(stream, storageKey, normalizedUsage);
 
-                if (state.activeStream === stream && updater.isAvailable()) {
+                sendIfActive(stream, state, updater, () => {
                   updater.updateRunUsage(stream, storageKey, normalizedUsage);
-                }
+                });
               },
             );
           },

--- a/src/progressView/events/UsageEvents.ts
+++ b/src/progressView/events/UsageEvents.ts
@@ -32,7 +32,11 @@ export function createUsageEvents(shared: BaseEventShared): UsageEventsModule {
                   cost: Number(usage.cost ?? 0),
                 };
 
-                await state.usageStats.setRunUsage(stream, storageKey, normalizedUsage);
+                await state.usageStats.setRunUsage(
+                  stream,
+                  storageKey,
+                  normalizedUsage,
+                );
 
                 sendIfActive(stream, state, updater, () => {
                   updater.updateRunUsage(stream, storageKey, normalizedUsage);

--- a/src/progressView/events/types.ts
+++ b/src/progressView/events/types.ts
@@ -106,3 +106,18 @@ export function createStatefulEventDisposable<K extends ProgressEvent>(
     bus.on(event, (payload) => handler(payload, state, updater)),
   );
 }
+
+/**
+ * Send update to webview only if stream is active and webview is available.
+ * Eliminates repetitive isAvailable/activeStream checks in every handler.
+ */
+export function sendIfActive(
+  stream: string,
+  state: ProgressViewState,
+  updater: WebviewUpdater,
+  send: () => void,
+): void {
+  if (updater.isAvailable() && stream === state.activeStream) {
+    send();
+  }
+}

--- a/src/progressView/managers/UsageStatsManager.ts
+++ b/src/progressView/managers/UsageStatsManager.ts
@@ -85,11 +85,7 @@ export class UsageStatsManager extends PersistentMapManager<
     const normalized = TokenUsageStatsParsingSchema.parse(usage);
     const current =
       this.items.get(stream) ?? new Map<string, TokenUsageStats>();
-    if (
-      normalized.inputTokens === 0 &&
-      normalized.outputTokens === 0 &&
-      normalized.cost === 0
-    ) {
+    if (isEmptyUsage(normalized)) {
       current.delete(storageKey);
     } else {
       current.set(storageKey, normalized);
@@ -152,11 +148,7 @@ export class UsageStatsManager extends PersistentMapManager<
       }
 
       const usage = TokenUsageStatsParsingSchema.parse(value);
-      if (
-        usage.inputTokens === 0 &&
-        usage.outputTokens === 0 &&
-        usage.cost === 0
-      ) {
+      if (isEmptyUsage(usage)) {
         continue;
       }
 

--- a/src/progressView/managers/WebviewUpdater.ts
+++ b/src/progressView/managers/WebviewUpdater.ts
@@ -256,11 +256,12 @@ export class WebviewUpdater {
   }
 
   /**
-   * Update instruction panel content
+   * Update or clear instruction panel content.
+   * Pass null for instruction to clear the panel.
    */
   updateInstruction(
-    stream: StreamTabId,
-    instruction: InstructionUpdate,
+    stream: StreamTabId | '',
+    instruction: InstructionUpdate | null,
     sessionKind?: string,
   ): void {
     this.sendMessage({
@@ -268,17 +269,6 @@ export class WebviewUpdater {
       stream,
       instruction,
       sessionKind,
-    });
-  }
-
-  /**
-   * Clear instruction panel content
-   */
-  clearInstruction(stream: StreamTabId | ''): void {
-    this.sendMessage({
-      command: COMMANDS.UPDATE_INSTRUCTION,
-      stream,
-      instruction: null,
     });
   }
 


### PR DESCRIPTION
- Eliminate TransportGroup duplication: VSCodeTransport now uses TaskGroup
  from LogTypes as single source of truth instead of duplicating the interface

- Consolidate debug mode configuration: Add getEmitFilter() to filterUtils
  as single source of truth for log filtering and debug mode state,
  replacing scattered getConfig calls

- Remove redundant log filtering: LogEvents no longer duplicates the
  filtering logic already done in VSCodeTransport.emitLogEvent()

- Simplify event handler factory pattern: Add createSimpleEventListener()
  helper and use it in RetryEvents/ApprovalEvents to reduce boilerplate

Net reduction: ~20 lines of code with cleaner separation of concerns

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Unifies progress logging and event handling while simplifying webview updates.
> 
> - Consolidates log filtering and debug mode via `getEmitFilter()`/`getDebugMode()` in `logger/filterUtils`; `VSCodeTransport` now uses this and sets `verbose` accordingly, and adopts `TaskGroup` type
> - Removes duplicate filtering from `LogEvents`; adds `sendIfActive()` helper used across `LogEvents`, `OutputEvents`, `UsageEvents`, and `TodoEvents`
> - Standardizes `bus.emit('clearMissingOutputs')` payload to `{ stream }`; updates callers in `cleanCommands`, `packCommands`, and handler in `OutputEvents`; updates event type in `ProgressEventBus`
> - Replaces `WebviewUpdater.clearInstruction()` with `updateInstruction(..., null)` and updates all call sites in `ProgressEventHandler` and `WebviewUpdater`
> - Simplifies `LogChannelRegistry` by exposing `ensure()` and removing private indirection; minor cleanup in approval events
> - Refactors `UsageStatsManager` to use shared `isEmptyUsage` logic for pruning zero-usage entries
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e90b5387523b55fb7951df3e1a3cc78ad8220b31. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->