### PR TITLE
Add automatic context editing for conversations

### DIFF
--- a/package.json
+++ b/package.json
@@ -280,6 +280,12 @@
             "description": "Percentage of context window to trigger automatic context management. For OpenAI, triggers conversation compaction via /responses/compact. For Anthropic, triggers server-side clearing of tool uses and thinking blocks. Set to 0 to disable.",
             "scope": "resource"
           },
+          "texra.model.enableThinkingClearing": {
+            "type": "boolean",
+            "default": false,
+            "description": "Enable Anthropic's thinking block clearing strategy. When enabled, old thinking blocks are cleared alongside tool uses. Disabled by default because thinking clearing runs before tool use clearing and may prevent tool use clearing from triggering.",
+            "scope": "resource"
+          },
           "texra.model.gpt5ReasoningSummary": {
             "type": "boolean",
             "default": false,

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -215,8 +215,6 @@ const CONTEXT_MANAGEMENT_BETA: AnthropicBeta = 'context-management-2025-06-27';
  */
 /** Number of recent tool use/result pairs to keep after context clearing */
 const CONTEXT_MANAGEMENT_KEEP_TOOL_USES = 3;
-/** Number of assistant turns with thinking blocks to keep (3 = preserve more reasoning context) */
-const CONTEXT_MANAGEMENT_KEEP_THINKING_TURNS = 3;
 /**
  * Minimum percentage of context to clear at once for tool uses.
  * This ensures cache invalidation is worthwhile - clearing too few tokens
@@ -441,10 +439,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
     }
 
     // Set up context management BEFORE token counting so countTokens can
-    // return accurate post-clearing token counts. This ensures:
-    // 1. Both clearing strategies work together (thinking + tool uses)
-    // 2. max_tokens is adjusted based on post-clearing token count
-    // 3. Server-side tool use clearing triggers correctly after thinking is cleared
+    // return accurate post-clearing token counts.
     if (this.agentType === AgentType.ToolUse) {
       const thresholdPercent = getConfig<number>(
         'texra.model.compactionThresholdPercent',
@@ -463,28 +458,12 @@ export class ModelHandlerAnthropic extends ModelHandler<
           (thresholdPercent / 100) * this.config.contextWindow,
         );
 
-        // Add thinking block clearing strategy if reasoning is enabled.
-        // We always include this for ToolUse agents with reasoning because:
-        // 1. The API doesn't support a trigger field for thinking clearing
-        // 2. keep: { thinking_turns: 3 } only clears turns beyond 3, so it's
-        //    a no-op when there are few thinking turns
-        // 3. Including it allows countTokens to return accurate post-clearing counts
-        if (
-          this.capabilities.supportsReasoning &&
-          options.thinking &&
-          !contextManagementEdits.some(
-            (edit) => edit.type === 'clear_thinking_20251015',
-          )
-        ) {
-          // Thinking clearing must come first in the edits array
-          contextManagementEdits.unshift({
-            type: 'clear_thinking_20251015' as const,
-            keep: {
-              type: 'thinking_turns' as const,
-              value: CONTEXT_MANAGEMENT_KEEP_THINKING_TURNS,
-            },
-          });
-        }
+        // NOTE: Thinking clearing is currently disabled to prioritize tool use clearing.
+        // The API requires thinking clearing to be listed first in edits, which means
+        // it runs before tool use clearing and reduces tokens before the tool use
+        // trigger is checked. This prevents tool use clearing from triggering in
+        // many scenarios. The API's default behavior (keep last 1 thinking turn)
+        // still applies even without explicit thinking clearing config.
 
         // Add tool result clearing strategy with server-side trigger.
         // The trigger ensures clearing only activates when input tokens exceed threshold.

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -228,6 +228,23 @@ const CONTEXT_MANAGEMENT_CLEAR_AT_LEAST_PERCENT = 10;
 const ANTHROPIC_1M_CONTEXT_WINDOW = 1_000_000;
 
 /**
+ * Extended response type for countTokens with context_management.
+ * The SDK doesn't export this, so we define it here for type safety.
+ */
+interface CountTokensContextManagementResponse {
+  original_input_tokens: number;
+}
+
+/**
+ * Options for setting up context management configuration.
+ */
+interface ContextManagementSetupOptions {
+  options: MessageCreateParams;
+  contextWindow: number;
+  supportsReasoning: boolean;
+}
+
+/**
  * Block types that support cache_control for prompt caching.
  * Uses SDK's ContentBlockParam with Extract to get text and tool_result types.
  */
@@ -303,6 +320,105 @@ export class ModelHandlerAnthropic extends ModelHandler<
     if (!options.betas.includes(beta)) {
       options.betas.push(beta);
     }
+  }
+
+  /**
+   * Sets up context management configuration for Anthropic's server-side editing.
+   * Must be called BEFORE token counting so countTokens returns accurate post-clearing counts.
+   */
+  private setupContextManagement({
+    options,
+    contextWindow,
+    supportsReasoning,
+  }: ContextManagementSetupOptions): void {
+    if (this.agentType !== AgentType.ToolUse) {
+      return;
+    }
+
+    const thresholdPercent = getConfig<number>(
+      'texra.model.compactionThresholdPercent',
+      DEFAULT_COMPACTION_THRESHOLD_PERCENT,
+    );
+
+    // Only enable context management if threshold is configured (> 0)
+    if (thresholdPercent <= 0) {
+      return;
+    }
+
+    this.ensureBeta(options, CONTEXT_MANAGEMENT_BETA);
+
+    const contextManagementEdits = [
+      ...(options.context_management?.edits ?? []),
+    ];
+
+    const triggerTokens = Math.floor(
+      (thresholdPercent / 100) * contextWindow,
+    );
+
+    // Thinking clearing is opt-in because the API requires it to be listed
+    // first in edits, which means it runs before tool use clearing and
+    // reduces tokens before the tool use trigger is checked. This can
+    // prevent tool use clearing from triggering in many scenarios.
+    // The API's default behavior (keep last 1 thinking turn) still applies
+    // even without explicit thinking clearing config.
+    const enableThinkingClearing = getConfig<boolean>(
+      'texra.model.enableThinkingClearing',
+      false,
+    );
+
+    if (
+      enableThinkingClearing &&
+      supportsReasoning &&
+      options.thinking &&
+      !contextManagementEdits.some(
+        (edit) => edit.type === 'clear_thinking_20251015',
+      )
+    ) {
+      // Thinking clearing must come first in the edits array per API requirement
+      contextManagementEdits.unshift({
+        type: 'clear_thinking_20251015' as const,
+        keep: {
+          type: 'thinking_turns' as const,
+          value: CONTEXT_MANAGEMENT_KEEP_THINKING_TURNS,
+        },
+      });
+    }
+
+    // Add tool result clearing strategy with server-side trigger.
+    // The trigger ensures clearing only activates when input tokens exceed threshold.
+    if (
+      !contextManagementEdits.some(
+        (edit) => edit.type === 'clear_tool_uses_20250919',
+      )
+    ) {
+      // clear_at_least ensures cache invalidation is worthwhile:
+      // Without it, the API may clear too few tokens, causing frequent
+      // cache misses without meaningful benefit.
+      const clearAtLeastTokens = Math.floor(
+        (CONTEXT_MANAGEMENT_CLEAR_AT_LEAST_PERCENT / 100) * contextWindow,
+      );
+
+      contextManagementEdits.push({
+        type: 'clear_tool_uses_20250919' as const,
+        trigger: {
+          type: 'input_tokens' as const,
+          value: triggerTokens,
+        },
+        keep: {
+          type: 'tool_uses' as const,
+          value: CONTEXT_MANAGEMENT_KEEP_TOOL_USES,
+        },
+        clear_at_least: {
+          type: 'input_tokens' as const,
+          value: clearAtLeastTokens,
+        },
+      });
+    }
+
+    options.context_management = {
+      ...(options.context_management ?? {}),
+      edits: contextManagementEdits,
+    } satisfies BetaContextManagementConfig;
   }
 
   private assignCacheControlToLatest(
@@ -442,91 +558,11 @@ export class ModelHandlerAnthropic extends ModelHandler<
 
     // Set up context management BEFORE token counting so countTokens can
     // return accurate post-clearing token counts.
-    if (this.agentType === AgentType.ToolUse) {
-      const thresholdPercent = getConfig<number>(
-        'texra.model.compactionThresholdPercent',
-        DEFAULT_COMPACTION_THRESHOLD_PERCENT,
-      );
-
-      // Only enable context management if threshold is configured (> 0)
-      if (thresholdPercent > 0) {
-        this.ensureBeta(options, CONTEXT_MANAGEMENT_BETA);
-
-        const contextManagementEdits = [
-          ...(options.context_management?.edits ?? []),
-        ];
-
-        const triggerTokens = Math.floor(
-          (thresholdPercent / 100) * this.config.contextWindow,
-        );
-
-        // Thinking clearing is opt-in because the API requires it to be listed
-        // first in edits, which means it runs before tool use clearing and
-        // reduces tokens before the tool use trigger is checked. This can
-        // prevent tool use clearing from triggering in many scenarios.
-        // The API's default behavior (keep last 1 thinking turn) still applies
-        // even without explicit thinking clearing config.
-        const enableThinkingClearing = getConfig<boolean>(
-          'texra.model.enableThinkingClearing',
-          false,
-        );
-
-        if (
-          enableThinkingClearing &&
-          this.capabilities.supportsReasoning &&
-          options.thinking &&
-          !contextManagementEdits.some(
-            (edit) => edit.type === 'clear_thinking_20251015',
-          )
-        ) {
-          // Thinking clearing must come first in the edits array per API requirement
-          contextManagementEdits.unshift({
-            type: 'clear_thinking_20251015' as const,
-            keep: {
-              type: 'thinking_turns' as const,
-              value: CONTEXT_MANAGEMENT_KEEP_THINKING_TURNS,
-            },
-          });
-        }
-
-        // Add tool result clearing strategy with server-side trigger.
-        // The trigger ensures clearing only activates when input tokens exceed threshold.
-        if (
-          !contextManagementEdits.some(
-            (edit) => edit.type === 'clear_tool_uses_20250919',
-          )
-        ) {
-          // clear_at_least ensures cache invalidation is worthwhile:
-          // Without it, the API may clear too few tokens, causing frequent
-          // cache misses without meaningful benefit.
-          const clearAtLeastTokens = Math.floor(
-            (CONTEXT_MANAGEMENT_CLEAR_AT_LEAST_PERCENT / 100) *
-              this.config.contextWindow,
-          );
-
-          contextManagementEdits.push({
-            type: 'clear_tool_uses_20250919' as const,
-            trigger: {
-              type: 'input_tokens' as const,
-              value: triggerTokens,
-            },
-            keep: {
-              type: 'tool_uses' as const,
-              value: CONTEXT_MANAGEMENT_KEEP_TOOL_USES,
-            },
-            clear_at_least: {
-              type: 'input_tokens' as const,
-              value: clearAtLeastTokens,
-            },
-          });
-        }
-
-        options.context_management = {
-          ...(options.context_management ?? {}),
-          edits: contextManagementEdits,
-        } satisfies BetaContextManagementConfig;
-      }
-    }
+    this.setupContextManagement({
+      options,
+      contextWindow: effectiveContextWindow,
+      supportsReasoning: this.capabilities.supportsReasoning,
+    });
 
     if (this.capabilities.supportsTokenCounting) {
       if (documentAnalysis.hasFileSource) {
@@ -588,7 +624,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
           // Log both original and post-clearing token counts if available
           const contextMgmtResponse = (
             responseTokenCount as typeof responseTokenCount & {
-              context_management?: { original_input_tokens?: number };
+              context_management?: CountTokensContextManagementResponse;
             }
           ).context_management;
           if (contextMgmtResponse?.original_input_tokens) {

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -440,6 +440,91 @@ export class ModelHandlerAnthropic extends ModelHandler<
       this.ensureBeta(options, CONTEXT_1M_BETA);
     }
 
+    // Set up context management BEFORE token counting so countTokens can
+    // return accurate post-clearing token counts. This ensures:
+    // 1. Both clearing strategies work together (thinking + tool uses)
+    // 2. max_tokens is adjusted based on post-clearing token count
+    // 3. Server-side tool use clearing triggers correctly after thinking is cleared
+    if (this.agentType === AgentType.ToolUse) {
+      const thresholdPercent = getConfig<number>(
+        'texra.model.compactionThresholdPercent',
+        DEFAULT_COMPACTION_THRESHOLD_PERCENT,
+      );
+
+      // Only enable context management if threshold is configured (> 0)
+      if (thresholdPercent > 0) {
+        this.ensureBeta(options, CONTEXT_MANAGEMENT_BETA);
+
+        const contextManagementEdits = [
+          ...(options.context_management?.edits ?? []),
+        ];
+
+        const triggerTokens = Math.floor(
+          (thresholdPercent / 100) * this.config.contextWindow,
+        );
+
+        // Add thinking block clearing strategy if reasoning is enabled.
+        // We always include this for ToolUse agents with reasoning because:
+        // 1. The API doesn't support a trigger field for thinking clearing
+        // 2. keep: { thinking_turns: 3 } only clears turns beyond 3, so it's
+        //    a no-op when there are few thinking turns
+        // 3. Including it allows countTokens to return accurate post-clearing counts
+        if (
+          this.capabilities.supportsReasoning &&
+          options.thinking &&
+          !contextManagementEdits.some(
+            (edit) => edit.type === 'clear_thinking_20251015',
+          )
+        ) {
+          // Thinking clearing must come first in the edits array
+          contextManagementEdits.unshift({
+            type: 'clear_thinking_20251015' as const,
+            keep: {
+              type: 'thinking_turns' as const,
+              value: CONTEXT_MANAGEMENT_KEEP_THINKING_TURNS,
+            },
+          });
+        }
+
+        // Add tool result clearing strategy with server-side trigger.
+        // The trigger ensures clearing only activates when input tokens exceed threshold.
+        if (
+          !contextManagementEdits.some(
+            (edit) => edit.type === 'clear_tool_uses_20250919',
+          )
+        ) {
+          // clear_at_least ensures cache invalidation is worthwhile:
+          // Without it, the API may clear too few tokens, causing frequent
+          // cache misses without meaningful benefit.
+          const clearAtLeastTokens = Math.floor(
+            (CONTEXT_MANAGEMENT_CLEAR_AT_LEAST_PERCENT / 100) *
+              this.config.contextWindow,
+          );
+
+          contextManagementEdits.push({
+            type: 'clear_tool_uses_20250919' as const,
+            trigger: {
+              type: 'input_tokens' as const,
+              value: triggerTokens,
+            },
+            keep: {
+              type: 'tool_uses' as const,
+              value: CONTEXT_MANAGEMENT_KEEP_TOOL_USES,
+            },
+            clear_at_least: {
+              type: 'input_tokens' as const,
+              value: clearAtLeastTokens,
+            },
+          });
+        }
+
+        options.context_management = {
+          ...(options.context_management ?? {}),
+          edits: contextManagementEdits,
+        } satisfies BetaContextManagementConfig;
+      }
+    }
+
     if (this.capabilities.supportsTokenCounting) {
       if (documentAnalysis.hasFileSource) {
         this.logger.debug(
@@ -474,10 +559,19 @@ export class ModelHandlerAnthropic extends ModelHandler<
             countTokensParams.thinking = options.thinking;
           }
 
+          // Include context_management in token counting to get accurate
+          // post-clearing token counts. This is critical for:
+          // 1. Correctly adjusting max_tokens based on actual available context
+          // 2. Allowing both clearing strategies to work together
+          if (options.context_management) {
+            countTokensParams.context_management = options.context_management;
+          }
+
           // Strip betas that only apply to message creation (e.g., output length)
           // while keeping context headers needed for accurate token counting.
           const countTokenBetas = options.betas?.filter(
-            (beta) => beta === CONTEXT_1M_BETA,
+            (beta) =>
+              beta === CONTEXT_1M_BETA || beta === CONTEXT_MANAGEMENT_BETA,
           );
           if (countTokenBetas && countTokenBetas.length > 0) {
             countTokensParams.betas = countTokenBetas;
@@ -487,7 +581,23 @@ export class ModelHandlerAnthropic extends ModelHandler<
             await client.beta.messages.countTokens(countTokensParams);
           const { input_tokens: inputTokens } = responseTokenCount;
           measuredInputTokens = inputTokens;
-          this.logger.debug(`Token count of message: ${inputTokens}`);
+
+          // Log both original and post-clearing token counts if available
+          const contextMgmtResponse = (
+            responseTokenCount as typeof responseTokenCount & {
+              context_management?: { original_input_tokens?: number };
+            }
+          ).context_management;
+          if (contextMgmtResponse?.original_input_tokens) {
+            const clearedTokens =
+              contextMgmtResponse.original_input_tokens - inputTokens;
+            this.logger.debug(
+              `Token count: ${inputTokens} (after clearing ${clearedTokens} tokens from ${contextMgmtResponse.original_input_tokens})`,
+            );
+          } else {
+            this.logger.debug(`Token count of message: ${inputTokens}`);
+          }
+
           if (inputTokens > effectiveContextWindow) {
             const errMsg = `Token count of message exceeds context window: ${inputTokens} > ${effectiveContextWindow}`;
             this.logger.error(errMsg);
@@ -563,91 +673,6 @@ export class ModelHandlerAnthropic extends ModelHandler<
 
     if (hasFileReference) {
       this.ensureBeta(options, FILES_API_BETA);
-    }
-
-    if (this.agentType === AgentType.ToolUse) {
-      // Use shared compaction threshold (percentage of context window)
-      // Set to 0 to disable context management entirely
-      const thresholdPercent = getConfig<number>(
-        'texra.model.compactionThresholdPercent',
-        DEFAULT_COMPACTION_THRESHOLD_PERCENT,
-      );
-
-      // Only enable context management if threshold is configured (> 0)
-      if (thresholdPercent > 0) {
-        this.ensureBeta(options, CONTEXT_MANAGEMENT_BETA);
-
-        const contextManagementEdits = [
-          ...(options.context_management?.edits ?? []),
-        ];
-
-        const triggerTokens = Math.floor(
-          (thresholdPercent / 100) * this.config.contextWindow,
-        );
-
-        // Add thinking block clearing strategy if reasoning is enabled
-        // NOTE: The Anthropic API doesn't support a trigger for thinking clearing,
-        // so we implement client-side triggering by only including the edit when
-        // token count is measured and exceeds the threshold.
-        const shouldClearThinking =
-          measuredInputTokens !== undefined &&
-          measuredInputTokens >= triggerTokens;
-
-        if (
-          shouldClearThinking &&
-          this.capabilities.supportsReasoning &&
-          options.thinking &&
-          !contextManagementEdits.some(
-            (edit) => edit.type === 'clear_thinking_20251015',
-          )
-        ) {
-          // Thinking clearing must come first in the edits array
-          contextManagementEdits.unshift({
-            type: 'clear_thinking_20251015' as const,
-            keep: {
-              type: 'thinking_turns' as const,
-              value: CONTEXT_MANAGEMENT_KEEP_THINKING_TURNS,
-            },
-          });
-        }
-
-        // Add tool result clearing strategy
-        // Tool use clearing has a server-side trigger - it only activates when input tokens exceed threshold
-        if (
-          !contextManagementEdits.some(
-            (edit) => edit.type === 'clear_tool_uses_20250919',
-          )
-        ) {
-          // clear_at_least ensures cache invalidation is worthwhile:
-          // Without it, the API may clear too few tokens, causing frequent
-          // cache misses without meaningful benefit.
-          const clearAtLeastTokens = Math.floor(
-            (CONTEXT_MANAGEMENT_CLEAR_AT_LEAST_PERCENT / 100) *
-              this.config.contextWindow,
-          );
-
-          contextManagementEdits.push({
-            type: 'clear_tool_uses_20250919' as const,
-            trigger: {
-              type: 'input_tokens' as const,
-              value: triggerTokens,
-            },
-            keep: {
-              type: 'tool_uses' as const,
-              value: CONTEXT_MANAGEMENT_KEEP_TOOL_USES,
-            },
-            clear_at_least: {
-              type: 'input_tokens' as const,
-              value: clearAtLeastTokens,
-            },
-          });
-        }
-
-        options.context_management = {
-          ...(options.context_management ?? {}),
-          edits: contextManagementEdits,
-        } satisfies BetaContextManagementConfig;
-      }
     }
 
     let response: BetaMessage;

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -217,6 +217,13 @@ const CONTEXT_MANAGEMENT_BETA: AnthropicBeta = 'context-management-2025-06-27';
 const CONTEXT_MANAGEMENT_KEEP_TOOL_USES = 3;
 /** Number of assistant turns with thinking blocks to keep (3 = preserve more reasoning context) */
 const CONTEXT_MANAGEMENT_KEEP_THINKING_TURNS = 3;
+/**
+ * Minimum percentage of context to clear at once for tool uses.
+ * This ensures cache invalidation is worthwhile - clearing too few tokens
+ * causes frequent cache misses without meaningful benefit.
+ * 10% is a reasonable balance between cache efficiency and context retention.
+ */
+const CONTEXT_MANAGEMENT_CLEAR_AT_LEAST_PERCENT = 10;
 
 const ANTHROPIC_1M_CONTEXT_WINDOW = 1_000_000;
 
@@ -611,6 +618,14 @@ export class ModelHandlerAnthropic extends ModelHandler<
             (edit) => edit.type === 'clear_tool_uses_20250919',
           )
         ) {
+          // clear_at_least ensures cache invalidation is worthwhile:
+          // Without it, the API may clear too few tokens, causing frequent
+          // cache misses without meaningful benefit.
+          const clearAtLeastTokens = Math.floor(
+            (CONTEXT_MANAGEMENT_CLEAR_AT_LEAST_PERCENT / 100) *
+              this.config.contextWindow,
+          );
+
           contextManagementEdits.push({
             type: 'clear_tool_uses_20250919' as const,
             trigger: {
@@ -620,6 +635,10 @@ export class ModelHandlerAnthropic extends ModelHandler<
             keep: {
               type: 'tool_uses' as const,
               value: CONTEXT_MANAGEMENT_KEEP_TOOL_USES,
+            },
+            clear_at_least: {
+              type: 'input_tokens' as const,
+              value: clearAtLeastTokens,
             },
           });
         }

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -242,6 +242,7 @@ interface ContextManagementSetupOptions {
   options: MessageCreateParams;
   contextWindow: number;
   supportsReasoning: boolean;
+  thresholdPercent: number;
 }
 
 /**
@@ -330,15 +331,11 @@ export class ModelHandlerAnthropic extends ModelHandler<
     options,
     contextWindow,
     supportsReasoning,
+    thresholdPercent,
   }: ContextManagementSetupOptions): void {
     if (this.agentType !== AgentType.ToolUse) {
       return;
     }
-
-    const thresholdPercent = getConfig<number>(
-      'texra.model.compactionThresholdPercent',
-      DEFAULT_COMPACTION_THRESHOLD_PERCENT,
-    );
 
     // Only enable context management if threshold is configured (> 0)
     if (thresholdPercent <= 0) {
@@ -351,9 +348,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
       ...(options.context_management?.edits ?? []),
     ];
 
-    const triggerTokens = Math.floor(
-      (thresholdPercent / 100) * contextWindow,
-    );
+    const triggerTokens = Math.floor((thresholdPercent / 100) * contextWindow);
 
     // Thinking clearing is opt-in because the API requires it to be listed
     // first in edits, which means it runs before tool use clearing and
@@ -558,10 +553,15 @@ export class ModelHandlerAnthropic extends ModelHandler<
 
     // Set up context management BEFORE token counting so countTokens can
     // return accurate post-clearing token counts.
+    const compactionThresholdPercent = getConfig<number>(
+      'texra.model.compactionThresholdPercent',
+      DEFAULT_COMPACTION_THRESHOLD_PERCENT,
+    );
     this.setupContextManagement({
       options,
       contextWindow: effectiveContextWindow,
       supportsReasoning: this.capabilities.supportsReasoning,
+      thresholdPercent: compactionThresholdPercent,
     });
 
     if (this.capabilities.supportsTokenCounting) {

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -215,6 +215,8 @@ const CONTEXT_MANAGEMENT_BETA: AnthropicBeta = 'context-management-2025-06-27';
  */
 /** Number of recent tool use/result pairs to keep after context clearing */
 const CONTEXT_MANAGEMENT_KEEP_TOOL_USES = 3;
+/** Number of assistant turns with thinking blocks to keep */
+const CONTEXT_MANAGEMENT_KEEP_THINKING_TURNS = 3;
 /**
  * Minimum percentage of context to clear at once for tool uses.
  * This ensures cache invalidation is worthwhile - clearing too few tokens
@@ -458,12 +460,34 @@ export class ModelHandlerAnthropic extends ModelHandler<
           (thresholdPercent / 100) * this.config.contextWindow,
         );
 
-        // NOTE: Thinking clearing is currently disabled to prioritize tool use clearing.
-        // The API requires thinking clearing to be listed first in edits, which means
-        // it runs before tool use clearing and reduces tokens before the tool use
-        // trigger is checked. This prevents tool use clearing from triggering in
-        // many scenarios. The API's default behavior (keep last 1 thinking turn)
-        // still applies even without explicit thinking clearing config.
+        // Thinking clearing is opt-in because the API requires it to be listed
+        // first in edits, which means it runs before tool use clearing and
+        // reduces tokens before the tool use trigger is checked. This can
+        // prevent tool use clearing from triggering in many scenarios.
+        // The API's default behavior (keep last 1 thinking turn) still applies
+        // even without explicit thinking clearing config.
+        const enableThinkingClearing = getConfig<boolean>(
+          'texra.model.enableThinkingClearing',
+          false,
+        );
+
+        if (
+          enableThinkingClearing &&
+          this.capabilities.supportsReasoning &&
+          options.thinking &&
+          !contextManagementEdits.some(
+            (edit) => edit.type === 'clear_thinking_20251015',
+          )
+        ) {
+          // Thinking clearing must come first in the edits array per API requirement
+          contextManagementEdits.unshift({
+            type: 'clear_thinking_20251015' as const,
+            keep: {
+              type: 'thinking_turns' as const,
+              value: CONTEXT_MANAGEMENT_KEEP_THINKING_TURNS,
+            },
+          });
+        }
 
         // Add tool result clearing strategy with server-side trigger.
         // The trigger ensures clearing only activates when input tokens exceed threshold.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces server-side context management for Anthropic conversations with accurate post-clearing token accounting.
> 
> - Adds `texra.model.enableThinkingClearing` setting to optionally clear Anthropic thinking blocks alongside tool uses
> - Refactors `modelHandlerAnthropic.ts` to configure `context_management` before token counting via `setupContextManagement()`
>   - Adds tool-use clearing with `clear_at_least` and keeps last `3` tool uses; optionally keeps last `3` thinking turns
>   - Passes `context_management` and required betas to `countTokens` for accurate input tokens and adjusts `max_tokens` accordingly
>   - Logs original vs post-clearing token counts and applied edits; removes prior client-side, post-count setup
> - Minor constants/types added for clarity (`CONTEXT_MANAGEMENT_CLEAR_AT_LEAST_PERCENT`, response typing) and small logging improvements
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1bd258317b09d97dc516dd78c6829a72da6dd7aa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->