### PR TITLE
refactor(logger): remove redundant caching layer in logUtils

### DIFF
--- a/src/eventBus/ProgressEventBus.ts
+++ b/src/eventBus/ProgressEventBus.ts
@@ -18,10 +18,6 @@ import type {
 } from './schemas';
 import type { RetryRequestPrompt, ToolEditApprovalPrompt } from './types';
 
-// Re-exports for consumers
-export type { StreamStatus };
-export type { TaskGroupStatus } from './schemas';
-
 // Maximum number of events to buffer when no listeners are registered
 const MAX_BUFFER_SIZE = 1000;
 

--- a/src/logger/AgentLogger.ts
+++ b/src/logger/AgentLogger.ts
@@ -234,56 +234,38 @@ export class AgentLogger {
     logger.initialize(this.channelId, this.isAgentLogger);
   }
 
-  /**
-   * Log a debug message with options object.
-   * Falls back to current group ID from AsyncLocalStorage if not specified.
-   */
+  /** Internal helper to log at any level with consistent options handling. */
+  private log(
+    level: 'debug' | 'info' | 'warn' | 'error',
+    message: string,
+    options: LogOptions = {},
+  ): void {
+    logger[level](this.channelId, message, {
+      groupId: options.groupId ?? this.resolveActiveGroupId(),
+      messageType: options.messageType,
+      isAgent: this.isAgentLogger,
+      data: options.data,
+    });
+  }
+
+  /** Log a debug message. Falls back to current group ID if not specified. */
   debug(message: string, options: LogOptions = {}): void {
-    logger.debug(this.channelId, message, {
-      groupId: options.groupId ?? this.resolveActiveGroupId(),
-      messageType: options.messageType,
-      isAgent: this.isAgentLogger,
-      data: options.data,
-    });
+    this.log('debug', message, options);
   }
 
-  /**
-   * Log an info message with options object.
-   * Falls back to current group ID from AsyncLocalStorage if not specified.
-   */
+  /** Log an info message. Falls back to current group ID if not specified. */
   info(message: string, options: LogOptions = {}): void {
-    logger.info(this.channelId, message, {
-      groupId: options.groupId ?? this.resolveActiveGroupId(),
-      messageType: options.messageType,
-      isAgent: this.isAgentLogger,
-      data: options.data,
-    });
+    this.log('info', message, options);
   }
 
-  /**
-   * Log a warning message with options object.
-   * Falls back to current group ID from AsyncLocalStorage if not specified.
-   */
+  /** Log a warning message. Falls back to current group ID if not specified. */
   warn(message: string, options: LogOptions = {}): void {
-    logger.warn(this.channelId, message, {
-      groupId: options.groupId ?? this.resolveActiveGroupId(),
-      messageType: options.messageType,
-      isAgent: this.isAgentLogger,
-      data: options.data,
-    });
+    this.log('warn', message, options);
   }
 
