### PR TITLE
refactor: consolidate progress streaming abstraction layers

### DIFF
--- a/src/logger/AgentLogger.ts
+++ b/src/logger/AgentLogger.ts
@@ -16,7 +16,7 @@ import { bus } from '@eventBus/ProgressEventBus';
 // Local imports - log
 import * as logger from './logUtils';
 import { END_GROUP_STATUS, MESSAGE_TYPES } from './messageTypes';
-import { shouldEmitToProgressView } from './filterUtils';
+import { getEmitFilter } from './filterUtils';
 
 // Type imports
 import type {
@@ -519,80 +519,49 @@ export class AgentLogger {
     const progressEnabled = options.progressViewEnabled ?? true;
     const groupId = options.groupId ?? this.resolveActiveGroupId();
 
-    // Apply the same filtering logic as ProgressViewSink
-    // This ensures debug mode and INTERNAL message filtering work consistently
-    const shouldEmit =
-      progressEnabled && shouldEmitToProgressView({ level, messageType: type });
+    // Apply filtering - get both shouldEmit and debugMode for verbose flag
+    // Matches VSCodeTransport.emitLogEvent() behavior for consistency
+    const { shouldEmit, debugMode } = progressEnabled
+      ? getEmitFilter({ level, messageType: type })
+      : { shouldEmit: false, debugMode: false };
+
+    // Helper to emit log message (reduces duplication between append/finalize)
+    const emitMessage = (isNew: boolean, text: string): void => {
+      if (isNew) {
+        bus.emit('addLogMessage', {
+          stream: streamId,
+          logMessage: {
+            id,
+            text,
+            level,
+            timestamp: Date.now(),
+            groupId,
+            messageType: type,
+            verbose: debugMode, // Now included for consistency with VSCodeTransport
+          },
+        });
+      } else {
+        bus.emit('updateLogMessage', {
+          stream: streamId,
+          logMessage: { id, text, groupId, messageType: type },
+        });
+      }
+    };
 
     return {
       append: (text: string) => {
-        if (!text) {
-          return;
-        }
-
+        if (!text) return;
         buffer += text;
+        if (!shouldEmit) return;
 
-        if (!shouldEmit) {
-          return;
-        }
-
-        if (isFirstUpdate) {
-          bus.emit('addLogMessage', {
-            stream: streamId,
-            logMessage: {
-              id,
-              text: buffer,
-              level,
-              timestamp: Date.now(),
-              groupId,
-              messageType: type,
-            },
-          });
-          isFirstUpdate = false;
-        } else {
-          bus.emit('updateLogMessage', {
-            stream: streamId,
-            logMessage: {
-              id,
-              text: buffer,
-              groupId,
-              messageType: type,
-            },
-          });
-        }
+        emitMessage(isFirstUpdate, buffer);
+        isFirstUpdate = false;
       },
       finalize: (finalText?: string) => {
-        if (typeof finalText === 'string') {
-          buffer = finalText;
-        }
+        if (typeof finalText === 'string') buffer = finalText;
 
-        if (!shouldEmit) {
-          this.debug(`Final ${type} length: ${buffer.length}`, { groupId });
-          return buffer;
-        }
-
-        if (isFirstUpdate) {
-          bus.emit('addLogMessage', {
-            stream: streamId,
-            logMessage: {
-              id,
-              text: buffer,
-              level,
-              timestamp: Date.now(),
-              groupId,
-              messageType: type,
-            },
-          });
-        } else {
-          bus.emit('updateLogMessage', {
-            stream: streamId,
-            logMessage: {
-              id,
-              text: buffer,
-              groupId,
-              messageType: type,
-            },
-          });
+        if (shouldEmit) {
+          emitMessage(isFirstUpdate, buffer);
         }
 
         this.debug(`Final ${type} length: ${buffer.length}`, { groupId });

--- a/src/logger/filterUtils.ts
+++ b/src/logger/filterUtils.ts
@@ -50,13 +50,3 @@ export function getEmitFilter(options: FilterOptions): FilterResult {
   return { shouldEmit: true, debugMode };
 }
 
-/**
- * Determines whether a log message should be emitted to the progress view
- * based on debug mode settings and message type.
- *
- * @param options - The log level and message type to filter
- * @returns true if the message should be emitted to the progress view, false otherwise
- */
-export function shouldEmitToProgressView(options: FilterOptions): boolean {
-  return getEmitFilter(options).shouldEmit;
-}

--- a/src/progressView/managers/RunInstructionManager.ts
+++ b/src/progressView/managers/RunInstructionManager.ts
@@ -3,17 +3,17 @@ import type { StorageKey, StreamTabId } from '@agent/types/IdentifierTypes';
 
 // Internal imports
 import { WorkspaceStateKey } from '@common/state/stateManager';
-import { AgentLogger } from '@logger/AgentLogger';
 
 // Local imports - types
 import type { InstructionUpdate } from '@progressView/types';
-
-// Internal imports
 import {
   PersistentMapManager,
   type StateStorage,
 } from '@progressView/persistence/PersistentMapManager';
-import { mapToRecord } from '@progressView/persistence/serializationUtils';
+import {
+  mapToRecord,
+  recordToMap,
+} from '@progressView/persistence/serializationUtils';
 
 type InstructionMap = Map<string, InstructionUpdate>;
 
@@ -24,11 +24,8 @@ export class RunInstructionManager extends PersistentMapManager<
   StreamTabId,
   InstructionMap
 > {
-  private readonly logger: AgentLogger;
-
   constructor(storage?: StateStorage) {
     super(WorkspaceStateKey.RUN_INSTRUCTIONS, storage);
-    this.logger = new AgentLogger('RunInstructionManager');
   }
 
   getInstructions(stream: StreamTabId): InstructionMap {
@@ -88,20 +85,8 @@ export class RunInstructionManager extends PersistentMapManager<
 
   protected override async deserialize(
     data: unknown,
-    stream: StreamTabId,
+    _stream: StreamTabId,
   ): Promise<InstructionMap> {
-    if (!data || typeof data !== 'object') {
-      return new Map();
-    }
-
-    try {
-      const entries = Object.entries(data as Record<string, InstructionUpdate>);
-      return new Map(entries as [string, InstructionUpdate][]);
-    } catch (error) {
-      this.logger.warn(
-        `Failed to deserialize run instructions for ${stream}: ${String(error)}`,
-      );
-      return new Map();
-    }
+    return recordToMap<InstructionUpdate>(data);
   }
 }

--- a/src/progressView/managers/TaskGroupManager.ts
+++ b/src/progressView/managers/TaskGroupManager.ts
@@ -10,7 +10,10 @@ import {
   PersistentMapManager,
   type StateStorage,
 } from '@progressView/persistence/PersistentMapManager';
-import { mapToRecord } from '@progressView/persistence/serializationUtils';
+import {
+  mapToRecord,
+  recordToMap,
+} from '@progressView/persistence/serializationUtils';
 import type { UpdateTaskGroupPayload } from '@eventBus/schemas';
 
 /**
@@ -145,11 +148,6 @@ export class TaskGroupManager extends PersistentMapManager<
     data: unknown,
     _key: StreamTabId,
   ): Promise<Map<string, TaskGroup>> {
-    if (!data || typeof data !== 'object') {
-      return new Map();
-    }
-
-    const entries = Object.entries(data as Record<string, TaskGroup>);
-    return new Map(entries as [string, TaskGroup][]);
+    return recordToMap<TaskGroup>(data);
   }
 }

--- a/src/progressView/persistence/serializationUtils.ts
+++ b/src/progressView/persistence/serializationUtils.ts
@@ -1,5 +1,5 @@
 /**
- * Shared serialization utilities for converting Map structures to plain objects.
+ * Shared serialization utilities for converting between Map and Record structures.
  * These are used throughout the progress view for persistence and webview messaging.
  */
 
@@ -11,6 +11,18 @@ export function mapToRecord<K extends string | number, V>(
   map: Map<K, V>,
 ): Record<string, V> {
   return Object.fromEntries(map.entries()) as Record<string, V>;
+}
+
+/**
+ * Deserialize a plain Record object to a Map.
+ * Handles null/undefined/non-object inputs gracefully by returning empty Map.
+ * @example recordToMap({ a: 1 }) // Map([['a', 1]])
+ */
+export function recordToMap<V>(data: unknown): Map<string, V> {
+  if (!data || typeof data !== 'object' || Array.isArray(data)) {
+    return new Map();
+  }
+  return new Map(Object.entries(data as Record<string, V>));
 }
 
 /**

--- a/src/test/logger/filterUtils.test.ts
+++ b/src/test/logger/filterUtils.test.ts
@@ -3,10 +3,10 @@ import { strict as assert } from 'assert';
 import * as vscode from 'vscode';
 
 // Local imports
-import { shouldEmitToProgressView } from '@logger/filterUtils';
+import { getEmitFilter } from '@logger/filterUtils';
 import { MESSAGE_TYPES } from '@logger/messageTypes';
 
-describe('shouldEmitToProgressView', () => {
+describe('getEmitFilter', () => {
   let originalConfig: any;
 
   beforeEach(() => {
@@ -21,48 +21,48 @@ describe('shouldEmitToProgressView', () => {
   describe('debug mode filtering', () => {
     it('filters debug-level messages when debug mode is off', () => {
       // Mock debug mode off (default)
-      const result = shouldEmitToProgressView({
+      const result = getEmitFilter({
         level: 'debug',
         messageType: MESSAGE_TYPES.DEFAULT,
       });
       assert.equal(
-        result,
+        result.shouldEmit,
         false,
         'Debug messages should be filtered when debug mode is off',
       );
     });
 
     it('allows info-level messages when debug mode is off', () => {
-      const result = shouldEmitToProgressView({
+      const result = getEmitFilter({
         level: 'info',
         messageType: MESSAGE_TYPES.DEFAULT,
       });
       assert.equal(
-        result,
+        result.shouldEmit,
         true,
         'Info messages should pass through when debug mode is off',
       );
     });
 
     it('allows warn-level messages when debug mode is off', () => {
-      const result = shouldEmitToProgressView({
+      const result = getEmitFilter({
         level: 'warn',
         messageType: MESSAGE_TYPES.DEFAULT,
       });
       assert.equal(
-        result,
+        result.shouldEmit,
         true,
         'Warn messages should pass through when debug mode is off',
       );
     });
 
     it('allows error-level messages when debug mode is off', () => {
-      const result = shouldEmitToProgressView({
+      const result = getEmitFilter({
         level: 'error',
         messageType: MESSAGE_TYPES.DEFAULT,
       });
       assert.equal(
-        result,
+        result.shouldEmit,
         true,
         'Error messages should pass through when debug mode is off',
       );
@@ -79,12 +79,12 @@ describe('shouldEmitToProgressView', () => {
       ];
 
       for (const level of levels) {
-        const result = shouldEmitToProgressView({
+        const result = getEmitFilter({
           level,
           messageType: MESSAGE_TYPES.INTERNAL,
         });
         assert.equal(
-          result,
+          result.shouldEmit,
           false,
           `INTERNAL messages at ${level} level should always be filtered`,
         );
@@ -106,12 +106,12 @@ describe('shouldEmitToProgressView', () => {
 
     it('allows all non-debug level messages for normal message types', () => {
       for (const messageType of normalTypes) {
-        const result = shouldEmitToProgressView({
+        const result = getEmitFilter({
           level: 'info',
           messageType,
         });
         assert.equal(
-          result,
+          result.shouldEmit,
           true,
           `${messageType} messages at info level should pass through`,
         );
@@ -120,16 +120,30 @@ describe('shouldEmitToProgressView', () => {
 
     it('filters debug level messages for normal message types when debug mode is off', () => {
       for (const messageType of normalTypes) {
-        const result = shouldEmitToProgressView({
+        const result = getEmitFilter({
           level: 'debug',
           messageType,
         });
         assert.equal(
-          result,
+          result.shouldEmit,
           false,
           `${messageType} messages at debug level should be filtered when debug mode is off`,
         );
       }
+    });
+  });
+
+  describe('debugMode flag', () => {
+    it('returns debugMode false when debug mode is off', () => {
+      const result = getEmitFilter({
+        level: 'info',
+        messageType: MESSAGE_TYPES.DEFAULT,
+      });
+      assert.equal(
+        result.debugMode,
+        false,
+        'debugMode should be false when debug mode is off',
+      );
     });
   });
 });


### PR DESCRIPTION
## Changes

1. **Unified log message emission paths**
   - AgentLogger.createStream() now uses getEmitFilter() to match
     VSCodeTransport behavior
   - Added missing `verbose` field to streamed log messages for
     consistency
   - Extracted duplicate bus.emit calls into helper function `emitMessage()`
   - Removed wrapper function shouldEmitToProgressView() - now using
     getEmitFilter() directly

2. **Consolidated deserialization patterns**
   - Added recordToMap<V>() utility to serializationUtils.ts
   - Updated TaskGroupManager and RunInstructionManager to use shared
     utility instead of duplicate Object.entries → Map conversions
   - Removed unused AgentLogger from RunInstructionManager

These changes reduce abstraction overhead and establish single source
of truth patterns as recommended in CLAUDE.md.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Logger/streaming**
> 
> - `AgentLogger.createStream()` now uses `getEmitFilter()` (aligned with `VSCodeTransport`) and adds `verbose` to emitted messages; extracted `emitMessage()` helper to DRY add/update events
> - Removed `shouldEmitToProgressView()`; updated tests to use `getEmitFilter()`
> 
> **Persistence utilities**
> 
> - Added `recordToMap<V>()` in `serializationUtils.ts` and used it in `RunInstructionManager` and `TaskGroupManager` `deserialize()` implementations; kept `mapToRecord()` for serialization
> - Cleaned up `RunInstructionManager`: removed unused `AgentLogger`; minor param rename (`_stream`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a6ef58dc0a504765e72a14ec0ecd4f264bd809c1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->