### PR TITLE
refactor(progressView): simplify state persistence and dynamic logic

### DIFF
--- a/src/auth/SupabaseAuthProvider.ts
+++ b/src/auth/SupabaseAuthProvider.ts
@@ -71,7 +71,9 @@ const GITHUB_TOKEN_TYPE_MAP: Record<string, string> = {
  * Returns null if session data is missing or invalid.
  * Logs warnings for corrupted data to help diagnose auth issues.
  */
-function parseStoredSession(sessionData: string | undefined): SupabaseSession | null {
+function parseStoredSession(
+  sessionData: string | undefined,
+): SupabaseSession | null {
   if (!sessionData) return null;
   try {
     const parsed = SupabaseSessionSchema.safeParse(JSON.parse(sessionData));
@@ -957,7 +959,10 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
       };
 
       await this.storeSession(refreshed);
-      logger.info('SupabaseAuthProvider', 'Token refreshed via custom endpoint');
+      logger.info(
+        'SupabaseAuthProvider',
+        'Token refreshed via custom endpoint',
+      );
       return refreshed;
     } catch (error) {
       logger.error(

--- a/src/auth/authCommands.ts
+++ b/src/auth/authCommands.ts
@@ -47,8 +47,16 @@ interface SignInOption {
 /** Build sign-in options based on enabled auth methods */
 function getSignInOptions(): SignInOption[] {
   const options: SignInOption[] = [
-    { label: '$(globe) Google', description: 'Sign in with Google', method: 'google' },
-    { label: '$(github) GitHub', description: 'Sign in with GitHub via web browser', method: 'github-browser' },
+    {
+      label: '$(globe) Google',
+      description: 'Sign in with Google',
+      method: 'google',
+    },
+    {
+      label: '$(github) GitHub',
+      description: 'Sign in with GitHub via web browser',
+      method: 'github-browser',
+    },
   ];
 
   if (EMAIL_LOGIN_ENABLED) {

--- a/src/logger/index.ts
+++ b/src/logger/index.ts
@@ -15,7 +15,11 @@ export * as logUtils from './logUtils';
 export { MESSAGE_TYPES, type MessageType } from './messageTypes';
 
 // Task state - commonly used for type checking
-export { type TaskState, isToolUseTaskState, isWorkflowTaskState } from './TaskState';
+export {
+  type TaskState,
+  isToolUseTaskState,
+  isWorkflowTaskState,
+} from './TaskState';
 
 // Usage logging service
 export { UsageLogService } from './UsageLogService';

--- a/src/logger/transports/VSCodeTransport.ts
+++ b/src/logger/transports/VSCodeTransport.ts
@@ -45,7 +45,8 @@ export class VSCodeTransport extends Transport {
   log(info: any, callback: () => void): void {
     const { level, message, timestamp, messageType, groupId } = info;
     // Serialize errors for logging (inline from serializeLogData)
-    const data = info.data instanceof Error ? serializeError(info.data) : info.data;
+    const data =
+      info.data instanceof Error ? serializeError(info.data) : info.data;
 
     this.writeToChannel(level, message, timestamp, data);
     this.emitLogEvent({

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -498,13 +498,11 @@ export class ProgressEventHandler {
     });
   };
 
-  /** Convert Map<number, T[]> to Record<number, T[]> for webview (from OutputEvents.ts) */
+  /** Convert Map<number, T[]> to Record for webview, or undefined if empty */
   private toRoundRecord<T>(
-    rounds?: Map<number, T[]>,
+    rounds: Map<number, T[]> | undefined,
   ): Record<number, T[]> | undefined {
-    return rounds && rounds.size > 0
-      ? Object.fromEntries(rounds.entries())
-      : undefined;
+    return rounds?.size ? Object.fromEntries(rounds) : undefined;
   }
 
   // ============================================================================

--- a/src/progressView/managers/OutputFilesManager.ts
+++ b/src/progressView/managers/OutputFilesManager.ts
@@ -294,7 +294,7 @@ export class OutputFilesManager extends PersistentMapManager<
     await this.ensureMissingOutputsLoaded();
   }
 
-  /** Load missing outputs from persistence */
+  /** Load missing outputs from persistence or migrate legacy data */
   private async loadMissingOutputs(): Promise<void> {
     const saved = this.storage.get<Record<string, unknown>>(
       WorkspaceStateKey.MISSING_OUTPUTS,
@@ -303,31 +303,24 @@ export class OutputFilesManager extends PersistentMapManager<
 
     if (saved && Object.keys(saved).length > 0) {
       this._missingOutputs = this.deserializeMissingOutputs(saved);
-      return;
-    }
-
-    const migrated = await this.migrateLegacyMissingOutputs();
-    if (!migrated) {
+    } else if (!(await this.migrateLegacyMissingOutputs())) {
       this._missingOutputs.clear();
     }
   }
 
+  /** Ensure missing outputs are loaded (lazy initialization with memoization) */
   private async ensureMissingOutputsLoaded(): Promise<void> {
-    if (this.missingOutputsLoaded) {
-      return;
-    }
+    if (this.missingOutputsLoaded) return;
 
-    if (!this.missingOutputsLoadPromise) {
-      this.missingOutputsLoadPromise = this.loadMissingOutputs()
-        .then(() => {
-          this.missingOutputsLoaded = true;
-        })
-        .catch((error) => {
-          this.logger.error('Failed to load missing outputs', { data: error });
-          this.missingOutputsLoadPromise = null;
-          throw error;
-        });
-    }
+    this.missingOutputsLoadPromise ??= this.loadMissingOutputs()
+      .then(() => {
+        this.missingOutputsLoaded = true;
+      })
+      .catch((error) => {
+        this.logger.error('Failed to load missing outputs', { data: error });
+        this.missingOutputsLoadPromise = null;
+        throw error;
+      });
 
     await this.missingOutputsLoadPromise;
   }

--- a/src/progressView/managers/StreamTabsManager.ts
+++ b/src/progressView/managers/StreamTabsManager.ts
@@ -108,23 +108,13 @@ export class StreamTabsManager extends PersistentMapManager<
     }
   }
 
-  /** Serialize messages before saving */
-  protected override serialize(
-    value: LogMessageData[],
-    _key: StreamTabId,
-  ): unknown {
-    return value;
-  }
-
-  /** Normalize loaded messages */
+  /** Normalize loaded messages (shallow copy each entry) */
   protected override async deserialize(
     data: unknown,
     _key: StreamTabId,
   ): Promise<LogMessageData[]> {
-    if (!Array.isArray(data)) {
-      return [];
-    }
-
-    return data.map((entry) => ({ ...entry })) as LogMessageData[];
+    return Array.isArray(data)
+      ? data.map((entry) => ({ ...entry }) as LogMessageData)
+      : [];
   }
 }

--- a/src/progressView/managers/UsageStatsManager.ts
+++ b/src/progressView/managers/UsageStatsManager.ts
@@ -29,43 +29,48 @@ const FiniteNumber = z.coerce
  * Schema for parsing TokenUsageStats with safe number coercion.
  * Uses canonical schema as source of truth - compile-time assertion ensures sync.
  */
-const TokenUsageStatsParsingBaseSchema = z.object({
-  // Required fields from canonical schema
-  inputTokens: FiniteNumber,
-  outputTokens: FiniteNumber,
-  cost: FiniteNumber,
-  // Optional fields from canonical schema (default to 0 for accumulation)
-  cacheReadInputTokens: FiniteNumber.optional().default(0),
-  cacheCreationInputTokens: FiniteNumber.optional().default(0),
-});
-
-const TokenUsageStatsParsingSchema = TokenUsageStatsParsingBaseSchema.catch({
-  inputTokens: 0,
-  outputTokens: 0,
-  cost: 0,
-  cacheReadInputTokens: 0,
-  cacheCreationInputTokens: 0,
-});
+const TokenUsageStatsParsingSchema = z
+  .object({
+    inputTokens: FiniteNumber,
+    outputTokens: FiniteNumber,
+    cost: FiniteNumber,
+    cacheReadInputTokens: FiniteNumber.optional().default(0),
+    cacheCreationInputTokens: FiniteNumber.optional().default(0),
+  })
+  .catch({
+    inputTokens: 0,
+    outputTokens: 0,
+    cost: 0,
+    cacheReadInputTokens: 0,
+    cacheCreationInputTokens: 0,
+  });
 
 // Compile-time assertion: parsing schema output must be assignable to canonical type.
-// This fails at compile time if TokenUsageStatsParsingSchema produces incompatible fields.
 type _AssertSchemaCompatible =
   z.infer<typeof TokenUsageStatsParsingSchema> extends TokenUsageStats
     ? true
     : never;
 void (true as _AssertSchemaCompatible);
 
-// Runtime assertion: ensure all canonical keys are handled
-const canonicalKeys = TokenUsageStatsSchema.keyof().options;
+// Runtime assertion: ensure parsing schema covers all canonical keys
+const canonicalKeys = new Set(TokenUsageStatsSchema.keyof().options);
 const parsingKeys = new Set(
-  Object.keys(TokenUsageStatsParsingBaseSchema.shape),
+  Object.keys(TokenUsageStatsParsingSchema._def.innerType.shape),
 );
-const missingKeys = canonicalKeys.filter((k) => !parsingKeys.has(k));
-if (missingKeys.length > 0) {
-  throw new Error(
-    `TokenUsageStatsParsingSchema missing keys from canonical schema: ${missingKeys.join(', ')}`,
-  );
+for (const key of canonicalKeys) {
+  if (!parsingKeys.has(key)) {
+    throw new Error(`TokenUsageStatsParsingSchema missing key: ${key}`);
+  }
 }
+
+/** Zero-initialized usage stats constant */
+const EMPTY_USAGE: TokenUsageStats = {
+  inputTokens: 0,
+  outputTokens: 0,
+  cost: 0,
+  cacheReadInputTokens: 0,
+  cacheCreationInputTokens: 0,
+};
 
 /** Checks if usage stats are all zeros (effectively empty) */
 function isEmptyUsage(usage: TokenUsageStats): boolean {
@@ -78,20 +83,9 @@ function isEmptyUsage(usage: TokenUsageStats): boolean {
   );
 }
 
-/** Returns zero-initialized usage stats */
-function emptyUsageStats(): TokenUsageStats {
-  return {
-    inputTokens: 0,
-    outputTokens: 0,
-    cost: 0,
-    cacheReadInputTokens: 0,
-    cacheCreationInputTokens: 0,
-  };
-}
-
 /** Accumulates usage stats from an iterable into a single total */
 function sumUsageStats(items: Iterable<TokenUsageStats>): TokenUsageStats {
-  const total = emptyUsageStats();
+  const total = { ...EMPTY_USAGE };
   for (const usage of items) {
     total.inputTokens += usage.inputTokens;
     total.outputTokens += usage.outputTokens;

--- a/src/progressView/managers/WebviewUpdater.ts
+++ b/src/progressView/managers/WebviewUpdater.ts
@@ -48,13 +48,11 @@ export class WebviewUpdater {
     taskState?: TaskState,
   ): InstructionUpdate | undefined {
     const text = taskState?.agentConfig?.instruction?.trim();
-    if (!text) {
-      return undefined;
-    }
+    if (!text) return undefined;
 
-    const lineCount = text.split(/\r?\n/).length;
-    const showToggle = lineCount > 6 || text.length > 600;
-    return showToggle ? { text, metadata: { showToggle: true } } : { text };
+    // Show toggle for long instructions (>6 lines or >600 chars)
+    const isLong = text.split(/\r?\n/).length > 6 || text.length > 600;
+    return isLong ? { text, metadata: { showToggle: true } } : { text };
   }
 
   /**

--- a/src/progressView/modules/formatters/htmlBuilders.js
+++ b/src/progressView/modules/formatters/htmlBuilders.js
@@ -73,7 +73,9 @@ export function wrapInPre(text, className = '') {
     const highlightedLines = text.split('\n').map((line) => {
       const diffClass = getDiffLineClass(line);
       const encoded = encodeHtml(line);
-      return diffClass ? `<span class="${diffClass}">${encoded}</span>` : encoded;
+      return diffClass
+        ? `<span class="${diffClass}">${encoded}</span>`
+        : encoded;
     });
     return `<pre${classAttr}>${highlightedLines.join('\n')}</pre>`;
   }

--- a/src/progressView/modules/uiManagers/StreamTabs.js
+++ b/src/progressView/modules/uiManagers/StreamTabs.js
@@ -200,8 +200,18 @@ export class StreamTabs {
     }
 
     // Property-based decorators - remove if condition false, apply icon if true
-    this._applyPropertyDecorator(tabEl, '.remote-agent', info.isRemote, 'remote');
-    this._applyPropertyDecorator(tabEl, '.multi-file', info.hasMultipleOutputs, 'multipleOutputs');
+    this._applyPropertyDecorator(
+      tabEl,
+      '.remote-agent',
+      info.isRemote,
+      'remote',
+    );
+    this._applyPropertyDecorator(
+      tabEl,
+      '.multi-file',
+      info.hasMultipleOutputs,
+      'multipleOutputs',
+    );
   }
 
   /**

--- a/src/progressView/persistence/schemaUtils.ts
+++ b/src/progressView/persistence/schemaUtils.ts
@@ -7,6 +7,15 @@ import { z } from 'zod';
 export const RoundKeySchema = z.coerce.number().int();
 
 /**
+ * Parse unknown data as a record, returning empty object for invalid inputs.
+ */
+function asRecord(data: unknown): Record<string, unknown> {
+  return data && typeof data === 'object' && !Array.isArray(data)
+    ? (data as Record<string, unknown>)
+    : {};
+}
+
+/**
  * Factory for creating round map schemas that transform { roundNum: items[] } to Map<number, T[]>.
  * Filters out invalid round keys and empty item arrays.
  *
@@ -39,14 +48,8 @@ export function createRunMapSchema<T>(
   roundMapSchema: z.ZodType<Map<number, T[]>>,
 ): z.ZodType<Map<string, Map<number, T[]>>> {
   return z.unknown().transform((data): Map<string, Map<number, T[]>> => {
-    if (!data || typeof data !== 'object') {
-      return new Map();
-    }
-
-    const record = data as Record<string, unknown>;
     const runMap = new Map<string, Map<number, T[]>>();
-
-    for (const [runId, value] of Object.entries(record)) {
+    for (const [runId, value] of Object.entries(asRecord(data))) {
       if (!value || typeof value !== 'object') continue;
       const result = roundMapSchema.safeParse(value);
       if (result.success && result.data.size > 0) {
@@ -71,18 +74,11 @@ export function createSingleValueRunMapSchema<T>(
   const isEmpty = options?.isEmpty;
 
   return z.unknown().transform((data): Map<string, T> => {
-    if (!data || typeof data !== 'object') {
-      return new Map();
-    }
-
-    const record = data as Record<string, unknown>;
     const runMap = new Map<string, T>();
-
-    for (const [runId, value] of Object.entries(record)) {
+    for (const [runId, value] of Object.entries(asRecord(data))) {
       if (!value || typeof value !== 'object') continue;
       const result = itemSchema.safeParse(value);
-      if (result.success) {
-        if (isEmpty?.(result.data)) continue;
+      if (result.success && !isEmpty?.(result.data)) {
         runMap.set(runId, result.data);
       }
     }

--- a/src/progressView/persistence/serializationUtils.ts
+++ b/src/progressView/persistence/serializationUtils.ts
@@ -11,22 +11,16 @@
  * @returns Plain object structure with all Maps converted to Records
  *
  * @example
- * // Depth 1: Map → Record
- * mapsToRecords(new Map([['a', 1]]), 1) // { a: 1 }
- *
- * // Depth 2: Map<K, Map<K, V>> → Record<K, Record<K, V>>
- * mapsToRecords(new Map([['run1', new Map([[1, 'v']])]]), 2) // { run1: { '1': 'v' } }
+ * mapsToRecords(new Map([['a', 1]]), 1)                         // { a: 1 }
+ * mapsToRecords(new Map([['run1', new Map([[1, 'v']])]]), 2)    // { run1: { '1': 'v' } }
  */
 function mapsToRecords(value: unknown, depth: number): unknown {
-  if (depth <= 0 || !(value instanceof Map)) {
-    return value;
-  }
-  return Object.fromEntries(
-    Array.from((value as Map<unknown, unknown>).entries(), ([k, v]) => [
-      String(k),
-      mapsToRecords(v, depth - 1),
-    ]),
-  );
+  if (depth <= 0 || !(value instanceof Map)) return value;
+  const entries = [...value].map(([k, v]) => [
+    String(k),
+    mapsToRecords(v, depth - 1),
+  ]);
+  return Object.fromEntries(entries);
 }
 
 /**

--- a/src/progressView/state/ProgressViewState.ts
+++ b/src/progressView/state/ProgressViewState.ts
@@ -286,8 +286,7 @@ export class ProgressViewState {
   /**
    * Resolve and optionally persist the active run ID for a stream.
    *
-   * This method determines which run (task group) should be active for display
-   * in the progress view. The resolution strategy:
+   * Resolution strategy:
    * 1. If a specific runId is requested, validate it exists and use it
    * 2. Otherwise, check for a previously active runId
    * 3. If only one run exists, use that
@@ -308,18 +307,12 @@ export class ProgressViewState {
   ): string | null {
     const persist = options?.persist ?? true;
 
-    // Helper to persist and return a resolved runId
-    const resolve = (runId: string | null): string | null => {
-      if (runId && persist) {
-        this.setActiveRunId(stream, runId);
-      }
-      return runId;
-    };
-
     // 1. If specific runId requested, validate it exists
     if (requested) {
       const candidates = this.collectRunCandidates(stream);
-      return candidates.has(requested) ? resolve(requested) : null;
+      if (!candidates.has(requested)) return null;
+      if (persist) this.setActiveRunId(stream, requested);
+      return requested;
     }
 
     // 2. Use existing active run if set
@@ -328,12 +321,13 @@ export class ProgressViewState {
 
     // 3. Auto-select: single candidate or latest
     const candidates = this.collectRunCandidates(stream);
-    if (candidates.size === 1) {
-      const [only] = candidates;
-      return resolve(only);
-    }
+    const runId =
+      candidates.size === 1 ? [...candidates][0] : this.findLatestRunId(stream);
 
-    return resolve(this.findLatestRunId(stream));
+    if (runId && persist) {
+      this.setActiveRunId(stream, runId);
+    }
+    return runId;
   }
 
   private collectRunCandidates(stream: StreamTabId): Set<string> {
@@ -644,6 +638,7 @@ export class ProgressViewState {
 
   /**
    * Extract task state entries from either legacy or flat format.
+   * Legacy format had { workflow: {...}, toolUse: {...} } structure.
    */
   private extractTaskStateEntries(
     raw: Record<string, unknown>,
@@ -651,26 +646,15 @@ export class ProgressViewState {
     const isLegacyFormat =
       typeof raw.workflow === 'object' || typeof raw.toolUse === 'object';
 
-    if (!isLegacyFormat) {
-      return Object.entries(raw).filter(
-        ([, value]) => value && typeof value === 'object',
-      );
-    }
+    const buckets = isLegacyFormat ? [raw.workflow, raw.toolUse] : [raw];
 
-    // Legacy format: collect from workflow and toolUse sub-objects
-    const entries: Array<[string, unknown]> = [];
-    for (const bucket of [raw.workflow, raw.toolUse]) {
-      if (bucket && typeof bucket === 'object') {
-        for (const [stream, value] of Object.entries(
-          bucket as Record<string, unknown>,
-        )) {
-          if (value && typeof value === 'object') {
-            entries.push([stream, value]);
-          }
-        }
-      }
-    }
-    return entries;
+    return buckets.flatMap((bucket) =>
+      bucket && typeof bucket === 'object'
+        ? Object.entries(bucket as Record<string, unknown>).filter(
+            ([, value]) => value && typeof value === 'object',
+          )
+        : [],
+    );
   }
 
   /**

--- a/src/progressView/streamInfoUtils.ts
+++ b/src/progressView/streamInfoUtils.ts
@@ -46,8 +46,8 @@ function matchesFilter(
 }
 
 /**
- * Build a StreamTabInfo object for a single stream ID.
- * Returns null if the stream doesn't match the filter.
+ * Build a single StreamTabInfo for the given stream ID.
+ * Returns null if the stream should be filtered out.
  */
 function buildStreamInfo(
   state: ProgressViewState,
@@ -58,50 +58,47 @@ function buildStreamInfo(
   const taskState = state.getTaskState(id);
   const hints = state.getStreamHints(id);
   const logs = state.streamTabs.getMessages(id);
-  const lastTimestamp = logs.length > 0 ? logs.at(-1)?.timestamp : undefined;
-  const creationTimestamp = logs.length > 0 ? logs[0].timestamp : undefined;
-  const inputFile = taskState?.agentConfig.inputFile ?? '';
-  const rawAgentName = taskState?.agentConfig.agent ?? id.split('@')[0];
-  const agentName = getCleanAgentName(rawAgentName);
   const rawCategory =
     taskState?.agentConfig.session?.agentCategory ?? hints.sessionCategory;
 
+  // Filter check: returns resolved category or null if filtered out
   const sessionCategory = matchesFilter(rawCategory, filter);
   if (sessionCategory === null) {
     return null;
   }
 
-  const agentType =
-    taskState?.agentConfig.session?.agentType ??
-    taskState?.agentConfig.agentType;
+  const rawAgentName = taskState?.agentConfig.agent ?? id.split('@')[0];
+  const agentName = getCleanAgentName(rawAgentName);
+  const inputFile = taskState?.agentConfig.inputFile ?? '';
   const isToolAgent = sessionCategory === AgentCategory.ToolUse;
-  const isRemote = taskState
-    ? isRemoteAgent(rawAgentName)
-    : (hints.isRemote ?? false);
-  const executionId = state.getExecutionId(id);
 
+  // Build label: tool-use shows agent only, workflows show agent + file basename
   const label =
-    sessionCategory !== AgentCategory.ToolUse && inputFile
-      ? `${agentName}: ${path.basename(inputFile)}`
-      : agentName;
+    isToolAgent || !inputFile
+      ? agentName
+      : `${agentName}: ${path.basename(inputFile)}`;
 
   return {
     name: id,
     label,
     model: taskState?.agentConfig.model,
     agent: taskState?.agentConfig.agent,
-    agentType,
+    agentType:
+      taskState?.agentConfig.session?.agentType ??
+      taskState?.agentConfig.agentType,
     agentSessionKind: sessionCategory,
     uiTraits: { sessionKind: sessionCategory, isToolAgent },
     hasMultipleOutputs: taskState
       ? taskState.agentConfig.useMultipleOutputs
       : (hints.hasMultipleOutputs ?? false),
-    isRemote,
-    lastTimestamp,
+    isRemote: taskState
+      ? isRemoteAgent(rawAgentName)
+      : (hints.isRemote ?? false),
+    lastTimestamp: logs.at(-1)?.timestamp,
     inputFile,
-    creationTimestamp,
+    creationTimestamp: logs[0]?.timestamp,
     status: statuses?.get(id),
-    executionId,
+    executionId: state.getExecutionId(id),
   };
 }
 

--- a/supabase/functions/auth-github/index.ts
+++ b/supabase/functions/auth-github/index.ts
@@ -107,7 +107,11 @@ function errorResponse(c: Context, error: string, status: number) {
 function buildSessionResponse(
   accessToken: string,
   refreshToken: string,
-  user: { id: string; email?: string | null; user_metadata?: Record<string, unknown> },
+  user: {
+    id: string;
+    email?: string | null;
+    user_metadata?: Record<string, unknown>;
+  },
 ) {
   const now = Math.floor(Date.now() / 1000);
   return {

--- a/supabase/functions/log-usage/index.ts
+++ b/supabase/functions/log-usage/index.ts
@@ -277,7 +277,11 @@ Deno.serve(async (req: Request) => {
     }
 
     // 7. Return success response
-    return jsonResponse(req, { success: true, accepted: validEntries.length }, 200);
+    return jsonResponse(
+      req,
+      { success: true, accepted: validEntries.length },
+      200,
+    );
   } catch (error) {
     console.error('[LOG_USAGE] Unexpected error:', error);
     return errorResponse(req, 'Internal server error', 500);


### PR DESCRIPTION
Holistic refinements to progressView state management, persistence,
and dynamic logic for improved clarity and maintainability:

- streamInfoUtils: Extract buildStreamInfo helper, replace reduce with
  map/filter chain for clearer stream metadata building
- schemaUtils: Add asRecord helper to consolidate null/object checks
  across schema factories
- serializationUtils: Streamline mapsToRecords with cleaner spread syntax
- UsageStatsManager: Consolidate schema definition, use EMPTY_USAGE
  constant, simplify runtime assertion loop
- ProgressViewState: Simplify resolveRunId by removing nested helper,
  use flatMap for extractTaskStateEntries legacy format handling
- StreamTabsManager: Remove redundant serialize override (base class
  already handles identity serialization)
- WebviewUpdater: Inline computeInstructionMetadata into createInstructionUpdate
- ProgressEventHandler: Simplify toRoundRecord helper with optional chaining
- OutputFilesManager: Use nullish coalescing for lazy load memoization,
  consolidate loadMissingOutputs branches

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Focuses on clarity and maintainability across progress view state, persistence, and UI updates.
> 
> - Simplifies `ProgressViewState.resolveRunId` and legacy task-state parsing (flatMap), preserves active run persistence logic
> - Streamlines webview updates: `WebviewUpdater.createInstructionUpdate` inlined toggle logic; `ProgressEventHandler.toRoundRecord` simplified; targeted status updates maintained
> - Consolidates usage parsing in `UsageStatsManager` (single schema, `EMPTY_USAGE`, tighter runtime key check) and sums via helper
> - Cleans persistence helpers: `schemaUtils.asRecord` for safe object coercion; `createRunMapSchema`/`createSingleValueRunMapSchema` use it; `serializationUtils.mapsToRecords` simplified
> - Output files: lazy-load/memoized missing outputs with legacy migration fallback; cleaner branches in `loadMissingOutputs`
> - Stream tabs/messages: lighter `deserialize` (shallow copy), remove redundant serialize override
> - `streamInfoUtils`: clearer label/category filtering, timestamps via `logs.at(-1)/[0]`, remote/multiple-output flags handled consistently
> - Minor formatting/typing cleanups in auth/logging and Supabase edge functions (no behavior change)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9a73d91b975ac40097b64571769d9814c8358487. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->