### PR TITLE
refactor: simplify interruption chain and surface area code

### DIFF
--- a/src/agent/toolUse/ToolUseAgentRegistry.ts
+++ b/src/agent/toolUse/ToolUseAgentRegistry.ts
@@ -77,14 +77,9 @@ export function getToolUseFlowContext(
   streamTabId: StreamTabId,
 ): ToolUseFlowContext<any> | undefined {
   const entry = registry.get(streamTabId);
-  // Type guard: check if it's a ToolUseFlowContext (has 'session' property with appendFollowUp method)
-  if (
-    entry &&
-    'session' in entry &&
-    entry.session &&
-    typeof entry.session === 'object' &&
-    'appendFollowUp' in entry.session
-  ) {
+  // Type guard: ToolUseFlowContext has a session with appendFollowUp method
+  const session = (entry as ToolUseFlowContext<any> | undefined)?.session;
+  if (session && typeof session.appendFollowUp === 'function') {
     return entry as ToolUseFlowContext<any>;
   }
   return undefined;
@@ -98,11 +93,9 @@ export function getToolUseFlowContext(
  * Remove registry entries for streams that no longer have an active session.
  */
 export function cleanupInactiveAgents(activeStreams: Set<StreamTabId>): void {
-  // Collect keys to delete first to avoid modifying Map during iteration
-  const keysToDelete = [...registry.keys()].filter(
-    (streamId) => !activeStreams.has(streamId),
-  );
-  for (const streamId of keysToDelete) {
-    registry.delete(streamId);
+  for (const streamId of registry.keys()) {
+    if (!activeStreams.has(streamId)) {
+      registry.delete(streamId);
+    }
   }
 }

--- a/src/commands/agent/agentCommands.ts
+++ b/src/commands/agent/agentCommands.ts
@@ -26,7 +26,3 @@ async function handleStopAgent(stream: string): Promise<void> {
   // Update the UI status
   StreamStatusService.set(stream, 'stopped');
 }
-
-export const agentCommands = {
-  handleStopAgent,
-};

--- a/src/commands/agent/index.ts
+++ b/src/commands/agent/index.ts
@@ -1,5 +1,5 @@
 // Barrel export for agent commands
-export { agentCommands, registerAgentCommands } from './agentCommands';
+export { registerAgentCommands } from './agentCommands';
 export {
   agentCreatorCommands,
   registerAgentCreatorCommands,

--- a/src/frontend/editor/activeFileGuards.ts
+++ b/src/frontend/editor/activeFileGuards.ts
@@ -26,14 +26,6 @@ export type ActiveFileGuardResult =
       status: ActiveFileGuardFailureReason;
     };
 
-const ensureLeadingDot = (extension: string): string =>
-  extension.startsWith('.') ? extension : `.${extension}`;
-
-const toLowerCase = (value: string): string => value.toLowerCase();
-
-const formatExtensionList = (extensions: string[]): string =>
-  extensions.length > 0 ? extensions.join(', ') : '';
-
 /**
  * Retrieve the active text editor when available and ensure the document
  * matches the required extension list. Optionally saves dirty documents.
@@ -54,8 +46,12 @@ export async function getActiveEditorWithGuards(
     return { status: 'noEditor' };
   }
 
-  const extensionsForDisplay = allowedExtensions.map(ensureLeadingDot);
-  const normalizedExtensions = extensionsForDisplay.map(toLowerCase);
+  const extensionsForDisplay = allowedExtensions.map((ext) =>
+    ext.startsWith('.') ? ext : `.${ext}`,
+  );
+  const normalizedExtensions = extensionsForDisplay.map((ext) =>
+    ext.toLowerCase(),
+  );
   const fileName = editor.document.fileName.toLowerCase();
 
   if (
@@ -65,7 +61,7 @@ export async function getActiveEditorWithGuards(
     const resourceLabel = resourceName
       ? `${resourceName} files`
       : 'files with the supported extensions';
-    const extensionList = formatExtensionList(extensionsForDisplay);
+    const extensionList = extensionsForDisplay.join(', ');
     await vscode.window.showWarningMessage(
       `This command only works with ${resourceLabel} (${extensionList}).`,
     );

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -96,11 +96,6 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     });
   }
 
-  private async deleteSessionSnapshot(_stream: StreamTabId): Promise<void> {
-    // PersistedFlow handles state cleanup automatically.
-    // ExecutionKVStore cleanup is managed by the flow lifecycle.
-  }
-
   protected createHandlers(): Record<
     string,
     MessageHandler<vscode.WebviewView | vscode.WebviewPanel>
@@ -194,8 +189,6 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
   }
 
   private async handleDeleteStream(message: any): Promise<void> {
-    // Delete persisted session data if any
-    await this.deleteSessionSnapshot(message.stream);
     // Clear pending task groups to prevent memory leaks
     this.provider.eventHandler.clearPendingTaskGroups(message.stream);
     await this.provider.state.clearStream(message.stream);
@@ -214,12 +207,6 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
 
     if (confirmation !== 'Delete All') {
       return;
-    }
-
-    // Delete all persisted session data
-    const allStates = this.provider.state.getAllTaskStates();
-    for (const [stream] of allStates) {
-      await this.deleteSessionSnapshot(stream);
     }
 
     // Clear all pending task groups to prevent memory leaks

--- a/src/webview/MainViewMessageHandler.ts
+++ b/src/webview/MainViewMessageHandler.ts
@@ -43,7 +43,7 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
       transcriptionCommand: MAIN_VIEW_COMMANDS.INSTRUCTION_TEXT_TRANSCRIBED,
       progressTitle: 'Transcribing instruction',
     });
-    this.fileManager = new FileManager(context);
+    this.fileManager = new FileManager();
     this.executionManager = new ExecutionManager();
     this.diffManager = new DiffManager();
     this.instructionManager = new InstructionManager(context);

--- a/src/webview/managers/ExecutionManager.ts
+++ b/src/webview/managers/ExecutionManager.ts
@@ -20,11 +20,6 @@ import {
 const CHANNEL = 'ExecutionManager';
 logger.initialize(CHANNEL);
 
-/** Normalize nullish file arrays to empty arrays */
-function toArray<T>(files: T[] | undefined | null): T[] {
-  return files ?? [];
-}
-
 export class ExecutionManager {
   async handleExecute(message: any): Promise<void> {
     const isToolUseAgent = Boolean(message.isToolUseAgent);
@@ -51,7 +46,9 @@ export class ExecutionManager {
       ? { agentType: AgentType.ToolUse, agentCategory: AgentCategory.ToolUse }
       : { agentCategory: AgentCategory.Workflow };
 
-    const outputFiles = isToolUse ? [] : toArray<string>(message.outputFiles);
+    const outputFiles: string[] = isToolUse
+      ? []
+      : (message.outputFiles ?? []);
     const useMultipleOutputs = isToolUse
       ? false
       : Boolean(message.outputFilesActive) || outputFiles.length > 1;
@@ -66,22 +63,22 @@ export class ExecutionManager {
           autoCompileInputPdf: message.autoCompileInputPdf,
         };
 
+    const mediaFiles = (message.mediaFiles ?? [])
+      .map((f: string | null) => this.mapMediaPath(f))
+      .filter((f: string | null): f is string => f !== null);
+
     return {
       agent: message.agent,
       model: message.model,
       instruction: message.instruction,
       inputFile: message.inputFile ?? '',
-      inputFiles: toArray<string>(message.inputFiles),
+      inputFiles: message.inputFiles ?? [],
       referenceFile: message.referenceFile ?? null,
-      referenceFiles: toArray<string>(message.referenceFiles),
+      referenceFiles: message.referenceFiles ?? [],
       auxiliaryFile: message.auxiliaryFile ?? null,
-      auxiliaryFiles: toArray<string>(message.auxiliaryFiles),
+      auxiliaryFiles: message.auxiliaryFiles ?? [],
       mediaFile: this.mapMediaPath(message.mediaFile ?? null),
-      mediaFiles: toArray<string>(
-        (message.mediaFiles ?? [])
-          .map((f: string | null) => this.mapMediaPath(f))
-          .filter((f: string | null): f is string => f !== null),
-      ),
+      mediaFiles,
       editedFile: null,
       agentType: session.agentType,
       session,

--- a/src/webview/managers/FileManager.ts
+++ b/src/webview/managers/FileManager.ts
@@ -52,10 +52,6 @@ type FileUpdateOptions = {
 export class FileManager extends BaseWebviewManager {
   protected readonly channel = CHANNEL;
 
-  constructor(_context: vscode.ExtensionContext) {
-    super();
-  }
-
   async handleFileSelection(message: FileSelectionMessage): Promise<void> {
     const singleFileType = message.command.replace('select', '');
     logger.debug(CHANNEL, `Selecting ${singleFileType}`);

--- a/src/webview/managers/InstructionManager.ts
+++ b/src/webview/managers/InstructionManager.ts
@@ -46,46 +46,6 @@ export class InstructionManager extends BaseWebviewManager {
     }, 100);
   }
 
-  /**
-   * Validate that the given file path is a non-empty value.
-   * Type guard to ensure file is a string.
-   */
-  private isValidFile(file?: string): file is string {
-    return !!file && file !== 'None' && file !== '';
-  }
-
-  /**
-   * Add a single file to the context when it passes validation.
-   */
-  private addSingleFileIfValid(
-    context: FileContext,
-    contextKey: 'inputFile' | 'referenceFile' | 'auxiliaryFile' | 'mediaFile',
-    file?: string,
-  ): void {
-    if (this.isValidFile(file)) {
-      context[contextKey] = file;
-    }
-  }
-
-  /**
-   * Add a list of files to the context when they are enabled and present.
-   */
-  private addMultipleFilesIfValid(
-    context: FileContext,
-    contextKey:
-      | 'inputFiles'
-      | 'referenceFiles'
-      | 'auxiliaryFiles'
-      | 'mediaFiles'
-      | 'outputFiles',
-    active: boolean,
-    files?: string[],
-  ): void {
-    if (active && Array.isArray(files) && files.length > 0) {
-      context[contextKey] = files;
-    }
-  }
-
   async handlePolishInstructionText(
     message: PolishInstructionMessage,
   ): Promise<void> {
@@ -93,53 +53,38 @@ export class InstructionManager extends BaseWebviewManager {
       return;
     }
     try {
-      const fileContext: FileContext = { agent: message.agent };
+      // Build file context, filtering out empty/placeholder values
+      const isValid = (f?: string): f is string =>
+        !!f && f !== 'None' && f !== '';
+      const hasFiles = (active: boolean, files?: string[]) =>
+        active && Array.isArray(files) && files.length > 0;
 
-      // Add single files
-      this.addSingleFileIfValid(fileContext, 'inputFile', message.inputFile);
-      this.addSingleFileIfValid(
-        fileContext,
-        'referenceFile',
-        message.referenceFile,
-      );
-      this.addSingleFileIfValid(
-        fileContext,
-        'auxiliaryFile',
-        message.auxiliaryFile,
-      );
-      this.addSingleFileIfValid(fileContext, 'mediaFile', message.mediaFile);
-
-      // Add multiple files
-      this.addMultipleFilesIfValid(
-        fileContext,
-        'inputFiles',
-        !!message.inputFilesActive,
-        message.inputFiles,
-      );
-      this.addMultipleFilesIfValid(
-        fileContext,
-        'referenceFiles',
-        !!message.referenceFilesActive,
-        message.referenceFiles,
-      );
-      this.addMultipleFilesIfValid(
-        fileContext,
-        'auxiliaryFiles',
-        !!message.auxiliaryFilesActive,
-        message.auxiliaryFiles,
-      );
-      this.addMultipleFilesIfValid(
-        fileContext,
-        'mediaFiles',
-        !!message.mediaFilesActive,
-        message.mediaFiles,
-      );
-      this.addMultipleFilesIfValid(
-        fileContext,
-        'outputFiles',
-        !!message.outputFilesActive,
-        message.outputFiles,
-      );
+      const fileContext: FileContext = {
+        agent: message.agent,
+        ...(isValid(message.inputFile) && { inputFile: message.inputFile }),
+        ...(isValid(message.referenceFile) && {
+          referenceFile: message.referenceFile,
+        }),
+        ...(isValid(message.auxiliaryFile) && {
+          auxiliaryFile: message.auxiliaryFile,
+        }),
+        ...(isValid(message.mediaFile) && { mediaFile: message.mediaFile }),
+        ...(hasFiles(!!message.inputFilesActive, message.inputFiles) && {
+          inputFiles: message.inputFiles,
+        }),
+        ...(hasFiles(!!message.referenceFilesActive, message.referenceFiles) && {
+          referenceFiles: message.referenceFiles,
+        }),
+        ...(hasFiles(!!message.auxiliaryFilesActive, message.auxiliaryFiles) && {
+          auxiliaryFiles: message.auxiliaryFiles,
+        }),
+        ...(hasFiles(!!message.mediaFilesActive, message.mediaFiles) && {
+          mediaFiles: message.mediaFiles,
+        }),
+        ...(hasFiles(!!message.outputFilesActive, message.outputFiles) && {
+          outputFiles: message.outputFiles,
+        }),
+      };
 
       const result = await polishTextWithAI(message.text, fileContext);
       if (result.success) {


### PR DESCRIPTION
Key simplifications:
- Remove empty deleteSessionSnapshot method and its calls
- Remove unused agentCommands export object
- Simplify getToolUseFlowContext type guard in registry
- Inline InstructionManager file context helper methods
- Remove toArray helper in ExecutionManager, use ?? [] directly
- Simplify cleanupInactiveAgents iteration pattern
- Remove empty FileManager constructor
- Inline trivial helper functions in activeFileGuards.ts

Net reduction: ~90 lines removed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Focuses on simplifying interruption handling and reducing surface area across agents and webviews.
> 
> - **Registry cleanup:** Simplify `getToolUseFlowContext` type guard and iterate/deletes in `cleanupInactiveAgents`; consolidate stop logic via unified `getInterruptible` and UI status update
> - **Command exports:** Remove unused `agentCommands` export object and update barrel (`agent/index.ts`) to only export `registerAgentCommands`
> - **Progress view:** Remove no-op `deleteSessionSnapshot` and its usages in delete operations
> - **Editor guard utils:** Inline trivial helpers in `activeFileGuards.ts` for extension normalization and messages
> - **Webview managers:**
>   - `MainViewMessageHandler`: construct `FileManager()` without context
>   - `FileManager`: remove empty constructor
>   - `ExecutionManager`: drop `toArray` helper; use `?? []`, simplify media file mapping
>   - `InstructionManager`: inline file-context construction with simple validators
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 48f7e937d54a59b2de56196a5622a1fbf61fc304. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->