### PR TITLE
debug: add logging to trace Init group context propagation

### DIFF
--- a/src/logger/logUtils.ts
+++ b/src/logger/logUtils.ts
@@ -163,6 +163,14 @@ function logWithGroup(
   const entry = getCachedEntryByKey(key) ?? getCachedEntry(channel, isAgent);
   const activeGroupId = resolveActiveGroupByKey(key, options.groupId);
 
+  // DEBUG: trace groupId resolution for file loading messages
+  if (message.includes('Loading') && message.includes('Files')) {
+    const context = contextStorage.getStore()?.get(key);
+    console.log(
+      `[DEBUG logWithGroup] message="${message}" key="${key}" activeGroupId=${activeGroupId} contextStack=${JSON.stringify(context?.stack)}`,
+    );
+  }
+
   entry.logger.log(level, message, {
     groupId: activeGroupId,
     messageType: options.messageType,
@@ -183,6 +191,13 @@ export function startGroup(
 ): string {
   const transport = getOrCreateTransport(channel, isAgent);
   const groupId = id ?? randomUUID();
+  // DEBUG: trace Init group creation
+  if (groupName === 'Init') {
+    const key = getChannelKey(channel, isAgent);
+    console.log(
+      `[DEBUG startGroup] groupName="${groupName}" groupId=${groupId} key="${key}" channel="${channel}" isAgent=${isAgent}`,
+    );
+  }
   pushGroupContext(channel, groupId, isAgent);
   return transport.startGroup(groupName, groupId, parentGroupId);
 }
@@ -211,7 +226,17 @@ export async function runWithGroupContext<T>(
   isAgent: boolean,
   fn: () => Promise<T> | T,
 ): Promise<T> {
+  // DEBUG: trace runWithGroupContext calls
+  const key = getChannelKey(channel, isAgent);
+  const contextBefore = contextStorage.getStore()?.get(key);
+  console.log(
+    `[DEBUG runWithGroupContext] ENTER groupId=${groupId} key="${key}" stackBefore=${JSON.stringify(contextBefore?.stack)}`,
+  );
   pushGroupContext(channel, groupId, isAgent);
+  const contextAfter = contextStorage.getStore()?.get(key);
+  console.log(
+    `[DEBUG runWithGroupContext] AFTER PUSH stackAfter=${JSON.stringify(contextAfter?.stack)}`,
+  );
   try {
     return await fn();
   } finally {


### PR DESCRIPTION
Temporary debug logging to investigate why file loading logs don't appear under the Init group in progress view. Logs trace:
- Init group creation with groupId
- runWithGroupContext stack state before/after push
- logWithGroup activeGroupId resolution for file loading messages

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds temporary tracing to help inspect group context propagation in `src/logger/logUtils.ts`.
> 
> - Logs groupId resolution and context stack in `logWithGroup` when messages contain `Loading` and `Files`
> - Logs `Init` group creation details (groupId, key, channel, isAgent) in `startGroup`
> - Logs stack state before and after `pushGroupContext` in `runWithGroupContext`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2c8c3d6147c3d1f7f07d621adb5501173c598bba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->