### PR TITLE
Simplify and improve code clarity

### DIFF
--- a/src/agent/core/AgentState.ts
+++ b/src/agent/core/AgentState.ts
@@ -12,28 +12,21 @@ import {
   RunUsageAccumulatorJSONSchema,
 } from './RunUsageAccumulator';
 
-/** Default values for ConversationRoundState */
-const ROUND_STATE_DEFAULTS = {
-  continuationCount: 0,
-  responseTimeMs: 0,
-  outputFile: '',
-  normalizedUsage: null,
-} as const;
-
+/**
+ * Schema for ConversationRoundState snapshot.
+ * Defaults are defined inline via .prefault() - schema is the single source of truth.
+ */
 export const ConversationRoundStateSnapshotSchema = z.object({
   roundIndex: z.int().nonnegative(),
-  continuationCount: z
-    .int()
-    .nonnegative()
-    .prefault(ROUND_STATE_DEFAULTS.continuationCount),
-  responseTimeMs: z
-    .number()
-    .nonnegative()
-    .prefault(ROUND_STATE_DEFAULTS.responseTimeMs),
-  outputFile: z.string().prefault(ROUND_STATE_DEFAULTS.outputFile),
-  normalizedUsage: NormalizedUsageSchema.nullable().prefault(
-    ROUND_STATE_DEFAULTS.normalizedUsage,
-  ),
+  continuationCount: z.int().nonnegative().prefault(0),
+  responseTimeMs: z.number().nonnegative().prefault(0),
+  outputFile: z.string().prefault(''),
+  normalizedUsage: NormalizedUsageSchema.nullable().prefault(null),
+});
+
+/** Parsed defaults for ConversationRoundState - derived from schema */
+const ROUND_STATE_DEFAULTS = ConversationRoundStateSnapshotSchema.parse({
+  roundIndex: 0,
 });
 
 /**
@@ -117,24 +110,21 @@ export class ConversationRoundState {
   }
 }
 
-/** Default values for AgentRunState */
-const RUN_STATE_DEFAULTS = {
-  totalRounds: 0,
-  totalResponseTimeMs: 0,
-} as const;
-
+/**
+ * Schema for AgentRunState snapshot.
+ * Defaults are defined inline via .prefault() - schema is the single source of truth.
+ */
 export const AgentRunStateSnapshotSchema = z.object({
-  totalRounds: z.int().nonnegative().prefault(RUN_STATE_DEFAULTS.totalRounds),
-  totalResponseTimeMs: z
-    .number()
-    .nonnegative()
-    .prefault(RUN_STATE_DEFAULTS.totalResponseTimeMs),
-  // Prefault normalizes missing accumulator before validation
+  totalRounds: z.int().nonnegative().prefault(0),
+  totalResponseTimeMs: z.number().nonnegative().prefault(0),
   usageAccumulator: RunUsageAccumulatorJSONSchema.prefault({
     totals: DEFAULT_TOTALS,
     normalizedSnapshots: [],
   }),
 });
+
+/** Parsed defaults for AgentRunState - derived from schema */
+const RUN_STATE_DEFAULTS = AgentRunStateSnapshotSchema.parse({});
 
 /**
  * Single source of truth for AgentRunState serialization format.

--- a/src/agent/modelHandlers/modelHandlerOpenRouter.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenRouter.ts
@@ -49,7 +49,9 @@ const extractTextFromReasoningDetails = (
   }
 
   return details
-    .filter((item): item is ReasoningDetailItem => !!item && typeof item === 'object')
+    .filter(
+      (item): item is ReasoningDetailItem => !!item && typeof item === 'object',
+    )
     .map(getReasoningItemText)
     .filter((text): text is string => !!text)
     .join('');

--- a/src/agent/modelHandlers/types/ServerToolTypes.ts
+++ b/src/agent/modelHandlers/types/ServerToolTypes.ts
@@ -5,7 +5,10 @@
  * than locally. This module provides a unified abstraction layer.
  *
  * Uses native SDK types where available for better type safety and maintainability.
+ * Zod schemas are the single source of truth; types are derived via z.infer<>.
  */
