### PR TITLE
Enable thinking for reasoning model

### DIFF
--- a/src/agent/core/RunUsageAccumulator.ts
+++ b/src/agent/core/RunUsageAccumulator.ts
@@ -99,10 +99,8 @@ export class RunUsageAccumulator {
 
   recordNormalizedUsage(round: number, usage: NormalizedUsage): void {
     if (this.totals.firstInputTokens === 0) {
-      this.totals.firstInputTokens =
-        usage.inputTokens +
-        (usage.cachedInputTokens ?? 0) +
-        (usage.cacheCreationTokens ?? 0);
+      // inputTokens already includes cached tokens (total context measurement)
+      this.totals.firstInputTokens = usage.inputTokens;
     }
 
     this.totals.totalInputTokens += usage.inputTokens;

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -708,6 +708,12 @@ export class ModelHandlerAnthropic extends ModelHandler<
     }
 
     const contextWindow = this.config.contextWindow;
+
+    // Calculate total input tokens (Anthropic SDK: total = input + cache_read + cache_creation)
+    const totalInputTokens =
+      response.usage.input_tokens +
+      (response.usage.cache_read_input_tokens ?? 0) +
+      (response.usage.cache_creation_input_tokens ?? 0);
     type AppliedEdit =
       | BetaClearToolUses20250919EditResponse
       | BetaClearThinking20251015EditResponse;
@@ -727,14 +733,12 @@ export class ModelHandlerAnthropic extends ModelHandler<
           `Cleared ${clearedToolUses} tool use(s): ${clearedTokens.toLocaleString()} tokens freed (${utilizationReduction.toFixed(1)}% of context)`,
           {
             action: 'clear_tool_uses',
-            tokensBefore: response.usage.input_tokens + clearedTokens,
-            tokensAfter: response.usage.input_tokens,
+            tokensBefore: totalInputTokens + clearedTokens,
+            tokensAfter: totalInputTokens,
             contextWindow,
             utilizationBefore:
-              ((response.usage.input_tokens + clearedTokens) / contextWindow) *
-              100,
-            utilizationAfter:
-              (response.usage.input_tokens / contextWindow) * 100,
+              ((totalInputTokens + clearedTokens) / contextWindow) * 100,
+            utilizationAfter: (totalInputTokens / contextWindow) * 100,
             details: `Anthropic server-side: cleared ${clearedToolUses} tool use(s)`,
           },
         );
@@ -754,14 +758,12 @@ export class ModelHandlerAnthropic extends ModelHandler<
           `Cleared ${clearedTurns} thinking turn(s): ${clearedTokens.toLocaleString()} tokens freed (${utilizationReduction.toFixed(1)}% of context)`,
           {
             action: 'clear_thinking',
-            tokensBefore: response.usage.input_tokens + clearedTokens,
-            tokensAfter: response.usage.input_tokens,
+            tokensBefore: totalInputTokens + clearedTokens,
+            tokensAfter: totalInputTokens,
             contextWindow,
             utilizationBefore:
-              ((response.usage.input_tokens + clearedTokens) / contextWindow) *
-              100,
-            utilizationAfter:
-              (response.usage.input_tokens / contextWindow) * 100,
+              ((totalInputTokens + clearedTokens) / contextWindow) * 100,
+            utilizationAfter: (totalInputTokens / contextWindow) * 100,
             details: `Anthropic server-side: cleared ${clearedTurns} thinking turn(s)`,
           },
         );
@@ -1506,18 +1508,24 @@ export class ModelHandlerAnthropic extends ModelHandler<
       };
     }
 
-    const inputTokens = rawUsage.input_tokens ?? 0;
+    // Anthropic SDK docs: "Total input tokens in a request is the summation
+    // of `input_tokens`, `cache_creation_input_tokens`, and `cache_read_input_tokens`."
+    const baseInputTokens = rawUsage.input_tokens ?? 0;
     const outputTokens = rawUsage.output_tokens ?? 0;
     const cacheReadTokens = rawUsage.cache_read_input_tokens ?? 0;
     const cacheCreationTokens = rawUsage.cache_creation_input_tokens ?? 0;
 
-    // Calculate percentage cached
+    // Total input tokens for context measurement (includes all cached tokens)
+    const totalInputTokens =
+      baseInputTokens + cacheReadTokens + cacheCreationTokens;
+
+    // Calculate percentage cached (relative to total)
     const totalCacheTokens = cacheReadTokens + cacheCreationTokens;
     const percentageCached =
-      inputTokens > 0 ? (totalCacheTokens / inputTokens) * 100 : 0;
+      totalInputTokens > 0 ? (totalCacheTokens / totalInputTokens) * 100 : 0;
 
     return {
-      inputTokens,
+      inputTokens: totalInputTokens,
       outputTokens,
       cost: this.computePrice(rawUsage),
       responseTimeMs,


### PR DESCRIPTION
The Anthropic SDK docs state that total input tokens is the sum of `input_tokens`, `cache_creation_input_tokens`, and `cache_read_input_tokens`.

Previously, `normalizeUsage()` only used `input_tokens` for the context measurement, which underreported actual context usage when prompt caching was active (e.g., showing 8 tokens instead of 102k).

This caused:
- Misleading context utilization display (0.0% instead of ~50%)
- Client-side context management decisions based on wrong token counts

Changes:
- Calculate totalInputTokens as the sum of all three token types
- Fix percentageCached to be relative to total (not just non-cached)
- Update RunUsageAccumulator to not double-count now that inputTokens includes cached tokens

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns token accounting with Anthropic SDK totals and fixes context utilization reporting.
> 
> - Normalize usage to set `inputTokens = input_tokens + cache_read_input_tokens + cache_creation_input_tokens`; compute `percentageCached` relative to this total
> - Update context-management logs to base `tokensBefore/After` and utilization on total input tokens instead of just `input_tokens`
> - In `RunUsageAccumulator`, set `firstInputTokens` to `usage.inputTokens` (already includes cached), preventing prior double-counting
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7d927176856b9d0d6340f4be97b5aa21cba4e698. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->