### PR TITLE
Simplify and improve code clarity

### DIFF
--- a/src/eventBus/ProgressEventBus.ts
+++ b/src/eventBus/ProgressEventBus.ts
@@ -1,27 +1,25 @@
 // Standard library imports
 import { EventEmitter } from 'events';
 
-// Local imports - agent
+// Type imports
 import type { AgentSessionDescriptor } from '@agent/core/AgentDataclass';
 import type { OutputFileInfo } from '@agent/output/types';
-import type { StreamTabId, ExecutionId } from '@agent/types/IdentifierTypes';
+import type { ExecutionId, StreamTabId } from '@agent/types/IdentifierTypes';
 import type { TokenUsageStats } from '@agent/types/UsageTypes';
 import type { StreamStatus } from '@common/constants/streamStatus';
 import type { ContextStateData } from '@logger/AgentLogger';
 import type { LogMessageData, LogMessageUpdate } from '@logger/LogTypes';
 import type { TaskState } from '@logger/TaskState';
-import type { ToolEditApprovalPrompt, RetryRequestPrompt } from './types';
 import type {
   AddTaskGroupPayload,
-  UpdateTaskGroupPayload,
   RunScopedPayload,
+  UpdateTaskGroupPayload,
   UpdateTodosPayload,
 } from './schemas';
+import type { RetryRequestPrompt, ToolEditApprovalPrompt } from './types';
 
-// Re-export for consumers that import from this module
+// Re-exports for consumers
 export type { StreamStatus };
-
-// Re-export schema types for consumers
 export type { TaskGroupStatus } from './schemas';
 
 // Maximum number of events to buffer when no listeners are registered
