### PR TITLE
style: merge providers and models into unified display card

### DIFF
--- a/src/profileView/index.html
+++ b/src/profileView/index.html
@@ -106,12 +106,17 @@
             </span>
           </label>
         </div>
-        <p id="enabledProvidersInfo" class="enabled-providers-info"></p>
-        <p
-          id="allowedModelsInfo"
-          class="allowed-models-info"
-          style="display: none"
-        ></p>
+        <div id="modelAccessInfo" class="model-access-info" style="display: none">
+          <div class="model-access-row">
+            <span class="model-access-label">Providers</span>
+            <span id="enabledProvidersInfo" class="model-access-value"></span>
+          </div>
+          <div class="model-access-row">
+            <span class="model-access-label">Models</span>
+            <span id="allowedModelsInfo" class="model-access-value"></span>
+          </div>
+          <div id="modelsListContainer" class="models-list-container"></div>
+        </div>
       </div>
 
       <div

--- a/src/profileView/index.html
+++ b/src/profileView/index.html
@@ -107,14 +107,12 @@
           </label>
         </div>
         <div id="modelAccessInfo" class="model-access-info" style="display: none">
-          <div class="model-access-row">
-            <span class="model-access-label">Providers</span>
-            <span id="enabledProvidersInfo" class="model-access-value"></span>
-          </div>
-          <div class="model-access-row">
-            <span class="model-access-label">Models</span>
-            <span id="allowedModelsInfo" class="model-access-value"></span>
-          </div>
+          <button type="button" id="modelAccessSummary" class="model-access-summary">
+            <span id="enabledProvidersInfo"></span>
+            <span class="separator">·</span>
+            <span id="allowedModelsInfo"></span>
+            <span id="modelsToggle" class="models-toggle codicon codicon-chevron-down"></span>
+          </button>
           <div id="modelsListContainer" class="models-list-container"></div>
         </div>
       </div>

--- a/src/profileView/index.html
+++ b/src/profileView/index.html
@@ -106,15 +106,14 @@
             </span>
           </label>
         </div>
-        <div id="modelAccessInfo" class="model-access-info" style="display: none">
-          <button type="button" id="modelAccessSummary" class="model-access-summary">
+        <details id="modelAccessInfo" class="model-access-info" style="display: none">
+          <summary class="model-access-summary">
             <span id="enabledProvidersInfo"></span>
             <span class="separator">·</span>
             <span id="allowedModelsInfo"></span>
-            <span id="modelsToggle" class="models-toggle codicon codicon-chevron-down"></span>
-          </button>
+          </summary>
           <div id="modelsListContainer" class="models-list-container"></div>
-        </div>
+        </details>
       </div>
 
       <div

