### PR TITLE
Simplify and improve code clarity

### DIFF
--- a/src/frontend/files/listing.ts
+++ b/src/frontend/files/listing.ts
@@ -4,6 +4,16 @@ import * as path from 'path';
 // Third-party imports
 import * as vscode from 'vscode';
 
+/** Normalize backslashes to forward slashes for consistent comparison */
+function toForwardSlashes(str: string): string {
+  return str.split('\\').join('/');
+}
+
+/** Convert forward slashes to platform-native separators */
+function toPlatformSeparators(str: string): string {
+  return str.split('/').join(path.sep);
+}
+
 function sanitizeDirectories(directories: string[]): string[] {
   return directories
     .map((dir) => dir.trim())
@@ -60,8 +70,7 @@ function getRelativePathPreservingSymlinks(
 
   // If root is the workspace root, return the workspace-relative path
   if (workspaceRoot && path.normalize(root) === path.normalize(workspaceRoot)) {
-    // Normalize separators to platform-native
-    return wsRelative.split('/').join(path.sep);
+    return toPlatformSeparators(wsRelative);
   }
 
   // root is a subdirectory - compute path from workspace-relative path
@@ -73,14 +82,13 @@ function getRelativePathPreservingSymlinks(
   }
 
   // Both paths are workspace-relative, compute relative path between them
-  // Normalize to forward slashes for consistent comparison
-  const wsRelativeNorm = wsRelative.split('\\').join('/');
-  const rootRelativeNorm = rootRelative.split('\\').join('/');
+  const wsRelativeNorm = toForwardSlashes(wsRelative);
+  const rootRelativeNorm = toForwardSlashes(rootRelative);
 
   if (wsRelativeNorm.startsWith(rootRelativeNorm + '/')) {
     // File is under root, strip the root prefix
     const result = wsRelativeNorm.slice(rootRelativeNorm.length + 1);
-    return result.split('/').join(path.sep);
+    return toPlatformSeparators(result);
   }
 
   // File is not under root in workspace structure, use path.relative

--- a/src/frontend/files/listing.ts
+++ b/src/frontend/files/listing.ts
@@ -6,12 +6,12 @@ import * as vscode from 'vscode';
 
 /** Normalize backslashes to forward slashes for consistent comparison */
 function toForwardSlashes(str: string): string {
-  return str.split('\\').join('/');
+  return str.replaceAll('\\', '/');
 }
 
 /** Convert forward slashes to platform-native separators */
 function toPlatformSeparators(str: string): string {
-  return str.split('/').join(path.sep);
+  return str.replaceAll('/', path.sep);
 }
 
 function sanitizeDirectories(directories: string[]): string[] {

--- a/src/frontend/ui/dialogs.ts
+++ b/src/frontend/ui/dialogs.ts
@@ -37,10 +37,7 @@ export async function selectFiles(
   options: FileDialogOptions,
 ): Promise<string[] | null> {
   const defaultUri =
-    options.defaultUri ??
-    (options.currentFile
-      ? getDefaultUri(options.currentFile)
-      : getDefaultUri(''));
+    options.defaultUri ?? getDefaultUri(options.currentFile ?? '');
   if (!defaultUri) {
     vscode.window.showErrorMessage('No workspace folder open');
     return null;

--- a/src/latex/TikzPictureManager.ts
+++ b/src/latex/TikzPictureManager.ts
@@ -17,6 +17,16 @@ import {
 import { getConfig } from '@utils/config';
 
 // Local imports - latex utils
+
+/**
+ * Get the appropriate path from a FileLocation based on its kind.
+ * Uses relativePath for workspace files, absolutePath for external files.
+ */
+function getLocationPath(location: FileLocation): string {
+  return location.kind !== 'external'
+    ? location.relativePath
+    : location.absolutePath;
+}
 import { compileLatex2Pdf } from './texTools';
 
 const CHANNEL = 'LaTeXCommands';
@@ -122,10 +132,7 @@ export class TikzPictureManager {
       });
 
       const filename = suffix ? `${label}_${suffix}.tex` : `${label}.tex`;
-      const buildDir =
-        buildDirLocation.kind !== 'external'
-          ? buildDirLocation.relativePath
-          : buildDirLocation.absolutePath;
+      const buildDir = getLocationPath(buildDirLocation);
       const fileRelativePath = path.join(buildDir, filename);
 
       // Use fileService if available (run-storage aware), otherwise create workspace location
@@ -161,10 +168,7 @@ export class TikzPictureManager {
   ): Promise<FileLocation[]> {
     try {
       const inputName = path.parse(path.basename(latexFile.absolutePath)).name;
-      const inputDir =
-        latexFile.kind !== 'external'
-          ? path.dirname(latexFile.relativePath)
-          : path.dirname(latexFile.absolutePath);
+      const inputDir = path.dirname(getLocationPath(latexFile));
       const buildRelativePath = path.join(inputDir, 'build', inputName);
 
       // Create build directory location (run-storage aware if fileService available)
@@ -211,10 +215,7 @@ export class TikzPictureManager {
           const pdfFilename = path
             .basename(texLocation.absolutePath)
             .replace(/\.tex$/, '.pdf');
-          const texDir =
-            texLocation.kind !== 'external'
-              ? path.dirname(texLocation.relativePath)
-              : path.dirname(texLocation.absolutePath);
+          const texDir = path.dirname(getLocationPath(texLocation));
           const pdfRelativePath = path.join(texDir, pdfFilename);
 
           const pdfLocation = this.fileService

--- a/src/latex/TikzPictureManager.ts
+++ b/src/latex/TikzPictureManager.ts
@@ -17,6 +17,7 @@ import {
 import { getConfig } from '@utils/config';
 
 // Local imports - latex utils
+import { compileLatex2Pdf } from './texTools';
 
 /**
  * Get the appropriate path from a FileLocation based on its kind.
@@ -27,7 +28,6 @@ function getLocationPath(location: FileLocation): string {
     ? location.relativePath
     : location.absolutePath;
 }
-import { compileLatex2Pdf } from './texTools';
 
 const CHANNEL = 'LaTeXCommands';
 logger.initialize(CHANNEL);

--- a/src/latex/arxivProcessor.ts
+++ b/src/latex/arxivProcessor.ts
@@ -29,6 +29,30 @@ export class ArxivSourceProcessor {
     logger.initialize(this.channel);
   }
 
+  /**
+   * Determine file extension from content-type header.
+   * Handles tar, gzip, and tex content types.
+   */
+  private getExtensionFromContentType(contentType: string): string {
+    const isTar = contentType.includes('tar');
+    const isGzip = contentType.includes('gzip') || contentType.includes('gz');
+    const isTex = contentType.includes('tex') || contentType.includes('plain');
+
+    if (isTar && isGzip) {
+      return '.tar.gz';
+    }
+    if (isTar) {
+      return '.tar';
+    }
+    if (isGzip) {
+      return '.gz';
+    }
+    if (isTex) {
+      return '.tex';
+    }
+    return '';
+  }
+
   public isValidId(id: string): boolean {
     const extractedIds = arxivIdentifiers.extract(id);
     return extractedIds.length > 0 && extractedIds.includes(id);
@@ -80,21 +104,8 @@ export class ArxivSourceProcessor {
           );
         }
       } else {
-        const contentType = response.headers['content-type'];
-        let extension = '';
-        if (contentType) {
-          if (contentType.includes('tar')) {
-            extension = '.tar';
-          }
-          if (contentType.includes('gzip') || contentType.includes('gz')) {
-            extension = extension ? `${extension}.gz` : '.gz';
-          } else if (
-            contentType.includes('tex') ||
-            contentType.includes('plain')
-          ) {
-            extension = '.tex';
-          }
-        }
+        const contentType = response.headers['content-type'] ?? '';
+        const extension = this.getExtensionFromContentType(contentType);
         destPath = destBasePath + extension;
       }
 

--- a/src/model/computeModelOptions.ts
+++ b/src/model/computeModelOptions.ts
@@ -124,20 +124,30 @@ export async function computeModelOptions(): Promise<string> {
           : '';
       const costStr = formatCost(config.inputPrice, config.outputPrice);
 
-      const attrs = [
-        `value="${model}"`,
-        !available &&
+      const attrs = [`value="${model}"`];
+      if (!available) {
+        attrs.push(
           'data-requires-key="true" class="disabled-option disabled-model"',
-        provider && `data-provider="${provider}"`,
-        contextStr && `data-context="${contextStr}"`,
-        costStr && `data-cost="${costStr}"`,
-      ].filter(Boolean);
+        );
+      }
+      if (provider) {
+        attrs.push(`data-provider="${provider}"`);
+      }
+      if (contextStr) {
+        attrs.push(`data-context="${contextStr}"`);
+      }
+      if (costStr) {
+        attrs.push(`data-cost="${costStr}"`);
+      }
 
       // Build description from context and cost
-      const descriptionParts = [
-        contextStr && `Context: ${contextStr}`,
-        costStr && `Cost (in/out per 1M): ${costStr}`,
-      ].filter(Boolean);
+      const descriptionParts: string[] = [];
+      if (contextStr) {
+        descriptionParts.push(`Context: ${contextStr}`);
+      }
+      if (costStr) {
+        descriptionParts.push(`Cost (in/out per 1M): ${costStr}`);
+      }
       if (descriptionParts.length > 0) {
         attrs.push(`description="${descriptionParts.join(' | ')}"`);
       }

--- a/src/tools/DiagnosticsTool.ts
+++ b/src/tools/DiagnosticsTool.ts
@@ -8,6 +8,7 @@ import {
   countDiagnosticsBySeverity,
 } from '@frontend/latex/linter';
 import * as logger from '@logger/logUtils';
+import { formatResultCount } from '@tools/utils';
 
 // Local file imports
 import { defineTool } from './core/define';
@@ -80,10 +81,10 @@ export class DiagnosticsTool extends defineTool({
 
     const { errors = 0, warnings = 0, info = 0, hints = 0 } = severity;
     const counts = [
-      errors > 0 && `${errors} error${errors === 1 ? '' : 's'}`,
-      warnings > 0 && `${warnings} warning${warnings === 1 ? '' : 's'}`,
+      errors > 0 && formatResultCount(errors, 'error'),
+      warnings > 0 && formatResultCount(warnings, 'warning'),
       info > 0 && `${info} info`,
-      hints > 0 && `${hints} hint${hints === 1 ? '' : 's'}`,
+      hints > 0 && formatResultCount(hints, 'hint'),
     ]
       .filter(Boolean)
       .join(', ');

--- a/src/tools/TextEditorTool.ts
+++ b/src/tools/TextEditorTool.ts
@@ -31,6 +31,13 @@ const CHANNEL = 'TextEditorTool';
 logger.initialize(CHANNEL);
 const SNIPPET_LINES = 4;
 
+/** Maps API type versions to their corresponding tool names */
+const API_TYPE_TO_NAME = {
+  text_editor_20250429: 'str_replace_based_edit_tool',
+  text_editor_20250124: 'str_replace_editor',
+  text_editor_20241022: 'str_replace_editor',
+} as const;
+
 export const TextEditorInputSchema = z.strictObject({
   command: z.enum(['view', 'create', 'str_replace', 'insert', 'undo_edit']),
   path: z.string(),
@@ -75,10 +82,7 @@ export class TextEditorTool extends defineTool({
       | 'text_editor_20241022'
       | 'text_editor_20250429' = 'text_editor_20250124',
   ) {
-    const name =
-      apiType === 'text_editor_20250429'
-        ? 'str_replace_based_edit_tool'
-        : 'str_replace_editor';
+    const name = API_TYPE_TO_NAME[apiType];
     super({ name });
     this.apiType = apiType;
     this.name = name;

--- a/src/tools/ls.ts
+++ b/src/tools/ls.ts
@@ -71,11 +71,9 @@ export class LsTool extends defineTool({
     }
 
     const ignoreMatchers = input.ignore.map(createGlobMatcher);
-    const matchesCustomIgnore =
-      input.ignore.length === 0
-        ? () => false
-        : (entryPath: string) =>
-            ignoreMatchers.some((matcher) => matcher(entryPath));
+    // Empty array.some() returns false, so no special case needed
+    const matchesCustomIgnore = (entryPath: string): boolean =>
+      ignoreMatchers.some((matcher) => matcher(entryPath));
 
     if (stats.type === vscode.FileType.File) {
       const relativePosix = toPosixPath(relative);

--- a/src/tools/todo/TodoTool.ts
+++ b/src/tools/todo/TodoTool.ts
@@ -25,6 +25,13 @@ import {
   type TodoStatus,
 } from '@eventBus/schemas';
 
+/** Configuration for displaying todo status - icon and label for each status */
+const STATUS_DISPLAY: Record<TodoStatus, { icon: string; label: string }> = {
+  [TODO_STATUS.PENDING]: { icon: '○', label: 'PENDING' },
+  [TODO_STATUS.IN_PROGRESS]: { icon: '◐', label: 'IN PROGRESS' },
+  [TODO_STATUS.COMPLETED]: { icon: '●', label: 'COMPLETED' },
+};
+
 /**
  * Schema for the todo_write tool input.
  * Uses TodoItemSchema from eventBus/schemas as single source of truth.
@@ -131,42 +138,13 @@ Best practices:
 
     for (let i = 0; i < todos.length; i++) {
       const todo = todos[i];
-      const statusIcon = this.getStatusIcon(todo.status);
-      const statusLabel = this.getStatusLabel(todo.status);
-      lines.push(`${i + 1}. ${statusIcon} [${statusLabel}] ${todo.content}`);
+      const { icon, label } = STATUS_DISPLAY[todo.status];
+      lines.push(`${i + 1}. ${icon} [${label}] ${todo.content}`);
       if (todo.status === TODO_STATUS.IN_PROGRESS) {
         lines.push(`   → ${todo.activeForm}...`);
       }
     }
 
     return lines.join('\n');
-  }
-
-  /**
-   * Get a status icon for display.
-   */
-  private getStatusIcon(status: TodoStatus): string {
-    switch (status) {
-      case TODO_STATUS.PENDING:
-        return '○';
-      case TODO_STATUS.IN_PROGRESS:
-        return '◐';
-      case TODO_STATUS.COMPLETED:
-        return '●';
-    }
-  }
-
-  /**
-   * Get a human-readable status label.
-   */
-  private getStatusLabel(status: TodoStatus): string {
-    switch (status) {
-      case TODO_STATUS.PENDING:
-        return 'PENDING';
-      case TODO_STATUS.IN_PROGRESS:
-        return 'IN PROGRESS';
-      case TODO_STATUS.COMPLETED:
-        return 'COMPLETED';
-    }
   }
 }

--- a/src/utils/system/execUtils.ts
+++ b/src/utils/system/execUtils.ts
@@ -100,7 +100,10 @@ export async function executeCommand(
     let result;
     if (Array.isArray(command)) {
       const [cmd, ...args] = command;
-      logger.debug(logChannel, `Running command: ${shellQuote([cmd, ...args])}`);
+      logger.debug(
+        logChannel,
+        `Running command: ${shellQuote([cmd, ...args])}`,
+      );
       result = await execa(cmd, args, execaOptions);
     } else {
       logger.debug(logChannel, `Running command: ${command}`);

--- a/src/utils/system/toolUtils.ts
+++ b/src/utils/system/toolUtils.ts
@@ -285,7 +285,6 @@ export async function checkToolInstalled(
       isInstalled = executeWithFallback(parsed.cmdName, parsed.args);
     }
 
-
     if (!isInstalled && showError) {
       const actions = config.openDocsCommand ? ['View Installation Guide'] : [];
       const choice = await vscode.window.showErrorMessage(

--- a/src/webview/managers/InstructionManager.ts
+++ b/src/webview/managers/InstructionManager.ts
@@ -113,31 +113,31 @@ export class InstructionManager extends BaseWebviewManager {
       this.addMultipleFilesIfValid(
         fileContext,
         'inputFiles',
-        Boolean(message.inputFilesActive),
+        !!message.inputFilesActive,
         message.inputFiles,
       );
       this.addMultipleFilesIfValid(
         fileContext,
         'referenceFiles',
-        Boolean(message.referenceFilesActive),
+        !!message.referenceFilesActive,
         message.referenceFiles,
       );
       this.addMultipleFilesIfValid(
         fileContext,
         'auxiliaryFiles',
-        Boolean(message.auxiliaryFilesActive),
+        !!message.auxiliaryFilesActive,
         message.auxiliaryFiles,
       );
       this.addMultipleFilesIfValid(
         fileContext,
         'mediaFiles',
-        Boolean(message.mediaFilesActive),
+        !!message.mediaFilesActive,
         message.mediaFiles,
       );
       this.addMultipleFilesIfValid(
         fileContext,
         'outputFiles',
-        Boolean(message.outputFilesActive),
+        !!message.outputFilesActive,
         message.outputFiles,
       );
 


### PR DESCRIPTION
- Extract getLocationPath helper for FileLocation path extraction in TikzPictureManager.ts
- Replace API type ternary with object lookup in TextEditorTool.ts
- Use formatResultCount utility in DiagnosticsTool.ts for consistent pluralization
- Simplify conditional function in ls.ts (empty array.some() returns false)
- Consolidate status switch statements to STATUS_DISPLAY map in TodoTool.ts
- Replace condition && 'string' pattern with explicit if statements in computeModelOptions.ts
- Replace redundant Boolean() wrappers with !! in InstructionManager.ts
- Simplify nested ternary with nullish coalescing in dialogs.ts
- Extract toForwardSlashes and toPlatformSeparators helpers in listing.ts
- Extract getExtensionFromContentType method in arxivProcessor.ts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves clarity and consistency via helper extraction and conditional simplification across key modules.
> 
> - Frontend: Added `toForwardSlashes`/`toPlatformSeparators` and refactored symlink-aware relative path logic in `listing.ts`; simplified default URI resolution in `dialogs.ts`.
> - LaTeX: Introduced `getLocationPath` for `FileLocation` in `TikzPictureManager` and `getExtensionFromContentType` in `arxivProcessor` to derive archive/text extensions.
> - Models: Rewrote attribute/description assembly in `computeModelOptions.ts` with explicit conditionals (no truthy-filter pattern).
> - Tools: Used `formatResultCount` in `DiagnosticsTool` for pluralization; mapped API types via constant in `TextEditorTool`; simplified ignore matching in `ls.ts`.
> - TODO/Webview: Consolidated status rendering via `STATUS_DISPLAY` in `TodoTool`; replaced `Boolean()` with `!!` flags in `InstructionManager`.
> - Misc: Minor logging formatting in `execUtils.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 634e35b48ab702cfdebed9fa13f2435e7ff15ee0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->