### PR TITLE
Simplify and improve code clarity

### DIFF
--- a/src/agent/index/agentRegistry.ts
+++ b/src/agent/index/agentRegistry.ts
@@ -664,6 +664,21 @@ export async function computeAgentOptions(): Promise<AgentOptionsPayload> {
   return buildAgentOptions();
 }
 
+/** Build placeholder options from config when cache isn't ready. */
+function buildPlaceholderOptions(
+  configKey: string,
+  defaultAgent: string,
+): string {
+  const agents = getConfig<string[]>(configKey, []);
+  const names = agents.length > 0 ? agents : [defaultAgent];
+  return names
+    .map(
+      (name) =>
+        `<vscode-option value="${encodeHtml(name)}">${encodeHtml(name)}</vscode-option>`,
+    )
+    .join('\n');
+}
+
 /**
  * Sync version - returns placeholders from config if not loaded.
  */
@@ -672,20 +687,11 @@ export function computeAgentOptionsSync(): AgentOptionsPayload {
     return buildAgentOptions();
   }
 
-  // Build placeholder options from config when cache isn't ready
-  function buildPlaceholder(configKey: string, defaultAgent: string): string {
-    const agents = getConfig<string[]>(configKey, []);
-    const names = agents.length > 0 ? agents : [defaultAgent];
-    return names
-      .map(
-        (name) =>
-          `<vscode-option value="${encodeHtml(name)}">${encodeHtml(name)}</vscode-option>`,
-      )
-      .join('\n');
-  }
-
   return {
-    workflow: buildPlaceholder('texra.agents', DEFAULT_WORKFLOW_AGENT),
-    toolUse: buildPlaceholder('texra.toolUseAgents', DEFAULT_TOOL_USE_AGENT),
+    workflow: buildPlaceholderOptions('texra.agents', DEFAULT_WORKFLOW_AGENT),
+    toolUse: buildPlaceholderOptions(
+      'texra.toolUseAgents',
+      DEFAULT_TOOL_USE_AGENT,
+    ),
   };
 }

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -228,6 +228,17 @@ const CONTEXT_MANAGEMENT_CLEAR_AT_LEAST_PERCENT = 10;
 const ANTHROPIC_1M_CONTEXT_WINDOW = 1_000_000;
 
 /**
+ * Model patterns that require temperature removal when thinking is enabled.
+ * Per Anthropic docs, Claude 4 and Claude 3.7 Sonnet models don't support temperature with thinking.
+ */
+const THINKING_TEMPERATURE_EXCLUDED_PATTERNS = [
+  'claude-opus-4',
+  'claude-sonnet-4',
+  'claude-haiku-4',
+  'claude-3-7-sonnet',
+];
+
+/**
  * Extended response type for countTokens with context_management.
  * The SDK doesn't export this, so we define it here for type safety.
  */
@@ -525,14 +536,10 @@ export class ModelHandlerAnthropic extends ModelHandler<
       );
 
       // Remove temperature for Claude 4 models when thinking is enabled as per Anthropic docs
-      if (
-        this.config.fullName.includes('claude-opus-4') ||
-        this.config.fullName.includes('claude-opus-4-5') ||
-        this.config.fullName.includes('claude-sonnet-4-5') ||
-        this.config.fullName.includes('claude-sonnet-4') ||
-        this.config.fullName.includes('claude-haiku-4-5') ||
-        this.config.fullName.includes('claude-3-7-sonnet')
-      ) {
+      const requiresNoTemperature = THINKING_TEMPERATURE_EXCLUDED_PATTERNS.some(
+        (pattern) => this.config.fullName.includes(pattern),
+      );
+      if (requiresNoTemperature) {
         delete options.temperature;
       }
     }
@@ -1643,29 +1650,19 @@ export class ModelHandlerAnthropic extends ModelHandler<
           ? secondLastMessage.content.filter(isAnyThinkingBlockParam)
           : [];
 
-        // Anthropic models should include thinking blocks first in the content array
-        // Add all thinking blocks from workspaceState if we have them
+        // Log if we have thinking blocks from previous message
         if (thinkingBlocks.length > 0) {
-          // if we have thinking blocks, then we use them
           this.logger.debug(
             `Using ${thinkingBlocks.length} existing thinking blocks from previous message`,
           );
-          if (Array.isArray(secondLastMessage.content)) {
-            secondLastMessage.content.push({
-              type: 'text',
-              text: bestConnector + newResponse,
-            } as ContentBlockParam);
-          }
-        } else {
-          if (Array.isArray(secondLastMessage.content)) {
-            secondLastMessage.content.push({
-              type: 'text',
-              text: bestConnector + newResponse,
-            } as ContentBlockParam);
-          }
         }
 
+        // Append text content to the previous assistant message and update cache control
         if (Array.isArray(secondLastMessage.content)) {
+          secondLastMessage.content.push({
+            type: 'text',
+            text: bestConnector + newResponse,
+          } as ContentBlockParam);
           this.assignCacheControlToLatest(secondLastMessage.content);
         }
 
