### PR TITLE
Fix todos not recovering after reload

### DIFF
--- a/src/agent/implementations/flows/ToolUseRunFlow.ts
+++ b/src/agent/implementations/flows/ToolUseRunFlow.ts
@@ -314,6 +314,15 @@ class ToolUseCycleNode<C> extends Node<
     super(NODE_NO_RETRY, NODE_NO_WAIT);
   }
 
+  /** Emit todos update event to progress view. */
+  private emitTodosUpdate(todos: TodoItem[]): void {
+    bus.emit('updateTodos', {
+      stream: this.services.streamId,
+      executionId: this.services.executionId,
+      todos,
+    });
+  }
+
   async prep(shared: ToolUseRunShared): Promise<CycleNodePrepResult> {
     // Validate invariant: PrepareNode must have run before us
     assertPreparedState(shared.state);
@@ -340,11 +349,7 @@ class ToolUseCycleNode<C> extends Node<
       // Emit recovered todos to restore progress view UI after reload
       const recoveredTodos = prepRes.workspaceState.todos.todos;
       if (recoveredTodos.length > 0) {
-        bus.emit('updateTodos', {
-          stream: this.services.streamId,
-          executionId: this.services.executionId,
-          todos: recoveredTodos,
-        });
+        this.emitTodosUpdate(recoveredTodos);
       }
       return { kind: 'skipped' };
     }
@@ -386,11 +391,7 @@ class ToolUseCycleNode<C> extends Node<
 
     // Set up todo update callback to emit changes to the progress view
     prepRes.workspaceState.todos.setOnUpdate((todos: TodoItem[]) => {
-      bus.emit('updateTodos', {
-        stream: this.services.streamId,
-        executionId: this.services.executionId,
-        todos,
-      });
+      this.emitTodosUpdate(todos);
     });
 
     try {

--- a/src/agent/implementations/flows/ToolUseRunFlow.ts
+++ b/src/agent/implementations/flows/ToolUseRunFlow.ts
@@ -335,8 +335,17 @@ class ToolUseCycleNode<C> extends Node<
   }
 
   async exec(prepRes: CycleNodePrepResult): Promise<CycleExecResult> {
-    // Handle skip (resume case) - pure decision, no side effects
+    // Handle skip (resume case) - emit recovered todos before skipping
     if (prepRes.shouldSkip) {
+      // Emit recovered todos to restore progress view UI after reload
+      const recoveredTodos = prepRes.workspaceState.todos.todos;
+      if (recoveredTodos.length > 0) {
+        bus.emit('updateTodos', {
+          stream: this.services.streamId,
+          executionId: this.services.executionId,
+          todos: recoveredTodos,
+        });
+      }
       return { kind: 'skipped' };
     }
 


### PR DESCRIPTION
When a tool-use session is in WAITING state and the extension reloads, todos were lost because:
1. Todos exist in the persisted workspace snapshot
2. On resume, shouldSkipCycle is true so the cycle is skipped
3. The todo callback was only set up during cycle execution
4. No updateTodos event was ever emitted to restore the UI

Now emit recovered todos when skipping the cycle, ensuring the progress view displays persisted todos after reloading.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes lost todos after extension reload by ensuring the progress view is updated even when a tool-use cycle is skipped.
> 
> - When `shouldSkip` in `ToolUseCycleNode.exec`, emit recovered `todos` from `workspaceState` before returning `skipped`
> - Refactors todo event emission into a private `emitTodosUpdate` helper and reuses it for the `todos.setOnUpdate` callback
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 45ba62597a2f2f517c5d9c88662d624bc69f9269. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->