### PR TITLE
Simplify and improve code clarity

### DIFF
--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -55,6 +55,25 @@ import {
 // All debug options (context + file options) are derived at maybeSaveDebugObject call sites.
 
 // ============================================================================
+// Helpers
+// ============================================================================
+
+type ErrorLogger = { error: (msg: string) => void };
+
+/** Log detailed repetition detection error for debugging. */
+function logRepetitionDetected(
+  newResponse: string,
+  messages: ProviderMessage[],
+  logger: ErrorLogger,
+): void {
+  const preview = newResponse.substring(0, REPETITION_DETECTION_THRESHOLD);
+  logger.error(`The new response is (first ${REPETITION_DETECTION_THRESHOLD} chars): ${preview}`);
+  logger.error('Massive repetition detected - skipping this response');
+  logger.error('Message structure when repetition detected:');
+  logger.error(JSON.stringify(messageToSkeleton(messages), null, 2));
+}
+
+// ============================================================================
 // Cycle Fields Schema (Extends Base)
 // ============================================================================
 
@@ -550,14 +569,7 @@ class ResponseProcessNode<C> extends BaseNode<
       );
 
       if (repetitionResult.massiveRepetitionDetected && newResponse) {
-        logger.error(
-          `The new response is (first ${REPETITION_DETECTION_THRESHOLD} chars): ${newResponse.substring(0, REPETITION_DETECTION_THRESHOLD)}`,
-        );
-        logger.error('Massive repetition detected - skipping this response');
-        logger.error('Message structure when repetition detected:');
-        logger.error(
-          JSON.stringify(messageToSkeleton(prepRes.messages), null, 2),
-        );
+        logRepetitionDetected(newResponse, prepRes.messages, logger);
       }
 
       let processedResponse: string | undefined;

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -68,16 +68,22 @@ interface ToolValidationDiagnostics {
   }>;
 }
 
