### PR TITLE
Simplify and improve code clarity

### DIFF
--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -659,15 +659,12 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
 
     const outputFilesArray = [...allFiles];
 
-    // Determine if multiple outputs mode is active (explicit config takes priority)
-    let useMultipleOutputs: boolean;
-    if (taskState.agentConfig.useMultipleOutputs !== undefined) {
-      useMultipleOutputs = taskState.agentConfig.useMultipleOutputs;
-    } else if (taskState.activeFiles.output !== undefined) {
-      useMultipleOutputs = taskState.activeFiles.output;
-    } else {
-      useMultipleOutputs = outputFilesArray.length > 1;
-    }
+    // Determine if multiple outputs mode is active
+    // Priority: explicit config > activeFiles flag > infer from file count
+    const useMultipleOutputs =
+      taskState.agentConfig.useMultipleOutputs ??
+      taskState.activeFiles.output ??
+      outputFilesArray.length > 1;
     await vscode.commands.executeCommand(command, {
       streamId: stream,
       agent: taskState.agentConfig.agent,

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -272,26 +272,32 @@ export class ProgressViewProvider
     this._pendingUpdateOptions = null;
     this.updateWebview({ forceRebuild: true });
 
-    if (this.webviewUpdater.isAvailable()) {
-      // Replay pending approval prompts
-      for (const prompt of this.pendingApprovalPrompts.values()) {
-        this.webviewUpdater.showToolEditApprovalPrompt(prompt);
-      }
-      this.webviewUpdater.updateToolEditApprovalState(
-        this.approvalBypassActive,
-      );
+    // Replay pending prompts and requests
+    this.replayPendingPrompts();
+  }
 
-      // Replay pending retry requests
-      for (const payload of this.pendingRetryRequests.values()) {
-        this.webviewUpdater.showRetryRequest(payload);
-      }
+  /**
+   * Replay pending approval prompts and retry requests to newly ready webview.
+   */
+  private replayPendingPrompts(): void {
+    if (!this.webviewUpdater.isAvailable()) {
+      return;
+    }
+
+    for (const prompt of this.pendingApprovalPrompts.values()) {
+      this.webviewUpdater.showToolEditApprovalPrompt(prompt);
+    }
+    this.webviewUpdater.updateToolEditApprovalState(this.approvalBypassActive);
+
+    for (const payload of this.pendingRetryRequests.values()) {
+      this.webviewUpdater.showRetryRequest(payload);
     }
   }
 
   public showToolEditApprovalPrompt(prompt: ToolEditApprovalPrompt): void {
     this.pendingApprovalPrompts.set(prompt.requestId, prompt);
 
-    if (this.isAnyViewReady() && this.webviewUpdater.isAvailable()) {
+    if (this.canSendToWebview()) {
       this.webviewUpdater.showToolEditApprovalPrompt(prompt);
     }
   }
@@ -299,7 +305,7 @@ export class ProgressViewProvider
   public resolveToolEditApprovalPrompt(requestId: string): void {
     this.pendingApprovalPrompts.delete(requestId);
 
-    if (this.isAnyViewReady() && this.webviewUpdater.isAvailable()) {
+    if (this.canSendToWebview()) {
       this.webviewUpdater.resolveToolEditApprovalPrompt(requestId);
     }
   }
@@ -307,7 +313,7 @@ export class ProgressViewProvider
   public updateToolEditApprovalBypassState(bypassActive: boolean): void {
     this.approvalBypassActive = bypassActive;
 
-    if (this.isAnyViewReady() && this.webviewUpdater.isAvailable()) {
+    if (this.canSendToWebview()) {
       this.webviewUpdater.updateToolEditApprovalState(bypassActive);
     }
   }
@@ -317,7 +323,7 @@ export class ProgressViewProvider
   ): void {
     this.pendingRetryRequests.set(payload.streamId, payload);
 
-    if (this.isAnyViewReady() && this.webviewUpdater.isAvailable()) {
+    if (this.canSendToWebview()) {
       this.webviewUpdater.showRetryRequest(payload);
     }
   }
@@ -325,9 +331,17 @@ export class ProgressViewProvider
   public resolveRetryRequest(streamId: string): void {
     this.pendingRetryRequests.delete(streamId);
 
-    if (this.isAnyViewReady() && this.webviewUpdater.isAvailable()) {
+    if (this.canSendToWebview()) {
       this.webviewUpdater.resolveRetryRequest(streamId);
     }
+  }
+
+  /**
+   * Check if webview is ready to receive messages.
+   * Combines readiness check with availability check.
+   */
+  private canSendToWebview(): boolean {
+    return this.isAnyViewReady() && this.webviewUpdater.isAvailable();
   }
 
   /**

--- a/src/progressView/managers/WebviewUpdater.ts
+++ b/src/progressView/managers/WebviewUpdater.ts
@@ -53,22 +53,13 @@ export class WebviewUpdater {
   static createInstructionUpdate(
     taskState?: TaskState,
   ): InstructionUpdate | undefined {
-    if (!taskState) {
+    const text = taskState?.agentConfig?.instruction?.trim();
+    if (!text) {
       return undefined;
     }
 
-    const text = taskState.agentConfig?.instruction ?? '';
-    const normalized = text.trim();
-    if (!normalized) {
-      return undefined;
-    }
-
-    const metadata = WebviewUpdater.computeInstructionMetadata(normalized);
-    const payload: InstructionUpdate = { text: normalized };
-    if (metadata) {
-      payload.metadata = metadata;
-    }
-    return payload;
+    const metadata = WebviewUpdater.computeInstructionMetadata(text);
+    return metadata ? { text, metadata } : { text };
   }
 
   private static computeInstructionMetadata(

--- a/src/webview/managers/FileManager.ts
+++ b/src/webview/managers/FileManager.ts
@@ -263,76 +263,107 @@ export class FileManager extends BaseWebviewManager {
     const currentOpenFile = await vscode.commands.executeCommand<string>(
       'texra.getCurrentFile',
     );
-    if (currentOpenFile) {
-      let commitCheckFile: string | null = null;
-      if (fileType === 'edited') {
-        const baseFile = message.baseFile;
-        if (baseFile) {
-          const baseFileName = path.basename(baseFile, path.extname(baseFile));
-          const currentFileName = path.basename(
-            currentOpenFile,
-            path.extname(currentOpenFile),
-          );
-          if (
-            currentFileName.startsWith(baseFileName) &&
-            currentFileName !== baseFileName
-          ) {
-            this.postMessage({
-              command: MAIN_VIEW_COMMANDS.SET_CURRENT_FILE,
-              filePath: currentOpenFile,
-              fileType,
-            });
-            commitCheckFile = currentOpenFile;
-          } else {
-            vscode.window.showInformationMessage(
-              'The current file is not a valid edited version of the base file.',
-            );
-          }
-        } else {
-          vscode.window.showInformationMessage(
-            'Please select a base file first.',
-          );
-        }
-      } else {
-        let filePathToSelect = currentOpenFile;
-        if (fileType === 'base') {
-          const derivedBaseFile =
-            this._deriveBaseFileFromLatexDiff(currentOpenFile);
-          if (derivedBaseFile) {
-            const baseExists = await WorkspaceFS.exists(derivedBaseFile);
-            if (baseExists) {
-              await this.handleRequestBaseFile({
-                command: 'requestBaseFile',
-                preserveBaseFile: true,
-              });
-              filePathToSelect = derivedBaseFile;
-            } else {
-              logger.info(
-                CHANNEL,
-                `Derived base file ${derivedBaseFile} from ${currentOpenFile} does not exist on disk`,
-              );
-              vscode.window.showInformationMessage(
-                `The base file ${derivedBaseFile} could not be found. Keeping ${currentOpenFile} selected.`,
-              );
-            }
-          }
-        }
 
-        this.postMessage({
-          command: MAIN_VIEW_COMMANDS.SET_CURRENT_FILE,
-          filePath: filePathToSelect,
-          fileType,
-        });
-        commitCheckFile = currentOpenFile;
-      }
-      if (commitCheckFile) {
-        await this._maybeSelectCommitFromDiffFile(commitCheckFile);
-      }
-    } else {
+    if (!currentOpenFile) {
       vscode.window.showInformationMessage(
         'No file is currently open or the file is not part of the workspace.',
       );
+      return;
     }
+
+    // Handle edited file type separately due to base file validation
+    if (fileType === 'edited') {
+      await this.handleGetCurrentEditedFile(currentOpenFile, message.baseFile);
+      return;
+    }
+
+    // Handle base and other file types
+    const filePathToSelect = await this.resolveFilePathForType(
+      currentOpenFile,
+      fileType,
+    );
+
+    this.postMessage({
+      command: MAIN_VIEW_COMMANDS.SET_CURRENT_FILE,
+      filePath: filePathToSelect,
+      fileType,
+    });
+
+    await this._maybeSelectCommitFromDiffFile(currentOpenFile);
+  }
+
+  /**
+   * Handle selection of current file as edited file.
+   * Validates that the file is a valid edited version of the base file.
+   */
+  private async handleGetCurrentEditedFile(
+    currentOpenFile: string,
+    baseFile?: string,
+  ): Promise<void> {
+    if (!baseFile) {
+      vscode.window.showInformationMessage('Please select a base file first.');
+      return;
+    }
+
+    const baseFileName = path.basename(baseFile, path.extname(baseFile));
+    const currentFileName = path.basename(
+      currentOpenFile,
+      path.extname(currentOpenFile),
+    );
+
+    const isValidEditedFile =
+      currentFileName.startsWith(baseFileName) &&
+      currentFileName !== baseFileName;
+
+    if (!isValidEditedFile) {
+      vscode.window.showInformationMessage(
+        'The current file is not a valid edited version of the base file.',
+      );
+      return;
+    }
+
+    this.postMessage({
+      command: MAIN_VIEW_COMMANDS.SET_CURRENT_FILE,
+      filePath: currentOpenFile,
+      fileType: 'edited',
+    });
+
+    await this._maybeSelectCommitFromDiffFile(currentOpenFile);
+  }
+
+  /**
+   * Resolve file path for base file type, deriving from latex diff if applicable.
+   */
+  private async resolveFilePathForType(
+    currentOpenFile: string,
+    fileType: string,
+  ): Promise<string> {
+    if (fileType !== 'base') {
+      return currentOpenFile;
+    }
+
+    const derivedBaseFile = this._deriveBaseFileFromLatexDiff(currentOpenFile);
+    if (!derivedBaseFile) {
+      return currentOpenFile;
+    }
+
+    const baseExists = await WorkspaceFS.exists(derivedBaseFile);
+    if (!baseExists) {
+      logger.info(
+        CHANNEL,
+        `Derived base file ${derivedBaseFile} from ${currentOpenFile} does not exist on disk`,
+      );
+      vscode.window.showInformationMessage(
+        `The base file ${derivedBaseFile} could not be found. Keeping ${currentOpenFile} selected.`,
+      );
+      return currentOpenFile;
+    }
+
+    await this.handleRequestBaseFile({
+      command: 'requestBaseFile',
+      preserveBaseFile: true,
+    });
+    return derivedBaseFile;
   }
 
   private async _maybeSelectCommitFromDiffFile(
@@ -493,34 +524,27 @@ export class FileManager extends BaseWebviewManager {
   }
 
   private async getOpenedFiles(): Promise<string[]> {
-    const workspacePath = WorkspaceFS.getPath();
-    if (!workspacePath) {
+    if (!WorkspaceFS.getPath()) {
       logger.warn(CHANNEL, 'No workspace path found for opened files');
       return [];
     }
 
-    // Use tabGroups to get only files actually open in tabs
-    // (workspace.textDocuments includes closed files still in memory)
-    const openedFiles: string[] = [];
-    for (const tabGroup of vscode.window.tabGroups.all) {
-      for (const tab of tabGroup.tabs) {
-        // TabInputText: regular text files (.tex, .md, etc.)
-        // TabInputCustom: media files opened in custom editors (images, PDFs)
-        const input = tab.input;
-        if (
+    // Extract file URIs from all tabs (text files and custom editors like images/PDFs)
+    const fileUris = vscode.window.tabGroups.all
+      .flatMap((group) => group.tabs)
+      .map((tab) => tab.input)
+      .filter(
+        (input): input is vscode.TabInputText | vscode.TabInputCustom =>
           input instanceof vscode.TabInputText ||
-          input instanceof vscode.TabInputCustom
-        ) {
-          const uri = input.uri;
-          if (uri.scheme === 'file') {
-            openedFiles.push(workspace.asRelativePath(uri.fsPath, false));
-          }
-        }
-      }
-    }
+          input instanceof vscode.TabInputCustom,
+      )
+      .map((input) => input.uri)
+      .filter((uri) => uri.scheme === 'file');
 
-    // Remove duplicates (same file can be open in multiple tab groups)
-    const relevantFiles = [...new Set(openedFiles)];
+    // Convert to relative paths and deduplicate
+    const relevantFiles = [
+      ...new Set(fileUris.map((uri) => workspace.asRelativePath(uri.fsPath, false))),
+    ];
 
     logger.debug(CHANNEL, `Found opened files: ${relevantFiles.join(', ')}`);
     return relevantFiles;

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -1078,30 +1078,27 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
    * @returns {'workflow' | 'toolUse'} The normalized session type
    */
   _determineSessionType(canonicalSession, state) {
-    // Priority 1: Canonical session descriptor (single source of truth)
-    const category = canonicalSession?.agentCategory;
-    if (
-      category === SESSION_TYPES.TOOL_USE ||
-      category === SESSION_TYPES.WORKFLOW
-    ) {
-      return category;
+    const isValidSessionType = (value) =>
+      value === SESSION_TYPES.TOOL_USE || value === SESSION_TYPES.WORKFLOW;
+
+    // Priority order: canonical > explicit > inferred > default
+    const candidates = [
+      canonicalSession?.agentCategory,
+      state.sessionType,
+      canonicalSession?.agentType ?? state.agentType,
+    ];
+
+    for (const candidate of candidates) {
+      if (isValidSessionType(candidate)) {
+        return candidate;
+      }
     }
 
-    // Priority 2: Explicit sessionType property (for legacy/webview state)
-    if (
-      state.sessionType === SESSION_TYPES.TOOL_USE ||
-      state.sessionType === SESSION_TYPES.WORKFLOW
-    ) {
-      return state.sessionType;
-    }
-
-    // Priority 3: Infer from agentType or isToolUseAgent flag (legacy support)
-    const agentType = canonicalSession?.agentType ?? state.agentType;
-    if (agentType === SESSION_TYPES.TOOL_USE || state.isToolUseAgent) {
+    // Legacy: check isToolUseAgent flag
+    if (state.isToolUseAgent) {
       return SESSION_TYPES.TOOL_USE;
     }
 
-    // Default to workflow
     return SESSION_TYPES.WORKFLOW;
   }
 
@@ -1111,20 +1108,16 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
    * separate workflowAgent/toolUseAgent fields for UI persistence.
    */
   _extractAgentValue(state, forToolUse, isCurrentlyToolUse) {
-    // Check for explicit session-specific agent value first (webview state format)
-    // Use nullish check (!= null) to preserve empty string as an explicit value
+    // Prefer explicit session-specific value (nullish check preserves empty string)
     const explicitValue = forToolUse ? state.toolUseAgent : state.workflowAgent;
     if (explicitValue != null) {
       return explicitValue;
     }
 
-    // Fall back to generic 'agent' field only if it matches the session type
-    // This prevents workflow agent from being assigned to tool-use dropdown and vice versa
-    if (state.agent != null && forToolUse === isCurrentlyToolUse) {
-      return state.agent;
-    }
-
-    return '';
+    // Use generic 'agent' only when it matches current session type
+    const shouldUseGenericAgent =
+      state.agent != null && forToolUse === isCurrentlyToolUse;
+    return shouldUseGenericAgent ? state.agent : '';
   }
 
   /**
@@ -1217,48 +1210,65 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
 
   _restoreFileArrays(state, savedState, activeFiles = {}) {
     for (const fileType of FILE_TYPES) {
-      const filesArray =
-        state[`${fileType}Files`] ||
-        state[`multiple${capitalize(fileType)}Files`] ||
-        [];
-      const isVisible =
-        activeFiles[fileType] ||
-        state[`${fileType}FilesActive`] ||
-        state[`multiple${capitalize(fileType)}FilesActive`] ||
-        false;
+      const { files, isVisible } = this._getFileArrayState(
+        state,
+        activeFiles,
+        fileType,
+      );
 
-      const targetArrayName = `${fileType}Files`;
-      const visibilityName = `${targetArrayName}Active`;
-      savedState[targetArrayName] = filesArray;
-      savedState[visibilityName] = isVisible;
+      // Update savedState
+      savedState[`${fileType}Files`] = files;
+      savedState[`${fileType}FilesActive`] = isVisible;
 
-      const multipleFilesId = `${fileType}Files`;
-      const containerId = `${fileType}FilesContainer`;
-      const toggleId = `toggle${capitalize(fileType)}Files`;
+      // Update DOM
+      this._updateFileArrayDOM(fileType, files, isVisible);
+    }
+  }
 
-      const multipleFiles = this._getElement(multipleFilesId);
-      const container = this._getElement(containerId);
-      const toggleElement = this._getElement(toggleId);
+  /**
+   * Extract file array and visibility state for a file type.
+   */
+  _getFileArrayState(state, activeFiles, fileType) {
+    const capitalizedType = capitalize(fileType);
+    const files =
+      state[`${fileType}Files`] ||
+      state[`multiple${capitalizedType}Files`] ||
+      [];
+    const isVisible =
+      activeFiles[fileType] ||
+      state[`${fileType}FilesActive`] ||
+      state[`multiple${capitalizedType}FilesActive`] ||
+      false;
+    return { files, isVisible };
+  }
 
-      // Always clear existing files first to handle restoration to empty state
-      if (multipleFiles) {
-        multipleFiles.innerHTML = '';
-      }
+  /**
+   * Update DOM elements for a file array.
+   */
+  _updateFileArrayDOM(fileType, files, isVisible) {
+    const listId = `${fileType}Files`;
+    const containerId = `${fileType}FilesContainer`;
+    const toggleId = `toggle${capitalize(fileType)}Files`;
 
-      // Set container visibility and toggle icon
-      if (container) {
-        container.style.display = isVisible ? 'block' : 'none';
-      }
-      this._setToggleIcon(toggleElement, isVisible);
+    const listElement = this._getElement(listId);
+    const container = this._getElement(containerId);
 
-      // Add files if any
-      if (filesArray.length > 0 && multipleFiles) {
-        fileList._batchMode = true;
-        filesArray.forEach((file) => {
-          fileList.add(multipleFilesId, file);
-        });
-        fileList._batchMode = false;
-      }
+    // Clear existing content
+    if (listElement) {
+      listElement.innerHTML = '';
+    }
+
+    // Set visibility
+    if (container) {
+      container.style.display = isVisible ? 'block' : 'none';
+    }
+    this._setToggleIcon(this._getElement(toggleId), isVisible);
+
+    // Populate files in batch mode
+    if (files.length > 0 && listElement) {
+      fileList._batchMode = true;
+      files.forEach((file) => fileList.add(listId, file));
+      fileList._batchMode = false;
     }
   }
 


### PR DESCRIPTION
This refactoring improves code clarity across webview-related files without changing functionality:

- ProgressViewProvider: Extract canSendToWebview() and replayPendingPrompts() helpers to reduce code duplication in 5 methods
- ProgressViewMessageHandler: Simplify useMultipleOutputs logic using nullish coalescing instead of nested if-else
- WebviewUpdater: Streamline createInstructionUpdate with cleaner early returns and optional chaining
- FileManager: Flatten handleGetCurrentFile into three focused methods with early returns instead of deep nesting; refactor getOpenedFiles using flatMap for cleaner data transformation
- messageHandlers.js: Simplify _determineSessionType using candidate iteration; extract _getFileArrayState and _updateFileArrayDOM from _restoreFileArrays; streamline _extractAgentValue logic

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Focuses on clarity and DRYness across progress view and webview modules.
> 
> - Simplifies `useMultipleOutputs` computation in `ProgressViewMessageHandler` using nullish coalescing
> - Extracts `replayPendingPrompts()` and `canSendToWebview()` in `ProgressViewProvider`; centralizes replay of pending approval/retry prompts on webview ready
> - Streamlines `WebviewUpdater.createInstructionUpdate()` with early return and optional chaining
> - Refactors `FileManager.handleGetCurrentFile` into `handleGetCurrentEditedFile` and `resolveFilePathForType`; improves empty-file and base-file derivation handling; rewrites `getOpenedFiles()` with tab traversal and deduplication
> - Cleans up webview `messageHandlers.js`: simplifies `_determineSessionType` and `_extractAgentValue`; factors `_getFileArrayState` and `_updateFileArrayDOM` out of `_restoreFileArrays` for readability
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 19dc59e3cbec4135b3d59d9da9b002a9fdd5bde6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->