### PR TITLE
Fix follow-up message after page reload

### DIFF
--- a/src/logger/AgentLogger.ts
+++ b/src/logger/AgentLogger.ts
@@ -405,11 +405,14 @@ export class AgentLogger {
     };
     // Use info level to ensure message reaches progress view (debug is filtered)
     // The CONTEXT_STATE message type triggers UI update without cluttering logs
-    this.info(`Context: ${inputTokens}/${contextWindow} tokens (${utilizationPercent.toFixed(1)}%)`, {
-      groupId,
-      messageType: MESSAGE_TYPES.CONTEXT_STATE,
-      data,
-    });
+    this.info(
+      `Context: ${inputTokens}/${contextWindow} tokens (${utilizationPercent.toFixed(1)}%)`,
+      {
+        groupId,
+        messageType: MESSAGE_TYPES.CONTEXT_STATE,
+        data,
+      },
+    );
   }
 
   /**

--- a/src/memoryView/MemoryViewMessageHandler.ts
+++ b/src/memoryView/MemoryViewMessageHandler.ts
@@ -60,8 +60,7 @@ export class MemoryViewMessageHandler extends BaseViewMessageHandler<
         this.handleOpenMemoryFile.bind(this),
       [MEMORY_VIEW_COMMANDS.OPEN_MEMORY_FOLDER]:
         this.handleOpenMemoryFolder.bind(this),
-      [MEMORY_VIEW_COMMANDS.DELETE_MEMORY]:
-        this.handleDeleteMemory.bind(this),
+      [MEMORY_VIEW_COMMANDS.DELETE_MEMORY]: this.handleDeleteMemory.bind(this),
     };
   }
 

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -58,7 +58,6 @@ export class ProgressViewProvider
    */
   private _pendingUpdateOptions: { forceRebuild: boolean } | null = null;
   private _hasResolved = false;
-  private _lastRenderedStream = ''; // Track last rendered stream for switch detection
   private readonly logger: AgentLogger;
   private readonly pendingApprovalPrompts = new Map<
     string,
@@ -135,7 +134,7 @@ export class ProgressViewProvider
     super.cleanupView();
     this._webviewReady = false;
     this._pendingUpdateOptions = null;
-    this._lastRenderedStream = '';
+    this.state.clearRenderedStreamTracking();
   }
 
   public resolveWebviewView(webviewView: vscode.WebviewView): void {
@@ -147,8 +146,8 @@ export class ProgressViewProvider
 
     this._webviewReady = false;
     this._pendingUpdateOptions = null;
-    // Clear last rendered stream to force rebuild - DOM state is stale after resolve
-    this._lastRenderedStream = '';
+    // Clear rendered stream tracking to force rebuild - DOM state is stale after resolve
+    this.state.clearRenderedStreamTracking();
     webviewView.webview.options = {
       enableScripts: true,
       enableCommandUris: true,
@@ -210,20 +209,16 @@ export class ProgressViewProvider
       theme,
     );
 
-    // Determine if full DOM rebuild is needed.
-    // forceRebuild has tri-state behavior:
-    // - true: Always rebuild (e.g., after state.load(), data deletion)
-    // - false: Always use incremental update (caller explicitly knows content unchanged)
-    // - undefined: Auto-detect based on stream switch or first render
-    const isStreamSwitch = this._lastRenderedStream !== activeStream;
+    // Use state as single source of truth for stream switch detection
+    const isStreamSwitch = this.state.isStreamSwitch(activeStream);
     const shouldForceRebuild = options?.forceRebuild ?? isStreamSwitch;
 
     this.eventHandler.refreshStreamSurface(activeStream || '', {
       forceRebuild: shouldForceRebuild,
     });
 
-    // Update tracking after refresh
-    this._lastRenderedStream = activeStream;
+    // Mark stream as rendered for future switch detection
+    this.state.markStreamRendered(activeStream);
     this._pendingUpdateOptions = null;
   }
 

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -104,7 +104,8 @@ export class ProgressEventHandler {
         const { stream, session, isRemote, hasMultipleOutputs } = payload;
         if (!stream) return;
 
-        const isStreamSwitch = this.state.activeStream !== stream;
+        // Use state's single source of truth for stream switch detection
+        const isStreamSwitch = this.state.isStreamSwitch(stream);
 
         await this.state.streamTabs.ensureStream(stream);
         this.state.updateStreamHints(stream, {
@@ -148,6 +149,8 @@ export class ProgressEventHandler {
             updateInstruction: false,
             forceRebuild: isStreamSwitch,
           });
+          // Mark stream as rendered for future switch detection
+          this.state.markStreamRendered(stream);
           this.sendInstructionUpdate(stream, activeRunId);
         }
       },