+/**
+ * Parse tool input, handling various input formats from different model providers.
+ * Returns parsed JSON if input is a JSON string, otherwise returns input as-is.
+ */
 function parseToolInput(
   raw: unknown,
   callId: string,
   logger: AgentLogger,
 ): unknown {
-  if (raw === null) {
+  // Handle null/undefined
+  if (raw === null || raw === undefined) {
     logger.warn(`Tool call ${callId}: Received null input, using empty object`);
     return {};
   }
 
+  // Handle primitives (boolean, number) - pass through with warning
   if (typeof raw === 'boolean' || typeof raw === 'number') {
     logger.warn(
       `Tool call ${callId}: Received primitive input (${String(raw)}), passing through`,
@@ -85,47 +91,77 @@ function parseToolInput(
     return raw;
   }
 
-  if (typeof raw !== 'string') return raw ?? {};
+  // Handle objects/arrays - pass through directly
+  if (typeof raw !== 'string') {
+    return raw;
+  }
+
+  // Handle strings - try to parse as JSON
   try {
     return JSON.parse(raw);
-  } catch (error) {
+  } catch {
     logger.warn(
       `Tool call ${callId}: Failed to parse input as JSON, using raw string`,
-      { data: error },
     );
     return raw;
   }
 }
 
+/** Check if an error is a Zod validation error (has issues array). */
+function isZodValidationError(
+  error: unknown,
+): error is { issues: Array<Record<string, unknown>> } {
+  return (
+    error !== null &&
+    typeof error === 'object' &&
+    'issues' in error &&
+    Array.isArray((error as { issues?: unknown }).issues)
+  );
+}
+
+/** Format a Zod issue into a readable diagnostic entry. */
+function formatZodIssue(issue: Record<string, unknown>): {
+  path: string;
+  message: string;
+  expected?: unknown;
+  received?: unknown;
+  code?: string;
+} {
+  return {
+    path: Array.isArray(issue.path) ? issue.path.join('.') : '',
+    message: String(issue.message ?? ''),
+    expected: issue.expected,
+    received: issue.received,
+    code: typeof issue.code === 'string' ? issue.code : undefined,
+  };
+}
+
+/**
+ * Normalize a tool call error into a user-friendly message with optional diagnostics.
+ */
 function normalizeToolCallError(
   toolName: string,
   error: unknown,
 ): { message: string; diagnostics?: ToolValidationDiagnostics } {
-  if (error && typeof error === 'object' && 'issues' in error) {
-    const zodError = error as { issues?: any[] };
-    const issues = Array.isArray(zodError.issues) ? zodError.issues : [];
+  // Handle Zod validation errors with structured diagnostics
+  if (isZodValidationError(error)) {
     return {
       message: `${toolName}: Invalid parameters provided`,
       diagnostics: {
         type: DIAGNOSTIC_TYPE_VALIDATION_ERROR,
-        issues,
-        formatted: issues.map((issue) => ({
-          path: Array.isArray(issue.path) ? issue.path.join('.') : '',
-          message: issue.message,
-          expected: issue.expected,
-          received: issue.received,
-          code: issue.code,
-        })),
+        issues: error.issues,
+        formatted: error.issues.map(formatZodIssue),
       },
     };
   }
 
-  const fallbackMessage =
+  // Handle standard errors and unknown types
+  const message =
     error instanceof Error
       ? `${toolName}: ${error.message}`
       : `${toolName}: ${String(error)}`;
 
-  return { message: fallbackMessage };
+  return { message };
 }
 
 // ============================================================================
@@ -849,31 +885,47 @@ class ToolUseDispatchNode<C> extends BaseNode<
       data: toolUseLog,
     });
 
-    if (result.files && result.files.length > 0) {
-      const toAdd: FileLocation[] = [];
-      for (const attachment of result.files) {
-        const candidate = attachment.path;
-        if (typeof candidate !== 'string' || candidate.trim() === '') {
-          continue;
-        }
-        // Convert to FileLocation - pathToLocation handles both absolute and relative paths,
-        // including external paths outside the workspace
-        const location = pathToLocation(candidate);
-        try {
-          // Use AbsoluteFS for file existence check to support external paths
-          const exists = await AbsoluteFS.exists(location.absolutePath);
-          if (exists) {
-            toAdd.push(location);
-          }
-        } catch (_err) {
-          // Ignore errors when checking existence
-        }
+    // Process media file attachments if present
+    const mediaLocations = await this.collectValidMediaLocations(result.files);
+    if (mediaLocations.length > 0) {
+      workspace.media.addMediaFiles(mediaLocations);
+    }
+  }
+
+  /**
+   * Collect valid file locations from tool result attachments.
+   * Filters out invalid paths and non-existent files.
+   */
+  private async collectValidMediaLocations(
+    files: ToolResult['files'],
+  ): Promise<FileLocation[]> {
+    if (!files || files.length === 0) {
+      return [];
+    }
+
+    const validLocations: FileLocation[] = [];
+
+    for (const attachment of files) {
+      const path = attachment.path;
+
+      // Skip invalid paths
+      if (typeof path !== 'string' || path.trim() === '') {
+        continue;
       }
-      if (toAdd.length > 0) {
-        // addMediaFiles handles deduplication (both within toAdd and against existing files)
-        workspace.media.addMediaFiles(toAdd);
+
+      const location = pathToLocation(path);
+
+      // Check if file exists (ignore errors)
+      try {
+        if (await AbsoluteFS.exists(location.absolutePath)) {
+          validLocations.push(location);
+        }
+      } catch {
+        // Ignore file access errors
       }
     }
+
+    return validLocations;
   }
 
   /**

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -58,7 +58,7 @@ import {
 
 interface ToolValidationDiagnostics {
   type: typeof DIAGNOSTIC_TYPE_VALIDATION_ERROR;
-  issues: any;
+  issues: Array<Record<string, unknown>>;
   formatted: Array<{
     path: string;
     message: string;
@@ -895,6 +895,7 @@ class ToolUseDispatchNode<C> extends BaseNode<
   /**
    * Collect valid file locations from tool result attachments.
    * Filters out invalid paths and non-existent files.
+   * Uses parallel file existence checks for better performance.
    */
   private async collectValidMediaLocations(
     files: ToolResult['files'],
@@ -903,29 +904,27 @@ class ToolUseDispatchNode<C> extends BaseNode<
       return [];
     }
 
-    const validLocations: FileLocation[] = [];
+    const results = await Promise.all(
+      files.map(async (attachment) => {
+        const path = attachment.path;
 
-    for (const attachment of files) {
-      const path = attachment.path;
-
-      // Skip invalid paths
-      if (typeof path !== 'string' || path.trim() === '') {
-        continue;
-      }
-
-      const location = pathToLocation(path);
-
-      // Check if file exists (ignore errors)
-      try {
-        if (await AbsoluteFS.exists(location.absolutePath)) {
-          validLocations.push(location);
+        // Skip invalid paths
+        if (typeof path !== 'string' || path.trim() === '') {
+          return null;
         }
-      } catch {
-        // Ignore file access errors
-      }
-    }
 
-    return validLocations;
+        const location = pathToLocation(path);
+
+        // Check if file exists (ignore errors)
+        try {
+          return (await AbsoluteFS.exists(location.absolutePath)) ? location : null;
+        } catch {
+          return null;
+        }
+      }),
+    );
+
+    return results.filter((loc): loc is FileLocation => loc !== null);
   }
 
   /**

--- a/src/agent/implementations/flows/reflection/nodes/OutputNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/OutputNode.ts
@@ -37,6 +37,28 @@ interface OutputPrepInput {
 type OutputExecResult = RoundOutput;
 
 // ============================================================================
+// Helpers
+// ============================================================================
+
+type WarnLogger = { warn: (msg: string) => void };
+
+/**
+ * Execute an operation that can fail gracefully.
+ * Logs warnings on failure but doesn't throw.
+ */
+async function tryOperation(
+  label: string,
+  operation: () => Promise<void>,
+  logger: WarnLogger,
+): Promise<void> {
+  try {
+    await operation();
+  } catch (error) {
+    logger.warn(`${label} failed: ${toErrorMessage(error)}`);
+  }
+}
+
+// ============================================================================
 // Node Implementation
 // ============================================================================
 
@@ -70,52 +92,39 @@ export class OutputNode<C = unknown> extends Node<
 
   async exec(prepRes: OutputPrepInput): Promise<OutputExecResult> {
     const { outputHandler, setting, logger } = this.services;
-    const {
-      currentRound,
-      outputLocation,
-      endTurn,
-      baseFiles,
-      ensureXmlStructure,
-    } = prepRes;
-
-    // Helper for non-critical operations that can fail gracefully
-    const tryOperation = async (
-      label: string,
-      operation: () => Promise<void>,
-    ): Promise<void> => {
-      try {
-        await operation();
-      } catch (error) {
-        logger.warn(`${label} failed: ${toErrorMessage(error)}`);
-      }
-    };
+    const { currentRound, outputLocation, endTurn, baseFiles, ensureXmlStructure } = prepRes;
 
     // Only process if turn ended (model completed response)
     if (endTurn) {
       logger.debug(`Processing output for round ${currentRound}`);
 
       if (ensureXmlStructure) {
-        await tryOperation('XML structure', () =>
-          outputHandler.ensureXmlStructure(
-            outputLocation,
-            setting.documentTag ?? 'document',
-          ),
+        await tryOperation(
+          'XML structure',
+          () => outputHandler.ensureXmlStructure(outputLocation, setting.documentTag ?? 'document'),
+          logger,
         );
       }
 
-      await tryOperation('Output processing', () =>
-        outputHandler.processOutputFiles(outputLocation, currentRound),
+      await tryOperation(
+        'Output processing',
+        () => outputHandler.processOutputFiles(outputLocation, currentRound),
+        logger,
       );
 
       if (outputHandler.hasRoundOutputs(currentRound)) {
-        await tryOperation('Latexdiff', () =>
-          this.handleLatexdiff(currentRound, baseFiles),
+        await tryOperation(
+          'Latexdiff',
+          () => this.handleLatexdiff(currentRound, baseFiles),
+          logger,
         );
       }
     }
 
-    await tryOperation('Round finalization', () =>
-      outputHandler.finalizeRound(outputLocation, currentRound, { endTurn }),
+    await tryOperation(
+      'Round finalization',
+      () => outputHandler.finalizeRound(outputLocation, currentRound, { endTurn }),
+      logger,
     );
 
     // Get round artifacts - this is critical, throw if it fails

--- a/src/agent/implementations/flows/reflection/nodes/ResponseCycleNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/ResponseCycleNode.ts
@@ -41,6 +41,7 @@ import {
   finalizeRound,
   type CycleStateSlices,
 } from '@agent/core/flows/CycleServices';
+import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
 import type { AgentFileLocation } from '@utils/files';
 
 import {
@@ -68,6 +69,32 @@ type CycleExecResult =
   | ({ kind: 'success'; endTurn: boolean } & CycleCompletionResult &
       CycleStateSlices)
   | { kind: 'error'; error: Error };
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/**
+ * Initialize cycle fields on shared state for native nesting.
+ * Resets all transient cycle state before running the cycle flow.
+ */
+function initializeCycleFields(
+  shared: ReflectionFlowShared,
+  messages: ProviderMessage[],
+  outputLocation: AgentFileLocation,
+): void {
+  shared.messages = messages;
+  shared.outputLocation = outputLocation;
+  shared.endTurn = false;
+  shared.shouldStop = false;
+  shared.outputExists = false;
+  shared.systemPrompt = undefined;
+  shared.responseObject = undefined;
+  shared.responseTimeMs = undefined;
+  shared.stopReason = undefined;
+  shared.processedResponse = undefined;
+  shared.lastError = undefined;
+}
 
 // ============================================================================
 // Node Implementation
@@ -161,18 +188,8 @@ export class ResponseCycleNode<C = unknown> extends Node<
     const onRoundFinalized = this.services.getUsageRecorder();
 
     try {
-      // === NATIVE NESTING: Populate cycle fields directly on shared ===
-      shared.messages = initializedMessages;
-      shared.outputLocation = prepRes.outputLocation;
-      shared.endTurn = false;
-      shared.shouldStop = false;
-      shared.outputExists = false;
-      shared.systemPrompt = undefined;
-      shared.responseObject = undefined;
-      shared.responseTimeMs = undefined;
-      shared.stopReason = undefined;
-      shared.processedResponse = undefined;
-      shared.lastError = undefined;
+      // Initialize cycle fields for native nesting
+      initializeCycleFields(shared, initializedMessages, prepRes.outputLocation);
 
       // Create and run the flow directly on shared (native nesting)
       // Spread parent services directly - no intermediate cycleOptions object

--- a/src/agent/implementations/flows/reflection/runReflectionFlow.ts
+++ b/src/agent/implementations/flows/reflection/runReflectionFlow.ts
@@ -114,6 +114,55 @@ interface DerivedConfig {
   outputExt: string;
 }
 
+/** Determine if XML structure enforcement is needed based on settings and scratchpad usage. */
+function shouldEnforceXmlStructure(
+  setting: AgentWorkflowSetting,
+  useScratchpad: boolean,
+): boolean {
+  // Explicit mode takes precedence
+  if (setting.xmlStructureMode !== undefined) {
+    switch (setting.xmlStructureMode) {
+      case 'always':
+        return true;
+      case 'scratchpadOnly':
+        return useScratchpad;
+      case 'never':
+        return false;
+    }
+  }
+
+  // Fall back to agent type defaults
+  switch (setting.agentType) {
+    case 'CoT':
+      return true;
+    case 'direct':
+      return useScratchpad;
+    default:
+      return false;
+  }
+}
+
+/** Compute the total number of rounds based on settings and prompt. */
+function computeTotalRounds(
+  setting: AgentWorkflowSetting,
+  prompt: RunReflectionFlowInput['prompt'],
+): number {
+  if (setting.maxRounds !== undefined) {
+    return setting.maxRounds;
+  }
+
+  if (setting.agentType === 'direct') {
+    return 1;
+  }
+
+  const requests = Array.isArray(prompt.userRequest)
+    ? prompt.userRequest
+    : prompt.userRequest
+      ? [prompt.userRequest]
+      : [];
+  return Math.max(setting.rounds ?? 2, requests.length);
+}
+
 /** Derive configuration values from settings and prompts. */
 function deriveConfig(
   setting: AgentWorkflowSetting,
@@ -121,37 +170,10 @@ function deriveConfig(
 ): DerivedConfig {
   const useScratchpad = setting.prefills?.includes('<scratchpad>') ?? false;
 
-  // Determine XML structure enforcement
-  let shouldEnsureXmlStructure = false;
-  if (setting.xmlStructureMode !== undefined) {
-    shouldEnsureXmlStructure =
-      setting.xmlStructureMode === 'always' ||
-      (setting.xmlStructureMode === 'scratchpadOnly' && useScratchpad);
-  } else if (setting.agentType === 'CoT') {
-    shouldEnsureXmlStructure = true;
-  } else if (setting.agentType === 'direct') {
-    shouldEnsureXmlStructure = useScratchpad;
-  }
-
-  // Compute total rounds
-  let totalRounds: number;
-  if (setting.maxRounds !== undefined) {
-    totalRounds = setting.maxRounds;
-  } else if (setting.agentType === 'direct') {
-    totalRounds = 1;
-  } else {
-    const requests = Array.isArray(prompt.userRequest)
-      ? prompt.userRequest
-      : prompt.userRequest
-        ? [prompt.userRequest]
-        : [];
-    totalRounds = Math.max(setting.rounds ?? 2, requests.length);
-  }
-
   return {
     useScratchpad,
-    shouldEnsureXmlStructure,
-    totalRounds,
+    shouldEnsureXmlStructure: shouldEnforceXmlStructure(setting, useScratchpad),
+    totalRounds: computeTotalRounds(setting, prompt),
     outputExt: useScratchpad ? 'xml' : setting.outputExt,
   };
 }

--- a/src/agent/implementations/flows/tooluse/ToolUseFlowContext.ts
+++ b/src/agent/implementations/flows/tooluse/ToolUseFlowContext.ts
@@ -38,34 +38,49 @@ export interface ToolUseFlowContext<C = unknown> {
 }
 
 // ============================================================================
-// Tool Resolution Helper
+// Tool Resolution
 // ============================================================================
 
-interface ResolveToolsParams {
-  tools: AgentToolUseSetting['tools'];
+interface ToolResolutionContext {
   toolRegistry: IToolRegistry;
   logger: { warn: (msg: string) => void };
 }
 
-/** Resolve tool definitions from setting, validating against registry. */
-function resolveTools(params: ResolveToolsParams): ToolDefinition[] {
-  const { tools, toolRegistry, logger } = params;
+/** Normalize tool config to a ToolDefinition. */
+function normalizeToolConfig(
+  config: string | ToolDefinition,
+): ToolDefinition {
+  return typeof config === 'string' ? { name: config } : config;
+}
 
+/**
+ * Resolve tool definitions from agent settings, validating against registry.
+ * Optionally injects the memory tool if enabled in user settings.
+ */
+function resolveTools(
+  tools: AgentToolUseSetting['tools'],
+  ctx: ToolResolutionContext,
+): ToolDefinition[] {
+  const { toolRegistry, logger } = ctx;
   const toolConfigs = Array.isArray(tools) ? tools : [];
+
+  // Resolve configured tools
   const resolved: ToolDefinition[] = [];
   const resolvedNames = new Set<string>();
 
-  for (const t of toolConfigs) {
-    const def = typeof t === 'string' ? { name: t } : t;
+  for (const config of toolConfigs) {
+    const def = normalizeToolConfig(config);
+
     if (!toolRegistry.has(def.name)) {
       logger.warn(`Tool "${def.name}" not found in registry`);
       continue;
     }
+
     resolved.push(def);
     resolvedNames.add(def.name);
   }
 
-  // Inject memory tool if enabled and not already present
+  // Auto-inject memory tool if enabled and not already configured
   if (getToolUseMemoryEnabled() && !resolvedNames.has('memory')) {
     const memoryTool = toolRegistry.get('memory');
     if (memoryTool) {
@@ -91,11 +106,7 @@ export function createToolUseFlowContext<C = unknown>(
   const toolRegistry = init.toolRegistry ?? getDefaultToolRegistry();
   const sessionLifecycle = new ToolUseSessionLifecycle(streamId);
 
-  const resolvedTools = resolveTools({
-    tools: setting.tools,
-    toolRegistry,
-    logger,
-  });
+  const resolvedTools = resolveTools(setting.tools, { toolRegistry, logger });
 
   const services: ToolUseServices<C> = {
     ...init,


### PR DESCRIPTION
Refactor agent and flow code to improve clarity and maintainability:

- runReflectionFlow.ts: Extract shouldEnforceXmlStructure and computeTotalRounds helpers using switch statements for clearer decision logic

- ToolUseCycleFlow.ts: Improve parseToolInput and normalizeToolCallError functions with better type guards and structure; extract collectValidMediaLocations helper for media file handling

- ResponseCycleNode.ts: Extract initializeCycleFields helper to simplify the exec method initialization logic

- OutputNode.ts: Extract tryOperation to module-level helper for non-critical operations that can fail gracefully

- ResponseCycleFlow.ts: Extract logRepetitionDetected helper for cleaner repetition detection logging

- ToolUseFlowContext.ts: Add normalizeToolConfig helper and restructure resolveTools function for improved clarity

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Consolidates logic into small helpers and clarifies control flow across response, tool-use, and reflection paths.
> 
> - **Response**: Add `logRepetitionDetected` in `ResponseCycleFlow` and `initializeCycleFields` in `ResponseCycleNode` to centralize logging and shared-state setup
> - **Tool-use**: Strengthen types for validation diagnostics; add `parseToolInput` (robust JSON/primitive/object handling) and `normalizeToolCallError` (Zod-aware); extract `collectValidMediaLocations` for parallel file checks and cleaner media attachment handling
> - **Output handling**: Move non-critical failure wrapper to module-level `tryOperation` in `OutputNode` and use it for XML enforcement, processing, latexdiff, and finalization
> - **Reflection config**: Extract `shouldEnforceXmlStructure` and `computeTotalRounds` helpers in `runReflectionFlow` for clearer decision logic
> - **Tool resolution**: Add `normalizeToolConfig` and refactor `resolveTools` in `ToolUseFlowContext`, keeping memory-tool auto-injection behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9c910997a2131c610419191d8e99da27b6beffca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->