+
+import { z } from 'zod';
 
 // SDK type imports - using native types for better type safety
 // Consumers should import SDK types directly from the respective SDKs:
@@ -22,41 +25,47 @@ import type {
 } from 'openai/resources/responses/responses';
 
 // ============================================================================
-// Web Search Result Types
+// Web Search Result Schemas - Single Source of Truth
 // ============================================================================
 
 /**
- * A single web search result entry.
+ * Schema for a single web search result entry.
  * Normalized across all providers.
  */
-export interface WebSearchResultEntry {
+export const WebSearchResultEntrySchema = z.object({
   /** URL of the search result */
-  url: string;
+  url: z.string(),
   /** Title of the page */
-  title: string;
+  title: z.string(),
   /** Text snippet/description (may be encrypted for Anthropic) */
-  snippet?: string;
+  snippet: z.string().optional(),
   /** Domain extracted from URL */
-  domain?: string;
+  domain: z.string().optional(),
   /** Page age/freshness hint (Anthropic only) */
-  pageAge?: string;
-}
+  pageAge: z.string().optional(),
+});
+
+/** A single web search result entry - derived from schema. */
+export type WebSearchResultEntry = z.infer<typeof WebSearchResultEntrySchema>;
 
 /**
- * Unified web search result across all providers.
+ * Schema for unified web search result across all providers.
  */
-export interface WebSearchResult {
+export const WebSearchResultSchema = z.object({
   /** The search query that was executed */
-  query: string;
+  query: z.string(),
   /** Search result entries */
-  results: WebSearchResultEntry[];
+  results: z.array(WebSearchResultEntrySchema),
   /** Provider that executed the search */
-  provider: 'anthropic' | 'openai';
+  provider: z.enum(['anthropic', 'openai']),
   /** Unique identifier for this search call */
-  callId?: string;
+  callId: z.string().optional(),
   /** Status of the search */
-  status: 'completed' | 'in_progress' | 'failed';
-}
+  status: z.enum(['completed', 'in_progress', 'failed']),
+});
+
+/** Unified web search result - derived from schema. */
+export type WebSearchResult = z.infer<typeof WebSearchResultSchema>;
 
 // ============================================================================
 // Server Tool Content Block Types

--- a/src/agent/runtime/SessionResumeRetrieval.ts
+++ b/src/agent/runtime/SessionResumeRetrieval.ts
@@ -12,8 +12,12 @@
 import { z } from 'zod';
 
 import { getExecutionStore } from '@agent/storage';
-import type { AgentConfig } from '@agent/core/AgentConfig';
-import type { StreamTabId, ExecutionId } from '@agent/types/IdentifierTypes';
+import { AgentConfigSchema } from '@agent/core/AgentConfig';
+import {
+  ExecutionIdSchema,
+  type StreamTabId,
+  type ExecutionId,
+} from '@agent/types/IdentifierTypes';
 import type { FlowRecord } from '@agent/node/persisted-flow';
 import { AgentRunStateSnapshotSchema } from '@agent/core/AgentState';
 import { AgentWorkspaceStateSnapshotSchema } from '@agent/core/AgentWorkspaceState';
@@ -31,33 +35,45 @@ import { AgentLogger } from '@logger/AgentLogger';
 const logger = new AgentLogger('SessionResumeRetrieval');
 
 // =============================================================================
-// Types
+// Types - Zod schemas as single source of truth
 // =============================================================================
 
 /**
- * Resume data for tool-use sessions.
+ * Schema for tool-use session resume data.
  * Contains full snapshot with messages, state slices, etc.
  */
