### PR TITLE
Add explicit rejection message to model

### DIFF
--- a/src/test/tools/ToolEditApprovalGate.test.ts
+++ b/src/test/tools/ToolEditApprovalGate.test.ts
@@ -88,7 +88,10 @@ describe('Tool edit approval gating', () => {
 
     assert.strictEqual(appendCalled, false);
     assert.strictEqual(result.isError, true);
-    assert.strictEqual(result.error, 'Rejected by user');
+    // Rejection message is explicit; user feedback goes to userInstruction
+    assert.strictEqual(result.error, 'User rejected file_op for summary.txt.');
+    assert.strictEqual(result.output, 'User rejected file_op for summary.txt.');
+    assert.strictEqual(result.userInstruction, 'Rejected by user');
   });
 
   it('write_file skips approval when disabled via config', async () => {

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -762,8 +762,11 @@ export function buildApprovalRejectedResult(
   // while still forwarding any user note as explicit instruction for the model.
   const note = userMessage?.trim();
   const result: ToolResult = {
+    // Use output to ensure the rejection message is always shown to the model.
+    // formatToolResultAsText prioritizes output over error/summary.
+    output: baseMessage,
     summary: baseMessage,
-    error: note && note.length > 0 ? note : baseMessage,
+    error: baseMessage,
     isError: true,
     ...(note && note.length > 0 ? { userInstruction: note } : {}),
   };


### PR DESCRIPTION
When a user rejects an edit, the rejection message was not being explicitly communicated to the model if the user also provided feedback. The user's note was set as both the error and userInstruction fields, but formatToolResultAsText only showed "User feedback: {note}" without the explicit rejection message.

Now buildApprovalRejectedResult sets the output field to the rejection message ("User rejected {tool} for {path}.") which ensures it's always shown to the model via formatToolResultAsText. User feedback still goes to userInstruction for additional context.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Clarifies rejection signaling for tool edit approvals.
> 
> - `buildApprovalRejectedResult` now sets `output` and `error` to the explicit rejection message (`"User rejected {tool} for {path}."`) and routes any user note to `userInstruction`, ensuring `formatToolResultAsText` always shows the rejection
> - Updates `ToolEditApprovalGate.test.ts` to assert the explicit rejection in `error` and `output`, with user feedback in `userInstruction`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aacb8f844a8bb088ca073c779bb2fb73ec754505. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->