### PR TITLE
chore: remove debug logging and update ignored keywords defaults

### DIFF
--- a/package.json
+++ b/package.json
@@ -560,7 +560,6 @@
             "default": [
               "Makefile",
               "template",
-              "_log",
               "_thinking",
               "_diff",
               "draw",

--- a/src/webview/managers/FileManager.ts
+++ b/src/webview/managers/FileManager.ts
@@ -140,12 +140,6 @@ export class FileManager extends BaseWebviewManager {
         path.extname(message.baseFile),
       );
       allEditedFiles = await fileLister.listEditedFiles(baseFileNameForEdited);
-      logger.debug(
-        CHANNEL,
-        `handleRequestEditedFile: baseFile=${message.baseFile}, baseName=${baseFileNameForEdited}, foundFiles=${allEditedFiles.length}: ${allEditedFiles.join(', ')}`,
-      );
-    } else {
-      logger.debug(CHANNEL, `handleRequestEditedFile: baseFile is empty`);
     }
     this.postFileUpdate('Edited', allEditedFiles, {
       notifyWhenEmpty: !!message.notifyWhenEmpty,

--- a/src/webview/modules/handlers/fileHandlers.js
+++ b/src/webview/modules/handlers/fileHandlers.js
@@ -40,7 +40,6 @@ export function createFileHandlers(ctx) {
   // 2. Calling restore() after would be redundant and could cause issues
   //    if the state was modified during the async file list refresh
   const createSetFileHandler = (fileType, domId) => (message) => {
-    console.log(`[createSetFileHandler] fileType=${fileType}, domId=${domId}, files=${message.files?.length}:`, message.files);
     const options = getRestorationOptions(domId);
     fileSelect.update(domId, message.files, options);
   };
@@ -151,7 +150,6 @@ export function createFileHandlers(ctx) {
     const currentBaseFileDiv = getElement(BASE_FILE);
     if (currentBaseFileDiv) {
       const options = getRestorationOptions(BASE_FILE);
-      console.log(`[handleSetBaseFile] files=${message.files?.length}, preserveBaseFile=${message.preserveBaseFile}, options=`, options);
       // Only restore currentValue if preserveBaseFile flag is set
       if (!message.preserveBaseFile) {
         options.currentValue = undefined;
@@ -159,7 +157,6 @@ export function createFileHandlers(ctx) {
       // Use returned value instead of reading from DOM
       // (vscode-single-select doesn't reflect .value changes immediately)
       const restoredValue = fileSelect.update(BASE_FILE, message.files, options);
-      console.log(`[handleSetBaseFile] after update, restoredValue=${restoredValue}`);
       fileSelect.updateEdited(restoredValue || '');
     }
     // No postHandle needed - fileSelect.update handles state

--- a/src/webview/modules/uiManagers/FileSelect.js
+++ b/src/webview/modules/uiManagers/FileSelect.js
@@ -57,8 +57,6 @@ export class FileSelect {
       (currentValue && sortedFiles.includes(currentValue) && currentValue) ||
       null;
 
-    console.log(`[FileSelect.update] id=${id}, files=${sortedFiles.length}, storedValue=${storedValue}, currentValue=${currentValue}, restoredValue=${restoredValue}`);
-
     // Block saves during option updates - vscode-single-select fires change events
     // when innerHTML is cleared, which would trigger save() with temporary "None" state
     mainViewState.blockSave();


### PR DESCRIPTION
- Remove console.log statements added for dropdown debugging
- Remove logger.debug statements from FileManager.handleRequestEditedFile
- Remove '_log' from default ignored keywords as it incorrectly matched files containing '_logic' (e.g., main_logic_r0_gemini3p.tex)

The underlying dropdown fix (returning restoredValue from FileSelect.update instead of reading from DOM) remains in place from the previous commit.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes temporary debugging noise and tightens file-selection defaults.
> 
> - Delete `logger.debug`/`console.log` statements from `FileManager.ts`, `fileHandlers.js`, and `FileSelect.js`
> - Update `package.json` config: remove `_log` from `texra.files.ignored.keywords` defaults (it unintentionally matched `_logic`-like filenames)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ca86935eae014f72bfc764d4eaeea4d8725e11e9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->