### PR TITLE
Add collapsible queue for follow-up messages

### DIFF
--- a/src/agent/toolUse/FollowUpQueue.ts
+++ b/src/agent/toolUse/FollowUpQueue.ts
@@ -58,4 +58,12 @@ export class FollowUpQueue {
     this.cancelWait();
     this.clear();
   }
+
+  /**
+   * Get a copy of all queued messages for display purposes.
+   * This doesn't modify the queue.
+   */
+  getAll(): string[] {
+    return [...this.queued];
+  }
 }

--- a/src/agent/toolUse/ToolUseFollowUpQueueManager.ts
+++ b/src/agent/toolUse/ToolUseFollowUpQueueManager.ts
@@ -67,4 +67,16 @@ export class ToolUseFollowUpQueue {
     );
     return drained;
   }
+
+  /**
+   * Get all queued follow-up messages for a stream without consuming them.
+   * Used for UI display purposes.
+   */
+  static getAll(streamId: StreamTabId): string[] {
+    const queue = this.queues.get(streamId);
+    if (!queue) {
+      return [];
+    }
+    return queue.getAll();
+  }
 }

--- a/src/commands/agent/followUpCommand.ts
+++ b/src/commands/agent/followUpCommand.ts
@@ -8,7 +8,6 @@ import {
   sendFollowUp,
   type SendFollowUpResult,
 } from '@agent/toolUse/ToolUseFollowUp';
-import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
 import { retrieveSessionResumeData } from '@agent/runtime/SessionResumeRetrieval';
 import { hasPersistedFlowRecord } from '@agent/storage/detectWaitingStreams';
 import { STREAM_STATUS } from '@common/constants/streamStatus';
@@ -19,22 +18,10 @@ import {
 } from '@frontend/ui/messageUtils';
 import { AgentLogger } from '@logger/AgentLogger';
 import { ProgressViewProvider } from '@progressView/ProgressViewProvider';
+import { updateQueuedFollowUpsUI } from '@progressView/utils/updateQueuedFollowUps';
 import { ResumeAgentResultSchema } from './resumeCommand';
 
 const logger = new AgentLogger('followUpCommand');
-
-/**
- * Update the queued follow-ups display in the webview.
- */
-function updateQueuedFollowUpsUI(streamId: StreamTabId): void {
-  const provider = ProgressViewProvider.getInstance();
-  if (!provider) {
-    return;
-  }
-
-  const messages = ToolUseFollowUpQueue.getAll(streamId);
-  provider.webviewUpdater.updateQueuedFollowUps(streamId, messages);
-}
 
 // Track in-flight lazy detection checks to prevent race conditions
 const inFlightDetections = new Set<StreamTabId>();

--- a/src/commands/agent/followUpCommand.ts
+++ b/src/commands/agent/followUpCommand.ts
@@ -8,6 +8,7 @@ import {
   sendFollowUp,
   type SendFollowUpResult,
 } from '@agent/toolUse/ToolUseFollowUp';
+import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
 import { retrieveSessionResumeData } from '@agent/runtime/SessionResumeRetrieval';
 import { hasPersistedFlowRecord } from '@agent/storage/detectWaitingStreams';
 import { STREAM_STATUS } from '@common/constants/streamStatus';
@@ -21,6 +22,19 @@ import { ProgressViewProvider } from '@progressView/ProgressViewProvider';
 import { ResumeAgentResultSchema } from './resumeCommand';
 
 const logger = new AgentLogger('followUpCommand');
+
+/**
+ * Update the queued follow-ups display in the webview.
+ */
+function updateQueuedFollowUpsUI(streamId: StreamTabId): void {
+  const provider = ProgressViewProvider.getInstance();
+  if (!provider) {
+    return;
+  }
+
+  const messages = ToolUseFollowUpQueue.getAll(streamId);
+  provider.webviewUpdater.updateQueuedFollowUps(streamId, messages);
+}
 
 // Track in-flight lazy detection checks to prevent race conditions
 const inFlightDetections = new Set<StreamTabId>();
