### PR TITLE
fix: support both Bearer and token auth formats for GitHub tokens

### DIFF
--- a/src/auth/SupabaseAuthProvider.ts
+++ b/src/auth/SupabaseAuthProvider.ts
@@ -43,6 +43,14 @@ type GitHubTokenExchangeResponse = z.infer<typeof GitHubTokenExchangeSchema>;
 /** Timeout for Edge Function requests (30 seconds) */
 const EDGE_FUNCTION_TIMEOUT_MS = 30000;
 
+/** GitHub token type prefixes for diagnostic logging. */
+const GITHUB_TOKEN_TYPE_MAP: Record<string, string> = {
+  ghp_: 'classic PAT',
+  gho_: 'OAuth token',
+  ghu_: 'user-to-server token',
+  ghs_: 'server-to-server token',
+};
+
 /** Session data stored in VS Code SecretStorage. */
 interface SupabaseSession {
   id: string;
@@ -492,16 +500,7 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
 
       // Log token format to help diagnose auth issues (token prefix indicates type)
       const tokenPrefix = githubSession.accessToken.substring(0, 4);
-      const tokenType =
-        tokenPrefix === 'ghp_'
-          ? 'classic PAT'
-          : tokenPrefix === 'gho_'
-            ? 'OAuth token'
-            : tokenPrefix === 'ghu_'
-              ? 'user-to-server token'
-              : tokenPrefix === 'ghs_'
-                ? 'server-to-server token'
-                : 'unknown format';
+      const tokenType = GITHUB_TOKEN_TYPE_MAP[tokenPrefix] ?? 'unknown format';
 
       logger.info(
         'SupabaseAuthProvider',

--- a/src/auth/SupabaseAuthProvider.ts
+++ b/src/auth/SupabaseAuthProvider.ts
@@ -490,13 +490,22 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
         throw new Error('GitHub authentication was cancelled');
       }
 
+      // Log token format to help diagnose auth issues (token prefix indicates type)
+      const tokenPrefix = githubSession.accessToken.substring(0, 4);
+      const tokenType =
+        tokenPrefix === 'ghp_'
+          ? 'classic PAT'
+          : tokenPrefix === 'gho_'
+            ? 'OAuth token'
+            : tokenPrefix === 'ghu_'
+              ? 'user-to-server token'
+              : tokenPrefix === 'ghs_'
+                ? 'server-to-server token'
+                : 'unknown format';
+
       logger.info(
         'SupabaseAuthProvider',
-        `Got VS Code GitHub session for ${githubSession.account.label} (scopes: ${githubSession.scopes.join(', ') || 'default'})`,
-      );
-      logger.debug(
-        'SupabaseAuthProvider',
-        `GitHub token preview: ${githubSession.accessToken.substring(0, 10)}...`,
+        `Got VS Code GitHub session for ${githubSession.account.label} (scopes: ${githubSession.scopes.join(', ') || 'default'}, token type: ${tokenType})`,
       );
 
       // Exchange GitHub token for Supabase session via Edge Function
@@ -530,8 +539,14 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
           errorData.error || `Token exchange failed: ${response.status}`;
         logger.error(
           'SupabaseAuthProvider',
-          `GitHub token exchange failed (${response.status}): ${errorMsg}`,
+          `GitHub token exchange failed (${response.status}): ${errorMsg} [token type: ${tokenType}]`,
         );
+        // Provide user-friendly error messages for common issues
+        if (response.status === 401) {
+          throw new Error(
+            'GitHub token validation failed. Please try signing out of GitHub in VS Code and signing in again.',
+          );
+        }
         throw new Error(errorMsg);
       }
 

