### PR TITLE
Fix gemini3p model subscription error

### DIFF
--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -265,6 +265,13 @@ export abstract class ModelHandler<
     const serverSideKeyService = getServerSideKeyService();
     const useIncludedAccess = serverSideKeyService.getUseIncludedModelAccess();
 
+    // Prime caches before using sync methods. This ensures that after reload/continue,
+    // the tier config and access status are fetched before shouldUseServerSideKeys() is called.
+    // Without this, sync methods return false due to empty caches, causing incorrect tier errors.
+    if (useIncludedAccess) {
+      await serverSideKeyService.canUseServerSideKeys();
+    }
+
     // Use centralized check to ensure consistency with getBaseUrl()
     if (this.shouldUseServerSideKeys()) {
       const accessToken = await SupabaseClient.getAccessToken();


### PR DESCRIPTION
After reload/continue, the tier config and access status caches were empty, causing shouldUseServerSideKeysSync() to return false. This led to an incorrect "model not available for tier" error even for valid models because useIncludedAccess was true but caches weren't primed.

Now we call canUseServerSideKeys() to prime caches before using sync methods when included access mode is enabled.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures server-side key access state is loaded before sync checks to avoid false "model not available for tier" errors.
> 
> - In `ModelHandler.getApiKey()`, when `useIncludedAccess` is true, call `serverSideKeyService.canUseServerSideKeys()` to prime caches before `shouldUseServerSideKeys()`
> - Keeps routing decisions consistent with `getBaseUrl()` and maintains no-fallback behavior when Included Access is enabled
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ba914e9a2ab664b9fe194c0ad699651a12126de3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->