### PR TITLE
Configure OpenAI API key and background mode

### DIFF
--- a/src/tools/memory/MemoryTool.ts
+++ b/src/tools/memory/MemoryTool.ts
@@ -143,7 +143,15 @@ export class MemoryTool extends defineTool({
   ): Promise<ToolResult> {
     const resolvedPath = this.resolveMemoryPath(inputPath);
     const exists = await StorageFS.exists(resolvedPath);
+
+    // Handle non-existent root directory gracefully - return empty listing
+    // instead of error (consistent with MemoryViewMessageHandler behavior)
     if (!exists) {
+      if (resolvedPath === MEMORY_STORAGE_ROOT) {
+        return {
+          output: `The memory directory is empty. This is a fresh start - use the create command to add memory files.`,
+        };
+      }
       throw new ToolError(
         `The path ${inputPath} does not exist. Please provide a valid path.`,
       );


### PR DESCRIPTION
When the /memories directory doesn't exist (before any memory files are created), the memory tool now returns an empty listing instead of throwing an error. This prevents GPT-5 models from entering error loops when trying to inspect the memory system at the start of a conversation.

This makes the memory tool behavior consistent with MemoryViewMessageHandler which already handles missing directories by returning an empty array.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures the memory tool doesn’t error on a fresh start when the `/memories` directory is absent.
> 
> - Updates `MemoryTool.view` to return an empty-root message when `MEMORY_STORAGE_ROOT` doesn’t exist, instead of throwing a `ToolError`
> - Keeps existing error behavior for other non-existent paths; no other logic changed
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8f09aec59230472a554acdb2fcd225486a2a0d54. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->