### PR TITLE
fix: preserve flow records during extension reload

### DIFF
--- a/src/agent/implementations/flows/reflection/runReflectionFlow.ts
+++ b/src/agent/implementations/flows/reflection/runReflectionFlow.ts
@@ -19,39 +19,51 @@
  * - PersistedFlow handles persistence transparently
  */
 
+// Local imports - agent output
 import type { RoundOutput, IOutputHandler } from '@agent/output';
 import { OutputHandler } from '@agent/output';
+
+// Local imports - agent runtime and storage
 import { getExecutionStore, type ExecutionKVStore } from '@agent/storage';
+import { isExtensionDeactivating } from '@agent/runtime/extensionLifecycle';
+import { retryCoordinator } from '@agent/runtime/RetryRequestCoordinator';
 import type {
   StreamTabId,
   StorageKeyManager,
 } from '@agent/types/IdentifierTypes';
+
+// Local imports - agent core and flow
 import type { RoundFinalizedCallback } from '@agent/core/flows/CycleServices';
+import { AgentRunState } from '@agent/core/AgentState';
+import { AgentWorkspaceState } from '@agent/core/AgentWorkspaceState';
+import type { AgentWorkflowSetting } from '@agent/core/AgentDataclass';
+import type { BaseFlowContextInit } from '@agent/implementations/flows/common';
+import { type FlowRecord } from '@agent/node/persisted-flow';
+import { RoundPersistedFlow } from '@agent/node/round-persisted-flow';
 import {
   registerInterruptible,
   unregisterInterruptible,
   type IInterruptible,
 } from '@agent/toolUse/ToolUseAgentRegistry';
-import type { BaseFlowContextInit } from '@agent/implementations/flows/common';
-import { retryCoordinator } from '@agent/runtime/RetryRequestCoordinator';
 
-import { AgentRunState } from '@agent/core/AgentState';
-import { AgentWorkspaceState } from '@agent/core/AgentWorkspaceState';
-import type { AgentWorkflowSetting } from '@agent/core/AgentDataclass';
-import { type FlowRecord } from '@agent/node/persisted-flow';
-import { RoundPersistedFlow } from '@agent/node/round-persisted-flow';
+// Local imports - common
 import { normalizeRunId } from '@common/constants/runIds';
 import {
   EXECUTION_STATUS,
   executionToEndStatus,
   type ExecutionStatus,
 } from '@common/constants/streamStatus';
+
+// Local imports - logger
 import type { AgentLogStage } from '@logger/AgentLogger';
 import { END_GROUP_STATUS, type EndGroupStatus } from '@logger/messageTypes';
+
+// Local imports - utilities
 import { PromptBuilder } from '@utils/prompt';
 import { TaskRunFileService, type AgentFileLocation } from '@utils/files';
 import { LatexMediaManager } from '@latex';
 
