### PR TITLE
Fix chat history clearing on webview reload

### DIFF
--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -251,13 +251,13 @@ export class ProgressViewProvider
     // Frontend detects stream switches using its own lastRenderedStream tracking.
     // Backend just sends data with action: 'render', frontend decides if rebuild needed.
     //
-    // IMPORTANT: Only call refreshStreamSurface('') if there truly are no streams.
-    // If activeStream is empty but streams exist in state, this is likely a temporary
-    // filter mismatch (e.g., during resume flow). Calling refreshStreamSurface('')
-    // would send action: 'clear' and wipe the frontend display incorrectly.
+    // Skip refresh when activeStream is empty but streams exist in state - this indicates
+    // a temporary filter mismatch (e.g., during resume flow race conditions).
+    // Calling refreshStreamSurface('') would send action: 'clear' and wipe the display.
     const hasStreams = this.state.streamTabs.keys().length > 0;
-    if (activeStream || !hasStreams) {
-      this.eventHandler.refreshStreamSurface(activeStream || '');
+    const isFilterMismatch = !activeStream && hasStreams;
+    if (!isFilterMismatch) {
+      this.eventHandler.refreshStreamSurface(activeStream);
     }
 
     this._pendingUpdateOptions = null;

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -250,7 +250,15 @@ export class ProgressViewProvider
 
     // Frontend detects stream switches using its own lastRenderedStream tracking.
     // Backend just sends data with action: 'render', frontend decides if rebuild needed.
-    this.eventHandler.refreshStreamSurface(activeStream || '');
+    //
+    // IMPORTANT: Only call refreshStreamSurface('') if there truly are no streams.
+    // If activeStream is empty but streams exist in state, this is likely a temporary
+    // filter mismatch (e.g., during resume flow). Calling refreshStreamSurface('')
+    // would send action: 'clear' and wipe the frontend display incorrectly.
+    const hasStreams = this.state.streamTabs.keys().length > 0;
+    if (activeStream || !hasStreams) {
+      this.eventHandler.refreshStreamSurface(activeStream || '');
+    }
 
     this._pendingUpdateOptions = null;
   }

--- a/src/progressView/state/ProgressViewState.ts
+++ b/src/progressView/state/ProgressViewState.ts
@@ -144,6 +144,10 @@ export class ProgressViewState {
    * current active stream is not in the available set (e.g., due to filtering),
    * this method picks the first available stream and updates the state.
    *
+   * IMPORTANT: When availableStreams is empty but streams exist in state, we
+   * preserve the current activeStream to avoid clearing content during temporary
+   * filter mismatches (e.g., during resume flow race conditions).
+   *
    * @param availableStreams - Array of stream IDs that are currently visible/available
    * @returns The resolved active stream ID (may be empty string if no streams available)
    */
@@ -158,8 +162,12 @@ export class ProgressViewState {
     // Otherwise, pick the first available stream (or empty if none)
     const resolved = availableStreams[0] ?? '';
 
-    // Only update state if it actually changed
-    if (resolved !== currentActive) {
+    // Only update state if we have a valid resolved stream.
+    // Don't persist empty activeStream when availableStreams is empty -
+    // this could be a temporary filter mismatch (e.g., during resume flow).
+    // Clearing activeStream would cause refreshStreamSurface('') to send
+    // action: 'clear', wiping the frontend display incorrectly.
+    if (resolved && resolved !== currentActive) {
       this._activeStream = resolved;
       this.saveActiveStream();
     }

--- a/src/progressView/state/ProgressViewState.ts
+++ b/src/progressView/state/ProgressViewState.ts
@@ -144,12 +144,13 @@ export class ProgressViewState {
    * current active stream is not in the available set (e.g., due to filtering),
    * this method picks the first available stream and updates the state.
    *
-   * IMPORTANT: When availableStreams is empty but streams exist in state, we
-   * preserve the current activeStream to avoid clearing content during temporary
-   * filter mismatches (e.g., during resume flow race conditions).
+   * IMPORTANT: When availableStreams is empty, we preserve and return the current
+   * activeStream to avoid clearing content during temporary filter mismatches
+   * (e.g., during resume flow race conditions). The return value is always
+   * consistent with state._activeStream.
    *
    * @param availableStreams - Array of stream IDs that are currently visible/available
-   * @returns The resolved active stream ID (may be empty string if no streams available)
+   * @returns The resolved active stream ID (current active if no streams available)
    */
   resolveActiveStream(availableStreams: StreamTabId[]): StreamTabId {
     const currentActive = this._activeStream;
@@ -159,20 +160,19 @@ export class ProgressViewState {
       return currentActive;
     }
 
-    // Otherwise, pick the first available stream (or empty if none)
-    const resolved = availableStreams[0] ?? '';
+    // Pick the first available stream, or preserve current if none available.
+    // Preserving current when availableStreams is empty prevents clearing content
+    // during temporary filter mismatches (e.g., during resume flow race conditions).
+    const resolved = availableStreams[0];
 
-    // Only update state if we have a valid resolved stream.
-    // Don't persist empty activeStream when availableStreams is empty -
-    // this could be a temporary filter mismatch (e.g., during resume flow).
-    // Clearing activeStream would cause refreshStreamSurface('') to send
-    // action: 'clear', wiping the frontend display incorrectly.
     if (resolved && resolved !== currentActive) {
       this._activeStream = resolved;
       this.saveActiveStream();
     }
 
-    return resolved;
+    // Return resolved if valid, otherwise preserve current active.
+    // This keeps return value consistent with state._activeStream.
+    return resolved || currentActive;
   }
 
   get streamSortOrder(): string {


### PR DESCRIPTION
…eload

When a user sends a follow-up message after reloading the webview, the chat history was being cleared due to race conditions in the resume flow:

1. After webview reload, content is correctly displayed
2. User sends follow-up -> triggers resume
3. Resume emits setActiveStream event
4. The async handler is not awaited (fire-and-forget)
5. Meanwhile, another event triggers updateWebview()
6. resolveActiveStream() returns '' due to filter mismatch
7. refreshStreamSurface('') sends action: 'clear' -> history cleared

Root causes fixed:

1. resolveActiveStream(): Don't persist empty activeStream when resolution fails. If availableStreams is empty but streams exist in state, this is likely a temporary filter mismatch, not a legitimate "no streams" scenario.

2. updateWebview(): Guard against calling refreshStreamSurface('') when streams exist in state. Only send 'clear' action when there truly are no streams.

These defensive guards prevent accidental UI clearing during race conditions that can occur when async event handlers overlap with webview updates.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents accidental UI clearing caused by race conditions during resume flows after webview reloads.
> 
> - In `ProgressViewState.resolveActiveStream`, preserve current `activeStream` when `availableStreams` is empty; only update state when a valid resolved stream exists, and return current if none
> - In `ProgressViewProvider.updateWebview`, skip `refreshStreamSurface` when `activeStream` is empty but streams exist (filter mismatch), avoiding sending action: `clear`
> - Adds inline documentation clarifying the single-source-of-truth behavior for active stream resolution and the guard against temporary filter mismatches
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bc2ef4e81d37396bd987feabaa4fc25e52f5dbba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->