### PR TITLE
Simplify and improve code clarity

### DIFF
--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -224,16 +224,6 @@ export class ProgressViewProvider
    * @param options.forceRebuild - Force full DOM rebuild in frontend
    */
   public updateWebview(options?: { forceRebuild?: boolean }): void {
-    // DIAGNOSTIC: Track updateWebview calls
-    const stack = new Error().stack
-      ?.split('\n')
-      .slice(2, 5)
-      .map((s) => s.trim())
-      .join(' <- ');
-    this.logger.debug(
-      `[updateWebview] forceRebuild=${options?.forceRebuild}, caller: ${stack}`,
-    );
-
     if (!this._view && !this._panelView) return;
 
     if (!this.isAnyViewReady()) {
@@ -284,11 +274,6 @@ export class ProgressViewProvider
     } else {
       this._sidebarReady = true;
     }
-
-    // DIAGNOSTIC: Log reload flow
-    this.logger.debug(
-      `[markWebviewReady] activeStream="${this.state.activeStream}", streamTabs=${this.state.streamTabs.keys().length}`,
-    );
 
     // Clear pending options - we always force rebuild on first load anyway,
     // and that takes precedence over any pending options.

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -20,6 +20,7 @@ import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
 import { bus } from '@eventBus/ProgressEventBus';
 
 // Local file imports - domain event handlers
+import { canUpdateWebview, type EventHandlerContext } from './EventHandlerContext';
 import { registerLogEventHandlers } from './LogEventHandlers';
 import { registerOutputEventHandlers } from './OutputEventHandlers';
 import { registerUsageEventHandlers } from './UsageEventHandlers';
@@ -44,23 +45,16 @@ export class ProgressEventHandler {
    */
   private readonly pendingTaskGroups = new Map<string, TaskGroup[]>();
 
+  /** Shared context for domain handlers - used for canUpdateWebview checks */
+  private readonly ctx: EventHandlerContext;
+
   constructor(
     private state: ProgressViewState,
     private webviewUpdater: WebviewUpdater,
     private readonly uiCallbacks: UICallbacks,
   ) {
     this.logger = new AgentLogger('ProgressEventHandler');
-  }
-
-  /**
-   * Check if webview is available and the stream is active.
-   * Common guard condition for event handlers that should only update
-   * the webview when it's visible and showing the relevant stream.
-   */
-  private canUpdateWebview(stream: StreamTabId): boolean {
-    return (
-      this.webviewUpdater.isAvailable() && stream === this.state.activeStream
-    );
+    this.ctx = { state: this.state, webviewUpdater: this.webviewUpdater };
   }
 
   /**
@@ -95,9 +89,6 @@ export class ProgressEventHandler {
     const controller = new AbortController();
     const { signal } = controller;
 
-    // Build shared context for domain handlers
-    const ctx = { state: this.state, webviewUpdater: this.webviewUpdater };
-
     // Core stream/task events (handled inline - stream lifecycle)
     bus.on('setActiveStream', this.handleSetActiveStream, { signal });
     bus.on('updateStreamStatus', this.handleUpdateStreamStatus, { signal });
@@ -109,10 +100,10 @@ export class ProgressEventHandler {
     });
 
     // Domain-specific event handlers (modular, focused files)
-    registerLogEventHandlers(bus, ctx, signal);
-    registerOutputEventHandlers(bus, ctx, signal);
-    registerUsageEventHandlers(bus, ctx, signal);
-    registerTodoEventHandlers(bus, ctx, signal);
+    registerLogEventHandlers(bus, this.ctx, signal);
+    registerOutputEventHandlers(bus, this.ctx, signal);
+    registerUsageEventHandlers(bus, this.ctx, signal);
+    registerTodoEventHandlers(bus, this.ctx, signal);
     registerUIEvents(bus, this.uiCallbacks, signal);
 
     // Single disposable that cleans up everything
@@ -276,7 +267,7 @@ export class ProgressEventHandler {
       async () => {
         await this.state.taskGroups.updateGroup(data);
 
-        if (this.canUpdateWebview(data.stream)) {
+        if (canUpdateWebview(this.ctx, data.stream)) {
           this.webviewUpdater.updateTaskGroup(data);
         }
       },
@@ -605,12 +596,7 @@ export class ProgressEventHandler {
     this.state.updateStreamHints(stream, {
       sessionCategory: AgentCategory.Workflow,
     });
-
-    const currentFilter = this.state.agentTypeFilter;
-    if (currentFilter !== 'all' && currentFilter !== AgentCategory.Workflow) {
-      this.state.agentTypeFilter = AgentCategory.Workflow;
-    }
-
+    this.maybeUpdateFilterForCategory(AgentCategory.Workflow);
     this.state.activeStream = stream;
 
     if (this.webviewUpdater.isAvailable()) {

--- a/src/progressView/managers/WebviewUpdater.ts
+++ b/src/progressView/managers/WebviewUpdater.ts
@@ -9,7 +9,6 @@ import type { TokenUsageStats } from '@agent/types/UsageTypes';
 import type { StreamStatus } from '@common/constants/streamStatus';
 import type { LogMessageData } from '@logger/LogTypes';
 import type { TaskState } from '@logger/TaskState';
-import { AgentLogger } from '@logger/AgentLogger';
 import type { InstructionUpdate, StreamTabInfo } from '@progressView/types';
 
 // Internal imports
@@ -29,11 +28,7 @@ import type { TodoItem, UpdateTaskGroupPayload } from '@eventBus/schemas';
  * Supports multiple webviews (e.g., sidebar + editor tab panel).
  */
 export class WebviewUpdater {
-  private readonly logger: AgentLogger;
-
-  constructor(private getWebviews: () => (vscode.Webview | undefined)[]) {
-    this.logger = new AgentLogger('WebviewUpdater');
-  }
+  constructor(private getWebviews: () => (vscode.Webview | undefined)[]) {}
 
   /** Helper to send messages to all registered webviews */
   private sendMessage(message: any): void {
@@ -65,10 +60,6 @@ export class WebviewUpdater {
     activeStream: StreamTabId,
     agentFilter: AgentTypeFilter,
   ): void {
-    // DIAGNOSTIC: Log what we're sending to track reload issues
-    this.logger.debug(
-      `[UPDATE_STREAMS] sending: activeStream="${activeStream}", streams=${streams.length}, filter=${agentFilter}`,
-    );
     this.sendMessage({
       command: COMMANDS.UPDATE_STREAMS,
       streams,
@@ -109,10 +100,6 @@ export class WebviewUpdater {
     },
     action: 'render' | 'clear' = 'render',
   ): void {
-    // DIAGNOSTIC: Log what we're sending to track reload issues
-    this.logger.debug(
-      `[UPDATE_LOGS] sending: stream="${stream}", messages=${messages.length}, groups=${groups.length}, action=${action}`,
-    );
     this.sendMessage({
       command: COMMANDS.UPDATE_LOGS,
       stream,
@@ -396,10 +383,6 @@ export class WebviewUpdater {
     }
 
     this.updateStreams(streams, activeStream, state.agentTypeFilter);
-
-    this.logger.debug(
-      `Updated webview streams (${streams.length}) active: ${activeStream}`,
-    );
 
     return activeStream;
   }


### PR DESCRIPTION
- Consolidate canUpdateWebview guards: remove duplicate private method from ProgressEventHandler, use shared helper from EventHandlerContext
- Store ctx as instance property for consistent access across handlers
- Simplify filter mutation: use maybeUpdateFilterForCategory in initializeStreamForTaskGroup instead of inline conditional
- Remove DIAGNOSTIC logging from ProgressViewProvider and WebviewUpdater
- Remove unused logger from WebviewUpdater class

This reduces code duplication and improves separation of concerns by centralizing the webview availability guard logic.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Streamlines progress view event/webview coordination and removes noisy diagnostics.
> 
> - Centralizes `canUpdateWebview` by importing from `EventHandlerContext` and storing shared `ctx` on `ProgressEventHandler`; updates handlers to use it
> - Simplifies agent filter updates with `maybeUpdateFilterForCategory` (used in `initializeStreamForTaskGroup` and relevant handlers)
> - Removes DIAGNOSTIC logging from `ProgressViewProvider.updateWebview` and `markWebviewReady`, and from multiple `WebviewUpdater` methods; drops unused logger from `WebviewUpdater`
> - Minor orchestration tweaks: consistent `updateAll` + `refreshStreamSurface` flow and buffered task-group replay without altering behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d3f043615c372613d404c0a78b55b459327f61e6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->