### PR TITLE
Add memory button to main webview

### DIFF
--- a/package.json
+++ b/package.json
@@ -967,12 +967,6 @@
             "description": "Require user approval in a diff view before tool-driven edits modify workspace files",
             "scope": "resource"
           },
-          "texra.toolUse.memory.enabled": {
-            "type": "boolean",
-            "default": false,
-            "description": "Enable the memory tool for all tool-use sessions",
-            "scope": "resource"
-          },
           "texra.toolUse.persistence.enabled": {
             "type": "boolean",
             "default": true,

--- a/package.json
+++ b/package.json
@@ -1553,9 +1553,14 @@
           "group": "navigation@2"
         },
         {
-          "command": "texra.auth.accountMenu",
+          "command": "texra.showMemory",
           "when": "view == texra.mainView",
           "group": "navigation@3"
+        },
+        {
+          "command": "texra.auth.accountMenu",
+          "when": "view == texra.mainView",
+          "group": "navigation@4"
         }
       ],
       "view/item/context": [

--- a/src/common/state/stateManager.ts
+++ b/src/common/state/stateManager.ts
@@ -21,6 +21,7 @@ export enum WorkspaceStateKey {
 export enum GlobalStateKey {
   LAST_KNOWN_VERSION = 'lastKnownVersion',
   MODEL_LIST_VERSION = 'modelListVersion',
+  MEMORY_ENABLED = 'texra.memory.enabled',
 }
 
 // Prefix used for per-instruction suppression flags

--- a/src/common/webview/commands.ts
+++ b/src/common/webview/commands.ts
@@ -268,6 +268,9 @@ export const MEMORY_VIEW_COMMANDS = {
   OPEN_MEMORY_FILE: 'openMemoryFile',
   OPEN_MEMORY_FOLDER: 'openMemoryFolder',
   DELETE_MEMORY: 'deleteMemory',
+  GET_MEMORY_ENABLED: 'getMemoryEnabled',
+  SET_MEMORY_ENABLED: 'setMemoryEnabled',
+  UPDATE_MEMORY_ENABLED: 'updateMemoryEnabled',
 };
 
 // Export all commands in a single object for convenience

--- a/src/memoryView/MemoryViewMessageHandler.ts
+++ b/src/memoryView/MemoryViewMessageHandler.ts
@@ -27,6 +27,10 @@ import {
 // Local imports - storage
 import { StorageFS } from '@utils/files';
 
+// Local imports - config
+import { setConfig } from '@utils/config';
+import { getToolUseMemoryEnabled } from '@utils/config/constants';
+
 // Local imports - schemas
 import {
   MemoryPathMessageSchema,
@@ -61,6 +65,10 @@ export class MemoryViewMessageHandler extends BaseViewMessageHandler<
       [MEMORY_VIEW_COMMANDS.OPEN_MEMORY_FOLDER]:
         this.handleOpenMemoryFolder.bind(this),
       [MEMORY_VIEW_COMMANDS.DELETE_MEMORY]: this.handleDeleteMemory.bind(this),
+      [MEMORY_VIEW_COMMANDS.GET_MEMORY_ENABLED]:
+        this.handleGetMemoryEnabled.bind(this),
+      [MEMORY_VIEW_COMMANDS.SET_MEMORY_ENABLED]:
+        this.handleSetMemoryEnabled.bind(this),
     };
   }
 
@@ -155,6 +163,38 @@ export class MemoryViewMessageHandler extends BaseViewMessageHandler<
         }
       },
     );
