### PR TITLE
Add dropdown menus to homepage

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -16,10 +16,12 @@ hero:
       <span class="chevron">▼</span>
     </button>
     <div class="dropdown-menu">
-      <a href="/guide/">Documentation</a>
-      <a href="vscode:extension/texra-ai.texra">VS Code</a>
-      <a href="/launch">GitHub Codespaces</a>
+      <a href="vscode:extension/texra-ai.texra">VS Code*</a>
+      <a href="cursor://texra-ai.texra">Cursor*</a>
+      <a href="windsurf://texra-ai.texra">Windsurf*</a>
       <a href="https://marketplace.visualstudio.com/items?itemName=texra-ai.texra">VS Code Marketplace</a>
+      <a href="/launch">Web (Codespaces)</a>
+      <span class="dropdown-note">*Requires app install</span>
     </div>
   </div>
   <a href="https://github.com/texra-ai/texra-issues" class="alt-button">View on GitHub</a>
@@ -221,6 +223,13 @@ If you run into a bug, drop us a line at [contact@texra.ai](mailto:contact@texra
 }
 .dropdown-menu a:hover {
   background: var(--vp-c-bg-soft);
+}
+.dropdown-note {
+  display: block;
+  padding: 0.5rem 1rem;
+  font-size: 0.8rem;
+  color: var(--vp-c-text-3);
+  border-top: 1px solid var(--vp-c-divider);
 }
 .alt-button {
   display: inline-flex;

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,20 +7,23 @@ hero:
   image:
     src: /logo-1024x1024.svg
     alt: TeXRA Logo
-  actions:
-    - theme: brand
-      text: Get Started
-      link: /guide/
-    - theme: alt
-      text: Install from Marketplace
-      link: vscode:extension/texra-ai.texra
-    - theme: alt
-      text: Try it on Web
-      link: /launch
-    - theme: alt
-      text: View on GitHub
-      link: https://github.com/texra-ai/texra-issues
 ---
+
+<div class="hero-buttons">
+  <div class="dropdown">
+    <button class="dropdown-button brand">
+      Get started
+      <span class="chevron">▼</span>
+    </button>
+    <div class="dropdown-menu">
+      <a href="/guide/">Documentation</a>
+      <a href="vscode:extension/texra-ai.texra">VS Code</a>
+      <a href="/launch">GitHub Codespaces</a>
+      <a href="https://marketplace.visualstudio.com/items?itemName=texra-ai.texra">VS Code Marketplace</a>
+    </div>
+  </div>
+  <a href="https://github.com/texra-ai/texra-issues" class="alt-button">View on GitHub</a>
+</div>
 
 <div class="workflow-container">
   <div class="workflow-steps">
@@ -144,6 +147,98 @@ Installing TeXRA is simple. Follow our [Installation Guide](/guide/installation)
 If you run into a bug, drop us a line at [contact@texra.ai](mailto:contact@texra.ai).
 
 <style>
+/* Hero buttons with dropdown */
+.hero-buttons {
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+  margin: -1rem 0 2rem;
+  flex-wrap: wrap;
+}
+.dropdown {
+  position: relative;
+  display: inline-block;
+}
+.dropdown-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1.25rem;
+  font-size: 1rem;
+  font-weight: 500;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+.dropdown-button.brand {
+  background: var(--vp-c-brand);
+  color: white;
+}
+.dropdown-button.brand:hover {
+  background: var(--vp-c-brand-dark);
+}
+.dropdown-button .chevron {
+  font-size: 0.7rem;
+  transition: transform 0.2s;
+}
+.dropdown:hover .chevron {
+  transform: rotate(180deg);
+}
+.dropdown-menu {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  min-width: 200px;
+  background: var(--vp-c-bg-elv);
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(-4px);
+  transition: all 0.2s;
+  z-index: 100;
+}
+.dropdown:hover .dropdown-menu {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0);
+}
+.dropdown-menu a {
+  display: block;
+  padding: 0.75rem 1rem;
+  color: var(--vp-c-text-1);
+  text-decoration: none;
+  font-size: 0.95rem;
+  transition: background 0.15s;
+}
+.dropdown-menu a:first-child {
+  border-radius: 8px 8px 0 0;
+}
+.dropdown-menu a:last-child {
+  border-radius: 0 0 8px 8px;
+}
+.dropdown-menu a:hover {
+  background: var(--vp-c-bg-soft);
+}
+.alt-button {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.75rem 1.25rem;
+  font-size: 1rem;
+  font-weight: 500;
+  color: var(--vp-c-brand);
+  background: transparent;
+  border: 1px solid var(--vp-c-brand);
+  border-radius: 8px;
+  text-decoration: none;
+  transition: all 0.2s;
+}
+.alt-button:hover {
+  background: var(--vp-c-brand-soft);
+}
+
 .features-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));

--- a/src/webview/index.html
+++ b/src/webview/index.html
@@ -640,6 +640,41 @@
           style="display: none"
         >
           <span class="getting-started-text"></span>
+          <div class="getting-started-actions">
+            <div class="dropdown-container dropdown-left">
+              <vscode-button
+                id="getStartedDropdownButton"
+                appearance="primary"
+                aria-haspopup="true"
+                aria-expanded="false"
+              >
+                Get started
+                <span slot="end" class="codicon codicon-chevron-down"></span>
+              </vscode-button>
+              <vscode-context-menu
+                id="getStartedDropdownMenu"
+                class="dropdown-menu"
+              >
+                <div class="dropdown-menu-content">
+                  <a
+                    href="command:texra.openGettingStarted"
+                    class="dropdown-link"
+                    >Walkthrough</a
+                  >
+                  <a
+                    href="https://github.com/codespaces/new?repo=LionSR/TeXRA"
+                    class="dropdown-link"
+                    >GitHub Codespaces</a
+                  >
+                  <a
+                    href="https://marketplace.visualstudio.com/items?itemName=LionSR.texra"
+                    class="dropdown-link"
+                    >VS Code Marketplace</a
+                  >
+                </div>
+              </vscode-context-menu>
+            </div>
+          </div>
         </div>
 
         <!-- Login Banner -->

