### PR TITLE
fix: prevent race condition in workflow launch deduplication

### DIFF
--- a/src/agent/runtime/StreamStatusService.ts
+++ b/src/agent/runtime/StreamStatusService.ts
@@ -32,6 +32,39 @@ export const StreamStatusService = {
   },
 
   /**
+   * Attempt to acquire a stream for execution.
+   * Returns true if acquired (sets INITIALIZING), false if already running/initializing.
+   *
+   * This is an atomic check-and-set to prevent race conditions when launching
+   * workflows concurrently.
+   */
+  tryAcquire(stream: StreamTabId): boolean {
+    const current = statusMemory.get(stream);
+
+    // Block if already running or initializing
+    if (
+      current === STREAM_STATUS.RUNNING ||
+      current === STREAM_STATUS.INITIALIZING
+    ) {
+      return false;
+    }
+
+    // Acquire by setting INITIALIZING
+    this.set(stream, STREAM_STATUS.INITIALIZING);
+    return true;
+  },
+
+  /**
+   * Release an INITIALIZING stream on error.
+   * Only clears if current status is still INITIALIZING.
+   */
+  releaseIfInitializing(stream: StreamTabId): void {
+    if (statusMemory.get(stream) === STREAM_STATUS.INITIALIZING) {
+      this.clear(stream);
+    }
+  },
+
+  /**
    * Set the status for a stream.
    * @param stream - Stream identifier
    * @param status - New status (READY clears the status)

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -22,7 +22,13 @@ import { ZodError } from 'zod';
 
 // Local imports - agent components (types only - no agent class instantiation)
 import type { IModelHandler } from '@agent/modelHandlers';
-import { resolveAgent, isRemoteAgent } from '@agent/index';
+import {
+  resolveAgent,
+  isRemoteAgent,
+  getAgent,
+  getCleanAgentName,
+  getMultipleName,
+} from '@agent/index';
 import type { ResolvedAgent } from '@agent/index';
 import { createMergeOutputFileLocationGetter } from '@agent/utils/outputFileUtils';
 import type { ToolUseSessionSnapshot } from '@agent/implementations/flows/tooluse/ToolUseSessionTypes';
@@ -108,6 +114,39 @@ interface ResolvedAgentBase extends StorageKeyManager {
   usageMonitor: UsageMonitor;
   /** Parent stage for flow execution. Init stage is a child of this. */
   runStage: AgentLogStage;
+}
+
+// ============================================================================
+// Early Stream ID Computation (Race Condition Prevention)
+// ============================================================================
+
+/**
+ * Compute a preliminary stream ID from config parameters BEFORE expensive resolution.
+ * Used for early duplicate detection to prevent race conditions.
+ *
+ * This mirrors the logic in getStreamTabId() but uses the agent registry cache
+ * to get agentType synchronously, avoiding the need for YAML loading.
+ */
+function computePreliminaryStreamId(
+  configPayload: Partial<AgentConfig>,
+  executionId?: ExecutionId,
+): StreamTabId {
+  const { agent, model, inputFile, useMultipleOutputs } = configPayload;
+
+  if (!agent || !model) {
+    throw new Error('Missing required fields: model and/or agent');
+  }
+
+  // Get agent type from registry cache (fast synchronous lookup)
+  const agentEntry = getAgent(agent);
+  const agentType = agentEntry?.agentType ?? AgentType.CoT;
+
+  // Delegate to canonical implementation
+  return getStreamTabId(agent, model, inputFile ?? '', {
+    agentType,
+    executionId,
+    useMultipleOutputs,
+  });
 }
 
 // ============================================================================
@@ -505,6 +544,23 @@ export async function executeAgent(
     throw new Error('Missing required fields: model and/or agent');
   }
 
+  // Early acquisition to prevent race conditions.
+  // Compute preliminary stream ID and atomically acquire before expensive resolution.
+  const preliminaryStreamId = computePreliminaryStreamId(
+    configPayload,
+    executionId,
+  );
+  if (!StreamStatusService.tryAcquire(preliminaryStreamId)) {
+    const currentStatus = StreamStatusService.get(preliminaryStreamId);
+    const statusMsg =
+      currentStatus === STREAM_STATUS.INITIALIZING
+        ? 'already launching'
+        : 'already running';
+    throw new Error(
+      `Task "${preliminaryStreamId}" is ${statusMsg}. Please wait for it to complete or stop it first.`,
+    );
+  }
+
   // Resolve agent and prepare base context
   // Wrapped in try-catch to display agent loading errors to users
   let ctx: ResolvedAgentBase;
