### PR TITLE
Investigate cleared thinking trigger timing

### DIFF
--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -586,9 +586,9 @@ export class ModelHandlerAnthropic extends ModelHandler<
         // Add thinking block clearing strategy if reasoning is enabled
         // NOTE: The Anthropic API doesn't support a trigger for thinking clearing,
         // so we implement client-side triggering by only including the edit when
-        // token count exceeds the threshold (or when count is unavailable).
+        // token count is measured and exceeds the threshold.
         const shouldClearThinking =
-          measuredInputTokens === undefined ||
+          measuredInputTokens !== undefined &&
           measuredInputTokens >= triggerTokens;
 
         if (


### PR DESCRIPTION
Previously, thinking was cleared whenever token count was unavailable OR exceeded the threshold. This caused premature clearing on early turns when tokens hadn't been measured yet. Now thinking is only cleared when we have a measured token count that exceeds the threshold.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refines Anthropic client-side context management to avoid premature reasoning clearance.
> 
> - In `modelHandlerAnthropic.ts`, updates `shouldClearThinking` to require a measured token count (`measuredInputTokens !== undefined`) that meets/exceeds the computed `triggerTokens` before adding `clear_thinking_20251015` edit
> - Updates inline comment to reflect the measured-token requirement
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fc46ba1347b701eeececc755ca4f697ffe187a04. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->