### PR TITLE
Update changelog for version 0.35.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to this project will be documented in this file.
 - Added a **Lean Proof** tool-use agent for informal-to-formal Lean 4 verification workflows.
 - Added **LaTeXdiff preview** button in tool edit approval dropdown for comparing proposed changes.
 - Added expandable error details to retry dialog UI for better debugging.
-- Relay errors are now retryable with clearer error messaging.
+- Relay errors are now retryable with clearer error messaging and distinct UI indicators.
 
 ### Bug Fixes
 
@@ -18,6 +18,8 @@ All notable changes to this project will be documented in this file.
 - Fixed round pattern extraction in multiple output filenames.
 - Fixed workspace temp file cleanup on approval resolution.
 - Fixed relay error handling and recovery.
+- Fixed status indicator tooltip clipping by positioning it below.
+- Fixed LaTeXdiff dropdowns opening downward and causing overflow.
 
 ### Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to this project will be documented in this file.
 - Fixed relay error recovery.
 - Fixed tooltip and dropdown clipping issues.
 - Fixed bash tool error messages to include stdout.
+- Fixed queued follow-up messages not being combined.
 
 ### Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.35.5] - 2026-01-14
+
+### Features
+
+- Added a **Lean Proof** tool-use agent for informal-to-formal Lean 4 verification workflows.
+- Added **LaTeXdiff preview** button in tool edit approval dropdown for comparing proposed changes.
+- Added expandable error details to retry dialog UI for better debugging.
+- Relay errors are now retryable with clearer error messaging.
+
+### Bug Fixes
+
+- Fixed race condition in workflow launch deduplication.
+- Fixed cancellation propagation for more responsive agent stopping.
+- Fixed round pattern extraction in multiple output filenames.
+- Fixed workspace temp file cleanup on approval resolution.
+- Fixed relay error handling and recovery.
+
+### Improvements
+
+- Internal refactoring to simplify code patterns and improve consistency across command handlers.
+
 ## [0.35.4] - 2026-01-10
 
 ### Features
@@ -17,7 +38,6 @@ All notable changes to this project will be documented in this file.
 - Added cache token display (read and creation) in usage statistics.
 - Token counts now format as millions (M) when >= 100K for readability.
 - Model is now informed when users modify or reject suggested edits.
-- Added a `lean_proof` tool-use agent for informal-to-formal Lean verification workflows.
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to this project will be documented in this file.
 - Added **LaTeXdiff preview** button in tool edit approval dropdown for comparing proposed changes.
 - Added expandable error details to retry dialog UI for better debugging.
 - Relay errors are now retryable with clearer error messaging and distinct UI indicators.
+- Added setting to control thinking block clearing (`texra.model.enableThinkingClearing`).
+- VS Code GitHub login is now hidden behind a config flag.
 
 ### Bug Fixes
 
@@ -19,6 +21,7 @@ All notable changes to this project will be documented in this file.
 - Fixed temp file cleanup.
 - Fixed relay error recovery.
 - Fixed tooltip and dropdown clipping issues.
+- Fixed bash tool error messages to include stdout.
 
 ### Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,13 +13,12 @@ All notable changes to this project will be documented in this file.
 
 ### Bug Fixes
 
-- Fixed race condition in workflow launch deduplication.
-- Fixed cancellation propagation for more responsive agent stopping.
-- Fixed round pattern extraction in multiple output filenames.
-- Fixed workspace temp file cleanup on approval resolution.
-- Fixed relay error handling and recovery.
-- Fixed status indicator tooltip clipping by positioning it below.
-- Fixed LaTeXdiff dropdowns opening downward and causing overflow.
+- Fixed duplicate workflow launches.
+- Fixed agent cancellation responsiveness.
+- Fixed multiple output filename handling.
+- Fixed temp file cleanup.
+- Fixed relay error recovery.
+- Fixed tooltip and dropdown clipping issues.
 
 ### Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
+- Added **Followup Task** feature for workflow continuation directly in the Progress View, with chat mode for discussing results and support for multiple file merges.
 - Added a **Lean Proof** tool-use agent for informal-to-formal Lean 4 verification workflows.
+- Added a **Merge Multiple** agent for batch merge operations.
 - Added **LaTeXdiff preview** button in tool edit approval dropdown for comparing proposed changes.
 - Added expandable error details to retry dialog UI for better debugging.
 - Relay errors are now retryable with clearer error messaging and distinct UI indicators.
@@ -23,6 +25,7 @@ All notable changes to this project will be documented in this file.
 - Fixed tooltip and dropdown clipping issues.
 - Fixed bash tool error messages to include stdout.
 - Fixed queued follow-up messages not being combined.
+- Fixed context state display to use only actual API tokens.
 
 ### Improvements
 


### PR DESCRIPTION
- Add Lean Proof tool-use agent (moved from 0.35.4)
- Add LaTeXdiff preview feature
- Add bug fixes for cancellation, workflow deduplication, and relay errors

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds 0.35.5 release notes with new features, fixes, and improvements; also removes the `lean_proof` entry from `0.35.4` (now documented under `0.35.5`).
> 
> - **Features**: Followup Task in Progress View (chat mode, multi-file merges), `Lean Proof` tool-use agent, `Merge Multiple` agent, LaTeXdiff preview in approvals, expandable error details in retry dialog, retryable relay errors, setting for thinking clearing (`texra.model.enableThinkingClearing`), GitHub login hidden behind config flag.
> - **Bug Fixes**: Workflow deduplication, cancellation responsiveness, multi-output filename handling, temp file cleanup, relay error recovery, tooltip/dropdown clipping, bash tool messages include stdout, combine queued follow-ups, context state shows only actual API tokens.
> - **Improvements**: Internal refactors to simplify patterns and unify command handlers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a5c9774d59a957d446301ddcca7912966cd19cf0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->