### PR TITLE
Fix range parameter type validation error

### DIFF
--- a/src/tools/ReadTool.ts
+++ b/src/tools/ReadTool.ts
@@ -15,9 +15,20 @@ import { defineTool } from './core/define';
 
 export const READ_FILE_MAX_LINES = 2000;
 
-const ReadInputSchema = z.strictObject({
-  path: z.string(),
-  range: z
+/**
+ * Schema for range parameter with preprocessing to handle array format.
+ * Some models (e.g., DeepSeek) may provide range as [start, end] array
+ * instead of {start, end} object. This preprocessor normalizes both formats.
+ */
+const RangeSchema = z.preprocess(
+  (val) => {
+    // Convert array format [start, end] to object format {start, end}
+    if (Array.isArray(val) && val.length >= 1) {
+      return { start: val[0], end: val[1] };
+    }
+    return val;
+  },
+  z
     .strictObject({
       start: z.int().min(1),
       end: z.int().min(1).nullish(),
@@ -26,8 +37,12 @@ const ReadInputSchema = z.strictObject({
     .refine((value) => value.end == null || value.end >= value.start, {
       path: ['end'],
       error: 'range.end must be greater than or equal to range.start',
-    })
-    .nullish(),
+    }),
+);
+
+const ReadInputSchema = z.strictObject({
+  path: z.string(),
+  range: RangeSchema.nullish(),
 });
 
 export type ReadInput = z.infer<typeof ReadInputSchema>;


### PR DESCRIPTION
Some models (e.g., DeepSeek) may provide the range parameter as an array [start, end] instead of an object {start, end}. Added Zod preprocessing to normalize both formats, preventing validation errors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **fix(ReadTool): normalize `range` input for `read_file`**
> 
> - Adds `RangeSchema` with Zod `preprocess` to accept array `[start, end]` or object `{start, end}` and normalize to object
> - Updates `ReadInputSchema.range` to use `RangeSchema`, preserving existing validation (min 1, `end >= start`, optional)
> - Prevents validation errors from models that return array-form ranges
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2bf647e9f7cf1b288f6b9df9e7167bae298b5b9f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->