### PR TITLE
Fix invalid memory tool input tag error

### DIFF
--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -449,8 +449,14 @@ export class ModelHandlerAnthropic extends ModelHandler<
 
           // Include tools in token counting for accurate measurement.
           // Tool schemas can be substantial and affect context utilization.
+          // Filter out memory tool as countTokens API doesn't support it yet.
           if (options.tools && options.tools.length > 0) {
-            countTokensParams.tools = options.tools;
+            const countableTools = options.tools.filter(
+              (tool) => !('type' in tool && tool.type === 'memory_20250818'),
+            );
+            if (countableTools.length > 0) {
+              countTokensParams.tools = countableTools;
+            }
           }
 
           // If thinking is enabled, we need to pass it to countTokens as well

--- a/src/agent/modelHandlers/toolConversion.ts
+++ b/src/agent/modelHandlers/toolConversion.ts
@@ -46,6 +46,7 @@ const ANTHROPIC_TOOL_TYPE_MAP: Record<string, string> = {
   str_replace_editor: 'text_editor_20250429',
   str_replace_based_edit_tool: 'text_editor_20250429',
   web_search: 'web_search_20250305',
+  memory: 'memory_20250818',
 } as const;
 
 /**

--- a/src/agent/modelHandlers/toolConversion.ts
+++ b/src/agent/modelHandlers/toolConversion.ts
@@ -46,7 +46,6 @@ const ANTHROPIC_TOOL_TYPE_MAP: Record<string, string> = {
   str_replace_editor: 'text_editor_20250429',
   str_replace_based_edit_tool: 'text_editor_20250429',
   web_search: 'web_search_20250305',
-  memory: 'memory_20250818',
 } as const;
 
 /**


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Prevents token counting failures by excluding unsupported memory tool schema.
> 
> - When building `countTokensParams`, filters out tools with `type === 'memory_20250818'` and only includes remaining tools in `countTokens`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9a1a944a8eeec1fcc0b1f2f33f2ab5d635332258. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->