### PR TITLE
Set up context loading and message prefilling

### DIFF
--- a/src/progressView/modules/uiManagers/Status.js
+++ b/src/progressView/modules/uiManagers/Status.js
@@ -54,7 +54,10 @@ export class Status {
         label: 'Ready',
         enable: [
           ELEMENT_IDS.RUN_NEW_BTN,
+          ELEMENT_IDS.PACK_STREAM_BTN,
+          ELEMENT_IDS.CLEAN_STREAM_BTN,
           ELEMENT_IDS.RESTORE_STATE_BTN,
+          ELEMENT_IDS.DIFF_STREAM_BTN,
           ELEMENT_IDS.OPEN_TASK_STORAGE_BTN,
         ],
       },


### PR DESCRIPTION
The READY status represents a completed execution but previously only enabled run-new, restore, and storage buttons. This was inconsistent with STOPPED status which enabled pack/clean/diff.

StreamTabs already treated READY as STOPPED for display purposes, but Status.js didn't enable the same buttons, causing pack/clean commands to be unavailable after viewing a completed run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns READY status with STOPPED by enabling post-run actions in the toolbar.
> 
> - In `Status.js`, READY now enables `PACK_STREAM_BTN`, `CLEAN_STREAM_BTN`, and `DIFF_STREAM_BTN` in addition to existing buttons, making pack/clean/diff available after a run completes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f5483f6558ea31202ef0f8079d69bb25a4f067eb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->