### PR TITLE
refactor: simplify ToolUseRunFlow prep and wait logic

### DIFF
--- a/src/agent/implementations/flows/ToolUseRunFlow.ts
+++ b/src/agent/implementations/flows/ToolUseRunFlow.ts
@@ -271,13 +271,14 @@ class ToolUsePrepareNode<C> extends Node<
         },
       );
 
+    const systemMessage = systemPrompt
+      ? `${systemPrompt}\n${instructionSuffix}`
+      : instructionSuffix;
     const messages = await modelHandler.initializeMessages(
       userPrefix,
       userRequest,
       undefined,
-      systemPrompt
-        ? `${systemPrompt}\n${instructionSuffix}`
-        : instructionSuffix,
+      systemMessage,
     );
 
     return {
@@ -446,11 +447,6 @@ class ToolUseCycleNode<C> extends Node<
       // Return messages explicitly to ensure they're synced in post()
       // cycleShared.messages was mutated during the cycle flow
       return { kind: 'success', messages: cycleShared.messages };
-    } catch (error) {
-      return {
-        kind: 'failed',
-        message: error instanceof Error ? error.message : String(error),
-      };
     } finally {
       // Clear the todo update callback to prevent memory leaks
       prepRes.workspaceState.todos.clearOnUpdate();
@@ -531,14 +527,8 @@ class ToolUseWaitNode<C> extends Node<
    * PocketFlow compliance: Extract data, no blocking I/O here.
    */
   async prep(_shared: ToolUseRunShared): Promise<WaitNodePrepResult> {
-    const checkInterruption = this.services.checkInterruption;
-
-    // Check interruption first - if interrupted, skip exec entirely
-    if (checkInterruption()) {
-      return { interrupted: true };
-    }
-
-    return { interrupted: false };
+    const interrupted = this.services.checkInterruption();
+    return { interrupted };
   }
 
   /**
@@ -564,7 +554,6 @@ class ToolUseWaitNode<C> extends Node<
     // Wait for follow-up (blocking I/O - errors caught by execFallback)
     const followUp = await session.waitForFollowUp(checkInterruption);
 
-    // Check interruption after wait
     if (!followUp || checkInterruption()) {
       return { kind: 'stop', reason: 'interrupted' };
     }


### PR DESCRIPTION
### Motivation

- Make the tool-use flow preparation logic more explicit and readable by avoiding inline expressions and nested control flow. 
- Reduce unnecessary error-handling indirection so thrown errors propagate naturally while preserving cleanup. 
- Simplify the interruption check path for the wait node to be clearer and more concise. 
- Keep behavior identical while improving clarity and maintainability of the PocketFlow nodes.

### Description

- Extracted the composed system message into a `systemMessage` variable and pass it to `modelHandler.initializeMessages` instead of using an inline ternary. 
- Removed the broad `try/catch` inside `ToolUseCycleNode.exec` that mapped thrown exceptions to a `failed` result and kept a `finally` block to always clear the todo update callback to avoid leaks. 
- Simplified `ToolUseWaitNode.prep` to return the interruption state directly (`return { interrupted }`) instead of calling and branching on the check. 
- Performed small readability/formatting cleanups in `src/agent/implementations/flows/ToolUseRunFlow.ts` without changing runtime behavior.

### Testing

- Ran `npm run format` which completed successfully. 
- Ran `npm run compile` which failed with a TypeScript error: `TS2322` in `src/agent/implementations/flows/tooluse/runToolUseFlow.ts:113` (type mismatch), preventing a successful build. 
- Ran `npm run lint` which completed but reported warnings for `eqeqeq` in `src/agent/modelHandlers/openAIMessageUtils.ts` and `src/tools/ReadTool.ts`. 
- No unit tests were changed; the observed compile error is a TypeScript type issue outside the modified lines and must be addressed separately.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960e0d75d4c832493492307bff5edb8)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors `ToolUseRunFlow` for clarity without changing intended behavior.
> 
> - Extracts a composed `systemMessage` and passes it to `initializeMessages` instead of inline ternary logic
> - Removes broad try/catch in `ToolUseCycleNode.exec` so errors propagate to `execFallback`, while retaining `finally` cleanup of todo callbacks
> - Simplifies `ToolUseWaitNode.prep` to return the interruption flag directly; minor wait logic/comment cleanups
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2184e34e6aa3406183a26cfae1ed5fea248f4a0d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->