### PR TITLE
Remove largest abstraction overhead

### DIFF
--- a/src/agent/core/AgentWorkspaceState.ts
+++ b/src/agent/core/AgentWorkspaceState.ts
@@ -42,11 +42,6 @@ export type ResponseAssemblyState = z.output<
   typeof ResponseAssemblyStateSchema
 >;
 
-/** Create a fresh ResponseAssemblyState */
-export function createResponseAssemblyState(): ResponseAssemblyState {
-  return { lastResponse: '', accumulatedOutput: '' };
-}
-
 /** Schema for FileInteractionState serialization */
 export const FileInteractionStateSnapshotSchema = z.object({
   readFiles: z.array(z.string()).prefault([]),
@@ -241,11 +236,6 @@ export const ReasoningCacheStateSchema = z.object({
 /** Reasoning cache state - plain object type derived from schema */
 export type ReasoningCacheState = z.output<typeof ReasoningCacheStateSchema>;
 
-/** Create a fresh ReasoningCacheState */
-export function createReasoningCacheState(): ReasoningCacheState {
-  return { thinkingBlocks: [], thinkingAdded: false };
-}
-
 /** Get the primary thinking block, or null if none */
 export function getReasoningPrimaryBlock(
   state: ReasoningCacheState,
@@ -277,11 +267,6 @@ export interface ServerToolContentState {
   contentBlocks: ServerToolContentBlock[];
   /** Full assistant content blocks from last response, excluding tool_use. Typed as unknown[] for cross-provider compatibility. */
   lastAssistantContent: unknown[];
-}
-
-/** Create a fresh ServerToolContentState */
-export function createServerToolContentState(): ServerToolContentState {
-  return { contentBlocks: [], lastAssistantContent: [] };
 }
 
 /** Reset server tool content state to initial values */
@@ -422,11 +407,11 @@ export class AgentWorkspaceState {
   /** Factory method to create a fresh AgentWorkspaceState */
   static create(): AgentWorkspaceState {
     return new AgentWorkspaceState(
-      createResponseAssemblyState(),
+      ResponseAssemblyStateSchema.parse({}),
       new MediaAttachmentState(),
-      createReasoningCacheState(),
+      ReasoningCacheStateSchema.parse({}),
       new FileInteractionState(),
-      createServerToolContentState(),
+      { contentBlocks: [], lastAssistantContent: [] },
       new TodoState(),
     );
   }
@@ -439,7 +424,7 @@ export class AgentWorkspaceState {
       MediaAttachmentState.fromSnapshot(parsed.media),
       parsed.reasoning, // Plain object - schema already validates
       FileInteractionState.fromSnapshot(parsed.interactions),
-      createServerToolContentState(), // Ephemeral - not serialized
+      { contentBlocks: [], lastAssistantContent: [] }, // Ephemeral - not serialized
       TodoState.fromSnapshot(parsed.todos),
     );
   }

--- a/src/agent/core/flows/RetryState.ts
+++ b/src/agent/core/flows/RetryState.ts
@@ -105,15 +105,6 @@ function getNodeRetryConfig(): NodeRetryConfig {
 // ============================================================================
 
 /**
- * Creates initial retry state.
- */
-export function createRetryState(): RetryState {
-  return {
-    lastError: undefined,
-  };
-}
-
-/**
  * Clears error state. Used internally by handleInvocationResult.
  */
 function clearRetryError(state: RetryState): void {

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -40,21 +40,21 @@ import { DIAGNOSTIC_TYPE_VALIDATION_ERROR } from '@tools/result';
 import { AbsoluteFS, pathToLocation, type FileLocation } from '@utils/files';
 import { isNonEmptyString } from '@utils/core';
 import { formatContent } from '@utils/text/xmlUtils';
-import { createRetryState, type RetryState } from './RetryState';
 
 // Local file imports
 import { FlowTransition } from './FlowTransitions';
-import {
-  type InvocationResult,
-  RetryableInvocationNode,
-  handleInvocationResult,
-} from './RetryState';
 import {
   finalizeToolUseCycle,
   type ToolUseCycleOptions,
   type ToolUseCycleServices,
   type ToolUseCycleParams,
 } from './CycleServices';
+import {
+  type InvocationResult,
+  type RetryState,
+  RetryableInvocationNode,
+  handleInvocationResult,
+} from './RetryState';
 
 interface ToolValidationDiagnostics {
   type: typeof DIAGNOSTIC_TYPE_VALIDATION_ERROR;

--- a/src/agent/implementations/flows/ToolUseRunFlow.ts
+++ b/src/agent/implementations/flows/ToolUseRunFlow.ts
@@ -98,20 +98,6 @@ export interface ToolUseRunState {
 }
 
 /**
- * Create initial state for a tool-use flow run.
- *
- * Factory function for consistency with ReflectionFlow pattern
- * (which uses createInitialReflectionState).
- */
-export function createInitialToolUseState(): ToolUseRunState {
-  return {
-    conversation: [],
-    shouldSkipCycle: false,
-    stateSlices: null,
-  };
-}
-
-/**
  * Shared context passed through the flow.
  *
  * Contains only mutable runtime state. All dependencies (session, interruption

--- a/src/agent/implementations/flows/ToolUseRunFlow.ts
+++ b/src/agent/implementations/flows/ToolUseRunFlow.ts
@@ -44,18 +44,12 @@ import {
   NODE_NO_RETRY,
   NODE_NO_WAIT,
 } from '@agent/implementations/flows/common';
+import { buildInitialToolUsePrompts } from '@utils/prompt';
 import type { TodoItem } from '@eventBus/schemas';
 import { bus } from '@eventBus/ProgressEventBus';
 
-// Internal imports
-
-// Service types and helper functions (direct calls, no closures)
-import {
-  prepareInitialState,
-  applyFollowUpMessage,
-  type ToolUseServices,
-  type ToolUseFlowParams,
-} from './tooluse';
+// Service types
+import { type ToolUseServices, type ToolUseFlowParams } from './tooluse';
 
 // ============================================================================
 // State Types
@@ -234,12 +228,67 @@ class ToolUsePrepareNode<C> extends Node<
   async exec(
     _prepRes: void,
   ): Promise<{ kind: 'success'; result: ToolUsePrepareResult }> {
-    // Call helper functions directly (no closure wrappers)
-    // prepareInitialState returns individual slices directly (no store wrapper)
-    const prepared = await prepareInitialState(this.services);
+    const { modelHandler, prompt, userVarChannels, logger, snapshot } =
+      this.services;
+
+    // Resume from snapshot if available
+    if (snapshot) {
+      logger.debug('Resuming tool-use session from saved state.');
+      const runState = AgentRunState.fromSnapshot(snapshot.run);
+      const workspaceState = AgentWorkspaceState.fromSnapshot(
+        snapshot.workspace,
+      );
+      const userChannels = {
+        input: Object.freeze({ ...snapshot.user.input }),
+        transient: { ...snapshot.user.transient },
+      };
+      return {
+        kind: 'success',
+        result: {
+          messages: snapshot.messages,
+          runState,
+          workspaceState,
+          userChannels,
+          shouldSkipCycle: true,
+        },
+      };
+    }
+
+    // Create fresh state for new sessions
+    const runState = new AgentRunState();
+    const workspaceState = AgentWorkspaceState.create();
+    const memoryEnabled = this.services.resolvedTools.some(
+      (t) => t.name === 'memory',
+    );
+
+    const { systemPrompt, userPrefix, userRequest, instructionSuffix } =
+      await buildInitialToolUsePrompts(
+        prompt,
+        userVarChannels.transient,
+        logger,
+        {
+          memoryEnabled,
+        },
+      );
+
+    const messages = await modelHandler.initializeMessages(
+      userPrefix,
+      userRequest,
+      undefined,
+      systemPrompt
+        ? `${systemPrompt}\n${instructionSuffix}`
+        : instructionSuffix,
+    );
+
     return {
       kind: 'success',
-      result: prepared,
+      result: {
+        messages,
+        runState,
+        workspaceState,
+        userChannels: userVarChannels,
+        shouldSkipCycle: false,
+      },
     };
   }
 
@@ -555,11 +604,12 @@ class ToolUseWaitNode<C> extends Node<
     // Apply follow-up (state mutation in post - correct)
     const session = this.services.session;
     await session.markRunning();
-    shared.state.conversation = await applyFollowUpMessage(
-      this.services,
-      execRes.followUp,
-      shared.state.conversation,
-    );
+    this.services.logger.userMessage(execRes.followUp);
+    shared.state.conversation =
+      await this.services.modelHandler.createUserFollowUpMessages(
+        shared.state.conversation,
+        execRes.followUp,
+      );
 
     // Loop back to CycleNode
     return FlowTransition.CONTINUE;

--- a/src/agent/implementations/flows/reflection/ReflectionFlowState.ts
+++ b/src/agent/implementations/flows/reflection/ReflectionFlowState.ts
@@ -29,7 +29,6 @@ import { z } from 'zod';
 
 import { RoundOutputSchema } from '@agent/output';
 import {
-  AgentRunState,
   AgentRunStateSnapshotSchema,
   ConversationRoundState,
   ConversationRoundStateSnapshotSchema,
@@ -37,7 +36,6 @@ import {
   type ConversationRoundStateSnapshot,
 } from '@agent/core/AgentState';
 import {
-  AgentWorkspaceState,
   AgentWorkspaceStateSnapshotSchema,
   type AgentWorkspaceSnapshot,
 } from '@agent/core/AgentWorkspaceState';
@@ -172,132 +170,3 @@ export type ReflectionFlowState = z.infer<typeof ReflectionFlowStateSchema>;
  * CycleTransientFields is imported from ResponseCycleFlow.ts (single source of truth).
  */
 export type ReflectionFlowShared = ReflectionFlowState & CycleTransientFields;
-
-/**
- * Create initial state for a reflection flow run.
- *
- * @param totalRounds - Total rounds to execute
- * @param initialWorkspaceSnapshot - Initial workspace state snapshot
- */
-export function createInitialReflectionState(
-  totalRounds: number,
-  initialWorkspaceSnapshot: AgentWorkspaceSnapshot,
-): ReflectionFlowState {
-  return {
-    currentRound: 0,
-    totalRounds,
-    workspaceSnapshot: initialWorkspaceSnapshot,
-    context: null,
-    outputLocation: null,
-    conversation: [],
-    runStateSnapshot: new AgentRunState().toSnapshot(),
-    roundStateSnapshots: [],
-    roundOutputs: [],
-    continueRounds: true,
-    endTurn: false,
-  };
-}
-
-// ============================================================================
-// Helper Functions for Snapshot Conversion
-// ============================================================================
-
-/**
- * Reconstruct AgentWorkspaceState from snapshot for mutation.
- *
- * ## When to use this helper vs direct access
- *
- * - **Use this helper** when you need to mutate workspace state (e.g., adding media files,
- *   modifying workspace data). The reconstructed class instance provides methods for
- *   manipulation.
- * - **Use direct access** (`shared.workspaceSnapshot`) when you only need to read
- *   immutable snapshot data or pass the snapshot to other functions.
- *
- * ## Pattern: Reconstruct → Mutate → Update Snapshot
- *
- * This helper is step 1 of the standard mutation pattern:
- *
- * ```typescript
- * // 1. Reconstruct class instance from snapshot
- * const workspaceState = getWorkspaceState(shared);
- *
- * // 2. Mutate the instance (e.g., in latexMediaManager.processInputFiles)
- * await latexMediaManager.processInputFiles(files, workspaceState, ...);
- *
- * // 3. Update snapshot to persist changes
- * updateWorkspaceSnapshot(shared, workspaceState);
- * ```
- *
- * ## Why these helpers exist
- *
- * Following the koala-code-reader pattern, shared state stores **snapshots** (plain JSON)
- * instead of class instances to ensure `structuredClone()` works correctly in PersistedFlow.
- * These helpers maintain snapshot consistency while allowing nodes to work with rich
- * class instances that provide mutation methods.
- *
- * @param shared - The reflection flow shared state containing the workspace snapshot
- * @returns Reconstructed AgentWorkspaceState instance with mutation methods
- *
- * @example
- * // In MediaExtractionNode.prep()
- * const workspaceState = getWorkspaceState(shared);
- * // ... pass to latexMediaManager for mutation ...
- * // ... in post(), call updateWorkspaceSnapshot() to persist changes
- */
-export function getWorkspaceState(
-  shared: ReflectionFlowShared,
-): AgentWorkspaceState {
-  return AgentWorkspaceState.fromSnapshot(shared.workspaceSnapshot);
-}
-
-/**
- * Update workspace snapshot after mutation to persist changes.
- *
- * This is step 3 of the standard mutation pattern - call this after modifying
- * a workspace state instance to save changes back to the shared state snapshot.
- *
- * ## Pattern: Reconstruct → Mutate → Update Snapshot
- *
- * ```typescript
- * // 1. Reconstruct
- * const workspaceState = getWorkspaceState(shared);
- *
- * // 2. Mutate (e.g., adding media files)
- * await latexMediaManager.processInputFiles(files, workspaceState, ...);
- *
- * // 3. Update snapshot (THIS FUNCTION)
- * updateWorkspaceSnapshot(shared, workspaceState);
- * ```
- *
- * **CRITICAL**: Always call this after mutations or changes will be lost.
- * The snapshot is what gets persisted and restored across flow executions.
- *
- * @param shared - The reflection flow shared state to update
- * @param workspaceState - The mutated workspace state instance
- *
- * @example
- * // In MediaExtractionNode.post() - CRITICAL step
- * updateWorkspaceSnapshot(shared, prepRes.workspaceState);
- */
-export function updateWorkspaceSnapshot(
-  shared: ReflectionFlowShared,
-  workspaceState: AgentWorkspaceState,
-): void {
-  shared.workspaceSnapshot = workspaceState.toSnapshot();
-}
-
-/**
- * Create fresh workspace snapshot for a new round.
- *
- * Used when transitioning between rounds to reset workspace state.
- * Each round starts with a clean workspace to avoid state pollution.
- *
- * @returns Fresh AgentWorkspaceSnapshot for a new round
- *
- * @example
- * // In RoundCompleteNode.post() - transitioning to next round
- * shared.workspaceSnapshot = createFreshWorkspaceSnapshot();
- */
-export function createFreshWorkspaceSnapshot(): AgentWorkspaceSnapshot {
-  return AgentWorkspaceState.create().toSnapshot();
-}

--- a/src/agent/implementations/flows/reflection/index.ts
+++ b/src/agent/implementations/flows/reflection/index.ts
@@ -45,7 +45,6 @@ export {
 // State types and schemas
 export {
   type RoundContext,
-  createInitialReflectionState,
   ReflectionFlowStateSchema,
   RoundContextSchema,
 } from './ReflectionFlowState';

--- a/src/agent/implementations/flows/reflection/nodes/MediaExtractionNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/MediaExtractionNode.ts
@@ -11,14 +11,12 @@ import {
   NODE_NO_RETRY,
   NODE_NO_WAIT,
 } from '@agent/implementations/flows/common';
-import type { AgentWorkspaceState } from '@agent/core/AgentWorkspaceState';
+import { AgentWorkspaceState } from '@agent/core/AgentWorkspaceState';
 import type { FileLocation } from '@utils/files';
 
 import { getFilesForRound } from '../helpers';
 
 import {
-  getWorkspaceState,
-  updateWorkspaceSnapshot,
   type ReflectionFlowShared,
   type RoundContext,
 } from '../ReflectionFlowState';
@@ -49,7 +47,9 @@ export class MediaExtractionNode<C = unknown> extends Node<
     const { config, fileService, modelHandler } = this.services;
     const { currentRound, roundOutputs, context } = shared;
 
-    const workspaceState = getWorkspaceState(shared);
+    const workspaceState = AgentWorkspaceState.fromSnapshot(
+      shared.workspaceSnapshot,
+    );
     const files = getFilesForRound(
       currentRound,
       roundOutputs,
@@ -118,7 +118,7 @@ export class MediaExtractionNode<C = unknown> extends Node<
     mediaFiles: FileLocation[] | null,
   ): Promise<string | undefined> {
     // Always update workspace snapshot since prep() reconstructed it
-    updateWorkspaceSnapshot(shared, prepRes.workspaceState);
+    shared.workspaceSnapshot = prepRes.workspaceState.toSnapshot();
 
     if (mediaFiles && mediaFiles.length > 0 && shared.context) {
       await this.services.modelHandler.addMediaToUserMessage(

--- a/src/agent/implementations/flows/reflection/nodes/ResponseCycleNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/ResponseCycleNode.ts
@@ -28,6 +28,7 @@ import {
   NODE_NO_WAIT,
 } from '@agent/implementations/flows/common';
 import { ConversationRoundState, AgentRunState } from '@agent/core/AgentState';
+import { AgentWorkspaceState } from '@agent/core/AgentWorkspaceState';
 import {
   createResponseCycleFlow,
   assertCycleFieldsPopulated,
@@ -43,8 +44,6 @@ import {
 import type { AgentFileLocation } from '@utils/files';
 
 import {
-  getWorkspaceState,
-  updateWorkspaceSnapshot,
   type ReflectionFlowShared,
   type RoundContext,
 } from '../ReflectionFlowState';
@@ -98,7 +97,9 @@ export class ResponseCycleNode<C = unknown> extends Node<
     }
 
     // Reconstruct state instances from snapshots
-    const workspace = getWorkspaceState(shared);
+    const workspace = AgentWorkspaceState.fromSnapshot(
+      shared.workspaceSnapshot,
+    );
     const run = AgentRunState.fromSnapshot(shared.runStateSnapshot);
     const round = ConversationRoundState.fromSnapshot(
       context.stateRoundSnapshot,
@@ -268,7 +269,7 @@ export class ResponseCycleNode<C = unknown> extends Node<
 
     // Update snapshots from slices (cycle results already in shared via native nesting)
     shared.runStateSnapshot = execRes.run.toSnapshot();
-    updateWorkspaceSnapshot(shared, execRes.workspace);
+    shared.workspaceSnapshot = execRes.workspace.toSnapshot();
 
     // Sync conversation state - messages modified in-place during cycle
     shared.conversation = prepRes.context.messages;

--- a/src/agent/implementations/flows/reflection/runReflectionFlow.ts
+++ b/src/agent/implementations/flows/reflection/runReflectionFlow.ts
@@ -36,6 +36,7 @@ import type { BaseFlowContextInit } from '@agent/implementations/flows/common';
 import { retryCoordinator } from '@agent/runtime/RetryRequestCoordinator';
 import { getOutputFileName } from '@agent/utils/outputFileUtils';
 
+import { AgentRunState } from '@agent/core/AgentState';
 import { AgentWorkspaceState } from '@agent/core/AgentWorkspaceState';
 import type { AgentWorkflowSetting } from '@agent/core/AgentDataclass';
 import { type FlowRecord } from '@agent/node/persisted-flow';
@@ -56,11 +57,7 @@ import {
   createReflectionFlow,
   type ReflectionFlowShared,
 } from './ReflectionFlow';
-import {
-  createFreshWorkspaceSnapshot,
-  createInitialReflectionState,
-  ReflectionFlowStateSchema,
-} from './ReflectionFlowState';
+import { ReflectionFlowStateSchema } from './ReflectionFlowState';
 import { createBaseFileLocations } from './helpers';
 import type { ReflectionServices } from './ReflectionServices';
 
@@ -277,10 +274,19 @@ export async function runReflectionFlow<C = unknown>(
 
     // Create fresh state if not resuming
     if (!shared) {
-      shared = createInitialReflectionState(
+      shared = {
+        currentRound: 0,
         totalRounds,
-        AgentWorkspaceState.create().toSnapshot(),
-      );
+        workspaceSnapshot: AgentWorkspaceState.create().toSnapshot(),
+        context: null,
+        outputLocation: null,
+        conversation: [],
+        runStateSnapshot: new AgentRunState().toSnapshot(),
+        roundStateSnapshots: [],
+        roundOutputs: [],
+        continueRounds: true,
+        endTurn: false,
+      };
     }
 
     // Create RoundPersistedFlow with the start node
@@ -301,7 +307,7 @@ export async function runReflectionFlow<C = unknown>(
           });
         },
         resetForNextRound: (s) => {
-          s.workspaceSnapshot = createFreshWorkspaceSnapshot();
+          s.workspaceSnapshot = AgentWorkspaceState.create().toSnapshot();
         },
         checkInterruption,
         onFlowEnd: (_shared, flowEndStatus) => {

--- a/src/agent/implementations/flows/tooluse/ToolUseFlowContext.ts
+++ b/src/agent/implementations/flows/tooluse/ToolUseFlowContext.ts
@@ -1,28 +1,23 @@
 /**
- * ToolUseFlowContext - Factory and helpers for tool-use flow services.
- * Services pass context values directly; nodes call helpers without closures.
+ * ToolUseFlowContext - Factory for tool-use flow services.
  */
 
 import type { AgentToolUseSetting } from '@agent/core/AgentDataclass';
 import type { IToolRegistry } from '@agent/core/ToolTypes';
-import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
 import type { StreamTabId } from '@agent/types/IdentifierTypes';
 import type { BaseFlowContextInit } from '@agent/implementations/flows/common';
 
-import { AgentWorkspaceState } from '@agent/core/AgentWorkspaceState';
-import { AgentRunState } from '@agent/core/AgentState';
 import { retryCoordinator } from '@agent/runtime/RetryRequestCoordinator';
 import type { RoundFinalizedCallback } from '@agent/core/flows/CycleServices';
 import type { ToolDefinition } from '@model';
 import { getDefaultToolRegistry } from '@tools/registry';
-import { buildInitialToolUsePrompts } from '@utils/prompt';
 import { getToolUseMemoryEnabled } from '@utils/config/constants';
 import {
   ToolUseSessionLifecycle,
   type IToolUseSession,
 } from './ToolUseSessionLifecycle';
 
-import type { ToolUseServices, PrepareStateResult } from './ToolUseServices';
+import type { ToolUseServices } from './ToolUseServices';
 import type { ToolUseSessionSnapshot } from './ToolUseSessionTypes';
 
 // ============================================================================
@@ -73,88 +68,6 @@ export interface ToolUseFlowContext<C = unknown> {
 
   /** Dispose context resources */
   dispose(): void;
-}
-
-// ============================================================================
-// Helper Functions (called directly by nodes, no closure wrappers)
-// ============================================================================
-
-/**
- * Prepare initial state for tool-use session (new or resumed from snapshot).
- *
- * Returns individual state slices directly instead of wrapping in AgentSharedStore.
- * This eliminates the convert→pass→convert overhead pattern.
- */
-export async function prepareInitialState<C>(
-  services: ToolUseServices<C>,
-): Promise<PrepareStateResult> {
-  const { modelHandler, prompt, userVarChannels, logger, snapshot } = services;
-
-  if (snapshot) {
-    logger.debug('Resuming tool-use session from saved state.');
-
-    // Reconstruct state slices directly from snapshot (v2 schema - no wrapper)
-    const runState = AgentRunState.fromSnapshot(snapshot.run);
-    const workspaceState = AgentWorkspaceState.fromSnapshot(snapshot.workspace);
-    // User channels from snapshot with frozen input
-    const userChannels = {
-      input: Object.freeze({ ...snapshot.user.input }),
-      transient: { ...snapshot.user.transient },
-    };
-
-    return {
-      messages: snapshot.messages,
-      runState,
-      workspaceState,
-      userChannels,
-      shouldSkipCycle: true,
-    };
-  }
-
-  // Create fresh state for new sessions
-  const runState = new AgentRunState();
-  const workspaceState = AgentWorkspaceState.create();
-
-  // Check if memory tool is enabled for this session
-  const memoryEnabled = services.resolvedTools.some((t) => t.name === 'memory');
-
-  const { systemPrompt, userPrefix, userRequest, instructionSuffix } =
-    await buildInitialToolUsePrompts(
-      prompt,
-      userVarChannels.transient,
-      logger,
-      {
-        memoryEnabled,
-      },
-    );
-
-  const messages = await modelHandler.initializeMessages(
-    userPrefix,
-    userRequest,
-    undefined,
-    systemPrompt ? `${systemPrompt}\n${instructionSuffix}` : instructionSuffix,
-  );
-
-  return {
-    messages,
-    runState,
-    workspaceState,
-    userChannels: userVarChannels,
-    shouldSkipCycle: false,
-  };
-}
-
-/** Apply a follow-up message to the conversation. */
-export async function applyFollowUpMessage<C>(
-  services: ToolUseServices<C>,
-  followUp: string,
-  messages: ProviderMessage[],
-): Promise<ProviderMessage[]> {
-  services.logger.userMessage(followUp);
-  return await services.modelHandler.createUserFollowUpMessages(
-    messages,
-    followUp,
-  );
 }
 
 // ============================================================================

--- a/src/agent/implementations/flows/tooluse/index.ts
+++ b/src/agent/implementations/flows/tooluse/index.ts
@@ -3,11 +3,6 @@
  *
  * Service interfaces and flow-first execution for tool-use agents.
  * The flow itself is in ToolUseRunFlow.ts (parent directory).
- *
- * Architecture (refactored - no closure wrappers):
- * - Helper functions are exported for direct use by nodes
- * - Services pass context values directly (resolvedTools, snapshot, etc.)
- * - Eliminates closure indirection for cleaner call stacks
  */
 
 export type {
@@ -19,9 +14,6 @@ export type {
 export {
   ToolUseFlowContext,
   type ToolUseFlowContextInit,
-  // Helper functions for direct use by nodes (no closure wrappers)
-  prepareInitialState,
-  applyFollowUpMessage,
 } from './ToolUseFlowContext';
 
 export {

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -23,11 +23,7 @@ import {
 } from '@common/constants/streamStatus';
 import { END_GROUP_STATUS, type EndGroupStatus } from '@logger/messageTypes';
 
-import {
-  createToolUseRunFlow,
-  createInitialToolUseState,
-  type ToolUseRunShared,
-} from '../ToolUseRunFlow';
+import { createToolUseRunFlow, type ToolUseRunShared } from '../ToolUseRunFlow';
 import {
   createToolUseFlowContext,
   type ToolUseFlowContext,
@@ -125,7 +121,7 @@ export async function runToolUseFlow<C = unknown>(
 
     // Create shared state
     const shared: ToolUseRunShared = {
-      state: createInitialToolUseState(),
+      state: { conversation: [], shouldSkipCycle: false, stateSlices: null },
     };
 
     // Create PersistedFlow with the start node

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -1323,7 +1323,10 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
 
     // Only process attachments if the handler supports them
     if (this.canProcessToolResultAttachments && attachments.length > 0) {
-      attachmentSummary = formatAttachmentSummary(attachments, 'included-inline');
+      attachmentSummary = formatAttachmentSummary(
+        attachments,
+        'included-inline',
+      );
 
       const encodedParts = await Promise.all(
         attachments.map((attachment) =>
@@ -1344,7 +1347,9 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
 
     // Google SDK requires Record<string, unknown> for response parameter,
     // so we must wrap the text in an object (unlike OpenAI which accepts string)
-    const simplifiedResult = { result: formatToolResultAsText(result, attachmentSummary) };
+    const simplifiedResult = {
+      result: formatToolResultAsText(result, attachmentSummary),
+    };
 
     // Use SDK's createPartFromFunctionResponse with native attachment support
     // The 4th parameter accepts FunctionResponsePart[] for media attachments

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -1696,7 +1696,10 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     }
 
     // Build tool result as plain text - JSON wastes tokens
-    const combinedText = formatToolResultAsText(result, finalResult.attachmentSummary);
+    const combinedText = formatToolResultAsText(
+      result,
+      finalResult.attachmentSummary,
+    );
 
     let outputPayload: string | ResponseFunctionCallOutputItemList;
 

--- a/src/agent/modelHandlers/utils/toolAttachmentUtils.ts
+++ b/src/agent/modelHandlers/utils/toolAttachmentUtils.ts
@@ -265,7 +265,9 @@ export function formatToolResultAsText(
   // userPatch captures user modifications to tool proposals (distinct from userDiffNote
   // which only shows merge conflicts). Include when user modified the proposed edit.
   if (result.userPatch) {
-    textPieces.push(`User modifications:\n\`\`\`diff\n${result.userPatch}\n\`\`\``);
+    textPieces.push(
+      `User modifications:\n\`\`\`diff\n${result.userPatch}\n\`\`\``,
+    );
   }
   if (result.userInstruction) {
     textPieces.push(`User feedback: ${result.userInstruction}`);

--- a/src/progressView/streamInfoUtils.ts
+++ b/src/progressView/streamInfoUtils.ts
@@ -19,36 +19,6 @@ const sortComparators = {
     (a.agent ?? '').localeCompare(b.agent ?? ''),
 } as const;
 
-function matchesAgentFilter(
-  sessionCategory: AgentCategory,
-  filter: AgentFilter,
-): boolean {
-  switch (filter) {
-    case 'all':
-      return true;
-    case 'toolUse':
-      return sessionCategory === AgentCategory.ToolUse;
-    case 'workflow':
-      return sessionCategory === AgentCategory.Workflow;
-    default:
-      return true;
-  }
-}
-
-function buildStreamLabel(
-  agentName: string,
-  inputFile: string,
-  sessionCategory: AgentCategory,
-): string {
-  if (sessionCategory === AgentCategory.ToolUse) {
-    return agentName;
-  }
-
-  const agentLabel = agentName;
-  const baseName = inputFile ? path.basename(inputFile) : '';
-  return baseName ? `${agentLabel}: ${baseName}` : agentLabel;
-}
-
 /**
  * Build metadata objects for all streams in the given state.
  */
@@ -77,8 +47,15 @@ export function buildStreamInfos(
       }
       // Default to Workflow for display purposes only when filter is "all"
       sessionCategory = AgentCategory.Workflow;
-    } else if (!matchesAgentFilter(sessionCategory, filter)) {
-      return acc;
+    } else {
+      // Inline filter matching: check if session category matches filter
+      const matchesFilter =
+        filter === 'all' ||
+        (filter === 'toolUse' && sessionCategory === AgentCategory.ToolUse) ||
+        (filter === 'workflow' && sessionCategory === AgentCategory.Workflow);
+      if (!matchesFilter) {
+        return acc;
+      }
     }
 
     const agentType =
@@ -92,7 +69,13 @@ export function buildStreamInfos(
       ? isRemoteAgent(rawAgentName)
       : (hints.isRemote ?? false);
     const executionId = state.getExecutionId(id);
-    const label = buildStreamLabel(agentName, inputFile, sessionCategory);
+    // Build label: tool-use shows agent only, workflows show agent + file basename
+    const label =
+      sessionCategory === AgentCategory.ToolUse
+        ? agentName
+        : inputFile
+          ? `${agentName}: ${path.basename(inputFile)}`
+          : agentName;
     acc.push({
       name: id,
       label,

--- a/src/tools/DiagnosticsTool.ts
+++ b/src/tools/DiagnosticsTool.ts
@@ -126,7 +126,8 @@ export class DiagnosticsTool extends defineTool({
     if ('messages' in args && args.messages.length > 0) {
       const messageLines = args.messages.map((d) => {
         const line = d.range.start.line + 1; // VS Code lines are 0-indexed
-        const severity = ['error', 'warning', 'info', 'hint'][d.severity] ?? 'unknown';
+        const severity =
+          ['error', 'warning', 'info', 'hint'][d.severity] ?? 'unknown';
         return `  ${line}: [${severity}] ${d.message}`;
       });
       output = `${header}\n\n${messageLines.join('\n')}`;

--- a/src/tools/core/base.ts
+++ b/src/tools/core/base.ts
@@ -62,8 +62,7 @@ export abstract class BaseTool<T> implements ITool {
       }
       const message = toErrorMessage(err);
       // Only include error name - stack traces waste tokens and aren't actionable by models
-      const diagnostics =
-        err instanceof Error ? { name: err.name } : undefined;
+      const diagnostics = err instanceof Error ? { name: err.name } : undefined;
       return {
         error: message,
         isError: true,


### PR DESCRIPTION
- Delete dead code: createRetryState() was exported but never called
- Inline single-caller factories: createInitialToolUseState(), createFreshWorkspaceSnapshot(), createInitialReflectionState()
- Use Zod schema.parse({}) for createResponseAssemblyState() and createReasoningCacheState() - leverages schema defaults
- Inline createServerToolContentState() at both call sites
- Inline getWorkspaceState() and updateWorkspaceSnapshot() thin wrappers

~157 lines of abstraction overhead removed. Follows CLAUDE.md guidance on flattening abstraction layers and using Zod defaults.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reduces abstraction overhead and standardizes state handling via schema-first patterns and direct snapshot use.
> 
> - Core: use `ResponseAssemblyStateSchema.parse({})` and `ReasoningCacheStateSchema.parse({})`; inline `serverToolContent` init; remove unused creators (e.g., `createRetryState`).
> - Tool-use flow: delete `prepareInitialState`/`applyFollowUpMessage` helpers; `ToolUseRunFlow` now builds initial prompts/messages and follow-ups directly via model handler; initialize shared state inline in `runToolUseFlow`.
> - Reflection flow: remove `createInitialReflectionState`/workspace snapshot helpers; reconstruct `AgentWorkspaceState` directly in nodes and write back snapshots inline; reset workspace per round with `AgentWorkspaceState.create().toSnapshot()`.
> - Nodes: replace wrapper calls with direct `AgentRunState/AgentWorkspaceState.fromSnapshot()` and snapshot assignment; keep PocketFlow retry/exec patterns unchanged.
> - UI: inline agent filter/label logic in `streamInfoUtils` (remove helper functions).
> - Misc: minor formatting/argument wrapping in model handlers and tool utils; no API surface changes besides removed helpers/exports.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a9bf6105ca077b9a0d0e5c3095a374f83c769480. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->