### PR TITLE
Manage conversation state in model interactions

### DIFF
--- a/package.json
+++ b/package.json
@@ -277,7 +277,7 @@
             "default": 75,
             "minimum": 0,
             "maximum": 100,
-            "description": "Percentage of context window to trigger automatic conversation compaction with OpenAI Responses API. When cumulative input tokens exceed this percentage of the model's context window, the conversation is compacted to reduce context size. Set to 0 to disable automatic compaction.",
+            "description": "Percentage of context window to trigger automatic context management. For OpenAI, triggers conversation compaction via /responses/compact. For Anthropic, triggers server-side clearing of tool uses and thinking blocks. Set to 0 to disable.",
             "scope": "resource"
           },
           "texra.model.gpt5ReasoningSummary": {

--- a/package.json
+++ b/package.json
@@ -272,6 +272,14 @@
             "description": "Enable background mode for OpenAI Responses API to handle long-running generations (>10mins) more reliably by preventing request timeouts. Adds polling overhead.",
             "scope": "resource"
           },
+          "texra.model.compactionThresholdPercent": {
+            "type": "number",
+            "default": 75,
+            "minimum": 0,
+            "maximum": 100,
+            "description": "Percentage of context window to trigger automatic conversation compaction with OpenAI Responses API. When cumulative input tokens exceed this percentage of the model's context window, the conversation is compacted to reduce context size. Set to 0 to disable automatic compaction.",
+            "scope": "resource"
+          },
           "texra.model.gpt5ReasoningSummary": {
             "type": "boolean",
             "default": false,

--- a/package.json
+++ b/package.json
@@ -292,27 +292,6 @@
             "description": "Attach the `context-1m-2025-08-07` beta header for Claude Sonnet 4 requests to enable the 1M-token context window (usage capped at 200 K by extension).",
             "scope": "resource"
           },
-          "texra.model.anthropicContextManagementTrigger": {
-            "type": "number",
-            "default": 100000,
-            "minimum": 0,
-            "description": "Token threshold for triggering Anthropic's server-side context management (clear_tool_uses). When input tokens exceed this value, old tool results are cleared. Set to 0 to use API defaults.",
-            "scope": "resource"
-          },
-          "texra.model.anthropicContextManagementKeep": {
-            "type": "number",
-            "default": 3,
-            "minimum": 1,
-            "description": "Number of recent tool use/result pairs to keep after context clearing. The oldest tool interactions are removed first.",
-            "scope": "resource"
-          },
-          "texra.model.anthropicThinkingBlocksKeep": {
-            "type": "number",
-            "default": 1,
-            "minimum": 0,
-            "description": "Number of assistant turns with thinking blocks to keep. Set to 0 to keep all thinking blocks (maximizes cache hits). Only applies when extended thinking is enabled.",
-            "scope": "resource"
-          },
           "texra.model.instructionPolishModel": {
             "type": "string",
             "default": "sonnet45",

--- a/package.json
+++ b/package.json
@@ -292,6 +292,27 @@
             "description": "Attach the `context-1m-2025-08-07` beta header for Claude Sonnet 4 requests to enable the 1M-token context window (usage capped at 200 K by extension).",
             "scope": "resource"
           },
+          "texra.model.anthropicContextManagementTrigger": {
+            "type": "number",
+            "default": 100000,
+            "minimum": 0,
+            "description": "Token threshold for triggering Anthropic's server-side context management (clear_tool_uses). When input tokens exceed this value, old tool results are cleared. Set to 0 to use API defaults.",
+            "scope": "resource"
+          },
+          "texra.model.anthropicContextManagementKeep": {
+            "type": "number",
+            "default": 3,
+            "minimum": 1,
+            "description": "Number of recent tool use/result pairs to keep after context clearing. The oldest tool interactions are removed first.",
+            "scope": "resource"
+          },
+          "texra.model.anthropicThinkingBlocksKeep": {
+            "type": "number",
+            "default": 1,
+            "minimum": 0,
+            "description": "Number of assistant turns with thinking blocks to keep. Set to 0 to keep all thinking blocks (maximizes cache hits). Only applies when extended thinking is enabled.",
+            "scope": "resource"
+          },
           "texra.model.instructionPolishModel": {
             "type": "string",
             "default": "sonnet45",

--- a/src/agent/modelHandlers/contextManagementConstants.ts
+++ b/src/agent/modelHandlers/contextManagementConstants.ts
@@ -1,0 +1,16 @@
+/**
+ * Shared constants for context management across model handlers.
+ * Single source of truth for compaction/truncation settings.
+ */
+
+/**
+ * Default compaction threshold percentage.
+ * When context utilization exceeds this percentage of the model's context window,
+ * context management (compaction, truncation, or clearing) is triggered.
+ *
+ * This value must match the default in package.json for:
+ * - texra.model.compactionThresholdPercent
+ *
+ * Set to 0 to disable context management entirely.
+ */
+export const DEFAULT_COMPACTION_THRESHOLD_PERCENT = 75;

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -523,12 +523,67 @@ export class ModelHandlerAnthropic extends ModelHandler<
         ...(options.context_management?.edits ?? []),
       ];
 
+      // Add thinking block clearing strategy if reasoning is enabled
+      if (
+        this.capabilities.supportsReasoning &&
+        options.thinking &&
+        !contextManagementEdits.some(
+          (edit) => edit.type === 'clear_thinking_20251015',
+        )
+      ) {
+        const thinkingKeep = getConfig<number>(
+          'texra.model.anthropicThinkingBlocksKeep',
+          1,
+        );
+        // Thinking clearing must come first in the edits array
+        const thinkingEdit =
+          thinkingKeep === 0
+            ? { type: 'clear_thinking_20251015' as const, keep: 'all' as const }
+            : {
+                type: 'clear_thinking_20251015' as const,
+                keep: {
+                  type: 'thinking_turns' as const,
+                  value: thinkingKeep,
+                },
+              };
+        contextManagementEdits.unshift(thinkingEdit);
+      }
+
+      // Add tool result clearing strategy
       if (
         !contextManagementEdits.some(
           (edit) => edit.type === 'clear_tool_uses_20250919',
         )
       ) {
-        contextManagementEdits.push({ type: 'clear_tool_uses_20250919' });
+        const triggerTokens = getConfig<number>(
+          'texra.model.anthropicContextManagementTrigger',
+          100000,
+        );
+        const keepToolUses = getConfig<number>(
+          'texra.model.anthropicContextManagementKeep',
+          3,
+        );
+
+        // Build the tool clear edit with optional configuration
+        // Use type assertion since the SDK types may not include all options yet
+        const toolClearEdit = {
+          type: 'clear_tool_uses_20250919' as const,
+          // Only add trigger/keep if not using defaults (0 means use API defaults)
+          ...(triggerTokens > 0 && {
+            trigger: {
+              type: 'input_tokens' as const,
+              value: triggerTokens,
+            },
+          }),
+          ...(keepToolUses > 0 && {
+            keep: {
+              type: 'tool_uses' as const,
+              value: keepToolUses,
+            },
+          }),
+        };
+
+        contextManagementEdits.push(toolClearEdit);
       }
 
       options.context_management = {
@@ -588,6 +643,9 @@ export class ModelHandlerAnthropic extends ModelHandler<
 
         // Store thinking blocks for API conversation continuation
         this.processThinkingBlock(response);
+
+        // Log context management events if any edits were applied (streaming)
+        this.logContextManagementFromResponse(response);
       } finally {
         // Always finalize stream handler to prevent memory leaks on error
         streamHandler.finalize();
@@ -603,9 +661,91 @@ export class ModelHandlerAnthropic extends ModelHandler<
         () => client.beta.messages.create(options, { signal }),
       );
     }
-    // Note: Errors propagate to PocketFlow's execFallback which logs once (log at boundary principle)
+
+    // Log context management events if any edits were applied
+    this.logContextManagementFromResponse(response);
 
     return response;