@@ -581,7 +584,7 @@ export class ProgressEventHandler {
     const { updateInstruction = true, forceRebuild = false } = options;
 
     if (!stream) {
-      this.webviewUpdater.updateLogContent('', [], []);
+      this.webviewUpdater.updateLogContent('', [], [], undefined, true);
       this.webviewUpdater.updateFiles('', { reset: true });
       this.webviewUpdater.updateMissingOutputs('', { reset: true });
       this.webviewUpdater.updateUsage('', {});
@@ -627,7 +630,7 @@ export class ProgressEventHandler {
         runUsage: usageByRun,
         runFiles: filesByRun,
       },
-      { forceRebuild },
+      forceRebuild,
     );
 
     // Note: Files are already included in UPDATE_LOGS (runFiles) and handled
@@ -827,11 +830,12 @@ export class ProgressEventHandler {
       // Force rebuild to clear any previous stream's content. The new task
       // group must be added to state BEFORE this call (in TaskGroupEvents)
       // so UPDATE_LOGS includes it and the frontend renders it correctly.
-      // Use the returned runId to avoid duplicate resolveRunId call.
       const activeRunId = this.refreshStreamSurface(stream, {
         updateInstruction: false,
         forceRebuild: true,
       });
+      // Mark stream as rendered for future switch detection
+      this.state.markStreamRendered(stream);
       this.sendInstructionUpdate(stream, activeRunId);
     }
   }

--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -211,7 +211,10 @@
               open
               hidden
             >
-              <div id="queuedFollowUpsList" class="queued-follow-ups-list"></div>
+              <div
+                id="queuedFollowUpsList"
+                class="queued-follow-ups-list"
+              ></div>
             </vscode-collapsible>
             <vscode-textarea
               id="followUpInput"

