### PR TITLE
Check Gemini 3 Pro reasoning effort parameter

### DIFF
--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -202,15 +202,26 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
       return undefined;
     }
 
-    if (requestedLevel === ReasoningEffort.MEDIUM) {
-      return ThinkingLevel.MEDIUM;
-    }
-
     if (requestedLevel === ReasoningEffort.LOW) {
       return ThinkingLevel.LOW;
     }
 
-    if (requestedLevel === ReasoningEffort.HIGH) {
+    if (requestedLevel === ReasoningEffort.MEDIUM) {
+      // Gemini 3 Pro only supports LOW/HIGH; MEDIUM falls back to HIGH for Pro
+      if (isGemini3 && this.config.fullName.includes('-pro')) {
+        this.logger.debug(
+          'Gemini 3 Pro does not support MEDIUM thinking level. Using HIGH.',
+        );
+        return ThinkingLevel.HIGH;
+      }
+      return ThinkingLevel.MEDIUM;
+    }
+
+    // HIGH and XHIGH both map to ThinkingLevel.HIGH (the maximum in Google's SDK)
+    if (
+      requestedLevel === ReasoningEffort.HIGH ||
+      requestedLevel === ReasoningEffort.XHIGH
+    ) {
       return ThinkingLevel.HIGH;
     }
 


### PR DESCRIPTION
- Add handling for ReasoningEffort.XHIGH to map to ThinkingLevel.HIGH (previously fell through to undefined, effectively disabling thinking)
- Add fallback for Gemini 3 Pro when MEDIUM is requested (Pro only supports LOW/HIGH, so MEDIUM now falls back to HIGH with debug log)
- Reorder checks for clarity (LOW before MEDIUM)

Note: Both gemini3p and gemini3f have identical reasoningEffort: "high" in llm-zoo, so thinking level differences are model behavior, not config.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refines reasoning/thinking level mapping for Google Gemini 3 models.
> 
> - `MEDIUM` now supported; on Gemini 3 Pro (`-pro`) it falls back to `ThinkingLevel.HIGH` with a debug log
> - `HIGH` and `XHIGH` both map to `ThinkingLevel.HIGH` (max supported by SDK)
> - Keeps `LOW` mapping; `NONE` on Gemini 3 warns and uses `LOW` instead of disabling thinking
> - Reorders checks for clarity and adds targeted logging
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ebc6e37b53754d2cc1b918c8451c99a26aa5284e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->