### PR TITLE
Use shared sizing tokens for webview headers

### DIFF
--- a/src/common/styles/common.css
+++ b/src/common/styles/common.css
@@ -83,6 +83,11 @@ body {
   --width-icon: 16px;
   --width-button-min: 80px;
   --width-dropdown: 160px;
+  --width-dropdown-wide-min: calc(var(--width-dropdown) + var(--spacing-large));
+  --width-dropdown-wide-max: calc(
+    var(--width-dropdown) + var(--spacing-xlarge)
+  );
+  --width-label-column: 12ch;
 
   /* Borders */
   --border-thin: 1px;
@@ -106,6 +111,66 @@ body {
   align-items: center;
   position: relative;
   top: 0;
+}
+
+/* Shared header layout for webviews */
+.view-header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-small);
+  padding: var(--spacing-small) 0 var(--spacing-medium);
+  margin-bottom: var(--spacing-medium);
+  border-bottom: var(--border-thin) solid var(--color-border);
+}
+
+.view-header__primary {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-medium);
+}
+
+.view-header__titles {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-tiny);
+  min-width: 0;
+}
+
+.view-header__title {
+  font-size: var(--font-size-lg);
+  font-weight: 600;
+  color: var(--vscode-editor-foreground);
+  line-height: 1.2;
+  margin: 0;
+}
+
+.view-header__subtitle {
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-sm);
+  margin: 0;
+}
+
+.view-header__title-group {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-small);
+  min-width: 0;
+}
+
+.view-header__actions {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-small);
+  margin-left: auto;
+}
+
+.view-header__secondary {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-small);
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-sm);
+  flex-wrap: wrap;
 }
 
 /* VSCode Elements toolbar styling */

--- a/src/historyView/index.html
+++ b/src/historyView/index.html
@@ -54,17 +54,23 @@
   </head>
 
   <body>
-    <div>
-      <h2>Agent Execution History</h2>
-
-      <div id="searchContainer" class="search-container">
+    <div class="view-header">
+      <div class="view-header__primary">
+        <div class="view-header__titles">
+          <h2 class="view-header__title">Agent Execution History</h2>
+          <p class="view-header__subtitle">
+            Search and revisit your previous sessions
+          </p>
+        </div>
+      </div>
+      <div id="searchContainer" class="view-header__secondary search-container">
         <vscode-textfield
           id="searchInput"
           class="search-input"
           type="search"
           placeholder="Search history items..."
         ></vscode-textfield>
-        <vscode-toolbar-container class="search-controls">
+        <vscode-toolbar-container class="search-controls view-header__actions">
           <vscode-toolbar-button
             id="prevMatch"
             class="search-nav-btn"
@@ -82,14 +88,14 @@
           <span id="matchCount" class="match-count"></span>
         </vscode-toolbar-container>
       </div>
+    </div>
 
-      <div id="clearButtonContainer">
-        <!-- Clear button will be added here if history items exist -->
-      </div>
+    <div id="clearButtonContainer">
+      <!-- Clear button will be added here if history items exist -->
+    </div>
 
-      <div id="historyContainer" class="history-container">
-        <!-- History items will be inserted here -->
-      </div>
+    <div id="historyContainer" class="history-container">
+      <!-- History items will be inserted here -->
     </div>
     <template id="historyItemTemplate">
       <div class="history-item">

--- a/src/historyView/styles/index.css
+++ b/src/historyView/styles/index.css
@@ -9,15 +9,10 @@ body {
   padding: var(--spacing-xlarge);
 }
 
-h2 {
-  margin-bottom: var(--spacing-xlarge);
-}
-
 /* Search container */
 .search-container {
   display: flex;
   align-items: center;
-  margin-bottom: var(--spacing-xlarge);
   gap: var(--spacing-medium);
   width: 100%;
 }
@@ -101,7 +96,7 @@ mark.current-match {
 
 .history-details {
   display: grid;
-  grid-template-columns: 100px 1fr;
+  grid-template-columns: var(--width-label-column) 1fr;
   gap: var(--spacing-small);
   margin-top: var(--spacing-medium);
 }

--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -92,11 +92,11 @@
     <div class="main-container">
       <vscode-split-layout initial-handle-position="80%">
         <div slot="start" class="content-area">
-          <div class="log-header">
-            <div class="log-header__primary">
-              <div class="header-left">
+          <div class="log-header view-header">
+            <div class="log-header__primary view-header__primary">
+              <div class="header-left view-header__title-group">
                 <div class="stream-header">
-                  <span id="activeStreamName"></span>
+                  <span id="activeStreamName" class="view-header__title"></span>
                 </div>
                 <span
                   id="statusIndicator"
@@ -106,16 +106,19 @@
               </div>
               <vscode-toolbar-container
                 id="toolbarContainer"
-                class="header-actions"
+                class="header-actions view-header__actions"
               ></vscode-toolbar-container>
             </div>
             <div
-              class="log-header__secondary"
+              class="log-header__secondary view-header__secondary"
               id="runSelectorRow"
               hidden
               aria-hidden="true"
             >
-              <div class="run-selector-title" aria-hidden="true">
+              <div
+                class="run-selector-title view-header__subtitle"
+                aria-hidden="true"
+              >
                 <i class="codicon codicon-history"></i>
                 <span>Sessions</span>
               </div>

--- a/src/progressView/styles/logs.css
+++ b/src/progressView/styles/logs.css
@@ -91,7 +91,7 @@
   flex-direction: column;
   gap: var(--spacing-small);
   color: var(--color-text-secondary);
-  border-bottom: 1px solid var(--color-border);
+  border-bottom: var(--border-thin) solid var(--color-border);
 }
 
 .log-header__primary {
@@ -130,8 +130,8 @@
 }
 
 .run-selector {
-  min-width: 180px;
-  max-width: 260px;
+  min-width: var(--width-dropdown-wide-min);
+  max-width: var(--width-dropdown-wide-max);
   flex-shrink: 0;
 }
 

--- a/src/webview/index.html
+++ b/src/webview/index.html
@@ -60,7 +60,6 @@
       src="${vscodeElementsBundleUri}"
     ></script>
     <script type="module" nonce="${nonce}" src="${scriptUri}"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/Sortable/1.14.0/Sortable.min.js"></script>
   </head>
 
   <body>


### PR DESCRIPTION
## Summary
- add shared width tokens for dropdowns and label columns to replace hard-coded pixel widths
- update history and progress view styles to use the new sizing variables and existing border tokens

## Testing
- npm run format
- npm run compile
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ba2ca4d9c83248a01b8604b405f6e)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Unifies webview header layout and sizing via shared CSS tokens and classes.
> 
> - Adds `--width-dropdown-wide-{min,max}` and `--width-label-column` tokens and introduces reusable `view-header*` styles in `common.css`
> - Refactors `historyView` and `progressView` headers to use `view-header` structure; converts hard-coded widths/borders to tokens (e.g., run selector min/max, label grid column, border-thin)
> - Cleans up styles by removing redundant margins and aligning typography; no functional logic changes
> - Removes unused Sortable CDN script from `webview/index.html`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 706cc08f9aa07871342dfb0d1c0624db1f4d17cd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->