### PR TITLE
Simplify and improve code clarity

### DIFF
--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -67,12 +67,12 @@ function logRepetitionDetected(
   logger: ErrorLogger,
 ): void {
   const preview = newResponse.substring(0, REPETITION_DETECTION_THRESHOLD);
+  const skeleton = JSON.stringify(messageToSkeleton(messages), null, 2);
   logger.error(
-    `The new response is (first ${REPETITION_DETECTION_THRESHOLD} chars): ${preview}`,
+    `Massive repetition detected - skipping this response\n` +
+      `First ${REPETITION_DETECTION_THRESHOLD} chars: ${preview}\n` +
+      `Message structure:\n${skeleton}`,
   );
-  logger.error('Massive repetition detected - skipping this response');
-  logger.error('Message structure when repetition detected:');
-  logger.error(JSON.stringify(messageToSkeleton(messages), null, 2));
 }
 
 // ============================================================================

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -77,26 +77,13 @@ function parseToolInput(
   callId: string,
   logger: AgentLogger,
 ): unknown {
-  // Handle null/undefined
   if (raw === null || raw === undefined) {
     logger.warn(`Tool call ${callId}: Received null input, using empty object`);
     return {};
   }
-
-  // Handle primitives (boolean, number) - pass through with warning
-  if (typeof raw === 'boolean' || typeof raw === 'number') {
-    logger.warn(
-      `Tool call ${callId}: Received primitive input (${String(raw)}), passing through`,
-    );
-    return raw;
-  }
-
-  // Handle objects/arrays - pass through directly
   if (typeof raw !== 'string') {
-    return raw;
+    return raw; // Objects, arrays, primitives pass through directly
   }
-
-  // Handle strings - try to parse as JSON
   try {
     return JSON.parse(raw);
   } catch {
@@ -112,28 +99,11 @@ function isZodValidationError(
   error: unknown,
 ): error is { issues: Array<Record<string, unknown>> } {
   return (
-    error !== null &&
     typeof error === 'object' &&
+    error !== null &&
     'issues' in error &&
     Array.isArray((error as { issues?: unknown }).issues)
   );
-}
-
-/** Format a Zod issue into a readable diagnostic entry. */
-function formatZodIssue(issue: Record<string, unknown>): {
-  path: string;
-  message: string;
-  expected?: unknown;
-  received?: unknown;
-  code?: string;
-} {
-  return {
-    path: Array.isArray(issue.path) ? issue.path.join('.') : '',
-    message: String(issue.message ?? ''),
-    expected: issue.expected,
-    received: issue.received,
-    code: typeof issue.code === 'string' ? issue.code : undefined,
-  };
 }
 
 /**
@@ -143,25 +113,26 @@ function normalizeToolCallError(
   toolName: string,
   error: unknown,
 ): { message: string; diagnostics?: ToolValidationDiagnostics } {
-  // Handle Zod validation errors with structured diagnostics
   if (isZodValidationError(error)) {
     return {
       message: `${toolName}: Invalid parameters provided`,
       diagnostics: {
         type: DIAGNOSTIC_TYPE_VALIDATION_ERROR,
         issues: error.issues,
-        formatted: error.issues.map(formatZodIssue),
+        formatted: error.issues.map((issue) => ({
+          path: Array.isArray(issue.path) ? issue.path.join('.') : '',
+          message: String(issue.message ?? ''),
+          expected: issue.expected,
+          received: issue.received,
+          code: typeof issue.code === 'string' ? issue.code : undefined,
+        })),
       },
     };
   }
 
-  // Handle standard errors and unknown types
-  const message =
-    error instanceof Error
-      ? `${toolName}: ${error.message}`
-      : `${toolName}: ${String(error)}`;
-
-  return { message };
+  const errorMessage =
+    error instanceof Error ? error.message : String(error);
+  return { message: `${toolName}: ${errorMessage}` };
 }
 
 // ============================================================================
@@ -895,7 +866,6 @@ class ToolUseDispatchNode<C> extends BaseNode<
   /**
    * Collect valid file locations from tool result attachments.
    * Filters out invalid paths and non-existent files.
-   * Uses parallel file existence checks for better performance.
    */
   private async collectValidMediaLocations(
     files: ToolResult['files'],
@@ -904,29 +874,22 @@ class ToolUseDispatchNode<C> extends BaseNode<
       return [];
     }
 
-    const results = await Promise.all(
-      files.map(async (attachment) => {
-        const path = attachment.path;
-
-        // Skip invalid paths
-        if (typeof path !== 'string' || path.trim() === '') {
-          return null;
+    const validLocations: FileLocation[] = [];
+    for (const attachment of files) {
+      const filePath = attachment.path;
+      if (typeof filePath !== 'string' || filePath.trim() === '') {
+        continue;
+      }
+      const location = pathToLocation(filePath);
+      try {
+        if (await AbsoluteFS.exists(location.absolutePath)) {
+          validLocations.push(location);
         }
-
-        const location = pathToLocation(path);
-
-        // Check if file exists (ignore errors)
-        try {
-          return (await AbsoluteFS.exists(location.absolutePath))
-            ? location
-            : null;
-        } catch {
-          return null;
-        }
-      }),
-    );
-
-    return results.filter((loc): loc is FileLocation => loc !== null);
+      } catch {
+        // Ignore files that can't be accessed
+      }
+    }
+    return validLocations;
   }
 
   /**

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -36,7 +36,11 @@ import { AgentLogger } from '@logger/AgentLogger';
 import { MESSAGE_TYPES } from '@logger/messageTypes';
 // Type imports
 import type { ToolDefinition } from '@model';
-import { DIAGNOSTIC_TYPE_VALIDATION_ERROR } from '@tools/result';
+import {
+  DIAGNOSTIC_TYPE_VALIDATION_ERROR,
+  formatZodIssuesForDiagnostics,
+  type ValidationErrorDiagnostics,
+} from '@tools/result';
 import { AbsoluteFS, pathToLocation, type FileLocation } from '@utils/files';
 import { isNonEmptyString } from '@utils/core';
 import { formatContent } from '@utils/text/xmlUtils';
@@ -55,18 +59,6 @@ import {
   RetryableInvocationNode,
   handleInvocationResult,
 } from './RetryState';
-
-interface ToolValidationDiagnostics {
-  type: typeof DIAGNOSTIC_TYPE_VALIDATION_ERROR;
-  issues: Array<Record<string, unknown>>;
-  formatted: Array<{
-    path: string;
-    message: string;
-    expected?: unknown;
-    received?: unknown;
-    code?: string;
-  }>;
-}
 
 /**
  * Parse tool input, handling various input formats from different model providers.
@@ -94,10 +86,13 @@ function parseToolInput(
   }
 }
 
-/** Check if an error is a Zod validation error (has issues array). */
-function isZodValidationError(
+/**
+ * Check if an error has Zod-like issues array (duck typing).
+ * Handles both real ZodError and error-like objects with issues.
+ */
+function hasZodIssues(
   error: unknown,
-): error is { issues: Array<Record<string, unknown>> } {
+): error is { issues: Array<{ path: (string | number)[]; message: string }> } {
   return (
     typeof error === 'object' &&
     error !== null &&
@@ -108,30 +103,34 @@ function isZodValidationError(
 
 /**
  * Normalize a tool call error into a user-friendly message with optional diagnostics.
+ * Uses shared formatting utilities from @tools/result for consistency.
  */
 function normalizeToolCallError(
   toolName: string,
   error: unknown,
-): { message: string; diagnostics?: ToolValidationDiagnostics } {
-  if (isZodValidationError(error)) {
+): { message: string; diagnostics?: ValidationErrorDiagnostics } {
+  if (hasZodIssues(error)) {
+    // Cast issues to ZodIssue-like for the shared formatter
+    const issues = error.issues as Array<{
+      path: (string | number)[];
+      message: string;
+      expected?: unknown;
+      received?: unknown;
+      code?: string;
+    }>;
     return {
       message: `${toolName}: Invalid parameters provided`,
       diagnostics: {
         type: DIAGNOSTIC_TYPE_VALIDATION_ERROR,
-        issues: error.issues,
-        formatted: error.issues.map((issue) => ({
-          path: Array.isArray(issue.path) ? issue.path.join('.') : '',
-          message: String(issue.message ?? ''),
-          expected: issue.expected,
-          received: issue.received,
-          code: typeof issue.code === 'string' ? issue.code : undefined,
-        })),
+        issues: issues as ValidationErrorDiagnostics['issues'],
+        formatted: formatZodIssuesForDiagnostics(
+          issues as ValidationErrorDiagnostics['issues'],
+        ),
       },
     };
   }
 
-  const errorMessage =
-    error instanceof Error ? error.message : String(error);
+  const errorMessage = error instanceof Error ? error.message : String(error);
   return { message: `${toolName}: ${errorMessage}` };
 }
 

--- a/src/agent/implementations/flows/reflection/runReflectionFlow.ts
+++ b/src/agent/implementations/flows/reflection/runReflectionFlow.ts
@@ -114,32 +114,33 @@ interface DerivedConfig {
   outputExt: string;
 }
 
+/** XML structure mode lookup - explicit setting takes precedence. */
+const XML_STRUCTURE_MODE_MAP: Record<
+  NonNullable<AgentWorkflowSetting['xmlStructureMode']>,
+  boolean | 'scratchpad'
+> = {
+  always: true,
+  scratchpadOnly: 'scratchpad',
+  never: false,
+};
+
+/** Agent type defaults when xmlStructureMode is not set. */
+const AGENT_TYPE_XML_DEFAULTS: Record<string, boolean | 'scratchpad'> = {
+  CoT: true,
+  direct: 'scratchpad',
+};
+
 /** Determine if XML structure enforcement is needed based on settings and scratchpad usage. */
 function shouldEnforceXmlStructure(
   setting: AgentWorkflowSetting,
   useScratchpad: boolean,
 ): boolean {
-  // Explicit mode takes precedence
-  if (setting.xmlStructureMode !== undefined) {
-    switch (setting.xmlStructureMode) {
-      case 'always':
-        return true;
-      case 'scratchpadOnly':
-        return useScratchpad;
-      case 'never':
-        return false;
-    }
-  }
+  const mode =
+    setting.xmlStructureMode !== undefined
+      ? XML_STRUCTURE_MODE_MAP[setting.xmlStructureMode]
+      : (AGENT_TYPE_XML_DEFAULTS[setting.agentType] ?? false);
 
-  // Fall back to agent type defaults
-  switch (setting.agentType) {
-    case 'CoT':
-      return true;
-    case 'direct':
-      return useScratchpad;
-    default:
-      return false;
-  }
+  return mode === 'scratchpad' ? useScratchpad : mode;
 }
 
 /** Compute the total number of rounds based on settings and prompt. */

--- a/src/agent/modelHandlers/utils/toolAttachmentUtils.ts
+++ b/src/agent/modelHandlers/utils/toolAttachmentUtils.ts
@@ -163,15 +163,11 @@ export function describeAttachments(
   attachments: ToolFileAttachment[],
 ): string[] {
   return attachments.map((file) => {
-    const path =
-      typeof file.path === 'string' && file.path.length > 0
-        ? file.path
-        : 'attachment';
-    const type =
-      typeof file.mimeType === 'string' && file.mimeType.length > 0
-        ? file.mimeType
-        : DEFAULT_ATTACHMENT_MIME_TYPE;
-    return `- ${path} (${type})`;
+    const filePath = isNonEmptyString(file.path) ? file.path : 'attachment';
+    const mimeType = isNonEmptyString(file.mimeType)
+      ? file.mimeType
+      : DEFAULT_ATTACHMENT_MIME_TYPE;
+    return `- ${filePath} (${mimeType})`;
   });
 }
 
@@ -202,6 +198,15 @@ export function formatAttachmentSummary(
   return formatAttachmentSummaryFromNotes(descriptions, variant);
 }
 
+const ATTACHMENT_SUMMARY_TEMPLATES: Record<AttachmentSummaryVariant, string> = {
+  'included-inline': 'Attachments included in this response:',
+  'metadata-fallback':
+    'Attachments available but returned as metadata only:',
+  'metadata-only': 'Attachments available:',
+};
+
+const READ_FILE_HINT = 'Use the read_file tool to read them.';
+
 /**
  * Format attachment summary from pre-built description notes.
  * Use this when descriptions come from multiple sources (e.g., Anthropic handler).
@@ -210,15 +215,11 @@ export function formatAttachmentSummaryFromNotes(
   notes: string,
   variant: AttachmentSummaryVariant = 'metadata-only',
 ): string {
-  switch (variant) {
-    case 'included-inline':
-      return `Attachments included in this response:\n${notes}`;
-    case 'metadata-fallback':
-      return `Attachments available but returned as metadata only:\n${notes}\nUse the read_file tool if you need the raw bytes.`;
-    case 'metadata-only':
-    default:
-      return `Attachments available:\n${notes}\nUse the read_file tool to read them.`;
-  }
+  const header = ATTACHMENT_SUMMARY_TEMPLATES[variant];
+  const needsReadHint = variant !== 'included-inline';
+  return needsReadHint
+    ? `${header}\n${notes}\n${READ_FILE_HINT}`
+    : `${header}\n${notes}`;
 }
 
 export async function loadAttachmentBuffer(

--- a/src/tools/core/base.ts
+++ b/src/tools/core/base.ts
@@ -1,11 +1,14 @@
 // Third-party imports
 import { ZodError, type ZodType } from 'zod';
 
-// Local imports - common
-
 // Local imports - core tool types (single source of truth)
 import type { ITool, ToolDefinition, ToolResult } from '@agent/core/ToolTypes';
 import { toErrorMessage } from '@common/errors';
+import {
+  DIAGNOSTIC_TYPE_VALIDATION_ERROR,
+  formatZodIssuesAsMessage,
+  formatZodIssuesForDiagnostics,
+} from '@tools/result';
 
 /**
  * Abstract base class for tool implementations.
@@ -51,13 +54,14 @@ export abstract class BaseTool<T> implements ITool {
       return await this.execute(input);
     } catch (err) {
       if (err instanceof ZodError) {
-        // Include validation details in error message so model can self-correct
-        const issues = err.issues
-          .map((i) => `- ${i.path.join('.')}: ${i.message}`)
-          .join('\n');
         return {
-          error: `Invalid input:\n${issues}`,
+          error: formatZodIssuesAsMessage(err.issues),
           isError: true,
+          diagnostics: {
+            type: DIAGNOSTIC_TYPE_VALIDATION_ERROR,
+            issues: err.issues,
+            formatted: formatZodIssuesForDiagnostics(err.issues),
+          },
         };
       }
       const message = toErrorMessage(err);

--- a/src/tools/result.ts
+++ b/src/tools/result.ts
@@ -78,6 +78,71 @@ export type FlattenedEditRecord = z.infer<typeof FlattenedEditRecordSchema>;
  */
 export const DIAGNOSTIC_TYPE_VALIDATION_ERROR = 'validation_error' as const;
 
+/**
+ * Formatted Zod issue for model consumption.
+ * Provides structured information that helps models self-correct.
+ */
+export interface FormattedZodIssue {
+  path: string;
+  message: string;
+  expected?: unknown;
+  received?: unknown;
+  code?: string;
+}
+
+/**
+ * Structured validation error diagnostics.
+ * Used to provide rich error information to models for self-correction.
+ */
+export interface ValidationErrorDiagnostics {
+  type: typeof DIAGNOSTIC_TYPE_VALIDATION_ERROR;
+  issues: ZodIssue[];
+  formatted: FormattedZodIssue[];
+}
+
+/**
+ * Format Zod issues into structured diagnostics for model consumption.
+ * Single source of truth for Zod validation error formatting.
+ *
+ * Note: `expected` and `received` are only present on certain ZodIssue subtypes
+ * (e.g., invalid_type, invalid_literal), so we access them via casting.
+ *
+ * @param issues - Raw Zod issues array
+ * @returns Formatted issues with path, message, expected, received, code
+ */
+export function formatZodIssuesForDiagnostics(
+  issues: ZodIssue[],
+): FormattedZodIssue[] {
+  return issues.map((issue) => {
+    // Cast to access subtype-specific fields (expected/received)
+    const extendedIssue = issue as ZodIssue & {
+      expected?: unknown;
+      received?: unknown;
+    };
+    return {
+      path: issue.path.join('.'),
+      message: issue.message,
+      expected: extendedIssue.expected,
+      received: extendedIssue.received,
+      code: issue.code,
+    };
+  });
+}
+
+/**
+ * Format Zod issues as a simple error message string.
+ * Used for the error field in ToolResult.
+ *
+ * @param issues - Raw Zod issues array
+ * @returns Human-readable error message
+ */
+export function formatZodIssuesAsMessage(issues: ZodIssue[]): string {
+  const lines = issues.map((i) =>
+    i.path.length ? `- ${i.path.join('.')}: ${i.message}` : `- ${i.message}`,
+  );
+  return `Invalid input:\n${lines.join('\n')}`;
+}
+
 export interface DiagnosticsPayload {
   path: string;
   command: 'list' | 'count';


### PR DESCRIPTION
- Inline trivial formatZodIssue factory into normalizeToolCallError
- Consolidate logRepetitionDetected from 4 log calls to 1
- Replace formatAttachmentSummaryFromNotes switch with lookup object
- Simplify collectValidMediaLocations with cleaner for loop
- Streamline parseToolInput conditional handling
- Use isNonEmptyString in describeAttachments for consistency
- Replace shouldEnforceXmlStructure nested switches with lookup objects
- Reorder isZodValidationError checks (typeof before null check)

Net reduction of ~35 lines while improving readability.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Unifies validation error handling and streamlines flow utilities for clarity and consistency.
> 
> - Adds shared Zod helpers in `@tools/result` (`formatZodIssuesForDiagnostics`, `formatZodIssuesAsMessage`, `ValidationErrorDiagnostics`) and updates `BaseTool` to return structured diagnostics
> - Updates `ToolUseCycleFlow` to use shared diagnostics, adds `hasZodIssues`, simplifies `parseToolInput`, and refactors media file collection into a clearer loop
> - Replaces verbose logging in `ResponseCycleFlow` with a single `logger.error` including preview and `messageToSkeleton`
> - Standardizes attachment summaries in `toolAttachmentUtils` via template lookups and uses `isNonEmptyString` in `describeAttachments`
> - Simplifies XML structure enforcement in `runReflectionFlow` using lookup maps (`XML_STRUCTURE_MODE_MAP`, `AGENT_TYPE_XML_DEFAULTS`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 196c67d15f765e69de41bf774ccd43a6d2932930. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->