### PR TITLE
Clarify relay errors in UI messaging

### DIFF
--- a/src/agent/core/flows/CommonCycleTypes.ts
+++ b/src/agent/core/flows/CommonCycleTypes.ts
@@ -31,8 +31,8 @@ import {
   type ProviderMessage,
 } from '@agent/modelHandlers/types/ProviderMessage';
 import type { ExecutionId } from '@agent/types/IdentifierTypes';
+import { RetryErrorInfoSchema } from '@common/errors/schemas';
 import type { AgentLogger } from '@logger/AgentLogger';
-import { RetryErrorInfoSchema } from './RetryState';
 
 // ============================================================================
 // Base Cycle Schema (Single Source of Truth)

--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -21,15 +21,18 @@ import { messageToSkeleton } from '@agent/utils/messageSkeletonUtils';
 import { checkForMassiveRepetition } from '@agent/utils/text/repetitionUtils';
 
 import { isTokenLimitStopReason } from '@agent/modelHandlers/utils/stopReasonUtils';
+import {
+  RetryErrorInfoSchema,
+  type RetryErrorInfo,
+} from '@common/errors/schemas';
 import { MESSAGE_TYPES } from '@logger/messageTypes';
 import replacementEngine from '@replacement/engine';
-import { getSystemPromptWithRules } from '@utils/prompt';
 import { AgentFileLocationSchema, type AgentFileLocation } from '@utils/files';
-import { K_SLICE, REPETITION_DETECTION_THRESHOLD } from '@utils/config';
 import { AbsoluteFS, flexibleFS } from '@utils/files';
+import { K_SLICE, REPETITION_DETECTION_THRESHOLD } from '@utils/config';
+import { getSystemPromptWithRules } from '@utils/prompt';
 import { extractScratchpad } from '@utils/text/xmlUtils';
 import { bestConnectionMethod } from '@latex';
