### PR TITLE
fix: compact OpenAI responses only near token limit

### DIFF
--- a/docs/guide/models.md
+++ b/docs/guide/models.md
@@ -274,4 +274,3 @@ Configure streaming in VS Code Settings:
 
 - [Built-in Agents](./built-in-agents.md): See which agents work well with different models.
 - [Configuration](./configuration.md): Learn about other model-related settings like streaming.
-- [OpenAI Responses API](./openai-responses-api.md): Overview of the new API used when `useOpenAIResponsesAPI` is enabled.

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -176,6 +176,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
 
   private static readonly BACKGROUND_POLL_INTERVAL_MS = 15000;
   private static readonly BACKGROUND_MAX_DURATION_MS = 3 * 60 * 60 * 1000; // 3 hours
+  private static readonly COMPACTION_TOKEN_THRESHOLD = 0.85;
   /** Statuses indicating the background response is still processing. */
   private static readonly BACKGROUND_PENDING_STATUSES: readonly ResponseStatus[] =
     ['queued', 'in_progress'];
@@ -184,6 +185,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     ['completed', 'failed', 'cancelled', 'incomplete'];
   private previousResponseId: string | null = null;
   private sentMessages = 0;
+  private lastResponseTotalTokens = 0;
 
   /**
    * Manually set the previous response ID to resume a conversation.
@@ -192,6 +194,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
   setPreviousResponseId(id: string | null): void {
     this.previousResponseId = id;
     this.sentMessages = 0;
+    this.lastResponseTotalTokens = 0;
   }
 
   /** Retrieve the stored previous response ID. */
@@ -223,6 +226,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
   ): Promise<ResponseInputItem[]> {
     this.previousResponseId = null;
     this.sentMessages = 0;
+    this.lastResponseTotalTokens = 0;
 
     const messages: ResponseInputItem[] = [];
 
@@ -487,6 +491,57 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     }
   }
 
+  private shouldCompactConversation(): boolean {
+    const contextWindow = this.config.contextWindow;
+    if (contextWindow <= 0) {
+      return false;
+    }
+
+    return (
+      !this.isOpenRouterRoutingEnabled() &&
+      this.previousResponseId !== null &&
+      this.lastResponseTotalTokens / contextWindow >=
+        ModelHandlerOpenAIResponse.COMPACTION_TOKEN_THRESHOLD
+    );
+  }
+
+  private async compactConversation(
+    client: OpenAI,
+    systemPrompt: string | undefined,
+    signal: AbortSignal | undefined,
+  ): Promise<void> {
+    if (!this.previousResponseId) {
+      return;
+    }
+
+    this.logger.debug('Compacting OpenAI Responses conversation context.', {
+      data: {
+        model: this.config.fullName,
+        previousResponseId: this.previousResponseId,
+      },
+    });
+
+    const compacted = await executeRequest(
+      {
+        model: this.config.name,
+        operation: 'openai.responses.compact',
+        signal,
+      },
+      () =>
+        client.responses.compact(
+          {
+            model: this.config.fullName,
+            previous_response_id: this.previousResponseId,
+            instructions: systemPrompt,
+          },
+          { signal },
+        ),
+    );
+
+    this.previousResponseId = compacted.id;
+    this.lastResponseTotalTokens = 0;
+  }
+
   /**
    * Create a response using the Responses API.
    * The handler submits only the messages that were not part of the previous
@@ -520,6 +575,10 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     const useBackgroundResponses =
       this.backgroundModeSupported && backgroundToggleEnabled && isEligible;
     const useStreaming = streamingToggleEnabled && !useBackgroundResponses;
+
+    if (this.shouldCompactConversation()) {
+      await this.compactConversation(client, systemPrompt, signal);
+    }
 
     if (streamingToggleEnabled && useBackgroundResponses) {
       this.logger.debug(
@@ -672,6 +731,11 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
 
       this.previousResponseId = response.id;
       this.sentMessages = messages.length;
+      const responseUsage = response.usage;
+      this.lastResponseTotalTokens =
+        responseUsage?.total_tokens ??
+        (responseUsage?.input_tokens ?? 0) +
+          (responseUsage?.output_tokens ?? 0);
       return response;
     }
 
@@ -716,6 +780,10 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     }
     this.previousResponseId = response.id;
     this.sentMessages = messages.length;
+    const responseUsage = response.usage;
+    this.lastResponseTotalTokens =
+      responseUsage?.total_tokens ??
+      (responseUsage?.input_tokens ?? 0) + (responseUsage?.output_tokens ?? 0);
     return response;
   }
 


### PR DESCRIPTION
### Motivation
- Reduce unnecessary calls to OpenAI Responses `compact` by only compacting when conversation token usage is close to the model context window.
- Replace the previous rounds-based compaction heuristic with a token-usage based gate to honor the request to "Only do this when token consumption is close to the limit." 
- Keep compaction bookkeeping reset behavior on session starts or manual `previous_response_id` resets.

### Description
- Replace `COMPACTION_ROUND_INTERVAL`/`roundsSinceCompaction` with `COMPACTION_TOKEN_THRESHOLD` and `lastResponseTotalTokens` in `src/agent/modelHandlers/modelHandlerOpenAIResponse.ts`.
- Implement `shouldCompactConversation()` to compare `lastResponseTotalTokens / contextWindow` against `COMPACTION_TOKEN_THRESHOLD` and call `compactConversation()` only when threshold is reached.
- Track the last response token counts from `response.usage` (prefer `total_tokens`, fall back to `input_tokens + output_tokens`) and reset `lastResponseTotalTokens` on compaction and session initialization.
- Invoke compaction before issuing a new Responses API call and set `previousResponseId` and `sentMessages` as before for both streaming and non-streaming code paths.

### Testing
- Ran `npm run format` and it completed successfully.
- Ran `npm run compile` and compilation finished with a single warning about a dynamic `nunjucks` dependency.
- Ran `npm run lint` and it completed with existing warnings related to `eqeqeq` and `import/order` rules.
- No new unit or integration tests were added for the compaction flow in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e6abf8acc8324863684e2e2660de9)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements token-based compaction for OpenAI Responses and updates docs.
> 
> - Add `COMPACTION_TOKEN_THRESHOLD` (0.85) and track `lastResponseTotalTokens`; reset on session/init (`setPreviousResponseId`, `initializeMessages`)
> - New `shouldCompactConversation()` and `compactConversation()`; compaction runs only when `previous_response_id` exists, OpenRouter routing is off, and `lastResponseTotalTokens / contextWindow` ≥ threshold
> - Capture token usage from `response.usage` (prefer `total_tokens`, fallback to `input_tokens + output_tokens`) in both streaming and non-streaming paths
> - Invoke compaction before creating a new response; maintain `previousResponseId`/`sentMessages` bookkeeping
> - Docs: remove outdated `OpenAI Responses API` link in `docs/guide/models.md`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 56ed03121764710fa331723225c2f4180c67e94c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->