### PR TITLE
Fix dropdown menu auto-loading regression

### DIFF
--- a/src/webview/modules/uiManagers/FileSelect.js
+++ b/src/webview/modules/uiManagers/FileSelect.js
@@ -66,8 +66,11 @@ export class FileSelect {
         this.addOption(selectDiv, f, f, f === restoredValue),
       );
 
-      // Only update state if we successfully restored a value.
+      // Explicitly set .value for synchronous access by callers.
+      // Setting selected=true on options works for slotchange (async), but callers
+      // reading selectDiv.value immediately after update() need the value set now.
       if (restoredValue) {
+        selectDiv.value = restoredValue;
         mainViewState.update({ [id]: restoredValue });
       }
     } finally {


### PR DESCRIPTION
When FileSelect.update() rebuilds dropdown options, vscode-single-select's slotchange event fires asynchronously. Callers reading selectDiv.value immediately after update() would get stale values.

This caused handleSetBaseFile to call updateEdited with an empty value when the base file wasn't selected yet (due to async timing), resulting in the edited files dropdown showing only "None" instead of matching files.

Fix by explicitly setting selectDiv.value = restoredValue after adding options, ensuring synchronous access works correctly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures file dropdowns reflect the restored selection immediately after options are rebuilt.
> 
> - In `FileSelect.update()`, after adding options (and marking the restored one as `selected`), explicitly sets `selectDiv.value = restoredValue` so callers can read the correct value synchronously, avoiding async `slotchange` timing issues
> - Minor comment adjustments clarifying synchronous vs. asynchronous selection behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9a81005ac69008cd3257a2038fee661ec67d1ab9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->