### PR TITLE
Fix missing total usage display for sessions

### DIFF
--- a/src/agent/core/RunUsageAccumulator.ts
+++ b/src/agent/core/RunUsageAccumulator.ts
@@ -139,4 +139,14 @@ export class RunUsageAccumulator {
   getNormalizedSnapshots(): readonly NormalizedUsageSnapshot[] {
     return this.normalizedSnapshots;
   }
+
+  /**
+   * Reset the accumulator to initial state.
+   * Used by workflow sessions to ensure each round reports per-round usage
+   * rather than cumulative totals.
+   */
+  reset(): void {
+    this.totals = { ...DEFAULT_TOTALS };
+    this.normalizedSnapshots.length = 0;
+  }
 }

--- a/src/agent/core/RunUsageAccumulator.ts
+++ b/src/agent/core/RunUsageAccumulator.ts
@@ -141,12 +141,41 @@ export class RunUsageAccumulator {
   }
 
   /**
-   * Reset the accumulator to initial state.
-   * Used by workflow sessions to ensure each round reports per-round usage
-   * rather than cumulative totals.
+   * Capture current totals as baseline for delta computation.
+   * Called at the start of each workflow round to enable per-round reporting.
    */
-  reset(): void {
-    this.totals = { ...DEFAULT_TOTALS };
-    this.normalizedSnapshots.length = 0;
+  captureBaseline(): void {
+    this._baselineTotals = { ...this.totals };
   }
+
+  /**
+   * Get usage delta since the last captured baseline.
+   * Returns per-round values while preserving cumulative totals for safety checks.
+   */
+  getDeltaSinceBaseline(): RunUsageTotals {
+    const baseline = this._baselineTotals ?? DEFAULT_TOTALS;
+    return {
+      // Preserve firstInputTokens from actual first input (not delta)
+      firstInputTokens: this.totals.firstInputTokens,
+      totalInputTokens: this.totals.totalInputTokens - baseline.totalInputTokens,
+      totalOutputTokens:
+        this.totals.totalOutputTokens - baseline.totalOutputTokens,
+      totalCost: this.totals.totalCost - baseline.totalCost,
+      totalCacheReadInputTokens:
+        this.totals.totalCacheReadInputTokens -
+        baseline.totalCacheReadInputTokens,
+      totalCacheCreationInputTokens:
+        this.totals.totalCacheCreationInputTokens -
+        baseline.totalCacheCreationInputTokens,
+      totalReasoningTokens:
+        this.totals.totalReasoningTokens - baseline.totalReasoningTokens,
+      totalToolUsePromptTokens:
+        this.totals.totalToolUsePromptTokens - baseline.totalToolUsePromptTokens,
+      totalServerToolRequests:
+        this.totals.totalServerToolRequests - baseline.totalServerToolRequests,
+    };
+  }
+
+  /** Baseline totals for delta computation (null = start of run) */
+  private _baselineTotals: RunUsageTotals | null = null;
 }

