### PR TITLE
Simplify and improve code clarity

### DIFF
--- a/src/agent/core/flows/CommonCycleTypes.ts
+++ b/src/agent/core/flows/CommonCycleTypes.ts
@@ -97,6 +97,18 @@ export const BaseCycleFieldsSchema = z.object({
 export type BaseCycleFields = z.infer<typeof BaseCycleFieldsSchema>;
 
 /**
+ * Reset values for base cycle fields (excludes messages which persists).
+ * Co-located with schema as single source of truth for reset behavior.
+ */
+export const BASE_CYCLE_RESET_VALUES: Omit<BaseCycleFields, 'messages'> = {
+  shouldStop: false,
+  endTurn: false,
+  responseTimeMs: undefined,
+  stopReason: undefined,
+  lastError: undefined,
+};
+
+/**
  * Unified debug context used across all cycle flows.
  * Provides consistent logging and execution tracking.
  *
@@ -161,34 +173,21 @@ export type SkippableNodeResult<T> =
   | { kind: 'success'; value: T };
 
 /**
- * Generic reset function for cycle states.
- * Resets base state fields and any additional optional fields to undefined.
+ * Reset cycle state to initial values.
  *
- * IMPORTANT: Only pass fields that should be reset to undefined.
- * - Do NOT pass 'messages' (preserved across cycles)
- * - Do NOT pass boolean fields like 'endTurn'
- *   (these should be reset to false separately, not undefined)
+ * Resets base fields using BASE_CYCLE_RESET_VALUES, then resets additional
+ * flow-specific fields to undefined.
  *
  * @param state - The state object to reset (must extend BaseCycleFields)
- * @param additionalFields - Field names to reset to undefined (typically optional object fields)
+ * @param additionalFields - Field names to reset to undefined (flow-specific fields)
  */
 export function resetCycleState<T extends BaseCycleFields>(
   state: T,
-  additionalFields: (keyof T)[],
+  additionalFields: (keyof T)[] = [],
 ): void {
-  // Reset base cycle state fields
-  state.shouldStop = false;
-  state.endTurn = false;
-  state.responseTimeMs = undefined;
-  state.stopReason = undefined;
-  state.lastError = undefined;
-
-  // Reset additional optional fields to undefined
+  Object.assign(state, BASE_CYCLE_RESET_VALUES);
   for (const field of additionalFields) {
-    // Skip 'messages' to preserve it across resets
-    if (field !== 'messages') {
-      state[field] = undefined as T[typeof field];
-    }
+    state[field] = undefined as T[typeof field];
   }
 }
 

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -184,15 +184,9 @@ export type ToolUseCycleFields = z.infer<typeof ToolUseCycleFieldsSchema>;
  * Called at the start of each cycle to clear transient fields.
  */
 function resetToolUseState(shared: ToolUseCycleShared): void {
-  resetCycleState(shared, []);
-  shared.response = undefined;
-  shared.toolCalls = undefined;
-  shared.text = undefined;
-  // Reset cycle metrics for next cycle
+  resetCycleState(shared, ['response', 'toolCalls', 'text', 'cycleNormalizedUsage']);
   shared.cycleResponseTimeMs = 0;
-  shared.cycleNormalizedUsage = undefined;
-  // Note: cycleIndex is incremented, not reset
-  // Note: endTurn is reset by resetCycleState (part of base fields)
+  // Note: cycleIndex is incremented in ToolUseProcessNode.post(), not reset here
 }
 
 /**

--- a/src/agent/implementations/flows/reflection/nodes/OutputNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/OutputNode.ts
@@ -1,27 +1,8 @@
 /**
  * OutputNode - Handles output processing after response cycle.
  *
- * Responsibilities:
- * - Ensure XML structure (if applicable)
- * - Process output files
- * - Handle latexdiff operations
- * - Finalize round and get artifacts
- *
- * All operations can fail gracefully - latexdiff failures
- * shouldn't stop the round from completing.
- *
- * PocketFlow pattern:
- * - prep(): Extract output location and round info
- * - exec(): Process output files and latexdiff
- * - post(): Store round output in shared
- *
- * Serialization pattern (koala-code-reader):
- * - Accesses only natively serializable state fields
- * - Stores RoundOutput (plain JSON) to shared.roundOutputs
- * - No class instances or runtime dependencies in state
- *
- * Services accessed via native `this.services`:
- * - outputHandler, logger, setting, fileService
+ * Processes output files, handles latexdiff, and finalizes round artifacts.
+ * Non-critical operations can fail gracefully (logged as warnings).
  */
 
 import { Node } from '@agent/node';
@@ -69,9 +50,6 @@ export class OutputNode<C = unknown> extends Node<
     super(NODE_NO_RETRY, NODE_NO_WAIT);
   }
 
-  /**
-   * Extract data needed for output processing.
-   */
   async prep(shared: ReflectionFlowShared): Promise<OutputPrepInput> {
     const { config, fileService, setting } = this.services;
     const { currentRound, outputLocation, endTurn } = shared;
@@ -97,10 +75,6 @@ export class OutputNode<C = unknown> extends Node<
     };
   }
 
