### PR TITLE
Claude/show context usage dl kcj

### DIFF
--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -537,6 +537,13 @@ class ResponseProcessNode<C> extends BaseNode<
         prepRes.responseTimeMs ?? 0,
       );
 
+      // Emit context state for UI display (centralized for all model handlers)
+      const { inputTokens } = normalizedUsage;
+      const { contextWindow } = modelHandler.config;
+      if (inputTokens > 0 && contextWindow > 0) {
+        logger.logContextState(inputTokens, contextWindow);
+      }
+
       const repetitionResult = checkForMassiveRepetition(
         prepRes.lastResponse,
         newResponse,

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -522,6 +522,12 @@ class ToolUseProcessNode<C> extends BaseNode<
         usage,
         prepRes.responseTimeMs ?? 0,
       );
+      // Emit context state for UI display (centralized for all model handlers)
+      const { inputTokens } = normalizedUsage;
+      const { contextWindow } = services.modelHandler.config;
+      if (inputTokens > 0 && contextWindow > 0) {
+        services.logger.logContextState(inputTokens, contextWindow);
+      }
     }
 
     const endTurn = services.modelHandler.isEndTurnStop(stopReason);

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -482,8 +482,6 @@ export class ModelHandlerAnthropic extends ModelHandler<
           const { input_tokens: inputTokens } = responseTokenCount;
           measuredInputTokens = inputTokens;
           this.logger.debug(`Token count of message: ${inputTokens}`);
-          // Emit context state for UI display
-          this.logger.logContextState(inputTokens, effectiveContextWindow);
           if (inputTokens > effectiveContextWindow) {
             const errMsg = `Token count of message exceeds context window: ${inputTokens} > ${effectiveContextWindow}`;
             this.logger.error(errMsg);

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -1513,6 +1513,12 @@ export class ModelHandlerAnthropic extends ModelHandler<
     const cacheReadTokens = rawUsage.cache_read_input_tokens ?? 0;
     const cacheCreationTokens = rawUsage.cache_creation_input_tokens ?? 0;
 
+    // Emit context state as fallback for when token counting is skipped
+    // (e.g., when file sources are present or countTokens fails)
+    if (inputTokens > 0 && this.config.contextWindow > 0) {
+      this.logger.logContextState(inputTokens, this.config.contextWindow);
+    }
+
     // Calculate percentage cached
     const totalCacheTokens = cacheReadTokens + cacheCreationTokens;
     const percentageCached =

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -1513,12 +1513,6 @@ export class ModelHandlerAnthropic extends ModelHandler<
     const cacheReadTokens = rawUsage.cache_read_input_tokens ?? 0;
     const cacheCreationTokens = rawUsage.cache_creation_input_tokens ?? 0;
 
-    // Emit context state as fallback for when token counting is skipped
-    // (e.g., when file sources are present or countTokens fails)
-    if (inputTokens > 0 && this.config.contextWindow > 0) {
-      this.logger.logContextState(inputTokens, this.config.contextWindow);
-    }
-
     // Calculate percentage cached
     const totalCacheTokens = cacheReadTokens + cacheCreationTokens;
     const percentageCached =

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -470,8 +470,6 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
         );
         const totalTokens = responseTokenCount.totalTokens ?? 0;
         this.logger.debug(`Token count of message: ${totalTokens}`);