@@ -175,8 +189,12 @@ async function handleFollowUpResult(
   switch (result.status) {
     case 'sent':
       // Silent success - no notification needed
+      // Also update queue display (message was sent, queue may be empty now)
+      updateQueuedFollowUpsUI(streamId);
       break;
     case 'queued':
+      // Update the queued follow-ups display
+      updateQueuedFollowUpsUI(streamId);
       if (result.reason === 'waiting') {
         // Auto-resume WAITING tool-use sessions
         const resumed = await tryAutoResume(streamId);

--- a/src/commands/agent/resumeCommand.ts
+++ b/src/commands/agent/resumeCommand.ts
@@ -17,6 +17,7 @@ import type { StreamTabId } from '@agent/types/IdentifierTypes';
 import type { ToolUseSessionSnapshot } from '@agent/implementations/flows/tooluse/ToolUseSessionTypes';
 import { STREAM_STATUS } from '@common/constants/streamStatus';
 import { logErrorMessage } from '@common/errors/errorHandlingUtils';
+import { ProgressViewProvider } from '@progressView/ProgressViewProvider';
 import { getToolUsePersistenceEnabled } from '@utils/config';
 
 // Type imports
@@ -44,6 +45,19 @@ interface ResumeAgentCommandPayload {
 // ============================================================================
 
 const CHANNEL = 'resumeCommand';
+
+/**
+ * Update the queued follow-ups display in the webview.
+ */
+function updateQueuedFollowUpsUI(streamId: StreamTabId): void {
+  const provider = ProgressViewProvider.getInstance();
+  if (!provider) {
+    return;
+  }
+
+  const messages = ToolUseFollowUpQueue.getAll(streamId);
+  provider.webviewUpdater.updateQueuedFollowUps(streamId, messages);
+}
 
 function formatLostFollowUpSuffix(count: number): string {
   if (count === 0) {
@@ -86,6 +100,8 @@ async function resumeFromSnapshot(
   try {
     // Drain queued follow-ups before starting the flow
     queuedFollowUps = ToolUseFollowUpQueue.drain(streamId);
+    // Update UI to show queue is now empty (messages are being processed)
+    updateQueuedFollowUpsUI(streamId);
 
     // Resume using flow-first execution
     await resumeToolUseFromSnapshot(snapshot, (session) => {

--- a/src/commands/agent/resumeCommand.ts
+++ b/src/commands/agent/resumeCommand.ts
@@ -17,7 +17,7 @@ import type { StreamTabId } from '@agent/types/IdentifierTypes';
 import type { ToolUseSessionSnapshot } from '@agent/implementations/flows/tooluse/ToolUseSessionTypes';
 import { STREAM_STATUS } from '@common/constants/streamStatus';
 import { logErrorMessage } from '@common/errors/errorHandlingUtils';
-import { ProgressViewProvider } from '@progressView/ProgressViewProvider';
+import { updateQueuedFollowUpsUI } from '@progressView/utils/updateQueuedFollowUps';
 import { getToolUsePersistenceEnabled } from '@utils/config';
 
 // Type imports
@@ -45,19 +45,6 @@ interface ResumeAgentCommandPayload {
 // ============================================================================
 
 const CHANNEL = 'resumeCommand';
-
-/**
- * Update the queued follow-ups display in the webview.
- */
-function updateQueuedFollowUpsUI(streamId: StreamTabId): void {
-  const provider = ProgressViewProvider.getInstance();
-  if (!provider) {
-    return;
-  }
-
-  const messages = ToolUseFollowUpQueue.getAll(streamId);
-  provider.webviewUpdater.updateQueuedFollowUps(streamId, messages);
-}
 
 function formatLostFollowUpSuffix(count: number): string {
   if (count === 0) {
@@ -105,14 +92,21 @@ async function resumeFromSnapshot(
 
     // Resume using flow-first execution
     await resumeToolUseFromSnapshot(snapshot, (session) => {
-      // Append any follow-up messages to the session
+      // Combine all follow-ups into a single message
+      const allFollowUps: string[] = [];
+
+      // Add explicit follow-up first if provided
       if (followUp !== undefined) {
-        session.appendFollowUp(followUp);
+        allFollowUps.push(followUp);
       }
 
-      // Append any queued follow-ups
-      for (const queuedFollowUp of queuedFollowUps) {
-        session.appendFollowUp(queuedFollowUp);
+      // Add queued follow-ups
+      allFollowUps.push(...queuedFollowUps);
+
+      // Send as single concatenated message
+      if (allFollowUps.length > 0) {
+        const combinedMessage = allFollowUps.join('\n\n');
+        session.appendFollowUp(combinedMessage);
       }
     });
 

--- a/src/common/webview/commands.js
+++ b/src/common/webview/commands.js
@@ -178,6 +178,9 @@ export const PROGRESS_VIEW_COMMANDS = {
   // Todo List
   UPDATE_TODOS: 'updateTodos',
 
+  // Queued follow-ups
+  UPDATE_QUEUED_FOLLOW_UPS: 'updateQueuedFollowUps',
+
   // Status and files
   UPDATE_STATUS: 'updateStatus',
   UPDATE_STREAM_STATUS: 'updateStreamStatus', // Update single stream's status in tabs

--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -204,6 +204,15 @@
             <span id="runSummary" class="run-summary"></span>
           </div>
           <div id="followUpContainer" class="follow-up-container">
+            <vscode-collapsible
+              id="queuedFollowUpsCollapsible"
+              title="Queued Messages"
+              class="queued-follow-ups-collapsible"
+              open
+              hidden
+            >
+              <div id="queuedFollowUpsList" class="queued-follow-ups-list"></div>
+            </vscode-collapsible>
             <vscode-textarea
               id="followUpInput"
               placeholder="Send follow-up message"
@@ -503,6 +512,12 @@
                   >Yolo</vscode-toolbar-button
                 >
               </vscode-toolbar-container>
+            </div>
+          </template>
+          <template id="queuedFollowUpTemplate">
+            <div class="queued-follow-up-item">
+              <i class="codicon codicon-comment queued-follow-up-icon"></i>
+              <span class="queued-follow-up-text"></span>
             </div>
           </template>
         </div>

--- a/src/progressView/managers/WebviewUpdater.ts
+++ b/src/progressView/managers/WebviewUpdater.ts
@@ -362,6 +362,17 @@ export class WebviewUpdater {
   }
 
   /**
+   * Update the queued follow-ups display for a stream
+   */
+  updateQueuedFollowUps(stream: StreamTabId, messages: string[]): void {
+    this.sendMessage({
+      command: COMMANDS.UPDATE_QUEUED_FOLLOW_UPS,
+      stream,
+      messages,
+    });
+  }
+
+  /**
    * Update stream metadata and theme for the webview.
    * Returns the active stream after applying the update.
    *

--- a/src/progressView/modules/constants.js
+++ b/src/progressView/modules/constants.js
@@ -48,6 +48,8 @@ export const ELEMENT_IDS = {
   OPEN_TASK_STORAGE_BTN: 'openTaskStorageBtn',
   FOLLOW_UP_CONTAINER: 'followUpContainer',
   FOLLOW_UP_INPUT: 'followUpInput',
+  QUEUED_FOLLOW_UPS_COLLAPSIBLE: 'queuedFollowUpsCollapsible',
+  QUEUED_FOLLOW_UPS_LIST: 'queuedFollowUpsList',
   RECORD_FOLLOW_UP_BTN: 'recordFollowUpBtn',
   RESET_APPROVAL_BYPASS_BTN: 'resetApprovalBypassBtn',
   POLISH_FOLLOW_UP_BTN: 'polishFollowUpBtn',

--- a/src/progressView/modules/domHandlers.js
+++ b/src/progressView/modules/domHandlers.js
@@ -14,6 +14,7 @@ import { ApprovalRequests } from './uiManagers/ApprovalRequests.js';
 import { RetryRequests } from './uiManagers/RetryRequests.js';
 import { Toolbar } from './uiManagers/Toolbar.js';
 import { TodoList } from './uiManagers/TodoList.js';
+import { QueuedFollowUps } from './uiManagers/QueuedFollowUps.js';
 import { UsageSummary } from './usageManagers.js';
 import { BaseDomHandler } from '@common/BaseDomHandler.js';
 import { vscode } from '@common/webviewContext.js';
@@ -41,6 +42,7 @@ class ProgressViewDomHandler extends BaseDomHandler {
       approvalRequests: new ApprovalRequests(),
       retryRequests: new RetryRequests(),
       todoList: new TodoList(),
+      queuedFollowUps: new QueuedFollowUps(),
     });
   }
 }

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -236,6 +236,8 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       [COMMANDS.RECORDING_STOPPED]: this.handleRecordingStopped.bind(this),
       [COMMANDS.RECORDING_ERROR]: this.handleRecordingError.bind(this),
       [COMMANDS.UPDATE_TODOS]: this.handleUpdateTodos.bind(this),
+      [COMMANDS.UPDATE_QUEUED_FOLLOW_UPS]:
+        this.handleUpdateQueuedFollowUps.bind(this),
     };
   }
 
@@ -339,17 +341,22 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       dom.instructionPanel.hide();
       dom.runSelector.clear();
       dom.todoList.clear();
+      dom.queuedFollowUps.clear();
       dom.fileList.clear();
       state.clearRunInstructions();
       state.clearAllActiveRuns();
       state.clearAllPendingInstructions();
       state.clearAllTodos();
+      state.clearAllQueuedFollowUps();
     } else {
       const streamStatus = state.streamStatuses.get(message.activeStream);
       dom.status.update(streamStatus || STREAM_STATUS.STOPPED);
       // Refresh todos for the active stream
       const todos = state.getTodos(message.activeStream);
       dom.todoList.update(todos ?? []);
+      // Refresh queued follow-ups for the active stream
+      const queuedFollowUps = state.getQueuedFollowUps(message.activeStream);
+      dom.queuedFollowUps.update(queuedFollowUps ?? []);
       this._focusFollowUpIfWaiting(streamStatus);
     }
 
@@ -927,6 +934,7 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       state.clearRunMissingOutputs(message.stream);
       state.clearRunUsage(message.stream);
       state.clearTodos(message.stream);
+      state.clearQueuedFollowUps(message.stream);
       state.clearContextState(message.stream);
       if (deletingActiveStream) {
         state.activeStream = '';
@@ -935,6 +943,7 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
         dom.instructionPanel.hide();
         dom.runSelector.clear();
         dom.todoList.clear();
+        dom.queuedFollowUps.clear();
         dom.fileList.clear();
         dom.usageSummary?.clearContextDisplay?.();
       }
@@ -955,9 +964,11 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     state.clearRunMissingOutputs();
     state.clearAllActiveRuns();
     state.clearAllTodos();
+    state.clearAllQueuedFollowUps();
     state.clearContextState(); // Clear all context state entries
     dom.runSelector.clear();
     dom.todoList.clear();
+    dom.queuedFollowUps.clear();
     dom.fileList.clear();
     dom.usageSummary?.clearContextDisplay?.();
     this._updatePlaceholderVisibility();
@@ -1008,6 +1019,26 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     // Only update DOM if this is the active stream
     if (stream === state.activeStream) {
       dom.todoList.update(todos);
+    }
+  }
+
+  /**
+   * Handle UPDATE_QUEUED_FOLLOW_UPS command from extension host.
+   * Updates the queued follow-ups display for the specified stream.
+   * @param {{ stream: string, messages: string[] }} message
+   */
+  handleUpdateQueuedFollowUps(message) {
+    const { stream, messages } = message;
+    if (!stream || !Array.isArray(messages)) {
+      return;
+    }
+
+    // Always store queued messages in state for persistence
+    state.setQueuedFollowUps(stream, messages);
+
+    // Only update DOM if this is the active stream
+    if (stream === state.activeStream) {
+      dom.queuedFollowUps.update(messages);
     }
   }
 }

--- a/src/progressView/modules/progressViewState.js
+++ b/src/progressView/modules/progressViewState.js
@@ -283,6 +283,8 @@ export class ProgressViewState {
     this.contextState = new Map();
     // Todo storage by stream ID
     this.streamTodos = new Map();
+    // Queued follow-ups storage by stream ID
+    this.streamQueuedFollowUps = new Map();
 
     // Initialize managers
     this.taskGroups = new TaskGroups();
@@ -767,6 +769,51 @@ export class ProgressViewState {
    */
   clearAllTodos() {
     this.streamTodos.clear();
+  }
+
+  /**
+   * Set queued follow-ups for a stream.
+   * @param {string} streamId - The stream ID
+   * @param {string[]} messages - The queued message texts
+   */
+  setQueuedFollowUps(streamId, messages) {
+    const targetStream = this._resolveStreamId(streamId);
+    if (targetStream == null) {
+      return;
+    }
+    this.streamQueuedFollowUps.set(targetStream, messages ?? []);
+  }
+
+  /**
+   * Get queued follow-ups for a stream.
+   * @param {string} streamId - The stream ID
+   * @returns {string[]|null}
+   */
+  getQueuedFollowUps(streamId) {
+    const targetStream = this._resolveStreamId(streamId);
+    if (targetStream == null) {
+      return null;
+    }
+    return this.streamQueuedFollowUps.get(targetStream) || null;
+  }
+
+  /**
+   * Clear queued follow-ups for a specific stream.
+   * @param {string} streamId - The stream ID
+   */
+  clearQueuedFollowUps(streamId) {
+    const targetStream = this._resolveStreamId(streamId);
+    if (targetStream == null) {
+      return;
+    }
+    this.streamQueuedFollowUps.delete(targetStream);
+  }
+
+  /**
+   * Clear all queued follow-ups across all streams.
+   */
+  clearAllQueuedFollowUps() {
+    this.streamQueuedFollowUps.clear();
   }
 }
 

--- a/src/progressView/modules/uiManagers/QueuedFollowUps.js
+++ b/src/progressView/modules/uiManagers/QueuedFollowUps.js
@@ -3,7 +3,6 @@ import { ELEMENT_IDS } from '../constants.js';
 
 // Local imports - shared helpers
 import { safeGetElementById, setVisibilityState } from '@common/domUtils.js';
-import { escapeHtml } from '@common/htmlEncoding.js';
 
 /**
  * Manages the queued follow-ups display in the progress view.
@@ -38,6 +37,7 @@ export class QueuedFollowUps {
 
   /**
    * Update the queued follow-ups display.
+   * Shows all queued messages concatenated into a single preview.
    * @param {string[]} messages - The queued message texts
    */
   update(messages) {
@@ -53,20 +53,18 @@ export class QueuedFollowUps {
       return;
     }
 
+    // Concatenate all messages with newlines
+    const combinedText = this._currentMessages.join('\n\n');
+
     // Update the title to show count
     const count = this._currentMessages.length;
-    elements.container.setAttribute(
-      'title',
-      `Queued Messages (${count})`,
-    );
+    const suffix = count === 1 ? '' : ` (${count} combined)`;
+    elements.container.setAttribute('title', `Queued Message${suffix}`);
 
-    // Clear and rebuild the list
+    // Clear and show single combined message
     elements.list.innerHTML = '';
-
-    for (const text of this._currentMessages) {
-      const item = this._createMessageItem(text);
-      elements.list.appendChild(item);
-    }
+    const item = this._createMessageItem(combinedText);
+    elements.list.appendChild(item);
 
     this.show();
   }

--- a/src/progressView/modules/uiManagers/QueuedFollowUps.js
+++ b/src/progressView/modules/uiManagers/QueuedFollowUps.js
@@ -1,0 +1,164 @@
+// Local imports - progress view
+import { ELEMENT_IDS } from '../constants.js';
+
+// Local imports - shared helpers
+import { safeGetElementById, setVisibilityState } from '@common/domUtils.js';
+import { escapeHtml } from '@common/htmlEncoding.js';
+
+/**
+ * Manages the queued follow-ups display in the progress view.
+ * Shows pending messages that will be sent when the agent resumes.
+ */
+export class QueuedFollowUps {
+  constructor() {
+    this._elements = null;
+    this._currentMessages = [];
+  }
+
+  /**
+   * Lazily get DOM elements.
+   * @returns {{container: HTMLElement, list: HTMLElement}|null}
+   */
+  _getElements() {
+    if (!this._elements) {
+      const container = safeGetElementById(
+        ELEMENT_IDS.QUEUED_FOLLOW_UPS_COLLAPSIBLE,
+      );
+      const list = safeGetElementById(ELEMENT_IDS.QUEUED_FOLLOW_UPS_LIST);
+
+      if (!container || !list) {
+        return null;
+      }
+
+      this._elements = { container, list };
+    }
+
+    return this._elements;
+  }
+
+  /**
+   * Update the queued follow-ups display.
+   * @param {string[]} messages - The queued message texts
+   */
+  update(messages) {
+    const elements = this._getElements();
+    if (!elements) {
+      return;
+    }
+
+    this._currentMessages = messages ?? [];
+
+    if (this._currentMessages.length === 0) {
+      this.hide();
+      return;
+    }
+
+    // Update the title to show count
+    const count = this._currentMessages.length;
+    elements.container.setAttribute(
+      'title',
+      `Queued Messages (${count})`,
+    );
+
+    // Clear and rebuild the list
+    elements.list.innerHTML = '';
+
+    for (const text of this._currentMessages) {
+      const item = this._createMessageItem(text);
+      elements.list.appendChild(item);
+    }
+
+    this.show();
+  }
+
+  /**
+   * Create a DOM element for a single queued message.
+   * @param {string} text - The message text
+   * @returns {HTMLElement}
+   */
+  _createMessageItem(text) {
+    const template = document.getElementById('queuedFollowUpTemplate');
+    if (template) {
+      const clone = template.content.cloneNode(true);
+      const textEl = clone.querySelector('.queued-follow-up-text');
+      if (textEl) {
+        // Truncate long messages for display
+        const displayText =
+          text.length > 200 ? text.substring(0, 200) + '...' : text;
+        textEl.textContent = displayText;
+        textEl.title = text; // Full text in tooltip
+      }
+      return clone.firstElementChild ?? this._createFallbackItem(text);
+    }
+
+    return this._createFallbackItem(text);
+  }
+
+  /**
+   * Create a fallback DOM element if template is not available.
+   * @param {string} text - The message text
+   * @returns {HTMLElement}
+   */
+  _createFallbackItem(text) {
+    const item = document.createElement('div');
+    item.className = 'queued-follow-up-item';
+
+    const icon = document.createElement('i');
+    icon.className = 'codicon codicon-comment queued-follow-up-icon';
+    item.appendChild(icon);
+
+    const content = document.createElement('span');
+    content.className = 'queued-follow-up-text';
+    const displayText =
+      text.length > 200 ? text.substring(0, 200) + '...' : text;
+    content.textContent = displayText;
+    content.title = text;
+    item.appendChild(content);
+
+    return item;
+  }
+
+  /**
+   * Show the queued follow-ups container (vscode-collapsible).
+   */
+  show() {
+    const elements = this._getElements();
+    if (!elements) {
+      return;
+    }
+
+    setVisibilityState(elements.container, true);
+  }
+
+  /**
+   * Hide the queued follow-ups container (vscode-collapsible).
+   */
+  hide() {
+    const elements = this._getElements();
+    if (!elements) {
+      return;
+    }
+
+    setVisibilityState(elements.container, false);
+  }
+
+  /**
+   * Clear the queued follow-ups list.
+   */
+  clear() {
+    this._currentMessages = [];
+    const elements = this._getElements();
+    if (elements) {
+      elements.list.innerHTML = '';
+    }
+    this.hide();
+  }
+
+  /**
+   * Get the current queued messages.
+   * @returns {string[]}
+   */
+  getMessages() {
+    return this._currentMessages;
+  }
+}

--- a/src/progressView/styles/index.css
+++ b/src/progressView/styles/index.css
@@ -28,3 +28,4 @@
 @import './approval-requests.css';
 @import './retry-requests.css';
 @import './todo-list.css';
+@import './queued-follow-ups.css';

--- a/src/progressView/styles/queued-follow-ups.css
+++ b/src/progressView/styles/queued-follow-ups.css
@@ -1,0 +1,55 @@
+/**
+ * Queued follow-ups styles for the ProgressView
+ * Shows pending messages that will be sent when the agent resumes
+ */
+
+/* Collapsible container styling */
+.queued-follow-ups-collapsible {
+  margin-bottom: var(--spacing-small);
+  border-radius: var(--radius);
+  background-color: var(--vscode-inputValidation-infoBackground);
+  border: 1px solid var(--vscode-inputValidation-infoBorder);
+}
+
+/* Override vscode-collapsible header padding */
+.queued-follow-ups-collapsible::part(header) {
+  padding: var(--spacing-small) var(--spacing-medium);
+  font-weight: 500;
+}
+
+.queued-follow-ups-collapsible::part(body) {
+  padding: 0 var(--spacing-medium) var(--spacing-small);
+}
+
+.queued-follow-ups-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-tiny);
+}
+
+.queued-follow-up-item {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--spacing-small);
+  padding: var(--spacing-tiny) var(--spacing-small);
+  font-size: var(--font-size);
+  line-height: 1.4;
+  background-color: var(--vscode-editor-background);
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border);
+}
+
+.queued-follow-up-icon {
+  flex-shrink: 0;
+  font-size: var(--font-size-icon-sm);
+  line-height: 1.4;
+  margin-top: var(--border-thin);
+  color: var(--vscode-inputValidation-infoBorder);
+}
+
+.queued-follow-up-text {
+  flex: 1;
+  word-break: break-word;
+  white-space: pre-wrap;
+  color: var(--color-text);
+}

--- a/src/progressView/utils/updateQueuedFollowUps.ts
+++ b/src/progressView/utils/updateQueuedFollowUps.ts
@@ -1,0 +1,22 @@
+/**
+ * Utility for updating the queued follow-ups display in the webview.
+ */
+
+import type { StreamTabId } from '@agent/types/IdentifierTypes';
+import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
+import { ProgressViewProvider } from '@progressView/ProgressViewProvider';
+
+/**
+ * Update the queued follow-ups display in the webview.
+ * If the webview is not available, this is a no-op (the queue state
+ * is maintained in ToolUseFollowUpQueue and will be sent on view init).
+ */
+export function updateQueuedFollowUpsUI(streamId: StreamTabId): void {
+  const provider = ProgressViewProvider.getInstance();
+  if (!provider) {
+    return;
+  }
+
+  const messages = ToolUseFollowUpQueue.getAll(streamId);
+  provider.webviewUpdater.updateQueuedFollowUps(streamId, messages);
+}


### PR DESCRIPTION
When follow-up messages are queued (during WAITING or RESUMING state), they are now displayed in a collapsible VS Code element above the follow-up input textarea. This provides clear visibility of pending messages before they are sent to the message list.

- Add UPDATE_QUEUED_FOLLOW_UPS command for webview updates
- Add QueuedFollowUps UI manager with collapsible display
- Add message handler and state management for queued messages
- Update webview when messages are queued or drained
- Add CSS styling with info-themed collapsible container

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Provides clear visibility of pending follow-ups during WAITING/RESUMING and keeps UI in sync with queue state.
> 
> - Adds `QueuedFollowUps` UI manager, HTML template, and CSS; new collapsible shown above `followUpInput`
> - Introduces `UPDATE_QUEUED_FOLLOW_UPS` webview command and `webviewUpdater.updateQueuedFollowUps`; message handler and `ProgressViewState` store queued messages; cleared on stream switches/deletes
> - Agent: adds `getAll()` to `FollowUpQueue` and `ToolUseFollowUpQueue.getAll`; new `updateQueuedFollowUpsUI` util; `followUpCommand`/`resumeCommand` call it when messages are queued/drained
> - Resume flow now concatenates explicit + queued follow-ups into a single message and drains the queue before starting
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 399ea45fc8329c019984c892b83f3a5618731ea5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->