### PR TITLE
Open progress view in separate tab

### DIFF
--- a/package.json
+++ b/package.json
@@ -1517,6 +1517,11 @@
           "group": "navigation@7"
         },
         {
+          "command": "texra.openProgressViewInTab",
+          "when": "view == texra.progressView",
+          "group": "navigation@8"
+        },
+        {
           "command": "texra.folderExplorer.newFile",
           "when": "view == texra.folderExplorer",
           "group": "navigation"

--- a/package.json
+++ b/package.json
@@ -1327,6 +1327,12 @@
         "title": "Show Tasks",
         "category": "TeXRA",
         "icon": "$(eye)"
+      },
+      {
+        "command": "texra.openProgressViewInTab",
+        "title": "Open Tasks in Editor Tab",
+        "category": "TeXRA",
+        "icon": "$(go-to-file)"
       }
     ],
     "walkthroughs": [

--- a/package.json
+++ b/package.json
@@ -1331,8 +1331,9 @@
       {
         "command": "texra.openProgressViewInTab",
         "title": "Open Tasks in Editor Tab",
+        "shortTitle": "Open in Tab",
         "category": "TeXRA",
-        "icon": "$(go-to-file)"
+        "icon": "$(multiple-windows)"
       }
     ],
     "walkthroughs": [

--- a/src/commands/progress/progressViewCommands.ts
+++ b/src/commands/progress/progressViewCommands.ts
@@ -4,6 +4,7 @@ import * as vscode from 'vscode';
 // Internal imports
 import { safeExecuteCommand } from '@frontend/system/commandUtils';
 import { AgentLogger } from '@logger/AgentLogger';
+import { ProgressViewProvider } from '@progressView/ProgressViewProvider';
 
 const CHANNEL = 'progressViewCommands';
 const logger = new AgentLogger(CHANNEL);
@@ -19,6 +20,23 @@ async function showProgressView() {
 }
 
 /**
+ * Open the Progress View in a separate editor tab
+ */
+function openProgressViewInTab() {
+  const provider = ProgressViewProvider.getInstance();
+  if (!provider) {
+    logger.error('ProgressViewProvider not initialized');
+    vscode.window.showErrorMessage(
+      'Progress View is not available. Please try again.',
+    );
+    return;
+  }
+
+  provider.showProgressViewAsPanel();
+  logger.info('ProgressView opened in separate tab');
+}
+
+/**
  * Register all progress view related commands
  */
 export function registerProgressViewCommands(context: vscode.ExtensionContext) {
@@ -26,9 +44,14 @@ export function registerProgressViewCommands(context: vscode.ExtensionContext) {
 
   context.subscriptions.push(
     vscode.commands.registerCommand('texra.showProgressView', showProgressView),
+    vscode.commands.registerCommand(
+      'texra.openProgressViewInTab',
+      openProgressViewInTab,
+    ),
   );
 
   return {
     showProgressView,
+    openProgressViewInTab,
   };
 }

--- a/src/common/managers/RecordingManager.ts
+++ b/src/common/managers/RecordingManager.ts
@@ -28,7 +28,9 @@ export class RecordingManager {
     private readonly commandConfig: RecordingManagerConfig,
   ) {}
 
-  async start(webviewView: vscode.WebviewView): Promise<void> {
+  async start(
+    webviewView: vscode.WebviewView | vscode.WebviewPanel,
+  ): Promise<void> {
     try {
       const result = await startRecording(this.context);
       if (result.success) {
@@ -54,7 +56,9 @@ export class RecordingManager {
     }
   }
 
-  async stop(webviewView: vscode.WebviewView): Promise<void> {
+  async stop(
+    webviewView: vscode.WebviewView | vscode.WebviewPanel,
+  ): Promise<void> {
     let stopAcknowledged = false;
     const acknowledgeStop = () => {
       if (stopAcknowledged) {

--- a/src/common/webview/BaseWebviewProvider.ts
+++ b/src/common/webview/BaseWebviewProvider.ts
@@ -69,8 +69,9 @@ export abstract class BaseWebviewProvider {
    * @returns true if panel was created, false if existing panel was revealed
    */
   protected createOrShowPanel(options: PanelOptions): boolean {
-    // If we already have a panel, reveal it
-    if (this._view && 'reveal' in this._view) {
+    // If we already have a panel (not a sidebar WebviewView), reveal it.
+    // Check for 'viewColumn' which is unique to WebviewPanel (WebviewView doesn't have it).
+    if (this._view && 'viewColumn' in this._view) {
       this._view.reveal(options.column ?? vscode.ViewColumn.One);
       return false;
     }

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -61,7 +61,9 @@ interface CompareMessage extends BaseFileCommandMessage {
   prev?: string;
 }
 
-export class ProgressViewMessageHandler extends BaseViewMessageHandler {
+export class ProgressViewMessageHandler extends BaseViewMessageHandler<
+  vscode.WebviewView | vscode.WebviewPanel
+> {
   private readonly recordingManager: RecordingManager;
 
   constructor(
@@ -86,7 +88,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
 
   protected createHandlers(): Record<
     string,
-    MessageHandler<vscode.WebviewView>
+    MessageHandler<vscode.WebviewView | vscode.WebviewPanel>
   > {
     return {
       // Common handlers
@@ -168,8 +170,8 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
     const webviewView = this.getActiveView();
     if (webviewView) {
       await super.handleWebviewReady(message, webviewView);
+      this.provider.markWebviewReady(webviewView);
     }
-    this.provider.markWebviewReady();
   }
 
   private async handleSwitchStream(message: any): Promise<void> {

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -450,14 +450,12 @@ export class ProgressViewProvider
       }),
     );
 
-    // Cleanup on panel dispose (added to disposables for consistency)
-    this._panelDisposables.push(
-      this._panelView.onDidDispose(() => {
-        this._panelDisposables.forEach((d) => d.dispose());
-        this._panelDisposables = [];
-        this._panelView = undefined;
-      }),
-    );
+    // Cleanup on panel dispose (not added to _panelDisposables to avoid self-disposal during iteration)
+    this._panelView.onDidDispose(() => {
+      this._panelDisposables.forEach((d) => d.dispose());
+      this._panelDisposables = [];
+      this._panelView = undefined;
+    });
 
     // Trigger initial update (webview will send WEBVIEW_READY when loaded)
     this.updateWebview();

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -363,4 +363,22 @@ export class ProgressViewProvider
     this.state.activeStream = stream;
     this.updateWebview();
   }
+
+  /**
+   * Open the progress view in a separate editor tab (WebviewPanel).
+   * This creates a standalone panel that can be positioned anywhere in the editor.
+   */
+  public showProgressViewAsPanel(): void {
+    const isNew = this.createOrShowPanel({
+      viewType: ProgressViewProvider.viewType + '.panel',
+      title: 'TeXRA ProgressBoard',
+      viewPath: 'progressView',
+    });
+
+    if (isNew) {
+      // For new panels, mark as ready and trigger initial update
+      // The panel's webview will signal ready via message, same as sidebar
+      this.logger.info('ProgressView opened in separate tab');
+    }
+  }
 }

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -344,10 +344,10 @@ export class ProgressViewProvider
   }
 
   /**
-   * Check if view is visible (legacy compatibility)
+   * Check if any view is visible (sidebar or panel)
    */
   public isViewVisible(): boolean {
-    return this._view?.visible ?? false;
+    return (this._view?.visible ?? false) || (this._panelView?.visible ?? false);
   }
 
   // ===== IRunStorageService implementation =====
@@ -436,11 +436,23 @@ export class ProgressViewProvider
     // Setup content, message handler, and theme listener (shared with sidebar)
     this._panelDisposables.push(...this.setupWebviewContent(this._panelView));
 
+    // Add visibility listener (panel uses onDidChangeViewState instead of onDidChangeVisibility)
+    this._panelDisposables.push(
+      this._panelView.onDidChangeViewState((e) => {
+        if (e.webviewPanel.visible) {
+          this.updateWebview();
+        }
+      }),
+    );
+
     // Cleanup on panel dispose
     this._panelView.onDidDispose(() => {
       this._panelDisposables.forEach((d) => d.dispose());
       this._panelDisposables = [];
       this._panelView = undefined;
     });
+
+    // Trigger initial update (webview will send WEBVIEW_READY when loaded)
+    this.updateWebview();
   }
 }

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -29,6 +29,11 @@ import { ProgressViewState } from './state/ProgressViewState';
  * This class now focuses on orchestration and delegation to focused managers,
  * following the design principles from AGENTS.md.
  *
+ * Supports two simultaneous views:
+ * - Sidebar view (_view): Standard VS Code webview view in the bottom panel
+ * - Panel view (_panelView): Standalone editor tab for more screen real estate
+ * Both views share state and receive synchronized updates via WebviewUpdater.
+ *
  * Implements IRunStorageService to provide run state access to the agent runtime
  * without creating circular dependencies.
  */
@@ -445,14 +450,25 @@ export class ProgressViewProvider
       }),
     );
 
-    // Cleanup on panel dispose
-    this._panelView.onDidDispose(() => {
-      this._panelDisposables.forEach((d) => d.dispose());
-      this._panelDisposables = [];
-      this._panelView = undefined;
-    });
+    // Cleanup on panel dispose (added to disposables for consistency)
+    this._panelDisposables.push(
+      this._panelView.onDidDispose(() => {
+        this._panelDisposables.forEach((d) => d.dispose());
+        this._panelDisposables = [];
+        this._panelView = undefined;
+      }),
+    );
 
     // Trigger initial update (webview will send WEBVIEW_READY when loaded)
     this.updateWebview();
+  }
+
+  public override dispose(): void {
+    // Clean up panel resources
+    this._panelDisposables.forEach((d) => d.dispose());
+    this._panelDisposables = [];
+    this._panelView?.dispose();
+    this._panelView = undefined;
+    super.dispose();
   }
 }

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -375,10 +375,11 @@ export class ProgressViewProvider
       viewPath: 'progressView',
     });
 
-    if (isNew) {
-      // For new panels, mark as ready and trigger initial update
-      // The panel's webview will signal ready via message, same as sidebar
-      this.logger.info('ProgressView opened in separate tab');
+    if (!isNew) {
+      // Refresh data when revealing existing panel
+      this.updateWebview({ forceRebuild: true });
     }
+    // For new panels, the webview will signal ready via WEBVIEW_READY message,
+    // which triggers markWebviewReady() and the initial updateWebview()
   }
 }

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -381,7 +381,7 @@ export class ProgressViewProvider
     // If panel already exists, reveal it
     if (this._panelView) {
       this._panelView.reveal(vscode.ViewColumn.One);
-      this.updatePanelWebview({ forceRebuild: true });
+      this.updateWebview({ forceRebuild: true });
       return;
     }
 
@@ -413,11 +413,11 @@ export class ProgressViewProvider
       ),
     );
 
