### PR TITLE
Fix ripgrep search in matrix norm files

### DIFF
--- a/src/test/tools/grep.test.ts
+++ b/src/test/tools/grep.test.ts
@@ -16,4 +16,25 @@ describe('buildArguments', () => {
     const args = buildArguments(baseInput, 'files_with_matches');
     assert.ok(args.includes('--files-with-matches'));
   });
+
+  it('includes --fixed-strings when literal is true', () => {
+    const args = buildArguments({ ...baseInput, literal: true }, 'content');
+    assert.ok(args.includes('--fixed-strings'));
+  });
+
+  it('omits --fixed-strings when literal is false or nullish', () => {
+    const argsWithFalse = buildArguments(
+      { ...baseInput, literal: false },
+      'content',
+    );
+    const argsWithNull = buildArguments(
+      { ...baseInput, literal: null },
+      'content',
+    );
+    const argsWithUndefined = buildArguments(baseInput, 'content');
+
+    assert.ok(!argsWithFalse.includes('--fixed-strings'));
+    assert.ok(!argsWithNull.includes('--fixed-strings'));
+    assert.ok(!argsWithUndefined.includes('--fixed-strings'));
+  });
 });

--- a/src/tools/grep.ts
+++ b/src/tools/grep.ts
@@ -27,6 +27,7 @@ const GrepInputSchema = z.strictObject({
   type: z.string().nullish(),
   head_limit: z.int().min(1).nullish(),
   multiline: z.boolean().nullish(),
+  literal: z.boolean().nullish(),
 });
 
 export type GrepInput = z.infer<typeof GrepInputSchema>;
@@ -50,6 +51,7 @@ export function buildArguments(
   if (input.glob) args.push('--glob', input.glob);
   if (input.type) args.push('--type', input.type);
   if (input['-i']) args.push('-i');
+  if (input.literal) args.push('--fixed-strings');
   if (input.multiline) args.push('--multiline', '--multiline-dotall');
 
   // Context flags (only for content mode)


### PR DESCRIPTION
Add a `literal` option to the grep tool schema that enables ripgrep's `--fixed-strings` flag. This allows searching for literal text patterns without regex interpretation, fixing errors when patterns contain unbalanced regex metacharacters like `Norm \(Matrix`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds literal fixed-string search support to the grep tool and tests its behavior.
> 
> - Extends `GrepInputSchema` with `literal?: boolean`
> - Updates `buildArguments` to append `--fixed-strings` when `input.literal` is true
> - Adds unit tests validating inclusion/exclusion of `--fixed-strings` and existing output mode flags in `grep.test.ts`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7bcdc1397cee86083137be0e3746337112b72ba2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->