### PR TITLE
refactor: unify header and item CSS across history/profile/memory views

### DIFF
--- a/src/common/styles/common.css
+++ b/src/common/styles/common.css
@@ -180,10 +180,6 @@ vscode-toolbar-button {
 }
 
 /* ==========================================================================
-   Utility Classes
-   ========================================================================== */
-
-/* ==========================================================================
    View Header - Shared page header styling for history/profile/memory views
    ========================================================================== */
 
@@ -201,12 +197,6 @@ vscode-toolbar-button {
 
 .view-header h1 {
   color: var(--color-text-link);
-}
-
-.view-toolbar {
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-small);
 }
 
 /* ==========================================================================
@@ -265,7 +255,6 @@ vscode-toolbar-button {
   text-align: center;
   margin-top: calc(var(--spacing-xlarge) * 2);
   color: var(--color-text-secondary);
-  font-style: italic;
 }
 
 /* ==========================================================================

--- a/src/common/styles/common.css
+++ b/src/common/styles/common.css
@@ -182,6 +182,32 @@ vscode-toolbar-button {
    ========================================================================== */
 
 /* ==========================================================================
+   View Header - Shared page header styling for history/profile/memory views
+   ========================================================================== */
+
+.view-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: var(--spacing-xlarge);
+}
+
+.view-header h1,
+.view-header h2 {
+  margin: 0;
+}
+
+.view-header h1 {
+  color: var(--color-text-link);
+}
+
+.view-toolbar {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-small);
+}
+
+/* ==========================================================================
    Badge Base - Common styling for badge components
    Addresses duplication in profileView and historyView
    ========================================================================== */

--- a/src/common/styles/common.css
+++ b/src/common/styles/common.css
@@ -208,6 +208,50 @@ vscode-toolbar-button {
 }
 
 /* ==========================================================================
+   List Item Card - Shared card styling for history/memory item lists
+   ========================================================================== */
+
+.list-item {
+  border: var(--border-thin) solid var(--vscode-panelSection-border);
+  border-radius: var(--border-radius-large);
+  padding: var(--spacing-medium);
+  background-color: var(--vscode-editor-background);
+  transition:
+    transform 0.2s ease,
+    box-shadow 0.2s ease;
+}
+
+.list-item:hover {
+  background-color: var(--vscode-list-hoverBackground);
+}
+
+.list-item-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+/* ==========================================================================
+   Secondary Text - For timestamps, metadata, descriptions
+   ========================================================================== */
+
+.text-secondary {
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-sm);
+}
+
+/* ==========================================================================
+   Empty State - Shown when lists have no items
+   ========================================================================== */
+
+.empty-state {
+  text-align: center;
+  margin-top: calc(var(--spacing-xlarge) * 2);
+  color: var(--color-text-secondary);
+  font-style: italic;
+}
+
+/* ==========================================================================
    Badge Base - Common styling for badge components
    Addresses duplication in profileView and historyView
    ========================================================================== */

--- a/src/common/styles/common.css
+++ b/src/common/styles/common.css
@@ -13,9 +13,11 @@
 
 body {
   margin: 0;
+  padding: var(--spacing-xlarge);
   font-family: var(--vscode-font-family);
   font-size: var(--vscode-font-size);
   color: var(--vscode-editor-foreground);
+  background-color: var(--vscode-editor-background);
   box-sizing: border-box;
 }
 
