### PR TITLE
Initialize usage logging and authentication services

### DIFF
--- a/src/agent/implementations/flows/reflection/runReflectionFlow.ts
+++ b/src/agent/implementations/flows/reflection/runReflectionFlow.ts
@@ -232,8 +232,9 @@ export async function runReflectionFlow<C = unknown>(
   createdRunStage = !parentStage;
 
   // For new runs, update storage key to match the run stage ID
-  if (createdRunStage && runStage.id && hasInitialStorageKey()) {
-    const runStorageKey = normalizeRunId(runStage.id);
+  // Note: runStage.id is always defined for newly created stages
+  if (createdRunStage && hasInitialStorageKey()) {
+    const runStorageKey = normalizeRunId(runStage.id!);
     updateStorageKey(runStorageKey);
   }
 

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -462,15 +462,13 @@ async function logFlowError(
   errorMsg: string,
   err: unknown,
   agentName: string,
-  streamId: StreamTabId,
   agentLogger: AgentLogger,
 ): Promise<void> {
+  // Log error directly without creating a new visible group.
+  // The error is already captured in the runStage (ended with ERROR status).
+  // Using skip: true prevents creating a separate "Error:" session entry.
   const errorContext = { operation: `execute ${agentName}` };
-  await agentLogger.withScope(
-    `Error: ${agentName}`,
-    async () => agentLogger.logError(errorMsg, err, errorContext),
-    { errorStatus: 'error' },
-  );
+  await agentLogger.logError(errorMsg, err, errorContext);
 }
 
 async function handleFlowError(
@@ -489,8 +487,8 @@ async function handleFlowError(
     vscode.window.showErrorMessage(errorMsg);
   }
 
-  // Log with proper grouping
-  await logFlowError(errorMsg, err, agentName, streamId, agentLogger);
+  // Log error (without creating a separate session group)
+  await logFlowError(errorMsg, err, agentName, agentLogger);
 
   throw new Error(errorMsg);
 }

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -277,11 +277,9 @@ async function resolveAgentBase(
   }
 
   // 6. Build user variable channels (replaces agent.init() logic)
-  // Init stage is a CHILD of runStage so it appears in the same session.
-  const initStage = await runStage.stage('Init');
-  // Use initStage.run() to ensure buildUserVars executes within the stage's
-  // group context - this makes file loading logs appear under the Init group
-  const baseVars = await initStage.run(() =>
+  // For workflow agents: wrap in Init stage so file loading logs are properly grouped.
+  // For tool-use agents: skip Init stage (no file loading to show).
+  const buildVars = () =>
     buildUserVars(
       config,
       setting,
@@ -293,8 +291,12 @@ async function resolveAgentBase(
         isGoogle: modelHandler.isGoogle,
       },
       agentLogger,
-    ),
-  );
+    );
+
+  const baseVars =
+    setting.agentType === AgentType.ToolUse
+      ? await buildVars()
+      : await (await runStage.stage('Init')).run(buildVars);
   const userVarChannels: UserVariableChannels = {
     input: Object.freeze({ ...baseVars }),
     transient: { ...baseVars },
@@ -590,36 +592,33 @@ export async function executeAgent(
       logger.info(`Executing ${agentName} with model ${config.model}`);
 
       const interruptManager = new InterruptManager();
-      let flowStatus: EndGroupStatus = END_GROUP_STATUS.STOPPED;
+      let flowStatus: EndGroupStatus;
 
-      try {
-        if (setting.agentType === 'toolUse') {
-          // Tool-use flow execution
-          const result = await runToolUseFlow({
-            ...ctx,
-            ...interruptManager.asFlowInput(),
-            getUsageRecorder: createUsageRecorder(ctx.usageMonitor, 'tool-use'),
-            setting: ctx.setting as AgentToolUseSetting,
-          });
-          flowStatus = result.status;
-        } else {
-          // Reflection flow execution (direct/CoT/workflow)
-          // Pass runStage as parentStage so r0, r1 become children of it
-          const result = await runReflectionFlow({
-            ...ctx,
-            ...interruptManager.asFlowInput(),
-            getUsageRecorder: createUsageRecorder(ctx.usageMonitor, 'workflow'),
-            setting: ctx.setting as AgentWorkflowSetting,
-            parentStage: ctx.runStage,
-          });
-          flowStatus = result.status;
-        }
-      } finally {
-        // End the runStage since we created it in resolveAgentBase
-        // (runReflectionFlow won't end it when parentStage is provided)
-        ctx.runStage.end(flowStatus);
+      if (setting.agentType === 'toolUse') {
+        // Tool-use flow execution
+        const result = await runToolUseFlow({
+          ...ctx,
+          ...interruptManager.asFlowInput(),
+          getUsageRecorder: createUsageRecorder(ctx.usageMonitor, 'tool-use'),
+          setting: ctx.setting as AgentToolUseSetting,
+        });
+        flowStatus = result.status;
+      } else {
+        // Reflection flow execution (direct/CoT/workflow)
+        // Pass runStage as parentStage so r0, r1 become children of it
+        const result = await runReflectionFlow({
+          ...ctx,
+          ...interruptManager.asFlowInput(),
+          getUsageRecorder: createUsageRecorder(ctx.usageMonitor, 'workflow'),
+          setting: ctx.setting as AgentWorkflowSetting,
+          parentStage: ctx.runStage,
+        });
+        flowStatus = result.status;
       }
 
+      // End the runStage since we created it in resolveAgentBase
+      // (runReflectionFlow won't end it when parentStage is provided)
+      ctx.runStage.end(flowStatus);
       updateFlowStatus(streamTabId, flowStatus);
       logger.debug(`Task completed with status: ${flowStatus}`);
     });
@@ -676,7 +675,6 @@ export async function executeMergeAgent(
       logger.info(`Executing merge with model ${model}`);
 
       const interruptManager = new InterruptManager();
-      let flowStatus: EndGroupStatus = END_GROUP_STATUS.STOPPED;
 
       // Create merge-specific output file location getter
       const fileService = new TaskRunFileService(executionId);
@@ -686,25 +684,21 @@ export async function executeMergeAgent(
         fileService,
       );
 
-      try {
-        // Run reflection flow with custom file naming
-        // Pass runStage as parentStage so r0, r1 become children of it
-        const result = await runReflectionFlow({
-          ...ctx,
-          ...interruptManager.asFlowInput(),
-          getUsageRecorder: createUsageRecorder(ctx.usageMonitor, 'workflow'),
-          setting: ctx.setting as AgentWorkflowSetting,
-          getOutputFileLocation,
-          parentStage: ctx.runStage,
-        });
-        flowStatus = result.status;
-      } finally {
-        // End the runStage since we created it in resolveAgentBase
-        ctx.runStage.end(flowStatus);
-      }
+      // Run reflection flow with custom file naming
+      // Pass runStage as parentStage so r0, r1 become children of it
+      const result = await runReflectionFlow({
+        ...ctx,
+        ...interruptManager.asFlowInput(),
+        getUsageRecorder: createUsageRecorder(ctx.usageMonitor, 'workflow'),
+        setting: ctx.setting as AgentWorkflowSetting,
+        getOutputFileLocation,
+        parentStage: ctx.runStage,
+      });
 
-      updateFlowStatus(streamTabId, flowStatus);
-      logger.debug(`Task completed with status: ${flowStatus}`);
+      // End the runStage since we created it in resolveAgentBase
+      ctx.runStage.end(result.status);
+      updateFlowStatus(streamTabId, result.status);
+      logger.debug(`Task completed with status: ${result.status}`);
     });
   } catch (err) {
     // End the runStage with error status on exception
@@ -758,30 +752,25 @@ export async function resumeToolUseFromSnapshot(
   }
 
   const interruptManager = new InterruptManager();
-  let flowStatus: EndGroupStatus = END_GROUP_STATUS.STOPPED;
 
   try {
     setupFlowUIState(ctx);
 
-    try {
-      // Run the flow with resume snapshot
-      const result = await runToolUseFlow(
-        {
-          ...ctx,
-          ...interruptManager.asFlowInput(),
-          getUsageRecorder: createUsageRecorder(ctx.usageMonitor, 'tool-use'),
-          setting: setting as AgentToolUseSetting,
-          resumeSnapshot: snapshot,
-        },
-        setupSession ? (context) => setupSession(context.session) : undefined,
-      );
-      flowStatus = result.status;
-    } finally {
-      // End the runStage since we created it in resolveAgentBase
-      ctx.runStage.end(flowStatus);
-    }
+    // Run the flow with resume snapshot
+    const result = await runToolUseFlow(
+      {
+        ...ctx,
+        ...interruptManager.asFlowInput(),
+        getUsageRecorder: createUsageRecorder(ctx.usageMonitor, 'tool-use'),
+        setting: setting as AgentToolUseSetting,
+        resumeSnapshot: snapshot,
+      },
+      setupSession ? (context) => setupSession(context.session) : undefined,
+    );
 
-    updateFlowStatus(streamTabId, flowStatus);
+    // End the runStage since we created it in resolveAgentBase
+    ctx.runStage.end(result.status);
+    updateFlowStatus(streamTabId, result.status);
   } catch (error) {
     // End the runStage with error status on exception
     ctx.runStage.end(END_GROUP_STATUS.ERROR);

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -64,8 +64,10 @@ import { getSdkErrorMessage } from '@common/errors/sdkErrorUtils';
 import { showInstructionWithSuppress } from '@frontend/ui/instruction';
 import { showErrorMessage } from '@frontend/ui/messageUtils';
 import { getMainWebview } from '@frontend/system/commandUtils';
+import type { AgentLogStage } from '@logger/AgentLogger';
 import { AgentLogger } from '@logger/AgentLogger';
 import { AgentUsageReporter } from '@logger/AgentUsageReporter';
+import { END_GROUP_STATUS, type EndGroupStatus } from '@logger/messageTypes';
 import { MODEL_CONFIGS } from '@model/ModelRegistry';
 import { TaskRunFileService } from '@utils/files';
 import { agentConfigToTaskState } from '@utils/config';
@@ -104,6 +106,8 @@ interface ResolvedAgentBase extends StorageKeyManager {
   executionId: ExecutionId;
   userVarChannels: UserVariableChannels;
   usageMonitor: UsageMonitor;
+  /** Parent stage for flow execution. Init stage is a child of this. */
+  runStage: AgentLogStage;
 }
 
 // ============================================================================
@@ -237,9 +241,9 @@ async function resolveAgentBase(
   modelHandler.setAgentType(setting.agentType);
   modelHandler.setLogger(agentLogger);
 
-  // Emit setActiveStream BEFORE Init stage creation.
+  // Emit setActiveStream BEFORE stage creation.
   // This ensures the frontend has state.activeStream set when addTaskGroup arrives,
-  // preventing the race condition where Init groups are dropped.
+  // preventing the race condition where groups are dropped.
   bus.emit('setActiveStream', {
     stream: streamId,
     session: sessionDescriptor,
@@ -247,9 +251,34 @@ async function resolveAgentBase(
     hasMultipleOutputs: fullConfig.useMultipleOutputs,
   });
 
-  // 4. Build user variable channels (replaces agent.init() logic)
-  // Wrap in "Init" stage so file loading logs are properly grouped
-  const initStage = await agentLogger.stage('Init');
+  // 4. Define mutable storage key with callbacks
+  // Initial value is executionId (normalized); updated to runStage.id after stage creation
+  const initialStorageKey = normalizeRunId(executionId);
+  let storageKey: StorageKey = initialStorageKey;
+  const getStorageKey = () => storageKey;
+  const hasInitialStorageKey = () => storageKey === initialStorageKey;
+  const updateStorageKey = (key: StorageKey) => {
+    if (!hasInitialStorageKey()) {
+      agentLogger.warn(
+        `Storage key already set to ${storageKey}, updating to ${key}. This may indicate a bug.`,
+      );
+    }
+    storageKey = key;
+  };
+
+  // 5. Create Run stage FIRST - this is the single top-level session group.
+  // Both Init and round stages (r0, r1, etc.) will be children of this stage.
+  // This ensures the Sessions dropdown shows only ONE entry per execution.
+  const runStage = await agentLogger.stage(`Run: ${config.agent}`);
+
+  // Update storage key to match the run stage ID (for file storage organization)
+  if (runStage.id && hasInitialStorageKey()) {
+    updateStorageKey(normalizeRunId(runStage.id));
+  }
+
+  // 6. Build user variable channels (replaces agent.init() logic)
+  // Init stage is a CHILD of runStage so it appears in the same session.
+  const initStage = await runStage.stage('Init');
   // Use initStage.run() to ensure buildUserVars executes within the stage's
   // group context - this makes file loading logs appear under the Init group
   const baseVars = await initStage.run(() =>
@@ -271,22 +300,7 @@ async function resolveAgentBase(
     transient: { ...baseVars },
   };
 
-  // 5. Define mutable storage key with callbacks
-  // Initial value is executionId (normalized); workflow agents update it to task group ID
-  const initialStorageKey = normalizeRunId(executionId);
-  let storageKey: StorageKey = initialStorageKey;
-  const getStorageKey = () => storageKey;
-  const hasInitialStorageKey = () => storageKey === initialStorageKey;
-  const updateStorageKey = (key: StorageKey) => {
-    if (!hasInitialStorageKey()) {
-      agentLogger.warn(
-        `Storage key already set to ${storageKey}, updating to ${key}. This may indicate a bug.`,
-      );
-    }
-    storageKey = key;
-  };
-
-  // 6. Create usage monitor for tracking API usage
+  // 7. Create usage monitor for tracking API usage
   // Pass only the minimal model info needed (capabilities + config subset)
   const isMultipleOutput =
     setting.agentCategory === AgentCategory.Workflow
@@ -324,6 +338,7 @@ async function resolveAgentBase(
     updateStorageKey,
     userVarChannels,
     usageMonitor,
+    runStage,
   };
 }
 
@@ -575,32 +590,42 @@ export async function executeAgent(
       logger.info(`Executing ${agentName} with model ${config.model}`);
 
       const interruptManager = new InterruptManager();
-      let flowStatus: 'error' | 'stopped';
+      let flowStatus: EndGroupStatus = END_GROUP_STATUS.STOPPED;
 
-      if (setting.agentType === 'toolUse') {
-        // Tool-use flow execution
-        const result = await runToolUseFlow({
-          ...ctx,
-          ...interruptManager.asFlowInput(),
-          getUsageRecorder: createUsageRecorder(ctx.usageMonitor, 'tool-use'),
-          setting: ctx.setting as AgentToolUseSetting,
-        });
-        flowStatus = result.status;
-      } else {
-        // Reflection flow execution (direct/CoT/workflow)
-        const result = await runReflectionFlow({
-          ...ctx,
-          ...interruptManager.asFlowInput(),
-          getUsageRecorder: createUsageRecorder(ctx.usageMonitor, 'workflow'),
-          setting: ctx.setting as AgentWorkflowSetting,
-        });
-        flowStatus = result.status;
+      try {
+        if (setting.agentType === 'toolUse') {
+          // Tool-use flow execution
+          const result = await runToolUseFlow({
+            ...ctx,
+            ...interruptManager.asFlowInput(),
+            getUsageRecorder: createUsageRecorder(ctx.usageMonitor, 'tool-use'),
+            setting: ctx.setting as AgentToolUseSetting,
+          });
+          flowStatus = result.status;
+        } else {
+          // Reflection flow execution (direct/CoT/workflow)
+          // Pass runStage as parentStage so r0, r1 become children of it
+          const result = await runReflectionFlow({
+            ...ctx,
+            ...interruptManager.asFlowInput(),
+            getUsageRecorder: createUsageRecorder(ctx.usageMonitor, 'workflow'),
+            setting: ctx.setting as AgentWorkflowSetting,
+            parentStage: ctx.runStage,
+          });
+          flowStatus = result.status;
+        }
+      } finally {
+        // End the runStage since we created it in resolveAgentBase
+        // (runReflectionFlow won't end it when parentStage is provided)
+        ctx.runStage.end(flowStatus);
       }
 
       updateFlowStatus(streamTabId, flowStatus);
       logger.debug(`Task completed with status: ${flowStatus}`);
     });
   } catch (err) {
+    // End the runStage with error status on exception
+    ctx.runStage.end(END_GROUP_STATUS.ERROR);
     StreamStatusService.set(streamTabId, STREAM_STATUS.ERROR);
     await handleFlowError(err, agentName, streamTabId, agentLogger);
   }
@@ -651,6 +676,7 @@ export async function executeMergeAgent(
       logger.info(`Executing merge with model ${model}`);
 
       const interruptManager = new InterruptManager();
+      let flowStatus: EndGroupStatus = END_GROUP_STATUS.STOPPED;
 
       // Create merge-specific output file location getter
       const fileService = new TaskRunFileService(executionId);
@@ -660,19 +686,29 @@ export async function executeMergeAgent(
         fileService,
       );
 
-      // Run reflection flow with custom file naming
-      const result = await runReflectionFlow({
-        ...ctx,
-        ...interruptManager.asFlowInput(),
-        getUsageRecorder: createUsageRecorder(ctx.usageMonitor, 'workflow'),
-        setting: ctx.setting as AgentWorkflowSetting,
-        getOutputFileLocation,
-      });
+      try {
+        // Run reflection flow with custom file naming
+        // Pass runStage as parentStage so r0, r1 become children of it
+        const result = await runReflectionFlow({
+          ...ctx,
+          ...interruptManager.asFlowInput(),
+          getUsageRecorder: createUsageRecorder(ctx.usageMonitor, 'workflow'),
+          setting: ctx.setting as AgentWorkflowSetting,
+          getOutputFileLocation,
+          parentStage: ctx.runStage,
+        });
+        flowStatus = result.status;
+      } finally {
+        // End the runStage since we created it in resolveAgentBase
+        ctx.runStage.end(flowStatus);
+      }
 
-      updateFlowStatus(streamTabId, result.status);
-      logger.debug(`Task completed with status: ${result.status}`);
+      updateFlowStatus(streamTabId, flowStatus);
+      logger.debug(`Task completed with status: ${flowStatus}`);
     });
   } catch (err) {
+    // End the runStage with error status on exception
+    ctx.runStage.end(END_GROUP_STATUS.ERROR);
     StreamStatusService.set(streamTabId, STREAM_STATUS.ERROR);
     await handleFlowError(err, 'merge', streamTabId, agentLogger);
   }
@@ -722,24 +758,33 @@ export async function resumeToolUseFromSnapshot(
   }
 
   const interruptManager = new InterruptManager();
+  let flowStatus: EndGroupStatus = END_GROUP_STATUS.STOPPED;
 
   try {
     setupFlowUIState(ctx);
 
-    // Run the flow with resume snapshot
-    const result = await runToolUseFlow(
-      {
-        ...ctx,
-        ...interruptManager.asFlowInput(),
-        getUsageRecorder: createUsageRecorder(ctx.usageMonitor, 'tool-use'),
-        setting: setting as AgentToolUseSetting,
-        resumeSnapshot: snapshot,
-      },
-      setupSession ? (context) => setupSession(context.session) : undefined,
-    );
+    try {
+      // Run the flow with resume snapshot
+      const result = await runToolUseFlow(
+        {
+          ...ctx,
+          ...interruptManager.asFlowInput(),
+          getUsageRecorder: createUsageRecorder(ctx.usageMonitor, 'tool-use'),
+          setting: setting as AgentToolUseSetting,
+          resumeSnapshot: snapshot,
+        },
+        setupSession ? (context) => setupSession(context.session) : undefined,
+      );
+      flowStatus = result.status;
+    } finally {
+      // End the runStage since we created it in resolveAgentBase
+      ctx.runStage.end(flowStatus);
+    }
 
-    updateFlowStatus(streamTabId, result.status);
+    updateFlowStatus(streamTabId, flowStatus);
   } catch (error) {
+    // End the runStage with error status on exception
+    ctx.runStage.end(END_GROUP_STATUS.ERROR);
     StreamStatusService.set(streamTabId, STREAM_STATUS.ERROR);
     await handleFlowError(
       error,

--- a/src/logger/logUtils.ts
+++ b/src/logger/logUtils.ts
@@ -74,8 +74,19 @@ function popGroupContext(
   if (!context?.stack.length) {
     store.delete(key);
   } else {
-    // Remove the specific groupId from stack (supports non-LIFO group endings)
-    const newStack = context.stack.filter((id) => id !== groupId);
+    // Remove only the LAST occurrence of groupId from stack.
+    // This supports:
+    // 1. Non-LIFO group endings (different group IDs can end out of order)
+    // 2. Duplicate pushes of the same groupId (nested runWithGroupContext calls)
+    const lastIndex = context.stack.lastIndexOf(groupId);
+    if (lastIndex === -1) {
+      // groupId not found, nothing to pop
+      return;
+    }
+    const newStack = [
+      ...context.stack.slice(0, lastIndex),
+      ...context.stack.slice(lastIndex + 1),
+    ];
     if (newStack.length === 0) {
       store.delete(key);
     } else {

--- a/src/progressView/modules/uiManagers/RunSelector.js
+++ b/src/progressView/modules/uiManagers/RunSelector.js
@@ -283,10 +283,11 @@ export class RunSelector {
 
   _formatRunLabel(group) {
     const timestamp = this._formatTimestamp(group.startTime);
+    const name = group.name || 'Session';
     if (timestamp) {
-      return timestamp;
+      return `${name}: ${timestamp}`;
     }
-    return 'Session';
+    return name;
   }
 
   _formatTimestamp(value) {

--- a/src/progressView/modules/uiManagers/RunSelector.js
+++ b/src/progressView/modules/uiManagers/RunSelector.js
@@ -283,7 +283,7 @@ export class RunSelector {
 
   _formatRunLabel(group) {
     const timestamp = this._formatTimestamp(group.startTime);
-    const name = group.name || 'Session';
+    const name = group.name ?? 'Session';
     if (timestamp) {
       return `${name}: ${timestamp}`;
     }

--- a/supabase/functions/relay/index.ts
+++ b/supabase/functions/relay/index.ts
@@ -532,8 +532,8 @@ app.all('/:provider{[^/]+}/*', async (c) => {
   // 6. Validate model for non-Ultra tiers
   // Skip model validation for endpoints that don't require a model (e.g., file uploads)
   // - OpenAI: /v1/files
+  // - Anthropic: /v1/files (same as OpenAI)
   // - Google: /upload/*, /v1beta/files
-  // - Anthropic: uses base64 in messages, no separate file API
   const MODEL_FREE_PATHS = ['/v1/files', '/files', '/upload', '/v1beta/files'];
   const isModelFreePath = MODEL_FREE_PATHS.some(
     (prefix) => apiPath === prefix || apiPath.startsWith(prefix + '/'),

--- a/supabase/functions/relay/index.ts
+++ b/supabase/functions/relay/index.ts
@@ -530,10 +530,19 @@ app.all('/:provider{[^/]+}/*', async (c) => {
   }
 
   // 6. Validate model for non-Ultra tiers
+  // Skip model validation for endpoints that don't require a model (e.g., file uploads)
+  // - OpenAI: /v1/files
+  // - Google: /upload/*, /v1beta/files
+  // - Anthropic: uses base64 in messages, no separate file API
+  const MODEL_FREE_PATHS = ['/v1/files', '/files', '/upload', '/v1beta/files'];
+  const isModelFreePath = MODEL_FREE_PATHS.some(
+    (prefix) => apiPath === prefix || apiPath.startsWith(prefix + '/'),
+  );
+
   let requestBody: string | null = null;
   let modelName: string | null = null;
 
-  if (userTier !== ULTRA_TIER && c.req.method !== 'GET') {
+  if (userTier !== ULTRA_TIER && c.req.method !== 'GET' && !isModelFreePath) {
     requestBody = await c.req.text();
 
     try {


### PR DESCRIPTION
Two fixes for ProgressView usability:

1. Emit setTaskState immediately after setActiveStream so the instruction panel displays without delay. Previously instruction only appeared after Init stage completion, causing a noticeable visual delay.

2. Include group name in run selector dropdown labels (e.g., "Init: Jan 05...") so users can easily identify and switch between Init and run stages.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Unifies session grouping and stabilizes storage, logging, and UI, with a small relay safeguard.
> 
> - Runtime: Create a single top-level `Run: <agent>` stage in `executeAgent.ts` and pass as `parentStage` to reflection/tool-use flows; move `setActiveStream` before stage creation; update storage key to `runStage.id`; build workflow vars under `Init` child; always end `runStage` with flow status; use `EndGroupStatus` consistently; log errors without opening a new group.
> - Reflection flow: Accept optional `parentStage`; only create/end run stage when not provided; update storage key using `runStage.id!`; ensure `OutputHandler` uses the active storage key.
> - Logger: `popGroupContext` now removes only the last occurrence of a group ID to support non-LIFO endings and nested contexts.
> - ProgressView: Run selector labels now include group name (e.g., `Init: Jan 05, ...`) in `RunSelector.js`.
> - Relay: Skip tier-based model validation for file-upload paths (e.g., `/v1/files`, Google `/upload/*`, `/v1beta/files`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 16738258d877b44c75116725962cedc01be42245. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->