### PR TITLE
debug: add console.log to trace dropdown file population

### DIFF
--- a/src/webview/managers/FileManager.ts
+++ b/src/webview/managers/FileManager.ts
@@ -140,6 +140,12 @@ export class FileManager extends BaseWebviewManager {
         path.extname(message.baseFile),
       );
       allEditedFiles = await fileLister.listEditedFiles(baseFileNameForEdited);
+      logger.debug(
+        CHANNEL,
+        `handleRequestEditedFile: baseFile=${message.baseFile}, baseName=${baseFileNameForEdited}, foundFiles=${allEditedFiles.length}: ${allEditedFiles.join(', ')}`,
+      );
+    } else {
+      logger.debug(CHANNEL, `handleRequestEditedFile: baseFile is empty`);
     }
     this.postFileUpdate('Edited', allEditedFiles, {
       notifyWhenEmpty: !!message.notifyWhenEmpty,

--- a/src/webview/modules/handlers/fileHandlers.js
+++ b/src/webview/modules/handlers/fileHandlers.js
@@ -40,6 +40,7 @@ export function createFileHandlers(ctx) {
   // 2. Calling restore() after would be redundant and could cause issues
   //    if the state was modified during the async file list refresh
   const createSetFileHandler = (fileType, domId) => (message) => {
+    console.log(`[createSetFileHandler] fileType=${fileType}, domId=${domId}, files=${message.files?.length}:`, message.files);
     const options = getRestorationOptions(domId);
     fileSelect.update(domId, message.files, options);
   };
@@ -150,13 +151,16 @@ export function createFileHandlers(ctx) {
     const currentBaseFileDiv = getElement(BASE_FILE);
     if (currentBaseFileDiv) {
       const options = getRestorationOptions(BASE_FILE);
+      console.log(`[handleSetBaseFile] files=${message.files?.length}, preserveBaseFile=${message.preserveBaseFile}, options=`, options);
       // Only restore currentValue if preserveBaseFile flag is set
       if (!message.preserveBaseFile) {
         options.currentValue = undefined;
       }
       fileSelect.update(BASE_FILE, message.files, options);
       // Read value after update to get the actual restored value
-      fileSelect.updateEdited(currentBaseFileDiv.value);
+      const baseValue = currentBaseFileDiv.value;
+      console.log(`[handleSetBaseFile] after update, baseValue=${baseValue}`);
+      fileSelect.updateEdited(baseValue);
     }
     // No postHandle needed - fileSelect.update handles state
   }

--- a/src/webview/modules/uiManagers/FileSelect.js
+++ b/src/webview/modules/uiManagers/FileSelect.js
@@ -56,6 +56,8 @@ export class FileSelect {
       (currentValue && sortedFiles.includes(currentValue) && currentValue) ||
       null;
 
+    console.log(`[FileSelect.update] id=${id}, files=${sortedFiles.length}, storedValue=${storedValue}, currentValue=${currentValue}, restoredValue=${restoredValue}`);
+
     // Block saves during option updates - vscode-single-select fires change events
     // when innerHTML is cleared, which would trigger save() with temporary "None" state
     mainViewState.blockSave();
@@ -66,11 +68,13 @@ export class FileSelect {
         this.addOption(selectDiv, f, f, f === restoredValue),
       );
 
-      // Explicitly set .value for synchronous access by callers.
+      // Always set .value for synchronous access by callers.
       // Setting selected=true on options works for slotchange (async), but callers
       // reading selectDiv.value immediately after update() need the value set now.
+      // Use restoredValue if available, otherwise default to empty string (None).
+      selectDiv.value = restoredValue ?? '';
+      console.log(`[FileSelect.update] after setting value: selectDiv.value=${selectDiv.value}`);
       if (restoredValue) {
-        selectDiv.value = restoredValue;
         mainViewState.update({ [id]: restoredValue });
       }
     } finally {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Improves traceability of file dropdown population and fixes selection restoration behavior.
> 
> - In `FileSelect.update()`, always set `selectDiv.value` (defaulting to empty) for immediate, synchronous reads; add before/after debug logs
> - In `handleSetBaseFile`, log inputs, conditionally preserve current selection, then read the updated base value and call `fileSelect.updateEdited(baseValue)`
> - Add debug logs to `FileManager.handleRequestEditedFile` and `createSetFileHandler` to trace base/edited files and list sizes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4f8c0bd80e76dd237ddee5aeca7bd1419e0d0d8b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->