### PR TITLE
Simplify and improve code clarity

### DIFF
--- a/src/auth/SupabaseAuthProvider.ts
+++ b/src/auth/SupabaseAuthProvider.ts
@@ -451,33 +451,36 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
     scopes: readonly string[],
   ): Promise<vscode.AuthenticationSession> {
     // Extract provider from scopes (format: "provider:github", "provider:github-browser", or "provider:google")
-    const providerScope = scopes.find((s) => s.startsWith('provider:'));
-    const requestedProvider = providerScope?.split(':')[1];
+    const requestedProvider = scopes
+      .find((s) => s.startsWith('provider:'))
+      ?.split(':')[1];
 
-    // Handle github-browser as a special case - use browser OAuth flow for GitHub
-    if (requestedProvider === 'github-browser') {
-      logger.info(
-        'SupabaseAuthProvider',
-        'Using browser-based GitHub auth (Supabase OAuth flow)',
-      );
-      return this.createSessionViaSupabaseOAuth('github');
+    // Route to appropriate auth flow based on provider
+    switch (requestedProvider) {
+      case 'github-browser':
+        logger.info(
+          'SupabaseAuthProvider',
+          'Using browser-based GitHub auth (Supabase OAuth flow)',
+        );
+        return this.createSessionViaSupabaseOAuth('github');
+
+      case 'github':
+      case undefined:
+        // Default to VS Code's built-in GitHub auth - works everywhere and is simpler
+        logger.info(
+          'SupabaseAuthProvider',
+          'Using VS Code GitHub auth (works on desktop and Codespaces)',
+        );
+        return this.createSessionViaVSCodeGitHub();
+
+      default:
+        // Other providers (Google) use traditional Supabase OAuth flow
+        return this.createSessionViaSupabaseOAuth(
+          isOAuthProvider(requestedProvider)
+            ? requestedProvider
+            : DEFAULT_OAUTH_PROVIDER,
+        );
     }
-
-    const provider = isOAuthProvider(requestedProvider)
-      ? requestedProvider
-      : DEFAULT_OAUTH_PROVIDER;
-
-    // For GitHub, use VS Code's built-in auth - works everywhere and is simpler
-    if (provider === 'github') {
-      logger.info(
-        'SupabaseAuthProvider',
-        'Using VS Code GitHub auth (works on desktop and Codespaces)',
-      );
-      return this.createSessionViaVSCodeGitHub();
-    }
-
-    // For other providers (Google), use traditional Supabase OAuth flow
-    return this.createSessionViaSupabaseOAuth(provider);
   }
 
   /**

--- a/src/auth/authCommands.ts
+++ b/src/auth/authCommands.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import { ProfileViewProvider } from '@profileView/ProfileViewProvider';
+import { toErrorMessage } from '@common/errors/errorHandlingUtils';
 import { SupabaseClient } from './SupabaseClient';
 import { SupabaseAuthProvider } from './SupabaseAuthProvider';
 import { type OAuthProvider, getExternalAuthCallbackUri } from './config';
@@ -125,8 +126,9 @@ export async function signIn(): Promise<void> {
       );
     }
   } catch (error) {
-    const message = error instanceof Error ? error.message : 'Unknown error';
-    void vscode.window.showErrorMessage(`Sign in failed: ${message}`);
+    void vscode.window.showErrorMessage(
+      `Sign in failed: ${toErrorMessage(error)}`,
+    );
   }
 }
 
@@ -178,9 +180,8 @@ async function signInWithEmail(): Promise<void> {
       `Magic link sent to ${email}. Click the link in your email - VS Code will sign you in automatically.`,
     );
   } catch (error) {
-    const message = error instanceof Error ? error.message : 'Unknown error';
     void vscode.window.showErrorMessage(
-      `Failed to send magic link: ${message}`,
+      `Failed to send magic link: ${toErrorMessage(error)}`,
     );
   }
 }
@@ -226,8 +227,9 @@ export async function signOut(): Promise<void> {
       );
     }
   } catch (error) {
-    const message = error instanceof Error ? error.message : 'Unknown error';
-    void vscode.window.showErrorMessage(`Sign out failed: ${message}`);
+    void vscode.window.showErrorMessage(
+      `Sign out failed: ${toErrorMessage(error)}`,
+    );
   }
 }
 
@@ -246,8 +248,9 @@ export async function viewProfile(): Promise<void> {
   try {
     await profileViewProvider.showProfileView();
   } catch (error) {
-    const message = error instanceof Error ? error.message : 'Unknown error';
-    void vscode.window.showErrorMessage(`Failed to load profile: ${message}`);
+    void vscode.window.showErrorMessage(
+      `Failed to load profile: ${toErrorMessage(error)}`,
+    );
   }
 }
 
@@ -331,9 +334,8 @@ export async function showAccountMenu(): Promise<void> {
       }
     }
   } catch (error) {
-    const message = error instanceof Error ? error.message : 'Unknown error';
     void vscode.window.showErrorMessage(
-      `Failed to show account menu: ${message}`,
+      `Failed to show account menu: ${toErrorMessage(error)}`,
     );
   }
 }

--- a/src/auth/config.ts
+++ b/src/auth/config.ts
@@ -151,25 +151,19 @@ export function hasVisibilityAccess(
   permissions: string[],
   visibility: string | string[] | undefined | null,
 ): boolean {
-  // Handle undefined/null visibility - treat as public
-  if (!visibility) {
+  // Normalize to array and filter out non-strings
+  const visibilityArray = visibility
+    ? (Array.isArray(visibility) ? visibility : [visibility]).filter(
+        (v): v is string => typeof v === 'string',
+      )
+    : [];
+
+  // Empty/null visibility or 'public' tag means accessible to all
+  if (visibilityArray.length === 0 || visibilityArray.includes('public')) {
     return true;
   }
-  const visibilityArray = Array.isArray(visibility) ? visibility : [visibility];
-  // Filter out any undefined/null elements
-  const cleanedVisibility = visibilityArray.filter(
-    (v): v is string => typeof v === 'string',
-  );
-  // Empty visibility array is treated as public
-  if (cleanedVisibility.length === 0) {
-    return true;
-  }
-  // Public agents are always accessible
-  if (cleanedVisibility.includes('public')) {
-    return true;
-  }
-  // Check for any overlap between visibility and permissions
-  return cleanedVisibility.some((v) => permissions.includes(v));
+
+  return visibilityArray.some((v) => permissions.includes(v));
 }
 
 /**
@@ -234,22 +228,6 @@ export function getAuthCallbackUri(uriScheme: string): string {
 }
 
 /**
- * Get the environment-appropriate OAuth callback URI.
- * Uses vscode.env.asExternalUri() to handle different environments:
- * - Desktop VS Code: returns vscode://texra-ai.texra/auth-callback
- * - Cursor: returns cursor://texra-ai.texra/auth-callback
- * - Codespaces: returns https://*.github.dev/extension-auth-callback
- * - Remote SSH: handles port forwarding automatically
- */
-export async function getExternalAuthCallbackUri(): Promise<string> {
-  const baseCallbackUri = vscode.Uri.parse(
-    getAuthCallbackUri(vscode.env.uriScheme),
-  );
-  const externalUri = await vscode.env.asExternalUri(baseCallbackUri);
-  return externalUri.toString();
-}
-
-/**
  * Result of parsing the external auth callback URI.
  * In Codespaces, VS Code adds a state parameter that must be preserved
  * for the callback routing to work.
@@ -265,30 +243,33 @@ export interface ExternalAuthCallbackInfo {
 
 /**
  * Get the external auth callback URI with parsed components.
+ * Uses vscode.env.asExternalUri() to handle different environments:
+ * - Desktop VS Code: returns vscode://texra-ai.texra/auth-callback
+ * - Cursor: returns cursor://texra-ai.texra/auth-callback
+ * - Codespaces: returns https://*.github.dev/extension-auth-callback
+ * - Remote SSH: handles port forwarding automatically
+ *
  * In Codespaces, VS Code generates a state parameter that MUST be preserved
  * and passed through the OAuth flow for the callback routing to work.
- *
- * Without this, the callback URL gets the state URL-encoded into the path,
- * breaking VS Code's ability to route it to the extension.
  */
 export async function getExternalAuthCallbackInfo(): Promise<ExternalAuthCallbackInfo> {
   const baseCallbackUri = vscode.Uri.parse(
     getAuthCallbackUri(vscode.env.uriScheme),
   );
   const externalUri = await vscode.env.asExternalUri(baseCallbackUri);
-
-  // Parse VS Code's state parameter if present (added in Codespaces/web)
-  const queryParams = new URLSearchParams(externalUri.query);
-  const vscodeState = queryParams.get('state');
-
-  // Build base URL without query params
+  const vscodeState = new URLSearchParams(externalUri.query).get('state');
   const baseUrl = `${externalUri.scheme}://${externalUri.authority}${externalUri.path}`;
 
-  return {
-    baseUrl,
-    vscodeState,
-    fullUrl: externalUri.toString(),
-  };
+  return { baseUrl, vscodeState, fullUrl: externalUri.toString() };
+}
+
+/**
+ * Get the environment-appropriate OAuth callback URI as a simple string.
+ * Use getExternalAuthCallbackInfo() when you need access to parsed components.
+ */
+export async function getExternalAuthCallbackUri(): Promise<string> {
+  const info = await getExternalAuthCallbackInfo();
+  return info.fullUrl;
 }
 
 /** Timeout for waiting for OAuth callback (2 minutes in ms) */

--- a/src/auth/serverKeys/ServerSideKeyService.ts
+++ b/src/auth/serverKeys/ServerSideKeyService.ts
@@ -250,22 +250,22 @@ export class ServerSideKeyService {
 
   private async fetchAccessStatus(): Promise<boolean> {
     try {
-      const isAuthenticated = await this.authProvider.isAuthenticated();
-      if (!isAuthenticated) {
-        this.accessResult = false;
-        this.userTier = null;
-        return false;
+      if (!(await this.authProvider.isAuthenticated())) {
+        return this.setAccessDenied();
       }
-
       const tier = await this.authProvider.getUserTier();
       this.accessResult = true;
       this.userTier = tier || FREE_TIER;
       return true;
-    } catch (_err) {
-      this.accessResult = false;
-      this.userTier = null;
-      return false;
+    } catch {
+      return this.setAccessDenied();
     }
+  }
+
+  private setAccessDenied(): false {
+    this.accessResult = false;
+    this.userTier = null;
+    return false;
   }
 
   /**

--- a/src/auth/tier/TierService.ts
+++ b/src/auth/tier/TierService.ts
@@ -19,6 +19,7 @@ import {
   TierModelConfigSchema,
   UserAccessStatusSchema,
   type TierModelConfig,
+  type TierModelsConfig,
   type UserAccessStatus,
 } from './types';
 
@@ -162,6 +163,17 @@ export class TierService {
   }
 
   /**
+   * Get tier-specific config from cached or provided config.
+   * Returns null if config or tier config not available.
+   */
+  private getTierConfig(
+    tier: UserTier,
+    config?: TierModelConfig | null,
+  ): TierModelsConfig | null {
+    return (config ?? this.cache)?.tiers[tier] ?? null;
+  }
+
+  /**
    * Check if a specific model is available for a user tier.
    *
    * @param tier - User's tier (free, Max, Ultra)
@@ -173,20 +185,9 @@ export class TierService {
     modelName: string,
     config?: TierModelConfig | null,
   ): boolean {
-    const cfg = config ?? this.cache;
-    if (!cfg) {
-      return false;
-    }
-
-    const tierConfig = cfg.tiers[tier];
-    if (!tierConfig) {
-      return false;
-    }
-
-    if (tierConfig.models === '*') {
-      return true;
-    }
-
+    const tierConfig = this.getTierConfig(tier, config);
+    if (!tierConfig) return false;
+    if (tierConfig.models === '*') return true;
     return tierConfig.models.includes(modelName);
   }
 
@@ -198,20 +199,9 @@ export class TierService {
     tier: UserTier,
     config?: TierModelConfig | null,
   ): string[] | null {
-    const cfg = config ?? this.cache;
-    if (!cfg) {
-      return [];
-    }
-
-    const tierConfig = cfg.tiers[tier];
-    if (!tierConfig) {
-      return [];
-    }
-
-    if (tierConfig.models === '*') {
-      return null;
-    }
-
+    const tierConfig = this.getTierConfig(tier, config);
+    if (!tierConfig) return [];
+    if (tierConfig.models === '*') return null;
     return tierConfig.models;
   }
 
@@ -220,8 +210,7 @@ export class TierService {
    * All tiers have access to the same providers.
    */
   getProviders(config?: TierModelConfig | null): string[] {
-    const cfg = config ?? this.cache;
-    return cfg?.providers ?? [];
+    return (config ?? this.cache)?.providers ?? [];
   }
 
   /**
@@ -231,25 +220,11 @@ export class TierService {
     tier: UserTier,
     config?: TierModelConfig | null,
   ): string {
-    const cfg = config ?? this.cache;
-    if (!cfg) {
-      return 'No included model access';
-    }
-
-    const tierConfig = cfg.tiers[tier];
-    if (!tierConfig) {
-      return 'No included model access';
-    }
-
-    if (tierConfig.models === '*') {
-      return 'All models included';
-    }
-
+    const tierConfig = this.getTierConfig(tier, config);
+    if (!tierConfig) return 'No included model access';
+    if (tierConfig.models === '*') return 'All models included';
     const modelCount = tierConfig.models.length;
-    if (modelCount === 0) {
-      return 'No included model access';
-    }
-
+    if (modelCount === 0) return 'No included model access';
     return `${modelCount} model${modelCount === 1 ? '' : 's'} included`;
   }
 

--- a/supabase/functions/relay/index.ts
+++ b/supabase/functions/relay/index.ts
@@ -198,6 +198,9 @@ function extractModelFromPath(apiPath: string): string | null {
   return match ? match[1] : null;
 }
 
+/** Milliseconds in one day */
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
 /**
  * Calculate access status for a user based on their tier and expiration date.
  */
@@ -219,16 +222,14 @@ function calculateAccessStatus(
     };
   }
 
-  const expiresAt = new Date(accessExpiresAt);
-  const now = new Date();
-  const diffMs = expiresAt.getTime() - now.getTime();
-  const daysRemaining = Math.ceil(diffMs / (1000 * 60 * 60 * 24));
-  const isExpired = daysRemaining <= 0;
+  const daysRemaining = Math.ceil(
+    (new Date(accessExpiresAt).getTime() - Date.now()) / MS_PER_DAY,
+  );
 
   return {
     tier,
     accessExpiresAt,
-    isExpired,
+    isExpired: daysRemaining <= 0,
     daysRemaining,
   };
 }

--- a/supabase/functions/relay/models.ts
+++ b/supabase/functions/relay/models.ts
@@ -148,9 +148,10 @@ export const FREE_TIER = 'free';
  * Get the monthly spending limit for a tier.
  */
 export function getSpendingLimit(tier: string): number {
-  if (tier === ULTRA_TIER) return TIER_SPENDING_LIMITS.Ultra;
-  if (tier === MAX_TIER) return TIER_SPENDING_LIMITS.Max;
-  return TIER_SPENDING_LIMITS.free;
+  return (
+    TIER_SPENDING_LIMITS[tier as keyof TierSpendingLimits] ??
+    TIER_SPENDING_LIMITS.free
+  );
 }
 
 // =============================================================================
@@ -166,27 +167,18 @@ export function isModelAllowedForTier(
   tier: string,
   modelName: string | null,
 ): boolean {
-  if (tier === ULTRA_TIER) {
-    return true;
-  }
-
+  if (tier === ULTRA_TIER) return true;
   if (!modelName) return false;
 
   const normalizedModel = modelName.toLowerCase();
+  const patterns =
+    tier === MAX_TIER
+      ? MAX_TIER_API_PATTERNS
+      : tier === FREE_TIER
+        ? FREE_TIER_API_PATTERNS
+        : [];
 
-  if (tier === MAX_TIER) {
-    return MAX_TIER_API_PATTERNS.some((pattern) =>
-      normalizedModel.startsWith(pattern),
-    );
-  }
-
-  if (tier === FREE_TIER) {
-    return FREE_TIER_API_PATTERNS.some((pattern) =>
-      normalizedModel.startsWith(pattern),
-    );
-  }
-
-  return false;
+  return patterns.some((pattern) => normalizedModel.startsWith(pattern));
 }
 
 // =============================================================================


### PR DESCRIPTION
Holistic simplification of authentication, tier management, and relay code:

- Use object lookup instead of if/else chain in getSpendingLimit
- Consolidate error message extraction with toErrorMessage utility
- Add getTierConfig helper to reduce redundancy in TierService
- Simplify hasVisibilityAccess with cleaner array normalization
- Use MS_PER_DAY constant for cleaner date calculations
- Consolidate getExternalAuthCallbackUri and getExternalAuthCallbackInfo
- Simplify isModelAllowedForTier with pattern array lookup
- Clean up provider scope parsing with switch statement
- Add setAccessDenied helper in ServerSideKeyService

Net reduction of ~46 lines while improving readability.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Focuses on code clarity and small structural improvements across auth, tier, and relay modules.
> 
> - Simplifies `createSession` in `SupabaseAuthProvider` with a `switch` for provider routing; defaults to VS Code GitHub auth and routes others to Supabase OAuth
> - Centralizes error handling in `authCommands` via `toErrorMessage`; keeps UI messages consistent
> - Cleans `hasVisibilityAccess` by normalizing `visibility` once and checking `public`/overlap succinctly
> - Consolidates callback utilities: adds `getExternalAuthCallbackInfo()` and lightweight `getExternalAuthCallbackUri()`; minor parsing cleanup
> - `ServerSideKeyService`: adds `setAccessDenied()` and streamlines `fetchAccessStatus`/cache checks
> - `TierService`: introduces `getTierConfig()` and simplifies `isModelAvailable`, `getAllowedModels`, `getProviders`, and `getAccessDescription`
> - Relay: adds `MS_PER_DAY` and simplifies `calculateAccessStatus`; streamlines `getSpendingLimit` and `isModelAllowedForTier` in `models.ts`
> 
> Net: fewer lines, clearer control flow and reusable helpers; no API surface changes indicated.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d48014bc3e8b8851924d61da6e7b07f9fe7de072. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->