### PR TITLE
Remove extra characters from YAML output

### DIFF
--- a/src/progressView/modules/formatters/normalizers.js
+++ b/src/progressView/modules/formatters/normalizers.js
@@ -53,7 +53,10 @@ export function stringifyForDisplay(value) {
   }
 
   try {
-    const yamlString = yaml.stringify(value);
+    const yamlString = yaml.stringify(value, {
+      lineWidth: 0, // Disable line wrapping to avoid block scalar indicators
+      blockQuote: false, // Prefer inline strings over block scalars
+    });
     return typeof yamlString === 'string' ? yamlString.trimEnd() : '';
   } catch {
     return String(value);


### PR DESCRIPTION
Configure yaml.stringify() with lineWidth: 0 and blockQuote: false to avoid block scalar indicators like "|-", "|2-" appearing in rendered tool results. Multiline strings are now displayed as escaped inline strings instead.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts YAML rendering in `stringifyForDisplay` to avoid block scalar indicators and wrapping.
> 
> - Configure `yaml.stringify(value, { lineWidth: 0, blockQuote: false })` in `normalizers.js`
> - Multiline strings now render as escaped inline strings instead of block scalars (removes markers like `"|-"`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a339b735e6c121f0841423d14c64ac8813e0e0fc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->