### PR TITLE
Simplify and improve code clarity

### DIFF
--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -349,23 +349,6 @@ export abstract class ModelHandler<
     });
   }
 
-  /** Set of providers that use OpenAI-compatible API format. */
-  private static readonly OPENAI_COMPATIBLE_PROVIDERS = new Set([
-    ModelProvider.OPENAI,
-    ModelProvider.GOOGLE,
-    ModelProvider.OTHERS,
-    ModelProvider.DEEPSEEK,
-    ModelProvider.XAI,
-    ModelProvider.MOONSHOT,
-    ModelProvider.DASHSCOPE,
-    ModelProvider.ANTHROPIC,
-  ]);
-
-  /** Checks if the model uses an OpenAI-compatible API format. */
-  get isOpenaiCompatible(): boolean {
-    return ModelHandler.OPENAI_COMPATIBLE_PROVIDERS.has(this.config.provider);
-  }
-
   /** Checks if the model is from a specific provider. */
   isProvider(provider: ModelProvider): boolean {
     return this.config.provider === provider;

--- a/src/agent/modelHandlers/modelHandlerKimi.ts
+++ b/src/agent/modelHandlers/modelHandlerKimi.ts
@@ -1,195 +1,49 @@
-// Third-party imports
-import OpenAI from 'openai';
-
 // Local imports - agent
 import type { NormalizedUsage } from '@agent/types/NormalizedUsage';
 import { BaseReasoningStreamAggregator } from './BaseReasoningStreamAggregator';
 import { ModelHandlerOpenAI } from './modelHandlerOpenAI';
-import { executeRequest } from './utils/requestExecutor';
-import { toOpenAITools } from './toolConversion';
-import type { CreateResponseOptions } from './types/IModelHandler';
-import type {
-  ChatCompletion,
-  ChatCompletionChunk,
-  ChatCompletionMessageParam,
-} from 'openai/resources/chat/completions';
-import type { ContentDeltaEvent } from 'openai/lib/ChatCompletionStream';
+import type { NormalizeOpenAIMessageContentOptions } from './openAIMessageUtils';
 
 /**
  * Handler for Moonshot Kimi models using OpenAI-compatible API.
+ *
+ * Kimi K2 Thinking models automatically enable reasoning based on model name.
+ * No explicit `thinking` parameter is needed - the API returns reasoning_content
+ * automatically when streaming. The base class's executeStreamingChat handles
+ * reasoning_content extraction via extractReasoningDelta.
+ *
+ * Note: getBaseUrl() is NOT overridden here.
+ * The base ModelHandler.getBaseUrl() correctly handles:
+ * - Server-side keys: routes through relay
+ * - Direct access: uses BASE_URLS[MOONSHOT] = 'https://api.moonshot.cn/v1'
  */
 export class ModelHandlerKimi extends ModelHandlerOpenAI {
   protected override get usageProvider(): NormalizedUsage['provider'] {
     return 'kimi';
   }
 
-  protected createStreamingAggregator(): BaseReasoningStreamAggregator | null {
-    // Use aggregator for thinking models to properly reconstruct the response
-    const isThinkingModel =
-      this.config.capabilities.supportsReasoning ||
-      this.capabilities.supportsReasoning;
-    return isThinkingModel ? new BaseReasoningStreamAggregator() : null;
+  /**
+   * Create streaming aggregator for thinking models.
+   * Uses BaseReasoningStreamAggregator to properly reconstruct responses
+   * with reasoning_content.
+   */
+  protected override createStreamingAggregator(): BaseReasoningStreamAggregator | null {
+    return this.capabilities.supportsReasoning
+      ? new BaseReasoningStreamAggregator()
+      : null;
   }
-  // Note: getBaseUrl() is NOT overridden here.
-  // The base ModelHandler.getBaseUrl() correctly handles:
-  // - Server-side keys: routes through relay
-  // - Direct access: uses BASE_URLS[MOONSHOT] = 'https://api.moonshot.cn/v1'
 
   /**
-   * Override createResponse to preprocess messages for Kimi models.
-   *
-   * Note: This handler does NOT use the getMessageNormalizationOptions() hook
-   * because Kimi thinking models require additional custom logic:
-   * - Reasoning auto-enabled via model name (no explicit parameter needed)
-   * - Custom streaming aggregation for reasoning_content
-   * - Different request structure for thinking vs regular models
-   *
-   * processThinkingBlock is inherited from ModelHandlerOpenAI which
-   * already handles reasoning_content extraction via extractReasoningFromMessage().
+   * Kimi requires string content format for messages.
+   * Uses the parent's normalization hook instead of overriding createResponse.
    */
-  async createResponse(
-    options: CreateResponseOptions<ChatCompletionMessageParam, OpenAI>,
-  ): Promise<ChatCompletion> {
-    const { client, messages, temperature, endTag, signal, tools } = options;
-    // Preprocess messages for Kimi compatibility
-    const processedMessages = this.prepareNormalizedMessages(
-      messages,
-      {
-        convertContentToString: true,
-      },
-      'Kimi',
-    );
-
-    // For Kimi thinking model, add the thinking parameter
-    const isThinkingModel =
-      this.config.capabilities.supportsReasoning ||
-      this.capabilities.supportsReasoning;
-
-    if (isThinkingModel) {
-      this.logger.debug(
-        'Using Kimi thinking model - reasoning enabled via model name',
-      );
-
-      // Check if streaming is enabled
-      const useStreaming = this.getStreamingConfig();
-
-      // Kimi K2 Thinking models automatically enable reasoning based on model name.
-      // No `thinking` parameter is needed - the API returns reasoning_content automatically.
-      // Recommended: temperature=1.0, max_tokens >= 16000, stream=true
-      const kwargs: any = {
-        model: this.config.fullName,
-        messages: processedMessages,
-        temperature: temperature,
-        max_tokens: this.config.maxOutputTokens,
-      };
-
-      if (endTag) {
-        kwargs.stop = [endTag];
-      }
-
-      if (tools && tools.length > 0) {
-        kwargs.tools = toOpenAITools(tools);
-        kwargs.tool_choice = 'auto';
-      }
-
-      if (useStreaming) {
-        // Use streaming with aggregator for thinking model
-        kwargs.stream = true;
-        kwargs.stream_options = { include_usage: true };
-
-        const stream = await executeRequest(
-          {
-            model: this.config.name,
-            operation: 'kimi.chat.completions.stream',
-            signal,
-          },
-          () => client.chat.completions.stream(kwargs, { signal }),
-        );
-        const thinking = this.createThinkingStream();
-        const output = this.isOutputStreamingEnabled()
-          ? this.createOutputStream()
-          : undefined;
-
-        // Create aggregator to properly reconstruct the final response
-        const streamingAggregator = new BaseReasoningStreamAggregator();
-
-        const onContentDelta = ({ delta }: ContentDeltaEvent): void => {
-          if (!delta) {
-            return;
-          }
-          output?.append(delta);
-          streamingAggregator.appendContent(delta);
-        };
-
-        const onChunk = (chunk: ChatCompletionChunk): void => {
-          streamingAggregator.consumeChunk(chunk);
-
-          // Extract reasoning_content from the chunk delta
-          const choice = chunk.choices?.[0];
-          if (!choice) {
-            return;
-          }
-          const delta = choice.delta as unknown;
-          if (
-            delta &&
-            typeof delta === 'object' &&
-            'reasoning_content' in delta
-          ) {
-            const reasoningContent = (delta as { reasoning_content?: unknown })
-              .reasoning_content;
-            const reasoningDelta =
-              typeof reasoningContent === 'string' ? reasoningContent : '';
-            if (reasoningDelta) {
-              thinking.append(reasoningDelta);
-              streamingAggregator.appendReasoning(reasoningDelta);
-            }
-          }
-        };
-
-        stream.on('content.delta', onContentDelta);
-        stream.on('chunk', onChunk);
-
-        try {
-          // Usage is captured by the aggregator from choices[0].usage (Kimi's format)
-          const finalResponse = await this.awaitFinalResponse(
-            stream,
-            streamingAggregator,
-          );
-
-          const finalReasoning = this.processThinkingBlock(finalResponse);
-          if (finalReasoning === null) {
-            thinking.finalize();
-          } else {
-            thinking.finalize(finalReasoning);
-          }
-          const finalOutput =
-            finalResponse.choices?.[0]?.message?.content ?? '';
-          output?.finalize(finalOutput);
-          return finalResponse;
-        } finally {
-          stream.off('content.delta', onContentDelta);
-          stream.off('chunk', onChunk);
-        }
-      }
-
-      // Non-streaming request
-      return executeRequest(
-        {
-          model: this.config.name,
-          operation: 'kimi.chat.completions.create',
-          signal,
-        },
-        () => client.chat.completions.create(kwargs, { signal }),
-      );
-    }
-
-    // For regular Kimi models, call the parent implementation
-    return super.createResponse({
-      ...options,
-      messages: processedMessages,
-    });
+  protected override getMessageNormalizationOptions(): NormalizeOpenAIMessageContentOptions {
+    return { convertContentToString: true };
   }
 
+  // Note: processThinkingBlock is inherited from ModelHandlerOpenAI which
+  // already handles reasoning_content extraction via extractReasoningFromMessage().
+  //
   // Note: createMediaContent is inherited from ModelHandlerOpenAI which
   // already handles images via buildStandardVisionParts() and logs
   // appropriate warnings for unsupported media categories.

--- a/src/agent/modelHandlers/modelHandlerXAI.ts
+++ b/src/agent/modelHandlers/modelHandlerXAI.ts
@@ -1,9 +1,3 @@
-// (none needed)
-
-// Local imports - agent
-import { AgentWorkspaceState } from '@agent/core/AgentWorkspaceState';
-import { K_SLICE } from '@utils/config';
-
 // Local file imports
 import { ModelHandlerOpenAI } from './modelHandlerOpenAI';
 
@@ -12,80 +6,28 @@ import type { ExtractResponseResult } from './types/IModelHandler';
 
 /**
  * Handler for xAI models using OpenAI-compatible API.
+ *
+ * Note: reasoning_effort is not supported by grok-4 models.
+ * Specifying reasoning_effort parameter will result in an error response.
+ *
+ * processThinkingBlock is inherited from ModelHandlerOpenAI which already
+ * extracts reasoning_content from the response message.
+ *
  * usageProvider and toolCallProvider inherit from base class via config.provider.
  */
 export class ModelHandlerXAI extends ModelHandlerOpenAI {
-  /**
-   * Process thinking blocks for xAI models
-   * @param responseObject The raw response object from the model
-   * @param workspaceState Optional workspaceState to update with the thinking block
-   * @returns The extracted reasoning_content or null if none
-   */
-  processThinkingBlock(
-    responseObject: any,
-    workspaceState?: AgentWorkspaceState,
-  ): string | null {
-    if (!responseObject) {
-      return null;
-    }
-
-    // reasoning_effort is not supported by grok-4.
-    // Specifying reasoning_effort parameter will get an error response.
-
-    // Extract reasoning content from xAI response
-    let reasoningContent = null;
-
-    // Check for reasoning_content based on xAI API structure
-    if (
-      responseObject.choices &&
-      responseObject.choices.length > 0 &&
-      responseObject.choices[0].message
-    ) {
-      const message = responseObject.choices[0].message;
-
-      // Extract reasoning_content from xAI response
-      if (message.reasoning_content) {
-        reasoningContent = message.reasoning_content;
-        this.logger.debug(
-          'Found reasoning_content in choices[0].message.reasoning_content',
-        );
-
-        // If workspaceState is provided and we have reasoning content,
-        // store it in the workspaceState for future use
-        if (workspaceState && !workspaceState.reasoning.thinkingAdded) {
-          // Create a thinking block in a consistent format
-          const thinkingBlock = {
-            type: 'thinking',
-            thinking: reasoningContent,
-          };
-
-          workspaceState.reasoning.thinkingBlocks = [thinkingBlock];
-          workspaceState.reasoning.thinkingAdded = true;
-        }
-      }
-    }
-
-    if (!reasoningContent) {
-      return null;
-    }
-
-    // Log preview of thinking content
-    this.logger.debug(
-      `xAI reasoning content preview: ${reasoningContent.substring(0, K_SLICE)}...`,
-    );
-
-    return reasoningContent;
-  }
-
   /** Extracts response text and usage statistics from API response. */
-  extractResponse(responseObject: any, endTag: string): ExtractResponseResult {
+  override extractResponse(
+    responseObject: any,
+    endTag: string,
+  ): ExtractResponseResult {
     const result = super.extractResponse(responseObject, endTag);
 
-    // Extract and add reasoning tokens for usage calculation
-    if (responseObject.usage?.completion_tokens_details?.reasoning_tokens) {
-      this.logger.debug(
-        `Found reasoning tokens: ${responseObject.usage.completion_tokens_details.reasoning_tokens}`,
-      );
+    // Log reasoning tokens if present (xAI-specific debug info)
+    const reasoningTokens =
+      responseObject.usage?.completion_tokens_details?.reasoning_tokens;
+    if (reasoningTokens) {
+      this.logger.debug(`Found reasoning tokens: ${reasoningTokens}`);
     }
 
     return result;

--- a/src/agent/modelHandlers/types/IModelHandler.ts
+++ b/src/agent/modelHandlers/types/IModelHandler.ts
@@ -173,9 +173,6 @@ export interface IModelHandler<
   /** Whether the handler supports processing attachments in tool results. */
   readonly canProcessToolResultAttachments: boolean;
 
-  /** Checks if the provider implements the OpenAI API. */
-  readonly isOpenaiCompatible: boolean;
-
   /** Set the logger instance for the handler. */
   setLogger(logger: AgentLogger): void;
 


### PR DESCRIPTION
- Simplify ModelHandlerKimi from ~197 to ~51 lines by using parent's executeStreamingChat and getMessageNormalizationOptions hook instead of duplicating streaming logic
- Remove redundant processThinkingBlock from ModelHandlerXAI (parent already handles reasoning_content extraction via extractReasoningFromMessage)
- Remove unused isOpenaiCompatible getter and OPENAI_COMPATIBLE_PROVIDERS set from ModelHandler (dead code never called)
- Remove isOpenaiCompatible from IModelHandler interface

Total: 224 lines removed while preserving all functionality

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Cuts redundant logic and centralizes behavior in shared utilities.
> 
> - Simplifies `modelHandlerKimi.ts` by delegating streaming and reasoning handling to `ModelHandlerOpenAI`; uses `getMessageNormalizationOptions()` (`convertContentToString: true`) and `BaseReasoningStreamAggregator` when `supportsReasoning` is true
> - Cleans up `modelHandlerXAI.ts`: removes custom `processThinkingBlock`; now only overrides `extractResponse()` to log xAI `reasoning_tokens`
> - Removes unused OpenAI-compat code from core:
>   - Drops `OPENAI_COMPATIBLE_PROVIDERS` and `isOpenaiCompatible` from `ModelHandler.ts`
>   - Removes `isOpenaiCompatible` from `IModelHandler` interface
> 
> No changes to base URL routing; `ModelHandler.getBaseUrl()` remains the source of truth
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6ca5dc2b24432aa9cd059e056b79efee83028f8a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->