### PR TITLE
refactor: simplify codebase - remove unused returns and redundant patterns

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -141,7 +141,6 @@ export {
   agentCreatorCommands,
 } from '@commands/agent';
 export {
-  testCommands,
   xmlCommands,
   yamlCommands,
   textEditorCommands,

--- a/src/commands/history/historyCommands.ts
+++ b/src/commands/history/historyCommands.ts
@@ -11,16 +11,15 @@ export const historyCommands = {
 /**
  * Register the commands related to agent execution history
  */
-export function registerHistoryCommands(context: vscode.ExtensionContext) {
-  // Create history view provider
+export function registerHistoryCommands(
+  context: vscode.ExtensionContext,
+): void {
   const historyViewProvider = new HistoryViewProvider(context);
 
-  // Register show history command
-  const showHistoryCommand = vscode.commands.registerCommand(
-    historyCommands.showHistory,
-    () => historyViewProvider.showHistoryView(),
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      historyCommands.showHistory,
+      () => historyViewProvider.showHistoryView(),
+    ),
   );
-
-  // Add subscriptions
-  context.subscriptions.push(showHistoryCommand);
 }

--- a/src/commands/system/helpCommands.ts
+++ b/src/commands/system/helpCommands.ts
@@ -5,18 +5,15 @@ export const helpCommands = {
   openDoc: 'texra.openDoc',
 };
 
-export function registerHelpCommands(context: vscode.ExtensionContext) {
-  const openDocCommand = vscode.commands.registerCommand(
-    helpCommands.openDoc,
-    async (page: string) => {
+export function registerHelpCommands(context: vscode.ExtensionContext): void {
+  context.subscriptions.push(
+    vscode.commands.registerCommand(helpCommands.openDoc, async (page: string) => {
       if (!page) {
         return;
       }
       const baseUrl = 'https://texra.ai/guide/';
       const url = `${baseUrl}${page}.html`;
       await vscode.env.openExternal(vscode.Uri.parse(url));
-    },
+    }),
   );
-
-  context.subscriptions.push(openDocCommand);
 }

--- a/src/commands/system/index.ts
+++ b/src/commands/system/index.ts
@@ -6,7 +6,7 @@ export {
   registerSampleProjectCommands,
 } from './sampleProjectCommands';
 export { settingsCommands, registerSettingsCommands } from './settingsCommands';
-export { testCommands, registerTestCommands } from './testCommands';
+export { registerTestCommands } from './testCommands';
 export {
   textEditorCommands,
   registerTextEditorCommands,

--- a/src/commands/system/sampleProjectCommands.ts
+++ b/src/commands/system/sampleProjectCommands.ts
@@ -19,7 +19,7 @@ export const sampleProjectCommands = {
 
 export function registerSampleProjectCommands(
   context: vscode.ExtensionContext,
-) {
+): void {
   const createSampleProjectCommand = vscode.commands.registerCommand(
     sampleProjectCommands.createSampleProject,
     async () => {

--- a/src/commands/system/settingsCommands.ts
+++ b/src/commands/system/settingsCommands.ts
@@ -8,15 +8,17 @@ export const settingsCommands = {
   openSettings: 'texra.openSettings',
 };
 
-export function registerSettingsCommands(context: vscode.ExtensionContext) {
-  const openSettingsCommand = vscode.commands.registerCommand(
-    settingsCommands.openSettings,
-    () =>
-      vscode.commands.executeCommand(
-        'workbench.action.openSettings',
-        SETTINGS_QUERY.EXTENSION,
-      ),
+export function registerSettingsCommands(
+  context: vscode.ExtensionContext,
+): void {
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      settingsCommands.openSettings,
+      () =>
+        vscode.commands.executeCommand(
+          'workbench.action.openSettings',
+          SETTINGS_QUERY.EXTENSION,
+        ),
+    ),
   );
-
-  context.subscriptions.push(openSettingsCommand);
 }

--- a/src/commands/system/testCommands.ts
+++ b/src/commands/system/testCommands.ts
@@ -8,7 +8,7 @@ import { handleTestConnection } from '@commands/tests/connectionTests';
 const CHANNEL = 'TestCommands';
 logger.initialize(CHANNEL);
 
-export function registerTestCommands(context: vscode.ExtensionContext) {
+export function registerTestCommands(context: vscode.ExtensionContext): void {
   context.subscriptions.push(
     vscode.commands.registerCommand(
       'texra.testConnection',
@@ -16,7 +16,3 @@ export function registerTestCommands(context: vscode.ExtensionContext) {
     ),
   );
 }
-
-export const testCommands = {
-  handleTestConnection,
-};

--- a/src/commands/system/walkthroughCommands.ts
+++ b/src/commands/system/walkthroughCommands.ts
@@ -5,15 +5,17 @@ export const walkthroughCommands = {
   openGettingStarted: 'texra.openGettingStarted',
 };
 
-export function registerWalkthroughCommands(context: vscode.ExtensionContext) {
-  const openGettingStartedCommand = vscode.commands.registerCommand(
-    walkthroughCommands.openGettingStarted,
-    () =>
-      vscode.commands.executeCommand(
-        'workbench.action.openWalkthrough',
-        'texra.gettingStarted',
-      ),
+export function registerWalkthroughCommands(
+  context: vscode.ExtensionContext,
+): void {
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      walkthroughCommands.openGettingStarted,
+      () =>
+        vscode.commands.executeCommand(
+          'workbench.action.openWalkthrough',
+          'texra.gettingStarted',
+        ),
+    ),
   );
-
-  context.subscriptions.push(openGettingStartedCommand);
 }

--- a/src/commands/system/xmlCommands.ts
+++ b/src/commands/system/xmlCommands.ts
@@ -48,17 +48,13 @@ export async function handleParseXml(): Promise<void> {
       attributeNamePrefix: '',
     });
 
-    try {
-      const parsedXml = parser.parse(content);
+    const parsedXml = parser.parse(content);
 
-      logger.debug(CHANNEL, 'Parsed XML(JSON)');
-      logger.debug(
-        CHANNEL,
-        `Parsed structure: ${JSON.stringify(parsedXml, null, 2)}`,
-      );
-    } catch (err) {
-      await showLoggedErrorMessage(CHANNEL, 'Failed to parse XML', err);
-    }
+    logger.debug(CHANNEL, 'Parsed XML(JSON)');
+    logger.debug(
+      CHANNEL,
+      `Parsed structure: ${JSON.stringify(parsedXml, null, 2)}`,
+    );
   } catch (err) {
     await showLoggedErrorMessage(CHANNEL, 'Error parsing XML', err);
   }
@@ -67,9 +63,7 @@ export async function handleParseXml(): Promise<void> {
 /**
  * Validate and fix XML errors using Claude
  */
-export async function handleValidateAndFixXml(
-  _context: vscode.ExtensionContext,
-): Promise<void> {
+export async function handleValidateAndFixXml(): Promise<void> {
   try {
     const guardResult = await getActiveEditorWithGuards({
       allowedExtensions: ['.xml'],
@@ -98,12 +92,12 @@ export async function handleValidateAndFixXml(
   }
 }
 
-export function registerXmlCommands(context: vscode.ExtensionContext) {
+export function registerXmlCommands(context: vscode.ExtensionContext): void {
   context.subscriptions.push(
     vscode.commands.registerCommand(xmlCommands.parseXml, handleParseXml),
-    vscode.commands.registerCommand(xmlCommands.validateAndFixXml, () =>
-      handleValidateAndFixXml(context),
+    vscode.commands.registerCommand(
+      xmlCommands.validateAndFixXml,
+      handleValidateAndFixXml,
     ),
   );
-  return xmlCommands;
 }

--- a/src/commands/wolfram/wolframToolCommands.ts
+++ b/src/commands/wolfram/wolframToolCommands.ts
@@ -13,37 +13,40 @@ export const wolframToolCommands = {
   testWolframTool: 'texra.testWolframTool',
 };
 
-export function registerWolframToolCommands(context: vscode.ExtensionContext) {
-  const testCommand = vscode.commands.registerCommand(
-    wolframToolCommands.testWolframTool,
-    async () => {
-      try {
-        const code = await vscode.window.showInputBox({
-          prompt: 'Enter Wolfram Language code to run with the tool',
-          placeHolder: 'N[Pi,20]',
-        });
-        if (!code) {
-          return;
-        }
-        const tool = new WolframTool();
-        const result = await tool.call({ code });
-        if (result.isError) {
+export function registerWolframToolCommands(
+  context: vscode.ExtensionContext,
+): void {
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      wolframToolCommands.testWolframTool,
+      async () => {
+        try {
+          const code = await vscode.window.showInputBox({
+            prompt: 'Enter Wolfram Language code to run with the tool',
+            placeHolder: 'N[Pi,20]',
+          });
+          if (!code) {
+            return;
+          }
+          const tool = new WolframTool();
+          const result = await tool.call({ code });
+          if (result.isError) {
+            await showLoggedErrorMessage(
+              CHANNEL,
+              'Wolfram tool error',
+              result.error,
+            );
+          } else {
+            vscode.window.showInformationMessage(result.output ?? 'No output');
+          }
+        } catch (err) {
           await showLoggedErrorMessage(
             CHANNEL,
-            'Wolfram tool error',
-            result.error,
+            'Error running Wolfram tool',
+            err,
           );
-        } else {
-          vscode.window.showInformationMessage(result.output ?? 'No output');
         }
-      } catch (err) {
-        await showLoggedErrorMessage(
-          CHANNEL,
-          'Error running Wolfram tool',
-          err,
-        );
-      }
-    },
+      },
+    ),
   );
-  context.subscriptions.push(testCommand);
 }

--- a/src/common/state/stateManager.ts
+++ b/src/common/state/stateManager.ts
@@ -36,10 +36,10 @@ class StateManagerImpl {
   get<T>(key: string): T | undefined;
   get<T>(key: string, defaultValue: T): T;
   get<T>(key: string, defaultValue?: T): T | undefined {
-    if (arguments.length === 1) {
-      return this.memento.get<T>(key);
-    }
-    return this.memento.get<T>(key, defaultValue!);
+    // Use arguments.length to distinguish between no default and undefined default
+    return arguments.length === 1
+      ? this.memento.get<T>(key)
+      : this.memento.get<T>(key, defaultValue as T);
   }
 
   update<T>(key: string, value: T): Thenable<void> {

--- a/src/frontend/terminal/index.ts
+++ b/src/frontend/terminal/index.ts
@@ -1,14 +1,13 @@
 // Third-party imports
 import * as vscode from 'vscode';
 
-let terminal: vscode.Terminal | undefined;
-
+/**
+ * Get an existing terminal by name or create a new one.
+ * Only returns terminals that haven't exited.
+ */
 export function getOrCreateTerminal(name: string): vscode.Terminal {
-  const existingTerminal = vscode.window.terminals.find((t) => t.name === name);
-  if (existingTerminal) {
-    terminal = existingTerminal;
-  } else if (!terminal || terminal.exitStatus !== undefined) {
-    terminal = vscode.window.createTerminal(name);
-  }
-  return terminal;
+  const existing = vscode.window.terminals.find(
+    (t) => t.name === name && t.exitStatus === undefined,
+  );
+  return existing ?? vscode.window.createTerminal(name);
 }

--- a/src/historyView/HistoryViewContentProvider.ts
+++ b/src/historyView/HistoryViewContentProvider.ts
@@ -14,7 +14,7 @@ const HISTORY_VIEW_MODULES = [
 
 export class HistoryViewContentProvider extends BaseViewContentProvider {
   constructor(context: vscode.ExtensionContext) {
-    super(context, 'HistoryView', [...HISTORY_VIEW_MODULES]);
+    super(context, 'HistoryView', HISTORY_VIEW_MODULES);
   }
 
   protected getViewPath(): string {

--- a/src/memoryView/MemoryViewContentProvider.ts
+++ b/src/memoryView/MemoryViewContentProvider.ts
@@ -13,7 +13,7 @@ const MEMORY_VIEW_MODULES = [
 
 export class MemoryViewContentProvider extends BaseViewContentProvider {
   constructor(context: vscode.ExtensionContext) {
-    super(context, 'MemoryView', [...MEMORY_VIEW_MODULES]);
+    super(context, 'MemoryView', MEMORY_VIEW_MODULES);
   }
 
   protected getViewPath(): string {

--- a/src/profileView/ProfileViewContentProvider.ts
+++ b/src/profileView/ProfileViewContentProvider.ts
@@ -16,7 +16,7 @@ const PROFILE_VIEW_MODULES = [
 
 export class ProfileViewContentProvider extends BaseViewContentProvider {
   constructor(context: vscode.ExtensionContext) {
-    super(context, 'ProfileView', [...PROFILE_VIEW_MODULES]);
+    super(context, 'ProfileView', PROFILE_VIEW_MODULES);
   }
 
   protected getViewPath(): string {


### PR DESCRIPTION
- Remove unused return values from command registration functions
  (historyCommands, settingsCommands, helpCommands, walkthroughCommands,
  sampleProjectCommands, wolframToolCommands, testCommands, xmlCommands)
- Remove unused _context parameter from handleValidateAndFixXml
- Remove unnecessary testCommands re-export from testCommands.ts
- Consolidate nested try-catch in xmlCommands handleParseXml
- Remove unnecessary array spreading in view content providers
  (ProfileView, HistoryView, MemoryView) - constants are already readonly
- Inline trivial toLowerCase wrapper in activeFileGuards.ts
- Simplify terminal module - remove confusing module-level state tracking
- Add explicit void return types to registration functions
- Consolidate stateManager get() implementation to single ternary

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Focuses on reducing boilerplate and unused code across commands and utilities.
> 
> - Simplifies command registration by pushing disposables directly to `context.subscriptions` and adding explicit `void` return types (history, help, settings, walkthrough, wolframTool, test, xml, sampleProject)
> - Removes unused exports/params: drops `testCommands` re-export/object; removes `_context` from `handleValidateAndFixXml`; updates system index/barrel exports accordingly
> - XML commands: flattens nested try/catch in `handleParseXml`; `handleValidateAndFixXml` no longer needs context; unchanged behavior
> - Terminal utility: removes module-level state; `getOrCreateTerminal` now returns existing non-exited terminal or creates a new one
> - State manager: consolidates `get()` overload into a single ternary using `arguments.length`
> - Webview content providers: removes unnecessary array spread when passing readonly module lists (HistoryView, MemoryView, ProfileView)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b29731d1dcb39f5fba1b56229a1a254b58da8717. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->