### PR TITLE
feat: add LaTeXdiff button to tool edit approval preview

### DIFF
--- a/docs/prd/settings-view-unified.md
+++ b/docs/prd/settings-view-unified.md
@@ -107,6 +107,7 @@ VS Code-native styling without custom CSS complexity.
 ```
 
 **Not Logged In State:**
+
 ```
 ┌─────────────────────────────────────────────────────────────────────────────┐
 │  Use TeXRA with your own API keys                         [Sign In]    [×]  │
@@ -119,6 +120,7 @@ VS Code-native styling without custom CSS complexity.
 ```
 
 **Tab Structure (5 tabs for v1):**
+
 ```
 Tab 1: Models
 ├── Routing options (radio: direct/openrouter/proxy)
@@ -149,6 +151,7 @@ Tab 5: History
 ```
 
 **Deferred to Future Release:**
+
 ```
 Tab 6: Advanced
 ├── ▼ Multi-Agent (collapsible) - merge model, future ensemble
@@ -307,6 +310,7 @@ Tab 6: Advanced
 **Purpose:** Combined model selection and API provider configuration. Each provider shows API status + model selection together.
 
 **Layout:**
+
 ```
 ┌─────────────────────────────────────────────────────────────────┐
 │  Models & Providers                                             │
@@ -357,6 +361,7 @@ Tab 6: Advanced
 ```
 
 **Key Design:**
+
 - Each provider accordion shows: status indicator + [Configure] button + model list
 - Provider status: `✓ API Key`, `✗ No Key`, or `🔑 Env Var`
 - Clicking [Configure] opens provider modal (API key + endpoint + streaming toggle)
@@ -365,16 +370,24 @@ Tab 6: Advanced
 **Data Source:** `llm-zoo` package (ModelRegistry)
 
 **Model Metadata Displayed:**
+
 - Name (display name)
 - Context window
 - Cost (input/output per 1M tokens)
 - Capabilities icons: 🧠 Reasoning, 👁 Vision, 📄 PDF, 🎧 Audio, 💬 Tools, ⚡ Cache
 
 **Recommended Models (hardcoded):**
+
 ```typescript
 const RECOMMENDED_MODELS = [
-  'sonnet45T', 'opus45T', 'gpt52', 'gemini3p',
-  'grok4', 'deepseekT', 'kimi2T', 'qwen3max'
+  'sonnet45T',
+  'opus45T',
+  'gpt52',
+  'gemini3p',
+  'grok4',
+  'deepseekT',
+  'kimi2T',
+  'qwen3max',
 ];
 ```
 
