### PR TITLE
refactor: reuse shared view utilities

### DIFF
--- a/src/agent/implementations/flows/tooluse/ToolUseFlowContext.ts
+++ b/src/agent/implementations/flows/tooluse/ToolUseFlowContext.ts
@@ -119,9 +119,14 @@ export async function prepareInitialState<C>(
   const memoryEnabled = services.resolvedTools.some((t) => t.name === 'memory');
 
   const { systemPrompt, userPrefix, userRequest, instructionSuffix } =
-    await buildInitialToolUsePrompts(prompt, userVarChannels.transient, logger, {
-      memoryEnabled,
-    });
+    await buildInitialToolUsePrompts(
+      prompt,
+      userVarChannels.transient,
+      logger,
+      {
+        memoryEnabled,
+      },
+    );
 
   const messages = await modelHandler.initializeMessages(
     userPrefix,

--- a/src/commands/git/gitCommands.ts
+++ b/src/commands/git/gitCommands.ts
@@ -1,6 +1,3 @@
-// Standard library imports
-import { promises as fs } from 'fs';
-
 // Third-party imports
 import { execa, execaSync } from 'execa';
 import * as vscode from 'vscode';
@@ -9,9 +6,6 @@ import * as vscode from 'vscode';
 import * as logger from '@logger/logUtils';
 import { getConfig } from '@utils/config';
 import { WorkspaceFS } from '@utils/files';
-
-// Type imports
-import type { Dirent } from 'fs';
 
 const CHANNEL = 'gitCommands';
 const COMMIT_LABEL_FORMAT = '%h: %s (%cr)';
@@ -204,9 +198,9 @@ async function cloneOverleafProject(
     return;
   }
 
-  let directoryEntries: Dirent[];
+  let directoryEntries: [string, vscode.FileType][];
   try {
-    directoryEntries = await fs.readdir(workspacePath, { withFileTypes: true });
+    directoryEntries = await WorkspaceFS.readDir(workspacePath);
   } catch (error) {
     vscode.window.showErrorMessage(
       'Unable to inspect the workspace folder before cloning the Overleaf project.',
@@ -218,7 +212,7 @@ async function cloneOverleafProject(
 
   const ignoredWorkspaceEntries = new Set(['.DS_Store', 'Thumbs.db']);
   const nonIgnoredEntries = directoryEntries.filter(
-    (entry) => !ignoredWorkspaceEntries.has(entry.name),
+    ([name]) => !ignoredWorkspaceEntries.has(name),
   );
 
   if (nonIgnoredEntries.length > 0) {

--- a/src/common/modules/stringUtils.js
+++ b/src/common/modules/stringUtils.js
@@ -6,6 +6,14 @@ export function uncapitalize(str) {
   return str.charAt(0).toLowerCase() + str.slice(1);
 }
 
+const DATE_TIME_FORMATTER = new Intl.DateTimeFormat(undefined, {
+  year: 'numeric',
+  month: 'short',
+  day: 'numeric',
+  hour: '2-digit',
+  minute: '2-digit',
+});
+
 /**
  * Formats a timestamp as a relative time string (e.g., "2 mins ago").
  * @param {number} timestamp - Unix epoch time in milliseconds
@@ -24,4 +32,37 @@ export function formatRelativeTime(timestamp) {
   const days = Math.floor(hours / 24);
   if (days === 1) return '1 day ago';
   return `${days} days ago`;
+}
+
+export function formatUpdatedDate(value) {
+  if (!value) {
+    return 'Updated: unknown';
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return 'Updated: unknown';
+  }
+  return `Updated ${DATE_TIME_FORMATTER.format(date)}`;
+}
+
+export function formatLineCount(count) {
+  if (count === 1) {
+    return '1 line';
+  }
+  return `${count} lines`;
+}
+
+export function formatBytes(bytes) {
+  if (bytes < 1024) {
+    return `${bytes} B`;
+  }
+
+  const units = ['KB', 'MB', 'GB', 'TB'];
+  let value = bytes / 1024;
+  let unitIndex = 0;
+  while (value >= 1024 && unitIndex < units.length - 1) {
+    value /= 1024;
+    unitIndex += 1;
+  }
+  return `${value.toFixed(1)} ${units[unitIndex]}`;
 }

--- a/src/memoryView/modules/uiManagers/MemoryRenderer.js
+++ b/src/memoryView/modules/uiManagers/MemoryRenderer.js
@@ -1,16 +1,14 @@
 // Local imports - memory view
 import { COMMANDS, ELEMENT_IDS, LABELS } from '../constants.js';
 import { memoryViewState } from '../memoryViewState.js';
+// Local imports - common helpers
 import { clearElement, safeGetElementById } from '@common/domUtils.js';
+import {
+  formatBytes,
+  formatLineCount,
+  formatUpdatedDate,
+} from '@common/stringUtils.js';
 import { createFromTemplate } from '@common/templateUtils.js';
-
-const DATE_FORMATTER = new Intl.DateTimeFormat(undefined, {
-  year: 'numeric',
-  month: 'short',
-  day: 'numeric',
-  hour: '2-digit',
-  minute: '2-digit',
-});
 
 /**
  * Renders memory items and manages item markup.
@@ -80,43 +78,10 @@ export class MemoryRenderer {
   }
 
   buildMeta(item) {
-    const size = this.formatBytes(item.size ?? 0);
-    const lines = this.formatLines(item.lineCount ?? 0);
-    const updated = this.formatDate(item.mtime);
+    const size = formatBytes(item.size ?? 0);
+    const lines = formatLineCount(item.lineCount ?? 0);
+    const updated = formatUpdatedDate(item.mtime);
     return [size, lines, updated].filter(Boolean).join(' · ');
-  }
-
-  formatDate(value) {
-    if (!value) {
-      return 'Updated: unknown';
-    }
-    const date = new Date(value);
-    if (Number.isNaN(date.getTime())) {
-      return 'Updated: unknown';
-    }
-    return `Updated ${DATE_FORMATTER.format(date)}`;
-  }
-
-  formatLines(count) {
-    if (count === 1) {
-      return '1 line';
-    }
-    return `${count} lines`;
-  }
-
-  formatBytes(bytes) {
-    if (bytes < 1024) {
-      return `${bytes} B`;
-    }
-
-    const units = ['KB', 'MB', 'GB', 'TB'];
-    let value = bytes / 1024;
-    let unitIndex = 0;
-    while (value >= 1024 && unitIndex < units.length - 1) {
-      value /= 1024;
-      unitIndex += 1;
-    }
-    return `${value.toFixed(1)} ${units[unitIndex]}`;
   }
 }
 

--- a/src/progressView/managers/UsageStatsManager.ts
+++ b/src/progressView/managers/UsageStatsManager.ts
@@ -57,7 +57,9 @@ void (true as _AssertSchemaCompatible);
 
 // Runtime assertion: ensure all canonical keys are handled
 const canonicalKeys = TokenUsageStatsSchema.keyof().options;
-const parsingKeys = new Set(Object.keys(TokenUsageStatsParsingBaseSchema.shape));
+const parsingKeys = new Set(
+  Object.keys(TokenUsageStatsParsingBaseSchema.shape),
+);
 const missingKeys = canonicalKeys.filter((k) => !parsingKeys.has(k));
 if (missingKeys.length > 0) {
   throw new Error(

--- a/src/progressView/modules/taskManagers.js
+++ b/src/progressView/modules/taskManagers.js
@@ -4,9 +4,10 @@ import {
   TaskGroupHeaderFormatter,
   getSharedLogEntryFormatter,
 } from './formatters/index.js';
-// Local imports
 import { progressViewState } from './progressViewState.js';
 import { insertChronologically } from './utils.js';
+// Local imports - common helpers
+import { safeGetElementById } from '@common/domUtils.js';
 import { createFromTemplate } from '@common/templateUtils.js';
 
 /**
@@ -69,7 +70,7 @@ export class TaskGroupDomManager {
 
   _resolveGroupContent(parentGroupId) {
     if (!parentGroupId) {
-      return document.getElementById(ELEMENT_IDS.LOG_CONTENT);
+      return safeGetElementById(ELEMENT_IDS.LOG_CONTENT);
     }
     const parentDetails = this.groupElements.get(parentGroupId);
     return parentDetails?.querySelector('.log-group-content') ?? null;
@@ -80,7 +81,7 @@ export class TaskGroupDomManager {
       return;
     }
 
-    const container = document.getElementById(ELEMENT_IDS.LOG_CONTENT);
+    const container = safeGetElementById(ELEMENT_IDS.LOG_CONTENT);
     if (!container) {
       return;
     }
@@ -466,7 +467,7 @@ export class LogEntryManager {
     // If the message has a group ID, append it to the right group
     if (logMessage.groupId) {
       const groupContentId = `${GROUP_DOM_IDS.CONTENT_PREFIX}${logMessage.groupId}`;
-      const groupContent = document.getElementById(groupContentId);
+      const groupContent = safeGetElementById(groupContentId);
       if (groupContent) {
         const logLineElement = this.entryFormatter.format(logMessage, options);
         if (!logLineElement) {

--- a/src/progressView/modules/uiManagers/RunSelector.js
+++ b/src/progressView/modules/uiManagers/RunSelector.js
@@ -1,16 +1,8 @@
 // Local imports - progress view
 import { ELEMENT_IDS } from '../constants.js';
+import { getDateTimeFormatter } from '../formatters/timestampUtils.js';
 // Local imports - shared helpers
 import { safeGetElementById } from '@common/domUtils.js';
-
-const RUN_LABEL_DATETIME_FORMATTER = new Intl.DateTimeFormat(undefined, {
-  year: 'numeric',
-  month: 'short',
-  day: '2-digit',
-  hour: '2-digit',
-  minute: '2-digit',
-  second: '2-digit',
-});
 
 /**
  * Manages the run selector dropdown in the progress view header.
@@ -299,7 +291,7 @@ export class RunSelector {
       return '';
     }
 
-    return RUN_LABEL_DATETIME_FORMATTER.format(date);
+    return getDateTimeFormatter().format(date);
   }
 
   _syncVisibility() {

--- a/src/progressView/modules/uiManagers/Status.js
+++ b/src/progressView/modules/uiManagers/Status.js
@@ -4,9 +4,9 @@ import {
   ALL_TOOLBAR_BUTTON_IDS,
   ELEMENT_IDS,
 } from '../constants.js';
-// Local imports
 import { progressViewState } from '../progressViewState.js';
-import { setElementsDisabled } from '@common/domUtils.js';
+// Local imports - common helpers
+import { safeGetElementById, setElementsDisabled } from '@common/domUtils.js';
 
 /**
  * Manages status display and button states.
@@ -92,10 +92,8 @@ export class Status {
   }
 
   _applyExecutionAvailability() {
-    const storageButton = document.getElementById(
-      ELEMENT_IDS.OPEN_TASK_STORAGE_BTN,
-    );
-    const resumeButton = document.getElementById(ELEMENT_IDS.RESUME_BTN);
+    const storageButton = safeGetElementById(ELEMENT_IDS.OPEN_TASK_STORAGE_BTN);
+    const resumeButton = safeGetElementById(ELEMENT_IDS.RESUME_BTN);
 
     const isAvailable = this._executionAvailable;
 
@@ -124,18 +122,16 @@ export class Status {
    */
   update(status) {
     this._applyExecutionAvailability();
-    const statusIndicator = document.getElementById(
-      ELEMENT_IDS.STATUS_INDICATOR,
-    );
+    const statusIndicator = safeGetElementById(ELEMENT_IDS.STATUS_INDICATOR);
     if (!statusIndicator) {
       console.error('Status.update: statusIndicator element not found');
       return;
     }
 
     // Query buttons fresh each time to handle toolbar re-rendering
-    const buttons = this.BUTTON_IDS.map((id) =>
-      document.getElementById(id),
-    ).filter(Boolean);
+    const buttons = this.BUTTON_IDS.map((id) => safeGetElementById(id)).filter(
+      Boolean,
+    );
 
     setElementsDisabled(buttons, true);
 
@@ -158,7 +154,7 @@ export class Status {
       statusIndicator.dataset.status = cfg.label;
 
       const elementsToEnable = cfg.enable
-        .map((id) => document.getElementById(id))
+        .map((id) => safeGetElementById(id))
         .filter((el) => {
           if (!el) {
             return false;

--- a/src/progressView/modules/uiManagers/Toolbar.js
+++ b/src/progressView/modules/uiManagers/Toolbar.js
@@ -1,6 +1,7 @@
 // Local imports - progress view
-// Local imports
 import { TOOLBAR_BUTTONS, ELEMENT_IDS } from '../constants.js';
+// Local imports - common helpers
+import { safeGetElementById } from '@common/domUtils.js';
 import { createIconButton } from '@common/templateUtils.js';
 
 /**
@@ -8,7 +9,7 @@ import { createIconButton } from '@common/templateUtils.js';
  */
 export class Toolbar {
   render(sessionKind = 'workflow') {
-    const container = document.getElementById(ELEMENT_IDS.TOOLBAR_CONTAINER);
+    const container = safeGetElementById(ELEMENT_IDS.TOOLBAR_CONTAINER);
     if (!container) {
       console.error('Toolbar.render: toolbarContainer not found');
       return;

--- a/src/progressView/modules/usageManagers.js
+++ b/src/progressView/modules/usageManagers.js
@@ -54,18 +54,22 @@ export class UsageSummary {
     // Build cache segments: placed after input since cache is conceptually related to input
     // Cache read: tokens served from cache (discounted rate)
     // Cache creation: tokens written to cache (Anthropic: 1.25x input price)
-    const cacheReadSegment = cacheReadTokens > 0
-      ? ` · <i class="codicon codicon-cloud-download" title="Cache read tokens (discounted)"></i>${formatTokens(cacheReadTokens)}`
-      : '';
-    const cacheCreationSegment = cacheCreationTokens > 0
-      ? ` · <i class="codicon codicon-database" title="Cache creation tokens (1.25x cost)"></i>${formatTokens(cacheCreationTokens)}`
-      : '';
-    const cacheReadAriaLabel = cacheReadTokens > 0
-      ? `, ${formatTokens(cacheReadTokens)} cache read tokens`
-      : '';
-    const cacheCreationAriaLabel = cacheCreationTokens > 0
-      ? `, ${formatTokens(cacheCreationTokens)} cache creation tokens`
-      : '';
+    const cacheReadSegment =
+      cacheReadTokens > 0
+        ? ` · <i class="codicon codicon-cloud-download" title="Cache read tokens (discounted)"></i>${formatTokens(cacheReadTokens)}`
+        : '';
+    const cacheCreationSegment =
+      cacheCreationTokens > 0
+        ? ` · <i class="codicon codicon-database" title="Cache creation tokens (1.25x cost)"></i>${formatTokens(cacheCreationTokens)}`
+        : '';
+    const cacheReadAriaLabel =
+      cacheReadTokens > 0
+        ? `, ${formatTokens(cacheReadTokens)} cache read tokens`
+        : '';
+    const cacheCreationAriaLabel =
+      cacheCreationTokens > 0
+        ? `, ${formatTokens(cacheCreationTokens)} cache creation tokens`
+        : '';
 
     this._summaryElem.innerHTML = `
       <i class="codicon codicon-meter"></i>


### PR DESCRIPTION
### Motivation

- Reduce duplicated formatting logic for dates, byte sizes, and line counts across views by centralizing helpers. 
- Ensure progress view modules use a consistent DOM lookup helper to avoid direct `document.getElementById` usage. 
- Align run timestamp formatting with a shared date/time formatter to avoid divergent formats in the UI. 
- Use the repository `WorkspaceFS` utility for workspace directory scanning to keep filesystem access consistent.

### Description

- Added shared formatting helpers (`formatBytes`, `formatLineCount`, `formatUpdatedDate`) to `src/common/modules/stringUtils.js` and a reusable `DATE_TIME_FORMATTER`. 
- Replaced per-view formatting in `MemoryRenderer` to use `@common/stringUtils.js` and removed the view-local date/size/line implementations. 
- Standardized DOM access in progress view modules by adopting `safeGetElementById` in `TaskGroupDomManager`, `Toolbar`, `Status`, and `RunSelector`, and switched `RunSelector` to use the shared date/time formatter (`getDateTimeFormatter`). 
- Switched workspace scanning in the Overleaf clone flow to `WorkspaceFS.readDir` and adjusted the directory-entry type handling in `src/commands/git/gitCommands.ts`, plus small formatting/structure tweaks in `UsageStatsManager` and `ToolUseFlowContext`.

### Testing

- Ran `npm run format` which completed successfully. 
- Ran `npm run compile`, which completed but reported a webpack warning about a critical dependency in `nunjucks`. 
- Ran `npm run lint`, which completed with warnings (not blocking) in `src/tools/ReadTool.ts` regarding `eqeqeq`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960343421dc8324923a281c0cd055f4)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Unifies shared helpers across views and standardizes filesystem access**
> 
> - Adds `formatBytes`, `formatLineCount`, and `formatUpdatedDate` (with shared `Intl.DateTimeFormat`) to `@common/stringUtils.js`; `MemoryRenderer` now uses these and drops local implementations
> - Progress view modules (`TaskGroupDomManager`, `Toolbar`, `Status`, `RunSelector`) now use `safeGetElementById`; `RunSelector` uses shared date/time formatter via `getDateTimeFormatter`
> - Overleaf clone flow in `gitCommands.ts` now uses `WorkspaceFS.readDir` and updates directory entry typing/filtering; removes direct `fs` usage
> - Minor non-functional formatting/structure tweaks in `UsageStatsManager`, `UsageSummary`, and `ToolUseFlowContext`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1442c0c0aeadc8674f6168f7a71c20f34aa86d76. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->