### PR TITLE
refactor: modernize string replacement patterns and fix trivial spread

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,6 +3,7 @@ import js from '@eslint/js';
 import tseslint from 'typescript-eslint';
 import stylistic from '@stylistic/eslint-plugin';
 import importPlugin from 'eslint-plugin-import';
+import unicorn from 'eslint-plugin-unicorn';
 import globals from 'globals';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -69,8 +70,20 @@ export default tseslint.config(
     plugins: {
       '@stylistic': stylistic,
       import: importPlugin,
+      unicorn,
     },
     rules: {
+      // --- Unicorn modernization rules (ES2023+) ---
+      'unicorn/prefer-string-replace-all': 'warn',
+      'unicorn/prefer-at': 'warn',
+      'unicorn/prefer-array-flat-map': 'warn',
+      'unicorn/prefer-includes': 'warn',
+      'unicorn/prefer-array-find': 'warn',
+      'unicorn/no-array-push-push': 'warn',
+      'unicorn/prefer-spread': 'warn',
+      'unicorn/prefer-ternary': 'off', // Often less readable
+      'unicorn/no-null': 'off', // null is valid in this codebase
+      'unicorn/prevent-abbreviations': 'off', // Too strict
       // --- Migrated rules from .eslintrc.json ---
       '@typescript-eslint/naming-convention': [
         'warn',

--- a/package-lock.json
+++ b/package-lock.json
@@ -74,6 +74,7 @@
         "@vscode/test-electron": "^2.5.2",
         "eslint": "^9.39.2",
         "eslint-plugin-import": "^2.32.0",
+        "eslint-plugin-unicorn": "^62.0.0",
         "globals": "^17.0.0",
         "jsdom": "^27.4.0",
         "node-loader": "^2.1.0",
@@ -154,6 +155,16 @@
       "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
     },
     "node_modules/@babel/runtime": {
       "version": "7.28.4",
@@ -2590,6 +2601,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/builtin-modules": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-5.0.0.tgz",
+      "integrity": "sha512-bkXY9WsVpY7CvMhKSR6pZilZu9Ln5WDrKVBUXf2S443etkmEO4V58heTecXcUIsNsi4Rx8JUO4NfX1IcQl4deg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -2755,6 +2779,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/change-case": {
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/change-case/-/change-case-5.4.4.tgz",
+      "integrity": "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/chokidar": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
@@ -2797,6 +2828,45 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.0"
+      }
+    },
+    "node_modules/ci-info": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.3.1.tgz",
+      "integrity": "sha512-Wdy2Igu8OcBpI2pZePZ5oWjPC38tmDVx5WKUXKwlLYkA0ozo85sLsLvkBbBn/sZaSCMFOGZJ14fvW9t5/d7kdA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/clean-regexp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/clean-regexp/-/clean-regexp-1.0.0.tgz",
+      "integrity": "sha512-GfisEZEJvzKrmGWkvfhgzcz/BllN1USeqD2V6tg14OAOgaCD2Z/PUEuxnAZ/nPvmaHRG7a8y77p1T/IRQ4D1Hw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/clean-regexp/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/cli-cursor": {
@@ -3048,6 +3118,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.6.0"
+      }
+    },
+    "node_modules/core-js-compat": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.47.0.tgz",
+      "integrity": "sha512-IGfuznZ/n7Kp9+nypamBhvwdwLsW6KC8IOaURw2doAK5e98AG3acVLdh0woOnEqCfUtS+Vu882JE4k/DAm3ItQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.28.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
       }
     },
     "node_modules/core-util-is": {
@@ -3853,6 +3937,55 @@
         "strip-bom": "^3.0.0"
       }
     },
+    "node_modules/eslint-plugin-unicorn": {
+      "version": "62.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-62.0.0.tgz",
+      "integrity": "sha512-HIlIkGLkvf29YEiS/ImuDZQbP12gWyx5i3C6XrRxMvVdqMroCI9qoVYCoIl17ChN+U89pn9sVwLxhIWj5nEc7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@eslint-community/eslint-utils": "^4.9.0",
+        "@eslint/plugin-kit": "^0.4.0",
+        "change-case": "^5.4.4",
+        "ci-info": "^4.3.1",
+        "clean-regexp": "^1.0.0",
+        "core-js-compat": "^3.46.0",
+        "esquery": "^1.6.0",
+        "find-up-simple": "^1.0.1",
+        "globals": "^16.4.0",
+        "indent-string": "^5.0.0",
+        "is-builtin-module": "^5.0.0",
+        "jsesc": "^3.1.0",
+        "pluralize": "^8.0.0",
+        "regexp-tree": "^0.1.27",
+        "regjsparser": "^0.13.0",
+        "semver": "^7.7.3",
+        "strip-indent": "^4.1.1"
+      },
+      "engines": {
+        "node": "^20.10.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/eslint-plugin-unicorn?sponsor=1"
+      },
+      "peerDependencies": {
+        "eslint": ">=9.38.0"
+      }
+    },
+    "node_modules/eslint-plugin-unicorn/node_modules/globals": {
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-16.5.0.tgz",
+      "integrity": "sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/eslint-scope": {
       "version": "8.4.0",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
@@ -4320,6 +4453,19 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/find-up-simple": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/find-up-simple/-/find-up-simple-1.0.1.tgz",
+      "integrity": "sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -5149,6 +5295,19 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/indent-string": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
+      "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -5277,6 +5436,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-builtin-module": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-5.0.0.tgz",
+      "integrity": "sha512-f4RqJKBUe5rQkJ2eJEJBXSticB3hGbN9j0yxxMQFqIW89Jp9WYFtzfTcRlstDKVUTRzSOTLKRfO9vIztenwtxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "builtin-modules": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-callable": {
@@ -5861,6 +6036,19 @@
         "canvas": {
           "optional": true
         }
+      }
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/json-bigint": {
@@ -7387,6 +7575,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/pluralize": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
+      "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -7704,6 +7902,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/regexp-tree": {
+      "version": "0.1.27",
+      "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.27.tgz",
+      "integrity": "sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "regexp-tree": "bin/regexp-tree"
+      }
+    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
@@ -7723,6 +7931,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/regjsparser": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.13.0.tgz",
+      "integrity": "sha512-NZQZdC5wOE/H3UT28fVGL+ikOZcEzfMGk/c3iN9UGxzWHMa1op7274oyiUVrAG4B2EuFhus8SvkaYnhvW92p9Q==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "jsesc": "~3.1.0"
+      },
+      "bin": {
+        "regjsparser": "bin/parser"
       }
     },
     "node_modules/require-directory": {
@@ -8591,6 +8812,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-4.1.1.tgz",
+      "integrity": "sha512-SlyRoSkdh1dYP0PzclLE7r0M9sgbFKKMFXpFRUMNuKhQSbC6VQIGzq3E0qsfvGJaUFJPGv6Ws1NZ/haTAjfbMA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/package-lock.json
+++ b/package-lock.json
@@ -86,7 +86,8 @@
         "typescript": "^5.9.3",
         "typescript-eslint": "^8.51.0",
         "webpack": "^5.104.1",
-        "webpack-cli": "^6.0.1"
+        "webpack-cli": "^6.0.1",
+        "zod-v3-to-v4": "^1.11.0"
       },
       "engines": {
         "vscode": "^1.99.3"
@@ -186,6 +187,29 @@
         "node-html-better-parser": ">=1.4.0",
         "pako": "^1.0.11",
         "tslib": ">=2"
+      }
+    },
+    "node_modules/@clack/core": {
+      "version": "1.0.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@clack/core/-/core-1.0.0-alpha.1.tgz",
+      "integrity": "sha512-rFbCU83JnN7l3W1nfgCqqme4ZZvTTgsiKQ6FM0l+r0P+o2eJpExcocBUWUIwnDzL76Aca9VhUdWmB2MbUv+Qyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picocolors": "^1.0.0",
+        "sisteransi": "^1.0.5"
+      }
+    },
+    "node_modules/@clack/prompts": {
+      "version": "1.0.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-1.0.0-alpha.1.tgz",
+      "integrity": "sha512-07MNT0OsxjKOcyVfX8KhXBhJiyUbDP1vuIAcHc+nx5v93MJO23pX3X/k3bWz6T3rpM9dgWPq90i4Jq7gZAyMbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@clack/core": "1.0.0-alpha.1",
+        "picocolors": "^1.0.0",
+        "sisteransi": "^1.0.5"
       }
     },
     "node_modules/@colors/colors": {
@@ -884,6 +908,44 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
     },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/@pdf-lib/standard-fonts": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@pdf-lib/standard-fonts/-/standard-fonts-1.0.0.tgz",
@@ -1093,6 +1155,18 @@
       },
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@ts-morph/common": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.27.0.tgz",
+      "integrity": "sha512-Wf29UqxWDpc+i61k3oIOzcUfQt79PIT9y/MWfAGlrkjg6lBC1hwDECLXPVJAhWjiGbfBCxZd65F/LIZF3+jeJQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-glob": "^3.3.3",
+        "minimatch": "^10.0.1",
+        "path-browserify": "^1.0.1"
       }
     },
     "node_modules/@types/diff-match-patch": {
@@ -2847,6 +2921,13 @@
         "node": ">=6"
       }
     },
+    "node_modules/code-block-writer": {
+      "version": "13.0.3",
+      "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-13.0.3.tgz",
+      "integrity": "sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/color": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
@@ -4037,6 +4118,23 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
     },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -4093,6 +4191,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4.9.1"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
       }
     },
     "node_modules/fdir": {
@@ -6193,6 +6301,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/micromatch": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
@@ -7430,6 +7548,27 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -7676,6 +7815,17 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/router": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
@@ -7690,6 +7840,30 @@
       },
       "engines": {
         "node": ">= 18"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
       }
     },
     "node_modules/safe-array-concat": {
@@ -8132,6 +8306,13 @@
       "dependencies": {
         "is-arrayish": "^0.3.1"
       }
+    },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/sortablejs": {
       "version": "1.15.6",
