### PR TITLE
Simplify and improve code clarity

### DIFF
--- a/src/replacement/advanced.ts
+++ b/src/replacement/advanced.ts
@@ -107,45 +107,16 @@ export function applyLatexQuotesFormatting(text: string): string {
  * already escaped are preserved so the helper is idempotent.
  */
 export function escapeTextttUnderscores(text: string): string {
-  const textttRegex = /\\texttt\{([^}]*)\}/g;
-  let totalReplacements = 0;
-
-  const processedText = text.replaceAll(
-    textttRegex,
-    (_match, rawContent: string) => {
-      let replacementCount = 0;
-      // (?<!\\)_ matches underscore not preceded by backslash
-      // This ensures we don't double-escape already escaped underscores
-      const processedContent = rawContent.replaceAll(/(?<!\\)_/g, () => {
-        replacementCount += 1;
-        totalReplacements += 1;
-        return '\\_';
-      });
-
-      logger.debug(
-        CHANNEL,
-        `Escaped ${replacementCount} underscores in texttt block`,
-      );
-
-      return `\\texttt{${processedContent}}`;
-    },
+  // (?<!\\)_ matches underscore not preceded by backslash
+  // This ensures we don't double-escape already escaped underscores
+  return text.replaceAll(
+    /\\texttt\{([^}]*)\}/g,
+    (_, content: string) => `\\texttt{${content.replaceAll(/(?<!\\)_/g, '\\_')}}`,
   );
-
-  logger.debug(
-    CHANNEL,
-    `Finished escaping texttt underscores: ${totalReplacements} replacements total`,
-  );
-
-  return processedText;
 }
 