-  /**
-   * Process output files and handle latexdiff.
-   * Logs warnings for non-critical failures. Throws on critical failures.
-   */
   async exec(prepRes: OutputPrepInput): Promise<OutputExecResult> {
     const { outputHandler, setting, logger } = this.services;
     const {
@@ -115,7 +89,6 @@ export class OutputNode<C = unknown> extends Node<
     if (endTurn) {
       logger.debug(`Processing output for round ${currentRound}`);
 
-      // Ensure XML structure if needed
       if (ensureXmlStructure) {
         try {
           await outputHandler.ensureXmlStructure(
@@ -123,47 +96,37 @@ export class OutputNode<C = unknown> extends Node<
             setting.documentTag ?? 'document',
           );
         } catch (error) {
-          const msg = toErrorMessage(error);
-          logger.warn(`XML structure failed: ${msg}`);
+          logger.warn(`XML structure failed: ${toErrorMessage(error)}`);
         }
       }
 
-      // Process output files
       try {
         await outputHandler.processOutputFiles(outputLocation, currentRound);
       } catch (error) {
-        const msg = toErrorMessage(error);
-        logger.warn(`Output processing failed: ${msg}`);
+        logger.warn(`Output processing failed: ${toErrorMessage(error)}`);
       }
 
-      // Handle latexdiff if we have outputs and base files
       if (outputHandler.hasRoundOutputs(currentRound)) {
         try {
           await this.handleLatexdiff(currentRound, baseFiles);
         } catch (error) {
-          const msg = toErrorMessage(error);
-          logger.warn(`Latexdiff failed: ${msg}`);
+          logger.warn(`Latexdiff failed: ${toErrorMessage(error)}`);
         }
       }
     }
 
-    // Finalize round
     try {
       await outputHandler.finalizeRound(outputLocation, currentRound, {
         endTurn,
       });
     } catch (error) {
-      const msg = toErrorMessage(error);
-      logger.warn(`Round finalization failed: ${msg}`);
+      logger.warn(`Round finalization failed: ${toErrorMessage(error)}`);
     }
 
     // Get round artifacts - this is critical, throw if it fails
     return await outputHandler.getRoundArtifacts(currentRound);
   }
 
-  /**
-   * Handle total failure - log warning and return empty output.
-   */
   async execFallback(
     prepRes: OutputPrepInput,
     error: Error,
@@ -182,9 +145,6 @@ export class OutputNode<C = unknown> extends Node<
     };
   }
 
-  /**
-   * Store round output in shared.
-   */
   async post(
     shared: ReflectionFlowShared,
     _prepRes: OutputPrepInput,
@@ -197,9 +157,6 @@ export class OutputNode<C = unknown> extends Node<
     return FlowTransition.DEFAULT;
   }
 
