### PR TITLE
refactor: simplify codebase with targeted code improvements

### DIFF
--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -245,7 +245,9 @@ async function resolveAgentBase(
     agentType: sessionDescriptor.agentType,
     session: sessionDescriptor,
   };
-  const modelHandler = ModelFactory.createHandler(MODEL_CONFIGS[fullConfig.model]);
+  const modelHandler = ModelFactory.createHandler(
+    MODEL_CONFIGS[fullConfig.model],
+  );
 
   // 3. Create execution context
   // Compute stream ID, applying override for resume scenarios

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -139,8 +139,6 @@ export {
   arXivCommands,
   compareCommands,
 } from '@commands/latex';
-export { gitCommands } from '@commands/git/gitCommands';
-export { packCommands } from '@commands/housekeeping';
 export {
   mergeCommands,
   runExecuteCommand,

--- a/src/commands/git/gitCommands.ts
+++ b/src/commands/git/gitCommands.ts
@@ -256,10 +256,3 @@ async function cloneOverleafProject(
     }
   }
 }
-
-export const gitCommands = {
-  isGitRepository,
-  getRecentCommits,
-  findCommitInHistory,
-  cloneOverleafProject,
-};

--- a/src/commands/history/historyCommands.ts
+++ b/src/commands/history/historyCommands.ts
@@ -18,9 +18,7 @@ export function registerHistoryCommands(context: vscode.ExtensionContext) {
   // Register show history command
   const showHistoryCommand = vscode.commands.registerCommand(
     historyCommands.showHistory,
-    async () => {
-      await historyViewProvider.showHistoryView();
-    },
+    () => historyViewProvider.showHistoryView(),
   );
 
   // Add subscriptions

--- a/src/commands/housekeeping/cleanCommands.ts
+++ b/src/commands/housekeeping/cleanCommands.ts
@@ -155,9 +155,3 @@ export async function handleClean(config: {
     bus.emit('clearMissingOutputs', { stream: streamId });
   }
 }
-
-export const cleanCommands = {
-  handleCleanSingle,
-  handleCleanMultiple,
-  handleClean,
-};

--- a/src/commands/housekeeping/index.ts
+++ b/src/commands/housekeeping/index.ts
@@ -1,7 +1,3 @@
 // Barrel export for housekeeping commands
-export {
-  cleanCommands,
-  handleClean,
-  registerCleanCommands,
-} from './cleanCommands';
-export { packCommands, registerPackCommands } from './packCommands';
+export { handleClean, registerCleanCommands } from './cleanCommands';
+export { registerPackCommands } from './packCommands';

--- a/src/commands/housekeeping/packCommands.ts
+++ b/src/commands/housekeeping/packCommands.ts
@@ -201,9 +201,3 @@ export function registerPackCommands(context: vscode.ExtensionContext): void {
     vscode.commands.registerCommand('texra.packMultiple', handlePackMultiple),
   );
 }
-
-export const packCommands = {
-  handlePack,
-  handlePackSingle,
-  handlePackMultiple,
-};

--- a/src/commands/progress/progressViewCommands.ts
+++ b/src/commands/progress/progressViewCommands.ts
@@ -12,17 +12,15 @@ const logger = new AgentLogger(CHANNEL);
 /**
  * Show the Progress View panel
  */
