### PR TITLE
Make queued message collapsible above input box

### DIFF
--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -216,48 +216,50 @@
                 class="queued-follow-ups-list"
               ></div>
             </vscode-collapsible>
-            <vscode-textarea
-              id="followUpInput"
-              placeholder="Send follow-up message"
-              rows="10"
-              resize="vertical"
-            ></vscode-textarea>
-            <div class="follow-up-actions">
-              <vscode-toolbar-button
-                id="polishFollowUpBtn"
-                icon="sparkle"
-                label="Polish follow-up"
-                title="Polish follow-up with AI"
-              ></vscode-toolbar-button>
-              <vscode-progress-ring
-                id="polishFollowUpProgressContainer"
-                style="display: none; width: 16px; height: 16px"
-              ></vscode-progress-ring>
-              <vscode-toolbar-button
-                id="resetApprovalBypassBtn"
-                icon="shield"
-                label="Resume approval prompts"
-                title="Resume approval prompts"
-                hidden
-              ></vscode-toolbar-button>
-              <vscode-toolbar-button
-                id="recordFollowUpBtn"
-                icon="mic"
-                label="Record follow-up"
-                title="Record follow-up with microphone"
-              ></vscode-toolbar-button>
-              <vscode-toolbar-button
-                id="clearFollowUpBtn"
-                icon="clear-all"
-                label="Clear input"
-                title="Clear input"
-              ></vscode-toolbar-button>
-              <vscode-toolbar-button
-                id="sendFollowUpBtn"
-                icon="send"
-                label="Send"
-                title="Send follow-up message"
-              ></vscode-toolbar-button>
+            <div class="follow-up-input-row">
+              <vscode-textarea
+                id="followUpInput"
+                placeholder="Send follow-up message"
+                rows="10"
+                resize="vertical"
+              ></vscode-textarea>
+              <div class="follow-up-actions">
+                <vscode-toolbar-button
+                  id="polishFollowUpBtn"
+                  icon="sparkle"
+                  label="Polish follow-up"
+                  title="Polish follow-up with AI"
+                ></vscode-toolbar-button>
+                <vscode-progress-ring
+                  id="polishFollowUpProgressContainer"
+                  style="display: none; width: 16px; height: 16px"
+                ></vscode-progress-ring>
+                <vscode-toolbar-button
+                  id="resetApprovalBypassBtn"
+                  icon="shield"
+                  label="Resume approval prompts"
+                  title="Resume approval prompts"
+                  hidden
+                ></vscode-toolbar-button>
+                <vscode-toolbar-button
+                  id="recordFollowUpBtn"
+                  icon="mic"
+                  label="Record follow-up"
+                  title="Record follow-up with microphone"
+                ></vscode-toolbar-button>
+                <vscode-toolbar-button
+                  id="clearFollowUpBtn"
+                  icon="clear-all"
+                  label="Clear input"
+                  title="Clear input"
+                ></vscode-toolbar-button>
+                <vscode-toolbar-button
+                  id="sendFollowUpBtn"
+                  icon="send"
+                  label="Send"
+                  title="Send follow-up message"
+                ></vscode-toolbar-button>
+              </div>
             </div>
           </div>
           <template id="fileItemTemplate">

--- a/src/progressView/styles/follow-up-input.css
+++ b/src/progressView/styles/follow-up-input.css
@@ -6,7 +6,7 @@
 /* Follow-up input container */
 .follow-up-container {
   display: none;
-  align-items: flex-end;
+  flex-direction: column;
   padding: var(--spacing-medium);
   border-top: 1px solid var(--color-border);
   gap: var(--spacing-small);
@@ -14,6 +14,13 @@
 
 .follow-up-container.is-visible {
   display: flex;
+}
+
+/* Row container for textarea and action buttons */
+.follow-up-input-row {
+  display: flex;
+  align-items: flex-end;
+  gap: var(--spacing-small);
 }
 
 /* Style the textarea for multi-line input */

--- a/src/progressView/styles/queued-follow-ups.css
+++ b/src/progressView/styles/queued-follow-ups.css
@@ -5,7 +5,6 @@
 
 /* Collapsible container styling */
 .queued-follow-ups-collapsible {
-  margin-bottom: var(--spacing-small);
   border-radius: var(--radius);
   background-color: var(--vscode-inputValidation-infoBackground);
   border: 1px solid var(--vscode-inputValidation-infoBorder);


### PR DESCRIPTION
The queued message collapsible was displayed alongside the input textarea due to the flex container's default row direction. This caused the queued message to squeeze out the input box when expanded.

Changes:
- Wrap textarea and action buttons in a new .follow-up-input-row container
- Set .follow-up-container to flex-direction: column for vertical stacking
- Remove redundant margin-bottom from queued-follow-ups-collapsible (handled by gap)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns the follow-up section so `Queued Messages` appears above the input without squeezing the textarea.
> 
> - Wraps `followUpInput` and action buttons in `div.follow-up-input-row` for side-by-side alignment
> - Sets `.follow-up-container` to `flex-direction: column` to vertically stack the collapsible and input row
> - Makes `.follow-up-actions` a vertical column; tweaks textarea sizing via `::part(control)`
> - Removes redundant margin from `queued-follow-ups-collapsible` (spacing handled by container gap)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9495ca321f2ba144f454a7fb33c36e17e094288b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->