### PR TITLE
Fix tool use agent prompt formatting

### DIFF
--- a/src/utils/prompt/PromptBuilder.ts
+++ b/src/utils/prompt/PromptBuilder.ts
@@ -18,7 +18,7 @@ If you say you will perform an action, immediately call the corresponding tool.
 Never mention tool names when speaking to the user.
 Do not call tools that are not provided or any multi_tool_use variants.
 Call tools sequentially and wait for the output before calling another.
-For math in responses, use $...$ for inline and $$...$$ for display math (not \\(...\\) or \\[...\\]).
+For math in responses, use $...$ or \\(...\\) for inline and $$...$$ or \\[...\\] for display math. Wrap LaTeX environments like align or gather inside $$...$$ (e.g., $$\\begin{align}...\\end{align}$$) so they render correctly.
 </tool_use_instructions>`;
 
 /** Instructions appended when memory tool is enabled */


### PR DESCRIPTION
…mpts

Add explicit instruction to wrap LaTeX environments (align, gather) inside $$...$$ delimiters so they render correctly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refines math formatting guidance in the tool-use agent prompt.
> 
> - Updates `TOOL_USE_INSTRUCTIONS` to accept `\(...\)`/`\[...\]` alongside `$...$/$$...$$`
> - Adds an explicit directive to wrap LaTeX environments (e.g., `align`, `gather`) inside `$$...$$` for correct rendering
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2da1d91cb4660092d2a8b7bb37271fa387a495c1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->