### PR TITLE
refactor: simplify progress logging infrastructure

### DIFF
--- a/src/logger/logUtils.ts
+++ b/src/logger/logUtils.ts
@@ -25,6 +25,13 @@ interface ChannelContext {
 const contextStorage = new AsyncLocalStorage<Map<ChannelKey, ChannelContext>>();
 const previousStacks = new Map<string, string[]>();
 
+// Cache for initialized channels to avoid repeated registry.ensure() calls
+// This eliminates the overhead of Map lookup + string interpolation on every log
+const initializedChannels = new Map<
+  ChannelKey,
+  ReturnType<typeof registry.ensure>
+>();
+
 function getChannelKey(channel: string, isAgent: boolean): ChannelKey {
   return `${isAgent ? 'agent' : 'default'}::${channel}`;
 }
@@ -118,19 +125,39 @@ function resolveActiveGroup(
   return context.stack.at(-1);
 }
 
+/**
+ * Get or create a cached channel entry.
+ * Single source of truth for channel initialization - eliminates repeated registry.ensure() calls.
+ */
+function getCachedEntry(
+  channel: string,
+  isAgent: boolean,
+): ReturnType<typeof registry.ensure> {
+  const key = getChannelKey(channel, isAgent);
+  let entry = initializedChannels.get(key);
+  if (!entry) {
+    entry = registry.ensure(channel, { isAgent });
+    initializedChannels.set(key, entry);
+  }
+  return entry;
+}
+
 function getTransport(
   channel: string,
   isAgent = false,
 ): VSCodeTransport | undefined {
-  return registry.getTransport(channel, { isAgent });
+  const key = getChannelKey(channel, isAgent);
+  return (
+    initializedChannels.get(key)?.transport ??
+    registry.getTransport(channel, { isAgent })
+  );
 }
 
 function getOrCreateTransport(
   channel: string,
   isAgent: boolean,
 ): VSCodeTransport {
-  const entry = registry.ensure(channel, { isAgent });
-  return entry.transport;
+  return getCachedEntry(channel, isAgent).transport;
 }
 
 function logWithGroup(
@@ -140,8 +167,7 @@ function logWithGroup(
   options: LogUtilsOptions = {},
 ): void {
   const isAgent = options.isAgent ?? false;
-  const entry = registry.ensure(channel, { isAgent });
-  const { logger } = entry;
+  const { logger } = getCachedEntry(channel, isAgent);
   const activeGroupId = resolveActiveGroup(channel, options.groupId, isAgent);
 
   logger.log(level, message, {
@@ -152,7 +178,7 @@ function logWithGroup(
 }
 
 export function initialize(channel: string, isAgent = false): void {
-  registry.ensure(channel, { isAgent });
+  getCachedEntry(channel, isAgent);
 }
 
 export function startGroup(

--- a/src/logger/transports/VSCodeTransport.ts
+++ b/src/logger/transports/VSCodeTransport.ts
@@ -6,7 +6,7 @@ import Transport from 'winston-transport';
 // Internal imports
 import { bus } from '@eventBus/ProgressEventBus';
 import { getEmitFilter } from '@logger/filterUtils';
-import type { LogMessageData, TaskGroup } from '@logger/LogTypes';
+import type { LogMessageData } from '@logger/LogTypes';
 import { MESSAGE_TYPES, type MessageType } from '@logger/messageTypes';
 import type { EndGroupStatus } from '@logger/messageTypes';
 import { getColorForLevel, serializeLogData } from '@logger/utils';
@@ -23,8 +23,6 @@ export class VSCodeTransport extends Transport {
   private readonly streamName: string;
   private readonly isAgentChannel: boolean;
   private readonly includeStructuredData?: () => boolean;
-  private readonly groups = new Map<string, TaskGroup>();
-  private activeGroupId?: string;
 
   constructor(options: VSCodeTransportOptions) {
     super(options);
@@ -39,9 +37,8 @@ export class VSCodeTransport extends Transport {
   }
 
   log(info: any, callback: () => void): void {
-    const { level, message, timestamp, messageType } = info;
+    const { level, message, timestamp, messageType, groupId } = info;
     const data = serializeLogData(info.data);
-    const groupId = info.groupId ?? this.activeGroupId;
 
     this.writeToChannel(level, message, timestamp, data);
     this.emitLogEvent({
@@ -57,36 +54,12 @@ export class VSCodeTransport extends Transport {
   }
 
   startGroup(groupName: string, id: string, parentGroupId?: string): string {
-    const now = Date.now();
-    const group: TaskGroup = {
-      id,
-      name: groupName,
-      startTime: now,
-      status: 'running',
-      parentGroupId,
-    };
-    this.groups.set(id, group);
-    this.activeGroupId = id;
-
-    this.emitGroupStarted(id, groupName, now, parentGroupId);
-
+    this.emitGroupStarted(id, groupName, Date.now(), parentGroupId);
     return id;
   }
 
   endGroup(groupId: string, status: EndGroupStatus): void {
-    const group = this.groups.get(groupId);
-    if (!group) {
-      return;
-    }
-
-    group.endTime = Date.now();
-    group.status = status;
-
-    this.emitGroupFinished(groupId, status, group.endTime);
-
-    if (this.activeGroupId === groupId) {
-      this.activeGroupId = group.parentGroupId;
-    }
+    this.emitGroupFinished(groupId, status, Date.now());
   }
 
   private writeToChannel(

--- a/src/profileView/index.html
+++ b/src/profileView/index.html
@@ -106,7 +106,11 @@
             </span>
           </label>
         </div>
-        <details id="modelAccessInfo" class="model-access-info" style="display: none">
+        <details
+          id="modelAccessInfo"
+          class="model-access-info"
+          style="display: none"
+        >
           <summary class="model-access-summary">
             <span id="enabledProvidersInfo"></span>
             <span class="separator">·</span>

--- a/src/progressView/events/ApprovalEvents.ts
+++ b/src/progressView/events/ApprovalEvents.ts
@@ -4,16 +4,17 @@ import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
 // Local file imports
 import {
   createEventDisposable,
-  type BaseEventShared,
   type EventModuleBase,
   type ProgressEventBusLike,
 } from './types';
+import { withEventErrorHandling } from './errorHandling';
+
+const MODULE = 'ApprovalEvents';
 
 /**
- * Shared context for ApprovalEvents module.
- * Extends BaseEventShared with approval-specific callbacks.
+ * Callbacks for approval event handling.
  */
-export interface ApprovalEventsShared extends BaseEventShared {
+export interface ApprovalEventsShared {
   showToolEditApprovalPrompt: (
     payload: ProgressEventPayloads['showToolEditApprovalPrompt'],
   ) => void;
@@ -21,40 +22,40 @@ export interface ApprovalEventsShared extends BaseEventShared {
   updateToolEditApprovalBypassState: (bypassActive: boolean) => void;
 }
 
-/**
- * ApprovalEvents module interface.
- * Uses EventModuleBase pattern (bus only, no state/updater).
- */
 export type ApprovalEventsModule = EventModuleBase;
 
 /**
- * Creates a module for handling tool edit approval events.
- * Follows the established event module pattern used by RetryEvents.
+ * Create approval event module for registration.
  */
 export function createApprovalEvents(
-  shared: ApprovalEventsShared,
+  callbacks: ApprovalEventsShared,
 ): ApprovalEventsModule {
-  const { withErrorBoundary } = shared;
-
   return {
-    register(bus: ProgressEventBusLike) {
+    register(bus) {
       return [
         createEventDisposable(bus, 'showToolEditApprovalPrompt', (payload) =>
-          withErrorBoundary('failed to show approval prompt', () =>
-            shared.showToolEditApprovalPrompt(payload),
+          withEventErrorHandling(MODULE, 'failed to show approval prompt', () =>
+            callbacks.showToolEditApprovalPrompt(payload),
           ),
         ),
         createEventDisposable(bus, 'resolveToolEditApprovalPrompt', (payload) =>
-          withErrorBoundary('failed to resolve approval prompt', () =>
-            shared.resolveToolEditApprovalPrompt(payload.requestId),
+          withEventErrorHandling(
+            MODULE,
+            'failed to resolve approval prompt',
+            () => callbacks.resolveToolEditApprovalPrompt(payload.requestId),
           ),
         ),
         createEventDisposable(
           bus,
           'updateToolEditApprovalBypassState',
           (payload) =>
-            withErrorBoundary('failed to update approval bypass state', () =>
-              shared.updateToolEditApprovalBypassState(payload.bypassActive),
+            withEventErrorHandling(
+              MODULE,
+              'failed to update approval bypass state',
+              () =>
+                callbacks.updateToolEditApprovalBypassState(
+                  payload.bypassActive,
+                ),
             ),
         ),
       ];

--- a/src/progressView/events/LogEvents.ts
+++ b/src/progressView/events/LogEvents.ts
@@ -6,39 +6,42 @@ import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
 import {
   createStatefulEventDisposable,
   sendIfActive,
-  type BaseEventShared,
+  type ProgressEventBusLike,
   type StatefulEventModule,
 } from './types';
+import { withEventErrorHandling } from './errorHandling';
+
+const MODULE = 'LogEvents';
 
 export type LogEventsModule = StatefulEventModule;
 
-export function createLogEvents(shared: BaseEventShared): LogEventsModule {
-  const { withErrorBoundary } = shared;
+const handleAddLogMessage = (
+  data: ProgressEventPayloads['addLogMessage'],
+  state: ProgressViewState,
+  updater: WebviewUpdater,
+): void => {
+  // Note: Debug level and INTERNAL message filtering is done at the source
+  // in VSCodeTransport.emitLogEvent() before events reach this handler.
+  withEventErrorHandling(MODULE, 'failed to handle addLogMessage', async () => {
+    const { stream, logMessage } = data;
 
-  const handleAddLogMessage = (
-    data: ProgressEventPayloads['addLogMessage'],
-    state: ProgressViewState,
-    updater: WebviewUpdater,
-  ): void => {
-    // Note: Debug level and INTERNAL message filtering is done at the source
-    // in VSCodeTransport.emitLogEvent() before events reach this handler.
-    withErrorBoundary('failed to handle addLogMessage', async () => {
-      const { stream, logMessage } = data;
+    const isNew = await state.streamTabs.addMessage(stream, logMessage);
 
-      const isNew = await state.streamTabs.addMessage(stream, logMessage);
+    if (isNew && updater.isAvailable()) {
+      updater.appendLogMessage(stream, logMessage);
+    }
+  });
+};
 
-      if (isNew && updater.isAvailable()) {
-        updater.appendLogMessage(stream, logMessage);
-      }
-    });
-  };
-
-  const handleUpdateLogMessage = (
-    data: ProgressEventPayloads['updateLogMessage'],
-    state: ProgressViewState,
-    updater: WebviewUpdater,
-  ): void => {
-    withErrorBoundary('failed to handle updateLogMessage', async () => {
+const handleUpdateLogMessage = (
+  data: ProgressEventPayloads['updateLogMessage'],
+  state: ProgressViewState,
+  updater: WebviewUpdater,
+): void => {
+  withEventErrorHandling(
+    MODULE,
+    'failed to handle updateLogMessage',
+    async () => {
       const { stream, logMessage } = data;
 
       if (!state.streamTabs.has(stream)) {
@@ -72,9 +75,14 @@ export function createLogEvents(shared: BaseEventShared): LogEventsModule {
       sendIfActive(stream, state, updater, () => {
         updater.updateLogMessage(stream, existing);
       });
-    });
-  };
+    },
+  );
+};
 
+/**
+ * Create log event module for registration.
+ */
+export function createLogEvents(_shared: unknown = {}): LogEventsModule {
   return {
     register(bus, state, updater) {
       return [

--- a/src/progressView/events/OutputEvents.ts
+++ b/src/progressView/events/OutputEvents.ts
@@ -1,10 +1,17 @@
+// Type imports
+import type { WebviewUpdater } from '@progressView/managers';
+import type { ProgressViewState } from '@progressView/state/ProgressViewState';
+
 // Local file imports
 import {
   createStatefulEventDisposable,
   sendIfActive,
-  type BaseEventShared,
+  type ProgressEventBusLike,
   type StatefulEventModule,
 } from './types';
+import { withEventErrorHandling } from './errorHandling';
+
+const MODULE = 'OutputEvents';
 
 export type OutputEventsModule = StatefulEventModule;
 
@@ -14,11 +21,10 @@ const toRoundRecord = <T>(
 ): Record<number, T[]> | undefined =>
   rounds && rounds.size > 0 ? Object.fromEntries(rounds.entries()) : undefined;
 
-export function createOutputEvents(
-  shared: BaseEventShared,
-): OutputEventsModule {
-  const { withErrorBoundary } = shared;
-
+/**
+ * Create output event module for registration.
+ */
+export function createOutputEvents(_shared: unknown = {}): OutputEventsModule {
   return {
     register(bus, state, updater) {
       return [
@@ -28,22 +34,28 @@ export function createOutputEvents(
           state,
           updater,
           ({ stream, storageKey, filesByRound }) => {
-            withErrorBoundary('failed to handle addOutputFiles', async () => {
-              await state.outputFiles.addFiles(
-                stream,
-                storageKey,
-                filesByRound,
-              );
-              if (!updater.isAvailable()) return;
-              const runFiles = state.outputFiles
-                .getFiles(stream)
-                .get(storageKey);
-              const rounds = toRoundRecord(runFiles);
-              updater.updateFiles(
-                stream,
-                rounds ? { runId: storageKey, rounds } : { runId: storageKey },
-              );
-            });
+            withEventErrorHandling(
+              MODULE,
+              'failed to handle addOutputFiles',
+              async () => {
+                await state.outputFiles.addFiles(
+                  stream,
+                  storageKey,
+                  filesByRound,
+                );
+                if (!updater.isAvailable()) return;
+                const runFiles = state.outputFiles
+                  .getFiles(stream)
+                  .get(storageKey);
+                const rounds = toRoundRecord(runFiles);
+                updater.updateFiles(
+                  stream,
+                  rounds
+                    ? { runId: storageKey, rounds }
+                    : { runId: storageKey },
+                );
+              },
+            );
           },
         ),
         createStatefulEventDisposable(
@@ -52,7 +64,8 @@ export function createOutputEvents(
           state,
           updater,
           ({ stream, storageKey, filesByRound }) => {
-            withErrorBoundary(
+            withEventErrorHandling(
+              MODULE,
               'failed to handle updateMissingOutputs',
               async () => {
                 await state.outputFiles.updateMissingOutputs(
@@ -81,7 +94,8 @@ export function createOutputEvents(
           state,
           updater,
           ({ stream }) => {
-            withErrorBoundary(
+            withEventErrorHandling(
+              MODULE,
               'failed to handle clearMissingOutputs',
               async () => {
                 await state.outputFiles.clearMissingOutputs(stream);

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -19,7 +19,6 @@ import { bus } from '@eventBus/ProgressEventBus';
 
 // Local file imports
 import type { StreamStatus } from '@eventBus/ProgressEventBus';
-import { createErrorBoundary } from './errorHandling';
 import {
   createStreamStatusEvents,
   type StreamStatusEventModule,
@@ -82,44 +81,30 @@ export class ProgressEventHandler {
   ) {
     this.logger = new AgentLogger('ProgressEventHandler');
 
-    // Create error boundaries centrally - modules receive pre-configured boundaries
+    // Modules now use withEventErrorHandling() directly - no error boundary injection needed
     this.streamStatusEvents = createStreamStatusEvents({
-      withErrorBoundary: createErrorBoundary(this.logger, 'StreamStatusEvents'),
       streamStatus: this._streamStatus,
       setStreamStatus: this.setStreamStatus.bind(this),
       sendInstructionUpdate: this.sendInstructionUpdate.bind(this),
       refreshStreamSurface: this.refreshStreamSurface.bind(this),
-      warnLog: this.logger.warn.bind(this.logger),
       debugLog: this.logger.debug.bind(this.logger),
       replayPendingTaskGroups: this.replayPendingTaskGroups.bind(this),
     });
-    this.outputEvents = createOutputEvents({
-      withErrorBoundary: createErrorBoundary(this.logger, 'OutputEvents'),
-    });
-    this.usageEvents = createUsageEvents({
-      withErrorBoundary: createErrorBoundary(this.logger, 'UsageEvents'),
-    });
-    this.logEvents = createLogEvents({
-      withErrorBoundary: createErrorBoundary(this.logger, 'LogEvents'),
-    });
+    this.outputEvents = createOutputEvents({});
+    this.usageEvents = createUsageEvents({});
+    this.logEvents = createLogEvents({});
     this.taskGroupEvents = createTaskGroupEvents({
-      withErrorBoundary: createErrorBoundary(this.logger, 'TaskGroupEvents'),
       initializeStreamForTaskGroup:
         this.initializeStreamForTaskGroup.bind(this),
       debugLog: this.logger.debug.bind(this.logger),
       bufferTaskGroupForReplay: this.bufferTaskGroupForReplay.bind(this),
     });
-    this.todoEvents = createTodoEvents({
-      withErrorBoundary: createErrorBoundary(this.logger, 'TodoEvents'),
-      debugLog: this.logger.debug.bind(this.logger),
-    });
+    this.todoEvents = createTodoEvents({});
     this.retryEvents = createRetryEvents({
-      withErrorBoundary: createErrorBoundary(this.logger, 'RetryEvents'),
       showRetryRequest: callbacks.showRetryRequest,
       resolveRetryRequest: callbacks.resolveRetryRequest,
     });
     this.approvalEvents = createApprovalEvents({
-      withErrorBoundary: createErrorBoundary(this.logger, 'ApprovalEvents'),
       showToolEditApprovalPrompt: callbacks.showToolEditApprovalPrompt,
       resolveToolEditApprovalPrompt: callbacks.resolveToolEditApprovalPrompt,
       updateToolEditApprovalBypassState:

--- a/src/progressView/events/RetryEvents.ts
+++ b/src/progressView/events/RetryEvents.ts
@@ -4,50 +4,44 @@ import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
 // Local file imports
 import {
   createEventDisposable,
-  type BaseEventShared,
   type EventModuleBase,
   type ProgressEventBusLike,
 } from './types';
+import { withEventErrorHandling } from './errorHandling';
+
+const MODULE = 'RetryEvents';
 
 /**
- * Shared context for RetryEvents module.
- * Extends BaseEventShared with retry-specific callbacks.
+ * Callbacks for retry event handling.
  */
-export interface RetryEventsShared extends BaseEventShared {
-  /** Callback to show retry request (routes through provider for queueing) */
+export interface RetryEventsShared {
   showRetryRequest: (
     payload: ProgressEventPayloads['showRetryRequest'],
   ) => void;
-  /** Callback to resolve retry request (routes through provider for queueing) */
   resolveRetryRequest: (streamId: string) => void;
 }
 
-/**
- * RetryEvents module interface.
- * Uses EventModuleBase pattern (bus only, no state/updater).
- */
 export type RetryEventsModule = EventModuleBase;
 
 /**
- * Creates a module for handling retry request events.
- * Follows the established event module pattern used by StreamStatusEvents, LogEvents, etc.
+ * Create retry event module for registration.
  */
 export function createRetryEvents(
-  shared: RetryEventsShared,
+  callbacks: RetryEventsShared,
 ): RetryEventsModule {
-  const { withErrorBoundary } = shared;
-
   return {
-    register(bus: ProgressEventBusLike) {
+    register(bus) {
       return [
         createEventDisposable(bus, 'showRetryRequest', (payload) =>
-          withErrorBoundary('failed to show retry request', () =>
-            shared.showRetryRequest(payload),
+          withEventErrorHandling(MODULE, 'failed to show retry request', () =>
+            callbacks.showRetryRequest(payload),
           ),
         ),
         createEventDisposable(bus, 'resolveRetryRequest', (payload) =>
-          withErrorBoundary('failed to resolve retry request', () =>
-            shared.resolveRetryRequest(payload.streamId),
+          withEventErrorHandling(
+            MODULE,
+            'failed to resolve retry request',
+            () => callbacks.resolveRetryRequest(payload.streamId),
           ),
         ),
       ];

--- a/src/progressView/events/StreamStatusEvents.ts
+++ b/src/progressView/events/StreamStatusEvents.ts
@@ -38,7 +38,7 @@ export interface StreamStatusEventShared {
 export type StreamStatusEventModule = StatefulEventModule;
 
 export function createStreamStatusEvents(
-  shared: StreamStatusEventShared & { withErrorBoundary?: unknown },
+  shared: StreamStatusEventShared,
 ): StreamStatusEventModule {
   const { debugLog } = shared;
 

--- a/src/progressView/events/StreamStatusEvents.ts
+++ b/src/progressView/events/StreamStatusEvents.ts
@@ -14,15 +14,16 @@ import type {
 import {
   createStatefulEventDisposable,
   type ProgressEventBusLike,
+  type StatefulEventModule,
 } from './types';
-import type { BaseEventShared, StatefulEventModule } from './types';
+import { withEventErrorHandling } from './errorHandling';
+
+const MODULE = 'StreamStatusEvents';
 
 /**
- * Shared context for StreamStatusEvents module.
- * Extends BaseEventShared with stream status management callbacks.
- * Also requires logging callbacks for warn/debug messages.
+ * Callbacks for stream status event handling.
  */
-export interface StreamStatusEventShared extends BaseEventShared {
+export interface StreamStatusEventShared {
   streamStatus: Map<string, StreamStatus>;
   setStreamStatus(stream: string, status: StreamStatus): void;
   sendInstructionUpdate(stream: StreamTabId | '', runId?: string | null): void;
@@ -30,96 +31,91 @@ export interface StreamStatusEventShared extends BaseEventShared {
     stream: string,
     options?: { updateInstruction?: boolean; forceRebuild?: boolean },
   ): string | null;
-  warnLog(message: string): void;
   debugLog(message: string): void;
-  /**
-   * Replay any task groups that were buffered while waiting for this stream
-   * to become active. Called after state.activeStream is set.
-   */
   replayPendingTaskGroups(stream: string, updater: WebviewUpdater): void;
 }
 
-/**
- * StreamStatusEvents module interface.
- * Uses StatefulEventModule pattern for state/updater access.
- */
 export type StreamStatusEventModule = StatefulEventModule;
 
 export function createStreamStatusEvents(
-  shared: StreamStatusEventShared,
+  shared: StreamStatusEventShared & { withErrorBoundary?: unknown },
 ): StreamStatusEventModule {
-  const { withErrorBoundary, warnLog, debugLog } = shared;
+  const { debugLog } = shared;
 
   const handleSetActiveStream = (
     payload: ProgressEventPayloads['setActiveStream'],
     state: ProgressViewState,
     updater: WebviewUpdater,
   ): void => {
-    withErrorBoundary('failed to handle setActiveStream', async () => {
-      const { stream, session, isRemote, hasMultipleOutputs } = payload;
+    withEventErrorHandling(
+      MODULE,
+      'failed to handle setActiveStream',
+      async () => {
+        const { stream, session, isRemote, hasMultipleOutputs } = payload;
 
-      if (!stream) {
-        return;
-      }
+        if (!stream) {
+          return;
+        }
 
-      // Track if this is actually switching to a different stream
-      const previousStream = state.activeStream;
-      const isStreamSwitch = previousStream !== stream;
+        // Track if this is actually switching to a different stream
+        const previousStream = state.activeStream;
+        const isStreamSwitch = previousStream !== stream;
 
-      await state.streamTabs.ensureStream(stream);
+        await state.streamTabs.ensureStream(stream);
 
-      // Store hints so the UI can show indicators before the full TaskState is set
-      state.updateStreamHints(stream, {
-        sessionCategory: session?.agentCategory,
-        isRemote,
-        hasMultipleOutputs,
-      });
-
-      const currentFilter = state.agentTypeFilter;
-      const targetCategory = session?.agentCategory;
-      if (
-        targetCategory &&
-        currentFilter !== 'all' &&
-        currentFilter !== targetCategory
-      ) {
-        state.agentTypeFilter = targetCategory;
-      }
-
-      state.activeStream = stream;
-
-      // Replay any task groups that were buffered before this stream became active.
-      // Must be called AFTER setting state.activeStream so subsequent events see it.
-      if (updater.isAvailable()) {
-        shared.replayPendingTaskGroups(stream, updater);
-      }
-
-      const status: StreamStatus =
-        shared.streamStatus.get(stream) ?? STREAM_STATUS.RUNNING;
-
-      if (updater.isAvailable()) {
-        // ORDERING REQUIREMENTS:
-        // 1. ensureStream (line 70) must be awaited BEFORE this block to ensure
-        //    backend state.streamTabs.has(stream) returns true in setStreamStatus.
-        // 2. updateAll sends UPDATE_STREAMS which creates the frontend tab.
-        // 3. setStreamStatus sends UPDATE_STREAM_STATUS to update the existing tab.
-        // Frontend processes messages FIFO, so tab exists before status update.
-        // If setStreamStatus is called before stream is in backend state, it will
-        // trigger another full updateAll, which is inefficient but safe.
-        updater.updateAll(state, shared.streamStatus);
-      }
-
-      shared.setStreamStatus(stream, status);
-
-      if (updater.isAvailable()) {
-        // Only force rebuild when actually switching streams.
-        // Use the returned runId to avoid duplicate resolveRunId call.
-        const activeRunId = shared.refreshStreamSurface(stream, {
-          updateInstruction: false,
-          forceRebuild: isStreamSwitch,
+        // Store hints so the UI can show indicators before the full TaskState is set
+        state.updateStreamHints(stream, {
+          sessionCategory: session?.agentCategory,
+          isRemote,
+          hasMultipleOutputs,
         });
-        shared.sendInstructionUpdate(stream, activeRunId);
-      }
-    });
+
+        const currentFilter = state.agentTypeFilter;
+        const targetCategory = session?.agentCategory;
+        if (
+          targetCategory &&
+          currentFilter !== 'all' &&
+          currentFilter !== targetCategory
+        ) {
+          state.agentTypeFilter = targetCategory;
+        }
+
+        state.activeStream = stream;
+
+        // Replay any task groups that were buffered before this stream became active.
+        // Must be called AFTER setting state.activeStream so subsequent events see it.
+        if (updater.isAvailable()) {
+          shared.replayPendingTaskGroups(stream, updater);
+        }
+
+        const status: StreamStatus =
+          shared.streamStatus.get(stream) ?? STREAM_STATUS.RUNNING;
+
+        if (updater.isAvailable()) {
+          // ORDERING REQUIREMENTS:
+          // 1. ensureStream (line 70) must be awaited BEFORE this block to ensure
+          //    backend state.streamTabs.has(stream) returns true in setStreamStatus.
+          // 2. updateAll sends UPDATE_STREAMS which creates the frontend tab.
+          // 3. setStreamStatus sends UPDATE_STREAM_STATUS to update the existing tab.
+          // Frontend processes messages FIFO, so tab exists before status update.
+          // If setStreamStatus is called before stream is in backend state, it will
+          // trigger another full updateAll, which is inefficient but safe.
+          updater.updateAll(state, shared.streamStatus);
+        }
+
+        shared.setStreamStatus(stream, status);
+
+        if (updater.isAvailable()) {
+          // Only force rebuild when actually switching streams.
+          // Use the returned runId to avoid duplicate resolveRunId call.
+          const activeRunId = shared.refreshStreamSurface(stream, {
+            updateInstruction: false,
+            forceRebuild: isStreamSwitch,
+          });
+          shared.sendInstructionUpdate(stream, activeRunId);
+        }
+      },
+    );
   };
 
   const handleSetTaskState = (
@@ -127,7 +123,7 @@ export function createStreamStatusEvents(
     state: ProgressViewState,
     updater: WebviewUpdater,
   ): void => {
-    withErrorBoundary('failed to handle setTaskState', () => {
+    withEventErrorHandling(MODULE, 'failed to handle setTaskState', () => {
       const { streamTabId, executionId, taskState } = data;
 
       state.setTaskState(streamTabId, taskState);
@@ -185,8 +181,10 @@ export function createStreamStatusEvents(
           state,
           updater,
           (payload) => {
-            withErrorBoundary('failed to handle updateStreamStatus', () =>
-              shared.setStreamStatus(payload.stream, payload.status),
+            withEventErrorHandling(
+              MODULE,
+              'failed to handle updateStreamStatus',
+              () => shared.setStreamStatus(payload.stream, payload.status),
             );
           },
         ),

--- a/src/progressView/events/TaskGroupEvents.ts
+++ b/src/progressView/events/TaskGroupEvents.ts
@@ -26,7 +26,7 @@ interface TaskGroupEventsShared {
 export type TaskGroupEventsModule = StatefulEventModule;
 
 export function createTaskGroupEvents(
-  shared: TaskGroupEventsShared & { withErrorBoundary?: unknown },
+  shared: TaskGroupEventsShared,
 ): TaskGroupEventsModule {
   const { debugLog } = shared;
 

--- a/src/progressView/events/TaskGroupEvents.ts
+++ b/src/progressView/events/TaskGroupEvents.ts
@@ -8,34 +8,27 @@ import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
 import {
   createStatefulEventDisposable,
   type ProgressEventBusLike,
+  type StatefulEventModule,
 } from './types';
-import type { BaseEventShared, StatefulEventModule } from './types';
+import { withEventErrorHandling } from './errorHandling';
+
+const MODULE = 'TaskGroupEvents';
 
 /**
- * Shared context for TaskGroupEvents module.
- * Extends BaseEventShared with task group initialization callback.
- * Also requires debugLog for verbose logging during stream creation.
+ * Callbacks for task group event handling.
  */
-interface TaskGroupEventsShared extends BaseEventShared {
+interface TaskGroupEventsShared {
   initializeStreamForTaskGroup(stream: string): Promise<void>;
   debugLog(message: string): void;
-  /**
-   * Buffer a task group for later replay when the stream becomes active.
-   * Used when addTaskGroup arrives before setActiveStream for a stream.
-   */
   bufferTaskGroupForReplay(stream: string, group: TaskGroup): void;
 }
 
-/**
- * TaskGroupEvents module interface.
- * Uses StatefulEventModule pattern for state/updater access.
- */
 export type TaskGroupEventsModule = StatefulEventModule;
 
 export function createTaskGroupEvents(
-  shared: TaskGroupEventsShared,
+  shared: TaskGroupEventsShared & { withErrorBoundary?: unknown },
 ): TaskGroupEventsModule {
-  const { withErrorBoundary, debugLog } = shared;
+  const { debugLog } = shared;
 
   const handleAddTaskGroup = (
     data: ProgressEventPayloads['addTaskGroup'],
@@ -46,47 +39,51 @@ export function createTaskGroupEvents(
       `addTaskGroup: id=${data.id}, name=${data.name}, parentGroupId=${data.parentGroupId ?? 'none'}, stream=${data.stream}`,
     );
 
-    withErrorBoundary('failed to handle addTaskGroup', async () => {
-      const { stream, ...group } = data;
-      const { id, parentGroupId } = group;
+    withEventErrorHandling(
+      MODULE,
+      'failed to handle addTaskGroup',
+      async () => {
+        const { stream, ...group } = data;
+        const { id, parentGroupId } = group;
 
-      const hasStream = state.streamTabs.has(stream);
+        const hasStream = state.streamTabs.has(stream);
 
-      // Add group to state BEFORE initializeStreamForTaskGroup, so that
-      // refreshStreamSurface (called inside) includes this group in UPDATE_LOGS.
-      // addGroup synchronously adds to in-memory state; save is async.
-      const addGroupPromise = state.taskGroups.addGroup(stream, id, group);
+        // Add group to state BEFORE initializeStreamForTaskGroup, so that
+        // refreshStreamSurface (called inside) includes this group in UPDATE_LOGS.
+        // addGroup synchronously adds to in-memory state; save is async.
+        const addGroupPromise = state.taskGroups.addGroup(stream, id, group);
 
-      if (!parentGroupId) {
-        state.setActiveRunId(stream, id);
-      }
-
-      if (!hasStream) {
-        debugLog(`Creating stream from addTaskGroup: ${stream}`);
-        // Initialize stream after group is in state. This sends UPDATE_LOGS
-        // with forceRebuild: true, which will include the new group.
-        await shared.initializeStreamForTaskGroup(stream);
-      }
-
-      // Send ADD_TASK_GROUP to frontend only if this stream is currently active.
-      // If the stream isn't active yet (addTaskGroup arrived before setActiveStream),
-      // buffer the group for replay when setActiveStream is processed.
-      // This fixes the race condition where Init groups are dropped by the frontend
-      // because state.activeStream isn't set when the ADD_TASK_GROUP message arrives.
-      if (updater.isAvailable()) {
-        if (stream === state.activeStream) {
-          updater.addTaskGroup(stream, group);
-        } else {
-          debugLog(
-            `Buffering task group ${id} for stream ${stream} (activeStream=${state.activeStream})`,
-          );
-          shared.bufferTaskGroupForReplay(stream, group);
+        if (!parentGroupId) {
+          state.setActiveRunId(stream, id);
         }
-      }
 
-      // Ensure group persistence completes
-      await addGroupPromise;
-    });
+        if (!hasStream) {
+          debugLog(`Creating stream from addTaskGroup: ${stream}`);
+          // Initialize stream after group is in state. This sends UPDATE_LOGS
+          // with forceRebuild: true, which will include the new group.
+          await shared.initializeStreamForTaskGroup(stream);
+        }
+
+        // Send ADD_TASK_GROUP to frontend only if this stream is currently active.
+        // If the stream isn't active yet (addTaskGroup arrived before setActiveStream),
+        // buffer the group for replay when setActiveStream is processed.
+        // This fixes the race condition where Init groups are dropped by the frontend
+        // because state.activeStream isn't set when the ADD_TASK_GROUP message arrives.
+        if (updater.isAvailable()) {
+          if (stream === state.activeStream) {
+            updater.addTaskGroup(stream, group);
+          } else {
+            debugLog(
+              `Buffering task group ${id} for stream ${stream} (activeStream=${state.activeStream})`,
+            );
+            shared.bufferTaskGroupForReplay(stream, group);
+          }
+        }
+
+        // Ensure group persistence completes
+        await addGroupPromise;
+      },
+    );
   };
 
   const handleUpdateTaskGroup = (
@@ -98,20 +95,24 @@ export function createTaskGroupEvents(
       `updateTaskGroup: id=${data.id}, status=${data.status}, stream=${data.stream}`,
     );
 
-    withErrorBoundary('failed to handle updateTaskGroup', async () => {
-      // Pass event data directly - no transformation needed
-      await state.taskGroups.updateGroup(data);
+    withEventErrorHandling(
+      MODULE,
+      'failed to handle updateTaskGroup',
+      async () => {
+        // Pass event data directly - no transformation needed
+        await state.taskGroups.updateGroup(data);
 
-      const shouldSendToWebview =
-        updater.isAvailable() && data.stream === state.activeStream;
-      debugLog(
-        `updateTaskGroup: shouldSendToWebview=${shouldSendToWebview}, activeStream=${state.activeStream}`,
-      );
+        const shouldSendToWebview =
+          updater.isAvailable() && data.stream === state.activeStream;
+        debugLog(
+          `updateTaskGroup: shouldSendToWebview=${shouldSendToWebview}, activeStream=${state.activeStream}`,
+        );
 
-      if (shouldSendToWebview) {
-        updater.updateTaskGroup(data);
-      }
-    });
+        if (shouldSendToWebview) {
+          updater.updateTaskGroup(data);
+        }
+      },
+    );
   };
 
   return {

--- a/src/progressView/events/TodoEvents.ts
+++ b/src/progressView/events/TodoEvents.ts
@@ -2,55 +2,38 @@
 import type { WebviewUpdater } from '@progressView/managers';
 import type { ProgressViewState } from '@progressView/state/ProgressViewState';
 import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
-import { TODO_STATUS } from '@eventBus/schemas';
 
 // Local file imports
 import {
   createStatefulEventDisposable,
   sendIfActive,
-  type BaseEventShared,
+  type ProgressEventBusLike,
   type StatefulEventModule,
 } from './types';
+import { withEventErrorHandling } from './errorHandling';
 
-/**
- * Shared context for TodoEvents module.
- * Extends BaseEventShared with debug logging.
- */
-interface TodoEventsShared extends BaseEventShared {
-  debugLog(message: string): void;
-}
+const MODULE = 'TodoEvents';
 
-/**
- * TodoEvents module interface.
- * Uses StatefulEventModule pattern for state/updater access.
- */
 export type TodoEventsModule = StatefulEventModule;
 
-export function createTodoEvents(shared: TodoEventsShared): TodoEventsModule {
-  const { withErrorBoundary, debugLog } = shared;
-
-  const handleUpdateTodos = (
-    data: ProgressEventPayloads['updateTodos'],
-    state: ProgressViewState,
-    updater: WebviewUpdater,
-  ): void => {
-    const todoCount = data.todos.length;
-    const inProgress = data.todos.filter(
-      (t) => t.status === TODO_STATUS.IN_PROGRESS,
-    ).length;
-    debugLog(
-      `updateTodos: stream=${data.stream}, count=${todoCount}, inProgress=${inProgress}`,
-    );
-
-    withErrorBoundary('failed to handle updateTodos', () => {
-      const { stream, todos } = data;
-      state.setTodos(stream, todos);
-      sendIfActive(stream, state, updater, () => {
-        updater.updateTodos(stream, todos);
-      });
+const handleUpdateTodos = (
+  data: ProgressEventPayloads['updateTodos'],
+  state: ProgressViewState,
+  updater: WebviewUpdater,
+): void => {
+  withEventErrorHandling(MODULE, 'failed to handle updateTodos', () => {
+    const { stream, todos } = data;
+    state.setTodos(stream, todos);
+    sendIfActive(stream, state, updater, () => {
+      updater.updateTodos(stream, todos);
     });
-  };
+  });
+};
 
+/**
+ * Create todo event module for registration.
+ */
+export function createTodoEvents(_shared: unknown = {}): TodoEventsModule {
   return {
     register(bus, state, updater) {
       return [

--- a/src/progressView/events/UsageEvents.ts
+++ b/src/progressView/events/UsageEvents.ts
@@ -1,19 +1,25 @@
 // Type imports
 import type { TokenUsageStats } from '@agent/types/UsageTypes';
+import type { WebviewUpdater } from '@progressView/managers';
+import type { ProgressViewState } from '@progressView/state/ProgressViewState';
 
 // Local file imports
 import {
   createStatefulEventDisposable,
   sendIfActive,
-  type BaseEventShared,
+  type ProgressEventBusLike,
   type StatefulEventModule,
 } from './types';
+import { withEventErrorHandling } from './errorHandling';
+
+const MODULE = 'UsageEvents';
 
 export type UsageEventsModule = StatefulEventModule;
 
-export function createUsageEvents(shared: BaseEventShared): UsageEventsModule {
-  const { withErrorBoundary } = shared;
-
+/**
+ * Create usage event module for registration.
+ */
+export function createUsageEvents(_shared: unknown = {}): UsageEventsModule {
   return {
     register(bus, state, updater) {
       return [
@@ -23,7 +29,8 @@ export function createUsageEvents(shared: BaseEventShared): UsageEventsModule {
           state,
           updater,
           ({ stream, usage, storageKey }) => {
-            withErrorBoundary(
+            withEventErrorHandling(
+              MODULE,
               'failed to handle updateStreamUsage',
               async () => {
                 const normalizedUsage: TokenUsageStats = {

--- a/src/progressView/events/errorHandling.ts
+++ b/src/progressView/events/errorHandling.ts
@@ -1,15 +1,6 @@
 // Local imports - logger
-import type { AgentLogger } from '@logger/AgentLogger';
+import { AgentLogger } from '@logger/AgentLogger';
 import { serializeError } from '@utils/core';
-
-/**
- * Type for error boundary functions created by createErrorBoundary.
- * Wraps async handlers to catch and log errors.
- */
-export type ErrorBoundaryFn = (
-  context: string,
-  fn: () => unknown | Promise<unknown>,
-) => void;
 
 /** Serialize an error for logging, preserving original error reference. */
 function serializeErrorForLog(error: unknown): Record<string, unknown> {
@@ -19,24 +10,34 @@ function serializeErrorForLog(error: unknown): Record<string, unknown> {
   return { error };
 }
 
-export function createErrorBoundary(
-  logger: AgentLogger,
+// Shared logger for all event handlers - eliminates per-module logger instances
+const eventLogger = new AgentLogger('ProgressEvents');
+
+/**
+ * Wraps an async event handler with error logging.
+ * Single source of truth for event error handling.
+ *
+ * @param moduleName - Module name for error context (e.g., 'LogEvents')
+ * @param context - Error context message (e.g., 'failed to handle addLogMessage')
+ * @param fn - The async handler function to wrap
+ */
+export function withEventErrorHandling(
   moduleName: string,
-): ErrorBoundaryFn {
-  return (context: string, fn: () => unknown | Promise<unknown>): void => {
-    try {
-      const result = fn();
-      if (result && typeof (result as Promise<unknown>).catch === 'function') {
-        void (result as Promise<unknown>).catch((error) => {
-          logger.error(`[${moduleName}] ${context}`, {
-            data: serializeErrorForLog(error),
-          });
+  context: string,
+  fn: () => unknown | Promise<unknown>,
+): void {
+  try {
+    const result = fn();
+    if (result && typeof (result as Promise<unknown>).catch === 'function') {
+      void (result as Promise<unknown>).catch((error) => {
+        eventLogger.error(`[${moduleName}] ${context}`, {
+          data: serializeErrorForLog(error),
         });
-      }
-    } catch (error) {
-      logger.error(`[${moduleName}] ${context}`, {
-        data: serializeErrorForLog(error),
       });
     }
-  };
+  } catch (error) {
+    eventLogger.error(`[${moduleName}] ${context}`, {
+      data: serializeErrorForLog(error),
+    });
+  }
 }

--- a/src/progressView/events/index.ts
+++ b/src/progressView/events/index.ts
@@ -1,5 +1,5 @@
 // Barrel export for progress view events
-export { createErrorBoundary } from './errorHandling';
+export { withEventErrorHandling } from './errorHandling';
 export { LogEventsModule, createLogEvents } from './LogEvents';
 export { OutputEventsModule, createOutputEvents } from './OutputEvents';
 export { ProgressEventHandler } from './ProgressEventHandler';

--- a/src/progressView/events/types.ts
+++ b/src/progressView/events/types.ts
@@ -9,9 +9,6 @@ import type {
   ProgressEventPayloads,
 } from '@eventBus/ProgressEventBus';
 
-// Local imports
-import type { ErrorBoundaryFn } from './errorHandling';
-
 // ============================================================================
 // Event Bus Interface
 // ============================================================================
@@ -28,16 +25,8 @@ export interface ProgressEventBusLike {
 }
 
 // ============================================================================
-// Base Interfaces for Event Modules
+// Event Module Interfaces
 // ============================================================================
-
-/**
- * Base shared context for all event modules.
- * Provides pre-configured error boundary - modules don't need to create their own.
- */
-export interface BaseEventShared {
-  withErrorBoundary: ErrorBoundaryFn;
-}
 
 /**
  * Base event module interface for simple event handlers (bus only).

--- a/src/test/progressView/events/LogEvents.test.ts
+++ b/src/test/progressView/events/LogEvents.test.ts
@@ -2,12 +2,10 @@
 import { strict as assert } from 'assert';
 
 // Local imports - logger
-import { AgentLogger } from '@logger/AgentLogger';
 import type { LogMessageData } from '@logger/LogTypes';
 import { MESSAGE_TYPES } from '@logger/messageTypes';
 
 // Local imports - progress view
-import { createErrorBoundary } from '@progressView/events/errorHandling';
 import { createLogEvents } from '@progressView/events/LogEvents';
 import type { ProgressEventBusLike } from '@progressView/events/types';
 import { StreamTabsManager } from '@progressView/managers/StreamTabsManager';
@@ -80,9 +78,7 @@ describe('LogEvents', () => {
     } as unknown as WebviewUpdater;
 
     const bus = new TestBus();
-    const logger = new AgentLogger('LogEventsTest');
-    const withErrorBoundary = createErrorBoundary(logger, 'LogEventsTest');
-    const { register } = createLogEvents({ withErrorBoundary });
+    const { register } = createLogEvents();
     const disposables = register(bus, state, updater);
 
     const thinkingMessage: LogMessageData = {


### PR DESCRIPTION
Key changes:
- Cache logger channel entries in logUtils to avoid repeated registry.ensure() calls
- Remove VSCodeTransport.groups Map duplication (now uses TaskGroupManager only)
- Replace per-module error boundary closures with shared withEventErrorHandling()
- Consolidate event module patterns for consistency
- Remove deprecated BaseEventShared interface and createErrorBoundary

This reduces abstraction overhead and establishes a single source of truth for:
- Logger channel initialization (cached in initializedChannels Map)
- Event error handling (shared eventLogger in errorHandling.ts)
- Task group state (only in TaskGroupManager, not also in VSCodeTransport)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Streamlines logging and progress event handling.
> 
> - Cache `registry.ensure()` results in `logUtils` via `initializedChannels` and `getCachedEntry`; reuse transport/logger across logs
> - Remove duplicate task group state from `VSCodeTransport` (no internal `groups`/`activeGroupId`), emitting only bus events
> - Replace per-module error boundaries with shared `withEventErrorHandling` and a single `eventLogger`; drop `BaseEventShared` and `createErrorBoundary`
> - Normalize event modules (Approval/Retry/Log/Output/Usage/Todo/StreamStatus/TaskGroup): simpler `register` signatures, helpers in `types.ts`, and consistent error wrapping
> - Update `ProgressEventHandler` wiring to match new module APIs; minor HTML formatting and test updates
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1f798b0a88527a92679955f56cf1af7f5012c9af. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->