### PR TITLE
Simplify and improve code clarity

### DIFF
--- a/src/common/constants/streamStatus.ts
+++ b/src/common/constants/streamStatus.ts
@@ -86,12 +86,5 @@ export type ExecutionStatus = z.infer<typeof ExecutionStatusSchema>;
 export function executionToEndStatus(
   status: ExecutionStatus,
 ): 'error' | 'stopped' {
-  switch (status) {
-    case EXECUTION_STATUS.COMPLETED:
-      return 'stopped';
-    case EXECUTION_STATUS.INTERRUPTED:
-      return 'error';
-    case EXECUTION_STATUS.ERROR:
-      return 'error';
-  }
+  return status === EXECUTION_STATUS.COMPLETED ? 'stopped' : 'error';
 }

--- a/src/common/webview/BaseViewContentProvider.ts
+++ b/src/common/webview/BaseViewContentProvider.ts
@@ -147,71 +147,61 @@ export abstract class BaseViewContentProvider {
     }
   }
 
+  /** Common module descriptors from src/common */
+  private static readonly COMMON_MODULE_DESCRIPTORS: readonly ModuleDescriptor[] =
+    [
+      { key: 'commonStyleUri', path: 'styles/common.css' },
+      { key: 'webviewStateUri', path: 'modules/webviewState.js' },
+      { key: 'webviewContextUri', path: 'modules/webviewContext.js' },
+      { key: 'commandsUri', path: 'webview/commands.js' },
+      { key: 'webviewThemeHandlersUri', path: 'webview/themeHandlers.js' },
+      { key: 'templateUtilsUri', path: 'modules/templateUtils.js' },
+      { key: 'recordingButtonManagerUri', path: 'modules/RecordingButtonManager.js' },
+      { key: 'textareaUtilsUri', path: 'modules/textareaUtils.js' },
+      { key: 'htmlEncodingUri', path: 'modules/htmlEncoding.js' },
+      { key: 'iconConstantsUri', path: 'modules/iconConstants.js' },
+      { key: 'baseWebviewMessageHandlerUri', path: 'modules/BaseWebviewMessageHandler.js' },
+      { key: 'baseFileUtilsUri', path: 'modules/files/baseFileUtils.js' },
+      { key: 'domUtilsUri', path: 'modules/domUtils.js' },
+      { key: 'baseDomHandlerUri', path: 'modules/BaseDomHandler.js' },
+      { key: 'stringUtilsUri', path: 'modules/stringUtils.js' },
+      { key: 'pathUtilsUri', path: 'modules/pathUtils.js' },
+      { key: 'debounceUri', path: 'modules/debounce.js' },
+      { key: 'clipboardUtilsUri', path: 'modules/clipboardUtils.js' },
+      { key: 'streamStatusUri', path: 'constants/streamStatus.js' },
+      { key: 'todoStatusUri', path: 'constants/todoStatus.js' },
+      { key: 'agentTypesUri', path: 'constants/agentTypes.js' },
+      { key: 'toggleStateStoreUri', path: 'modules/ToggleStateStore.js' },
+    ];
+
+  /** Node module descriptors from node_modules */
+  private static readonly NODE_MODULE_DESCRIPTORS: readonly ModuleDescriptor[] =
+    [
+      { key: 'vscodeElementsBundleUri', path: '@vscode-elements/elements/dist/bundled.js' },
+      { key: 'codiconUri', path: '@vscode/codicons/dist/codicon.css' },
+      { key: 'codiconsFontUri', path: '@vscode/codicons/dist/codicon.ttf' },
+    ];
+
   /**
    * Common URIs used by all views
    */
   private getCommonModuleUris(
     webview: vscode.Webview,
   ): Record<string, vscode.Uri> {
-    return {
-      commonStyleUri: this.getCommonUri(webview, 'styles/common.css'),
-      webviewStateUri: this.getCommonUri(webview, 'modules/webviewState.js'),
-      webviewContextUri: this.getCommonUri(
-        webview,
-        'modules/webviewContext.js',
-      ),
-      commandsUri: this.getCommonUri(webview, 'webview/commands.js'),
-      webviewThemeHandlersUri: this.getCommonUri(
-        webview,
-        'webview/themeHandlers.js',
-      ),
-      templateUtilsUri: this.getCommonUri(webview, 'modules/templateUtils.js'),
-      recordingButtonManagerUri: this.getCommonUri(
-        webview,
-        'modules/RecordingButtonManager.js',
-      ),
-      textareaUtilsUri: this.getCommonUri(webview, 'modules/textareaUtils.js'),
-      htmlEncodingUri: this.getCommonUri(webview, 'modules/htmlEncoding.js'),
-      iconConstantsUri: this.getCommonUri(webview, 'modules/iconConstants.js'),
-      baseWebviewMessageHandlerUri: this.getCommonUri(
-        webview,
-        'modules/BaseWebviewMessageHandler.js',
-      ),
-      baseFileUtilsUri: this.getCommonUri(
-        webview,
-        'modules/files/baseFileUtils.js',
-      ),
-      domUtilsUri: this.getCommonUri(webview, 'modules/domUtils.js'),
-      baseDomHandlerUri: this.getCommonUri(
-        webview,
-        'modules/BaseDomHandler.js',
-      ),
-      stringUtilsUri: this.getCommonUri(webview, 'modules/stringUtils.js'),
-      pathUtilsUri: this.getCommonUri(webview, 'modules/pathUtils.js'),
-      debounceUri: this.getCommonUri(webview, 'modules/debounce.js'),
-      clipboardUtilsUri: this.getCommonUri(
-        webview,
-        'modules/clipboardUtils.js',
-      ),
-      streamStatusUri: this.getCommonUri(webview, 'constants/streamStatus.js'),
-      todoStatusUri: this.getCommonUri(webview, 'constants/todoStatus.js'),
-      agentTypesUri: this.getCommonUri(webview, 'constants/agentTypes.js'),
-      toggleStateStoreUri: this.getCommonUri(
-        webview,
-        'modules/ToggleStateStore.js',
-      ),
-      vscodeElementsBundleUri: this.getNodeModulesUri(
-        webview,
-        '@vscode-elements/elements/dist/bundled.js',
-      ),
-      codiconUri: this.getNodeModulesUri(
-        webview,
-        '@vscode/codicons/dist/codicon.css',
-      ),
-      codiconsFontUri: this.getNodeModulesUri(
-        webview,
-        '@vscode/codicons/dist/codicon.ttf',
-      ),
-    };
+    const commonUris = BaseViewContentProvider.COMMON_MODULE_DESCRIPTORS.reduce<
+      Record<string, vscode.Uri>
+    >((acc, d) => {
+      acc[d.key] = this.getCommonUri(webview, d.path);
+      return acc;
+    }, {});
+
+    const nodeUris = BaseViewContentProvider.NODE_MODULE_DESCRIPTORS.reduce<
+      Record<string, vscode.Uri>
+    >((acc, d) => {
+      acc[d.key] = this.getNodeModulesUri(webview, d.path);
+      return acc;
+    }, {});
+
+    return { ...commonUris, ...nodeUris };
   }
 }

