### PR TITLE
Display context usage on left sidebar

### DIFF
--- a/src/progressView/modules/constants.js
+++ b/src/progressView/modules/constants.js
@@ -25,6 +25,7 @@ export const ELEMENT_IDS = {
   RUN_SELECTOR_CONTAINER: 'runSelectorRow',
   STATUS_INDICATOR: 'statusIndicator',
   RUN_SUMMARY: 'runSummary',
+  CONTEXT_STATE: 'contextState',
   TODO_LIST_CONTAINER: 'todoListContainer',
   TODO_LIST: 'todoList',
   INSTRUCTION_CONTAINER: 'instructionContainer',

--- a/src/progressView/modules/formatters/index.js
+++ b/src/progressView/modules/formatters/index.js
@@ -163,6 +163,8 @@ export class LogEntryFormatter {
           () => formatStatistics(message.normalizedPayload, message.id),
           'statistics',
         ),
+      // Context state is displayed in the footer, not inline in logs
+      contextState: () => null,
       userMessage: (message) =>
         safeFormat(
           () =>
@@ -215,7 +217,8 @@ export class LogEntryFormatter {
       if (
         messageType === 'thinking' ||
         messageType === 'scratchpad' ||
-        messageType === 'modelResponse'
+        messageType === 'modelResponse' ||
+        messageType === 'contextState'
       ) {
         return null;
       }

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -117,6 +117,20 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
   }
 
   /**
+   * Refresh context state display for the active stream.
+   * Clears display if stream has no context state.
+   */
+  _refreshContextStateForActiveStream() {
+    const stream = state.activeStream;
+    const contextState = stream ? state.getContextState(stream) : null;
+    if (contextState) {
+      dom.usageSummary.updateContextDisplay(contextState);
+    } else {
+      dom.usageSummary.clearContextDisplay();
+    }
+  }
+
+  /**
    * Auto-focus follow-up input when status is WAITING.
    * Extracted to avoid duplication in handleUpdateStreams and handleUpdateStreamStatus.
    * @param {string} status - The stream status to check
@@ -363,6 +377,7 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     this._refreshInstructionForActiveRun();
     this._refreshUsageForActiveRun();
     this._refreshOutputsForActiveRun();
+    this._refreshContextStateForActiveStream();
   }
 
   handleUpdateLogs(message) {
@@ -713,7 +728,7 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     state.setContextState(targetStream, message.contextState);
     // Update the context display if this is the active stream
     if (targetStream === state.activeStream) {
-      this.usageSummary?.updateContextDisplay?.(message.contextState);
+      dom.usageSummary.updateContextDisplay(message.contextState);
     }
   }
 
@@ -943,7 +958,7 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
         dom.todoList.clear();
         dom.queuedFollowUps.clear();
         dom.fileList.clear();
-        dom.usageSummary?.clearContextDisplay?.();
+        dom.usageSummary.clearContextDisplay();
       }
     }
 
@@ -968,7 +983,7 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     dom.todoList.clear();
     dom.queuedFollowUps.clear();
     dom.fileList.clear();
-    dom.usageSummary?.clearContextDisplay?.();
+    dom.usageSummary.clearContextDisplay();
     this._updatePlaceholderVisibility();
   }
 

--- a/src/progressView/modules/usageManagers.js
+++ b/src/progressView/modules/usageManagers.js
@@ -11,6 +11,31 @@ export class UsageSummary {
   constructor() {
     this._summaryElem = null;
     this._contextElem = null;
+    this._footerElem = null;
+  }
+
+  /**
+   * Get the footer element, caching it after first successful lookup.
+   * Only caches when a valid footer is found to allow retry if called early.
+   * Checks isConnected to handle webview refresh scenarios.
+   * @returns {HTMLElement|null}
+   */
+  _getFooter() {
+    if (this._footerElem?.isConnected) return this._footerElem;
+    const anchor = this._summaryElem || this._contextElem;
+    if (anchor) {
+      this._footerElem = anchor.closest('.usage-summary-footer');
+    }
+    return this._footerElem;
+  }
+
+  /**
+   * Cache the context element if not already cached.
+   */
+  _ensureContextElem() {
+    if (!this._contextElem) {
+      this._contextElem = document.getElementById(ELEMENT_IDS.CONTEXT_STATE);
+    }
   }
 
   /**
@@ -24,7 +49,8 @@ export class UsageSummary {
       this._summaryElem = document.getElementById(ELEMENT_IDS.RUN_SUMMARY);
     }
     if (!this._summaryElem) return;
-    const footer = this._summaryElem.closest('.usage-summary-footer');
+
+    const footer = this._getFooter();
     // If usage is not provided, compute it from existing log groups
     const totals = usage ?? this.computeTotal();
 
@@ -35,7 +61,10 @@ export class UsageSummary {
     if (!inputTokens && !outputTokens && !cost) {
       this._summaryElem.textContent = '';
       this._summaryElem.removeAttribute('aria-label');
-      if (footer) {
+      // Only hide footer if context state is also not visible
+      this._ensureContextElem();
+      const contextVisible = this._contextElem?.hidden === false;
+      if (footer && !contextVisible) {
         footer.hidden = true;
       }
       return;
@@ -92,10 +121,7 @@ export class UsageSummary {
    * @param {{ inputTokens: number, contextWindow: number, utilizationPercent: number }} contextState
    */
   updateContextDisplay(contextState) {
-    // Cache the context element
-    if (!this._contextElem) {
-      this._contextElem = document.getElementById('contextState');
-    }
+    this._ensureContextElem();
     if (!this._contextElem) return;
 
     const { inputTokens, contextWindow, utilizationPercent } = contextState;
@@ -104,6 +130,12 @@ export class UsageSummary {
       this._contextElem.textContent = '';
       this._contextElem.hidden = true;
       return;
+    }
+
+    // Ensure footer is visible when context state is displayed
+    const footer = this._getFooter();
+    if (footer) {
+      footer.hidden = false;
     }
 
     const contextLeft = Math.max(0, 100 - utilizationPercent);
@@ -121,14 +153,22 @@ export class UsageSummary {
 
   /**
    * Clear the context state display.
+   * Also hides the footer if usage summary is empty.
    */
   clearContextDisplay() {
-    if (!this._contextElem) {
-      this._contextElem = document.getElementById('contextState');
-    }
-    if (this._contextElem) {
-      this._contextElem.textContent = '';
-      this._contextElem.hidden = true;
+    this._ensureContextElem();
+    if (!this._contextElem) return;
+
+    this._contextElem.textContent = '';
+    this._contextElem.hidden = true;
+
+    // Hide footer if usage is also empty
+    const usageEmpty = !this._summaryElem?.textContent;
+    if (usageEmpty) {
+      const footer = this._getFooter();
+      if (footer) {
+        footer.hidden = true;
+      }
     }
   }
 }


### PR DESCRIPTION
Move context usage display from inline log messages to the footer panel alongside total usage. Changes:

- Add contextState formatter that returns null to suppress inline display
- Fix handleUpdateContextState to use dom.usageSummary instead of this.usageSummary
- Ensure footer remains visible when context state is displayed
- Only hide footer when both usage and context state are empty

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Moves context utilization from inline logs to the footer and tightens footer visibility logic.
> 
> - Add `ELEMENT_IDS.CONTEXT_STATE` and `UsageSummary` footer/context caching helpers; ensure footer shows when context is visible and hides only when both usage and context are empty
> - Suppress inline context logs: `formatters` map `contextState` ➜ `null` and exclude in `format()`
> - Message flow: new `_refreshContextStateForActiveStream()`; invoked on stream updates; fix `handleUpdateContextState` to use `dom.usageSummary.updateContextDisplay`; clear context display on stream deletions and global resets
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 581a1d0502ec1a6ed55b62ff49f785f4ac8dd3aa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->