### PR TITLE
Fix debug mode regression for agent

### DIFF
--- a/src/MainViewProvider.ts
+++ b/src/MainViewProvider.ts
@@ -98,6 +98,13 @@ export class MainViewProvider
 
     // Watch for file configuration changes - only refresh file list
     watchConfig(this.context, ['texra.files'], this.refreshFiles.bind(this));
+
+    // Watch for debug mode changes - push to webview immediately
+    watchConfig(
+      this.context,
+      ['texra.logger.debugMode'],
+      this.refreshDebugMode.bind(this),
+    );
   }
 
   private setupAuthListener() {
@@ -169,6 +176,21 @@ export class MainViewProvider
     this._view.webview.postMessage({
       command: MAIN_VIEW_COMMANDS.SET_MODEL_OPTIONS,
       options: modelOptions,
+    });
+  }
+
+  /**
+   * Push debug mode to webview.
+   * Called when debug mode config changes (texra.logger.debugMode).
+   */
+  private refreshDebugMode() {
+    if (!this._view) {
+      return;
+    }
+    const debugMode = getConfig<boolean>('texra.logger.debugMode', false);
+    this._view.webview.postMessage({
+      command: MAIN_VIEW_COMMANDS.DEBUG_MODE_SET,
+      debugMode,
     });
   }
 

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -7,8 +7,9 @@ import type { IRunStorageService } from '@agent/runtime/RunStorageService';
 import { setRunStorageService } from '@agent/runtime/RunStorageService';
 import type { StreamTabId, StorageKey } from '@agent/types/IdentifierTypes';
 import { BaseWebviewProvider } from '@common/webview';
-import { getSharedLocalResourceRoots } from '@common/webview';
+import { getSharedLocalResourceRoots, COMMON_COMMANDS } from '@common/webview';
 import { AgentLogger } from '@logger/AgentLogger';
+import { watchConfig, getConfig } from '@utils/config';
 
 // Local file imports
 import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
@@ -110,6 +111,13 @@ export class ProgressViewProvider
         // Force rebuild after state reload to ensure freshly loaded data is rendered
         this.updateWebview({ forceRebuild: true });
       }),
+    );
+
+    // Watch for debug mode changes - push to webview immediately
+    watchConfig(
+      this.context,
+      ['texra.logger.debugMode'],
+      this.refreshDebugMode.bind(this),
     );
   }
 
@@ -367,5 +375,20 @@ export class ProgressViewProvider
   public setActiveStream(stream: string): void {
     this.state.activeStream = stream;
     this.updateWebview();
+  }
+
+  /**
+   * Push debug mode to webview.
+   * Called when debug mode config changes (texra.logger.debugMode).
+   */
+  private refreshDebugMode(): void {
+    if (!this._view) {
+      return;
+    }
+    const debugMode = getConfig<boolean>('texra.logger.debugMode', false);
+    this._view.webview.postMessage({
+      command: COMMON_COMMANDS.DEBUG_MODE_SET,
+      debugMode,
+    });
   }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Ensures debug mode changes are reflected immediately in both webviews.
> 
> - Add config watchers for `texra.logger.debugMode` in `MainViewProvider` and `ProgressViewProvider`
> - Implement `refreshDebugMode()` in both providers to read `getConfig('texra.logger.debugMode')` and post `DEBUG_MODE_SET` (via `MAIN_VIEW_COMMANDS`/`COMMON_COMMANDS`) to the webviews
> - Update imports in `ProgressViewProvider` to include `COMMON_COMMANDS`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e92f1b0657b2b48d50f25ff78c611b956d2eceb4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->