### PR TITLE
Simplify code clarity and consistency standards

### DIFF
--- a/src/webview/managers/ExecutionManager.ts
+++ b/src/webview/managers/ExecutionManager.ts
@@ -20,13 +20,14 @@ import {
 const CHANNEL = 'ExecutionManager';
 logger.initialize(CHANNEL);
 
-function getFilesIfNotEmpty<T>(files: T[] | undefined | null): T[] {
-  return files?.length ? files : [];
+/** Normalize nullish file arrays to empty arrays */
+function toArray<T>(files: T[] | undefined | null): T[] {
+  return files ?? [];
 }
 
 export class ExecutionManager {
   async handleExecute(message: any): Promise<void> {
-    const isToolUseAgent = !!message.isToolUseAgent;
+    const isToolUseAgent = Boolean(message.isToolUseAgent);
     const config = isToolUseAgent
       ? this.buildToolUseCommandPayload(message)
       : await this.buildWorkflowCommandPayload(message);
@@ -70,10 +71,9 @@ export class ExecutionManager {
     session: AgentSessionDescriptor,
   ): AgentConfig {
     const baseConfig = this.composeBaseAgentConfig(message, session);
-    const outputFiles = getFilesIfNotEmpty<string>(message.outputFiles);
-    const useMultipleOutputs = !!(
-      message.outputFilesActive || outputFiles.length > 1
-    );
+    const outputFiles = toArray<string>(message.outputFiles);
+    const useMultipleOutputs =
+      Boolean(message.outputFilesActive) || outputFiles.length > 1;
 
     // toolConfig only applies to workflow agents
     const toolConfig: ToolConfig = {
@@ -127,13 +127,13 @@ export class ExecutionManager {
       model: message.model,
       instruction: message.instruction,
       inputFile: message.inputFile ?? '',
-      inputFiles: getFilesIfNotEmpty<string>(message.inputFiles),
+      inputFiles: toArray<string>(message.inputFiles),
       referenceFile: message.referenceFile ?? null,
-      referenceFiles: getFilesIfNotEmpty<string>(message.referenceFiles),
+      referenceFiles: toArray<string>(message.referenceFiles),
       auxiliaryFile: message.auxiliaryFile ?? null,
-      auxiliaryFiles: getFilesIfNotEmpty<string>(message.auxiliaryFiles),
+      auxiliaryFiles: toArray<string>(message.auxiliaryFiles),
       mediaFile: this.mapMediaPath(message.mediaFile ?? null),
-      mediaFiles: getFilesIfNotEmpty<string>(
+      mediaFiles: toArray<string>(
         (message.mediaFiles ?? [])
           .map((f: string | null) => this.mapMediaPath(f))
           .filter((f: string | null): f is string => f !== null),

--- a/src/webview/managers/InstructionManager.ts
+++ b/src/webview/managers/InstructionManager.ts
@@ -89,8 +89,7 @@ export class InstructionManager extends BaseWebviewManager {
   async handlePolishInstructionText(
     message: PolishInstructionMessage,
   ): Promise<void> {
-    const webviewView = this.getWebview();
-    if (!webviewView) {
+    if (!this.getWebview()) {
       return;
     }
     try {
@@ -114,49 +113,49 @@ export class InstructionManager extends BaseWebviewManager {
       this.addMultipleFilesIfValid(
         fileContext,
         'inputFiles',
-        !!message.inputFilesActive,
+        Boolean(message.inputFilesActive),
         message.inputFiles,
       );
       this.addMultipleFilesIfValid(
         fileContext,
         'referenceFiles',
-        !!message.referenceFilesActive,
+        Boolean(message.referenceFilesActive),
         message.referenceFiles,
       );
       this.addMultipleFilesIfValid(
         fileContext,
         'auxiliaryFiles',
-        !!message.auxiliaryFilesActive,
+        Boolean(message.auxiliaryFilesActive),
         message.auxiliaryFiles,
       );
       this.addMultipleFilesIfValid(
         fileContext,
         'mediaFiles',
-        !!message.mediaFilesActive,
+        Boolean(message.mediaFilesActive),
         message.mediaFiles,
       );
       this.addMultipleFilesIfValid(
         fileContext,
         'outputFiles',
-        !!message.outputFilesActive,
+        Boolean(message.outputFilesActive),
         message.outputFiles,
       );
 
       try {
         const result = await polishTextWithAI(message.text, fileContext);
         if (result.success) {
-          webviewView.webview.postMessage({
+          this.postMessage({
             command: MAIN_VIEW_COMMANDS.INSTRUCTION_TEXT_POLISHED,
             text: result.text,
           });
         } else {
-          webviewView.webview.postMessage({
+          this.postMessage({
             command: MAIN_VIEW_COMMANDS.INSTRUCTION_TEXT_POLISH_ERROR,
             error: result.error ?? 'Error polishing text',
           });
         }
       } catch (error) {
-        webviewView.webview.postMessage({
+        this.postMessage({
           command: MAIN_VIEW_COMMANDS.INSTRUCTION_TEXT_POLISH_ERROR,
           error: toErrorMessage(error),
         });
@@ -166,7 +165,7 @@ export class InstructionManager extends BaseWebviewManager {
         );
       }
     } catch (error) {
-      webviewView.webview.postMessage({
+      this.postMessage({
         command: MAIN_VIEW_COMMANDS.INSTRUCTION_TEXT_POLISH_ERROR,
         error: toErrorMessage(error),
       });
@@ -184,8 +183,7 @@ export class InstructionManager extends BaseWebviewManager {
   }
 
   async handleClipboardImage(message: ClipboardImageMessage): Promise<void> {
-    const webviewView = this.getWebview();
-    if (!webviewView) {
+    if (!this.getWebview()) {
       return;
     }
     try {
@@ -197,7 +195,7 @@ export class InstructionManager extends BaseWebviewManager {
       const relativePath = path.join(PASTED_DIR, fileName);
       await StorageFS.write(relativePath, Buffer.from(base64, 'base64'));
       await StorageFS.cleanupOldFiles(PASTED_DIR, THREE_DAYS_MS);
-      webviewView.webview.postMessage({
+      this.postMessage({
         command: MAIN_VIEW_COMMANDS.ADD_MEDIA_FILE,
         file: fileName,
       });


### PR DESCRIPTION
- OutputNode: inline handleLatexdiff() single-use private method (per CLAUDE.md flattening abstraction layers guidance)
- InstructionManager: use inherited postMessage() instead of direct webviewView.webview.postMessage() calls for consistency
- InstructionManager: replace !! double negation with Boolean() for clearer intent when converting to boolean
- ExecutionManager: simplify getFilesIfNotEmpty() using nullish coalescing (files ?? []) instead of complex ternary
- ExecutionManager: replace !! double negation with Boolean()

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Focuses on clarity and consistency across webview managers.
> 
> - Introduces `toArray` in `ExecutionManager` to normalize nullable file arrays and updates `inputFiles`, `referenceFiles`, `auxiliaryFiles`, `mediaFiles`, and `outputFiles` usage
> - Replaces `!!` with `Boolean()` for clearer boolean conversion in both managers
> - `InstructionManager` now uses inherited `postMessage` instead of direct `webviewView.webview.postMessage` and simplifies webview checks
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 56f81abf41f71698e8cebeaf8fe37123cfa9277f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->