--- a/src/progressView/managers/WebviewUpdater.ts
+++ b/src/progressView/managers/WebviewUpdater.ts
@@ -96,13 +96,10 @@ export class WebviewUpdater {
   }
 
   /**
-   * Update log content for a specific stream
-   * @param options.forceRebuild - Controls frontend DOM rebuild behavior:
-   *   - `true`: Full DOM rebuild (required when switching streams or after data deletion)
-   *   - `false`: Incremental update only (skip DOM rebuild, update metadata)
-   *   - `undefined`: Full DOM rebuild (legacy behavior, same as true)
-   *   Note: Frontend uses strict `=== false` check, so explicit `false` is required
-   *   for incremental updates.
+   * Update log content for a specific stream.
+   * @param forceRebuild - Controls frontend DOM rebuild behavior:
+   *   - `true`: Full DOM rebuild (stream switch, data deletion, first load)
+   *   - `false`: Incremental update only (same stream, metadata changes)
    */
   updateLogContent(
     stream: StreamTabId,
@@ -114,9 +111,7 @@ export class WebviewUpdater {
       runUsage?: Record<string, TokenUsageStats>;
       runFiles?: Record<string, { [key: number]: OutputFileInfo[] }>;
     },
-    options?: {
-      forceRebuild?: boolean;
-    },
+    forceRebuild: boolean = false,
   ): void {
     this.sendMessage({
       command: COMMANDS.UPDATE_LOGS,
@@ -127,7 +122,7 @@ export class WebviewUpdater {
       activeRunId: extras?.activeRunId,
       runUsage: extras?.runUsage,
       runFiles: extras?.runFiles,
-      forceRebuild: options?.forceRebuild,
+      forceRebuild,
     });
   }
 

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -373,9 +373,18 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
 
     // Determine rebuild strategy based on forceRebuild flag:
     // - false: Incremental update only (skip DOM rebuild)
-    // - true/undefined: Full DOM rebuild needed
+    // - true: Full DOM rebuild required (stream switch, data deletion)
+    // - undefined: Legacy behavior, but avoid clearing if no messages
     // See WebviewUpdater.updateLogContent() JSDoc for contract details.
-    const useIncrementalUpdate = message.forceRebuild === false;
+    //
+    // IMPORTANT: When forceRebuild is not explicitly true and incoming messages
+    // are empty, use incremental update to prevent clearing existing content.
+    // This prevents data loss during follow-up after reload scenarios where
+    // UPDATE_LOGS arrives with empty/stale data before messages are loaded.
+    const logMessages = message.messages ?? [];
+    const useIncrementalUpdate =
+      message.forceRebuild === false ||
+      (message.forceRebuild !== true && logMessages.length === 0);
     if (useIncrementalUpdate) {
       this._handleIncrementalUpdate(message);
       this._updatePlaceholderVisibility();
@@ -430,7 +439,6 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     } else {
       dom.taskGroups.showRun(null);
     }
-    const logMessages = message.messages ?? [];
     logMessages.forEach((msg) => {
       if (msg.groupId) {
         if (!dom.logEntries.append(msg)) {

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -371,27 +371,17 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       return;
     }
 
-    // Determine rebuild strategy based on forceRebuild flag:
-    // - false: Incremental update only (skip DOM rebuild)
-    // - true: Full DOM rebuild required (stream switch, data deletion)
-    // - undefined: Legacy behavior, but avoid clearing if no messages
-    // See WebviewUpdater.updateLogContent() JSDoc for contract details.
-    //
-    // IMPORTANT: When forceRebuild is not explicitly true and incoming messages
-    // are empty, use incremental update to prevent clearing existing content.
-    // This prevents data loss during follow-up after reload scenarios where
-    // UPDATE_LOGS arrives with empty/stale data before messages are loaded.
-    const logMessages = message.messages ?? [];
-    const useIncrementalUpdate =
-      message.forceRebuild === false ||
-      (message.forceRebuild !== true && logMessages.length === 0);
-    if (useIncrementalUpdate) {
+    // forceRebuild is now always a boolean from backend:
+    // - false: Incremental update only (same stream, metadata changes)
+    // - true: Full DOM rebuild (stream switch, data deletion, first load)
+    if (!message.forceRebuild) {
       this._handleIncrementalUpdate(message);
       this._updatePlaceholderVisibility();
       return;
     }
 
-    // Full rebuild path (stream switch, explicit forceRebuild, or legacy undefined)
+    // Full rebuild path
+    const logMessages = message.messages ?? [];
     const logContent = document.getElementById(ELEMENT_IDS.LOG_CONTENT);
     pendingLogUpdates.clear();
     dom.taskGroups.clear();

--- a/src/progressView/state/ProgressViewState.ts
+++ b/src/progressView/state/ProgressViewState.ts
@@ -61,6 +61,12 @@ export class ProgressViewState {
   private _usageStats: UsageStatsManager;
   private _runInstructions: RunInstructionManager;
   private _activeStream: StreamTabId = '';
+  /**
+   * Tracks the stream that was last rendered to the webview.
+   * Used as single source of truth for stream switch detection.
+   * Reset when webview is cleaned up to force rebuild on next render.
+   */
+  private _lastRenderedStream: StreamTabId = '';
   private _streamSortOrder = 'time';
   private _agentTypeFilter: AgentFilter = 'all';
   private readonly taskStates = new Map<StreamTabId, TaskState>();
@@ -135,6 +141,32 @@ export class ProgressViewState {
   set activeStream(stream: StreamTabId) {
     this._activeStream = stream;
     this.saveActiveStream();
+  }
+
+  // Stream switch detection (single source of truth)
+
+  /**
+   * Check if rendering the given stream would be a stream switch.
+   * Uses lastRenderedStream as the single source of truth.
+   */
+  isStreamSwitch(stream: StreamTabId): boolean {
+    return this._lastRenderedStream !== stream;
+  }
+
+  /**
+   * Mark a stream as having been rendered.
+   * Called after successfully rendering stream content to webview.
+   */
+  markStreamRendered(stream: StreamTabId): void {
+    this._lastRenderedStream = stream;
+  }
+
+  /**
+   * Clear rendered stream tracking.
+   * Called when webview is cleaned up to force rebuild on next render.
+   */
+  clearRenderedStreamTracking(): void {
+    this._lastRenderedStream = '';
   }
 
   /**


### PR DESCRIPTION
When sending a follow-up message after webview reload, the UPDATE_LOGS message could arrive with empty messages before the actual content was loaded, causing all displayed messages to be cleared.

The fix adds a guard in handleUpdateLogs to use incremental update mode when forceRebuild is not explicitly true AND messages array is empty. This preserves existing DOM content instead of clearing it.

- forceRebuild: true → always full rebuild (for stream switches)
- forceRebuild: false → incremental update (explicit request)
- forceRebuild: undefined + empty messages → incremental (preserve content)
- forceRebuild: undefined + has messages → full rebuild (backward compat)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves reliability of progress view updates and prevents accidental DOM clears after reloads or stream switches.
> 
> - Moves stream-switch detection to `ProgressViewState` (`isStreamSwitch`, `markStreamRendered`, `clearRenderedStreamTracking`); provider and event handler now use this single source of truth and mark streams rendered after updates
> - Standardizes `UPDATE_LOGS` contract: `WebviewUpdater.updateLogContent` now takes `forceRebuild: boolean`; frontend `handleUpdateLogs` treats it strictly (false = incremental, true = full rebuild); removes legacy `undefined` path
> - Ensures empty-stream refresh clears UI safely by calling `updateLogContent('', ..., true)` and resets related panels/files/usage/status
> - Minor non-functional cleanups (formatting in logger/memory view/index.html)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 248d60c77939bdb0e6df448fcbd78fbb7ebef0be. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->