### PR TITLE
fix: handle missing persisted flow record

### DIFF
--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -110,7 +110,7 @@ export async function runToolUseFlow<C = unknown>(
     // Check for persisted flow (resume scenario)
     let flowRecord: FlowRecord | null = null;
     try {
-      flowRecord = await kv.read<FlowRecord>(`flow:${executionId}`);
+      flowRecord = (await kv.read<FlowRecord>(`flow:${executionId}`)) ?? null;
     } catch (error) {
       logger.debug(
         `Resume parse failed, starting fresh: ${error instanceof Error ? error.message : 'unknown'}`,


### PR DESCRIPTION
### Motivation

- Resolve a TypeScript compile error (TS2322) caused by `kv.read` returning `undefined` where `FlowRecord | null` was expected.
- Ensure the tool-use flow resume path treats missing persisted records consistently as `null` instead of `undefined`.
- Prevent a potential runtime/type mismatch during flow resume detection without changing flow semantics.

### Description

- Coalesce the result of `await kv.read<FlowRecord>(
  `flow:${executionId}`)` to `null` using `?? null` so the value matches `FlowRecord | null`.
- Update is confined to `runToolUseFlow` in `src/agent/implementations/flows/tooluse/runToolUseFlow.ts` and does not alter resume logic.
- No behavioral changes to `PersistedFlow` or service injection were made.

### Testing

- Ran `npm run format` which completed successfully.
- Ran `npm run compile` (webpack) which completed successfully but produced one warning about a dynamic dependency in `nunjucks`.
- Ran `npm run lint` which completed successfully but reported 4 existing `eqeqeq` warnings.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960df641a8c832481bc034686edbfc6)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures resume persistence reads are `null`-safe without changing flow behavior.
> 
> - In `runToolUseFlow.ts`, coalesces `await kv.read<FlowRecord>(`flow:${executionId}`)` to `null` via `?? null` so `flowRecord` is `FlowRecord | null`
> - Keeps resume detection (`Boolean(flowRecord?.shared)`) and overall execution semantics unchanged
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 357c9c27058e807c9405ee2cb4f9881154173ebe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->