### PR TITLE
Review MPO transcribe diff results

### DIFF
--- a/src/latex/latexdiff/diffFileNameManager.ts
+++ b/src/latex/latexdiff/diffFileNameManager.ts
@@ -34,7 +34,13 @@ export class DiffFileNameManager {
     );
     const editedRoundMatch = extractLastRoundModelMatch(editedFileName);
 
-    if (inputRoundMatch && editedRoundMatch) {
+    // Only use round-based naming if both files have rounds AND rounds differ.
+    // Same-round comparisons (e.g., original vs proposed temp files) fall back to suffix.
+    if (
+      inputRoundMatch &&
+      editedRoundMatch &&
+      inputRoundMatch[1] !== editedRoundMatch[1]
+    ) {
       return this.generateRoundBasedFileName(
         editedFileName,
         inputRoundMatch,


### PR DESCRIPTION
When comparing original vs proposed temp files (e.g., from tool edit approval), both files have the same _r{N}_{model} pattern since they're derived from the same source. This caused meaningless diff names like "diffr1r1" instead of using the fallback suffix.

Now only uses round-based naming when rounds actually differ.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refines diff filename generation to avoid misleading names when comparing same-round files.
> 
> - In `DiffFileNameManager.generateDiffFileName`, apply round-based naming only if both files include round info and the rounds differ; otherwise fall back to `name + suffix + .tex`
> - Keeps existing round-based format via `generateRoundBasedFileName` unchanged; impacts comparisons of original vs proposed temp files with identical rounds
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 13aeb584c30a434481125ba99c4a3b2f5d01ed26. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->