### PR TITLE
refactor(webview): unify bootstrapping, centralize head markup, and simplify message handlers

### DIFF
--- a/src/common/modules/domUtils.js
+++ b/src/common/modules/domUtils.js
@@ -111,6 +111,13 @@ export function safeGetElementChecked(id) {
   return element.checked;
 }
 
+export function toggleHidden(element, isHidden) {
+  if (!element) {
+    return;
+  }
+  element.classList.toggle('is-hidden', isHidden);
+}
+
 export function setElementDisabled(element, disabled) {
   if (!element) {
     return;

--- a/src/common/modules/messageHandlerFactory.js
+++ b/src/common/modules/messageHandlerFactory.js
@@ -7,12 +7,7 @@ import { BaseWebviewMessageHandler } from './BaseWebviewMessageHandler.js';
  * @returns {BaseWebviewMessageHandler}
  */
 export function createMessageHandler(handlers) {
-  class ViewMessageHandler extends BaseWebviewMessageHandler {
-    constructor() {
-      super();
-      this._handlers = handlers;
-    }
-  }
-
-  return new ViewMessageHandler();
+  const instance = new BaseWebviewMessageHandler();
+  instance._handlers = handlers;
+  return instance;
 }

--- a/src/common/modules/messageHandlerFactory.js
+++ b/src/common/modules/messageHandlerFactory.js
@@ -1,0 +1,18 @@
+// Local imports - common
+import { BaseWebviewMessageHandler } from './BaseWebviewMessageHandler.js';
+
+/**
+ * Create a webview message handler instance for a handler map.
+ * @param {Record<string, Function>} handlers
+ * @returns {BaseWebviewMessageHandler}
+ */
+export function createMessageHandler(handlers) {
+  class ViewMessageHandler extends BaseWebviewMessageHandler {
+    constructor() {
+      super();
+      this._handlers = handlers;
+    }
+  }
+
+  return new ViewMessageHandler();
+}

--- a/src/common/modules/viewBootstrap.js
+++ b/src/common/modules/viewBootstrap.js
@@ -1,0 +1,42 @@
+// Local imports - common
+
+/**
+ * Bootstrap a webview with consistent lifecycle hooks.
+ * @param {Object} options
+ * @param {Function} [options.initializeState]
+ * @param {Function} [options.setupHandlers]
+ * @param {Function} [options.beforeDomReady]
+ * @param {Function} [options.onDomReady]
+ * @param {Function} [options.onDispose]
+ */
+export function bootstrapWebview({
+  initializeState,
+  setupHandlers,
+  beforeDomReady,
+  onDomReady,
+  onDispose,
+} = {}) {
+  if (initializeState) {
+    initializeState();
+  }
+
+  if (setupHandlers) {
+    setupHandlers();
+  }
+
+  if (beforeDomReady) {
+    beforeDomReady();
+  }
+
+  document.addEventListener('DOMContentLoaded', () => {
+    if (onDomReady) {
+      onDomReady();
+    }
+  });
+
+  window.addEventListener('beforeunload', () => {
+    if (onDispose) {
+      onDispose();
+    }
+  });
+}

--- a/src/common/modules/viewBootstrap.js
+++ b/src/common/modules/viewBootstrap.js
@@ -5,14 +5,12 @@
  * @param {Object} options
  * @param {Function} [options.initializeState]
  * @param {Function} [options.setupHandlers]
- * @param {Function} [options.beforeDomReady]
  * @param {Function} [options.onDomReady]
  * @param {Function} [options.onDispose]
  */
 export function bootstrapWebview({
   initializeState,
   setupHandlers,
-  beforeDomReady,
   onDomReady,
   onDispose,
 } = {}) {
@@ -22,10 +20,6 @@ export function bootstrapWebview({
 
   if (setupHandlers) {
     setupHandlers();
-  }
-
-  if (beforeDomReady) {
-    beforeDomReady();
   }
 
   document.addEventListener('DOMContentLoaded', () => {

--- a/src/common/styles/common.css
+++ b/src/common/styles/common.css
@@ -118,6 +118,11 @@ vscode-toolbar-container {
   flex-wrap: nowrap;
 }
 
+/* Visibility helpers */
+.is-hidden {
+  display: none !important;
+}
+
 vscode-toolbar-button {
   flex-shrink: 0;
 }

--- a/src/common/webview/BaseViewContentProvider.ts
+++ b/src/common/webview/BaseViewContentProvider.ts
@@ -125,7 +125,10 @@ export abstract class BaseViewContentProvider {
       const commonUris = this.getCommonModuleUris(webview);
       const sharedUris = this.getSharedModuleUris(webview);
       const specificUris = this.getModuleUris(webview);
-      const templateVariables = this.getTemplateVariables();
+      const templateVariables = {
+        commonHead: this.buildCommonHead(sharedUris, commonUris),
+        ...this.getTemplateVariables(),
+      };
 
       this.logger.debug(
         this.channel,
@@ -155,6 +158,7 @@ export abstract class BaseViewContentProvider {
   ): Record<string, vscode.Uri> {
     return {
       commonStyleUri: this.getCommonUri(webview, 'styles/common.css'),
+      viewBootstrapUri: this.getCommonUri(webview, 'modules/viewBootstrap.js'),
       webviewStateUri: this.getCommonUri(webview, 'modules/webviewState.js'),
       webviewContextUri: this.getCommonUri(
         webview,
@@ -166,6 +170,10 @@ export abstract class BaseViewContentProvider {
         'webview/themeHandlers.js',
       ),
       templateUtilsUri: this.getCommonUri(webview, 'modules/templateUtils.js'),
+      messageHandlerFactoryUri: this.getCommonUri(
+        webview,
+        'modules/messageHandlerFactory.js',
+      ),
       recordingButtonManagerUri: this.getCommonUri(
         webview,
         'modules/RecordingButtonManager.js',
@@ -213,5 +221,24 @@ export abstract class BaseViewContentProvider {
         '@vscode/codicons/dist/codicon.ttf',
       ),
     };
+  }
+
+  private buildCommonHead(
+    sharedUris: Record<string, vscode.Uri>,
+    commonUris: Record<string, vscode.Uri>,
+  ): string {
+    const commonStyleUri = commonUris.commonStyleUri?.toString() ?? '';
+    const styleUri = sharedUris.styleUri?.toString() ?? '';
+    const codiconUri = commonUris.codiconUri?.toString() ?? '';
+
+    return [
+      `<link rel="stylesheet" href="${commonStyleUri}" />`,
+      `<link rel="stylesheet" href="${styleUri}" />`,
+      `<link`,
+      `  rel="stylesheet"`,
+      `  href="${codiconUri}"`,
+      `  id="vscode-codicon-stylesheet"`,
+      `/>`,
+    ].join('\n    ');
   }
 }

--- a/src/historyView/index.html
+++ b/src/historyView/index.html
@@ -7,13 +7,7 @@
       http-equiv="Content-Security-Policy"
       content="default-src 'none'; style-src ${cspSource} vscode-resource: 'unsafe-inline'; script-src 'nonce-${nonce}' https://cdnjs.cloudflare.com https://esm.sh; connect-src https://cdnjs.cloudflare.com https://esm.sh; font-src ${cspSource} vscode-resource:;"
     />
-    <link rel="stylesheet" href="${commonStyleUri}" />
-    <link rel="stylesheet" href="${styleUri}" />
-    <link
-      rel="stylesheet"
-      href="${codiconUri}"
-      id="vscode-codicon-stylesheet"
-    />
+    ${commonHead}
     <title>TeXRA History</title>
     <script
       nonce="${nonce}"
@@ -38,7 +32,9 @@
           "@common/htmlEncoding.js": "${htmlEncodingUri}",
           "@common/iconConstants.js": "${iconConstantsUri}",
           "@common/BaseWebviewMessageHandler.js": "${baseWebviewMessageHandlerUri}",
+          "@common/messageHandlerFactory.js": "${messageHandlerFactoryUri}",
           "@common/BaseDomHandler.js": "${baseDomHandlerUri}",
+          "@common/viewBootstrap.js": "${viewBootstrapUri}",
           "@common/ToggleStateStore.js": "${toggleStateStoreUri}",
           "@common/constants/agentTypes.js": "${agentTypesUri}",
           "he": "https://esm.sh/he@1.2.0"

--- a/src/historyView/modules/domHandlers.js
+++ b/src/historyView/modules/domHandlers.js
@@ -1,9 +1,9 @@
 // Local imports - history view
 import { historyViewState } from './historyViewState.js';
 import { HistoryEventsManager } from './uiManagers/HistoryEventsManager.js';
-// Local imports
 import { HistoryRenderer } from './uiManagers/HistoryRenderer.js';
 import { SearchManager } from './uiManagers/SearchManager.js';
+// Local imports - common
 import { BaseDomHandler } from '@common/BaseDomHandler.js';
 
 /**

--- a/src/historyView/modules/messageHandlers.js
+++ b/src/historyView/modules/messageHandlers.js
@@ -1,29 +1,18 @@
 // Local imports - history view
 import { historyViewDomHandler } from './domHandlers.js';
+// Local imports - common
 import { HISTORY_VIEW_COMMANDS } from '@common/webview/commands.js';
-import { BaseWebviewMessageHandler } from '@common/BaseWebviewMessageHandler.js';
+import { createMessageHandler } from '@common/messageHandlerFactory.js';
 
-/**
- * Handles messages from the extension for the history view.
- */
-export class HistoryViewMessageHandler extends BaseWebviewMessageHandler {
-  constructor() {
-    super();
-    this._handlers = {
-      [HISTORY_VIEW_COMMANDS.UPDATE_HISTORY]: (m) =>
-        this.handleUpdateHistory(m),
-      [HISTORY_VIEW_COMMANDS.HISTORY_CLEARED]: () =>
-        this.handleHistoryCleared(),
-    };
-  }
-
-  handleUpdateHistory(message) {
-    historyViewDomHandler.renderer.render(message.historyItems);
-  }
-
-  handleHistoryCleared() {
-    historyViewDomHandler.renderer.render([]);
-  }
+function handleUpdateHistory(message) {
+  historyViewDomHandler.renderer.render(message.historyItems);
 }
 
-export const messageHandler = new HistoryViewMessageHandler();
+function handleHistoryCleared() {
+  historyViewDomHandler.renderer.render([]);
+}
+
+export const messageHandler = createMessageHandler({
+  [HISTORY_VIEW_COMMANDS.UPDATE_HISTORY]: handleUpdateHistory,
+  [HISTORY_VIEW_COMMANDS.HISTORY_CLEARED]: handleHistoryCleared,
+});

--- a/src/historyView/script.js
+++ b/src/historyView/script.js
@@ -15,7 +15,8 @@ bootstrapWebview({
     vscode.postMessage({ command: HISTORY_VIEW_COMMANDS.GET_HISTORY_DATA });
   },
   onDispose: () => {
-    historyViewDomHandler.dispose();
+    historyViewDomHandler.events.dispose();
+    historyViewDomHandler.searchManager.dispose();
     messageHandler.dispose();
   },
 });

--- a/src/historyView/script.js
+++ b/src/historyView/script.js
@@ -2,21 +2,20 @@
 import { historyViewDomHandler } from './modules/domHandlers.js';
 import { historyViewState } from './modules/historyViewState.js';
 import { messageHandler } from './modules/messageHandlers.js';
+// Local imports - common
 import { HISTORY_VIEW_COMMANDS } from '@common/webview/commands.js';
+import { bootstrapWebview } from '@common/viewBootstrap.js';
 import { vscode } from '@common/webviewContext.js';
 
-historyViewState.initialize();
-
-// Register handlers early so messages aren't missed
-messageHandler.setup();
-
-document.addEventListener('DOMContentLoaded', () => {
-  historyViewDomHandler.events.setup();
-  vscode.postMessage({ command: HISTORY_VIEW_COMMANDS.GET_HISTORY_DATA });
-});
-
-window.addEventListener('beforeunload', () => {
-  historyViewDomHandler.events.dispose();
-  historyViewDomHandler.searchManager.dispose();
-  messageHandler.dispose();
+bootstrapWebview({
+  initializeState: () => historyViewState.initialize(),
+  setupHandlers: () => messageHandler.setup(),
+  onDomReady: () => {
+    historyViewDomHandler.events.setup();
+    vscode.postMessage({ command: HISTORY_VIEW_COMMANDS.GET_HISTORY_DATA });
+  },
+  onDispose: () => {
+    historyViewDomHandler.dispose();
+    messageHandler.dispose();
+  },
 });

--- a/src/memoryView/index.html
+++ b/src/memoryView/index.html
@@ -7,13 +7,7 @@
       http-equiv="Content-Security-Policy"
       content="default-src 'none'; style-src ${cspSource} vscode-resource: 'unsafe-inline'; script-src 'nonce-${nonce}'; font-src ${cspSource} vscode-resource:;"
     />
-    <link rel="stylesheet" href="${commonStyleUri}" />
-    <link rel="stylesheet" href="${styleUri}" />
-    <link
-      rel="stylesheet"
-      href="${codiconUri}"
-      id="vscode-codicon-stylesheet"
-    />
+    ${commonHead}
     <title>TeXRA Memory</title>
     <script type="importmap" nonce="${nonce}">
       {
@@ -31,7 +25,9 @@
           "@common/templateUtils.js": "${templateUtilsUri}",
           "@common/htmlEncoding.js": "${htmlEncodingUri}",
           "@common/BaseWebviewMessageHandler.js": "${baseWebviewMessageHandlerUri}",
-          "@common/BaseDomHandler.js": "${baseDomHandlerUri}"
+          "@common/messageHandlerFactory.js": "${messageHandlerFactoryUri}",
+          "@common/BaseDomHandler.js": "${baseDomHandlerUri}",
+          "@common/viewBootstrap.js": "${viewBootstrapUri}"
         }
       }
     </script>

--- a/src/memoryView/modules/domHandlers.js
+++ b/src/memoryView/modules/domHandlers.js
@@ -1,6 +1,8 @@
 // Local imports - memory view
 import { MemoryEventsManager } from './uiManagers/MemoryEventsManager.js';
-import { memoryRenderer } from './uiManagers/MemoryRenderer.js';
+import { MemoryRenderer } from './uiManagers/MemoryRenderer.js';
+import { memoryViewState } from './memoryViewState.js';
+// Local imports - common
 import { BaseDomHandler } from '@common/BaseDomHandler.js';
 
 /**
@@ -9,9 +11,10 @@ import { BaseDomHandler } from '@common/BaseDomHandler.js';
  */
 class MemoryViewDomHandler extends BaseDomHandler {
   constructor() {
-    super();
-    this.events = new MemoryEventsManager();
-    this.renderer = memoryRenderer;
+    super({
+      events: new MemoryEventsManager(),
+      renderer: new MemoryRenderer(memoryViewState),
+    });
   }
 
   /**

--- a/src/memoryView/modules/messageHandlers.js
+++ b/src/memoryView/modules/messageHandlers.js
@@ -1,22 +1,13 @@
 // Local imports - memory view
 import { memoryViewDomHandler } from './domHandlers.js';
+// Local imports - common
 import { MEMORY_VIEW_COMMANDS } from '@common/webview/commands.js';
-import { BaseWebviewMessageHandler } from '@common/BaseWebviewMessageHandler.js';
+import { createMessageHandler } from '@common/messageHandlerFactory.js';
 
-/**
- * Handles messages from the extension for the memory view.
- */
-export class MemoryViewMessageHandler extends BaseWebviewMessageHandler {
-  constructor() {
-    super();
-    this._handlers = {
-      [MEMORY_VIEW_COMMANDS.UPDATE_MEMORY]: (m) => this.handleUpdateMemory(m),
-    };
-  }
-
-  handleUpdateMemory(message) {
-    memoryViewDomHandler.renderMemoryItems(message.items);
-  }
+function handleUpdateMemory(message) {
+  memoryViewDomHandler.renderMemoryItems(message.items);
 }
 
-export const messageHandler = new MemoryViewMessageHandler();
+export const messageHandler = createMessageHandler({
+  [MEMORY_VIEW_COMMANDS.UPDATE_MEMORY]: handleUpdateMemory,
+});

--- a/src/memoryView/modules/uiManagers/MemoryRenderer.js
+++ b/src/memoryView/modules/uiManagers/MemoryRenderer.js
@@ -1,6 +1,6 @@
 // Local imports - memory view
 import { COMMANDS, ELEMENT_IDS, LABELS } from '../constants.js';
-import { memoryViewState } from '../memoryViewState.js';
+// Local imports - common
 import { clearElement, safeGetElementById } from '@common/domUtils.js';
 import { createFromTemplate } from '@common/templateUtils.js';
 
@@ -119,5 +119,3 @@ export class MemoryRenderer {
     return `${value.toFixed(1)} ${units[unitIndex]}`;
   }
 }
-
-export const memoryRenderer = new MemoryRenderer(memoryViewState);

--- a/src/memoryView/script.js
+++ b/src/memoryView/script.js
@@ -2,20 +2,20 @@
 import { memoryViewDomHandler } from './modules/domHandlers.js';
 import { memoryViewState } from './modules/memoryViewState.js';
 import { messageHandler } from './modules/messageHandlers.js';
+// Local imports - common
 import { MEMORY_VIEW_COMMANDS } from '@common/webview/commands.js';
+import { bootstrapWebview } from '@common/viewBootstrap.js';
 import { vscode } from '@common/webviewContext.js';
 
-memoryViewState.initialize();
-
-// Register handlers early so messages aren't missed
-messageHandler.setup();
-
-document.addEventListener('DOMContentLoaded', () => {
-  memoryViewDomHandler.events.setup();
-  vscode.postMessage({ command: MEMORY_VIEW_COMMANDS.GET_MEMORY_DATA });
-});
-
-window.addEventListener('beforeunload', () => {
-  memoryViewDomHandler.events.dispose();
-  messageHandler.dispose();
+bootstrapWebview({
+  initializeState: () => memoryViewState.initialize(),
+  setupHandlers: () => messageHandler.setup(),
+  onDomReady: () => {
+    memoryViewDomHandler.events.setup();
+    vscode.postMessage({ command: MEMORY_VIEW_COMMANDS.GET_MEMORY_DATA });
+  },
+  onDispose: () => {
+    memoryViewDomHandler.dispose();
+    messageHandler.dispose();
+  },
 });

--- a/src/profileView/index.html
+++ b/src/profileView/index.html
@@ -7,13 +7,7 @@
       http-equiv="Content-Security-Policy"
       content="default-src 'none'; style-src ${cspSource} vscode-resource: 'unsafe-inline'; script-src 'nonce-${nonce}'; font-src ${cspSource} vscode-resource:;"
     />
-    <link rel="stylesheet" href="${commonStyleUri}" />
-    <link rel="stylesheet" href="${styleUri}" />
-    <link
-      rel="stylesheet"
-      href="${codiconUri}"
-      id="vscode-codicon-stylesheet"
-    />
+    ${commonHead}
     <title>TeXRA Profile</title>
     <script type="importmap" nonce="${nonce}">
       {
@@ -31,7 +25,9 @@
           "@common/templateUtils.js": "${templateUtilsUri}",
           "@common/htmlEncoding.js": "${htmlEncodingUri}",
           "@common/BaseWebviewMessageHandler.js": "${baseWebviewMessageHandlerUri}",
-          "@common/BaseDomHandler.js": "${baseDomHandlerUri}"
+          "@common/messageHandlerFactory.js": "${messageHandlerFactoryUri}",
+          "@common/BaseDomHandler.js": "${baseDomHandlerUri}",
+          "@common/viewBootstrap.js": "${viewBootstrapUri}"
         }
       }
     </script>
@@ -62,17 +58,13 @@
           <span class="label">Tier:</span>
           <span id="userTier" class="badge tier-badge">Loading...</span>
         </div>
-        <div id="accessExpirationRow" class="info-row" style="display: none">
+        <div id="accessExpirationRow" class="info-row is-hidden">
           <span class="label">Access Expires:</span>
           <span id="accessExpiration" class="value"></span>
         </div>
       </div>
 
-      <div
-        id="apiAccessSection"
-        class="api-access-section"
-        style="display: none"
-      >
+      <div id="apiAccessSection" class="api-access-section is-hidden">
         <h2>Model Access</h2>
         <p class="api-access-description">
           As a subscriber, you can use TeXRA's included model access or provide
@@ -108,11 +100,7 @@
             </span>
           </label>
         </div>
-        <details
-          id="modelAccessInfo"
-          class="model-access-info"
-          style="display: none"
-        >
+        <details id="modelAccessInfo" class="model-access-info is-hidden">
           <summary class="model-access-summary">
             <span id="enabledProvidersInfo"></span>
             <span class="separator">·</span>
@@ -122,11 +110,7 @@
         </details>
       </div>
 
-      <div
-        id="notAuthenticated"
-        class="not-authenticated"
-        style="display: none"
-      >
+      <div id="notAuthenticated" class="not-authenticated is-hidden">
         <p>You are not signed in to TeXRA.</p>
         <vscode-button id="signInBtn">
           <span slot="start" class="codicon codicon-sign-in"></span>
@@ -134,16 +118,12 @@
         </vscode-button>
       </div>
 
-      <div
-        id="remoteAgentsSection"
-        class="remote-agents-section"
-        style="display: none"
-      >
+      <div id="remoteAgentsSection" class="remote-agents-section is-hidden">
         <h2>Available Remote Agents</h2>
         <div id="agentsTableContainer">
           <!-- Agents table will be rendered here -->
         </div>
-        <p id="noAgentsMessage" class="no-agents" style="display: none">
+        <p id="noAgentsMessage" class="no-agents is-hidden">
           No remote agents available. Contact support@texra.ai for assistance.
         </p>
       </div>

--- a/src/profileView/modules/constants.js
+++ b/src/profileView/modules/constants.js
@@ -38,6 +38,7 @@ export const CLASS_NAMES = {
   AGENT_ROW: 'agent-row',
   SELECT_BTN: 'select-btn',
   TAG: 'tag',
+  HIDDEN: 'is-hidden',
 };
 
 // Default values

--- a/src/profileView/modules/constants.js
+++ b/src/profileView/modules/constants.js
@@ -38,7 +38,6 @@ export const CLASS_NAMES = {
   AGENT_ROW: 'agent-row',
   SELECT_BTN: 'select-btn',
   TAG: 'tag',
-  HIDDEN: 'is-hidden',
 };
 
 // Default values

--- a/src/profileView/modules/messageHandlers.js
+++ b/src/profileView/modules/messageHandlers.js
@@ -1,56 +1,46 @@
 // Local imports - profile view
 import { profileViewDomHandler } from './domHandlers.js';
 import { profileViewState } from './profileViewState.js';
+// Local imports - common
 import { PROFILE_VIEW_COMMANDS } from '@common/webview/commands.js';
-import { BaseWebviewMessageHandler } from '@common/BaseWebviewMessageHandler.js';
+import { createMessageHandler } from '@common/messageHandlerFactory.js';
 
-/**
- * Handles messages from the extension for the profile view.
- */
-export class ProfileViewMessageHandler extends BaseWebviewMessageHandler {
-  constructor() {
-    super();
-    this._handlers = {
-      [PROFILE_VIEW_COMMANDS.UPDATE_PROFILE]: (m) =>
-        this.handleUpdateProfile(m),
-    };
-  }
+function handleUpdateProfile(message) {
+  // allowedModels semantics (from backend ProfileViewMessageHandler.ts):
+  // - null: all models allowed (Ultra tier)
+  // - []: no models available (unauthenticated, or Max tier with failed config fetch)
+  // - string[]: specific models allowed (Max tier with successful config)
+  // Note: undefined fallback to [] handles potential message serialization edge cases
+  const allowedModels =
+    message.allowedModels === undefined ? [] : message.allowedModels;
 
-  handleUpdateProfile(message) {
-    // allowedModels semantics (from backend ProfileViewMessageHandler.ts):
-    // - null: all models allowed (Ultra tier)
-    // - []: no models available (unauthenticated, or Max tier with failed config fetch)
-    // - string[]: specific models allowed (Max tier with successful config)
-    // Note: undefined fallback to [] handles potential message serialization edge cases
-    const allowedModels =
-      message.allowedModels === undefined ? [] : message.allowedModels;
+  // Update state
+  profileViewState.updateProfile({
+    authenticated: message.authenticated,
+    user: message.user,
+    tier: message.tier,
+    remoteAgents: message.remoteAgents,
+    apiAccessMode: message.apiAccessMode,
+    enabledProviders: message.enabledProviders ?? [],
+    allowedModels,
+    tierConstants: message.tierConstants,
+    accessExpiresAt: message.accessExpiresAt ?? null,
+  });
 
-    // Update state
-    profileViewState.updateProfile({
-      authenticated: message.authenticated,
-      user: message.user,
-      tier: message.tier,
-      remoteAgents: message.remoteAgents,
-      apiAccessMode: message.apiAccessMode,
-      enabledProviders: message.enabledProviders ?? [],
-      allowedModels,
-      tierConstants: message.tierConstants,
-      accessExpiresAt: message.accessExpiresAt ?? null,
-    });
-
-    // Update UI
-    profileViewDomHandler.agentsTable.render({
-      authenticated: message.authenticated,
-      user: message.user,
-      tier: message.tier,
-      remoteAgents: message.remoteAgents,
-      apiAccessMode: message.apiAccessMode,
-      enabledProviders: message.enabledProviders ?? [],
-      allowedModels,
-      tierConstants: message.tierConstants,
-      accessExpiresAt: message.accessExpiresAt ?? null,
-    });
-  }
+  // Update UI
+  profileViewDomHandler.agentsTable.render({
+    authenticated: message.authenticated,
+    user: message.user,
+    tier: message.tier,
+    remoteAgents: message.remoteAgents,
+    apiAccessMode: message.apiAccessMode,
+    enabledProviders: message.enabledProviders ?? [],
+    allowedModels,
+    tierConstants: message.tierConstants,
+    accessExpiresAt: message.accessExpiresAt ?? null,
+  });
 }
 
-export const messageHandler = new ProfileViewMessageHandler();
+export const messageHandler = createMessageHandler({
+  [PROFILE_VIEW_COMMANDS.UPDATE_PROFILE]: handleUpdateProfile,
+});

--- a/src/profileView/modules/uiManagers/AgentsTable.js
+++ b/src/profileView/modules/uiManagers/AgentsTable.js
@@ -1,9 +1,17 @@
 /* global document, console */
 // Local imports - profile view
 import { ELEMENT_IDS, CLASS_NAMES } from '../constants.js';
+// Local imports - common
 import { PROFILE_VIEW_COMMANDS } from '@common/webview/commands.js';
 import { vscode } from '@common/webviewContext.js';
 import { safeGetElementById } from '@common/domUtils.js';
+
+const toggleHidden = (element, isHidden) => {
+  if (!element) {
+    return;
+  }
+  element.classList.toggle(CLASS_NAMES.HIDDEN, isHidden);
+};
 
 /**
  * Manages the agents table rendering and interactions.
@@ -70,16 +78,18 @@ export class AgentsTable {
 
     if (!authenticated) {
       // Show not authenticated state
-      profileInfo.style.display = 'none';
-      notAuthenticated.style.display = 'block';
-      remoteAgentsSection.style.display = 'none';
-      if (apiAccessSection) apiAccessSection.style.display = 'none';
+      toggleHidden(profileInfo, true);
+      toggleHidden(notAuthenticated, false);
+      toggleHidden(remoteAgentsSection, true);
+      if (apiAccessSection) {
+        toggleHidden(apiAccessSection, true);
+      }
       return;
     }
 
     // Show authenticated state
-    profileInfo.style.display = 'block';
-    notAuthenticated.style.display = 'none';
+    toggleHidden(profileInfo, false);
+    toggleHidden(notAuthenticated, true);
 
     // Update user info
     const userEmail = safeGetElementById(ELEMENT_IDS.USER_EMAIL);
@@ -105,17 +115,17 @@ export class AgentsTable {
           undefined,
           { year: 'numeric', month: 'short', day: 'numeric' },
         );
-        expirationRow.style.display = 'flex';
+        toggleHidden(expirationRow, false);
       } else {
         // No expiration - don't show the row
-        expirationRow.style.display = 'none';
+        toggleHidden(expirationRow, true);
       }
     }
 
     // Show API access section for all authenticated users
     // All tiers have some server-side access (free=budget, Max=mid-tier, Ultra=all)
     if (apiAccessSection) {
-      apiAccessSection.style.display = 'block';
+      toggleHidden(apiAccessSection, false);
       this.renderApiAccessSection(
         apiAccessMode,
         enabledProviders,
@@ -125,14 +135,14 @@ export class AgentsTable {
 
     // Show remote agents section for all authenticated users
     // RLS filters which agents they can see based on permissions
-    remoteAgentsSection.style.display = 'block';
+    toggleHidden(remoteAgentsSection, false);
 
     if (remoteAgents && remoteAgents.length > 0) {
       this.renderAgentsTable(remoteAgents);
-      noAgentsMessage.style.display = 'none';
+      toggleHidden(noAgentsMessage, true);
     } else {
       if (this.container) this.container.innerHTML = '';
-      noAgentsMessage.style.display = 'block';
+      toggleHidden(noAgentsMessage, false);
     }
   }
 
@@ -175,7 +185,7 @@ export class AgentsTable {
       enabledProviders.length > 0;
 
     if (modelAccessInfo) {
-      modelAccessInfo.style.display = showModelAccessInfo ? 'block' : 'none';
+      toggleHidden(modelAccessInfo, !showModelAccessInfo);
     }
 
     // Update providers info with count format

--- a/src/profileView/modules/uiManagers/AgentsTable.js
+++ b/src/profileView/modules/uiManagers/AgentsTable.js
@@ -4,14 +4,7 @@ import { ELEMENT_IDS, CLASS_NAMES } from '../constants.js';
 // Local imports - common
 import { PROFILE_VIEW_COMMANDS } from '@common/webview/commands.js';
 import { vscode } from '@common/webviewContext.js';
-import { safeGetElementById } from '@common/domUtils.js';
-
-const toggleHidden = (element, isHidden) => {
-  if (!element) {
-    return;
-  }
-  element.classList.toggle(CLASS_NAMES.HIDDEN, isHidden);
-};
+import { safeGetElementById, toggleHidden } from '@common/domUtils.js';
 
 /**
  * Manages the agents table rendering and interactions.

--- a/src/profileView/script.js
+++ b/src/profileView/script.js
@@ -1,22 +1,21 @@
-/* global document, window */
 // Local imports - profile view
 import { profileViewDomHandler } from './modules/domHandlers.js';
 import { profileViewState } from './modules/profileViewState.js';
 import { messageHandler } from './modules/messageHandlers.js';
+// Local imports - common
 import { PROFILE_VIEW_COMMANDS } from '@common/webview/commands.js';
+import { bootstrapWebview } from '@common/viewBootstrap.js';
 import { vscode } from '@common/webviewContext.js';
 
-profileViewState.initialize();
-
-// Register handlers early so messages aren't missed
-messageHandler.setup();
-
-document.addEventListener('DOMContentLoaded', () => {
-  profileViewDomHandler.events.setup();
-  vscode.postMessage({ command: PROFILE_VIEW_COMMANDS.GET_PROFILE_DATA });
-});
-
-window.addEventListener('beforeunload', () => {
-  profileViewDomHandler.events.dispose();
-  messageHandler.dispose();
+bootstrapWebview({
+  initializeState: () => profileViewState.initialize(),
+  setupHandlers: () => messageHandler.setup(),
+  onDomReady: () => {
+    profileViewDomHandler.events.setup();
+    vscode.postMessage({ command: PROFILE_VIEW_COMMANDS.GET_PROFILE_DATA });
+  },
+  onDispose: () => {
+    profileViewDomHandler.dispose();
+    messageHandler.dispose();
+  },
 });

--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -7,13 +7,7 @@
       http-equiv="Content-Security-Policy"
       content="default-src 'none'; style-src ${cspSource} vscode-resource: 'unsafe-inline' https://cdn.jsdelivr.net; script-src 'nonce-${nonce}' https://esm.sh; connect-src https://esm.sh; font-src ${cspSource} vscode-resource: https://cdn.jsdelivr.net; img-src ${cspSource} data: https:;"
     />
-    <link rel="stylesheet" href="${commonStyleUri}" />
-    <link rel="stylesheet" href="${styleUri}" />
-    <link
-      rel="stylesheet"
-      href="${codiconUri}"
-      id="vscode-codicon-stylesheet"
-    />
+    ${commonHead}
     <link
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/npm/katex@0.16.22/dist/katex.min.css"
@@ -57,6 +51,7 @@
           "@common/webview/themeHandlers.js": "${webviewThemeHandlersUri}",
           "@common/webviewState.js": "${webviewStateUri}",
           "@common/templateUtils.js": "${templateUtilsUri}",
+          "@common/viewBootstrap.js": "${viewBootstrapUri}",
           "@common/RecordingButtonManager.js": "${recordingButtonManagerUri}",
           "@common/textareaUtils.js": "${textareaUtilsUri}",
           "@common/modules/files/baseFileUtils.js": "${baseFileUtilsUri}",

--- a/src/progressView/modules/domHandlers.js
+++ b/src/progressView/modules/domHandlers.js
@@ -74,10 +74,6 @@ class ProgressViewDomHandler extends BaseDomHandler {
     this.retryRequests.setup();
     this.events.applyToggleStates();
   }
-
-  disposeUI() {
-    this.dispose();
-  }
 }
 
 export const progressViewDomHandler = new ProgressViewDomHandler();

--- a/src/progressView/modules/domHandlers.js
+++ b/src/progressView/modules/domHandlers.js
@@ -1,6 +1,4 @@
 // Local imports - progress view
-// Local imports
-import { progressViewState } from './progressViewState.js';
 import { TaskGroupDomManager, LogEntryManager } from './taskManagers.js';
 import { EventsManager } from './uiManagers/EventsManager.js';
 import { FileList } from './uiManagers/FileList.js';
@@ -16,7 +14,9 @@ import { Toolbar } from './uiManagers/Toolbar.js';
 import { TodoList } from './uiManagers/TodoList.js';
 import { QueuedFollowUps } from './uiManagers/QueuedFollowUps.js';
 import { UsageSummary } from './usageManagers.js';
+// Local imports - common
 import { BaseDomHandler } from '@common/BaseDomHandler.js';
+import { validateTemplates } from '@common/templateUtils.js';
 import { vscode } from '@common/webviewContext.js';
 
 /**
@@ -44,6 +44,39 @@ class ProgressViewDomHandler extends BaseDomHandler {
       todoList: new TodoList(),
       queuedFollowUps: new QueuedFollowUps(),
     });
+  }
+
+  initializeUI() {
+    validateTemplates([
+      'fileItemTemplate',
+      'usageTemplate',
+      'bulletTemplate',
+      'streamTabTemplate',
+      'roundHeaderTemplate',
+      'logLineTemplate',
+      'nativeStatusTemplate',
+      'bannerDetailsTemplate',
+      'toolUseTemplate',
+      'fileListDetailsTemplate',
+      'missingOutputsDetailsTemplate',
+      'latexdiffDetailsTemplate',
+      'statisticsDetailsTemplate',
+      'groupHeaderTemplate',
+      'groupDetailsTemplate',
+      'retryRequestTemplate',
+      'approvalRequestTemplate',
+    ]);
+    this.toolbar.render('workflow');
+    this.placeholder.show();
+    this.events.setup();
+    this.followUpInput.setup();
+    this.approvalRequests.setup();
+    this.retryRequests.setup();
+    this.events.applyToggleStates();
+  }
+
+  disposeUI() {
+    this.dispose();
   }
 }
 

--- a/src/progressView/modules/progressViewState.js
+++ b/src/progressView/modules/progressViewState.js
@@ -329,6 +329,10 @@ export class ProgressViewState {
     }
   }
 
+  initialize() {
+    this.load();
+  }
+
   setStreams(streams) {
     this.streams = new Set(streams?.filter(Boolean));
   }

--- a/src/progressView/script.js
+++ b/src/progressView/script.js
@@ -16,6 +16,6 @@ bootstrapWebview({
   },
   onDispose: () => {
     messageHandler.dispose();
-    progressViewDomHandler.disposeUI();
+    progressViewDomHandler.dispose();
   },
 });

--- a/src/progressView/script.js
+++ b/src/progressView/script.js
@@ -3,51 +3,19 @@ import { COMMANDS } from './modules/constants.js';
 import { progressViewDomHandler } from './modules/domHandlers.js';
 import { messageHandler } from './modules/messageHandlers.js';
 import { progressViewState } from './modules/progressViewState.js';
-import { validateTemplates } from '@common/templateUtils.js';
+// Local imports - common
+import { bootstrapWebview } from '@common/viewBootstrap.js';
 import { vscode } from '@common/webviewContext.js';
 
-// Initialize the state when the window loads
-progressViewState.load();
-
-// Register handlers for VSCode messages
-messageHandler.setup();
-
-window.addEventListener('beforeunload', () => {
-  messageHandler.dispose();
-});
-
-// Initialize event listeners and state when DOM is loaded
-document.addEventListener('DOMContentLoaded', () => {
-  validateTemplates([
-    'fileItemTemplate',
-    'usageTemplate',
-    'bulletTemplate',
-    'streamTabTemplate',
-    'roundHeaderTemplate',
-    'logLineTemplate',
-    'nativeStatusTemplate',
-    'bannerDetailsTemplate',
-    'toolUseTemplate',
-    'fileListDetailsTemplate',
-    'missingOutputsDetailsTemplate',
-    'latexdiffDetailsTemplate',
-    'statisticsDetailsTemplate',
-    'groupHeaderTemplate',
-    'groupDetailsTemplate',
-    'retryRequestTemplate',
-    'approvalRequestTemplate',
-  ]);
-  progressViewDomHandler.toolbar.render('workflow');
-  progressViewDomHandler.placeholder.show();
-  // Setup UI event listeners
-  progressViewDomHandler.events.setup();
-  progressViewDomHandler.followUpInput.setup();
-  progressViewDomHandler.approvalRequests.setup();
-  progressViewDomHandler.retryRequests.setup();
-
-  // Apply saved group toggle states to any groups already in the DOM
-  progressViewDomHandler.events.applyToggleStates();
-
-  // Notify extension that the webview is ready to receive messages
-  vscode.postMessage({ command: COMMANDS.WEBVIEW_READY });
+bootstrapWebview({
+  initializeState: () => progressViewState.initialize(),
+  setupHandlers: () => messageHandler.setup(),
+  onDomReady: () => {
+    progressViewDomHandler.initializeUI();
+    vscode.postMessage({ command: COMMANDS.WEBVIEW_READY });
+  },
+  onDispose: () => {
+    messageHandler.dispose();
+    progressViewDomHandler.disposeUI();
+  },
 });

--- a/src/webview/index.html
+++ b/src/webview/index.html
@@ -7,13 +7,7 @@
       http-equiv="Content-Security-Policy"
       content="default-src 'none'; style-src ${cspSource} vscode-resource: 'unsafe-inline'; script-src 'nonce-${nonce}' https://cdnjs.cloudflare.com https://unpkg.com; connect-src https://cdnjs.cloudflare.com https://unpkg.com; img-src https: vscode-resource:; font-src ${cspSource} vscode-resource:;"
     />
-    <link rel="stylesheet" href="${commonStyleUri}" />
-    <link rel="stylesheet" href="${styleUri}" />
-    <link
-      rel="stylesheet"
-      href="${codiconUri}"
-      id="vscode-codicon-stylesheet"
-    />
+    ${commonHead}
     <script type="importmap" nonce="${nonce}">
       {
         "imports": {
@@ -40,6 +34,7 @@
           "@common/webview/commands.js": "${commandsUri}",
           "@common/webview/themeHandlers.js": "${webviewThemeHandlersUri}",
           "@common/templateUtils.js": "${templateUtilsUri}",
+          "@common/viewBootstrap.js": "${viewBootstrapUri}",
           "@common/RecordingButtonManager.js": "${recordingButtonManagerUri}",
           "@common/textareaUtils.js": "${textareaUtilsUri}",
           "@common/domUtils.js": "${domUtilsUri}",
@@ -60,7 +55,6 @@
       src="${vscodeElementsBundleUri}"
     ></script>
     <script type="module" nonce="${nonce}" src="${scriptUri}"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/Sortable/1.14.0/Sortable.min.js"></script>
   </head>
 
   <body>

--- a/src/webview/modules/mainViewState.js
+++ b/src/webview/modules/mainViewState.js
@@ -211,6 +211,10 @@ export class MainViewState {
     }
   }
 
+  initialize() {
+    this.restore();
+  }
+
   /**
    * @returns {boolean} true if setDefaults() was called and needs a save after
    */

--- a/src/webview/script.js
+++ b/src/webview/script.js
@@ -9,22 +9,22 @@ import {
   setup as setupHandlers,
   dispose as disposeHandlers,
 } from './modules/messageHandlers.js';
+// Local imports - common
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
+import { bootstrapWebview } from '@common/viewBootstrap.js';
 import { vscode } from '@common/webviewContext.js';
 
-// Register handlers immediately so early messages aren't missed
-setupHandlers({ requestData: false });
-
-window.addEventListener('beforeunload', () => {
-  disposeHandlers();
-  disposeManagers();
-});
-
-// Setup UI when DOM is loaded
-document.addEventListener('DOMContentLoaded', function () {
-  mainViewState.restore();
-  instructionManager.setup();
-  mainViewDomHandler.initializeUI();
-  setupHandlers({ requestData: true });
-  vscode.postMessage({ command: MAIN_VIEW_COMMANDS.WEBVIEW_READY });
+bootstrapWebview({
+  initializeState: () => mainViewState.initialize(),
+  setupHandlers: () => setupHandlers({ requestData: false }),
+  onDomReady: () => {
+    instructionManager.setup();
+    mainViewDomHandler.initializeUI();
+    setupHandlers({ requestData: true });
+    vscode.postMessage({ command: MAIN_VIEW_COMMANDS.WEBVIEW_READY });
+  },
+  onDispose: () => {
+    disposeHandlers();
+    disposeManagers();
+  },
 });

--- a/src/webview/script.js
+++ b/src/webview/script.js
@@ -15,9 +15,9 @@ import { bootstrapWebview } from '@common/viewBootstrap.js';
 import { vscode } from '@common/webviewContext.js';
 
 bootstrapWebview({
-  initializeState: () => mainViewState.initialize(),
   setupHandlers: () => setupHandlers({ requestData: false }),
   onDomReady: () => {
+    mainViewState.initialize();
     instructionManager.setup();
     mainViewDomHandler.initializeUI();
     setupHandlers({ requestData: true });


### PR DESCRIPTION
### Motivation
- Reduce duplication across webview entrypoints by centralizing lifecycle setup and teardown logic.  
- Remove repeated small message-handler boilerplate by providing a lightweight factory for handler maps.  
- Keep HTML head/link markup consistent across views by generating a common head block in the content provider.  
- Standardize visibility toggles and DOM lifecycle initialization patterns across views.

### Description
- Add a shared bootstrap helper `bootstrapWebview` in `src/common/modules/viewBootstrap.js` and replace per-view lifecycle code with calls to `bootstrapWebview` in webview entry scripts.  
- Introduce `createMessageHandler` in `src/common/modules/messageHandlerFactory.js` and refactor view `messageHandlers.js` files to use it instead of small `BaseWebviewMessageHandler` subclasses.  
- Centralize common head/link generation in `BaseViewContentProvider.ts` by injecting a `commonHead` template variable and add `viewBootstrap`/`messageHandlerFactory` URIs to the provider.  
- Update webview HTML and scripts to import `@common/viewBootstrap.js` and `@common/messageHandlerFactory.js`, add `.is-hidden` utility in `common.css`, replace inline `style.display` usage in the profile view with class-based toggling, and align `BaseDomHandler` instantiation patterns (notably memory renderer instantiation and `ProgressViewDomHandler` UI init/dispose methods). 

### Testing
- Ran `npm run format` and formatting completed successfully.  
- Ran `npm run compile` (webpack) and compilation finished successfully with one warning about a critical dependency in `nunjucks` loader.  
- Ran `npm run lint` (eslint) and it completed with 2 warnings in `src/tools/ReadTool.ts` (no errors).  
- Basic smoke checks: webview entry scripts were updated to call the shared bootstrap and message handlers were registered/ disposed via the new helpers.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696032396fa48324a848752cda7151b0)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Consolidates duplicated webview setup and markup while simplifying message handling.
> 
> - Adds `bootstrapWebview` (`@common/viewBootstrap.js`) and replaces per-view init/teardown in `script.js` for main, progress, history, memory, and profile views
> - Introduces `createMessageHandler` (`@common/messageHandlerFactory.js`) and refactors view `messageHandlers.js` to handler maps instead of `BaseWebviewMessageHandler` subclasses
> - Centralizes head links via `BaseViewContentProvider.getHtmlContent()` injecting `commonHead`; updates view `index.html` files to use `${commonHead}` and adds new common URIs
> - Standardizes visibility: adds `.is-hidden` in `common.css` and `toggleHidden()` in `domUtils.js`; replaces inline `style.display` usage in profile view
> - Progress view: adds `ProgressViewDomHandler.initializeUI()`, moves state `load()` to `initialize()`, and wires bootstrap disposal; minor Memory view constructor/render refactor
> - Minor importmap and template validations aligned across views; removes redundant script/link markup where centralized
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 90a032f62aba395013c594f5b23420964863912b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->