### PR TITLE
Enable thinking for Anthropic API model

### DIFF
--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -466,6 +466,8 @@ export class ModelHandlerAnthropic extends ModelHandler<
           );
           const { input_tokens: inputTokens } = responseTokenCount;
           this.logger.debug(`Token count of message: ${inputTokens}`);
+          // Emit context state for UI display
+          this.logger.logContextState(inputTokens, effectiveContextWindow);
           if (inputTokens > effectiveContextWindow) {
             const errMsg = `Token count of message exceeds context window: ${inputTokens} > ${effectiveContextWindow}`;
             this.logger.error(errMsg);

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -468,6 +468,8 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
         );
         const totalTokens = responseTokenCount.totalTokens ?? 0;
         this.logger.debug(`Token count of message: ${totalTokens}`);
+        // Emit context state for UI display
+        this.logger.logContextState(totalTokens, this.config.contextWindow);
         if (totalTokens > this.config.contextWindow) {
           this.logger.error(
             `Token count of message exceeds context window: ${totalTokens} > ${this.config.contextWindow}`,

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -216,6 +216,11 @@ export class ModelHandlerOpenAI<
       this.logger.debug(
         `Approximate token count of message: ${approximateInputTokens}`,
       );
+      // Emit context state for UI display
+      this.logger.logContextState(
+        approximateInputTokens,
+        this.config.contextWindow,
+      );
 
       if (approximateInputTokens > this.config.contextWindow) {
         const errorMsg = `Approximate token count of message exceeds context window: ${approximateInputTokens} > ${this.config.contextWindow}`;

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -909,6 +909,11 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       if (response.usage?.input_tokens) {
         this.conversationState.cumulativeInputTokens =
           response.usage.input_tokens;
+        // Emit context state for UI display (no native pre-request token counting)
+        this.logger.logContextState(
+          response.usage.input_tokens,
+          this.config.contextWindow,
+        );
       }
       // Reset compacted flag after successful request (ready for next compaction if needed)
       this.conversationState.isCompacted = false;
@@ -967,6 +972,11 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     if (response.usage?.input_tokens) {
       this.conversationState.cumulativeInputTokens =
         response.usage.input_tokens;
+      // Emit context state for UI display (no native pre-request token counting)
+      this.logger.logContextState(
+        response.usage.input_tokens,
+        this.config.contextWindow,
+      );
     }
     // Reset compacted flag after successful request (ready for next compaction if needed)
     this.conversationState.isCompacted = false;

--- a/src/agent/utils/UsageMonitor.ts
+++ b/src/agent/utils/UsageMonitor.ts
@@ -46,7 +46,10 @@ export interface UsageMonitorModelInfo {
     | 'supportsReasoning'
     | 'cacheDiscountFactor'
   >;
-  config: Pick<ModelConfig, 'provider' | 'name' | 'fullName' | 'inputPrice'>;
+  config: Pick<
+    ModelConfig,
+    'provider' | 'name' | 'fullName' | 'inputPrice' | 'contextWindow'
+  >;
 }
 
 /**
@@ -163,6 +166,12 @@ export class UsageMonitor {
       // Get current storageKey via callback - handles mutable state correctly
       const storageKey = this.context.getStorageKey();
       usageReporter.report(payload, storageKey);
+
+      // Emit context state for UI display (based on actual response usage)
+      const contextWindow = this.modelInfo.config.contextWindow;
+      if (contextWindow > 0) {
+        logger.logContextState(roundUsage.inputTokens, contextWindow);
+      }
 
       // Log to backend for analytics (non-blocking, fire-and-forget)
       this.logToBackend(stateGlobal.totalResponseTimeMs, roundUsage);

--- a/src/agent/utils/UsageMonitor.ts
+++ b/src/agent/utils/UsageMonitor.ts
@@ -46,10 +46,7 @@ export interface UsageMonitorModelInfo {
     | 'supportsReasoning'
     | 'cacheDiscountFactor'
   >;
-  config: Pick<
-    ModelConfig,
-    'provider' | 'name' | 'fullName' | 'inputPrice' | 'contextWindow'
-  >;
+  config: Pick<ModelConfig, 'provider' | 'name' | 'fullName' | 'inputPrice'>;
 }
 
 /**
@@ -167,11 +164,9 @@ export class UsageMonitor {
       const storageKey = this.context.getStorageKey();
       usageReporter.report(payload, storageKey);
 
-      // Emit context state for UI display (based on actual response usage)
-      const contextWindow = this.modelInfo.config.contextWindow;
-      if (contextWindow > 0) {
-        logger.logContextState(roundUsage.inputTokens, contextWindow);
-      }
+      // Note: Context state is emitted by model handlers during token counting
+      // (Anthropic, Google, OpenAI). This avoids duplicate emissions and ensures
+      // we use the native token count which is more accurate than response usage.
 
       // Log to backend for analytics (non-blocking, fire-and-forget)
       this.logToBackend(stateGlobal.totalResponseTimeMs, roundUsage);

--- a/src/eventBus/ProgressEventBus.ts
+++ b/src/eventBus/ProgressEventBus.ts
@@ -7,6 +7,7 @@ import type { OutputFileInfo } from '@agent/output/types';
 import type { StreamTabId, ExecutionId } from '@agent/types/IdentifierTypes';
 import type { TokenUsageStats } from '@agent/types/UsageTypes';
 import type { StreamStatus } from '@common/constants/streamStatus';
+import type { ContextStateData } from '@logger/AgentLogger';
 import type { LogMessageData, LogMessageUpdate } from '@logger/LogTypes';
 import type { TaskState } from '@logger/TaskState';
 import type { ToolEditApprovalPrompt, RetryRequestPrompt } from './types';
@@ -69,11 +70,7 @@ export interface ProgressEventPayloads {
   };
   updateContextState: {
     stream: StreamTabId;
-    contextState: {
-      inputTokens: number;
-      contextWindow: number;
-      utilizationPercent: number;
-    };
+    contextState: ContextStateData;
   };
   showRetryRequest: RetryRequestPrompt;
   resolveRetryRequest: { streamId: StreamTabId };

--- a/src/logger/AgentLogger.ts
+++ b/src/logger/AgentLogger.ts
@@ -403,8 +403,9 @@ export class AgentLogger {
       contextWindow,
       utilizationPercent,
     };
-    // Use debug level since this is frequent and informational
-    this.debug(`Context: ${inputTokens}/${contextWindow} tokens (${utilizationPercent.toFixed(1)}%)`, {
+    // Use info level to ensure message reaches progress view (debug is filtered)
+    // The CONTEXT_STATE message type triggers UI update without cluttering logs
+    this.info(`Context: ${inputTokens}/${contextWindow} tokens (${utilizationPercent.toFixed(1)}%)`, {
       groupId,
       messageType: MESSAGE_TYPES.CONTEXT_STATE,
       data,

--- a/src/logger/AgentLogger.ts
+++ b/src/logger/AgentLogger.ts
@@ -55,6 +55,21 @@ export const ContextManagementDataSchema = z.object({
 
 export type ContextManagementData = z.infer<typeof ContextManagementDataSchema>;
 
+/**
+ * Context state data for tracking current context utilization.
+ * Emitted after token counting to update UI with current usage.
+ */
+export const ContextStateDataSchema = z.object({
+  /** Current input tokens in the context */
+  inputTokens: z.number().nonnegative(),
+  /** Maximum context window size */
+  contextWindow: z.number().positive(),
+  /** Percentage of context utilized (0-100) */
+  utilizationPercent: z.number().nonnegative(),
+});
+
+export type ContextStateData = z.infer<typeof ContextStateDataSchema>;
+
 export interface LoggerScopeOptions {
   parentGroupId?: string;
   /**
@@ -364,6 +379,34 @@ export class AgentLogger {
     this.info(message, {
       groupId,
       messageType: MESSAGE_TYPES.CONTEXT_MANAGEMENT,
+      data,
+    });
+  }
+
+  /**
+   * Log current context state (utilization percentage).
+   * Single source of truth for CONTEXT_STATE message type.
+   * Used to update UI with current context usage after token counting.
+   *
+   * @param inputTokens - Current input tokens in context
+   * @param contextWindow - Maximum context window size
+   * @param groupId - Optional group ID for progress view
+   */
+  logContextState(
+    inputTokens: number,
+    contextWindow: number,
+    groupId?: string,
+  ): void {
+    const utilizationPercent = (inputTokens / contextWindow) * 100;
+    const data: ContextStateData = {
+      inputTokens,
+      contextWindow,
+      utilizationPercent,
+    };
+    // Use debug level since this is frequent and informational
+    this.debug(`Context: ${inputTokens}/${contextWindow} tokens (${utilizationPercent.toFixed(1)}%)`, {
+      groupId,
+      messageType: MESSAGE_TYPES.CONTEXT_STATE,
       data,
     });
   }

--- a/src/logger/messageTypes.ts
+++ b/src/logger/messageTypes.ts
@@ -79,6 +79,8 @@ export const MESSAGE_TYPES = {
   INTERNAL: 'internal',
   /** Context management events (compaction, context clearing) */
   CONTEXT_MANAGEMENT: 'contextManagement',
+  /** Context state updates (current context utilization) */
+  CONTEXT_STATE: 'contextState',
   DEFAULT: 'default',
 } as const;
 
@@ -97,6 +99,7 @@ export const MessageTypeSchema = z.enum([
   MESSAGE_TYPES.ERROR,
   MESSAGE_TYPES.INTERNAL,
   MESSAGE_TYPES.CONTEXT_MANAGEMENT,
+  MESSAGE_TYPES.CONTEXT_STATE,
   MESSAGE_TYPES.DEFAULT,
 ]);
 

--- a/src/logger/transports/VSCodeTransport.ts
+++ b/src/logger/transports/VSCodeTransport.ts
@@ -7,6 +7,7 @@ import Transport from 'winston-transport';
 import {
   ContextManagementDataSchema,
   ContextStateDataSchema,
+  type ContextStateData,
 } from '@logger/AgentLogger';
 import { getEmitFilter } from '@logger/filterUtils';
 import type { LogMessageData } from '@logger/LogTypes';
@@ -168,13 +169,10 @@ export class VSCodeTransport extends Transport {
         contextData.utilizationAfter ??
         (inputTokens / contextData.contextWindow) * 100;
 
-      bus.emit('updateContextState', {
-        stream: this.streamName,
-        contextState: {
-          inputTokens,
-          contextWindow: contextData.contextWindow,
-          utilizationPercent,
-        },
+      this.emitContextState({
+        inputTokens,
+        contextWindow: contextData.contextWindow,
+        utilizationPercent,
       });
     }
 
@@ -185,11 +183,18 @@ export class VSCodeTransport extends Transport {
         return; // Skip invalid context state data
       }
 
-      const contextState = parseResult.data;
-      bus.emit('updateContextState', {
-        stream: this.streamName,
-        contextState,
-      });
+      this.emitContextState(parseResult.data);
     }
+  }
+
+  /**
+   * Emit context state to the progress view event bus.
+   * Shared helper for both CONTEXT_MANAGEMENT and CONTEXT_STATE messages.
+   */
+  private emitContextState(contextState: ContextStateData): void {
+    bus.emit('updateContextState', {
+      stream: this.streamName,
+      contextState,
+    });
   }
 }

--- a/src/logger/transports/VSCodeTransport.ts
+++ b/src/logger/transports/VSCodeTransport.ts
@@ -4,7 +4,10 @@ import * as vscode from 'vscode';
 import Transport from 'winston-transport';
 
 // Internal imports
-import { ContextManagementDataSchema } from '@logger/AgentLogger';
+import {
+  ContextManagementDataSchema,
+  ContextStateDataSchema,
+} from '@logger/AgentLogger';
 import { getEmitFilter } from '@logger/filterUtils';
 import type { LogMessageData } from '@logger/LogTypes';
 import { MESSAGE_TYPES, type MessageType } from '@logger/messageTypes';
@@ -172,6 +175,20 @@ export class VSCodeTransport extends Transport {
           contextWindow: contextData.contextWindow,
           utilizationPercent,
         },
+      });
+    }
+
+    // Emit context state update for CONTEXT_STATE messages (from token counting)
+    if (validatedMessageType === MESSAGE_TYPES.CONTEXT_STATE && event.data) {
+      const parseResult = ContextStateDataSchema.safeParse(event.data);
+      if (!parseResult.success) {
+        return; // Skip invalid context state data
+      }
+
+      const contextState = parseResult.data;
+      bus.emit('updateContextState', {
+        stream: this.streamName,
+        contextState,
       });
     }
   }

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -477,6 +477,8 @@ export class ProgressEventHandler {
       'UsageEvents',
       'failed to handle updateContextState',
       () => {
+        // Store context state for replay when switching streams
+        this.state.setContextState(stream, contextState);
         if (
           this.webviewUpdater.isAvailable() &&
           stream === this.state.activeStream
@@ -646,6 +648,12 @@ export class ProgressEventHandler {
     const todos = this.state.getTodos(stream);
     if (todos !== undefined) {
       this.webviewUpdater.updateTodos(stream, todos);
+    }
+
+    // Refresh context state for the stream (ephemeral state)
+    const contextState = this.state.getContextState(stream);
+    if (contextState !== undefined) {
+      this.webviewUpdater.updateContextState(stream, contextState);
     }
 
     // Update status for current stream. Don't default to RUNNING - that causes a race

--- a/src/progressView/state/ProgressViewState.ts
+++ b/src/progressView/state/ProgressViewState.ts
@@ -16,7 +16,7 @@ import type { OutputFileInfo } from '@agent/output/types';
 import { cleanupInactiveAgents } from '@agent/toolUse/ToolUseAgentRegistry';
 import { normalizeRunId } from '@common/constants/runIds';
 import { workspaceSM, WorkspaceStateKey } from '@common/state/stateManager';
-import { AgentLogger } from '@logger/AgentLogger';
+import { AgentLogger, type ContextStateData } from '@logger/AgentLogger';
 import type { TaskGroup } from '@logger/LogTypes';
 import {
   TaskState,
@@ -86,10 +86,7 @@ export class ProgressViewState {
    * Stores context utilization (input tokens vs context window) for replay
    * when switching streams.
    */
-  private _contextState: Map<
-    StreamTabId,
-    { inputTokens: number; contextWindow: number; utilizationPercent: number }
-  > = new Map();
+  private _contextState: Map<StreamTabId, ContextStateData> = new Map();
   private readonly storage: StateStorage;
   private readonly logger: AgentLogger;
 
@@ -242,25 +239,14 @@ export class ProgressViewState {
    * Set context state for a stream.
    * Stores context utilization so it can be replayed when switching streams.
    */
-  setContextState(
-    stream: StreamTabId,
-    contextState: {
-      inputTokens: number;
-      contextWindow: number;
-      utilizationPercent: number;
-    },
-  ): void {
+  setContextState(stream: StreamTabId, contextState: ContextStateData): void {
     this._contextState.set(stream, contextState);
   }
 
   /**
    * Get context state for a stream.
    */
-  getContextState(
-    stream: StreamTabId,
-  ):
-    | { inputTokens: number; contextWindow: number; utilizationPercent: number }
-    | undefined {
+  getContextState(stream: StreamTabId): ContextStateData | undefined {
     return this._contextState.get(stream);
   }
 

--- a/src/progressView/state/ProgressViewState.ts
+++ b/src/progressView/state/ProgressViewState.ts
@@ -81,6 +81,15 @@ export class ProgressViewState {
    * Not persisted - session-only state that's also stored in AgentWorkspaceState.
    */
   private _todos: Map<StreamTabId, TodoItem[]> = new Map();
+  /**
+   * Ephemeral context state storage keyed by stream ID.
+   * Stores context utilization (input tokens vs context window) for replay
+   * when switching streams.
+   */
+  private _contextState: Map<
+    StreamTabId,
+    { inputTokens: number; contextWindow: number; utilizationPercent: number }
+  > = new Map();
   private readonly storage: StateStorage;
   private readonly logger: AgentLogger;
 
@@ -226,6 +235,40 @@ export class ProgressViewState {
    */
   clearAllTodos(): void {
     this._todos.clear();
+  }
+
+  // Context state management (ephemeral, non-persistent)
+  /**
+   * Set context state for a stream.
+   * Stores context utilization so it can be replayed when switching streams.
+   */
+  setContextState(
+    stream: StreamTabId,
+    contextState: {
+      inputTokens: number;
+      contextWindow: number;
+      utilizationPercent: number;
+    },
+  ): void {
+    this._contextState.set(stream, contextState);
+  }
+
+  /**
+   * Get context state for a stream.
+   */
+  getContextState(
+    stream: StreamTabId,
+  ):
+    | { inputTokens: number; contextWindow: number; utilizationPercent: number }
+    | undefined {
+    return this._contextState.get(stream);
+  }
+
+  /**
+   * Clear context state for a stream.
+   */
+  clearContextState(stream: StreamTabId): void {
+    this._contextState.delete(stream);
   }
 
   setActiveRunId(stream: StreamTabId, runId: string | null): void {
@@ -523,6 +566,7 @@ export class ProgressViewState {
     this.clearStreamHints(stream);
     this.clearActiveRun(stream);
     this.clearTodos(stream);
+    this.clearContextState(stream);
 
     // Update active stream if necessary
     if (this._activeStream === stream) {
@@ -550,6 +594,7 @@ export class ProgressViewState {
     this._executionIds.clear();
     this._streamHints.clear();
     this._todos.clear();
+    this._contextState.clear();
     this._activeRunIds.clear();
     this._activeStream = '';
     this.saveActiveStream();


### PR DESCRIPTION
Add CONTEXT_STATE message type to track current context window utilization after token counting. This enables the progress view to display context usage percentages for each API call, not just during context management operations.

Changes:
- Add CONTEXT_STATE message type to messageTypes.ts
- Add ContextStateDataSchema and logContextState() to AgentLogger
- Update VSCodeTransport to emit updateContextState for CONTEXT_STATE
- Call logContextState from Anthropic and Google model handlers

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a unified `CONTEXT_STATE` signal and UI plumbing to show live context utilization from token counting across providers.
> 
> - Adds `CONTEXT_STATE` message type and `ContextStateDataSchema` with `AgentLogger.logContextState()` to emit `inputTokens/contextWindow` utilization
> - Model handlers emit context state after token counting: `modelHandlerAnthropic`, `modelHandlerGoogleGenAI`, `modelHandlerOpenAI` (approx preflight), and `modelHandlerOpenAIResponse` (post-response usage)
> - `VSCodeTransport` parses `CONTEXT_STATE` and `CONTEXT_MANAGEMENT`, refactors emission via `emitContextState()` and forwards `updateContextState`
> - Event bus updates: `ProgressEventBus` payload now uses `ContextStateData`; `ProgressEventHandler` stores/replays context state; `ProgressViewState` adds per-stream ephemeral context state with lifecycle clearing
> - Minor: `UsageMonitor` notes context state is emitted by model handlers to avoid duplicates
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 40aa2d915ef84dd9b9e05232d428f8f56b20ae52. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->