### PR TITLE
Fix checkbox sync with memory state

### DIFF
--- a/src/memoryView/modules/messageHandlers.js
+++ b/src/memoryView/modules/messageHandlers.js
@@ -26,11 +26,15 @@ export class MemoryViewMessageHandler extends BaseWebviewMessageHandler {
   }
 
   async handleUpdateMemoryEnabled(message) {
-    // Wait for vscode-checkbox web component to be defined before setting state
-    // Without this, setting checked on un-upgraded element can be lost during upgrade
-    await customElements.whenDefined('vscode-checkbox');
-    safeSetElementChecked(ELEMENT_IDS.MEMORY_ENABLED_TOGGLE, message.enabled);
-    setElementsDisabled(ELEMENT_IDS.MEMORY_ENABLED_TOGGLE, false);
+    try {
+      // Wait for vscode-checkbox web component to be defined before setting state
+      // Without this, setting checked on un-upgraded element can be lost during upgrade
+      await customElements.whenDefined('vscode-checkbox');
+      safeSetElementChecked(ELEMENT_IDS.MEMORY_ENABLED_TOGGLE, message.enabled);
+      setElementsDisabled(ELEMENT_IDS.MEMORY_ENABLED_TOGGLE, false);
+    } catch (error) {
+      console.error('[MemoryView] Failed to update memory enabled state:', error);
+    }
   }
 }
 

--- a/src/memoryView/modules/messageHandlers.js
+++ b/src/memoryView/modules/messageHandlers.js
@@ -25,7 +25,10 @@ export class MemoryViewMessageHandler extends BaseWebviewMessageHandler {
     memoryViewDomHandler.renderMemoryItems(message.items);
   }
 
-  handleUpdateMemoryEnabled(message) {
+  async handleUpdateMemoryEnabled(message) {
+    // Wait for vscode-checkbox web component to be defined before setting state
+    // Without this, setting checked on un-upgraded element can be lost during upgrade
+    await customElements.whenDefined('vscode-checkbox');
     safeSetElementChecked(ELEMENT_IDS.MEMORY_ENABLED_TOGGLE, message.enabled);
     setElementsDisabled(ELEMENT_IDS.MEMORY_ENABLED_TOGGLE, false);
   }


### PR DESCRIPTION
The memory enabled checkbox was not properly syncing with its stored state because the vscode-checkbox web component might not be fully upgraded when the message handler tried to set its checked property. Properties set on un-upgraded custom elements can be lost during the upgrade process.

The fix waits for the custom element to be defined using customElements.whenDefined() before setting the checked state.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves reliability of the memory-enabled toggle by handling custom element upgrade timing.
> 
> - Make `handleUpdateMemoryEnabled` async and await `customElements.whenDefined('vscode-checkbox')` before setting `checked`
> - Add try/catch with console error logging to avoid silent failures
> - Re-enable the toggle after state sync using existing utilities
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7a6e88352eb16a32d223510ec871922805d73e12. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->