### PR TITLE
Simplify and improve code clarity

### DIFF
--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -406,10 +406,7 @@ class ToolUseProcessNode<C> extends BaseNode<
 
     if (!useStreaming) {
       for (const searchResult of serverToolData.webSearchResults) {
-        services.logger.info('', {
-          messageType: MESSAGE_TYPES.WEB_SEARCH,
-          data: searchResult,
-        });
+        services.logger.logWebSearch(searchResult);
       }
     }
 
@@ -710,10 +707,7 @@ class ToolUseDispatchNode<C> extends BaseNode<
       ...(editedFiles.length > 0 && { files: editedFiles }),
       isError: Boolean(result.isError),
     };
-    options.logger.info('', {
-      messageType: MESSAGE_TYPES.TOOL_USE,
-      data: toolUseLog,
-    });
+    options.logger.logToolUse(toolUseLog);
 
     const mediaLocations = await this.collectValidMediaLocations(
       result.files,

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -654,7 +654,7 @@ class ToolUseDispatchNode<C> extends BaseNode<
           {
             tracker,
             todoState,
-            streamId: options.logger.channelId,
+            streamId: options.logger.streamId,
             executionId: options.executionId,
             toolCallId: call.callId,
           },

--- a/src/agent/implementations/flows/reflection/runReflectionFlow.ts
+++ b/src/agent/implementations/flows/reflection/runReflectionFlow.ts
@@ -234,7 +234,6 @@ export async function runReflectionFlow<C = unknown>(
   const outputHandler: IOutputHandler = new OutputHandler(
     setting,
     config,
-    0, // logId
     baseFiles,
     logger,
     fileService,

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -213,10 +213,7 @@ export abstract class ModelHandler<
     if (!this.progressViewEnabled) {
       return;
     }
-    this.logger.info('', {
-      messageType: MESSAGE_TYPES.WEB_SEARCH,
-      data: result,
-    });
+    this.logger.logWebSearch(result);
   }
 
   /**

--- a/src/agent/modelHandlers/support/AnthropicStreamHandler.ts
+++ b/src/agent/modelHandlers/support/AnthropicStreamHandler.ts
@@ -352,9 +352,6 @@ export class AnthropicStreamHandler {
     if (!this.config.progressViewEnabled) {
       return;
     }
-    this.logger.info('', {
-      messageType: MESSAGE_TYPES.WEB_SEARCH,
-      data: result,
-    });
+    this.logger.logWebSearch(result);
   }
 }

--- a/src/agent/output/OutputHandler.ts
+++ b/src/agent/output/OutputHandler.ts
@@ -44,7 +44,6 @@ interface RoundData {
 export class OutputHandler implements IOutputHandler {
   public agentSetting: AgentWorkflowSetting;
   public agentConfig: AgentConfig;
-  public logId: number;
   private rounds: Map<number, RoundData>;
 
   public get outputFiles(): { [key: number]: OutputFileInfo[] } {
@@ -70,7 +69,6 @@ export class OutputHandler implements IOutputHandler {
   constructor(
     agentSetting: AgentSetting,
     agentConfig: AgentConfig,
-    logId: number,
     baseFiles: FileLocation[],
     logger: AgentLogger,
     fileService: TaskRunFileService,
@@ -78,11 +76,10 @@ export class OutputHandler implements IOutputHandler {
   ) {
     this.agentSetting = requireWorkflowSetting(agentSetting);
     this.agentConfig = agentConfig;
-    this.logId = logId;
     this.rounds = new Map();
     this.baseFiles = baseFiles;
     this.logger = logger;
-    this.channel = this.logger.channelId;
+    this.channel = this.logger.streamId;
     this.fileService = fileService;
     this.executionId = executionId;
 

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -653,7 +653,8 @@ export async function executeAgent(
     }
 
     // Execute the appropriate flow based on agent type
-    return logger.withScope(`Task: ${agentName}@${config.model}`, async () => {
+    const taskStage = await logger.stage(`Task: ${agentName}@${config.model}`);
+    return taskStage.run(async () => {
       logger.info(`Executing ${agentName} with model ${config.model}`);
 
       const interruptManager = new InterruptManager();
@@ -728,7 +729,8 @@ export async function executeMergeAgent(
   await runFlowWithLifecycle(ctx, streamTabId, 'merge', async () => {
     StreamStatusService.set(ctx.streamId, STREAM_STATUS.RUNNING);
 
-    return logger.withScope(`Task: merge@${model}`, async () => {
+    const taskStage = await logger.stage(`Task: merge@${model}`);
+    return taskStage.run(async () => {
       logger.info(`Executing merge with model ${model}`);
 
       const interruptManager = new InterruptManager();

--- a/src/common/managers/RecordingManager.ts
+++ b/src/common/managers/RecordingManager.ts
@@ -49,9 +49,9 @@ export class RecordingManager {
         this.notifyError(webviewView.webview, result.error);
       }
     } catch (error) {
-      const message = `Error starting recording: ${toErrorMessage(error)}`;
-      logger.error(CHANNEL, message);
-      this.notifyError(webviewView.webview, message);
+      const errorMsg = toErrorMessage(error);
+      logger.error(CHANNEL, `Error starting recording: ${errorMsg}`);
+      this.notifyError(webviewView.webview, errorMsg);
     }
   }
 
@@ -89,9 +89,9 @@ export class RecordingManager {
         },
       );
     } catch (error) {
-      const message = `Error stopping recording: ${toErrorMessage(error)}`;
-      logger.error(CHANNEL, message);
-      this.notifyError(webviewView.webview, message);
+      const errorMsg = toErrorMessage(error);
+      logger.error(CHANNEL, `Error stopping recording: ${errorMsg}`);
+      this.notifyError(webviewView.webview, errorMsg);
       acknowledgeStop();
     }
   }

--- a/src/common/managers/RecordingManager.ts
+++ b/src/common/managers/RecordingManager.ts
@@ -28,14 +28,8 @@ export class RecordingManager {
     private readonly commandConfig: RecordingManagerConfig,
   ) {}
 
-  private handleError(
-    webview: vscode.Webview,
-    error: unknown,
-    operation: string,
-  ): void {
-    const message = toErrorMessage(error);
-    vscode.window.showErrorMessage(`Error ${operation}: ${message}`);
-    logger.error(CHANNEL, `Error in ${operation}: ${message}`);
+  private notifyError(webview: vscode.Webview, message: string): void {
+    vscode.window.showErrorMessage(message);
     webview.postMessage({
       command: this.commandConfig.recordingErrorCommand,
       error: message,
@@ -52,14 +46,12 @@ export class RecordingManager {
           command: this.commandConfig.recordingStartedCommand,
         });
       } else if (result.error) {
-        vscode.window.showErrorMessage(result.error);
-        webviewView.webview.postMessage({
-          command: this.commandConfig.recordingErrorCommand,
-          error: result.error,
-        });
+        this.notifyError(webviewView.webview, result.error);
       }
     } catch (error) {
-      this.handleError(webviewView.webview, error, 'starting recording');
+      const message = `Error starting recording: ${toErrorMessage(error)}`;
+      logger.error(CHANNEL, message);
+      this.notifyError(webviewView.webview, message);
     }
   }
 
@@ -67,10 +59,8 @@ export class RecordingManager {
     webviewView: vscode.WebviewView | vscode.WebviewPanel,
   ): Promise<void> {
     let stopAcknowledged = false;
-    const acknowledgeStop = () => {
-      if (stopAcknowledged) {
-        return;
-      }
+    const acknowledgeStop = (): void => {
+      if (stopAcknowledged) return;
       stopAcknowledged = true;
       webviewView.webview.postMessage({
         command: this.commandConfig.recordingStoppedCommand,
@@ -94,16 +84,14 @@ export class RecordingManager {
               text: result.text,
             });
           } else if (result.error) {
-            vscode.window.showErrorMessage(result.error);
-            webviewView.webview.postMessage({
-              command: this.commandConfig.recordingErrorCommand,
-              error: result.error,
-            });
+            this.notifyError(webviewView.webview, result.error);
           }
         },
       );
     } catch (error) {
-      this.handleError(webviewView.webview, error, 'stopping recording');
+      const message = `Error stopping recording: ${toErrorMessage(error)}`;
+      logger.error(CHANNEL, message);
+      this.notifyError(webviewView.webview, message);
       acknowledgeStop();
     }
   }

--- a/src/logger/AgentLogger.ts
+++ b/src/logger/AgentLogger.ts
@@ -225,11 +225,12 @@ export class AgentLogger {
   public readonly isAgentLogger: boolean;
 
   constructor(
-    public channelId: string,
+    /** The stream identifier used for routing log messages. */
+    public readonly streamId: string,
     isAgentLogger = false,
   ) {
     this.isAgentLogger = isAgentLogger;
-    logger.initialize(this.channelId, this.isAgentLogger);
+    logger.initialize(this.streamId, this.isAgentLogger);
   }
 
   /** Internal helper to log at any level with consistent options handling. */
@@ -238,7 +239,7 @@ export class AgentLogger {
     message: string,
     options: LogOptions = {},
   ): void {
-    logger[level](this.channelId, message, {
+    logger[level](this.streamId, message, {
       groupId: options.groupId ?? this.resolveActiveGroupId(),
       messageType: options.messageType,
       isAgent: this.isAgentLogger,
@@ -526,7 +527,7 @@ export class AgentLogger {
     }
 
     return logger.runWithGroupContext(
-      this.channelId,
+      this.streamId,
       groupId,
       this.isAgentLogger,
       fn,
@@ -589,7 +590,7 @@ export class AgentLogger {
     type: MessageType,
     options: AgentLogStreamOptions = {},
   ): AgentLogStream {
-    const streamId = this.channelId;
+    const emitStreamId = this.streamId;
     const id = randomUUID();
     let buffer = '';
     let isFirstUpdate = true;
@@ -607,7 +608,7 @@ export class AgentLogger {
     const emitMessage = (isNew: boolean, text: string): void => {
       if (isNew) {
         bus.emit('addLogMessage', {
-          stream: streamId,
+          stream: emitStreamId,
           logMessage: {
             id,
             text,
@@ -620,7 +621,7 @@ export class AgentLogger {
         });
       } else {
         bus.emit('updateLogMessage', {
-          stream: streamId,
+          stream: emitStreamId,
           logMessage: { id, text, groupId, messageType: type },
         });
       }
@@ -655,7 +656,7 @@ export class AgentLogger {
   ): Promise<string> {
     await sleep(SHORT_SLEEP_MS);
     return logger.startGroup(
-      this.channelId,
+      this.streamId,
       groupName,
       id,
       parentGroupId,
@@ -667,10 +668,10 @@ export class AgentLogger {
     groupId: string,
     status: EndGroupStatus = END_GROUP_STATUS.STOPPED,
   ): void {
-    logger.endGroup(this.channelId, groupId, status, this.isAgentLogger);
+    logger.endGroup(this.streamId, groupId, status, this.isAgentLogger);
   }
 
   private resolveActiveGroupId(): string | undefined {
-    return logger.getActiveGroupId(this.channelId, this.isAgentLogger);
+    return logger.getActiveGroupId(this.streamId, this.isAgentLogger);
   }
 }

--- a/src/logger/AgentLogger.ts
+++ b/src/logger/AgentLogger.ts
@@ -505,6 +505,30 @@ export class AgentLogger {
     });
   }
 
+  /**
+   * Log a tool use event for display in the progress view.
+   * Single source of truth for TOOL_USE message type.
+   */
+  logToolUse(data: unknown, groupId?: string): void {
+    this.info('', {
+      groupId,
+      messageType: MESSAGE_TYPES.TOOL_USE,
+      data,
+    });
+  }
+
+  /**
+   * Log a web search result for display in the progress view.
+   * Single source of truth for WEB_SEARCH message type.
+   */
+  logWebSearch(data: unknown, groupId?: string): void {
+    this.info('', {
+      groupId,
+      messageType: MESSAGE_TYPES.WEB_SEARCH,
+      data,
+    });
+  }
+
   withCurrentGroup<T>(fn: (groupId: string) => T): T | undefined {
     const groupId = this.resolveActiveGroupId();
     if (!groupId) {
@@ -532,15 +556,6 @@ export class AgentLogger {
       this.isAgentLogger,
       fn,
     );
-  }
-
-  async withScope<T>(
-    groupName: string,
-    fn: () => Promise<T>,
-    options: LoggerScopeOptions = {},
-  ): Promise<T> {
-    const stage = await this.createStageHandle(groupName, options);
-    return stage.run(fn);
   }
 
   async stage(

--- a/src/logger/filterUtils.ts
+++ b/src/logger/filterUtils.ts
@@ -14,11 +14,6 @@ export interface FilterResult {
   debugMode: boolean;
 }
 
-/** Get the current debug mode setting. */
-function getDebugMode(): boolean {
-  return getConfig<boolean>('texra.logger.debugMode', false);
-}
-
 /**
  * Determines whether a log message should be emitted to the progress view
  * and returns the debug mode state for setting the verbose flag.
@@ -28,7 +23,7 @@ function getDebugMode(): boolean {
  * - AgentLogger.createStream() (stream-based logging path)
  */
 export function getEmitFilter(options: FilterOptions): FilterResult {
-  const debugMode = getDebugMode();
+  const debugMode = getConfig<boolean>('texra.logger.debugMode', false);
   // Filter: INTERNAL messages always hidden; debug-level messages hidden unless debugMode
   const shouldEmit =
     options.messageType !== MESSAGE_TYPES.INTERNAL &&

--- a/src/logger/logUtils.ts
+++ b/src/logger/logUtils.ts
@@ -53,6 +53,11 @@ function pushGroupContext(
   contextStorage.enterWith(store);
 }
 
+/**
+ * Removes the specified groupId from the context stack.
+ * Uses lastIndexOf to find and remove only the most recent occurrence,
+ * supporting both LIFO (normal) and non-LIFO (out-of-order) group endings.
+ */
 function popGroupContext(
   channel: string,
   groupId: string,
@@ -62,29 +67,17 @@ function popGroupContext(
   const key = getChannelKey(channel, isAgent);
   const context = store.get(key);
 
-  // No context or empty stack - nothing to pop
-  if (!context?.stack.length) {
-    return;
-  }
+  if (!context?.stack.length) return;
 
-  // Remove only the LAST occurrence of groupId from stack.
-  // This supports:
-  // 1. Non-LIFO group endings (different group IDs can end out of order)
-  // 2. Duplicate pushes of the same groupId (nested runWithGroupContext calls)
   const lastIndex = context.stack.lastIndexOf(groupId);
-  if (lastIndex === -1) {
-    return;
-  }
+  if (lastIndex === -1) return;
 
-  // Create new stack without the removed element
   const newStack = context.stack.toSpliced(lastIndex, 1);
-
   if (newStack.length === 0) {
     store.delete(key);
   } else {
     store.set(key, { stack: newStack });
   }
-
   contextStorage.enterWith(store);
 }
 

--- a/src/logger/logUtils.ts
+++ b/src/logger/logUtils.ts
@@ -35,11 +35,6 @@ function getStore(): Map<ChannelKey, ChannelContext> {
   return store;
 }
 
-function getContextByKey(key: ChannelKey): ChannelContext | undefined {
-  const store = getStore();
-  return store.get(key);
-}
-
 function pushGroupContext(
   channel: string,
   groupId: string,
@@ -86,7 +81,7 @@ function resolveActiveGroupByKey(
   groupId: string | undefined,
 ): string | undefined {
   if (groupId) return groupId;
-  return getContextByKey(key)?.stack.at(-1);
+  return getStore().get(key)?.stack.at(-1);
 }
 
 /**

--- a/src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts
+++ b/src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts
@@ -405,7 +405,7 @@ describe('ModelHandlerAnthropic message guards', () => {
   it('uploads base64 PDF documents before creating responses', async () => {
     const handler = createAnthropicHandler({ supportsNativePdf: true });
     const loggerStub = {
-      channelId: 'test',
+      streamId: 'test',
       debug: () => {},
       info: () => {},
       warn: () => {},
@@ -492,7 +492,7 @@ describe('ModelHandlerAnthropic message guards', () => {
   it('sanitizes uploaded PDF filenames to strip directories and forbidden characters', async () => {
     const handler = createAnthropicHandler({ supportsNativePdf: true });
     const loggerStub = {
-      channelId: 'test',
+      streamId: 'test',
       debug: () => {},
       info: () => {},
       warn: () => {},
@@ -568,7 +568,7 @@ describe('ModelHandlerAnthropic message guards', () => {
   it('opts into the Files API when messages already reference uploaded PDFs', async () => {
     const handler = createAnthropicHandler({ supportsNativePdf: true });
     const loggerStub = {
-      channelId: 'test',
+      streamId: 'test',
       debug: () => {},
       info: () => {},
       warn: () => {},
@@ -652,7 +652,7 @@ describe('ModelHandlerAnthropic message guards', () => {
       supportsTokenCounting: true,
     });
     const loggerStub = {
-      channelId: 'test',
+      streamId: 'test',
       debug: () => {},
       info: () => {},
       warn: () => {},
@@ -732,7 +732,7 @@ describe('ModelHandlerAnthropic message guards', () => {
       supportsTokenCounting: true,
     });
     const loggerStub = {
-      channelId: 'test',
+      streamId: 'test',
       debug: () => {},
       info: () => {},
       warn: () => {},
@@ -810,7 +810,7 @@ describe('ModelHandlerAnthropic message guards', () => {
 
     const warnMessages: string[] = [];
     const loggerStub = {
-      channelId: 'test',
+      streamId: 'test',
       debug: () => {},
       info: () => {},
       warn: (message: string) => {

--- a/src/test/agent/modelHandlers/ModelHandlerGoogleGenAI.test.ts
+++ b/src/test/agent/modelHandlers/ModelHandlerGoogleGenAI.test.ts
@@ -37,13 +37,13 @@ import type {
 } from '@google/genai';
 
 interface LoggerStub extends Partial<AgentLogger> {
-  channelId: string;
+  streamId: string;
   fileListEntries: Array<Array<{ path: string; ok: boolean }>>;
 }
 
 function createLoggerStub(): { logger: AgentLogger; stub: LoggerStub } {
   const stub: LoggerStub = {
-    channelId: 'test-channel',
+    streamId: 'test-channel',
     fileListEntries: [],
     debug: () => {
       /* no-op for tests */

--- a/src/test/agent/modelHandlers/ModelHandlerOpenAINormalize.test.ts
+++ b/src/test/agent/modelHandlers/ModelHandlerOpenAINormalize.test.ts
@@ -19,7 +19,7 @@ import {
 } from '@model/ModelConfig';
 
 type LoggerStub = Partial<AgentLogger> & {
-  channelId: string;
+  streamId: string;
   debugMessages: string[];
   infoMessages: string[];
 };
@@ -28,7 +28,7 @@ function createLoggerStub(): LoggerStub {
   const debugMessages: string[] = [];
   const infoMessages: string[] = [];
   return {
-    channelId: 'test-channel',
+    streamId: 'test-channel',
     debugMessages,
     infoMessages,
     debug: (message: string) => {

--- a/src/test/agent/modelHandlers/support/MediaAttachmentProcessor.test.ts
+++ b/src/test/agent/modelHandlers/support/MediaAttachmentProcessor.test.ts
@@ -25,7 +25,7 @@ import {
 import { AbsoluteFS, pathToLocation, getShortDisplayPath } from '@utils/files';
 
 interface LoggerStub extends Partial<AgentLogger> {
-  channelId: string;
+  streamId: string;
   debugMessages: string[];
   warnMessages: string[];
   errorMessages: string[];
@@ -34,7 +34,7 @@ interface LoggerStub extends Partial<AgentLogger> {
 
 function createLoggerStub(): { logger: AgentLogger; stub: LoggerStub } {
   const stub: LoggerStub = {
-    channelId: 'media-test',
+    streamId: 'media-test',
     debugMessages: [],
     warnMessages: [],
     errorMessages: [],


### PR DESCRIPTION
- Remove unused `logId` field from OutputHandler that was always passed as 0
- Rename AgentLogger.channelId to streamId for semantic clarity (it's a stream identifier, not channel ID)
- Simplify group context stack logic in logUtils.ts with clearer documentation
- Consolidate error notification pattern in RecordingManager to reduce duplication
- Update all references and test mocks to use new streamId naming

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Modernizes logging and error handling across agents and utilities.
> 
> - **Logging API cleanup**: Rename `AgentLogger.channelId` to `streamId`; add `logger.logToolUse()` and `logger.logWebSearch()` and switch call sites (tool-use flow, model handlers, Anthropic streaming) to use them
> - **Output handling**: Remove unused `logId` from `OutputHandler`; bind channels via `logger.streamId`; adjust constructor and consumers
> - **Flow/runtime updates**: Replace scoped logging with `logger.stage().run(...)` in `executeAgent` (including merge); propagate `streamId` through tool execution contexts and reflection flow
> - **Recording error handling**: Consolidate to `notifyError()` in `RecordingManager` and improve error logging/messages
> - **Logger internals**: Simplify filter logic (`getEmitFilter`) and group context stack in `logUtils`; minor internal cleanups
> - **Tests/mocks**: Update all logger stubs and expectations to `streamId` naming
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 460620c4fb83ef45084503b4cccbfba3d1b6cd70. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->