-async function showProgressView() {
-  // Focus the progress view
+async function showProgressView(): Promise<void> {
   await safeExecuteCommand('texra.progressView.focus', [], CHANNEL);
-
   logger.info('ProgressView panel shown');
 }
 
 /**
  * Open the Progress View in a separate editor tab
  */
-function openProgressViewInTab() {
+function openProgressViewInTab(): void {
   const provider = ProgressViewProvider.getInstance();
   if (!provider) {
     logger.error('ProgressViewProvider not initialized');
@@ -39,7 +37,9 @@ function openProgressViewInTab() {
 /**
  * Register all progress view related commands
  */
-export function registerProgressViewCommands(context: vscode.ExtensionContext) {
+export function registerProgressViewCommands(
+  context: vscode.ExtensionContext,
+): void {
   logger.debug('Registering progress view commands');
 
   context.subscriptions.push(
@@ -49,9 +49,4 @@ export function registerProgressViewCommands(context: vscode.ExtensionContext) {
       openProgressViewInTab,
     ),
   );
-
-  return {
-    showProgressView,
-    openProgressViewInTab,
-  };
 }

--- a/src/commands/system/settingsCommands.ts
+++ b/src/commands/system/settingsCommands.ts
@@ -11,13 +11,11 @@ export const settingsCommands = {
 export function registerSettingsCommands(context: vscode.ExtensionContext) {
   const openSettingsCommand = vscode.commands.registerCommand(
     settingsCommands.openSettings,
-    async () => {
-      // Open VS Code settings with TeXRA filter
-      await vscode.commands.executeCommand(
+    () =>
+      vscode.commands.executeCommand(
         'workbench.action.openSettings',
         SETTINGS_QUERY.EXTENSION,
-      );
-    },
+      ),
   );
 
   context.subscriptions.push(openSettingsCommand);

--- a/src/commands/system/walkthroughCommands.ts
+++ b/src/commands/system/walkthroughCommands.ts
@@ -8,12 +8,11 @@ export const walkthroughCommands = {
 export function registerWalkthroughCommands(context: vscode.ExtensionContext) {
   const openGettingStartedCommand = vscode.commands.registerCommand(
     walkthroughCommands.openGettingStarted,
-    async () => {
-      await vscode.commands.executeCommand(
+    () =>
+      vscode.commands.executeCommand(
         'workbench.action.openWalkthrough',
         'texra.gettingStarted',
-      );
-    },
+      ),
   );
 
   context.subscriptions.push(openGettingStartedCommand);

--- a/src/commands/tests/connectionTests.ts
+++ b/src/commands/tests/connectionTests.ts
@@ -14,39 +14,42 @@ import {
 const CHANNEL = 'TestCommands';
 logger.initialize(CHANNEL);
 
+type TestCase = { str1: string; str2: string };
+type ConnectionMethod = (
+  str1: string,
+  str2: string,
+) => Promise<{ connector: string }>;
+
+async function runConnectionTests(
+  name: string,
+  testCases: TestCase[],
+  method: ConnectionMethod,
+): Promise<void> {
+  logger.info(CHANNEL, `Testing ${name} implementation:`);
+  for (const { str1, str2 } of testCases) {
+    logger.debug(CHANNEL, `\nTesting: "${str1}" + "${str2}"`);
+    const result = await method(str1, str2);
+    logger.info(CHANNEL, `Result: ${JSON.stringify(result)}`);
+    logger.info(CHANNEL, `Connected text: "${str1}${result.connector}${str2}"`);
+  }
+}
+
 export async function handleTestConnection(): Promise<void> {
+  const testCases: TestCase[] = [
+    { str1: 'Hello', str2: 'world' },
+    { str1: 'The cat', str2: 'sat on the mat' },
+    { str1: 'Therefore,', str2: 'we conclude' },
+    { str1: '\\section{Introduction}', str2: 'This paper presents' },
+  ];
+
   try {
-    // Test cases
-    const testCases = [
-      { str1: 'Hello', str2: 'world' },
-      { str1: 'The cat', str2: 'sat on the mat' },
-      { str1: 'Therefore,', str2: 'we conclude' },
-      { str1: '\\section{Introduction}', str2: 'This paper presents' },
-    ];
-
-    logger.info(CHANNEL, 'Testing OpenAI implementation:');
-    for (const { str1, str2 } of testCases) {
-      logger.debug(CHANNEL, `\nTesting: "${str1}" + "${str2}"`);
-      const result = await bestConnectionMethod(str1, str2);
-      logger.info(CHANNEL, `Result: ${JSON.stringify(result)}`);
-      logger.info(
-        CHANNEL,
-        `Connected text: "${str1}${result.connector}${str2}"`,
-      );
-    }
-
+    await runConnectionTests('OpenAI', testCases, bestConnectionMethod);
     logger.info(CHANNEL, '\n-------------------\n');
-
-    logger.info(CHANNEL, 'Testing Anthropic implementation:');
-    for (const { str1, str2 } of testCases) {
-      logger.debug(CHANNEL, `\nTesting: "${str1}" + "${str2}"`);
-      const result = await bestConnectionMethodAnthropic(str1, str2);
-      logger.info(CHANNEL, `Result: ${JSON.stringify(result)}`);
-      logger.info(
-        CHANNEL,
-        `Connected text: "${str1}${result.connector}${str2}"`,
-      );
-    }
+    await runConnectionTests(
+      'Anthropic',
+      testCases,
+      bestConnectionMethodAnthropic,
+    );
 
     vscode.window.showInformationMessage(
       'Check Debug Console for test results',

--- a/src/latex/textConnection.ts
+++ b/src/latex/textConnection.ts
@@ -41,20 +41,13 @@ function getMajorityChoice(choices: string[]): ConnectionResult {
     counts.set(choice, (counts.get(choice) ?? 0) + 1);
   }
 
-  let majorityChoice = '';
-  let maxCount = 0;
-  for (const [choice, count] of counts) {
-    if (count > maxCount) {
-      maxCount = count;
-      majorityChoice = choice;
-    }
-  }
+  const majorityChoice = [...counts.entries()].reduce((a, b) =>
+    b[1] > a[1] ? b : a,
+  )[0];
 
-  if (majorityChoice in CASE_CONNECTORS) {
-    return {
-      connector: CASE_CONNECTORS[majorityChoice],
-      choice: majorityChoice,
-    };
+  const connector = CASE_CONNECTORS[majorityChoice];
+  if (connector !== undefined) {
+    return { connector, choice: majorityChoice };
   }
 
   logger.debug(

--- a/src/utils/core/async.ts
+++ b/src/utils/core/async.ts
@@ -16,7 +16,6 @@ export async function sleep(ms: number): Promise<void> {
 /**
  * Wait for the specified duration with support for AbortSignal cancellation.
  * If the signal is aborted before the timeout completes, throws an AbortError.
- * Uses AbortSignal.timeout() when available for better performance.
  *
  * @param ms Number of milliseconds to wait
  * @param signal Optional AbortSignal to allow cancellation
@@ -27,46 +26,24 @@ export async function sleepWithAbort(
   signal?: AbortSignal,
 ): Promise<void> {
   if (!signal) {
-    await sleep(ms);
-    return;
+    return sleep(ms);
   }
 
   if (signal.aborted) {
     throw new DOMException('The operation was aborted.', 'AbortError');
   }
 
-  const supportsAbortTimeout = typeof AbortSignal.timeout === 'function';
-
-  await new Promise<void>((resolve, reject) => {
-    let timeoutId: ReturnType<typeof setTimeout> | undefined;
-    let timeoutSignal: AbortSignal | undefined;
-
-    const cleanup = () => {
+  return new Promise<void>((resolve, reject) => {
+    const timeoutId = setTimeout(() => {
       signal.removeEventListener('abort', onAbort);
-      timeoutSignal?.removeEventListener('abort', onTimeout);
-      if (timeoutId) {
-        clearTimeout(timeoutId);
-        timeoutId = undefined;
-      }
-    };
+      resolve();
+    }, ms);
 
     const onAbort = () => {
-      cleanup();
+      clearTimeout(timeoutId);
       reject(new DOMException('The operation was aborted.', 'AbortError'));
     };
 
-    const onTimeout = () => {
-      cleanup();
-      resolve();
-    };
-
     signal.addEventListener('abort', onAbort, { once: true });
-
-    if (supportsAbortTimeout) {
-      timeoutSignal = AbortSignal.timeout(ms);
-      timeoutSignal.addEventListener('abort', onTimeout, { once: true });
-    } else {
-      timeoutId = setTimeout(onTimeout, ms);
-    }
   });
 }

--- a/src/utils/files/flexibleFS.ts
+++ b/src/utils/files/flexibleFS.ts
@@ -82,15 +82,15 @@ export class FlexibleFS {
     }
   }
 
-  async ensureDir(target: FileLocation): Promise<void> {
-    await AbsoluteFS.ensureDir(target.absolutePath);
+  ensureDir(target: FileLocation): Promise<void> {
+    return AbsoluteFS.ensureDir(target.absolutePath);
   }
 
-  async delete(
+  delete(
     target: FileLocation,
     options?: { recursive?: boolean; useTrash?: boolean },
   ): Promise<void> {
-    await AbsoluteFS.delete(target.absolutePath, options);
+    return AbsoluteFS.delete(target.absolutePath, options);
   }
 
   stat(target: FileLocation) {

--- a/src/utils/prompt/promptUtils.ts
+++ b/src/utils/prompt/promptUtils.ts
@@ -28,19 +28,12 @@ export async function getXmlFormatFromFiles(
     return null;
   }
 
-  const xmlPromises = files.map(async (file) => {
-    try {
+  const xmlContents = await Promise.all(
+    files.map(async (file) => {
       const content = await WorkspaceFS.read(file);
       return `<document name="${file}">\n${content}\n</document>`;
-    } catch (err) {
-      logger.error(
-        CHANNEL,
-        `Error formatting file as XML: ${toErrorMessage(err)}`,
-      );
-      throw err;
-    }
-  });
-  const xmlContents = await Promise.all(xmlPromises);
+    }),
+  );
   return xmlContents.join('\n');
 }
 
@@ -56,6 +49,19 @@ export function getListOfFiles(files: string[] | null | undefined): string {
   return files.filter((f) => f.trim() !== '').join(', ');
 }
 
+async function resolveValue(value: unknown): Promise<unknown> {
+  if (value instanceof Promise) {
+    return value;
+  }
+  if (typeof value === 'object' && value !== null) {
+    const entries = await Promise.all(
+      Object.entries(value).map(async ([k, v]) => [k, await resolveValue(v)]),
+    );
+    return Object.fromEntries(entries);
+  }
+  return value;
+}
+
 /**
  * Render a prompt string using nunjucks templating
  * @param prompt The prompt template string
@@ -64,33 +70,11 @@ export function getListOfFiles(files: string[] | null | undefined): string {
  */
 export async function renderPrompt(
   prompt: string,
-  variables: { [key: string]: any },
+  variables: Record<string, unknown>,
 ): Promise<string> {
-  try {
-    // Resolve any Promise values in variables (including nested objects)
-    const resolvedVariables: { [key: string]: any } = {};
-    for (const [key, value] of Object.entries(variables)) {
-      if (value instanceof Promise) {
-        resolvedVariables[key] = await value;
-      } else if (typeof value === 'object' && value !== null) {
-        // Handle nested objects that might contain promises
-        const resolved: { [key: string]: any } = {};
-        for (const [nestedKey, nestedValue] of Object.entries(value)) {
-          resolved[nestedKey] =
-            nestedValue instanceof Promise ? await nestedValue : nestedValue;
-        }
-        resolvedVariables[key] = resolved;
-      } else {
-        resolvedVariables[key] = value;
-      }
-    }
-
-    const env = nunjucks.configure({ autoescape: false });
-    return env.renderString(prompt, resolvedVariables);
-  } catch (err) {
-    logger.error(CHANNEL, `Error rendering prompt: ${toErrorMessage(err)}`);
-    throw err;
-  }
+  const resolvedVariables = await resolveValue(variables);
+  const env = nunjucks.configure({ autoescape: false });
+  return env.renderString(prompt, resolvedVariables as Record<string, unknown>);
 }
 
 /**


### PR DESCRIPTION
- Simplify textConnection.ts getMajorityChoice using reduce
- Extract reusable test helper in connectionTests.ts
- Remove unused command export objects (gitCommands, cleanCommands, packCommands)
- Simplify async.ts sleepWithAbort by removing AbortSignal.timeout complexity
- Simplify promptUtils.ts with recursive resolveValue helper
- Remove unnecessary async wrappers in historyCommands, settingsCommands, walkthroughCommands
- Simplify flexibleFS.ts by removing unnecessary async/await in passthrough methods
- Add explicit return type annotations in progressViewCommands.ts
- Remove unused barrel exports from housekeeping/index.ts and commands.ts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Focuses on cleanup and simplification across commands and utilities.
> 
> - Removed unused command export objects (`gitCommands`, `cleanCommands`, `packCommands`) and stopped exporting them from barrels; registration functions now return `void` and some callbacks no longer use unnecessary `async`
> - Updated `commands.ts` to register Git/pack/clean via `register*Commands` and pruned unused barrel exports
> - Added explicit return types and minor signature cleanups in progress/history/settings/walkthrough command modules
> - Simplified helpers:
>   - `async.sleepWithAbort` now uses a single `setTimeout` + `AbortSignal` listener
>   - `flexibleFS` passthroughs return underlying promises directly; minor tidy in `ensureDir`/`delete`
>   - `promptUtils.renderPrompt` adds recursive `resolveValue`; `getXmlFormatFromFiles` simplified
>   - `textConnection.getMajorityChoice` reduced via `reduce` and streamlined connector mapping; tests refactored with `runConnectionTests`
> - Minor formatting in `executeAgent` (multi-line handler creation)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 339e0a55bc7b10af4b985f12f695ce0cb76972e7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->