### PR TITLE
Simplify and refine recently modified code

### DIFF
--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -736,12 +736,10 @@ export class ProgressEventHandler {
    * Returns undefined if category cannot be determined.
    */
   private getStreamCategory(stream: string): AgentCategory | undefined {
-    const taskState = this.state.getTaskState(stream);
-    if (taskState?.agentConfig?.session?.agentCategory) {
-      return taskState.agentConfig.session.agentCategory;
-    }
-    const hints = this.state.getStreamHints(stream);
-    return hints.sessionCategory;
+    return (
+      this.state.getTaskState(stream)?.agentConfig?.session?.agentCategory ??
+      this.state.getStreamHints(stream).sessionCategory
+    );
   }
 
   /**

--- a/src/progressView/managers/RunInstructionManager.ts
+++ b/src/progressView/managers/RunInstructionManager.ts
@@ -84,10 +84,10 @@ export class RunInstructionManager extends PersistentMapManager<
     return mapToRecord(value);
   }
 
-  protected override async deserialize(
+  protected override deserialize(
     data: unknown,
     _stream: StreamTabId,
-  ): Promise<InstructionMap> {
+  ): InstructionMap {
     return recordToMap<InstructionUpdate>(data);
   }
 }

--- a/src/progressView/managers/StreamTabsManager.ts
+++ b/src/progressView/managers/StreamTabsManager.ts
@@ -108,23 +108,14 @@ export class StreamTabsManager extends PersistentMapManager<
     }
   }
 
-  /** Serialize messages before saving */
-  protected override serialize(
-    value: LogMessageData[],
-    _key: StreamTabId,
-  ): unknown {
-    return value;
-  }
-
-  /** Normalize loaded messages */
-  protected override async deserialize(
+  /** Normalize loaded messages with shallow copies for independence */
+  protected override deserialize(
     data: unknown,
     _key: StreamTabId,
-  ): Promise<LogMessageData[]> {
+  ): LogMessageData[] {
     if (!Array.isArray(data)) {
       return [];
     }
-
     return data.map((entry) => ({ ...entry })) as LogMessageData[];
   }
 }

--- a/src/progressView/managers/TaskGroupManager.ts
+++ b/src/progressView/managers/TaskGroupManager.ts
@@ -85,21 +85,21 @@ export class TaskGroupManager extends PersistentMapManager<
     const affected: StreamTabId[] = [];
 
     for (const [streamId, groups] of this.items.entries()) {
-      const runningGroups = [...groups.values()].filter(
-        (g) => g.status === STREAM_STATUS.RUNNING,
-      );
-
-      if (runningGroups.length === 0) continue;
-
-      for (const group of runningGroups) {
-        group.status = STREAM_STATUS.ERROR;
-        group.endTime = now;
+      let count = 0;
+      for (const group of groups.values()) {
+        if (group.status === STREAM_STATUS.RUNNING) {
+          group.status = STREAM_STATUS.ERROR;
+          group.endTime = now;
+          count++;
+        }
       }
 
-      affected.push(streamId);
-      this.logger.debug(
-        `Marked ${runningGroups.length} running task groups in stream ${streamId} as ERROR after reload`,
-      );
+      if (count > 0) {
+        affected.push(streamId);
+        this.logger.debug(
+          `Marked ${count} running task groups in stream ${streamId} as ERROR after reload`,
+        );
+      }
     }
 
     if (affected.length > 0) {
@@ -143,10 +143,10 @@ export class TaskGroupManager extends PersistentMapManager<
   }
 
   /** Normalize loaded groups */
-  protected override async deserialize(
+  protected override deserialize(
     data: unknown,
     _key: StreamTabId,
-  ): Promise<Map<string, TaskGroup>> {
+  ): Map<string, TaskGroup> {
     return recordToMap<TaskGroup>(data);
   }
 }

--- a/src/progressView/managers/UsageStatsManager.ts
+++ b/src/progressView/managers/UsageStatsManager.ts
@@ -269,10 +269,7 @@ export class UsageStatsManager extends PersistentMapManager<
     return mapToRecord(value);
   }
 
-  protected override async deserialize(
-    data: unknown,
-    _key: StreamTabId,
-  ): Promise<RunUsageMap> {
+  protected override deserialize(data: unknown, _key: StreamTabId): RunUsageMap {
     return UsageDataSchema.parse(data);
   }
 }

--- a/src/progressView/modules/progressViewState.js
+++ b/src/progressView/modules/progressViewState.js
@@ -133,19 +133,9 @@ class RunScopedMap {
     this._data = new Map();
   }
 
-  /**
-   * Resolve stream and optionally validate runId.
-   * Returns null if validation fails.
-   */
-  _resolve(streamId, runId = null, requireRunId = false) {
-    const targetStream = this._resolveStreamId(streamId);
-    if (targetStream == null) return null;
-    if (requireRunId && !runId) return null;
-    return targetStream;
-  }
-
   set(streamId, runId, value) {
-    const stream = this._resolve(streamId, runId, true);
+    if (!runId) return;
+    const stream = this._resolveStreamId(streamId);
     if (!stream) return;
 
     let runs = this._data.get(stream);
@@ -162,7 +152,8 @@ class RunScopedMap {
   }
 
   delete(streamId, runId) {
-    const stream = this._resolve(streamId, runId, true);
+    if (!runId) return;
+    const stream = this._resolveStreamId(streamId);
     if (!stream) return;
 
     const runs = this._data.get(stream);
@@ -175,7 +166,7 @@ class RunScopedMap {
   }
 
   clearStream(streamId) {
-    const stream = this._resolve(streamId);
+    const stream = this._resolveStreamId(streamId);
     if (stream) this._data.delete(stream);
   }
 
@@ -184,7 +175,7 @@ class RunScopedMap {
   }
 
   getStreamMap(streamId) {
-    const stream = this._resolve(streamId);
+    const stream = this._resolveStreamId(streamId);
     return stream ? (this._data.get(stream) ?? null) : null;
   }
 
@@ -498,15 +489,12 @@ export class ProgressViewState {
 
   clearRunInstructions(streamId) {
     if (streamId != null) {
-      const targetStream = this._resolveStreamId(streamId);
-      if (targetStream != null) {
-        this.runInstructions.clearStream(targetStream);
-        this.clearPendingInstruction(targetStream);
-      }
-      return;
+      this.runInstructions.clearStream(streamId);
+      this.clearPendingInstruction(streamId);
+    } else {
+      this.runInstructions.clearAll();
+      this.clearAllPendingInstructions();
     }
-    this.runInstructions.clearAll();
-    this.clearAllPendingInstructions();
   }
 
   setRunFiles(streamId, runId, filesByRound) {
@@ -521,13 +509,10 @@ export class ProgressViewState {
 
   clearRunFiles(streamId) {
     if (streamId != null) {
-      const targetStream = this._resolveStreamId(streamId);
-      if (targetStream != null) {
-        this.runFiles.clearStream(targetStream);
-      }
-      return;
+      this.runFiles.clearStream(streamId);
+    } else {
+      this.runFiles.clearAll();
     }
-    this.runFiles.clearAll();
   }
 
   deleteRunFiles(streamId, runId) {
@@ -546,13 +531,10 @@ export class ProgressViewState {
 
   clearRunMissingOutputs(streamId) {
     if (streamId != null) {
-      const targetStream = this._resolveStreamId(streamId);
-      if (targetStream != null) {
-        this.runMissingOutputs.clearStream(targetStream);
-      }
-      return;
+      this.runMissingOutputs.clearStream(streamId);
+    } else {
+      this.runMissingOutputs.clearAll();
     }
-    this.runMissingOutputs.clearAll();
   }
 
   setRunUsage(streamId, runId, usage) {
@@ -584,12 +566,12 @@ export class ProgressViewState {
 
   clearRunUsage(streamId, runId) {
     if (runId) {
-      return this.runUsage.delete(streamId, runId);
+      this.runUsage.delete(streamId, runId);
+    } else if (streamId != null) {
+      this.runUsage.clearStream(streamId);
+    } else {
+      this.runUsage.clearAll();
     }
-    if (streamId != null) {
-      return this.runUsage.clearStream(streamId);
-    }
-    this.runUsage.clearAll();
   }
 
   /**

--- a/src/progressView/persistence/PersistentMapManager.ts
+++ b/src/progressView/persistence/PersistentMapManager.ts
@@ -75,7 +75,7 @@ export abstract class PersistentMapManager<K extends string, V> {
   }
 
   /** Deserialize a persisted value. Override for custom deserialization. */
-  protected async deserialize(data: unknown, _key: K): Promise<V> {
+  protected deserialize(data: unknown, _key: K): V | Promise<V> {
     return data as V;
   }
 
@@ -107,6 +107,7 @@ export abstract class PersistentMapManager<K extends string, V> {
   ): Promise<void> {
     const entries: [K, V][] = [];
     for (const [key, value] of Object.entries(record)) {
+      // await handles both sync and async deserialize implementations
       const deserialized = await this.deserialize(value, key as K);
       entries.push([key as K, deserialized]);
     }

--- a/src/progressView/state/ProgressViewState.ts
+++ b/src/progressView/state/ProgressViewState.ts
@@ -573,7 +573,7 @@ export class ProgressViewState {
    * Load all state from persistence
    */
   async load(): Promise<void> {
-    // Load basic state first
+    // Load basic state first (async managers)
     await Promise.all([
       this._streamTabs.load(),
       this._taskGroups.load(),
@@ -582,21 +582,19 @@ export class ProgressViewState {
       this._runInstructions.load(),
     ]);
 
-    // Load dependent state after basic state is loaded
-    await Promise.all([
-      this.loadActiveStream(), // Depends on stream tabs being loaded
-      this.loadTaskStates(),
-      this.loadExecutionIds(),
-      this.loadStreamSortOrder(),
-      this.loadAgentTypeFilter(),
-      this.loadActiveRunIds(),
-    ]);
+    // Load dependent state after basic state is loaded (synchronous operations)
+    this.loadActiveStream(); // Depends on stream tabs being loaded
+    this.loadTaskStates();
+    this.loadExecutionIds();
+    this.loadStreamSortOrder();
+    this.loadAgentTypeFilter();
+    this.loadActiveRunIds();
   }
 
   /**
    * Load active stream from persistence
    */
-  private async loadActiveStream(): Promise<void> {
+  private loadActiveStream(): void {
     const savedActiveStream = this.storage.get<string>(
       WorkspaceStateKey.ACTIVE_STREAM_TAB,
       '',
@@ -613,7 +611,7 @@ export class ProgressViewState {
    * Load task states from persistence.
    * Handles both current flat format and legacy workflow/toolUse format.
    */
-  private async loadTaskStates(): Promise<void> {
+  private loadTaskStates(): void {
     const raw = this.loadRecord(WorkspaceStateKey.TASK_STATES);
     this.taskStates.clear();
 
@@ -680,7 +678,7 @@ export class ProgressViewState {
   /**
    * Load execution IDs from persistence
    */
-  private async loadExecutionIds(): Promise<void> {
+  private loadExecutionIds(): void {
     const savedIdsRecord = this.loadRecord(WorkspaceStateKey.EXECUTION_IDS);
 
     const entries = Object.entries(savedIdsRecord).filter(
@@ -740,7 +738,7 @@ export class ProgressViewState {
     void this.storage.update(WorkspaceStateKey.EXECUTION_IDS, executionIdsObj);
   }
 
-  private async loadStreamSortOrder(): Promise<void> {
+  private loadStreamSortOrder(): void {
     const configDefault = getConfig(
       'texra.progressBoard.streamSortOrder',
       'time',
@@ -758,7 +756,7 @@ export class ProgressViewState {
     );
   }
 
-  private async loadAgentTypeFilter(): Promise<void> {
+  private loadAgentTypeFilter(): void {
     const savedFilter = this.storage.get<string>(
       WorkspaceStateKey.STREAM_AGENT_FILTER,
       'all',


### PR DESCRIPTION
- Remove unnecessary async from ProgressViewState load methods (loadActiveStream, loadTaskStates, loadExecutionIds, etc.)
- Simplify TaskGroupManager endRunningGroups to avoid double iteration
- Remove redundant _resolve helper in RunScopedMap (JS)
- Simplify clearRunFiles/clearRunMissingOutputs/clearRunUsage/clearRunInstructions by leveraging internal stream resolution in RunScopedMap
- Remove redundant serialize override in StreamTabsManager
- Update deserialize signatures from async to sync in all managers (StreamTabsManager, TaskGroupManager, RunInstructionManager, UsageStatsManager)
- Update PersistentMapManager base class to support both sync and async deserialize
- Simplify getStreamCategory in ProgressEventHandler

Net reduction: ~33 lines of code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reduces complexity and I/O by making dependent state loads synchronous and simplifying persistence APIs.
> 
> - Switch `deserialize` overrides to sync in `StreamTabsManager`, `TaskGroupManager`, `RunInstructionManager`, `UsageStatsManager`; base `PersistentMapManager.deserialize` now supports sync or async with unified awaiting in `populateFromRecord`
> - Simplify `ProgressViewState.load` follow-up steps to synchronous methods (`loadActiveStream`, `loadTaskStates`, `loadExecutionIds`, `loadStreamSortOrder`, `loadAgentTypeFilter`, `loadActiveRunIds`)
> - Remove redundant `serialize` override in `StreamTabsManager` and use shallow-copy normalization in `deserialize`
> - Simplify `TaskGroupManager.endRunningGroups` to single pass and consolidated logging/persisting
> - Collapse `RunScopedMap` `_resolve` helper and update callers: streamline `clearRunInstructions`, `clearRunFiles`, `clearRunMissingOutputs`, `clearRunUsage` logic in `progressViewState.js`
> - Simplify `getStreamCategory` in `ProgressEventHandler` to nullish-coalescing lookup
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0374d29eb8de83a15253e6d8481b79ed583f50f6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->