-export interface ToolUseResumeData {
-  type: 'toolUse';
-  snapshot: ToolUseSessionSnapshot;
-}
+const ToolUseResumeDataSchema = z.object({
+  type: z.literal('toolUse'),
+  snapshot: ToolUseSessionSnapshotSchema,
+});
 
 /**
- * Resume data for workflow sessions.
+ * Schema for workflow session resume data.
  * Contains minimal data - flow reads persisted state via executionId.
  */
-export interface WorkflowResumeData {
-  type: 'workflow';
-  agentConfig: AgentConfig;
-  executionId: ExecutionId;
-}
+const WorkflowResumeDataSchema = z.object({
+  type: z.literal('workflow'),
+  agentConfig: AgentConfigSchema,
+  executionId: ExecutionIdSchema,
+});
 
 /**
- * Discriminated union of session resume data.
- * Use `type` field to determine how to resume.
+ * Discriminated union schema for session resume data.
+ * Uses z.discriminatedUnion for O(1) lookup and better error messages.
  */
-export type SessionResumeData = ToolUseResumeData | WorkflowResumeData;
+export const SessionResumeDataSchema = z.discriminatedUnion('type', [
+  ToolUseResumeDataSchema,
+  WorkflowResumeDataSchema,
+]);
+
+/** Resume data for tool-use sessions - derived from schema. */
+export type ToolUseResumeData = z.infer<typeof ToolUseResumeDataSchema>;
+
+/** Resume data for workflow sessions - derived from schema. */
+export type WorkflowResumeData = z.infer<typeof WorkflowResumeDataSchema>;
+
+/** Discriminated union of session resume data - derived from schema. */
+export type SessionResumeData = z.infer<typeof SessionResumeDataSchema>;
 
 // =============================================================================
 // Schema for Tool-Use Flow Record Validation

--- a/src/commands/agent/followUpCommand.ts
+++ b/src/commands/agent/followUpCommand.ts
@@ -87,8 +87,8 @@ async function tryAutoResume(streamId: StreamTabId): Promise<boolean> {
     const missing = !progressState
       ? 'ProgressViewProvider'
       : !executionId
-      ? 'execution ID'
-      : 'task state';
+        ? 'execution ID'
+        : 'task state';
     logger.warn(`No ${missing} found for stream: ${streamId}`);
     return false;
   }

