### PR TITLE
Hide context panel by default in chat view

### DIFF
--- a/src/agent/modelHandlers/utils/toolAttachmentUtils.ts
+++ b/src/agent/modelHandlers/utils/toolAttachmentUtils.ts
@@ -200,8 +200,7 @@ export function formatAttachmentSummary(
 
 const ATTACHMENT_SUMMARY_TEMPLATES: Record<AttachmentSummaryVariant, string> = {
   'included-inline': 'Attachments included in this response:',
-  'metadata-fallback':
-    'Attachments available but returned as metadata only:',
+  'metadata-fallback': 'Attachments available but returned as metadata only:',
   'metadata-only': 'Attachments available:',
 };
 

--- a/src/common/modules/domUtils.js
+++ b/src/common/modules/domUtils.js
@@ -104,7 +104,11 @@ export function safeSetElementChecked(id, checked) {
  * @param {string} value - The value to select
  * @param {string} [selector='vscode-radio'] - Selector for radio elements
  */
-export function setRadioGroupValue(radioGroup, value, selector = 'vscode-radio') {
+export function setRadioGroupValue(
+  radioGroup,
+  value,
+  selector = 'vscode-radio',
+) {
   if (!radioGroup) return;
   if ('value' in radioGroup) {
     radioGroup.value = value;

--- a/src/memoryView/modules/messageHandlers.js
+++ b/src/memoryView/modules/messageHandlers.js
@@ -3,7 +3,10 @@ import { memoryViewDomHandler } from './domHandlers.js';
 import { ELEMENT_IDS } from './constants.js';
 import { MEMORY_VIEW_COMMANDS } from '@common/webview/commands.js';
 import { BaseWebviewMessageHandler } from '@common/BaseWebviewMessageHandler.js';
-import { safeSetElementChecked, setElementsDisabled } from '@common/domUtils.js';
+import {
+  safeSetElementChecked,
+  setElementsDisabled,
+} from '@common/domUtils.js';
 
 /**
  * Handles messages from the extension for the memory view.

--- a/src/progressView/modules/uiManagers/ApprovalRequests.js
+++ b/src/progressView/modules/uiManagers/ApprovalRequests.js
@@ -3,7 +3,10 @@ import { COMMANDS } from '../constants.js';
 import { BaseUIRequestManager } from './BaseUIRequestManager.js';
 
 // Local imports - common helpers
-import { addEventListenerSafely, setElementCheckedState } from '@common/domUtils.js';
+import {
+  addEventListenerSafely,
+  setElementCheckedState,
+} from '@common/domUtils.js';
 import { createFromTemplate } from '@common/templateUtils.js';
 import { vscode } from '@common/webviewContext.js';
 

--- a/src/webview/index.html
+++ b/src/webview/index.html
@@ -447,27 +447,27 @@
           <div class="instruction-header">
             <div class="instruction-header-leading">
               <div class="instruction-session-toggle">
-                <input type="hidden" id="sessionType" value="workflow" />
+                <input type="hidden" id="sessionType" value="toolUse" />
                 <vscode-radio-group
                   id="sessionTypeToggle"
                   aria-label="Choose the session type"
                   orientation="horizontal"
-                  value="workflow"
+                  value="toolUse"
                 >
-                  <vscode-radio
-                    value="workflow"
-                    data-session-type="workflow"
-                    checked
-                    title="Workflow agents automate document editing tasks"
-                  >
-                    Workflow
-                  </vscode-radio>
                   <vscode-radio
                     value="toolUse"
                     data-session-type="toolUse"
+                    checked
                     title="Chat agents execute commands and scripts"
                   >
                     Chat
+                  </vscode-radio>
+                  <vscode-radio
+                    value="workflow"
+                    data-session-type="workflow"
+                    title="Workflow agents automate document editing tasks"
+                  >
+                    Workflow
                   </vscode-radio>
                 </vscode-radio-group>
               </div>
@@ -529,19 +529,19 @@
                   <div class="agent-select-dropdowns">
                     <vscode-single-select
                       id="workflowAgent"
-                      class="agent-select agent-select--active"
+                      class="agent-select agent-select--hidden"
                       data-session-type="workflow"
                       aria-label="Workflow agent"
+                      tabindex="-1"
+                      aria-hidden="true"
                     >
                       ${workflowAgentOptions}
                     </vscode-single-select>
                     <vscode-single-select
                       id="toolUseAgent"
-                      class="agent-select agent-select--hidden"
+                      class="agent-select agent-select--active"
                       data-session-type="toolUse"
                       aria-label="Tool-use agent"
-                      tabindex="-1"
-                      aria-hidden="true"
                     >
                       ${toolUseAgentOptions}
                     </vscode-single-select>

--- a/src/webview/modules/mainViewState.js
+++ b/src/webview/modules/mainViewState.js
@@ -41,7 +41,7 @@ function getSessionDefaultAgent(sessionType) {
 
 function getDefaultState() {
   return {
-    sessionType: SESSION_TYPES.WORKFLOW,
+    sessionType: SESSION_TYPES.TOOL_USE,
     workflowAgent: getSelectDefaultValue(
       AGENT_SELECT_IDS[SESSION_TYPES.WORKFLOW],
       DEFAULT_WORKFLOW_AGENT,
@@ -167,7 +167,7 @@ export class MainViewState {
 
   /** Initialize UI with default state */
   setDefaults() {
-    this.applySessionType(SESSION_TYPES.WORKFLOW, { skipSave: true });
+    this.applySessionType(SESSION_TYPES.TOOL_USE, { skipSave: true });
 
     const workflowAgentDefault = getSelectDefaultValue(
       AGENT_SELECT_IDS[SESSION_TYPES.WORKFLOW],

--- a/src/webview/styles/containers.css
+++ b/src/webview/styles/containers.css
@@ -14,9 +14,7 @@
 }
 
 .file-selection-group--disabled {
-  opacity: 0.6;
-  filter: grayscale(0.3);
-  pointer-events: none;
+  display: none;
 }
 
 /* LaTeX diffs section */


### PR DESCRIPTION
- Change default session type from Workflow to Chat (toolUse)
- Move Chat radio button to the left position
- Hide context panel completely when Chat mode is selected
- Apply consistent formatting changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Sets Chat as the primary experience and streamlines the UI for it.
> 
> - Default session changed to `toolUse` in state and HTML; Chat radio moved first and checked; `workflow` moved after
> - Agent selects swapped: `toolUseAgent` is active; `workflowAgent` hidden with aria/tabindex updates
> - Context/file selection panel now fully hidden in Chat via `.file-selection-group--disabled { display: none }` and session-driven toggling
> - Keeps LaTeX diffs and other UI intact; minor formatting tidy-ups in `domUtils`, `index.html`, and attachment summary templates
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8f582238b4fe6b238c6b4e7babc98798ec926ce3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->