### PR TITLE
fix: set dropdown value synchronously for immediate access by callers

### DIFF
--- a/src/webview/modules/uiManagers/FileSelect.js
+++ b/src/webview/modules/uiManagers/FileSelect.js
@@ -66,8 +66,11 @@ export class FileSelect {
         this.addOption(selectDiv, f, f, f === restoredValue),
       );
 
-      // Only update state if we successfully restored a value.
+      // Explicitly set .value for synchronous access by callers.
+      // Setting selected=true on options works for slotchange (async), but callers
+      // reading selectDiv.value immediately after update() need the value set now.
       if (restoredValue) {
+        selectDiv.value = restoredValue;
         mainViewState.update({ [id]: restoredValue });
       }
     } finally {
@@ -96,9 +99,8 @@ export class FileSelect {
    * @param {string} value - The option value
    * @param {string} text - The option display text
    * @param {boolean} [selected=false] - Whether this option should be selected.
-   *   Setting this is critical for vscode-single-select because its
-   *   _setStateFromSlottedElements reads this property during slot change
-   *   and defaults to index 0 if none found.
+   *   Must set both attribute AND property for vscode-single-select to pick it up
+   *   during slotchange (_setStateFromSlottedElements reads the selected attribute).
    */
   addOption(select, value, text, selected = false) {
     if (!select) {
@@ -108,6 +110,8 @@ export class FileSelect {
     option.value = value;
     option.textContent = text;
     if (selected) {
+      // Set both attribute and property for vscode-single-select compatibility
+      option.setAttribute('selected', '');
       option.selected = true;
     }
     select.appendChild(option);


### PR DESCRIPTION
When FileSelect.update() rebuilds dropdown options, vscode-single-select's slotchange event fires asynchronously. Callers reading selectDiv.value immediately after update() would get stale values.

This caused handleSetBaseFile to call updateEdited with an empty value when the base file wasn't selected yet (due to async timing), resulting in the edited files dropdown showing only "None" instead of matching files.

Two fixes applied:
1. Explicitly set selectDiv.value = restoredValue after adding options
2. In addOption(), set both 'selected' attribute AND property for vscode-single-select compatibility (matching the pattern used in messageHandlers.js for agent/model dropdowns)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Addresses async selection issues in the file and commit dropdowns for vscode-single-select.
> 
> - In `FileSelect.update()`, explicitly sets `selectDiv.value = restoredValue` after rebuilding options to allow immediate synchronous reads and updates `mainViewState`
> - In `addOption()`, sets both the `selected` attribute and `selected` property on `vscode-option` to ensure selection is recognized during `slotchange`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 38248f7437005da6da27c4a5dcc603d087f72963. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->