### PR TITLE
fix: use removeAttribute for enabling vscode-checkbox

### DIFF
--- a/src/memoryView/modules/messageHandlers.js
+++ b/src/memoryView/modules/messageHandlers.js
@@ -26,7 +26,7 @@ export class MemoryViewMessageHandler extends BaseWebviewMessageHandler {
     const toggle = safeGetElementById(ELEMENT_IDS.MEMORY_ENABLED_TOGGLE);
     if (toggle) {
       toggle.checked = message.enabled;
-      toggle.disabled = false;
+      toggle.removeAttribute('disabled');
     }
   }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adjusts how the memory view checkbox is re-enabled to ensure proper behavior with VS Code webview components.
> 
> - In `handleUpdateMemoryEnabled`, replace `toggle.disabled = false` with `toggle.removeAttribute('disabled')` to correctly re-enable `vscode-checkbox`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7d23ee826b815993a3fd23433828c9ccfb9b4693. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->