--- a/src/frontend/files/fileLister.ts
+++ b/src/frontend/files/fileLister.ts
@@ -96,6 +96,50 @@ export class FileLister {
     return this.workspacePath ?? null;
   }
 
+  /** Get file listing config for each file type */
+  private getListConfig(fileType: ListableFileType): {
+    extensions: string[];
+    ignoredExtensions: string[];
+    ignoredDirs: string[];
+    ignoredKeywords: string[];
+    ignoredFiles?: string[];
+  } | null {
+    switch (fileType) {
+      case 'input':
+        return {
+          extensions: getIncludedExtensions(fileType),
+          ignoredExtensions: this.ignoredFileExtensions,
+          ignoredDirs: [...this.ignoredDirectories, ...this.ignoredInputDirectories],
+          ignoredKeywords: this.ignoredKeywords,
+          ignoredFiles: this.ignoredInputFiles,
+        };
+      case 'reference':
+        return {
+          extensions: getIncludedExtensions(fileType),
+          ignoredExtensions: this.ignoredFileExtensions,
+          ignoredDirs: this.ignoredDirectories,
+          ignoredKeywords: this.ignoredKeywords,
+          ignoredFiles: this.ignoredInputFiles,
+        };
+      case 'auxiliary':
+        return {
+          extensions: getIncludedExtensions('auxiliary'),
+          ignoredExtensions: this.ignoredFileExtensions,
+          ignoredDirs: this.ignoredDirectories,
+          ignoredKeywords: [...this.ignoredKeywords, ...this.ignoredAuxKeywords],
+        };
+      case 'media':
+        return {
+          extensions: getIncludedExtensions('media'),
+          ignoredExtensions: [],
+          ignoredDirs: this.ignoredMediaDirs,
+          ignoredKeywords: this.ignoredKeywords,
+        };
+      case 'edited':
+        return null; // Handled separately by listEditedFiles
+    }
+  }
+
   public async list(fileType: ListableFileType): Promise<string[]> {
     const workspace = this.workspace;
     if (!workspace) {
@@ -103,49 +147,20 @@ export class FileLister {
       return [];
     }
 
-    switch (fileType) {
-      case 'input':
-        return getFilesRecursively(
-          workspace,
-          workspace,
-          getIncludedExtensions(fileType),
-          this.ignoredFileExtensions,
-          [...this.ignoredDirectories, ...this.ignoredInputDirectories],
-          this.ignoredKeywords,
-          this.ignoredInputFiles,
-        );
-      case 'reference':
-        return getFilesRecursively(
-          workspace,
-          workspace,
-          getIncludedExtensions(fileType),
-          this.ignoredFileExtensions,
-          this.ignoredDirectories,
-          this.ignoredKeywords,
-          this.ignoredInputFiles,
-        );
-      case 'auxiliary':
-        return getFilesRecursively(
-          workspace,
-          workspace,
-          getIncludedExtensions('auxiliary'),
-          this.ignoredFileExtensions,
-          this.ignoredDirectories,
-          [...this.ignoredKeywords, ...this.ignoredAuxKeywords],
-        );
-      case 'media':
-        return getFilesRecursively(
-          workspace,
-          workspace,
-          getIncludedExtensions('media'),
-          [],
-          this.ignoredMediaDirs,
-          this.ignoredKeywords,
-        );
-      case 'edited':
-        // Handled separately
-        return [];
+    const config = this.getListConfig(fileType);
+    if (!config) {
+      return [];
     }
+
+    return getFilesRecursively(
+      workspace,
+      workspace,
+      config.extensions,
+      config.ignoredExtensions,
+      config.ignoredDirs,
+      config.ignoredKeywords,
+      config.ignoredFiles,
+    );
   }
 
   public async listEditedFiles(baseFileName: string): Promise<string[]> {

--- a/src/frontend/latex/linter.ts
+++ b/src/frontend/latex/linter.ts
@@ -180,22 +180,19 @@ export async function getLinterMessages(
   }
 }
 
+/** Map from DiagnosticSeverity to string name */
+const SEVERITY_MAP: Record<vscode.DiagnosticSeverity, string> = {
+  [vscode.DiagnosticSeverity.Error]: 'error',
+  [vscode.DiagnosticSeverity.Warning]: 'warning',
+  [vscode.DiagnosticSeverity.Information]: 'info',
+  [vscode.DiagnosticSeverity.Hint]: 'hint',
+};
+
 /**
  * Convert diagnostic severity to a readable string
  */
 export function getSeverityString(severity: vscode.DiagnosticSeverity): string {
-  switch (severity) {
-    case vscode.DiagnosticSeverity.Error:
-      return 'error';
-    case vscode.DiagnosticSeverity.Warning:
-      return 'warning';
-    case vscode.DiagnosticSeverity.Information:
-      return 'info';
-    case vscode.DiagnosticSeverity.Hint:
-      return 'hint';
-    default:
-      return 'unknown';
-  }
+  return SEVERITY_MAP[severity] ?? 'unknown';
 }
 
 /**
@@ -207,29 +204,20 @@ export function countDiagnosticsBySeverity(diagnostics: vscode.Diagnostic[]): {
   info: number;
   hints: number;
 } {
-  const counts = {
-    errors: 0,
-    warnings: 0,
-    info: 0,
-    hints: 0,
+  const counts = { errors: 0, warnings: 0, info: 0, hints: 0 };
+  const countKey: Record<string, keyof typeof counts> = {
+    error: 'errors',
+    warning: 'warnings',
+    info: 'info',
+    hint: 'hints',
   };
 
-  diagnostics.forEach((diagnostic) => {
-    switch (diagnostic.severity) {
-      case vscode.DiagnosticSeverity.Error:
-        counts.errors++;
-        break;
-      case vscode.DiagnosticSeverity.Warning:
-        counts.warnings++;
-        break;
-      case vscode.DiagnosticSeverity.Information:
-        counts.info++;
-        break;
-      case vscode.DiagnosticSeverity.Hint:
-        counts.hints++;
-        break;
+  for (const diagnostic of diagnostics) {
+    const key = countKey[getSeverityString(diagnostic.severity)];
+    if (key) {
+      counts[key]++;
     }
-  });
+  }
 
   return counts;
 }

--- a/src/frontend/secretManager.ts
+++ b/src/frontend/secretManager.ts
@@ -52,21 +52,32 @@ export class SecretManager {
     return `apiKey.${provider}`;
   }
 
-  public static async getApiKey(provider: ApiProvider): Promise<string> {
+  /**
+   * Lookup API key from secret storage or environment variable.
+   * Returns the key value if found, undefined otherwise.
+   */
+  private static async lookupApiKey(
+    provider: ApiProvider,
+  ): Promise<string | undefined> {
     const secretKey = await this.get(this.getApiKeySecretName(provider));
     if (secretKey) {
       return secretKey;
     }
 
     const envKey = `${provider.toUpperCase()}_API_KEY`;
-    const envValue = process.env[envKey];
-    if (!envValue) {
-      throw new Error(
-        `No API key found for ${provider}. Please set it using the "Set API Key" command or ${envKey} environment variable.`,
-      );
+    return process.env[envKey];
+  }
+
+  public static async getApiKey(provider: ApiProvider): Promise<string> {
+    const key = await this.lookupApiKey(provider);
+    if (key) {
+      return key;
     }
 
-    return envValue;
+    const envKey = `${provider.toUpperCase()}_API_KEY`;
+    throw new Error(
+      `No API key found for ${provider}. Please set it using the "Set API Key" command or ${envKey} environment variable.`,
+    );
   }
 
   public static async anyApiKeyExists(): Promise<boolean> {
@@ -79,21 +90,11 @@ export class SecretManager {
 
     // Check if server-side keys are available (Ultra tier + enabled providers)
     // This returns true if user has Ultra tier and at least one provider is enabled
-    if (await getServerSideKeyService().canUseServerSideKeys()) {
-      return true;
-    }
-
-    return false;
+    return getServerSideKeyService().canUseServerSideKeys();
   }
 
   public static async apiKeyExists(provider: ApiProvider): Promise<boolean> {
-    const secretKey = await this.get(this.getApiKeySecretName(provider));
-    if (secretKey) {
-      return true;
-    }
-
-    const envKey = `${provider.toUpperCase()}_API_KEY`;
-    return !!process.env[envKey];
+    return (await this.lookupApiKey(provider)) !== undefined;
   }
 
   public static async getApiProviderQuickPickItems(): Promise<

--- a/src/frontend/secretManager.ts
+++ b/src/frontend/secretManager.ts
@@ -94,7 +94,7 @@ export class SecretManager {
   }
 
   public static async apiKeyExists(provider: ApiProvider): Promise<boolean> {
-    return (await this.lookupApiKey(provider)) !== undefined;
+    return !!(await this.lookupApiKey(provider));
   }
 
   public static async getApiProviderQuickPickItems(): Promise<

--- a/src/frontend/setup.ts
+++ b/src/frontend/setup.ts
@@ -200,6 +200,13 @@ export async function refreshModelListIfNeeded(): Promise<void> {
   }
 }
 
+/** Default options for global settings that should only be set if not already configured */
+const GLOBAL_IF_UNSET = {
+  target: vscode.ConfigurationTarget.Global,
+  prefix: false,
+  ifUnset: true,
+} as const;
+
 /**
  * Configure LaTeX-related workspace settings if LaTeX Workshop extension is installed
  */
@@ -215,105 +222,48 @@ export async function configureLatexSettings() {
         'extension',
         'LaTeX Workshop extension detected, configuring settings',
       );
-      // Update LaTeX Workshop build settings
-      await updateConfig(
-        'latex-workshop.latex.external.build.args',
-        ['--output-directory=build', '-f', '-pdf'],
-        {
-          target: vscode.ConfigurationTarget.Global,
-          prefix: false,
-          ifUnset: true,
-        },
-      );
 
-      await updateConfig('latex-workshop.latex.outDir', '%DIR%/build/', {
-        target: vscode.ConfigurationTarget.Global,
-        prefix: false,
-        ifUnset: true,
-      });
-
-      // Add nonstopmode magic arguments for LaTeX Workshop
-      await updateConfig(
-        'latex-workshop.latex.magic.args',
+      // Define all settings to configure
+      const settings: Array<[string, unknown]> = [
+        // LaTeX Workshop build settings
         [
-          '-synctex=1',
-          '-interaction=nonstopmode',
-          '-file-line-error',
-          '%DOCFILE%',
-          '-pdf',
-          '-f',
+          'latex-workshop.latex.external.build.args',
+          ['--output-directory=build', '-f', '-pdf'],
         ],
-        {
-          target: vscode.ConfigurationTarget.Global,
-          prefix: false,
-          ifUnset: true,
-        },
-      );
+        ['latex-workshop.latex.outDir', '%DIR%/build/'],
+        [
+          'latex-workshop.latex.magic.args',
+          [
+            '-synctex=1',
+            '-interaction=nonstopmode',
+            '-file-line-error',
+            '%DOCFILE%',
+            '-pdf',
+            '-f',
+          ],
+        ],
+        ['latex-workshop.formatting.latex', 'latexindent'],
+        // Language-specific editor settings
+        ['[latex]', { 'editor.wordWrap': 'on', 'files.autoSave': 'afterDelay' }],
+        ['[yaml]', { 'editor.wordWrap': 'on', 'files.autoSave': 'afterDelay' }],
+        // Explorer settings
+        ['explorer.autoRevealExclude', { 'build/': true }],
+        ['explorer.autoReveal', false],
+      ];
 
-      // Configure LaTeX formatting
-      await updateConfig('latex-workshop.formatting.latex', 'latexindent', {
-        target: vscode.ConfigurationTarget.Global,
-        prefix: false,
-        ifUnset: true,
-      });
-
-      // Configure word wrap for LaTeX files
-      await updateConfig(
-        '[latex]',
-        {
-          'editor.wordWrap': 'on',
-          'files.autoSave': 'afterDelay',
-        },
-        {
-          target: vscode.ConfigurationTarget.Global,
-          prefix: false,
-          ifUnset: true,
-        },
-      );
-
-      // Also add word wrap for yaml files
-      await updateConfig(
-        '[yaml]',
-        {
-          'editor.wordWrap': 'on',
-          'files.autoSave': 'afterDelay',
-        },
-        {
-          target: vscode.ConfigurationTarget.Global,
-          prefix: false,
-          ifUnset: true,
-        },
-      );
-
-      // Configure explorer settings to not automatically reveal build directory
-      await updateConfig(
-        'explorer.autoRevealExclude',
-        { 'build/': true },
-        {
-          target: vscode.ConfigurationTarget.Global,
-          prefix: false,
-          ifUnset: true,
-        },
-      );
-
-      // Disable automatic revealing of files in explorer
-      await updateConfig('explorer.autoReveal', false, {
-        target: vscode.ConfigurationTarget.Global,
-        prefix: false,
-        ifUnset: true,
-      });
+      // Apply all settings
+      for (const [key, value] of settings) {
+        await updateConfig(key, value, GLOBAL_IF_UNSET);
+      }
 
       const isWindsurf = vscode.env.appName?.toLowerCase().includes('windsurf');
 
       if (!isWindsurf) {
-        const activityBarKey = 'workbench.activityBar.location';
-
-        // Update activity bar location only if unset
-        await updateConfig(activityBarKey, 'default', {
-          target: vscode.ConfigurationTarget.Global,
-          prefix: false,
-          ifUnset: true,
-        });
+        await updateConfig(
+          'workbench.activityBar.location',
+          'default',
+          GLOBAL_IF_UNSET,
+        );
         logger.info('extension', 'Activity bar location set to default');
       }
 

--- a/src/utils/files/baseFS.ts
+++ b/src/utils/files/baseFS.ts
@@ -156,43 +156,45 @@ export abstract class BaseFS {
     );
   }
 
+  /**
+   * Check if file type matches a predicate.
+   * Returns false if the target doesn't exist or an error occurs.
+   */
+  private static async checkFileType(
+    this: typeof BaseFS,
+    target: PathInput,
+    predicate: (type: vscode.FileType) => boolean,
+  ): Promise<boolean> {
+    try {
+      const stats = await this.stat(target);
+      return predicate(stats.type);
+    } catch (_err) {
+      return false;
+    }
+  }
+
   public static async isDir(
     this: typeof BaseFS,
     target: PathInput,
   ): Promise<boolean> {
-    try {
-      const stats = await this.stat(target);
-      return stats.type === vscode.FileType.Directory;
-    } catch (_err) {
-      return false;
-    }
+    return this.checkFileType(target, (t) => t === vscode.FileType.Directory);
   }
 
   public static async isFile(
     this: typeof BaseFS,
     target: PathInput,
   ): Promise<boolean> {
-    try {
-      const stats = await this.stat(target);
-      return stats.type === vscode.FileType.File;
-    } catch (_err) {
-      return false;
-    }
+    return this.checkFileType(target, (t) => t === vscode.FileType.File);
   }
 
   public static async isSymbolicLink(
     this: typeof BaseFS,
     target: PathInput,
   ): Promise<boolean> {
-    try {
-      const stats = await this.stat(target);
-      return (
-        (stats.type & vscode.FileType.SymbolicLink) ===
-        vscode.FileType.SymbolicLink
-      );
-    } catch (_err) {
-      return false;
-    }
+    return this.checkFileType(
+      target,
+      (t) => (t & vscode.FileType.SymbolicLink) === vscode.FileType.SymbolicLink,
+    );
   }
 
   // ===== Sync Methods =====

--- a/src/utils/files/relativeFS.ts
+++ b/src/utils/files/relativeFS.ts
@@ -20,10 +20,6 @@ export abstract class RelativeFS extends BaseFS {
       : path.join(this.getBasePath(), target);
   }
 
-  public static override fullPath(target: string): string {
-    return super.fullPath(target);
-  }
-
   public static async writeJson<T>(target: string, value: T): Promise<void> {
     const json = JSON.stringify(value, null, 2);
     await this.write(target, json);

--- a/src/utils/text/xmlConversion.ts
+++ b/src/utils/text/xmlConversion.ts
@@ -96,6 +96,16 @@ export function convertHtmlToMarkdown(html: string): string {
 }
 
 /**
+ * Reference type patterns for Pandoc normalization.
+ * Each entry maps reference type to the LaTeX command.
+ */
+const REFERENCE_PATTERNS: Array<{ type: string; command: string }> = [
+  { type: 'ref', command: 'ref' },
+  { type: 'eqref', command: 'eqref' },
+  { type: '[Cc]ref', command: 'cref' },
+];
+
+/**
  * Normalize Pandoc reference syntax to canonical LaTeX format.
  * Pandoc outputs references in formats like:
  * - [label]{reference-type="ref" reference="label"}
@@ -103,47 +113,34 @@ export function convertHtmlToMarkdown(html: string): string {
  * These are converted to standard \ref{label}, \cref{label}, \eqref{label}
  */
 function normalizePandocReferences(text: string): string {
-  // Handle markdown-link format: [\[label\]](#anchor){reference-type="ref" reference="label"}
-  text = text.replaceAll(
-    /\[\\?\[([^\]]+)\\?\]\]\(#[^)]*\)\{reference-type="ref"\s+reference="([^"]+)"\}/g,
-    '\\ref{$2}',
-  );
-  text = text.replaceAll(
-    /\[\\?\[([^\]]+)\\?\]\]\(#[^)]*\)\{reference-type="eqref"\s+reference="([^"]+)"\}/g,
-    '\\eqref{$2}',
-  );
-  text = text.replaceAll(
-    /\[\\?\[([^\]]+)\\?\]\]\(#[^)]*\)\{reference-type="[Cc]ref"\s+reference="([^"]+)"\}/g,
-    '\\cref{$2}',
-  );
+  for (const { type, command } of REFERENCE_PATTERNS) {
+    // Handle markdown-link format: [\[label\]](#anchor){reference-type="ref" reference="label"}
+    text = text.replaceAll(
+      new RegExp(
+        `\\[\\\\?\\[([^\\]]+)\\\\?\\]\\]\\(#[^)]*\\)\\{reference-type="${type}"\\s+reference="([^"]+)"\\}`,
+        'g',
+      ),
+      `\\${command}{$2}`,
+    );
 
-  // Handle plain markdown-link format: [label](#anchor){reference-type="ref" reference="label"}
-  text = text.replaceAll(
-    /\[([^\[\]]+)\]\(#[^)]*\)\{reference-type="ref"\s+reference="([^"]+)"\}/g,
-    '\\ref{$2}',
-  );
-  text = text.replaceAll(
-    /\[([^\[\]]+)\]\(#[^)]*\)\{reference-type="eqref"\s+reference="([^"]+)"\}/g,
-    '\\eqref{$2}',
-  );
-  text = text.replaceAll(
-    /\[([^\[\]]+)\]\(#[^)]*\)\{reference-type="[Cc]ref"\s+reference="([^"]+)"\}/g,
-    '\\cref{$2}',
-  );
+    // Handle plain markdown-link format: [label](#anchor){reference-type="ref" reference="label"}
+    text = text.replaceAll(
+      new RegExp(
+        `\\[([^\\[\\]]+)\\]\\(#[^)]*\\)\\{reference-type="${type}"\\s+reference="([^"]+)"\\}`,
+        'g',
+      ),
+      `\\${command}{$2}`,
+    );
 
-  // Handle simple Pandoc format: [label]{reference-type="ref" reference="label"}
-  text = text.replaceAll(
-    /\[([^\]]+)\]\{reference-type="ref"\s+reference="([^"]+)"\}/g,
-    '\\ref{$2}',
-  );
-  text = text.replaceAll(
-    /\[([^\]]+)\]\{reference-type="eqref"\s+reference="([^"]+)"\}/g,
-    '\\eqref{$2}',
-  );
-  text = text.replaceAll(
-    /\[([^\]]+)\]\{reference-type="[Cc]ref"\s+reference="([^"]+)"\}/g,
-    '\\cref{$2}',
-  );
+    // Handle simple Pandoc format: [label]{reference-type="ref" reference="label"}
+    text = text.replaceAll(
+      new RegExp(
+        `\\[([^\\]]+)\\]\\{reference-type="${type}"\\s+reference="([^"]+)"\\}`,
+        'g',
+      ),
+      `\\${command}{$2}`,
+    );
+  }
 
   return text;
 }


