### PR TITLE
refactor: simplify progressView state and UI managers

### DIFF
--- a/src/common/modules/StreamScopedMap.js
+++ b/src/common/modules/StreamScopedMap.js
@@ -73,6 +73,19 @@ export class StreamScopedMap {
   }
 
   /**
+   * Clear a specific stream's value or all values.
+   * Convenience method for the common pattern: clear one stream or clear all.
+   * @param {string|null|undefined} streamId - Stream to clear, or null/undefined to clear all
+   */
+  clearStreamOrAll(streamId) {
+    if (streamId == null) {
+      this._data.clear();
+    } else {
+      this.delete(streamId);
+    }
+  }
+
+  /**
    * Get the number of stored entries.
    * @returns {number}
    */

--- a/src/progressView/modules/formatters/index.js
+++ b/src/progressView/modules/formatters/index.js
@@ -60,31 +60,30 @@ export class LogEntryFormatter {
   }
 
   _buildFormatterMap() {
-    // Helper to wrap formatter functions with error handling
+    // Wrapper for error handling
     const safe = (fn, label) => (m) => safeFormat(() => fn(m), label);
 
-    // Banner formatter factory for thinking/scratchpad
-    const banner = (title) => (m) =>
-      formatBannerContent(
-        m.normalizedPayload,
-        title,
-        m.id,
-        m.groupId,
-        m.timestamp,
-      );
-
-    // Data formatter factory for payload+id patterns
-    const data = (fn) => (m) => fn(m.normalizedPayload, m.id);
-
-    // Meta formatter factory for payload+id+groupId+timestamp patterns
-    const meta = (fn) => (m) =>
+    // Field extractors for common formatter signatures
+    const withPayloadId = (fn) => (m) => fn(m.normalizedPayload, m.id);
+    const withFullMeta = (fn) => (m) =>
       fn(m.normalizedPayload, m.id, m.groupId, m.timestamp);
 
+    // Banner formatter (thinking/scratchpad)
+    const banner = (title) =>
+      withFullMeta((p, id, gid, ts) =>
+        formatBannerContent(p, title, id, gid, ts),
+      );
+
     return {
+      // Collapsible content banners
       thinking: safe(banner('Thinking'), 'thinking'),
       scratchpad: safe(banner('Scratchpad'), 'scratchpad'),
-      toolUse: safe(meta(formatToolUse), 'tool use'),
-      webSearch: safe(meta(formatWebSearch), 'web search'),
+
+      // Tool/search results (need full metadata)
+      toolUse: safe(withFullMeta(formatToolUse), 'tool use'),
+      webSearch: safe(withFullMeta(formatWebSearch), 'web search'),
+
+      // Model response (custom field mapping)
       modelResponse: safe(
         (m) =>
           formatModelResponse({
@@ -97,15 +96,22 @@ export class LogEntryFormatter {
           }),
         'Assistant',
       ),
-      fileList: safe(data(formatFileList), 'file list'),
-      missingOutputs: safe(data(formatMissingOutputs), 'missing outputs'),
-      latexdiff: safe(data(formatLatexdiff), 'latexdiff'),
-      statistics: safe(data(formatStatistics), 'statistics'),
+
+      // Data formatters (payload + id only)
+      fileList: safe(withPayloadId(formatFileList), 'file list'),
+      missingOutputs: safe(
+        withPayloadId(formatMissingOutputs),
+        'missing outputs',
+      ),
+      latexdiff: safe(withPayloadId(formatLatexdiff), 'latexdiff'),
+      statistics: safe(withPayloadId(formatStatistics), 'statistics'),
       contextManagement: safe(
-        data(formatContextManagement),
+        withPayloadId(formatContextManagement),
         'context management',
       ),
-      contextState: () => null, // Displayed in footer, not inline
+
+      // Special cases
+      contextState: () => null, // Displayed in footer
       userMessage: safe(
         (m) => formatUserMessage(m.normalizedPayload, m.id, m.timestamp),
         'user message',

--- a/src/progressView/modules/formatters/index.js
+++ b/src/progressView/modules/formatters/index.js
@@ -60,7 +60,7 @@ export class LogEntryFormatter {
   }
 
   _buildFormatterMap() {
-    // Wrapper for error handling
+    // Wrap formatter functions with error handling for graceful degradation
     const safe = (fn, label) => (m) => safeFormat(() => fn(m), label);
 
     // Field extractors for common formatter signatures

--- a/src/progressView/modules/progressViewState.js
+++ b/src/progressView/modules/progressViewState.js
@@ -162,12 +162,14 @@ class RunScopedMap {
   }
 
   delete(streamId, runId) {
-    const runs = this._getOrCreateStreamMap(streamId, runId);
+    const stream = runId ? this._resolveStreamId(streamId) : null;
+    if (!stream) return;
+
+    const runs = this._data.get(stream);
     if (!runs) return;
 
     runs.delete(runId);
     if (runs.size === 0) {
-      const stream = this._resolveStreamId(streamId);
       this._data.delete(stream);
     }
   }

--- a/src/progressView/modules/progressViewState.js
+++ b/src/progressView/modules/progressViewState.js
@@ -133,30 +133,38 @@ class RunScopedMap {
     this._data = new Map();
   }
 
-  set(streamId, runId, value) {
+  /** Resolve stream and get its run map, optionally creating if missing */
+  _getOrCreateStreamMap(streamId, runId, create = false) {
     const stream = runId ? this._resolveStreamId(streamId) : null;
-    if (!stream) return;
+    if (!stream) return null;
 
     let runs = this._data.get(stream);
-    if (!runs) {
+    if (!runs && create) {
       runs = new Map();
       this._data.set(stream, runs);
     }
-    runs.set(runId, value);
+    return runs ?? null;
+  }
+
+  set(streamId, runId, value) {
+    const runs = this._getOrCreateStreamMap(streamId, runId, true);
+    if (runs) runs.set(runId, value);
   }
 
   get(streamId, runId) {
     if (!runId) return null;
-    return this.getStreamMap(streamId)?.get(runId) ?? null;
+    return this._getOrCreateStreamMap(streamId, runId)?.get(runId) ?? null;
   }
 
   delete(streamId, runId) {
-    const stream = runId ? this._resolveStreamId(streamId) : null;
-    const runs = stream ? this._data.get(stream) : null;
+    const runs = this._getOrCreateStreamMap(streamId, runId);
     if (!runs) return;
 
     runs.delete(runId);
-    if (runs.size === 0) this._data.delete(stream);
+    if (runs.size === 0) {
+      const stream = this._resolveStreamId(streamId);
+      this._data.delete(stream);
+    }
   }
 
   clearStream(streamId) {

--- a/src/progressView/modules/progressViewState.js
+++ b/src/progressView/modules/progressViewState.js
@@ -85,13 +85,18 @@ class TaskGroups {
     return [...(this.childrenByParent.get(parentId) ?? [])];
   }
 
-  _linkChild(parentId, childId) {
+  /** Get or create children set for a parent */
+  _getChildrenSet(parentId) {
     let children = this.childrenByParent.get(parentId);
     if (!children) {
       children = new Set();
       this.childrenByParent.set(parentId, children);
     }
-    children.add(childId);
+    return children;
+  }
+
+  _linkChild(parentId, childId) {
+    this._getChildrenSet(parentId).add(childId);
     this.parentByChild.set(childId, parentId);
   }
 
@@ -363,21 +368,15 @@ export class ProgressViewState {
       this.runUsage,
     ];
     for (const runMap of runMaps) {
-      const streamMap = runMap.getStreamMap(streamId);
-      if (streamMap) {
-        for (const runId of streamMap.keys()) {
-          if (runId) {
-            candidates.add(runId);
-          }
-        }
+      const keys = runMap.getStreamMap(streamId)?.keys();
+      if (keys) {
+        for (const runId of keys) if (runId) candidates.add(runId);
       }
     }
 
-    // Add root task group IDs
+    // Add root task group IDs (groups without a parent)
     for (const group of this.taskGroups.getGroupMap().values()) {
-      if (group && !group.parentGroupId) {
-        candidates.add(group.id);
-      }
+      if (group && !group.parentGroupId) candidates.add(group.id);
     }
 
     return candidates;

--- a/src/progressView/modules/taskManagers.js
+++ b/src/progressView/modules/taskManagers.js
@@ -41,6 +41,11 @@ export class TaskGroupDomManager {
     }
 
     // Child groups need a header and collapsible details wrapper
+    return this._createChildGroupElement(group, groupContainer);
+  }
+
+  /** Create collapsible details element for child groups */
+  _createChildGroupElement(group, groupContainer) {
     const headerElement = this.headerFormatter.create(group);
     if (!headerElement) return null;
 
@@ -50,17 +55,21 @@ export class TaskGroupDomManager {
     detailsElem.appendChild(headerElement);
     detailsElem.appendChild(groupContainer);
 
-    // Restore collapsed state: toggleStates stores whether collapsed (true = collapsed)
-    const isCollapsed = progressViewState.toggleStates.get(group.id) === true;
-    detailsElem.open = !isCollapsed;
-    const toggleListener = () => {
-      progressViewState.toggleStates.set(group.id, !detailsElem.open);
-    };
-    detailsElem.addEventListener('toggle', toggleListener);
-    this.toggleListeners.set(group.id, toggleListener);
-
+    this._setupToggleState(group.id, detailsElem);
     this._registerGroupElement(group, detailsElem);
     return detailsElem;
+  }
+
+  /** Set up toggle state persistence for a collapsible group */
+  _setupToggleState(groupId, detailsElem) {
+    const isCollapsed = progressViewState.toggleStates.get(groupId) === true;
+    detailsElem.open = !isCollapsed;
+
+    const toggleListener = () => {
+      progressViewState.toggleStates.set(groupId, !detailsElem.open);
+    };
+    detailsElem.addEventListener('toggle', toggleListener);
+    this.toggleListeners.set(groupId, toggleListener);
   }
 
   /**

--- a/src/progressView/modules/uiManagers/FileList.js
+++ b/src/progressView/modules/uiManagers/FileList.js
@@ -149,45 +149,51 @@ export class FileList {
     const filePath = file.location.absolutePath;
     const diffBase = file.lineage?.diffBase?.absolutePath;
 
-    // Standard buttons that use effectiveBase
-    const standardButtons = [
+    // Configure standard buttons (require effectiveBase)
+    const buttonConfigs = [
       { selector: '.compare-btn', command: COMMANDS.COMPARE_ORIGINAL },
       { selector: '.accept-btn', command: COMMANDS.ACCEPT_FILE },
       { selector: '.merge-btn', command: COMMANDS.MERGE_FILE },
       { selector: '.diff-btn', command: COMMANDS.LATEXDIFF_FILE },
     ];
 
-    for (const { selector, command } of standardButtons) {
-      const btn = clone.querySelector(selector);
-      if (!btn) continue;
-      if (effectiveBase) {
-        btn.dataset.command = command;
-        btn.dataset.file = filePath;
-        btn.dataset.base = effectiveBase;
-      } else {
-        btn.style.display = 'none';
-      }
+    for (const { selector, command } of buttonConfigs) {
+      this._configureButton(clone, selector, effectiveBase, {
+        command,
+        file: filePath,
+        base: effectiveBase,
+      });
     }
 
-    // Previous button has special handling
-    const prevBtn = clone.querySelector('.prev-btn');
-    if (prevBtn) {
-      if (diffBase) {
-        prevBtn.dataset.command = COMMANDS.COMPARE_PREVIOUS;
-        prevBtn.dataset.file = filePath;
-        prevBtn.dataset.prev = diffBase;
-        if (effectiveBase) prevBtn.dataset.base = effectiveBase;
-      } else {
-        prevBtn.style.display = 'none';
-      }
-    }
+    // Previous button (requires diffBase)
+    this._configureButton(clone, '.prev-btn', diffBase, {
+      command: COMMANDS.COMPARE_PREVIOUS,
+      file: filePath,
+      prev: diffBase,
+      ...(effectiveBase && { base: effectiveBase }),
+    });
 
-    // File path link
+    // File path link (always enabled)
     const filePathSpan = clone.querySelector('.file-path');
     if (filePathSpan) {
       filePathSpan.classList.add('clickable-link');
       filePathSpan.dataset.command = COMMANDS.OPEN_FILE;
       filePathSpan.dataset.file = filePath;
+    }
+  }
+
+  /**
+   * Configure a button: set dataset if condition met, hide otherwise
+   * @private
+   */
+  _configureButton(clone, selector, condition, datasetValues) {
+    const btn = clone.querySelector(selector);
+    if (!btn) return;
+
+    if (condition) {
+      Object.assign(btn.dataset, datasetValues);
+    } else {
+      btn.style.display = 'none';
     }
   }
 

--- a/src/progressView/modules/uiManagers/StreamTabs.js
+++ b/src/progressView/modules/uiManagers/StreamTabs.js
@@ -92,23 +92,22 @@ export class StreamTabs {
   _buildTooltip(info, includeLastActivity = false) {
     if (!info) return '';
 
-    const parts = [
+    const mainParts = [
       info.label,
       info.model && `Model: ${info.model}`,
       info.inputFile && `Input: ${info.inputFile}`,
     ].filter(Boolean);
 
+    const mainLine = mainParts.join(' • ');
+
+    // Add last activity on separate line if requested and available
     if (includeLastActivity && info.lastTimestamp) {
       const lastSeen = formatRelativeTime(info.lastTimestamp);
-      if (lastSeen) parts.push(`Last activity ${lastSeen}`);
+      if (lastSeen && mainLine) return `${mainLine}\nLast activity ${lastSeen}`;
+      if (lastSeen) return `Last activity ${lastSeen}`;
     }
 
-    // Use newline before last activity when present and multiple parts
-    if (includeLastActivity && parts.length > 1) {
-      const lastPart = parts.pop();
-      return `${parts.join(' • ')}\n${lastPart}`;
-    }
-    return parts.join(' • ');
+    return mainLine;
   }
 
   /**

--- a/src/progressView/modules/usageManagers.js
+++ b/src/progressView/modules/usageManagers.js
@@ -33,21 +33,18 @@ export class UsageSummary {
     this._footerElem = null;
   }
 
-  /** Get cached element or fetch by ID, validating connection */
-  _getCachedElement(cacheKey, elementId) {
-    if (this[cacheKey]?.isConnected) return this[cacheKey];
-    this[cacheKey] = document.getElementById(elementId);
-    return this[cacheKey];
-  }
-
-  /** Get the summary element with caching */
+  /** Get the summary element with caching and connection validation */
   _getSummary() {
-    return this._getCachedElement('_summaryElem', ELEMENT_IDS.RUN_SUMMARY);
+    if (this._summaryElem?.isConnected) return this._summaryElem;
+    this._summaryElem = document.getElementById(ELEMENT_IDS.RUN_SUMMARY);
+    return this._summaryElem;
   }
 
-  /** Get the context element with caching */
+  /** Get the context element with caching and connection validation */
   _getContext() {
-    return this._getCachedElement('_contextElem', ELEMENT_IDS.CONTEXT_STATE);
+    if (this._contextElem?.isConnected) return this._contextElem;
+    this._contextElem = document.getElementById(ELEMENT_IDS.CONTEXT_STATE);
+    return this._contextElem;
   }
 
   /** Get the footer element, deriving from anchor elements */

--- a/src/progressView/modules/usageManagers.js
+++ b/src/progressView/modules/usageManagers.js
@@ -33,12 +33,24 @@ export class UsageSummary {
     this._footerElem = null;
   }
 
-  /**
-   * Get the footer element, caching it after first successful lookup.
-   * Only caches when a valid footer is found to allow retry if called early.
-   * Checks isConnected to handle webview refresh scenarios.
-   * @returns {HTMLElement|null}
-   */
+  /** Get cached element or fetch by ID, validating connection */
+  _getCachedElement(cacheKey, elementId) {
+    if (this[cacheKey]?.isConnected) return this[cacheKey];
+    this[cacheKey] = document.getElementById(elementId);
+    return this[cacheKey];
+  }
+
+  /** Get the summary element with caching */
+  _getSummary() {
+    return this._getCachedElement('_summaryElem', ELEMENT_IDS.RUN_SUMMARY);
+  }
+
+  /** Get the context element with caching */
+  _getContext() {
+    return this._getCachedElement('_contextElem', ELEMENT_IDS.CONTEXT_STATE);
+  }
+
+  /** Get the footer element, deriving from anchor elements */
   _getFooter() {
     if (this._footerElem?.isConnected) return this._footerElem;
     const anchor = this._summaryElem || this._contextElem;
@@ -48,21 +60,11 @@ export class UsageSummary {
     return this._footerElem;
   }
 
-  /**
-   * Sync footer visibility based on whether context is displayed.
-   * @param {HTMLElement|null} footer - The footer element
-   */
+  /** Sync footer visibility based on whether context is displayed */
   _syncFooterVisibility(footer) {
     if (!footer) return;
-    this._ensureContextElem();
-    footer.hidden = this._contextElem?.hidden !== false;
-  }
-
-  /**
-   * Cache the context element if not already cached.
-   */
-  _ensureContextElem() {
-    this._contextElem ??= document.getElementById(ELEMENT_IDS.CONTEXT_STATE);
+    const contextElem = this._getContext();
+    footer.hidden = contextElem?.hidden !== false;
   }
 
   /**
@@ -71,11 +73,8 @@ export class UsageSummary {
    * @param {Object} [usage] - Optional pre-computed usage totals
    */
   update(usage) {
-    // Cache the summary element
-    if (!this._summaryElem) {
-      this._summaryElem = document.getElementById(ELEMENT_IDS.RUN_SUMMARY);
-    }
-    if (!this._summaryElem) return;
+    const summaryElem = this._getSummary();
+    if (!summaryElem) return;
 
     const footer = this._getFooter();
     // If usage is not provided, compute it from existing log groups
@@ -88,8 +87,8 @@ export class UsageSummary {
     const cacheCreationTokens = totals?.cacheCreationInputTokens ?? 0;
 
     if (!inputTokens && !outputTokens && !cost) {
-      this._summaryElem.textContent = '';
-      this._summaryElem.removeAttribute('aria-label');
+      summaryElem.textContent = '';
+      summaryElem.removeAttribute('aria-label');
       this._syncFooterVisibility(footer);
       return;
     }
@@ -114,7 +113,7 @@ export class UsageSummary {
       'cache creation tokens',
     );
 
-    this._summaryElem.innerHTML = `
+    summaryElem.innerHTML = `
       <i class="codicon codicon-meter"></i>
       <span class="run-summary__label">Total usage:</span>
       <span class="run-summary__value">
@@ -123,7 +122,7 @@ export class UsageSummary {
         ${formattedCost}
       </span>
     `;
-    this._summaryElem.setAttribute(
+    summaryElem.setAttribute(
       'aria-label',
       `Total usage: ${formattedInput} input tokens${cacheRead.aria}${cacheCreation.aria}, ${formattedOutput} output tokens, ${formattedCost}`,
     );
@@ -157,34 +156,32 @@ export class UsageSummary {
    * @param {{ inputTokens: number, contextWindow: number, utilizationPercent: number }} contextState
    */
   updateContextDisplay(contextState) {
-    this._ensureContextElem();
-    if (!this._contextElem) return;
+    const contextElem = this._getContext();
+    if (!contextElem) return;
 
     const { inputTokens, contextWindow, utilizationPercent } = contextState;
 
     if (!contextWindow || contextWindow <= 0) {
-      this._contextElem.textContent = '';
-      this._contextElem.hidden = true;
+      contextElem.textContent = '';
+      contextElem.hidden = true;
       return;
     }
 
     // Ensure footer is visible when context state is displayed
     const footer = this._getFooter();
-    if (footer) {
-      footer.hidden = false;
-    }
+    if (footer) footer.hidden = false;
 
     const contextLeft = Math.max(0, 100 - utilizationPercent);
     const formattedInput = formatTokens(inputTokens);
     const formattedWindow = formatTokens(contextWindow);
 
-    this._contextElem.innerHTML = `
+    contextElem.innerHTML = `
       <i class="codicon codicon-window" title="Context window"></i>
       <span class="context-state__value" title="${formattedInput} / ${formattedWindow} tokens used">
         ${contextLeft.toFixed(0)}% context left
       </span>
     `;
-    this._contextElem.hidden = false;
+    contextElem.hidden = false;
   }
 
   /**
@@ -192,14 +189,15 @@ export class UsageSummary {
    * Also hides the footer if usage summary is empty.
    */
   clearContextDisplay() {
-    this._ensureContextElem();
-    if (!this._contextElem) return;
+    const contextElem = this._getContext();
+    if (!contextElem) return;
 
-    this._contextElem.textContent = '';
-    this._contextElem.hidden = true;
+    contextElem.textContent = '';
+    contextElem.hidden = true;
 
     // Hide footer if usage is also empty
-    if (!this._summaryElem?.textContent) {
+    const summaryElem = this._getSummary();
+    if (!summaryElem?.textContent) {
       const footer = this._getFooter();
       if (footer) footer.hidden = true;
     }


### PR DESCRIPTION
Improve code clarity and reduce duplication in progressView modules:

- progressViewState.js: Extract _getOrCreateStreamMap helper in
  RunScopedMap to consolidate stream resolution logic
- taskManagers.js: Extract _createChildGroupElement and _setupToggleState
  methods to clarify _createGroupElement branching
- StreamTabs.js: Simplify _buildTooltip by separating main line
  construction from last activity handling
- usageManagers.js: Add unified _getCachedElement helper for consistent
  element caching pattern with isConnected validation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Streamlines progress view internals for clarity and reuse, with small utility additions.
> 
> - **Common**: Add `StreamScopedMap.clearStreamOrAll(streamId)` convenience method
> - **Formatters**: Introduce `withPayloadId`/`withFullMeta` wrappers; simplify banner/tool/search mapping; improve error-wrapped formatters
> - **State**: Extract `TaskGroups._getChildrenSet` and `RunScopedMap._getOrCreateStreamMap`; simplify run ID candidate collection and latest-run resolution
> - **Task managers**: Factor `_createChildGroupElement` and `_setupToggleState` from `_createGroupElement` for clearer collapsing logic
> - **File list UI**: Centralize button wiring via `_configureButton`; streamline previous/compare/merge/diff button setup
> - **Stream tabs**: Simplify `_buildTooltip` by separating main line and last-activity handling
> - **Usage summary**: Add cached element getters (`_getSummary`, `_getContext`, `_getFooter`); simplify footer/context visibility and updates
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 620d0aae3083f219cee2d40b2e3d777e2faa0a2f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->