### PR TITLE
Designing an unified settings view

### DIFF
--- a/docs/prd/settings-view-unified.md
+++ b/docs/prd/settings-view-unified.md
@@ -1205,27 +1205,71 @@ type SettingsMessage =
   | { command: 'SET_AGENTS_DATA', agents: AgentInfo[], enabled: string[] }
   | { command: 'SET_LATEX_DATA', settings: LatexSettings }
   | { command: 'SET_HISTORY_DATA', items: HistoryItem[] }
+  | { command: 'SET_MEMORY_DATA', files: MemoryFileInfo[] }
   | { command: 'SET_PROFILE_DATA', profile: ProfileInfo | null }
-  | { command: 'SELECT_TAB', tab: string };
+  | { command: 'SELECT_TAB', tab: SettingsTab };
 
 // Webview → Extension
 type SettingsAction =
+  | { command: 'GET_INITIAL_DATA' }  // Request all tab data on load
+  | { command: 'TAB_CHANGED', tab: SettingsTab }  // Notify extension of tab switch
   | { command: 'SAVE_ENABLED_MODELS', models: string[] }
   | { command: 'SAVE_ENABLED_AGENTS', agents: string[] }
   | { command: 'SAVE_LATEX_SETTING', key: string, value: unknown }
+  | { command: 'SAVE_AGENT_SETTING', key: string, value: unknown }
   | { command: 'RESTORE_HISTORY', id: string }
   | { command: 'DELETE_HISTORY', id: string }
   | { command: 'SIGN_IN' }
   | { command: 'SIGN_OUT' }
-  | { command: 'SET_API_KEY', provider: string, key: string };
+  | { command: 'SET_API_KEY', provider: string, key: string }
+  | { command: 'OPEN_MEMORY_FILE', path: string }
+  | { command: 'DELETE_MEMORY_FILE', path: string };
 
-// Agent info includes category
+type SettingsTab = 'models' | 'agents' | 'latex' | 'memory' | 'history';
+
+// Agent info includes category (derived from YAML agentCategory field)
 interface AgentInfo {
   name: string;
   description: string;
-  category: 'workflow' | 'toolUse';
-  source: 'builtIn' | 'builtInToolUse' | 'custom' | 'remote';
+  category: 'workflow' | 'toolUse';  // From YAML: agentCategory field
+  agentType: 'cot' | 'direct' | 'merge' | 'reflect' | 'toolUse';  // From YAML: settings.agentType
+  rounds?: number;  // From YAML: settings.rounds (if > 1)
+  inherits?: string;  // From YAML: inherits field
+  source: 'builtIn' | 'custom' | 'remote';
   enabled: boolean;
+}
+```
+
+### Agent Category Derivation
+
+Agent categories are determined from the YAML `agentCategory` field:
+
+```yaml
+# Example agent YAML
+name: correct
+description: Fix typos & LaTeX errors
+agentCategory: workflow  # Explicit category: 'workflow' | 'toolUse'
+settings:
+  agentType: cot
+  rounds: 2
+inherits: polish
+```
+
+**Category Rules:**
+1. **Explicit**: Use `agentCategory` field if present in YAML
+2. **Inferred**: If missing, infer from `settings.agentType`:
+   - `toolUse` type → `toolUse` category
+   - All others (`cot`, `direct`, `merge`, `reflect`) → `workflow` category
+3. **Built-in tool-use agents**: Located in `resources/agents/toolUse/` directory
+
+```typescript
+function deriveAgentCategory(yaml: AgentYaml): 'workflow' | 'toolUse' {
+  // Explicit category takes precedence
+  if (yaml.agentCategory) {
+    return yaml.agentCategory;
+  }
+  // Infer from agent type
+  return yaml.settings?.agentType === 'toolUse' ? 'toolUse' : 'workflow';
 }
 ```
 
@@ -1563,26 +1607,51 @@ export class SettingsViewContentProvider extends BaseViewContentProvider {
 ```
 
 ### Tab Manager Pattern (Frontend)
+
+Aligns with existing `BaseDomHandler.js` pattern using `containerSelector`:
+
 ```javascript
 // modules/tabs/BaseTab.js - Abstract base for all tabs
+// Follows BaseDomHandler.js pattern from src/common/modules/
 export class BaseTab {
-  constructor(containerId) {
-    this.container = document.getElementById(containerId);
+  /**
+   * @param {string} containerSelector - CSS selector for tab container
+   */
+  constructor(containerSelector) {
+    this.containerSelector = containerSelector;
+    this.container = document.querySelector(containerSelector);
+    this._eventListeners = [];
   }
 
   render(data) { throw new Error('Implement render()'); }
 
   dispose() {
-    // Clean up event listeners
+    // Clean up registered event listeners
+    this._eventListeners.forEach(({ element, event, handler }) => {
+      element.removeEventListener(event, handler);
+    });
+    this._eventListeners = [];
   }
 
-  // Shared helpers
-  createSettingRow(label, control) {
-    const row = document.createElement('div');
-    row.className = 'setting-row';
-    row.innerHTML = `<span class="setting-label">${label}</span>`;
-    row.appendChild(control);
-    return row;
+  // Register event listener with automatic cleanup
+  addListener(element, event, handler) {
+    element.addEventListener(event, handler);
+    this._eventListeners.push({ element, event, handler });
+  }
+
+  // Shared helpers for vscode-elements
+  createFormGroup(label, control, description) {
+    const group = document.createElement('vscode-form-group');
+    const labelEl = document.createElement('vscode-label');
+    labelEl.textContent = label;
+    group.appendChild(labelEl);
+    group.appendChild(control);
+    if (description) {
+      const helper = document.createElement('vscode-form-helper');
+      helper.textContent = description;
+      group.appendChild(helper);
+    }
+    return group;
   }
 
   createCheckbox(id, label, checked) {
@@ -1604,6 +1673,13 @@ export class BaseTab {
       select.appendChild(option);
     });
     return select;
+  }
+
+  createCollapsible(title, open = false) {
+    const collapsible = document.createElement('vscode-collapsible');
+    collapsible.title = title;
+    if (open) collapsible.open = true;
+    return collapsible;
   }
 }
 ```
@@ -1770,6 +1846,74 @@ Based on actual `package.json` configuration (14 settings total):
 | `texra.latex.enabledReplacementsRegex` | Checkbox group (6 options) |
 | `texra.latex.customReplacements` | `<vscode-collapsible>` + JSON editor |
 | `texra.latex.customReplacementsRegex` | `<vscode-collapsible>` + JSON editor |
+
+---
+
+## General Implementation Guidelines
+
+### Code Style
+1. **Use TypeScript** for all backend code (`.ts` files)
+2. **Use JavaScript** for frontend webview modules (`.js` files) - no bundler
+3. **Follow existing patterns** in `src/common/` for base classes and utilities
+4. **Use path aliases** (`@settingsView/*`, `@common/*`) as defined in `tsconfig.json`
+
+### VS Code Configuration Best Practices
+```typescript
+// Always specify ConfigurationTarget explicitly
+await config.update(key, value, ConfigurationTarget.Global);    // User settings
+await config.update(key, value, ConfigurationTarget.Workspace); // .vscode/settings.json
+
+// Read with type safety
+const models = config.get<string[]>('models', []);  // Always provide default
+
+// Batch updates when possible (reduces config change events)
+const edit = new vscode.WorkspaceEdit();
+// ... multiple changes
+await vscode.workspace.applyEdit(edit);
+```
+
+### Event Listener Cleanup
+Always clean up event listeners to prevent memory leaks:
+```javascript
+// Pattern: Track listeners for cleanup
+class MyTab extends BaseTab {
+  init() {
+    // Use addListener from BaseTab for automatic cleanup
+    this.addListener(this.saveButton, 'click', this.handleSave.bind(this));
+  }
+}
+```
+
+### Error Handling
+```typescript
+// Backend: Use typed errors from @common/errors
+throw new TeXRAError('Provider not configured', { provider: providerId });
+
+// Frontend: Show user-friendly messages
+try {
+  await saveSettings();
+} catch (error) {
+  vscode.postMessage({ command: 'SHOW_ERROR', message: error.message });
+}
+```
+
+### Testing Considerations
+1. **Unit test** message handlers independently
+2. **Mock VS Code API** using existing test utilities
+3. **Test ConfigurationTarget** scoping (global vs workspace)
+4. **Verify backwards compatibility** - existing settings.json should work unchanged
+
+### Accessibility
+1. Use native vscode-elements (built-in keyboard navigation)
+2. Provide `aria-label` for icon-only buttons
+3. Ensure tab order is logical
+4. Test with keyboard-only navigation
+
+### Performance
+1. **Lazy load** tab content (don't render all tabs on initial load)
+2. **Debounce** settings saves (avoid rapid config updates)
+3. **Cache** model metadata from llm-zoo in globalState
+4. **Virtualize** long lists (agents, models) if > 50 items
 
 ---
 

--- a/docs/prd/settings-view-unified.md
+++ b/docs/prd/settings-view-unified.md
@@ -749,9 +749,21 @@ When clicking [Edit] or [Configure] on a provider:
 ```
 
 **Streaming Settings (per provider):**
-The `texra.model.useStreaming*` settings (9 total) are now configured per provider
-in the Advanced Options of each provider's configuration modal. This replaces the
-scattered VS Code settings with a unified UI.
+Each provider's modal streaming toggle maps to its specific setting:
+
+| Provider Modal | VS Code Setting |
+|----------------|-----------------|
+| Anthropic | `texra.model.useStreamingAnthropic` |
+| OpenAI | `texra.model.useStreamingOpenai` |
+| Google | `texra.model.useStreamingGoogle` |
+| DeepSeek | `texra.model.useStreamingDeepseek` |
+| xAI | `texra.model.useStreamingXai` |
+| Moonshot | `texra.model.useStreamingMoonshot` |
+| Dashscope | `texra.model.useStreamingDashscope` |
+| OpenRouter | `texra.model.useStreamingOpenrouter` |
+| (Global fallback) | `texra.model.useStreaming` |
+
+Per-provider settings override the global `useStreaming` setting.
 
 **OpenRouter (Special Case):**
 ```
@@ -786,6 +798,12 @@ scattered VS Code settings with a unified UI.
 │                                            [Cancel]   [Save]   │
 └─────────────────────────────────────────────────────────────────┘
 ```
+
+**Settings mapping:**
+| UI Element | VS Code Setting |
+|------------|-----------------|
+| API Key | SecretStorage `openrouter` |
+| Routing Mode | `texra.model.useOpenRouter` (boolean: false = only required, true = all models) |
 
 ---
 
@@ -1175,36 +1193,81 @@ src/
 
 ### Commands
 
+**File:** `src/commands/settings/settingsCommands.ts`
+
+Follow existing pattern from `historyCommands.ts`:
+
 ```typescript
-// Register command to open settings view
-commands.registerCommand('texra.openSettings', (tab?: SettingsTab) => {
-  settingsViewProvider.show();
-  if (tab) {
-    // Tab index: 0=models, 1=agents, 2=latex, 3=memory, 4=history, 5=advanced
-    settingsViewProvider.selectTab(tab);
-  }
-});
+// src/commands/settings/settingsCommands.ts
+import * as vscode from 'vscode';
+import { SettingsViewProvider } from '@settingsView/SettingsViewProvider';
+import type { SettingsTab } from '@settingsView/schemas';
 
-type SettingsTab = 'models' | 'agents' | 'latex' | 'memory' | 'history' | 'advanced';
+export const settingsCommands = {
+  openSettings: 'texra.openSettings',
+  openModelSettings: 'texra.openModelSettings',
+  openAgentSettings: 'texra.openAgentSettings',
+  openLatexSettings: 'texra.openLatexSettings',
+} as const;
 
-// Shortcut commands
-commands.registerCommand('texra.openModelSettings', () =>
-  commands.executeCommand('texra.openSettings', 'models'));
-commands.registerCommand('texra.openAgentSettings', () =>
-  commands.executeCommand('texra.openSettings', 'agents'));
-commands.registerCommand('texra.openLatexSettings', () =>
-  commands.executeCommand('texra.openSettings', 'latex'));
+export function registerSettingsCommands(context: vscode.ExtensionContext) {
+  const settingsViewProvider = new SettingsViewProvider(context);
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      settingsCommands.openSettings,
+      async (tab?: SettingsTab) => {
+        await settingsViewProvider.show();
+        if (tab) settingsViewProvider.selectTab(tab);
+      }
+    ),
+    vscode.commands.registerCommand(settingsCommands.openModelSettings, () =>
+      vscode.commands.executeCommand(settingsCommands.openSettings, 'models')),
+    vscode.commands.registerCommand(settingsCommands.openAgentSettings, () =>
+      vscode.commands.executeCommand(settingsCommands.openSettings, 'agents')),
+    vscode.commands.registerCommand(settingsCommands.openLatexSettings, () =>
+      vscode.commands.executeCommand(settingsCommands.openSettings, 'latex')),
+  );
+
+  return { settingsViewProvider };
+}
 ```
 
+**Register in:** `src/commands/index.ts`
+
 ### Message Protocol (Zod-native)
+
+**File:** `src/settingsView/schemas.ts`
 
 Use Zod schemas as single source of truth. Reference existing types from the codebase.
 
 ```typescript
+// src/settingsView/schemas.ts
 import { z } from 'zod';
 import { ModelConfigSchema } from '@model/ModelConfig';           // From llm-zoo
 import { AgentSource } from '@agent/core/AgentDataclass';         // Zod enum
 import type { AgentEntry } from '@agent/index/agentRegistry';     // Existing interface
+
+// =============================================================================
+// Command Constants (following src/common/webview/commands.ts pattern)
+// =============================================================================
+
+export const SETTINGS_VIEW_COMMANDS = {
+  // Extension → Webview
+  SET_MODELS_DATA: 'SET_MODELS_DATA',
+  SET_AGENTS_DATA: 'SET_AGENTS_DATA',
+  SET_LATEX_DATA: 'SET_LATEX_DATA',
+  SELECT_TAB: 'SELECT_TAB',
+  // Webview → Extension
+  GET_INITIAL_DATA: 'GET_INITIAL_DATA',
+  TAB_CHANGED: 'TAB_CHANGED',
+  SAVE_ENABLED_MODELS: 'SAVE_ENABLED_MODELS',
+  SAVE_ENABLED_AGENTS: 'SAVE_ENABLED_AGENTS',
+  SAVE_SETTING: 'SAVE_SETTING',
+  SET_API_KEY: 'SET_API_KEY',
+  SIGN_IN: 'SIGN_IN',
+  SIGN_OUT: 'SIGN_OUT',
+} as const;
 
 // =============================================================================
 // Shared Schemas
@@ -1282,23 +1345,26 @@ export type SettingsAction = z.infer<typeof SettingsActionSchema>;
 
 ### Agent Category Derivation
 
-Agent categories are determined by `agentRegistry.ts` logic:
+**Use existing functions - do NOT re-implement:**
 
-**For local agents (built-in and custom):**
 ```typescript
-// From src/agent/index/agentRegistry.ts
-const category =
-  source === 'builtInToolUse' || agentType === AgentType.ToolUse
-    ? AgentCategory.ToolUse
-    : AgentCategory.Workflow;
+// Settings View should call these existing functions:
+import {
+  getWorkflowAgents,    // Returns AgentEntry[] with category already set
+  getToolUseAgents,     // Returns AgentEntry[] with category already set
+  buildAgentOptions,    // Returns HTML <option> elements (if needed)
+} from '@agent/index/agentRegistry';
+
+// Category is already derived in AgentEntry - just use it
+const agents = [...getWorkflowAgents(), ...getToolUseAgents()];
 ```
 
-**For remote agents:**
-- Uses `agentCategory` field from remote agent definition
+**Implementation detail (for reference only):**
+- Local agents: category derived from `source === 'builtInToolUse' || agentType === 'toolUse'`
+- Remote agents: uses `agentCategory` field from remote definition
+- Config override: `texra.toolUseAgents` setting can override any agent
 
-**Config override:** Any agent can be marked as tool-use via `texra.toolUseAgents` setting.
-
-**Note:** Local agent YAML files don't have an `agentCategory` field - category is derived from source/agentType.
+**Note:** Local agent YAML files don't have an `agentCategory` field.
 
 ---
 
