### PR TITLE
Show diff after accepting manual edits

### DIFF
--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -33,7 +33,7 @@ import {
   handleProgressViewToolEditApprovalAction,
   resetToolEditApprovalSessionBypass,
 } from '@tools/approval/toolEditApproval';
-import { pathToLocation } from '@utils/files';
+import { pathToLocation, flexibleFS, createExternalLocation } from '@utils/files';
 import { isNonEmptyString } from '@utils/core';
 import { ensureRunDir, getRunDir } from '@utils/files/taskRunStorage';
 import {
@@ -65,6 +65,16 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
   vscode.WebviewView | vscode.WebviewPanel
 > {
   private readonly recordingManager: RecordingManager;
+
+  /**
+   * Stores model's original output when compare view is opened.
+   * Key: edited file path, Value: { content, streamId }
+   * Used to detect user modifications and inform the model via follow-up.
+   */
+  private readonly modelOutputBackups = new Map<
+    string,
+    { content: string; streamId: StreamTabId }
+  >();
 
   constructor(
     private readonly provider: ProgressViewProvider,
@@ -513,6 +523,18 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
   private async handleCompareOriginal(
     message: BaseFileCommandMessage,
   ): Promise<void> {
+    // Backup model's original output before user can modify it in the diff view
+    const streamId = this.provider.state.activeStream;
+    if (streamId && message.file) {
+      try {
+        const fileLocation = createExternalLocation(message.file);
+        const content = await flexibleFS.read(fileLocation);
+        this.modelOutputBackups.set(message.file, { content, streamId });
+      } catch {
+        // Ignore backup errors - don't block the compare operation
+      }
+    }
+
     await this.executeWithBaseFile(message, 'Compare original', (file, base) =>
       vscode.commands.executeCommand(
         'texra.compare',
@@ -546,6 +568,19 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
   private async handleAcceptFile(
     message: BaseFileCommandMessage,
   ): Promise<void> {
+    // Check if user modified the model's output before accepting
+    const backup = message.file ? this.modelOutputBackups.get(message.file) : null;
+    let currentContent: string | null = null;
+
+    if (backup) {
+      try {
+        const fileLocation = createExternalLocation(message.file);
+        currentContent = await flexibleFS.read(fileLocation);
+      } catch {
+        // Ignore read errors
+      }
+    }
+
     await this.executeWithBaseFile(message, 'Accept', (file, base) =>
       vscode.commands.executeCommand(
         'texra.acceptEdited',
@@ -554,6 +589,22 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
         pathToLocation(file),
       ),
     );
+
+    // Inform the model about user modifications via follow-up
+    if (backup && currentContent !== null && currentContent !== backup.content) {
+      const fileName = path.basename(message.file);
+      const followUpText = `[System: User modified the model's suggested output for "${fileName}" before accepting. The accepted version differs from the original model output.]`;
+
+      await vscode.commands.executeCommand('texra.sendFollowUp', {
+        stream: backup.streamId,
+        text: followUpText,
+      });
+    }
+
+    // Clean up backup
+    if (message.file) {
+      this.modelOutputBackups.delete(message.file);
+    }
   }
 
   private async handleMergeFile(

--- a/src/tools/EditTool.ts
+++ b/src/tools/EditTool.ts
@@ -125,7 +125,7 @@ export class EditFileTool extends defineTool({
 
     const userDiffNote = formatUnifiedApprovalUserDiff(
       targetPath,
-      finalContent,
+      updatedContent,
       appliedContent,
     );
     const output = userDiffNote

--- a/src/tools/TextEditorTool.ts
+++ b/src/tools/TextEditorTool.ts
@@ -360,7 +360,7 @@ export class TextEditorTool extends defineTool({
 
       const userDiffNote = formatUnifiedApprovalUserDiff(
         filePath,
-        finalContent,
+        proposedContent,
         appliedContent,
       );
       const output = userDiffNote
@@ -478,7 +478,7 @@ export class TextEditorTool extends defineTool({
       // Prepare success message
       const userDiffNote = formatUnifiedApprovalUserDiff(
         filePath,
-        approvedContent,
+        newFileContent,
         finalContent,
       );
       const successIntro = `The file ${filePath} has been edited.`;
@@ -597,7 +597,7 @@ export class TextEditorTool extends defineTool({
       const startLine = snippetStart + 1;
       const userDiffNote = formatUnifiedApprovalUserDiff(
         filePath,
-        approvedContent,
+        newFileContent,
         finalContent,
       );
 
@@ -688,7 +688,7 @@ export class TextEditorTool extends defineTool({
 
       const userDiffNote = formatUnifiedApprovalUserDiff(
         filePath,
-        approvedContent,
+        previousContent,
         finalContent,
       );
       const baseOutput = `Last edit to ${filePath} undone successfully. ${this.makeOutput(finalContent, filePath)}`;

--- a/src/tools/WriteTool.ts
+++ b/src/tools/WriteTool.ts
@@ -81,7 +81,7 @@ export class WriteFileTool extends defineTool({
 
     const userDiffNote = formatUnifiedApprovalUserDiff(
       input.path,
-      finalContent,
+      proposedContent,
       appliedContent,
     );
     const output = userDiffNote ? `written\n\n${userDiffNote}` : 'written';

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -712,13 +712,17 @@ export async function handleProgressViewToolEditApprovalAction(
   }
 
   if (payload.action === 'approve') {
-    entry.settle({ accepted: true });
+    // Read the current content from the proposed file - user may have modified it in the diff view
+    const appliedContent = await fs.readFile(entry.proposedUri.fsPath, 'utf-8');
+    entry.settle({ accepted: true, appliedContent });
     return;
   }
 
   if (payload.action === 'approveAll') {
     enableSessionApprovalBypass();
-    entry.settle({ accepted: true });
+    // Read the current content from the proposed file - user may have modified it in the diff view
+    const appliedContent = await fs.readFile(entry.proposedUri.fsPath, 'utf-8');
+    entry.settle({ accepted: true, appliedContent });
     return;
   }
 

--- a/src/tools/fileOp.ts
+++ b/src/tools/fileOp.ts
@@ -94,7 +94,7 @@ export class FileOpTool extends defineTool({
 
         const userDiffNote = formatUnifiedApprovalUserDiff(
           path,
-          finalContent,
+          proposed,
           appliedContent,
         );
 
@@ -166,7 +166,7 @@ export class FileOpTool extends defineTool({
         const appliedContent = await WorkspaceFS.read(path);
         const userDiffNote = formatUnifiedApprovalUserDiff(
           path,
-          finalContent,
+          proposedContent,
           appliedContent,
         );
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Highlights user modifications between suggested and accepted edits and makes them visible to both the UI and the model.
> 
> - **Progress view**: When opening `Compare original`, backs up the model’s suggested file content. On **Accept**, compares the current file to the backup; if changed, sends a follow-up note to the model indicating the user modified the suggestion. Adds `flexibleFS`/`createExternalLocation` reads and cleans up backups.
> - **Approval flow**: On `approve`/`approveAll`, reads the content from the proposed temp file to capture any in-diff manual edits (`appliedContent`) before settling, ensuring accurate patches and line-change summaries.
> - **Tools**: Standardize `formatUnifiedApprovalUserDiff` calls to use `suggested/proposed` vs `applied` content (EditTool, TextEditorTool: create/str_replace/insert/undo, WriteTool, FileOp write/append), fixing previously inverted arguments so user adjustments display correctly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7c420361acd0899eae29eb4b9f65e2921f4aaac2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->