### PR TITLE
Fix progress view with large datasets

### DIFF
--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -363,8 +363,13 @@ export class ProgressViewProvider
 
   /**
    * Set active stream (used by message handler)
+   * Loads stream data lazily before updating the webview.
    */
-  public setActiveStream(stream: string): void {
+  public async setActiveStream(stream: string): Promise<void> {
+    // Load stream data before switching (for lazy loading)
+    if (stream) {
+      await this.state.ensureStreamLoaded(stream);
+    }
     this.state.activeStream = stream;
     this.updateWebview();
   }

--- a/src/progressView/managers/OutputFilesManager.ts
+++ b/src/progressView/managers/OutputFilesManager.ts
@@ -65,6 +65,8 @@ const OutputFilesDataSchema = createRunMapSchema(OutputFilesRoundMapSchema);
 /**
  * Manages output files collection with persistence and file existence validation.
  * Handles adding, updating, and managing output files for different streams.
+ *
+ * Uses file-based storage to enable lazy loading and avoid VS Code IPC limits.
  */
 export class OutputFilesManager extends PersistentMapManager<
   StreamTabId,
@@ -79,7 +81,8 @@ export class OutputFilesManager extends PersistentMapManager<
   private readonly logger: AgentLogger;
 
   constructor(storage?: StateStorage) {
-    super(WorkspaceStateKey.OUTPUT_FILES, storage);
+    // Enable file-based storage for lazy loading
+    super(WorkspaceStateKey.OUTPUT_FILES, storage, { useFileStorage: true });
     this.logger = new AgentLogger('OutputFilesManager');
   }
 
@@ -95,11 +98,16 @@ export class OutputFilesManager extends PersistentMapManager<
     storageKey: StorageKey,
     filesByRound: { [key: number]: OutputFileInfo[] },
   ): Promise<void> {
+    // Ensure stream data is loaded before modifying
+    await this.ensureLoaded(stream);
+
     // storageKey is already branded - use directly, no normalization needed
     let streamRuns = this.items.get(stream);
     if (!streamRuns) {
       streamRuns = new Map();
       this.items.set(stream, streamRuns);
+      this.knownKeys.add(stream);
+      this.loadedKeys.add(stream);
     }
 
     let runRounds = streamRuns.get(storageKey);
@@ -127,7 +135,7 @@ export class OutputFilesManager extends PersistentMapManager<
       runRounds.set(roundNum, normalizedFiles);
     }
 
