### PR TITLE
Simplify and improve code clarity

### DIFF
--- a/src/agent/implementations/flows/ToolUseRunFlow.ts
+++ b/src/agent/implementations/flows/ToolUseRunFlow.ts
@@ -349,15 +349,6 @@ class ToolUseCycleNode<C> extends Node<
     super(NODE_NO_RETRY, NODE_NO_WAIT);
   }
 
-  /** Emit todos update event to progress view. */
-  private emitTodosUpdate(todos: TodoItem[]): void {
-    bus.emit('updateTodos', {
-      stream: this.services.streamId,
-      executionId: this.services.executionId,
-      todos,
-    });
-  }
-
   async prep(shared: ToolUseRunShared): Promise<CycleNodePrepResult> {
     // Validate invariant: PrepareNode must have run before us
     assertPreparedState(shared.state);
@@ -384,7 +375,11 @@ class ToolUseCycleNode<C> extends Node<
       // Emit recovered todos to restore progress view UI after reload
       const recoveredTodos = prepRes.workspaceState.todos.todos;
       if (recoveredTodos.length > 0) {
-        this.emitTodosUpdate(recoveredTodos);
+        bus.emit('updateTodos', {
+          stream: this.services.streamId,
+          executionId: this.services.executionId,
+          todos: recoveredTodos,
+        });
       }
       return { kind: 'skipped' };
     }
@@ -426,7 +421,11 @@ class ToolUseCycleNode<C> extends Node<
 
     // Set up todo update callback to emit changes to the progress view
     prepRes.workspaceState.todos.setOnUpdate((todos: TodoItem[]) => {
-      this.emitTodosUpdate(todos);
+      bus.emit('updateTodos', {
+        stream: this.services.streamId,
+        executionId: this.services.executionId,
+        todos,
+      });
     });
 
     try {

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -283,17 +283,13 @@ export class ModelHandlerAnthropic extends ModelHandler<
     this.cacheControlledBlock = undefined;
   }
 
