### PR TITLE
fix: default temperature fallback to 1.0

### DIFF
--- a/src/agent/core/AgentDataclass.ts
+++ b/src/agent/core/AgentDataclass.ts
@@ -115,7 +115,7 @@ export const AgentSettingBaseSchema = z.strictObject({
     .min(MIN_TEMPERATURE)
     .max(MAX_TEMPERATURE)
     .nullable()
-    .prefault(0.0),
+    .prefault(1.0),
   requiredFiles: z.record(z.string(), z.string()).prefault({}),
   requiredFilesInternal: z.record(z.string(), z.string()).prefault({}),
   defaultOutputFiles: z.array(z.string()).prefault([]),

--- a/src/agent/core/flows/CommonCycleTypes.ts
+++ b/src/agent/core/flows/CommonCycleTypes.ts
@@ -154,15 +154,12 @@ export function getDebugContext(
 
 /**
  * Resolve the effective temperature for model invocation.
- * Defaults legacy zero/empty values to 1.0.
+ * Defaults nullish values to 1.0.
  */
 export function resolveDefaultTemperature(
   temperature: number | null | undefined,
 ): number {
-  if (temperature === null || temperature === undefined || temperature === 0) {
-    return 1.0;
-  }
-  return temperature;
+  return temperature ?? 1.0;
 }
 
 /**

--- a/src/agent/core/flows/CommonCycleTypes.ts
+++ b/src/agent/core/flows/CommonCycleTypes.ts
@@ -153,6 +153,19 @@ export function getDebugContext(
 }
 
 /**
+ * Resolve the effective temperature for model invocation.
+ * Defaults legacy zero/empty values to 1.0.
+ */
+export function resolveDefaultTemperature(
+  temperature: number | null | undefined,
+): number {
+  if (temperature === null || temperature === undefined || temperature === 0) {
+    return 1.0;
+  }
+  return temperature;
+}
+
+/**
  * Result type for nodes that can be skipped based on flow state.
  * Uses 'kind' discriminant for consistency with InvocationResult.
  */

--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -13,6 +13,7 @@ import {
   BaseInvocationPrepResult,
   BaseInvocationSuccessData,
   getDebugContext,
+  resolveDefaultTemperature,
   resetCycleState,
   SkippableNodeResult,
 } from '@agent/core/flows/CommonCycleTypes';
@@ -318,7 +319,7 @@ class ResponseModelInvocationNode<C> extends RetryableInvocationNode<
         const modelResponse = await services.modelHandler.createResponse({
           client: services.client,
           messages: prepRes.messages,
-          temperature: services.setting.temperature || 0.0,
+          temperature: resolveDefaultTemperature(services.setting.temperature),
           systemPrompt: prepRes.systemPrompt,
           endTag: services.setting.endTag,
           signal,

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -10,6 +10,7 @@ import {
   BaseInvocationSuccessData,
   resetCycleState,
   getDebugContext,
+  resolveDefaultTemperature,
 } from '@agent/core/flows/CommonCycleTypes';
 import type { SdkToolCall } from '@agent/modelHandlers/types/IModelHandler';
 import type { ServerToolContentBlock } from '@agent/modelHandlers/types/ServerToolTypes';
@@ -321,7 +322,7 @@ class ToolUseCallNode<C> extends RetryableInvocationNode<
       const response = await services.modelHandler.createResponse({
         client: services.client,
         messages: prepRes.messages,
-        temperature: services.setting.temperature ?? 0,
+        temperature: resolveDefaultTemperature(services.setting.temperature),
         signal,
         tools: services.setting.tools as ToolDefinition[] | undefined,
       });


### PR DESCRIPTION
### Motivation

- Ensure agents do not default to a zero temperature (deterministic) when no value is set or legacy code provided 0.0.
- Preserve existing behavior for explicitly configured temperatures while treating null/undefined/0 as a modern default of `1.0`.

### Description

- Change the agent settings schema default for `temperature` to `1.0` via `AgentSettingBaseSchema` in `src/agent/core/AgentDataclass.ts` using `prefault(1.0)`.
- Add a helper `resolveDefaultTemperature` in `src/agent/core/flows/CommonCycleTypes.ts` that returns `1.0` when the input is `null`, `undefined`, or `0`.
- Use `resolveDefaultTemperature(services.setting.temperature)` for model invocations in `src/agent/core/flows/ResponseCycleFlow.ts` and `src/agent/core/flows/ToolUseCycleFlow.ts` to normalize temperature at call sites.

### Testing

- Ran `npm run format` and it completed successfully.
- Ran `npm run compile` and the build succeeded with a webpack warning about nunjucks dynamic dependency (non-fatal).
- Ran `npm run lint` which completed with warnings (not errors) related to `src/tools/ReadTool.ts` about `eqeqeq`/unused eslint-disable.
- No automated test failures were observed during the change (existing test suite was not re-run in full).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69602f7dd4108324844a7ac7a3b26059)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts temperature handling to avoid unintended 0.0 values during model invocations.
> 
> - Set `temperature` default to `1.0` in `AgentSettingBaseSchema` (`AgentDataclass.ts`)
> - Add `resolveDefaultTemperature()` in `CommonCycleTypes.ts` to coalesce nullish values to `1.0`
> - Use `resolveDefaultTemperature(services.setting.temperature)` in `ResponseCycleFlow.ts` and `ToolUseCycleFlow.ts` when calling `modelHandler.createResponse`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 08c4e4e8325410c3f70bd2895453fbad352ef54f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->