### PR TITLE
Show context length usage indicator

### DIFF
--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -469,6 +469,7 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     this._refreshInstructionForActiveRun(activeRunId);
     this._refreshOutputsForActiveRun(activeRunId);
     this._refreshUsageForActiveRun();
+    this._refreshContextStateForActiveStream();
 
     this._updatePlaceholderVisibility();
   }
@@ -525,6 +526,7 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     this._refreshInstructionForActiveRun(activeRunId);
     this._refreshOutputsForActiveRun(activeRunId);
     this._refreshUsageForActiveRun();
+    this._refreshContextStateForActiveStream();
   }
 
   handleAppendLog(message) {


### PR DESCRIPTION
Add _refreshContextStateForActiveStream() calls to handleUpdateLogs and _handleIncrementalUpdate to ensure the context utilization display ("X% context left") on the left side of the footer is properly refreshed when switching streams or updating log content.

Previously, the context state was only refreshed in handleUpdateStreams, which meant the display would not show after log updates.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures the footer context utilization ("X% context left") stays in sync during log updates and stream switches.
> 
> - Calls `_refreshContextStateForActiveStream()` after usage updates in `handleUpdateLogs` (full rebuild) and `_handleIncrementalUpdate` (incremental update)
> - No other behavior changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f9746f473faec2f8e51cc891fcc427ba1efd3c24. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->