### PR TITLE
Initialize usage logging and authentication services

### DIFF
--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -234,10 +234,10 @@ async function resolveAgentBase(
   // 4. Build user variable channels (replaces agent.init() logic)
   // Wrap in "Init" stage so file loading logs are properly grouped
   const initStage = await executionContext.logger.stage('Init');
-  let baseVars: Awaited<ReturnType<typeof buildUserVars>>;
-  try {
-    // Extract just the provider flags needed for prompt variables
-    baseVars = await buildUserVars(
+  // Use initStage.run() to ensure buildUserVars executes within the stage's
+  // group context - this makes file loading logs appear under the Init group
+  const baseVars = await initStage.run(() =>
+    buildUserVars(
       config,
       setting,
       prompt,
@@ -248,12 +248,8 @@ async function resolveAgentBase(
         isGoogle: modelHandler.isGoogle,
       },
       executionContext.logger,
-    );
-    initStage.end('stopped');
-  } catch (err) {
-    initStage.end('error');
-    throw err;
-  }
+    ),
+  );
   const userVarChannels: UserVariableChannels = {
     input: Object.freeze({ ...baseVars }),
     transient: { ...baseVars },


### PR DESCRIPTION
The buildUserVars() call was not running within the Init stage's group context, causing file loading logs ("Loading Input Files", etc.) to have no groupId association. This fix uses initStage.run() to execute within the stage's context, making logs correctly appear under the Init group.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures initialization logs are properly grouped under the `Init` stage.
> 
> - Wraps `buildUserVars` in `initStage.run()` to execute within the stage's group context
> - Removes manual try/catch and `initStage.end()` calls in favor of the stage runner
> - No other functional behavior changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0ee488503af0a6e7d71dae60026e7712472ffe0d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->