@@ -216,9 +218,6 @@ vscode-toolbar-button {
   border-radius: var(--border-radius-large);
   padding: var(--spacing-medium);
   background-color: var(--vscode-editor-background);
-  transition:
-    transform 0.2s ease,
-    box-shadow 0.2s ease;
 }
 
 .list-item:hover {
@@ -229,6 +228,24 @@ vscode-toolbar-button {
   display: flex;
   justify-content: space-between;
   align-items: center;
+}
+
+/* ==========================================================================
+   Collapsible - Shared styling for vscode-collapsible elements
+   ========================================================================== */
+
+.collapsible {
+  margin-top: var(--spacing-small);
+}
+
+.collapsible::part(body) {
+  max-height: var(--height-medium);
+  overflow: hidden;
+  transition: max-height 0.3s ease;
+}
+
+.collapsible[open]::part(body) {
+  max-height: var(--height-max);
 }
 
 /* ==========================================================================

--- a/src/historyView/index.html
+++ b/src/historyView/index.html
@@ -94,9 +94,9 @@
       </div>
     </div>
     <template id="historyItemTemplate">
-      <div class="history-item">
-        <div class="history-item-header">
-          <div class="history-timestamp"></div>
+      <div class="list-item history-item">
+        <div class="list-item-header">
+          <div class="text-secondary history-timestamp"></div>
           <vscode-toolbar-container class="history-actions">
             <vscode-toolbar-button
               class="delete-btn"

--- a/src/historyView/index.html
+++ b/src/historyView/index.html
@@ -119,7 +119,7 @@
           </vscode-toolbar-container>
         </div>
         <div class="history-details basic-details"></div>
-        <vscode-collapsible class="history-collapsible">
+        <vscode-collapsible class="collapsible">
           <div class="history-details extra-details"></div>
         </vscode-collapsible>
       </div>

--- a/src/historyView/index.html
+++ b/src/historyView/index.html
@@ -55,7 +55,9 @@
 
   <body>
     <div>
-      <h2>Agent Execution History</h2>
+      <header class="view-header">
+        <h2>Agent Execution History</h2>
+      </header>
 
       <div id="searchContainer" class="search-container">
         <vscode-textfield

--- a/src/historyView/modules/constants.js
+++ b/src/historyView/modules/constants.js
@@ -21,7 +21,7 @@ export const ELEMENT_IDS = {
 
 // CSS class names used across modules
 export const CLASS_NAMES = {
-  HISTORY_COLLAPSIBLE: 'history-collapsible',
+  COLLAPSIBLE: 'collapsible',
   CURRENT_MATCH: 'current-match',
 };
 

--- a/src/historyView/modules/uiManagers/HistoryRenderer.js
+++ b/src/historyView/modules/uiManagers/HistoryRenderer.js
@@ -79,13 +79,13 @@ export class HistoryRenderer {
         '.history-timestamp': date,
       },
       attributes: {
-        '.history-collapsible': { heading: LABELS.MORE_DETAILS },
+        '.collapsible': { heading: LABELS.MORE_DETAILS },
         '.delete-btn': { title: 'Delete this history item' },
         '.restore-btn': { title: 'Load configuration to main view' },
         '.rerun-btn': { title: 'Execute this configuration' },
       },
       dataset: {
-        '.history-collapsible': { id: item.id },
+        '.collapsible': { id: item.id },
         '.delete-btn': { id: item.id, command: COMMANDS.DELETE_AGENT },
         '.restore-btn': { id: item.id, command: COMMANDS.RESTORE_AGENT },
         '.rerun-btn': { id: item.id, command: COMMANDS.RERUN_AGENT },
@@ -95,9 +95,7 @@ export class HistoryRenderer {
     if (!container) return document.createElement('div');
 
     const basicDetails = container.querySelector('.basic-details');
-    const collapsible = container.querySelector(
-      `.${CLASS_NAMES.HISTORY_COLLAPSIBLE}`,
-    );
+    const collapsible = container.querySelector(`.${CLASS_NAMES.COLLAPSIBLE}`);
     const detailsContainer = container.querySelector('.extra-details');
 
     if (!basicDetails || !collapsible || !detailsContainer) {
@@ -258,7 +256,7 @@ export class HistoryRenderer {
     });
 
     const collapsibles = container.querySelectorAll(
-      `.${CLASS_NAMES.HISTORY_COLLAPSIBLE}`,
+      `.${CLASS_NAMES.COLLAPSIBLE}`,
     );
     collapsibles.forEach((element) => {
       if (!(element instanceof HTMLElement)) {
@@ -285,7 +283,7 @@ export class HistoryRenderer {
     const entries = historyViewState.toggleStates.entries();
     for (const [id, expanded] of entries) {
       const collapsible = document.querySelector(
-        `.${CLASS_NAMES.HISTORY_COLLAPSIBLE}[data-id="${id}"]`,
+        `.${CLASS_NAMES.COLLAPSIBLE}[data-id="${id}"]`,
       );
       if (!collapsible) {
         continue;

--- a/src/historyView/modules/uiManagers/SearchManager.js
+++ b/src/historyView/modules/uiManagers/SearchManager.js
@@ -100,7 +100,7 @@ export class SearchManager {
 
   expandAllCollapsibleSections() {
     document
-      .querySelectorAll(`.${CLASS_NAMES.HISTORY_COLLAPSIBLE}`)
+      .querySelectorAll(`.${CLASS_NAMES.COLLAPSIBLE}`)
       .forEach((section) => {
         if (!(section instanceof HTMLElement)) {
           return;
@@ -114,7 +114,7 @@ export class SearchManager {
 
   applySavedToggleStates() {
     document
-      .querySelectorAll(`.${CLASS_NAMES.HISTORY_COLLAPSIBLE}`)
+      .querySelectorAll(`.${CLASS_NAMES.COLLAPSIBLE}`)
       .forEach((section) => {
         if (!(section instanceof HTMLElement)) {
           return;

--- a/src/historyView/styles/index.css
+++ b/src/historyView/styles/index.css
@@ -67,32 +67,13 @@ mark.current-match {
   gap: var(--spacing-medium);
 }
 
+/* History item extends .list-item from common.css */
 .history-item {
-  border: var(--border-thin) solid var(--vscode-panelSection-border);
-  border-radius: var(--border-radius-large);
-  padding: var(--spacing-medium);
   margin-bottom: var(--spacing-medium);
-  background-color: var(--vscode-editor-background);
-  transition:
-    transform 0.2s ease,
-    box-shadow 0.2s ease;
-}
-
-.history-item:hover {
-  background-color: var(--vscode-list-hoverBackground);
 }
 
 .history-timestamp {
-  color: var(--color-text-secondary);
-  font-size: var(--font-size-sm);
   margin-bottom: var(--spacing-small);
-}
-
-/* Header and details */
-.history-item-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
 }
 
 .history-details {
@@ -116,13 +97,6 @@ mark.current-match {
 .button-clear {
   margin-bottom: var(--spacing-xlarge);
   padding: var(--spacing-medium) var(--spacing-large);
-}
-
-/* Empty state */
-.empty-state {
-  text-align: center;
-  margin-top: calc(var(--spacing-xlarge) + var(--spacing-xlarge));
-  color: var(--color-text-secondary);
 }
 
 /* Collapsible content */

--- a/src/historyView/styles/index.css
+++ b/src/historyView/styles/index.css
@@ -9,10 +9,6 @@ body {
   padding: var(--spacing-xlarge);
 }
 
-h2 {
-  margin-bottom: var(--spacing-xlarge);
-}
-
 /* Search container */
 .search-container {
   display: flex;

--- a/src/historyView/styles/index.css
+++ b/src/historyView/styles/index.css
@@ -1,13 +1,7 @@
 /*
  * History view styles
- * Note: Base body styles (margin, font-family, font-size, box-sizing, color) inherited from common.css
+ * Base styles (body, list-item, collapsible, text-secondary) inherited from common.css
  */
-
-/* Base styles */
-body {
-  background-color: var(--vscode-editor-background);
-  padding: var(--spacing-xlarge);
-}
 
 /* Search container */
 .search-container {
@@ -97,21 +91,6 @@ mark.current-match {
 .button-clear {
   margin-bottom: var(--spacing-xlarge);
   padding: var(--spacing-medium) var(--spacing-large);
-}
-
-/* Collapsible content */
-.history-collapsible {
-  margin-top: var(--spacing-small);
-}
-
-.history-collapsible::part(body) {
-  max-height: var(--height-medium);
-  overflow: hidden;
-  transition: max-height 0.3s ease;
-}
-
-.history-collapsible[open]::part(body) {
-  max-height: var(--height-max);
 }
 
 /* Configuration section */

--- a/src/memoryView/index.html
+++ b/src/memoryView/index.html
@@ -45,9 +45,9 @@
 
   <body>
     <div class="memory-view-container">
-      <header class="memory-header">
+      <header class="view-header">
         <h2>Agent Memory</h2>
-        <vscode-toolbar-container class="memory-toolbar">
+        <vscode-toolbar-container class="view-toolbar">
           <vscode-toolbar-button
             id="refreshMemoryBtn"
             icon="refresh"

--- a/src/memoryView/index.html
+++ b/src/memoryView/index.html
@@ -63,7 +63,7 @@
         </vscode-toolbar-container>
       </header>
 
-      <p class="memory-description">
+      <p class="text-secondary memory-description">
         The AI assistant can save notes here to remember important information
         across conversations. These notes help the assistant provide more
         contextual and personalized help.
@@ -86,7 +86,7 @@
           ></vscode-toolbar-button>
         </div>
         <div class="text-secondary memory-meta"></div>
-        <vscode-collapsible class="memory-collapsible">
+        <vscode-collapsible class="collapsible">
           <pre class="memory-preview"></pre>
         </vscode-collapsible>
       </div>

--- a/src/memoryView/index.html
+++ b/src/memoryView/index.html
@@ -75,8 +75,8 @@
     </div>
 
     <template id="memoryItemTemplate">
-      <div class="memory-item">
-        <div class="memory-item-header">
+      <div class="list-item memory-item">
+        <div class="list-item-header">
           <div class="memory-path"></div>
           <vscode-toolbar-button
             class="open-memory-btn"
@@ -85,7 +85,7 @@
             title="Open in editor"
           ></vscode-toolbar-button>
         </div>
-        <div class="memory-meta"></div>
+        <div class="text-secondary memory-meta"></div>
         <vscode-collapsible class="memory-collapsible">
           <pre class="memory-preview"></pre>
         </vscode-collapsible>

--- a/src/memoryView/index.html
+++ b/src/memoryView/index.html
@@ -47,7 +47,7 @@
     <div class="memory-view-container">
       <header class="view-header">
         <h2>Agent Memory</h2>
-        <vscode-toolbar-container class="view-toolbar">
+        <vscode-toolbar-container>
           <vscode-toolbar-button
             id="refreshMemoryBtn"
             icon="refresh"

--- a/src/memoryView/modules/uiManagers/MemoryRenderer.js
+++ b/src/memoryView/modules/uiManagers/MemoryRenderer.js
@@ -49,7 +49,7 @@ export class MemoryRenderer {
         '.memory-meta': this.buildMeta(item),
       },
       attributes: {
-        '.memory-collapsible': { heading: LABELS.PREVIEW_HEADING },
+        '.collapsible': { heading: LABELS.PREVIEW_HEADING },
       },
       dataset: {
         '.open-memory-btn': {

--- a/src/memoryView/styles/index.css
+++ b/src/memoryView/styles/index.css
@@ -30,28 +30,7 @@ body {
   gap: var(--spacing-medium);
 }
 
-/* Memory item */
-.memory-item {
-  border: var(--border-thin) solid var(--vscode-panelSection-border);
-  border-radius: var(--border-radius-large);
-  padding: var(--spacing-medium);
-  background-color: var(--vscode-editor-background);
-  transition:
-    transform 0.2s ease,
-    box-shadow 0.2s ease;
-}
-
-.memory-item:hover {
-  background-color: var(--vscode-list-hoverBackground);
-}
-
-/* Item header */
-.memory-item-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-}
-
+/* Memory path styling */
 .memory-path {
   font-family: var(--vscode-editor-font-family), monospace;
   font-size: var(--font-size);
@@ -60,10 +39,8 @@ body {
   word-break: break-all;
 }
 
-/* Metadata */
+/* Metadata - extends .text-secondary from common.css */
 .memory-meta {
-  font-size: var(--font-size-sm);
-  color: var(--color-text-secondary);
   margin-top: var(--spacing-small);
 }
 
@@ -95,12 +72,4 @@ body {
   margin: 0;
   max-height: 200px;
   overflow-y: auto;
-}
-
-/* Empty state */
-.empty-state {
-  text-align: center;
-  margin-top: calc(var(--spacing-xlarge) + var(--spacing-xlarge));
-  color: var(--color-text-secondary);
-  font-style: italic;
 }

--- a/src/memoryView/styles/index.css
+++ b/src/memoryView/styles/index.css
@@ -1,13 +1,7 @@
 /*
  * Memory view styles
- * Note: Base body styles (margin, font-family, font-size, box-sizing, color) inherited from common.css
+ * Base styles (body, list-item, collapsible, text-secondary) inherited from common.css
  */
-
-/* Base styles */
-body {
-  background-color: var(--vscode-editor-background);
-  padding: var(--spacing-xlarge);
-}
 
 /* Container */
 .memory-view-container {
@@ -16,10 +10,8 @@ body {
   gap: var(--spacing-medium);
 }
 
-/* Description */
+/* Description - extends .text-secondary */
 .memory-description {
-  color: var(--color-text-secondary);
-  font-size: var(--font-size-sm);
   margin: 0 0 var(--spacing-medium) 0;
 }
 
@@ -42,21 +34,6 @@ body {
 /* Metadata - extends .text-secondary from common.css */
 .memory-meta {
   margin-top: var(--spacing-small);
-}
-
-/* Collapsible preview */
-.memory-collapsible {
-  margin-top: var(--spacing-small);
-}
-
-.memory-collapsible::part(body) {
-  max-height: var(--height-medium);
-  overflow: hidden;
-  transition: max-height 0.3s ease;
-}
-
-.memory-collapsible[open]::part(body) {
-  max-height: var(--height-max);
 }
 
 /* Preview text */

--- a/src/memoryView/styles/index.css
+++ b/src/memoryView/styles/index.css
@@ -16,24 +16,6 @@ body {
   gap: var(--spacing-medium);
 }
 
-/* Header */
-.memory-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: var(--spacing-medium);
-}
-
-.memory-header h2 {
-  margin: 0;
-}
-
-.memory-toolbar {
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-small);
-}
-
 /* Description */
 .memory-description {
   color: var(--color-text-secondary);

--- a/src/profileView/index.html
+++ b/src/profileView/index.html
@@ -45,7 +45,9 @@
 
   <body>
     <div class="profile-container">
-      <h1>TeXRA Account</h1>
+      <header class="view-header">
+        <h1>TeXRA Account</h1>
+      </header>
 
       <div id="profileInfo" class="profile-info">
         <div class="info-row">

--- a/src/profileView/styles/index.css
+++ b/src/profileView/styles/index.css
@@ -9,11 +9,7 @@ body {
   padding: var(--spacing-xlarge);
 }
 
-h1 {
-  color: var(--color-text-link);
-  margin-bottom: var(--spacing-xlarge);
-}
-
+/* Section headers (h2) have distinct styling with bottom border */
 h2 {
   color: var(--vscode-foreground);
   margin-top: var(--spacing-xlarge);

--- a/src/profileView/styles/index.css
+++ b/src/profileView/styles/index.css
@@ -1,13 +1,7 @@
 /*
  * Profile view styles
- * Note: Base body styles (margin, font-family, font-size, box-sizing, color) inherited from common.css
+ * Base styles (body, badge, text-secondary) inherited from common.css
  */
-
-/* Base styles */
-body {
-  background-color: var(--vscode-editor-background);
-  padding: var(--spacing-xlarge);
-}
 
 /* Section headers (h2) have distinct styling with bottom border */
 h2 {


### PR DESCRIPTION
## Summary
- Extract shared `.view-header` and `.view-toolbar` classes to `common.css` for consistent page headers
- Add shared `.list-item`, `.list-item-header`, `.text-secondary`, `.empty-state` classes for consistent card and list styling
- Add shared `.collapsible` class for `vscode-collapsible` elements
- Move common body styles (`background-color`, `padding`) to `common.css`
- Remove unused `transform`/`box-shadow` transitions from list items (only `background-color` changes on hover)
- Update history, profile, and memory views to use shared classes, removing ~60 lines of duplicate CSS

## Test plan
- [ ] Verify history view header, list items, and collapsibles render correctly
- [ ] Verify profile view header renders correctly  
- [ ] Verify memory view header, toolbar, list items, and collapsibles render correctly
- [ ] Verify empty states display correctly in history and memory views

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Consolidates styling to reduce duplication and standardize UI across views.
> 
> - Adds shared `body` reset plus `view-header`, `list-item`/`list-item-header`, `collapsible`, `text-secondary`, and `empty-state` styles in `common.css`
> - Updates History/Memory/Profile HTML to use shared classes; removes redundant per-view CSS
> - Renames `.history-collapsible` to generic `.collapsible`; updates selectors/attributes in `constants.js`, `HistoryRenderer.js`, `SearchManager.js`, and `MemoryRenderer.js`
> - Minor visual adjustments: timestamps/meta use `text-secondary`; body padding/background now set globally
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cf12bc5adcc3105909db6120b3c9135fdce3055f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->