### PR TITLE
Fix empty output display for tool use results

### DIFF
--- a/src/agent/modelHandlers/utils/toolAttachmentUtils.ts
+++ b/src/agent/modelHandlers/utils/toolAttachmentUtils.ts
@@ -272,8 +272,9 @@ export function formatToolResultAsText(
   if (result.userInstruction) {
     textPieces.push(`User feedback: ${result.userInstruction}`);
   }
-  // Include error when no meaningful output - use same check as above for consistency
-  if (result.isError && !isNonEmptyString(result.output) && result.error) {
+  // Include error when no meaningful output - check for non-empty error string
+  // rather than isError flag (which may be stripped by extractToolAttachments)
+  if (isNonEmptyString(result.error) && !isNonEmptyString(result.output)) {
     textPieces.push(result.error);
   }
   if (textPieces.length === 0 && result.summary) {

--- a/src/progressView/modules/formatters/normalizers.js
+++ b/src/progressView/modules/formatters/normalizers.js
@@ -197,10 +197,17 @@ export const normalizeToolUseLog = (structured) => {
     outputContent = output !== undefined ? output : rest;
   }
 
+  // Check if outputContent is an empty object (no meaningful data to display)
+  const isEmptyObject =
+    outputContent !== null &&
+    typeof outputContent === 'object' &&
+    !Array.isArray(outputContent) &&
+    Object.keys(outputContent).length === 0;
+
   const outputText =
     typeof outputContent === 'string'
       ? outputContent
-      : outputContent !== undefined
+      : outputContent !== undefined && !isEmptyObject
         ? stringifyForDisplay(outputContent)
         : '';
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Improves handling of tool results with empty or missing outputs to avoid misleading renderings.
> 
> - In `formatToolResultAsText`, include `error` text when present and `output` is empty, regardless of `isError` (which may be removed during sanitization)
> - In `normalizeToolUseLog`, detect empty objects and avoid stringifying them, preventing `{}` from appearing as output; only stringify non-empty content
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1ce7255fd7b6cdc20c95d686cb39c3fc737ac0a5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->