--- a/src/webview/modules/constants.js
+++ b/src/webview/modules/constants.js
@@ -108,6 +108,8 @@ export const ELEMENT_IDS = {
   DEPENDENCY_RECHECK_BUTTON: 'dependencyRecheckButton',
   DEPENDENCY_DISMISS_BUTTON: 'dependencyDismissButton',
   GETTING_STARTED_BANNER: 'gettingStartedBanner',
+  GET_STARTED_DROPDOWN_BUTTON: 'getStartedDropdownButton',
+  GET_STARTED_DROPDOWN_MENU: 'getStartedDropdownMenu',
   LOGIN_BANNER: 'loginBanner',
   LOGIN_BANNER_BUTTON: 'loginBannerButton',
   LOGIN_BANNER_DISMISS_BUTTON: 'loginBannerDismissButton',

--- a/src/webview/modules/uiManagers/SettingsButtonManager.js
+++ b/src/webview/modules/uiManagers/SettingsButtonManager.js
@@ -56,6 +56,11 @@ export class SettingsButtonManager extends BaseDomHandler {
       checkboxIds: CHECK_BOXES_TOOL_USE,
     });
 
+    this._initializeSimpleMenuToggle({
+      buttonId: ELEMENT_IDS.GET_STARTED_DROPDOWN_BUTTON,
+      menuId: ELEMENT_IDS.GET_STARTED_DROPDOWN_MENU,
+    });
+
     this.addListener(ELEMENT_IDS.TOGGLE_LATEXDIFFS, 'click', () => {
       this.latexdiffManager.toggleLatexdiffs();
     });
@@ -73,6 +78,10 @@ export class SettingsButtonManager extends BaseDomHandler {
       {
         menu: safeGetElementById(ELEMENT_IDS.TOOL_CONFIG_OPTIONS),
         button: safeGetElementById(ELEMENT_IDS.TOGGLE_TOOL_CONFIG),
+      },
+      {
+        menu: safeGetElementById(ELEMENT_IDS.GET_STARTED_DROPDOWN_MENU),
+        button: safeGetElementById(ELEMENT_IDS.GET_STARTED_DROPDOWN_BUTTON),
       },
     ];
 
@@ -162,6 +171,45 @@ export class SettingsButtonManager extends BaseDomHandler {
         menu.requestUpdate?.();
       }
     }
+  }
+
+  /**
+   * Initialize a simple menu toggle without checkbox state tracking.
+   * Used for dropdown menus that contain links rather than checkboxes.
+   * @param {object} config - Configuration object
+   * @param {string} config.buttonId - ID of the toggle button
+   * @param {string} config.menuId - ID of the context menu
+   */
+  _initializeSimpleMenuToggle({ buttonId, menuId }) {
+    const button = safeGetElementById(buttonId);
+    const menu = safeGetElementById(menuId);
+
+    if (!button || !menu) {
+      return;
+    }
+
+    this._ensureMenuUsesSlotContent(menu);
+
+    button.setAttribute('aria-haspopup', 'true');
+
+    const updateAriaExpanded = () => {
+      const expanded = Boolean(menu.show);
+      button.setAttribute('aria-expanded', expanded ? 'true' : 'false');
+    };
+
+    const handleButtonClick = (event) => {
+      event.stopPropagation();
+      menu.show = !menu.show;
+    };
+
+    this.addListener(button, 'click', handleButtonClick);
+
+    // Observe the "show" attribute so we react when the menu closes itself
+    const observer = new MutationObserver(updateAriaExpanded);
+    observer.observe(menu, { attributes: true, attributeFilter: ['show'] });
+    this._menuObservers.push(observer);
+
+    updateAriaExpanded();
   }
 
   _setupSettingsButtons() {

--- a/src/webview/styles/containers.css
+++ b/src/webview/styles/containers.css
@@ -139,6 +139,32 @@
   text-decoration: underline;
 }
 
+.getting-started-actions {
+  margin-top: var(--spacing-small);
+}
+
+.getting-started-actions .dropdown-container {
+  display: inline-block;
+}
+
+.getting-started-actions .dropdown-menu {
+  min-width: 180px;
+}
+
+.dropdown-link {
+  display: block;
+  padding: var(--spacing-tiny) var(--spacing-small);
+  color: var(--vscode-foreground);
+  text-decoration: none;
+  font-size: var(--font-size-sm);
+  border-radius: var(--border-radius-sm);
+}
+
+.dropdown-link:hover {
+  background: var(--vscode-list-hoverBackground);
+  text-decoration: none;
+}
+
 /* Login banner - promotional style */
 .login-banner {
   background: linear-gradient(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces dropdown-based entry points and supporting UI plumbing.
> 
> - **Docs homepage**: Replaces hero actions with a `Get started` dropdown (VS Code, Cursor, Windsurf, Marketplace, Web/Codespaces) and a GitHub button; adds inline CSS for dropdown styling
> - **Webview UI**: Adds a `Get started` dropdown in the getting-started banner with links (Walkthrough command, GitHub Codespaces, VS Code Marketplace)
> - **UI logic**: Extends `SettingsButtonManager` with `_initializeSimpleMenuToggle` and click-outside handling; wires new IDs from `constants.js` for button/menu
> - **Styles**: Updates `containers.css` with dropdown/menu and link styles for the getting-started banner
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0afb49ea1aded88ab473d0879a9e4d0becaf1781. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->