### PR TITLE
Fix chat resume system triggering on editor restart

### DIFF
--- a/src/agent/runtime/SessionResumeRetrieval.ts
+++ b/src/agent/runtime/SessionResumeRetrieval.ts
@@ -64,19 +64,70 @@ export type SessionResumeData = ToolUseResumeData | WorkflowResumeData;
 // =============================================================================
 
 /**
- * Schema for validating tool-use flow record shared state structure.
- * Maps internal field names to snapshot format.
+ * State slices schema (shared between flat and legacy formats).
  */
-const ToolUseFlowRecordStateSchema = z.object({
+const StateSlicesSchema = z.object({
+  runStateSnapshot: AgentRunStateSnapshotSchema,
+  workspaceSnapshot: AgentWorkspaceStateSnapshotSchema,
+  userChannels: UserVariableChannelsSchema,
+});
+
+/**
+ * Current flat format schema (introduced with state flattening refactor).
+ * Shared state has conversation and stateSlices at top level.
+ */
+const FlatToolUseFlowRecordStateSchema = z.object({
+  conversation: z.array(ProviderMessageSchema),
+  stateSlices: StateSlicesSchema,
+});
+
+/**
+ * Legacy format schema (pre-flattening).
+ * Shared state is wrapped in a `state` property.
+ */
+const LegacyToolUseFlowRecordStateSchema = z.object({
   state: z.object({
     conversation: z.array(ProviderMessageSchema),
-    stateSlices: z.object({
-      runStateSnapshot: AgentRunStateSnapshotSchema,
-      workspaceSnapshot: AgentWorkspaceStateSnapshotSchema,
-      userChannels: UserVariableChannelsSchema,
-    }),
+    stateSlices: StateSlicesSchema,
   }),
 });
+
+/**
+ * Normalized result from parsing either format.
+ * Both schemas are transformed to this common structure.
+ */
+interface NormalizedToolUseState {
+  conversation: z.infer<typeof ProviderMessageSchema>[];
+  stateSlices: z.infer<typeof StateSlicesSchema>;
+}
+
+/**
+ * Parse tool-use flow record shared state, supporting both flat and legacy formats.
+ * Returns normalized state structure regardless of input format.
+ */
+function parseToolUseFlowRecordState(
+  shared: unknown,
+): NormalizedToolUseState | null {
+  // Try flat format first (current)
+  const flatResult = FlatToolUseFlowRecordStateSchema.safeParse(shared);
+  if (flatResult.success) {
+    return {
+      conversation: flatResult.data.conversation,
+      stateSlices: flatResult.data.stateSlices,
+    };
+  }
+
+  // Fall back to legacy format
+  const legacyResult = LegacyToolUseFlowRecordStateSchema.safeParse(shared);
+  if (legacyResult.success) {
+    return {
+      conversation: legacyResult.data.state.conversation,
+      stateSlices: legacyResult.data.state.stateSlices,
+    };
+  }
+
+  return null;
+}
 
 /**
  * Minimal schema for validating workflow flow record exists and has resumable state.
@@ -141,17 +192,16 @@ async function retrieveToolUseResumeData(
       return null;
     }
 
-    const parseResult = ToolUseFlowRecordStateSchema.safeParse(
-      flowRecord.shared,
-    );
-    if (!parseResult.success) {
+    // Parse shared state, supporting both flat and legacy formats
+    const parsedState = parseToolUseFlowRecordState(flowRecord.shared);
+    if (!parsedState) {
       logger.warn(
         `Invalid flow record structure for execution: ${executionId}`,
       );
       return null;
     }
 
-    const { conversation, stateSlices } = parseResult.data.state;
+    const { conversation, stateSlices } = parsedState;
 
     // Construct and validate the complete snapshot.
     // Validation provides defense-in-depth: even if flow record is valid,


### PR DESCRIPTION
The SessionResumeRetrieval module was only validating against the legacy flow record format (with `state` wrapper), but newer sessions save in the flat format without that wrapper. This caused auto-resume to fail after VS Code restart, resulting in messages being queued instead of processed.

Added support for both formats by trying flat format first then falling back to legacy format.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Supports auto-resume for tool-use sessions across both state formats by normalizing persisted flow state before building the snapshot.
> 
> - Introduces `StateSlicesSchema`, `FlatToolUseFlowRecordStateSchema`, `LegacyToolUseFlowRecordStateSchema`, and `parseToolUseFlowRecordState` to parse/normalize `shared` state regardless of flat vs legacy structure
> - Updates `retrieveToolUseResumeData` to use the normalized state (`conversation`, `stateSlices`) and validate the assembled `ToolUseSessionSnapshot`
> - Workflow resume path remains with minimal validation via `WorkflowFlowRecordStateSchema`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6cf6a94fc4edb14b559389d37e074d8fb84879de. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->