### PR TITLE
Fix follow-up message disappearing after reload

### DIFF
--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -179,6 +179,8 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
   private async handleDeleteStream(message: any): Promise<void> {
     // Delete persisted session data if any
     await this.deleteSessionSnapshot(message.stream);
+    // Clear pending task groups to prevent memory leaks
+    this.provider.eventHandler.clearPendingTaskGroups(message.stream);
     await this.provider.state.clearStream(message.stream);
     // Force rebuild since we deleted a stream
     this.provider.updateWebview({ forceRebuild: true });
@@ -203,6 +205,8 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler {
       await this.deleteSessionSnapshot(stream);
     }
 
+    // Clear all pending task groups to prevent memory leaks
+    this.provider.eventHandler.clearAllPendingTaskGroups();
     await this.provider.state.clearAll();
     // Force rebuild since we deleted all streams
     this.provider.updateWebview({ forceRebuild: true });

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -647,13 +647,12 @@ export class ProgressEventHandler {
     });
 
     // Refresh todos for the stream (ephemeral state)
-    // Always send todos if defined (including empty array to clear stale UI)
-    const todos = this.state.getTodos(stream);
-    if (todos !== undefined) {
-      this.webviewUpdater.updateTodos(stream, todos);
-    }
+    // Always send update (empty array if undefined) to clear stale UI from previous stream
+    const todos = this.state.getTodos(stream) ?? [];
+    this.webviewUpdater.updateTodos(stream, todos);
 
     // Refresh context state for the stream (ephemeral state)
+    // Only send if defined - frontend will show default state if not set
     const contextState = this.state.getContextState(stream);
     if (contextState !== undefined) {
       this.webviewUpdater.updateContextState(stream, contextState);
@@ -838,6 +837,22 @@ export class ProgressEventHandler {
       this.state.markStreamRendered(stream);
       this.sendInstructionUpdate(stream, activeRunId);
     }
+  }
+
+  /**
+   * Clear pending task groups for a specific stream.
+   * Called when a stream is deleted to prevent memory leaks.
+   */
+  clearPendingTaskGroups(stream: string): void {
+    this.pendingTaskGroups.delete(stream);
+  }
+
+  /**
+   * Clear all pending task groups.
+   * Called when all streams are deleted to prevent memory leaks.
+   */
+  clearAllPendingTaskGroups(): void {
+    this.pendingTaskGroups.clear();
   }
 
   /**

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -345,6 +345,11 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       dom.todoList.clear();
       dom.queuedFollowUps.clear();
       dom.fileList.clear();
+      // Clear log content when no stream is active to avoid stale content
+      const logContent = document.getElementById(ELEMENT_IDS.LOG_CONTENT);
+      if (logContent) {
+        logContent.innerHTML = '';
+      }
       state.clearRunInstructions();
       state.clearAllActiveRuns();
       state.clearAllPendingInstructions();

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -133,16 +133,18 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
    * - Workflow sessions create hierarchical task groups
    * - Tool-use sessions don't create task groups at all
    * Stale groups from previous sessions interfere with run ID resolution.
+   *
+   * NOTE: Log content is NOT cleared here. It's handled by handleUpdateLogs
+   * with forceRebuild: true, which properly coordinates clearing with
+   * re-rendering. Clearing here would cause data loss when UPDATE_LOGS
+   * arrives with forceRebuild: false (same stream, incremental update).
+   *
    * @param {string} newSessionKind - The new session kind being switched to
    */
   _clearSessionKindState(newSessionKind) {
     if (newSessionKind !== state.activeSessionKind && state.activeSessionKind) {
       state.taskGroups.clear();
       dom.taskGroups.clear();
-      const logContent = document.getElementById(ELEMENT_IDS.LOG_CONTENT);
-      if (logContent) {
-        logContent.innerHTML = '';
-      }
     }
   }
 


### PR DESCRIPTION
Remove log content clearing from _clearSessionKindState() to fix data loss when sending follow-up messages after webview reload.

Root cause: When follow-up triggers session resume, setActiveStream event causes UPDATE_STREAMS (which may incorrectly detect session kind change due to missing task state) followed by UPDATE_LOGS with forceRebuild: false. The session kind change would clear log content, but the incremental UPDATE_LOGS wouldn't restore it.

Fix: Log content clearing should only happen in handleUpdateLogs with forceRebuild: true, which properly coordinates the clear operation with message re-rendering. Task group clearing remains in place as they're still incompatible between session kinds.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Addresses data loss when switching/resuming sessions and improves cleanup.
> 
> - Stop clearing `log` content in `_clearSessionKindState`; only clear during `handleUpdateLogs` with `forceRebuild: true`. Also clear logs when no active stream in `handleUpdateStreams`
> - Always send `todos` (default to `[]`) on stream refresh; send context state only if defined
> - Add `clearPendingTaskGroups(stream)` and `clearAllPendingTaskGroups()` in `ProgressEventHandler`, and invoke from `DELETE_STREAM`/`DELETE_ALL` handlers to prevent memory leaks
> - Keep full rebuilds on deletion via `updateWebview({ forceRebuild: true })`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 434966fbe01be36adaf24ee757f1e642ce52d303. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->