### PR TITLE
Simplify and improve code clarity

### DIFF
--- a/src/agent/runtime/SessionResumeRetrieval.ts
+++ b/src/agent/runtime/SessionResumeRetrieval.ts
@@ -111,19 +111,13 @@ function parseToolUseFlowRecordState(
   // Try flat format first (current)
   const flatResult = FlatToolUseFlowRecordStateSchema.safeParse(shared);
   if (flatResult.success) {
-    return {
-      conversation: flatResult.data.conversation,
-      stateSlices: flatResult.data.stateSlices,
-    };
+    return flatResult.data;
   }
 
-  // Fall back to legacy format
+  // Fall back to legacy format (unwrap nested state)
   const legacyResult = LegacyToolUseFlowRecordStateSchema.safeParse(shared);
   if (legacyResult.success) {
-    return {
-      conversation: legacyResult.data.state.conversation,
-      stateSlices: legacyResult.data.state.stateSlices,
-    };
+    return legacyResult.data.state;
   }
 
   return null;

--- a/src/frontend/vscode/vscodeDiagnostics.ts
+++ b/src/frontend/vscode/vscodeDiagnostics.ts
@@ -127,25 +127,29 @@ export function countBySeverity(
 // Formatting
 // ============================================================================
 
+/** Pluralization rules for severity counts */
+const COUNT_LABELS: Array<{
+  key: keyof SeverityCounts;
+  singular: string;
+  plural: string;
+}> = [
+  { key: 'errors', singular: 'error', plural: 'errors' },
+  { key: 'warnings', singular: 'warning', plural: 'warnings' },
+  { key: 'info', singular: 'info', plural: 'info' },
+  { key: 'hints', singular: 'hint', plural: 'hints' },
+];
+
 /**
  * Format severity counts as a human-readable summary string.
  * Example: "3 errors, 2 warnings, 1 hint"
  */
 export function formatCounts(counts: SeverityCounts): string {
-  const parts: string[] = [];
-
-  if (counts.errors > 0) {
-    parts.push(`${counts.errors} error${counts.errors !== 1 ? 's' : ''}`);
-  }
-  if (counts.warnings > 0) {
-    parts.push(`${counts.warnings} warning${counts.warnings !== 1 ? 's' : ''}`);
-  }
-  if (counts.info > 0) {
-    parts.push(`${counts.info} info`);
-  }
-  if (counts.hints > 0) {
-    parts.push(`${counts.hints} hint${counts.hints !== 1 ? 's' : ''}`);
-  }
+  const parts = COUNT_LABELS.filter(({ key }) => counts[key] > 0).map(
+    ({ key, singular, plural }) => {
+      const count = counts[key];
+      return `${count} ${count === 1 ? singular : plural}`;
+    },
+  );
 
   return parts.length > 0 ? parts.join(', ') : 'No issues';
 }

--- a/src/model/computeModelOptions.ts
+++ b/src/model/computeModelOptions.ts
@@ -113,6 +113,14 @@ export async function computeModelOptions(): Promise<string> {
   return optionTags.join('\n');
 }
 
+/** Build description attribute from context and cost info. */
+function buildDescription(contextStr: string, costStr: string): string {
+  const parts = [];
+  if (contextStr) parts.push(`Context: ${contextStr}`);
+  if (costStr) parts.push(`Cost (in/out per 1M): ${costStr}`);
+  return parts.length > 0 ? `description="${parts.join(' | ')}"` : '';
+}
+
 /** Build a single model option tag. */
 async function buildModelOption(
   model: string,
@@ -136,13 +144,7 @@ async function buildModelOption(
     config.provider && `data-provider="${config.provider}"`,
     contextStr && `data-context="${contextStr}"`,
     costStr && `data-cost="${costStr}"`,
-    (contextStr || costStr) &&
-      `description="${[
-        contextStr && `Context: ${contextStr}`,
-        costStr && `Cost (in/out per 1M): ${costStr}`,
-      ]
-        .filter(Boolean)
-        .join(' | ')}"`,
+    buildDescription(contextStr, costStr),
   ].filter(Boolean);
 
   return `<vscode-option ${attrs.join(' ')}>${model}</vscode-option>`;

--- a/src/progressView/events/LogEventHandlers.ts
+++ b/src/progressView/events/LogEventHandlers.ts
@@ -63,13 +63,11 @@ function handleUpdateLogMessage(ctx: EventHandlerContext) {
         const existing = messages.find((m) => m.id === logMessage.id);
         if (!existing) return;
 
-        // Skip INTERNAL message updates
-        if (
+        // Skip INTERNAL message updates (either existing or incoming)
+        const isInternalUpdate =
           existing.messageType === MESSAGE_TYPES.INTERNAL ||
-          logMessage.messageType === MESSAGE_TYPES.INTERNAL
-        ) {
-          return;
-        }
+          logMessage.messageType === MESSAGE_TYPES.INTERNAL;
+        if (isInternalUpdate) return;
 
         // Update fields from logMessage, preserving existing values for undefined fields
         const { id: _id, ...updates } = logMessage;

--- a/src/tools/DiagnosticsTool.ts
+++ b/src/tools/DiagnosticsTool.ts
@@ -14,7 +14,7 @@ import * as logger from '@logger/logUtils';
 
 // Local file imports
 import { defineTool } from './core/define';
-import { type DiagnosticsPayload, ToolResult, ToolError } from './result';
+import { ToolResult, ToolError } from './result';
 
 const CHANNEL = 'DiagnosticsTool';
 logger.initialize(CHANNEL);
@@ -38,28 +38,25 @@ export class DiagnosticsTool extends defineTool({
     try {
       const messages = await getLinterMessages(path);
       const counts = countBySeverity(messages);
-      const countsStr = formatCounts(counts);
-
+      const header = `${path}: ${formatCounts(counts)}`;
       const summary = `Diagnostics ${command} for ${path}`;
-      const header = `${path}: ${countsStr}`;
+
+      const baseDiagnostics = {
+        path,
+        command,
+        severity: counts,
+      };
 
       if (command === 'count') {
-        return {
-          summary,
-          output: header,
-          diagnostics: { path, command, severity: counts },
-        };
+        return { summary, output: header, diagnostics: baseDiagnostics };
       }
 
-      const output =
-        messages.length > 0
-          ? `${header}\n\n${formatMessageList(messages)}`
-          : header;
-
+      const messageDetails =
+        messages.length > 0 ? `\n\n${formatMessageList(messages)}` : '';
       return {
         summary,
-        output,
-        diagnostics: { path, command, severity: counts, messages },
+        output: `${header}${messageDetails}`,
+        diagnostics: { ...baseDiagnostics, messages },
       };
     } catch (error) {
       const detail = toErrorMessage(error);

--- a/src/tools/ReadTool.ts
+++ b/src/tools/ReadTool.ts
@@ -83,11 +83,19 @@ export class ReadFileTool extends defineTool({
     const totalLines = lines.length;
 
     const requestedStartLine = input.range?.start ?? 1;
-    const requestedEndLine =
-      input.range?.end ??
-      (input.range?.start
-        ? Math.min(requestedStartLine + READ_FILE_MAX_LINES - 1, totalLines)
-        : totalLines);
+    let requestedEndLine: number;
+    // eslint-disable-next-line eqeqeq -- nullish check (null or undefined)
+    if (input.range?.end != null) {
+      requestedEndLine = input.range.end;
+      // eslint-disable-next-line eqeqeq -- nullish check (null or undefined)
+    } else if (input.range?.start != null) {
+      requestedEndLine = Math.min(
+        requestedStartLine + READ_FILE_MAX_LINES - 1,
+        totalLines,
+      );
+    } else {
+      requestedEndLine = totalLines;
+    }
 
     // Convert the requested 1-based range into zero-based indices and clamp them to the
     // available file length so callers can safely request windows beyond the file bounds.

--- a/src/tools/grep.ts
+++ b/src/tools/grep.ts
@@ -41,10 +41,13 @@ export function buildArguments(
   const args: string[] = ['--color=never'];
 
   // Output mode flags
-  if (outputMode === 'files_with_matches') {
-    args.push('--files-with-matches');
-  } else if (outputMode === 'count') {
-    args.push('--count');
+  switch (outputMode) {
+    case 'files_with_matches':
+      args.push('--files-with-matches');
+      break;
+    case 'count':
+      args.push('--count');
+      break;
   }
 
   // Filter options

--- a/src/tools/lean/LspTools.ts
+++ b/src/tools/lean/LspTools.ts
@@ -43,6 +43,31 @@ const LeanRestartInputSchema = z.strictObject({
 export type LeanRestartInput = z.infer<typeof LeanRestartInputSchema>;
 
 // ============================================================================
+// Helper Functions
+// ============================================================================
+
+const NO_DIAGNOSTICS_HELP = `No errors, warnings, or hints for this file.
+
+If you expected errors:
+1. Check the Lean 4 output panel (import/dependency errors appear there)
+2. Make sure the file is saved
+3. Try \`lean_restart\` to refresh the Lean server
+4. Verify the Lean 4 extension is active (look for goal state in the infoview)`;
+
+/** Navigate editor to first error location if present. */
+async function navigateToFirstError(
+  filePath: string,
+  diagnostics: vscode.Diagnostic[],
+): Promise<void> {
+  const firstError = diagnostics.find(
+    (d) => d.severity === DiagnosticSeverity.Error,
+  );
+  if (firstError) {
+    await openFileInEditor(filePath, firstError.range.start.line + 1);
+  }
+}
+
+// ============================================================================
 // Tool Implementations
 // ============================================================================
 
@@ -74,17 +99,8 @@ Requires: Lean 4 VS Code extension installed and active.`,
     const { command, file } = input;
 
     try {
-      // Resolve the path first to set up the listener
-      const absolutePath = WorkspaceFS.toAbsolute(file);
-      const uri = vscode.Uri.file(absolutePath);
-
-      // Start listening for diagnostics BEFORE opening the file
-      // This ensures we don't miss the initial diagnostics event
-      const diagnosticsWait = waitForDiagnosticsChange(uri, 10000);
-
-      // Open file to trigger Lean processing
-      const openedPath = await openFileInEditor(file);
-      if (!openedPath) {
+      const diagnostics = await this.fetchDiagnostics(file);
+      if (!diagnostics) {
         return {
           summary: 'Failed to open file',
           output: `Could not open file: ${file}\n\nMake sure the file exists and is accessible.`,
@@ -92,57 +108,29 @@ Requires: Lean 4 VS Code extension installed and active.`,
         };
       }
 
-      // Wait for Lean to publish diagnostics
-      await diagnosticsWait;
+      await navigateToFirstError(file, diagnostics);
 
-      // Now get the diagnostics
-      const diagnostics = vscodeIntegration.getDiagnostics(openedPath);
-
-      // Position at first error if any
-      const firstError = diagnostics.find(
-        (d) => d.severity === DiagnosticSeverity.Error,
-      );
-      if (firstError) {
-        await openFileInEditor(openedPath, firstError.range.start.line + 1);
-      }
-
-      // Count by severity
       const counts = countBySeverity(diagnostics);
       const countsStr = formatCounts(counts);
 
       if (diagnostics.length === 0) {
-        return {
-          summary: '✓ No diagnostics',
-          output:
-            'No errors, warnings, or hints for this file.\n\n' +
-            'If you expected errors:\n' +
-            '1. Check the Lean 4 output panel (import/dependency errors appear there)\n' +
-            '2. Make sure the file is saved\n' +
-            '3. Try `lean_restart` to refresh the Lean server\n' +
-            '4. Verify the Lean 4 extension is active (look for goal state in the infoview)',
-        };
+        return { summary: '✓ No diagnostics', output: NO_DIAGNOSTICS_HELP };
       }
 
-      // For count command, just return the summary
+      const baseDiagnostics = { ...counts, total: diagnostics.length };
+
       if (command === 'count') {
         return {
           summary: countsStr,
           output: `${file}: ${countsStr}`,
-          diagnostics: { ...counts, total: diagnostics.length },
+          diagnostics: baseDiagnostics,
         };
       }
 
-      // For list command, return formatted details
-      const output = formatGroupedSections(diagnostics);
-
       return {
         summary: countsStr,
-        output,
-        diagnostics: {
-          ...counts,
-          total: diagnostics.length,
-          details: diagnostics,
-        },
+        output: formatGroupedSections(diagnostics),
+        diagnostics: { ...baseDiagnostics, details: diagnostics },
       };
     } catch (error) {
       return {
@@ -151,6 +139,20 @@ Requires: Lean 4 VS Code extension installed and active.`,
         isError: true,
       };
     }
+  }
+
+  /** Open file and wait for diagnostics to be published. */
+  private async fetchDiagnostics(
+    file: string,
+  ): Promise<vscode.Diagnostic[] | null> {
+    const uri = vscode.Uri.file(WorkspaceFS.toAbsolute(file));
+    const diagnosticsWait = waitForDiagnosticsChange(uri, 10000);
+
+    const openedPath = await openFileInEditor(file);
+    if (!openedPath) return null;
+
+    await diagnosticsWait;
+    return vscodeIntegration.getDiagnostics(openedPath);
   }
 }
 

--- a/src/tools/lean/VscodeIntegration.ts
+++ b/src/tools/lean/VscodeIntegration.ts
@@ -14,20 +14,23 @@ import { WorkspaceFS } from '@utils/files';
  */
 export function getDiagnostics(filePath: string): vscode.Diagnostic[] {
   const uri = vscode.Uri.file(WorkspaceFS.toAbsolute(filePath));
-  const diagnostics = vscode.languages.getDiagnostics(uri);
-
-  if (diagnostics.length > 0) {
-    return diagnostics;
+  const directLookup = vscode.languages.getDiagnostics(uri);
+  if (directLookup.length > 0) {
+    return directLookup;
   }
 
   // Fallback: search by path in case URI format differs
-  const resolvedPath = uri.fsPath.toLowerCase();
+  return findDiagnosticsByPath(uri.fsPath);
+}
+
+/** Find diagnostics by matching file path (case-insensitive). */
+function findDiagnosticsByPath(targetPath: string): vscode.Diagnostic[] {
+  const normalizedTarget = targetPath.toLowerCase();
   for (const [diagUri, diags] of vscode.languages.getDiagnostics()) {
-    if (diagUri.fsPath.toLowerCase() === resolvedPath && diags.length > 0) {
+    if (diagUri.fsPath.toLowerCase() === normalizedTarget && diags.length > 0) {
       return diags;
     }
   }
-
   return [];
 }
 


### PR DESCRIPTION
- ReadTool.ts: Replace nested ternary with explicit if/else for requestedEndLine
- grep.ts: Convert output mode if/else to switch statement
- vscodeDiagnostics.ts: Use data-driven approach for formatCounts
- SessionResumeRetrieval.ts: Simplify parseToolUseFlowRecordState return logic
- VscodeIntegration.ts: Extract findDiagnosticsByPath helper function
- executeAgent.ts: Replace nested ternary with if/else for outputInfo
- computeModelOptions.ts: Extract buildDescription helper function
- LogEventHandlers.ts: Consolidate INTERNAL message check into named variable
- DiagnosticsTool.ts: Streamline output building with baseDiagnostics
- LspTools.ts: Extract helper functions and constants for better structure

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Refactors and small improvements across diagnostics, Lean tooling, and utilities**
> 
> - Lean tools: extracted helpers (`fetchDiagnostics`, `navigateToFirstError`), added `NO_DIAGNOSTICS_HELP`, and improved VS Code diagnostics lookup with path-based fallback in `VscodeIntegration.getDiagnostics`
> - VS Code diagnostics: data-driven `formatCounts` via `COUNT_LABELS`
> - Tools: `read_file` clarifies requested end-line logic; `grep` switches to `switch`-based output mode; `diagnostics` tool simplifies output/diagnostics construction
> - Progress logs: consolidated INTERNAL message update check in `LogEventHandlers`
> - Model options: extracted `buildDescription` in `computeModelOptions`
> - Session resume: simplified `parseToolUseFlowRecordState` return logic
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 532dbc9c1b238b431d94e164f6790427ddee23f8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->