### PR TITLE
refactor: reduce resolve checks and simplify session handling

### DIFF
--- a/src/commands/files/openFileCommands.ts
+++ b/src/commands/files/openFileCommands.ts
@@ -4,15 +4,17 @@ import * as vscode from 'vscode';
 // Local imports - common
 import { toErrorMessage } from '@common/errors';
 
+// Local imports - frontend
+import { fileLister } from '@frontend/files';
+import { openBuildDisplayIfTex } from '@frontend/latex/openBuild';
+
 // Local imports - logging
 import * as logger from '@logger/logUtils';
 
-const CHANNEL = 'openFileCommands';
-
 // Local imports - utilities
-import { fileLister } from '@frontend/files';
-import { openBuildDisplayIfTex } from '@frontend/latex/openBuild';
 import { WorkspaceFS } from '@utils/files';
+
+const CHANNEL = 'openFileCommands';
 
 export async function openFile(file: string): Promise<void> {
   const uri = vscode.Uri.file(WorkspaceFS.toAbsolute(file));

--- a/src/common/modules/domUtils.js
+++ b/src/common/modules/domUtils.js
@@ -244,24 +244,29 @@ export function waitForElement(selector, options = {}) {
   }
 
   let observer = null;
-  let resolver = null;
   let timeoutId = null;
+  let resolved = false;
+  let resolvePromise;
+
+  const finish = (value) => {
+    if (resolved) {
+      return;
+    }
+    resolved = true;
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+      timeoutId = null;
+    }
+    observer?.disconnect();
+    observer = null;
+    resolvePromise(value);
+  };
 
   const promise = new Promise((resolve) => {
-    resolver = resolve;
+    resolvePromise = resolve;
 
-    // Set up optional timeout
     if (options.timeout && options.timeout > 0) {
-      timeoutId = setTimeout(() => {
-        if (observer) {
-          observer.disconnect();
-          observer = null;
-        }
-        if (resolver) {
-          resolver = null;
-          resolve(null);
-        }
-      }, options.timeout);
+      timeoutId = setTimeout(() => finish(null), options.timeout);
     }
 
     observer = new MutationObserver(() => {
@@ -269,16 +274,7 @@ export function waitForElement(selector, options = {}) {
       if (!element) {
         return;
       }
-      if (timeoutId) {
-        clearTimeout(timeoutId);
-        timeoutId = null;
-      }
-      if (observer) {
-        observer.disconnect();
-        observer = null;
-      }
-      resolver = null;
-      resolve(element);
+      finish(element);
     });
 
     observer.observe(document.documentElement, {
@@ -287,21 +283,7 @@ export function waitForElement(selector, options = {}) {
     });
   });
 
-  const dispose = () => {
-    if (timeoutId) {
-      clearTimeout(timeoutId);
-      timeoutId = null;
-    }
-    if (observer) {
-      observer.disconnect();
-      observer = null;
-    }
-    if (resolver) {
-      const resolve = resolver;
-      resolver = null;
-      resolve(null);
-    }
-  };
+  const dispose = () => finish(null);
 
   return { promise, dispose };
 }

--- a/src/common/modules/webviewState.js
+++ b/src/common/modules/webviewState.js
@@ -12,13 +12,8 @@ export class WebviewStateManager {
    */
   constructor(defaultState = {}) {
     this.defaultState = { ...defaultState };
-    try {
-      const saved = vscode.getState() || {};
-      this.state = { ...this.defaultState, ...saved };
-    } catch (e) {
-      console.error('Failed to get state:', e);
-      this.state = { ...this.defaultState };
-    }
+    const saved = vscode.getState() || {};
+    this.state = { ...this.defaultState, ...saved };
   }
 
   /**
@@ -34,11 +29,7 @@ export class WebviewStateManager {
    */
   setState(state) {
     this.state = { ...state };
-    try {
-      vscode.setState(this.state);
-    } catch (e) {
-      console.error('Failed to set state:', e);
-    }
+    vscode.setState(this.state);
   }
 
   /**

--- a/src/test/common/modules/pathUtils.test.js
+++ b/src/test/common/modules/pathUtils.test.js
@@ -1,4 +1,3 @@
-/* eslint-env mocha */
 /* global suite, test */
 import * as assert from 'assert';
 import { getBasename } from '../../../common/modules/pathUtils.js';

--- a/src/tools/ReadTool.ts
+++ b/src/tools/ReadTool.ts
@@ -22,10 +22,16 @@ const ReadInputSchema = z.strictObject({
       start: z.int().min(1),
       end: z.int().min(1).nullish(),
     })
-    .refine((value) => value.end == null || value.end >= value.start, {
-      path: ['end'],
-      error: 'range.end must be greater than or equal to range.start',
-    })
+    .refine(
+      (value) => {
+        // eslint-disable-next-line eqeqeq
+        return value.end == null || value.end >= value.start;
+      },
+      {
+        path: ['end'],
+        error: 'range.end must be greater than or equal to range.start',
+      },
+    )
     .nullish(),
 });
 
