### PR TITLE
refactor: simplify run handling and consolidate helper utilities

### DIFF
--- a/src/FolderExplorer.ts
+++ b/src/FolderExplorer.ts
@@ -23,14 +23,40 @@ export class FolderExplorer implements vscode.TreeDataProvider<FileItem> {
     this._onDidChangeTreeData.event;
 
   private builtInAgentsPath = '';
+  private builtInToolUsePath = '';
 
   constructor(
     _workspaceRoot: string | undefined,
     _context?: vscode.ExtensionContext,
   ) {
-    agentDirectories.builtIn().then((p) => {
-      this.builtInAgentsPath = p;
-    });
+    void this.loadBuiltInPaths();
+  }
+
+  private async loadBuiltInPaths(): Promise<void> {
+    const [builtInAgentsPath, builtInToolUsePath] = await Promise.all([
+      agentDirectories.builtIn(),
+      agentDirectories.builtInToolUse(),
+    ]);
+    this.builtInAgentsPath = builtInAgentsPath;
+    this.builtInToolUsePath = builtInToolUsePath;
+  }
+
+  private async ensureBuiltInPaths(): Promise<{
+    builtInAgentsPath: string;
+    builtInToolUsePath: string;
+  }> {
+    if (this.builtInAgentsPath && this.builtInToolUsePath) {
+      return {
+        builtInAgentsPath: this.builtInAgentsPath,
+        builtInToolUsePath: this.builtInToolUsePath,
+      };
+    }
+
+    await this.loadBuiltInPaths();
+    return {
+      builtInAgentsPath: this.builtInAgentsPath,
+      builtInToolUsePath: this.builtInToolUsePath,
+    };
   }
 
   refresh(): void {
@@ -61,12 +87,12 @@ export class FolderExplorer implements vscode.TreeDataProvider<FileItem> {
       }
 
       const items: FileItem[] = [];
-      const builtInPath = await agentDirectories.builtIn();
-      const builtInToolUsePath = await agentDirectories.builtInToolUse();
+      const { builtInAgentsPath, builtInToolUsePath } =
+        await this.ensureBuiltInPaths();
       items.push(
         new FileItem(
           'Built-in Agents',
-          vscode.Uri.file(builtInPath),
+          vscode.Uri.file(builtInAgentsPath),
           vscode.TreeItemCollapsibleState.Collapsed,
         ),
       );
@@ -108,8 +134,10 @@ export class FolderExplorer implements vscode.TreeDataProvider<FileItem> {
 
         const resourceUri = vscode.Uri.file(path.join(dirPath, name));
         const isBuiltIn =
-          this.builtInAgentsPath &&
-          resourceUri.fsPath.startsWith(this.builtInAgentsPath);
+          (this.builtInAgentsPath &&
+            resourceUri.fsPath.startsWith(this.builtInAgentsPath)) ||
+          (this.builtInToolUsePath &&
+            resourceUri.fsPath.startsWith(this.builtInToolUsePath));
 
         if (type === vscode.FileType.Directory) {
           items.push(

--- a/src/auth/SupabaseAuthProvider.ts
+++ b/src/auth/SupabaseAuthProvider.ts
@@ -508,29 +508,16 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
       );
 
       // Exchange GitHub token for Supabase session via Edge Function
-      // Use AbortController for timeout to prevent hanging requests
-      const controller = new AbortController();
-      const timeoutId = setTimeout(
-        () => controller.abort(),
-        EDGE_FUNCTION_TIMEOUT_MS,
-      );
-
-      let response: Response;
-      try {
-        response = await fetch(GITHUB_TOKEN_EXCHANGE_URL, {
+      const response = await this.fetchWithTimeout(
+        GITHUB_TOKEN_EXCHANGE_URL,
+        {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ github_token: githubSession.accessToken }),
-          signal: controller.signal,
-        });
-      } catch (fetchError) {
-        clearTimeout(timeoutId);
-        if (fetchError instanceof Error && fetchError.name === 'AbortError') {
-          throw new Error('Authentication server timeout. Please try again.');
-        }
-        throw fetchError;
-      }
-      clearTimeout(timeoutId);
+        },
+        EDGE_FUNCTION_TIMEOUT_MS,
+        'Authentication server timeout. Please try again.',
+      );
 
       if (!response.ok) {
         const errorData = await response.json().catch(() => ({}));
@@ -549,28 +536,7 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
         throw new Error(errorMsg);
       }
 
-      // Parse and validate response with Zod schema
-      let data: GitHubTokenExchangeResponse;
-      try {
-        const rawData = await response.json();
-        const parsed = GitHubTokenExchangeSchema.safeParse(rawData);
-        if (!parsed.success) {
-          logger.error(
-            'SupabaseAuthProvider',
-            `Token exchange response validation failed: ${parsed.error.message}`,
-          );
-          throw new Error('Invalid response format from authentication server');
-        }
-        data = parsed.data;
-      } catch (parseError) {
-        if (
-          parseError instanceof Error &&
-          parseError.message.includes('Invalid response')
-        ) {
-          throw parseError;
-        }
-        throw new Error('Invalid response format from authentication server');
-      }
+      const data = await this.parseTokenExchangeResponse(response);
 
       // Create session in same format as Supabase OAuth
       // Note: expires_at from Edge Function is in seconds, convert to milliseconds
@@ -621,6 +587,41 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
       void vscode.window.showErrorMessage(`Authentication failed: ${message}`);
       throw error;
     }
+  }
+
+  private async fetchWithTimeout(
+    url: string,
+    options: RequestInit,
+    timeoutMs: number,
+    timeoutMessage: string,
+  ): Promise<Response> {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+      return await fetch(url, { ...options, signal: controller.signal });
+    } catch (error) {
+      if (error instanceof Error && error.name === 'AbortError') {
+        throw new Error(timeoutMessage);
+      }
+      throw error;
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  }
+
+  private async parseTokenExchangeResponse(
+    response: Response,
+  ): Promise<GitHubTokenExchangeResponse> {
+    const rawData = await response.json();
+    const parsed = GitHubTokenExchangeSchema.safeParse(rawData);
+    if (!parsed.success) {
+      logger.error(
+        'SupabaseAuthProvider',
+        `Token exchange response validation failed: ${parsed.error.message}`,
+      );
+      throw new Error('Invalid response format from authentication server');
+    }
+    return parsed.data;
   }
 
   /**

--- a/src/explorer/ExplorerOperations.ts
+++ b/src/explorer/ExplorerOperations.ts
@@ -5,7 +5,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 
 // Local imports - explorer
-import { showLoggedErrorMessage } from '@common/errors';
+import { showLoggedErrorMessage, toErrorMessage } from '@common/errors';
 import { agentDirectories } from '@frontend/agents';
 import { validateYamlAndPromptAdd } from '@frontend/agents';
 import { safeExecuteCommand } from '@frontend/system/commandUtils';
@@ -59,24 +59,41 @@ export class ExplorerOperations {
     _context: vscode.ExtensionContext | undefined,
     private refresh: () => void,
   ) {
-    // Initialize agent directory paths asynchronously with error handling
-    agentDirectories
-      .builtIn()
-      .then((p) => {
-        this.builtInAgentsPath = p;
-      })
-      .catch((err) => {
-        logger.warn(CHANNEL, `Failed to get built-in agents path: ${err}`);
-      });
+    void this.loadBuiltInPaths();
+  }
 
-    agentDirectories
-      .builtInToolUse()
-      .then((p) => {
-        this.builtInToolUsePath = p;
-      })
-      .catch((err) => {
-        logger.warn(CHANNEL, `Failed to get built-in tool-use path: ${err}`);
-      });
+  private async loadBuiltInPaths(): Promise<void> {
+    try {
+      const [builtInAgentsPath, builtInToolUsePath] = await Promise.all([
+        agentDirectories.builtIn(),
+        agentDirectories.builtInToolUse(),
+      ]);
+      this.builtInAgentsPath = builtInAgentsPath;
+      this.builtInToolUsePath = builtInToolUsePath;
+    } catch (error) {
+      logger.warn(
+        CHANNEL,
+        `Failed to get built-in agents paths: ${toErrorMessage(error)}`,
+      );
+    }
+  }
+
+  private resolveCustomPath(targetPath: string, customBase: string): string {
+    const isBuiltInAgents = this.builtInAgentsPath
+      ? targetPath.startsWith(this.builtInAgentsPath)
+      : false;
+    const isBuiltInToolUse = this.builtInToolUsePath
+      ? targetPath.startsWith(this.builtInToolUsePath)
+      : false;
+    if (!isBuiltInAgents && !isBuiltInToolUse) {
+      return targetPath;
+    }
+
+    const base = isBuiltInToolUse
+      ? this.builtInToolUsePath
+      : this.builtInAgentsPath;
+    const relativePath = path.relative(base, targetPath);
+    return path.join(customBase, relativePath);
   }
 
   async open(uri: vscode.Uri) {
@@ -117,12 +134,7 @@ export class ExplorerOperations {
   private async createCustomCopy(uri: vscode.Uri) {
     try {
       const customPath = await agentDirectories.custom();
-
-      const base = uri.fsPath.startsWith(this.builtInToolUsePath)
-        ? this.builtInToolUsePath
-        : this.builtInAgentsPath;
-      const relativePath = path.relative(base, uri.fsPath);
-      const targetPath = path.join(customPath, relativePath);
+      const targetPath = this.resolveCustomPath(uri.fsPath, customPath);
 
       const targetDir = path.dirname(targetPath);
       await AbsoluteFS.ensureDir(targetDir);
@@ -148,16 +160,7 @@ export class ExplorerOperations {
 
       let parentPath = node?.resourceUri.fsPath || customBase;
 
-      if (
-        parentPath.startsWith(this.builtInAgentsPath) ||
-        parentPath.startsWith(this.builtInToolUsePath)
-      ) {
-        const base = parentPath.startsWith(this.builtInToolUsePath)
-          ? this.builtInToolUsePath
-          : this.builtInAgentsPath;
-        const relative = path.relative(base, parentPath);
-        parentPath = path.join(customBase, relative);
-      }
+      parentPath = this.resolveCustomPath(parentPath, customBase);
 
       if (!parentPath) {
         throw new Error('No valid parent path found');

--- a/src/housekeeping/indent.ts
+++ b/src/housekeeping/indent.ts
@@ -60,88 +60,63 @@ export async function indentLatexFilesInDirectory(
 
   let indentedCount = 0;
 
-  const processDirectory = async (dirPath: string) => {
-    try {
-      const entries = await WorkspaceFS.readDir(dirPath);
-      for (const [name, type] of entries) {
-        if (EXCLUDED_DIRS.has(name.toLowerCase())) {
-          continue;
-        }
-        if (name.includes('Diffs')) {
-          continue;
-        }
-
-        const fullPath = path.join(dirPath, name);
-
-        if (type === vscode.FileType.Directory) {
-          await processDirectory(fullPath);
-        } else if (type === vscode.FileType.File && name.endsWith('.tex')) {
-          if (progressCallback) {
-            progressCallback(`Indenting ${path.basename(fullPath)}...`, 0);
-          }
-
-          logger.debug(CHANNEL, `Processing file: ${fullPath}`);
-          try {
-            const success = await runLatexFormatter(fullPath);
-            if (success) {
-              logger.info(CHANNEL, `Successfully formatted: ${fullPath}`);
-              indentedCount++;
-            } else {
-              logger.error(CHANNEL, `Failed to format ${fullPath}`);
-            }
-          } catch (err) {
-            logger.error(CHANNEL, `Error formatting file ${fullPath}: ${err}`);
-            continue;
-          }
-        }
+  const walkDirectory = async (
+    dirPath: string,
+    onFile: (fullPath: string, name: string) => Promise<void>,
+  ) => {
+    const entries = await WorkspaceFS.readDir(dirPath);
+    for (const [name, type] of entries) {
+      if (EXCLUDED_DIRS.has(name.toLowerCase())) {
+        continue;
       }
-    } catch (err) {
-      logger.error(CHANNEL, `Error processing directory ${dirPath}: ${err}`);
+      if (name.includes('Diffs')) {
+        continue;
+      }
+
+      const fullPath = path.join(dirPath, name);
+
+      if (type === vscode.FileType.Directory) {
+        await walkDirectory(fullPath, onFile);
+      } else if (type === vscode.FileType.File) {
+        await onFile(fullPath, name);
+      }
     }
   };
 
   try {
-    await processDirectory(directory);
+    await walkDirectory(directory, async (fullPath, name) => {
+      if (!name.endsWith('.tex')) {
+        return;
+      }
+      if (progressCallback) {
+        progressCallback(`Indenting ${path.basename(fullPath)}...`, 0);
+      }
 
-    // Clean up temporary files recursively
-    const processCleanup = async (dirPath: string) => {
+      logger.debug(CHANNEL, `Processing file: ${fullPath}`);
       try {
-        const entries = await WorkspaceFS.readDir(dirPath);
-        for (const [name, type] of entries) {
-          if (EXCLUDED_DIRS.has(name.toLowerCase())) {
-            continue;
-          }
-          if (name.includes('Diffs')) {
-            continue;
-          }
-
-          const fullPath = path.join(dirPath, name);
-
-          if (type === vscode.FileType.Directory) {
-            await processCleanup(fullPath);
-          } else if (type === vscode.FileType.File) {
-            // Check for temporary files
-            if (
-              name.endsWith('.bak') ||
-              name.endsWith('.bak0') ||
-              name.endsWith('.bak1') ||
-              name === 'indent.log'
-            ) {
-              logger.debug(CHANNEL, `Found cleanup file: ${fullPath}`);
-              await WorkspaceFS.delete(fullPath);
-            }
-          }
+        const success = await runLatexFormatter(fullPath);
+        if (success) {
+          logger.info(CHANNEL, `Successfully formatted: ${fullPath}`);
+          indentedCount++;
+        } else {
+          logger.error(CHANNEL, `Failed to format ${fullPath}`);
         }
       } catch (err) {
-        logger.error(
-          CHANNEL,
-          `Error during cleanup in directory ${dirPath}: ${err}`,
-        );
+        logger.error(CHANNEL, `Error formatting file ${fullPath}: ${err}`);
       }
-    };
+    });
 
-    // Start cleanup from the specified directory
-    await processCleanup(directory);
+    await walkDirectory(directory, async (fullPath, name) => {
+      if (
+        name.endsWith('.bak') ||
+        name.endsWith('.bak0') ||
+        name.endsWith('.bak1') ||
+        name === 'indent.log'
+      ) {
+        logger.debug(CHANNEL, `Found cleanup file: ${fullPath}`);
+        await WorkspaceFS.delete(fullPath);
+      }
+    });
 
     logger.info(
       CHANNEL,

--- a/src/latex/arxivProcessor.ts
+++ b/src/latex/arxivProcessor.ts
@@ -52,6 +52,7 @@ export class ArxivSourceProcessor {
     timeout = 30000,
   ): Promise<string> {
     let destPath = destBasePath;
+    let shouldCleanup = true;
     try {
       const response = await axios.get(url, {
         responseType: 'stream',
@@ -101,17 +102,12 @@ export class ArxivSourceProcessor {
         response.data as NodeJS.ReadableStream,
         AbsoluteFS.createWriteStream(destPath),
       );
-
+      shouldCleanup = false;
       return destPath;
-    } catch (err) {
-      try {
-        if (destPath) {
-          await AbsoluteFS.delete(destPath);
-        }
-      } catch (_err) {
-        // ignore errors deleting destPath
+    } finally {
+      if (shouldCleanup && destPath) {
+        void AbsoluteFS.delete(destPath).catch(() => undefined);
       }
-      throw err;
     }
   }
 

--- a/src/latex/latexdiff.ts
+++ b/src/latex/latexdiff.ts
@@ -61,6 +61,29 @@ export class LaTeXdiffService {
     );
   }
 
+  private logDiffError(context: string, err: unknown): LaTeXdiffResult {
+    const message = formatError(context, err);
+    logger.error(this.channel, message, {
+      messageType: MESSAGE_TYPES.INTERNAL,
+    });
+    return { success: false, message };
+  }
+
+  private logDiffMultipleError(
+    context: string,
+    err: unknown,
+  ): LaTeXdiffMultipleResult {
+    const message = formatError(context, err);
+    logger.error(this.channel, message, {
+      messageType: MESSAGE_TYPES.INTERNAL,
+    });
+    return {
+      success: false,
+      results: { success: [], failed: [] },
+      message,
+    };
+  }
+
   async runDiff(
     inputLocation: FileLocation,
     editedLocation: FileLocation,
@@ -143,16 +166,13 @@ export class LaTeXdiffService {
         message: `LaTeXdiff completed successfully: ${diffFileName}`,
       };
     } catch (err) {
-      const message = formatError('Error running LaTeX diff', err);
-      logger.error(this.channel, message, {
-        messageType: MESSAGE_TYPES.INTERNAL,
-      });
+      const result = this.logDiffError('Error running LaTeX diff', err);
       logger.debug(
         this.channel,
         `Latexdiff failed: ${inputLocation.absolutePath} -> ${editedLocation.absolutePath}`,
         { messageType: MESSAGE_TYPES.INTERNAL },
       );
-      return { success: false, message };
+      return result;
     }
   }
 
@@ -189,11 +209,7 @@ export class LaTeXdiffService {
         message: `LaTeXdiff VC completed successfully: ${path.basename(diffFileName)}`,
       };
     } catch (err) {
-      const message = formatError('Error running LaTeX diff VC', err);
-      logger.error(this.channel, message, {
-        messageType: MESSAGE_TYPES.INTERNAL,
-      });
-      return { success: false, message };
+      return this.logDiffError('Error running LaTeX diff VC', err);
     }
   }
 
@@ -256,15 +272,7 @@ export class LaTeXdiffService {
         message: summary,
       };
     } catch (err) {
-      const message = formatError('Error in runDiffVcMultiple', err);
-      logger.error(this.channel, message, {
-        messageType: MESSAGE_TYPES.INTERNAL,
-      });
-      return {
-        success: false,
-        results: { success: [], failed: [] },
-        message,
-      };
+      return this.logDiffMultipleError('Error in runDiffVcMultiple', err);
     }
   }
 
@@ -295,11 +303,7 @@ export class LaTeXdiffService {
       logger.warn(this.channel, message);
       return { success: false, message };
     } catch (err) {
-      const message = formatError('Error in runDiffForRound', err);
-      logger.error(this.channel, message, {
-        messageType: MESSAGE_TYPES.INTERNAL,
-      });
-      return { success: false, message };
+      return this.logDiffError('Error in runDiffForRound', err);
     }
   }
 
@@ -341,11 +345,7 @@ export class LaTeXdiffService {
       logger.warn(this.channel, message);
       return { success: false, message };
     } catch (err) {
-      const message = formatError('Error in runDiffBetweenRounds', err);
-      logger.error(this.channel, message, {
-        messageType: MESSAGE_TYPES.INTERNAL,
-      });
-      return { success: false, message };
+      return this.logDiffError('Error in runDiffBetweenRounds', err);
     }
   }
 

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -12,14 +12,17 @@ import {
   isAgentTypeFilter,
 } from '@agent/types/AgentStreamTypes';
 // Type imports
-import type { StreamTabId, ExecutionId } from '@agent/types/IdentifierTypes';
+import type {
+  ExecutionId,
+  StorageKey,
+  StreamTabId,
+} from '@agent/types/IdentifierTypes';
 // Internal imports
 import { retryCoordinator } from '@agent/runtime/RetryRequestCoordinator';
 import { toErrorMessage } from '@common/errors';
 import { RecordingManager } from '@common/managers';
 import { BaseViewMessageHandler, MessageHandler } from '@common/webview';
 import { PROGRESS_VIEW_COMMANDS } from '@common/webview';
-import { normalizeRunId } from '@common/constants/runIds';
 import { safeExecuteCommand } from '@frontend/system/commandUtils';
 import {
   isWorkflowTaskState,
@@ -263,10 +266,11 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
       // storageKey is for logical indexing (finding file metadata in progress view state).
       // For workflow agents: activeRunId = task group ID; for tool-use: executionId.
       // Note: Physical file paths use executionId (see runId below), not storageKey.
-      const storageKey = normalizeRunId(activeRunId ?? executionId);
-      const runOutputs = this.provider.state.getRunOutputFiles(message.stream, {
-        storageKey,
-      });
+      const storageKey: StorageKey | null =
+        activeRunId ?? (executionId as StorageKey | undefined) ?? null;
+      const runOutputs = storageKey
+        ? this.provider.state.getRunOutputFiles(message.stream, { storageKey })
+        : undefined;
       const outputsByRound = runOutputs
         ? Object.fromEntries(runOutputs.entries())
         : undefined;
@@ -423,7 +427,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
       persist: false,
     });
     // Only fetch output files if we have a resolved run ID
-    const storageKey = resolvedRunId ? normalizeRunId(resolvedRunId) : null;
+    const storageKey = resolvedRunId ? (resolvedRunId as StorageKey) : null;
     const runOutputs = storageKey
       ? this.provider.state.getRunOutputFiles(stream, { storageKey })
       : undefined;
@@ -611,7 +615,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
     const generatedPaths = this.provider.state.outputFiles.getKnownFilePaths(
       stream,
       {
-        storageKey: resolvedRunId ? normalizeRunId(resolvedRunId) : null,
+        storageKey: resolvedRunId ? (resolvedRunId as StorageKey) : null,
         workspaceOnly: true,
       },
     );

--- a/src/progressView/state/ProgressViewState.ts
+++ b/src/progressView/state/ProgressViewState.ts
@@ -367,7 +367,7 @@ export class ProgressViewState {
         continue;
       }
 
-      const startTime = this.normalizeStartTime(group);
+      const startTime = group.startTime;
       if (!latest || startTime >= latest.start) {
         latest = { id: group.id, start: startTime };
       }
@@ -383,19 +383,6 @@ export class ProgressViewState {
     }
 
     return latest?.id ?? null;
-  }
-
-  private normalizeStartTime(group: TaskGroup): number {
-    if (typeof group.startTime === 'number') {
-      return group.startTime;
-    }
-
-    if (typeof group.startTime === 'string') {
-      const parsed = Date.parse(group.startTime);
-      return Number.isNaN(parsed) ? 0 : parsed;
-    }
-
-    return 0;
   }
 
   private loadActiveRunIds(): void {

--- a/supabase/functions/auth-github/index.ts
+++ b/supabase/functions/auth-github/index.ts
@@ -150,7 +150,9 @@ async function validateGitHubToken(
 
   if (!userRes || !userRes.ok || !workingHeaders) {
     console.error(`[AUTH] GitHub token validation failed: ${lastError}`);
-    return { error: `GitHub API rejected token (${lastError.split(' - ')[0]})` };
+    return {
+      error: `GitHub API rejected token (${lastError.split(' - ')[0]})`,
+    };
   }
 
   const user: GitHubUser = await userRes.json();


### PR DESCRIPTION
### Motivation
- Reduce redundant run ID normalization and clarify the distinction between logical `storageKey` and physical `executionId` when accessing run output files. 
- Consolidate duplicated built-in path resolution and custom-path mapping used by the agent explorer. 
- Centralize common error handling and parsing logic for LaTeX diff and auth token exchange flows to simplify callers. 
- Simplify directory traversal and cleanup for housekeeping utilities to make formatting logic clearer. 

### Description
- Progress view: removed extra `normalizeRunId` calls and adjusted calls to `getRunOutputFiles` / `getKnownFilePaths` to use typed `StorageKey | null` values, and added `StorageKey` imports where needed. 
- Explorer: added `loadBuiltInPaths` and `resolveCustomPath` in `ExplorerOperations` and `FolderExplorer` to cache built-in paths and map built-in locations to the custom directory when creating copies. 
- LaTeX & housekeeping: added `logDiffError` / `logDiffMultipleError` helpers in `latexdiff.ts` and refactored `indent.ts` to a `walkDirectory` callback pattern with a separate cleanup pass. 
- Auth & arXiv: introduced `fetchWithTimeout` and `parseTokenExchangeResponse` helpers in `SupabaseAuthProvider`, and ensured temporary file cleanup in `arxivProcessor.ts` using a `shouldCleanup` flag and `finally`. 
- Minor: small formatting/shape fix in `supabase/functions/auth-github/index.ts` error return. 

### Testing
- Ran `npm run format` which completed successfully. 
- Ran `npm run compile` which completed successfully but produced a webpack warning about a critical dependency from `nunjucks`. 
- Ran `npm run lint` which finished with warnings (import order and `eqeqeq`) but no errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f667d2d948324b6053dcd923783b3)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Scope**: Progress view run handling, agent explorer path resolution, auth token exchange, LaTeX diff/error handling, housekeeping and arXiv download cleanup.
> 
> - Progress view: replace `normalizeRunId` usage with typed `StorageKey`, adjust calls to `getRunOutputFiles`/`getKnownFilePaths`, and simplify latest-run resolution using `group.startTime`.
> - Explorer: add `loadBuiltInPaths` caching and `resolveCustomPath` to map built-in files to custom directory; mark built-in status for both agents and tool-use; use `toErrorMessage` in warnings.
> - Auth: extract `fetchWithTimeout` and `parseTokenExchangeResponse` in `SupabaseAuthProvider` to handle timeouts and schema validation; reuse in GitHub token exchange path.
> - LaTeX: add `logDiffError`/`logDiffMultipleError` helpers in `latexdiff.ts` and refactor callers to use them; `indent.ts` switches to a `walkDirectory` callback with a separate temp-file cleanup pass.
> - arXiv: ensure temporary file cleanup via `shouldCleanup` + `finally` in `downloadFile`.
> - Minor: format small error return in `supabase/functions/auth-github/index.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ff8e3ffe0a46c609c354079cac22ebb9c6cbad13. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->