### PR TITLE
Configure OpenAI API key and background mode

### DIFF
--- a/src/agent/implementations/flows/ToolUseRunFlow.ts
+++ b/src/agent/implementations/flows/ToolUseRunFlow.ts
@@ -563,6 +563,9 @@ class ToolUseWaitNode<C> extends Node<
       return FlowTransition.DEFAULT;
     }
 
+    // Notify that follow-up was consumed (updates queued message UI)
+    this.services.onFollowUpConsumed?.();
+
     // Apply follow-up (state mutation in post - correct)
     const session = this.services.session;
     await session.markRunning();

--- a/src/agent/implementations/flows/tooluse/ToolUseFlowContext.ts
+++ b/src/agent/implementations/flows/tooluse/ToolUseFlowContext.ts
@@ -48,6 +48,9 @@ export interface ToolUseFlowContextInit<
 
   /** Optional usage tracking callback */
   getUsageRecorder?: () => RoundFinalizedCallback;
+
+  /** Optional callback when a queued follow-up is consumed */
+  onFollowUpConsumed?: () => void;
 }
 
 // ============================================================================

--- a/src/agent/implementations/flows/tooluse/ToolUseServices.ts
+++ b/src/agent/implementations/flows/tooluse/ToolUseServices.ts
@@ -73,6 +73,12 @@ export interface ToolUseServices<C = unknown> extends BaseFlowContextInit<C> {
    * Returns a callback that will be invoked when a round finalizes.
    */
   readonly getUsageRecorder: () => RoundFinalizedCallback;
+
+  /**
+   * Callback invoked when a queued follow-up message is consumed.
+   * Used to update the UI (clear the queued message display).
+   */
+  readonly onFollowUpConsumed?: () => void;
 }
 
 /**

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -68,6 +68,7 @@ import { AgentLogger } from '@logger/AgentLogger';
 import { AgentUsageReporter } from '@logger/AgentUsageReporter';
 import { END_GROUP_STATUS, type EndGroupStatus } from '@logger/messageTypes';
 import { MODEL_CONFIGS } from '@model/ModelRegistry';
+import { updateQueuedFollowUpsUI } from '@progressView/utils/updateQueuedFollowUps';
 import { TaskRunFileService } from '@utils/files';
 import { agentConfigToTaskState } from '@utils/config';
 import { ensureRunDir } from '@utils/files/taskRunStorage';
@@ -616,6 +617,7 @@ export async function executeAgent(
           ...interruptManager.asFlowInput(),
           getUsageRecorder: createUsageRecorder(ctx.usageMonitor, 'tool-use'),
           setting: ctx.setting as AgentToolUseSetting,
+          onFollowUpConsumed: () => updateQueuedFollowUpsUI(ctx.streamId),
         });
         return result.status;
       }
@@ -759,6 +761,7 @@ export async function resumeToolUseFromSnapshot(
           getUsageRecorder: createUsageRecorder(ctx.usageMonitor, 'tool-use'),
           setting: setting as AgentToolUseSetting,
           resumeSnapshot: snapshot,
+          onFollowUpConsumed: () => updateQueuedFollowUpsUI(ctx.streamId),
         },
         setupSession ? (context) => setupSession(context.session) : undefined,
       );


### PR DESCRIPTION
The queued message UI was not being cleared after a follow-up message was consumed by the flow. This happened because:

1. When a message was queued (status 'waiting'), updateQueuedFollowUpsUI was called to show it in the UI
2. When waitForFollowUp() consumed the message from the queue, no UI update was triggered
3. The UI remained showing the queued message even though it was processed

Fix: Add onFollowUpConsumed callback to ToolUseServices that gets called in ToolUseWaitNode.post() after successfully consuming a follow-up. The callback is wired up in executeAgent.ts to call updateQueuedFollowUpsUI, which clears the queued message display.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures the queued follow-up indicator is cleared once a follow-up is consumed by the tool-use flow.
> 
> - Adds optional `onFollowUpConsumed` callback to `ToolUseServices` and `ToolUseFlowContextInit`
> - Calls `this.services.onFollowUpConsumed?.()` in `ToolUseWaitNode.post()` after a follow-up is retrieved
> - Wires the callback in `executeAgent.ts` (new and resume paths) to `updateQueuedFollowUpsUI(ctx.streamId)`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f19cec00fd9c967008f7e9d0e673132d2bf32f31. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->