@@ -115,8 +121,10 @@ export class ReadFileTool extends defineTool({
       requestedEndLine,
       truncated,
       rangeProvided: Boolean(input.range),
-      rangeEndExceeded:
-        input.range?.end != null && input.range.end > totalLines,
+      rangeEndExceeded: (() => {
+        // eslint-disable-next-line eqeqeq
+        return input.range?.end != null && input.range.end > totalLines;
+      })(),
     });
 
     return {

--- a/src/tools/TextEditorTool.ts
+++ b/src/tools/TextEditorTool.ts
@@ -129,6 +129,7 @@ export class TextEditorTool extends defineTool({
         );
 
       case 'insert':
+        // eslint-disable-next-line eqeqeq
         if (input.insert_line == null) {
           throw new ToolError(
             'Parameter `insert_line` is required for command: insert',

--- a/src/tools/fileOp.ts
+++ b/src/tools/fileOp.ts
@@ -48,6 +48,7 @@ export class FileOpTool extends defineTool({
         };
       }
       case 'write': {
+        // eslint-disable-next-line eqeqeq
         if (content == null) {
           return {
             error: 'content parameter is required for write',
@@ -105,6 +106,7 @@ export class FileOpTool extends defineTool({
         };
       }
       case 'append': {
+        // eslint-disable-next-line eqeqeq
         if (content == null) {
           return {
             error: 'content parameter is required for append',

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -11,7 +11,7 @@ import { toErrorMessage } from '@common/errors';
 import { ToolError, type ToolFileAttachment } from '@tools/result';
 
 // Local imports - core utilities
-import { getPathSegments, isNonEmptyString, toPosixPath } from '@utils/core';
+import { isNonEmptyString, toPosixPath } from '@utils/core';
 import { WorkspaceFS, getMimeType } from '@utils/files';
 
 export interface WorkspacePathResolution {
@@ -34,28 +34,33 @@ export function resolveWorkspaceRelativePath(
     throw new ToolError('Workspace path is not available.');
   }
 
-  if (!targetPath || targetPath.trim() === '' || targetPath === '.') {
+  const trimmed = targetPath?.trim();
+  if (!trimmed || trimmed === '.') {
     return {
       relative: '.',
       absolute: workspacePath,
     };
   }
 
-  const trimmed = targetPath.trim();
-  const absoluteCandidate = path.resolve(workspacePath, trimmed);
-  const relativeCandidate = path.relative(workspacePath, absoluteCandidate);
-  const normalizedRelative =
-    relativeCandidate === '' ? '.' : path.normalize(relativeCandidate);
+  if (path.isAbsolute(trimmed)) {
+    const relative = WorkspaceFS.relativePath(trimmed);
+    if (relative === trimmed || relative.startsWith('..')) {
+      throw new ToolError('Path must stay within the workspace.');
+    }
+    return {
+      relative: relative === '' ? '.' : relative,
+      absolute: trimmed,
+    };
+  }
 
-  // Use centralized path segment extraction
-  const segments = getPathSegments(normalizedRelative);
-  if (segments.includes('..')) {
+  const relative = path.normalize(trimmed);
+  if (relative.startsWith('..')) {
     throw new ToolError('Path must stay within the workspace.');
   }
 
   return {
-    relative: normalizedRelative,
-    absolute: absoluteCandidate,
+    relative,
+    absolute: path.join(workspacePath, relative),
   };
 }
 

--- a/src/utils/files/baseFS.ts
+++ b/src/utils/files/baseFS.ts
@@ -107,10 +107,7 @@ export abstract class BaseFS {
     target: PathInput,
   ): Promise<void> {
     try {
-      const existsResult = await this.exists(target);
-      if (!existsResult) {
-        await this.createDir(target);
-      }
+      await this.createDir(target);
     } catch (err) {
       if (err instanceof vscode.FileSystemError && err.code === 'FileExists') {
         return;

--- a/src/utils/files/taskRunStorage.ts
+++ b/src/utils/files/taskRunStorage.ts
@@ -112,6 +112,35 @@ type ResolvedPath =
   | { kind: 'workspace'; absolutePath: string; relativePath: string }
   | { kind: 'external'; absolutePath: string };
 
+function resolveAbsolutePathAgainstWorkspace(
+  absolutePath: string,
+  workspaceRoot: string | undefined,
+): ResolvedPath {
+  if (!workspaceRoot) {
+    return { kind: 'external', absolutePath };
+  }
+  const relative = WorkspaceFS.relativePath(absolutePath);
+  if (relative !== absolutePath && !relative.startsWith('..')) {
+    return {
+      kind: 'workspace',
+      absolutePath,
+      relativePath: relative,
+    };
+  }
+  return { kind: 'external', absolutePath };
+}
+
+function resolveRelativePathAgainstWorkspace(
+  relativePath: string,
+  workspaceRoot: string | undefined,
+): ResolvedPath {
+  if (!workspaceRoot) {
+    return { kind: 'external', absolutePath: path.resolve(relativePath) };
+  }
+  const absolutePath = path.join(workspaceRoot, relativePath);
+  return { kind: 'workspace', absolutePath, relativePath };
+}
+
 /**
  * Resolve a path (absolute or relative) against a workspace root.
  * This is the shared logic for path resolution used by createLocation,
@@ -132,37 +161,15 @@ function resolvePathAgainstWorkspace(
     return { kind: 'workspace', absolutePath: workspaceRoot, relativePath: '' };
   }
 
-  const normalized = path.normalize(inputPath);
-
-  if (path.isAbsolute(normalized)) {
+  if (path.isAbsolute(inputPath)) {
     // Absolute path - check if within workspace
     // Use WorkspaceFS.relativePath() which handles symlinks correctly via
     // vscode.workspace.asRelativePath(). Direct path.relative() fails when
     // the path is inside a symlinked directory.
-    if (workspaceRoot) {
-      const relative = WorkspaceFS.relativePath(normalized);
-      // asRelativePath returns the original path if outside workspace
-      if (relative !== normalized && !relative.startsWith('..')) {
-        return {
-          kind: 'workspace',
-          absolutePath: normalized,
-          relativePath: relative,
-        };
-      }
-    }
-    return { kind: 'external', absolutePath: normalized };
+    return resolveAbsolutePathAgainstWorkspace(inputPath, workspaceRoot);
   }
 
-  // Relative path
-  if (!workspaceRoot) {
-    // No workspace - resolve to absolute using process.cwd()
-    const absolutePath = path.resolve(normalized);
-    return { kind: 'external', absolutePath };
-  }
-
-  // Resolve relative path against workspace
-  const absolutePath = path.join(workspaceRoot, normalized);
-  return { kind: 'workspace', absolutePath, relativePath: normalized };
+  return resolveRelativePathAgainstWorkspace(inputPath, workspaceRoot);
 }
 
 /**
@@ -181,7 +188,7 @@ function getRunStoragePaths(
   id: ExecutionId,
   workspaceRelative: string,
 ): { absolute: string; storageRelative: string; runRelative: string } {
-  const relative = workspaceRelative ? path.normalize(workspaceRelative) : '';
+  const relative = workspaceRelative || '';
   const storageRelative = path.join(TASK_RUNS_DIR, id, relative);
   return {
     absolute: StorageFS.fullPath(storageRelative),

--- a/src/webview/modules/constants.js
+++ b/src/webview/modules/constants.js
@@ -127,6 +127,7 @@ export const AGENT_SELECT_IDS = {
 };
 
 export const AGENT_SELECT_LIST = Object.values(AGENT_SELECT_IDS);
+export const SESSION_TYPE_VALUES = new Set(Object.values(SESSION_TYPES));
 
 /**
  * Tag name constant for VS Code radio group web component
@@ -134,30 +135,10 @@ export const AGENT_SELECT_LIST = Object.values(AGENT_SELECT_IDS);
 export const VSCODE_RADIO_GROUP_TAG = 'VSCODE-RADIO-GROUP';
 
 /**
- * Normalizes a session type value to ensure it's a valid SESSION_TYPE.
- * @param {string} sessionType - The session type to normalize
- * @returns {string} Either SESSION_TYPES.TOOL_USE or SESSION_TYPES.WORKFLOW
+ * Parse a session type value if it is one of the supported session types.
+ * @param {string | undefined | null} sessionType - The session type to validate
+ * @returns {string | undefined} The valid session type, or undefined if invalid
  */
-export function normalizeSessionType(sessionType) {
-  return sessionType === SESSION_TYPES.TOOL_USE
-    ? SESSION_TYPES.TOOL_USE
-    : SESSION_TYPES.WORKFLOW;
-}
-
-/**
- * Resolves a vscode-radio-group element from a container element.
- * If the element itself is a radio group, returns it directly.
- * Otherwise, searches for a radio group child element.
- * @param {HTMLElement|null|undefined} element - The container element
- * @returns {HTMLElement|null} The radio group element, or null if not found
- */
-export function resolveRadioGroup(element) {
-  if (!element) {
-    return null;
-  }
-  if (element.tagName === VSCODE_RADIO_GROUP_TAG) {
-    return element;
-  }
-  const radioGroup = element.querySelector('vscode-radio-group');
-  return radioGroup instanceof HTMLElement ? radioGroup : null;
+export function parseSessionType(sessionType) {
+  return SESSION_TYPE_VALUES.has(sessionType) ? sessionType : undefined;
 }

--- a/src/webview/modules/domHandlers.js
+++ b/src/webview/modules/domHandlers.js
@@ -1,5 +1,5 @@
 // Local imports - webview
-import { ELEMENT_IDS, normalizeSessionType } from './constants.js';
+import { ELEMENT_IDS, parseSessionType, SESSION_TYPES } from './constants.js';
 import { webviewEventBus } from './eventBus.js';
 import { mainViewState } from './mainViewState.js';
 import { ActionButtonManager } from './uiManagers/ActionButtonManager.js';
@@ -115,9 +115,9 @@ class MainViewDomHandler extends BaseDomHandler {
     });
 
     this.addListener(ELEMENT_IDS.AGENT_CONFIG_EDIT_BUTTON, 'click', () => {
-      const sessionType = normalizeSessionType(
-        mainViewState.get()?.sessionType,
-      );
+      const sessionType =
+        parseSessionType(mainViewState.get()?.sessionType) ??
+        SESSION_TYPES.WORKFLOW;
       vscode.postMessage({
         command: MAIN_VIEW_COMMANDS.OPEN_AGENT_SETTINGS,
         sessionType,

--- a/src/webview/modules/mainViewState.js
+++ b/src/webview/modules/mainViewState.js
@@ -9,8 +9,8 @@ import {
   SESSION_TYPE_INPUT,
   AGENT_SELECT_IDS,
   AGENT_SELECT_LIST,
-  normalizeSessionType,
-  resolveRadioGroup,
+  parseSessionType,
+  VSCODE_RADIO_GROUP_TAG,
 } from './constants.js';
 import { fileList } from './uiManagers/FileList.js';
 import {
@@ -36,6 +36,22 @@ function getSessionDefaultAgent(sessionType) {
   return sessionType === SESSION_TYPES.TOOL_USE
     ? DEFAULT_TOOL_USE_AGENT
     : DEFAULT_WORKFLOW_AGENT;
+}
+
+function getDefaultState() {
+  return {
+    sessionType: SESSION_TYPES.WORKFLOW,
+    workflowAgent: getSelectDefaultValue(
+      AGENT_SELECT_IDS[SESSION_TYPES.WORKFLOW],
+      DEFAULT_WORKFLOW_AGENT,
+    ),
+    toolUseAgent: getSelectDefaultValue(
+      AGENT_SELECT_IDS[SESSION_TYPES.TOOL_USE],
+      DEFAULT_TOOL_USE_AGENT,
+    ),
+    model: 'gemini3p',
+    commit: 'HEAD',
+  };
 }
 
 function setFileSelectionGroupDisabled(isDisabled) {
@@ -201,43 +217,14 @@ export class MainViewState {
   _restoreImpl() {
     const previousState = this.stateManager.getState();
     if (previousState) {
-      const defaults = {
-        sessionType: SESSION_TYPES.WORKFLOW,
-        workflowAgent: getSelectDefaultValue(
-          AGENT_SELECT_IDS[SESSION_TYPES.WORKFLOW],
-          DEFAULT_WORKFLOW_AGENT,
-        ),
-        toolUseAgent: getSelectDefaultValue(
-          AGENT_SELECT_IDS[SESSION_TYPES.TOOL_USE],
-          DEFAULT_TOOL_USE_AGENT,
-        ),
-        model: 'gemini3p',
-        commit: 'HEAD',
-      };
-
-      const normalizedSessionType = normalizeSessionType(
-        previousState.sessionType ?? defaults.sessionType,
-      );
-
-      safeSetElementValue('sessionType', normalizedSessionType);
-      safeSetElementValue(
-        'workflowAgent',
-        previousState.workflowAgent ?? defaults.workflowAgent,
-      );
-      safeSetElementValue(
-        'toolUseAgent',
-        previousState.toolUseAgent ?? defaults.toolUseAgent,
-      );
+      const defaults = getDefaultState();
+      const mergedState = { ...defaults, ...previousState };
+      const sessionType =
+        parseSessionType(mergedState.sessionType) ?? defaults.sessionType;
+      mergedState.sessionType = sessionType;
 
       VALUE_ELEMENTS.forEach((id) => {
-        if (
-          id === 'sessionType' ||
-          id === 'workflowAgent' ||
-          id === 'toolUseAgent'
-        ) {
-          return;
-        }
-        safeSetElementValue(id, previousState[id] ?? defaults[id] ?? '');
+        safeSetElementValue(id, mergedState[id] ?? '');
       });
 
       // Load checkboxes
@@ -256,8 +243,8 @@ export class MainViewState {
         }
         selectDiv.innerHTML = '';
 
-        const filesArray = previousState[id] ?? [];
-        const isVisible = previousState[`${id}Visible`];
+        const filesArray = mergedState[id] ?? [];
+        const isVisible = mergedState[`${id}Visible`];
 
         if (filesArray && filesArray.length > 0) {
           filesArray.forEach((file) => {
@@ -280,13 +267,13 @@ export class MainViewState {
         ELEMENT_IDS.TOGGLE_LATEXDIFFS,
       );
       if (latexdiffsContent && toggleLatexdiffs) {
-        const visible = previousState.latexdiffsVisible ?? false;
+        const visible = mergedState.latexdiffsVisible ?? false;
         latexdiffsContent.style.display = visible ? 'block' : 'none';
         setChevronIcon(toggleLatexdiffs, visible);
         setExpandedState(latexdiffsContent, '.latexdiffs-section', visible);
       }
 
-      this.applySessionType(normalizedSessionType, { skipSave: true });
+      this.applySessionType(sessionType, { skipSave: true });
       fileList.hideEmpty(MULTIPLE_SELECTIONS);
       return false; // No save needed - state already exists
     } else {
@@ -333,15 +320,16 @@ export class MainViewState {
 
     const sessionTypeValue =
       state.sessionType ?? safeGetElementValue(SESSION_TYPE_INPUT);
-    const normalizedSessionType = normalizeSessionType(sessionTypeValue);
-    const activeSelectId = AGENT_SELECT_IDS[normalizedSessionType];
+    const resolvedSessionType =
+      parseSessionType(sessionTypeValue) ?? SESSION_TYPES.WORKFLOW;
+    const activeSelectId = AGENT_SELECT_IDS[resolvedSessionType];
     if (activeSelectId) {
       const agentValue = safeGetElementValue(activeSelectId) ?? '';
       // Save the actual DOM value, not a computed default.
       // DOM modification during save() can trigger unexpected change events.
       // If agent is empty, restore() or applySessionType() will handle defaults.
       state.agent = agentValue;
-      state.isToolUseAgent = normalizedSessionType === SESSION_TYPES.TOOL_USE;
+      state.isToolUseAgent = resolvedSessionType === SESSION_TYPES.TOOL_USE;
     }
 
     this.stateManager.setState(state);
@@ -349,17 +337,21 @@ export class MainViewState {
 
   applySessionType(sessionType, options = {}) {
     const { skipSave = false } = options;
-    const normalized = normalizeSessionType(sessionType);
-    const isToolUseSession = normalized === SESSION_TYPES.TOOL_USE;
+    const resolvedSessionType =
+      parseSessionType(sessionType) ?? SESSION_TYPES.WORKFLOW;
+    const isToolUseSession = resolvedSessionType === SESSION_TYPES.TOOL_USE;
 
     const sessionInput = safeGetElementById(SESSION_TYPE_INPUT);
     if (sessionInput) {
-      sessionInput.value = normalized;
+      sessionInput.value = resolvedSessionType;
     }
 
     const toggleContainer = safeGetElementById(ELEMENT_IDS.SESSION_TYPE_TOGGLE);
     if (toggleContainer) {
-      const radioGroup = resolveRadioGroup(toggleContainer);
+      const radioGroup =
+        toggleContainer.tagName === VSCODE_RADIO_GROUP_TAG
+          ? toggleContainer
+          : toggleContainer.querySelector('vscode-radio-group');
       if (radioGroup instanceof HTMLElement) {
         const radios = radioGroup.querySelectorAll('vscode-radio');
         radios.forEach((radio) => {
@@ -368,7 +360,7 @@ export class MainViewState {
           }
           const radioValue =
             radio.dataset.sessionType || radio.getAttribute('value');
-          const isActive = radioValue === normalized;
+          const isActive = radioValue === resolvedSessionType;
           if ('checked' in radio) {
             radio.checked = isActive;
           }
@@ -386,7 +378,7 @@ export class MainViewState {
           if (!(button instanceof HTMLElement)) {
             return;
           }
-          const isActive = button.dataset.sessionType === normalized;
+          const isActive = button.dataset.sessionType === resolvedSessionType;
           button.classList.toggle('active', isActive);
           button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
         });
@@ -398,7 +390,7 @@ export class MainViewState {
       if (!selectEl) {
         return;
       }
-      const isActive = selectId === AGENT_SELECT_IDS[normalized];
+      const isActive = selectId === AGENT_SELECT_IDS[resolvedSessionType];
       selectEl.classList.toggle('agent-select--active', isActive);
       selectEl.classList.toggle('agent-select--hidden', !isActive);
       selectEl.setAttribute('aria-hidden', isActive ? 'false' : 'true');
@@ -408,7 +400,7 @@ export class MainViewState {
         // (vscode-single-select may not synchronously update .value)
         const storedState = this.stateManager.getState() || {};
         const stateKey =
-          normalized === SESSION_TYPES.TOOL_USE
+          resolvedSessionType === SESSION_TYPES.TOOL_USE
             ? 'toolUseAgent'
             : 'workflowAgent';
         const storedValue = storedState[stateKey];
@@ -420,7 +412,7 @@ export class MainViewState {
           // Truly empty - apply default
           const fallback = getSelectDefaultValue(
             selectId,
-            getSessionDefaultAgent(normalized),
+            getSessionDefaultAgent(resolvedSessionType),
           );
           safeSetElementValue(selectId, fallback);
         }

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -13,7 +13,6 @@ import {
   AGENT_SELECT_IDS,
   AGENT_SELECT_LIST,
   CHECK_BOXES,
-  normalizeSessionType,
 } from './constants.js';
 import { webviewEventBus } from './eventBus.js';
 import { createFileHandlers } from './handlers/fileHandlers.js';

--- a/src/webview/modules/uiManagers/SettingsButtonManager.js
+++ b/src/webview/modules/uiManagers/SettingsButtonManager.js
@@ -1,14 +1,14 @@
 // Local imports - webview
 import {
+  AGENT_SELECT_IDS,
+  AGENT_SELECT_LIST,
   CHECK_BOXES_AUTO_EXTRACT,
   CHECK_BOXES_TOOL_USE,
   ELEMENT_IDS,
+  parseSessionType,
   SESSION_TYPES,
   SESSION_TYPE_INPUT,
-  AGENT_SELECT_IDS,
-  AGENT_SELECT_LIST,
-  normalizeSessionType,
-  resolveRadioGroup,
+  VSCODE_RADIO_GROUP_TAG,
 } from '../constants.js';
 import { handleCheckboxChange } from '../fileHandlers.js';
 import { mainViewState } from '../mainViewState.js';
@@ -166,7 +166,9 @@ export class SettingsButtonManager extends BaseDomHandler {
 
   _setupSettingsButtons() {
     this.addListener(ELEMENT_IDS.AGENT_SETTINGS_BUTTON, 'click', () => {
-      const sessionType = normalizeSessionType(this.state.get()?.sessionType);
+      const sessionType =
+        parseSessionType(this.state.get()?.sessionType) ??
+        SESSION_TYPES.WORKFLOW;
       this.vscode.postMessage({
         command: MAIN_VIEW_COMMANDS.OPEN_AGENT_SETTINGS,
         sessionType,
@@ -250,7 +252,8 @@ export class SettingsButtonManager extends BaseDomHandler {
     const toggleContainer = safeGetElementById(ELEMENT_IDS.SESSION_TYPE_TOGGLE);
     if (toggleContainer) {
       const handleSessionTypeSelection = (sessionType) => {
-        const normalized = normalizeSessionType(sessionType);
+        const normalized =
+          parseSessionType(sessionType) ?? SESSION_TYPES.WORKFLOW;
         this._setLastRadioSessionType(normalized);
         this.state.applySessionType(normalized);
         const selectId =
@@ -267,90 +270,27 @@ export class SettingsButtonManager extends BaseDomHandler {
         }
       };
 
-      /**
-       * Gets the current session type from a vscode-radio-group element.
-       * @param {HTMLElement} group - The radio group element
-       * @returns {string|undefined} The session type, or undefined if not found
-       */
-      const getSessionTypeFromGroup = (group) => {
-        if (!(group instanceof HTMLElement)) {
-          return undefined;
-        }
-
-        const radios = Array.from(group.querySelectorAll('vscode-radio'));
-        if (radios.length === 0) {
-          return undefined;
-        }
-
-        /**
-         * Extract session type from a radio element
-         * @param {HTMLElement} radio - The radio button element
-         * @returns {string|undefined} The session type or undefined if not found
-         */
-        const findSessionType = (radio) => {
-          if (!(radio instanceof HTMLElement)) {
-            return undefined;
-          }
-
-          const sessionType =
-            radio.dataset.sessionType || radio.getAttribute('value');
-          return sessionType && sessionType.length > 0
-            ? sessionType
-            : undefined;
-        };
-
-        const checkedRadio = radios.find((radio) => {
-          if (!(radio instanceof HTMLElement)) {
-            return false;
-          }
-          const hasCheckedProperty =
-            'checked' in radio && Boolean(radio.checked);
-          return (
-            hasCheckedProperty ||
-            radio.hasAttribute('checked') ||
-            radio.getAttribute('aria-checked') === 'true'
-          );
-        });
-
-        if (checkedRadio) {
-          return findSessionType(checkedRadio);
-        }
-
-        return findSessionType(radios[0]);
-      };
-
-      const radioGroup = resolveRadioGroup(toggleContainer);
+      const radioGroup =
+        toggleContainer.tagName === VSCODE_RADIO_GROUP_TAG
+          ? toggleContainer
+          : toggleContainer.querySelector('vscode-radio-group');
       if (radioGroup) {
         // Initialize last session type from radio group
         // Only set if we can determine a valid initial value to avoid masking the first user interaction
-        const initialSessionType = getSessionTypeFromGroup(radioGroup);
+        const initialSessionType = parseSessionType(radioGroup.value);
         if (initialSessionType) {
-          this._setLastRadioSessionType(
-            normalizeSessionType(initialSessionType),
-          );
+          this._setLastRadioSessionType(initialSessionType);
         }
 
-        this.addListener(radioGroup, 'change', (event) => {
-          let sessionType;
-          const target = event?.target;
-          if (target instanceof HTMLElement) {
-            if (isTagName(target, 'vscode-radio')) {
-              sessionType =
-                target.dataset.sessionType || target.getAttribute('value');
-            }
-          }
-
-          if (!sessionType) {
-            sessionType = getSessionTypeFromGroup(radioGroup);
-          }
+        this.addListener(radioGroup, 'change', () => {
+          const sessionType = parseSessionType(radioGroup.value);
           if (!sessionType) {
             return;
           }
-          const normalized = normalizeSessionType(sessionType);
-          if (normalized === this._lastRadioSessionType) {
+          if (sessionType === this._lastRadioSessionType) {
             return;
           }
-          handleSessionTypeSelection(normalized);
+          handleSessionTypeSelection(sessionType);
         });
       } else {
         const buttons = toggleContainer.querySelectorAll('[data-session-type]');
@@ -450,9 +390,9 @@ export class SettingsButtonManager extends BaseDomHandler {
 
     const sessionType =
       selectElement.dataset.sessionType || SESSION_TYPES.WORKFLOW;
-    const normalized = normalizeSessionType(sessionType);
-    this._setLastRadioSessionType(normalized);
-    this.state.applySessionType(normalized, { skipSave: true });
+    const parsed = parseSessionType(sessionType) ?? SESSION_TYPES.WORKFLOW;
+    this._setLastRadioSessionType(parsed);
+    this.state.applySessionType(parsed, { skipSave: true });
 
     const selectedAgent = selectElement.value;
     const selectedOption = getSelectedOptionElement(selectElement);
@@ -479,7 +419,7 @@ export class SettingsButtonManager extends BaseDomHandler {
 
     const sessionInput = safeGetElementById(SESSION_TYPE_INPUT);
     if (sessionInput) {
-      sessionInput.value = normalized;
+      sessionInput.value = parsed;
     }
 
     this.state.save();


### PR DESCRIPTION
### Motivation

- Remove excessive/fragile path normalization and duplicated defensive checks to make workspace-relative resolution clearer and less error prone.  
- Simplify webview/session state handling by replacing ad-hoc normalization and DOM traversal with a small validation helper and explicit defaults.  
- Make DOM utility waiters idempotent and easier to clean up to avoid race conditions during webview initialization.  
- Address lint ordering and `eqeqeq` warnings while keeping required nullish checks for tool inputs.

### Description

- Reordered imports in `src/commands/files/openFileCommands.ts` to satisfy lint `import/order` rules without behavioral changes.  
- Introduced `parseSessionType` and `VSCODE_RADIO_GROUP_TAG` in `src/webview/modules/constants.js` and replaced uses of legacy `normalizeSessionType`/`resolveRadioGroup` across `mainViewState`, `domHandlers`, `messageHandlers`, and `SettingsButtonManager` to use validated values with explicit defaults.  
- Simplified DOM waiter `waitForElement` in `src/common/modules/domUtils.js` to use a single `finish` closure and a resolved flag for idempotent cleanup and a minimal `dispose()` implementation.  
- Reduced path resolution/FS defensive logic by tightening `resolveWorkspaceRelativePath` in `src/tools/utils.ts`, splitting absolute/relative resolution helpers in `src/utils/files/taskRunStorage.ts`, and simplifying `ensureDir` in `src/utils/files/baseFS.ts` to directly call `createDir` and treat `FileExists` as a no-op, and added small test header cleanup in `src/test/common/modules/pathUtils.test.js`.

### Testing

- Ran `npm run format` and it completed successfully.  
- Ran `npm run compile` and Webpack completed successfully but emitted a single warning about a dynamic dependency in `nunjucks`.  
- Ran `npm run lint` and final runs report no blocking errors (ordering warnings were resolved and `eqeqeq` checks were silenced locally where nullish comparisons are required).  
- All automated tasks above completed (compile produced one non-failing warning).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f449759a083248ee947016d727dec)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Modernizes core utilities and webview state handling while reducing defensive path checks.
> 
> - Introduces `parseSessionType` and `VSCODE_RADIO_GROUP_TAG`; replaces legacy `normalizeSessionType`/`resolveRadioGroup` across `mainViewState`, `domHandlers`, `messageHandlers`, and `SettingsButtonManager` with validated values and explicit defaults
> - Refactors `waitForElement` to a single `finish` flow with resolved flag for idempotent cleanup; exposes minimal `dispose()`
> - Tightens workspace path handling: simplifies `resolveWorkspaceRelativePath`, splits absolute/relative resolvers in task run storage, and treats `FileExists` as no-op in `BaseFS.ensureDir`
> - Tools: adds explicit nullish checks (lint-safe) in `TextEditorTool`/`fileOp`; clarifies `ReadTool` range checks and summary flags without changing behavior
> - Minor: import reordering in `openFileCommands.ts`; test header cleanup in `pathUtils.test.js`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 077bbeb1e6a7a3e9f6e29dc29b1206a0684de9fd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->