### PR TITLE
claude/simplify-code-clarity-1Wq6r

### DIFF
--- a/src/agent/modelHandlers/modelHandlerOpenRouter.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenRouter.ts
@@ -49,7 +49,9 @@ const extractTextFromReasoningDetails = (
   }
 
   return details
-    .filter((item): item is ReasoningDetailItem => !!item && typeof item === 'object')
+    .filter(
+      (item): item is ReasoningDetailItem => !!item && typeof item === 'object',
+    )
     .map(getReasoningItemText)
     .filter((text): text is string => !!text)
     .join('');

--- a/src/commands/agent/agentCommands.ts
+++ b/src/commands/agent/agentCommands.ts
@@ -5,25 +5,12 @@ import * as vscode from 'vscode';
 import { getInterruptible } from '@agent/toolUse/ToolUseAgentRegistry';
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import { STREAM_STATUS } from '@common/constants/streamStatus';
-import * as logger from '@logger/logUtils';
-
-const CHANNEL = 'AgentCommands';
-logger.initialize(CHANNEL);
 
 export function registerAgentCommands(context: vscode.ExtensionContext): void {
   context.subscriptions.push(
-    vscode.commands.registerCommand('texra.stopAgent', handleStopAgent),
+    vscode.commands.registerCommand('texra.stopAgent', (stream: string) => {
+      getInterruptible(stream)?.interrupt();
+      StreamStatusService.set(stream, STREAM_STATUS.STOPPED);
+    }),
   );
-}
-
-async function handleStopAgent(stream: string): Promise<void> {
-  // Get the running execution from the unified registry
-  // Handles both flow contexts and agent class instances
-  const execution = getInterruptible(stream);
-  if (execution) {
-    execution.interrupt();
-  }
-
-  // Update the UI status
-  StreamStatusService.set(stream, STREAM_STATUS.STOPPED);
 }

--- a/src/commands/agent/mergeCommands.ts
+++ b/src/commands/agent/mergeCommands.ts
@@ -4,23 +4,13 @@ import * as vscode from 'vscode';
 // Local imports
 import { executeMergeAgent } from '@agent/runtime/executeAgent';
 import { showLoggedMessageWithDocs } from '@common/errors';
-import * as logger from '@logger/logUtils';
 import { getConfig } from '@utils/config';
 
 const CHANNEL = 'MergeCommands';
-logger.initialize(CHANNEL);
 
 export function registerMergeCommands(context: vscode.ExtensionContext): void {
   context.subscriptions.push(
-    vscode.commands.registerCommand(
-      'texra.merge',
-      (
-        inputFile: string,
-        baseFile: string,
-        editedFile: string,
-        model?: string,
-      ) => handleMerge(inputFile, baseFile, editedFile, model),
-    ),
+    vscode.commands.registerCommand('texra.merge', handleMerge),
   );
 }
 

--- a/src/commands/api/apiKeyCommands.ts
+++ b/src/commands/api/apiKeyCommands.ts
@@ -26,6 +26,11 @@ export const apiKeyCommands = {
   removeApiKey: 'texra.removeApiKey',
 };
 
