### PR TITLE
fix: return restored value from update() instead of reading from DOM

### DIFF
--- a/src/webview/modules/handlers/fileHandlers.js
+++ b/src/webview/modules/handlers/fileHandlers.js
@@ -156,11 +156,11 @@ export function createFileHandlers(ctx) {
       if (!message.preserveBaseFile) {
         options.currentValue = undefined;
       }
-      fileSelect.update(BASE_FILE, message.files, options);
-      // Read value after update to get the actual restored value
-      const baseValue = currentBaseFileDiv.value;
-      console.log(`[handleSetBaseFile] after update, baseValue=${baseValue}`);
-      fileSelect.updateEdited(baseValue);
+      // Use returned value instead of reading from DOM
+      // (vscode-single-select doesn't reflect .value changes immediately)
+      const restoredValue = fileSelect.update(BASE_FILE, message.files, options);
+      console.log(`[handleSetBaseFile] after update, restoredValue=${restoredValue}`);
+      fileSelect.updateEdited(restoredValue || '');
     }
     // No postHandle needed - fileSelect.update handles state
   }

--- a/src/webview/modules/uiManagers/FileSelect.js
+++ b/src/webview/modules/uiManagers/FileSelect.js
@@ -35,12 +35,13 @@ export class FileSelect {
    * @param {Object} [options] - Restoration options
    * @param {string} [options.storedValue] - Value from saved state (highest priority)
    * @param {string} [options.currentValue] - Current UI value (fallback priority)
+   * @returns {string|null} The restored value, or null if no restoration was possible
    */
   update(id, files, options = {}) {
     const selectDiv = document.getElementById(id);
     if (!selectDiv) {
       console.warn(`[FileSelect] Element with id '${id}' not found`);
-      return;
+      return null;
     }
 
     const normalizedFiles = Array.isArray(files) ? files : [];
@@ -73,13 +74,16 @@ export class FileSelect {
       // reading selectDiv.value immediately after update() need the value set now.
       // Use restoredValue if available, otherwise default to empty string (None).
       selectDiv.value = restoredValue ?? '';
-      console.log(`[FileSelect.update] after setting value: selectDiv.value=${selectDiv.value}`);
       if (restoredValue) {
         mainViewState.update({ [id]: restoredValue });
       }
     } finally {
       mainViewState.unblockSave();
     }
+
+    // Return the restored value so callers don't need to read from DOM
+    // (vscode-single-select doesn't reflect .value changes immediately)
+    return restoredValue;
   }
 
   updateEdited(baseFile) {


### PR DESCRIPTION
vscode-single-select doesn't reflect .value changes immediately after setting. Reading currentBaseFileDiv.value right after update() returned an empty string, causing updateEdited('') to clear the edited dropdown.

Fix by having update() return the restored value directly, so callers don't need to read from the DOM.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures reliable selection restoration without relying on immediate DOM reflection from `vscode-single-select`.
> 
> - `FileSelect.update(id, files, options)` now returns the restored value (or `null`), and returns `null` if the element isn’t found; callers no longer need to read `selectDiv.value` immediately
> - `handleSetBaseFile` uses the returned value from `fileSelect.update` to call `fileSelect.updateEdited`, preventing the edited dropdown from being cleared; logs updated
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6cdc1d98b126f2c58476c04b8bf6f31f6830c8eb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->