### PR TITLE
Simplify and improve code clarity

### DIFF
--- a/src/agent/modelHandlers/modelHandlerOpenRouter.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenRouter.ts
@@ -27,6 +27,14 @@ import type {
   ChatCompletionMessageParam,
 } from 'openai/resources/chat/completions';
 
+/** Extract text content from a reasoning detail item by type */
+function getReasoningItemText(item: ReasoningDetailItem): string | undefined {
+  if (item.type === 'reasoning.text') return item.text ?? undefined;
+  if (item.type === 'reasoning.summary') return item.summary;
+  // 'reasoning.encrypted' - encrypted content is not useful for display
+  return undefined;
+}
+
 /**
  * Extracts text content from OpenRouter reasoning_details array.
  * Handles the structured format with type-specific fields.
@@ -37,28 +45,14 @@ const extractTextFromReasoningDetails = (
 ): string => {
   if (!Array.isArray(details)) {
     // Fallback: if it's a string, return it directly
-    if (typeof details === 'string') return details;
-    return '';
+    return typeof details === 'string' ? details : '';
   }
 
-  const textParts: string[] = [];
-  for (const item of details) {
-    if (!item || typeof item !== 'object') continue;
-
-    switch (item.type) {
-      case 'reasoning.text':
-        if (item.text) textParts.push(item.text);
-        break;
-      case 'reasoning.summary':
-        if (item.summary) textParts.push(item.summary);
-        break;
-      case 'reasoning.encrypted':
-        // Encrypted content is not useful for display, skip it
-        break;
-    }
-  }
-
-  return textParts.join('');
+  return details
+    .filter((item): item is ReasoningDetailItem => !!item && typeof item === 'object')
+    .map(getReasoningItemText)
+    .filter((text): text is string => !!text)
+    .join('');
 };
 
 /**

--- a/src/auth/authCommands.ts
+++ b/src/auth/authCommands.ts
@@ -337,15 +337,12 @@ export async function showAccountMenu(): Promise<void> {
         placeHolder: 'Account Options',
       });
 
+      const actionCommands: Record<'viewProfile' | 'signOut', string> = {
+        viewProfile: AUTH_COMMANDS.VIEW_PROFILE,
+        signOut: AUTH_COMMANDS.SIGN_OUT,
+      };
       if (choice) {
-        switch (choice.action) {
-          case 'viewProfile':
-            await vscode.commands.executeCommand(AUTH_COMMANDS.VIEW_PROFILE);
-            break;
-          case 'signOut':
-            await vscode.commands.executeCommand(AUTH_COMMANDS.SIGN_OUT);
-            break;
-        }
+        await vscode.commands.executeCommand(actionCommands[choice.action]);
       }
     }
   } catch (error) {

--- a/src/commands/housekeeping/cleanCommands.ts
+++ b/src/commands/housekeeping/cleanCommands.ts
@@ -32,21 +32,17 @@ const CleanParamsSchema = z.object({
 // --- Helpers ---
 
 function showCleanResult(result: FileOpResult, inputFile: string): void {
-  switch (result.status) {
-    case 'success':
-      vscode.window.showInformationMessage(`Cleanup complete for ${inputFile}`);
-      break;
-    case 'noFiles':
-      vscode.window.showInformationMessage(
-        `No files found to clean for ${inputFile}`,
-      );
-      break;
-    case 'missingParams':
-      vscode.window.showErrorMessage('Missing required parameters for clean');
-      break;
-    case 'error':
-      vscode.window.showErrorMessage(`Error during cleanup: ${result.error}`);
-      break;
+  const messages: Record<FileOpResult['status'], { text: string; isError: boolean }> = {
+    success: { text: `Cleanup complete for ${inputFile}`, isError: false },
+    noFiles: { text: `No files found to clean for ${inputFile}`, isError: false },
+    missingParams: { text: 'Missing required parameters for clean', isError: true },
+    error: { text: `Error during cleanup: ${result.error}`, isError: true },
+  };
+  const msg = messages[result.status];
+  if (msg.isError) {
+    vscode.window.showErrorMessage(msg.text);
+  } else {
+    vscode.window.showInformationMessage(msg.text);
   }
 }
 

--- a/src/commands/latex/compareCommands.ts
+++ b/src/commands/latex/compareCommands.ts
@@ -245,33 +245,22 @@ function getNewFileTarget(
 
   // Preserve location kind from base file
   let targetLocation: FileLocation;
-  switch (baseLocation.kind) {
-    case 'workspace': {
-      const targetRelativePath = path.join(
-        path.dirname(baseLocation.relativePath),
-        targetFileName,
-      );
-      targetLocation = createWorkspaceLocation(
-        targetAbsolutePath,
-        targetRelativePath,
-      );
-      break;
-    }
-    case 'runStorage': {
-      const targetRelativePath = path.join(
-        path.dirname(baseLocation.relativePath),
-        targetFileName,
-      );
-      targetLocation = createRunStorageLocation(
-        targetAbsolutePath,
-        targetRelativePath,
-        baseLocation.executionId,
-      );
-      break;
-    }
-    case 'external':
-      targetLocation = createExternalLocation(targetAbsolutePath);
-      break;
+  if (baseLocation.kind === 'external') {
+    targetLocation = createExternalLocation(targetAbsolutePath);
+  } else {
+    // workspace and runStorage share the same relative path computation
+    const targetRelativePath = path.join(
+      path.dirname(baseLocation.relativePath),
+      targetFileName,
+    );
+    targetLocation =
+      baseLocation.kind === 'workspace'
+        ? createWorkspaceLocation(targetAbsolutePath, targetRelativePath)
+        : createRunStorageLocation(
+            targetAbsolutePath,
+            targetRelativePath,
+            baseLocation.executionId,
+          );
   }
 
   return { targetLocation, targetFileName, isNewFile: true };

--- a/src/frontend/vscode/vscodeDiagnostics.ts
+++ b/src/frontend/vscode/vscodeDiagnostics.ts
@@ -95,6 +95,14 @@ export function getSeverityLabel(severity: vscode.DiagnosticSeverity): string {
   return SEVERITY_LABELS[severity] ?? 'unknown';
 }
 
+/** Map from severity to counts key */
+const SEVERITY_TO_COUNT_KEY: Record<vscode.DiagnosticSeverity, keyof SeverityCounts> = {
+  [vscode.DiagnosticSeverity.Error]: 'errors',
+  [vscode.DiagnosticSeverity.Warning]: 'warnings',
+  [vscode.DiagnosticSeverity.Information]: 'info',
+  [vscode.DiagnosticSeverity.Hint]: 'hints',
+};
+
 /**
  * Count diagnostics by severity level.
  */