+  }
+
+  /**
+   * Log context management events from the Anthropic response.
+   * The response includes applied_edits when server-side context editing was performed.
+   */
+  private logContextManagementFromResponse(response: BetaMessage): void {
+    // Type assertion needed because context_management is in beta
+    const contextManagement = (
+      response as unknown as {
+        context_management?: {
+          applied_edits?: Array<{
+            type: string;
+            cleared_tool_uses?: number;
+            cleared_thinking_turns?: number;
+            cleared_input_tokens?: number;
+          }>;
+        };
+      }
+    ).context_management;
+
+    if (!contextManagement?.applied_edits?.length) {
+      return;
+    }
+
+    const contextWindow = this.config.contextWindow;
+
+    for (const edit of contextManagement.applied_edits) {
+      if (
+        edit.type === 'clear_tool_uses_20250919' &&
+        edit.cleared_input_tokens &&
+        edit.cleared_input_tokens > 0
+      ) {
+        const clearedTokens = edit.cleared_input_tokens;
+        const clearedToolUses = edit.cleared_tool_uses ?? 0;
+        const utilizationReduction = (clearedTokens / contextWindow) * 100;
+
+        this.logger.logContextManagement(
+          `Cleared ${clearedToolUses} tool use(s): ${clearedTokens.toLocaleString()} tokens freed (${utilizationReduction.toFixed(1)}% of context)`,
+          {
+            action: 'clear_tool_uses',
+            tokensBefore: response.usage.input_tokens + clearedTokens,
+            tokensAfter: response.usage.input_tokens,
+            contextWindow,
+            utilizationBefore:
+              ((response.usage.input_tokens + clearedTokens) / contextWindow) *
+              100,
+            utilizationAfter:
+              (response.usage.input_tokens / contextWindow) * 100,
+            details: `Anthropic server-side: cleared ${clearedToolUses} tool use(s)`,
+          },
+        );
+      }
+
+      if (
+        edit.type === 'clear_thinking_20251015' &&
+        edit.cleared_input_tokens &&
+        edit.cleared_input_tokens > 0
+      ) {
+        const clearedTokens = edit.cleared_input_tokens;
+        const clearedTurns = edit.cleared_thinking_turns ?? 0;
+        const utilizationReduction = (clearedTokens / contextWindow) * 100;
+
+        this.logger.logContextManagement(
+          `Cleared ${clearedTurns} thinking turn(s): ${clearedTokens.toLocaleString()} tokens freed (${utilizationReduction.toFixed(1)}% of context)`,
+          {
+            action: 'clear_tool_uses', // Reuse action type for now
+            tokensBefore: response.usage.input_tokens + clearedTokens,
+            tokensAfter: response.usage.input_tokens,
+            contextWindow,
+            utilizationBefore:
+              ((response.usage.input_tokens + clearedTokens) / contextWindow) *
+              100,
+            utilizationAfter:
+              (response.usage.input_tokens / contextWindow) * 100,
+            details: `Anthropic server-side: cleared ${clearedTurns} thinking turn(s)`,
+          },
+        );
+      }
+    }
   }
 
   private enforceCacheControlLimit(messages: MessageParam[]): void {

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -102,6 +102,9 @@ import type { AnthropicBeta } from '@anthropic-ai/sdk/resources/beta/beta';
 import type {
   BetaContentBlock,
   BetaContextManagementConfig,
+  BetaContextManagementResponse,
+  BetaClearToolUses20250919EditResponse,
+  BetaClearThinking20251015EditResponse,
   BetaImageBlockParam,
   BetaMessage,
   BetaRedactedThinkingBlock,
@@ -665,17 +668,10 @@ export class ModelHandlerAnthropic extends ModelHandler<
    * The response includes applied_edits when server-side context editing was performed.
    */
   private logContextManagementFromResponse(response: BetaMessage): void {
-    // Type assertion needed because context_management is in beta
+    // Access context_management from response - uses SDK types where available
     const contextManagement = (
-      response as unknown as {
-        context_management?: {
-          applied_edits?: Array<{
-            type: string;
-            cleared_tool_uses?: number;
-            cleared_thinking_turns?: number;
-            cleared_input_tokens?: number;
-          }>;
-        };
+      response as BetaMessage & {
+        context_management?: BetaContextManagementResponse | null;
       }
     ).context_management;
 
@@ -684,15 +680,19 @@ export class ModelHandlerAnthropic extends ModelHandler<
     }
 
     const contextWindow = this.config.contextWindow;
+    type AppliedEdit =
+      | BetaClearToolUses20250919EditResponse
+      | BetaClearThinking20251015EditResponse;
 
-    for (const edit of contextManagement.applied_edits) {
+    for (const edit of contextManagement.applied_edits as AppliedEdit[]) {
       if (
         edit.type === 'clear_tool_uses_20250919' &&
         edit.cleared_input_tokens &&
         edit.cleared_input_tokens > 0
       ) {
-        const clearedTokens = edit.cleared_input_tokens;
-        const clearedToolUses = edit.cleared_tool_uses ?? 0;
+        const typedEdit = edit as BetaClearToolUses20250919EditResponse;
+        const clearedTokens = typedEdit.cleared_input_tokens;
+        const clearedToolUses = typedEdit.cleared_tool_uses ?? 0;
         const utilizationReduction = (clearedTokens / contextWindow) * 100;
 
         this.logger.logContextManagement(
@@ -717,14 +717,15 @@ export class ModelHandlerAnthropic extends ModelHandler<
         edit.cleared_input_tokens &&
         edit.cleared_input_tokens > 0
       ) {
-        const clearedTokens = edit.cleared_input_tokens;
-        const clearedTurns = edit.cleared_thinking_turns ?? 0;
+        const typedEdit = edit as BetaClearThinking20251015EditResponse;
+        const clearedTokens = typedEdit.cleared_input_tokens;
+        const clearedTurns = typedEdit.cleared_thinking_turns ?? 0;
         const utilizationReduction = (clearedTokens / contextWindow) * 100;
 
         this.logger.logContextManagement(
           `Cleared ${clearedTurns} thinking turn(s): ${clearedTokens.toLocaleString()} tokens freed (${utilizationReduction.toFixed(1)}% of context)`,
           {
-            action: 'clear_tool_uses', // Reuse action type for now
+            action: 'clear_thinking',
             tokensBefore: response.usage.input_tokens + clearedTokens,
             tokensAfter: response.usage.input_tokens,
             contextWindow,

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -84,6 +84,7 @@ import {
 import { ANTHROPIC_STOP } from './types/StopReasonTypes';
 import { toAnthropicTools } from './toolConversion';
 import { executeRequest } from './utils/requestExecutor';
+import { DEFAULT_COMPACTION_THRESHOLD_PERCENT } from './contextManagementConstants';
 import {
   extractAnthropicWebSearchResults,
   isAnthropicServerToolContent,
@@ -210,12 +211,6 @@ const CONTEXT_MANAGEMENT_BETA: AnthropicBeta = 'context-management-2025-06-27';
 const CONTEXT_MANAGEMENT_KEEP_TOOL_USES = 3;
 /** Number of assistant turns with thinking blocks to keep (3 = preserve more reasoning context) */
 const CONTEXT_MANAGEMENT_KEEP_THINKING_TURNS = 3;
-/**
- * Default compaction threshold percentage (shared with OpenAI handler).
- * When context utilization exceeds this percentage, context management is triggered.
- * Must match texra.model.compactionThresholdPercent default in package.json.
- */
-const DEFAULT_COMPACTION_THRESHOLD_PERCENT = 75;
 
 const ANTHROPIC_1M_CONTEXT_WINDOW = 1_000_000;
 

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -210,6 +210,12 @@ const CONTEXT_MANAGEMENT_BETA: AnthropicBeta = 'context-management-2025-06-27';
 const CONTEXT_MANAGEMENT_KEEP_TOOL_USES = 3;
 /** Number of assistant turns with thinking blocks to keep (3 = preserve more reasoning context) */
 const CONTEXT_MANAGEMENT_KEEP_THINKING_TURNS = 3;
+/**
+ * Default compaction threshold percentage (shared with OpenAI handler).
+ * When context utilization exceeds this percentage, context management is triggered.
+ * Must match texra.model.compactionThresholdPercent default in package.json.
+ */
+const DEFAULT_COMPACTION_THRESHOLD_PERCENT = 75;
 
 const ANTHROPIC_1M_CONTEXT_WINDOW = 1_000_000;
 
@@ -533,7 +539,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
       // Set to 0 to disable context management entirely
       const thresholdPercent = getConfig<number>(
         'texra.model.compactionThresholdPercent',
-        75,
+        DEFAULT_COMPACTION_THRESHOLD_PERCENT,
       );
 
       // Only enable context management if threshold is configured (> 0)
@@ -574,12 +580,11 @@ export class ModelHandlerAnthropic extends ModelHandler<
 
           contextManagementEdits.push({
             type: 'clear_tool_uses_20250919' as const,
-            ...(triggerTokens > 0 && {
-              trigger: {
-                type: 'input_tokens' as const,
-                value: triggerTokens,
-              },
-            }),
+            // triggerTokens is guaranteed > 0 since thresholdPercent > 0 (checked above)
+            trigger: {
+              type: 'input_tokens' as const,
+              value: triggerTokens,
+            },
             keep: {
               type: 'tool_uses' as const,
               value: CONTEXT_MANAGEMENT_KEEP_TOOL_USES,

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -208,8 +208,8 @@ const CONTEXT_MANAGEMENT_BETA: AnthropicBeta = 'context-management-2025-06-27';
  */
 /** Number of recent tool use/result pairs to keep after context clearing */
 const CONTEXT_MANAGEMENT_KEEP_TOOL_USES = 3;
-/** Number of assistant turns with thinking blocks to keep (1 = most recent only) */
-const CONTEXT_MANAGEMENT_KEEP_THINKING_TURNS = 1;
+/** Number of assistant turns with thinking blocks to keep (3 = preserve more reasoning context) */
+const CONTEXT_MANAGEMENT_KEEP_THINKING_TURNS = 3;
 
 const ANTHROPIC_1M_CONTEXT_WINDOW = 1_000_000;
 
@@ -529,65 +529,69 @@ export class ModelHandlerAnthropic extends ModelHandler<
     }
 
     if (this.agentType === AgentType.ToolUse) {
-      this.appendBeta(options, CONTEXT_MANAGEMENT_BETA);
+      // Use shared compaction threshold (percentage of context window)
+      // Set to 0 to disable context management entirely
+      const thresholdPercent = getConfig<number>(
+        'texra.model.compactionThresholdPercent',
+        75,
+      );
 
-      const contextManagementEdits = [
-        ...(options.context_management?.edits ?? []),
-      ];
+      // Only enable context management if threshold is configured (> 0)
+      if (thresholdPercent > 0) {
+        this.appendBeta(options, CONTEXT_MANAGEMENT_BETA);
 
-      // Add thinking block clearing strategy if reasoning is enabled
-      if (
-        this.capabilities.supportsReasoning &&
-        options.thinking &&
-        !contextManagementEdits.some(
-          (edit) => edit.type === 'clear_thinking_20251015',
-        )
-      ) {
-        // Thinking clearing must come first in the edits array
-        contextManagementEdits.unshift({
-          type: 'clear_thinking_20251015' as const,
-          keep: {
-            type: 'thinking_turns' as const,
-            value: CONTEXT_MANAGEMENT_KEEP_THINKING_TURNS,
-          },
-        });
-      }
+        const contextManagementEdits = [
+          ...(options.context_management?.edits ?? []),
+        ];
 
-      // Add tool result clearing strategy
-      if (
-        !contextManagementEdits.some(
-          (edit) => edit.type === 'clear_tool_uses_20250919',
-        )
-      ) {
-        // Use shared compaction threshold (percentage of context window)
-        const thresholdPercent = getConfig<number>(
-          'texra.model.compactionThresholdPercent',
-          75,
-        );
-        const triggerTokens =
-          thresholdPercent > 0
-            ? Math.floor((thresholdPercent / 100) * this.config.contextWindow)
-            : 0;
-
-        contextManagementEdits.push({
-          type: 'clear_tool_uses_20250919' as const,
-          ...(triggerTokens > 0 && {
-            trigger: {
-              type: 'input_tokens' as const,
-              value: triggerTokens,
+        // Add thinking block clearing strategy if reasoning is enabled
+        if (
+          this.capabilities.supportsReasoning &&
+          options.thinking &&
+          !contextManagementEdits.some(
+            (edit) => edit.type === 'clear_thinking_20251015',
+          )
+        ) {
+          // Thinking clearing must come first in the edits array
+          contextManagementEdits.unshift({
+            type: 'clear_thinking_20251015' as const,
+            keep: {
+              type: 'thinking_turns' as const,
+              value: CONTEXT_MANAGEMENT_KEEP_THINKING_TURNS,
             },
-          }),
-          keep: {
-            type: 'tool_uses' as const,
-            value: CONTEXT_MANAGEMENT_KEEP_TOOL_USES,
-          },
-        });
-      }
+          });
+        }
 
-      options.context_management = {
-        ...(options.context_management ?? {}),
-        edits: contextManagementEdits,
-      } satisfies BetaContextManagementConfig;
+        // Add tool result clearing strategy
+        if (
+          !contextManagementEdits.some(
+            (edit) => edit.type === 'clear_tool_uses_20250919',
+          )
+        ) {
+          const triggerTokens = Math.floor(
+            (thresholdPercent / 100) * this.config.contextWindow,
+          );
+
+          contextManagementEdits.push({
+            type: 'clear_tool_uses_20250919' as const,
+            ...(triggerTokens > 0 && {
+              trigger: {
+                type: 'input_tokens' as const,
+                value: triggerTokens,
+              },
+            }),
+            keep: {
+              type: 'tool_uses' as const,
+              value: CONTEXT_MANAGEMENT_KEEP_TOOL_USES,
+            },
+          });
+        }
+
+        options.context_management = {
+          ...(options.context_management ?? {}),
+          edits: contextManagementEdits,
+        } satisfies BetaContextManagementConfig;
+      }
     }
 
     let response: BetaMessage;

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -638,9 +638,6 @@ export class ModelHandlerAnthropic extends ModelHandler<
 
         // Store thinking blocks for API conversation continuation
         this.processThinkingBlock(response);
-
-        // Log context management events if any edits were applied (streaming)
-        this.logContextManagementFromResponse(response);
       } finally {
         // Always finalize stream handler to prevent memory leaks on error
         streamHandler.finalize();

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -199,6 +199,15 @@ const INTERLEAVED_THINKING_BETA: AnthropicBeta =
   'interleaved-thinking-2025-05-14';
 const CONTEXT_MANAGEMENT_BETA: AnthropicBeta = 'context-management-2025-06-27';
 
+/**
+ * Context management constants for Anthropic's server-side editing.
+ * These are reasonable defaults that balance context efficiency with conversation continuity.
+ */
+/** Number of recent tool use/result pairs to keep after context clearing */
+const CONTEXT_MANAGEMENT_KEEP_TOOL_USES = 3;
+/** Number of assistant turns with thinking blocks to keep (1 = most recent only) */
+const CONTEXT_MANAGEMENT_KEEP_THINKING_TURNS = 1;
+
 const ANTHROPIC_1M_CONTEXT_WINDOW = 1_000_000;
 
 /**
@@ -531,22 +540,14 @@ export class ModelHandlerAnthropic extends ModelHandler<
           (edit) => edit.type === 'clear_thinking_20251015',
         )
       ) {
-        const thinkingKeep = getConfig<number>(
-          'texra.model.anthropicThinkingBlocksKeep',
-          1,
-        );
         // Thinking clearing must come first in the edits array
-        const thinkingEdit =
-          thinkingKeep === 0
-            ? { type: 'clear_thinking_20251015' as const, keep: 'all' as const }
-            : {
-                type: 'clear_thinking_20251015' as const,
-                keep: {
-                  type: 'thinking_turns' as const,
-                  value: thinkingKeep,
-                },
-              };
-        contextManagementEdits.unshift(thinkingEdit);
+        contextManagementEdits.unshift({
+          type: 'clear_thinking_20251015' as const,
+          keep: {
+            type: 'thinking_turns' as const,
+            value: CONTEXT_MANAGEMENT_KEEP_THINKING_TURNS,
+          },
+        });
       }
 
       // Add tool result clearing strategy
@@ -555,35 +556,29 @@ export class ModelHandlerAnthropic extends ModelHandler<
           (edit) => edit.type === 'clear_tool_uses_20250919',
         )
       ) {
-        const triggerTokens = getConfig<number>(
-          'texra.model.anthropicContextManagementTrigger',
-          100000,
+        // Use shared compaction threshold (percentage of context window)
+        const thresholdPercent = getConfig<number>(
+          'texra.model.compactionThresholdPercent',
+          75,
         );
-        const keepToolUses = getConfig<number>(
-          'texra.model.anthropicContextManagementKeep',
-          3,
-        );
+        const triggerTokens =
+          thresholdPercent > 0
+            ? Math.floor((thresholdPercent / 100) * this.config.contextWindow)
+            : 0;
 
-        // Build the tool clear edit with optional configuration
-        // Use type assertion since the SDK types may not include all options yet
-        const toolClearEdit = {
+        contextManagementEdits.push({
           type: 'clear_tool_uses_20250919' as const,
-          // Only add trigger/keep if not using defaults (0 means use API defaults)
           ...(triggerTokens > 0 && {
             trigger: {
               type: 'input_tokens' as const,
               value: triggerTokens,
             },
           }),
-          ...(keepToolUses > 0 && {
-            keep: {
-              type: 'tool_uses' as const,
-              value: keepToolUses,
-            },
-          }),
-        };
-
-        contextManagementEdits.push(toolClearEdit);
+          keep: {
+            type: 'tool_uses' as const,
+            value: CONTEXT_MANAGEMENT_KEEP_TOOL_USES,
+          },
+        });
       }
 
       options.context_management = {

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -283,9 +283,23 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
   }
 
   /**
+   * Result from compactConversation including messages and state updates.
+   * State updates are returned but not applied - caller is responsible for
+   * applying them only after successful API call to prevent stale state on retry.
+   */
+  private compactionResult?: {
+    compactedMessages: ResponseInputItem[];
+    tokensAfter: number;
+  };
+
+  /**
    * Compact the conversation to reduce context size.
    * Uses OpenAI's `/responses/compact` endpoint to replace prior assistant messages,
    * tool calls, and results with a single encrypted compaction item.
+   *
+   * State updates are stored in compactionResult but NOT applied immediately.
+   * The caller must apply them only after successful API call to prevent
+   * stale state if the API call fails and needs to retry.
    *
    * @param client - OpenAI client instance
    * @param messages - Current conversation messages
@@ -349,27 +363,42 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         },
       );
 
-      // Update state after successful compaction
-      this.conversationState.isCompacted = true;
-      // Reset cumulative tokens to the compacted usage (not additive - replaces history)
-      // This prevents double-counting since compacted output supersedes previous messages
-      this.conversationState.cumulativeInputTokens = tokensAfter;
-      // Reset sent messages counter since we're using compacted output
-      this.conversationState.sentMessages = 0;
-      // Clear previous_response_id - compacted output replaces server-side history
-      this.previousResponseId = null;
+      // Store compacted messages for use in this request.
+      // Mark as pending compaction - state will be finalized after successful API call.
+      // This prevents stale state if API call fails and needs retry.
+      const compactedMessages =
+        compactedResponse.output as unknown as ResponseInputItem[];
+      this.compactionResult = { compactedMessages, tokensAfter };
 
-      // Convert output items to input items for the next request.
-      // The compacted output contains user messages and a single compaction item.
-      // Type cast required: SDK's CompactedResponse.output is ResponseOutputItem[]
-      // but these are semantically valid as input items for the next request.
-      return compactedResponse.output as unknown as ResponseInputItem[];
+      return compactedMessages;
     } catch (err) {
       this.logger.warn(
         `Compaction failed, continuing with original messages: ${getSdkErrorMessage(err)}`,
       );
+      this.compactionResult = undefined;
       return messages;
     }
+  }
+
+  /**
+   * Apply compaction state updates after successful API call.
+   * Clears the pending compaction result and updates conversation state.
+   *
+   * Note: cumulativeInputTokens is NOT updated here - it will be set from
+   * response.usage.input_tokens after the API call to reflect actual usage.
+   */
+  private applyCompactionState(): void {
+    if (!this.compactionResult) return;
+
+    // Reset sent messages counter since we're using compacted output
+    this.conversationState.sentMessages = 0;
+    // Mark as compacted so subsequent requests know to send all messages
+    this.conversationState.isCompacted = true;
+    // Clear previous_response_id - compacted output replaces server-side history
+    this.previousResponseId = null;
+
+    // Clear the pending result
+    this.compactionResult = undefined;
   }
 
   /** Creates a configured OpenAI client instance. */
@@ -705,6 +734,8 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
 
     // Check if compaction is needed before processing the request
     let effectiveMessages = messages;
+    // Track if compaction happened in THIS call (not previous calls)
+    let compactedThisCall = false;
     if (this.shouldCompact()) {
       const threshold = this.getCompactionTokenThreshold();
       this.logger.logProgress(
@@ -716,11 +747,16 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         systemPrompt,
         signal,
       );
+      // compactionResult is set if compaction succeeded
+      compactedThisCall = this.compactionResult !== undefined;
     }
 
-    // After compaction, we send all messages (compacted output replaces history)
-    // Otherwise, we only send new messages since last request
-    const newMessages = this.conversationState.isCompacted
+    // After compaction in THIS call, send all compacted messages.
+    // If already compacted (from previous call), also send all messages.
+    // Otherwise, only send new messages since last request.
+    const shouldSendAll =
+      compactedThisCall || this.conversationState.isCompacted;
+    const newMessages = shouldSendAll
       ? effectiveMessages
       : effectiveMessages.slice(this.conversationState.sentMessages);
 
@@ -866,14 +902,20 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       // Emit any web searches not yet emitted (fallback for edge cases)
       this.emitWebSearchesFromResponse(response, state.emittedWebSearchIds);
 
+      // Apply compaction state if compaction happened this call
+      if (compactedThisCall) {
+        this.applyCompactionState();
+      }
+
       this.previousResponseId = response.id;
       this.conversationState.sentMessages = effectiveMessages.length;
-      // Update cumulative input tokens for compaction threshold checking
+      // Set cumulative input tokens from actual usage (not additive - this IS the total)
+      // The response's input_tokens reflects the full context including server-side history
       if (response.usage?.input_tokens) {
-        this.conversationState.cumulativeInputTokens +=
+        this.conversationState.cumulativeInputTokens =
           response.usage.input_tokens;
       }
-      // Reset compacted flag after successful request
+      // Reset compacted flag after successful request (ready for next compaction if needed)
       this.conversationState.isCompacted = false;
       return response;
     }
@@ -917,14 +959,21 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         signal,
       );
     }
+
+    // Apply compaction state if compaction happened this call
+    if (compactedThisCall) {
+      this.applyCompactionState();
+    }
+
     this.previousResponseId = response.id;
     this.conversationState.sentMessages = effectiveMessages.length;
-    // Update cumulative input tokens for compaction threshold checking
+    // Set cumulative input tokens from actual usage (not additive - this IS the total)
+    // The response's input_tokens reflects the full context including server-side history
     if (response.usage?.input_tokens) {
-      this.conversationState.cumulativeInputTokens +=
+      this.conversationState.cumulativeInputTokens =
         response.usage.input_tokens;
     }
-    // Reset compacted flag after successful request
+    // Reset compacted flag after successful request (ready for next compaction if needed)
     this.conversationState.isCompacted = false;
     return response;
   }

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -195,19 +195,28 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
   private static readonly DEFAULT_COMPACTION_THRESHOLD_PERCENT = 75;
 
   private previousResponseId: string | null = null;
-  private sentMessages = 0;
 
   /**
-   * Tracks cumulative input tokens across the conversation.
-   * Used to determine when compaction should be triggered.
+   * Conversation state for tracking messages, tokens, and compaction.
+   * Grouped together to ensure synchronized resets.
    */
-  private cumulativeInputTokens = 0;
+  private conversationState = {
+    /** Number of messages already sent to the API */
+    sentMessages: 0,
+    /** Cumulative input tokens across the conversation (for compaction trigger) */
+    cumulativeInputTokens: 0,
+    /** Whether the conversation has been compacted */
+    isCompacted: false,
+  };
 
-  /**
-   * Tracks whether the conversation has been compacted.
-   * After compaction, message handling changes to use compacted input.
-   */
-  private isCompacted = false;
+  /** Reset conversation state to initial values. */
+  private resetConversationState(): void {
+    this.conversationState = {
+      sentMessages: 0,
+      cumulativeInputTokens: 0,
+      isCompacted: false,
+    };
+  }
 
   /**
    * Manually set the previous response ID to resume a conversation.
@@ -215,9 +224,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
    */
   setPreviousResponseId(id: string | null): void {
     this.previousResponseId = id;
-    this.sentMessages = 0;
-    this.cumulativeInputTokens = 0;
-    this.isCompacted = false;
+    this.resetConversationState();
   }
 
   /** Retrieve the stored previous response ID. */
@@ -268,7 +275,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       return false;
     }
     const threshold = this.getCompactionTokenThreshold();
-    return this.cumulativeInputTokens > threshold;
+    return this.conversationState.cumulativeInputTokens > threshold;
   }
 
   /**
@@ -288,7 +295,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     systemPrompt?: string,
     signal?: AbortSignal,
   ): Promise<ResponseInputItem[]> {
-    const tokensBefore = this.cumulativeInputTokens;
+    const tokensBefore = this.conversationState.cumulativeInputTokens;
     const contextWindow = this.config.contextWindow;
     const utilizationBefore = (tokensBefore / contextWindow) * 100;
 
@@ -339,11 +346,13 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       );
 
       // Update state after successful compaction
-      this.isCompacted = true;
+      this.conversationState.isCompacted = true;
       // Reset cumulative tokens to the compacted usage
-      this.cumulativeInputTokens = tokensAfter;
+      this.conversationState.cumulativeInputTokens = tokensAfter;
       // Reset sent messages counter since we're using compacted output
-      this.sentMessages = 0;
+      this.conversationState.sentMessages = 0;
+      // Clear previous_response_id - compacted output replaces server-side history
+      this.previousResponseId = null;
 
       // Convert output items to input items for the next request
       // The compacted output contains user messages and a single compaction item
@@ -379,9 +388,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     systemPrompt?: string,
   ): Promise<ResponseInputItem[]> {
     this.previousResponseId = null;
-    this.sentMessages = 0;
-    this.cumulativeInputTokens = 0;
-    this.isCompacted = false;
+    this.resetConversationState();
 
     const messages: ResponseInputItem[] = [];
 
@@ -694,7 +701,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     if (this.shouldCompact()) {
       const threshold = this.getCompactionTokenThreshold();
       this.logger.logProgress(
-        `Compacting conversation (${this.cumulativeInputTokens} tokens exceed ${this.getCompactionThresholdPercent()}% threshold of ${threshold} tokens)`,
+        `Compacting conversation (${this.conversationState.cumulativeInputTokens} tokens exceed ${this.getCompactionThresholdPercent()}% threshold of ${threshold} tokens)`,
       );
       effectiveMessages = await this.compactConversation(
         client,
@@ -706,9 +713,9 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
 
     // After compaction, we send all messages (compacted output replaces history)
     // Otherwise, we only send new messages since last request
-    const newMessages = this.isCompacted
+    const newMessages = this.conversationState.isCompacted
       ? effectiveMessages
-      : effectiveMessages.slice(this.sentMessages);
+      : effectiveMessages.slice(this.conversationState.sentMessages);
 
     await this.uploadInlineInputFiles(client, newMessages);
 
@@ -853,13 +860,14 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       this.emitWebSearchesFromResponse(response, state.emittedWebSearchIds);
 
       this.previousResponseId = response.id;
-      this.sentMessages = effectiveMessages.length;
+      this.conversationState.sentMessages = effectiveMessages.length;
       // Update cumulative input tokens for compaction threshold checking
       if (response.usage?.input_tokens) {
-        this.cumulativeInputTokens += response.usage.input_tokens;
+        this.conversationState.cumulativeInputTokens +=
+          response.usage.input_tokens;
       }
       // Reset compacted flag after successful request
-      this.isCompacted = false;
+      this.conversationState.isCompacted = false;
       return response;
     }
 
@@ -903,13 +911,14 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       );
     }
     this.previousResponseId = response.id;
-    this.sentMessages = effectiveMessages.length;
+    this.conversationState.sentMessages = effectiveMessages.length;
     // Update cumulative input tokens for compaction threshold checking
     if (response.usage?.input_tokens) {
-      this.cumulativeInputTokens += response.usage.input_tokens;
+      this.conversationState.cumulativeInputTokens +=
+        response.usage.input_tokens;
     }
     // Reset compacted flag after successful request
-    this.isCompacted = false;
+    this.conversationState.isCompacted = false;
     return response;
   }
 

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -44,6 +44,7 @@ import { executeRequest } from './utils/requestExecutor';
 import { OPENAI_CHAT_FINISH } from './types/StopReasonTypes';
 import { toOpenAIResponseTools } from './toolConversion';
 import { ModelHandler } from './ModelHandler';
+import { DEFAULT_COMPACTION_THRESHOLD_PERCENT } from './contextManagementConstants';
 import {
   buildOpenAIWebSearchResult,
   extractOpenAIWebSearchResults,
@@ -185,15 +186,6 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
   private static readonly BACKGROUND_TERMINAL_STATUSES: readonly ResponseStatus[] =
     ['completed', 'failed', 'cancelled', 'incomplete'];
 
-  /**
-   * Default threshold percentage for triggering conversation compaction.
-   * When cumulative input tokens exceed this percentage of the model's context window,
-   * the conversation will be compacted using OpenAI's `/responses/compact` endpoint.
-   * Set to 0 to disable automatic compaction.
-   * Default: 75% of context window
-   */
-  private static readonly DEFAULT_COMPACTION_THRESHOLD_PERCENT = 75;
-
   private previousResponseId: string | null = null;
 
   /**
@@ -242,7 +234,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
   private getCompactionThresholdPercent(): number {
     return getConfig<number>(
       'texra.model.compactionThresholdPercent',
-      ModelHandlerOpenAIResponse.DEFAULT_COMPACTION_THRESHOLD_PERCENT,
+      DEFAULT_COMPACTION_THRESHOLD_PERCENT,
     );
   }
 
@@ -695,11 +687,14 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
    * request and relies on `previous_response_id` for conversation context.
    *
    * Supports automatic conversation compaction when cumulative input tokens
-   * exceed the configured threshold (texra.model.compactionThreshold).
+   * exceed the configured threshold (texra.model.compactionThresholdPercent).
    */
   async createResponse(
     options: CreateResponseOptions<ResponseInputItem, OpenAI>,
   ): Promise<Response> {
+    // Clear any stale compaction result from previous attempts (ensures clean state on retries)
+    this.compactionResult = undefined;
+
     const { client, messages, temperature, systemPrompt, signal, tools } =
       options;
     const streamingToggleEnabled = this.getStreamingConfig();

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -207,6 +207,8 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     cumulativeInputTokens: 0,
     /** Whether the conversation has been compacted */
     isCompacted: false,
+    /** Whether we've logged the OpenRouter compaction skip message */
+    openRouterSkipLogged: false,
   };
 
   /** Reset conversation state to initial values. */
@@ -215,6 +217,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       sentMessages: 0,
       cumulativeInputTokens: 0,
       isCompacted: false,
+      openRouterSkipLogged: false,
     };
   }
 
@@ -269,9 +272,10 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       return false;
     }
     if (this.isOpenRouterRoutingEnabled()) {
-      this.logger.debug(
-        'Skipping compaction check: OpenRouter routing is enabled',
-      );
+      if (!this.conversationState.openRouterSkipLogged) {
+        this.logger.debug('Skipping compaction: OpenRouter routing is enabled');
+        this.conversationState.openRouterSkipLogged = true;
+      }
       return false;
     }
     const threshold = this.getCompactionTokenThreshold();
@@ -347,15 +351,18 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
 
       // Update state after successful compaction
       this.conversationState.isCompacted = true;
-      // Reset cumulative tokens to the compacted usage
+      // Reset cumulative tokens to the compacted usage (not additive - replaces history)
+      // This prevents double-counting since compacted output supersedes previous messages
       this.conversationState.cumulativeInputTokens = tokensAfter;
       // Reset sent messages counter since we're using compacted output
       this.conversationState.sentMessages = 0;
       // Clear previous_response_id - compacted output replaces server-side history
       this.previousResponseId = null;
 
-      // Convert output items to input items for the next request
-      // The compacted output contains user messages and a single compaction item
+      // Convert output items to input items for the next request.
+      // The compacted output contains user messages and a single compaction item.
+      // Type cast required: SDK's CompactedResponse.output is ResponseOutputItem[]
+      // but these are semantically valid as input items for the next request.
       return compactedResponse.output as unknown as ResponseInputItem[];
     } catch (err) {
       this.logger.warn(

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -288,9 +288,12 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     systemPrompt?: string,
     signal?: AbortSignal,
   ): Promise<ResponseInputItem[]> {
-    const threshold = this.getCompactionTokenThreshold();
+    const tokensBefore = this.cumulativeInputTokens;
+    const contextWindow = this.config.contextWindow;
+    const utilizationBefore = (tokensBefore / contextWindow) * 100;
+
     this.logger.debug(
-      `Compacting conversation with ${this.cumulativeInputTokens} input tokens (threshold: ${threshold} tokens = ${this.getCompactionThresholdPercent()}% of ${this.config.contextWindow} context window)`,
+      `Compacting conversation with ${tokensBefore} input tokens (${utilizationBefore.toFixed(1)}% of ${contextWindow} context window)`,
     );
 
     const compactParams: ResponseCompactParams = {
@@ -316,14 +319,29 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         () => client.responses.compact(compactParams),
       );
 
-      this.logger.debug(
-        `Compaction successful: ${compactedResponse.usage.input_tokens} input tokens -> ${compactedResponse.output.length} output items`,
+      const tokensAfter = compactedResponse.usage.input_tokens;
+      const utilizationAfter = (tokensAfter / contextWindow) * 100;
+      const reduction = tokensBefore - tokensAfter;
+      const reductionPercent = ((reduction / tokensBefore) * 100).toFixed(1);
+
+      // Log context management event with structured data
+      this.logger.logContextManagement(
+        `Compacted conversation: ${tokensBefore.toLocaleString()} → ${tokensAfter.toLocaleString()} tokens (${reductionPercent}% reduction)`,
+        {
+          action: 'compaction',
+          tokensBefore,
+          tokensAfter,
+          contextWindow,
+          utilizationBefore: Number(utilizationBefore.toFixed(1)),
+          utilizationAfter: Number(utilizationAfter.toFixed(1)),
+          details: `OpenAI Responses API compaction: ${compactedResponse.output.length} items`,
+        },
       );
 
       // Update state after successful compaction
       this.isCompacted = true;
       // Reset cumulative tokens to the compacted usage
-      this.cumulativeInputTokens = compactedResponse.usage.input_tokens;
+      this.cumulativeInputTokens = tokensAfter;
       // Reset sent messages counter since we're using compacted output
       this.sentMessages = 0;
 

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -64,8 +64,10 @@ import type {
 import type { ResponseStreamParams } from 'openai/lib/responses/ResponseStream';
 import type { Reasoning } from 'openai/resources/shared';
 import type {
+  CompactedResponse,
   EasyInputMessage,
   Response,
+  ResponseCompactParams,
   ResponseUsage,
   ResponseCreateParamsBase,
   ResponseCreateParamsNonStreaming,
@@ -182,8 +184,30 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
   /** Statuses indicating the background response has finished (success or failure). */
   private static readonly BACKGROUND_TERMINAL_STATUSES: readonly ResponseStatus[] =
     ['completed', 'failed', 'cancelled', 'incomplete'];
+
+  /**
+   * Default threshold percentage for triggering conversation compaction.
+   * When cumulative input tokens exceed this percentage of the model's context window,
+   * the conversation will be compacted using OpenAI's `/responses/compact` endpoint.
+   * Set to 0 to disable automatic compaction.
+   * Default: 75% of context window
+   */
+  private static readonly DEFAULT_COMPACTION_THRESHOLD_PERCENT = 75;
+
   private previousResponseId: string | null = null;
   private sentMessages = 0;
+
+  /**
+   * Tracks cumulative input tokens across the conversation.
+   * Used to determine when compaction should be triggered.
+   */
+  private cumulativeInputTokens = 0;
+
+  /**
+   * Tracks whether the conversation has been compacted.
+   * After compaction, message handling changes to use compacted input.
+   */
+  private isCompacted = false;
 
   /**
    * Manually set the previous response ID to resume a conversation.
@@ -192,11 +216,126 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
   setPreviousResponseId(id: string | null): void {
     this.previousResponseId = id;
     this.sentMessages = 0;
+    this.cumulativeInputTokens = 0;
+    this.isCompacted = false;
   }
 
   /** Retrieve the stored previous response ID. */
   getPreviousResponseId(): string | null {
     return this.previousResponseId;
+  }
+
+  /**
+   * Get the configured compaction threshold percentage.
+   * Returns 0 if compaction is disabled.
+   */
+  private getCompactionThresholdPercent(): number {
+    return getConfig<number>(
+      'texra.model.compactionThresholdPercent',
+      ModelHandlerOpenAIResponse.DEFAULT_COMPACTION_THRESHOLD_PERCENT,
+    );
+  }
+
+  /**
+   * Calculate the absolute token threshold based on the model's context window
+   * and the configured percentage threshold.
+   */
+  private getCompactionTokenThreshold(): number {
+    const percent = this.getCompactionThresholdPercent();
+    if (percent <= 0) {
+      return 0;
+    }
+    // Calculate threshold as percentage of context window
+    return Math.floor((percent / 100) * this.config.contextWindow);
+  }
+
+  /**
+   * Check if the conversation should be compacted based on cumulative input tokens.
+   * Compaction is only triggered when:
+   * - Threshold percentage is greater than 0 (not disabled)
+   * - Cumulative input tokens exceed the calculated threshold (percentage of context window)
+   * - Not running through OpenRouter (which may not support compaction)
+   */
+  private shouldCompact(): boolean {
+    const thresholdPercent = this.getCompactionThresholdPercent();
+    if (thresholdPercent <= 0) {
+      return false;
+    }
+    if (this.isOpenRouterRoutingEnabled()) {
+      this.logger.debug(
+        'Skipping compaction check: OpenRouter routing is enabled',
+      );
+      return false;
+    }
+    const threshold = this.getCompactionTokenThreshold();
+    return this.cumulativeInputTokens > threshold;
+  }
+
+  /**
+   * Compact the conversation to reduce context size.
+   * Uses OpenAI's `/responses/compact` endpoint to replace prior assistant messages,
+   * tool calls, and results with a single encrypted compaction item.
+   *
+   * @param client - OpenAI client instance
+   * @param messages - Current conversation messages
+   * @param systemPrompt - Optional system instructions
+   * @param signal - Optional abort signal
+   * @returns The compacted messages array, or original messages if compaction fails
+   */
+  private async compactConversation(
+    client: OpenAI,
+    messages: ResponseInputItem[],
+    systemPrompt?: string,
+    signal?: AbortSignal,
+  ): Promise<ResponseInputItem[]> {
+    const threshold = this.getCompactionTokenThreshold();
+    this.logger.debug(
+      `Compacting conversation with ${this.cumulativeInputTokens} input tokens (threshold: ${threshold} tokens = ${this.getCompactionThresholdPercent()}% of ${this.config.contextWindow} context window)`,
+    );
+
+    const compactParams: ResponseCompactParams = {
+      model: this.config.fullName,
+      input: messages,
+    };
+
+    if (systemPrompt) {
+      compactParams.instructions = systemPrompt;
+    }
+
+    if (this.previousResponseId) {
+      compactParams.previous_response_id = this.previousResponseId;
+    }
+
+    try {
+      const compactedResponse: CompactedResponse = await executeRequest(
+        {
+          model: this.config.name,
+          operation: 'openai.responses.compact',
+          signal,
+        },
+        () => client.responses.compact(compactParams),
+      );
+
+      this.logger.debug(
+        `Compaction successful: ${compactedResponse.usage.input_tokens} input tokens -> ${compactedResponse.output.length} output items`,
+      );
+
+      // Update state after successful compaction
+      this.isCompacted = true;
+      // Reset cumulative tokens to the compacted usage
+      this.cumulativeInputTokens = compactedResponse.usage.input_tokens;
+      // Reset sent messages counter since we're using compacted output
+      this.sentMessages = 0;
+
+      // Convert output items to input items for the next request
+      // The compacted output contains user messages and a single compaction item
+      return compactedResponse.output as unknown as ResponseInputItem[];
+    } catch (err) {
+      this.logger.warn(
+        `Compaction failed, continuing with original messages: ${getSdkErrorMessage(err)}`,
+      );
+      return messages;
+    }
   }
 
   /** Creates a configured OpenAI client instance. */
@@ -223,6 +362,8 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
   ): Promise<ResponseInputItem[]> {
     this.previousResponseId = null;
     this.sentMessages = 0;
+    this.cumulativeInputTokens = 0;
+    this.isCompacted = false;
 
     const messages: ResponseInputItem[] = [];
 
@@ -491,6 +632,9 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
    * Create a response using the Responses API.
    * The handler submits only the messages that were not part of the previous
    * request and relies on `previous_response_id` for conversation context.
+   *
+   * Supports automatic conversation compaction when cumulative input tokens
+   * exceed the configured threshold (texra.model.compactionThreshold).
    */
   async createResponse(
     options: CreateResponseOptions<ResponseInputItem, OpenAI>,
@@ -526,7 +670,27 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         'Background mode enabled; skipping streaming to avoid unstable behavior.',
       );
     }
-    const newMessages = messages.slice(this.sentMessages);
+
+    // Check if compaction is needed before processing the request
+    let effectiveMessages = messages;
+    if (this.shouldCompact()) {
+      const threshold = this.getCompactionTokenThreshold();
+      this.logger.logProgress(
+        `Compacting conversation (${this.cumulativeInputTokens} tokens exceed ${this.getCompactionThresholdPercent()}% threshold of ${threshold} tokens)`,
+      );
+      effectiveMessages = await this.compactConversation(
+        client,
+        messages,
+        systemPrompt,
+        signal,
+      );
+    }
+
+    // After compaction, we send all messages (compacted output replaces history)
+    // Otherwise, we only send new messages since last request
+    const newMessages = this.isCompacted
+      ? effectiveMessages
+      : effectiveMessages.slice(this.sentMessages);
 
     await this.uploadInlineInputFiles(client, newMessages);
 
@@ -671,7 +835,13 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       this.emitWebSearchesFromResponse(response, state.emittedWebSearchIds);
 
       this.previousResponseId = response.id;
-      this.sentMessages = messages.length;
+      this.sentMessages = effectiveMessages.length;
+      // Update cumulative input tokens for compaction threshold checking
+      if (response.usage?.input_tokens) {
+        this.cumulativeInputTokens += response.usage.input_tokens;
+      }
+      // Reset compacted flag after successful request
+      this.isCompacted = false;
       return response;
     }
 
@@ -715,7 +885,13 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       );
     }
     this.previousResponseId = response.id;
-    this.sentMessages = messages.length;
+    this.sentMessages = effectiveMessages.length;
+    // Update cumulative input tokens for compaction threshold checking
+    if (response.usage?.input_tokens) {
+      this.cumulativeInputTokens += response.usage.input_tokens;
+    }
+    // Reset compacted flag after successful request
+    this.isCompacted = false;
     return response;
   }
 

--- a/src/agent/types/UsageTypes.ts
+++ b/src/agent/types/UsageTypes.ts
@@ -34,13 +34,6 @@ export const ExtendedTokenUsageStatsSchema = TokenUsageStatsSchema.extend({
   reasoningTokens: z.number().optional(),
   /** Tokens consumed by tool use */
   toolUseTokens: z.number().optional(),
-  // Context window tracking fields
-  /** Model's context window size in tokens */
-  contextWindow: z.number().optional(),
-  /** Cumulative input tokens across the conversation (effective context size) */
-  cumulativeInputTokens: z.number().optional(),
-  /** Percentage of context window utilized */
-  contextUtilizationPercent: z.number().optional(),
 });
 
 export type ExtendedTokenUsageStats = z.infer<

--- a/src/agent/types/UsageTypes.ts
+++ b/src/agent/types/UsageTypes.ts
@@ -34,6 +34,13 @@ export const ExtendedTokenUsageStatsSchema = TokenUsageStatsSchema.extend({
   reasoningTokens: z.number().optional(),
   /** Tokens consumed by tool use */
   toolUseTokens: z.number().optional(),
+  // Context window tracking fields
+  /** Model's context window size in tokens */
+  contextWindow: z.number().optional(),
+  /** Cumulative input tokens across the conversation (effective context size) */
+  cumulativeInputTokens: z.number().optional(),
+  /** Percentage of context window utilized */
+  contextUtilizationPercent: z.number().optional(),
 });
 
 export type ExtendedTokenUsageStats = z.infer<

--- a/src/common/webview/commands.ts
+++ b/src/common/webview/commands.ts
@@ -193,6 +193,7 @@ export const PROGRESS_VIEW_COMMANDS = {
   // Usage
   UPDATE_USAGE: 'updateUsage',
   UPDATE_RUN_USAGE: 'updateRunUsage', // Update single run's usage (incremental)
+  UPDATE_CONTEXT_STATE: 'updateContextState', // Update context utilization display
 
   // Actions
   RESUME: 'resume',

--- a/src/eventBus/ProgressEventBus.ts
+++ b/src/eventBus/ProgressEventBus.ts
@@ -67,6 +67,14 @@ export interface ProgressEventPayloads {
   updateStreamUsage: RunScopedPayload & {
     usage: TokenUsageStats;
   };
+  updateContextState: {
+    stream: StreamTabId;
+    contextState: {
+      inputTokens: number;
+      contextWindow: number;
+      utilizationPercent: number;
+    };
+  };
   showRetryRequest: RetryRequestPrompt;
   resolveRetryRequest: { streamId: StreamTabId };
   showToolEditApprovalPrompt: ToolEditApprovalPrompt;

--- a/src/logger/AgentLogger.ts
+++ b/src/logger/AgentLogger.ts
@@ -1,5 +1,6 @@
 // Third-party imports
 import { randomUUID } from 'crypto';
+import { z } from 'zod';
 
 // Local imports - events
 import type { ExtendedTokenUsageStats } from '@agent/types/UsageTypes';
@@ -28,23 +29,31 @@ import type { LogOptions } from './logOptions';
 
 /**
  * Context management event data for logging compaction, truncation, etc.
+ * Schema-first definition following project conventions (CLAUDE.md).
  */
-export interface ContextManagementData {
+export const ContextManagementDataSchema = z.object({
   /** Type of context management action */
-  action: 'compaction' | 'clear_tool_uses' | 'clear_thinking' | 'truncation';
+  action: z.enum([
+    'compaction',
+    'clear_tool_uses',
+    'clear_thinking',
+    'truncation',
+  ]),
   /** Tokens before the action */
-  tokensBefore: number;
+  tokensBefore: z.number().nonnegative(),
   /** Tokens after the action (if known) */
-  tokensAfter?: number;
+  tokensAfter: z.number().nonnegative().optional(),
   /** Context window size */
-  contextWindow: number;
+  contextWindow: z.number().positive(),
   /** Percentage of context utilized before action */
-  utilizationBefore: number;
+  utilizationBefore: z.number().nonnegative(),
   /** Percentage of context utilized after action (if known) */
-  utilizationAfter?: number;
+  utilizationAfter: z.number().nonnegative().optional(),
   /** Provider-specific details */
-  details?: string;
-}
+  details: z.string().optional(),
+});
+
+export type ContextManagementData = z.infer<typeof ContextManagementDataSchema>;
 
 export interface LoggerScopeOptions {
   parentGroupId?: string;

--- a/src/logger/AgentLogger.ts
+++ b/src/logger/AgentLogger.ts
@@ -31,7 +31,7 @@ import type { LogOptions } from './logOptions';
  */
 export interface ContextManagementData {
   /** Type of context management action */
-  action: 'compaction' | 'clear_tool_uses' | 'truncation';
+  action: 'compaction' | 'clear_tool_uses' | 'clear_thinking' | 'truncation';
   /** Tokens before the action */
   tokensBefore: number;
   /** Tokens after the action (if known) */

--- a/src/logger/AgentLogger.ts
+++ b/src/logger/AgentLogger.ts
@@ -26,6 +26,26 @@ import type {
 } from './messageTypes';
 import type { LogOptions } from './logOptions';
 
+/**
+ * Context management event data for logging compaction, truncation, etc.
+ */
+export interface ContextManagementData {
+  /** Type of context management action */
+  action: 'compaction' | 'clear_tool_uses' | 'truncation';
+  /** Tokens before the action */
+  tokensBefore: number;
+  /** Tokens after the action (if known) */
+  tokensAfter?: number;
+  /** Context window size */
+  contextWindow: number;
+  /** Percentage of context utilized before action */
+  utilizationBefore: number;
+  /** Percentage of context utilized after action (if known) */
+  utilizationAfter?: number;
+  /** Provider-specific details */
+  details?: string;
+}
+
 export interface LoggerScopeOptions {
   parentGroupId?: string;
   /**
@@ -316,6 +336,26 @@ export class AgentLogger {
     this.info(content, {
       groupId,
       messageType: MESSAGE_TYPES.SCRATCHPAD,
+    });
+  }
+
+  /**
+   * Log a context management event (compaction, context clearing, etc.).
+   * Single source of truth for CONTEXT_MANAGEMENT message type.
+   *
+   * @param message - Human-readable summary of the action
+   * @param data - Structured data about the context management action
+   * @param groupId - Optional group ID for progress view
+   */
+  logContextManagement(
+    message: string,
+    data?: ContextManagementData,
+    groupId?: string,
+  ): void {
+    this.info(message, {
+      groupId,
+      messageType: MESSAGE_TYPES.CONTEXT_MANAGEMENT,
+      data,
     });
   }
 

--- a/src/logger/AgentUsageReporter.ts
+++ b/src/logger/AgentUsageReporter.ts
@@ -61,24 +61,7 @@ export class AgentUsageReporter {
     }
   }
 
-  /**
-   * Report context state (utilization) to the progress view.
-   * Shows "X% context left" in the footer.
-   *
-   * @param inputTokens - Current cumulative input tokens
-   * @param contextWindow - Model's context window size
-   */
-  public reportContextState(inputTokens: number, contextWindow: number): void {
-    if (contextWindow <= 0) return;
-
-    const utilizationPercent = (inputTokens / contextWindow) * 100;
-    bus.emit('updateContextState', {
-      stream: this.streamId,
-      contextState: {
-        inputTokens,
-        contextWindow,
-        utilizationPercent,
-      },
-    });
-  }
+  // Note: Context state is emitted by VSCodeTransport when CONTEXT_MANAGEMENT
+  // log events are processed. This keeps context emission centralized in the
+  // logging infrastructure rather than split between reporter and transport.
 }

--- a/src/logger/AgentUsageReporter.ts
+++ b/src/logger/AgentUsageReporter.ts
@@ -60,4 +60,25 @@ export class AgentUsageReporter {
       this.logger.statistics(stats, storageKey);
     }
   }
+
+  /**
+   * Report context state (utilization) to the progress view.
+   * Shows "X% context left" in the footer.
+   *
+   * @param inputTokens - Current cumulative input tokens
+   * @param contextWindow - Model's context window size
+   */
+  public reportContextState(inputTokens: number, contextWindow: number): void {
+    if (contextWindow <= 0) return;
+
+    const utilizationPercent = (inputTokens / contextWindow) * 100;
+    bus.emit('updateContextState', {
+      stream: this.streamId,
+      contextState: {
+        inputTokens,
+        contextWindow,
+        utilizationPercent,
+      },
+    });
+  }
 }

--- a/src/logger/messageTypes.ts
+++ b/src/logger/messageTypes.ts
@@ -77,6 +77,8 @@ export const MESSAGE_TYPES = {
   ERROR: 'error',
   /** Internal/system messages used by the extension */
   INTERNAL: 'internal',
+  /** Context management events (compaction, context clearing) */
+  CONTEXT_MANAGEMENT: 'contextManagement',
   DEFAULT: 'default',
 } as const;
 
@@ -94,6 +96,7 @@ export const MessageTypeSchema = z.enum([
   MESSAGE_TYPES.PROGRESS_STATUS,
   MESSAGE_TYPES.ERROR,
   MESSAGE_TYPES.INTERNAL,
+  MESSAGE_TYPES.CONTEXT_MANAGEMENT,
   MESSAGE_TYPES.DEFAULT,
 ]);
 

--- a/src/logger/transports/VSCodeTransport.ts
+++ b/src/logger/transports/VSCodeTransport.ts
@@ -145,5 +145,35 @@ export class VSCodeTransport extends Transport {
       stream: this.streamName,
       logMessage,
     });
+
+    // Emit context state update for CONTEXT_MANAGEMENT messages
+    if (
+      validatedMessageType === MESSAGE_TYPES.CONTEXT_MANAGEMENT &&
+      event.data
+    ) {
+      const contextData = event.data as {
+        contextWindow?: number;
+        tokensAfter?: number;
+        tokensBefore?: number;
+        utilizationAfter?: number;
+      };
+      const contextWindow = contextData.contextWindow ?? 0;
+      const inputTokens =
+        contextData.tokensAfter ?? contextData.tokensBefore ?? 0;
+      const utilizationPercent =
+        contextData.utilizationAfter ??
+        (contextWindow > 0 ? (inputTokens / contextWindow) * 100 : 0);
+
+      if (contextWindow > 0) {
+        bus.emit('updateContextState', {
+          stream: this.streamName,
+          contextState: {
+            inputTokens,
+            contextWindow,
+            utilizationPercent,
+          },
+        });
+      }
+    }
   }
 }

--- a/src/logger/transports/VSCodeTransport.ts
+++ b/src/logger/transports/VSCodeTransport.ts
@@ -4,7 +4,7 @@ import * as vscode from 'vscode';
 import Transport from 'winston-transport';
 
 // Internal imports
-import type { ContextManagementData } from '@logger/AgentLogger';
+import { ContextManagementDataSchema } from '@logger/AgentLogger';
 import { getEmitFilter } from '@logger/filterUtils';
 import type { LogMessageData } from '@logger/LogTypes';
 import { MESSAGE_TYPES, type MessageType } from '@logger/messageTypes';
@@ -152,24 +152,24 @@ export class VSCodeTransport extends Transport {
       validatedMessageType === MESSAGE_TYPES.CONTEXT_MANAGEMENT &&
       event.data
     ) {
-      // Use the proper ContextManagementData type from AgentLogger
-      // Validate required fields before using to prevent runtime errors
-      const contextData = event.data as Partial<ContextManagementData>;
-      const contextWindow = contextData.contextWindow;
-      if (typeof contextWindow !== 'number' || contextWindow <= 0) {
+      // Validate using Zod schema at system boundary (CLAUDE.md schema-first approach)
+      const parseResult = ContextManagementDataSchema.safeParse(event.data);
+      if (!parseResult.success) {
         return; // Skip invalid context data
       }
 
+      const contextData = parseResult.data;
       const inputTokens =
         contextData.tokensAfter ?? contextData.tokensBefore ?? 0;
       const utilizationPercent =
-        contextData.utilizationAfter ?? (inputTokens / contextWindow) * 100;
+        contextData.utilizationAfter ??
+        (inputTokens / contextData.contextWindow) * 100;
 
       bus.emit('updateContextState', {
         stream: this.streamName,
         contextState: {
           inputTokens,
-          contextWindow,
+          contextWindow: contextData.contextWindow,
           utilizationPercent,
         },
       });

--- a/src/logger/transports/VSCodeTransport.ts
+++ b/src/logger/transports/VSCodeTransport.ts
@@ -153,24 +153,26 @@ export class VSCodeTransport extends Transport {
       event.data
     ) {
       // Use the proper ContextManagementData type from AgentLogger
-      const contextData = event.data as ContextManagementData;
-      const contextWindow = contextData.contextWindow ?? 0;
+      // Validate required fields before using to prevent runtime errors
+      const contextData = event.data as Partial<ContextManagementData>;
+      const contextWindow = contextData.contextWindow;
+      if (typeof contextWindow !== 'number' || contextWindow <= 0) {
+        return; // Skip invalid context data
+      }
+
       const inputTokens =
         contextData.tokensAfter ?? contextData.tokensBefore ?? 0;
       const utilizationPercent =
-        contextData.utilizationAfter ??
-        (contextWindow > 0 ? (inputTokens / contextWindow) * 100 : 0);
+        contextData.utilizationAfter ?? (inputTokens / contextWindow) * 100;
 
-      if (contextWindow > 0) {
-        bus.emit('updateContextState', {
-          stream: this.streamName,
-          contextState: {
-            inputTokens,
-            contextWindow,
-            utilizationPercent,
-          },
-        });
-      }
+      bus.emit('updateContextState', {
+        stream: this.streamName,
+        contextState: {
+          inputTokens,
+          contextWindow,
+          utilizationPercent,
+        },
+      });
     }
   }
 }

--- a/src/logger/transports/VSCodeTransport.ts
+++ b/src/logger/transports/VSCodeTransport.ts
@@ -4,6 +4,7 @@ import * as vscode from 'vscode';
 import Transport from 'winston-transport';
 
 // Internal imports
+import type { ContextManagementData } from '@logger/AgentLogger';
 import { getEmitFilter } from '@logger/filterUtils';
 import type { LogMessageData } from '@logger/LogTypes';
 import { MESSAGE_TYPES, type MessageType } from '@logger/messageTypes';
@@ -151,12 +152,8 @@ export class VSCodeTransport extends Transport {
       validatedMessageType === MESSAGE_TYPES.CONTEXT_MANAGEMENT &&
       event.data
     ) {
-      const contextData = event.data as {
-        contextWindow?: number;
-        tokensAfter?: number;
-        tokensBefore?: number;
-        utilizationAfter?: number;
-      };
+      // Use the proper ContextManagementData type from AgentLogger
+      const contextData = event.data as ContextManagementData;
       const contextWindow = contextData.contextWindow ?? 0;
       const inputTokens =
         contextData.tokensAfter ?? contextData.tokensBefore ?? 0;

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -81,6 +81,7 @@ export class ProgressEventHandler {
 
     // Usage events (inlined from UsageEvents.ts)
     bus.on('updateStreamUsage', this.handleUpdateStreamUsage, { signal });
+    bus.on('updateContextState', this.handleUpdateContextState, { signal });
 
     // Todo events (inlined from TodoEvents.ts)
     bus.on('updateTodos', this.handleUpdateTodos, { signal });
@@ -462,6 +463,25 @@ export class ProgressEventHandler {
             storageKey,
             normalizedUsage,
           );
+        }
+      },
+    );
+  };
+
+  /** Handle updateContextState - context utilization display */
+  private handleUpdateContextState = ({
+    stream,
+    contextState,
+  }: ProgressEventPayloads['updateContextState']): void => {
+    withEventErrorHandling(
+      'UsageEvents',
+      'failed to handle updateContextState',
+      () => {
+        if (
+          this.webviewUpdater.isAvailable() &&
+          stream === this.state.activeStream
+        ) {
+          this.webviewUpdater.updateContextState(stream, contextState);
         }
       },
     );

--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -200,6 +200,7 @@
             <div id="todoList" class="todo-list"></div>
           </vscode-collapsible>
           <div class="usage-summary-footer" hidden>
+            <span id="contextState" class="context-state" hidden></span>
             <span id="runSummary" class="run-summary"></span>
           </div>
           <div id="followUpContainer" class="follow-up-container">

--- a/src/progressView/managers/WebviewUpdater.ts
+++ b/src/progressView/managers/WebviewUpdater.ts
@@ -256,6 +256,25 @@ export class WebviewUpdater {
   }
 
   /**
+   * Update context utilization display in the footer.
+   * Shows "X% context left" based on current input tokens vs context window.
+   */
+  updateContextState(
+    stream: StreamTabId,
+    contextState: {
+      inputTokens: number;
+      contextWindow: number;
+      utilizationPercent: number;
+    },
+  ): void {
+    this.sendMessage({
+      command: COMMANDS.UPDATE_CONTEXT_STATE,
+      stream,
+      contextState,
+    });
+  }
+
+  /**
    * Update or clear instruction panel content.
    * Pass null for instruction to clear the panel.
    */

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -924,6 +924,7 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
         dom.runSelector.clear();
         dom.todoList.clear();
         dom.fileList.clear();
+        dom.usageSummary?.clearContextDisplay?.();
       }
     }
 
