### PR TITLE
Simplify agent and model selection logic

### DIFF
--- a/src/agent/index/agentRegistry.ts
+++ b/src/agent/index/agentRegistry.ts
@@ -400,10 +400,9 @@ async function scanYaml(
       category,
       agentType,
       description: validated.description,
-      defaultOutputFiles:
-        defaultOutputFiles && defaultOutputFiles.length > 0
-          ? defaultOutputFiles
-          : undefined,
+      defaultOutputFiles: defaultOutputFiles?.length
+        ? defaultOutputFiles
+        : undefined,
     };
   } catch (err) {
     logger.warn(CHANNEL, `Failed to scan ${yamlPath}: ${err}`);
@@ -435,27 +434,17 @@ async function loadRemoteAgents(): Promise<AgentEntry[]> {
     // Build entries from grouped agents
     const entries: AgentEntry[] = [];
     for (const [baseName, { base, multiple }] of grouped) {
-      // Use base agent's metadata, or fall back to multiple if only _multiple exists
       const primary = base || multiple;
       if (!primary) continue;
 
-      // If only _multiple exists without a base, use full name as the entry name
-      const entryName = base ? baseName : primary.name;
-
-      // Determine category from agentCategory (new) or agentType (legacy)
       const isToolUse = primary.agentCategory === AgentCategory.ToolUse;
-      const category = isToolUse
-        ? AgentCategory.ToolUse
-        : AgentCategory.Workflow;
-      const agentType = isToolUse ? AgentType.ToolUse : AgentType.CoT;
-
       entries.push({
-        name: entryName,
+        name: base ? baseName : primary.name,
         source: 'remote' as AgentSource,
         path: '',
-        multiplePath: multiple ? multiple.name : undefined,
-        category,
-        agentType,
+        multiplePath: multiple?.name,
+        category: isToolUse ? AgentCategory.ToolUse : AgentCategory.Workflow,
+        agentType: isToolUse ? AgentType.ToolUse : AgentType.CoT,
         description: primary.description ?? undefined,
         visibility: primary.visibility ?? undefined,
       });
@@ -644,15 +633,12 @@ function filterVisible(
     true,
   );
 
-  return entries.filter((entry) => {
-    // Remote agents auto-show when setting is enabled
-    if (entry.source === 'remote' && autoShowRemote) return true;
-    // Check if explicitly configured by source:name or just name
-    return (
+  return entries.filter(
+    (entry) =>
+      (entry.source === 'remote' && autoShowRemote) ||
       configured.has(createKey(entry.source, entry.name)) ||
-      configured.has(entry.name)
-    );
-  });
+      configured.has(entry.name),
+  );
 }
 
 function renderOptions(

--- a/src/agent/index/agentRegistry.ts
+++ b/src/agent/index/agentRegistry.ts
@@ -189,35 +189,27 @@ async function doLoad(): Promise<void> {
   );
 }
 
+/** Source priority for lookups (higher priority first). */
+const LOOKUP_PRIORITY: AgentSource[] = [
+  'custom',
+  'builtIn',
+  'builtInToolUse',
+  'remote',
+];
+
 /**
  * Get an agent by identifier.
- * Supports "source:name" format or just "name" (finds first match).
+ * Supports "source:name" format or just "name" (finds first match by priority).
  */
 export function getAgent(identifier: string): AgentEntry | undefined {
-  // Try direct lookup (source:name format)
-  const direct = cache.get(identifier);
-  if (direct) return direct;
+  // Direct lookup for source:name format
+  if (cache.has(identifier)) return cache.get(identifier);
 
-  // Parse source:name format
-  const colonIdx = identifier.indexOf(':');
-  if (colonIdx > 0) {
-    const source = identifier.slice(0, colonIdx);
-    const name = identifier.slice(colonIdx + 1);
-    return cache.get(`${source}:${name}`);
-  }
-
-  // Legacy: find first match by name (priority: custom > builtIn > builtInToolUse > remote)
-  const priorities: AgentSource[] = [
-    'custom',
-    'builtIn',
-    'builtInToolUse',
-    'remote',
-  ];
-  for (const source of priorities) {
+  // Legacy: find first match by name across sources
+  for (const source of LOOKUP_PRIORITY) {
     const entry = cache.get(`${source}:${identifier}`);
     if (entry) return entry;
   }
-
   return undefined;
 }
 
@@ -411,16 +403,10 @@ async function scanYaml(
 }
 
 function mapAgentType(value: string | undefined): AgentType {
-  switch (value) {
-    case 'toolUse':
-    case AgentType.ToolUse:
-      return AgentType.ToolUse;
-    case 'direct':
-    case AgentType.Direct:
-      return AgentType.Direct;
-    default:
-      return AgentType.CoT;
-  }
+  if (value === 'toolUse' || value === AgentType.ToolUse)
+    return AgentType.ToolUse;
+  if (value === 'direct' || value === AgentType.Direct) return AgentType.Direct;
+  return AgentType.CoT;
 }
 
 async function loadRemoteAgents(): Promise<AgentEntry[]> {
@@ -583,14 +569,6 @@ export function buildAgentOptions(): AgentOptionsPayload {
   };
 }
 
-/** Source priority for deduplication (lower index = higher priority). */
-const SOURCE_PRIORITY: AgentSource[] = [
-  'custom',
-  'builtIn',
-  'builtInToolUse',
-  'remote',
-];
-
 /**
  * Deduplicate agents by name, keeping only the highest priority source.
  * Custom agents override built-in agents with the same name.
@@ -601,20 +579,16 @@ function deduplicateByName(entries: AgentEntry[]): AgentEntry[] {
 
   for (const entry of entries) {
     // Remote agents use source:name key to preserve uniqueness
-    // Local agents use just name to allow custom overriding builtIn
     const key =
       entry.source === 'remote' ? `${entry.source}:${entry.name}` : entry.name;
-
     const existing = byKey.get(key);
-    if (!existing) {
-      byKey.set(key, entry);
-      continue;
-    }
 
-    // Keep higher priority source (lower SOURCE_PRIORITY index)
-    const existingPriority = SOURCE_PRIORITY.indexOf(existing.source);
-    const entryPriority = SOURCE_PRIORITY.indexOf(entry.source);
-    if (entryPriority < existingPriority) {
+    // Keep entry if none exists or if this one has higher priority
+    if (
+      !existing ||
+      LOOKUP_PRIORITY.indexOf(entry.source) <
+        LOOKUP_PRIORITY.indexOf(existing.source)
+    ) {
       byKey.set(key, entry);
     }
   }
@@ -650,15 +624,14 @@ function renderOptions(
     return `<vscode-option value="">${emptyMsg}</vscode-option>`;
   }
 
-  // Sort: default agent first, then alphabetically by name
-  const defaultEntry = entries.find((e) => e.name === defaultName);
+  // Sort: default agent first, then alphabetically
   const sorted = [...entries].sort((a, b) => {
-    if (a === defaultEntry) return -1;
-    if (b === defaultEntry) return 1;
+    if (a.name === defaultName) return -1;
+    if (b.name === defaultName) return 1;
     return a.name.localeCompare(b.name);
   });
 
-  return sorted.map((entry) => renderOption(entry)).join('\n');
+  return sorted.map(renderOption).join('\n');
 }
 
 function renderOption(entry: AgentEntry): string {

--- a/src/agent/index/agentRegistry.ts
+++ b/src/agent/index/agentRegistry.ts
@@ -624,10 +624,11 @@ function renderOptions(
     return `<vscode-option value="">${emptyMsg}</vscode-option>`;
   }
 
-  // Sort: default agent first, then alphabetically
+  // Sort: default agent first (by reference), then alphabetically
+  const defaultEntry = entries.find((e) => e.name === defaultName);
   const sorted = [...entries].sort((a, b) => {
-    if (a.name === defaultName) return -1;
-    if (b.name === defaultName) return 1;
+    if (a === defaultEntry) return -1;
+    if (b === defaultEntry) return 1;
     return a.name.localeCompare(b.name);
   });
 

--- a/src/agent/remote/RemoteAgentLoader.ts
+++ b/src/agent/remote/RemoteAgentLoader.ts
@@ -29,58 +29,64 @@ import {
 const CHANNEL = 'RemoteAgentLoader';
 logger.initialize(CHANNEL);
 
-/**
- * Maps HTTP status codes to user-friendly error messages.
- * Extracted to simplify the error handling in loadRemoteAgent.
- */
+interface HttpErrorResult {
+  message: string;
+  shouldContinue: boolean;
+}
+
+const HTTP_ERROR_MESSAGES: Partial<
+  Record<number, (agentName: string) => string>
+> = {
+  [StatusCodes.UNAUTHORIZED]: () =>
+    'Session expired. Sign in again to continue.',
+  [StatusCodes.FORBIDDEN]: (name) =>
+    `Access denied to agent "${name}". Upgrade your account for access.`,
+};
+
+/** Maps HTTP status codes to user-friendly error messages. */
 function mapHttpError(
   status: number,
   agentName: string,
   candidateName: string,
   isLastCandidate: boolean,
   errorText: string,
-): { message: string; shouldContinue: boolean } {
-  switch (status) {
-    case StatusCodes.UNAUTHORIZED:
-      return {
-        message: 'Session expired. Sign in again to continue.',
-        shouldContinue: false,
-      };
+): HttpErrorResult {
+  // Handle static error messages
+  const staticMessage = HTTP_ERROR_MESSAGES[status];
+  if (staticMessage) {
+    return { message: staticMessage(agentName), shouldContinue: false };
+  }
 
-    case StatusCodes.NOT_FOUND:
-      if (!isLastCandidate) {
-        logger.debug(
-          CHANNEL,
-          `Agent variant "${candidateName}" not found, trying next candidate`,
-        );
-        return {
-          message: `Agent variant "${candidateName}" not found`,
-          shouldContinue: true,
-        };
-      }
+  // Handle 404 with fallback logic
+  if (status === StatusCodes.NOT_FOUND) {
+    if (!isLastCandidate) {
+      logger.debug(
+        CHANNEL,
+        `Agent variant "${candidateName}" not found, trying next candidate`,
+      );
       return {
-        message: `Agent "${agentName}" not found or access denied. Verify the agent name and your permissions.`,
-        shouldContinue: false,
+        message: `Agent variant "${candidateName}" not found`,
+        shouldContinue: true,
       };
+    }
+    return {
+      message: `Agent "${agentName}" not found or access denied. Verify the agent name and your permissions.`,
+      shouldContinue: false,
+    };
+  }
 
-    case StatusCodes.FORBIDDEN:
-      return {
-        message: `Access denied to agent "${agentName}". Upgrade your account for access.`,
-        shouldContinue: false,
-      };
-
-    case StatusCodes.INTERNAL_SERVER_ERROR:
-      if (errorText.includes('Failed to load agent configuration')) {
-        return {
-          message:
-            `Failed to load agent "${agentName}": The agent configuration file could not be retrieved from storage. ` +
-            `This may indicate the agent's YAML file is missing or the storage path in the database is incorrect. ` +
-            `Please contact the TeXRA team if this agent should be available.`,
-          shouldContinue: false,
-        };
-      }
-      // Fall through to default
-      break;
+  // Handle 500 with storage-specific message
+  if (
+    status === StatusCodes.INTERNAL_SERVER_ERROR &&
+    errorText.includes('Failed to load agent configuration')
+  ) {
+    return {
+      message:
+        `Failed to load agent "${agentName}": The agent configuration file could not be retrieved from storage. ` +
+        `This may indicate the agent's YAML file is missing or the storage path in the database is incorrect. ` +
+        `Please contact the TeXRA team if this agent should be available.`,
+      shouldContinue: false,
+    };
   }
 
   return {
@@ -89,10 +95,7 @@ function mapHttpError(
   };
 }
 
-/**
- * Maps a database row to RemoteAgentMetadata using schema validation.
- * Shared between listRemoteAgents and getAgentMetadata.
- */
+/** Maps a database row to RemoteAgentMetadata using schema validation. */
 function parseMetadataRow(row: {
   id: string;
   name: string;
@@ -116,6 +119,19 @@ function parseMetadataRow(row: {
     return null;
   }
   return result.data;
+}
+
+/** Set up authenticated Supabase session for database queries. Returns null if not authenticated. */
+async function getAuthenticatedClient() {
+  const tokens = await SupabaseClient.getSessionTokens();
+  if (!tokens) return null;
+
+  const supabase = SupabaseClient.getClient();
+  await supabase.auth.setSession({
+    access_token: tokens.accessToken,
+    refresh_token: tokens.refreshToken,
+  });
+  return supabase;
 }
 
 /**
@@ -218,14 +234,13 @@ export class RemoteAgentLoader {
           throw new Error(message);
         }
 
-        const responseData = await response.json();
         const {
           config: yamlContent,
           name: responseName,
           description,
           visibility,
           agentCategory,
-        } = responseData;
+        } = await response.json();
 
         if (!yamlContent) {
           throw new Error(
@@ -233,7 +248,6 @@ export class RemoteAgentLoader {
           );
         }
 
-        // Parse YAML configuration
         logger.debug(
           CHANNEL,
           `Parsing YAML for remote agent: ${candidateName}`,
@@ -241,13 +255,8 @@ export class RemoteAgentLoader {
         const parsed = yaml.parse(yamlContent);
         const validated = AgentDefinitionSchema.parse(parsed);
 
-        // Extract settings and prompts
-        // Note: Remote agents are expected to be self-contained (no inheritance).
-        // If inherits field is present, it's ignored - merge should happen on upload.
+        // Extract and process settings (remote agents are self-contained, no inheritance)
         const settings: Partial<AgentSetting> = validated.settings;
-        const prompts: Partial<AgentPrompt> = validated.prompts;
-
-        // Resolve tool names to definitions using shared utility
         if (Array.isArray(settings.tools)) {
           const { resolveToolDefinitions } = await import('@tools/registry');
           settings.tools = resolveToolDefinitions(
@@ -257,29 +266,22 @@ export class RemoteAgentLoader {
           );
         }
 
-        const validatedSettings = parseAgentSetting(settings);
-        const validatedPrompts = AgentPromptSchema.parse(prompts);
-
         logger.info(
           CHANNEL,
           `Successfully loaded remote agent: ${agentName} (resolved to ${candidateName})`,
         );
 
-        // Build metadata from edge function response with schema validation
-        // The edge function returns camelCase fields, which matches the schema directly
-        const metadata = RemoteAgentMetadataSchema.parse({
-          id: '', // Not returned by edge function, not used by consumers
-          name: responseName || agentName,
-          description: description,
-          visibility: visibility,
-          agentCategory: agentCategory,
-        });
-
         return {
           name: validated.name || responseName || agentName,
-          settings: validatedSettings,
-          prompts: validatedPrompts,
-          metadata,
+          settings: parseAgentSetting(settings),
+          prompts: AgentPromptSchema.parse(validated.prompts),
+          metadata: RemoteAgentMetadataSchema.parse({
+            id: '',
+            name: responseName || agentName,
+            description,
+            visibility,
+            agentCategory,
+          }),
         };
       } catch (error) {
         // If this is the last candidate, throw the error
@@ -307,30 +309,14 @@ export class RemoteAgentLoader {
     );
   }
 
-  /**
-   * List all available remote agents for the current user.
-   */
+  /** List all available remote agents for the current user. */
   static async listRemoteAgents(): Promise<RemoteAgentMetadata[]> {
-    const isAuth = await SupabaseClient.isAuthenticated();
-    if (!isAuth) {
-      return [];
-    }
+    if (!(await SupabaseClient.isAuthenticated())) return [];
 
     try {
-      const tokens = await SupabaseClient.getSessionTokens();
-      if (!tokens) {
-        return [];
-      }
+      const supabase = await getAuthenticatedClient();
+      if (!supabase) return [];
 
-      const supabase = SupabaseClient.getClient();
-
-      // Set auth session for RLS - requires both tokens
-      await supabase.auth.setSession({
-        access_token: tokens.accessToken,
-        refresh_token: tokens.refreshToken,
-      });
-
-      // RLS will automatically filter based on user's permissions
       const { data, error } = await supabase
         .from('remote_agents')
         .select('id, name, description, visibility, agent_category')
@@ -341,10 +327,8 @@ export class RemoteAgentLoader {
         return [];
       }
 
-      // Map snake_case DB columns to camelCase and validate
-      // Use safeParse to filter invalid records without breaking the entire list
       return (data ?? [])
-        .map((row) => parseMetadataRow(row))
+        .map(parseMetadataRow)
         .filter((item): item is RemoteAgentMetadata => item !== null);
     } catch (error) {
       logger.error(
@@ -355,25 +339,13 @@ export class RemoteAgentLoader {
     }
   }
 
-  /**
-   * Get metadata for a specific remote agent.
-   */
+  /** Get metadata for a specific remote agent. */
   static async getAgentMetadata(
     agentName: string,
   ): Promise<RemoteAgentMetadata | null> {
     try {
-      const tokens = await SupabaseClient.getSessionTokens();
-      if (!tokens) {
-        return null;
-      }
-
-      const supabase = SupabaseClient.getClient();
-
-      // Set auth session for RLS - requires both tokens
-      await supabase.auth.setSession({
-        access_token: tokens.accessToken,
-        refresh_token: tokens.refreshToken,
-      });
+      const supabase = await getAuthenticatedClient();
+      if (!supabase) return null;
 
       const { data, error } = await supabase
         .from('remote_agents')

--- a/src/agent/remote/remoteAgentUtils.ts
+++ b/src/agent/remote/remoteAgentUtils.ts
@@ -62,26 +62,24 @@ async function handleSelectionFallback(
   }
 }
 
+interface SelectAgentOptions {
+  showSuccessMessage?: boolean;
+  copyToClipboardOnFailure?: boolean;
+  source?: AgentSource;
+}
+
 /**
  * Select an agent in the main webview's dropdown.
  * This is the single source of truth for agent selection across the extension.
- *
- * @param agentName - The name of the agent to select
- * @param options - Optional configuration for the selection behavior
- * @returns Result indicating success/failure and any fallback actions taken
  */
 export async function selectAgentInMainView(
   agentName: string,
-  options: {
-    showSuccessMessage?: boolean;
-    copyToClipboardOnFailure?: boolean;
-    source?: AgentSource;
-  } = {},
+  options: SelectAgentOptions = {},
 ): Promise<SelectAgentResult> {
   const {
     showSuccessMessage = true,
     copyToClipboardOnFailure = false,
-    source = 'remote' as AgentSource,
+    source = 'remote',
   } = options;
 
   // Format agent value as source:name for dropdown selection

--- a/src/agent/runtime/ModelFactory.ts
+++ b/src/agent/runtime/ModelFactory.ts
@@ -36,6 +36,8 @@ const PROVIDER_HANDLERS = new Map<
 
 /** Check if OpenAI model should use Responses API. */
 function shouldUseResponsesAPI(config: ModelConfig): boolean {
+  // openRouterOnly models must always route through OpenRouter
+  if (config.openRouterOnly) return false;
   if (config.requiresResponsesAPI) return true;
   if (!getConfig<boolean>('texra.model.useOpenRouter', false)) {
     return (

--- a/src/agent/runtime/ModelFactory.ts
+++ b/src/agent/runtime/ModelFactory.ts
@@ -34,15 +34,37 @@ const PROVIDER_HANDLERS = new Map<
   [ModelProvider.OTHERS, ModelHandlerOpenRouter],
 ]);
 
+/** Check if OpenAI model should use Responses API. */
+function shouldUseResponsesAPI(config: ModelConfig): boolean {
+  if (config.requiresResponsesAPI) return true;
+  if (!getConfig<boolean>('texra.model.useOpenRouter', false)) {
+    return (
+      getConfig<boolean>('texra.model.useOpenAIResponsesAPI', false) ||
+      config.fullName.startsWith('gpt-oss')
+    );
+  }
+  return false;
+}
+
+/** Create config with OpenRouter name for routing. */
+function withOpenRouterName(config: ModelConfig): ModelConfig {
+  return {
+    ...config,
+    openrouterFullName:
+      config.openrouterFullName || `${config.provider}/${config.fullName}`,
+  };
+}
+
 /** Factory class for instantiating appropriate model handlers based on configuration. */
 export class ModelFactory {
   /** Creates a model handler instance based on provider and routing configuration. */
   static createHandler(config: ModelConfig): ModelHandler {
-    const isOpenAI = config.provider === ModelProvider.OPENAI;
-
-    // OpenAI models requiring Responses API must bypass OpenRouter
-    if (isOpenAI && config.requiresResponsesAPI) {
-      logger.debug(CHANNEL, 'Using OpenAI Responses API Handler (required)');
+    // OpenAI Responses API (required or optional)
+    if (
+      config.provider === ModelProvider.OPENAI &&
+      shouldUseResponsesAPI(config)
+    ) {
+      logger.debug(CHANNEL, 'Using OpenAI Responses API Handler');
       return new ModelHandlerOpenAIResponse(config);
     }
 
@@ -51,27 +73,11 @@ export class ModelFactory {
       config.openRouterOnly ||
       getConfig<boolean>('texra.model.useOpenRouter', false);
     if (useOpenRouter) {
-      // Create new config with openrouterFullName to avoid mutating input
-      const openRouterConfig = {
-        ...config,
-        openrouterFullName:
-          config.openrouterFullName || `${config.provider}/${config.fullName}`,
-      };
+      const routerConfig = withOpenRouterName(config);
       if (config.provider === ModelProvider.ANTHROPIC) {
-        return new ModelHandlerAnthropicViaOpenRouter(openRouterConfig);
+        return new ModelHandlerAnthropicViaOpenRouter(routerConfig);
       }
-      return new ModelHandlerOpenRouter(openRouterConfig);
-    }
-
-    // OpenAI models with optional Responses API
-    if (isOpenAI) {
-      const useResponsesAPI =
-        getConfig<boolean>('texra.model.useOpenAIResponsesAPI', false) ||
-        config.fullName.startsWith('gpt-oss');
-      if (useResponsesAPI) {
-        logger.debug(CHANNEL, 'Using OpenAI Responses API Handler');
-        return new ModelHandlerOpenAIResponse(config);
-      }
+      return new ModelHandlerOpenRouter(routerConfig);
     }
 
     // Direct provider handler

--- a/src/agent/runtime/agentLoad.ts
+++ b/src/agent/runtime/agentLoad.ts
@@ -90,8 +90,8 @@ export function ensureAgentTypeForSource<T extends { agentType?: AgentType }>(
   settings: T,
   source: AgentSource,
 ): T {
-  if (source === 'builtInToolUse' && settings.agentType === undefined) {
-    settings.agentType = AgentType.ToolUse;
+  if (source === 'builtInToolUse' && !settings.agentType) {
+    return { ...settings, agentType: AgentType.ToolUse };
   }
   return settings;
 }

--- a/src/agent/runtime/agentLoad.ts
+++ b/src/agent/runtime/agentLoad.ts
@@ -152,7 +152,7 @@ export async function loadAgentSettingAndPrompts(
       });
     }
 
-    ensureAgentTypeForSource(settings, entry.source);
+    settings = ensureAgentTypeForSource(settings, entry.source);
 
     // Resolve tool names to definitions using shared utility
     if (Array.isArray(settings.tools)) {

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -403,14 +403,7 @@ function acquireStreamOrThrow(
   );
 }
 
-/**
- * Validate that config has session metadata, releasing stream on failure.
- *
- * @param config - Agent configuration to validate
- * @param streamId - Stream ID to release if validation fails
- * @param agentType - Type descriptor for error message (e.g., "Agent", "Merge agent")
- * @throws Error if session metadata is missing
- */
+/** Validate that config has session metadata, releasing stream on failure. */
 function ensureSessionMetadata(
   config: AgentConfig,
   streamId: StreamTabId,
@@ -422,19 +415,12 @@ function ensureSessionMetadata(
   }
 }
 
-/**
- * Create a usage recorder callback for flow execution.
- *
- * This callback is invoked when a round is finalized and records usage
- * statistics via the usage monitor.
- */
+/** Create a usage recorder callback for flow execution. */
 function createUsageRecorder(
   usageMonitor: UsageMonitor,
   runKind: 'workflow' | 'tool-use' = 'workflow',
 ): () => RoundFinalizedCallback {
-  return () => async (run) => {
-    await usageMonitor.recordUsage(run, { runKind });
-  };
+  return () => (run) => usageMonitor.recordUsage(run, { runKind });
 }
 
 type FlowRunner = () => Promise<EndGroupStatus>;
@@ -449,13 +435,12 @@ async function runFlowWithLifecycle(
     const flowStatus = await runner();
     ctx.runStage.end(flowStatus);
 
-    // Update stream status, preserving WAITING and STOPPED states
     if (!StreamStatusService.shouldPreserveOnCompletion(streamTabId)) {
-      const newStatus =
-        flowStatus === 'error' ? STREAM_STATUS.ERROR : STREAM_STATUS.STOPPED;
-      StreamStatusService.set(streamTabId, newStatus);
+      StreamStatusService.set(
+        streamTabId,
+        flowStatus === 'error' ? STREAM_STATUS.ERROR : STREAM_STATUS.STOPPED,
+      );
     }
-
     logger.debug(`Task completed with status: ${flowStatus}`);
   } catch (error) {
     ctx.runStage.end(END_GROUP_STATUS.ERROR);
@@ -473,14 +458,13 @@ function showAgentNotification(config: AgentConfig): void {
   const inputName = config.inputFile
     ? path.basename(config.inputFile)
     : 'selected input';
-
   const outputFiles = config.outputFiles ?? [];
-  let outputInfo = '';
-  if (config.useMultipleOutputs && outputFiles.length > 1) {
-    outputInfo = `to ${outputFiles.length} files`;
-  } else if (outputFiles[0]) {
-    outputInfo = `to ${path.basename(outputFiles[0])}`;
-  }
+  const outputInfo =
+    config.useMultipleOutputs && outputFiles.length > 1
+      ? `to ${outputFiles.length} files`
+      : outputFiles[0]
+        ? `to ${path.basename(outputFiles[0])}`
+        : '';
 
   void vscode.window
     .showInformationMessage(
@@ -492,9 +476,9 @@ function showAgentNotification(config: AgentConfig): void {
       },
       'Show ProgressBoard',
     )
-    .then((sel) => {
-      if (sel) void vscode.commands.executeCommand('texra.showProgressView');
-    });
+    .then(
+      (sel) => sel && vscode.commands.executeCommand('texra.showProgressView'),
+    );
 }
 
 /** Show API key error notification with action buttons. */

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -381,35 +381,26 @@ async function resolveAgentBase(
 // Flow Execution Helpers
 // ============================================================================
 
+const STATUS_MESSAGES: Record<string, string> = {
+  [STREAM_STATUS.INITIALIZING]: 'already launching',
+  [STREAM_STATUS.RESUMING]: 'resuming',
+};
+
 /**
  * Acquire stream for execution or throw if already in use.
  * Must be called before expensive resolution to prevent race conditions.
- *
- * @param streamId - The stream ID to acquire
- * @param taskType - Type descriptor for error message (e.g., "Task", "Merge task")
- * @throws Error if stream is already initializing, running, or resuming
  */
 function acquireStreamOrThrow(
   streamId: StreamTabId,
   taskType: string = 'Task',
 ): void {
-  if (!StreamStatusService.tryAcquire(streamId)) {
-    const currentStatus = StreamStatusService.get(streamId);
-    let statusMsg: string;
-    switch (currentStatus) {
-      case STREAM_STATUS.INITIALIZING:
-        statusMsg = 'already launching';
-        break;
-      case STREAM_STATUS.RESUMING:
-        statusMsg = 'resuming';
-        break;
-      default:
-        statusMsg = 'already running';
-    }
-    throw new Error(
-      `${taskType} "${streamId}" is ${statusMsg}. Please wait for it to complete or stop it first.`,
-    );
-  }
+  if (StreamStatusService.tryAcquire(streamId)) return;
+
+  const status = StreamStatusService.get(streamId) ?? '';
+  const statusMsg = STATUS_MESSAGES[status] || 'already running';
+  throw new Error(
+    `${taskType} "${streamId}" is ${statusMsg}. Please wait for it to complete or stop it first.`,
+  );
 }
 
 /**

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -384,6 +384,7 @@ async function resolveAgentBase(
 const STATUS_MESSAGES: Record<string, string> = {
   [STREAM_STATUS.INITIALIZING]: 'already launching',
   [STREAM_STATUS.RESUMING]: 'resuming',
+  [STREAM_STATUS.RUNNING]: 'already running',
 };
 
 /**

--- a/src/model/computeModelOptions.ts
+++ b/src/model/computeModelOptions.ts
@@ -2,61 +2,77 @@
 import { getServerSideKeyService } from '@auth/serverKeys';
 import { SecretManager, ApiProvider } from '@frontend/secretManager';
 import { MODEL_CONFIGS } from '@model/ModelRegistry';
+import type { ModelConfig } from '@model/ModelConfig';
 import { getConfig } from '@utils/config';
 
-/**
- * Format context window number for display
- */
+/** Format context window number for display. */
 function formatContext(context: number): string {
   if (context >= 1000000) return `${(context / 1000000).toFixed(1)}M`;
   if (context >= 1000) return `${Math.round(context / 1000)}K`;
   return context.toString();
 }
 
-/**
- * Format cost values for display
- */
+/** Format cost values for display. */
 function formatCost(inputPrice?: number, outputPrice?: number): string {
   if (inputPrice === undefined || outputPrice === undefined) return '';
   return `$${inputPrice.toFixed(3)}/$${outputPrice.toFixed(3)}`;
 }
 
-/**
- * Check if a model is available via personal API keys.
- * Called only when server-side access is not available and user is in "Use My Own Keys" mode.
- */
-async function checkPersonalKeyAvailability(
-  config: {
-    openRouterOnly?: boolean;
-    openrouterFullName?: string;
-    provider: string;
-  },
+/** Check if a model is available via personal API keys. */
+async function hasPersonalKeyForModel(
+  config: ModelConfig,
   hasOpenRouter: boolean,
 ): Promise<boolean> {
-  // openRouterOnly models can ONLY use OpenRouter
-  if (config.openRouterOnly) {
-    return hasOpenRouter;
-  }
+  // openRouterOnly models require OpenRouter
+  if (config.openRouterOnly) return hasOpenRouter;
 
   // Providers not in API_PROVIDERS don't require keys (e.g., COPILOT)
-  const provider = config.provider;
-  if (!SecretManager.API_PROVIDERS.includes(provider as ApiProvider)) {
+  if (!SecretManager.API_PROVIDERS.includes(config.provider as ApiProvider)) {
     return true;
   }
 
-  // Check provider-specific API key
+  // Check provider-specific API key or OpenRouter fallback
   try {
-    const hasProviderKey = await SecretManager.apiKeyExists(
-      provider as ApiProvider,
-    );
-    if (hasProviderKey) return true;
-
-    // Fall back to OpenRouter for models that support it
+    if (await SecretManager.apiKeyExists(config.provider as ApiProvider)) {
+      return true;
+    }
     return Boolean(config.openrouterFullName && hasOpenRouter);
-  } catch (error) {
-    console.warn(`Failed to check API key for ${provider}:`, error);
+  } catch {
     return false;
   }
+}
+
+interface ModelAvailabilityContext {
+  hasOpenRouter: boolean;
+  hasServerAccess: boolean;
+  useIncludedAccess: boolean;
+  serverSideKeyService: ReturnType<typeof getServerSideKeyService>;
+}
+
+/** Determine if a model is available based on access mode and keys. */
+async function isModelAvailable(
+  model: string,
+  config: ModelConfig,
+  ctx: ModelAvailabilityContext,
+): Promise<boolean> {
+  // openRouterOnly models always need OpenRouter key
+  if (config.openRouterOnly) return ctx.hasOpenRouter;
+
+  // Check server-side relay availability
+  if (
+    ctx.hasServerAccess &&
+    ctx.serverSideKeyService.isProviderOnServer(config.provider) &&
+    ctx.serverSideKeyService.canUseModelSync(model)
+  ) {
+    return true;
+  }
+
+  // Fall back to personal API keys (only when not in "Use Included Access" mode)
+  if (!ctx.useIncludedAccess) {
+    return hasPersonalKeyForModel(config, ctx.hasOpenRouter);
+  }
+
+  return false;
 }
 
 /**
@@ -69,81 +85,65 @@ async function checkPersonalKeyAvailability(
  * - Max tier: Only specific cheaper models available via relay (configured remotely)
  * - Free tier: Must bring own API keys
  *
- * When "Use Included Access" is enabled, only server-side availability is checked.
- * When "Use My Own Keys" is selected, personal API keys are checked as fallback.
- *
  * Note: Selection preservation is handled client-side via _markOptionAsSelected
  * in the webview, which uses DOMParser to add the 'selected' attribute based
  * on the current dropdown value before setting innerHTML.
  */
 export async function computeModelOptions(): Promise<string> {
   const models = getConfig<string[]>('texra.models', []);
-  const hasOpenRouter = await SecretManager.apiKeyExists('openRouter');
 
-  // Prime the server-side keys cache (fetches tier config + enabled providers)
-  // This ensures canUseServerSideKeysForModel has the data it needs
+  // Prime caches for availability checks
   const serverSideKeyService = getServerSideKeyService();
-  const hasAnyServerSideAccess =
-    await serverSideKeyService.canUseServerSideKeys();
+  const [hasOpenRouter, hasServerAccess] = await Promise.all([
+    SecretManager.apiKeyExists('openRouter'),
+    serverSideKeyService.canUseServerSideKeys(),
+  ]);
 
-  // Check if user wants to use included access (no personal key fallback)
-  const useIncludedAccess = serverSideKeyService.getUseIncludedModelAccess();
+  const availabilityCtx: ModelAvailabilityContext = {
+    hasOpenRouter,
+    hasServerAccess,
+    useIncludedAccess: serverSideKeyService.getUseIncludedModelAccess(),
+    serverSideKeyService,
+  };
 
-  // Build option tags for each model
-  // Server-side checks are sync (caches primed above), personal key checks are async
   const optionTags = await Promise.all(
-    models.map(async (model) => {
-      const config = MODEL_CONFIGS[model];
-      if (!config) {
-        return `<vscode-option value="${model}">${model}</vscode-option>`;
-      }
-
-      const provider = config.provider;
-
-      // Determine model availability with clear priority order
-      let available = false;
-      if (config.openRouterOnly) {
-        // openRouterOnly models NEVER use server-side - always need OpenRouter key
-        available = hasOpenRouter;
-      } else if (
-        hasAnyServerSideAccess &&
-        serverSideKeyService.isProviderOnServer(provider) &&
-        serverSideKeyService.canUseModelSync(model)
-      ) {
-        // Server-side relay available for this model
-        available = true;
-      } else if (!useIncludedAccess) {
-        // Fall back to personal API keys (only when not in "Use Included Access" mode)
-        available = await checkPersonalKeyAvailability(config, hasOpenRouter);
-      }
-
-      // Build option tag with data attributes
-      const contextStr =
-        config.contextWindow !== null && config.contextWindow !== undefined
-          ? formatContext(config.contextWindow)
-          : '';
-      const costStr = formatCost(config.inputPrice, config.outputPrice);
-
-      // Build description from context and cost
-      const descriptionParts = [
-        contextStr && `Context: ${contextStr}`,
-        costStr && `Cost (in/out per 1M): ${costStr}`,
-      ].filter(Boolean);
-
-      const attrs = [
-        `value="${model}"`,
-        !available &&
-          'data-requires-key="true" class="disabled-option disabled-model"',
-        provider && `data-provider="${provider}"`,
-        contextStr && `data-context="${contextStr}"`,
-        costStr && `data-cost="${costStr}"`,
-        descriptionParts.length > 0 &&
-          `description="${descriptionParts.join(' | ')}"`,
-      ].filter(Boolean);
-
-      return `<vscode-option ${attrs.join(' ')}>${model}</vscode-option>`;
-    }),
+    models.map((model) => buildModelOption(model, availabilityCtx)),
   );
 
   return optionTags.join('\n');
+}
+
+/** Build a single model option tag. */
+async function buildModelOption(
+  model: string,
+  ctx: ModelAvailabilityContext,
+): Promise<string> {
+  const config = MODEL_CONFIGS[model];
+  if (!config) {
+    return `<vscode-option value="${model}">${model}</vscode-option>`;
+  }
+
+  const available = await isModelAvailable(model, config, ctx);
+  const contextStr = config.contextWindow
+    ? formatContext(config.contextWindow)
+    : '';
+  const costStr = formatCost(config.inputPrice, config.outputPrice);
+
+  const attrs = [
+    `value="${model}"`,
+    !available &&
+      'data-requires-key="true" class="disabled-option disabled-model"',
+    config.provider && `data-provider="${config.provider}"`,
+    contextStr && `data-context="${contextStr}"`,
+    costStr && `data-cost="${costStr}"`,
+    (contextStr || costStr) &&
+      `description="${[
+        contextStr && `Context: ${contextStr}`,
+        costStr && `Cost (in/out per 1M): ${costStr}`,
+      ]
+        .filter(Boolean)
+        .join(' | ')}"`,
+  ].filter(Boolean);
+
+  return `<vscode-option ${attrs.join(' ')}>${model}</vscode-option>`;
 }

--- a/src/profileView/ProfileViewMessageHandler.ts
+++ b/src/profileView/ProfileViewMessageHandler.ts
@@ -92,15 +92,15 @@ export class ProfileViewMessageHandler extends BaseViewMessageHandler<
     const authContext = await SupabaseClient.getUserAuthContext();
 
     // Fetch remote agents - RLS filters based on user's permissions
-    // All authenticated users can see agents matching their visibility access
     await loadAgents();
-    const entries = getAgentsBySource('remote' as AgentSource);
-    const remoteAgents: RemoteAgentPayload[] = entries.map((entry) => ({
+    const remoteAgents: RemoteAgentPayload[] = getAgentsBySource(
+      'remote' as AgentSource,
+    ).map((entry) => ({
       name: entry.name,
       description: entry.description || '',
       visibility: entry.visibility || ['public'],
       category: entry.category || AgentCategory.Workflow,
-      supportsMultipleOutput: !!entry.multiplePath,
+      supportsMultipleOutput: Boolean(entry.multiplePath),
     }));
 
     // Get model access settings from the service (caches already primed)

--- a/src/webview/MainViewMessageHandler.ts
+++ b/src/webview/MainViewMessageHandler.ts
@@ -417,29 +417,31 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
     }
     await super.handleWebviewReady(_message, webviewView);
     try {
-      const modelOptions = await computeModelOptions();
+      // Fetch options and auth status concurrently
+      const [modelOptions, agentOptions, authStatus] = await Promise.all([
+        computeModelOptions(),
+        computeAgentOptions(),
+        getAuthStatus(),
+      ]);
+
       webviewView.webview.postMessage({
         command: MAIN_VIEW_COMMANDS.SET_MODEL_OPTIONS,
         options: modelOptions,
       });
-
-      const agentOptions = await computeAgentOptions();
       webviewView.webview.postMessage({
         command: MAIN_VIEW_COMMANDS.SET_AGENT_OPTIONS,
         options: agentOptions,
       });
 
-      const showLoginBanner = getConfig<boolean>('ui.showLoginBanner', true);
-      const authStatus = await getAuthStatus();
-      if (showLoginBanner && !authStatus.authenticated) {
-        webviewView.webview.postMessage({
-          command: MAIN_VIEW_COMMANDS.SHOW_LOGIN_BANNER,
-        });
-      } else if (authStatus.authenticated) {
-        webviewView.webview.postMessage({
-          command: MAIN_VIEW_COMMANDS.HIDE_LOGIN_BANNER,
-        });
-      }
+      // Show login banner if not authenticated and banner not dismissed
+      const showBanner =
+        !authStatus.authenticated &&
+        getConfig<boolean>('ui.showLoginBanner', true);
+      webviewView.webview.postMessage({
+        command: showBanner
+          ? MAIN_VIEW_COMMANDS.SHOW_LOGIN_BANNER
+          : MAIN_VIEW_COMMANDS.HIDE_LOGIN_BANNER,
+      });
     } catch (error) {
       this.logger.error(
         this.channel,


### PR DESCRIPTION
- Extract shouldUseResponsesAPI and withOpenRouterName helpers in ModelFactory
- Consolidate OpenAI Responses API handling into single check
- Extract isModelAvailable and buildModelOption helpers in computeModelOptions
- Parallelize model/agent options and auth status fetching in MainViewMessageHandler
- Simplify login banner logic using conditional command selection
- Replace switch statement with map lookup in acquireStreamOrThrow
- Consolidate remote agent entry building in agentRegistry
- Use optional chaining for multiplePath and defaultOutputFiles
- Simplify filterVisible with single expression filter
- Extract SelectAgentOptions interface in remoteAgentUtils

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Focuses on simplifying selection logic and tightening remote agent handling.
> 
> - **Agent registry:** Introduces `LOOKUP_PRIORITY` for consistent precedence; simplifies `getAgent` lookup and dedupe; minor cleanups (`defaultOutputFiles`, sorting, filters, type mapping).
> - **Remote agent loader:** Adds `getAuthenticatedClient`; refactors HTTP error mapping; streamlines JSON parsing and schema validation; consolidates entry building and metadata parsing; cleaner list/metadata queries.
> - **Model routing:** Extracts `shouldUseResponsesAPI` and `withOpenRouterName`; unifies OpenAI Responses API decision and OpenRouter routing in `ModelFactory`.
> - **Model options:** Extracts `hasPersonalKeyForModel`, `isModelAvailable`, and `buildModelOption`; primes availability checks concurrently; clarifies availability rules.
> - **Runtime execution:** Replaces switch with status map in `acquireStreamOrThrow`; simplifies usage recorder and notifications; immutably enforces tool-use type via `ensureAgentTypeForSource`.
> - **Webviews:** Parallelizes fetching model/agent options and auth status; simplifies login banner show/hide logic; minor payload cleanups in Profile view.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a8b75e5c736f56ee873dd2949a127b106fda7f05. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->