### PR TITLE
Simplify and improve code clarity

### DIFF
--- a/src/agent/index/agentRegistry.ts
+++ b/src/agent/index/agentRegistry.ts
@@ -700,11 +700,7 @@ function renderOption(entry: AgentEntry): string {
  * on the current dropdown value before setting innerHTML.
  */
 export async function computeAgentOptions(): Promise<AgentOptionsPayload> {
-  if (!initialized) {
-    await loadAgents();
-  } else if (initPromise) {
-    await initPromise;
-  }
+  await ensureAgentsLoaded();
   return buildAgentOptions();
 }
 

--- a/src/commands/history/stateRestoreCommand.ts
+++ b/src/commands/history/stateRestoreCommand.ts
@@ -35,30 +35,20 @@ async function restoreState(state: TaskState, executeImmediately?: boolean) {
 
   try {
     // Focus the webview panel first to make sure it's visible
-    // Use the specific view ID instead of the extension to avoid sidebar switching issues
     await vscode.commands.executeCommand('texra.mainView.focus');
 
-    // Try to get the webview directly using our safe command
-    try {
-      const webviewView = await getMainWebview(CHANNEL);
-
-      if (webviewView) {
-        webviewView.webview.postMessage({
-          command: 'restoreState',
-          state,
-          executeImmediately,
-        });
-        logger.info(CHANNEL, 'State restored via direct webview access');
-        return;
-      }
-      await storeStateForLater(state, executeImmediately);
-    } catch (error) {
-      logger.warn(
-        CHANNEL,
-        `Could not access webview: ${toErrorMessage(error)}`,
-      );
-      await storeStateForLater(state, executeImmediately);
+    const webviewView = await getMainWebview(CHANNEL);
+    if (webviewView) {
+      webviewView.webview.postMessage({
+        command: 'restoreState',
+        state,
+        executeImmediately,
+      });
+      logger.info(CHANNEL, 'State restored via direct webview access');
+      return;
     }
+
+    await storeStateForLater(state, executeImmediately);
   } catch (error) {
     await showLoggedErrorMessage(CHANNEL, 'Failed to restore state', error);
   }


### PR DESCRIPTION
- Remove nested try/catch in stateRestoreCommand.ts - the inner try/catch was redundant since both paths led to the same fallback function
- Simplify computeAgentOptions to reuse ensureAgentsLoaded() instead of duplicating its initialization logic

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Simplifies control flow and removes redundant logic**
> 
> - `computeAgentOptions()` now delegates initialization to `ensureAgentsLoaded()`, eliminating duplicated cache init checks while keeping output from `buildAgentOptions()` unchanged.
> - `stateRestoreCommand`: removes nested try/catch and direct-else-fallback duplication—focuses the main view, attempts `getMainWebview()` once to `postMessage('restoreState', ...)`, otherwise calls `storeStateForLater`; outer error handling remains intact.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bebbfc7b1af2ec7cd93083abbed29a33fcac9e2f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->