@@ -83,7 +81,23 @@ export interface ProgressEventPayloads {
 
 export type ProgressEvent = keyof ProgressEventPayloads;
 
-class ProgressEventBus {
+/**
+ * Interface for the progress event bus.
+ * Used by event handler modules for testability and dependency injection.
+ */
+export interface ProgressEventBusLike {
+  on<K extends ProgressEvent>(
+    event: K,
+    listener: (payload: ProgressEventPayloads[K]) => void,
+    options?: { signal?: AbortSignal },
+  ): () => void;
+  emit<K extends ProgressEvent>(
+    event: K,
+    payload: ProgressEventPayloads[K],
+  ): void;
+}
+
+class ProgressEventBus implements ProgressEventBusLike {
   private emitter = new EventEmitter();
   private buffer: {
     event: ProgressEvent;

--- a/src/eventBus/schemas.ts
+++ b/src/eventBus/schemas.ts
@@ -58,19 +58,19 @@ export const RunScopedPayloadSchema = z.strictObject({
 });
 export type RunScopedPayload = z.infer<typeof RunScopedPayloadSchema>;
 
-/**
- * Todo status constants - single source of truth for todo item states.
- * Used by tool-use agents for task tracking.
- */
+/** Todo status values - single source of truth for todo item states. */
+const todoStatusValues = ['pending', 'in_progress', 'completed'] as const;
+
+/** Todo status constants for programmatic access. */
 export const TODO_STATUS = {
   PENDING: 'pending',
   IN_PROGRESS: 'in_progress',
   COMPLETED: 'completed',
-} as const;
+} as const satisfies Record<string, (typeof todoStatusValues)[number]>;
 
 /** Status of a todo item */
 export const TodoStatusSchema = z
-  .enum([TODO_STATUS.PENDING, TODO_STATUS.IN_PROGRESS, TODO_STATUS.COMPLETED])
+  .enum(todoStatusValues)
   .describe('Current status of the task');
 export type TodoStatus = z.infer<typeof TodoStatusSchema>;
 

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -1,29 +1,27 @@
 // Third-party imports
 import * as vscode from 'vscode';
 
-// Local imports - agent and usage types
+// Type imports
 import type { StreamTabId } from '@agent/types/IdentifierTypes';
 import type { TokenUsageStats } from '@agent/types/UsageTypes';
 
 // Internal imports
 import { AgentCategory } from '@agent/core/AgentDataclass';
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
+import type { StreamStatus } from '@common/constants/streamStatus';
 import { normalizeRunId } from '@common/constants/runIds';
 import { STREAM_STATUS } from '@common/constants/streamStatus';
-import { AgentLogger } from '@logger/AgentLogger';
 import type { TaskGroup } from '@logger/LogTypes';
+import { AgentLogger } from '@logger/AgentLogger';
 import { MESSAGE_TYPES } from '@logger/messageTypes';
 import { WebviewUpdater } from '@progressView/managers';
 import { buildStreamInfos } from '@progressView/streamInfoUtils';
 import { ProgressViewState } from '@progressView/state/ProgressViewState';
 import { nestedMapToRecord } from '@progressView/persistence/serializationUtils';
+import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
 import { bus } from '@eventBus/ProgressEventBus';
 
 // Local file imports
-import type {
-  StreamStatus,
-  ProgressEventPayloads,
-} from '@eventBus/ProgressEventBus';
 import { registerUIEvents, type UICallbacks } from './UIEvents';
 import { withEventErrorHandling } from './errorHandling';
 

--- a/src/progressView/events/UIEvents.ts
+++ b/src/progressView/events/UIEvents.ts
@@ -7,17 +7,18 @@
  */
 
 // Type imports
-import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
+import type {
+  ProgressEvent,
+  ProgressEventBusLike,
+  ProgressEventPayloads,
+} from '@eventBus/ProgressEventBus';
 
 // Local file imports
 import { withEventErrorHandling } from './errorHandling';
-import type { ProgressEventBusLike } from './types';
 
 const MODULE = 'UIEvents';
 
-/**
- * Callbacks for retry event handling.
- */
+/** Callbacks for retry event handling. */
 export interface RetryCallbacks {
   showRetryRequest: (
     payload: ProgressEventPayloads['showRetryRequest'],
@@ -25,9 +26,7 @@ export interface RetryCallbacks {
   resolveRetryRequest: (streamId: string) => void;
 }
 
-/**
- * Callbacks for approval event handling.
- */
+/** Callbacks for approval event handling. */
 export interface ApprovalCallbacks {
   showToolEditApprovalPrompt: (
     payload: ProgressEventPayloads['showToolEditApprovalPrompt'],
@@ -36,10 +35,23 @@ export interface ApprovalCallbacks {
   updateToolEditApprovalBypassState: (bypassActive: boolean) => void;
 }
 
-/**
- * Combined UI callbacks interface.
- */
+/** Combined UI callbacks interface. */
 export type UICallbacks = RetryCallbacks & ApprovalCallbacks;
+
+/** Helper to register an event with error handling wrapper. */
+function registerEvent<K extends ProgressEvent>(
+  bus: ProgressEventBusLike,
+  event: K,
+  handler: (payload: ProgressEventPayloads[K]) => void,
+  context: string,
+  signal: AbortSignal,
+): void {
+  bus.on(
+    event,
+    (payload) => withEventErrorHandling(MODULE, context, () => handler(payload)),
+    { signal },
+  );
+}
 
 /**
  * Register all UI event handlers (retry and approval).
@@ -51,51 +63,11 @@ export function registerUIEvents(
   signal: AbortSignal,
 ): void {
   // Retry events
-  bus.on(
-    'showRetryRequest',
-    (payload) =>
-      withEventErrorHandling(MODULE, 'failed to show retry request', () =>
-        callbacks.showRetryRequest(payload),
-      ),
-    { signal },
-  );
-
-  bus.on(
-    'resolveRetryRequest',
-    (payload) =>
-      withEventErrorHandling(MODULE, 'failed to resolve retry request', () =>
-        callbacks.resolveRetryRequest(payload.streamId),
-      ),
-    { signal },
-  );
+  registerEvent(bus, 'showRetryRequest', callbacks.showRetryRequest, 'failed to show retry request', signal);
+  registerEvent(bus, 'resolveRetryRequest', (p) => callbacks.resolveRetryRequest(p.streamId), 'failed to resolve retry request', signal);
 
   // Approval events
-  bus.on(
-    'showToolEditApprovalPrompt',
-    (payload) =>
-      withEventErrorHandling(MODULE, 'failed to show approval prompt', () =>
-        callbacks.showToolEditApprovalPrompt(payload),
-      ),
-    { signal },
-  );
-
-  bus.on(
-    'resolveToolEditApprovalPrompt',
-    (payload) =>
-      withEventErrorHandling(MODULE, 'failed to resolve approval prompt', () =>
-        callbacks.resolveToolEditApprovalPrompt(payload.requestId),
-      ),
-    { signal },
-  );
-
-  bus.on(
-    'updateToolEditApprovalBypassState',
-    (payload) =>
-      withEventErrorHandling(
-        MODULE,
-        'failed to update approval bypass state',
-        () => callbacks.updateToolEditApprovalBypassState(payload.bypassActive),
-      ),
-    { signal },
-  );
+  registerEvent(bus, 'showToolEditApprovalPrompt', callbacks.showToolEditApprovalPrompt, 'failed to show approval prompt', signal);
+  registerEvent(bus, 'resolveToolEditApprovalPrompt', (p) => callbacks.resolveToolEditApprovalPrompt(p.requestId), 'failed to resolve approval prompt', signal);
+  registerEvent(bus, 'updateToolEditApprovalBypassState', (p) => callbacks.updateToolEditApprovalBypassState(p.bypassActive), 'failed to update approval bypass state', signal);
 }

--- a/src/progressView/events/errorHandling.ts
+++ b/src/progressView/events/errorHandling.ts
@@ -2,24 +2,29 @@
 import { AgentLogger } from '@logger/AgentLogger';
 import { serializeError } from '@utils/core';
 
-/** Serialize an error for logging, preserving original error reference. */
-function serializeErrorForLog(error: unknown): Record<string, unknown> {
-  if (error instanceof Error) {
-    return { ...serializeError(error), error };
-  }
-  return { error };
-}
-
-// Shared logger for all event handlers - eliminates per-module logger instances
+// Shared logger for all event handlers
 const eventLogger = new AgentLogger('ProgressEvents');
 
+/** Serialize an error for logging, preserving original error reference. */
+function toErrorData(error: unknown): Record<string, unknown> {
+  return error instanceof Error
+    ? { ...serializeError(error), error }
+    : { error };
+}
+
+/** Check if a value is a thenable (has .catch method). */
+function isThenable(value: unknown): value is PromiseLike<unknown> {
+  return value !== null && typeof (value as PromiseLike<unknown>)?.then === 'function';
+}
+
+/** Log an error with module context. */
+function logError(moduleName: string, context: string, error: unknown): void {
+  eventLogger.error(`[${moduleName}] ${context}`, { data: toErrorData(error) });
+}
+
 /**
- * Wraps an async event handler with error logging.
- * Single source of truth for event error handling.
- *
- * @param moduleName - Module name for error context (e.g., 'LogEvents')
- * @param context - Error context message (e.g., 'failed to handle addLogMessage')
- * @param fn - The async handler function to wrap
+ * Wraps an event handler with error logging.
+ * Handles both sync and async handlers, logging any errors.
  */
 export function withEventErrorHandling(
   moduleName: string,
@@ -28,16 +33,10 @@ export function withEventErrorHandling(
 ): void {
   try {
     const result = fn();
-    if (result && typeof (result as Promise<unknown>).catch === 'function') {
-      void (result as Promise<unknown>).catch((error) => {
-        eventLogger.error(`[${moduleName}] ${context}`, {
-          data: serializeErrorForLog(error),
-        });
-      });
+    if (isThenable(result)) {
+      void Promise.resolve(result).catch((error) => logError(moduleName, context, error));
     }
   } catch (error) {
-    eventLogger.error(`[${moduleName}] ${context}`, {
-      data: serializeErrorForLog(error),
-    });
+    logError(moduleName, context, error);
   }
 }

--- a/src/progressView/events/types.ts
+++ b/src/progressView/events/types.ts
@@ -1,21 +1,3 @@
-// Type imports
-import type {
-  ProgressEvent,
-  ProgressEventPayloads,
-} from '@eventBus/ProgressEventBus';
-
-/**
- * Interface for the progress event bus.
- * Used by event handler modules for testability.
- */
-export interface ProgressEventBusLike {
-  on<K extends ProgressEvent>(
-    event: K,
-    listener: (payload: ProgressEventPayloads[K]) => void,
-    options?: { signal?: AbortSignal },
-  ): () => void;
-  emit<K extends ProgressEvent>(
-    event: K,
-    payload: ProgressEventPayloads[K],
-  ): void;
-}
+// Re-export ProgressEventBusLike from the main event bus module
+// for backwards compatibility with existing imports
+export type { ProgressEventBusLike } from '@eventBus/ProgressEventBus';

--- a/src/progressView/managers/WebviewUpdater.ts
+++ b/src/progressView/managers/WebviewUpdater.ts
@@ -1,32 +1,23 @@
 // Third-party imports
 import * as vscode from 'vscode';
 
-// Local imports - progress view
+// Type imports
 import type { OutputFileInfo } from '@agent/output/types';
-import type { StreamTabId } from '@agent/types/IdentifierTypes';
 import type { AgentTypeFilter } from '@agent/types/AgentStreamTypes';
-// Types
+import type { StreamTabId } from '@agent/types/IdentifierTypes';
 import type { TokenUsageStats } from '@agent/types/UsageTypes';
-
-import { type StreamStatus } from '@common/constants/streamStatus';
-import { AgentLogger } from '@logger/AgentLogger';
-import { LogMessageData } from '@logger/LogTypes';
+import type { StreamStatus } from '@common/constants/streamStatus';
+import type { LogMessageData } from '@logger/LogTypes';
 import type { TaskState } from '@logger/TaskState';
+import { AgentLogger } from '@logger/AgentLogger';
 import type { InstructionUpdate, StreamTabInfo } from '@progressView/types';
+
 // Internal imports
 import { buildStreamInfos } from '@progressView/streamInfoUtils';
-
-// Internal imports
-import { ProgressViewState } from '@progressView/state/ProgressViewState';
 import { COMMANDS } from '@progressView/modules/constants.js';
-import type {
-  RetryRequestPrompt,
-  ToolEditApprovalPrompt,
-} from '@eventBus/types';
+import { ProgressViewState } from '@progressView/state/ProgressViewState';
+import type { RetryRequestPrompt, ToolEditApprovalPrompt } from '@eventBus/types';
 import type { TodoItem, UpdateTaskGroupPayload } from '@eventBus/schemas';
-
-// Logger imports
-// Type imports
 
 /**
  * Manages webview updates for the progress view.


### PR DESCRIPTION
- Consolidate ProgressEventBusLike interface into main event bus file
- Extract registerEvent helper in UIEvents to reduce repetitive patterns
- Simplify withEventErrorHandling with clearer async detection
- Clean up import organization across event bus modules
- Add type safety to TODO_STATUS with satisfies constraint
- Implement ProgressEventBusLike interface on ProgressEventBus class

These changes reduce code by ~44 lines while improving type safety and readability.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Streamlines event infrastructure and improves type safety.
> 
> - Implements `ProgressEventBusLike` directly in `ProgressEventBus` and exports it for DI/back-compat; updates consumers to use the main module
> - Extracts `registerEvent` helper in `UIEvents` and consolidates retry/approval handlers for less duplication
> - Simplifies `withEventErrorHandling` with unified sync/async error handling and shared logger
> - Tightens todo typing: derives `TodoStatusSchema` from `todoStatusValues` and adds `satisfies` constraint to `TODO_STATUS`
> - Cleans up import organization in `ProgressEventHandler` and `WebviewUpdater` without behavioral changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3b76dfcfaa3d5351dad8d2157c9560c114067c3f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->