### PR TITLE
Simplify and improve code clarity

### DIFF
--- a/src/agent/implementations/flows/reflection/ReflectionFlowState.ts
+++ b/src/agent/implementations/flows/reflection/ReflectionFlowState.ts
@@ -44,7 +44,7 @@ import {
   CycleFieldsSchema,
   type CycleTransientFields,
 } from '@agent/core/flows/ResponseCycleFlow';
-import { AgentFileLocationSchema } from '@utils/files';
+import { AgentFileLocationSchema, FileLocationSchema } from '@utils/files';
 
 // ============================================================================
 // Schemas (Single Source of Truth)
@@ -57,6 +57,9 @@ import { AgentFileLocationSchema } from '@utils/files';
  * - stateRoundSnapshot is a plain JSON snapshot (not class instance)
  * - Nodes reconstruct ConversationRoundState when needed for mutation
  * - This ensures structuredClone() works correctly in PersistedFlow
+ *
+ * Pre-computed values to avoid redundant calculations across nodes:
+ * - filesForRound: computed once in PrepareContextNode, reused by TeXCountNode and MediaExtractionNode
  */
 export const RoundContextSchema = z.object({
   /** Prepared messages for the model */
@@ -65,6 +68,8 @@ export const RoundContextSchema = z.object({
   prefill: z.string(),
   /** Round state snapshot (natively serializable) */
   stateRoundSnapshot: ConversationRoundStateSnapshotSchema,
+  /** Files to process for this round (computed once, reused by multiple nodes) */
+  filesForRound: z.array(FileLocationSchema),
 });
 
 /** Derived type from schema */

--- a/src/agent/implementations/flows/reflection/ReflectionFlowState.ts
+++ b/src/agent/implementations/flows/reflection/ReflectionFlowState.ts
@@ -44,7 +44,7 @@ import {
   CycleFieldsSchema,
   type CycleTransientFields,
 } from '@agent/core/flows/ResponseCycleFlow';
-import { AgentFileLocationSchema, FileLocationSchema } from '@utils/files';
+import { AgentFileLocationSchema } from '@utils/files';
 
 // ============================================================================
 // Schemas (Single Source of Truth)
@@ -52,24 +52,12 @@ import { AgentFileLocationSchema, FileLocationSchema } from '@utils/files';
 
 /**
  * Natively serializable context prepared for a round.
- *
- * Following koala-code-reader pattern:
- * - stateRoundSnapshot is a plain JSON snapshot (not class instance)
- * - Nodes reconstruct ConversationRoundState when needed for mutation
- * - This ensures structuredClone() works correctly in PersistedFlow
- *
- * Pre-computed values to avoid redundant calculations across nodes:
- * - filesForRound: computed once in PrepareContextNode, reused by TeXCountNode and MediaExtractionNode
+ * Stores snapshots (not class instances) for structuredClone() compatibility.
  */
 export const RoundContextSchema = z.object({
-  /** Prepared messages for the model */
   messages: z.array(ProviderMessageSchema),
-  /** Prefill text for assistant response */
   prefill: z.string(),
-  /** Round state snapshot (natively serializable) */
   stateRoundSnapshot: ConversationRoundStateSnapshotSchema,
-  /** Files to process for this round (computed once, reused by multiple nodes) */
-  filesForRound: z.array(FileLocationSchema),
 });
 
 /** Derived type from schema */

--- a/src/agent/implementations/flows/reflection/ReflectionServices.ts
+++ b/src/agent/implementations/flows/reflection/ReflectionServices.ts
@@ -15,7 +15,11 @@ import type { AgentWorkflowSetting } from '@agent/core/AgentDataclass';
 import type { RoundFinalizedCallback } from '@agent/core/flows/CycleServices';
 import type { AgentLogStage } from '@logger/AgentLogger';
 import type { PromptBuilder } from '@utils/prompt';
-import type { AgentFileLocation, TaskRunFileService } from '@utils/files';
+import type {
+  AgentFileLocation,
+  TaskRunFileService,
+  WorkspaceFileLocation,
+} from '@utils/files';
 import type { LatexMediaManager } from '@latex';
 import type { BaseFlowContextInit } from '../common/BaseFlowServices';
 
@@ -80,6 +84,12 @@ export interface ReflectionServices<
    * Returns a callback that will be invoked when a round finalizes.
    */
   readonly getUsageRecorder: () => RoundFinalizedCallback;
+
+  /**
+   * Base files for latexdiff operations.
+   * Pre-computed once in runReflectionFlow to avoid redundant recalculation.
+   */
+  readonly baseFiles: WorkspaceFileLocation[];
 }
 
 /**

--- a/src/agent/implementations/flows/reflection/ReflectionServices.ts
+++ b/src/agent/implementations/flows/reflection/ReflectionServices.ts
@@ -79,16 +79,7 @@ export interface ReflectionServices<
    */
   readonly shouldEnsureXmlStructure: boolean;
 
-  /**
-   * Get usage recorder callback for tracking round statistics.
-   * Returns a callback that will be invoked when a round finalizes.
-   */
   readonly getUsageRecorder: () => RoundFinalizedCallback;
-
-  /**
-   * Base files for latexdiff operations.
-   * Pre-computed once in runReflectionFlow to avoid redundant recalculation.
-   */
   readonly baseFiles: WorkspaceFileLocation[];
 }
 

