### PR TITLE
Restore detailed session header information

### DIFF
--- a/src/logger/LogTypes.ts
+++ b/src/logger/LogTypes.ts
@@ -26,6 +26,10 @@ export const TaskGroupSchema = z.strictObject({
   status: TaskGroupStatusSchema,
   /** Parent group ID for nested groups */
   parentGroupId: z.string().optional(),
+  /** Model identifier (enriched from taskState) */
+  model: z.string().optional(),
+  /** Agent identifier (enriched from taskState) */
+  agent: z.string().optional(),
 });
 
 export type TaskGroup = z.infer<typeof TaskGroupSchema>;

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -222,11 +222,19 @@ export class ProgressEventHandler {
         const { stream, ...group } = data;
         const { id, parentGroupId } = group;
 
+        // Enrich group with model/agent info from taskState for display
+        const taskState = this.state.getTaskState(stream);
+        const enrichedGroup: TaskGroup = {
+          ...group,
+          model: taskState?.agentConfig?.model,
+          agent: taskState?.agentConfig?.agent,
+        };
+
         const hasStream = this.state.streamTabs.has(stream);
         const addGroupPromise = this.state.taskGroups.addGroup(
           stream,
           id,
-          group,
+          enrichedGroup,
         );
 
         if (!parentGroupId) {
@@ -244,9 +252,9 @@ export class ProgressEventHandler {
           this.webviewUpdater.isAvailable() &&
           stream === this.state.activeStream
         ) {
-          this.webviewUpdater.addTaskGroup(stream, group);
+          this.webviewUpdater.addTaskGroup(stream, enrichedGroup);
         } else {
-          this.bufferTaskGroupForReplay(stream, group);
+          this.bufferTaskGroupForReplay(stream, enrichedGroup);
         }
 
         await addGroupPromise;

--- a/src/progressView/modules/uiManagers/RunSelector.js
+++ b/src/progressView/modules/uiManagers/RunSelector.js
@@ -139,6 +139,8 @@ export class RunSelector {
       id: group.id,
       name: group.name,
       startTime: group.startTime,
+      model: group.model,
+      agent: group.agent,
     });
 
     if (this._ensureDropdown()) {
@@ -156,6 +158,8 @@ export class RunSelector {
           id: group.id,
           name: group.name,
           startTime: group.startTime,
+          model: group.model,
+          agent: group.agent,
         });
       }
     });

--- a/src/progressView/modules/uiManagers/StreamTabs.js
+++ b/src/progressView/modules/uiManagers/StreamTabs.js
@@ -74,7 +74,18 @@ export class StreamTabs {
     );
     if (streamNameElem) {
       const label = activeInfo?.label || '';
-      streamNameElem.textContent = label;
+      const model = activeInfo?.model || '';
+      const agent = activeInfo?.agent || '';
+      // Build header: label · agent · model (skip duplicates)
+      const parts = [label];
+      // Only add agent if different from label (label may already contain agent name)
+      if (agent && !label.toLowerCase().startsWith(agent.toLowerCase())) {
+        parts.push(agent);
+      }
+      if (model) {
+        parts.push(model);
+      }
+      streamNameElem.textContent = parts.join(' · ');
       streamNameElem.title = activeInfo
         ? this._buildActiveTitle(activeInfo)
         : '';


### PR DESCRIPTION
Display model identifier alongside timestamp in the run selector dropdown (e.g., "gpt52 Jan 06, 23:12:41") to restore session details that were previously simplified. This enriches task groups with model/agent info from taskState during progress event handling.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enhances task group metadata and UI to surface model/agent details.
> 
> - Adds optional `model` and `agent` fields to `TaskGroupSchema` in `LogTypes.ts`
> - Enriches task groups with `model`/`agent` from `taskState` in `ProgressEventHandler.handleAddTaskGroup`, and propagates to state, webview, and replay buffer
> - `RunSelector` now stores `model` and `agent` for runs (used when rendering options)
> - `StreamTabs` updates active stream header to display `label · agent · model`, avoiding duplicate agent/label prefixes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 02d92485cad47bc57231b7cc96319a4df78cf2fb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->