### PR TITLE
Fix context window info update on stream tab

### DIFF
--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -855,19 +855,22 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
   /**
    * Handle context state update (input tokens vs context window).
    * Updates the context utilization display in the footer.
+   *
+   * Always saves state to frontend cache regardless of active stream.
+   * This prevents race conditions where UPDATE_CONTEXT_STATE arrives
+   * before UPDATE_STREAMS has set state.activeStream.
    */
   handleUpdateContextState(message) {
-    if (message.stream && !this._isActiveStream(message)) {
-      return;
-    }
-
     const targetStream = this._getTargetStream(message);
     if (!targetStream || !message.contextState) {
       return;
     }
 
+    // Always save to state cache - ensures data is available when
+    // switching streams even if display update was skipped
     state.setContextState(targetStream, message.contextState);
-    // Update the context display if this is the active stream
+
+    // Update the context display only for the active stream
     if (targetStream === state.activeStream) {
       dom.usageSummary.updateContextDisplay(message.contextState);
     }

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -815,41 +815,51 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     }
   }
 
+  /**
+   * Handle full usage update (replaces all run usage for a stream).
+   *
+   * Always saves state regardless of active stream to prevent race conditions
+   * where messages arrive before UPDATE_STREAMS sets state.activeStream.
+   */
   handleUpdateUsage(message) {
-    if (message.stream && !this._isActiveStream(message)) {
-      return;
-    }
-
     const targetStream = this._getTargetStream(message);
     if (!targetStream) {
       return;
     }
 
+    // Always save state - ensures data available when switching streams
     state.clearRunUsage(targetStream);
     const usageByRun = message.usageByRun ?? {};
     Object.entries(usageByRun).forEach(([runId, usage]) => {
       state.setRunUsage(targetStream, runId, usage);
     });
-    this._refreshUsageForActiveRun();
+
+    // Only refresh display for active stream
+    if (targetStream === state.activeStream) {
+      this._refreshUsageForActiveRun();
+    }
   }
 
   /**
    * Handle incremental usage update for a single run.
    * More efficient than handleUpdateUsage during streaming.
+   *
+   * Always saves state regardless of active stream to prevent race conditions
+   * where messages arrive before UPDATE_STREAMS sets state.activeStream.
    */
   handleUpdateRunUsage(message) {
-    if (message.stream && !this._isActiveStream(message)) {
-      return;
-    }
-
     const targetStream = this._getTargetStream(message);
     if (!targetStream || !message.runId) {
       return;
     }
 
-    // Update only the specific run's usage without clearing others
+    // Always save state - ensures data available when switching streams
     state.setRunUsage(targetStream, message.runId, message.usage);
-    this._refreshUsageForActiveRun();
+
+    // Only refresh display for active stream
+    if (targetStream === state.activeStream) {
+      this._refreshUsageForActiveRun();
+    }
   }
 
   /**


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Ensures usage and context data are not lost when updates arrive before the active stream is set, preventing stale/missing context window info when switching tabs.
> 
> - `handleUpdateUsage`, `handleUpdateRunUsage`, `handleUpdateContextState`: always save state for `message.stream` (via `_getTargetStream`) and only refresh UI when it matches `state.activeStream`
> - Refresh context footer via `dom.usageSummary.updateContextDisplay` only for active stream
> - `handleUpdateStreamStatus`: now also calls `_updateFollowupSection()` when status changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b987756a1064e8b6b882233fc8af379483112d5d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->