### PR TITLE
Simplify and improve code clarity

### DIFF
--- a/src/FolderExplorer.ts
+++ b/src/FolderExplorer.ts
@@ -64,18 +64,14 @@ export class FolderExplorer implements vscode.TreeDataProvider<FileItem> {
   }
 
   getTreeItem(element: FileItem): vscode.TreeItem {
+    const isFile =
+      element.collapsibleState === vscode.TreeItemCollapsibleState.None;
     if (element.editing) {
       element.contextValue = 'editing';
     } else if (element.isBuiltIn) {
-      element.contextValue =
-        element.collapsibleState === vscode.TreeItemCollapsibleState.None
-          ? 'builtInFile'
-          : 'builtInFolder';
+      element.contextValue = isFile ? 'builtInFile' : 'builtInFolder';
     } else {
-      element.contextValue =
-        element.collapsibleState === vscode.TreeItemCollapsibleState.None
-          ? 'file'
-          : 'folder';
+      element.contextValue = isFile ? 'file' : 'folder';
     }
     return element;
   }
@@ -166,12 +162,14 @@ export class FolderExplorer implements vscode.TreeDataProvider<FileItem> {
         }
       }
 
+      // Sort: folders first, then alphabetically by label
       return items.sort((a, b) => {
-        if (a.collapsibleState !== b.collapsibleState) {
-          return b.collapsibleState ===
-            vscode.TreeItemCollapsibleState.Collapsed
-            ? 1
-            : -1;
+        const aIsFolder =
+          a.collapsibleState === vscode.TreeItemCollapsibleState.Collapsed;
+        const bIsFolder =
+          b.collapsibleState === vscode.TreeItemCollapsibleState.Collapsed;
+        if (aIsFolder !== bIsFolder) {
+          return bIsFolder ? 1 : -1;
         }
         return a.label!.toString().localeCompare(b.label!.toString());
       });

--- a/src/MainViewProvider.ts
+++ b/src/MainViewProvider.ts
@@ -191,15 +191,20 @@ export class MainViewProvider
     // Cache of agent directory paths for filtering
     let agentDirPaths: string[] = [];
 
-    // Debounced refresh - updates agent dirs and options
-    const debouncedAgentFileRefresh = debounce(async () => {
+    // Update cache (called directly for init, debounced for file changes)
+    const updateAgentDirs = async () => {
       const dirs = await agentDirectories.getAllLocal();
       agentDirPaths = dirs.map((d) => d.directory);
+    };
+
+    // Initialize cache immediately (not debounced)
+    void updateAgentDirs();
+
+    // Debounced refresh - updates dirs and options on file changes
+    const debouncedAgentFileRefresh = debounce(async () => {
+      await updateAgentDirs();
       await this.refreshAgentOptions();
     }, DEBOUNCE_STATE_SAVE_MS);
-
-    // Initialize cache
-    void debouncedAgentFileRefresh();
 
     // Filter and debounce agent file changes
     const onAgentFileChange = (uri: vscode.Uri) => {

--- a/src/MainViewProvider.ts
+++ b/src/MainViewProvider.ts
@@ -190,28 +190,21 @@ export class MainViewProvider
 
     // Cache of agent directory paths for filtering
     let agentDirPaths: string[] = [];
-    const updateAgentDirs = async () => {
-      const dirs = await agentDirectories.getAllLocal();
-      agentDirPaths = dirs.map((d) => d.directory);
-    };
-    // Initialize and refresh periodically (directories might change)
-    void updateAgentDirs();
-
-    // Check if a file path is within an agent directory
-    const isAgentFile = (uri: vscode.Uri): boolean => {
-      const filePath = uri.fsPath;
-      return agentDirPaths.some((dir) => filePath.startsWith(dir));
-    };
 
     // Debounced refresh - updates agent dirs and options
     const debouncedAgentFileRefresh = debounce(async () => {
-      await updateAgentDirs();
+      const dirs = await agentDirectories.getAllLocal();
+      agentDirPaths = dirs.map((d) => d.directory);
       await this.refreshAgentOptions();
     }, DEBOUNCE_STATE_SAVE_MS);
 
+    // Initialize cache
+    void debouncedAgentFileRefresh();
+
     // Filter and debounce agent file changes
     const onAgentFileChange = (uri: vscode.Uri) => {
-      if (isAgentFile(uri)) {
+      const filePath = uri.fsPath;
+      if (agentDirPaths.some((dir) => filePath.startsWith(dir))) {
         void debouncedAgentFileRefresh();
       }
     };

--- a/src/commands/agent/followUpCommand.ts
+++ b/src/commands/agent/followUpCommand.ts
@@ -87,8 +87,8 @@ async function tryAutoResume(streamId: StreamTabId): Promise<boolean> {
     const missing = !progressState
       ? 'ProgressViewProvider'
       : !executionId
-        ? 'execution ID'
-        : 'task state';
+      ? 'execution ID'
+      : 'task state';
     logger.warn(`No ${missing} found for stream: ${streamId}`);
     return false;
   }

--- a/src/commands/housekeeping/cleanCommands.ts
+++ b/src/commands/housekeeping/cleanCommands.ts
@@ -32,18 +32,37 @@ const CleanParamsSchema = z.object({
 // --- Helpers ---
 
 function showCleanResult(result: FileOpResult, inputFile: string): void {
-  const messages: Record<FileOpResult['status'], { text: string; isError: boolean }> = {
-    success: { text: `Cleanup complete for ${inputFile}`, isError: false },
-    noFiles: { text: `No files found to clean for ${inputFile}`, isError: false },
-    missingParams: { text: 'Missing required parameters for clean', isError: true },
-    error: { text: `Error during cleanup: ${result.error}`, isError: true },
+  const isError = result.status === 'missingParams' || result.status === 'error';
+  const messages: Record<FileOpResult['status'], string> = {
+    success: `Cleanup complete for ${inputFile}`,
+    noFiles: `No files found to clean for ${inputFile}`,
+    missingParams: 'Missing required parameters for clean',
+    error: `Error during cleanup: ${result.error}`,
   };
-  const msg = messages[result.status];
-  if (msg.isError) {
-    vscode.window.showErrorMessage(msg.text);
+  const text = messages[result.status];
+  if (isError) {
+    vscode.window.showErrorMessage(text);
   } else {
-    vscode.window.showInformationMessage(msg.text);
+    vscode.window.showInformationMessage(text);
   }
+}
+
+/** Validate clean params and log error if invalid. Returns parsed data or null. */
+async function validateCleanParams(
+  inputFile: string,
+  agent: string,
+  model: string,
+  commandName: string,
+): Promise<z.infer<typeof CleanParamsSchema> | null> {
+  const parsed = CleanParamsSchema.safeParse({ inputFile, agent, model });
+  if (!parsed.success) {
+    await showLoggedMessage(
+      CHANNEL,
+      `Invalid params for ${commandName}: ${formatZodError(parsed.error)}`,
+    );
+    return null;
+  }
+  return parsed.data;
 }
 
 export function registerCleanCommands(context: vscode.ExtensionContext): void {
@@ -61,16 +80,9 @@ async function handleCleanSingle(
   agent: string,
   model: string,
 ): Promise<void> {
-  const parsed = CleanParamsSchema.safeParse({ inputFile, agent, model });
-  if (!parsed.success) {
-    await showLoggedMessage(
-      CHANNEL,
-      `Invalid params for cleanSingle: ${formatZodError(parsed.error)}`,
-    );
-    return;
-  }
+  const data = await validateCleanParams(inputFile, agent, model, 'cleanSingle');
+  if (!data) return;
 
-  const data = parsed.data;
   const result = await runCleanSingle(data.model, data.inputFile, data.agent);
   showCleanResult(result, data.inputFile);
 
@@ -86,17 +98,11 @@ async function handleCleanMultiple(
   model: string,
   outputFiles: string[] = [],
 ): Promise<void> {
-  const parsed = CleanParamsSchema.safeParse({ inputFile, agent, model });
-  if (!parsed.success) {
-    await showLoggedMessage(
-      CHANNEL,
-      `Invalid params for cleanMultiple: ${formatZodError(parsed.error)}`,
-    );
-    return;
-  }
+  const data = await validateCleanParams(inputFile, agent, model, 'cleanMultiple');
+  if (!data) return;
+
   logger.debug(CHANNEL, `Additional files: ${outputFiles.join(', ')}`);
 
-  const data = parsed.data;
   const result = await runCleanMultiple(
     data.model,
     data.inputFile,

--- a/src/commands/latex/compareCommands.ts
+++ b/src/commands/latex/compareCommands.ts
@@ -186,14 +186,10 @@ async function handleAcceptEdited(
     // Check if new file would overwrite an existing file
     const targetExists = isNewFile && (await flexibleFS.exists(targetLocation));
 
-    let confirmMessage: string;
-    if (isNewFile && targetExists) {
-      confirmMessage = `Extensions differ (${baseExt} vs ${editedExt}). This will overwrite existing '${targetFileName}' with content from '${editedFileName}'. Are you sure?`;
-    } else if (isNewFile) {
-      confirmMessage = `Extensions differ (${baseExt} vs ${editedExt}). This will create '${targetFileName}' with content from '${editedFileName}'. Are you sure?`;
-    } else {
-      confirmMessage = `This will overwrite '${targetFileName}' with content from '${editedFileName}'. Are you sure?`;
-    }
+    // Build confirmation message based on operation type
+    const action = targetExists ? 'overwrite existing' : isNewFile ? 'create' : 'overwrite';
+    const extensionNote = isNewFile ? `Extensions differ (${baseExt} vs ${editedExt}). ` : '';
+    const confirmMessage = `${extensionNote}This will ${action} '${targetFileName}' with content from '${editedFileName}'. Are you sure?`;
 
     const answer = await vscode.window.showWarningMessage(
       confirmMessage,

--- a/src/explorer/ExplorerOperations.ts
+++ b/src/explorer/ExplorerOperations.ts
@@ -67,9 +67,9 @@ export class ExplorerOperations {
    */
   private isBuiltInPath(targetPath: string): boolean {
     return (
-      (this.builtInAgentsPath !== '' &&
+      (!!this.builtInAgentsPath &&
         targetPath.startsWith(this.builtInAgentsPath)) ||
-      (this.builtInToolUsePath !== '' &&
+      (!!this.builtInToolUsePath &&
         targetPath.startsWith(this.builtInToolUsePath))
     );
   }
@@ -96,7 +96,7 @@ export class ExplorerOperations {
     }
 
     const isBuiltInToolUse =
-      this.builtInToolUsePath !== '' &&
+      !!this.builtInToolUsePath &&
       targetPath.startsWith(this.builtInToolUsePath);
     const base = isBuiltInToolUse
       ? this.builtInToolUsePath

--- a/src/explorer/WatcherManager.ts
+++ b/src/explorer/WatcherManager.ts
@@ -93,20 +93,17 @@ export class WatcherManager {
         );
         this.disposables.push(watcher);
 
-        watcher.onDidCreate((uri) => {
+        const refreshAndValidate = (uri: vscode.Uri) => {
           this.triggerRefresh();
           scheduleYamlValidation(uri);
-        });
-        watcher.onDidDelete(this.triggerRefresh);
+        };
 
-        if (isCustomPath(watchPath)) {
-          watcher.onDidChange((uri) => {
-            this.triggerRefresh();
-            scheduleYamlValidation(uri);
-          });
-        } else {
-          watcher.onDidChange(this.triggerRefresh);
-        }
+        watcher.onDidCreate(refreshAndValidate);
+        watcher.onDidDelete(this.triggerRefresh);
+        // Only validate YAML on change for custom agents (built-in are read-only)
+        watcher.onDidChange(
+          isCustomPath(watchPath) ? refreshAndValidate : this.triggerRefresh,
+        );
       }
 
       logger.info(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -86,15 +86,13 @@ async function refreshApiKeyStatus() {
 
 export async function activate(context: vscode.ExtensionContext) {
   const workspaceFolders = vscode.workspace.workspaceFolders;
-  if (!workspaceFolders || workspaceFolders.length === 0) {
-    promptToOpenFolder(
-      'TeXRA requires an open workspace. Please open a folder to enable the extension.',
-    );
-    return; // Exit before further initialization
-  } else if (workspaceFolders.length > 1) {
-    promptToOpenFolder(
-      'TeXRA supports only a single-folder workspace. Please open one folder to enable the extension.',
-    );
+
+  if (!workspaceFolders || workspaceFolders.length !== 1) {
+    const message =
+      !workspaceFolders || workspaceFolders.length === 0
+        ? 'TeXRA requires an open workspace. Please open a folder to enable the extension.'
+        : 'TeXRA supports only a single-folder workspace. Please open one folder to enable the extension.';
+    promptToOpenFolder(message);
     return;
   }
   const workspaceRoot = workspaceFolders[0].uri.fsPath;
@@ -243,6 +241,10 @@ export async function activate(context: vscode.ExtensionContext) {
   );
 
   const runningStreams = new Set<string>();
+  const updateStatusBarText = () => {
+    statusBarItem!.text =
+      runningStreams.size > 0 ? 'TeXRA: Running' : 'TeXRA: Idle';
+  };
 
   disposeStatusListener = bus.on(
     'updateStreamStatus',
@@ -252,8 +254,7 @@ export async function activate(context: vscode.ExtensionContext) {
       } else if (isTerminalStatus(status)) {
         runningStreams.delete(stream);
       }
-      statusBarItem!.text =
-        runningStreams.size > 0 ? 'TeXRA: Running' : 'TeXRA: Idle';
+      updateStatusBarText();
     },
   );
 

--- a/src/frontend/editor/activeFileGuards.ts
+++ b/src/frontend/editor/activeFileGuards.ts
@@ -46,11 +46,9 @@ export async function getActiveEditorWithGuards(
     return { status: 'noEditor' };
   }
 
-  const extensionsForDisplay = allowedExtensions.map((ext) =>
-    ext.startsWith('.') ? ext : `.${ext}`,
-  );
-  const normalizedExtensions = extensionsForDisplay.map((ext) =>
-    ext.toLowerCase(),
+  // Normalize extensions: ensure dot prefix and lowercase for comparison
+  const normalizedExtensions = allowedExtensions.map((ext) =>
+    (ext.startsWith('.') ? ext : `.${ext}`).toLowerCase(),
   );
   const fileName = editor.document.fileName.toLowerCase();
 
@@ -61,9 +59,8 @@ export async function getActiveEditorWithGuards(
     const resourceLabel = resourceName
       ? `${resourceName} files`
       : 'files with the supported extensions';
-    const extensionList = extensionsForDisplay.join(', ');
     await vscode.window.showWarningMessage(
-      `This command only works with ${resourceLabel} (${extensionList}).`,
+      `This command only works with ${resourceLabel} (${normalizedExtensions.join(', ')}).`,
     );
     return { status: 'unsupportedExtension' };
   }

--- a/src/frontend/files/listing.ts
+++ b/src/frontend/files/listing.ts
@@ -145,6 +145,23 @@ function prepareFilters(
   };
 }
 
+/** Check if a filename passes extension and keyword filters */
+function passesFileFilters(
+  fileNameLower: string,
+  filters: NormalizedListingOptions,
+): boolean {
+  const matchesInclude =
+    filters.includeExt.length === 0 ||
+    filters.includeExt.some((ext) => fileNameLower.endsWith(ext));
+  const matchesExcludeExt = filters.excludeExt.some((ext) =>
+    fileNameLower.endsWith(ext),
+  );
+  const matchesExcludeKeyword = filters.excludeKeywords.some((keyword) =>
+    fileNameLower.includes(keyword),
+  );
+  return matchesInclude && !matchesExcludeExt && !matchesExcludeKeyword;
+}
+
 export async function getFilesInDirectory(
   dir: string,
   includeExtensions: string[] = [],
@@ -172,14 +189,8 @@ export async function getFilesInDirectory(
     })
     .map((uri) => path.basename(uri.fsPath))
     .filter((name) => {
-      const nameLower = name.toLowerCase();
-      return (
-        !name.startsWith('.') &&
-        (filters.includeExt.length === 0 ||
-          filters.includeExt.some((ext) => nameLower.endsWith(ext))) &&
-        !filters.excludeExt.some((ext) => nameLower.endsWith(ext)) &&
-        !filters.excludeKeywords.some((keyword) => nameLower.includes(keyword))
-      );
+      if (name.startsWith('.')) return false;
+      return passesFileFilters(name.toLowerCase(), filters);
     });
 }
 
@@ -220,17 +231,8 @@ export async function getFilesRecursively(
         return false;
       }
 
-      const fileName = path.basename(relativePath);
-      const fileNameLower = fileName.toLowerCase();
-
-      return (
-        (filters.includeExt.length === 0 ||
-          filters.includeExt.some((ext) => fileNameLower.endsWith(ext))) &&
-        !filters.excludeExt.some((ext) => fileNameLower.endsWith(ext)) &&
-        !filters.excludeKeywords.some((keyword) =>
-          fileNameLower.includes(keyword),
-        ) &&
-        !filters.excludeFiles.includes(fileNameLower)
-      );
+      const fileNameLower = path.basename(relativePath).toLowerCase();
+      if (filters.excludeFiles.includes(fileNameLower)) return false;
+      return passesFileFilters(fileNameLower, filters);
     });
 }

--- a/src/frontend/latex/linter.ts
+++ b/src/frontend/latex/linter.ts
@@ -14,13 +14,18 @@ const CHANNEL = 'LinterUtils';
 
 const DIAGNOSTIC_UPDATE_TIMEOUT_MS = 7500;
 
+/** Check if a file path is a LaTeX file */
+function isTexFile(filePath: string): boolean {
+  return filePath.toLowerCase().endsWith('.tex');
+}
+
 /**
  * Trigger a LaTeX build for a specific file
  * @param filePath Path to the file (relative to workspace)
  * @returns Promise resolving when build is triggered
  */
 export async function triggerLaTeXBuild(filePath: string): Promise<void> {
-  if (!filePath.toLowerCase().endsWith('.tex')) {
+  if (!isTexFile(filePath)) {
     return;
   }
 
@@ -68,7 +73,7 @@ export function getDiagnostics(filePath: string): vscode.Diagnostic[] {
 export async function getLinterMessages(
   filePath: string,
 ): Promise<vscode.Diagnostic[]> {
-  if (filePath.toLowerCase().endsWith('.tex')) {
+  if (isTexFile(filePath)) {
     await triggerLaTeXBuild(filePath);
   }
   return getDiagnostics(filePath);

--- a/src/frontend/vscode/vscodeEditor.ts
+++ b/src/frontend/vscode/vscodeEditor.ts
@@ -8,6 +8,11 @@ import * as vscode from 'vscode';
 
 import { WorkspaceFS } from '@utils/files';
 
+/** Convert a file path to a VS Code URI */
+function toFileUri(filePath: string): vscode.Uri {
+  return vscode.Uri.file(WorkspaceFS.toAbsolute(filePath));
+}
+
 /**
  * Open a file in VS Code editor, optionally positioning cursor at a line.
  * Reuses existing editor if file is already open.
@@ -23,12 +28,12 @@ export async function openFileInEditor(
   column?: number,
 ): Promise<string | undefined> {
   try {
-    const absolutePath = WorkspaceFS.toAbsolute(filePath);
-    const uri = vscode.Uri.file(absolutePath);
+    const uri = toFileUri(filePath);
+    const absolutePath = uri.fsPath;
 
     // Check if file is already open in an editor
     const existingEditor = vscode.window.visibleTextEditors.find(
-      (e) => e.document.uri.fsPath === uri.fsPath,
+      (e) => e.document.uri.fsPath === absolutePath,
     );
 
     let editor: vscode.TextEditor;
@@ -78,8 +83,8 @@ export async function ensureFileOpen(
   options: { preserveFocus?: boolean; save?: boolean } = {},
 ): Promise<{ editor: vscode.TextEditor; absolutePath: string } | undefined> {
   try {
-    const absolutePath = WorkspaceFS.toAbsolute(filePath);
-    const uri = vscode.Uri.file(absolutePath);
+    const uri = toFileUri(filePath);
+    const absolutePath = uri.fsPath;
 
     // Check if file is already open
     const existingEditor = vscode.window.visibleTextEditors.find(

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -227,20 +227,17 @@ export class ProgressViewProvider
     if (!this._view && !this._panelView) return;
 
     if (!this.isAnyViewReady()) {
-      // Queue the update, preserving forceRebuild if any caller requested it.
-      // Once forceRebuild is true, it stays true until the update is processed.
+      // Queue the update, preserving forceRebuild if any caller requested it
       const currentForce = this._pendingUpdateOptions?.forceRebuild ?? false;
-      const requestedForce = options?.forceRebuild ?? false;
       this._pendingUpdateOptions = {
-        forceRebuild: currentForce || requestedForce,
+        forceRebuild: currentForce || !!options?.forceRebuild,
       };
       return;
     }
 
-    const theme =
-      vscode.window.activeColorTheme.kind === vscode.ColorThemeKind.Dark
-        ? 'dark'
-        : 'light';
+    const isDarkTheme =
+      vscode.window.activeColorTheme.kind === vscode.ColorThemeKind.Dark;
+    const theme = isDarkTheme ? 'dark' : 'light';
 
     const activeStream = this.webviewUpdater.updateAll(
       this.state,
@@ -366,9 +363,7 @@ export class ProgressViewProvider
    * Check if any view is visible (sidebar or panel)
    */
   public isViewVisible(): boolean {
-    return (
-      (this._view?.visible ?? false) || (this._panelView?.visible ?? false)
-    );
+    return !!this._view?.visible || !!this._panelView?.visible;
   }
 
   // ===== IRunStorageService implementation =====

--- a/src/webview/MainViewMessageHandler.ts
+++ b/src/webview/MainViewMessageHandler.ts
@@ -385,43 +385,34 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
   }
 
   private async handleThemeRequest(_message: unknown): Promise<void> {
-    const webviewView = this.getActiveView();
-    if (!webviewView) {
-      return;
-    }
-    const theme =
-      vscode.window.activeColorTheme.kind === vscode.ColorThemeKind.Dark
-        ? 'dark'
-        : 'light';
-    webviewView.webview.postMessage({
+    const isDarkTheme =
+      vscode.window.activeColorTheme.kind === vscode.ColorThemeKind.Dark;
+    this.postToActiveView({
       command: MAIN_VIEW_COMMANDS.THEME_SET,
-      theme,
+      theme: isDarkTheme ? 'dark' : 'light',
     });
   }
 
   private async handleDebugModeRequest(_message: unknown): Promise<void> {
-    const webviewView = this.getActiveView();
-    if (!webviewView) {
-      return;
-    }
     const debugMode = getConfig<boolean>('texra.logger.debugMode', false);
-    webviewView.webview.postMessage({
+    this.postToActiveView({
       command: MAIN_VIEW_COMMANDS.DEBUG_MODE_SET,
       debugMode,
     });
   }
 
   private async handleModelSelection(message: any): Promise<void> {
-    const webviewView = this.getActiveView();
-    if (!webviewView) {
-      return;
-    }
     if (message.model) {
-      webviewView.webview.postMessage({
+      this.postToActiveView({
         command: MAIN_VIEW_COMMANDS.MODEL_SELECTED,
         model: message.model,
       });
     }
+  }
+
+  /** Post message to active view if available */
+  private postToActiveView(message: any): void {
+    this.getActiveView()?.webview.postMessage(message);
   }
 
   private async handleShowAgentHistory(_message: unknown): Promise<void> {


### PR DESCRIPTION
- FolderExplorer: Extract isFile check, clarify sort comparison with explicit variable names
- extension.ts: Extract updateStatusBarText function, simplify workspace validation
- MainViewProvider: Consolidate setupAgentWatcher by merging cache update into debounced refresh
- ProgressViewProvider: Simplify isViewVisible and updateWebview conditionals
- WatcherManager: Consolidate event handlers with refreshAndValidate helper
- ExplorerOperations: Use !! for empty string checks in isBuiltInPath

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves consistency and readability across core UI and file handling with small, targeted refactors.
> 
> - FolderExplorer: extract `isFile` usage and simplify sort (folders-first), streamline `contextValue` logic
> - MainViewProvider: consolidate agent YAML watcher with cached dir list + debounced refresh; minor handler cleanups
> - Explorer/Watcher: centralize YAML validation + refresh handling; use truthy checks for built-in paths
> - Housekeeping clean commands: add `validateCleanParams` helper and simplify result messaging
> - Compare commands: unify confirmation message construction for overwrite/create paths
> - Editor/VSC utilities: add `toFileUri`; reuse in `openFileInEditor`/`ensureFileOpen`
> - Active file guards: normalize extensions once and improve warning text
> - File listing: extract `passesFileFilters` and reuse in directory/recursive listings; keep dotfiles excluded
> - LaTeX linter: add `isTexFile` and reuse in build/diagnostics
> - Progress view/webview: simplify pending update handling, theme detection, and `isViewVisible`
> - Main view message handler: add `postToActiveView` and use for theme/debug/model posts
> - Extension activation: unify workspace validation messaging and extract `updateStatusBarText` helper
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bfd30977526d51a06d8d4989006f551d766ecb59. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->