### PR TITLE
refactor: simplify error handling and propagation patterns

### DIFF
--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -715,7 +715,10 @@ class ToolUseDispatchNode<C> extends BaseNode<
       data: toolUseLog,
     });
 
-    const mediaLocations = await this.collectValidMediaLocations(result.files);
+    const mediaLocations = await this.collectValidMediaLocations(
+      result.files,
+      options.logger,
+    );
     if (mediaLocations.length > 0) {
       workspace.media.addMediaFiles(mediaLocations);
     }
@@ -724,6 +727,7 @@ class ToolUseDispatchNode<C> extends BaseNode<
   /** Collect valid file locations from tool result attachments. */
   private async collectValidMediaLocations(
     files: ToolResult['files'],
+    logger: AgentLogger,
   ): Promise<FileLocation[]> {
     if (!files || files.length === 0) {
       return [];
@@ -740,8 +744,10 @@ class ToolUseDispatchNode<C> extends BaseNode<
         if (await AbsoluteFS.exists(location.absolutePath)) {
           validLocations.push(location);
         }
-      } catch {
-        // Ignore files that can't be accessed
+      } catch (err) {
+        logger.debug(
+          `Skipping inaccessible media file: ${filePath} (${err instanceof Error ? err.message : 'unknown error'})`,
+        );
       }
     }
     return validLocations;

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -1698,27 +1698,17 @@ export class ModelHandlerAnthropic extends ModelHandler<
     const thinkingBlocks: BetaThinkingContent[] = [];
     let regularThinkingContent: string | null = null;
 