### PR DESCRIPTION
- Extract GLOBAL_IF_UNSET constant and use data-driven settings in setup.ts
- Consolidate file listing logic with getListConfig helper in fileLister.ts
- Use SEVERITY_MAP and data-driven counting in linter.ts
- Extract lookupApiKey helper to eliminate duplication in secretManager.ts
- Use REFERENCE_PATTERNS array for data-driven reference normalization in xmlConversion.ts
- Remove redundant fullPath override in relativeFS.ts
- Simplify executionToEndStatus to ternary in streamStatus.ts
- Add checkFileType helper to consolidate isDir/isFile/isSymbolicLink in baseFS.ts
- Refactor BaseViewContentProvider to use module descriptors for URIs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Streamlines internals with helper extraction, data-driven patterns, and smaller logic simplifications.
> 
> - Webview: `BaseViewContentProvider` now builds common/node module URIs from descriptor arrays via reducers, reducing boilerplate
> - Setup: extracts `GLOBAL_IF_UNSET` and applies LaTeX/Explorer/editor settings via a single `settings` list loop
> - Files: `FileLister` consolidates listing rules into `getListConfig`; `BaseFS` adds `checkFileType` used by `isDir`/`isFile`/`isSymbolicLink`; removes redundant `fullPath` override in `RelativeFS`
> - Linter: introduces `SEVERITY_MAP` and a compact counter using `getSeverityString`
> - Secrets: adds `lookupApiKey` to unify key retrieval; simplifies `anyApiKeyExists`/`apiKeyExists`
> - Text conversion: normalizes Pandoc references using `REFERENCE_PATTERNS` with generated regexes
> - Constants: simplifies `executionToEndStatus` to a ternary
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1049265af5d16c074a4c20f8088897818814ea7d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->