### PR TITLE
Fix invalid memory tool input tag error

### DIFF
--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -377,6 +377,11 @@ export class ModelHandlerAnthropic extends ModelHandler<
       if (this.config.capabilities.supportsInterleavedThinking) {
         this.appendBeta(options, INTERLEAVED_THINKING_BETA);
       }
+
+      // Memory tool requires the context management beta header
+      if (tools.some((t) => t.name === 'memory')) {
+        this.appendBeta(options, CONTEXT_MANAGEMENT_BETA);
+      }
     }
 
     // Enable thinking for any models that support reasoning


### PR DESCRIPTION
The memory_20250818 tool type requires the context-management-2025-06-27 beta header to be included in API requests. Without this header, the API returns an HTTP 400 error indicating the memory tool type is invalid.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures Anthropic requests include the proper beta when the `memory` tool is used.
> 
> - In `modelHandlerAnthropic.createResponse`, when `tools` contains `memory`, appends `context-management-2025-06-27` beta to `options.betas`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 417e48dff16f24eb725620a017032bdc3a8c11de. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->