### PR TITLE
fix: buffer progress view log rebuilds

### DIFF
--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -22,6 +22,7 @@ import { scrollToBottom, setRadioGroupValue } from '@common/domUtils.js';
 const state = progressViewState;
 const dom = progressViewDomHandler;
 const pendingLogUpdates = new Map();
+const pendingLogRebuilds = new Map();
 
 // Create formatter instances
 
@@ -491,11 +492,20 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       this._focusFollowUpIfWaiting(streamStatus);
     }
 
+    const pendingRebuild = pendingLogRebuilds.get(state.activeStream);
+    if (pendingRebuild) {
+      pendingLogRebuilds.delete(state.activeStream);
+      this.handleUpdateLogs(pendingRebuild);
+    }
+
     this._refreshActiveRunPanels();
   }
 
   handleUpdateLogs(message) {
     if (!this._isActiveStream(message)) {
+      if (!state.activeStream && message.stream) {
+        pendingLogRebuilds.set(message.stream, message);
+      }
       this._updatePlaceholderVisibility();
       return;
     }
@@ -1027,6 +1037,7 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
 
     const deletingActiveStream = message.stream === state.activeStream;
     pendingLogUpdates.clear();
+    pendingLogRebuilds.delete(message.stream);
     state.removeStream(message.stream);
     state.streamStatuses.delete(message.stream);
     this._clearRunScopedState(message.stream);
@@ -1044,6 +1055,7 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
 
   handleDeleteAll() {
     pendingLogUpdates.clear();
+    pendingLogRebuilds.clear();
     state.toggleStates.clearAll();
     state.clearStreams();
     state.activeStream = '';


### PR DESCRIPTION
### Motivation
- Prevent full log rebuild payloads from being lost when the progress view receives them before an active stream is selected, which caused empty or stale log content after reloads.  
- Ensure full rebuilds are replayed once the stream selection arrives so the UI shows the correct history.  
- Avoid replaying rebuilds for streams that have been deleted to prevent showing stale content.  

### Description
- Add a `pendingLogRebuilds` Map to buffer full log rebuild `UPDATE_LOGS` messages when `state.activeStream` is not set.  
- In `handleUpdateLogs` buffer the incoming `message` for `message.stream` when no active stream exists, and in `handleUpdateStreams` replay any buffered rebuild by calling `handleUpdateLogs`.  
- Clear buffered rebuilds for a stream in `handleDeleteStream` and clear all buffers in `handleDeleteAll` to avoid stale replays.  

### Testing
- Ran `npm run format` which completed successfully.  
- Ran `npm run compile` which failed with `TS2307: Cannot find module '@openrouter/sdk/models'`.  
- Ran `npm run lint` which passed with warnings about `import/order` and `eqeqeq`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962915415088324b3eb0e13529b6f89)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures full log rebuilds are not lost during reloads or before a stream is selected, and avoids replaying them after deletion.
> 
> - Add `pendingLogRebuilds` buffer for full `UPDATE_LOGS` payloads when `state.activeStream` is unset
> - On `handleUpdateStreams`, replay and remove any buffered rebuild for the now-active stream
> - In `handleUpdateLogs`, buffer rebuilds targeting a stream when inactive; proceed normally when active
> - Clear buffered rebuilds for a stream in `handleDeleteStream` and all buffers in `handleDeleteAll`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f53d7792276d4658941dd282ab4450f1851bcc81. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->