### PR TITLE
Simplify and improve code clarity

### DIFF
--- a/src/agent/core/AgentDataclass.ts
+++ b/src/agent/core/AgentDataclass.ts
@@ -190,16 +190,13 @@ const normalizeAgentSettingInput = (input: unknown): unknown => {
     return input;
   }
   const obj = input as Record<string, unknown>;
-  if (obj.agentCategory === undefined) {
-    return {
-      ...obj,
-      agentCategory:
-        obj.agentType === AgentType.ToolUse
-          ? AgentCategory.ToolUse
-          : AgentCategory.Workflow,
-    };
+  if (obj.agentCategory !== undefined) {
+    return input;
   }
-  return input;
+  return {
+    ...obj,
+    agentCategory: deriveAgentCategory(obj.agentType as AgentType | undefined),
+  };
 };
 
 /**

--- a/src/agent/index/agentRegistry.ts
+++ b/src/agent/index/agentRegistry.ts
@@ -298,33 +298,45 @@ async function scanDirectory(
   }
 }
 
-function groupByBaseName(
-  files: string[],
-): Map<string, { base?: string; multiple?: string }> {
-  const groups = new Map<string, { base?: string; multiple?: string }>();
+/**
+ * Generic helper to group items by base name, separating base vs _multiple variants.
+ */
+function groupByVariants<T>(
+  items: T[],
+  getName: (item: T) => string,
+): Map<string, { base?: T; multiple?: T }> {
+  const groups = new Map<string, { base?: T; multiple?: T }>();
 
-  for (const file of files) {
-    const name = path.basename(file, '.yaml');
-    const isMultiple = name.endsWith(MULTIPLE_SUFFIX);
-    const baseName = isMultiple ? name.slice(0, -MULTIPLE_SUFFIX.length) : name;
+  for (const item of items) {
+    const name = getName(item);
+    const isMultiple = isMultipleVariant(name);
+    const baseName = isMultiple ? getBaseName(name) : name;
 
     const group = groups.get(baseName) ?? {};
     if (isMultiple) {
-      group.multiple = file;
+      group.multiple = item;
     } else {
-      group.base = file;
+      group.base = item;
     }
     groups.set(baseName, group);
   }
 
+  return groups;
+}
+
+function groupByBaseName(
+  files: string[],
+): Map<string, { base?: string; multiple?: string }> {
+  const groups = groupByVariants(files, (f) => path.basename(f, '.yaml'));
+
   // Filter: must have base, or promote _multiple-only to base
   const result = new Map<string, { base?: string; multiple?: string }>();
-  for (const [name, paths] of groups) {
-    if (paths.base) {
-      result.set(name, paths);
-    } else if (paths.multiple) {
+  for (const [name, { base, multiple }] of groups) {
+    if (base) {
+      result.set(name, { base, multiple });
+    } else if (multiple) {
       // Only _multiple exists, use it as base
-      result.set(`${name}${MULTIPLE_SUFFIX}`, { base: paths.multiple });
+      result.set(`${name}${MULTIPLE_SUFFIX}`, { base: multiple });
     }
   }
 
@@ -396,27 +408,7 @@ async function loadRemoteAgents(): Promise<AgentEntry[]> {
 
   try {
     const remotes = await RemoteAgentLoader.listRemoteAgents();
-
-    // Group remote agents by base name (same pattern as local agents)
-    // This ensures consistency: both "criticize" and "criticize_multiple" from
-    // the database become a single entry with multiplePath set
-    const grouped = new Map<
-      string,
-      { base?: (typeof remotes)[0]; multiple?: (typeof remotes)[0] }
-    >();
-
-    for (const r of remotes) {
-      const isMultiple = isMultipleVariant(r.name);
-      const baseName = isMultiple ? getBaseName(r.name) : r.name;
-
-      const group = grouped.get(baseName) ?? {};
-      if (isMultiple) {
-        group.multiple = r;
-      } else {
-        group.base = r;
-      }
-      grouped.set(baseName, group);
-    }
+    const grouped = groupByVariants(remotes, (r) => r.name);
 
     // Build entries from grouped agents
     const entries: AgentEntry[] = [];
@@ -433,15 +425,12 @@ async function loadRemoteAgents(): Promise<AgentEntry[]> {
       const category = isToolUse
         ? AgentCategory.ToolUse
         : AgentCategory.Workflow;
-      // Derive agentType from category (toolUse category -> ToolUse type, otherwise CoT)
       const agentType = isToolUse ? AgentType.ToolUse : AgentType.CoT;
 
       entries.push({
         name: entryName,
         source: 'remote' as AgentSource,
         path: '',
-        // Set multiplePath to indicate multiple output support (for UI indicator)
-        // True if _multiple variant exists, or if this IS a _multiple-only agent
         multiplePath: multiple ? multiple.name : undefined,
         category,
         agentType,
@@ -588,34 +577,32 @@ const SOURCE_PRIORITY: AgentSource[] = [
 /**
  * Deduplicate agents by name, keeping only the highest priority source.
  * Custom agents override built-in agents with the same name.
- * Remote agents are NEVER deduplicated - they always show separately.
+ * Remote agents use source:name keys to prevent deduplication.
  */
 function deduplicateByName(entries: AgentEntry[]): AgentEntry[] {
-  const byName = new Map<string, AgentEntry>();
-  const remoteEntries: AgentEntry[] = [];
+  const byKey = new Map<string, AgentEntry>();
 
   for (const entry of entries) {
-    // Remote agents never get deduplicated - always show them
-    if (entry.source === 'remote') {
-      remoteEntries.push(entry);
-      continue;
-    }
+    // Remote agents use source:name key to preserve uniqueness
+    // Local agents use just name to allow custom overriding builtIn
+    const key =
+      entry.source === 'remote' ? `${entry.source}:${entry.name}` : entry.name;
 
-    const existing = byName.get(entry.name);
+    const existing = byKey.get(key);
     if (!existing) {
-      byName.set(entry.name, entry);
+      byKey.set(key, entry);
       continue;
     }
 
-    // Keep the one with higher priority (lower index in SOURCE_PRIORITY)
+    // Keep higher priority source (lower SOURCE_PRIORITY index)
     const existingPriority = SOURCE_PRIORITY.indexOf(existing.source);
     const entryPriority = SOURCE_PRIORITY.indexOf(entry.source);
     if (entryPriority < existingPriority) {
-      byName.set(entry.name, entry);
+      byKey.set(key, entry);
     }
   }
 
-  return [...byName.values(), ...remoteEntries];
+  return [...byKey.values()];
 }
 
 function filterVisible(
@@ -626,12 +613,17 @@ function filterVisible(
 
   const autoShowRemote = getConfig<boolean>('texra.remoteAgents.autoShow', true);
 
-  return entries.filter((e) =>
-    // Remote agents auto-show if enabled, otherwise check config
-    (autoShowRemote && e.source === 'remote') ||
-    configured.has(createKey(e.source, e.name)) ||
-    configured.has(e.name)
-  );
+  function isVisible(entry: AgentEntry): boolean {
+    // Remote agents auto-show when setting is enabled
+    if (entry.source === 'remote' && autoShowRemote) return true;
+    // Check if explicitly configured by source:name or just name
+    return (
+      configured.has(createKey(entry.source, entry.name)) ||
+      configured.has(entry.name)
+    );
+  }
+
+  return entries.filter(isVisible);
 }
 
 function renderOptions(

--- a/src/agent/runtime/ModelFactory.ts
+++ b/src/agent/runtime/ModelFactory.ts
@@ -40,7 +40,7 @@ export class ModelFactory {
   static createHandler(config: ModelConfig): ModelHandler {
     const isOpenAI = config.provider === ModelProvider.OPENAI;
 
-    // Models requiring Responses API must bypass OpenRouter (e.g., deep research)
+    // OpenAI models requiring Responses API must bypass OpenRouter
     if (isOpenAI && config.requiresResponsesAPI) {
       logger.debug(CHANNEL, 'Using OpenAI Responses API Handler (required)');
       return new ModelHandlerOpenAIResponse(config);
@@ -52,12 +52,13 @@ export class ModelFactory {
       getConfig<boolean>('texra.model.useOpenRouter', false);
     if (useOpenRouter) {
       config.openrouterFullName ||= `${config.provider}/${config.fullName}`;
-      return config.provider === ModelProvider.ANTHROPIC
-        ? new ModelHandlerAnthropicViaOpenRouter(config)
-        : new ModelHandlerOpenRouter(config);
+      if (config.provider === ModelProvider.ANTHROPIC) {
+        return new ModelHandlerAnthropicViaOpenRouter(config);
+      }
+      return new ModelHandlerOpenRouter(config);
     }
 
-    // Check for optional OpenAI Responses API usage
+    // OpenAI models with optional Responses API
     if (isOpenAI) {
       const useResponsesAPI =
         getConfig<boolean>('texra.model.useOpenAIResponsesAPI', false) ||
@@ -68,12 +69,11 @@ export class ModelFactory {
       }
     }
 
-    // Use direct provider handler
+    // Direct provider handler
     const HandlerClass = PROVIDER_HANDLERS.get(config.provider);
     if (!HandlerClass) {
       throw new Error(`Unsupported model provider: ${config.provider}`);
     }
-
     logger.debug(CHANNEL, `Using Handler: ${HandlerClass.name}`);
     return new HandlerClass(config);
   }

--- a/src/agent/runtime/agentLoad.ts
+++ b/src/agent/runtime/agentLoad.ts
@@ -126,35 +126,28 @@ export async function loadAgentSettingAndPrompts(
     const rawConfig = await loadYaml(resolution.definitionPath);
     const config = AgentDefinitionSchema.parse(rawConfig);
 
-    const parent = config.inherits;
+    // Initialize with own settings/prompts (spread creates a mutable copy)
+    let settings: Partial<AgentSetting> = { ...config.settings };
+    let prompts: Partial<AgentPrompt> = { ...config.prompts };
 
-    let settings: Partial<AgentSetting> = {};
-    let prompts: Partial<AgentPrompt> = {};
-
-    if (parent) {
-      // Load parent settings and prompts recursively using the registry
-      const parentResolution = resolveAgent(`${entry.source}:${parent}`);
+    // Merge with parent if inheritance is specified
+    if (config.inherits) {
+      const parentResolution = resolveAgent(
+        `${entry.source}:${config.inherits}`,
+      );
       if (!parentResolution) {
         throw new Error(
-          `Unable to locate parent agent "${parent}" in source "${entry.source}".`,
+          `Unable to locate parent agent "${config.inherits}" in source "${entry.source}".`,
         );
       }
       const [parentSettings, parentPrompts] =
         await loadAgentSettingAndPrompts(parentResolution);
 
-      // Merge with parent settings and prompts
+      // Parent provides defaults, child overrides
       settings = deepmerge(parentSettings, config.settings, {
         arrayMerge: (_d, s) => s,
       });
       prompts = deepmerge(parentPrompts, config.prompts, {
-        arrayMerge: (_d, s) => s,
-      });
-    } else {
-      // No inheritance, just take own settings and prompts
-      settings = deepmerge({}, config.settings, {
-        arrayMerge: (_d, s) => s,
-      });
-      prompts = deepmerge({}, config.prompts, {
         arrayMerge: (_d, s) => s,
       });
     }

--- a/src/commands/system/mainViewCommands.ts
+++ b/src/commands/system/mainViewCommands.ts
@@ -27,6 +27,17 @@ function logRefreshError(error: unknown, context: string): void {
 }
 
 /**
+ * Post options to webview. Synchronous since we don't handle postMessage result.
+ */
+function postOptionsToWebview(
+  webview: vscode.WebviewView,
+  command: string,
+  options: unknown,
+): void {
+  webview.webview.postMessage({ command, options });
+}
+
+/**
  * Registers main view commands for the extension
  * @param context - The VS Code extension context
  * @returns Object containing the registered commands
@@ -36,18 +47,16 @@ export function registerMainViewCommands(context: vscode.ExtensionContext) {
     mainViewCommands.reset,
     async () => {
       const webviewView = await getMainWebview(CHANNEL);
-
-      if (webviewView) {
-        webviewView.webview.postMessage({
-          command: MAIN_VIEW_COMMANDS.STATE_RESTORE,
-          state: {},
-        });
-      } else {
-        // Log warning when webview is not available
+      if (!webviewView) {
         vscode.window.showWarningMessage(
           'Main view is not available. Please ensure the TeXRA view is open.',
         );
+        return;
       }
+      webviewView.webview.postMessage({
+        command: MAIN_VIEW_COMMANDS.STATE_RESTORE,
+        state: {},
+      });
     },
   );
 
@@ -62,10 +71,11 @@ export function registerMainViewCommands(context: vscode.ExtensionContext) {
 
       try {
         const options = await computeModelOptions();
-        webview.webview.postMessage({
-          command: MAIN_VIEW_COMMANDS.SET_MODEL_OPTIONS,
+        postOptionsToWebview(
+          webview,
+          MAIN_VIEW_COMMANDS.SET_MODEL_OPTIONS,
           options,
-        });
+        );
       } catch (error) {
         logRefreshError(error, 'refresh model options');
       }
@@ -82,13 +92,13 @@ export function registerMainViewCommands(context: vscode.ExtensionContext) {
       if (!webview) return;
 
       try {
-        // Reload agent index to pick up config changes
         await refresh();
         const options = await computeAgentOptions();
-        webview.webview.postMessage({
-          command: MAIN_VIEW_COMMANDS.SET_AGENT_OPTIONS,
+        postOptionsToWebview(
+          webview,
+          MAIN_VIEW_COMMANDS.SET_AGENT_OPTIONS,
           options,
-        });
+        );
       } catch (error) {
         logRefreshError(error, 'refresh agent options');
       }
@@ -106,21 +116,21 @@ export function registerMainViewCommands(context: vscode.ExtensionContext) {
       if (!webview) return;
 
       try {
-        // Reload agent index first, then compute both in parallel
         await refresh();
         const [modelOptions, agentOptions] = await Promise.all([
           computeModelOptions(),
           computeAgentOptions(),
         ]);
-
-        webview.webview.postMessage({
-          command: MAIN_VIEW_COMMANDS.SET_MODEL_OPTIONS,
-          options: modelOptions,
-        });
-        webview.webview.postMessage({
-          command: MAIN_VIEW_COMMANDS.SET_AGENT_OPTIONS,
-          options: agentOptions,
-        });
+        postOptionsToWebview(
+          webview,
+          MAIN_VIEW_COMMANDS.SET_MODEL_OPTIONS,
+          modelOptions,
+        );
+        postOptionsToWebview(
+          webview,
+          MAIN_VIEW_COMMANDS.SET_AGENT_OPTIONS,
+          agentOptions,
+        );
       } catch (error) {
         logRefreshError(error, 'refresh options');
       }

--- a/src/model/computeModelOptions.ts
+++ b/src/model/computeModelOptions.ts
@@ -24,10 +24,6 @@ function formatCost(inputPrice?: number, outputPrice?: number): string {
 /**
  * Check if a model is available via personal API keys.
  * Called only when server-side access is not available and user is in "Use My Own Keys" mode.
- *
- * @param config - Model configuration
- * @param hasOpenRouter - Whether user has OpenRouter API key
- * @returns Whether the model is available via personal keys
  */
 async function checkPersonalKeyAvailability(
   config: {
@@ -42,27 +38,25 @@ async function checkPersonalKeyAvailability(
     return hasOpenRouter;
   }
 
+  // Providers not in API_PROVIDERS don't require keys (e.g., COPILOT)
   const provider = config.provider;
-
-  // Check provider-specific API key
-  if (SecretManager.API_PROVIDERS.includes(provider as ApiProvider)) {
-    try {
-      const hasProviderKey = await SecretManager.apiKeyExists(
-        provider as ApiProvider,
-      );
-      if (hasProviderKey) {
-        return true;
-      }
-      // Check OpenRouter as fallback for models that support it
-      return !!(config.openrouterFullName && hasOpenRouter);
-    } catch (error) {
-      console.warn(`Failed to check API key for ${provider}:`, error);
-      return false;
-    }
+  if (!SecretManager.API_PROVIDERS.includes(provider as ApiProvider)) {
+    return true;
   }
 
-  // Providers not in API_PROVIDERS don't require keys (e.g., COPILOT)
-  return true;
+  // Check provider-specific API key
+  try {
+    const hasProviderKey = await SecretManager.apiKeyExists(
+      provider as ApiProvider,
+    );
+    if (hasProviderKey) return true;
+
+    // Fall back to OpenRouter for models that support it
+    return Boolean(config.openrouterFullName && hasOpenRouter);
+  } catch (error) {
+    console.warn(`Failed to check API key for ${provider}:`, error);
+    return false;
+  }
 }
 
 /**
@@ -132,7 +126,8 @@ export async function computeModelOptions(): Promise<string> {
 
       const attrs = [
         `value="${model}"`,
-        !available && 'data-requires-key="true" class="disabled-option disabled-model"',
+        !available &&
+          'data-requires-key="true" class="disabled-option disabled-model"',
         provider && `data-provider="${provider}"`,
         contextStr && `data-context="${contextStr}"`,
         costStr && `data-cost="${costStr}"`,


### PR DESCRIPTION
- agentRegistry.ts: Extract groupByVariants helper to consolidate duplicate grouping logic; simplify deduplicateByName to use composite keys for remote agents; clarify filterVisible with explicit isVisible helper function
- computeModelOptions.ts: Use early returns in checkPersonalKeyAvailability; replace filter(Boolean) pattern with explicit if statements for attribute building
- ModelFactory.ts: Replace ternary with if statement for OpenRouter routing
- agentLoad.ts: Remove redundant deepmerge when no parent inheritance, use spread instead
- AgentDataclass.ts: Reuse deriveAgentCategory in normalizeAgentSettingInput
- mainViewCommands.ts: Extract postOptionsToWebview helper, use early return in reset command

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> - **Agent registry:** Introduces generic `groupByVariants` and reuses it for local/remote agents; simplifies `loadRemoteAgents`; changes dedup to use composite keys for `remote` (avoid collapsing), and clarifies visibility via `isVisible` helper.
> - **Agent loading:** Initialize settings/prompts via spread; only `deepmerge` when `inherits` is set; clearer error when parent missing; preserve tool resolution and validation.
> - **Webview commands:** Adds `postOptionsToWebview` helper and early-return flow in `reset`; uses helper to post refreshed model/agent options.
> - **ModelFactory:** Clarifies OpenRouter routing with explicit `if` branches; OpenAI Responses API handling unchanged but more explicit.
> - **Model options:** Refactors `checkPersonalKeyAvailability` with early returns and provider key checks; minor attribute building tweaks.
> - **Agent schema:** Normalizes settings by deriving `agentCategory` from `agentType` when absent.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 98d604df4379ec1e745a10160967a3f9f0828d72. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->