### PR TITLE
claude/fix-filename-versioning-yyAjI

### DIFF
--- a/src/agent/output/XmlOutputManager.ts
+++ b/src/agent/output/XmlOutputManager.ts
@@ -9,6 +9,7 @@ import type { AgentConfig } from '@agent/core/AgentConfig';
 // Internal imports
 import { AgentSetting } from '@agent/core/AgentDataclass';
 import { getOutputFileName } from '@agent/utils/outputFileUtils';
+import { extractLastRoundMatch } from '@agent/utils/mergeFileUtils';
 import { toErrorMessage } from '@common/errors/errorHandlingUtils';
 import { AgentLogger } from '@logger/AgentLogger';
 import {
@@ -282,12 +283,7 @@ export class XmlOutputManager {
     const agent = outputParts.at(-3) ?? '';
     const model = outputParts.at(-1)?.split('.')[0] ?? '';
 
-    // Extract round from the LAST _rN_ pattern in the filename
-    // The base filename may contain _rN_ patterns (e.g., main_enhance_r1_gpt52_criticize_r0_gpt52.tex)
-    // so we need to find all matches and take the last one
-    const outputBasename = path.basename(outputLocation.absolutePath);
-    const roundMatches = [...outputBasename.matchAll(/_r(\d+)_/g)];
-    const lastRoundMatch = roundMatches.at(-1);
+    const lastRoundMatch = extractLastRoundMatch(outputLocation.absolutePath);
     const currRound = lastRoundMatch ? parseInt(lastRoundMatch[1]) : 0;
 
     for (const doc of latexDocuments) {

--- a/src/agent/output/XmlOutputManager.ts
+++ b/src/agent/output/XmlOutputManager.ts
@@ -282,7 +282,10 @@ export class XmlOutputManager {
     const agent = outputParts.at(-3) ?? '';
     const model = outputParts.at(-1)?.split('.')[0] ?? '';
 
-    const roundMatch = outputLocation.absolutePath.match(/_r(\d+)_/);
+    // Extract round from the correct position: {base}_{agent}_r{round}_{model}.{ext}
+    // Using position-based extraction (at -2) to avoid matching _rN_ from the base filename
+    const roundPart = outputParts.at(-2) ?? '';
+    const roundMatch = roundPart.match(/^r(\d+)$/);
     const currRound = roundMatch ? parseInt(roundMatch[1]) : 0;
 
     for (const doc of latexDocuments) {

--- a/src/agent/output/XmlOutputManager.ts
+++ b/src/agent/output/XmlOutputManager.ts
@@ -282,11 +282,13 @@ export class XmlOutputManager {
     const agent = outputParts.at(-3) ?? '';
     const model = outputParts.at(-1)?.split('.')[0] ?? '';
 
-    // Extract round from the correct position: {base}_{agent}_r{round}_{model}.{ext}
-    // Using position-based extraction (at -2) to avoid matching _rN_ from the base filename
-    const roundPart = outputParts.at(-2) ?? '';
-    const roundMatch = roundPart.match(/^r(\d+)$/);
-    const currRound = roundMatch ? parseInt(roundMatch[1]) : 0;
+    // Extract round from the LAST _rN_ pattern in the filename
+    // The base filename may contain _rN_ patterns (e.g., main_enhance_r1_gpt52_criticize_r0_gpt52.tex)
+    // so we need to find all matches and take the last one
+    const outputBasename = path.basename(outputLocation.absolutePath);
+    const roundMatches = [...outputBasename.matchAll(/_r(\d+)_/g)];
+    const lastRoundMatch = roundMatches.at(-1);
+    const currRound = lastRoundMatch ? parseInt(lastRoundMatch[1]) : 0;
 
     for (const doc of latexDocuments) {
       if (!doc.name || doc.name === 'unknown' || !doc.content) {

--- a/src/agent/utils/mergeFileUtils.ts
+++ b/src/agent/utils/mergeFileUtils.ts
@@ -62,14 +62,16 @@ export function parseFilenameParts(editedBase: string): FilenameParts {
     );
   }
 
-  // Extract round number
-  const roundMatch = editedBase.match(/_r(\d+)_/);
-  if (!roundMatch) {
+  // Extract round number from the LAST _rN_ pattern
+  // (base filename may contain its own _rN_ pattern)
+  const roundMatches = [...editedBase.matchAll(/_r(\d+)_/g)];
+  const lastRoundMatch = roundMatches.at(-1);
+  if (!lastRoundMatch) {
     throw new Error(
       `Could not extract round number from edited base: ${editedBase}`,
     );
   }
-  const roundNum = parseInt(roundMatch[1], 10);
+  const roundNum = parseInt(lastRoundMatch[1], 10);
 
   // Get model name (last part)
   const model = parts.at(-1) || '';

--- a/src/agent/utils/mergeFileUtils.ts
+++ b/src/agent/utils/mergeFileUtils.ts
@@ -19,6 +19,23 @@ export function extractLastRoundMatch(filename: string): RegExpMatchArray | null
 }
 
 /**
+ * Extracts the last _rN_model match from a filename, capturing both round and model.
+ * Model capture stops at underscore or dot to handle chained filenames.
+ *
+ * @param filename The filename or path to extract from
+ * @returns The last RegExpMatchArray with [0]=full match, [1]=round, [2]=model, or null
+ *
+ * @example
+ * extractLastRoundModelMatch('main_enhance_r1_gpt52_criticize_r0_gpt52.tex')
+ * // Returns match for '_r0_gpt52' with [1]='0', [2]='gpt52'
+ */
+export function extractLastRoundModelMatch(
+  filename: string,
+): RegExpMatchArray | null {
+  return [...filename.matchAll(/_r(\d+)_([^_.]+)/g)].at(-1) ?? null;
+}
+
+/**
  * Parsed components from a merge filename.
  */
 export type FilenameParts = {
@@ -76,6 +93,11 @@ export function parseFilenameParts(editedBase: string): FilenameParts {
  * Extracts agent suffix by comparing base and edited filenames.
  * Use when the base filename contains underscores and simple parsing won't work.
  *
+ * Note: This function isolates the suffix first by stripping the known base,
+ * then finds the first _rN in that suffix. This is correct because the suffix
+ * represents a single agent operation (e.g., "_transcribe_r1_gemini"), not a
+ * nested filename. For nested filenames, use parseFilenameParts() instead.
+ *
  * @example
  * extractAgentSuffix(
  *   "20251018_meeting_notes",
@@ -93,7 +115,8 @@ export function extractAgentSuffix(
   // Get suffix after base name, e.g., "_transcribe_r1_gemini3p"
   const suffix = editedNameWithoutExt.slice(baseNameWithoutExt.length);
 
-  // Extract agent: everything between leading underscore and _r{digits}
+  // Extract agent: everything between leading underscore and first _r{digits}
+  // Using first match is correct here since suffix is already isolated
   const match = suffix.match(/^_(.+?)_r\d+/);
   return match?.[1] ?? null;
 }

--- a/src/agent/utils/mergeFileUtils.ts
+++ b/src/agent/utils/mergeFileUtils.ts
@@ -4,6 +4,28 @@
  */
 
 /**
+ * Round pattern regex for matching _rN_ in filenames.
+ * Use with matchAll and .at(-1) to get the last occurrence.
+ */
+export const ROUND_PATTERN = /_r(\d+)_/g;
+
+/**
+ * Extracts the last _rN_ match from a filename.
+ * Use this to correctly handle nested filenames where the base contains its own _rN_ pattern.
+ *
+ * @param filename The filename or path to extract from
+ * @returns The last RegExpMatchArray or null if no match found
+ *
+ * @example
+ * extractLastRoundMatch('main_enhance_r1_gpt52_criticize_r0_gpt52.tex')
+ * // Returns match for '_r0_' (the last occurrence), not '_r1_'
+ */
+export function extractLastRoundMatch(filename: string): RegExpMatchArray | null {
+  // Must create new regex instance since global regexes are stateful
+  return [...filename.matchAll(/_r(\d+)_/g)].at(-1) ?? null;
+}
+
+/**
  * Parsed components from a merge filename.
  */
 export type FilenameParts = {
@@ -27,9 +49,7 @@ export type FilenameParts = {
  * @throws Error if filename components cannot be extracted
  */
 export function parseFilenameParts(editedBase: string): FilenameParts {
-  // Find the LAST _rN_ pattern (base filename may contain its own _rN_ pattern)
-  const roundMatches = [...editedBase.matchAll(/_r(\d+)_/g)];
-  const lastRoundMatch = roundMatches.at(-1);
+  const lastRoundMatch = extractLastRoundMatch(editedBase);
   if (!lastRoundMatch || lastRoundMatch.index === undefined) {
     throw new Error(
       `Could not extract round number from edited base: ${editedBase}`,

--- a/src/agent/utils/mergeFileUtils.ts
+++ b/src/agent/utils/mergeFileUtils.ts
@@ -4,12 +4,6 @@
  */
 
 /**
- * Round pattern regex for matching _rN_ in filenames.
- * Use with matchAll and .at(-1) to get the last occurrence.
- */
-export const ROUND_PATTERN = /_r(\d+)_/g;
-
-/**
  * Extracts the last _rN_ match from a filename.
  * Use this to correctly handle nested filenames where the base contains its own _rN_ pattern.
  *
@@ -21,7 +15,6 @@ export const ROUND_PATTERN = /_r(\d+)_/g;
  * // Returns match for '_r0_' (the last occurrence), not '_r1_'
  */
 export function extractLastRoundMatch(filename: string): RegExpMatchArray | null {
-  // Must create new regex instance since global regexes are stateful
   return [...filename.matchAll(/_r(\d+)_/g)].at(-1) ?? null;
 }
 

--- a/src/agent/utils/mergeFileUtils.ts
+++ b/src/agent/utils/mergeFileUtils.ts
@@ -18,63 +18,43 @@ export type FilenameParts = {
 };
 
 /**
- * Extracts agent name from filename parts handling multiple formats.
- * @param parts Array of filename parts split by underscore
- * @param underscoreCount Total number of underscores in filename
- * @returns Agent name or null if not found
- */
-export function extractAgentName(
-  parts: string[],
-  underscoreCount: number,
-): string | null {
-  if (underscoreCount === 3 && parts.length >= 2) {
-    // Standard format
-    return parts[1];
-  }
-
-  // Complex format - find round number index and join parts before it
-  const partsAfterBase = parts.slice(1);
-  const roundIndex = partsAfterBase.findIndex(
-    (part) => part.startsWith('r') && /^\d+$/.test(part.slice(1)),
-  );
-
-  return roundIndex !== -1
-    ? partsAfterBase.slice(0, roundIndex).join('_')
-    : null;
-}
-
-/**
  * Extracts components from edited filename for merge operations.
+ * Works backwards from the LAST _rN_ pattern to correctly handle nested filenames
+ * like "main_enhance_r1_gpt52_criticize_r0_gpt52".
+ *
  * @param editedBase Base name of edited file without extension
  * @returns Parsed filename components
  * @throws Error if filename components cannot be extracted
  */
 export function parseFilenameParts(editedBase: string): FilenameParts {
-  const parts = editedBase.split('_');
-  const underscoreCount = parts.length - 1;
-  const base = parts[0];
+  // Find the LAST _rN_ pattern (base filename may contain its own _rN_ pattern)
+  const roundMatches = [...editedBase.matchAll(/_r(\d+)_/g)];
+  const lastRoundMatch = roundMatches.at(-1);
+  if (!lastRoundMatch || lastRoundMatch.index === undefined) {
+    throw new Error(
+      `Could not extract round number from edited base: ${editedBase}`,
+    );
+  }
 
-  // Extract agent name
-  const agent = extractAgentName(parts, underscoreCount);
-  if (!agent) {
+  const roundNum = parseInt(lastRoundMatch[1], 10);
+  const roundIndex = lastRoundMatch.index;
+
+  // Model is everything after _rN_
+  const model = editedBase.slice(roundIndex + lastRoundMatch[0].length);
+
+  // Everything before _rN_ is base + agent
+  const beforeRound = editedBase.slice(0, roundIndex);
+
+  // Agent is the part after the last underscore before _rN_
+  const lastUnderscoreIndex = beforeRound.lastIndexOf('_');
+  if (lastUnderscoreIndex === -1) {
     throw new Error(
       `Could not extract agent name from edited base: ${editedBase}`,
     );
   }
 
-  // Extract round number from the LAST _rN_ pattern
-  // (base filename may contain its own _rN_ pattern)
-  const roundMatches = [...editedBase.matchAll(/_r(\d+)_/g)];
-  const lastRoundMatch = roundMatches.at(-1);
-  if (!lastRoundMatch) {
-    throw new Error(
-      `Could not extract round number from edited base: ${editedBase}`,
-    );
-  }
-  const roundNum = parseInt(lastRoundMatch[1], 10);
-
-  // Get model name (last part)
-  const model = parts.at(-1) || '';
+  const base = beforeRound.slice(0, lastUnderscoreIndex);
+  const agent = beforeRound.slice(lastUnderscoreIndex + 1);
 
   return { base, agent, roundNum, model };
 }

--- a/src/agent/utils/outputFileUtils.ts
+++ b/src/agent/utils/outputFileUtils.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 // Local imports
 import type { TaskRunFileService, AgentFileLocation } from '@utils/files';
 import { getAgentFirstNameChunk } from '@housekeeping/utils';
-import { parseFilenameParts } from './mergeFileUtils';
+import { parseFilenameParts, extractLastRoundMatch } from './mergeFileUtils';
 
 /**
  * Generates an output filename incorporating model and round information.
@@ -33,9 +33,7 @@ export function getOutputFileName(
 
   let newRound = currRound;
   if (editedFile) {
-    // Find the LAST _rN_ pattern (base filename may contain its own _rN_)
-    const matches = [...editedFile.matchAll(/_r(\d+)_/g)];
-    const lastMatch = matches.at(-1);
+    const lastMatch = extractLastRoundMatch(editedFile);
     const editedRound = lastMatch ? parseInt(lastMatch[1]) : 0;
     newRound += editedRound + 1;
   }

--- a/src/agent/utils/outputFileUtils.ts
+++ b/src/agent/utils/outputFileUtils.ts
@@ -33,8 +33,10 @@ export function getOutputFileName(
 
   let newRound = currRound;
   if (editedFile) {
-    const match = editedFile.match(/_r(\d+)_/);
-    const editedRound = match ? parseInt(match[1]) : 0;
+    // Find the LAST _rN_ pattern (base filename may contain its own _rN_)
+    const matches = [...editedFile.matchAll(/_r(\d+)_/g)];
+    const lastMatch = matches.at(-1);
+    const editedRound = lastMatch ? parseInt(lastMatch[1]) : 0;
     newRound += editedRound + 1;
   }
 

--- a/src/latex/latexdiff.ts
+++ b/src/latex/latexdiff.ts
@@ -325,8 +325,11 @@ export class LaTeXdiffService {
         return { success: false, message };
       }
 
-      const firstRoundMatch = firstLocation.absolutePath.match(/_r(\d+)_/);
-      const secondRoundMatch = secondLocation.absolutePath.match(/_r(\d+)_/);
+      // Find the LAST _rN_ pattern (base filename may contain its own _rN_)
+      const firstMatches = [...firstLocation.absolutePath.matchAll(/_r(\d+)_/g)];
+      const secondMatches = [...secondLocation.absolutePath.matchAll(/_r(\d+)_/g)];
+      const firstRoundMatch = firstMatches.at(-1);
+      const secondRoundMatch = secondMatches.at(-1);
 
       if (!firstRoundMatch || !secondRoundMatch) {
         const message = 'Could not extract round numbers from file names';

--- a/src/latex/latexdiff.ts
+++ b/src/latex/latexdiff.ts
@@ -16,6 +16,7 @@ import { runLatexFormatter } from './texFormatter';
 import { DiffFileNameManager } from './latexdiff/diffFileNameManager';
 import { DiffFileProcessor } from './latexdiff/diffFileProcessor';
 import { DiffCommandExecutor } from './latexdiff/diffCommandExecutor';
+import { extractLastRoundMatch } from '@agent/utils/mergeFileUtils';
 
 // Type imports
 import type { MathMarkupOption } from './latexdiff/mathMarkup';
@@ -325,11 +326,8 @@ export class LaTeXdiffService {
         return { success: false, message };
       }
 
-      // Find the LAST _rN_ pattern (base filename may contain its own _rN_)
-      const firstMatches = [...firstLocation.absolutePath.matchAll(/_r(\d+)_/g)];
-      const secondMatches = [...secondLocation.absolutePath.matchAll(/_r(\d+)_/g)];
-      const firstRoundMatch = firstMatches.at(-1);
-      const secondRoundMatch = secondMatches.at(-1);
+      const firstRoundMatch = extractLastRoundMatch(firstLocation.absolutePath);
+      const secondRoundMatch = extractLastRoundMatch(secondLocation.absolutePath);
 
       if (!firstRoundMatch || !secondRoundMatch) {
         const message = 'Could not extract round numbers from file names';

--- a/src/latex/latexdiff/diffFileNameManager.ts
+++ b/src/latex/latexdiff/diffFileNameManager.ts
@@ -3,12 +3,17 @@ import * as path from 'path';
 
 /** Extract base name from filename using round pattern */
 function extractBaseName(filename: string, includeRound: boolean): string {
-  const pattern = includeRound ? /^(.*?_r\d+)/ : /^(.*?)_r\d+/;
-  const match = path.parse(filename).name.match(pattern);
-  if (!match) {
+  const name = path.parse(filename).name;
+  // Find the LAST _rN_ pattern position
+  const matches = [...name.matchAll(/_r(\d+)_/g)];
+  const lastMatch = matches.at(-1);
+  if (!lastMatch || lastMatch.index === undefined) {
     throw new Error('Failed to extract base name from edited file');
   }
-  return match[1];
+  // Return everything up to (or including) the last _rN
+  return includeRound
+    ? name.slice(0, lastMatch.index + lastMatch[0].length - 1) // include _rN but not trailing _
+    : name.slice(0, lastMatch.index);
 }
 
 export class DiffFileNameManager {
@@ -19,8 +24,9 @@ export class DiffFileNameManager {
   ): string {
     const editedFileName = path.basename(editedFile);
     // Find the LAST _rN_ pattern (base filename may contain its own _rN_)
-    const inputMatches = [...path.basename(inputFile).matchAll(/_r(\d+)_([^.]+)/g)];
-    const editedMatches = [...editedFileName.matchAll(/_r(\d+)_([^.]+)/g)];
+    // Use [^_.]+ to stop at underscores, allowing multiple matches
+    const inputMatches = [...path.basename(inputFile).matchAll(/_r(\d+)_([^_.]+)/g)];
+    const editedMatches = [...editedFileName.matchAll(/_r(\d+)_([^_.]+)/g)];
     const inputRoundMatch = inputMatches.at(-1);
     const editedRoundMatch = editedMatches.at(-1);
 

--- a/src/latex/latexdiff/diffFileNameManager.ts
+++ b/src/latex/latexdiff/diffFileNameManager.ts
@@ -1,18 +1,19 @@
 // Standard library imports
 import * as path from 'path';
 
+import { extractLastRoundMatch } from '@agent/utils/mergeFileUtils';
+
 /** Extract base name from filename using round pattern */
 function extractBaseName(filename: string, includeRound: boolean): string {
   const name = path.parse(filename).name;
-  // Find the LAST _rN_ pattern position
-  const matches = [...name.matchAll(/_r(\d+)_/g)];
-  const lastMatch = matches.at(-1);
+  const lastMatch = extractLastRoundMatch(name);
   if (!lastMatch || lastMatch.index === undefined) {
     throw new Error('Failed to extract base name from edited file');
   }
   // Return everything up to (or including) the last _rN
+  // The -1 excludes the trailing underscore from _rN_ when includeRound is true
   return includeRound
-    ? name.slice(0, lastMatch.index + lastMatch[0].length - 1) // include _rN but not trailing _
+    ? name.slice(0, lastMatch.index + lastMatch[0].length - 1)
     : name.slice(0, lastMatch.index);
 }
 

--- a/src/latex/latexdiff/diffFileNameManager.ts
+++ b/src/latex/latexdiff/diffFileNameManager.ts
@@ -18,8 +18,11 @@ export class DiffFileNameManager {
     suffix: string,
   ): string {
     const editedFileName = path.basename(editedFile);
-    const inputRoundMatch = path.basename(inputFile).match(/_r(\d+)_([^.]+)/);
-    const editedRoundMatch = editedFileName.match(/_r(\d+)_([^.]+)/);
+    // Find the LAST _rN_ pattern (base filename may contain its own _rN_)
+    const inputMatches = [...path.basename(inputFile).matchAll(/_r(\d+)_([^.]+)/g)];
+    const editedMatches = [...editedFileName.matchAll(/_r(\d+)_([^.]+)/g)];
+    const inputRoundMatch = inputMatches.at(-1);
+    const editedRoundMatch = editedMatches.at(-1);
 
     if (inputRoundMatch && editedRoundMatch) {
       return this.generateRoundBasedFileName(

--- a/src/latex/latexdiff/diffFileNameManager.ts
+++ b/src/latex/latexdiff/diffFileNameManager.ts
@@ -1,14 +1,17 @@
 // Standard library imports
 import * as path from 'path';
 
-import { extractLastRoundMatch } from '@agent/utils/mergeFileUtils';
+import {
+  extractLastRoundMatch,
+  extractLastRoundModelMatch,
+} from '@agent/utils/mergeFileUtils';
 
 /** Extract base name from filename using round pattern */
 function extractBaseName(filename: string, includeRound: boolean): string {
   const name = path.parse(filename).name;
   const lastMatch = extractLastRoundMatch(name);
   if (!lastMatch || lastMatch.index === undefined) {
-    throw new Error('Failed to extract base name from edited file');
+    throw new Error(`Failed to extract base name from edited file: ${filename}`);
   }
   // Return everything up to (or including) the last _rN
   // The -1 excludes the trailing underscore from _rN_ when includeRound is true
@@ -17,9 +20,6 @@ function extractBaseName(filename: string, includeRound: boolean): string {
     : name.slice(0, lastMatch.index);
 }
 
-/** Pattern to extract round and model: _r{N}_{model} where model stops at underscore or dot */
-const ROUND_MODEL_PATTERN = /_r(\d+)_([^_.]+)/g;
-
 export class DiffFileNameManager {
   generateDiffFileName(
     inputFile: string,
@@ -27,9 +27,8 @@ export class DiffFileNameManager {
     suffix: string,
   ): string {
     const editedFileName = path.basename(editedFile);
-    // Find the LAST _rN_model pattern (base filename may contain its own _rN_)
-    const inputRoundMatch = [...path.basename(inputFile).matchAll(ROUND_MODEL_PATTERN)].at(-1);
-    const editedRoundMatch = [...editedFileName.matchAll(ROUND_MODEL_PATTERN)].at(-1);
+    const inputRoundMatch = extractLastRoundModelMatch(path.basename(inputFile));
+    const editedRoundMatch = extractLastRoundModelMatch(editedFileName);
 
     if (inputRoundMatch && editedRoundMatch) {
       return this.generateRoundBasedFileName(

--- a/src/latex/latexdiff/diffFileNameManager.ts
+++ b/src/latex/latexdiff/diffFileNameManager.ts
@@ -17,6 +17,9 @@ function extractBaseName(filename: string, includeRound: boolean): string {
     : name.slice(0, lastMatch.index);
 }
 
+/** Pattern to extract round and model: _r{N}_{model} where model stops at underscore or dot */
+const ROUND_MODEL_PATTERN = /_r(\d+)_([^_.]+)/g;
+
 export class DiffFileNameManager {
   generateDiffFileName(
     inputFile: string,
@@ -24,12 +27,9 @@ export class DiffFileNameManager {
     suffix: string,
   ): string {
     const editedFileName = path.basename(editedFile);
-    // Find the LAST _rN_ pattern (base filename may contain its own _rN_)
-    // Use [^_.]+ to stop at underscores, allowing multiple matches
-    const inputMatches = [...path.basename(inputFile).matchAll(/_r(\d+)_([^_.]+)/g)];
-    const editedMatches = [...editedFileName.matchAll(/_r(\d+)_([^_.]+)/g)];
-    const inputRoundMatch = inputMatches.at(-1);
-    const editedRoundMatch = editedMatches.at(-1);
+    // Find the LAST _rN_model pattern (base filename may contain its own _rN_)
+    const inputRoundMatch = [...path.basename(inputFile).matchAll(ROUND_MODEL_PATTERN)].at(-1);
+    const editedRoundMatch = [...editedFileName.matchAll(ROUND_MODEL_PATTERN)].at(-1);
 
     if (inputRoundMatch && editedRoundMatch) {
       return this.generateRoundBasedFileName(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Fix nested filename parsing**
> 
> - Add `extractLastRoundMatch` and `extractLastRoundModelMatch` utilities and rework `parseFilenameParts` to derive `base/agent/round/model` from the last `_rN_` occurrence
> - Update `XmlOutputManager`, `outputFileUtils.getOutputFileName`, and `LaTeXdiffService` to use the new utilities for round extraction
> - Improve diff naming via `DiffFileNameManager` to compute base and model-aware suffixes from the last `_rN_model` segment, handling chained filenames
> 
> *Result:* Correct round/model detection and consistent output/diff filenames for nested or chained agent operations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1d3a32c8f4d3473f9164bacdd83856cc6e71901d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->