### PR TITLE
Fix memory enabled status display issue

### DIFF
--- a/src/common/modules/domUtils.js
+++ b/src/common/modules/domUtils.js
@@ -76,15 +76,43 @@ export function safeSetElementValue(id, value) {
   element.value = value;
 }
 
+/**
+ * Set checked state on an element (checkbox, radio, toggle button).
+ * VS Code web components require both property and attribute for visual sync.
+ * @param {HTMLElement} element - The element to update
+ * @param {boolean} checked - The checked state
+ */
+export function setElementCheckedState(element, checked) {
+  if (!element) return;
+  element.checked = checked;
+  element.toggleAttribute('checked', checked);
+  element.setAttribute('aria-checked', String(checked));
+}
+
 export function safeSetElementChecked(id, checked) {
   const element = document.getElementById(id);
   if (!element) {
     console.warn(`Element with id '${id}' not found`);
     return;
   }
-  // VS Code web components require both property and attribute for visual sync
-  element.checked = checked;
-  element.toggleAttribute('checked', checked);
+  setElementCheckedState(element, checked);
+}
+
+/**
+ * Set the active radio in a group of vscode-radio elements.
+ * @param {HTMLElement} radioGroup - The radio group container
+ * @param {string} value - The value to select
+ * @param {string} [selector='vscode-radio'] - Selector for radio elements
+ */
+export function setRadioGroupValue(radioGroup, value, selector = 'vscode-radio') {
+  if (!radioGroup) return;
+  if ('value' in radioGroup) {
+    radioGroup.value = value;
+  }
+  for (const radio of radioGroup.querySelectorAll(selector)) {
+    const isActive = radio.value === value;
+    setElementCheckedState(radio, isActive);
+  }
 }
 
 export function safeGetElementById(id) {

--- a/src/common/modules/domUtils.js
+++ b/src/common/modules/domUtils.js
@@ -82,7 +82,9 @@ export function safeSetElementChecked(id, checked) {
     console.warn(`Element with id '${id}' not found`);
     return;
   }
+  // VS Code web components require both property and attribute for visual sync
   element.checked = checked;
+  element.toggleAttribute('checked', checked);
 }
 
 export function safeGetElementById(id) {

--- a/src/memoryView/modules/messageHandlers.js
+++ b/src/memoryView/modules/messageHandlers.js
@@ -26,6 +26,7 @@ export class MemoryViewMessageHandler extends BaseWebviewMessageHandler {
     const toggle = safeGetElementById(ELEMENT_IDS.MEMORY_ENABLED_TOGGLE);
     if (toggle) {
       toggle.checked = message.enabled;
+      toggle.toggleAttribute('checked', message.enabled);
       setElementDisabled(toggle, false);
     }
   }

--- a/src/memoryView/modules/messageHandlers.js
+++ b/src/memoryView/modules/messageHandlers.js
@@ -3,7 +3,7 @@ import { memoryViewDomHandler } from './domHandlers.js';
 import { ELEMENT_IDS } from './constants.js';
 import { MEMORY_VIEW_COMMANDS } from '@common/webview/commands.js';
 import { BaseWebviewMessageHandler } from '@common/BaseWebviewMessageHandler.js';
-import { safeGetElementById, setElementDisabled } from '@common/domUtils.js';
+import { safeSetElementChecked, setElementsDisabled } from '@common/domUtils.js';
 
 /**
  * Handles messages from the extension for the memory view.
@@ -23,13 +23,8 @@ export class MemoryViewMessageHandler extends BaseWebviewMessageHandler {
   }
 
   handleUpdateMemoryEnabled(message) {
-    const toggle = safeGetElementById(ELEMENT_IDS.MEMORY_ENABLED_TOGGLE);
-    if (toggle) {
-      // VS Code web components require both property and attribute for visual sync
-      toggle.checked = message.enabled;
-      toggle.toggleAttribute('checked', message.enabled);
-      setElementDisabled(toggle, false);
-    }
+    safeSetElementChecked(ELEMENT_IDS.MEMORY_ENABLED_TOGGLE, message.enabled);
+    setElementsDisabled(ELEMENT_IDS.MEMORY_ENABLED_TOGGLE, false);
   }
 }
 

--- a/src/memoryView/modules/messageHandlers.js
+++ b/src/memoryView/modules/messageHandlers.js
@@ -25,6 +25,7 @@ export class MemoryViewMessageHandler extends BaseWebviewMessageHandler {
   handleUpdateMemoryEnabled(message) {
     const toggle = safeGetElementById(ELEMENT_IDS.MEMORY_ENABLED_TOGGLE);
     if (toggle) {
+      // VS Code web components require both property and attribute for visual sync
       toggle.checked = message.enabled;
       toggle.toggleAttribute('checked', message.enabled);
       setElementDisabled(toggle, false);

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -13,7 +13,7 @@ import { getSharedLogEntryFormatter } from './formatters/index.js';
 import { progressViewState } from './progressViewState.js';
 import { BaseWebviewMessageHandler } from '@common/BaseWebviewMessageHandler.js';
 import { vscode } from '@common/webviewContext.js';
-import { scrollToBottom } from '@common/domUtils.js';
+import { scrollToBottom, setRadioGroupValue } from '@common/domUtils.js';
 
 // Session kind values match TypeScript AgentSessionKind enum
 // No need to duplicate - we use the actual values from messages
@@ -251,16 +251,7 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     const radioGroup = document.getElementById(
       ELEMENT_IDS.AGENT_FILTER_CONTAINER,
     );
-    if (!radioGroup) {
-      return;
-    }
-    radioGroup.value = state.agentTypeFilter;
-    for (const radio of radioGroup.querySelectorAll('vscode-radio')) {
-      const isActive = radio.value === state.agentTypeFilter;
-      radio.checked = isActive;
-      radio.setAttribute('aria-checked', String(isActive));
-      radio.toggleAttribute('checked', isActive);
-    }
+    setRadioGroupValue(radioGroup, state.agentTypeFilter);
   }
 
   /**

--- a/src/progressView/modules/uiManagers/ApprovalRequests.js
+++ b/src/progressView/modules/uiManagers/ApprovalRequests.js
@@ -94,8 +94,11 @@ export class ApprovalRequests extends BaseUIRequestManager {
 
     if (bypassButton) {
       const allowBypass = request.allowBypass !== false;
+      const isActive = Boolean(this.isBypassActive);
       bypassButton.toggleAttribute('disabled', !allowBypass);
-      bypassButton.checked = Boolean(this.isBypassActive);
+      // VS Code web components require both property and attribute for visual sync
+      bypassButton.checked = isActive;
+      bypassButton.toggleAttribute('checked', isActive);
     }
   }
 

--- a/src/progressView/modules/uiManagers/ApprovalRequests.js
+++ b/src/progressView/modules/uiManagers/ApprovalRequests.js
@@ -3,7 +3,7 @@ import { COMMANDS } from '../constants.js';
 import { BaseUIRequestManager } from './BaseUIRequestManager.js';
 
 // Local imports - common helpers
-import { addEventListenerSafely } from '@common/domUtils.js';
+import { addEventListenerSafely, setElementCheckedState } from '@common/domUtils.js';
 import { createFromTemplate } from '@common/templateUtils.js';
 import { vscode } from '@common/webviewContext.js';
 
@@ -94,11 +94,8 @@ export class ApprovalRequests extends BaseUIRequestManager {
 
     if (bypassButton) {
       const allowBypass = request.allowBypass !== false;
-      const isActive = Boolean(this.isBypassActive);
       bypassButton.toggleAttribute('disabled', !allowBypass);
-      // VS Code web components require both property and attribute for visual sync
-      bypassButton.checked = isActive;
-      bypassButton.toggleAttribute('checked', isActive);
+      setElementCheckedState(bypassButton, Boolean(this.isBypassActive));
     }
   }
 

--- a/src/webview/modules/mainViewState.js
+++ b/src/webview/modules/mainViewState.js
@@ -21,6 +21,7 @@ import {
   safeSetElementChecked,
   setChevronIcon,
   setElementDisabled,
+  setElementCheckedState,
   isSelectLikeElement,
   getSelectOptionElements,
   setExpandedState,
@@ -351,16 +352,7 @@ export class MainViewState {
           const radioValue =
             radio.dataset.sessionType || radio.getAttribute('value');
           const isActive = radioValue === resolvedSessionType;
-          if ('checked' in radio) {
-            radio.checked = isActive;
-          }
-          if (isActive) {
-            radio.setAttribute('checked', '');
-            radio.setAttribute('aria-checked', 'true');
-          } else {
-            radio.removeAttribute('checked');
-            radio.setAttribute('aria-checked', 'false');
-          }
+          setElementCheckedState(radio, isActive);
         });
       } else {
         const buttons = toggleContainer.querySelectorAll('[data-session-type]');


### PR DESCRIPTION
The vscode-checkbox web component requires both the .checked property AND the checked attribute to be set for the visual state to update correctly. Without the attribute toggle, the checkbox appeared unchecked even when memory was enabled.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves reliability of UI state sync for VS Code web components and refactors consumers to use new helpers.
> 
> - **Add** `setElementCheckedState`, `setRadioGroupValue`, and `setElementsDisabled` in `common/domUtils` to set `.checked`, `checked` attribute, and `aria-checked`, and to sync radio groups
> - **Fix** memory enabled toggle UI by using `safeSetElementChecked` and `setElementsDisabled` in `memoryView/messageHandlers`
> - **Refactor** agent filter radio syncing in `progressView/messageHandlers` to `setRadioGroupValue`
> - **Refactor** approval request bypass toggle in `ApprovalRequests` to use `setElementCheckedState`
> - **Refactor** session type toggle radios in `mainViewState` to use `setElementCheckedState`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4ee9a2a8d8b1c8fc673711c5a4ae42fd715b87ac. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->