### PR TITLE
Align queued message box with input

### DIFF
--- a/src/progressView/styles/follow-up-input.css
+++ b/src/progressView/styles/follow-up-input.css
@@ -3,30 +3,34 @@
  * Minimal styling for the user input area
  */
 
-/* Follow-up input container */
+/* Follow-up input container - uses CSS Grid for consistent column alignment */
 .follow-up-container {
   display: none;
-  flex-direction: column;
+  grid-template-columns: 1fr auto;
   padding: var(--spacing-medium);
   border-top: 1px solid var(--color-border);
   gap: var(--spacing-small);
 }
 
 .follow-up-container.is-visible {
-  display: flex;
+  display: grid;
 }
 
-/* Row container for textarea and action buttons */
+/* Queued messages span only the main content column */
+.follow-up-container > .queued-follow-ups-collapsible {
+  grid-column: 1;
+}
+
+/* Input row children participate directly in grid */
 .follow-up-input-row {
-  display: flex;
-  align-items: flex-end;
-  gap: var(--spacing-small);
+  display: contents;
 }
 
 /* Style the textarea for multi-line input */
 #followUpInput {
   display: block;
-  flex: 1;
+  grid-column: 1;
+  align-self: end;
   line-height: 1.4;
   min-height: 106px;
   max-height: var(--height-xlarge);
@@ -45,6 +49,7 @@ vscode-toolbar-container.follow-up-actions {
   display: flex;
   flex-direction: column !important;
   align-items: center;
+  align-self: end;
   gap: var(--spacing-small);
 }
 

--- a/src/progressView/styles/logs.css
+++ b/src/progressView/styles/logs.css
@@ -432,13 +432,6 @@
   }
 
   .follow-up-container {
-    display: none;
     padding: var(--spacing-small);
-    border-top: 1px solid var(--color-border);
-    gap: var(--spacing-small);
-  }
-
-  .follow-up-container textarea {
-    flex: 1;
   }
 }

--- a/src/progressView/styles/queued-follow-ups.css
+++ b/src/progressView/styles/queued-follow-ups.css
@@ -8,6 +8,8 @@
   border-radius: var(--radius);
   background-color: var(--vscode-inputValidation-infoBackground);
   border: 1px solid var(--vscode-inputValidation-infoBorder);
+  /* Align with textarea by accounting for action buttons width + gap */
+  margin-right: calc(28px + var(--spacing-small));
 }
 
 /* Override vscode-collapsible header padding */

--- a/src/progressView/styles/queued-follow-ups.css
+++ b/src/progressView/styles/queued-follow-ups.css
@@ -8,8 +8,6 @@
   border-radius: var(--radius);
   background-color: var(--vscode-inputValidation-infoBackground);
   border: 1px solid var(--vscode-inputValidation-infoBorder);
-  /* Align with textarea by accounting for action buttons width + gap */
-  margin-right: calc(28px + var(--spacing-small));
 }
 
 /* Override vscode-collapsible header padding */


### PR DESCRIPTION
Add margin-right to the queued messages collapsible to account for the action buttons column width, creating symmetric alignment with the textarea below.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors the follow-up input layout for consistent column alignment and simplifies related responsive styles.
> 
> - Convert `follow-up-container` to CSS Grid (`grid-template-columns: 1fr auto`) and use `display: grid` when `.is-visible`
> - Align queued messages (`.queued-follow-ups-collapsible`) and `#followUpInput` to the main column; stack `.follow-up-actions` in the actions column with vertical layout and end alignment
> - Make `.follow-up-input-row` `display: contents` so children participate directly in the grid
> - Clean up `logs.css` mobile rules by removing redundant `follow-up-container` properties, leaving only padding
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 465bb6845a7e2c37d5452765ba52e2fea1a7fe2f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->