### PR TITLE
fix: use Grid to align queued messages with textarea

### DIFF
--- a/src/progressView/styles/follow-up-input.css
+++ b/src/progressView/styles/follow-up-input.css
@@ -1,33 +1,36 @@
 /**
  * Follow-up input styles for ProgressView
- * Minimal styling for the user input area
+ * Uses CSS Grid to align queued messages with textarea
  */
 
-/* Follow-up input container */
+/* Follow-up input container - Grid aligns queued messages with textarea */
 .follow-up-container {
   display: none;
-  flex-direction: column;
+  grid-template-columns: 1fr auto;
   padding: var(--spacing-medium);
   border-top: 1px solid var(--color-border);
   gap: var(--spacing-small);
 }
 
 .follow-up-container.is-visible {
-  display: flex;
+  display: grid;
 }
 
-/* Row container for textarea and action buttons */
+/* Queued messages align with textarea column only */
+.follow-up-container > .queued-follow-ups-collapsible {
+  grid-column: 1;
+}
+
+/* Input row children participate directly in grid */
 .follow-up-input-row {
-  display: flex;
-  align-items: flex-end;
-  gap: var(--spacing-small);
-  width: 100%;
+  display: contents;
 }
 
 /* Style the textarea for multi-line input */
 #followUpInput {
   display: block;
-  flex: 1;
+  grid-column: 1;
+  align-self: end;
   min-width: 0; /* Allow shrinking below default 320px */
   line-height: 1.4;
   min-height: 106px;
@@ -47,5 +50,6 @@ vscode-toolbar-container.follow-up-actions {
   display: flex;
   flex-direction: column !important;
   align-items: center;
+  align-self: end;
   gap: var(--spacing-small);
 }

--- a/src/progressView/styles/queued-follow-ups.css
+++ b/src/progressView/styles/queued-follow-ups.css
@@ -5,7 +5,6 @@
 
 /* Collapsible container styling */
 .queued-follow-ups-collapsible {
-  width: 100%;
   border-radius: var(--radius);
   background-color: var(--vscode-inputValidation-infoBackground);
   border: 1px solid var(--vscode-inputValidation-infoBorder);


### PR DESCRIPTION
- Grid columns: 1fr auto (textarea column + buttons column)
- Queued messages placed in column 1 only (aligns with textarea)
- Input row uses display:contents so children participate in grid
- Removes width:100% from queued (Grid handles sizing)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns the follow-up input area using CSS Grid for consistent layout between queued messages and the textarea.
> 
> - Change `follow-up-container` to `display: grid` with `grid-template-columns: 1fr auto`; `.is-visible` now displays as grid
> - Place `.queued-follow-ups-collapsible` in grid column `1` to align with the textarea; remove `width: 100%`
> - Make `.follow-up-input-row` `display: contents` so children participate in the grid
> - Set `#followUpInput` to grid column `1` and align end; stack `.follow-up-actions` vertically and align end
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 00be7f8d3d6cf9d2386ecdf11d3f1839c1806565. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->