-    // Setup theme change listener for panel
+    // Setup theme change listener for panel (uses shared updateWebview)
     this._panelDisposables.push(
       vscode.window.onDidChangeActiveColorTheme(() => {
         if (this._panelView?.visible) {
-          this.updatePanelWebview();
+          this.updateWebview();
         }
       }),
     );
@@ -428,38 +428,5 @@ export class ProgressViewProvider
       this._panelDisposables = [];
       this._panelView = undefined;
     });
-  }
-
-  /**
-   * Update the panel webview content (separate from sidebar updates).
-   */
-  private updatePanelWebview(options?: { forceRebuild?: boolean }): void {
-    if (!this._panelView) return;
-
-    const theme =
-      vscode.window.activeColorTheme.kind === vscode.ColorThemeKind.Dark
-        ? 'dark'
-        : 'light';
-
-    const activeStream = this.state.activeStream;
-    const streamStatuses = this.eventHandler.getAllStreamStatuses();
-
-    // Send data to panel webview
-    this._panelView.webview.postMessage({
-      command: 'updateAll',
-      data: {
-        streams: this.state.getAllStreams(),
-        activeStream,
-        streamStatuses: Object.fromEntries(streamStatuses),
-        theme,
-      },
-    });
-
-    if (options?.forceRebuild) {
-      this._panelView.webview.postMessage({
-        command: 'refreshStreamSurface',
-        data: { streamId: activeStream || '', forceRebuild: true },
-      });
-    }
   }
 }

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -51,6 +51,9 @@ export class ProgressViewProvider
   // Infrastructure
   private readonly _viewTitle: string;
   private _webviewReady = false;
