### PR TITLE
Fix CSS layout and excessive white space

### DIFF
--- a/src/progressView/styles/follow-up-input.css
+++ b/src/progressView/styles/follow-up-input.css
@@ -3,34 +3,30 @@
  * Minimal styling for the user input area
  */
 
-/* Follow-up input container - uses CSS Grid for consistent column alignment */
+/* Follow-up input container */
 .follow-up-container {
   display: none;
-  grid-template-columns: 1fr auto;
+  flex-direction: column;
   padding: var(--spacing-medium);
   border-top: 1px solid var(--color-border);
   gap: var(--spacing-small);
 }
 
 .follow-up-container.is-visible {
-  display: grid;
+  display: flex;
 }
 
-/* Queued messages span only the main content column */
-.follow-up-container > .queued-follow-ups-collapsible {
-  grid-column: 1;
-}
-
-/* Input row children participate directly in grid */
+/* Row container for textarea and action buttons */
 .follow-up-input-row {
-  display: contents;
+  display: flex;
+  align-items: flex-end;
+  gap: var(--spacing-small);
 }
 
 /* Style the textarea for multi-line input */
 #followUpInput {
   display: block;
-  grid-column: 1;
-  align-self: end;
+  flex: 1;
   line-height: 1.4;
   min-height: 106px;
   max-height: var(--height-xlarge);
@@ -49,7 +45,6 @@ vscode-toolbar-container.follow-up-actions {
   display: flex;
   flex-direction: column !important;
   align-items: center;
-  align-self: end;
   gap: var(--spacing-small);
 }
 

--- a/src/progressView/styles/follow-up-input.css
+++ b/src/progressView/styles/follow-up-input.css
@@ -21,12 +21,14 @@
   display: flex;
   align-items: flex-end;
   gap: var(--spacing-small);
+  width: 100%;
 }
 
 /* Style the textarea for multi-line input */
 #followUpInput {
   display: block;
   flex: 1;
+  min-width: 0; /* Allow shrinking below default 320px */
   line-height: 1.4;
   min-height: 106px;
   max-height: var(--height-xlarge);
@@ -46,9 +48,4 @@ vscode-toolbar-container.follow-up-actions {
   flex-direction: column !important;
   align-items: center;
   gap: var(--spacing-small);
-}
-
-.follow-up-actions vscode-button,
-.follow-up-actions vscode-toolbar-button {
-  /* Remove margin-bottom since we're using gap in flex column */
 }

--- a/src/progressView/styles/queued-follow-ups.css
+++ b/src/progressView/styles/queued-follow-ups.css
@@ -5,6 +5,7 @@
 
 /* Collapsible container styling */
 .queued-follow-ups-collapsible {
+  width: 100%;
   border-radius: var(--radius);
   background-color: var(--vscode-inputValidation-infoBackground);
   border: 1px solid var(--vscode-inputValidation-infoBorder);


### PR DESCRIPTION
The CSS Grid layout with grid-column: 1 restricted the queued follow-ups collapsible to only the first column, creating excessive whitespace.

Revert to the flexbox approach from commit 9495ca3 where:
- Container uses flex-direction: column
- Queued collapsible naturally spans full width
- Input row uses nested flex for textarea + buttons

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Simplifies layout to remove excess whitespace and improve responsiveness in ProgressView.
> 
> - Reworks `follow-up-input.css` from CSS Grid to Flexbox: `follow-up-container` now `display: flex` with column direction; new `follow-up-input-row` flex layout; textarea made flexible with `flex: 1` and `min-width: 0`; action buttons stack via `.follow-up-actions` with forced column direction
> - Ensures `queued-follow-ups.css` collapsible spans full width by adding `width: 100%` to `.queued-follow-ups-collapsible`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c7c6d4970c4812080566ef3416b4b520e21c14d1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->