### PR TITLE
Fix follow-up message box issue

### DIFF
--- a/src/progressView/styles/follow-up-input.css
+++ b/src/progressView/styles/follow-up-input.css
@@ -16,9 +16,12 @@
   display: grid;
 }
 
-/* Queued messages align with textarea column only */
+/* Queued messages span full width above textarea */
 .follow-up-container > .queued-follow-ups-collapsible {
-  grid-column: 1;
+  display: block;
+  grid-column: 1 / -1;
+  min-width: 0;
+  box-sizing: border-box;
 }
 
 /* Input row children participate directly in grid */


### PR DESCRIPTION
The queued messages collapsible now spans both grid columns (1 / -1) to match the full container width, while textarea and buttons remain in their respective columns below.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts follow-up input layout so queued messages span the full container width above the textarea, improving alignment and wrapping.
> 
> - Update `.queued-follow-ups-collapsible` to `display: block`, `grid-column: 1 / -1`, `min-width: 0`, and `box-sizing: border-box` so it spans full width above the input
> - Container visibility and input/action grid structure remain unchanged
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit afa9028b0f1be5788cd0484e644dfad5c33d813b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->