-  private getMutableBetas(options: MessageCreateParams): AnthropicBeta[] {
+  /** Ensures a beta flag is included in options, initializing the array if needed. */
+  private ensureBeta(options: MessageCreateParams, beta: AnthropicBeta): void {
     if (!options.betas) {
       options.betas = [];
     }
-    return options.betas;
-  }
-
-  private appendBeta(options: MessageCreateParams, beta: AnthropicBeta): void {
-    const betas = this.getMutableBetas(options);
-    if (!betas.includes(beta)) {
-      betas.push(beta);
+    if (!options.betas.includes(beta)) {
+      options.betas.push(beta);
     }
   }
 
@@ -376,12 +372,12 @@ export class ModelHandlerAnthropic extends ModelHandler<
       (options as MessageCreateParams).tool_choice = { type: 'auto' };
 
       if (this.config.capabilities.supportsInterleavedThinking) {
-        this.appendBeta(options, INTERLEAVED_THINKING_BETA);
+        this.ensureBeta(options, INTERLEAVED_THINKING_BETA);
       }
 
       // Memory tool requires the context management beta header
       if (tools.some((t) => t.name === 'memory')) {
-        this.appendBeta(options, CONTEXT_MANAGEMENT_BETA);
+        this.ensureBeta(options, CONTEXT_MANAGEMENT_BETA);
       }
     }
 
@@ -420,9 +416,8 @@ export class ModelHandlerAnthropic extends ModelHandler<
 
     // Add beta features for Claude 3.7 Sonnet to increase max output to 128k tokens and enable thinking
     if (this.config.fullName === 'claude-3-7-sonnet-20250219') {
-      const sonnetBetas = this.getMutableBetas(options);
-      sonnetBetas.length = 0;
-      sonnetBetas.push(SONNET_37_OUTPUT_BETA);
+      // Reset betas to only include the output beta for this specific model
+      options.betas = [SONNET_37_OUTPUT_BETA];
       // Update max tokens to use the higher limit when streaming
       options.max_tokens = useStreaming ? 64000 : this.config.maxOutputTokens;
       // The thinking configuration is now handled above for all reasoning models
@@ -430,7 +425,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
 
     // Opt-in beta for 1M context window on Claude Sonnet 4 family
     if (isAnthropic1MBetaActive) {
-      this.appendBeta(options, CONTEXT_1M_BETA);
+      this.ensureBeta(options, CONTEXT_1M_BETA);
     }
 
     if (this.capabilities.supportsTokenCounting) {
@@ -549,7 +544,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
     }
 
     if (hasFileReference) {
-      this.appendBeta(options, FILES_API_BETA);
+      this.ensureBeta(options, FILES_API_BETA);
     }
 
     if (this.agentType === AgentType.ToolUse) {
@@ -562,7 +557,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
 
       // Only enable context management if threshold is configured (> 0)
       if (thresholdPercent > 0) {
-        this.appendBeta(options, CONTEXT_MANAGEMENT_BETA);
+        this.ensureBeta(options, CONTEXT_MANAGEMENT_BETA);
 
         const contextManagementEdits = [
           ...(options.context_management?.edits ?? []),
@@ -790,13 +785,9 @@ export class ModelHandlerAnthropic extends ModelHandler<
       }
 
       for (const block of content) {
+        // Clear cache_control from ineligible blocks (defensive cleanup)
         if (!isCacheControlEligibleBlock(block)) {
-          if (
-            block &&
-            typeof block === 'object' &&
-            'cache_control' in block &&
-            (block as { cache_control?: unknown }).cache_control
-          ) {
+          if (block && typeof block === 'object' && 'cache_control' in block) {
             delete (block as { cache_control?: unknown }).cache_control;
           }
           continue;
@@ -808,19 +799,16 @@ export class ModelHandlerAnthropic extends ModelHandler<
       }
     }
 
-    if (cacheControlledBlocks.length <= MAX_CACHE_CONTROLLED_BLOCKS) {
-      this.cacheControlledBlock = cacheControlledBlocks.at(-1);
-      return;
-    }
-
-    const excess = cacheControlledBlocks.length - MAX_CACHE_CONTROLLED_BLOCKS;
+    // Remove excess cache control markers, keeping only the last MAX_CACHE_CONTROLLED_BLOCKS
+    const excess = Math.max(
+      0,
+      cacheControlledBlocks.length - MAX_CACHE_CONTROLLED_BLOCKS,
+    );
     for (let idx = 0; idx < excess; idx += 1) {
-      const block = cacheControlledBlocks[idx];
-      delete block.cache_control;
+      delete cacheControlledBlocks[idx].cache_control;
     }
 
-    const remainingBlocks = cacheControlledBlocks.slice(excess);
-    this.cacheControlledBlock = remainingBlocks.at(-1);
+    this.cacheControlledBlock = cacheControlledBlocks.at(-1);
   }
 
   private async replaceDocumentDataWithUploads(
@@ -928,23 +916,23 @@ export class ModelHandlerAnthropic extends ModelHandler<
       }
 
       for (const block of contentBlocks) {
-        if (block.type !== 'document') {
+        // Skip non-document blocks or those without source
+        if (block.type !== 'document' || !block.source) {
           continue;
         }
 
-        const source = block.source;
-        if (!source) {
-          continue;
-        }
-
+        const { source } = block;
         if ('file_id' in (source as { file_id?: string })) {
           hasFileSource = true;
-        } else if (source.type === 'base64') {
-          if (source.media_type === 'application/pdf' && source.data) {
-            hasBase64Pdf = true;
-          }
+        } else if (
+          source.type === 'base64' &&
+          source.media_type === 'application/pdf' &&
+          source.data
+        ) {
+          hasBase64Pdf = true;
         }
 
+        // Early exit if both found
         if (hasFileSource && hasBase64Pdf) {
           return { hasFileSource: true, hasBase64Pdf: true };
         }

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -570,45 +570,26 @@ export class ModelHandlerOpenAI<
       userMessageContent.push(...formattedMediaContent);
     }
 
-    // Append the formatted content to the correct message
-    let lastRole = messages.length > 0 ? messages.at(-1).role : null;
-    if (lastRole === 'system' || messages.length === 0) {
-      messages.push({ role: 'user', content: userMessageContent });
-    } else if (lastRole === 'user') {
-      messages.at(-1).content.push(...userMessageContent);
+    // Append content to last user message, or create new user message
+    const lastMsg = messages.at(-1);
+    if (lastMsg?.role === 'user' && Array.isArray(lastMsg.content)) {
+      lastMsg.content.push(...userMessageContent);
     } else {
-      // Fallback: Should not happen with current logic but good to handle
       messages.push({ role: 'user', content: userMessageContent });
-      this.logger.warn(
-        'Unexpected message structure, adding new user message.',
-      );
     }
 
     // Add final user request
     const requestRole = this.config.capabilities.supportsIntermDevMsgs
       ? 'system'
       : 'user';
-    lastRole = messages.length > 0 ? messages.at(-1)?.role : null;
+    const lastMessage = messages.at(-1);
 
-    if (requestRole === 'system') {
-      messages.push({
-        role: requestRole,
-        content: [{ type: 'text', text: userRequest }],
-      });
-    } else if (requestRole === 'user' && lastRole === 'user') {
-      const lastMessage = messages.at(-1);
-      if (lastMessage && Array.isArray(lastMessage.content)) {
-        lastMessage.content.push({
-          type: 'text',
-          text: userRequest,
-        });
-      } else if (lastMessage && typeof lastMessage.content === 'string') {
-        // Convert string content to array format
-        lastMessage.content = [
-          { type: 'text', text: lastMessage.content },
-          { type: 'text', text: userRequest },
-        ];
-      }
+    if (
+      requestRole === 'user' &&
+      lastMessage?.role === 'user' &&
+      Array.isArray(lastMessage.content)
+    ) {
+      lastMessage.content.push({ type: 'text', text: userRequest });
     } else {
       messages.push({
         role: requestRole,

--- a/src/progressView/modules/usageManagers.js
+++ b/src/progressView/modules/usageManagers.js
@@ -5,6 +5,25 @@ import { formatTokens } from './formatters/index.js';
 import { progressViewState } from './progressViewState.js';
 
 /**
+ * Build HTML and aria-label segments for cache token display.
+ * @param {number} tokens - Token count
+ * @param {string} iconClass - Codicon class name (without 'codicon-' prefix)
+ * @param {string} titleText - Title for HTML tooltip
+ * @param {string} ariaText - Text for aria-label
+ * @returns {{ html: string, aria: string }}
+ */
+function buildCacheSegment(tokens, iconClass, titleText, ariaText) {
+  if (tokens <= 0) {
+    return { html: '', aria: '' };
+  }
+  const formatted = formatTokens(tokens);
+  return {
+    html: ` · <i class="codicon codicon-${iconClass}" title="${titleText}"></i>${formatted}`,
+    aria: `, ${formatted} ${ariaText}`,
+  };
+}
+
+/**
  * Manages usage summary display.
  */
 export class UsageSummary {
@@ -81,37 +100,31 @@ export class UsageSummary {
     const formattedCost = `$${cost.toFixed(3)}`;
 
     // Build cache segments: placed after input since cache is conceptually related to input
-    // Cache read: tokens served from cache (discounted rate)
-    // Cache creation: tokens written to cache (Anthropic: 1.25x input price)
-    const cacheReadSegment =
-      cacheReadTokens > 0
-        ? ` · <i class="codicon codicon-cloud-download" title="Cache read tokens (discounted)"></i>${formatTokens(cacheReadTokens)}`
-        : '';
-    const cacheCreationSegment =
-      cacheCreationTokens > 0
-        ? ` · <i class="codicon codicon-database" title="Cache creation tokens (1.25x cost)"></i>${formatTokens(cacheCreationTokens)}`
-        : '';
-    const cacheReadAriaLabel =
-      cacheReadTokens > 0
-        ? `, ${formatTokens(cacheReadTokens)} cache read tokens`
-        : '';
-    const cacheCreationAriaLabel =
-      cacheCreationTokens > 0
-        ? `, ${formatTokens(cacheCreationTokens)} cache creation tokens`
-        : '';
+    const cacheRead = buildCacheSegment(
+      cacheReadTokens,
+      'cloud-download',
+      'Cache read tokens (discounted)',
+      'cache read tokens',
+    );
+    const cacheCreation = buildCacheSegment(
+      cacheCreationTokens,
+      'database',
+      'Cache creation tokens (1.25x cost)',
+      'cache creation tokens',
+    );
 
     this._summaryElem.innerHTML = `
       <i class="codicon codicon-meter"></i>
       <span class="run-summary__label">Total usage:</span>
       <span class="run-summary__value">
-        <i class="codicon codicon-arrow-up" title="Input tokens"></i>${formattedInput}${cacheReadSegment}${cacheCreationSegment} ·
+        <i class="codicon codicon-arrow-up" title="Input tokens"></i>${formattedInput}${cacheRead.html}${cacheCreation.html} ·
         <i class="codicon codicon-arrow-down" title="Output tokens"></i>${formattedOutput} ·
         ${formattedCost}
       </span>
     `;
     this._summaryElem.setAttribute(
       'aria-label',
-      `Total usage: ${formattedInput} input tokens${cacheReadAriaLabel}${cacheCreationAriaLabel}, ${formattedOutput} output tokens, ${formattedCost}`,
+      `Total usage: ${formattedInput} input tokens${cacheRead.aria}${cacheCreation.aria}, ${formattedOutput} output tokens, ${formattedCost}`,
     );
   }
 

--- a/src/progressView/streamInfoUtils.ts
+++ b/src/progressView/streamInfoUtils.ts
@@ -40,20 +40,21 @@ export function buildStreamInfos(
     let sessionCategory =
       taskState?.agentConfig.session?.agentCategory ?? hints.sessionCategory;
 
-    // Filter logic: streams without category only show when filter is "all"
+    // Filter logic: check if stream matches the current filter
     if (!sessionCategory) {
+      // Streams without category only show when filter is "all"
       if (filter !== 'all') {
         return acc;
       }
-      // Default to Workflow for display purposes only when filter is "all"
       sessionCategory = AgentCategory.Workflow;
-    } else {
-      // Inline filter matching: check if session category matches filter
-      const matchesFilter =
-        filter === 'all' ||
-        (filter === 'toolUse' && sessionCategory === AgentCategory.ToolUse) ||
-        (filter === 'workflow' && sessionCategory === AgentCategory.Workflow);
-      if (!matchesFilter) {
+    } else if (filter !== 'all') {
+      // Check if session category matches filter
+      const filterMap: Record<AgentFilter, AgentCategory | null> = {
+        all: null,
+        toolUse: AgentCategory.ToolUse,
+        workflow: AgentCategory.Workflow,
+      };
+      if (filterMap[filter] !== sessionCategory) {
         return acc;
       }
     }
@@ -69,13 +70,13 @@ export function buildStreamInfos(
       ? isRemoteAgent(rawAgentName)
       : (hints.isRemote ?? false);
     const executionId = state.getExecutionId(id);
+
     // Build label: tool-use shows agent only, workflows show agent + file basename
-    const label =
-      sessionCategory === AgentCategory.ToolUse
-        ? agentName
-        : inputFile
-          ? `${agentName}: ${path.basename(inputFile)}`
-          : agentName;
+    let label = agentName;
+    if (sessionCategory !== AgentCategory.ToolUse && inputFile) {
+      label = `${agentName}: ${path.basename(inputFile)}`;
+    }
+
     acc.push({
       name: id,
       label,

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -109,18 +109,13 @@ async function ensureStorageDir(): Promise<string> {
   return dir;
 }
 
-function resolveTempExtension(targetPath: string): string {
-  const ext = path.extname(targetPath);
-  return ext ? ext : '.txt';
-}
-
 async function createTempFile(
   side: 'original' | 'proposed',
   targetPath: string,
   content: string,
 ): Promise<vscode.Uri> {
   const dir = await ensureStorageDir();
-  const ext = resolveTempExtension(targetPath);
+  const ext = path.extname(targetPath) || '.txt';
   const fileName = `${randomUUID()}-${side}${ext}`;
   const filePath = path.join(dir, fileName);
   await fs.writeFile(filePath, content, 'utf8');

--- a/src/utils/prompt/promptUtils.ts
+++ b/src/utils/prompt/promptUtils.ts
@@ -17,23 +17,6 @@ const CHANNEL = 'promptUtils';
 logger.initialize(CHANNEL);
 
 /**
- * Get XML formatted string from a single file.
- * Internal helper used by getXmlFormatFromFiles.
- */
-async function getXmlFormatFromFile(file: string): Promise<string> {
-  try {
-    const content = await WorkspaceFS.read(file);
-    return `<document name="${file}">\n${content}\n</document>`;
-  } catch (err) {
-    logger.error(
-      CHANNEL,
-      `Error formatting file as XML: ${toErrorMessage(err)}`,
-    );
-    throw err;
-  }
-}
-
-/**
  * Get XML formatted string from multiple files
  * @param files List of file paths
  * @returns XML formatted string containing all file contents, or null if no files
@@ -45,7 +28,18 @@ export async function getXmlFormatFromFiles(
     return null;
   }
 
-  const xmlPromises = files.map((file) => getXmlFormatFromFile(file));
+  const xmlPromises = files.map(async (file) => {
+    try {
+      const content = await WorkspaceFS.read(file);
+      return `<document name="${file}">\n${content}\n</document>`;
+    } catch (err) {
+      logger.error(
+        CHANNEL,
+        `Error formatting file as XML: ${toErrorMessage(err)}`,
+      );
+      throw err;
+    }
+  });
   const xmlContents = await Promise.all(xmlPromises);
   return xmlContents.join('\n');
 }
@@ -73,24 +67,17 @@ export async function renderPrompt(
   variables: { [key: string]: any },
 ): Promise<string> {
   try {
-    // First resolve any Promise values in the variables
+    // Resolve any Promise values in variables (including nested objects)
     const resolvedVariables: { [key: string]: any } = {};
     for (const [key, value] of Object.entries(variables)) {
       if (value instanceof Promise) {
         resolvedVariables[key] = await value;
-      } else if (
-        typeof value === 'object' &&
-        value !== null &&
-        value !== undefined
-      ) {
+      } else if (typeof value === 'object' && value !== null) {
         // Handle nested objects that might contain promises
         const resolved: { [key: string]: any } = {};
         for (const [nestedKey, nestedValue] of Object.entries(value)) {
-          if (nestedValue instanceof Promise) {
-            resolved[nestedKey] = await nestedValue;
-          } else {
-            resolved[nestedKey] = nestedValue;
-          }
+          resolved[nestedKey] =
+            nestedValue instanceof Promise ? await nestedValue : nestedValue;
         }
         resolvedVariables[key] = resolved;
       } else {
@@ -99,8 +86,7 @@ export async function renderPrompt(
     }
 
     const env = nunjucks.configure({ autoescape: false });
-    const renderedPrompt = env.renderString(prompt, resolvedVariables);
-    return renderedPrompt;
+    return env.renderString(prompt, resolvedVariables);
   } catch (err) {
     logger.error(CHANNEL, `Error rendering prompt: ${toErrorMessage(err)}`);
     throw err;


### PR DESCRIPTION
- Inline trivial emitTodosUpdate wrapper in ToolUseRunFlow (called 2x)
- Consolidate getMutableBetas/appendBeta into single ensureBeta helper
- Flatten defensive checks in enforceCacheControlLimit method
- Simplify analyzeDocumentSources by combining guard patterns
- Simplify initializeMessages by removing dead code branches

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> - **Anthropic handler:** Replace `getMutableBetas/appendBeta` with `ensureBeta`, reset betas for `claude-3-7-sonnet-20250219`, ensure betas for files/context, tighten `cache_control` cleanup/limits, and simplify document source analysis.
> - **OpenAI handler:** Simplify `initializeMessages` to append to the last user message or create one; streamline final request insertion.
> - **ToolUseRunFlow:** Inline todos update emissions (remove wrapper) for resume and onUpdate callbacks.
> - **Progress view:** Add `buildCacheSegment` to DRY cache token HTML/aria; update usage summary rendering accordingly.
> - **Stream list utils:** Simplify filter matching and label construction.
> - **Misc:** Inline temp file extension resolution; fold XML-per-file helper into `getXmlFormatFromFiles`; simplify `renderPrompt` variable resolution.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f032af0d54a3cd4028a158ffb128765c01aff29f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->