### PR TITLE
Simplify and improve code clarity

### DIFF
--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -850,7 +850,11 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     );
     if (fileMapping.size === 0) {
       this.logger.warn(this.channel, 'Followup: No file mappings found', {
-        data: { stream, originalInputs: originalInputs.length, outputs: outputFiles.length },
+        data: {
+          stream,
+          originalInputs: originalInputs.length,
+          outputs: outputFiles.length,
+        },
       });
       await vscode.window.showWarningMessage(
         'Could not map output files to original inputs. File names may not match.',
@@ -880,9 +884,16 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
         executeImmediately,
       );
 
-      this.logger.info(this.channel, 'Followup task configured via restoreState');
+      this.logger.info(
+        this.channel,
+        'Followup task configured via restoreState',
+      );
     } catch (error) {
-      this.logger.error(this.channel, 'Failed to set up followup task', toErrorMessage(error));
+      this.logger.error(
+        this.channel,
+        'Failed to set up followup task',
+        toErrorMessage(error),
+      );
       await vscode.window.showErrorMessage(
         `Failed to set up followup task: ${toErrorMessage(error)}`,
       );
@@ -899,7 +910,9 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
   ): Promise<{ taskState: WorkflowTaskState; outputFiles: string[] } | null> {
     const taskState = this.provider.state.getTaskState(streamId);
     if (!taskState || !isWorkflowTaskState(taskState)) {
-      this.logger.warn(this.channel, 'Followup: No task state found', { data: { stream: streamId } });
+      this.logger.warn(this.channel, 'Followup: No task state found', {
+        data: { stream: streamId },
+      });
       await vscode.window.showWarningMessage(
         'No task state found for this stream. Cannot set up followup.',
       );
@@ -908,20 +921,30 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
 
     const agentEntry = getAgent(agent);
     if (!agentEntry) {
-      this.logger.warn(this.channel, 'Followup: Agent not found in registry', { data: { agent } });
-      await vscode.window.showWarningMessage(`Agent "${agent}" not found. Please select a valid agent.`);
+      this.logger.warn(this.channel, 'Followup: Agent not found in registry', {
+        data: { agent },
+      });
+      await vscode.window.showWarningMessage(
+        `Agent "${agent}" not found. Please select a valid agent.`,
+      );
       return null;
     }
 
-    const storageKey = this.provider.state.resolveRunId(streamId, undefined, { persist: false }) as StorageKey | null;
+    const storageKey = this.provider.state.resolveRunId(streamId, undefined, {
+      persist: false,
+    }) as StorageKey | null;
     const runOutputs = storageKey
       ? this.provider.state.getRunOutputFiles(streamId, { storageKey })
       : null;
     const outputFiles = this.extractOutputFilePaths(runOutputs);
 
     if (outputFiles.length === 0) {
-      this.logger.warn(this.channel, 'Followup: No output files found', { data: { stream: streamId } });
-      await vscode.window.showWarningMessage('No output files found. Cannot set up followup.');
+      this.logger.warn(this.channel, 'Followup: No output files found', {
+        data: { stream: streamId },
+      });
+      await vscode.window.showWarningMessage(
+        'No output files found. Cannot set up followup.',
+      );
       return null;
     }
 
@@ -937,15 +960,20 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
   ): Map<string, string> {
     const outputLocations = outputFiles.map((p) => pathToLocation(p));
     const inputLocations = originalInputs.map((p) => pathToLocation(p));
-    const pathMapping = createFileMapping(inputLocations, outputLocations, 'contains');
+    const pathMapping = createFileMapping(
+      inputLocations,
+      outputLocations,
+      'contains',
+    );
 
     const fileMapping = new Map<string, string>();
     for (let i = 0; i < originalInputs.length; i++) {
       const absolutePath = originalInputs[i];
       const location = inputLocations[i];
-      const comparablePath = location.kind !== 'external'
-        ? location.relativePath
-        : location.absolutePath;
+      const comparablePath =
+        location.kind !== 'external'
+          ? location.relativePath
+          : location.absolutePath;
       const output = pathMapping.get(comparablePath);
       if (output?.absolutePath) {
         fileMapping.set(absolutePath, output.absolutePath);
@@ -980,7 +1008,9 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     const newInputFiles = originalConfig.inputFiles.map(mapToRelative);
 
     // Build instruction from template
-    const template = isChat ? CHAT_INSTRUCTION_TEMPLATE : WORKFLOW_CONTEXT_TEMPLATE;
+    const template = isChat
+      ? CHAT_INSTRUCTION_TEMPLATE
+      : WORKFLOW_CONTEXT_TEMPLATE;
     const originalAgentEntry = getAgent(originalConfig.agent);
     const context = await this.renderFollowupInstruction(
       template,
@@ -991,14 +1021,17 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     );
 
     // Workflow mode can optionally append original instruction
-    const shouldAppendOriginal = !isChat && includeInstruction && originalConfig.instruction;
+    const shouldAppendOriginal =
+      !isChat && includeInstruction && originalConfig.instruction;
     const instruction = shouldAppendOriginal
       ? `${context}\n\n${originalConfig.instruction}`
       : context;
 
     // Build session with category based on mode
     const newAgentEntry = getAgent(agent);
-    const agentCategory = isChat ? AgentCategory.ToolUse : AgentCategory.Workflow;
+    const agentCategory = isChat
+      ? AgentCategory.ToolUse
+      : AgentCategory.Workflow;
     const session = { agentType: newAgentEntry?.agentType, agentCategory };
 
     // Build config preserving toolConfig, reference/auxiliary files
@@ -1017,7 +1050,10 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     if (isChat) {
       return { agentConfig: newConfig } as TaskState;
     }
-    return { agentConfig: newConfig, activeFiles: originalTaskState.activeFiles } as TaskState;
+    return {
+      agentConfig: newConfig,
+      activeFiles: originalTaskState.activeFiles,
+    } as TaskState;
   }
 
   /**

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -36,6 +36,11 @@ import {
   type TaskState,
 } from '@logger/TaskState';
 import {
+  CHAT_INSTRUCTION_TEMPLATE,
+  WORKFLOW_CONTEXT_TEMPLATE,
+  type FollowupInstructionVars,
+} from '@progressView/templates/followupInstructionTemplates';
+import {
   handleProgressViewToolEditApprovalAction,
   resetToolEditApprovalSessionBypass,
 } from '@tools/approval/toolEditApproval';
@@ -49,16 +54,11 @@ import {
   WorkspaceFS,
 } from '@utils/files';
 import { ensureRunDir, getRunDir } from '@utils/files/taskRunStorage';
+import { renderPrompt } from '@utils/prompt/promptUtils';
 import {
   buildFileContextFromTaskState,
   polishTextWithAI,
 } from '@utils/text/textEnhancementUtils';
-import { renderPrompt } from '@utils/prompt/promptUtils';
-import {
-  CHAT_INSTRUCTION_TEMPLATE,
-  WORKFLOW_CONTEXT_TEMPLATE,
-  type FollowupInstructionVars,
-} from '@progressView/templates/followupInstructionTemplates';
 import {
   PolishFollowUpMessageSchema,
   InfoMessageSchema,
@@ -816,7 +816,6 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
   /**
    * Process a followup request (setup or run).
    * Builds a TaskState directly and sends via restoreState for code reuse.
-   * This eliminates the intermediate followupTaskCommand layer.
    */
   private async processFollowup(
     data: {
@@ -831,88 +830,27 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
   ): Promise<void> {
     const { stream, mode, agent, model, includeInstruction, initialQuestion } =
       data;
-
     const streamId = stream as StreamTabId;
-    const taskState = this.provider.state.getTaskState(streamId);
-    if (!taskState || !isWorkflowTaskState(taskState)) {
-      this.logger.warn(this.channel, 'Followup: No task state found', {
-        data: { stream },
-      });
-      await vscode.window.showWarningMessage(
-        'No task state found for this stream. Cannot set up followup.',
-      );
-      return;
-    }
 
-    // Validate that the selected agent exists in registry
-    const agentEntry = getAgent(agent);
-    if (!agentEntry) {
-      this.logger.warn(this.channel, 'Followup: Agent not found in registry', {
-        data: { agent },
-      });
-      await vscode.window.showWarningMessage(
-        `Agent "${agent}" not found. Please select a valid agent.`,
-      );
-      return;
-    }
+    // Validate prerequisites
+    const prereq = await this.validateFollowupPrerequisites(streamId, agent);
+    if (!prereq) return;
 
-    // Get output files for file mapping
-    const storageKey = this.provider.state.resolveRunId(streamId, undefined, {
-      persist: false,
-    }) as StorageKey | null;
-    const runOutputs = storageKey
-      ? this.provider.state.getRunOutputFiles(streamId, { storageKey })
-      : null;
-
+    const { taskState, outputFiles } = prereq;
     const originalConfig = taskState.agentConfig;
-    const outputFiles = this.extractOutputFilePaths(runOutputs);
-
-    if (outputFiles.length === 0) {
-      this.logger.warn(this.channel, 'Followup: No output files found', {
-        data: { stream },
-      });
-      await vscode.window.showWarningMessage(
-        'No output files found. Cannot set up followup.',
-      );
-      return;
-    }
-
-    // Build file mapping: original inputs → output files
     const originalInputs = [
       originalConfig.inputFile,
       ...originalConfig.inputFiles,
     ].filter(Boolean);
-    const outputLocations = outputFiles.map((p) => pathToLocation(p));
-    const inputLocations = originalInputs.map((p) => pathToLocation(p));
-    const pathMapping = createFileMapping(
-      inputLocations,
-      outputLocations,
-      'contains',
+
+    // Build file mapping: original inputs → output files
+    const fileMapping = this.buildFollowupFileMapping(
+      originalInputs,
+      outputFiles,
     );
-
-    // Build absolute path → output absolute path lookup
-    const fileMapping = new Map<string, string>();
-    for (let i = 0; i < originalInputs.length; i++) {
-      const absolutePath = originalInputs[i];
-      const location = inputLocations[i];
-      const comparablePath =
-        location.kind !== 'external'
-          ? location.relativePath
-          : location.absolutePath;
-      const output = pathMapping.get(comparablePath);
-      if (output?.absolutePath) {
-        fileMapping.set(absolutePath, output.absolutePath);
-      }
-    }
-
-    // Validate that at least one file was mapped
     if (fileMapping.size === 0) {
       this.logger.warn(this.channel, 'Followup: No file mappings found', {
-        data: {
-          stream,
-          originalInputs: originalInputs.length,
-          outputs: outputFiles.length,
-        },
+        data: { stream, originalInputs: originalInputs.length, outputs: outputFiles.length },
       });
       await vscode.window.showWarningMessage(
         'Could not map output files to original inputs. File names may not match.',
@@ -932,16 +870,9 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
         taskState,
         originalConfig,
         fileMapping,
-        {
-          mode,
-          agent,
-          model,
-          includeInstruction,
-          initialQuestion,
-        },
+        { mode, agent, model, includeInstruction, initialQuestion },
       );
 
-      // Focus main view and send restore message with executeImmediately flag
       await vscode.commands.executeCommand('texra.mainView.focus');
       await vscode.commands.executeCommand(
         'texra.restoreState',
@@ -949,20 +880,78 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
         executeImmediately,
       );
 
-      this.logger.info(
-        this.channel,
-        'Followup task configured via restoreState',
-      );
+      this.logger.info(this.channel, 'Followup task configured via restoreState');
     } catch (error) {
-      this.logger.error(
-        this.channel,
-        'Failed to set up followup task',
-        toErrorMessage(error),
-      );
+      this.logger.error(this.channel, 'Failed to set up followup task', toErrorMessage(error));
       await vscode.window.showErrorMessage(
         `Failed to set up followup task: ${toErrorMessage(error)}`,
       );
     }
+  }
+
+  /**
+   * Validate followup prerequisites: task state, agent, and output files.
+   * Returns null if validation fails (with user notification).
+   */
+  private async validateFollowupPrerequisites(
+    streamId: StreamTabId,
+    agent: string,
+  ): Promise<{ taskState: WorkflowTaskState; outputFiles: string[] } | null> {
+    const taskState = this.provider.state.getTaskState(streamId);
+    if (!taskState || !isWorkflowTaskState(taskState)) {
+      this.logger.warn(this.channel, 'Followup: No task state found', { data: { stream: streamId } });
+      await vscode.window.showWarningMessage(
+        'No task state found for this stream. Cannot set up followup.',
+      );
+      return null;
+    }
+
+    const agentEntry = getAgent(agent);
+    if (!agentEntry) {
+      this.logger.warn(this.channel, 'Followup: Agent not found in registry', { data: { agent } });
+      await vscode.window.showWarningMessage(`Agent "${agent}" not found. Please select a valid agent.`);
+      return null;
+    }
+
+    const storageKey = this.provider.state.resolveRunId(streamId, undefined, { persist: false }) as StorageKey | null;
+    const runOutputs = storageKey
+      ? this.provider.state.getRunOutputFiles(streamId, { storageKey })
+      : null;
+    const outputFiles = this.extractOutputFilePaths(runOutputs);
+
+    if (outputFiles.length === 0) {
+      this.logger.warn(this.channel, 'Followup: No output files found', { data: { stream: streamId } });
+      await vscode.window.showWarningMessage('No output files found. Cannot set up followup.');
+      return null;
+    }
+
+    return { taskState, outputFiles };
+  }
+
+  /**
+   * Build a mapping from original input paths to output file paths.
+   */
+  private buildFollowupFileMapping(
+    originalInputs: string[],
+    outputFiles: string[],
+  ): Map<string, string> {
+    const outputLocations = outputFiles.map((p) => pathToLocation(p));
+    const inputLocations = originalInputs.map((p) => pathToLocation(p));
+    const pathMapping = createFileMapping(inputLocations, outputLocations, 'contains');
+
+    const fileMapping = new Map<string, string>();
+    for (let i = 0; i < originalInputs.length; i++) {
+      const absolutePath = originalInputs[i];
+      const location = inputLocations[i];
+      const comparablePath = location.kind !== 'external'
+        ? location.relativePath
+        : location.absolutePath;
+      const output = pathMapping.get(comparablePath);
+      if (output?.absolutePath) {
+        fileMapping.set(absolutePath, output.absolutePath);
+      }
+    }
+    return fileMapping;
   }
 
   /**
@@ -982,46 +971,37 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     },
   ): Promise<TaskState> {
     const { mode, agent, model, includeInstruction, initialQuestion } = options;
-
-    // Get new agent info for session descriptor
-    const newAgentEntry = getAgent(agent);
-    const originalAgentEntry = getAgent(originalConfig.agent);
+    const isChat = mode === 'chat';
 
     // Map input files: outputs become new inputs
-    const toRelative = (p: string) => (p ? WorkspaceFS.relativePath(p) : p);
-    const mapFile = (f: string) => toRelative(fileMapping.get(f) ?? f);
+    const mapToRelative = (p: string): string =>
+      WorkspaceFS.relativePath(fileMapping.get(p) ?? p);
+    const newInputFile = mapToRelative(originalConfig.inputFile);
+    const newInputFiles = originalConfig.inputFiles.map(mapToRelative);
 
-    const newInputFile = mapFile(originalConfig.inputFile);
-    const newInputFiles = originalConfig.inputFiles.map(mapFile);
-
-    // Build instruction based on mode
-    const template =
-      mode === 'chat' ? CHAT_INSTRUCTION_TEMPLATE : WORKFLOW_CONTEXT_TEMPLATE;
+    // Build instruction from template
+    const template = isChat ? CHAT_INSTRUCTION_TEMPLATE : WORKFLOW_CONTEXT_TEMPLATE;
+    const originalAgentEntry = getAgent(originalConfig.agent);
     const context = await this.renderFollowupInstruction(
       template,
       originalConfig,
       originalAgentEntry,
       fileMapping,
-      mode === 'chat' ? initialQuestion : undefined,
+      isChat ? initialQuestion : undefined,
     );
 
-    // For workflow mode with includeInstruction, append original instruction
-    const instruction =
-      mode === 'workflow' && includeInstruction && originalConfig.instruction
-        ? context + '\n\n' + originalConfig.instruction
-        : context;
+    // Workflow mode can optionally append original instruction
+    const shouldAppendOriginal = !isChat && includeInstruction && originalConfig.instruction;
+    const instruction = shouldAppendOriginal
+      ? `${context}\n\n${originalConfig.instruction}`
+      : context;
 
-    // Determine category based on mode (chat = toolUse, workflow = workflow)
-    const agentCategory =
-      mode === 'chat' ? AgentCategory.ToolUse : AgentCategory.Workflow;
+    // Build session with category based on mode
+    const newAgentEntry = getAgent(agent);
+    const agentCategory = isChat ? AgentCategory.ToolUse : AgentCategory.Workflow;
+    const session = { agentType: newAgentEntry?.agentType, agentCategory };
 
-    // Build session descriptor with correct category
-    const session = {
-      agentType: newAgentEntry?.agentType,
-      agentCategory,
-    };
-
-    // Create new config preserving toolConfig, reference/auxiliary files
+    // Build config preserving toolConfig, reference/auxiliary files
     const newConfig = {
       ...originalConfig,
       agent,
@@ -1031,22 +1011,13 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
       instruction,
       session,
       agentType: session.agentType,
-    };
+    } as AgentConfig;
 
-    // Return appropriate TaskState type based on mode
-    if (mode === 'chat') {
-      return {
-        agentConfig: newConfig as AgentConfig & {
-          session: { agentCategory: AgentCategory.ToolUse };
-        },
-      };
+    // Chat mode returns minimal TaskState, workflow preserves activeFiles
+    if (isChat) {
+      return { agentConfig: newConfig } as TaskState;
     }
-    return {
-      agentConfig: newConfig as AgentConfig & {
-        session: { agentCategory: AgentCategory.Workflow };
-      },
-      activeFiles: originalTaskState.activeFiles,
-    };
+    return { agentConfig: newConfig, activeFiles: originalTaskState.activeFiles } as TaskState;
   }
 
   /**

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -304,43 +304,41 @@ export class ProgressViewProvider
 
   public showToolEditApprovalPrompt(prompt: ToolEditApprovalPrompt): void {
     this.pendingApprovalPrompts.set(prompt.requestId, prompt);
-
-    if (this.canSendToWebview()) {
-      this.webviewUpdater.showToolEditApprovalPrompt(prompt);
-    }
+    this.sendIfReady(() =>
+      this.webviewUpdater.showToolEditApprovalPrompt(prompt),
+    );
   }
 
   public resolveToolEditApprovalPrompt(requestId: string): void {
     this.pendingApprovalPrompts.delete(requestId);
-
-    if (this.canSendToWebview()) {
-      this.webviewUpdater.resolveToolEditApprovalPrompt(requestId);
-    }
+    this.sendIfReady(() =>
+      this.webviewUpdater.resolveToolEditApprovalPrompt(requestId),
+    );
   }
 
   public updateToolEditApprovalBypassState(bypassActive: boolean): void {
     this.approvalBypassActive = bypassActive;
-
-    if (this.canSendToWebview()) {
-      this.webviewUpdater.updateToolEditApprovalState(bypassActive);
-    }
+    this.sendIfReady(() =>
+      this.webviewUpdater.updateToolEditApprovalState(bypassActive),
+    );
   }
 
   public showRetryRequest(
     payload: ProgressEventPayloads['showRetryRequest'],
   ): void {
     this.pendingRetryRequests.set(payload.streamId, payload);
-
-    if (this.canSendToWebview()) {
-      this.webviewUpdater.showRetryRequest(payload);
-    }
+    this.sendIfReady(() => this.webviewUpdater.showRetryRequest(payload));
   }
 
   public resolveRetryRequest(streamId: string): void {
     this.pendingRetryRequests.delete(streamId);
+    this.sendIfReady(() => this.webviewUpdater.resolveRetryRequest(streamId));
+  }
 
+  /** Send to webview if ready, otherwise skip (pending state will be replayed later) */
+  private sendIfReady(send: () => void): void {
     if (this.canSendToWebview()) {
-      this.webviewUpdater.resolveRetryRequest(streamId);
+      send();
     }
   }
 

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -156,7 +156,9 @@ export class ProgressEventHandler {
     }
 
     // Refresh stream surface and instruction panel
-    const activeRunId = this.refreshStreamSurface(stream, { updateInstruction: false });
+    const activeRunId = this.refreshStreamSurface(stream, {
+      updateInstruction: false,
+    });
     this.sendInstructionUpdate(stream, activeRunId);
   }
 

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -119,49 +119,46 @@ export class ProgressEventHandler {
     withEventErrorHandling(
       'StreamStatus',
       'failed to handle setActiveStream',
-      async () => {
-        const { stream, session, isRemote, hasMultipleOutputs } = payload;
-        if (!stream) return;
-
-        await this.state.streamTabs.ensureStream(stream);
-        this.state.updateStreamHints(stream, {
-          sessionCategory: session?.agentCategory,
-          isRemote,
-          hasMultipleOutputs,
-        });
-        this.maybeUpdateFilterForCategory(session?.agentCategory);
-        this.state.activeStream = stream;
-        this.replayPendingTaskGroups(stream);
-
-        // Get current status without defaulting to RUNNING.
-        // Status should only be set to RUNNING by setupFlowUIState in executeAgent,
-        // not here. Defaulting to RUNNING here causes a race condition where the
-        // "already running" check in executeAgent fails because this event handler
-        // runs synchronously before the check.
-        const status = StreamStatusService.get(stream);
-
-        if (this.webviewUpdater.isAvailable()) {
-          this.webviewUpdater.updateAll(
-            this.state,
-            StreamStatusService.getAll(),
-          );
-        }
-
-        // Only update stream status if explicitly set (not for new streams)
-        if (status !== undefined) {
-          this.setStreamStatus(stream, status);
-        }
-
-        if (this.webviewUpdater.isAvailable()) {
-          // Frontend detects stream switches using lastRenderedStream tracking.
-          const activeRunId = this.refreshStreamSurface(stream, {
-            updateInstruction: false,
-          });
-          this.sendInstructionUpdate(stream, activeRunId);
-        }
-      },
+      () => this.processSetActiveStream(payload),
     );
   };
+
+  /** Core logic for setActiveStream event, separated for clarity */
+  private async processSetActiveStream(
+    payload: ProgressEventPayloads['setActiveStream'],
+  ): Promise<void> {
+    const { stream, session, isRemote, hasMultipleOutputs } = payload;
+    if (!stream) return;
+
+    // Initialize stream state
+    await this.state.streamTabs.ensureStream(stream);
+    this.state.updateStreamHints(stream, {
+      sessionCategory: session?.agentCategory,
+      isRemote,
+      hasMultipleOutputs,
+    });
+    this.maybeUpdateFilterForCategory(session?.agentCategory);
+    this.state.activeStream = stream;
+    this.replayPendingTaskGroups(stream);
+
+    // Get current status without defaulting to RUNNING.
+    // Status should only be set to RUNNING by setupFlowUIState in executeAgent,
+    // not here. Defaulting to RUNNING here causes a race condition.
+    const status = StreamStatusService.get(stream);
+
+    if (!this.webviewUpdater.isAvailable()) return;
+
+    // Update webview with stream data
+    this.webviewUpdater.updateAll(this.state, StreamStatusService.getAll());
+
+    if (status !== undefined) {
+      this.setStreamStatus(stream, status);
+    }
+
+    // Refresh stream surface and instruction panel
+    const activeRunId = this.refreshStreamSurface(stream, { updateInstruction: false });
+    this.sendInstructionUpdate(stream, activeRunId);
+  }
 
   private handleUpdateStreamStatus = (
     payload: ProgressEventPayloads['updateStreamStatus'],

--- a/src/progressView/state/ProgressViewState.ts
+++ b/src/progressView/state/ProgressViewState.ts
@@ -264,7 +264,7 @@ export class ProgressViewState {
 
   /** Get context state for a stream */
   getContextState(stream: StreamTabId): ContextStateData | undefined {
-    return this._ephemeral.get(stream)?.contextState ?? undefined;
+    return this._ephemeral.get(stream)?.contextState ?? undefined; // null → undefined
   }
 
   /** Clear context state for a stream */

--- a/src/progressView/streamInfoUtils.ts
+++ b/src/progressView/streamInfoUtils.ts
@@ -74,9 +74,10 @@ function buildStreamInfo(
   const isToolAgent = sessionCategory === AgentCategory.ToolUse;
 
   // Build display label
-  const label = !isToolAgent && inputFile
-    ? `${agentName}: ${path.basename(inputFile)}`
-    : agentName;
+  const label =
+    !isToolAgent && inputFile
+      ? `${agentName}: ${path.basename(inputFile)}`
+      : agentName;
 
   return {
     name: id,
@@ -86,8 +87,11 @@ function buildStreamInfo(
     agentType: config?.session?.agentType ?? config?.agentType,
     agentSessionKind: sessionCategory,
     uiTraits: { sessionKind: sessionCategory, isToolAgent },
-    hasMultipleOutputs: config?.useMultipleOutputs ?? hints.hasMultipleOutputs ?? false,
-    isRemote: taskState ? isRemoteAgent(rawAgentName) : (hints.isRemote ?? false),
+    hasMultipleOutputs:
+      config?.useMultipleOutputs ?? hints.hasMultipleOutputs ?? false,
+    isRemote: taskState
+      ? isRemoteAgent(rawAgentName)
+      : (hints.isRemote ?? false),
     lastTimestamp,
     inputFile,
     creationTimestamp,

--- a/src/progressView/streamInfoUtils.ts
+++ b/src/progressView/streamInfoUtils.ts
@@ -54,51 +54,45 @@ function buildStreamInfo(
 ): StreamTabInfo | null {
   const taskState = state.getTaskState(id);
   const hints = state.getStreamHints(id);
-  const logs = state.streamTabs.getMessages(id);
-  const lastTimestamp = logs.length > 0 ? logs.at(-1)?.timestamp : undefined;
-  const creationTimestamp = logs.length > 0 ? logs[0].timestamp : undefined;
-  const inputFile = taskState?.agentConfig.inputFile ?? '';
-  const rawAgentName = taskState?.agentConfig.agent ?? id.split('@')[0];
-  const agentName = getCleanAgentName(rawAgentName);
-  const rawCategory =
-    taskState?.agentConfig.session?.agentCategory ?? hints.sessionCategory;
+  const config = taskState?.agentConfig;
 
+  // Determine category and check filter
+  const rawCategory = config?.session?.agentCategory ?? hints.sessionCategory;
   const sessionCategory = matchesFilter(rawCategory, filter);
-  if (sessionCategory === null) {
-    return null;
-  }
+  if (sessionCategory === null) return null;
 
-  const agentType =
-    taskState?.agentConfig.session?.agentType ??
-    taskState?.agentConfig.agentType;
+  // Extract timestamps from logs
+  const logs = state.streamTabs.getMessages(id);
+  const hasLogs = logs.length > 0;
+  const lastTimestamp = hasLogs ? logs.at(-1)?.timestamp : undefined;
+  const creationTimestamp = hasLogs ? logs[0].timestamp : undefined;
+
+  // Agent and file info (with fallbacks to hints)
+  const inputFile = config?.inputFile ?? '';
+  const rawAgentName = config?.agent ?? id.split('@')[0];
+  const agentName = getCleanAgentName(rawAgentName);
   const isToolAgent = sessionCategory === AgentCategory.ToolUse;
-  const isRemote = taskState
-    ? isRemoteAgent(rawAgentName)
-    : (hints.isRemote ?? false);
-  const executionId = state.getExecutionId(id);
 
-  const label =
-    sessionCategory !== AgentCategory.ToolUse && inputFile
-      ? `${agentName}: ${path.basename(inputFile)}`
-      : agentName;
+  // Build display label
+  const label = !isToolAgent && inputFile
+    ? `${agentName}: ${path.basename(inputFile)}`
+    : agentName;
 
   return {
     name: id,
     label,
-    model: taskState?.agentConfig.model,
-    agent: taskState?.agentConfig.agent,
-    agentType,
+    model: config?.model,
+    agent: config?.agent,
+    agentType: config?.session?.agentType ?? config?.agentType,
     agentSessionKind: sessionCategory,
     uiTraits: { sessionKind: sessionCategory, isToolAgent },
-    hasMultipleOutputs: taskState
-      ? taskState.agentConfig.useMultipleOutputs
-      : (hints.hasMultipleOutputs ?? false),
-    isRemote,
+    hasMultipleOutputs: config?.useMultipleOutputs ?? hints.hasMultipleOutputs ?? false,
+    isRemote: taskState ? isRemoteAgent(rawAgentName) : (hints.isRemote ?? false),
     lastTimestamp,
     inputFile,
     creationTimestamp,
     status: statuses?.get(id),
-    executionId,
+    executionId: state.getExecutionId(id),
   };
 }
 

--- a/src/webview/managers/ExecutionManager.ts
+++ b/src/webview/managers/ExecutionManager.ts
@@ -42,15 +42,17 @@ export class ExecutionManager {
   }
 
   private composeAgentConfig(message: any, isToolUse: boolean): AgentConfig {
+    // Session descriptor depends on agent type
     const session: AgentSessionDescriptor = isToolUse
       ? { agentType: AgentType.ToolUse, agentCategory: AgentCategory.ToolUse }
       : { agentCategory: AgentCategory.Workflow };
 
+    // Tool-use agents don't produce output files
     const outputFiles: string[] = isToolUse ? [] : (message.outputFiles ?? []);
-    const useMultipleOutputs = isToolUse
-      ? false
-      : Boolean(message.outputFilesActive) || outputFiles.length > 1;
+    const useMultipleOutputs =
+      !isToolUse && (Boolean(message.outputFilesActive) || outputFiles.length > 1);
 
+    // Tool config: workflow agents use message values, tool-use uses defaults
     const toolConfig: ToolConfig = isToolUse
       ? DEFAULT_TOOL_CONFIG
       : {
@@ -61,8 +63,10 @@ export class ExecutionManager {
           autoCompileInputPdf: message.autoCompileInputPdf,
         };
 
+    // Map media file paths, filtering out null values
+    const mapMedia = (f: string | null): string | null => this.mapMediaPath(f);
     const mediaFiles = (message.mediaFiles ?? [])
-      .map((f: string | null) => this.mapMediaPath(f))
+      .map(mapMedia)
       .filter((f: string | null): f is string => f !== null);
 
     return {
@@ -75,7 +79,7 @@ export class ExecutionManager {
       referenceFiles: message.referenceFiles ?? [],
       auxiliaryFile: message.auxiliaryFile ?? null,
       auxiliaryFiles: message.auxiliaryFiles ?? [],
-      mediaFile: this.mapMediaPath(message.mediaFile ?? null),
+      mediaFile: mapMedia(message.mediaFile ?? null),
       mediaFiles,
       editedFile: null,
       editedFiles: message.editedFiles ?? [],

--- a/src/webview/managers/ExecutionManager.ts
+++ b/src/webview/managers/ExecutionManager.ts
@@ -50,7 +50,8 @@ export class ExecutionManager {
     // Tool-use agents don't produce output files
     const outputFiles: string[] = isToolUse ? [] : (message.outputFiles ?? []);
     const useMultipleOutputs =
-      !isToolUse && (Boolean(message.outputFilesActive) || outputFiles.length > 1);
+      !isToolUse &&
+      (Boolean(message.outputFilesActive) || outputFiles.length > 1);
 
     // Tool config: workflow agents use message values, tool-use uses defaults
     const toolConfig: ToolConfig = isToolUse


### PR DESCRIPTION
Key improvements:
- Extract `sendIfReady` helper in ProgressViewProvider for approval/retry prompts
- Split processFollowup into focused helpers: validateFollowupPrerequisites, buildFollowupFileMapping
- Simplify buildFollowupTaskState with clearer mode-based structure
- Flatten handleSetActiveStream by extracting processSetActiveStream method
- Clarify ExecutionManager.composeAgentConfig conditional logic
- Improve streamInfoUtils.buildStreamInfo with better grouping and early returns
- Fix import ordering in ProgressViewMessageHandler

Net reduction of 36 lines while improving readability.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves structure and safety across progress view and webview interactions.
> 
> - Extracts `validateFollowupPrerequisites` and `buildFollowupFileMapping`; simplifies `buildFollowupTaskState` and follow-up flow in `ProgressViewMessageHandler`
> - Adds `sendIfReady` in `ProgressViewProvider` and applies it to approval/retry messaging
> - Splits `setActiveStream` logic into `processSetActiveStream` in `ProgressEventHandler`, clarifying status reads and webview updates
> - Stream tab info generation refactored in `streamInfoUtils.buildStreamInfo` with clearer grouping and early returns
> - Clarifies `ExecutionManager.composeAgentConfig` (session descriptor, outputs, toolConfig, media mapping)
> - Minor state tweak in `ProgressViewState.getContextState` (normalize null→undefined) and import ordering cleanup
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b523328013ad28c408411d8b50ad4dc4289a79b0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->