### PR TITLE
Simplify and improve code clarity

### DIFF
--- a/src/agent/core/ToolTypes.ts
+++ b/src/agent/core/ToolTypes.ts
@@ -101,8 +101,7 @@ export interface IToolRegistry {
 
 /**
  * Simple implementation of IToolRegistry backed by a Map or Record.
- *
- * Use createToolRegistry() to wrap an existing Record<string, ITool>.
+ * Instantiate directly: new MapToolRegistry({ name: tool, ... })
  */
 export class MapToolRegistry implements IToolRegistry {
   private readonly tools: Map<string, ITool>;
@@ -134,16 +133,4 @@ export class MapToolRegistry implements IToolRegistry {
   entries(): IterableIterator<[string, ITool]> {
     return this.tools.entries();
   }
-}
-
-/**
- * Create an IToolRegistry from a Record of tools.
- *
- * @param tools - Record mapping tool names to ITool implementations
- * @returns An IToolRegistry wrapping the tools
- */
-export function createToolRegistry(
-  tools: Record<string, ITool>,
-): IToolRegistry {
-  return new MapToolRegistry(tools);
 }

--- a/src/agent/index/agentRegistry.ts
+++ b/src/agent/index/agentRegistry.ts
@@ -680,36 +680,24 @@ export async function computeAgentOptions(): Promise<AgentOptionsPayload> {
 }
 
 /**
- * Build placeholder options from config when cache isn't ready.
- * Only uses default when no agents are configured.
- */
-function buildPlaceholderOptions(
-  configKey: string,
-  defaultAgent: string,
-): string {
-  const configured = getConfig<string[]>(configKey, []);
-  // Only use default if nothing is configured
-  const agents = configured.length > 0 ? configured : [defaultAgent];
-
-  return agents
-    .map(
-      (name) =>
-        `<vscode-option value="${encodeHtml(name)}">${encodeHtml(name)}</vscode-option>`,
-    )
-    .join('\n');
-}
-
-/**
  * Sync version - returns placeholders from config if not loaded.
  */
 export function computeAgentOptionsSync(): AgentOptionsPayload {
   if (!initialized) {
+    const buildPlaceholder = (configKey: string, defaultAgent: string) => {
+      const configured = getConfig<string[]>(configKey, []);
+      const agents = configured.length > 0 ? configured : [defaultAgent];
+      return agents
+        .map(
+          (name) =>
+            `<vscode-option value="${encodeHtml(name)}">${encodeHtml(name)}</vscode-option>`,
+        )
+        .join('\n');
+    };
+
     return {
-      workflow: buildPlaceholderOptions('texra.agents', DEFAULT_WORKFLOW_AGENT),
-      toolUse: buildPlaceholderOptions(
-        'texra.toolUseAgents',
-        DEFAULT_TOOL_USE_AGENT,
-      ),
+      workflow: buildPlaceholder('texra.agents', DEFAULT_WORKFLOW_AGENT),
+      toolUse: buildPlaceholder('texra.toolUseAgents', DEFAULT_TOOL_USE_AGENT),
     };
   }
   return buildAgentOptions();

--- a/src/latex/extractBibliography.ts
+++ b/src/latex/extractBibliography.ts
@@ -24,10 +24,17 @@ const CITE_COMMANDS = [
   'Footcite',
 ];
 
-const DIRECTIVE_PATTERN_SOURCE =
-  '(?:bibliography|addbibresource)(?:\\s*\\[[^\\]]*\\])?\\s*\\{([^}]*)\\}';
+// Compiled regex patterns (matchAll clones the regex, so module-level is safe)
+const DIRECTIVE_PATTERN = new RegExp(
+  '(?:bibliography|addbibresource)(?:\\s*\\[[^\\]]*\\])?\\s*\\{([^}]*)\\}',
+  'g',
+);
 
-const CITATION_PATTERN_SOURCE = `\\\\(?:${CITE_COMMANDS.join('|')})\\*?(?:\\[[^\\]]*\\])*\{([^}]*)\}`;
+const CITATION_PATTERN = new RegExp(
+  `\\\\(?:${CITE_COMMANDS.join('|')})\\*?(?:\\[[^\\]]*\\])*\\{([^}]*)\\}`,
+  'g',
+);
+
 const COMMENT_PATTERN = /(^|[^\\])%.*$/gm;
 
 export interface BibliographyReferenceResult {
@@ -64,7 +71,7 @@ function normalizeBibPath(baseDir: string, target: string): string {
 function collectBibliographyPaths(baseDir: string, content: string): string[] {
   const paths = new Set<string>();
 
-  for (const match of content.matchAll(new RegExp(DIRECTIVE_PATTERN_SOURCE, 'g'))) {
+  for (const match of content.matchAll(DIRECTIVE_PATTERN)) {
     const block = match[1];
     for (const raw of block.split(',')) {
       const normalized = normalizeBibPath(baseDir, raw);
@@ -80,7 +87,7 @@ function collectBibliographyPaths(baseDir: string, content: string): string[] {
 function collectCitationKeys(content: string): string[] {
   const keys = new Set<string>();
 
-  for (const match of content.matchAll(new RegExp(CITATION_PATTERN_SOURCE, 'g'))) {
+  for (const match of content.matchAll(CITATION_PATTERN)) {
     const block = match[1];
     for (const raw of block.split(',')) {
       const key = raw.trim();

--- a/src/latex/extractBibliography.ts
+++ b/src/latex/extractBibliography.ts
@@ -7,8 +7,6 @@ import { BibEntry, parseBibFile } from 'bibtex';
 // Local imports - utils
 import { WorkspaceFS } from '@utils/files';
 
-const DIRECTIVE_PATTERN_SOURCE =
-  '(?:bibliography|addbibresource)(?:\\s*\\[[^\\]]*\\])?\\s*\\{([^}]*)\\}';
 const CITE_COMMANDS = [
   'cite',
   'citet',
@@ -25,16 +23,11 @@ const CITE_COMMANDS = [
   'Parencite',
   'Footcite',
 ];
-function createDirectivePattern(): RegExp {
-  return new RegExp(DIRECTIVE_PATTERN_SOURCE, 'g');
-}
 
-function createCitationPattern(): RegExp {
-  return new RegExp(
-    `\\\\(?:${CITE_COMMANDS.join('|')})\\*?(?:\\[[^\\]]*\\])*\{([^}]*)\}`,
-    'g',
-  );
-}
+const DIRECTIVE_PATTERN_SOURCE =
+  '(?:bibliography|addbibresource)(?:\\s*\\[[^\\]]*\\])?\\s*\\{([^}]*)\\}';
+
+const CITATION_PATTERN_SOURCE = `\\\\(?:${CITE_COMMANDS.join('|')})\\*?(?:\\[[^\\]]*\\])*\{([^}]*)\}`;
 const COMMENT_PATTERN = /(^|[^\\])%.*$/gm;
 
 export interface BibliographyReferenceResult {
@@ -70,9 +63,8 @@ function normalizeBibPath(baseDir: string, target: string): string {
 
 function collectBibliographyPaths(baseDir: string, content: string): string[] {
   const paths = new Set<string>();
-  const directivePattern = createDirectivePattern();
 
-  for (const match of content.matchAll(directivePattern)) {
+  for (const match of content.matchAll(new RegExp(DIRECTIVE_PATTERN_SOURCE, 'g'))) {
     const block = match[1];
     for (const raw of block.split(',')) {
       const normalized = normalizeBibPath(baseDir, raw);
@@ -87,9 +79,8 @@ function collectBibliographyPaths(baseDir: string, content: string): string[] {
 
 function collectCitationKeys(content: string): string[] {
   const keys = new Set<string>();
-  const citationPattern = createCitationPattern();
 
-  for (const match of content.matchAll(citationPattern)) {
+  for (const match of content.matchAll(new RegExp(CITATION_PATTERN_SOURCE, 'g'))) {
     const block = match[1];
     for (const raw of block.split(',')) {
       const key = raw.trim();

--- a/src/test/tools/BashTool.test.ts
+++ b/src/test/tools/BashTool.test.ts
@@ -25,7 +25,7 @@ import type { ExecResult } from '@agent/types/ResultTypes';
 import type { StreamTabId } from '@agent/types/IdentifierTypes';
 
 // Internal imports
-import { createToolRegistry } from '@agent/core/ToolTypes';
+import { MapToolRegistry } from '@agent/core/ToolTypes';
 import { AgentLogger } from '@logger/AgentLogger';
 import {
   DEFAULT_MODEL_CAPABILITIES,
@@ -166,7 +166,7 @@ describe('BashTool', () => {
       userVarChannels: { input: {}, transient: {} },
       logger: new AgentLogger('BashToolTest', true),
       client: {} as OpenAI,
-      toolRegistry: createToolRegistry({ bash: bashTool }),
+      toolRegistry: new MapToolRegistry({ bash: bashTool }),
       checkInterruption: () => false,
       setAbortController: () => {},
       modelName: 'test',

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -179,11 +179,6 @@ export function setToolEditApprovalHandler(
   customHandler = handler;
 }
 
-function createApprovalRequestId(): string {
-  approvalCounter += 1;
-  return `approval-${Date.now().toString(36)}-${approvalCounter}`;
-}
-
 async function showProgressViewApprovalPrompt(
   requestId: string,
   request: ToolEditApprovalRequest,
@@ -436,7 +431,8 @@ async function nativeRequestApproval(
   const { path, originalContent, proposedContent, sourceTool, streamId } =
     request;
 
-  const requestId = createApprovalRequestId();
+  approvalCounter += 1;
+  const requestId = `approval-${Date.now().toString(36)}-${approvalCounter}`;
   const originalUri = await createTempFile('original', path, originalContent);
   const proposedUri = await createTempFile('proposed', path, proposedContent);
 

--- a/src/tools/gitignore.ts
+++ b/src/tools/gitignore.ts
@@ -2,12 +2,12 @@
 import * as os from 'os';
 import * as path from 'path';
 
-// Third-party imports
-import { Minimatch } from 'minimatch';
-
 // Local imports - utils
 import { toPosixPath } from '@utils/core';
 import { AbsoluteFS, WorkspaceFS } from '@utils/files';
+
+// Local file imports
+import { createGlobMatcher } from './utils';
 
 type GitignoreRule = {
   matcher: (value: string) => boolean;
@@ -32,16 +32,6 @@ const EMPTY_GITIGNORE_MATCHER: GitignoreMatcher = {
 };
 
 let gitignoreMatcherPromise: Promise<GitignoreMatcher> | undefined;
-
-function createGlobMatcher(pattern: string): (value: string) => boolean {
-  const matcher = new Minimatch(pattern, {
-    dot: true,
-    matchBase: true,
-    nocase: false,
-  });
-
-  return (value: string) => matcher.match(value.replaceAll('\\', '/'));
-}
 
 function expandGitignorePattern(
   pattern: string,

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -1,6 +1,6 @@
 // Local imports - core types
 import type { IToolRegistry } from '@agent/core/ToolTypes';
-import { createToolRegistry } from '@agent/core/ToolTypes';
+import { MapToolRegistry } from '@agent/core/ToolTypes';
 
 // Local imports - model types
 import {
@@ -43,7 +43,7 @@ let defaultRegistryInstance: IToolRegistry | null = null;
  */
 export function getDefaultToolRegistry(): IToolRegistry {
   if (!defaultRegistryInstance) {
-    defaultRegistryInstance = createToolRegistry({
+    defaultRegistryInstance = new MapToolRegistry({
       str_replace_editor: new TextEditorTool(),
       diagnostics: new DiagnosticsTool(),
       bash: new BashTool(),

--- a/src/utils/text/textEnhancementUtils.ts
+++ b/src/utils/text/textEnhancementUtils.ts
@@ -93,58 +93,6 @@ export function buildFileContextFromTaskState(
 }
 
 /**
- * Build a formatted string describing file context for AI prompts.
- */
-function buildFileContextString(context: FileContext): string {
-  const lines: string[] = ['Current context:'];
-
-  if (context.agent) {
-    lines.push(`Agent: ${context.agent}`);
-  }
-
-  // Collect file entries
-  const fileEntries: Array<{ label: string; value: string }> = [];
-
-  // Single files
-  if (context.inputFile) {
-    fileEntries.push({ label: 'Input File', value: context.inputFile });
-  }
-  if (context.referenceFile) {
-    fileEntries.push({ label: 'Reference File', value: context.referenceFile });
-  }
-  if (context.auxiliaryFile) {
-    fileEntries.push({ label: 'Auxiliary File', value: context.auxiliaryFile });
-  }
-  if (context.mediaFile) {
-    fileEntries.push({ label: 'Figure File', value: context.mediaFile });
-  }
-
-  // File arrays
-  const arrays: Array<[string, string[] | undefined]> = [
-    ['Input Files', context.inputFiles],
-    ['Reference Files', context.referenceFiles],
-    ['Auxiliary Files', context.auxiliaryFiles],
-    ['Media Files', context.mediaFiles],
-    ['Output Files', context.outputFiles],
-  ];
-
-  for (const [label, files] of arrays) {
-    if (files && files.length > 0) {
-      fileEntries.push({ label, value: files.join(', ') });
-    }
-  }
-
-  if (fileEntries.length > 0) {
-    lines.push('', 'Files in the task:');
-    for (const { label, value } of fileEntries) {
-      lines.push(`${label}: ${value}`);
-    }
-  }
-
-  return lines.join('\n');
-}
-
-/**
  * Polishes instruction text using Claude AI model
  * Corrects spelling, grammar, and formatting for LaTeX, XML, and Markdown
  * Also corrects file references if fileContext is provided
@@ -161,9 +109,58 @@ export async function polishTextWithAI(
     const useCopilot = getConfig<boolean>('texra.model.useCopilot', false);
 
     // Build file context string if available
-    const fileContextString = fileContext
-      ? buildFileContextString(fileContext)
-      : '';
+    let fileContextString = '';
+    if (fileContext) {
+      const lines: string[] = ['Current context:'];
+
+      if (fileContext.agent) {
+        lines.push(`Agent: ${fileContext.agent}`);
+      }
+
+      const fileEntries: Array<{ label: string; value: string }> = [];
+
+      if (fileContext.inputFile) {
+        fileEntries.push({ label: 'Input File', value: fileContext.inputFile });
+      }
+      if (fileContext.referenceFile) {
+        fileEntries.push({
+          label: 'Reference File',
+          value: fileContext.referenceFile,
+        });
+      }
+      if (fileContext.auxiliaryFile) {
+        fileEntries.push({
+          label: 'Auxiliary File',
+          value: fileContext.auxiliaryFile,
+        });
+      }
+      if (fileContext.mediaFile) {
+        fileEntries.push({ label: 'Figure File', value: fileContext.mediaFile });
+      }
+
+      const arrays: Array<[string, string[] | undefined]> = [
+        ['Input Files', fileContext.inputFiles],
+        ['Reference Files', fileContext.referenceFiles],
+        ['Auxiliary Files', fileContext.auxiliaryFiles],
+        ['Media Files', fileContext.mediaFiles],
+        ['Output Files', fileContext.outputFiles],
+      ];
+
+      for (const [label, files] of arrays) {
+        if (files && files.length > 0) {
+          fileEntries.push({ label, value: files.join(', ') });
+        }
+      }
+
+      if (fileEntries.length > 0) {
+        lines.push('', 'Files in the task:');
+        for (const { label, value } of fileEntries) {
+          lines.push(`${label}: ${value}`);
+        }
+      }
+
+      fileContextString = lines.join('\n');
+    }
 
     // Setup the prompt
     const prompt = `Please review the following instruction text and correct any spelling errors, typos, grammatical mistakes, or punctuation issues. Preserve the original meaning and tone without adding new content or changing the structure unless necessary for clarity.

--- a/src/webview/managers/ExecutionManager.ts
+++ b/src/webview/managers/ExecutionManager.ts
@@ -28,21 +28,9 @@ function toArray<T>(files: T[] | undefined | null): T[] {
 export class ExecutionManager {
   async handleExecute(message: any): Promise<void> {
     const isToolUseAgent = Boolean(message.isToolUseAgent);
-    const config = isToolUseAgent
-      ? this.buildToolUseCommandPayload(message)
-      : await this.buildWorkflowCommandPayload(message);
 
-    if (!config) {
-      return;
-    }
-
-    await vscode.commands.executeCommand('texra.execute', config);
-  }
-
-  private async buildWorkflowCommandPayload(
-    message: any,
-  ): Promise<AgentConfig | null> {
-    if (!message.inputFile) {
+    // Tool-use agents don't need input file validation
+    if (!isToolUseAgent && !message.inputFile) {
       const openDocs = 'File Management Guide';
       const choice = await vscode.window.showErrorMessage(
         'Please select an input file.',
@@ -51,73 +39,36 @@ export class ExecutionManager {
       if (choice === openDocs) {
         void vscode.commands.executeCommand('texra.openDoc', 'file-management');
       }
-      return null;
+      return;
     }
 
-    return this.composeWorkflowAgentConfig(message, {
-      agentCategory: AgentCategory.Workflow,
-    });
+    const config = this.composeAgentConfig(message, isToolUseAgent);
+    await vscode.commands.executeCommand('texra.execute', config);
   }
 
-  private buildToolUseCommandPayload(message: any): AgentConfig {
-    return this.composeToolUseAgentConfig(message, {
-      agentType: AgentType.ToolUse,
-      agentCategory: AgentCategory.ToolUse,
-    });
-  }
-
-  private composeWorkflowAgentConfig(
+  private composeAgentConfig(
     message: any,
-    session: AgentSessionDescriptor,
+    isToolUse: boolean,
   ): AgentConfig {
-    const baseConfig = this.composeBaseAgentConfig(message, session);
-    const outputFiles = toArray<string>(message.outputFiles);
-    const useMultipleOutputs =
-      Boolean(message.outputFilesActive) || outputFiles.length > 1;
+    const session: AgentSessionDescriptor = isToolUse
+      ? { agentType: AgentType.ToolUse, agentCategory: AgentCategory.ToolUse }
+      : { agentCategory: AgentCategory.Workflow };
 
-    // toolConfig only applies to workflow agents
-    const toolConfig: ToolConfig = {
-      autoExtractFigure: message.autoExtractFigure,
-      autoExtractTikzFigure: message.autoExtractTikzFigure,
-      attachTeXCount: message.attachTeXCount,
-      attachDiagnostics: message.attachDiagnostics,
-      autoCompileInputPdf: message.autoCompileInputPdf,
-    };
+    const outputFiles = isToolUse ? [] : toArray<string>(message.outputFiles);
+    const useMultipleOutputs = isToolUse
+      ? false
+      : Boolean(message.outputFilesActive) || outputFiles.length > 1;
 
-    return {
-      ...baseConfig,
-      toolConfig,
-      useMultipleOutputs,
-      outputFiles,
-    };
-  }
+    const toolConfig: ToolConfig = isToolUse
+      ? DEFAULT_TOOL_CONFIG
+      : {
+          autoExtractFigure: message.autoExtractFigure,
+          autoExtractTikzFigure: message.autoExtractTikzFigure,
+          attachTeXCount: message.attachTeXCount,
+          attachDiagnostics: message.attachDiagnostics,
+          autoCompileInputPdf: message.autoCompileInputPdf,
+        };
 
-  private composeToolUseAgentConfig(
-    message: any,
-    session: AgentSessionDescriptor,
-  ): AgentConfig {
-    const baseConfig = this.composeBaseAgentConfig(message, session);
-
-    return {
-      ...baseConfig,
-      // Tool-use agents use default (all-false) toolConfig
-      toolConfig: DEFAULT_TOOL_CONFIG,
-      // Tool-use runs intentionally stay single-output so the execution
-      // pipeline never attempts to resolve `_multiple` agent variants or
-      // manage output file selections that the UI disables for this mode.
-      useMultipleOutputs: false,
-      outputFiles: [],
-    };
-  }
-
-  private mapMediaPath(f: string | null): string | null {
-    return f && isPastedImage(f) ? getPastedImageFullPath(f) : f;
-  }
-
-  private composeBaseAgentConfig(
-    message: any,
-    session: AgentSessionDescriptor,
-  ): Omit<AgentConfig, 'useMultipleOutputs' | 'outputFiles' | 'toolConfig'> {
     return {
       agent: message.agent,
       model: message.model,
@@ -137,7 +88,14 @@ export class ExecutionManager {
       editedFile: null,
       agentType: session.agentType,
       session,
+      toolConfig,
+      useMultipleOutputs,
+      outputFiles,
     };
+  }
+
+  private mapMediaPath(f: string | null): string | null {
+    return f && isPastedImage(f) ? getPastedImageFullPath(f) : f;
   }
 
   handleFileOperation(message: any): void {


### PR DESCRIPTION
- extractBibliography.ts: Convert regex factory functions to module-level constants, eliminating unnecessary function call overhead
- gitignore.ts: Remove duplicate createGlobMatcher, import from utils
- textEnhancementUtils.ts: Inline buildFileContextString into polishTextWithAI (single-use function)
- agentRegistry.ts: Inline buildPlaceholderOptions into computeAgentOptionsSync
- toolEditApproval.ts: Inline trivial createApprovalRequestId function
- ToolTypes.ts: Remove createToolRegistry factory, use MapToolRegistry directly
- registry.ts & BashTool.test.ts: Update to use MapToolRegistry directly
- ExecutionManager.ts: Flatten 4-layer config composition to 2 layers, merging buildX and composeX functions into single composeAgentConfig

Net reduction: ~93 lines of unnecessary abstraction

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Major simplifications and minor cleanups across agent, tools, and webview layers.
> 
> - Replace `createToolRegistry` with direct `new MapToolRegistry({...})`; update usages in `tools/registry.ts` and `BashTool.test.ts`
> - Inline small helpers: placeholder builder in `computeAgentOptionsSync`, ID generation in `toolEditApproval`, and file-context formatter into `polishTextWithAI`
> - Consolidate ExecutionManager config flow: merge build/compose functions into `composeAgentConfig`, with streamlined input-file validation for workflow vs. tool-use agents
> - `extractBibliography.ts`: convert regex factory functions to module-level constants; keep logic the same
> - `gitignore.ts`: remove duplicate `createGlobMatcher` and import from local `utils` instead
> 
> Net effect: fewer layers/abstractions and clearer data flow with no functional behavior changes intended.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fc6df45d943d6ce97af0f18f5b556d6f4ef164b0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->