### PR TITLE
Fix hidden disable yolo mode button

### DIFF
--- a/src/common/webview/commands.js
+++ b/src/common/webview/commands.js
@@ -221,7 +221,7 @@ export const PROGRESS_VIEW_COMMANDS = {
   SHOW_INFORMATION_MESSAGE: 'showInformationMessage',
   OPEN_TASK_STORAGE: 'openTaskStorage',
   TOOL_EDIT_APPROVAL_ACTION: 'toolEditApprovalAction',
-  RESET_TOOL_EDIT_APPROVAL_BYPASS: 'resetToolEditApprovalBypass',
+  TOGGLE_TOOL_EDIT_APPROVAL_BYPASS: 'toggleToolEditApprovalBypass',
 
   // Memory
   OPEN_MEMORY_VIEW: 'openMemoryView',

--- a/src/common/webview/commands.ts
+++ b/src/common/webview/commands.ts
@@ -220,7 +220,7 @@ export const PROGRESS_VIEW_COMMANDS = {
   SHOW_INFORMATION_MESSAGE: 'showInformationMessage',
   OPEN_TASK_STORAGE: 'openTaskStorage',
   TOOL_EDIT_APPROVAL_ACTION: 'toolEditApprovalAction',
-  RESET_TOOL_EDIT_APPROVAL_BYPASS: 'resetToolEditApprovalBypass',
+  TOGGLE_TOOL_EDIT_APPROVAL_BYPASS: 'toggleToolEditApprovalBypass',
 
   // Memory
   OPEN_MEMORY_VIEW: 'openMemoryView',

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -42,7 +42,7 @@ import {
 } from '@progressView/templates/followupInstructionTemplates';
 import {
   handleProgressViewToolEditApprovalAction,
-  resetToolEditApprovalSessionBypass,
+  toggleToolEditApprovalSessionBypass,
 } from '@tools/approval/toolEditApproval';
 import { getConfig } from '@utils/config';
 import { isNonEmptyString } from '@utils/core';
@@ -159,8 +159,8 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
         this.handleShowInformationMessage.bind(this),
       [PROGRESS_VIEW_COMMANDS.TOOL_EDIT_APPROVAL_ACTION]:
         this.handleToolEditApprovalAction.bind(this),
-      [PROGRESS_VIEW_COMMANDS.RESET_TOOL_EDIT_APPROVAL_BYPASS]:
-        this.handleResetToolEditApprovalBypass.bind(this),
+      [PROGRESS_VIEW_COMMANDS.TOGGLE_TOOL_EDIT_APPROVAL_BYPASS]:
+        this.handleToggleToolEditApprovalBypass.bind(this),
 
       // Profile
       [PROGRESS_VIEW_COMMANDS.OPEN_PROFILE]: this.handleOpenProfile.bind(this),
@@ -439,11 +439,12 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     );
   }
 
