### PR TITLE
fix: map memory tool to global storage

### DIFF
--- a/src/agent/modelHandlers/toolConversion.ts
+++ b/src/agent/modelHandlers/toolConversion.ts
@@ -46,6 +46,7 @@ const ANTHROPIC_TOOL_TYPE_MAP: Record<string, string> = {
   str_replace_editor: 'text_editor_20250429',
   str_replace_based_edit_tool: 'text_editor_20250429',
   web_search: 'web_search_20250305',
+  memory: 'memory_20250818',
 } as const;
 
 /**

--- a/src/commands/files/openFileCommands.ts
+++ b/src/commands/files/openFileCommands.ts
@@ -4,14 +4,16 @@ import * as vscode from 'vscode';
 // Local imports - common
 import { toErrorMessage } from '@common/errors';
 
+const CHANNEL = 'openFileCommands';
+
+// Local imports - frontend
+import { fileLister } from '@frontend/files';
+import { openBuildDisplayIfTex } from '@frontend/latex/openBuild';
+
 // Local imports - logging
 import * as logger from '@logger/logUtils';
 
-const CHANNEL = 'openFileCommands';
-
 // Local imports - utilities
-import { fileLister } from '@frontend/files';
-import { openBuildDisplayIfTex } from '@frontend/latex/openBuild';
 import { WorkspaceFS } from '@utils/files';
 
 export async function openFile(file: string): Promise<void> {

--- a/src/tools/ReadTool.ts
+++ b/src/tools/ReadTool.ts
@@ -22,10 +22,16 @@ const ReadInputSchema = z.strictObject({
       start: z.int().min(1),
       end: z.int().min(1).nullish(),
     })
-    .refine((value) => value.end == null || value.end >= value.start, {
-      path: ['end'],
-      error: 'range.end must be greater than or equal to range.start',
-    })
+    .refine(
+      (value) =>
+        value.end === null ||
+        value.end === undefined ||
+        value.end >= value.start,
+      {
+        path: ['end'],
+        error: 'range.end must be greater than or equal to range.start',
+      },
+    )
     .nullish(),
 });
 
@@ -116,7 +122,9 @@ export class ReadFileTool extends defineTool({
       truncated,
       rangeProvided: Boolean(input.range),
       rangeEndExceeded:
-        input.range?.end != null && input.range.end > totalLines,
+        input.range?.end !== null &&
+        input.range?.end !== undefined &&
+        input.range.end > totalLines,
     });
 
     return {

--- a/src/tools/TextEditorTool.ts
+++ b/src/tools/TextEditorTool.ts
@@ -129,7 +129,7 @@ export class TextEditorTool extends defineTool({
         );
 
       case 'insert':
-        if (input.insert_line == null) {
+        if (input.insert_line === null || input.insert_line === undefined) {
           throw new ToolError(
             'Parameter `insert_line` is required for command: insert',
           );

--- a/src/tools/fileOp.ts
+++ b/src/tools/fileOp.ts
@@ -48,7 +48,7 @@ export class FileOpTool extends defineTool({
         };
       }
       case 'write': {
-        if (content == null) {
+        if (content === null || content === undefined) {
           return {
             error: 'content parameter is required for write',
             isError: true,
@@ -105,7 +105,7 @@ export class FileOpTool extends defineTool({
         };
       }
       case 'append': {
-        if (content == null) {
+        if (content === null || content === undefined) {
           return {
             error: 'content parameter is required for append',
             isError: true,

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -20,3 +20,4 @@ export * from './citation';
 export * from './web/WebFetchTool';
 export * from './web/WebSearchTool';
 export * from './todo';
+export * from './memory';

--- a/src/tools/memory/MemoryTool.ts
+++ b/src/tools/memory/MemoryTool.ts
@@ -6,7 +6,7 @@ import * as vscode from 'vscode';
 import { z } from 'zod';
 
 // Local imports - filesystem utilities
-import { GlobalStorageFS } from '@utils/files';
+import { StorageFS } from '@utils/files';
 
 // Local imports - tool core
 import { defineTool } from '../core/define';
@@ -29,10 +29,16 @@ const MemoryToolInputSchema = z.strictObject({
   ]),
   path: z.string().nullish(),
   file_text: z.string().nullish(),
-  view_range: z.tuple([z.number(), z.number()]).nullish(),
+  view_range: z
+    .tuple([z.int().min(1), z.int().min(1)])
+    .refine(([start, end]) => end >= start, {
+      error: 'view_range[1] must be greater than or equal to view_range[0]',
+    })
+    .nullish(),
   old_str: z.string().nullish(),
   new_str: z.string().nullish(),
-  insert_line: z.number().nullish(),
+  insert_line: z.int().min(0).nullish(),
+  insert_text: z.string().nullish(),
   old_path: z.string().nullish(),
   new_path: z.string().nullish(),
 });
@@ -71,7 +77,11 @@ export class MemoryTool extends defineTool({
         return this.insert(
           this.requirePath(input.path, input.command),
           this.requireField(input.insert_line, 'insert_line', input.command),
-          this.requireField(input.new_str, 'new_str', input.command),
+          this.requireField(
+            input.insert_text ?? input.new_str,
+            'insert_text',
+            input.command,
+          ),
         );
       case 'delete':
         return this.delete(this.requirePath(input.path, input.command));
@@ -117,17 +127,20 @@ export class MemoryTool extends defineTool({
         `The path ${inputPath} does not exist. Please provide a valid path.`,
       );
     }
-    if (inputPath.split('/').includes('..')) {
-      throw new ToolError(
-        `The path ${inputPath} does not exist. Please provide a valid path.`,
-      );
-    }
     const suffix =
       inputPath === MEMORY_ROOT
         ? ''
         : inputPath.slice(`${MEMORY_ROOT}/`.length);
-    return suffix
-      ? path.join(MEMORY_STORAGE_ROOT, suffix)
+    const resolved = path.resolve(MEMORY_STORAGE_ROOT, suffix);
+    const base = path.resolve(MEMORY_STORAGE_ROOT);
+    if (!resolved.startsWith(`${base}${path.sep}`) && resolved !== base) {
+      throw new ToolError(
+        `The path ${inputPath} does not exist. Please provide a valid path.`,
+      );
+    }
+    const relative = path.relative(base, resolved);
+    return relative
+      ? path.join(MEMORY_STORAGE_ROOT, relative)
       : MEMORY_STORAGE_ROOT;
   }
 
@@ -145,14 +158,14 @@ export class MemoryTool extends defineTool({
     viewRange?: [number, number],
   ): Promise<ToolResult> {
     const resolvedPath = this.resolveMemoryPath(inputPath);
-    const exists = await GlobalStorageFS.exists(resolvedPath);
+    const exists = await StorageFS.exists(resolvedPath);
     if (!exists) {
       throw new ToolError(
         `The path ${inputPath} does not exist. Please provide a valid path.`,
       );
     }
 
-    const stats = await GlobalStorageFS.stat(resolvedPath);
+    const stats = await StorageFS.stat(resolvedPath);
     if (stats.type === vscode.FileType.Directory) {
       const listing = await this.buildDirectoryListing(resolvedPath);
       return {
@@ -163,7 +176,7 @@ export class MemoryTool extends defineTool({
       };
     }
 
-    const content = await GlobalStorageFS.read(resolvedPath);
+    const content = await StorageFS.read(resolvedPath);
     const lines = content.split(/\r?\n/);
     if (lines.length > 0 && lines.at(-1) === '') {
       lines.pop();
@@ -199,14 +212,14 @@ export class MemoryTool extends defineTool({
     fileText: string,
   ): Promise<ToolResult> {
     const resolvedPath = this.resolveMemoryPath(inputPath);
-    const exists = await GlobalStorageFS.exists(resolvedPath);
+    const exists = await StorageFS.exists(resolvedPath);
     if (exists) {
       throw new ToolError(`Error: File ${inputPath} already exists`);
     }
 
-    await GlobalStorageFS.ensureDir(MEMORY_STORAGE_ROOT);
-    await GlobalStorageFS.ensureDir(path.dirname(resolvedPath));
-    await GlobalStorageFS.write(resolvedPath, fileText);
+    await StorageFS.ensureDir(MEMORY_STORAGE_ROOT);
+    await StorageFS.ensureDir(path.dirname(resolvedPath));
+    await StorageFS.write(resolvedPath, fileText);
 
     return {
       output: `File created successfully at: ${inputPath}`,
@@ -219,21 +232,21 @@ export class MemoryTool extends defineTool({
     newStr: string,
   ): Promise<ToolResult> {
     const resolvedPath = this.resolveMemoryPath(inputPath);
-    const exists = await GlobalStorageFS.exists(resolvedPath);
+    const exists = await StorageFS.exists(resolvedPath);
     if (!exists) {
       throw new ToolError(
         `Error: The path ${inputPath} does not exist. Please provide a valid path.`,
       );
     }
 
-    const isDir = await GlobalStorageFS.isDir(resolvedPath);
+    const isDir = await StorageFS.isDir(resolvedPath);
     if (isDir) {
       throw new ToolError(
         `Error: The path ${inputPath} does not exist. Please provide a valid path.`,
       );
     }
 
-    const content = await GlobalStorageFS.read(resolvedPath);
+    const content = await StorageFS.read(resolvedPath);
     const occurrences = content.split(oldStr).length - 1;
     if (occurrences === 0) {
       throw new ToolError(
@@ -254,7 +267,7 @@ export class MemoryTool extends defineTool({
     }
 
     const updated = content.replace(oldStr, newStr);
-    await GlobalStorageFS.write(resolvedPath, updated);
+    await StorageFS.write(resolvedPath, updated);
 
     const updatedLines = updated.split(/\r?\n/);
     const numbered = updatedLines.map((line, index) => {
@@ -279,17 +292,17 @@ export class MemoryTool extends defineTool({
     insertText: string,
   ): Promise<ToolResult> {
     const resolvedPath = this.resolveMemoryPath(inputPath);
-    const exists = await GlobalStorageFS.exists(resolvedPath);
+    const exists = await StorageFS.exists(resolvedPath);
     if (!exists) {
       throw new ToolError(`Error: The path ${inputPath} does not exist`);
     }
 
-    const isDir = await GlobalStorageFS.isDir(resolvedPath);
+    const isDir = await StorageFS.isDir(resolvedPath);
     if (isDir) {
       throw new ToolError(`Error: The path ${inputPath} does not exist`);
     }
 
-    const content = await GlobalStorageFS.read(resolvedPath);
+    const content = await StorageFS.read(resolvedPath);
     const lines = content.split(/\r?\n/);
     const totalLines = lines.length;
     if (insertLine < 0 || insertLine > totalLines) {
@@ -305,7 +318,7 @@ export class MemoryTool extends defineTool({
       ...lines.slice(insertLine),
     ];
 
-    await GlobalStorageFS.write(resolvedPath, updatedLines.join('\n'));
+    await StorageFS.write(resolvedPath, updatedLines.join('\n'));
 
     return {
       output: `The file ${inputPath} has been edited.`,
@@ -314,12 +327,12 @@ export class MemoryTool extends defineTool({
 
   private async delete(inputPath: string): Promise<ToolResult> {
     const resolvedPath = this.resolveMemoryPath(inputPath);
-    const exists = await GlobalStorageFS.exists(resolvedPath);
+    const exists = await StorageFS.exists(resolvedPath);
     if (!exists) {
       throw new ToolError(`Error: The path ${inputPath} does not exist`);
     }
 
-    await GlobalStorageFS.delete(resolvedPath, { recursive: true });
+    await StorageFS.delete(resolvedPath, { recursive: true });
     return {
       output: `Successfully deleted ${inputPath}`,
     };
@@ -332,19 +345,19 @@ export class MemoryTool extends defineTool({
     const resolvedOldPath = this.resolveMemoryPath(oldPathInput);
     const resolvedNewPath = this.resolveMemoryPath(newPathInput);
 
-    const oldExists = await GlobalStorageFS.exists(resolvedOldPath);
+    const oldExists = await StorageFS.exists(resolvedOldPath);
     if (!oldExists) {
       throw new ToolError(`Error: The path ${oldPathInput} does not exist`);
     }
 
-    const newExists = await GlobalStorageFS.exists(resolvedNewPath);
+    const newExists = await StorageFS.exists(resolvedNewPath);
     if (newExists) {
       throw new ToolError(
         `Error: The destination ${newPathInput} already exists`,
       );
     }
 
-    await GlobalStorageFS.rename(resolvedOldPath, resolvedNewPath);
+    await StorageFS.rename(resolvedOldPath, resolvedNewPath);
     return {
       output: `Successfully renamed ${oldPathInput} to ${newPathInput}`,
     };
@@ -352,7 +365,7 @@ export class MemoryTool extends defineTool({
 
   private async buildDirectoryListing(resolvedPath: string): Promise<string[]> {
     const entries: Array<{ path: string; size: number }> = [];
-    const rootStats = await GlobalStorageFS.stat(resolvedPath);
+    const rootStats = await StorageFS.stat(resolvedPath);
     entries.push({ path: resolvedPath, size: rootStats.size });
 
     await this.walkDirectory(resolvedPath, 0, entries);
@@ -372,13 +385,13 @@ export class MemoryTool extends defineTool({
       return;
     }
 
-    const children = await GlobalStorageFS.readDir(currentPath);
+    const children = await StorageFS.readDir(currentPath);
     for (const [name, type] of children) {
       if (name.startsWith('.') || name === 'node_modules') {
         continue;
       }
       const childPath = path.join(currentPath, name);
-      const stats = await GlobalStorageFS.stat(childPath);
+      const stats = await StorageFS.stat(childPath);
       entries.push({ path: childPath, size: stats.size });
 
       if (

--- a/src/tools/memory/MemoryTool.ts
+++ b/src/tools/memory/MemoryTool.ts
@@ -1,0 +1,407 @@
+// Standard library imports
+import * as path from 'path';
+
+// Third-party imports
+import * as vscode from 'vscode';
+import { z } from 'zod';
+
+// Local imports - filesystem utilities
+import { GlobalStorageFS } from '@utils/files';
+
+// Local imports - tool core
+import { defineTool } from '../core/define';
+import { ToolError, type ToolResult } from '../result';
+
+const MEMORY_ROOT = '/memories';
+const MEMORY_STORAGE_ROOT = 'memories';
+const MAX_VIEW_LINES = 999_999;
+const LINE_NUMBER_WIDTH = 6;
+const DIRECTORY_LISTING_DEPTH = 2;
+
+const MemoryToolInputSchema = z.strictObject({
+  command: z.enum([
+    'view',
+    'create',
+    'str_replace',
+    'insert',
+    'delete',
+    'rename',
+  ]),
+  path: z.string().nullish(),
+  file_text: z.string().nullish(),
+  view_range: z.tuple([z.number(), z.number()]).nullish(),
+  old_str: z.string().nullish(),
+  new_str: z.string().nullish(),
+  insert_line: z.number().nullish(),
+  old_path: z.string().nullish(),
+  new_path: z.string().nullish(),
+});
+
+/** Derived from MemoryToolInputSchema - single source of truth */
+export type MemoryToolInput = z.infer<typeof MemoryToolInputSchema>;
+
+/**
+ * Memory tool for managing persistent context files under /memories.
+ */
+export class MemoryTool extends defineTool({
+  name: 'memory',
+  description:
+    'Store, read, and manage persistent memory files under /memories using view, create, str_replace, insert, delete, or rename.',
+  schema: MemoryToolInputSchema,
+}) {
+  protected async execute(input: MemoryToolInput): Promise<ToolResult> {
+    switch (input.command) {
+      case 'view':
+        return this.view(
+          this.requirePath(input.path, input.command),
+          input.view_range ?? undefined,
+        );
+      case 'create':
+        return this.create(
+          this.requirePath(input.path, input.command),
+          this.requireField(input.file_text, 'file_text', input.command),
+        );
+      case 'str_replace':
+        return this.strReplace(
+          this.requirePath(input.path, input.command),
+          this.requireField(input.old_str, 'old_str', input.command),
+          this.requireField(input.new_str, 'new_str', input.command),
+        );
+      case 'insert':
+        return this.insert(
+          this.requirePath(input.path, input.command),
+          this.requireField(input.insert_line, 'insert_line', input.command),
+          this.requireField(input.new_str, 'new_str', input.command),
+        );
+      case 'delete':
+        return this.delete(this.requirePath(input.path, input.command));
+      case 'rename':
+        return this.rename(
+          this.requireField(input.old_path, 'old_path', input.command),
+          this.requireField(input.new_path, 'new_path', input.command),
+        );
+      default:
+        throw new ToolError(`Unrecognized command: ${input.command}`);
+    }
+  }
+
+  private requirePath(
+    value: string | null | undefined,
+    command: string,
+  ): string {
+    if (!value) {
+      throw new ToolError(
+        `Parameter \`path\` is required for command: ${command}`,
+      );
+    }
+    return value;
+  }
+
+  private requireField<T>(
+    value: T | null | undefined,
+    name: string,
+    command: string,
+  ): T {
+    // eslint-disable-next-line eqeqeq -- use nullish check for tool inputs
+    if (value == null) {
+      throw new ToolError(
+        `Parameter \`${name}\` is required for command: ${command}`,
+      );
+    }
+    return value;
+  }
+
+  private resolveMemoryPath(inputPath: string): string {
+    if (inputPath !== MEMORY_ROOT && !inputPath.startsWith(`${MEMORY_ROOT}/`)) {
+      throw new ToolError(
+        `The path ${inputPath} does not exist. Please provide a valid path.`,
+      );
+    }
+    if (inputPath.split('/').includes('..')) {
+      throw new ToolError(
+        `The path ${inputPath} does not exist. Please provide a valid path.`,
+      );
+    }
+    const suffix =
+      inputPath === MEMORY_ROOT
+        ? ''
+        : inputPath.slice(`${MEMORY_ROOT}/`.length);
+    return suffix
+      ? path.join(MEMORY_STORAGE_ROOT, suffix)
+      : MEMORY_STORAGE_ROOT;
+  }
+
+  private toDisplayPath(storagePath: string): string {
+    const relative = path.relative(MEMORY_STORAGE_ROOT, storagePath);
+    if (!relative || relative === '') {
+      return MEMORY_ROOT;
+    }
+    const normalized = relative.split(path.sep).join('/');
+    return `${MEMORY_ROOT}/${normalized}`;
+  }
+
+  private async view(
+    inputPath: string,
+    viewRange?: [number, number],
+  ): Promise<ToolResult> {
+    const resolvedPath = this.resolveMemoryPath(inputPath);
+    const exists = await GlobalStorageFS.exists(resolvedPath);
+    if (!exists) {
+      throw new ToolError(
+        `The path ${inputPath} does not exist. Please provide a valid path.`,
+      );
+    }
+
+    const stats = await GlobalStorageFS.stat(resolvedPath);
+    if (stats.type === vscode.FileType.Directory) {
+      const listing = await this.buildDirectoryListing(resolvedPath);
+      return {
+        output: [
+          `Here're the files and directories up to 2 levels deep in ${inputPath}, excluding hidden items and node_modules:`,
+          ...listing,
+        ].join('\n'),
+      };
+    }
+
+    const content = await GlobalStorageFS.read(resolvedPath);
+    const lines = content.split(/\r?\n/);
+    if (lines.length > 0 && lines.at(-1) === '') {
+      lines.pop();
+    }
+    if (lines.length > MAX_VIEW_LINES) {
+      throw new ToolError(
+        `File ${inputPath} exceeds maximum line limit of 999,999 lines.`,
+      );
+    }
+
+    const [start, end] = viewRange ?? [1, lines.length];
+    const startIndex = Math.max(start - 1, 0);
+    const endIndex = Math.min(end, lines.length);
+    const selected = lines.slice(startIndex, endIndex);
+
+    const numbered = selected.map((line, index) => {
+      const lineNumber = (startIndex + index + 1)
+        .toString()
+        .padStart(LINE_NUMBER_WIDTH, ' ');
+      return `${lineNumber}\t${line}`;
+    });
+
+    return {
+      output: [
+        `Here's the content of ${inputPath} with line numbers:`,
+        ...numbered,
+      ].join('\n'),
+    };
+  }
+
+  private async create(
+    inputPath: string,
+    fileText: string,
+  ): Promise<ToolResult> {
+    const resolvedPath = this.resolveMemoryPath(inputPath);
+    const exists = await GlobalStorageFS.exists(resolvedPath);
+    if (exists) {
+      throw new ToolError(`Error: File ${inputPath} already exists`);
+    }
+
+    await GlobalStorageFS.ensureDir(MEMORY_STORAGE_ROOT);
+    await GlobalStorageFS.ensureDir(path.dirname(resolvedPath));
+    await GlobalStorageFS.write(resolvedPath, fileText);
+
+    return {
+      output: `File created successfully at: ${inputPath}`,
+    };
+  }
+
+  private async strReplace(
+    inputPath: string,
+    oldStr: string,
+    newStr: string,
+  ): Promise<ToolResult> {
+    const resolvedPath = this.resolveMemoryPath(inputPath);
+    const exists = await GlobalStorageFS.exists(resolvedPath);
+    if (!exists) {
+      throw new ToolError(
+        `Error: The path ${inputPath} does not exist. Please provide a valid path.`,
+      );
+    }
+
+    const isDir = await GlobalStorageFS.isDir(resolvedPath);
+    if (isDir) {
+      throw new ToolError(
+        `Error: The path ${inputPath} does not exist. Please provide a valid path.`,
+      );
+    }
+
+    const content = await GlobalStorageFS.read(resolvedPath);
+    const occurrences = content.split(oldStr).length - 1;
+    if (occurrences === 0) {
+      throw new ToolError(
+        `No replacement was performed, old_str \`${oldStr}\` did not appear verbatim in ${inputPath}.`,
+      );
+    }
+
+    const lines = content.split(/\r?\n/);
+    if (occurrences > 1) {
+      const lineNumbers = lines
+        .map((line, index) => (line.includes(oldStr) ? index + 1 : null))
+        .filter((lineNumber): lineNumber is number => lineNumber !== null);
+      throw new ToolError(
+        `No replacement was performed. Multiple occurrences of old_str \`${oldStr}\` in lines: ${lineNumbers.join(
+          ', ',
+        )}. Please ensure it is unique`,
+      );
+    }
+
+    const updated = content.replace(oldStr, newStr);
+    await GlobalStorageFS.write(resolvedPath, updated);
+
+    const updatedLines = updated.split(/\r?\n/);
+    const numbered = updatedLines.map((line, index) => {
+      const lineNumber = (index + 1)
+        .toString()
+        .padStart(LINE_NUMBER_WIDTH, ' ');
+      return `${lineNumber}\t${line}`;
+    });
+
+    return {
+      output: [
+        'The memory file has been edited.',
+        `Here's the content of ${inputPath} with line numbers:`,
+        ...numbered,
+      ].join('\n'),
+    };
+  }
+
+  private async insert(
+    inputPath: string,
+    insertLine: number,
+    insertText: string,
+  ): Promise<ToolResult> {
+    const resolvedPath = this.resolveMemoryPath(inputPath);
+    const exists = await GlobalStorageFS.exists(resolvedPath);
+    if (!exists) {
+      throw new ToolError(`Error: The path ${inputPath} does not exist`);
+    }
+
+    const isDir = await GlobalStorageFS.isDir(resolvedPath);
+    if (isDir) {
+      throw new ToolError(`Error: The path ${inputPath} does not exist`);
+    }
+
+    const content = await GlobalStorageFS.read(resolvedPath);
+    const lines = content.split(/\r?\n/);
+    const totalLines = lines.length;
+    if (insertLine < 0 || insertLine > totalLines) {
+      throw new ToolError(
+        `Error: Invalid \`insert_line\` parameter: ${insertLine}. It should be within the range of lines of the file: [0, ${totalLines}]`,
+      );
+    }
+
+    const insertLines = insertText.split(/\r?\n/);
+    const updatedLines = [
+      ...lines.slice(0, insertLine),
+      ...insertLines,
+      ...lines.slice(insertLine),
+    ];
+
+    await GlobalStorageFS.write(resolvedPath, updatedLines.join('\n'));
+
+    return {
+      output: `The file ${inputPath} has been edited.`,
+    };
+  }
+
+  private async delete(inputPath: string): Promise<ToolResult> {
+    const resolvedPath = this.resolveMemoryPath(inputPath);
+    const exists = await GlobalStorageFS.exists(resolvedPath);
+    if (!exists) {
+      throw new ToolError(`Error: The path ${inputPath} does not exist`);
+    }
+
+    await GlobalStorageFS.delete(resolvedPath, { recursive: true });
+    return {
+      output: `Successfully deleted ${inputPath}`,
+    };
+  }
+
+  private async rename(
+    oldPathInput: string,
+    newPathInput: string,
+  ): Promise<ToolResult> {
+    const resolvedOldPath = this.resolveMemoryPath(oldPathInput);
+    const resolvedNewPath = this.resolveMemoryPath(newPathInput);
+
+    const oldExists = await GlobalStorageFS.exists(resolvedOldPath);
+    if (!oldExists) {
+      throw new ToolError(`Error: The path ${oldPathInput} does not exist`);
+    }
+
+    const newExists = await GlobalStorageFS.exists(resolvedNewPath);
+    if (newExists) {
+      throw new ToolError(
+        `Error: The destination ${newPathInput} already exists`,
+      );
+    }
+
+    await GlobalStorageFS.rename(resolvedOldPath, resolvedNewPath);
+    return {
+      output: `Successfully renamed ${oldPathInput} to ${newPathInput}`,
+    };
+  }
+
+  private async buildDirectoryListing(resolvedPath: string): Promise<string[]> {
+    const entries: Array<{ path: string; size: number }> = [];
+    const rootStats = await GlobalStorageFS.stat(resolvedPath);
+    entries.push({ path: resolvedPath, size: rootStats.size });
+
+    await this.walkDirectory(resolvedPath, 0, entries);
+
+    return entries.map((entry) => {
+      const displayPath = this.toDisplayPath(entry.path);
+      return `${this.formatSize(entry.size)}\t${displayPath}`;
+    });
+  }
+
+  private async walkDirectory(
+    currentPath: string,
+    depth: number,
+    entries: Array<{ path: string; size: number }>,
+  ): Promise<void> {
+    if (depth >= DIRECTORY_LISTING_DEPTH) {
+      return;
+    }
+
+    const children = await GlobalStorageFS.readDir(currentPath);
+    for (const [name, type] of children) {
+      if (name.startsWith('.') || name === 'node_modules') {
+        continue;
+      }
+      const childPath = path.join(currentPath, name);
+      const stats = await GlobalStorageFS.stat(childPath);
+      entries.push({ path: childPath, size: stats.size });
+
+      if (
+        type === vscode.FileType.Directory &&
+        depth + 1 < DIRECTORY_LISTING_DEPTH
+      ) {
+        await this.walkDirectory(childPath, depth + 1, entries);
+      }
+    }
+  }
+
+  private formatSize(bytes: number): string {
+    if (bytes < 1024) {
+      return `${bytes}B`;
+    }
+
+    const units = ['K', 'M', 'G', 'T'];
+    let value = bytes / 1024;
+    let unitIndex = 0;
+    while (value >= 1024 && unitIndex < units.length - 1) {
+      value /= 1024;
+      unitIndex += 1;
+    }
+    return `${value.toFixed(1)}${units[unitIndex]}`;
+  }
+}

