### PR TITLE
Add database schema for analytics logging

### DIFF
--- a/src/agent/modelHandlers/BaseReasoningStreamAggregator.ts
+++ b/src/agent/modelHandlers/BaseReasoningStreamAggregator.ts
@@ -45,11 +45,20 @@ export class BaseReasoningStreamAggregator implements StreamingAggregator {
     if (chunk.choices.length > 0) {
       this.lastChunkWithChoices = chunk;
     }
+    // Check root-level usage (OpenAI format with stream_options.include_usage)
     if (chunk.usage) {
       this.usageChunk = chunk;
     }
 
     const choice = chunk.choices[0];
+
+    // Check choice-level usage (Kimi format - usage is inside the choice object)
+    const choiceUsage = (choice as { usage?: ChatCompletionChunk['usage'] })
+      ?.usage;
+    if (choiceUsage && !this.usageChunk) {
+      // Store as if it were root-level usage for consistency
+      this.usageChunk = { ...chunk, usage: choiceUsage };
+    }
     if (!choice) {
       return;
     }

--- a/src/agent/modelHandlers/modelHandlerKimi.ts
+++ b/src/agent/modelHandlers/modelHandlerKimi.ts
@@ -150,10 +150,20 @@ export class ModelHandlerKimi extends ModelHandlerOpenAI {
         stream.on('chunk', onChunk);
 
         try {
-          const finalResponse = await this.awaitFinalResponse(
+          let finalResponse = await this.awaitFinalResponse(
             stream,
             streamingAggregator,
           );
+
+          // Ensure usage is captured - use SDK's totalUsage() as fallback
+          if (!finalResponse.usage) {
+            try {
+              const totalUsage = await stream.totalUsage();
+              finalResponse = { ...finalResponse, usage: totalUsage };
+            } catch (_err) {
+              // totalUsage() may fail if stream ended abnormally
+            }
+          }
 
           const finalReasoning = this.processThinkingBlock(finalResponse);
           if (finalReasoning === null) {

--- a/src/agent/modelHandlers/modelHandlerKimi.ts
+++ b/src/agent/modelHandlers/modelHandlerKimi.ts
@@ -150,20 +150,11 @@ export class ModelHandlerKimi extends ModelHandlerOpenAI {
         stream.on('chunk', onChunk);
 
         try {
-          let finalResponse = await this.awaitFinalResponse(
+          // Usage is captured by the aggregator from choices[0].usage (Kimi's format)
+          const finalResponse = await this.awaitFinalResponse(
             stream,
             streamingAggregator,
           );
-
-          // Ensure usage is captured - use SDK's totalUsage() as fallback
-          if (!finalResponse.usage) {
-            try {
-              const totalUsage = await stream.totalUsage();
-              finalResponse = { ...finalResponse, usage: totalUsage };
-            } catch (_err) {
-              // totalUsage() may fail if stream ended abnormally
-            }
-          }
 
           const finalReasoning = this.processThinkingBlock(finalResponse);
           if (finalReasoning === null) {


### PR DESCRIPTION
Add totalUsage() fallback for Kimi thinking models, matching the OpenAI handler pattern. Previously, streaming responses would show 0 for all token counts because the aggregator didn't preserve usage data from chunks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures usage metrics are preserved for Kimi reasoning streams by normalizing where usage is read during aggregation.
> 
> - In `BaseReasoningStreamAggregator`, capture `usage` from both root-level `chunk.usage` (OpenAI format) and choice-level `choices[0].usage` (Kimi format), storing it for the finalized response
> - `finalize()` now prefers preserved `usage` (from usage/last-choice chunks) to avoid missing token counts
> - `modelHandlerKimi` streaming flow relies on the aggregator for usage; no API changes to request/response handling
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f41e1862cc9fa4c4eebd73ee9df6aa1d2bdb6c13. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->