### PR TITLE
Fix chat history cleanup after extension reload

### DIFF
--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -152,7 +152,6 @@ export class ProgressViewProvider
     super.cleanupView();
     this._sidebarReady = false;
     this._pendingUpdateOptions = null;
-    this.state.clearRenderedStreamTracking();
   }
 
   /**
@@ -187,8 +186,6 @@ export class ProgressViewProvider
 
     this._sidebarReady = false;
     this._pendingUpdateOptions = null;
-    // Clear rendered stream tracking to force rebuild - DOM state is stale after resolve
-    this.state.clearRenderedStreamTracking();
 
     webviewView.webview.options = {
       enableScripts: true,
@@ -251,16 +248,10 @@ export class ProgressViewProvider
       theme,
     );
 
-    // Use state as single source of truth for stream switch detection
-    const isStreamSwitch = this.state.isStreamSwitch(activeStream);
-    const shouldForceRebuild = options?.forceRebuild ?? isStreamSwitch;
+    // Frontend detects stream switches using its own lastRenderedStream tracking.
+    // Backend just sends data with action: 'render', frontend decides if rebuild needed.
+    this.eventHandler.refreshStreamSurface(activeStream || '');
 
-    this.eventHandler.refreshStreamSurface(activeStream || '', {
-      forceRebuild: shouldForceRebuild,
-    });
-
-    // Mark stream as rendered for future switch detection
-    this.state.markStreamRendered(activeStream);
     this._pendingUpdateOptions = null;
   }
 

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -104,9 +104,6 @@ export class ProgressEventHandler {
         const { stream, session, isRemote, hasMultipleOutputs } = payload;
         if (!stream) return;
 
-        // Use state's single source of truth for stream switch detection
-        const isStreamSwitch = this.state.isStreamSwitch(stream);
-
         await this.state.streamTabs.ensureStream(stream);
         this.state.updateStreamHints(stream, {
           sessionCategory: session?.agentCategory,
@@ -145,12 +142,10 @@ export class ProgressEventHandler {
         }
 
         if (this.webviewUpdater.isAvailable()) {
+          // Frontend detects stream switches using lastRenderedStream tracking.
           const activeRunId = this.refreshStreamSurface(stream, {
             updateInstruction: false,
-            forceRebuild: isStreamSwitch,
           });
-          // Mark stream as rendered for future switch detection
-          this.state.markStreamRendered(stream);
           this.sendInstructionUpdate(stream, activeRunId);
         }
       },
@@ -577,24 +572,27 @@ export class ProgressEventHandler {
 
   /**
    * Refresh all webview surface data for a specific stream.
-   * @param options.forceRebuild - If true, frontend will do full DOM rebuild.
-   *   Required when switching streams or after data deletion. Defaults to false
-   *   for incremental updates.
+   *
+   * Sends UPDATE_LOGS with action: 'render' (or 'clear' if stream is empty).
+   * Frontend detects stream switches using its lastRenderedStream tracking
+   * and decides whether to do full rebuild or incremental update.
+   *
+   * @param options.updateInstruction - If true (default), also update instruction panel.
    * @returns The resolved active run ID, useful for callers that need to pass it
    *   to sendInstructionUpdate separately (when updateInstruction is false).
    */
   public refreshStreamSurface(
     stream: string,
-    options: { updateInstruction?: boolean; forceRebuild?: boolean } = {},
+    options: { updateInstruction?: boolean } = {},
   ): string | null {
     if (!this.webviewUpdater.isAvailable()) return null;
 
-    const { updateInstruction = true, forceRebuild = false } = options;
+    const { updateInstruction = true } = options;
 
     if (!stream) {
-      // No active stream: explicitly clear content with clearContent: true.
-      // This is an intentional clear (not a bug), so we pass the explicit flag.
-      this.webviewUpdater.updateLogContent('', [], [], undefined, true, true);
+      // No active stream: explicitly clear content with action: 'clear'.
+      // This is an intentional clear (e.g., stream deleted, no streams left).
+      this.webviewUpdater.updateLogContent('', [], [], undefined, 'clear');
       this.webviewUpdater.updateFiles('', { reset: true });
       this.webviewUpdater.updateMissingOutputs('', { reset: true });
       this.webviewUpdater.updateUsage('', {});
@@ -630,18 +628,14 @@ export class ProgressEventHandler {
     // Groups already in state will be sent via updateLogContent.
     this.pendingTaskGroups.delete(stream);
 
-    this.webviewUpdater.updateLogContent(
-      stream,
-      messages,
-      groups,
-      {
-        runInstructions,
-        activeRunId,
-        runUsage: usageByRun,
-        runFiles: filesByRun,
-      },
-      forceRebuild,
-    );
+    // Send data with action: 'render' (default).
+    // Frontend detects stream switch by comparing stream with lastRenderedStream.
+    this.webviewUpdater.updateLogContent(stream, messages, groups, {
+      runInstructions,
+      activeRunId,
+      runUsage: usageByRun,
+      runFiles: filesByRun,
+    });
 
     // Note: Files are already included in UPDATE_LOGS (runFiles) and handled
     // by handleUpdateLogs in the frontend. We don't send separate UPDATE_FILES
@@ -836,15 +830,12 @@ export class ProgressEventHandler {
       // sets state.activeStream. Without this, UPDATE_LOGS fails _isActiveStream check.
       this.webviewUpdater.updateAll(this.state, StreamStatusService.getAll());
 
-      // Force rebuild to clear any previous stream's content. The new task
-      // group must be added to state BEFORE this call (in TaskGroupEvents)
+      // The new task group must be added to state BEFORE this call (in TaskGroupEvents)
       // so UPDATE_LOGS includes it and the frontend renders it correctly.
+      // Frontend detects stream switches using lastRenderedStream tracking.
       const activeRunId = this.refreshStreamSurface(stream, {
         updateInstruction: false,
-        forceRebuild: true,
       });
-      // Mark stream as rendered for future switch detection
-      this.state.markStreamRendered(stream);
       this.sendInstructionUpdate(stream, activeRunId);
     }
   }

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -592,7 +592,9 @@ export class ProgressEventHandler {
     const { updateInstruction = true, forceRebuild = false } = options;
 
     if (!stream) {
-      this.webviewUpdater.updateLogContent('', [], [], undefined, true);
+      // No active stream: explicitly clear content with clearContent: true.
+      // This is an intentional clear (not a bug), so we pass the explicit flag.
+      this.webviewUpdater.updateLogContent('', [], [], undefined, true, true);
       this.webviewUpdater.updateFiles('', { reset: true });
       this.webviewUpdater.updateMissingOutputs('', { reset: true });
       this.webviewUpdater.updateUsage('', {});

--- a/src/progressView/managers/WebviewUpdater.ts
+++ b/src/progressView/managers/WebviewUpdater.ts
@@ -101,14 +101,17 @@ export class WebviewUpdater {
   /**
    * Update log content for a specific stream.
    *
-   * Behavior based on flags:
-   * - `clearContent: true` → Explicitly clear DOM content (for stream deletion, no active stream)
-   * - `forceRebuild: true` with messages → Clear and rebuild with new content (stream switch)
-   * - `forceRebuild: true` without messages → Preserve existing content (safety guard)
-   * - `forceRebuild: false` → Incremental update only (metadata changes)
+   * Action types:
+   * - `'render'` (default): Send data to display. Frontend detects stream switch
+   *   by comparing message.stream with its lastRenderedStream. If stream changed,
+   *   frontend clears and rebuilds. If same stream, frontend does incremental update.
+   * - `'clear'`: Explicitly clear DOM content (for stream deletion, no active stream).
+   *   Frontend always clears, even without messages.
    *
-   * @param forceRebuild - Whether a full DOM rebuild is intended
-   * @param clearContent - Whether to explicitly clear content (use for intentional clearing)
+   * This design moves stream switch detection to the frontend (which tracks
+   * lastRenderedStream) and removes the need for backend to track render state.
+   *
+   * @param action - The action type: 'render' (default) or 'clear'
    */
   updateLogContent(
     stream: StreamTabId,
@@ -120,8 +123,7 @@ export class WebviewUpdater {
       runUsage?: Record<string, TokenUsageStats>;
       runFiles?: Record<string, { [key: number]: OutputFileInfo[] }>;
     },
-    forceRebuild: boolean = false,
-    clearContent: boolean = false,
+    action: 'render' | 'clear' = 'render',
   ): void {
     this.sendMessage({
       command: COMMANDS.UPDATE_LOGS,
@@ -132,8 +134,7 @@ export class WebviewUpdater {
       activeRunId: extras?.activeRunId,
       runUsage: extras?.runUsage,
       runFiles: extras?.runFiles,
-      forceRebuild,
-      clearContent,
+      action,
     });
   }
 

--- a/src/progressView/managers/WebviewUpdater.ts
+++ b/src/progressView/managers/WebviewUpdater.ts
@@ -100,9 +100,15 @@ export class WebviewUpdater {
 
   /**
    * Update log content for a specific stream.
-   * @param forceRebuild - Controls frontend DOM rebuild behavior:
-   *   - `true`: Full DOM rebuild (stream switch, data deletion, first load)
-   *   - `false`: Incremental update only (same stream, metadata changes)
+   *
+   * Behavior based on flags:
+   * - `clearContent: true` → Explicitly clear DOM content (for stream deletion, no active stream)
+   * - `forceRebuild: true` with messages → Clear and rebuild with new content (stream switch)
+   * - `forceRebuild: true` without messages → Preserve existing content (safety guard)
+   * - `forceRebuild: false` → Incremental update only (metadata changes)
+   *
+   * @param forceRebuild - Whether a full DOM rebuild is intended
+   * @param clearContent - Whether to explicitly clear content (use for intentional clearing)
    */
   updateLogContent(
     stream: StreamTabId,
@@ -115,6 +121,7 @@ export class WebviewUpdater {
       runFiles?: Record<string, { [key: number]: OutputFileInfo[] }>;
     },
     forceRebuild: boolean = false,
+    clearContent: boolean = false,
   ): void {
     this.sendMessage({
       command: COMMANDS.UPDATE_LOGS,
@@ -126,6 +133,7 @@ export class WebviewUpdater {
       runUsage: extras?.runUsage,
       runFiles: extras?.runFiles,
       forceRebuild,
+      clearContent,
     });
   }
 

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -393,17 +393,35 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       return;
     }
 
-    // forceRebuild is now always a boolean from backend:
-    // - false: Incremental update only (same stream, metadata changes)
-    // - true: Full DOM rebuild (stream switch, data deletion, first load)
-    if (!message.forceRebuild) {
+    const logMessages = message.messages ?? [];
+
+    // Determine rebuild strategy based on explicit flags:
+    //
+    // clearContent: Explicit signal to clear DOM content (e.g., no active stream,
+    //               stream deletion). When true, we clear even with empty messages.
+    //
+    // forceRebuild: Signal that a full DOM rebuild is appropriate. However:
+    //   - forceRebuild: true with messages → Clear and rebuild
+    //   - forceRebuild: true without messages → Preserve content (safety guard)
+    //                   This prevents data loss from race conditions, filter mismatches,
+    //                   or other edge cases where forceRebuild is set but data isn't ready.
+    //
+    // forceRebuild: false → Incremental update only (metadata changes)
+    //
+    // The clearContent flag makes intent explicit and removes ambiguity from the
+    // "forceRebuild: true with empty messages" case that previously caused bugs.
+    const explicitClear = Boolean(message.clearContent);
+    const hasMessages = logMessages.length > 0;
+    const shouldFullRebuild =
+      explicitClear || (message.forceRebuild && hasMessages);
+
+    if (!shouldFullRebuild) {
       this._handleIncrementalUpdate(message);
       this._updatePlaceholderVisibility();
       return;
     }
 
-    // Full rebuild path
-    const logMessages = message.messages ?? [];
+    // Full rebuild path: clear and rebuild (either explicit clear or have messages)
     const logContent = document.getElementById(ELEMENT_IDS.LOG_CONTENT);
     pendingLogUpdates.clear();
     dom.taskGroups.clear();

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -364,6 +364,8 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       if (logContent) {
         logContent.innerHTML = '';
       }
+      // Reset lastRenderedStream since we cleared content
+      state.lastRenderedStream = '';
       state.clearRunInstructions();
       state.clearAllActiveRuns();
       state.clearAllPendingInstructions();
@@ -395,25 +397,29 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
 
     const logMessages = message.messages ?? [];
 
-    // Determine rebuild strategy based on explicit flags:
+    // Action-based rebuild strategy (simpler than boolean flags):
     //
-    // clearContent: Explicit signal to clear DOM content (e.g., no active stream,
-    //               stream deletion). When true, we clear even with empty messages.
+    // action: 'clear' → Explicitly clear DOM content (no active stream, stream deleted)
+    // action: 'render' (default) → Send data to display, frontend decides:
+    //   - Stream switch (message.stream !== lastRenderedStream) → Full rebuild
+    //   - Same stream → Incremental update (just metadata)
     //
-    // forceRebuild: Signal that a full DOM rebuild is appropriate. However:
-    //   - forceRebuild: true with messages → Clear and rebuild
-    //   - forceRebuild: true without messages → Preserve content (safety guard)
-    //                   This prevents data loss from race conditions, filter mismatches,
-    //                   or other edge cases where forceRebuild is set but data isn't ready.
+    // This design moves stream switch detection to the frontend, which tracks
+    // lastRenderedStream. Backend just sends data with intent, no longer tracks
+    // what was rendered. The frontend is the single source of truth for render state.
+    const action = message.action ?? 'render';
+    const isExplicitClear = action === 'clear';
+    const isStreamSwitch = message.stream !== state.lastRenderedStream;
+
+    // Determine if we need full rebuild:
+    // - Explicit clear: always clear (even without messages)
+    // - Stream switch: always clear (user switched, expects different content)
+    // - Same stream: incremental update only (metadata changes, messages via APPEND_LOG)
     //
-    // forceRebuild: false → Incremental update only (metadata changes)
-    //
-    // The clearContent flag makes intent explicit and removes ambiguity from the
-    // "forceRebuild: true with empty messages" case that previously caused bugs.
-    const explicitClear = Boolean(message.clearContent);
-    const hasMessages = logMessages.length > 0;
-    const shouldFullRebuild =
-      explicitClear || (message.forceRebuild && hasMessages);
+    // Note: Stream switch ALWAYS triggers full rebuild, even with empty messages.
+    // Showing empty content for a new stream is correct; showing the previous
+    // stream's content would be confusing and a source of bugs.
+    const shouldFullRebuild = isExplicitClear || isStreamSwitch;
 
     if (!shouldFullRebuild) {
       this._handleIncrementalUpdate(message);
@@ -421,7 +427,7 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       return;
     }
 
-    // Full rebuild path: clear and rebuild (either explicit clear or have messages)
+    // Full rebuild path: clear and rebuild
     const logContent = document.getElementById(ELEMENT_IDS.LOG_CONTENT);
     pendingLogUpdates.clear();
     dom.taskGroups.clear();
@@ -488,6 +494,10 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     this._refreshOutputsForActiveRun(activeRunId);
     this._refreshUsageForActiveRun();
     this._refreshContextStateForActiveStream();
+
+    // Update lastRenderedStream AFTER successful render.
+    // This is the single source of truth for stream switch detection.
+    state.lastRenderedStream = message.stream;
 
     this._updatePlaceholderVisibility();
   }
@@ -978,6 +988,8 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       state.clearContextState(message.stream);
       if (deletingActiveStream) {
         state.activeStream = '';
+        // Reset lastRenderedStream since the rendered stream was deleted
+        state.lastRenderedStream = '';
         const groupIds = Array.from(state.taskGroups.getGroupMap().keys());
         state.toggleStates.clearSelection(groupIds);
         dom.instructionPanel.hide();
@@ -998,6 +1010,8 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     state.resetExecutionIdAvailability();
     state.clearStreams();
     state.activeStream = '';
+    // Reset lastRenderedStream since all streams are deleted
+    state.lastRenderedStream = '';
     dom.instructionPanel.hide();
     state.clearRunInstructions();
     state.clearRunFiles();

--- a/src/progressView/modules/progressViewState.js
+++ b/src/progressView/modules/progressViewState.js
@@ -265,6 +265,12 @@ export class ProgressViewState {
   constructor() {
     this.stateManager = new WebviewStateManager();
     this.activeStream = '';
+    /**
+     * Tracks the stream that was last rendered to the DOM.
+     * Used by frontend to detect stream switches independently.
+     * This is the SINGLE SOURCE OF TRUTH for stream switch detection.
+     */
+    this.lastRenderedStream = '';
     this.streams = new Set();
     this.agentTypeFilter = 'all';
     this.pendingFilterUpdate = false;

--- a/src/progressView/state/ProgressViewState.ts
+++ b/src/progressView/state/ProgressViewState.ts
@@ -61,12 +61,6 @@ export class ProgressViewState {
   private _usageStats: UsageStatsManager;
   private _runInstructions: RunInstructionManager;
   private _activeStream: StreamTabId = '';
-  /**
-   * Tracks the stream that was last rendered to the webview.
-   * Used as single source of truth for stream switch detection.
-   * Reset when webview is cleaned up to force rebuild on next render.
-   */
-  private _lastRenderedStream: StreamTabId = '';
   private _streamSortOrder = 'time';
   private _agentTypeFilter: AgentFilter = 'all';
   private readonly taskStates = new Map<StreamTabId, TaskState>();
@@ -141,32 +135,6 @@ export class ProgressViewState {
   set activeStream(stream: StreamTabId) {
     this._activeStream = stream;
     this.saveActiveStream();
-  }
-
-  // Stream switch detection (single source of truth)
-
-  /**
-   * Check if rendering the given stream would be a stream switch.
-   * Uses lastRenderedStream as the single source of truth.
-   */
-  isStreamSwitch(stream: StreamTabId): boolean {
-    return this._lastRenderedStream !== stream;
-  }
-
-  /**
-   * Mark a stream as having been rendered.
-   * Called after successfully rendering stream content to webview.
-   */
-  markStreamRendered(stream: StreamTabId): void {
-    this._lastRenderedStream = stream;
-  }
-
-  /**
-   * Clear rendered stream tracking.
-   * Called when webview is cleaned up to force rebuild on next render.
-   */
-  clearRenderedStreamTracking(): void {
-    this._lastRenderedStream = '';
   }
 
   /**


### PR DESCRIPTION
Add explicit clearContent flag to UPDATE_LOGS messages to distinguish between intentional content clearing and rebuild requests without data.

Previously, forceRebuild: true with empty messages would clear the DOM content, causing data loss when:
- Extension reloads and filter mismatches cause empty activeStream
- Race conditions result in UPDATE_LOGS arriving before data is ready
- Task state validation fails, filtering out the stream

The fix introduces a two-part solution:
1. Backend: Add clearContent parameter to updateLogContent() that must be explicitly set when content should be cleared (e.g., no active stream)
2. Frontend: Only clear DOM when clearContent: true OR when we have messages to render. Preserve existing content when forceRebuild: true but no messages and no clearContent flag.

This makes the intent explicit and removes ambiguity from edge cases that previously caused the chat history cleanup bug.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Resolves unintended log clears by making render intent explicit and shifting stream-switch detection to the webview.
> 
> - Introduces `UPDATE_LOGS` `action: 'render' | 'clear'` (default 'render'); use `'clear'` only for intentional wipes (no active stream, deletions)
> - Frontend tracks `state.lastRenderedStream` and performs full rebuilds only on stream switches or explicit `'clear'`; same-stream updates are incremental
> - Removes backend render tracking and flags: deletes `isStreamSwitch/markStreamRendered/clearRenderedStreamTracking` and `forceRebuild` plumbing; `updateLogContent` no longer takes a boolean
> - Provider/EventHandler now always send render data and call `refreshStreamSurface` without rebuild hints; explicit clears sent when stream is empty
> - Frontend message handlers updated to action-based logic; reset `lastRenderedStream` on clears/deletions; preserve DOM on empty renders to avoid data loss
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5c59ca7fc3fa9a207176dcea9e07ebe762fde70c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->