### PR TITLE
refactor: unify agent flow execution lifecycle

### DIFF
--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -62,7 +62,6 @@ import { MAIN_VIEW_COMMANDS } from '@common/webview/commands';
 import { toErrorMessage } from '@common/errors/errorHandlingUtils';
 import { getSdkErrorMessage } from '@common/errors/sdkErrorUtils';
 import { showInstructionWithSuppress } from '@frontend/ui/instruction';
-import { showErrorMessage } from '@frontend/ui/messageUtils';
 import { getMainWebview } from '@frontend/system/commandUtils';
 import type { AgentLogStage } from '@logger/AgentLogger';
 import { AgentLogger } from '@logger/AgentLogger';
@@ -402,6 +401,26 @@ function updateFlowStatus(
   }
 }
 
+type FlowRunner = () => Promise<EndGroupStatus>;
+
+async function runFlowWithLifecycle(
+  ctx: ResolvedAgentBase,
+  streamTabId: StreamTabId,
+  agentName: string,
+  runner: FlowRunner,
+): Promise<void> {
+  try {
+    const flowStatus = await runner();
+    ctx.runStage.end(flowStatus);
+    updateFlowStatus(streamTabId, flowStatus);
+    logger.debug(`Task completed with status: ${flowStatus}`);
+  } catch (error) {
+    ctx.runStage.end(END_GROUP_STATUS.ERROR);
+    StreamStatusService.set(streamTabId, STREAM_STATUS.ERROR);
+    await handleFlowError(error, agentName, ctx.logger);
+  }
+}
+
 // ============================================================================
 // UI and Error Handling
 // ============================================================================
