### PR TITLE
Fix status indicator hover popup visibility

### DIFF
--- a/src/progressView/styles/logs.css
+++ b/src/progressView/styles/logs.css
@@ -206,9 +206,9 @@
   content: attr(data-status);
   position: absolute;
   left: 50%;
-  bottom: 100%;
+  top: 100%;
   transform: translateX(-50%);
-  margin-bottom: var(--spacing-tiny);
+  margin-top: var(--spacing-tiny);
   padding: var(--spacing-small) var(--spacing-medium);
   background: var(--background-color);
   border: var(--border-thin) solid var(--color-border);


### PR DESCRIPTION
The tooltip was positioned above the indicator using bottom: 100%,
causing it to be clipped by parent containers with overflow: hidden.
Changed to top: 100% to position below, consistent with other dropdowns.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Moves the status tooltip to appear below its indicator for hover state.
> 
> - In `logs.css`, changes `.status-indicator::after` from `bottom: 100%` with `margin-bottom` to `top: 100%` with `margin-top`, keeping alignment and styles intact
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dfce96b98cdcac95fc5d5dc70f7a0c9f2697c7e4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->