### PR TITLE
Reduce workflow stage dropdown display text

### DIFF
--- a/src/progressView/modules/uiManagers/RunSelector.js
+++ b/src/progressView/modules/uiManagers/RunSelector.js
@@ -283,11 +283,10 @@ export class RunSelector {
 
   _formatRunLabel(group) {
     const timestamp = this._formatTimestamp(group.startTime);
-    const name = group.name ?? 'Session';
     if (timestamp) {
-      return `${name}: ${timestamp}`;
+      return timestamp;
     }
-    return name;
+    return group.name ?? 'Session';
   }
 
   _formatTimestamp(value) {


### PR DESCRIPTION
Display just the timestamp in the workflow session dropdown instead of "Stage X/Y: timestamp" to save space in the UI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Simplifies run label text in the progress view dropdown to save space.
> 
> - Updates `RunSelector._formatRunLabel` to return only the formatted timestamp when available
> - Falls back to `group.name` or `"Session"` when no valid timestamp exists
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 334cf9deefb4880d98b670c46931d5d8799deba0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->