### PR TITLE
Lazy load tool use sessions on user input

### DIFF
--- a/src/agent/storage/detectWaitingStreams.ts
+++ b/src/agent/storage/detectWaitingStreams.ts
@@ -28,8 +28,9 @@ export async function hasPersistedFlowRecord(
   try {
     const kv = getExecutionStore(executionId);
     const flowRecord = await kv.read<FlowRecord>(`flow:${executionId}`);
-    // Validate the record has the expected shape (shared state exists)
-    return flowRecord?.shared !== undefined;
+    // Use truthy check to match resume logic in SessionResumeRetrieval.ts
+    // This rejects null, undefined, and empty objects consistently
+    return !!flowRecord?.shared;
   } catch {
     return false;
   }
@@ -51,16 +52,8 @@ export async function detectWaitingStreams(
   const waitingStreams = new Set<StreamTabId>();
 
   for (const [streamId, executionId] of executionIdMap) {
-    try {
-      const kv = getExecutionStore(executionId);
-      const flowRecord = await kv.read<FlowRecord>(`flow:${executionId}`);
-
-      // Validate the record has the expected shape - corrupted records are skipped
-      if (flowRecord?.shared !== undefined) {
-        waitingStreams.add(streamId);
-      }
-    } catch {
-      // Ignore errors - stream won't be marked as waiting
+    if (await hasPersistedFlowRecord(executionId)) {
+      waitingStreams.add(streamId);
     }
   }
 

--- a/src/agent/storage/detectWaitingStreams.ts
+++ b/src/agent/storage/detectWaitingStreams.ts
@@ -7,7 +7,6 @@
  */
 
 import type { ExecutionId, StreamTabId } from '@agent/types/IdentifierTypes';
-import type { FlowRecord } from '@agent/node/persisted-flow';
 
 import { getExecutionStore } from './ExecutionKVStore';
 
@@ -29,10 +28,12 @@ export async function detectWaitingStreams(
   for (const [streamId, executionId] of executionIdMap) {
     try {
       const kv = getExecutionStore(executionId);
-      const flowRecord = await kv.read<FlowRecord>(`flow:${executionId}`);
+      // Use exists() instead of read() to avoid loading entire session into memory.
+      // The flow record can be large (contains full conversation history).
+      // We only need to know if it exists - actual loading happens on resume.
+      const hasFlowRecord = await kv.exists(`flow:${executionId}`);
 
-      // If a flow record exists, this stream was mid-session and should be WAITING
-      if (flowRecord?.shared) {
+      if (hasFlowRecord) {
         waitingStreams.add(streamId);
       }
     } catch {

--- a/src/agent/storage/detectWaitingStreams.ts
+++ b/src/agent/storage/detectWaitingStreams.ts
@@ -1,14 +1,32 @@
 /**
  * Detect waiting streams from persisted flow data.
  *
- * On extension startup, scans ExecutionKVStore for persisted tool-use flows
- * that were interrupted mid-session. These streams should be marked as WAITING
- * so users can send follow-ups and resume them.
+ * Provides lazy detection of persisted tool-use flows that were interrupted
+ * mid-session. These streams can be resumed when the user sends a follow-up.
  */
 
 import type { ExecutionId, StreamTabId } from '@agent/types/IdentifierTypes';
 
 import { getExecutionStore } from './ExecutionKVStore';
+
+/**
+ * Check if a single stream has a persisted flow record.
+ *
+ * Used for lazy detection when a user sends a follow-up to a stream
+ * that wasn't detected at startup (or when startup detection is skipped).
+ *
+ * @returns true if a persisted flow record exists (session can be resumed)
+ */
+export async function hasPersistedFlowRecord(
+  executionId: ExecutionId,
+): Promise<boolean> {
+  try {
+    const kv = getExecutionStore(executionId);
+    return await kv.exists(`flow:${executionId}`);
+  } catch {
+    return false;
+  }
+}
 
 /**
  * Detect streams that have persisted flow state and should be marked as WAITING.

--- a/src/agent/storage/detectWaitingStreams.ts
+++ b/src/agent/storage/detectWaitingStreams.ts
@@ -5,24 +5,31 @@
  * mid-session. These streams can be resumed when the user sends a follow-up.
  */
 
+import type { FlowRecord } from '@agent/node/persisted-flow';
 import type { ExecutionId, StreamTabId } from '@agent/types/IdentifierTypes';
 
 import { getExecutionStore } from './ExecutionKVStore';
 
 /**
- * Check if a single stream has a persisted flow record.
+ * Check if a single stream has a valid, resumable flow record.
  *
  * Used for lazy detection when a user sends a follow-up to a stream
  * that wasn't detected at startup (or when startup detection is skipped).
  *
- * @returns true if a persisted flow record exists (session can be resumed)
+ * Note: We read and validate the record rather than just checking existence,
+ * because a corrupted/truncated record (e.g., from a crash during write)
+ * would cause resume to fail, leaving the stream stuck in WAITING state.
+ *
+ * @returns true if a valid flow record exists (session can be resumed)
  */
 export async function hasPersistedFlowRecord(
   executionId: ExecutionId,
 ): Promise<boolean> {
   try {
     const kv = getExecutionStore(executionId);
-    return await kv.exists(`flow:${executionId}`);
+    const flowRecord = await kv.read<FlowRecord>(`flow:${executionId}`);
+    // Validate the record has the expected shape (shared state exists)
+    return flowRecord?.shared !== undefined;
   } catch {
     return false;
   }
@@ -46,12 +53,10 @@ export async function detectWaitingStreams(
   for (const [streamId, executionId] of executionIdMap) {
     try {
       const kv = getExecutionStore(executionId);
-      // Use exists() instead of read() to avoid loading entire session into memory.
-      // The flow record can be large (contains full conversation history).
-      // We only need to know if it exists - actual loading happens on resume.
-      const hasFlowRecord = await kv.exists(`flow:${executionId}`);
+      const flowRecord = await kv.read<FlowRecord>(`flow:${executionId}`);
 
-      if (hasFlowRecord) {
+      // Validate the record has the expected shape - corrupted records are skipped
+      if (flowRecord?.shared !== undefined) {
         waitingStreams.add(streamId);
       }
     } catch {

--- a/src/agent/storage/index.ts
+++ b/src/agent/storage/index.ts
@@ -5,4 +5,7 @@
  */
 
 export { type ExecutionKVStore, getExecutionStore } from './ExecutionKVStore';
-export { detectWaitingStreams } from './detectWaitingStreams';
+export {
+  detectWaitingStreams,
+  hasPersistedFlowRecord,
+} from './detectWaitingStreams';

--- a/src/commands/agent/followUpCommand.ts
+++ b/src/commands/agent/followUpCommand.ts
@@ -22,6 +22,9 @@ import { ResumeAgentResultSchema } from './resumeCommand';
 
 const logger = new AgentLogger('followUpCommand');
 
+// Track in-flight lazy detection checks to prevent race conditions
+const inFlightDetections = new Set<StreamTabId>();
+
 /**
  * Lazily detect if a stream has a persisted flow record and set WAITING status.
  *
@@ -37,6 +40,11 @@ async function lazyDetectWaitingStatus(streamId: StreamTabId): Promise<boolean> 
     return currentStatus === STREAM_STATUS.WAITING;
   }
 
+  // Skip if detection is already in progress for this stream
+  if (inFlightDetections.has(streamId)) {
+    return false;
+  }
+
   // Get execution ID to check for persisted flow
   const progressState = ProgressViewProvider.getInstance()?.state;
   const executionId = progressState?.getExecutionId(streamId);
@@ -44,16 +52,21 @@ async function lazyDetectWaitingStatus(streamId: StreamTabId): Promise<boolean> 
     return false;
   }
 
-  // Check if a persisted flow record exists
-  const hasFlow = await hasPersistedFlowRecord(executionId);
-  if (hasFlow) {
-    // Set WAITING status so sendFollowUp will queue the message
-    StreamStatusService.set(streamId, STREAM_STATUS.WAITING);
-    logger.debug(`Lazy detected waiting session for stream: ${streamId}`);
-    return true;
+  // Mark as in-flight to prevent duplicate checks
+  inFlightDetections.add(streamId);
+  try {
+    // Check if a persisted flow record exists
+    const hasFlow = await hasPersistedFlowRecord(executionId);
+    if (hasFlow) {
+      // Set WAITING status so sendFollowUp will queue the message
+      StreamStatusService.set(streamId, STREAM_STATUS.WAITING);
+      logger.debug(`Lazy detected waiting session for stream: ${streamId}`);
+      return true;
+    }
+    return false;
+  } finally {
+    inFlightDetections.delete(streamId);
   }
-
-  return false;
 }
 
 /**

--- a/src/commands/agent/followUpCommand.ts
+++ b/src/commands/agent/followUpCommand.ts
@@ -9,6 +9,7 @@ import {
   type SendFollowUpResult,
 } from '@agent/toolUse/ToolUseFollowUp';
 import { retrieveSessionResumeData } from '@agent/runtime/SessionResumeRetrieval';
+import { hasPersistedFlowRecord } from '@agent/storage/detectWaitingStreams';
 import { STREAM_STATUS } from '@common/constants/streamStatus';
 import {
   showErrorMessage,
@@ -20,6 +21,40 @@ import { ProgressViewProvider } from '@progressView/ProgressViewProvider';
 import { ResumeAgentResultSchema } from './resumeCommand';
 
 const logger = new AgentLogger('followUpCommand');
+
+/**
+ * Lazily detect if a stream has a persisted flow record and set WAITING status.
+ *
+ * This enables lazy loading of session state - instead of checking all streams
+ * at startup, we only check when the user actually sends a follow-up.
+ *
+ * @returns true if a persisted flow was detected and status was set to WAITING
+ */
+async function lazyDetectWaitingStatus(streamId: StreamTabId): Promise<boolean> {
+  // Skip if status is already set (active, resuming, waiting, etc.)
+  const currentStatus = StreamStatusService.get(streamId);
+  if (currentStatus) {
+    return currentStatus === STREAM_STATUS.WAITING;
+  }
+
+  // Get execution ID to check for persisted flow
+  const progressState = ProgressViewProvider.getInstance()?.state;
+  const executionId = progressState?.getExecutionId(streamId);
+  if (!executionId) {
+    return false;
+  }
+
+  // Check if a persisted flow record exists
+  const hasFlow = await hasPersistedFlowRecord(executionId);
+  if (hasFlow) {
+    // Set WAITING status so sendFollowUp will queue the message
+    StreamStatusService.set(streamId, STREAM_STATUS.WAITING);
+    logger.debug(`Lazy detected waiting session for stream: ${streamId}`);
+    return true;
+  }
+
+  return false;
+}
 
 /**
  * Attempt to auto-resume a WAITING tool-use session.
@@ -154,6 +189,11 @@ export function registerFollowUpCommand(context: vscode.ExtensionContext) {
       'texra.sendFollowUp',
       async (payload: { stream: string; text: string }) => {
         const streamId = payload.stream as StreamTabId;
+
+        // Lazy detection: check for persisted flow if status not already set.
+        // This avoids iterating through all streams at startup.
+        await lazyDetectWaitingStatus(streamId);
+
         const result = await sendFollowUp(streamId, payload.text);
         await handleFollowUpResult(result, streamId);
       },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,9 +6,6 @@ import * as vscode from 'vscode';
 import dotenv from 'dotenv';
 
 // Local imports - core
-import { detectWaitingStreams } from '@agent/storage';
-import { StreamStatusService } from '@agent/runtime/StreamStatusService';
-import { STREAM_STATUS } from '@common/constants/streamStatus';
 import { toErrorMessage } from '@common/errors/errorHandlingUtils';
 import { initializeStateManagers } from '@common/state/stateManager';
 import { SecretManager } from '@frontend/secretManager';
@@ -204,33 +201,13 @@ export async function activate(context: vscode.ExtensionContext) {
   const progressViewProvider = new ProgressViewProvider(context);
   await progressViewProvider.initialize();
 
-  // Detect streams with persisted flows that should be marked as WAITING.
-  // This allows users to send follow-ups and resume interrupted sessions.
-  const executionIdMap = progressViewProvider.state.getAllExecutionIds();
-  const waitingStreams = await detectWaitingStreams(executionIdMap);
-
-  // Set stream status for waiting streams.
-  // StreamStatusService is the single source of truth for stream status.
-  // It's used by ToolUseFollowUp to determine if follow-ups can be queued.
-  // The event emitted by set() will update ProgressEventHandler's webview.
-  for (const streamId of waitingStreams) {
-    StreamStatusService.set(streamId, STREAM_STATUS.WAITING);
-  }
-
   // Log activation message to ensure the logger is working correctly
   logger.info('extension', 'TeXRA extension activated');
-  if (waitingStreams.size > 0) {
-    logger.debug(
-      'extension',
-      `Detected ${waitingStreams.size} waiting stream(s) with persisted flows`,
-    );
-  }
 
-  // Clean up UI state: mark running streams as ERROR (or WAITING if in waitingStreams).
-  // This only affects streams that were RUNNING in the UI state, which won't include
-  // any streams on a fresh restart. The StreamStatusService.set() above handles the
-  // backend status for all waiting streams regardless of prior UI state.
-  await progressViewProvider.cleanupTasksAfterRestart(waitingStreams);
+  // Clean up UI state: mark running streams as ERROR.
+  // Note: Waiting stream detection is now lazy - happens when user sends follow-up.
+  // See followUpCommand.ts lazyDetectWaitingStatus() for details.
+  await progressViewProvider.cleanupTasksAfterRestart();
 
   // Configure LaTeX settings if LaTeX Workshop is installed
   configureLatexSettings();


### PR DESCRIPTION
Previously, detectWaitingStreams() would read and deserialize the entire FlowRecord JSON for each session just to check if the file exists. This is wasteful since FlowRecords can be large (they contain full conversation history).

Now we use kv.exists() which only checks file existence without loading content into memory. Actual session loading happens lazily when the user sends a follow-up message.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements lazy detection and resume of interrupted sessions, reducing startup work and loading state only when needed.
> 
> - Add `hasPersistedFlowRecord(executionId)` to validate resumable flow records and reuse in `detectWaitingStreams`
> - In `followUpCommand`, lazily set `WAITING` status on first follow-up via `hasPersistedFlowRecord`, prevent duplicate checks, and auto-resume queued tool-use sessions
> - Remove startup scanning of waiting streams from `extension.ts`; update `cleanupTasksAfterRestart()` call to no-args (waiting detection now lazy)
> - Re-export `hasPersistedFlowRecord` from storage index
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 68e191485e88dd300b6056ceba6e7dedb2e0c757. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->