### PR TITLE
Fix excessive whitespace near button

### DIFF
--- a/src/progressView/styles/queued-follow-ups.css
+++ b/src/progressView/styles/queued-follow-ups.css
@@ -10,6 +10,11 @@
   border: 1px solid var(--vscode-inputValidation-infoBorder);
 }
 
+/* Override vscode-collapsible display to respect hidden attribute */
+.queued-follow-ups-collapsible[hidden] {
+  display: none;
+}
+
 /* Override vscode-collapsible header padding */
 .queued-follow-ups-collapsible::part(header) {
   padding: var(--spacing-small) var(--spacing-medium);


### PR DESCRIPTION
The vscode-collapsible web component overrides the hidden attribute's default display behavior. Add explicit CSS rule to ensure the component is hidden when the hidden attribute is present, fixing excessive whitespace above the follow-up input textarea.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures the queued follow-ups collapsible properly hides when `hidden` is set, removing unnecessary whitespace in the ProgressView.
> 
> - Adds CSS override `.queued-follow-ups-collapsible[hidden] { display: none; }` to counter `vscode-collapsible` default behavior
> - No logic changes; styling-only adjustment affecting spacing above the follow-up input
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cd7c87a3e03ba43fa5db7efe7395e10a173225f6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->