### PR TITLE
style: use native menu items for diff dropdown options

### DIFF
--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -596,10 +596,14 @@
                   <vscode-context-menu class="dropdown-menu diff-dropdown-menu">
                     <vscode-context-menu-item
                       label="Preview proposed"
+                      title="Compile and preview the proposed document"
+                      icon="eye"
                       value="previewProposed"
                     ></vscode-context-menu-item>
                     <vscode-context-menu-item
                       label="LaTeXdiff (PDF)"
+                      title="Compile and preview the LaTeXdiff PDF"
+                      icon="file-pdf"
                       value="showLatexdiff"
                     ></vscode-context-menu-item>
                   </vscode-context-menu>

--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -594,28 +594,14 @@
                     hidden
                   ></vscode-toolbar-button>
                   <vscode-context-menu class="dropdown-menu diff-dropdown-menu">
-                    <div class="dropdown-menu-content">
-                      <div
-                        class="dropdown-action preview-menu-item"
-                        data-action="previewProposed"
-                        title="Compile and preview the proposed document"
-                        tabindex="0"
-                        role="menuitem"
-                      >
-                        <i class="codicon codicon-eye"></i>
-                        <span>Preview proposed</span>
-                      </div>
-                      <div
-                        class="dropdown-action latexdiff-menu-item"
-                        data-action="showLatexdiff"
-                        title="Show LaTeXdiff (compiles to PDF)"
-                        tabindex="0"
-                        role="menuitem"
-                      >
-                        <i class="codicon codicon-file-pdf"></i>
-                        <span>LaTeXdiff (PDF)</span>
-                      </div>
-                    </div>
+                    <vscode-context-menu-item
+                      label="Preview proposed"
+                      value="previewProposed"
+                    ></vscode-context-menu-item>
+                    <vscode-context-menu-item
+                      label="LaTeXdiff (PDF)"
+                      value="showLatexdiff"
+                    ></vscode-context-menu-item>
                   </vscode-context-menu>
                 </div>
                 <vscode-toolbar-button

--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -595,22 +595,26 @@
                   ></vscode-toolbar-button>
                   <vscode-context-menu class="dropdown-menu diff-dropdown-menu">
                     <div class="dropdown-menu-content">
-                      <vscode-toolbar-button
-                        icon="eye"
-                        label="Preview proposed"
-                        title="Compile and preview the proposed document"
+                      <div
+                        class="dropdown-action preview-menu-item"
                         data-action="previewProposed"
-                        class="preview-menu-item"
-                        >Preview proposed</vscode-toolbar-button
+                        title="Compile and preview the proposed document"
+                        tabindex="0"
+                        role="menuitem"
                       >
-                      <vscode-toolbar-button
-                        icon="file-pdf"
-                        label="LaTeXdiff"
-                        title="Show LaTeXdiff (compiles to PDF)"
+                        <i class="codicon codicon-eye"></i>
+                        <span>Preview proposed</span>
+                      </div>
+                      <div
+                        class="dropdown-action latexdiff-menu-item"
                         data-action="showLatexdiff"
-                        class="latexdiff-menu-item"
-                        >LaTeXdiff (PDF)</vscode-toolbar-button
+                        title="Show LaTeXdiff (compiles to PDF)"
+                        tabindex="0"
+                        role="menuitem"
                       >
+                        <i class="codicon codicon-file-pdf"></i>
+                        <span>LaTeXdiff (PDF)</span>
+                      </div>
                     </div>
                   </vscode-context-menu>
                 </div>

--- a/src/progressView/modules/uiManagers/ApprovalRequests.js
+++ b/src/progressView/modules/uiManagers/ApprovalRequests.js
@@ -221,32 +221,7 @@ export class ApprovalRequests extends BaseUIRequestManager {
       return;
     }
 
-    // Map and validate action
-    const mappedAction = action === 'open' ? 'openDiff' : action;
-    const validActions = [
-      'openDiff',
-      'approve',
-      'approveAll',
-      'reject',
-      'showLatexdiff',
-      'previewProposed',
-    ];
-    if (!validActions.includes(mappedAction)) {
-      return;
-    }
-
-    if (
-      mappedAction === 'showLatexdiff' ||
-      mappedAction === 'previewProposed'
-    ) {
-      this._closeAllDropdowns();
-    }
-
-    vscode.postMessage({
-      command: COMMANDS.TOOL_EDIT_APPROVAL_ACTION,
-      requestId,
-      action: mappedAction,
-    });
+    this._dispatchApprovalAction(requestId, action);
   }
 
   /** @private */
