### PR TITLE
Remove repetitive title display in tool use

### DIFF
--- a/src/memoryView/modules/messageHandlers.js
+++ b/src/memoryView/modules/messageHandlers.js
@@ -3,10 +3,7 @@ import { memoryViewDomHandler } from './domHandlers.js';
 import { ELEMENT_IDS } from './constants.js';
 import { MEMORY_VIEW_COMMANDS } from '@common/webview/commands.js';
 import { BaseWebviewMessageHandler } from '@common/BaseWebviewMessageHandler.js';
-import {
-  safeGetElementById,
-  setElementDisabled,
-} from '@common/domUtils.js';
+import { safeGetElementById, setElementDisabled } from '@common/domUtils.js';
 
 /**
  * Handles messages from the extension for the memory view.

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -67,7 +67,9 @@ export class ProgressEventHandler {
    * Update agentTypeFilter to match the session category if needed.
    * Only updates when filter is not 'all' and doesn't already match.
    */
-  private maybeUpdateFilterForCategory(category: AgentCategory | undefined): void {
+  private maybeUpdateFilterForCategory(
+    category: AgentCategory | undefined,
+  ): void {
     if (
       category &&
       this.state.agentTypeFilter !== 'all' &&

--- a/src/progressView/modules/formatters/normalizers.js
+++ b/src/progressView/modules/formatters/normalizers.js
@@ -213,8 +213,7 @@ export const normalizeToolUseLog = (structured) => {
 
   // Extract tool name from either toolName or tool field
   const rawToolName = parsed.toolName ?? parsed.tool;
-  const toolName =
-    typeof rawToolName === 'string' ? rawToolName.trim() : '';
+  const toolName = typeof rawToolName === 'string' ? rawToolName.trim() : '';
 
   // Detect user feedback: when userInstruction is present, this is user-provided
   // guidance rather than a system error, even if isError is true

--- a/src/tools/arxiv/ArxivMetadataTool.ts
+++ b/src/tools/arxiv/ArxivMetadataTool.ts
@@ -82,7 +82,7 @@ export class ArxivMetadataTool extends defineTool({
     };
 
     return {
-      summary: `Retrieved metadata for arXiv ID ${metadata.id}`,
+      summary: `Retrieved: ${metadata.id}`,
       output: JSON.stringify(metadata, null, 2),
     };
   }

--- a/src/tools/arxiv/ArxivSearchTool.ts
+++ b/src/tools/arxiv/ArxivSearchTool.ts
@@ -152,7 +152,7 @@ export class ArxivSearchTool extends defineTool({
 
     const fieldLabel = searchField !== 'all' ? ` (${searchField})` : '';
     return {
-      summary: `Found ${results.length} arXiv result${results.length === 1 ? '' : 's'} for "${trimmedQuery}"${fieldLabel}`,
+      summary: `Found: ${results.length} result${results.length === 1 ? '' : 's'} for "${trimmedQuery}"${fieldLabel}`,
       output: JSON.stringify(payload, null, 2),
     };
   }

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -30,7 +30,7 @@ export class BashTool extends defineTool({
           ? `${input.command.slice(0, 57)}…`
           : input.command;
       return {
-        summary: `Ran bash: ${commandPreview}`,
+        summary: `Ran: ${commandPreview}`,
         output: result.stdout || '',
       };
     }

--- a/src/tools/citation/CrossrefDoiTool.ts
+++ b/src/tools/citation/CrossrefDoiTool.ts
@@ -63,7 +63,7 @@ export class CrossrefDoiTool extends defineTool({
     };
 
     return {
-      summary: `Retrieved Crossref metadata for DOI ${metadata.doi}`,
+      summary: `Retrieved: DOI ${metadata.doi}`,
       output: JSON.stringify(metadata, null, 2),
     };
   }

--- a/src/tools/citation/CrossrefSearchTool.ts
+++ b/src/tools/citation/CrossrefSearchTool.ts
@@ -105,7 +105,7 @@ export class CrossrefSearchTool extends defineTool({
     };
 
     return {
-      summary: `Found ${results.length} Crossref result${results.length === 1 ? '' : 's'} for "${trimmedQuery}"`,
+      summary: `Found: ${results.length} result${results.length === 1 ? '' : 's'} for "${trimmedQuery}"`,
       output: JSON.stringify(payload, null, 2),
     };
   }

--- a/src/tools/glob.ts
+++ b/src/tools/glob.ts
@@ -96,7 +96,7 @@ export class GlobTool extends defineTool({
     const header = `Matches for pattern "${input.pattern}" under ${display}`;
     const lines = sorted.map((item) => toPosixPath(item.relativePath));
     return {
-      summary: `glob "${input.pattern}" under ${display}`,
+      summary: `Matched: "${input.pattern}" under ${display}`,
       output: formatToolOutput(header, lines, '(no matches)'),
     };
   }

--- a/src/tools/texcount/TexcountTool.ts
+++ b/src/tools/texcount/TexcountTool.ts
@@ -58,9 +58,7 @@ export class TexcountTool extends defineTool({
       };
     }
 
-    const summary = `texcount analysis for ${files.length} file${
-      files.length === 1 ? '' : 's'
-    }`;
+    const summary = `Analyzed: ${files.length} file${files.length === 1 ? '' : 's'}`;
 
     return {
       summary,

--- a/src/tools/web/WebFetchTool.ts
+++ b/src/tools/web/WebFetchTool.ts
@@ -143,7 +143,7 @@ export class WebFetchTool extends defineTool({
     }
 
     return {
-      summary: `Fetched ${url}`,
+      summary: url,
       output: sections.join('\n\n'),
     };
   }

--- a/src/tools/web/WebFetchTool.ts
+++ b/src/tools/web/WebFetchTool.ts
@@ -143,7 +143,7 @@ export class WebFetchTool extends defineTool({
     }
 
     return {
-      summary: url,
+      summary: `Fetched: ${url}`,
       output: sections.join('\n\n'),
     };
   }

--- a/src/tools/web/WebSearchTool.ts
+++ b/src/tools/web/WebSearchTool.ts
@@ -96,13 +96,13 @@ export class WebSearchTool extends defineTool({
 
     if (results.length === 0) {
       return {
-        summary: `Search "${query}" (no results)`,
+        summary: `"${query}" (no results)`,
         output:
           'No results found. Note: This search uses DuckDuckGo Instant Answers API which works best for factual/entity queries. For general web searches, try rephrasing the query or use more specific terms.',
       };
     }
     return {
-      summary: `Search "${query}"`,
+      summary: `"${query}"`,
       output: results.slice(0, max_results).join('\n\n'),
     };
   }

--- a/src/tools/web/WebSearchTool.ts
+++ b/src/tools/web/WebSearchTool.ts
@@ -96,13 +96,13 @@ export class WebSearchTool extends defineTool({
 
     if (results.length === 0) {
       return {
-        summary: `"${query}" (no results)`,
+        summary: `Searched: "${query}" (no results)`,
         output:
           'No results found. Note: This search uses DuckDuckGo Instant Answers API which works best for factual/entity queries. For general web searches, try rephrasing the query or use more specific terms.',
       };
     }
     return {
-      summary: `"${query}"`,
+      summary: `Searched: "${query}"`,
       output: results.slice(0, max_results).join('\n\n'),
     };
   }

--- a/src/tools/wolfram/WolframTool.ts
+++ b/src/tools/wolfram/WolframTool.ts
@@ -27,7 +27,7 @@ export class WolframTool extends defineTool({
     });
     if (result.success) {
       return {
-        summary: 'Executed Wolfram code',
+        summary: 'Executed: code evaluation',
         output: result.output ?? '',
       };
     }

--- a/src/tools/wolfram/WolframTool.ts
+++ b/src/tools/wolfram/WolframTool.ts
@@ -27,7 +27,7 @@ export class WolframTool extends defineTool({
     });
     if (result.success) {
       return {
-        summary: 'Executed: code evaluation',
+        summary: 'Executed',
         output: result.output ?? '',
       };
     }


### PR DESCRIPTION
Tool summaries were repeating the tool name when displayed in the UI, e.g., "Tool Use: bash — Ran bash: git status" showed "bash" twice.

Updated tool summaries to avoid including the tool name since it's already shown in the title prefix:
- bash: "Ran bash: X" → "Ran: X"
- glob: "glob X" → "Matched: X"
- texcount: "texcount analysis..." → "Analyzed: X files"
- wolfram: "Executed Wolfram code" → "Executed: code evaluation"
- arxiv_metadata: "Retrieved metadata for arXiv ID X" → "Retrieved: X"
- arxiv_search: "Found N arXiv results" → "Found: N results"
- crossref_doi: "Retrieved Crossref metadata" → "Retrieved: DOI X"
- crossref_search: "Found N Crossref results" → "Found: N results"
- web_search: "Search X" → "X"
- web_fetch: "Fetched X" → X (just the URL)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Streamlines tool result summaries to avoid repeating the tool name already shown by the UI prefix.
> 
> - Standardizes summaries across tools to concise verb-first phrasing (e.g., `bash` → `Ran: …`, `glob` → `Matched: …`, `texcount` → `Analyzed: …`, `wolfram` → `Executed`, `arxiv_*`/`crossref_*` → `Retrieved:`/`Found: …`, `web_*` → `Fetched:`/`Searched:`)
> - Minor non-functional cleanups in progress/memory view and normalizers (formatting and small signature wrap), no logic changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fee4780e86d8e639738b5c9012d7825582e38bc3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->