@@ -945,6 +946,7 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     dom.runSelector.clear();
     dom.todoList.clear();
     dom.fileList.clear();
+    dom.usageSummary?.clearContextDisplay?.();
     this._updatePlaceholderVisibility();
   }
 

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -916,6 +916,7 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       state.clearRunMissingOutputs(message.stream);
       state.clearRunUsage(message.stream);
       state.clearTodos(message.stream);
+      state.clearContextState(message.stream);
       if (deletingActiveStream) {
         state.activeStream = '';
         const groupIds = Array.from(state.taskGroups.getGroupMap().keys());
@@ -943,6 +944,7 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     state.clearRunMissingOutputs();
     state.clearAllActiveRuns();
     state.clearAllTodos();
+    state.clearContextState(); // Clear all context state entries
     dom.runSelector.clear();
     dom.todoList.clear();
     dom.fileList.clear();

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -212,6 +212,7 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       [COMMANDS.UPDATE_STREAM_STATUS]: this.handleUpdateStreamStatus.bind(this),
       [COMMANDS.UPDATE_USAGE]: this.handleUpdateUsage.bind(this),
       [COMMANDS.UPDATE_RUN_USAGE]: this.handleUpdateRunUsage.bind(this),
+      [COMMANDS.UPDATE_CONTEXT_STATE]: this.handleUpdateContextState.bind(this),
       [COMMANDS.UPDATE_FILES]: this.handleUpdateFiles.bind(this),
       [COMMANDS.UPDATE_MISSING_OUTPUTS]:
         this.handleUpdateMissingOutputs.bind(this),
@@ -681,6 +682,27 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     // Update only the specific run's usage without clearing others
     state.setRunUsage(targetStream, message.runId, message.usage);
     this._refreshUsageForActiveRun();
+  }
+
+  /**
+   * Handle context state update (input tokens vs context window).
+   * Updates the context utilization display in the footer.
+   */
+  handleUpdateContextState(message) {
+    if (message.stream && !this._isActiveStream(message)) {
+      return;
+    }
+
+    const targetStream = this._getTargetStream(message);
+    if (!targetStream || !message.contextState) {
+      return;
+    }
+
+    state.setContextState(targetStream, message.contextState);
+    // Update the context display if this is the active stream
+    if (targetStream === state.activeStream) {
+      this.usageSummary?.updateContextDisplay?.(message.contextState);
+    }
   }
 
   handleUpdateFiles(message) {

--- a/src/progressView/modules/progressViewState.js
+++ b/src/progressView/modules/progressViewState.js
@@ -279,6 +279,8 @@ export class ProgressViewState {
     this.runFiles = new RunScopedMap(streamResolver);
     this.runMissingOutputs = new RunScopedMap(streamResolver);
     this.runUsage = new RunScopedMap(streamResolver);
+    // Context state (input tokens, context window) per stream
+    this.contextState = new Map();
     // Todo storage by stream ID
     this.streamTodos = new Map();
 
@@ -671,6 +673,51 @@ export class ProgressViewState {
     }
 
     this.runUsage.clearAll();
+  }
+
+  /**
+   * Set context state for a stream (input tokens vs context window).
+   * @param {string} streamId - The stream ID
+   * @param {{ inputTokens: number, contextWindow: number, utilizationPercent: number }} state
+   */
+  setContextState(streamId, state) {
+    const targetStream = this._resolveStreamId(streamId);
+    if (targetStream == null || !state) {
+      return;
+    }
+    this.contextState.set(targetStream, {
+      inputTokens: state.inputTokens ?? 0,
+      contextWindow: state.contextWindow ?? 0,
+      utilizationPercent: state.utilizationPercent ?? 0,
+    });
+  }
+
+  /**
+   * Get context state for a stream.
+   * @param {string} streamId - The stream ID
+   * @returns {{ inputTokens: number, contextWindow: number, utilizationPercent: number } | null}
+   */
+  getContextState(streamId) {
+    const targetStream = this._resolveStreamId(streamId);
+    if (targetStream == null) {
+      return null;
+    }
+    return this.contextState.get(targetStream) || null;
+  }
+
+  /**
+   * Clear context state for a stream.
+   * @param {string} streamId - The stream ID
+   */
+  clearContextState(streamId) {
+    if (streamId != null) {
+      const targetStream = this._resolveStreamId(streamId);
+      if (targetStream != null) {
+        this.contextState.delete(targetStream);
+      }
+      return;
+    }
+    this.contextState.clear();
   }
 
   deleteRunMissingOutputs(streamId, runId) {

--- a/src/progressView/modules/usageManagers.js
+++ b/src/progressView/modules/usageManagers.js
@@ -10,6 +10,7 @@ import { progressViewState } from './progressViewState.js';
 export class UsageSummary {
   constructor() {
     this._summaryElem = null;
+    this._contextElem = null;
   }
 
   /**
@@ -83,5 +84,51 @@ export class UsageSummary {
     }
 
     return { inputTokens: 0, outputTokens: 0, cost: 0 };
+  }
+
+  /**
+   * Update the context utilization display in the footer.
+   * Shows "X% context left" based on current input tokens vs context window.
+   * @param {{ inputTokens: number, contextWindow: number, utilizationPercent: number }} contextState
+   */
+  updateContextDisplay(contextState) {
+    // Cache the context element
+    if (!this._contextElem) {
+      this._contextElem = document.getElementById('contextState');
+    }
+    if (!this._contextElem) return;
+
+    const { inputTokens, contextWindow, utilizationPercent } = contextState;
+
+    if (!contextWindow || contextWindow <= 0) {
+      this._contextElem.textContent = '';
+      this._contextElem.hidden = true;
+      return;
+    }
+
+    const contextLeft = Math.max(0, 100 - utilizationPercent);
+    const formattedInput = formatTokens(inputTokens);
+    const formattedWindow = formatTokens(contextWindow);
+
+    this._contextElem.innerHTML = `
+      <i class="codicon codicon-window" title="Context window"></i>
+      <span class="context-state__value" title="${formattedInput} / ${formattedWindow} tokens used">
+        ${contextLeft.toFixed(0)}% context left
+      </span>
+    `;
+    this._contextElem.hidden = false;
+  }
+
+  /**
+   * Clear the context state display.
+   */
+  clearContextDisplay() {
+    if (!this._contextElem) {
+      this._contextElem = document.getElementById('contextState');
+    }
+    if (this._contextElem) {
+      this._contextElem.textContent = '';
+      this._contextElem.hidden = true;
+    }
   }
 }

--- a/src/progressView/styles/logs.css
+++ b/src/progressView/styles/logs.css
@@ -273,7 +273,8 @@
   background-color: var(--vscode-sideBarSectionHeader-background);
   padding: var(--spacing-small) var(--spacing-medium);
   display: flex;
-  justify-content: flex-end;
+  justify-content: space-between;
+  align-items: center;
   font-size: var(--font-size-sm);
   color: var(--color-text-secondary);
 }
@@ -284,6 +285,29 @@
 
 .usage-summary-footer .run-summary {
   margin-left: auto;
+}
+
+/* Context state display (left side of footer) */
+.context-state {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-tiny);
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-sm);
+  opacity: 0.9;
+}
+
+.context-state[hidden] {
+  display: none;
+}
+
+.context-state .codicon {
+  font-size: var(--font-size-icon-sm);
+  opacity: 0.75;
+}
+
+.context-state__value {
+  color: var(--vscode-foreground);
 }
 
 .file-item {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces automatic context management with a single configurable threshold and surfaces its effects across logging and the ProgressBoard.
> 
> - Adds `texra.model.compactionThresholdPercent` setting (default 75%) and shared `DEFAULT_COMPACTION_THRESHOLD_PERCENT`
> - OpenAI Responses handler: tracks conversation state and cumulative input tokens; triggers `/responses/compact` when threshold is exceeded; applies state post-call; skips when routing via OpenRouter; emits structured context-management logs
> - Anthropic handler: enables server-side `context_management` beta when threshold > 0; adds `clear_thinking_20251015` (keeps last 3 turns) and `clear_tool_uses_20250919` (keeps last 3 uses; token trigger computed from model context); logs applied edits with utilization deltas
> - Logging/UI: new `MESSAGE_TYPES.CONTEXT_MANAGEMENT` and Zod-validated data; VSCode transport parses these events and emits `updateContextState`; ProgressEventBus/Webview now handle `UPDATE_CONTEXT_STATE` and display “X% context left” in the footer with new styles
> - Minor: footer layout updated to show context state left-aligned and run summary right-aligned
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fe9b4739f4241a51643fb852678c0bc28302bf75. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->