### PR TITLE
Fix text area spacing near button group

### DIFF
--- a/src/progressView/styles/follow-up-input.css
+++ b/src/progressView/styles/follow-up-input.css
@@ -24,17 +24,19 @@
   box-sizing: border-box;
 }
 
-/* Input row children participate directly in grid */
+/* Input row spans full width, uses flexbox internally for reliable alignment */
 .follow-up-input-row {
-  display: contents;
+  display: flex;
+  align-items: flex-end;
+  gap: var(--spacing-small);
+  grid-column: 1 / -1;
 }
 
 /* Style the textarea for multi-line input */
 #followUpInput {
   display: block;
-  grid-column: 1;
-  align-self: end;
-  min-width: 0; /* Allow shrinking below default 320px */
+  flex: 1; /* Fill remaining space, staying adjacent to buttons */
+  min-width: 0; /* Allow shrinking below vscode-textarea default 320px */
   line-height: 1.4;
   min-height: 106px;
   max-height: var(--height-xlarge);
@@ -53,6 +55,5 @@ vscode-toolbar-container.follow-up-actions {
   display: flex;
   flex-direction: column !important;
   align-items: center;
-  align-self: end;
   gap: var(--spacing-small);
 }


### PR DESCRIPTION
…ignment

The vscode-textarea component has a default width of 320px in its shadow DOM. Using display:contents with grid caused unreliable width behavior.

Changes:
- Replace display:contents with proper flex container for .follow-up-input-row
- Use flex:1 (like original flexbox layout) instead of width:100%
- Keep grid for outer container to handle queued messages row
- Both rows span full width, flexbox handles internal layout

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors the follow-up input layout for consistent sizing and alignment.
> 
> - Switches `follow-up-input-row` from `display: contents` to a full-width flex container for reliable alignment
> - Makes `#followUpInput` `flex: 1` with `min-width: 0` to avoid shadow DOM width constraints and enable proper shrinking
> - Keeps outer grid for queued messages; both rows span full width
> - Simplifies actions layout (column flex, centers items) by removing redundant self-alignment
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 17b82676b1755335ef1be57a3ca3f97bb7781ba3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->