### PR TITLE
Format large token counts with millions abbreviation

### DIFF
--- a/src/progressView/modules/formatters/timestampUtils.js
+++ b/src/progressView/modules/formatters/timestampUtils.js
@@ -49,11 +49,17 @@ export const formatTimestamp = (date) => {
 };
 
 /**
- * Format token counts, displaying values in "k" units when exceeding 4096.
+ * Format token counts for display.
+ * - Values >= 100,000 display as "M" (millions), e.g., "1.2M"
+ * - Values > 4096 display as "k" (thousands), e.g., "50k"
+ * - Values <= 4096 display as raw numbers
  * @param {number} tokens - Raw token count
  * @returns {string} Formatted token count
  */
 export const formatTokens = (tokens) => {
+  if (tokens >= 100_000) {
+    return `${(tokens / 1_000_000).toFixed(1)}M`;
+  }
   return tokens > 4096 ? `${Math.round(tokens / 1000)}k` : `${tokens}`;
 };
 


### PR DESCRIPTION
Updated formatTokens() to display large values more readably:
- Values >= 100,000 now show as "X.XM" (e.g., "8.1M" instead of "8087k")
- Values > 4096 continue to show as "Xk" (e.g., "50k")
- Values <= 4096 display as raw numbers

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds millions-scale abbreviation for token counts.
> 
> - Updates `formatTokens` in `timestampUtils.js` to format values >= `100,000` as `M` (e.g., `1.2M`), retains `k` for > `4096`, and raw numbers otherwise
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ccdb2082942daa493e382e5783935407b578c190. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->