### PR TITLE
Add context management message type

### DIFF
--- a/src/agent/modelHandlers/contextManagementConstants.ts
+++ b/src/agent/modelHandlers/contextManagementConstants.ts
@@ -14,3 +14,49 @@
  * Set to 0 to disable context management entirely.
  */
 export const DEFAULT_COMPACTION_THRESHOLD_PERCENT = 75;
+
+/**
+ * Minimum completion tokens to ensure the model can produce output.
+ * Used when reducing max tokens due to context pressure.
+ */
+export const MIN_COMPLETION_TOKENS = 100;
+
+/**
+ * Safety buffer subtracted from available tokens.
+ * Used by handlers that perform exact token counting (Anthropic, Google).
+ */
+export const TOKEN_SAFETY_BUFFER = 10;
+
+/**
+ * Larger safety buffer for heuristic token counting (OpenAI).
+ * Accounts for estimation uncertainty.
+ */
+export const HEURISTIC_TOKEN_BUFFER = 5000;
+
+/**
+ * Compute reduced max tokens when context pressure requires adjustment.
+ * Ensures minimum completion tokens while respecting available space.
+ *
+ * @param availableTokens - Tokens available for output (contextWindow - inputTokens)
+ * @param tokenBuffer - Safety buffer to subtract (default: TOKEN_SAFETY_BUFFER)
+ * @returns Reduced max tokens value (minimum 1)
+ */
+export function computeReducedMaxTokens(
+  availableTokens: number,
+  tokenBuffer: number = TOKEN_SAFETY_BUFFER,
+): number {
+  // If no space available, force to minimum (1 token)
+  if (availableTokens <= 0) {
+    return 1;
+  }
+
+  // Apply buffer and enforce minimum
+  const buffered = availableTokens - tokenBuffer;
+
+  // If buffered value is below minimum, use all available space (skip buffer)
+  if (buffered < MIN_COMPLETION_TOKENS) {
+    return Math.max(1, availableTokens);
+  }
+
+  return Math.max(MIN_COMPLETION_TOKENS, buffered);
+}

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -488,12 +488,26 @@ export class ModelHandlerAnthropic extends ModelHandler<
             throw new Error(errMsg);
           }
           if (effectiveContextWindow - inputTokens < options.max_tokens) {
+            const MIN_COMPLETION_TOKENS = 100;
+            const originalMaxTokens = options.max_tokens;
             const reducedMaxTokens = Math.max(
-              0,
+              MIN_COMPLETION_TOKENS,
               effectiveContextWindow - inputTokens - 10,
             );
-            const warnMsg = `Token count of message plus max tokens exceeds context window: ${inputTokens} + ${options.max_tokens} > ${effectiveContextWindow}. Reducing max tokens to ${reducedMaxTokens}.`;
-            this.logger.warn(warnMsg);
+            const utilizationPercent =
+              (inputTokens / effectiveContextWindow) * 100;
+            this.logger.logContextManagement(
+              `Token count of message plus max tokens exceeds context window: ${inputTokens} + ${originalMaxTokens} > ${effectiveContextWindow}. Reducing max tokens to ${reducedMaxTokens}.`,
+              {
+                action: 'max_tokens_reduced',
+                tokensBefore: inputTokens,
+                contextWindow: effectiveContextWindow,
+                utilizationBefore: utilizationPercent,
+                originalMaxTokens,
+                reducedMaxTokens,
+                details: 'Anthropic: max_tokens reduced to fit context window',
+              },
+            );
             options.max_tokens = reducedMaxTokens;
 
             if (

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -85,7 +85,11 @@ import {
 import { ANTHROPIC_STOP } from './types/StopReasonTypes';
 import { toAnthropicTools } from './toolConversion';
 import { executeRequest } from './utils/requestExecutor';
-import { DEFAULT_COMPACTION_THRESHOLD_PERCENT } from './contextManagementConstants';
+import {
+  DEFAULT_COMPACTION_THRESHOLD_PERCENT,
+  computeReducedMaxTokens,
+  TOKEN_SAFETY_BUFFER,
+} from './contextManagementConstants';
 import {
   extractAnthropicWebSearchResults,
   isAnthropicServerToolContent,
@@ -487,12 +491,12 @@ export class ModelHandlerAnthropic extends ModelHandler<
             this.logger.error(errMsg);
             throw new Error(errMsg);
           }
-          if (effectiveContextWindow - inputTokens < options.max_tokens) {
-            const MIN_COMPLETION_TOKENS = 100;
+          const availableTokens = effectiveContextWindow - inputTokens;
+          if (availableTokens < options.max_tokens) {
             const originalMaxTokens = options.max_tokens;
-            const reducedMaxTokens = Math.max(
-              MIN_COMPLETION_TOKENS,
-              effectiveContextWindow - inputTokens - 10,
+            const reducedMaxTokens = computeReducedMaxTokens(
+              availableTokens,
+              TOKEN_SAFETY_BUFFER,
             );
             const utilizationPercent =
               (inputTokens / effectiveContextWindow) * 100;

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -75,6 +75,10 @@ import {
 } from './utils/toolAttachmentUtils';
 import { executeRequest } from './utils/requestExecutor';
 import { toGoogleTools } from './toolConversion';
+import {
+  computeReducedMaxTokens,
+  TOKEN_SAFETY_BUFFER,
+} from './contextManagementConstants';
 
 // Type imports
 import type { MediaFileResult } from './support/MediaAttachmentProcessor';
@@ -479,11 +483,11 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
           );
         }
         const originalMaxTokens = generationConfig.maxOutputTokens ?? 8192;
-        if (this.config.contextWindow - totalTokens < originalMaxTokens) {
-          const MIN_COMPLETION_TOKENS = 100;
-          const reducedMaxTokens = Math.max(
-            MIN_COMPLETION_TOKENS,
-            this.config.contextWindow - totalTokens - 10,
+        const availableTokens = this.config.contextWindow - totalTokens;
+        if (availableTokens < originalMaxTokens) {
+          const reducedMaxTokens = computeReducedMaxTokens(
+            availableTokens,
+            TOKEN_SAFETY_BUFFER,
           );
           const utilizationPercent =
             (totalTokens / this.config.contextWindow) * 100;

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -478,15 +478,28 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
             `Token count of message exceeds context window: ${totalTokens} > ${this.config.contextWindow}`,
           );
         }
-        if (
-          this.config.contextWindow - totalTokens <
-          (generationConfig.maxOutputTokens ?? 8192)
-        ) {
-          this.logger.warn(
-            `Token count of message plus max tokens exceeds context window: ${totalTokens} + ${generationConfig.maxOutputTokens} > ${this.config.contextWindow}. Reducing max tokens to ${this.config.contextWindow - totalTokens}.`,
+        const originalMaxTokens = generationConfig.maxOutputTokens ?? 8192;
+        if (this.config.contextWindow - totalTokens < originalMaxTokens) {
+          const MIN_COMPLETION_TOKENS = 100;
+          const reducedMaxTokens = Math.max(
+            MIN_COMPLETION_TOKENS,
+            this.config.contextWindow - totalTokens - 10,
           );
-          generationConfig.maxOutputTokens =
-            this.config.contextWindow - totalTokens - 10;
+          const utilizationPercent =
+            (totalTokens / this.config.contextWindow) * 100;
+          this.logger.logContextManagement(
+            `Token count of message plus max tokens exceeds context window: ${totalTokens} + ${originalMaxTokens} > ${this.config.contextWindow}. Reducing max tokens to ${reducedMaxTokens}.`,
+            {
+              action: 'max_tokens_reduced',
+              tokensBefore: totalTokens,
+              contextWindow: this.config.contextWindow,
+              utilizationBefore: utilizationPercent,
+              originalMaxTokens,
+              reducedMaxTokens,
+              details: 'Google: maxOutputTokens reduced to fit context window',
+            },
+          );
+          generationConfig.maxOutputTokens = reducedMaxTokens;
         }
       } catch (err) {
         // Re-throw context window violations - these are intentional validation errors

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -64,6 +64,10 @@ import {
 } from './utils/toolAttachmentUtils';
 import { executeRequest } from './utils/requestExecutor';
 import { ModelHandler } from './ModelHandler';
+import {
+  computeReducedMaxTokens,
+  HEURISTIC_TOKEN_BUFFER,
+} from './contextManagementConstants';
 import type {
   CreateResponseOptions,
   ExtractResponseResult,
@@ -232,45 +236,32 @@ export class ModelHandlerOpenAI<
         this.config.contextWindow - approximateInputTokens;
       const currentMax = baseParams[maxOutputKey];
       if (typeof currentMax === 'number' && availableTokens < currentMax) {
-        const TOKEN_BUFFER = 5000;
-        const MIN_COMPLETION_TOKENS = 100;
         const utilizationPercent =
           (approximateInputTokens / this.config.contextWindow) * 100;
+        const reducedMaxTokens = computeReducedMaxTokens(
+          availableTokens,
+          HEURISTIC_TOKEN_BUFFER,
+        );
+        baseParams[maxOutputKey] = reducedMaxTokens;
 
-        if (availableTokens <= 0) {
-          baseParams[maxOutputKey] = 1;
-          this.logger.logContextManagement(
-            `Approximate token count (${approximateInputTokens}) already exceeds context window (${this.config.contextWindow}). Forcing ${maxOutputKey} to 1 token.`,
-            {
-              action: 'max_tokens_reduced',
-              tokensBefore: approximateInputTokens,
-              contextWindow: this.config.contextWindow,
-              utilizationBefore: utilizationPercent,
-              originalMaxTokens: currentMax,
-              reducedMaxTokens: 1,
-              details: `OpenAI: ${maxOutputKey} forced to 1 due to context overflow`,
-            },
-          );
-        } else {
-          const adjustedWithBuffer = Math.max(
-            MIN_COMPLETION_TOKENS,
-            availableTokens - TOKEN_BUFFER,
-          );
-          const adjusted = Math.min(availableTokens, adjustedWithBuffer);
-          baseParams[maxOutputKey] = adjusted;
-          this.logger.logContextManagement(
-            `Approximate token count (${approximateInputTokens}) + max tokens (${currentMax}) exceeds context window (${this.config.contextWindow}). Reducing ${maxOutputKey} to ${adjusted}.`,
-            {
-              action: 'max_tokens_reduced',
-              tokensBefore: approximateInputTokens,
-              contextWindow: this.config.contextWindow,
-              utilizationBefore: utilizationPercent,
-              originalMaxTokens: currentMax,
-              reducedMaxTokens: adjusted,
-              details: `OpenAI: ${maxOutputKey} reduced to fit context window`,
-            },
-          );
-        }
+        const detailsMsg =
+          availableTokens <= 0
+            ? `OpenAI: ${maxOutputKey} forced to 1 due to context overflow`
+            : `OpenAI: ${maxOutputKey} reduced to fit context window`;
+        const logMsg =
+          availableTokens <= 0
+            ? `Approximate token count (${approximateInputTokens}) already exceeds context window (${this.config.contextWindow}). Forcing ${maxOutputKey} to ${reducedMaxTokens} token.`
+            : `Approximate token count (${approximateInputTokens}) + max tokens (${currentMax}) exceeds context window (${this.config.contextWindow}). Reducing ${maxOutputKey} to ${reducedMaxTokens}.`;
+
+        this.logger.logContextManagement(logMsg, {
+          action: 'max_tokens_reduced',
+          tokensBefore: approximateInputTokens,
+          contextWindow: this.config.contextWindow,
+          utilizationBefore: utilizationPercent,
+          originalMaxTokens: currentMax,
+          reducedMaxTokens,
+          details: detailsMsg,
+        });
       }
     } catch (err) {
       // Re-throw context window violations - these are intentional validation errors

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -234,11 +234,22 @@ export class ModelHandlerOpenAI<
       if (typeof currentMax === 'number' && availableTokens < currentMax) {
         const TOKEN_BUFFER = 5000;
         const MIN_COMPLETION_TOKENS = 100;
+        const utilizationPercent =
+          (approximateInputTokens / this.config.contextWindow) * 100;
 
         if (availableTokens <= 0) {
           baseParams[maxOutputKey] = 1;
-          this.logger.warn(
+          this.logger.logContextManagement(
             `Approximate token count (${approximateInputTokens}) already exceeds context window (${this.config.contextWindow}). Forcing ${maxOutputKey} to 1 token.`,
+            {
+              action: 'max_tokens_reduced',
+              tokensBefore: approximateInputTokens,
+              contextWindow: this.config.contextWindow,
+              utilizationBefore: utilizationPercent,
+              originalMaxTokens: currentMax,
+              reducedMaxTokens: 1,
+              details: `OpenAI: ${maxOutputKey} forced to 1 due to context overflow`,
+            },
           );
         } else {
           const adjustedWithBuffer = Math.max(
@@ -247,8 +258,17 @@ export class ModelHandlerOpenAI<
           );
           const adjusted = Math.min(availableTokens, adjustedWithBuffer);
           baseParams[maxOutputKey] = adjusted;
-          this.logger.warn(
+          this.logger.logContextManagement(
             `Approximate token count (${approximateInputTokens}) + max tokens (${currentMax}) exceeds context window (${this.config.contextWindow}). Reducing ${maxOutputKey} to ${adjusted}.`,
+            {
+              action: 'max_tokens_reduced',
+              tokensBefore: approximateInputTokens,
+              contextWindow: this.config.contextWindow,
+              utilizationBefore: utilizationPercent,
+              originalMaxTokens: currentMax,
+              reducedMaxTokens: adjusted,
+              details: `OpenAI: ${maxOutputKey} reduced to fit context window`,
+            },
           );
         }
       }

--- a/src/logger/AgentLogger.ts
+++ b/src/logger/AgentLogger.ts
@@ -28,17 +28,29 @@ import type {
 import type { LogOptions } from './logOptions';
 
 /**
+ * Context management actions that can be logged.
+ * - compaction: OpenAI conversation compaction
+ * - clear_tool_uses: Anthropic server-side tool use clearing
+ * - clear_thinking: Anthropic server-side thinking clearing
+ * - truncation: Generic message/context truncation
+ * - max_tokens_reduced: Max output tokens reduced due to context pressure
+ */
+export const ContextManagementAction = z.enum([
+  'compaction',
+  'clear_tool_uses',
+  'clear_thinking',
+  'truncation',
+  'max_tokens_reduced',
+]);
+export type ContextManagementAction = z.infer<typeof ContextManagementAction>;
+
+/**
  * Context management event data for logging compaction, truncation, etc.
  * Schema-first definition following project conventions (CLAUDE.md).
  */
 export const ContextManagementDataSchema = z.object({
   /** Type of context management action */
-  action: z.enum([
-    'compaction',
-    'clear_tool_uses',
-    'clear_thinking',
-    'truncation',
-  ]),
+  action: ContextManagementAction,
   /** Tokens before the action */
   tokensBefore: z.number().nonnegative(),
   /** Tokens after the action (if known) */
@@ -51,6 +63,10 @@ export const ContextManagementDataSchema = z.object({
   utilizationAfter: z.number().nonnegative().optional(),
   /** Provider-specific details */
   details: z.string().optional(),
+  /** Original max tokens before reduction (for max_tokens_reduced action) */
+  originalMaxTokens: z.number().positive().optional(),
+  /** Reduced max tokens after adjustment (for max_tokens_reduced action) */
+  reducedMaxTokens: z.number().positive().optional(),
 });
 
 export type ContextManagementData = z.infer<typeof ContextManagementDataSchema>;

--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -439,6 +439,16 @@
               <div class="statistics-content detail-content"></div>
             </details>
           </template>
+          <template id="contextManagementTemplate">
+            <details class="context-management-details detail-section">
+              <summary class="details-summary">
+                <i class="toggle-icon"></i>
+                <i class="codicon codicon-history context-management-icon"></i>
+                <span class="context-management-title">Context Management</span>
+              </summary>
+              <div class="context-management-content detail-content"></div>
+            </details>
+          </template>
           <template id="groupDetailsTemplate">
             <div class="log-group">
               <div class="log-group-content"></div>

--- a/src/progressView/modules/formatters/index.js
+++ b/src/progressView/modules/formatters/index.js
@@ -60,6 +60,7 @@ import {
   formatLatexdiff,
   formatStatistics,
 } from './logFormatters/dataFormatters.js';
+import { formatContextManagement } from './logFormatters/contextManagementFormatters.js';
 import {
   formatUserMessage,
   formatProgressStatus,
@@ -121,6 +122,7 @@ export class LogEntryFormatter {
       missingOutputs: safe(withPayloadAndId(formatMissingOutputs), 'missing outputs'),
       latexdiff: safe(withPayloadAndId(formatLatexdiff), 'latexdiff'),
       statistics: safe(withPayloadAndId(formatStatistics), 'statistics'),
+      contextManagement: safe(withPayloadAndId(formatContextManagement), 'context management'),
       // Context state is displayed in the footer, not inline in logs
       contextState: () => null,
       userMessage: safe(

--- a/src/progressView/modules/formatters/index.js
+++ b/src/progressView/modules/formatters/index.js
@@ -85,23 +85,31 @@ export class LogEntryFormatter {
 
   _buildFormatterMap() {
     // Helper to wrap formatter functions with error handling
-    const safe = (fn, label) => (message) => safeFormat(() => fn(message), label);
+    const safe = (fn, label) => (message) =>
+      safeFormat(() => fn(message), label);
 
     // Common pattern extractors for cleaner formatter definitions
     const withPayloadAndMeta = (fn) => (message) =>
-      fn(message.normalizedPayload, message.id, message.groupId, message.timestamp);
+      fn(
+        message.normalizedPayload,
+        message.id,
+        message.groupId,
+        message.timestamp,
+      );
     const withPayloadAndId = (fn) => (message) =>
       fn(message.normalizedPayload, message.id);
 
     return {
       thinking: safe(
         withPayloadAndMeta((payload, id, groupId, ts) =>
-          formatBannerContent(payload, 'Thinking', id, groupId, ts)),
+          formatBannerContent(payload, 'Thinking', id, groupId, ts),
+        ),
         'thinking',
       ),
       scratchpad: safe(
         withPayloadAndMeta((payload, id, groupId, ts) =>
-          formatBannerContent(payload, 'Scratchpad', id, groupId, ts)),
+          formatBannerContent(payload, 'Scratchpad', id, groupId, ts),
+        ),
         'scratchpad',
       ),
       toolUse: safe(withPayloadAndMeta(formatToolUse), 'tool use'),
@@ -119,18 +127,31 @@ export class LogEntryFormatter {
         'Assistant',
       ),
       fileList: safe(withPayloadAndId(formatFileList), 'file list'),
-      missingOutputs: safe(withPayloadAndId(formatMissingOutputs), 'missing outputs'),
+      missingOutputs: safe(
+        withPayloadAndId(formatMissingOutputs),
+        'missing outputs',
+      ),
       latexdiff: safe(withPayloadAndId(formatLatexdiff), 'latexdiff'),
       statistics: safe(withPayloadAndId(formatStatistics), 'statistics'),
-      contextManagement: safe(withPayloadAndId(formatContextManagement), 'context management'),
+      contextManagement: safe(
+        withPayloadAndId(formatContextManagement),
+        'context management',
+      ),
       // Context state is displayed in the footer, not inline in logs
       contextState: () => null,
       userMessage: safe(
         (message) =>
-          formatUserMessage(message.normalizedPayload, message.id, message.timestamp),
+          formatUserMessage(
+            message.normalizedPayload,
+            message.id,
+            message.timestamp,
+          ),
         'user message',
       ),
-      progressStatus: safe((message) => formatProgressStatus(message), 'progress status'),
+      progressStatus: safe(
+        (message) => formatProgressStatus(message),
+        'progress status',
+      ),
       error: safe((message) => formatError(message), 'error'),
     };
   }

--- a/src/progressView/modules/formatters/logFormatters/contextManagementFormatters.js
+++ b/src/progressView/modules/formatters/logFormatters/contextManagementFormatters.js
@@ -54,7 +54,7 @@ export const formatContextManagement = (normalizedPayload, logId) => {
   initToggleIcon(element, false);
 
   const parsed = normalizedPayload?.structured;
-  if (!parsed || typeof parsed !== 'object') {
+  if (parsed === null || typeof parsed !== 'object') {
     return null;
   }
 
@@ -98,7 +98,11 @@ export const formatContextManagement = (normalizedPayload, logId) => {
   };
 
   // For max_tokens_reduced, show the reduction
-  if (action === 'max_tokens_reduced' && originalMaxTokens && reducedMaxTokens) {
+  if (
+    action === 'max_tokens_reduced' &&
+    originalMaxTokens &&
+    reducedMaxTokens
+  ) {
     pushItem(
       'codicon-arrow-down',
       'Max tokens reduced',
@@ -108,25 +112,24 @@ export const formatContextManagement = (normalizedPayload, logId) => {
 
   // For clearing actions, show tokens freed
   if (
-    (action === 'clear_tool_uses' || action === 'clear_thinking' || action === 'compaction') &&
+    (action === 'clear_tool_uses' ||
+      action === 'clear_thinking' ||
+      action === 'compaction') &&
     tokensBefore !== undefined &&
     tokensAfter !== undefined
   ) {
     const tokensFreed = tokensBefore - tokensAfter;
     if (tokensFreed > 0) {
-      pushItem(
-        'codicon-dash',
-        'Tokens freed',
-        formatTokens(tokensFreed),
-      );
+      pushItem('codicon-dash', 'Tokens freed', formatTokens(tokensFreed));
     }
   }
 
   // Show context utilization
   if (utilizationBefore !== undefined) {
-    const utilizationDisplay = utilizationAfter !== undefined
-      ? `${utilizationBefore.toFixed(1)}% → ${utilizationAfter.toFixed(1)}%`
-      : `${utilizationBefore.toFixed(1)}%`;
+    const utilizationDisplay =
+      utilizationAfter !== undefined
+        ? `${utilizationBefore.toFixed(1)}% → ${utilizationAfter.toFixed(1)}%`
+        : `${utilizationBefore.toFixed(1)}%`;
     pushItem('codicon-pie-chart', 'Context utilization', utilizationDisplay);
   }
 

--- a/src/progressView/modules/formatters/logFormatters/contextManagementFormatters.js
+++ b/src/progressView/modules/formatters/logFormatters/contextManagementFormatters.js
@@ -1,0 +1,149 @@
+/**
+ * Context management message formatters.
+ * Displays context management events (compaction, clearing, max_tokens reduction)
+ * as native UI elements in the progress view.
+ */
+
+import { createFromTemplate } from '@common/templateUtils.js';
+import { initToggleIcon } from '../htmlBuilders.js';
+import { formatTokens } from '../timestampUtils.js';
+
+/**
+ * Action display configuration
+ * @type {Record<string, {icon: string, label: string, color: string}>}
+ */
+const ACTION_CONFIG = {
+  compaction: {
+    icon: 'codicon-fold',
+    label: 'Compacted',
+    color: 'var(--vscode-charts-blue)',
+  },
+  clear_tool_uses: {
+    icon: 'codicon-trash',
+    label: 'Cleared Tool Uses',
+    color: 'var(--vscode-charts-green)',
+  },
+  clear_thinking: {
+    icon: 'codicon-lightbulb',
+    label: 'Cleared Thinking',
+    color: 'var(--vscode-charts-green)',
+  },
+  truncation: {
+    icon: 'codicon-ellipsis',
+    label: 'Truncated',
+    color: 'var(--vscode-charts-orange)',
+  },
+  max_tokens_reduced: {
+    icon: 'codicon-arrow-small-down',
+    label: 'Max Tokens Reduced',
+    color: 'var(--vscode-charts-yellow)',
+  },
+};
+
+/**
+ * Format context management event for display
+ * @param {object} normalizedPayload - Normalized payload with structured data
+ * @param {string} logId - Log entry ID
+ * @returns {HTMLElement|null} Context management element or null
+ */
+export const formatContextManagement = (normalizedPayload, logId) => {
+  const element = createFromTemplate('contextManagementTemplate');
+  if (!element) return null;
+
+  const contentElem = element.querySelector('.context-management-content');
+  initToggleIcon(element, false);
+
+  const parsed = normalizedPayload?.structured;
+  if (!parsed || typeof parsed !== 'object') {
+    return null;
+  }
+
+  const {
+    action,
+    tokensBefore,
+    tokensAfter,
+    contextWindow,
+    utilizationBefore,
+    utilizationAfter,
+    originalMaxTokens,
+    reducedMaxTokens,
+    details,
+  } = parsed;
+
+  const config = ACTION_CONFIG[action] || {
+    icon: 'codicon-history',
+    label: action || 'Context Management',
+    color: 'var(--vscode-foreground)',
+  };
+
+  // Update the icon and title
+  const iconElem = element.querySelector('.context-management-icon');
+  if (iconElem) {
+    iconElem.className = `codicon ${config.icon} context-management-icon`;
+    iconElem.style.color = config.color;
+  }
+
+  const titleElem = element.querySelector('.context-management-title');
+  if (titleElem) {
+    titleElem.textContent = config.label;
+    titleElem.style.color = config.color;
+  }
+
+  // Build stat items
+  const items = [];
+  const pushItem = (icon, label, value, suffix = '') => {
+    items.push(
+      `<span class="stat-item detail-item" title="${label}"><i class="codicon ${icon}"></i> ${value}${suffix}</span>`,
+    );
+  };
+
+  // For max_tokens_reduced, show the reduction
+  if (action === 'max_tokens_reduced' && originalMaxTokens && reducedMaxTokens) {
+    pushItem(
+      'codicon-arrow-down',
+      'Max tokens reduced',
+      `${formatTokens(originalMaxTokens)} → ${formatTokens(reducedMaxTokens)}`,
+    );
+  }
+
+  // For clearing actions, show tokens freed
+  if (
+    (action === 'clear_tool_uses' || action === 'clear_thinking' || action === 'compaction') &&
+    tokensBefore !== undefined &&
+    tokensAfter !== undefined
+  ) {
+    const tokensFreed = tokensBefore - tokensAfter;
+    if (tokensFreed > 0) {
+      pushItem(
+        'codicon-dash',
+        'Tokens freed',
+        formatTokens(tokensFreed),
+      );
+    }
+  }
+
+  // Show context utilization
+  if (utilizationBefore !== undefined) {
+    const utilizationDisplay = utilizationAfter !== undefined
+      ? `${utilizationBefore.toFixed(1)}% → ${utilizationAfter.toFixed(1)}%`
+      : `${utilizationBefore.toFixed(1)}%`;
+    pushItem('codicon-pie-chart', 'Context utilization', utilizationDisplay);
+  }
+
+  // Show context window
+  if (contextWindow !== undefined) {
+    pushItem('codicon-window', 'Context window', formatTokens(contextWindow));
+  }
+
+  // Show details if present
+  if (details) {
+    pushItem('codicon-info', 'Details', details);
+  }
+
+  if (contentElem) {
+    contentElem.innerHTML = items.join('');
+    if (logId) contentElem.dataset.logId = logId;
+  }
+
+  return element;
+};

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -237,7 +237,11 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
    */
   _resolveSessionKind(streamInfo) {
     if (!streamInfo) return state.activeSessionKind || 'workflow';
-    return streamInfo.agentSessionKind || streamInfo.uiTraits?.sessionKind || 'workflow';
+    return (
+      streamInfo.agentSessionKind ||
+      streamInfo.uiTraits?.sessionKind ||
+      'workflow'
+    );
   }
 
   /**
@@ -405,7 +409,9 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
 
     this._updatePlaceholderVisibility();
 
-    const activeStreamInfo = streams.find((s) => s.name === message.activeStream);
+    const activeStreamInfo = streams.find(
+      (s) => s.name === message.activeStream,
+    );
     const sessionKind = this._resolveSessionKind(activeStreamInfo);
     const isToolAgent = sessionKind === 'toolUse';
 
@@ -533,7 +539,9 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       if (parentGroups.length > 0) {
         const runIds = parentGroups.map((g) => g.id);
         const preferredRun = this._resolvePreferredRunId(
-          runIds, message.activeRunId, previousRunId,
+          runIds,
+          message.activeRunId,
+          previousRunId,
         );
         state.setActiveRunId(message.stream, preferredRun);
         dom.runSelector.setActiveRun(preferredRun);
@@ -544,7 +552,10 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
 
       // Sync state if resolution differs
       const resolvedRunId = state.resolveActiveRunId(message.stream);
-      if (resolvedRunId && state.getActiveRunId(message.stream) !== resolvedRunId) {
+      if (
+        resolvedRunId &&
+        state.getActiveRunId(message.stream) !== resolvedRunId
+      ) {
         state.setActiveRunId(message.stream, resolvedRunId);
       }
     } else {
@@ -836,7 +847,8 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     if (message.reset) {
       state.clearRunFiles(targetStream);
     } else if (message.runId) {
-      const hasRounds = message.rounds && Object.keys(message.rounds).length > 0;
+      const hasRounds =
+        message.rounds && Object.keys(message.rounds).length > 0;
       if (hasRounds) {
         state.setRunFiles(targetStream, message.runId, message.rounds);
       } else {

--- a/src/progressView/styles/context-management.css
+++ b/src/progressView/styles/context-management.css
@@ -1,0 +1,36 @@
+/**
+ * Context management log styles for ProgressView
+ */
+
+.context-management-details {
+  --context-management-accent: var(--vscode-charts-yellow);
+}
+
+.context-management-details .details-summary {
+  color: var(--context-management-accent);
+}
+
+.context-management-icon {
+  margin-right: var(--spacing-small);
+}
+
+.context-management-title {
+  font-weight: 500;
+}
+
+.context-management-content {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-large);
+}
+
+.context-management-content .stat-item {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-tiny);
+  font-size: var(--font-size-sm);
+}
+
+.context-management-content .stat-item .codicon {
+  opacity: 0.7;
+}

--- a/src/progressView/styles/index.css
+++ b/src/progressView/styles/index.css
@@ -21,6 +21,7 @@
 @import './file-list.css';
 @import './latexdiff.css';
 @import './statistics.css';
+@import './context-management.css';
 @import './user-message.css';
 @import './follow-up-input.css';
 @import './instruction-panel.css';


### PR DESCRIPTION
…ens reduction

- Add `max_tokens_reduced` action to ContextManagementAction enum
- Add `originalMaxTokens` and `reducedMaxTokens` fields to ContextManagementDataSchema
- Update Anthropic, OpenAI, and Google handlers to use logContextManagement for max_tokens reduction warnings
- Add MIN_COMPLETION_TOKENS (100) threshold to prevent reducing to 0 tokens

This unifies context management messages across providers, including:
- OpenAI conversation compaction
- Anthropic server-side tool use/thinking clearing
- Max tokens reduction due to context pressure (new)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Unifies context management across providers and surfaces it in the UI.
> 
> - **Shared logic:** New `contextManagementConstants` with `MIN_COMPLETION_TOKENS`, safety buffers (`TOKEN_SAFETY_BUFFER`, `HEURISTIC_TOKEN_BUFFER`), and `computeReducedMaxTokens()`
> - **Handlers updated:** Anthropic, Google, and OpenAI now reduce `max_tokens` when over budget using shared util and emit `logContextManagement` with utilization and before/after values
> - **Structured logging:** `ContextManagementAction` adds `max_tokens_reduced`; `ContextManagementDataSchema` adds `originalMaxTokens` and `reducedMaxTokens`
> - **ProgressView UI:** New formatter, template, and styles render context-management events (compaction/clearing/reduction) with icons and token/utilization stats
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 94bc48707a9a140387685e1737128d09067068c4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->