### PR TITLE
fix: sync agent dropdown with session toggle

### DIFF
--- a/src/webview/modules/uiManagers/SettingsButtonManager.js
+++ b/src/webview/modules/uiManagers/SettingsButtonManager.js
@@ -251,6 +251,25 @@ export class SettingsButtonManager extends BaseDomHandler {
   _setupDropdowns() {
     const toggleContainer = safeGetElementById(ELEMENT_IDS.SESSION_TYPE_TOGGLE);
     if (toggleContainer) {
+      const resolveSessionTypeFromEvent = (event, radioGroup) => {
+        const target = event?.target;
+        if (target instanceof HTMLElement) {
+          const radio = isTagName(target, 'vscode-radio')
+            ? target
+            : target.closest?.('vscode-radio');
+          if (radio instanceof HTMLElement) {
+            const radioValue =
+              radio.dataset.sessionType || radio.getAttribute('value');
+            const parsed = parseSessionType(radioValue);
+            if (parsed) {
+              return parsed;
+            }
+          }
+        }
+
+        return parseSessionType(radioGroup?.value);
+      };
+
       const handleSessionTypeSelection = (sessionType) => {
         const normalized =
           parseSessionType(sessionType) ?? SESSION_TYPES.WORKFLOW;
@@ -279,8 +298,8 @@ export class SettingsButtonManager extends BaseDomHandler {
           this._setLastRadioSessionType(initialSessionType);
         }
 
-        this.addListener(radioGroup, 'change', () => {
-          const sessionType = parseSessionType(radioGroup.value);
+        this.addListener(radioGroup, 'change', (event) => {
+          const sessionType = resolveSessionTypeFromEvent(event, radioGroup);
           if (!sessionType) {
             return;
           }


### PR DESCRIPTION
### Motivation
- The simplified radio-group logic stopped synchronizing the agent dropdown when switching between workflow/chat because `radioGroup.value` can lag behind the active radio element in `@vscode-elements/elements`.
- The UI should derive the session type from the actual change event so the dropdown and hidden input remain in sync with the selected radio.

### Description
- Add `resolveSessionTypeFromEvent(event, radioGroup)` to extract session type from the `change` event target (reads `data-session-type` or `value` on the active `vscode-radio`) and fall back to `radioGroup.value` when necessary.
- Wire the radio group's `change` listener to use the new resolver and only call the session handler when the resolved type differs from the cached `_lastRadioSessionType`.
- Preserve existing behavior of applying session type, updating the active agent select, focusing it, and saving state when appropriate by calling `handleSessionTypeSelection`.
- Change is confined to `src/webview/modules/uiManagers/SettingsButtonManager.js` and keeps the external API unchanged.

### Testing
- Ran `npm run format` and code was formatted successfully.
- Ran `npm run compile` and the webpack build completed (one existing nunjucks warning reported). 
- Ran `npm run lint` and ESLint completed with pre-existing warnings (no new errors introduced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960f7000bf88324998f35a50908cb17)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures session type changes propagate correctly to the agent selector and hidden input.
> 
> - Adds `resolveSessionTypeFromEvent(event, radioGroup)` to derive session type from the active `vscode-radio` (`data-session-type`/`value`) with fallback to `radioGroup.value` in `SettingsButtonManager.js`
> - Updates radio group `change` listener to use the resolver and skip redundant updates when equal to `_lastRadioSessionType`
> - Preserves existing `handleSessionTypeSelection` flow (apply session type, update/focus agent select, or save state)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0e2c0b5b1be8902ec89235c51a666c925c8bf886. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->