### PR TITLE
Add line numbers to glob and grep tools

### DIFF
--- a/src/test/tools/grep.test.ts
+++ b/src/test/tools/grep.test.ts
@@ -7,8 +7,13 @@ import { buildArguments, type GrepInput } from '@tools/grep';
 describe('buildArguments', () => {
   const baseInput: GrepInput = { pattern: 'example' };
 
-  it('omits --files-with-matches when using content mode', () => {
+  it('includes -n by default in content mode', () => {
     const args = buildArguments(baseInput, 'content');
+    assert.deepEqual(args, ['--color=never', '-n']);
+  });
+
+  it('omits -n when explicitly disabled', () => {
+    const args = buildArguments({ ...baseInput, '-n': false }, 'content');
     assert.deepEqual(args, ['--color=never']);
   });
 

--- a/src/tools/glob.ts
+++ b/src/tools/glob.ts
@@ -27,6 +27,7 @@ export type GlobInput = z.infer<typeof GlobInputSchema>;
 interface GlobMatchInfo {
   relativePath: string;
   mtime: number;
+  lineCount: number | null;
 }
 
 export class GlobTool extends defineTool({
@@ -72,12 +73,25 @@ export class GlobTool extends defineTool({
 
       try {
         const stat = await WorkspaceFS.stat(relativePath);
+        let lineCount: number | null = null;
+
+        // Count lines for regular files
+        if (stat.isFile) {
+          try {
+            const content = await WorkspaceFS.readFile(relativePath);
+            lineCount = content.split('\n').length;
+          } catch {
+            // Ignore read errors (binary files, permission issues, etc.)
+          }
+        }
+
         return {
           relativePath,
           mtime: stat.mtime ?? 0,
+          lineCount,
         };
       } catch (_err) {
-        return { relativePath, mtime: 0 };
+        return { relativePath, mtime: 0, lineCount: null };
       }
     });
 
@@ -94,7 +108,13 @@ export class GlobTool extends defineTool({
     });
 
     const header = `Matches for pattern "${input.pattern}" under ${display}`;
-    const lines = sorted.map((item) => toPosixPath(item.relativePath));
+    const lines = sorted.map((item) => {
+      const path = toPosixPath(item.relativePath);
+      if (item.lineCount !== null) {
+        return `${path} (${item.lineCount} lines)`;
+      }
+      return path;
+    });
     return {
       summary: `glob "${input.pattern}" under ${display}`,
       output: formatToolOutput(header, lines, '(no matches)'),

--- a/src/tools/glob.ts
+++ b/src/tools/glob.ts
@@ -128,27 +128,30 @@ export class GlobTool extends defineTool({
         item !== null,
     );
 
-    // Count lines for all files in batch using wc -l (efficient, no memory issues)
-    const filePaths = statsOnly
-      .filter((item) => item.isFile)
-      .map((item) => item.relativePath);
-    const lineCounts = await countLinesForFiles(filePaths);
-
-    const decorated: GlobMatchInfo[] = statsOnly.map((item) => ({
-      relativePath: item.relativePath,
-      mtime: item.mtime,
-      lineCount: item.isFile ? (lineCounts.get(item.relativePath) ?? null) : null,
-    }));
-
-    const sorted = decorated.sort((a, b) => {
+    // Sort by mtime first, then count lines only for top N files
+    const sorted = statsOnly.sort((a, b) => {
       if (b.mtime !== a.mtime) {
         return b.mtime - a.mtime;
       }
       return a.relativePath.localeCompare(b.relativePath);
     });
 
+    // Count lines for files using wc -l, but limit to avoid slowdowns on large results
+    const LINE_COUNT_LIMIT = 50;
+    const filesToCount = sorted
+      .filter((item) => item.isFile)
+      .slice(0, LINE_COUNT_LIMIT)
+      .map((item) => item.relativePath);
+    const lineCounts = await countLinesForFiles(filesToCount);
+
+    const decorated: GlobMatchInfo[] = sorted.map((item) => ({
+      relativePath: item.relativePath,
+      mtime: item.mtime,
+      lineCount: item.isFile ? (lineCounts.get(item.relativePath) ?? null) : null,
+    }));
+
     const header = `Matches for pattern "${input.pattern}" under ${display}`;
-    const lines = sorted.map((item) => {
+    const lines = decorated.map((item) => {
       const path = toPosixPath(item.relativePath);
       if (item.lineCount !== null) {
         return `${path} (${item.lineCount} lines)`;

--- a/src/tools/glob.ts
+++ b/src/tools/glob.ts
@@ -13,6 +13,7 @@ import {
 import { getGitignoreMatcher } from '@tools/gitignore';
 import { toPosixPath } from '@utils/core';
 import { WorkspaceFS } from '@utils/files';
+import { executeCommand } from '@utils/system/execUtils';
 
 // Local file imports
 import { defineTool } from './core/define';
@@ -28,6 +29,44 @@ interface GlobMatchInfo {
   relativePath: string;
   mtime: number;
   lineCount: number | null;
+}
+
+/**
+ * Count lines for multiple files using `wc -l` (efficient, streams files).
+ * Returns a map from relative path to line count.
+ */
+async function countLinesForFiles(
+  filePaths: string[],
+): Promise<Map<string, number>> {
+  const lineCounts = new Map<string, number>();
+  if (filePaths.length === 0) {
+    return lineCounts;
+  }
+
+  // Batch files to avoid command line length limits
+  const BATCH_SIZE = 100;
+  for (let i = 0; i < filePaths.length; i += BATCH_SIZE) {
+    const batch = filePaths.slice(i, i + BATCH_SIZE);
+    const result = await executeCommand(['wc', '-l', ...batch], {
+      channel: 'GlobTool',
+    });
+
+    if (result.success && result.stdout) {
+      // Parse wc -l output: "  123 path/to/file"
+      for (const line of result.stdout.split('\n')) {
+        const match = line.match(/^\s*(\d+)\s+(.+)$/);
+        if (match) {
+          const [, count, path] = match;
+          // Skip "total" line that wc outputs when given multiple files
+          if (path !== 'total') {
+            lineCounts.set(path, parseInt(count, 10));
+          }
+        }
+      }
+    }
+  }
+
+  return lineCounts;
 }
 
 export class GlobTool extends defineTool({
@@ -73,32 +112,33 @@ export class GlobTool extends defineTool({
 
       try {
         const stat = await WorkspaceFS.stat(relativePath);
-        let lineCount: number | null = null;
-
-        // Count lines for regular files
-        if (stat.isFile) {
-          try {
-            const content = await WorkspaceFS.readFile(relativePath);
-            lineCount = content.split('\n').length;
-          } catch {
-            // Ignore read errors (binary files, permission issues, etc.)
-          }
-        }
-
         return {
           relativePath,
           mtime: stat.mtime ?? 0,
-          lineCount,
+          isFile: stat.isFile,
         };
       } catch (_err) {
-        return { relativePath, mtime: 0, lineCount: null };
+        return { relativePath, mtime: 0, isFile: false };
       }
     });
 
     const decoratedWithNulls = await Promise.all(statPromises);
-    const decorated = decoratedWithNulls.filter(
-      (item): item is GlobMatchInfo => item !== null,
+    const statsOnly = decoratedWithNulls.filter(
+      (item): item is { relativePath: string; mtime: number; isFile: boolean } =>
+        item !== null,
     );
+
+    // Count lines for all files in batch using wc -l (efficient, no memory issues)
+    const filePaths = statsOnly
+      .filter((item) => item.isFile)
+      .map((item) => item.relativePath);
+    const lineCounts = await countLinesForFiles(filePaths);
+
+    const decorated: GlobMatchInfo[] = statsOnly.map((item) => ({
+      relativePath: item.relativePath,
+      mtime: item.mtime,
+      lineCount: item.isFile ? (lineCounts.get(item.relativePath) ?? null) : null,
+    }));
 
     const sorted = decorated.sort((a, b) => {
       if (b.mtime !== a.mtime) {

--- a/src/tools/grep.ts
+++ b/src/tools/grep.ts
@@ -62,7 +62,8 @@ export function buildArguments(
   }
 
   if (outputMode === 'content') {
-    if (input['-n']) {
+    // Line numbers enabled by default for better navigation
+    if (input['-n'] !== false) {
       args.push('-n');
     }
     if (typeof input['-A'] === 'number') {
@@ -95,7 +96,7 @@ function applyHeadLimit(output: string | null, headLimit?: number): string {
 export class GrepTool extends defineTool({
   name: 'grep',
   description:
-    'Search file contents using regex patterns. Supports context (-A/-B/-C), glob/type filters, and multiline matching.',
+    'Search file contents using regex patterns. Shows line numbers by default. Supports context (-A/-B/-C), glob/type filters, and multiline matching.',
   schema: GrepInputSchema,
 }) {
   protected async execute(input: GrepInput): Promise<ToolResult> {


### PR DESCRIPTION
- Glob tool now shows line count for each file (e.g., "file.ts (103 lines)")
- Grep tool now shows line numbers by default in content mode
- Can disable line numbers with -n: false if needed

These changes help agents navigate codebases more effectively by providing location context and file size information upfront.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enhances discoverability and context in code search outputs.
> 
> - `glob`: Appends line counts to up to 50 most-recent files using `wc -l` (batched calls via `executeCommand`); output now shows `path (N lines)`. Internals capture `isFile`, preserve mtime sort, and skip counting for non-files.
> - `grep`: `buildArguments` now includes `-n` by default in `content` mode unless `'-n': false`; tool description updated. Tests added/updated to cover default `-n`, disabling it, and `--files-with-matches`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 01ee71618d8d235e7d85060d68e59ad22a346647. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->