### PR TITLE
Simplify and improve code clarity

### DIFF
--- a/src/agent/implementations/flows/reflection/runReflectionFlow.ts
+++ b/src/agent/implementations/flows/reflection/runReflectionFlow.ts
@@ -104,82 +104,6 @@ export interface RunReflectionFlowResult {
 }
 
 // ============================================================================
-// Configuration Derivation
-// ============================================================================
-
-interface DerivedConfig {
-  useScratchpad: boolean;
-  shouldEnsureXmlStructure: boolean;
-  totalRounds: number;
-  outputExt: string;
-}
-
-/** XML structure mode lookup - explicit setting takes precedence. */
-const XML_STRUCTURE_MODE_MAP: Record<
-  NonNullable<AgentWorkflowSetting['xmlStructureMode']>,
-  boolean | 'scratchpad'
-> = {
-  always: true,
-  scratchpadOnly: 'scratchpad',
-  never: false,
-};
-
-/** Agent type defaults when xmlStructureMode is not set. */
-const AGENT_TYPE_XML_DEFAULTS: Record<string, boolean | 'scratchpad'> = {
-  CoT: true,
-  direct: 'scratchpad',
-};
-
-/** Determine if XML structure enforcement is needed based on settings and scratchpad usage. */
-function shouldEnforceXmlStructure(
-  setting: AgentWorkflowSetting,
-  useScratchpad: boolean,
-): boolean {
-  const mode =
-    setting.xmlStructureMode !== undefined
-      ? XML_STRUCTURE_MODE_MAP[setting.xmlStructureMode]
-      : (AGENT_TYPE_XML_DEFAULTS[setting.agentType] ?? false);
-
-  return mode === 'scratchpad' ? useScratchpad : mode;
-}
-
-/** Compute the total number of rounds based on settings and prompt. */
-function computeTotalRounds(
-  setting: AgentWorkflowSetting,
-  prompt: RunReflectionFlowInput['prompt'],
-): number {
-  if (setting.maxRounds !== undefined) {
-    return setting.maxRounds;
-  }
-
-  if (setting.agentType === 'direct') {
-    return 1;
-  }
-
-  const requests = Array.isArray(prompt.userRequest)
-    ? prompt.userRequest
-    : prompt.userRequest
-      ? [prompt.userRequest]
-      : [];
-  return Math.max(setting.rounds ?? 2, requests.length);
-}
-
-/** Derive configuration values from settings and prompts. */
-function deriveConfig(
-  setting: AgentWorkflowSetting,
-  prompt: RunReflectionFlowInput['prompt'],
-): DerivedConfig {
-  const useScratchpad = setting.prefills?.includes('<scratchpad>') ?? false;
-
-  return {
-    useScratchpad,
-    shouldEnsureXmlStructure: shouldEnforceXmlStructure(setting, useScratchpad),
-    totalRounds: computeTotalRounds(setting, prompt),
-    outputExt: useScratchpad ? 'xml' : setting.outputExt,
-  };
-}
-
-// ============================================================================
 // Flow Runner
 // ============================================================================
 