-        // Emit context state for UI display
-        this.logger.logContextState(totalTokens, this.config.contextWindow);
         if (totalTokens > this.config.contextWindow) {
           this.logger.error(
             `Token count of message exceeds context window: ${totalTokens} > ${this.config.contextWindow}`,

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -940,6 +940,11 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
     const { inputTokens, outputTokens, reasoningTokens } =
       this.computeTokenCounts(rawUsage);
 
+    // Emit context state for UI display (fallback for when token counting doesn't emit it)
+    if (inputTokens > 0 && this.config.contextWindow > 0) {
+      this.logger.logContextState(inputTokens, this.config.contextWindow);
+    }
+
     const cachedTokens = rawUsage.cachedContentTokenCount ?? 0;
     const percentageCached =
       inputTokens > 0 ? (cachedTokens / inputTokens) * 100 : 0;

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -940,11 +940,6 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
     const { inputTokens, outputTokens, reasoningTokens } =
       this.computeTokenCounts(rawUsage);
 
-    // Emit context state for UI display (fallback for when token counting doesn't emit it)
-    if (inputTokens > 0 && this.config.contextWindow > 0) {
-      this.logger.logContextState(inputTokens, this.config.contextWindow);
-    }
-
     const cachedTokens = rawUsage.cachedContentTokenCount ?? 0;
     const percentageCached =
       inputTokens > 0 ? (cachedTokens / inputTokens) * 100 : 0;

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -1017,6 +1017,11 @@ export class ModelHandlerOpenAI<
     const inputTokens = rawUsage.prompt_tokens ?? 0;
     const outputTokens = rawUsage.completion_tokens ?? 0;
 
+    // Emit context state for UI display (fallback for when token counting doesn't emit it)
+    if (inputTokens > 0 && this.config.contextWindow > 0) {
+      this.logger.logContextState(inputTokens, this.config.contextWindow);
+    }
+
     // Extract cached tokens (OpenAI style or DeepSeek style)
     const cachedTokens =
       rawUsage.prompt_tokens_details?.cached_tokens ??

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -1017,11 +1017,6 @@ export class ModelHandlerOpenAI<
     const inputTokens = rawUsage.prompt_tokens ?? 0;
     const outputTokens = rawUsage.completion_tokens ?? 0;
 
-    // Emit context state for UI display (fallback for when token counting doesn't emit it)
-    if (inputTokens > 0 && this.config.contextWindow > 0) {
-      this.logger.logContextState(inputTokens, this.config.contextWindow);
-    }
-
     // Extract cached tokens (OpenAI style or DeepSeek style)
     const cachedTokens =
       rawUsage.prompt_tokens_details?.cached_tokens ??

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -217,11 +217,6 @@ export class ModelHandlerOpenAI<
       this.logger.debug(
         `Approximate token count of message: ${approximateInputTokens}`,
       );
-      // Emit context state for UI display
-      this.logger.logContextState(
-        approximateInputTokens,
-        this.config.contextWindow,
-      );
 
       if (approximateInputTokens > this.config.contextWindow) {
         const errorMsg = `Approximate token count of message exceeds context window: ${approximateInputTokens} > ${this.config.contextWindow}`;

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -910,11 +910,6 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       if (response.usage?.input_tokens) {
         this.conversationState.cumulativeInputTokens =
           response.usage.input_tokens;
-        // Emit context state for UI display (no native pre-request token counting)
-        this.logger.logContextState(
-          response.usage.input_tokens,
-          this.config.contextWindow,
-        );
       }
       // Reset compacted flag after successful request (ready for next compaction if needed)
       this.conversationState.isCompacted = false;
@@ -973,11 +968,6 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     if (response.usage?.input_tokens) {
       this.conversationState.cumulativeInputTokens =
         response.usage.input_tokens;
-      // Emit context state for UI display (no native pre-request token counting)
-      this.logger.logContextState(
-        response.usage.input_tokens,
-        this.config.contextWindow,
-      );
     }
     // Reset compacted flag after successful request (ready for next compaction if needed)
     this.conversationState.isCompacted = false;

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -1099,6 +1099,11 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     const reasoningTokens =
       rawUsage.output_tokens_details?.reasoning_tokens ?? 0;
 
+    // Emit context state for UI display (fallback for when token counting doesn't emit it)
+    if (inputTokens > 0 && this.config.contextWindow > 0) {
+      this.logger.logContextState(inputTokens, this.config.contextWindow);
+    }
+
     // Calculate percentage cached
     const percentageCached =
       inputTokens > 0 ? (cachedTokens / inputTokens) * 100 : 0;

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -1099,11 +1099,6 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     const reasoningTokens =
       rawUsage.output_tokens_details?.reasoning_tokens ?? 0;
 
-    // Emit context state for UI display (fallback for when token counting doesn't emit it)
-    if (inputTokens > 0 && this.config.contextWindow > 0) {
-      this.logger.logContextState(inputTokens, this.config.contextWindow);
-    }
-
     // Calculate percentage cached
     const percentageCached =
       inputTokens > 0 ? (cachedTokens / inputTokens) * 100 : 0;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Moves context state emission to a single point post-usage normalization for consistency.
> 
> - Add centralized `logger.logContextState(inputTokens, contextWindow)` in `ResponseCycleFlow` and `ToolUseCycleFlow`
> - Remove per-model context logging from `modelHandlerAnthropic`, `modelHandlerGoogleGenAI`, `modelHandlerOpenAI`, and OpenAI Responses handler to prevent duplicate UI updates
> - No functional API changes; aligns UI context display across providers
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 119f6d41fc8889c00048701829c4921e3352da8f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->