@@ -1683,10 +1680,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
         'Last message is a request message rather than a ask to continue after cut off',
       );
       // Create a new assistant message with the response
-      const assistantMessage: MessageParam = {
-        role: 'assistant',
-        content: [],
-      };
+      const content: ContentBlockParam[] = [];
 
       // Include all thinking blocks from workspaceState if available
       if (
@@ -1696,30 +1690,22 @@ export class ModelHandlerAnthropic extends ModelHandler<
         this.logger.debug(
           `Adding ${workspaceState.reasoning.thinkingBlocks.length} thinking blocks to new assistant message`,
         );
-        if (Array.isArray(assistantMessage.content)) {
-          // Include thinking blocks from workspace state in the message content
-          assistantMessage.content.push(
-            ...(workspaceState.reasoning
-              .thinkingBlocks as AnthropicThinkingContentParam[]),
-          );
-        }
+        content.push(
+          ...(workspaceState.reasoning
+            .thinkingBlocks as AnthropicThinkingContentParam[]),
+        );
         // Clear cached thinking so the next response can store fresh blocks
         workspaceState.resetReasoning();
       }
 
       // Add the text content
-      if (Array.isArray(assistantMessage.content)) {
-        assistantMessage.content.push({
-          type: 'text',
-          text: workspaceState.assembly.accumulatedOutput,
-        } as ContentBlockParam);
-      }
+      content.push({
+        type: 'text',
+        text: workspaceState.assembly.accumulatedOutput,
+      } as ContentBlockParam);
 
-      messages.push(assistantMessage);
-
-      if (Array.isArray(assistantMessage.content)) {
-        this.assignCacheControlToLatest(assistantMessage.content);
-      }
+      this.assignCacheControlToLatest(content);
+      messages.push({ role: 'assistant', content });
 
       this.logger.debug('Added a new assistant message');
     }

