### PR TITLE
Simplify and improve code clarity

### DIFF
--- a/src/agent/core/AgentWorkspaceState.ts
+++ b/src/agent/core/AgentWorkspaceState.ts
@@ -122,29 +122,16 @@ export class FileInteractionState {
       const path = entry?.path;
       if (!path) continue;
 
-      const deltaAdded = entry.lineChanges?.added ?? 0;
-      const deltaRemoved = entry.lineChanges?.removed ?? 0;
+      const added = entry.lineChanges?.added ?? 0;
+      const removed = entry.lineChanges?.removed ?? 0;
 
       // Update cumulative edits
-      const cumulative = this.edits.get(path);
-      if (cumulative) {
-        cumulative.added += deltaAdded;
-        cumulative.removed += deltaRemoved;
-      } else {
-        this.edits.set(path, { added: deltaAdded, removed: deltaRemoved });
-      }
-
+      this.updateEditMap(this.edits, path, added, removed);
       // Update per-call edits
-      const current = perCallEdits.get(path);
-      if (current) {
-        current.added += deltaAdded;
-        current.removed += deltaRemoved;
-      } else {
-        perCallEdits.set(path, { added: deltaAdded, removed: deltaRemoved });
-      }
+      this.updateEditMap(perCallEdits, path, added, removed);
 
-      totalAdded += deltaAdded;
-      totalRemoved += deltaRemoved;
+      totalAdded += added;
+      totalRemoved += removed;
     }
 
     const editsForCall = [...perCallEdits.entries()].map(([path, diff]) => ({
@@ -155,11 +142,28 @@ export class FileInteractionState {
           : undefined,
     }));
 
-    const lineChanges =
-      totalAdded || totalRemoved
-        ? { added: totalAdded, removed: totalRemoved }
-        : undefined;
-    return { edits: editsForCall, lineChanges };
+    return {
+      edits: editsForCall,
+      lineChanges:
+        totalAdded || totalRemoved
+          ? { added: totalAdded, removed: totalRemoved }
+          : undefined,
+    };
+  }
+
+  private updateEditMap(
+    map: Map<string, { added: number; removed: number }>,
+    path: string,
+    added: number,
+    removed: number,
+  ): void {
+    const existing = map.get(path);
+    if (existing) {
+      existing.added += added;
+      existing.removed += removed;
+    } else {
+      map.set(path, { added, removed });
+    }
   }
 }
 
