### PR TITLE
Continue Gemini model followup message typing

### DIFF
--- a/src/agent/implementations/flows/ToolUseRunFlow.ts
+++ b/src/agent/implementations/flows/ToolUseRunFlow.ts
@@ -148,7 +148,7 @@ type ToolUsePrepareExecResult = NodeExecResult<ToolUsePrepareResult>;
  * Uses 'kind' discriminant for clarity (matches PocketFlow's InvocationResult).
  */
 type CycleExecResult =
-  | { kind: 'success' }
+  | { kind: 'success'; messages: ProviderMessage[] }
   | { kind: 'skipped' }
   | { kind: 'failed'; message: string }
   | { kind: 'cancelled' };
@@ -409,7 +409,9 @@ class ToolUseCycleNode<C> extends Node<
       if (completion.userCancelled) {
         return { kind: 'cancelled' };
       }
-      return { kind: 'success' };
+      // Return messages explicitly to ensure they're synced in post()
+      // cycleShared.messages was mutated during the cycle flow
+      return { kind: 'success', messages: cycleShared.messages };
     } catch (error) {
       return {
         kind: 'failed',
@@ -448,6 +450,13 @@ class ToolUseCycleNode<C> extends Node<
 
     switch (execRes.kind) {
       case 'success':
+        // Explicitly sync conversation from cycle result to ensure messages are preserved
+        // This is defensive - the array should be the same reference, but explicit sync
+        // ensures PersistedFlow saves the correct state
+        shared.state.conversation = execRes.messages;
+        // PersistedFlow handles checkpoint persistence automatically after each node
+        return FlowTransition.DEFAULT; // Follow next() → WaitNode
+
       case 'skipped':
         // PersistedFlow handles checkpoint persistence automatically after each node
         return FlowTransition.DEFAULT; // Follow next() → WaitNode

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -297,13 +297,20 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     const activeStreamInfo = streams.find(
       (s) => s.name === message.activeStream,
     );
-    const sessionKind =
-      activeStreamInfo?.agentSessionKind ||
-      activeStreamInfo?.uiTraits?.sessionKind ||
-      'workflow'; // Default fallback
+    // Only determine session kind if we have stream info - avoid false 'workflow' default
+    // that would incorrectly clear tool-use log content
+    const sessionKind = activeStreamInfo
+      ? activeStreamInfo.agentSessionKind ||
+        activeStreamInfo.uiTraits?.sessionKind ||
+        'workflow'
+      : state.activeSessionKind || 'workflow';
     const isToolAgent = sessionKind === 'toolUse';
 
-    this._clearSessionKindState(sessionKind);
+    // Only clear session state if we have confirmed stream info for the session kind change
+    // This prevents clearing log content when stream info is temporarily unavailable
+    if (activeStreamInfo) {
+      this._clearSessionKindState(sessionKind);
+    }
     state.activeSessionKind = sessionKind;
 
     dom.runSelector.setDisplayEnabled(
@@ -796,7 +803,11 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       message.sessionKind || state.activeSessionKind || 'workflow';
     const isToolUseAgent = sessionKind === 'toolUse';
 
-    this._clearSessionKindState(sessionKind);
+    // Only clear session state if message explicitly provides session kind
+    // This prevents clearing log content when session kind is derived from state fallback
+    if (message.sessionKind) {
+      this._clearSessionKindState(sessionKind);
+    }
     state.activeSessionKind = sessionKind;
 
     let activeRunId = state.getActiveRunId(activeStream);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Strengthens state persistence and UI stability for tool-use sessions.
> 
> - ToolUseRunFlow: `CycleExecResult` success now carries `messages`; cycle `exec()` returns these and `post()` explicitly syncs `shared.state.conversation` to ensure PersistedFlow saves the updated conversation.
> - Progress view: Safer session-kind resolution. Only clear session state when stream info or explicit `sessionKind` is present; fall back to previous `state.activeSessionKind` instead of defaulting to `workflow`, preventing accidental clearing of tool-use log content. Applies in `handleUpdateStreams` and `handleUpdateInstruction`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2238386a7b7c7212671e683da544b97db683873a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->