--- a/supabase/functions/auth-github/index.ts
+++ b/supabase/functions/auth-github/index.ts
@@ -120,6 +120,7 @@ async function validateGitHubToken(
 
   let lastError = '';
   let userRes: Response | null = null;
+  let workingHeaders: Record<string, string> | null = null;
 
   for (const authHeader of authFormats) {
     const headers = {
@@ -131,6 +132,7 @@ async function validateGitHubToken(
     userRes = await fetch('https://api.github.com/user', { headers });
 
     if (userRes.ok) {
+      workingHeaders = headers;
       break;
     }
 
@@ -146,7 +148,7 @@ async function validateGitHubToken(
     }
   }
 
-  if (!userRes || !userRes.ok) {
+  if (!userRes || !userRes.ok || !workingHeaders) {
     console.error(`[AUTH] GitHub token validation failed: ${lastError}`);
     return { error: `GitHub API rejected token (${lastError.split(' - ')[0]})` };
   }
@@ -155,7 +157,7 @@ async function validateGitHubToken(
   let primaryEmail = user.email;
 
   const emailsRes = await fetch('https://api.github.com/user/emails', {
-    headers,
+    headers: workingHeaders,
   });
   if (emailsRes.ok) {
     const emails = await emailsRes.json();

--- a/supabase/functions/auth-github/index.ts
+++ b/supabase/functions/auth-github/index.ts
@@ -113,19 +113,42 @@ function jsonResponse(
 async function validateGitHubToken(
   token: string,
 ): Promise<{ user: GitHubUser; email: string } | { error: string }> {
-  const headers = {
-    Authorization: `Bearer ${token}`,
-    Accept: 'application/vnd.github+json',
-    'User-Agent': 'TeXRA-Auth',
-  };
+  // Try both authorization header formats since VS Code's GitHub auth
+  // provider returns different token types depending on the environment.
+  // Modern tokens use "Bearer", legacy/OAuth tokens may require "token".
+  const authFormats = [`Bearer ${token}`, `token ${token}`];
 
-  const userRes = await fetch('https://api.github.com/user', { headers });
-  if (!userRes.ok) {
+  let lastError = '';
+  let userRes: Response | null = null;
+
+  for (const authHeader of authFormats) {
+    const headers = {
+      Authorization: authHeader,
+      Accept: 'application/vnd.github+json',
+      'User-Agent': 'TeXRA-Auth',
+    };
+
+    userRes = await fetch('https://api.github.com/user', { headers });
+
+    if (userRes.ok) {
+      break;
+    }
+
     const errorText = await userRes.text().catch(() => 'unknown');
-    console.error(
-      `[AUTH] GitHub /user API failed: ${userRes.status} - ${errorText}`,
+    lastError = `${userRes.status} - ${errorText}`;
+    console.warn(
+      `[AUTH] GitHub /user API failed with ${authHeader.split(' ')[0]} auth: ${lastError}`,
     );
-    return { error: `GitHub API rejected token (${userRes.status})` };
+
+    // Only retry with next format if we got 401 (unauthorized)
+    if (userRes.status !== 401) {
+      break;
+    }
+  }
+
+  if (!userRes || !userRes.ok) {
+    console.error(`[AUTH] GitHub token validation failed: ${lastError}`);
+    return { error: `GitHub API rejected token (${lastError.split(' - ')[0]})` };
   }
 
   const user: GitHubUser = await userRes.json();


### PR DESCRIPTION
VS Code's GitHub auth provider returns different token types depending on
the environment (desktop, Codespaces, web). Some tokens work with "Bearer"
prefix, while others require the legacy "token" prefix format.

Changes:
- Edge function now tries both auth header formats when validating GitHub
  tokens, falling back to "token" prefix if "Bearer" fails with 401
- Added better logging to track token type (gho_, ghp_, ghu_, ghs_) to
  help diagnose future authentication issues
- Improved error messages for 401 failures to guide users toward resolution

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves reliability of GitHub auth across environments and adds better diagnostics.
> 
> - Edge function `auth-github/index.ts`: `validateGitHubToken` now attempts both `Authorization: Bearer` and `Authorization: token`, retrying only on 401 and reusing the working headers for `/user` and `/user/emails`; clearer error messages and logs.
> - VS Code `SupabaseAuthProvider.ts`: logs inferred GitHub token type based on prefix (`ghp_/gho_/ghu_/ghs_`); includes token type in failure logs; surfaces a user-friendly hint on 401 to re-authenticate; removes token preview logging.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7c847c4096ad6dcf4b18b30f5dff2482d7ae79c0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->