+  }
+
+  private async handleGetMemoryEnabled(
+    _message: unknown,
+    view: vscode.WebviewView | vscode.WebviewPanel,
+  ): Promise<void> {
+    const enabled = getToolUseMemoryEnabled();
+    await view.webview.postMessage({
+      command: MEMORY_VIEW_COMMANDS.UPDATE_MEMORY_ENABLED,
+      enabled,
+    });
+  }
+
+  private async handleSetMemoryEnabled(
+    message: unknown,
+    view: vscode.WebviewView | vscode.WebviewPanel,
+  ): Promise<void> {
+    const enabled =
+      typeof message === 'object' &&
+      message !== null &&
+      'enabled' in message &&
+      typeof (message as { enabled: unknown }).enabled === 'boolean'
+        ? (message as { enabled: boolean }).enabled
+        : false;
+
+    await setConfig('texra.toolUse.memory.enabled', enabled);
+
+    // Confirm the update back to the webview
+    await view.webview.postMessage({
+      command: MEMORY_VIEW_COMMANDS.UPDATE_MEMORY_ENABLED,
+      enabled,
+    });
   }
 
   private async loadMemoryItems(): Promise<MemoryViewItem[]> {

--- a/src/memoryView/MemoryViewMessageHandler.ts
+++ b/src/memoryView/MemoryViewMessageHandler.ts
@@ -28,8 +28,10 @@ import {
 import { StorageFS } from '@utils/files';
 
 // Local imports - config
-import { setConfig } from '@utils/config';
-import { getToolUseMemoryEnabled } from '@utils/config/constants';
+import {
+  getToolUseMemoryEnabled,
+  setToolUseMemoryEnabled,
+} from '@utils/config/constants';
 
 // Local imports - schemas
 import {
@@ -190,7 +192,7 @@ export class MemoryViewMessageHandler extends BaseViewMessageHandler<
       message,
       'setMemoryEnabled',
       async ({ enabled }) => {
-        await setConfig('texra.toolUse.memory.enabled', enabled);
+        await setToolUseMemoryEnabled(enabled);
 
         // Confirm the update back to the webview
         await this.sendMemoryEnabled(view.webview);

--- a/src/memoryView/MemoryViewMessageHandler.ts
+++ b/src/memoryView/MemoryViewMessageHandler.ts
@@ -35,6 +35,7 @@ import { getToolUseMemoryEnabled } from '@utils/config/constants';
 import {
   MemoryPathMessageSchema,
   MemoryDeleteMessageSchema,
+  MemoryEnabledMessageSchema,
 } from '@webview/types/messages';
 
 interface MemoryViewItem {
@@ -165,36 +166,36 @@ export class MemoryViewMessageHandler extends BaseViewMessageHandler<
     );
   }
 
+  public async sendMemoryEnabled(webview: vscode.Webview): Promise<void> {
+    const enabled = getToolUseMemoryEnabled();
+    await webview.postMessage({
+      command: MEMORY_VIEW_COMMANDS.UPDATE_MEMORY_ENABLED,
+      enabled,
+    });
+  }
+
   private async handleGetMemoryEnabled(
     _message: unknown,
     view: vscode.WebviewView | vscode.WebviewPanel,
   ): Promise<void> {
-    const enabled = getToolUseMemoryEnabled();
-    await view.webview.postMessage({
-      command: MEMORY_VIEW_COMMANDS.UPDATE_MEMORY_ENABLED,
-      enabled,
-    });
+    await this.sendMemoryEnabled(view.webview);
   }
 
   private async handleSetMemoryEnabled(
     message: unknown,
     view: vscode.WebviewView | vscode.WebviewPanel,
   ): Promise<void> {
-    const enabled =
-      typeof message === 'object' &&
-      message !== null &&
-      'enabled' in message &&
-      typeof (message as { enabled: unknown }).enabled === 'boolean'
-        ? (message as { enabled: boolean }).enabled
-        : false;
+    await this.withValidatedMessage(
+      MemoryEnabledMessageSchema,
+      message,
+      'setMemoryEnabled',
+      async ({ enabled }) => {
+        await setConfig('texra.toolUse.memory.enabled', enabled);
 
-    await setConfig('texra.toolUse.memory.enabled', enabled);
-
-    // Confirm the update back to the webview
-    await view.webview.postMessage({
-      command: MEMORY_VIEW_COMMANDS.UPDATE_MEMORY_ENABLED,
-      enabled,
-    });
+        // Confirm the update back to the webview
+        await this.sendMemoryEnabled(view.webview);
+      },
+    );
   }
 
   private async loadMemoryItems(): Promise<MemoryViewItem[]> {

--- a/src/memoryView/MemoryViewProvider.ts
+++ b/src/memoryView/MemoryViewProvider.ts
@@ -51,7 +51,10 @@ export class MemoryViewProvider
     });
 
     if (!isNew && this._view) {
-      await this.messageHandler.sendMemoryData(this._view.webview);
+      await Promise.all([
+        this.messageHandler.sendMemoryData(this._view.webview),
+        this.messageHandler.sendMemoryEnabled(this._view.webview),
+      ]);
     }
   }
 }

--- a/src/memoryView/index.html
+++ b/src/memoryView/index.html
@@ -64,6 +64,12 @@
         </vscode-toolbar-container>
       </header>
 
