### PR TITLE
refactor: simplify usage statistics chain and surface areas

### DIFF
--- a/src/agent/core/RunUsageAccumulator.ts
+++ b/src/agent/core/RunUsageAccumulator.ts
@@ -99,7 +99,6 @@ export class RunUsageAccumulator {
 
   recordNormalizedUsage(round: number, usage: NormalizedUsage): void {
     if (this.totals.firstInputTokens === 0) {
-      // inputTokens already includes cached tokens (total context measurement)
       this.totals.firstInputTokens = usage.inputTokens;
     }
 
@@ -116,22 +115,20 @@ export class RunUsageAccumulator {
   }
 
   merge(other: RunUsageAccumulator): void {
-    const otherTotals = other.totals;
+    const src = other.totals;
     if (this.totals.firstInputTokens === 0) {
-      this.totals.firstInputTokens = otherTotals.firstInputTokens;
+      this.totals.firstInputTokens = src.firstInputTokens;
     }
 
-    this.totals.totalInputTokens += otherTotals.totalInputTokens;
-    this.totals.totalOutputTokens += otherTotals.totalOutputTokens;
-    this.totals.totalCost += otherTotals.totalCost;
-    this.totals.totalCacheReadInputTokens +=
-      otherTotals.totalCacheReadInputTokens;
+    this.totals.totalInputTokens += src.totalInputTokens;
+    this.totals.totalOutputTokens += src.totalOutputTokens;
+    this.totals.totalCost += src.totalCost;
+    this.totals.totalCacheReadInputTokens += src.totalCacheReadInputTokens;
     this.totals.totalCacheCreationInputTokens +=
-      otherTotals.totalCacheCreationInputTokens;
-    this.totals.totalReasoningTokens += otherTotals.totalReasoningTokens;
-    this.totals.totalToolUsePromptTokens +=
-      otherTotals.totalToolUsePromptTokens;
-    this.totals.totalServerToolRequests += otherTotals.totalServerToolRequests;
+      src.totalCacheCreationInputTokens;
+    this.totals.totalReasoningTokens += src.totalReasoningTokens;
+    this.totals.totalToolUsePromptTokens += src.totalToolUsePromptTokens;
+    this.totals.totalServerToolRequests += src.totalServerToolRequests;
 
     this.normalizedSnapshots.push(...other.normalizedSnapshots);
   }

--- a/src/agent/core/flows/CycleServices.ts
+++ b/src/agent/core/flows/CycleServices.ts
@@ -85,4 +85,3 @@ export type ResponseCycleParams<C = unknown> = CycleParams<
 export type ToolUseCycleParams<C = unknown> = CycleParams<
   ToolUseCycleServices<C>
 >;
-

--- a/src/agent/core/flows/RetryState.ts
+++ b/src/agent/core/flows/RetryState.ts
@@ -29,7 +29,6 @@ import {
   getModelRetryMaxAttempts,
 } from '@utils/config';
 
-
 /**
  * Minimum retry count for background mode (at least 3 attempts before manual retry UI).
  * Background jobs may fail due to timeouts and need more automatic recovery attempts.

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -47,17 +47,17 @@ import { formatContent } from '@utils/text/xmlUtils';
 
 // Local file imports
 import { FlowTransition } from './FlowTransitions';
-import type {
-  ToolUseCycleOptions,
-  ToolUseCycleServices,
-  ToolUseCycleParams,
-} from './CycleServices';
 import {
   type InvocationResult,
   type RetryState,
   RetryableInvocationNode,
   handleInvocationResult,
 } from './RetryState';
+import type {
+  ToolUseCycleOptions,
+  ToolUseCycleServices,
+  ToolUseCycleParams,
+} from './CycleServices';
 
 /** Parse tool input, handling JSON strings and other formats from model providers. */
 function parseToolInput(

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -184,16 +184,14 @@ const extractTextFromContent = (
   content: BetaContentBlock[] | undefined,
   trim = false,
 ): string => {
-  if (!Array.isArray(content)) {
-    return '';
-  }
-  let text = '';
-  for (const block of content) {
-    if (block.type === 'text') {
-      text += trim ? block.text.trim() : block.text;
-    }
-  }
-  return text;
+  if (!content) return '';
+  return content
+    .filter(
+      (block): block is Extract<BetaContentBlock, { type: 'text' }> =>
+        block.type === 'text',
+    )
+    .map((block) => (trim ? block.text.trim() : block.text))
+    .join('');
 };
 
 /**

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -73,6 +73,10 @@ import { flexibleFS } from '@utils/files';
 import { isNonEmptyString } from '@utils/core';
 import { objectToLogString } from '@utils/text/stringUtils';
 import { extractScratchpad } from '@utils/text/xmlUtils';
+import {
+  computeCachePercentage,
+  nonZeroOrUndefined,
+} from './utils/usageNormalization';
 
 // Local file imports
 import {
@@ -1466,33 +1470,27 @@ export class ModelHandlerAnthropic extends ModelHandler<
       };
     }
 
-    // Anthropic SDK docs: "Total input tokens in a request is the summation
-    // of `input_tokens`, `cache_creation_input_tokens`, and `cache_read_input_tokens`."
-    const baseInputTokens = rawUsage.input_tokens ?? 0;
-    const outputTokens = rawUsage.output_tokens ?? 0;
-    const cacheReadTokens = rawUsage.cache_read_input_tokens ?? 0;
-    const cacheCreationTokens = rawUsage.cache_creation_input_tokens ?? 0;
-
-    // Total input tokens for context measurement (includes all cached tokens)
-    const totalInputTokens =
-      baseInputTokens + cacheReadTokens + cacheCreationTokens;
-
-    // Calculate percentage cached (relative to total)
-    const totalCacheTokens = cacheReadTokens + cacheCreationTokens;
-    const percentageCached =
-      totalInputTokens > 0 ? (totalCacheTokens / totalInputTokens) * 100 : 0;
+    // Anthropic: total = input_tokens + cache_read + cache_creation
+    const baseInput = rawUsage.input_tokens ?? 0;
+    const cacheRead = rawUsage.cache_read_input_tokens ?? 0;
+    const cacheCreation = rawUsage.cache_creation_input_tokens ?? 0;
+    const totalInput = baseInput + cacheRead + cacheCreation;
 
     return {
-      inputTokens: totalInputTokens,
-      outputTokens,
+      inputTokens: totalInput,
+      outputTokens: rawUsage.output_tokens ?? 0,
       cost: this.computePrice(rawUsage),
       responseTimeMs,
       provider: 'anthropic',
-      cachedInputTokens: cacheReadTokens || undefined,
-      cacheCreationTokens: cacheCreationTokens || undefined,
-      percentageCached: percentageCached > 0 ? percentageCached : undefined,
-      serverToolRequests:
-        rawUsage.server_tool_use?.web_search_requests || undefined,
+      cachedInputTokens: nonZeroOrUndefined(cacheRead),
+      cacheCreationTokens: nonZeroOrUndefined(cacheCreation),
+      percentageCached: computeCachePercentage(
+        cacheRead + cacheCreation,
+        totalInput,
+      ),
+      serverToolRequests: nonZeroOrUndefined(
+        rawUsage.server_tool_use?.web_search_requests,
+      ),
       _native: rawUsage,
     };
   }

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -64,6 +64,10 @@ import { K_SLICE } from '@utils/config';
 import { isNonEmptyString } from '@utils/core';
 import { flexibleFS, getShortDisplayPath } from '@utils/files';
 import { extractScratchpad } from '@utils/text/xmlUtils';
+import {
+  computeCachePercentage,
+  nonZeroOrUndefined,
+} from './utils/usageNormalization';
 
 // Local file imports
 import {
@@ -918,10 +922,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
 
     const { inputTokens, outputTokens, reasoningTokens } =
       this.computeTokenCounts(rawUsage);
-
     const cachedTokens = rawUsage.cachedContentTokenCount ?? 0;
-    const percentageCached =
-      inputTokens > 0 ? (cachedTokens / inputTokens) * 100 : 0;
 
     return {
       inputTokens,
@@ -929,10 +930,10 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
       cost: this.computePrice(rawUsage),
       responseTimeMs,
       provider: 'google',
-      cachedInputTokens: cachedTokens || undefined,
-      percentageCached: percentageCached > 0 ? percentageCached : undefined,
-      reasoningTokens: reasoningTokens || undefined,
-      toolUsePromptTokens: rawUsage.toolUsePromptTokenCount || undefined,
+      cachedInputTokens: nonZeroOrUndefined(cachedTokens),
+      percentageCached: computeCachePercentage(cachedTokens, inputTokens),
+      reasoningTokens: nonZeroOrUndefined(reasoningTokens),
+      toolUsePromptTokens: nonZeroOrUndefined(rawUsage.toolUsePromptTokenCount),
       _native: rawUsage,
     };
   }

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -49,6 +49,10 @@ import { K_SLICE, MESSAGE_PREVIEW_LENGTH } from '@utils/config';
 import { flexibleFS } from '@utils/files';
 import { objectToLogString } from '@utils/text/stringUtils';
 import { extractScratchpad } from '@utils/text/xmlUtils';
+import {
+  computeCachePercentage,
+  nonZeroOrUndefined,
+} from './utils/usageNormalization';
 
 // Local file imports
 import { OPENAI_CHAT_FINISH } from './types/StopReasonTypes';
@@ -981,31 +985,23 @@ export class ModelHandlerOpenAI<
     }
 
     const inputTokens = rawUsage.prompt_tokens ?? 0;
-    const outputTokens = rawUsage.completion_tokens ?? 0;
-
-    // Extract cached tokens (OpenAI style or DeepSeek style)
+    // OpenAI: prompt_tokens_details.cached_tokens; DeepSeek: prompt_cache_hit_tokens
     const cachedTokens =
       rawUsage.prompt_tokens_details?.cached_tokens ??
-      rawUsage.prompt_cache_hit_tokens ?? // DeepSeek
+      rawUsage.prompt_cache_hit_tokens ??
       0;
-
-    // Extract reasoning tokens
-    const reasoningTokens =
-      rawUsage.completion_tokens_details?.reasoning_tokens ?? 0;
-
-    // Calculate percentage cached
-    const percentageCached =
-      inputTokens > 0 ? (cachedTokens / inputTokens) * 100 : 0;
 
     return {
       inputTokens,
-      outputTokens,
+      outputTokens: rawUsage.completion_tokens ?? 0,
       cost: this.computePrice(rawUsage),
       responseTimeMs,
       provider: this.usageProvider,
-      cachedInputTokens: cachedTokens || undefined,
-      percentageCached: percentageCached > 0 ? percentageCached : undefined,
-      reasoningTokens: reasoningTokens || undefined,
+      cachedInputTokens: nonZeroOrUndefined(cachedTokens),
+      percentageCached: computeCachePercentage(cachedTokens, inputTokens),
+      reasoningTokens: nonZeroOrUndefined(
+        rawUsage.completion_tokens_details?.reasoning_tokens,
+      ),
       _native: rawUsage,
     };
   }

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -37,6 +37,10 @@ import { sleepWithAbort } from '@utils/core';
 import { flexibleFS } from '@utils/files';
 import { isNonEmptyString } from '@utils/core';
 import { extractScratchpad } from '@utils/text/xmlUtils';
+import {
+  computeCachePercentage,
+  nonZeroOrUndefined,
+} from './utils/usageNormalization';
 
 // Local file imports
 import {
@@ -1109,24 +1113,19 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     }
 
     const inputTokens = rawUsage.input_tokens ?? 0;
-    const outputTokens = rawUsage.output_tokens ?? 0;
     const cachedTokens = rawUsage.input_tokens_details?.cached_tokens ?? 0;
-    const reasoningTokens =
-      rawUsage.output_tokens_details?.reasoning_tokens ?? 0;
-
-    // Calculate percentage cached
-    const percentageCached =
-      inputTokens > 0 ? (cachedTokens / inputTokens) * 100 : 0;
 
     return {
       inputTokens,
-      outputTokens,
+      outputTokens: rawUsage.output_tokens ?? 0,
       cost: this.computePrice(rawUsage),
       responseTimeMs,
       provider: 'openai-response',
-      cachedInputTokens: cachedTokens || undefined,
-      percentageCached: percentageCached > 0 ? percentageCached : undefined,
-      reasoningTokens: reasoningTokens || undefined,
+      cachedInputTokens: nonZeroOrUndefined(cachedTokens),
+      percentageCached: computeCachePercentage(cachedTokens, inputTokens),
+      reasoningTokens: nonZeroOrUndefined(
+        rawUsage.output_tokens_details?.reasoning_tokens,
+      ),
       _native: rawUsage,
     };
   }

--- a/src/agent/modelHandlers/utils/usageNormalization.ts
+++ b/src/agent/modelHandlers/utils/usageNormalization.ts
@@ -1,0 +1,36 @@
+/**
+ * Shared utilities for normalizing usage statistics across model handlers.
+ *
+ * These helpers ensure consistent behavior across all providers while
+ * respecting provider-specific token naming conventions (see handler
+ * implementations for details on each provider's native format).
+ */
+
+/**
+ * Calculate cache percentage from cached and total input tokens.
+ * Returns undefined if no caching occurred (to avoid storing 0 values).
+ *
+ * @param cachedTokens - Number of tokens served from cache
+ * @param totalInputTokens - Total input tokens (must be > 0)
+ * @returns Percentage cached (0-100), or undefined if no caching
+ */
+export function computeCachePercentage(
+  cachedTokens: number,
+  totalInputTokens: number,
+): number | undefined {
+  if (totalInputTokens <= 0 || cachedTokens <= 0) return undefined;
+  return (cachedTokens / totalInputTokens) * 100;
+}
+
+/**
+ * Convert a numeric value to undefined if zero/falsy.
+ * Used to avoid storing 0 values in optional fields.
+ *
+ * @param value - Numeric value to convert
+ * @returns The value if truthy, undefined otherwise
+ */
+export function nonZeroOrUndefined(
+  value: number | undefined,
+): number | undefined {
+  return value || undefined;
+}

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -494,15 +494,15 @@ function showAgentNotification(config: AgentConfig): void {
     ? path.basename(config.inputFile)
     : 'selected input';
 
-  const outputCount = config.outputFiles?.length ?? 0;
-  const outputInfo =
-    config.useMultipleOutputs && outputCount > 1
-      ? `to ${outputCount} files`
-      : config.outputFiles?.[0]
-        ? `to ${path.basename(config.outputFiles[0])}`
-        : '';
+  const outputFiles = config.outputFiles ?? [];
+  let outputInfo = '';
+  if (config.useMultipleOutputs && outputFiles.length > 1) {
+    outputInfo = `to ${outputFiles.length} files`;
+  } else if (outputFiles[0]) {
+    outputInfo = `to ${path.basename(outputFiles[0])}`;
+  }
 
-  vscode.window
+  void vscode.window
     .showInformationMessage(
       `TeXRA Agent Started: "${config.agent}" is processing ${inputName} with ${config.model} ${outputInfo}. View in ProgressBoard for progress.`,
       {
@@ -512,7 +512,7 @@ function showAgentNotification(config: AgentConfig): void {
       },
       'Show ProgressBoard',
     )
-    .then((sel: string | undefined) => {
+    .then((sel) => {
       if (sel) void vscode.commands.executeCommand('texra.showProgressView');
     });
 }

--- a/src/agent/utils/UsageMonitor.ts
+++ b/src/agent/utils/UsageMonitor.ts
@@ -196,37 +196,10 @@ export class UsageMonitor {
   ): void {
     try {
       const { config } = this.modelInfo;
-
-      // Validate provider against schema, fallback to 'unknown' if invalid
-      const providerLower = config.provider.toLowerCase();
-      const provider =
-        UsageProviderSchema.catch('unknown').parse(providerLower);
-
-      // Check if server-side keys (relay) were used for this request
-      const usedRelay = getServerSideKeyService().shouldUseServerSideKeysSync(
-        config.provider,
-        config.name,
+      const provider = UsageProviderSchema.catch('unknown').parse(
+        config.provider.toLowerCase(),
       );
-
-      // Relay billing should only reflect the current round's net tokens and cost
-      // rather than cumulative history. Downstream dashboards should treat each
-      // entry as a single round; if cumulative views are needed, aggregate by
-      // streamId/task.
-      const roundInputTokens = usage.inputTokens;
-      const roundOutputTokens = usage.outputTokens;
-      const roundCachedInputTokens = usage.cachedInputTokens ?? 0;
-      const roundCacheCreationTokens = usage.cacheCreationInputTokens ?? 0;
-      const roundReasoningTokens = usage.reasoningTokens ?? 0;
-      const roundCost = usage.cost;
-
-      const netInputTokens = Math.max(
-        0,
-        roundInputTokens - roundCachedInputTokens,
-      );
-
-      // roundCost already includes any cache discounts from the provider;
-      // avoid double-subtracting cached tokens here.
-      const relayCost = roundCost;
+      const cachedInputTokens = usage.cachedInputTokens ?? 0;
 
       UsageLogService.log({
         model: config.fullName,
@@ -234,18 +207,20 @@ export class UsageMonitor {
         agentName: this.metadata?.agentName,
         agentCategory: this.metadata?.agentCategory,
         isMultipleOutput: this.metadata?.isMultipleOutput,
-        inputTokens: netInputTokens,
-        outputTokens: roundOutputTokens,
-        cost: Number(relayCost.toFixed(6)),
+        inputTokens: Math.max(0, usage.inputTokens - cachedInputTokens),
+        outputTokens: usage.outputTokens,
+        cost: Number(usage.cost.toFixed(6)),
         responseTimeMs: Math.round(totalResponseTimeMs),
-        cachedInputTokens: roundCachedInputTokens,
-        cacheCreationInputTokens: roundCacheCreationTokens,
-        reasoningTokens: roundReasoningTokens,
-        usedRelay,
+        cachedInputTokens,
+        cacheCreationInputTokens: usage.cacheCreationInputTokens ?? 0,
+        reasoningTokens: usage.reasoningTokens ?? 0,
+        usedRelay: getServerSideKeyService().shouldUseServerSideKeysSync(
+          config.provider,
+          config.name,
+        ),
         streamId: this.context.streamId,
       });
     } catch (error) {
-      // Silently ignore backend logging errors - this should never block the main flow
       this.context.logger.debug(`Backend usage logging failed: ${error}`);
     }
   }

--- a/src/agent/utils/mergeFileUtils.ts
+++ b/src/agent/utils/mergeFileUtils.ts
@@ -6,7 +6,10 @@
 /**
  * Helper to extract the last match of a pattern from text.
  */
-function extractLastMatch(text: string, pattern: RegExp): RegExpMatchArray | null {
+function extractLastMatch(
+  text: string,
+  pattern: RegExp,
+): RegExpMatchArray | null {
   return [...text.matchAll(pattern)].at(-1) ?? null;
 }
 
@@ -21,7 +24,9 @@ function extractLastMatch(text: string, pattern: RegExp): RegExpMatchArray | nul
  * extractLastRoundMatch('main_enhance_r1_gpt52_criticize_r0_gpt52.tex')
  * // Returns match for '_r0_' (the last occurrence), not '_r1_'
  */
-export function extractLastRoundMatch(filename: string): RegExpMatchArray | null {
+export function extractLastRoundMatch(
+  filename: string,
+): RegExpMatchArray | null {
   return extractLastMatch(filename, /_r(\d+)_/g);
 }
 

--- a/src/agent/utils/userVars.ts
+++ b/src/agent/utils/userVars.ts
@@ -106,7 +106,7 @@ function combineFiles(
   single: string | undefined,
   multiple: string[],
 ): string[] {
-  return [single, ...multiple].filter(Boolean) as string[];
+  return [single, ...multiple].filter((f): f is string => Boolean(f));
 }
 
 async function getFileVars(
@@ -158,16 +158,13 @@ async function getFileVars(
       : null;
   }
 
+  const filterStrings = (arr: string[]): string[] =>
+    arr.filter((s): s is string => Boolean(s));
+
   const collectionMappings: Record<string, [string[], string[]]> = {
-    INPUT: [agentConfig.inputFiles.filter(Boolean) as string[], allInputFiles],
-    REFERENCE: [
-      agentConfig.referenceFiles.filter(Boolean) as string[],
-      allReferenceFiles,
-    ],
-    AUXILIARY: [
-      agentConfig.auxiliaryFiles.filter(Boolean) as string[],
-      allAuxiliaryFiles,
-    ],
+    INPUT: [filterStrings(agentConfig.inputFiles), allInputFiles],
+    REFERENCE: [filterStrings(agentConfig.referenceFiles), allReferenceFiles],
+    AUXILIARY: [filterStrings(agentConfig.auxiliaryFiles), allAuxiliaryFiles],
   };
 
   for (const [prefix, [additionalFiles, allFiles]] of Object.entries(

--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -123,11 +123,9 @@ const SDK_ERRORS: SdkErrorEntry[] = [
   ...createErrorPair(OpenAIBadRequestError, AnthropicBadRequestError, {
     fallbackStatusCode: StatusCodes.BAD_REQUEST,
   }),
-  ...createErrorPair(
-    OpenAIAuthenticationError,
-    AnthropicAuthenticationError,
-    { fallbackStatusCode: StatusCodes.UNAUTHORIZED },
-  ),
+  ...createErrorPair(OpenAIAuthenticationError, AnthropicAuthenticationError, {
+    fallbackStatusCode: StatusCodes.UNAUTHORIZED,
+  }),
   ...createErrorPair(
     OpenAIPermissionDeniedError,
     AnthropicPermissionDeniedError,
@@ -147,11 +145,9 @@ const SDK_ERRORS: SdkErrorEntry[] = [
   ...createErrorPair(OpenAIRateLimitError, AnthropicRateLimitError, {
     fallbackStatusCode: StatusCodes.TOO_MANY_REQUESTS,
   }),
-  ...createErrorPair(
-    OpenAIInternalServerError,
-    AnthropicInternalServerError,
-    { fallbackStatusCode: StatusCodes.INTERNAL_SERVER_ERROR },
-  ),
+  ...createErrorPair(OpenAIInternalServerError, AnthropicInternalServerError, {
+    fallbackStatusCode: StatusCodes.INTERNAL_SERVER_ERROR,
+  }),
   // Generic API errors (no fallback)
   { ctor: OpenAIAPIError },
   { ctor: AnthropicAPIError },

--- a/src/explorer/ExplorerCommands.ts
+++ b/src/explorer/ExplorerCommands.ts
@@ -24,7 +24,10 @@ export class ExplorerCommands {
 
     this.context.subscriptions.push(
       ...fileItemCommands.map(([name, handler]) =>
-        vscode.commands.registerCommand(`texra.folderExplorer.${name}`, handler),
+        vscode.commands.registerCommand(
+          `texra.folderExplorer.${name}`,
+          handler,
+        ),
       ),
       vscode.commands.registerCommand(
         'texra.folderExplorer.openFile',

--- a/src/frontend/ui/diffView.ts
+++ b/src/frontend/ui/diffView.ts
@@ -41,9 +41,7 @@ export function registerDiffRefresh(
   disposables.forEach((d) => d.dispose());
   disposables = [];
 
-  disposables.push(
-    vscode.window.onDidChangeTextEditorViewColumn(refreshDiff),
-  );
+  disposables.push(vscode.window.onDidChangeTextEditorViewColumn(refreshDiff));
   logger.debug(CHANNEL, 'Registered diff refresh listeners');
 }
 

--- a/src/latex/latexdiff.ts
+++ b/src/latex/latexdiff.ts
@@ -327,7 +327,9 @@ export class LaTeXdiffService {
       }
 
       const firstRoundMatch = extractLastRoundMatch(firstLocation.absolutePath);
-      const secondRoundMatch = extractLastRoundMatch(secondLocation.absolutePath);
+      const secondRoundMatch = extractLastRoundMatch(
+        secondLocation.absolutePath,
+      );
 
       if (!firstRoundMatch || !secondRoundMatch) {
         const message = 'Could not extract round numbers from file names';

--- a/src/latex/latexdiff.ts
+++ b/src/latex/latexdiff.ts
@@ -5,6 +5,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 
 // Local imports - log
+import { extractLastRoundMatch } from '@agent/utils/mergeFileUtils';
 import { formatError, toErrorMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
 import { MESSAGE_TYPES } from '@logger/messageTypes';
@@ -16,7 +17,6 @@ import { runLatexFormatter } from './texFormatter';
 import { DiffFileNameManager } from './latexdiff/diffFileNameManager';
 import { DiffFileProcessor } from './latexdiff/diffFileProcessor';
 import { DiffCommandExecutor } from './latexdiff/diffCommandExecutor';
-import { extractLastRoundMatch } from '@agent/utils/mergeFileUtils';
 
 // Type imports
 import type { MathMarkupOption } from './latexdiff/mathMarkup';

--- a/src/latex/latexdiff/diffFileNameManager.ts
+++ b/src/latex/latexdiff/diffFileNameManager.ts
@@ -11,11 +11,14 @@ function extractBaseName(filename: string, includeRound: boolean): string {
   const name = path.parse(filename).name;
   const lastMatch = extractLastRoundMatch(name);
   if (!lastMatch || lastMatch.index === undefined) {
-    throw new Error(`Failed to extract base name from edited file: ${filename}`);
+    throw new Error(
+      `Failed to extract base name from edited file: ${filename}`,
+    );
   }
   // Return everything up to (or including) the last _rN
   // The -1 excludes the trailing underscore from _rN_ when includeRound is true
-  const endIndex = lastMatch.index + (includeRound ? lastMatch[0].length - 1 : 0);
+  const endIndex =
+    lastMatch.index + (includeRound ? lastMatch[0].length - 1 : 0);
   return name.slice(0, endIndex);
 }
 
@@ -26,7 +29,9 @@ export class DiffFileNameManager {
     suffix: string,
   ): string {
     const editedFileName = path.basename(editedFile);
-    const inputRoundMatch = extractLastRoundModelMatch(path.basename(inputFile));
+    const inputRoundMatch = extractLastRoundModelMatch(
+      path.basename(inputFile),
+    );
     const editedRoundMatch = extractLastRoundModelMatch(editedFileName);
 
     if (inputRoundMatch && editedRoundMatch) {

--- a/src/logger/AgentUsageReporter.ts
+++ b/src/logger/AgentUsageReporter.ts
@@ -38,7 +38,6 @@ export class AgentUsageReporter {
    * @param storageKey - THE key for storage (from context.storageKey) - REQUIRED
    */
   public report(stats: ExtendedTokenUsageStats, storageKey: StorageKey): void {
-    // storageKey is THE single source of truth - no fallbacks, no round-trips
     bus.emit('updateStreamUsage', {
       stream: this.streamId,
       storageKey,
@@ -46,16 +45,11 @@ export class AgentUsageReporter {
         inputTokens: stats.inputTokens,
         outputTokens: stats.outputTokens,
         cost: stats.cost,
-        ...(stats.cacheReadInputTokens && {
-          cacheReadInputTokens: stats.cacheReadInputTokens,
-        }),
-        ...(stats.cacheCreationInputTokens && {
-          cacheCreationInputTokens: stats.cacheCreationInputTokens,
-        }),
+        cacheReadInputTokens: stats.cacheReadInputTokens,
+        cacheCreationInputTokens: stats.cacheCreationInputTokens,
       },
     });
 
-    // Log detailed statistics for workflow agents
     if (this.agentCategory === AgentCategory.Workflow) {
       this.logger.statistics(stats, storageKey);
     }

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -498,13 +498,11 @@ export class ProgressEventHandler {
     });
   };
 
-  /** Convert Map<number, T[]> to Record<number, T[]> for webview (from OutputEvents.ts) */
+  /** Convert Map<number, T[]> to Record<number, T[]> for webview */
   private toRoundRecord<T>(
     rounds?: Map<number, T[]>,
   ): Record<number, T[]> | undefined {
-    return rounds && rounds.size > 0
-      ? Object.fromEntries(rounds.entries())
-      : undefined;
+    return rounds?.size ? Object.fromEntries(rounds) : undefined;
   }
 
   // ============================================================================

--- a/src/progressView/managers/OutputFilesManager.ts
+++ b/src/progressView/managers/OutputFilesManager.ts
@@ -173,8 +173,7 @@ export class OutputFilesManager extends PersistentMapManager<
 
   /** Get output files for a stream */
   getFiles(stream: StreamTabId): Map<string, Map<number, OutputFileInfo[]>> {
-    const runs = this.items.get(stream);
-    return runs ? new Map(runs) : new Map();
+    return new Map(this.items.get(stream) ?? []);
   }
 
   getRun(
@@ -301,7 +300,7 @@ export class OutputFilesManager extends PersistentMapManager<
       {},
     );
 
-    if (saved && Object.keys(saved).length > 0) {
+    if (Object.keys(saved).length > 0) {
       this._missingOutputs = this.deserializeMissingOutputs(saved);
       return;
     }
@@ -365,7 +364,7 @@ export class OutputFilesManager extends PersistentMapManager<
       [key: string]: { [key: number]: string[] };
     }>(legacyKey, {});
 
-    if (!legacy || Object.keys(legacy).length === 0) {
+    if (Object.keys(legacy).length === 0) {
       return false;
     }
 

--- a/src/progressView/managers/UsageStatsManager.ts
+++ b/src/progressView/managers/UsageStatsManager.ts
@@ -245,13 +245,9 @@ export class UsageStatsManager extends PersistentMapManager<
    * Calculate total usage across all streams
    */
   getTotalUsage(): TokenUsageStats {
-    // Flatten all run usage maps into a single iterable
-    const allUsage = (function* (items: Map<StreamTabId, RunUsageMap>) {
-      for (const runMap of items.values()) {
-        yield* runMap.values();
-      }
-    })(this.items);
-
+    const allUsage = [...this.items.values()].flatMap((runMap) => [
+      ...runMap.values(),
+    ]);
     return sumUsageStats(allUsage);
   }
 


### PR DESCRIPTION
- userVars.ts: Use type predicate filter instead of `as string[]` assertions
- RunUsageAccumulator.ts: Rename variable for clarity (otherTotals -> src)
- UsageMonitor.ts: Inline intermediate variables in logToBackend
- ProgressEventHandler.ts: Simplify toRoundRecord with optional chaining
- OutputFilesManager.ts: Simplify getFiles and Object.keys checks
- UsageStatsManager.ts: Use spread operator in getTotalUsage
- AgentUsageReporter.ts: Remove conditional spread patterns
- executeAgent.ts: Replace nested ternary with if/else for clarity
- modelHandlerAnthropic.ts: Use filter/map/join for text extraction

Code formatting improvements applied by prettier to related files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Unifies and simplifies how token/cache usage is computed and reported across the app.
> 
> - Adds shared `utils/usageNormalization` (`computeCachePercentage`, `nonZeroOrUndefined`) and updates Anthropic/Google/OpenAI handlers to use it; cleans up per-provider usage extraction and text parsing
> - Streamlines usage reporting paths: `RunUsageAccumulator` merge clarifications, `UsageMonitor`/`AgentUsageReporter` simplify backend payload and numeric handling
> - Improves flow/tool-use code: minor import/order fixes, clearer retry/config handling in `RetryState`, and cleaner Tool-Use cycle nodes
> - Reduces UI/infra noise: simpler notifications in `executeAgent`, map/record conversions in Progress view managers, and safer array filtering in `userVars`
> - Introduces `mergeFileUtils` helpers and applies them in LaTeX diff naming logic
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 12c70452f29a58d1ef12433c689cc2aae10f7a1e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->