-  /**
-   * Handle latexdiff operations.
-   */
   private async handleLatexdiff(
     currentRound: number,
     baseFiles: FileLocation[],

--- a/src/agent/implementations/flows/reflection/nodes/RoundCompleteNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/RoundCompleteNode.ts
@@ -1,20 +1,8 @@
 /**
- * RoundCompleteNode - Handles round completion and continuation logic.
+ * RoundCompleteNode - Determines whether to continue to next round or finalize.
  *
- * Responsibilities:
- * - Check if more rounds should run (bounds, interruption, flags)
- * - Signal intent to RoundPersistedFlow (CONTINUE_NEXT_ROUND or FINALIZE)
- *
- * Note: RoundPersistedFlow OWNS the round increment. This node only signals
- * intent, and the flow handles all round lifecycle (increment, stages, reset).
- *
- * PocketFlow pattern:
- * - prep(): Extract current state
- * - exec(): Determine next action (pure logic)
- * - post(): Route based on decision
- *
- * Services accessed via native `this.services`:
- * - logger, checkInterruption
+ * Checks bounds, interruption, and continue flag to decide next action.
+ * RoundPersistedFlow owns round lifecycle; this node only signals intent.
  */
 
 import { Node } from '@agent/node';
@@ -58,9 +46,6 @@ export class RoundCompleteNode<C = unknown> extends Node<
     super(NODE_NO_RETRY, NODE_NO_WAIT);
   }
 
-  /**
-   * Extract state for completion decision.
-   */
   async prep(shared: ReflectionFlowShared): Promise<RoundCompletePrepInput> {
     return {
       currentRound: shared.currentRound,
@@ -69,9 +54,6 @@ export class RoundCompleteNode<C = unknown> extends Node<
     };
   }
 
-  /**
-   * Determine whether to continue or finalize.
-   */
   async exec(
     prepRes: RoundCompletePrepInput,
   ): Promise<RoundCompleteExecResult> {
@@ -106,29 +88,16 @@ export class RoundCompleteNode<C = unknown> extends Node<
   }
 
   /**
-   * Route based on decision.
-   *
-   * RoundPersistedFlow OWNS all round lifecycle:
-   * - Incrementing currentRound (single source of truth)
-   * - Stage lifecycle (end old stage, create new stage)
-   * - Workspace reset (via resetForNextRound hook)
-   *
-   * This node only signals intent via FlowTransitions.
+   * Route based on decision. RoundPersistedFlow owns all round lifecycle
+   * (incrementing, stages, workspace reset) - this node only signals intent.
    */
   async post(
     _shared: ReflectionFlowShared,
     _prepRes: RoundCompletePrepInput,
     execRes: RoundCompleteExecResult,
   ): Promise<string | undefined> {
-    if (execRes.kind === 'finalize') {
-      return FlowTransition.FINALIZE;
-    }
-
-    // Signal intent to continue - RoundPersistedFlow will:
-    // 1. Increment currentRound (single source of truth)
-    // 2. End old round stage
-    // 3. Call resetForNextRound hook (workspace reset)
-    // 4. Create new round stage
-    return FlowTransition.CONTINUE_NEXT_ROUND;
+    return execRes.kind === 'finalize'
+      ? FlowTransition.FINALIZE
+      : FlowTransition.CONTINUE_NEXT_ROUND;
   }
 }


### PR DESCRIPTION
- Add BASE_CYCLE_RESET_VALUES const co-located with schema (single source of truth)
- Update resetCycleState to use Object.assign with the const
- Keep simple array-based API for additional fields (clearer than object API)
- Simplify RoundCompleteNode: remove verbose comments, use ternary in post()
- Simplify OutputNode file header (keep explicit try-catch - clearer than helper)

The array-based API for additionalFields is clearer: it explicitly means "reset these to undefined", while specific values like cycleResponseTimeMs=0 remain as separate assignments.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Core reset logic**
> 
> - Add `BASE_CYCLE_RESET_VALUES` in `CommonCycleTypes.ts` and refactor `resetCycleState` to use it (with default `additionalFields=[]`).
> - Unify reset behavior by assigning base fields via `Object.assign` and clearing flow-specific fields to `undefined`.
> 
> **Tool-use flow**
> 
> - Update `resetToolUseState` to call `resetCycleState(shared, ['response','toolCalls','text','cycleNormalizedUsage'])` and keep metric handling (`cycleResponseTimeMs=0`, `cycleIndex` increment elsewhere).
> 
> **Reflection nodes**
> 
> - Simplify `OutputNode` and `RoundCompleteNode` (trim comments, use ternary in `post()`), and inline warn messages using `toErrorMessage`. Functional behavior remains the same.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 07cc569f82d4af7354d9dd8dc3b016238bbe7db0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->