-import { RetryErrorInfoSchema, type RetryErrorInfo } from './RetryState';
 
 import { FlowTransition } from './FlowTransitions';
 import {

--- a/src/agent/core/flows/RetryState.ts
+++ b/src/agent/core/flows/RetryState.ts
@@ -23,12 +23,16 @@ import {
   formatProviderHttpError,
   type ProviderError,
 } from '@common/errors/sdkErrorUtils';
+import { type RetryErrorInfo } from '@common/errors/schemas';
 import type { AgentLogger } from '@logger/AgentLogger';
 import { MESSAGE_TYPES } from '@logger/messageTypes';
 import {
   getModelRetryBackoffMs,
   getModelRetryMaxAttempts,
 } from '@utils/config';
+
+// Re-export from canonical source for backward compatibility
+export { RetryErrorInfoSchema, type RetryErrorInfo } from '@common/errors/schemas';
 
 /**
  * Minimum retry count for background mode (at least 3 attempts before manual retry UI).
@@ -40,19 +44,13 @@ export const BACKGROUND_MODE_MIN_RETRIES = 3;
 // Error State Types (using canonical schema)
 // ============================================================================
 
-// Re-export from canonical source for backward compatibility
-export {
-  RetryErrorInfoSchema,
-  type RetryErrorInfo,
-} from '@common/errors/schemas';
-
 /**
  * Retry state for tracking errors across the retry flow.
  * Used to communicate error details to callers and UI.
  */
 export interface RetryState {
   /** Information about the last error, if any. */
-  lastError?: { message: string; retryable: boolean };
+  lastError?: RetryErrorInfo;
 }
 
 // ============================================================================

--- a/src/agent/core/flows/RetryState.ts
+++ b/src/agent/core/flows/RetryState.ts
@@ -12,8 +12,6 @@
  * - Base class for retryable invocation nodes (single source of truth)
  */
 
-import { z } from 'zod';
-
 import { Node } from '@agent/node';
 import {
   retryCoordinator,
@@ -21,7 +19,10 @@ import {
 } from '@agent/runtime/RetryRequestCoordinator';
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import { STREAM_STATUS } from '@common/constants/streamStatus';
-import { formatProviderHttpError } from '@common/errors/sdkErrorUtils';
+import {
+  formatProviderHttpError,
+  type ProviderError,
+} from '@common/errors/sdkErrorUtils';
 import type { AgentLogger } from '@logger/AgentLogger';
 import { MESSAGE_TYPES } from '@logger/messageTypes';
 import {
@@ -36,20 +37,14 @@ import {
 export const BACKGROUND_MODE_MIN_RETRIES = 3;
 
 // ============================================================================
-// Schemas (Single Source of Truth)
+// Error State Types (using canonical schema)
 // ============================================================================
 
-/**
- * Error information for retry handling.
- * Schema-first: used for persistence validation and type derivation.
- */
-export const RetryErrorInfoSchema = z.object({
-  message: z.string(),
-  retryable: z.boolean(),
-});
-
-/** Derived type from schema */
-export type RetryErrorInfo = z.infer<typeof RetryErrorInfoSchema>;
+// Re-export from canonical source for backward compatibility
+export {
+  RetryErrorInfoSchema,
+  type RetryErrorInfo,
+} from '@common/errors/schemas';
 
 /**
  * Retry state for tracking errors across the retry flow.
@@ -57,7 +52,7 @@ export type RetryErrorInfo = z.infer<typeof RetryErrorInfoSchema>;
  */
 export interface RetryState {
   /** Information about the last error, if any. */
-  lastError?: RetryErrorInfo;
+  lastError?: { message: string; retryable: boolean };
 }
 
 // ============================================================================
@@ -306,6 +301,7 @@ export abstract class RetryableInvocationNode<
   ): Promise<ManualRetryPromptResult> {
     const { streamId, logger } = this.getServices();
     const operationName = this.getOperationName();
+    // Format error ONCE and reuse - no redundant calls
     const formatted = formatProviderHttpError(error);
 
     // If not retryable, don't show UI - go straight to execFallback
@@ -313,15 +309,11 @@ export abstract class RetryableInvocationNode<
       return { shouldRetry: false, userCancelled: false };
     }
 
-    // Log the error before showing retry UI
-    logger.logErrorData(`${operationName} failed: ${formatted.message}`, {
-      message: formatted.message,
-      statusCode: formatted.statusCode,
-      retryable: formatted.retryable,
-      ...(formatted.rawErrorBody !== undefined && {
-        rawErrorBody: formatted.rawErrorBody,
-      }),
-    });
+    // Log the error before showing retry UI - pass FULL formatted error
+    logger.logErrorData(
+      `${operationName} failed: ${formatted.message}`,
+      formatted, // Pass complete ProviderError - no field loss
+    );
 
     // Emit waiting status and wait for user action
     StreamStatusService.set(streamId, STREAM_STATUS.WAITING);
@@ -331,7 +323,7 @@ export abstract class RetryableInvocationNode<
         operation: operationName,
         errorMessage: formatted.message,
         logger,
-        errorDetails: formatted,
+        errorDetails: formatted, // Pass complete ProviderError - no field loss
       },
     );
 
@@ -368,14 +360,7 @@ export abstract class RetryableInvocationNode<
     if (!formatted.retryable) {
       this.getServices().logger.logErrorData(
         `${this.getOperationName()} failed (not retryable): ${formatted.message}`,
-        {
-          message: formatted.message,
-          statusCode: formatted.statusCode,
-          retryable: formatted.retryable,
-          ...(formatted.rawErrorBody !== undefined && {
-            rawErrorBody: formatted.rawErrorBody,
-          }),
-        },
+        formatted, // Pass complete ProviderError - no field loss
       );
     }
     return { kind: 'failed', message: formatted.message };

--- a/src/agent/core/flows/RetryState.ts
+++ b/src/agent/core/flows/RetryState.ts
@@ -22,8 +22,8 @@ import { STREAM_STATUS } from '@common/constants/streamStatus';
 import {
   formatProviderHttpError,
   type ProviderError,
-} from '@common/errors/sdkErrorUtils';
-import { type RetryErrorInfo } from '@common/errors/schemas';
+  type RetryErrorInfo,
+} from '@common/errors';
 import type { AgentLogger } from '@logger/AgentLogger';
 import { MESSAGE_TYPES } from '@logger/messageTypes';
 import {
@@ -32,7 +32,7 @@ import {
 } from '@utils/config';
 
 // Re-export from canonical source for backward compatibility
-export { RetryErrorInfoSchema, type RetryErrorInfo } from '@common/errors/schemas';
+export { RetryErrorInfoSchema, type RetryErrorInfo } from '@common/errors';
 
 /**
  * Minimum retry count for background mode (at least 3 attempts before manual retry UI).

--- a/src/agent/core/flows/RetryState.ts
+++ b/src/agent/core/flows/RetryState.ts
@@ -299,7 +299,9 @@ export abstract class RetryableInvocationNode<
   ): Promise<ManualRetryPromptResult> {
     const { streamId, logger } = this.getServices();
     const operationName = this.getOperationName();
-    // Format error ONCE and reuse - no redundant calls
+    // Format error for this method's scope (retryable error handling)
+    // Note: getFallbackResult() formats separately for non-retryable errors
+    // to ensure each path logs exactly once at the appropriate point
     const formatted = formatProviderHttpError(error);
 
     // If not retryable, don't show UI - go straight to execFallback

--- a/src/common/errors/index.ts
+++ b/src/common/errors/index.ts
@@ -11,10 +11,23 @@ export {
   showLoggedInfoMessage,
   showLoggedMessageWithDocs,
 } from './errorHandlingUtils';
+
+// Canonical error schemas - SINGLE SOURCE OF TRUTH
 export {
-  ProviderHttpErrorDetails,
-  ErrorLogContext,
-  ErrorLogData,
+  ProviderErrorSchema,
+  ErrorLogDataSchema,
+  ErrorContextSchema,
+  ProviderErrorPartialSchema,
+  RetryErrorInfoSchema,
+  type ProviderError,
+  type ErrorLogData,
+  type ErrorContext,
+  type ProviderErrorPartial,
+  type RetryErrorInfo,
+} from './schemas';
+
+// Error utility functions
+export {
   formatProviderHttpError,
   getSdkErrorMessage,
   isContextWindowError,

--- a/src/common/errors/schemas.ts
+++ b/src/common/errors/schemas.ts
@@ -29,7 +29,7 @@ export const ProviderErrorSchema = z.object({
   /** Human-readable error message (includes HTTP prefix when applicable) */
   message: z.string(),
   /** HTTP status code reported by the provider, when present */
-  statusCode: z.number().int().optional(),
+  statusCode: z.int().optional(),
   /** HTTP status text (e.g., "Not Found", "Too Many Requests") */
   statusText: z.string().optional(),
   /** Provider identifier (openai, anthropic, google, kimi) */

--- a/src/common/errors/schemas.ts
+++ b/src/common/errors/schemas.ts
@@ -1,0 +1,127 @@
+/**
+ * Canonical error schemas - SINGLE SOURCE OF TRUTH
+ *
+ * All error-related types in the codebase should derive from these schemas.
+ * This file has NO internal project imports to avoid circular dependencies.
+ *
+ * Schema hierarchy:
+ * - ProviderErrorSchema: Core error from provider/SDK (base)
+ * - ErrorContextSchema: Where/when the error occurred (composition)
+ * - ErrorLogDataSchema: Combined for logging (extends both)
+ */
+
+import { z } from 'zod';
+
+// ============================================================================
+// Core Provider Error Schema
+// ============================================================================
+
+/**
+ * Core error details from a provider/SDK.
+ * This is THE canonical error schema - all other error types derive from this.
+ *
+ * Used by:
+ * - formatProviderHttpError() return type
+ * - Retry request UI (errorDetails)
+ * - Progress view error display
+ */
+export const ProviderErrorSchema = z.object({
+  /** Human-readable error message (includes HTTP prefix when applicable) */
+  message: z.string(),
+  /** HTTP status code reported by the provider, when present */
+  statusCode: z.number().int().optional(),
+  /** HTTP status text (e.g., "Not Found", "Too Many Requests") */
+  statusText: z.string().optional(),
+  /** Provider identifier (openai, anthropic, google, kimi) */
+  provider: z.string().optional(),
+  /**
+   * Whether the error can be retried:
+   * - Connection errors (timeout, network) → true
+   * - Server errors (5xx) and rate limits (429) → true
+   * - User abort, auth errors, bad requests → false
+   */
+  retryable: z.boolean(),
+  /**
+   * Whether error originated from relay service.
+   * Relay errors have `_relay` field in rawErrorBody.
+   */
+  isRelayError: z.boolean(),
+  /** Provider request ID for support debugging */
+  requestId: z.string().optional(),
+  /** Raw error body from provider API response */
+  rawErrorBody: z.unknown().optional(),
+});
+
+/** Core error details from a provider/SDK */
+export type ProviderError = z.infer<typeof ProviderErrorSchema>;
+
+// ============================================================================
+// Error Context Schema (for composition)
+// ============================================================================
+
+/**
+ * Context about where/when the error occurred.
+ * Separate from error details for clean composition.
+ */
+export const ErrorContextSchema = z.object({
+  /** Operation that failed (e.g., "Model invocation", "Tool-use call") */
+  operation: z.string().optional(),
+  /** Model being used when error occurred */
+  model: z.string().optional(),
+});
+
+/** Context about where/when the error occurred */
+export type ErrorContext = z.infer<typeof ErrorContextSchema>;
+
+// ============================================================================
+// Error Log Data Schema (composed)
+// ============================================================================
+
+/**
+ * Complete error log data - combines provider error with context.
+ * Used for progress view logging via AgentLogger.
+ */
+export const ErrorLogDataSchema = ProviderErrorSchema.extend({
+  /** Operation that failed */
+  operation: z.string().optional(),
+  /** Model being used */
+  model: z.string().optional(),
+  /** Original error message before formatting (if different from message) */
+  rawMessage: z.string().optional(),
+});
+
+/** Complete error data for logging */
+export type ErrorLogData = z.infer<typeof ErrorLogDataSchema>;
+
+// ============================================================================
+// Partial Schema for Event Bus (optional fields for transport)
+// ============================================================================
+
+/**
+ * Provider error with all fields optional for event transport.
+ * Used when passing error details through the event bus where
+ * some fields may not be present.
+ */
+export const ProviderErrorPartialSchema = ProviderErrorSchema.partial();
+
+/** Provider error with optional fields */
+export type ProviderErrorPartial = z.infer<typeof ProviderErrorPartialSchema>;
+
+// ============================================================================
+// Minimal Error Info Schema (for flow state persistence)
+// ============================================================================
+
+/**
+ * Minimal error info for retry state tracking.
+ * Subset of ProviderError fields needed for flow control and persistence.
+ *
+ * Used by cycle flows to track last error across retry attempts.
+ * This is intentionally minimal - full error details are logged separately.
+ */
+export const RetryErrorInfoSchema = ProviderErrorSchema.pick({
+  message: true,
+  retryable: true,
+});
+
+/** Minimal error info for flow state */
+export type RetryErrorInfo = z.infer<typeof RetryErrorInfoSchema>;

--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -165,7 +165,7 @@ function isRetryableStatusCode(statusCode?: number): boolean {
  * Matches known SDK error types and returns structured error details.
  * Handles both message-only errors (connection/abort) and HTTP errors.
  */
-function matchSdkError(err: unknown): ProviderHttpErrorDetails | undefined {
+function matchSdkError(err: unknown): ProviderError | undefined {
   const entry = SDK_ERRORS.find(({ ctor }) => err instanceof ctor);
   if (!entry) {
     return undefined;
@@ -398,9 +398,7 @@ function determineRetryable(
   return isRetryableStatusCode(statusCode);
 }
 
-export function formatProviderHttpError(
-  err: unknown,
-): ProviderHttpErrorDetails {
+export function formatProviderHttpError(err: unknown): ProviderError {
   // Extract raw error body for all paths - useful for debugging relay errors
   const rawErrorBody = detectRawErrorBody(err);
 

--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -162,10 +162,20 @@ function isRetryableStatusCode(statusCode?: number): boolean {
 }
 
 /**
+ * Partial result from SDK error matching.
+ * Does NOT include isRelayError or rawErrorBody - those are added by
+ * formatProviderHttpError() after relay detection.
+ */
+type SdkMatchResult = Omit<ProviderError, 'isRelayError' | 'rawErrorBody'>;
+
+/**
  * Matches known SDK error types and returns structured error details.
  * Handles both message-only errors (connection/abort) and HTTP errors.
+ *
+ * NOTE: Returns partial result without isRelayError/rawErrorBody.
+ * formatProviderHttpError() adds those fields after relay detection.
  */
-function matchSdkError(err: unknown): ProviderError | undefined {
+function matchSdkError(err: unknown): SdkMatchResult | undefined {
   const entry = SDK_ERRORS.find(({ ctor }) => err instanceof ctor);
   if (!entry) {
     return undefined;
@@ -180,7 +190,6 @@ function matchSdkError(err: unknown): ProviderError | undefined {
       message: entry.message,
       provider,
       retryable: entry.retryable ?? false,
-      isRelayError: false,
       requestId,
     };
   }
@@ -203,7 +212,6 @@ function matchSdkError(err: unknown): ProviderError | undefined {
       message: finalMessage,
       provider,
       retryable: false,
-      isRelayError: false,
       requestId,
     };
   }
@@ -215,7 +223,6 @@ function matchSdkError(err: unknown): ProviderError | undefined {
     statusText,
     provider,
     retryable: isRetryableStatusCode(statusCode),
-    isRelayError: false,
     requestId,
   };
 }

--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -56,6 +56,12 @@ export interface ProviderHttpErrorDetails {
    * - User abort, auth errors, bad requests → NOT retryable
    */
   retryable: boolean;
+  /**
+   * Whether this error originated from the relay service.
+   * Relay errors have a `_relay` field in the raw error body and indicate
+   * issues with the proxy/relay infrastructure rather than the upstream provider.
+   */
+  isRelayError: boolean;
   /** Request ID from the provider, useful for debugging with support. */
   requestId?: string;
   /**
@@ -190,6 +196,7 @@ function matchSdkError(err: unknown): ProviderHttpErrorDetails | undefined {
       message: entry.message,
       provider,
       retryable: entry.retryable ?? false,
+      isRelayError: false,
       requestId,
     };
   }
@@ -212,6 +219,7 @@ function matchSdkError(err: unknown): ProviderHttpErrorDetails | undefined {
       message: finalMessage,
       provider,
       retryable: false,
+      isRelayError: false,
       requestId,
     };
   }
@@ -223,6 +231,7 @@ function matchSdkError(err: unknown): ProviderHttpErrorDetails | undefined {
     statusText,
     provider,
     retryable: isRetryableStatusCode(statusCode),
+    isRelayError: false,
     requestId,
   };
 }
@@ -417,6 +426,7 @@ export function formatProviderHttpError(
     return {
       message: 'Request aborted',
       retryable: false,
+      isRelayError: false,
       rawErrorBody,
     };
   }
@@ -425,10 +435,11 @@ export function formatProviderHttpError(
   const sdkMatch = matchSdkError(err);
   if (sdkMatch) {
     // Check if this should be retryable due to relay/overloaded error
+    const isRelay = isRelayError(rawErrorBody);
     const retryable =
       determineRetryable(err, sdkMatch.statusCode, rawErrorBody) ||
       sdkMatch.retryable;
-    return { ...sdkMatch, retryable, rawErrorBody };
+    return { ...sdkMatch, retryable, isRelayError: isRelay, rawErrorBody };
   }
 
   // Fallback for unrecognized errors
@@ -436,6 +447,7 @@ export function formatProviderHttpError(
   const statusText = detectStatusText(err, statusCode);
   const provider = detectProvider(err);
   const requestId = detectRequestId(err);
+  const isRelay = isRelayError(rawErrorBody);
 
   const fallbackMessage = statusCode
     ? safeGetReasonPhrase(statusCode)
@@ -452,6 +464,7 @@ export function formatProviderHttpError(
       message: finalMessage,
       provider,
       retryable: true,
+      isRelayError: isRelay,
       requestId,
       rawErrorBody,
     };
@@ -464,6 +477,7 @@ export function formatProviderHttpError(
     statusText,
     provider,
     retryable: determineRetryable(err, statusCode, rawErrorBody),
+    isRelayError: isRelay,
     requestId,
     rawErrorBody,
   };

--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -37,23 +37,9 @@ import { toErrorMessage } from './errorHandlingUtils';
 // Import canonical schemas - SINGLE SOURCE OF TRUTH
 import {
   type ProviderError,
-  type ErrorLogData as SchemaErrorLogData,
+  type ErrorLogData,
   type ErrorContext,
 } from './schemas';
-
-// Re-export canonical types for consumers
-export type { ProviderError, ErrorContext };
-export {
-  ProviderErrorSchema,
-  ErrorLogDataSchema,
-  ErrorContextSchema,
-} from './schemas';
-
-/**
- * @deprecated Use ProviderError from './schemas' instead.
- * Kept for backward compatibility.
- */
-export type ProviderHttpErrorDetails = ProviderError;
 
 /** Get reason phrase, returning undefined for unknown codes (getReasonPhrase throws). */
 function safeGetReasonPhrase(statusCode: number): string | undefined {
@@ -568,25 +554,13 @@ export function isPreviousResponseIdError(err: unknown): boolean {
 }
 
 /**
- * @deprecated Use ErrorContext from './schemas' instead.
- * Kept for backward compatibility.
- */
-export type ErrorLogContext = ErrorContext;
-
-/**
- * @deprecated Use ErrorLogData from './schemas' instead.
- * Kept for backward compatibility.
- */
-export type ErrorLogData = SchemaErrorLogData;
-
-/**
  * Builds consistent error data for logging with MESSAGE_TYPES.ERROR.
  * Ensures all error logs have the same structure for DRY display formatting.
  */
 export function buildErrorLogData(
   err: unknown,
   context?: ErrorContext,
-): SchemaErrorLogData {
+): ErrorLogData {
   const formatted = formatProviderHttpError(err);
   const rawMessage = toErrorMessage(err);
 

--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -34,42 +34,26 @@ import {
 import { extractErrorMessage, isObject, isString } from '@utils/core';
 import { toErrorMessage } from './errorHandlingUtils';
 
+// Import canonical schemas - SINGLE SOURCE OF TRUTH
+import {
+  type ProviderError,
+  type ErrorLogData as SchemaErrorLogData,
+  type ErrorContext,
+} from './schemas';
+
+// Re-export canonical types for consumers
+export type { ProviderError, ErrorContext };
+export {
+  ProviderErrorSchema,
+  ErrorLogDataSchema,
+  ErrorContextSchema,
+} from './schemas';
+
 /**
- * Structured representation of a provider HTTP failure.
+ * @deprecated Use ProviderError from './schemas' instead.
+ * Kept for backward compatibility.
  */
-export interface ProviderHttpErrorDetails {
-  /**
-   * Human readable description of the provider failure. Includes HTTP prefix when
-   * a status code is available.
-   */
-  message: string;
-  /** HTTP status code reported by the provider, when present. */
-  statusCode?: number;
-  /** HTTP status text reported by the provider or derived from the status code. */
-  statusText?: string;
-  /** Identifier for the provider that produced the error, when known. */
-  provider?: string;
-  /**
-   * Whether the error is retryable. Based on native SDK error types:
-   * - Connection errors (timeout, network) → retryable
-   * - Server errors (5xx) and rate limits (429) → retryable
-   * - User abort, auth errors, bad requests → NOT retryable
-   */
-  retryable: boolean;
-  /**
-   * Whether this error originated from the relay service.
-   * Relay errors have a `_relay` field in the raw error body and indicate
-   * issues with the proxy/relay infrastructure rather than the upstream provider.
-   */
-  isRelayError: boolean;
-  /** Request ID from the provider, useful for debugging with support. */
-  requestId?: string;
-  /**
-   * Raw error body from the provider API response.
-   * Useful for debugging relay errors where the error contains additional context.
-   */
-  rawErrorBody?: unknown;
-}
+export type ProviderHttpErrorDetails = ProviderError;
 
 /** Get reason phrase, returning undefined for unknown codes (getReasonPhrase throws). */
 function safeGetReasonPhrase(statusCode: number): string | undefined {
@@ -579,27 +563,16 @@ export function isPreviousResponseIdError(err: unknown): boolean {
 }
 
 /**
- * Context for building error log data.
+ * @deprecated Use ErrorContext from './schemas' instead.
+ * Kept for backward compatibility.
  */
-export interface ErrorLogContext {
-  /** The operation that failed (e.g., 'API request', 'manual retry'). */
-  operation?: string;
-  /** The model being used when the error occurred. */
-  model?: string;
-}
+export type ErrorLogContext = ErrorContext;
 
 /**
- * Structured data for error log messages.
- * Used by progressView formatters to display error details.
+ * @deprecated Use ErrorLogData from './schemas' instead.
+ * Kept for backward compatibility.
  */
-export interface ErrorLogData extends ProviderHttpErrorDetails {
-  /** Raw error message before formatting. */
-  rawMessage?: string;
-  /** The operation that failed. */
-  operation?: string;
-  /** The model being used. */
-  model?: string;
-}
+export type ErrorLogData = SchemaErrorLogData;
 
 /**
  * Builds consistent error data for logging with MESSAGE_TYPES.ERROR.
@@ -607,8 +580,8 @@ export interface ErrorLogData extends ProviderHttpErrorDetails {
  */
 export function buildErrorLogData(
   err: unknown,
-  context?: ErrorLogContext,
-): ErrorLogData {
+  context?: ErrorContext,
+): SchemaErrorLogData {
   const formatted = formatProviderHttpError(err);
   const rawMessage = toErrorMessage(err);
 

--- a/src/eventBus/types.ts
+++ b/src/eventBus/types.ts
@@ -4,6 +4,13 @@
 import { z } from 'zod';
 import { StreamTabIdSchema } from '@agent/types/IdentifierTypes';
 
+// Import canonical error schema - SINGLE SOURCE OF TRUTH
+// schemas.ts has no internal project imports, so no circular dependency risk
+import {
+  ProviderErrorPartialSchema,
+  type ProviderErrorPartial,
+} from '@common/errors/schemas';
+
 /** Tool edit approval request prompt */
 export const ToolEditApprovalPromptSchema = z.strictObject({
   requestId: z.string(),
@@ -20,17 +27,12 @@ export type ToolEditApprovalPrompt = z.infer<
   typeof ToolEditApprovalPromptSchema
 >;
 
-/** Manual retry request prompt */
-export const RetryErrorDetailsSchema = z.strictObject({
-  provider: z.string().optional(),
-  statusCode: z.int().optional(),
-  /** Whether the error is retryable (user can click retry button). */
-  retryable: z.boolean().optional(),
-  /** Whether the error originated from the relay service. */
-  isRelayError: z.boolean().optional(),
-  rawErrorBody: z.unknown().optional(),
-});
-export type RetryErrorDetails = z.infer<typeof RetryErrorDetailsSchema>;
+/**
+ * Error details for retry requests.
+ * Uses ProviderErrorPartialSchema from canonical source - all fields optional for transport.
+ */
+export const RetryErrorDetailsSchema = ProviderErrorPartialSchema;
+export type RetryErrorDetails = ProviderErrorPartial;
 
 export const RetryRequestPromptSchema = z.strictObject({
   streamId: StreamTabIdSchema,

--- a/src/eventBus/types.ts
+++ b/src/eventBus/types.ts
@@ -24,6 +24,10 @@ export type ToolEditApprovalPrompt = z.infer<
 export const RetryErrorDetailsSchema = z.strictObject({
   provider: z.string().optional(),
   statusCode: z.int().optional(),
+  /** Whether the error is retryable (user can click retry button). */
+  retryable: z.boolean().optional(),
+  /** Whether the error originated from the relay service. */
+  isRelayError: z.boolean().optional(),
   rawErrorBody: z.unknown().optional(),
 });
 export type RetryErrorDetails = z.infer<typeof RetryErrorDetailsSchema>;

--- a/src/logger/AgentLogger.ts
+++ b/src/logger/AgentLogger.ts
@@ -6,10 +6,8 @@ import { z } from 'zod';
 import type { ExtendedTokenUsageStats } from '@agent/types/UsageTypes';
 
 // Internal imports
-import {
-  buildErrorLogData,
-  type ErrorLogContext,
-} from '@common/errors/sdkErrorUtils';
+import { buildErrorLogData } from '@common/errors/sdkErrorUtils';
+import { type ErrorContext } from '@common/errors/schemas';
 import { sleep } from '@utils/core';
 import { SHORT_SLEEP_MS } from '@utils/config';
 import { bus } from '@eventBus/ProgressEventBus';
@@ -280,7 +278,7 @@ export class AgentLogger {
   logError(
     message: string,
     err: unknown,
-    context?: ErrorLogContext,
+    context?: ErrorContext,
     groupId?: string,
   ): void {
     const errorData = buildErrorLogData(err, context);
@@ -301,7 +299,7 @@ export class AgentLogger {
    */
   logProgress(
     message: string,
-    context?: ErrorLogContext,
+    context?: ErrorContext,
     groupId?: string,
   ): void {
     this.info(message, {

--- a/src/progressView/modules/formatters/logFormatters/messageFormatters.js
+++ b/src/progressView/modules/formatters/logFormatters/messageFormatters.js
@@ -87,17 +87,18 @@ export function formatProgressStatus(message) {
   return container;
 }
 
-// Error detail fields in display order
+// Error detail fields in display order (matches ProviderError schema)
 const ERROR_DETAIL_FIELDS = [
   'message',
   'operation',
   'model',
   'provider',
   'statusCode',
+  'statusText',
   'isRelayError',
   'retryable',
-  'rawMessage',
   'requestId',
+  'rawMessage',
   'rawErrorBody',
 ];
 

--- a/src/progressView/modules/formatters/logFormatters/messageFormatters.js
+++ b/src/progressView/modules/formatters/logFormatters/messageFormatters.js
@@ -115,9 +115,8 @@ export function formatError(message) {
 
   const structured = normalizedPayload.structured ?? {};
   const isRelayError = structured.isRelayError === true;
-  const retryable = structured.retryable === true;
 
-  // Build summary text with relay/retryable indicators
+  // Build summary text with relay indicator
   let summaryText =
     (normalizedPayload.decodedText || message.text || '').trim() ||
     'Error occurred';

--- a/src/progressView/modules/formatters/logFormatters/messageFormatters.js
+++ b/src/progressView/modules/formatters/logFormatters/messageFormatters.js
@@ -94,6 +94,7 @@ const ERROR_DETAIL_FIELDS = [
   'model',
   'provider',
   'statusCode',
+  'isRelayError',
   'retryable',
   'rawMessage',
   'requestId',
@@ -111,16 +112,30 @@ export function formatError(message) {
     new Date(timestamp ?? Date.now()),
   );
 
-  const summaryText =
+  const structured = normalizedPayload.structured ?? {};
+  const isRelayError = structured.isRelayError === true;
+  const retryable = structured.retryable === true;
+
+  // Build summary text with relay/retryable indicators
+  let summaryText =
+    (normalizedPayload.decodedText || message.text || '').trim() ||
+    'Error occurred';
+
+  // Add prefix indicator for relay errors
+  if (isRelayError) {
+    summaryText = `[Relay] ${summaryText}`;
+  }
+
+  // Store original text for duplicate detection (before relay prefix was added)
+  const originalSummaryText =
     (normalizedPayload.decodedText || message.text || '').trim() ||
     'Error occurred';
 
   // Build error details from structured data
-  const structured = normalizedPayload.structured ?? {};
   const detailLines = ERROR_DETAIL_FIELDS.filter((key) => {
     const value = structured[key];
-    // Skip null/undefined values and message if it duplicates summary
-    return value != null && !(key === 'message' && value === summaryText);
+    // Skip null/undefined values and message if it duplicates the original summary
+    return value != null && !(key === 'message' && value === originalSummaryText);
   }).map((key) => {
     const value = structured[key];
     // Format objects (like rawErrorBody) as indented JSON
@@ -150,6 +165,11 @@ export function formatError(message) {
 
   // Add error class to the banner
   bannerEntry.element.classList.add('banner-details--error');
+
+  // Add relay error class for distinct styling
+  if (isRelayError) {
+    bannerEntry.element.classList.add('banner-details--relay-error');
+  }
 
   // If there are no details, hide the copy button and make it non-expandable
   if (!detailText) {

--- a/src/progressView/modules/formatters/logFormatters/messageFormatters.js
+++ b/src/progressView/modules/formatters/logFormatters/messageFormatters.js
@@ -116,20 +116,13 @@ export function formatError(message) {
   const structured = normalizedPayload.structured ?? {};
   const isRelayError = structured.isRelayError === true;
 
-  // Build summary text with relay indicator
-  let summaryText =
-    (normalizedPayload.decodedText || message.text || '').trim() ||
-    'Error occurred';
-
-  // Add prefix indicator for relay errors
-  if (isRelayError) {
-    summaryText = `[Relay] ${summaryText}`;
-  }
-
-  // Store original text for duplicate detection (before relay prefix was added)
+  // Build summary text (used for display and duplicate detection)
   const originalSummaryText =
     (normalizedPayload.decodedText || message.text || '').trim() ||
     'Error occurred';
+  const summaryText = isRelayError
+    ? `[Relay] ${originalSummaryText}`
+    : originalSummaryText;
 
   // Build error details from structured data
   const detailLines = ERROR_DETAIL_FIELDS.filter((key) => {

--- a/src/progressView/modules/uiManagers/RetryRequests.js
+++ b/src/progressView/modules/uiManagers/RetryRequests.js
@@ -57,10 +57,19 @@ export class RetryRequests extends BaseUIRequestManager {
     const errorElem = element.querySelector('.retry-request__error');
     element.dataset.streamId = request.streamId || '';
 
+    // Check if this is a relay error
+    const isRelayError = request.errorDetails?.isRelayError === true;
+    const retryable = request.errorDetails?.retryable !== false; // Default to true for retry requests
+
+    // Update element class for styling
+    element.classList.toggle('retry-request--relay', isRelayError);
+
     if (operationElem) {
+      // Add [Relay] prefix for relay errors
+      const prefix = isRelayError ? '[Relay] ' : '';
       operationElem.textContent = request.operation
-        ? `Failed: ${request.operation}`
-        : 'Request failed';
+        ? `${prefix}Failed: ${request.operation}`
+        : `${prefix}Request failed`;
     }
 
     if (metaElem) {
@@ -68,6 +77,12 @@ export class RetryRequests extends BaseUIRequestManager {
       if (request.model) {
         parts.push(`Model: ${request.model}`);
       }
+      // Add source indicator
+      if (isRelayError) {
+        parts.push('Source: Relay');
+      }
+      // Add retryable status
+      parts.push(retryable ? 'Retryable: Yes' : 'Retryable: No');
       metaElem.textContent = parts.join(' \u2022 ');
     }
 
@@ -116,6 +131,16 @@ export class RetryRequests extends BaseUIRequestManager {
 
     if (details.statusCode != null) {
       lines.push(`statusCode: ${details.statusCode}`);
+    }
+
+    // Show relay error indicator prominently
+    if (details.isRelayError != null) {
+      lines.push(`isRelayError: ${details.isRelayError}`);
+    }
+
+    // Show retryable status
+    if (details.retryable != null) {
+      lines.push(`retryable: ${details.retryable}`);
     }
 
     if (details.rawErrorBody != null) {

--- a/src/progressView/modules/uiManagers/RetryRequests.js
+++ b/src/progressView/modules/uiManagers/RetryRequests.js
@@ -115,7 +115,8 @@ export class RetryRequests extends BaseUIRequestManager {
 
   /**
    * Formats error details into a displayable string.
-   * @param {Object|undefined} details - Error details object
+   * Uses all fields from ProviderError schema (single source of truth).
+   * @param {Object|undefined} details - Error details object (ProviderError)
    * @returns {string|null} Formatted details string, or null if no details
    */
   _formatErrorDetails(details) {
@@ -125,12 +126,17 @@ export class RetryRequests extends BaseUIRequestManager {
 
     const lines = [];
 
+    // Display fields in logical order matching ProviderError schema
     if (details.provider) {
       lines.push(`provider: ${details.provider}`);
     }
 
     if (details.statusCode != null) {
       lines.push(`statusCode: ${details.statusCode}`);
+    }
+
+    if (details.statusText) {
+      lines.push(`statusText: ${details.statusText}`);
     }
 
     // Show relay error indicator prominently
@@ -141,6 +147,11 @@ export class RetryRequests extends BaseUIRequestManager {
     // Show retryable status
     if (details.retryable != null) {
       lines.push(`retryable: ${details.retryable}`);
+    }
+
+    // Request ID for provider support debugging
+    if (details.requestId) {
+      lines.push(`requestId: ${details.requestId}`);
     }
 
     if (details.rawErrorBody != null) {

--- a/src/progressView/modules/uiManagers/RetryRequests.js
+++ b/src/progressView/modules/uiManagers/RetryRequests.js
@@ -127,6 +127,10 @@ export class RetryRequests extends BaseUIRequestManager {
     const lines = [];
 
     // Display fields in logical order matching ProviderError schema
+    if (details.message) {
+      lines.push(`message: ${details.message}`);
+    }
+
     if (details.provider) {
       lines.push(`provider: ${details.provider}`);
     }

--- a/src/progressView/styles/retry-requests.css
+++ b/src/progressView/styles/retry-requests.css
@@ -71,3 +71,19 @@
   max-height: 12em;
   overflow-y: auto;
 }
+
+/* Relay error styling - distinct visual indicator */
+.retry-request--relay .retry-request__operation {
+  color: var(--vscode-editorWarning-foreground, #ff8c00);
+}
+
+.retry-request--relay::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 3px;
+  background: var(--vscode-editorWarning-foreground, #ff8c00);
+  border-radius: var(--border-radius-small) 0 0 var(--border-radius-small);
+}

--- a/src/progressView/styles/scratchpad.css
+++ b/src/progressView/styles/scratchpad.css
@@ -62,6 +62,26 @@
   word-break: break-word;
 }
 
+/* Relay error styling - distinct orange/warning color to indicate relay origin */
+.banner-details--relay-error {
+  position: relative;
+}
+
+.banner-details--relay-error::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 3px;
+  background: var(--vscode-editorWarning-foreground, #ff8c00);
+  border-radius: var(--border-radius-small) 0 0 var(--border-radius-small);
+}
+
+.banner-details--relay-error > .details-summary .label {
+  color: var(--vscode-editorWarning-foreground, #ff8c00);
+}
+
 /* User feedback styling - distinct from errors */
 .tool-use-user-feedback > .details-summary .tool-use-title,
 .tool-use-user-feedback > .details-summary .codicon {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Centralizes error typing and improves user-facing clarity for provider/relay failures.
> 
> - **Canonical schemas**: Add `@common/errors/schemas` (`ProviderError`, `ErrorLogData`, `RetryErrorInfo`, etc.) and re-export via `@common/errors`; remove ad-hoc schemas from `RetryState`
> - **Structured formatting**: `formatProviderHttpError` now returns `ProviderError` with `statusText`, `isRelayError`, `requestId`, `rawErrorBody`; `buildErrorLogData` composes context
> - **Runtime integration**: Update `RetryState` to use canonical types, pass full formatted error to `logger` and retry coordinator; `CommonCycleTypes` uses `RetryErrorInfoSchema`
> - **Logger/Event bus**: `AgentLogger` now consumes `ErrorContext`; event bus `RetryErrorDetails` uses `ProviderErrorPartial`
> - **UI updates**: ProgressView error banners and Retry Requests display structured fields, prefix `[Relay]` for relay errors, and add distinct relay styling; CSS added/updated to reflect relay warnings
> - **Minor cleanups**: Import ordering and small refactors in `ResponseCycleFlow`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1b4484f0a27a946ca3b8001e8359b53904296b89. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->