+// Local imports - reflection flow
 import {
   createReflectionFlow,
   type ReflectionFlowShared,
@@ -320,13 +332,17 @@ export async function runReflectionFlow<C = unknown>(
     // Only delete flow record on successful completion
     // Keep it for interrupted/error flows to enable resume
     // Note: END_GROUP_STATUS.STOPPED means "completed" (not user-stopped)
-    if (status === END_GROUP_STATUS.STOPPED) {
+    if (status === END_GROUP_STATUS.STOPPED && !isExtensionDeactivating()) {
       try {
         const kv = getExecutionStore(executionId);
         await kv.delete(`flow:${executionId}`);
       } catch {
         // Ignore cleanup errors
       }
+    } else if (isExtensionDeactivating()) {
+      logger.debug(
+        'Skipping reflection flow record cleanup during extension deactivation',
+      );
     }
 
     if (createdRunStage) {

--- a/src/agent/implementations/flows/reflection/runReflectionFlow.ts
+++ b/src/agent/implementations/flows/reflection/runReflectionFlow.ts
@@ -25,7 +25,7 @@ import { OutputHandler } from '@agent/output';
 
 // Local imports - agent runtime and storage
 import { getExecutionStore, type ExecutionKVStore } from '@agent/storage';
-import { isExtensionDeactivating } from '@agent/runtime/extensionLifecycle';
+import { shouldPreserveFlowRecord } from '@agent/runtime/flowRecordUtils';
 import { retryCoordinator } from '@agent/runtime/RetryRequestCoordinator';
 import type {
   StreamTabId,
@@ -332,17 +332,15 @@ export async function runReflectionFlow<C = unknown>(
     // Only delete flow record on successful completion
     // Keep it for interrupted/error flows to enable resume
     // Note: END_GROUP_STATUS.STOPPED means "completed" (not user-stopped)
-    if (status === END_GROUP_STATUS.STOPPED && !isExtensionDeactivating()) {
+    if (shouldPreserveFlowRecord(status, false)) {
+      logger.debug('Preserving reflection flow record for resume capability');
+    } else {
       try {
         const kv = getExecutionStore(executionId);
         await kv.delete(`flow:${executionId}`);
       } catch {
         // Ignore cleanup errors
       }
-    } else if (isExtensionDeactivating()) {
-      logger.debug(
-        'Skipping reflection flow record cleanup during extension deactivation',
-      );
     }
 
     if (createdRunStage) {

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -9,20 +9,26 @@
  * - State persistence via PersistedFlow
  */
 
+// Local imports - agent runtime and storage
 import { getExecutionStore, type ExecutionKVStore } from '@agent/storage';
+import { isExtensionDeactivating } from '@agent/runtime/extensionLifecycle';
 import type { StreamTabId } from '@agent/types/IdentifierTypes';
 import {
   registerInterruptible,
   unregisterInterruptible,
 } from '@agent/toolUse/ToolUseAgentRegistry';
-
 import { PersistedFlow, type FlowRecord } from '@agent/node/persisted-flow';
+
+// Local imports - common
 import {
   EXECUTION_STATUS,
   executionToEndStatus,
 } from '@common/constants/streamStatus';
+
+// Local imports - logger
 import { END_GROUP_STATUS, type EndGroupStatus } from '@logger/messageTypes';
 
+// Local imports - tool-use flow
 import { createToolUseRunFlow, type ToolUseRunShared } from '../ToolUseRunFlow';
 import {
   createToolUseFlowContext,
@@ -159,16 +165,27 @@ export async function runToolUseFlow<C = unknown>(
     // When VS Code reloads mid-execution, this block never runs, preserving
     // the record for sessions that were genuinely interrupted mid-wait.
     try {
-      const kv = getExecutionStore(executionId);
-      const flowRecord = await kv.read<FlowRecord>(`flow:${executionId}`);
-      const sharedState = flowRecord?.shared as { state?: { userCancelledRetry?: boolean } } | undefined;
-      const userCancelledRetry = sharedState?.state?.userCancelledRetry === true;
-
-      if (userCancelledRetry) {
-        // Preserve flow record for resume - user can continue from last successful breakpoint
-        logger.debug('Flow record preserved after retry cancellation for resume capability');
+      if (isExtensionDeactivating()) {
+        logger.debug(
+          'Skipping tool-use flow record cleanup during extension deactivation',
+        );
       } else {
-        await kv.delete(`flow:${executionId}`);
+        const kv = getExecutionStore(executionId);
+        const flowRecord = await kv.read<FlowRecord>(`flow:${executionId}`);
+        const sharedState = flowRecord?.shared as
+          | { state?: { userCancelledRetry?: boolean } }
+          | undefined;
+        const userCancelledRetry =
+          sharedState?.state?.userCancelledRetry === true;
+
+        if (userCancelledRetry) {
+          // Preserve flow record for resume - user can continue from last successful breakpoint
+          logger.debug(
+            'Flow record preserved after retry cancellation for resume capability',
+          );
+        } else {
+          await kv.delete(`flow:${executionId}`);
+        }
       }
     } catch {
       // Ignore cleanup errors - non-critical

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -11,7 +11,7 @@
 
 // Local imports - agent runtime and storage
 import { getExecutionStore, type ExecutionKVStore } from '@agent/storage';
-import { isExtensionDeactivating } from '@agent/runtime/extensionLifecycle';
+import { shouldPreserveFlowRecord } from '@agent/runtime/flowRecordUtils';
 import type { StreamTabId } from '@agent/types/IdentifierTypes';
 import {
   registerInterruptible,
@@ -165,27 +165,22 @@ export async function runToolUseFlow<C = unknown>(
     // When VS Code reloads mid-execution, this block never runs, preserving
     // the record for sessions that were genuinely interrupted mid-wait.
     try {
-      if (isExtensionDeactivating()) {
-        logger.debug(
-          'Skipping tool-use flow record cleanup during extension deactivation',
-        );
-      } else {
-        const kv = getExecutionStore(executionId);
-        const flowRecord = await kv.read<FlowRecord>(`flow:${executionId}`);
-        const sharedState = flowRecord?.shared as
-          | { state?: { userCancelledRetry?: boolean } }
-          | undefined;
-        const userCancelledRetry =
-          sharedState?.state?.userCancelledRetry === true;
+      const kv = getExecutionStore(executionId);
+      const flowRecord = await kv.read<FlowRecord>(`flow:${executionId}`);
+      const sharedState = flowRecord?.shared as
+        | { state?: { userCancelledRetry?: boolean } }
+        | undefined;
+      const userCancelledRetry =
+        sharedState?.state?.userCancelledRetry === true;
+      const shouldPreserve = shouldPreserveFlowRecord(
+        status,
+        userCancelledRetry,
+      );
 
-        if (userCancelledRetry) {
-          // Preserve flow record for resume - user can continue from last successful breakpoint
-          logger.debug(
-            'Flow record preserved after retry cancellation for resume capability',
-          );
-        } else {
-          await kv.delete(`flow:${executionId}`);
-        }
+      if (shouldPreserve) {
+        logger.debug('Preserving tool-use flow record for resume capability');
+      } else {
+        await kv.delete(`flow:${executionId}`);
       }
     } catch {
       // Ignore cleanup errors - non-critical

--- a/src/agent/runtime/extensionLifecycle.ts
+++ b/src/agent/runtime/extensionLifecycle.ts
@@ -19,6 +19,8 @@ export function initializeExtensionLifecycle(): void {
 export function disposeExtensionLifecycle(): void {
   cleanup?.();
   cleanup = undefined;
+  initialized = false;
+  extensionIsDeactivating = false;
 }
 
 export function isExtensionDeactivating(): boolean {

--- a/src/agent/runtime/extensionLifecycle.ts
+++ b/src/agent/runtime/extensionLifecycle.ts
@@ -3,6 +3,7 @@ import { bus } from '@eventBus/ProgressEventBus';
 
 let initialized = false;
 let extensionIsDeactivating = false;
+let cleanup: (() => void) | undefined;
 
 export function initializeExtensionLifecycle(): void {
   if (initialized) {
@@ -10,9 +11,14 @@ export function initializeExtensionLifecycle(): void {
   }
   initialized = true;
 
-  bus.on('extensionDeactivating', () => {
+  cleanup = bus.on('extensionDeactivating', () => {
     extensionIsDeactivating = true;
   });
+}
+
+export function disposeExtensionLifecycle(): void {
+  cleanup?.();
+  cleanup = undefined;
 }
 
 export function isExtensionDeactivating(): boolean {

--- a/src/agent/runtime/extensionLifecycle.ts
+++ b/src/agent/runtime/extensionLifecycle.ts
@@ -10,6 +10,7 @@ export function initializeExtensionLifecycle(): void {
     return;
   }
   initialized = true;
+  extensionIsDeactivating = false;
 
   cleanup = bus.on('extensionDeactivating', () => {
     extensionIsDeactivating = true;
@@ -20,7 +21,6 @@ export function disposeExtensionLifecycle(): void {
   cleanup?.();
   cleanup = undefined;
   initialized = false;
-  extensionIsDeactivating = false;
 }
 
 export function isExtensionDeactivating(): boolean {

--- a/src/agent/runtime/extensionLifecycle.ts
+++ b/src/agent/runtime/extensionLifecycle.ts
@@ -1,0 +1,20 @@
+// Local imports - event bus
+import { bus } from '@eventBus/ProgressEventBus';
+
+let initialized = false;
+let extensionIsDeactivating = false;
+
+export function initializeExtensionLifecycle(): void {
+  if (initialized) {
+    return;
+  }
+  initialized = true;
+
+  bus.on('extensionDeactivating', () => {
+    extensionIsDeactivating = true;
+  });
+}
+
+export function isExtensionDeactivating(): boolean {
+  return extensionIsDeactivating;
+}

--- a/src/agent/runtime/flowRecordUtils.ts
+++ b/src/agent/runtime/flowRecordUtils.ts
@@ -1,0 +1,24 @@
+// Local imports - agent runtime
+import { isExtensionDeactivating } from '@agent/runtime/extensionLifecycle';
+
+// Local imports - logger
+import { END_GROUP_STATUS, type EndGroupStatus } from '@logger/messageTypes';
+
+export function shouldPreserveFlowRecord(
+  status: EndGroupStatus,
+  userCancelledRetry: boolean,
+): boolean {
+  if (isExtensionDeactivating()) {
+    return true;
+  }
+
+  if (status !== END_GROUP_STATUS.STOPPED) {
+    return true;
+  }
+
+  if (userCancelledRetry) {
+    return true;
+  }
+
+  return false;
+}

--- a/src/agent/runtime/flowRecordUtils.ts
+++ b/src/agent/runtime/flowRecordUtils.ts
@@ -8,17 +8,9 @@ export function shouldPreserveFlowRecord(
   status: EndGroupStatus,
   userCancelledRetry: boolean,
 ): boolean {
-  if (isExtensionDeactivating()) {
-    return true;
-  }
-
-  if (status !== END_GROUP_STATUS.STOPPED) {
-    return true;
-  }
-
-  if (userCancelledRetry) {
-    return true;
-  }
-
-  return false;
+  return (
+    isExtensionDeactivating() ||
+    status !== END_GROUP_STATUS.STOPPED ||
+    userCancelledRetry
+  );
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,7 +6,10 @@ import * as vscode from 'vscode';
 import dotenv from 'dotenv';
 
 // Local imports - core
-import { initializeExtensionLifecycle } from '@agent/runtime/extensionLifecycle';
+import {
+  disposeExtensionLifecycle,
+  initializeExtensionLifecycle,
+} from '@agent/runtime/extensionLifecycle';
 import { toErrorMessage } from '@common/errors/errorHandlingUtils';
 import { initializeStateManagers } from '@common/state/stateManager';
 import { SecretManager } from '@frontend/secretManager';
@@ -331,6 +334,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
 export async function deactivate() {
   disposeStatusListener?.();
+  disposeExtensionLifecycle();
 
   // Flush any pending usage logs before deactivating
   await UsageLogService.dispose();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,6 +6,7 @@ import * as vscode from 'vscode';
 import dotenv from 'dotenv';
 
 // Local imports - core
+import { initializeExtensionLifecycle } from '@agent/runtime/extensionLifecycle';
 import { toErrorMessage } from '@common/errors/errorHandlingUtils';
 import { initializeStateManagers } from '@common/state/stateManager';
 import { SecretManager } from '@frontend/secretManager';
@@ -104,6 +105,7 @@ export async function activate(context: vscode.ExtensionContext) {
   agentDirectories.initialize(context);
   await StorageFS.ensureDir(TASK_RUNS_DIR);
   initializeStateManagers(context);
+  initializeExtensionLifecycle();
   FileLister.initialize(context);
   // Initialize server-side key access with SupabaseClient as auth provider
   initializeServerSideKeyAccess(context, {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -334,15 +334,16 @@ export async function activate(context: vscode.ExtensionContext) {
 
 export async function deactivate() {
   disposeStatusListener?.();
+
+  // Notify all listeners that extension is deactivating
+  bus.emit('extensionDeactivating', undefined);
+
   disposeExtensionLifecycle();
 
   // Flush any pending usage logs before deactivating
   await UsageLogService.dispose();
 
   // PersistedFlow cleanup is handled automatically via ExecutionKVStore.
-
-  // Notify all listeners that extension is deactivating
-  bus.emit('extensionDeactivating', undefined);
 
   statusBarItem?.dispose();
   disposeDiffRefresh();


### PR DESCRIPTION
### Motivation
- Extension reloads were causing persisted tool-use and workflow flow records to be deleted, losing the ability to resume interrupted sessions and conversation state.
- Introduce a simple lifecycle flag so cleanup logic can detect an intentional extension deactivation and avoid removing resumable flow records.

### Description
- Add `src/agent/runtime/extensionLifecycle.ts` to track extension deactivation via the event bus and expose `initializeExtensionLifecycle()` and `isExtensionDeactivating()`.
- Initialize the lifecycle tracker in `activate()` by calling `initializeExtensionLifecycle()` from `src/extension.ts`.
- Guard flow-record cleanup in tool-use and reflection runners (`runToolUseFlow` and `runReflectionFlow`) to skip deleting `flow:${executionId}` when `isExtensionDeactivating()` is true, preserving resumable state.
- Minor import reordering and logging additions to make the new lifecycle checks and debug messages clear.

### Testing
- Ran `npm run format` and code was formatted successfully.
- Ran `npm run compile` and the webpack build completed successfully with a known nunjucks dynamic-dependency warning but no errors.
- Ran `npm run lint` which completed and produced only existing warnings unrelated to the new changes (no lint errors).
- Verified the new lifecycle file is created and referenced and that flow cleanup paths are now conditional on `isExtensionDeactivating()`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696105d3100883249085b2b1dccb88a3)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures persisted flow records survive intentional extension reloads to allow resuming sessions.
> 
> - Add `extensionLifecycle` with `initializeExtensionLifecycle()`, `disposeExtensionLifecycle()`, and `isExtensionDeactivating()`; subscribe to `bus` `extensionDeactivating` event and wire into `activate()`/`deactivate()`
> - Introduce `shouldPreserveFlowRecord(status, userCancelledRetry)` and use it in `runToolUseFlow` and `runReflectionFlow` to conditionally skip deleting `flow:${executionId}`; add debug logs
> - Reorder deactivation: emit `extensionDeactivating` and dispose lifecycle before other cleanup; minor import/organization updates
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5de533a0b4874140b44a1ba007a0f569aa302cd0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->