### PR TITLE
refactor(progressView): simplify message rendering code clarity

### DIFF
--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -337,16 +337,9 @@ export class ProgressEventHandler {
           return;
         }
 
-        // Update fields if provided
-        if (logMessage.text !== undefined) existing.text = logMessage.text;
-        if (logMessage.messageType !== undefined)
-          existing.messageType = logMessage.messageType;
-        if (logMessage.level) existing.level = logMessage.level;
-        if (logMessage.timestamp !== undefined)
-          existing.timestamp = logMessage.timestamp;
-        if (logMessage.verbose !== undefined)
-          existing.verbose = logMessage.verbose;
-        if (logMessage.data !== undefined) existing.data = logMessage.data;
+        // Update fields from logMessage, preserving existing values for undefined fields
+        const { id: _id, ...updates } = logMessage;
+        Object.assign(existing, updates);
 
         await this.state.streamTabs.save();
 
@@ -640,13 +633,11 @@ export class ProgressEventHandler {
     // messages here to avoid a race condition where reset: true would clear
     // the files just populated from UPDATE_LOGS.
 
+    // Reset and send all missing outputs in sequence
     this.webviewUpdater.updateMissingOutputs(stream, { reset: true });
-    Object.entries(missingByRun).forEach(([runId, rounds]) => {
-      this.webviewUpdater.updateMissingOutputs(stream, {
-        runId,
-        rounds,
-      });
-    });
+    for (const [runId, rounds] of Object.entries(missingByRun)) {
+      this.webviewUpdater.updateMissingOutputs(stream, { runId, rounds });
+    }
 
     // Refresh todos for the stream (ephemeral state)
     // Always send update (empty array if undefined) to clear stale UI from previous stream

--- a/src/progressView/managers/WebviewUpdater.ts
+++ b/src/progressView/managers/WebviewUpdater.ts
@@ -52,19 +52,9 @@ export class WebviewUpdater {
       return undefined;
     }
 
-    const metadata = WebviewUpdater.computeInstructionMetadata(text);
-    return metadata ? { text, metadata } : { text };
-  }
-
-  private static computeInstructionMetadata(
-    text: string,
-  ): InstructionUpdate['metadata'] | undefined {
     const lineCount = text.split(/\r?\n/).length;
-    const shouldShowToggle = lineCount > 6 || text.length > 600;
-    if (!shouldShowToggle) {
-      return undefined;
-    }
-    return { showToggle: true };
+    const showToggle = lineCount > 6 || text.length > 600;
+    return showToggle ? { text, metadata: { showToggle: true } } : { text };
   }
 
   /**

--- a/src/progressView/modules/formatters/logFormatters/messageFormatters.js
+++ b/src/progressView/modules/formatters/logFormatters/messageFormatters.js
@@ -46,33 +46,28 @@ export const formatUserMessage = (normalizedPayload, logId, timestamp) => {
  * @returns {HTMLElement} Progress status element
  */
 export const formatProgressStatus = (message) => {
-  const normalizedPayload = message.normalizedPayload ?? {};
-  const severity = message.level || 'info';
-  const date = new Date(message.timestamp ?? Date.now());
-  const { fullTimestamp, timeDisplay, tooltipTimestamp } =
-    formatTimestamp(date);
+  const { normalizedPayload = {}, level = 'info', id, groupId, timestamp } = message;
+  const { fullTimestamp, timeDisplay, tooltipTimestamp } = formatTimestamp(
+    new Date(timestamp ?? Date.now()),
+  );
 
   const summaryText =
     (normalizedPayload.decodedText || message.text || '').trim() ||
     'Status update';
   const detailText = stringifyForDisplay(normalizedPayload.structured);
-  const emoji = EMOJI_BY_LEVEL[severity] || '•';
+  const emoji = EMOJI_BY_LEVEL[level] || '•';
 
   const container = document.createElement('div');
-  setElementDataset(container, {
-    logId: message.id,
-    groupId: message.groupId,
-    timestamp: fullTimestamp,
-  });
+  setElementDataset(container, { logId: id, groupId, timestamp: fullTimestamp });
 
   const summaryLine = document.createElement('div');
   summaryLine.className = 'log-line';
-  summaryLine.innerHTML = `<span class="timestamp" title="${tooltipTimestamp}">${emoji} [${timeDisplay}]</span> <span class="message-${severity}">${encodeHtml(summaryText)}</span>`;
+  summaryLine.innerHTML = `<span class="timestamp" title="${tooltipTimestamp}">${emoji} [${timeDisplay}]</span> <span class="message-${level}">${encodeHtml(summaryText)}</span>`;
   container.appendChild(summaryLine);
 
   if (detailText) {
     const detailLine = document.createElement('pre');
-    detailLine.className = `log-line message-${severity}`;
+    detailLine.className = `log-line message-${level}`;
     detailLine.textContent = detailText;
     container.appendChild(detailLine);
   }
@@ -86,10 +81,10 @@ export const formatProgressStatus = (message) => {
  * @returns {HTMLElement|null} Error banner element or null
  */
 export const formatError = (message) => {
-  const normalizedPayload = message.normalizedPayload ?? {};
-  const date = new Date(message.timestamp ?? Date.now());
-  const { fullTimestamp, timeDisplay, tooltipTimestamp } =
-    formatTimestamp(date);
+  const { normalizedPayload = {}, id, groupId, timestamp } = message;
+  const { fullTimestamp, timeDisplay, tooltipTimestamp } = formatTimestamp(
+    new Date(timestamp ?? Date.now()),
+  );
 
   const summaryText =
     (normalizedPayload.decodedText || message.text || '').trim() ||
@@ -118,8 +113,8 @@ export const formatError = (message) => {
   const detailText = detailLines.join('\n');
 
   const bannerEntry = createBannerEntry({
-    logId: message.id,
-    groupId: message.groupId,
+    logId: id,
+    groupId,
     timestamp: fullTimestamp,
     iconClass: 'codicon-error',
     labelText: `[${timeDisplay}] ${summaryText}`,

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -208,6 +208,7 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
    */
   _clearRunScopedState(stream) {
     if (stream) {
+      // Clear stream-specific state
       state.clearExecutionIdAvailability(stream);
       state.clearActiveRun(stream);
       state.clearRunInstructions(stream);
@@ -219,6 +220,7 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       state.clearContextState(stream);
       state.clearFollowUpText(stream);
     } else {
+      // Clear all state
       state.resetExecutionIdAvailability();
       state.clearAllActiveRuns();
       state.clearRunInstructions();
@@ -290,29 +292,23 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
    * @param {Object} message - Message containing runInstructions, runUsage, runFiles, contextState
    */
   _updateRunMetadata(stream, message) {
-    // Apply run-scoped metadata
-    this._applyRunData(stream, message.runInstructions, state.setRunInstruction);
-    this._applyRunData(stream, message.runUsage, state.setRunUsage);
-    this._applyRunData(stream, message.runFiles, state.setRunFiles);
+    // Apply run-scoped metadata (runId → value mappings)
+    const runDataSources = [
+      [message.runInstructions, state.setRunInstruction],
+      [message.runUsage, state.setRunUsage],
+      [message.runFiles, state.setRunFiles],
+    ];
+
+    for (const [data, setter] of runDataSources) {
+      if (!data) continue;
+      for (const [runId, value] of Object.entries(data)) {
+        if (runId) setter.call(state, stream, runId, value);
+      }
+    }
 
     // Context state is stream-scoped (not run-scoped)
     if (message.contextState) {
       state.setContextState(stream, message.contextState);
-    }
-  }
-
-  /**
-   * Apply run-scoped data using a setter function.
-   * @param {string} stream - The stream to update
-   * @param {Object|undefined} data - Data object keyed by runId
-   * @param {Function} setter - Setter function (stream, runId, value) => void
-   */
-  _applyRunData(stream, data, setter) {
-    if (!data) return;
-    for (const [runId, value] of Object.entries(data)) {
-      if (runId) {
-        setter.call(state, stream, runId, value);
-      }
     }
   }
 

--- a/src/progressView/modules/progressViewState.js
+++ b/src/progressView/modules/progressViewState.js
@@ -125,6 +125,7 @@ class TaskGroups {
 
 /**
  * Manages stream status information.
+ * Stores only non-ready statuses; 'ready' and falsy values trigger deletion.
  */
 class StreamStatuses {
   constructor() {
@@ -136,14 +137,13 @@ class StreamStatuses {
   }
 
   set(stream, status) {
-    if (!stream) {
-      return;
-    }
+    if (!stream) return;
+    // Only store meaningful statuses; 'ready' is the default state
     if (!status || status === 'ready') {
       this.statuses.delete(stream);
-      return;
+    } else {
+      this.statuses.set(stream, status);
     }
-    this.statuses.set(stream, status);
   }
 
   delete(stream) {

--- a/src/progressView/streamInfoUtils.ts
+++ b/src/progressView/streamInfoUtils.ts
@@ -46,6 +46,66 @@ function matchesFilter(
 }
 
 /**
+ * Build a StreamTabInfo object for a single stream ID.
+ * Returns null if the stream doesn't match the filter.
+ */
+function buildStreamInfo(
+  state: ProgressViewState,
+  id: string,
+  statuses: Map<string, string> | undefined,
+  filter: AgentFilter,
+): StreamTabInfo | null {
+  const taskState = state.getTaskState(id);
+  const hints = state.getStreamHints(id);
+  const logs = state.streamTabs.getMessages(id);
+  const lastTimestamp = logs.length > 0 ? logs.at(-1)?.timestamp : undefined;
+  const creationTimestamp = logs.length > 0 ? logs[0].timestamp : undefined;
+  const inputFile = taskState?.agentConfig.inputFile ?? '';
+  const rawAgentName = taskState?.agentConfig.agent ?? id.split('@')[0];
+  const agentName = getCleanAgentName(rawAgentName);
+  const rawCategory =
+    taskState?.agentConfig.session?.agentCategory ?? hints.sessionCategory;
+
+  const sessionCategory = matchesFilter(rawCategory, filter);
+  if (sessionCategory === null) {
+    return null;
+  }
+
+  const agentType =
+    taskState?.agentConfig.session?.agentType ??
+    taskState?.agentConfig.agentType;
+  const isToolAgent = sessionCategory === AgentCategory.ToolUse;
+  const isRemote = taskState
+    ? isRemoteAgent(rawAgentName)
+    : (hints.isRemote ?? false);
+  const executionId = state.getExecutionId(id);
+
+  const label =
+    sessionCategory !== AgentCategory.ToolUse && inputFile
+      ? `${agentName}: ${path.basename(inputFile)}`
+      : agentName;
+
+  return {
+    name: id,
+    label,
+    model: taskState?.agentConfig.model,
+    agent: taskState?.agentConfig.agent,
+    agentType,
+    agentSessionKind: sessionCategory,
+    uiTraits: { sessionKind: sessionCategory, isToolAgent },
+    hasMultipleOutputs: taskState
+      ? taskState.agentConfig.useMultipleOutputs
+      : (hints.hasMultipleOutputs ?? false),
+    isRemote,
+    lastTimestamp,
+    inputFile,
+    creationTimestamp,
+    status: statuses?.get(id),
+    executionId,
+  };
+}
+
+/**
  * Build metadata objects for all streams in the given state.
  */
 export function buildStreamInfos(
@@ -53,68 +113,10 @@ export function buildStreamInfos(
   statuses?: Map<string, string>,
   filter: AgentFilter = 'all',
 ): StreamTabInfo[] {
-  const infos = state.streamTabs.keys().reduce<StreamTabInfo[]>((acc, id) => {
-    const taskState = state.getTaskState(id);
-    const hints = state.getStreamHints(id);
-    const logs = state.streamTabs.getMessages(id);
-    const lastTimestamp = logs.length > 0 ? logs.at(-1)?.timestamp : undefined;
-    const creationTimestamp = logs.length > 0 ? logs[0].timestamp : undefined;
-    const inputFile = taskState?.agentConfig.inputFile ?? '';
-    // Extract clean agent name (strip source: prefix if present)
-    const rawAgentName = taskState?.agentConfig.agent ?? id.split('@')[0];
-    const agentName = getCleanAgentName(rawAgentName);
-    const rawCategory =
-      taskState?.agentConfig.session?.agentCategory ?? hints.sessionCategory;
-
-    // Filter check: returns resolved category or null if filtered out
-    const sessionCategory = matchesFilter(rawCategory, filter);
-    if (sessionCategory === null) {
-      return acc;
-    }
-
-    const agentType =
-      taskState?.agentConfig.session?.agentType ??
-      taskState?.agentConfig.agentType;
-    const isToolAgent = sessionCategory === AgentCategory.ToolUse;
-    // When taskState is available, rawAgentName has the full key (e.g., "remote:generic")
-    // and isRemoteAgent can reliably determine the source. When taskState is null,
-    // rawAgentName is just the clean name from the stream ID, so fall back to the hint.
-    const isRemote = taskState
-      ? isRemoteAgent(rawAgentName)
-      : (hints.isRemote ?? false);
-    const executionId = state.getExecutionId(id);
-
-    // Build label: tool-use shows agent only, workflows show agent + file basename
-    let label = agentName;
-    if (sessionCategory !== AgentCategory.ToolUse && inputFile) {
-      label = `${agentName}: ${path.basename(inputFile)}`;
-    }
-
-    acc.push({
-      name: id,
-      label,
-      model: taskState?.agentConfig.model,
-      agent: taskState?.agentConfig.agent,
-      agentType,
-      agentSessionKind: sessionCategory,
-      uiTraits: {
-        sessionKind: sessionCategory,
-        isToolAgent,
-      },
-      // useMultipleOutputs is the single source of truth (workflow-only concept).
-      // When taskState is null, fall back to the hint from setActiveStream event.
-      hasMultipleOutputs: taskState
-        ? taskState.agentConfig.useMultipleOutputs
-        : (hints.hasMultipleOutputs ?? false),
-      isRemote,
-      lastTimestamp,
-      inputFile,
-      creationTimestamp,
-      status: statuses?.get(id),
-      executionId,
-    });
-    return acc;
-  }, []);
+  const infos = state.streamTabs
+    .keys()
+    .map((id) => buildStreamInfo(state, id, statuses, filter))
+    .filter((info): info is StreamTabInfo => info !== null);
 
   const comparator = sortComparators[state.streamSortOrder];
   if (comparator) {


### PR DESCRIPTION
- Inline WebviewUpdater.computeInstructionMetadata into createInstructionUpdate
- Simplify handleUpdateLogMessage field updates using Object.assign
- Replace reduce with filter().map() in buildStreamInfos for readability
- Extract buildStreamInfo helper function for single-stream metadata
- Consolidate _updateRunMetadata using data-driven loop pattern
- Simplify for...of loop in refreshStreamSurface for missing outputs
- Apply destructuring in formatProgressStatus and formatError
- Improve StreamStatuses.set with clearer conditional structure

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves readability and consistency across progress view backend and frontend with targeted refactors.
> 
> - Inlines instruction metadata logic in `WebviewUpdater.createInstructionUpdate` and removes the separate helper
> - Simplifies `handleUpdateLogMessage` by `Object.assign`-ing updates (excluding `id`) and keeps INTERNAL messages untouched
> - Sends missing outputs in sequence after a `reset` in `refreshStreamSurface`, reducing race potential
> - Extracts `buildStreamInfo` and rewrites `buildStreamInfos` using `map`/`filter` for clarity; preserves sort behavior
> - Consolidates run-scoped metadata updates in `_updateRunMetadata` via a data-driven loop; removes `_applyRunData`
> - Cleans up frontend formatters (`formatProgressStatus`, `formatError`) using destructuring and consistent `level`/dataset usage
> - Updates `StreamStatuses.set` to store only non-`ready` statuses and early-return on falsy stream
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1a9b8f9ca4341470f1f59650bc1d878e7264eb3d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->