### PR TITLE
Hide GitHub login temporarily

### DIFF
--- a/package.json
+++ b/package.json
@@ -176,6 +176,12 @@
             "default": true,
             "description": "Show login banner prompting users to sign in for access to remote agents",
             "scope": "resource"
+          },
+          "texra.auth.enableVSCodeGitHub": {
+            "type": "boolean",
+            "default": false,
+            "description": "Enable VS Code native GitHub authentication (experimental)",
+            "scope": "resource"
           }
         }
       },

--- a/src/auth/authCommands.ts
+++ b/src/auth/authCommands.ts
@@ -37,6 +37,13 @@ type AuthMethod = OAuthProvider | 'github-browser' | 'email';
 /** Email login is disabled due to remote configuration issues */
 const EMAIL_LOGIN_ENABLED = false;
 
+/** Check if VS Code native GitHub auth is enabled via settings */
+function isVSCodeGitHubEnabled(): boolean {
+  return vscode.workspace
+    .getConfiguration('texra.auth')
+    .get('enableVSCodeGitHub', false);
+}
+
 /** Sign-in option shown to users */
 interface SignInOption {
   label: string;
@@ -67,12 +74,13 @@ function getSignInOptions(): SignInOption[] {
     });
   }
 
-  // VS Code GitHub auth is always last (fallback option)
-  options.push({
-    label: '$(github) GitHub (VS Code)',
-    description: 'Sign in using VS Code GitHub authentication',
-    method: 'github',
-  });
+  if (isVSCodeGitHubEnabled()) {
+    options.push({
+      label: '$(github) GitHub (VS Code)',
+      description: 'Sign in using VS Code GitHub authentication',
+      method: 'github',
+    });
+  }
 
   return options;
 }


### PR DESCRIPTION
The VS Code native GitHub authentication is not yet working, so hiding it behind a VS Code setting (texra.auth.enableVSCodeGitHub). Set to true in settings to test.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a feature flag to control exposure of VS Code's native GitHub authentication.
> 
> - Adds `texra.auth.enableVSCodeGitHub` setting in `package.json` (default: `false`)
> - Updates `authCommands.ts` to conditionally include the `"GitHub (VS Code)"` sign-in option based on `isVSCodeGitHubEnabled()`
> - No functional changes to other auth methods; email remains disabled
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9ff40db80b1673d30994aa5f741344ee0fd50202. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->