### PR TITLE
Simplify and improve code clarity

### DIFF
--- a/src/agent/output/DiffStatsManager.ts
+++ b/src/agent/output/DiffStatsManager.ts
@@ -9,10 +9,9 @@ import { flexibleFS, type FileLocation } from '@utils/files';
 
 export class DiffStatsManager {
   private countLines(text: string): number {
-    if (text.length === 0) return 0;
-    return text.endsWith('\n')
-      ? text.split('\n').length - 1
-      : text.split('\n').length;
+    if (!text) return 0;
+    const lines = text.split('\n');
+    return text.endsWith('\n') ? lines.length - 1 : lines.length;
   }
 
   public async computeDiffStats(

--- a/src/agent/output/FileLineageCalculator.ts
+++ b/src/agent/output/FileLineageCalculator.ts
@@ -130,46 +130,38 @@ export class FileLineageCalculator {
 
   /**
    * Find the base file that matches the given source name.
-   * Tries heuristics in priority order (first match wins):
-   * 1. Exact match: basename === source
+   * Single-pass algorithm that checks all priority heuristics:
+   * 1. Exact match: basename === source (immediate return)
    * 2. Names without extensions match
    * 3. Base name (no ext) matches source
    * 4. Source (no ext) matches base name
    */
   findMatchingBaseFile(source: string): FileLocation | undefined {
     const sourceNoExt = path.parse(source).name;
+    let priority2Match: FileLocation | undefined;
+    let priority3Match: FileLocation | undefined;
+    let priority4Match: FileLocation | undefined;
 
-    // Priority 1: Exact match
     for (const baseLoc of this.baseFiles) {
-      if (this.getBaseName(baseLoc) === source) {
+      const baseName = this.getBaseName(baseLoc);
+      const baseNameNoExt = path.parse(baseName).name;
+
+      // Priority 1: Exact match - return immediately
+      if (baseName === source) {
         return baseLoc;
+      }
+
+      // Track lower priority matches (first match for each priority wins)
+      if (!priority2Match && baseNameNoExt === sourceNoExt) {
+        priority2Match = baseLoc;
+      } else if (!priority3Match && baseNameNoExt === source) {
+        priority3Match = baseLoc;
+      } else if (!priority4Match && baseName === sourceNoExt) {
+        priority4Match = baseLoc;
       }
     }
 
-    // Priority 2: Names without extensions match
-    for (const baseLoc of this.baseFiles) {
-      const baseNameNoExt = path.parse(this.getBaseName(baseLoc)).name;
-      if (baseNameNoExt === sourceNoExt) {
-        return baseLoc;
-      }
-    }
-
-    // Priority 3: Base name (no ext) matches source exactly
-    for (const baseLoc of this.baseFiles) {
-      const baseNameNoExt = path.parse(this.getBaseName(baseLoc)).name;
-      if (baseNameNoExt === source) {
-        return baseLoc;
-      }
-    }
-
-    // Priority 4: Source (no ext) matches base name exactly
-    for (const baseLoc of this.baseFiles) {
-      if (this.getBaseName(baseLoc) === sourceNoExt) {
-        return baseLoc;
-      }
-    }
-
-    return undefined;
+    return priority2Match ?? priority3Match ?? priority4Match;
   }
 
   /**

--- a/src/agent/output/LatexDiffManager.ts
+++ b/src/agent/output/LatexDiffManager.ts
@@ -142,8 +142,7 @@ export class LatexDiffManager {
     mapping: RoundFileMapping,
     stage?: AgentLogStage,
   ): Promise<void> {
-    const execute = () =>
-      this.performLatexdiffOperations(currRound, mapping);
+    const execute = () => this.performLatexdiffOperations(currRound, mapping);
 
     try {
       await (stage ? stage.within(execute) : execute());
@@ -167,9 +166,7 @@ export class LatexDiffManager {
     }
 
     const outputFiles = this.getOutputFiles()[currRound] ?? [];
-    const outputPaths = outputFiles.map(
-      (entry) => entry.location.absolutePath,
-    );
+    const outputPaths = outputFiles.map((entry) => entry.location.absolutePath);
     if (outputPaths.length === 0) {
       this.logger.warn(
         `No output files found for round ${currRound}, skipping latexdiff operations`,

--- a/src/agent/output/LatexDiffManager.ts
+++ b/src/agent/output/LatexDiffManager.ts
@@ -113,11 +113,7 @@ export class LatexDiffManager {
    * Get display label (basename) from FileLocation for UI/logging.
    */
   private getDisplayLabel(location: FileLocation): string {
-    return path.basename(
-      location.kind === 'workspace' || location.kind === 'runStorage'
-        ? location.relativePath
-        : location.absolutePath,
-    );
+    return path.basename(getComparablePath(location));
   }
 
   private async ensureWorkspaceDependency(

--- a/src/agent/output/LatexOutputUtils.ts
+++ b/src/agent/output/LatexOutputUtils.ts
@@ -25,9 +25,7 @@ export async function indentLatexFiles(
   fileLocations: FileLocation[],
   logger: Logger,
 ): Promise<void> {
-  for (const location of fileLocations) {
-    await indentLatexFile(location, logger);
-  }
+  await Promise.all(fileLocations.map((loc) => indentLatexFile(loc, logger)));
 }
 
 /** Clean up latexindent backup files after formatting. */

--- a/src/agent/output/OutputFileProcessor.ts
+++ b/src/agent/output/OutputFileProcessor.ts
@@ -200,91 +200,70 @@ export class OutputFileProcessor {
     processed: OutputFileInfo[],
     stage?: AgentLogStage,
   ): Promise<void> {
-    const { agentSetting, logger } = this.ctx;
-
-    const execute = async () => {
-      const singleFile =
-        processed.length === 1 ? processed[0].location.absolutePath : null;
-      const data = this.ctx.ensureRoundData(round);
-
-      if (!rawOutput?.absolutePath) {
-        data.xmlSummary = {
-          tagContents: {},
-          documents: [],
-          singleOutputFile: singleFile,
-          sourceLocation: rawOutput,
-        };
-        return;
-      }
-
-      try {
-        const rawContent = await flexibleFS.read(rawOutput);
-        const tagContents: Record<string, string | string[]> = {};
-        const documents: string[] = [];
-
-        const documentTag = agentSetting.documentTag;
-        const documentEntries = extractMultipleTextFromTag(
-          rawContent,
-          documentTag,
-        );
-        if (documentEntries.length > 0) {
-          const trimmedDocuments = documentEntries.map((entry) =>
-            entry.content.trim(),
-          );
-          if (trimmedDocuments.length === 1) {
-            tagContents[documentTag] = trimmedDocuments[0];
-          } else {
-            tagContents[documentTag] = trimmedDocuments;
-          }
-
-          for (const entry of documentEntries) {
-            const nameAttr = entry.name ? ` name="${entry.name}"` : '';
-            const trimmed = entry.content.trim();
-            documents.push(
-              `<${documentTag}${nameAttr}>${trimmed}</${documentTag}>`,
-            );
-          }
-        } else {
-          const singleDocument = extractTextFromTag(
-            rawContent,
-            documentTag,
-          ).trim();
-          if (singleDocument) {
-            tagContents[documentTag] = singleDocument;
-            documents.push(
-              `<${documentTag}>${singleDocument}</${documentTag}>`,
-            );
-          }
-        }
-
-        const scratchpadContent = extractTextFromTag(
-          rawContent,
-          'scratchpad',
-        ).trim();
-        if (scratchpadContent) {
-          tagContents.scratchpad = scratchpadContent;
-        }
-
-        data.xmlSummary = {
-          tagContents,
-          documents,
-          singleOutputFile: singleFile,
-          sourceLocation: rawOutput,
-        };
-      } catch (error) {
-        logger.debug(
-          `Failed to collect XML summary for round ${round}: ${toErrorMessage(error)}`,
-          { messageType: MESSAGE_TYPES.INTERNAL },
-        );
-        data.xmlSummary = {
-          tagContents: {},
-          documents: [],
-          singleOutputFile: singleFile,
-          sourceLocation: rawOutput,
-        };
-      }
-    };
-
+    const execute = () => this.buildXmlSummary(round, rawOutput, processed);
     await (stage ? stage.within(execute) : execute());
+  }
+
+  private async buildXmlSummary(
+    round: number,
+    rawOutput: FileLocation | null,
+    processed: OutputFileInfo[],
+  ): Promise<void> {
+    const { agentSetting, logger } = this.ctx;
+    const data = this.ctx.ensureRoundData(round);
+    const singleFile =
+      processed.length === 1 ? processed[0].location.absolutePath : null;
+
+    const createEmptySummary = () => ({
+      tagContents: {},
+      documents: [] as string[],
+      singleOutputFile: singleFile,
+      sourceLocation: rawOutput,
+    });
+
+    if (!rawOutput?.absolutePath) {
+      data.xmlSummary = createEmptySummary();
+      return;
+    }
+
+    try {
+      const rawContent = await flexibleFS.read(rawOutput);
+      const tagContents: Record<string, string | string[]> = {};
+      const documents: string[] = [];
+      const documentTag = agentSetting.documentTag;
+
+      const documentEntries = extractMultipleTextFromTag(rawContent, documentTag);
+      if (documentEntries.length > 0) {
+        const trimmedDocuments = documentEntries.map((e) => e.content.trim());
+        tagContents[documentTag] =
+          trimmedDocuments.length === 1 ? trimmedDocuments[0] : trimmedDocuments;
+
+        for (const entry of documentEntries) {
+          const nameAttr = entry.name ? ` name="${entry.name}"` : '';
+          documents.push(
+            `<${documentTag}${nameAttr}>${entry.content.trim()}</${documentTag}>`,
+          );
+        }
+      } else {
+        const singleDocument = extractTextFromTag(rawContent, documentTag).trim();
+        if (singleDocument) {
+          tagContents[documentTag] = singleDocument;
+          documents.push(`<${documentTag}>${singleDocument}</${documentTag}>`);
+        }
+      }
+
+      const scratchpadContent = extractTextFromTag(rawContent, 'scratchpad').trim();
+      if (scratchpadContent) {
+        tagContents.scratchpad = scratchpadContent;
+      }
+
+      data.xmlSummary = { tagContents, documents, singleOutputFile: singleFile, sourceLocation: rawOutput };
+    } catch (error) {
+      logger.debug(
+        `Failed to collect XML summary for round ${round}: ${toErrorMessage(error)}`,
+        { messageType: MESSAGE_TYPES.INTERNAL },
+      );
+      data.xmlSummary = createEmptySummary();
+    }
   }
 }

--- a/src/agent/output/OutputFileProcessor.ts
+++ b/src/agent/output/OutputFileProcessor.ts
@@ -232,11 +232,16 @@ export class OutputFileProcessor {
       const documents: string[] = [];
       const documentTag = agentSetting.documentTag;
 
-      const documentEntries = extractMultipleTextFromTag(rawContent, documentTag);
+      const documentEntries = extractMultipleTextFromTag(
+        rawContent,
+        documentTag,
+      );
       if (documentEntries.length > 0) {
         const trimmedDocuments = documentEntries.map((e) => e.content.trim());
         tagContents[documentTag] =
-          trimmedDocuments.length === 1 ? trimmedDocuments[0] : trimmedDocuments;
+          trimmedDocuments.length === 1
+            ? trimmedDocuments[0]
+            : trimmedDocuments;
 
         for (const entry of documentEntries) {
           const nameAttr = entry.name ? ` name="${entry.name}"` : '';
@@ -245,19 +250,30 @@ export class OutputFileProcessor {
           );
         }
       } else {
-        const singleDocument = extractTextFromTag(rawContent, documentTag).trim();
+        const singleDocument = extractTextFromTag(
+          rawContent,
+          documentTag,
+        ).trim();
         if (singleDocument) {
           tagContents[documentTag] = singleDocument;
           documents.push(`<${documentTag}>${singleDocument}</${documentTag}>`);
         }
       }
 
-      const scratchpadContent = extractTextFromTag(rawContent, 'scratchpad').trim();
+      const scratchpadContent = extractTextFromTag(
+        rawContent,
+        'scratchpad',
+      ).trim();
       if (scratchpadContent) {
         tagContents.scratchpad = scratchpadContent;
       }
 
-      data.xmlSummary = { tagContents, documents, singleOutputFile: singleFile, sourceLocation: rawOutput };
+      data.xmlSummary = {
+        tagContents,
+        documents,
+        singleOutputFile: singleFile,
+        sourceLocation: rawOutput,
+      };
     } catch (error) {
       logger.debug(
         `Failed to collect XML summary for round ${round}: ${toErrorMessage(error)}`,

--- a/src/agent/output/OutputHandler.ts
+++ b/src/agent/output/OutputHandler.ts
@@ -148,10 +148,9 @@ export class OutputHandler implements IOutputHandler {
     this.openedOutputs.clear();
 
     const supportFiles = this.collectRunSupportFiles();
-    this.runPreparation = this.fileService.prepareRunWorkspace(
-      this.baseFiles,
-      { linkFiles: supportFiles },
-    );
+    this.runPreparation = this.fileService.prepareRunWorkspace(this.baseFiles, {
+      linkFiles: supportFiles,
+    });
   }
 
   private getStorageKey(): StorageKey {

--- a/src/agent/output/OutputHandler.ts
+++ b/src/agent/output/OutputHandler.ts
@@ -117,10 +117,6 @@ export class OutputHandler implements IOutputHandler {
     });
   }
 
-  private collectRunSnapshotFiles(): FileLocation[] {
-    return this.baseFiles;
-  }
-
   private collectRunSupportFiles(): FileLocation[] {
     const extras = new Map<string, FileLocation>();
     const add = (value?: string | FileLocation | null) => {
@@ -151,10 +147,9 @@ export class OutputHandler implements IOutputHandler {
     this._storageKey = storageKey;
     this.openedOutputs.clear();
 
-    const snapshotTargets = this.collectRunSnapshotFiles();
     const supportFiles = this.collectRunSupportFiles();
     this.runPreparation = this.fileService.prepareRunWorkspace(
-      snapshotTargets,
+      this.baseFiles,
       { linkFiles: supportFiles },
     );
   }

--- a/src/agent/output/XmlOutputManager.ts
+++ b/src/agent/output/XmlOutputManager.ts
@@ -210,7 +210,9 @@ export class XmlOutputManager {
     const tagsToWrap = [thinkingTag, 'document'];
     outputContent = addCdataToTagsMultiple(outputContent, tagsToWrap);
 
-    const tryFallbackExtraction = async (): Promise<OutputFileInfo[] | null> => {
+    const tryFallbackExtraction = async (): Promise<
+      OutputFileInfo[] | null
+    > => {
       const fallbackDocs = this.extractMultipleDocumentsbyRegex(
         outputContent,
         documentTag,

--- a/src/agent/output/XmlOutputManager.ts
+++ b/src/agent/output/XmlOutputManager.ts
@@ -33,6 +33,16 @@ import {
 import { getFileDirectory } from './displayUtils';
 import type { OutputFileInfo } from './types';
 
+/** Shared XMLParser configuration for scratchpad output extraction */
+const XML_PARSER_OPTIONS = {
+  ignoreAttributes: false,
+  parseTagValue: true,
+  textNodeName: 'content',
+  attributeNamePrefix: '',
+  processEntities: false,
+  ignoreDeclaration: true,
+} as const;
+
 export class XmlOutputManager {
   constructor(
     private readonly agentSetting: AgentSetting,
@@ -136,14 +146,7 @@ export class XmlOutputManager {
       return texLocation;
     }
 
-    const parser = new XMLParser({
-      ignoreAttributes: false,
-      parseTagValue: true,
-      textNodeName: 'content',
-      attributeNamePrefix: '',
-      processEntities: false,
-      ignoreDeclaration: true,
-    });
+    const parser = new XMLParser(XML_PARSER_OPTIONS);
     const root = parser.parse(outputContent);
 
     const latexDocument = extractContentFromXMLbyTag(root, documentTag);
@@ -225,14 +228,7 @@ export class XmlOutputManager {
     };
 
     try {
-      const parser = new XMLParser({
-        ignoreAttributes: false,
-        parseTagValue: true,
-        textNodeName: 'content',
-        attributeNamePrefix: '',
-        processEntities: false,
-        ignoreDeclaration: true,
-      });
+      const parser = new XMLParser(XML_PARSER_OPTIONS);
       const root = parser.parse(outputContent);
 
       const documents = extractContentFromXMLbyTagMultiple(root, documentTag);
@@ -356,11 +352,10 @@ export class XmlOutputManager {
     this.logger.debug(
       `Splitting multiple scratchpad output XML: ${outputLocation.absolutePath}`,
     );
-    const processedOutputFiles = await this.splitScratchpadMultipleOutputXml(
+    return this.splitScratchpadMultipleOutputXml(
       outputLocation,
       this.agentSetting.documentTag,
     );
-    return processedOutputFiles;
   }
 
   async ensureCorrectXmlStructure(


### PR DESCRIPTION
- Inline trivial collectRunSnapshotFiles() method in OutputHandler
- Extract repeated XMLParser config to constant in XmlOutputManager
- Optimize FileLineageCalculator.findMatchingBaseFile() to single-pass
- Simplify getDisplayLabel() in LatexDiffManager using getComparablePath
- Refactor captureXmlSummary() with separate buildXmlSummary method
- Parallelize indentLatexFiles() with Promise.all for performance
- Simplify countLines() in DiffStatsManager for clarity

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Scope**: Cleanup and small perf improvements across output processing.
> 
> - Optimize `FileLineageCalculator.findMatchingBaseFile` to a single-pass heuristic with prioritized matches
> - Extract shared `XML_PARSER_OPTIONS` and reuse in `XmlOutputManager` parsing paths; minor return/flow simplifications
> - Refactor `OutputFileProcessor.captureXmlSummary` into wrapper + `buildXmlSummary`; add `createEmptySummary` helper
> - Simplify `LatexDiffManager.getDisplayLabel` via `getComparablePath`; minor logging/flow tidy-ups
> - Parallelize `indentLatexFiles` with `Promise.all` for faster formatting
> - Simplify `DiffStatsManager.countLines` logic
> - Inline snapshot collection in `OutputHandler.setActiveRun` by using `this.baseFiles` directly
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a8f1e1de2625da7307c910467034103b378eecc5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->