### PR TITLE
Fix snapshot invalidation on manual retry timeout

### DIFF
--- a/src/agent/core/flows/RetryState.ts
+++ b/src/agent/core/flows/RetryState.ts
@@ -417,11 +417,13 @@ export abstract class RetryableInvocationNode<
       return { shouldRetry: true, userCancelled: false };
     }
 
-    // User cancelled or timeout
+    // User cancelled or timeout - preserve WAITING status so user can resume
+    // from last successful breakpoint. The flow record is NOT deleted when
+    // userCancelled is true, enabling resume capability.
     logger.info('Retry cancelled by user', {
       messageType: MESSAGE_TYPES.PROGRESS_STATUS,
     });
-    StreamStatusService.set(streamId, STREAM_STATUS.STOPPED);
+    StreamStatusService.set(streamId, STREAM_STATUS.WAITING);
     return { shouldRetry: false, userCancelled: true };
   }
 

--- a/src/agent/implementations/flows/ToolUseRunFlow.ts
+++ b/src/agent/implementations/flows/ToolUseRunFlow.ts
@@ -89,6 +89,11 @@ export interface ToolUseRunState {
   shouldSkipCycle: boolean;
   /** State slices (natively serializable) - reconstruct via fromSnapshot() */
   stateSlices: StateSlicesSnapshot | null;
+  /**
+   * Tracks if user cancelled manual retry (timeout or explicit cancel).
+   * When true, flow record should be preserved so user can resume from last successful breakpoint.
+   */
+  userCancelledRetry?: boolean;
 }
 
 /**
@@ -497,6 +502,8 @@ class ToolUseCycleNode<C> extends Node<
 
       case 'cancelled':
         // User cancelled - not an error, flow ends gracefully
+        // Mark state so flow record is preserved for resume from last successful breakpoint
+        shared.state.userCancelledRetry = true;
         // Return FINALIZE to exit flow (no finalize successor = flow ends)
         return FlowTransition.FINALIZE;
     }

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -154,12 +154,22 @@ export async function runToolUseFlow<C = unknown>(
     status = END_GROUP_STATUS.ERROR;
     throw error;
   } finally {
-    // Clean up flow record on completion.
+    // Clean up flow record on completion - but preserve if user cancelled retry
+    // so they can resume from the last successful breakpoint.
     // When VS Code reloads mid-execution, this block never runs, preserving
     // the record for sessions that were genuinely interrupted mid-wait.
     try {
       const kv = getExecutionStore(executionId);
-      await kv.delete(`flow:${executionId}`);
+      const flowRecord = await kv.read<FlowRecord>(`flow:${executionId}`);
+      const sharedState = flowRecord?.shared as { state?: { userCancelledRetry?: boolean } } | undefined;
+      const userCancelledRetry = sharedState?.state?.userCancelledRetry === true;
+
+      if (userCancelledRetry) {
+        // Preserve flow record for resume - user can continue from last successful breakpoint
+        logger.debug('Flow record preserved after retry cancellation for resume capability');
+      } else {
+        await kv.delete(`flow:${executionId}`);
+      }
     } catch {
       // Ignore cleanup errors - non-critical
     }


### PR DESCRIPTION
When a user cancels the manual retry prompt (or it times out after 5 minutes), the snapshot from the last successful breakpoint should be preserved so the user can resume from that point.

Previously, the flow record was always deleted in the finally block, losing the ability to resume after retry cancellation. Now:

- Track userCancelledRetry flag in ToolUseRunState
- Set flag when cycle returns 'cancelled' result
- Set WAITING status instead of STOPPED on retry cancellation
- Preserve flow record when userCancelledRetry is true

This allows users to continue from the last successful checkpoint after cancelling a retry, rather than losing their progress.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Preserves last successful checkpoint when a manual retry is cancelled or times out, enabling resume instead of losing progress.
> 
> - Add `userCancelledRetry` to `ToolUseRunState`; set it when cycle returns `cancelled`
> - Keep stream status `WAITING` (not `STOPPED`) on retry cancellation in `RetryState`
> - In `runToolUseFlow`, conditionally delete `flow:${executionId}` only if `userCancelledRetry` is not set; otherwise preserve record
> - Update post-flow handling in `ToolUseRunFlow` to mark cancellation and finalize without error
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 96a76d497e55cb5fd7ddff4fad0f0889c36889d9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->