### PR TITLE
Resume OpenAI memory tool flow from persistence

### DIFF
--- a/src/tools/TextEditorTool.ts
+++ b/src/tools/TextEditorTool.ts
@@ -41,7 +41,7 @@ export const TextEditorInputSchema = z.strictObject({
   command: z.enum(['view', 'create', 'str_replace', 'insert', 'undo_edit']),
   path: z.string(),
   file_text: z.string().nullish(),
-  view_range: z.tuple([z.number(), z.number()]).nullish(),
+  view_range: z.array(z.number()).length(2).nullish(),
   old_str: z.string().nullish(),
   new_str: z.string().nullish(),
   insert_line: z.number().nullish(),
@@ -217,7 +217,7 @@ export class TextEditorTool extends defineTool({
    */
   private async view(
     filePath: string,
-    viewRange?: [number, number],
+    viewRange?: number[],
   ): Promise<ToolResult> {
     try {
       // Check if the path is a directory

--- a/src/tools/memory/MemoryTool.ts
+++ b/src/tools/memory/MemoryTool.ts
@@ -35,7 +35,8 @@ const MemoryToolInputSchema = z.strictObject({
   path: z.string().nullish(),
   file_text: z.string().nullish(),
   view_range: z
-    .tuple([z.int().min(1), z.int().min(1)])
+    .array(z.int().min(1))
+    .length(2)
     .refine(([start, end]) => end >= start, {
       error: 'view_range[1] must be greater than or equal to view_range[0]',
     })
@@ -138,7 +139,7 @@ export class MemoryTool extends defineTool({
 
   private async view(
     inputPath: string,
-    viewRange?: [number, number],
+    viewRange?: number[],
   ): Promise<ToolResult> {
     const resolvedPath = this.resolveMemoryPath(inputPath);
     const exists = await StorageFS.exists(resolvedPath);


### PR DESCRIPTION
OpenAI's API requires array schemas to have an `items` property. The z.tuple() type generates prefixItems without items, causing HTTP 400 errors. Changed to z.array().length(2) which produces compatible JSON Schema.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures OpenAI-compatible JSON Schema for text/memory tools by changing `view_range` to a fixed-length array and aligning method types.
> 
> - Replace `z.tuple` with `z.array(...).length(2)` for `view_range` in `TextEditorTool` and `MemoryTool`; keep existing validation/refinement in memory tool
> - Update `view()` parameter types from `[number, number]` to `number[]` and adjust in-file validations; functional behavior otherwise unchanged
> - Generates JSON Schema with `items` to prevent API 400s when calling OpenAI
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e7ca235af59ea8c92b24ff8a6ad7edcdc3db0457. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->