### PR TITLE
Simplify and improve code clarity

### DIFF
--- a/src/tools/DiagnosticsTool.ts
+++ b/src/tools/DiagnosticsTool.ts
@@ -37,28 +37,9 @@ export class DiagnosticsTool extends defineTool({
   protected async execute(input: DiagnosticsInput): Promise<ToolResult> {
     const { command, path } = input;
     const { messages, severity } = await this.collectDiagnostics(path);
-
-    switch (command) {
-      case 'list':
-        return this.createResult({
-          command,
-          path,
-          summary: `Diagnostics list for ${path}`,
-          severity,
-          messages,
-        });
-      case 'count':
-        return this.createResult({
-          command,
-          path,
-          summary: `Diagnostics count for ${path}`,
-          severity,
-        });
-      default:
-        throw new ToolError(
-          `Diagnostics tool error: Unrecognized command '${command}'. Expected 'list' or 'count'.`,
-        );
-    }
+    const summary = `Diagnostics ${command} for ${path}`;
+    const includeMessages = command === 'list' ? messages : undefined;
+    return this.createResult(path, command, summary, severity, includeMessages);
   }
 
   /**
@@ -86,30 +67,20 @@ export class DiagnosticsTool extends defineTool({
    * Wrap diagnostics data in the shared tool result format.
    */
   private createResult(
-    args:
-      | {
-          command: 'list';
-          path: string;
-          summary: string;
-          severity: DiagnosticsSeverityCounts;
-          messages: Diagnostic[];
-        }
-      | {
-          command: 'count';
-          path: string;
-          summary: string;
-          severity: DiagnosticsSeverityCounts;
-        },
+    path: string,
+    command: 'list' | 'count',
+    summary: string,
+    severity: DiagnosticsSeverityCounts,
+    messages?: Diagnostic[],
   ): ToolResult {
     const payload: DiagnosticsPayload = {
-      path: args.path,
-      command: args.command,
-      severity: args.severity,
-      ...('messages' in args ? { messages: args.messages } : {}),
+      path,
+      command,
+      severity,
+      ...(messages ? { messages } : {}),
     };
 
-    // Build human-readable output
-    const { errors = 0, warnings = 0, info = 0, hints = 0 } = args.severity;
+    const { errors = 0, warnings = 0, info = 0, hints = 0 } = severity;
     const counts = [
       errors > 0 && `${errors} error${errors === 1 ? '' : 's'}`,
       warnings > 0 && `${warnings} warning${warnings === 1 ? '' : 's'}`,
@@ -119,26 +90,23 @@ export class DiagnosticsTool extends defineTool({
       .filter(Boolean)
       .join(', ');
 
-    // For 'list' command, include actual diagnostic messages so model can see them
-    // Always include file path so model knows which file diagnostics belong to
-    let output: string;
-    const header = `${args.path}: ${counts || 'No issues found'}`;
-    if ('messages' in args && args.messages.length > 0) {
-      const messageLines = args.messages.map((d) => {
-        const line = d.range.start.line + 1; // VS Code lines are 0-indexed
-        const severity =
-          ['error', 'warning', 'info', 'hint'][d.severity] ?? 'unknown';
-        return `  ${line}: [${severity}] ${d.message}`;
-      });
-      output = `${header}\n\n${messageLines.join('\n')}`;
-    } else {
-      output = header;
-    }
+    const header = `${path}: ${counts || 'No issues found'}`;
+    const output =
+      messages && messages.length > 0
+        ? `${header}\n\n${this.formatMessages(messages)}`
+        : header;
 
-    return {
-      summary: args.summary,
-      output,
-      diagnostics: payload,
-    };
+    return { summary, output, diagnostics: payload };
+  }
+
+  private formatMessages(messages: Diagnostic[]): string {
+    const severityLabels = ['error', 'warning', 'info', 'hint'] as const;
+    return messages
+      .map((d) => {
+        const line = d.range.start.line + 1;
+        const label = severityLabels[d.severity] ?? 'unknown';
+        return `  ${line}: [${label}] ${d.message}`;
+      })
+      .join('\n');
   }
 }

--- a/src/tools/EditTool.ts
+++ b/src/tools/EditTool.ts
@@ -29,18 +29,12 @@ const EditInputSchema = z.strictObject({
 export type EditInput = z.infer<typeof EditInputSchema>;
 
 function countOccurrences(haystack: string, needle: string): number {
-  if (needle.length === 0) {
-    return 0;
-  }
+  if (needle.length === 0) return 0;
   let count = 0;
-  let index = 0;
-  while (index < haystack.length) {
-    const foundIndex = haystack.indexOf(needle, index);
-    if (foundIndex === -1) {
-      break;
-    }
-    count += 1;
-    index = foundIndex + needle.length;
+  let index = haystack.indexOf(needle);
+  while (index !== -1) {
+    count++;
+    index = haystack.indexOf(needle, index + needle.length);
   }
   return count;
 }

--- a/src/tools/ReadTool.ts
+++ b/src/tools/ReadTool.ts
@@ -22,16 +22,11 @@ const ReadInputSchema = z.strictObject({
       start: z.int().min(1),
       end: z.int().min(1).nullish(),
     })
-    .refine(
-      (value) => {
-        // eslint-disable-next-line eqeqeq
-        return value.end == null || value.end >= value.start;
-      },
-      {
-        path: ['end'],
-        error: 'range.end must be greater than or equal to range.start',
-      },
-    )
+    // eslint-disable-next-line eqeqeq -- nullish check (null or undefined)
+    .refine((value) => value.end == null || value.end >= value.start, {
+      path: ['end'],
+      error: 'range.end must be greater than or equal to range.start',
+    })
     .nullish(),
 });
 
@@ -121,9 +116,8 @@ export class ReadFileTool extends defineTool({
       requestedEndLine,
       truncated,
       rangeProvided: Boolean(input.range),
-      // eslint-disable-next-line eqeqeq
-      rangeEndExceeded:
-        input.range?.end != null && input.range.end > totalLines,
+      // eslint-disable-next-line eqeqeq -- nullish check (null or undefined)
+      rangeEndExceeded: input.range?.end != null && input.range.end > totalLines,
     });
 
     return {
@@ -156,34 +150,23 @@ export class ReadFileTool extends defineTool({
     rangeEndExceeded,
   }: BuildSummaryParams): string {
     if (visibleCount === 0) {
-      if (totalLines === 0) {
-        return `Read ${path} (file is empty)`;
-      }
-      return `Read ${path} (no lines in requested range)`;
+      return totalLines === 0
+        ? `Read ${path} (file is empty)`
+        : `Read ${path} (no lines in requested range)`;
     }
 
-    const safeActualStartLine = actualStartLine ?? 1;
-    const safeActualEndLine =
-      actualEndLine ?? safeActualStartLine + visibleCount - 1;
-    const describeRange =
-      rangeProvided ||
-      truncated ||
-      safeActualStartLine !== 1 ||
-      safeActualEndLine !== totalLines;
+    const startLine = actualStartLine ?? 1;
+    const endLine = actualEndLine ?? startLine + visibleCount - 1;
+    const isPartialRead =
+      rangeProvided || truncated || startLine !== 1 || endLine !== totalLines;
+
     const rangeLabel =
-      safeActualStartLine === safeActualEndLine
-        ? `line ${safeActualStartLine}`
-        : `lines ${safeActualStartLine}-${safeActualEndLine}`;
+      startLine === endLine ? `line ${startLine}` : `lines ${startLine}-${endLine}`;
+    const base = isPartialRead ? `Read ${rangeLabel} of ${path}` : `Read ${path}`;
 
-    let summary = describeRange
-      ? `Read ${rangeLabel} of ${path}`
-      : `Read ${path}`;
-
-    if (rangeEndExceeded) {
-      summary += ` (requested end ${requestedEndLine} exceeds file length ${totalLines})`;
-    }
-
-    return summary;
+    return rangeEndExceeded
+      ? `${base} (requested end ${requestedEndLine} exceeds file length ${totalLines})`
+      : base;
   }
 
   private getAttachmentConfig(

--- a/src/tools/gitignore.ts
+++ b/src/tools/gitignore.ts
@@ -116,48 +116,43 @@ function parseGitignore(content: string): GitignoreRule[] {
   return rules;
 }
 
+async function readGitignoreFile(
+  absolutePath: string,
+  readContent: () => Promise<string>,
+): Promise<GitignoreSource | null> {
+  try {
+    const content = await readContent();
+    return { absolutePath, rules: parseGitignore(content) };
+  } catch {
+    return null;
+  }
+}
+
 async function readWorkspaceGitignore(
   relativePath: string,
 ): Promise<GitignoreSource | null> {
-  try {
-    const workspacePath = WorkspaceFS.getPath();
-    if (!workspacePath) {
-      return null;
-    }
-
-    const normalized = relativePath.replace(/^\/+/, '');
-    const exists = await WorkspaceFS.exists(normalized);
-    if (!exists) {
-      return null;
-    }
-
-    const content = await WorkspaceFS.read(normalized);
-    return {
-      absolutePath: path.join(workspacePath, normalized),
-      rules: parseGitignore(content),
-    };
-  } catch (_err) {
+  const workspacePath = WorkspaceFS.getPath();
+  if (!workspacePath) {
     return null;
   }
+  const normalized = relativePath.replace(/^\/+/, '');
+  const exists = await WorkspaceFS.exists(normalized);
+  if (!exists) {
+    return null;
+  }
+  return readGitignoreFile(path.join(workspacePath, normalized), () =>
+    WorkspaceFS.read(normalized),
+  );
 }
 
 async function readAbsoluteGitignore(
   absolutePath: string,
 ): Promise<GitignoreSource | null> {
-  try {
-    const exists = await AbsoluteFS.exists(absolutePath);
-    if (!exists) {
-      return null;
-    }
-
-    const content = await AbsoluteFS.read(absolutePath);
-    return {
-      absolutePath,
-      rules: parseGitignore(content),
-    };
-  } catch (_err) {
+  const exists = await AbsoluteFS.exists(absolutePath);
+  if (!exists) {
     return null;
   }
+  return readGitignoreFile(absolutePath, () => AbsoluteFS.read(absolutePath));
 }
 
 async function readGlobalGitignore(): Promise<GitignoreSource[]> {
@@ -194,18 +189,16 @@ async function loadGitignoreMatcher(): Promise<GitignoreMatcher> {
         readWorkspaceGitignore('.gitignore'),
       ]);
 
-    const sources: GitignoreSource[] = [
+    const sources = [
       ...globalSources,
-      ...(workspaceGlobalSource ? [workspaceGlobalSource] : []),
-      ...(workspaceSource ? [workspaceSource] : []),
-    ];
+      workspaceGlobalSource,
+      workspaceSource,
+    ].filter((source): source is GitignoreSource => source !== null);
 
     const rules = sources.flatMap((source) => source.rules);
     if (rules.length === 0) {
       return EMPTY_GITIGNORE_MATCHER;
     }
-
-    const ignoreFiles = sources.map((source) => source.absolutePath);
 
     return {
       hasRules: true,
@@ -222,9 +215,9 @@ async function loadGitignoreMatcher(): Promise<GitignoreMatcher> {
         }
         return ignored;
       },
-      ignoreFiles,
+      ignoreFiles: sources.map((source) => source.absolutePath),
     };
-  } catch (_err) {
+  } catch {
     return EMPTY_GITIGNORE_MATCHER;
   }
 }

--- a/src/tools/glob.ts
+++ b/src/tools/glob.ts
@@ -55,7 +55,7 @@ export class GlobTool extends defineTool({
     }
 
     // Process matches in parallel for better performance
-    const statPromises = matches.map(async (match) => {
+    const statPromises = matches.map(async (match): Promise<GlobMatchInfo | null> => {
       let resolved;
       try {
         resolved = joinWorkspaceRelativePath(base.relative, match);
@@ -70,21 +70,12 @@ export class GlobTool extends defineTool({
         return null;
       }
 
-      try {
-        const stat = await WorkspaceFS.stat(relativePath);
-        return {
-          relativePath,
-          mtime: stat.mtime ?? 0,
-        };
-      } catch (_err) {
-        return { relativePath, mtime: 0 };
-      }
+      const stat = await WorkspaceFS.stat(relativePath).catch(() => null);
+      return { relativePath, mtime: stat?.mtime ?? 0 };
     });
 
-    const decoratedWithNulls = await Promise.all(statPromises);
-    const decorated = decoratedWithNulls.filter(
-      (item): item is GlobMatchInfo => item !== null,
-    );
+    const results = await Promise.all(statPromises);
+    const decorated = results.filter((item): item is GlobMatchInfo => item !== null);
 
     const sorted = decorated.sort((a, b) => {
       if (b.mtime !== a.mtime) {

--- a/src/tools/grep.ts
+++ b/src/tools/grep.ts
@@ -55,9 +55,12 @@ export function buildArguments(
   // Context flags (only for content mode)
   if (outputMode === 'content') {
     if (input['-n']) args.push('-n');
-    if (input['-A'] !== undefined) args.push('-A', String(input['-A']));
-    if (input['-B'] !== undefined) args.push('-B', String(input['-B']));
-    if (input['-C'] !== undefined) args.push('-C', String(input['-C']));
+    // eslint-disable-next-line eqeqeq -- nullish check for .nullish() schema fields
+    if (input['-A'] != null) args.push('-A', String(input['-A']));
+    // eslint-disable-next-line eqeqeq -- nullish check for .nullish() schema fields
+    if (input['-B'] != null) args.push('-B', String(input['-B']));
+    // eslint-disable-next-line eqeqeq -- nullish check for .nullish() schema fields
+    if (input['-C'] != null) args.push('-C', String(input['-C']));
   }
 
   return args;

--- a/src/tools/grep.ts
+++ b/src/tools/grep.ts
@@ -39,57 +39,34 @@ export function buildArguments(
 ): string[] {
   const args: string[] = ['--color=never'];
 
+  // Output mode flags
   if (outputMode === 'files_with_matches') {
     args.push('--files-with-matches');
   } else if (outputMode === 'count') {
     args.push('--count');
   }
 
-  if (input.glob) {
-    args.push('--glob', input.glob);
-  }
+  // Filter options
+  if (input.glob) args.push('--glob', input.glob);
+  if (input.type) args.push('--type', input.type);
+  if (input['-i']) args.push('-i');
+  if (input.multiline) args.push('--multiline', '--multiline-dotall');
 
-  if (input.type) {
-    args.push('--type', input.type);
-  }
-
-  if (input['-i']) {
-    args.push('-i');
-  }
-
-  if (input.multiline) {
-    args.push('--multiline', '--multiline-dotall');
-  }
-
+  // Context flags (only for content mode)
   if (outputMode === 'content') {
-    if (input['-n']) {
-      args.push('-n');
-    }
-    if (typeof input['-A'] === 'number') {
-      args.push('-A', String(input['-A']));
-    }
-    if (typeof input['-B'] === 'number') {
-      args.push('-B', String(input['-B']));
-    }
-    if (typeof input['-C'] === 'number') {
-      args.push('-C', String(input['-C']));
-    }
+    if (input['-n']) args.push('-n');
+    if (input['-A'] !== undefined) args.push('-A', String(input['-A']));
+    if (input['-B'] !== undefined) args.push('-B', String(input['-B']));
+    if (input['-C'] !== undefined) args.push('-C', String(input['-C']));
   }
 
   return args;
 }
 
 function applyHeadLimit(output: string | null, headLimit?: number): string {
-  if (!output) {
-    return '';
-  }
-
-  if (!headLimit || headLimit <= 0) {
-    return output;
-  }
-
-  const lines = output.split(/\r?\n/);
-  return lines.slice(0, headLimit).join('\n');
+  if (!output) return '';
+  if (!headLimit || headLimit <= 0) return output;
+  return output.split(/\r?\n/).slice(0, headLimit).join('\n');
 }
 
 export class GrepTool extends defineTool({

--- a/src/tools/ls.ts
+++ b/src/tools/ls.ts
@@ -31,16 +31,22 @@ function isDefaultHiddenName(name: string): boolean {
   return DEFAULT_HIDDEN_NAMES.has(name);
 }
 
+function getFileTypeLabel(type: vscode.FileType): string {
+  switch (type) {
+    case vscode.FileType.Directory:
+      return 'dir';
+    case vscode.FileType.SymbolicLink:
+      return 'link';
+    case vscode.FileType.File:
+      return 'file';
+    default:
+      return 'other';
+  }
+}
+
 function formatEntry(name: string, type: vscode.FileType): string {
   const suffix = type === vscode.FileType.Directory ? '/' : '';
-  const label =
-    type === vscode.FileType.Directory
-      ? 'dir '
-      : type === vscode.FileType.SymbolicLink
-        ? 'link'
-        : type === vscode.FileType.File
-          ? 'file'
-          : 'other';
+  const label = getFileTypeLabel(type);
   return `${label.padEnd(4, ' ')} ${name}${suffix}`;
 }
 
@@ -110,20 +116,17 @@ export class LsTool extends defineTool({
     }
 
     const entries = await WorkspaceFS.readDir(relative);
-    const filtered = entries.filter(([name, _type]) => {
-      const resolvedChild = joinWorkspaceRelativePath(target.relative, name);
-      const entryRelative = resolvedChild.relative;
-      const entryPath = toPosixPath(entryRelative);
+    const filtered = entries.filter(([name]) => {
       if (isDefaultHiddenName(name)) {
         return false;
       }
-      if (gitignore.ignores(entryRelative)) {
-        return false;
-      }
-      if (matchesCustomIgnore(entryPath) || matchesCustomIgnore(name)) {
-        return false;
-      }
-      return true;
+      const resolvedChild = joinWorkspaceRelativePath(target.relative, name);
+      const entryPath = toPosixPath(resolvedChild.relative);
+      return (
+        !gitignore.ignores(resolvedChild.relative) &&
+        !matchesCustomIgnore(entryPath) &&
+        !matchesCustomIgnore(name)
+      );
     });
 
     const sorted = filtered.sort(([a], [b]) => a.localeCompare(b));

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -115,31 +115,28 @@ export function resolveToolDefinitions(
   tools: RawToolConfig[],
   warnOnMissing?: (toolName: string) => void,
 ): ToolDefinition[] {
+  const registry = getDefaultToolRegistry();
+
   return tools.map((item): ToolDefinition => {
+    const name = typeof item === 'string' ? item : item.name;
+
+    if (!isValidToolName(name)) {
+      warnOnMissing?.(name);
+      return { name };
+    }
+
+    const tool = registry.get(name);
+    if (!tool) {
+      warnOnMissing?.(name);
+      if (typeof item === 'string') {
+        return { name };
+      }
+      return ToolDefinitionSchema.catch({ name }).parse(item);
+    }
+
     if (typeof item === 'string') {
-      // Validate tool name format - warn but preserve original name for debugging
-      if (!isValidToolName(item)) {
-        warnOnMissing?.(item);
-        return { name: item };
-      }
-      const registry = getDefaultToolRegistry();
-      const tool = registry.get(item);
-      if (!tool) {
-        warnOnMissing?.(item);
-        return { name: item };
-      }
       return tool.definition;
     }
-    // Validate tool name format for object form - warn but preserve original name
-    if (!isValidToolName(item.name)) {
-      warnOnMissing?.(item.name);
-      return { name: item.name };
-    }
-    const registry = getDefaultToolRegistry();
-    if (!registry.get(item.name)) {
-      warnOnMissing?.(item.name);
-    }
-    // Parse with fallback to minimal definition if validation fails
-    return ToolDefinitionSchema.catch({ name: item.name }).parse(item);
+    return ToolDefinitionSchema.catch({ name }).parse(item);
   });
 }

--- a/src/tools/result.ts
+++ b/src/tools/result.ts
@@ -85,12 +85,18 @@ export interface DiagnosticsPayload {
   messages?: Diagnostic[];
 }
 
-// Define proper type for diagnostic information
+/**
+ * Union type for diagnostic information attached to tool results.
+ * - ZodIssue[]: Validation errors from schema parsing
+ * - Error-like: Regular errors with name and optional stack
+ * - DiagnosticsPayload: Structured diagnostics from tools
+ * - unknown: Other diagnostic formats for forward compatibility
+ */
 export type ErrorDiagnostics =
-  | ZodIssue[] // For validation errors
-  | { name: string; stack?: string } // For regular errors
-  | DiagnosticsPayload // For diagnostics payloads returned by tools
-  | unknown; // For other types of diagnostics
+  | ZodIssue[]
+  | { name: string; stack?: string }
+  | DiagnosticsPayload
+  | unknown;
 
 // ============================================================================
 // ToolResult Schema

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -157,50 +157,29 @@ export async function buildFileAttachment({
     throw new ToolError(`Attachment not found: ${display}`);
   }
 
-  let stats: { size: number } | undefined;
-  try {
-    stats = await WorkspaceFS.stat(resolved.relative);
-  } catch (err) {
-    throw new ToolError(
-      `Failed to inspect attachment ${display}: ${toErrorMessage(err)}`,
-    );
-  }
+  const stats = await WorkspaceFS.stat(resolved.relative).catch((err) => {
+    throw new ToolError(`Failed to inspect attachment ${display}: ${toErrorMessage(err)}`);
+  });
 
   if (stats.size > maxBytes) {
     const limitMb = (maxBytes / (1024 * 1024)).toFixed(1);
-    throw new ToolError(
-      `Attachment ${display} exceeds maximum size of ${limitMb} MiB.`,
-    );
+    throw new ToolError(`Attachment ${display} exceeds maximum size of ${limitMb} MiB.`);
   }
 
-  let buffer: Buffer;
-  try {
-    buffer = await WorkspaceFS.readFileBytes(resolved.relative);
-  } catch (err) {
-    throw new ToolError(
-      `Failed to read attachment ${display}: ${toErrorMessage(err)}`,
-    );
-  }
+  const buffer = await WorkspaceFS.readFileBytes(resolved.relative).catch((err) => {
+    throw new ToolError(`Failed to read attachment ${display}: ${toErrorMessage(err)}`);
+  });
 
-  const inferredMime =
-    mimeType ?? getMimeType(resolved.relative) ?? 'application/octet-stream';
-
-  const base64Payload = includeBase64 ? buffer.toString('base64') : undefined;
+  const inferredMime = mimeType ?? getMimeType(resolved.relative) ?? 'application/octet-stream';
+  const base64Data = includeBase64 ? buffer.toString('base64') : undefined;
   const bytes = Uint8Array.from(buffer);
   buffer.fill(0);
 
-  const attachment: ToolFileAttachment = {
+  return {
     path: display,
     mimeType: inferredMime,
     bytes,
+    ...(description ? { description } : {}),
+    ...(base64Data ? { base64Data } : {}),
   };
-
-  if (description) {
-    attachment.description = description;
-  }
-  if (base64Payload) {
-    attachment.base64Data = base64Payload;
-  }
-
-  return attachment;
 }


### PR DESCRIPTION
- gitignore.ts: Extract common read logic into readGitignoreFile helper, simplify source filtering with single filter pass
- grep.ts: Consolidate argument building with inline conditionals, simplify applyHeadLimit function
- glob.ts: Use Promise.catch for stat errors instead of try-catch
- ls.ts: Replace nested ternaries with switch statement for file type labels, consolidate filter logic with boolean expressions
- DiagnosticsTool.ts: Simplify execute method to single createResult call, extract formatMessages helper, use positional parameters
- registry.ts: Move registry lookup outside map loop, consolidate name extraction and validation
- ReadTool.ts: Simplify buildSummary method with cleaner conditionals
- EditTool.ts: Simplify countOccurrences loop structure
- utils.ts: Use Promise.catch for error handling in buildFileAttachment, simplify return object construction
- result.ts: Improve ErrorDiagnostics documentation

Net reduction: 109 lines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reduces complexity and improves consistency across tool implementations, focusing on cleaner conditionals, shared helpers, and tighter error handling/output.
> 
> - Diagnostics: single `createResult(path, command, ...)` flow with `formatMessages`; simplified summary building
> - Read file: cleaner range validation and `buildSummary`; minor formatting tweaks
> - Edit file: tighter `countOccurrences` loop
> - Glob/Grep/Ls: consolidated option handling, parallel/stat error handling via `Promise.catch`, filtered/sorted outputs, and clearer file type labels
> - Gitignore: extracted `readGitignoreFile`, unified workspace/absolute/global loading and source filtering
> - Registry: prefetch registry, unified name extraction/validation and parsing fallback
> - Utils: simplified `buildFileAttachment` with `Promise.catch` and lean return object
> - Result: improved `ErrorDiagnostics` union documentation
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cc7182fe99f39719c41b792832b03246860728e1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->