@@ -8814,6 +8995,17 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">= 12"
+      }
+    },
+    "node_modules/ts-morph": {
+      "version": "26.0.0",
+      "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-26.0.0.tgz",
+      "integrity": "sha512-ztMO++owQnz8c/gIENcM9XfCEzgoGphTv+nKpYNM1bgsdOVC/jRZuEBf6N+mLLDNg68Kl+GgUZfOySaRiG1/Ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ts-morph/common": "~0.27.0",
+        "code-block-writer": "^13.0.3"
       }
     },
     "node_modules/tsconfig-paths": {
@@ -9918,6 +10110,20 @@
       "license": "ISC",
       "peerDependencies": {
         "zod": "^3.25 || ^4"
+      }
+    },
+    "node_modules/zod-v3-to-v4": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/zod-v3-to-v4/-/zod-v3-to-v4-1.11.0.tgz",
+      "integrity": "sha512-YMBO0Yw4QOlYGvu3R5dS3Xeacf7qNyzTTssYGQzPDF5TODyxONP4dMW2PWRWsJ9Hm3hiyU6fJhrqgXNs/g+LPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@clack/prompts": "1.0.0-alpha.1",
+        "ts-morph": "26.0.0"
+      },
+      "bin": {
+        "zod-v3-to-v4": "dist/index.js"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1595,6 +1595,7 @@
     "@vscode/test-electron": "^2.5.2",
     "eslint": "^9.39.2",
     "eslint-plugin-import": "^2.32.0",
+    "eslint-plugin-unicorn": "^62.0.0",
     "globals": "^17.0.0",
     "jsdom": "^27.4.0",
     "node-loader": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -1607,7 +1607,8 @@
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.51.0",
     "webpack": "^5.104.1",
-    "webpack-cli": "^6.0.1"
+    "webpack-cli": "^6.0.1",
+    "zod-v3-to-v4": "^1.11.0"
   },
   "repository": {
     "type": "git",

--- a/src/agent/core/AgentCycleOptions.ts
+++ b/src/agent/core/AgentCycleOptions.ts
@@ -3,8 +3,8 @@ import { z } from 'zod';
 
 // Local imports - agent configuration
 import type { AgentExecutionContext } from '@agent/runtime/AgentExecutionContext';
-import type { AgentLogger } from '@logger/AgentLogger';
 import type { BaseFlowContextInit } from '@agent/implementations/flows/common/BaseFlowServices';
+import type { AgentLogger } from '@logger/AgentLogger';
 
 /**
  * User variable channels for template rendering.

--- a/src/agent/core/AgentWorkspaceState.ts
+++ b/src/agent/core/AgentWorkspaceState.ts
@@ -84,8 +84,8 @@ export class FileInteractionState {
   /** Serialize to a snapshot. */
   toSnapshot(): FileInteractionStateSnapshot {
     return {
-      readFiles: Array.from(this.readFiles),
-      edits: Array.from(this.edits.entries()).map(([path, diff]) => ({
+      readFiles: [...this.readFiles],
+      edits: [...this.edits.entries()].map(([path, diff]) => ({
         path,
         added: diff.added,
         removed: diff.removed,
@@ -144,7 +144,7 @@ export class FileInteractionState {
       removed += deltaRemoved;
     }
 
-    const editsForCall = Array.from(perCallEdits.entries()).map(
+    const editsForCall = [...perCallEdits.entries()].map(
       ([path, diff]) => ({
         path,
         lineChanges:

--- a/src/agent/core/AgentWorkspaceState.ts
+++ b/src/agent/core/AgentWorkspaceState.ts
@@ -144,15 +144,13 @@ export class FileInteractionState {
       removed += deltaRemoved;
     }
 
-    const editsForCall = [...perCallEdits.entries()].map(
-      ([path, diff]) => ({
-        path,
-        lineChanges:
-          diff.added || diff.removed
-            ? { added: diff.added, removed: diff.removed }
-            : undefined,
-      }),
-    );
+    const editsForCall = [...perCallEdits.entries()].map(([path, diff]) => ({
+      path,
+      lineChanges:
+        diff.added || diff.removed
+          ? { added: diff.added, removed: diff.removed }
+          : undefined,
+    }));
 
     const lineChanges = added || removed ? { added, removed } : undefined;
     return { edits: editsForCall, lineChanges };

--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -16,7 +16,6 @@ import {
   resetCycleState,
   SkippableNodeResult,
 } from '@agent/core/flows/CommonCycleTypes';
-import { RetryErrorInfoSchema, type RetryErrorInfo } from './RetryState';
 // Type imports
 import { type ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
 import type { ProviderStopReason } from '@agent/modelHandlers/types/StopReasonTypes';
@@ -38,6 +37,7 @@ import { K_SLICE, REPETITION_DETECTION_THRESHOLD } from '@utils/config';
 import { AbsoluteFS, flexibleFS } from '@utils/files';
 import { extractScratchpad } from '@utils/text/xmlUtils';
 import { bestConnectionMethod } from '@latex';
+import { RetryErrorInfoSchema, type RetryErrorInfo } from './RetryState';
 
 // Local file imports
 import { FlowTransition } from './FlowTransitions';

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -11,7 +11,6 @@ import {
   resetCycleState,
   getDebugContext,
 } from '@agent/core/flows/CommonCycleTypes';
-import { createRetryState, type RetryState } from './RetryState';
 import type { SdkToolCall } from '@agent/modelHandlers/types/IModelHandler';
 import type { ServerToolContentBlock } from '@agent/modelHandlers/types/ServerToolTypes';
 import type { ProviderStopReason } from '@agent/modelHandlers/types/StopReasonTypes';
@@ -40,6 +39,7 @@ import type { ToolDefinition } from '@model';
 import { AbsoluteFS, pathToLocation, type FileLocation } from '@utils/files';
 import { isNonEmptyString } from '@utils/core';
 import { formatContent } from '@utils/text/xmlUtils';
+import { createRetryState, type RetryState } from './RetryState';
 
 // Local file imports
 import { FlowTransition } from './FlowTransitions';

--- a/src/agent/implementations/flows/ToolUseRunFlow.ts
+++ b/src/agent/implementations/flows/ToolUseRunFlow.ts
@@ -39,15 +39,15 @@ import { interpretCycleCompletion } from '@agent/core/flows/CommonCycleTypes';
 // Type imports
 import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
 import type { IToolUseSession } from '@agent/implementations/flows/tooluse/ToolUseSessionLifecycle';
-import type { TodoItem } from '@eventBus/schemas';
-import { bus } from '@eventBus/ProgressEventBus';
-
-// Internal imports
 import {
   type NodeExecResult,
   NODE_NO_RETRY,
   NODE_NO_WAIT,
 } from '@agent/implementations/flows/common';
+import type { TodoItem } from '@eventBus/schemas';
+import { bus } from '@eventBus/ProgressEventBus';
+
+// Internal imports
 
 // Service types and helper functions (direct calls, no closures)
 import {

--- a/src/agent/implementations/flows/reflection/ReflectionFlowState.ts
+++ b/src/agent/implementations/flows/reflection/ReflectionFlowState.ts
@@ -155,7 +155,7 @@ export const ReflectionFlowStateSchema = z
     // Note: lastError is inherited from OptionalCycleFieldsSchema (via BaseCycleFieldsSchema).
     // Used to distinguish failure from cancellation during resume.
   })
-  .merge(OptionalCycleFieldsSchema);
+  .extend(OptionalCycleFieldsSchema.shape);
 
 /** Derived type from schema (serializable fields only) */
 export type ReflectionFlowState = z.infer<typeof ReflectionFlowStateSchema>;

--- a/src/agent/implementations/flows/reflection/ReflectionServices.ts
+++ b/src/agent/implementations/flows/reflection/ReflectionServices.ts
@@ -13,14 +13,14 @@
 import type { IOutputHandler } from '@agent/output';
 import type { AgentWorkflowSetting } from '@agent/core/AgentDataclass';
 import type { RoundFinalizedCallback } from '@agent/core/flows/CycleServices';
-import type {
-  BaseFlowContextInit,
-  FlowServiceAccessors,
-} from '../common/BaseFlowServices';
 import type { AgentLogStage } from '@logger/AgentLogger';
 import type { PromptBuilder } from '@utils/prompt';
 import type { AgentFileLocation, TaskRunFileService } from '@utils/files';
 import type { LatexMediaManager } from '@latex';
+import type {
+  BaseFlowContextInit,
+  FlowServiceAccessors,
+} from '../common/BaseFlowServices';
 
 /**
  * Services for reflection flow nodes.

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -866,7 +866,10 @@ export class ModelHandlerAnthropic extends ModelHandler<
     const withoutControlChars = Array.from(trimmed, (char) =>
       char.charCodeAt(0) < 32 ? '_' : char,
     ).join('');
-    const withoutForbidden = withoutControlChars.replaceAll(/[:<>"|?*\\/]/g, '_');
+    const withoutForbidden = withoutControlChars.replaceAll(
+      /[:<>"|?*\\/]/g,
+      '_',
+    );
     // Use || here (not ??) because we need to catch empty strings, not just null/undefined
     const sanitized = withoutForbidden || 'document.pdf';
     // Removing directory information avoids Anthropic rejecting names that contain

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -866,7 +866,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
     const withoutControlChars = Array.from(trimmed, (char) =>
       char.charCodeAt(0) < 32 ? '_' : char,
     ).join('');
-    const withoutForbidden = withoutControlChars.replace(/[:<>"|?*\\/]/g, '_');
+    const withoutForbidden = withoutControlChars.replaceAll(/[:<>"|?*\\/]/g, '_');
     // Use || here (not ??) because we need to catch empty strings, not just null/undefined
     const sanitized = withoutForbidden || 'document.pdf';
     // Removing directory information avoids Anthropic rejecting names that contain

--- a/src/agent/node/index.ts
+++ b/src/agent/node/index.ts
@@ -83,7 +83,7 @@ class BaseNode<
       next = this._successors.get(nextAction);
     if (!next && this._successors.size > 0)
       console.warn(
-        `Flow ends: '${nextAction}' not found in [${Array.from(this._successors.keys())}]`,
+        `Flow ends: '${nextAction}' not found in [${[...this._successors.keys()]}]`,
       );
     return next;
   }

--- a/src/agent/output/LatexDiffManager.ts
+++ b/src/agent/output/LatexDiffManager.ts
@@ -176,7 +176,7 @@ export class LatexDiffManager {
       );
       this.logger.debug(`r${currRound} output files: ${outputPaths}`);
 
-      const basePairs = Array.from(mapping.baseToOutput.entries());
+      const basePairs = [...mapping.baseToOutput.entries()];
       if (basePairs.length > 0) {
         this.logger.debug(
           `Matched base files to output files: ${basePairs
@@ -257,7 +257,7 @@ export class LatexDiffManager {
 
       if (generateBetweenRoundDiffs && currRound > 0) {
         this.logger.debug('Running between-rounds latexdiff operations');
-        const prevPairs = Array.from(mapping.prevToOutput.entries());
+        const prevPairs = [...mapping.prevToOutput.entries()];
 
         if (prevPairs.length > 0) {
           this.logger.debug(

--- a/src/agent/output/OutputHandler.ts
+++ b/src/agent/output/OutputHandler.ts
@@ -142,7 +142,7 @@ export class OutputHandler implements IOutputHandler {
     add(cfg.inputFile ?? undefined);
     cfg.inputFiles.forEach((file) => add(file));
 
-    return Array.from(extras.values());
+    return [...extras.values()];
   }
 
   public setActiveRun(storageKey: StorageKey): void {

--- a/src/agent/storage/ExecutionKVStore.ts
+++ b/src/agent/storage/ExecutionKVStore.ts
@@ -77,7 +77,7 @@ class StorageFSKVStore implements ExecutionKVStore {
 
   private keyToPath(key: string): string {
     // Sanitize key to prevent path traversal
-    const sanitized = key.replace(/\.\./g, '_').replace(/[<>:"|?*]/g, '_');
+    const sanitized = key.replaceAll('..', '_').replace(/[<>:"|?*]/g, '_');
     return path.join(EXECUTIONS_DIR, this.executionId, `${sanitized}.json`);
   }
 

--- a/src/agent/storage/ExecutionKVStore.ts
+++ b/src/agent/storage/ExecutionKVStore.ts
@@ -77,7 +77,7 @@ class StorageFSKVStore implements ExecutionKVStore {
 
   private keyToPath(key: string): string {
     // Sanitize key to prevent path traversal
-    const sanitized = key.replaceAll('..', '_').replace(/[<>:"|?*]/g, '_');
+    const sanitized = key.replaceAll('..', '_').replaceAll(/[<>:"|?*]/g, '_');
     return path.join(EXECUTIONS_DIR, this.executionId, `${sanitized}.json`);
   }
 

--- a/src/agent/utils/UsageMonitor.ts
+++ b/src/agent/utils/UsageMonitor.ts
@@ -11,11 +11,11 @@ import type {
   ExtendedTokenUsageStats,
 } from '@agent/types/UsageTypes';
 import { UsageProviderSchema } from '@agent/types/NormalizedUsage';
-import type { ModelCapabilities, ModelConfig } from '@model';
 
 // Internal imports
 import { AgentExecutionContext } from '@agent/runtime/AgentExecutionContext';
 import { UsageLogService } from '@logger/UsageLogService';
+import type { ModelCapabilities, ModelConfig } from '@model';
 
 /**
  * Optional metadata for usage logging.

--- a/src/agent/utils/debugMessageSaver.ts
+++ b/src/agent/utils/debugMessageSaver.ts
@@ -92,7 +92,7 @@ export async function maybeSaveDebugObject({
       : baseName;
   const cont =
     continuationCount !== undefined ? `_cont${continuationCount}` : '';
-  const modelPart = modelName ? `_${modelName.replace(/[\\/]/g, '_')}` : '';
+  const modelPart = modelName ? `_${modelName.replaceAll(/[\\/]/g, '_')}` : '';
   const debugFileName = `${fileBase}${modelPart}${cont}.json`;
 
   try {

--- a/src/commands/files/openFileCommands.ts
+++ b/src/commands/files/openFileCommands.ts
@@ -20,7 +20,7 @@ export async function openFile(file: string): Promise<void> {
 }
 
 export async function openLabel(label: string): Promise<void> {
-  const escape = label.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const escape = label.replaceAll(/[.*+?^${}()|[\]\\]/g, '\\$&');
   const pattern = new RegExp(`\\\\label\\{${escape}\\}`, 'm');
   const candidates = new Set([
     ...(await fileLister.list('input')),

--- a/src/commands/latex/latexdiffCommands.ts
+++ b/src/commands/latex/latexdiffCommands.ts
@@ -789,7 +789,7 @@ async function runLatexdiffViaWorkspaceScan(params: {
   for (const [, roundOutputs] of inputToOutputsMap.entries()) {
     totalOperations += roundOutputs.size;
 
-    const rounds = Array.from(roundOutputs.keys()).sort((a, b) => a - b);
+    const rounds = [...roundOutputs.keys()].sort((a, b) => a - b);
     if (generateBetweenRoundDiffs && rounds.length > 1) {
       totalOperations += rounds.length - 1;
     }
@@ -810,7 +810,7 @@ async function runLatexdiffViaWorkspaceScan(params: {
       message: `Running diffs for ${path.basename(baseFile)}...`,
     });
 
-    const rounds = Array.from(roundOutputs.keys()).sort((a, b) => a - b);
+    const rounds = [...roundOutputs.keys()].sort((a, b) => a - b);
 
     for (const round of rounds) {
       const outputFile = roundOutputs.get(round)!;

--- a/src/commands/latex/latexdiffCommands.ts
+++ b/src/commands/latex/latexdiffCommands.ts
@@ -746,7 +746,7 @@ async function runLatexdiffViaWorkspaceScan(params: {
 
     const roundOutputsMap = new Map<number, string>();
     const outputFilePattern = new RegExp(
-      `${baseInputName}_${agentNameChunk}_r(\\d+)_${model.replace(/\./g, '')}`,
+      `${baseInputName}_${agentNameChunk}_r(\\d+)_${model.replaceAll('.', '')}`,
     );
 
     for (const [fileName, fileType] of dirEntries) {

--- a/src/commands/wolfram/wolframScriptCommands.ts
+++ b/src/commands/wolfram/wolframScriptCommands.ts
@@ -322,7 +322,7 @@ export function registerWolframScriptCommands(
             <div class="file-info">File: ${filePath}</div>
             <div class="input">
               <h3>File Content (sample):</h3>
-              <pre>${sampleContent.replace(/</g, '&lt;').replace(/>/g, '&gt;')}</pre>
+              <pre>${sampleContent.replaceAll('<', '&lt;').replaceAll('>', '&gt;')}</pre>
             </div>
             ${outputContent}
             ${errorContent}

--- a/src/frontend/files/listing.ts
+++ b/src/frontend/files/listing.ts
@@ -9,7 +9,7 @@ function sanitizeDirectories(directories: string[]): string[] {
     .map((dir) => dir.trim())
     .filter((dir) => dir.length > 0)
     .map((dir) =>
-      dir.replace(/\\/g, '/').replace(/^\//, '').replace(/\/$/, ''),
+      dir.replaceAll('\\', '/').replace(/^\//, '').replace(/\/$/, ''),
     );
 }
 

--- a/src/frontend/webview/html.ts
+++ b/src/frontend/webview/html.ts
@@ -17,8 +17,8 @@ export function buildWebviewHtml(
   const nonce = nanoid(32);
 
   let result = htmlContent
-    .replace(/\${nonce}/g, nonce)
-    .replace(/\${cspSource}/g, webview.cspSource);
+    .replaceAll('${nonce}', nonce)
+    .replaceAll('${cspSource}', webview.cspSource);
 
   for (const [key, value] of Object.entries(replacements)) {
     const replaced =

--- a/src/frontend/webview/html.ts
+++ b/src/frontend/webview/html.ts
@@ -25,7 +25,7 @@ export function buildWebviewHtml(
       value instanceof vscode.Uri
         ? webview.asWebviewUri(value).toString()
         : value;
-    result = result.replace(new RegExp(`\\$\\{${key}\\}`, 'g'), replaced);
+    result = result.replaceAll(new RegExp(`\\$\\{${key}\\}`, 'g'), replaced);
   }
 
   return result;

--- a/src/housekeeping/clean.ts
+++ b/src/housekeeping/clean.ts
@@ -155,7 +155,7 @@ export async function runCleanBuild(): Promise<void> {
     return;
   }
 
-  const ignorePatterns = Array.from(EXCLUDED_DIRS)
+  const ignorePatterns = [...EXCLUDED_DIRS]
     .filter((dir) => dir !== 'build')
     .map((dir) => `**/${dir}/**`);
 
@@ -195,7 +195,7 @@ export async function runCleanOutput(): Promise<void> {
   }
 
   const modelsPattern = MODELS.join(',');
-  const ignorePatterns = Array.from(EXCLUDED_DIRS).map((d) => `**/${d}/**`);
+  const ignorePatterns = [...EXCLUDED_DIRS].map((d) => `**/${d}/**`);
 
   const files = globSync(`**/*_{${modelsPattern}}*.{tex,pdf,xml}`, {
     cwd: workspacePath,

--- a/src/housekeeping/latexdiff.ts
+++ b/src/housekeeping/latexdiff.ts
@@ -66,7 +66,7 @@ export async function runPackLatexdiffvc(
       vscode.window.showInformationMessage('LaTeXdiff files cleaned');
     } else {
       // Move files to output folder only when needed
-      const now = new Date().toISOString().replace(/[-:]/g, '').split('.')[0];
+      const now = new Date().toISOString().replaceAll(/[-:]/g, '').split('.')[0];
       const outputFolder = path.join(
         inputDir,
         'Diffs',

--- a/src/housekeeping/latexdiff.ts
+++ b/src/housekeeping/latexdiff.ts
@@ -66,7 +66,10 @@ export async function runPackLatexdiffvc(
       vscode.window.showInformationMessage('LaTeXdiff files cleaned');
     } else {
       // Move files to output folder only when needed
-      const now = new Date().toISOString().replaceAll(/[-:]/g, '').split('.')[0];
+      const now = new Date()
+        .toISOString()
+        .replaceAll(/[-:]/g, '')
+        .split('.')[0];
       const outputFolder = path.join(
         inputDir,
         'Diffs',

--- a/src/housekeeping/pack.ts
+++ b/src/housekeeping/pack.ts
@@ -99,7 +99,7 @@ export async function runPackSingle(
           : ''),
     );
 
-    const now = new Date().toISOString().replace(/[-:]/g, '').split('.')[0];
+    const now = new Date().toISOString().replaceAll(/[-:]/g, '').split('.')[0];
     outputFolder =
       outputFolder ||
       path.join(inputDir, HISTORY_DIR, `${now}_${baseName}_${agent}_${model}`);
@@ -172,7 +172,7 @@ export async function runPackMultiple(
   const baseName = path.parse(fileToPack).name;
   const outputDir = path.dirname(fileToPack);
 
-  const now = new Date().toISOString().replace(/[-:]/g, '').split('.')[0];
+  const now = new Date().toISOString().replaceAll(/[-:]/g, '').split('.')[0];
   const commonOutputFolder = path.join(
     outputDir,
     HISTORY_DIR,

--- a/src/latex/LatexMediaManager.ts
+++ b/src/latex/LatexMediaManager.ts
@@ -70,7 +70,7 @@ export class LatexMediaManager {
       return;
     }
 
-    const tasks = Array.from(targetLocations).map(async (targetLocation) => {
+    const tasks = [...targetLocations].map(async (targetLocation) => {
       try {
         await this.fileService!.mirrorWorkspaceFile(targetLocation);
       } catch (error) {

--- a/src/latex/arxivProcessor.ts
+++ b/src/latex/arxivProcessor.ts
@@ -169,7 +169,7 @@ export class ArxivSourceProcessor {
     }
 
     // Create project directory for the arXiv paper (sanitize ID to avoid path issues)
-    const sanitizedId = id.replace(/\//g, '_');
+    const sanitizedId = id.replaceAll('/', '_');
     const paperDirRelative = sanitizedId;
     await WorkspaceFS.ensureDir(paperDirRelative);
 

--- a/src/latex/extractBibliography.ts
+++ b/src/latex/extractBibliography.ts
@@ -54,7 +54,7 @@ export interface BibliographyEntriesResult {
 }
 
 function stripComments(content: string): string {
-  return content.replace(COMMENT_PATTERN, '$1');
+  return content.replaceAll(COMMENT_PATTERN, '$1');
 }
 
 function normalizeBibPath(baseDir: string, target: string): string {
@@ -82,7 +82,7 @@ function collectBibliographyPaths(baseDir: string, content: string): string[] {
     }
   }
 
-  return Array.from(paths);
+  return [...paths];
 }
 
 function collectCitationKeys(content: string): string[] {
@@ -99,7 +99,7 @@ function collectCitationKeys(content: string): string[] {
     }
   }
 
-  return Array.from(keys);
+  return [...keys];
 }
 
 export async function extractBibliographyContext(
@@ -264,7 +264,7 @@ export function summarizeBibliographyEntries(
   entries: Map<string, string>,
   limit: number,
 ): string[] {
-  const values = Array.from(entries.values());
+  const values = [...entries.values()];
   const limited = values.slice(0, limit);
   const lines: string[] = [];
 

--- a/src/latex/extractFigure.ts
+++ b/src/latex/extractFigure.ts
@@ -23,17 +23,18 @@ function parseGraphicspath(content: string): string[] {
   const pathPattern = /\{([^{}]+)\}/g;
 
   // Use flatMap to process outer matches and extract inner paths
-  const extractedPaths = [...content.matchAll(graphicspathPattern)].flatMap((outerMatch) =>
-    [...outerMatch[1].matchAll(pathPattern)]
-      .map((pathMatch) => {
-        let p = pathMatch[1].trim();
-        // Ensure path has trailing slash
-        if (p && !p.endsWith('/')) {
-          p += '/';
-        }
-        return p;
-      })
-      .filter(Boolean),
+  const extractedPaths = [...content.matchAll(graphicspathPattern)].flatMap(
+    (outerMatch) =>
+      [...outerMatch[1].matchAll(pathPattern)]
+        .map((pathMatch) => {
+          let p = pathMatch[1].trim();
+          // Ensure path has trailing slash
+          if (p && !p.endsWith('/')) {
+            p += '/';
+          }
+          return p;
+        })
+        .filter(Boolean),
   );
 
   paths.push(...extractedPaths);

--- a/src/latex/extractFigure.ts
+++ b/src/latex/extractFigure.ts
@@ -23,10 +23,8 @@ function parseGraphicspath(content: string): string[] {
   const pathPattern = /\{([^{}]+)\}/g;
 
   // Use flatMap to process outer matches and extract inner paths
-  const extractedPaths = Array.from(
-    content.matchAll(graphicspathPattern),
-  ).flatMap((outerMatch) =>
-    Array.from(outerMatch[1].matchAll(pathPattern))
+  const extractedPaths = [...content.matchAll(graphicspathPattern)].flatMap((outerMatch) =>
+    [...outerMatch[1].matchAll(pathPattern)]
       .map((pathMatch) => {
         let p = pathMatch[1].trim();
         // Ensure path has trailing slash
@@ -70,7 +68,7 @@ export async function extractFigurePathsFromLatex(
     const paths = parseGraphicspath(content);
     for (const p of paths) {
       const normalizedPath = path.normalize(
-        path.join(latexDir, p.replace(/^\/+|\/+$/g, '')),
+        path.join(latexDir, p.replaceAll(/^\/+|\/+$/g, '')),
       );
       graphicspaths.push(normalizedPath);
     }

--- a/src/latex/formatter/latexindentpt.ts
+++ b/src/latex/formatter/latexindentpt.ts
@@ -81,7 +81,7 @@ export async function runLatexIndent(filePath: string): Promise<boolean> {
         `${fileBaseName}.tex.bak`,
         `${fileBaseName}.bak*`,
         `${fileBaseName}.bak`,
-      ].map((pattern) => path.join(fileDir, pattern).replace(/\\/g, '/'));
+      ].map((pattern) => path.join(fileDir, pattern).replaceAll('\\', '/'));
 
       logger.debug(
         CHANNEL,

--- a/src/latex/latexdiff/diffFileProcessor.ts
+++ b/src/latex/latexdiff/diffFileProcessor.ts
@@ -39,8 +39,8 @@ export class DiffFileProcessor {
       'g',
     );
 
-    return content.replace(starEnvRegex, (_match, envName, envContent) => {
-      const cleanContent = envContent.replace(/\\label\{[^}]*\}/g, '');
+    return content.replaceAll(starEnvRegex, (_match, envName, envContent) => {
+      const cleanContent = envContent.replaceAll(/\\label\{[^}]*\}/g, '');
       return `\\begin{${envName}}${cleanContent}\\end{${envName}}`;
     });
   }

--- a/src/logger/TaskState.ts
+++ b/src/logger/TaskState.ts
@@ -40,7 +40,7 @@ const WorkflowTaskStateSchema = z.object({
   agentConfig: AgentConfigWithSessionSchema.refine(
     (c) => c.session.agentCategory === AgentCategory.Workflow,
     {
-        error: 'Expected Workflow category'
+      error: 'Expected Workflow category',
     },
   ),
   activeFiles: ActiveFilesSchema,
@@ -51,7 +51,7 @@ const ToolUseTaskStateSchema = z.object({
   agentConfig: AgentConfigWithSessionSchema.refine(
     (c) => c.session.agentCategory === AgentCategory.ToolUse,
     {
-        error: 'Expected ToolUse category'
+      error: 'Expected ToolUse category',
     },
   ),
   toolSessionState: ToolSessionStateSchema.optional(),

--- a/src/logger/TaskState.ts
+++ b/src/logger/TaskState.ts
@@ -23,7 +23,7 @@ const ToolSessionStateSchema = z.object({
 });
 
 /** Active files record schema */
-const ActiveFilesSchema = z.record(
+const ActiveFilesSchema = z.partialRecord(
   z.enum(FILE_TYPES),
   z.boolean(),
 ) as z.ZodType<Record<FileType, boolean>>;
@@ -39,7 +39,9 @@ const AgentConfigWithSessionSchema = z.looseObject({
 const WorkflowTaskStateSchema = z.object({
   agentConfig: AgentConfigWithSessionSchema.refine(
     (c) => c.session.agentCategory === AgentCategory.Workflow,
-    { message: 'Expected Workflow category' },
+    {
+        error: 'Expected Workflow category'
+    },
   ),
   activeFiles: ActiveFilesSchema,
 });
@@ -48,7 +50,9 @@ const WorkflowTaskStateSchema = z.object({
 const ToolUseTaskStateSchema = z.object({
   agentConfig: AgentConfigWithSessionSchema.refine(
     (c) => c.session.agentCategory === AgentCategory.ToolUse,
-    { message: 'Expected ToolUse category' },
+    {
+        error: 'Expected ToolUse category'
+    },
   ),
   toolSessionState: ToolSessionStateSchema.optional(),
 });

--- a/src/logger/TaskState.ts
+++ b/src/logger/TaskState.ts
@@ -29,13 +29,11 @@ const ActiveFilesSchema = z.record(
 ) as z.ZodType<Record<FileType, boolean>>;
 
 /** Minimal agentConfig schema - just validates the discriminator exists */
-const AgentConfigWithSessionSchema = z
-  .object({
-    session: z.object({
-      agentCategory: z.enum(AgentCategory),
-    }),
-  })
-  .passthrough();
+const AgentConfigWithSessionSchema = z.looseObject({
+  session: z.object({
+    agentCategory: z.enum(AgentCategory),
+  }),
+});
 
 /** Schema for workflow task state */
 const WorkflowTaskStateSchema = z.object({

--- a/src/logger/UsageLogTypes.ts
+++ b/src/logger/UsageLogTypes.ts
@@ -86,8 +86,8 @@ export type UsageLogStats = z.infer<typeof UsageLogStatsSchema>;
  * Single usage log entry sent to the backend.
  * Composed from metadata + stats + timestamp/version fields.
  */
-export const UsageLogEntrySchema = UsageLogMetadataSchema.merge(
-  UsageLogStatsSchema,
+export const UsageLogEntrySchema = UsageLogMetadataSchema.extend(
+  UsageLogStatsSchema.shape
 ).extend({
   /** Timestamp when the API call completed (ISO 8601) */
   timestamp: z.iso.datetime(),

--- a/src/logger/UsageLogTypes.ts
+++ b/src/logger/UsageLogTypes.ts
@@ -87,7 +87,7 @@ export type UsageLogStats = z.infer<typeof UsageLogStatsSchema>;
  * Composed from metadata + stats + timestamp/version fields.
  */
 export const UsageLogEntrySchema = UsageLogMetadataSchema.extend(
-  UsageLogStatsSchema.shape
+  UsageLogStatsSchema.shape,
 ).extend({
   /** Timestamp when the API call completed (ISO 8601) */
   timestamp: z.iso.datetime(),

--- a/src/logger/filterUtils.ts
+++ b/src/logger/filterUtils.ts
@@ -1,6 +1,6 @@
 // Local imports
-import { MESSAGE_TYPES, type MessageType } from './messageTypes';
 import { getConfig } from '@utils/config';
+import { MESSAGE_TYPES, type MessageType } from './messageTypes';
 
 export interface FilterOptions {
   level: 'debug' | 'info' | 'warn' | 'error';

--- a/src/logger/filterUtils.ts
+++ b/src/logger/filterUtils.ts
@@ -49,4 +49,3 @@ export function getEmitFilter(options: FilterOptions): FilterResult {
 
   return { shouldEmit: true, debugMode };
 }
-

--- a/src/logger/streamUtils.ts
+++ b/src/logger/streamUtils.ts
@@ -47,6 +47,6 @@ export function getStreamTabId(
   // in different directories. Normalize backslashes to forward slashes for consistent IDs
   // across platforms and to avoid issues with CSS attribute selectors where backslashes
   // are treated as escape characters.
-  const filePath = (inputFile ?? '').replace(/\\/g, '/');
+  const filePath = (inputFile ?? '').replaceAll('\\', '/');
   return `${agentName}@${model}: ${filePath}`;
 }

--- a/src/logger/transports/VSCodeTransport.ts
+++ b/src/logger/transports/VSCodeTransport.ts
@@ -4,12 +4,12 @@ import * as vscode from 'vscode';
 import Transport from 'winston-transport';
 
 // Internal imports
-import { bus } from '@eventBus/ProgressEventBus';
 import { getEmitFilter } from '@logger/filterUtils';
 import type { LogMessageData } from '@logger/LogTypes';
 import { MESSAGE_TYPES, type MessageType } from '@logger/messageTypes';
 import type { EndGroupStatus } from '@logger/messageTypes';
 import { getColorForLevel, serializeLogData } from '@logger/utils';
+import { bus } from '@eventBus/ProgressEventBus';
 
 interface VSCodeTransportOptions extends Transport.TransportStreamOptions {
   channel: vscode.OutputChannel;

--- a/src/logger/transports/VSCodeTransport.ts
+++ b/src/logger/transports/VSCodeTransport.ts
@@ -146,5 +146,4 @@ export class VSCodeTransport extends Transport {
       logMessage,
     });
   }
-
 }

--- a/src/model/ModelConfig.ts
+++ b/src/model/ModelConfig.ts
@@ -23,9 +23,9 @@ import type { ModelConfig, ModelCapabilities } from 'llm-zoo';
 // Zod v4 Schemas - Local (avoids moduleResolution issues with subpath imports)
 // ============================================================================
 
-export const ReasoningEffortSchema = z.nativeEnum(ReasoningEffort);
+export const ReasoningEffortSchema = z.enum(ReasoningEffort);
 
-export const ModelProviderSchema = z.nativeEnum(ModelProvider);
+export const ModelProviderSchema = z.enum(ModelProvider);
 
 /** Feature flags defining model's supported capabilities and behaviors. */
 export const ModelCapabilitiesSchema = z.object({

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -634,7 +634,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
       }
     }
 
-    const outputFilesArray = Array.from(allFiles);
+    const outputFilesArray = [...allFiles];
     const useMultipleOutputs =
       taskState.agentConfig.useMultipleOutputs ??
       taskState.activeFiles.output ??

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -270,12 +270,19 @@ export class ProgressEventHandler {
     stream,
     logMessage,
   }: ProgressEventPayloads['addLogMessage']): void => {
-    withEventErrorHandling('LogEvents', 'failed to handle addLogMessage', async () => {
-      const isNew = await this.state.streamTabs.addMessage(stream, logMessage);
-      if (isNew && this.webviewUpdater.isAvailable()) {
-        this.webviewUpdater.appendLogMessage(stream, logMessage);
-      }
-    });
+    withEventErrorHandling(
+      'LogEvents',
+      'failed to handle addLogMessage',
+      async () => {
+        const isNew = await this.state.streamTabs.addMessage(
+          stream,
+          logMessage,
+        );
+        if (isNew && this.webviewUpdater.isAvailable()) {
+          this.webviewUpdater.appendLogMessage(stream, logMessage);
+        }
+      },
+    );
   };
 
   /** Handle updateLogMessage - inlined from LogEvents.ts */
@@ -283,40 +290,45 @@ export class ProgressEventHandler {
     stream,
     logMessage,
   }: ProgressEventPayloads['updateLogMessage']): void => {
-    withEventErrorHandling('LogEvents', 'failed to handle updateLogMessage', async () => {
-      if (!this.state.streamTabs.has(stream)) return;
+    withEventErrorHandling(
+      'LogEvents',
+      'failed to handle updateLogMessage',
+      async () => {
+        if (!this.state.streamTabs.has(stream)) return;
 
-      const messages = this.state.streamTabs.getMessages(stream);
-      const existing = messages.find((m) => m.id === logMessage.id);
-      if (!existing) return;
+        const messages = this.state.streamTabs.getMessages(stream);
+        const existing = messages.find((m) => m.id === logMessage.id);
+        if (!existing) return;
 
-      // Skip INTERNAL message updates
-      if (
-        existing.messageType === MESSAGE_TYPES.INTERNAL ||
-        logMessage.messageType === MESSAGE_TYPES.INTERNAL
-      ) {
-        return;
-      }
+        // Skip INTERNAL message updates
+        if (
+          existing.messageType === MESSAGE_TYPES.INTERNAL ||
+          logMessage.messageType === MESSAGE_TYPES.INTERNAL
+        ) {
+          return;
+        }
 
-      // Update fields if provided
-      if (logMessage.text !== undefined) existing.text = logMessage.text;
-      if (logMessage.messageType !== undefined)
-        existing.messageType = logMessage.messageType;
-      if (logMessage.level) existing.level = logMessage.level;
-      if (logMessage.timestamp !== undefined)
-        existing.timestamp = logMessage.timestamp;
-      if (logMessage.verbose !== undefined) existing.verbose = logMessage.verbose;
-      if (logMessage.data !== undefined) existing.data = logMessage.data;
+        // Update fields if provided
+        if (logMessage.text !== undefined) existing.text = logMessage.text;
+        if (logMessage.messageType !== undefined)
+          existing.messageType = logMessage.messageType;
+        if (logMessage.level) existing.level = logMessage.level;
+        if (logMessage.timestamp !== undefined)
+          existing.timestamp = logMessage.timestamp;
+        if (logMessage.verbose !== undefined)
+          existing.verbose = logMessage.verbose;
+        if (logMessage.data !== undefined) existing.data = logMessage.data;
 
-      await this.state.streamTabs.save();
+        await this.state.streamTabs.save();
 
-      if (
-        this.webviewUpdater.isAvailable() &&
-        stream === this.state.activeStream
-      ) {
-        this.webviewUpdater.updateLogMessage(stream, existing);
-      }
-    });
+        if (
+          this.webviewUpdater.isAvailable() &&
+          stream === this.state.activeStream
+        ) {
+          this.webviewUpdater.updateLogMessage(stream, existing);
+        }
+      },
+    );
   };
 
   /** Handle addOutputFiles - inlined from OutputEvents.ts */
@@ -325,17 +337,23 @@ export class ProgressEventHandler {
     storageKey,
     filesByRound,
   }: ProgressEventPayloads['addOutputFiles']): void => {
-    withEventErrorHandling('OutputEvents', 'failed to handle addOutputFiles', async () => {
-      await this.state.outputFiles.addFiles(stream, storageKey, filesByRound);
-      if (!this.webviewUpdater.isAvailable()) return;
+    withEventErrorHandling(
+      'OutputEvents',
+      'failed to handle addOutputFiles',
+      async () => {
+        await this.state.outputFiles.addFiles(stream, storageKey, filesByRound);
+        if (!this.webviewUpdater.isAvailable()) return;
 
-      const runFiles = this.state.outputFiles.getFiles(stream).get(storageKey);
-      const rounds = this.toRoundRecord(runFiles);
-      this.webviewUpdater.updateFiles(
-        stream,
-        rounds ? { runId: storageKey, rounds } : { runId: storageKey },
-      );
-    });
+        const runFiles = this.state.outputFiles
+          .getFiles(stream)
+          .get(storageKey);
+        const rounds = this.toRoundRecord(runFiles);
+        this.webviewUpdater.updateFiles(
+          stream,
+          rounds ? { runId: storageKey, rounds } : { runId: storageKey },
+        );
+      },
+    );
   };
 
   /** Handle updateMissingOutputs - inlined from OutputEvents.ts */
@@ -392,22 +410,34 @@ export class ProgressEventHandler {
     usage,
     storageKey,
   }: ProgressEventPayloads['updateStreamUsage']): void => {
-    withEventErrorHandling('UsageEvents', 'failed to handle updateStreamUsage', async () => {
-      const normalizedUsage: TokenUsageStats = {
-        inputTokens: Number(usage.inputTokens ?? 0),
-        outputTokens: Number(usage.outputTokens ?? 0),
-        cost: Number(usage.cost ?? 0),
-      };
+    withEventErrorHandling(
+      'UsageEvents',
+      'failed to handle updateStreamUsage',
+      async () => {
+        const normalizedUsage: TokenUsageStats = {
+          inputTokens: Number(usage.inputTokens ?? 0),
+          outputTokens: Number(usage.outputTokens ?? 0),
+          cost: Number(usage.cost ?? 0),
+        };
 
-      await this.state.usageStats.setRunUsage(stream, storageKey, normalizedUsage);
+        await this.state.usageStats.setRunUsage(
+          stream,
+          storageKey,
+          normalizedUsage,
+        );
 
-      if (
-        this.webviewUpdater.isAvailable() &&
-        stream === this.state.activeStream
-      ) {
-        this.webviewUpdater.updateRunUsage(stream, storageKey, normalizedUsage);
-      }
-    });
+        if (
+          this.webviewUpdater.isAvailable() &&
+          stream === this.state.activeStream
+        ) {
+          this.webviewUpdater.updateRunUsage(
+            stream,
+            storageKey,
+            normalizedUsage,
+          );
+        }
+      },
+    );
   };
 
   /** Handle updateTodos - inlined from TodoEvents.ts */

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -514,9 +514,7 @@ export class ProgressEventHandler {
     }
 
     const messages = this.state.streamTabs.getMessages(stream);
-    const groups = Array.from(
-      this.state.taskGroups.getStreamGroups(stream).values(),
-    );
+    const groups = [...this.state.taskGroups.getStreamGroups(stream).values()];
     const activeRunId = this.state.resolveRunId(stream, undefined, {
       persist: false,
     });

--- a/src/progressView/events/UIEvents.ts
+++ b/src/progressView/events/UIEvents.ts
@@ -10,8 +10,8 @@
 import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
 
 // Local file imports
-import type { ProgressEventBusLike } from './types';
 import { withEventErrorHandling } from './errorHandling';
+import type { ProgressEventBusLike } from './types';
 
 const MODULE = 'UIEvents';
 

--- a/src/progressView/managers/OutputFilesManager.ts
+++ b/src/progressView/managers/OutputFilesManager.ts
@@ -224,7 +224,7 @@ export class OutputFilesManager extends PersistentMapManager<
     const targetRunIds =
       options.storageKey !== undefined && options.storageKey !== null
         ? [options.storageKey]
-        : Array.from(runs.keys());
+        : [...runs.keys()];
 
     for (const target of targetRunIds) {
       const runRounds = runs.get(target);

--- a/src/progressView/persistence/PersistentMapManager.ts
+++ b/src/progressView/persistence/PersistentMapManager.ts
@@ -70,7 +70,7 @@ export abstract class PersistentMapManager<K extends string, V> {
 
   /** Get all keys */
   keys(): K[] {
-    return Array.from(this.items.keys());
+    return [...this.items.keys()];
   }
 
   /** Replace all entries (used during loading) */
@@ -110,7 +110,7 @@ export abstract class PersistentMapManager<K extends string, V> {
 
   /** Save current state to persistence */
   async save(): Promise<void> {
-    const serialized = Array.from(this.items.entries()).map(([key, value]) => [
+    const serialized = [...this.items.entries()].map(([key, value]) => [
       key,
       this.serialize(value, key),
     ]);

--- a/src/replacement/advanced.ts
+++ b/src/replacement/advanced.ts
@@ -43,7 +43,7 @@ export function applyLatexQuotesFormatting(text: string): string {
     let tikzCounter = 0;
 
     // Replace tikzpicture environments with placeholders
-    const contentWithoutTikz = documentContent.replace(
+    const contentWithoutTikz = documentContent.replaceAll(
       tikzRegex,
       (tikzMatchStr: string) => {
         const placeholder = `__TIKZ_PLACEHOLDER_${tikzCounter++}__`;
@@ -56,7 +56,7 @@ export function applyLatexQuotesFormatting(text: string): string {
 
     // Process quotes in the remaining content
     let replacementCount = 0;
-    const processedContent = contentWithoutTikz.replace(
+    const processedContent = contentWithoutTikz.replaceAll(
       /(?<!\\"|\{)"([^"]{3,16})"(?!\})/g,
       (_match, quotedText) => {
         replacementCount++;
@@ -110,13 +110,13 @@ export function escapeTextttUnderscores(text: string): string {
   const textttRegex = /\\texttt\{([^}]*)\}/g;
   let totalReplacements = 0;
 
-  const processedText = text.replace(
+  const processedText = text.replaceAll(
     textttRegex,
     (_match, rawContent: string) => {
       let replacementCount = 0;
       // (?<!\\)_ matches underscore not preceded by backslash
       // This ensures we don't double-escape already escaped underscores
-      const processedContent = rawContent.replace(/(?<!\\)_/g, () => {
+      const processedContent = rawContent.replaceAll(/(?<!\\)_/g, () => {
         replacementCount += 1;
         totalReplacements += 1;
         return '\\_';
@@ -337,13 +337,13 @@ export function replaceMathUnicode(text: string): string {
       const replacedContent = Object.entries(mathUnicodeMap)
         .reduce(
           (content, [unicode, latex]) =>
-            content.replace(new RegExp(unicode, 'g'), latex),
+            content.replaceAll(new RegExp(unicode, 'g'), latex),
           mathContent,
         )
         // Replace HTML subscript tags with LaTeX subscript syntax
-        .replace(/<sub>(.*?)<\/sub>/g, '_{$1}')
+        .replaceAll(/<sub>(.*?)<\/sub>/g, '_{$1}')
         // Replace HTML superscript tags with LaTeX superscript syntax
-        .replace(/<sup>(.*?)<\/sup>/g, '^{$1}');
+        .replaceAll(/<sup>(.*?)<\/sup>/g, '^{$1}');
 
       // Replace the original math content with the processed one
       if (replacedContent !== mathContent) {
@@ -360,17 +360,17 @@ export function replaceMathUnicode(text: string): string {
 
   // Also handle inline math with $ ... $
   const inlineMathPattern = /\$(.*?)\$/g;
-  text = text.replace(inlineMathPattern, (_match, p1) => {
+  text = text.replaceAll(inlineMathPattern, (_match, p1) => {
     // Replace Unicode characters with LaTeX commands, then HTML sub/sup tags
     const content = Object.entries(mathUnicodeMap)
       .reduce(
-        (c, [unicode, latex]) => c.replace(new RegExp(unicode, 'g'), latex),
+        (c, [unicode, latex]) => c.replaceAll(new RegExp(unicode, 'g'), latex),
         p1 as string,
       )
       // Replace HTML subscript tags with LaTeX subscript syntax
-      .replace(/<sub>(.*?)<\/sub>/g, '_{$1}')
+      .replaceAll(/<sub>(.*?)<\/sub>/g, '_{$1}')
       // Replace HTML superscript tags with LaTeX superscript syntax
-      .replace(/<sup>(.*?)<\/sup>/g, '^{$1}');
+      .replaceAll(/<sup>(.*?)<\/sup>/g, '^{$1}');
 
     return `$${content}$`;
   });
@@ -385,17 +385,17 @@ export function replaceMathUnicode(text: string): string {
 export function fixLatexQuoteIssues(text: string): string {
   // ''text'' -> ``text''
   // But avoid modifying text that's already in the format ``text''
-  text = text.replace(/(?<!`)''([a-zA-Z\s]{3,16})''(?!`)/g, "``$1''");
+  text = text.replaceAll(/(?<!`)''([a-zA-Z\s]{3,16})''(?!`)/g, "``$1''");
 
   // 'text' -> `text'
   // Only for single quotes that aren't already in the format `text'
-  text = text.replace(/(?<![\w`])'([a-zA-Z\s]{3,16})'(?![\w'])/g, "`$1'");
+  text = text.replaceAll(/(?<![\w`])'([a-zA-Z\s]{3,16})'(?![\w'])/g, "`$1'");
 
   // Move punctuation outside closing double quotes
-  text = text.replace(/(``[a-zA-Z\s]{3,16})([.,;:])('')(.*)/g, "$1''$2$4");
+  text = text.replaceAll(/(``[a-zA-Z\s]{3,16})([.,;:])('')(.*)/g, "$1''$2$4");
 
   // Move punctuation outside closing single quotes
-  text = text.replace(/(`[a-zA-Z\s]{3,16})([.,;:])(')/g, "$1'$2");
+  text = text.replaceAll(/(`[a-zA-Z\s]{3,16})([.,;:])(')/g, "$1'$2");
 
   return text;
 }
@@ -421,5 +421,5 @@ export function wrapCritiqueInAlign(text: string): string {
     }
     return block;
   }
-  return text.replace(alignRegex, wrapCommands);
+  return text.replaceAll(alignRegex, wrapCommands);
 }

--- a/src/replacement/constants.ts
+++ b/src/replacement/constants.ts
@@ -49,7 +49,7 @@ export const MATH_OPERATORS = [
 ];
 
 const escapeRegExp = (value: string): string =>
-  value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  value.replaceAll(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
 export const FENCED_LATEX_ENVIRONMENTS = [
   'align',

--- a/src/replacement/maxRules.ts
+++ b/src/replacement/maxRules.ts
@@ -219,7 +219,7 @@ export const MAX_AUTO_REPLACEMENTS: ReplacementCategory = {
     // Examples:
     // \vec{p} -> \vp (momentum vector)
     // \vec{x} -> \vx (position vector)
-    const vectorLetters = 'pqvxyz'.split('');
+    const vectorLetters = [...'pqvxyz'];
     patterns = { ...patterns, ...generateVectorShortcuts(vectorLetters) };
 
     // Greek Letters (Regular)
@@ -248,7 +248,7 @@ export const MAX_AUTO_REPLACEMENTS: ReplacementCategory = {
 
     // Mathcal Letters
     // Map \mathcal{X} to shorter \cX versions for all uppercase letters
-    const upperLetters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('');
+    const upperLetters = [...'ABCDEFGHIJKLMNOPQRSTUVWXYZ'];
     patterns = {
       ...patterns,
       ...generateMathFontShortcuts(upperLetters, 'mathcal', 'c'),
@@ -256,7 +256,7 @@ export const MAX_AUTO_REPLACEMENTS: ReplacementCategory = {
 
     // Mathbb Letters
     // Map \mathbb{X} to shorter \eX versions for specific letters
-    const mathbbLetters = 'CEINPQRTV'.split('');
+    const mathbbLetters = [...'CEINPQRTV'];
     patterns = {
       ...patterns,
       ...generateMathFontShortcuts(mathbbLetters, 'mathbb', 'e'),
@@ -264,7 +264,7 @@ export const MAX_AUTO_REPLACEMENTS: ReplacementCategory = {
 
     // Mathbf Letters (Lowercase)
     // Map \mathbf{x} to shorter \bx versions
-    const lowerLetters = 'abcdefghjnpqrsuvwxyz'.split('');
+    const lowerLetters = [...'abcdefghjnpqrsuvwxyz'];
     patterns = {
       ...patterns,
       ...generateMathFontShortcuts(lowerLetters, 'mathbf', 'b'),
@@ -272,7 +272,7 @@ export const MAX_AUTO_REPLACEMENTS: ReplacementCategory = {
 
     // Mathbf Letters (Uppercase)
     // Map \mathbf{X} to shorter \bX versions for uppercase letters
-    const mathbfUpperLetters = 'ABCDEFGIJKMQRUVWXYZ'.split('');
+    const mathbfUpperLetters = [...'ABCDEFGIJKMQRUVWXYZ'];
     patterns = {
       ...patterns,
       ...generateMathFontShortcuts(mathbfUpperLetters, 'mathbf', 'b'),
@@ -280,7 +280,7 @@ export const MAX_AUTO_REPLACEMENTS: ReplacementCategory = {
 
     // Normalize legacy font commands {\rm X}, {\bf X} and {\cal X}
     const alphabetLetters =
-      'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz'.split('');
+      [...'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz'];
     patterns = {
       ...patterns,
       ...generateLegacyTextCommandNormalization(
@@ -308,7 +308,7 @@ export const MAX_AUTO_REPLACEMENTS: ReplacementCategory = {
 
     // Tilde variables - simple letters
     // Examples: \tilde{x} -> \tx, \tilde{B} -> \tB
-    const tildeLetters = 'xzpqBFJMPTZ'.split('');
+    const tildeLetters = [...'xzpqBFJMPTZ'];
     patterns = {
       ...patterns,
       ...generateDecoratorShortcuts('tilde', tildeLetters, 't'),
@@ -316,7 +316,7 @@ export const MAX_AUTO_REPLACEMENTS: ReplacementCategory = {
 
     // Tilde with mathbf - lowercase
     // Example: \tilde{\mathbf{x}} -> \tbx
-    const tildeLettersMathbf = 'axpvwz'.split('');
+    const tildeLettersMathbf = [...'axpvwz'];
     patterns = {
       ...patterns,
       ...generateNestedDecoratorShortcuts(
@@ -330,7 +330,7 @@ export const MAX_AUTO_REPLACEMENTS: ReplacementCategory = {
 
     // Tilde with mathbf - uppercase
     // Example: \tilde{\mathbf{M}} -> \tbM
-    const tildeLettersMathbfUppercase = 'MTX'.split('');
+    const tildeLettersMathbfUppercase = [...'MTX'];
     patterns = {
       ...patterns,
       ...generateNestedDecoratorShortcuts(
@@ -344,7 +344,7 @@ export const MAX_AUTO_REPLACEMENTS: ReplacementCategory = {
 
     // Tilde with mathcal - uppercase
     // Example: \tilde{\mathcal{H}} -> \tcH
-    const tildeLettersMathcal = 'HQSW'.split('');
+    const tildeLettersMathcal = [...'HQSW'];
     patterns = {
       ...patterns,
       ...generateNestedDecoratorShortcuts(
@@ -388,7 +388,7 @@ export const MAX_AUTO_REPLACEMENTS: ReplacementCategory = {
 
     // Hat variables
     // Example: \hat{H} -> \hH
-    const hatLetters = 'HFP'.split('');
+    const hatLetters = [...'HFP'];
     patterns = {
       ...patterns,
       ...generateDecoratorShortcuts('hat', hatLetters, 'h'),
@@ -409,7 +409,7 @@ export const MAX_AUTO_REPLACEMENTS: ReplacementCategory = {
 
     // Hat with mathbf
     // Example: \hat{\mathbf{n}} -> \hbn
-    const hatMathbfLetters = 'nv'.split('');
+    const hatMathbfLetters = [...'nv'];
     patterns = {
       ...patterns,
       ...generateNestedDecoratorShortcuts(

--- a/src/replacement/maxRules.ts
+++ b/src/replacement/maxRules.ts
@@ -279,8 +279,9 @@ export const MAX_AUTO_REPLACEMENTS: ReplacementCategory = {
     };
 
     // Normalize legacy font commands {\rm X}, {\bf X} and {\cal X}
-    const alphabetLetters =
-      [...'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz'];
+    const alphabetLetters = [
+      ...'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz',
+    ];
     patterns = {
       ...patterns,
       ...generateLegacyTextCommandNormalization(

--- a/src/replacement/rules/equations.ts
+++ b/src/replacement/rules/equations.ts
@@ -47,15 +47,15 @@ export const EQUATION_REPLACEMENTS: ReplacementCategory = {
     // ===== Grouped backslash fixes =====
     // Use the new grouped helper to organize the backslash fixes logically
     const groupedBackslashPatterns = generateGroupedBackslashFixes({
-      mathOperators: MATH_OPERATORS.concat(['pi', 'bna']),
-      greekLetters: GREEK_LETTERS.concat([
+      mathOperators: [...MATH_OPERATORS, 'pi', 'bna'],
+      greekLetters: [...GREEK_LETTERS, 
         'partial',
         'Delta',
         'Gamma',
         'Lambda',
         'Sigma',
         'Omega',
-      ]),
+      ],
       delimiters: 'left right left( right( left[ right['.split(' '),
       mathCommands: 'frac sum_ prod_ int_ oint_ nabla'.split(' '),
       integrals: 'int iint iiint oint ooint ooooint'.split(' '),
@@ -87,7 +87,7 @@ export const EQUATION_REPLACEMENTS: ReplacementCategory = {
     // \a_ -> a_
     // \a^ -> a^
     // \x^ -> x^ [this should not be included]
-    const letters = 'abcdefghijklmnopqrstuvwyz'.split('');
+    const letters = [...'abcdefghijklmnopqrstuvwyz'];
     letters.forEach((letter) => {
       patterns[`\\${letter}_`] = `${letter}_`;
       patterns[`\\${letter}^`] = `${letter}^`;

--- a/src/replacement/rules/equations.ts
+++ b/src/replacement/rules/equations.ts
@@ -48,7 +48,8 @@ export const EQUATION_REPLACEMENTS: ReplacementCategory = {
     // Use the new grouped helper to organize the backslash fixes logically
     const groupedBackslashPatterns = generateGroupedBackslashFixes({
       mathOperators: [...MATH_OPERATORS, 'pi', 'bna'],
-      greekLetters: [...GREEK_LETTERS, 
+      greekLetters: [
+        ...GREEK_LETTERS,
         'partial',
         'Delta',
         'Gamma',

--- a/src/replacement/rules/fontCommands.ts
+++ b/src/replacement/rules/fontCommands.ts
@@ -8,7 +8,7 @@ export const FONT_COMMAND_REPLACEMENTS: ReplacementCategory = {
   patterns: (() => {
     const patterns: { [key: string]: string } = {};
     const letters =
-      'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz'.split('');
+      [...'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz'];
     letters.forEach((letter) => {
       patterns[`{\\rm ${letter}}`] = `\\mathrm{${letter}}`;
       patterns[`{\\bf ${letter}}`] = `\\mathbf{${letter}}`;
@@ -17,7 +17,7 @@ export const FONT_COMMAND_REPLACEMENTS: ReplacementCategory = {
       patterns[`{\\tt ${letter}}`] = `\\mathtt{${letter}}`;
     });
 
-    const uppercase = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('');
+    const uppercase = [...'ABCDEFGHIJKLMNOPQRSTUVWXYZ'];
     uppercase.forEach((letter) => {
       patterns[`{\\cal ${letter}}`] = `\\mathcal{${letter}}`;
     });

--- a/src/replacement/rules/fontCommands.ts
+++ b/src/replacement/rules/fontCommands.ts
@@ -7,8 +7,7 @@ export const FONT_COMMAND_REPLACEMENTS: ReplacementCategory = {
   isRegex: false,
   patterns: (() => {
     const patterns: { [key: string]: string } = {};
-    const letters =
-      [...'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz'];
+    const letters = [...'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz'];
     letters.forEach((letter) => {
       patterns[`{\\rm ${letter}}`] = `\\mathrm{${letter}}`;
       patterns[`{\\bf ${letter}}`] = `\\mathbf{${letter}}`;

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -591,7 +591,7 @@ function finalizeApprovalResult(
   request: ToolEditApprovalRequest,
 ): ToolEditApprovalResult {
   if (!result.accepted) {
-    return { ...result };
+    return result;
   }
 
   const appliedContent = result.appliedContent ?? request.proposedContent;

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -15,6 +15,7 @@ import * as difflib from 'difflib';
 import type { StreamTabId } from '@agent/types/IdentifierTypes';
 
 // Local imports - utils
+import { getCurrentToolFileInteractionContext } from '@agent/toolUse/ToolFileInteractionContext';
 import { safeExecuteCommand } from '@frontend/system/commandUtils';
 import { type ToolResult, type LineChanges } from '@tools/result';
 import { WorkspaceFS } from '@utils/files';
@@ -22,7 +23,6 @@ import { getConfig } from '@utils/config';
 import { bus } from '@eventBus/ProgressEventBus';
 
 // Local file imports
-import { getCurrentToolFileInteractionContext } from '@agent/toolUse/ToolFileInteractionContext';
 
 export interface ToolEditApprovalRequest {
   path: string;

--- a/src/tools/gitignore.ts
+++ b/src/tools/gitignore.ts
@@ -40,14 +40,14 @@ function createGlobMatcher(pattern: string): (value: string) => boolean {
     nocase: false,
   });
 
-  return (value: string) => matcher.match(value.replace(/\\/g, '/'));
+  return (value: string) => matcher.match(value.replaceAll('\\', '/'));
 }
 
 function expandGitignorePattern(
   pattern: string,
   options: { anchored: boolean; dirOnly: boolean },
 ): string[] {
-  const normalized = pattern.replace(/\\/g, '/');
+  const normalized = pattern.replaceAll('\\', '/');
   const basePattern = options.anchored
     ? normalized.replace(/^\/+/, '')
     : normalized.startsWith('**/')
@@ -104,8 +104,8 @@ function parseGitignore(content: string): GitignoreRule[] {
       continue;
     }
 
-    line = line.replace(/\\ /g, ' ');
-    line = line.replace(/\\#/g, '#').replace(/\\!/g, '!');
+    line = line.replaceAll('\\ ', ' ');
+    line = line.replaceAll('\\#', '#').replaceAll('\\!', '!');
 
     const patterns = expandGitignorePattern(line, { anchored, dirOnly });
     for (const pattern of patterns) {

--- a/src/tools/latex/ExtractFiguresTool.ts
+++ b/src/tools/latex/ExtractFiguresTool.ts
@@ -34,7 +34,7 @@ export class ExtractLatexFiguresTool extends defineTool({
     const figurePaths = await extractFigurePathsFromLatex(
       pathToLocation(resolved.absolute),
     );
-    const uniqueFigures = Array.from(new Set(figurePaths));
+    const uniqueFigures = [...new Set(figurePaths)];
 
     if (uniqueFigures.length === 0) {
       const summary = `No figures found in ${display}.`;

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -49,7 +49,7 @@ export function resolveWorkspaceRelativePath(
 
   // Use centralized path segment extraction
   const segments = getPathSegments(normalizedRelative);
-  if (segments.some((segment) => segment === '..')) {
+  if (segments.includes('..')) {
     throw new ToolError('Path must stay within the workspace.');
   }
 
@@ -83,7 +83,7 @@ export function createGlobMatcher(pattern: string): (value: string) => boolean {
     nocase: false,
   });
 
-  return (value: string) => matcher.match(value.replace(/\\/g, '/'));
+  return (value: string) => matcher.match(value.replaceAll('\\', '/'));
 }
 
 // Re-export gitignore utilities from standalone module

--- a/src/utils/core/pathCore.ts
+++ b/src/utils/core/pathCore.ts
@@ -14,7 +14,7 @@ export function toPosixPath(relativePath: string): string {
   }
   return relativePath
     .trim()
-    .replace(/\\/g, '/')
+    .replaceAll('\\', '/')
     .split(PATH_SEPARATORS)
     .filter(Boolean)
     .join('/');

--- a/src/utils/files/fileMappingUtils.ts
+++ b/src/utils/files/fileMappingUtils.ts
@@ -178,9 +178,7 @@ export async function replaceInputCommands(
   }
 
   logger?.debug(
-    `File mappings for input replacement: ${Array.from(
-      baseToOutputMap.entries(),
-    )
+    `File mappings for input replacement: ${[...baseToOutputMap.entries()]
       .map(
         ([basePath, outputLoc]) =>
           `${path.basename(basePath)} -> ${path.basename(outputLoc.kind !== 'external' ? outputLoc.relativePath : outputLoc.absolutePath)}`,
@@ -203,7 +201,7 @@ export async function replaceInputCommands(
 
     try {
       const content = await flexibleFS.read(outputLocation);
-      const newContent = content.replace(
+      const newContent = content.replaceAll(
         /\\input{([^}]+)}/g,
         (match, rawPath) => {
           const normalizedPath = normalizeLatexPath(rawPath);

--- a/src/utils/files/taskRunStorage.ts
+++ b/src/utils/files/taskRunStorage.ts
@@ -442,7 +442,7 @@ export class TaskRunFileService {
     await Promise.all(captureTasks);
 
     if (linkTargets.size > 0) {
-      const candidates = Array.from(linkTargets);
+      const candidates = [...linkTargets];
       await Promise.all(
         candidates.map(async (candidate) => {
           try {

--- a/src/utils/system/platformPaths.ts
+++ b/src/utils/system/platformPaths.ts
@@ -126,7 +126,7 @@ export function getExtraDirs(): string[] {
 
   const homeDir = process.env.HOME || process.env.USERPROFILE;
   if (homeDir) {
-    const normalized = homeDir.replace(/\\/g, '/');
+    const normalized = homeDir.replaceAll('\\', '/');
     texDistPatterns.push(`${normalized}/texlive/*/bin/*`);
     texDistPatterns.push(`${normalized}/TinyTeX/bin/*`);
     for (const tool of TEX_TOOLS) {
@@ -158,7 +158,7 @@ export function getExtraDirs(): string[] {
   }
 
   // Cache and return the unique directories
-  cachedExtraDirs = Array.from(new Set(dirs));
+  cachedExtraDirs = [...new Set(dirs)];
   return cachedExtraDirs;
 }
 

--- a/src/utils/text/xmlCdata.ts
+++ b/src/utils/text/xmlCdata.ts
@@ -26,7 +26,7 @@ const CDATA_PATTERN = /<!\[CDATA\[([\s\S]*?)\]\]>/g;
  * @returns Content with CDATA wrappers removed
  */
 export function removeCDATA(content: string): string {
-  return content.replace(CDATA_PATTERN, '$1');
+  return content.replaceAll(CDATA_PATTERN, '$1');
 }
 
 /**

--- a/src/utils/text/xmlConversion.ts
+++ b/src/utils/text/xmlConversion.ts
@@ -116,43 +116,43 @@ export function convertHtmlToMarkdown(html: string): string {
  */
 function normalizePandocReferences(text: string): string {
   // Handle markdown-link format: [\[label\]](#anchor){reference-type="ref" reference="label"}
-  text = text.replace(
+  text = text.replaceAll(
     /\[\\?\[([^\]]+)\\?\]\]\(#[^)]*\)\{reference-type="ref"\s+reference="([^"]+)"\}/g,
     '\\ref{$2}',
   );
-  text = text.replace(
+  text = text.replaceAll(
     /\[\\?\[([^\]]+)\\?\]\]\(#[^)]*\)\{reference-type="eqref"\s+reference="([^"]+)"\}/g,
     '\\eqref{$2}',
   );
-  text = text.replace(
+  text = text.replaceAll(
     /\[\\?\[([^\]]+)\\?\]\]\(#[^)]*\)\{reference-type="[Cc]ref"\s+reference="([^"]+)"\}/g,
     '\\cref{$2}',
   );
 
   // Handle plain markdown-link format: [label](#anchor){reference-type="ref" reference="label"}
-  text = text.replace(
+  text = text.replaceAll(
     /\[([^\[\]]+)\]\(#[^)]*\)\{reference-type="ref"\s+reference="([^"]+)"\}/g,
     '\\ref{$2}',
   );
-  text = text.replace(
+  text = text.replaceAll(
     /\[([^\[\]]+)\]\(#[^)]*\)\{reference-type="eqref"\s+reference="([^"]+)"\}/g,
     '\\eqref{$2}',
   );
-  text = text.replace(
+  text = text.replaceAll(
     /\[([^\[\]]+)\]\(#[^)]*\)\{reference-type="[Cc]ref"\s+reference="([^"]+)"\}/g,
     '\\cref{$2}',
   );
 
   // Handle simple Pandoc format: [label]{reference-type="ref" reference="label"}
-  text = text.replace(
+  text = text.replaceAll(
     /\[([^\]]+)\]\{reference-type="ref"\s+reference="([^"]+)"\}/g,
     '\\ref{$2}',
   );
-  text = text.replace(
+  text = text.replaceAll(
     /\[([^\]]+)\]\{reference-type="eqref"\s+reference="([^"]+)"\}/g,
     '\\eqref{$2}',
   );
-  text = text.replace(
+  text = text.replaceAll(
     /\[([^\]]+)\]\{reference-type="[Cc]ref"\s+reference="([^"]+)"\}/g,
     '\\cref{$2}',
   );

--- a/src/utils/text/xmlExtraction.ts
+++ b/src/utils/text/xmlExtraction.ts
@@ -58,7 +58,7 @@ export function extractTextFromTag(
 ): string {
   // Find all matches and get the last one using matchAll
   const regex = new RegExp(`<${documentTag}>(.*?)<\/${documentTag}>`, 'gs');
-  const matches = Array.from(inputContent.matchAll(regex));
+  const matches = [...inputContent.matchAll(regex)];
   const lastContent = matches.at(-1)?.[1] ?? '';
 
   // Use centralized CDATA removal

--- a/src/webview/managers/FileManager.ts
+++ b/src/webview/managers/FileManager.ts
@@ -20,8 +20,8 @@ import {
 import { fileLister } from '@frontend/files';
 import { selectFiles } from '@frontend/ui/dialogs';
 import * as logger from '@logger/logUtils';
-import { uncapitalize } from '@utils/text/stringUtils';
 import { WorkspaceFS } from '@utils/files';
+import { uncapitalize } from '@utils/text/stringUtils';
 import { BaseWebviewManager } from './BaseWebviewManager';
 
 // Local imports - types


### PR DESCRIPTION
- Replace .replace(/pattern/g, ...) with .replaceAll() for simple string replacements
- Remove unnecessary object spread in finalizeApprovalResult when returning unchanged result
- Applies ES2023+ best practices per AGENTS.md guidelines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Scope:** Codebase-wide modernization and linting enhancements.
> 
> - **Linting:** Add `eslint-plugin-unicorn` with ES2023 modernization rules (prefer `replaceAll`, `at`, spread, etc.) and integrate into `eslint.config.mjs`.
> - **Refactors:** Replace string/regex `.replace(/.../g, ...)` with `.replaceAll(...)`; switch `Array.from(...)` on Maps/Sets to spread (`[...]`); normalize path handling and timestamps with `replaceAll`; minor import tidy-ups.
> - **Zod updates:** Migrate to v4-friendly patterns (`z.enum(...)`, `.extend(...shape)`, `partialRecord`, `looseObject`) across schemas (logger, reflection, model config, etc.).
> - **Minor behavior nits:** Simplify `finalizeApprovalResult` return; small logging/webview handler adjustments without changing features.
> - **Deps:** Add `eslint-plugin-unicorn`; add `zod-v3-to-v4` (and transitive tooling) in devDependencies.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 05b310cfce83cb3f6ff08d2a252f8c382470aea7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->