### PR TITLE
Fix usage panel display in tool sessions

### DIFF
--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -446,6 +446,13 @@ export class ProgressEventHandler {
           normalizedUsage,
         );
 
+        // For tool-use sessions (no task groups), set active run ID from usage
+        // so the frontend can resolve which run's usage to display.
+        // For workflow sessions, task group creation already set this.
+        if (!this.state.getActiveRunId(stream)) {
+          this.state.setActiveRunId(stream, storageKey);
+        }
+
         if (
           this.webviewUpdater.isAvailable() &&
           stream === this.state.activeStream

--- a/src/progressView/state/ProgressViewState.ts
+++ b/src/progressView/state/ProgressViewState.ts
@@ -373,6 +373,15 @@ export class ProgressViewState {
       }
     }
 
+    // For tool-use sessions, there are no task groups - fall back to usage runs
+    if (!latest) {
+      const usageRuns = this._usageStats.getRunUsage(stream);
+      if (usageRuns.size > 0) {
+        // Return the last key (most recently added run)
+        return [...usageRuns.keys()].at(-1) ?? null;
+      }
+    }
+
     return latest?.id ?? null;
   }
 


### PR DESCRIPTION
Tool-use sessions weren't displaying the usage panel because:
1. Backend findLatestRunId only looked at task groups (tool-use has none)
2. Active run ID was never set for tool-use sessions

Changes:
- Add usage run fallback in findLatestRunId when no task groups exist
- Set active run ID from storageKey when usage arrives for tool-use

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures the usage panel appears for tool-use sessions that lack task groups.
> 
> - In `ProgressEventHandler.ts`, when handling `updateStreamUsage`, set `activeRunId` from `storageKey` if none is set so the UI knows which run to display
> - In `ProgressViewState.ts`, update `findLatestRunId` to fall back to the last usage run when no task groups exist
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit caf16acb0b2f68feb323ca6b571f2324000c9e86. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->