--- a/src/commands/housekeeping/cleanCommands.ts
+++ b/src/commands/housekeeping/cleanCommands.ts
@@ -32,7 +32,8 @@ const CleanParamsSchema = z.object({
 // --- Helpers ---
 
 function showCleanResult(result: FileOpResult, inputFile: string): void {
-  const isError = result.status === 'missingParams' || result.status === 'error';
+  const isError =
+    result.status === 'missingParams' || result.status === 'error';
   const messages: Record<FileOpResult['status'], string> = {
     success: `Cleanup complete for ${inputFile}`,
     noFiles: `No files found to clean for ${inputFile}`,
@@ -80,7 +81,12 @@ async function handleCleanSingle(
   agent: string,
   model: string,
 ): Promise<void> {
-  const data = await validateCleanParams(inputFile, agent, model, 'cleanSingle');
+  const data = await validateCleanParams(
+    inputFile,
+    agent,
+    model,
+    'cleanSingle',
+  );
   if (!data) return;
 
   const result = await runCleanSingle(data.model, data.inputFile, data.agent);
@@ -98,7 +104,12 @@ async function handleCleanMultiple(
   model: string,
   outputFiles: string[] = [],
 ): Promise<void> {
-  const data = await validateCleanParams(inputFile, agent, model, 'cleanMultiple');
+  const data = await validateCleanParams(
+    inputFile,
+    agent,
+    model,
+    'cleanMultiple',
+  );
   if (!data) return;
 
   logger.debug(CHANNEL, `Additional files: ${outputFiles.join(', ')}`);

--- a/src/commands/latex/compareCommands.ts
+++ b/src/commands/latex/compareCommands.ts
@@ -187,8 +187,14 @@ async function handleAcceptEdited(
     const targetExists = isNewFile && (await flexibleFS.exists(targetLocation));
 
     // Build confirmation message based on operation type
-    const action = targetExists ? 'overwrite existing' : isNewFile ? 'create' : 'overwrite';
-    const extensionNote = isNewFile ? `Extensions differ (${baseExt} vs ${editedExt}). ` : '';
+    const action = targetExists
+      ? 'overwrite existing'
+      : isNewFile
+        ? 'create'
+        : 'overwrite';
+    const extensionNote = isNewFile
+      ? `Extensions differ (${baseExt} vs ${editedExt}). `
+      : '';
     const confirmMessage = `${extensionNote}This will ${action} '${targetFileName}' with content from '${editedFileName}'. Are you sure?`;
 
     const answer = await vscode.window.showWarningMessage(

--- a/src/frontend/vscode/vscodeDiagnostics.ts
+++ b/src/frontend/vscode/vscodeDiagnostics.ts
@@ -96,7 +96,10 @@ export function getSeverityLabel(severity: vscode.DiagnosticSeverity): string {
 }
 
 /** Map from severity to counts key */
-const SEVERITY_TO_COUNT_KEY: Record<vscode.DiagnosticSeverity, keyof SeverityCounts> = {
+const SEVERITY_TO_COUNT_KEY: Record<
+  vscode.DiagnosticSeverity,
+  keyof SeverityCounts
+> = {
   [vscode.DiagnosticSeverity.Error]: 'errors',
   [vscode.DiagnosticSeverity.Warning]: 'warnings',
   [vscode.DiagnosticSeverity.Information]: 'info',

--- a/src/latex/latexdiff.ts
+++ b/src/latex/latexdiff.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 
 // Third-party imports
 import * as vscode from 'vscode';
+import { z } from 'zod';
 
 // Local imports - log
 import { extractLastRoundMatch } from '@agent/utils/mergeFileUtils';
@@ -21,20 +22,28 @@ import { DiffCommandExecutor } from './latexdiff/diffCommandExecutor';
 // Type imports
 import type { MathMarkupOption } from './latexdiff/mathMarkup';
 
-export interface LaTeXdiffResult {
-  success: boolean;
-  diffFileName?: string;
-  message?: string;
-}
+// ============================================================================
+// LaTeXdiff Result Schemas
+// ============================================================================
 
-export interface LaTeXdiffMultipleResult {
-  success: boolean;
-  results: {
-    success: string[];
-    failed: string[];
-  };
-  message?: string;
-}
+export const LaTeXdiffResultSchema = z.object({
+  success: z.boolean(),
+  diffFileName: z.string().optional(),
+  message: z.string().optional(),
+});
+export type LaTeXdiffResult = z.infer<typeof LaTeXdiffResultSchema>;
+
+export const LaTeXdiffMultipleResultSchema = z.object({
+  success: z.boolean(),
+  results: z.object({
+    success: z.array(z.string()),
+    failed: z.array(z.string()),
+  }),
+  message: z.string().optional(),
+});
+export type LaTeXdiffMultipleResult = z.infer<
+  typeof LaTeXdiffMultipleResultSchema
+>;
 
 const CHANNEL = 'LaTeXCommands';
 logger.initialize(CHANNEL);

--- a/src/latex/texcount.ts
+++ b/src/latex/texcount.ts
@@ -1,3 +1,5 @@
+import { z } from 'zod';
+
 // Local imports - log
 import { toErrorMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
@@ -40,34 +42,31 @@ async function hasChinesePackages(
   }
 }
 
+// ============================================================================
+// Texcount Schemas
+// ============================================================================
+
+export const TexcountModeSchema = z.enum(['separate', 'include', 'sum']);
+export type TexcountMode = z.infer<typeof TexcountModeSchema>;
+
+export const TexcountOptionsSchema = z.object({
+  mode: TexcountModeSchema.optional(),
+  channel: z.string().optional(),
+});
+export type TexcountOptions = z.infer<typeof TexcountOptionsSchema>;
+
+export const TexcountResultSchema = z.object({
+  output: z.string().nullable(),
+  errors: z.array(z.string()),
+});
+export type TexcountResult = z.infer<typeof TexcountResultSchema>;
+
+/** Internal validation result - simple discriminated union */
+type ValidationResult = { valid: true } | { valid: false; reason: string };
+
 /**
- * Get full statistics for LaTeX documents using the texcount Perl script
- * @param filePaths Single file path or array of file paths
- * @param options Options to control merging behavior and logging channel
- * @returns Promise<TexcountResult> Combined texcount output and any errors encountered during processing
+ * Get full statistics for LaTeX documents using the texcount Perl script.
  */
-export type TexcountMode = 'separate' | 'include' | 'sum';
-
-export interface TexcountOptions {
-  mode?: TexcountMode;
-  channel?: string;
-}
-
-interface ValidationSuccess {
-  valid: true;
-}
-
-interface ValidationFailure {
-  valid: false;
-  reason: string;
-}
-
-type ValidationResult = ValidationSuccess | ValidationFailure;
-
-export interface TexcountResult {
-  output: string | null;
-  errors: string[];
-}
 
 async function validateTexFile(
   fileLocation: FileLocation,

--- a/src/logger/filterUtils.ts
+++ b/src/logger/filterUtils.ts
@@ -1,18 +1,23 @@
-// Local imports
+import { z } from 'zod';
+
 import { getConfig } from '@utils/config';
-import { MESSAGE_TYPES, type MessageType } from './messageTypes';
+import { MESSAGE_TYPES, MessageTypeSchema } from './messageTypes';
 
-export interface FilterOptions {
-  level: 'debug' | 'info' | 'warn' | 'error';
-  messageType: MessageType;
-}
+// ============================================================================
+// Filter Schemas
+// ============================================================================
 
-export interface FilterResult {
-  /** Whether the message should be emitted to the progress view */
-  shouldEmit: boolean;
-  /** Current debug mode state (for setting verbose flag on emitted messages) */
-  debugMode: boolean;
-}
+export const FilterOptionsSchema = z.object({
+  level: z.enum(['debug', 'info', 'warn', 'error']),
+  messageType: MessageTypeSchema,
+});
+export type FilterOptions = z.infer<typeof FilterOptionsSchema>;
+
+export const FilterResultSchema = z.object({
+  shouldEmit: z.boolean(),
+  debugMode: z.boolean(),
+});
+export type FilterResult = z.infer<typeof FilterResultSchema>;
 
 /**
  * Determines whether a log message should be emitted to the progress view

--- a/src/progressView/types.ts
+++ b/src/progressView/types.ts
@@ -1,42 +1,47 @@
-// Local imports - agent types
-import type { AgentCategory, AgentType } from '@agent/core/AgentDataclass';
-import type { ExecutionId } from '@agent/types/IdentifierTypes';
+import { z } from 'zod';
+
+import { AgentCategory, AgentType } from '@agent/core/AgentDataclass';
+import { ExecutionIdSchema } from '@agent/types/IdentifierTypes';
 import type { AgentTypeFilter } from '@agent/types/AgentStreamTypes';
 
-export interface StreamUITraits {
-  /** Canonical session grouping for the stream. */
-  sessionKind: AgentCategory;
-  /** Indicates whether the associated agent is a tool-use session. */
-  isToolAgent: boolean;
-}
+// ============================================================================
+// Progress View Schemas
+// ============================================================================
 
-export interface StreamTabInfo {
-  name: string;
-  /** Short label displayed in the tab UI */
-  label: string;
-  model?: string;
-  agent?: string;
-  agentType?: AgentType;
-  agentSessionKind: AgentCategory;
-  uiTraits: StreamUITraits;
-  hasMultipleOutputs?: boolean;
-  /** Whether this is a remote agent */
-  isRemote?: boolean;
-  lastTimestamp?: number;
-  inputFile?: string;
-  creationTimestamp?: number;
-  status?: string;
-  executionId?: ExecutionId;
-}
+export const StreamUITraitsSchema = z.object({
+  sessionKind: z.nativeEnum(AgentCategory),
+  isToolAgent: z.boolean(),
+});
+export type StreamUITraits = z.infer<typeof StreamUITraitsSchema>;
+
+export const StreamTabInfoSchema = z.object({
+  name: z.string(),
+  label: z.string(),
+  model: z.string().optional(),
+  agent: z.string().optional(),
+  agentType: z.nativeEnum(AgentType).optional(),
+  agentSessionKind: z.nativeEnum(AgentCategory),
+  uiTraits: StreamUITraitsSchema,
+  hasMultipleOutputs: z.boolean().optional(),
+  isRemote: z.boolean().optional(),
+  lastTimestamp: z.number().optional(),
+  inputFile: z.string().optional(),
+  creationTimestamp: z.number().optional(),
+  status: z.string().optional(),
+  executionId: ExecutionIdSchema.optional(),
+});
+export type StreamTabInfo = z.infer<typeof StreamTabInfoSchema>;
 
 export type AgentFilter = AgentTypeFilter;
 
-export interface InstructionMetadata {
-  showToggle?: boolean;
-  expanded?: boolean;
-}
+export const InstructionMetadataSchema = z.object({
+  showToggle: z.boolean().optional(),
+  expanded: z.boolean().optional(),
+});
+export type InstructionMetadata = z.infer<typeof InstructionMetadataSchema>;
 
-export interface InstructionUpdate {
-  text: string;
-  metadata?: InstructionMetadata;
-}
+export const InstructionUpdateSchema = z.object({
+  text: z.string(),
+  metadata: InstructionMetadataSchema.optional(),
+});
+export type InstructionUpdate = z.infer<typeof InstructionUpdateSchema>;

--- a/src/test/tools/ToolEditApprovalGate.test.ts
+++ b/src/test/tools/ToolEditApprovalGate.test.ts
@@ -175,14 +175,26 @@ describe('Tool edit approval gating', () => {
 
     // Handler should NOT be called when bypass is on
     await tool.call({ path: 'doc.txt', content: 'content2' });
-    assert.strictEqual(handlerCallCount, 1, 'Handler not called when bypass on');
+    assert.strictEqual(
+      handlerCallCount,
+      1,
+      'Handler not called when bypass on',
+    );
 
     // Toggle off - should return false
     const disabledState = toggleToolEditApprovalSessionBypass();
-    assert.strictEqual(disabledState, false, 'Toggle returns false when disabling');
+    assert.strictEqual(
+      disabledState,
+      false,
+      'Toggle returns false when disabling',
+    );
 
     // Handler should be called again when bypass is off
     await tool.call({ path: 'doc.txt', content: 'content3' });
-    assert.strictEqual(handlerCallCount, 2, 'Handler called again when bypass off');
+    assert.strictEqual(
+      handlerCallCount,
+      2,
+      'Handler called again when bypass off',
+    );
   });
 });

--- a/src/tools/latex/arxivShared.ts
+++ b/src/tools/latex/arxivShared.ts
@@ -1,40 +1,56 @@
 // Third-party imports
 import arxivClient from 'arxiv-client';
 import { extract as extractArxivId } from 'identifiers-arxiv';
+import { z } from 'zod';
 
 /** Infer ArxivEntry type from the client's execute() return type */
 type ArxivEntry = Awaited<ReturnType<typeof arxivClient.execute>>[number];
 
-/**
- * Base arXiv paper metadata shared between search and metadata tools.
- */
-export interface ArxivPaperBase {
-  id: string | null;
-  doi: string | null;
-  title: string;
-  published: Date | null;
-  updated: Date | null;
-  authors: string[];
-  primaryCategory: string | null;
-}
+// ============================================================================
+// arXiv Paper Schemas - Single Source of Truth
+// ============================================================================
 
 /**
- * arXiv paper metadata returned by search results.
+ * Schema for base arXiv paper metadata shared between search and metadata tools.
  */
-export interface ArxivSearchResult extends ArxivPaperBase {
-  abstract: string | null;
-  arxivUrl: string | null;
-}
+export const ArxivPaperBaseSchema = z.object({
+  id: z.string().nullable(),
+  doi: z.string().nullable(),
+  title: z.string(),
+  published: z.date().nullable(),
+  updated: z.date().nullable(),
+  authors: z.array(z.string()),
+  primaryCategory: z.string().nullable(),
+});
+
+/** Base arXiv paper metadata - derived from schema. */
+export type ArxivPaperBase = z.infer<typeof ArxivPaperBaseSchema>;
 
 /**
- * Detailed arXiv paper metadata with additional fields.
+ * Schema for arXiv paper metadata returned by search results.
+ * Extends ArxivPaperBaseSchema with search-specific fields.
  */
-export interface ArxivPaperMetadata extends ArxivPaperBase {
-  abstract?: string | null;
-  journalReference: string | null;
-  comment: string | null;
-  links: unknown;
-}
+export const ArxivSearchResultSchema = ArxivPaperBaseSchema.extend({
+  abstract: z.string().nullable(),
+  arxivUrl: z.string().nullable(),
+});
+
+/** arXiv search result - derived from schema. */
+export type ArxivSearchResult = z.infer<typeof ArxivSearchResultSchema>;
+
+/**
+ * Schema for detailed arXiv paper metadata with additional fields.
+ * Extends ArxivPaperBaseSchema with metadata-specific fields.
+ */
+export const ArxivPaperMetadataSchema = ArxivPaperBaseSchema.extend({
+  abstract: z.string().nullish(),
+  journalReference: z.string().nullable(),
+  comment: z.string().nullable(),
+  links: z.unknown(),
+});
+
+/** Detailed arXiv paper metadata - derived from schema. */
+export type ArxivPaperMetadata = z.infer<typeof ArxivPaperMetadataSchema>;
 
 export type ArxivClientInstance = typeof arxivClient;
 

--- a/src/tools/latex/figureExtractionShared.ts
+++ b/src/tools/latex/figureExtractionShared.ts
@@ -1,5 +1,10 @@
-// Local imports - tools
-import { ToolError, type ToolFileAttachment } from '@tools/result';
+import { z } from 'zod';
+
+import {
+  ToolError,
+  ToolFileAttachmentSchema,
+  type ToolFileAttachment,
+} from '@tools/result';
 import {
   buildFileAttachment,
   resolveAndFormat,
@@ -7,22 +12,31 @@ import {
 } from '@tools/utils';
 import { WorkspaceFS } from '@utils/files';
 
-export interface LatexFileResolution {
-  resolved: WorkspacePathResolution;
-  display: string;
-}
+// ============================================================================
+// Figure Extraction Schemas
+// ============================================================================
 
-export interface AttachmentLimitResult {
-  attachments: ToolFileAttachment[];
-  limitedPaths: string[];
-  limitReached: boolean;
-}
+export const LatexFileResolutionSchema = z.object({
+  resolved: z.custom<WorkspacePathResolution>(),
+  display: z.string(),
+});
+export type LatexFileResolution = z.infer<typeof LatexFileResolutionSchema>;
 
-export interface AttachmentLimitOptions {
-  limit: number;
-  describe: (filePath: string) => string;
-  mimeType?: string;
-}
+export const AttachmentLimitResultSchema = z.object({
+  attachments: z.array(ToolFileAttachmentSchema),
+  limitedPaths: z.array(z.string()),
+  limitReached: z.boolean(),
+});
+export type AttachmentLimitResult = z.infer<typeof AttachmentLimitResultSchema>;
+
+export const AttachmentLimitOptionsSchema = z.object({
+  limit: z.number(),
+  describe: z.custom<(filePath: string) => string>(),
+  mimeType: z.string().optional(),
+});
+export type AttachmentLimitOptions = z.infer<
+  typeof AttachmentLimitOptionsSchema
+>;
 
 export async function resolveLatexFileOrThrow(
   texPath: string,

--- a/src/utils/text/xmlExtraction.ts
+++ b/src/utils/text/xmlExtraction.ts
@@ -1,7 +1,10 @@
 /**
  * XML content extraction utilities.
  * Functions for extracting content from XML tags and documents.
+ * Zod schemas are the single source of truth; types are derived via z.infer<>.
  */
+
+import { z } from 'zod';
 
 // Local imports - common
 import { toErrorMessage } from '@common/errors';
@@ -247,21 +250,25 @@ export async function extractScratchpad(
   return extractedContent ? await formatContent(extractedContent) : null;
 }
 
-/**
- * Result of single document extraction with method indicator
- */
-export interface ExtractionResult {
-  content: string | null;
-  method: 'named' | 'simple' | 'markdown' | 'latex' | 'none';
-}
+// ============================================================================
+// Extraction Result Schemas
+// ============================================================================
 
-/**
- * Result of multiple document extraction with method indicator
- */
-export interface MultipleExtractionResult {
-  documents: Array<{ content: string; name: string }> | null;
-  method: 'simple' | 'none';
-}
+export const ExtractionResultSchema = z.object({
+  content: z.string().nullable(),
+  method: z.enum(['named', 'simple', 'markdown', 'latex', 'none']),
+});
+export type ExtractionResult = z.infer<typeof ExtractionResultSchema>;
+
+export const MultipleExtractionResultSchema = z.object({
+  documents: z
+    .array(z.object({ content: z.string(), name: z.string() }))
+    .nullable(),
+  method: z.enum(['simple', 'none']),
+});
+export type MultipleExtractionResult = z.infer<
+  typeof MultipleExtractionResultSchema
+>;
 
 /**
  * Extract document content using a consolidated cascade of fallback methods.


### PR DESCRIPTION
- SessionResumeRetrieval.ts: Convert manual interfaces to Zod schemas with z.discriminatedUnion() for ToolUseResumeData and WorkflowResumeData. Types are now derived from schemas using z.infer<>.

- AgentState.ts: Eliminate defaults duplication by deriving defaults from schema parsing. The schema with .prefault() is now the single source of truth, and ROUND_STATE_DEFAULTS/RUN_STATE_DEFAULTS are derived via parse().

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Standardizes on schema-driven types and defaults, reducing duplication and improving validation.
> 
> - Core: Collapse duplicate defaults in `AgentState` by using `.prefault()` and parsing schema-derived defaults
> - Runtime: Define discriminated `SessionResumeData` via `z.discriminatedUnion`, validate tool-use/workflow resume payloads, and use during follow-up auto-resume
> - Model handlers: Minor formatting; keep OpenRouter reasoning parsing logic intact
> - Server tools: Add `WebSearchResultEntry`/`WebSearchResult` Zod schemas; retain SDK-based type guards and extractors
> - VS Code/commands: Minor formatting and param validation tweaks in clean/compare/follow-up commands
> - LaTeX tools: Introduce Zod result/options schemas in `latexdiff` and `texcount`
> - Logger/UI: Add Zod schemas for filter options/results and progress view types
> - Utils: Add Zod schemas for XML extraction result types
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0d8f45142b7b4b70a7dfe4f019f1e69bed611b0a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->