### PR TITLE
Initialize usage logging and authentication services

### DIFF
--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -123,8 +123,12 @@ export class ProgressEventHandler {
         this.state.activeStream = stream;
         this.replayPendingTaskGroups(stream);
 
-        // Default to RUNNING for new streams without explicit status
-        const status = StreamStatusService.get(stream) ?? STREAM_STATUS.RUNNING;
+        // Get current status without defaulting to RUNNING.
+        // Status should only be set to RUNNING by setupFlowUIState in executeAgent,
+        // not here. Defaulting to RUNNING here causes a race condition where the
+        // "already running" check in executeAgent fails because this event handler
+        // runs synchronously before the check.
+        const status = StreamStatusService.get(stream);
 
         if (this.webviewUpdater.isAvailable()) {
           this.webviewUpdater.updateAll(
@@ -133,7 +137,10 @@ export class ProgressEventHandler {
           );
         }
 
-        this.setStreamStatus(stream, status);
+        // Only update stream status if explicitly set (not for new streams)
+        if (status !== undefined) {
+          this.setStreamStatus(stream, status);
+        }
 
         if (this.webviewUpdater.isAvailable()) {
           const activeRunId = this.refreshStreamSurface(stream, {
@@ -605,9 +612,10 @@ export class ProgressEventHandler {
       this.webviewUpdater.updateTodos(stream, todos);
     }
 
-    // Update status for current stream - default to RUNNING for new streams without explicit status
-    // (matches old behavior and avoids flash of STOPPED before setupFlowUIState sets RUNNING)
-    const status = StreamStatusService.get(stream) ?? STREAM_STATUS.RUNNING;
+    // Update status for current stream. Don't default to RUNNING - that causes a race
+    // condition where the "already running" check in executeAgent fails. Let setupFlowUIState
+    // be the only place that sets RUNNING. Use READY as fallback for uninitialized streams.
+    const status = StreamStatusService.get(stream) ?? STREAM_STATUS.READY;
     this.webviewUpdater.updateStatus(status);
 
     if (updateInstruction) {


### PR DESCRIPTION
Remove default RUNNING status assignment in event handlers that was causing a race condition. When setActiveStream was emitted from resolveAgentBase, the event handler would immediately set status to RUNNING before the actual "already running" check in executeAgent could run, causing valid task executions to be rejected.

The fix:
- In handleSetActiveStream: Only call setStreamStatus if status is explicitly set (not undefined)
- In refreshStreamSurface: Use READY as fallback instead of RUNNING

Status should only be set to RUNNING by setupFlowUIState in executeAgent, which runs after the duplicate execution check.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents a race where streams were prematurely marked `RUNNING`, causing valid executions to fail the "already running" check.
> 
> - In `handleSetActiveStream`: stop defaulting status to `RUNNING`; only call `setStreamStatus` when `StreamStatusService.get(stream)` returns a value
> - In `refreshStreamSurface`: change fallback to `STREAM_STATUS.READY` instead of `RUNNING` and update webview status accordingly
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fd543671eaccd8967679a69e7b64436641df3ee2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->