@@ -515,6 +571,8 @@ export async function executeAgent(
       executionId,
     );
   } catch (err) {
+    // Release acquisition on resolution failure
+    StreamStatusService.releaseIfInitializing(preliminaryStreamId);
     // Show error to user unless it's a ZodError (handled by executeCommand.ts)
     if (!(err instanceof ZodError)) {
       void vscode.window.showErrorMessage(toErrorMessage(err));
@@ -526,14 +584,15 @@ export async function executeAgent(
   const agentName = config.agent;
 
   if (!config.session) {
+    StreamStatusService.releaseIfInitializing(preliminaryStreamId);
     throw new Error('Agent configuration is missing session metadata.');
   }
 
-  // Check if already running before any state modifications
-  const currentStatus = StreamStatusService.get(streamTabId);
-  if (currentStatus === STREAM_STATUS.RUNNING) {
-    throw new Error(
-      `Task "${streamTabId}" is already running. Please wait for it to complete or stop it first.`,
+  // Verify stream IDs match (paranoid check for ID computation consistency)
+  if (streamTabId !== preliminaryStreamId) {
+    logger.warn(
+      `Stream ID mismatch: preliminary=${preliminaryStreamId}, resolved=${streamTabId}. ` +
+        'This may indicate a bug in stream ID computation.',
     );
   }
 
@@ -622,26 +681,42 @@ export async function executeMergeAgent(
   inputFile: string,
   editedFile: string,
 ): Promise<void> {
-  // Flow errors handled by runFlowWithLifecycle; validation errors propagate to VS Code
-  const ctx = await resolveAgentBase('merge', {
+  // Early acquisition to prevent race conditions
+  const preliminaryStreamId = computePreliminaryStreamId({
     agent: 'merge',
     model,
     inputFile,
-    editedFile,
   });
+  if (!StreamStatusService.tryAcquire(preliminaryStreamId)) {
+    const currentStatus = StreamStatusService.get(preliminaryStreamId);
+    const statusMsg =
+      currentStatus === STREAM_STATUS.INITIALIZING
+        ? 'already launching'
+        : 'already running';
+    throw new Error(
+      `Merge task "${preliminaryStreamId}" is ${statusMsg}. Please wait for it to complete or stop it first.`,
+    );
+  }
+
+  // Flow errors handled by runFlowWithLifecycle; validation errors propagate to VS Code
+  let ctx: ResolvedAgentBase;
+  try {
+    ctx = await resolveAgentBase('merge', {
+      agent: 'merge',
+      model,
+      inputFile,
+      editedFile,
+    });
+  } catch (err) {
+    StreamStatusService.releaseIfInitializing(preliminaryStreamId);
+    throw err;
+  }
 
   const { streamId: streamTabId, config, executionId } = ctx;
 
   if (!config.session) {
+    StreamStatusService.releaseIfInitializing(preliminaryStreamId);
     throw new Error('Merge agent configuration is missing session metadata.');
-  }
-
-  // Check if already running
-  const currentStatus = StreamStatusService.get(streamTabId);
-  if (currentStatus === STREAM_STATUS.RUNNING) {
-    throw new Error(
-      `Merge task "${streamTabId}" is already running. Please wait for it to complete or stop it first.`,
-    );
   }
 
   await runFlowWithLifecycle(ctx, streamTabId, 'merge', async () => {

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -388,6 +388,49 @@ async function resolveAgentBase(
 // ============================================================================
 
 /**
+ * Acquire stream for execution or throw if already in use.
+ * Must be called before expensive resolution to prevent race conditions.
+ *
+ * @param streamId - The stream ID to acquire
+ * @param taskType - Type descriptor for error message (e.g., "Task", "Merge task")
+ * @throws Error if stream is already initializing or running
+ */
+function acquireStreamOrThrow(
+  streamId: StreamTabId,
+  taskType: string = 'Task',
+): void {
+  if (!StreamStatusService.tryAcquire(streamId)) {
+    const currentStatus = StreamStatusService.get(streamId);
+    const statusMsg =
+      currentStatus === STREAM_STATUS.INITIALIZING
+        ? 'already launching'
+        : 'already running';
+    throw new Error(
+      `${taskType} "${streamId}" is ${statusMsg}. Please wait for it to complete or stop it first.`,
+    );
+  }
+}
+
+/**
+ * Validate that config has session metadata, releasing stream on failure.
+ *
+ * @param config - Agent configuration to validate
+ * @param streamId - Stream ID to release if validation fails
+ * @param agentType - Type descriptor for error message (e.g., "Agent", "Merge agent")
+ * @throws Error if session metadata is missing
+ */
+function ensureSessionMetadata(
+  config: AgentConfig,
+  streamId: StreamTabId,
+  agentType: string = 'Agent',
+): void {
+  if (!config.session) {
+    StreamStatusService.releaseIfInitializing(streamId);
+    throw new Error(`${agentType} configuration is missing session metadata.`);
+  }
+}
+
+/**
  * Create a usage recorder callback for flow execution.
  *
  * This callback is invoked when a round is finalized and records usage
@@ -550,16 +593,7 @@ export async function executeAgent(
     configPayload,
     executionId,
   );
-  if (!StreamStatusService.tryAcquire(preliminaryStreamId)) {
-    const currentStatus = StreamStatusService.get(preliminaryStreamId);
-    const statusMsg =
-      currentStatus === STREAM_STATUS.INITIALIZING
-        ? 'already launching'
-        : 'already running';
-    throw new Error(
-      `Task "${preliminaryStreamId}" is ${statusMsg}. Please wait for it to complete or stop it first.`,
-    );
-  }
+  acquireStreamOrThrow(preliminaryStreamId);
 
   // Resolve agent and prepare base context
   // Wrapped in try-catch to display agent loading errors to users
@@ -583,10 +617,7 @@ export async function executeAgent(
   const { setting, streamId: streamTabId, config } = ctx;
   const agentName = config.agent;
 
-  if (!config.session) {
-    StreamStatusService.releaseIfInitializing(preliminaryStreamId);
-    throw new Error('Agent configuration is missing session metadata.');
-  }
+  ensureSessionMetadata(config, preliminaryStreamId);
 
   // Verify stream IDs match (paranoid check for ID computation consistency)
   if (streamTabId !== preliminaryStreamId) {
@@ -687,16 +718,7 @@ export async function executeMergeAgent(
     model,
     inputFile,
   });
-  if (!StreamStatusService.tryAcquire(preliminaryStreamId)) {
-    const currentStatus = StreamStatusService.get(preliminaryStreamId);
-    const statusMsg =
-      currentStatus === STREAM_STATUS.INITIALIZING
-        ? 'already launching'
-        : 'already running';
-    throw new Error(
-      `Merge task "${preliminaryStreamId}" is ${statusMsg}. Please wait for it to complete or stop it first.`,
-    );
-  }
+  acquireStreamOrThrow(preliminaryStreamId, 'Merge task');
 
   // Flow errors handled by runFlowWithLifecycle; validation errors propagate to VS Code
   let ctx: ResolvedAgentBase;
@@ -714,10 +736,7 @@ export async function executeMergeAgent(
 
   const { streamId: streamTabId, config, executionId } = ctx;
 
-  if (!config.session) {
-    StreamStatusService.releaseIfInitializing(preliminaryStreamId);
-    throw new Error('Merge agent configuration is missing session metadata.');
-  }
+  ensureSessionMetadata(config, preliminaryStreamId, 'Merge agent');
 
   await runFlowWithLifecycle(ctx, streamTabId, 'merge', async () => {
     setupFlowUIState(ctx);

--- a/src/common/constants/streamStatus.ts
+++ b/src/common/constants/streamStatus.ts
@@ -10,6 +10,7 @@ export const STREAM_STATUS = {
   READY: 'ready',
   WAITING: 'waiting',
   RESUMING: 'resuming',
+  INITIALIZING: 'initializing',
 } as const;
 
 export const StreamStatusSchema = z.enum([
@@ -19,6 +20,7 @@ export const StreamStatusSchema = z.enum([
   STREAM_STATUS.READY,
   STREAM_STATUS.WAITING,
   STREAM_STATUS.RESUMING,
+  STREAM_STATUS.INITIALIZING,
 ]);
 
 export type StreamStatus = z.infer<typeof StreamStatusSchema>;


### PR DESCRIPTION
Add early acquisition pattern to prevent concurrent launches of the same
workflow from both proceeding. Previously, the deduplication check happened
after expensive async resolution, creating a TOCTOU race window.

Changes:
- Add INITIALIZING status for streams being prepared
- Add tryAcquire/releaseIfInitializing to StreamStatusService for atomic check-and-set
- Compute preliminary stream ID before resolution using cached agent registry
- Release acquisition on resolution failure to avoid deadlocks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces an early, atomic acquisition step to eliminate the TOCTOU window when launching workflows/merge tasks.
> 
> - Adds `INITIALIZING` to `STREAM_STATUS` and updates `StreamStatusSchema`
> - New `StreamStatusService.tryAcquire` and `releaseIfInitializing` for atomic check-and-set and safe release on failure
> - Computes a preliminary stream ID (`computePreliminaryStreamId`) using the agent registry cache, then `acquireStreamOrThrow` before expensive resolution
> - Updates `executeAgent` and `executeMergeAgent` to use early acquisition; release on resolution/validation errors; verifies stream ID consistency
> - Adds `ensureSessionMetadata` guard and minor logging improvements
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9318cda64082434aed668b3d5822d252248e4c46. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->