### PR TITLE
fix: emit/update progress entries for tool use and web search

### DIFF
--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -763,6 +763,19 @@ class ToolUseDispatchNode<C> extends BaseNode<
     let result: ToolResult;
     const parsedInput = parseToolInput(call.input, call.callId, options.logger);
 
+    if (!options.modelHandler.getStreamingConfig()) {
+      options.logger.emitLogMessage({
+        id: call.callId,
+        messageType: MESSAGE_TYPES.TOOL_USE,
+        data: {
+          toolName: call.name,
+          input: parsedInput ?? call.raw,
+          status: 'started',
+          callId: call.callId,
+        },
+      });
+    }
+
     if (!tool) {
       result = {
         error: `Unknown tool ${call.name}`,
@@ -836,11 +849,14 @@ class ToolUseDispatchNode<C> extends BaseNode<
       input: parsedInput ?? call.raw,
       output: sanitizedOutput,
       ...(editedFiles.length > 0 && { files: editedFiles }),
+      status: result.isError ? 'failed' : 'completed',
       isError: Boolean(result.isError),
     };
-    options.logger.info('', {
+    options.logger.emitLogMessage({
+      id: call.callId,
       messageType: MESSAGE_TYPES.TOOL_USE,
       data: toolUseLog,
+      update: true,
     });
 
     if (result.files && result.files.length > 0) {

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -209,13 +209,20 @@ export abstract class ModelHandler<
    * This allows search results to appear in correct order based on when
    * they occurred in the response, rather than being logged after streaming.
    */
-  protected emitWebSearchResult(result: WebSearchResult): void {
+  protected emitWebSearchResult(
+    result: WebSearchResult,
+    options: { update?: boolean } = {},
+  ): void {
     if (!this.progressViewEnabled) {
       return;
     }
-    this.logger.info('', {
+    const logId = result.callId ?? `${Date.now()}`;
+    const shouldUpdate = (options.update ?? false) && Boolean(result.callId);
+    this.logger.emitLogMessage({
+      id: logId,
       messageType: MESSAGE_TYPES.WEB_SEARCH,
       data: result,
+      update: shouldUpdate,
     });
   }
 

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -45,7 +45,9 @@ import {
   getSdkErrorMessage,
   isContextWindowError,
 } from '@common/errors/sdkErrorUtils';
+// Local imports - logging
 import { AgentLogger } from '@logger/AgentLogger';
+import { MESSAGE_TYPES } from '@logger/messageTypes';
 
 import { ReasoningEffort } from '@model/ModelConfig';
 
@@ -530,6 +532,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
           ? this.createOutputStream()
           : undefined;
 
+        const startedToolCalls = new Set<string>();
         let baseResponse: GenerateContentResponse | undefined;
         let latestCandidate:
           | NonNullable<GenerateContentResponse['candidates']>[number]
@@ -546,6 +549,26 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
             const parts = candidate.content?.parts ?? [];
             aggregatedParts.push(...parts);
             for (const part of parts) {
+              const functionCall = (part as { functionCall?: FunctionCall })
+                .functionCall;
+              if (functionCall?.name) {
+                const callId =
+                  functionCall.id ??
+                  `${functionCall.name}:${startedToolCalls.size}`;
+                if (!startedToolCalls.has(callId)) {
+                  startedToolCalls.add(callId);
+                  this.logger.emitLogMessage({
+                    id: callId,
+                    messageType: MESSAGE_TYPES.TOOL_USE,
+                    data: {
+                      toolName: functionCall.name,
+                      input: functionCall.args,
+                      status: 'started',
+                      callId,
+                    },
+                  });
+                }
+              }
               if (part.thought && isTextPart(part)) {
                 thinking.append(part.text);
               }
@@ -1229,9 +1252,9 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
       return [];
     }
 
-    return functionCalls.map(({ call, thoughtSignature }) => ({
+    return functionCalls.map(({ call, thoughtSignature }, index) => ({
       provider: 'google',
-      callId: call.id ?? randomUUID(),
+      callId: call.id ?? `${call.name}:${index}`,
       name: call.name!,
       input: call.args,
       raw: call,

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -36,6 +36,8 @@ import {
   isContextWindowError,
   isMissingFinishReasonError,
 } from '@common/errors/sdkErrorUtils';
+// Local imports - logging
+import { MESSAGE_TYPES } from '@logger/messageTypes';
 
 // Type imports
 import type { ToolDefinition } from '@model';
@@ -319,6 +321,7 @@ export class ModelHandlerOpenAI<
           signal,
         });
         const streamingAggregator = this.createStreamingAggregator();
+        const startedToolCalls = new Set<number>();
 
         const onContentDelta = ({ delta }: ContentDeltaEvent): void => {
           if (!delta) {
@@ -334,6 +337,32 @@ export class ModelHandlerOpenAI<
           if (reasoningDelta) {
             thinking.append(reasoningDelta);
             streamingAggregator?.appendReasoning(reasoningDelta);
+          }
+
+          const toolCalls = chunk.choices[0]?.delta?.tool_calls;
+          if (!Array.isArray(toolCalls)) {
+            return;
+          }
+
+          for (const call of toolCalls) {
+            if (!call.function?.name) {
+              continue;
+            }
+            if (startedToolCalls.has(call.index)) {
+              continue;
+            }
+            startedToolCalls.add(call.index);
+            const callId = call.id || `tool_call_${call.index}`;
+            this.logger.emitLogMessage({
+              id: callId,
+              messageType: MESSAGE_TYPES.TOOL_USE,
+              data: {
+                toolName: call.function.name,
+                input: call.function.arguments,
+                status: 'started',
+                callId,
+              },
+            });
           }
         };
 

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -88,6 +88,7 @@ import type {
   ResponseReasoningSummaryTextDeltaEvent,
   ResponseOutputItemDoneEvent,
   ResponseWebSearchCallInProgressEvent,
+  ResponseWebSearchCallSearchingEvent,
 } from 'openai/resources/responses/responses';
 
 interface UploadedOpenAIResponseAttachment {
@@ -621,6 +622,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
           ? this.createOutputStream()
           : null,
         emittedWebSearchIds: new Set<string>(),
+        inProgressWebSearchIds: new Set<string>(),
         hasThinkingContent: false,
       };
 
@@ -630,7 +632,14 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
           state.hasThinkingContent = true;
         } else if (this.isTextDeltaEvent(event)) {
           state.outputStream?.append(event.delta);
-        } else if (this.isWebSearchInProgressEvent(event)) {
+        } else if (
+          this.isWebSearchInProgressEvent(event) ||
+          this.isWebSearchSearchingEvent(event)
+        ) {
+          if (!state.inProgressWebSearchIds.has(event.item_id)) {
+            this.emitOpenAIWebSearchInProgress(event.item_id);
+            state.inProgressWebSearchIds.add(event.item_id);
+          }
           // Web search starting - finalize current thinking stream
           // Don't emit placeholder here - wait for output_item.done with full data
           if (state.hasThinkingContent) {
@@ -653,7 +662,9 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
               state.hasThinkingContent = false;
               state.thinkingStream = this.createThinkingStream();
             }
-            this.emitOpenAIWebSearch(item);
+            this.emitOpenAIWebSearch(item, {
+              update: state.inProgressWebSearchIds.has(item.id),
+            });
             state.emittedWebSearchIds.add(item.id);
           }
         }
@@ -668,7 +679,11 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       if (state.outputStream) state.outputStream.finalize(finalText);
 
       // Emit any web searches not yet emitted (fallback for edge cases)
-      this.emitWebSearchesFromResponse(response, state.emittedWebSearchIds);
+      this.emitWebSearchesFromResponse(
+        response,
+        state.emittedWebSearchIds,
+        state.inProgressWebSearchIds,
+      );
 
       this.previousResponseId = response.id;
       this.sentMessages = messages.length;
@@ -1609,6 +1624,13 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     return event.type === 'response.web_search_call.in_progress';
   }
 
+  /** Type guard for web search searching events. */
+  private isWebSearchSearchingEvent(
+    event: ResponseStreamEvent,
+  ): event is ResponseWebSearchCallSearchingEvent {
+    return event.type === 'response.web_search_call.searching';
+  }
+
   /** Type guard for text output delta events. */
   private isTextDeltaEvent(
     event: ResponseStreamEvent,
@@ -1634,8 +1656,21 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
    * Emit web search result to progress view during streaming.
    * Uses shared helper for consistent WebSearchResult construction.
    */
-  private emitOpenAIWebSearch(item: ResponseFunctionWebSearch): void {
-    this.emitWebSearchResult(buildOpenAIWebSearchResult(item));
+  private emitOpenAIWebSearch(
+    item: ResponseFunctionWebSearch,
+    options: { update?: boolean } = {},
+  ): void {
+    this.emitWebSearchResult(buildOpenAIWebSearchResult(item), options);
+  }
+
+  private emitOpenAIWebSearchInProgress(callId: string): void {
+    this.emitWebSearchResult({
+      query: '',
+      results: [],
+      provider: 'openai',
+      callId,
+      status: 'in_progress',
+    });
   }
 
   /**
@@ -1652,6 +1687,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
   private emitWebSearchesFromResponse(
     response: Response,
     alreadyEmitted: Set<string>,
+    inProgressIds: Set<string>,
   ): void {
     const output = response?.output;
     if (!Array.isArray(output)) {
@@ -1664,7 +1700,9 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         !alreadyEmitted.has(item.id) &&
         hasOpenAIWebSearchData(item)
       ) {
-        this.emitOpenAIWebSearch(item);
+        this.emitOpenAIWebSearch(item, {
+          update: inProgressIds.has(item.id),
+        });
         alreadyEmitted.add(item.id);
       }
     }

--- a/src/agent/modelHandlers/support/AnthropicStreamHandler.ts
+++ b/src/agent/modelHandlers/support/AnthropicStreamHandler.ts
@@ -2,17 +2,21 @@
  * Dedicated stream handler for Anthropic responses.
  * Encapsulates the streaming event handling logic for improved testability and readability.
  */
+// Local imports - tool handling
 import {
   extractDomain,
   type WebSearchResult,
   type WebSearchResultEntry,
 } from '@agent/modelHandlers/types/ServerToolTypes';
+// Local imports - logging
 import { MESSAGE_TYPES } from '@logger/messageTypes';
 import type { AgentLogger } from '@logger/AgentLogger';
 
+// Third-party imports
 import type { BetaRawMessageStreamEvent } from '@anthropic-ai/sdk/resources/beta/messages';
 import type {
   ServerToolUseBlock,
+  ToolUseBlock,
   WebSearchToolResultBlock,
   WebSearchResultBlock,
 } from '@anthropic-ai/sdk/resources/messages';
@@ -191,11 +195,26 @@ export class AnthropicStreamHandler {
       // Track web search server tool use to get query
       const block = event.content_block as ServerToolUseBlock;
       if (block.name === 'web_search') {
+        const input = block.input as { query?: string } | undefined;
+        this.emitWebSearchResult(
+          {
+            query: input?.query ?? '',
+            results: [],
+            provider: 'anthropic',
+            callId: block.id,
+            status: 'in_progress',
+          },
+          { update: false },
+        );
         this.state.pendingSearches.set(block.id, {
           index: blockIndex,
           input: '',
         });
       }
+      // Finalize any pending text stream
+      this.finalizeOutputStream();
+    } else if (blockType === 'tool_use') {
+      this.emitToolUseStart(event.content_block as ToolUseBlock);
       // Finalize any pending text stream
       this.finalizeOutputStream();
     } else if (blockType === 'web_search_tool_result') {
@@ -268,13 +287,16 @@ export class AnthropicStreamHandler {
 
     // Emit to progress view
     if (entries.length > 0 || query) {
-      this.emitWebSearchResult({
-        query,
-        results: entries,
-        provider: 'anthropic',
-        callId: block.tool_use_id,
-        status: 'completed',
-      });
+      this.emitWebSearchResult(
+        {
+          query,
+          results: entries,
+          provider: 'anthropic',
+          callId: block.tool_use_id,
+          status: 'completed',
+        },
+        { update: true },
+      );
       this.state.emittedSearchIds.add(block.tool_use_id);
     }
 
@@ -342,13 +364,35 @@ export class AnthropicStreamHandler {
   /**
    * Emits a web search result to the progress view.
    */
-  private emitWebSearchResult(result: WebSearchResult): void {
+  private emitWebSearchResult(
+    result: WebSearchResult,
+    options: { update: boolean },
+  ): void {
     if (!this.config.progressViewEnabled) {
       return;
     }
-    this.logger.info('', {
+    const logId = result.callId ?? `${Date.now()}`;
+    this.logger.emitLogMessage({
+      id: logId,
       messageType: MESSAGE_TYPES.WEB_SEARCH,
       data: result,
+      update: options.update,
+    });
+  }
+
+  private emitToolUseStart(block: ToolUseBlock): void {
+    if (!this.config.progressViewEnabled) {
+      return;
+    }
+    this.logger.emitLogMessage({
+      id: block.id,
+      messageType: MESSAGE_TYPES.TOOL_USE,
+      data: {
+        toolName: block.name,
+        input: block.input,
+        status: 'started',
+        callId: block.id,
+      },
     });
   }
 }

--- a/src/logger/AgentLogger.ts
+++ b/src/logger/AgentLogger.ts
@@ -226,6 +226,59 @@ export class AgentLogger {
     });
   }
 
+  emitLogMessage(options: {
+    id: string;
+    messageType: MessageType;
+    data?: unknown;
+    text?: string;
+    level?: 'debug' | 'info' | 'warn' | 'error';
+    groupId?: string;
+    update?: boolean;
+  }): void {
+    const {
+      id,
+      messageType,
+      data,
+      text = '',
+      level = 'info',
+      update = false,
+    } = options;
+    const groupId = options.groupId ?? this.resolveActiveGroupId();
+
+    const { shouldEmit, debugMode } = getEmitFilter({ level, messageType });
+    if (!shouldEmit) {
+      return;
+    }
+
+    if (update) {
+      bus.emit('updateLogMessage', {
+        stream: this.channelId,
+        logMessage: {
+          id,
+          text,
+          groupId,
+          messageType,
+          data,
+        },
+      });
+      return;
+    }
+
+    bus.emit('addLogMessage', {
+      stream: this.channelId,
+      logMessage: {
+        id,
+        text,
+        level,
+        timestamp: Date.now(),
+        groupId,
+        messageType,
+        verbose: debugMode,
+        data,
+      },
+    });
+  }
+
   /**
    * Log a structured error with consistent formatting.
    * Single source of truth for ERROR message type logging.

--- a/src/progressView/modules/formatters/logFormatters/toolFormatters.js
+++ b/src/progressView/modules/formatters/logFormatters/toolFormatters.js
@@ -55,7 +55,9 @@ export const formatToolUse = (normalizedPayload, logId, groupId, timestamp) => {
     return null;
   }
 
-  const { parsed, toolName, errorText, outputText, input } = normalizedToolLog;
+  const { parsed, toolName, errorText, outputText, input, status } =
+    normalizedToolLog;
+  const isStarting = status === 'started' || status === 'in_progress';
 
   // Use tool-specific icon
   const iconClass = getToolIconClass(toolName, normalizedToolLog.isError);
@@ -68,9 +70,15 @@ export const formatToolUse = (normalizedPayload, logId, groupId, timestamp) => {
   // Build title
   const titlePrefix = normalizedToolLog.isError ? 'Tool Error' : 'Tool Use';
   const titleBase = toolName ? `${titlePrefix}: ${toolName}` : titlePrefix;
+  const statusSuffix =
+    status === 'started' || status === 'in_progress'
+      ? ' (starting...)'
+      : status === 'failed'
+        ? ' (failed)'
+        : '';
   const titleText = normalizedToolLog.headerSummary
-    ? `${titleBase} — ${normalizedToolLog.headerSummary}`
-    : titleBase;
+    ? `${titleBase}${statusSuffix} — ${normalizedToolLog.headerSummary}`
+    : `${titleBase}${statusSuffix}`;
 
   if (headerLabel) {
     headerLabel.textContent = titleText;
@@ -78,6 +86,9 @@ export const formatToolUse = (normalizedPayload, logId, groupId, timestamp) => {
 
   // Icon already set in createToolElement; just toggle error state
   element.classList.toggle('tool-use-error', normalizedToolLog.isError);
+  if (iconElem) {
+    iconElem.className = `codicon ${iconClass}${isStarting ? ' spin' : ''}`;
+  }
 
   if (!contentElem) {
     return element;

--- a/src/progressView/modules/formatters/normalizers.js
+++ b/src/progressView/modules/formatters/normalizers.js
@@ -161,6 +161,11 @@ export const normalizeToolUseLog = (structured) => {
       ? parsed.output
       : {};
 
+  const status =
+    (typeof parsed.status === 'string' && parsed.status.trim()) ||
+    (typeof outputDetails.status === 'string' && outputDetails.status.trim()) ||
+    '';
+
   const summaryText =
     (typeof parsed.summary === 'string' && parsed.summary.trim()) ||
     (typeof outputDetails.summary === 'string' &&
@@ -208,6 +213,7 @@ export const normalizeToolUseLog = (structured) => {
     errorText,
     outputText,
     input: parsed.input,
+    status,
     isError: Boolean(
       parsed.isError || outputDetails.isError || errorText.length > 0,
     ),


### PR DESCRIPTION
### Motivation
- Surface in-progress tool and web-search activity in the progress view so entries can show a `started`/`in_progress` state before completion. 
- Ensure later stream events update the same progress entry (instead of creating duplicates) so the UI shows a single lifecycle per call. 
- Provide a single helper API for emitting and updating progress entries by ID to centralize filtering and payload shape. 
- Keep existing completion/error logs while enabling minimal streaming hooks for smoother UX.

### Description
- Add `AgentLogger.emitLogMessage` to emit `addLogMessage` or `updateLogMessage` events by `id` with filtering via `getEmitFilter` and a simple `update` flag. 
- Emit `TOOL_USE` "started" events from streaming handlers (`modelHandlerOpenAI`, `modelHandlerGoogleGenAI`, and `AnthropicStreamHandler`) using stable/fallback `callId`s and dedupe with a `startedToolCalls` set, and update final tool logs via `emitLogMessage` with `update: true`. 
- Emit `WEB_SEARCH` in-progress and completed events during streaming by updating `ModelHandler.emitWebSearchResult` (now accepts `options.update`) and by extending OpenAI Responses handler to recognize `searching`/`in_progress` events and track `inProgressWebSearchIds`. 
- Update progress-view normalization/formatting to include `status` (via `normalizeToolUseLog`) and rendering tweaks in `formatToolUse` to show a spinner class for starting/in-progress status and a status-aware title suffix.

### Testing
- Ran `npm run format` which completed successfully. 
- Ran `npm run compile` (webpack) which completed successfully with a single non-blocking nunjucks warning. 
- Ran `npm run lint` which finished successfully and reported only existing lint warnings (no new errors). 
- Manual/UI verification of progress view entries requires the VS Code webview to observe in-place updates and spinner behavior (not covered by CI).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f3957d204832497b114c1d72fdfd4)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves progress view fidelity by showing a single lifecycle per tool/web-search call with in-progress updates and final results.
> 
> - Adds `AgentLogger.emitLogMessage({ id, messageType, data, update })` to emit or update log entries by ID (centralized filtering)
> - Emits `TOOL_USE` "started" during streaming in OpenAI, Google GenAI, and Anthropic handlers; non-streaming path logs "started" in `ToolUseCycleFlow` and updates to "completed/failed"
> - Extends `ModelHandler.emitWebSearchResult(result, { update })`; OpenAI Responses now emits `web_search` in-progress (`searching`/`in_progress`) and updates on completion; Anthropic emits in-progress and updates results
> - Stabilizes IDs for tool calls/web searches (e.g., Google: `name:index`, OpenAI: chunk `id`/index; dedup via `startedToolCalls`)
> - Progress view normalizers/formatters include `status`, add spinner for starting/in-progress, and status-aware title suffix
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 136681354846d9f157fe8b96e97fa743b0e1102f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->