@@ -400,6 +413,7 @@ const RECOMMENDED_MODELS = [
 | Source | File location | `Built-in`, `Custom`, `Remote` |
 
 **Agent Type Icons (codicons):**
+
 - `$(lightbulb)` CoT (Chain-of-Thought)
 - `$(zap)` Direct
 - `$(git-merge)` Merge
@@ -407,6 +421,7 @@ const RECOMMENDED_MODELS = [
 - `$(tools)` Tool-Use
 
 **Layout:**
+
 ```
 ┌─────────────────────────────────────────────────────────────────┐
 │  Select which agents appear in the dropdown.                    │
@@ -491,6 +506,7 @@ const RECOMMENDED_MODELS = [
 ```
 
 **Custom Agent Actions:**
+
 - `[Source Code]` - Opens agent YAML file in editor
 - `[Delete]` - Deletes custom agent YAML file
 
@@ -520,6 +536,7 @@ const RECOMMENDED_MODELS = [
 **Design Philosophy:** Consolidate scattered LaTeX-related VS Code settings into a visual, grouped interface. Settings remain in VS Code configuration for backwards compatibility.
 
 **Layout:**
+
 ```
 ┌─────────────────────────────────────────────────────────────────┐
 │  Configure LaTeX formatting and processing options.             │
@@ -621,6 +638,7 @@ const RECOMMENDED_MODELS = [
 **Key Design:** Show memory content on expand (like current memoryView implementation).
 
 **Layout:**
+
 ```
 ┌─────────────────────────────────────────────────────────────────┐
 │  Memory                                                         │
@@ -654,6 +672,7 @@ const RECOMMENDED_MODELS = [
 ```
 
 **Features:** (Migrated from memoryView)
+
 - Memory file browser with expandable content preview
 - Click file to expand and show content preview (first ~20 lines)
 - [View Full] opens file in editor
@@ -662,6 +681,7 @@ const RECOMMENDED_MODELS = [
 - Storage usage display
 
 **Data Sources:**
+
 - Memory files: `/memories` directory managed by MemoryTool
 
 **Storage:** File system (no extension state needed)
@@ -673,6 +693,7 @@ const RECOMMENDED_MODELS = [
 **Purpose:** Browse and restore previous agent executions.
 
 **Layout:** (Migrated from existing historyView)
+
 ```
 ┌─────────────────────────────────────────────────────────────────┐
 │  ┌──────────────────────────────────────────────────────────┐   │
@@ -698,6 +719,7 @@ const RECOMMENDED_MODELS = [
 ```
 
 **Features:** (Same as current historyView)
+
 - Search with highlighting (mark.js)
 - Delete, Restore, Rerun actions
 - Collapsible details per item
@@ -711,6 +733,7 @@ const RECOMMENDED_MODELS = [
 When clicking [Edit] or [Configure] on a provider:
 
 **Standard Provider (Anthropic, OpenAI, Google, etc.):**
+
 ```
 ┌─────────────────────────────────────────────────────────────────┐
 │  Configure Anthropic                                     [×]   │
@@ -751,21 +774,22 @@ When clicking [Edit] or [Configure] on a provider:
 **Streaming Settings (per provider):**
 Each provider's modal streaming toggle maps to its specific setting:
 
-| Provider Modal | VS Code Setting |
-|----------------|-----------------|
-| Anthropic | `texra.model.useStreamingAnthropic` |
-| OpenAI | `texra.model.useStreamingOpenai` |
-| Google | `texra.model.useStreamingGoogle` |
-| DeepSeek | `texra.model.useStreamingDeepseek` |
-| xAI | `texra.model.useStreamingXai` |
-| Moonshot | `texra.model.useStreamingMoonshot` |
-| Dashscope | `texra.model.useStreamingDashscope` |
-| OpenRouter | `texra.model.useStreamingOpenrouter` |
-| (Global fallback) | `texra.model.useStreaming` |
+| Provider Modal    | VS Code Setting                      |
+| ----------------- | ------------------------------------ |
+| Anthropic         | `texra.model.useStreamingAnthropic`  |
+| OpenAI            | `texra.model.useStreamingOpenai`     |
+| Google            | `texra.model.useStreamingGoogle`     |
+| DeepSeek          | `texra.model.useStreamingDeepseek`   |
+| xAI               | `texra.model.useStreamingXai`        |
+| Moonshot          | `texra.model.useStreamingMoonshot`   |
+| Dashscope         | `texra.model.useStreamingDashscope`  |
+| OpenRouter        | `texra.model.useStreamingOpenrouter` |
+| (Global fallback) | `texra.model.useStreaming`           |
 
 Per-provider settings override the global `useStreaming` setting.
 
 **OpenRouter (Special Case):**
+
 ```
 ┌─────────────────────────────────────────────────────────────────┐
 │  Configure OpenRouter                                    [×]   │
@@ -821,6 +845,7 @@ In the Models tab, show provider/routing status on each model:
 ```
 
 **Status Icons:**
+
 - `✓ Ready` - API key configured, model available
 - `⚠ No key` - Provider not configured (click to configure)
 - `🔀 OpenRouter` - Available via OpenRouter only
@@ -835,6 +860,7 @@ In the Models tab, show provider/routing status on each model:
 **Purpose:** Multi-agent settings, UI preferences, retry behavior, system paths, and developer options. Uses vscode-collapsible for organization.
 
 **Layout:**
+
 ```
 ┌─────────────────────────────────────────────────────────────────┐
 │  Advanced settings and system configuration.                    │
@@ -917,6 +943,7 @@ In the Models tab, show provider/routing status on each model:
 ### Features Summary
 
 **Tab Layout with Header Bar (v1 - 5 tabs):**
+
 - **Header Bar** - Account info, sign in/out, manage account (always visible)
 - **Models Tab** - Provider configuration, model selection, routing options
 - **Agents Tab** - Agent list, Workflow Settings (collapsible), Tool-Use Settings (collapsible)
@@ -925,9 +952,11 @@ In the Models tab, show provider/routing status on each model:
 - **History Tab** - Execution history browser
 
 **Deferred to Later Release:**
+
 - **Advanced Tab** - Multi-Agent, UI preferences, git, system paths, debug (all collapsibles)
 
 **Key Features:**
+
 - Account info in header bar (minimal custom CSS, always visible)
 - Native vscode-tabs for navigation (no custom styling)
 - vscode-collapsible for subsections within tabs
@@ -938,6 +967,7 @@ In the Models tab, show provider/routing status on each model:
 - Environment variable hints
 
 **Key UX Improvements:**
+
 1. **Works without login** - Configure API keys without account
 2. **Visual provider status** - See which providers are configured at a glance
 3. **Custom endpoints exposed** - No more hidden VS Code settings
@@ -962,7 +992,11 @@ await config.update('maxImageDimension', 2048, ConfigurationTarget.Global);
 
 // Workspace settings (project-level, .vscode/settings.json)
 await config.update('agents', enabledAgents, ConfigurationTarget.Workspace);
-await config.update('agentOutputs.storageMode', 'folder', ConfigurationTarget.Workspace);
+await config.update(
+  'agentOutputs.storageMode',
+  'folder',
+  ConfigurationTarget.Workspace,
+);
 ```
 
 **Setting Scopes:**
@@ -977,6 +1011,7 @@ await config.update('agentOutputs.storageMode', 'folder', ConfigurationTarget.Wo
 | `texra.latex.*` | Global/Workspace | User choice |
 
 **Benefits of VS Code Config:**
+
 - No extension state migration needed
 - Works with VS Code Settings Sync automatically
 - Users can still edit settings.json directly
@@ -988,7 +1023,7 @@ Only for caching and truly ephemeral UI state:
 
 ```typescript
 // globalState - only for caching
-context.globalState.get('modelMetadataCache');  // Cached llm-zoo data
+context.globalState.get('modelMetadataCache'); // Cached llm-zoo data
 
 // No settings stored in extension state
 ```
@@ -1029,6 +1064,7 @@ XAI_API_KEY=...
 ```
 
 **Priority order:**
+
 1. VS Code Secrets (highest)
 2. Environment variables
 3. `.env` file in workspace
@@ -1037,19 +1073,42 @@ XAI_API_KEY=...
 
 ```typescript
 const RECOMMENDED_MODELS = [
-  'sonnet45T', 'opus45T', 'gpt52', 'gemini3p',
-  'grok4', 'deepseekT', 'kimi2T', 'qwen3max'
+  'sonnet45T',
+  'opus45T',
+  'gpt52',
+  'gemini3p',
+  'grok4',
+  'deepseekT',
+  'kimi2T',
+  'qwen3max',
 ];
 
 const DEFAULT_ENABLED_MODELS = [
-  'sonnet45T', 'opus45T', 'gpt52', 'gpt52pro', 'gpt41',
-  'gemini3p', 'gemini3f', 'grok4', 'deepseekT',
-  'kimi2T', 'kimi2', 'qwen3max'
+  'sonnet45T',
+  'opus45T',
+  'gpt52',
+  'gpt52pro',
+  'gpt41',
+  'gemini3p',
+  'gemini3f',
+  'grok4',
+  'deepseekT',
+  'kimi2T',
+  'kimi2',
+  'qwen3max',
 ];
 
 const DEFAULT_ENABLED_AGENTS = [
-  'ask', 'chat', 'correct', 'draw', 'ocr',
-  'paper2slide', 'paper2poster', 'polish', 'research', 'search'
+  'ask',
+  'chat',
+  'correct',
+  'draw',
+  'ocr',
+  'paper2slide',
+  'paper2poster',
+  'polish',
+  'research',
+  'search',
 ];
 
 const DEFAULT_ROUTING = {
@@ -1125,7 +1184,7 @@ context.secrets.get('apiKey.anthropic');
 context.secrets.store('apiKey.anthropic', 'sk-...');
 
 // Environment variable fallback also unchanged
-process.env.ANTHROPIC_API_KEY
+process.env.ANTHROPIC_API_KEY;
 ```
 
 Users who have configured API keys will continue to work without any action.
@@ -1219,14 +1278,17 @@ export function registerSettingsCommands(context: vscode.ExtensionContext) {
       async (tab?: SettingsTab) => {
         await settingsViewProvider.show();
         if (tab) settingsViewProvider.selectTab(tab);
-      }
+      },
     ),
     vscode.commands.registerCommand(settingsCommands.openModelSettings, () =>
-      vscode.commands.executeCommand(settingsCommands.openSettings, 'models')),
+      vscode.commands.executeCommand(settingsCommands.openSettings, 'models'),
+    ),
     vscode.commands.registerCommand(settingsCommands.openAgentSettings, () =>
-      vscode.commands.executeCommand(settingsCommands.openSettings, 'agents')),
+      vscode.commands.executeCommand(settingsCommands.openSettings, 'agents'),
+    ),
     vscode.commands.registerCommand(settingsCommands.openLatexSettings, () =>
-      vscode.commands.executeCommand(settingsCommands.openSettings, 'latex')),
+      vscode.commands.executeCommand(settingsCommands.openSettings, 'latex'),
+    ),
   );
 
   return { settingsViewProvider };
@@ -1244,9 +1306,9 @@ Use Zod schemas as single source of truth. Reference existing types from the cod
 ```typescript
 // src/settingsView/schemas.ts
 import { z } from 'zod';
-import { ModelConfigSchema } from '@model/ModelConfig';           // From llm-zoo
-import { AgentSource } from '@agent/core/AgentDataclass';         // Zod enum
-import type { AgentEntry } from '@agent/index/agentRegistry';     // Existing interface
+import { ModelConfigSchema } from '@model/ModelConfig'; // From llm-zoo
+import { AgentSource } from '@agent/core/AgentDataclass'; // Zod enum
+import type { AgentEntry } from '@agent/index/agentRegistry'; // Existing interface
 
 // =============================================================================
 // Command Constants (following src/common/webview/commands.ts pattern)
@@ -1273,7 +1335,13 @@ export const SETTINGS_VIEW_COMMANDS = {
 // Shared Schemas
 // =============================================================================
 
-export const SettingsTabSchema = z.enum(['models', 'agents', 'latex', 'memory', 'history']);
+export const SettingsTabSchema = z.enum([
+  'models',
+  'agents',
+  'latex',
+  'memory',
+  'history',
+]);
 export type SettingsTab = z.infer<typeof SettingsTabSchema>;
 
 // =============================================================================
@@ -1282,25 +1350,28 @@ export type SettingsTab = z.infer<typeof SettingsTabSchema>;
 
 export const SetModelsDataSchema = z.object({
   command: z.literal('SET_MODELS_DATA'),
-  models: z.array(ModelConfigSchema),  // Use llm-zoo schema directly
+  models: z.array(ModelConfigSchema), // Use llm-zoo schema directly
   enabled: z.array(z.string()),
 });
 
 export const SetAgentsDataSchema = z.object({
   command: z.literal('SET_AGENTS_DATA'),
-  agents: z.array(z.object({           // Mirrors AgentEntry + enabled flag
-    name: z.string(),
-    source: AgentSource,
-    category: z.enum(['workflow', 'toolUse']),
-    agentType: z.enum(['CoT', 'direct', 'toolUse']),
-    description: z.string().optional(),
-    enabled: z.boolean(),
-  })),
+  agents: z.array(
+    z.object({
+      // Mirrors AgentEntry + enabled flag
+      name: z.string(),
+      source: AgentSource,
+      category: z.enum(['workflow', 'toolUse']),
+      agentType: z.enum(['CoT', 'direct', 'toolUse']),
+      description: z.string().optional(),
+      enabled: z.boolean(),
+    }),
+  ),
 });
 
 export const SetLatexDataSchema = z.object({
   command: z.literal('SET_LATEX_DATA'),
-  settings: z.record(z.unknown()),     // VS Code config snapshot
+  settings: z.record(z.unknown()), // VS Code config snapshot
 });
 
 export const SelectTabSchema = z.object({
@@ -1325,10 +1396,24 @@ export type SettingsMessage = z.infer<typeof SettingsMessageSchema>;
 export const SettingsActionSchema = z.discriminatedUnion('command', [
   z.object({ command: z.literal('GET_INITIAL_DATA') }),
   z.object({ command: z.literal('TAB_CHANGED'), tab: SettingsTabSchema }),
-  z.object({ command: z.literal('SAVE_ENABLED_MODELS'), models: z.array(z.string()) }),
-  z.object({ command: z.literal('SAVE_ENABLED_AGENTS'), agents: z.array(z.string()) }),
-  z.object({ command: z.literal('SAVE_SETTING'), key: z.string(), value: z.unknown() }),
-  z.object({ command: z.literal('SET_API_KEY'), provider: z.string(), key: z.string() }),
+  z.object({
+    command: z.literal('SAVE_ENABLED_MODELS'),
+    models: z.array(z.string()),
+  }),
+  z.object({
+    command: z.literal('SAVE_ENABLED_AGENTS'),
+    agents: z.array(z.string()),
+  }),
+  z.object({
+    command: z.literal('SAVE_SETTING'),
+    key: z.string(),
+    value: z.unknown(),
+  }),
+  z.object({
+    command: z.literal('SET_API_KEY'),
+    provider: z.string(),
+    key: z.string(),
+  }),
   z.object({ command: z.literal('SIGN_IN') }),
   z.object({ command: z.literal('SIGN_OUT') }),
   // History/Memory actions reuse existing schemas
@@ -1338,6 +1423,7 @@ export type SettingsAction = z.infer<typeof SettingsActionSchema>;
 ```
 
 **Key points:**
+
 - `ModelConfigSchema` from `@model/ModelConfig` (mirrors llm-zoo types)
 - `AgentSource` Zod enum from `@agent/core/AgentDataclass`
 - `AgentEntry` interface from `@agent/index/agentRegistry` (no duplication)
@@ -1350,9 +1436,9 @@ export type SettingsAction = z.infer<typeof SettingsActionSchema>;
 ```typescript
 // Settings View should call these existing functions:
 import {
-  getWorkflowAgents,    // Returns AgentEntry[] with category already set
-  getToolUseAgents,     // Returns AgentEntry[] with category already set
-  buildAgentOptions,    // Returns HTML <option> elements (if needed)
+  getWorkflowAgents, // Returns AgentEntry[] with category already set
+  getToolUseAgents, // Returns AgentEntry[] with category already set
+  buildAgentOptions, // Returns HTML <option> elements (if needed)
 } from '@agent/index/agentRegistry';
 
 // Category is already derived in AgentEntry - just use it
@@ -1360,6 +1446,7 @@ const agents = [...getWorkflowAgents(), ...getToolUseAgents()];
 ```
 
 **Implementation detail (for reference only):**
+
 - Local agents: category derived from `source === 'builtInToolUse' || agentType === 'toolUse'`
 - Remote agents: uses `agentCategory` field from remote definition
 - Config override: `texra.toolUseAgents` setting can override any agent
@@ -1387,6 +1474,7 @@ const agents = [...getWorkflowAgents(), ...getToolUseAgents()];
 ## Success Metrics
 
 ### v1 Release
+
 1. Single entry point for 5 core tabs (Models, Agents, LaTeX, Memory, History)
 2. Native vscode-tabs navigation (keyboard accessible)
 3. Settings properly scoped (models global, agents per-workspace via ConfigurationTarget)
@@ -1404,12 +1492,14 @@ const agents = [...getWorkflowAgents(), ...getToolUseAgents()];
 ### v1 Release (5 Tabs)
 
 #### Phase 1: Core Structure
+
 - Create settingsView with vscode-tabs + header bar
 - Implement header bar (account info, sign in/out - minimal custom CSS)
 - Add main webview entry point (gear icon)
 - Deep link support (open to specific tab)
 
 #### Phase 2: Models Tab
+
 - Implement Models tab with provider collapsibles
 - Provider accordions with API status + model list
 - Provider configuration modal (API key + endpoint + streaming toggle)
@@ -1417,6 +1507,7 @@ const agents = [...getWorkflowAgents(), ...getToolUseAgents()];
 - Migrate provider config from old profileView
 
 #### Phase 3: Agents Tab
+
 - Implement Agents tab with agent list
 - Show category badges (workflow/toolUse) and source (built-in/custom/remote)
 - Add Workflow Settings collapsible (output storage mode)
@@ -1425,6 +1516,7 @@ const agents = [...getWorkflowAgents(), ...getToolUseAgents()];
 - **Note:** Supersedes FolderExplorer/agent explorer view
 
 #### Phase 4: LaTeX Tab
+
 - Implement LaTeX tab with collapsible sections:
   - Formatter (collapsible)
   - LaTeXdiff (collapsible)
@@ -1434,11 +1526,13 @@ const agents = [...getWorkflowAgents(), ...getToolUseAgents()];
 - Add file browser for config paths
 
 #### Phase 5: Memory Tab
+
 - Migrate memoryView to Memory tab
 - Implement expandable content preview
 - Delete old memoryView
 
 #### Phase 6: History Tab + v1 Cleanup
+
 - Move history rendering to History tab
 - Preserve search, delete, restore, rerun functionality
 - Delete old historyView
@@ -1449,6 +1543,7 @@ const agents = [...getWorkflowAgents(), ...getToolUseAgents()];
 ### Future Release (Deferred)
 
 #### Advanced Tab
+
 - Multi-Agent (merge model + ensemble features)
 - UI Preferences (reminders, image dimension, sort order)
 - Git Integration
@@ -1456,10 +1551,12 @@ const agents = [...getWorkflowAgents(), ...getToolUseAgents()];
 - Debug
 
 #### Agent Creation Wizard
+
 - AI-assisted agent creation from plain English description
 - Form-based editing without YAML knowledge
 
 #### Multi-Agent Ensemble
+
 - Run across multiple models with voting/consensus
 
 ---
@@ -1470,25 +1567,26 @@ Based on 79 total settings in package.json:
 
 ### v1 Release - Covered by Settings View
 
-| Tab | Settings Covered |
-|-----|------------------|
-| **Models** | `texra.models`, `texra.model.useStreaming*` (9), `texra.model.useOpenRouter`, `texra.model.useImprovedConnection`, `texra.model.improvedConnectionDomain`, `texra.model.baseUrlDeepSeek` |
-| **Agents** | `texra.agents`, `texra.toolUseAgents`, `texra.remoteAgents.autoShow`, `texra.explorer.agentsDirectory`, `texra.agentOutputs.storageMode`, `texra.toolUse.*` (3), `texra.model.compactionThresholdPercent`, `texra.model.retry.*` (2) |
-| **LaTeX** | `texra.latex.*` (7), `texra.latexdiff.*` (4) |
-| **Memory** | Memory file browser (no config, file system) |
-| **History** | History browser (existing storage) |
+| Tab         | Settings Covered                                                                                                                                                                                                                     |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Models**  | `texra.models`, `texra.model.useStreaming*` (9), `texra.model.useOpenRouter`, `texra.model.useImprovedConnection`, `texra.model.improvedConnectionDomain`, `texra.model.baseUrlDeepSeek`                                             |
+| **Agents**  | `texra.agents`, `texra.toolUseAgents`, `texra.remoteAgents.autoShow`, `texra.explorer.agentsDirectory`, `texra.agentOutputs.storageMode`, `texra.toolUse.*` (3), `texra.model.compactionThresholdPercent`, `texra.model.retry.*` (2) |
+| **LaTeX**   | `texra.latex.*` (7), `texra.latexdiff.*` (4)                                                                                                                                                                                         |
+| **Memory**  | Memory file browser (no config, file system)                                                                                                                                                                                         |
+| **History** | History browser (existing storage)                                                                                                                                                                                                   |
 
 ### Deferred to Future Release (Advanced Tab)
 
-| Section | Settings |
-|---------|----------|
-| **Multi-Agent** | `texra.merge.defaultModel` |
-| **UI Preferences** | `texra.ui.*` (3), `texra.progressBoard.streamSortOrder`, `texra.maxImageDimension` |
-| **Git Integration** | `texra.git.numberOfCommitsToShow` |
-| **System Paths** | `texra.audio.soxPath` |
-| **Debug** | `texra.debug.*`, `texra.logger.*` |
+| Section             | Settings                                                                           |
+| ------------------- | ---------------------------------------------------------------------------------- |
+| **Multi-Agent**     | `texra.merge.defaultModel`                                                         |
+| **UI Preferences**  | `texra.ui.*` (3), `texra.progressBoard.streamSortOrder`, `texra.maxImageDimension` |
+| **Git Integration** | `texra.git.numberOfCommitsToShow`                                                  |
+| **System Paths**    | `texra.audio.soxPath`                                                              |
+| **Debug**           | `texra.debug.*`, `texra.logger.*`                                                  |
 
 ### Remain as VS Code Settings Only
+
 These are advanced/power-user settings that don't need UI exposure:
 
 - `texra.files.*` (16) - File type filtering patterns (power user)
@@ -1502,49 +1600,58 @@ These are advanced/power-user settings that don't need UI exposure:
 Key integration points that need updating when implementing the Settings View:
 
 ### 1. Main Webview Entry Points
-| Location | Current Behavior | New Behavior |
-|----------|-----------------|--------------|
-| `src/webview/index.html` line 524 | Agent settings button → VS Code settings | → Settings View (Agents tab) |
-| `src/webview/index.html` line 552 | Model settings button → VS Code settings | → Settings View (Models tab) |
-| `src/webview/modules/uiManagers/SettingsButtonManager.js` | Opens VS Code settings | Opens Settings View |
+
+| Location                                                  | Current Behavior                         | New Behavior                 |
+| --------------------------------------------------------- | ---------------------------------------- | ---------------------------- |
+| `src/webview/index.html` line 524                         | Agent settings button → VS Code settings | → Settings View (Agents tab) |
+| `src/webview/index.html` line 552                         | Model settings button → VS Code settings | → Settings View (Models tab) |
+| `src/webview/modules/uiManagers/SettingsButtonManager.js` | Opens VS Code settings                   | Opens Settings View          |
 
 ### 2. Commands to Update
-| Command | File | Change |
-|---------|------|--------|
+
+| Command              | File                   | Change                                         |
+| -------------------- | ---------------------- | ---------------------------------------------- |
 | `texra.openSettings` | `src/commands/system/` | Open Settings View instead of VS Code settings |
 
 **New commands to add (shortcuts):**
+
 - `texra.openAgentSettings` → Opens Settings View → Agents tab
 - `texra.openModelSettings` → Opens Settings View → Models tab
 
 ### 3. Dropdown Options Computation
-| Function | File | Impact |
-|----------|------|--------|
+
+| Function                | File                               | Impact                                 |
+| ----------------------- | ---------------------------------- | -------------------------------------- |
 | `computeAgentOptions()` | `src/agent/index/agentRegistry.ts` | No change - still reads VS Code config |
 | `computeModelOptions()` | `src/model/computeModelOptions.ts` | No change - still reads VS Code config |
 
 ### 4. Configuration Watchers
+
 `src/MainViewProvider.ts` (lines 84-120) watches for config changes.
+
 - No change needed - Settings View writes to VS Code config
 - Existing watchers will pick up changes automatically
 
 ### 5. View Registrations (package.json)
-| View | Current | After Implementation |
-|------|---------|---------------------|
-| `texra.profileView` | Registered in contributes.views | Remove after Phase 6 |
-| `texra.historyView` | Command-opened panel | Remove after Phase 5 |
-| `texra.memoryView` | Command-opened panel | Remove after Phase 4 |
-| `texra.agentExplorer` | TreeView in sidebar | Remove after Phase 2 |
-| `texra.settingsView` | N/A | Add new panel registration |
+
+| View                  | Current                         | After Implementation       |
+| --------------------- | ------------------------------- | -------------------------- |
+| `texra.profileView`   | Registered in contributes.views | Remove after Phase 6       |
+| `texra.historyView`   | Command-opened panel            | Remove after Phase 5       |
+| `texra.memoryView`    | Command-opened panel            | Remove after Phase 4       |
+| `texra.agentExplorer` | TreeView in sidebar             | Remove after Phase 2       |
+| `texra.settingsView`  | N/A                             | Add new panel registration |
 
 ### 6. Message Handlers to Migrate
-| Handler | From | To |
-|---------|------|-----|
+
+| Handler                     | From               | To                            |
+| --------------------------- | ------------------ | ----------------------------- |
 | `ProfileViewMessageHandler` | `src/profileView/` | `src/settingsView/` (compose) |
 | `HistoryViewMessageHandler` | `src/historyView/` | `src/settingsView/` (compose) |
-| `MemoryViewMessageHandler` | `src/memoryView/` | `src/settingsView/` (compose) |
+| `MemoryViewMessageHandler`  | `src/memoryView/`  | `src/settingsView/` (compose) |
 
 ### 7. No State Migration Needed
+
 Settings View reads/writes directly to VS Code configuration - no migration required.
 
 ---
@@ -1552,6 +1659,7 @@ Settings View reads/writes directly to VS Code configuration - no migration requ
 ## Component Mapping (vscode-elements)
 
 ### Tab Layout
+
 ```html
 <vscode-tabs>                   <!-- Tab container -->
   <vscode-tab-header>           <!-- Tab buttons -->
@@ -1561,18 +1669,19 @@ Settings View reads/writes directly to VS Code configuration - no migration requ
 
 ### Form Components by Tab
 
-| UI Pattern | Component | Example Usage |
-|------------|-----------|---------------|
-| **Single selection** | `<vscode-single-select>` | Formatter dropdown, Math markup |
-| **Checkbox** | `<vscode-checkbox>` | Enable/disable toggles |
-| **Text input** | `<vscode-textfield>` | API keys, file paths |
-| **Multiline text** | `<vscode-textarea>` | TikZ template, agent instructions |
-| **Radio group** | `<vscode-radio-group>` | Routing mode, access mode |
-| **Collapsible section** | `<vscode-collapsible>` | Advanced options, provider details |
-| **Button** | `<vscode-button>` | Save, Browse, Create Agent |
-| **Badge** | `<vscode-badge>` | Category badges (workflow/toolUse) |
+| UI Pattern              | Component                | Example Usage                      |
+| ----------------------- | ------------------------ | ---------------------------------- |
+| **Single selection**    | `<vscode-single-select>` | Formatter dropdown, Math markup    |
+| **Checkbox**            | `<vscode-checkbox>`      | Enable/disable toggles             |
+| **Text input**          | `<vscode-textfield>`     | API keys, file paths               |
+| **Multiline text**      | `<vscode-textarea>`      | TikZ template, agent instructions  |
+| **Radio group**         | `<vscode-radio-group>`   | Routing mode, access mode          |
+| **Collapsible section** | `<vscode-collapsible>`   | Advanced options, provider details |
+| **Button**              | `<vscode-button>`        | Save, Browse, Create Agent         |
+| **Badge**               | `<vscode-badge>`         | Category badges (workflow/toolUse) |
 
 ### Form Layout Components
+
 ```html
 <!-- Standard form group with label -->
 <vscode-form-group>
@@ -1603,11 +1712,13 @@ Settings View reads/writes directly to VS Code configuration - no migration requ
 ```
 
 ### Models Tab Components
+
 - `<vscode-collapsible>` - Provider accordions (Anthropic, OpenAI, etc.)
 - `<vscode-checkbox>` - Model enable/disable
 - `<vscode-badge>` - Capability icons, status indicators
 
 ### Agents Tab Components
+
 - `<vscode-checkbox>` - Agent enable/disable
 - `<vscode-badge>` - Category badges (workflow/toolUse), source badges
 - `<vscode-button>` - Create Agent, Edit, Delete
@@ -1615,6 +1726,7 @@ Settings View reads/writes directly to VS Code configuration - no migration requ
 - `<vscode-textarea>` - Agent instructions
 
 ### LaTeX Tab Components
+
 - `<vscode-single-select>` - Formatter, math markup
 - `<vscode-checkbox>` - Boolean settings
 - `<vscode-textfield>` - File paths, regex patterns
@@ -1622,6 +1734,7 @@ Settings View reads/writes directly to VS Code configuration - no migration requ
 - `<vscode-collapsible>` - Advanced sections
 
 ### Header Bar + Provider Modal Components
+
 - `<vscode-button>` - Manage, Sign In/Out
 - `<vscode-textfield type="password">` - API keys (in modal)
 - `<vscode-radio-group>` - Routing mode (in Models tab)
@@ -1641,10 +1754,13 @@ src/settingsView/
 ```
 
 ### Provider Pattern
+
 ```typescript
 // SettingsViewProvider.ts
-export class SettingsViewProvider extends BaseWebviewProvider
-    implements vscode.WebviewViewProvider {
+export class SettingsViewProvider
+  extends BaseWebviewProvider
+  implements vscode.WebviewViewProvider
+{
   public static readonly viewType = 'texra.settingsView';
 
   protected contentProvider: SettingsViewContentProvider;
@@ -1659,7 +1775,10 @@ export class SettingsViewProvider extends BaseWebviewProvider
   public resolveWebviewView(webviewView: vscode.WebviewView): void {
     webviewView.webview.options = {
       enableScripts: true,
-      localResourceRoots: getSharedLocalResourceRoots(this.context, 'settingsView'),
+      localResourceRoots: getSharedLocalResourceRoots(
+        this.context,
+        'settingsView',
+      ),
     };
     super.resolveWebviewViewInternal(webviewView);
   }
@@ -1679,6 +1798,7 @@ export class SettingsViewProvider extends BaseWebviewProvider
 ```
 
 ### Module Descriptors Pattern
+
 ```typescript
 // SettingsViewContentProvider.ts
 const SETTINGS_VIEW_MODULES = [
@@ -1696,7 +1816,9 @@ export class SettingsViewContentProvider extends BaseViewContentProvider {
   constructor(context: vscode.ExtensionContext) {
     super(context, 'SettingsView', [...SETTINGS_VIEW_MODULES]);
   }
-  protected getViewPath(): string { return 'settingsView'; }
+  protected getViewPath(): string {
+    return 'settingsView';
+  }
 }
 ```
 
@@ -1710,18 +1832,22 @@ import { BaseDomHandler } from '@common/modules/BaseDomHandler.js';
 
 export class ModelsTab extends BaseDomHandler {
   constructor(containerSelector) {
-    super();  // BaseDomHandler provides addListener, removeListener, dispose
+    super(); // BaseDomHandler provides addListener, removeListener, dispose
     this.container = document.querySelector(containerSelector);
   }
 
   render(data) {
     this.container.innerHTML = `
       <vscode-collapsible title="Recommended Models" open>
-        ${data.recommended.map(m => `
+        ${data.recommended
+          .map(
+            (m) => `
           <vscode-checkbox id="model-${m.name}" ${m.enabled ? 'checked' : ''}>
             ${m.fullName} - ${m.provider}
           </vscode-checkbox>
-        `).join('')}
+        `,
+          )
+          .join('')}
       </vscode-collapsible>
     `;
     this.attachEventListeners();
@@ -1729,7 +1855,7 @@ export class ModelsTab extends BaseDomHandler {
 
   attachEventListeners() {
     // Use inherited addListener for automatic cleanup on dispose()
-    this.container.querySelectorAll('vscode-checkbox').forEach(cb => {
+    this.container.querySelectorAll('vscode-checkbox').forEach((cb) => {
       this.addListener(cb, 'change', () => this.handleModelToggle(cb));
     });
   }
@@ -1737,11 +1863,13 @@ export class ModelsTab extends BaseDomHandler {
 ```
 
 **Key point:** `BaseDomHandler` already provides:
+
 - `addListener(element, event, handler)` - with automatic cleanup
 - `removeListener(element, event, handler)`
 - `dispose()` - cleans up all registered listeners
 
 ### Minimal Custom CSS (extend common.css)
+
 ```css
 /* settingsView/styles/index.css */
 /* Rely on vscode-form-group and vscode-elements for layout */
@@ -1778,6 +1906,7 @@ export class ModelsTab extends BaseDomHandler {
 ```
 
 ### Message Handler Composition
+
 ```typescript
 // SettingsViewMessageHandler.ts
 export class SettingsViewMessageHandler extends BaseViewMessageHandler<...> {
@@ -1814,6 +1943,7 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<...> {
 ```
 
 ### Reducing Boilerplate: Setting Renderer Factory
+
 ```javascript
 // modules/utils/SettingRenderer.js
 export const SettingRenderer = {
@@ -1823,7 +1953,7 @@ export const SettingRenderer = {
       <div class="setting-row">
         <span class="setting-label">${label}</span>
         <vscode-single-select id="${id}" value="${value}">
-          ${options.map(o => `<vscode-option value="${o.value}">${o.label}</vscode-option>`).join('')}
+          ${options.map((o) => `<vscode-option value="${o.value}">${o.label}</vscode-option>`).join('')}
         </vscode-single-select>
       </div>
     `;
@@ -1862,7 +1992,7 @@ export const SettingRenderer = {
         ${settingsHtml}
       </div>
     `;
-  }
+  },
 };
 ```
 
@@ -1873,55 +2003,61 @@ export const SettingRenderer = {
 Based on actual `package.json` configuration (14 settings total):
 
 ### Group 1: Formatter (4 settings)
-| Setting | UI Component |
-|---------|--------------|
-| `texra.latex.formatter` | `<vscode-single-select>` (latexindent/tex-fmt/none) |
-| `texra.latex.latexindentConfig` | `<vscode-textfield>` + Browse |
-| `texra.latex.texfmtConfig` | `<vscode-textfield>` + Browse |
-| `texra.latex.showLatexindentWarning` | `<vscode-checkbox>` |
+
+| Setting                              | UI Component                                        |
+| ------------------------------------ | --------------------------------------------------- |
+| `texra.latex.formatter`              | `<vscode-single-select>` (latexindent/tex-fmt/none) |
+| `texra.latex.latexindentConfig`      | `<vscode-textfield>` + Browse                       |
+| `texra.latex.texfmtConfig`           | `<vscode-textfield>` + Browse                       |
+| `texra.latex.showLatexindentWarning` | `<vscode-checkbox>`                                 |
 
 ### Group 2: LaTeXdiff (4 settings)
-| Setting | UI Component |
-|---------|--------------|
-| `texra.latexdiff.mathMarkup` | `<vscode-single-select>` (off/whole/coarse/fine) |
-| `texra.latexdiff.timeoutMs` | `<vscode-textfield type="number">` |
-| `texra.latexdiff.pictureEnvironments` | `<vscode-textfield>` (regex) |
-| `texra.latexdiff.generateBetweenRoundDiffs` | `<vscode-checkbox>` |
+
+| Setting                                     | UI Component                                     |
+| ------------------------------------------- | ------------------------------------------------ |
+| `texra.latexdiff.mathMarkup`                | `<vscode-single-select>` (off/whole/coarse/fine) |
+| `texra.latexdiff.timeoutMs`                 | `<vscode-textfield type="number">`               |
+| `texra.latexdiff.pictureEnvironments`       | `<vscode-textfield>` (regex)                     |
+| `texra.latexdiff.generateBetweenRoundDiffs` | `<vscode-checkbox>`                              |
 
 ### Group 3: TikZ Figures (3 settings)
-| Setting | UI Component |
-|---------|--------------|
-| `texra.latex.tikzInputDirectory` | `<vscode-textfield>` + Browse |
-| `texra.latex.includeWorkspaceInTexinputs` | `<vscode-checkbox>` |
-| `texra.latex.tikzTemplate` | `<vscode-collapsible>` + `<vscode-textarea>` |
+
+| Setting                                   | UI Component                                 |
+| ----------------------------------------- | -------------------------------------------- |
+| `texra.latex.tikzInputDirectory`          | `<vscode-textfield>` + Browse                |
+| `texra.latex.includeWorkspaceInTexinputs` | `<vscode-checkbox>`                          |
+| `texra.latex.tikzTemplate`                | `<vscode-collapsible>` + `<vscode-textarea>` |
 
 ### Group 4: Replacements (5 settings) - Collapsible Advanced
-| Setting | UI Component |
-|---------|--------------|
-| `texra.latex.wrapCritiqueInAlign` | `<vscode-checkbox>` |
-| `texra.latex.enabledReplacements` | Checkbox group (14 options) |
-| `texra.latex.enabledReplacementsRegex` | Checkbox group (6 options) |
-| `texra.latex.customReplacements` | `<vscode-collapsible>` + JSON editor |
-| `texra.latex.customReplacementsRegex` | `<vscode-collapsible>` + JSON editor |
+
+| Setting                                | UI Component                         |
+| -------------------------------------- | ------------------------------------ |
+| `texra.latex.wrapCritiqueInAlign`      | `<vscode-checkbox>`                  |
+| `texra.latex.enabledReplacements`      | Checkbox group (14 options)          |
+| `texra.latex.enabledReplacementsRegex` | Checkbox group (6 options)           |
+| `texra.latex.customReplacements`       | `<vscode-collapsible>` + JSON editor |
+| `texra.latex.customReplacementsRegex`  | `<vscode-collapsible>` + JSON editor |
 
 ---
 
 ## General Implementation Guidelines
 
 ### Code Style
+
 1. **Use TypeScript** for all backend code (`.ts` files)
 2. **Use JavaScript** for frontend webview modules (`.js` files) - no bundler
 3. **Follow existing patterns** in `src/common/` for base classes and utilities
 4. **Use path aliases** (`@settingsView/*`, `@common/*`) as defined in `tsconfig.json`
 
 ### VS Code Configuration Best Practices
+
 ```typescript
 // Always specify ConfigurationTarget explicitly
-await config.update(key, value, ConfigurationTarget.Global);    // User settings
+await config.update(key, value, ConfigurationTarget.Global); // User settings
 await config.update(key, value, ConfigurationTarget.Workspace); // .vscode/settings.json
 
 // Read with type safety
-const models = config.get<string[]>('models', []);  // Always provide default
+const models = config.get<string[]>('models', []); // Always provide default
 
 // Batch updates when possible (reduces config change events)
 const edit = new vscode.WorkspaceEdit();
@@ -1930,7 +2066,9 @@ await vscode.workspace.applyEdit(edit);
 ```
 
 ### Event Listener Cleanup
+
 Use `BaseDomHandler` for automatic cleanup:
+
 ```javascript
 // Extend BaseDomHandler - dispose() cleans up all listeners
 class ModelsTab extends BaseDomHandler {
@@ -1942,6 +2080,7 @@ class ModelsTab extends BaseDomHandler {
 ```
 
 ### Error Handling
+
 ```typescript
 // Backend: Use typed errors from @common/errors
 throw new TeXRAError('Provider not configured', { provider: providerId });
@@ -1955,18 +2094,21 @@ try {
 ```
 
 ### Testing Considerations
+
 1. **Unit test** message handlers independently
 2. **Mock VS Code API** using existing test utilities
 3. **Test ConfigurationTarget** scoping (global vs workspace)
 4. **Verify backwards compatibility** - existing settings.json should work unchanged
 
 ### Accessibility
+
 1. Use native vscode-elements (built-in keyboard navigation)
 2. Provide `aria-label` for icon-only buttons
 3. Ensure tab order is logical
 4. Test with keyboard-only navigation
 
 ### Performance
+
 1. **Lazy load** tab content (don't render all tabs on initial load)
 2. **Debounce** settings saves (avoid rapid config updates)
 3. **Cache** model metadata from llm-zoo in globalState

--- a/package.json
+++ b/package.json
@@ -808,6 +808,20 @@
             "default": false,
             "description": "Generate diffs between consecutive agent rounds in addition to comparing each round to the original input.",
             "order": 4
+          },
+          "texra.latexdiff.tempFileLocation": {
+            "type": "string",
+            "enum": [
+              "sameDirectory",
+              "workspaceTemp"
+            ],
+            "enumDescriptions": [
+              "Create temp files in the same directory as the original file. Best for resolving \\input{} and relative paths.",
+              "Create temp files in .texra-temp directory at workspace root. Keeps source directories clean but may break relative paths."
+            ],
+            "default": "sameDirectory",
+            "description": "Where to create temporary files for LaTeX preview and diff operations during tool edit approval.",
+            "order": 5
           }
         }
       },

--- a/src/common/files/fileTypeUtils.ts
+++ b/src/common/files/fileTypeUtils.ts
@@ -51,3 +51,16 @@ export function getIncludedExtensions(
 export function isTexFile(filePath: string): boolean {
   return hasExtension(filePath, '.tex');
 }
+
+/**
+ * LaTeX file extensions that can be compiled to PDF.
+ */
+export const LATEX_EXTENSIONS = ['.tex', '.ltx', '.latex'] as const;
+
+/**
+ * Returns true if the file has a LaTeX extension (.tex, .ltx, .latex).
+ * Use this for features that should work with all LaTeX document types.
+ */
+export function isLatexFile(filePath: string): boolean {
+  return LATEX_EXTENSIONS.some((ext) => hasExtension(filePath, ext));
+}

--- a/src/common/files/index.ts
+++ b/src/common/files/index.ts
@@ -9,5 +9,7 @@ export {
   ExtensionCategory,
   FileType,
   getIncludedExtensions,
+  isLatexFile,
   isTexFile,
+  LATEX_EXTENSIONS,
 } from './fileTypeUtils';

--- a/src/eventBus/types.ts
+++ b/src/eventBus/types.ts
@@ -14,6 +14,7 @@ export const ToolEditApprovalPromptSchema = z.strictObject({
   streamId: z.union([StreamTabIdSchema, z.literal('')]),
   addedLines: z.int().nonnegative(),
   removedLines: z.int().nonnegative(),
+  isLatex: z.boolean(),
 });
 export type ToolEditApprovalPrompt = z.infer<
   typeof ToolEditApprovalPromptSchema

--- a/src/frontend/latex/openBuild.ts
+++ b/src/frontend/latex/openBuild.ts
@@ -4,7 +4,7 @@ import * as vscode from 'vscode';
 
 // Local imports - common
 import { toErrorMessage } from '@common/errors';
-import { isTexFile } from '@common/files/fileTypeUtils';
+import { isLatexFile } from '@common/files/fileTypeUtils';
 
 // Local imports - log
 import * as logger from '@logger/logUtils';
@@ -41,7 +41,7 @@ export async function openAndBuildIfTex(
     const fullPath = WorkspaceFS.toAbsolute(file);
     const uri = vscode.Uri.file(fullPath);
 
-    if (isTexFile(file)) {
+    if (isLatexFile(file)) {
       const doc = await vscode.workspace.openTextDocument(uri);
       await vscode.window.showTextDocument(doc, {
         // preview: false,
@@ -79,7 +79,7 @@ export async function openBuildDisplayIfTex(
   const file = fileLocation.absolutePath;
   await openAndBuildIfTex(file, options);
 
-  if (isTexFile(file)) {
+  if (isLatexFile(file)) {
     try {
       setTimeout(async () => {
         await vscode.commands.executeCommand('latex-workshop.view');

--- a/src/frontend/setup.ts
+++ b/src/frontend/setup.ts
@@ -226,6 +226,8 @@ export async function configureLatexSettings() {
       // Define all settings to configure
       const settings: Array<[string, unknown]> = [
         // LaTeX Workshop build settings
+        // Run builds from workspace folder so relative paths resolve consistently
+        ['latex-workshop.latex.build.fromWorkspaceFolder', true],
         [
           'latex-workshop.latex.external.build.args',
           ['--output-directory=build', '-f', '-pdf'],

--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -518,6 +518,14 @@
                   <vscode-context-menu class="dropdown-menu diff-dropdown-menu">
                     <div class="dropdown-menu-content">
                       <vscode-toolbar-button
+                        icon="eye"
+                        label="Preview proposed"
+                        title="Compile and preview the proposed document"
+                        data-action="previewProposed"
+                        class="preview-menu-item"
+                        >Preview proposed</vscode-toolbar-button
+                      >
+                      <vscode-toolbar-button
                         icon="file-pdf"
                         label="LaTeXdiff"
                         title="Show LaTeXdiff (compiles to PDF)"

--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -497,13 +497,37 @@
                 <div class="approval-request__meta"></div>
               </div>
               <vscode-toolbar-container class="approval-request__actions">
-                <vscode-toolbar-button
-                  icon="diff"
-                  label="Open diff"
-                  title="Open diff"
-                  data-action="open"
-                  >Open diff</vscode-toolbar-button
-                >
+                <div class="dropdown-container dropdown-left diff-dropdown">
+                  <vscode-toolbar-button
+                    icon="diff"
+                    label="Open diff"
+                    title="Open diff (click arrow for more options)"
+                    data-action="open"
+                    class="diff-main-button"
+                    >Open diff</vscode-toolbar-button
+                  >
+                  <vscode-toolbar-button
+                    icon="chevron-down"
+                    title="More diff options"
+                    class="diff-dropdown-trigger"
+                    toggleable
+                    aria-haspopup="true"
+                    aria-expanded="false"
+                    hidden
+                  ></vscode-toolbar-button>
+                  <vscode-context-menu class="dropdown-menu diff-dropdown-menu">
+                    <div class="dropdown-menu-content">
+                      <vscode-toolbar-button
+                        icon="file-pdf"
+                        label="LaTeXdiff"
+                        title="Show LaTeXdiff (compiles to PDF)"
+                        data-action="showLatexdiff"
+                        class="latexdiff-menu-item"
+                        >LaTeXdiff (PDF)</vscode-toolbar-button
+                      >
+                    </div>
+                  </vscode-context-menu>
+                </div>
                 <vscode-toolbar-button
                   icon="check"
                   label="Approve"

--- a/src/progressView/modules/uiManagers/ApprovalRequests.js
+++ b/src/progressView/modules/uiManagers/ApprovalRequests.js
@@ -23,6 +23,8 @@ export class ApprovalRequests extends BaseUIRequestManager {
     });
     this.isBypassActive = false;
     this._handleToggle = this._handleToggle.bind(this);
+    this._handleDropdownToggle = this._handleDropdownToggle.bind(this);
+    this._handleClickOutside = this._handleClickOutside.bind(this);
   }
 
   /** @override */
@@ -34,14 +36,28 @@ export class ApprovalRequests extends BaseUIRequestManager {
         this._handleToggle,
         true,
       );
+      addEventListenerSafely(
+        this.container,
+        'click',
+        this._handleDropdownToggle,
+        true,
+      );
     }
+    // Listen for clicks outside to close dropdown menus
+    document.addEventListener('click', this._handleClickOutside, true);
   }
 
   /** @override */
   _cleanupAdditionalListeners() {
     if (this.container) {
       this.container.removeEventListener('change', this._handleToggle, true);
+      this.container.removeEventListener(
+        'click',
+        this._handleDropdownToggle,
+        true,
+      );
     }
+    document.removeEventListener('click', this._handleClickOutside, true);
   }
 
   /** @override */
@@ -85,6 +101,8 @@ export class ApprovalRequests extends BaseUIRequestManager {
     const pathElem = element.querySelector('.approval-request__path');
     const metaElem = element.querySelector('.approval-request__meta');
     const bypassButton = element.querySelector('[data-action="approveAll"]');
+    const dropdownTrigger = element.querySelector('.diff-dropdown-trigger');
+    const latexdiffMenuItem = element.querySelector('.latexdiff-menu-item');
     element.dataset.streamId = request.streamId || '';
 
     if (pathElem) {
@@ -99,6 +117,14 @@ export class ApprovalRequests extends BaseUIRequestManager {
       const allowBypass = request.allowBypass !== false;
       bypassButton.toggleAttribute('disabled', !allowBypass);
       setElementCheckedState(bypassButton, Boolean(this.isBypassActive));
+    }
+
+    // Show/hide dropdown trigger and menu item based on whether file is LaTeX
+    if (dropdownTrigger) {
+      dropdownTrigger.toggleAttribute('hidden', !request.isLatex);
+    }
+    if (latexdiffMenuItem) {
+      latexdiffMenuItem.dataset.requestId = request.requestId;
     }
   }
 
@@ -186,6 +212,7 @@ export class ApprovalRequests extends BaseUIRequestManager {
       approve: 'approve',
       approveAll: 'approveAll',
       reject: 'reject',
+      showLatexdiff: 'showLatexdiff',
     };
 
     const mappedAction = actionMap[action];
@@ -232,5 +259,77 @@ export class ApprovalRequests extends BaseUIRequestManager {
       requestId,
       action,
     });
+  }
+
+  /**
+   * Handle dropdown trigger clicks to toggle menu visibility.
+   * @private
+   */
+  _handleDropdownToggle(event) {
+    if (!(event.target instanceof Element)) {
+      return;
+    }
+
+    const trigger = event.target.closest('.diff-dropdown-trigger');
+    if (!trigger) {
+      return;
+    }
+
+    event.stopPropagation();
+
+    const dropdown = trigger.closest('.diff-dropdown');
+    if (!dropdown) {
+      return;
+    }
+
+    const menu = dropdown.querySelector('.diff-dropdown-menu');
+    if (!menu) {
+      return;
+    }
+
+    // Close other open menus first
+    this._closeAllDropdowns();
+
+    // Toggle this menu
+    const isExpanded = trigger.getAttribute('aria-expanded') === 'true';
+    menu.show = !isExpanded;
+    trigger.setAttribute('aria-expanded', isExpanded ? 'false' : 'true');
+  }
+
+  /**
+   * Handle clicks outside dropdown menus to close them.
+   * @private
+   */
+  _handleClickOutside(event) {
+    if (!(event.target instanceof Element)) {
+      return;
+    }
+
+    // If click is inside a dropdown, don't close
+    if (event.target.closest('.diff-dropdown')) {
+      return;
+    }
+
+    this._closeAllDropdowns();
+  }
+
+  /**
+   * Close all open dropdown menus.
+   * @private
+   */
+  _closeAllDropdowns() {
+    if (!this.container) {
+      return;
+    }
+
+    const triggers = this.container.querySelectorAll('.diff-dropdown-trigger');
+    for (const trigger of triggers) {
+      const dropdown = trigger.closest('.diff-dropdown');
+      const menu = dropdown?.querySelector('.diff-dropdown-menu');
+      if (menu) {
+        menu.show = false;
+      }
+      trigger.setAttribute('aria-expanded', 'false');
+    }
   }
 }

--- a/src/progressView/modules/uiManagers/ApprovalRequests.js
+++ b/src/progressView/modules/uiManagers/ApprovalRequests.js
@@ -236,7 +236,10 @@ export class ApprovalRequests extends BaseUIRequestManager {
       return;
     }
 
-    if (mappedAction === 'showLatexdiff' || mappedAction === 'previewProposed') {
+    if (
+      mappedAction === 'showLatexdiff' ||
+      mappedAction === 'previewProposed'
+    ) {
       this._closeAllDropdowns();
     }
 
@@ -293,7 +296,9 @@ export class ApprovalRequests extends BaseUIRequestManager {
 
     event.stopPropagation();
 
-    const menu = trigger.closest('.diff-dropdown')?.querySelector('.diff-dropdown-menu');
+    const menu = trigger
+      .closest('.diff-dropdown')
+      ?.querySelector('.diff-dropdown-menu');
     if (!menu) {
       return;
     }

--- a/src/progressView/modules/uiManagers/ApprovalRequests.js
+++ b/src/progressView/modules/uiManagers/ApprovalRequests.js
@@ -146,10 +146,7 @@ export class ApprovalRequests extends BaseUIRequestManager {
     }
   }
 
-  /**
-   * Update the meta element with diff information.
-   * @private
-   */
+  /** @private */
   _updateMetaElement(metaElem, request) {
     const toCount = (v) => (Number.isFinite(v) ? Math.max(0, v) : 0);
     const added = toCount(request.addedLines);
@@ -162,10 +159,10 @@ export class ApprovalRequests extends BaseUIRequestManager {
       parts.push(`Requested by ${request.sourceTool}`);
     }
 
-    // Build diff summary
-    const diffParts = [];
-    if (added > 0) diffParts.push(`+${added}`);
-    if (removed > 0) diffParts.push(`-${removed}`);
+    const diffParts = [
+      ...(added > 0 ? [`+${added}`] : []),
+      ...(removed > 0 ? [`-${removed}`] : []),
+    ];
     const tooltip =
       diffParts.length > 0
         ? `${diffParts.join(' / ')} ${lineLabel} changed`
@@ -225,35 +222,32 @@ export class ApprovalRequests extends BaseUIRequestManager {
       return;
     }
 
-    // Close dropdown if action is from menu item
-    if (action === 'showLatexdiff' || action === 'previewProposed') {
-      this._closeAllDropdowns();
-    }
-
-    // Map action names (only 'open' differs from its mapped value)
     const mappedAction = action === 'open' ? 'openDiff' : action;
-    const validActions = [
+    const validActions = new Set([
       'openDiff',
       'approve',
       'approveAll',
       'reject',
       'showLatexdiff',
       'previewProposed',
-    ];
+    ]);
 
-    if (validActions.includes(mappedAction)) {
-      vscode.postMessage({
-        command: COMMANDS.TOOL_EDIT_APPROVAL_ACTION,
-        requestId,
-        action: mappedAction,
-      });
+    if (!validActions.has(mappedAction)) {
+      return;
     }
+
+    if (mappedAction === 'showLatexdiff' || mappedAction === 'previewProposed') {
+      this._closeAllDropdowns();
+    }
+
+    vscode.postMessage({
+      command: COMMANDS.TOOL_EDIT_APPROVAL_ACTION,
+      requestId,
+      action: mappedAction,
+    });
   }
 
-  /**
-   * Handle toggle button changes.
-   * @private
-   */
+  /** @private */
   _handleToggle(event) {
     if (!(event.target instanceof Element)) {
       return;
@@ -286,10 +280,7 @@ export class ApprovalRequests extends BaseUIRequestManager {
     });
   }
 
-  /**
-   * Handle dropdown trigger clicks to toggle menu visibility.
-   * @private
-   */
+  /** @private */
   _handleDropdownToggle(event) {
     if (!(event.target instanceof Element)) {
       return;
@@ -302,27 +293,16 @@ export class ApprovalRequests extends BaseUIRequestManager {
 
     event.stopPropagation();
 
-    const dropdown = trigger.closest('.diff-dropdown');
-    if (!dropdown) {
-      return;
-    }
-
-    const menu = dropdown.querySelector('.diff-dropdown-menu');
+    const menu = trigger.closest('.diff-dropdown')?.querySelector('.diff-dropdown-menu');
     if (!menu) {
       return;
     }
 
-    // Capture expanded state BEFORE closing all dropdowns
     const wasExpanded = trigger.getAttribute('aria-expanded') === 'true';
-
-    // Close other open menus first
     this._closeAllDropdowns();
 
-    // Toggle this menu (only open if it wasn't already expanded)
     if (!wasExpanded) {
-      // Workaround: vscode-context-menu defaults data to [] which prevents slot rendering.
-      // Setting data to undefined allows slotted children to render.
-      // Must call requestUpdate() to force Lit element to re-render.
+      // Workaround: vscode-context-menu defaults data to [] which prevents slot rendering
       if (Array.isArray(menu.data) && menu.data.length === 0) {
         menu.data = undefined;
         menu.requestUpdate?.();
@@ -332,27 +312,17 @@ export class ApprovalRequests extends BaseUIRequestManager {
     }
   }
 
-  /**
-   * Handle clicks outside dropdown menus to close them.
-   * @private
-   */
+  /** @private */
   _handleClickOutside(event) {
     if (!(event.target instanceof Element)) {
       return;
     }
-
-    // If click is inside a dropdown, don't close
-    if (event.target.closest('.diff-dropdown')) {
-      return;
+    if (!event.target.closest('.diff-dropdown')) {
+      this._closeAllDropdowns();
     }
-
-    this._closeAllDropdowns();
   }
 
-  /**
-   * Close all open dropdown menus.
-   * @private
-   */
+  /** @private */
   _closeAllDropdowns() {
     if (!this.container) {
       return;

--- a/src/progressView/modules/uiManagers/ApprovalRequests.js
+++ b/src/progressView/modules/uiManagers/ApprovalRequests.js
@@ -306,10 +306,12 @@ export class ApprovalRequests extends BaseUIRequestManager {
 
     // Toggle this menu (only open if it wasn't already expanded)
     if (!wasExpanded) {
-      // Workaround: vscode-context-menu defaults data to [] which prevents slot rendering
-      // Setting data to undefined allows slotted children to render
-      if (menu.data !== undefined) {
+      // Workaround: vscode-context-menu defaults data to [] which prevents slot rendering.
+      // Setting data to undefined allows slotted children to render.
+      // Must call requestUpdate() to force Lit element to re-render.
+      if (Array.isArray(menu.data) && menu.data.length === 0) {
         menu.data = undefined;
+        menu.requestUpdate?.();
       }
       menu.show = true;
       trigger.setAttribute('aria-expanded', 'true');

--- a/src/progressView/modules/uiManagers/ApprovalRequests.js
+++ b/src/progressView/modules/uiManagers/ApprovalRequests.js
@@ -211,23 +211,23 @@ export class ApprovalRequests extends BaseUIRequestManager {
       return;
     }
 
-    const actionMap = {
-      open: 'openDiff',
-      approve: 'approve',
-      approveAll: 'approveAll',
-      reject: 'reject',
-      showLatexdiff: 'showLatexdiff',
-      previewProposed: 'previewProposed',
-    };
-
     // Close dropdown if action is from menu item
-    const dropdownActions = ['showLatexdiff', 'previewProposed'];
-    if (dropdownActions.includes(action)) {
+    if (action === 'showLatexdiff' || action === 'previewProposed') {
       this._closeAllDropdowns();
     }
 
-    const mappedAction = actionMap[action];
-    if (mappedAction) {
+    // Map action names (only 'open' differs from its mapped value)
+    const mappedAction = action === 'open' ? 'openDiff' : action;
+    const validActions = [
+      'openDiff',
+      'approve',
+      'approveAll',
+      'reject',
+      'showLatexdiff',
+      'previewProposed',
+    ];
+
+    if (validActions.includes(mappedAction)) {
       vscode.postMessage({
         command: COMMANDS.TOOL_EDIT_APPROVAL_ACTION,
         requestId,

--- a/src/progressView/modules/uiManagers/ApprovalRequests.js
+++ b/src/progressView/modules/uiManagers/ApprovalRequests.js
@@ -292,13 +292,22 @@ export class ApprovalRequests extends BaseUIRequestManager {
       return;
     }
 
+    // Capture expanded state BEFORE closing all dropdowns
+    const wasExpanded = trigger.getAttribute('aria-expanded') === 'true';
+
     // Close other open menus first
     this._closeAllDropdowns();
 
-    // Toggle this menu
-    const isExpanded = trigger.getAttribute('aria-expanded') === 'true';
-    menu.show = !isExpanded;
-    trigger.setAttribute('aria-expanded', isExpanded ? 'false' : 'true');
+    // Toggle this menu (only open if it wasn't already expanded)
+    if (!wasExpanded) {
+      // Workaround: vscode-context-menu defaults data to [] which prevents slot rendering
+      // Setting data to undefined allows slotted children to render
+      if (menu.data !== undefined) {
+        menu.data = undefined;
+      }
+      menu.show = true;
+      trigger.setAttribute('aria-expanded', 'true');
+    }
   }
 
   /**

--- a/src/progressView/modules/uiManagers/ApprovalRequests.js
+++ b/src/progressView/modules/uiManagers/ApprovalRequests.js
@@ -101,7 +101,9 @@ export class ApprovalRequests extends BaseUIRequestManager {
     const pathElem = element.querySelector('.approval-request__path');
     const metaElem = element.querySelector('.approval-request__meta');
     const bypassButton = element.querySelector('[data-action="approveAll"]');
+    const mainDiffButton = element.querySelector('.diff-main-button');
     const dropdownTrigger = element.querySelector('.diff-dropdown-trigger');
+    const dropdownMenu = element.querySelector('.diff-dropdown-menu');
     const previewMenuItem = element.querySelector('.preview-menu-item');
     const latexdiffMenuItem = element.querySelector('.latexdiff-menu-item');
     element.dataset.streamId = request.streamId || '';
@@ -120,9 +122,17 @@ export class ApprovalRequests extends BaseUIRequestManager {
       setElementCheckedState(bypassButton, Boolean(this.isBypassActive));
     }
 
+    if (mainDiffButton) {
+      mainDiffButton.dataset.requestId = request.requestId;
+    }
+
     // Show/hide dropdown trigger and set requestIds on menu items for LaTeX files
     if (dropdownTrigger) {
       dropdownTrigger.toggleAttribute('hidden', !request.isLatex);
+      dropdownTrigger.setAttribute('aria-expanded', 'false');
+    }
+    if (dropdownMenu) {
+      dropdownMenu.show = false;
     }
     if (previewMenuItem) {
       previewMenuItem.dataset.requestId = request.requestId;

--- a/src/progressView/modules/uiManagers/ApprovalRequests.js
+++ b/src/progressView/modules/uiManagers/ApprovalRequests.js
@@ -302,7 +302,9 @@ export class ApprovalRequests extends BaseUIRequestManager {
     this._closeAllDropdowns();
 
     if (!wasExpanded) {
-      // Workaround: vscode-context-menu defaults data to [] which prevents slot rendering
+      // Workaround: vscode-context-menu constructor sets _data=[] which prevents slot rendering.
+      // See: node_modules/@vscode-elements/elements/dist/vscode-context-menu/vscode-context-menu.js
+      // render() returns this.data ? data.map(...) : <slot>, so empty array skips slot.
       if (Array.isArray(menu.data) && menu.data.length === 0) {
         menu.data = undefined;
         menu.requestUpdate?.();

--- a/src/progressView/modules/uiManagers/ApprovalRequests.js
+++ b/src/progressView/modules/uiManagers/ApprovalRequests.js
@@ -102,6 +102,7 @@ export class ApprovalRequests extends BaseUIRequestManager {
     const metaElem = element.querySelector('.approval-request__meta');
     const bypassButton = element.querySelector('[data-action="approveAll"]');
     const dropdownTrigger = element.querySelector('.diff-dropdown-trigger');
+    const previewMenuItem = element.querySelector('.preview-menu-item');
     const latexdiffMenuItem = element.querySelector('.latexdiff-menu-item');
     element.dataset.streamId = request.streamId || '';
 
@@ -119,9 +120,12 @@ export class ApprovalRequests extends BaseUIRequestManager {
       setElementCheckedState(bypassButton, Boolean(this.isBypassActive));
     }
 
-    // Show/hide dropdown trigger and menu item based on whether file is LaTeX
+    // Show/hide dropdown trigger and set requestIds on menu items for LaTeX files
     if (dropdownTrigger) {
       dropdownTrigger.toggleAttribute('hidden', !request.isLatex);
+    }
+    if (previewMenuItem) {
+      previewMenuItem.dataset.requestId = request.requestId;
     }
     if (latexdiffMenuItem) {
       latexdiffMenuItem.dataset.requestId = request.requestId;
@@ -213,6 +217,7 @@ export class ApprovalRequests extends BaseUIRequestManager {
       approveAll: 'approveAll',
       reject: 'reject',
       showLatexdiff: 'showLatexdiff',
+      previewProposed: 'previewProposed',
     };
 
     const mappedAction = actionMap[action];

--- a/src/progressView/modules/uiManagers/ApprovalRequests.js
+++ b/src/progressView/modules/uiManagers/ApprovalRequests.js
@@ -133,6 +133,10 @@ export class ApprovalRequests extends BaseUIRequestManager {
     }
     if (dropdownMenu) {
       dropdownMenu.show = false;
+      if (Array.isArray(dropdownMenu.data) && dropdownMenu.data.length === 0) {
+        dropdownMenu.data = undefined;
+        dropdownMenu.requestUpdate?.();
+      }
     }
     if (previewMenuItem) {
       previewMenuItem.dataset.requestId = request.requestId;

--- a/src/progressView/modules/uiManagers/ApprovalRequests.js
+++ b/src/progressView/modules/uiManagers/ApprovalRequests.js
@@ -220,6 +220,12 @@ export class ApprovalRequests extends BaseUIRequestManager {
       previewProposed: 'previewProposed',
     };
 
+    // Close dropdown if action is from menu item
+    const dropdownActions = ['showLatexdiff', 'previewProposed'];
+    if (dropdownActions.includes(action)) {
+      this._closeAllDropdowns();
+    }
+
     const mappedAction = actionMap[action];
     if (mappedAction) {
       vscode.postMessage({

--- a/src/progressView/modules/uiManagers/ApprovalRequests.js
+++ b/src/progressView/modules/uiManagers/ApprovalRequests.js
@@ -48,7 +48,7 @@ export class ApprovalRequests extends BaseUIRequestManager {
   }
 
   /** @override */
-  _cleanupAdditionalListeners() {
+  _disposeAdditionalListeners() {
     if (this.container) {
       this.container.removeEventListener('change', this._handleToggle, true);
       this.container.removeEventListener(

--- a/src/progressView/styles/approval-requests.css
+++ b/src/progressView/styles/approval-requests.css
@@ -70,7 +70,8 @@
   padding: 0;
   border-top-left-radius: 0;
   border-bottom-left-radius: 0;
-  border-left: 1px solid var(--vscode-button-separator, var(--vscode-input-border));
+  border-left: 1px solid
+    var(--vscode-button-separator, var(--vscode-input-border));
 }
 
 .approval-request__actions .diff-dropdown .diff-dropdown-menu {
@@ -100,6 +101,8 @@
 }
 
 /* Chevron rotation for dropdown */
-.approval-request__actions .diff-dropdown-trigger[aria-expanded='true'] .codicon-chevron-down {
+.approval-request__actions
+  .diff-dropdown-trigger[aria-expanded='true']
+  .codicon-chevron-down {
   transform: rotate(180deg);
 }

--- a/src/progressView/styles/approval-requests.css
+++ b/src/progressView/styles/approval-requests.css
@@ -88,11 +88,13 @@
   padding: var(--spacing-tiny);
 }
 
+.approval-request__actions .diff-dropdown .preview-menu-item,
 .approval-request__actions .diff-dropdown .latexdiff-menu-item {
   width: 100%;
   justify-content: flex-start;
 }
 
+.approval-request__actions .diff-dropdown .preview-menu-item:hover,
 .approval-request__actions .diff-dropdown .latexdiff-menu-item:hover {
   background: var(--vscode-list-hoverBackground);
 }

--- a/src/progressView/styles/approval-requests.css
+++ b/src/progressView/styles/approval-requests.css
@@ -48,3 +48,56 @@
   font-size: var(--font-size-xs);
   opacity: 0.9;
 }
+
+/* Diff dropdown button group styling */
+.approval-request__actions .diff-dropdown {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  flex: 1 1 12rem;
+}
+
+.approval-request__actions .diff-dropdown .diff-main-button {
+  flex: 1;
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.approval-request__actions .diff-dropdown .diff-dropdown-trigger {
+  flex: 0 0 auto;
+  width: 20px;
+  min-width: 20px;
+  padding: 0;
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+  border-left: 1px solid var(--vscode-button-separator, var(--vscode-input-border));
+}
+
+.approval-request__actions .diff-dropdown .diff-dropdown-menu {
+  position: absolute;
+  top: calc(100% + var(--spacing-tiny));
+  left: 0;
+  z-index: 100;
+  min-width: 150px;
+}
+
+.approval-request__actions .diff-dropdown .dropdown-menu-content {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  padding: var(--spacing-tiny);
+}
+
+.approval-request__actions .diff-dropdown .latexdiff-menu-item {
+  width: 100%;
+  justify-content: flex-start;
+}
+
+.approval-request__actions .diff-dropdown .latexdiff-menu-item:hover {
+  background: var(--vscode-list-hoverBackground);
+}
+
+/* Chevron rotation for dropdown */
+.approval-request__actions .diff-dropdown-trigger[aria-expanded='true'] .codicon-chevron-down {
+  transform: rotate(180deg);
+}

--- a/src/tools/approval/latexPreview.ts
+++ b/src/tools/approval/latexPreview.ts
@@ -1,0 +1,234 @@
+/**
+ * LaTeX preview and diff operations for tool edit approval.
+ * Handles creating temp files, running latexdiff, and building PDFs.
+ */
+
+import { randomUUID } from 'crypto';
+import fs from 'fs/promises';
+import path from 'path';
+import * as vscode from 'vscode';
+
+import { openBuildDisplayIfTex } from '@frontend/latex/openBuild';
+import { getConfig } from '@utils/config';
+import { WorkspaceFS, pathToLocation } from '@utils/files';
+import { LaTeXdiffService } from '@latex/latexdiff';
+import { TEMP_EXTENSIONS } from '@housekeeping/constants';
+
+/** Interface for entries that support LaTeX preview operations */
+export interface LatexPreviewEntry {
+  request: { path: string };
+  originalUri: vscode.Uri;
+  proposedUri: vscode.Uri;
+  originalContent: string;
+  proposedContent: string;
+  isSettled: () => boolean;
+  workspaceTempCleanup: Array<() => Promise<void>>;
+  latexOperationInProgress: boolean;
+}
+
+/** Temp file location options */
+type TempFileLocation = 'sameDirectory' | 'workspaceTemp';
+
+const TEXRA_TEMP_DIR = '.texra-temp';
+/** Length of UUID prefix for temp file names (8 chars = 4 billion combinations, sufficient for uniqueness) */
+const UUID_PREFIX_LENGTH = 8;
+
+const latexdiffService = new LaTeXdiffService('ToolEditApproval');
+
+/**
+ * Clean up LaTeX auxiliary files for a given base path.
+ */
+async function cleanupLatexAuxFiles(filePath: string): Promise<void> {
+  const ext = path.extname(filePath);
+  const basePathNoExt = filePath.slice(0, -ext.length);
+  for (const tempExt of TEMP_EXTENSIONS) {
+    await fs.unlink(basePathNoExt + tempExt).catch(() => {});
+  }
+}
+
+/**
+ * Register cleanup function with entry, or run immediately if already settled.
+ */
+function registerCleanup(
+  entry: LatexPreviewEntry,
+  cleanup: () => Promise<void>,
+): void {
+  if (entry.isSettled()) {
+    void cleanup().catch(() => {});
+    return;
+  }
+  entry.workspaceTempCleanup.push(cleanup);
+}
+
+/**
+ * Create a temporary file for LaTeX compilation.
+ * Location is controlled by texra.latexdiff.tempFileLocation setting.
+ */
+async function createTempFile(
+  originalPath: string,
+  content: string,
+  suffix: string,
+): Promise<{ tempPath: string; cleanup: () => Promise<void> }> {
+  const workspacePath = WorkspaceFS.getPath();
+  if (!workspacePath) {
+    throw new Error('No workspace folder open');
+  }
+
+  const location = getConfig<TempFileLocation>(
+    'texra.latexdiff.tempFileLocation',
+    'sameDirectory',
+  );
+
+  const ext = path.extname(originalPath);
+  const basename = path.basename(originalPath, ext);
+  const tempFileName = `${basename}${suffix}-${randomUUID().slice(0, UUID_PREFIX_LENGTH)}${ext}`;
+
+  const isWorkspaceTemp = location === 'workspaceTemp';
+  let tempDir: string;
+
+  if (isWorkspaceTemp) {
+    tempDir = path.join(workspacePath, TEXRA_TEMP_DIR);
+    await fs.mkdir(tempDir, { recursive: true });
+  } else {
+    const absoluteOriginal = path.isAbsolute(originalPath)
+      ? originalPath
+      : path.join(workspacePath, originalPath);
+    tempDir = path.dirname(absoluteOriginal);
+  }
+
+  const tempPath = path.join(tempDir, tempFileName);
+  await fs.writeFile(tempPath, content, 'utf8');
+
+  const cleanup = async () => {
+    await fs.unlink(tempPath).catch(() => {});
+    await cleanupLatexAuxFiles(tempPath);
+    if (isWorkspaceTemp) {
+      await fs.rmdir(tempDir).catch(() => {});
+    }
+  };
+
+  return { tempPath, cleanup };
+}
+
+/**
+ * Preview the proposed LaTeX document by creating a temp file and building it.
+ */
+export async function previewProposedLatex(
+  entry: LatexPreviewEntry,
+): Promise<void> {
+  if (entry.latexOperationInProgress) {
+    return;
+  }
+  entry.latexOperationInProgress = true;
+
+  try {
+    const content = await fs
+      .readFile(entry.proposedUri.fsPath, 'utf8')
+      .catch(() => entry.proposedContent);
+
+    const { tempPath, cleanup } = await createTempFile(
+      entry.request.path,
+      content,
+      '_preview',
+    );
+
+    registerCleanup(entry, cleanup);
+    if (entry.isSettled()) {
+      return;
+    }
+
+    const tempLocation = pathToLocation(tempPath);
+    await openBuildDisplayIfTex(tempLocation, { preserveFocus: true });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    vscode.window.showErrorMessage(`Preview failed: ${message}`);
+  } finally {
+    entry.latexOperationInProgress = false;
+  }
+}
+
+/**
+ * Run latexdiff on the original and proposed content.
+ */
+export async function runLatexdiff(entry: LatexPreviewEntry): Promise<void> {
+  if (entry.latexOperationInProgress) {
+    return;
+  }
+  entry.latexOperationInProgress = true;
+
+  try {
+    const originalContent = await fs
+      .readFile(entry.originalUri.fsPath, 'utf8')
+      .catch(() => entry.originalContent);
+    const proposedContent = await fs
+      .readFile(entry.proposedUri.fsPath, 'utf8')
+      .catch(() => entry.proposedContent);
+
+    const original = await createTempFile(
+      entry.request.path,
+      originalContent,
+      '_original',
+    );
+    registerCleanup(entry, original.cleanup);
+
+    const proposed = await createTempFile(
+      entry.request.path,
+      proposedContent,
+      '_proposed',
+    );
+    registerCleanup(entry, proposed.cleanup);
+
+    const originalLocation = pathToLocation(original.tempPath);
+    const proposedLocation = pathToLocation(proposed.tempPath);
+
+    const workspacePath = WorkspaceFS.getPath();
+    const result = await latexdiffService.runDiff(
+      originalLocation,
+      proposedLocation,
+      '_diff',
+      false,
+      'coarse',
+      { cwd: workspacePath ?? path.dirname(original.tempPath) },
+    );
+
+    if (!result.success || !result.diffFileName) {
+      vscode.window.showErrorMessage(
+        result.message ?? 'Failed to generate LaTeXdiff',
+      );
+      return;
+    }
+
+    // Validate filename to prevent path traversal
+    if (
+      result.diffFileName.includes('/') ||
+      result.diffFileName.includes('\\') ||
+      result.diffFileName.includes('..')
+    ) {
+      vscode.window.showErrorMessage(
+        'LaTeXdiff failed: invalid output filename',
+      );
+      return;
+    }
+
+    const diffFilePath = path.join(
+      path.dirname(original.tempPath),
+      result.diffFileName,
+    );
+    registerCleanup(entry, async () => {
+      await fs.unlink(diffFilePath).catch(() => {});
+      await cleanupLatexAuxFiles(diffFilePath);
+    });
+
+    if (entry.isSettled()) {
+      return;
+    }
+
+    const diffLocation = pathToLocation(diffFilePath);
+    await openBuildDisplayIfTex(diffLocation, { preserveFocus: true });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    vscode.window.showErrorMessage(`LaTeXdiff failed: ${message}`);
+  } finally {
+    entry.latexOperationInProgress = false;
+  }
+}

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -17,10 +17,12 @@ import type { StreamTabId } from '@agent/types/IdentifierTypes';
 // Local imports - utils
 import { getCurrentToolFileInteractionContext } from '@agent/toolUse/ToolFileInteractionContext';
 import { safeExecuteCommand } from '@frontend/system/commandUtils';
+import { openBuildDisplayIfTex } from '@frontend/latex/openBuild';
 import { type ToolResult, type LineChanges } from '@tools/result';
-import { WorkspaceFS } from '@utils/files';
 import { getConfig } from '@utils/config';
+import { WorkspaceFS, pathToLocation } from '@utils/files';
 import { bus } from '@eventBus/ProgressEventBus';
+import { LaTeXdiffService } from '@latex/latexdiff';
 
 // Local file imports
 
@@ -65,6 +67,7 @@ export const PROGRESS_VIEW_APPROVAL_ACTIONS = [
   'openDiff',
   'approveAll',
   'resumeApprovals',
+  'showLatexdiff',
 ] as const;
 
 export type ProgressViewApprovalAction =
@@ -179,6 +182,11 @@ export function setToolEditApprovalHandler(
   customHandler = handler;
 }
 
+function isLatexFile(filePath: string): boolean {
+  const ext = path.extname(filePath).toLowerCase();
+  return ext === '.tex' || ext === '.ltx' || ext === '.latex';
+}
+
 async function showProgressViewApprovalPrompt(
   requestId: string,
   request: ToolEditApprovalRequest,
@@ -195,6 +203,7 @@ async function showProgressViewApprovalPrompt(
     streamId: request.streamId ?? '',
     addedLines: lineChanges.added,
     removedLines: lineChanges.removed,
+    isLatex: isLatexFile(request.path),
   });
 }
 
@@ -420,6 +429,57 @@ async function closeApprovalEditors(
 
   if (tabsToClose.length > 0) {
     await vscode.window.tabGroups.close(tabsToClose);
+  }
+}
+
+const latexdiffService = new LaTeXdiffService('ToolEditApproval');
+
+/**
+ * Run latexdiff on the original and proposed temp files for an approval entry.
+ * Opens the result in the LaTeX build preview (compiles to PDF).
+ *
+ * The temp files are stored in extension storage, but we execute latexdiff
+ * from the workspace directory so that \input{}, \include{}, and package
+ * dependencies can be resolved properly.
+ */
+async function runLatexdiffForApproval(
+  entry: PendingApprovalEntry,
+): Promise<void> {
+  try {
+    const originalLocation = pathToLocation(entry.originalUri.fsPath);
+    const proposedLocation = pathToLocation(entry.proposedUri.fsPath);
+
+    // Get workspace path for executing latexdiff - this ensures dependencies
+    // like \input{} and \include{} can be resolved from the workspace
+    const workspacePath = WorkspaceFS.getPath();
+
+    // Run latexdiff on the temp files with workspace as working directory
+    const result = await latexdiffService.runDiff(
+      originalLocation,
+      proposedLocation,
+      '_diff',
+      false, // don't run indent
+      'coarse', // default math markup
+      { cwd: workspacePath || path.dirname(entry.originalUri.fsPath) },
+    );
+
+    if (!result.success || !result.diffFileName) {
+      vscode.window.showErrorMessage(
+        result.message ?? 'Failed to generate LaTeXdiff',
+      );
+      return;
+    }
+
+    // Open the generated diff file in the LaTeX build preview
+    const diffFilePath = path.join(
+      path.dirname(entry.originalUri.fsPath),
+      result.diffFileName,
+    );
+    const diffLocation = pathToLocation(diffFilePath);
+    await openBuildDisplayIfTex(diffLocation, { preserveFocus: true });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    vscode.window.showErrorMessage(`LaTeXdiff failed: ${message}`);
   }
 }
 
@@ -700,6 +760,16 @@ export async function handleProgressViewToolEditApprovalAction(
       entry.originalContent,
       entry.proposedContent,
     );
+    return;
+  }
+
+  if (payload.action === 'showLatexdiff') {
+    if (entry.isSettled()) {
+      return;
+    }
+
+    // Run latexdiff on the original and proposed temp files
+    await runLatexdiffForApproval(entry);
     return;
   }
 

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -448,11 +448,14 @@ async function cleanupLatexAuxFiles(filePath: string): Promise<void> {
   }
 }
 
+/** Temp file location options */
+type TempFileLocation = 'sameDirectory' | 'workspaceTemp';
+
 /**
- * Create a temporary file in the same directory as the original for LaTeX compilation.
- * Placing the temp file alongside the original ensures \input{}, \include{}, and
- * relative paths resolve correctly (they're relative to the file's directory).
- * Returns the temp file path and a cleanup function.
+ * Create a temporary file for LaTeX compilation.
+ * Location is controlled by texra.latexdiff.tempFileLocation setting:
+ * - sameDirectory: Same directory as original (best for \input{} paths)
+ * - workspaceTemp: .texra-temp directory (keeps source clean)
  */
 async function createWorkspaceTempFile(
   originalPath: string,
@@ -464,32 +467,46 @@ async function createWorkspaceTempFile(
     throw new Error('No workspace folder open');
   }
 
-  // Resolve the original path relative to workspace
-  const absoluteOriginal = path.isAbsolute(originalPath)
-    ? originalPath
-    : path.join(workspacePath, originalPath);
+  const location = getConfig<TempFileLocation>(
+    'texra.latexdiff.tempFileLocation',
+    'sameDirectory',
+  );
 
   const ext = path.extname(originalPath);
   const basename = path.basename(originalPath, ext);
-  const originalDir = path.dirname(absoluteOriginal);
-
-  // Create temp file in the SAME directory as original so relative paths work
   const tempFileName = `${basename}${suffix}-${randomUUID().slice(0, 8)}${ext}`;
-  const tempPath = path.join(originalDir, tempFileName);
 
+  let tempDir: string;
+  if (location === 'workspaceTemp') {
+    tempDir = path.join(workspacePath, '.texra-temp');
+    await fs.mkdir(tempDir, { recursive: true });
+  } else {
+    // sameDirectory: place alongside original for correct path resolution
+    const absoluteOriginal = path.isAbsolute(originalPath)
+      ? originalPath
+      : path.join(workspacePath, originalPath);
+    tempDir = path.dirname(absoluteOriginal);
+  }
+
+  const tempPath = path.join(tempDir, tempFileName);
   await fs.writeFile(tempPath, content, 'utf8');
 
   const cleanup = async () => {
     await fs.unlink(tempPath).catch(() => {});
     await cleanupLatexAuxFiles(tempPath);
+    // Try to remove .texra-temp if empty (only relevant for workspaceTemp mode)
+    if (location === 'workspaceTemp') {
+      const texraTempDir = path.join(workspacePath, '.texra-temp');
+      await fs.rmdir(texraTempDir).catch(() => {});
+    }
   };
 
   return { tempPath, cleanup };
 }
 
 /**
- * Preview the proposed LaTeX document by creating a temp file in the same directory.
- * This ensures \input{}, \include{}, and relative paths resolve correctly.
+ * Preview the proposed LaTeX document by creating a temp file.
+ * Location is controlled by texra.latexdiff.tempFileLocation setting.
  * Cleanup is registered with the entry and executed when approval is resolved.
  */
 async function previewProposedLatex(entry: PendingApprovalEntry): Promise<void> {
@@ -526,7 +543,7 @@ async function previewProposedLatex(entry: PendingApprovalEntry): Promise<void> 
 
 /**
  * Run latexdiff on the original and proposed content.
- * Creates temp files in the same directory as the original for proper path resolution.
+ * Temp file location is controlled by texra.latexdiff.tempFileLocation setting.
  * Cleanup is registered with the entry and executed when approval is resolved.
  */
 async function runLatexdiffForApproval(

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -666,25 +666,17 @@ async function nativeRequestApproval(
     originalContent,
     proposedContent,
   );
-  const totalChanged = Math.max(lineChanges.added + lineChanges.removed, 0);
-  const changeSummaryParts: string[] = [];
-  if (lineChanges.added > 0) {
-    changeSummaryParts.push(`+${lineChanges.added}`);
-  }
-  if (lineChanges.removed > 0) {
-    changeSummaryParts.push(`-${lineChanges.removed}`);
-  }
-  const changeSummary =
-    changeSummaryParts.length > 0
-      ? `${changeSummaryParts.join(' / ')} ${
-          totalChanged === 1 ? 'line' : 'lines'
-        }`
-      : undefined;
-
-  const titleDetails = changeSummary
-    ? `${description} · ${changeSummary}`
-    : description;
-  const title = `Tool edit (${sourceTool}): ${titleDetails}`;
+  const { added, removed } = lineChanges;
+  const totalChanged = added + removed;
+  const changeParts = [
+    ...(added > 0 ? [`+${added}`] : []),
+    ...(removed > 0 ? [`-${removed}`] : []),
+  ];
+  const changeSuffix =
+    changeParts.length > 0
+      ? ` · ${changeParts.join(' / ')} ${totalChanged === 1 ? 'line' : 'lines'}`
+      : '';
+  const title = `Tool edit (${sourceTool}): ${description}${changeSuffix}`;
   let result: ToolEditApprovalResult = { accepted: false };
   try {
     await vscode.commands.executeCommand(
@@ -845,8 +837,6 @@ export function getApprovedContent(
   return approval.appliedContent ?? fallback;
 }
 
-// (legacy formatting removed; use formatUnifiedApprovalUserDiff instead)
-
 /**
  * Render a human-readable, line-numbered unified diff for user adjustments.
  * Uses difflib to compute a unified diff between the suggested and applied
@@ -962,34 +952,14 @@ export async function handleProgressViewToolEditApprovalAction(
     return;
   }
 
-  if (payload.action === 'approve') {
-    // Read the current content from the proposed file - user may have modified it in the diff view
-    try {
-      const appliedContent = await fs.readFile(
-        entry.proposedUri.fsPath,
-        'utf-8',
-      );
-      entry.settle({ accepted: true, appliedContent });
-    } catch {
-      // Fall back to original proposed content if file read fails
-      entry.settle({ accepted: true, appliedContent: entry.proposedContent });
+  if (payload.action === 'approve' || payload.action === 'approveAll') {
+    if (payload.action === 'approveAll') {
+      enableSessionApprovalBypass();
     }
-    return;
-  }
-
-  if (payload.action === 'approveAll') {
-    enableSessionApprovalBypass();
-    // Read the current content from the proposed file - user may have modified it in the diff view
-    try {
-      const appliedContent = await fs.readFile(
-        entry.proposedUri.fsPath,
-        'utf-8',
-      );
-      entry.settle({ accepted: true, appliedContent });
-    } catch {
-      // Fall back to original proposed content if file read fails
-      entry.settle({ accepted: true, appliedContent: entry.proposedContent });
-    }
+    const appliedContent = await fs
+      .readFile(entry.proposedUri.fsPath, 'utf-8')
+      .catch(() => entry.proposedContent);
+    entry.settle({ accepted: true, appliedContent });
     return;
   }
 

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -656,7 +656,7 @@ async function nativeRequestApproval(
           return;
         }
         settled = true;
-        pendingApprovals.delete(requestId);
+        // Note: Don't delete from pendingApprovals here - finally block handles cleanup
         resolve(value);
       };
 

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -480,12 +480,8 @@ async function createWorkspaceTempFile(
   await fs.writeFile(tempPath, content, 'utf8');
 
   const cleanup = async () => {
-    try {
-      await fs.unlink(tempPath).catch(() => {});
-      await cleanupLatexAuxFiles(tempPath);
-    } catch {
-      // Ignore cleanup errors
-    }
+    await fs.unlink(tempPath).catch(() => {});
+    await cleanupLatexAuxFiles(tempPath);
   };
 
   return { tempPath, cleanup };

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -17,13 +17,14 @@ import type { StreamTabId } from '@agent/types/IdentifierTypes';
 // Local imports - utils
 import { getCurrentToolFileInteractionContext } from '@agent/toolUse/ToolFileInteractionContext';
 import { isLatexFile } from '@common/files/fileTypeUtils';
+import { bus } from '@eventBus/ProgressEventBus';
 import { safeExecuteCommand } from '@frontend/system/commandUtils';
 import { openBuildDisplayIfTex } from '@frontend/latex/openBuild';
+import { TEMP_EXTENSIONS } from '@housekeeping/constants';
+import { LaTeXdiffService } from '@latex/latexdiff';
 import { type ToolResult, type LineChanges } from '@tools/result';
 import { getConfig } from '@utils/config';
 import { WorkspaceFS, pathToLocation } from '@utils/files';
-import { bus } from '@eventBus/ProgressEventBus';
-import { LaTeXdiffService } from '@latex/latexdiff';
 
 // Local file imports
 
@@ -59,6 +60,8 @@ interface PendingApprovalEntry {
   lineChanges: LineChanges;
   isSettled: () => boolean;
   settle: (result: ToolEditApprovalResult) => void;
+  /** Cleanup functions for workspace temp files created by preview/latexdiff */
+  workspaceTempCleanup: Array<() => Promise<void>>;
 }
 
 /** All valid approval actions for tool edit prompts */
@@ -457,12 +460,12 @@ async function createWorkspaceTempFile(
 
   const cleanup = async () => {
     try {
+      // Clean up the main temp file
       await fs.unlink(tempPath).catch(() => {});
-      // Also clean up any generated aux files
-      const auxFiles = ['.aux', '.log', '.pdf', '.synctex.gz', '.fls', '.fdb_latexmk'];
-      for (const auxExt of auxFiles) {
-        const auxPath = tempPath.replace(ext, auxExt);
-        await fs.unlink(auxPath).catch(() => {});
+      // Clean up all LaTeX auxiliary files using shared TEMP_EXTENSIONS
+      const basePathNoExt = tempPath.slice(0, -ext.length);
+      for (const tempExt of TEMP_EXTENSIONS) {
+        await fs.unlink(basePathNoExt + tempExt).catch(() => {});
       }
       // Try to remove temp dir if empty
       await fs.rmdir(tempDir).catch(() => {});
@@ -477,48 +480,40 @@ async function createWorkspaceTempFile(
 /**
  * Preview the proposed LaTeX document by creating a temp file in the workspace.
  * This allows \input{}, \include{}, and packages to be resolved properly.
+ * Cleanup is registered with the entry and executed when approval is resolved.
  */
 async function previewProposedLatex(entry: PendingApprovalEntry): Promise<void> {
-  let cleanup: (() => Promise<void>) | undefined;
-
   try {
     // Read current content from proposed file (user may have edited it)
     const content = await fs.readFile(entry.proposedUri.fsPath, 'utf8');
 
     // Create temp file in workspace for proper dependency resolution
-    const { tempPath, cleanup: cleanupFn } = await createWorkspaceTempFile(
+    const { tempPath, cleanup } = await createWorkspaceTempFile(
       entry.request.path,
       content,
       '_preview',
     );
-    cleanup = cleanupFn;
+
+    // Register cleanup to run when approval is resolved
+    entry.workspaceTempCleanup.push(cleanup);
 
     // Open and build the temp file
     const tempLocation = pathToLocation(tempPath);
     await openBuildDisplayIfTex(tempLocation, { preserveFocus: true });
-
-    // Delay cleanup to allow build to complete
-    setTimeout(() => {
-      void cleanup?.();
-    }, 30000); // 30 seconds should be enough for most builds
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     vscode.window.showErrorMessage(`Preview failed: ${message}`);
-    await cleanup?.();
   }
 }
 
 /**
  * Run latexdiff on the original and proposed content.
  * Creates temp files in the workspace for proper dependency resolution.
+ * Cleanup is registered with the entry and executed when approval is resolved.
  */
 async function runLatexdiffForApproval(
   entry: PendingApprovalEntry,
 ): Promise<void> {
-  let cleanupOriginal: (() => Promise<void>) | undefined;
-  let cleanupProposed: (() => Promise<void>) | undefined;
-  let cleanupDiff: (() => Promise<void>) | undefined;
-
   try {
     // Read current content from files (user may have edited proposed in diff view)
     const originalContent = await fs.readFile(entry.originalUri.fsPath, 'utf8');
@@ -530,14 +525,14 @@ async function runLatexdiffForApproval(
       originalContent,
       '_original',
     );
-    cleanupOriginal = original.cleanup;
+    entry.workspaceTempCleanup.push(original.cleanup);
 
     const proposed = await createWorkspaceTempFile(
       entry.request.path,
       proposedContent,
       '_proposed',
     );
-    cleanupProposed = proposed.cleanup;
+    entry.workspaceTempCleanup.push(proposed.cleanup);
 
     // Run latexdiff on the workspace temp files
     const originalLocation = pathToLocation(original.tempPath);
@@ -566,28 +561,18 @@ async function runLatexdiffForApproval(
     const diffLocation = pathToLocation(diffFilePath);
     await openBuildDisplayIfTex(diffLocation, { preserveFocus: true });
 
-    // Setup cleanup for diff file
-    cleanupDiff = async () => {
-      const ext = path.extname(diffFilePath);
-      const auxFiles = ['.aux', '.log', '.pdf', '.synctex.gz', '.fls', '.fdb_latexmk', ''];
-      for (const auxExt of auxFiles) {
-        const auxPath = auxExt ? diffFilePath.replace(ext, auxExt) : diffFilePath;
-        await fs.unlink(auxPath).catch(() => {});
+    // Register cleanup for diff file and its aux files
+    const ext = path.extname(diffFilePath);
+    const diffBasePathNoExt = diffFilePath.slice(0, -ext.length);
+    entry.workspaceTempCleanup.push(async () => {
+      await fs.unlink(diffFilePath).catch(() => {});
+      for (const tempExt of TEMP_EXTENSIONS) {
+        await fs.unlink(diffBasePathNoExt + tempExt).catch(() => {});
       }
-    };
-
-    // Delay cleanup to allow build to complete
-    setTimeout(() => {
-      void cleanupOriginal?.();
-      void cleanupProposed?.();
-      void cleanupDiff?.();
-    }, 30000);
+    });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     vscode.window.showErrorMessage(`LaTeXdiff failed: ${message}`);
-    await cleanupOriginal?.();
-    await cleanupProposed?.();
-    await cleanupDiff?.();
   }
 }
 
@@ -664,6 +649,7 @@ async function nativeRequestApproval(
         lineChanges,
         isSettled: () => settled,
         settle,
+        workspaceTempCleanup: [],
       };
 
       pendingApprovals.set(requestId, entry);
@@ -697,10 +683,20 @@ async function nativeRequestApproval(
       lineChanges: result.lineChanges ?? lineChanges,
     };
   } finally {
+    // Get entry before deleting to access workspace temp cleanup functions
+    const entry = pendingApprovals.get(requestId);
     pendingApprovals.delete(requestId);
     await closeApprovalEditors(originalUri, proposedUri);
     await cleanupTempFile(originalUri);
     await cleanupTempFile(proposedUri);
+
+    // Clean up any workspace temp files created by preview/latexdiff
+    if (entry?.workspaceTempCleanup) {
+      for (const cleanup of entry.workspaceTempCleanup) {
+        await cleanup().catch(() => {});
+      }
+    }
+
     resolveProgressViewApprovalPrompt(requestId);
   }
 }

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -17,14 +17,14 @@ import type { StreamTabId } from '@agent/types/IdentifierTypes';
 // Local imports - utils
 import { getCurrentToolFileInteractionContext } from '@agent/toolUse/ToolFileInteractionContext';
 import { isLatexFile } from '@common/files/fileTypeUtils';
-import { bus } from '@eventBus/ProgressEventBus';
 import { safeExecuteCommand } from '@frontend/system/commandUtils';
 import { openBuildDisplayIfTex } from '@frontend/latex/openBuild';
-import { TEMP_EXTENSIONS } from '@housekeeping/constants';
-import { LaTeXdiffService } from '@latex/latexdiff';
 import { type ToolResult, type LineChanges } from '@tools/result';
 import { getConfig } from '@utils/config';
 import { WorkspaceFS, pathToLocation } from '@utils/files';
+import { bus } from '@eventBus/ProgressEventBus';
+import { LaTeXdiffService } from '@latex/latexdiff';
+import { TEMP_EXTENSIONS } from '@housekeeping/constants';
 
 // Local file imports
 
@@ -62,6 +62,8 @@ interface PendingApprovalEntry {
   settle: (result: ToolEditApprovalResult) => void;
   /** Cleanup functions for workspace temp files created by preview/latexdiff */
   workspaceTempCleanup: Array<() => Promise<void>>;
+  /** Guard to prevent multiple concurrent preview/diff operations */
+  latexOperationInProgress: boolean;
 }
 
 /** All valid approval actions for tool edit prompts */
@@ -435,6 +437,18 @@ async function closeApprovalEditors(
 const latexdiffService = new LaTeXdiffService('ToolEditApproval');
 
 /**
+ * Clean up LaTeX auxiliary files for a given base path.
+ * Uses TEMP_EXTENSIONS from housekeeping constants.
+ */
+async function cleanupLatexAuxFiles(filePath: string): Promise<void> {
+  const ext = path.extname(filePath);
+  const basePathNoExt = filePath.slice(0, -ext.length);
+  for (const tempExt of TEMP_EXTENSIONS) {
+    await fs.unlink(basePathNoExt + tempExt).catch(() => {});
+  }
+}
+
+/**
  * Create a temporary file in the same directory as the original for LaTeX compilation.
  * Placing the temp file alongside the original ensures \input{}, \include{}, and
  * relative paths resolve correctly (they're relative to the file's directory).
@@ -467,13 +481,8 @@ async function createWorkspaceTempFile(
 
   const cleanup = async () => {
     try {
-      // Clean up the main temp file
       await fs.unlink(tempPath).catch(() => {});
-      // Clean up all LaTeX auxiliary files using shared TEMP_EXTENSIONS
-      const basePathNoExt = tempPath.slice(0, -ext.length);
-      for (const tempExt of TEMP_EXTENSIONS) {
-        await fs.unlink(basePathNoExt + tempExt).catch(() => {});
-      }
+      await cleanupLatexAuxFiles(tempPath);
     } catch {
       // Ignore cleanup errors
     }
@@ -488,6 +497,12 @@ async function createWorkspaceTempFile(
  * Cleanup is registered with the entry and executed when approval is resolved.
  */
 async function previewProposedLatex(entry: PendingApprovalEntry): Promise<void> {
+  // Guard against multiple concurrent operations
+  if (entry.latexOperationInProgress) {
+    return;
+  }
+  entry.latexOperationInProgress = true;
+
   try {
     // Read current content from proposed file (user may have edited it)
     const content = await fs.readFile(entry.proposedUri.fsPath, 'utf8');
@@ -508,6 +523,8 @@ async function previewProposedLatex(entry: PendingApprovalEntry): Promise<void> 
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     vscode.window.showErrorMessage(`Preview failed: ${message}`);
+  } finally {
+    entry.latexOperationInProgress = false;
   }
 }
 
@@ -519,6 +536,12 @@ async function previewProposedLatex(entry: PendingApprovalEntry): Promise<void> 
 async function runLatexdiffForApproval(
   entry: PendingApprovalEntry,
 ): Promise<void> {
+  // Guard against multiple concurrent operations
+  if (entry.latexOperationInProgress) {
+    return;
+  }
+  entry.latexOperationInProgress = true;
+
   try {
     // Read current content from files (user may have edited proposed in diff view)
     const originalContent = await fs.readFile(entry.originalUri.fsPath, 'utf8');
@@ -567,17 +590,15 @@ async function runLatexdiffForApproval(
     await openBuildDisplayIfTex(diffLocation, { preserveFocus: true });
 
     // Register cleanup for diff file and its aux files
-    const ext = path.extname(diffFilePath);
-    const diffBasePathNoExt = diffFilePath.slice(0, -ext.length);
     entry.workspaceTempCleanup.push(async () => {
       await fs.unlink(diffFilePath).catch(() => {});
-      for (const tempExt of TEMP_EXTENSIONS) {
-        await fs.unlink(diffBasePathNoExt + tempExt).catch(() => {});
-      }
+      await cleanupLatexAuxFiles(diffFilePath);
     });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     vscode.window.showErrorMessage(`LaTeXdiff failed: ${message}`);
+  } finally {
+    entry.latexOperationInProgress = false;
   }
 }
 
@@ -655,6 +676,7 @@ async function nativeRequestApproval(
         isSettled: () => settled,
         settle,
         workspaceTempCleanup: [],
+        latexOperationInProgress: false,
       };
 
       pendingApprovals.set(requestId, entry);
@@ -696,7 +718,7 @@ async function nativeRequestApproval(
     await cleanupTempFile(proposedUri);
 
     // Clean up any workspace temp files created by preview/latexdiff
-    if (entry?.workspaceTempCleanup) {
+    if (entry?.workspaceTempCleanup.length) {
       for (const cleanup of entry.workspaceTempCleanup) {
         await cleanup().catch(() => {});
       }

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -451,6 +451,8 @@ async function cleanupLatexAuxFiles(filePath: string): Promise<void> {
 /** Temp file location options */
 type TempFileLocation = 'sameDirectory' | 'workspaceTemp';
 
+const TEXRA_TEMP_DIR = '.texra-temp';
+
 /**
  * Create a temporary file for LaTeX compilation.
  * Location is controlled by texra.latexdiff.tempFileLocation setting:
@@ -476,12 +478,13 @@ async function createWorkspaceTempFile(
   const basename = path.basename(originalPath, ext);
   const tempFileName = `${basename}${suffix}-${randomUUID().slice(0, 8)}${ext}`;
 
+  const isWorkspaceTemp = location === 'workspaceTemp';
   let tempDir: string;
-  if (location === 'workspaceTemp') {
-    tempDir = path.join(workspacePath, '.texra-temp');
+
+  if (isWorkspaceTemp) {
+    tempDir = path.join(workspacePath, TEXRA_TEMP_DIR);
     await fs.mkdir(tempDir, { recursive: true });
   } else {
-    // sameDirectory: place alongside original for correct path resolution
     const absoluteOriginal = path.isAbsolute(originalPath)
       ? originalPath
       : path.join(workspacePath, originalPath);
@@ -494,10 +497,8 @@ async function createWorkspaceTempFile(
   const cleanup = async () => {
     await fs.unlink(tempPath).catch(() => {});
     await cleanupLatexAuxFiles(tempPath);
-    // Try to remove .texra-temp if empty (only relevant for workspaceTemp mode)
-    if (location === 'workspaceTemp') {
-      const texraTempDir = path.join(workspacePath, '.texra-temp');
-      await fs.rmdir(texraTempDir).catch(() => {});
+    if (isWorkspaceTemp) {
+      await fs.rmdir(tempDir).catch(() => {});
     }
   };
 

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -536,7 +536,9 @@ async function nativeRequestApproval(
 
     // Clean up any workspace temp files created by preview/latexdiff (parallel for performance)
     if (entry?.workspaceTempCleanup.length) {
-      await Promise.all(entry.workspaceTempCleanup.map((fn) => fn().catch(() => {})));
+      await Promise.all(
+        entry.workspaceTempCleanup.map((fn) => fn().catch(() => {})),
+      );
     }
 
     resolveProgressViewApprovalPrompt(requestId);

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -16,6 +16,7 @@ import type { StreamTabId } from '@agent/types/IdentifierTypes';
 
 // Local imports - utils
 import { getCurrentToolFileInteractionContext } from '@agent/toolUse/ToolFileInteractionContext';
+import { isLatexFile } from '@common/files/fileTypeUtils';
 import { safeExecuteCommand } from '@frontend/system/commandUtils';
 import { openBuildDisplayIfTex } from '@frontend/latex/openBuild';
 import { type ToolResult, type LineChanges } from '@tools/result';
@@ -181,11 +182,6 @@ export function setToolEditApprovalHandler(
   ) => Promise<ToolEditApprovalResult>,
 ): void {
   customHandler = handler;
-}
-
-function isLatexFile(filePath: string): boolean {
-  const ext = path.extname(filePath).toLowerCase();
-  return ext === '.tex' || ext === '.ltx' || ext === '.latex';
 }
 
 async function showProgressViewApprovalPrompt(
@@ -436,32 +432,123 @@ async function closeApprovalEditors(
 const latexdiffService = new LaTeXdiffService('ToolEditApproval');
 
 /**
- * Run latexdiff on the original and proposed temp files for an approval entry.
- * Opens the result in the LaTeX build preview (compiles to PDF).
- *
- * The temp files are stored in extension storage, but we execute latexdiff
- * from the workspace directory so that \input{}, \include{}, and package
- * dependencies can be resolved properly.
+ * Create a temporary file in the workspace for LaTeX compilation.
+ * Files created in the workspace can resolve \input{}, \include{}, and packages.
+ * Returns the temp file path and a cleanup function.
+ */
+async function createWorkspaceTempFile(
+  originalPath: string,
+  content: string,
+  suffix: string,
+): Promise<{ tempPath: string; cleanup: () => Promise<void> }> {
+  const workspacePath = WorkspaceFS.getPath();
+  if (!workspacePath) {
+    throw new Error('No workspace folder open');
+  }
+
+  const ext = path.extname(originalPath);
+  const basename = path.basename(originalPath, ext);
+  const tempDir = path.join(workspacePath, '.texra-temp');
+  const tempFileName = `${basename}${suffix}-${randomUUID().slice(0, 8)}${ext}`;
+  const tempPath = path.join(tempDir, tempFileName);
+
+  await fs.mkdir(tempDir, { recursive: true });
+  await fs.writeFile(tempPath, content, 'utf8');
+
+  const cleanup = async () => {
+    try {
+      await fs.unlink(tempPath).catch(() => {});
+      // Also clean up any generated aux files
+      const auxFiles = ['.aux', '.log', '.pdf', '.synctex.gz', '.fls', '.fdb_latexmk'];
+      for (const auxExt of auxFiles) {
+        const auxPath = tempPath.replace(ext, auxExt);
+        await fs.unlink(auxPath).catch(() => {});
+      }
+      // Try to remove temp dir if empty
+      await fs.rmdir(tempDir).catch(() => {});
+    } catch {
+      // Ignore cleanup errors
+    }
+  };
+
+  return { tempPath, cleanup };
+}
+
+/**
+ * Preview the proposed LaTeX document by creating a temp file in the workspace.
+ * This allows \input{}, \include{}, and packages to be resolved properly.
+ */
+async function previewProposedLatex(entry: PendingApprovalEntry): Promise<void> {
+  let cleanup: (() => Promise<void>) | undefined;
+
+  try {
+    // Read current content from proposed file (user may have edited it)
+    const content = await fs.readFile(entry.proposedUri.fsPath, 'utf8');
+
+    // Create temp file in workspace for proper dependency resolution
+    const { tempPath, cleanup: cleanupFn } = await createWorkspaceTempFile(
+      entry.request.path,
+      content,
+      '_preview',
+    );
+    cleanup = cleanupFn;
+
+    // Open and build the temp file
+    const tempLocation = pathToLocation(tempPath);
+    await openBuildDisplayIfTex(tempLocation, { preserveFocus: true });
+
+    // Delay cleanup to allow build to complete
+    setTimeout(() => {
+      void cleanup?.();
+    }, 30000); // 30 seconds should be enough for most builds
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    vscode.window.showErrorMessage(`Preview failed: ${message}`);
+    await cleanup?.();
+  }
+}
+
+/**
+ * Run latexdiff on the original and proposed content.
+ * Creates temp files in the workspace for proper dependency resolution.
  */
 async function runLatexdiffForApproval(
   entry: PendingApprovalEntry,
 ): Promise<void> {
+  let cleanupOriginal: (() => Promise<void>) | undefined;
+  let cleanupProposed: (() => Promise<void>) | undefined;
+  let cleanupDiff: (() => Promise<void>) | undefined;
+
   try {
-    const originalLocation = pathToLocation(entry.originalUri.fsPath);
-    const proposedLocation = pathToLocation(entry.proposedUri.fsPath);
+    // Read current content from files (user may have edited proposed in diff view)
+    const originalContent = await fs.readFile(entry.originalUri.fsPath, 'utf8');
+    const proposedContent = await fs.readFile(entry.proposedUri.fsPath, 'utf8');
 
-    // Get workspace path for executing latexdiff - this ensures dependencies
-    // like \input{} and \include{} can be resolved from the workspace
-    const workspacePath = WorkspaceFS.getPath();
+    // Create temp files in workspace for proper dependency resolution
+    const original = await createWorkspaceTempFile(
+      entry.request.path,
+      originalContent,
+      '_original',
+    );
+    cleanupOriginal = original.cleanup;
 
-    // Run latexdiff on the temp files with workspace as working directory
+    const proposed = await createWorkspaceTempFile(
+      entry.request.path,
+      proposedContent,
+      '_proposed',
+    );
+    cleanupProposed = proposed.cleanup;
+
+    // Run latexdiff on the workspace temp files
+    const originalLocation = pathToLocation(original.tempPath);
+    const proposedLocation = pathToLocation(proposed.tempPath);
+
     const result = await latexdiffService.runDiff(
       originalLocation,
       proposedLocation,
       '_diff',
       false, // don't run indent
       'coarse', // default math markup
-      { cwd: workspacePath || path.dirname(entry.originalUri.fsPath) },
     );
 
     if (!result.success || !result.diffFileName) {
@@ -473,14 +560,34 @@ async function runLatexdiffForApproval(
 
     // Open the generated diff file in the LaTeX build preview
     const diffFilePath = path.join(
-      path.dirname(entry.originalUri.fsPath),
+      path.dirname(original.tempPath),
       result.diffFileName,
     );
     const diffLocation = pathToLocation(diffFilePath);
     await openBuildDisplayIfTex(diffLocation, { preserveFocus: true });
+
+    // Setup cleanup for diff file
+    cleanupDiff = async () => {
+      const ext = path.extname(diffFilePath);
+      const auxFiles = ['.aux', '.log', '.pdf', '.synctex.gz', '.fls', '.fdb_latexmk', ''];
+      for (const auxExt of auxFiles) {
+        const auxPath = auxExt ? diffFilePath.replace(ext, auxExt) : diffFilePath;
+        await fs.unlink(auxPath).catch(() => {});
+      }
+    };
+
+    // Delay cleanup to allow build to complete
+    setTimeout(() => {
+      void cleanupOriginal?.();
+      void cleanupProposed?.();
+      void cleanupDiff?.();
+    }, 30000);
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     vscode.window.showErrorMessage(`LaTeXdiff failed: ${message}`);
+    await cleanupOriginal?.();
+    await cleanupProposed?.();
+    await cleanupDiff?.();
   }
 }
 
@@ -779,9 +886,8 @@ export async function handleProgressViewToolEditApprovalAction(
       return;
     }
 
-    // Compile and preview the proposed LaTeX document
-    const proposedLocation = pathToLocation(entry.proposedUri.fsPath);
-    await openBuildDisplayIfTex(proposedLocation, { preserveFocus: true });
+    // Compile and preview the proposed LaTeX document in workspace context
+    await previewProposedLatex(entry);
     return;
   }
 

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -893,16 +893,26 @@ export async function handleProgressViewToolEditApprovalAction(
 
   if (payload.action === 'approve') {
     // Read the current content from the proposed file - user may have modified it in the diff view
-    const appliedContent = await fs.readFile(entry.proposedUri.fsPath, 'utf-8');
-    entry.settle({ accepted: true, appliedContent });
+    try {
+      const appliedContent = await fs.readFile(entry.proposedUri.fsPath, 'utf-8');
+      entry.settle({ accepted: true, appliedContent });
+    } catch {
+      // Fall back to original proposed content if file read fails
+      entry.settle({ accepted: true, appliedContent: entry.proposedContent });
+    }
     return;
   }
 
   if (payload.action === 'approveAll') {
     enableSessionApprovalBypass();
     // Read the current content from the proposed file - user may have modified it in the diff view
-    const appliedContent = await fs.readFile(entry.proposedUri.fsPath, 'utf-8');
-    entry.settle({ accepted: true, appliedContent });
+    try {
+      const appliedContent = await fs.readFile(entry.proposedUri.fsPath, 'utf-8');
+      entry.settle({ accepted: true, appliedContent });
+    } catch {
+      // Fall back to original proposed content if file read fails
+      entry.settle({ accepted: true, appliedContent: entry.proposedContent });
+    }
     return;
   }
 

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -68,6 +68,7 @@ export const PROGRESS_VIEW_APPROVAL_ACTIONS = [
   'approveAll',
   'resumeApprovals',
   'showLatexdiff',
+  'previewProposed',
 ] as const;
 
 export type ProgressViewApprovalAction =
@@ -770,6 +771,17 @@ export async function handleProgressViewToolEditApprovalAction(
 
     // Run latexdiff on the original and proposed temp files
     await runLatexdiffForApproval(entry);
+    return;
+  }
+
+  if (payload.action === 'previewProposed') {
+    if (entry.isSettled()) {
+      return;
+    }
+
+    // Compile and preview the proposed LaTeX document
+    const proposedLocation = pathToLocation(entry.proposedUri.fsPath);
+    await openBuildDisplayIfTex(proposedLocation, { preserveFocus: true });
     return;
   }
 

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -18,15 +18,17 @@ import type { StreamTabId } from '@agent/types/IdentifierTypes';
 import { getCurrentToolFileInteractionContext } from '@agent/toolUse/ToolFileInteractionContext';
 import { isLatexFile } from '@common/files/fileTypeUtils';
 import { safeExecuteCommand } from '@frontend/system/commandUtils';
-import { openBuildDisplayIfTex } from '@frontend/latex/openBuild';
 import { type ToolResult, type LineChanges } from '@tools/result';
 import { getConfig } from '@utils/config';
-import { WorkspaceFS, pathToLocation } from '@utils/files';
+import { WorkspaceFS } from '@utils/files';
 import { bus } from '@eventBus/ProgressEventBus';
-import { LaTeXdiffService } from '@latex/latexdiff';
-import { TEMP_EXTENSIONS } from '@housekeeping/constants';
 
 // Local file imports
+import {
+  type LatexPreviewEntry,
+  previewProposedLatex,
+  runLatexdiff,
+} from './latexPreview';
 
 export interface ToolEditApprovalRequest {
   path: string;
@@ -49,21 +51,12 @@ export const TOOL_EDIT_APPROVAL_CONFIG_KEY =
 
 const REVEAL_TIMEOUT_MS = 1500;
 
-interface PendingApprovalEntry {
+interface PendingApprovalEntry extends LatexPreviewEntry {
   request: ToolEditApprovalRequest;
-  originalUri: vscode.Uri;
-  proposedUri: vscode.Uri;
-  originalContent: string;
-  proposedContent: string;
   title: string;
   streamId?: StreamTabId;
   lineChanges: LineChanges;
-  isSettled: () => boolean;
   settle: (result: ToolEditApprovalResult) => void;
-  /** Cleanup functions for workspace temp files created by preview/latexdiff */
-  workspaceTempCleanup: Array<() => Promise<void>>;
-  /** Guard to prevent multiple concurrent preview/diff operations */
-  latexOperationInProgress: boolean;
 }
 
 /** All valid approval actions for tool edit prompts */
@@ -434,226 +427,6 @@ async function closeApprovalEditors(
   }
 }
 
-const latexdiffService = new LaTeXdiffService('ToolEditApproval');
-
-/**
- * Clean up LaTeX auxiliary files for a given base path.
- * Uses TEMP_EXTENSIONS from housekeeping constants.
- */
-async function cleanupLatexAuxFiles(filePath: string): Promise<void> {
-  const ext = path.extname(filePath);
-  const basePathNoExt = filePath.slice(0, -ext.length);
-  for (const tempExt of TEMP_EXTENSIONS) {
-    await fs.unlink(basePathNoExt + tempExt).catch(() => {});
-  }
-}
-
-/** Temp file location options */
-type TempFileLocation = 'sameDirectory' | 'workspaceTemp';
-
-const TEXRA_TEMP_DIR = '.texra-temp';
-/** Length of UUID prefix for temp file names (8 chars = 4 billion combinations, sufficient for uniqueness) */
-const UUID_PREFIX_LENGTH = 8;
-
-function registerWorkspaceTempCleanup(
-  entry: PendingApprovalEntry,
-  cleanup: () => Promise<void>,
-): void {
-  if (entry.isSettled()) {
-    void cleanup().catch(() => {});
-    return;
-  }
-  entry.workspaceTempCleanup.push(cleanup);
-}
-
-/**
- * Create a temporary file for LaTeX compilation.
- * Location is controlled by texra.latexdiff.tempFileLocation setting:
- * - sameDirectory: Same directory as original (best for \input{} paths)
- * - workspaceTemp: .texra-temp directory (keeps source clean)
- */
-async function createWorkspaceTempFile(
-  originalPath: string,
-  content: string,
-  suffix: string,
-): Promise<{ tempPath: string; cleanup: () => Promise<void> }> {
-  const workspacePath = WorkspaceFS.getPath();
-  if (!workspacePath) {
-    throw new Error('No workspace folder open');
-  }
-
-  const location = getConfig<TempFileLocation>(
-    'texra.latexdiff.tempFileLocation',
-    'sameDirectory',
-  );
-
-  const ext = path.extname(originalPath);
-  const basename = path.basename(originalPath, ext);
-  const tempFileName = `${basename}${suffix}-${randomUUID().slice(0, UUID_PREFIX_LENGTH)}${ext}`;
-
-  const isWorkspaceTemp = location === 'workspaceTemp';
-  let tempDir: string;
-
-  if (isWorkspaceTemp) {
-    tempDir = path.join(workspacePath, TEXRA_TEMP_DIR);
-    await fs.mkdir(tempDir, { recursive: true });
-  } else {
-    const absoluteOriginal = path.isAbsolute(originalPath)
-      ? originalPath
-      : path.join(workspacePath, originalPath);
-    tempDir = path.dirname(absoluteOriginal);
-  }
-
-  const tempPath = path.join(tempDir, tempFileName);
-  await fs.writeFile(tempPath, content, 'utf8');
-
-  const cleanup = async () => {
-    await fs.unlink(tempPath).catch(() => {});
-    await cleanupLatexAuxFiles(tempPath);
-    if (isWorkspaceTemp) {
-      await fs.rmdir(tempDir).catch(() => {});
-    }
-  };
-
-  return { tempPath, cleanup };
-}
-
-/**
- * Preview the proposed LaTeX document by creating a temp file.
- * Location is controlled by texra.latexdiff.tempFileLocation setting.
- * Cleanup is registered with the entry and executed when approval is resolved.
- */
-async function previewProposedLatex(
-  entry: PendingApprovalEntry,
-): Promise<void> {
-  // Guard against multiple concurrent operations
-  if (entry.latexOperationInProgress) {
-    return;
-  }
-  entry.latexOperationInProgress = true;
-
-  try {
-    // Read current content from proposed file (user may have edited it)
-    const content = await fs
-      .readFile(entry.proposedUri.fsPath, 'utf8')
-      .catch(() => entry.proposedContent);
-
-    // Create temp file in workspace for proper dependency resolution
-    const { tempPath, cleanup } = await createWorkspaceTempFile(
-      entry.request.path,
-      content,
-      '_preview',
-    );
-
-    // Register cleanup to run when approval is resolved
-    registerWorkspaceTempCleanup(entry, cleanup);
-    if (entry.isSettled()) {
-      return;
-    }
-
-    // Open and build the temp file
-    const tempLocation = pathToLocation(tempPath);
-    await openBuildDisplayIfTex(tempLocation, { preserveFocus: true });
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    vscode.window.showErrorMessage(`Preview failed: ${message}`);
-  } finally {
-    entry.latexOperationInProgress = false;
-  }
-}
-
-/**
- * Run latexdiff on the original and proposed content.
- * Temp file location is controlled by texra.latexdiff.tempFileLocation setting.
- * Cleanup is registered with the entry and executed when approval is resolved.
- */
-async function runLatexdiffForApproval(
-  entry: PendingApprovalEntry,
-): Promise<void> {
-  // Guard against multiple concurrent operations
-  if (entry.latexOperationInProgress) {
-    return;
-  }
-  entry.latexOperationInProgress = true;
-
-  try {
-    // Read current content from files (user may have edited proposed in diff view)
-    const originalContent = await fs
-      .readFile(entry.originalUri.fsPath, 'utf8')
-      .catch(() => entry.originalContent);
-    const proposedContent = await fs
-      .readFile(entry.proposedUri.fsPath, 'utf8')
-      .catch(() => entry.proposedContent);
-
-    // Create temp files in workspace for proper dependency resolution
-    const original = await createWorkspaceTempFile(
-      entry.request.path,
-      originalContent,
-      '_original',
-    );
-    registerWorkspaceTempCleanup(entry, original.cleanup);
-
-    const proposed = await createWorkspaceTempFile(
-      entry.request.path,
-      proposedContent,
-      '_proposed',
-    );
-    registerWorkspaceTempCleanup(entry, proposed.cleanup);
-
-    // Run latexdiff on the workspace temp files
-    const originalLocation = pathToLocation(original.tempPath);
-    const proposedLocation = pathToLocation(proposed.tempPath);
-
-    const workspacePath = WorkspaceFS.getPath();
-    const result = await latexdiffService.runDiff(
-      originalLocation,
-      proposedLocation,
-      '_diff',
-      false, // don't run indent
-      'coarse', // default math markup
-      { cwd: workspacePath ?? path.dirname(original.tempPath) },
-    );
-
-    if (!result.success || !result.diffFileName) {
-      vscode.window.showErrorMessage(
-        result.message ?? 'Failed to generate LaTeXdiff',
-      );
-      return;
-    }
-
-    // Open the generated diff file in the LaTeX build preview
-    if (
-      result.diffFileName.includes('/') ||
-      result.diffFileName.includes('\\') ||
-      result.diffFileName.includes('..')
-    ) {
-      vscode.window.showErrorMessage(
-        'LaTeXdiff failed: invalid output filename',
-      );
-      return;
-    }
-
-    const diffFilePath = path.join(
-      path.dirname(original.tempPath),
-      result.diffFileName,
-    );
-    registerWorkspaceTempCleanup(entry, async () => {
-      await fs.unlink(diffFilePath).catch(() => {});
-      await cleanupLatexAuxFiles(diffFilePath);
-    });
-    if (entry.isSettled()) {
-      return;
-    }
-    const diffLocation = pathToLocation(diffFilePath);
-    await openBuildDisplayIfTex(diffLocation, { preserveFocus: true });
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    vscode.window.showErrorMessage(`LaTeXdiff failed: ${message}`);
-  } finally {
-    entry.latexOperationInProgress = false;
-  }
-}
-
 async function nativeRequestApproval(
   request: ToolEditApprovalRequest,
 ): Promise<ToolEditApprovalResult> {
@@ -940,7 +713,7 @@ export async function handleProgressViewToolEditApprovalAction(
     }
 
     // Run latexdiff on the original and proposed temp files
-    await runLatexdiffForApproval(entry);
+    await runLatexdiff(entry);
     return;
   }
 

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -435,8 +435,9 @@ async function closeApprovalEditors(
 const latexdiffService = new LaTeXdiffService('ToolEditApproval');
 
 /**
- * Create a temporary file in the workspace for LaTeX compilation.
- * Files created in the workspace can resolve \input{}, \include{}, and packages.
+ * Create a temporary file in the same directory as the original for LaTeX compilation.
+ * Placing the temp file alongside the original ensures \input{}, \include{}, and
+ * relative paths resolve correctly (they're relative to the file's directory).
  * Returns the temp file path and a cleanup function.
  */
 async function createWorkspaceTempFile(
@@ -449,13 +450,19 @@ async function createWorkspaceTempFile(
     throw new Error('No workspace folder open');
   }
 
+  // Resolve the original path relative to workspace
+  const absoluteOriginal = path.isAbsolute(originalPath)
+    ? originalPath
+    : path.join(workspacePath, originalPath);
+
   const ext = path.extname(originalPath);
   const basename = path.basename(originalPath, ext);
-  const tempDir = path.join(workspacePath, '.texra-temp');
-  const tempFileName = `${basename}${suffix}-${randomUUID().slice(0, 8)}${ext}`;
-  const tempPath = path.join(tempDir, tempFileName);
+  const originalDir = path.dirname(absoluteOriginal);
 
-  await fs.mkdir(tempDir, { recursive: true });
+  // Create temp file in the SAME directory as original so relative paths work
+  const tempFileName = `${basename}${suffix}-${randomUUID().slice(0, 8)}${ext}`;
+  const tempPath = path.join(originalDir, tempFileName);
+
   await fs.writeFile(tempPath, content, 'utf8');
 
   const cleanup = async () => {
@@ -467,8 +474,6 @@ async function createWorkspaceTempFile(
       for (const tempExt of TEMP_EXTENSIONS) {
         await fs.unlink(basePathNoExt + tempExt).catch(() => {});
       }
-      // Try to remove temp dir if empty
-      await fs.rmdir(tempDir).catch(() => {});
     } catch {
       // Ignore cleanup errors
     }
@@ -478,8 +483,8 @@ async function createWorkspaceTempFile(
 }
 
 /**
- * Preview the proposed LaTeX document by creating a temp file in the workspace.
- * This allows \input{}, \include{}, and packages to be resolved properly.
+ * Preview the proposed LaTeX document by creating a temp file in the same directory.
+ * This ensures \input{}, \include{}, and relative paths resolve correctly.
  * Cleanup is registered with the entry and executed when approval is resolved.
  */
 async function previewProposedLatex(entry: PendingApprovalEntry): Promise<void> {
@@ -508,7 +513,7 @@ async function previewProposedLatex(entry: PendingApprovalEntry): Promise<void> 
 
 /**
  * Run latexdiff on the original and proposed content.
- * Creates temp files in the workspace for proper dependency resolution.
+ * Creates temp files in the same directory as the original for proper path resolution.
  * Cleanup is registered with the entry and executed when approval is resolved.
  */
 async function runLatexdiffForApproval(

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -452,6 +452,8 @@ async function cleanupLatexAuxFiles(filePath: string): Promise<void> {
 type TempFileLocation = 'sameDirectory' | 'workspaceTemp';
 
 const TEXRA_TEMP_DIR = '.texra-temp';
+/** Length of UUID prefix for temp file names (8 chars = 4 billion combinations, sufficient for uniqueness) */
+const UUID_PREFIX_LENGTH = 8;
 
 function registerWorkspaceTempCleanup(
   entry: PendingApprovalEntry,
@@ -487,7 +489,7 @@ async function createWorkspaceTempFile(
 
   const ext = path.extname(originalPath);
   const basename = path.basename(originalPath, ext);
-  const tempFileName = `${basename}${suffix}-${randomUUID().slice(0, 8)}${ext}`;
+  const tempFileName = `${basename}${suffix}-${randomUUID().slice(0, UUID_PREFIX_LENGTH)}${ext}`;
 
   const isWorkspaceTemp = location === 'workspaceTemp';
   let tempDir: string;
@@ -532,7 +534,9 @@ async function previewProposedLatex(
 
   try {
     // Read current content from proposed file (user may have edited it)
-    const content = await fs.readFile(entry.proposedUri.fsPath, 'utf8');
+    const content = await fs
+      .readFile(entry.proposedUri.fsPath, 'utf8')
+      .catch(() => entry.proposedContent);
 
     // Create temp file in workspace for proper dependency resolution
     const { tempPath, cleanup } = await createWorkspaceTempFile(
@@ -574,8 +578,12 @@ async function runLatexdiffForApproval(
 
   try {
     // Read current content from files (user may have edited proposed in diff view)
-    const originalContent = await fs.readFile(entry.originalUri.fsPath, 'utf8');
-    const proposedContent = await fs.readFile(entry.proposedUri.fsPath, 'utf8');
+    const originalContent = await fs
+      .readFile(entry.originalUri.fsPath, 'utf8')
+      .catch(() => entry.originalContent);
+    const proposedContent = await fs
+      .readFile(entry.proposedUri.fsPath, 'utf8')
+      .catch(() => entry.proposedContent);
 
     // Create temp files in workspace for proper dependency resolution
     const original = await createWorkspaceTempFile(
@@ -753,11 +761,9 @@ async function nativeRequestApproval(
     await cleanupTempFile(originalUri);
     await cleanupTempFile(proposedUri);
 
-    // Clean up any workspace temp files created by preview/latexdiff
+    // Clean up any workspace temp files created by preview/latexdiff (parallel for performance)
     if (entry?.workspaceTempCleanup.length) {
-      for (const cleanup of entry.workspaceTempCleanup) {
-        await cleanup().catch(() => {});
-      }
+      await Promise.all(entry.workspaceTempCleanup.map((fn) => fn().catch(() => {})));
     }
 
     resolveProgressViewApprovalPrompt(requestId);

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -596,12 +596,14 @@ async function runLatexdiffForApproval(
     const originalLocation = pathToLocation(original.tempPath);
     const proposedLocation = pathToLocation(proposed.tempPath);
 
+    const workspacePath = WorkspaceFS.getPath();
     const result = await latexdiffService.runDiff(
       originalLocation,
       proposedLocation,
       '_diff',
       false, // don't run indent
       'coarse', // default math markup
+      { cwd: workspacePath ?? path.dirname(original.tempPath) },
     );
 
     if (!result.success || !result.diffFileName) {

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -453,6 +453,17 @@ type TempFileLocation = 'sameDirectory' | 'workspaceTemp';
 
 const TEXRA_TEMP_DIR = '.texra-temp';
 
+function registerWorkspaceTempCleanup(
+  entry: PendingApprovalEntry,
+  cleanup: () => Promise<void>,
+): void {
+  if (entry.isSettled()) {
+    void cleanup().catch(() => {});
+    return;
+  }
+  entry.workspaceTempCleanup.push(cleanup);
+}
+
 /**
  * Create a temporary file for LaTeX compilation.
  * Location is controlled by texra.latexdiff.tempFileLocation setting:
@@ -510,7 +521,9 @@ async function createWorkspaceTempFile(
  * Location is controlled by texra.latexdiff.tempFileLocation setting.
  * Cleanup is registered with the entry and executed when approval is resolved.
  */
-async function previewProposedLatex(entry: PendingApprovalEntry): Promise<void> {
+async function previewProposedLatex(
+  entry: PendingApprovalEntry,
+): Promise<void> {
   // Guard against multiple concurrent operations
   if (entry.latexOperationInProgress) {
     return;
@@ -529,7 +542,10 @@ async function previewProposedLatex(entry: PendingApprovalEntry): Promise<void> 
     );
 
     // Register cleanup to run when approval is resolved
-    entry.workspaceTempCleanup.push(cleanup);
+    registerWorkspaceTempCleanup(entry, cleanup);
+    if (entry.isSettled()) {
+      return;
+    }
 
     // Open and build the temp file
     const tempLocation = pathToLocation(tempPath);
@@ -567,14 +583,14 @@ async function runLatexdiffForApproval(
       originalContent,
       '_original',
     );
-    entry.workspaceTempCleanup.push(original.cleanup);
+    registerWorkspaceTempCleanup(entry, original.cleanup);
 
     const proposed = await createWorkspaceTempFile(
       entry.request.path,
       proposedContent,
       '_proposed',
     );
-    entry.workspaceTempCleanup.push(proposed.cleanup);
+    registerWorkspaceTempCleanup(entry, proposed.cleanup);
 
     // Run latexdiff on the workspace temp files
     const originalLocation = pathToLocation(original.tempPath);
@@ -596,18 +612,30 @@ async function runLatexdiffForApproval(
     }
 
     // Open the generated diff file in the LaTeX build preview
+    if (
+      result.diffFileName.includes('/') ||
+      result.diffFileName.includes('\\') ||
+      result.diffFileName.includes('..')
+    ) {
+      vscode.window.showErrorMessage(
+        'LaTeXdiff failed: invalid output filename',
+      );
+      return;
+    }
+
     const diffFilePath = path.join(
       path.dirname(original.tempPath),
       result.diffFileName,
     );
-    const diffLocation = pathToLocation(diffFilePath);
-    await openBuildDisplayIfTex(diffLocation, { preserveFocus: true });
-
-    // Register cleanup for diff file and its aux files
-    entry.workspaceTempCleanup.push(async () => {
+    registerWorkspaceTempCleanup(entry, async () => {
       await fs.unlink(diffFilePath).catch(() => {});
       await cleanupLatexAuxFiles(diffFilePath);
     });
+    if (entry.isSettled()) {
+      return;
+    }
+    const diffLocation = pathToLocation(diffFilePath);
+    await openBuildDisplayIfTex(diffLocation, { preserveFocus: true });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     vscode.window.showErrorMessage(`LaTeXdiff failed: ${message}`);
@@ -935,7 +963,10 @@ export async function handleProgressViewToolEditApprovalAction(
   if (payload.action === 'approve') {
     // Read the current content from the proposed file - user may have modified it in the diff view
     try {
-      const appliedContent = await fs.readFile(entry.proposedUri.fsPath, 'utf-8');
+      const appliedContent = await fs.readFile(
+        entry.proposedUri.fsPath,
+        'utf-8',
+      );
       entry.settle({ accepted: true, appliedContent });
     } catch {
       // Fall back to original proposed content if file read fails
@@ -948,7 +979,10 @@ export async function handleProgressViewToolEditApprovalAction(
     enableSessionApprovalBypass();
     // Read the current content from the proposed file - user may have modified it in the diff view
     try {
-      const appliedContent = await fs.readFile(entry.proposedUri.fsPath, 'utf-8');
+      const appliedContent = await fs.readFile(
+        entry.proposedUri.fsPath,
+        'utf-8',
+      );
       entry.settle({ accepted: true, appliedContent });
     } catch {
       // Fall back to original proposed content if file read fails


### PR DESCRIPTION
Add a dropdown button to the tool edit approval card that allows users
to view LaTeXdiff output for proposed LaTeX document changes. The button
appears as a dropdown option under "Open diff" when the file is a LaTeX
document (.tex, .ltx, .latex).

Changes:
- Add 'showLatexdiff' action to approval actions
- Add isLatex flag to approval prompt event data
- Implement dropdown button UI with vscode-context-menu
- Add backend logic to run latexdiff on temp files with workspace cwd
- Style the dropdown to appear as a split button

The latexdiff is executed with the workspace directory as cwd, ensuring
that \input{}, \include{}, and package dependencies can be resolved.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces LaTeX-specific actions in tool edit approvals and supporting infra.
> 
> - Adds split "Open diff" dropdown for LaTeX files with `Preview proposed` (compile & view) and `LaTeXdiff (PDF)` actions; dropdown UI, event wiring, outside-click handling, and styles
> - Backend: new `latexPreview.ts` to create temp files, run `latexdiff`, and build/preview PDFs; new approval actions `previewProposed`/`showLatexdiff`; prompt data now includes `isLatex`
> - File-type support: `LATEX_EXTENSIONS` and `isLatexFile()`; `openBuild` now handles `.tex/.ltx/.latex`
> - Config: new `texra.latexdiff.tempFileLocation` (sameDirectory/workspaceTemp); set `latex-workshop.latex.build.fromWorkspaceFolder=true` for reliable path resolution
> - Event/schema updates (`ToolEditApprovalPrompt.isLatex`), robust cleanup of temp and aux files after preview/diff
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aa04e94e8f8e6a29dac695e6a307ff2529e24191. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->