### PR TITLE
fix: restore YAML block scalar format for cleaner tool output display

### DIFF
--- a/src/progressView/modules/formatters/normalizers.js
+++ b/src/progressView/modules/formatters/normalizers.js
@@ -53,10 +53,7 @@ export function stringifyForDisplay(value) {
   }
 
   try {
-    const yamlString = yaml.stringify(value, {
-      lineWidth: 0, // Disable line wrapping to avoid block scalar indicators
-      blockQuote: false, // Prefer inline strings over block scalars
-    });
+    const yamlString = yaml.stringify(value);
     return typeof yamlString === 'string' ? yamlString.trimEnd() : '';
   } catch {
     return String(value);


### PR DESCRIPTION
Revert yaml.stringify options that were causing escaped inline strings
(e.g., \n displayed as \\n). Block scalar format is more readable for
multiline content in the progress view.

Reverts: a339b73

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Restores default YAML formatting for display strings to improve readability of multiline content.
> 
> - `stringifyForDisplay` now calls `yaml.stringify(value)` without custom options, reverting from forced inline/escaped strings to default (block scalar) formatting for complex values
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c5c3b0052c7a21d967de451f617467203f048b19. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->