### PR TITLE
fix: add warning to bash tool about sed escaping issues

### DIFF
--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -17,7 +17,9 @@ export type BashInput = z.infer<typeof BashInputSchema>;
 export class BashTool extends defineTool({
   name: 'bash',
   description:
-    'Execute shell commands. Returns stdout on success, throws error with stderr on failure.',
+    'Execute shell commands. Returns stdout on success, throws error with stderr on failure. ' +
+    'WARNING: For text replacement in files, use edit_file instead of bash+sed - ' +
+    'sed has escaping issues with special characters, file paths with spaces, and LaTeX patterns.',
   schema: BashInputSchema,
 }) {
   protected async execute(input: BashInput): Promise<ToolResult> {


### PR DESCRIPTION
Added a warning in the bash tool description advising users to use
edit_file instead of bash+sed for text replacement. This helps prevent
escaping issues with special characters, file paths containing spaces,
and complex LaTeX patterns.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Update `bash` tool description**
> 
> - Expands `description` to warn against `sed` for text replacement and recommend `edit_file` (avoids escaping issues with special characters, spaces, LaTeX patterns)
> - No changes to execution logic or APIs
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a92d45a08b509b29043c10874de15bb2f34e0922. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->