### PR TITLE
fix: include context state in UPDATE_LOGS for reliable delivery

### DIFF
--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -628,6 +628,9 @@ export class ProgressEventHandler {
     // Groups already in state will be sent via updateLogContent.
     this.pendingTaskGroups.delete(stream);
 
+    // Get context state for this stream (ephemeral - not persisted)
+    const contextState = this.state.getContextState(stream);
+
     // Send data with action: 'render' (default).
     // Frontend detects stream switch by comparing stream with lastRenderedStream.
     this.webviewUpdater.updateLogContent(stream, messages, groups, {
@@ -635,6 +638,7 @@ export class ProgressEventHandler {
       activeRunId,
       runUsage: usageByRun,
       runFiles: filesByRun,
+      contextState,
     });
 
     // Note: Files are already included in UPDATE_LOGS (runFiles) and handled
@@ -655,12 +659,8 @@ export class ProgressEventHandler {
     const todos = this.state.getTodos(stream) ?? [];
     this.webviewUpdater.updateTodos(stream, todos);
 
-    // Refresh context state for the stream (ephemeral state)
-    // Only send if defined - frontend will show default state if not set
-    const contextState = this.state.getContextState(stream);
-    if (contextState !== undefined) {
-      this.webviewUpdater.updateContextState(stream, contextState);
-    }
+    // Context state is already included in updateLogContent above (via contextState field)
+    // No separate UPDATE_CONTEXT_STATE message needed here
 
     // Update status for current stream. Don't default to RUNNING - that causes a race
     // condition where the "already running" check in executeAgent fails. Let setupFlowUIState

--- a/src/progressView/managers/WebviewUpdater.ts
+++ b/src/progressView/managers/WebviewUpdater.ts
@@ -122,6 +122,11 @@ export class WebviewUpdater {
       activeRunId?: string | null;
       runUsage?: Record<string, TokenUsageStats>;
       runFiles?: Record<string, { [key: number]: OutputFileInfo[] }>;
+      contextState?: {
+        inputTokens: number;
+        contextWindow: number;
+        utilizationPercent: number;
+      };
     },
     action: 'render' | 'clear' = 'render',
   ): void {
@@ -134,6 +139,7 @@ export class WebviewUpdater {
       activeRunId: extras?.activeRunId,
       runUsage: extras?.runUsage,
       runFiles: extras?.runFiles,
+      contextState: extras?.contextState,
       action,
     });
   }

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -163,10 +163,10 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
   }
 
   /**
-   * Update run-scoped metadata (instructions, usage, files) from message.
+   * Update run-scoped metadata (instructions, usage, files, context) from message.
    * Shared by handleUpdateLogs and _handleIncrementalUpdate to avoid duplication.
    * @param {string} stream - The stream to update
-   * @param {Object} message - Message containing runInstructions, runUsage, runFiles
+   * @param {Object} message - Message containing runInstructions, runUsage, runFiles, contextState
    */
   _updateRunMetadata(stream, message) {
     if (message.runInstructions) {
@@ -191,6 +191,11 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
           state.setRunFiles(stream, runId, filesByRound);
         }
       });
+    }
+
+    // Context state is stream-scoped (not run-scoped), store if provided
+    if (message.contextState) {
+      state.setContextState(stream, message.contextState);
     }
   }
 


### PR DESCRIPTION
Previously, context state was sent via a separate UPDATE_CONTEXT_STATE
message, which could be lost if emitted before the webview's message
handler was fully initialized (race condition with DOMContentLoaded).

Now context state is included directly in the UPDATE_LOGS message
alongside runUsage. Since UPDATE_LOGS is properly handled, this ensures
the context utilization display ("X% context left") is reliably shown
in the progress view footer.

Changes:
- Add contextState field to updateLogContent() in WebviewUpdater
- Include contextState in refreshStreamSurface() when sending logs
- Update frontend _updateRunMetadata() to store contextState from message
- Remove redundant separate UPDATE_CONTEXT_STATE call in refreshStreamSurface

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Moves context utilization delivery into the main logs update to prevent initialization races.
> 
> - Adds `contextState` to `WebviewUpdater.updateLogContent(...)` payload and message
> - `ProgressEventHandler.refreshStreamSurface(...)` now includes `contextState` in `UPDATE_LOGS` and removes separate `UPDATE_CONTEXT_STATE` during refresh
> - Frontend `messageHandlers._updateRunMetadata(...)` stores `contextState` from `UPDATE_LOGS`; context footer refreshes during both full and incremental updates
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5789b6321a83cec97b21c31d2d7cdaad150ee8cc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->