### PR TITLE
Simplify and improve code clarity

### DIFF
--- a/src/agent/core/flows/CommonCycleTypes.ts
+++ b/src/agent/core/flows/CommonCycleTypes.ts
@@ -97,18 +97,6 @@ export const BaseCycleFieldsSchema = z.object({
 export type BaseCycleFields = z.infer<typeof BaseCycleFieldsSchema>;
 
 /**
- * Reset values for base cycle fields (excludes messages which persists).
- * Co-located with schema as single source of truth for reset behavior.
- */
-export const BASE_CYCLE_RESET_VALUES: Omit<BaseCycleFields, 'messages'> = {
-  shouldStop: false,
-  endTurn: false,
-  responseTimeMs: undefined,
-  stopReason: undefined,
-  lastError: undefined,
-};
-
-/**
  * Unified debug context used across all cycle flows.
  * Provides consistent logging and execution tracking.
  *
@@ -125,36 +113,12 @@ export interface CycleDebugContext {
 }
 
 /**
- * Minimal services interface for deriving debug context.
- * Both ResponseCycleServices and ToolUseCycleServices satisfy this.
- */
-export interface DebugContextServices {
-  logger: AgentLogger;
-  executionId?: ExecutionId;
-}
-
-/**
- * Parameters for creating debug context (fields not available in services).
- */
-export interface DebugContextParams {
-  modelName?: string;
-  isRemote?: boolean;
-}
-
-/**
  * Derive CycleDebugContext from services at call site.
- *
- * This eliminates redundant storage of logger/executionId in shared state.
- * Call this at each `maybeSaveDebugObject` invocation instead of storing
- * the context in shared or passing through prep/exec results.
- *
- * @param services - Services containing logger and context
- * @param params - Additional params not available from services (modelName, isRemote)
- * @returns CycleDebugContext for maybeSaveDebugObject
+ * Eliminates redundant storage of logger/executionId in shared state.
  */
 export function getDebugContext(
-  services: DebugContextServices,
-  params: DebugContextParams,
+  services: { logger: AgentLogger; executionId?: ExecutionId },
+  params: { modelName?: string; isRemote?: boolean },
 ): CycleDebugContext {
   return {
     logger: services.logger,

--- a/src/agent/core/flows/CycleServices.ts
+++ b/src/agent/core/flows/CycleServices.ts
@@ -100,22 +100,16 @@ export async function finalizeRound(slices: CycleStateSlices): Promise<void> {
   }
 }
 
-/** Input for tool-use cycle finalization. */
-export interface ToolUseCycleFinalizeInput {
-  cycleIndex: number;
-  responseTimeMs: number;
-  normalizedUsage: NormalizedUsage | null;
-  run: BaseCycleStateSlices['run'];
-  onRoundFinalized?: RoundFinalizedCallback;
-}
-
 /** Finalize a tool-use cycle by recording metrics directly. */
 export async function finalizeToolUseCycle(
-  input: ToolUseCycleFinalizeInput,
+  cycleIndex: number,
+  responseTimeMs: number,
+  normalizedUsage: NormalizedUsage | null,
+  run: AgentRunState,
+  onRoundFinalized?: RoundFinalizedCallback,
 ): Promise<void> {
-  const { cycleIndex, responseTimeMs, normalizedUsage, run } = input;
   run.recordCycleMetrics(cycleIndex, responseTimeMs, normalizedUsage);
-  if (input.onRoundFinalized) {
-    await input.onRoundFinalized(run);
+  if (onRoundFinalized) {
+    await onRoundFinalized(run);
   }
 }

--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -545,8 +545,15 @@ class ResponseProcessNode<C> extends BaseNode<
       );
 
       if (repetitionResult.massiveRepetitionDetected && newResponse) {
-        const preview = newResponse.substring(0, REPETITION_DETECTION_THRESHOLD);
-        const skeleton = JSON.stringify(messageToSkeleton(prepRes.messages), null, 2);
+        const preview = newResponse.substring(
+          0,
+          REPETITION_DETECTION_THRESHOLD,
+        );
+        const skeleton = JSON.stringify(
+          messageToSkeleton(prepRes.messages),
+          null,
+          2,
+        );
         logger.error(
           `Massive repetition detected - skipping this response\n` +
             `First ${REPETITION_DETECTION_THRESHOLD} chars: ${preview}\n` +

--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -55,27 +55,6 @@ import {
 // All debug options (context + file options) are derived at maybeSaveDebugObject call sites.
 
 // ============================================================================
-// Helpers
-// ============================================================================
-
-type ErrorLogger = { error: (msg: string) => void };
-
-/** Log detailed repetition detection error for debugging. */
-function logRepetitionDetected(
-  newResponse: string,
-  messages: ProviderMessage[],
-  logger: ErrorLogger,
-): void {
-  const preview = newResponse.substring(0, REPETITION_DETECTION_THRESHOLD);
-  const skeleton = JSON.stringify(messageToSkeleton(messages), null, 2);
-  logger.error(
-    `Massive repetition detected - skipping this response\n` +
-      `First ${REPETITION_DETECTION_THRESHOLD} chars: ${preview}\n` +
-      `Message structure:\n${skeleton}`,
-  );
-}
-
-// ============================================================================
 // Cycle Fields Schema (Extends Base)
 // ============================================================================
 
@@ -566,7 +545,13 @@ class ResponseProcessNode<C> extends BaseNode<
       );
 
       if (repetitionResult.massiveRepetitionDetected && newResponse) {
-        logRepetitionDetected(newResponse, prepRes.messages, logger);
+        const preview = newResponse.substring(0, REPETITION_DETECTION_THRESHOLD);
+        const skeleton = JSON.stringify(messageToSkeleton(prepRes.messages), null, 2);
+        logger.error(
+          `Massive repetition detected - skipping this response\n` +
+            `First ${REPETITION_DETECTION_THRESHOLD} chars: ${preview}\n` +
+            `Message structure:\n${skeleton}`,
+        );
       }
 
       let processedResponse: string | undefined;

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -179,21 +179,6 @@ export const ToolUseCycleFieldsSchema = BaseCycleFieldsSchema.extend({
 export type ToolUseCycleFields = z.infer<typeof ToolUseCycleFieldsSchema>;
 
 /**
- * Reset tool-use cycle state for a new iteration.
- * Called at the start of each cycle to clear transient fields.
- */
-function resetToolUseState(shared: ToolUseCycleShared): void {
-  resetCycleState(shared, [
-    'response',
-    'toolCalls',
-    'text',
-    'cycleNormalizedUsage',
-  ]);
-  shared.cycleResponseTimeMs = 0;
-  // Note: cycleIndex is incremented in ToolUseProcessNode.post(), not reset here
-}
-
-/**
  * Shared state for tool-use cycle flows.
  *
  * Uses flat structure (like ResponseCycleFlow) for consistency.
@@ -238,7 +223,13 @@ class ToolUsePrepNode<C> extends BaseNode<
 
     // Reset at the start of each cycle so downstream nodes observe a clean
     // runtime state before enriching it with model responses.
-    resetToolUseState(shared);
+    resetCycleState(shared, [
+      'response',
+      'toolCalls',
+      'text',
+      'cycleNormalizedUsage',
+    ]);
+    shared.cycleResponseTimeMs = 0;
 
     const { modelName, agentName } = this.services;
     await maybeSaveDebugObject({
@@ -586,13 +577,13 @@ class ToolUseProcessNode<C> extends BaseNode<
     }
 
     // Finalize cycle using direct values (no round object needed)
-    await finalizeToolUseCycle({
-      cycleIndex: shared.cycleIndex,
-      responseTimeMs: shared.cycleResponseTimeMs,
-      normalizedUsage: shared.cycleNormalizedUsage ?? null,
+    await finalizeToolUseCycle(
+      shared.cycleIndex,
+      shared.cycleResponseTimeMs,
+      shared.cycleNormalizedUsage ?? null,
       run,
       onRoundFinalized,
-    });
+    );
     run.incrementRounds();
 
     shared.stopReason = execRes.stopReason;

--- a/src/agent/implementations/flows/reflection/nodes/ResponseCycleNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/ResponseCycleNode.ts
@@ -41,7 +41,6 @@ import {
   finalizeRound,
   type CycleStateSlices,
 } from '@agent/core/flows/CycleServices';
-import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
 import type { AgentFileLocation } from '@utils/files';
 
 import {
@@ -69,32 +68,6 @@ type CycleExecResult =
   | ({ kind: 'success'; endTurn: boolean } & CycleCompletionResult &
       CycleStateSlices)
   | { kind: 'error'; error: Error };
-
-// ============================================================================
-// Helpers
-// ============================================================================
-
-/**
- * Initialize cycle fields on shared state for native nesting.
- * Resets all transient cycle state before running the cycle flow.
- */
-function initializeCycleFields(
-  shared: ReflectionFlowShared,
-  messages: ProviderMessage[],
-  outputLocation: AgentFileLocation,
-): void {
-  shared.messages = messages;
-  shared.outputLocation = outputLocation;
-  shared.endTurn = false;
-  shared.shouldStop = false;
-  shared.outputExists = false;
-  shared.systemPrompt = undefined;
-  shared.responseObject = undefined;
-  shared.responseTimeMs = undefined;
-  shared.stopReason = undefined;
-  shared.processedResponse = undefined;
-  shared.lastError = undefined;
-}
 
 // ============================================================================
 // Node Implementation
@@ -189,11 +162,17 @@ export class ResponseCycleNode<C = unknown> extends Node<
 
     try {
       // Initialize cycle fields for native nesting
-      initializeCycleFields(
-        shared,
-        initializedMessages,
-        prepRes.outputLocation,
-      );
+      shared.messages = initializedMessages;
+      shared.outputLocation = prepRes.outputLocation;
+      shared.endTurn = false;
+      shared.shouldStop = false;
+      shared.outputExists = false;
+      shared.systemPrompt = undefined;
+      shared.responseObject = undefined;
+      shared.responseTimeMs = undefined;
+      shared.stopReason = undefined;
+      shared.processedResponse = undefined;
+      shared.lastError = undefined;
 
       // Create and run the flow directly on shared (native nesting)
       // Spread parent services directly - no intermediate cycleOptions object

--- a/src/agent/implementations/flows/tooluse/ToolUseFlowContext.ts
+++ b/src/agent/implementations/flows/tooluse/ToolUseFlowContext.ts
@@ -41,33 +41,22 @@ export interface ToolUseFlowContext<C = unknown> {
 // Tool Resolution
 // ============================================================================
 
-interface ToolResolutionContext {
-  toolRegistry: IToolRegistry;
-  logger: { warn: (msg: string) => void };
-}
-
-/** Normalize tool config to a ToolDefinition. */
-function normalizeToolConfig(config: string | ToolDefinition): ToolDefinition {
-  return typeof config === 'string' ? { name: config } : config;
-}
-
 /**
  * Resolve tool definitions from agent settings, validating against registry.
  * Optionally injects the memory tool if enabled in user settings.
  */
 function resolveTools(
   tools: AgentToolUseSetting['tools'],
-  ctx: ToolResolutionContext,
+  toolRegistry: IToolRegistry,
+  logger: { warn: (msg: string) => void },
 ): ToolDefinition[] {
-  const { toolRegistry, logger } = ctx;
   const toolConfigs = Array.isArray(tools) ? tools : [];
 
-  // Resolve configured tools
   const resolved: ToolDefinition[] = [];
   const resolvedNames = new Set<string>();
 
   for (const config of toolConfigs) {
-    const def = normalizeToolConfig(config);
+    const def = typeof config === 'string' ? { name: config } : config;
 
     if (!toolRegistry.has(def.name)) {
       logger.warn(`Tool "${def.name}" not found in registry`);
@@ -104,7 +93,7 @@ export function createToolUseFlowContext<C = unknown>(
   const toolRegistry = init.toolRegistry ?? getDefaultToolRegistry();
   const sessionLifecycle = new ToolUseSessionLifecycle(streamId);
 
-  const resolvedTools = resolveTools(setting.tools, { toolRegistry, logger });
+  const resolvedTools = resolveTools(setting.tools, toolRegistry, logger);
 
   const services: ToolUseServices<C> = {
     ...init,

--- a/src/progressView/modules/formatters/logFormatters/messageFormatters.js
+++ b/src/progressView/modules/formatters/logFormatters/messageFormatters.js
@@ -46,7 +46,13 @@ export const formatUserMessage = (normalizedPayload, logId, timestamp) => {
  * @returns {HTMLElement} Progress status element
  */
 export const formatProgressStatus = (message) => {
-  const { normalizedPayload = {}, level = 'info', id, groupId, timestamp } = message;
+  const {
+    normalizedPayload = {},
+    level = 'info',
+    id,
+    groupId,
+    timestamp,
+  } = message;
   const { fullTimestamp, timeDisplay, tooltipTimestamp } = formatTimestamp(
     new Date(timestamp ?? Date.now()),
   );
@@ -58,7 +64,11 @@ export const formatProgressStatus = (message) => {
   const emoji = EMOJI_BY_LEVEL[level] || '•';
 
   const container = document.createElement('div');
-  setElementDataset(container, { logId: id, groupId, timestamp: fullTimestamp });
+  setElementDataset(container, {
+    logId: id,
+    groupId,
+    timestamp: fullTimestamp,
+  });
 
   const summaryLine = document.createElement('div');
   summaryLine.className = 'log-line';

--- a/src/progressView/modules/uiManagers/BaseUIRequestManager.js
+++ b/src/progressView/modules/uiManagers/BaseUIRequestManager.js
@@ -181,7 +181,8 @@ export class BaseUIRequestManager {
 
     const activeStream = this.activeStream;
     const shouldDisplay =
-      this._meetsAgentRequirement() && Boolean(activeStream && activeStream.length);
+      this._meetsAgentRequirement() &&
+      Boolean(activeStream && activeStream.length);
 
     const fragment = document.createDocumentFragment();
     for (const entry of this.requests.values()) {

--- a/src/progressView/modules/uiManagers/Status.js
+++ b/src/progressView/modules/uiManagers/Status.js
@@ -150,7 +150,8 @@ export class Status {
         .filter(
           (el) =>
             el &&
-            (this._executionAvailable || !EXECUTION_DEPENDENT_BUTTONS.has(el.id)),
+            (this._executionAvailable ||
+              !EXECUTION_DEPENDENT_BUTTONS.has(el.id)),
         );
       if (elementsToEnable.length > 0) {
         setElementsDisabled(elementsToEnable, false);

--- a/src/tools/ReadTool.ts
+++ b/src/tools/ReadTool.ts
@@ -116,7 +116,7 @@ export class ReadFileTool extends defineTool({
       requestedEndLine,
       truncated,
       rangeProvided: Boolean(input.range),
-       
+
       rangeEndExceeded:
         input.range?.end != null && input.range.end > totalLines,
     });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Refactors cycle flows and tool-use context for clarity and reduced indirection.
> 
> - Core: simplify `getDebugContext` typing; remove unused reset/constants/interfaces; rely on `resetCycleState` for per-cycle resets
> - ResponseCycleFlow: inline massive-repetition logging; keep state mutations in post() and persist debug artifacts via derived context
> - ToolUseCycleFlow: reset transient fields directly; accumulate metrics; change `finalizeToolUseCycle` to use positional args instead of an input object
> - Reflection ResponseCycleNode: inline initialization of cycle fields; drop unused imports; run cycle with native nesting
> - ToolUseFlowContext: simplify `resolveTools` (direct params, inline string→definition conversion)
> - Progress view (UI): minor formatting/dataset destructuring and visibility logic cleanups (no functional change)
> - ReadTool: trivial whitespace tidy-up
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 88d81a0a51756f3c4bf8deb8fb4ce2e29ab1dd2c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->