### PR TITLE
Simplify and improve code clarity

### DIFF
--- a/src/tools/EditTool.ts
+++ b/src/tools/EditTool.ts
@@ -7,6 +7,7 @@ import {
   recordToolFileRead,
   requireFileReadForEdit,
 } from '@tools/fileInteractions';
+import { pluralize } from '@tools/utils';
 import {
   buildApprovalRejectedResult,
   formatUnifiedApprovalUserDiff,
@@ -102,14 +103,11 @@ export class EditFileTool extends defineTool({
       finalContent,
     );
 
-    // Record file as "read" after editing so subsequent edits don't require
-    // an explicit read again.
     recordToolFileRead(targetPath);
 
     const count = replace_all === true ? occurrences : 1;
-    const pluralSuffix = count === 1 ? '' : 's';
-    const replacementSummary = `Replaced ${count} occurrence${pluralSuffix}.`;
-    const summary = `Edited ${targetPath}: replaced ${count} occurrence${pluralSuffix}`;
+    const replacementSummary = `Replaced ${count} ${pluralize(count, 'occurrence')}.`;
+    const summary = `Edited ${targetPath}: replaced ${count} ${pluralize(count, 'occurrence')}`;
 
     const userDiffNote = formatUnifiedApprovalUserDiff(
       targetPath,

--- a/src/tools/WriteTool.ts
+++ b/src/tools/WriteTool.ts
@@ -69,10 +69,6 @@ export class WriteFileTool extends defineTool({
       finalContent,
     );
 
-    // Record the file as "read" after writing so subsequent edits don't require
-    // an explicit read. This is especially important for new files that were
-    // just created - without this, any immediate edit would fail with
-    // "prior read required" even though the user just wrote the file.
     recordToolFileRead(input.path);
 
     const userDiffNote = formatUnifiedApprovalUserDiff(

--- a/src/tools/arxiv/ArxivMetadataTool.ts
+++ b/src/tools/arxiv/ArxivMetadataTool.ts
@@ -7,8 +7,7 @@ import { ToolError } from '@tools/result';
 import {
   type ArxivPaperMetadata,
   createArxivClient,
-  extractEntryIdentifier,
-  getAuthorNames,
+  extractBasePaperMetadata,
   normaliseArxivIdentifier,
 } from '@tools/latex/arxivShared';
 import { ARXIV_CONSTANTS } from '@tools/citation/constants';
@@ -54,30 +53,16 @@ export class ArxivMetadataTool extends defineTool({
       throw new ToolError(`No metadata found for arXiv ID ${requestId}`);
     }
 
-    // Take the first result (should be the only one for ID lookup)
     const targetEntry = entries[0];
-
-    const authorNames = getAuthorNames(
-      targetEntry.authors,
-      input.maxAuthors ?? undefined,
-    );
+    const base = extractBasePaperMetadata(targetEntry, input.maxAuthors ?? undefined);
     const includeAbstract = input.includeAbstract ?? true;
 
     const metadata: ArxivPaperMetadata = {
-      id: extractEntryIdentifier(targetEntry.id) ?? requestId,
-      doi: targetEntry.doi?.id ?? null,
-      title:
-        typeof targetEntry.title === 'string'
-          ? targetEntry.title.trim()
-          : targetEntry.title,
-      published: targetEntry.published ?? null,
-      updated: targetEntry.updated ?? null,
-      authors: authorNames,
+      ...base,
+      id: base.id ?? requestId,
       journalReference: targetEntry.journalRef ?? null,
       comment: targetEntry.comment ?? null,
-      primaryCategory: targetEntry.primaryCategory ?? null,
       links: targetEntry.links ?? null,
-      // Conditionally include abstract field only when requested
       ...(includeAbstract && { abstract: targetEntry.summary ?? null }),
     };
 

--- a/src/tools/arxiv/ArxivSearchTool.ts
+++ b/src/tools/arxiv/ArxivSearchTool.ts
@@ -9,19 +9,21 @@ import {
 } from 'arxiv-client';
 import { z } from 'zod';
 
-// Local imports - latex
+// Local imports
 import { toErrorMessage } from '@common/errors';
-import { ToolError } from '@tools/result';
-import {
-  type ArxivSearchResult,
-  createArxivClient,
-  extractEntryIdentifier,
-  getAuthorNames,
-  normaliseArxivIdentifier,
-} from '@tools/latex/arxivShared';
 import { ARXIV_CONSTANTS } from '@tools/citation/constants';
 import { waitForRateLimit } from '@tools/citation/rateLimiter';
 import { defineTool } from '@tools/core/define';
+import {
+  type ArxivSearchResult,
+  createArxivClient,
+  extractBasePaperMetadata,
+  normaliseArxivIdentifier,
+} from '@tools/latex/arxivShared';
+// eslint-disable-next-line import/order -- grouped with tools imports
+import { ToolError } from '@tools/result';
+// eslint-disable-next-line import/order -- grouped with tools imports
+import { pluralize } from '@tools/utils';
 
 const SortBySchema = z.enum(['relevance', 'lastUpdatedDate', 'submittedDate']);
 const SortOrderSchema = z.enum(['ascending', 'descending']);
@@ -124,19 +126,12 @@ export class ArxivSearchTool extends defineTool({
     }
 
     const results: ArxivSearchResult[] = entries.map((entry) => {
-      const identifier = extractEntryIdentifier(entry.id);
+      const base = extractBasePaperMetadata(entry);
       return {
-        id: identifier ?? null,
-        doi: entry.doi?.id ?? null,
-        title:
-          typeof entry.title === 'string' ? entry.title.trim() : entry.title,
+        ...base,
         abstract: entry.summary ?? null,
-        published: entry.published ?? null,
-        updated: entry.updated ?? null,
-        authors: getAuthorNames(entry.authors),
-        primaryCategory: entry.primaryCategory ?? null,
-        arxivUrl: identifier
-          ? `https://arxiv.org/abs/${normaliseArxivIdentifier(identifier)}`
+        arxivUrl: base.id
+          ? `https://arxiv.org/abs/${normaliseArxivIdentifier(base.id)}`
           : null,
       };
     });
@@ -152,7 +147,7 @@ export class ArxivSearchTool extends defineTool({
 
     const fieldLabel = searchField !== 'all' ? ` (${searchField})` : '';
     return {
-      summary: `Found: ${results.length} result${results.length === 1 ? '' : 's'} for "${trimmedQuery}"${fieldLabel}`,
+      summary: `Found: ${results.length} ${pluralize(results.length, 'result')} for "${trimmedQuery}"${fieldLabel}`,
       output: JSON.stringify(payload, null, 2),
     };
   }

--- a/src/tools/citation/CrossrefSearchTool.ts
+++ b/src/tools/citation/CrossrefSearchTool.ts
@@ -8,10 +8,12 @@ import {
 } from '@jamesgopsill/crossref-client';
 import { z } from 'zod';
 
-// Local imports - metadata
+// Local imports
 import { toErrorMessage } from '@common/errors';
-import { ToolError } from '@tools/result';
+// eslint-disable-next-line import/order -- grouped by semantic meaning
 import { defineTool } from '@tools/core/define';
+import { ToolError } from '@tools/result';
+import { pluralize } from '@tools/utils';
 
 // Local file imports
 import { CROSSREF_CONSTANTS } from './constants';
@@ -105,7 +107,7 @@ export class CrossrefSearchTool extends defineTool({
     };
 
     return {
-      summary: `Found: ${results.length} result${results.length === 1 ? '' : 's'} for "${trimmedQuery}"`,
+      summary: `Found: ${results.length} ${pluralize(results.length, 'result')} for "${trimmedQuery}"`,
       output: JSON.stringify(payload, null, 2),
     };
   }

--- a/src/tools/fileOp.ts
+++ b/src/tools/fileOp.ts
@@ -46,12 +46,9 @@ export class FileOpTool extends defineTool({
         };
       }
       case 'write': {
-        // eslint-disable-next-line eqeqeq
+        // eslint-disable-next-line eqeqeq -- intentional nullish check
         if (content == null) {
-          return {
-            error: 'content parameter is required for write',
-            isError: true,
-          };
+          throw new ToolError('content parameter is required for write');
         }
         const exists = await WorkspaceFS.exists(path);
         const readGate = requireFileReadForEdit(path, exists);
@@ -86,8 +83,6 @@ export class FileOpTool extends defineTool({
           finalContent,
         );
 
-        // Record file as "read" after writing so subsequent edits don't require
-        // an explicit read - especially important for newly created files.
         recordToolFileRead(path);
 
         const userDiffNote = formatUnifiedApprovalUserDiff(
@@ -104,12 +99,9 @@ export class FileOpTool extends defineTool({
         };
       }
       case 'append': {
-        // eslint-disable-next-line eqeqeq
+        // eslint-disable-next-line eqeqeq -- intentional nullish check
         if (content == null) {
-          return {
-            error: 'content parameter is required for append',
-            isError: true,
-          };
+          throw new ToolError('content parameter is required for append');
         }
         const exists = await WorkspaceFS.exists(path);
         const readGate = requireFileReadForEdit(path, exists);
@@ -156,11 +148,7 @@ export class FileOpTool extends defineTool({
           await WorkspaceFS.appendFile(path, appendedSegment);
         }
 
-        // Record file as "read" after appending so subsequent edits don't require
-        // an explicit read - especially important for newly created files.
         recordToolFileRead(path);
-
-        // Report the actual applied content after append
         const appliedContent = await WorkspaceFS.read(path);
         const userDiffNote = formatUnifiedApprovalUserDiff(
           path,

--- a/src/tools/latex/arxivShared.ts
+++ b/src/tools/latex/arxivShared.ts
@@ -69,10 +69,32 @@ export const extractEntryIdentifier = (rawId: unknown): string | null => {
 };
 
 /** Extract author names, optionally limiting to maxAuthors */
-export const getAuthorNames = (
+export function getAuthorNames(
   authors: ArxivEntry['authors'],
   maxAuthors?: number,
-): string[] => {
+): string[] {
   const names = authors.map((author) => author.name);
   return maxAuthors !== undefined ? names.slice(0, maxAuthors) : names;
-};
+}
+
+/** Normalize entry title by trimming if string */
+export function normalizeEntryTitle(title: string | unknown): string {
+  return typeof title === 'string' ? title.trim() : String(title);
+}
+
+/** Extract base paper metadata from an arXiv entry */
+export function extractBasePaperMetadata(
+  entry: ArxivEntry,
+  maxAuthors?: number,
+): ArxivPaperBase {
+  const identifier = extractEntryIdentifier(entry.id);
+  return {
+    id: identifier,
+    doi: entry.doi?.id ?? null,
+    title: normalizeEntryTitle(entry.title),
+    published: entry.published ?? null,
+    updated: entry.updated ?? null,
+    authors: getAuthorNames(entry.authors, maxAuthors),
+    primaryCategory: entry.primaryCategory ?? null,
+  };
+}

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -96,6 +96,30 @@ export { getGitignoreMatcher, clearGitignoreCache } from './gitignore';
 export type { GitignoreMatcher } from './gitignore';
 
 /**
+ * Pluralize a word based on count.
+ * Returns the singular form for count === 1, plural form otherwise.
+ */
+export function pluralize(
+  count: number,
+  singular: string,
+  plural?: string,
+): string {
+  return count === 1 ? singular : (plural ?? `${singular}s`);
+}
+
+/**
+ * Format a result count with proper pluralization.
+ * Example: formatResultCount(3, 'result') returns "3 results"
+ */
+export function formatResultCount(
+  count: number,
+  singular: string,
+  plural?: string,
+): string {
+  return `${count} ${pluralize(count, singular, plural)}`;
+}
+
+/**
  * Format tool output with a header and content.
  */
 export function formatToolOutput(


### PR DESCRIPTION
…ation

- Add pluralize and formatResultCount helpers to tools/utils.ts
- Add extractBasePaperMetadata helper to arxivShared.ts for shared entry transformation
- Update ArxivSearchTool, ArxivMetadataTool, CrossrefSearchTool, and EditTool to use pluralize helper for consistent result count formatting
- Remove redundant recordToolFileRead comments across WriteTool, fileOp
- Simplify fileOp null checks by throwing ToolError instead of returning error object
- Consolidate arXiv entry-to-result mapping to use shared extractBasePaperMetadata

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Refactors and utilities**
> 
> - Adds `pluralize` and `formatResultCount` to `tools/utils.ts` for consistent count formatting.
> - Introduces `extractBasePaperMetadata` (plus helpers) in `arxivShared.ts` to centralize arXiv entry-to-metadata transformation.
> 
> **Tool updates**
> 
> - Updates `ArxivSearchTool` and `ArxivMetadataTool` to use `extractBasePaperMetadata`; simplifies field mapping and IDs.
> - Standardizes result summaries using `pluralize` across `ArxivSearchTool`, `CrossrefSearchTool`, and `EditTool`.
> - In `file_op`, replace null-check error returns with thrown `ToolError` for `write`/`append`; retains read gating and approval flow.
> 
> **Cleanups**
> 
> - Removes redundant `recordToolFileRead` comments and minor import/order tweaks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f2cdd54ed1511d4cf97ed5180acb48d9556e0591. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->