### PR TITLE
fix: extract session type from event target for reliable dropdown sync

### DIFF
--- a/src/webview/modules/uiManagers/SettingsButtonManager.js
+++ b/src/webview/modules/uiManagers/SettingsButtonManager.js
@@ -272,15 +272,46 @@ export class SettingsButtonManager extends BaseDomHandler {
 
       const radioGroup = resolveRadioGroup(toggleContainer);
       if (radioGroup) {
-        // Initialize last session type from radio group
-        // Only set if we can determine a valid initial value to avoid masking the first user interaction
-        const initialSessionType = parseSessionType(radioGroup.value);
+        // Helper to extract session type from a radio element
+        const getRadioSessionType = (radio) => {
+          if (!(radio instanceof HTMLElement)) {
+            return undefined;
+          }
+          return parseSessionType(
+            radio.dataset.sessionType || radio.getAttribute('value'),
+          );
+        };
+
+        // Helper to find the checked radio's session type in the group
+        // Note: vscode-radio-group has no .value property, must scan radios
+        const getCheckedSessionType = () => {
+          const radios = radioGroup.querySelectorAll('vscode-radio');
+          for (const radio of radios) {
+            if (radio.checked || radio.hasAttribute('checked')) {
+              return getRadioSessionType(radio);
+            }
+          }
+          return undefined;
+        };
+
+        // Initialize last session type from the currently checked radio
+        const initialSessionType = getCheckedSessionType();
         if (initialSessionType) {
           this._setLastRadioSessionType(initialSessionType);
         }
 
-        this.addListener(radioGroup, 'change', () => {
-          const sessionType = parseSessionType(radioGroup.value);
+        this.addListener(radioGroup, 'change', (event) => {
+          // The change event bubbles from the clicked vscode-radio element
+          // event.target is the radio, not the group (group has no .value)
+          const target = event?.target;
+          let sessionType;
+          if (isTagName(target, 'vscode-radio')) {
+            sessionType = getRadioSessionType(target);
+          }
+          // Fallback: scan for checked radio (e.g., keyboard navigation)
+          if (!sessionType) {
+            sessionType = getCheckedSessionType();
+          }
           if (!sessionType) {
             return;
           }


### PR DESCRIPTION
The vscode-radio-group component has no .value property - the change
event bubbles from individual vscode-radio elements. The simplified
handler was reading radioGroup.value (always undefined), breaking the
dropdown sync when switching between Workflow/Chat modes.

Fix by:
1. Reading session type from event.target (the clicked radio)
2. Falling back to scanning for the checked radio in the group
3. Fixing initialization to also scan for the checked radio

This restores behavior that was inadvertently lost in afc87ae when the
handler was over-simplified.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Restores reliable session type sync between radio toggle and agent dropdown.
> 
> - In `SettingsButtonManager.js`, stop reading `radioGroup.value`; extract session type from `event.target` (`vscode-radio`) with fallback to scanning for the checked radio
> - Add helpers `getRadioSessionType` and `getCheckedSessionType`; use them for change handling and for initialization of the last session type
> - Keeps dropdown focus/save behavior, only adjusting how session type is derived
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a4f2e4f8cd83e71b08627e3188cdcda9d41ac5b5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->