### PR TITLE
Improve user feedback rendering in tool responses

### DIFF
--- a/src/progressView/modules/formatters/logFormatters/toolFormatters.js
+++ b/src/progressView/modules/formatters/logFormatters/toolFormatters.js
@@ -68,8 +68,10 @@ export const formatToolUse = (normalizedPayload, logId, groupId, timestamp) => {
   // Determine display state: user feedback takes precedence over error styling
   const showAsError = normalizedToolLog.isError && !isUserFeedback;
 
-  // Use tool-specific icon
-  const iconClass = getToolIconClass(toolName, showAsError);
+  // Use appropriate icon: comment for user feedback, otherwise tool-specific
+  const iconClass = isUserFeedback
+    ? 'codicon-comment'
+    : getToolIconClass(toolName, showAsError);
 
   const toolElement = createToolElement(logId, groupId, timestamp, iconClass);
   if (!toolElement) return null;
@@ -111,19 +113,25 @@ export const formatToolUse = (normalizedPayload, logId, groupId, timestamp) => {
 
   // Note: File path is already in headerSummary, so we skip the Files section
 
-  // Show user feedback, error, or output (in priority order)
+  // Show output if present (primary result from tool)
+  if (outputText) {
+    sections.push(
+      buildToolUseSection('Output:', wrapInPre(outputText, 'tool-output-full')),
+    );
+  }
+
+  // Show error if present and not superseded by user feedback
+  if (errorText && !isUserFeedback) {
+    sections.push(buildToolUseSection('Error:', wrapInPre(errorText)));
+  }
+
+  // Show user instruction as supplementary note/warning if present
   if (isUserFeedback && userInstructionText) {
     sections.push(
       buildToolUseSection(
         'User Instruction:',
         wrapInPre(userInstructionText, 'tool-user-feedback'),
       ),
-    );
-  } else if (errorText) {
-    sections.push(buildToolUseSection('Error:', wrapInPre(errorText)));
-  } else if (outputText) {
-    sections.push(
-      buildToolUseSection('Output:', wrapInPre(outputText, 'tool-output-full')),
     );
   }
 

--- a/src/progressView/modules/formatters/logFormatters/toolFormatters.js
+++ b/src/progressView/modules/formatters/logFormatters/toolFormatters.js
@@ -55,18 +55,33 @@ export const formatToolUse = (normalizedPayload, logId, groupId, timestamp) => {
     return null;
   }
 
-  const { parsed, toolName, errorText, outputText, input } = normalizedToolLog;
+  const {
+    parsed,
+    toolName,
+    errorText,
+    outputText,
+    userInstructionText,
+    input,
+    isUserFeedback,
+  } = normalizedToolLog;
+
+  // Determine display state: user feedback takes precedence over error styling
+  const showAsError = normalizedToolLog.isError && !isUserFeedback;
 
   // Use tool-specific icon
-  const iconClass = getToolIconClass(toolName, normalizedToolLog.isError);
+  const iconClass = getToolIconClass(toolName, showAsError);
 
   const toolElement = createToolElement(logId, groupId, timestamp, iconClass);
   if (!toolElement) return null;
 
   const { element, headerLabel, iconElem, contentElem } = toolElement;
 
-  // Build title
-  const titlePrefix = normalizedToolLog.isError ? 'Tool Error' : 'Tool Use';
+  // Build title based on state
+  const titlePrefix = isUserFeedback
+    ? 'User Feedback'
+    : showAsError
+      ? 'Tool Error'
+      : 'Tool Use';
   const titleBase = toolName ? `${titlePrefix}: ${toolName}` : titlePrefix;
   const titleText = normalizedToolLog.headerSummary
     ? `${titleBase} — ${normalizedToolLog.headerSummary}`
@@ -76,8 +91,9 @@ export const formatToolUse = (normalizedPayload, logId, groupId, timestamp) => {
     headerLabel.textContent = titleText;
   }
 
-  // Icon already set in createToolElement; just toggle error state
-  element.classList.toggle('tool-use-error', normalizedToolLog.isError);
+  // Apply appropriate styling class
+  element.classList.toggle('tool-use-error', showAsError);
+  element.classList.toggle('tool-use-user-feedback', isUserFeedback);
 
   if (!contentElem) {
     return element;
@@ -95,8 +111,15 @@ export const formatToolUse = (normalizedPayload, logId, groupId, timestamp) => {
 
   // Note: File path is already in headerSummary, so we skip the Files section
 
-  // Show error or output
-  if (errorText) {
+  // Show user feedback, error, or output (in priority order)
+  if (isUserFeedback && userInstructionText) {
+    sections.push(
+      buildToolUseSection(
+        'User Instruction:',
+        wrapInPre(userInstructionText, 'tool-user-feedback'),
+      ),
+    );
+  } else if (errorText) {
     sections.push(buildToolUseSection('Error:', wrapInPre(errorText)));
   } else if (outputText) {
     sections.push(

--- a/src/progressView/modules/formatters/normalizers.js
+++ b/src/progressView/modules/formatters/normalizers.js
@@ -202,16 +202,26 @@ export const normalizeToolUseLog = (structured) => {
         ? parsed.tool.trim()
         : '';
 
+  // Detect user feedback: when userInstruction is present, this is user-provided
+  // guidance rather than a system error, even if isError is true
+  const userInstructionText =
+    (typeof parsed.userInstruction === 'string' &&
+      parsed.userInstruction.trim()) ||
+    '';
+  const isUserFeedback = userInstructionText.length > 0;
+
   return {
     parsed,
     toolName,
     errorText,
     outputText,
+    userInstructionText,
     input: parsed.input,
     isError: Boolean(
       parsed.isError || outputDetails.isError || errorText.length > 0,
     ),
-    headerSummary: summaryText || errorText,
+    isUserFeedback,
+    headerSummary: summaryText || (isUserFeedback ? '' : errorText),
   };
 };
 

--- a/src/progressView/styles/scratchpad.css
+++ b/src/progressView/styles/scratchpad.css
@@ -62,6 +62,24 @@
   word-break: break-word;
 }
 
+/* User feedback styling - distinct from errors */
+.tool-use-user-feedback > .details-summary .tool-use-title,
+.tool-use-user-feedback > .details-summary .codicon {
+  color: var(--vscode-textLink-foreground, #3794ff);
+}
+
+.tool-user-feedback {
+  white-space: pre-wrap;
+  word-break: break-word;
+  padding: var(--spacing-small);
+  background-color: var(
+    --vscode-inputValidation-infoBackground,
+    rgba(55, 148, 255, 0.1)
+  );
+  border-radius: var(--border-radius-small);
+  border-left: 3px solid var(--vscode-textLink-foreground, #3794ff);
+}
+
 .tool-output-full {
   white-space: pre-wrap;
   word-break: break-word;

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -737,7 +737,11 @@ export async function handleProgressViewToolEditApprovalAction(
         prompt: 'Optionally share why the change was rejected',
         placeHolder: 'Add guidance for the assistant (press Enter to skip)',
       });
-      userMessage = note?.trim();
+      // If user pressed Escape, cancel the rejection and keep waiting
+      if (note === undefined) {
+        return;
+      }
+      userMessage = note.trim();
     }
 
     entry.settle({


### PR DESCRIPTION
When a tool returns userInstruction (e.g., user rejection with a note), it was being rendered with error styling (red) even though it's user feedback, not an error. This change:

- Adds isUserFeedback detection in normalizeToolUseLog when userInstruction is present
- Renders user feedback with "User Feedback" title prefix instead of "Tool Error"
- Applies distinct blue styling (tool-use-user-feedback class) instead of error styling
- Shows user instruction in a styled "User Instruction" section

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Makes user-provided guidance render distinctly from errors in tool logs and adjusts rejection UX.
> 
> - **ProgressView formatting**: `normalizeToolUseLog` now detects `userInstruction` as `isUserFeedback`, propagates `userInstructionText`, and suppresses error text in `headerSummary` when feedback is present
> - **Rendering**: `formatToolUse` shows `User Feedback` title, uses `codicon-comment`, applies `tool-use-user-feedback` class, prioritizes `Output` over `Error`, hides errors for feedback, and adds a `User Instruction` section (`tool-user-feedback`)
> - **Styling**: Adds blue feedback styles in `scratchpad.css` for `.tool-use-user-feedback` and `.tool-user-feedback`, distinct from `.tool-use-error`
> - **Approval flow**: In `toolEditApproval.ts`, rejecting now cancels if the feedback input is dismissed (Escape), preventing unintended rejection
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d8a5d5da9634a639fbd55358dca6a15b907c070e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->