### PR TITLE
refactor: simplify code across 10 files

### DIFF
--- a/src/MainViewProvider.ts
+++ b/src/MainViewProvider.ts
@@ -60,25 +60,21 @@ export class MainViewProvider
   }
 
   private registerCommandHandlers() {
-    // Only register commands if they haven't been registered yet
-    if (!MainViewProvider.commandsRegistered) {
-      // Create a promise to check if the command exists and register if it doesn't
-      vscode.commands.getCommands(true).then((commands) => {
-        if (!commands.includes('texra.getWebviewView')) {
-          this.context.subscriptions.push(
-            vscode.commands.registerCommand('texra.getWebviewView', () => {
-              return this._view as vscode.WebviewView;
-            }),
-          );
-          MainViewProvider.commandsRegistered = true;
-          return true;
-        }
-        MainViewProvider.commandsRegistered = true;
-        return false;
-      });
-
-      // Command registration is handled asynchronously
+    if (MainViewProvider.commandsRegistered) {
+      return;
     }
+    MainViewProvider.commandsRegistered = true;
+
+    // Register command asynchronously only if it doesn't already exist
+    void vscode.commands.getCommands(true).then((commands) => {
+      if (!commands.includes('texra.getWebviewView')) {
+        this.context.subscriptions.push(
+          vscode.commands.registerCommand('texra.getWebviewView', () => {
+            return this._view as vscode.WebviewView;
+          }),
+        );
+      }
+    });
   }
 
   private setupConfigurationWatcher() {

--- a/src/commands/agent/executeCommand.ts
+++ b/src/commands/agent/executeCommand.ts
@@ -35,7 +35,9 @@ export async function runExecuteCommand(input: unknown): Promise<void> {
   try {
     // Support both raw config and wrapped { config, executionId? } format
     const wrapped = isWrappedConfig(input) ? input : null;
-    const config = AgentConfigSchema.parse(wrapped?.config ?? input);
+    // Parse wrapped.config when wrapped (allows Zod to fail on undefined),
+    // otherwise parse input directly
+    const config = AgentConfigSchema.parse(wrapped ? wrapped.config : input);
 
     // Use provided executionId (resume) or create new one (fresh)
     const executionId =

--- a/src/commands/agent/executeCommand.ts
+++ b/src/commands/agent/executeCommand.ts
@@ -35,8 +35,7 @@ export async function runExecuteCommand(input: unknown): Promise<void> {
   try {
     // Support both raw config and wrapped { config, executionId? } format
     const wrapped = isWrappedConfig(input) ? input : null;
-    const rawConfig = wrapped ? wrapped.config : input;
-    const config = AgentConfigSchema.parse(rawConfig);
+    const config = AgentConfigSchema.parse(wrapped?.config ?? input);
 
     // Use provided executionId (resume) or create new one (fresh)
     const executionId =

--- a/src/commands/latex/arXivCommands.ts
+++ b/src/commands/latex/arXivCommands.ts
@@ -94,23 +94,12 @@ export function registerArXivCommands(context: vscode.ExtensionContext) {
           );
         }
       } catch (error) {
-        if (error instanceof Error) {
-          vscode.window.showErrorMessage(
-            `Failed to download arXiv source: ${error.message}`,
-          );
-          logger.error(
-            CHANNEL,
-            `Error downloading arXiv source: ${error.message}`,
-          );
-        } else {
-          vscode.window.showErrorMessage(
-            'An unknown error occurred while downloading arXiv source',
-          );
-          logger.error(
-            CHANNEL,
-            `Unknown error downloading arXiv source: ${error}`,
-          );
-        }
+        const message =
+          error instanceof Error ? error.message : 'An unknown error occurred';
+        vscode.window.showErrorMessage(
+          `Failed to download arXiv source: ${message}`,
+        );
+        logger.error(CHANNEL, `Error downloading arXiv source: ${message}`);
       }
     },
   );

--- a/src/commands/latex/figCommands.ts
+++ b/src/commands/latex/figCommands.ts
@@ -15,6 +15,11 @@ import { tikzPictureManager } from '@latex/TikzPictureManager';
 const CHANNEL = 'TestCommands';
 logger.initialize(CHANNEL);
 
+/** Simple pluralization helper */
+function pluralize(count: number, singular: string): string {
+  return count === 1 ? singular : `${singular}s`;
+}
+
 export function registerFigureCommands(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     vscode.commands.registerCommand(
@@ -94,7 +99,7 @@ async function handleExtractTikzFigures(): Promise<void> {
           // Create QuickPick items from the labels
           const items = labeledTikzPictures.map(
             ([label, tikzpicturess]: [string, string[]]) => ({
-              label: `${label} (${tikzpicturess.length} TikZ picture${tikzpicturess.length > 1 ? 's' : ''})`,
+              label: `${label} (${tikzpicturess.length} TikZ ${pluralize(tikzpicturess.length, 'picture')})`,
               description: `Figure with label: ${label}`,
               detail: `${tikzpicturess[0].substring(0, 100)}...`, // Show first 100 chars of first TikZ picture
             }),
@@ -180,7 +185,7 @@ async function handleCompileTikzFigures(): Promise<void> {
 
               await showLoggedInfoMessage(
                 CHANNEL,
-                `Successfully compiled ${compiledFiles.length} TikZ figure${compiledFiles.length > 1 ? 's' : ''}`,
+                `Successfully compiled ${compiledFiles.length} TikZ ${pluralize(compiledFiles.length, 'figure')}`,
               );
             } else {
               await showLoggedInfoMessage(

--- a/src/explorer/ExplorerCommands.ts
+++ b/src/explorer/ExplorerCommands.ts
@@ -12,34 +12,19 @@ export class ExplorerCommands {
   ) {}
 
   register() {
+    const commands: Array<[string, (arg: FileItem | vscode.Uri) => unknown]> = [
+      ['newFile', (node) => this.operations.create(node as FileItem, false)],
+      ['newFolder', (node) => this.operations.create(node as FileItem, true)],
+      ['rename', (node) => this.operations.rename(node as FileItem)],
+      ['delete', (node) => this.operations.delete(node as FileItem)],
+      ['openFile', (uri) => this.operations.open(uri as vscode.Uri)],
+      ['addToList', (node) => this.operations.addToList(node as FileItem)],
+      ['revealInOS', (node) => this.operations.reveal((node as FileItem).resourceUri)],
+    ];
+
     this.context.subscriptions.push(
-      vscode.commands.registerCommand(
-        'texra.folderExplorer.newFile',
-        (node: FileItem) => this.operations.create(node, false),
-      ),
-      vscode.commands.registerCommand(
-        'texra.folderExplorer.newFolder',
-        (node: FileItem) => this.operations.create(node, true),
-      ),
-      vscode.commands.registerCommand(
-        'texra.folderExplorer.rename',
-        (node: FileItem) => this.operations.rename(node),
-      ),
-      vscode.commands.registerCommand(
-        'texra.folderExplorer.delete',
-        (node: FileItem) => this.operations.delete(node),
-      ),
-      vscode.commands.registerCommand(
-        'texra.folderExplorer.openFile',
-        (uri: vscode.Uri) => this.operations.open(uri),
-      ),
-      vscode.commands.registerCommand(
-        'texra.folderExplorer.addToList',
-        (node: FileItem) => this.operations.addToList(node),
-      ),
-      vscode.commands.registerCommand(
-        'texra.folderExplorer.revealInOS',
-        (node: FileItem) => this.operations.reveal(node.resourceUri),
+      ...commands.map(([name, handler]) =>
+        vscode.commands.registerCommand(`texra.folderExplorer.${name}`, handler),
       ),
     );
   }

--- a/src/explorer/ExplorerCommands.ts
+++ b/src/explorer/ExplorerCommands.ts
@@ -12,19 +12,23 @@ export class ExplorerCommands {
   ) {}
 
   register() {
-    const commands: Array<[string, (arg: FileItem | vscode.Uri) => unknown]> = [
-      ['newFile', (node) => this.operations.create(node as FileItem, false)],
-      ['newFolder', (node) => this.operations.create(node as FileItem, true)],
-      ['rename', (node) => this.operations.rename(node as FileItem)],
-      ['delete', (node) => this.operations.delete(node as FileItem)],
-      ['openFile', (uri) => this.operations.open(uri as vscode.Uri)],
-      ['addToList', (node) => this.operations.addToList(node as FileItem)],
-      ['revealInOS', (node) => this.operations.reveal((node as FileItem).resourceUri)],
+    // Separate by argument type for type safety
+    const fileItemCommands: Array<[string, (node: FileItem) => unknown]> = [
+      ['newFile', (node) => this.operations.create(node, false)],
+      ['newFolder', (node) => this.operations.create(node, true)],
+      ['rename', (node) => this.operations.rename(node)],
+      ['delete', (node) => this.operations.delete(node)],
+      ['addToList', (node) => this.operations.addToList(node)],
+      ['revealInOS', (node) => this.operations.reveal(node.resourceUri)],
     ];
 
     this.context.subscriptions.push(
-      ...commands.map(([name, handler]) =>
+      ...fileItemCommands.map(([name, handler]) =>
         vscode.commands.registerCommand(`texra.folderExplorer.${name}`, handler),
+      ),
+      vscode.commands.registerCommand(
+        'texra.folderExplorer.openFile',
+        (uri: vscode.Uri) => this.operations.open(uri),
       ),
     );
   }

--- a/src/explorer/WatcherManager.ts
+++ b/src/explorer/WatcherManager.ts
@@ -100,11 +100,9 @@ export class WatcherManager {
         watcher.onDidDelete(this.triggerRefresh);
 
         if (isCustomPath(watchPath)) {
-          watcher.onDidChange(async (uri) => {
+          watcher.onDidChange((uri) => {
             this.triggerRefresh();
-            if (path.extname(uri.fsPath).toLowerCase() === '.yaml') {
-              await validateYamlAndPromptAdd(uri.fsPath);
-            }
+            scheduleYamlValidation(uri);
           });
         } else {
           watcher.onDidChange(this.triggerRefresh);

--- a/src/explorer/WatcherManager.ts
+++ b/src/explorer/WatcherManager.ts
@@ -60,6 +60,27 @@ export class WatcherManager {
         pathsToWatch.push(customAgentsPath);
       }
 
+      const isCustomPath = (watchPath: string): boolean =>
+        path.resolve(watchPath) === path.resolve(customAgentsPath ?? '');
+
+      const scheduleYamlValidation = (uri: vscode.Uri) => {
+        if (path.extname(uri.fsPath).toLowerCase() !== '.yaml') {
+          return;
+        }
+        const handle = setTimeout(async () => {
+          try {
+            await validateYamlAndPromptAdd(uri.fsPath);
+          } catch (error) {
+            logger.error(CHANNEL, `Error validating YAML: ${error}`);
+          } finally {
+            this.validationHandles = this.validationHandles.filter(
+              (h) => h !== handle,
+            );
+          }
+        }, WatcherManager.VALIDATION_DELAY);
+        this.validationHandles.push(handle);
+      };
+
       for (const watchPath of pathsToWatch) {
         if (!watchPath) continue;
 
@@ -74,27 +95,11 @@ export class WatcherManager {
 
         watcher.onDidCreate((uri) => {
           this.triggerRefresh();
-          if (path.extname(uri.fsPath).toLowerCase() === '.yaml') {
-            const handle = setTimeout(async () => {
-              try {
-                await validateYamlAndPromptAdd(uri.fsPath);
-              } catch (error) {
-                logger.error(CHANNEL, `Error validating YAML: ${error}`);
-              } finally {
-                this.validationHandles = this.validationHandles.filter(
-                  (h) => h !== handle,
-                );
-              }
-            }, WatcherManager.VALIDATION_DELAY);
-
-            this.validationHandles.push(handle);
-          }
+          scheduleYamlValidation(uri);
         });
-        // triggerRefresh can be passed directly because it's a debounced closure
-        // that already captures `this` in its constructor initialization
         watcher.onDidDelete(this.triggerRefresh);
 
-        if (path.resolve(watchPath) === path.resolve(customAgentsPath ?? '')) {
+        if (isCustomPath(watchPath)) {
           watcher.onDidChange(async (uri) => {
             this.triggerRefresh();
             if (path.extname(uri.fsPath).toLowerCase() === '.yaml') {

--- a/src/frontend/ui/diffView.ts
+++ b/src/frontend/ui/diffView.ts
@@ -32,13 +32,6 @@ function refreshDiff() {
   logger.debug(CHANNEL, 'Refreshed diff view');
 }
 
-// Note: Configuration change listener removed as editor.action.toggleWordWrap
-// command doesn't update the configuration that can be read via Configuration API
-
-function onViewColumnChange() {
-  refreshDiff();
-}
-
 export function registerDiffRefresh(
   left: vscode.Uri,
   right: vscode.Uri,
@@ -49,7 +42,7 @@ export function registerDiffRefresh(
   disposables = [];
 
   disposables.push(
-    vscode.window.onDidChangeTextEditorViewColumn(onViewColumnChange),
+    vscode.window.onDidChangeTextEditorViewColumn(refreshDiff),
   );
   logger.debug(CHANNEL, 'Registered diff refresh listeners');
 }

--- a/src/housekeeping/pack.ts
+++ b/src/housekeeping/pack.ts
@@ -88,16 +88,14 @@ export async function runPackSingle(
 
   let result: FileOpResult;
   if (movedFiles.length > 0 || copiedFiles.length > 0) {
-    logger.debug(
-      CHANNEL,
-      'Found files to process:' +
-        (movedFiles.length > 0
-          ? `\nFiles to move:\n${movedFiles.join('\n')}`
-          : '') +
-        (copiedFiles.length > 0
-          ? `\nFiles to copy:\n${copiedFiles.join('\n')}`
-          : ''),
-    );
+    const logParts = ['Found files to process:'];
+    if (movedFiles.length > 0) {
+      logParts.push(`Files to move:\n${movedFiles.join('\n')}`);
+    }
+    if (copiedFiles.length > 0) {
+      logParts.push(`Files to copy:\n${copiedFiles.join('\n')}`);
+    }
+    logger.debug(CHANNEL, logParts.join('\n'));
 
     const now = new Date().toISOString().replaceAll(/[-:]/g, '').split('.')[0];
     outputFolder =

--- a/src/latex/extractFigure.ts
+++ b/src/latex/extractFigure.ts
@@ -83,38 +83,40 @@ export async function extractFigurePathsFromLatex(
     // Find all matches in the processed content for both patterns
     const discovered = new Set<string>();
 
+    // Helper to find the first existing file path
+    async function findExistingPath(
+      figPath: string,
+      basePaths: string[],
+    ): Promise<string | null> {
+      const extensions = figPath.includes('.')
+        ? ['']
+        : ['.pdf', '.png', '.jpg', '.jpeg'];
+
+      for (const basePath of basePaths) {
+        const normPath = path.normalize(path.join(basePath, figPath));
+        for (const ext of extensions) {
+          const pathToCheck = normPath + ext;
+          if (
+            await flexibleFS.exists({
+              kind: 'external',
+              absolutePath: pathToCheck,
+            })
+          ) {
+            return pathToCheck;
+          }
+        }
+      }
+      return null;
+    }
+
     for (const pattern of figurePatterns) {
       for (const match of processedLines.matchAll(pattern)) {
-        const figPath = match[1];
-        let found = false;
-        for (const basePath of graphicspaths) {
-          const normPath = path.normalize(path.join(basePath, figPath));
-          // Try with common extensions if no extension is provided
-          const extensions = figPath.includes('.')
-            ? ['']
-            : ['.pdf', '.png', '.jpg', '.jpeg'];
-
-          for (const ext of extensions) {
-            const pathToCheck = normPath + ext;
-
-            if (
-              await flexibleFS.exists({
-                kind: 'external',
-                absolutePath: pathToCheck,
-              })
-            ) {
-              const relative = path.relative(latexDir, pathToCheck);
-              if (!discovered.has(relative)) {
-                figurePaths.push(relative);
-                discovered.add(relative);
-              }
-              found = true;
-              break;
-            }
-          }
-
-          if (found) {
-            break;
+        const existingPath = await findExistingPath(match[1], graphicspaths);
+        if (existingPath) {
+          const relative = path.relative(latexDir, existingPath);
+          if (!discovered.has(relative)) {
+            figurePaths.push(relative);
+            discovered.add(relative);
           }
         }
       }

--- a/src/latex/texFormatter.ts
+++ b/src/latex/texFormatter.ts
@@ -7,11 +7,13 @@ import { runTexFmt } from './formatter/texfmt';
 
 export async function runLatexFormatter(filePath: string): Promise<boolean> {
   const formatter = getConfig<string>('texra.latex.formatter', 'latexindent');
-  if (formatter === 'none') {
-    return true;
+
+  switch (formatter) {
+    case 'none':
+      return true;
+    case 'tex-fmt':
+      return runTexFmt(filePath);
+    default:
+      return runLatexIndent(filePath);
   }
-  if (formatter === 'tex-fmt') {
-    return runTexFmt(filePath);
-  }
-  return runLatexIndent(filePath);
 }


### PR DESCRIPTION
- ExplorerCommands: convert repetitive command registration to data-driven loop
- diffView: remove trivial onViewColumnChange wrapper function
- texFormatter: convert if-if-return chain to switch statement
- extractFigure: extract findExistingPath helper to reduce nested loops
- MainViewProvider: simplify async command registration with early return
- pack: replace nested ternaries with array-based log message building
- arXivCommands: consolidate duplicate error handling branches
- executeCommand: simplify config unwrapping with nullish coalescing
- WatcherManager: extract isCustomPath and scheduleYamlValidation helpers
- figCommands: add pluralize helper for consistent pluralization

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Broad refactors for clarity and maintainability with minimal behavior changes.
> 
> - Simplifies command registration (e.g., `MainViewProvider`, `ExplorerCommands`) with early-return and data-driven mapping
> - Consolidates error handling in `arXivCommands` and simplifies config parsing in `executeCommand`
> - Extracts helpers in `WatcherManager` (`isCustomPath`, `scheduleYamlValidation`) and `extractFigure` (`findExistingPath`) to reduce nesting
> - Unifies pluralization in `figCommands` and converts formatter selection to a `switch` in `texFormatter`
> - Tweaks diff refresh to call `refreshDiff` directly and restructures pack logging for readability
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 84e7f70b684b4463863d0ed6fcb362c019784f01. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->