### PR TITLE
Configure OpenAI API key and background mode

### DIFF
--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -1642,29 +1642,43 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     text?: string,
   ): Promise<ResponseInputItem[]> {
     const messages: ResponseInputItem[] = [];
-    if (text) {
+
+    // When using previous_response_id (response chaining), the previous response's
+    // output items (reasoning, web_search_call, function_call) are already in
+    // OpenAI's server-side history. We should only send NEW items (function_call_output).
+    // Including them again causes "Duplicate item found" errors.
+    const isResponseChaining = Boolean(this.previousResponseId);
+
+    if (text && !isResponseChaining) {
+      // Only include assistant text when not chaining (it's in previous response)
       messages.push(this.createAssistantMessage(text));
     }
 
-    // Include server tool content blocks (reasoning, web_search_call) from workspace state
+    // Include server tool content blocks (reasoning, web_search_call) from workspace state.
     // These need to be preserved when both server and local tools are in the same response.
     // Reasoning items must be included when web_search_call references them.
+    // SKIP when response chaining - these items are already in previous_response_id context.
+    // Always clear after processing to prevent accumulation across cycles.
     if (workspaceState?.serverToolContent.contentBlocks.length) {
-      // Filter to only OpenAI server tool content (reasoning + web_search_call)
-      const openaiBlocks = workspaceState.serverToolContent.contentBlocks
-        .filter(isOpenAIServerToolContent)
-        .map((block) => block as ResponseInputItem);
-      messages.push(...openaiBlocks);
-      // Clear after consuming to prevent duplicates - use reset method for consistency
+      if (!isResponseChaining) {
+        const openaiBlocks = workspaceState.serverToolContent.contentBlocks
+          .filter(isOpenAIServerToolContent)
+          .map((block) => block as ResponseInputItem);
+        messages.push(...openaiBlocks);
+      }
       workspaceState.resetServerToolContent();
     }
 
-    const callMsg: ResponseFunctionToolCall = {
-      type: 'function_call',
-      call_id: call.callId,
-      name: call.name,
-      arguments: call.raw.arguments,
-    };
+    // function_call is part of the previous response output when chaining,
+    // so only include it when NOT using previous_response_id
+    const callMsg: ResponseFunctionToolCall | undefined = isResponseChaining
+      ? undefined
+      : {
+          type: 'function_call',
+          call_id: call.callId,
+          name: call.name,
+          arguments: call.raw.arguments,
+        };
 
     // Create mutable copy for adding attachmentSummary/files
     const finalResult: ToolResultPayload = { ...result };
@@ -1732,7 +1746,13 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       output: outputPayload,
     };
 
-    messages.push(callMsg, resultMsg);
+    // When response chaining, only push function_call_output (callMsg is undefined)
+    // When not chaining, push both function_call and function_call_output
+    if (callMsg) {
+      messages.push(callMsg, resultMsg);
+    } else {
+      messages.push(resultMsg);
+    }
     return messages;
   }
 


### PR DESCRIPTION
When using previous_response_id for response chaining, items from the previous response's output (reasoning, web_search_call, function_call) are already in OpenAI's server-side history. Re-sending them in follow-up messages causes "Duplicate item found" HTTP 400 errors.

This fix conditionally skips adding these items when response chaining is active, only sending the new function_call_output items.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents "Duplicate item found" errors when using `previous_response_id` by only sending new data in follow-ups.
> 
> - Detects response chaining via `previous_response_id` and omits assistant text and prior output items
> - Skips sending `reasoning`/`web_search_call` content blocks and `function_call` when chaining; always clears stored blocks
> - Sends only `function_call_output` during chaining; otherwise sends both `function_call` and `function_call_output`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7a8cdd04a94c30acc5a06b6de80fc53c2dccaa01. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->