### PR TITLE
Set up OpenAI API key relay server

### DIFF
--- a/src/agent/modelHandlers/toolConversion.ts
+++ b/src/agent/modelHandlers/toolConversion.ts
@@ -1,6 +1,5 @@
 // Third-party imports
 import { toJSONSchema } from 'zod';
-import { zodFunction } from 'openai/helpers/zod';
 
 // Type imports
 import type { ToolDefinition } from '@model';
@@ -50,39 +49,16 @@ const ANTHROPIC_TOOL_TYPE_MAP: Record<string, string> = {
 
 /**
  * Convert generic ToolDefinition objects to OpenAI ChatCompletionTool format.
- *
- * When a tool has a zodSchema, uses OpenAI's native zodFunction() helper which:
- * - Converts Zod schema to JSON Schema using SDK's optimized conversion
- * - Enables strict mode for better type safety
- *
- * Note: zodFunction() may throw for invalid schemas - this is intentional fail-fast
- * behavior since invalid tool schemas are programming errors caught during development.
  */
 export function toOpenAITools(defs: ToolDefinition[]): ChatCompletionTool[] {
-  return defs.map((d) => {
-    // Use native SDK Zod conversion when schema is available
-    // zodFunction() returns AutoParseableTool which extends ChatCompletionFunctionTool
-    // with additional parsing metadata - structurally compatible with ChatCompletionTool
-    if (d.zodSchema) {
-      return zodFunction({
-        name: d.name,
-        description: d.description,
-        parameters: d.zodSchema,
-      }) as ChatCompletionTool;
-    }
-
-    // Fallback to manual conversion for legacy definitions
-    // Cast to ChatCompletionFunctionTool since ToolDefinition.parameters
-    // is a union type that includes provider-specific schemas
-    return {
-      type: 'function',
-      function: {
-        name: d.name,
-        description: d.description,
-        parameters: d.parameters,
-      },
-    } as ChatCompletionFunctionTool;
-  });
+  return defs.map((d): ChatCompletionFunctionTool => ({
+    type: 'function',
+    function: {
+      name: d.name,
+      description: d.description,
+      parameters: convertToolSchema(d) as ChatCompletionFunctionTool['function']['parameters'],
+    },
+  }));
 }
 
 /**

--- a/src/tools/web/WebFetchTool.ts
+++ b/src/tools/web/WebFetchTool.ts
@@ -14,10 +14,17 @@ import { defineTool } from '@tools/core/define';
 
 const WebFetchInputSchema = z.strictObject({
   url: z
-    .url('Provide a valid absolute URL to fetch.')
+    .string()
     .refine(
-      (value) => value.startsWith('http://') || value.startsWith('https://'),
-      'URL must use HTTP or HTTPS protocol',
+      (value) => {
+        try {
+          const parsed = new URL(value);
+          return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+        } catch {
+          return false;
+        }
+      },
+      'Provide a valid HTTP or HTTPS URL',
     ),
   prompt: z.string().min(1).nullish(),
 });


### PR DESCRIPTION
…rmat in Chat Completion API

OpenAI's Chat Completion API rejects JSON Schema with `format: "uri"` that Zod's z.url() produces. Instead of stripping formats at conversion time, fix at source by using z.string().refine() with URL validation in WebFetchTool.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> - **Eliminate `format: "uri"` in `WebFetchTool`**: Switch `url` from `z.url()` to `z.string().refine()` using `URL` parsing and HTTP/HTTPS check; updates error message to "Provide a valid HTTP or HTTPS URL".
> - **Unify OpenAI tool conversion**: Remove `zodFunction` usage and always emit `function` tools using a shared `convertToolSchema()` utility that prefers Zod→JSON Schema via `toJSONSchema` and falls back to `parameters`.
> - Keeps Anthropic and Google converters, now also using `convertToolSchema` where applicable for consistency.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dd2c2a19cfa34c8d42df14184e56690be2a947be. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->