-/**
- * Helper function to convert Unicode characters to LaTeX commands
- * within math environments only
- */
-export function replaceMathUnicode(text: string): string {
-  // Map of Unicode characters to their LaTeX equivalents
-  const mathUnicodeMap: { [key: string]: string } = {
+// Map of Unicode characters to their LaTeX equivalents
+const MATH_UNICODE_MAP: { [key: string]: string } = {
     // Greek letters (alphabetical)
     α: '\\alpha', // alpha
     β: '\\beta', // beta
@@ -299,53 +270,55 @@ export function replaceMathUnicode(text: string): string {
 
     // Combining Diacritics (experimental - may need pre-processing for ideal LaTeX)
     // '̇': '\\dot{}', // combining dot above (U+0307) - User commented out
-  };
+};
 
-  // Environment patterns to search for
-  const mathEnvironments = [
-    { start: '\\begin{equation}', end: '\\end{equation}' },
-    { start: '\\begin{equation*}', end: '\\end{equation*}' },
-    { start: '\\begin{align}', end: '\\end{align}' },
-    { start: '\\begin{align*}', end: '\\end{align*}' },
-    { start: '\\begin{aligned}', end: '\\end{aligned}' },
-    { start: '\\begin{multline}', end: '\\end{multline}' },
-    { start: '\\begin{gather}', end: '\\end{gather}' },
-    { start: '\\begin{cases}', end: '\\end{cases}' },
-    { start: '\\[', end: '\\]' },
-    { start: '$$', end: '$$' },
-  ];
+// Math environment delimiters to search for
+const MATH_ENVIRONMENTS = [
+  { start: '\\begin{equation}', end: '\\end{equation}' },
+  { start: '\\begin{equation*}', end: '\\end{equation*}' },
+  { start: '\\begin{align}', end: '\\end{align}' },
+  { start: '\\begin{align*}', end: '\\end{align*}' },
+  { start: '\\begin{aligned}', end: '\\end{aligned}' },
+  { start: '\\begin{multline}', end: '\\end{multline}' },
+  { start: '\\begin{gather}', end: '\\end{gather}' },
+  { start: '\\begin{cases}', end: '\\end{cases}' },
+  { start: '\\[', end: '\\]' },
+  { start: '$$', end: '$$' },
+];
 
-  // Process each math environment
-  for (const env of mathEnvironments) {
+/**
+ * Convert Unicode characters and HTML sub/sup tags to LaTeX within math content.
+ */
+function convertMathContent(content: string): string {
+  let result = content;
+  for (const [unicode, latex] of Object.entries(MATH_UNICODE_MAP)) {
+    result = result.replaceAll(unicode, latex);
+  }
+  return result
+    .replaceAll(/<sub>(.*?)<\/sub>/g, '_{$1}')
+    .replaceAll(/<sup>(.*?)<\/sup>/g, '^{$1}');
+}
+
+/**
+ * Helper function to convert Unicode characters to LaTeX commands
+ * within math environments only
+ */
+export function replaceMathUnicode(text: string): string {
+  // Process each block math environment
+  for (const env of MATH_ENVIRONMENTS) {
     let startIdx = 0;
-    // Continue searching for math environments from where we left off
     while ((startIdx = text.indexOf(env.start, startIdx)) !== -1) {
       const envStart = startIdx + env.start.length;
       const envEnd = text.indexOf(env.end, envStart);
 
-      // If we can't find the end, skip this instance
       if (envEnd === -1) {
         startIdx += env.start.length;
         continue;
       }
 
-      // Extract the content of the math environment
       const mathContent = text.substring(envStart, envEnd);
+      const replacedContent = convertMathContent(mathContent);
 
-      // Apply Unicode replacements within the math content
-      // Replace Unicode characters with LaTeX commands, then HTML sub/sup tags
-      const replacedContent = Object.entries(mathUnicodeMap)
-        .reduce(
-          (content, [unicode, latex]) =>
-            content.replaceAll(new RegExp(unicode, 'g'), latex),
-          mathContent,
-        )
-        // Replace HTML subscript tags with LaTeX subscript syntax
-        .replaceAll(/<sub>(.*?)<\/sub>/g, '_{$1}')
-        // Replace HTML superscript tags with LaTeX superscript syntax
-        .replaceAll(/<sup>(.*?)<\/sup>/g, '^{$1}');
-
-      // Replace the original math content with the processed one
       if (replacedContent !== mathContent) {
         text =
           text.substring(0, envStart) +
@@ -353,29 +326,14 @@ export function replaceMathUnicode(text: string): string {
           text.substring(envEnd);
       }
 
-      // Move past this environment
       startIdx = envStart + replacedContent.length;
     }
   }
 
-  // Also handle inline math with $ ... $
-  const inlineMathPattern = /\$(.*?)\$/g;
-  text = text.replaceAll(inlineMathPattern, (_match, p1) => {
-    // Replace Unicode characters with LaTeX commands, then HTML sub/sup tags
-    const content = Object.entries(mathUnicodeMap)
-      .reduce(
-        (c, [unicode, latex]) => c.replaceAll(new RegExp(unicode, 'g'), latex),
-        p1 as string,
-      )
-      // Replace HTML subscript tags with LaTeX subscript syntax
-      .replaceAll(/<sub>(.*?)<\/sub>/g, '_{$1}')
-      // Replace HTML superscript tags with LaTeX superscript syntax
-      .replaceAll(/<sup>(.*?)<\/sup>/g, '^{$1}');
-
-    return `$${content}$`;
+  // Handle inline math with $ ... $
+  return text.replaceAll(/\$(.*?)\$/g, (_, p1: string) => {
+    return `$${convertMathContent(p1)}$`;
   });
-
-  return text;
 }
 
 /**

--- a/src/replacement/engine.ts
+++ b/src/replacement/engine.ts
@@ -290,6 +290,11 @@ export function applyReplacements(
         // Non-regex patterns only use string replacements
         if (typeof newText === 'string') {
           text = text.replaceAll(old, newText);
+        } else {
+          logger.debug(
+            CHANNEL,
+            `Skipping function pattern "${old}" in non-regex category "${category.name}"`,
+          );
         }
       }
     }
@@ -309,11 +314,12 @@ export function applyReplacements(
 
 /**
  * Clean content using all replacement rules.
- * Delegates to the engine's applyAll method which applies non-regex rules twice
- * (before and after regex rules) to catch artifacts introduced by regex processing.
+ * Applies non-regex, then regex rules, then conditional critique wrapping.
  */
 export function cleanFileContent(content: string): string {
-  return replacementEngine.applyAll(content);
+  let cleaned = applyReplacements(content, getAllReplacements()).trim();
+  cleaned = applyReplacements(cleaned, getAllReplacementsRegex()).trim();
+  return shouldWrapCritiqueInAlign() ? wrapCritiqueInAlign(cleaned) : cleaned;
 }
 
 /**

--- a/src/replacement/engine.ts
+++ b/src/replacement/engine.ts
@@ -169,14 +169,12 @@ export function getAllReplacements(): ReplacementCategory {
     enabledCategoryNames.includes(category.name),
   );
 
-  // Combine patterns from all enabled categories
-  let allPatterns: { [key: string]: ReplacementValue } = {};
-  enabledCategories.forEach((category) => {
-    allPatterns = { ...allPatterns, ...category.patterns };
-  });
-
-  // Add custom replacements (these take precedence over built-in ones)
-  allPatterns = { ...allPatterns, ...customReplacements };
+  // Combine patterns from all enabled categories with custom replacements taking precedence
+  const allPatterns: { [key: string]: ReplacementValue } = Object.assign(
+    {},
+    ...enabledCategories.map((c) => c.patterns),
+    customReplacements,
+  );
 
   return {
     name: 'all',
@@ -237,19 +235,10 @@ export function getAllReplacementsRegex(): ReplacementCategory[] {
 export function getReplacementsByCategory(
   categoryName: string,
 ): ReplacementCategory | undefined {
-  // Define all available categories
-  const allCategories = [...NON_REGEX_CATEGORIES, ...REGEX_CATEGORIES];
-
-  // Create a map for efficient lookup by name
-  const categoryMap = new Map<string, ReplacementCategory>();
-
-  // Add all categories to the map
-  allCategories.forEach((category) => {
-    categoryMap.set(category.name, category);
-  });
-
-  // Return the requested category if it exists
-  return categoryMap.get(categoryName);
+  return (
+    NON_REGEX_CATEGORIES.find((c) => c.name === categoryName) ??
+    REGEX_CATEGORIES.find((c) => c.name === categoryName)
+  );
 }
 
 /**
@@ -284,12 +273,11 @@ export function applyReplacements(
       for (const [pattern, repl] of Object.entries(category.patterns)) {
         try {
           const regex = new RegExp(pattern, category.flags);
-          if (typeof repl === 'function') {
-            const replacer = repl as ReplacementFunction;
-            text = text.replace(regex, (...args) => replacer(...args));
-          } else {
-            text = text.replace(regex, repl);
-          }
+          // Type narrowing: if repl is a function, use it as callback; otherwise use as string
+          text =
+            typeof repl === 'function'
+              ? text.replace(regex, repl)
+              : text.replace(regex, repl);
         } catch (regexErr) {
           logger.error(
             CHANNEL,
@@ -299,7 +287,10 @@ export function applyReplacements(
       }
     } else {
       for (const [old, newText] of Object.entries(category.patterns)) {
-        text = text.replaceAll(old, newText as string);
+        // Non-regex patterns only use string replacements
+        if (typeof newText === 'string') {
+          text = text.replaceAll(old, newText);
+        }
       }
     }
   }
@@ -318,11 +309,11 @@ export function applyReplacements(
 
 /**
  * Clean content using all replacement rules.
+ * Delegates to the engine's applyAll method which applies non-regex rules twice
+ * (before and after regex rules) to catch artifacts introduced by regex processing.
  */
 export function cleanFileContent(content: string): string {
-  let cleaned = applyReplacements(content, getAllReplacements()).trim();
-  cleaned = applyReplacements(cleaned, getAllReplacementsRegex()).trim();
-  return shouldWrapCritiqueInAlign() ? wrapCritiqueInAlign(cleaned) : cleaned;
+  return replacementEngine.applyAll(content);
 }
 
 /**

--- a/src/replacement/helpers.ts
+++ b/src/replacement/helpers.ts
@@ -42,24 +42,11 @@ export function generateBackslashFixes(commands: string[]): {
 export function generateGroupedBackslashFixes(commandGroups: {
   [groupName: string]: string[];
 }): { [key: string]: string } {
-  const patterns: { [key: string]: string } = {};
-
-  // For each group, process all its commands
-  for (const [groupName, commands] of Object.entries(commandGroups)) {
-    // Add a comment for the group
-    if (commands.length > 0) {
-      // We're creating a fake pattern with a comment that will be visible
-      // when inspecting the patterns object, but won't affect replacements
-      patterns[`// == ${groupName} ==`] = `// ${commands.length} commands`;
-    }
-
-    // Add the actual patterns for this group
-    commands.forEach((cmd) => {
-      patterns[`\\\\${cmd}`] = `\\${cmd}`;
-    });
-  }
-
-  return patterns;
+  return Object.fromEntries(
+    Object.values(commandGroups)
+      .flat()
+      .map((cmd) => [`\\\\${cmd}`, `\\${cmd}`]),
+  );
 }
 
 /**

--- a/src/replacement/maxRules.ts
+++ b/src/replacement/maxRules.ts
@@ -59,7 +59,7 @@ export const MAX_AUTO_REPLACEMENTS: ReplacementCategory = {
   isRegex: false,
   patterns: (() => {
     // Initialize patterns object
-    let patterns: { [key: string]: string } = {};
+    const patterns: { [key: string]: string } = {};
 
     // ====================================================================
     // Backslash and command fixes
@@ -80,7 +80,7 @@ export const MAX_AUTO_REPLACEMENTS: ReplacementCategory = {
     ];
 
     // Generate backslash fixes for all the above commands
-    patterns = { ...patterns, ...generateBackslashFixes(backslashFixCommands) };
+    Object.assign(patterns, generateBackslashFixes(backslashFixCommands));
 
     // ====================================================================
     // Specialized handling for math operators and text commands
@@ -94,9 +94,9 @@ export const MAX_AUTO_REPLACEMENTS: ReplacementCategory = {
     ];
 
     // Direct mapping: \mathrm{op} -> \op and \text{op} -> \op
-    patterns = {
-      ...patterns,
-      ...Object.fromEntries(
+    Object.assign(
+      patterns,
+      Object.fromEntries(
         mathOperators.flatMap((op) => [
           [`\\mathrm{${op}}`, `\\${op}`],
           [`\\text{${op}}`, `\\${op}`],
@@ -107,7 +107,7 @@ export const MAX_AUTO_REPLACEMENTS: ReplacementCategory = {
           [`^\\op`, `^{\\${op}}`],
         ]),
       ),
-    };
+    );
 
     // 2. Text Commands (defined with \newcommand{\cmd}{{\text{name}}})
     // These allow direct subscript/superscript like P_\cmd
@@ -115,9 +115,9 @@ export const MAX_AUTO_REPLACEMENTS: ReplacementCategory = {
     const textCommands = ['sys', 'bath', 'tot', 'const', 'discrete', 'decoder', 'encoder', 'pool', 'data', 'mar', 'model', 'prior', 'target', 'full', 'observed', 'accept', 'aux', 'eq', 'st', 'nc', 'irr', 'rev', 'hkp', 'adi', 'nadi', 'exc', 'pos', 'head', 'PE', 'class', 'window', 'Output', 'FFN', 'Strat', 'Ito', 'diss'];
 
     // Direct mapping: \text{cmd} -> \cmd
-    patterns = {
-      ...patterns,
-      ...Object.fromEntries(
+    Object.assign(
+      patterns,
+      Object.fromEntries(
         textCommands.flatMap((cmd) => [
           [`\\text{${cmd}}`, `\\${cmd}`],
           [`\\mathrm{${cmd}}`, `\\${cmd}`],
@@ -130,7 +130,7 @@ export const MAX_AUTO_REPLACEMENTS: ReplacementCategory = {
           [`^{${cmd}}`, `^\\${cmd}`],
         ]),
       ),
-    };
+    );
 
     // prettier-ignore
     const symbolOperators = [
@@ -141,15 +141,15 @@ export const MAX_AUTO_REPLACEMENTS: ReplacementCategory = {
       'bu', 'ta'
     ];
     // these variables might occur as lower indices, but they do not need {..}
-    patterns = {
-      ...patterns,
-      ...Object.fromEntries(
+    Object.assign(
+      patterns,
+      Object.fromEntries(
         symbolOperators.flatMap((op) => [
           [`_{\\${op}}`, `_\\${op}`],
           [`^{\\${op}}`, `^\\${op}`],
         ]),
       ),
-    };
+    );
 
     // ====================================================================
     // Auto-generated differential notation patterns
@@ -160,20 +160,19 @@ export const MAX_AUTO_REPLACEMENTS: ReplacementCategory = {
     const differentialVariables = ['x', 't', 'tau', 'ttau', 'beta', 'bx', 'bz', 'bze', 'bxi', 'tbx'];
 
     // Generate differential spacing patterns
-    const differentialSpacingPatterns = generateDifferentialSpacing(
-      differentialVariables,
-      '~',
+    Object.assign(
+      patterns,
+      generateDifferentialSpacing(differentialVariables, '~'),
     );
-    patterns = { ...patterns, ...differentialSpacingPatterns };
 
     // Variables that need differential replacement in fractions and integrals
     // prettier-ignore
     const fractionDiffVariables = ['t', 'x', 'tau', 'ttau', 'beta', 'bx', 'bz', 'bze', 'bxi', 'S'];
 
     // Generate patterns for each variable
-    patterns = {
-      ...patterns,
-      ...Object.fromEntries(
+    Object.assign(
+      patterns,
+      Object.fromEntries(
         fractionDiffVariables.flatMap((variable) => [
           // Handle cases like {dx} -> {\\dd x}
           [`{d${variable}}`, `{\\dd${variable}}`],
@@ -183,7 +182,7 @@ export const MAX_AUTO_REPLACEMENTS: ReplacementCategory = {
           [`\\frac{d}{d${variable}}`, `\\frac{\\dd}{\\dd${variable}}`],
         ]),
       ),
-    };
+    );
 
     // Integration patterns
     patterns['\\int d\\'] = '\\int \\dd\\';
@@ -202,10 +201,7 @@ export const MAX_AUTO_REPLACEMENTS: ReplacementCategory = {
       Leftrightarrow: 'LRa',
       Longleftrightarrow: 'LRa',
     };
-    patterns = {
-      ...patterns,
-      ...generateArrowRelationShortcuts(arrowRelationMap),
-    };
+    Object.assign(patterns, generateArrowRelationShortcuts(arrowRelationMap));
 
     // Calculus command shortcuts
     // Examples: \partial -> \der, \nabla -> \na
@@ -213,14 +209,14 @@ export const MAX_AUTO_REPLACEMENTS: ReplacementCategory = {
       partial: 'der',
       nabla: 'na',
     };
-    patterns = { ...patterns, ...generateCommandShortcuts(calculusCommandMap) };
+    Object.assign(patterns, generateCommandShortcuts(calculusCommandMap));
 
     // Vector Variables
     // Examples:
     // \vec{p} -> \vp (momentum vector)
     // \vec{x} -> \vx (position vector)
     const vectorLetters = [...'pqvxyz'];
-    patterns = { ...patterns, ...generateVectorShortcuts(vectorLetters) };
+    Object.assign(patterns, generateVectorShortcuts(vectorLetters));
 
     // Greek Letters (Regular)
     // Map full Greek letter names to shorter versions
@@ -232,7 +228,7 @@ export const MAX_AUTO_REPLACEMENTS: ReplacementCategory = {
     const greekShortcuts = { ...GREEK_LETTER_SHORTCUTS };
     delete greekShortcuts['Delta']; // Prevent Delta from being shortened to De
 
-    patterns = { ...patterns, ...generateMathCommandShortcuts(greekShortcuts) };
+    Object.assign(patterns, generateMathCommandShortcuts(greekShortcuts));
 
     // Greek Letters (Bold)
     // Generate patterns for bold Greek letters with \b prefix
@@ -241,239 +237,187 @@ export const MAX_AUTO_REPLACEMENTS: ReplacementCategory = {
 
     // prettier-ignore
     const greekBoldLetters = [...commonGreekLetters, 'chi', 'pi', 'varphi', 'Sigma', 'lambda', 'Gamma', 'Lambda'];
-    patterns = {
-      ...patterns,
-      ...generateDecoratedMathShortcuts(['boldsymbol'], greekBoldLetters, 'b'),
-    };
+    Object.assign(
+      patterns,
+      generateDecoratedMathShortcuts(['boldsymbol'], greekBoldLetters, 'b'),
+    );
 
     // Mathcal Letters
     // Map \mathcal{X} to shorter \cX versions for all uppercase letters
     const upperLetters = [...'ABCDEFGHIJKLMNOPQRSTUVWXYZ'];
-    patterns = {
-      ...patterns,
-      ...generateMathFontShortcuts(upperLetters, 'mathcal', 'c'),
-    };
+    Object.assign(
+      patterns,
+      generateMathFontShortcuts(upperLetters, 'mathcal', 'c'),
+    );
 
     // Mathbb Letters
     // Map \mathbb{X} to shorter \eX versions for specific letters
     const mathbbLetters = [...'CEINPQRTV'];
-    patterns = {
-      ...patterns,
-      ...generateMathFontShortcuts(mathbbLetters, 'mathbb', 'e'),
-    };
+    Object.assign(
+      patterns,
+      generateMathFontShortcuts(mathbbLetters, 'mathbb', 'e'),
+    );
 
     // Mathbf Letters (Lowercase)
     // Map \mathbf{x} to shorter \bx versions
     const lowerLetters = [...'abcdefghjnpqrsuvwxyz'];
-    patterns = {
-      ...patterns,
-      ...generateMathFontShortcuts(lowerLetters, 'mathbf', 'b'),
-    };
+    Object.assign(
+      patterns,
+      generateMathFontShortcuts(lowerLetters, 'mathbf', 'b'),
+    );
 
     // Mathbf Letters (Uppercase)
     // Map \mathbf{X} to shorter \bX versions for uppercase letters
     const mathbfUpperLetters = [...'ABCDEFGIJKMQRUVWXYZ'];
-    patterns = {
-      ...patterns,
-      ...generateMathFontShortcuts(mathbfUpperLetters, 'mathbf', 'b'),
-    };
+    Object.assign(
+      patterns,
+      generateMathFontShortcuts(mathbfUpperLetters, 'mathbf', 'b'),
+    );
 
     // Normalize legacy font commands {\rm X}, {\bf X} and {\cal X}
     const alphabetLetters = [
       ...'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz',
     ];
-    patterns = {
-      ...patterns,
-      ...generateLegacyTextCommandNormalization(
-        alphabetLetters,
-        'mathrm',
-        'rm',
-      ),
-    };
-    patterns = {
-      ...patterns,
-      ...generateLegacyTextCommandNormalization(
-        alphabetLetters,
-        'mathbf',
-        'bf',
-      ),
-    };
-    patterns = {
-      ...patterns,
-      ...generateLegacyTextCommandNormalization(
-        alphabetLetters,
-        'mathcal',
-        'cal',
-      ),
-    };
+    Object.assign(
+      patterns,
+      generateLegacyTextCommandNormalization(alphabetLetters, 'mathrm', 'rm'),
+    );
+    Object.assign(
+      patterns,
+      generateLegacyTextCommandNormalization(alphabetLetters, 'mathbf', 'bf'),
+    );
+    Object.assign(
+      patterns,
+      generateLegacyTextCommandNormalization(alphabetLetters, 'mathcal', 'cal'),
+    );
 
     // Tilde variables - simple letters
     // Examples: \tilde{x} -> \tx, \tilde{B} -> \tB
     const tildeLetters = [...'xzpqBFJMPTZ'];
-    patterns = {
-      ...patterns,
-      ...generateDecoratorShortcuts('tilde', tildeLetters, 't'),
-    };
+    Object.assign(
+      patterns,
+      generateDecoratorShortcuts('tilde', tildeLetters, 't'),
+    );
 
     // Tilde with mathbf - lowercase
     // Example: \tilde{\mathbf{x}} -> \tbx
     const tildeLettersMathbf = [...'axpvwz'];
-    patterns = {
-      ...patterns,
-      ...generateNestedDecoratorShortcuts(
-        'tilde',
-        'mathbf',
-        tildeLettersMathbf,
-        't',
-        'b',
-      ),
-    };
+    Object.assign(
+      patterns,
+      generateNestedDecoratorShortcuts('tilde', 'mathbf', tildeLettersMathbf, 't', 'b'),
+    );
 
     // Tilde with mathbf - uppercase
     // Example: \tilde{\mathbf{M}} -> \tbM
     const tildeLettersMathbfUppercase = [...'MTX'];
-    patterns = {
-      ...patterns,
-      ...generateNestedDecoratorShortcuts(
-        'tilde',
-        'mathbf',
-        tildeLettersMathbfUppercase,
-        't',
-        'b',
-      ),
-    };
+    Object.assign(
+      patterns,
+      generateNestedDecoratorShortcuts('tilde', 'mathbf', tildeLettersMathbfUppercase, 't', 'b'),
+    );
 
     // Tilde with mathcal - uppercase
     // Example: \tilde{\mathcal{H}} -> \tcH
     const tildeLettersMathcal = [...'HQSW'];
-    patterns = {
-      ...patterns,
-      ...generateNestedDecoratorShortcuts(
-        'tilde',
-        'mathcal',
-        tildeLettersMathcal,
-        't',
-        'c',
-      ),
-    };
+    Object.assign(
+      patterns,
+      generateNestedDecoratorShortcuts('tilde', 'mathcal', tildeLettersMathcal, 't', 'c'),
+    );
 
     // Tilde with Greek letters
     // Example: \tilde{\gamma} -> \tga
-    const tildeGreekLetters = 'gamma lambda phi psi rho Sigma mu tau'.split(
-      ' ',
-    );
-    patterns = {
-      ...patterns,
-      ...Object.fromEntries(
+    const tildeGreekLetters = 'gamma lambda phi psi rho Sigma mu tau'.split(' ');
+    Object.assign(
+      patterns,
+      Object.fromEntries(
         tildeGreekLetters.map((letter) => [
           `\\tilde{\\${letter}}`,
           `\\t${GREEK_LETTER_SHORTCUTS[letter] || letter}`,
         ]),
       ),
-    };
+    );
 
     // Tilde with boldsymbol+Greek
     // Example: \tilde{\boldsymbol{\zeta}} -> \tbze
-    const tildeGreekBoldLetters = 'zeta gamma lambda pi xi eta Gamma'.split(
-      ' ',
-    );
-    patterns = {
-      ...patterns,
-      ...Object.fromEntries(
+    const tildeGreekBoldLetters = 'zeta gamma lambda pi xi eta Gamma'.split(' ');
+    Object.assign(
+      patterns,
+      Object.fromEntries(
         tildeGreekBoldLetters.map((letter) => [
           `\\tilde{\\boldsymbol{\\${letter}}}`,
           `\\tb${GREEK_LETTER_SHORTCUTS[letter] || letter}`,
         ]),
       ),
-    };
+    );
 
     // Hat variables
     // Example: \hat{H} -> \hH
     const hatLetters = [...'HFP'];
-    patterns = {
-      ...patterns,
-      ...generateDecoratorShortcuts('hat', hatLetters, 'h'),
-    };
+    Object.assign(patterns, generateDecoratorShortcuts('hat', hatLetters, 'h'));
 
     // Hat with Greek letters
     // Example: \hat{\sigma} -> \hsg
     const hatGreekLetters = 'sigma Sigma pi rho'.split(' ');
-    patterns = {
-      ...patterns,
-      ...Object.fromEntries(
+    Object.assign(
+      patterns,
+      Object.fromEntries(
         hatGreekLetters.map((letter) => [
           `\\hat{\\${letter}}`,
           `\\h${GREEK_LETTER_SHORTCUTS[letter] || letter}`,
         ]),
       ),
-    };
+    );
 
     // Hat with mathbf
     // Example: \hat{\mathbf{n}} -> \hbn
     const hatMathbfLetters = [...'nv'];
-    patterns = {
-      ...patterns,
-      ...generateNestedDecoratorShortcuts(
-        'hat',
-        'mathbf',
-        hatMathbfLetters,
-        'h',
-        'b',
-      ),
-    };
+    Object.assign(
+      patterns,
+      generateNestedDecoratorShortcuts('hat', 'mathbf', hatMathbfLetters, 'h', 'b'),
+    );
 
     // Hat with boldsymbol+Greek
     // Example: \hat{\boldsymbol{\zeta}} -> \hbze
-    const hatBoldsymbolLetters = 'zeta'.split(' ');
-    patterns = {
-      ...patterns,
-      ...Object.fromEntries(
+    const hatBoldsymbolLetters = ['zeta'];
+    Object.assign(
+      patterns,
+      Object.fromEntries(
         hatBoldsymbolLetters.map((letter) => [
           `\\hat{\\boldsymbol{\\${letter}}}`,
           `\\hb${GREEK_LETTER_SHORTCUTS[letter] || letter}`,
         ]),
       ),
-    };
+    );
 
     // Fix for extra backslashes in bold symbols
     // Automatically generate fixes for lowercase bold letters (e.g., \\ba -> \ba)
-    patterns = {
-      ...patterns,
-      ...generateBoldBackslashFixes('b', lowerLetters),
-    };
+    Object.assign(patterns, generateBoldBackslashFixes('b', lowerLetters));
 
     // Automatically generate fixes for uppercase bold letters (e.g., \\bA -> \bA)
-    patterns = {
-      ...patterns,
-      ...generateBoldBackslashFixes('b', mathbfUpperLetters),
-    };
+    Object.assign(patterns, generateBoldBackslashFixes('b', mathbfUpperLetters));
 
     // Fix for double backslashes in custom commands
     // Examples: \\bet -> \bet, \\bbf -> \bbf
     const customShortcutFixes = ['bet', 'bze', 'cP', 'Om', 'bbf'];
-    patterns = {
-      ...patterns,
-      ...Object.fromEntries(
-        customShortcutFixes.map((shortcut) => [
-          `\\\\${shortcut}`,
-          `\\${shortcut}`,
-        ]),
+    Object.assign(
+      patterns,
+      Object.fromEntries(
+        customShortcutFixes.map((shortcut) => [`\\\\${shortcut}`, `\\${shortcut}`]),
       ),
-    };
+    );
 
     // Convert functions to simpler forms (e.g., F_/G_)
     // Examples: \F_ -> F_, \G( -> G(
     const functionNames = ['F', 'G'];
-    patterns = {
-      ...patterns,
-      ...Object.fromEntries(
+    Object.assign(
+      patterns,
+      Object.fromEntries(
         functionNames.flatMap((name) => [
           [`\\${name}_`, `${name}_`],
           [`\\${name}^`, `${name}^`],
           [`\\${name}(`, `${name}(`],
         ]),
       ),
-    };
+    );
 
     return patterns;
   })(),
@@ -618,13 +562,10 @@ export const MAX_STYLE_REPLACEMENTS: ReplacementCategory = {
   name: 'max_style',
   description: 'Maximum style replacements for LaTeX commands and symbols',
   isRegex: false,
-  patterns: (() => {
-    const combinedPatterns = {
-      ...MAX_AUTO_REPLACEMENTS.patterns,
-      ...MAX_MANUAL_REPLACEMENTS.patterns,
-    };
-    return combinedPatterns;
-  })(),
+  patterns: {
+    ...MAX_AUTO_REPLACEMENTS.patterns,
+    ...MAX_MANUAL_REPLACEMENTS.patterns,
+  },
 };
 
 // Helper to create | separated regex part from a list of words

--- a/src/replacement/rules/equations.ts
+++ b/src/replacement/rules/equations.ts
@@ -76,42 +76,37 @@ export const EQUATION_REPLACEMENTS: ReplacementCategory = {
         .split(/\s+/),
     });
 
-    // Initialize patterns object with generated patterns
+    // Greek letter notation fixes
+    // Examples: \a_ -> a_, \a^ -> a^
+    const letters = [...'abcdefghijklmnopqrstuvwyz'];
+    const letterNotationFixes = Object.fromEntries(
+      letters.flatMap((letter) => [
+        [`\\${letter}_`, `${letter}_`],
+        [`\\${letter}^`, `${letter}^`],
+      ]),
+    );
+
+    // Environment end command fixes
+    // Examples: \n\\nend{align} -> \n\end{align}
+    const environments =
+      'align equation itemize enumerate figure tikzpicture document'.split(' ');
+    const envEndFixes = Object.fromEntries(
+      environments.map((env) => [`\n\\\nend{${env}}`, `\n\\end{${env}}`]),
+    );
+
+    // Environment braces/brackets fixes
+    // Examples: {\align} -> {align}
+    const bracesFixes = generateEnvironmentBracesFixes(environments);
+
+    // Initialize patterns object with all generated patterns
     const patterns: { [key: string]: string } = {
       ...linebreakFixesPatterns,
       ...referencePatterns,
       ...groupedBackslashPatterns,
+      ...letterNotationFixes,
+      ...envEndFixes,
+      ...bracesFixes,
     };
-
-    // Greek letter notation fixes
-    // Examples:
-    // \a_ -> a_
-    // \a^ -> a^
-    // \x^ -> x^ [this should not be included]
-    const letters = [...'abcdefghijklmnopqrstuvwyz'];
-    letters.forEach((letter) => {
-      patterns[`\\${letter}_`] = `${letter}_`;
-      patterns[`\\${letter}^`] = `${letter}^`;
-    });
-
-    // ===== Environment end command fixes =====
-    // Examples:
-    // \n\\nend{align} -> \n\end{align}
-    // \n\\nend{document} -> \n\end{document}
-    const environments =
-      'align equation itemize enumerate figure tikzpicture document'.split(' ');
-    environments.forEach((env) => {
-      patterns[`\n\\\nend{${env}}`] = `\n\\end{${env}}`;
-    });
-
-    // ===== Environment braces/brackets fixes =====
-    // Examples:
-    // {\align} -> {align}
-    // {\document} -> {document}
-    const bracesEnvironments =
-      'align equation itemize enumerate figure tikzpicture document'.split(' ');
-    const bracesFixes = generateEnvironmentBracesFixes(bracesEnvironments);
-    Object.assign(patterns, bracesFixes);
 
     // ===================================================================
     // Manual replacements - for specific cases that need special handling

--- a/src/replacement/rulesRegex.ts
+++ b/src/replacement/rulesRegex.ts
@@ -8,6 +8,10 @@ import {
 const EQUATION_ENVIRONMENT_PATTERN =
   '(?:align\\*?|aligned\\*?|alignat\\*?|flalign\\*?|gather\\*?|multline\\*?|equation\\*?|eqnarray\\*?|split\\*?)';
 
+function getSafeString(value: string | number | undefined): string {
+  return typeof value === 'string' ? value : '';
+}
+
 const convertFencedLatexBlock: ReplacementFunction = (
   match,
   leadingBreak,
@@ -17,22 +21,17 @@ const convertFencedLatexBlock: ReplacementFunction = (
   inlineBody,
 ) => {
   const newline = match.includes('\r\n') ? '\r\n' : '\n';
-  const safeLeadingBreak = typeof leadingBreak === 'string' ? leadingBreak : '';
-  const safeIndent = typeof indent === 'string' ? indent : '';
-  const safeEnvironment = typeof environment === 'string' ? environment : '';
-  const safeBody =
-    typeof multilineBody === 'string'
-      ? multilineBody
-      : typeof inlineBody === 'string'
-        ? inlineBody
-        : '';
+  const safeLeadingBreak = getSafeString(leadingBreak);
+  const safeIndent = getSafeString(indent);
+  const safeEnvironment = getSafeString(environment);
+  const safeBody = getSafeString(multilineBody) || getSafeString(inlineBody);
 
-  const bodyWithTrailingBreak =
-    safeBody === ''
-      ? ''
-      : safeBody.endsWith(newline)
-        ? safeBody
-        : `${safeBody}${newline}`;
+  let bodyWithTrailingBreak = '';
+  if (safeBody !== '') {
+    bodyWithTrailingBreak = safeBody.endsWith(newline)
+      ? safeBody
+      : `${safeBody}${newline}`;
+  }
   const emptyBodyPadding = safeBody === '' ? newline : '';
 
   return `${safeLeadingBreak}${safeIndent}\\begin{${safeEnvironment}}${newline}${emptyBodyPadding}${bodyWithTrailingBreak}${safeIndent}\\end{${safeEnvironment}}`;


### PR DESCRIPTION
- Simplify getReplacementsByCategory using Array.find instead of Map
- Use Object.assign for pattern accumulation in getAllReplacements
- Fix nested ternary in convertFencedLatexBlock with helper function
- Remove fake comment patterns from generateGroupedBackslashFixes
- Consolidate cleanFileContent to delegate to engine.applyAll
- Extract convertMathContent helper to reduce code duplication
- Simplify maxRules.ts pattern accumulation using Object.assign
- Remove unnecessary type assertions in applyReplacements
- Simplify escapeTextttUnderscores to single expression
- Convert equations.ts forEach loops to Object.fromEntries

Net reduction of ~130 lines while preserving all functionality.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reduces duplication and simplifies the LaTeX replacement pipeline while preserving behavior.
> 
> - Extracts `MATH_UNICODE_MAP`, `MATH_ENVIRONMENTS`, and `convertMathContent` in `advanced.ts`; streamlines `replaceMathUnicode` and condenses `escapeTextttUnderscores` to a single expression
> - Simplifies pattern aggregation using `Object.assign`/`Object.fromEntries` across `engine.ts`, `maxRules.ts`, and `rules/equations.ts`; removes fake comment entries from `generateGroupedBackslashFixes`
> - Refactors `getReplacementsByCategory` to use direct `find` lookups; `getAllReplacements` now merges enabled patterns with custom ones taking precedence
> - Tightens `applyReplacements` type handling (skips non-string entries in non-regex categories and logs), and simplifies regex replacement callback usage
> - Improves fenced LaTeX block conversion in `rulesRegex.ts` via `getSafeString` helper and clearer newline handling
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 945d16747f4f3d6321339da36ae6bf73b3d5a2c3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->