### PR TITLE
fix: improve memory tool description and error messages for path validation

### DIFF
--- a/src/tools/memory/MemoryTool.ts
+++ b/src/tools/memory/MemoryTool.ts
@@ -69,8 +69,9 @@ export type MemoryToolInput = z.infer<typeof MemoryToolInputSchema>;
  */
 export class MemoryTool extends defineTool({
   name: 'memory',
-  description:
-    'Store, read, and manage persistent memory files under /memories using view, create, str_replace, insert, delete, or rename.',
+  description: `Manage persistent memory files under /memories (view, create, str_replace, insert, delete, rename).
+
+Paths must start with /memories. Use /memories to list files, /memories/file.md for specific files. "/" alone is invalid.`,
   schema: MemoryToolInputSchema,
 }) {
   protected async execute(input: MemoryToolInput): Promise<ToolResult> {
@@ -144,7 +145,7 @@ export class MemoryTool extends defineTool({
       return displayToStoragePath(inputPath);
     } catch {
       throw new ToolError(
-        `The path ${inputPath} does not exist. Please provide a valid path.`,
+        `Invalid path "${inputPath}". All memory paths must start with /memories (e.g., /memories or /memories/notes.md).`,
       );
     }
   }

--- a/src/tools/memory/memoryUtils.ts
+++ b/src/tools/memory/memoryUtils.ts
@@ -79,7 +79,7 @@ export function displayToStoragePath(displayPath: string): string {
     !displayPath.startsWith(`${MEMORY_DISPLAY_ROOT}/`)
   ) {
     throw new Error(
-      `The path ${displayPath} does not exist. Please provide a valid path.`,
+      `Invalid path "${displayPath}". All memory paths must start with /memories (e.g., /memories or /memories/notes.md).`,
     );
   }
   const suffix =


### PR DESCRIPTION
Update tool description to clarify that paths must start with /memories
and that "/" alone is invalid. Update error messages to provide clearer
guidance when invalid paths are used.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves path validation messaging for memory operations.
> 
> - Updates `MemoryTool` description to specify that all paths must start with `
> /memories`, `"/"` is invalid, and how to list vs. access files
> - Standardizes clearer invalid path errors in `MemoryTool.resolveMemoryPath` and `memoryUtils.displayToStoragePath`, guiding users to `
> /memories` or `
> /memories/file.md`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 45e10dcd259f74406ea7afb8e2f8aaca26e415f6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->