### PR TITLE
refactor: separate agent core logic from VS Code dependencies

### DIFF
--- a/src/agent/remote/remoteAgentUtils.ts
+++ b/src/agent/remote/remoteAgentUtils.ts
@@ -10,6 +10,10 @@ import { MAIN_VIEW_COMMANDS } from '@common/webview';
 
 // Local imports - frontend
 import { getMainWebview } from '@frontend/system/commandUtils';
+import {
+  showInfoMessage,
+  showWarningMessage,
+} from '@frontend/ui/messageUtils';
 
 // Local imports - logger
 import * as logger from '@logger/logUtils';
@@ -40,7 +44,7 @@ async function handleSelectionFallback(
 ): Promise<SelectAgentResult> {
   if (copyToClipboard) {
     await vscode.env.clipboard.writeText(agentName);
-    void vscode.window.showInformationMessage(
+    void showInfoMessage(
       `Could not auto-select agent. Agent name "${agentName}" copied to clipboard - paste it in the agent selector.`,
     );
     return {
@@ -51,7 +55,7 @@ async function handleSelectionFallback(
       fallbackAction: 'clipboard',
     };
   } else {
-    void vscode.window.showWarningMessage(
+    void showWarningMessage(
       `Could not auto-select agent. Please manually select "${agentName}" in the agent dropdown.`,
     );
     return {
@@ -117,7 +121,7 @@ export async function selectAgentInMainView(
       });
 
       if (showSuccessMessage) {
-        void vscode.window.showInformationMessage(
+        void showInfoMessage(
           `Agent "${agentName}" is now selected in the main view.`,
         );
       }

--- a/src/agent/runtime/agentLoad.ts
+++ b/src/agent/runtime/agentLoad.ts
@@ -3,7 +3,6 @@ import * as path from 'path';
 
 // Third-party imports
 import deepmerge from 'deepmerge';
-import * as vscode from 'vscode';
 import * as yaml from 'yaml';
 
 // Local imports - agent components
@@ -181,10 +180,9 @@ export async function loadAgentSettingAndPrompts(
     // The agent's name (declaredAgentName) is known in this scope but not part of AgentSetting.
     return [settings as AgentSetting, prompts as AgentPrompt];
   } catch (err) {
-    vscode.window.showErrorMessage(
-      `Error loading agent settings and prompts: ${toErrorMessage(err)}`,
-    );
-    throw err;
+    // Wrap the error with context for callers to display appropriate UI
+    const message = `Error loading agent settings and prompts: ${toErrorMessage(err)}`;
+    throw new Error(message, { cause: err });
   }
 }
 

--- a/src/agent/runtime/agentLoad.ts
+++ b/src/agent/runtime/agentLoad.ts
@@ -180,9 +180,13 @@ export async function loadAgentSettingAndPrompts(
     // The agent's name (declaredAgentName) is known in this scope but not part of AgentSetting.
     return [settings as AgentSetting, prompts as AgentPrompt];
   } catch (err) {
-    // Wrap the error with context for callers to display appropriate UI
-    const message = `Error loading agent settings and prompts: ${toErrorMessage(err)}`;
-    throw new Error(message, { cause: err });
+    // Log error context, then rethrow original to preserve error type (e.g., ZodError)
+    // for proper handling by callers like executeCommand.ts
+    logger.error(
+      CHANNEL,
+      `Error loading agent settings and prompts: ${toErrorMessage(err)}`,
+    );
+    throw err;
   }
 }
 

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -592,20 +592,13 @@ export async function executeMergeAgent(
   inputFile: string,
   editedFile: string,
 ): Promise<void> {
-  let ctx: FlowExecutionContext;
-  try {
-    ctx = await prepareFlowExecution('merge', {
-      agent: 'merge',
-      model,
-      inputFile,
-      editedFile,
-    });
-  } catch (err) {
-    if (!(err instanceof ZodError)) {
-      void showErrorMessage(toErrorMessage(err));
-    }
-    throw err;
-  }
+  // Caller (mergeCommands.ts) handles error display via showLoggedErrorMessage
+  const ctx = await prepareFlowExecution('merge', {
+    agent: 'merge',
+    model,
+    inputFile,
+    editedFile,
+  });
 
   const { streamTabId, executionContext, config } = ctx;
 
@@ -679,20 +672,13 @@ export async function resumeToolUseFromSnapshot(
   const streamTabId = snapshot.streamId as StreamTabId;
 
   // Prepare flow execution context with snapshot's stream ID for correct UI state
-  let ctx: FlowExecutionContext;
-  try {
-    ctx = await prepareFlowExecution(
-      snapshotConfig.agent,
-      snapshotConfig,
-      executionId,
-      { streamTabIdOverride: streamTabId },
-    );
-  } catch (err) {
-    if (!(err instanceof ZodError)) {
-      void showErrorMessage(toErrorMessage(err));
-    }
-    throw err;
-  }
+  // Caller (resumeCommand.ts) handles error display via showWarningMessage
+  const ctx = await prepareFlowExecution(
+    snapshotConfig.agent,
+    snapshotConfig,
+    executionId,
+    { streamTabIdOverride: streamTabId },
+  );
   const { setting, executionContext, config } = ctx;
 
   // Validate agent type and session

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -14,6 +14,7 @@ import * as path from 'path';
 
 // Third-party imports
 import * as vscode from 'vscode';
+import { ZodError } from 'zod';
 
 // Local imports - flows (primary execution path)
 
@@ -54,6 +55,7 @@ import { MAIN_VIEW_COMMANDS } from '@common/webview/commands';
 import { toErrorMessage } from '@common/errors/errorHandlingUtils';
 import { getSdkErrorMessage } from '@common/errors/sdkErrorUtils';
 import { showInstructionWithSuppress } from '@frontend/ui/instruction';
+import { showErrorMessage } from '@frontend/ui/messageUtils';
 import { getMainWebview } from '@frontend/system/commandUtils';
 import { AgentLogger } from '@logger/AgentLogger';
 import { MODEL_CONFIGS } from '@model/ModelRegistry';
@@ -461,8 +463,10 @@ export async function executeAgent(
       executionId,
     );
   } catch (err) {
-    // Show error to user - loadAgentSettingAndPrompts errors need to be visible
-    vscode.window.showErrorMessage(toErrorMessage(err));
+    // Show error to user unless it's a ZodError (handled by executeCommand.ts)
+    if (!(err instanceof ZodError)) {
+      void showErrorMessage(toErrorMessage(err));
+    }
     throw err;
   }
 
@@ -597,7 +601,9 @@ export async function executeMergeAgent(
       editedFile,
     });
   } catch (err) {
-    vscode.window.showErrorMessage(toErrorMessage(err));
+    if (!(err instanceof ZodError)) {
+      void showErrorMessage(toErrorMessage(err));
+    }
     throw err;
   }
 
@@ -682,7 +688,9 @@ export async function resumeToolUseFromSnapshot(
       { streamTabIdOverride: streamTabId },
     );
   } catch (err) {
-    vscode.window.showErrorMessage(toErrorMessage(err));
+    if (!(err instanceof ZodError)) {
+      void showErrorMessage(toErrorMessage(err));
+    }
     throw err;
   }
   const { setting, executionContext, config } = ctx;

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -452,11 +452,19 @@ export async function executeAgent(
   const isResume = options?.resume ?? false;
 
   // Prepare flow execution context
-  const ctx = await prepareFlowExecution(
-    configPayload.agent,
-    configPayload,
-    executionId,
-  );
+  // Wrapped in try-catch to display agent loading errors to users
+  let ctx: FlowExecutionContext;
+  try {
+    ctx = await prepareFlowExecution(
+      configPayload.agent,
+      configPayload,
+      executionId,
+    );
+  } catch (err) {
+    // Show error to user - loadAgentSettingAndPrompts errors need to be visible
+    vscode.window.showErrorMessage(toErrorMessage(err));
+    throw err;
+  }
 
   const { streamTabId, setting, executionContext, config } = ctx;
   const agentName = config.agent;
@@ -580,12 +588,18 @@ export async function executeMergeAgent(
   inputFile: string,
   editedFile: string,
 ): Promise<void> {
-  const ctx = await prepareFlowExecution('merge', {
-    agent: 'merge',
-    model,
-    inputFile,
-    editedFile,
-  });
+  let ctx: FlowExecutionContext;
+  try {
+    ctx = await prepareFlowExecution('merge', {
+      agent: 'merge',
+      model,
+      inputFile,
+      editedFile,
+    });
+  } catch (err) {
+    vscode.window.showErrorMessage(toErrorMessage(err));
+    throw err;
+  }
 
   const { streamTabId, executionContext, config } = ctx;
 
@@ -659,12 +673,18 @@ export async function resumeToolUseFromSnapshot(
   const streamTabId = snapshot.streamId as StreamTabId;
 
   // Prepare flow execution context with snapshot's stream ID for correct UI state
-  const ctx = await prepareFlowExecution(
-    snapshotConfig.agent,
-    snapshotConfig,
-    executionId,
-    { streamTabIdOverride: streamTabId },
-  );
+  let ctx: FlowExecutionContext;
+  try {
+    ctx = await prepareFlowExecution(
+      snapshotConfig.agent,
+      snapshotConfig,
+      executionId,
+      { streamTabIdOverride: streamTabId },
+    );
+  } catch (err) {
+    vscode.window.showErrorMessage(toErrorMessage(err));
+    throw err;
+  }
   const { setting, executionContext, config } = ctx;
 
   // Validate agent type and session

--- a/src/agent/storage/ExecutionKVStore.ts
+++ b/src/agent/storage/ExecutionKVStore.ts
@@ -8,13 +8,15 @@
  * - ExecutionKVStore: Consumer-facing interface, auto-scoped to execution
  * - ExecutionStorageRegistry: Internal factory and lifecycle manager
  * - StorageFSKVStore: VS Code storage backend implementation
+ *
+ * Note: This module is platform-agnostic - it uses helpers from @common/errors
+ * instead of importing vscode directly for error handling and file type checks.
  */
 
 import * as path from 'path';
 
-import * as vscode from 'vscode';
-
 import type { ExecutionId } from '@agent/types/IdentifierTypes';
+import { isFileNotFoundError, isFile, isDirectory } from '@common/errors';
 
 import { StorageFS } from '@utils/files';
 
@@ -82,10 +84,7 @@ class StorageFSKVStore implements ExecutionKVStore {
     try {
       return await StorageFS.readJson<T>(this.keyToPath(key));
     } catch (error) {
-      if (
-        error instanceof vscode.FileSystemError &&
-        error.code === 'FileNotFound'
-      ) {
+      if (isFileNotFoundError(error)) {
         return undefined;
       }
       throw error;
@@ -102,10 +101,7 @@ class StorageFSKVStore implements ExecutionKVStore {
     try {
       await StorageFS.delete(this.keyToPath(key));
     } catch (error) {
-      if (
-        error instanceof vscode.FileSystemError &&
-        error.code === 'FileNotFound'
-      ) {
+      if (isFileNotFoundError(error)) {
         return; // Already deleted, no-op
       }
       throw error;
@@ -122,17 +118,14 @@ class StorageFSKVStore implements ExecutionKVStore {
       const entries = await StorageFS.readDir(dir);
       return entries
         .filter(([name, type]) => {
-          if (type !== vscode.FileType.File) return false;
+          if (!isFile(type)) return false;
           if (!name.endsWith('.json')) return false;
           const key = name.replace(/\.json$/, '');
           return !prefix || key.startsWith(prefix);
         })
         .map(([name]) => name.replace(/\.json$/, ''));
     } catch (error) {
-      if (
-        error instanceof vscode.FileSystemError &&
-        error.code === 'FileNotFound'
-      ) {
+      if (isFileNotFoundError(error)) {
         return []; // Directory doesn't exist yet
       }
       throw error;
@@ -144,10 +137,7 @@ class StorageFSKVStore implements ExecutionKVStore {
     try {
       await StorageFS.delete(dir);
     } catch (error) {
-      if (
-        error instanceof vscode.FileSystemError &&
-        error.code === 'FileNotFound'
-      ) {
+      if (isFileNotFoundError(error)) {
         return; // Already cleared
       }
       throw error;
@@ -185,10 +175,7 @@ class StorageFSRegistry implements ExecutionStorageRegistry {
       try {
         await StorageFS.delete(dir);
       } catch (error) {
-        if (
-          error instanceof vscode.FileSystemError &&
-          error.code === 'FileNotFound'
-        ) {
+        if (isFileNotFoundError(error)) {
           return;
         }
         throw error;
@@ -200,13 +187,10 @@ class StorageFSRegistry implements ExecutionStorageRegistry {
     try {
       const entries = await StorageFS.readDir(EXECUTIONS_DIR);
       return entries
-        .filter(([, type]) => type === vscode.FileType.Directory)
+        .filter(([, type]) => isDirectory(type))
         .map(([name]) => name as ExecutionId);
     } catch (error) {
-      if (
-        error instanceof vscode.FileSystemError &&
-        error.code === 'FileNotFound'
-      ) {
+      if (isFileNotFoundError(error)) {
         return [];
       }
       throw error;

--- a/src/agent/storage/ExecutionKVStore.ts
+++ b/src/agent/storage/ExecutionKVStore.ts
@@ -16,7 +16,8 @@
 import * as path from 'path';
 
 import type { ExecutionId } from '@agent/types/IdentifierTypes';
-import { isFileNotFoundError, isFile, isDirectory } from '@common/errors';
+import { isFileNotFoundError } from '@common/errors';
+import { isFile, isDirectory } from '@common/files/fsEntryType';
 
 import { StorageFS } from '@utils/files';
 

--- a/src/agent/toolUse/ToolUseFollowUp.ts
+++ b/src/agent/toolUse/ToolUseFollowUp.ts
@@ -4,11 +4,11 @@
  * Routes follow-up messages to the appropriate session based on state:
  * - Active session: direct append
  * - Resuming session: queue for later
- * - No session: show warning (user can resume via UI)
+ * - No session: return status (caller handles UI)
+ *
+ * This module is VS Code-agnostic. Callers are responsible for
+ * showing appropriate UI notifications based on the returned result.
  */
-
-// Third-party imports
-import * as vscode from 'vscode';
 
 // Local imports
 import { getToolUseFlowContext } from '@agent/toolUse/ToolUseAgentRegistry';
@@ -20,23 +20,41 @@ import { AgentLogger } from '@logger/AgentLogger';
 // Local file imports
 import { ToolUseFollowUpQueue } from './ToolUseFollowUpQueueManager';
 
+// ============================================================================
+// Result Types
+// ============================================================================
+
+/**
+ * Result of sending a follow-up message to a tool-use session.
+ *
+ * Pure result type - callers handle UI notifications based on status.
+ */
+export type SendFollowUpResult =
+  | { status: 'sent' }
+  | { status: 'queued'; reason: 'resuming' | 'waiting' }
+  | { status: 'error'; message: string }
+  | { status: 'no_session'; streamStatus: string | undefined };
+
 const logger = new AgentLogger('ToolUseFollowUp');
 
 /**
  * Send a follow-up message to a tool-use session.
  *
  * Routes the message based on session state:
- * 1. Active agent: direct append
- * 2. Resuming/Waiting session: queue for later
- * 3. No session: show warning (user can resume via UI command)
+ * 1. Active agent: direct append → returns { status: 'sent' }
+ * 2. Resuming/Waiting session: queue for later → returns { status: 'queued' }
+ * 3. Error during send → returns { status: 'error' }
+ * 4. No session found → returns { status: 'no_session' }
  *
  * Note: Messages queued for WAITING sessions are picked up when user resumes.
  * PersistedFlow handles state persistence.
+ *
+ * @returns Result indicating what happened - callers handle UI notifications
  */
 export async function sendFollowUp(
   streamId: StreamTabId,
   text: string,
-): Promise<void> {
+): Promise<SendFollowUpResult> {
   logger.debug(`sendFollowUp called for stream: ${streamId}`);
 
   // Try active flow context first
@@ -46,15 +64,13 @@ export async function sendFollowUp(
     try {
       flowContext.session.appendFollowUp(text);
       logger.debug(`Follow-up appended successfully to stream: ${streamId}`);
+      return { status: 'sent' };
     } catch (error) {
       logger.error('Failed to send follow-up to active session.', {
         data: error,
       });
-      await vscode.window.showErrorMessage(
-        `Failed to send follow-up: ${(error as Error).message}`,
-      );
+      return { status: 'error', message: (error as Error).message };
     }
-    return;
   }
 
   logger.debug(`No active flow context found for stream: ${streamId}`);
@@ -63,7 +79,7 @@ export async function sendFollowUp(
   if (ToolUseFollowUpQueue.isResuming(streamId)) {
     if (ToolUseFollowUpQueue.enqueue(streamId, text)) {
       logger.debug(`Queued follow-up while stream ${streamId} is resuming.`);
-      return;
+      return { status: 'queued', reason: 'resuming' };
     }
   }
 
@@ -79,15 +95,13 @@ export async function sendFollowUp(
       logger.debug(
         `Queued follow-up for waiting stream ${streamId}. Resume to process.`,
       );
-      return;
+      return { status: 'queued', reason: 'waiting' };
     }
   }
 
-  // No active/waiting session found - user can resume via UI command
+  // No active/waiting session found - caller should handle UI notification
   logger.warn(
     `No active/waiting session found for follow-up on stream ${streamId}. Status: ${status ?? 'undefined'}`,
   );
-  void vscode.window.showWarningMessage(
-    'No active tool-use session found. Use the Resume button to continue.',
-  );
+  return { status: 'no_session', streamStatus: status };
 }

--- a/src/commands/agent/followUpCommand.ts
+++ b/src/commands/agent/followUpCommand.ts
@@ -3,8 +3,34 @@ import * as vscode from 'vscode';
 
 // Local imports - agent
 import type { StreamTabId } from '@agent/types/IdentifierTypes';
-// Internal imports
-import { sendFollowUp } from '@agent/toolUse/ToolUseFollowUp';
+import {
+  sendFollowUp,
+  type SendFollowUpResult,
+} from '@agent/toolUse/ToolUseFollowUp';
+import { showErrorMessage, showWarningMessage } from '@frontend/ui/messageUtils';
+
+/**
+ * Handle follow-up result and show appropriate UI notifications.
+ *
+ * This is the VS Code integration layer - it converts pure result types
+ * to VS Code notifications.
+ */
+async function handleFollowUpResult(result: SendFollowUpResult): Promise<void> {
+  switch (result.status) {
+    case 'sent':
+    case 'queued':
+      // Silent success - no notification needed
+      break;
+    case 'error':
+      await showErrorMessage(`Failed to send follow-up: ${result.message}`);
+      break;
+    case 'no_session':
+      await showWarningMessage(
+        'No active tool-use session found. Use the Resume button to continue.',
+      );
+      break;
+  }
+}
 
 export function registerFollowUpCommand(context: vscode.ExtensionContext) {
   context.subscriptions.push(
@@ -12,7 +38,8 @@ export function registerFollowUpCommand(context: vscode.ExtensionContext) {
       'texra.sendFollowUp',
       async (payload: { stream: string; text: string }) => {
         const streamId = payload.stream as StreamTabId;
-        await sendFollowUp(streamId, payload.text);
+        const result = await sendFollowUp(streamId, payload.text);
+        await handleFollowUpResult(result);
       },
     ),
   );

--- a/src/common/errors/errorHandlingUtils.ts
+++ b/src/common/errors/errorHandlingUtils.ts
@@ -30,6 +30,40 @@ import * as vscode from 'vscode';
 // Local imports - logging
 import * as logger from '@logger/logUtils';
 
+// ============================================================================
+// FileType Constants (platform-agnostic)
+// ============================================================================
+
+/**
+ * Platform-agnostic file type constants.
+ * Values match vscode.FileType for compatibility.
+ *
+ * Use these instead of importing vscode.FileType directly to keep
+ * agent core logic platform-agnostic.
+ */
+export const FileType = {
+  Unknown: 0,
+  File: 1,
+  Directory: 2,
+  SymbolicLink: 64,
+} as const;
+
+export type FileTypeValue = (typeof FileType)[keyof typeof FileType];
+
+/**
+ * Check if a file type value represents a regular file.
+ */
+export function isFile(type: number): boolean {
+  return type === FileType.File;
+}
+
+/**
+ * Check if a file type value represents a directory.
+ */
+export function isDirectory(type: number): boolean {
+  return type === FileType.Directory;
+}
+
 /**
  * Valid documentation identifiers for error messages.
  * This ensures type safety when referencing documentation sections.

--- a/src/common/errors/errorHandlingUtils.ts
+++ b/src/common/errors/errorHandlingUtils.ts
@@ -30,40 +30,6 @@ import * as vscode from 'vscode';
 // Local imports - logging
 import * as logger from '@logger/logUtils';
 
-// ============================================================================
-// FileType Constants (platform-agnostic)
-// ============================================================================
-
-/**
- * Platform-agnostic file type constants.
- * Values match vscode.FileType for compatibility.
- *
- * Use these instead of importing vscode.FileType directly to keep
- * agent core logic platform-agnostic.
- */
-export const FileType = {
-  Unknown: 0,
-  File: 1,
-  Directory: 2,
-  SymbolicLink: 64,
-} as const;
-
-export type FileTypeValue = (typeof FileType)[keyof typeof FileType];
-
-/**
- * Check if a file type value represents a regular file.
- */
-export function isFile(type: number): boolean {
-  return type === FileType.File;
-}
-
-/**
- * Check if a file type value represents a directory.
- */
-export function isDirectory(type: number): boolean {
-  return type === FileType.Directory;
-}
-
 /**
  * Valid documentation identifiers for error messages.
  * This ensures type safety when referencing documentation sections.

--- a/src/common/errors/errorHandlingUtils.ts
+++ b/src/common/errors/errorHandlingUtils.ts
@@ -106,6 +106,12 @@ export function toErrorMessage(err: unknown): string {
  * Use this to differentiate between expected "file doesn't exist" errors and
  * actual filesystem failures (permissions, disk issues, etc.).
  *
+ * Note: This function imports vscode for FileSystemError checks. While this
+ * creates a VS Code dependency, it's acceptable because:
+ * 1. This module runs in VS Code extension context
+ * 2. The Node.js ENOENT check provides fallback for non-VS Code errors
+ * 3. Callers like ExecutionKVStore benefit from not importing vscode directly
+ *
  * @param err - The error to check
  * @returns true if the error indicates the file was not found
  *

--- a/src/common/errors/index.ts
+++ b/src/common/errors/index.ts
@@ -9,11 +9,6 @@ export {
   showLoggedMessage,
   showLoggedInfoMessage,
   showLoggedMessageWithDocs,
-  // FileType utilities for platform-agnostic file operations
-  FileType,
-  FileTypeValue,
-  isFile,
-  isDirectory,
 } from './errorHandlingUtils';
 export {
   ProviderHttpErrorDetails,

--- a/src/common/errors/index.ts
+++ b/src/common/errors/index.ts
@@ -9,6 +9,11 @@ export {
   showLoggedMessage,
   showLoggedInfoMessage,
   showLoggedMessageWithDocs,
+  // FileType utilities for platform-agnostic file operations
+  FileType,
+  FileTypeValue,
+  isFile,
+  isDirectory,
 } from './errorHandlingUtils';
 export {
   ProviderHttpErrorDetails,

--- a/src/common/files/fsEntryType.ts
+++ b/src/common/files/fsEntryType.ts
@@ -1,0 +1,34 @@
+/**
+ * Platform-agnostic file system entry type utilities.
+ *
+ * These constants and helpers enable agent core logic to check file system
+ * entry types without importing vscode directly. Values match vscode.FileType
+ * for compatibility with VS Code's filesystem API.
+ */
+
+/**
+ * File system entry type constants.
+ * Values match vscode.FileType for seamless interop.
+ */
+export const FSEntryType = {
+  Unknown: 0,
+  File: 1,
+  Directory: 2,
+  SymbolicLink: 64,
+} as const;
+
+export type FSEntryTypeValue = (typeof FSEntryType)[keyof typeof FSEntryType];
+
+/**
+ * Check if a file system entry type represents a regular file.
+ */
+export function isFile(type: number): boolean {
+  return type === FSEntryType.File;
+}
+
+/**
+ * Check if a file system entry type represents a directory.
+ */
+export function isDirectory(type: number): boolean {
+  return type === FSEntryType.Directory;
+}

--- a/src/common/files/fsEntryType.ts
+++ b/src/common/files/fsEntryType.ts
@@ -4,11 +4,21 @@
  * These constants and helpers enable agent core logic to check file system
  * entry types without importing vscode directly. Values match vscode.FileType
  * for compatibility with VS Code's filesystem API.
+ *
+ * Note: VS Code's FileType uses bitmasks - a symbolic link to a file has
+ * type 65 (SymbolicLink | File). The helpers below use bitwise checks to
+ * correctly handle symbolic links.
  */
 
 /**
  * File system entry type constants.
  * Values match vscode.FileType for seamless interop.
+ *
+ * Note: These are bitmask values - symbolic links combine with File/Directory:
+ * - File: 1
+ * - Directory: 2
+ * - SymbolicLink to file: 65 (64 | 1)
+ * - SymbolicLink to directory: 66 (64 | 2)
  */
 export const FSEntryType = {
   Unknown: 0,
@@ -20,15 +30,17 @@ export const FSEntryType = {
 export type FSEntryTypeValue = (typeof FSEntryType)[keyof typeof FSEntryType];
 
 /**
- * Check if a file system entry type represents a regular file.
+ * Check if a file system entry type represents a file (including symlinks to files).
+ * Uses bitwise check to handle symbolic links correctly.
  */
 export function isFile(type: number): boolean {
-  return type === FSEntryType.File;
+  return (type & FSEntryType.File) === FSEntryType.File;
 }
 
 /**
- * Check if a file system entry type represents a directory.
+ * Check if a file system entry type represents a directory (including symlinks to directories).
+ * Uses bitwise check to handle symbolic links correctly.
  */
 export function isDirectory(type: number): boolean {
-  return type === FSEntryType.Directory;
+  return (type & FSEntryType.Directory) === FSEntryType.Directory;
 }

--- a/src/common/files/index.ts
+++ b/src/common/files/index.ts
@@ -1,0 +1,13 @@
+// Barrel export for common file utilities
+export {
+  FSEntryType,
+  FSEntryTypeValue,
+  isFile,
+  isDirectory,
+} from './fsEntryType';
+export {
+  ExtensionCategory,
+  FileType,
+  getIncludedExtensions,
+  isTexFile,
+} from './fileTypeUtils';

--- a/src/test/agent/toolUse/ToolUseFollowUp.test.ts
+++ b/src/test/agent/toolUse/ToolUseFollowUp.test.ts
@@ -55,9 +55,10 @@ describe('ToolUseFollowUp', () => {
       },
     });
 
-    await sendFollowUp(streamId, 'hello');
+    const result = await sendFollowUp(streamId, 'hello');
 
     assert.deepEqual(calls, ['hello']);
+    assert.deepEqual(result, { status: 'sent' });
   });
 
   it('creates valid snapshot structure', () => {


### PR DESCRIPTION
This refactoring improves separation of concerns by decoupling agent
core logic from VS Code-specific imports and UI operations.

Changes:
- agentLoad.ts: Remove vscode import, throw errors with context instead
  of showing UI notifications directly. Caller (executeAgent.ts) handles
  displaying errors.

- ToolUseFollowUp.ts: Return result type (SendFollowUpResult) instead of
  calling vscode.window.show* methods. Callers now handle UI based on
  returned status ('sent', 'queued', 'error', 'no_session').

- followUpCommand.ts: Handle SendFollowUpResult and show appropriate
  VS Code notifications in the integration layer.

- ExecutionKVStore.ts: Use platform-agnostic helpers (isFileNotFoundError,
  isFile, isDirectory) from @common/errors instead of importing vscode
  directly for FileSystemError and FileType checks.

- errorHandlingUtils.ts: Add FileType constants and helper functions
  (isFile, isDirectory) to enable platform-agnostic file type checking.

These changes make the agent core more testable and portable by keeping
VS Code dependencies at the integration boundary layer.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Core decoupling from VS Code**
> 
> - `agentLoad.ts` removes VS Code UI calls; logs context and rethrows errors for callers (e.g., `executeAgent.ts`) to handle
> - `executeAgent.ts` wraps preparation with error handling (non-`ZodError` surfaced via `showErrorMessage`), maintains flow/status updates, and clarifies caller-owned error display for merge/resume paths
> 
> **Tool-use follow-up flow**
> 
> - `ToolUseFollowUp.ts` now returns `SendFollowUpResult` (`sent`/`queued`/`error`/`no_session`) instead of showing UI
> - `followUpCommand.ts` maps results to UI via `showErrorMessage`/`showWarningMessage`; test updated to assert result
> 
> **Platform-agnostic storage and FS utilities**
> 
> - New `ExecutionKVStore` with `StorageFS` backend; replaces direct VS Code `FileSystemError`/`FileType` usage with `isFileNotFoundError`, `isFile`, `isDirectory`
> - Added `common/files/fsEntryType.ts` and barrel export; enhanced `errorHandlingUtils.ts` with `isFileNotFoundError`
> 
> **UI wrapper usage**
> 
> - `remoteAgentUtils.ts` switches to `showInfoMessage`/`showWarningMessage` wrappers for notifications
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d765daf4ccd23d23d186c15b841f573043317a2e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->