@@ -474,7 +493,6 @@ async function logFlowError(
 async function handleFlowError(
   err: unknown,
   agentName: string,
-  streamId: StreamTabId,
   agentLogger: AgentLogger,
 ): Promise<never> {
   const rawMsg = toErrorMessage(err);
@@ -523,12 +541,12 @@ export async function executeAgent(
   } catch (err) {
     // Show error to user unless it's a ZodError (handled by executeCommand.ts)
     if (!(err instanceof ZodError)) {
-      void showErrorMessage(toErrorMessage(err));
+      void vscode.window.showErrorMessage(toErrorMessage(err));
     }
     throw err;
   }
 
-  const { setting, streamId: streamTabId, config, logger: agentLogger } = ctx;
+  const { setting, streamId: streamTabId, config } = ctx;
   const agentName = config.agent;
 
   if (!config.session) {
@@ -543,7 +561,7 @@ export async function executeAgent(
     );
   }
 
-  try {
+  await runFlowWithLifecycle(ctx, streamTabId, agentName, async () => {
     if (executionId) await ensureRunDir(executionId);
 
     const runStorage = getRunStorageService();
@@ -586,11 +604,10 @@ export async function executeAgent(
     }
 
     // Execute the appropriate flow based on agent type
-    await logger.withScope(`Task: ${agentName}@${config.model}`, async () => {
+    return logger.withScope(`Task: ${agentName}@${config.model}`, async () => {
       logger.info(`Executing ${agentName} with model ${config.model}`);
 
       const interruptManager = new InterruptManager();
-      let flowStatus: EndGroupStatus;
 
       if (setting.agentType === 'toolUse') {
         // Tool-use flow execution
@@ -600,32 +617,21 @@ export async function executeAgent(
           getUsageRecorder: createUsageRecorder(ctx.usageMonitor, 'tool-use'),
           setting: ctx.setting as AgentToolUseSetting,
         });
-        flowStatus = result.status;
-      } else {
-        // Reflection flow execution (direct/CoT/workflow)
-        // Pass runStage as parentStage so r0, r1 become children of it
-        const result = await runReflectionFlow({
-          ...ctx,
-          ...interruptManager.asFlowInput(),
-          getUsageRecorder: createUsageRecorder(ctx.usageMonitor, 'workflow'),
-          setting: ctx.setting as AgentWorkflowSetting,
-          parentStage: ctx.runStage,
-        });
-        flowStatus = result.status;
+        return result.status;
       }
 
-      // End the runStage since we created it in resolveAgentBase
-      // (runReflectionFlow won't end it when parentStage is provided)
-      ctx.runStage.end(flowStatus);
-      updateFlowStatus(streamTabId, flowStatus);
-      logger.debug(`Task completed with status: ${flowStatus}`);
+      // Reflection flow execution (direct/CoT/workflow)
+      // Pass runStage as parentStage so r0, r1 become children of it
+      const result = await runReflectionFlow({
+        ...ctx,
+        ...interruptManager.asFlowInput(),
+        getUsageRecorder: createUsageRecorder(ctx.usageMonitor, 'workflow'),
+        setting: ctx.setting as AgentWorkflowSetting,
+        parentStage: ctx.runStage,
+      });
+      return result.status;
     });
-  } catch (err) {
-    // End the runStage with error status on exception
-    ctx.runStage.end(END_GROUP_STATUS.ERROR);
-    StreamStatusService.set(streamTabId, STREAM_STATUS.ERROR);
-    await handleFlowError(err, agentName, streamTabId, agentLogger);
-  }
+  });
 }
 
 /**
@@ -647,12 +653,7 @@ export async function executeMergeAgent(
     editedFile,
   });
 
-  const {
-    streamId: streamTabId,
-    config,
-    logger: agentLogger,
-    executionId,
-  } = ctx;
+  const { streamId: streamTabId, config, executionId } = ctx;
 
   if (!config.session) {
     throw new Error('Merge agent configuration is missing session metadata.');
@@ -666,10 +667,10 @@ export async function executeMergeAgent(
     );
   }
 
-  try {
+  await runFlowWithLifecycle(ctx, streamTabId, 'merge', async () => {
     setupFlowUIState(ctx);
 
-    await logger.withScope(`Task: merge@${model}`, async () => {
+    return logger.withScope(`Task: merge@${model}`, async () => {
       logger.info(`Executing merge with model ${model}`);
 
       const interruptManager = new InterruptManager();
@@ -693,17 +694,9 @@ export async function executeMergeAgent(
         parentStage: ctx.runStage,
       });
 
-      // End the runStage since we created it in resolveAgentBase
-      ctx.runStage.end(result.status);
-      updateFlowStatus(streamTabId, result.status);
-      logger.debug(`Task completed with status: ${result.status}`);
+      return result.status;
     });
-  } catch (err) {
-    // End the runStage with error status on exception
-    ctx.runStage.end(END_GROUP_STATUS.ERROR);
-    StreamStatusService.set(streamTabId, STREAM_STATUS.ERROR);
-    await handleFlowError(err, 'merge', streamTabId, agentLogger);
-  }
+  });
 }
 
 // ============================================================================
@@ -736,7 +729,7 @@ export async function resumeToolUseFromSnapshot(
     executionId,
     { streamTabIdOverride: snapshot.streamId as StreamTabId },
   );
-  const { setting, streamId: streamTabId, config, logger: agentLogger } = ctx;
+  const { setting, streamId: streamTabId, config } = ctx;
 
   // Validate agent type and session
   if (setting.agentType !== 'toolUse') {
@@ -751,33 +744,26 @@ export async function resumeToolUseFromSnapshot(
 
   const interruptManager = new InterruptManager();
 
-  try {
-    setupFlowUIState(ctx);
+  await runFlowWithLifecycle(
+    ctx,
+    streamTabId,
+    snapshotConfig.agent,
+    async () => {
+      setupFlowUIState(ctx);
 
-    // Run the flow with resume snapshot
-    const result = await runToolUseFlow(
-      {
-        ...ctx,
-        ...interruptManager.asFlowInput(),
-        getUsageRecorder: createUsageRecorder(ctx.usageMonitor, 'tool-use'),
-        setting: setting as AgentToolUseSetting,
-        resumeSnapshot: snapshot,
-      },
-      setupSession ? (context) => setupSession(context.session) : undefined,
-    );
+      // Run the flow with resume snapshot
+      const result = await runToolUseFlow(
+        {
+          ...ctx,
+          ...interruptManager.asFlowInput(),
+          getUsageRecorder: createUsageRecorder(ctx.usageMonitor, 'tool-use'),
+          setting: setting as AgentToolUseSetting,
+          resumeSnapshot: snapshot,
+        },
+        setupSession ? (context) => setupSession(context.session) : undefined,
+      );
 
-    // End the runStage since we created it in resolveAgentBase
-    ctx.runStage.end(result.status);
-    updateFlowStatus(streamTabId, result.status);
-  } catch (error) {
-    // End the runStage with error status on exception
-    ctx.runStage.end(END_GROUP_STATUS.ERROR);
-    StreamStatusService.set(streamTabId, STREAM_STATUS.ERROR);
-    await handleFlowError(
-      error,
-      snapshotConfig.agent,
-      streamTabId,
-      agentLogger,
-    );
-  }
+      return result.status;
+    },
+  );
 }


### PR DESCRIPTION
### Motivation
- Reduce duplicated lifecycle, status update, and error handling logic across agent execution paths to make the code DRY and easier to maintain.
- Ensure consistent `runStage` end/cleanup and stream status updates for normal completion and error cases across all flows.

### Description
- Introduce a `FlowRunner` type and a shared `runFlowWithLifecycle` helper that centralizes `runStage` completion, `StreamStatusService` updates, and error handling via `handleFlowError`.
- Refactor `executeAgent`, `executeMergeAgent`, and `resumeToolUseFromSnapshot` to invoke `runFlowWithLifecycle` and return per-flow status from their scoped runners, preserving per-flow setup logic like `setupFlowUIState` and interrupt management.
- Remove the now-unused `showErrorMessage` import and call `vscode.window.showErrorMessage` directly when needed.
- Preserve existing behaviors including `setActiveStream`, run-stage creation, usage recording, and multi-output warnings.

### Testing
- Ran `npm run format`, which completed successfully.
- Ran `npm run compile`, which completed successfully but emitted a webpack warning about a dynamic `nunjucks` require.
- Ran `npm run lint`, which completed successfully and reported existing unrelated lint warnings.
- Verified the refactor compiles and the modified file passes project formatting and lint steps.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f47a290488324b8f08ec825984c5d)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Consolidates agent execution lifecycle into a shared helper for consistent status updates and error handling across flows.
> 
> - Introduces `FlowRunner` and `runFlowWithLifecycle` to centralize `runStage` completion, `StreamStatusService` updates (via `updateFlowStatus`), and error handling (`handleFlowError`)
> - Refactors `executeAgent`, `executeMergeAgent`, and `resumeToolUseFromSnapshot` to delegate to the shared runner and return per-flow `status` from their scoped executions
> - Simplifies error UI by removing `showErrorMessage` import and using `vscode.window.showErrorMessage` directly; updates `handleFlowError` signature to drop `streamId`
> - Preserves existing behaviors (UI setup via `setupFlowUIState`, usage recording, multi-output warnings, parent `runStage` wiring) while reducing duplicated try/catch and status-setting logic
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ea6a246d7251119ccbe0bab0430daf7c82305c5d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->