### PR TITLE
Reduce repetitive display code

### DIFF
--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -36,6 +36,7 @@ import { AgentLogger } from '@logger/AgentLogger';
 import { MESSAGE_TYPES } from '@logger/messageTypes';
 // Type imports
 import type { ToolDefinition } from '@model';
+import { DIAGNOSTIC_TYPE_VALIDATION_ERROR } from '@tools/result';
 import { AbsoluteFS, pathToLocation, type FileLocation } from '@utils/files';
 import { isNonEmptyString } from '@utils/core';
 import { formatContent } from '@utils/text/xmlUtils';
@@ -56,7 +57,7 @@ import {
 } from './CycleServices';
 
 interface ToolValidationDiagnostics {
-  type: 'validation_error';
+  type: typeof DIAGNOSTIC_TYPE_VALIDATION_ERROR;
   issues: any;
   formatted: Array<{
     path: string;
@@ -106,7 +107,7 @@ function normalizeToolCallError(
     return {
       message: `${toolName}: Invalid parameters provided`,
       diagnostics: {
-        type: 'validation_error',
+        type: DIAGNOSTIC_TYPE_VALIDATION_ERROR,
         issues,
         formatted: issues.map((issue) => ({
           path: Array.isArray(issue.path) ? issue.path.join('.') : '',

--- a/src/agent/modelHandlers/utils/toolAttachmentUtils.ts
+++ b/src/agent/modelHandlers/utils/toolAttachmentUtils.ts
@@ -10,6 +10,7 @@ import {
   FileReferenceSchema,
   LineChangesSchema,
   EditRecordSchema,
+  DIAGNOSTIC_TYPE_VALIDATION_ERROR,
 } from '@tools/result';
 
 // Local imports - utils
@@ -111,12 +112,30 @@ export function extractToolAttachments(
   // Parse with Zod - passthrough() ensures this never fails
   const parsed = ToolResultPayloadSchema.parse(result);
 
-  // Build sanitized result, stripping binary data and undefined values
+  // Build sanitized result, stripping binary data, undefined values, and redundant error fields
   const sanitizedResult: ToolResultPayload = {};
+  const hasError = typeof parsed.error === 'string' && parsed.error.length > 0;
+
   for (const [key, value] of Object.entries(parsed)) {
     if (value === undefined) continue;
     // Skip binary fields (these belong in files array attachments)
     if (key === 'base64Data' || key === 'bytes') {
+      continue;
+    }
+    // Skip isError when error message is present (redundant)
+    if (key === 'isError' && hasError) {
+      continue;
+    }
+    // Simplify diagnostics: keep validation error details, remove verbose stack traces
+    if (key === 'diagnostics' && value && typeof value === 'object') {
+      const diag = value as Record<string, unknown>;
+      // For validation errors, keep the formatted details (useful for model)
+      if (diag.type === DIAGNOSTIC_TYPE_VALIDATION_ERROR && diag.formatted) {
+        sanitizedResult[key] = { type: diag.type, formatted: diag.formatted };
+        continue;
+      }
+      // For regular errors (ToolError), skip diagnostics entirely - the error
+      // message is already in the error field, and the stack trace just repeats it
       continue;
     }
     sanitizedResult[key] = value;

--- a/src/progressView/modules/formatters/normalizers.js
+++ b/src/progressView/modules/formatters/normalizers.js
@@ -177,13 +177,22 @@ export const normalizeToolUseLog = (structured) => {
 
   // Extract the actual output content, avoiding redundant nesting
   // If outputCandidate is an object with an 'output' field, use that directly
+  // Also exclude fields that are displayed elsewhere (error, isError, diagnostics, userInstruction)
   let outputContent = outputCandidate;
   if (
     outputCandidate !== null &&
     typeof outputCandidate === 'object' &&
     !Array.isArray(outputCandidate)
   ) {
-    const { summary: _unusedSummary, output, ...rest } = outputCandidate;
+    const {
+      summary: _unusedSummary,
+      output,
+      error: _extractedError,
+      isError: _extractedIsError,
+      diagnostics: _extractedDiagnostics,
+      userInstruction: _extractedUserInstruction,
+      ...rest
+    } = outputCandidate;
     // Prefer the nested output field if it exists, otherwise use remaining fields
     outputContent = output !== undefined ? output : rest;
   }
@@ -207,6 +216,8 @@ export const normalizeToolUseLog = (structured) => {
   const userInstructionText =
     (typeof parsed.userInstruction === 'string' &&
       parsed.userInstruction.trim()) ||
+    (typeof outputDetails.userInstruction === 'string' &&
+      outputDetails.userInstruction.trim()) ||
     '';
   const isUserFeedback = userInstructionText.length > 0;
 

--- a/src/tools/result.ts
+++ b/src/tools/result.ts
@@ -72,6 +72,12 @@ export type FlattenedEditRecord = z.infer<typeof FlattenedEditRecordSchema>;
 // Diagnostics Types (not Zod - these are complex unions with external types)
 // ============================================================================
 
+/**
+ * Diagnostic type identifier for tool parameter validation errors.
+ * Used when Zod validation fails on tool input parameters.
+ */
+export const DIAGNOSTIC_TYPE_VALIDATION_ERROR = 'validation_error' as const;
+
 export interface DiagnosticsPayload {
   path: string;
   command: 'list' | 'count';


### PR DESCRIPTION
When a tool error occurred, the error message was displayed 4 times:
1. In the header (via headerSummary)
2. In the Output section (stringified output object with error/isError/diagnostics)
3. In the Error section (errorText)
4. In diagnostics.stack (includes error message)

Now exclude error, isError, diagnostics, and userInstruction fields from the output display since they are already shown in dedicated sections. This results in a cleaner display where errors show only:
- Header with error summary
- Input section with tool parameters
- Error section with error message

Also fixed userInstructionText extraction to check both parsed and outputDetails, following the same pattern as errorText and summaryText.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Cleans up tool result rendering and logging to avoid repeated error messages and noisy diagnostics.
> 
> - Progress view normalizer excludes `error`, `isError`, `diagnostics`, and `userInstruction` from `output` rendering; pulls `userInstructionText` from both `parsed` and `outputDetails`
> - `toolAttachmentUtils`: builds sanitized tool result payloads by stripping binary fields, dropping redundant `isError` when `error` exists, and keeping only formatted validation diagnostics; preserves file metadata
> - Introduces `DIAGNOSTIC_TYPE_VALIDATION_ERROR` in `@tools/result` and uses it in `ToolUseCycleFlow` for typed validation diagnostics
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2b15ce8f21f944bf6863a8125ec18dad071a1480. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->