### PR TITLE
Fix extension reload deleting persisted records

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -204,10 +204,17 @@ export async function activate(context: vscode.ExtensionContext) {
   // Log activation message to ensure the logger is working correctly
   logger.info('extension', 'TeXRA extension activated');
 
-  // Clean up UI state: mark running streams as ERROR.
-  // Note: Waiting stream detection is now lazy - happens when user sends follow-up.
-  // See followUpCommand.ts lazyDetectWaitingStatus() for details.
-  await progressViewProvider.cleanupTasksAfterRestart();
+  // Detect waiting streams BEFORE cleanup to preserve resumable sessions.
+  // This ensures streams with persisted flow records are marked WAITING (not ERROR),
+  // preventing loss of ability to resume interrupted sessions.
+  const { detectWaitingStreams } = await import(
+    '@agent/storage/detectWaitingStreams'
+  );
+  const executionIdMap = progressViewProvider.state.getAllExecutionIds();
+  const waitingStreams = await detectWaitingStreams(executionIdMap);
+
+  // Clean up UI state: mark running streams as ERROR (except waiting ones).
+  await progressViewProvider.cleanupTasksAfterRestart(waitingStreams);
 
   // Configure LaTeX settings if LaTeX Workshop is installed
   configureLatexSettings();

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -864,11 +864,32 @@ export class ProgressEventHandler {
   /**
    * Reset running tasks to ERROR status (used during webview reload)
    * Returns the list of affected streams for further processing
+   *
+   * Also sets WAITING status for streams with persisted flow records,
+   * ensuring resumable sessions are properly marked on extension reload.
    */
   resetRunningTasksToError(waitingStreams?: Set<string>): string[] {
     const affectedStreams: string[] = [];
     const waitingSet = waitingStreams ?? new Set<string>();
 
+    // First: Mark streams with persisted flow records as WAITING.
+    // This is critical on extension reload when StreamStatusService is empty.
+    // Without this, users don't know which sessions can be resumed.
+    for (const stream of waitingSet) {
+      const currentStatus = StreamStatusService.get(stream);
+      // Only set WAITING if not already RUNNING or WAITING
+      if (
+        currentStatus !== STREAM_STATUS.RUNNING &&
+        currentStatus !== STREAM_STATUS.WAITING
+      ) {
+        StreamStatusService.set(stream, STREAM_STATUS.WAITING, { emit: false });
+        this.logger.debug(
+          `Stream ${stream} set to WAITING (has persisted flow record)`,
+        );
+      }
+    }
+
+    // Second: Handle streams that were RUNNING but shouldn't be WAITING
     for (const [stream, status] of StreamStatusService.entries()) {
       if (status === STREAM_STATUS.RUNNING) {
         if (waitingSet.has(stream)) {


### PR DESCRIPTION
…able sessions

On extension reload, flow records were being preserved but streams weren't being marked as WAITING, causing users to lose the ability to resume interrupted sessions.

Changes:
- Detect streams with persisted flow records at extension startup
- Mark those streams as WAITING instead of ERROR
- This ensures users can see and resume interrupted tool-use and workflow sessions after VS Code reloads

The fix works by calling detectWaitingStreams() before cleanupTasksAfterRestart() and passing the waiting streams set so they are properly marked instead of defaulting to ERROR status.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures resumable sessions survive VS Code reloads by recognizing persisted streams and preventing them from being marked as ERROR.
> 
> - In `extension.ts`, call `detectWaitingStreams()` before cleanup, pass the resulting set to `cleanupTasksAfterRestart(waitingStreams)`
> - Update `ProgressEventHandler.resetRunningTasksToError(waitingStreams)` to pre-mark streams in the waiting set as `WAITING` and only set `ERROR` for prior `RUNNING` streams not in the waiting set
> - Add debug logging for state transitions (WAITING/ERROR) to aid diagnostics
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b707adf447bad2463113ee3d1f00d0ca4f7dec3d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->