--- a/src/agent/core/RunUsageAccumulator.ts
+++ b/src/agent/core/RunUsageAccumulator.ts
@@ -60,6 +60,8 @@ export type NormalizedUsageSnapshot = z.infer<
 export const RunUsageAccumulatorJSONSchema = z.object({
   totals: RunUsageTotalsSchema.prefault(DEFAULT_TOTALS),
   normalizedSnapshots: z.array(NormalizedUsageSnapshotSchema).prefault([]),
+  /** Baseline for delta computation - null means start of run */
+  baselineTotals: RunUsageTotalsSchema.nullable().prefault(null),
 });
 
 /**
@@ -73,6 +75,8 @@ export type RunUsageAccumulatorJSON = z.output<
 export class RunUsageAccumulator {
   private totals: RunUsageTotals = { ...DEFAULT_TOTALS };
   private readonly normalizedSnapshots: NormalizedUsageSnapshot[] = [];
+  /** Baseline totals for delta computation (null = start of run) */
+  private _baselineTotals: RunUsageTotals | null = null;
 
   /** Deserialize from a snapshot. Schema transform handles default merging. */
   static fromSnapshot(snapshot: unknown): RunUsageAccumulator {
@@ -80,6 +84,7 @@ export class RunUsageAccumulator {
     const acc = new RunUsageAccumulator();
     acc.totals = parsed.totals;
     acc.normalizedSnapshots.push(...parsed.normalizedSnapshots);
+    acc._baselineTotals = parsed.baselineTotals;
     return acc;
   }
 
@@ -88,6 +93,7 @@ export class RunUsageAccumulator {
     return {
       totals: this.totals,
       normalizedSnapshots: [...this.normalizedSnapshots],
+      baselineTotals: this._baselineTotals,
     };
   }
 
@@ -151,6 +157,10 @@ export class RunUsageAccumulator {
   /**
    * Get usage delta since the last captured baseline.
    * Returns per-round values while preserving cumulative totals for safety checks.
+   *
+   * Note: Returns RunUsageTotals type for API compatibility, but values represent
+   * deltas (current - baseline), not cumulative totals. Field names like
+   * "totalInputTokens" contain per-round delta values in this context.
    */
   getDeltaSinceBaseline(): RunUsageTotals {
     const baseline = this._baselineTotals ?? DEFAULT_TOTALS;
@@ -175,7 +185,4 @@ export class RunUsageAccumulator {
         this.totals.totalServerToolRequests - baseline.totalServerToolRequests,
     };
   }
-
-  /** Baseline totals for delta computation (null = start of run) */
-  private _baselineTotals: RunUsageTotals | null = null;
 }

--- a/src/agent/core/RunUsageAccumulator.ts
+++ b/src/agent/core/RunUsageAccumulator.ts
@@ -44,6 +44,17 @@ export const RunUsageTotalsSchema = z.object({
 });
 export type RunUsageTotals = z.infer<typeof RunUsageTotalsSchema>;
 
+/**
+ * Type alias for per-round usage deltas.
+ * Structurally identical to RunUsageTotals but semantically represents
+ * the difference between current and baseline values.
+ *
+ * Note: Field names like "totalInputTokens" contain delta values, not cumulative totals.
+ * The "firstInputTokens" field is an exception - it always contains the actual first
+ * input tokens from the run, not a delta.
+ */
+export type RunUsageDelta = RunUsageTotals;
+
 /** Schema for normalized usage snapshot */
 export const NormalizedUsageSnapshotSchema = z.object({
   round: z.number(),
@@ -62,6 +73,8 @@ export const RunUsageAccumulatorJSONSchema = z.object({
   normalizedSnapshots: z.array(NormalizedUsageSnapshotSchema).prefault([]),
   /** Baseline for delta computation - null means start of run */
   baselineTotals: RunUsageTotalsSchema.nullable().prefault(null),
+  /** Baseline response time in ms for delta computation */
+  baselineResponseTimeMs: z.number().nonnegative().prefault(0),
 });
 
 /**
@@ -77,6 +90,8 @@ export class RunUsageAccumulator {
   private readonly normalizedSnapshots: NormalizedUsageSnapshot[] = [];
   /** Baseline totals for delta computation (null = start of run) */
   private _baselineTotals: RunUsageTotals | null = null;
+  /** Baseline response time in ms for delta computation */
+  private _baselineResponseTimeMs: number = 0;
 
   /** Deserialize from a snapshot. Schema transform handles default merging. */
   static fromSnapshot(snapshot: unknown): RunUsageAccumulator {
@@ -85,6 +100,7 @@ export class RunUsageAccumulator {
     acc.totals = parsed.totals;
     acc.normalizedSnapshots.push(...parsed.normalizedSnapshots);
     acc._baselineTotals = parsed.baselineTotals;
+    acc._baselineResponseTimeMs = parsed.baselineResponseTimeMs;
     return acc;
   }
 
@@ -94,6 +110,7 @@ export class RunUsageAccumulator {
       totals: this.totals,
       normalizedSnapshots: [...this.normalizedSnapshots],
       baselineTotals: this._baselineTotals,
+      baselineResponseTimeMs: this._baselineResponseTimeMs,
     };
   }
 
@@ -149,20 +166,30 @@ export class RunUsageAccumulator {
   /**
    * Capture current totals as baseline for delta computation.
    * Called at the start of each workflow round to enable per-round reporting.
+   * @param responseTimeMs - Current cumulative response time to use as baseline
    */
-  captureBaseline(): void {
+  captureBaseline(responseTimeMs: number = 0): void {
     this._baselineTotals = { ...this.totals };
+    this._baselineResponseTimeMs = responseTimeMs;
+  }
+
+  /**
+   * Get response time delta since the last captured baseline.
+   * @param currentResponseTimeMs - Current cumulative response time
+   * @returns Per-round response time in ms
+   */
+  getResponseTimeDelta(currentResponseTimeMs: number): number {
+    return currentResponseTimeMs - this._baselineResponseTimeMs;
   }
 
   /**
    * Get usage delta since the last captured baseline.
    * Returns per-round values while preserving cumulative totals for safety checks.
    *
-   * Note: Returns RunUsageTotals type for API compatibility, but values represent
-   * deltas (current - baseline), not cumulative totals. Field names like
-   * "totalInputTokens" contain per-round delta values in this context.
+   * @returns RunUsageDelta - Per-round delta values (not cumulative totals).
+   *          Exception: firstInputTokens always contains the actual first input tokens.
    */
-  getDeltaSinceBaseline(): RunUsageTotals {
+  getDeltaSinceBaseline(): RunUsageDelta {
     const baseline = this._baselineTotals ?? DEFAULT_TOTALS;
     return {
       // Preserve firstInputTokens from actual first input (not delta)

--- a/src/agent/implementations/flows/reflection/nodes/ResponseCycleNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/ResponseCycleNode.ts
@@ -101,7 +101,7 @@ export class ResponseCycleNode<C = unknown> extends Node<
     const workspace = getWorkspaceState(shared);
     const run = AgentRunState.fromSnapshot(shared.runStateSnapshot);
     // Capture baseline so we can report per-round usage delta (preserves cumulative for safety checks)
-    run.usageAccumulator.captureBaseline();
+    run.usageAccumulator.captureBaseline(run.totalResponseTimeMs);
     const round = ConversationRoundState.fromSnapshot(
       context.stateRoundSnapshot,
     );

--- a/src/agent/implementations/flows/reflection/nodes/ResponseCycleNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/ResponseCycleNode.ts
@@ -100,8 +100,8 @@ export class ResponseCycleNode<C = unknown> extends Node<
     // Reconstruct state instances from snapshots
     const workspace = getWorkspaceState(shared);
     const run = AgentRunState.fromSnapshot(shared.runStateSnapshot);
-    // Reset usage accumulator so each round reports per-round usage, not cumulative
-    run.usageAccumulator.reset();
+    // Capture baseline so we can report per-round usage delta (preserves cumulative for safety checks)
+    run.usageAccumulator.captureBaseline();
     const round = ConversationRoundState.fromSnapshot(
       context.stateRoundSnapshot,
     );

--- a/src/agent/implementations/flows/reflection/nodes/ResponseCycleNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/ResponseCycleNode.ts
@@ -100,6 +100,8 @@ export class ResponseCycleNode<C = unknown> extends Node<
     // Reconstruct state instances from snapshots
     const workspace = getWorkspaceState(shared);
     const run = AgentRunState.fromSnapshot(shared.runStateSnapshot);
+    // Reset usage accumulator so each round reports per-round usage, not cumulative
+    run.usageAccumulator.reset();
     const round = ConversationRoundState.fromSnapshot(
       context.stateRoundSnapshot,
     );

--- a/src/agent/implementations/flows/reflection/runReflectionFlow.ts
+++ b/src/agent/implementations/flows/reflection/runReflectionFlow.ts
@@ -300,6 +300,14 @@ export async function runReflectionFlow<C = unknown>(
             parent: parent ?? undefined,
           });
         },
+        onRoundStart: (context) => {
+          // Update storageKey to round stage ID so each round has its own usage storage
+          // This ensures per-round usage values instead of cumulative totals
+          const roundStageId = context.roundStage?.id;
+          if (roundStageId) {
+            updateStorageKey(normalizeRunId(roundStageId));
+          }
+        },
         resetForNextRound: (s) => {
           s.workspaceSnapshot = createFreshWorkspaceSnapshot();
         },

--- a/src/agent/implementations/flows/reflection/runReflectionFlow.ts
+++ b/src/agent/implementations/flows/reflection/runReflectionFlow.ts
@@ -301,11 +301,16 @@ export async function runReflectionFlow<C = unknown>(
           });
         },
         onRoundStart: (context) => {
-          // Update storageKey to round stage ID so each round has its own usage storage
-          // This ensures per-round usage values instead of cumulative totals
+          // Update storageKey to round stage ID so each round has its own usage storage.
+          // This works in conjunction with captureBaseline() in ResponseCycleNode:
+          // - Per-round storageKey: Ensures each round stores usage under a unique key (r0, r1)
+          // - Delta computation: Ensures we report only this round's usage, not cumulative
+          // Both are needed because without deltas, cumulative values under separate keys
+          // would cause double-counting when summed in computeTotal().
           const roundStageId = context.roundStage?.id;
           if (roundStageId) {
-            updateStorageKey(normalizeRunId(roundStageId));
+            // Use silent=true since per-round key updates are expected, not bugs
+            updateStorageKey(normalizeRunId(roundStageId), true);
           } else {
             logger.warn(
               `Round ${context.shared.currentRound}: No round stage ID available, usage may accumulate under previous key`,

--- a/src/agent/implementations/flows/reflection/runReflectionFlow.ts
+++ b/src/agent/implementations/flows/reflection/runReflectionFlow.ts
@@ -306,6 +306,10 @@ export async function runReflectionFlow<C = unknown>(
           const roundStageId = context.roundStage?.id;
           if (roundStageId) {
             updateStorageKey(normalizeRunId(roundStageId));
+          } else {
+            logger.warn(
+              `Round ${context.shared.currentRound}: No round stage ID available, usage may accumulate under previous key`,
+            );
           }
         },
         resetForNextRound: (s) => {

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -257,8 +257,8 @@ async function resolveAgentBase(
   let storageKey: StorageKey = initialStorageKey;
   const getStorageKey = () => storageKey;
   const hasInitialStorageKey = () => storageKey === initialStorageKey;
-  const updateStorageKey = (key: StorageKey) => {
-    if (!hasInitialStorageKey()) {
+  const updateStorageKey = (key: StorageKey, silent?: boolean) => {
+    if (!hasInitialStorageKey() && !silent) {
       agentLogger.warn(
         `Storage key already set to ${storageKey}, updating to ${key}. This may indicate a bug.`,
       );

--- a/src/agent/types/IdentifierTypes.ts
+++ b/src/agent/types/IdentifierTypes.ts
@@ -62,6 +62,10 @@ export interface StorageKeyManager {
   getStorageKey: () => StorageKey;
   /** Check if storage key is still initial (new run, not resumed) */
   hasInitialStorageKey: () => boolean;
-  /** Update storage key to task group ID (called by workflow agents) */
-  updateStorageKey: (key: StorageKey) => void;
+  /**
+   * Update storage key to task group ID (called by workflow agents).
+   * @param key - New storage key
+   * @param silent - If true, suppress warning for expected updates (e.g., per-round keys)
+   */
+  updateStorageKey: (key: StorageKey, silent?: boolean) => void;
 }

--- a/src/agent/utils/UsageMonitor.ts
+++ b/src/agent/utils/UsageMonitor.ts
@@ -90,7 +90,12 @@ export class UsageMonitor {
     const runKind: UsageMonitorRunKind = options?.runKind ?? 'workflow';
 
     try {
-      const totals = stateGlobal.usageAccumulator.getTotals();
+      // Workflow sessions: Report per-round delta (each round has its own storageKey)
+      // Tool-use sessions: Report cumulative (same storageKey, each report overwrites)
+      const totals =
+        runKind === 'workflow'
+          ? stateGlobal.usageAccumulator.getDeltaSinceBaseline()
+          : stateGlobal.usageAccumulator.getTotals();
 
       // Cost is already computed and stored in totals - no need to recompute!
       const cost = totals.totalCost;

--- a/src/agent/utils/UsageMonitor.ts
+++ b/src/agent/utils/UsageMonitor.ts
@@ -123,11 +123,18 @@ export class UsageMonitor {
         cost: Number(cost.toFixed(3)),
       };
 
+      // Workflow sessions: Use per-round elapsed time delta
+      // Tool-use sessions: Use cumulative elapsed time (same storageKey, overwrites)
+      const elapsedTimeMs =
+        runKind === 'workflow'
+          ? stateGlobal.usageAccumulator.getResponseTimeDelta(
+              stateGlobal.totalResponseTimeMs,
+            )
+          : stateGlobal.totalResponseTimeMs;
+
       const payload: ExtendedTokenUsageStats = {
         ...baseStats,
-        elapsedTime: Number(
-          (stateGlobal.totalResponseTimeMs / 1000).toFixed(1),
-        ),
+        elapsedTime: Number((elapsedTimeMs / 1000).toFixed(1)),
         ...(cachingStats && {
           cacheReadInputTokens: totals.totalCacheReadInputTokens,
           ...(this.modelInfo.capabilities.supportsPromptCaching && {

--- a/src/progressView/modules/usageManagers.js
+++ b/src/progressView/modules/usageManagers.js
@@ -65,23 +65,36 @@ export class UsageSummary {
 
   /**
    * Compute total usage for the active session in the active stream.
-   * Each stream tab can have multiple sessions; this returns the current session's total.
+   * Sums usage across all runs (rounds) in the stream.
    * @returns {Object} Total usage with inputTokens, outputTokens, and cost
    */
   computeTotal() {
     const stream = progressViewState.activeStream;
-    const activeRunId = progressViewState.resolveActiveRunId(stream);
-    if (stream && activeRunId) {
-      const usage = progressViewState.getRunUsage(stream, activeRunId);
+    if (!stream) {
+      return { inputTokens: 0, outputTokens: 0, cost: 0 };
+    }
+
+    const usageMap = progressViewState.runUsage.getStreamMap(stream);
+    if (!usageMap || usageMap.size === 0) {
+      return { inputTokens: 0, outputTokens: 0, cost: 0 };
+    }
+
+    let totalInput = 0;
+    let totalOutput = 0;
+    let totalCost = 0;
+
+    for (const usage of usageMap.values()) {
       if (usage) {
-        return {
-          inputTokens: usage.inputTokens || 0,
-          outputTokens: usage.outputTokens || 0,
-          cost: usage.cost || 0,
-        };
+        totalInput += usage.inputTokens || 0;
+        totalOutput += usage.outputTokens || 0;
+        totalCost += usage.cost || 0;
       }
     }
 
-    return { inputTokens: 0, outputTokens: 0, cost: 0 };
+    return {
+      inputTokens: totalInput,
+      outputTokens: totalOutput,
+      cost: totalCost,
+    };
   }
 }

--- a/src/progressView/modules/usageManagers.js
+++ b/src/progressView/modules/usageManagers.js
@@ -85,9 +85,9 @@ export class UsageSummary {
 
     for (const usage of usageMap.values()) {
       if (usage) {
-        totalInput += usage.inputTokens || 0;
-        totalOutput += usage.outputTokens || 0;
-        totalCost += usage.cost || 0;
+        totalInput += usage.inputTokens ?? 0;
+        totalOutput += usage.outputTokens ?? 0;
+        totalCost += usage.cost ?? 0;
       }
     }
 


### PR DESCRIPTION
The computeTotal() method was only returning usage for the active run instead of summing across all runs (rounds) in the session. This caused the "Total usage" footer to show stats from only the last round instead of the cumulative total.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes incorrect "Total usage" by summing across all runs and introduces robust per-round usage accounting for workflow sessions.
> 
> - **Usage accumulation**: Add baselining and delta APIs to `RunUsageAccumulator` (`captureBaseline`, `getDeltaSinceBaseline`, `getResponseTimeDelta`); extend JSON schema with `baselineTotals` and `baselineResponseTimeMs`.
> - **Workflow integration**: Capture baseline at round start in `ResponseCycleNode`; update per-round `storageKey` in `runReflectionFlow` (silent warning) to isolate round usage; propagate `updateStorageKey(key, silent?)` to `executeAgent` and `IdentifierTypes`.
> - **Reporting**: `UsageMonitor` now reports per-round deltas and elapsed time deltas for workflow runs, keeps cumulative reporting for tool-use.
> - **UI**: Progress view `computeTotal()` now sums usage across all runs in the active stream for correct footer totals.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 82b1fd301376980ba82be7f294f8163664f67757. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->