### PR TITLE
refactor(logger, eventBus): simplify code and enhance type safety

### DIFF
--- a/src/agent/core/index.ts
+++ b/src/agent/core/index.ts
@@ -1,126 +1,23 @@
 /**
  * Agent core barrel export.
  *
- * Consolidates core agent types, schemas, and utilities.
+ * Exports commonly used types, enums, and classes.
+ * For less common exports, import directly from the specific file.
  */
 
-// Agent dataclass - types, enums, and settings
-export {
-  // Constants
-  MIN_TEMPERATURE,
-  MAX_TEMPERATURE,
-  WORKFLOW_TYPES,
-  TOOL_USE_TYPES,
-  // Enums and types
-  AgentSource,
-  AgentCategory,
-  AgentType,
-  type WorkflowAgentType,
-  type ToolUseAgentType,
-  // Schemas
-  AgentSettingBaseSchema,
-  AgentWorkflowSettingSchema,
-  AgentToolUseSettingSchema,
-  AgentSettingSchema,
-  AgentPromptSchema,
-  AgentDefinitionSchema,
-  XmlStructureMode,
-  // Types
-  type AgentSetting,
-  type AgentWorkflowSetting,
-  type AgentToolUseSetting,
-  type AgentPrompt,
-  type AgentDefinition,
-  type AgentSessionDescriptor,
-  // Functions
-  deriveAgentCategory,
-  resolveAgentSessionDescriptor,
-  getAgentSessionDescriptor,
-  isWorkflowSetting,
-  requireWorkflowSetting,
-  hasEndTag,
-  parseAgentSetting,
+// Most commonly used - enums and category types
+export { AgentCategory, AgentType, hasEndTag } from './AgentDataclass';
+export type {
+  AgentSetting,
+  AgentPrompt,
+  AgentWorkflowSetting,
+  AgentSessionDescriptor,
 } from './AgentDataclass';
 
-// Session schema
-export { AgentSessionDescriptorSchema } from './AgentSessionSchema';
+// Config types
+export type { AgentConfig } from './AgentConfig';
+export type { ToolConfig } from './ToolConfig';
 
-// Agent config
-export {
-  AgentConfigSchema,
-  type AgentConfig,
-  type AgentConfigInput,
-} from './AgentConfig';
-
-// Cycle options
-export {
-  UserVariableChannelsSchema,
-  type UserVariableChannels,
-  type AgentCycleBaseOptions,
-} from './AgentCycleOptions';
-
-// Tool config
-export {
-  DEFAULT_TOOL_CONFIG,
-  ToolConfigSchema,
-  type ToolConfig,
-} from './ToolConfig';
-
-// Tool types
-export { type ITool, type ToolResult } from './ToolTypes';
-
-// Response usage types
-export {
-  type ExtendedCompletionUsage,
-  type NativeUsagePayload,
-  type ProviderUsage,
-  type ResponseUsageBase,
-  type OpenAIAPIResponseUsage,
-  type AnthropicAPIResponseUsage,
-} from './ResponseUsage';
-
-// Run usage accumulator
-export {
-  RunUsageAccumulatorJSONSchema,
-  RunUsageAccumulator,
-  type RunUsageAccumulatorJSON,
-} from './RunUsageAccumulator';
-
-// Agent state
-export {
-  ConversationRoundStateSnapshotSchema,
-  AgentRunStateSnapshotSchema,
-  ConversationRoundState,
-  AgentRunState,
-  type ConversationRoundStateSnapshot,
-  type AgentRunStateSnapshot,
-} from './AgentState';
-
-// Agent workspace state
-export {
-  ThinkingBlockSchema,
-  ResponseAssemblyStateSchema,
-  FileInteractionStateSnapshotSchema,
-  MediaAttachmentStateSnapshotSchema,
-  ReasoningCacheStateSchema,
-  TodoStateSnapshotSchema,
-  AgentWorkspaceStateSnapshotSchema,
-  FileInteractionState,
-  MediaAttachmentState,
-  TodoState,
-  AgentWorkspaceState,
-  type ThinkingBlock,
-  type ResponseAssemblyState,
-  type FileInteractionStateSnapshot,
-  type MediaAttachmentStateSnapshot,
-  type ReasoningCacheState,
-  type TodoStateSnapshot,
-  type AgentWorkspaceSnapshot,
-  type ServerToolContentState,
-  getReasoningPrimaryBlock,
-  resetReasoningCacheState,
-  resetServerToolContentState,
-} from './AgentWorkspaceState';
-
-// Stream execution index
-export { StreamExecutionIndex } from './StreamExecutionIndex';
+// State classes - commonly instantiated
+export { AgentWorkspaceState } from './AgentWorkspaceState';
+export { ConversationRoundState } from './AgentState';

--- a/src/agent/core/index.ts
+++ b/src/agent/core/index.ts
@@ -1,0 +1,126 @@
+/**
+ * Agent core barrel export.
+ *
+ * Consolidates core agent types, schemas, and utilities.
+ */
+
+// Agent dataclass - types, enums, and settings
+export {
+  // Constants
+  MIN_TEMPERATURE,
+  MAX_TEMPERATURE,
+  WORKFLOW_TYPES,
+  TOOL_USE_TYPES,
+  // Enums and types
+  AgentSource,
+  AgentCategory,
+  AgentType,
+  type WorkflowAgentType,
+  type ToolUseAgentType,
+  // Schemas
+  AgentSettingBaseSchema,
+  AgentWorkflowSettingSchema,
+  AgentToolUseSettingSchema,
+  AgentSettingSchema,
+  AgentPromptSchema,
+  AgentDefinitionSchema,
+  XmlStructureMode,
+  // Types
+  type AgentSetting,
+  type AgentWorkflowSetting,
+  type AgentToolUseSetting,
+  type AgentPrompt,
+  type AgentDefinition,
+  type AgentSessionDescriptor,
+  // Functions
+  deriveAgentCategory,
+  resolveAgentSessionDescriptor,
+  getAgentSessionDescriptor,
+  isWorkflowSetting,
+  requireWorkflowSetting,
+  hasEndTag,
+  parseAgentSetting,
+} from './AgentDataclass';
+
+// Session schema
+export { AgentSessionDescriptorSchema } from './AgentSessionSchema';
+
+// Agent config
+export {
+  AgentConfigSchema,
+  type AgentConfig,
+  type AgentConfigInput,
+} from './AgentConfig';
+
+// Cycle options
+export {
+  UserVariableChannelsSchema,
+  type UserVariableChannels,
+  type AgentCycleBaseOptions,
+} from './AgentCycleOptions';
+
+// Tool config
+export {
+  DEFAULT_TOOL_CONFIG,
+  ToolConfigSchema,
+  type ToolConfig,
+} from './ToolConfig';
+
+// Tool types
+export { type ITool, type ToolResult } from './ToolTypes';
+
+// Response usage types
+export {
+  type ExtendedCompletionUsage,
+  type NativeUsagePayload,
+  type ProviderUsage,
+  type ResponseUsageBase,
+  type OpenAIAPIResponseUsage,
+  type AnthropicAPIResponseUsage,
+} from './ResponseUsage';
+
+// Run usage accumulator
+export {
+  RunUsageAccumulatorJSONSchema,
+  RunUsageAccumulator,
+  type RunUsageAccumulatorJSON,
+} from './RunUsageAccumulator';
+
+// Agent state
+export {
+  ConversationRoundStateSnapshotSchema,
+  AgentRunStateSnapshotSchema,
+  ConversationRoundState,
+  AgentRunState,
+  type ConversationRoundStateSnapshot,
+  type AgentRunStateSnapshot,
+} from './AgentState';
+
+// Agent workspace state
+export {
+  ThinkingBlockSchema,
+  ResponseAssemblyStateSchema,
+  FileInteractionStateSnapshotSchema,
+  MediaAttachmentStateSnapshotSchema,
+  ReasoningCacheStateSchema,
+  TodoStateSnapshotSchema,
+  AgentWorkspaceStateSnapshotSchema,
+  FileInteractionState,
+  MediaAttachmentState,
+  TodoState,
+  AgentWorkspaceState,
+  type ThinkingBlock,
+  type ResponseAssemblyState,
+  type FileInteractionStateSnapshot,
+  type MediaAttachmentStateSnapshot,
+  type ReasoningCacheState,
+  type TodoStateSnapshot,
+  type AgentWorkspaceSnapshot,
+  type ServerToolContentState,
+  getReasoningPrimaryBlock,
+  resetReasoningCacheState,
+  resetServerToolContentState,
+} from './AgentWorkspaceState';
+
+// Stream execution index
+export { StreamExecutionIndex } from './StreamExecutionIndex';

--- a/src/agent/toolUse/index.ts
+++ b/src/agent/toolUse/index.ts
@@ -1,0 +1,30 @@
+/**
+ * Tool-use agent utilities barrel export.
+ *
+ * Consolidates exports for tool-use session management, follow-up handling,
+ * and agent registry functions.
+ */
+
+// Follow-up queue management
+export { FollowUpQueue } from './FollowUpQueue';
+export { ToolUseFollowUpQueue } from './ToolUseFollowUpQueueManager';
+
+// Follow-up execution
+export { sendFollowUp, type SendFollowUpResult } from './ToolUseFollowUp';
+
+// Agent registry for interrupt handling
+export {
+  type IInterruptible,
+  registerInterruptible,
+  unregisterInterruptible,
+  getInterruptible,
+  getToolUseFlowContext,
+  cleanupInactiveAgents,
+} from './ToolUseAgentRegistry';
+
+// File interaction context (AsyncLocalStorage)
+export {
+  type ToolFileInteractionContext,
+  withToolFileInteractionContext,
+  getCurrentToolFileInteractionContext,
+} from './ToolFileInteractionContext';

--- a/src/agent/types/index.ts
+++ b/src/agent/types/index.ts
@@ -1,52 +1,16 @@
 /**
  * Agent types barrel export.
  *
- * Consolidates shared type definitions and schemas for agent system.
+ * Exports commonly used type definitions.
+ * For schemas and less common types, import directly from the specific file.
  */
 
-// Identifier types
-export {
-  StreamTabIdSchema,
-  ExecutionIdSchema,
-  StorageKeySchema,
-  ExecutionIdentitySchema,
-  type StreamTabId,
-  type ExecutionId,
-  type StorageKey,
-  type ExecutionIdentity,
-  type StorageKeyManager,
-} from './IdentifierTypes';
+// Identifier types - most commonly used
+export type { StreamTabId, ExecutionId, StorageKey } from './IdentifierTypes';
 
 // Usage types
-export {
-  TokenUsageStatsSchema,
-  ExtendedTokenUsageStatsSchema,
-  StreamUsageMessageSchema,
-  type TokenUsageStats,
-  type ExtendedTokenUsageStats,
-  type StreamUsageMessage,
-} from './UsageTypes';
-
-// Normalized usage
-export {
-  UsageProviderSchema,
-  NormalizedUsageSchema,
-  type UsageProvider,
-  type NormalizedUsage,
-} from './NormalizedUsage';
+export type { TokenUsageStats, ExtendedTokenUsageStats } from './UsageTypes';
+export type { NormalizedUsage } from './NormalizedUsage';
 
 // Result types
-export {
-  ExecResultSchema,
-  FileOpStatusSchema,
-  FileOpResultSchema,
-  type ExecResult,
-  type FileOpStatus,
-  type FileOpResult,
-} from './ResultTypes';
-
-// Diff types
-export { DiffStatsSchema, type DiffStats } from './DiffTypes';
-
-// Agent stream types
-export { type AgentTypeFilter, isAgentTypeFilter } from './AgentStreamTypes';
+export type { ExecResult, FileOpResult } from './ResultTypes';

--- a/src/agent/types/index.ts
+++ b/src/agent/types/index.ts
@@ -1,0 +1,52 @@
+/**
+ * Agent types barrel export.
+ *
+ * Consolidates shared type definitions and schemas for agent system.
+ */
+
+// Identifier types
+export {
+  StreamTabIdSchema,
+  ExecutionIdSchema,
+  StorageKeySchema,
+  ExecutionIdentitySchema,
+  type StreamTabId,
+  type ExecutionId,
+  type StorageKey,
+  type ExecutionIdentity,
+  type StorageKeyManager,
+} from './IdentifierTypes';
+
+// Usage types
+export {
+  TokenUsageStatsSchema,
+  ExtendedTokenUsageStatsSchema,
+  StreamUsageMessageSchema,
+  type TokenUsageStats,
+  type ExtendedTokenUsageStats,
+  type StreamUsageMessage,
+} from './UsageTypes';
+
+// Normalized usage
+export {
+  UsageProviderSchema,
+  NormalizedUsageSchema,
+  type UsageProvider,
+  type NormalizedUsage,
+} from './NormalizedUsage';
+
+// Result types
+export {
+  ExecResultSchema,
+  FileOpStatusSchema,
+  FileOpResultSchema,
+  type ExecResult,
+  type FileOpStatus,
+  type FileOpResult,
+} from './ResultTypes';
+
+// Diff types
+export { DiffStatsSchema, type DiffStats } from './DiffTypes';
+
+// Agent stream types
+export { type AgentTypeFilter, isAgentTypeFilter } from './AgentStreamTypes';

--- a/src/eventBus/ProgressEventBus.ts
+++ b/src/eventBus/ProgressEventBus.ts
@@ -2,17 +2,17 @@
 import { EventEmitter } from 'events';
 
 // Type imports
-import type { AgentSessionDescriptor } from '@agent/core/AgentDataclass';
 import type { OutputFileInfo } from '@agent/output/types';
-import type { ExecutionId, StreamTabId } from '@agent/types/IdentifierTypes';
+import type { StreamTabId } from '@agent/types/IdentifierTypes';
 import type { TokenUsageStats } from '@agent/types/UsageTypes';
 import type { StreamStatus } from '@common/constants/streamStatus';
 import type { ContextStateData } from '@logger/AgentLogger';
 import type { LogMessageData, LogMessageUpdate } from '@logger/LogTypes';
-import type { TaskState } from '@logger/TaskState';
 import type {
   AddTaskGroupPayload,
   RunScopedPayload,
+  SetActiveStreamPayload,
+  SetTaskStatePayload,
   UpdateTaskGroupPayload,
   UpdateTodosPayload,
 } from './schemas';
@@ -20,24 +20,6 @@ import type { RetryRequestPrompt, ToolEditApprovalPrompt } from './types';
 
 // Maximum number of events to buffer when no listeners are registered
 const MAX_BUFFER_SIZE = 1000;
-
-// SetActiveStreamPayload and SetTaskStatePayload are defined inline
-// because they reference types from external modules (AgentSessionDescriptor, TaskState)
-// that don't have schemas yet. These can be migrated when those modules are updated.
-interface SetActiveStreamPayload {
-  stream: StreamTabId | null;
-  session?: AgentSessionDescriptor | null;
-  /** Hint whether this is a remote agent (for UI display before TaskState is set) */
-  isRemote?: boolean;
-  /** Hint whether this agent uses multiple outputs (for UI display before TaskState is set) */
-  hasMultipleOutputs?: boolean;
-}
-
-interface SetTaskStatePayload {
-  streamTabId: StreamTabId;
-  executionId?: ExecutionId;
-  taskState: TaskState;
-}
 
 export interface ProgressEventPayloads {
   addLogMessage: { stream: StreamTabId; logMessage: LogMessageData };

--- a/src/eventBus/schemas.ts
+++ b/src/eventBus/schemas.ts
@@ -117,12 +117,16 @@ export type SetActiveStreamPayload = z.infer<
 
 /**
  * Payload for setting task state on a stream.
- * Uses z.custom for taskState since TaskStateSchema is a validation-only schema
- * (uses looseObject) while the actual type has full AgentConfig fields.
+ *
+ * TaskStateSchema uses looseObject for validation efficiency (only validates
+ * discriminator fields), while the full TaskState type has all AgentConfig fields.
+ * We use pipe() to validate structure then cast to the full type, preserving
+ * error messages from the underlying schema.
  */
 export const SetTaskStatePayloadSchema = z.strictObject({
   streamTabId: StreamTabIdSchema,
   executionId: ExecutionIdSchema.optional(),
-  taskState: z.custom<TaskState>((val) => TaskStateSchema.safeParse(val).success),
+  // Validate with TaskStateSchema, then cast output to full TaskState type
+  taskState: TaskStateSchema.pipe(z.custom<TaskState>(() => true)),
 });
 export type SetTaskStatePayload = z.infer<typeof SetTaskStatePayloadSchema>;

--- a/src/eventBus/schemas.ts
+++ b/src/eventBus/schemas.ts
@@ -3,6 +3,7 @@
  * Types are derived from schemas for single source of truth.
  */
 import { z } from 'zod';
+import { AgentSessionDescriptorSchema } from '@agent/core/AgentSessionSchema';
 import {
   StreamTabIdSchema,
   ExecutionIdSchema,
@@ -13,6 +14,7 @@ import {
   type TaskGroupStatus,
 } from '@common/constants/streamStatus';
 import { TaskGroupSchema } from '@logger/LogTypes';
+import { TaskStateSchema, type TaskState } from '@logger/TaskState';
 
 /**
  * Re-export from types.ts to break circular dependency:
@@ -95,3 +97,32 @@ export const UpdateTodosPayloadSchema = z.strictObject({
   todos: z.array(TodoItemSchema),
 });
 export type UpdateTodosPayload = z.infer<typeof UpdateTodosPayloadSchema>;
+
+// =============================================================================
+// Stream State Payloads
+// =============================================================================
+
+/** Payload for setting the active stream with optional session metadata */
+export const SetActiveStreamPayloadSchema = z.strictObject({
+  stream: StreamTabIdSchema.nullable(),
+  session: AgentSessionDescriptorSchema.nullish(),
+  /** Hint whether this is a remote agent (for UI display before TaskState is set) */
+  isRemote: z.boolean().optional(),
+  /** Hint whether this agent uses multiple outputs (for UI display before TaskState is set) */
+  hasMultipleOutputs: z.boolean().optional(),
+});
+export type SetActiveStreamPayload = z.infer<
+  typeof SetActiveStreamPayloadSchema
+>;
+
+/**
+ * Payload for setting task state on a stream.
+ * Uses z.custom for taskState since TaskStateSchema is a validation-only schema
+ * (uses looseObject) while the actual type has full AgentConfig fields.
+ */
+export const SetTaskStatePayloadSchema = z.strictObject({
+  streamTabId: StreamTabIdSchema,
+  executionId: ExecutionIdSchema.optional(),
+  taskState: z.custom<TaskState>((val) => TaskStateSchema.safeParse(val).success),
+});
+export type SetTaskStatePayload = z.infer<typeof SetTaskStatePayloadSchema>;

--- a/src/logger/AgentLogger.ts
+++ b/src/logger/AgentLogger.ts
@@ -419,11 +419,7 @@ export class AgentLogger {
    */
   fileList(files: FileListEntry[], groupId?: string): void {
     const summary = `Loaded ${files.length} file${files.length === 1 ? '' : 's'}`;
-    this.info(summary, {
-      groupId,
-      messageType: MESSAGE_TYPES.FILE_LIST,
-      data: files,
-    });
+    this.logFileListData(summary, files, groupId);
   }
 
   /**
@@ -451,10 +447,19 @@ export class AgentLogger {
       sourceDisplay: category,
     }));
 
+    this.logFileListData(summary, entries, groupId);
+  }
+
+  /** Internal helper for FILE_LIST logging - shared by fileList and logFileCategory */
+  private logFileListData(
+    summary: string,
+    files: FileListEntry[],
+    groupId?: string,
+  ): void {
     this.info(summary, {
       groupId,
       messageType: MESSAGE_TYPES.FILE_LIST,
-      data: entries,
+      data: files,
     });
   }
 
@@ -503,14 +508,6 @@ export class AgentLogger {
       groupId,
       messageType: MESSAGE_TYPES.USER_MESSAGE,
     });
-  }
-
-  /**
-   * Returns the currently active group ID, or undefined if no group is active.
-   * Convenience method to avoid the `withCurrentGroup((id) => id)` boilerplate.
-   */
-  getCurrentGroupId(): string | undefined {
-    return this.resolveActiveGroupId();
   }
 
   withCurrentGroup<T>(fn: (groupId: string) => T): T | undefined {

--- a/src/logger/index.ts
+++ b/src/logger/index.ts
@@ -1,75 +1,21 @@
 /**
  * Logger module barrel exports.
  *
- * Provides a single entry point for all logger-related exports.
- * Consolidates types, schemas, and utilities for cleaner imports.
+ * Exports commonly used logger types and utilities.
+ * For less common exports, import directly from the specific file.
  */
 
-// Core logger
-export {
-  AgentLogger,
-  type AgentLogStage,
-  type AgentLogStream,
-  type AgentLogStreamOptions,
-  type AgentLoggerStageOptions,
-  type LoggerScopeOptions,
-  // Context management types
-  ContextManagementAction,
-  ContextManagementDataSchema,
-  type ContextManagementData,
-  ContextStateDataSchema,
-  type ContextStateData,
-} from './AgentLogger';
+// Core logger class
+export { AgentLogger, type AgentLogStage } from './AgentLogger';
 
-// Log utility functions (namespace import pattern)
+// Log utility functions (namespace import pattern - very common)
 export * as logUtils from './logUtils';
 
-// Message types and schemas
-export {
-  MESSAGE_TYPES,
-  MessageTypeSchema,
-  type MessageType,
-  END_GROUP_STATUS,
-  EndGroupStatusSchema,
-  type EndGroupStatus,
-  LOG_LEVELS,
-  LogLevelSchema,
-  FileListEntrySchema,
-  type FileListEntry,
-} from './messageTypes';
+// Message types - commonly used constants
+export { MESSAGE_TYPES, type MessageType } from './messageTypes';
 
-// Log data types
-export {
-  TaskGroupSchema,
-  type TaskGroup,
-  LogMessageDataSchema,
-  type LogMessageData,
-  LogMessageUpdateSchema,
-  type LogMessageUpdate,
-} from './LogTypes';
+// Task state - commonly used for type checking
+export { type TaskState, isToolUseTaskState, isWorkflowTaskState } from './TaskState';
 
-// Task state
-export {
-  TaskStateSchema,
-  type TaskState,
-  isToolUseTaskState,
-  isWorkflowTaskState,
-} from './TaskState';
-
-// Usage logging
+// Usage logging service
 export { UsageLogService } from './UsageLogService';
-export { AgentUsageReporter } from './AgentUsageReporter';
-export type {
-  UsageLogMetadata,
-  UsageLogEntry,
-  UsageLogBatch,
-} from './UsageLogTypes';
-
-// Filter utilities
-export { getEmitFilter, type FilterOptions, type FilterResult } from './filterUtils';
-
-// Stream utilities
-export { getStreamTabId } from './streamUtils';
-
-// Options
-export type { LogOptions, LogUtilsOptions } from './logOptions';

--- a/src/logger/index.ts
+++ b/src/logger/index.ts
@@ -1,0 +1,75 @@
+/**
+ * Logger module barrel exports.
+ *
+ * Provides a single entry point for all logger-related exports.
+ * Consolidates types, schemas, and utilities for cleaner imports.
+ */
+
+// Core logger
+export {
+  AgentLogger,
+  type AgentLogStage,
+  type AgentLogStream,
+  type AgentLogStreamOptions,
+  type AgentLoggerStageOptions,
+  type LoggerScopeOptions,
+  // Context management types
+  ContextManagementAction,
+  ContextManagementDataSchema,
+  type ContextManagementData,
+  ContextStateDataSchema,
+  type ContextStateData,
+} from './AgentLogger';
+
+// Log utility functions (namespace import pattern)
+export * as logUtils from './logUtils';
+
+// Message types and schemas
+export {
+  MESSAGE_TYPES,
+  MessageTypeSchema,
+  type MessageType,
+  END_GROUP_STATUS,
+  EndGroupStatusSchema,
+  type EndGroupStatus,
+  LOG_LEVELS,
+  LogLevelSchema,
+  FileListEntrySchema,
+  type FileListEntry,
+} from './messageTypes';
+
+// Log data types
+export {
+  TaskGroupSchema,
+  type TaskGroup,
+  LogMessageDataSchema,
+  type LogMessageData,
+  LogMessageUpdateSchema,
+  type LogMessageUpdate,
+} from './LogTypes';
+
+// Task state
+export {
+  TaskStateSchema,
+  type TaskState,
+  isToolUseTaskState,
+  isWorkflowTaskState,
+} from './TaskState';
+
+// Usage logging
+export { UsageLogService } from './UsageLogService';
+export { AgentUsageReporter } from './AgentUsageReporter';
+export type {
+  UsageLogMetadata,
+  UsageLogEntry,
+  UsageLogBatch,
+} from './UsageLogTypes';
+
+// Filter utilities
+export { getEmitFilter, type FilterOptions, type FilterResult } from './filterUtils';
+
+// Stream utilities
+export { getStreamTabId } from './streamUtils';
+
+// Options
+export type { LogOptions, LogUtilsOptions } from './logOptions';

--- a/src/tools/core/index.ts
+++ b/src/tools/core/index.ts
@@ -1,0 +1,8 @@
+/**
+ * Core tool infrastructure barrel export.
+ *
+ * Provides base classes and utilities for defining tools.
+ */
+
+export { BaseTool } from './base';
+export { defineTool } from './define';

--- a/src/tools/web/index.ts
+++ b/src/tools/web/index.ts
@@ -1,0 +1,8 @@
+/**
+ * Web tools barrel export.
+ *
+ * Provides tools for web content fetching and searching.
+ */
+
+export { WebFetchTool, type WebFetchInput } from './WebFetchTool';
+export { WebSearchTool, type WebSearchInput } from './WebSearchTool';


### PR DESCRIPTION
Logger improvements:
- Add barrel export index.ts for cleaner imports
- Extract shared logFileListData helper for fileList and logFileCategory
- Remove unused getCurrentGroupId wrapper method

EventBus improvements:
- Add Zod schemas for SetActiveStreamPayload and SetTaskStatePayload
- Move inline payload interfaces to schemas.ts with proper validation
- Use z.custom<TaskState> to preserve full type while validating structure
- Clean up unused imports in ProgressEventBus.ts

These changes improve code organization and type consistency without
altering functionality.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves organization and type safety without changing behavior.
> 
> - **Barrel exports:** New `index.ts` files for `agent/core`, `agent/toolUse`, `agent/types`, `logger`, `tools/core`, and `tools/web` to simplify imports.
> - **EventBus schemas:** Introduces Zod schemas for `SetActiveStreamPayload` and `SetTaskStatePayload` in `schemas.ts` (including `AgentSessionDescriptorSchema` and `TaskStateSchema`), and updates `ProgressEventBus` to consume them with cleaned imports.
> - **Logger refactor:** Extracts shared `logFileListData` used by `fileList` and `logFileCategory`; removes unused `getCurrentGroupId` convenience method.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d57e6e9c501aad4b5738c6fa9b9f6f38a147b233. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->