### PR TITLE
fix: reduce whitespace in generated files section with collapsible ro…

### DIFF
--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -327,9 +327,9 @@
             </div>
           </template>
           <template id="roundHeaderTemplate">
-            <details class="round-group" open>
-              <summary class="round-header"></summary>
-            </details>
+            <vscode-collapsible class="round-collapsible" open>
+              <div class="round-content"></div>
+            </vscode-collapsible>
           </template>
           <template id="logLineTemplate">
             <div class="log-line">

--- a/src/progressView/modules/uiManagers/FileList.js
+++ b/src/progressView/modules/uiManagers/FileList.js
@@ -66,13 +66,13 @@ export class FileList {
         // Workflow mode: create collapsible round group for each round
         const roundGroup = createFromTemplate('roundHeaderTemplate');
         if (!roundGroup) return;
-        const roundHeader = roundGroup.querySelector('.round-header');
-        if (roundHeader) {
-          roundHeader.textContent = `r${round}`;
-        }
+        // roundGroup is the vscode-collapsible root element
+        roundGroup.setAttribute('title', `r${round}`);
+        const roundContent = roundGroup.querySelector('.round-content');
+        if (!roundContent) return;
 
         files.forEach((file) => {
-          this._renderFileItem(template, roundGroup, file, round);
+          this._renderFileItem(template, roundContent, file, round);
         });
 
         container.appendChild(roundGroup);

--- a/src/progressView/styles/logs.css
+++ b/src/progressView/styles/logs.css
@@ -339,45 +339,22 @@
   margin-left: var(--spacing-tiny);
 }
 
-/* Round group - collapsible details for workflow mode */
-.round-group {
-  margin: 0;
+/* Round collapsible - vscode-collapsible for workflow mode */
+.round-collapsible {
   border-top: 1px solid var(--color-border);
 }
 
-.round-group:first-child {
+.round-collapsible:first-child {
   border-top: none;
 }
 
-.round-header {
-  font-weight: 600;
-  font-size: var(--font-size-sm);
+.round-collapsible::part(header) {
   padding: var(--spacing-tiny) 0;
-  cursor: pointer;
-  list-style: none;
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-tiny);
-  color: var(--color-text-secondary);
+  font-size: var(--font-size-sm);
 }
 
-.round-header::-webkit-details-marker {
-  display: none;
-}
-
-.round-header::before {
-  content: '';
-  display: inline-block;
-  width: 0;
-  height: 0;
-  border-left: 4px solid currentColor;
-  border-top: 3px solid transparent;
-  border-bottom: 3px solid transparent;
-  transition: transform 0.15s ease;
-}
-
-.round-group[open] > .round-header::before {
-  transform: rotate(90deg);
+.round-collapsible::part(body) {
+  padding: 0;
 }
 
 .added {


### PR DESCRIPTION
…unds

- Make round headers (r0, r1) collapsible using vscode-collapsible component
- Add horizontal separator lines between rounds using border-top
- Reduce padding and margins throughout the files section
- Remove gap between files collapsible and usage footer panel

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Moves round headers to `vscode-collapsible` and streamlines spacing in the files list.
> 
> - Replace `details.round-group`/`.round-header` with `vscode-collapsible.round-collapsible` in `index.html`; render files into `.round-content` and set header via `title` (e.g., `r1`)
> - Update `FileList.update` to target `.round-content` when grouping by round; preserve flat mode; continue toggling container visibility
> - Adjust CSS to style `round-collapsible` via `::part(header/body)`, add round separators with `border-top`, and reduce padding/margins for denser layout
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a6e6679051be09abc4ae5895f5119b2ec9f71344. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->