### PR TITLE
feat: add memory tool system prompt when memory is enabled

### DIFF
--- a/src/agent/implementations/flows/tooluse/ToolUseFlowContext.ts
+++ b/src/agent/implementations/flows/tooluse/ToolUseFlowContext.ts
@@ -115,8 +115,13 @@ export async function prepareInitialState<C>(
   const runState = new AgentRunState();
   const workspaceState = AgentWorkspaceState.create();
 
+  // Check if memory tool is enabled for this session
+  const memoryEnabled = services.resolvedTools.some((t) => t.name === 'memory');
+
   const { systemPrompt, userPrefix, userRequest, instructionSuffix } =
-    await buildInitialToolUsePrompts(prompt, userVarChannels.transient, logger);
+    await buildInitialToolUsePrompts(prompt, userVarChannels.transient, logger, {
+      memoryEnabled,
+    });
 
   const messages = await modelHandler.initializeMessages(
     userPrefix,

--- a/src/utils/prompt/PromptBuilder.ts
+++ b/src/utils/prompt/PromptBuilder.ts
@@ -23,14 +23,16 @@ For math in responses, use $...$ for inline and $$...$$ for display math (not \\
 
 /** Instructions appended when memory tool is enabled */
 const MEMORY_TOOL_INSTRUCTIONS = `<memory_tool_instructions>
-You have access to a persistent memory system under /memories for storing important information across sessions.
-Use the memory tool to:
-- Store key findings, decisions, or context that may be useful later
-- Organize notes by topic using subdirectories (e.g., /memories/project-notes/, /memories/references/)
-- Review existing memories before starting complex tasks to maintain continuity
+IMPORTANT: ALWAYS VIEW YOUR MEMORY DIRECTORY BEFORE DOING ANYTHING ELSE.
 
-Memory commands: view (read file/directory), create (new file), str_replace (edit), insert (add lines), delete, rename.
-Keep memory files concise and well-organized. Prefer updating existing files over creating duplicates.
+MEMORY PROTOCOL:
+1. Use the \`view\` command of your \`memory\` tool to check for earlier progress.
+2. ... (work on the task) ...
+   - As you make progress, record status / progress / thoughts etc in your memory.
+
+ASSUME INTERRUPTION: Your context window might be reset at any moment, so you risk losing any progress that is not recorded in your memory directory.
+
+Note: when editing your memory folder, always try to keep its content up-to-date, coherent and organized. You can rename or delete files that are no longer relevant. Do not create new files unless necessary.
 </memory_tool_instructions>`;
 
 /**

--- a/src/utils/prompt/PromptBuilder.ts
+++ b/src/utils/prompt/PromptBuilder.ts
@@ -28,9 +28,10 @@ IMPORTANT: ALWAYS VIEW YOUR MEMORY DIRECTORY BEFORE DOING ANYTHING ELSE.
 MEMORY PROTOCOL:
 1. Use the \`view\` command of your \`memory\` tool to check for earlier progress.
 2. ... (work on the task) ...
-   - As you make progress, record status / progress / thoughts etc in your memory.
+   - As you make progress, record status, progress, and thoughts in your memory.
+   - Record user preferences and general style guidelines from the user.
 
-ASSUME INTERRUPTION: Your context window might be reset at any moment, so you risk losing any progress that is not recorded in your memory directory.
+Your memory persists across conversations, allowing you to continue tasks and remember user preferences over time.
 
 Note: when editing your memory folder, always try to keep its content up-to-date, coherent and organized. You can rename or delete files that are no longer relevant. Do not create new files unless necessary.
 </memory_tool_instructions>`;

--- a/src/utils/prompt/PromptBuilder.ts
+++ b/src/utils/prompt/PromptBuilder.ts
@@ -21,6 +21,18 @@ Call tools sequentially and wait for the output before calling another.
 For math in responses, use $...$ for inline and $$...$$ for display math (not \\(...\\) or \\[...\\]).
 </tool_use_instructions>`;
 
+/** Instructions appended when memory tool is enabled */
+const MEMORY_TOOL_INSTRUCTIONS = `<memory_tool_instructions>
+You have access to a persistent memory system under /memories for storing important information across sessions.
+Use the memory tool to:
+- Store key findings, decisions, or context that may be useful later
+- Organize notes by topic using subdirectories (e.g., /memories/project-notes/, /memories/references/)
+- Review existing memories before starting complex tasks to maintain continuity
+
+Memory commands: view (read file/directory), create (new file), str_replace (edit), insert (add lines), delete, rename.
+Keep memory files concise and well-organized. Prefer updating existing files over creating duplicates.
+</memory_tool_instructions>`;
+
 /**
  * Combine the base system prompt with optional rules from `.texrarules`.
  *
@@ -152,10 +164,16 @@ export type InitialPrompts = Awaited<
   ReturnType<PromptBuilder['buildInitialPrompts']>
 >;
 
+export interface ToolUsePromptOptions {
+  /** Whether the memory tool is enabled for this session */
+  memoryEnabled?: boolean;
+}
+
 export async function buildInitialToolUsePrompts(
   agentPrompt: AgentPrompt,
   userVars: Record<string, any>,
   logger?: AgentLogger,
+  options?: ToolUsePromptOptions,
 ): Promise<InitialPrompts & { instructionSuffix: string }> {
   const builder = new PromptBuilder(
     agentPrompt,
@@ -165,8 +183,15 @@ export async function buildInitialToolUsePrompts(
   );
   const initial = await builder.buildInitialPrompts();
 
+  // Build instruction suffix: always include tool-use instructions,
+  // optionally append memory instructions when enabled
+  const suffixParts = [TOOL_USE_INSTRUCTIONS];
+  if (options?.memoryEnabled) {
+    suffixParts.push(MEMORY_TOOL_INSTRUCTIONS);
+  }
+
   return {
     ...initial,
-    instructionSuffix: TOOL_USE_INSTRUCTIONS,
+    instructionSuffix: suffixParts.join('\n'),
   };
 }


### PR DESCRIPTION
Appends memory tool instructions to the system prompt when the memory
tool is detected in the resolved tools list. This provides the model
with guidance on using the persistent memory system for storing
important information across sessions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds conditional memory guidance to tool-use prompts.
> 
> - Detects `memory` tool in `ToolUseFlowContext` and passes `memoryEnabled` to `buildInitialToolUsePrompts`
> - `PromptBuilder.buildInitialToolUsePrompts` accepts `ToolUsePromptOptions` and appends `MEMORY_TOOL_INSTRUCTIONS` after `TOOL_USE_INSTRUCTIONS` when enabled
> - Introduces memory instruction template and maintains existing prompt-building flow
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4a3bb1c1dd9c89a9955769e75dc5ff45e1b9624b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->