@@ -244,9 +168,45 @@ export async function runReflectionFlow<C = unknown>(
 
   const latexMediaManager = new LatexMediaManager(logger, fileService);
 
-  // Derive configuration values
-  const { useScratchpad, shouldEnsureXmlStructure, totalRounds, outputExt } =
-    deriveConfig(setting, prompt);
+  // Derive configuration values inline (these helpers were only called once)
+  const useScratchpad = setting.prefills?.includes('<scratchpad>') ?? false;
+  const outputExt = useScratchpad ? 'xml' : setting.outputExt;
+
+  // Compute XML structure enforcement based on mode setting or agent type defaults
+  const xmlMode = setting.xmlStructureMode;
+  let shouldEnsureXmlStructure: boolean;
+  if (xmlMode === 'always') {
+    shouldEnsureXmlStructure = true;
+  } else if (xmlMode === 'never') {
+    shouldEnsureXmlStructure = false;
+  } else if (xmlMode === 'scratchpadOnly') {
+    shouldEnsureXmlStructure = useScratchpad;
+  } else {
+    // No explicit mode - use agent type defaults
+    const agentType = setting.agentType;
+    if (agentType === 'CoT') {
+      shouldEnsureXmlStructure = true;
+    } else if (agentType === 'direct') {
+      shouldEnsureXmlStructure = useScratchpad;
+    } else {
+      shouldEnsureXmlStructure = false;
+    }
+  }
+
+  // Compute total rounds
+  let totalRounds: number;
+  if (setting.maxRounds !== undefined) {
+    totalRounds = setting.maxRounds;
+  } else if (setting.agentType === 'direct') {
+    totalRounds = 1;
+  } else {
+    const requests = Array.isArray(prompt.userRequest)
+      ? prompt.userRequest
+      : prompt.userRequest
+        ? [prompt.userRequest]
+        : [];
+    totalRounds = Math.max(setting.rounds ?? 2, requests.length);
+  }
 
   // Create output file location getter
   const modelName = modelHandler.config.name;

--- a/src/agent/implementations/flows/tooluse/ToolUseFlowContext.ts
+++ b/src/agent/implementations/flows/tooluse/ToolUseFlowContext.ts
@@ -38,49 +38,6 @@ export interface ToolUseFlowContext<C = unknown> {
 }
 
 // ============================================================================
-// Tool Resolution
-// ============================================================================
-
-/**
- * Resolve tool definitions from agent settings, validating against registry.
- * Optionally injects the memory tool if enabled in user settings.
- */
-function resolveTools(
-  tools: AgentToolUseSetting['tools'],
-  toolRegistry: IToolRegistry,
-  logger: { warn: (msg: string) => void },
-): ToolDefinition[] {
-  const toolConfigs = Array.isArray(tools) ? tools : [];
-
-  const resolved: ToolDefinition[] = [];
-  const resolvedNames = new Set<string>();
-
-  for (const config of toolConfigs) {
-    const def = typeof config === 'string' ? { name: config } : config;
-
-    if (!toolRegistry.has(def.name)) {
-      logger.warn(`Tool "${def.name}" not found in registry`);
-      continue;
-    }
-
-    resolved.push(def);
-    resolvedNames.add(def.name);
-  }
-
-  // Auto-inject memory tool if enabled and not already configured
-  if (getToolUseMemoryEnabled() && !resolvedNames.has('memory')) {
-    const memoryTool = toolRegistry.get('memory');
-    if (memoryTool) {
-      resolved.push(memoryTool.definition);
-    } else {
-      logger.warn('Memory tool not found in registry');
-    }
-  }
-
-  return resolved;
-}
-
-// ============================================================================
 // Factory Function
 // ============================================================================
 
@@ -93,7 +50,30 @@ export function createToolUseFlowContext<C = unknown>(
   const toolRegistry = init.toolRegistry ?? getDefaultToolRegistry();
   const sessionLifecycle = new ToolUseSessionLifecycle(streamId);
 
-  const resolvedTools = resolveTools(setting.tools, toolRegistry, logger);
+  // Resolve tool definitions inline (previously a separate function called once)
+  const toolConfigs = Array.isArray(setting.tools) ? setting.tools : [];
+  const resolvedTools: ToolDefinition[] = [];
+  const resolvedNames = new Set<string>();
+
+  for (const config of toolConfigs) {
+    const def = typeof config === 'string' ? { name: config } : config;
+    if (!toolRegistry.has(def.name)) {
+      logger.warn(`Tool "${def.name}" not found in registry`);
+      continue;
+    }
+    resolvedTools.push(def);
+    resolvedNames.add(def.name);
+  }
+
+  // Auto-inject memory tool if enabled and not already configured
+  if (getToolUseMemoryEnabled() && !resolvedNames.has('memory')) {
+    const memoryTool = toolRegistry.get('memory');
+    if (memoryTool) {
+      resolvedTools.push(memoryTool.definition);
+    } else {
+      logger.warn('Memory tool not found in registry');
+    }
+  }
 
   const services: ToolUseServices<C> = {
     ...init,

--- a/src/agent/index/agentRegistry.ts
+++ b/src/agent/index/agentRegistry.ts
@@ -611,7 +611,10 @@ function filterVisible(
 ): AgentEntry[] {
   if (configured.size === 0) return entries;
 
-  const autoShowRemote = getConfig<boolean>('texra.remoteAgents.autoShow', true);
+  const autoShowRemote = getConfig<boolean>(
+    'texra.remoteAgents.autoShow',
+    true,
+  );
 
   function isVisible(entry: AgentEntry): boolean {
     // Remote agents auto-show when setting is enabled

--- a/src/agent/modelHandlers/openAIMessageUtils.ts
+++ b/src/agent/modelHandlers/openAIMessageUtils.ts
@@ -45,7 +45,11 @@ function mergeMessageContent(
       return;
     }
 
-    if (prevContent === null || prevContent === undefined || prevContent === '') {
+    if (
+      prevContent === null ||
+      prevContent === undefined ||
+      prevContent === ''
+    ) {
       previous.content = clonedCurrent;
     }
     return;

--- a/src/tools/arxiv/ArxivMetadataTool.ts
+++ b/src/tools/arxiv/ArxivMetadataTool.ts
@@ -54,7 +54,10 @@ export class ArxivMetadataTool extends defineTool({
     }
 
     const targetEntry = entries[0];
-    const base = extractBasePaperMetadata(targetEntry, input.maxAuthors ?? undefined);
+    const base = extractBasePaperMetadata(
+      targetEntry,
+      input.maxAuthors ?? undefined,
+    );
     const includeAbstract = input.includeAbstract ?? true;
 
     const metadata: ArxivPaperMetadata = {


### PR DESCRIPTION
- Inline deriveConfig(), shouldEnforceXmlStructure(), and computeTotalRounds() directly in runReflectionFlow.ts - these were only called once

- Remove XML_STRUCTURE_MODE_MAP and AGENT_TYPE_XML_DEFAULTS lookup maps, replacing with clearer if/else chains in runReflectionFlow.ts

- Inline resolveTools() directly in createToolUseFlowContext() - it was only called once

- Apply code formatting via Prettier

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Simplifies flow setup by inlining one-off helpers; minor formatting cleanups.**
> 
> - In `runReflectionFlow.ts`, inlines `deriveConfig`, `shouldEnforceXmlStructure`, and `computeTotalRounds` logic directly: computes `useScratchpad`, `outputExt`, XML structure enforcement, and `totalRounds` inline
> - In `ToolUseFlowContext.ts`, inlines tool resolution (including memory tool auto-injection) into `createToolUseFlowContext`
> - Minor readability/formatting updates in `agentRegistry.ts` (`getConfig` call split), `openAIMessageUtils.ts` (expanded null/empty check), and `ArxivMetadataTool.ts` (multi-line arg formatting)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cfcae9b8996f905d82fa28cad5e84615d0a3fffe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->