--- a/src/profileView/modules/constants.js
+++ b/src/profileView/modules/constants.js
@@ -23,7 +23,6 @@ export const ELEMENT_IDS = {
   API_ACCESS_INCLUDED: 'apiAccessIncluded',
   API_ACCESS_PERSONAL: 'apiAccessPersonal',
   MODEL_ACCESS_INFO: 'modelAccessInfo',
-  MODEL_ACCESS_SUMMARY: 'modelAccessSummary',
   ENABLED_PROVIDERS_INFO: 'enabledProvidersInfo',
   ALLOWED_MODELS_INFO: 'allowedModelsInfo',
   MODELS_LIST_CONTAINER: 'modelsListContainer',

--- a/src/profileView/modules/constants.js
+++ b/src/profileView/modules/constants.js
@@ -22,8 +22,10 @@ export const ELEMENT_IDS = {
   API_ACCESS_SECTION: 'apiAccessSection',
   API_ACCESS_INCLUDED: 'apiAccessIncluded',
   API_ACCESS_PERSONAL: 'apiAccessPersonal',
+  MODEL_ACCESS_INFO: 'modelAccessInfo',
   ENABLED_PROVIDERS_INFO: 'enabledProvidersInfo',
   ALLOWED_MODELS_INFO: 'allowedModelsInfo',
+  MODELS_LIST_CONTAINER: 'modelsListContainer',
   // Access expiration
   ACCESS_EXPIRATION_ROW: 'accessExpirationRow',
   ACCESS_EXPIRATION: 'accessExpiration',

--- a/src/profileView/modules/constants.js
+++ b/src/profileView/modules/constants.js
@@ -23,6 +23,7 @@ export const ELEMENT_IDS = {
   API_ACCESS_INCLUDED: 'apiAccessIncluded',
   API_ACCESS_PERSONAL: 'apiAccessPersonal',
   MODEL_ACCESS_INFO: 'modelAccessInfo',
+  MODEL_ACCESS_SUMMARY: 'modelAccessSummary',
   ENABLED_PROVIDERS_INFO: 'enabledProvidersInfo',
   ALLOWED_MODELS_INFO: 'allowedModelsInfo',
   MODELS_LIST_CONTAINER: 'modelsListContainer',

--- a/src/profileView/modules/uiManagers/AgentsTable.js
+++ b/src/profileView/modules/uiManagers/AgentsTable.js
@@ -147,9 +147,6 @@ export class AgentsTable {
     const includedRadio = safeGetElementById(ELEMENT_IDS.API_ACCESS_INCLUDED);
     const personalRadio = safeGetElementById(ELEMENT_IDS.API_ACCESS_PERSONAL);
     const modelAccessInfo = safeGetElementById(ELEMENT_IDS.MODEL_ACCESS_INFO);
-    const modelAccessSummary = safeGetElementById(
-      ELEMENT_IDS.MODEL_ACCESS_SUMMARY,
-    );
     const providersInfo = safeGetElementById(
       ELEMENT_IDS.ENABLED_PROVIDERS_INFO,
     );
@@ -196,14 +193,6 @@ export class AgentsTable {
         resolvedAllowedModels,
         enabledProviders,
       );
-    }
-
-    // Add toggle listener for expanding/collapsing models list
-    if (modelAccessSummary && !this._modelsToggleListenerAdded) {
-      this._modelsToggleListenerAdded = true;
-      modelAccessSummary.addEventListener('click', () => {
-        modelAccessInfo?.classList.toggle('expanded');
-      });
     }
 
     // Add event listeners (only once)

--- a/src/profileView/modules/uiManagers/AgentsTable.js
+++ b/src/profileView/modules/uiManagers/AgentsTable.js
@@ -146,10 +146,14 @@ export class AgentsTable {
   renderApiAccessSection(apiAccessMode, enabledProviders, allowedModels) {
     const includedRadio = safeGetElementById(ELEMENT_IDS.API_ACCESS_INCLUDED);
     const personalRadio = safeGetElementById(ELEMENT_IDS.API_ACCESS_PERSONAL);
+    const modelAccessInfo = safeGetElementById(ELEMENT_IDS.MODEL_ACCESS_INFO);
     const providersInfo = safeGetElementById(
       ELEMENT_IDS.ENABLED_PROVIDERS_INFO,
     );
     const modelsInfo = safeGetElementById(ELEMENT_IDS.ALLOWED_MODELS_INFO);
+    const modelsListContainer = safeGetElementById(
+      ELEMENT_IDS.MODELS_LIST_CONTAINER,
+    );
     const resolvedAllowedModels = Array.isArray(allowedModels)
       ? allowedModels
       : allowedModels === null
@@ -164,27 +168,29 @@ export class AgentsTable {
       personalRadio.checked = apiAccessMode === 'personal';
     }
 
-    // Show enabled providers info when using included access
-    if (providersInfo) {
-      if (
-        apiAccessMode === 'included' &&
-        enabledProviders &&
-        enabledProviders.length > 0
-      ) {
-        const providerNames = enabledProviders
-          .map((p) => p.charAt(0).toUpperCase() + p.slice(1))
-          .join(', ');
-        providersInfo.textContent = `Providers: ${providerNames}`;
-        providersInfo.style.display = 'block';
-      } else {
-        providersInfo.style.display = 'none';
-      }
+    // Show model access info card when using included access with providers
+    const showModelAccessInfo =
+      apiAccessMode === 'included' &&
+      enabledProviders &&
+      enabledProviders.length > 0;
+
+    if (modelAccessInfo) {
+      modelAccessInfo.style.display = showModelAccessInfo ? 'block' : 'none';
+    }
+
+    // Update providers info
+    if (providersInfo && showModelAccessInfo) {
+      const providerNames = enabledProviders
+        .map((p) => p.charAt(0).toUpperCase() + p.slice(1))
+        .join(', ');
+      providersInfo.textContent = providerNames;
     }
 
     // Render model display section
-    if (modelsInfo) {
+    if (modelsInfo && modelsListContainer) {
       this.renderModelsDisplay(
         modelsInfo,
+        modelsListContainer,
         apiAccessMode,
         resolvedAllowedModels,
         enabledProviders,
@@ -215,13 +221,15 @@ export class AgentsTable {
 
   /**
    * Render the models display section based on access mode and allowed models.
-   * @param {HTMLElement} modelsInfo - The models info container element
+   * @param {HTMLElement} modelsInfo - The models info value element
+   * @param {HTMLElement} modelsListContainer - The container for the models list
    * @param {string} apiAccessMode - 'included' or 'personal'
    * @param {string[]|null} allowedModels - Array of model names, or null for all models
    * @param {string[]} enabledProviders - Array of enabled provider names (for error detection)
    */
   renderModelsDisplay(
     modelsInfo,
+    modelsListContainer,
     apiAccessMode,
     allowedModels,
     enabledProviders,
@@ -233,63 +241,30 @@ export class AgentsTable {
     if (apiAccessMode === 'included') {
       if (allowedModels === null) {
         // null means all models are allowed (Ultra tier)
-        modelsInfo.textContent = 'All models included';
+        modelsInfo.textContent = 'All included';
         modelsInfo.title = '';
-        modelsInfo.style.display = 'block';
-        this.clearModelsList(modelsInfo);
+        modelsListContainer.textContent = '';
       } else if (allowedModels.length > 0) {
         // Specific models allowed - display count and list
-        modelsInfo.textContent = `Models: ${allowedModels.length} included`;
+        modelsInfo.textContent = `${allowedModels.length} included`;
         modelsInfo.title = '';
-        modelsInfo.style.display = 'block';
-        this.renderModelsList(modelsInfo, allowedModels);
+        modelsListContainer.textContent = allowedModels.join(', ');
       } else {
         // Empty array - config fetch failed or no models configured
         const configFetchFailed = enabledProviders.length === 0;
         modelsInfo.textContent = configFetchFailed
-          ? 'Unable to load models'
-          : 'No models configured';
+          ? 'Unable to load'
+          : 'None configured';
         modelsInfo.title = configFetchFailed
           ? 'Try signing out and back in to refresh'
           : '';
-        modelsInfo.style.display = 'block';
-        this.clearModelsList(modelsInfo);
+        modelsListContainer.textContent = '';
       }
     } else {
-      // Personal mode - hide models info and clean up
-      modelsInfo.style.display = 'none';
-      this.clearModelsList(modelsInfo);
+      // Personal mode - clear content (card is hidden by parent)
+      modelsInfo.textContent = '';
+      modelsListContainer.textContent = '';
     }
-  }
-
-  /**
-   * Clear any existing models list from the DOM.
-   * @param {HTMLElement} container - The container element near the models list
-   */
-  clearModelsList(container) {
-    const existingList =
-      container?.parentElement?.querySelector('.models-list');
-    if (existingList) {
-      existingList.remove();
-    }
-  }
-
-  /**
-   * Render the list of allowed models as a formatted list.
-   * @param {HTMLElement} container - The container element to append the list to
-   * @param {string[]} models - Array of model names
-   */
-  renderModelsList(container, models) {
-    // Remove any existing models list first
-    this.clearModelsList(container);
-
-    // Create the models list element
-    const modelsList = document.createElement('div');
-    modelsList.className = 'models-list';
-    modelsList.textContent = models.join(', ');
-
-    // Insert after the container (modelsInfo element)
-    container.parentElement?.insertBefore(modelsList, container.nextSibling);
   }
 
   /**

--- a/src/profileView/modules/uiManagers/AgentsTable.js
+++ b/src/profileView/modules/uiManagers/AgentsTable.js
@@ -147,6 +147,9 @@ export class AgentsTable {
     const includedRadio = safeGetElementById(ELEMENT_IDS.API_ACCESS_INCLUDED);
     const personalRadio = safeGetElementById(ELEMENT_IDS.API_ACCESS_PERSONAL);
     const modelAccessInfo = safeGetElementById(ELEMENT_IDS.MODEL_ACCESS_INFO);
+    const modelAccessSummary = safeGetElementById(
+      ELEMENT_IDS.MODEL_ACCESS_SUMMARY,
+    );
     const providersInfo = safeGetElementById(
       ELEMENT_IDS.ENABLED_PROVIDERS_INFO,
     );
@@ -178,12 +181,10 @@ export class AgentsTable {
       modelAccessInfo.style.display = showModelAccessInfo ? 'block' : 'none';
     }
 
-    // Update providers info
+    // Update providers info with count format
     if (providersInfo && showModelAccessInfo) {
-      const providerNames = enabledProviders
-        .map((p) => p.charAt(0).toUpperCase() + p.slice(1))
-        .join(', ');
-      providersInfo.textContent = providerNames;
+      const count = enabledProviders.length;
+      providersInfo.textContent = `${count} provider${count !== 1 ? 's' : ''}`;
     }
 
     // Render model display section
@@ -195,6 +196,14 @@ export class AgentsTable {
         resolvedAllowedModels,
         enabledProviders,
       );
+    }
+
+    // Add toggle listener for expanding/collapsing models list
+    if (modelAccessSummary && !this._modelsToggleListenerAdded) {
+      this._modelsToggleListenerAdded = true;
+      modelAccessSummary.addEventListener('click', () => {
+        modelAccessInfo?.classList.toggle('expanded');
+      });
     }
 
     // Add event listeners (only once)
@@ -241,20 +250,21 @@ export class AgentsTable {
     if (apiAccessMode === 'included') {
       if (allowedModels === null) {
         // null means all models are allowed (Ultra tier)
-        modelsInfo.textContent = 'All included';
+        modelsInfo.textContent = 'all models';
         modelsInfo.title = '';
         modelsListContainer.textContent = '';
       } else if (allowedModels.length > 0) {
         // Specific models allowed - display count and list
-        modelsInfo.textContent = `${allowedModels.length} included`;
+        const count = allowedModels.length;
+        modelsInfo.textContent = `${count} model${count !== 1 ? 's' : ''}`;
         modelsInfo.title = '';
         modelsListContainer.textContent = allowedModels.join(', ');
       } else {
         // Empty array - config fetch failed or no models configured
         const configFetchFailed = enabledProviders.length === 0;
         modelsInfo.textContent = configFetchFailed
-          ? 'Unable to load'
-          : 'None configured';
+          ? 'unable to load'
+          : 'no models';
         modelsInfo.title = configFetchFailed
           ? 'Try signing out and back in to refresh'
           : '';

--- a/src/profileView/styles/index.css
+++ b/src/profileView/styles/index.css
@@ -247,14 +247,30 @@ h2 {
   gap: var(--spacing-small);
   padding: var(--spacing-small) var(--spacing-medium);
   background: var(--vscode-textBlockQuote-background);
-  border: none;
   border-radius: var(--border-radius);
   font-size: var(--font-size-sm);
   color: var(--color-text-secondary);
   cursor: pointer;
-  width: 100%;
-  text-align: left;
-  transition: background-color 0.15s ease;
+  list-style: none;
+}
+
+.model-access-summary::-webkit-details-marker {
+  display: none;
+}
+
+.model-access-summary::after {
+  content: '';
+  margin-left: auto;
+  border: solid var(--color-text-secondary);
+  border-width: 0 1.5px 1.5px 0;
+  padding: 3px;
+  transform: rotate(45deg);
+  opacity: 0.6;
+  transition: transform 0.2s ease;
+}
+
+.model-access-info[open] .model-access-summary::after {
+  transform: rotate(-135deg);
 }
 
 .model-access-summary:hover {
@@ -265,18 +281,7 @@ h2 {
   opacity: 0.5;
 }
 
-.models-toggle {
-  margin-left: auto;
-  opacity: 0.6;
-  transition: transform 0.2s ease;
-}
-
-.model-access-info.expanded .models-toggle {
-  transform: rotate(180deg);
-}
-
 .models-list-container {
-  display: none;
   margin-top: var(--spacing-small);
   padding: var(--spacing-small) var(--spacing-medium);
   background: var(--vscode-textBlockQuote-background);
@@ -284,8 +289,4 @@ h2 {
   font-size: var(--font-size-sm);
   color: var(--color-text-secondary);
   line-height: 1.6;
-}
-
-.model-access-info.expanded .models-list-container {
-  display: block;
 }

--- a/src/profileView/styles/index.css
+++ b/src/profileView/styles/index.css
@@ -236,22 +236,48 @@ h2 {
   color: var(--color-text-secondary);
 }
 
-.enabled-providers-info,
-.allowed-models-info {
+/* Model access info card - unified providers and models display */
+.model-access-info {
   margin-top: var(--spacing-medium);
-  padding: var(--spacing-small) var(--spacing-medium);
+  padding: var(--spacing-medium);
   background: var(--vscode-textBlockQuote-background);
   border-radius: var(--border-radius);
   font-size: var(--font-size-sm);
+}
+
+.model-access-row {
+  display: flex;
+  gap: var(--spacing-medium);
+  padding: var(--spacing-small) 0;
+}
+
+.model-access-row:first-child {
+  padding-top: 0;
+}
+
+.model-access-row:not(:last-child) {
+  border-bottom: var(--border-thin) solid var(--color-border);
+}
+
+.model-access-label {
+  font-weight: 600;
+  color: var(--vscode-foreground);
+  min-width: 70px;
+  flex-shrink: 0;
+}
+
+.model-access-value {
   color: var(--color-text-secondary);
 }
 
-.models-list {
+.models-list-container {
   margin-top: var(--spacing-small);
-  padding: var(--spacing-small) var(--spacing-medium);
-  background: var(--vscode-textBlockQuote-background);
-  border-radius: var(--border-radius);
-  font-size: var(--font-size-sm);
+  padding-top: var(--spacing-small);
+  border-top: var(--border-thin) solid var(--color-border);
   color: var(--color-text-secondary);
   line-height: 1.5;
+}
+
+.models-list-container:empty {
+  display: none;
 }

--- a/src/profileView/styles/index.css
+++ b/src/profileView/styles/index.css
@@ -236,48 +236,56 @@ h2 {
   color: var(--color-text-secondary);
 }
 
-/* Model access info card - unified providers and models display */
+/* Model access info - compact summary with collapsible models */
 .model-access-info {
   margin-top: var(--spacing-medium);
-  padding: var(--spacing-medium);
+}
+
+.model-access-summary {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-small);
+  padding: var(--spacing-small) var(--spacing-medium);
   background: var(--vscode-textBlockQuote-background);
+  border: none;
   border-radius: var(--border-radius);
   font-size: var(--font-size-sm);
-}
-
-.model-access-row {
-  display: flex;
-  gap: var(--spacing-medium);
-  padding: var(--spacing-small) 0;
-}
-
-.model-access-row:first-child {
-  padding-top: 0;
-}
-
-.model-access-row:not(:last-child) {
-  border-bottom: var(--border-thin) solid var(--color-border);
-}
-
-.model-access-label {
-  font-weight: 600;
-  color: var(--vscode-foreground);
-  min-width: 70px;
-  flex-shrink: 0;
-}
-
-.model-access-value {
   color: var(--color-text-secondary);
+  cursor: pointer;
+  width: 100%;
+  text-align: left;
+  transition: background-color 0.15s ease;
+}
+
+.model-access-summary:hover {
+  background: var(--vscode-list-hoverBackground);
+}
+
+.model-access-summary .separator {
+  opacity: 0.5;
+}
+
+.models-toggle {
+  margin-left: auto;
+  opacity: 0.6;
+  transition: transform 0.2s ease;
+}
+
+.model-access-info.expanded .models-toggle {
+  transform: rotate(180deg);
 }
 
 .models-list-container {
+  display: none;
   margin-top: var(--spacing-small);
-  padding-top: var(--spacing-small);
-  border-top: var(--border-thin) solid var(--color-border);
+  padding: var(--spacing-small) var(--spacing-medium);
+  background: var(--vscode-textBlockQuote-background);
+  border-radius: var(--border-radius);
+  font-size: var(--font-size-sm);
   color: var(--color-text-secondary);
-  line-height: 1.5;
+  line-height: 1.6;
 }
 
-.models-list-container:empty {
-  display: none;
+.model-access-info.expanded .models-list-container {
+  display: block;
 }


### PR DESCRIPTION
Combine the separate providers and models info displays into a single
cohesive card with labeled rows. The models list now appears inside
the card with a separator line, improving visual organization.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Consolidates model access details into a single, collapsible `details` card for included access.
> 
> - Replaces separate `enabledProvidersInfo`/`allowedModelsInfo` paragraphs with `details#modelAccessInfo` containing a summary (provider count · model status) and a `modelsListContainer`
> - Updates `AgentsTable.renderApiAccessSection` to show/hide the card based on mode/providers and to render concise counts/messages (e.g., `all models`, `N models`, `unable to load`)
> - Simplifies model list rendering by writing to `modelsListContainer` and removing DOM helper methods for list insertion
> - Adds new element IDs in `constants.js` and comprehensive CSS for the card, summary chevron, hover states, separator, and list container; removes old providers/models styles
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5a5c72c0be05cb99ed7ceb0eb853d9211be59e34. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->