### PR TITLE
Debug and identify root cause issue

### DIFF
--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -34,8 +34,9 @@ export class BashTool extends defineTool({
         output: result.stdout || '',
       };
     }
-    throw new ToolError(
-      `Bash command failed: ${result.stderr || 'No error output available'}`,
-    );
+    // Many CLI tools (including latexmk) write errors to stdout, not stderr
+    const outputs = [result.stderr, result.stdout].filter(Boolean);
+    const errorOutput = outputs.join('\n') || 'No error output available';
+    throw new ToolError(`Bash command failed: ${errorOutput}`);
   }
 }


### PR DESCRIPTION
Many CLI tools (including latexmk) write error output to stdout rather than stderr. Previously, failed commands would show "No error output available" when stderr was empty, hiding the actual error information.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves `bash` tool failure handling to expose actual error output.
> 
> - On command failure, error message now concatenates `stderr` and `stdout` instead of relying solely on `stderr`
> - Success path and command preview/truncation behavior unchanged
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 59dc5c58b545bcbcf202449deb030d5821e44ce2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->