+      <div class="memory-settings">
+        <vscode-checkbox id="memoryEnabledToggle">
+          Enable memory for chat agents
+        </vscode-checkbox>
+      </div>
+
       <p class="text-secondary memory-description">
         The AI assistant can save notes here to remember important information
         across conversations. These notes help the assistant provide more

--- a/src/memoryView/index.html
+++ b/src/memoryView/index.html
@@ -65,7 +65,7 @@
       </header>
 
       <div class="memory-settings">
-        <vscode-checkbox id="memoryEnabledToggle">
+        <vscode-checkbox id="memoryEnabledToggle" disabled>
           Enable memory for chat agents
         </vscode-checkbox>
       </div>

--- a/src/memoryView/modules/constants.js
+++ b/src/memoryView/modules/constants.js
@@ -12,6 +12,7 @@ export const ELEMENT_IDS = {
   MEMORY_LIST: 'memoryList',
   REFRESH_MEMORY_BTN: 'refreshMemoryBtn',
   OPEN_MEMORY_FOLDER_BTN: 'openMemoryFolderBtn',
+  MEMORY_ENABLED_TOGGLE: 'memoryEnabledToggle',
 };
 
 // Text labels and messages

--- a/src/memoryView/modules/messageHandlers.js
+++ b/src/memoryView/modules/messageHandlers.js
@@ -26,6 +26,7 @@ export class MemoryViewMessageHandler extends BaseWebviewMessageHandler {
     const toggle = safeGetElementById(ELEMENT_IDS.MEMORY_ENABLED_TOGGLE);
     if (toggle) {
       toggle.checked = message.enabled;
+      toggle.disabled = false;
     }
   }
 }

--- a/src/memoryView/modules/messageHandlers.js
+++ b/src/memoryView/modules/messageHandlers.js
@@ -1,7 +1,9 @@
 // Local imports - memory view
 import { memoryViewDomHandler } from './domHandlers.js';
+import { ELEMENT_IDS } from './constants.js';
 import { MEMORY_VIEW_COMMANDS } from '@common/webview/commands.js';
 import { BaseWebviewMessageHandler } from '@common/BaseWebviewMessageHandler.js';
