### PR TITLE
Show accumulated usage and cache creation metrics

### DIFF
--- a/src/agent/types/UsageTypes.ts
+++ b/src/agent/types/UsageTypes.ts
@@ -14,6 +14,8 @@ export const TokenUsageStatsSchema = z.strictObject({
   outputTokens: z.number(),
   /** Total cost in USD for the request */
   cost: z.number(),
+  /** Tokens written to cache (Anthropic: charged at 1.25x input price) */
+  cacheCreationInputTokens: z.number().optional(),
 });
 
 export type TokenUsageStats = z.infer<typeof TokenUsageStatsSchema>;

--- a/src/agent/types/UsageTypes.ts
+++ b/src/agent/types/UsageTypes.ts
@@ -24,11 +24,19 @@ export type TokenUsageStats = z.infer<typeof TokenUsageStatsSchema>;
 
 /**
  * Extended statistics tracked during agent execution.
+ *
+ * IMPORTANT: This type has dual-use semantics:
+ * - Token counts (inputTokens, outputTokens, etc.) are per-round deltas
+ * - percentageCached is calculated from accumulated session totals
+ *
+ * This is intentional: percentageCached should reflect overall session caching
+ * effectiveness, not per-round fluctuations. Consumers accumulate the per-round
+ * deltas while percentageCached provides the running session percentage.
  */
 export const ExtendedTokenUsageStatsSchema = TokenUsageStatsSchema.extend({
   /** Total elapsed time in seconds */
   elapsedTime: z.number().optional(),
-  /** Percentage of tokens served from cache */
+  /** Percentage of tokens served from cache (calculated from session totals) */
   percentageCached: z.number().optional(),
   /** Tokens used for reasoning */
   reasoningTokens: z.number().optional(),

--- a/src/agent/types/UsageTypes.ts
+++ b/src/agent/types/UsageTypes.ts
@@ -14,6 +14,8 @@ export const TokenUsageStatsSchema = z.strictObject({
   outputTokens: z.number(),
   /** Total cost in USD for the request */
   cost: z.number(),
+  /** Tokens read from cache (discounted rate) */
+  cacheReadInputTokens: z.number().optional(),
   /** Tokens written to cache (Anthropic: charged at 1.25x input price) */
   cacheCreationInputTokens: z.number().optional(),
 });
@@ -26,10 +28,6 @@ export type TokenUsageStats = z.infer<typeof TokenUsageStatsSchema>;
 export const ExtendedTokenUsageStatsSchema = TokenUsageStatsSchema.extend({
   /** Total elapsed time in seconds */
   elapsedTime: z.number().optional(),
-  /** Tokens read from cache */
-  cacheReadInputTokens: z.number().optional(),
-  /** Tokens written to cache */
-  cacheCreationInputTokens: z.number().optional(),
   /** Percentage of tokens served from cache */
   percentageCached: z.number().optional(),
   /** Tokens used for reasoning */

--- a/src/agent/utils/UsageMonitor.ts
+++ b/src/agent/utils/UsageMonitor.ts
@@ -133,10 +133,13 @@ export class UsageMonitor {
           : 0
         : undefined;
 
+      // Use accumulated totals for the UI display, not per-round usage
       const baseStats: TokenUsageStats = {
-        inputTokens: roundUsage.inputTokens,
-        outputTokens: roundUsage.outputTokens,
-        cost: Number(roundUsage.cost.toFixed(3)),
+        inputTokens: totals.totalInputTokens,
+        outputTokens: totals.totalOutputTokens,
+        cost: Number(totals.totalCost.toFixed(3)),
+        // Include cache creation tokens for Anthropic (charged at 1.25x input price)
+        cacheCreationInputTokens: totals.totalCacheCreationInputTokens || undefined,
       };
 
       const payload: ExtendedTokenUsageStats = {

--- a/src/agent/utils/UsageMonitor.ts
+++ b/src/agent/utils/UsageMonitor.ts
@@ -138,7 +138,8 @@ export class UsageMonitor {
         inputTokens: totals.totalInputTokens,
         outputTokens: totals.totalOutputTokens,
         cost: Number(totals.totalCost.toFixed(3)),
-        // Include cache creation tokens for Anthropic (charged at 1.25x input price)
+        // Include cache tokens for display
+        cacheReadInputTokens: totals.totalCacheReadInputTokens || undefined,
         cacheCreationInputTokens: totals.totalCacheCreationInputTokens || undefined,
       };
 

--- a/src/agent/utils/UsageMonitor.ts
+++ b/src/agent/utils/UsageMonitor.ts
@@ -99,23 +99,19 @@ export class UsageMonitor {
         .at(-1);
       const latestUsage = latestUsageSnapshot?.usage;
 
-      // Per-round usage for backend analytics only (not for UI display)
-      // Backend billing should reflect the current round's net tokens, not cumulative
-      const backendLogUsage = {
-        inputTokens: latestUsage?.inputTokens ?? totals.totalInputTokens,
-        outputTokens: latestUsage?.outputTokens ?? totals.totalOutputTokens,
-        cachedInputTokens:
-          latestUsage?.cachedInputTokens ?? totals.totalCacheReadInputTokens,
-        reasoningTokens:
-          latestUsage?.reasoningTokens ?? totals.totalReasoningTokens,
-        cost: latestUsage?.cost ?? totals.totalCost,
-      };
+      // Per-round usage - sent to both UI (for accumulation) and backend analytics
+      const roundInputTokens = latestUsage?.inputTokens ?? 0;
+      const roundOutputTokens = latestUsage?.outputTokens ?? 0;
+      const roundCacheReadTokens = latestUsage?.cachedInputTokens ?? 0;
+      const roundCacheCreationTokens = latestUsage?.cacheCreationTokens ?? 0;
+      const roundReasoningTokens = latestUsage?.reasoningTokens ?? 0;
+      const roundCost = latestUsage?.cost ?? 0;
 
       const cachingStats =
         this.modelInfo.capabilities.supportsPromptCaching ||
         this.modelInfo.capabilities.supportsAutoPromptCaching;
 
-      // Use accumulated totals for cache percentage calculation
+      // Use accumulated totals for cache percentage calculation (for display)
       const totalCacheReadTokens = totals.totalCacheReadInputTokens;
       const totalCacheCreationTokens = totals.totalCacheCreationInputTokens;
 
@@ -131,16 +127,16 @@ export class UsageMonitor {
           : 0
         : undefined;
 
-      // Use accumulated totals for the UI display, not per-round usage
+      // Send per-round deltas - storage will accumulate them
       const baseStats: TokenUsageStats = {
-        inputTokens: totals.totalInputTokens,
-        outputTokens: totals.totalOutputTokens,
-        cost: Number(totals.totalCost.toFixed(3)),
+        inputTokens: roundInputTokens,
+        outputTokens: roundOutputTokens,
+        cost: Number(roundCost.toFixed(3)),
         // Include cache tokens for display (only if > 0)
         cacheReadInputTokens:
-          totalCacheReadTokens > 0 ? totalCacheReadTokens : undefined,
+          roundCacheReadTokens > 0 ? roundCacheReadTokens : undefined,
         cacheCreationInputTokens:
-          totalCacheCreationTokens > 0 ? totalCacheCreationTokens : undefined,
+          roundCacheCreationTokens > 0 ? roundCacheCreationTokens : undefined,
       };
 
       const payload: ExtendedTokenUsageStats = {
@@ -152,11 +148,11 @@ export class UsageMonitor {
           percentageCached: Number((percentageCached ?? 0).toFixed(2)),
         }),
         ...(this.modelInfo.capabilities.supportsReasoning && {
-          reasoningTokens: totals.totalReasoningTokens,
+          reasoningTokens: roundReasoningTokens,
         }),
         // Include tool usage if any is present
-        ...(totals.totalToolUsePromptTokens > 0 && {
-          toolUseTokens: totals.totalToolUsePromptTokens,
+        ...((latestUsage?.toolUsePromptTokens ?? 0) > 0 && {
+          toolUseTokens: latestUsage?.toolUsePromptTokens ?? 0,
         }),
       };
 
@@ -165,6 +161,13 @@ export class UsageMonitor {
       usageReporter.report(payload, storageKey);
 
       // Log to backend for analytics (non-blocking, fire-and-forget)
+      const backendLogUsage = {
+        inputTokens: roundInputTokens,
+        outputTokens: roundOutputTokens,
+        cachedInputTokens: roundCacheReadTokens,
+        reasoningTokens: roundReasoningTokens,
+        cost: roundCost,
+      };
       this.logToBackend(stateGlobal.totalResponseTimeMs, backendLogUsage);
     } catch (error) {
       logger.error(`Error printing ${runKind} statistics: ${error}`);

--- a/src/agent/utils/UsageMonitor.ts
+++ b/src/agent/utils/UsageMonitor.ts
@@ -136,9 +136,11 @@ export class UsageMonitor {
         inputTokens: totals.totalInputTokens,
         outputTokens: totals.totalOutputTokens,
         cost: Number(totals.totalCost.toFixed(3)),
-        // Include cache tokens for display
-        cacheReadInputTokens: totalCacheReadTokens || undefined,
-        cacheCreationInputTokens: totalCacheCreationTokens || undefined,
+        // Include cache tokens for display (only if > 0)
+        cacheReadInputTokens:
+          totalCacheReadTokens > 0 ? totalCacheReadTokens : undefined,
+        cacheCreationInputTokens:
+          totalCacheCreationTokens > 0 ? totalCacheCreationTokens : undefined,
       };
 
       const payload: ExtendedTokenUsageStats = {

--- a/src/agent/utils/UsageMonitor.ts
+++ b/src/agent/utils/UsageMonitor.ts
@@ -118,18 +118,19 @@ export class UsageMonitor {
         this.modelInfo.capabilities.supportsPromptCaching ||
         this.modelInfo.capabilities.supportsAutoPromptCaching;
 
-      const roundCacheReadTokens = roundUsage.cachedInputTokens ?? 0;
-      const roundCacheCreationTokens = roundUsage.cacheCreationTokens ?? 0;
+      // Use accumulated totals for cache percentage calculation
+      const totalCacheReadTokens = totals.totalCacheReadInputTokens;
+      const totalCacheCreationTokens = totals.totalCacheCreationInputTokens;
 
       const totalCacheableTokens = cachingStats
         ? this.modelInfo.capabilities.supportsPromptCaching
-          ? roundCacheCreationTokens + roundCacheReadTokens
-          : roundUsage.inputTokens
+          ? totalCacheCreationTokens + totalCacheReadTokens
+          : totals.totalInputTokens
         : 0;
 
       const percentageCached = cachingStats
         ? totalCacheableTokens > 0
-          ? (roundCacheReadTokens / totalCacheableTokens) * 100
+          ? (totalCacheReadTokens / totalCacheableTokens) * 100
           : 0
         : undefined;
 
@@ -139,8 +140,8 @@ export class UsageMonitor {
         outputTokens: totals.totalOutputTokens,
         cost: Number(totals.totalCost.toFixed(3)),
         // Include cache tokens for display
-        cacheReadInputTokens: totals.totalCacheReadInputTokens || undefined,
-        cacheCreationInputTokens: totals.totalCacheCreationInputTokens || undefined,
+        cacheReadInputTokens: totalCacheReadTokens || undefined,
+        cacheCreationInputTokens: totalCacheCreationTokens || undefined,
       };
 
       const payload: ExtendedTokenUsageStats = {
@@ -149,18 +150,14 @@ export class UsageMonitor {
           (stateGlobal.totalResponseTimeMs / 1000).toFixed(1),
         ),
         ...(cachingStats && {
-          cacheReadInputTokens: roundCacheReadTokens,
-          ...(this.modelInfo.capabilities.supportsPromptCaching && {
-            cacheCreationInputTokens: roundCacheCreationTokens,
-          }),
           percentageCached: Number((percentageCached ?? 0).toFixed(2)),
         }),
         ...(this.modelInfo.capabilities.supportsReasoning && {
-          reasoningTokens: roundUsage.reasoningTokens ?? 0,
+          reasoningTokens: totals.totalReasoningTokens,
         }),
         // Include tool usage if any is present
-        ...((roundUsage.toolUsePromptTokens ?? 0) > 0 && {
-          toolUseTokens: roundUsage.toolUsePromptTokens ?? 0,
+        ...(totals.totalToolUsePromptTokens > 0 && {
+          toolUseTokens: totals.totalToolUsePromptTokens,
         }),
       };
 

--- a/src/agent/utils/UsageMonitor.ts
+++ b/src/agent/utils/UsageMonitor.ts
@@ -165,6 +165,7 @@ export class UsageMonitor {
         inputTokens: roundInputTokens,
         outputTokens: roundOutputTokens,
         cachedInputTokens: roundCacheReadTokens,
+        cacheCreationInputTokens: roundCacheCreationTokens,
         reasoningTokens: roundReasoningTokens,
         cost: roundCost,
       };
@@ -184,6 +185,7 @@ export class UsageMonitor {
       inputTokens: number;
       outputTokens: number;
       cachedInputTokens?: number;
+      cacheCreationInputTokens?: number;
       reasoningTokens?: number;
       cost: number;
     },
@@ -209,6 +211,7 @@ export class UsageMonitor {
       const roundInputTokens = usage.inputTokens;
       const roundOutputTokens = usage.outputTokens;
       const roundCachedInputTokens = usage.cachedInputTokens ?? 0;
+      const roundCacheCreationTokens = usage.cacheCreationInputTokens ?? 0;
       const roundReasoningTokens = usage.reasoningTokens ?? 0;
       const roundCost = usage.cost;
 
@@ -232,6 +235,7 @@ export class UsageMonitor {
         cost: Number(relayCost.toFixed(6)),
         responseTimeMs: Math.round(totalResponseTimeMs),
         cachedInputTokens: roundCachedInputTokens,
+        cacheCreationInputTokens: roundCacheCreationTokens,
         reasoningTokens: roundReasoningTokens,
         usedRelay,
         streamId: this.context.streamId,

--- a/src/agent/utils/UsageMonitor.ts
+++ b/src/agent/utils/UsageMonitor.ts
@@ -99,18 +99,15 @@ export class UsageMonitor {
         .at(-1);
       const latestUsage = latestUsageSnapshot?.usage;
 
-      const roundUsage = {
+      // Per-round usage for backend analytics only (not for UI display)
+      // Backend billing should reflect the current round's net tokens, not cumulative
+      const backendLogUsage = {
         inputTokens: latestUsage?.inputTokens ?? totals.totalInputTokens,
         outputTokens: latestUsage?.outputTokens ?? totals.totalOutputTokens,
         cachedInputTokens:
           latestUsage?.cachedInputTokens ?? totals.totalCacheReadInputTokens,
-        cacheCreationTokens:
-          latestUsage?.cacheCreationTokens ??
-          totals.totalCacheCreationInputTokens,
         reasoningTokens:
           latestUsage?.reasoningTokens ?? totals.totalReasoningTokens,
-        toolUsePromptTokens:
-          latestUsage?.toolUsePromptTokens ?? totals.totalToolUsePromptTokens,
         cost: latestUsage?.cost ?? totals.totalCost,
       };
 
@@ -166,19 +163,19 @@ export class UsageMonitor {
       usageReporter.report(payload, storageKey);
 
       // Log to backend for analytics (non-blocking, fire-and-forget)
-      this.logToBackend(stateGlobal.totalResponseTimeMs, roundUsage);
+      this.logToBackend(stateGlobal.totalResponseTimeMs, backendLogUsage);
     } catch (error) {
       logger.error(`Error printing ${runKind} statistics: ${error}`);
     }
   }
 
   /**
-   * Log usage to backend for analytics.
+   * Log per-round usage to backend for analytics/billing.
    * Non-blocking - errors are caught and logged, never thrown.
    */
   private logToBackend(
     totalResponseTimeMs: number,
-    roundUsage: {
+    usage: {
       inputTokens: number;
       outputTokens: number;
       cachedInputTokens?: number;
@@ -204,11 +201,11 @@ export class UsageMonitor {
       // rather than cumulative history. Downstream dashboards should treat each
       // entry as a single round; if cumulative views are needed, aggregate by
       // streamId/task.
-      const roundInputTokens = roundUsage.inputTokens;
-      const roundOutputTokens = roundUsage.outputTokens;
-      const roundCachedInputTokens = roundUsage.cachedInputTokens ?? 0;
-      const roundReasoningTokens = roundUsage.reasoningTokens ?? 0;
-      const roundCost = roundUsage.cost;
+      const roundInputTokens = usage.inputTokens;
+      const roundOutputTokens = usage.outputTokens;
+      const roundCachedInputTokens = usage.cachedInputTokens ?? 0;
+      const roundReasoningTokens = usage.reasoningTokens ?? 0;
+      const roundCost = usage.cost;
 
       const netInputTokens = Math.max(
         0,

--- a/src/logger/AgentUsageReporter.ts
+++ b/src/logger/AgentUsageReporter.ts
@@ -40,11 +40,17 @@ export class AgentUsageReporter {
   public report(stats: ExtendedTokenUsageStats, storageKey: StorageKey): void {
     const logStatistics = this.agentCategory === AgentCategory.Workflow;
 
-    // Pass through usage without modification
+    // Pass through usage including cache tokens for display
     const usage = {
       inputTokens: stats.inputTokens,
       outputTokens: stats.outputTokens,
       cost: stats.cost,
+      ...(stats.cacheReadInputTokens && {
+        cacheReadInputTokens: stats.cacheReadInputTokens,
+      }),
+      ...(stats.cacheCreationInputTokens && {
+        cacheCreationInputTokens: stats.cacheCreationInputTokens,
+      }),
     };
 
     // storageKey is THE single source of truth - no fallbacks, no round-trips

--- a/src/logger/UsageLogTypes.ts
+++ b/src/logger/UsageLogTypes.ts
@@ -69,8 +69,11 @@ export const UsageLogStatsSchema = z.object({
   /** Response time in milliseconds */
   responseTimeMs: z.number().nonnegative().optional(),
 
-  /** Tokens served from cache */
+  /** Tokens served from cache (discounted rate) */
   cachedInputTokens: z.int().nonnegative().optional(),
+
+  /** Tokens written to cache (Anthropic: 1.25x cost) */
+  cacheCreationInputTokens: z.int().nonnegative().optional(),
 
   /** Tokens used for reasoning (o1, DeepSeek-R1, etc.) */
   reasoningTokens: z.int().nonnegative().optional(),

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -439,13 +439,9 @@ export class ProgressEventHandler {
           inputTokens: Number(usage.inputTokens ?? 0),
           outputTokens: Number(usage.outputTokens ?? 0),
           cost: Number(usage.cost ?? 0),
-          // Pass through cache tokens for display
-          ...(usage.cacheReadInputTokens && {
-            cacheReadInputTokens: Number(usage.cacheReadInputTokens),
-          }),
-          ...(usage.cacheCreationInputTokens && {
-            cacheCreationInputTokens: Number(usage.cacheCreationInputTokens),
-          }),
+          // Cache tokens for display (use ?? 0 for consistent falsy handling)
+          cacheReadInputTokens: Number(usage.cacheReadInputTokens ?? 0),
+          cacheCreationInputTokens: Number(usage.cacheCreationInputTokens ?? 0),
         };
 
         await this.state.usageStats.setRunUsage(

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -439,7 +439,10 @@ export class ProgressEventHandler {
           inputTokens: Number(usage.inputTokens ?? 0),
           outputTokens: Number(usage.outputTokens ?? 0),
           cost: Number(usage.cost ?? 0),
-          // Pass through cache creation tokens for Anthropic (charged at 1.25x input price)
+          // Pass through cache tokens for display
+          ...(usage.cacheReadInputTokens && {
+            cacheReadInputTokens: Number(usage.cacheReadInputTokens),
+          }),
           ...(usage.cacheCreationInputTokens && {
             cacheCreationInputTokens: Number(usage.cacheCreationInputTokens),
           }),

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -444,6 +444,7 @@ export class ProgressEventHandler {
           cacheCreationInputTokens: Number(usage.cacheCreationInputTokens ?? 0),
         };
 
+        // Backend accumulates the delta
         await this.state.usageStats.setRunUsage(
           stream,
           storageKey,
@@ -461,11 +462,17 @@ export class ProgressEventHandler {
           this.webviewUpdater.isAvailable() &&
           stream === this.state.activeStream
         ) {
-          this.webviewUpdater.updateRunUsage(
-            stream,
-            storageKey,
-            normalizedUsage,
-          );
+          // Send accumulated value to frontend (not the delta)
+          // Frontend uses SET semantics to avoid double-counting
+          const runUsageMap = this.state.usageStats.getRunUsage(stream);
+          const accumulatedUsage = runUsageMap.get(storageKey);
+          if (accumulatedUsage) {
+            this.webviewUpdater.updateRunUsage(
+              stream,
+              storageKey,
+              accumulatedUsage,
+            );
+          }
         }
       },
     );

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -439,13 +439,14 @@ export class ProgressEventHandler {
           inputTokens: Number(usage.inputTokens ?? 0),
           outputTokens: Number(usage.outputTokens ?? 0),
           cost: Number(usage.cost ?? 0),
-          // Cache tokens for display (use ?? 0 for consistent falsy handling)
+          // Cache tokens for display (use ?? for nullish-only coalescing)
           cacheReadInputTokens: Number(usage.cacheReadInputTokens ?? 0),
           cacheCreationInputTokens: Number(usage.cacheCreationInputTokens ?? 0),
         };
 
-        // Backend accumulates the delta
-        await this.state.usageStats.setRunUsage(
+        // Backend accumulates the delta and returns the accumulated value
+        // This avoids race conditions from a separate read operation
+        const accumulatedUsage = await this.state.usageStats.setRunUsage(
           stream,
           storageKey,
           normalizedUsage,
@@ -460,19 +461,16 @@ export class ProgressEventHandler {
 
         if (
           this.webviewUpdater.isAvailable() &&
-          stream === this.state.activeStream
+          stream === this.state.activeStream &&
+          accumulatedUsage
         ) {
           // Send accumulated value to frontend (not the delta)
           // Frontend uses SET semantics to avoid double-counting
-          const runUsageMap = this.state.usageStats.getRunUsage(stream);
-          const accumulatedUsage = runUsageMap.get(storageKey);
-          if (accumulatedUsage) {
-            this.webviewUpdater.updateRunUsage(
-              stream,
-              storageKey,
-              accumulatedUsage,
-            );
-          }
+          this.webviewUpdater.updateRunUsage(
+            stream,
+            storageKey,
+            accumulatedUsage,
+          );
         }
       },
     );

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -439,6 +439,10 @@ export class ProgressEventHandler {
           inputTokens: Number(usage.inputTokens ?? 0),
           outputTokens: Number(usage.outputTokens ?? 0),
           cost: Number(usage.cost ?? 0),
+          // Pass through cache creation tokens for Anthropic (charged at 1.25x input price)
+          ...(usage.cacheCreationInputTokens && {
+            cacheCreationInputTokens: Number(usage.cacheCreationInputTokens),
+          }),
         };
 
         await this.state.usageStats.setRunUsage(

--- a/src/progressView/managers/UsageStatsManager.ts
+++ b/src/progressView/managers/UsageStatsManager.ts
@@ -31,8 +31,17 @@ const TokenUsageStatsParsingSchema = z
     inputTokens: FiniteNumber,
     outputTokens: FiniteNumber,
     cost: FiniteNumber,
+    // Cache tokens for display (optional, default to 0)
+    cacheReadInputTokens: FiniteNumber.optional().default(0),
+    cacheCreationInputTokens: FiniteNumber.optional().default(0),
   })
-  .catch({ inputTokens: 0, outputTokens: 0, cost: 0 });
+  .catch({
+    inputTokens: 0,
+    outputTokens: 0,
+    cost: 0,
+    cacheReadInputTokens: 0,
+    cacheCreationInputTokens: 0,
+  });
 
 // Compile-time assertion: ensure parsing schema produces type compatible with TokenUsageStats
 type _AssertSchemaCompatible =
@@ -119,14 +128,24 @@ export class UsageStatsManager extends PersistentMapManager<
     let inputTokens = 0;
     let outputTokens = 0;
     let cost = 0;
+    let cacheReadInputTokens = 0;
+    let cacheCreationInputTokens = 0;
 
     for (const usage of runs.values()) {
       inputTokens += usage.inputTokens;
       outputTokens += usage.outputTokens;
       cost += usage.cost;
+      cacheReadInputTokens += usage.cacheReadInputTokens ?? 0;
+      cacheCreationInputTokens += usage.cacheCreationInputTokens ?? 0;
     }
 
-    return { inputTokens, outputTokens, cost };
+    return {
+      inputTokens,
+      outputTokens,
+      cost,
+      cacheReadInputTokens,
+      cacheCreationInputTokens,
+    };
   }
 
   /**
@@ -167,16 +186,26 @@ export class UsageStatsManager extends PersistentMapManager<
     let inputTokens = 0;
     let outputTokens = 0;
     let cost = 0;
+    let cacheReadInputTokens = 0;
+    let cacheCreationInputTokens = 0;
 
     for (const usage of this.items.values()) {
       for (const runUsage of usage.values()) {
         inputTokens += runUsage.inputTokens;
         outputTokens += runUsage.outputTokens;
         cost += runUsage.cost;
+        cacheReadInputTokens += runUsage.cacheReadInputTokens ?? 0;
+        cacheCreationInputTokens += runUsage.cacheCreationInputTokens ?? 0;
       }
     }
 
-    return { inputTokens, outputTokens, cost };
+    return {
+      inputTokens,
+      outputTokens,
+      cost,
+      cacheReadInputTokens,
+      cacheCreationInputTokens,
+    };
   }
 
   /**

--- a/src/progressView/managers/UsageStatsManager.ts
+++ b/src/progressView/managers/UsageStatsManager.ts
@@ -67,7 +67,11 @@ if (missingKeys.length > 0) {
 /** Checks if usage stats are all zeros (effectively empty) */
 function isEmptyUsage(usage: TokenUsageStats): boolean {
   return (
-    usage.inputTokens === 0 && usage.outputTokens === 0 && usage.cost === 0
+    usage.inputTokens === 0 &&
+    usage.outputTokens === 0 &&
+    usage.cost === 0 &&
+    (usage.cacheReadInputTokens ?? 0) === 0 &&
+    (usage.cacheCreationInputTokens ?? 0) === 0
   );
 }
 
@@ -98,20 +102,22 @@ export class UsageStatsManager extends PersistentMapManager<
 
   /**
    * Accumulate usage statistics for a stream (adds deltas to existing values).
+   * Returns the accumulated value to avoid race conditions from separate read.
    * @param storageKey - THE key for storage operations
+   * @returns The accumulated usage, or undefined if delta was empty
    */
   async setRunUsage(
     stream: StreamTabId,
     storageKey: StorageKey,
     usage: TokenUsageStats,
-  ): Promise<void> {
+  ): Promise<TokenUsageStats | undefined> {
     const delta = TokenUsageStatsParsingSchema.parse(usage);
     const current =
       this.items.get(stream) ?? new Map<string, TokenUsageStats>();
 
     if (isEmptyUsage(delta)) {
-      // Empty delta means nothing to add
-      return;
+      // Empty delta means nothing to add - return existing if any
+      return current.get(storageKey);
     }
 
     // Accumulate: add delta to existing values
@@ -132,13 +138,25 @@ export class UsageStatsManager extends PersistentMapManager<
     this.items.set(stream, current);
 
     await this.save();
+    return accumulated;
   }
 
   /**
-   * Get usage statistics for a stream
+   * Get usage statistics for a stream (returns a copy of the map)
    */
   getRunUsage(stream: StreamTabId): RunUsageMap {
     return new Map(this.items.get(stream) ?? []);
+  }
+
+  /**
+   * Get usage for a specific key without copying the entire map.
+   * More efficient for single-key lookups.
+   */
+  getUsageForKey(
+    stream: StreamTabId,
+    storageKey: StorageKey,
+  ): TokenUsageStats | undefined {
+    return this.items.get(stream)?.get(storageKey);
   }
 
   /**

--- a/src/progressView/managers/UsageStatsManager.ts
+++ b/src/progressView/managers/UsageStatsManager.ts
@@ -151,7 +151,8 @@ export class UsageStatsManager extends PersistentMapManager<
 
   /**
    * Get usage for a specific key without copying the entire map.
-   * More efficient for single-key lookups.
+   * More efficient for single-key lookups in read-only scenarios
+   * (e.g., refreshStreamSurface bulk updates, displaying current usage).
    */
   getUsageForKey(
     stream: StreamTabId,

--- a/src/progressView/managers/UsageStatsManager.ts
+++ b/src/progressView/managers/UsageStatsManager.ts
@@ -3,8 +3,11 @@ import { z } from 'zod';
 
 // Local imports - identifiers
 import type { StorageKey, StreamTabId } from '@agent/types/IdentifierTypes';
-// Types - import canonical type (schema defines structure)
-import { type TokenUsageStats } from '@agent/types/UsageTypes';
+// Types - import canonical schema as source of truth
+import {
+  TokenUsageStatsSchema,
+  type TokenUsageStats,
+} from '@agent/types/UsageTypes';
 import { normalizeRunId } from '@common/constants/runIds';
 import { WorkspaceStateKey } from '@common/state/stateManager';
 import { AgentLogger } from '@logger/AgentLogger';
@@ -24,31 +27,42 @@ const FiniteNumber = z.coerce
 
 /**
  * Schema for parsing TokenUsageStats with safe number coercion.
- * Extends the canonical schema shape with coercion for persistence resilience.
+ * Uses canonical schema as source of truth - compile-time assertion ensures sync.
  */
-const TokenUsageStatsParsingSchema = z
-  .object({
-    inputTokens: FiniteNumber,
-    outputTokens: FiniteNumber,
-    cost: FiniteNumber,
-    // Cache tokens for display (optional, default to 0)
-    cacheReadInputTokens: FiniteNumber.optional().default(0),
-    cacheCreationInputTokens: FiniteNumber.optional().default(0),
-  })
-  .catch({
-    inputTokens: 0,
-    outputTokens: 0,
-    cost: 0,
-    cacheReadInputTokens: 0,
-    cacheCreationInputTokens: 0,
-  });
+const TokenUsageStatsParsingBaseSchema = z.object({
+  // Required fields from canonical schema
+  inputTokens: FiniteNumber,
+  outputTokens: FiniteNumber,
+  cost: FiniteNumber,
+  // Optional fields from canonical schema (default to 0 for accumulation)
+  cacheReadInputTokens: FiniteNumber.optional().default(0),
+  cacheCreationInputTokens: FiniteNumber.optional().default(0),
+});
 
-// Compile-time assertion: ensure parsing schema produces type compatible with TokenUsageStats
+const TokenUsageStatsParsingSchema = TokenUsageStatsParsingBaseSchema.catch({
+  inputTokens: 0,
+  outputTokens: 0,
+  cost: 0,
+  cacheReadInputTokens: 0,
+  cacheCreationInputTokens: 0,
+});
+
+// Compile-time assertions to ensure parsing schema stays in sync with canonical schema
 type _AssertSchemaCompatible =
   z.infer<typeof TokenUsageStatsParsingSchema> extends TokenUsageStats
     ? true
     : never;
 const _assertCompatible: _AssertSchemaCompatible = true;
+
+// Runtime assertion: ensure all canonical keys are handled
+const canonicalKeys = TokenUsageStatsSchema.keyof().options;
+const parsingKeys = new Set(Object.keys(TokenUsageStatsParsingBaseSchema.shape));
+const missingKeys = canonicalKeys.filter((k) => !parsingKeys.has(k));
+if (missingKeys.length > 0) {
+  throw new Error(
+    `TokenUsageStatsParsingSchema missing keys from canonical schema: ${missingKeys.join(', ')}`,
+  );
+}
 
 /** Checks if usage stats are all zeros (effectively empty) */
 function isEmptyUsage(usage: TokenUsageStats): boolean {
@@ -83,7 +97,7 @@ export class UsageStatsManager extends PersistentMapManager<
   }
 
   /**
-   * Update usage statistics for a stream
+   * Accumulate usage statistics for a stream (adds deltas to existing values).
    * @param storageKey - THE key for storage operations
    */
   async setRunUsage(
@@ -91,20 +105,31 @@ export class UsageStatsManager extends PersistentMapManager<
     storageKey: StorageKey,
     usage: TokenUsageStats,
   ): Promise<void> {
-    const normalized = TokenUsageStatsParsingSchema.parse(usage);
+    const delta = TokenUsageStatsParsingSchema.parse(usage);
     const current =
       this.items.get(stream) ?? new Map<string, TokenUsageStats>();
-    if (isEmptyUsage(normalized)) {
-      current.delete(storageKey);
-    } else {
-      current.set(storageKey, normalized);
+
+    if (isEmptyUsage(delta)) {
+      // Empty delta means nothing to add
+      return;
     }
 
-    if (current.size === 0) {
-      this.items.delete(stream);
-    } else {
-      this.items.set(stream, current);
-    }
+    // Accumulate: add delta to existing values
+    const existing = current.get(storageKey);
+    const accumulated: TokenUsageStats = {
+      inputTokens: (existing?.inputTokens ?? 0) + delta.inputTokens,
+      outputTokens: (existing?.outputTokens ?? 0) + delta.outputTokens,
+      cost: (existing?.cost ?? 0) + delta.cost,
+      cacheReadInputTokens:
+        (existing?.cacheReadInputTokens ?? 0) +
+        (delta.cacheReadInputTokens ?? 0),
+      cacheCreationInputTokens:
+        (existing?.cacheCreationInputTokens ?? 0) +
+        (delta.cacheCreationInputTokens ?? 0),
+    };
+
+    current.set(storageKey, accumulated);
+    this.items.set(stream, current);
 
     await this.save();
   }

--- a/src/progressView/managers/UsageStatsManager.ts
+++ b/src/progressView/managers/UsageStatsManager.ts
@@ -47,12 +47,13 @@ const TokenUsageStatsParsingSchema = TokenUsageStatsParsingBaseSchema.catch({
   cacheCreationInputTokens: 0,
 });
 
-// Compile-time assertions to ensure parsing schema stays in sync with canonical schema
+// Compile-time assertion: parsing schema output must be assignable to canonical type.
+// This fails at compile time if TokenUsageStatsParsingSchema produces incompatible fields.
 type _AssertSchemaCompatible =
   z.infer<typeof TokenUsageStatsParsingSchema> extends TokenUsageStats
     ? true
     : never;
-const _assertCompatible: _AssertSchemaCompatible = true;
+void (true as _AssertSchemaCompatible);
 
 // Runtime assertion: ensure all canonical keys are handled
 const canonicalKeys = TokenUsageStatsSchema.keyof().options;

--- a/src/progressView/modules/progressViewState.js
+++ b/src/progressView/modules/progressViewState.js
@@ -656,7 +656,9 @@ export class ProgressViewState {
       normalized.outputTokens === 0 &&
       normalized.cost === 0
     ) {
-      // Empty usage means nothing to store
+      // Empty usage means nothing to store.
+      // Note: We intentionally only check input/output/cost, not cache tokens.
+      // If cost is 0, there's no billing impact regardless of cache token counts.
       return;
     }
     this.runUsage.set(targetStream, runId, normalized);

--- a/src/progressView/modules/progressViewState.js
+++ b/src/progressView/modules/progressViewState.js
@@ -641,7 +641,7 @@ export class ProgressViewState {
     if (targetStream == null || !runId) {
       return;
     }
-    const normalized = {
+    const delta = {
       inputTokens: Number(usage?.inputTokens ?? 0),
       outputTokens: Number(usage?.outputTokens ?? 0),
       cost: Number(usage?.cost ?? 0),
@@ -650,14 +650,25 @@ export class ProgressViewState {
       cacheCreationInputTokens: Number(usage?.cacheCreationInputTokens ?? 0),
     };
     if (
-      normalized.inputTokens === 0 &&
-      normalized.outputTokens === 0 &&
-      normalized.cost === 0
+      delta.inputTokens === 0 &&
+      delta.outputTokens === 0 &&
+      delta.cost === 0
     ) {
-      this.clearRunUsage(targetStream, runId);
+      // Empty delta means nothing to add
       return;
     }
-    this.runUsage.set(targetStream, runId, normalized);
+    // Accumulate: add delta to existing values
+    const existing = this.runUsage.get(targetStream, runId);
+    const accumulated = {
+      inputTokens: (existing?.inputTokens ?? 0) + delta.inputTokens,
+      outputTokens: (existing?.outputTokens ?? 0) + delta.outputTokens,
+      cost: (existing?.cost ?? 0) + delta.cost,
+      cacheReadInputTokens:
+        (existing?.cacheReadInputTokens ?? 0) + delta.cacheReadInputTokens,
+      cacheCreationInputTokens:
+        (existing?.cacheCreationInputTokens ?? 0) + delta.cacheCreationInputTokens,
+    };
+    this.runUsage.set(targetStream, runId, accumulated);
   }
 
   getRunUsage(streamId, runId) {

--- a/src/progressView/modules/progressViewState.js
+++ b/src/progressView/modules/progressViewState.js
@@ -645,6 +645,9 @@ export class ProgressViewState {
       inputTokens: Number(usage?.inputTokens) || 0,
       outputTokens: Number(usage?.outputTokens) || 0,
       cost: Number(usage?.cost) || 0,
+      // Include cache tokens for display (optional fields)
+      cacheReadInputTokens: Number(usage?.cacheReadInputTokens) || 0,
+      cacheCreationInputTokens: Number(usage?.cacheCreationInputTokens) || 0,
     };
     if (
       normalized.inputTokens === 0 &&

--- a/src/progressView/modules/progressViewState.js
+++ b/src/progressView/modules/progressViewState.js
@@ -657,8 +657,9 @@ export class ProgressViewState {
       normalized.cost === 0
     ) {
       // Empty usage means nothing to store.
-      // Note: We intentionally only check input/output/cost, not cache tokens.
-      // If cost is 0, there's no billing impact regardless of cache token counts.
+      // Note: We only check input/output/cost, not cache tokens separately.
+      // Cost is calculated upstream and already includes cache creation charges
+      // (Anthropic: 1.25x input price), so cost=0 implies no cache creation billing.
       return;
     }
     this.runUsage.set(targetStream, runId, normalized);

--- a/src/progressView/modules/progressViewState.js
+++ b/src/progressView/modules/progressViewState.js
@@ -643,11 +643,11 @@ export class ProgressViewState {
     }
     // SET semantics: backend sends accumulated values, we store directly
     // (no accumulation here - backend handles accumulation in UsageStatsManager)
+    // Use ?? (nullish coalescing) not || to preserve 0 and NaN as intentional values
     const normalized = {
       inputTokens: Number(usage?.inputTokens ?? 0),
       outputTokens: Number(usage?.outputTokens ?? 0),
       cost: Number(usage?.cost ?? 0),
-      // Include cache tokens for display (use ?? 0 for consistent falsy handling)
       cacheReadInputTokens: Number(usage?.cacheReadInputTokens ?? 0),
       cacheCreationInputTokens: Number(usage?.cacheCreationInputTokens ?? 0),
     };

--- a/src/progressView/modules/progressViewState.js
+++ b/src/progressView/modules/progressViewState.js
@@ -641,7 +641,9 @@ export class ProgressViewState {
     if (targetStream == null || !runId) {
       return;
     }
-    const delta = {
+    // SET semantics: backend sends accumulated values, we store directly
+    // (no accumulation here - backend handles accumulation in UsageStatsManager)
+    const normalized = {
       inputTokens: Number(usage?.inputTokens ?? 0),
       outputTokens: Number(usage?.outputTokens ?? 0),
       cost: Number(usage?.cost ?? 0),
@@ -650,25 +652,14 @@ export class ProgressViewState {
       cacheCreationInputTokens: Number(usage?.cacheCreationInputTokens ?? 0),
     };
     if (
-      delta.inputTokens === 0 &&
-      delta.outputTokens === 0 &&
-      delta.cost === 0
+      normalized.inputTokens === 0 &&
+      normalized.outputTokens === 0 &&
+      normalized.cost === 0
     ) {
-      // Empty delta means nothing to add
+      // Empty usage means nothing to store
       return;
     }
-    // Accumulate: add delta to existing values
-    const existing = this.runUsage.get(targetStream, runId);
-    const accumulated = {
-      inputTokens: (existing?.inputTokens ?? 0) + delta.inputTokens,
-      outputTokens: (existing?.outputTokens ?? 0) + delta.outputTokens,
-      cost: (existing?.cost ?? 0) + delta.cost,
-      cacheReadInputTokens:
-        (existing?.cacheReadInputTokens ?? 0) + delta.cacheReadInputTokens,
-      cacheCreationInputTokens:
-        (existing?.cacheCreationInputTokens ?? 0) + delta.cacheCreationInputTokens,
-    };
-    this.runUsage.set(targetStream, runId, accumulated);
+    this.runUsage.set(targetStream, runId, normalized);
   }
 
   getRunUsage(streamId, runId) {

--- a/src/progressView/modules/progressViewState.js
+++ b/src/progressView/modules/progressViewState.js
@@ -642,12 +642,12 @@ export class ProgressViewState {
       return;
     }
     const normalized = {
-      inputTokens: Number(usage?.inputTokens) || 0,
-      outputTokens: Number(usage?.outputTokens) || 0,
-      cost: Number(usage?.cost) || 0,
-      // Include cache tokens for display (optional fields)
-      cacheReadInputTokens: Number(usage?.cacheReadInputTokens) || 0,
-      cacheCreationInputTokens: Number(usage?.cacheCreationInputTokens) || 0,
+      inputTokens: Number(usage?.inputTokens ?? 0),
+      outputTokens: Number(usage?.outputTokens ?? 0),
+      cost: Number(usage?.cost ?? 0),
+      // Include cache tokens for display (use ?? 0 for consistent falsy handling)
+      cacheReadInputTokens: Number(usage?.cacheReadInputTokens ?? 0),
+      cacheCreationInputTokens: Number(usage?.cacheCreationInputTokens ?? 0),
     };
     if (
       normalized.inputTokens === 0 &&

--- a/src/progressView/modules/usageManagers.js
+++ b/src/progressView/modules/usageManagers.js
@@ -31,6 +31,7 @@ export class UsageSummary {
     const inputTokens = totals?.inputTokens ?? 0;
     const outputTokens = totals?.outputTokens ?? 0;
     const cost = totals?.cost ?? 0;
+    const cacheReadTokens = totals?.cacheReadInputTokens ?? 0;
     const cacheCreationTokens = totals?.cacheCreationInputTokens ?? 0;
 
     if (!inputTokens && !outputTokens && !cost) {
@@ -50,9 +51,17 @@ export class UsageSummary {
     const formattedOutput = formatTokens(outputTokens);
     const formattedCost = `$${cost.toFixed(3)}`;
 
-    // Build cache creation segment if present (Anthropic: charged at 1.25x input price)
+    // Build cache segments: placed after input since cache is conceptually related to input
+    // Cache read: tokens served from cache (discounted rate)
+    // Cache creation: tokens written to cache (Anthropic: 1.25x input price)
+    const cacheReadSegment = cacheReadTokens > 0
+      ? ` · <i class="codicon codicon-arrow-circle-up" title="Cache read tokens (discounted)"></i>${formatTokens(cacheReadTokens)}`
+      : '';
     const cacheCreationSegment = cacheCreationTokens > 0
       ? ` · <i class="codicon codicon-database" title="Cache creation tokens (1.25x cost)"></i>${formatTokens(cacheCreationTokens)}`
+      : '';
+    const cacheReadAriaLabel = cacheReadTokens > 0
+      ? `, ${formatTokens(cacheReadTokens)} cache read tokens`
       : '';
     const cacheCreationAriaLabel = cacheCreationTokens > 0
       ? `, ${formatTokens(cacheCreationTokens)} cache creation tokens`
@@ -62,21 +71,21 @@ export class UsageSummary {
       <i class="codicon codicon-meter"></i>
       <span class="run-summary__label">Total usage:</span>
       <span class="run-summary__value">
-        <i class="codicon codicon-arrow-up" title="Input tokens"></i>${formattedInput} ·
-        <i class="codicon codicon-arrow-down" title="Output tokens"></i>${formattedOutput}${cacheCreationSegment} ·
+        <i class="codicon codicon-arrow-up" title="Input tokens"></i>${formattedInput}${cacheReadSegment}${cacheCreationSegment} ·
+        <i class="codicon codicon-arrow-down" title="Output tokens"></i>${formattedOutput} ·
         ${formattedCost}
       </span>
     `;
     this._summaryElem.setAttribute(
       'aria-label',
-      `Total usage: ${formattedInput} input tokens, ${formattedOutput} output tokens${cacheCreationAriaLabel}, ${formattedCost}`,
+      `Total usage: ${formattedInput} input tokens${cacheReadAriaLabel}${cacheCreationAriaLabel}, ${formattedOutput} output tokens, ${formattedCost}`,
     );
   }
 
   /**
    * Compute total usage for the active session in the active stream.
    * Each stream tab can have multiple sessions; this returns the current session's total.
-   * @returns {Object} Total usage with inputTokens, outputTokens, cost, and cacheCreationInputTokens
+   * @returns {Object} Total usage with inputTokens, outputTokens, cost, and cache token counts
    */
   computeTotal() {
     const stream = progressViewState.activeStream;
@@ -88,12 +97,19 @@ export class UsageSummary {
           inputTokens: usage.inputTokens || 0,
           outputTokens: usage.outputTokens || 0,
           cost: usage.cost || 0,
+          cacheReadInputTokens: usage.cacheReadInputTokens || 0,
           cacheCreationInputTokens: usage.cacheCreationInputTokens || 0,
         };
       }
     }
 
-    return { inputTokens: 0, outputTokens: 0, cost: 0, cacheCreationInputTokens: 0 };
+    return {
+      inputTokens: 0,
+      outputTokens: 0,
+      cost: 0,
+      cacheReadInputTokens: 0,
+      cacheCreationInputTokens: 0,
+    };
   }
 
   /**

--- a/src/progressView/modules/usageManagers.js
+++ b/src/progressView/modules/usageManagers.js
@@ -55,7 +55,7 @@ export class UsageSummary {
     // Cache read: tokens served from cache (discounted rate)
     // Cache creation: tokens written to cache (Anthropic: 1.25x input price)
     const cacheReadSegment = cacheReadTokens > 0
-      ? ` · <i class="codicon codicon-arrow-circle-up" title="Cache read tokens (discounted)"></i>${formatTokens(cacheReadTokens)}`
+      ? ` · <i class="codicon codicon-cloud-download" title="Cache read tokens (discounted)"></i>${formatTokens(cacheReadTokens)}`
       : '';
     const cacheCreationSegment = cacheCreationTokens > 0
       ? ` · <i class="codicon codicon-database" title="Cache creation tokens (1.25x cost)"></i>${formatTokens(cacheCreationTokens)}`

--- a/src/progressView/modules/usageManagers.js
+++ b/src/progressView/modules/usageManagers.js
@@ -31,6 +31,7 @@ export class UsageSummary {
     const inputTokens = totals?.inputTokens ?? 0;
     const outputTokens = totals?.outputTokens ?? 0;
     const cost = totals?.cost ?? 0;
+    const cacheCreationTokens = totals?.cacheCreationInputTokens ?? 0;
 
     if (!inputTokens && !outputTokens && !cost) {
       this._summaryElem.textContent = '';
@@ -49,25 +50,33 @@ export class UsageSummary {
     const formattedOutput = formatTokens(outputTokens);
     const formattedCost = `$${cost.toFixed(3)}`;
 
+    // Build cache creation segment if present (Anthropic: charged at 1.25x input price)
+    const cacheCreationSegment = cacheCreationTokens > 0
+      ? ` · <i class="codicon codicon-database" title="Cache creation tokens (1.25x cost)"></i>${formatTokens(cacheCreationTokens)}`
+      : '';
+    const cacheCreationAriaLabel = cacheCreationTokens > 0
+      ? `, ${formatTokens(cacheCreationTokens)} cache creation tokens`
+      : '';
+
     this._summaryElem.innerHTML = `
       <i class="codicon codicon-meter"></i>
       <span class="run-summary__label">Total usage:</span>
       <span class="run-summary__value">
         <i class="codicon codicon-arrow-up" title="Input tokens"></i>${formattedInput} ·
-        <i class="codicon codicon-arrow-down" title="Output tokens"></i>${formattedOutput} ·
+        <i class="codicon codicon-arrow-down" title="Output tokens"></i>${formattedOutput}${cacheCreationSegment} ·
         ${formattedCost}
       </span>
     `;
     this._summaryElem.setAttribute(
       'aria-label',
-      `Total usage: ${formattedInput} input tokens, ${formattedOutput} output tokens, ${formattedCost}`,
+      `Total usage: ${formattedInput} input tokens, ${formattedOutput} output tokens${cacheCreationAriaLabel}, ${formattedCost}`,
     );
   }
 
   /**
    * Compute total usage for the active session in the active stream.
    * Each stream tab can have multiple sessions; this returns the current session's total.
-   * @returns {Object} Total usage with inputTokens, outputTokens, and cost
+   * @returns {Object} Total usage with inputTokens, outputTokens, cost, and cacheCreationInputTokens
    */
   computeTotal() {
     const stream = progressViewState.activeStream;
@@ -79,11 +88,12 @@ export class UsageSummary {
           inputTokens: usage.inputTokens || 0,
           outputTokens: usage.outputTokens || 0,
           cost: usage.cost || 0,
+          cacheCreationInputTokens: usage.cacheCreationInputTokens || 0,
         };
       }
     }
 
-    return { inputTokens: 0, outputTokens: 0, cost: 0 };
+    return { inputTokens: 0, outputTokens: 0, cost: 0, cacheCreationInputTokens: 0 };
   }
 
   /**

--- a/src/progressView/modules/usageManagers.js
+++ b/src/progressView/modules/usageManagers.js
@@ -94,11 +94,11 @@ export class UsageSummary {
       const usage = progressViewState.getRunUsage(stream, activeRunId);
       if (usage) {
         return {
-          inputTokens: usage.inputTokens || 0,
-          outputTokens: usage.outputTokens || 0,
-          cost: usage.cost || 0,
-          cacheReadInputTokens: usage.cacheReadInputTokens || 0,
-          cacheCreationInputTokens: usage.cacheCreationInputTokens || 0,
+          inputTokens: usage.inputTokens ?? 0,
+          outputTokens: usage.outputTokens ?? 0,
+          cost: usage.cost ?? 0,
+          cacheReadInputTokens: usage.cacheReadInputTokens ?? 0,
+          cacheCreationInputTokens: usage.cacheCreationInputTokens ?? 0,
         };
       }
     }

--- a/src/test/logger/AgentUsageReporter.test.ts
+++ b/src/test/logger/AgentUsageReporter.test.ts
@@ -54,6 +54,7 @@ describe('AgentUsageReporter', () => {
 
       assert.equal(streamEvents.length, 1);
       // storageKey is THE single source of truth - no runId needed
+      // Cache tokens are passed through for display
       assert.deepEqual(streamEvents[0], {
         stream: streamId,
         storageKey,
@@ -61,6 +62,7 @@ describe('AgentUsageReporter', () => {
           inputTokens: 10,
           outputTokens: 5,
           cost: 0.25,
+          cacheCreationInputTokens: 4,
         },
       });
       // Verify statistics were logged with storageKey
@@ -105,6 +107,7 @@ describe('AgentUsageReporter', () => {
       reporter.report(stats, storageKey);
 
       assert.equal(streamEvents.length, 1);
+      // Cache tokens are passed through for display
       assert.deepEqual(streamEvents[0], {
         stream: streamId,
         storageKey,
@@ -112,6 +115,7 @@ describe('AgentUsageReporter', () => {
           inputTokens: 6,
           outputTokens: 2,
           cost: 0.1,
+          cacheCreationInputTokens: 1,
         },
       });
     } finally {

--- a/src/test/logger/AgentUsageReporter.test.ts
+++ b/src/test/logger/AgentUsageReporter.test.ts
@@ -122,4 +122,99 @@ describe('AgentUsageReporter', () => {
       disposeStream();
     }
   });
+
+  it('passes through both cacheRead and cacheCreation tokens', () => {
+    const streamId = 'stream:test';
+    const storageKey = 'task-group-789' as StorageKey;
+    const streamEvents: unknown[] = [];
+    const disposeStream = bus.on('updateStreamUsage', (payload) => {
+      streamEvents.push(payload);
+    });
+
+    const loggerStub = {
+      statistics: () => {
+        /* no-op */
+      },
+    } as unknown as AgentLogger;
+
+    const reporter = new AgentUsageReporter(
+      loggerStub,
+      streamId,
+      AgentCategory.Workflow,
+    );
+
+    const stats: ExtendedTokenUsageStats = {
+      inputTokens: 100,
+      outputTokens: 50,
+      cost: 1.5,
+      cacheReadInputTokens: 80, // Cache hits (discounted)
+      cacheCreationInputTokens: 20, // Cache writes (1.25x for Anthropic)
+    };
+
+    try {
+      reporter.report(stats, storageKey);
+
+      assert.equal(streamEvents.length, 1);
+      // Both cache token types should be passed through
+      assert.deepEqual(streamEvents[0], {
+        stream: streamId,
+        storageKey,
+        usage: {
+          inputTokens: 100,
+          outputTokens: 50,
+          cost: 1.5,
+          cacheReadInputTokens: 80,
+          cacheCreationInputTokens: 20,
+        },
+      });
+    } finally {
+      disposeStream();
+    }
+  });
+
+  it('omits cache tokens when zero or undefined', () => {
+    const streamId = 'stream:test';
+    const storageKey = 'task-group-000' as StorageKey;
+    const streamEvents: unknown[] = [];
+    const disposeStream = bus.on('updateStreamUsage', (payload) => {
+      streamEvents.push(payload);
+    });
+
+    const loggerStub = {
+      statistics: () => {
+        /* no-op */
+      },
+    } as unknown as AgentLogger;
+
+    const reporter = new AgentUsageReporter(
+      loggerStub,
+      streamId,
+      AgentCategory.Workflow,
+    );
+
+    // No cache tokens in stats
+    const stats: ExtendedTokenUsageStats = {
+      inputTokens: 10,
+      outputTokens: 5,
+      cost: 0.1,
+    };
+
+    try {
+      reporter.report(stats, storageKey);
+
+      assert.equal(streamEvents.length, 1);
+      // Cache tokens should be omitted when not present
+      assert.deepEqual(streamEvents[0], {
+        stream: streamId,
+        storageKey,
+        usage: {
+          inputTokens: 10,
+          outputTokens: 5,
+          cost: 0.1,
+        },
+      });
+    } finally {
+      disposeStream();
+    }
+  });
 });


### PR DESCRIPTION
- Change usage display to show accumulated totals across all rounds instead of per-round usage
- Add cacheCreationInputTokens field to TokenUsageStats schema
- Display cache creation tokens in the UI footer for Anthropic models (these are charged at 1.25x input price)
- Pass through cache creation tokens from UsageMonitor through ProgressEventHandler to the frontend

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Shows accumulated usage totals instead of per-round deltas and adds cache token visibility across the stack.
> 
> - Extend `TokenUsageStats` and `UsageLogStats` with optional `cacheReadInputTokens` and `cacheCreationInputTokens`; compute `percentageCached` from session totals
> - `UsageMonitor`: emit per-round deltas; backend log includes `cacheCreationInputTokens`; cache percentage uses accumulated totals
> - `UsageStatsManager`: accumulates deltas per `storageKey` and returns accumulated totals; provides stream/global totals and single-key lookups
> - `ProgressEventHandler`: normalizes deltas, stores via manager, and sends accumulated totals to the webview (SET semantics)
> - UI (`usageManagers.js`, `progressViewState.js`): footer shows total input/output/cost plus cache read/creation tokens with icons and ARIA labels; preserves zero values via nullish coalescing
> - `AgentUsageReporter`: passes through cache tokens; tests updated/added to validate pass-through and omission when zero
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d0ced51341d614ba073f7f80874c6b5c6a762a3f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->