-  /**
-   * Log an error message with options object.
-   * Falls back to current group ID from AsyncLocalStorage if not specified.
-   */
+  /** Log an error message. Falls back to current group ID if not specified. */
   error(message: string, options: LogOptions = {}): void {
-    logger.error(this.channelId, message, {
-      groupId: options.groupId ?? this.resolveActiveGroupId(),
-      messageType: options.messageType,
-      isAgent: this.isAgentLogger,
-      data: options.data,
-    });
+    this.log('error', message, options);
   }
 
   /**

--- a/src/logger/filterUtils.ts
+++ b/src/logger/filterUtils.ts
@@ -14,11 +14,8 @@ export interface FilterResult {
   debugMode: boolean;
 }
 
-/**
- * Get the current debug mode setting.
- * Single source of truth for debug mode configuration.
- */
-export function getDebugMode(): boolean {
+/** Get the current debug mode setting. */
+function getDebugMode(): boolean {
   return getConfig<boolean>('texra.logger.debugMode', false);
 }
 

--- a/src/logger/logUtils.ts
+++ b/src/logger/logUtils.ts
@@ -21,8 +21,9 @@ interface ChannelContext {
 
 const contextStorage = new AsyncLocalStorage<Map<ChannelKey, ChannelContext>>();
 
+/** Key format matches LogChannelRegistry.getKey() for consistency. */
 function getChannelKey(channel: string, isAgent: boolean): ChannelKey {
-  return `${isAgent ? 'agent' : 'default'}::${channel}`;
+  return `${channel}::${isAgent ? 'agent' : 'shared'}`;
 }
 
 function getStore(): Map<ChannelKey, ChannelContext> {

--- a/src/logger/logUtils.ts
+++ b/src/logger/logUtils.ts
@@ -13,9 +13,6 @@ import type { EndGroupStatus } from './messageTypes';
 import type { VSCodeTransport } from './transports/VSCodeTransport';
 import type { LogUtilsOptions } from './logOptions';
 
-// Re-export for convenience
-export type { LogOptions } from './logOptions';
-
 type ChannelKey = string;
 
 interface ChannelContext {
@@ -23,13 +20,6 @@ interface ChannelContext {
 }
 
 const contextStorage = new AsyncLocalStorage<Map<ChannelKey, ChannelContext>>();
-
-// Cache for initialized channels to avoid repeated registry.ensure() calls
-// This eliminates the overhead of Map lookup + string interpolation on every log
-const initializedChannels = new Map<
-  ChannelKey,
-  ReturnType<typeof registry.ensure>
->();
 
 function getChannelKey(channel: string, isAgent: boolean): ChannelKey {
   return `${isAgent ? 'agent' : 'default'}::${channel}`;
@@ -106,20 +96,14 @@ function resolveActiveGroupByKey(
 }
 
 /**
- * Get or create a cached channel entry.
- * Single source of truth for channel initialization.
+ * Get or create a channel entry.
+ * Delegates to registry which handles its own caching.
  */
 function getOrCreateEntry(
   channel: string,
   isAgent: boolean,
 ): ReturnType<typeof registry.ensure> {
-  const key = getChannelKey(channel, isAgent);
-  let entry = initializedChannels.get(key);
-  if (!entry) {
-    entry = registry.ensure(channel, { isAgent });
-    initializedChannels.set(key, entry);
-  }
-  return entry;
+  return registry.ensure(channel, { isAgent });
 }
 
 /**
@@ -131,11 +115,10 @@ function getTransport(
   isAgent: boolean,
   createIfMissing: boolean,
 ): VSCodeTransport | undefined {
-  const key = getChannelKey(channel, isAgent);
-  const cached = initializedChannels.get(key);
-  if (cached) return cached.transport;
-  if (createIfMissing) return getOrCreateEntry(channel, isAgent).transport;
-  return undefined;
+  if (createIfMissing) {
+    return getOrCreateEntry(channel, isAgent).transport;
+  }
+  return registry.getTransport(channel, { isAgent });
 }
 
 function logWithGroup(

--- a/src/logger/messageTypes.ts
+++ b/src/logger/messageTypes.ts
@@ -50,7 +50,6 @@ export type EndGroupStatus = z.infer<typeof EndGroupStatusSchema>;
 
 // Compile-time assertion: EndGroupStatus must be a subset of TaskGroupStatus.
 // This ensures type compatibility when assigning EndGroupStatus to TaskGroupStatus fields.
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 type _AssertEndGroupStatusSubset = EndGroupStatus extends TaskGroupStatus
   ? true
   : never;

--- a/src/logger/transports/VSCodeTransport.ts
+++ b/src/logger/transports/VSCodeTransport.ts
@@ -17,7 +17,8 @@ import {
   type MessageType,
 } from '@logger/messageTypes';
 import type { EndGroupStatus } from '@logger/messageTypes';
-import { getColorForLevel, serializeLogData } from '@logger/utils';
+import { getColorForLevel } from '@logger/utils';
+import { serializeError } from '@utils/core';
 import { bus } from '@eventBus/ProgressEventBus';
 
 interface VSCodeTransportOptions extends Transport.TransportStreamOptions {
@@ -43,7 +44,8 @@ export class VSCodeTransport extends Transport {
 
   log(info: any, callback: () => void): void {
     const { level, message, timestamp, messageType, groupId } = info;
-    const data = serializeLogData(info.data);
+    // Serialize errors for logging (inline from serializeLogData)
+    const data = info.data instanceof Error ? serializeError(info.data) : info.data;
 
     this.writeToChannel(level, message, timestamp, data);
     this.emitLogEvent({

--- a/src/logger/utils/index.ts
+++ b/src/logger/utils/index.ts
@@ -1,3 +1,2 @@
 // Barrel export for logger utilities
 export { getColorForLevel } from './levelColors';
-export { serializeLogData } from './serializeLogData';

--- a/src/logger/utils/serializeLogData.ts
+++ b/src/logger/utils/serializeLogData.ts
@@ -1,5 +1,0 @@
-import { serializeError } from '@utils/core';
-
-export function serializeLogData(data: unknown): unknown {
-  return data instanceof Error ? serializeError(data) : data;
-}

--- a/src/progressView/events/index.ts
+++ b/src/progressView/events/index.ts
@@ -7,4 +7,3 @@ export {
   type ApprovalCallbacks,
 } from './UIEvents';
 export { type ProgressEventBusLike } from './types';
-export type { StreamStatus } from '@eventBus/ProgressEventBus';


### PR DESCRIPTION
- Remove initializedChannels Map that duplicated LogChannelRegistry cache
- Remove unused LogOptions re-export from logUtils
- Simplify getOrCreateEntry to directly delegate to registry.ensure()
- Simplify getTransport to use registry.getTransport() for non-creating lookups

The double caching was unnecessary overhead since LogChannelRegistry
already maintains its own channel cache with O(1) Map lookups.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Refactor logging backend to rely on registry caching and reduce duplication.**
> 
> - Remove `initializedChannels` cache in `logUtils`; delegate to `registry.ensure()`/`registry.getTransport()` and update channel key format for consistency
> - Simplify `AgentLogger` via a shared private `log()` helper used by `debug`/`info`/`warn`/`error`
> - Make `getDebugMode` internal in `filterUtils`; keep shared emit filtering unchanged
> - `VSCodeTransport`: inline error serialization; remove `serializeLogData` and its barrel export
> - Remove unused type re-exports from `ProgressEventBus` and `progressView/events`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9fae1664b0ef19271632504c1d38d37a8099ff16. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->