--- a/src/tools/memory/index.ts
+++ b/src/tools/memory/index.ts
@@ -1,0 +1,1 @@
+export * from './MemoryTool';

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -32,6 +32,7 @@ import { WolframTool } from './wolfram';
 import { TexcountTool } from './texcount';
 import { CrossrefDoiTool, CrossrefSearchTool } from './citation';
 import { TodoWriteTool } from './todo';
+import { MemoryTool } from './memory';
 
 /** Singleton IToolRegistry instance for the default tools. */
 let defaultRegistryInstance: IToolRegistry | null = null;
@@ -67,6 +68,7 @@ export function getDefaultToolRegistry(): IToolRegistry {
       web_fetch: new WebFetchTool(),
       web_search: new WebSearchTool(),
       todo_write: new TodoWriteTool(),
+      memory: new MemoryTool(),
     });
   }
   return defaultRegistryInstance;


### PR DESCRIPTION
### Motivation

- Provide a working backing store for the `/memories` Anthropic memory tool that is compatible with VS Code extension storage semantics. 
- Avoid using absolute filesystem paths which cannot target extension storage URIs, and map the virtual `/memories` root to storage instead. 
- Align our tool shape with the Anthropic SDK `memory_20250818` contract and keep listing output in the `/memories` virtual namespace. 

