### PR TITLE
Fix dropdown menu overflow in latexdiff

### DIFF
--- a/src/webview/index.html
+++ b/src/webview/index.html
@@ -703,7 +703,7 @@
                 ></vscode-toolbar-button>
               </vscode-toolbar-container>
             </div>
-            <vscode-single-select id="baseFile">
+            <vscode-single-select id="baseFile" position="above">
               <vscode-option value="">None</vscode-option>
             </vscode-single-select>
           </div>
@@ -761,7 +761,7 @@
                 ></vscode-toolbar-button>
               </vscode-toolbar-container>
             </div>
-            <vscode-single-select id="editedFile">
+            <vscode-single-select id="editedFile" position="above">
               <vscode-option value="">None</vscode-option>
             </vscode-single-select>
           </div>
@@ -797,7 +797,7 @@
                 ></vscode-toolbar-button>
               </vscode-toolbar-container>
             </div>
-            <vscode-single-select id="commit">
+            <vscode-single-select id="commit" position="above">
               <vscode-option value="HEAD">HEAD</vscode-option>
             </vscode-single-select>
           </div>


### PR DESCRIPTION
The vscode-single-select dropdowns in the LaTeXDiffs section are at the bottom of the webview frame. When they open downward (default), there's no space for the dropdown list to display properly.

Added position="above" attribute to all three dropdowns (baseFile, editedFile, commit) to make them open upward where there's always sufficient space.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures LaTeXDiffs dropdowns render within view when near the bottom of the webview.
> 
> - Adds `position="above"` to `vscode-single-select` for `baseFile`, `editedFile`, and `commit` in `src/webview/index.html` so menus open upward
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d92c3f779eccfc2881884748788b6c7a3bc824b8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->