### PR TITLE
feat: enable memory tool by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -969,7 +969,7 @@
           },
           "texra.toolUse.memory.enabled": {
             "type": "boolean",
-            "default": false,
+            "default": true,
             "description": "Enable the memory tool for all tool-use sessions",
             "scope": "resource"
           },

--- a/src/utils/config/constants.ts
+++ b/src/utils/config/constants.ts
@@ -66,7 +66,7 @@ export const DEBOUNCE_STATE_SAVE_MS = 500; // State persistence (slower, batched
 
 // Tool-use persistence defaults
 export const DEFAULT_TOOL_USE_PERSISTENCE_TTL_HOURS = 72;
-export const DEFAULT_TOOL_USE_MEMORY_ENABLED = false;
+export const DEFAULT_TOOL_USE_MEMORY_ENABLED = true;
 
 // Retry defaults
 // Default to 0 automatic retries - users must click retry button


### PR DESCRIPTION
### Motivation
- Enable the memory tool by default for all tool-use sessions so tool-use flows include memory without requiring manual opt-in.

### Description
- Set `DEFAULT_TOOL_USE_MEMORY_ENABLED` to `true` in `src/utils/config/constants.ts`.
- Update the VS Code configuration metadata default for `texra.toolUse.memory.enabled` to `true` in `package.json`.

### Testing
- Ran `npm run format` and it completed successfully.
- Ran `npm run lint` and it completed with warnings (two `eqeqeq` warnings in `src/tools/ReadTool.ts`).
- Attempted `npm run compile` / `npm run compile -- --stats=errors-only` but the webpack compile stalled/was interrupted in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695fd251931083248176fa4e543a11a2)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables the memory tool by default across tool-use sessions.
> 
> - Updates `texra.toolUse.memory.enabled` default to `true` in `package.json`
> - Sets `DEFAULT_TOOL_USE_MEMORY_ENABLED` to `true` in `src/utils/config/constants.ts` (affects `getToolUseMemoryEnabled()` fallback)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 71dd27bff31239e4a3ac1a73f25faf59b699708a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->