### PR TITLE
Fix statistics latexdiff placement in r0 group

### DIFF
--- a/src/logger/AgentLogger.ts
+++ b/src/logger/AgentLogger.ts
@@ -176,10 +176,11 @@ export class AgentLogger {
 
   /**
    * Log a debug message with options object.
+   * Falls back to current group ID from AsyncLocalStorage if not specified.
    */
   debug(message: string, options: LogOptions = {}): void {
     logger.debug(this.channelId, message, {
-      groupId: options.groupId,
+      groupId: options.groupId ?? this.resolveActiveGroupId(),
       messageType: options.messageType,
       isAgent: this.isAgentLogger,
       data: options.data,
@@ -188,10 +189,11 @@ export class AgentLogger {
 
   /**
    * Log an info message with options object.
+   * Falls back to current group ID from AsyncLocalStorage if not specified.
    */
   info(message: string, options: LogOptions = {}): void {
     logger.info(this.channelId, message, {
-      groupId: options.groupId,
+      groupId: options.groupId ?? this.resolveActiveGroupId(),
       messageType: options.messageType,
       isAgent: this.isAgentLogger,
       data: options.data,
@@ -200,10 +202,11 @@ export class AgentLogger {
 
   /**
    * Log a warning message with options object.
+   * Falls back to current group ID from AsyncLocalStorage if not specified.
    */
   warn(message: string, options: LogOptions = {}): void {
     logger.warn(this.channelId, message, {
-      groupId: options.groupId,
+      groupId: options.groupId ?? this.resolveActiveGroupId(),
       messageType: options.messageType,
       isAgent: this.isAgentLogger,
       data: options.data,
@@ -212,10 +215,11 @@ export class AgentLogger {
 
   /**
    * Log an error message with options object.
+   * Falls back to current group ID from AsyncLocalStorage if not specified.
    */
   error(message: string, options: LogOptions = {}): void {
     logger.error(this.channelId, message, {
-      groupId: options.groupId,
+      groupId: options.groupId ?? this.resolveActiveGroupId(),
       messageType: options.messageType,
       isAgent: this.isAgentLogger,
       data: options.data,


### PR DESCRIPTION
…1 group

These logging methods now fall back to getCurrentGroupId() when no explicit groupId is provided. This ensures logs are correctly associated with their round group (r0, r1, etc.) in the progress view instead of appearing outside all groups.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures log messages auto-associate with the active progress group when no `groupId` is provided.
> 
> - `AgentLogger` methods `debug`, `info`, `warn`, and `error` now default `groupId` to `resolveActiveGroupId()` (AsyncLocalStorage-backed)
> - Docstrings updated to note the fallback behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 107876d7d14516e0ebdfb09b05069cb2d09048b2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->