### PR TITLE
refactor: simplify webview provider architecture and reduce duplication

### DIFF
--- a/src/common/webview/BaseViewContentProvider.ts
+++ b/src/common/webview/BaseViewContentProvider.ts
@@ -19,6 +19,7 @@ export interface ModuleDescriptor {
 export abstract class BaseViewContentProvider {
   protected readonly logger: any;
   protected readonly channel: string;
+  private readonly viewPath: string;
 
   /**
    * @param context - VS Code extension context
@@ -26,21 +27,28 @@ export abstract class BaseViewContentProvider {
    * @param moduleDescriptors - Optional view-specific module descriptors.
    *   If provided, getModuleUris() will automatically build URIs from these.
    *   If not provided, subclasses must override getModuleUris().
+   * @param viewPath - Optional view folder path. Defaults to camelCase of viewName.
    */
   constructor(
     protected readonly context: vscode.ExtensionContext,
     protected readonly viewName: string,
     private readonly moduleDescriptors: readonly ModuleDescriptor[] = [],
+    viewPath?: string,
   ) {
     this.logger = logger;
     this.channel = `${viewName}ContentProvider`;
+    // Default: convert 'HistoryView' to 'historyView'
+    this.viewPath =
+      viewPath ?? viewName.charAt(0).toLowerCase() + viewName.slice(1);
     logger.initialize(this.channel);
   }
 
   /**
-   * Subclasses must provide the relative path to their view directory
+   * Returns the relative path to the view directory.
    */
-  protected abstract getViewPath(): string;
+  protected getViewPath(): string {
+    return this.viewPath;
+  }
 
   /**
    * Returns view-specific module URIs. Default implementation uses

--- a/src/common/webview/BaseWebviewProvider.ts
+++ b/src/common/webview/BaseWebviewProvider.ts
@@ -33,11 +33,27 @@ export abstract class BaseWebviewProvider {
 
   constructor(protected readonly context: vscode.ExtensionContext) {}
 
+  /**
+   * Returns the view folder name for resource roots.
+   * Subclasses should override this to specify their view path.
+   * Used by resolveWebviewView to set up localResourceRoots.
+   */
+  protected getViewPath(): string | undefined {
+    return undefined;
+  }
+
   public resolveWebviewView(
     webviewView: vscode.WebviewView,
     _context: vscode.WebviewViewResolveContext,
     _token: vscode.CancellationToken,
   ): void {
+    const viewPath = this.getViewPath();
+    if (viewPath) {
+      webviewView.webview.options = {
+        enableScripts: true,
+        localResourceRoots: getSharedLocalResourceRoots(this.context, viewPath),
+      };
+    }
     this.resolveWebviewViewInternal(webviewView);
   }
 

--- a/src/historyView/HistoryViewContentProvider.ts
+++ b/src/historyView/HistoryViewContentProvider.ts
@@ -16,8 +16,4 @@ export class HistoryViewContentProvider extends BaseViewContentProvider {
   constructor(context: vscode.ExtensionContext) {
     super(context, 'HistoryView', HISTORY_VIEW_MODULES);
   }
-
-  protected getViewPath(): string {
-    return 'historyView';
-  }
 }

--- a/src/historyView/HistoryViewProvider.ts
+++ b/src/historyView/HistoryViewProvider.ts
@@ -2,10 +2,7 @@
 import * as vscode from 'vscode';
 
 // Local imports - common webview
-import {
-  BaseWebviewProvider,
-  getSharedLocalResourceRoots,
-} from '@common/webview';
+import { BaseWebviewProvider } from '@common/webview';
 
 // Local imports - history view components
 import { HistoryViewContentProvider } from './HistoryViewContentProvider';
@@ -25,19 +22,8 @@ export class HistoryViewProvider
     this.messageHandler = new HistoryViewMessageHandler(context);
   }
 
-  /**
-   * Resolve webview for potential sidebar integration.
-   */
-  public resolveWebviewView(webviewView: vscode.WebviewView): void {
-    webviewView.webview.options = {
-      enableScripts: true,
-      localResourceRoots: getSharedLocalResourceRoots(
-        this.context,
-        'historyView',
-      ),
-    };
-
-    super.resolveWebviewViewInternal(webviewView);
+  protected override getViewPath(): string {
+    return 'historyView';
   }
 
   /**

--- a/src/memoryView/MemoryViewContentProvider.ts
+++ b/src/memoryView/MemoryViewContentProvider.ts
@@ -15,8 +15,4 @@ export class MemoryViewContentProvider extends BaseViewContentProvider {
   constructor(context: vscode.ExtensionContext) {
     super(context, 'MemoryView', MEMORY_VIEW_MODULES);
   }
-
-  protected getViewPath(): string {
-    return 'memoryView';
-  }
 }

--- a/src/memoryView/MemoryViewProvider.ts
+++ b/src/memoryView/MemoryViewProvider.ts
@@ -2,10 +2,7 @@
 import * as vscode from 'vscode';
 
 // Local imports - common webview
-import {
-  BaseWebviewProvider,
-  getSharedLocalResourceRoots,
-} from '@common/webview';
+import { BaseWebviewProvider } from '@common/webview';
 
 // Local imports - memory view components
 import { MemoryViewContentProvider } from './MemoryViewContentProvider';
@@ -25,19 +22,8 @@ export class MemoryViewProvider
     this.messageHandler = new MemoryViewMessageHandler(context);
   }
 
-  /**
-   * Resolve webview for potential sidebar integration.
-   */
-  public resolveWebviewView(webviewView: vscode.WebviewView): void {
-    webviewView.webview.options = {
-      enableScripts: true,
-      localResourceRoots: getSharedLocalResourceRoots(
-        this.context,
-        'memoryView',
-      ),
-    };
-
-    super.resolveWebviewViewInternal(webviewView);
+  protected override getViewPath(): string {
+    return 'memoryView';
   }
 
   /**

--- a/src/profileView/ProfileViewContentProvider.ts
+++ b/src/profileView/ProfileViewContentProvider.ts
@@ -18,8 +18,4 @@ export class ProfileViewContentProvider extends BaseViewContentProvider {
   constructor(context: vscode.ExtensionContext) {
     super(context, 'ProfileView', PROFILE_VIEW_MODULES);
   }
-
-  protected getViewPath(): string {
-    return 'profileView';
-  }
 }

--- a/src/profileView/ProfileViewProvider.ts
+++ b/src/profileView/ProfileViewProvider.ts
@@ -2,10 +2,7 @@
 import * as vscode from 'vscode';
 
 // Local imports - common webview
-import {
-  BaseWebviewProvider,
-  getSharedLocalResourceRoots,
-} from '@common/webview';
+import { BaseWebviewProvider } from '@common/webview';
 
 // Local imports - profile view components
 import { ProfileViewContentProvider } from './ProfileViewContentProvider';
@@ -25,19 +22,8 @@ export class ProfileViewProvider
     this.messageHandler = new ProfileViewMessageHandler(context);
   }
 
-  /**
-   * Resolve webview for potential sidebar integration.
-   */
-  public resolveWebviewView(webviewView: vscode.WebviewView): void {
-    webviewView.webview.options = {
-      enableScripts: true,
-      localResourceRoots: getSharedLocalResourceRoots(
-        this.context,
-        'profileView',
-      ),
-    };
-
-    super.resolveWebviewViewInternal(webviewView);
+  protected override getViewPath(): string {
+    return 'profileView';
   }
 
   /**

--- a/src/webview/MainViewMessageHandler.ts
+++ b/src/webview/MainViewMessageHandler.ts
@@ -87,38 +87,42 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
         this.handleShowAgentHistory.bind(this),
 
       // File selection commands - delegated to FileManager
-      [MAIN_VIEW_COMMANDS.SELECT_INPUT_FILE]: (m) =>
-        this.fileManager.handleFileSelection(m),
-      [MAIN_VIEW_COMMANDS.SELECT_REFERENCE_FILE]: (m) =>
-        this.fileManager.handleFileSelection(m),
-      [MAIN_VIEW_COMMANDS.SELECT_AUXILIARY_FILE]: (m) =>
-        this.fileManager.handleFileSelection(m),
-      [MAIN_VIEW_COMMANDS.SELECT_MEDIA_FILE]: (m) =>
-        this.fileManager.handleFileSelection(m),
+      ...this.createDelegateHandlers(
+        [
+          MAIN_VIEW_COMMANDS.SELECT_INPUT_FILE,
+          MAIN_VIEW_COMMANDS.SELECT_REFERENCE_FILE,
+          MAIN_VIEW_COMMANDS.SELECT_AUXILIARY_FILE,
+          MAIN_VIEW_COMMANDS.SELECT_MEDIA_FILE,
+        ],
+        (m) => this.fileManager.handleFileSelection(m),
+      ),
       [MAIN_VIEW_COMMANDS.SELECT_EDITED_FILE]: () =>
         this.fileManager.handleEditedFileSelection(),
 
       // File selected commands
       [MAIN_VIEW_COMMANDS.INPUT_FILE_SELECTED]: (m) =>
         this.fileManager.handleInputFileSelected(m),
-      [MAIN_VIEW_COMMANDS.REFERENCE_FILE_SELECTED]: (m) =>
-        this.fileManager.handleGenericFileSelected(m),
-      [MAIN_VIEW_COMMANDS.AUXILIARY_FILE_SELECTED]: (m) =>
-        this.fileManager.handleGenericFileSelected(m),
-      [MAIN_VIEW_COMMANDS.MEDIA_FILE_SELECTED]: (m) =>
-        this.fileManager.handleGenericFileSelected(m),
-      [MAIN_VIEW_COMMANDS.EDITED_FILE_SELECTED]: (m) =>
-        this.fileManager.handleGenericFileSelected(m),
+      ...this.createDelegateHandlers(
+        [
+          MAIN_VIEW_COMMANDS.REFERENCE_FILE_SELECTED,
+          MAIN_VIEW_COMMANDS.AUXILIARY_FILE_SELECTED,
+          MAIN_VIEW_COMMANDS.MEDIA_FILE_SELECTED,
+          MAIN_VIEW_COMMANDS.EDITED_FILE_SELECTED,
+        ],
+        (m) => this.fileManager.handleGenericFileSelected(m),
+      ),
 
       // Request file commands
       [MAIN_VIEW_COMMANDS.REQUEST_INPUT_FILE]: (m) =>
         this.fileManager.handleRequestInputFile(m),
-      [MAIN_VIEW_COMMANDS.REQUEST_REFERENCE_FILE]: (m) =>
-        this.fileManager.handleRequestFile(m),
-      [MAIN_VIEW_COMMANDS.REQUEST_AUXILIARY_FILE]: (m) =>
-        this.fileManager.handleRequestFile(m),
-      [MAIN_VIEW_COMMANDS.REQUEST_MEDIA_FILE]: (m) =>
-        this.fileManager.handleRequestFile(m),
+      ...this.createDelegateHandlers(
+        [
+          MAIN_VIEW_COMMANDS.REQUEST_REFERENCE_FILE,
+          MAIN_VIEW_COMMANDS.REQUEST_AUXILIARY_FILE,
+          MAIN_VIEW_COMMANDS.REQUEST_MEDIA_FILE,
+        ],
+        (m) => this.fileManager.handleRequestFile(m),
+      ),
       [MAIN_VIEW_COMMANDS.REQUEST_EDITED_FILE]: (m) =>
         this.fileManager.handleRequestEditedFile(m),
       [MAIN_VIEW_COMMANDS.REQUEST_BASE_FILE]: (m) =>
@@ -127,14 +131,15 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
         this.fileManager.handleRequestDefaultOutputFiles(m),
 
       // Multiple file operations
-      [MAIN_VIEW_COMMANDS.SET_INPUT_FILES]: (m) =>
-        this.fileManager.handleSetMultipleFiles(m),
-      [MAIN_VIEW_COMMANDS.SET_REFERENCE_FILES]: (m) =>
-        this.fileManager.handleSetMultipleFiles(m),
-      [MAIN_VIEW_COMMANDS.SET_AUXILIARY_FILES]: (m) =>
-        this.fileManager.handleSetMultipleFiles(m),
-      [MAIN_VIEW_COMMANDS.SET_MEDIA_FILES]: (m) =>
-        this.fileManager.handleSetMultipleFiles(m),
+      ...this.createDelegateHandlers(
+        [
+          MAIN_VIEW_COMMANDS.SET_INPUT_FILES,
+          MAIN_VIEW_COMMANDS.SET_REFERENCE_FILES,
+          MAIN_VIEW_COMMANDS.SET_AUXILIARY_FILES,
+          MAIN_VIEW_COMMANDS.SET_MEDIA_FILES,
+        ],
+        (m) => this.fileManager.handleSetMultipleFiles(m),
+      ),
       [MAIN_VIEW_COMMANDS.SELECT_MULTIPLE_FILES]: (m) =>
         this.fileManager.handleSelectMultipleFiles(m),
 
@@ -145,10 +150,10 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
         this.fileManager.handleAddOpenedFiles(m.fileType),
 
       // Execution commands
-      [MAIN_VIEW_COMMANDS.MERGE]: (m) =>
-        this.executionManager.handleFileOperation(m),
-      [MAIN_VIEW_COMMANDS.COMPARE]: (m) =>
-        this.executionManager.handleFileOperation(m),
+      ...this.createDelegateHandlers(
+        [MAIN_VIEW_COMMANDS.MERGE, MAIN_VIEW_COMMANDS.COMPARE],
+        (m) => this.executionManager.handleFileOperation(m),
+      ),
 
       // Settings commands
       [MAIN_VIEW_COMMANDS.SETTINGS_OPEN]: async () =>
@@ -299,16 +304,16 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
       // File refresh and update operations
       [MAIN_VIEW_COMMANDS.REFRESH_ALL_FILES]: () =>
         this.fileManager.handleRefreshAllFiles(),
-      [MAIN_VIEW_COMMANDS.UPDATE_INPUT_FILES]: (m) =>
-        this.fileManager.handleUpdateFiles(m),
-      [MAIN_VIEW_COMMANDS.UPDATE_REFERENCE_FILES]: (m) =>
-        this.fileManager.handleUpdateFiles(m),
-      [MAIN_VIEW_COMMANDS.UPDATE_AUXILIARY_FILES]: (m) =>
-        this.fileManager.handleUpdateFiles(m),
-      [MAIN_VIEW_COMMANDS.UPDATE_MEDIA_FILES]: (m) =>
-        this.fileManager.handleUpdateFiles(m),
-      [MAIN_VIEW_COMMANDS.UPDATE_OUTPUT_FILES]: (m) =>
-        this.fileManager.handleUpdateFiles(m),
+      ...this.createDelegateHandlers(
+        [
+          MAIN_VIEW_COMMANDS.UPDATE_INPUT_FILES,
+          MAIN_VIEW_COMMANDS.UPDATE_REFERENCE_FILES,
+          MAIN_VIEW_COMMANDS.UPDATE_AUXILIARY_FILES,
+          MAIN_VIEW_COMMANDS.UPDATE_MEDIA_FILES,
+          MAIN_VIEW_COMMANDS.UPDATE_OUTPUT_FILES,
+        ],
+        (m) => this.fileManager.handleUpdateFiles(m),
+      ),
 
       // Git/diff operations
       [MAIN_VIEW_COMMANDS.REQUEST_RECENT_COMMITS]: (m) =>
@@ -319,26 +324,31 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
         this.diffManager.handleLatexdiff(m),
       [MAIN_VIEW_COMMANDS.LATEXDIFFVC]: (m) =>
         this.diffManager.handleLatexdiffvc(m),
-      [MAIN_VIEW_COMMANDS.PACK_LATEXDIFFVC]: (m) =>
-        this.diffManager.handleLatexdiffvcOperation(m),
-      [MAIN_VIEW_COMMANDS.CLEAN_LATEXDIFFVC]: (m) =>
-        this.diffManager.handleLatexdiffvcOperation(m),
+      ...this.createDelegateHandlers(
+        [
+          MAIN_VIEW_COMMANDS.PACK_LATEXDIFFVC,
+          MAIN_VIEW_COMMANDS.CLEAN_LATEXDIFFVC,
+        ],
+        (m) => this.diffManager.handleLatexdiffvcOperation(m),
+      ),
 
       // Housekeeping operations
-      [MAIN_VIEW_COMMANDS.CLEAN_OUTPUT]: (m) =>
-        this.executionManager.handleHousekeeping(m),
-      [MAIN_VIEW_COMMANDS.CLEAN_BUILD]: (m) =>
-        this.executionManager.handleHousekeeping(m),
-      [MAIN_VIEW_COMMANDS.INDENT_TEX]: (m) =>
-        this.executionManager.handleHousekeeping(m),
-      [MAIN_VIEW_COMMANDS.PACK_SINGLE]: (m) =>
-        this.executionManager.handleSingleOperation(m),
-      [MAIN_VIEW_COMMANDS.CLEAN_SINGLE]: (m) =>
-        this.executionManager.handleSingleOperation(m),
-      [MAIN_VIEW_COMMANDS.PACK_MULTIPLE]: (m) =>
-        this.executionManager.handleMultipleOperation(m),
-      [MAIN_VIEW_COMMANDS.CLEAN_MULTIPLE]: (m) =>
-        this.executionManager.handleMultipleOperation(m),
+      ...this.createDelegateHandlers(
+        [
+          MAIN_VIEW_COMMANDS.CLEAN_OUTPUT,
+          MAIN_VIEW_COMMANDS.CLEAN_BUILD,
+          MAIN_VIEW_COMMANDS.INDENT_TEX,
+        ],
+        (m) => this.executionManager.handleHousekeeping(m),
+      ),
+      ...this.createDelegateHandlers(
+        [MAIN_VIEW_COMMANDS.PACK_SINGLE, MAIN_VIEW_COMMANDS.CLEAN_SINGLE],
+        (m) => this.executionManager.handleSingleOperation(m),
+      ),
+      ...this.createDelegateHandlers(
+        [MAIN_VIEW_COMMANDS.PACK_MULTIPLE, MAIN_VIEW_COMMANDS.CLEAN_MULTIPLE],
+        (m) => this.executionManager.handleMultipleOperation(m),
+      ),
 
       // Other operations
       [MAIN_VIEW_COMMANDS.ACCEPT_EDITED]: (m) =>
@@ -356,9 +366,17 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
   private createBannerForwardHandlers(
     commands: string[],
   ): Record<string, MessageHandler<vscode.WebviewView>> {
-    return Object.fromEntries(
-      commands.map((cmd) => [cmd, (m: any) => this.forwardToWebview(m)]),
+    return this.createDelegateHandlers(commands, (m) =>
+      this.forwardToWebview(m),
     );
+  }
+
+  /** Create handlers that delegate to the same handler function */
+  private createDelegateHandlers(
+    commands: string[],
+    handler: (m: any) => void | Promise<void>,
+  ): Record<string, MessageHandler<vscode.WebviewView>> {
+    return Object.fromEntries(commands.map((cmd) => [cmd, handler]));
   }
 
   private async handleInfoMessage(message: any): Promise<void> {


### PR DESCRIPTION
- Move webview options setup to BaseWebviewProvider with getViewPath() hook
- Simplify secondary view providers (History, Profile, Memory) by removing
  redundant resolveWebviewView overrides
- Make ContentProvider viewPath derivable from viewName by default
- Remove redundant getViewPath() implementations in ContentProvider subclasses
- Add createDelegateHandlers helper to MainViewMessageHandler
- Consolidate repetitive file/execution handlers using delegate pattern
- Refactor createBannerForwardHandlers to use new helper

This reduces boilerplate while maintaining flexibility for complex providers.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Streamlines webview architecture and reduces boilerplate.
> 
> - **BaseWebviewProvider**: adds `getViewPath()` hook and sets `webview.options` (incl. `localResourceRoots`) in `resolveWebviewView`; panel creation uses shared roots
> - **BaseViewContentProvider**: introduces default `viewPath` derived from `viewName` and provides concrete `getViewPath()`; subclasses can omit `getViewPath()`
> - **History/Memory/Profile**: providers now just override `getViewPath()`; removed redundant `resolveWebviewView` implementations; content providers drop `getViewPath()`
> - **MainViewMessageHandler**: adds `createDelegateHandlers()` and uses it to consolidate numerous command mappings (file selection/updates, multi-file ops, execution, git/diff, housekeeping, banners)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 396845558a820d8092952ce6ae1854aabb688138. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->