### PR TITLE
docs: add PRD for agent history access via /runs virtual filesystem

### DIFF
--- a/docs/prd/agent-history-access.md
+++ b/docs/prd/agent-history-access.md
@@ -176,7 +176,9 @@ const [namespace, id, resource, ...rest] = segments;
 
 if (namespace !== 'runs') throw new ToolError('Path must start with /runs');
 if (!id) return this.listRuns();
-if (!resource) return this.showExecution(id);  // Config + conversation combined
+if (!resource) return this.showSummary(id);
+if (resource === 'config') return this.showConfig(id);
+if (resource === 'conversation') return this.showConversation(id);
 if (resource === 'files') {
   if (rest.length === 0) return this.listFiles(id);
   return this.readFile(id, rest.join('/'));
@@ -186,7 +188,7 @@ if (resource === 'files') {
 ### Files Created
 
 ```
-src/tools/RunsTool.ts  # Single file, ~280 lines
+src/tools/RunsTool.ts  # Single file, ~400 lines
 ```
 
 ### Files Modified
@@ -289,12 +291,14 @@ An orchestrating tool-use agent can:
 
 ## Success Criteria
 
-1. Agent can list past executions
-2. Agent can view execution detail (config + conversation combined)
-3. Agent can read generated files from past runs
-4. Works for both tool-use and workflow agents
-5. No breaking changes to existing code
-6. Single file implementation (~280 lines)
+1. Agent can list past executions (sorted by time, most recent first)
+2. Agent can view execution summary with navigation hints
+3. Agent can get config as JSON (for propose_workflow/propose_agent)
+4. Agent can view conversation history
+5. Agent can read generated files from past runs
+6. Works for both tool-use and workflow agents
+7. No breaking changes to existing code
+8. Single file implementation (~400 lines)
 
 ## References
 

--- a/docs/prd/agent-history-access.md
+++ b/docs/prd/agent-history-access.md
@@ -25,29 +25,26 @@ A new `runs` tool providing read-only virtual filesystem access to execution sto
 
 ```
 /runs                        → List all executions
-/runs/current                → Alias for active execution
-/runs/{id}                   → Summary + conversation history
-/runs/{id}/config            → AgentConfig JSON
+/runs/{id}                   → Execution detail (config + conversation)
 /runs/{id}/files             → List generated files
 /runs/{id}/files/{path}      → Read file content
 ```
 
+Use `current` as `{id}` to access the active execution.
+
 ### Design Principles
 
-1. **Minimal surface** - 5 path patterns, not 12
-2. **Read-only** - History is immutable
-3. **Agent-type agnostic** - Works for both tool-use and workflow agents (both have `conversation[]`)
-4. **No over-abstraction** - Single tool file, no elaborate backend hierarchy
-5. **Follows existing patterns** - Mirrors `/memories` tool interface
+1. **Minimal surface** - 4 path patterns
+2. **Read-only** - History is immutable, no `command` parameter needed
+3. **Agent-type agnostic** - Works for both tool-use and workflow agents
+4. **Single file** - `src/tools/RunsTool.ts`, no subdirectory
+5. **Config merged into detail** - `/runs/{id}` shows config + conversation together
 
 ## Schema
 
 ```typescript
 const RunsToolInputSchema = z.strictObject({
-  /** Only 'view' supported - runs are read-only */
-  command: z.literal('view'),
-
-  /** Virtual path starting with /runs */
+  /** Virtual path: /runs, /runs/{id}, /runs/{id}/files, /runs/{id}/files/{path} */
   path: z.string(),
 
   /** Optional line range [start, end] for large outputs */
@@ -55,29 +52,24 @@ const RunsToolInputSchema = z.strictObject({
 });
 ```
 
+No `command` parameter - it's always "view" (read-only).
+
 ## Path Semantics
 
 | Path | Source | Returns |
 |------|--------|---------|
-| `/runs` | `AgentHistoryManager.getHistory()` | List: id, agent, timestamp, status |
-| `/runs/{id}` | `ExecutionKVStore` → `flow:{id}` | Header + `conversation[]` formatted |
-| `/runs/{id}/config` | `ExecutionKVStore` → `flow:{id}` | `agentConfig` as JSON |
+| `/runs` | `AgentHistoryManager.getHistory()` | List: id, timestamp, agent, model, summary |
+| `/runs/{id}` | History + `ExecutionKVStore` | Config + conversation combined |
 | `/runs/{id}/files` | `StorageFS` → `taskRuns/{id}/` | Directory listing |
 | `/runs/{id}/files/{path}` | `StorageFS` → `taskRuns/{id}/{path}` | File content |
 
-### Special: `/runs/current`
+### Special: `current`
 
-Resolves to the active execution via `ToolFileInteractionContext.executionId`.
+Use `current` as execution ID to access the active session:
 
-```typescript
-function resolveExecutionId(id: string): string {
-  if (id === 'current') {
-    const ctx = getCurrentToolFileInteractionContext();
-    if (!ctx?.executionId) throw new Error('No active execution');
-    return ctx.executionId;
-  }
-  return id;
-}
+```
+runs({ path: '/runs/current' })
+runs({ path: '/runs/current/files' })
 ```
 
 ## Storage Architecture (Unchanged)
@@ -103,50 +95,52 @@ Both agent types store accumulated messages in `shared.conversation[]`. The tool
 
 ```
 // List past executions
-runs({ command: 'view', path: '/runs' })
-→ abc123  research-assistant  2024-01-15 10:30  completed
-  def456  latex-rewriter      2024-01-15 11:00  completed
-  ...
+runs({ path: '/runs' })
+→ abc123  2024-01-15T10:30:00Z  research-assistant  sonnet45  Find related work...
+  def456  2024-01-15T11:00:00Z  latex-rewriter      gemini3p  Fix grammar errors...
 
-// View execution history
-runs({ command: 'view', path: '/runs/abc123' })
-→ Agent: research-assistant
-  Model: claude-sonnet-4-20250514
-  Started: 2024-01-15 10:30:00
-  Status: completed
+// View execution detail (config + conversation)
+runs({ path: '/runs/abc123' })
+→ === Config ===
+  Agent: research-assistant
+  Model: sonnet45
+  Timestamp: 2024-01-15T10:30:00Z
+  Task: Find related work
+  Tools: read_file, web_search, arxiv_search
 
-  [1] user: Find papers about quantum computing...
-  [2] assistant: I'll search for relevant papers...
-  [3] tool_use: arxiv_search({query: "quantum computing"})
-  [4] tool_result: Found 10 papers...
-  ...
+  === Conversation ===
 
-// View config (useful for proposing new runs)
-runs({ command: 'view', path: '/runs/abc123/config' })
-→ {
-    "agent": "research-assistant",
-    "model": "claude-sonnet-4-20250514",
-    "tools": ["read_file", "web_search", "arxiv_search"],
-    "session": {
-      "inputFiles": ["paper.tex"],
-      "taskSummary": "Find related work"
-    }
-  }
+  [1] user:
+  Find papers about quantum computing...
+
+  [2] assistant:
+  I'll search for relevant papers...
+
+  [3] assistant:
+  [tool_use: arxiv_search({"query": "quantum computing"})]
+
+  [4] user:
+  [tool_result: Found 10 papers...]
 
 // List generated files
-runs({ command: 'view', path: '/runs/abc123/files' })
-→ output.tex      2,451 bytes
-  summary.md      1,203 bytes
-  original/
-    input.tex     3,102 bytes
+runs({ path: '/runs/abc123/files' })
+→ Files in /runs/abc123/files:
+
+      2.4K  output.tex
+      1.2K  summary.md
+    <dir>  original
+      3.1K  original/input.tex
 
 // Read generated file
-runs({ command: 'view', path: '/runs/abc123/files/output.tex' })
-→ [file content...]
+runs({ path: '/runs/abc123/files/output.tex' })
+→ File: /runs/abc123/files/output.tex
+
+  \documentclass{article}
+  ...
 
 // Access current session
-runs({ command: 'view', path: '/runs/current' })
-→ [current execution history so far]
+runs({ path: '/runs/current' })
+→ [current execution detail]
 ```
 
 ## Implementation
@@ -158,33 +152,29 @@ Use existing `getPathSegments` from `src/utils/core/pathCore.ts`:
 ```typescript
 import { getPathSegments } from '@utils/core/pathCore';
 
-// Example: '/runs/abc123/config' → ['runs', 'abc123', 'config']
+// Example: '/runs/abc123/files' → ['runs', 'abc123', 'files']
 const segments = getPathSegments(input.path);
 const [namespace, id, resource, ...rest] = segments;
 
 if (namespace !== 'runs') throw new ToolError('Path must start with /runs');
 if (!id) return this.listRuns();
-if (!resource) return this.showExecution(id);
-if (resource === 'config') return this.showConfig(id);
+if (!resource) return this.showExecution(id);  // Config + conversation combined
 if (resource === 'files') {
   if (rest.length === 0) return this.listFiles(id);
   return this.readFile(id, rest.join('/'));
 }
 ```
 
-### Files to Create
+### Files Created
 
 ```
-src/tools/runs/
-├── constants.ts      # RUNS_DISPLAY_ROOT = '/runs'
-├── RunsTool.ts       # Main tool (~150 lines)
-└── index.ts          # Exports
+src/tools/RunsTool.ts  # Single file, ~280 lines
 ```
 
-### Files to Modify
+### Files Modified
 
 ```
-src/tools/registry.ts  # Register RunsTool (1 line)
+src/tools/registry.ts  # Import + register RunsTool
 ```
 
 ### Existing Utilities to Reuse
@@ -212,25 +202,28 @@ View execution history and generated files (read-only).
 
 Paths:
 - /runs - List all past executions
-- /runs/current - Current session
-- /runs/{id} - Execution summary and conversation history
-- /runs/{id}/config - Agent configuration used
+- /runs/{id} - Execution detail with config and conversation
 - /runs/{id}/files - List generated files
 - /runs/{id}/files/{path} - Read specific file
 
+Use "current" as {id} to access the active execution.
 Use view_range: [start, end] to paginate large outputs.
 ```
 
 ## Integration with Agent Proposal Tools
 
-The `/runs/{id}/config` path enables agents to learn from past executions and propose new ones:
+The `/runs/{id}` path shows config + conversation, enabling agents to learn and propose new executions:
 
 ### Tool-Use Agent History → Propose New Tool-Use Agent
 
 ```
-// View past tool-use execution
-runs({ command: 'view', path: '/runs/abc123/config' })
-→ { agent: "search", model: "sonnet45", instruction: "Find papers on attention..." }
+// View past execution (config included in output)
+runs({ path: '/runs/abc123' })
+→ === Config ===
+  Agent: search
+  Model: sonnet45
+  Task: Find papers on attention...
+  ...
 
 // Propose similar with modifications
 propose_agent({
@@ -243,9 +236,13 @@ propose_agent({
 ### Workflow Agent History → Propose New Workflow
 
 ```
-// View past workflow execution
-runs({ command: 'view', path: '/runs/def456/config' })
-→ { agent: "correct", model: "sonnet45", inputFile: "paper.tex", ... }
+// View past execution
+runs({ path: '/runs/def456' })
+→ === Config ===
+  Agent: correct
+  Model: sonnet45
+  Input files: paper.tex
+  ...
 
 // Propose similar with modifications
 propose_workflow({
@@ -262,11 +259,6 @@ An orchestrating tool-use agent can:
 1. Review tool-use execution history (what searches worked)
 2. Review workflow execution history (what corrections were applied)
 3. Propose either type based on current needs
-
-This creates a learning loop where agents can:
-- Review what worked before (both types)
-- Understand successful configurations
-- Propose improvements based on history
 
 ## Future Considerations
 
@@ -286,12 +278,11 @@ This creates a learning loop where agents can:
 ## Success Criteria
 
 1. Agent can list past executions
-2. Agent can read conversation history from any execution
-3. Agent can view config to understand/propose new runs
-4. Agent can read generated files from past runs
-5. Works for both tool-use and workflow agents
-6. No breaking changes to existing code
-7. Implementation < 200 lines
+2. Agent can view execution detail (config + conversation combined)
+3. Agent can read generated files from past runs
+4. Works for both tool-use and workflow agents
+5. No breaking changes to existing code
+6. Single file implementation (~280 lines)
 
 ## References
 

--- a/docs/prd/agent-history-access.md
+++ b/docs/prd/agent-history-access.md
@@ -151,12 +151,33 @@ runs({ command: 'view', path: '/runs/current' })
 
 ## Implementation
 
+### Path Parsing
+
+Use existing `getPathSegments` from `src/utils/core/pathCore.ts`:
+
+```typescript
+import { getPathSegments } from '@utils/core/pathCore';
+
+// Example: '/runs/abc123/config' → ['runs', 'abc123', 'config']
+const segments = getPathSegments(input.path);
+const [namespace, id, resource, ...rest] = segments;
+
+if (namespace !== 'runs') throw new ToolError('Path must start with /runs');
+if (!id) return this.listRuns();
+if (!resource) return this.showExecution(id);
+if (resource === 'config') return this.showConfig(id);
+if (resource === 'files') {
+  if (rest.length === 0) return this.listFiles(id);
+  return this.readFile(id, rest.join('/'));
+}
+```
+
 ### Files to Create
 
 ```
 src/tools/runs/
-├── constants.ts      # RUNS_DISPLAY_ROOT, path patterns
-├── RunsTool.ts       # Main tool (~180 lines)
+├── constants.ts      # RUNS_DISPLAY_ROOT = '/runs'
+├── RunsTool.ts       # Main tool (~150 lines)
 └── index.ts          # Exports
 ```
 
@@ -166,12 +187,23 @@ src/tools/runs/
 src/tools/registry.ts  # Register RunsTool (1 line)
 ```
 
+### Existing Utilities to Reuse
+
+| Utility | Location | Usage |
+|---------|----------|-------|
+| `getPathSegments` | `@utils/core/pathCore` | Parse virtual paths |
+| `getCurrentToolFileInteractionContext` | `@agent/toolUse/ToolFileInteractionContext` | Get current executionId |
+| `getExecutionStore` | `@agent/storage/ExecutionKVStore` | Read flow records |
+| `AgentHistoryManager` | `@common/history` | List executions |
+| `StorageFS` | `@utils/files` | Read task run files |
+
 ### No Changes Required
 
 - `ExecutionKVStore` - read as-is
 - `AgentHistoryManager` - read as-is
 - `TaskRunFileService` - read as-is
 - `Memory tool` - untouched (follows Anthropic API)
+- `pathCore.ts` - already has `getPathSegments`
 
 ## Tool Description (for LLM)
 
@@ -188,6 +220,33 @@ Paths:
 
 Use view_range: [start, end] to paginate large outputs.
 ```
+
+## Integration with WorkflowTool
+
+The `/runs/{id}/config` path enables a powerful workflow:
+
+1. Agent views past execution config via `runs` tool
+2. Agent proposes modified execution via `propose_workflow` or `propose_agent` tools
+
+Example agent reasoning:
+```
+// Agent reads past successful config
+runs({ command: 'view', path: '/runs/abc123/config' })
+→ { agent: "correct", model: "sonnet45", inputFile: "paper.tex", ... }
+
+// Agent proposes similar run with modifications
+propose_workflow({
+  agent: "correct",
+  model: "opus45",  // Upgraded model
+  inputFile: "paper_v2.tex",
+  instruction: "Same corrections as before, plus check citations"
+})
+```
+
+This creates a learning loop where agents can:
+- Review what worked before
+- Understand successful configurations
+- Propose improvements based on history
 
 ## Future Considerations
 

--- a/docs/prd/agent-history-access.md
+++ b/docs/prd/agent-history-access.md
@@ -1,0 +1,222 @@
+# PRD: Agent History Access via `/runs` Virtual Filesystem
+
+## Overview
+
+Give tool-use agents read-only access to execution history and generated files through a virtual filesystem interface (`/runs`), following the same pattern as the existing `/memories` tool.
+
+## Problem Statement
+
+Agents currently have:
+- ✅ Full access to workspace files via `read_file`, `write_file`, `ls`
+- ✅ Full access to `/memories` via `memory` tool
+- ❌ No access to execution history (past conversations, tool calls)
+- ❌ No access to task run files (generated outputs)
+
+This limits an agent's ability to:
+- Learn from previous attempts
+- Reference past outputs
+- Propose improved configurations based on what worked
+
+## Solution
+
+A new `runs` tool providing read-only virtual filesystem access to execution storage.
+
+### Virtual Filesystem Structure
+
+```
+/runs                        → List all executions
+/runs/current                → Alias for active execution
+/runs/{id}                   → Summary + conversation history
+/runs/{id}/config            → AgentConfig JSON
+/runs/{id}/files             → List generated files
+/runs/{id}/files/{path}      → Read file content
+```
+
+### Design Principles
+
+1. **Minimal surface** - 5 path patterns, not 12
+2. **Read-only** - History is immutable
+3. **Agent-type agnostic** - Works for both tool-use and workflow agents (both have `conversation[]`)
+4. **No over-abstraction** - Single tool file, no elaborate backend hierarchy
+5. **Follows existing patterns** - Mirrors `/memories` tool interface
+
+## Schema
+
+```typescript
+const RunsToolInputSchema = z.strictObject({
+  /** Only 'view' supported - runs are read-only */
+  command: z.literal('view'),
+
+  /** Virtual path starting with /runs */
+  path: z.string(),
+
+  /** Optional line range [start, end] for large outputs */
+  view_range: z.array(z.int().min(1)).length(2).nullish(),
+});
+```
+
+## Path Semantics
+
+| Path | Source | Returns |
+|------|--------|---------|
+| `/runs` | `AgentHistoryManager.getHistory()` | List: id, agent, timestamp, status |
+| `/runs/{id}` | `ExecutionKVStore` → `flow:{id}` | Header + `conversation[]` formatted |
+| `/runs/{id}/config` | `ExecutionKVStore` → `flow:{id}` | `agentConfig` as JSON |
+| `/runs/{id}/files` | `StorageFS` → `taskRuns/{id}/` | Directory listing |
+| `/runs/{id}/files/{path}` | `StorageFS` → `taskRuns/{id}/{path}` | File content |
+
+### Special: `/runs/current`
+
+Resolves to the active execution via `ToolFileInteractionContext.executionId`.
+
+```typescript
+function resolveExecutionId(id: string): string {
+  if (id === 'current') {
+    const ctx = getCurrentToolFileInteractionContext();
+    if (!ctx?.executionId) throw new Error('No active execution');
+    return ctx.executionId;
+  }
+  return id;
+}
+```
+
+## Storage Architecture (Unchanged)
+
+The tool reads from existing storage - no refactoring required:
+
+| Component | Location | What We Read |
+|-----------|----------|--------------|
+| `AgentHistoryManager` | WorkspaceState | Execution list (id, timestamp, agentConfig) |
+| `ExecutionKVStore` | `executions/{id}/flow:{id}.json` | `conversation[]`, `agentConfig` |
+| `TaskRunFileService` | `taskRuns/{id}/` | Generated files |
+
+### Tool-Use vs Workflow Agents
+
+Both agent types store accumulated messages in `shared.conversation[]`. The tool does not expose workflow-specific internals (rounds, per-round state) - these are implementation details.
+
+| Agent Type | `conversation[]` | Rounds | Exposed? |
+|------------|------------------|--------|----------|
+| Tool-use | All messages | N/A | ✅ via `/runs/{id}` |
+| Workflow | Accumulated across rounds | Internal | ✅ via `/runs/{id}` (flattened) |
+
+## Example Usage
+
+```
+// List past executions
+runs({ command: 'view', path: '/runs' })
+→ abc123  research-assistant  2024-01-15 10:30  completed
+  def456  latex-rewriter      2024-01-15 11:00  completed
+  ...
+
+// View execution history
+runs({ command: 'view', path: '/runs/abc123' })
+→ Agent: research-assistant
+  Model: claude-sonnet-4-20250514
+  Started: 2024-01-15 10:30:00
+  Status: completed
+
+  [1] user: Find papers about quantum computing...
+  [2] assistant: I'll search for relevant papers...
+  [3] tool_use: arxiv_search({query: "quantum computing"})
+  [4] tool_result: Found 10 papers...
+  ...
+
+// View config (useful for proposing new runs)
+runs({ command: 'view', path: '/runs/abc123/config' })
+→ {
+    "agent": "research-assistant",
+    "model": "claude-sonnet-4-20250514",
+    "tools": ["read_file", "web_search", "arxiv_search"],
+    "session": {
+      "inputFiles": ["paper.tex"],
+      "taskSummary": "Find related work"
+    }
+  }
+
+// List generated files
+runs({ command: 'view', path: '/runs/abc123/files' })
+→ output.tex      2,451 bytes
+  summary.md      1,203 bytes
+  original/
+    input.tex     3,102 bytes
+
+// Read generated file
+runs({ command: 'view', path: '/runs/abc123/files/output.tex' })
+→ [file content...]
+
+// Access current session
+runs({ command: 'view', path: '/runs/current' })
+→ [current execution history so far]
+```
+
+## Implementation
+
+### Files to Create
+
+```
+src/tools/runs/
+├── constants.ts      # RUNS_DISPLAY_ROOT, path patterns
+├── RunsTool.ts       # Main tool (~180 lines)
+└── index.ts          # Exports
+```
+
+### Files to Modify
+
+```
+src/tools/registry.ts  # Register RunsTool (1 line)
+```
+
+### No Changes Required
+
+- `ExecutionKVStore` - read as-is
+- `AgentHistoryManager` - read as-is
+- `TaskRunFileService` - read as-is
+- `Memory tool` - untouched (follows Anthropic API)
+
+## Tool Description (for LLM)
+
+```
+View execution history and generated files (read-only).
+
+Paths:
+- /runs - List all past executions
+- /runs/current - Current session
+- /runs/{id} - Execution summary and conversation history
+- /runs/{id}/config - Agent configuration used
+- /runs/{id}/files - List generated files
+- /runs/{id}/files/{path} - Read specific file
+
+Use view_range: [start, end] to paginate large outputs.
+```
+
+## Future Considerations
+
+### Not in Scope (Intentionally)
+
+- **Per-round access for workflows** - Implementation detail, not useful for agents
+- **State snapshots** - Debugging concern, not reasoning
+- **Write operations** - History is immutable
+- **Search/filter** - Keep it simple; can add later if needed
+
+### Potential Extensions (Later)
+
+- `/runs/{id}/tools` - List of tool calls with timing/success
+- `/runs/{id}/usage` - Token usage statistics
+- Search by agent name or date range
+
+## Success Criteria
+
+1. Agent can list past executions
+2. Agent can read conversation history from any execution
+3. Agent can view config to understand/propose new runs
+4. Agent can read generated files from past runs
+5. Works for both tool-use and workflow agents
+6. No breaking changes to existing code
+7. Implementation < 200 lines
+
+## References
+
+- Memory tool pattern: `src/tools/memory/MemoryTool.ts`
+- Execution storage: `src/agent/storage/ExecutionKVStore.ts`
+- History manager: `src/common/history/AgentHistoryManager.ts`
+- Task run files: `src/utils/files/taskRunStorage.ts`

--- a/docs/prd/agent-history-access.md
+++ b/docs/prd/agent-history-access.md
@@ -25,7 +25,9 @@ A new `runs` tool providing read-only virtual filesystem access to execution sto
 
 ```
 /runs                        → List all executions
-/runs/{id}                   → Execution detail (config + conversation)
+/runs/{id}                   → Execution summary (with navigation hints)
+/runs/{id}/config            → Agent configuration (JSON, for propose_*)
+/runs/{id}/conversation      → Message history (tool calls, responses)
 /runs/{id}/files             → List generated files
 /runs/{id}/files/{path}      → Read file content
 ```
@@ -34,11 +36,11 @@ Use `current` as `{id}` to access the active execution.
 
 ### Design Principles
 
-1. **Minimal surface** - 4 path patterns
+1. **Separation of concerns** - Config (structured) vs conversation (log) vs files (artifacts)
 2. **Read-only** - History is immutable, no `command` parameter needed
 3. **Agent-type agnostic** - Works for both tool-use and workflow agents
 4. **Single file** - `src/tools/RunsTool.ts`, no subdirectory
-5. **Config merged into detail** - `/runs/{id}` shows config + conversation together
+5. **Friendly output** - Summary shows what's available, not everything at once
 
 ## Schema
 
@@ -59,7 +61,9 @@ No `command` parameter - it's always "view" (read-only).
 | Path | Source | Returns |
 |------|--------|---------|
 | `/runs` | `AgentHistoryManager.getHistory()` | List: id, timestamp, agent, model, summary |
-| `/runs/{id}` | History + `ExecutionKVStore` | Config + conversation combined |
+| `/runs/{id}` | `AgentHistoryManager` | Summary + navigation hints |
+| `/runs/{id}/config` | `AgentHistoryManager` | `AgentConfig` as JSON |
+| `/runs/{id}/conversation` | `ExecutionKVStore` → `flow:{id}` | `conversation[]` formatted |
 | `/runs/{id}/files` | `StorageFS` → `taskRuns/{id}/` | Directory listing |
 | `/runs/{id}/files/{path}` | `StorageFS` → `taskRuns/{id}/{path}` | File content |
 
@@ -96,21 +100,39 @@ Both agent types store accumulated messages in `shared.conversation[]`. The tool
 ```
 // List past executions
 runs({ path: '/runs' })
-→ abc123  2024-01-15T10:30:00Z  research-assistant  sonnet45  Find related work...
+→ Executions (2):
+
+  abc123  2024-01-15T10:30:00Z  research-assistant  sonnet45  Find related work...
   def456  2024-01-15T11:00:00Z  latex-rewriter      gemini3p  Fix grammar errors...
 
-// View execution detail (config + conversation)
+// View execution summary (friendly, shows what's available)
 runs({ path: '/runs/abc123' })
-→ === Config ===
+→ Execution: abc123
   Agent: research-assistant
   Model: sonnet45
   Timestamp: 2024-01-15T10:30:00Z
   Task: Find related work
-  Tools: read_file, web_search, arxiv_search
 
-  === Conversation ===
+  Available paths:
+    /runs/abc123/config - Agent configuration (JSON)
+    /runs/abc123/conversation - Message history
+    /runs/abc123/files - Generated files
 
-  [1] user:
+// Get config as JSON (for propose_workflow / propose_agent)
+runs({ path: '/runs/abc123/config' })
+→ {
+    "agent": "research-assistant",
+    "model": "sonnet45",
+    "tools": ["read_file", "web_search", "arxiv_search"],
+    "session": {
+      "taskSummary": "Find related work",
+      "inputFiles": ["paper.tex"]
+    }
+  }
+
+// View conversation history
+runs({ path: '/runs/abc123/conversation' })
+→ [1] user:
   Find papers about quantum computing...
 
   [2] assistant:
@@ -137,10 +159,6 @@ runs({ path: '/runs/abc123/files/output.tex' })
 
   \documentclass{article}
   ...
-
-// Access current session
-runs({ path: '/runs/current' })
-→ [current execution detail]
 ```
 
 ## Implementation
@@ -202,7 +220,9 @@ View execution history and generated files (read-only).
 
 Paths:
 - /runs - List all past executions
-- /runs/{id} - Execution detail with config and conversation
+- /runs/{id} - Execution summary
+- /runs/{id}/config - Agent configuration (JSON, use with propose_*)
+- /runs/{id}/conversation - Message history
 - /runs/{id}/files - List generated files
 - /runs/{id}/files/{path} - Read specific file
 
@@ -212,18 +232,14 @@ Use view_range: [start, end] to paginate large outputs.
 
 ## Integration with Agent Proposal Tools
 
-The `/runs/{id}` path shows config + conversation, enabling agents to learn and propose new executions:
+The `/runs/{id}/config` path returns clean JSON, enabling agents to learn and propose new executions:
 
 ### Tool-Use Agent History → Propose New Tool-Use Agent
 
 ```
-// View past execution (config included in output)
-runs({ path: '/runs/abc123' })
-→ === Config ===
-  Agent: search
-  Model: sonnet45
-  Task: Find papers on attention...
-  ...
+// Get past config as JSON
+runs({ path: '/runs/abc123/config' })
+→ { "agent": "search", "model": "sonnet45", ... }
 
 // Propose similar with modifications
 propose_agent({
@@ -236,13 +252,9 @@ propose_agent({
 ### Workflow Agent History → Propose New Workflow
 
 ```
-// View past execution
-runs({ path: '/runs/def456' })
-→ === Config ===
-  Agent: correct
-  Model: sonnet45
-  Input files: paper.tex
-  ...
+// Get past config as JSON
+runs({ path: '/runs/def456/config' })
+→ { "agent": "correct", "model": "sonnet45", "inputFile": "paper.tex", ... }
 
 // Propose similar with modifications
 propose_workflow({
@@ -256,9 +268,9 @@ propose_workflow({
 ### Cross-Type Learning
 
 An orchestrating tool-use agent can:
-1. Review tool-use execution history (what searches worked)
-2. Review workflow execution history (what corrections were applied)
-3. Propose either type based on current needs
+1. List executions: `/runs`
+2. Check what worked: `/runs/{id}/config` + `/runs/{id}/conversation`
+3. Propose new execution with modifications
 
 ## Future Considerations
 

--- a/docs/prd/agent-history-access.md
+++ b/docs/prd/agent-history-access.md
@@ -221,30 +221,50 @@ Paths:
 Use view_range: [start, end] to paginate large outputs.
 ```
 
-## Integration with WorkflowTool
+## Integration with Agent Proposal Tools
 
-The `/runs/{id}/config` path enables a powerful workflow:
+The `/runs/{id}/config` path enables agents to learn from past executions and propose new ones:
 
-1. Agent views past execution config via `runs` tool
-2. Agent proposes modified execution via `propose_workflow` or `propose_agent` tools
+### Tool-Use Agent History → Propose New Tool-Use Agent
 
-Example agent reasoning:
 ```
-// Agent reads past successful config
+// View past tool-use execution
 runs({ command: 'view', path: '/runs/abc123/config' })
-→ { agent: "correct", model: "sonnet45", inputFile: "paper.tex", ... }
+→ { agent: "search", model: "sonnet45", instruction: "Find papers on attention..." }
 
-// Agent proposes similar run with modifications
-propose_workflow({
-  agent: "correct",
-  model: "opus45",  // Upgraded model
-  inputFile: "paper_v2.tex",
-  instruction: "Same corrections as before, plus check citations"
+// Propose similar with modifications
+propose_agent({
+  agent: "search",
+  model: "opus45",
+  instruction: "Find papers on linear attention, focusing on memory efficiency"
 })
 ```
 
+### Workflow Agent History → Propose New Workflow
+
+```
+// View past workflow execution
+runs({ command: 'view', path: '/runs/def456/config' })
+→ { agent: "correct", model: "sonnet45", inputFile: "paper.tex", ... }
+
+// Propose similar with modifications
+propose_workflow({
+  agent: "correct",
+  model: "opus45",
+  inputFile: "paper_v2.tex",
+  instruction: "Same corrections, plus check citations"
+})
+```
+
+### Cross-Type Learning
+
+An orchestrating tool-use agent can:
+1. Review tool-use execution history (what searches worked)
+2. Review workflow execution history (what corrections were applied)
+3. Propose either type based on current needs
+
 This creates a learning loop where agents can:
-- Review what worked before
+- Review what worked before (both types)
 - Understand successful configurations
 - Propose improvements based on history
 

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
               "ask",
               "chat",
               "lean",
+              "orchestrator",
               "research",
               "search"
             ],

--- a/resources/tool_use_agents/orchestrator.yaml
+++ b/resources/tool_use_agents/orchestrator.yaml
@@ -6,6 +6,7 @@ settings:
   tools:
     - propose_workflow
     - propose_agent
+    - runs
     - todo_write
     - read_file
     - write_file
@@ -34,6 +35,8 @@ prompts:
     Once approved, proposals execute asynchronously. You do not wait for completion or receive results directly. Output files are written alongside the input with a model-specific suffix by default, or to custom paths if you specify outputFiles. To review results later, read the output files or check git status for new files.
 
     Delegate liberally rather than trying to do everything yourself. Compute-intensive tasks like long formula derivations, full document corrections, or extensive rewrites belong to specialized agents who can focus deeply. For batch operations across multiple files, propose separate workflows for each so they can be approved and monitored independently. When a task benefits from diverse perspectives, propose the same work to different agents or models to get independent opinions, then synthesize the results yourself. If you encounter multiple versions of notes or drafts that need consolidation, your job is to establish a single source of truth with internal self-consistency, resolving contradictions and merging the best elements.
+
+    Use runs to access execution history. Browse past executions at /runs, view config at /runs/{id}/config, conversation at /runs/{id}/conversation, and generated files at /runs/{id}/files. This helps you learn from what worked before and propose improved configurations.
 
     Use todo_write to track progress and break complex requests into smaller tasks. If this is a git repository, check git log for recent work and look for README or TODO files to understand project goals.
 

--- a/src/tools/RunsTool.ts
+++ b/src/tools/RunsTool.ts
@@ -4,6 +4,7 @@
  */
 
 // Third-party imports
+import * as vscode from 'vscode';
 import { z } from 'zod';
 
 // Local imports - agent
@@ -234,26 +235,15 @@ Use view_range: [start, end] to paginate large outputs.`,
       return { output: '(No conversation history available)' };
     }
 
-    const lines: string[] = [];
-    for (let i = 0; i < conversation.length; i++) {
-      const msg = conversation[i] as { role?: string; content?: unknown };
-      const role = msg.role ?? 'unknown';
-      const content = this.formatMessageContent(msg.content);
-      lines.push(`[${i + 1}] ${role}:`);
-      lines.push(content);
-      lines.push('');
-    }
+    const messages = conversation.map((msg, i) => {
+      const m = msg as { role?: string; content?: unknown };
+      const role = m.role ?? 'unknown';
+      const content = this.formatMessageContent(m.content);
+      return `<message index="${i + 1}" role="${role}">\n${content}\n</message>`;
+    });
 
-    let output = lines.join('\n');
-
-    // Apply view_range if specified
-    if (viewRange) {
-      const outputLines = output.split('\n');
-      const [start, end] = viewRange;
-      const startIdx = Math.max(start - 1, 0);
-      const endIdx = Math.min(end, outputLines.length);
-      output = outputLines.slice(startIdx, endIdx).join('\n');
-    }
+    const header = `Conversation (${conversation.length} messages):\n\n`;
+    const output = this.applyViewRange(header + messages.join('\n\n'), viewRange);
 
     return { output };
   }
@@ -329,7 +319,7 @@ Use view_range: [start, end] to paginate large outputs.`,
       for (const [name, type] of entries) {
         const entryRelative = relativePath ? `${relativePath}/${name}` : name;
         const entryFull = `${basePath}/${entryRelative}`;
-        const isDir = type === 2; // vscode.FileType.Directory
+        const isDir = type === vscode.FileType.Directory;
 
         try {
           const stats = await StorageFS.stat(entryFull);
@@ -365,24 +355,17 @@ Use view_range: [start, end] to paginate large outputs.`,
     }
 
     const stats = await StorageFS.stat(fullPath);
-    if (stats.type === 2) { // Directory
+    if (stats.type === vscode.FileType.Directory) {
       throw new ToolError(`Path is a directory: /runs/${executionId}/files/${filePath}. Use without trailing path to list.`);
     }
 
-    let content = await StorageFS.read(fullPath);
+    const content = await StorageFS.read(fullPath);
+    const output = this.applyViewRange(
+      `File: /runs/${executionId}/files/${filePath}\n\n${content}`,
+      viewRange,
+    );
 
-    // Apply view_range if specified
-    if (viewRange) {
-      const lines = content.split('\n');
-      const [start, end] = viewRange;
-      const startIdx = Math.max(start - 1, 0);
-      const endIdx = Math.min(end, lines.length);
-      content = lines.slice(startIdx, endIdx).join('\n');
-    }
-
-    return {
-      output: `File: /runs/${executionId}/files/${filePath}\n\n${content}`,
-    };
+    return { output };
   }
 
   /**
@@ -392,5 +375,15 @@ Use view_range: [start, end] to paginate large outputs.`,
     if (bytes < 1024) return `${bytes}B`;
     if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)}K`;
     return `${(bytes / (1024 * 1024)).toFixed(1)}M`;
+  }
+
+  /**
+   * Apply view_range to output string (line-based pagination).
+   */
+  private applyViewRange(output: string, viewRange?: [number, number]): string {
+    if (!viewRange) return output;
+    const lines = output.split('\n');
+    const [start, end] = viewRange;
+    return lines.slice(Math.max(start - 1, 0), Math.min(end, lines.length)).join('\n');
   }
 }

--- a/src/tools/RunsTool.ts
+++ b/src/tools/RunsTool.ts
@@ -134,7 +134,7 @@ Use view_range: [start, end] to paginate large outputs.`,
   }
 
   /**
-   * List all executions from history.
+   * List all executions from history (most recent first).
    */
   private async listRuns(): Promise<ToolResult> {
     const history = await AgentHistoryManager.getHistory();
@@ -147,12 +147,14 @@ Use view_range: [start, end] to paginate large outputs.`,
       const agent = item.agentConfig.agent;
       const model = item.agentConfig.model ?? 'unknown';
       const summary = item.agentConfig.session?.taskSummary ?? '';
-      const shortSummary = summary.length > 50 ? summary.slice(0, 47) + '...' : summary;
-      return `${item.id}  ${item.timestamp}  ${agent}  ${model}  ${shortSummary}`;
+      const shortSummary = summary.length > 40 ? summary.slice(0, 37) + '...' : summary;
+      // Format timestamp: extract date and time
+      const ts = item.timestamp.replace('T', ' ').replace(/\.\d+Z$/, '');
+      return `${item.id}  ${ts}  ${agent}  ${model}  ${shortSummary}`;
     });
 
     return {
-      output: `Executions (${history.length}):\n\n${lines.join('\n')}`,
+      output: `Executions (${history.length}, most recent first):\n\n${lines.join('\n')}`,
     };
   }
 

--- a/src/tools/RunsTool.ts
+++ b/src/tools/RunsTool.ts
@@ -1,0 +1,351 @@
+/**
+ * Tool for viewing execution history and generated files.
+ * Read-only access to past runs - agents can learn from history.
+ */
+
+// Third-party imports
+import { z } from 'zod';
+
+// Local imports - agent
+import { getExecutionStore } from '@agent/storage/ExecutionKVStore';
+import { getCurrentToolFileInteractionContext } from '@agent/toolUse/ToolFileInteractionContext';
+import type { ExecutionId } from '@agent/types/IdentifierTypes';
+
+// Local imports - common
+import { AgentHistoryManager } from '@common/history';
+
+// Local imports - tools
+import { defineTool } from './core/define';
+import { ToolError, type ToolResult } from './result';
+
+// Local imports - utils
+import { StorageFS } from '@utils/files';
+import { TASK_RUNS_DIR } from '@utils/files/taskRunStorage';
+import { getPathSegments } from '@utils/core/pathCore';
+
+// ============================================================================
+// Schema
+// ============================================================================
+
+const RunsToolInputSchema = z.strictObject({
+  /** Virtual path: /runs, /runs/{id}, /runs/{id}/files, /runs/{id}/files/{path} */
+  path: z.string().describe('Path starting with /runs'),
+
+  /** Optional line range [start, end] for large outputs */
+  view_range: z
+    .array(z.int().min(1))
+    .length(2)
+    .refine(([start, end]) => end >= start, {
+      message: 'view_range[1] must be >= view_range[0]',
+    })
+    .nullish(),
+});
+
+export type RunsToolInput = z.infer<typeof RunsToolInputSchema>;
+
+// ============================================================================
+// Tool Implementation
+// ============================================================================
+
+/**
+ * Read-only tool for viewing execution history and generated files.
+ *
+ * Paths:
+ * - /runs - List all past executions
+ * - /runs/{id} - Execution detail (config + conversation)
+ * - /runs/{id}/files - List generated files
+ * - /runs/{id}/files/{path} - Read specific file
+ */
+export class RunsTool extends defineTool({
+  name: 'runs',
+  description: `View execution history and generated files (read-only).
+
+Paths:
+- /runs - List all past executions
+- /runs/{id} - Execution detail with config and conversation
+- /runs/{id}/files - List generated files
+- /runs/{id}/files/{path} - Read specific file
+
+Use "current" as {id} to access the active execution.
+Use view_range: [start, end] to paginate large outputs.`,
+  schema: RunsToolInputSchema,
+}) {
+  protected async execute(input: RunsToolInput): Promise<ToolResult> {
+    const segments = getPathSegments(input.path);
+    const [namespace, id, resource, ...rest] = segments;
+
+    if (namespace !== 'runs') {
+      throw new ToolError(
+        `Path must start with /runs. Got: ${input.path}`,
+      );
+    }
+
+    // /runs - list all executions
+    if (!id) {
+      return this.listRuns();
+    }
+
+    const executionId = this.resolveExecutionId(id);
+
+    // /runs/{id} - execution detail
+    if (!resource) {
+      return this.showExecution(executionId, input.view_range ?? undefined);
+    }
+
+    // /runs/{id}/files or /runs/{id}/files/{path}
+    if (resource === 'files') {
+      if (rest.length === 0) {
+        return this.listFiles(executionId);
+      }
+      return this.readFile(executionId, rest.join('/'), input.view_range ?? undefined);
+    }
+
+    throw new ToolError(
+      `Unknown path: ${input.path}. Expected /runs, /runs/{id}, /runs/{id}/files, or /runs/{id}/files/{path}`,
+    );
+  }
+
+  /**
+   * Resolve "current" to active execution ID, or return as-is.
+   */
+  private resolveExecutionId(id: string): ExecutionId {
+    if (id === 'current') {
+      const ctx = getCurrentToolFileInteractionContext();
+      if (!ctx?.executionId) {
+        throw new ToolError('No active execution. Use a specific execution ID instead of "current".');
+      }
+      return ctx.executionId;
+    }
+    return id as ExecutionId;
+  }
+
+  /**
+   * List all executions from history.
+   */
+  private async listRuns(): Promise<ToolResult> {
+    const history = await AgentHistoryManager.getHistory();
+
+    if (history.length === 0) {
+      return { output: 'No execution history found.' };
+    }
+
+    const lines = history.map((item) => {
+      const agent = item.agentConfig.agent;
+      const model = item.agentConfig.model ?? 'unknown';
+      const summary = item.agentConfig.session?.taskSummary ?? '';
+      const shortSummary = summary.length > 50 ? summary.slice(0, 47) + '...' : summary;
+      return `${item.id}  ${item.timestamp}  ${agent}  ${model}  ${shortSummary}`;
+    });
+
+    return {
+      output: `Executions (${history.length}):\n\n${lines.join('\n')}`,
+    };
+  }
+
+  /**
+   * Show execution detail: config + conversation history.
+   */
+  private async showExecution(
+    executionId: ExecutionId,
+    viewRange?: [number, number],
+  ): Promise<ToolResult> {
+    // Get metadata from history
+    const historyItem = await AgentHistoryManager.getHistoryItemById(executionId);
+
+    // Get flow record from KV store
+    const store = getExecutionStore(executionId);
+    const flow = await store.read<{ shared?: { conversation?: unknown[] } }>(`flow:${executionId}`);
+
+    if (!historyItem && !flow) {
+      throw new ToolError(`Execution not found: ${executionId}`);
+    }
+
+    const lines: string[] = [];
+
+    // Header with config
+    if (historyItem) {
+      const config = historyItem.agentConfig;
+      lines.push('=== Config ===');
+      lines.push(`Agent: ${config.agent}`);
+      lines.push(`Model: ${config.model ?? 'default'}`);
+      lines.push(`Timestamp: ${historyItem.timestamp}`);
+      if (config.session?.taskSummary) {
+        lines.push(`Task: ${config.session.taskSummary}`);
+      }
+      if (config.session?.inputFiles?.length) {
+        lines.push(`Input files: ${config.session.inputFiles.join(', ')}`);
+      }
+      if (config.tools?.length) {
+        lines.push(`Tools: ${config.tools.map(t => typeof t === 'string' ? t : t.name).join(', ')}`);
+      }
+      lines.push('');
+    }
+
+    // Conversation history
+    const conversation = flow?.shared?.conversation;
+    if (Array.isArray(conversation) && conversation.length > 0) {
+      lines.push('=== Conversation ===');
+      lines.push('');
+
+      for (let i = 0; i < conversation.length; i++) {
+        const msg = conversation[i] as { role?: string; content?: unknown };
+        const role = msg.role ?? 'unknown';
+        const content = this.formatMessageContent(msg.content);
+        lines.push(`[${i + 1}] ${role}:`);
+        lines.push(content);
+        lines.push('');
+      }
+    } else {
+      lines.push('(No conversation history available)');
+    }
+
+    let output = lines.join('\n');
+
+    // Apply view_range if specified
+    if (viewRange) {
+      const outputLines = output.split('\n');
+      const [start, end] = viewRange;
+      const startIdx = Math.max(start - 1, 0);
+      const endIdx = Math.min(end, outputLines.length);
+      output = outputLines.slice(startIdx, endIdx).join('\n');
+    }
+
+    return { output };
+  }
+
+  /**
+   * Format message content for display.
+   */
+  private formatMessageContent(content: unknown): string {
+    if (typeof content === 'string') {
+      return content.length > 500 ? content.slice(0, 497) + '...' : content;
+    }
+    if (Array.isArray(content)) {
+      // Handle content blocks (text, tool_use, tool_result)
+      return content.map((block) => {
+        if (typeof block === 'string') return block;
+        if (block?.type === 'text') return block.text ?? '';
+        if (block?.type === 'tool_use') {
+          const input = JSON.stringify(block.input ?? {});
+          const shortInput = input.length > 100 ? input.slice(0, 97) + '...' : input;
+          return `[tool_use: ${block.name}(${shortInput})]`;
+        }
+        if (block?.type === 'tool_result') {
+          const output = typeof block.content === 'string' ? block.content : JSON.stringify(block.content);
+          const shortOutput = output.length > 100 ? output.slice(0, 97) + '...' : output;
+          return `[tool_result: ${shortOutput}]`;
+        }
+        return JSON.stringify(block).slice(0, 100);
+      }).join('\n');
+    }
+    return JSON.stringify(content).slice(0, 500);
+  }
+
+  /**
+   * List files in task run directory.
+   */
+  private async listFiles(executionId: ExecutionId): Promise<ToolResult> {
+    const runDir = `${TASK_RUNS_DIR}/${executionId}`;
+
+    if (!await StorageFS.exists(runDir)) {
+      return { output: 'No files generated for this execution.' };
+    }
+
+    const entries = await this.walkDirectory(runDir, '', 2);
+
+    if (entries.length === 0) {
+      return { output: 'No files generated for this execution.' };
+    }
+
+    const lines = entries.map(({ path: p, size, isDir }) => {
+      const sizeStr = isDir ? '<dir>' : this.formatSize(size);
+      return `${sizeStr.padStart(8)}  ${p}`;
+    });
+
+    return {
+      output: `Files in /runs/${executionId}/files:\n\n${lines.join('\n')}`,
+    };
+  }
+
+  /**
+   * Walk directory up to maxDepth levels.
+   */
+  private async walkDirectory(
+    basePath: string,
+    relativePath: string,
+    maxDepth: number,
+  ): Promise<Array<{ path: string; size: number; isDir: boolean }>> {
+    const results: Array<{ path: string; size: number; isDir: boolean }> = [];
+    const fullPath = relativePath ? `${basePath}/${relativePath}` : basePath;
+
+    try {
+      const entries = await StorageFS.readDir(fullPath);
+
+      for (const [name, type] of entries) {
+        const entryRelative = relativePath ? `${relativePath}/${name}` : name;
+        const entryFull = `${basePath}/${entryRelative}`;
+        const isDir = type === 2; // vscode.FileType.Directory
+
+        try {
+          const stats = await StorageFS.stat(entryFull);
+          results.push({ path: entryRelative, size: stats.size, isDir });
+
+          if (isDir && maxDepth > 1) {
+            const children = await this.walkDirectory(basePath, entryRelative, maxDepth - 1);
+            results.push(...children);
+          }
+        } catch {
+          // Skip entries we can't stat
+        }
+      }
+    } catch {
+      // Directory doesn't exist or can't be read
+    }
+
+    return results;
+  }
+
+  /**
+   * Read a specific file from task run storage.
+   */
+  private async readFile(
+    executionId: ExecutionId,
+    filePath: string,
+    viewRange?: [number, number],
+  ): Promise<ToolResult> {
+    const fullPath = `${TASK_RUNS_DIR}/${executionId}/${filePath}`;
+
+    if (!await StorageFS.exists(fullPath)) {
+      throw new ToolError(`File not found: /runs/${executionId}/files/${filePath}`);
+    }
+
+    const stats = await StorageFS.stat(fullPath);
+    if (stats.type === 2) { // Directory
+      throw new ToolError(`Path is a directory: /runs/${executionId}/files/${filePath}. Use without trailing path to list.`);
+    }
+
+    let content = await StorageFS.read(fullPath);
+
+    // Apply view_range if specified
+    if (viewRange) {
+      const lines = content.split('\n');
+      const [start, end] = viewRange;
+      const startIdx = Math.max(start - 1, 0);
+      const endIdx = Math.min(end, lines.length);
+      content = lines.slice(startIdx, endIdx).join('\n');
+    }
+
+    return {
+      output: `File: /runs/${executionId}/files/${filePath}\n\n${content}`,
+    };
+  }
+
+  /**
+   * Format bytes to human-readable size.
+   */
+  private formatSize(bytes: number): string {
+    if (bytes < 1024) return `${bytes}B`;
+    if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)}K`;
+    return `${(bytes / (1024 * 1024)).toFixed(1)}M`;
+  }
+}

--- a/src/tools/RunsTool.ts
+++ b/src/tools/RunsTool.ts
@@ -52,7 +52,9 @@ export type RunsToolInput = z.infer<typeof RunsToolInputSchema>;
  *
  * Paths:
  * - /runs - List all past executions
- * - /runs/{id} - Execution detail (config + conversation)
+ * - /runs/{id} - Execution summary
+ * - /runs/{id}/config - Agent configuration (JSON)
+ * - /runs/{id}/conversation - Message history
  * - /runs/{id}/files - List generated files
  * - /runs/{id}/files/{path} - Read specific file
  */
@@ -62,7 +64,9 @@ export class RunsTool extends defineTool({
 
 Paths:
 - /runs - List all past executions
-- /runs/{id} - Execution detail with config and conversation
+- /runs/{id} - Execution summary (agent, model, timestamp)
+- /runs/{id}/config - Agent configuration JSON (for propose_workflow/propose_agent)
+- /runs/{id}/conversation - Full message history
 - /runs/{id}/files - List generated files
 - /runs/{id}/files/{path} - Read specific file
 
@@ -87,9 +91,19 @@ Use view_range: [start, end] to paginate large outputs.`,
 
     const executionId = this.resolveExecutionId(id);
 
-    // /runs/{id} - execution detail
+    // /runs/{id} - execution summary
     if (!resource) {
-      return this.showExecution(executionId, input.view_range ?? undefined);
+      return this.showSummary(executionId);
+    }
+
+    // /runs/{id}/config - agent configuration
+    if (resource === 'config') {
+      return this.showConfig(executionId);
+    }
+
+    // /runs/{id}/conversation - message history
+    if (resource === 'conversation') {
+      return this.showConversation(executionId, input.view_range ?? undefined);
     }
 
     // /runs/{id}/files or /runs/{id}/files/{path}
@@ -101,7 +115,7 @@ Use view_range: [start, end] to paginate large outputs.`,
     }
 
     throw new ToolError(
-      `Unknown path: ${input.path}. Expected /runs, /runs/{id}, /runs/{id}/files, or /runs/{id}/files/{path}`,
+      `Unknown path: ${input.path}. Valid: /runs/{id}, /runs/{id}/config, /runs/{id}/conversation, /runs/{id}/files`,
     );
   }
 
@@ -143,60 +157,89 @@ Use view_range: [start, end] to paginate large outputs.`,
   }
 
   /**
-   * Show execution detail: config + conversation history.
+   * Show execution summary (brief metadata).
    */
-  private async showExecution(
+  private async showSummary(executionId: ExecutionId): Promise<ToolResult> {
+    const historyItem = await AgentHistoryManager.getHistoryItemById(executionId);
+
+    if (!historyItem) {
+      // Check if flow exists even without history entry
+      const store = getExecutionStore(executionId);
+      const flow = await store.read(`flow:${executionId}`);
+      if (!flow) {
+        throw new ToolError(`Execution not found: ${executionId}`);
+      }
+      return {
+        output: `Execution: ${executionId}\n(No metadata available - use /runs/${executionId}/conversation to view messages)`,
+      };
+    }
+
+    const config = historyItem.agentConfig;
+    const lines = [
+      `Execution: ${executionId}`,
+      `Agent: ${config.agent}`,
+      `Model: ${config.model ?? 'default'}`,
+      `Timestamp: ${historyItem.timestamp}`,
+    ];
+
+    if (config.session?.taskSummary) {
+      lines.push(`Task: ${config.session.taskSummary}`);
+    }
+
+    lines.push('');
+    lines.push('Available paths:');
+    lines.push(`  /runs/${executionId}/config - Agent configuration (JSON)`);
+    lines.push(`  /runs/${executionId}/conversation - Message history`);
+    lines.push(`  /runs/${executionId}/files - Generated files`);
+
+    return { output: lines.join('\n') };
+  }
+
+  /**
+   * Show agent configuration as JSON.
+   */
+  private async showConfig(executionId: ExecutionId): Promise<ToolResult> {
+    const historyItem = await AgentHistoryManager.getHistoryItemById(executionId);
+
+    if (!historyItem) {
+      throw new ToolError(
+        `Config not found for execution: ${executionId}. Config is only available for executions in history.`,
+      );
+    }
+
+    const config = historyItem.agentConfig;
+    return {
+      output: JSON.stringify(config, null, 2),
+    };
+  }
+
+  /**
+   * Show conversation/message history.
+   */
+  private async showConversation(
     executionId: ExecutionId,
     viewRange?: [number, number],
   ): Promise<ToolResult> {
-    // Get metadata from history
-    const historyItem = await AgentHistoryManager.getHistoryItemById(executionId);
-
-    // Get flow record from KV store
     const store = getExecutionStore(executionId);
     const flow = await store.read<{ shared?: { conversation?: unknown[] } }>(`flow:${executionId}`);
 
-    if (!historyItem && !flow) {
+    if (!flow) {
       throw new ToolError(`Execution not found: ${executionId}`);
     }
 
-    const lines: string[] = [];
-
-    // Header with config
-    if (historyItem) {
-      const config = historyItem.agentConfig;
-      lines.push('=== Config ===');
-      lines.push(`Agent: ${config.agent}`);
-      lines.push(`Model: ${config.model ?? 'default'}`);
-      lines.push(`Timestamp: ${historyItem.timestamp}`);
-      if (config.session?.taskSummary) {
-        lines.push(`Task: ${config.session.taskSummary}`);
-      }
-      if (config.session?.inputFiles?.length) {
-        lines.push(`Input files: ${config.session.inputFiles.join(', ')}`);
-      }
-      if (config.tools?.length) {
-        lines.push(`Tools: ${config.tools.map(t => typeof t === 'string' ? t : t.name).join(', ')}`);
-      }
-      lines.push('');
+    const conversation = flow?.shared?.conversation;
+    if (!Array.isArray(conversation) || conversation.length === 0) {
+      return { output: '(No conversation history available)' };
     }
 
-    // Conversation history
-    const conversation = flow?.shared?.conversation;
-    if (Array.isArray(conversation) && conversation.length > 0) {
-      lines.push('=== Conversation ===');
+    const lines: string[] = [];
+    for (let i = 0; i < conversation.length; i++) {
+      const msg = conversation[i] as { role?: string; content?: unknown };
+      const role = msg.role ?? 'unknown';
+      const content = this.formatMessageContent(msg.content);
+      lines.push(`[${i + 1}] ${role}:`);
+      lines.push(content);
       lines.push('');
-
-      for (let i = 0; i < conversation.length; i++) {
-        const msg = conversation[i] as { role?: string; content?: unknown };
-        const role = msg.role ?? 'unknown';
-        const content = this.formatMessageContent(msg.content);
-        lines.push(`[${i + 1}] ${role}:`);
-        lines.push(content);
-        lines.push('');
-      }
-    } else {
-      lines.push('(No conversation history available)');
     }
 
     let output = lines.join('\n');

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -40,6 +40,7 @@ import {
   LeanLoogleTool,
 } from './lean';
 import { WorkflowAgentTool, DelegateAgentTool } from './WorkflowTool';
+import { RunsTool } from './RunsTool';
 
 /** Singleton IToolRegistry instance for the default tools. */
 let defaultRegistryInstance: IToolRegistry | null = null;
@@ -83,6 +84,7 @@ export function getDefaultToolRegistry(): IToolRegistry {
       lean_loogle: new LeanLoogleTool(),
       propose_workflow: new WorkflowAgentTool(),
       propose_agent: new DelegateAgentTool(),
+      runs: new RunsTool(),
     });
   }
   return defaultRegistryInstance;


### PR DESCRIPTION
Design document for giving tool-use agents read-only access to:
- Execution history (past conversations, tool calls)
- Agent configurations (for proposing new runs)
- Generated files from task runs

Follows minimal 5-path design pattern mirroring /memories tool.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a read-only virtual filesystem for execution history accessible to tool-use agents.
> 
> - **New tool:** `src/tools/RunsTool.ts` providing `/runs`, `/runs/{id}`, `/runs/{id}/config`, `/runs/{id}/conversation`, `/runs/{id}/files[/path]` with optional `view_range` pagination and support for `current` execution
> - **Integration:** Registered in `src/tools/registry.ts`; added to `resources/tool_use_agents/orchestrator.yaml` tool list and prompt; `package.json` default tool-use agents updated to include `orchestrator`
> - **Docs:** PRD added at `docs/prd/agent-history-access.md` describing schema, paths, storage sources, and usage
> 
> Scope/Risk: New isolated tool + registry wiring; existing storage utilities reused (read-only), minimal impact to existing code paths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 155a3706ddf3cda307920cb3bb102d922a45495e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->