### PR TITLE
refactor(tools): simplify code clarity and remove dead code

### DIFF
--- a/src/tools/DiagnosticsTool.ts
+++ b/src/tools/DiagnosticsTool.ts
@@ -73,12 +73,10 @@ export class DiagnosticsTool extends defineTool({
     severity: DiagnosticsSeverityCounts,
     messages?: Diagnostic[],
   ): ToolResult {
-    const payload: DiagnosticsPayload = {
-      path,
-      command,
-      severity,
-      ...(messages ? { messages } : {}),
-    };
+    const payload: DiagnosticsPayload = { path, command, severity };
+    if (messages) {
+      payload.messages = messages;
+    }
 
     const { errors = 0, warnings = 0, info = 0, hints = 0 } = severity;
     const counts = [

--- a/src/tools/TextEditorTool.ts
+++ b/src/tools/TextEditorTool.ts
@@ -26,12 +26,6 @@ import { WorkspaceFS, AbsoluteFS } from '@utils/files';
 import { defineTool } from './core/define';
 import { ToolResult, ToolError } from './result';
 
-// Local imports - approval helpers
-
-// Local imports - logging
-
-// Local imports - filesystem utilities
-
 // Constants
 const CHANNEL = 'TextEditorTool';
 logger.initialize(CHANNEL);
@@ -489,9 +483,10 @@ export class TextEditorTool extends defineTool({
       );
       const reviewMessage =
         'Review the changes and make sure they are as expected. Edit the file again if necessary.';
+      const baseMsg = `${successIntro} ${snippetOutput}${reviewMessage}`;
       const successMsg = userDiffNote
-        ? `${successIntro} ${snippetOutput}${reviewMessage}\n\n${userDiffNote}`
-        : `${successIntro} ${snippetOutput}${reviewMessage}`;
+        ? `${baseMsg}\n\n${userDiffNote}`
+        : baseMsg;
 
       return {
         summary: `Updated ${filePath}`,
@@ -602,19 +597,17 @@ export class TextEditorTool extends defineTool({
       );
 
       const successIntro = `The file ${filePath} has been edited.`;
+      const snippetOutput = this.makeOutput(
+        snippetText,
+        'a snippet of the edited file',
+        startLine,
+      );
       const reviewNote =
         'Review the changes and make sure they are as expected (correct indentation, no duplicate lines, etc). Edit the file again if necessary.';
+      const baseMsg = `${successIntro} ${snippetOutput}${reviewNote}`;
       const successMsg = userDiffNote
-        ? `${successIntro} ${this.makeOutput(
-            snippetText,
-            'a snippet of the edited file',
-            startLine,
-          )}${reviewNote}\n\n${userDiffNote}`
-        : `${successIntro} ${this.makeOutput(
-            snippetText,
-            'a snippet of the edited file',
-            startLine,
-          )}${reviewNote}`;
+        ? `${baseMsg}\n\n${userDiffNote}`
+        : baseMsg;
 
       return {
         summary: `Inserted text into ${filePath}`,

--- a/src/tools/WriteTool.ts
+++ b/src/tools/WriteTool.ts
@@ -21,10 +21,6 @@ import { WorkspaceFS } from '@utils/files';
 // Local file imports
 import { defineTool } from './core/define';
 
-// Local imports - tools
-
-// Local imports - utils
-
 const WriteInputSchema = z.strictObject({
   path: z.string(),
   content: z.string(),

--- a/src/tools/fileOp.ts
+++ b/src/tools/fileOp.ts
@@ -21,8 +21,6 @@ import { WorkspaceFS } from '@utils/files';
 // Local file imports
 import { defineTool } from './core/define';
 
-// Local imports - tools
-
 const FileOpInputSchema = z.strictObject({
   command: z.enum(['read', 'write', 'append']),
   path: z.string(),

--- a/src/tools/memory/MemoryTool.ts
+++ b/src/tools/memory/MemoryTool.ts
@@ -23,6 +23,18 @@ import {
 } from './constants';
 import { toDisplayPath, formatSize, displayToStoragePath } from './memoryUtils';
 
+function formatLinesWithNumbers(
+  lines: string[],
+  startIndex: number = 0,
+): string[] {
+  return lines.map((line, index) => {
+    const lineNumber = (startIndex + index + 1)
+      .toString()
+      .padStart(LINE_NUMBER_WIDTH, ' ');
+    return `${lineNumber}\t${line}`;
+  });
+}
+
 const MemoryToolInputSchema = z.strictObject({
   command: z.enum([
     'view',
@@ -183,13 +195,7 @@ export class MemoryTool extends defineTool({
     const startIndex = Math.max(start - 1, 0);
     const endIndex = Math.min(end, lines.length);
     const selected = lines.slice(startIndex, endIndex);
-
-    const numbered = selected.map((line, index) => {
-      const lineNumber = (startIndex + index + 1)
-        .toString()
-        .padStart(LINE_NUMBER_WIDTH, ' ');
-      return `${lineNumber}\t${line}`;
-    });
+    const numbered = formatLinesWithNumbers(selected, startIndex);
 
     return {
       output: [
@@ -262,12 +268,7 @@ export class MemoryTool extends defineTool({
     await StorageFS.write(resolvedPath, updated);
 
     const updatedLines = updated.split(/\r?\n/);
-    const numbered = updatedLines.map((line, index) => {
-      const lineNumber = (index + 1)
-        .toString()
-        .padStart(LINE_NUMBER_WIDTH, ' ');
-      return `${lineNumber}\t${line}`;
-    });
+    const numbered = formatLinesWithNumbers(updatedLines);
 
     return {
       output: [

--- a/src/tools/todo/TodoTool.ts
+++ b/src/tools/todo/TodoTool.ts
@@ -15,8 +15,6 @@ import { AgentLogger } from '@logger/AgentLogger';
 import { type ToolResult } from '@tools/result';
 import { defineTool } from '@tools/core/define';
 
-// Local imports - logging
-
 const logger = new AgentLogger('TodoWriteTool');
 
 // Import todo schemas from single source of truth

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -184,11 +184,16 @@ export async function buildFileAttachment({
   const bytes = Uint8Array.from(buffer);
   buffer.fill(0);
 
-  return {
+  const attachment: ToolFileAttachment = {
     path: display,
     mimeType: inferredMime,
     bytes,
-    ...(description ? { description } : {}),
-    ...(base64Data ? { base64Data } : {}),
   };
+  if (description) {
+    attachment.description = description;
+  }
+  if (base64Data) {
+    attachment.base64Data = base64Data;
+  }
+  return attachment;
 }


### PR DESCRIPTION
- Remove empty comment blocks in TextEditorTool.ts, WriteTool.ts, fileOp.ts, and TodoTool.ts
- Extract formatLinesWithNumbers helper in MemoryTool.ts to avoid duplication
- Simplify userDiffNote conditionals in TextEditorTool.ts by computing base message first
- Replace conditional spread patterns with explicit if statements in utils.ts and DiagnosticsTool.ts
- Net reduction of 11 lines while improving readability

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Refactor for clarity and minor cleanup**
> 
> - Extracts `formatLinesWithNumbers` in `MemoryTool` and uses it in `view` and `str_replace` to remove duplicated line-numbering logic
> - Simplifies success message composition in `TextEditorTool` (`str_replace`, `insert`) by building a base message first
> - Replaces conditional spread patterns with explicit assignments in `utils.buildFileAttachment` and `DiagnosticsTool` payload construction
> - Removes redundant comment blocks in `TextEditorTool`, `WriteTool`, `fileOp`, and `TodoTool`
> 
> *No functional behavior or API changes intended; improves readability and maintainability.*
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8e0e6f4bea21a1fe319257bc3cffc79f1c03984f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->