### PR TITLE
Add manual memory deletion buttons

### DIFF
--- a/src/common/webview/commands.ts
+++ b/src/common/webview/commands.ts
@@ -267,6 +267,7 @@ export const MEMORY_VIEW_COMMANDS = {
   UPDATE_MEMORY: 'updateMemory',
   OPEN_MEMORY_FILE: 'openMemoryFile',
   OPEN_MEMORY_FOLDER: 'openMemoryFolder',
+  DELETE_MEMORY: 'deleteMemory',
 };
 
 // Export all commands in a single object for convenience

--- a/src/memoryView/MemoryViewMessageHandler.ts
+++ b/src/memoryView/MemoryViewMessageHandler.ts
@@ -28,7 +28,10 @@ import {
 import { StorageFS } from '@utils/files';
 
 // Local imports - schemas
-import { MemoryPathMessageSchema } from '@webview/types/messages';
+import {
+  MemoryPathMessageSchema,
+  MemoryDeleteMessageSchema,
+} from '@webview/types/messages';
 
 interface MemoryViewItem {
   displayPath: string;
@@ -57,6 +60,8 @@ export class MemoryViewMessageHandler extends BaseViewMessageHandler<
         this.handleOpenMemoryFile.bind(this),
       [MEMORY_VIEW_COMMANDS.OPEN_MEMORY_FOLDER]:
         this.handleOpenMemoryFolder.bind(this),
+      [MEMORY_VIEW_COMMANDS.DELETE_MEMORY]:
+        this.handleDeleteMemory.bind(this),
     };
   }
 
@@ -115,6 +120,41 @@ export class MemoryViewMessageHandler extends BaseViewMessageHandler<
         error,
       );
     }
+  }
+
+  private async handleDeleteMemory(
+    message: unknown,
+    view: vscode.WebviewView | vscode.WebviewPanel,
+  ): Promise<void> {
+    await this.withValidatedMessage(
+      MemoryDeleteMessageSchema,
+      message,
+      'deleteMemory',
+      async ({ storagePath, displayPath }) => {
+        const confirm = await vscode.window.showWarningMessage(
+          `Delete "${displayPath}"?`,
+          { modal: true },
+          'Delete',
+        );
+
+        if (confirm !== 'Delete') {
+          return;
+        }
+
+        try {
+          const resolvedPath = resolveMemoryStoragePath(storagePath);
+          await StorageFS.delete(resolvedPath, { recursive: true });
+          // Refresh the memory list after deletion
+          await this.sendMemoryData(view.webview);
+        } catch (error) {
+          await showLoggedErrorMessage(
+            this.channel,
+            'Failed to delete memory',
+            error,
+          );
+        }
+      },
+    );
   }
 
   private async loadMemoryItems(): Promise<MemoryViewItem[]> {

--- a/src/memoryView/MemoryViewMessageHandler.ts
+++ b/src/memoryView/MemoryViewMessageHandler.ts
@@ -144,14 +144,15 @@ export class MemoryViewMessageHandler extends BaseViewMessageHandler<
         try {
           const resolvedPath = resolveMemoryStoragePath(storagePath);
           await StorageFS.delete(resolvedPath, { recursive: true });
-          // Refresh the memory list after deletion
-          await this.sendMemoryData(view.webview);
         } catch (error) {
           await showLoggedErrorMessage(
             this.channel,
             'Failed to delete memory',
             error,
           );
+        } finally {
+          // Always refresh the memory list to reflect current state
+          await this.sendMemoryData(view.webview);
         }
       },
     );

--- a/src/memoryView/index.html
+++ b/src/memoryView/index.html
@@ -78,12 +78,20 @@
       <div class="list-item memory-item">
         <div class="list-item-header">
           <div class="memory-path"></div>
-          <vscode-toolbar-button
-            class="open-memory-btn"
-            icon="go-to-file"
-            label="Open"
-            title="Open in editor"
-          ></vscode-toolbar-button>
+          <vscode-toolbar-container>
+            <vscode-toolbar-button
+              class="open-memory-btn"
+              icon="go-to-file"
+              label="Open"
+              title="Open in editor"
+            ></vscode-toolbar-button>
+            <vscode-toolbar-button
+              class="delete-memory-btn"
+              icon="trash"
+              label="Delete"
+              title="Delete this memory"
+            ></vscode-toolbar-button>
+          </vscode-toolbar-container>
         </div>
         <div class="text-secondary memory-meta"></div>
         <vscode-collapsible class="collapsible">