@@ -443,11 +447,14 @@ export class AgentWorkspaceState {
   /** Serialize to a snapshot. */
   toSnapshot(): AgentWorkspaceSnapshot {
     return {
-      assembly: { ...this.assembly },
+      assembly: {
+        lastResponse: this.assembly.lastResponse,
+        accumulatedOutput: this.assembly.accumulatedOutput,
+      },
       media: this.media.toSnapshot(),
       reasoning: {
-        ...this.reasoning,
         thinkingBlocks: [...this.reasoning.thinkingBlocks],
+        thinkingAdded: this.reasoning.thinkingAdded,
       },
       interactions: this.interactions.toSnapshot(),
       todos: this.todos.toSnapshot(),

--- a/src/agent/core/flows/CommonCycleTypes.ts
+++ b/src/agent/core/flows/CommonCycleTypes.ts
@@ -185,7 +185,12 @@ export function resetCycleState<T extends BaseCycleFields>(
   state: T,
   additionalFields: (keyof T)[] = [],
 ): void {
-  Object.assign(state, BASE_CYCLE_RESET_VALUES);
+  state.shouldStop = false;
+  state.endTurn = false;
+  state.responseTimeMs = undefined;
+  state.stopReason = undefined;
+  state.lastError = undefined;
+
   for (const field of additionalFields) {
     state[field] = undefined as T[typeof field];
   }

--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -147,22 +147,17 @@ export type ResponseCycleShared = CycleFields & CycleTransientFields;
 export function assertCycleFieldsPopulated<T extends object>(
   shared: T,
 ): asserts shared is T & ResponseCycleShared {
-  // Required fields that must be defined (not undefined)
-  const requiredDefined = [
-    'messages',
-    'shouldStop',
-    'endTurn',
-    'outputExists',
-  ] as const;
   const obj = shared as Record<string, unknown>;
-  for (const field of requiredDefined) {
+  const requiredFields = ['messages', 'shouldStop', 'endTurn', 'outputExists'];
+
+  for (const field of requiredFields) {
     if (obj[field] === undefined) {
       throw new Error(
         `Cycle field '${field}' must be populated before running cycle flow`,
       );
     }
   }
-  // outputLocation must be non-null (downstream code uses it directly)
+
   if (obj['outputLocation'] === undefined || obj['outputLocation'] === null) {
     throw new Error(
       `Cycle field 'outputLocation' must be set to a valid location before running cycle flow`,

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -73,9 +73,11 @@ function parseToolInput(
     logger.warn(`Tool call ${callId}: Received null input, using empty object`);
     return {};
   }
+
   if (typeof raw !== 'string') {
-    return raw; // Objects, arrays, primitives pass through directly
+    return raw;
   }
+
   try {
     return JSON.parse(raw);
   } catch {
@@ -109,29 +111,20 @@ function normalizeToolCallError(
   toolName: string,
   error: unknown,
 ): { message: string; diagnostics?: ValidationErrorDiagnostics } {
-  if (hasZodIssues(error)) {
-    // Cast issues to ZodIssue-like for the shared formatter
-    const issues = error.issues as Array<{
-      path: (string | number)[];
-      message: string;
-      expected?: unknown;
-      received?: unknown;
-      code?: string;
-    }>;
-    return {
-      message: `${toolName}: Invalid parameters provided`,
-      diagnostics: {
-        type: DIAGNOSTIC_TYPE_VALIDATION_ERROR,
-        issues: issues as ValidationErrorDiagnostics['issues'],
-        formatted: formatZodIssuesForDiagnostics(
-          issues as ValidationErrorDiagnostics['issues'],
-        ),
-      },
-    };
+  if (!hasZodIssues(error)) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    return { message: `${toolName}: ${errorMessage}` };
   }
 
-  const errorMessage = error instanceof Error ? error.message : String(error);
-  return { message: `${toolName}: ${errorMessage}` };
+  const issues = error.issues as ValidationErrorDiagnostics['issues'];
+  return {
+    message: `${toolName}: Invalid parameters provided`,
+    diagnostics: {
+      type: DIAGNOSTIC_TYPE_VALIDATION_ERROR,
+      issues,
+      formatted: formatZodIssuesForDiagnostics(issues),
+    },
+  };
 }
 
 // ============================================================================
@@ -421,8 +414,6 @@ type ToolUseProcessExecResult =
       lastAssistantContent?: unknown[];
       normalizedUsage?: NormalizedUsage;
       responseTimeMs?: number;
-      createAssistantMessage?: boolean;
-      lastResponseUpdate?: string;
     };
 
 /**
@@ -548,8 +539,6 @@ class ToolUseProcessNode<C> extends BaseNode<
         lastAssistantContent,
         normalizedUsage,
         responseTimeMs: prepRes.responseTimeMs,
-        createAssistantMessage: Boolean(text),
-        lastResponseUpdate: text ?? undefined,
       };
     }
 
@@ -606,33 +595,29 @@ class ToolUseProcessNode<C> extends BaseNode<
     });
     run.incrementRounds();
 
+    shared.stopReason = execRes.stopReason;
+
     if (execRes.endTurn) {
-      // Apply side effects for end turn
       shared.toolCalls = undefined;
-      if (execRes.createAssistantMessage && execRes.text) {
+      shared.shouldStop = true;
+      shared.endTurn = true;
+      if (execRes.text) {
         shared.messages.push(
           services.modelHandler.createAssistantMessage(execRes.text),
         );
         workspace.assembly.lastResponse = execRes.text;
       }
-      // Clear ephemeral state
       workspace.resetServerToolContent();
       workspace.resetReasoning();
-      shared.shouldStop = true;
-      shared.endTurn = true; // Normal completion (model said end_turn)
-      shared.stopReason = execRes.stopReason;
       return FlowTransition.COMPLETE;
     }
 
-    // Apply side effects for continuing with tool calls
+    // Continue with tool calls
     shared.toolCalls = execRes.toolCalls;
     shared.text = execRes.text;
-    shared.stopReason = execRes.stopReason;
-    // Increment cycle index and reset metrics for next cycle
     shared.cycleIndex += 1;
     shared.cycleResponseTimeMs = 0;
     shared.cycleNormalizedUsage = undefined;
-
     return FlowTransition.DEFAULT;
   }
 }


### PR DESCRIPTION
- AgentWorkspaceState: use explicit property assignments in toSnapshot(), extract updateEditMap() helper to remove duplication in recordEdits()
- CommonCycleTypes: use direct property assignments in resetCycleState() instead of Object.assign()
- ResponseCycleFlow: simplify assertCycleFieldsPopulated() loop structure
- ToolUseCycleFlow: simplify parseToolInput() early returns, invert normalizeToolCallError() condition, remove redundant fields from ToolUseProcessExecResult, streamline post() method

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Focuses on clarity, deduplication, and safer serialization across agent core flows.
> 
> - AgentWorkspaceState: extracts `updateEditMap()` to dedupe edit aggregation; `recordEdits()` simplified; `toSnapshot()` now serializes only `assembly.lastResponse/accumulatedOutput` and explicit `reasoning` fields
> - CommonCycleTypes: `resetCycleState()` uses direct assignments for base fields, then clears additional fields
> - ResponseCycleFlow: `assertCycleFieldsPopulated()` simplified to a single loop and explicit `outputLocation` null/undef check
> - ToolUseCycleFlow: simplifies `parseToolInput()` returns; inverts `normalizeToolCallError()` for cleaner non-Zod path and adds structured diagnostics when present; removes unused fields from exec result type; streamlines `post()` to set `stopReason`, manage `shouldStop/endTurn`, reset ephemeral state, and roll cycle metrics forward
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 09fb08e9206116c2f4eb4d4901433e9053bdd117. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->