### PR TITLE
Set up OpenAI API key relay server

### DIFF
--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -478,6 +478,9 @@ class ToolUseProcessNode<C> extends BaseNode<
 
     // Extract response data
     const toolCalls = services.modelHandler.extractToolUse(prepRes.response);
+    services.logger.debug(
+      `[ToolUseProcess] Extracted ${toolCalls.length} tool calls: ${toolCalls.map((c) => c.name).join(', ') || '(none)'}`,
+    );
     const {
       response: text,
       usage,
@@ -838,6 +841,9 @@ class ToolUseDispatchNode<C> extends BaseNode<
       ...(editedFiles.length > 0 && { files: editedFiles }),
       isError: Boolean(result.isError),
     };
+    options.logger.debug(
+      `[ToolUseLog] Emitting TOOL_USE message for tool: ${call.name}`,
+    );
     options.logger.info('', {
       messageType: MESSAGE_TYPES.TOOL_USE,
       data: toolUseLog,
@@ -895,6 +901,9 @@ class ToolUseDispatchNode<C> extends BaseNode<
     const { execResults, assistantText } = execRes;
 
     // Step 1: Log each tool execution and process media files
+    services.logger.debug(
+      `[ToolUseDispatch] Processing ${execResults.length} tool execution results`,
+    );
     for (const execResult of execResults) {
       await this.logAndProcessMediaFiles(execResult, services, workspace);
     }

--- a/src/logger/transports/VSCodeTransport.ts
+++ b/src/logger/transports/VSCodeTransport.ts
@@ -40,6 +40,13 @@ export class VSCodeTransport extends Transport {
     const { level, message, timestamp, messageType, groupId } = info;
     const data = serializeLogData(info.data);
 
+    // Debug logging for tool use messages
+    if (messageType === MESSAGE_TYPES.TOOL_USE) {
+      console.log(
+        `[VSCodeTransport] TOOL_USE message - hasData: ${data !== undefined}, data keys: ${data ? Object.keys(data as object).join(', ') : 'none'}`,
+      );
+    }
+
     this.writeToChannel(level, message, timestamp, data);
     this.emitLogEvent({
       level,


### PR DESCRIPTION
Add debug logging at key points in the tool use flow to identify where tool use data might be getting lost:

- Log number of tool calls extracted from model response
- Log when tool execution results are being processed
- Log when TOOL_USE message is being emitted
- Log in VSCodeTransport when TOOL_USE message arrives with data info

This will help diagnose why tool use information isn't displaying in the progress view for OpenAI models using the relay.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds minimal debug instrumentation to trace tool-use lifecycle and surfaced data.
> 
> - Log extracted tool calls after `extractToolUse` in `ToolUseCycleFlow.ts` (`[ToolUseProcess] ...`)
> - Log per-tool emission before `MESSAGE_TYPES.TOOL_USE` is sent (`[ToolUseLog] ...`)
> - Log count of tool execution results before follow-up processing (`[ToolUseDispatch] ...`)
> - In `VSCodeTransport.ts`, log when a `TOOL_USE` message is received and list data presence/keys
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3d95a50d4240876374fc8a436e78f3523b16df4f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->