--- a/src/memoryView/modules/uiManagers/MemoryEventsManager.js
+++ b/src/memoryView/modules/uiManagers/MemoryEventsManager.js
@@ -66,6 +66,9 @@ export class MemoryEventsManager {
       const storagePath = target.dataset.path;
       if (command === COMMANDS.OPEN_MEMORY_FILE && storagePath) {
         vscode.postMessage({ command, storagePath });
+      } else if (command === COMMANDS.DELETE_MEMORY && storagePath) {
+        const displayPath = target.dataset.displayPath;
+        vscode.postMessage({ command, storagePath, displayPath });
       }
     };
 

--- a/src/memoryView/modules/uiManagers/MemoryEventsManager.js
+++ b/src/memoryView/modules/uiManagers/MemoryEventsManager.js
@@ -63,7 +63,7 @@ export class MemoryEventsManager {
       }
 
       const command = target.dataset.command;
-      const storagePath = target.dataset.path;
+      const storagePath = target.dataset.storagePath;
       if (command === COMMANDS.OPEN_MEMORY_FILE && storagePath) {
         vscode.postMessage({ command, storagePath });
       } else if (command === COMMANDS.DELETE_MEMORY && storagePath) {

--- a/src/memoryView/modules/uiManagers/MemoryRenderer.js
+++ b/src/memoryView/modules/uiManagers/MemoryRenderer.js
@@ -56,6 +56,11 @@ export class MemoryRenderer {
           command: COMMANDS.OPEN_MEMORY_FILE,
           path: item.storagePath,
         },
+        '.delete-memory-btn': {
+          command: COMMANDS.DELETE_MEMORY,
+          path: item.storagePath,
+          displayPath: item.displayPath,
+        },
       },
     });
 

--- a/src/memoryView/modules/uiManagers/MemoryRenderer.js
+++ b/src/memoryView/modules/uiManagers/MemoryRenderer.js
@@ -54,11 +54,11 @@ export class MemoryRenderer {
       dataset: {
         '.open-memory-btn': {
           command: COMMANDS.OPEN_MEMORY_FILE,
-          path: item.storagePath,
+          storagePath: item.storagePath,
         },
         '.delete-memory-btn': {
           command: COMMANDS.DELETE_MEMORY,
-          path: item.storagePath,
+          storagePath: item.storagePath,
           displayPath: item.displayPath,
         },
       },

--- a/src/webview/types/messages.ts
+++ b/src/webview/types/messages.ts
@@ -269,3 +269,10 @@ export const MemoryPathMessageSchema = z.object({
 });
 
 export type MemoryPathMessage = z.infer<typeof MemoryPathMessageSchema>;
+
+/** Memory delete message with display path for confirmation */
+export const MemoryDeleteMessageSchema = MemoryPathMessageSchema.extend({
+  displayPath: z.string().min(1),
+});
+
+export type MemoryDeleteMessage = z.infer<typeof MemoryDeleteMessageSchema>;


### PR DESCRIPTION
Add the ability to manually delete memory contents from the Memory View with delete buttons. Each memory item now has a trash icon button that, when clicked, shows a confirmation dialog before deleting the file.

Changes:
- Add DELETE_MEMORY command to MEMORY_VIEW_COMMANDS
- Add delete button with trash icon to memory item template
- Add MemoryDeleteMessageSchema for validation with displayPath
- Handle delete button clicks in MemoryEventsManager
- Implement handleDeleteMemory with confirmation dialog in message handler
- Auto-refresh memory list after successful deletion

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds end-to-end delete support for memory items in the Memory View.
> 
> - Introduces `DELETE_MEMORY` in `MEMORY_VIEW_COMMANDS` and wires it through UI → webview → extension
> - Renders a new trash button per item in `index.html`; `MemoryRenderer` sets `data-*` attributes for `storagePath`/`displayPath`
> - `MemoryEventsManager` posts `deleteMemory` messages on click
> - Adds `MemoryDeleteMessageSchema` (extends `MemoryPathMessageSchema`) with `displayPath` for confirmation text
> - Implements `handleDeleteMemory` in `MemoryViewMessageHandler`: validates message, shows modal confirm, deletes via `StorageFS.delete(..., { recursive: true })`, then refreshes with `UPDATE_MEMORY`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cd6a0c63e6bdebe6bcb5a970954d1bf3dfd6d59e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->