### PR TITLE
Fix unclickable button issue

### DIFF
--- a/src/memoryView/index.html
+++ b/src/memoryView/index.html
@@ -65,7 +65,7 @@
       </header>
 
       <div class="memory-settings">
-        <vscode-checkbox id="memoryEnabledToggle" disabled>
+        <vscode-checkbox id="memoryEnabledToggle">
           Enable memory for chat agents
         </vscode-checkbox>
       </div>

--- a/src/memoryView/modules/messageHandlers.js
+++ b/src/memoryView/modules/messageHandlers.js
@@ -3,7 +3,10 @@ import { memoryViewDomHandler } from './domHandlers.js';
 import { ELEMENT_IDS } from './constants.js';
 import { MEMORY_VIEW_COMMANDS } from '@common/webview/commands.js';
 import { BaseWebviewMessageHandler } from '@common/BaseWebviewMessageHandler.js';
-import { safeGetElementById } from '@common/domUtils.js';
+import {
+  safeGetElementById,
+  setElementDisabled,
+} from '@common/domUtils.js';
 
 /**
  * Handles messages from the extension for the memory view.
@@ -26,7 +29,7 @@ export class MemoryViewMessageHandler extends BaseWebviewMessageHandler {
     const toggle = safeGetElementById(ELEMENT_IDS.MEMORY_ENABLED_TOGGLE);
     if (toggle) {
       toggle.checked = message.enabled;
-      toggle.removeAttribute('disabled');
+      setElementDisabled(toggle, false);
     }
   }
 }


### PR DESCRIPTION
vscode-checkbox component requires both the disabled property and attribute to be set for proper behavior. Added toggle.disabled = false before removeAttribute to ensure the checkbox becomes clickable.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes the memory view toggle so it can be clicked and correctly re-enabled during updates.
> 
> - Remove `disabled` attribute from `vscode-checkbox` in `index.html`
> - In `messageHandlers.js`, replace `removeAttribute('disabled')` with `setElementDisabled(toggle, false)` and add the corresponding import
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b0036fcb8b949c14f0cafc4a9b909783c3c49c24. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->