### PR TITLE
Simplify and improve code clarity

### DIFF
--- a/src/agent/core/AgentState.ts
+++ b/src/agent/core/AgentState.ts
@@ -59,6 +59,14 @@ export class ConversationRoundState {
     this.normalizedUsage = ROUND_STATE_DEFAULTS.normalizedUsage;
   }
 
+  /** Apply default values to all fields except roundIndex. */
+  private applyDefaults(): void {
+    this.continuationCount = ROUND_STATE_DEFAULTS.continuationCount;
+    this.responseTimeMs = ROUND_STATE_DEFAULTS.responseTimeMs;
+    this.outputFile = ROUND_STATE_DEFAULTS.outputFile;
+    this.normalizedUsage = ROUND_STATE_DEFAULTS.normalizedUsage;
+  }
+
   /** Deserialize from a snapshot. Validates and applies schema defaults. */
   static fromSnapshot(snapshot: unknown): ConversationRoundState {
     const parsed = ConversationRoundStateSnapshotSchema.parse(snapshot);
@@ -105,10 +113,7 @@ export class ConversationRoundState {
    */
   reset(newRoundIndex: number): void {
     this.roundIndex = newRoundIndex;
-    this.continuationCount = ROUND_STATE_DEFAULTS.continuationCount;
-    this.responseTimeMs = ROUND_STATE_DEFAULTS.responseTimeMs;
-    this.outputFile = ROUND_STATE_DEFAULTS.outputFile;
-    this.normalizedUsage = ROUND_STATE_DEFAULTS.normalizedUsage;
+    this.applyDefaults();
   }
 }
 

--- a/src/agent/core/flows/RetryState.ts
+++ b/src/agent/core/flows/RetryState.ts
@@ -462,7 +462,14 @@ interface InvocationResultHandlerOptions {
   operationName: string;
 }
 
-/** Helper to mark flow as stopped without normal completion. */
+/**
+ * Mark flow as stopped without normal completion.
+ *
+ * Sets shouldStop=true to halt the flow, and endTurn=false to indicate
+ * this was not a normal model completion (e.g., due to cancellation,
+ * failure, or empty response). This distinction is important for
+ * determining whether to persist state for resume.
+ */
 function markFlowStopped(state: { shouldStop: boolean; endTurn: boolean }): void {
   state.shouldStop = true;
   state.endTurn = false;

--- a/src/agent/core/flows/RetryState.ts
+++ b/src/agent/core/flows/RetryState.ts
@@ -462,6 +462,12 @@ interface InvocationResultHandlerOptions {
   operationName: string;
 }
 
+/** Helper to mark flow as stopped without normal completion. */
+function markFlowStopped(state: { shouldStop: boolean; endTurn: boolean }): void {
+  state.shouldStop = true;
+  state.endTurn = false;
+}
+
 /**
  * Handles common invocation result cases in post().
  *
@@ -499,8 +505,7 @@ export function handleInvocationResult<T extends { response: unknown }>(
   // Handle user cancellation (do NOT record error - distinguishes from failure)
   if (result.kind === 'cancelled') {
     retryState.lastError = undefined;
-    state.shouldStop = true;
-    state.endTurn = false; // Not a normal completion
+    markFlowStopped(state);
     return null;
   }
 
@@ -510,8 +515,7 @@ export function handleInvocationResult<T extends { response: unknown }>(
       message: result.message,
       retryable: false, // Already exhausted retries
     };
-    state.shouldStop = true;
-    state.endTurn = false; // Not a normal completion
+    markFlowStopped(state);
     return null;
   }
 
@@ -524,8 +528,7 @@ export function handleInvocationResult<T extends { response: unknown }>(
       message: EMPTY_RESPONSE_ERROR_MESSAGE,
       retryable: false,
     };
-    state.shouldStop = true;
-    state.endTurn = false; // Not a normal completion
+    markFlowStopped(state);
     return null;
   }
 

--- a/src/agent/implementations/flows/reflection/nodes/OutputNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/OutputNode.ts
@@ -78,43 +78,45 @@ export class OutputNode<C = unknown> extends Node<
       ensureXmlStructure,
     } = prepRes;
 
+    // Helper for non-critical operations that can fail gracefully
+    const tryOperation = async (
+      label: string,
+      operation: () => Promise<void>,
+    ): Promise<void> => {
+      try {
+        await operation();
+      } catch (error) {
+        logger.warn(`${label} failed: ${toErrorMessage(error)}`);
+      }
+    };
+
     // Only process if turn ended (model completed response)
     if (endTurn) {
       logger.debug(`Processing output for round ${currentRound}`);
 
       if (ensureXmlStructure) {
-        try {
-          await outputHandler.ensureXmlStructure(
+        await tryOperation('XML structure', () =>
+          outputHandler.ensureXmlStructure(
             outputLocation,
             setting.documentTag ?? 'document',
-          );
-        } catch (error) {
-          logger.warn(`XML structure failed: ${toErrorMessage(error)}`);
-        }
+          ),
+        );
       }
 
-      try {
-        await outputHandler.processOutputFiles(outputLocation, currentRound);
-      } catch (error) {
-        logger.warn(`Output processing failed: ${toErrorMessage(error)}`);
-      }
+      await tryOperation('Output processing', () =>
+        outputHandler.processOutputFiles(outputLocation, currentRound),
+      );
 
       if (outputHandler.hasRoundOutputs(currentRound)) {
-        try {
-          await this.handleLatexdiff(currentRound, baseFiles);
-        } catch (error) {
-          logger.warn(`Latexdiff failed: ${toErrorMessage(error)}`);
-        }
+        await tryOperation('Latexdiff', () =>
+          this.handleLatexdiff(currentRound, baseFiles),
+        );
       }
     }
 
-    try {
-      await outputHandler.finalizeRound(outputLocation, currentRound, {
-        endTurn,
-      });
-    } catch (error) {
-      logger.warn(`Round finalization failed: ${toErrorMessage(error)}`);
-    }
+    await tryOperation('Round finalization', () =>
+      outputHandler.finalizeRound(outputLocation, currentRound, { endTurn }),
+    );
 
     // Get round artifacts - this is critical, throw if it fails
     return await outputHandler.getRoundArtifacts(currentRound);

--- a/src/agent/implementations/flows/reflection/nodes/RoundCompleteNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/RoundCompleteNode.ts
@@ -61,6 +61,9 @@ export class RoundCompleteNode<C = unknown> extends Node<
     const { currentRound, totalRounds, continueRounds } = prepRes;
 
     const nextRound = currentRound + 1;
+    // Display rounds as 1-indexed for user-friendly logging
+    const displayCurrent = currentRound + 1;
+    const displayNext = nextRound + 1;
 
     // Check for interruption
     if (checkInterruption()) {
@@ -81,9 +84,7 @@ export class RoundCompleteNode<C = unknown> extends Node<
     }
 
     // Continue to next round
-    logger.debug(
-      `Round ${currentRound + 1} complete, continuing to round ${nextRound + 1}`,
-    );
+    logger.debug(`Round ${displayCurrent} complete, continuing to round ${displayNext}`);
     return { kind: 'continue' };
   }
 

--- a/src/agent/implementations/flows/tooluse/ToolUseFlowContext.ts
+++ b/src/agent/implementations/flows/tooluse/ToolUseFlowContext.ts
@@ -71,6 +71,47 @@ export interface ToolUseFlowContext<C = unknown> {
 }
 
 // ============================================================================
+// Tool Resolution Helper
+// ============================================================================
+
+interface ResolveToolsParams {
+  tools: AgentToolUseSetting['tools'];
+  toolRegistry: IToolRegistry;
+  logger: { warn: (msg: string) => void };
+}
+
+/** Resolve tool definitions from setting, validating against registry. */
+function resolveTools(params: ResolveToolsParams): ToolDefinition[] {
+  const { tools, toolRegistry, logger } = params;
+
+  const toolConfigs = Array.isArray(tools) ? tools : [];
+  const resolved: ToolDefinition[] = [];
+  const resolvedNames = new Set<string>();
+
+  for (const t of toolConfigs) {
+    const def = typeof t === 'string' ? { name: t } : t;
+    if (!toolRegistry.has(def.name)) {
+      logger.warn(`Tool "${def.name}" not found in registry`);
+      continue;
+    }
+    resolved.push(def);
+    resolvedNames.add(def.name);
+  }
+
+  // Inject memory tool if enabled and not already present
+  if (getToolUseMemoryEnabled() && !resolvedNames.has('memory')) {
+    const memoryTool = toolRegistry.get('memory');
+    if (memoryTool) {
+      resolved.push(memoryTool.definition);
+    } else {
+      logger.warn('Memory tool not found in registry');
+    }
+  }
+
+  return resolved;
+}
+
+// ============================================================================
 // Factory Function
 // ============================================================================
 
@@ -89,29 +130,11 @@ export function createToolUseFlowContext<C = unknown>(
   const toolRegistry = customRegistry ?? getDefaultToolRegistry();
   const sessionLifecycle = new ToolUseSessionLifecycle(streamId);
 
-  // Resolve tools once at construction time
-  const toolConfigs = Array.isArray(setting.tools) ? setting.tools : [];
-  const resolvedTools: ToolDefinition[] = [];
-  const resolvedNames = new Set<string>();
-  for (const t of toolConfigs) {
-    const def = typeof t === 'string' ? { name: t } : t;
-    if (!toolRegistry.has(def.name)) {
-      logger.warn(`Tool "${def.name}" not found in registry`);
-      continue;
-    }
-    resolvedTools.push(def);
-    resolvedNames.add(def.name);
-  }
-
-  if (getToolUseMemoryEnabled() && !resolvedNames.has('memory')) {
-    const memoryTool = toolRegistry.get('memory');
-    if (memoryTool) {
-      resolvedTools.push(memoryTool.definition);
-      resolvedNames.add('memory');
-    } else {
-      logger.warn('Memory tool not found in registry');
-    }
-  }
+  const resolvedTools = resolveTools({
+    tools: setting.tools,
+    toolRegistry,
+    logger,
+  });
 
   // Spread init directly - it already contains setting, logger, etc.
   const services: ToolUseServices<C> = {

--- a/src/commands/housekeeping/cleanCommands.ts
+++ b/src/commands/housekeeping/cleanCommands.ts
@@ -1,5 +1,6 @@
 // Third-party imports
 import * as vscode from 'vscode';
+import { z } from 'zod';
 
 // Local imports
 import type { FileOpResult } from '@agent/types/ResultTypes';
@@ -16,6 +17,27 @@ import { getStreamTabId } from '@/logger/streamUtils';
 
 const CHANNEL = 'cleanCommands';
 logger.initialize(CHANNEL);
+
+// --- Schemas ---
+
+const RequiredString = z.string().min(1);
+
+/** For cleanSingle/cleanMultiple - all fields required */
+const CleanParamsSchema = z.object({
+  inputFile: RequiredString,
+  agent: RequiredString,
+  model: RequiredString,
+});
+
+// --- Helpers ---
+
+function formatZodError(error: z.ZodError): string {
+  return error.issues
+    .map((i) =>
+      i.path.length ? `${i.path.join('.')}: ${i.message}` : i.message,
+    )
+    .join(', ');
+}
 
 function showCleanResult(result: FileOpResult, inputFile: string): void {
   switch (result.status) {
@@ -36,32 +58,6 @@ function showCleanResult(result: FileOpResult, inputFile: string): void {
   }
 }
 
-/** Validates and logs required parameters, returns false if any are missing */
-async function validateParams(
-  inputFile: string,
-  agent: string,
-  model: string,
-  commandName: string,
-): Promise<boolean> {
-  logger.debug(
-    CHANNEL,
-    `Command called with: inputFile=${inputFile}, agent=${agent}, model=${model}`,
-  );
-
-  if (!inputFile || !agent || !model) {
-    const missing = [];
-    if (!inputFile) missing.push('inputFile');
-    if (!agent) missing.push('agent');
-    if (!model) missing.push('model');
-    await showLoggedMessage(
-      CHANNEL,
-      `Missing required parameters for ${commandName}: ${missing.join(', ')}`,
-    );
-    return false;
-  }
-  return true;
-}
-
 export function registerCleanCommands(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     vscode.commands.registerCommand('texra.clean', handleClean),
@@ -77,14 +73,20 @@ async function handleCleanSingle(
   agent: string,
   model: string,
 ) {
-  if (!(await validateParams(inputFile, agent, model, 'cleanSingle'))) {
+  const parsed = CleanParamsSchema.safeParse({ inputFile, agent, model });
+  if (!parsed.success) {
+    await showLoggedMessage(
+      CHANNEL,
+      `Invalid params for cleanSingle: ${formatZodError(parsed.error)}`,
+    );
     return;
   }
 
-  const result = await runCleanSingle(model, inputFile, agent);
-  showCleanResult(result, inputFile);
+  const data = parsed.data;
+  const result = await runCleanSingle(data.model, data.inputFile, data.agent);
+  showCleanResult(result, data.inputFile);
 
-  const streamId = getStreamTabId(agent, model, inputFile, {
+  const streamId = getStreamTabId(data.agent, data.model, data.inputFile, {
     useMultipleOutputs: false,
   });
   bus.emit('clearMissingOutputs', { stream: streamId });
@@ -96,15 +98,26 @@ async function handleCleanMultiple(
   model: string,
   outputFiles: string[] = [],
 ) {
-  if (!(await validateParams(inputFile, agent, model, 'cleanMultiple'))) {
+  const parsed = CleanParamsSchema.safeParse({ inputFile, agent, model });
+  if (!parsed.success) {
+    await showLoggedMessage(
+      CHANNEL,
+      `Invalid params for cleanMultiple: ${formatZodError(parsed.error)}`,
+    );
     return;
   }
   logger.debug(CHANNEL, `Additional files: ${outputFiles.join(', ')}`);
 
-  const result = await runCleanMultiple(model, inputFile, agent, outputFiles);
-  showCleanResult(result, inputFile);
+  const data = parsed.data;
+  const result = await runCleanMultiple(
+    data.model,
+    data.inputFile,
+    data.agent,
+    outputFiles,
+  );
+  showCleanResult(result, data.inputFile);
 
-  const streamId = getStreamTabId(agent, model, inputFile, {
+  const streamId = getStreamTabId(data.agent, data.model, data.inputFile, {
     useMultipleOutputs: true,
   });
   bus.emit('clearMissingOutputs', { stream: streamId });

--- a/src/commands/latex/latexdiffCommands.ts
+++ b/src/commands/latex/latexdiffCommands.ts
@@ -50,11 +50,6 @@ const service = new LaTeXdiffService(CHANNEL);
 
 type LatexdiffTool = 'latexdiff' | 'latexdiff-vc';
 
-/** Select the primary file to use, preferring baseFile over inputFile. */
-function selectFile(baseFile: string, inputFile: string): string {
-  return baseFile ?? inputFile;
-}
-
 /**
  * Ensures the required latexdiff tool is installed before running a command.
  * @param tool The tool name to verify.
@@ -182,7 +177,7 @@ async function handleLatexdiff(
     return;
   }
 
-  const fileToUse = selectFile(baseFile, inputFile);
+  const fileToUse = baseFile ?? inputFile;
   try {
     if (!(await ensureLatexdiffToolInstalled('latexdiff'))) {
       return;
@@ -223,7 +218,7 @@ async function handleLatexdiffvc(
   baseFile: string,
   commitHash: string,
 ) {
-  const fileToUse = selectFile(baseFile, inputFile);
+  const fileToUse = baseFile ?? inputFile;
   try {
     if (!(await ensureLatexdiffToolInstalled('latexdiff-vc'))) {
       return;
@@ -272,7 +267,7 @@ async function handlePackLatexdiffvc(
       CHANNEL,
       `Command called with: inputFile=${inputFile}, baseFile=${baseFile}, commitHash=${commitHash}, clean=${clean}`,
     );
-    const fileToUse = selectFile(baseFile, inputFile);
+    const fileToUse = baseFile ?? inputFile;
     await runPackLatexdiffvc(fileToUse, commitHash, clean);
   } catch (err) {
     await showLoggedErrorMessage(CHANNEL, 'Error packing LaTeX diff', err);
@@ -314,7 +309,7 @@ async function handleCleanLatexdiffvc(
       CHANNEL,
       `Command called with: inputFile=${inputFile}, baseFile=${baseFile}, commitHash=${commitHash}`,
     );
-    const fileToUse = selectFile(baseFile, inputFile);
+    const fileToUse = baseFile ?? inputFile;
     await runCleanLatexdiffvc(fileToUse, commitHash);
   } catch (err) {
     await showLoggedErrorMessage(CHANNEL, 'Error cleaning LaTeX diff', err);

--- a/src/commands/latex/latexdiffCommands.ts
+++ b/src/commands/latex/latexdiffCommands.ts
@@ -50,6 +50,11 @@ const service = new LaTeXdiffService(CHANNEL);
 
 type LatexdiffTool = 'latexdiff' | 'latexdiff-vc';
 
+/** Select the primary file to use, preferring baseFile over inputFile. */
+function selectFile(baseFile: string, inputFile: string): string {
+  return baseFile ?? inputFile;
+}
+
 /**
  * Ensures the required latexdiff tool is installed before running a command.
  * @param tool The tool name to verify.
@@ -177,7 +182,7 @@ async function handleLatexdiff(
     return;
   }
 
-  const fileToUse = baseFile ?? inputFile;
+  const fileToUse = selectFile(baseFile, inputFile);
   try {
     if (!(await ensureLatexdiffToolInstalled('latexdiff'))) {
       return;
@@ -218,7 +223,7 @@ async function handleLatexdiffvc(
   baseFile: string,
   commitHash: string,
 ) {
-  const fileToUse = baseFile ?? inputFile;
+  const fileToUse = selectFile(baseFile, inputFile);
   try {
     if (!(await ensureLatexdiffToolInstalled('latexdiff-vc'))) {
       return;
@@ -267,7 +272,7 @@ async function handlePackLatexdiffvc(
       CHANNEL,
       `Command called with: inputFile=${inputFile}, baseFile=${baseFile}, commitHash=${commitHash}, clean=${clean}`,
     );
-    const fileToUse = baseFile ?? inputFile;
+    const fileToUse = selectFile(baseFile, inputFile);
     await runPackLatexdiffvc(fileToUse, commitHash, clean);
   } catch (err) {
     await showLoggedErrorMessage(CHANNEL, 'Error packing LaTeX diff', err);
@@ -309,7 +314,7 @@ async function handleCleanLatexdiffvc(
       CHANNEL,
       `Command called with: inputFile=${inputFile}, baseFile=${baseFile}, commitHash=${commitHash}`,
     );
-    const fileToUse = baseFile ?? inputFile;
+    const fileToUse = selectFile(baseFile, inputFile);
     await runCleanLatexdiffvc(fileToUse, commitHash);
   } catch (err) {
     await showLoggedErrorMessage(CHANNEL, 'Error cleaning LaTeX diff', err);

--- a/src/tools/EditTool.ts
+++ b/src/tools/EditTool.ts
@@ -112,16 +112,10 @@ export class EditFileTool extends defineTool({
     // an explicit read again.
     recordToolFileRead(targetPath);
 
-    const replacementSummary =
-      replace_all === true
-        ? `Replaced ${occurrences} occurrence${occurrences === 1 ? '' : 's'}.`
-        : 'Replaced 1 occurrence.';
-    const summary =
-      replace_all === true
-        ? `Edited ${targetPath}: replaced ${occurrences} occurrence${
-            occurrences === 1 ? '' : 's'
-          }`
-        : `Edited ${targetPath}: replaced 1 occurrence`;
+    const count = replace_all === true ? occurrences : 1;
+    const pluralSuffix = count === 1 ? '' : 's';
+    const replacementSummary = `Replaced ${count} occurrence${pluralSuffix}.`;
+    const summary = `Edited ${targetPath}: replaced ${count} occurrence${pluralSuffix}`;
 
     const userDiffNote = formatUnifiedApprovalUserDiff(
       targetPath,

--- a/src/utils/files/fileMappingUtils.ts
+++ b/src/utils/files/fileMappingUtils.ts
@@ -15,6 +15,14 @@ import { flexibleFS } from './flexibleFS';
 import type { FileLocation } from './taskRunStorage';
 
 /**
+ * Get the comparable path from a FileLocation.
+ * Returns relativePath for workspace/runStorage, absolutePath for external files.
+ */
+function getComparablePath(loc: FileLocation): string {
+  return loc.kind !== 'external' ? loc.relativePath : loc.absolutePath;
+}
+
+/**
  * Create a mapping between two file lists based on name similarity.
  * Uses string keys (comparable paths) for robust lookups, FileLocation values for data.
  * This ensures lookups work even when FileLocation objects are reconstructed.
@@ -37,12 +45,8 @@ export function createFileMapping(
     return fileMapping;
   }
 
-  // Use getComparablePath helper consistently for path extraction
-  const getPath = (loc: FileLocation): string =>
-    loc.kind !== 'external' ? loc.relativePath : loc.absolutePath;
-
   for (const target of targetFiles) {
-    const targetPath = getPath(target);
+    const targetPath = getComparablePath(target);
     const targetBaseName = path.basename(targetPath);
 
     let bestMatchSourcePath: string | null = null;
@@ -53,7 +57,7 @@ export function createFileMapping(
         continue;
       }
 
-      const sourcePath = getPath(sourceFile);
+      const sourcePath = getComparablePath(sourceFile);
       const sourceBaseName = path.basename(sourcePath);
 
       const sourceName = path.parse(sourceBaseName).name;
@@ -120,10 +124,7 @@ function buildReplacementLookup(
   for (const [baseFile, outputLoc] of baseToOutputMap.entries()) {
     if (!baseFile || !outputLoc) continue;
 
-    const outputFile =
-      outputLoc.kind !== 'external'
-        ? outputLoc.relativePath
-        : outputLoc.absolutePath;
+    const outputFile = getComparablePath(outputLoc);
 
     const baseSegments = getPathSegments(baseFile);
     const outputSegments = getPathSegments(outputFile);
@@ -176,7 +177,7 @@ export async function replaceInputCommands(
     `File mappings for input replacement: ${[...baseToOutputMap.entries()]
       .map(
         ([basePath, outputLoc]) =>
-          `${path.basename(basePath)} -> ${path.basename(outputLoc.kind !== 'external' ? outputLoc.relativePath : outputLoc.absolutePath)}`,
+          `${path.basename(basePath)} -> ${path.basename(getComparablePath(outputLoc))}`,
       )
       .join(', ')}`,
   );
@@ -189,10 +190,7 @@ export async function replaceInputCommands(
   }
 
   for (const outputLocation of outputFiles) {
-    const outputPath =
-      outputLocation.kind !== 'external'
-        ? outputLocation.relativePath
-        : outputLocation.absolutePath;
+    const outputPath = getComparablePath(outputLocation);
 
     try {
       const content = await flexibleFS.read(outputLocation);

--- a/src/utils/text/xmlConversion.ts
+++ b/src/utils/text/xmlConversion.ts
@@ -35,10 +35,12 @@ let pandocCheckPromise: Promise<boolean> | null = null;
 
 async function isPandocAvailable(): Promise<boolean> {
   if (pandocCheckPromise === null) {
-    pandocCheckPromise = checkToolInstalled('pandoc', false).catch(() => {
-      // Clear cache on failure to allow retry next time
-      pandocCheckPromise = null;
-      return false;
+    pandocCheckPromise = checkToolInstalled('pandoc', false).then((result) => {
+      // Clear cache on negative result to allow retry next time
+      if (!result) {
+        pandocCheckPromise = null;
+      }
+      return result;
     });
   }
   return pandocCheckPromise;

--- a/src/utils/text/xmlConversion.ts
+++ b/src/utils/text/xmlConversion.ts
@@ -26,35 +26,16 @@ import {
 const CHANNEL = 'xmlConversion';
 logger.initialize(CHANNEL);
 
-// Cache pandoc availability check
-let pandocAvailable: boolean | null = null;
+/**
+ * Cached promise for pandoc availability check.
+ * Uses a single promise variable - once resolved, will always return same value.
+ */
 let pandocCheckPromise: Promise<boolean> | null = null;
 
 async function isPandocAvailable(): Promise<boolean> {
-  if (pandocAvailable !== null) {
-    return pandocAvailable;
+  if (pandocCheckPromise === null) {
+    pandocCheckPromise = checkToolInstalled('pandoc', false).catch(() => false);
   }
-
-  // If a check is already in progress, wait for it
-  if (pandocCheckPromise !== null) {
-    return pandocCheckPromise;
-  }
-
-  // Start new check and store the promise
-  pandocCheckPromise = checkToolInstalled('pandoc', false)
-    .then((result) => {
-      pandocAvailable = result;
-      return result;
-    })
-    .catch(() => {
-      // Cache negative result on error to prevent infinite retries
-      pandocAvailable = false;
-      return false;
-    })
-    .finally(() => {
-      pandocCheckPromise = null;
-    });
-
   return pandocCheckPromise;
 }
 

--- a/src/utils/text/xmlConversion.ts
+++ b/src/utils/text/xmlConversion.ts
@@ -27,14 +27,19 @@ const CHANNEL = 'xmlConversion';
 logger.initialize(CHANNEL);
 
 /**
- * Cached promise for pandoc availability check.
- * Uses a single promise variable - once resolved, will always return same value.
+ * Cached pandoc availability check.
+ * Caches positive results permanently, but clears on failure to allow retry
+ * (e.g., if user installs pandoc mid-session).
  */
 let pandocCheckPromise: Promise<boolean> | null = null;
 
 async function isPandocAvailable(): Promise<boolean> {
   if (pandocCheckPromise === null) {
-    pandocCheckPromise = checkToolInstalled('pandoc', false).catch(() => false);
+    pandocCheckPromise = checkToolInstalled('pandoc', false).catch(() => {
+      // Clear cache on failure to allow retry next time
+      pandocCheckPromise = null;
+      return false;
+    });
   }
   return pandocCheckPromise;
 }


### PR DESCRIPTION
Extract helper functions and consolidate repeated patterns:
- OutputNode: Extract tryOperation helper for graceful error handling
- EditTool: Consolidate plural suffix logic into reusable variables
- fileMappingUtils: Add getComparablePath helper for FileLocation paths
- RoundCompleteNode: Clarify display round numbering with named variables
- AgentState: Add applyDefaults method to eliminate constructor/reset duplication
- RetryState: Extract markFlowStopped helper for state transitions
- ToolUseFlowContext: Extract resolveTools function for tool resolution
- cleanCommands: Replace manual validation with Zod schema validation
- latexdiffCommands: Add selectFile helper for baseFile/inputFile selection
- xmlConversion: Simplify pandoc availability caching to single promise

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> General cleanup to reduce duplication and centralize logic.
> 
> - **AgentState**: Adds `applyDefaults()` and uses it in `reset()`; no behavior change to serialization.
> - **RetryState**: Extracts `markFlowStopped()` and centralizes `post()` result handling via `handleInvocationResult` paths (cancelled/failed/empty response).
> - **Reflection OutputNode**: Introduces `tryOperation` wrapper to gracefully log non-critical failures (XML structure, processing, latexdiff, finalization).
> - **RoundCompleteNode**: Clarifies log messages using 1-indexed `displayCurrent`/`displayNext` variables.
> - **ToolUseFlowContext**: Adds `resolveTools()` to validate/resolve tools and inject memory tool when enabled.
> - **cleanCommands**: Replaces ad-hoc param checks with Zod `CleanParamsSchema`; improves error messaging.
> - **EditTool**: Simplifies replacement summaries with shared count/pluralization.
> - **fileMappingUtils**: Adds `getComparablePath()` and uses it consistently for mapping and replacements.
> - **xmlConversion**: Simplifies Pandoc availability caching to a single promise with retry on negative results.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 88c6596a1b012c661e6a1d78947d9d6ecc2daa14. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->