+import { safeGetElementById } from '@common/domUtils.js';
 
 /**
  * Handles messages from the extension for the memory view.
@@ -11,11 +13,20 @@ export class MemoryViewMessageHandler extends BaseWebviewMessageHandler {
     super();
     this._handlers = {
       [MEMORY_VIEW_COMMANDS.UPDATE_MEMORY]: (m) => this.handleUpdateMemory(m),
+      [MEMORY_VIEW_COMMANDS.UPDATE_MEMORY_ENABLED]: (m) =>
+        this.handleUpdateMemoryEnabled(m),
     };
   }
 
   handleUpdateMemory(message) {
     memoryViewDomHandler.renderMemoryItems(message.items);
+  }
+
+  handleUpdateMemoryEnabled(message) {
+    const toggle = safeGetElementById(ELEMENT_IDS.MEMORY_ENABLED_TOGGLE);
+    if (toggle) {
+      toggle.checked = message.enabled;
+    }
   }
 }
 

--- a/src/memoryView/modules/uiManagers/MemoryEventsManager.js
+++ b/src/memoryView/modules/uiManagers/MemoryEventsManager.js
@@ -51,6 +51,23 @@ export class MemoryEventsManager {
       });
     }
 
+    // Memory enabled toggle
+    const memoryEnabledToggle = safeGetElementById(
+      ELEMENT_IDS.MEMORY_ENABLED_TOGGLE,
+    );
+    if (memoryEnabledToggle) {
+      const toggleHandler = (event) => {
+        const enabled = event.target.checked;
+        vscode.postMessage({ command: COMMANDS.SET_MEMORY_ENABLED, enabled });
+      };
+      memoryEnabledToggle.addEventListener('change', toggleHandler);
+      this.handlers.push({
+        element: memoryEnabledToggle,
+        type: 'change',
+        handler: toggleHandler,
+      });
+    }
+
     const list = safeGetElementById(ELEMENT_IDS.MEMORY_LIST);
     if (!list) {
       return;

--- a/src/memoryView/script.js
+++ b/src/memoryView/script.js
@@ -13,6 +13,7 @@ messageHandler.setup();
 document.addEventListener('DOMContentLoaded', () => {
   memoryViewDomHandler.events.setup();
   vscode.postMessage({ command: MEMORY_VIEW_COMMANDS.GET_MEMORY_DATA });
+  vscode.postMessage({ command: MEMORY_VIEW_COMMANDS.GET_MEMORY_ENABLED });
 });
 
 window.addEventListener('beforeunload', () => {

--- a/src/memoryView/styles/index.css
+++ b/src/memoryView/styles/index.css
@@ -10,6 +10,14 @@
   gap: var(--spacing-medium);
 }
 
+/* Settings section */
+.memory-settings {
+  padding: var(--spacing-medium);
+  background-color: var(--vscode-editor-inactiveSelectionBackground);
+  border-radius: var(--border-radius);
+  margin-bottom: var(--spacing-small);
+}
+
 /* Description - extends .text-secondary */
 .memory-description {
   margin: 0 0 var(--spacing-medium) 0;

--- a/src/utils/config/constants.ts
+++ b/src/utils/config/constants.ts
@@ -69,7 +69,7 @@ export const DEBOUNCE_STATE_SAVE_MS = 500; // State persistence (slower, batched
 
 // Tool-use persistence defaults
 export const DEFAULT_TOOL_USE_PERSISTENCE_TTL_HOURS = 72;
-export const DEFAULT_TOOL_USE_MEMORY_ENABLED = false;
+export const DEFAULT_TOOL_USE_MEMORY_ENABLED = true;
 
 // Retry defaults
 // Default to 0 automatic retries - users must click retry button

--- a/src/utils/config/constants.ts
+++ b/src/utils/config/constants.ts
@@ -1,3 +1,6 @@
+// Local imports - common
+import { globalSM, GlobalStateKey } from '@common/state/stateManager';
+
 // Local imports - config utils
 import * as logger from '@logger/logUtils';
 import { getConfig } from './configUtils';
@@ -98,10 +101,15 @@ export function getToolUsePersistenceTtlHours(): number {
 
 /** Determine whether the memory tool is enabled for tool-use sessions. */
 export function getToolUseMemoryEnabled(): boolean {
-  return getConfig<boolean>(
-    'texra.toolUse.memory.enabled',
+  return globalSM?.get<boolean>(
+    GlobalStateKey.MEMORY_ENABLED,
     DEFAULT_TOOL_USE_MEMORY_ENABLED,
-  );
+  ) ?? DEFAULT_TOOL_USE_MEMORY_ENABLED;
+}
+
+/** Set whether the memory tool is enabled for tool-use sessions. */
+export async function setToolUseMemoryEnabled(enabled: boolean): Promise<void> {
+  await globalSM?.update(GlobalStateKey.MEMORY_ENABLED, enabled);
 }
 
 export function getModelRetryMaxAttempts(): number {

--- a/src/webview/types/messages.ts
+++ b/src/webview/types/messages.ts
@@ -276,3 +276,10 @@ export const MemoryDeleteMessageSchema = MemoryPathMessageSchema.extend({
 });
 
 export type MemoryDeleteMessage = z.infer<typeof MemoryDeleteMessageSchema>;
+
+/** Memory enabled toggle message */
+export const MemoryEnabledMessageSchema = z.object({
+  enabled: z.boolean(),
+});
+
+export type MemoryEnabledMessage = z.infer<typeof MemoryEnabledMessageSchema>;


### PR DESCRIPTION
…view

- Add memory button to main webview's VS Code native toolbar (next to history, settings, and profile buttons)
- Add memory enabled toggle checkbox in memory view to control the texra.toolUse.memory.enabled setting
- Handle GET_MEMORY_ENABLED and SET_MEMORY_ENABLED commands in memory view message handler
- Add styling for memory settings section in memory view

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a first-class Memory control and migrates enablement from a settings flag to persisted global state.
> 
> - **UI:** Adds `texra.showMemory` button to the main view toolbar; Memory view now includes an "Enable memory for chat agents" checkbox with styling
> - **State:** New `GlobalStateKey.MEMORY_ENABLED`; memory enablement now stored via `globalSM` with default `true` (removes `texra.toolUse.memory.enabled` config)
> - **Webview wiring:** Adds `GET_MEMORY_ENABLED`/`SET_MEMORY_ENABLED`/`UPDATE_MEMORY_ENABLED` commands; Memory view requests state on load and updates via checkbox; handler validates and persists, then echoes updated state
> - **Provider:** On reopen, sends both memory items and enabled state in parallel
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ebf61bb99f1ea7c75802445308419f7545888cc0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->