+  // Separate panel view (editor tab) from sidebar view
+  private _panelView?: vscode.WebviewPanel;
+  private _panelDisposables: vscode.Disposable[] = [];
   /**
    * Tracks pending update options when webview is not ready.
    * Uses an object instead of boolean to preserve forceRebuild requests.
@@ -79,7 +82,11 @@ export class ProgressViewProvider
 
     // Initialize new modular architecture
     this.state = new ProgressViewState();
-    this.webviewUpdater = new WebviewUpdater(() => this._view?.webview);
+    // WebviewUpdater sends to all available webviews (sidebar + panel)
+    this.webviewUpdater = new WebviewUpdater(() => [
+      this._view?.webview,
+      this._panelView?.webview,
+    ]);
     this.eventHandler = new ProgressEventHandler(
       this.state,
       this.webviewUpdater,
@@ -181,11 +188,12 @@ export class ProgressViewProvider
   }
 
   /**
-   * Update webview content using the new architecture
+   * Update webview content using the new architecture.
+   * WebviewUpdater automatically sends to all registered webviews (sidebar + panel).
    * @param options.forceRebuild - Force full DOM rebuild in frontend
    */
   public updateWebview(options?: { forceRebuild?: boolean }): void {
-    if (!this._view) return;
+    if (!this._view && !this._panelView) return;
 
     if (!this._webviewReady) {
       // Queue the update, preserving forceRebuild if any caller requested it.
@@ -367,19 +375,91 @@ export class ProgressViewProvider
   /**
    * Open the progress view in a separate editor tab (WebviewPanel).
    * This creates a standalone panel that can be positioned anywhere in the editor.
+   * The panel is tracked separately from the sidebar view.
    */
   public showProgressViewAsPanel(): void {
-    const isNew = this.createOrShowPanel({
-      viewType: ProgressViewProvider.viewType + '.panel',
-      title: 'TeXRA ProgressBoard',
-      viewPath: 'progressView',
+    // If panel already exists, reveal it
+    if (this._panelView) {
+      this._panelView.reveal(vscode.ViewColumn.One);
+      this.updatePanelWebview({ forceRebuild: true });
+      return;
+    }
+
+    // Create new panel
+    this._panelView = vscode.window.createWebviewPanel(
+      ProgressViewProvider.viewType + '.panel',
+      'TeXRA ProgressBoard',
+      vscode.ViewColumn.One,
+      {
+        enableScripts: true,
+        enableCommandUris: true,
+        retainContextWhenHidden: true,
+        localResourceRoots: getSharedLocalResourceRoots(
+          this.context,
+          'progressView',
+        ),
+      },
+    );
+
+    // Set panel HTML content
+    this._panelView.webview.html = this.contentProvider.getHtmlContent(
+      this._panelView.webview,
+    );
+
+    // Setup panel message handling
+    this._panelDisposables.push(
+      this._panelView.webview.onDidReceiveMessage((message) =>
+        this.messageHandler.handleMessage(message, this._panelView!),
+      ),
+    );
+
+    // Setup theme change listener for panel
+    this._panelDisposables.push(
+      vscode.window.onDidChangeActiveColorTheme(() => {
+        if (this._panelView?.visible) {
+          this.updatePanelWebview();
+        }
+      }),
+    );
+
+    // Cleanup on panel dispose
+    this._panelView.onDidDispose(() => {
+      this._panelDisposables.forEach((d) => d.dispose());
+      this._panelDisposables = [];
+      this._panelView = undefined;
+    });
+  }
+
+  /**
+   * Update the panel webview content (separate from sidebar updates).
+   */
+  private updatePanelWebview(options?: { forceRebuild?: boolean }): void {
+    if (!this._panelView) return;
+
+    const theme =
+      vscode.window.activeColorTheme.kind === vscode.ColorThemeKind.Dark
+        ? 'dark'
+        : 'light';
+
+    const activeStream = this.state.activeStream;
+    const streamStatuses = this.eventHandler.getAllStreamStatuses();
+
+    // Send data to panel webview
+    this._panelView.webview.postMessage({
+      command: 'updateAll',
+      data: {
+        streams: this.state.getAllStreams(),
+        activeStream,
+        streamStatuses: Object.fromEntries(streamStatuses),
+        theme,
+      },
     });
 
-    if (!isNew) {
-      // Refresh data when revealing existing panel
-      this.updateWebview({ forceRebuild: true });
+    if (options?.forceRebuild) {
+      this._panelView.webview.postMessage({
+        command: 'refreshStreamSurface',
+        data: { streamId: activeStream || '', forceRebuild: true },
+      });
     }
-    // For new panels, the webview will signal ready via WEBVIEW_READY message,
-    // which triggers markWebviewReady() and the initial updateWebview()
   }
 }

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -144,6 +144,38 @@ export class ProgressViewProvider
     this.state.clearRenderedStreamTracking();
   }
 
+  /**
+   * Common setup for any webview (sidebar or panel).
+   * Sets HTML content, message handler, and theme listener.
+   * @returns disposables that should be cleaned up when the view is disposed
+   */
+  private setupWebviewContent(
+    view: vscode.WebviewView | vscode.WebviewPanel,
+  ): vscode.Disposable[] {
+    const disposables: vscode.Disposable[] = [];
+
+    // Set HTML content
+    view.webview.html = this.contentProvider.getHtmlContent(view.webview);
+
+    // Setup message handling
+    disposables.push(
+      view.webview.onDidReceiveMessage((message) =>
+        this.messageHandler.handleMessage(message, view),
+      ),
+    );
+
+    // Setup theme change listener
+    disposables.push(
+      vscode.window.onDidChangeActiveColorTheme(() => {
+        if (view.visible) {
+          this.updateWebview();
+        }
+      }),
+    );
+
+    return disposables;
+  }
+
   public resolveWebviewView(webviewView: vscode.WebviewView): void {
     // Mark running tasks as cancelled on subsequent webview resolves
     if (this._hasResolved) {
@@ -155,6 +187,7 @@ export class ProgressViewProvider
     this._pendingUpdateOptions = null;
     // Clear rendered stream tracking to force rebuild - DOM state is stale after resolve
     this.state.clearRenderedStreamTracking();
+
     webviewView.webview.options = {
       enableScripts: true,
       enableCommandUris: true,
@@ -163,25 +196,24 @@ export class ProgressViewProvider
         'progressView',
       ),
     };
-
     webviewView.title = this._viewTitle;
 
-    // Call super first to set up base functionality and clean up old disposables
-    super.resolveWebviewViewInternal(webviewView);
+    // Clean up old view and set new one
+    this.cleanupView();
+    this._view = webviewView;
 
-    // Add visibility and theme listeners after super.resolveWebviewView
-    // This ensures they aren't cleared by the base class's cleanupView()
-    this.addViewDisposables(
+    // Setup content, message handler, and theme listener
+    const disposables = this.setupWebviewContent(webviewView);
+    this._viewDisposables.push(...disposables);
+
+    // Add visibility listener (specific to sidebar)
+    this._viewDisposables.push(
       webviewView.onDidChangeVisibility(() => {
         if (webviewView.visible) {
           this.updateWebview();
         }
       }),
-      vscode.window.onDidChangeActiveColorTheme(() => {
-        if (webviewView.visible) {
-          this.updateWebview();
-        }
-      }),
+      webviewView.onDidDispose(this.cleanupView.bind(this)),
     );
 
     this.updateWebview();
@@ -401,26 +433,8 @@ export class ProgressViewProvider
       },
     );
 
-    // Set panel HTML content
-    this._panelView.webview.html = this.contentProvider.getHtmlContent(
-      this._panelView.webview,
-    );
-
-    // Setup panel message handling
-    this._panelDisposables.push(
-      this._panelView.webview.onDidReceiveMessage((message) =>
-        this.messageHandler.handleMessage(message, this._panelView!),
-      ),
-    );
-
-    // Setup theme change listener for panel (uses shared updateWebview)
-    this._panelDisposables.push(
-      vscode.window.onDidChangeActiveColorTheme(() => {
-        if (this._panelView?.visible) {
-          this.updateWebview();
-        }
-      }),
-    );
+    // Setup content, message handler, and theme listener (shared with sidebar)
+    this._panelDisposables.push(...this.setupWebviewContent(this._panelView));
 
     // Cleanup on panel dispose
     this._panelView.onDidDispose(() => {

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -55,7 +55,8 @@ export class ProgressViewProvider
 
   // Infrastructure
   private readonly _viewTitle: string;
-  private _webviewReady = false;
+  private _sidebarReady = false;
+  private _panelReady = false;
   // Separate panel view (editor tab) from sidebar view
   private _panelView?: vscode.WebviewPanel;
   private _panelDisposables: vscode.Disposable[] = [];
@@ -121,6 +122,11 @@ export class ProgressViewProvider
         // Force rebuild after state reload to ensure freshly loaded data is rendered
         this.updateWebview({ forceRebuild: true });
       }),
+      vscode.window.onDidChangeActiveColorTheme(() => {
+        if (this.isViewVisible()) {
+          this.updateWebview();
+        }
+      }),
     );
   }
 
@@ -144,14 +150,14 @@ export class ProgressViewProvider
 
   protected override cleanupView(): void {
     super.cleanupView();
-    this._webviewReady = false;
+    this._sidebarReady = false;
     this._pendingUpdateOptions = null;
     this.state.clearRenderedStreamTracking();
   }
 
   /**
    * Common setup for any webview (sidebar or panel).
-   * Sets HTML content, message handler, and theme listener.
+   * Sets HTML content and message handler.
    * @returns disposables that should be cleaned up when the view is disposed
    */
   private setupWebviewContent(
@@ -169,15 +175,6 @@ export class ProgressViewProvider
       ),
     );
 