--- a/src/agent/modelHandlers/openAIMessageUtils.ts
+++ b/src/agent/modelHandlers/openAIMessageUtils.ts
@@ -13,6 +13,16 @@ type MessageLike = {
 
 type ContentArray = Array<Record<string, unknown>>;
 
+/** Type guard for text content items in message content arrays. */
+function isTextContentItem(item: unknown): item is { type: string; text: string } {
+  return (
+    item !== null &&
+    typeof item === 'object' &&
+    (item as { type?: unknown }).type === 'text' &&
+    typeof (item as { text?: unknown }).text === 'string'
+  );
+}
+
 function mergeMessageContent(
   previous: MessageLike,
   current: MessageLike,
@@ -109,15 +119,8 @@ export function normalizeOpenAIMessageContent<T extends MessageLike>(
     working.forEach((message) => {
       if (Array.isArray(message.content)) {
         // Extract text from content array items and join with newlines
-        // Filter defensively to handle null/undefined items
         message.content = (message.content as Array<unknown>)
-          .filter(
-            (item): item is { type: string; text: string } =>
-              item !== null &&
-              typeof item === 'object' &&
-              (item as { type?: unknown }).type === 'text' &&
-              typeof (item as { text?: unknown }).text === 'string',
-          )
+          .filter(isTextContentItem)
           .map((item) => item.text)
           .join('\n');
       }

--- a/src/agent/modelHandlers/support/ProxyConfigResolver.ts
+++ b/src/agent/modelHandlers/support/ProxyConfigResolver.ts
@@ -9,15 +9,13 @@ const DEFAULT_PROXY_DOMAIN = 'proxy.texra.ai';
  * Preserves any path component provided.
  */
 function normalizeUrl(input: string): string {
-  if (!input) {
-    return '';
-  }
+  if (!input) return '';
+  const withProtocol = input.includes('://') ? input : `https://${input}`;
   try {
-    const url = new URL(input.includes('://') ? input : `https://${input}`);
-    const withoutProtocol = `${url.host}${url.pathname}`;
-    return withoutProtocol.replace(/\/+$/, '');
-  } catch (_err) {
-    return input.replace(/^https?:\/\//, '').replace(/\/+$/, '');
+    const url = new URL(withProtocol);
+    return `${url.host}${url.pathname}`.replace(/\/+$/, '');
+  } catch {
+    return withProtocol.replace(/^https?:\/\//, '').replace(/\/+$/, '');
   }
 }
 

--- a/src/agent/modelHandlers/utils/toolAttachmentUtils.ts
+++ b/src/agent/modelHandlers/utils/toolAttachmentUtils.ts
@@ -215,26 +215,16 @@ export function formatAttachmentSummaryFromNotes(
   variant: AttachmentSummaryVariant = 'metadata-only',
 ): string {
   const header = ATTACHMENT_SUMMARY_TEMPLATES[variant];
-  const needsReadHint = variant !== 'included-inline';
-  return needsReadHint
-    ? `${header}\n${notes}\n${READ_FILE_HINT}`
-    : `${header}\n${notes}`;
+  const hint = variant !== 'included-inline' ? `\n${READ_FILE_HINT}` : '';
+  return `${header}\n${notes}${hint}`;
 }
 
 export async function loadAttachmentBuffer(
   attachment: ToolFileAttachment,
 ): Promise<Buffer> {
-  if (attachment.bytes && attachment.bytes.length > 0) {
-    return Buffer.from(attachment.bytes);
-  }
-
-  if (attachment.base64Data && attachment.base64Data.length > 0) {
-    return Buffer.from(attachment.base64Data, 'base64');
-  }
-
-  if (attachment.path && attachment.path.length > 0) {
-    return WorkspaceFS.readFileBytes(attachment.path);
-  }
+  if (attachment.bytes?.length) return Buffer.from(attachment.bytes);
+  if (attachment.base64Data?.length) return Buffer.from(attachment.base64Data, 'base64');
+  if (attachment.path?.length) return WorkspaceFS.readFileBytes(attachment.path);
 
   throw new Error('Attachment did not include bytes, base64 data, or a path.');
 }

--- a/src/agent/utils/outputFileUtils.ts
+++ b/src/agent/utils/outputFileUtils.ts
@@ -74,8 +74,7 @@ export function createMergeOutputFileLocationGetter(
   const outputFile = `${finalBase}_${agent}_r${roundNum}_full_${model}.tex`;
   const outputPath = path.join(inputDir, outputFile);
 
-  // Return a getter that always returns the same location (merge is single-output)
-  return (_round: number): AgentFileLocation => {
-    return fileService.createLocation(outputPath) as AgentFileLocation;
-  };
+  // Pre-compute location (merge is single-output, always the same location)
+  const location = fileService.createLocation(outputPath) as AgentFileLocation;
+  return (_round: number): AgentFileLocation => location;
 }

--- a/src/common/errors/errorHandlingUtils.ts
+++ b/src/common/errors/errorHandlingUtils.ts
@@ -69,14 +69,11 @@ const MAX_ERROR_LENGTH = 500;
  * ```
  */
 export function formatError(prefix: string, err: unknown): string {
-  let detail = toErrorMessage(err);
-
-  // Truncate overly long error details for better readability
-  if (detail.length > MAX_ERROR_LENGTH) {
-    detail = `${detail.substring(0, MAX_ERROR_LENGTH)}...`;
-  }
-
-  return `${prefix}: ${detail}`;
+  const detail = toErrorMessage(err);
+  const truncated = detail.length > MAX_ERROR_LENGTH
+    ? `${detail.substring(0, MAX_ERROR_LENGTH)}...`
+    : detail;
+  return `${prefix}: ${truncated}`;
 }
 
 /**
@@ -150,15 +147,10 @@ export function formatZodError(error: z.ZodError): string {
  * ```
  */
 export function isFileNotFoundError(err: unknown): boolean {
-  // VS Code FileSystemError (explicit check for type safety)
-  if (err instanceof vscode.FileSystemError) {
-    return err.code === 'FileNotFound';
-  }
+  // VS Code FileSystemError
+  if (err instanceof vscode.FileSystemError) return err.code === 'FileNotFound';
   // Node.js filesystem errors (ENOENT)
-  if (err && typeof err === 'object' && 'code' in err) {
-    return (err as { code: string }).code === 'ENOENT';
-  }
-  return false;
+  return (err as { code?: string })?.code === 'ENOENT';
 }
 
 /**


### PR DESCRIPTION
- modelHandlerAnthropic.ts: Remove duplicate if/else branches, use lookup array for model name checks, consolidate Array.isArray checks, build content array directly without redundant guards
- openAIMessageUtils.ts: Extract inline type guard to named function
- outputFileUtils.ts: Pre-compute location in merge getter instead of recreating on each call
- agentRegistry.ts: Extract buildPlaceholderOptions from nested function
- toolAttachmentUtils.ts: Use optional chaining in loadAttachmentBuffer, simplify string concatenation in formatAttachmentSummaryFromNotes
- errorHandlingUtils.ts: Simplify formatError and isFileNotFoundError
- ProxyConfigResolver.ts: Simplify normalizeUrl with early return

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Focuses on clarity and small behavior-safe refactors across agent/options, message utilities, and error handling.
> 
> - **Anthropic handler**: Centralizes model checks via `THINKING_TEMPERATURE_EXCLUDED_PATTERNS` to remove `temperature` when thinking is enabled; simplifies continuation flow by always appending text and preserving prior thinking blocks; cleans up construction of assistant messages and cache-control assignment.
> - **Agent options**: Extracts `buildPlaceholderOptions` and uses it in `computeAgentOptionsSync()` for pre-cache dropdowns.
> - **OpenAI message utils**: Introduces `isTextContentItem` guard and uses it when converting content arrays to strings.
> - **Attachments utils**: Simplifies `formatAttachmentSummaryFromNotes()` concatenation and `loadAttachmentBuffer()` with optional chaining.
> - **Proxy config**: Streamlines `normalizeUrl()`; no routing logic changes.
> - **Output file utils**: Precomputes merge output location in `createMergeOutputFileLocationGetter()`.
> - **Error utils**: Condenses `formatError()` truncation and `isFileNotFoundError()` checks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1a8c4e7de4daa69fcc2e59239969dd0ba4ad25d4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->