-    await this.save();
+    await this.saveEntry(stream, streamRuns);
   }
 
   /**

--- a/src/progressView/managers/RunInstructionManager.ts
+++ b/src/progressView/managers/RunInstructionManager.ts
@@ -19,16 +19,27 @@ type InstructionMap = Map<string, InstructionUpdate>;
 
 /**
  * Persists run-scoped instruction updates per stream.
+ *
+ * Uses file-based storage to enable lazy loading and avoid VS Code IPC limits.
  */
 export class RunInstructionManager extends PersistentMapManager<
   StreamTabId,
   InstructionMap
 > {
   constructor(storage?: StateStorage) {
-    super(WorkspaceStateKey.RUN_INSTRUCTIONS, storage);
+    // Enable file-based storage for lazy loading
+    super(WorkspaceStateKey.RUN_INSTRUCTIONS, storage, { useFileStorage: true });
   }
 
   getInstructions(stream: StreamTabId): InstructionMap {
+    return new Map(this.get(stream) ?? []);
+  }
+
+  /**
+   * Get instructions for a stream, ensuring data is loaded first.
+   */
+  async getInstructionsAsync(stream: StreamTabId): Promise<InstructionMap> {
+    await this.ensureLoaded(stream);
     return new Map(this.get(stream) ?? []);
   }
 
@@ -37,6 +48,9 @@ export class RunInstructionManager extends PersistentMapManager<
     storageKey: StorageKey,
     instruction: InstructionUpdate | null,
   ): Promise<void> {
+    // Ensure stream data is loaded before modifying
+    await this.ensureLoaded(stream);
+
     const existing = this.items.get(stream) ?? new Map();
 
     if (!instruction) {
@@ -47,11 +61,17 @@ export class RunInstructionManager extends PersistentMapManager<
 
     if (existing.size === 0) {
       this.items.delete(stream);
+      this.knownKeys.delete(stream);
+      this.loadedKeys.delete(stream);
+      if (this.useFileStorage) {
+        await this.delete(stream);
+      }
     } else {
       this.items.set(stream, existing);
+      this.knownKeys.add(stream);
+      this.loadedKeys.add(stream);
+      await this.saveEntry(stream, existing);
     }
-
-    await this.save();
   }
 
   async deleteRun(stream: StreamTabId, storageKey: StorageKey): Promise<void> {

--- a/src/progressView/managers/StreamTabsManager.ts
+++ b/src/progressView/managers/StreamTabsManager.ts
@@ -13,6 +13,8 @@ import {
 /**
  * Manages stream tabs collection with persistence.
  * Handles adding, retrieving, and managing log messages for different streams.
+ *
+ * Uses file-based storage to enable lazy loading and avoid VS Code IPC limits.
  */
 export class StreamTabsManager extends PersistentMapManager<
   StreamTabId,
@@ -22,7 +24,8 @@ export class StreamTabsManager extends PersistentMapManager<
   private readonly logger: AgentLogger;
 
   constructor(storage?: StateStorage) {
-    super(WorkspaceStateKey.STREAM_TABS, storage);
+    // Enable file-based storage for lazy loading
+    super(WorkspaceStateKey.STREAM_TABS, storage, { useFileStorage: true });
     this.logger = new AgentLogger('StreamTabsManager');
   }
 
@@ -33,6 +36,8 @@ export class StreamTabsManager extends PersistentMapManager<
     stream: StreamTabId,
     message: LogMessageData,
   ): Promise<boolean> {
+    // Ensure stream data is loaded before modifying
+    await this.ensureLoaded(stream);
     const messages = this.ensureMessages(stream);
 
     const existingIndex = messages.findIndex(
@@ -82,6 +87,15 @@ export class StreamTabsManager extends PersistentMapManager<
   }
 
   getMessages(stream: StreamTabId): LogMessageData[] {
+    return this.ensureMessages(stream);
+  }
+
+  /**
+   * Get messages for a stream, ensuring data is loaded first.
+   * Use this for file-based storage to ensure data is available.
+   */
+  async getMessagesAsync(stream: StreamTabId): Promise<LogMessageData[]> {
+    await this.ensureLoaded(stream);
     return this.ensureMessages(stream);
   }
 

--- a/src/progressView/managers/TaskGroupManager.ts
+++ b/src/progressView/managers/TaskGroupManager.ts
@@ -19,6 +19,8 @@ import type { UpdateTaskGroupPayload } from '@eventBus/schemas';
 /**
  * Manages task groups collection with persistence.
  * Handles adding, updating, and managing task groups for different streams.
+ *
+ * Uses file-based storage to enable lazy loading and avoid VS Code IPC limits.
  */
 export class TaskGroupManager extends PersistentMapManager<
   StreamTabId,
@@ -27,7 +29,8 @@ export class TaskGroupManager extends PersistentMapManager<
   private readonly logger: AgentLogger;
 
   constructor(storage?: StateStorage) {
-    super(WorkspaceStateKey.TASK_GROUPS, storage);
+    // Enable file-based storage for lazy loading
+    super(WorkspaceStateKey.TASK_GROUPS, storage, { useFileStorage: true });
     this.logger = new AgentLogger('TaskGroupManager');
   }
 
@@ -39,13 +42,18 @@ export class TaskGroupManager extends PersistentMapManager<
     groupId: string,
     group: TaskGroup,
   ): Promise<void> {
+    // Ensure stream data is loaded before modifying
+    await this.ensureLoaded(stream);
+
     if (!this.has(stream)) {
       this.items.set(stream, new Map());
+      this.knownKeys.add(stream);
+      this.loadedKeys.add(stream);
     }
 
     const streamGroups = this.get(stream)!;
     streamGroups.set(groupId, { ...group });
-    await this.save();
+    await this.saveEntry(stream, streamGroups);
   }
 
   /**
@@ -58,6 +66,9 @@ export class TaskGroupManager extends PersistentMapManager<
     status,
     endTime,
   }: UpdateTaskGroupPayload): Promise<void> {
+    // Ensure stream data is loaded before modifying
+    await this.ensureLoaded(stream);
+
     const streamGroups = this.get(stream);
     if (!streamGroups) {
       this.logger.warn(`Cannot update group ${id}: stream ${stream} not found`);
@@ -78,11 +89,16 @@ export class TaskGroupManager extends PersistentMapManager<
       updated.endTime = endTime;
     }
     streamGroups.set(id, updated);
-    await this.save();
+    await this.saveEntry(stream, streamGroups);
   }
 
   async endRunningGroups(now: number = Date.now()): Promise<StreamTabId[]> {
     const affected: StreamTabId[] = [];
+
+    // Load all streams to check for running groups
+    for (const streamId of this.keys()) {
+      await this.ensureLoaded(streamId);
+    }
 
     for (const [streamId, groups] of this.items.entries()) {
       let updated = false;
@@ -97,14 +113,11 @@ export class TaskGroupManager extends PersistentMapManager<
 
       if (updated) {
         affected.push(streamId);
+        await this.saveEntry(streamId, groups);
         this.logger.debug(
           `Marked running task groups in stream ${streamId} as ERROR after reload`,
         );
       }
-    }
-
-    if (affected.length > 0) {
-      await this.save();
     }
 
     return affected;
@@ -119,9 +132,29 @@ export class TaskGroupManager extends PersistentMapManager<
   }
 
   /**
+   * Get a specific task group, ensuring data is loaded first.
+   */
+  async getGroupAsync(
+    stream: StreamTabId,
+    groupId: string,
+  ): Promise<TaskGroup | undefined> {
+    await this.ensureLoaded(stream);
+    const streamGroups = this.get(stream);
+    return streamGroups?.get(groupId);
+  }
+
+  /**
    * Get all groups for a stream
    */
   getStreamGroups(stream: StreamTabId): Map<string, TaskGroup> {
+    return this.get(stream) || new Map();
+  }
+
+  /**
+   * Get all groups for a stream, ensuring data is loaded first.
+   */
+  async getStreamGroupsAsync(stream: StreamTabId): Promise<Map<string, TaskGroup>> {
+    await this.ensureLoaded(stream);
     return this.get(stream) || new Map();
   }
 

--- a/src/progressView/managers/UsageStatsManager.ts
+++ b/src/progressView/managers/UsageStatsManager.ts
@@ -59,6 +59,8 @@ const UsageDataSchema = createSingleValueRunMapSchema(
 /**
  * Manages usage statistics collection with persistence.
  * Handles tracking and updating token usage and costs for different streams.
+ *
+ * Uses file-based storage to enable lazy loading and avoid VS Code IPC limits.
  */
 type RunUsageMap = Map<string, TokenUsageStats>;
 
@@ -69,7 +71,8 @@ export class UsageStatsManager extends PersistentMapManager<
   private readonly logger: AgentLogger;
 
   constructor(storage?: StateStorage) {
-    super(WorkspaceStateKey.USAGE_STATS, storage);
+    // Enable file-based storage for lazy loading
+    super(WorkspaceStateKey.USAGE_STATS, storage, { useFileStorage: true });
     this.logger = new AgentLogger('UsageStatsManager');
   }
 
@@ -82,6 +85,9 @@ export class UsageStatsManager extends PersistentMapManager<
     storageKey: StorageKey,
     usage: TokenUsageStats,
   ): Promise<void> {
+    // Ensure stream data is loaded before modifying
+    await this.ensureLoaded(stream);
+
     const normalized = TokenUsageStatsParsingSchema.parse(usage);
     const current =
       this.items.get(stream) ?? new Map<string, TokenUsageStats>();
@@ -93,11 +99,17 @@ export class UsageStatsManager extends PersistentMapManager<
 
     if (current.size === 0) {
       this.items.delete(stream);
+      this.knownKeys.delete(stream);
+      this.loadedKeys.delete(stream);
+      if (this.useFileStorage) {
+        await this.delete(stream);
+      }
     } else {
       this.items.set(stream, current);
+      this.knownKeys.add(stream);
+      this.loadedKeys.add(stream);
+      await this.saveEntry(stream, current);
     }
-
-    await this.save();
   }
 
   /**

--- a/src/progressView/persistence/FileBasedStreamStorage.ts
+++ b/src/progressView/persistence/FileBasedStreamStorage.ts
@@ -1,0 +1,202 @@
+// Third-party imports
+import * as path from 'path';
+
+// Local imports
+import type { StreamTabId } from '@agent/types/IdentifierTypes';
+import { AgentLogger } from '@logger/AgentLogger';
+import { StorageFS } from '@utils/files/storageFS';
+
+/**
+ * Directory name for progress view storage within StorageFS base path.
+ */
+const PROGRESS_STORAGE_DIR = 'progress';
+
+/**
+ * File-based storage for stream data to avoid VS Code workspaceState IPC limits.
+ *
+ * Stores heavy data (messages, task groups, output files, etc.) in individual
+ * files per stream, enabling lazy loading when streams are accessed.
+ */
+export class FileBasedStreamStorage {
+  private readonly logger = new AgentLogger('FileBasedStreamStorage');
+  private readonly cache = new Map<string, Map<StreamTabId, unknown>>();
+
+  /**
+   * Get the storage directory for a specific data type.
+   */
+  private getStorageDir(dataType: string): string {
+    return path.join(PROGRESS_STORAGE_DIR, dataType);
+  }
+
+  /**
+   * Get the file path for a specific stream's data.
+   */
+  private getFilePath(dataType: string, streamId: StreamTabId): string {
+    // Sanitize stream ID for use as filename (replace invalid chars)
+    const safeId = streamId.replaceAll(/[<>:"/\\|?*]/g, '_');
+    return path.join(this.getStorageDir(dataType), `${safeId}.json`);
+  }
+
+  /**
+   * Save data for a specific stream.
+   */
+  async save<T>(
+    dataType: string,
+    streamId: StreamTabId,
+    data: T,
+  ): Promise<void> {
+    try {
+      const filePath = this.getFilePath(dataType, streamId);
+      await StorageFS.writeJson(filePath, data);
+
+      // Update cache
+      let typeCache = this.cache.get(dataType);
+      if (!typeCache) {
+        typeCache = new Map();
+        this.cache.set(dataType, typeCache);
+      }
+      typeCache.set(streamId, data);
+    } catch (error) {
+      this.logger.error(`Failed to save ${dataType} for stream ${streamId}`, {
+        data: error,
+      });
+      throw error;
+    }
+  }
+
+  /**
+   * Load data for a specific stream (lazy loading with cache).
+   */
+  async load<T>(dataType: string, streamId: StreamTabId): Promise<T | null> {
+    // Check cache first
+    const typeCache = this.cache.get(dataType);
+    if (typeCache?.has(streamId)) {
+      return typeCache.get(streamId) as T;
+    }
+
+    try {
+      const filePath = this.getFilePath(dataType, streamId);
+      const exists = await StorageFS.exists(filePath);
+      if (!exists) {
+        return null;
+      }
+
+      const data = await StorageFS.readJson<T>(filePath);
+
+      // Update cache
+      let cache = this.cache.get(dataType);
+      if (!cache) {
+        cache = new Map();
+        this.cache.set(dataType, cache);
+      }
+      cache.set(streamId, data);
+
+      return data;
+    } catch (error) {
+      this.logger.warn(`Failed to load ${dataType} for stream ${streamId}`, {
+        data: error,
+      });
+      return null;
+    }
+  }
+
+  /**
+   * Delete data for a specific stream.
+   */
+  async delete(dataType: string, streamId: StreamTabId): Promise<void> {
+    try {
+      const filePath = this.getFilePath(dataType, streamId);
+      const exists = await StorageFS.exists(filePath);
+      if (exists) {
+        await StorageFS.delete(filePath);
+      }
+
+      // Clear from cache
+      this.cache.get(dataType)?.delete(streamId);
+    } catch (error) {
+      this.logger.warn(`Failed to delete ${dataType} for stream ${streamId}`, {
+        data: error,
+      });
+    }
+  }
+
+  /**
+   * Delete all data for a specific stream across all data types.
+   */
+  async deleteStream(streamId: StreamTabId): Promise<void> {
+    const dataTypes = [
+      'streamTabs',
+      'taskGroups',
+      'outputFiles',
+      'missingOutputs',
+      'usageStats',
+      'runInstructions',
+      'taskStates',
+    ];
+
+    await Promise.all(
+      dataTypes.map((dataType) => this.delete(dataType, streamId)),
+    );
+  }
+
+  /**
+   * List all stream IDs that have data for a specific data type.
+   */
+  async listStreams(dataType: string): Promise<StreamTabId[]> {
+    try {
+      const dir = this.getStorageDir(dataType);
+      const exists = await StorageFS.exists(dir);
+      if (!exists) {
+        return [];
+      }
+
+      const entries = await StorageFS.readDir(dir);
+      return entries
+        .filter(([name]) => name.endsWith('.json'))
+        .map(([name]) => name.replace('.json', '') as StreamTabId);
+    } catch (error) {
+      this.logger.warn(`Failed to list streams for ${dataType}`, {
+        data: error,
+      });
+      return [];
+    }
+  }
+
+  /**
+   * Clear all cached data.
+   */
+  clearCache(): void {
+    this.cache.clear();
+  }
+
+  /**
+   * Clear cache for a specific stream.
+   */
+  clearStreamCache(streamId: StreamTabId): void {
+    for (const typeCache of this.cache.values()) {
+      typeCache.delete(streamId);
+    }
+  }
+
+  /**
+   * Clear all data (files and cache).
+   */
+  async clearAll(): Promise<void> {
+    try {
+      const exists = await StorageFS.exists(PROGRESS_STORAGE_DIR);
+      if (exists) {
+        await StorageFS.delete(PROGRESS_STORAGE_DIR);
+      }
+      this.cache.clear();
+    } catch (error) {
+      this.logger.error('Failed to clear all progress storage', {
+        data: error,
+      });
+    }
+  }
+}
+
+/**
+ * Singleton instance of FileBasedStreamStorage.
+ */
+export const streamStorage = new FileBasedStreamStorage();

--- a/src/progressView/persistence/PersistentMapManager.ts
+++ b/src/progressView/persistence/PersistentMapManager.ts
@@ -137,10 +137,34 @@ export abstract class PersistentMapManager<K extends string, V> {
   /** Load state from persistence */
   async load(): Promise<void> {
     if (this.useFileStorage) {
+      // First, migrate any existing data from workspaceState to files
+      await this.migrateFromWorkspaceState();
       await this.loadFromFiles();
     } else {
       await this.loadFromWorkspaceState();
     }
+  }
+
+  /**
+   * Migrate existing data from workspaceState to file storage.
+   * This is a one-time migration that clears the old workspaceState data.
+   */
+  private async migrateFromWorkspaceState(): Promise<void> {
+    const saved = this.storage.get<Record<string, unknown>>(this.storageKey);
+
+    if (!saved || Object.keys(saved).length === 0) {
+      return; // Nothing to migrate
+    }
+
+    // Migrate each entry to file storage
+    for (const [key, value] of Object.entries(saved)) {
+      const deserialized = await this.deserialize(value, key as K);
+      const serialized = this.serialize(deserialized, key as K);
+      await streamStorage.save(this.storageKey, key, serialized);
+    }
+
+    // Clear the old workspaceState data
+    await this.storage.update(this.storageKey, undefined as never);
   }
 
   /** Load only the list of keys (for file storage mode) */

--- a/src/progressView/persistence/PersistentMapManager.ts
+++ b/src/progressView/persistence/PersistentMapManager.ts
@@ -1,5 +1,6 @@
 // Local imports
 import { workspaceSM, WorkspaceStateKey } from '@common/state/stateManager';
+import { streamStorage } from './FileBasedStreamStorage';
 
 export interface StateStorage {
   get<T>(key: string): T | undefined;
@@ -7,16 +8,34 @@ export interface StateStorage {
   update<T>(key: string, value: T): Thenable<void>;
 }
 
+export interface PersistentMapManagerOptions {
+  /** Use file-based storage instead of workspaceState for lazy loading */
+  useFileStorage?: boolean;
+}
+
 /**
  * Generic manager for map-based state with persistence support.
  * Handles common map operations and storage serialization.
+ *
+ * Supports two storage modes:
+ * - workspaceState: All data in VS Code memento (legacy, limited by IPC threshold)
+ * - file-based: Data stored in files per key, loaded lazily (recommended for large data)
  */
 export abstract class PersistentMapManager<K extends string, V> {
   protected items: Map<K, V> = new Map();
   protected readonly storage: StateStorage;
   protected readonly storageKey: WorkspaceStateKey;
+  protected readonly useFileStorage: boolean;
+  /** Track which keys exist (for file storage mode) */
+  protected knownKeys: Set<K> = new Set();
+  /** Track which keys have been loaded from file */
+  protected loadedKeys: Set<K> = new Set();
 
-  constructor(storageKey: WorkspaceStateKey, storage?: StateStorage) {
+  constructor(
+    storageKey: WorkspaceStateKey,
+    storage?: StateStorage,
+    options?: PersistentMapManagerOptions,
+  ) {
     const resolvedStorage = storage ?? workspaceSM;
     if (!resolvedStorage) {
       throw new Error('workspace state manager is not initialized');
@@ -24,28 +43,58 @@ export abstract class PersistentMapManager<K extends string, V> {
 
     this.storage = resolvedStorage;
     this.storageKey = storageKey;
+    this.useFileStorage = options?.useFileStorage ?? false;
   }
 
   /** Add an entry to the map and persist it */
   async add(key: K, value: V): Promise<void> {
     this.items.set(key, value);
-    await this.save();
+    this.knownKeys.add(key);
+    this.loadedKeys.add(key);
+    await this.saveEntry(key, value);
   }
 
   /** Delete an entry and persist the change */
   async delete(key: K): Promise<void> {
     this.items.delete(key);
-    await this.save();
+    this.knownKeys.delete(key);
+    this.loadedKeys.delete(key);
+    if (this.useFileStorage) {
+      await streamStorage.delete(this.storageKey, key);
+    } else {
+      await this.save();
+    }
   }
 
   /** Clear the map and persist the change */
   async clear(): Promise<void> {
+    if (this.useFileStorage) {
+      // Delete all files for this data type
+      for (const key of this.knownKeys) {
+        await streamStorage.delete(this.storageKey, key);
+      }
+    }
     this.items.clear();
-    await this.save();
+    this.knownKeys.clear();
+    this.loadedKeys.clear();
+    if (!this.useFileStorage) {
+      await this.save();
+    }
   }
 
-  /** Get a value for the key */
+  /** Get a value for the key (loads from file if using file storage) */
   get(key: K): V | undefined {
+    return this.items.get(key);
+  }
+
+  /**
+   * Get a value for the key, loading from file if necessary (async version).
+   * Use this for file-based storage to ensure data is loaded.
+   */
+  async getAsync(key: K): Promise<V | undefined> {
+    if (this.useFileStorage && !this.loadedKeys.has(key) && this.knownKeys.has(key)) {
+      await this.loadEntry(key);
+    }
     return this.items.get(key);
   }
 
@@ -56,17 +105,21 @@ export abstract class PersistentMapManager<K extends string, V> {
 
   /** Check if key exists */
   has(key: K): boolean {
-    return this.items.has(key);
+    return this.useFileStorage ? this.knownKeys.has(key) : this.items.has(key);
   }
 
   /** Get all keys */
   keys(): K[] {
-    return [...this.items.keys()];
+    return this.useFileStorage
+      ? [...this.knownKeys]
+      : [...this.items.keys()];
   }
 
   /** Replace all entries (used during loading) */
   setAll(entries: Map<K, V>): void {
     this.items = new Map(entries);
+    this.knownKeys = new Set(entries.keys());
+    this.loadedKeys = new Set(entries.keys());
   }
 
   /** Serialize a value before saving */
@@ -83,6 +136,24 @@ export abstract class PersistentMapManager<K extends string, V> {
 
   /** Load state from persistence */
   async load(): Promise<void> {
+    if (this.useFileStorage) {
+      await this.loadFromFiles();
+    } else {
+      await this.loadFromWorkspaceState();
+    }
+  }
+
+  /** Load only the list of keys (for file storage mode) */
+  private async loadFromFiles(): Promise<void> {
+    // Get list of existing streams from file system
+    const streamIds = await streamStorage.listStreams(this.storageKey);
+    this.knownKeys = new Set(streamIds as K[]);
+    this.items.clear();
+    this.loadedKeys.clear();
+  }
+
+  /** Load from workspaceState (legacy mode) */
+  private async loadFromWorkspaceState(): Promise<void> {
     const saved = this.storage.get<Record<string, unknown>>(
       this.storageKey,
       {},
@@ -92,17 +163,55 @@ export abstract class PersistentMapManager<K extends string, V> {
       await this.populateFromRecord(saved);
     } else {
       this.items.clear();
+      this.knownKeys.clear();
+      this.loadedKeys.clear();
+    }
+  }
+
+  /** Load a single entry from file storage */
+  protected async loadEntry(key: K): Promise<void> {
+    if (!this.useFileStorage) return;
+
+    const data = await streamStorage.load<unknown>(this.storageKey, key);
+    if (data !== null) {
+      const deserialized = await this.deserialize(data, key);
+      this.items.set(key, deserialized);
+      this.loadedKeys.add(key);
+    }
+  }
+
+  /** Ensure an entry is loaded (for file storage mode) */
+  async ensureLoaded(key: K): Promise<void> {
+    if (this.useFileStorage && !this.loadedKeys.has(key) && this.knownKeys.has(key)) {
+      await this.loadEntry(key);
     }
   }
 
   /** Save current state to persistence */
   async save(): Promise<void> {
-    const serialized = [...this.items.entries()].map(([key, value]) => [
-      key,
-      this.serialize(value, key),
-    ]);
-    const obj = Object.fromEntries(serialized);
-    await this.storage.update(this.storageKey, obj);
+    if (this.useFileStorage) {
+      // Save all modified entries
+      for (const [key, value] of this.items.entries()) {
+        await this.saveEntry(key, value);
+      }
+    } else {
+      const serialized = [...this.items.entries()].map(([key, value]) => [
+        key,
+        this.serialize(value, key),
+      ]);
+      const obj = Object.fromEntries(serialized);
+      await this.storage.update(this.storageKey, obj);
+    }
+  }
+
+  /** Save a single entry (for file storage mode) */
+  protected async saveEntry(key: K, value: V): Promise<void> {
+    if (this.useFileStorage) {
+      const serialized = this.serialize(value, key);
+      await streamStorage.save(this.storageKey, key, serialized);
+    } else {
+      await this.save();
+    }
   }
 
   private async populateFromRecord(
@@ -114,5 +223,7 @@ export abstract class PersistentMapManager<K extends string, V> {
       entries.push([key as K, deserialized]);
     }
     this.items = new Map(entries);
+    this.knownKeys = new Set(this.items.keys());
+    this.loadedKeys = new Set(this.items.keys());
   }
 }

--- a/src/progressView/state/ProgressViewState.ts
+++ b/src/progressView/state/ProgressViewState.ts
@@ -50,6 +50,13 @@ export const StreamHintsSchema = z.object({
 export type StreamHints = z.infer<typeof StreamHintsSchema>;
 
 /**
+ * Maximum number of streams to retain in storage.
+ * When exceeded during load, oldest streams are pruned to prevent
+ * VS Code storage IPC threshold warnings (~5MB limit).
+ */
+const MAX_STREAMS = 50;
+
+/**
  * Core state management for the progress view.
  * Composes focused manager classes and provides a clean interface
  * for state operations while hiding implementation details.
@@ -581,6 +588,9 @@ export class ProgressViewState {
       this.loadAgentTypeFilter(),
       this.loadActiveRunIds(),
     ]);
+
+    // Prune old streams to prevent storage bloat
+    await this.pruneOldStreams();
   }
 
   /**
@@ -759,5 +769,57 @@ export class ProgressViewState {
       WorkspaceStateKey.STREAM_AGENT_FILTER,
       this._agentTypeFilter,
     );
+  }
+
+  /**
+   * Prune old streams if the count exceeds MAX_STREAMS.
+   * Removes oldest streams based on task group timestamps.
+   * Called during load to prevent storage bloat.
+   */
+  private async pruneOldStreams(): Promise<void> {
+    const allStreams = this._streamTabs.keys();
+    if (allStreams.length <= MAX_STREAMS) {
+      return;
+    }
+
+    // Get timestamps for all streams (from task groups or fallback to 0)
+    const streamTimestamps: Array<{ stream: StreamTabId; timestamp: number }> =
+      allStreams.map((stream) => ({
+        stream,
+        timestamp: this.getStreamTimestamp(stream),
+      }));
+
+    // Sort by timestamp descending (newest first)
+    streamTimestamps.sort((a, b) => b.timestamp - a.timestamp);
+
+    // Keep the newest MAX_STREAMS, remove the rest
+    const streamsToRemove = streamTimestamps.slice(MAX_STREAMS);
+
+    if (streamsToRemove.length > 0) {
+      this.logger.info(
+        `Pruning ${streamsToRemove.length} old streams to stay under ${MAX_STREAMS} limit`,
+      );
+
+      for (const { stream } of streamsToRemove) {
+        await this.clearStream(stream);
+      }
+    }
+  }
+
+  /**
+   * Get the most recent timestamp for a stream.
+   * Uses task group start times, falling back to 0 for streams without groups.
+   */
+  private getStreamTimestamp(stream: StreamTabId): number {
+    const groups = this._taskGroups.getStreamGroups(stream);
+    let maxTimestamp = 0;
+
+    for (const group of groups.values()) {
+      if (group.startTime > maxTimestamp) {
+        maxTimestamp = group.startTime;
+      }
+    }
+
+    return maxTimestamp;
   }
 }

--- a/src/progressView/state/ProgressViewState.ts
+++ b/src/progressView/state/ProgressViewState.ts
@@ -132,6 +132,20 @@ export class ProgressViewState {
   }
 
   /**
+   * Ensure all data for a stream is loaded (for lazy loading mode).
+   * Call this before accessing stream data to ensure it's available.
+   */
+  async ensureStreamLoaded(stream: StreamTabId): Promise<void> {
+    await Promise.all([
+      this._streamTabs.ensureLoaded(stream),
+      this._taskGroups.ensureLoaded(stream),
+      this._outputFiles.ensureLoaded(stream),
+      this._usageStats.ensureLoaded(stream),
+      this._runInstructions.ensureLoaded(stream),
+    ]);
+  }
+
+  /**
    * Ensure the active stream is valid within the given set of available streams.
    *
    * This is the SINGLE SOURCE OF TRUTH for active stream resolution. If the

--- a/src/progressView/state/ProgressViewState.ts
+++ b/src/progressView/state/ProgressViewState.ts
@@ -50,13 +50,6 @@ export const StreamHintsSchema = z.object({
 export type StreamHints = z.infer<typeof StreamHintsSchema>;
 
 /**
- * Maximum number of streams to retain in storage.
- * When exceeded during load, oldest streams are pruned to prevent
- * VS Code storage IPC threshold warnings (~5MB limit).
- */
-const MAX_STREAMS = 50;
-
-/**
  * Core state management for the progress view.
  * Composes focused manager classes and provides a clean interface
  * for state operations while hiding implementation details.
@@ -588,9 +581,6 @@ export class ProgressViewState {
       this.loadAgentTypeFilter(),
       this.loadActiveRunIds(),
     ]);
-
-    // Prune old streams to prevent storage bloat
-    await this.pruneOldStreams();
   }
 
   /**
@@ -769,57 +759,5 @@ export class ProgressViewState {
       WorkspaceStateKey.STREAM_AGENT_FILTER,
       this._agentTypeFilter,
     );
-  }
-
-  /**
-   * Prune old streams if the count exceeds MAX_STREAMS.
-   * Removes oldest streams based on task group timestamps.
-   * Called during load to prevent storage bloat.
-   */
-  private async pruneOldStreams(): Promise<void> {
-    const allStreams = this._streamTabs.keys();
-    if (allStreams.length <= MAX_STREAMS) {
-      return;
-    }
-
-    // Get timestamps for all streams (from task groups or fallback to 0)
-    const streamTimestamps: Array<{ stream: StreamTabId; timestamp: number }> =
-      allStreams.map((stream) => ({
-        stream,
-        timestamp: this.getStreamTimestamp(stream),
-      }));
-
-    // Sort by timestamp descending (newest first)
-    streamTimestamps.sort((a, b) => b.timestamp - a.timestamp);
-
-    // Keep the newest MAX_STREAMS, remove the rest
-    const streamsToRemove = streamTimestamps.slice(MAX_STREAMS);
-
-    if (streamsToRemove.length > 0) {
-      this.logger.info(
-        `Pruning ${streamsToRemove.length} old streams to stay under ${MAX_STREAMS} limit`,
-      );
-
-      for (const { stream } of streamsToRemove) {
-        await this.clearStream(stream);
-      }
-    }
-  }
-
-  /**
-   * Get the most recent timestamp for a stream.
-   * Uses task group start times, falling back to 0 for streams without groups.
-   */
-  private getStreamTimestamp(stream: StreamTabId): number {
-    const groups = this._taskGroups.getStreamGroups(stream);
-    let maxTimestamp = 0;
-
-    for (const group of groups.values()) {
-      if (group.startTime > maxTimestamp) {
-        maxTimestamp = group.startTime;
-      }
-    }
-
-    return maxTimestamp;
   }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Moves heavy progress data off workspaceState to avoid IPC limits and enable scalable lazy loading.
> 
> - Introduces `FileBasedStreamStorage` and extends `PersistentMapManager` with file-based mode (`useFileStorage`), per-key `saveEntry`, `ensureLoaded`, key tracking, and migration from `workspaceState`
> - Converts `StreamTabsManager`, `TaskGroupManager`, `OutputFilesManager`, `UsageStatsManager`, and `RunInstructionManager` to file storage, adding async getters and per-stream save/delete
> - Adds `ProgressViewState.ensureStreamLoaded` and makes `ProgressViewProvider.setActiveStream` async to preload stream data before webview updates
> - Improves reload handling: `TaskGroupManager.endRunningGroups` loads all streams before marking running groups and saves per affected stream
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit db46b7727da90433a0b8a6a574f8978814c58f54. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->