--- a/src/agent/implementations/flows/reflection/helpers.ts
+++ b/src/agent/implementations/flows/reflection/helpers.ts
@@ -1,19 +1,10 @@
-/**
- * Shared helper functions for ReflectionFlow nodes.
- *
- * These helpers consolidate logic that would otherwise be duplicated
- * across multiple nodes, following DRY principles.
- */
+/** Shared helper functions for ReflectionFlow nodes. */
 
 import * as path from 'path';
 
 import type { RoundOutput } from '@agent/output';
-
 import type { AgentConfig } from '@agent/core/AgentConfig';
-import type {
-  AgentWorkflowSetting,
-  AgentPrompt,
-} from '@agent/core/AgentDataclass';
+import type { AgentWorkflowSetting, AgentPrompt } from '@agent/core/AgentDataclass';
 import { getOutputFileName } from '@agent/utils/outputFileUtils';
 import {
   WorkspaceFS,
@@ -24,18 +15,7 @@ import {
   type WorkspaceFileLocation,
 } from '@utils/files';
 
-/**
- * Determine which files to process for a given round.
- *
- * Used by TeXCountNode and MediaExtractionNode to avoid duplicating
- * the file determination logic.
- *
- * @param currentRound - Current round index (0-based)
- * @param roundOutputs - Outputs from previous rounds
- * @param config - Agent configuration
- * @param fileService - File service for creating locations
- * @returns Array of file locations to process
- */
+/** Get files to process for a round (input files for round 0, previous outputs otherwise). */
 export function getFilesForRound(
   currentRound: number,
   roundOutputs: RoundOutput[],
@@ -64,133 +44,53 @@ export function getFilesForRound(
   return [];
 }
 
-/**
- * Create base file locations for latexdiff and artifact tracking.
- *
- * Base files are ALWAYS workspace locations (inputs from workspace).
- * Even in run-storage mode, we snapshot FROM workspace TO run storage.
- * Latexdiff must reference the original workspace files, not their
- * run storage copies.
- *
- * @param config - Agent configuration with outputFiles and inputFile
- * @returns Array of workspace file locations for base files
- */
-export function createBaseFileLocations(
-  config: AgentConfig,
-): WorkspaceFileLocation[] {
-  const files =
-    config.outputFiles.length > 0 ? config.outputFiles : [config.inputFile];
+/** Create workspace file locations for latexdiff base files. */
+export function createBaseFileLocations(config: AgentConfig): WorkspaceFileLocation[] {
+  const files = config.outputFiles.length > 0 ? config.outputFiles : [config.inputFile];
   return files.map((f) => {
-    // Handle absolute paths correctly: path.join() incorrectly concatenates
-    // when the second arg is absolute, so we must check first.
-    // See resolveFilePath in pathUtils.ts for the canonical pattern.
     const absolutePath = path.isAbsolute(f) ? f : WorkspaceFS.fullPath(f);
     const relativePath = path.isAbsolute(f) ? WorkspaceFS.relativePath(f) : f;
     return createWorkspaceLocation(absolutePath, relativePath);
   });
 }
 
-/**
- * Compute whether to enforce XML structure in responses.
- *
- * Extracted from runReflectionFlow for clarity and testability.
- * Logic priority:
- * 1. Explicit xmlStructureMode setting takes precedence
- * 2. CoT agents always use XML structure
- * 3. Direct agents only use XML structure with scratchpad
- *
- * @param setting - Agent workflow settings
- * @param useScratchpad - Whether scratchpad prefill is enabled
- * @returns Whether to enforce XML structure
- */
+/** Determine if XML structure should be enforced based on setting and agent type. */
 export function computeShouldEnsureXmlStructure(
   setting: AgentWorkflowSetting,
   useScratchpad: boolean,
 ): boolean {
   if (setting.xmlStructureMode !== undefined) {
-    return (
-      setting.xmlStructureMode === 'always' ||
-      (setting.xmlStructureMode === 'scratchpadOnly' && useScratchpad)
-    );
+    return setting.xmlStructureMode === 'always' ||
+      (setting.xmlStructureMode === 'scratchpadOnly' && useScratchpad);
   }
-  if (setting.agentType === 'CoT') {
-    return true;
-  }
-  if (setting.agentType === 'direct') {
-    return useScratchpad;
-  }
+  if (setting.agentType === 'CoT') return true;
+  if (setting.agentType === 'direct') return useScratchpad;
   return false;
 }
 
-/**
- * Compute total rounds for workflow execution.
- *
- * Extracted from runReflectionFlow for clarity and testability.
- * Logic priority:
- * 1. Explicit maxRounds setting takes precedence
- * 2. Direct agents always run 1 round
- * 3. Otherwise use max of configured rounds or request count
- *
- * @param setting - Agent workflow settings
- * @param prompt - Agent prompt with user requests
- * @returns Number of rounds to execute
- */
-export function computeTotalRounds(
-  setting: AgentWorkflowSetting,
-  prompt: AgentPrompt,
-): number {
-  if (setting.maxRounds !== undefined) {
-    return setting.maxRounds;
-  }
-  if (setting.agentType === 'direct') {
-    return 1;
-  }
+/** Compute total rounds: explicit maxRounds, or 1 for direct, or max(rounds, requests). */
+export function computeTotalRounds(setting: AgentWorkflowSetting, prompt: AgentPrompt): number {
+  if (setting.maxRounds !== undefined) return setting.maxRounds;
+  if (setting.agentType === 'direct') return 1;
   const requests = Array.isArray(prompt.userRequest)
     ? prompt.userRequest
-    : prompt.userRequest
-      ? [prompt.userRequest]
-      : [];
+    : prompt.userRequest ? [prompt.userRequest] : [];
   return Math.max(setting.rounds ?? 2, requests.length);
 }
 
-/**
- * Parameters for creating an output file location getter.
- */
-interface OutputFileLocationParams {
+/** Create a getter for output file locations per round. */
+export function createOutputFileLocationGetter(params: {
   fileService: TaskRunFileService;
   config: AgentConfig;
   modelName: string;
   setting: AgentWorkflowSetting;
   useScratchpad: boolean;
-}
-
-/**
- * Create a function that generates output file locations for each round.
- *
- * Extracted from runReflectionFlow for clarity and reuse.
- *
- * @param params - Configuration for output file generation
- * @returns Function that maps round number to output file location
- */
-export function createOutputFileLocationGetter(
-  params: OutputFileLocationParams,
-): (round: number) => AgentFileLocation {
+}): (round: number) => AgentFileLocation {
   const { fileService, config, modelName, setting, useScratchpad } = params;
-  const fileExtension = useScratchpad ? 'xml' : setting.outputExt;
+  const ext = useScratchpad ? 'xml' : setting.outputExt;
 
-  return (currRound: number): AgentFileLocation => {
-    const fileName = getOutputFileName(
-      config.inputFile,
-      config.agent,
-      modelName,
-      fileExtension,
-      currRound,
-      config.editedFile || undefined,
-    );
-    return (
-      useScratchpad
-        ? fileService.createRawOutputLocation(fileName)
-        : fileService.createLocation(fileName)
-    ) as AgentFileLocation;
+  return (round: number): AgentFileLocation => {
+    const fileName = getOutputFileName(config.inputFile, config.agent, modelName, ext, round, config.editedFile || undefined);
+    return (useScratchpad ? fileService.createRawOutputLocation(fileName) : fileService.createLocation(fileName)) as AgentFileLocation;
   };
 }

--- a/src/agent/implementations/flows/reflection/helpers.ts
+++ b/src/agent/implementations/flows/reflection/helpers.ts
@@ -10,9 +10,15 @@ import * as path from 'path';
 import type { RoundOutput } from '@agent/output';
 
 import type { AgentConfig } from '@agent/core/AgentConfig';
+import type {
+  AgentWorkflowSetting,
+  AgentPrompt,
+} from '@agent/core/AgentDataclass';
+import { getOutputFileName } from '@agent/utils/outputFileUtils';
 import {
   WorkspaceFS,
   createWorkspaceLocation,
+  type AgentFileLocation,
   type FileLocation,
   type TaskRunFileService,
   type WorkspaceFileLocation,
@@ -82,4 +88,109 @@ export function createBaseFileLocations(
     const relativePath = path.isAbsolute(f) ? WorkspaceFS.relativePath(f) : f;
     return createWorkspaceLocation(absolutePath, relativePath);
   });
+}
+
+/**
+ * Compute whether to enforce XML structure in responses.
+ *
+ * Extracted from runReflectionFlow for clarity and testability.
+ * Logic priority:
+ * 1. Explicit xmlStructureMode setting takes precedence
+ * 2. CoT agents always use XML structure
+ * 3. Direct agents only use XML structure with scratchpad
+ *
+ * @param setting - Agent workflow settings
+ * @param useScratchpad - Whether scratchpad prefill is enabled
+ * @returns Whether to enforce XML structure
+ */
+export function computeShouldEnsureXmlStructure(
+  setting: AgentWorkflowSetting,
+  useScratchpad: boolean,
+): boolean {
+  if (setting.xmlStructureMode !== undefined) {
+    return (
+      setting.xmlStructureMode === 'always' ||
+      (setting.xmlStructureMode === 'scratchpadOnly' && useScratchpad)
+    );
+  }
+  if (setting.agentType === 'CoT') {
+    return true;
+  }
+  if (setting.agentType === 'direct') {
+    return useScratchpad;
+  }
+  return false;
+}
+
+/**
+ * Compute total rounds for workflow execution.
+ *
+ * Extracted from runReflectionFlow for clarity and testability.
+ * Logic priority:
+ * 1. Explicit maxRounds setting takes precedence
+ * 2. Direct agents always run 1 round
+ * 3. Otherwise use max of configured rounds or request count
+ *
+ * @param setting - Agent workflow settings
+ * @param prompt - Agent prompt with user requests
+ * @returns Number of rounds to execute
+ */
+export function computeTotalRounds(
+  setting: AgentWorkflowSetting,
+  prompt: AgentPrompt,
+): number {
+  if (setting.maxRounds !== undefined) {
+    return setting.maxRounds;
+  }
+  if (setting.agentType === 'direct') {
+    return 1;
+  }
+  const requests = Array.isArray(prompt.userRequest)
+    ? prompt.userRequest
+    : prompt.userRequest
+      ? [prompt.userRequest]
+      : [];
+  return Math.max(setting.rounds ?? 2, requests.length);
+}
+
+/**
+ * Parameters for creating an output file location getter.
+ */
+interface OutputFileLocationParams {
+  fileService: TaskRunFileService;
+  config: AgentConfig;
+  modelName: string;
+  setting: AgentWorkflowSetting;
+  useScratchpad: boolean;
+}
+
+/**
+ * Create a function that generates output file locations for each round.
+ *
+ * Extracted from runReflectionFlow for clarity and reuse.
+ *
+ * @param params - Configuration for output file generation
+ * @returns Function that maps round number to output file location
+ */
+export function createOutputFileLocationGetter(
+  params: OutputFileLocationParams,
+): (round: number) => AgentFileLocation {
+  const { fileService, config, modelName, setting, useScratchpad } = params;
+  const fileExtension = useScratchpad ? 'xml' : setting.outputExt;
+
+  return (currRound: number): AgentFileLocation => {
+    const fileName = getOutputFileName(
+      config.inputFile,
+      config.agent,
+      modelName,
+      fileExtension,
+      currRound,
+      config.editedFile || undefined,
+    );
+    return (
+      useScratchpad
+        ? fileService.createRawOutputLocation(fileName)
+        : fileService.createLocation(fileName)
+    ) as AgentFileLocation;
+  };
 }

--- a/src/agent/implementations/flows/reflection/nodes/MediaExtractionNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/MediaExtractionNode.ts
@@ -14,8 +14,6 @@ import {
 import { AgentWorkspaceState } from '@agent/core/AgentWorkspaceState';
 import type { FileLocation } from '@utils/files';
 
-import { getFilesForRound } from '../helpers';
-
 import {
   type ReflectionFlowShared,
   type RoundContext,
@@ -45,16 +43,10 @@ export class MediaExtractionNode<C = unknown> extends Node<
 
   async prep(shared: ReflectionFlowShared): Promise<MediaPrepInput> {
     const { config, fileService, modelHandler } = this.services;
-    const { currentRound, roundOutputs, context } = shared;
+    const { currentRound, context } = shared;
 
     const workspaceState = AgentWorkspaceState.fromSnapshot(
       shared.workspaceSnapshot,
-    );
-    const files = getFilesForRound(
-      currentRound,
-      roundOutputs,
-      config,
-      fileService,
     );
 
     const extraMediaFiles: FileLocation[] = [];
@@ -68,7 +60,7 @@ export class MediaExtractionNode<C = unknown> extends Node<
     }
 
     return {
-      files,
+      files: context?.filesForRound ?? [],
       currentRound,
       supportsVision: modelHandler.capabilities.supportsVision,
       extraMediaFiles,

--- a/src/agent/implementations/flows/reflection/nodes/MediaExtractionNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/MediaExtractionNode.ts
@@ -14,14 +14,9 @@ import {
 import { AgentWorkspaceState } from '@agent/core/AgentWorkspaceState';
 import type { FileLocation } from '@utils/files';
 
-import {
-  type ReflectionFlowShared,
-  type RoundContext,
-} from '../ReflectionFlowState';
-import type {
-  ReflectionFlowParams,
-  ReflectionServices,
-} from '../ReflectionServices';
+import { getFilesForRound } from '../helpers';
+import type { ReflectionFlowShared, RoundContext } from '../ReflectionFlowState';
+import type { ReflectionFlowParams, ReflectionServices } from '../ReflectionServices';
 
 interface MediaPrepInput {
   files: FileLocation[];
@@ -43,24 +38,17 @@ export class MediaExtractionNode<C = unknown> extends Node<
 
   async prep(shared: ReflectionFlowShared): Promise<MediaPrepInput> {
     const { config, fileService, modelHandler } = this.services;
-    const { currentRound, context } = shared;
+    const { currentRound, roundOutputs, context } = shared;
 
-    const workspaceState = AgentWorkspaceState.fromSnapshot(
-      shared.workspaceSnapshot,
-    );
-
+    const workspaceState = AgentWorkspaceState.fromSnapshot(shared.workspaceSnapshot);
     const extraMediaFiles: FileLocation[] = [];
     if (currentRound === 0 && modelHandler.capabilities.supportsVision) {
-      if (config.mediaFile) {
-        extraMediaFiles.push(fileService.createLocation(config.mediaFile));
-      }
-      for (const mediaPath of config.mediaFiles) {
-        extraMediaFiles.push(fileService.createLocation(mediaPath));
-      }
+      if (config.mediaFile) extraMediaFiles.push(fileService.createLocation(config.mediaFile));
+      for (const p of config.mediaFiles) extraMediaFiles.push(fileService.createLocation(p));
     }
 
     return {
-      files: context?.filesForRound ?? [],
+      files: getFilesForRound(currentRound, roundOutputs, config, fileService),
       currentRound,
       supportsVision: modelHandler.capabilities.supportsVision,
       extraMediaFiles,

--- a/src/agent/implementations/flows/reflection/nodes/OutputNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/OutputNode.ts
@@ -35,7 +35,6 @@ import { toErrorMessage } from '@common/errors';
 import type { AgentFileLocation, FileLocation } from '@utils/files';
 import { flexibleFS } from '@utils/files';
 
-import { createBaseFileLocations } from '../helpers';
 import type { ReflectionFlowShared } from '../ReflectionFlowState';
 import type {
   ReflectionFlowParams,
@@ -73,7 +72,7 @@ export class OutputNode<C = unknown> extends Node<
    * Extract data needed for output processing.
    */
   async prep(shared: ReflectionFlowShared): Promise<OutputPrepInput> {
-    const { config, fileService, setting } = this.services;
+    const { baseFiles, shouldEnsureXmlStructure } = this.services;
     const { currentRound, outputLocation, endTurn } = shared;
 
     if (!outputLocation) {
@@ -82,18 +81,12 @@ export class OutputNode<C = unknown> extends Node<
       );
     }
 
-    // Base files for latexdiff - MUST be workspace locations
-    const baseFiles = createBaseFileLocations(config);
-
-    // Determine if we should ensure XML structure (based on xmlStructureMode config)
-    const ensureXmlStructure = this.services.shouldEnsureXmlStructure;
-
     return {
       currentRound,
       outputLocation,
       endTurn,
       baseFiles,
-      ensureXmlStructure,
+      ensureXmlStructure: shouldEnsureXmlStructure,
     };
   }
 

--- a/src/agent/implementations/flows/reflection/nodes/PrepareContextNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/PrepareContextNode.ts
@@ -25,9 +25,7 @@ import {
   NODE_NO_WAIT,
 } from '@agent/implementations/flows/common';
 import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
-import type { FileLocation } from '@utils/files';
 
-import { getFilesForRound } from '../helpers';
 import type {
   ReflectionFlowShared,
   RoundContext,
@@ -44,7 +42,6 @@ import type {
 interface ContextPrepInput {
   currentRound: number;
   conversation: ProviderMessage[];
-  filesForRound: FileLocation[];
 }
 
 type ContextExecResult = { kind: 'ready'; context: RoundContext };
@@ -62,96 +59,48 @@ export class PrepareContextNode<C = unknown> extends Node<
     super(NODE_NO_RETRY, NODE_NO_WAIT);
   }
 
-  /**
-   * Extract data needed for context preparation.
-   * Computes filesForRound here to avoid redundant calls in subsequent nodes.
-   */
   async prep(shared: ReflectionFlowShared): Promise<ContextPrepInput> {
-    const { config, fileService } = this.services;
-    const { currentRound, conversation, roundOutputs } = shared;
-
-    // Compute filesForRound once here, reused by TeXCountNode and MediaExtractionNode
-    const filesForRound = getFilesForRound(
-      currentRound,
-      roundOutputs,
-      config,
-      fileService,
-    );
-
     return {
-      currentRound,
-      conversation,
-      filesForRound,
+      currentRound: shared.currentRound,
+      conversation: shared.conversation,
     };
   }
 
-  /**
-   * Build prompts and base messages for the round.
-   * Does NOT include texcount stats or media - those are added by subsequent nodes.
-   */
   async exec(prepRes: ContextPrepInput): Promise<ContextExecResult> {
     const { promptBuilder, modelHandler, logger } = this.services;
-    const { currentRound, conversation, filesForRound } = prepRes;
+    const { currentRound, conversation } = prepRes;
 
     const stateRound = new ConversationRoundState(currentRound);
 
     if (currentRound === 0) {
-      // First round: build initial prompts
       const { systemPrompt, userRequest, userPrefix } =
         await promptBuilder.buildInitialPrompts();
-
-      // Build prefill
       const prefill = await promptBuilder.buildPrefill(currentRound);
-
-      // Initialize base messages (no media - will be added by MediaExtractionNode)
       const messages = await modelHandler.initializeMessages(
         userPrefix,
         userRequest,
-        undefined, // media added later by MediaExtractionNode
+        undefined,
         systemPrompt,
       );
 
-      logger.debug(
-        `Prepared first round base context with ${messages.length} messages`,
-      );
+      logger.debug(`Prepared first round context with ${messages.length} messages`);
 
       return {
         kind: 'ready',
-        context: {
-          messages,
-          prefill: prefill ?? '',
-          stateRoundSnapshot: stateRound.toSnapshot(),
-          filesForRound,
-        },
-      };
-    } else {
-      // Subsequent rounds: build user request only
-      const userRequest = await promptBuilder.buildUserRequest(currentRound);
-
-      // Build prefill
-      const prefill = await promptBuilder.buildPrefill(currentRound);
-
-      // Create round messages (no media - will be added by MediaExtractionNode)
-      const messages = await modelHandler.createRoundMessages(
-        conversation,
-        userRequest,
-        undefined, // media added later by MediaExtractionNode
-      );
-
-      logger.debug(
-        `Prepared round ${currentRound} base context with ${messages.length} messages`,
-      );
-
-      return {
-        kind: 'ready',
-        context: {
-          messages,
-          prefill: prefill ?? '',
-          stateRoundSnapshot: stateRound.toSnapshot(),
-          filesForRound,
-        },
+        context: { messages, prefill: prefill ?? '', stateRoundSnapshot: stateRound.toSnapshot() },
       };
     }
+
+    const userRequest = await promptBuilder.buildUserRequest(currentRound);
+    const prefill = await promptBuilder.buildPrefill(currentRound);
+    const messages = await modelHandler.createRoundMessages(conversation, userRequest, undefined);
+
+    logger.debug(`Prepared round ${currentRound} context with ${messages.length} messages`);
+
+    return {
+      kind: 'ready',
+      context: { messages, prefill: prefill ?? '', stateRoundSnapshot: stateRound.toSnapshot() },
+    };
   }
 
   /**

--- a/src/agent/implementations/flows/reflection/nodes/PrepareContextNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/PrepareContextNode.ts
@@ -25,7 +25,9 @@ import {
   NODE_NO_WAIT,
 } from '@agent/implementations/flows/common';
 import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
+import type { FileLocation } from '@utils/files';
 
+import { getFilesForRound } from '../helpers';
 import type {
   ReflectionFlowShared,
   RoundContext,
@@ -42,6 +44,7 @@ import type {
 interface ContextPrepInput {
   currentRound: number;
   conversation: ProviderMessage[];
+  filesForRound: FileLocation[];
 }
 
 type ContextExecResult = { kind: 'ready'; context: RoundContext };
@@ -61,11 +64,24 @@ export class PrepareContextNode<C = unknown> extends Node<
 
   /**
    * Extract data needed for context preparation.
+   * Computes filesForRound here to avoid redundant calls in subsequent nodes.
    */
   async prep(shared: ReflectionFlowShared): Promise<ContextPrepInput> {
+    const { config, fileService } = this.services;
+    const { currentRound, conversation, roundOutputs } = shared;
+
+    // Compute filesForRound once here, reused by TeXCountNode and MediaExtractionNode
+    const filesForRound = getFilesForRound(
+      currentRound,
+      roundOutputs,
+      config,
+      fileService,
+    );
+
     return {
-      currentRound: shared.currentRound,
-      conversation: shared.conversation,
+      currentRound,
+      conversation,
+      filesForRound,
     };
   }
 
@@ -75,7 +91,7 @@ export class PrepareContextNode<C = unknown> extends Node<
    */
   async exec(prepRes: ContextPrepInput): Promise<ContextExecResult> {
     const { promptBuilder, modelHandler, logger } = this.services;
-    const { currentRound, conversation } = prepRes;
+    const { currentRound, conversation, filesForRound } = prepRes;
 
     const stateRound = new ConversationRoundState(currentRound);
 
@@ -105,6 +121,7 @@ export class PrepareContextNode<C = unknown> extends Node<
           messages,
           prefill: prefill ?? '',
           stateRoundSnapshot: stateRound.toSnapshot(),
+          filesForRound,
         },
       };
     } else {
@@ -131,6 +148,7 @@ export class PrepareContextNode<C = unknown> extends Node<
           messages,
           prefill: prefill ?? '',
           stateRoundSnapshot: stateRound.toSnapshot(),
+          filesForRound,
         },
       };
     }

--- a/src/agent/implementations/flows/reflection/nodes/TeXCountNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/TeXCountNode.ts
@@ -11,14 +11,9 @@ import {
 import type { FileLocation } from '@utils/files';
 import { getTeXCountStats } from '@latex';
 
-import type {
-  ReflectionFlowShared,
-  RoundContext,
-} from '../ReflectionFlowState';
-import type {
-  ReflectionFlowParams,
-  ReflectionServices,
-} from '../ReflectionServices';
+import { getFilesForRound } from '../helpers';
+import type { ReflectionFlowShared, RoundContext } from '../ReflectionFlowState';
+import type { ReflectionFlowParams, ReflectionServices } from '../ReflectionServices';
 
 interface TeXCountPrepInput {
   files: FileLocation[];
@@ -36,13 +31,11 @@ export class TeXCountNode<C = unknown> extends Node<
   }
 
   async prep(shared: ReflectionFlowShared): Promise<TeXCountPrepInput> {
-    const { config } = this.services;
-    const { context } = shared;
-
+    const { config, fileService } = this.services;
     return {
-      files: context?.filesForRound ?? [],
+      files: getFilesForRound(shared.currentRound, shared.roundOutputs, config, fileService),
       attachTeXCount: config.toolConfig.attachTeXCount,
-      context,
+      context: shared.context,
     };
   }
 

--- a/src/agent/implementations/flows/reflection/nodes/TeXCountNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/TeXCountNode.ts
@@ -11,8 +11,6 @@ import {
 import type { FileLocation } from '@utils/files';
 import { getTeXCountStats } from '@latex';
 
-import { getFilesForRound } from '../helpers';
-
 import type {
   ReflectionFlowShared,
   RoundContext,
@@ -38,11 +36,11 @@ export class TeXCountNode<C = unknown> extends Node<
   }
 
   async prep(shared: ReflectionFlowShared): Promise<TeXCountPrepInput> {
-    const { config, fileService } = this.services;
-    const { currentRound, roundOutputs, context } = shared;
+    const { config } = this.services;
+    const { context } = shared;
 
     return {
-      files: getFilesForRound(currentRound, roundOutputs, config, fileService),
+      files: context?.filesForRound ?? [],
       attachTeXCount: config.toolConfig.attachTeXCount,
       context,
     };

--- a/src/agent/implementations/flows/reflection/runReflectionFlow.ts
+++ b/src/agent/implementations/flows/reflection/runReflectionFlow.ts
@@ -302,6 +302,7 @@ export async function runReflectionFlow<C = unknown>(
       getOutputFileLocation,
       shouldEnsureXmlStructure,
       runStage,
+      baseFiles,
     };
     pf.setServices(services);
 

--- a/src/agent/implementations/flows/reflection/runReflectionFlow.ts
+++ b/src/agent/implementations/flows/reflection/runReflectionFlow.ts
@@ -34,7 +34,6 @@ import {
 } from '@agent/toolUse/ToolUseAgentRegistry';
 import type { BaseFlowContextInit } from '@agent/implementations/flows/common';
 import { retryCoordinator } from '@agent/runtime/RetryRequestCoordinator';
-import { getOutputFileName } from '@agent/utils/outputFileUtils';
 
 import { AgentRunState } from '@agent/core/AgentState';
 import { AgentWorkspaceState } from '@agent/core/AgentWorkspaceState';
@@ -58,7 +57,12 @@ import {
   type ReflectionFlowShared,
 } from './ReflectionFlow';
 import { ReflectionFlowStateSchema } from './ReflectionFlowState';
-import { createBaseFileLocations } from './helpers';
+import {
+  createBaseFileLocations,
+  computeShouldEnsureXmlStructure,
+  computeTotalRounds,
+  createOutputFileLocationGetter,
+} from './helpers';
 import type { ReflectionServices } from './ReflectionServices';
 
 // ============================================================================
@@ -159,52 +163,23 @@ export async function runReflectionFlow<C = unknown>(
 
   const latexMediaManager = new LatexMediaManager(logger, fileService);
 
-  // Compute shouldEnsureXmlStructure from configuration
+  // Compute configuration values using helpers
   const useScratchpad = setting.prefills?.includes('<scratchpad>') ?? false;
-  let shouldEnsureXmlStructure = false;
-  if (setting.xmlStructureMode !== undefined) {
-    shouldEnsureXmlStructure =
-      setting.xmlStructureMode === 'always' ||
-      (setting.xmlStructureMode === 'scratchpadOnly' && useScratchpad);
-  } else if (setting.agentType === 'CoT') {
-    shouldEnsureXmlStructure = true;
-  } else if (setting.agentType === 'direct') {
-    shouldEnsureXmlStructure = useScratchpad;
-  }
-
-  // Compute totalRounds from configuration
-  let totalRounds: number;
-  if (setting.maxRounds !== undefined) {
-    totalRounds = setting.maxRounds;
-  } else if (setting.agentType === 'direct') {
-    totalRounds = 1;
-  } else {
-    const requestArray = Array.isArray(prompt.userRequest)
-      ? prompt.userRequest
-      : prompt.userRequest
-        ? [prompt.userRequest]
-        : [];
-    totalRounds = Math.max(setting.rounds ?? 2, requestArray.length);
-  }
+  const shouldEnsureXmlStructure = computeShouldEnsureXmlStructure(
+    setting,
+    useScratchpad,
+  );
+  const totalRounds = computeTotalRounds(setting, prompt);
 
   // Use custom getter if provided, otherwise create default
   const getOutputFileLocation =
     input.getOutputFileLocation ??
-    ((currRound: number): AgentFileLocation => {
-      const fileExtension = useScratchpad ? 'xml' : setting.outputExt;
-      const fileName = getOutputFileName(
-        config.inputFile,
-        config.agent,
-        modelHandler.config.name,
-        fileExtension,
-        currRound,
-        config.editedFile || undefined,
-      );
-      return (
-        useScratchpad
-          ? fileService.createRawOutputLocation(fileName)
-          : fileService.createLocation(fileName)
-      ) as AgentFileLocation;
+    createOutputFileLocationGetter({
+      fileService,
+      config,
+      modelName: modelHandler.config.name,
+      setting,
+      useScratchpad,
     });
 
   // Create interruptible object for registration


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Refactors reflection flow to reduce duplication and centralize configuration/output logic.
> 
> - Adds helpers: `computeShouldEnsureXmlStructure`, `computeTotalRounds`, `createOutputFileLocationGetter`, and `createBaseFileLocations`; runner now uses these to derive config and file locations
> - Extends `ReflectionServices` with `baseFiles` and uses `shouldEnsureXmlStructure` directly in `OutputNode`
> - Simplifies nodes (`PrepareContextNode`, `MediaExtractionNode`, `TeXCountNode`, `OutputNode`) to use shared helpers and cleaner control flow
> - Minor comment/import cleanups in `ReflectionFlowState.ts` and related files
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c5e1957a6e712129e131b461e2bf004f724d68cf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->