+async function refreshApiKeyUI(): Promise<void> {
+  await vscode.commands.executeCommand('texra.refreshApiKeyStatus');
+  void vscode.commands.executeCommand('texra.refreshAllOptions');
+}
+
 // Helper function to set API key for a specific provider
 async function setApiKeyForProvider(
   provider: ApiProvider,
@@ -67,9 +72,7 @@ async function setApiKeyForProvider(
       apiKey,
     );
     vscode.window.showInformationMessage(`${provider} API key has been set`);
-    await vscode.commands.executeCommand('texra.refreshApiKeyStatus');
-    // Refresh both model and agent options (model availability may change)
-    void vscode.commands.executeCommand('texra.refreshAllOptions');
+    await refreshApiKeyUI();
     const view = await getMainWebview();
     view?.webview.postMessage({
       command: MAIN_VIEW_COMMANDS.HIDE_API_KEY_BANNER,
@@ -131,9 +134,7 @@ export function registerApiKeyCommands(context: vscode.ExtensionContext) {
         vscode.window.showInformationMessage(
           `${provider} API key has been removed`,
         );
-        await vscode.commands.executeCommand('texra.refreshApiKeyStatus');
-        // Refresh both model and agent options (model availability may change)
-        void vscode.commands.executeCommand('texra.refreshAllOptions');
+        await refreshApiKeyUI();
         const hasAnyKey = await SecretManager.anyApiKeyExists();
         const bannerCommand = hasAnyKey
           ? MAIN_VIEW_COMMANDS.HIDE_API_KEY_BANNER

--- a/src/commands/git/gitCommands.ts
+++ b/src/commands/git/gitCommands.ts
@@ -10,7 +10,7 @@ import { WorkspaceFS } from '@utils/files';
 const CHANNEL = 'gitCommands';
 const COMMIT_LABEL_FORMAT = '%h: %s (%cr)';
 
-export function registerGitCommands(context: vscode.ExtensionContext) {
+export function registerGitCommands(context: vscode.ExtensionContext): void {
   context.subscriptions.push(
     vscode.commands.registerCommand('texra.isGitRepository', isGitRepository),
     vscode.commands.registerCommand('texra.getRecentCommits', getRecentCommits),

--- a/src/commands/history/historyCommands.ts
+++ b/src/commands/history/historyCommands.ts
@@ -8,9 +8,6 @@ export const historyCommands = {
   showHistory: 'texra.showAgentHistory',
 };
 
-/**
- * Register the commands related to agent execution history
- */
 export function registerHistoryCommands(
   context: vscode.ExtensionContext,
 ): void {

--- a/src/commands/housekeeping/cleanCommands.ts
+++ b/src/commands/housekeeping/cleanCommands.ts
@@ -6,14 +6,13 @@ import { z } from 'zod';
 import type { FileOpResult } from '@agent/types/ResultTypes';
 import { formatZodError, showLoggedMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
-import { bus } from '@eventBus/ProgressEventBus';
 import {
   runCleanSingle,
   runCleanMultiple,
   runCleanBuild,
   runCleanOutput,
 } from '@housekeeping';
-import { getStreamTabId } from '@/logger/streamUtils';
+import { emitClearMissingOutputs } from './streamEventUtils';
 
 const CHANNEL = 'cleanCommands';
 logger.initialize(CHANNEL);
@@ -29,10 +28,27 @@ const CleanParamsSchema = z.object({
   model: RequiredString,
 });
 
+/** For clean command - matches handlePack pattern */
+const CleanConfigSchema = z
+  .object({
+    inputFile: RequiredString,
+    agent: RequiredString,
+    model: RequiredString,
+    outputFiles: z.array(z.string()).prefault([]),
+    useMultipleOutputs: z.boolean().optional(),
+    streamId: z.string().optional(),
+    skipProgressViewClear: z.boolean().optional(),
+  })
+  .transform((c) => ({
+    ...c,
+    useMultipleOutputs: c.useMultipleOutputs ?? c.outputFiles.length > 1,
+  }));
+
 // --- Helpers ---
 
 function showCleanResult(result: FileOpResult, inputFile: string): void {
-  const isError = result.status === 'missingParams' || result.status === 'error';
+  const isError =
+    result.status === 'missingParams' || result.status === 'error';
   const messages: Record<FileOpResult['status'], string> = {
     success: `Cleanup complete for ${inputFile}`,
     noFiles: `No files found to clean for ${inputFile}`,
@@ -85,11 +101,7 @@ async function handleCleanSingle(
 
   const result = await runCleanSingle(data.model, data.inputFile, data.agent);
   showCleanResult(result, data.inputFile);
-
-  const streamId = getStreamTabId(data.agent, data.model, data.inputFile, {
-    useMultipleOutputs: false,
-  });
-  bus.emit('clearMissingOutputs', { stream: streamId });
+  emitClearMissingOutputs(data.agent, data.model, data.inputFile, false);
 }
 
 async function handleCleanMultiple(
@@ -98,7 +110,12 @@ async function handleCleanMultiple(
   model: string,
   outputFiles: string[] = [],
 ): Promise<void> {
-  const data = await validateCleanParams(inputFile, agent, model, 'cleanMultiple');
+  const data = await validateCleanParams(
+    inputFile,
+    agent,
+    model,
+    'cleanMultiple',
+  );
   if (!data) return;
 
   logger.debug(CHANNEL, `Additional files: ${outputFiles.join(', ')}`);
@@ -110,38 +127,33 @@ async function handleCleanMultiple(
     outputFiles,
   );
   showCleanResult(result, data.inputFile);
-
-  const streamId = getStreamTabId(data.agent, data.model, data.inputFile, {
-    useMultipleOutputs: true,
-  });
-  bus.emit('clearMissingOutputs', { stream: streamId });
+  emitClearMissingOutputs(data.agent, data.model, data.inputFile, true);
 }
 
-export async function handleClean(config: {
-  agent?: string;
-  model?: string;
-  inputFile?: string;
-  outputFiles?: string[];
-  useMultipleOutputs?: boolean;
-  streamId?: string;
-  skipProgressViewClear?: boolean;
-}): Promise<void> {
-  logger.debug(
-    CHANNEL,
-    `Clean command called with config: ${JSON.stringify(config)}`,
-  );
-
-  const { agent, model, inputFile } = config;
-  if (!agent || !model || !inputFile) {
-    await showLoggedMessage(CHANNEL, 'Missing required parameters in config');
+export async function handleClean(config: unknown): Promise<void> {
+  const parsed = CleanConfigSchema.safeParse(config);
+  if (!parsed.success) {
+    await showLoggedMessage(
+      CHANNEL,
+      `Invalid config: ${formatZodError(parsed.error)}`,
+    );
     return;
   }
 
-  const outputFiles = Array.isArray(config.outputFiles)
-    ? config.outputFiles
-    : [];
-  const useMultipleOutputs =
-    config.useMultipleOutputs ?? outputFiles.length > 1;
+  const {
+    agent,
+    model,
+    inputFile,
+    outputFiles,
+    useMultipleOutputs,
+    streamId,
+    skipProgressViewClear,
+  } = parsed.data;
+
+  logger.debug(
+    CHANNEL,
+    `Clean command called with config: ${JSON.stringify(parsed.data)}`,
+  );
 
   const result =
     useMultipleOutputs && outputFiles.length > 0
@@ -149,11 +161,13 @@ export async function handleClean(config: {
       : await runCleanSingle(model, inputFile, agent);
   showCleanResult(result, inputFile);
 
-  const streamId =
-    config.streamId ||
-    getStreamTabId(agent, model, inputFile, { useMultipleOutputs });
-
-  if (!config.skipProgressViewClear) {
-    bus.emit('clearMissingOutputs', { stream: streamId });
+  if (!skipProgressViewClear) {
+    emitClearMissingOutputs(
+      agent,
+      model,
+      inputFile,
+      useMultipleOutputs,
+      streamId,
+    );
   }
 }

--- a/src/commands/housekeeping/packCommands.ts
+++ b/src/commands/housekeeping/packCommands.ts
@@ -56,35 +56,46 @@ const PackMultipleSchema = z
 // --- Helpers ---
 
 function showPackResult(result: FileOpResult, inputFile: string): void {
-  switch (result.status) {
-    case 'success': {
-      const folder = result.outputFolder;
-      if (folder) {
-        vscode.window
-          .showInformationMessage(`Files packed into ${folder}`, 'Open Folder')
-          .then((sel) => {
-            if (sel === 'Open Folder') {
-              void vscode.commands.executeCommand(
-                'revealFileInOS',
-                vscode.Uri.file(WorkspaceFS.fullPath(folder)),
-              );
-            }
-          });
-      }
-      break;
+  if (result.status === 'success') {
+    const folder = result.outputFolder;
+    if (folder) {
+      vscode.window
+        .showInformationMessage(`Files packed into ${folder}`, 'Open Folder')
+        .then((sel) => {
+          if (sel === 'Open Folder') {
+            void vscode.commands.executeCommand(
+              'revealFileInOS',
+              vscode.Uri.file(WorkspaceFS.fullPath(folder)),
+            );
+          }
+        });
     }
-    case 'noFiles':
-      vscode.window.showInformationMessage(
-        `No files found to pack for ${inputFile}`,
-      );
-      break;
-    case 'missingParams':
-      vscode.window.showErrorMessage('Missing required parameters for pack');
-      break;
-    case 'error':
-      vscode.window.showErrorMessage(`Error during packing: ${result.error}`);
-      break;
+    return;
   }
+
+  const messages: Record<Exclude<FileOpResult['status'], 'success'>, { text: string; isError: boolean }> = {
+    noFiles: { text: `No files found to pack for ${inputFile}`, isError: false },
+    missingParams: { text: 'Missing required parameters for pack', isError: true },
+    error: { text: `Error during packing: ${result.error}`, isError: true },
+  };
+  const msg = messages[result.status];
+  if (msg.isError) {
+    vscode.window.showErrorMessage(msg.text);
+  } else {
+    vscode.window.showInformationMessage(msg.text);
+  }
+}
+
+function emitClearMissingOutputs(
+  agent: string,
+  model: string,
+  inputFile: string,
+  useMultipleOutputs: boolean,
+  streamId?: string,
+): void {
+  bus.emit('clearMissingOutputs', {
+    stream: streamId || getStreamTabId(agent, model, inputFile, { useMultipleOutputs }),
+  });
 }
 
 // --- Handlers ---
@@ -125,11 +136,7 @@ async function handlePack(config: unknown): Promise<void> {
   showPackResult(result, inputFile);
 
   if (!skipProgressViewClear) {
-    bus.emit('clearMissingOutputs', {
-      stream:
-        streamId ||
-        getStreamTabId(agent, model, inputFile, { useMultipleOutputs }),
-    });
+    emitClearMissingOutputs(agent, model, inputFile, useMultipleOutputs, streamId);
   }
 }
 
@@ -150,11 +157,7 @@ async function handlePackSingle(
   const data = parsed.data;
   const result = await runPackSingle(data.model, data.inputFile, data.agent);
   showPackResult(result, data.inputFile);
-  bus.emit('clearMissingOutputs', {
-    stream: getStreamTabId(data.agent, data.model, data.inputFile, {
-      useMultipleOutputs: false,
-    }),
-  });
+  emitClearMissingOutputs(data.agent, data.model, data.inputFile, false);
 }
 
 async function handlePackMultiple(
@@ -185,11 +188,7 @@ async function handlePackMultiple(
     data.outputFiles,
   );
   showPackResult(result, data.inputFile);
-  bus.emit('clearMissingOutputs', {
-    stream: getStreamTabId(data.agent, data.model, data.inputFile, {
-      useMultipleOutputs: true,
-    }),
-  });
+  emitClearMissingOutputs(data.agent, data.model, data.inputFile, true);
 }
 
 // --- Registration ---

--- a/src/commands/housekeeping/packCommands.ts
+++ b/src/commands/housekeeping/packCommands.ts
@@ -7,9 +7,8 @@ import type { FileOpResult } from '@agent/types/ResultTypes';
 import { formatZodError, showLoggedMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
 import { WorkspaceFS } from '@utils/files';
-import { bus } from '@eventBus/ProgressEventBus';
 import { runPack, runPackSingle, runPackMultiple } from '@housekeeping';
-import { getStreamTabId } from '@/logger/streamUtils';
+import { emitClearMissingOutputs } from './streamEventUtils';
 
 const CHANNEL = 'packCommands';
 logger.initialize(CHANNEL);
@@ -73,9 +72,18 @@ function showPackResult(result: FileOpResult, inputFile: string): void {
     return;
   }
 
-  const messages: Record<Exclude<FileOpResult['status'], 'success'>, { text: string; isError: boolean }> = {
-    noFiles: { text: `No files found to pack for ${inputFile}`, isError: false },
-    missingParams: { text: 'Missing required parameters for pack', isError: true },
+  const messages: Record<
+    Exclude<FileOpResult['status'], 'success'>,
+    { text: string; isError: boolean }
+  > = {
+    noFiles: {
+      text: `No files found to pack for ${inputFile}`,
+      isError: false,
+    },
+    missingParams: {
+      text: 'Missing required parameters for pack',
+      isError: true,
+    },
     error: { text: `Error during packing: ${result.error}`, isError: true },
   };
   const msg = messages[result.status];
@@ -84,18 +92,6 @@ function showPackResult(result: FileOpResult, inputFile: string): void {
   } else {
     vscode.window.showInformationMessage(msg.text);
   }
-}
-
-function emitClearMissingOutputs(
-  agent: string,
-  model: string,
-  inputFile: string,
-  useMultipleOutputs: boolean,
-  streamId?: string,
-): void {
-  bus.emit('clearMissingOutputs', {
-    stream: streamId || getStreamTabId(agent, model, inputFile, { useMultipleOutputs }),
-  });
 }
 
 // --- Handlers ---
@@ -136,7 +132,13 @@ async function handlePack(config: unknown): Promise<void> {
   showPackResult(result, inputFile);
 
   if (!skipProgressViewClear) {
-    emitClearMissingOutputs(agent, model, inputFile, useMultipleOutputs, streamId);
+    emitClearMissingOutputs(
+      agent,
+      model,
+      inputFile,
+      useMultipleOutputs,
+      streamId,
+    );
   }
 }
 

--- a/src/commands/housekeeping/streamEventUtils.ts
+++ b/src/commands/housekeeping/streamEventUtils.ts
@@ -1,0 +1,20 @@
+import { bus } from '@eventBus/ProgressEventBus';
+import { getStreamTabId } from '@/logger/streamUtils';
+
+/**
+ * Emit clearMissingOutputs event to update the progress view.
+ * Used after pack/clean operations to clear missing output indicators.
+ */
+export function emitClearMissingOutputs(
+  agent: string,
+  model: string,
+  inputFile: string,
+  useMultipleOutputs: boolean,
+  streamId?: string,
+): void {
+  bus.emit('clearMissingOutputs', {
+    stream:
+      streamId ||
+      getStreamTabId(agent, model, inputFile, { useMultipleOutputs }),
+  });
+}

--- a/src/commands/latex/linterCommands.ts
+++ b/src/commands/latex/linterCommands.ts
@@ -178,7 +178,7 @@ export async function handleFixLinterIssues(): Promise<void> {
   }
 }
 
-export function registerLinterCommands(context: vscode.ExtensionContext) {
+export function registerLinterCommands(context: vscode.ExtensionContext): void {
   context.subscriptions.push(
     vscode.commands.registerCommand(
       linterCommands.showLinterMessages,
@@ -193,5 +193,4 @@ export function registerLinterCommands(context: vscode.ExtensionContext) {
       handleFixLinterIssues,
     ),
   );
-  return linterCommands;
 }

--- a/src/commands/memory/memoryCommands.ts
+++ b/src/commands/memory/memoryCommands.ts
@@ -8,21 +8,12 @@ export const memoryCommands = {
   showMemory: 'texra.showMemory',
 };
 
-/**
- * Register the commands related to memory view
- */
-export function registerMemoryCommands(context: vscode.ExtensionContext) {
-  // Create memory view provider
+export function registerMemoryCommands(context: vscode.ExtensionContext): void {
   const memoryViewProvider = new MemoryViewProvider(context);
 
-  // Register show memory command
-  const showMemoryCommand = vscode.commands.registerCommand(
-    memoryCommands.showMemory,
-    async () => {
-      await memoryViewProvider.showMemoryView();
-    },
+  context.subscriptions.push(
+    vscode.commands.registerCommand(memoryCommands.showMemory, () =>
+      memoryViewProvider.showMemoryView(),
+    ),
   );
-
-  // Add subscriptions
-  context.subscriptions.push(showMemoryCommand);
 }

--- a/src/commands/progress/progressViewCommands.ts
+++ b/src/commands/progress/progressViewCommands.ts
@@ -3,47 +3,28 @@ import * as vscode from 'vscode';
 
 // Internal imports
 import { safeExecuteCommand } from '@frontend/system/commandUtils';
-import { AgentLogger } from '@logger/AgentLogger';
 import { ProgressViewProvider } from '@progressView/ProgressViewProvider';
 
 const CHANNEL = 'progressViewCommands';
-const logger = new AgentLogger(CHANNEL);
 
-/**
- * Show the Progress View panel
- */
-async function showProgressView(): Promise<void> {
-  await safeExecuteCommand('texra.progressView.focus', [], CHANNEL);
-  logger.info('ProgressView panel shown');
-}
-
-/**
- * Open the Progress View in a separate editor tab
- */
 function openProgressViewInTab(): void {
   const provider = ProgressViewProvider.getInstance();
   if (!provider) {
-    logger.error('ProgressViewProvider not initialized');
     vscode.window.showErrorMessage(
       'Progress View is not available. Please try again.',
     );
     return;
   }
-
   provider.showProgressViewAsPanel();
-  logger.info('ProgressView opened in separate tab');
 }
 
-/**
- * Register all progress view related commands
- */
 export function registerProgressViewCommands(
   context: vscode.ExtensionContext,
 ): void {
-  logger.debug('Registering progress view commands');
-
   context.subscriptions.push(
-    vscode.commands.registerCommand('texra.showProgressView', showProgressView),
+    vscode.commands.registerCommand('texra.showProgressView', () =>
+      safeExecuteCommand('texra.progressView.focus', [], CHANNEL),
+    ),
     vscode.commands.registerCommand(
       'texra.openProgressViewInTab',
       openProgressViewInTab,

--- a/src/frontend/vscode/vscodeDiagnostics.ts
+++ b/src/frontend/vscode/vscodeDiagnostics.ts
@@ -96,7 +96,10 @@ export function getSeverityLabel(severity: vscode.DiagnosticSeverity): string {
 }
 
 /** Map from severity to counts key */
-const SEVERITY_TO_COUNT_KEY: Record<vscode.DiagnosticSeverity, keyof SeverityCounts> = {
+const SEVERITY_TO_COUNT_KEY: Record<
+  vscode.DiagnosticSeverity,
+  keyof SeverityCounts
+> = {
   [vscode.DiagnosticSeverity.Error]: 'errors',
   [vscode.DiagnosticSeverity.Warning]: 'warnings',
   [vscode.DiagnosticSeverity.Information]: 'info',


### PR DESCRIPTION
- Extract emitClearMissingOutputs helper in packCommands and cleanCommands
- Extract refreshApiKeyUI helper in apiKeyCommands to reduce duplication
- Simplify showPackResult to use record-based lookup (consistent with cleanCommands)
- Inline trivial wrapper functions in progressViewCommands, memoryCommands
- Remove unused logger imports and unnecessary comments
- Add explicit return types to registration functions
- Reduce code by 55 lines while preserving functionality

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Focuses on deduplication and command wiring cleanup with minor type/format tweaks.
> 
> - Extracts `emitClearMissingOutputs` (new `streamEventUtils.ts`) and replaces direct `bus/getStreamTabId` usage in `packCommands` and `cleanCommands`
> - Adds `refreshApiKeyUI` helper and uses it after API key set/remove
> - Simplifies command registration: inline trivial handlers in `agent`, `merge`, `progressView`, `memory`, and `linter` commands; add explicit return types
> - Tightens config/param validation: new Zod `CleanConfigSchema`; `handleClean/handlePack` parse `unknown` configs; logs standardized
> - Refactors `showPackResult` to concise message handling; aligns with clean result handling
> - Removes unused logging and comments; minor typing/formatting updates in `gitCommands`, `vscodeDiagnostics`, and `modelHandlerOpenRouter`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1e63bf9e7c52f880d9b48ace63e3bc4724665db4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->