@@ -104,20 +112,8 @@ export function countBySeverity(
   const counts: SeverityCounts = { errors: 0, warnings: 0, info: 0, hints: 0 };
 
   for (const d of diagnostics) {
-    switch (d.severity) {
-      case vscode.DiagnosticSeverity.Error:
-        counts.errors++;
-        break;
-      case vscode.DiagnosticSeverity.Warning:
-        counts.warnings++;
-        break;
-      case vscode.DiagnosticSeverity.Information:
-        counts.info++;
-        break;
-      case vscode.DiagnosticSeverity.Hint:
-        counts.hints++;
-        break;
-    }
+    const key = SEVERITY_TO_COUNT_KEY[d.severity];
+    if (key) counts[key]++;
   }
 
   return counts;

--- a/src/latex/latexdiff/mathMarkup.ts
+++ b/src/latex/latexdiff/mathMarkup.ts
@@ -4,16 +4,13 @@ export type MathMarkupOption = (typeof MATH_MARKUP_OPTIONS)[number];
 
 export const DEFAULT_MATH_MARKUP: MathMarkupOption = 'coarse';
 
+const MATH_MARKUP_DESCRIPTIONS: Record<MathMarkupOption, string> = {
+  coarse: 'Default - recommended for most documents',
+  fine: 'Detailed math markup',
+  whole: 'Mark entire math environments',
+  off: 'No math markup',
+};
+
 export function describeMathMarkupOption(option: MathMarkupOption): string {
-  switch (option) {
-    case 'coarse':
-      return 'Default - recommended for most documents';
-    case 'fine':
-      return 'Detailed math markup';
-    case 'whole':
-      return 'Mark entire math environments';
-    case 'off':
-    default:
-      return 'No math markup';
-  }
+  return MATH_MARKUP_DESCRIPTIONS[option];
 }

--- a/src/tools/arxiv/ArxivSearchTool.ts
+++ b/src/tools/arxiv/ArxivSearchTool.ts
@@ -57,18 +57,13 @@ export class ArxivSearchTool extends defineTool({
 
     // Select the query function based on the field parameter
     const searchField = input.field ?? 'all';
-    const fieldQueryFn = (term: string) => {
-      switch (searchField) {
-        case 'author':
-          return authorQuery(term);
-        case 'title':
-          return titleQuery(term);
-        case 'abstract':
-          return abstractQuery(term);
-        default:
-          return all(term);
-      }
-    };
+    const fieldQueryFns = {
+      author: authorQuery,
+      title: titleQuery,
+      abstract: abstractQuery,
+      all: all,
+    } as const;
+    const fieldQueryFn = fieldQueryFns[searchField];
 
     // Build query using arxiv-client query builder
     const terms = Array.from(

--- a/src/tools/ls.ts
+++ b/src/tools/ls.ts
@@ -31,17 +31,15 @@ function isDefaultHiddenName(name: string): boolean {
   return DEFAULT_HIDDEN_NAMES.has(name);
 }
 
+const FILE_TYPE_LABELS: Record<vscode.FileType, string> = {
+  [vscode.FileType.Directory]: 'dir',
+  [vscode.FileType.SymbolicLink]: 'link',
+  [vscode.FileType.File]: 'file',
+  [vscode.FileType.Unknown]: 'other',
+};
+
 function getFileTypeLabel(type: vscode.FileType): string {
-  switch (type) {
-    case vscode.FileType.Directory:
-      return 'dir';
-    case vscode.FileType.SymbolicLink:
-      return 'link';
-    case vscode.FileType.File:
-      return 'file';
-    default:
-      return 'other';
-  }
+  return FILE_TYPE_LABELS[type] ?? 'other';
 }
 
 function formatEntry(name: string, type: vscode.FileType): string {


### PR DESCRIPTION
Replace switch statements with lookup tables for clearer, more maintainable code patterns across multiple files:

- ls.ts: FILE_TYPE_LABELS lookup for file type display
- mathMarkup.ts: MATH_MARKUP_DESCRIPTIONS lookup for option descriptions
- modelHandlerOpenRouter.ts: functional approach for reasoning extraction
- authCommands.ts: action-to-command lookup for dispatch
- compareCommands.ts: consolidate duplicate path computation in switch
- cleanCommands.ts: message lookup table for result handling
- ArxivSearchTool.ts: field query function lookup
- vscodeDiagnostics.ts: severity-to-count-key lookup

These changes follow CLAUDE.md guidelines for preferring data-driven patterns over verbose switch statements when appropriate.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Modernizes control flow and simplifies logic across the codebase using data-driven lookups and small functional helpers.
> 
> - **Reasoning extraction:** In `modelHandlerOpenRouter.ts`, adds `getReasoningItemText` and rewrites `extractTextFromReasoningDetails` to a functional pipeline; keeps streaming `reasoning` delta handling intact.
> - **Auth menu:** In `authCommands.ts`, replaces switch dispatch with `actionCommands` lookup for `viewProfile`/`signOut`.
> - **Housekeeping messages:** In `cleanCommands.ts`, consolidates result messaging via a `messages` lookup table.
> - **Compare targets:** In `compareCommands.ts`, unifies relative path computation for `workspace`/`runStorage` and simplifies `external` handling.
> - **Diagnostics counting:** In `vscodeDiagnostics.ts`, maps severities to count keys via `SEVERITY_TO_COUNT_KEY`.
> - **Math markup:** In `mathMarkup.ts`, switches to `MATH_MARKUP_DESCRIPTIONS` lookup.
> - **arXiv search:** In `ArxivSearchTool.ts`, selects field query via `fieldQueryFns` map.
> - **File listing:** In `ls.ts`, uses `FILE_TYPE_LABELS` map and helper for labels.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b870c26898d8676c3a14bbc3381a011d81c52858. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->