-    try {
-      if (responseObject.content && Array.isArray(responseObject.content)) {
-        // Collect all thinking and redacted_thinking blocks using type guards
-        for (const item of responseObject.content) {
-          if (isBetaThinkingBlock(item) && item.thinking) {
-            thinkingBlocks.push(item);
-            // Save the first regular thinking content for returning
-            if (regularThinkingContent === null) {
-              regularThinkingContent = item.thinking;
-            }
-          } else if (isBetaRedactedThinkingBlock(item) && item.data) {
-            thinkingBlocks.push(item);
+    if (responseObject.content && Array.isArray(responseObject.content)) {
+      for (const item of responseObject.content) {
+        if (isBetaThinkingBlock(item) && item.thinking) {
+          thinkingBlocks.push(item);
+          if (regularThinkingContent === null) {
+            regularThinkingContent = item.thinking;
           }
+        } else if (isBetaRedactedThinkingBlock(item) && item.data) {
+          thinkingBlocks.push(item);
         }
       }
-    } catch (e) {
-      this.logger.error(
-        `Error extracting thinking blocks: ${getSdkErrorMessage(e)}`,
-        { data: e },
-      );
-      return null;
     }
 
     if (thinkingBlocks.length === 0) {

--- a/src/agent/utils/text/repetitionUtils.ts
+++ b/src/agent/utils/text/repetitionUtils.ts
@@ -2,7 +2,6 @@
 import { diff_match_patch } from 'diff-match-patch';
 
 // Local imports - logging
-import { toErrorMessage } from '@common/errors/errorHandlingUtils';
 import * as logger from '@logger/logUtils';
 import {
   REPETITION_DETECTION_THRESHOLD,
@@ -26,46 +25,38 @@ export function checkForMassiveRepetition(
   lastResponse: string,
   newResponse: string,
 ): RepetitionResult {
-  try {
-    const dmp = new diff_match_patch();
-    const diffs = dmp.diff_main(lastResponse, newResponse);
+  const dmp = new diff_match_patch();
+  const diffs = dmp.diff_main(lastResponse, newResponse);
 
-    // Find longest common substring
-    let longestMatch = '';
-    for (const [type, text] of diffs) {
-      if (type === 0 && text.length > longestMatch.length) {
-        longestMatch = text;
-      }
+  // Find longest common substring
+  let longestMatch = '';
+  for (const [type, text] of diffs) {
+    if (type === 0 && text.length > longestMatch.length) {
+      longestMatch = text;
     }
+  }
 
-    // Calculate similarity ratio
-    const matchLength = diffs.reduce(
-      (sum, [type, text]) => (type === 0 ? sum + text.length : sum),
-      0,
-    );
-    const ratio =
-      (2.0 * matchLength) / (lastResponse.length + newResponse.length);
-    const massiveRepetitionDetected =
-      longestMatch.length > REPETITION_DETECTION_THRESHOLD;
+  // Calculate similarity ratio
+  const matchLength = diffs.reduce(
+    (sum, [type, text]) => (type === 0 ? sum + text.length : sum),
+    0,
+  );
+  const ratio =
+    (2.0 * matchLength) / (lastResponse.length + newResponse.length);
+  const massiveRepetitionDetected =
+    longestMatch.length > REPETITION_DETECTION_THRESHOLD;
 
-    if (massiveRepetitionDetected) {
-      const preview = longestMatch.slice(0, REPETITION_PREVIEW_LENGTH);
-      logger.error(
-        CHANNEL,
-        `Massive repetition detected - ratio: ${ratio}, preview: ${preview}. Stopping process.`,
-      );
-    }
-
-    return {
-      massiveRepetitionDetected,
-      ratio,
-      longestMatch,
-    };
-  } catch (err) {
+  if (massiveRepetitionDetected) {
+    const preview = longestMatch.slice(0, REPETITION_PREVIEW_LENGTH);
     logger.error(
       CHANNEL,
-      `Error checking repetition with DMP: ${toErrorMessage(err)}`,
+      `Massive repetition detected - ratio: ${ratio}, preview: ${preview}. Stopping process.`,
     );
-    throw err;
   }
+
+  return {
+    massiveRepetitionDetected,
+    ratio,
+    longestMatch,
+  };
 }

--- a/src/commands/agent/executeCommand.ts
+++ b/src/commands/agent/executeCommand.ts
@@ -9,6 +9,7 @@ import { ZodError } from 'zod';
 import { AgentConfigSchema } from '@agent/core/AgentConfig';
 import { executeAgent } from '@agent/runtime/executeAgent';
 import type { ExecutionId } from '@agent/types/IdentifierTypes';
+import { formatZodError } from '@common/errors';
 import { AgentHistoryManager } from '@common/history';
 import * as logger from '@logger/logUtils';
 
@@ -51,13 +52,9 @@ export async function runExecuteCommand(input: unknown): Promise<void> {
     await executeAgent(config, executionId);
   } catch (error) {
     if (error instanceof ZodError) {
-      const detail = error.issues.map((i) => i.message).join('; ');
-      logger.warn(CHANNEL, `Invalid agent configuration. ${detail}`, {
-        data: error,
-      });
-      void vscode.window.showErrorMessage(
-        `Invalid agent configuration. ${detail}`,
-      );
+      const message = `Invalid agent configuration. ${formatZodError(error)}`;
+      logger.warn(CHANNEL, message, { data: error });
+      void vscode.window.showErrorMessage(message);
       return;
     }
 

--- a/src/commands/latex/figCommands.ts
+++ b/src/commands/latex/figCommands.ts
@@ -20,6 +20,22 @@ function pluralize(count: number, singular: string): string {
   return count === 1 ? singular : `${singular}s`;
 }
 
+/**
+ * Execute a LaTeX command with standardized error handling.
+ * Wraps withLaTeXGuard and catches any errors to show them to the user.
+ */
+async function runLaTeXCommand(
+  action: string,
+  commandName: string,
+  operation: (context: { relativePath: string }) => Promise<void>,
+): Promise<void> {
+  try {
+    await withLaTeXGuard({ channel: CHANNEL, action }, operation);
+  } catch (err) {
+    await showLoggedErrorMessage(CHANNEL, `${commandName} command failed`, err);
+  }
+}
+
 export function registerFigureCommands(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     vscode.commands.registerCommand(
@@ -38,172 +54,141 @@ export function registerFigureCommands(context: vscode.ExtensionContext) {
 }
 
 async function handleExtractFigurePaths(): Promise<void> {
-  try {
-    await withLaTeXGuard(
-      { channel: CHANNEL, action: 'extract figure paths' },
-      async ({ relativePath: filePath }) => {
-        logger.debug(CHANNEL, `Processing LaTeX file: ${filePath}`);
+  await runLaTeXCommand(
+    'extract figure paths',
+    'extractFigurePaths',
+    async ({ relativePath: filePath }) => {
+      logger.debug(CHANNEL, `Processing LaTeX file: ${filePath}`);
 
-        // Extract figure paths
-        const figurePaths = await extractFigurePathsFromLatex(
-          pathToLocation(filePath),
-        );
+      const figurePaths = await extractFigurePathsFromLatex(
+        pathToLocation(filePath),
+      );
 
-        if (figurePaths.length > 0) {
-          // Show results in QuickPick
-          const selected = await vscode.window.showQuickPick(figurePaths, {
-            placeHolder: 'Found figures (select to copy path)',
-            canPickMany: false,
-          });
+      if (figurePaths.length > 0) {
+        const selected = await vscode.window.showQuickPick(figurePaths, {
+          placeHolder: 'Found figures (select to copy path)',
+          canPickMany: false,
+        });
 
-          if (selected) {
-            await vscode.env.clipboard.writeText(selected);
-            await showLoggedInfoMessage(
-              CHANNEL,
-              `Copied figure path: ${selected}`,
-            );
-          }
-        } else {
+        if (selected) {
+          await vscode.env.clipboard.writeText(selected);
           await showLoggedInfoMessage(
             CHANNEL,
-            'No figures found in the current file',
+            `Copied figure path: ${selected}`,
           );
         }
-      },
-    );
-  } catch (err) {
-    await showLoggedErrorMessage(
-      CHANNEL,
-      'extractFigurePaths command failed',
-      err,
-    );
-  }
+      } else {
+        await showLoggedInfoMessage(
+          CHANNEL,
+          'No figures found in the current file',
+        );
+      }
+    },
+  );
 }
 
 async function handleExtractTikzFigures(): Promise<void> {
-  try {
-    await withLaTeXGuard(
-      { channel: CHANNEL, action: 'extract TikZ figures' },
-      async ({ relativePath: filePath }) => {
-        logger.debug(
-          CHANNEL,
-          `Processing LaTeX file for TikZ figures: ${filePath}`,
+  await runLaTeXCommand(
+    'extract TikZ figures',
+    'extractTikzFigures',
+    async ({ relativePath: filePath }) => {
+      logger.debug(
+        CHANNEL,
+        `Processing LaTeX file for TikZ figures: ${filePath}`,
+      );
+
+      const labeledTikzPictures = await tikzPictureManager.extract(
+        pathToLocation(filePath),
+      );
+
+      if (labeledTikzPictures.length > 0) {
+        const items = labeledTikzPictures.map(
+          ([label, tikzpicturess]: [string, string[]]) => ({
+            label: `${label} (${tikzpicturess.length} TikZ ${pluralize(tikzpicturess.length, 'picture')})`,
+            description: `Figure with label: ${label}`,
+            detail: `${tikzpicturess[0].substring(0, 100)}...`,
+          }),
         );
 
-        // Extract TikZ pictures with labels
-        const labeledTikzPictures = await tikzPictureManager.extract(
-          pathToLocation(filePath),
-        );
+        const selected = await vscode.window.showQuickPick(items, {
+          placeHolder: 'Found TikZ figures (select to copy label)',
+          canPickMany: false,
+        });
 
-        if (labeledTikzPictures.length > 0) {
-          // Create QuickPick items from the labels
-          const items = labeledTikzPictures.map(
-            ([label, tikzpicturess]: [string, string[]]) => ({
-              label: `${label} (${tikzpicturess.length} TikZ ${pluralize(tikzpicturess.length, 'picture')})`,
-              description: `Figure with label: ${label}`,
-              detail: `${tikzpicturess[0].substring(0, 100)}...`, // Show first 100 chars of first TikZ picture
-            }),
-          );
-
-          // Show results in QuickPick
-          const selected = await vscode.window.showQuickPick(items, {
-            placeHolder: 'Found TikZ figures (select to copy label)',
-            canPickMany: false,
-          });
-
-          if (selected) {
-            const label = selected.label.split(' (')[0]; // Extract just the label part
-            await vscode.env.clipboard.writeText(label);
-            await showLoggedInfoMessage(
-              CHANNEL,
-              `Copied figure label: ${label}`,
-            );
-          }
-        } else {
+        if (selected) {
+          const label = selected.label.split(' (')[0];
+          await vscode.env.clipboard.writeText(label);
           await showLoggedInfoMessage(
             CHANNEL,
-            'No TikZ figures found in the current file',
+            `Copied figure label: ${label}`,
           );
         }
-      },
-    );
-  } catch (err) {
-    await showLoggedErrorMessage(
-      CHANNEL,
-      'extractTikzFigures command failed',
-      err,
-    );
-  }
+      } else {
+        await showLoggedInfoMessage(
+          CHANNEL,
+          'No TikZ figures found in the current file',
+        );
+      }
+    },
+  );
 }
 
 async function handleCompileTikzFigures(): Promise<void> {
-  try {
-    await withLaTeXGuard(
-      { channel: CHANNEL, action: 'compile TikZ figures' },
-      async ({ relativePath: filePath }) => {
-        logger.debug(
-          CHANNEL,
-          `Processing LaTeX file for TikZ compilation: ${filePath}`,
-        );
+  await runLaTeXCommand(
+    'compile TikZ figures',
+    'compileTikzFigures',
+    async ({ relativePath: filePath }) => {
+      logger.debug(
+        CHANNEL,
+        `Processing LaTeX file for TikZ compilation: ${filePath}`,
+      );
 
-        // Show progress indicator
-        await vscode.window.withProgress(
-          {
-            location: vscode.ProgressLocation.Notification,
-            title: 'Compiling TikZ Figures',
-            cancellable: false,
-          },
-          async (progress) => {
-            progress.report({
-              message: 'Extracting and compiling TikZ pictures...',
+      await vscode.window.withProgress(
+        {
+          location: vscode.ProgressLocation.Notification,
+          title: 'Compiling TikZ Figures',
+          cancellable: false,
+        },
+        async (progress) => {
+          progress.report({
+            message: 'Extracting and compiling TikZ pictures...',
+          });
+
+          const compiledFiles = await tikzPictureManager.compile(
+            pathToLocation(filePath),
+          );
+
+          if (compiledFiles.length > 0) {
+            const items = compiledFiles.map((fileLocation) => ({
+              label: path.basename(fileLocation.absolutePath),
+              description: fileLocation.absolutePath,
+              file: fileLocation.absolutePath,
+            }));
+
+            const selected = await vscode.window.showQuickPick(items, {
+              placeHolder: 'Compiled TikZ figures (select to open)',
+              canPickMany: false,
             });
 
-            // Extract and compile TikZ pictures
-            const compiledFiles = await tikzPictureManager.compile(
-              pathToLocation(filePath),
-            );
-
-            if (compiledFiles.length > 0) {
-              // Create QuickPick items from the compiled files
-              const items = compiledFiles.map((fileLocation) => ({
-                label: path.basename(fileLocation.absolutePath),
-                description: fileLocation.absolutePath,
-                file: fileLocation.absolutePath,
-              }));
-
-              // Show results in QuickPick
-              const selected = await vscode.window.showQuickPick(items, {
-                placeHolder: 'Compiled TikZ figures (select to open)',
-                canPickMany: false,
-              });
-
-              if (selected) {
-                // Open the selected PDF
-                const uri = vscode.Uri.file(selected.file);
-                await vscode.commands.executeCommand('vscode.open', uri);
-              }
-
-              await showLoggedInfoMessage(
-                CHANNEL,
-                `Successfully compiled ${compiledFiles.length} TikZ ${pluralize(compiledFiles.length, 'figure')}`,
-              );
-            } else {
-              await showLoggedInfoMessage(
-                CHANNEL,
-                'No TikZ figures found to compile',
-              );
+            if (selected) {
+              const uri = vscode.Uri.file(selected.file);
+              await vscode.commands.executeCommand('vscode.open', uri);
             }
-          },
-        );
-      },
-    );
-  } catch (err) {
-    await showLoggedErrorMessage(
-      CHANNEL,
-      'compileTikzFigures command failed',
-      err,
-    );
-  }
+
+            await showLoggedInfoMessage(
+              CHANNEL,
+              `Successfully compiled ${compiledFiles.length} TikZ ${pluralize(compiledFiles.length, 'figure')}`,
+            );
+          } else {
+            await showLoggedInfoMessage(
+              CHANNEL,
+              'No TikZ figures found to compile',
+            );
+          }
+        },
+      );
+    },
+  );
 }
 
 export const figureCommands = {


### PR DESCRIPTION
- Add withSoftErrorHandler utility for token counting soft failures
- Extract runLaTeXCommand wrapper to eliminate repetitive try-catch in figCommands.ts
- Add debug logging to collectValidMediaLocations instead of silent catch
- Remove unnecessary try-catch wrapping type guards in modelHandlerAnthropic
- Use formatZodError utility in executeCommand.ts for consistency
- Remove redundant log-and-rethrow pattern in repetitionUtils.ts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Focuses on simplifying error handling and improving observability while keeping behavior intact.
> 
> - **LaTeX commands:** Extracts `runLaTeXCommand` wrapper to centralize try/catch and user messaging; refactors `extractFigurePaths`, `extractTikzFigures`, and `compileTikzFigures` to use it
> - **Tool-use flow:** Updates `collectValidMediaLocations(files, logger)` to log debug when attachments are inaccessible instead of silently swallowing errors; propagates logger; unchanged media registration behavior
> - **Anthropic handler:** Removes unnecessary try/catch around thinking-block extraction in `processThinkingBlock`, keeping guarded iteration with SDK type guards
> - **Repetition utils:** Drops redundant try/catch and rethrow; keeps core DMP logic and logs only when massive repetition is detected
> - **Agent execute command:** Uses `formatZodError` to standardize `ZodError` messages and VS Code notifications
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 335d7199f4e8265bcbfc602634fb0cd650e9805f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->