@@ -350,29 +325,81 @@ export class ApprovalRequests extends BaseUIRequestManager {
    * @private
    */
   _handleMenuItemClick(event) {
-    const action = event.detail?.value;
-    if (!action) {
+    const menuItem = this._getMenuItemFromEvent(event);
+    if (!menuItem) {
       return;
     }
 
-    const menuItem = event.target;
-    const requestId = menuItem?.dataset?.requestId;
-    if (!requestId) {
+    const action = event.detail?.value ?? menuItem.getAttribute('value');
+    const requestId = menuItem.dataset.requestId;
+    if (!action || !requestId) {
       return;
     }
 
-    const validActions = ['showLatexdiff', 'previewProposed'];
-    if (!validActions.includes(action)) {
-      return;
+    this._dispatchApprovalAction(requestId, action, { closeDropdown: true });
+  }
+
+  /**
+   * Dispatches an approval action and optionally closes dropdowns.
+   * @private
+   * @param {string} requestId
+   * @param {string} action
+   * @param {{ closeDropdown?: boolean }} [options]
+   * @returns {boolean}
+   */
+  _dispatchApprovalAction(requestId, action, options = {}) {
+    const mappedAction = action === 'open' ? 'openDiff' : action;
+    const validActions = [
+      'openDiff',
+      'approve',
+      'approveAll',
+      'reject',
+      'showLatexdiff',
+      'previewProposed',
+    ];
+    if (!validActions.includes(mappedAction)) {
+      return false;
     }
 
-    this._closeAllDropdowns();
+    if (options.closeDropdown) {
+      this._closeAllDropdowns();
+    }
 
     vscode.postMessage({
       command: COMMANDS.TOOL_EDIT_APPROVAL_ACTION,
       requestId,
-      action,
+      action: mappedAction,
     });
+    return true;
+  }
+
+  /**
+   * Locates the clicked menu item for a vsc-click event.
+   * @private
+   * @param {Event} event
+   * @returns {Element | null}
+   */
+  _getMenuItemFromEvent(event) {
+    if (!(event.target instanceof Element)) {
+      return null;
+    }
+
+    const targetItem = event.target.closest('vscode-context-menu-item');
+    if (targetItem) {
+      return targetItem;
+    }
+
+    const path = event.composedPath?.() ?? [];
+    for (const entry of path) {
+      if (entry instanceof Element) {
+        const menuItem = entry.closest?.('vscode-context-menu-item');
+        if (menuItem) {
+          return menuItem;
+        }
+      }
+    }
+
+    return null;
   }
 
   /**

--- a/src/progressView/modules/uiManagers/ApprovalRequests.js
+++ b/src/progressView/modules/uiManagers/ApprovalRequests.js
@@ -25,6 +25,7 @@ export class ApprovalRequests extends BaseUIRequestManager {
     this._handleToggle = this._handleToggle.bind(this);
     this._handleDropdownToggle = this._handleDropdownToggle.bind(this);
     this._handleClickOutside = this._handleClickOutside.bind(this);
+    this._handleMenuItemClick = this._handleMenuItemClick.bind(this);
   }
 
   /** @override */
@@ -42,6 +43,12 @@ export class ApprovalRequests extends BaseUIRequestManager {
         this._handleDropdownToggle,
         true,
       );
+      addEventListenerSafely(
+        this.container,
+        'vsc-click',
+        this._handleMenuItemClick,
+        true,
+      );
     }
     // Listen for clicks outside to close dropdown menus
     document.addEventListener('click', this._handleClickOutside, true);
@@ -54,6 +61,11 @@ export class ApprovalRequests extends BaseUIRequestManager {
       this.container.removeEventListener(
         'click',
         this._handleDropdownToggle,
+        true,
+      );
+      this.container.removeEventListener(
+        'vsc-click',
+        this._handleMenuItemClick,
         true,
       );
     }
@@ -104,8 +116,12 @@ export class ApprovalRequests extends BaseUIRequestManager {
     const mainDiffButton = element.querySelector('.diff-main-button');
     const dropdownTrigger = element.querySelector('.diff-dropdown-trigger');
     const dropdownMenu = element.querySelector('.diff-dropdown-menu');
-    const previewMenuItem = element.querySelector('.preview-menu-item');
-    const latexdiffMenuItem = element.querySelector('.latexdiff-menu-item');
+    const previewMenuItem = element.querySelector(
+      'vscode-context-menu-item[value="previewProposed"]',
+    );
+    const latexdiffMenuItem = element.querySelector(
+      'vscode-context-menu-item[value="showLatexdiff"]',
+    );
     element.dataset.streamId = request.streamId || '';
 
     if (pathElem) {
@@ -327,6 +343,36 @@ export class ApprovalRequests extends BaseUIRequestManager {
       }
       trigger.setAttribute('aria-expanded', 'false');
     }
+  }
+
+  /**
+   * Handle vsc-click events from context menu items.
+   * @private
+   */
+  _handleMenuItemClick(event) {
+    const action = event.detail?.value;
+    if (!action) {
+      return;
+    }
+
+    const menuItem = event.target;
+    const requestId = menuItem?.dataset?.requestId;
+    if (!requestId) {
+      return;
+    }
+
+    const validActions = ['showLatexdiff', 'previewProposed'];
+    if (!validActions.includes(action)) {
+      return;
+    }
+
+    this._closeAllDropdowns();
+
+    vscode.postMessage({
+      command: COMMANDS.TOOL_EDIT_APPROVAL_ACTION,
+      requestId,
+      action,
+    });
   }
 
   /**

--- a/src/progressView/styles/approval-requests.css
+++ b/src/progressView/styles/approval-requests.css
@@ -82,40 +82,6 @@
   min-width: 150px;
 }
 
-.approval-request__actions .diff-dropdown .dropdown-menu-content {
-  display: flex;
-  flex-direction: column;
-  gap: 0;
-  padding: var(--spacing-tiny);
-}
-
-/* Native-style dropdown action items */
-.approval-request__actions .diff-dropdown .dropdown-action {
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-small);
-  padding: var(--spacing-tiny) var(--spacing-small);
-  font-size: var(--font-size-sm);
-  color: var(--vscode-foreground);
-  cursor: pointer;
-  border-radius: var(--border-radius-small);
-  white-space: nowrap;
-}
-
-.approval-request__actions .diff-dropdown .dropdown-action:hover {
-  background: var(--vscode-list-hoverBackground);
-}
-
-.approval-request__actions .diff-dropdown .dropdown-action:focus {
-  outline: 1px solid var(--vscode-focusBorder);
-  outline-offset: -1px;
-}
-
-.approval-request__actions .diff-dropdown .dropdown-action .codicon {
-  font-size: 14px;
-  flex-shrink: 0;
-}
-
 /* Chevron rotation for dropdown */
 .approval-request__actions
   .diff-dropdown-trigger[aria-expanded='true']

--- a/src/progressView/styles/approval-requests.css
+++ b/src/progressView/styles/approval-requests.css
@@ -89,15 +89,31 @@
   padding: var(--spacing-tiny);
 }
 
-.approval-request__actions .diff-dropdown .preview-menu-item,
-.approval-request__actions .diff-dropdown .latexdiff-menu-item {
-  width: 100%;
-  justify-content: flex-start;
+/* Native-style dropdown action items */
+.approval-request__actions .diff-dropdown .dropdown-action {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-small);
+  padding: var(--spacing-tiny) var(--spacing-small);
+  font-size: var(--font-size-sm);
+  color: var(--vscode-foreground);
+  cursor: pointer;
+  border-radius: var(--border-radius-small);
+  white-space: nowrap;
 }
 
-.approval-request__actions .diff-dropdown .preview-menu-item:hover,
-.approval-request__actions .diff-dropdown .latexdiff-menu-item:hover {
+.approval-request__actions .diff-dropdown .dropdown-action:hover {
   background: var(--vscode-list-hoverBackground);
+}
+
+.approval-request__actions .diff-dropdown .dropdown-action:focus {
+  outline: 1px solid var(--vscode-focusBorder);
+  outline-offset: -1px;
+}
+
+.approval-request__actions .diff-dropdown .dropdown-action .codicon {
+  font-size: 14px;
+  flex-shrink: 0;
 }
 
 /* Chevron rotation for dropdown */


### PR DESCRIPTION
Replace vscode-toolbar-button components with styled divs for the
latexdiff and PDF preview dropdown menu items. The toolbar buttons
were oversized and not VS Code native-looking. The new dropdown-action
class uses compact styling similar to native VS Code context menus.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches the diff dropdown to native VS Code context menu items and centralizes action dispatching.
> 
> - Replace custom toolbar-button menu items with `vscode-context-menu-item` entries in `index.html`; update labels/titles
> - `ApprovalRequests.js`: add `vsc-click` listener; new `_dispatchApprovalAction` and `_getMenuItemFromEvent`; route actions from buttons/menu items, map `open`→`openDiff`, and close dropdown after selection; update selectors
> - Remove obsolete custom dropdown item styling from `approval-requests.css`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e4758ac09c583af28f0f7b6841184c080a499215. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->