### PR TITLE
Fix queue display and model sending

### DIFF
--- a/src/agent/implementations/flows/tooluse/ToolUseSessionLifecycle.ts
+++ b/src/agent/implementations/flows/tooluse/ToolUseSessionLifecycle.ts
@@ -66,7 +66,8 @@ export class ToolUseSessionLifecycle implements IToolUseSession {
   async waitForFollowUp(
     checkInterruption: () => boolean,
   ): Promise<string | null> {
-    return this.followUps.waitForNext(checkInterruption);
+    // Wait for at least one message, then combine all queued messages
+    return this.followUps.waitAndDrainAll(checkInterruption);
   }
 
   async enterWaitingState(): Promise<void> {

--- a/src/agent/toolUse/FollowUpQueue.ts
+++ b/src/agent/toolUse/FollowUpQueue.ts
@@ -47,6 +47,25 @@ export class FollowUpQueue {
     });
   }
 
+  /**
+   * Wait for at least one message, then drain and combine all available.
+   * Returns all queued messages joined with double newlines.
+   */
+  async waitAndDrainAll(
+    checkInterruption: () => boolean,
+  ): Promise<string | null> {
+    const first = await this.waitForNext(checkInterruption);
+    if (first === null) {
+      return null;
+    }
+    // Drain any additional messages that arrived while waiting
+    const rest = this.drain();
+    if (rest.length === 0) {
+      return first;
+    }
+    return [first, ...rest].join('\n\n');
+  }
+
   cancelWait(): void {
     this.resolveWait(null);
   }

--- a/src/progressView/modules/uiManagers/QueuedFollowUps.js
+++ b/src/progressView/modules/uiManagers/QueuedFollowUps.js
@@ -58,7 +58,7 @@ export class QueuedFollowUps {
 
     // Update the title to show count
     const count = this._currentMessages.length;
-    const suffix = count === 1 ? '' : ` (${count} combined)`;
+    const suffix = count === 1 ? '' : ` (${count} pending)`;
     elements.container.setAttribute('title', `Queued Message${suffix}`);
 
     // Clear and show single combined message


### PR DESCRIPTION
When multiple follow-up messages are queued while waiting for user interaction, they are now combined into a single message (joined with double newlines) before being sent to the model.

Previously, queued messages were processed one at a time even when multiple were waiting. The new waitAndDrainAll method waits for the first message, then drains and combines any additional queued messages.

Also updated UI label from "combined" to "pending" for clarity.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Batches follow-up messages so multiple queued inputs are sent together instead of one-by-one.
> 
> - Replace `waitForFollowUp` behavior to use `FollowUpQueue.waitAndDrainAll`, concatenating messages with double newlines
> - Add `waitAndDrainAll` to `FollowUpQueue` to wait for the first item, drain the rest, and join them
> - Update progress view `QueuedFollowUps` title from "combined" to "pending" and render a single combined preview
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0d9dcc8d1fe163405f2f77d0baa5aa4c0383935a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->