-  private async handleResetToolEditApprovalBypass(): Promise<void> {
-    resetToolEditApprovalSessionBypass();
-    await vscode.window.showInformationMessage(
-      'Tool edit approvals will prompt again for this session.',
-    );
+  private async handleToggleToolEditApprovalBypass(): Promise<void> {
+    const isNowEnabled = toggleToolEditApprovalSessionBypass();
+    const message = isNowEnabled
+      ? 'YOLO mode enabled: Tool edits will be auto-approved for this session.'
+      : 'YOLO mode disabled: Tool edits will prompt for approval.';
+    await vscode.window.showInformationMessage(message);
   }
 
   private async handleOpenTaskStorage(message: any): Promise<void> {

--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -107,12 +107,11 @@
                   data-status="Ready"
                 ></span>
                 <vscode-toolbar-button
-                  id="resetApprovalBypassBtn"
+                  id="yoloToggleBtn"
                   icon="shield"
-                  label="Resume approval prompts"
-                  title="Resume approval prompts"
-                  class="yolo-reset-button"
-                  hidden
+                  label="Enable YOLO mode"
+                  title="Enable YOLO mode (skip approval prompts)"
+                  class="yolo-toggle-button"
                 ></vscode-toolbar-button>
               </div>
               <vscode-toolbar-container
@@ -622,15 +621,6 @@
                   title="Reject"
                   data-action="reject"
                   >Reject</vscode-toolbar-button
-                >
-                <vscode-toolbar-button
-                  icon="shield"
-                  label="Approve & Yolo this session"
-                  title="Approve & Yolo this session"
-                  data-action="approveAll"
-                  data-toggle-action="resumeApprovals"
-                  toggleable
-                  >Yolo</vscode-toolbar-button
                 >
               </vscode-toolbar-container>
             </div>

--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -106,6 +106,14 @@
                   class="status-indicator is-stopped"
                   data-status="Ready"
                 ></span>
+                <vscode-toolbar-button
+                  id="resetApprovalBypassBtn"
+                  icon="shield"
+                  label="Resume approval prompts"
+                  title="Resume approval prompts"
+                  class="yolo-reset-button"
+                  hidden
+                ></vscode-toolbar-button>
               </div>
               <vscode-toolbar-container
                 id="toolbarContainer"
@@ -306,13 +314,6 @@
                   id="polishFollowUpProgressContainer"
                   style="display: none; width: 16px; height: 16px"
                 ></vscode-progress-ring>
-                <vscode-toolbar-button
-                  id="resetApprovalBypassBtn"
-                  icon="shield"
-                  label="Resume approval prompts"
-                  title="Resume approval prompts"
-                  hidden
-                ></vscode-toolbar-button>
                 <vscode-toolbar-button
                   id="recordFollowUpBtn"
                   icon="mic"

--- a/src/progressView/modules/constants.js
+++ b/src/progressView/modules/constants.js
@@ -52,7 +52,7 @@ export const ELEMENT_IDS = {
   QUEUED_FOLLOW_UPS_COLLAPSIBLE: 'queuedFollowUpsCollapsible',
   QUEUED_FOLLOW_UPS_LIST: 'queuedFollowUpsList',
   RECORD_FOLLOW_UP_BTN: 'recordFollowUpBtn',
-  RESET_APPROVAL_BYPASS_BTN: 'resetApprovalBypassBtn',
+  YOLO_TOGGLE_BTN: 'yoloToggleBtn',
   POLISH_FOLLOW_UP_BTN: 'polishFollowUpBtn',
   CLEAR_FOLLOW_UP_BTN: 'clearFollowUpBtn',
   SEND_FOLLOW_UP_BTN: 'sendFollowUpBtn',

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -921,7 +921,6 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
   handleUpdateToolEditApprovalState(message) {
     const bypassActive = Boolean(message?.bypassActive);
     state.approvalBypassActive = bypassActive;
-    dom.approvalRequests.setSessionBypassActive(bypassActive);
     dom.followUpInput.setApprovalBypassState(bypassActive);
   }
 

--- a/src/progressView/modules/uiManagers/ApprovalRequests.js
+++ b/src/progressView/modules/uiManagers/ApprovalRequests.js
@@ -3,10 +3,7 @@ import { COMMANDS } from '../constants.js';
 import { BaseUIRequestManager } from './BaseUIRequestManager.js';
 
 // Local imports - common helpers
-import {
-  addEventListenerSafely,
-  setElementCheckedState,
-} from '@common/domUtils.js';
+import { addEventListenerSafely } from '@common/domUtils.js';
 import { createFromTemplate } from '@common/templateUtils.js';
 import { vscode } from '@common/webviewContext.js';
 
@@ -112,7 +109,6 @@ export class ApprovalRequests extends BaseUIRequestManager {
   _updateRequestElement(element, request) {
     const pathElem = element.querySelector('.approval-request__path');
     const metaElem = element.querySelector('.approval-request__meta');
-    const bypassButton = element.querySelector('[data-action="approveAll"]');
     const mainDiffButton = element.querySelector('.diff-main-button');
     const dropdownTrigger = element.querySelector('.diff-dropdown-trigger');
     const dropdownMenu = element.querySelector('.diff-dropdown-menu');
@@ -130,12 +126,6 @@ export class ApprovalRequests extends BaseUIRequestManager {
 
     if (metaElem) {
       this._updateMetaElement(metaElem, request);
-    }
-
-    if (bypassButton) {
-      const allowBypass = request.allowBypass !== false;
-      bypassButton.toggleAttribute('disabled', !allowBypass);
-      setElementCheckedState(bypassButton, Boolean(this.isBypassActive));
     }
 
     // Set requestId on all diff-related elements
@@ -352,7 +342,6 @@ export class ApprovalRequests extends BaseUIRequestManager {
     const validActions = [
       'openDiff',
       'approve',
-      'approveAll',
       'reject',
       'showLatexdiff',
       'previewProposed',

--- a/src/progressView/modules/uiManagers/ApprovalRequests.js
+++ b/src/progressView/modules/uiManagers/ApprovalRequests.js
@@ -18,7 +18,6 @@ export class ApprovalRequests extends BaseUIRequestManager {
       listSelector: '.approval-requests__list',
       idAttribute: 'requestId',
     });
-    this.isBypassActive = false;
     this._handleToggle = this._handleToggle.bind(this);
     this._handleDropdownToggle = this._handleDropdownToggle.bind(this);
     this._handleClickOutside = this._handleClickOutside.bind(this);
@@ -72,19 +71,6 @@ export class ApprovalRequests extends BaseUIRequestManager {
   /** @override */
   dispose() {
     super.dispose();
-    this.isBypassActive = false;
-  }
-
-  /**
-   * Set whether session bypass is active.
-   * @param {boolean} isActive
-   */
-  setSessionBypassActive(isActive) {
-    this.isBypassActive = Boolean(isActive);
-    this.requests.forEach((entry) => {
-      this._updateRequestElement(entry.element, entry.data);
-    });
-    this._syncVisibleEntries();
   }
 
   /** @override */

--- a/src/progressView/modules/uiManagers/FollowUpInputManager.js
+++ b/src/progressView/modules/uiManagers/FollowUpInputManager.js
@@ -18,9 +18,10 @@ export class FollowUpInputManager {
   constructor(vscode) {
     this.vscode = vscode;
     this.textarea = null;
-    this.approvalBypassButton = null;
+    this.yoloToggleButton = null;
     this._isContainerVisible = false;
     this._focusTimer = null;
+    this._isYoloActive = false;
     this.recordingButton = new RecordingButtonManager(vscode, {
       buttonId: ELEMENT_IDS.RECORD_FOLLOW_UP_BTN,
       startCommand: COMMANDS.START_RECORDING,
@@ -31,15 +32,15 @@ export class FollowUpInputManager {
   }
 
   setup() {
+    // Setup YOLO toggle button (in header, independent of follow-up input)
+    this._setupYoloToggleButton();
+
     const target = safeGetElementById(ELEMENT_IDS.FOLLOW_UP_INPUT);
     if (!target) {
       return;
     }
 
     this.textarea = target;
-    this.approvalBypassButton = safeGetElementById(
-      ELEMENT_IDS.RESET_APPROVAL_BYPASS_BTN,
-    );
 
     const applySetup = () => {
       const { textarea } = resolveTextareaTarget(target);
@@ -70,18 +71,21 @@ export class FollowUpInputManager {
         this._clearFollowUp();
       });
 
-      addEventListenerSafely(
-        ELEMENT_IDS.RESET_APPROVAL_BYPASS_BTN,
-        'click',
-        () => {
-          this._resetApprovalBypass();
-        },
-      );
-
       this.recordingButton.setup();
     };
 
     awaitTextareaUpgrade(target, () => applySetup());
+  }
+
+  _setupYoloToggleButton() {
+    this.yoloToggleButton = safeGetElementById(ELEMENT_IDS.YOLO_TOGGLE_BTN);
+    if (!this.yoloToggleButton) {
+      return;
+    }
+
+    addEventListenerSafely(ELEMENT_IDS.YOLO_TOGGLE_BTN, 'click', () => {
+      this._toggleApprovalBypass();
+    });
   }
 
   _sendFollowUp() {
@@ -139,9 +143,9 @@ export class FollowUpInputManager {
     this.focus();
   }
 
-  _resetApprovalBypass() {
+  _toggleApprovalBypass() {
     this.vscode.postMessage({
-      command: COMMANDS.RESET_TOOL_EDIT_APPROVAL_BYPASS,
+      command: COMMANDS.TOGGLE_TOOL_EDIT_APPROVAL_BYPASS,
     });
   }
 
@@ -205,18 +209,27 @@ export class FollowUpInputManager {
   }
 
   setApprovalBypassState(isBypassed) {
+    this._isYoloActive = Boolean(isBypassed);
+
     // Always get a fresh reference to handle cases where setup() hasn't run yet
     // or the button reference became stale
     const button =
-      this.approvalBypassButton ||
-      safeGetElementById(ELEMENT_IDS.RESET_APPROVAL_BYPASS_BTN);
+      this.yoloToggleButton ||
+      safeGetElementById(ELEMENT_IDS.YOLO_TOGGLE_BTN);
     if (!button) {
       return;
     }
 
-    const showButton = Boolean(isBypassed);
-    button.toggleAttribute('hidden', !showButton);
-    button.toggleAttribute('disabled', !showButton);
+    // Update button appearance based on YOLO mode state
+    button.classList.toggle('is-active', this._isYoloActive);
+
+    if (this._isYoloActive) {
+      button.setAttribute('label', 'Disable YOLO mode');
+      button.setAttribute('title', 'Disable YOLO mode (resume approval prompts)');
+    } else {
+      button.setAttribute('label', 'Enable YOLO mode');
+      button.setAttribute('title', 'Enable YOLO mode (skip approval prompts)');
+    }
   }
 
   /**

--- a/src/progressView/modules/uiManagers/FollowUpInputManager.js
+++ b/src/progressView/modules/uiManagers/FollowUpInputManager.js
@@ -214,8 +214,7 @@ export class FollowUpInputManager {
     // Always get a fresh reference to handle cases where setup() hasn't run yet
     // or the button reference became stale
     const button =
-      this.yoloToggleButton ||
-      safeGetElementById(ELEMENT_IDS.YOLO_TOGGLE_BTN);
+      this.yoloToggleButton || safeGetElementById(ELEMENT_IDS.YOLO_TOGGLE_BTN);
     if (!button) {
       return;
     }
@@ -225,7 +224,10 @@ export class FollowUpInputManager {
 
     if (this._isYoloActive) {
       button.setAttribute('label', 'Disable YOLO mode');
-      button.setAttribute('title', 'Disable YOLO mode (resume approval prompts)');
+      button.setAttribute(
+        'title',
+        'Disable YOLO mode (resume approval prompts)',
+      );
     } else {
       button.setAttribute('label', 'Enable YOLO mode');
       button.setAttribute('title', 'Enable YOLO mode (skip approval prompts)');

--- a/src/progressView/styles/buttons.css
+++ b/src/progressView/styles/buttons.css
@@ -21,3 +21,13 @@
 #toolbarContainer .toolbar-button--hidden {
   display: none;
 }
+
+/* YOLO reset button - shown in header when approval bypass is active */
+.yolo-reset-button {
+  color: var(--vscode-inputValidation-warningForeground, #dd8500);
+  flex-shrink: 0;
+}
+
+.yolo-reset-button[hidden] {
+  display: none;
+}

--- a/src/progressView/styles/buttons.css
+++ b/src/progressView/styles/buttons.css
@@ -22,12 +22,12 @@
   display: none;
 }
 
-/* YOLO reset button - shown in header when approval bypass is active */
-.yolo-reset-button {
-  color: var(--vscode-inputValidation-warningForeground, #dd8500);
+/* YOLO toggle button - always visible in header */
+.yolo-toggle-button {
   flex-shrink: 0;
 }
 
-.yolo-reset-button[hidden] {
-  display: none;
+/* Active state when YOLO mode is enabled */
+.yolo-toggle-button.is-active {
+  color: var(--vscode-inputValidation-warningForeground, #dd8500);
 }

--- a/src/test/tools/ToolEditApprovalGate.test.ts
+++ b/src/test/tools/ToolEditApprovalGate.test.ts
@@ -6,6 +6,7 @@ import { WriteFileTool } from '@tools/WriteTool';
 import {
   setToolEditApprovalHandler,
   setToolEditApprovalSessionBypass,
+  toggleToolEditApprovalSessionBypass,
   type ToolEditApprovalRequest,
 } from '@tools/approval/toolEditApproval';
 import * as configModule from '@utils/config';
@@ -149,5 +150,39 @@ describe('Tool edit approval gating', () => {
     assert.strictEqual(handlerCalled, false);
     assert.strictEqual(writtenContent, 'auto');
     assert.strictEqual(result.output, 'written');
+  });
+
+  it('toggleToolEditApprovalSessionBypass toggles state and returns new value', async () => {
+    const tool = new WriteFileTool();
+    let handlerCallCount = 0;
+
+    WorkspaceFS.exists = async () => false;
+    WorkspaceFS.read = async () => '';
+    WorkspaceFS.write = async () => {};
+
+    setToolEditApprovalHandler(async () => {
+      handlerCallCount++;
+      return { accepted: true };
+    });
+
+    // Initially bypass is off (set in beforeEach), so handler should be called
+    await tool.call({ path: 'doc.txt', content: 'content1' });
+    assert.strictEqual(handlerCallCount, 1, 'Handler called when bypass off');
+
+    // Toggle on - should return true
+    const enabledState = toggleToolEditApprovalSessionBypass();
+    assert.strictEqual(enabledState, true, 'Toggle returns true when enabling');
+
+    // Handler should NOT be called when bypass is on
+    await tool.call({ path: 'doc.txt', content: 'content2' });
+    assert.strictEqual(handlerCallCount, 1, 'Handler not called when bypass on');
+
+    // Toggle off - should return false
+    const disabledState = toggleToolEditApprovalSessionBypass();
+    assert.strictEqual(disabledState, false, 'Toggle returns false when disabling');
+
+    // Handler should be called again when bypass is off
+    await tool.call({ path: 'doc.txt', content: 'content3' });
+    assert.strictEqual(handlerCallCount, 2, 'Handler called again when bypass off');
   });
 });

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -64,7 +64,6 @@ export const PROGRESS_VIEW_APPROVAL_ACTIONS = [
   'approve',
   'reject',
   'openDiff',
-  'approveAll',
   'resumeApprovals',
   'showLatexdiff',
   'previewProposed',
@@ -147,11 +146,6 @@ async function readCurrentContent(
   } catch (_err) {
     return fallback;
   }
-}
-
-function enableSessionApprovalBypass(): void {
-  approvalsBypassedForSession = true;
-  notifyProgressViewApprovalBypassState();
 }
 
 export function setToolEditApprovalSessionBypass(enabled: boolean): void {
@@ -715,11 +709,7 @@ export async function handleProgressViewToolEditApprovalAction(
       await previewProposedLatex(entry);
       break;
 
-    case 'approve':
-    case 'approveAll': {
-      if (payload.action === 'approveAll') {
-        enableSessionApprovalBypass();
-      }
+    case 'approve': {
       const appliedContent = await fs
         .readFile(entry.proposedUri.fsPath, 'utf-8')
         .catch(() => entry.proposedContent);

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -163,6 +163,12 @@ export function resetToolEditApprovalSessionBypass(): void {
   setToolEditApprovalSessionBypass(false);
 }
 
+export function toggleToolEditApprovalSessionBypass(): boolean {
+  const newState = !approvalsBypassedForSession;
+  setToolEditApprovalSessionBypass(newState);
+  return newState;
+}
+
 export function initializeToolEditApproval(
   context: vscode.ExtensionContext,
 ): void {

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -159,10 +159,6 @@ export function setToolEditApprovalSessionBypass(enabled: boolean): void {
   notifyProgressViewApprovalBypassState();
 }
 
-export function resetToolEditApprovalSessionBypass(): void {
-  setToolEditApprovalSessionBypass(false);
-}
-
 export function toggleToolEditApprovalSessionBypass(): boolean {
   const newState = !approvalsBypassedForSession;
   setToolEditApprovalSessionBypass(newState);
@@ -687,7 +683,7 @@ export async function handleProgressViewToolEditApprovalAction(
 
   // State modification action - no isSettled check needed
   if (payload.action === 'resumeApprovals') {
-    resetToolEditApprovalSessionBypass();
+    setToolEditApprovalSessionBypass(false);
     return;
   }
 

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -64,7 +64,6 @@ export const PROGRESS_VIEW_APPROVAL_ACTIONS = [
   'approve',
   'reject',
   'openDiff',
-  'resumeApprovals',
   'showLatexdiff',
   'previewProposed',
 ] as const;
@@ -671,18 +670,7 @@ export async function handleProgressViewToolEditApprovalAction(
   payload: ProgressViewApprovalActionPayload,
 ): Promise<void> {
   const entry = pendingApprovals.get(payload.requestId);
-  if (!entry) {
-    return;
-  }
-
-  // State modification action - no isSettled check needed
-  if (payload.action === 'resumeApprovals') {
-    setToolEditApprovalSessionBypass(false);
-    return;
-  }
-
-  // All other actions require the entry to not be settled
-  if (entry.isSettled()) {
+  if (!entry || entry.isSettled()) {
     return;
   }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces a session-wide approval bypass toggle and cleans up deprecated per-request controls.
> 
> - Adds `TOGGLE_TOOL_EDIT_APPROVAL_BYPASS` command; replaces `RESET_TOOL_EDIT_APPROVAL_BYPASS`
> - New header `yoloToggleBtn` with visual state and messages; `FollowUpInputManager` posts toggle and updates button label/title
> - Removes per-request "Approve & Yolo this session" and related toggle/checkbox plumbing from approval prompts
> - Simplifies approval actions: drops `approveAll`/`resumeApprovals`; `handleProgressViewToolEditApprovalAction` no longer handles them
> - Implements `toggleToolEditApprovalSessionBypass()` in `toolEditApproval.ts` and wires ProgressView handler to show enable/disable notifications
> - Updates UI constants/templates/styles for the new toggle; approval UI no longer manages bypass state
> - Adds tests covering toggle behavior in `ToolEditApprovalGate.test.ts`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f502c861122b6da72aac57f084f6f7bd28eb995a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->