### PR TITLE
feat: add diff syntax highlighting to tool output

### DIFF
--- a/src/progressView/modules/formatters/htmlBuilders.js
+++ b/src/progressView/modules/formatters/htmlBuilders.js
@@ -28,13 +28,56 @@ export function buildToolUseSection(label, content) {
 }
 
 /**
- * Wrap text in a pre element with optional class
+ * Get diff line class based on line content
+ * @param {string} line - Line to check
+ * @returns {string|null} CSS class or null if not a diff line
+ */
+function getDiffLineClass(line) {
+  if (line.startsWith('@@')) return 'diff-hunk';
+  if (line.startsWith('+') && !line.startsWith('+++')) return 'diff-add';
+  if (line.startsWith('-') && !line.startsWith('---')) return 'diff-remove';
+  return null;
+}
+
+/**
+ * Check if text appears to be diff output
+ * @param {string} text - Text to check
+ * @returns {boolean} True if text looks like diff output
+ */
+function isDiffContent(text) {
+  const lines = text.split('\n').slice(0, 20); // Check first 20 lines
+  let diffMarkers = 0;
+  for (const line of lines) {
+    if (
+      line.startsWith('@@') ||
+      line.startsWith('+++') ||
+      line.startsWith('---')
+    ) {
+      diffMarkers++;
+    }
+  }
+  return diffMarkers >= 2;
+}
+
+/**
+ * Wrap text in a pre element with optional class and diff highlighting
  * @param {string} text - Text to wrap (will be HTML encoded)
  * @param {string} [className] - Optional CSS class
  * @returns {string} HTML string
  */
 export function wrapInPre(text, className = '') {
   const classAttr = className ? ` class="${className}"` : '';
+
+  // Apply diff highlighting if content looks like a diff
+  if (isDiffContent(text)) {
+    const highlightedLines = text.split('\n').map((line) => {
+      const diffClass = getDiffLineClass(line);
+      const encoded = encodeHtml(line);
+      return diffClass ? `<span class="${diffClass}">${encoded}</span>` : encoded;
+    });
+    return `<pre${classAttr}>${highlightedLines.join('\n')}</pre>`;
+  }
+
   return `<pre${classAttr}>${encodeHtml(text)}</pre>`;
 }
 

--- a/src/progressView/styles/scratchpad.css
+++ b/src/progressView/styles/scratchpad.css
@@ -86,3 +86,16 @@
   max-height: var(--height-large);
   overflow: auto;
 }
+
+/* Diff line highlighting */
+.diff-add {
+  color: var(--vscode-gitDecoration-addedResourceForeground, #3fb950);
+}
+
+.diff-remove {
+  color: var(--vscode-gitDecoration-deletedResourceForeground, #f85149);
+}
+
+.diff-hunk {
+  color: var(--vscode-gitDecoration-modifiedResourceForeground, #d29922);
+}


### PR DESCRIPTION
Color-code +/- lines in tool output when diff content is detected:
- Green for added lines (+)
- Red for removed lines (-)
- Yellow/orange for hunk markers (@@)

Uses VS Code's git decoration colors for theme consistency.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds diff-aware rendering for tool output to improve readability.
> 
> - `wrapInPre` now detects diff content and wraps lines with `diff-add`, `diff-remove`, or `diff-hunk`
> - New helpers `getDiffLineClass` and `isDiffContent` to determine diff styling
> - Adds CSS styles for `.diff-add`, `.diff-remove`, `.diff-hunk` using VS Code git decoration colors
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7fdb05c021659f2ca538a43cdcb37785ef19c889. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->