### PR TITLE
Simplify and improve code clarity

### DIFF
--- a/src/agent/implementations/flows/tooluse/ToolUseSessionTypes.ts
+++ b/src/agent/implementations/flows/tooluse/ToolUseSessionTypes.ts
@@ -21,6 +21,10 @@ import { AgentRunStateSnapshotSchema } from '@agent/core/AgentState';
 import { AgentWorkspaceStateSnapshotSchema } from '@agent/core/AgentWorkspaceState';
 import { UserVariableChannelsSchema } from '@agent/core/AgentCycleOptions';
 import { ProviderMessageSchema } from '@agent/modelHandlers/types/ProviderMessage';
+import {
+  ExecutionIdSchema,
+  StreamTabIdSchema,
+} from '@agent/types/IdentifierTypes';
 
 // ============================================================================
 // Snapshot Schema & Types
@@ -39,8 +43,8 @@ export const TOOL_USE_SNAPSHOT_VERSION = 2;
  */
 export const ToolUseSessionSnapshotSchema = z.object({
   version: z.literal(TOOL_USE_SNAPSHOT_VERSION),
-  executionId: z.string(),
-  streamId: z.string(),
+  executionId: ExecutionIdSchema,
+  streamId: StreamTabIdSchema,
   agentConfig: AgentConfigSchema,
   messages: z.array(ProviderMessageSchema),
   // State slices stored directly (no wrapper)

--- a/src/agent/runtime/StreamStatusService.ts
+++ b/src/agent/runtime/StreamStatusService.ts
@@ -113,4 +113,26 @@ export const StreamStatusService = {
   has(stream: StreamTabId): boolean {
     return statusMemory.has(stream);
   },
+
+  // ============================================================================
+  // Guard Helpers - Centralized status checks for consistency
+  // ============================================================================
+
+  /**
+   * Check if stream is actively processing (RUNNING or RESUMING).
+   * Use to guard against concurrent operations.
+   */
+  isActiveOrResuming(stream: StreamTabId): boolean {
+    const status = statusMemory.get(stream);
+    return status === STREAM_STATUS.RUNNING || status === STREAM_STATUS.RESUMING;
+  },
+
+  /**
+   * Check if stream status should be preserved on flow completion.
+   * WAITING and STOPPED states shouldn't be overwritten by flow end status.
+   */
+  shouldPreserveOnCompletion(stream: StreamTabId): boolean {
+    const status = statusMemory.get(stream);
+    return status === STREAM_STATUS.WAITING || status === STREAM_STATUS.STOPPED;
+  },
 };

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -439,16 +439,6 @@ function createUsageRecorder(
   };
 }
 
-/**
- * Setup UI state for flow execution.
- *
- * Sets the stream status to RUNNING. Note: setActiveStream is emitted
- * in resolveAgentBase BEFORE Init stage creation to ensure correct
- * ordering of task group events.
- */
-function setupFlowUIState(ctx: ResolvedAgentBase): void {
-  StreamStatusService.set(ctx.streamId, STREAM_STATUS.RUNNING);
-}
 
 type FlowRunner = () => Promise<EndGroupStatus>;
 
@@ -626,8 +616,8 @@ export async function executeAgent(
 
     const runStorage = getRunStorageService();
 
-    // Setup UI state
-    setupFlowUIState(ctx);
+    // Set stream status to running
+    StreamStatusService.set(ctx.streamId, STREAM_STATUS.RUNNING);
 
     logger.info(`Starting task execution for ${streamTabId}`);
     logger.info(`Input file: ${config.inputFile}`);
@@ -737,7 +727,7 @@ export async function executeMergeAgent(
   ensureSessionMetadata(config, preliminaryStreamId, 'Merge agent');
 
   await runFlowWithLifecycle(ctx, streamTabId, 'merge', async () => {
-    setupFlowUIState(ctx);
+    StreamStatusService.set(ctx.streamId, STREAM_STATUS.RUNNING);
 
     return logger.withScope(`Task: merge@${model}`, async () => {
       logger.info(`Executing merge with model ${model}`);
@@ -787,7 +777,6 @@ export async function resumeToolUseFromSnapshot(
   setupSession?: (session: IToolUseSession) => void,
 ): Promise<void> {
   const snapshotConfig = snapshot.agentConfig;
-  const executionId = snapshot.executionId as ExecutionId;
 
   // Resolve agent base with snapshot's stream ID for correct UI state
   // The streamTabIdOverride ensures ctx.streamId matches the snapshot
@@ -795,8 +784,8 @@ export async function resumeToolUseFromSnapshot(
   const ctx = await resolveAgentBase(
     snapshotConfig.agent,
     snapshotConfig,
-    executionId,
-    { streamTabIdOverride: snapshot.streamId as StreamTabId },
+    snapshot.executionId,
+    { streamTabIdOverride: snapshot.streamId },
   );
   const { setting, streamId: streamTabId, config } = ctx;
 
@@ -818,7 +807,7 @@ export async function resumeToolUseFromSnapshot(
     streamTabId,
     snapshotConfig.agent,
     async () => {
-      setupFlowUIState(ctx);
+      StreamStatusService.set(ctx.streamId, STREAM_STATUS.RUNNING);
 
       // Run the flow with resume snapshot
       const result = await runToolUseFlow(

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -452,15 +452,8 @@ async function runFlowWithLifecycle(
     const flowStatus = await runner();
     ctx.runStage.end(flowStatus);
 
-    // Update stream status, preserving WAITING and STOPPED states:
-    // - WAITING: tool-use flows awaiting follow-up
-    // - STOPPED: user explicitly stopped the agent (don't overwrite with ERROR)
-    const currentStatus = StreamStatusService.get(streamTabId);
-    const shouldPreserveStatus =
-      currentStatus === STREAM_STATUS.WAITING ||
-      currentStatus === STREAM_STATUS.STOPPED;
-
-    if (!shouldPreserveStatus) {
+    // Update stream status, preserving WAITING and STOPPED states
+    if (!StreamStatusService.shouldPreserveOnCompletion(streamTabId)) {
       const newStatus =
         flowStatus === 'error' ? STREAM_STATUS.ERROR : STREAM_STATUS.STOPPED;
       StreamStatusService.set(streamTabId, newStatus);

--- a/src/commands/agent/agentCommands.ts
+++ b/src/commands/agent/agentCommands.ts
@@ -4,6 +4,7 @@ import * as vscode from 'vscode';
 // Local imports - agent
 import { getInterruptible } from '@agent/toolUse/ToolUseAgentRegistry';
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
+import { STREAM_STATUS } from '@common/constants/streamStatus';
 import * as logger from '@logger/logUtils';
 
 const CHANNEL = 'AgentCommands';
@@ -24,5 +25,5 @@ async function handleStopAgent(stream: string): Promise<void> {
   }
 
   // Update the UI status
-  StreamStatusService.set(stream, 'stopped');
+  StreamStatusService.set(stream, STREAM_STATUS.STOPPED);
 }

--- a/src/commands/agent/followUpCommand.ts
+++ b/src/commands/agent/followUpCommand.ts
@@ -24,44 +24,39 @@ const inFlightDetections = new Set<StreamTabId>();
 /**
  * Lazily detect if a stream has a persisted flow record and set WAITING status.
  *
- * This enables lazy loading of session state - instead of checking all streams
- * at startup, we only check when the user actually sends a follow-up.
+ * Enables lazy loading - we only check for persisted flows when user sends a follow-up,
+ * avoiding startup iteration through all streams.
  *
  * @returns true if a persisted flow was detected and status was set to WAITING
  */
 async function lazyDetectWaitingStatus(
   streamId: StreamTabId,
 ): Promise<boolean> {
-  // Skip if status is already set (active, resuming, waiting, etc.)
+  // Skip if status already set or detection in progress
   const currentStatus = StreamStatusService.get(streamId);
   if (currentStatus) {
     return currentStatus === STREAM_STATUS.WAITING;
   }
-
-  // Skip if detection is already in progress for this stream
   if (inFlightDetections.has(streamId)) {
     return false;
   }
 
   // Get execution ID to check for persisted flow
-  const progressState = ProgressViewProvider.getInstance()?.state;
-  const executionId = progressState?.getExecutionId(streamId);
+  const executionId =
+    ProgressViewProvider.getInstance()?.state?.getExecutionId(streamId);
   if (!executionId) {
     return false;
   }
 
-  // Mark as in-flight to prevent duplicate checks
+  // Check for persisted flow (with in-flight guard)
   inFlightDetections.add(streamId);
   try {
-    // Check if a persisted flow record exists
     const hasFlow = await hasPersistedFlowRecord(executionId);
     if (hasFlow) {
-      // Set WAITING status so sendFollowUp will queue the message
       StreamStatusService.set(streamId, STREAM_STATUS.WAITING);
       logger.debug(`Lazy detected waiting session for stream: ${streamId}`);
-      return true;
     }
-    return false;
+    return hasFlow;
   } finally {
     inFlightDetections.delete(streamId);
   }
@@ -77,8 +72,7 @@ async function lazyDetectWaitingStatus(
  * @returns true if resume was triggered, false otherwise
  */
 async function tryAutoResume(streamId: StreamTabId): Promise<boolean> {
-  // Guard against concurrent resume attempts.
-  // If already resuming or running, don't trigger another resume.
+  // Guard against concurrent resume attempts
   const currentStatus = StreamStatusService.get(streamId);
   if (
     currentStatus === STREAM_STATUS.RESUMING ||
@@ -90,24 +84,18 @@ async function tryAutoResume(streamId: StreamTabId): Promise<boolean> {
     return false;
   }
 
-  // Use ProgressViewState for task state and execution ID access.
-  // This handles legacy storage structure (workflow/toolUse buckets) and
-  // provides already-validated task states, avoiding parallel access patterns.
+  // Get state dependencies - ProgressViewState handles legacy storage structure
   const progressState = ProgressViewProvider.getInstance()?.state;
-  if (!progressState) {
-    logger.warn(`ProgressViewProvider not available for stream: ${streamId}`);
-    return false;
-  }
+  const executionId = progressState?.getExecutionId(streamId);
+  const taskState = progressState?.getTaskState(streamId);
 
-  const executionId = progressState.getExecutionId(streamId);
-  if (!executionId) {
-    logger.warn(`No execution ID found for stream: ${streamId}`);
-    return false;
-  }
-
-  const taskState = progressState.getTaskState(streamId);
-  if (!taskState) {
-    logger.warn(`No task state found for stream: ${streamId}`);
+  if (!progressState || !executionId || !taskState) {
+    const missing = !progressState
+      ? 'ProgressViewProvider'
+      : !executionId
+        ? 'execution ID'
+        : 'task state';
+    logger.warn(`No ${missing} found for stream: ${streamId}`);
     return false;
   }
 
@@ -117,39 +105,29 @@ async function tryAutoResume(streamId: StreamTabId): Promise<boolean> {
     executionId,
     taskState,
   );
-
   if (!resumeData) {
-    // retrieveSessionResumeData logs specific failure reason
     return false;
   }
 
-  // Trigger resume based on session type.
-  // Note: Tool-use and workflow have different resume semantics:
-  // - Tool-use: resumeAgent returns { success: boolean } for explicit result checking
-  // - Workflow: execute returns void and throws on failure (async fire-and-forget)
+  // Trigger resume based on session type
   logger.info(
     `Auto-resuming ${resumeData.type} session for stream: ${streamId}`,
   );
   try {
     if (resumeData.type === 'toolUse') {
-      // Tool-use: pass snapshot to resumeAgent command, validate result with schema
       const rawResult = await vscode.commands.executeCommand(
         'texra.resumeAgent',
-        {
-          snapshot: resumeData.snapshot,
-        },
+        { snapshot: resumeData.snapshot },
       );
       const parseResult = ResumeAgentResultSchema.safeParse(rawResult);
       return parseResult.success && parseResult.data.success;
-    } else {
-      // Workflow: pass config and executionId to execute command.
-      // Execute returns void - success if no exception thrown.
-      await vscode.commands.executeCommand('texra.execute', {
-        config: resumeData.agentConfig,
-        executionId: resumeData.executionId,
-      });
-      return true;
     }
+    // Workflow: execute returns void - success if no exception thrown
+    await vscode.commands.executeCommand('texra.execute', {
+      config: resumeData.agentConfig,
+      executionId: resumeData.executionId,
+    });
+    return true;
   } catch (error) {
     logger.error(`Failed to execute resume command for stream: ${streamId}`, {
       data: error,

--- a/src/commands/agent/followUpCommand.ts
+++ b/src/commands/agent/followUpCommand.ts
@@ -73,14 +73,8 @@ async function lazyDetectWaitingStatus(
  */
 async function tryAutoResume(streamId: StreamTabId): Promise<boolean> {
   // Guard against concurrent resume attempts
-  const currentStatus = StreamStatusService.get(streamId);
-  if (
-    currentStatus === STREAM_STATUS.RESUMING ||
-    currentStatus === STREAM_STATUS.RUNNING
-  ) {
-    logger.debug(
-      `Stream ${streamId} already ${currentStatus}, skipping auto-resume`,
-    );
+  if (StreamStatusService.isActiveOrResuming(streamId)) {
+    logger.debug(`Stream ${streamId} is active/resuming, skipping auto-resume`);
     return false;
   }
 

--- a/src/commands/agent/resumeCommand.ts
+++ b/src/commands/agent/resumeCommand.ts
@@ -13,7 +13,6 @@ import { z } from 'zod';
 import { resumeToolUseFromSnapshot } from '@agent/runtime/executeAgent';
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
-import type { StreamTabId } from '@agent/types/IdentifierTypes';
 import type { ToolUseSessionSnapshot } from '@agent/implementations/flows/tooluse/ToolUseSessionTypes';
 import { STREAM_STATUS } from '@common/constants/streamStatus';
 import { logErrorMessage } from '@common/errors/errorHandlingUtils';
@@ -62,7 +61,7 @@ async function resumeFromSnapshot(
     return { success: false };
   }
 
-  const streamId = snapshot.streamId as StreamTabId;
+  const { streamId } = snapshot;
   const existingStatus = StreamStatusService.get(streamId);
 
   if (

--- a/src/commands/agent/resumeCommand.ts
+++ b/src/commands/agent/resumeCommand.ts
@@ -62,12 +62,9 @@ async function resumeFromSnapshot(
   }
 
   const { streamId } = snapshot;
-  const existingStatus = StreamStatusService.get(streamId);
 
-  if (
-    existingStatus === STREAM_STATUS.RUNNING ||
-    existingStatus === STREAM_STATUS.RESUMING
-  ) {
+  // Guard against concurrent resume attempts
+  if (StreamStatusService.isActiveOrResuming(streamId)) {
     return { success: false };
   }
 


### PR DESCRIPTION
Key changes:
- Inline setupFlowUIState one-liner wrapper (executeAgent.ts)
- Use branded ID types in ToolUseSessionSnapshotSchema to eliminate redundant type casts at call sites
- Consolidate null checks in tryAutoResume with unified error logging
- Simplify lazyDetectWaitingStatus control flow
- Remove unnecessary StreamTabId import from resumeCommand.ts

These changes reduce code complexity while maintaining functionality.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Focuses on simplifying status management and typing while preserving behavior.
> 
> - Add guard helpers to `StreamStatusService`: `isActiveOrResuming` and `shouldPreserveOnCompletion`; use them in flow completion and auto-resume checks
> - Update `ToolUseSessionSnapshotSchema` to use branded `ExecutionIdSchema` and `StreamTabIdSchema` (removes call-site casts)
> - Inline the former `setupFlowUIState` by setting `STREAM_STATUS.RUNNING` directly in `executeAgent`, merge execution, and resume paths
> - Simplify `followUpCommand`: streamline `lazyDetectWaitingStatus`, consolidate null checks in `tryAutoResume`, and simplify command invocations
> - Tidy `resumeCommand`: use centralized guard, drop redundant casts, and keep queued follow-up handling
> - Use `STREAM_STATUS.STOPPED` constant in `agentCommands`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8f83f8347bace74e5c094a4f48bf3e00daa3a7a5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->