### PR TITLE
Simplify and improve code clarity

### DIFF
--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -622,7 +622,7 @@ export async function executeMergeAgent(
   inputFile: string,
   editedFile: string,
 ): Promise<void> {
-  // Caller (mergeCommands.ts) handles error display via showLoggedErrorMessage
+  // Flow errors handled by runFlowWithLifecycle; validation errors propagate to VS Code
   const ctx = await resolveAgentBase('merge', {
     agent: 'merge',
     model,

--- a/src/commands/agent/agentCommands.ts
+++ b/src/commands/agent/agentCommands.ts
@@ -9,13 +9,15 @@ import * as logger from '@logger/logUtils';
 const CHANNEL = 'AgentCommands';
 logger.initialize(CHANNEL);
 
-export function registerAgentCommands(context: vscode.ExtensionContext) {
+export function registerAgentCommands(
+  context: vscode.ExtensionContext,
+): void {
   context.subscriptions.push(
     vscode.commands.registerCommand('texra.stopAgent', handleStopAgent),
   );
 }
 
-async function handleStopAgent(stream: string) {
+async function handleStopAgent(stream: string): Promise<void> {
   // Get the running execution from the unified registry
   // Handles both flow contexts and agent class instances
   const execution = getInterruptible(stream);

--- a/src/commands/agent/mergeCommands.ts
+++ b/src/commands/agent/mergeCommands.ts
@@ -1,34 +1,30 @@
 // Third-party imports
 import * as vscode from 'vscode';
 
-// Local imports - log
+// Local imports
 import { executeMergeAgent } from '@agent/runtime/executeAgent';
-import {
-  showLoggedMessageWithDocs,
-  showLoggedErrorMessage,
-} from '@common/errors';
+import { showLoggedMessageWithDocs } from '@common/errors';
 import * as logger from '@logger/logUtils';
 import { getConfig } from '@utils/config';
-
-export function registerMergeCommands(context: vscode.ExtensionContext) {
-  context.subscriptions.push(
-    vscode.commands.registerCommand(
-      'texra.merge',
-      (inputFile: string, baseFile: string, editedFile: string) =>
-        handleMerge(context, inputFile, baseFile, editedFile),
-    ),
-  );
-}
 
 const CHANNEL = 'MergeCommands';
 logger.initialize(CHANNEL);
 
+export function registerMergeCommands(context: vscode.ExtensionContext): void {
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      'texra.merge',
+      (inputFile: string, baseFile: string, editedFile: string) =>
+        handleMerge(inputFile, baseFile, editedFile),
+    ),
+  );
+}
+
 async function handleMerge(
-  _context: vscode.ExtensionContext,
   inputFile: string,
   baseFile: string,
   editedFile: string,
-) {
+): Promise<void> {
   if (!editedFile || (!baseFile && !inputFile)) {
     await showLoggedMessageWithDocs(
       CHANNEL,
@@ -42,17 +38,7 @@ async function handleMerge(
   const model = getConfig('texra.merge.defaultModel', 'sonnet37');
   const fileToUse = baseFile ?? inputFile;
 
-  try {
-    await executeMergeAgent(model, fileToUse, editedFile);
-  } catch (err) {
-    // Log the error before re-throwing
-    await showLoggedErrorMessage(
-      'MergeCommands',
-      'Merge operation failed',
-      err,
-    );
-    throw err;
-  }
+  await executeMergeAgent(model, fileToUse, editedFile);
 }
 
 export const mergeCommands = {

--- a/src/commands/files/fileSelectionCommands.ts
+++ b/src/commands/files/fileSelectionCommands.ts
@@ -58,7 +58,7 @@ function createPicker<Many extends boolean>(options: PickerOptions<Many>) {
 
 export function registerFileSelectionCommands(
   context: vscode.ExtensionContext,
-) {
+): void {
   context.subscriptions.push(
     vscode.commands.registerCommand('texra.selectInputFile', selectInputFile),
     vscode.commands.registerCommand('texra.selectInputFiles', selectInputFiles),
@@ -181,15 +181,21 @@ async function selectOutputFiles(
 }
 
 async function selectEditedFile(): Promise<string | null> {
-  const result = await selectFile({
-    openLabel: 'Select Edited File',
-    filters: {},
-  });
-  if (result) {
-    vscode.window.showInformationMessage(`Selected edited file: ${result}`);
-    logger.info(CHANNEL, `Selected edited file: ${result}`);
+  try {
+    const result = await selectFile({
+      openLabel: 'Select Edited File',
+      filters: {},
+    });
+    if (result) {
+      const message = `Selected edited file: ${result}`;
+      vscode.window.showInformationMessage(message);
+      logger.info(CHANNEL, message);
+    }
+    return result;
+  } catch (err) {
+    await showLoggedErrorMessage(CHANNEL, 'Error selecting edited file', err);
+    return null;
   }
-  return result;
 }
 
 async function getCurrentFile(): Promise<string | null> {
@@ -214,15 +220,25 @@ async function getCurrentFile(): Promise<string | null> {
 }
 
 async function selectBaseFile(): Promise<string | null> {
-  const result = await selectFile({
-    openLabel: 'Select Base File',
-    filters: {
-      'Text files': getIncludedExtensions('input').map((ext) =>
-        ext.replace('.', ''),
-      ),
-    },
-  });
-  return result ?? null;
+  try {
+    const result = await selectFile({
+      openLabel: 'Select Base File',
+      filters: {
+        'Text files': getIncludedExtensions('input').map((ext) =>
+          ext.replace('.', ''),
+        ),
+      },
+    });
+    if (result) {
+      const message = `Selected base file: ${result}`;
+      vscode.window.showInformationMessage(message);
+      logger.info(CHANNEL, message);
+    }
+    return result ?? null;
+  } catch (err) {
+    await showLoggedErrorMessage(CHANNEL, 'Error selecting base file', err);
+    return null;
+  }
 }
 
 export const fileSelectionCommands = {

--- a/src/commands/housekeeping/cleanCommands.ts
+++ b/src/commands/housekeeping/cleanCommands.ts
@@ -4,7 +4,7 @@ import { z } from 'zod';
 
 // Local imports
 import type { FileOpResult } from '@agent/types/ResultTypes';
-import { showLoggedMessage } from '@common/errors';
+import { formatZodError, showLoggedMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
 import { bus } from '@eventBus/ProgressEventBus';
 import {
@@ -31,14 +31,6 @@ const CleanParamsSchema = z.object({
 
 // --- Helpers ---
 
-function formatZodError(error: z.ZodError): string {
-  return error.issues
-    .map((i) =>
-      i.path.length ? `${i.path.join('.')}: ${i.message}` : i.message,
-    )
-    .join(', ');
-}
-
 function showCleanResult(result: FileOpResult, inputFile: string): void {
   switch (result.status) {
     case 'success':
@@ -58,7 +50,9 @@ function showCleanResult(result: FileOpResult, inputFile: string): void {
   }
 }
 
-export function registerCleanCommands(context: vscode.ExtensionContext) {
+export function registerCleanCommands(
+  context: vscode.ExtensionContext,
+): void {
   context.subscriptions.push(
     vscode.commands.registerCommand('texra.clean', handleClean),
     vscode.commands.registerCommand('texra.cleanSingle', handleCleanSingle),
@@ -72,7 +66,7 @@ async function handleCleanSingle(
   inputFile: string,
   agent: string,
   model: string,
-) {
+): Promise<void> {
   const parsed = CleanParamsSchema.safeParse({ inputFile, agent, model });
   if (!parsed.success) {
     await showLoggedMessage(
@@ -97,7 +91,7 @@ async function handleCleanMultiple(
   agent: string,
   model: string,
   outputFiles: string[] = [],
-) {
+): Promise<void> {
   const parsed = CleanParamsSchema.safeParse({ inputFile, agent, model });
   if (!parsed.success) {
     await showLoggedMessage(
@@ -126,8 +120,8 @@ async function handleCleanMultiple(
 export async function handleClean(config: {
   streamId?: string;
   skipProgressViewClear?: boolean;
-  [key: string]: any;
-}) {
+  [key: string]: unknown;
+}): Promise<void> {
   logger.debug(
     CHANNEL,
     `Clean command called with config: ${JSON.stringify(config)}`,

--- a/src/commands/housekeeping/packCommands.ts
+++ b/src/commands/housekeeping/packCommands.ts
@@ -4,7 +4,7 @@ import { z } from 'zod';
 
 // Local imports
 import type { FileOpResult } from '@agent/types/ResultTypes';
-import { showLoggedMessage } from '@common/errors';
+import { formatZodError, showLoggedMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
 import { WorkspaceFS } from '@utils/files';
 import { bus } from '@eventBus/ProgressEventBus';
@@ -55,14 +55,6 @@ const PackMultipleSchema = z
 
 // --- Helpers ---
 
-function formatZodError(error: z.ZodError): string {
-  return error.issues
-    .map((i) =>
-      i.path.length ? `${i.path.join('.')}: ${i.message}` : i.message,
-    )
-    .join(', ');
-}
-
 function showPackResult(result: FileOpResult, inputFile: string): void {
   switch (result.status) {
     case 'success': {
@@ -97,7 +89,7 @@ function showPackResult(result: FileOpResult, inputFile: string): void {
 
 // --- Handlers ---
 
-async function handlePack(config: unknown) {
+async function handlePack(config: unknown): Promise<void> {
   const parsed = PackConfigSchema.safeParse(config);
   if (!parsed.success) {
     await showLoggedMessage(
@@ -145,7 +137,7 @@ async function handlePackSingle(
   inputFile: string,
   agent: string,
   model: string,
-) {
+): Promise<void> {
   const parsed = PackParamsSchema.safeParse({ inputFile, agent, model });
   if (!parsed.success) {
     await showLoggedMessage(
@@ -170,7 +162,7 @@ async function handlePackMultiple(
   agent: string,
   model: string,
   outputFiles: string[] = [],
-) {
+): Promise<void> {
   const parsed = PackMultipleSchema.safeParse({
     inputFile,
     agent,
@@ -202,7 +194,7 @@ async function handlePackMultiple(
 
 // --- Registration ---
 
-export function registerPackCommands(context: vscode.ExtensionContext) {
+export function registerPackCommands(context: vscode.ExtensionContext): void {
   context.subscriptions.push(
     vscode.commands.registerCommand('texra.pack', handlePack),
     vscode.commands.registerCommand('texra.packSingle', handlePackSingle),

--- a/src/commands/latex/imageCommands.ts
+++ b/src/commands/latex/imageCommands.ts
@@ -53,9 +53,10 @@ async function handleCountPdfPages(): Promise<void> {
     const pageCount = await countPdfPages(selection.relativePath);
     if (pageCount > 0) {
       vscode.window.showInformationMessage(`The PDF has ${pageCount} pages`);
-    } else {
-      vscode.window.showErrorMessage('Could not count pages in the PDF');
+      return;
     }
+
+    vscode.window.showErrorMessage('Could not count pages in the PDF');
   } catch (err) {
     await showLoggedErrorMessage(CHANNEL, 'countPdfPages command failed', err);
   }
@@ -158,10 +159,10 @@ async function handleConvertPdfToImages(): Promise<
         'PDF conversion completed successfully',
       );
       return result;
-    } else {
-      vscode.window.showErrorMessage('Failed to convert PDF');
-      return undefined;
     }
+
+    vscode.window.showErrorMessage('Failed to convert PDF');
+    return undefined;
   } catch (err) {
     await showLoggedErrorMessage(
       CHANNEL,

--- a/src/commands/latex/latexCommands.ts
+++ b/src/commands/latex/latexCommands.ts
@@ -159,14 +159,10 @@ async function handleGetTeXCount(): Promise<void> {
                 headerMatch ? `Headers: ${headerMatch[1]}` : null,
                 captionMatch ? `Captions: ${captionMatch[1]}` : null,
                 mathInlineMatch ? `Inline math: ${mathInlineMatch[1]}` : null,
-                mathDisplayMatch
-                  ? `Display math: ${mathDisplayMatch[1]}`
-                  : null,
+                mathDisplayMatch ? `Display math: ${mathDisplayMatch[1]}` : null,
               ]
-                .filter(
-                  (item): item is string => item !== null && item !== undefined,
-                ) // Type guard to remove nulls
-                .map((label) => ({ label })); // Convert strings to QuickPickItems
+                .filter((item): item is string => item !== null)
+                .map((label) => ({ label }));
 
               // Show results in QuickPick
               await vscode.window.showQuickPick(stats, {

--- a/src/commands/latex/latexdiffCommands.ts
+++ b/src/commands/latex/latexdiffCommands.ts
@@ -127,9 +127,9 @@ async function openLatexdiffResult(
   return diffFilePath;
 }
 
-// Removed showLatexdiffError wrapper - using showLoggedMessageWithDocs directly
-
-export function registerLatexdiffCommands(context: vscode.ExtensionContext) {
+export function registerLatexdiffCommands(
+  context: vscode.ExtensionContext,
+): void {
   context.subscriptions.push(
     vscode.commands.registerCommand('texra.latexdiff', handleLatexdiff),
     vscode.commands.registerCommand('texra.latexdiffvc', handleLatexdiffvc),

--- a/src/commands/system/yamlCommands.ts
+++ b/src/commands/system/yamlCommands.ts
@@ -28,9 +28,7 @@ export const yamlCommands = {
   testYamlBrackets: 'texra.testYamlBrackets',
 };
 
-export async function handleTestAgentLoading(
-  _context: vscode.ExtensionContext,
-): Promise<void> {
+export async function handleTestAgentLoading(): Promise<void> {
   try {
     logger.info(CHANNEL, 'Testing agent loading from registry:');
 
@@ -81,9 +79,7 @@ export async function handleTestAgentLoading(
   }
 }
 
-export async function handleLoadSpecificAgent(
-  _context: vscode.ExtensionContext,
-): Promise<void> {
+export async function handleLoadSpecificAgent(): Promise<void> {
   try {
     // Get agent name from user
     const agentName = await vscode.window.showInputBox({
@@ -133,9 +129,7 @@ export async function handleLoadSpecificAgent(
   }
 }
 
-export async function handleParseYaml(
-  _context: vscode.ExtensionContext,
-): Promise<void> {
+export async function handleParseYaml(): Promise<void> {
   try {
     const guardResult = await getActiveEditorWithGuards({
       allowedExtensions: ['.yaml', '.yml'],
@@ -237,17 +231,19 @@ export async function handleTestYamlBrackets(
   }
 }
 
-export function registerYamlCommands(context: vscode.ExtensionContext) {
+export function registerYamlCommands(
+  context: vscode.ExtensionContext,
+): typeof yamlCommands {
   context.subscriptions.push(
-    vscode.commands.registerCommand(yamlCommands.testAgentLoading, () =>
-      handleTestAgentLoading(context),
+    vscode.commands.registerCommand(
+      yamlCommands.testAgentLoading,
+      handleTestAgentLoading,
     ),
-    vscode.commands.registerCommand(yamlCommands.loadSpecificAgent, () =>
-      handleLoadSpecificAgent(context),
+    vscode.commands.registerCommand(
+      yamlCommands.loadSpecificAgent,
+      handleLoadSpecificAgent,
     ),
-    vscode.commands.registerCommand(yamlCommands.parseYaml, () =>
-      handleParseYaml(context),
-    ),
+    vscode.commands.registerCommand(yamlCommands.parseYaml, handleParseYaml),
     vscode.commands.registerCommand(yamlCommands.testYamlBrackets, () =>
       handleTestYamlBrackets(context),
     ),

--- a/src/common/errors/errorHandlingUtils.ts
+++ b/src/common/errors/errorHandlingUtils.ts
@@ -26,6 +26,7 @@
 
 // Third-party imports
 import * as vscode from 'vscode';
+import type { z } from 'zod';
 
 // Local imports - logging
 import * as logger from '@logger/logUtils';
@@ -97,6 +98,32 @@ export function toErrorMessage(err: unknown): string {
     return 'null';
   }
   return String(err);
+}
+
+/**
+ * Format a Zod validation error into a human-readable string.
+ *
+ * Converts Zod's structured error issues into a comma-separated list
+ * of field paths and messages, making validation errors easier to understand.
+ *
+ * @param error - The Zod error to format
+ * @returns A formatted string describing the validation issues
+ *
+ * @example
+ * ```typescript
+ * const result = schema.safeParse(data);
+ * if (!result.success) {
+ *   const message = formatZodError(result.error);
+ *   // Returns: "inputFile: Required, model: String must contain at least 1 character(s)"
+ * }
+ * ```
+ */
+export function formatZodError(error: z.ZodError): string {
+  return error.issues
+    .map((i) =>
+      i.path.length ? `${i.path.join('.')}: ${i.message}` : i.message,
+    )
+    .join(', ');
 }
 
 /**

--- a/src/common/errors/index.ts
+++ b/src/common/errors/index.ts
@@ -2,6 +2,7 @@
 export {
   DocId,
   formatError,
+  formatZodError,
   isFileNotFoundError,
   toErrorMessage,
   logErrorMessage,


### PR DESCRIPTION
…erns

- Extract duplicate formatZodError from clean/packCommands into @common/errors
- Remove unnecessary try/catch rethrow in mergeCommands.ts
- Clean up unused _context parameters in yamlCommands.ts
- Add consistent error handling to fileSelectionCommands.ts
- Add explicit return type annotations throughout commands
- Remove redundant else clauses after returns in imageCommands.ts
- Simplify type guards in latexCommands.ts filter
- Remove dead comment in latexdiffCommands.ts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves consistency and clarity across command modules and error utilities.
> 
> - **Centralized validation errors**: Extracts `formatZodError` to `@common/errors` and exports it; updates `cleanCommands.ts` and `packCommands.ts` to use it
> - **Standardized typings**: Adds explicit `: void`/`Promise<void>` return types to command registrations/handlers across `agent`, `merge`, `fileSelection`, `clean`, `pack`, `latexdiff`, and `yaml` commands
> - **Simplified control flow**: Removes redundant `else` blocks after returns in `imageCommands.ts`; simplifies type guard filter in `latexCommands.ts`
> - **Error handling cleanups**: Improves file selection error paths (`selectEditedFile`, `selectBaseFile`); removes unnecessary try/catch rethrow in `mergeCommands.ts`; updates comment in `executeMergeAgent` to reflect lifecycle error handling
> - **Minor registration/signature tweaks**: Drops unused context parameters in YAML commands and adjusts registrations; small log/CHANNEL consistency fixes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f7ede3fb2a25c236e08f09cf934b3e91b4b17380. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->