### Description

- Implemented `MemoryTool` that maps virtual paths under `MEMORY_ROOT` (`/memories`) to a `memories/` folder inside extension global storage using `GlobalStorageFS` instead of `AbsoluteFS`. 
- Added path translation helpers (`resolveMemoryPath`, `toDisplayPath`) so file operations use `GlobalStorageFS` while displayed paths remain `/memories/...`. 
- Registered and exported the new tool by adding `export * from './memory'` and adding `memory: new MemoryTool()` to the default tool registry. 
- Added a mapping in provider conversion so the local tool `memory` maps to Anthropic’s `memory_20250818` type and validated the SDK reference implementation (`betaMemoryTool`) for handler shape. 

### Testing

- Ran `npm run format` and it completed successfully. 
- Ran `npm run compile` and the build succeeded with a known `nunjucks` dynamic dependency warning. 
- Ran `npm run lint` and it completed with existing warnings (no new lint errors introduced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f400e44d483249f769dde89b1bdc4)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements persistent memory management and wires it into provider/tool plumbing.
> 
> - Adds `MemoryTool` with `view/create/str_replace/insert/delete/rename` operating on a virtual `/memories` namespace backed by extension storage (`StorageFS`), including directory listings (depth 2) and line-numbered views
> - Registers/exports the tool in `tools/index.ts` and `tools/registry.ts`
> - Maps local `memory` to Anthropic `memory_20250818` in `agent/modelHandlers/toolConversion.ts`
> - Tightens null/undefined checks in `ReadTool`, `TextEditorTool`, and `fileOp`; minor import reordering in `openFileCommands.ts`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2f503e1e95d9cec8351664819858d702e0f7bc9a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->