-    // Setup theme change listener
-    disposables.push(
-      vscode.window.onDidChangeActiveColorTheme(() => {
-        if (view.visible) {
-          this.updateWebview();
-        }
-      }),
-    );
-
     return disposables;
   }
 
@@ -188,7 +185,7 @@ export class ProgressViewProvider
     }
     this._hasResolved = true;
 
-    this._webviewReady = false;
+    this._sidebarReady = false;
     this._pendingUpdateOptions = null;
     // Clear rendered stream tracking to force rebuild - DOM state is stale after resolve
     this.state.clearRenderedStreamTracking();
@@ -232,7 +229,7 @@ export class ProgressViewProvider
   public updateWebview(options?: { forceRebuild?: boolean }): void {
     if (!this._view && !this._panelView) return;
 
-    if (!this._webviewReady) {
+    if (!this.isAnyViewReady()) {
       // Queue the update, preserving forceRebuild if any caller requested it.
       // Once forceRebuild is true, it stays true until the update is processed.
       const currentForce = this._pendingUpdateOptions?.forceRebuild ?? false;
@@ -270,8 +267,14 @@ export class ProgressViewProvider
   /**
    * Mark the webview as ready and process any pending updates.
    */
-  public markWebviewReady(): void {
-    this._webviewReady = true;
+  public markWebviewReady(
+    view: vscode.WebviewView | vscode.WebviewPanel,
+  ): void {
+    if (this.isPanelView(view)) {
+      this._panelReady = true;
+    } else {
+      this._sidebarReady = true;
+    }
 
     // Clear pending options - we always force rebuild on first load anyway,
     // and that takes precedence over any pending options.
@@ -297,7 +300,7 @@ export class ProgressViewProvider
   public showToolEditApprovalPrompt(prompt: ToolEditApprovalPrompt): void {
     this.pendingApprovalPrompts.set(prompt.requestId, prompt);
 
-    if (this._webviewReady && this.webviewUpdater.isAvailable()) {
+    if (this.isAnyViewReady() && this.webviewUpdater.isAvailable()) {
       this.webviewUpdater.showToolEditApprovalPrompt(prompt);
     }
   }
@@ -305,7 +308,7 @@ export class ProgressViewProvider
   public resolveToolEditApprovalPrompt(requestId: string): void {
     this.pendingApprovalPrompts.delete(requestId);
 
-    if (this._webviewReady && this.webviewUpdater.isAvailable()) {
+    if (this.isAnyViewReady() && this.webviewUpdater.isAvailable()) {
       this.webviewUpdater.resolveToolEditApprovalPrompt(requestId);
     }
   }
@@ -313,7 +316,7 @@ export class ProgressViewProvider
   public updateToolEditApprovalBypassState(bypassActive: boolean): void {
     this.approvalBypassActive = bypassActive;
 
-    if (this._webviewReady && this.webviewUpdater.isAvailable()) {
+    if (this.isAnyViewReady() && this.webviewUpdater.isAvailable()) {
       this.webviewUpdater.updateToolEditApprovalState(bypassActive);
     }
   }
@@ -323,7 +326,7 @@ export class ProgressViewProvider
   ): void {
     this.pendingRetryRequests.set(payload.streamId, payload);
 
-    if (this._webviewReady && this.webviewUpdater.isAvailable()) {
+    if (this.isAnyViewReady() && this.webviewUpdater.isAvailable()) {
       this.webviewUpdater.showRetryRequest(payload);
     }
   }
@@ -331,7 +334,7 @@ export class ProgressViewProvider
   public resolveRetryRequest(streamId: string): void {
     this.pendingRetryRequests.delete(streamId);
 
-    if (this._webviewReady && this.webviewUpdater.isAvailable()) {
+    if (this.isAnyViewReady() && this.webviewUpdater.isAvailable()) {
       this.webviewUpdater.resolveRetryRequest(streamId);
     }
   }
@@ -352,7 +355,9 @@ export class ProgressViewProvider
    * Check if any view is visible (sidebar or panel)
    */
   public isViewVisible(): boolean {
-    return (this._view?.visible ?? false) || (this._panelView?.visible ?? false);
+    return (
+      (this._view?.visible ?? false) || (this._panelView?.visible ?? false)
+    );
   }
 
   // ===== IRunStorageService implementation =====
@@ -437,6 +442,7 @@ export class ProgressViewProvider
         ),
       },
     );
+    this._panelReady = false;
 
     // Setup content, message handler, and theme listener (shared with sidebar)
     this._panelDisposables.push(...this.setupWebviewContent(this._panelView));
@@ -450,12 +456,11 @@ export class ProgressViewProvider
       }),
     );
 
-    // Cleanup on panel dispose (not added to _panelDisposables to avoid self-disposal during iteration)
-    this._panelView.onDidDispose(() => {
-      this._panelDisposables.forEach((d) => d.dispose());
-      this._panelDisposables = [];
-      this._panelView = undefined;
-    });
+    this._panelDisposables.push(
+      this._panelView.onDidDispose(() => {
+        this.disposePanelResources();
+      }),
+    );
 
     // Trigger initial update (webview will send WEBVIEW_READY when loaded)
     this.updateWebview();
@@ -463,10 +468,28 @@ export class ProgressViewProvider
 
   public override dispose(): void {
     // Clean up panel resources
+    this.disposePanelResources(true);
+    super.dispose();
+  }
+
+  private isAnyViewReady(): boolean {
+    return this._sidebarReady || this._panelReady;
+  }
+
+  private isPanelView(
+    view: vscode.WebviewView | vscode.WebviewPanel,
+  ): view is vscode.WebviewPanel {
+    return 'viewColumn' in view;
+  }
+
+  private disposePanelResources(disposeView = false): void {
+    const panelView = this._panelView;
+    this._panelView = undefined;
     this._panelDisposables.forEach((d) => d.dispose());
     this._panelDisposables = [];
-    this._panelView?.dispose();
-    this._panelView = undefined;
-    super.dispose();
+    this._panelReady = false;
+    if (disposeView) {
+      panelView?.dispose();
+    }
   }
 }

--- a/src/progressView/managers/WebviewUpdater.ts
+++ b/src/progressView/managers/WebviewUpdater.ts
@@ -32,19 +32,22 @@ import type { TodoItem, UpdateTaskGroupPayload } from '@eventBus/schemas';
  * Manages webview updates for the progress view.
  * Provides a clean interface for updating different parts of the webview
  * without coupling business logic to DOM operations.
+ * Supports multiple webviews (e.g., sidebar + editor tab panel).
  */
 export class WebviewUpdater {
   private readonly logger: AgentLogger;
 
-  constructor(private getWebview: () => vscode.Webview | undefined) {
+  constructor(private getWebviews: () => (vscode.Webview | undefined)[]) {
     this.logger = new AgentLogger('WebviewUpdater');
   }
 
-  /** Helper to send messages to webview, eliminating repetitive null checks */
+  /** Helper to send messages to all registered webviews */
   private sendMessage(message: any): void {
-    const webview = this.getWebview();
-    if (!webview) return;
-    webview.postMessage(message);
+    for (const webview of this.getWebviews()) {
+      if (webview) {
+        webview.postMessage(message);
+      }
+    }
   }
 
   static createInstructionUpdate(
@@ -386,7 +389,7 @@ export class WebviewUpdater {
     // Delegate active stream resolution to state (single source of truth)
     const activeStream = state.resolveActiveStream(streamNames);
 
-    if (!this.getWebview()) {
+    if (!this.isAvailable()) {
       return activeStream;
     }
 
@@ -404,9 +407,9 @@ export class WebviewUpdater {
   }
 
   /**
-   * Check if webview is available
+   * Check if any webview is available
    */
   isAvailable(): boolean {
-    return this.getWebview() !== undefined;
+    return this.getWebviews().some((w) => w !== undefined);
   }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds an editor-tab view for the ProgressBoard and syncs it with the sidebar view.
> 
> - New command `texra.openProgressViewInTab` and View Title menu item to open Tasks in an editor tab
> - `ProgressViewProvider` now manages two views (sidebar `WebviewView` and panel `WebviewPanel`), with readiness tracking, visibility handling, and disposal for each
> - `WebviewUpdater` broadcasts updates to multiple webviews and reports availability accordingly
> - `ProgressViewMessageHandler`, `RecordingManager`, and base webview logic generalized to work with both `WebviewView` and `WebviewPanel`
> - Minor fix in `BaseWebviewProvider.createOrShowPanel` for correct panel detection; theme-change refresh wired for visibility
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bc7a8336c5bab776af651a764a8439efb9342ac2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->