@@ -1636,81 +1702,44 @@ export class SettingsViewContentProvider extends BaseViewContentProvider {
 
 ### Tab Manager Pattern (Frontend)
 
-Aligns with existing `BaseDomHandler.js` pattern using `containerSelector`:
+**Extend existing `BaseDomHandler.js`** - do not create a parallel hierarchy:
 
 ```javascript
-// modules/tabs/BaseTab.js - Abstract base for all tabs
-// Follows BaseDomHandler.js pattern from src/common/modules/
-export class BaseTab {
-  /**
-   * @param {string} containerSelector - CSS selector for tab container
-   */
+// modules/tabs/ModelsTab.js - Example tab extending BaseDomHandler
+import { BaseDomHandler } from '@common/modules/BaseDomHandler.js';
+
+export class ModelsTab extends BaseDomHandler {
   constructor(containerSelector) {
-    this.containerSelector = containerSelector;
+    super();  // BaseDomHandler provides addListener, removeListener, dispose
     this.container = document.querySelector(containerSelector);
-    this._eventListeners = [];
   }
 
-  render(data) { throw new Error('Implement render()'); }
+  render(data) {
+    this.container.innerHTML = `
+      <vscode-collapsible title="Recommended Models" open>
+        ${data.recommended.map(m => `
+          <vscode-checkbox id="model-${m.name}" ${m.enabled ? 'checked' : ''}>
+            ${m.fullName} - ${m.provider}
+          </vscode-checkbox>
+        `).join('')}
+      </vscode-collapsible>
+    `;
+    this.attachEventListeners();
+  }
 
-  dispose() {
-    // Clean up registered event listeners
-    this._eventListeners.forEach(({ element, event, handler }) => {
-      element.removeEventListener(event, handler);
+  attachEventListeners() {
+    // Use inherited addListener for automatic cleanup on dispose()
+    this.container.querySelectorAll('vscode-checkbox').forEach(cb => {
+      this.addListener(cb, 'change', () => this.handleModelToggle(cb));
     });
-    this._eventListeners = [];
-  }
-
-  // Register event listener with automatic cleanup
-  addListener(element, event, handler) {
-    element.addEventListener(event, handler);
-    this._eventListeners.push({ element, event, handler });
-  }
-
-  // Shared helpers for vscode-elements
-  createFormGroup(label, control, description) {
-    const group = document.createElement('vscode-form-group');
-    const labelEl = document.createElement('vscode-label');
-    labelEl.textContent = label;
-    group.appendChild(labelEl);
-    group.appendChild(control);
-    if (description) {
-      const helper = document.createElement('vscode-form-helper');
-      helper.textContent = description;
-      group.appendChild(helper);
-    }
-    return group;
-  }
-
-  createCheckbox(id, label, checked) {
-    const checkbox = document.createElement('vscode-checkbox');
-    checkbox.id = id;
-    checkbox.checked = checked;
-    checkbox.textContent = label;
-    return checkbox;
-  }
-
-  createSelect(id, options, value) {
-    const select = document.createElement('vscode-single-select');
-    select.id = id;
-    options.forEach(opt => {
-      const option = document.createElement('vscode-option');
-      option.value = opt.value;
-      option.textContent = opt.label;
-      if (opt.value === value) option.selected = true;
-      select.appendChild(option);
-    });
-    return select;
-  }
-
-  createCollapsible(title, open = false) {
-    const collapsible = document.createElement('vscode-collapsible');
-    collapsible.title = title;
-    if (open) collapsible.open = true;
-    return collapsible;
   }
 }
 ```
+
+**Key point:** `BaseDomHandler` already provides:
+- `addListener(element, event, handler)` - with automatic cleanup
+- `removeListener(element, event, handler)`
+- `dispose()` - cleans up all registered listeners
 
 ### Minimal Custom CSS (extend common.css)
 ```css
@@ -1901,15 +1930,15 @@ await vscode.workspace.applyEdit(edit);
 ```
 
 ### Event Listener Cleanup
-Always clean up event listeners to prevent memory leaks:
+Use `BaseDomHandler` for automatic cleanup:
 ```javascript
-// Pattern: Track listeners for cleanup
-class MyTab extends BaseTab {
-  init() {
-    // Use addListener from BaseTab for automatic cleanup
+// Extend BaseDomHandler - dispose() cleans up all listeners
+class ModelsTab extends BaseDomHandler {
+  attachEventListeners() {
     this.addListener(this.saveButton, 'click', this.handleSave.bind(this));
   }
 }
+// On tab switch: oldTab.dispose() removes all listeners automatically
 ```
 
 ### Error Handling

--- a/docs/prd/settings-view-unified.md
+++ b/docs/prd/settings-view-unified.md
@@ -16,10 +16,11 @@ Create a unified Settings View that consolidates model configuration, agent conf
 ## Goals
 
 1. **Single source of truth** - All configuration in one place
-2. **Easy navigation** - Tab-based switching between Models, Agents, History, Profile
-3. **No auth required** - Models, Agents, History tabs work without login
+2. **Easy navigation** - Tab-based switching between Models, Agents, LaTeX, Memory, History, Profile
+3. **No auth required** - Models, Agents, LaTeX, Memory, History tabs work without login
 4. **VS Code native** - Use `vscode-tabs`, `vscode-tab-header`, `vscode-tab-panel` components
 5. **Proper state management** - Global vs workspace state separation
+6. **Notion-style minimalism** - Clean, uncluttered interface with generous whitespace
 
 ---
 
@@ -30,6 +31,109 @@ Create a unified Settings View that consolidates model configuration, agent conf
 3. As a user, I want to browse execution history and restore previous sessions
 4. As a user, I want to manage my account and API keys in the same interface
 5. As a user, I want to easily switch between these configuration pages
+6. As a user, I want to configure LaTeX formatter, latexdiff, and TikZ settings in one place
+
+---
+
+## Design Principles (Notion-Inspired)
+
+The Settings View follows Notion's design philosophy: minimal chrome, generous whitespace, and content-first hierarchy.
+
+### Core Principles
+
+1. **Content over chrome** - No unnecessary borders, backgrounds, or decorations
+2. **Generous whitespace** - Let content breathe; padding > borders
+3. **Typography hierarchy** - Use font size/weight, not color, to establish importance
+4. **Invisible affordances** - Actions appear on hover, not by default
+5. **Grouped sections** - Clear visual separation using space, not lines
+
+### Visual Guidelines
+
+```css
+/* Typography hierarchy */
+.section-header {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--vscode-descriptionForeground);
+  margin-bottom: 12px;
+}
+
+.item-title {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--vscode-foreground);
+}
+
+.item-description {
+  font-size: 12px;
+  color: var(--vscode-descriptionForeground);
+}
+
+/* Spacing */
+.section {
+  padding: 16px 0;
+}
+
+.section + .section {
+  border-top: 1px solid var(--vscode-widget-border);
+}
+
+/* Hover actions (Notion-style) */
+.item-row .actions {
+  opacity: 0;
+  transition: opacity 0.15s;
+}
+
+.item-row:hover .actions {
+  opacity: 1;
+}
+
+/* Cards - minimal borders */
+.card {
+  background: var(--vscode-editor-background);
+  border: 1px solid var(--vscode-widget-border);
+  border-radius: 4px;
+  padding: 12px 16px;
+}
+
+/* Focus on content, not containers */
+.list-item {
+  padding: 8px 0;
+  /* No borders between items - use space */
+}
+```
+
+### Anti-Patterns to Avoid
+
+- ❌ Heavy borders and outlines everywhere
+- ❌ Colorful badges and status indicators
+- ❌ Multiple competing visual hierarchies
+- ❌ Actions always visible (clutter)
+- ❌ Compact, dense layouts
+- ❌ Deeply nested sections
+
+### Examples
+
+**Good (Notion-style):**
+```
+FORMATTER
+
+Formatter     latexindent ▼
+
+Config file   /path/to/config              Browse
+```
+
+**Bad (cluttered):**
+```
+┌─────────────────────────────────────────┐
+│ ⚙️ FORMATTER SETTINGS                   │
+├─────────────────────────────────────────┤
+│ [Formatter:] [latexindent ▼] [ℹ️]       │
+│ [Config:] [_______________] [📁 Browse] │
+└─────────────────────────────────────────┘
+```
 
 ---
 
@@ -54,7 +158,7 @@ Clicking ⚙️ (codicon: `settings-gear`) opens the unified Settings View.
 ┌─────────────────────────────────────────────────────────────────┐
 │  TeXRA Settings                                          [×]   │
 ├─────────────────────────────────────────────────────────────────┤
-│  [Models]   Agents    Memory    History    Profile              │
+│  [Models]  Agents   LaTeX   Memory   History   Profile         │
 │  ═══════                                                        │
 ├─────────────────────────────────────────────────────────────────┤
 │                                                                 │
@@ -69,6 +173,7 @@ Clicking ⚙️ (codicon: `settings-gear`) opens the unified Settings View.
 <vscode-tabs id="settingsTabs" selected-index="0">
   <vscode-tab-header slot="header">Models</vscode-tab-header>
   <vscode-tab-header slot="header">Agents</vscode-tab-header>
+  <vscode-tab-header slot="header">LaTeX</vscode-tab-header>
   <vscode-tab-header slot="header">Memory</vscode-tab-header>
   <vscode-tab-header slot="header">History</vscode-tab-header>
   <vscode-tab-header slot="header">Profile</vscode-tab-header>
@@ -78,6 +183,9 @@ Clicking ⚙️ (codicon: `settings-gear`) opens the unified Settings View.
   </vscode-tab-panel>
   <vscode-tab-panel id="agentsPanel">
     <!-- Agents tab content -->
+  </vscode-tab-panel>
+  <vscode-tab-panel id="latexPanel">
+    <!-- LaTeX tab content -->
   </vscode-tab-panel>
   <vscode-tab-panel id="memoryPanel">
     <!-- Memory tab content -->
@@ -176,6 +284,10 @@ const RECOMMENDED_MODELS = [
 
 **Design Philosophy:** Users should be able to create and modify agents through a simple UI, not by editing YAML files. The complexity is hidden; power users can access raw YAML if needed.
 
+**Agent Categories:**
+- `workflow` - Document-processing agents (input → output transformations)
+- `toolUse` - Interactive agents with tool capabilities (chat, research)
+
 **Layout:**
 ```
 ┌─────────────────────────────────────────────────────────────────┐
@@ -186,24 +298,24 @@ const RECOMMENDED_MODELS = [
 │  ─────────────────────────────────────────────────────────────  │
 │                                                                 │
 │  ┌───────────────────────────────────────────────────────────┐  │
-│  │ ☑ chat            Interactive conversation         Built-in│  │
-│  │ ☑ correct         Fix typos & LaTeX errors         Built-in│  │
-│  │ ☑ polish          Improve writing quality          Built-in│  │
-│  │ ☑ research        Research with tools              Built-in│  │
-│  │ ☑ my-reviewer     Reviews papers for clarity        Custom │  │
-│  │                                            [Edit] [Delete] │  │
-│  │ ☐ draw            Create TikZ figures              Built-in│  │
-│  │ ☐ ocr             Handwritten → LaTeX              Built-in│  │
-│  │ ☐ paper2slide     Paper → Beamer slides            Built-in│  │
-│  │ ☐ paper2poster    Paper → poster                   Built-in│  │
-│  │ ☐ transcribe      Audio transcription              Built-in│  │
+│  │ ☑ chat        Interactive conversation  [toolUse] Built-in│  │
+│  │ ☑ correct     Fix typos & LaTeX errors  [workflow] Built-in│  │
+│  │ ☑ polish      Improve writing quality   [workflow] Built-in│  │
+│  │ ☑ research    Research with tools       [toolUse] Built-in│  │
+│  │ ☑ my-reviewer Reviews papers...         [workflow]  Custom │  │
+│  │                                          [Edit] [Delete] │  │
+│  │ ☐ draw        Create TikZ figures       [workflow] Built-in│  │
+│  │ ☐ ocr         Handwritten → LaTeX       [workflow] Built-in│  │
+│  │ ☐ paper2slide Paper → Beamer slides     [workflow] Built-in│  │
+│  │ ☐ paper2poster Paper → poster           [workflow] Built-in│  │
+│  │ ☐ transcribe  Audio transcription       [workflow] Built-in│  │
 │  └───────────────────────────────────────────────────────────┘  │
 │                                                                 │
 │  REMOTE AGENTS                                                 │
 │  ─────────────────────────────────────────────────────────────  │
 │  ┌───────────────────────────────────────────────────────────┐  │
-│  │ ☑ team-reviewer   Team's paper reviewer       [Public]    │  │
-│  │ ☐ grant-writer    Grant proposal helper       [Team]      │  │
+│  │ ☑ team-reviewer   Team's paper reviewer  [workflow] Public │  │
+│  │ ☐ grant-writer    Grant proposal helper  [toolUse]  Team  │  │
 │  └───────────────────────────────────────────────────────────┘  │
 │                        ─ or if not logged in ─                  │
 │  ┌───────────────────────────────────────────────────────────┐  │
@@ -213,6 +325,24 @@ const RECOMMENDED_MODELS = [
 │  ─────────────────────────────────────────────────────────────  │
 │  [Advanced: Open Agent Files]          ← Power users only      │
 └─────────────────────────────────────────────────────────────────┘
+```
+
+**Category Badge Styling:**
+```css
+.category-badge {
+  font-size: 10px;
+  padding: 2px 6px;
+  border-radius: 3px;
+  text-transform: lowercase;
+}
+.category-badge--workflow {
+  background: var(--vscode-badge-background);
+  color: var(--vscode-badge-foreground);
+}
+.category-badge--toolUse {
+  background: var(--vscode-statusBarItem-prominentBackground);
+  color: var(--vscode-statusBarItem-prominentForeground);
+}
 ```
 
 ---
@@ -266,12 +396,8 @@ Click **[Edit]** on custom agent → Form-based editor:
 │  ─────────────────────────────────────────────────────────────  │
 │  Name:        [paper-reviewer                ]                 │
 │  Description: [Reviews papers for clarity    ]                 │
+│  Category:    [workflow ▼]                                     │
 │  Based on:    [correct ▼] (inherit from built-in)              │
-│                                                                 │
-│  BEHAVIOR                                                      │
-│  ─────────────────────────────────────────────────────────────  │
-│  Style:  ● Thorough (chain-of-thought)  ○ Quick (direct)       │
-│  Rounds: [2 ▼]                                                 │
 │                                                                 │
 │  INSTRUCTIONS                                                  │
 │  ─────────────────────────────────────────────────────────────  │
@@ -282,7 +408,7 @@ Click **[Edit]** on custom agent → Form-based editor:
 │  │ Suggest specific improvements with examples.              │  │
 │  └───────────────────────────────────────────────────────────┘  │
 │                                                                 │
-│  ▶ Advanced options                                            │
+│  ▶ Advanced options (rounds, agentType, etc.)                  │
 │                                                                 │
 │  ─────────────────────────────────────────────────────────────  │
 │  [View YAML]                       [Cancel]  [Test]  [Save]   │
@@ -292,9 +418,8 @@ Click **[Edit]** on custom agent → Form-based editor:
 **Form fields map to YAML transparently:**
 - Name → `name:`
 - Description → `description:`
+- Category → `agentCategory:` (workflow | toolUse)
 - Based on → `inherits:`
-- Style → `settings.agentType:`
-- Rounds → `settings.rounds:`
 - Instructions → `prompts.systemPrompt:`
 
 ---
@@ -306,8 +431,8 @@ Click **[Edit]** on custom agent → Form-based editor:
 | **Create agent** | Write YAML from scratch | Describe in English, AI generates |
 | **Edit agent** | Edit YAML syntax | Fill out form |
 | **Set inheritance** | `inherits: correct` | Dropdown: "Based on: correct" |
-| **Change rounds** | Edit `settings.rounds: 2` | Slider or dropdown |
-| **View all agents** | File explorer + folders | Single flat list |
+| **Change category** | Edit `agentCategory: workflow` | Dropdown |
+| **View all agents** | File explorer + folders | Single flat list with category badges |
 
 ---
 
@@ -337,6 +462,105 @@ YAML files remain the source of truth, but users interact through forms.
 3. YAML files still editable directly if preferred
 
 **Storage:** `workspaceState.enabledAgents: string[]`
+
+---
+
+### LaTeX Tab
+
+**Purpose:** Configure LaTeX formatting, latexdiff, and TikZ compilation settings.
+
+**Design Philosophy:** Consolidate scattered LaTeX-related VS Code settings into a visual, grouped interface. Settings remain in VS Code configuration for backwards compatibility.
+
+**Layout:**
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  Configure LaTeX formatting and processing options.             │
+│                                                                 │
+│  FORMATTER                                                     │
+│  ─────────────────────────────────────────────────────────────  │
+│                                                                 │
+│  Formatter:  [latexindent ▼]                                   │
+│              Options: latexindent, texfmt, none                 │
+│                                                                 │
+│  Config file (optional):                                       │
+│  ┌───────────────────────────────────────────────────────────┐  │
+│  │ /path/to/latexindent.yaml                       [Browse]  │  │
+│  └───────────────────────────────────────────────────────────┘  │
+│                                                                 │
+│  ☑ Show warning if latexindent is not installed                │
+│                                                                 │
+│  ─────────────────────────────────────────────────────────────  │
+│                                                                 │
+│  LATEXDIFF                                                     │
+│  ─────────────────────────────────────────────────────────────  │
+│                                                                 │
+│  Timeout: [30000 ms ▼]                                         │
+│                                                                 │
+│  Math markup:  [fine ▼]                                        │
+│                Options: off, whole, coarse, fine                │
+│                                                                 │
+│  Picture environments (regex):                                 │
+│  ┌───────────────────────────────────────────────────────────┐  │
+│  │ (?:picture|tikzpicture|scope|DIFnomarkup)[\w\d*@]*        │  │
+│  └───────────────────────────────────────────────────────────┘  │
+│                                                                 │
+│  ☐ Generate diffs between rounds (multi-round agents)          │
+│                                                                 │
+│  ─────────────────────────────────────────────────────────────  │
+│                                                                 │
+│  TIKZ FIGURES                                                  │
+│  ─────────────────────────────────────────────────────────────  │
+│                                                                 │
+│  Extra input directory (TEXINPUTS):                            │
+│  ┌───────────────────────────────────────────────────────────┐  │
+│  │ /path/to/tikz/inputs                            [Browse]  │  │
+│  └───────────────────────────────────────────────────────────┘  │
+│                                                                 │
+│  ☑ Include workspace root in TEXINPUTS                         │
+│                                                                 │
+│  ▶ TikZ template (advanced)                                    │
+│                                                                 │
+│  ─────────────────────────────────────────────────────────────  │
+│                                                                 │
+│  REPLACEMENTS                                                  │
+│  ─────────────────────────────────────────────────────────────  │
+│                                                                 │
+│  ☑ Wrap critique in align environment                          │
+│                                                                 │
+│  Enabled replacement categories:                               │
+│  ☑ latex_spacing      ☑ latex_forbidden_commands               │
+│  ☑ latex_xml          ☑ latex_document                         │
+│  ☐ latexdiff                                                   │
+│                                                                 │
+│  Enabled regex replacements:                                   │
+│  ☑ latexdiff_markup   ☐ (others)                               │
+│                                                                 │
+│  ▶ Custom replacements (advanced)                              │
+│                                                                 │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+**Settings Mapping:**
+| UI Element | VS Code Setting |
+|------------|-----------------|
+| Formatter dropdown | `texra.latex.formatter` |
+| Config file path | `texra.latex.latexindentConfig` / `texra.latex.texfmtConfig` |
+| Show warning checkbox | `texra.latex.showLatexindentWarning` |
+| Timeout | `texra.latexdiff.timeoutMs` |
+| Math markup | `texra.latexdiff.mathMarkup` |
+| Picture environments | `texra.latexdiff.pictureEnvironments` |
+| Generate between-round diffs | `texra.latexdiff.generateBetweenRoundDiffs` |
+| TikZ input directory | `texra.latex.tikzInputDirectory` |
+| Include workspace | `texra.latex.includeWorkspaceInTexinputs` |
+| TikZ template | `texra.latex.tikzTemplate` |
+| Wrap critique | `texra.latex.wrapCritiqueInAlign` |
+| Replacement categories | `texra.latex.enabledReplacements` |
+| Regex replacements | `texra.latex.enabledReplacementsRegex` |
+| Custom replacements | `texra.latex.customReplacements` / `texra.latex.customReplacementsRegex` |
+
+**Storage:** VS Code configuration (`texra.latex.*`, `texra.latexdiff.*`)
+
+**Note:** Unlike other tabs that use globalState/workspaceState, LaTeX settings remain in VS Code configuration for backwards compatibility and to allow users to configure via settings.json if preferred.
 
 ---
 
@@ -982,20 +1206,22 @@ src/
 │   ├── SettingsViewMessageHandler.ts
 │   ├── SettingsViewContentProvider.ts
 │   ├── index.html                   # Tabbed layout
-│   ├── styles.css
+│   ├── styles.css                   # Notion-inspired styling
 │   └── modules/
 │       ├── main.js                  # Entry point
 │       ├── messageHandlers.js
 │       ├── settingsViewState.js
 │       ├── tabs/
 │       │   ├── ModelsTab.js         # Models tab logic
-│       │   ├── AgentsTab.js         # Agents tab logic
+│       │   ├── AgentsTab.js         # Agents tab logic (with categories)
+│       │   ├── LatexTab.js          # LaTeX settings tab
 │       │   ├── MemoryTab.js         # Memory tab logic (migrated)
 │       │   ├── HistoryTab.js        # History tab logic (migrated)
 │       │   └── ProfileTab.js        # Profile tab logic (migrated)
 │       └── uiManagers/
 │           ├── ModelListRenderer.js
 │           ├── AgentListRenderer.js
+│           ├── LatexSettingsRenderer.js
 │           ├── MemoryRenderer.js    # From memoryView
 │           ├── HistoryRenderer.js   # From historyView
 │           └── ProfileRenderer.js   # From profileView
@@ -1012,7 +1238,8 @@ src/
 commands.registerCommand('texra.openSettings', (tab?: string) => {
   settingsViewProvider.show();
   if (tab) {
-    settingsViewProvider.selectTab(tab); // 'models' | 'agents' | 'history' | 'profile'
+    // 'models' | 'agents' | 'latex' | 'memory' | 'history' | 'profile'
+    settingsViewProvider.selectTab(tab);
   }
 });
 
@@ -1021,6 +1248,8 @@ commands.registerCommand('texra.openModelSettings', () =>
   commands.executeCommand('texra.openSettings', 'models'));
 commands.registerCommand('texra.openAgentSettings', () =>
   commands.executeCommand('texra.openSettings', 'agents'));
+commands.registerCommand('texra.openLatexSettings', () =>
+  commands.executeCommand('texra.openSettings', 'latex'));
 ```
 
 ### Message Protocol
@@ -1030,6 +1259,7 @@ commands.registerCommand('texra.openAgentSettings', () =>
 type SettingsMessage =
   | { command: 'SET_MODELS_DATA', models: ModelInfo[], enabled: string[] }
   | { command: 'SET_AGENTS_DATA', agents: AgentInfo[], enabled: string[] }
+  | { command: 'SET_LATEX_DATA', settings: LatexSettings }
   | { command: 'SET_HISTORY_DATA', items: HistoryItem[] }
   | { command: 'SET_PROFILE_DATA', profile: ProfileInfo | null }
   | { command: 'SELECT_TAB', tab: string };
@@ -1038,11 +1268,21 @@ type SettingsMessage =
 type SettingsAction =
   | { command: 'SAVE_ENABLED_MODELS', models: string[] }
   | { command: 'SAVE_ENABLED_AGENTS', agents: string[] }
+  | { command: 'SAVE_LATEX_SETTING', key: string, value: unknown }
   | { command: 'RESTORE_HISTORY', id: string }
   | { command: 'DELETE_HISTORY', id: string }
   | { command: 'SIGN_IN' }
   | { command: 'SIGN_OUT' }
   | { command: 'SET_API_KEY', provider: string, key: string };
+
+// Agent info includes category
+interface AgentInfo {
+  name: string;
+  description: string;
+  category: 'workflow' | 'toolUse';
+  source: 'builtIn' | 'builtInToolUse' | 'custom' | 'remote';
+  enabled: boolean;
+}
 ```
 
 ---
@@ -1070,44 +1310,56 @@ type SettingsAction =
 3. State properly persisted (models global, agents per-workspace)
 4. History search and restore working
 5. Profile/auth flow unchanged
+6. LaTeX settings functional and synced with VS Code config
+7. Notion-style minimalist appearance achieved
 
 ---
 
 ## Implementation Phases
 
 ### Phase 1: Core Structure
-- Create settingsView with tab navigation (5 tabs)
+- Create settingsView with tab navigation (6 tabs)
 - Implement Models tab with provider accordions
 - Wire up globalState for model preferences
 - Test graceful migration from VS Code config
+- Apply Notion-style CSS variables and spacing
 
 ### Phase 2: Agents Tab
 - Implement Agents tab with local/custom/remote sections
+- Add category badges (workflow/toolUse)
 - Wire up workspaceState for agent preferences
 - Handle remote agents auth state
+- Implement AI-assisted agent creation wizard
 
-### Phase 3: Memory Tab
+### Phase 3: LaTeX Tab
+- Implement LaTeX tab with formatter, latexdiff, TikZ sections
+- Wire up to existing VS Code configuration
+- Add file browser for config paths
+- Add collapsible advanced sections (TikZ template, custom replacements)
+
+### Phase 4: Memory Tab
 - Migrate memoryView to Memory tab
 - Add conversation persistence settings UI
 - Add active sessions list with resume/discard
 - Delete old memoryView
 
-### Phase 4: Migrate History
+### Phase 5: Migrate History
 - Move history rendering to History tab
 - Preserve search, delete, restore, rerun functionality
 - Delete old historyView
 
-### Phase 5: Migrate Profile
+### Phase 6: Migrate Profile
 - Move profile/auth to Profile tab
 - Implement provider configuration cards
 - Implement provider modal (API key + endpoint)
 - Add routing options UI
 - Delete old profileView
 
-### Phase 6: Polish
+### Phase 7: Polish
 - Add main webview entry point (gear icon)
 - Deep link support (open to specific tab)
 - Verify graceful migration (no breaking existing setups)
+- Accessibility audit (keyboard navigation)
 - Documentation
 
 ---

--- a/docs/prd/settings-view-unified.md
+++ b/docs/prd/settings-view-unified.md
@@ -172,42 +172,38 @@ const RECOMMENDED_MODELS = [
 
 ### Agents Tab
 
-**Purpose:** Configure which agents appear in agent dropdowns.
+**Purpose:** Configure agents and create custom ones without YAML complexity.
+
+**Design Philosophy:** Users should be able to create and modify agents through a simple UI, not by editing YAML files. The complexity is hidden; power users can access raw YAML if needed.
 
 **Layout:**
 ```
 ┌─────────────────────────────────────────────────────────────────┐
-│  Configure which agents appear in the agent dropdowns.          │
+│  Configure agents and create custom ones.                       │
 │  Settings are saved per workspace.                              │
 │                                                                 │
-│  LOCAL AGENTS                                     [Enable All] │
-│  ┌───────────────────────────────────────────────────────────┐  │
-│  │ ☑ ask             Quick Q&A without tools                 │  │
-│  │ ☑ chat            Interactive chat with context           │  │
-│  │ ☑ correct         Corrects typos, grammar, LaTeX          │  │
-│  │ ☑ draw            Creates/polishes TikZ figures           │  │
-│  │ ☐ merge           Merges partial edits into document      │  │
-│  │ ☑ ocr             Handwritten math → LaTeX                │  │
-│  │ ☑ paper2poster    Paper → academic poster                 │  │
-│  │ ☑ paper2slide     Paper → Beamer presentation             │  │
-│  │ ☑ polish          Improves writing quality & clarity      │  │
-│  │ ☑ research        Research assistant with tools           │  │
-│  │ ☑ search          Search & retrieval                      │  │
-│  │ ☐ transcribe_audio Audio transcription                    │  │
-│  └───────────────────────────────────────────────────────────┘  │
+│  MY AGENTS                                    [+ Create Agent]  │
+│  ─────────────────────────────────────────────────────────────  │
 │                                                                 │
-│  CUSTOM AGENTS                                                 │
 │  ┌───────────────────────────────────────────────────────────┐  │
-│  │  No custom agents in this workspace.        [Learn More]  │  │
+│  │ ☑ chat            Interactive conversation         Built-in│  │
+│  │ ☑ correct         Fix typos & LaTeX errors         Built-in│  │
+│  │ ☑ polish          Improve writing quality          Built-in│  │
+│  │ ☑ research        Research with tools              Built-in│  │
+│  │ ☑ my-reviewer     Reviews papers for clarity        Custom │  │
+│  │                                            [Edit] [Delete] │  │
+│  │ ☐ draw            Create TikZ figures              Built-in│  │
+│  │ ☐ ocr             Handwritten → LaTeX              Built-in│  │
+│  │ ☐ paper2slide     Paper → Beamer slides            Built-in│  │
+│  │ ☐ paper2poster    Paper → poster                   Built-in│  │
+│  │ ☐ transcribe      Audio transcription              Built-in│  │
 │  └───────────────────────────────────────────────────────────┘  │
 │                                                                 │
 │  REMOTE AGENTS                                                 │
+│  ─────────────────────────────────────────────────────────────  │
 │  ┌───────────────────────────────────────────────────────────┐  │
 │  │ ☑ team-reviewer   Team's paper reviewer       [Public]    │  │
-│  │ ☑ grant-writer    Grant proposal helper       [Team]      │  │
-│  │ ☐ thesis-helper   Thesis writing assistant    [Private]   │  │
-│  │                                                           │  │
-│  │  ☐ Auto-show new remote agents                            │  │
+│  │ ☐ grant-writer    Grant proposal helper       [Team]      │  │
 │  └───────────────────────────────────────────────────────────┘  │
 │                        ─ or if not logged in ─                  │
 │  ┌───────────────────────────────────────────────────────────┐  │
@@ -215,21 +211,130 @@ const RECOMMENDED_MODELS = [
 │  └───────────────────────────────────────────────────────────┘  │
 │                                                                 │
 │  ─────────────────────────────────────────────────────────────  │
-│  Selected: 12 agents                              [Save Changes]│
+│  [Advanced: Open Agent Files]          ← Power users only      │
 └─────────────────────────────────────────────────────────────────┘
 ```
 
-**Data Source:** `agentRegistry` (built-in, custom, remote)
+---
 
-**Agent Metadata Displayed:**
-- Name
-- Description
-- Source badge (for remote: visibility)
+### Create Agent Wizard
 
-**Sections:**
-1. **Local Agents** - Built-in agents from `resources/agents/`
-2. **Custom Agents** - User-defined agents in workspace
-3. **Remote Agents** - Shared team agents (requires auth)
+Click **[+ Create Agent]** → AI-assisted creation:
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  Create Custom Agent                                      [×]  │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                 │
+│  What should this agent do?                                    │
+│  ┌───────────────────────────────────────────────────────────┐  │
+│  │ Review my paper drafts and suggest improvements for       │  │
+│  │ clarity, argument structure, and academic tone.           │  │
+│  └───────────────────────────────────────────────────────────┘  │
+│                                                                 │
+│  Agent name: [paper-reviewer    ]                              │
+│                                                                 │
+│  Type:                                                         │
+│  ● Document processor (input → output)                         │
+│  ○ Interactive chat (conversation)                             │
+│                                                                 │
+│  ─────────────────────────────────────────────────────────────  │
+│  💡 AI will generate the agent for you.                        │
+│                                                                 │
+│                                      [Cancel]  [Create Agent]  │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+**Flow:**
+1. User describes what agent should do (plain English)
+2. AI generates YAML configuration behind the scenes
+3. Agent immediately appears in list, ready to use
+4. No YAML knowledge required
+
+---
+
+### Edit Agent Form
+
+Click **[Edit]** on custom agent → Form-based editor:
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  Edit Agent: paper-reviewer                               [×]  │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                 │
+│  BASIC                                                         │
+│  ─────────────────────────────────────────────────────────────  │
+│  Name:        [paper-reviewer                ]                 │
+│  Description: [Reviews papers for clarity    ]                 │
+│  Based on:    [correct ▼] (inherit from built-in)              │
+│                                                                 │
+│  BEHAVIOR                                                      │
+│  ─────────────────────────────────────────────────────────────  │
+│  Style:  ● Thorough (chain-of-thought)  ○ Quick (direct)       │
+│  Rounds: [2 ▼]                                                 │
+│                                                                 │
+│  INSTRUCTIONS                                                  │
+│  ─────────────────────────────────────────────────────────────  │
+│  What the agent should do:                                     │
+│  ┌───────────────────────────────────────────────────────────┐  │
+│  │ You are an academic paper reviewer. Analyze the document  │  │
+│  │ for clarity, argument structure, and academic tone.       │  │
+│  │ Suggest specific improvements with examples.              │  │
+│  └───────────────────────────────────────────────────────────┘  │
+│                                                                 │
+│  ▶ Advanced options                                            │
+│                                                                 │
+│  ─────────────────────────────────────────────────────────────  │
+│  [View YAML]                       [Cancel]  [Test]  [Save]   │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+**Form fields map to YAML transparently:**
+- Name → `name:`
+- Description → `description:`
+- Based on → `inherits:`
+- Style → `settings.agentType:`
+- Rounds → `settings.rounds:`
+- Instructions → `prompts.systemPrompt:`
+
+---
+
+### Complexity Comparison
+
+| Task | Before (YAML) | After (UI) |
+|------|---------------|------------|
+| **Create agent** | Write YAML from scratch | Describe in English, AI generates |
+| **Edit agent** | Edit YAML syntax | Fill out form |
+| **Set inheritance** | `inherits: correct` | Dropdown: "Based on: correct" |
+| **Change rounds** | Edit `settings.rounds: 2` | Slider or dropdown |
+| **View all agents** | File explorer + folders | Single flat list |
+
+---
+
+### Data Flow
+
+```
+┌─────────────────┐     ┌─────────────────┐     ┌─────────────────┐
+│   User Input    │────▶│   Form/Wizard   │────▶│   YAML File     │
+│  (plain text)   │     │   (abstracts)   │     │  (storage)      │
+└─────────────────┘     └─────────────────┘     └─────────────────┘
+                               │
+                               ▼
+                        ┌─────────────────┐
+                        │  Agent Registry │
+                        │  (runtime)      │
+                        └─────────────────┘
+```
+
+YAML files remain the source of truth, but users interact through forms.
+
+---
+
+### Power User Escape Hatches
+
+1. **[View YAML]** button in edit form - opens raw YAML
+2. **[Advanced: Open Agent Files]** - opens file explorer
+3. YAML files still editable directly if preferred
 
 **Storage:** `workspaceState.enabledAgents: string[]`
 

--- a/docs/prd/settings-view-unified.md
+++ b/docs/prd/settings-view-unified.md
@@ -16,11 +16,12 @@ Create a unified Settings View that consolidates model configuration, agent conf
 ## Goals
 
 1. **Single source of truth** - All configuration in one place
-2. **Easy navigation** - Tab-based switching between Models, Agents, LaTeX, Memory, History, Profile
-3. **No auth required** - Models, Agents, LaTeX, Memory, History tabs work without login
+2. **Easy navigation** - Tab-based switching between Models, Agents, Tool-Use, LaTeX, Memory, History, Profile, UI, Misc
+3. **No auth required** - Most tabs work without login (except Profile features)
 4. **VS Code native** - Use `vscode-tabs`, `vscode-tab-header`, `vscode-tab-panel` components
 5. **Proper state management** - Global vs workspace state separation
-6. **Notion-style minimalism** - Clean, uncluttered interface with generous whitespace
+6. **Backwards compatible** - Extend getConfig rather than replacing it; graceful migration
+7. **Notion-style minimalism** - Clean, uncluttered interface with generous whitespace
 
 ---
 
@@ -75,17 +76,28 @@ Clicking ⚙️ (codicon: `settings-gear`) opens the unified Settings View.
 ### Tab Structure
 
 ```
-┌─────────────────────────────────────────────────────────────────┐
-│  TeXRA Settings                                          [×]   │
-├─────────────────────────────────────────────────────────────────┤
-│  [Models]  Agents   LaTeX   Memory   History   Profile         │
-│  ═══════                                                        │
-├─────────────────────────────────────────────────────────────────┤
-│                                                                 │
-│                    Tab content here                             │
-│                                                                 │
-└─────────────────────────────────────────────────────────────────┘
+┌──────────────────────────────────────────────────────────────────────────────┐
+│  TeXRA Settings                                                       [×]   │
+├──────────────────────────────────────────────────────────────────────────────┤
+│  [Models]  Agents  Tool-Use  LaTeX  Memory  History  Profile  UI  Misc      │
+│  ═══════                                                                     │
+├──────────────────────────────────────────────────────────────────────────────┤
+│                                                                              │
+│                              Tab content here                                │
+│                                                                              │
+└──────────────────────────────────────────────────────────────────────────────┘
 ```
+
+**Tab Purposes:**
+- **Models** - Model selection, provider status
+- **Agents** - Agent enable/disable, view metadata, remote agents
+- **Tool-Use** - Tool execution settings (edit approval, permissions)
+- **LaTeX** - Formatter, latexdiff, TikZ, replacements
+- **Memory** - Persistent memory files, active sessions
+- **History** - Execution history browser
+- **Profile** - Account, API keys, streaming settings, routing
+- **UI** - UI behavior settings
+- **Misc** - Miscellaneous settings
 
 ### HTML Structure (using vscode-elements)
 
@@ -93,29 +105,23 @@ Clicking ⚙️ (codicon: `settings-gear`) opens the unified Settings View.
 <vscode-tabs id="settingsTabs" selected-index="0">
   <vscode-tab-header slot="header">Models</vscode-tab-header>
   <vscode-tab-header slot="header">Agents</vscode-tab-header>
+  <vscode-tab-header slot="header">Tool-Use</vscode-tab-header>
   <vscode-tab-header slot="header">LaTeX</vscode-tab-header>
   <vscode-tab-header slot="header">Memory</vscode-tab-header>
   <vscode-tab-header slot="header">History</vscode-tab-header>
   <vscode-tab-header slot="header">Profile</vscode-tab-header>
+  <vscode-tab-header slot="header">UI</vscode-tab-header>
+  <vscode-tab-header slot="header">Misc</vscode-tab-header>
 
-  <vscode-tab-panel id="modelsPanel">
-    <!-- Models tab content -->
-  </vscode-tab-panel>
-  <vscode-tab-panel id="agentsPanel">
-    <!-- Agents tab content -->
-  </vscode-tab-panel>
-  <vscode-tab-panel id="latexPanel">
-    <!-- LaTeX tab content -->
-  </vscode-tab-panel>
-  <vscode-tab-panel id="memoryPanel">
-    <!-- Memory tab content -->
-  </vscode-tab-panel>
-  <vscode-tab-panel id="historyPanel">
-    <!-- History tab content -->
-  </vscode-tab-panel>
-  <vscode-tab-panel id="profilePanel">
-    <!-- Profile tab content -->
-  </vscode-tab-panel>
+  <vscode-tab-panel id="modelsPanel"><!-- Models --></vscode-tab-panel>
+  <vscode-tab-panel id="agentsPanel"><!-- Agents --></vscode-tab-panel>
+  <vscode-tab-panel id="toolUsePanel"><!-- Tool-Use --></vscode-tab-panel>
+  <vscode-tab-panel id="latexPanel"><!-- LaTeX --></vscode-tab-panel>
+  <vscode-tab-panel id="memoryPanel"><!-- Memory --></vscode-tab-panel>
+  <vscode-tab-panel id="historyPanel"><!-- History --></vscode-tab-panel>
+  <vscode-tab-panel id="profilePanel"><!-- Profile --></vscode-tab-panel>
+  <vscode-tab-panel id="uiPanel"><!-- UI --></vscode-tab-panel>
+  <vscode-tab-panel id="miscPanel"><!-- Misc --></vscode-tab-panel>
 </vscode-tabs>
 ```
 
@@ -281,6 +287,69 @@ const RECOMMENDED_MODELS = [
 
 **Storage:** `workspaceState.enabledAgents: string[]`
 
+**Remote Agent Settings (moved from VS Code config):**
+- `texra.remoteAgents.autoShowIfAvailable` → `workspaceState.remoteAgentsAutoShow`
+- `texra.remoteAgents.cacheTimeHours` → Remains in VS Code config (advanced)
+
+---
+
+### Tool-Use Tab
+
+**Purpose:** Configure tool execution behavior, edit approval, and permissions.
+
+**Layout:**
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  Configure how tool-use agents interact with your workspace.    │
+│                                                                 │
+│  EDIT APPROVAL                                                  │
+│  ─────────────────────────────────────────────────────────────  │
+│                                                                 │
+│  ☑ Require approval before file edits                          │
+│    Show diff preview and require confirmation before            │
+│    tool-use agents modify files.                                │
+│                                                                 │
+│  ─────────────────────────────────────────────────────────────  │
+│                                                                 │
+│  SESSION PERSISTENCE                                            │
+│  ─────────────────────────────────────────────────────────────  │
+│                                                                 │
+│  ☑ Persist tool-use sessions across VS Code restarts           │
+│    Sessions are saved and can be resumed later.                │
+│                                                                 │
+│  Session retention: [72 hours ▼]                               │
+│    Options: 24h, 48h, 72h, 1 week, 2 weeks                     │
+│                                                                 │
+│  ─────────────────────────────────────────────────────────────  │
+│                                                                 │
+│  ACTIVE SESSIONS                                                │
+│  ─────────────────────────────────────────────────────────────  │
+│  Tool-use sessions waiting for continuation.                    │
+│                                                                 │
+│  ┌───────────────────────────────────────────────────────────┐  │
+│  │ research (chat)               Jan 11, 1:15 PM   WAITING   │  │
+│  │ "Help me analyze the survey results..."                   │  │
+│  │                                      [Resume] [Discard]   │  │
+│  └───────────────────────────────────────────────────────────┘  │
+│                                                                 │
+│  ┌───────────────────────────────────────────────────────────┐  │
+│  │ paper-writing (chat)          Jan 10, 3:00 PM   WAITING   │  │
+│  │ "Continue editing section 3..."                           │  │
+│  │                                      [Resume] [Discard]   │  │
+│  └───────────────────────────────────────────────────────────┘  │
+│                                                                 │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+**Settings Mapping:**
+| UI Element | VS Code Setting |
+|------------|-----------------|
+| Require approval checkbox | `texra.toolUse.requireEditApproval` |
+| Persist sessions checkbox | `texra.toolUse.persistence.enabled` |
+| Session retention dropdown | `texra.toolUse.persistence.ttlHours` |
+
+**Storage:** VS Code configuration (for backwards compatibility via extended getConfig)
+
 ---
 
 ### LaTeX Tab
@@ -384,25 +453,14 @@ const RECOMMENDED_MODELS = [
 
 ### Memory Tab
 
-**Purpose:** Manage persistent agent memory and conversation settings.
+**Purpose:** Browse and manage persistent memory files created by tool-use agents.
+
+**Note:** Tool-use settings (edit approval, session persistence) are in the Tool-Use Tab.
 
 **Layout:**
 ```
 ┌─────────────────────────────────────────────────────────────────┐
-│  Persistent memory storage for tool-use agents.                 │
-│                                                                 │
-│  TOOL-USE SETTINGS                                             │
-│  ─────────────────────────────────────────────────────────────  │
-│  ☑ Require approval before file edits                          │
-│    Show diff preview and require confirmation for tool edits.  │
-│                                                                 │
-│  ☑ Persist conversations across VS Code restarts               │
-│    Sessions are saved and can be resumed later.                │
-│                                                                 │
-│  Session retention: [72 hours ▼]                               │
-│    Options: 24h, 48h, 72h, 1 week, 2 weeks                     │
-│                                                                 │
-│  ─────────────────────────────────────────────────────────────  │
+│  Memory files created by tool-use agents.                       │
 │                                                                 │
 │  MEMORY FILES                                     [Refresh]    │
 │  ─────────────────────────────────────────────────────────────  │
@@ -427,41 +485,19 @@ const RECOMMENDED_MODELS = [
 │                                                                 │
 │  Total: 5 files, 24 KB                        [Clear All]      │
 │                                                                 │
-│  ─────────────────────────────────────────────────────────────  │
-│                                                                 │
-│  ACTIVE SESSIONS                                               │
-│  ─────────────────────────────────────────────────────────────  │
-│  Tool-use sessions waiting for continuation.                    │
-│                                                                 │
-│  ┌───────────────────────────────────────────────────────────┐  │
-│  │ research (chat)               Jan 11, 1:15 PM   WAITING   │  │
-│  │ "Help me analyze the survey results..."                   │  │
-│  │                                      [Resume] [Discard]   │  │
-│  └───────────────────────────────────────────────────────────┘  │
-│                                                                 │
-│  ┌───────────────────────────────────────────────────────────┐  │
-│  │ paper-writing (chat)          Jan 10, 3:00 PM   WAITING   │  │
-│  │ "Continue editing section 3..."                           │  │
-│  │                                      [Resume] [Discard]   │  │
-│  └───────────────────────────────────────────────────────────┘  │
-│                                                                 │
 └─────────────────────────────────────────────────────────────────┘
 ```
 
 **Features:** (Migrated from memoryView)
-- Conversation persistence toggle and TTL setting
 - Memory file browser (from existing memoryView)
 - File preview, delete actions
 - Directory browsing (2-level deep)
-- Active session list with resume/discard
 - Storage usage display
 
 **Data Sources:**
 - Memory files: `/memories` directory managed by MemoryTool
-- Active sessions: Tool-use session snapshots
-- Settings: `texra.toolUse.requireEditApproval`, `texra.toolUse.persistence.*`
 
-**Storage:** `workspaceState` for persistence settings
+**Storage:** File system (no extension state needed)
 
 ---
 
@@ -649,12 +685,21 @@ When clicking [Edit] or [Configure] on a provider:
 │  │ └─────────────────────────────────────────────────────┘   │  │
 │  │ Leave empty for default (api.anthropic.com)               │  │
 │  │ Use for: proxies, Azure OpenAI, self-hosted models        │  │
+│  │                                                           │  │
+│  │ ☑ Enable streaming                                        │  │
+│  │   Stream responses in real-time for this provider.        │  │
+│  │   Disable if experiencing issues with proxies.            │  │
 │  └───────────────────────────────────────────────────────────┘  │
 │                                                                 │
 │  ─────────────────────────────────────────────────────────────  │
 │                                            [Cancel]   [Save]   │
 └─────────────────────────────────────────────────────────────────┘
 ```
+
+**Streaming Settings (per provider):**
+The `texra.model.useStreaming*` settings (9 total) are now configured per provider
+in the Advanced Options of each provider's configuration modal. This replaces the
+scattered VS Code settings with a unified UI.
 
 **OpenRouter (Special Case):**
 ```
@@ -710,6 +755,123 @@ In the Models tab, show provider/routing status on each model:
 - `⚠ No key` - Provider not configured (click to configure)
 - `🔀 OpenRouter` - Available via OpenRouter only
 - `🔒 Premium` - Requires subscription tier (if using included access)
+
+---
+
+### UI Tab
+
+**Purpose:** Configure user interface behavior and display preferences.
+
+**Layout:**
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  Configure TeXRA user interface settings.                       │
+│                                                                 │
+│  DISPLAY OPTIONS                                                │
+│  ─────────────────────────────────────────────────────────────  │
+│                                                                 │
+│  ☑ Show quick pick for agent selection                          │
+│    Use VS Code quick pick instead of dropdown for agents.      │
+│                                                                 │
+│  ☑ Show quick pick for model selection                          │
+│    Use VS Code quick pick instead of dropdown for models.      │
+│                                                                 │
+│  ─────────────────────────────────────────────────────────────  │
+│                                                                 │
+│  PROGRESS BOARD                                                 │
+│  ─────────────────────────────────────────────────────────────  │
+│                                                                 │
+│  Stream sort order: [Timestamp descending ▼]                   │
+│    Options: Timestamp ascending, Timestamp descending          │
+│                                                                 │
+│  ─────────────────────────────────────────────────────────────  │
+│                                                                 │
+│  IMAGE PROCESSING                                               │
+│  ─────────────────────────────────────────────────────────────  │
+│                                                                 │
+│  Max image dimension: [2048 ▼]                                 │
+│    Larger images will be resized before sending to models.     │
+│    Options: 1024, 2048, 4096                                   │
+│                                                                 │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+**Settings Mapping:**
+| UI Element | VS Code Setting |
+|------------|-----------------|
+| Agent quick pick checkbox | `texra.ui.showAgentQuickPick` |
+| Model quick pick checkbox | `texra.ui.showModelQuickPick` |
+| Stream sort order dropdown | `texra.progressBoard.streamSortOrder` |
+| Max image dimension dropdown | `texra.maxImageDimension` |
+
+**Storage:** VS Code configuration (backwards compatible)
+
+---
+
+### Misc Tab
+
+**Purpose:** Miscellaneous settings that don't fit in other categories.
+
+**Layout:**
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  Miscellaneous settings.                                        │
+│                                                                 │
+│  CONTEXT & COMPACTION                                           │
+│  ─────────────────────────────────────────────────────────────  │
+│                                                                 │
+│  Compaction threshold: [85 %]                                  │
+│    Compact context when usage exceeds this percentage.          │
+│    Range: 50-95%                                                │
+│                                                                 │
+│  ─────────────────────────────────────────────────────────────  │
+│                                                                 │
+│  GIT INTEGRATION                                                │
+│  ─────────────────────────────────────────────────────────────  │
+│                                                                 │
+│  Commits to show: [50 ▼]                                       │
+│    Number of recent commits to show in git selection.          │
+│    Options: 25, 50, 100, 200                                   │
+│                                                                 │
+│  ─────────────────────────────────────────────────────────────  │
+│                                                                 │
+│  AGENT OUTPUTS                                                  │
+│  ─────────────────────────────────────────────────────────────  │
+│                                                                 │
+│  Storage mode: [Folder ▼]                                      │
+│    How to store agent outputs.                                 │
+│    Options: In-place, Folder                                   │
+│                                                                 │
+│  ─────────────────────────────────────────────────────────────  │
+│                                                                 │
+│  RETRY BEHAVIOR                                                 │
+│  ─────────────────────────────────────────────────────────────  │
+│                                                                 │
+│  Max retries: [3 ▼]                                            │
+│    Maximum number of retries for failed API requests.          │
+│                                                                 │
+│  Initial delay: [1000 ms]                                      │
+│    Initial delay before first retry (exponential backoff).     │
+│                                                                 │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+**Settings Mapping:**
+| UI Element | VS Code Setting |
+|------------|-----------------|
+| Compaction threshold | `texra.model.compactionThresholdPercent` |
+| Commits to show | `texra.git.numberOfCommitsToShow` |
+| Agent outputs storage mode | `texra.agentOutputs.storageMode` |
+| Max retries | `texra.model.retry.maxRetries` |
+| Initial delay | `texra.model.retry.initialDelayMs` |
+
+**Storage:** VS Code configuration (backwards compatible)
+
+---
+
+### Future: Multi-Agent Tab
+
+**Note:** The `texra.merge.defaultModel` setting is intended for a future Multi-Agent Tab that will configure multi-agent workflows (merge operations). This is deferred until the multi-agent feature set is more mature.
 
 ---
 
@@ -925,6 +1087,102 @@ Users who have configured API keys will continue to work without any action.
 
 ---
 
+### Critical: Extend getConfig for Backwards Compatibility
+
+**Key Principle:** There is too much logic code using `getConfig()` throughout the codebase. We should NOT break that. Instead, we **extend** `getConfig` to be aware of the new state sources.
+
+**Current Pattern (scattered throughout codebase):**
+```typescript
+const config = vscode.workspace.getConfiguration('texra');
+const models = config.get<string[]>('models');
+const useStreaming = config.get<boolean>('model.useStreamingAnthropic');
+```
+
+**Extended getConfig Pattern:**
+```typescript
+import { getConfig } from '@common/config';
+
+// getConfig now checks extension state first, then falls back to VS Code config
+const models = getConfig<string[]>('models');           // → Reads globalState first
+const useStreaming = getConfig<boolean>('model.useStreamingAnthropic'); // → Reads providerConfig
+```
+
+**Implementation:**
+```typescript
+// src/common/config.ts
+
+/**
+ * Extended configuration getter that supports both extension state and VS Code config.
+ *
+ * Priority for each setting type:
+ * 1. Extension state (globalState/workspaceState) - for settings moved to new UI
+ * 2. VS Code config - for backwards compatibility and advanced settings
+ * 3. Default value
+ *
+ * This allows existing code using getConfig to continue working unchanged.
+ */
+export function getConfig<T>(key: string, defaultValue?: T): T {
+  const context = getExtensionContext();
+
+  // Settings that have moved to extension state
+  const stateMapping: Record<string, () => T | undefined> = {
+    'models': () => context.globalState.get('enabledModels') as T,
+    'agents': () => context.workspaceState.get('enabledAgents') as T,
+    'toolUseAgents': () => context.workspaceState.get('enabledAgents') as T,
+    'model.useOpenRouter': () => {
+      const routing = context.globalState.get<RoutingConfig>('routing');
+      return (routing?.mode === 'openrouter') as unknown as T;
+    },
+    'model.useImprovedConnection': () => {
+      const routing = context.globalState.get<RoutingConfig>('routing');
+      return (routing?.mode === 'proxy') as unknown as T;
+    },
+    'model.improvedConnectionDomain': () => {
+      const routing = context.globalState.get<RoutingConfig>('routing');
+      return routing?.proxyDomain as T;
+    },
+    // Streaming settings now in provider config
+    'model.useStreamingAnthropic': () => getProviderStreaming('anthropic') as T,
+    'model.useStreamingOpenAI': () => getProviderStreaming('openai') as T,
+    'model.useStreamingGoogle': () => getProviderStreaming('google') as T,
+    // ... etc for all streaming settings
+  };
+
+  // Check extension state first
+  const stateGetter = stateMapping[key];
+  if (stateGetter) {
+    const fromState = stateGetter();
+    if (fromState !== undefined) {
+      return fromState;
+    }
+  }
+
+  // Fall back to VS Code config (existing behavior)
+  const config = vscode.workspace.getConfiguration('texra');
+  return config.get<T>(key, defaultValue as T);
+}
+
+function getProviderStreaming(providerId: string): boolean {
+  const context = getExtensionContext();
+  const providerConfig = context.globalState.get<ProviderConfigMap>('providerConfig');
+  return providerConfig?.[providerId]?.streaming ?? true; // Default: streaming enabled
+}
+```
+
+**Benefits:**
+1. **Zero breaking changes** - Existing `getConfig()` calls continue to work
+2. **Gradual migration** - Settings move to UI without code changes
+3. **Single source of truth** - UI writes to extension state, getConfig reads it
+4. **VS Code config fallback** - Power users can still override via settings.json
+
+**Migration Path:**
+1. Implement extended `getConfig()` with state awareness
+2. Build Settings UI that writes to extension state
+3. Existing code automatically picks up new values
+4. No mass refactoring of `getConfig()` calls needed
+
+---
+
 ### What Moves to Extension State
 
 | Setting | From | To | Reason |
@@ -1026,26 +1284,32 @@ src/
 │   ├── SettingsViewProvider.ts      # WebviewViewProvider
 │   ├── SettingsViewMessageHandler.ts
 │   ├── SettingsViewContentProvider.ts
-│   ├── index.html                   # Tabbed layout
-│   ├── styles.css                   # Notion-inspired styling
+│   ├── index.html                   # Tabbed layout (9 tabs)
+│   ├── styles.css                   # VS Code native styling
 │   └── modules/
 │       ├── main.js                  # Entry point
 │       ├── messageHandlers.js
 │       ├── settingsViewState.js
 │       ├── tabs/
 │       │   ├── ModelsTab.js         # Models tab logic
-│       │   ├── AgentsTab.js         # Agents tab logic (with categories)
+│       │   ├── AgentsTab.js         # Agents tab (includes remote agents)
+│       │   ├── ToolUseTab.js        # Tool-use settings + sessions
 │       │   ├── LatexTab.js          # LaTeX settings tab
-│       │   ├── MemoryTab.js         # Memory tab logic (migrated)
-│       │   ├── HistoryTab.js        # History tab logic (migrated)
-│       │   └── ProfileTab.js        # Profile tab logic (migrated)
+│       │   ├── MemoryTab.js         # Memory files browser
+│       │   ├── HistoryTab.js        # History tab (migrated)
+│       │   ├── ProfileTab.js        # Profile tab (streaming, routing)
+│       │   ├── UITab.js             # UI preferences
+│       │   └── MiscTab.js           # Miscellaneous settings
 │       └── uiManagers/
 │           ├── ModelListRenderer.js
 │           ├── AgentListRenderer.js
+│           ├── ToolUseRenderer.js
 │           ├── LatexSettingsRenderer.js
 │           ├── MemoryRenderer.js    # From memoryView
 │           ├── HistoryRenderer.js   # From historyView
-│           └── ProfileRenderer.js   # From profileView
+│           ├── ProfileRenderer.js   # From profileView
+│           ├── UIRenderer.js
+│           └── MiscRenderer.js
 │
 ├── profileView/                     # DEPRECATED - merge into settingsView
 ├── historyView/                     # DEPRECATED - merge into settingsView
@@ -1059,7 +1323,7 @@ src/
 commands.registerCommand('texra.openSettings', (tab?: string) => {
   settingsViewProvider.show();
   if (tab) {
-    // 'models' | 'agents' | 'latex' | 'memory' | 'history' | 'profile'
+    // 'models' | 'agents' | 'tooluse' | 'latex' | 'memory' | 'history' | 'profile' | 'ui' | 'misc'
     settingsViewProvider.selectTab(tab);
   }
 });
@@ -1138,8 +1402,9 @@ interface AgentInfo {
 
 ## Implementation Phases
 
-### Phase 1: Core Structure
-- Create settingsView with tab navigation (6 tabs)
+### Phase 1: Core Structure + Extended getConfig
+- Create settingsView with tab navigation (9 tabs)
+- Implement extended `getConfig()` with state awareness
 - Implement Models tab with provider accordions
 - Wire up globalState for model preferences
 - Test graceful migration from VS Code config
@@ -1149,35 +1414,46 @@ interface AgentInfo {
 - Implement Agents tab with list of all agents
 - Show category badges (workflow/toolUse) and source (built-in/custom/remote)
 - Wire up workspaceState for agent preferences
+- Include remote agents settings (autoShowIfAvailable)
 - Handle remote agents auth state
 - Link to YAML files for editing (power users)
 - **Note:** Supersedes FolderExplorer/agent explorer view
 
-### Phase 3: LaTeX Tab
+### Phase 3: Tool-Use Tab
+- Implement Tool-Use tab with edit approval settings
+- Add session persistence settings UI
+- Add active sessions list with resume/discard
+- Wire to VS Code config via extended getConfig
+
+### Phase 4: LaTeX Tab
 - Implement LaTeX tab with formatter, latexdiff, TikZ sections
 - Wire up to existing VS Code configuration
 - Add file browser for config paths
 - Add collapsible advanced sections (TikZ template, custom replacements)
 
-### Phase 4: Memory Tab
-- Migrate memoryView to Memory tab
-- Add conversation persistence settings UI
-- Add active sessions list with resume/discard
+### Phase 5: Memory Tab
+- Migrate memoryView to Memory tab (file browser only)
+- Remove tool-use settings (moved to Tool-Use tab)
 - Delete old memoryView
 
-### Phase 5: Migrate History
+### Phase 6: Migrate History
 - Move history rendering to History tab
 - Preserve search, delete, restore, rerun functionality
 - Delete old historyView
 
-### Phase 6: Migrate Profile
+### Phase 7: Migrate Profile
 - Move profile/auth to Profile tab
 - Implement provider configuration cards
-- Implement provider modal (API key + endpoint)
+- Implement provider modal (API key + endpoint + streaming toggle)
 - Add routing options UI
 - Delete old profileView
 
-### Phase 7: Polish & Cleanup
+### Phase 8: UI + Misc Tabs
+- Implement UI tab with display preferences
+- Implement Misc tab with advanced settings
+- Wire to VS Code config via extended getConfig
+
+### Phase 9: Polish & Cleanup
 - Add main webview entry point (gear icon)
 - Deep link support (open to specific tab)
 - Verify graceful migration (no breaking existing setups)
@@ -1187,37 +1463,45 @@ interface AgentInfo {
 - Documentation
 
 ### Future Scope (Deferred)
+- **Multi-Agent Tab** - Configure merge operations and `texra.merge.defaultModel`
 - **Agent Creation Wizard** - AI-assisted agent creation from plain English description
 - **Agent Edit Form** - Form-based editing without YAML knowledge
 
 ---
 
-## Uncovered Settings (Remain in VS Code Config)
+## Settings Coverage Summary
 
-Based on 79 total settings in package.json, these remain as advanced VS Code settings:
+Based on 79 total settings in package.json:
 
-### Could Be Added Later (17 settings)
-| Setting | Suggested Tab | Priority |
-|---------|--------------|----------|
-| `texra.model.useStreaming*` (9) | Models → Advanced | Medium |
-| `texra.toolUse.requireEditApproval` | Memory | High |
-| `texra.merge.defaultModel` | Models or Agents | Low |
-| `texra.model.compactionThresholdPercent` | Models → Advanced | Low |
-| `texra.model.baseUrlDeepSeek` | Profile → Providers | Low |
-| `texra.maxImageDimension` | LaTeX or new Files tab | Low |
-| `texra.progressBoard.streamSortOrder` | New UI Preferences tab | Low |
-| `texra.model.retry.*` (2) | Models → Advanced | Low |
+### Now Covered by Settings View (46 settings)
 
-### Should Remain as VS Code Settings (33 settings)
-- `texra.ui.*` (3) - UI behavior flags
-- `texra.files.*` (16) - File type filtering (power user)
-- `texra.logger.*`, `texra.debug.*` (3) - Development only
-- `texra.auth.*` (3) - System-level authentication
-- `texra.remoteAgents.*` (2) - Remote agent behavior
-- `texra.explorer.agentsDirectory` - System path
-- `texra.audio.soxPath` - System path
-- `texra.git.numberOfCommitsToShow` - Niche preference
-- `texra.agentOutputs.storageMode` - Advanced workflow
+| Tab | Settings Covered |
+|-----|------------------|
+| **Models** | `texra.models`, enabled model list |
+| **Agents** | `texra.agents`, `texra.toolUseAgents`, `texra.remoteAgents.autoShowIfAvailable` |
+| **Tool-Use** | `texra.toolUse.requireEditApproval`, `texra.toolUse.persistence.*` (2) |
+| **LaTeX** | `texra.latex.*` (7), `texra.latexdiff.*` (4) |
+| **Memory** | Memory file browser (no config, file system) |
+| **History** | History browser (existing storage) |
+| **Profile** | `texra.model.useStreaming*` (9), `texra.model.useOpenRouter`, `texra.model.useImprovedConnection`, `texra.model.improvedConnectionDomain`, `texra.model.baseUrlDeepSeek` |
+| **UI** | `texra.ui.*` (3), `texra.progressBoard.streamSortOrder`, `texra.maxImageDimension` |
+| **Misc** | `texra.model.compactionThresholdPercent`, `texra.git.numberOfCommitsToShow`, `texra.agentOutputs.storageMode`, `texra.model.retry.*` (2) |
+
+### Deferred to Future Tabs (1 setting)
+| Setting | Future Tab | Notes |
+|---------|------------|-------|
+| `texra.merge.defaultModel` | Multi-Agent | Awaiting multi-agent feature maturity |
+
+### Remain as VS Code Settings Only (32 settings)
+These are advanced/power-user settings that don't need UI exposure:
+
+- `texra.files.*` (16) - File type filtering patterns (power user)
+- `texra.logger.*`, `texra.debug.*` (3) - Development/debugging only
+- `texra.auth.*` (3) - System-level authentication endpoints
+- `texra.remoteAgents.cacheTimeHours` (1) - Advanced cache behavior
+- `texra.explorer.agentsDirectory` (1) - System path
+- `texra.audio.soxPath` (1) - System path for audio
+- Other system-level paths and debug flags (7)
 
 ---
 
@@ -1415,10 +1699,13 @@ const SETTINGS_VIEW_MODULES = [
   { key: 'settingsViewStateUri', path: 'modules/settingsViewState.js' },
   { key: 'modelsTabUri', path: 'modules/tabs/ModelsTab.js' },
   { key: 'agentsTabUri', path: 'modules/tabs/AgentsTab.js' },
+  { key: 'toolUseTabUri', path: 'modules/tabs/ToolUseTab.js' },
   { key: 'latexTabUri', path: 'modules/tabs/LatexTab.js' },
   { key: 'memoryTabUri', path: 'modules/tabs/MemoryTab.js' },
   { key: 'historyTabUri', path: 'modules/tabs/HistoryTab.js' },
   { key: 'profileTabUri', path: 'modules/tabs/ProfileTab.js' },
+  { key: 'uiTabUri', path: 'modules/tabs/UITab.js' },
+  { key: 'miscTabUri', path: 'modules/tabs/MiscTab.js' },
 ] as const;
 
 export class SettingsViewContentProvider extends BaseViewContentProvider {

--- a/docs/prd/settings-view-unified.md
+++ b/docs/prd/settings-view-unified.md
@@ -271,62 +271,232 @@ const RECOMMENDED_MODELS = [
 
 ### Profile Tab
 
-**Purpose:** Account management and API keys.
+**Purpose:** Account management, API provider configuration, and routing settings.
 
-**Layout:**
+**Layout (Logged In):**
 ```
 ┌─────────────────────────────────────────────────────────────────┐
 │                                                                 │
+│  ACCOUNT                                                       │
 │  ┌─────────────────────────────────────────────────────────┐    │
 │  │  👤 user@example.com                        [Sign Out]  │    │
 │  │     Pro Plan • Ultra Tier                               │    │
 │  │     Access expires: Feb 15, 2026                        │    │
 │  └─────────────────────────────────────────────────────────┘    │
 │                                                                 │
-│  MODEL ACCESS                                                  │
+│  MODEL ACCESS MODE                                             │
 │  ─────────────────────────────────────────────────────────────  │
-│  ○ Use Included Access                                         │
+│  ● Use Included Access                                         │
 │    Works automatically. No setup needed.                       │
+│    ▶ View included providers & models                          │
 │                                                                 │
-│  ● Use My Own API Keys                                         │
-│    Provide your own API keys from providers.                   │
+│  ○ Use My Own API Keys                                         │
+│    Configure providers below.                                  │
 │                                                                 │
-│  ▶ View included providers & models                            │
-│                                                                 │
-│  API KEYS                                                      │
 │  ─────────────────────────────────────────────────────────────  │
-│  Anthropic    ●●●●●●●●sk-1234              [Edit] [Delete]    │
-│  OpenAI       ●●●●●●●●sk-5678              [Edit] [Delete]    │
-│  Google       Not configured                      [Add Key]    │
-│  DeepSeek     Not configured                      [Add Key]    │
 │                                                                 │
-└─────────────────────────────────────────────────────────────────┘
-
-─── or if not logged in ───
-
-┌─────────────────────────────────────────────────────────────────┐
-│                                                                 │
-│  ┌─────────────────────────────────────────────────────────┐    │
-│  │  Sign in to sync settings and access premium features   │    │
-│  │                                         [Sign In]       │    │
-│  └─────────────────────────────────────────────────────────┘    │
-│                                                                 │
-│  API KEYS (Local Mode)                                         │
+│  API PROVIDERS                                                 │
 │  ─────────────────────────────────────────────────────────────  │
-│  Configure API keys to use AI models without an account.       │
+│  Configure API keys and endpoints for each provider.           │
 │                                                                 │
-│  Anthropic    Not configured                      [Add Key]    │
-│  OpenAI       Not configured                      [Add Key]    │
-│  ...                                                           │
+│  ┌───────────────────────────────────────────────────────────┐  │
+│  │ Anthropic                                        [Edit]  │  │
+│  │ ✓ API Key configured                                     │  │
+│  │ Endpoint: default                                        │  │
+│  └───────────────────────────────────────────────────────────┘  │
+│                                                                 │
+│  ┌───────────────────────────────────────────────────────────┐  │
+│  │ OpenAI                                           [Edit]  │  │
+│  │ ✓ API Key configured                                     │  │
+│  │ Endpoint: default                                        │  │
+│  └───────────────────────────────────────────────────────────┘  │
+│                                                                 │
+│  ┌───────────────────────────────────────────────────────────┐  │
+│  │ Google                                      [Configure]  │  │
+│  │ ✗ API Key not set                                        │  │
+│  └───────────────────────────────────────────────────────────┘  │
+│                                                                 │
+│  ┌───────────────────────────────────────────────────────────┐  │
+│  │ OpenRouter                                  [Configure]  │  │
+│  │ ✗ API Key not set                                        │  │
+│  │ ℹ Route multiple providers through one API key           │  │
+│  └───────────────────────────────────────────────────────────┘  │
+│                                                                 │
+│  ▶ More providers (DeepSeek, xAI, Moonshot, DashScope)         │
+│                                                                 │
+│  ─────────────────────────────────────────────────────────────  │
+│                                                                 │
+│  ROUTING OPTIONS                                               │
+│  ─────────────────────────────────────────────────────────────  │
+│  ● Direct to providers (recommended)                           │
+│    Connect directly to each provider's API                     │
+│                                                                 │
+│  ○ Route all through OpenRouter                                │
+│    Use OpenRouter for unified billing (requires OpenRouter key)│
+│                                                                 │
+│  ○ Use connection proxy                                        │
+│    Route through proxy.texra.ai for improved connectivity      │
 │                                                                 │
 └─────────────────────────────────────────────────────────────────┘
 ```
 
-**Features:**
-- Account info display
-- Model access mode toggle (included vs own keys)
-- API key management
+**Layout (Not Logged In):**
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                                                                 │
+│  ACCOUNT                                                       │
+│  ┌─────────────────────────────────────────────────────────┐    │
+│  │  Use TeXRA with your own API keys            [Sign In]  │    │
+│  │  Sign in to sync settings across devices                │    │
+│  └─────────────────────────────────────────────────────────┘    │
+│                                                                 │
+│  API PROVIDERS                                                 │
+│  ─────────────────────────────────────────────────────────────  │
+│  Configure API keys to use AI models.                          │
+│                                                                 │
+│  ┌───────────────────────────────────────────────────────────┐  │
+│  │ Anthropic                               [Configure]      │  │
+│  │ ✗ API Key not set                                        │  │
+│  │ Models: Claude Sonnet 4.5, Claude Opus 4.5, ...          │  │
+│  └───────────────────────────────────────────────────────────┘  │
+│                                                                 │
+│  ┌───────────────────────────────────────────────────────────┐  │
+│  │ OpenAI                                  [Configure]      │  │
+│  │ ✗ API Key not set                                        │  │
+│  │ Models: GPT-5.2, GPT-4.1, o4-mini, ...                   │  │
+│  └───────────────────────────────────────────────────────────┘  │
+│                                                                 │
+│  ┌───────────────────────────────────────────────────────────┐  │
+│  │ OpenRouter                              [Configure]      │  │
+│  │ ✗ API Key not set                                        │  │
+│  │ ℹ Access ALL providers with a single API key             │  │
+│  │   Get your key at openrouter.ai/keys                     │  │
+│  └───────────────────────────────────────────────────────────┘  │
+│                                                                 │
+│  ▶ More providers (Google, DeepSeek, xAI, Moonshot, DashScope) │
+│                                                                 │
+│  ─────────────────────────────────────────────────────────────  │
+│                                                                 │
+│  💡 TIP: Use OpenRouter to access all models with one key      │
+│                                                                 │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+### Provider Configuration Modal
+
+When clicking [Edit] or [Configure] on a provider:
+
+**Standard Provider (Anthropic, OpenAI, Google, etc.):**
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  Configure Anthropic                                     [×]   │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                 │
+│  API Key                                                       │
+│  ┌───────────────────────────────────────────────────────────┐  │
+│  │ sk-ant-api03-●●●●●●●●●●●●●●●●●●●●            [👁] [Clear] │  │
+│  └───────────────────────────────────────────────────────────┘  │
+│  Get your key at: console.anthropic.com                        │
+│                                                                 │
+│  ─────────────────────────────────────────────────────────────  │
+│                                                                 │
+│  Alternative: Environment Variable                             │
+│  Set ANTHROPIC_API_KEY in your environment or .env file        │
+│                                                                 │
+│  ─────────────────────────────────────────────────────────────  │
+│                                                                 │
+│  ▶ Advanced Options                                            │
+│  ┌───────────────────────────────────────────────────────────┐  │
+│  │ Custom Endpoint (optional)                                │  │
+│  │ ┌─────────────────────────────────────────────────────┐   │  │
+│  │ │                                                     │   │  │
+│  │ └─────────────────────────────────────────────────────┘   │  │
+│  │ Leave empty for default (api.anthropic.com)               │  │
+│  │ Use for: proxies, Azure OpenAI, self-hosted models        │  │
+│  └───────────────────────────────────────────────────────────┘  │
+│                                                                 │
+│  ─────────────────────────────────────────────────────────────  │
+│                                            [Cancel]   [Save]   │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+**OpenRouter (Special Case):**
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  Configure OpenRouter                                    [×]   │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                 │
+│  OpenRouter provides access to 200+ AI models from multiple    │
+│  providers through a single API key and unified billing.       │
+│                                                                 │
+│  API Key                                                       │
+│  ┌───────────────────────────────────────────────────────────┐  │
+│  │ sk-or-v1-●●●●●●●●●●●●●●●●●●●●●●●●            [👁] [Clear] │  │
+│  └───────────────────────────────────────────────────────────┘  │
+│  Get your key at: openrouter.ai/keys                           │
+│                                                                 │
+│  ─────────────────────────────────────────────────────────────  │
+│                                                                 │
+│  Routing Mode                                                  │
+│  ─────────────────────────────────────────────────────────────  │
+│                                                                 │
+│  ● OpenRouter-only models                                      │
+│    Only use OpenRouter for models that require it              │
+│    (marked with 🔀 in model list)                              │
+│                                                                 │
+│  ○ Route ALL models through OpenRouter                         │
+│    Use OpenRouter for every model request                      │
+│    Benefits: unified billing, usage tracking, fallbacks        │
+│    Note: Slightly higher latency, OpenRouter pricing applies   │
+│                                                                 │
+│  ─────────────────────────────────────────────────────────────  │
+│                                            [Cancel]   [Save]   │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+### Provider Status Indicators
+
+In the Models tab, show provider/routing status on each model:
+
+```
+┌───────────────────────────────────────────────────────────────┐
+│ ☑ Claude Sonnet 4.5 T    $3/$15   200K   🧠👁  ✓ Ready       │  ← Key configured
+│ ☑ GPT-5.2                $2/$10   256K   🧠👁  ✓ Ready       │
+│ ☐ Gemini 3 Pro           $1.25/$5 1M     🧠👁  ⚠ No key      │  ← Missing key
+│ ☑ Llama 3 405B           $0.90/$0 128K   🧠    🔀 OpenRouter │  ← OpenRouter only
+└───────────────────────────────────────────────────────────────┘
+```
+
+**Status Icons:**
+- `✓ Ready` - API key configured, model available
+- `⚠ No key` - Provider not configured (click to configure)
+- `🔀 OpenRouter` - Available via OpenRouter only
+- `🔒 Premium` - Requires subscription tier (if using included access)
+
+---
+
+### Features Summary
+
+**Profile Tab Features:**
+- Account info display (if logged in)
+- Model access mode toggle (included vs own keys) - only when logged in
+- Per-provider configuration cards
+- Provider modal with API key + custom endpoint
+- OpenRouter special configuration (routing mode)
+- Global routing options (direct/OpenRouter/proxy)
 - Sign in/out
+- Environment variable hints
+
+**Key UX Improvements:**
+1. **Works without login** - Configure API keys without account
+2. **Visual provider status** - See which providers are configured at a glance
+3. **Custom endpoints exposed** - No more hidden VS Code settings
+4. **OpenRouter simplified** - Clear explanation and routing options
+5. **Model availability feedback** - See which models are ready in Models tab
 
 ---
 
@@ -340,6 +510,21 @@ Shared across all workspaces, persists per machine.
 interface GlobalState {
   // Model preferences - same models everywhere
   enabledModels: string[];
+
+  // Provider configuration (non-secret parts)
+  providerConfig: {
+    [providerId: string]: {
+      customEndpoint?: string;   // Custom base URL (empty = default)
+      enabled: boolean;          // Show in provider list
+    };
+  };
+
+  // Routing preferences
+  routing: {
+    mode: 'direct' | 'openrouter' | 'proxy';  // Global routing strategy
+    openRouterMode: 'exclusive' | 'all';       // Only OR-models vs all
+    proxyDomain?: string;                      // Custom proxy domain
+  };
 
   // Version for migrations
   settingsVersion: number;
@@ -367,6 +552,46 @@ interface WorkspaceState {
 }
 ```
 
+### Secret Storage (`context.secrets`)
+
+Secure credential storage (VS Code SecretStorage API).
+
+```typescript
+// Keys stored in secrets (unchanged from current implementation)
+// apiKey.anthropic
+// apiKey.openai
+// apiKey.google
+// apiKey.openRouter
+// apiKey.deepseek
+// apiKey.xai
+// apiKey.moonshot
+// apiKey.dashscope
+
+// Access via SecretManager
+SecretManager.getApiKey('anthropic');
+SecretManager.setApiKey('anthropic', 'sk-...');
+SecretManager.deleteApiKey('anthropic');
+```
+
+### Environment Variable Fallback
+
+API keys can also be set via environment variables (existing behavior):
+
+```bash
+# In shell or .env file
+ANTHROPIC_API_KEY=sk-ant-...
+OPENAI_API_KEY=sk-...
+GOOGLE_API_KEY=...
+OPENROUTER_API_KEY=sk-or-...
+DEEPSEEK_API_KEY=...
+XAI_API_KEY=...
+```
+
+**Priority order:**
+1. VS Code Secrets (highest)
+2. Environment variables
+3. `.env` file in workspace
+
 ### Defaults (Hardcoded)
 
 ```typescript
@@ -385,6 +610,64 @@ const DEFAULT_ENABLED_AGENTS = [
   'ask', 'chat', 'correct', 'draw', 'ocr',
   'paper2slide', 'paper2poster', 'polish', 'research', 'search'
 ];
+
+const DEFAULT_ROUTING = {
+  mode: 'direct',
+  openRouterMode: 'exclusive',
+};
+
+// Provider metadata (for display)
+const PROVIDERS = {
+  anthropic: {
+    name: 'Anthropic',
+    keyUrl: 'https://console.anthropic.com/settings/keys',
+    envVar: 'ANTHROPIC_API_KEY',
+    defaultEndpoint: 'https://api.anthropic.com',
+  },
+  openai: {
+    name: 'OpenAI',
+    keyUrl: 'https://platform.openai.com/api-keys',
+    envVar: 'OPENAI_API_KEY',
+    defaultEndpoint: 'https://api.openai.com/v1',
+  },
+  google: {
+    name: 'Google',
+    keyUrl: 'https://aistudio.google.com/apikey',
+    envVar: 'GOOGLE_API_KEY',
+    defaultEndpoint: 'https://generativelanguage.googleapis.com',
+  },
+  openRouter: {
+    name: 'OpenRouter',
+    keyUrl: 'https://openrouter.ai/keys',
+    envVar: 'OPENROUTER_API_KEY',
+    defaultEndpoint: 'https://openrouter.ai/api/v1',
+    description: 'Access 200+ models with a single API key',
+  },
+  deepseek: {
+    name: 'DeepSeek',
+    keyUrl: 'https://platform.deepseek.com/api_keys',
+    envVar: 'DEEPSEEK_API_KEY',
+    defaultEndpoint: 'https://api.deepseek.com',
+  },
+  xai: {
+    name: 'xAI (Grok)',
+    keyUrl: 'https://console.x.ai',
+    envVar: 'XAI_API_KEY',
+    defaultEndpoint: 'https://api.x.ai/v1',
+  },
+  moonshot: {
+    name: 'Moonshot (Kimi)',
+    keyUrl: 'https://platform.moonshot.cn/console/api-keys',
+    envVar: 'MOONSHOT_API_KEY',
+    defaultEndpoint: 'https://api.moonshot.cn/v1',
+  },
+  dashscope: {
+    name: 'DashScope (Qwen)',
+    keyUrl: 'https://dashscope.console.aliyun.com/apiKey',
+    envVar: 'DASHSCOPE_API_KEY',
+    defaultEndpoint: 'https://dashscope-intl.aliyuncs.com/compatible-mode/v1',
+  },
+};
 ```
 
 ---

--- a/docs/prd/settings-view-unified.md
+++ b/docs/prd/settings-view-unified.md
@@ -54,7 +54,7 @@ Clicking ⚙️ (codicon: `settings-gear`) opens the unified Settings View.
 ┌─────────────────────────────────────────────────────────────────┐
 │  TeXRA Settings                                          [×]   │
 ├─────────────────────────────────────────────────────────────────┤
-│  [Models]   Agents    History    Profile                        │
+│  [Models]   Agents    Memory    History    Profile              │
 │  ═══════                                                        │
 ├─────────────────────────────────────────────────────────────────┤
 │                                                                 │
@@ -69,6 +69,7 @@ Clicking ⚙️ (codicon: `settings-gear`) opens the unified Settings View.
 <vscode-tabs id="settingsTabs" selected-index="0">
   <vscode-tab-header slot="header">Models</vscode-tab-header>
   <vscode-tab-header slot="header">Agents</vscode-tab-header>
+  <vscode-tab-header slot="header">Memory</vscode-tab-header>
   <vscode-tab-header slot="header">History</vscode-tab-header>
   <vscode-tab-header slot="header">Profile</vscode-tab-header>
 
@@ -77,6 +78,9 @@ Clicking ⚙️ (codicon: `settings-gear`) opens the unified Settings View.
   </vscode-tab-panel>
   <vscode-tab-panel id="agentsPanel">
     <!-- Agents tab content -->
+  </vscode-tab-panel>
+  <vscode-tab-panel id="memoryPanel">
+    <!-- Memory tab content -->
   </vscode-tab-panel>
   <vscode-tab-panel id="historyPanel">
     <!-- History tab content -->
@@ -228,6 +232,86 @@ const RECOMMENDED_MODELS = [
 3. **Remote Agents** - Shared team agents (requires auth)
 
 **Storage:** `workspaceState.enabledAgents: string[]`
+
+---
+
+### Memory Tab
+
+**Purpose:** Manage persistent agent memory and conversation settings.
+
+**Layout:**
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  Persistent memory storage for tool-use agents.                 │
+│                                                                 │
+│  CONVERSATION PERSISTENCE                                      │
+│  ─────────────────────────────────────────────────────────────  │
+│  ☑ Persist conversations across VS Code restarts               │
+│    Sessions are saved and can be resumed later.                │
+│                                                                 │
+│  Session retention: [72 hours ▼]                               │
+│    Options: 24h, 48h, 72h, 1 week, 2 weeks                     │
+│                                                                 │
+│  ─────────────────────────────────────────────────────────────  │
+│                                                                 │
+│  MEMORY FILES                                     [Refresh]    │
+│  ─────────────────────────────────────────────────────────────  │
+│  Agent-created memory files stored in /memories                 │
+│                                                                 │
+│  ┌───────────────────────────────────────────────────────────┐  │
+│  │ 📄 project-notes.md           12 KB    Jan 11, 2:34 PM    │  │
+│  │    Project context and key decisions...                   │  │
+│  │                                         [View] [Delete]   │  │
+│  └───────────────────────────────────────────────────────────┘  │
+│                                                                 │
+│  ┌───────────────────────────────────────────────────────────┐  │
+│  │ 📄 research-findings.md       8 KB     Jan 10, 4:12 PM    │  │
+│  │    Literature review notes and citations...               │  │
+│  │                                         [View] [Delete]   │  │
+│  └───────────────────────────────────────────────────────────┘  │
+│                                                                 │
+│  ┌───────────────────────────────────────────────────────────┐  │
+│  │ 📁 figures/                   3 files  Jan 9, 11:00 AM    │  │
+│  │                                         [Browse]          │  │
+│  └───────────────────────────────────────────────────────────┘  │
+│                                                                 │
+│  Total: 5 files, 24 KB                        [Clear All]      │
+│                                                                 │
+│  ─────────────────────────────────────────────────────────────  │
+│                                                                 │
+│  ACTIVE SESSIONS                                               │
+│  ─────────────────────────────────────────────────────────────  │
+│  Tool-use sessions waiting for continuation.                    │
+│                                                                 │
+│  ┌───────────────────────────────────────────────────────────┐  │
+│  │ research (chat)               Jan 11, 1:15 PM   WAITING   │  │
+│  │ "Help me analyze the survey results..."                   │  │
+│  │                                      [Resume] [Discard]   │  │
+│  └───────────────────────────────────────────────────────────┘  │
+│                                                                 │
+│  ┌───────────────────────────────────────────────────────────┐  │
+│  │ paper-writing (chat)          Jan 10, 3:00 PM   WAITING   │  │
+│  │ "Continue editing section 3..."                           │  │
+│  │                                      [Resume] [Discard]   │  │
+│  └───────────────────────────────────────────────────────────┘  │
+│                                                                 │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+**Features:** (Migrated from memoryView)
+- Conversation persistence toggle and TTL setting
+- Memory file browser (from existing memoryView)
+- File preview, delete actions
+- Directory browsing (2-level deep)
+- Active session list with resume/discard
+- Storage usage display
+
+**Data Sources:**
+- Memory files: `/memories` directory managed by MemoryTool
+- Active sessions: Tool-use session snapshots
+- Settings: `texra.toolUse.persistence.*`
+
+**Storage:** `workspaceState` for persistence settings
 
 ---
 
@@ -674,39 +758,111 @@ const PROVIDERS = {
 
 ## Migration Plan
 
-### From VS Code Config to State
+### Critical: API Keys Storage - NO CHANGE
 
-| Old (settings.json) | New (Extension State) |
-|---------------------|----------------------|
-| `texra.models` | `globalState.enabledModels` |
-| `texra.agents` | `workspaceState.enabledAgents` |
-| `texra.toolUseAgents` | `workspaceState.enabledAgents` |
-
-### Migration Logic
+**API keys remain in VS Code SecretStorage.** This is non-negotiable:
 
 ```typescript
-async function migrateSettings(context: vscode.ExtensionContext) {
+// UNCHANGED - Keys stay in VS Code Secrets
+context.secrets.get('apiKey.anthropic');
+context.secrets.store('apiKey.anthropic', 'sk-...');
+
+// Environment variable fallback also unchanged
+process.env.ANTHROPIC_API_KEY
+```
+
+Users who have configured API keys will continue to work without any action.
+
+---
+
+### What Moves to Extension State
+
+| Setting | From | To | Reason |
+|---------|------|-----|--------|
+| `texra.models` | VS Code config | `globalState.enabledModels` | UI in Models tab |
+| `texra.agents` | VS Code config | `workspaceState.enabledAgents` | UI in Agents tab |
+| `texra.toolUseAgents` | VS Code config | `workspaceState.enabledAgents` | Merge with agents |
+| `texra.model.useOpenRouter` | VS Code config | `globalState.routing.mode` | UI in Profile tab |
+| `texra.model.useImprovedConnection` | VS Code config | `globalState.routing.mode` | UI in Profile tab |
+| `texra.model.improvedConnectionDomain` | VS Code config | `globalState.routing.proxyDomain` | UI in Profile tab |
+| `texra.toolUse.persistence.enabled` | VS Code config | `workspaceState.memorySettings` | UI in Memory tab |
+| `texra.toolUse.persistence.ttlHours` | VS Code config | `workspaceState.memorySettings` | UI in Memory tab |
+
+### What Stays in VS Code Config
+
+These remain in VS Code settings (advanced, rarely changed, or system paths):
+
+- `texra.model.useStreaming*` - Provider-specific streaming toggles
+- `texra.model.compactionThresholdPercent` - Advanced context management
+- `texra.model.baseUrlDeepSeek` - Custom endpoint (moved to globalState.providerConfig)
+- `texra.latex.*` - LaTeX formatter settings
+- `texra.files.*` - File handling patterns
+- `texra.latexdiff.*` - Diff settings
+- `texra.logger.*`, `texra.debug.*` - Development settings
+- `texra.audio.soxPath`, `texra.explorer.agentsDirectory` - System paths
+
+### Graceful Migration Strategy
+
+**Principle:** Read from new state first, fallback to VS Code config, never break existing setups.
+
+```typescript
+/**
+ * Get enabled models with graceful migration.
+ * Priority: globalState > VS Code config > defaults
+ */
+function getEnabledModels(context: vscode.ExtensionContext): string[] {
+  // 1. Check new storage first
+  const fromState = context.globalState.get<string[]>('enabledModels');
+  if (fromState !== undefined) {
+    return fromState;
+  }
+
+  // 2. Fallback to VS Code config (existing users)
   const config = vscode.workspace.getConfiguration('texra');
-
-  // Migrate models (one-time)
-  if (!context.globalState.get('enabledModels')) {
-    const oldModels = config.get<string[]>('models');
-    if (oldModels?.length) {
-      await context.globalState.update('enabledModels', oldModels);
-    }
+  const fromConfig = config.get<string[]>('models');
+  if (fromConfig?.length) {
+    // Auto-migrate on first read
+    context.globalState.update('enabledModels', fromConfig);
+    return fromConfig;
   }
 
-  // Migrate agents (one-time per workspace)
-  if (!context.workspaceState.get('enabledAgents')) {
-    const oldAgents = config.get<string[]>('agents') ?? [];
-    const oldToolUse = config.get<string[]>('toolUseAgents') ?? [];
-    const combined = [...new Set([...oldAgents, ...oldToolUse])];
-    if (combined.length) {
-      await context.workspaceState.update('enabledAgents', combined);
-    }
+  // 3. Return defaults
+  return DEFAULT_ENABLED_MODELS;
+}
+
+/**
+ * Get routing configuration with migration.
+ */
+function getRoutingConfig(context: vscode.ExtensionContext): RoutingConfig {
+  const fromState = context.globalState.get<RoutingConfig>('routing');
+  if (fromState !== undefined) {
+    return fromState;
   }
+
+  // Migrate from scattered VS Code settings
+  const config = vscode.workspace.getConfiguration('texra.model');
+  const useOpenRouter = config.get<boolean>('useOpenRouter', false);
+  const useProxy = config.get<boolean>('useImprovedConnection', false);
+  const proxyDomain = config.get<string>('improvedConnectionDomain');
+
+  const migrated: RoutingConfig = {
+    mode: useOpenRouter ? 'openrouter' : useProxy ? 'proxy' : 'direct',
+    openRouterMode: 'exclusive',
+    proxyDomain,
+  };
+
+  // Auto-migrate
+  context.globalState.update('routing', migrated);
+  return migrated;
 }
 ```
+
+### Migration Timing
+
+1. **On extension activate:** Check and migrate settings lazily (on first read)
+2. **No forced migration:** Users can continue using VS Code config until they open Settings View
+3. **Settings View writes:** Once user saves in Settings View, new storage is used
+4. **VS Code config becomes secondary:** Still works for users who prefer it
 
 ---
 
@@ -729,16 +885,19 @@ src/
 │       ├── tabs/
 │       │   ├── ModelsTab.js         # Models tab logic
 │       │   ├── AgentsTab.js         # Agents tab logic
+│       │   ├── MemoryTab.js         # Memory tab logic (migrated)
 │       │   ├── HistoryTab.js        # History tab logic (migrated)
 │       │   └── ProfileTab.js        # Profile tab logic (migrated)
 │       └── uiManagers/
 │           ├── ModelListRenderer.js
 │           ├── AgentListRenderer.js
+│           ├── MemoryRenderer.js    # From memoryView
 │           ├── HistoryRenderer.js   # From historyView
 │           └── ProfileRenderer.js   # From profileView
 │
 ├── profileView/                     # DEPRECATED - merge into settingsView
 ├── historyView/                     # DEPRECATED - merge into settingsView
+├── memoryView/                      # DEPRECATED - merge into settingsView
 ```
 
 ### Commands
@@ -812,29 +971,38 @@ type SettingsAction =
 ## Implementation Phases
 
 ### Phase 1: Core Structure
-- Create settingsView with tab navigation
+- Create settingsView with tab navigation (5 tabs)
 - Implement Models tab with provider accordions
 - Wire up globalState for model preferences
+- Test graceful migration from VS Code config
 
 ### Phase 2: Agents Tab
 - Implement Agents tab with local/custom/remote sections
 - Wire up workspaceState for agent preferences
 - Handle remote agents auth state
 
-### Phase 3: Migrate History
+### Phase 3: Memory Tab
+- Migrate memoryView to Memory tab
+- Add conversation persistence settings UI
+- Add active sessions list with resume/discard
+- Delete old memoryView
+
+### Phase 4: Migrate History
 - Move history rendering to History tab
 - Preserve search, delete, restore, rerun functionality
 - Delete old historyView
 
-### Phase 4: Migrate Profile
+### Phase 5: Migrate Profile
 - Move profile/auth to Profile tab
-- Preserve API key management
+- Implement provider configuration cards
+- Implement provider modal (API key + endpoint)
+- Add routing options UI
 - Delete old profileView
 
-### Phase 5: Polish
+### Phase 6: Polish
 - Add main webview entry point (gear icon)
 - Deep link support (open to specific tab)
-- Migration from old VS Code config
+- Verify graceful migration (no breaking existing setups)
 - Documentation
 
 ---

--- a/docs/prd/settings-view-unified.md
+++ b/docs/prd/settings-view-unified.md
@@ -204,15 +204,23 @@ const RECOMMENDED_MODELS = [
 
 **Scope (Phase 1):** View-only with enable/disable. Agent creation wizard deferred to Future Scope.
 
-**Agent Categories:**
-- `workflow` - Document-processing agents (input → output transformations)
-- `toolUse` - Interactive agents with tool capabilities (chat, research)
+**Agent Metadata Displayed:**
+| Field | Source | Display |
+|-------|--------|---------|
+| Name | YAML `name` | Text |
+| Description | YAML `description` | Text (truncated) |
+| Category | `agentCategory` | Badge: `[workflow]` or `[toolUse]` |
+| Type | `settings.agentType` | Label: `CoT`, `Direct`, `Merge`, `Reflect` |
+| Rounds | `settings.rounds` | Label: `×2`, `×3` (if > 1) |
+| Inherits | `inherits` | Codicon: `$(extensions)` + parent name |
+| Source | File location | `Built-in`, `Custom`, `Remote` |
 
-**Agent Sources:**
-- `builtIn` - Shipped with extension (workflow agents)
-- `builtInToolUse` - Shipped with extension (tool-use agents)
-- `custom` - User-created YAML files in workspace
-- `remote` - Shared agents from team (requires login)
+**Agent Type Icons (codicons):**
+- `$(lightbulb)` CoT (Chain-of-Thought)
+- `$(zap)` Direct
+- `$(git-merge)` Merge
+- `$(sync)` Reflect
+- `$(tools)` Tool-Use
 
 **Layout:**
 ```
@@ -223,30 +231,39 @@ const RECOMMENDED_MODELS = [
 │  BUILT-IN AGENTS                                               │
 │  ─────────────────────────────────────────────────────────────  │
 │  ┌───────────────────────────────────────────────────────────┐  │
-│  │ ☑ chat        Interactive conversation         [toolUse] │  │
-│  │ ☑ correct     Fix typos & LaTeX errors        [workflow] │  │
-│  │ ☑ polish      Improve writing quality         [workflow] │  │
-│  │ ☑ research    Research with tools             [toolUse]  │  │
-│  │ ☐ draw        Create TikZ figures             [workflow] │  │
-│  │ ☐ ocr         Handwritten → LaTeX             [workflow] │  │
-│  │ ☐ paper2slide Paper → Beamer slides           [workflow] │  │
-│  │ ☐ paper2poster Paper → poster                 [workflow] │  │
-│  │ ☐ transcribe  Audio transcription             [workflow] │  │
+│  │ ☑ chat      Interactive conversation                      │  │
+│  │             $(tools) toolUse                              │  │
+│  │                                                           │  │
+│  │ ☑ correct   Fix typos & LaTeX errors                      │  │
+│  │             $(lightbulb) CoT  ×2  $(extensions) polish    │  │
+│  │                                                           │  │
+│  │ ☑ polish    Improve writing quality                       │  │
+│  │             $(lightbulb) CoT  ×2                          │  │
+│  │                                                           │  │
+│  │ ☑ research  Research with tools                           │  │
+│  │             $(tools) toolUse                              │  │
+│  │                                                           │  │
+│  │ ☐ draw      Create TikZ figures                           │  │
+│  │             $(zap) Direct                                 │  │
+│  │   ...                                                     │  │
 │  └───────────────────────────────────────────────────────────┘  │
 │                                                                 │
 │  CUSTOM AGENTS                                                 │
 │  ─────────────────────────────────────────────────────────────  │
 │  ┌───────────────────────────────────────────────────────────┐  │
-│  │ ☑ my-reviewer Reviews papers for clarity      [workflow] │  │
-│  │                                    [Open YAML] [Delete]  │  │
+│  │ ☑ my-reviewer   Reviews papers for clarity                │  │
+│  │                 $(lightbulb) CoT  $(extensions) correct   │  │
+│  │                              [Source Code] [Delete]       │  │
 │  └───────────────────────────────────────────────────────────┘  │
 │  📁 Custom agents are stored in: .texra/agents/                 │
 │                                                                 │
 │  REMOTE AGENTS                                                 │
 │  ─────────────────────────────────────────────────────────────  │
 │  ┌───────────────────────────────────────────────────────────┐  │
-│  │ ☑ team-reviewer   Team's paper reviewer       [workflow] │  │
-│  │ ☐ grant-writer    Grant proposal helper       [toolUse]  │  │
+│  │ ☑ team-reviewer   Team's paper reviewer                   │  │
+│  │                   $(lightbulb) CoT  ×3                    │  │
+│  │ ☐ grant-writer    Grant proposal helper                   │  │
+│  │                   $(tools) toolUse                        │  │
 │  └───────────────────────────────────────────────────────────┘  │
 │                        ─ or if not logged in ─                  │
 │  ┌───────────────────────────────────────────────────────────┐  │
@@ -256,16 +273,11 @@ const RECOMMENDED_MODELS = [
 └─────────────────────────────────────────────────────────────────┘
 ```
 
-**Category Badges:** Use `<vscode-badge>` for workflow/toolUse labels.
-
 **Custom Agent Actions:**
-- `[Open YAML]` - Opens agent YAML file in editor (for power users)
+- `[Source Code]` - Opens agent YAML file in editor
 - `[Delete]` - Deletes custom agent YAML file
 
-**Note:** Agent creation wizard and form-based editing are deferred to Future Scope. For now, users create agents by:
-1. Duplicating an existing YAML file in `.texra/agents/`
-2. Editing the YAML directly
-3. The agent appears automatically in the list
+**Note:** Agent creation wizard and form-based editing are deferred to Future Scope. For now, users create agents by duplicating an existing YAML file in `.texra/agents/` and editing it directly.
 
 **Storage:** `workspaceState.enabledAgents: string[]`
 
@@ -379,8 +391,11 @@ const RECOMMENDED_MODELS = [
 ┌─────────────────────────────────────────────────────────────────┐
 │  Persistent memory storage for tool-use agents.                 │
 │                                                                 │
-│  CONVERSATION PERSISTENCE                                      │
+│  TOOL-USE SETTINGS                                             │
 │  ─────────────────────────────────────────────────────────────  │
+│  ☑ Require approval before file edits                          │
+│    Show diff preview and require confirmation for tool edits.  │
+│                                                                 │
 │  ☑ Persist conversations across VS Code restarts               │
 │    Sessions are saved and can be resumed later.                │
 │                                                                 │
@@ -444,7 +459,7 @@ const RECOMMENDED_MODELS = [
 **Data Sources:**
 - Memory files: `/memories` directory managed by MemoryTool
 - Active sessions: Tool-use session snapshots
-- Settings: `texra.toolUse.persistence.*`
+- Settings: `texra.toolUse.requireEditApproval`, `texra.toolUse.persistence.*`
 
 **Storage:** `workspaceState` for persistence settings
 
@@ -1174,7 +1189,35 @@ interface AgentInfo {
 ### Future Scope (Deferred)
 - **Agent Creation Wizard** - AI-assisted agent creation from plain English description
 - **Agent Edit Form** - Form-based editing without YAML knowledge
-- **Agent Testing** - Test agent with sample input before saving
+
+---
+
+## Uncovered Settings (Remain in VS Code Config)
+
+Based on 79 total settings in package.json, these remain as advanced VS Code settings:
+
+### Could Be Added Later (17 settings)
+| Setting | Suggested Tab | Priority |
+|---------|--------------|----------|
+| `texra.model.useStreaming*` (9) | Models → Advanced | Medium |
+| `texra.toolUse.requireEditApproval` | Memory | High |
+| `texra.merge.defaultModel` | Models or Agents | Low |
+| `texra.model.compactionThresholdPercent` | Models → Advanced | Low |
+| `texra.model.baseUrlDeepSeek` | Profile → Providers | Low |
+| `texra.maxImageDimension` | LaTeX or new Files tab | Low |
+| `texra.progressBoard.streamSortOrder` | New UI Preferences tab | Low |
+| `texra.model.retry.*` (2) | Models → Advanced | Low |
+
+### Should Remain as VS Code Settings (33 settings)
+- `texra.ui.*` (3) - UI behavior flags
+- `texra.files.*` (16) - File type filtering (power user)
+- `texra.logger.*`, `texra.debug.*` (3) - Development only
+- `texra.auth.*` (3) - System-level authentication
+- `texra.remoteAgents.*` (2) - Remote agent behavior
+- `texra.explorer.agentsDirectory` - System path
+- `texra.audio.soxPath` - System path
+- `texra.git.numberOfCommitsToShow` - Niche preference
+- `texra.agentOutputs.storageMode` - Advanced workflow
 
 ---
 

--- a/docs/prd/settings-view-unified.md
+++ b/docs/prd/settings-view-unified.md
@@ -1196,49 +1196,89 @@ commands.registerCommand('texra.openLatexSettings', () =>
   commands.executeCommand('texra.openSettings', 'latex'));
 ```
 
-### Message Protocol
+### Message Protocol (Zod-native)
+
+Use Zod schemas as single source of truth. Reference existing types from the codebase.
 
 ```typescript
-// Extension → Webview
-type SettingsMessage =
-  | { command: 'SET_MODELS_DATA', models: ModelInfo[], enabled: string[] }
-  | { command: 'SET_AGENTS_DATA', agents: AgentInfo[], enabled: string[] }
-  | { command: 'SET_LATEX_DATA', settings: LatexSettings }
-  | { command: 'SET_HISTORY_DATA', items: HistoryItem[] }
-  | { command: 'SET_MEMORY_DATA', files: MemoryFileInfo[] }
-  | { command: 'SET_PROFILE_DATA', profile: ProfileInfo | null }
-  | { command: 'SELECT_TAB', tab: SettingsTab };
+import { z } from 'zod';
+import { ModelConfigSchema } from '@model/ModelConfig';           // From llm-zoo
+import { AgentSource } from '@agent/core/AgentDataclass';         // Zod enum
+import type { AgentEntry } from '@agent/index/agentRegistry';     // Existing interface
 
-// Webview → Extension
-type SettingsAction =
-  | { command: 'GET_INITIAL_DATA' }  // Request all tab data on load
-  | { command: 'TAB_CHANGED', tab: SettingsTab }  // Notify extension of tab switch
-  | { command: 'SAVE_ENABLED_MODELS', models: string[] }
-  | { command: 'SAVE_ENABLED_AGENTS', agents: string[] }
-  | { command: 'SAVE_LATEX_SETTING', key: string, value: unknown }
-  | { command: 'SAVE_AGENT_SETTING', key: string, value: unknown }
-  | { command: 'RESTORE_HISTORY', id: string }
-  | { command: 'DELETE_HISTORY', id: string }
-  | { command: 'SIGN_IN' }
-  | { command: 'SIGN_OUT' }
-  | { command: 'SET_API_KEY', provider: string, key: string }
-  | { command: 'OPEN_MEMORY_FILE', path: string }
-  | { command: 'DELETE_MEMORY_FILE', path: string };
+// =============================================================================
+// Shared Schemas
+// =============================================================================
 
-type SettingsTab = 'models' | 'agents' | 'latex' | 'memory' | 'history';
+export const SettingsTabSchema = z.enum(['models', 'agents', 'latex', 'memory', 'history']);
+export type SettingsTab = z.infer<typeof SettingsTabSchema>;
 
-// Agent info (mirrors AgentEntry from agentRegistry.ts)
-interface AgentInfo {
-  name: string;
-  description: string;
-  category: 'workflow' | 'toolUse';  // Derived from source/agentType (see Agent Category Derivation)
-  agentType: 'cot' | 'direct' | 'merge' | 'reflect' | 'toolUse';  // From YAML: settings.agentType
-  rounds?: number;  // From YAML: settings.rounds (if > 1)
-  inherits?: string;  // From YAML: inherits field
-  source: 'builtIn' | 'custom' | 'remote';
-  enabled: boolean;
-}
+// =============================================================================
+// Extension → Webview Messages
+// =============================================================================
+
+export const SetModelsDataSchema = z.object({
+  command: z.literal('SET_MODELS_DATA'),
+  models: z.array(ModelConfigSchema),  // Use llm-zoo schema directly
+  enabled: z.array(z.string()),
+});
+
+export const SetAgentsDataSchema = z.object({
+  command: z.literal('SET_AGENTS_DATA'),
+  agents: z.array(z.object({           // Mirrors AgentEntry + enabled flag
+    name: z.string(),
+    source: AgentSource,
+    category: z.enum(['workflow', 'toolUse']),
+    agentType: z.enum(['CoT', 'direct', 'toolUse']),
+    description: z.string().optional(),
+    enabled: z.boolean(),
+  })),
+});
+
+export const SetLatexDataSchema = z.object({
+  command: z.literal('SET_LATEX_DATA'),
+  settings: z.record(z.unknown()),     // VS Code config snapshot
+});
+
+export const SelectTabSchema = z.object({
+  command: z.literal('SELECT_TAB'),
+  tab: SettingsTabSchema,
+});
+
+export const SettingsMessageSchema = z.discriminatedUnion('command', [
+  SetModelsDataSchema,
+  SetAgentsDataSchema,
+  SetLatexDataSchema,
+  SelectTabSchema,
+  // History, Memory, Profile use existing view schemas
+]);
+
+export type SettingsMessage = z.infer<typeof SettingsMessageSchema>;
+
+// =============================================================================
+// Webview → Extension Actions
+// =============================================================================
+
+export const SettingsActionSchema = z.discriminatedUnion('command', [
+  z.object({ command: z.literal('GET_INITIAL_DATA') }),
+  z.object({ command: z.literal('TAB_CHANGED'), tab: SettingsTabSchema }),
+  z.object({ command: z.literal('SAVE_ENABLED_MODELS'), models: z.array(z.string()) }),
+  z.object({ command: z.literal('SAVE_ENABLED_AGENTS'), agents: z.array(z.string()) }),
+  z.object({ command: z.literal('SAVE_SETTING'), key: z.string(), value: z.unknown() }),
+  z.object({ command: z.literal('SET_API_KEY'), provider: z.string(), key: z.string() }),
+  z.object({ command: z.literal('SIGN_IN') }),
+  z.object({ command: z.literal('SIGN_OUT') }),
+  // History/Memory actions reuse existing schemas
+]);
+
+export type SettingsAction = z.infer<typeof SettingsActionSchema>;
 ```
+
+**Key points:**
+- `ModelConfigSchema` from `@model/ModelConfig` (mirrors llm-zoo types)
+- `AgentSource` Zod enum from `@agent/core/AgentDataclass`
+- `AgentEntry` interface from `@agent/index/agentRegistry` (no duplication)
+- Use `z.discriminatedUnion` for type-safe message handling
 
 ### Agent Category Derivation
 

--- a/docs/prd/settings-view-unified.md
+++ b/docs/prd/settings-view-unified.md
@@ -16,12 +16,12 @@ Create a unified Settings View that consolidates model configuration, agent conf
 ## Goals
 
 1. **Single source of truth** - All configuration in one place
-2. **Easy navigation** - Tab-based switching between Models, Agents, Tool-Use, LaTeX, Memory, History, Profile, UI, Misc
-3. **No auth required** - Most tabs work without login (except Profile features)
-4. **VS Code native** - Use `vscode-tabs`, `vscode-tab-header`, `vscode-tab-panel` components
+2. **Easy navigation** - Sidebar navigation (Cursor-style) with logical groupings
+3. **No auth required** - Most sections work without login (except account features)
+4. **VS Code native** - Use VS Code elements and styling patterns
 5. **Proper state management** - Global vs workspace state separation
 6. **Backwards compatible** - Extend getConfig rather than replacing it; graceful migration
-7. **Notion-style minimalism** - Clean, uncluttered interface with generous whitespace
+7. **Cursor-style clarity** - Clean sidebar + content layout, searchable settings
 
 ---
 
@@ -73,138 +73,245 @@ Single entry point from main webview:
 
 Clicking ⚙️ (codicon: `settings-gear`) opens the unified Settings View.
 
-### Tab Structure
+### Sidebar Navigation (Cursor-style)
+
+Instead of horizontal tabs, use a sidebar navigation like Cursor Settings for better organization
+and scalability.
 
 ```
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │  TeXRA Settings                                                       [×]   │
-├──────────────────────────────────────────────────────────────────────────────┤
-│  [Models]  Agents  Tool-Use  LaTeX  Memory  History  Profile  UI  Misc      │
-│  ═══════                                                                     │
-├──────────────────────────────────────────────────────────────────────────────┤
-│                                                                              │
-│                              Tab content here                                │
-│                                                                              │
-└──────────────────────────────────────────────────────────────────────────────┘
+├────────────────────────┬─────────────────────────────────────────────────────┤
+│                        │                                                     │
+│  user@example.com      │  General                                            │
+│  Pro Plan              │  ─────────────────────────────────────────────────  │
+│                        │                                                     │
+│  ┌──────────────────┐  │  Manage Account                                     │
+│  │ Search ⌘F        │  │  Manage your account and billing            [Open]  │
+│  └──────────────────┘  │                                                     │
+│                        │  ─────────────────────────────────────────────────  │
+│  ⚙️ General            │                                                     │
+│  ∞ Agents              │  Preferences                                        │
+│    → Workflow          │  ─────────────────────────────────────────────────  │
+│    → Tool-Use          │                                                     │
+│  ◎ Models & Providers  │  ☑ Show quick pick for agent selection             │
+│  ⚡ Multi-Agent        │    Use VS Code quick pick instead of dropdown.      │
+│                        │                                                     │
+│  ─────────────────     │  ☑ Show quick pick for model selection             │
+│  📄 LaTeX              │    Use VS Code quick pick instead of dropdown.      │
+│  🧠 Memory             │                                                     │
+│  📜 History            │  Max image dimension: [2048 ▼]                      │
+│                        │    Options: 1024, 2048, 4096                        │
+│  ─────────────────     │                                                     │
+│  🔧 Advanced           │  Progress board sort: [Timestamp descending ▼]      │
+│                        │                                                     │
+│  ─────────────────     │                                                     │
+│  📖 Docs ↗             │                                                     │
+│                        │                                                     │
+└────────────────────────┴─────────────────────────────────────────────────────┘
 ```
 
-**Tab Purposes:**
-- **Models** - Model selection, provider status
-- **Agents** - Agent enable/disable, view metadata, remote agents
-- **Tool-Use** - Tool execution settings (edit approval, permissions)
-- **LaTeX** - Formatter, latexdiff, TikZ, replacements
-- **Memory** - Persistent memory files, active sessions
-- **History** - Execution history browser
-- **Profile** - Account, API keys, streaming settings, routing
-- **UI** - UI behavior settings
-- **Misc** - Miscellaneous settings
+**Navigation Structure:**
+```
+Account (top)
+  └── Email, Plan info
 
-### HTML Structure (using vscode-elements)
+Search settings ⌘F
+
+Section 1: Core
+├── General          - Account, UI preferences
+├── Agents           - Agent list and settings
+│   ├── Workflow     - Workflow agent output settings
+│   └── Tool-Use     - Tool-use agent settings (edit approval, compaction)
+├── Models & Providers - Combined model selection + API providers
+└── Multi-Agent      - Merge operations settings (future features noted)
+
+Section 2: Features
+├── LaTeX            - Formatter, latexdiff, TikZ
+├── Memory           - Memory files browser (expandable)
+└── History          - Execution history
+
+Section 3: System
+└── Advanced         - System paths, debug, retry settings
+
+Footer
+└── Docs ↗           - Link to documentation
+```
+
+### HTML Structure (sidebar layout)
 
 ```html
-<vscode-tabs id="settingsTabs" selected-index="0">
-  <vscode-tab-header slot="header">Models</vscode-tab-header>
-  <vscode-tab-header slot="header">Agents</vscode-tab-header>
-  <vscode-tab-header slot="header">Tool-Use</vscode-tab-header>
-  <vscode-tab-header slot="header">LaTeX</vscode-tab-header>
-  <vscode-tab-header slot="header">Memory</vscode-tab-header>
-  <vscode-tab-header slot="header">History</vscode-tab-header>
-  <vscode-tab-header slot="header">Profile</vscode-tab-header>
-  <vscode-tab-header slot="header">UI</vscode-tab-header>
-  <vscode-tab-header slot="header">Misc</vscode-tab-header>
+<div class="settings-container">
+  <aside class="settings-sidebar">
+    <div class="account-section">
+      <span class="user-email">user@example.com</span>
+      <span class="user-plan">Pro Plan</span>
+    </div>
 
-  <vscode-tab-panel id="modelsPanel"><!-- Models --></vscode-tab-panel>
-  <vscode-tab-panel id="agentsPanel"><!-- Agents --></vscode-tab-panel>
-  <vscode-tab-panel id="toolUsePanel"><!-- Tool-Use --></vscode-tab-panel>
-  <vscode-tab-panel id="latexPanel"><!-- LaTeX --></vscode-tab-panel>
-  <vscode-tab-panel id="memoryPanel"><!-- Memory --></vscode-tab-panel>
-  <vscode-tab-panel id="historyPanel"><!-- History --></vscode-tab-panel>
-  <vscode-tab-panel id="profilePanel"><!-- Profile --></vscode-tab-panel>
-  <vscode-tab-panel id="uiPanel"><!-- UI --></vscode-tab-panel>
-  <vscode-tab-panel id="miscPanel"><!-- Misc --></vscode-tab-panel>
-</vscode-tabs>
+    <vscode-textfield placeholder="Search settings ⌘F" class="search-input">
+    </vscode-textfield>
+
+    <nav class="settings-nav">
+      <div class="nav-section">
+        <a href="#general" class="nav-item active">$(settings-gear) General</a>
+        <a href="#agents" class="nav-item">$(symbol-misc) Agents</a>
+        <a href="#agents-workflow" class="nav-item nav-subitem">→ Workflow</a>
+        <a href="#agents-tooluse" class="nav-item nav-subitem">→ Tool-Use</a>
+        <a href="#models" class="nav-item">$(server) Models & Providers</a>
+        <a href="#multiagent" class="nav-item">$(combine) Multi-Agent</a>
+      </div>
+
+      <div class="nav-section">
+        <a href="#latex" class="nav-item">$(file-code) LaTeX</a>
+        <a href="#memory" class="nav-item">$(database) Memory</a>
+        <a href="#history" class="nav-item">$(history) History</a>
+      </div>
+
+      <div class="nav-section">
+        <a href="#advanced" class="nav-item">$(tools) Advanced</a>
+      </div>
+
+      <div class="nav-section nav-footer">
+        <a href="https://docs.texra.ai" class="nav-item">$(book) Docs ↗</a>
+      </div>
+    </nav>
+  </aside>
+
+  <main class="settings-content">
+    <!-- Content for selected section -->
+  </main>
+</div>
 ```
 
 ---
 
-## Tab Specifications
+## Section Specifications
 
-### Models Tab
+### General Section
 
-**Purpose:** Configure which models appear in the model dropdown.
+**Purpose:** Account management and general UI preferences. Shown when user clicks "General" in sidebar.
 
 **Layout:**
 ```
 ┌─────────────────────────────────────────────────────────────────┐
-│  Configure which models appear in the model dropdown.           │
+│  General                                                        │
+│  ─────────────────────────────────────────────────────────────  │
 │                                                                 │
-│  ⭐ RECOMMENDED                                                 │
+│  Manage Account                                                 │
+│  Manage your account and billing                     [Open ↗]  │
+│                                                                 │
+│  ─────────────────────────────────────────────────────────────  │
+│                                                                 │
+│  Preferences                                                    │
+│  ─────────────────────────────────────────────────────────────  │
+│                                                                 │
+│  ☑ Show quick pick for agent selection                          │
+│    Use VS Code quick pick instead of dropdown for agents.      │
+│                                                                 │
+│  ☑ Show quick pick for model selection                          │
+│    Use VS Code quick pick instead of dropdown for models.      │
+│                                                                 │
+│  Max image dimension: [2048 ▼]                                 │
+│    Larger images will be resized before sending to models.     │
+│    Options: 1024, 2048, 4096                                   │
+│                                                                 │
+│  Progress board sort: [Timestamp descending ▼]                 │
+│    Options: Timestamp ascending, Timestamp descending          │
+│                                                                 │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+**Settings Mapping:**
+| UI Element | VS Code Setting |
+|------------|-----------------|
+| Agent quick pick checkbox | `texra.ui.showAgentQuickPick` |
+| Model quick pick checkbox | `texra.ui.showModelQuickPick` |
+| Max image dimension dropdown | `texra.maxImageDimension` |
+| Progress board sort dropdown | `texra.progressBoard.streamSortOrder` |
+
+---
+
+### Models & Providers Section
+
+**Purpose:** Combined model selection and API provider configuration. Each provider shows API status + model selection together.
+
+**Layout:**
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  Models & Providers                                             │
+│  ─────────────────────────────────────────────────────────────  │
+│                                                                 │
+│  ROUTING                                                        │
+│  ─────────────────────────────────────────────────────────────  │
+│  ● Direct to providers (recommended)                            │
+│  ○ Route all through OpenRouter                                 │
+│  ○ Use connection proxy                                         │
+│                                                                 │
+│  ⭐ RECOMMENDED MODELS                                          │
 │  ┌───────────────────────────────────────────────────────────┐  │
 │  │ ☑ Claude Sonnet 4.5 T    Anthropic   $3/$15    200K  🧠👁 │  │
-│  │ ☑ Claude Opus 4.5 T      Anthropic   $15/$75   200K  🧠👁 │  │
 │  │ ☑ GPT-5.2                OpenAI      $2/$10    256K  🧠👁 │  │
 │  │ ☑ Gemini 3 Pro           Google      $1.25/$5  1M    🧠👁 │  │
-│  │ ☑ Grok 4                 xAI         $3/$15    256K  🧠👁 │  │
 │  │ ☑ DeepSeek R1            DeepSeek    $0.55/$2  64K   🧠   │  │
 │  └───────────────────────────────────────────────────────────┘  │
 │                                                                 │
-│  ALL MODELS                                                     │
+│  PROVIDERS                                                      │
 │  ─────────────────────────────────────────────────────────────  │
 │                                                                 │
-│  ▼ Anthropic (21)                                 [Enable All] │
+│  ▼ Anthropic                         ✓ API Key    [Configure]  │
 │  ┌───────────────────────────────────────────────────────────┐  │
-│  │ ☑ Claude Sonnet 4.5 Thinking   200K   $3/$15    🧠👁📄    │  │
-│  │ ☑ Claude Opus 4.5 Thinking     200K   $15/$75   🧠👁📄🎧  │  │
-│  │ ☐ Claude Sonnet 4.5            200K   $3/$15    👁📄      │  │
-│  │ ☐ Claude Sonnet 4.0            200K   $3/$15    👁📄      │  │
-│  │ ☐ Claude Haiku 3.5             200K   $0.8/$4   👁        │  │
-│  │   ... more                                                │  │
+│  │ ☑ Claude Sonnet 4.5 T     200K   $3/$15    🧠👁📄         │  │
+│  │ ☑ Claude Opus 4.5 T       200K   $15/$75   🧠👁📄🎧       │  │
+│  │ ☐ Claude Sonnet 4.5       200K   $3/$15    👁📄           │  │
+│  │ ☐ Claude Haiku 3.5        200K   $0.8/$4   👁             │  │
+│  │   ... more (21 models)                      [Enable All]  │  │
 │  └───────────────────────────────────────────────────────────┘  │
 │                                                                 │
-│  ▶ OpenAI (28)                                                 │
-│  ▶ Google (6)                                                  │
-│  ▶ DeepSeek (7)                                                │
-│  ▶ xAI (5)                                                     │
-│  ▶ Moonshot (8)                                                │
-│  ▶ DashScope (3)                                               │
+│  ▶ OpenAI (28)                       ✓ API Key    [Configure]  │
+│  ▶ Google (6)                        ✗ No Key     [Configure]  │
+│  ▶ DeepSeek (7)                      ✓ API Key    [Configure]  │
+│  ▶ xAI (5)                           ✗ No Key     [Configure]  │
+│  ▶ Moonshot (8)                      ✗ No Key     [Configure]  │
+│  ▶ DashScope (3)                     ✗ No Key     [Configure]  │
+│                                                                 │
+│  ▼ OpenRouter                        ✓ API Key    [Configure]  │
+│  ┌───────────────────────────────────────────────────────────┐  │
+│  │ OpenRouter provides access to 200+ models with one key.   │  │
+│  │ Routing: ● OpenRouter-only  ○ Route ALL through OR        │  │
+│  └───────────────────────────────────────────────────────────┘  │
 │                                                                 │
 │  ─────────────────────────────────────────────────────────────  │
-│  Selected: 12 models                              [Save Changes]│
+│  Selected: 12 models                                            │
 └─────────────────────────────────────────────────────────────────┘
 ```
+
+**Key Design:**
+- Each provider accordion shows: status indicator + [Configure] button + model list
+- Provider status: `✓ API Key`, `✗ No Key`, or `🔑 Env Var`
+- Clicking [Configure] opens provider modal (API key + endpoint + streaming toggle)
+- Models are listed under their provider for clear ownership
 
 **Data Source:** `llm-zoo` package (ModelRegistry)
 
 **Model Metadata Displayed:**
 - Name (display name)
-- Provider
-- Cost (input/output per 1M tokens)
 - Context window
+- Cost (input/output per 1M tokens)
 - Capabilities icons: 🧠 Reasoning, 👁 Vision, 📄 PDF, 🎧 Audio, 💬 Tools, ⚡ Cache
-
-**Sorting:**
-- Recommended section: hardcoded curated list
-- Provider sections: newest model families first within each provider
 
 **Recommended Models (hardcoded):**
 ```typescript
 const RECOMMENDED_MODELS = [
-  'sonnet45T',   // Claude Sonnet 4.5 Thinking
-  'opus45T',     // Claude Opus 4.5 Thinking
-  'gpt52',       // GPT-5.2
-  'gemini3p',    // Gemini 3 Pro
-  'grok4',       // Grok 4
-  'deepseekT',   // DeepSeek R1
-  'kimi2T',      // Kimi K2 Thinking
-  'qwen3max',    // Qwen 3 Max
+  'sonnet45T', 'opus45T', 'gpt52', 'gemini3p',
+  'grok4', 'deepseekT', 'kimi2T', 'qwen3max'
 ];
 ```
 
-**Storage:** `globalState.enabledModels: string[]`
+**Storage:** `globalState.enabledModels: string[]`, `globalState.providerConfig`
 
 ---
 
-### Agents Tab
+### Agents Section (Main)
 
 **Purpose:** View and enable/disable agents. Supersedes the FolderExplorer/agent explorer.
 
@@ -231,6 +338,8 @@ const RECOMMENDED_MODELS = [
 **Layout:**
 ```
 ┌─────────────────────────────────────────────────────────────────┐
+│  Agents                                                         │
+│  ─────────────────────────────────────────────────────────────  │
 │  Select which agents appear in the dropdown.                    │
 │  Settings are saved per workspace.                              │
 │                                                                 │
@@ -245,12 +354,6 @@ const RECOMMENDED_MODELS = [
 │  │                                                           │  │
 │  │ ☑ polish    Improve writing quality                       │  │
 │  │             $(lightbulb) CoT  ×2                          │  │
-│  │                                                           │  │
-│  │ ☑ research  Research with tools                           │  │
-│  │             $(tools) toolUse                              │  │
-│  │                                                           │  │
-│  │ ☐ draw      Create TikZ figures                           │  │
-│  │             $(zap) Direct                                 │  │
 │  │   ...                                                     │  │
 │  └───────────────────────────────────────────────────────────┘  │
 │                                                                 │
@@ -265,6 +368,7 @@ const RECOMMENDED_MODELS = [
 │                                                                 │
 │  REMOTE AGENTS                                                 │
 │  ─────────────────────────────────────────────────────────────  │
+│  ☑ Auto-show remote agents if available                        │
 │  ┌───────────────────────────────────────────────────────────┐  │
 │  │ ☑ team-reviewer   Team's paper reviewer                   │  │
 │  │                   $(lightbulb) CoT  ×3                    │  │
@@ -276,6 +380,11 @@ const RECOMMENDED_MODELS = [
 │  │  🔒 Sign in to access shared team agents       [Sign In]  │  │
 │  └───────────────────────────────────────────────────────────┘  │
 │                                                                 │
+│  ▶ Advanced                                                    │
+│  ┌───────────────────────────────────────────────────────────┐  │
+│  │ Custom agents directory: [.texra/agents       ] [Browse]  │  │
+│  └───────────────────────────────────────────────────────────┘  │
+│                                                                 │
 └─────────────────────────────────────────────────────────────────┘
 ```
 
@@ -283,24 +392,56 @@ const RECOMMENDED_MODELS = [
 - `[Source Code]` - Opens agent YAML file in editor
 - `[Delete]` - Deletes custom agent YAML file
 
-**Note:** Agent creation wizard and form-based editing are deferred to Future Scope. For now, users create agents by duplicating an existing YAML file in `.texra/agents/` and editing it directly.
+**Note:** Agent creation wizard and form-based editing are deferred to Future Scope.
+
+**Settings Mapping:**
+| UI Element | VS Code Setting |
+|------------|-----------------|
+| Auto-show remote agents | `texra.remoteAgents.autoShowIfAvailable` |
+| Custom agents directory | `texra.explorer.agentsDirectory` (Advanced) |
 
 **Storage:** `workspaceState.enabledAgents: string[]`
 
-**Remote Agent Settings (moved from VS Code config):**
-- `texra.remoteAgents.autoShowIfAvailable` → `workspaceState.remoteAgentsAutoShow`
-- `texra.remoteAgents.cacheTimeHours` → Remains in VS Code config (advanced)
-
 ---
 
-### Tool-Use Tab
+### Agents → Workflow (Subsection)
 
-**Purpose:** Configure tool execution behavior, edit approval, and permissions.
+**Purpose:** Settings specific to workflow agents (non-tool-use agents).
 
 **Layout:**
 ```
 ┌─────────────────────────────────────────────────────────────────┐
-│  Configure how tool-use agents interact with your workspace.    │
+│  Agents → Workflow                                              │
+│  ─────────────────────────────────────────────────────────────  │
+│  Settings for workflow agents (correct, polish, translate...).  │
+│                                                                 │
+│  OUTPUT STORAGE                                                 │
+│  ─────────────────────────────────────────────────────────────  │
+│                                                                 │
+│  Storage mode: [Folder ▼]                                      │
+│    How to store agent outputs.                                 │
+│    Options: In-place (overwrite), Folder (texra-outputs/)      │
+│                                                                 │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+**Settings Mapping:**
+| UI Element | VS Code Setting |
+|------------|-----------------|
+| Storage mode dropdown | `texra.agentOutputs.storageMode` |
+
+---
+
+### Agents → Tool-Use (Subsection)
+
+**Purpose:** Settings specific to tool-use agents (chat, research, etc.).
+
+**Layout:**
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  Agents → Tool-Use                                              │
+│  ─────────────────────────────────────────────────────────────  │
+│  Settings for tool-use agents (chat, research...).              │
 │                                                                 │
 │  EDIT APPROVAL                                                  │
 │  ─────────────────────────────────────────────────────────────  │
@@ -322,21 +463,12 @@ const RECOMMENDED_MODELS = [
 │                                                                 │
 │  ─────────────────────────────────────────────────────────────  │
 │                                                                 │
-│  ACTIVE SESSIONS                                                │
+│  CONTEXT MANAGEMENT                                             │
 │  ─────────────────────────────────────────────────────────────  │
-│  Tool-use sessions waiting for continuation.                    │
 │                                                                 │
-│  ┌───────────────────────────────────────────────────────────┐  │
-│  │ research (chat)               Jan 11, 1:15 PM   WAITING   │  │
-│  │ "Help me analyze the survey results..."                   │  │
-│  │                                      [Resume] [Discard]   │  │
-│  └───────────────────────────────────────────────────────────┘  │
-│                                                                 │
-│  ┌───────────────────────────────────────────────────────────┐  │
-│  │ paper-writing (chat)          Jan 10, 3:00 PM   WAITING   │  │
-│  │ "Continue editing section 3..."                           │  │
-│  │                                      [Resume] [Discard]   │  │
-│  └───────────────────────────────────────────────────────────┘  │
+│  Compaction threshold: [85 %]                                  │
+│    Compact context when usage exceeds this percentage.          │
+│    Range: 50-95%                                                │
 │                                                                 │
 └─────────────────────────────────────────────────────────────────┘
 ```
@@ -347,12 +479,50 @@ const RECOMMENDED_MODELS = [
 | Require approval checkbox | `texra.toolUse.requireEditApproval` |
 | Persist sessions checkbox | `texra.toolUse.persistence.enabled` |
 | Session retention dropdown | `texra.toolUse.persistence.ttlHours` |
+| Compaction threshold | `texra.model.compactionThresholdPercent` |
 
 **Storage:** VS Code configuration (for backwards compatibility via extended getConfig)
 
 ---
 
-### LaTeX Tab
+### Multi-Agent Section
+
+**Purpose:** Configure multi-agent operations (merge, ensemble). Some features awaiting future development.
+
+**Layout:**
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  Multi-Agent                                                    │
+│  ─────────────────────────────────────────────────────────────  │
+│  Configure multi-agent operations and ensemble runs.            │
+│                                                                 │
+│  MERGE SETTINGS                                                 │
+│  ─────────────────────────────────────────────────────────────  │
+│                                                                 │
+│  Default merge model: [Claude Sonnet 4.5 ▼]                    │
+│    Model used for combining outputs from multiple agents.       │
+│                                                                 │
+│  ─────────────────────────────────────────────────────────────  │
+│                                                                 │
+│  COMING SOON                                                    │
+│  ─────────────────────────────────────────────────────────────  │
+│  • Ensemble runs across multiple models                         │
+│  • Agent pipeline configurations                                │
+│  • Output voting and consensus                                  │
+│                                                                 │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+**Settings Mapping:**
+| UI Element | VS Code Setting |
+|------------|-----------------|
+| Default merge model | `texra.merge.defaultModel` |
+
+**Note:** This section is included now but some features are awaiting multi-agent feature maturity.
+
+---
+
+### LaTeX Section
 
 **Purpose:** Configure LaTeX formatting, latexdiff, and TikZ compilation settings.
 
@@ -451,46 +621,52 @@ const RECOMMENDED_MODELS = [
 
 ---
 
-### Memory Tab
+### Memory Section
 
 **Purpose:** Browse and manage persistent memory files created by tool-use agents.
 
-**Note:** Tool-use settings (edit approval, session persistence) are in the Tool-Use Tab.
+**Note:** Tool-use settings (edit approval, session persistence) are in Agents → Tool-Use.
+
+**Key Design:** Show memory content on expand (like current memoryView implementation).
 
 **Layout:**
 ```
 ┌─────────────────────────────────────────────────────────────────┐
+│  Memory                                                         │
+│  ─────────────────────────────────────────────────────────────  │
 │  Memory files created by tool-use agents.                       │
 │                                                                 │
 │  MEMORY FILES                                     [Refresh]    │
 │  ─────────────────────────────────────────────────────────────  │
 │  Agent-created memory files stored in /memories                 │
 │                                                                 │
+│  ▼ 📄 project-notes.md           12 KB    Jan 11, 2:34 PM      │
 │  ┌───────────────────────────────────────────────────────────┐  │
-│  │ 📄 project-notes.md           12 KB    Jan 11, 2:34 PM    │  │
-│  │    Project context and key decisions...                   │  │
-│  │                                         [View] [Delete]   │  │
+│  │ # Project Notes                                           │  │
+│  │                                                           │  │
+│  │ ## Key Decisions                                          │  │
+│  │ - Using XYZ framework for...                              │  │
+│  │ - Architecture follows...                                 │  │
+│  │                                        [View Full] [Delete]│  │
 │  └───────────────────────────────────────────────────────────┘  │
 │                                                                 │
-│  ┌───────────────────────────────────────────────────────────┐  │
-│  │ 📄 research-findings.md       8 KB     Jan 10, 4:12 PM    │  │
-│  │    Literature review notes and citations...               │  │
-│  │                                         [View] [Delete]   │  │
-│  └───────────────────────────────────────────────────────────┘  │
+│  ▶ 📄 research-findings.md       8 KB     Jan 10, 4:12 PM      │
 │                                                                 │
-│  ┌───────────────────────────────────────────────────────────┐  │
-│  │ 📁 figures/                   3 files  Jan 9, 11:00 AM    │  │
-│  │                                         [Browse]          │  │
-│  └───────────────────────────────────────────────────────────┘  │
+│  ▶ 📄 citations.bib              2 KB     Jan 9, 3:00 PM       │
 │                                                                 │
+│  ▶ 📁 figures/                   3 files  Jan 9, 11:00 AM      │
+│                                                                 │
+│  ─────────────────────────────────────────────────────────────  │
 │  Total: 5 files, 24 KB                        [Clear All]      │
 │                                                                 │
 └─────────────────────────────────────────────────────────────────┘
 ```
 
 **Features:** (Migrated from memoryView)
-- Memory file browser (from existing memoryView)
-- File preview, delete actions
+- Memory file browser with expandable content preview
+- Click file to expand and show content preview (first ~20 lines)
+- [View Full] opens file in editor
+- [Delete] removes file
 - Directory browsing (2-level deep)
 - Storage usage display
 
@@ -501,7 +677,7 @@ const RECOMMENDED_MODELS = [
 
 ---
 
-### History Tab
+### History Section
 
 **Purpose:** Browse and restore previous agent executions.
 
@@ -758,71 +934,26 @@ In the Models tab, show provider/routing status on each model:
 
 ---
 
-### UI Tab
+### Advanced Section
 
-**Purpose:** Configure user interface behavior and display preferences.
-
-**Layout:**
-```
-┌─────────────────────────────────────────────────────────────────┐
-│  Configure TeXRA user interface settings.                       │
-│                                                                 │
-│  DISPLAY OPTIONS                                                │
-│  ─────────────────────────────────────────────────────────────  │
-│                                                                 │
-│  ☑ Show quick pick for agent selection                          │
-│    Use VS Code quick pick instead of dropdown for agents.      │
-│                                                                 │
-│  ☑ Show quick pick for model selection                          │
-│    Use VS Code quick pick instead of dropdown for models.      │
-│                                                                 │
-│  ─────────────────────────────────────────────────────────────  │
-│                                                                 │
-│  PROGRESS BOARD                                                 │
-│  ─────────────────────────────────────────────────────────────  │
-│                                                                 │
-│  Stream sort order: [Timestamp descending ▼]                   │
-│    Options: Timestamp ascending, Timestamp descending          │
-│                                                                 │
-│  ─────────────────────────────────────────────────────────────  │
-│                                                                 │
-│  IMAGE PROCESSING                                               │
-│  ─────────────────────────────────────────────────────────────  │
-│                                                                 │
-│  Max image dimension: [2048 ▼]                                 │
-│    Larger images will be resized before sending to models.     │
-│    Options: 1024, 2048, 4096                                   │
-│                                                                 │
-└─────────────────────────────────────────────────────────────────┘
-```
-
-**Settings Mapping:**
-| UI Element | VS Code Setting |
-|------------|-----------------|
-| Agent quick pick checkbox | `texra.ui.showAgentQuickPick` |
-| Model quick pick checkbox | `texra.ui.showModelQuickPick` |
-| Stream sort order dropdown | `texra.progressBoard.streamSortOrder` |
-| Max image dimension dropdown | `texra.maxImageDimension` |
-
-**Storage:** VS Code configuration (backwards compatible)
-
----
-
-### Misc Tab
-
-**Purpose:** Miscellaneous settings that don't fit in other categories.
+**Purpose:** System-level settings, paths, retry behavior, and developer options.
 
 **Layout:**
 ```
 ┌─────────────────────────────────────────────────────────────────┐
-│  Miscellaneous settings.                                        │
+│  Advanced                                                       │
+│  ─────────────────────────────────────────────────────────────  │
+│  System-level settings for advanced users.                      │
 │                                                                 │
-│  CONTEXT & COMPACTION                                           │
+│  RETRY BEHAVIOR                                                 │
 │  ─────────────────────────────────────────────────────────────  │
 │                                                                 │
-│  Compaction threshold: [85 %]                                  │
-│    Compact context when usage exceeds this percentage.          │
-│    Range: 50-95%                                                │
+│  Max retries: [3 ▼]                                            │
+│    Maximum number of retries for failed API requests.          │
+│    Options: 1, 2, 3, 5                                         │
+│                                                                 │
+│  Initial delay: [1000 ms]                                      │
+│    Initial delay before first retry (exponential backoff).     │
 │                                                                 │
 │  ─────────────────────────────────────────────────────────────  │
 │                                                                 │
@@ -835,23 +966,18 @@ In the Models tab, show provider/routing status on each model:
 │                                                                 │
 │  ─────────────────────────────────────────────────────────────  │
 │                                                                 │
-│  AGENT OUTPUTS                                                  │
+│  SYSTEM PATHS                                                   │
 │  ─────────────────────────────────────────────────────────────  │
 │                                                                 │
-│  Storage mode: [Folder ▼]                                      │
-│    How to store agent outputs.                                 │
-│    Options: In-place, Folder                                   │
+│  Sox audio path: [/usr/bin/sox            ] [Browse]           │
+│    Path to sox executable for audio processing.                │
 │                                                                 │
 │  ─────────────────────────────────────────────────────────────  │
 │                                                                 │
-│  RETRY BEHAVIOR                                                 │
+│  DEBUG (Developer)                                              │
 │  ─────────────────────────────────────────────────────────────  │
-│                                                                 │
-│  Max retries: [3 ▼]                                            │
-│    Maximum number of retries for failed API requests.          │
-│                                                                 │
-│  Initial delay: [1000 ms]                                      │
-│    Initial delay before first retry (exponential backoff).     │
+│  ☐ Enable debug logging                                        │
+│  ☐ Enable verbose output                                       │
 │                                                                 │
 └─────────────────────────────────────────────────────────────────┘
 ```
@@ -859,27 +985,32 @@ In the Models tab, show provider/routing status on each model:
 **Settings Mapping:**
 | UI Element | VS Code Setting |
 |------------|-----------------|
-| Compaction threshold | `texra.model.compactionThresholdPercent` |
-| Commits to show | `texra.git.numberOfCommitsToShow` |
-| Agent outputs storage mode | `texra.agentOutputs.storageMode` |
 | Max retries | `texra.model.retry.maxRetries` |
 | Initial delay | `texra.model.retry.initialDelayMs` |
+| Commits to show | `texra.git.numberOfCommitsToShow` |
+| Sox audio path | `texra.audio.soxPath` |
+| Debug logging | `texra.debug.*` |
 
 **Storage:** VS Code configuration (backwards compatible)
 
 ---
 
-### Future: Multi-Agent Tab
-
-**Note:** The `texra.merge.defaultModel` setting is intended for a future Multi-Agent Tab that will configure multi-agent workflows (merge operations). This is deferred until the multi-agent feature set is more mature.
-
----
-
 ### Features Summary
 
-**Profile Tab Features:**
-- Account info display (if logged in)
-- Model access mode toggle (included vs own keys) - only when logged in
+**Sidebar Navigation Sections:**
+- **General** - Account info, UI preferences (quick picks, image dimension, sort order)
+- **Agents** (main) - Agent list enable/disable, remote agents, custom agents directory
+- **Agents → Workflow** - Workflow agent output storage settings
+- **Agents → Tool-Use** - Edit approval, session persistence, compaction threshold
+- **Models & Providers** - Combined model selection + provider configuration + routing
+- **Multi-Agent** - Merge settings (future ensemble features noted)
+- **LaTeX** - Formatter, latexdiff, TikZ settings
+- **Memory** - Memory file browser with expandable content preview
+- **History** - Execution history browser
+- **Advanced** - System paths, retry behavior, debug settings
+
+**Key Features:**
+- Account info display at sidebar top (if logged in)
 - Per-provider configuration cards
 - Provider modal with API key + custom endpoint
 - OpenRouter special configuration (routing mode)
@@ -1284,32 +1415,32 @@ src/
 │   ├── SettingsViewProvider.ts      # WebviewViewProvider
 │   ├── SettingsViewMessageHandler.ts
 │   ├── SettingsViewContentProvider.ts
-│   ├── index.html                   # Tabbed layout (9 tabs)
-│   ├── styles.css                   # VS Code native styling
+│   ├── index.html                   # Sidebar navigation layout
+│   ├── styles.css                   # Cursor-style sidebar styling
 │   └── modules/
 │       ├── main.js                  # Entry point
 │       ├── messageHandlers.js
 │       ├── settingsViewState.js
-│       ├── tabs/
-│       │   ├── ModelsTab.js         # Models tab logic
-│       │   ├── AgentsTab.js         # Agents tab (includes remote agents)
-│       │   ├── ToolUseTab.js        # Tool-use settings + sessions
-│       │   ├── LatexTab.js          # LaTeX settings tab
-│       │   ├── MemoryTab.js         # Memory files browser
-│       │   ├── HistoryTab.js        # History tab (migrated)
-│       │   ├── ProfileTab.js        # Profile tab (streaming, routing)
-│       │   ├── UITab.js             # UI preferences
-│       │   └── MiscTab.js           # Miscellaneous settings
+│       ├── sidebarNav.js            # Sidebar navigation logic
+│       ├── sections/
+│       │   ├── GeneralSection.js    # Account + UI preferences
+│       │   ├── AgentsSection.js     # Agent list (main)
+│       │   ├── AgentsWorkflow.js    # Agents → Workflow subsection
+│       │   ├── AgentsToolUse.js     # Agents → Tool-Use subsection
+│       │   ├── ModelsProviders.js   # Combined Models & Providers
+│       │   ├── MultiAgentSection.js # Multi-agent settings
+│       │   ├── LatexSection.js      # LaTeX settings
+│       │   ├── MemorySection.js     # Memory files browser
+│       │   ├── HistorySection.js    # History (migrated)
+│       │   └── AdvancedSection.js   # Advanced settings
 │       └── uiManagers/
+│           ├── SidebarRenderer.js
 │           ├── ModelListRenderer.js
+│           ├── ProviderRenderer.js
 │           ├── AgentListRenderer.js
-│           ├── ToolUseRenderer.js
 │           ├── LatexSettingsRenderer.js
 │           ├── MemoryRenderer.js    # From memoryView
-│           ├── HistoryRenderer.js   # From historyView
-│           ├── ProfileRenderer.js   # From profileView
-│           ├── UIRenderer.js
-│           └── MiscRenderer.js
+│           └── HistoryRenderer.js   # From historyView
 │
 ├── profileView/                     # DEPRECATED - merge into settingsView
 ├── historyView/                     # DEPRECATED - merge into settingsView
@@ -1320,11 +1451,11 @@ src/
 
 ```typescript
 // Register command to open settings view
-commands.registerCommand('texra.openSettings', (tab?: string) => {
+commands.registerCommand('texra.openSettings', (section?: string) => {
   settingsViewProvider.show();
-  if (tab) {
-    // 'models' | 'agents' | 'tooluse' | 'latex' | 'memory' | 'history' | 'profile' | 'ui' | 'misc'
-    settingsViewProvider.selectTab(tab);
+  if (section) {
+    // 'general' | 'agents' | 'agents-workflow' | 'agents-tooluse' | 'models' | 'multiagent' | 'latex' | 'memory' | 'history' | 'advanced'
+    settingsViewProvider.selectSection(section);
   }
 });
 
@@ -1391,81 +1522,75 @@ interface AgentInfo {
 ## Success Metrics
 
 1. Single entry point for all configuration
-2. Easy tab navigation (keyboard accessible)
+2. Cursor-style sidebar navigation (keyboard accessible)
 3. State properly persisted (models global, agents per-workspace)
 4. History search and restore working
-5. Profile/auth flow unchanged
+5. Profile/auth flow unchanged (account info in sidebar header)
 6. LaTeX settings functional and synced with VS Code config
-7. Notion-style minimalist appearance achieved
+7. Clean sidebar + content layout achieved
 
 ---
 
 ## Implementation Phases
 
 ### Phase 1: Core Structure + Extended getConfig
-- Create settingsView with tab navigation (9 tabs)
+- Create settingsView with Cursor-style sidebar navigation
 - Implement extended `getConfig()` with state awareness
-- Implement Models tab with provider accordions
+- Implement General section (account + UI preferences)
 - Wire up globalState for model preferences
 - Test graceful migration from VS Code config
-- Use vscode-form-group for all form layouts
 
-### Phase 2: Agents Tab (View-Only First)
-- Implement Agents tab with list of all agents
+### Phase 2: Models & Providers Section
+- Implement combined Models & Providers section
+- Provider accordions with API status + model list
+- Provider configuration modal (API key + endpoint + streaming toggle)
+- Routing options UI
+- Migrate provider config from old profileView
+
+### Phase 3: Agents Section (View-Only First)
+- Implement Agents section with list of all agents
 - Show category badges (workflow/toolUse) and source (built-in/custom/remote)
 - Wire up workspaceState for agent preferences
-- Include remote agents settings (autoShowIfAvailable)
-- Handle remote agents auth state
-- Link to YAML files for editing (power users)
+- Include remote agents settings + custom agents directory (Advanced)
 - **Note:** Supersedes FolderExplorer/agent explorer view
 
-### Phase 3: Tool-Use Tab
-- Implement Tool-Use tab with edit approval settings
-- Add session persistence settings UI
-- Add active sessions list with resume/discard
+### Phase 4: Agents Subsections
+- Implement Agents → Workflow subsection (output storage mode)
+- Implement Agents → Tool-Use subsection (edit approval, persistence, compaction)
 - Wire to VS Code config via extended getConfig
 
-### Phase 4: LaTeX Tab
-- Implement LaTeX tab with formatter, latexdiff, TikZ sections
+### Phase 5: Multi-Agent Section
+- Implement Multi-Agent section with merge settings
+- Add "Coming Soon" placeholder for future ensemble features
+
+### Phase 6: LaTeX Section
+- Implement LaTeX section with formatter, latexdiff, TikZ
 - Wire up to existing VS Code configuration
 - Add file browser for config paths
-- Add collapsible advanced sections (TikZ template, custom replacements)
 
-### Phase 5: Memory Tab
-- Migrate memoryView to Memory tab (file browser only)
-- Remove tool-use settings (moved to Tool-Use tab)
+### Phase 7: Memory Section
+- Migrate memoryView to Memory section
+- Implement expandable content preview
 - Delete old memoryView
 
-### Phase 6: Migrate History
-- Move history rendering to History tab
+### Phase 8: History Section
+- Move history rendering to History section
 - Preserve search, delete, restore, rerun functionality
 - Delete old historyView
 
-### Phase 7: Migrate Profile
-- Move profile/auth to Profile tab
-- Implement provider configuration cards
-- Implement provider modal (API key + endpoint + streaming toggle)
-- Add routing options UI
-- Delete old profileView
-
-### Phase 8: UI + Misc Tabs
-- Implement UI tab with display preferences
-- Implement Misc tab with advanced settings
-- Wire to VS Code config via extended getConfig
-
-### Phase 9: Polish & Cleanup
+### Phase 9: Advanced Section + Cleanup
+- Implement Advanced section (retry, git, system paths, debug)
 - Add main webview entry point (gear icon)
-- Deep link support (open to specific tab)
+- Deep link support (open to specific section)
 - Verify graceful migration (no breaking existing setups)
-- Accessibility audit (keyboard navigation)
 - Remove deprecated views (profileView, historyView, memoryView)
-- Remove FolderExplorer/agent explorer (superseded by Agents tab)
+- Remove FolderExplorer/agent explorer (superseded)
 - Documentation
 
 ### Future Scope (Deferred)
-- **Multi-Agent Tab** - Configure merge operations and `texra.merge.defaultModel`
 - **Agent Creation Wizard** - AI-assisted agent creation from plain English description
 - **Agent Edit Form** - Form-based editing without YAML knowledge
+- **Multi-Agent Ensemble** - Run across multiple models with voting/consensus
 
 ---
 
@@ -1473,35 +1598,29 @@ interface AgentInfo {
 
 Based on 79 total settings in package.json:
 
-### Now Covered by Settings View (46 settings)
+### Now Covered by Settings View (47 settings)
 
-| Tab | Settings Covered |
-|-----|------------------|
-| **Models** | `texra.models`, enabled model list |
-| **Agents** | `texra.agents`, `texra.toolUseAgents`, `texra.remoteAgents.autoShowIfAvailable` |
-| **Tool-Use** | `texra.toolUse.requireEditApproval`, `texra.toolUse.persistence.*` (2) |
+| Section | Settings Covered |
+|---------|------------------|
+| **General** | `texra.ui.*` (3), `texra.progressBoard.streamSortOrder`, `texra.maxImageDimension` |
+| **Agents (main)** | `texra.agents`, `texra.toolUseAgents`, `texra.remoteAgents.autoShowIfAvailable`, `texra.explorer.agentsDirectory` |
+| **Agents → Workflow** | `texra.agentOutputs.storageMode` |
+| **Agents → Tool-Use** | `texra.toolUse.requireEditApproval`, `texra.toolUse.persistence.*` (2), `texra.model.compactionThresholdPercent` |
+| **Models & Providers** | `texra.models`, `texra.model.useStreaming*` (9), `texra.model.useOpenRouter`, `texra.model.useImprovedConnection`, `texra.model.improvedConnectionDomain`, `texra.model.baseUrlDeepSeek` |
+| **Multi-Agent** | `texra.merge.defaultModel` |
 | **LaTeX** | `texra.latex.*` (7), `texra.latexdiff.*` (4) |
 | **Memory** | Memory file browser (no config, file system) |
 | **History** | History browser (existing storage) |
-| **Profile** | `texra.model.useStreaming*` (9), `texra.model.useOpenRouter`, `texra.model.useImprovedConnection`, `texra.model.improvedConnectionDomain`, `texra.model.baseUrlDeepSeek` |
-| **UI** | `texra.ui.*` (3), `texra.progressBoard.streamSortOrder`, `texra.maxImageDimension` |
-| **Misc** | `texra.model.compactionThresholdPercent`, `texra.git.numberOfCommitsToShow`, `texra.agentOutputs.storageMode`, `texra.model.retry.*` (2) |
-
-### Deferred to Future Tabs (1 setting)
-| Setting | Future Tab | Notes |
-|---------|------------|-------|
-| `texra.merge.defaultModel` | Multi-Agent | Awaiting multi-agent feature maturity |
+| **Advanced** | `texra.model.retry.*` (2), `texra.git.numberOfCommitsToShow`, `texra.audio.soxPath`, `texra.debug.*` |
 
 ### Remain as VS Code Settings Only (32 settings)
 These are advanced/power-user settings that don't need UI exposure:
 
 - `texra.files.*` (16) - File type filtering patterns (power user)
-- `texra.logger.*`, `texra.debug.*` (3) - Development/debugging only
+- `texra.logger.*` (2) - Logging configuration
 - `texra.auth.*` (3) - System-level authentication endpoints
 - `texra.remoteAgents.cacheTimeHours` (1) - Advanced cache behavior
-- `texra.explorer.agentsDirectory` (1) - System path
-- `texra.audio.soxPath` (1) - System path for audio
-- Other system-level paths and debug flags (7)
+- Other system-level paths and debug flags (10)
 
 ---
 

--- a/docs/prd/settings-view-unified.md
+++ b/docs/prd/settings-view-unified.md
@@ -1,0 +1,565 @@
+# PRD: Unified Settings View
+
+**Status:** Draft
+**Author:** Claude
+**Date:** 2026-01-11
+**Related:** Model dropdown, Agent dropdown, Profile View, History View
+
+---
+
+## Overview
+
+Create a unified Settings View that consolidates model configuration, agent configuration, execution history, and profile/account management into a single tabbed interface. This replaces the scattered entry points with a cohesive settings experience.
+
+---
+
+## Goals
+
+1. **Single source of truth** - All configuration in one place
+2. **Easy navigation** - Tab-based switching between Models, Agents, History, Profile
+3. **No auth required** - Models, Agents, History tabs work without login
+4. **VS Code native** - Use `vscode-tabs`, `vscode-tab-header`, `vscode-tab-panel` components
+5. **Proper state management** - Global vs workspace state separation
+
+---
+
+## User Stories
+
+1. As a user, I want to click a settings icon to configure which models appear in my dropdown
+2. As a user, I want to configure different agents per workspace (research project vs thesis)
+3. As a user, I want to browse execution history and restore previous sessions
+4. As a user, I want to manage my account and API keys in the same interface
+5. As a user, I want to easily switch between these configuration pages
+
+---
+
+## Design
+
+### Entry Point
+
+Single entry point from main webview:
+
+```
+┌─────────────────────────────────────────────┐
+│  Model: [Claude Sonnet 4.5 ▼]               │
+│  Agent: [chat ▼]               [⚙️ Settings]│
+└─────────────────────────────────────────────┘
+```
+
+Clicking ⚙️ (codicon: `settings-gear`) opens the unified Settings View.
+
+### Tab Structure
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  TeXRA Settings                                          [×]   │
+├─────────────────────────────────────────────────────────────────┤
+│  [Models]   Agents    History    Profile                        │
+│  ═══════                                                        │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                 │
+│                    Tab content here                             │
+│                                                                 │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### HTML Structure (using vscode-elements)
+
+```html
+<vscode-tabs id="settingsTabs" selected-index="0">
+  <vscode-tab-header slot="header">Models</vscode-tab-header>
+  <vscode-tab-header slot="header">Agents</vscode-tab-header>
+  <vscode-tab-header slot="header">History</vscode-tab-header>
+  <vscode-tab-header slot="header">Profile</vscode-tab-header>
+
+  <vscode-tab-panel id="modelsPanel">
+    <!-- Models tab content -->
+  </vscode-tab-panel>
+  <vscode-tab-panel id="agentsPanel">
+    <!-- Agents tab content -->
+  </vscode-tab-panel>
+  <vscode-tab-panel id="historyPanel">
+    <!-- History tab content -->
+  </vscode-tab-panel>
+  <vscode-tab-panel id="profilePanel">
+    <!-- Profile tab content -->
+  </vscode-tab-panel>
+</vscode-tabs>
+```
+
+---
+
+## Tab Specifications
+
+### Models Tab
+
+**Purpose:** Configure which models appear in the model dropdown.
+
+**Layout:**
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  Configure which models appear in the model dropdown.           │
+│                                                                 │
+│  ⭐ RECOMMENDED                                                 │
+│  ┌───────────────────────────────────────────────────────────┐  │
+│  │ ☑ Claude Sonnet 4.5 T    Anthropic   $3/$15    200K  🧠👁 │  │
+│  │ ☑ Claude Opus 4.5 T      Anthropic   $15/$75   200K  🧠👁 │  │
+│  │ ☑ GPT-5.2                OpenAI      $2/$10    256K  🧠👁 │  │
+│  │ ☑ Gemini 3 Pro           Google      $1.25/$5  1M    🧠👁 │  │
+│  │ ☑ Grok 4                 xAI         $3/$15    256K  🧠👁 │  │
+│  │ ☑ DeepSeek R1            DeepSeek    $0.55/$2  64K   🧠   │  │
+│  └───────────────────────────────────────────────────────────┘  │
+│                                                                 │
+│  ALL MODELS                                                     │
+│  ─────────────────────────────────────────────────────────────  │
+│                                                                 │
+│  ▼ Anthropic (21)                                 [Enable All] │
+│  ┌───────────────────────────────────────────────────────────┐  │
+│  │ ☑ Claude Sonnet 4.5 Thinking   200K   $3/$15    🧠👁📄    │  │
+│  │ ☑ Claude Opus 4.5 Thinking     200K   $15/$75   🧠👁📄🎧  │  │
+│  │ ☐ Claude Sonnet 4.5            200K   $3/$15    👁📄      │  │
+│  │ ☐ Claude Sonnet 4.0            200K   $3/$15    👁📄      │  │
+│  │ ☐ Claude Haiku 3.5             200K   $0.8/$4   👁        │  │
+│  │   ... more                                                │  │
+│  └───────────────────────────────────────────────────────────┘  │
+│                                                                 │
+│  ▶ OpenAI (28)                                                 │
+│  ▶ Google (6)                                                  │
+│  ▶ DeepSeek (7)                                                │
+│  ▶ xAI (5)                                                     │
+│  ▶ Moonshot (8)                                                │
+│  ▶ DashScope (3)                                               │
+│                                                                 │
+│  ─────────────────────────────────────────────────────────────  │
+│  Selected: 12 models                              [Save Changes]│
+└─────────────────────────────────────────────────────────────────┘
+```
+
+**Data Source:** `llm-zoo` package (ModelRegistry)
+
+**Model Metadata Displayed:**
+- Name (display name)
+- Provider
+- Cost (input/output per 1M tokens)
+- Context window
+- Capabilities icons: 🧠 Reasoning, 👁 Vision, 📄 PDF, 🎧 Audio, 💬 Tools, ⚡ Cache
+
+**Sorting:**
+- Recommended section: hardcoded curated list
+- Provider sections: newest model families first within each provider
+
+**Recommended Models (hardcoded):**
+```typescript
+const RECOMMENDED_MODELS = [
+  'sonnet45T',   // Claude Sonnet 4.5 Thinking
+  'opus45T',     // Claude Opus 4.5 Thinking
+  'gpt52',       // GPT-5.2
+  'gemini3p',    // Gemini 3 Pro
+  'grok4',       // Grok 4
+  'deepseekT',   // DeepSeek R1
+  'kimi2T',      // Kimi K2 Thinking
+  'qwen3max',    // Qwen 3 Max
+];
+```
+
+**Storage:** `globalState.enabledModels: string[]`
+
+---
+
+### Agents Tab
+
+**Purpose:** Configure which agents appear in agent dropdowns.
+
+**Layout:**
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  Configure which agents appear in the agent dropdowns.          │
+│  Settings are saved per workspace.                              │
+│                                                                 │
+│  LOCAL AGENTS                                     [Enable All] │
+│  ┌───────────────────────────────────────────────────────────┐  │
+│  │ ☑ ask             Quick Q&A without tools                 │  │
+│  │ ☑ chat            Interactive chat with context           │  │
+│  │ ☑ correct         Corrects typos, grammar, LaTeX          │  │
+│  │ ☑ draw            Creates/polishes TikZ figures           │  │
+│  │ ☐ merge           Merges partial edits into document      │  │
+│  │ ☑ ocr             Handwritten math → LaTeX                │  │
+│  │ ☑ paper2poster    Paper → academic poster                 │  │
+│  │ ☑ paper2slide     Paper → Beamer presentation             │  │
+│  │ ☑ polish          Improves writing quality & clarity      │  │
+│  │ ☑ research        Research assistant with tools           │  │
+│  │ ☑ search          Search & retrieval                      │  │
+│  │ ☐ transcribe_audio Audio transcription                    │  │
+│  └───────────────────────────────────────────────────────────┘  │
+│                                                                 │
+│  CUSTOM AGENTS                                                 │
+│  ┌───────────────────────────────────────────────────────────┐  │
+│  │  No custom agents in this workspace.        [Learn More]  │  │
+│  └───────────────────────────────────────────────────────────┘  │
+│                                                                 │
+│  REMOTE AGENTS                                                 │
+│  ┌───────────────────────────────────────────────────────────┐  │
+│  │ ☑ team-reviewer   Team's paper reviewer       [Public]    │  │
+│  │ ☑ grant-writer    Grant proposal helper       [Team]      │  │
+│  │ ☐ thesis-helper   Thesis writing assistant    [Private]   │  │
+│  │                                                           │  │
+│  │  ☐ Auto-show new remote agents                            │  │
+│  └───────────────────────────────────────────────────────────┘  │
+│                        ─ or if not logged in ─                  │
+│  ┌───────────────────────────────────────────────────────────┐  │
+│  │  🔒 Sign in to access shared team agents       [Sign In]  │  │
+│  └───────────────────────────────────────────────────────────┘  │
+│                                                                 │
+│  ─────────────────────────────────────────────────────────────  │
+│  Selected: 12 agents                              [Save Changes]│
+└─────────────────────────────────────────────────────────────────┘
+```
+
+**Data Source:** `agentRegistry` (built-in, custom, remote)
+
+**Agent Metadata Displayed:**
+- Name
+- Description
+- Source badge (for remote: visibility)
+
+**Sections:**
+1. **Local Agents** - Built-in agents from `resources/agents/`
+2. **Custom Agents** - User-defined agents in workspace
+3. **Remote Agents** - Shared team agents (requires auth)
+
+**Storage:** `workspaceState.enabledAgents: string[]`
+
+---
+
+### History Tab
+
+**Purpose:** Browse and restore previous agent executions.
+
+**Layout:** (Migrated from existing historyView)
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  ┌──────────────────────────────────────────────────────────┐   │
+│  │ 🔍 Search history items...            [◀] [▶] 3 matches  │   │
+│  └──────────────────────────────────────────────────────────┘   │
+│                                                                 │
+│  [Clear All History]                                           │
+│                                                                 │
+│  ┌───────────────────────────────────────────────────────────┐  │
+│  │ Jan 11, 2026 2:34 PM              [🗑] [↩ Restore] [▶ Run]│  │
+│  │ Agent: correct • Model: sonnet45T                         │  │
+│  │ Input: paper.tex • Output: paper_corrected.tex            │  │
+│  │ ▶ Show details                                            │  │
+│  └───────────────────────────────────────────────────────────┘  │
+│                                                                 │
+│  ┌───────────────────────────────────────────────────────────┐  │
+│  │ Jan 11, 2026 1:15 PM              [🗑] [↩ Restore] [▶ Run]│  │
+│  │ Agent: polish • Model: gpt52                              │  │
+│  │ ...                                                       │  │
+│  └───────────────────────────────────────────────────────────┘  │
+│                                                                 │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+**Features:** (Same as current historyView)
+- Search with highlighting (mark.js)
+- Delete, Restore, Rerun actions
+- Collapsible details per item
+
+**Storage:** Existing history storage mechanism
+
+---
+
+### Profile Tab
+
+**Purpose:** Account management and API keys.
+
+**Layout:**
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                                                                 │
+│  ┌─────────────────────────────────────────────────────────┐    │
+│  │  👤 user@example.com                        [Sign Out]  │    │
+│  │     Pro Plan • Ultra Tier                               │    │
+│  │     Access expires: Feb 15, 2026                        │    │
+│  └─────────────────────────────────────────────────────────┘    │
+│                                                                 │
+│  MODEL ACCESS                                                  │
+│  ─────────────────────────────────────────────────────────────  │
+│  ○ Use Included Access                                         │
+│    Works automatically. No setup needed.                       │
+│                                                                 │
+│  ● Use My Own API Keys                                         │
+│    Provide your own API keys from providers.                   │
+│                                                                 │
+│  ▶ View included providers & models                            │
+│                                                                 │
+│  API KEYS                                                      │
+│  ─────────────────────────────────────────────────────────────  │
+│  Anthropic    ●●●●●●●●sk-1234              [Edit] [Delete]    │
+│  OpenAI       ●●●●●●●●sk-5678              [Edit] [Delete]    │
+│  Google       Not configured                      [Add Key]    │
+│  DeepSeek     Not configured                      [Add Key]    │
+│                                                                 │
+└─────────────────────────────────────────────────────────────────┘
+
+─── or if not logged in ───
+
+┌─────────────────────────────────────────────────────────────────┐
+│                                                                 │
+│  ┌─────────────────────────────────────────────────────────┐    │
+│  │  Sign in to sync settings and access premium features   │    │
+│  │                                         [Sign In]       │    │
+│  └─────────────────────────────────────────────────────────┘    │
+│                                                                 │
+│  API KEYS (Local Mode)                                         │
+│  ─────────────────────────────────────────────────────────────  │
+│  Configure API keys to use AI models without an account.       │
+│                                                                 │
+│  Anthropic    Not configured                      [Add Key]    │
+│  OpenAI       Not configured                      [Add Key]    │
+│  ...                                                           │
+│                                                                 │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+**Features:**
+- Account info display
+- Model access mode toggle (included vs own keys)
+- API key management
+- Sign in/out
+
+---
+
+## State Management
+
+### Global State (`context.globalState`)
+
+Shared across all workspaces, persists per machine.
+
+```typescript
+interface GlobalState {
+  // Model preferences - same models everywhere
+  enabledModels: string[];
+
+  // Version for migrations
+  settingsVersion: number;
+}
+```
+
+### Workspace State (`context.workspaceState`)
+
+Per-workspace, different projects have different preferences.
+
+```typescript
+interface WorkspaceState {
+  // Agent preferences - different per project
+  enabledAgents: string[];
+
+  // Last selections - restore on reopen
+  lastUsedAgent: string;
+  lastUsedModel: string;
+
+  // Remote agent settings
+  remoteAgentsAutoShow: boolean;
+
+  // Version for migrations
+  settingsVersion: number;
+}
+```
+
+### Defaults (Hardcoded)
+
+```typescript
+const RECOMMENDED_MODELS = [
+  'sonnet45T', 'opus45T', 'gpt52', 'gemini3p',
+  'grok4', 'deepseekT', 'kimi2T', 'qwen3max'
+];
+
+const DEFAULT_ENABLED_MODELS = [
+  'sonnet45T', 'opus45T', 'gpt52', 'gpt52pro', 'gpt41',
+  'gemini3p', 'gemini3f', 'grok4', 'deepseekT',
+  'kimi2T', 'kimi2', 'qwen3max'
+];
+
+const DEFAULT_ENABLED_AGENTS = [
+  'ask', 'chat', 'correct', 'draw', 'ocr',
+  'paper2slide', 'paper2poster', 'polish', 'research', 'search'
+];
+```
+
+---
+
+## Migration Plan
+
+### From VS Code Config to State
+
+| Old (settings.json) | New (Extension State) |
+|---------------------|----------------------|
+| `texra.models` | `globalState.enabledModels` |
+| `texra.agents` | `workspaceState.enabledAgents` |
+| `texra.toolUseAgents` | `workspaceState.enabledAgents` |
+
+### Migration Logic
+
+```typescript
+async function migrateSettings(context: vscode.ExtensionContext) {
+  const config = vscode.workspace.getConfiguration('texra');
+
+  // Migrate models (one-time)
+  if (!context.globalState.get('enabledModels')) {
+    const oldModels = config.get<string[]>('models');
+    if (oldModels?.length) {
+      await context.globalState.update('enabledModels', oldModels);
+    }
+  }
+
+  // Migrate agents (one-time per workspace)
+  if (!context.workspaceState.get('enabledAgents')) {
+    const oldAgents = config.get<string[]>('agents') ?? [];
+    const oldToolUse = config.get<string[]>('toolUseAgents') ?? [];
+    const combined = [...new Set([...oldAgents, ...oldToolUse])];
+    if (combined.length) {
+      await context.workspaceState.update('enabledAgents', combined);
+    }
+  }
+}
+```
+
+---
+
+## Architecture
+
+### File Structure
+
+```
+src/
+├── settingsView/                    # NEW - Unified settings view
+│   ├── SettingsViewProvider.ts      # WebviewViewProvider
+│   ├── SettingsViewMessageHandler.ts
+│   ├── SettingsViewContentProvider.ts
+│   ├── index.html                   # Tabbed layout
+│   ├── styles.css
+│   └── modules/
+│       ├── main.js                  # Entry point
+│       ├── messageHandlers.js
+│       ├── settingsViewState.js
+│       ├── tabs/
+│       │   ├── ModelsTab.js         # Models tab logic
+│       │   ├── AgentsTab.js         # Agents tab logic
+│       │   ├── HistoryTab.js        # History tab logic (migrated)
+│       │   └── ProfileTab.js        # Profile tab logic (migrated)
+│       └── uiManagers/
+│           ├── ModelListRenderer.js
+│           ├── AgentListRenderer.js
+│           ├── HistoryRenderer.js   # From historyView
+│           └── ProfileRenderer.js   # From profileView
+│
+├── profileView/                     # DEPRECATED - merge into settingsView
+├── historyView/                     # DEPRECATED - merge into settingsView
+```
+
+### Commands
+
+```typescript
+// Register command to open settings view
+commands.registerCommand('texra.openSettings', (tab?: string) => {
+  settingsViewProvider.show();
+  if (tab) {
+    settingsViewProvider.selectTab(tab); // 'models' | 'agents' | 'history' | 'profile'
+  }
+});
+
+// Shortcut commands
+commands.registerCommand('texra.openModelSettings', () =>
+  commands.executeCommand('texra.openSettings', 'models'));
+commands.registerCommand('texra.openAgentSettings', () =>
+  commands.executeCommand('texra.openSettings', 'agents'));
+```
+
+### Message Protocol
+
+```typescript
+// Extension → Webview
+type SettingsMessage =
+  | { command: 'SET_MODELS_DATA', models: ModelInfo[], enabled: string[] }
+  | { command: 'SET_AGENTS_DATA', agents: AgentInfo[], enabled: string[] }
+  | { command: 'SET_HISTORY_DATA', items: HistoryItem[] }
+  | { command: 'SET_PROFILE_DATA', profile: ProfileInfo | null }
+  | { command: 'SELECT_TAB', tab: string };
+
+// Webview → Extension
+type SettingsAction =
+  | { command: 'SAVE_ENABLED_MODELS', models: string[] }
+  | { command: 'SAVE_ENABLED_AGENTS', agents: string[] }
+  | { command: 'RESTORE_HISTORY', id: string }
+  | { command: 'DELETE_HISTORY', id: string }
+  | { command: 'SIGN_IN' }
+  | { command: 'SIGN_OUT' }
+  | { command: 'SET_API_KEY', provider: string, key: string };
+```
+
+---
+
+## Open Questions
+
+1. **Deep linking:** Should clicking model dropdown gear go directly to Models tab?
+   - **Proposed:** Yes, via `texra.openSettings` command with tab parameter
+
+2. **History size:** History tab may have many items - pagination or virtual scroll?
+   - **Proposed:** Keep current approach (load all, search/filter client-side)
+
+3. **Remote agents in profile:** Remove completely or keep summary?
+   - **Proposed:** Remove from profile, fully in Agents tab
+
+4. **Settings sync:** Future cloud sync of preferences?
+   - **Proposed:** Out of scope for v1, design state structure to support later
+
+---
+
+## Success Metrics
+
+1. Single entry point for all configuration
+2. Easy tab navigation (keyboard accessible)
+3. State properly persisted (models global, agents per-workspace)
+4. History search and restore working
+5. Profile/auth flow unchanged
+
+---
+
+## Implementation Phases
+
+### Phase 1: Core Structure
+- Create settingsView with tab navigation
+- Implement Models tab with provider accordions
+- Wire up globalState for model preferences
+
+### Phase 2: Agents Tab
+- Implement Agents tab with local/custom/remote sections
+- Wire up workspaceState for agent preferences
+- Handle remote agents auth state
+
+### Phase 3: Migrate History
+- Move history rendering to History tab
+- Preserve search, delete, restore, rerun functionality
+- Delete old historyView
+
+### Phase 4: Migrate Profile
+- Move profile/auth to Profile tab
+- Preserve API key management
+- Delete old profileView
+
+### Phase 5: Polish
+- Add main webview entry point (gear icon)
+- Deep link support (open to specific tab)
+- Migration from old VS Code config
+- Documentation
+
+---
+
+## References
+
+- VS Code Elements: `@vscode-elements/elements`
+  - `vscode-tabs`, `vscode-tab-header`, `vscode-tab-panel`
+  - `vscode-collapsible`, `vscode-checkbox`, `vscode-button`
+- LLM Zoo: Model metadata source
+- Existing views: `src/profileView/`, `src/historyView/`

--- a/docs/prd/settings-view-unified.md
+++ b/docs/prd/settings-view-unified.md
@@ -1364,10 +1364,407 @@ interface AgentInfo {
 
 ---
 
+## Component Mapping (vscode-elements)
+
+### Tab Layout
+```html
+<vscode-tabs>                   <!-- Tab container -->
+  <vscode-tab-header>           <!-- Tab buttons -->
+  <vscode-tab-panel>            <!-- Tab content panels -->
+</vscode-tabs>
+```
+
+### Form Components by Tab
+
+| UI Pattern | Component | Example Usage |
+|------------|-----------|---------------|
+| **Single selection** | `<vscode-single-select>` | Formatter dropdown, Math markup |
+| **Checkbox** | `<vscode-checkbox>` | Enable/disable toggles |
+| **Text input** | `<vscode-textfield>` | API keys, file paths |
+| **Multiline text** | `<vscode-textarea>` | TikZ template, agent instructions |
+| **Radio group** | `<vscode-radio-group>` | Routing mode, access mode |
+| **Collapsible section** | `<vscode-collapsible>` | Advanced options, provider details |
+| **Button** | `<vscode-button>` | Save, Browse, Create Agent |
+| **Badge** | `<vscode-badge>` | Category badges (workflow/toolUse) |
+
+### Form Layout Components
+```html
+<!-- Notion-style form row (no vscode-form-group for cleaner look) -->
+<div class="setting-row">
+  <span class="setting-label">Formatter</span>
+  <vscode-single-select>
+    <vscode-option value="latexindent">latexindent</vscode-option>
+    <vscode-option value="tex-fmt">tex-fmt</vscode-option>
+    <vscode-option value="none">none</vscode-option>
+  </vscode-single-select>
+</div>
+
+<!-- Checkbox row -->
+<div class="setting-row">
+  <vscode-checkbox id="showWarning">
+    Show warning if latexindent is not installed
+  </vscode-checkbox>
+</div>
+
+<!-- File path row with browse button -->
+<div class="setting-row">
+  <span class="setting-label">Config file</span>
+  <div class="setting-input-group">
+    <vscode-textfield placeholder="/path/to/config"></vscode-textfield>
+    <vscode-button appearance="secondary">Browse</vscode-button>
+  </div>
+</div>
+```
+
+### Models Tab Components
+- `<vscode-collapsible>` - Provider accordions (Anthropic, OpenAI, etc.)
+- `<vscode-checkbox>` - Model enable/disable
+- `<vscode-badge>` - Capability icons, status indicators
+
+### Agents Tab Components
+- `<vscode-checkbox>` - Agent enable/disable
+- `<vscode-badge>` - Category badges (workflow/toolUse), source badges
+- `<vscode-button>` - Create Agent, Edit, Delete
+- `<vscode-single-select>` - Category dropdown, inheritance dropdown
+- `<vscode-textarea>` - Agent instructions
+
+### LaTeX Tab Components
+- `<vscode-single-select>` - Formatter, math markup
+- `<vscode-checkbox>` - Boolean settings
+- `<vscode-textfield>` - File paths, regex patterns
+- `<vscode-textarea>` - TikZ template
+- `<vscode-collapsible>` - Advanced sections
+
+### Profile Tab Components
+- `<vscode-radio-group>` - Access mode, routing mode
+- `<vscode-textfield type="password">` - API keys
+- `<vscode-button>` - Sign In/Out, Configure, Save
+- `<vscode-collapsible>` - Provider details
+
+---
+
+## Code Reuse Patterns
+
+### Base Classes (Extend Existing Infrastructure)
+
+```
+src/settingsView/
+├── SettingsViewProvider.ts         # extends BaseWebviewProvider
+├── SettingsViewMessageHandler.ts   # extends BaseViewMessageHandler
+├── SettingsViewContentProvider.ts  # extends BaseViewContentProvider
+```
+
+### Provider Pattern
+```typescript
+// SettingsViewProvider.ts
+export class SettingsViewProvider extends BaseWebviewProvider
+    implements vscode.WebviewViewProvider {
+  public static readonly viewType = 'texra.settingsView';
+
+  protected contentProvider: SettingsViewContentProvider;
+  protected messageHandler: SettingsViewMessageHandler;
+
+  constructor(context: vscode.ExtensionContext) {
+    super(context);
+    this.contentProvider = new SettingsViewContentProvider(context);
+    this.messageHandler = new SettingsViewMessageHandler(context);
+  }
+
+  public resolveWebviewView(webviewView: vscode.WebviewView): void {
+    webviewView.webview.options = {
+      enableScripts: true,
+      localResourceRoots: getSharedLocalResourceRoots(this.context, 'settingsView'),
+    };
+    super.resolveWebviewViewInternal(webviewView);
+  }
+
+  /** Open settings to specific tab */
+  public async showSettings(tab?: SettingsTab): Promise<void> {
+    const isNew = this.createOrShowPanel({
+      viewType: SettingsViewProvider.viewType,
+      title: 'TeXRA Settings',
+      viewPath: 'settingsView',
+    });
+    if (tab) {
+      await this.messageHandler.selectTab(this._view?.webview, tab);
+    }
+  }
+}
+```
+
+### Module Descriptors Pattern
+```typescript
+// SettingsViewContentProvider.ts
+const SETTINGS_VIEW_MODULES = [
+  { key: 'settingsViewStateUri', path: 'modules/settingsViewState.js' },
+  { key: 'modelsTabUri', path: 'modules/tabs/ModelsTab.js' },
+  { key: 'agentsTabUri', path: 'modules/tabs/AgentsTab.js' },
+  { key: 'latexTabUri', path: 'modules/tabs/LatexTab.js' },
+  { key: 'memoryTabUri', path: 'modules/tabs/MemoryTab.js' },
+  { key: 'historyTabUri', path: 'modules/tabs/HistoryTab.js' },
+  { key: 'profileTabUri', path: 'modules/tabs/ProfileTab.js' },
+] as const;
+
+export class SettingsViewContentProvider extends BaseViewContentProvider {
+  constructor(context: vscode.ExtensionContext) {
+    super(context, 'SettingsView', [...SETTINGS_VIEW_MODULES]);
+  }
+  protected getViewPath(): string { return 'settingsView'; }
+}
+```
+
+### Tab Manager Pattern (Frontend)
+```javascript
+// modules/tabs/BaseTab.js - Abstract base for all tabs
+export class BaseTab {
+  constructor(containerId) {
+    this.container = document.getElementById(containerId);
+  }
+
+  render(data) { throw new Error('Implement render()'); }
+
+  dispose() {
+    // Clean up event listeners
+  }
+
+  // Shared helpers
+  createSettingRow(label, control) {
+    const row = document.createElement('div');
+    row.className = 'setting-row';
+    row.innerHTML = `<span class="setting-label">${label}</span>`;
+    row.appendChild(control);
+    return row;
+  }
+
+  createCheckbox(id, label, checked) {
+    const checkbox = document.createElement('vscode-checkbox');
+    checkbox.id = id;
+    checkbox.checked = checked;
+    checkbox.textContent = label;
+    return checkbox;
+  }
+
+  createSelect(id, options, value) {
+    const select = document.createElement('vscode-single-select');
+    select.id = id;
+    options.forEach(opt => {
+      const option = document.createElement('vscode-option');
+      option.value = opt.value;
+      option.textContent = opt.label;
+      if (opt.value === value) option.selected = true;
+      select.appendChild(option);
+    });
+    return select;
+  }
+}
+```
+
+### Shared CSS Variables (extend common.css)
+```css
+/* settingsView/styles/index.css */
+@import '../../common/styles/common.css';
+
+/* Notion-style settings layout */
+.settings-container {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: var(--spacing-large);
+}
+
+.section {
+  padding: var(--spacing-large) 0;
+}
+
+.section + .section {
+  border-top: 1px solid var(--vscode-widget-border);
+}
+
+.section-header {
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--vscode-descriptionForeground);
+  margin-bottom: var(--spacing-medium);
+}
+
+.setting-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--spacing-small) 0;
+  min-height: 32px;
+}
+
+.setting-label {
+  flex: 0 0 160px;
+  color: var(--vscode-foreground);
+}
+
+.setting-row vscode-single-select,
+.setting-row vscode-textfield {
+  flex: 1;
+  max-width: 300px;
+}
+
+.setting-input-group {
+  display: flex;
+  gap: var(--spacing-small);
+  flex: 1;
+  max-width: 400px;
+}
+
+.setting-input-group vscode-textfield {
+  flex: 1;
+}
+
+/* Hover actions (Notion-style) */
+.item-row .actions {
+  opacity: 0;
+  transition: opacity 0.15s;
+}
+.item-row:hover .actions {
+  opacity: 1;
+}
+```
+
+### Message Handler Composition
+```typescript
+// SettingsViewMessageHandler.ts
+export class SettingsViewMessageHandler extends BaseViewMessageHandler<...> {
+  // Compose handlers from existing views where possible
+  private historyHandlers: HistoryHandlers;
+  private profileHandlers: ProfileHandlers;
+
+  constructor(context: vscode.ExtensionContext) {
+    super('SettingsView');
+    this.historyHandlers = new HistoryHandlers(context);
+    this.profileHandlers = new ProfileHandlers(context);
+  }
+
+  protected createHandlers(): Record<string, MessageHandler<...>> {
+    return {
+      // Models tab
+      [SETTINGS_COMMANDS.GET_MODELS_DATA]: this.handleGetModels.bind(this),
+      [SETTINGS_COMMANDS.SAVE_ENABLED_MODELS]: this.handleSaveModels.bind(this),
+
+      // Agents tab
+      [SETTINGS_COMMANDS.GET_AGENTS_DATA]: this.handleGetAgents.bind(this),
+      [SETTINGS_COMMANDS.SAVE_ENABLED_AGENTS]: this.handleSaveAgents.bind(this),
+
+      // LaTeX tab (direct VS Code config read/write)
+      [SETTINGS_COMMANDS.GET_LATEX_DATA]: this.handleGetLatex.bind(this),
+      [SETTINGS_COMMANDS.SAVE_LATEX_SETTING]: this.handleSaveLatex.bind(this),
+
+      // Delegate to existing handlers
+      ...this.historyHandlers.getHandlers(),
+      ...this.profileHandlers.getHandlers(),
+    };
+  }
+}
+```
+
+### Reducing Boilerplate: Setting Renderer Factory
+```javascript
+// modules/utils/SettingRenderer.js
+export const SettingRenderer = {
+  /** Render a dropdown setting row */
+  dropdown(id, label, options, value, onChange) {
+    return `
+      <div class="setting-row">
+        <span class="setting-label">${label}</span>
+        <vscode-single-select id="${id}" value="${value}">
+          ${options.map(o => `<vscode-option value="${o.value}">${o.label}</vscode-option>`).join('')}
+        </vscode-single-select>
+      </div>
+    `;
+  },
+
+  /** Render a checkbox setting row */
+  checkbox(id, label, checked, description) {
+    return `
+      <div class="setting-row setting-row--checkbox">
+        <vscode-checkbox id="${id}" ${checked ? 'checked' : ''}>
+          ${label}
+        </vscode-checkbox>
+        ${description ? `<span class="setting-description">${description}</span>` : ''}
+      </div>
+    `;
+  },
+
+  /** Render a file path setting row */
+  filePath(id, label, value, placeholder) {
+    return `
+      <div class="setting-row">
+        <span class="setting-label">${label}</span>
+        <div class="setting-input-group">
+          <vscode-textfield id="${id}" value="${value}" placeholder="${placeholder}"></vscode-textfield>
+          <vscode-button appearance="secondary" data-browse="${id}">Browse</vscode-button>
+        </div>
+      </div>
+    `;
+  },
+
+  /** Render a section with settings */
+  section(title, settingsHtml) {
+    return `
+      <div class="section">
+        <div class="section-header">${title}</div>
+        ${settingsHtml}
+      </div>
+    `;
+  }
+};
+```
+
+---
+
+## LaTeX Settings Grouping
+
+Based on actual `package.json` configuration (14 settings total):
+
+### Group 1: Formatter (4 settings)
+| Setting | UI Component |
+|---------|--------------|
+| `texra.latex.formatter` | `<vscode-single-select>` (latexindent/tex-fmt/none) |
+| `texra.latex.latexindentConfig` | `<vscode-textfield>` + Browse |
+| `texra.latex.texfmtConfig` | `<vscode-textfield>` + Browse |
+| `texra.latex.showLatexindentWarning` | `<vscode-checkbox>` |
+
+### Group 2: LaTeXdiff (4 settings)
+| Setting | UI Component |
+|---------|--------------|
+| `texra.latexdiff.mathMarkup` | `<vscode-single-select>` (off/whole/coarse/fine) |
+| `texra.latexdiff.timeoutMs` | `<vscode-textfield type="number">` |
+| `texra.latexdiff.pictureEnvironments` | `<vscode-textfield>` (regex) |
+| `texra.latexdiff.generateBetweenRoundDiffs` | `<vscode-checkbox>` |
+
+### Group 3: TikZ Figures (3 settings)
+| Setting | UI Component |
+|---------|--------------|
+| `texra.latex.tikzInputDirectory` | `<vscode-textfield>` + Browse |
+| `texra.latex.includeWorkspaceInTexinputs` | `<vscode-checkbox>` |
+| `texra.latex.tikzTemplate` | `<vscode-collapsible>` + `<vscode-textarea>` |
+
+### Group 4: Replacements (5 settings) - Collapsible Advanced
+| Setting | UI Component |
+|---------|--------------|
+| `texra.latex.wrapCritiqueInAlign` | `<vscode-checkbox>` |
+| `texra.latex.enabledReplacements` | Checkbox group (14 options) |
+| `texra.latex.enabledReplacementsRegex` | Checkbox group (6 options) |
+| `texra.latex.customReplacements` | `<vscode-collapsible>` + JSON editor |
+| `texra.latex.customReplacementsRegex` | `<vscode-collapsible>` + JSON editor |
+
+---
+
 ## References
 
 - VS Code Elements: `@vscode-elements/elements`
-  - `vscode-tabs`, `vscode-tab-header`, `vscode-tab-panel`
-  - `vscode-collapsible`, `vscode-checkbox`, `vscode-button`
+  - Tabs: `vscode-tabs`, `vscode-tab-header`, `vscode-tab-panel`
+  - Forms: `vscode-single-select`, `vscode-checkbox`, `vscode-textfield`, `vscode-textarea`
+  - Layout: `vscode-collapsible`, `vscode-form-group` (avoid for Notion-style)
+  - Actions: `vscode-button`, `vscode-badge`
+- Base Classes: `src/common/webview/Base*.ts`
+- Shared Styles: `src/common/styles/common.css`
 - LLM Zoo: Model metadata source
-- Existing views: `src/profileView/`, `src/historyView/`
+- Existing views: `src/profileView/`, `src/historyView/`, `src/memoryView/`

--- a/docs/prd/settings-view-unified.md
+++ b/docs/prd/settings-view-unified.md
@@ -118,7 +118,7 @@ VS Code-native styling without custom CSS complexity.
 └─────────────────────────────────────────────────────────────────────────────┘
 ```
 
-**Tab Structure (6 tabs):**
+**Tab Structure (5 tabs for v1):**
 ```
 Tab 1: Models
 ├── Routing options (radio: direct/openrouter/proxy)
@@ -146,7 +146,10 @@ Tab 4: Memory
 
 Tab 5: History
 └── Execution history browser (search, restore, rerun)
+```
 
+**Deferred to Future Release:**
+```
 Tab 6: Advanced
 ├── ▼ Multi-Agent (collapsible) - merge model, future ensemble
 ├── ▼ UI Preferences (collapsible) - reminders, image dimension, sort
@@ -181,7 +184,7 @@ Tab 6: Advanced
     <vscode-tab-header slot="header">LaTeX</vscode-tab-header>
     <vscode-tab-header slot="header">Memory</vscode-tab-header>
     <vscode-tab-header slot="header">History</vscode-tab-header>
-    <vscode-tab-header slot="header">Advanced</vscode-tab-header>
+    <!-- Advanced tab deferred to future release -->
 
     <!-- Models Tab -->
     <vscode-tab-panel>
@@ -254,30 +257,7 @@ Tab 6: Advanced
       </div>
     </vscode-tab-panel>
 
-    <!-- Advanced Tab -->
-    <vscode-tab-panel>
-      <div class="tab-content">
-        <vscode-collapsible title="Multi-Agent">
-          <!-- Merge model + coming soon -->
-        </vscode-collapsible>
-
-        <vscode-collapsible title="Retry Behavior">
-          <!-- Retry settings -->
-        </vscode-collapsible>
-
-        <vscode-collapsible title="Git Integration">
-          <!-- Git settings -->
-        </vscode-collapsible>
-
-        <vscode-collapsible title="System Paths">
-          <!-- Path settings -->
-        </vscode-collapsible>
-
-        <vscode-collapsible title="Debug">
-          <!-- Debug flags -->
-        </vscode-collapsible>
-      </div>
-    </vscode-tab-panel>
+    <!-- Advanced Tab - deferred to future release -->
   </vscode-tabs>
 </div>
 ```
@@ -830,7 +810,9 @@ In the Models tab, show provider/routing status on each model:
 
 ---
 
-### Advanced Tab
+### Advanced Tab (DEFERRED TO FUTURE RELEASE)
+
+> **Note:** This tab is not included in v1. Specifications kept for future reference.
 
 **Purpose:** Multi-agent settings, UI preferences, retry behavior, system paths, and developer options. Uses vscode-collapsible for organization.
 
@@ -916,13 +898,15 @@ In the Models tab, show provider/routing status on each model:
 
 ### Features Summary
 
-**Tab Layout with Header Bar:**
+**Tab Layout with Header Bar (v1 - 5 tabs):**
 - **Header Bar** - Account info, sign in/out, manage account (always visible)
 - **Models Tab** - Provider configuration, model selection, routing options
 - **Agents Tab** - Agent list, Workflow Settings (collapsible), Tool-Use Settings (collapsible)
 - **LaTeX Tab** - Formatter, latexdiff, TikZ (all as collapsibles)
 - **Memory Tab** - Memory file browser with expandable content preview
 - **History Tab** - Execution history browser
+
+**Deferred to Later Release:**
 - **Advanced Tab** - Multi-Agent, UI preferences, git, system paths, debug (all collapsibles)
 
 **Key Features:**
@@ -947,54 +931,48 @@ In the Models tab, show provider/routing status on each model:
 
 ## State Management
 
-### Global State (`context.globalState`)
+### VS Code Configuration (Primary)
 
-Shared across all workspaces, persists per machine.
+Settings View reads/writes directly to VS Code configuration using `ConfigurationTarget`:
 
 ```typescript
-interface GlobalState {
-  // Model preferences - same models everywhere
-  enabledModels: string[];
+const config = vscode.workspace.getConfiguration('texra');
 
-  // Provider configuration (non-secret parts)
-  providerConfig: {
-    [providerId: string]: {
-      customEndpoint?: string;   // Custom base URL (empty = default)
-      enabled: boolean;          // Show in provider list
-    };
-  };
+// Global settings (user-level, all workspaces)
+await config.update('models', enabledModels, ConfigurationTarget.Global);
+await config.update('maxImageDimension', 2048, ConfigurationTarget.Global);
 
-  // Routing preferences
-  routing: {
-    mode: 'direct' | 'openrouter' | 'proxy';  // Global routing strategy
-    openRouterMode: 'exclusive' | 'all';       // Only OR-models vs all
-    proxyDomain?: string;                      // Custom proxy domain
-  };
-
-  // Version for migrations
-  settingsVersion: number;
-}
+// Workspace settings (project-level, .vscode/settings.json)
+await config.update('agents', enabledAgents, ConfigurationTarget.Workspace);
+await config.update('agentOutputs.storageMode', 'folder', ConfigurationTarget.Workspace);
 ```
 
-### Workspace State (`context.workspaceState`)
+**Setting Scopes:**
+| Setting | ConfigurationTarget | Reason |
+|---------|---------------------|--------|
+| `texra.models` | Global | Same models everywhere |
+| `texra.maxImageDimension` | Global | User preference |
+| Provider endpoints | Global | Same API setup everywhere |
+| `texra.agents` | Workspace | Different projects need different agents |
+| `texra.agentOutputs.storageMode` | Workspace | Project-specific output location |
+| `texra.toolUse.*` | Global | Consistent behavior |
+| `texra.latex.*` | Global/Workspace | User choice |
 
-Per-workspace, different projects have different preferences.
+**Benefits of VS Code Config:**
+- No extension state migration needed
+- Works with VS Code Settings Sync automatically
+- Users can still edit settings.json directly
+- Respects VS Code conventions
+
+### Extension State (Minimal)
+
+Only for caching and truly ephemeral UI state:
 
 ```typescript
-interface WorkspaceState {
-  // Agent preferences - different per project
-  enabledAgents: string[];
+// globalState - only for caching
+context.globalState.get('modelMetadataCache');  // Cached llm-zoo data
 
-  // Last selections - restore on reopen
-  lastUsedAgent: string;
-  lastUsedModel: string;
-
-  // Remote agent settings
-  remoteAgentsAutoShow: boolean;
-
-  // Version for migrations
-  settingsVersion: number;
-}
+// No settings stored in extension state
 ```
 
 ### Secret Storage (`context.secrets`)
@@ -1136,190 +1114,25 @@ Users who have configured API keys will continue to work without any action.
 
 ---
 
-### Critical: Extend getConfig for Backwards Compatibility
+### No Migration Needed
 
-**Key Principle:** There is too much logic code using `getConfig()` throughout the codebase. We should NOT break that. Instead, we **extend** `getConfig` to be aware of the new state sources.
+Since Settings View reads/writes directly to VS Code configuration:
 
-**Current Pattern (scattered throughout codebase):**
+1. **Existing settings.json configurations continue to work unchanged**
+2. **No extension state migration required**
+3. **Settings View is just a GUI wrapper around existing VS Code settings**
+
 ```typescript
+// Settings View simply reads and writes VS Code config
 const config = vscode.workspace.getConfiguration('texra');
+
+// Read
 const models = config.get<string[]>('models');
-const useStreaming = config.get<boolean>('model.useStreamingAnthropic');
+
+// Write with appropriate scope
+await config.update('models', newModels, ConfigurationTarget.Global);
+await config.update('agents', newAgents, ConfigurationTarget.Workspace);
 ```
-
-**Extended getConfig Pattern:**
-```typescript
-import { getConfig } from '@common/config';
-
-// getConfig now checks extension state first, then falls back to VS Code config
-const models = getConfig<string[]>('models');           // → Reads globalState first
-const useStreaming = getConfig<boolean>('model.useStreamingAnthropic'); // → Reads providerConfig
-```
-
-**Implementation:**
-```typescript
-// src/common/config.ts
-
-/**
- * Extended configuration getter that supports both extension state and VS Code config.
- *
- * Priority for each setting type:
- * 1. Extension state (globalState/workspaceState) - for settings moved to new UI
- * 2. VS Code config - for backwards compatibility and advanced settings
- * 3. Default value
- *
- * This allows existing code using getConfig to continue working unchanged.
- */
-export function getConfig<T>(key: string, defaultValue?: T): T {
-  const context = getExtensionContext();
-
-  // Settings that have moved to extension state
-  const stateMapping: Record<string, () => T | undefined> = {
-    'models': () => context.globalState.get('enabledModels') as T,
-    'agents': () => context.workspaceState.get('enabledAgents') as T,
-    'toolUseAgents': () => context.workspaceState.get('enabledAgents') as T,
-    'model.useOpenRouter': () => {
-      const routing = context.globalState.get<RoutingConfig>('routing');
-      return (routing?.mode === 'openrouter') as unknown as T;
-    },
-    'model.useImprovedConnection': () => {
-      const routing = context.globalState.get<RoutingConfig>('routing');
-      return (routing?.mode === 'proxy') as unknown as T;
-    },
-    'model.improvedConnectionDomain': () => {
-      const routing = context.globalState.get<RoutingConfig>('routing');
-      return routing?.proxyDomain as T;
-    },
-    // Streaming settings now in provider config
-    'model.useStreamingAnthropic': () => getProviderStreaming('anthropic') as T,
-    'model.useStreamingOpenAI': () => getProviderStreaming('openai') as T,
-    'model.useStreamingGoogle': () => getProviderStreaming('google') as T,
-    // ... etc for all streaming settings
-  };
-
-  // Check extension state first
-  const stateGetter = stateMapping[key];
-  if (stateGetter) {
-    const fromState = stateGetter();
-    if (fromState !== undefined) {
-      return fromState;
-    }
-  }
-
-  // Fall back to VS Code config (existing behavior)
-  const config = vscode.workspace.getConfiguration('texra');
-  return config.get<T>(key, defaultValue as T);
-}
-
-function getProviderStreaming(providerId: string): boolean {
-  const context = getExtensionContext();
-  const providerConfig = context.globalState.get<ProviderConfigMap>('providerConfig');
-  return providerConfig?.[providerId]?.streaming ?? true; // Default: streaming enabled
-}
-```
-
-**Benefits:**
-1. **Zero breaking changes** - Existing `getConfig()` calls continue to work
-2. **Gradual migration** - Settings move to UI without code changes
-3. **Single source of truth** - UI writes to extension state, getConfig reads it
-4. **VS Code config fallback** - Power users can still override via settings.json
-
-**Migration Path:**
-1. Implement extended `getConfig()` with state awareness
-2. Build Settings UI that writes to extension state
-3. Existing code automatically picks up new values
-4. No mass refactoring of `getConfig()` calls needed
-
----
-
-### What Moves to Extension State
-
-| Setting | From | To | Reason |
-|---------|------|-----|--------|
-| `texra.models` | VS Code config | `globalState.enabledModels` | UI in Models tab |
-| `texra.agents` | VS Code config | `workspaceState.enabledAgents` | UI in Agents tab |
-| `texra.toolUseAgents` | VS Code config | `workspaceState.enabledAgents` | Merge with agents |
-| `texra.model.useOpenRouter` | VS Code config | `globalState.routing.mode` | UI in Models tab (routing section) |
-| `texra.model.useImprovedConnection` | VS Code config | `globalState.routing.mode` | UI in Models tab (routing section) |
-| `texra.model.improvedConnectionDomain` | VS Code config | `globalState.routing.proxyDomain` | UI in Models tab (routing section) |
-| `texra.toolUse.persistence.enabled` | VS Code config | `workspaceState.memorySettings` | UI in Memory tab |
-| `texra.toolUse.persistence.ttlHours` | VS Code config | `workspaceState.memorySettings` | UI in Memory tab |
-
-### What Stays in VS Code Config
-
-These remain in VS Code settings (advanced, rarely changed, or system paths):
-
-- `texra.model.useStreaming*` - Provider-specific streaming toggles
-- `texra.model.compactionThresholdPercent` - Advanced context management
-- `texra.model.baseUrlDeepSeek` - Custom endpoint (moved to globalState.providerConfig)
-- `texra.latex.*` - LaTeX formatter settings
-- `texra.files.*` - File handling patterns
-- `texra.latexdiff.*` - Diff settings
-- `texra.logger.*`, `texra.debug.*` - Development settings
-- `texra.audio.soxPath`, `texra.explorer.agentsDirectory` - System paths
-
-### Graceful Migration Strategy
-
-**Principle:** Read from new state first, fallback to VS Code config, never break existing setups.
-
-```typescript
-/**
- * Get enabled models with graceful migration.
- * Priority: globalState > VS Code config > defaults
- */
-function getEnabledModels(context: vscode.ExtensionContext): string[] {
-  // 1. Check new storage first
-  const fromState = context.globalState.get<string[]>('enabledModels');
-  if (fromState !== undefined) {
-    return fromState;
-  }
-
-  // 2. Fallback to VS Code config (existing users)
-  const config = vscode.workspace.getConfiguration('texra');
-  const fromConfig = config.get<string[]>('models');
-  if (fromConfig?.length) {
-    // Auto-migrate on first read
-    context.globalState.update('enabledModels', fromConfig);
-    return fromConfig;
-  }
-
-  // 3. Return defaults
-  return DEFAULT_ENABLED_MODELS;
-}
-
-/**
- * Get routing configuration with migration.
- */
-function getRoutingConfig(context: vscode.ExtensionContext): RoutingConfig {
-  const fromState = context.globalState.get<RoutingConfig>('routing');
-  if (fromState !== undefined) {
-    return fromState;
-  }
-
-  // Migrate from scattered VS Code settings
-  const config = vscode.workspace.getConfiguration('texra.model');
-  const useOpenRouter = config.get<boolean>('useOpenRouter', false);
-  const useProxy = config.get<boolean>('useImprovedConnection', false);
-  const proxyDomain = config.get<string>('improvedConnectionDomain');
-
-  const migrated: RoutingConfig = {
-    mode: useOpenRouter ? 'openrouter' : useProxy ? 'proxy' : 'direct',
-    openRouterMode: 'exclusive',
-    proxyDomain,
-  };
-
-  // Auto-migrate
-  context.globalState.update('routing', migrated);
-  return migrated;
-}
-```
-
-### Migration Timing
-
-1. **On extension activate:** Check and migrate settings lazily (on first read)
-2. **No forced migration:** Users can continue using VS Code config until they open Settings View
-3. **Settings View writes:** Once user saves in Settings View, new storage is used
-4. **VS Code config becomes secondary:** Still works for users who prefer it
 
 ---
 
@@ -1340,13 +1153,13 @@ src/
 │       ├── messageHandlers.js
 │       ├── settingsViewState.js
 │       ├── headerBar.js             # Account header bar logic
-│       ├── tabs/                    # Tab content modules
+│       ├── tabs/                    # Tab content modules (v1)
 │       │   ├── ModelsTab.js         # Models + providers + routing
 │       │   ├── AgentsTab.js         # Agents + collapsible settings
 │       │   ├── LatexTab.js          # LaTeX settings (collapsibles)
 │       │   ├── MemoryTab.js         # Memory files browser
-│       │   ├── HistoryTab.js        # History (migrated)
-│       │   └── AdvancedTab.js       # Multi-Agent, UI, retry, etc.
+│       │   └── HistoryTab.js        # History (migrated)
+│       │   # AdvancedTab.js - deferred to future release
 │       └── uiManagers/
 │           ├── ModelListRenderer.js
 │           ├── ProviderRenderer.js
@@ -1436,43 +1249,45 @@ interface AgentInfo {
 
 ## Success Metrics
 
-1. Single entry point for all configuration
+### v1 Release
+1. Single entry point for 5 core tabs (Models, Agents, LaTeX, Memory, History)
 2. Native vscode-tabs navigation (keyboard accessible)
-3. State properly persisted (models global, agents per-workspace)
+3. Settings properly scoped (models global, agents per-workspace via ConfigurationTarget)
 4. History search and restore working
 5. Account info visible in header bar (minimal custom CSS)
 6. LaTeX settings functional and synced with VS Code config
 7. vscode-collapsible used effectively for subsections
 8. Only header bar needs custom styling (everything else native)
+9. Existing settings.json configurations continue to work unchanged
 
 ---
 
 ## Implementation Phases
 
-### Phase 1: Core Structure + Extended getConfig
+### v1 Release (5 Tabs)
+
+#### Phase 1: Core Structure
 - Create settingsView with vscode-tabs + header bar
 - Implement header bar (account info, sign in/out - minimal custom CSS)
-- Implement extended `getConfig()` with state awareness
-- Wire up globalState for model preferences
-- Test graceful migration from VS Code config
+- Add main webview entry point (gear icon)
+- Deep link support (open to specific tab)
 
-### Phase 2: Models Tab
+#### Phase 2: Models Tab
 - Implement Models tab with provider collapsibles
 - Provider accordions with API status + model list
 - Provider configuration modal (API key + endpoint + streaming toggle)
 - Routing options (radio group at top)
 - Migrate provider config from old profileView
 
-### Phase 3: Agents Tab
+#### Phase 3: Agents Tab
 - Implement Agents tab with agent list
 - Show category badges (workflow/toolUse) and source (built-in/custom/remote)
-- Wire up workspaceState for agent preferences
 - Add Workflow Settings collapsible (output storage mode)
 - Add Tool-Use Settings collapsible (edit approval, persistence, compaction, retry behavior)
 - Include Advanced collapsible (custom agents directory)
 - **Note:** Supersedes FolderExplorer/agent explorer view
 
-### Phase 4: LaTeX Tab
+#### Phase 4: LaTeX Tab
 - Implement LaTeX tab with collapsible sections:
   - Formatter (collapsible)
   - LaTeXdiff (collapsible)
@@ -1481,34 +1296,34 @@ interface AgentInfo {
 - Wire up to existing VS Code configuration
 - Add file browser for config paths
 
-### Phase 5: Memory Tab
+#### Phase 5: Memory Tab
 - Migrate memoryView to Memory tab
 - Implement expandable content preview
 - Delete old memoryView
 
-### Phase 6: History Tab
+#### Phase 6: History Tab + v1 Cleanup
 - Move history rendering to History tab
 - Preserve search, delete, restore, rerun functionality
 - Delete old historyView
-
-### Phase 7: Advanced Tab + Cleanup
-- Implement Advanced tab with collapsible sections:
-  - Multi-Agent (merge model + "Coming Soon")
-  - UI Preferences (reminders, image dimension, sort order)
-  - Git Integration
-  - System Paths
-  - Debug
-- Add main webview entry point (gear icon)
-- Deep link support (open to specific tab)
-- Verify graceful migration (no breaking existing setups)
 - Remove deprecated views (profileView, historyView, memoryView)
 - Remove FolderExplorer/agent explorer (superseded)
 - Documentation
 
-### Future Scope (Deferred)
-- **Agent Creation Wizard** - AI-assisted agent creation from plain English description
-- **Agent Edit Form** - Form-based editing without YAML knowledge
-- **Multi-Agent Ensemble** - Run across multiple models with voting/consensus
+### Future Release (Deferred)
+
+#### Advanced Tab
+- Multi-Agent (merge model + ensemble features)
+- UI Preferences (reminders, image dimension, sort order)
+- Git Integration
+- System Paths
+- Debug
+
+#### Agent Creation Wizard
+- AI-assisted agent creation from plain English description
+- Form-based editing without YAML knowledge
+
+#### Multi-Agent Ensemble
+- Run across multiple models with voting/consensus
 
 ---
 
@@ -1516,29 +1331,33 @@ interface AgentInfo {
 
 Based on 79 total settings in package.json:
 
-### Now Covered by Settings View (47 settings)
+### v1 Release - Covered by Settings View
 
-| Section | Settings Covered |
-|---------|------------------|
-| **General** | `texra.ui.*` (3), `texra.progressBoard.streamSortOrder`, `texra.maxImageDimension` |
-| **Agents (main)** | `texra.agents`, `texra.toolUseAgents`, `texra.remoteAgents.autoShowIfAvailable`, `texra.explorer.agentsDirectory` |
-| **Agents → Workflow** | `texra.agentOutputs.storageMode` |
-| **Agents → Tool-Use** | `texra.toolUse.requireEditApproval`, `texra.toolUse.persistence.*` (2), `texra.model.compactionThresholdPercent` |
-| **Models & Providers** | `texra.models`, `texra.model.useStreaming*` (9), `texra.model.useOpenRouter`, `texra.model.useImprovedConnection`, `texra.model.improvedConnectionDomain`, `texra.model.baseUrlDeepSeek` |
-| **Multi-Agent** | `texra.merge.defaultModel` |
+| Tab | Settings Covered |
+|-----|------------------|
+| **Models** | `texra.models`, `texra.model.useStreaming*` (9), `texra.model.useOpenRouter`, `texra.model.useImprovedConnection`, `texra.model.improvedConnectionDomain`, `texra.model.baseUrlDeepSeek` |
+| **Agents** | `texra.agents`, `texra.toolUseAgents`, `texra.remoteAgents.autoShow`, `texra.explorer.agentsDirectory`, `texra.agentOutputs.storageMode`, `texra.toolUse.*` (3), `texra.model.compactionThresholdPercent`, `texra.model.retry.*` (2) |
 | **LaTeX** | `texra.latex.*` (7), `texra.latexdiff.*` (4) |
 | **Memory** | Memory file browser (no config, file system) |
 | **History** | History browser (existing storage) |
-| **Advanced** | `texra.model.retry.*` (2), `texra.git.numberOfCommitsToShow`, `texra.audio.soxPath`, `texra.debug.*` |
 
-### Remain as VS Code Settings Only (32 settings)
+### Deferred to Future Release (Advanced Tab)
+
+| Section | Settings |
+|---------|----------|
+| **Multi-Agent** | `texra.merge.defaultModel` |
+| **UI Preferences** | `texra.ui.*` (3), `texra.progressBoard.streamSortOrder`, `texra.maxImageDimension` |
+| **Git Integration** | `texra.git.numberOfCommitsToShow` |
+| **System Paths** | `texra.audio.soxPath` |
+| **Debug** | `texra.debug.*`, `texra.logger.*` |
+
+### Remain as VS Code Settings Only
 These are advanced/power-user settings that don't need UI exposure:
 
 - `texra.files.*` (16) - File type filtering patterns (power user)
-- `texra.logger.*` (2) - Logging configuration
 - `texra.auth.*` (3) - System-level authentication endpoints
 - `texra.remoteAgents.cacheTimeHours` (1) - Advanced cache behavior
-- Other system-level paths and debug flags (10)
+- Other system-level paths and debug flags
 
 ---
 
@@ -1563,13 +1382,13 @@ Key integration points that need updating when implementing the Settings View:
 ### 3. Dropdown Options Computation
 | Function | File | Impact |
 |----------|------|--------|
-| `computeAgentOptions()` | `src/agent/index/agentRegistry.ts` | Read from workspaceState instead of VS Code config |
-| `computeModelOptions()` | `src/model/computeModelOptions.ts` | Read from globalState instead of VS Code config |
+| `computeAgentOptions()` | `src/agent/index/agentRegistry.ts` | No change - still reads VS Code config |
+| `computeModelOptions()` | `src/model/computeModelOptions.ts` | No change - still reads VS Code config |
 
 ### 4. Configuration Watchers
-`src/MainViewProvider.ts` (lines 84-120) watches for config changes. Update to:
-- Watch globalState/workspaceState changes instead
-- Or keep VS Code config watchers for backwards compatibility during migration
+`src/MainViewProvider.ts` (lines 84-120) watches for config changes.
+- No change needed - Settings View writes to VS Code config
+- Existing watchers will pick up changes automatically
 
 ### 5. View Registrations (package.json)
 | View | Current | After Implementation |
@@ -1587,16 +1406,8 @@ Key integration points that need updating when implementing the Settings View:
 | `HistoryViewMessageHandler` | `src/historyView/` | `src/settingsView/` (compose) |
 | `MemoryViewMessageHandler` | `src/memoryView/` | `src/settingsView/` (compose) |
 
-### 7. State Migration Points
-```typescript
-// Settings that move FROM VS Code config TO extension state:
-'texra.agents'           → workspaceState.enabledAgents
-'texra.toolUseAgents'    → workspaceState.enabledAgents (merge)
-'texra.models'           → globalState.enabledModels
-'texra.model.useOpenRouter'           → globalState.routing.mode
-'texra.model.useImprovedConnection'   → globalState.routing.mode
-'texra.model.improvedConnectionDomain' → globalState.routing.proxyDomain
-```
+### 7. No State Migration Needed
+Settings View reads/writes directly to VS Code configuration - no migration required.
 
 ---
 

--- a/docs/prd/settings-view-unified.md
+++ b/docs/prd/settings-view-unified.md
@@ -16,12 +16,12 @@ Create a unified Settings View that consolidates model configuration, agent conf
 ## Goals
 
 1. **Single source of truth** - All configuration in one place
-2. **Easy navigation** - Sidebar navigation (Cursor-style) with logical groupings
-3. **No auth required** - Most sections work without login (except account features)
-4. **VS Code native** - Use VS Code elements and styling patterns
+2. **Easy navigation** - vscode-tabs with logical groupings, vscode-collapsible for subsections
+3. **No auth required** - Most tabs work without login (except account features in header)
+4. **VS Code native** - Use vscode-tabs, vscode-collapsible, vscode-form-group (native components)
 5. **Proper state management** - Global vs workspace state separation
 6. **Backwards compatible** - Extend getConfig rather than replacing it; graceful migration
-7. **Cursor-style clarity** - Clean sidebar + content layout, searchable settings
+7. **Minimal custom CSS** - Only header bar needs custom styling, everything else native
 
 ---
 
@@ -73,165 +73,256 @@ Single entry point from main webview:
 
 Clicking ⚙️ (codicon: `settings-gear`) opens the unified Settings View.
 
-### Sidebar Navigation (Cursor-style)
+### Header Bar + Tabs Layout
 
-Instead of horizontal tabs, use a sidebar navigation like Cursor Settings for better organization
-and scalability.
+Use native `vscode-tabs` for navigation with an account header bar at the top. This provides
+VS Code-native styling without custom CSS complexity.
 
 ```
-┌──────────────────────────────────────────────────────────────────────────────┐
-│  TeXRA Settings                                                       [×]   │
-├────────────────────────┬─────────────────────────────────────────────────────┤
-│                        │                                                     │
-│  user@example.com      │  General                                            │
-│  Pro Plan              │  ─────────────────────────────────────────────────  │
-│                        │                                                     │
-│  ┌──────────────────┐  │  Manage Account                                     │
-│  │ Search ⌘F        │  │  Manage your account and billing            [Open]  │
-│  └──────────────────┘  │                                                     │
-│                        │  ─────────────────────────────────────────────────  │
-│  ⚙️ General            │                                                     │
-│  ∞ Agents              │  Preferences                                        │
-│    → Workflow          │  ─────────────────────────────────────────────────  │
-│    → Tool-Use          │                                                     │
-│  ◎ Models & Providers  │  ☑ Show quick pick for agent selection             │
-│  ⚡ Multi-Agent        │    Use VS Code quick pick instead of dropdown.      │
-│                        │                                                     │
-│  ─────────────────     │  ☑ Show quick pick for model selection             │
-│  📄 LaTeX              │    Use VS Code quick pick instead of dropdown.      │
-│  🧠 Memory             │                                                     │
-│  📜 History            │  Max image dimension: [2048 ▼]                      │
-│                        │    Options: 1024, 2048, 4096                        │
-│  ─────────────────     │                                                     │
-│  🔧 Advanced           │  Progress board sort: [Timestamp descending ▼]      │
-│                        │                                                     │
-│  ─────────────────     │                                                     │
-│  📖 Docs ↗             │                                                     │
-│                        │                                                     │
-└────────────────────────┴─────────────────────────────────────────────────────┘
+┌─────────────────────────────────────────────────────────────────────────────┐
+│  👤 user@example.com • Pro Plan                    [Manage] [Sign Out] [×]  │
+├─────────────────────────────────────────────────────────────────────────────┤
+│  [Models]  Agents  LaTeX  Memory  History  Advanced                         │
+│  ═══════                                                                    │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                             │
+│  Tab content with vscode-collapsible for subsections                        │
+│                                                                             │
+│  ▼ Recommended Models                                                       │
+│  ┌─────────────────────────────────────────────────────────────────────┐    │
+│  │ ☑ Claude Sonnet 4.5 T    Anthropic   $3/$15    200K  🧠👁           │    │
+│  │ ☑ GPT-5.2                OpenAI      $2/$10    256K  🧠👁           │    │
+│  └─────────────────────────────────────────────────────────────────────┘    │
+│                                                                             │
+│  ▼ Anthropic                                       ✓ API Key  [Configure]   │
+│  ┌─────────────────────────────────────────────────────────────────────┐    │
+│  │ ☑ Claude Sonnet 4.5 T     200K   $3/$15    🧠👁📄                   │    │
+│  │ ☑ Claude Opus 4.5 T       200K   $15/$75   🧠👁📄🎧                 │    │
+│  └─────────────────────────────────────────────────────────────────────┘    │
+│                                                                             │
+│  ▶ OpenAI (28)                                     ✓ API Key  [Configure]   │
+│  ▶ Google (6)                                      ✗ No Key   [Configure]   │
+│                                                                             │
+└─────────────────────────────────────────────────────────────────────────────┘
 ```
 
-**Navigation Structure:**
+**Not Logged In State:**
 ```
-Account (top)
-  └── Email, Plan info
-
-Search settings ⌘F
-
-Section 1: Core
-├── General          - Account, UI preferences
-├── Agents           - Agent list and settings
-│   ├── Workflow     - Workflow agent output settings
-│   └── Tool-Use     - Tool-use agent settings (edit approval, compaction)
-├── Models & Providers - Combined model selection + API providers
-└── Multi-Agent      - Merge operations settings (future features noted)
-
-Section 2: Features
-├── LaTeX            - Formatter, latexdiff, TikZ
-├── Memory           - Memory files browser (expandable)
-└── History          - Execution history
-
-Section 3: System
-└── Advanced         - System paths, debug, retry settings
-
-Footer
-└── Docs ↗           - Link to documentation
+┌─────────────────────────────────────────────────────────────────────────────┐
+│  Use TeXRA with your own API keys                         [Sign In]    [×]  │
+├─────────────────────────────────────────────────────────────────────────────┤
+│  [Models]  Agents  LaTeX  Memory  History  Advanced                         │
+│  ═══════                                                                    │
+├─────────────────────────────────────────────────────────────────────────────┤
+│  ...                                                                        │
+└─────────────────────────────────────────────────────────────────────────────┘
 ```
 
-### HTML Structure (sidebar layout)
+**Tab Structure (6 tabs):**
+```
+Tab 1: Models
+├── Routing options (radio: direct/openrouter/proxy)
+├── ▼ Recommended Models (collapsible)
+└── Provider accordions (collapsible per provider)
+    └── Model checkboxes + [Configure] for API key
+
+Tab 2: Agents
+├── Built-in agents list
+├── Custom agents list
+├── Remote agents (if logged in)
+├── ▼ Workflow Settings (collapsible subsection)
+│   └── Output storage mode
+└── ▼ Tool-Use Settings (collapsible subsection)
+    └── Edit approval, persistence, compaction
+
+Tab 3: LaTeX
+├── ▼ Formatter (collapsible)
+├── ▼ LaTeXdiff (collapsible)
+├── ▼ TikZ Figures (collapsible)
+└── ▼ Replacements (collapsible, advanced)
+
+Tab 4: Memory
+└── Memory file browser with expandable content preview
+
+Tab 5: History
+└── Execution history browser (search, restore, rerun)
+
+Tab 6: Advanced
+├── ▼ Multi-Agent (collapsible) - merge model, future ensemble
+├── ▼ Retry Behavior (collapsible)
+├── ▼ Git Integration (collapsible)
+├── ▼ System Paths (collapsible)
+└── ▼ Debug (collapsible)
+```
+
+### HTML Structure (vscode-tabs + header bar)
 
 ```html
 <div class="settings-container">
-  <aside class="settings-sidebar">
-    <div class="account-section">
+  <!-- Header Bar (only custom CSS needed) -->
+  <header class="settings-header">
+    <div class="account-info">
+      <!-- Logged in state -->
+      <span class="codicon codicon-account"></span>
       <span class="user-email">user@example.com</span>
+      <span class="separator">•</span>
       <span class="user-plan">Pro Plan</span>
     </div>
+    <div class="account-actions">
+      <vscode-button appearance="secondary">Manage</vscode-button>
+      <vscode-button appearance="secondary">Sign Out</vscode-button>
+    </div>
+  </header>
 
-    <vscode-textfield placeholder="Search settings ⌘F" class="search-input">
-    </vscode-textfield>
+  <!-- Native vscode-tabs (no custom CSS) -->
+  <vscode-tabs selected-index="0">
+    <vscode-tab-header slot="header">Models</vscode-tab-header>
+    <vscode-tab-header slot="header">Agents</vscode-tab-header>
+    <vscode-tab-header slot="header">LaTeX</vscode-tab-header>
+    <vscode-tab-header slot="header">Memory</vscode-tab-header>
+    <vscode-tab-header slot="header">History</vscode-tab-header>
+    <vscode-tab-header slot="header">Advanced</vscode-tab-header>
 
-    <nav class="settings-nav">
-      <div class="nav-section">
-        <a href="#general" class="nav-item active">$(settings-gear) General</a>
-        <a href="#agents" class="nav-item">$(symbol-misc) Agents</a>
-        <a href="#agents-workflow" class="nav-item nav-subitem">→ Workflow</a>
-        <a href="#agents-tooluse" class="nav-item nav-subitem">→ Tool-Use</a>
-        <a href="#models" class="nav-item">$(server) Models & Providers</a>
-        <a href="#multiagent" class="nav-item">$(combine) Multi-Agent</a>
+    <!-- Models Tab -->
+    <vscode-tab-panel>
+      <div class="tab-content">
+        <vscode-collapsible title="Recommended Models" open>
+          <!-- Model checkboxes -->
+        </vscode-collapsible>
+
+        <vscode-collapsible title="Anthropic" open>
+          <!-- Provider models + Configure button -->
+        </vscode-collapsible>
+
+        <vscode-collapsible title="OpenAI">
+          <!-- Provider models + Configure button -->
+        </vscode-collapsible>
+        <!-- More providers... -->
       </div>
+    </vscode-tab-panel>
 
-      <div class="nav-section">
-        <a href="#latex" class="nav-item">$(file-code) LaTeX</a>
-        <a href="#memory" class="nav-item">$(database) Memory</a>
-        <a href="#history" class="nav-item">$(history) History</a>
+    <!-- Agents Tab -->
+    <vscode-tab-panel>
+      <div class="tab-content">
+        <!-- Agent list (no collapsible needed for main content) -->
+        <div class="agents-list">
+          <!-- Agent checkboxes with badges -->
+        </div>
+
+        <vscode-collapsible title="Workflow Settings">
+          <!-- Output storage mode -->
+        </vscode-collapsible>
+
+        <vscode-collapsible title="Tool-Use Settings">
+          <!-- Edit approval, persistence, compaction -->
+        </vscode-collapsible>
       </div>
+    </vscode-tab-panel>
 
-      <div class="nav-section">
-        <a href="#advanced" class="nav-item">$(tools) Advanced</a>
+    <!-- LaTeX Tab -->
+    <vscode-tab-panel>
+      <div class="tab-content">
+        <vscode-collapsible title="Formatter" open>
+          <!-- Formatter settings -->
+        </vscode-collapsible>
+
+        <vscode-collapsible title="LaTeXdiff">
+          <!-- Diff settings -->
+        </vscode-collapsible>
+
+        <vscode-collapsible title="TikZ Figures">
+          <!-- TikZ settings -->
+        </vscode-collapsible>
+
+        <vscode-collapsible title="Replacements">
+          <!-- Replacement rules -->
+        </vscode-collapsible>
       </div>
+    </vscode-tab-panel>
 
-      <div class="nav-section nav-footer">
-        <a href="https://docs.texra.ai" class="nav-item">$(book) Docs ↗</a>
+    <!-- Memory Tab -->
+    <vscode-tab-panel>
+      <div class="tab-content">
+        <!-- Memory file browser -->
       </div>
-    </nav>
-  </aside>
+    </vscode-tab-panel>
 
-  <main class="settings-content">
-    <!-- Content for selected section -->
-  </main>
+    <!-- History Tab -->
+    <vscode-tab-panel>
+      <div class="tab-content">
+        <!-- History browser -->
+      </div>
+    </vscode-tab-panel>
+
+    <!-- Advanced Tab -->
+    <vscode-tab-panel>
+      <div class="tab-content">
+        <vscode-collapsible title="Multi-Agent">
+          <!-- Merge model + coming soon -->
+        </vscode-collapsible>
+
+        <vscode-collapsible title="Retry Behavior">
+          <!-- Retry settings -->
+        </vscode-collapsible>
+
+        <vscode-collapsible title="Git Integration">
+          <!-- Git settings -->
+        </vscode-collapsible>
+
+        <vscode-collapsible title="System Paths">
+          <!-- Path settings -->
+        </vscode-collapsible>
+
+        <vscode-collapsible title="Debug">
+          <!-- Debug flags -->
+        </vscode-collapsible>
+      </div>
+    </vscode-tab-panel>
+  </vscode-tabs>
 </div>
 ```
 
----
+### Header Bar CSS (minimal custom styles)
 
-## Section Specifications
+```css
+/* Only custom CSS needed - everything else is native vscode-elements */
+.settings-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: var(--spacing-medium);
+  border-bottom: 1px solid var(--vscode-widget-border);
+  background: var(--vscode-sideBar-background);
+}
 
-### General Section
+.account-info {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-small);
+  color: var(--vscode-foreground);
+}
 
-**Purpose:** Account management and general UI preferences. Shown when user clicks "General" in sidebar.
+.account-info .separator {
+  color: var(--vscode-descriptionForeground);
+}
 
-**Layout:**
+.account-actions {
+  display: flex;
+  gap: var(--spacing-small);
+}
+
+/* Tab content padding */
+.tab-content {
+  padding: var(--spacing-large);
+  max-width: 720px;
+}
 ```
-┌─────────────────────────────────────────────────────────────────┐
-│  General                                                        │
-│  ─────────────────────────────────────────────────────────────  │
-│                                                                 │
-│  Manage Account                                                 │
-│  Manage your account and billing                     [Open ↗]  │
-│                                                                 │
-│  ─────────────────────────────────────────────────────────────  │
-│                                                                 │
-│  Preferences                                                    │
-│  ─────────────────────────────────────────────────────────────  │
-│                                                                 │
-│  ☑ Show quick pick for agent selection                          │
-│    Use VS Code quick pick instead of dropdown for agents.      │
-│                                                                 │
-│  ☑ Show quick pick for model selection                          │
-│    Use VS Code quick pick instead of dropdown for models.      │
-│                                                                 │
-│  Max image dimension: [2048 ▼]                                 │
-│    Larger images will be resized before sending to models.     │
-│    Options: 1024, 2048, 4096                                   │
-│                                                                 │
-│  Progress board sort: [Timestamp descending ▼]                 │
-│    Options: Timestamp ascending, Timestamp descending          │
-│                                                                 │
-└─────────────────────────────────────────────────────────────────┘
-```
-
-**Settings Mapping:**
-| UI Element | VS Code Setting |
-|------------|-----------------|
-| Agent quick pick checkbox | `texra.ui.showAgentQuickPick` |
-| Model quick pick checkbox | `texra.ui.showModelQuickPick` |
-| Max image dimension dropdown | `texra.maxImageDimension` |
-| Progress board sort dropdown | `texra.progressBoard.streamSortOrder` |
 
 ---
 
-### Models & Providers Section
+## Tab Specifications
+
+### Models Tab
 
 **Purpose:** Combined model selection and API provider configuration. Each provider shows API status + model selection together.
 
@@ -311,9 +402,9 @@ const RECOMMENDED_MODELS = [
 
 ---
 
-### Agents Section (Main)
+### Agents Tab
 
-**Purpose:** View and enable/disable agents. Supersedes the FolderExplorer/agent explorer.
+**Purpose:** View and enable/disable agents, plus agent-specific settings. Supersedes the FolderExplorer/agent explorer.
 
 **Scope (Phase 1):** View-only with enable/disable. Agent creation wizard deferred to Future Scope.
 
@@ -338,8 +429,6 @@ const RECOMMENDED_MODELS = [
 **Layout:**
 ```
 ┌─────────────────────────────────────────────────────────────────┐
-│  Agents                                                         │
-│  ─────────────────────────────────────────────────────────────  │
 │  Select which agents appear in the dropdown.                    │
 │  Settings are saved per workspace.                              │
 │                                                                 │
@@ -380,6 +469,31 @@ const RECOMMENDED_MODELS = [
 │  │  🔒 Sign in to access shared team agents       [Sign In]  │  │
 │  └───────────────────────────────────────────────────────────┘  │
 │                                                                 │
+│  ─────────────────────────────────────────────────────────────  │
+│                                                                 │
+│  ▼ Workflow Settings                                           │
+│  ┌───────────────────────────────────────────────────────────┐  │
+│  │ Settings for workflow agents (correct, polish, etc.)      │  │
+│  │                                                           │  │
+│  │ Storage mode: [Folder ▼]                                  │  │
+│  │   How to store agent outputs.                             │  │
+│  │   Options: In-place (overwrite), Folder (texra-outputs/)  │  │
+│  └───────────────────────────────────────────────────────────┘  │
+│                                                                 │
+│  ▼ Tool-Use Settings                                           │
+│  ┌───────────────────────────────────────────────────────────┐  │
+│  │ Settings for tool-use agents (chat, research, etc.)       │  │
+│  │                                                           │  │
+│  │ ☑ Require approval before file edits                      │  │
+│  │   Show diff preview and require confirmation.             │  │
+│  │                                                           │  │
+│  │ ☑ Persist sessions across VS Code restarts                │  │
+│  │   Session retention: [72 hours ▼]                         │  │
+│  │                                                           │  │
+│  │ Compaction threshold: [85 %]                              │  │
+│  │   Compact context when usage exceeds this percentage.     │  │
+│  └───────────────────────────────────────────────────────────┘  │
+│                                                                 │
 │  ▶ Advanced                                                    │
 │  ┌───────────────────────────────────────────────────────────┐  │
 │  │ Custom agents directory: [.texra/agents       ] [Browse]  │  │
@@ -398,131 +512,18 @@ const RECOMMENDED_MODELS = [
 | UI Element | VS Code Setting |
 |------------|-----------------|
 | Auto-show remote agents | `texra.remoteAgents.autoShowIfAvailable` |
-| Custom agents directory | `texra.explorer.agentsDirectory` (Advanced) |
-
-**Storage:** `workspaceState.enabledAgents: string[]`
-
----
-
-### Agents → Workflow (Subsection)
-
-**Purpose:** Settings specific to workflow agents (non-tool-use agents).
-
-**Layout:**
-```
-┌─────────────────────────────────────────────────────────────────┐
-│  Agents → Workflow                                              │
-│  ─────────────────────────────────────────────────────────────  │
-│  Settings for workflow agents (correct, polish, translate...).  │
-│                                                                 │
-│  OUTPUT STORAGE                                                 │
-│  ─────────────────────────────────────────────────────────────  │
-│                                                                 │
-│  Storage mode: [Folder ▼]                                      │
-│    How to store agent outputs.                                 │
-│    Options: In-place (overwrite), Folder (texra-outputs/)      │
-│                                                                 │
-└─────────────────────────────────────────────────────────────────┘
-```
-
-**Settings Mapping:**
-| UI Element | VS Code Setting |
-|------------|-----------------|
 | Storage mode dropdown | `texra.agentOutputs.storageMode` |
-
----
-
-### Agents → Tool-Use (Subsection)
-
-**Purpose:** Settings specific to tool-use agents (chat, research, etc.).
-
-**Layout:**
-```
-┌─────────────────────────────────────────────────────────────────┐
-│  Agents → Tool-Use                                              │
-│  ─────────────────────────────────────────────────────────────  │
-│  Settings for tool-use agents (chat, research...).              │
-│                                                                 │
-│  EDIT APPROVAL                                                  │
-│  ─────────────────────────────────────────────────────────────  │
-│                                                                 │
-│  ☑ Require approval before file edits                          │
-│    Show diff preview and require confirmation before            │
-│    tool-use agents modify files.                                │
-│                                                                 │
-│  ─────────────────────────────────────────────────────────────  │
-│                                                                 │
-│  SESSION PERSISTENCE                                            │
-│  ─────────────────────────────────────────────────────────────  │
-│                                                                 │
-│  ☑ Persist tool-use sessions across VS Code restarts           │
-│    Sessions are saved and can be resumed later.                │
-│                                                                 │
-│  Session retention: [72 hours ▼]                               │
-│    Options: 24h, 48h, 72h, 1 week, 2 weeks                     │
-│                                                                 │
-│  ─────────────────────────────────────────────────────────────  │
-│                                                                 │
-│  CONTEXT MANAGEMENT                                             │
-│  ─────────────────────────────────────────────────────────────  │
-│                                                                 │
-│  Compaction threshold: [85 %]                                  │
-│    Compact context when usage exceeds this percentage.          │
-│    Range: 50-95%                                                │
-│                                                                 │
-└─────────────────────────────────────────────────────────────────┘
-```
-
-**Settings Mapping:**
-| UI Element | VS Code Setting |
-|------------|-----------------|
 | Require approval checkbox | `texra.toolUse.requireEditApproval` |
 | Persist sessions checkbox | `texra.toolUse.persistence.enabled` |
 | Session retention dropdown | `texra.toolUse.persistence.ttlHours` |
 | Compaction threshold | `texra.model.compactionThresholdPercent` |
+| Custom agents directory | `texra.explorer.agentsDirectory` (Advanced collapsible) |
 
-**Storage:** VS Code configuration (for backwards compatibility via extended getConfig)
-
----
-
-### Multi-Agent Section
-
-**Purpose:** Configure multi-agent operations (merge, ensemble). Some features awaiting future development.
-
-**Layout:**
-```
-┌─────────────────────────────────────────────────────────────────┐
-│  Multi-Agent                                                    │
-│  ─────────────────────────────────────────────────────────────  │
-│  Configure multi-agent operations and ensemble runs.            │
-│                                                                 │
-│  MERGE SETTINGS                                                 │
-│  ─────────────────────────────────────────────────────────────  │
-│                                                                 │
-│  Default merge model: [Claude Sonnet 4.5 ▼]                    │
-│    Model used for combining outputs from multiple agents.       │
-│                                                                 │
-│  ─────────────────────────────────────────────────────────────  │
-│                                                                 │
-│  COMING SOON                                                    │
-│  ─────────────────────────────────────────────────────────────  │
-│  • Ensemble runs across multiple models                         │
-│  • Agent pipeline configurations                                │
-│  • Output voting and consensus                                  │
-│                                                                 │
-└─────────────────────────────────────────────────────────────────┘
-```
-
-**Settings Mapping:**
-| UI Element | VS Code Setting |
-|------------|-----------------|
-| Default merge model | `texra.merge.defaultModel` |
-
-**Note:** This section is included now but some features are awaiting multi-agent feature maturity.
+**Storage:** `workspaceState.enabledAgents: string[]`, VS Code configuration for settings
 
 ---
 
-### LaTeX Section
+### LaTeX Tab
 
 **Purpose:** Configure LaTeX formatting, latexdiff, and TikZ compilation settings.
 
@@ -621,11 +622,11 @@ const RECOMMENDED_MODELS = [
 
 ---
 
-### Memory Section
+### Memory Tab
 
 **Purpose:** Browse and manage persistent memory files created by tool-use agents.
 
-**Note:** Tool-use settings (edit approval, session persistence) are in Agents → Tool-Use.
+**Note:** Tool-use settings (edit approval, session persistence) are in the Agents tab under Tool-Use Settings collapsible.
 
 **Key Design:** Show memory content on expand (like current memoryView implementation).
 
@@ -677,7 +678,7 @@ const RECOMMENDED_MODELS = [
 
 ---
 
-### History Section
+### History Tab
 
 **Purpose:** Browse and restore previous agent executions.
 
@@ -715,122 +716,7 @@ const RECOMMENDED_MODELS = [
 
 ---
 
-### Profile Tab
-
-**Purpose:** Account management, API provider configuration, and routing settings.
-
-**Layout (Logged In):**
-```
-┌─────────────────────────────────────────────────────────────────┐
-│                                                                 │
-│  ACCOUNT                                                       │
-│  ┌─────────────────────────────────────────────────────────┐    │
-│  │  👤 user@example.com                        [Sign Out]  │    │
-│  │     Pro Plan • Ultra Tier                               │    │
-│  │     Access expires: Feb 15, 2026                        │    │
-│  └─────────────────────────────────────────────────────────┘    │
-│                                                                 │
-│  MODEL ACCESS MODE                                             │
-│  ─────────────────────────────────────────────────────────────  │
-│  ● Use Included Access                                         │
-│    Works automatically. No setup needed.                       │
-│    ▶ View included providers & models                          │
-│                                                                 │
-│  ○ Use My Own API Keys                                         │
-│    Configure providers below.                                  │
-│                                                                 │
-│  ─────────────────────────────────────────────────────────────  │
-│                                                                 │
-│  API PROVIDERS                                                 │
-│  ─────────────────────────────────────────────────────────────  │
-│  Configure API keys and endpoints for each provider.           │
-│                                                                 │
-│  ┌───────────────────────────────────────────────────────────┐  │
-│  │ Anthropic                                        [Edit]  │  │
-│  │ ✓ API Key configured                                     │  │
-│  │ Endpoint: default                                        │  │
-│  └───────────────────────────────────────────────────────────┘  │
-│                                                                 │
-│  ┌───────────────────────────────────────────────────────────┐  │
-│  │ OpenAI                                           [Edit]  │  │
-│  │ ✓ API Key configured                                     │  │
-│  │ Endpoint: default                                        │  │
-│  └───────────────────────────────────────────────────────────┘  │
-│                                                                 │
-│  ┌───────────────────────────────────────────────────────────┐  │
-│  │ Google                                      [Configure]  │  │
-│  │ ✗ API Key not set                                        │  │
-│  └───────────────────────────────────────────────────────────┘  │
-│                                                                 │
-│  ┌───────────────────────────────────────────────────────────┐  │
-│  │ OpenRouter                                  [Configure]  │  │
-│  │ ✗ API Key not set                                        │  │
-│  │ ℹ Route multiple providers through one API key           │  │
-│  └───────────────────────────────────────────────────────────┘  │
-│                                                                 │
-│  ▶ More providers (DeepSeek, xAI, Moonshot, DashScope)         │
-│                                                                 │
-│  ─────────────────────────────────────────────────────────────  │
-│                                                                 │
-│  ROUTING OPTIONS                                               │
-│  ─────────────────────────────────────────────────────────────  │
-│  ● Direct to providers (recommended)                           │
-│    Connect directly to each provider's API                     │
-│                                                                 │
-│  ○ Route all through OpenRouter                                │
-│    Use OpenRouter for unified billing (requires OpenRouter key)│
-│                                                                 │
-│  ○ Use connection proxy                                        │
-│    Route through proxy.texra.ai for improved connectivity      │
-│                                                                 │
-└─────────────────────────────────────────────────────────────────┘
-```
-
-**Layout (Not Logged In):**
-```
-┌─────────────────────────────────────────────────────────────────┐
-│                                                                 │
-│  ACCOUNT                                                       │
-│  ┌─────────────────────────────────────────────────────────┐    │
-│  │  Use TeXRA with your own API keys            [Sign In]  │    │
-│  │  Sign in to sync settings across devices                │    │
-│  └─────────────────────────────────────────────────────────┘    │
-│                                                                 │
-│  API PROVIDERS                                                 │
-│  ─────────────────────────────────────────────────────────────  │
-│  Configure API keys to use AI models.                          │
-│                                                                 │
-│  ┌───────────────────────────────────────────────────────────┐  │
-│  │ Anthropic                               [Configure]      │  │
-│  │ ✗ API Key not set                                        │  │
-│  │ Models: Claude Sonnet 4.5, Claude Opus 4.5, ...          │  │
-│  └───────────────────────────────────────────────────────────┘  │
-│                                                                 │
-│  ┌───────────────────────────────────────────────────────────┐  │
-│  │ OpenAI                                  [Configure]      │  │
-│  │ ✗ API Key not set                                        │  │
-│  │ Models: GPT-5.2, GPT-4.1, o4-mini, ...                   │  │
-│  └───────────────────────────────────────────────────────────┘  │
-│                                                                 │
-│  ┌───────────────────────────────────────────────────────────┐  │
-│  │ OpenRouter                              [Configure]      │  │
-│  │ ✗ API Key not set                                        │  │
-│  │ ℹ Access ALL providers with a single API key             │  │
-│  │   Get your key at openrouter.ai/keys                     │  │
-│  └───────────────────────────────────────────────────────────┘  │
-│                                                                 │
-│  ▶ More providers (Google, DeepSeek, xAI, Moonshot, DashScope) │
-│                                                                 │
-│  ─────────────────────────────────────────────────────────────  │
-│                                                                 │
-│  💡 TIP: Use OpenRouter to access all models with one key      │
-│                                                                 │
-└─────────────────────────────────────────────────────────────────┘
-```
-
----
-
-### Provider Configuration Modal
+### Provider Configuration Modal (from Models Tab)
 
 When clicking [Edit] or [Configure] on a provider:
 
@@ -934,50 +820,68 @@ In the Models tab, show provider/routing status on each model:
 
 ---
 
-### Advanced Section
+### Advanced Tab
 
-**Purpose:** System-level settings, paths, retry behavior, and developer options.
+**Purpose:** Multi-agent settings, UI preferences, retry behavior, system paths, and developer options. Uses vscode-collapsible for organization.
 
 **Layout:**
 ```
 ┌─────────────────────────────────────────────────────────────────┐
-│  Advanced                                                       │
-│  ─────────────────────────────────────────────────────────────  │
-│  System-level settings for advanced users.                      │
+│  Advanced settings and system configuration.                    │
 │                                                                 │
-│  RETRY BEHAVIOR                                                 │
-│  ─────────────────────────────────────────────────────────────  │
+│  ▼ Multi-Agent                                                 │
+│  ┌───────────────────────────────────────────────────────────┐  │
+│  │ Configure multi-agent operations and ensemble runs.       │  │
+│  │                                                           │  │
+│  │ Default merge model: [Claude Sonnet 4.5 ▼]                │  │
+│  │   Model used for combining outputs from multiple agents.  │  │
+│  │                                                           │  │
+│  │ ─────────────────────────────────────────────────────────│  │
+│  │ COMING SOON                                               │  │
+│  │ • Ensemble runs across multiple models                    │  │
+│  │ • Agent pipeline configurations                           │  │
+│  │ • Output voting and consensus                             │  │
+│  └───────────────────────────────────────────────────────────┘  │
 │                                                                 │
-│  Max retries: [3 ▼]                                            │
-│    Maximum number of retries for failed API requests.          │
-│    Options: 1, 2, 3, 5                                         │
+│  ▼ UI Preferences                                              │
+│  ┌───────────────────────────────────────────────────────────┐  │
+│  │ General interface preferences.                            │  │
+│  │                                                           │  │
+│  │ ☑ Show quick pick for agent selection                     │  │
+│  │   Use VS Code quick pick instead of dropdown for agents.  │  │
+│  │                                                           │  │
+│  │ ☑ Show quick pick for model selection                     │  │
+│  │   Use VS Code quick pick instead of dropdown for models.  │  │
+│  │                                                           │  │
+│  │ Max image dimension: [2048 ▼]                             │  │
+│  │   Larger images resized before sending to models.         │  │
+│  │   Options: 1024, 2048, 4096                               │  │
+│  │                                                           │  │
+│  │ Progress board sort: [Timestamp descending ▼]             │  │
+│  │   Options: Timestamp ascending, Timestamp descending      │  │
+│  └───────────────────────────────────────────────────────────┘  │
 │                                                                 │
-│  Initial delay: [1000 ms]                                      │
-│    Initial delay before first retry (exponential backoff).     │
+│  ▶ Retry Behavior                                              │
+│  ┌───────────────────────────────────────────────────────────┐  │
+│  │ Max retries: [3 ▼]                                        │  │
+│  │ Initial delay: [1000 ms]                                  │  │
+│  └───────────────────────────────────────────────────────────┘  │
 │                                                                 │
-│  ─────────────────────────────────────────────────────────────  │
+│  ▶ Git Integration                                             │
+│  ┌───────────────────────────────────────────────────────────┐  │
+│  │ Commits to show: [50 ▼]                                   │  │
+│  └───────────────────────────────────────────────────────────┘  │
 │                                                                 │
-│  GIT INTEGRATION                                                │
-│  ─────────────────────────────────────────────────────────────  │
+│  ▶ System Paths                                                │
+│  ┌───────────────────────────────────────────────────────────┐  │
+│  │ Sox audio path: [/usr/bin/sox            ] [Browse]       │  │
+│  └───────────────────────────────────────────────────────────┘  │
 │                                                                 │
-│  Commits to show: [50 ▼]                                       │
-│    Number of recent commits to show in git selection.          │
-│    Options: 25, 50, 100, 200                                   │
-│                                                                 │
-│  ─────────────────────────────────────────────────────────────  │
-│                                                                 │
-│  SYSTEM PATHS                                                   │
-│  ─────────────────────────────────────────────────────────────  │
-│                                                                 │
-│  Sox audio path: [/usr/bin/sox            ] [Browse]           │
-│    Path to sox executable for audio processing.                │
-│                                                                 │
-│  ─────────────────────────────────────────────────────────────  │
-│                                                                 │
-│  DEBUG (Developer)                                              │
-│  ─────────────────────────────────────────────────────────────  │
-│  ☐ Enable debug logging                                        │
-│  ☐ Enable verbose output                                       │
+│  ▶ Debug (Developer)                                           │
+│  ┌───────────────────────────────────────────────────────────┐  │
+│  │ ☐ Enable debug logging                                    │  │
+│  │ ☐ Enable verbose output                                   │  │
+│  └───────────────────────────────────────────────────────────┘  │
 │                                                                 │
 └─────────────────────────────────────────────────────────────────┘
 ```
@@ -985,6 +889,11 @@ In the Models tab, show provider/routing status on each model:
 **Settings Mapping:**
 | UI Element | VS Code Setting |
 |------------|-----------------|
+| Default merge model | `texra.merge.defaultModel` |
+| Agent quick pick | `texra.ui.showAgentQuickPick` |
+| Model quick pick | `texra.ui.showModelQuickPick` |
+| Max image dimension | `texra.maxImageDimension` |
+| Progress board sort | `texra.progressBoard.streamSortOrder` |
 | Max retries | `texra.model.retry.maxRetries` |
 | Initial delay | `texra.model.retry.initialDelayMs` |
 | Commits to show | `texra.git.numberOfCommitsToShow` |
@@ -993,29 +902,29 @@ In the Models tab, show provider/routing status on each model:
 
 **Storage:** VS Code configuration (backwards compatible)
 
+**Note:** Multi-Agent is included now, but ensemble features are awaiting multi-agent feature maturity.
+
 ---
 
 ### Features Summary
 
-**Sidebar Navigation Sections:**
-- **General** - Account info, UI preferences (quick picks, image dimension, sort order)
-- **Agents** (main) - Agent list enable/disable, remote agents, custom agents directory
-- **Agents → Workflow** - Workflow agent output storage settings
-- **Agents → Tool-Use** - Edit approval, session persistence, compaction threshold
-- **Models & Providers** - Combined model selection + provider configuration + routing
-- **Multi-Agent** - Merge settings (future ensemble features noted)
-- **LaTeX** - Formatter, latexdiff, TikZ settings
-- **Memory** - Memory file browser with expandable content preview
-- **History** - Execution history browser
-- **Advanced** - System paths, retry behavior, debug settings
+**Tab Layout with Header Bar:**
+- **Header Bar** - Account info, sign in/out, manage account (always visible)
+- **Models Tab** - Provider configuration, model selection, routing options
+- **Agents Tab** - Agent list, Workflow Settings (collapsible), Tool-Use Settings (collapsible)
+- **LaTeX Tab** - Formatter, latexdiff, TikZ (all as collapsibles)
+- **Memory Tab** - Memory file browser with expandable content preview
+- **History Tab** - Execution history browser
+- **Advanced Tab** - Multi-Agent, UI preferences, retry, git, system paths, debug (all collapsibles)
 
 **Key Features:**
-- Account info display at sidebar top (if logged in)
-- Per-provider configuration cards
-- Provider modal with API key + custom endpoint
+- Account info in header bar (minimal custom CSS, always visible)
+- Native vscode-tabs for navigation (no custom styling)
+- vscode-collapsible for subsections within tabs
+- Per-provider configuration in Models tab
+- Provider modal with API key + custom endpoint + streaming toggle
 - OpenRouter special configuration (routing mode)
 - Global routing options (direct/OpenRouter/proxy)
-- Sign in/out
 - Environment variable hints
 
 **Key UX Improvements:**
@@ -1024,6 +933,7 @@ In the Models tab, show provider/routing status on each model:
 3. **Custom endpoints exposed** - No more hidden VS Code settings
 4. **OpenRouter simplified** - Clear explanation and routing options
 5. **Model availability feedback** - See which models are ready in Models tab
+6. **Minimal custom CSS** - Only header bar needs styling, tabs and collapsibles are native
 
 ---
 
@@ -1321,9 +1231,9 @@ function getProviderStreaming(providerId: string): boolean {
 | `texra.models` | VS Code config | `globalState.enabledModels` | UI in Models tab |
 | `texra.agents` | VS Code config | `workspaceState.enabledAgents` | UI in Agents tab |
 | `texra.toolUseAgents` | VS Code config | `workspaceState.enabledAgents` | Merge with agents |
-| `texra.model.useOpenRouter` | VS Code config | `globalState.routing.mode` | UI in Profile tab |
-| `texra.model.useImprovedConnection` | VS Code config | `globalState.routing.mode` | UI in Profile tab |
-| `texra.model.improvedConnectionDomain` | VS Code config | `globalState.routing.proxyDomain` | UI in Profile tab |
+| `texra.model.useOpenRouter` | VS Code config | `globalState.routing.mode` | UI in Models tab (routing section) |
+| `texra.model.useImprovedConnection` | VS Code config | `globalState.routing.mode` | UI in Models tab (routing section) |
+| `texra.model.improvedConnectionDomain` | VS Code config | `globalState.routing.proxyDomain` | UI in Models tab (routing section) |
 | `texra.toolUse.persistence.enabled` | VS Code config | `workspaceState.memorySettings` | UI in Memory tab |
 | `texra.toolUse.persistence.ttlHours` | VS Code config | `workspaceState.memorySettings` | UI in Memory tab |
 
@@ -1415,26 +1325,21 @@ src/
 │   ├── SettingsViewProvider.ts      # WebviewViewProvider
 │   ├── SettingsViewMessageHandler.ts
 │   ├── SettingsViewContentProvider.ts
-│   ├── index.html                   # Sidebar navigation layout
-│   ├── styles.css                   # Cursor-style sidebar styling
+│   ├── index.html                   # Header bar + vscode-tabs layout
+│   ├── styles.css                   # Minimal CSS (header bar only)
 │   └── modules/
 │       ├── main.js                  # Entry point
 │       ├── messageHandlers.js
 │       ├── settingsViewState.js
-│       ├── sidebarNav.js            # Sidebar navigation logic
-│       ├── sections/
-│       │   ├── GeneralSection.js    # Account + UI preferences
-│       │   ├── AgentsSection.js     # Agent list (main)
-│       │   ├── AgentsWorkflow.js    # Agents → Workflow subsection
-│       │   ├── AgentsToolUse.js     # Agents → Tool-Use subsection
-│       │   ├── ModelsProviders.js   # Combined Models & Providers
-│       │   ├── MultiAgentSection.js # Multi-agent settings
-│       │   ├── LatexSection.js      # LaTeX settings
-│       │   ├── MemorySection.js     # Memory files browser
-│       │   ├── HistorySection.js    # History (migrated)
-│       │   └── AdvancedSection.js   # Advanced settings
+│       ├── headerBar.js             # Account header bar logic
+│       ├── tabs/                    # Tab content modules
+│       │   ├── ModelsTab.js         # Models + providers + routing
+│       │   ├── AgentsTab.js         # Agents + collapsible settings
+│       │   ├── LatexTab.js          # LaTeX settings (collapsibles)
+│       │   ├── MemoryTab.js         # Memory files browser
+│       │   ├── HistoryTab.js        # History (migrated)
+│       │   └── AdvancedTab.js       # Multi-Agent, UI, retry, etc.
 │       └── uiManagers/
-│           ├── SidebarRenderer.js
 │           ├── ModelListRenderer.js
 │           ├── ProviderRenderer.js
 │           ├── AgentListRenderer.js
@@ -1451,13 +1356,15 @@ src/
 
 ```typescript
 // Register command to open settings view
-commands.registerCommand('texra.openSettings', (section?: string) => {
+commands.registerCommand('texra.openSettings', (tab?: SettingsTab) => {
   settingsViewProvider.show();
-  if (section) {
-    // 'general' | 'agents' | 'agents-workflow' | 'agents-tooluse' | 'models' | 'multiagent' | 'latex' | 'memory' | 'history' | 'advanced'
-    settingsViewProvider.selectSection(section);
+  if (tab) {
+    // Tab index: 0=models, 1=agents, 2=latex, 3=memory, 4=history, 5=advanced
+    settingsViewProvider.selectTab(tab);
   }
 });
+
+type SettingsTab = 'models' | 'agents' | 'latex' | 'memory' | 'history' | 'advanced';
 
 // Shortcut commands
 commands.registerCommand('texra.openModelSettings', () =>
@@ -1522,66 +1429,70 @@ interface AgentInfo {
 ## Success Metrics
 
 1. Single entry point for all configuration
-2. Cursor-style sidebar navigation (keyboard accessible)
+2. Native vscode-tabs navigation (keyboard accessible)
 3. State properly persisted (models global, agents per-workspace)
 4. History search and restore working
-5. Profile/auth flow unchanged (account info in sidebar header)
+5. Account info visible in header bar (minimal custom CSS)
 6. LaTeX settings functional and synced with VS Code config
-7. Clean sidebar + content layout achieved
+7. vscode-collapsible used effectively for subsections
+8. Only header bar needs custom styling (everything else native)
 
 ---
 
 ## Implementation Phases
 
 ### Phase 1: Core Structure + Extended getConfig
-- Create settingsView with Cursor-style sidebar navigation
+- Create settingsView with vscode-tabs + header bar
+- Implement header bar (account info, sign in/out - minimal custom CSS)
 - Implement extended `getConfig()` with state awareness
-- Implement General section (account + UI preferences)
 - Wire up globalState for model preferences
 - Test graceful migration from VS Code config
 
-### Phase 2: Models & Providers Section
-- Implement combined Models & Providers section
+### Phase 2: Models Tab
+- Implement Models tab with provider collapsibles
 - Provider accordions with API status + model list
 - Provider configuration modal (API key + endpoint + streaming toggle)
-- Routing options UI
+- Routing options (radio group at top)
 - Migrate provider config from old profileView
 
-### Phase 3: Agents Section (View-Only First)
-- Implement Agents section with list of all agents
+### Phase 3: Agents Tab
+- Implement Agents tab with agent list
 - Show category badges (workflow/toolUse) and source (built-in/custom/remote)
 - Wire up workspaceState for agent preferences
-- Include remote agents settings + custom agents directory (Advanced)
+- Add Workflow Settings collapsible (output storage mode)
+- Add Tool-Use Settings collapsible (edit approval, persistence, compaction)
+- Include Advanced collapsible (custom agents directory)
 - **Note:** Supersedes FolderExplorer/agent explorer view
 
-### Phase 4: Agents Subsections
-- Implement Agents → Workflow subsection (output storage mode)
-- Implement Agents → Tool-Use subsection (edit approval, persistence, compaction)
-- Wire to VS Code config via extended getConfig
-
-### Phase 5: Multi-Agent Section
-- Implement Multi-Agent section with merge settings
-- Add "Coming Soon" placeholder for future ensemble features
-
-### Phase 6: LaTeX Section
-- Implement LaTeX section with formatter, latexdiff, TikZ
+### Phase 4: LaTeX Tab
+- Implement LaTeX tab with collapsible sections:
+  - Formatter (collapsible)
+  - LaTeXdiff (collapsible)
+  - TikZ Figures (collapsible)
+  - Replacements (collapsible)
 - Wire up to existing VS Code configuration
 - Add file browser for config paths
 
-### Phase 7: Memory Section
-- Migrate memoryView to Memory section
+### Phase 5: Memory Tab
+- Migrate memoryView to Memory tab
 - Implement expandable content preview
 - Delete old memoryView
 
-### Phase 8: History Section
-- Move history rendering to History section
+### Phase 6: History Tab
+- Move history rendering to History tab
 - Preserve search, delete, restore, rerun functionality
 - Delete old historyView
 
-### Phase 9: Advanced Section + Cleanup
-- Implement Advanced section (retry, git, system paths, debug)
+### Phase 7: Advanced Tab + Cleanup
+- Implement Advanced tab with collapsible sections:
+  - Multi-Agent (merge model + "Coming Soon")
+  - UI Preferences (quick picks, image dimension, sort order)
+  - Retry Behavior
+  - Git Integration
+  - System Paths
+  - Debug
 - Add main webview entry point (gear icon)
-- Deep link support (open to specific section)
+- Deep link support (open to specific tab)
 - Verify graceful migration (no breaking existing setups)
 - Remove deprecated views (profileView, historyView, memoryView)
 - Remove FolderExplorer/agent explorer (superseded)
@@ -1754,11 +1665,11 @@ Key integration points that need updating when implementing the Settings View:
 - `<vscode-textarea>` - TikZ template
 - `<vscode-collapsible>` - Advanced sections
 
-### Profile Tab Components
-- `<vscode-radio-group>` - Access mode, routing mode
-- `<vscode-textfield type="password">` - API keys
-- `<vscode-button>` - Sign In/Out, Configure, Save
-- `<vscode-collapsible>` - Provider details
+### Header Bar + Provider Modal Components
+- `<vscode-button>` - Manage, Sign In/Out
+- `<vscode-textfield type="password">` - API keys (in modal)
+- `<vscode-radio-group>` - Routing mode (in Models tab)
+- `<vscode-collapsible>` - Provider details (in Models tab)
 
 ---
 
@@ -1816,15 +1727,13 @@ export class SettingsViewProvider extends BaseWebviewProvider
 // SettingsViewContentProvider.ts
 const SETTINGS_VIEW_MODULES = [
   { key: 'settingsViewStateUri', path: 'modules/settingsViewState.js' },
+  { key: 'headerBarUri', path: 'modules/headerBar.js' },
   { key: 'modelsTabUri', path: 'modules/tabs/ModelsTab.js' },
   { key: 'agentsTabUri', path: 'modules/tabs/AgentsTab.js' },
-  { key: 'toolUseTabUri', path: 'modules/tabs/ToolUseTab.js' },
   { key: 'latexTabUri', path: 'modules/tabs/LatexTab.js' },
   { key: 'memoryTabUri', path: 'modules/tabs/MemoryTab.js' },
   { key: 'historyTabUri', path: 'modules/tabs/HistoryTab.js' },
-  { key: 'profileTabUri', path: 'modules/tabs/ProfileTab.js' },
-  { key: 'uiTabUri', path: 'modules/tabs/UITab.js' },
-  { key: 'miscTabUri', path: 'modules/tabs/MiscTab.js' },
+  { key: 'advancedTabUri', path: 'modules/tabs/AdvancedTab.js' },
 ] as const;
 
 export class SettingsViewContentProvider extends BaseViewContentProvider {

--- a/docs/prd/settings-view-unified.md
+++ b/docs/prd/settings-view-unified.md
@@ -393,7 +393,7 @@ const RECOMMENDED_MODELS = [
 |-------|--------|---------|
 | Name | YAML `name` | Text |
 | Description | YAML `description` | Text (truncated) |
-| Category | `agentCategory` | Badge: `[workflow]` or `[toolUse]` |
+| Category | Derived (see Agent Category Derivation) | Badge: `[workflow]` or `[toolUse]` |
 | Type | `settings.agentType` | Label: `CoT`, `Direct`, `Merge`, `Reflect` |
 | Rounds | `settings.rounds` | Label: `×2`, `×3` (if > 1) |
 | Inherits | `inherits` | Codicon: `$(extensions)` + parent name |
@@ -1227,11 +1227,11 @@ type SettingsAction =
 
 type SettingsTab = 'models' | 'agents' | 'latex' | 'memory' | 'history';
 
-// Agent info includes category (derived from YAML agentCategory field)
+// Agent info (mirrors AgentEntry from agentRegistry.ts)
 interface AgentInfo {
   name: string;
   description: string;
-  category: 'workflow' | 'toolUse';  // From YAML: agentCategory field
+  category: 'workflow' | 'toolUse';  // Derived from source/agentType (see Agent Category Derivation)
   agentType: 'cot' | 'direct' | 'merge' | 'reflect' | 'toolUse';  // From YAML: settings.agentType
   rounds?: number;  // From YAML: settings.rounds (if > 1)
   inherits?: string;  // From YAML: inherits field
@@ -1242,36 +1242,23 @@ interface AgentInfo {
 
 ### Agent Category Derivation
 
-Agent categories are determined from the YAML `agentCategory` field:
+Agent categories are determined by `agentRegistry.ts` logic:
 
-```yaml
-# Example agent YAML
-name: correct
-description: Fix typos & LaTeX errors
-agentCategory: workflow  # Explicit category: 'workflow' | 'toolUse'
-settings:
-  agentType: cot
-  rounds: 2
-inherits: polish
-```
-
-**Category Rules:**
-1. **Explicit**: Use `agentCategory` field if present in YAML
-2. **Inferred**: If missing, infer from `settings.agentType`:
-   - `toolUse` type → `toolUse` category
-   - All others (`cot`, `direct`, `merge`, `reflect`) → `workflow` category
-3. **Built-in tool-use agents**: Located in `resources/agents/toolUse/` directory
-
+**For local agents (built-in and custom):**
 ```typescript
-function deriveAgentCategory(yaml: AgentYaml): 'workflow' | 'toolUse' {
-  // Explicit category takes precedence
-  if (yaml.agentCategory) {
-    return yaml.agentCategory;
-  }
-  // Infer from agent type
-  return yaml.settings?.agentType === 'toolUse' ? 'toolUse' : 'workflow';
-}
+// From src/agent/index/agentRegistry.ts
+const category =
+  source === 'builtInToolUse' || agentType === AgentType.ToolUse
+    ? AgentCategory.ToolUse
+    : AgentCategory.Workflow;
 ```
+
+**For remote agents:**
+- Uses `agentCategory` field from remote agent definition
+
+**Config override:** Any agent can be marked as tool-use via `texra.toolUseAgents` setting.
+
+**Note:** Local agent YAML files don't have an `agentCategory` field - category is derived from source/agentType.
 
 ---
 
@@ -1400,7 +1387,6 @@ These are advanced/power-user settings that don't need UI exposure:
 
 - `texra.files.*` (16) - File type filtering patterns (power user)
 - `texra.auth.*` (3) - System-level authentication endpoints
-- `texra.remoteAgents.cacheTimeHours` (1) - Advanced cache behavior
 - Other system-level paths and debug flags
 
 ---
@@ -1420,8 +1406,10 @@ Key integration points that need updating when implementing the Settings View:
 | Command | File | Change |
 |---------|------|--------|
 | `texra.openSettings` | `src/commands/system/` | Open Settings View instead of VS Code settings |
-| `texra.openAgentSettings` | `src/commands/system/` | Open Settings View → Agents tab |
-| `texra.openModelSettings` | `src/commands/system/` | Open Settings View → Models tab |
+
+**New commands to add (shortcuts):**
+- `texra.openAgentSettings` → Opens Settings View → Agents tab
+- `texra.openModelSettings` → Opens Settings View → Models tab
 
 ### 3. Dropdown Options Computation
 | Function | File | Impact |

--- a/docs/prd/settings-view-unified.md
+++ b/docs/prd/settings-view-unified.md
@@ -35,105 +35,25 @@ Create a unified Settings View that consolidates model configuration, agent conf
 
 ---
 
-## Design Principles (Notion-Inspired)
+## Design Principles
 
-The Settings View follows Notion's design philosophy: minimal chrome, generous whitespace, and content-first hierarchy.
+The Settings View prioritizes simplicity and user-friendliness, inspired by Notion's philosophy of clean, uncluttered interfaces.
 
 ### Core Principles
 
-1. **Content over chrome** - No unnecessary borders, backgrounds, or decorations
-2. **Generous whitespace** - Let content breathe; padding > borders
-3. **Typography hierarchy** - Use font size/weight, not color, to establish importance
-4. **Invisible affordances** - Actions appear on hover, not by default
-5. **Grouped sections** - Clear visual separation using space, not lines
+1. **Simplicity first** - Use VS Code native components; avoid custom styling
+2. **Clear grouping** - Logical sections with clear headers
+3. **Progressive disclosure** - Hide advanced options in collapsibles
+4. **Immediate feedback** - Settings save automatically or with clear feedback
+5. **Familiar patterns** - Follow VS Code settings UI conventions
 
-### Visual Guidelines
+### Implementation Guidelines
 
-```css
-/* Typography hierarchy */
-.section-header {
-  font-size: 11px;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
-  color: var(--vscode-descriptionForeground);
-  margin-bottom: 12px;
-}
-
-.item-title {
-  font-size: 13px;
-  font-weight: 500;
-  color: var(--vscode-foreground);
-}
-
-.item-description {
-  font-size: 12px;
-  color: var(--vscode-descriptionForeground);
-}
-
-/* Spacing */
-.section {
-  padding: 16px 0;
-}
-
-.section + .section {
-  border-top: 1px solid var(--vscode-widget-border);
-}
-
-/* Hover actions (Notion-style) */
-.item-row .actions {
-  opacity: 0;
-  transition: opacity 0.15s;
-}
-
-.item-row:hover .actions {
-  opacity: 1;
-}
-
-/* Cards - minimal borders */
-.card {
-  background: var(--vscode-editor-background);
-  border: 1px solid var(--vscode-widget-border);
-  border-radius: 4px;
-  padding: 12px 16px;
-}
-
-/* Focus on content, not containers */
-.list-item {
-  padding: 8px 0;
-  /* No borders between items - use space */
-}
-```
-
-### Anti-Patterns to Avoid
-
-- ❌ Heavy borders and outlines everywhere
-- ❌ Colorful badges and status indicators
-- ❌ Multiple competing visual hierarchies
-- ❌ Actions always visible (clutter)
-- ❌ Compact, dense layouts
-- ❌ Deeply nested sections
-
-### Examples
-
-**Good (Notion-style):**
-```
-FORMATTER
-
-Formatter     latexindent ▼
-
-Config file   /path/to/config              Browse
-```
-
-**Bad (cluttered):**
-```
-┌─────────────────────────────────────────┐
-│ ⚙️ FORMATTER SETTINGS                   │
-├─────────────────────────────────────────┤
-│ [Formatter:] [latexindent ▼] [ℹ️]       │
-│ [Config:] [_______________] [📁 Browse] │
-└─────────────────────────────────────────┘
-```
+- Use `<vscode-form-group>` for all form layouts (native VS Code styling)
+- Use `<vscode-collapsible>` for advanced/optional sections
+- Keep actions visible (no hover-to-reveal complexity)
+- Use standard VS Code color variables
+- Follow existing webview patterns in the codebase
 
 ---
 
@@ -280,186 +200,72 @@ const RECOMMENDED_MODELS = [
 
 ### Agents Tab
 
-**Purpose:** Configure agents and create custom ones without YAML complexity.
+**Purpose:** View and enable/disable agents. Supersedes the FolderExplorer/agent explorer.
 
-**Design Philosophy:** Users should be able to create and modify agents through a simple UI, not by editing YAML files. The complexity is hidden; power users can access raw YAML if needed.
+**Scope (Phase 1):** View-only with enable/disable. Agent creation wizard deferred to Future Scope.
 
 **Agent Categories:**
 - `workflow` - Document-processing agents (input → output transformations)
 - `toolUse` - Interactive agents with tool capabilities (chat, research)
 
+**Agent Sources:**
+- `builtIn` - Shipped with extension (workflow agents)
+- `builtInToolUse` - Shipped with extension (tool-use agents)
+- `custom` - User-created YAML files in workspace
+- `remote` - Shared agents from team (requires login)
+
 **Layout:**
 ```
 ┌─────────────────────────────────────────────────────────────────┐
-│  Configure agents and create custom ones.                       │
+│  Select which agents appear in the dropdown.                    │
 │  Settings are saved per workspace.                              │
 │                                                                 │
-│  MY AGENTS                                    [+ Create Agent]  │
+│  BUILT-IN AGENTS                                               │
 │  ─────────────────────────────────────────────────────────────  │
-│                                                                 │
 │  ┌───────────────────────────────────────────────────────────┐  │
-│  │ ☑ chat        Interactive conversation  [toolUse] Built-in│  │
-│  │ ☑ correct     Fix typos & LaTeX errors  [workflow] Built-in│  │
-│  │ ☑ polish      Improve writing quality   [workflow] Built-in│  │
-│  │ ☑ research    Research with tools       [toolUse] Built-in│  │
-│  │ ☑ my-reviewer Reviews papers...         [workflow]  Custom │  │
-│  │                                          [Edit] [Delete] │  │
-│  │ ☐ draw        Create TikZ figures       [workflow] Built-in│  │
-│  │ ☐ ocr         Handwritten → LaTeX       [workflow] Built-in│  │
-│  │ ☐ paper2slide Paper → Beamer slides     [workflow] Built-in│  │
-│  │ ☐ paper2poster Paper → poster           [workflow] Built-in│  │
-│  │ ☐ transcribe  Audio transcription       [workflow] Built-in│  │
+│  │ ☑ chat        Interactive conversation         [toolUse] │  │
+│  │ ☑ correct     Fix typos & LaTeX errors        [workflow] │  │
+│  │ ☑ polish      Improve writing quality         [workflow] │  │
+│  │ ☑ research    Research with tools             [toolUse]  │  │
+│  │ ☐ draw        Create TikZ figures             [workflow] │  │
+│  │ ☐ ocr         Handwritten → LaTeX             [workflow] │  │
+│  │ ☐ paper2slide Paper → Beamer slides           [workflow] │  │
+│  │ ☐ paper2poster Paper → poster                 [workflow] │  │
+│  │ ☐ transcribe  Audio transcription             [workflow] │  │
 │  └───────────────────────────────────────────────────────────┘  │
+│                                                                 │
+│  CUSTOM AGENTS                                                 │
+│  ─────────────────────────────────────────────────────────────  │
+│  ┌───────────────────────────────────────────────────────────┐  │
+│  │ ☑ my-reviewer Reviews papers for clarity      [workflow] │  │
+│  │                                    [Open YAML] [Delete]  │  │
+│  └───────────────────────────────────────────────────────────┘  │
+│  📁 Custom agents are stored in: .texra/agents/                 │
 │                                                                 │
 │  REMOTE AGENTS                                                 │
 │  ─────────────────────────────────────────────────────────────  │
 │  ┌───────────────────────────────────────────────────────────┐  │
-│  │ ☑ team-reviewer   Team's paper reviewer  [workflow] Public │  │
-│  │ ☐ grant-writer    Grant proposal helper  [toolUse]  Team  │  │
+│  │ ☑ team-reviewer   Team's paper reviewer       [workflow] │  │
+│  │ ☐ grant-writer    Grant proposal helper       [toolUse]  │  │
 │  └───────────────────────────────────────────────────────────┘  │
 │                        ─ or if not logged in ─                  │
 │  ┌───────────────────────────────────────────────────────────┐  │
 │  │  🔒 Sign in to access shared team agents       [Sign In]  │  │
 │  └───────────────────────────────────────────────────────────┘  │
 │                                                                 │
-│  ─────────────────────────────────────────────────────────────  │
-│  [Advanced: Open Agent Files]          ← Power users only      │
 └─────────────────────────────────────────────────────────────────┘
 ```
 
-**Category Badge Styling:**
-```css
-.category-badge {
-  font-size: 10px;
-  padding: 2px 6px;
-  border-radius: 3px;
-  text-transform: lowercase;
-}
-.category-badge--workflow {
-  background: var(--vscode-badge-background);
-  color: var(--vscode-badge-foreground);
-}
-.category-badge--toolUse {
-  background: var(--vscode-statusBarItem-prominentBackground);
-  color: var(--vscode-statusBarItem-prominentForeground);
-}
-```
+**Category Badges:** Use `<vscode-badge>` for workflow/toolUse labels.
 
----
+**Custom Agent Actions:**
+- `[Open YAML]` - Opens agent YAML file in editor (for power users)
+- `[Delete]` - Deletes custom agent YAML file
 
-### Create Agent Wizard
-
-Click **[+ Create Agent]** → AI-assisted creation:
-
-```
-┌─────────────────────────────────────────────────────────────────┐
-│  Create Custom Agent                                      [×]  │
-├─────────────────────────────────────────────────────────────────┤
-│                                                                 │
-│  What should this agent do?                                    │
-│  ┌───────────────────────────────────────────────────────────┐  │
-│  │ Review my paper drafts and suggest improvements for       │  │
-│  │ clarity, argument structure, and academic tone.           │  │
-│  └───────────────────────────────────────────────────────────┘  │
-│                                                                 │
-│  Agent name: [paper-reviewer    ]                              │
-│                                                                 │
-│  Type:                                                         │
-│  ● Document processor (input → output)                         │
-│  ○ Interactive chat (conversation)                             │
-│                                                                 │
-│  ─────────────────────────────────────────────────────────────  │
-│  💡 AI will generate the agent for you.                        │
-│                                                                 │
-│                                      [Cancel]  [Create Agent]  │
-└─────────────────────────────────────────────────────────────────┘
-```
-
-**Flow:**
-1. User describes what agent should do (plain English)
-2. AI generates YAML configuration behind the scenes
-3. Agent immediately appears in list, ready to use
-4. No YAML knowledge required
-
----
-
-### Edit Agent Form
-
-Click **[Edit]** on custom agent → Form-based editor:
-
-```
-┌─────────────────────────────────────────────────────────────────┐
-│  Edit Agent: paper-reviewer                               [×]  │
-├─────────────────────────────────────────────────────────────────┤
-│                                                                 │
-│  BASIC                                                         │
-│  ─────────────────────────────────────────────────────────────  │
-│  Name:        [paper-reviewer                ]                 │
-│  Description: [Reviews papers for clarity    ]                 │
-│  Category:    [workflow ▼]                                     │
-│  Based on:    [correct ▼] (inherit from built-in)              │
-│                                                                 │
-│  INSTRUCTIONS                                                  │
-│  ─────────────────────────────────────────────────────────────  │
-│  What the agent should do:                                     │
-│  ┌───────────────────────────────────────────────────────────┐  │
-│  │ You are an academic paper reviewer. Analyze the document  │  │
-│  │ for clarity, argument structure, and academic tone.       │  │
-│  │ Suggest specific improvements with examples.              │  │
-│  └───────────────────────────────────────────────────────────┘  │
-│                                                                 │
-│  ▶ Advanced options (rounds, agentType, etc.)                  │
-│                                                                 │
-│  ─────────────────────────────────────────────────────────────  │
-│  [View YAML]                       [Cancel]  [Test]  [Save]   │
-└─────────────────────────────────────────────────────────────────┘
-```
-
-**Form fields map to YAML transparently:**
-- Name → `name:`
-- Description → `description:`
-- Category → `agentCategory:` (workflow | toolUse)
-- Based on → `inherits:`
-- Instructions → `prompts.systemPrompt:`
-
----
-
-### Complexity Comparison
-
-| Task | Before (YAML) | After (UI) |
-|------|---------------|------------|
-| **Create agent** | Write YAML from scratch | Describe in English, AI generates |
-| **Edit agent** | Edit YAML syntax | Fill out form |
-| **Set inheritance** | `inherits: correct` | Dropdown: "Based on: correct" |
-| **Change category** | Edit `agentCategory: workflow` | Dropdown |
-| **View all agents** | File explorer + folders | Single flat list with category badges |
-
----
-
-### Data Flow
-
-```
-┌─────────────────┐     ┌─────────────────┐     ┌─────────────────┐
-│   User Input    │────▶│   Form/Wizard   │────▶│   YAML File     │
-│  (plain text)   │     │   (abstracts)   │     │  (storage)      │
-└─────────────────┘     └─────────────────┘     └─────────────────┘
-                               │
-                               ▼
-                        ┌─────────────────┐
-                        │  Agent Registry │
-                        │  (runtime)      │
-                        └─────────────────┘
-```
-
-YAML files remain the source of truth, but users interact through forms.
-
----
-
-### Power User Escape Hatches
-
-1. **[View YAML]** button in edit form - opens raw YAML
-2. **[Advanced: Open Agent Files]** - opens file explorer
-3. YAML files still editable directly if preferred
+**Note:** Agent creation wizard and form-based editing are deferred to Future Scope. For now, users create agents by:
+1. Duplicating an existing YAML file in `.texra/agents/`
+2. Editing the YAML directly
+3. The agent appears automatically in the list
 
 **Storage:** `workspaceState.enabledAgents: string[]`
 
@@ -1322,14 +1128,15 @@ interface AgentInfo {
 - Implement Models tab with provider accordions
 - Wire up globalState for model preferences
 - Test graceful migration from VS Code config
-- Apply Notion-style CSS variables and spacing
+- Use vscode-form-group for all form layouts
 
-### Phase 2: Agents Tab
-- Implement Agents tab with local/custom/remote sections
-- Add category badges (workflow/toolUse)
+### Phase 2: Agents Tab (View-Only First)
+- Implement Agents tab with list of all agents
+- Show category badges (workflow/toolUse) and source (built-in/custom/remote)
 - Wire up workspaceState for agent preferences
 - Handle remote agents auth state
-- Implement AI-assisted agent creation wizard
+- Link to YAML files for editing (power users)
+- **Note:** Supersedes FolderExplorer/agent explorer view
 
 ### Phase 3: LaTeX Tab
 - Implement LaTeX tab with formatter, latexdiff, TikZ sections
@@ -1355,12 +1162,77 @@ interface AgentInfo {
 - Add routing options UI
 - Delete old profileView
 
-### Phase 7: Polish
+### Phase 7: Polish & Cleanup
 - Add main webview entry point (gear icon)
 - Deep link support (open to specific tab)
 - Verify graceful migration (no breaking existing setups)
 - Accessibility audit (keyboard navigation)
+- Remove deprecated views (profileView, historyView, memoryView)
+- Remove FolderExplorer/agent explorer (superseded by Agents tab)
 - Documentation
+
+### Future Scope (Deferred)
+- **Agent Creation Wizard** - AI-assisted agent creation from plain English description
+- **Agent Edit Form** - Form-based editing without YAML knowledge
+- **Agent Testing** - Test agent with sample input before saving
+
+---
+
+## Integration Surface Areas
+
+Key integration points that need updating when implementing the Settings View:
+
+### 1. Main Webview Entry Points
+| Location | Current Behavior | New Behavior |
+|----------|-----------------|--------------|
+| `src/webview/index.html` line 524 | Agent settings button → VS Code settings | → Settings View (Agents tab) |
+| `src/webview/index.html` line 552 | Model settings button → VS Code settings | → Settings View (Models tab) |
+| `src/webview/modules/uiManagers/SettingsButtonManager.js` | Opens VS Code settings | Opens Settings View |
+
+### 2. Commands to Update
+| Command | File | Change |
+|---------|------|--------|
+| `texra.openSettings` | `src/commands/system/` | Open Settings View instead of VS Code settings |
+| `texra.openAgentSettings` | `src/commands/system/` | Open Settings View → Agents tab |
+| `texra.openModelSettings` | `src/commands/system/` | Open Settings View → Models tab |
+
+### 3. Dropdown Options Computation
+| Function | File | Impact |
+|----------|------|--------|
+| `computeAgentOptions()` | `src/agent/index/agentRegistry.ts` | Read from workspaceState instead of VS Code config |
+| `computeModelOptions()` | `src/model/computeModelOptions.ts` | Read from globalState instead of VS Code config |
+
+### 4. Configuration Watchers
+`src/MainViewProvider.ts` (lines 84-120) watches for config changes. Update to:
+- Watch globalState/workspaceState changes instead
+- Or keep VS Code config watchers for backwards compatibility during migration
+
+### 5. View Registrations (package.json)
+| View | Current | After Implementation |
+|------|---------|---------------------|
+| `texra.profileView` | Registered in contributes.views | Remove after Phase 6 |
+| `texra.historyView` | Command-opened panel | Remove after Phase 5 |
+| `texra.memoryView` | Command-opened panel | Remove after Phase 4 |
+| `texra.agentExplorer` | TreeView in sidebar | Remove after Phase 2 |
+| `texra.settingsView` | N/A | Add new panel registration |
+
+### 6. Message Handlers to Migrate
+| Handler | From | To |
+|---------|------|-----|
+| `ProfileViewMessageHandler` | `src/profileView/` | `src/settingsView/` (compose) |
+| `HistoryViewMessageHandler` | `src/historyView/` | `src/settingsView/` (compose) |
+| `MemoryViewMessageHandler` | `src/memoryView/` | `src/settingsView/` (compose) |
+
+### 7. State Migration Points
+```typescript
+// Settings that move FROM VS Code config TO extension state:
+'texra.agents'           → workspaceState.enabledAgents
+'texra.toolUseAgents'    → workspaceState.enabledAgents (merge)
+'texra.models'           → globalState.enabledModels
+'texra.model.useOpenRouter'           → globalState.routing.mode
+'texra.model.useImprovedConnection'   → globalState.routing.mode
+'texra.model.improvedConnectionDomain' → globalState.routing.proxyDomain
+```
 
 ---
 
@@ -1389,31 +1261,32 @@ interface AgentInfo {
 
 ### Form Layout Components
 ```html
-<!-- Notion-style form row (no vscode-form-group for cleaner look) -->
-<div class="setting-row">
-  <span class="setting-label">Formatter</span>
+<!-- Standard form group with label -->
+<vscode-form-group>
+  <vscode-label>Formatter</vscode-label>
   <vscode-single-select>
     <vscode-option value="latexindent">latexindent</vscode-option>
     <vscode-option value="tex-fmt">tex-fmt</vscode-option>
     <vscode-option value="none">none</vscode-option>
   </vscode-single-select>
-</div>
+</vscode-form-group>
 
-<!-- Checkbox row -->
-<div class="setting-row">
-  <vscode-checkbox id="showWarning">
-    Show warning if latexindent is not installed
-  </vscode-checkbox>
-</div>
+<!-- Checkbox (self-labeled) -->
+<vscode-checkbox id="showWarning">
+  Show warning if latexindent is not installed
+</vscode-checkbox>
 
-<!-- File path row with browse button -->
-<div class="setting-row">
-  <span class="setting-label">Config file</span>
-  <div class="setting-input-group">
+<!-- File path with browse button -->
+<vscode-form-group>
+  <vscode-label>Config file</vscode-label>
+  <div class="input-with-button">
     <vscode-textfield placeholder="/path/to/config"></vscode-textfield>
     <vscode-button appearance="secondary">Browse</vscode-button>
   </div>
-</div>
+</vscode-form-group>
+
+<!-- Section header using vscode-label -->
+<vscode-label class="section-label">FORMATTER</vscode-label>
 ```
 
 ### Models Tab Components
@@ -1559,72 +1432,39 @@ export class BaseTab {
 }
 ```
 
-### Shared CSS Variables (extend common.css)
+### Minimal Custom CSS (extend common.css)
 ```css
 /* settingsView/styles/index.css */
-@import '../../common/styles/common.css';
+/* Rely on vscode-form-group and vscode-elements for layout */
+/* Only add minimal custom styles where needed */
 
-/* Notion-style settings layout */
 .settings-container {
   max-width: 720px;
   margin: 0 auto;
   padding: var(--spacing-large);
 }
 
-.section {
-  padding: var(--spacing-large) 0;
-}
-
+/* Section dividers */
 .section + .section {
   border-top: 1px solid var(--vscode-widget-border);
+  padding-top: var(--spacing-large);
+  margin-top: var(--spacing-large);
 }
 
-.section-header {
-  font-size: var(--font-size-sm);
-  font-weight: 600;
+/* Section labels (uppercase headers) */
+.section-label {
   text-transform: uppercase;
   letter-spacing: 0.5px;
-  color: var(--vscode-descriptionForeground);
   margin-bottom: var(--spacing-medium);
 }
 
-.setting-row {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: var(--spacing-small) 0;
-  min-height: 32px;
-}
-
-.setting-label {
-  flex: 0 0 160px;
-  color: var(--vscode-foreground);
-}
-
-.setting-row vscode-single-select,
-.setting-row vscode-textfield {
-  flex: 1;
-  max-width: 300px;
-}
-
-.setting-input-group {
+/* Input + button combos */
+.input-with-button {
   display: flex;
   gap: var(--spacing-small);
+}
+.input-with-button vscode-textfield {
   flex: 1;
-  max-width: 400px;
-}
-
-.setting-input-group vscode-textfield {
-  flex: 1;
-}
-
-/* Hover actions (Notion-style) */
-.item-row .actions {
-  opacity: 0;
-  transition: opacity 0.15s;
-}
-.item-row:hover .actions {
-  opacity: 1;
 }
 ```
 

--- a/docs/prd/settings-view-unified.md
+++ b/docs/prd/settings-view-unified.md
@@ -133,7 +133,7 @@ Tab 2: Agents
 ├── ▼ Workflow Settings (collapsible subsection)
 │   └── Output storage mode
 └── ▼ Tool-Use Settings (collapsible subsection)
-    └── Edit approval, persistence, compaction
+    └── Edit approval, persistence, compaction, retry behavior
 
 Tab 3: LaTeX
 ├── ▼ Formatter (collapsible)
@@ -149,7 +149,7 @@ Tab 5: History
 
 Tab 6: Advanced
 ├── ▼ Multi-Agent (collapsible) - merge model, future ensemble
-├── ▼ Retry Behavior (collapsible)
+├── ▼ UI Preferences (collapsible) - reminders, image dimension, sort
 ├── ▼ Git Integration (collapsible)
 ├── ▼ System Paths (collapsible)
 └── ▼ Debug (collapsible)
@@ -492,6 +492,14 @@ const RECOMMENDED_MODELS = [
 │  │                                                           │  │
 │  │ Compaction threshold: [85 %]                              │  │
 │  │   Compact context when usage exceeds this percentage.     │  │
+│  │                                                           │  │
+│  │ ─────────────────────────────────────────────────────────│  │
+│  │ Retry Behavior                                            │  │
+│  │ Max attempts: [3 ▼]                                       │  │
+│  │   Maximum retry attempts for failed API requests.         │  │
+│  │                                                           │  │
+│  │ Backoff delay: [1000 ms]                                  │  │
+│  │   Initial delay before retry (exponential backoff).       │  │
 │  └───────────────────────────────────────────────────────────┘  │
 │                                                                 │
 │  ▶ Advanced                                                    │
@@ -511,12 +519,14 @@ const RECOMMENDED_MODELS = [
 **Settings Mapping:**
 | UI Element | VS Code Setting |
 |------------|-----------------|
-| Auto-show remote agents | `texra.remoteAgents.autoShowIfAvailable` |
+| Auto-show remote agents | `texra.remoteAgents.autoShow` |
 | Storage mode dropdown | `texra.agentOutputs.storageMode` |
 | Require approval checkbox | `texra.toolUse.requireEditApproval` |
 | Persist sessions checkbox | `texra.toolUse.persistence.enabled` |
 | Session retention dropdown | `texra.toolUse.persistence.ttlHours` |
 | Compaction threshold | `texra.model.compactionThresholdPercent` |
+| Max attempts | `texra.model.retry.maxAttempts` |
+| Backoff delay | `texra.model.retry.backoffMs` |
 | Custom agents directory | `texra.explorer.agentsDirectory` (Advanced collapsible) |
 
 **Storage:** `workspaceState.enabledAgents: string[]`, VS Code configuration for settings
@@ -847,11 +857,14 @@ In the Models tab, show provider/routing status on each model:
 │  ┌───────────────────────────────────────────────────────────┐  │
 │  │ General interface preferences.                            │  │
 │  │                                                           │  │
-│  │ ☑ Show quick pick for agent selection                     │  │
-│  │   Use VS Code quick pick instead of dropdown for agents.  │  │
+│  │ ☑ Show API key reminders                                  │  │
+│  │   Show reminders when API keys are missing.               │  │
 │  │                                                           │  │
-│  │ ☑ Show quick pick for model selection                     │  │
-│  │   Use VS Code quick pick instead of dropdown for models.  │  │
+│  │ ☑ Show dependency reminders                               │  │
+│  │   Show reminders for missing dependencies (latexindent).  │  │
+│  │                                                           │  │
+│  │ ☑ Show login banner                                       │  │
+│  │   Show banner suggesting to sign in.                      │  │
 │  │                                                           │  │
 │  │ Max image dimension: [2048 ▼]                             │  │
 │  │   Larger images resized before sending to models.         │  │
@@ -859,12 +872,6 @@ In the Models tab, show provider/routing status on each model:
 │  │                                                           │  │
 │  │ Progress board sort: [Timestamp descending ▼]             │  │
 │  │   Options: Timestamp ascending, Timestamp descending      │  │
-│  └───────────────────────────────────────────────────────────┘  │
-│                                                                 │
-│  ▶ Retry Behavior                                              │
-│  ┌───────────────────────────────────────────────────────────┐  │
-│  │ Max retries: [3 ▼]                                        │  │
-│  │ Initial delay: [1000 ms]                                  │  │
 │  └───────────────────────────────────────────────────────────┘  │
 │                                                                 │
 │  ▶ Git Integration                                             │
@@ -890,19 +897,20 @@ In the Models tab, show provider/routing status on each model:
 | UI Element | VS Code Setting |
 |------------|-----------------|
 | Default merge model | `texra.merge.defaultModel` |
-| Agent quick pick | `texra.ui.showAgentQuickPick` |
-| Model quick pick | `texra.ui.showModelQuickPick` |
+| Show API key reminders | `texra.ui.showApiKeyReminders` |
+| Show dependency reminders | `texra.ui.showDependencyReminders` |
+| Show login banner | `texra.ui.showLoginBanner` |
 | Max image dimension | `texra.maxImageDimension` |
 | Progress board sort | `texra.progressBoard.streamSortOrder` |
-| Max retries | `texra.model.retry.maxRetries` |
-| Initial delay | `texra.model.retry.initialDelayMs` |
 | Commits to show | `texra.git.numberOfCommitsToShow` |
 | Sox audio path | `texra.audio.soxPath` |
-| Debug logging | `texra.debug.*` |
+| Debug mode | `texra.logger.debugMode` |
+| Save debug objects | `texra.debug.saveDebugObjects` |
+| Save input prompt | `texra.debug.saveInputPrompt` |
 
 **Storage:** VS Code configuration (backwards compatible)
 
-**Note:** Multi-Agent is included now, but ensemble features are awaiting multi-agent feature maturity.
+**Note:** Multi-Agent is included now, but ensemble features are awaiting multi-agent feature maturity. Retry settings are in the Agents tab (Tool-Use Settings).
 
 ---
 
@@ -915,7 +923,7 @@ In the Models tab, show provider/routing status on each model:
 - **LaTeX Tab** - Formatter, latexdiff, TikZ (all as collapsibles)
 - **Memory Tab** - Memory file browser with expandable content preview
 - **History Tab** - Execution history browser
-- **Advanced Tab** - Multi-Agent, UI preferences, retry, git, system paths, debug (all collapsibles)
+- **Advanced Tab** - Multi-Agent, UI preferences, git, system paths, debug (all collapsibles)
 
 **Key Features:**
 - Account info in header bar (minimal custom CSS, always visible)
@@ -1460,7 +1468,7 @@ interface AgentInfo {
 - Show category badges (workflow/toolUse) and source (built-in/custom/remote)
 - Wire up workspaceState for agent preferences
 - Add Workflow Settings collapsible (output storage mode)
-- Add Tool-Use Settings collapsible (edit approval, persistence, compaction)
+- Add Tool-Use Settings collapsible (edit approval, persistence, compaction, retry behavior)
 - Include Advanced collapsible (custom agents directory)
 - **Note:** Supersedes FolderExplorer/agent explorer view
 
@@ -1486,8 +1494,7 @@ interface AgentInfo {
 ### Phase 7: Advanced Tab + Cleanup
 - Implement Advanced tab with collapsible sections:
   - Multi-Agent (merge model + "Coming Soon")
-  - UI Preferences (quick picks, image dimension, sort order)
-  - Retry Behavior
+  - UI Preferences (reminders, image dimension, sort order)
   - Git Integration
   - System Paths
   - Debug


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces a detailed PRD for a unified Settings View that consolidates configuration into a VS Code-native tabbed UI.
> 
> - Defines 5 core tabs: `Models`, `Agents`, `LaTeX`, `Memory`, `History` with a minimal-CSS account header bar
> - Specifies provider configuration modal (API key, endpoint, per-provider streaming), OpenRouter routing modes, and model/provider status indicators
> - Establishes state management via VS Code configuration, SecretStorage for API keys, and minimal extension state; no migration required
> - Outlines architecture/file structure for `src/settingsView/*`, message schemas (Zod), commands (`texra.openSettings`, tab-specific open commands), and reuse of existing history/memory handlers
> - Maps UI controls to existing `texra.*` settings; keeps LaTeX settings in VS Code config for backward compatibility
> - Notes deprecation/replacement of `profileView`, `historyView`, `memoryView`, and agent explorer over phased implementation
> - Provides implementation phases, accessibility/performance guidance, and component mapping using `vscode-*` elements
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d2e820dea9c7deeb0d4a987c6db7dfb5e829a6bd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->