### PR TITLE
Simplify and improve code clarity

### DIFF
--- a/src/agent/implementations/flows/reflection/nodes/OutputNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/OutputNode.ts
@@ -178,22 +178,15 @@ export class OutputNode<C = unknown> extends Node<
   ): Promise<void> {
     const { outputHandler, logger } = this.services;
 
-    // Check if any base files exist
     const existingBase = await Promise.all(
-      baseFiles.map(async (f) => await flexibleFS.exists(f)),
+      baseFiles.map((f) => flexibleFS.exists(f)),
     );
-
-    if (!existingBase.some((e) => e)) {
+    if (!existingBase.some(Boolean)) {
       logger.debug('No base files found for latexdiff');
       return;
     }
 
     const mapping = outputHandler.getRoundMapping(currentRound);
-    if (!mapping) {
-      logger.debug('No round mapping found for latexdiff');
-      return;
-    }
-
     await outputHandler.diffManager.handleLatexdiffofOutput(
       currentRound,
       mapping,

--- a/src/agent/output/LatexDiffManager.ts
+++ b/src/agent/output/LatexDiffManager.ts
@@ -146,217 +146,208 @@ export class LatexDiffManager {
     mapping: RoundFileMapping,
     stage?: AgentLogStage,
   ): Promise<void> {
-    const generateBetweenRoundDiffs = this.dependencies.getConfig<boolean>(
-      'texra.latexdiff.generateBetweenRoundDiffs',
-      false,
-    );
-    const aggregated: DiffOperationResult[] = [];
-
-    const execute = async () => {
-      if (!(await this.dependencies.checkToolInstalled('latexdiff'))) {
-        this.logger.warn(
-          'Skipping latexdiff operations - latexdiff not installed',
-        );
-        return;
-      }
-
-      const outputFiles = this.getOutputFiles()[currRound] ?? [];
-      const outputPaths = outputFiles.map(
-        (entry) => entry.location.absolutePath,
-      );
-      if (outputPaths.length === 0) {
-        this.logger.warn(
-          `No output files found for round ${currRound}, skipping latexdiff operations`,
-        );
-        return;
-      }
-
-      this.logger.debug(
-        `Base files: ${this.baseFiles.map((f) => f.absolutePath).join(', ')}`,
-      );
-      this.logger.debug(`r${currRound} output files: ${outputPaths}`);
-
-      const basePairs = [...mapping.baseToOutput.entries()];
-      if (basePairs.length > 0) {
-        this.logger.debug(
-          `Matched base files to output files: ${basePairs
-            .map(
-              ([outputPath, base]) =>
-                `${this.getDisplayLabel(base)} -> ${path.basename(outputPath)}`,
-            )
-            .join(', ')}`,
-        );
-      } else if (this.baseFiles.length > 0) {
-        this.logger.debug(
-          'No base file mappings found for current round outputs',
-        );
-      }
-
-      if (this.agentSetting.isRewrite) {
-        this.logger.debug('Running round-based latexdiff operations');
-        for (const [outputPath, baseLocation] of basePairs) {
-          // Find the revised/output FileLocation from current round outputs
-          const revisedLocation = outputFiles.find(
-            (o: OutputFileInfo) => getComparablePath(o.location) === outputPath,
-          )?.location;
-          if (!revisedLocation) {
-            this.logger.debug(
-              `Skipping diff: output file not found for path ${outputPath}`,
-            );
-            continue;
-          }
-          await this.ensureWorkspaceDependency(baseLocation);
-          await this.ensureWorkspaceDependency(revisedLocation);
-
-          // Use revised file's directory as cwd so latexdiff can resolve relative includes
-          const cwd = await this.getWorkingDirectory(revisedLocation);
-
-          const result = await this.latexdiffService.runDiffForRound(
-            baseLocation,
-            revisedLocation,
-            currRound,
-            undefined,
-            { cwd },
-          );
-          this.logLatexdiffResult(result, 'round-diff');
-          let diffLocation: FileLocation | undefined;
-
-          if (result.success && result.diffFileName) {
-            // Create diff location using fileService - it knows whether to use workspace or run storage
-            const baseRelDir = getFileDirectory(baseLocation);
-            const diffRelativePath = path.join(baseRelDir, result.diffFileName);
-
-            // This automatically uses run storage if enabled, workspace otherwise
-            diffLocation = this.fileService.createLocation(diffRelativePath);
-
-            const buildDir = path.join(
-              path.dirname(diffLocation.absolutePath),
-              'build',
-            );
-            await this.dependencies.compileLatex2Pdf(
-              diffLocation,
-              this.channel,
-              buildDir,
-              true,
-            );
-          }
-
-          aggregated.push({
-            baseLabel: this.getDisplayLabel(baseLocation),
-            revisedLabel: this.getDisplayLabel(revisedLocation),
-            status: result.success ? 'success' : 'error',
-            message: result.success ? undefined : result.message,
-            locations: {
-              base: baseLocation,
-              revised: revisedLocation,
-              diff: diffLocation ?? null,
-            },
-          });
-        }
-      }
-
-      if (generateBetweenRoundDiffs && currRound > 0) {
-        this.logger.debug('Running between-rounds latexdiff operations');
-        const prevPairs = [...mapping.prevToOutput.entries()];
-
-        if (prevPairs.length > 0) {
-          this.logger.debug(
-            `Matched previous round files to current round files: ${prevPairs
-              .map(
-                ([outputPath, prev]) =>
-                  `${this.getDisplayLabel(prev)} -> ${path.basename(outputPath)}`,
-              )
-              .join(', ')}`,
-          );
-        } else {
-          this.logger.debug(
-            'No previous round mappings found for current round outputs',
-          );
-        }
-
-        for (const [outputPath, prevLocation] of prevPairs) {
-          // Find the current round FileLocation from current round outputs
-          const currLocation = outputFiles.find(
-            (o: OutputFileInfo) => getComparablePath(o.location) === outputPath,
-          )?.location;
-
-          if (!currLocation) {
-            this.logger.debug(
-              `Skipping diff: current round file not found for path ${outputPath}`,
-            );
-            continue;
-          }
-          await this.ensureWorkspaceDependency(prevLocation);
-          await this.ensureWorkspaceDependency(currLocation);
-
-          // Use current file's directory as cwd so latexdiff can resolve relative includes
-          const cwd = await this.getWorkingDirectory(currLocation);
-          const result = await this.latexdiffService.runDiffBetweenRounds(
-            prevLocation,
-            currLocation,
-            undefined,
-            { cwd },
-          );
-          this.logLatexdiffResult(result, 'between-rounds-diff');
-          let diffLocation: FileLocation | undefined;
-
-          if (result.success && result.diffFileName) {
-            // Create diff location using fileService - it knows whether to use workspace or run storage
-            const refLocation = prevLocation ?? currLocation;
-            const refRelDir = getFileDirectory(refLocation);
-            const diffRelativePath = path.join(refRelDir, result.diffFileName);
-
-            // This automatically uses run storage if enabled, workspace otherwise
-            diffLocation = this.fileService.createLocation(diffRelativePath);
-
-            const buildDir = path.join(
-              path.dirname(diffLocation.absolutePath),
-              'build',
-            );
-            await this.dependencies.compileLatex2Pdf(
-              diffLocation,
-              this.channel,
-              buildDir,
-              true,
-            );
-          }
-
-          aggregated.push({
-            baseLabel: this.getDisplayLabel(prevLocation),
-            revisedLabel: this.getDisplayLabel(currLocation),
-            status: result.success ? 'success' : 'error',
-            message: result.success ? undefined : result.message,
-            locations: {
-              base: prevLocation ?? null,
-              revised: currLocation ?? null,
-              diff: diffLocation ?? null,
-            },
-          });
-        }
-      } else if (!generateBetweenRoundDiffs) {
-        this.logger.debug(
-          'Skipping between-round latexdiff operations: disabled in settings',
-        );
-      }
-
-      if (aggregated.length > 0) {
-        this.logger.latexDiff(aggregated);
-      } else {
-        this.logger.debug('No latexdiff results to report');
-      }
-    };
+    const execute = () =>
+      this.performLatexdiffOperations(currRound, mapping);
 
     try {
-      if (stage) {
-        await stage.within(execute);
-      } else {
-        await execute();
-      }
+      await (stage ? stage.within(execute) : execute());
     } catch (err) {
       this.logger.error(
         `Error during latexdiff processing: ${toErrorMessage(err)}`,
         { messageType: MESSAGE_TYPES.INTERNAL },
       );
     }
+  }
+
+  private async performLatexdiffOperations(
+    currRound: number,
+    mapping: RoundFileMapping,
+  ): Promise<void> {
+    if (!(await this.dependencies.checkToolInstalled('latexdiff'))) {
+      this.logger.warn(
+        'Skipping latexdiff operations - latexdiff not installed',
+      );
+      return;
+    }
+
+    const outputFiles = this.getOutputFiles()[currRound] ?? [];
+    const outputPaths = outputFiles.map(
+      (entry) => entry.location.absolutePath,
+    );
+    if (outputPaths.length === 0) {
+      this.logger.warn(
+        `No output files found for round ${currRound}, skipping latexdiff operations`,
+      );
+      return;
+    }
+
+    this.logger.debug(
+      `Base files: ${this.baseFiles.map((f) => f.absolutePath).join(', ')}`,
+    );
+    this.logger.debug(`r${currRound} output files: ${outputPaths}`);
+
+    const basePairs = [...mapping.baseToOutput.entries()];
+    if (basePairs.length > 0) {
+      this.logger.debug(
+        `Matched base files to output files: ${basePairs
+          .map(
+            ([outputPath, base]) =>
+              `${this.getDisplayLabel(base)} -> ${path.basename(outputPath)}`,
+          )
+          .join(', ')}`,
+      );
+    } else if (this.baseFiles.length > 0) {
+      this.logger.debug(
+        'No base file mappings found for current round outputs',
+      );
+    }
+
+    const aggregated: DiffOperationResult[] = [];
+
+    if (this.agentSetting.isRewrite) {
+      this.logger.debug('Running round-based latexdiff operations');
+      for (const [outputPath, baseLocation] of basePairs) {
+        const revisedLocation = outputFiles.find(
+          (o: OutputFileInfo) => getComparablePath(o.location) === outputPath,
+        )?.location;
+        if (!revisedLocation) {
+          this.logger.debug(
+            `Skipping diff: output file not found for path ${outputPath}`,
+          );
+          continue;
+        }
+        await this.ensureWorkspaceDependency(baseLocation);
+        await this.ensureWorkspaceDependency(revisedLocation);
+
+        const cwd = await this.getWorkingDirectory(revisedLocation);
+        const result = await this.latexdiffService.runDiffForRound(
+          baseLocation,
+          revisedLocation,
+          currRound,
+          undefined,
+          { cwd },
+        );
+        this.logLatexdiffResult(result, 'round-diff');
+
+        const diffLocation = await this.compileDiffIfSuccessful(
+          result,
+          baseLocation,
+        );
+
+        aggregated.push({
+          baseLabel: this.getDisplayLabel(baseLocation),
+          revisedLabel: this.getDisplayLabel(revisedLocation),
+          status: result.success ? 'success' : 'error',
+          message: result.success ? undefined : result.message,
+          locations: {
+            base: baseLocation,
+            revised: revisedLocation,
+            diff: diffLocation,
+          },
+        });
+      }
+    }
+
+    const generateBetweenRoundDiffs = this.dependencies.getConfig<boolean>(
+      'texra.latexdiff.generateBetweenRoundDiffs',
+      false,
+    );
+
+    if (generateBetweenRoundDiffs && currRound > 0) {
+      this.logger.debug('Running between-rounds latexdiff operations');
+      const prevPairs = [...mapping.prevToOutput.entries()];
+
+      if (prevPairs.length > 0) {
+        this.logger.debug(
+          `Matched previous round files to current round files: ${prevPairs
+            .map(
+              ([outputPath, prev]) =>
+                `${this.getDisplayLabel(prev)} -> ${path.basename(outputPath)}`,
+            )
+            .join(', ')}`,
+        );
+      } else {
+        this.logger.debug(
+          'No previous round mappings found for current round outputs',
+        );
+      }
+
+      for (const [outputPath, prevLocation] of prevPairs) {
+        const currLocation = outputFiles.find(
+          (o: OutputFileInfo) => getComparablePath(o.location) === outputPath,
+        )?.location;
+
+        if (!currLocation) {
+          this.logger.debug(
+            `Skipping diff: current round file not found for path ${outputPath}`,
+          );
+          continue;
+        }
+        await this.ensureWorkspaceDependency(prevLocation);
+        await this.ensureWorkspaceDependency(currLocation);
+
+        const cwd = await this.getWorkingDirectory(currLocation);
+        const result = await this.latexdiffService.runDiffBetweenRounds(
+          prevLocation,
+          currLocation,
+          undefined,
+          { cwd },
+        );
+        this.logLatexdiffResult(result, 'between-rounds-diff');
+
+        const diffLocation = await this.compileDiffIfSuccessful(
+          result,
+          prevLocation ?? currLocation,
+        );
+
+        aggregated.push({
+          baseLabel: this.getDisplayLabel(prevLocation),
+          revisedLabel: this.getDisplayLabel(currLocation),
+          status: result.success ? 'success' : 'error',
+          message: result.success ? undefined : result.message,
+          locations: {
+            base: prevLocation ?? null,
+            revised: currLocation ?? null,
+            diff: diffLocation,
+          },
+        });
+      }
+    } else if (!generateBetweenRoundDiffs) {
+      this.logger.debug(
+        'Skipping between-round latexdiff operations: disabled in settings',
+      );
+    }
+
+    if (aggregated.length > 0) {
+      this.logger.latexDiff(aggregated);
+    } else {
+      this.logger.debug('No latexdiff results to report');
+    }
+  }
+
+  private async compileDiffIfSuccessful(
+    result: LaTeXdiffResult,
+    referenceLocation: FileLocation,
+  ): Promise<FileLocation | null> {
+    if (!result.success || !result.diffFileName) {
+      return null;
+    }
+
+    const refRelDir = getFileDirectory(referenceLocation);
+    const diffRelativePath = path.join(refRelDir, result.diffFileName);
+    const diffLocation = this.fileService.createLocation(diffRelativePath);
+
+    const buildDir = path.join(
+      path.dirname(diffLocation.absolutePath),
+      'build',
+    );
+    await this.dependencies.compileLatex2Pdf(
+      diffLocation,
+      this.channel,
+      buildDir,
+      true,
+    );
+
+    return diffLocation;
   }
 }

--- a/src/agent/output/OutputFileProcessor.ts
+++ b/src/agent/output/OutputFileProcessor.ts
@@ -27,6 +27,9 @@ import {
 import type { XmlOutputManager } from './XmlOutputManager';
 import type { OutputFileInfo, OutputXmlSummary } from './types';
 
+/** Pattern to detect scratchpad XML tags in prefills */
+const SCRATCHPAD_TAG_PATTERN = /<scratchpad\s*>/i;
+
 export interface ProcessingContext {
   agentSetting: AgentWorkflowSetting;
   baseFiles: FileLocation[];
@@ -126,7 +129,7 @@ export class OutputFileProcessor {
 
       const hasScratchpadPrefill =
         agentSetting.prefills?.some((prefill) =>
-          /<scratchpad\s*>/i.test(prefill),
+          SCRATCHPAD_TAG_PATTERN.test(prefill),
         ) ?? false;
       const hasDocumentTag = Boolean(agentSetting.documentTag);
       const shouldProcessXml =
@@ -199,18 +202,17 @@ export class OutputFileProcessor {
   ): Promise<void> {
     const { agentSetting, logger } = this.ctx;
 
-    const run = async () => {
+    const execute = async () => {
       const singleFile =
         processed.length === 1 ? processed[0].location.absolutePath : null;
       const data = this.ctx.ensureRoundData(round);
-      const sourceLocation = rawOutput ?? null;
 
       if (!rawOutput?.absolutePath) {
         data.xmlSummary = {
           tagContents: {},
           documents: [],
           singleOutputFile: singleFile,
-          sourceLocation,
+          sourceLocation: rawOutput,
         };
         return;
       }
@@ -267,7 +269,7 @@ export class OutputFileProcessor {
           tagContents,
           documents,
           singleOutputFile: singleFile,
-          sourceLocation,
+          sourceLocation: rawOutput,
         };
       } catch (error) {
         logger.debug(
@@ -278,16 +280,11 @@ export class OutputFileProcessor {
           tagContents: {},
           documents: [],
           singleOutputFile: singleFile,
-          sourceLocation,
+          sourceLocation: rawOutput,
         };
       }
     };
 
-    if (stage) {
-      await stage.within(run);
-      return;
-    }
-
-    await run();
+    await (stage ? stage.within(execute) : execute());
   }
 }

--- a/src/agent/output/OutputHandler.ts
+++ b/src/agent/output/OutputHandler.ts
@@ -48,11 +48,9 @@ export class OutputHandler implements IOutputHandler {
   private rounds: Map<number, RoundData>;
 
   public get outputFiles(): { [key: number]: OutputFileInfo[] } {
-    const result: { [key: number]: OutputFileInfo[] } = {};
-    this.rounds.forEach((data, round) => {
-      result[round] = data.outputs;
-    });
-    return result;
+    return Object.fromEntries(
+      [...this.rounds].map(([round, data]) => [round, data.outputs]),
+    );
   }
 
   public baseFiles: FileLocation[];
@@ -120,7 +118,7 @@ export class OutputHandler implements IOutputHandler {
   }
 
   private collectRunSnapshotFiles(): FileLocation[] {
-    return this.baseFiles.filter((candidate) => candidate !== null);
+    return this.baseFiles;
   }
 
   private collectRunSupportFiles(): FileLocation[] {
@@ -255,12 +253,12 @@ export class OutputHandler implements IOutputHandler {
         const originalLocation =
           mapping.originByOutput.get(locationPath) ?? null;
 
-        const isSameFile =
+        // Use baseLocation for diff, or originalLocation if it's a different file
+        const originalIsDifferentFile =
           originalLocation &&
-          getComparablePath(originalLocation) === locationPath;
+          getComparablePath(originalLocation) !== locationPath;
         const diffBaseLocation =
-          baseLocation ??
-          (originalLocation && !isSameFile ? originalLocation : null);
+          baseLocation ?? (originalIsDifferentFile ? originalLocation : null);
 
         const stats = await this.diffStatsManager.computeDiffStats(
           diffBaseLocation,
@@ -373,8 +371,7 @@ export class OutputHandler implements IOutputHandler {
       stage,
       async (scope) => {
         const data = this.ensureRoundData(currRound);
-        const rawLocation = data.rawOutput ?? outputFile;
-        data.rawOutput = rawLocation;
+        data.rawOutput ??= outputFile;
 
         const fileInfos = await this.gatherOutputFileInfo(currRound);
         data.outputs = fileInfos;
@@ -433,8 +430,8 @@ export class OutputHandler implements IOutputHandler {
         await this.prepareRunWorkspaceIfNeeded();
 
         const data = this.ensureRoundData(currRound);
-        const rawLocation = data.rawOutput ?? outputLocation;
-        data.rawOutput = rawLocation;
+        data.rawOutput ??= outputLocation;
+        const rawLocation = data.rawOutput;
 
         if (
           Array.isArray(this.agentConfig.outputFiles) &&
@@ -462,20 +459,17 @@ export class OutputHandler implements IOutputHandler {
   }
 
   public async getRoundArtifacts(round: number): Promise<RoundOutput> {
-    const data = this.rounds.get(round);
-    let fileInfos = data?.outputs;
-    if (!fileInfos) {
-      fileInfos = await this.gatherOutputFileInfo(round);
-      const updatedData = this.ensureRoundData(round);
-      updatedData.outputs = fileInfos;
+    const data = this.ensureRoundData(round);
+
+    if (data.outputs.length === 0) {
+      data.outputs = await this.gatherOutputFileInfo(round);
     }
 
-    const roundData = this.rounds.get(round);
     return {
       round,
-      rawOutput: roundData?.rawOutput ?? null,
-      outputs: fileInfos,
-      xmlSummary: roundData?.xmlSummary ?? this.getRoundXmlSummary(round),
+      rawOutput: data.rawOutput,
+      outputs: data.outputs,
+      xmlSummary: data.xmlSummary,
     };
   }
 

--- a/src/agent/output/XmlOutputManager.ts
+++ b/src/agent/output/XmlOutputManager.ts
@@ -202,12 +202,27 @@ export class XmlOutputManager {
     thinkingTag: string = 'scratchpad',
   ): Promise<OutputFileInfo[]> {
     let outputContent = await AbsoluteFS.read(outputLocation.absolutePath);
-
-    // Count expected document tags before processing
     const expectedDocumentCount = this.countDocumentTags(outputContent);
 
     const tagsToWrap = [thinkingTag, 'document'];
     outputContent = addCdataToTagsMultiple(outputContent, tagsToWrap);
+
+    const tryFallbackExtraction = async (): Promise<OutputFileInfo[] | null> => {
+      const fallbackDocs = this.extractMultipleDocumentsbyRegex(
+        outputContent,
+        documentTag,
+      );
+      if (fallbackDocs) {
+        this.warnPartialExtraction(
+          outputLocation,
+          expectedDocumentCount,
+          fallbackDocs.length,
+        );
+        return this.processMultipleLatexDocuments(fallbackDocs, outputLocation);
+      }
+      this.warnPartialExtraction(outputLocation, expectedDocumentCount, 0);
+      return null;
+    };
 
     try {
       const parser = new XMLParser({
@@ -229,46 +244,17 @@ export class XmlOutputManager {
         );
         return this.processMultipleLatexDocuments(documents, outputLocation);
       }
+
       this.logger.debugInternal(
         `No ${documentTag} found in parsed XML, attempting fallback extraction...`,
       );
-      const fallbackDocuments = this.extractMultipleDocumentsbyRegex(
-        outputContent,
-        documentTag,
-      );
-      if (fallbackDocuments) {
-        this.warnPartialExtraction(
-          outputLocation,
-          expectedDocumentCount,
-          fallbackDocuments.length,
-        );
-        return this.processMultipleLatexDocuments(
-          fallbackDocuments,
-          outputLocation,
-        );
-      }
-      this.warnPartialExtraction(outputLocation, expectedDocumentCount, 0);
-      return [];
+      return (await tryFallbackExtraction()) ?? [];
     } catch (err) {
       this.logger.debugInternal(
         `Failed to parse XML content: ${toErrorMessage(err)}, attempting fallback extraction...`,
       );
-      const fallbackDocuments = this.extractMultipleDocumentsbyRegex(
-        outputContent,
-        documentTag,
-      );
-      if (fallbackDocuments) {
-        this.warnPartialExtraction(
-          outputLocation,
-          expectedDocumentCount,
-          fallbackDocuments.length,
-        );
-        return this.processMultipleLatexDocuments(
-          fallbackDocuments,
-          outputLocation,
-        );
-      }
-      this.warnPartialExtraction(outputLocation, expectedDocumentCount, 0);
+      const result = await tryFallbackExtraction();
+      if (result) return result;
       throw err;
     }
   }


### PR DESCRIPTION
- Simplify OutputHandler.outputFiles getter using Object.fromEntries
- Remove redundant null filter in collectRunSnapshotFiles
- Clarify gatherOutputFileInfo diffBase logic with positive condition name
- Extract SCRATCHPAD_TAG_PATTERN constant in OutputFileProcessor
- Simplify captureXmlSummary stage execution pattern
- Extract LatexDiffManager core logic to performLatexdiffOperations, consolidate diff compilation to compileDiffIfSuccessful helper
- Simplify OutputNode.handleLatexdiff base file check
- Consolidate XmlOutputManager fallback extraction with async helper
- Simplify OutputHandler.getRoundArtifacts null handling using ensureRoundData
- Use nullish assignment (??=) for rawOutput initialization

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves clarity and robustness across output processing and diffing.
> 
> - Extracts `performLatexdiffOperations` and `compileDiffIfSuccessful` in `LatexDiffManager`, adds staged execution wrapper, clearer logging, and skips when `latexdiff` or outputs are unavailable
> - Simplifies `OutputNode.handleLatexdiff` base-file existence check and removes unnecessary mapping guard
> - Consolidates XML fallback extraction with an async helper in `XmlOutputManager`, adds document-count warnings, and preserves behavior on parser failure
> - Introduces `SCRATCHPAD_TAG_PATTERN` in `OutputFileProcessor`; simplifies `captureXmlSummary` stage handling and consistently sets `sourceLocation`
> - Uses nullish assignment (`??=`) for `rawOutput` initialization and simplifies getters/collection logic in `OutputHandler` (`outputFiles`, run snapshot files, `getRoundArtifacts`)
> - Clarifies diff base selection in `gatherOutputFileInfo` (prefer `baseLocation`, otherwise `originalLocation` when different)
> - Minor logging and control-flow cleanups (e.g., early returns, boolean checks)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f716efa6b42656e5d3ccc2c31481b562a0448b8b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->