### PR TITLE
fix: always include function_call in messages for OpenAI Response API

### DIFF
--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -1659,16 +1659,16 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       workspaceState.resetServerToolContent();
     }
 
-    // function_call is part of the previous response output when chaining,
-    // so only include it when NOT using previous_response_id
-    const callMsg: ResponseFunctionToolCall | undefined = isResponseChaining
-      ? undefined
-      : {
-          type: 'function_call',
-          call_id: call.callId,
-          name: call.name,
-          arguments: call.raw.arguments,
-        };
+    // Always include function_call in messages for persistence and resume.
+    // When response chaining is active, the model already has this via previous_response_id,
+    // but we still need it in our local array so resumed sessions have complete history.
+    // The slicing logic (sentMessages) handles avoiding re-sends during chaining.
+    const callMsg: ResponseFunctionToolCall = {
+      type: 'function_call',
+      call_id: call.callId,
+      name: call.name,
+      arguments: call.raw.arguments,
+    };
 
     // Create mutable copy for adding attachmentSummary/files
     const finalResult: ToolResultPayload = { ...result };
@@ -1736,13 +1736,9 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       output: outputPayload,
     };
 
-    // When response chaining, only push function_call_output (callMsg is undefined)
-    // When not chaining, push both function_call and function_call_output
-    if (callMsg) {
-      messages.push(callMsg, resultMsg);
-    } else {
-      messages.push(resultMsg);
-    }
+    // Always push both function_call and function_call_output for complete history.
+    // The slicing logic (sentMessages) handles avoiding re-sends during response chaining.
+    messages.push(callMsg, resultMsg);
     return messages;
   }
 

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -719,6 +719,13 @@ export class ProgressEventHandler {
           ));
 
       if (needsFullRefresh) {
+        // Ensure filter matches the stream's category to prevent it from being filtered out.
+        // This is important when resuming from WAITING state - the stream must remain visible.
+        const streamCategory = this.getStreamCategory(stream);
+        if (streamCategory) {
+          this.maybeUpdateFilterForCategory(streamCategory);
+        }
+
         // Include current status in refresh map so frontend displays it correctly.
         const statusesForRefresh = StreamStatusService.getAll();
         statusesForRefresh.set(stream, status);
@@ -733,6 +740,19 @@ export class ProgressEventHandler {
         this.webviewUpdater.updateStreamStatus(stream, status, lastTimestamp);
       }
     }
+  }
+
+  /**
+   * Get the session category for a stream from taskState or hints.
+   * Returns undefined if category cannot be determined.
+   */
+  private getStreamCategory(stream: string): AgentCategory | undefined {
+    const taskState = this.state.getTaskState(stream);
+    if (taskState?.agentConfig?.session?.agentCategory) {
+      return taskState.agentConfig.session.agentCategory;
+    }
+    const hints = this.state.getStreamHints(stream);
+    return hints.sessionCategory;
   }
 
   /**


### PR DESCRIPTION
When using response chaining (previous_response_id), the function_call
was being omitted from local messages since it existed in server-side
history. However, when sessions were resumed without previousResponseId
(e.g., after VS Code reload), this caused orphaned function_call_output
errors:

"No tool call found for function call output with call_id ..."

Now function_call is always included in the local messages array for
persistence. The sentMessages slicing logic already handles avoiding
re-sends during response chaining.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures conversation continuity and UI visibility.
> 
> - Always push `function_call` and `function_call_output` into local `messages` in `modelHandlerOpenAIResponse` for persistence/resume; relies on sent message slicing to avoid re-sends during chaining
> - Progress view: on status updates that trigger a full refresh, sync agent-type filter with the stream’s category (via `getStreamCategory` + `maybeUpdateFilterForCategory`) to prevent streams from being filtered out, especially when resuming from `WAITING`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fbd40d94f380d188146d9e05420e14654a73aa51. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->