### PR TITLE
refactor: simplify code patterns with extracted helper methods

### DIFF
--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -316,13 +316,21 @@ function detectRequestId(err: unknown): string | undefined {
     headers?: { get?: (key: string) => string | null };
   };
 
-  // Try property names, then headers
-  return (
-    (isString(candidate.request_id) && candidate.request_id) ||
-    (isString(candidate.requestId) && candidate.requestId) ||
-    candidate.headers?.get?.('x-request-id') ||
-    undefined
-  );
+  // Try property names first
+  if (isString(candidate.request_id) && candidate.request_id) {
+    return candidate.request_id;
+  }
+  if (isString(candidate.requestId) && candidate.requestId) {
+    return candidate.requestId;
+  }
+
+  // Try headers (Anthropic stores request ID here)
+  const headerValue = candidate.headers?.get?.('x-request-id');
+  if (headerValue) {
+    return headerValue;
+  }
+
+  return undefined;
 }
 
 /**

--- a/src/latex/extractBibliography.ts
+++ b/src/latex/extractBibliography.ts
@@ -148,11 +148,8 @@ function formatFieldValue(value: unknown): string {
       if (candidate.type === 'quotedstringwrapper') {
         return `"${rendered}"`;
       }
-
       return `{${rendered}}`;
     }
-
-    return `{${String(value)}}`;
   }
 
   return `{${String(value)}}`;

--- a/src/latex/extractFigure.ts
+++ b/src/latex/extractFigure.ts
@@ -19,34 +19,36 @@ function normalizePath(latexDir: string, relativePath: string): string {
 }
 
 /**
- * Parse graphicspath commands supporting both single and multiple path formats
+ * Normalize a path to ensure it has a trailing slash.
+ */
+function ensureTrailingSlash(p: string): string {
+  const trimmed = p.trim();
+  if (!trimmed) {
+    return '';
+  }
+  return trimmed.endsWith('/') ? trimmed : `${trimmed}/`;
+}
+
+/**
+ * Parse graphicspath commands supporting both single and multiple path formats.
  * @param content LaTeX file content
  * @returns Array of paths found in graphicspath commands
  */
 function parseGraphicspath(content: string): string[] {
-  const paths: string[] = [];
-  // Match both single and multiple path formats
   const graphicspathPattern = /\\graphicspath\s*\{((?:\s*\{[^{}]+\}\s*)+)\}/g;
-  // Pattern to extract individual paths from nested braces
   const pathPattern = /\{([^{}]+)\}/g;
 
-  // Use flatMap to process outer matches and extract inner paths
-  const extractedPaths = [...content.matchAll(graphicspathPattern)].flatMap(
-    (outerMatch) =>
-      [...outerMatch[1].matchAll(pathPattern)]
-        .map((pathMatch) => {
-          let p = pathMatch[1].trim();
-          // Ensure path has trailing slash
-          if (p && !p.endsWith('/')) {
-            p += '/';
-          }
-          return p;
-        })
-        .filter(Boolean),
-  );
+  const extractedPaths: string[] = [];
+  for (const outerMatch of content.matchAll(graphicspathPattern)) {
+    for (const pathMatch of outerMatch[1].matchAll(pathPattern)) {
+      const normalized = ensureTrailingSlash(pathMatch[1]);
+      if (normalized) {
+        extractedPaths.push(normalized);
+      }
+    }
+  }
 
-  paths.push(...extractedPaths);
-  return paths;
+  return extractedPaths;
 }
 
 /**

--- a/src/tools/memory/MemoryTool.ts
+++ b/src/tools/memory/MemoryTool.ts
@@ -149,6 +149,24 @@ export class MemoryTool extends defineTool({
     }
   }
 
+  /**
+   * Validates that the path exists and is a file (not a directory).
+   * Throws ToolError if validation fails.
+   */
+  private async requireEditableFile(
+    resolvedPath: string,
+    inputPath: string,
+  ): Promise<void> {
+    const exists = await StorageFS.exists(resolvedPath);
+    if (!exists) {
+      throw new ToolError(`Error: The path ${inputPath} does not exist`);
+    }
+    const isDir = await StorageFS.isDir(resolvedPath);
+    if (isDir) {
+      throw new ToolError(`Error: The path ${inputPath} does not exist`);
+    }
+  }
+
   private async view(
     inputPath: string,
     viewRange?: number[],
@@ -230,19 +248,7 @@ export class MemoryTool extends defineTool({
     newStr: string,
   ): Promise<ToolResult> {
     const resolvedPath = this.resolveMemoryPath(inputPath);
-    const exists = await StorageFS.exists(resolvedPath);
-    if (!exists) {
-      throw new ToolError(
-        `Error: The path ${inputPath} does not exist. Please provide a valid path.`,
-      );
-    }
-
-    const isDir = await StorageFS.isDir(resolvedPath);
-    if (isDir) {
-      throw new ToolError(
-        `Error: The path ${inputPath} does not exist. Please provide a valid path.`,
-      );
-    }
+    await this.requireEditableFile(resolvedPath, inputPath);
 
     const content = await StorageFS.read(resolvedPath);
     const occurrences = content.split(oldStr).length - 1;
@@ -252,11 +258,14 @@ export class MemoryTool extends defineTool({
       );
     }
 
-    const lines = content.split(/\r?\n/);
     if (occurrences > 1) {
-      const lineNumbers = lines
-        .map((line, index) => (line.includes(oldStr) ? index + 1 : null))
-        .filter((lineNumber): lineNumber is number => lineNumber !== null);
+      const lines = content.split(/\r?\n/);
+      const lineNumbers: number[] = [];
+      lines.forEach((line, index) => {
+        if (line.includes(oldStr)) {
+          lineNumbers.push(index + 1);
+        }
+      });
       throw new ToolError(
         `No replacement was performed. Multiple occurrences of old_str \`${oldStr}\` in lines: ${lineNumbers.join(
           ', ',
@@ -285,15 +294,7 @@ export class MemoryTool extends defineTool({
     insertText: string,
   ): Promise<ToolResult> {
     const resolvedPath = this.resolveMemoryPath(inputPath);
-    const exists = await StorageFS.exists(resolvedPath);
-    if (!exists) {
-      throw new ToolError(`Error: The path ${inputPath} does not exist`);
-    }
-
-    const isDir = await StorageFS.isDir(resolvedPath);
-    if (isDir) {
-      throw new ToolError(`Error: The path ${inputPath} does not exist`);
-    }
+    await this.requireEditableFile(resolvedPath, inputPath);
 
     const content = await StorageFS.read(resolvedPath);
     const lines = content.split(/\r?\n/);


### PR DESCRIPTION
- TikzPictureManager: extract createLocation() to reduce repeated ternary
- UsageMonitor: extract computeCacheableTokens() and computeCachePercentage()
- sdkErrorUtils: simplify detectRequestId() with early returns
- textConnection: extract getOpenAIClient() and getAnthropicClient()
- ReadTool: extract computeRequestedEndLine() from nested ternary
- extractFigure: extract ensureTrailingSlash() and simplify parseGraphicspath
- extractBibliography: remove duplicate return statement in formatFieldValue
- MemoryTool: extract requireEditableFile() to reduce repeated validation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Focuses on code simplification and reuse without altering behavior.
> 
> - **SDK errors**: `detectRequestId` now uses early returns; still prioritizes `request_id`/`requestId` then `headers['x-request-id']`
> - **LaTeX figures**: adds `ensureTrailingSlash()` and rewrites `parseGraphicspath` to iterative extraction with normalized trailing slashes
> - **Bibliography**: removes redundant return path in `formatFieldValue`
> - **Memory tool**: introduces `requireEditableFile()` and uses it in `str_replace` and `insert`; minor cleanup of line-number reporting
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9896146e237b33df398fbd7872e2e094a0b5a602. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->