### PR TITLE
Simplify and improve code clarity

### DIFF
--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -456,11 +456,8 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
       return;
     }
 
-    const resolvedRunId = this.provider.state.resolveRunId(stream, undefined, {
-      persist: false,
-    });
-    // Only fetch output files if we have a resolved run ID
-    const storageKey = resolvedRunId ? (resolvedRunId as StorageKey) : null;
+    // Use cached activeRunId (set by event handlers when data arrives)
+    const storageKey = this.provider.state.getActiveRunId(stream);
     const runOutputs = storageKey
       ? this.provider.state.getRunOutputFiles(stream, { storageKey })
       : undefined;
@@ -648,15 +645,10 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     taskState: WorkflowTaskState,
     command: 'texra.pack' | 'texra.clean',
   ): Promise<void> {
-    const resolvedRunId = this.provider.state.resolveRunId(stream, undefined, {
-      persist: false,
-    });
+    const storageKey = this.provider.state.getActiveRunId(stream);
     const generatedPaths = this.provider.state.outputFiles.getKnownFilePaths(
       stream,
-      {
-        storageKey: resolvedRunId ? (resolvedRunId as StorageKey) : null,
-        workspaceOnly: true,
-      },
+      { storageKey, workspaceOnly: true },
     );
 
     // Collect all output files from declared config and generated paths
@@ -931,9 +923,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
       return null;
     }
 
-    const storageKey = this.provider.state.resolveRunId(streamId, undefined, {
-      persist: false,
-    }) as StorageKey | null;
+    const storageKey = this.provider.state.getActiveRunId(streamId);
     const runOutputs = storageKey
       ? this.provider.state.getRunOutputFiles(streamId, { storageKey })
       : null;

--- a/src/progressView/events/EventHandlerContext.ts
+++ b/src/progressView/events/EventHandlerContext.ts
@@ -3,6 +3,18 @@
  *
  * Provides access to state, webview updater, and common utilities
  * without creating circular dependencies.
+ *
+ * ## Multi-Agent Architecture: "Backend broadcasts, Frontend decides"
+ *
+ * For run-scoped data (usage, outputs, todos, instructions), use `isWebviewAvailable()`
+ * to broadcast updates to the frontend regardless of which run is "active". The frontend
+ * decides what to display based on user focus.
+ *
+ * For stream-level operations (like clearing all content), use `canUpdateWebview()`
+ * which checks both webview availability AND active stream.
+ *
+ * This design supports concurrent subagents - each run receives updates independently,
+ * and the frontend can display multiple runs simultaneously in the future.
  */
 import type { StreamTabId } from '@agent/types/IdentifierTypes';
 import type { WebviewUpdater } from '@progressView/managers';
@@ -21,7 +33,16 @@ export interface EventHandlerContext {
 
 /**
  * Check if webview is available (regardless of active stream).
- * Use for events that should always be sent when webview is visible.
+ *
+ * Use for run-scoped data that should always be broadcast:
+ * - Usage statistics (per-run)
+ * - Output files (per-run)
+ * - Missing outputs (per-run)
+ * - Todos (per-run)
+ * - Log messages (append - messages persist across stream switches)
+ *
+ * This enables multi-agent support where concurrent runs can all update
+ * the webview, and the frontend decides what to display.
  */
 export function isWebviewAvailable(ctx: EventHandlerContext): boolean {
   return ctx.webviewUpdater.isAvailable();
@@ -40,11 +61,13 @@ export function isActiveStream(
 
 /**
  * Check if webview is available and the stream is active.
- * Common guard for event handlers that should only update the webview
- * when it's visible and showing the relevant stream.
  *
- * For multi-agent scenarios, consider using isWebviewAvailable() and
- * isActiveStream() separately to handle non-active stream updates.
+ * Use for stream-level operations that affect the entire display:
+ * - Log message updates (modifying existing messages in current view)
+ * - Stream metadata changes
+ *
+ * NOT for run-scoped data - use isWebviewAvailable() instead to support
+ * multi-agent scenarios where concurrent runs should all receive updates.
  */
 export function canUpdateWebview(
   ctx: EventHandlerContext,

--- a/src/progressView/events/EventHandlerContext.ts
+++ b/src/progressView/events/EventHandlerContext.ts
@@ -52,20 +52,3 @@ export function canUpdateWebview(
 ): boolean {
   return isWebviewAvailable(ctx) && isActiveStream(ctx, stream);
 }
-
-/**
- * Determine update strategy for a stream event.
- * Returns 'immediate' for active stream, 'buffer' for background streams,
- * or 'skip' if webview is unavailable.
- *
- * This enables proper multi-agent support by distinguishing between:
- * - Active stream: immediate webview updates
- * - Background streams: buffer for later replay
- */
-export function getUpdateStrategy(
-  ctx: EventHandlerContext,
-  stream: StreamTabId,
-): 'immediate' | 'buffer' | 'skip' {
-  if (!isWebviewAvailable(ctx)) return 'skip';
-  return isActiveStream(ctx, stream) ? 'immediate' : 'buffer';
-}

--- a/src/progressView/events/EventHandlerContext.ts
+++ b/src/progressView/events/EventHandlerContext.ts
@@ -20,13 +20,52 @@ export interface EventHandlerContext {
 }
 
 /**
+ * Check if webview is available (regardless of active stream).
+ * Use for events that should always be sent when webview is visible.
+ */
+export function isWebviewAvailable(ctx: EventHandlerContext): boolean {
+  return ctx.webviewUpdater.isAvailable();
+}
+
+/**
+ * Check if the stream is the currently active stream.
+ * Use to determine if immediate UI updates should occur.
+ */
+export function isActiveStream(
+  ctx: EventHandlerContext,
+  stream: StreamTabId,
+): boolean {
+  return stream === ctx.state.activeStream;
+}
+
+/**
  * Check if webview is available and the stream is active.
  * Common guard for event handlers that should only update the webview
  * when it's visible and showing the relevant stream.
+ *
+ * For multi-agent scenarios, consider using isWebviewAvailable() and
+ * isActiveStream() separately to handle non-active stream updates.
  */
 export function canUpdateWebview(
   ctx: EventHandlerContext,
   stream: StreamTabId,
 ): boolean {
-  return ctx.webviewUpdater.isAvailable() && stream === ctx.state.activeStream;
+  return isWebviewAvailable(ctx) && isActiveStream(ctx, stream);
+}
+
+/**
+ * Determine update strategy for a stream event.
+ * Returns 'immediate' for active stream, 'buffer' for background streams,
+ * or 'skip' if webview is unavailable.
+ *
+ * This enables proper multi-agent support by distinguishing between:
+ * - Active stream: immediate webview updates
+ * - Background streams: buffer for later replay
+ */
+export function getUpdateStrategy(
+  ctx: EventHandlerContext,
+  stream: StreamTabId,
+): 'immediate' | 'buffer' | 'skip' {
+  if (!isWebviewAvailable(ctx)) return 'skip';
+  return isActiveStream(ctx, stream) ? 'immediate' : 'buffer';
 }

--- a/src/progressView/events/LogEventHandlers.ts
+++ b/src/progressView/events/LogEventHandlers.ts
@@ -23,11 +23,9 @@ export function registerLogEventHandlers(
   ctx: EventHandlerContext,
   signal: AbortSignal,
 ): void {
-  bus.on(
-    'addLogMessage',
-    (payload) => handleAddLogMessage(ctx, payload),
-    { signal },
-  );
+  bus.on('addLogMessage', (payload) => handleAddLogMessage(ctx, payload), {
+    signal,
+  });
   bus.on(
     'updateLogMessage',
     (payload) => handleUpdateLogMessage(ctx, payload),
@@ -39,42 +37,57 @@ function handleAddLogMessage(
   ctx: EventHandlerContext,
   { stream, logMessage }: ProgressEventPayloads['addLogMessage'],
 ): void {
-  withEventErrorHandling('LogEvents', 'failed to handle addLogMessage', async () => {
-    const isNew = await ctx.state.streamTabs.addMessage(stream, logMessage);
-    // Send to webview if available (regardless of active stream - messages persist)
-    if (isNew && isWebviewAvailable(ctx)) {
-      ctx.webviewUpdater.appendLogMessage(stream, logMessage);
-    }
-  });
+  withEventErrorHandling(
+    'LogEvents',
+    'failed to handle addLogMessage',
+    async () => {
+      const isNew = await ctx.state.streamTabs.addMessage(stream, logMessage);
+      // Send to webview if available (regardless of active stream - messages persist)
+      if (isNew && isWebviewAvailable(ctx)) {
+        ctx.webviewUpdater.appendLogMessage(stream, logMessage);
+      }
+    },
+  );
 }
 
 function handleUpdateLogMessage(
   ctx: EventHandlerContext,
   { stream, logMessage }: ProgressEventPayloads['updateLogMessage'],
 ): void {
-  withEventErrorHandling('LogEvents', 'failed to handle updateLogMessage', () => {
-    if (!ctx.state.streamTabs.has(stream)) return;
+  withEventErrorHandling(
+    'LogEvents',
+    'failed to handle updateLogMessage',
+    () => {
+      if (!ctx.state.streamTabs.has(stream)) return;
 
-    // Check if message exists and get its type for INTERNAL filtering
-    const messages = ctx.state.streamTabs.getMessages(stream);
-    const existing = messages.find((m) => m.id === logMessage.id);
-    if (!existing) return;
+      // Check if message exists and get its type for INTERNAL filtering
+      const messages = ctx.state.streamTabs.getMessages(stream);
+      const existing = messages.find((m) => m.id === logMessage.id);
+      if (!existing) return;
 
-    // Skip INTERNAL message updates (either existing or incoming)
-    if (
-      existing.messageType === MESSAGE_TYPES.INTERNAL ||
-      logMessage.messageType === MESSAGE_TYPES.INTERNAL
-    ) {
-      return;
-    }
+      // Skip INTERNAL message updates (either existing or incoming)
+      if (
+        existing.messageType === MESSAGE_TYPES.INTERNAL ||
+        logMessage.messageType === MESSAGE_TYPES.INTERNAL
+      ) {
+        return;
+      }
 
-    // Update via proper encapsulated method (no direct mutation)
-    const { id: _id, ...updates } = logMessage;
-    const updated = ctx.state.streamTabs.updateMessage(stream, logMessage.id, updates);
+      // Update via proper encapsulated method (no direct mutation)
+      const { id: _id, ...updates } = logMessage;
+      const updated = ctx.state.streamTabs.updateMessage(
+        stream,
+        logMessage.id,
+        updates,
+      );
 
-    if (updated && canUpdateWebview(ctx, stream)) {
-      // Send merged update to webview
-      ctx.webviewUpdater.updateLogMessage(stream, { ...existing, ...updates });
-    }
-  });
+      if (updated && canUpdateWebview(ctx, stream)) {
+        // Send merged update to webview
+        ctx.webviewUpdater.updateLogMessage(stream, {
+          ...existing,
+          ...updates,
+        });
+      }
+    },
+  );
 }

--- a/src/progressView/events/LogEventHandlers.ts
+++ b/src/progressView/events/LogEventHandlers.ts
@@ -61,7 +61,10 @@ function handleUpdateLogMessage(
       // Skip INTERNAL messages entirely (never shown to users)
       if (logMessage.messageType === MESSAGE_TYPES.INTERNAL) return;
 
-      // Find existing message (also verifies stream exists via empty array return)
+      // Guard: don't create phantom streams for updates to non-existent streams
+      if (!ctx.state.streamTabs.has(stream)) return;
+
+      // Find existing message
       const messages = ctx.state.streamTabs.getMessages(stream);
       const existing = messages.find((m) => m.id === logMessage.id);
       if (!existing || existing.messageType === MESSAGE_TYPES.INTERNAL) return;

--- a/src/progressView/events/LogEventHandlers.ts
+++ b/src/progressView/events/LogEventHandlers.ts
@@ -58,22 +58,15 @@ function handleUpdateLogMessage(
     'LogEvents',
     'failed to handle updateLogMessage',
     () => {
-      if (!ctx.state.streamTabs.has(stream)) return;
+      // Skip INTERNAL messages entirely (never shown to users)
+      if (logMessage.messageType === MESSAGE_TYPES.INTERNAL) return;
 
-      // Check if message exists and get its type for INTERNAL filtering
+      // Find existing message (also verifies stream exists via empty array return)
       const messages = ctx.state.streamTabs.getMessages(stream);
       const existing = messages.find((m) => m.id === logMessage.id);
-      if (!existing) return;
+      if (!existing || existing.messageType === MESSAGE_TYPES.INTERNAL) return;
 
-      // Skip INTERNAL message updates (either existing or incoming)
-      if (
-        existing.messageType === MESSAGE_TYPES.INTERNAL ||
-        logMessage.messageType === MESSAGE_TYPES.INTERNAL
-      ) {
-        return;
-      }
-
-      // Update via proper encapsulated method (no direct mutation)
+      // Update state and notify webview
       const { id: _id, ...updates } = logMessage;
       const updated = ctx.state.streamTabs.updateMessage(
         stream,
@@ -82,7 +75,6 @@ function handleUpdateLogMessage(
       );
 
       if (updated && canUpdateWebview(ctx, stream)) {
-        // Send merged update to webview
         ctx.webviewUpdater.updateLogMessage(stream, {
           ...existing,
           ...updates,

--- a/src/progressView/events/LogEventHandlers.ts
+++ b/src/progressView/events/LogEventHandlers.ts
@@ -11,74 +11,69 @@ import type {
 import { withEventErrorHandling } from './errorHandling';
 import {
   canUpdateWebview,
+  isWebviewAvailable,
   type EventHandlerContext,
 } from './EventHandlerContext';
 
 /**
  * Register log event handlers on the event bus.
- *
- * @param bus - Progress event bus
- * @param ctx - Event handler context with state and webview updater
- * @param signal - AbortController signal for cleanup
  */
 export function registerLogEventHandlers(
   bus: ProgressEventBusLike,
   ctx: EventHandlerContext,
   signal: AbortSignal,
 ): void {
-  bus.on('addLogMessage', handleAddLogMessage(ctx), { signal });
-  bus.on('updateLogMessage', handleUpdateLogMessage(ctx), { signal });
+  bus.on(
+    'addLogMessage',
+    (payload) => handleAddLogMessage(ctx, payload),
+    { signal },
+  );
+  bus.on(
+    'updateLogMessage',
+    (payload) => handleUpdateLogMessage(ctx, payload),
+    { signal },
+  );
 }
 
-function handleAddLogMessage(ctx: EventHandlerContext) {
-  return ({
-    stream,
-    logMessage,
-  }: ProgressEventPayloads['addLogMessage']): void => {
-    withEventErrorHandling(
-      'LogEvents',
-      'failed to handle addLogMessage',
-      async () => {
-        const isNew = await ctx.state.streamTabs.addMessage(stream, logMessage);
-        if (isNew && ctx.webviewUpdater.isAvailable()) {
-          ctx.webviewUpdater.appendLogMessage(stream, logMessage);
-        }
-      },
-    );
-  };
+function handleAddLogMessage(
+  ctx: EventHandlerContext,
+  { stream, logMessage }: ProgressEventPayloads['addLogMessage'],
+): void {
+  withEventErrorHandling('LogEvents', 'failed to handle addLogMessage', async () => {
+    const isNew = await ctx.state.streamTabs.addMessage(stream, logMessage);
+    // Send to webview if available (regardless of active stream - messages persist)
+    if (isNew && isWebviewAvailable(ctx)) {
+      ctx.webviewUpdater.appendLogMessage(stream, logMessage);
+    }
+  });
 }
 
-function handleUpdateLogMessage(ctx: EventHandlerContext) {
-  return ({
-    stream,
-    logMessage,
-  }: ProgressEventPayloads['updateLogMessage']): void => {
-    withEventErrorHandling(
-      'LogEvents',
-      'failed to handle updateLogMessage',
-      async () => {
-        if (!ctx.state.streamTabs.has(stream)) return;
+function handleUpdateLogMessage(
+  ctx: EventHandlerContext,
+  { stream, logMessage }: ProgressEventPayloads['updateLogMessage'],
+): void {
+  withEventErrorHandling('LogEvents', 'failed to handle updateLogMessage', async () => {
+    if (!ctx.state.streamTabs.has(stream)) return;
 
-        const messages = ctx.state.streamTabs.getMessages(stream);
-        const existing = messages.find((m) => m.id === logMessage.id);
-        if (!existing) return;
+    const messages = ctx.state.streamTabs.getMessages(stream);
+    const existing = messages.find((m) => m.id === logMessage.id);
+    if (!existing) return;
 
-        // Skip INTERNAL message updates (either existing or incoming)
-        const isInternalUpdate =
-          existing.messageType === MESSAGE_TYPES.INTERNAL ||
-          logMessage.messageType === MESSAGE_TYPES.INTERNAL;
-        if (isInternalUpdate) return;
+    // Skip INTERNAL message updates (either existing or incoming)
+    if (
+      existing.messageType === MESSAGE_TYPES.INTERNAL ||
+      logMessage.messageType === MESSAGE_TYPES.INTERNAL
+    ) {
+      return;
+    }
 
-        // Update fields from logMessage, preserving existing values for undefined fields
-        const { id: _id, ...updates } = logMessage;
-        Object.assign(existing, updates);
+    // Update fields, preserving existing values for undefined fields
+    const { id: _id, ...updates } = logMessage;
+    Object.assign(existing, updates);
+    await ctx.state.streamTabs.save();
 
-        await ctx.state.streamTabs.save();
-
-        if (canUpdateWebview(ctx, stream)) {
-          ctx.webviewUpdater.updateLogMessage(stream, existing);
-        }
-      },
-    );
-  };
+    if (canUpdateWebview(ctx, stream)) {
+      ctx.webviewUpdater.updateLogMessage(stream, existing);
+    }
+  });
 }

--- a/src/progressView/events/LogEventHandlers.ts
+++ b/src/progressView/events/LogEventHandlers.ts
@@ -52,9 +52,10 @@ function handleUpdateLogMessage(
   ctx: EventHandlerContext,
   { stream, logMessage }: ProgressEventPayloads['updateLogMessage'],
 ): void {
-  withEventErrorHandling('LogEvents', 'failed to handle updateLogMessage', async () => {
+  withEventErrorHandling('LogEvents', 'failed to handle updateLogMessage', () => {
     if (!ctx.state.streamTabs.has(stream)) return;
 
+    // Check if message exists and get its type for INTERNAL filtering
     const messages = ctx.state.streamTabs.getMessages(stream);
     const existing = messages.find((m) => m.id === logMessage.id);
     if (!existing) return;
@@ -67,13 +68,13 @@ function handleUpdateLogMessage(
       return;
     }
 
-    // Update fields, preserving existing values for undefined fields
+    // Update via proper encapsulated method (no direct mutation)
     const { id: _id, ...updates } = logMessage;
-    Object.assign(existing, updates);
-    await ctx.state.streamTabs.save();
+    const updated = ctx.state.streamTabs.updateMessage(stream, logMessage.id, updates);
 
-    if (canUpdateWebview(ctx, stream)) {
-      ctx.webviewUpdater.updateLogMessage(stream, existing);
+    if (updated && canUpdateWebview(ctx, stream)) {
+      // Send merged update to webview
+      ctx.webviewUpdater.updateLogMessage(stream, { ...existing, ...updates });
     }
   });
 }

--- a/src/progressView/events/OutputEventHandlers.ts
+++ b/src/progressView/events/OutputEventHandlers.ts
@@ -9,7 +9,6 @@ import type {
 } from '@eventBus/ProgressEventBus';
 import { withEventErrorHandling } from './errorHandling';
 import {
-  canUpdateWebview,
   isWebviewAvailable,
   type EventHandlerContext,
 } from './EventHandlerContext';
@@ -105,7 +104,8 @@ function handleClearMissingOutputs(
     'failed to handle clearMissingOutputs',
     async () => {
       await ctx.state.outputFiles.clearMissingOutputs(stream);
-      if (canUpdateWebview(ctx, stream)) {
+      // Broadcast to webview - frontend decides which run to display
+      if (isWebviewAvailable(ctx)) {
         ctx.webviewUpdater.updateMissingOutputs(stream, { reset: true });
       }
     },

--- a/src/progressView/events/OutputEventHandlers.ts
+++ b/src/progressView/events/OutputEventHandlers.ts
@@ -10,24 +10,33 @@ import type {
 import { withEventErrorHandling } from './errorHandling';
 import {
   canUpdateWebview,
+  isWebviewAvailable,
   type EventHandlerContext,
 } from './EventHandlerContext';
 
 /**
  * Register output event handlers on the event bus.
- *
- * @param bus - Progress event bus
- * @param ctx - Event handler context with state and webview updater
- * @param signal - AbortController signal for cleanup
  */
 export function registerOutputEventHandlers(
   bus: ProgressEventBusLike,
   ctx: EventHandlerContext,
   signal: AbortSignal,
 ): void {
-  bus.on('addOutputFiles', handleAddOutputFiles(ctx), { signal });
-  bus.on('updateMissingOutputs', handleUpdateMissingOutputs(ctx), { signal });
-  bus.on('clearMissingOutputs', handleClearMissingOutputs(ctx), { signal });
+  bus.on(
+    'addOutputFiles',
+    (payload) => handleAddOutputFiles(ctx, payload),
+    { signal },
+  );
+  bus.on(
+    'updateMissingOutputs',
+    (payload) => handleUpdateMissingOutputs(ctx, payload),
+    { signal },
+  );
+  bus.on(
+    'clearMissingOutputs',
+    (payload) => handleClearMissingOutputs(ctx, payload),
+    { signal },
+  );
 }
 
 /** Convert Map<number, T[]> to Record<number, T[]> for webview */
@@ -37,71 +46,48 @@ function toRoundRecord<T>(
   return rounds?.size ? Object.fromEntries(rounds) : undefined;
 }
 
-function handleAddOutputFiles(ctx: EventHandlerContext) {
-  return ({
-    stream,
-    storageKey,
-    filesByRound,
-  }: ProgressEventPayloads['addOutputFiles']): void => {
-    withEventErrorHandling(
-      'OutputEvents',
-      'failed to handle addOutputFiles',
-      async () => {
-        await ctx.state.outputFiles.addFiles(stream, storageKey, filesByRound);
-        if (!ctx.webviewUpdater.isAvailable()) return;
+function handleAddOutputFiles(
+  ctx: EventHandlerContext,
+  { stream, storageKey, filesByRound }: ProgressEventPayloads['addOutputFiles'],
+): void {
+  withEventErrorHandling('OutputEvents', 'failed to handle addOutputFiles', async () => {
+    await ctx.state.outputFiles.addFiles(stream, storageKey, filesByRound);
+    if (!isWebviewAvailable(ctx)) return;
 
-        const runFiles = ctx.state.outputFiles.getFiles(stream).get(storageKey);
-        const rounds = toRoundRecord(runFiles);
-        ctx.webviewUpdater.updateFiles(stream, {
-          runId: storageKey,
-          ...(rounds && { rounds }),
-        });
-      },
-    );
-  };
+    const runFiles = ctx.state.outputFiles.getFiles(stream).get(storageKey);
+    const rounds = toRoundRecord(runFiles);
+    ctx.webviewUpdater.updateFiles(stream, {
+      runId: storageKey,
+      ...(rounds && { rounds }),
+    });
+  });
 }
 
-function handleUpdateMissingOutputs(ctx: EventHandlerContext) {
-  return ({
-    stream,
-    storageKey,
-    filesByRound,
-  }: ProgressEventPayloads['updateMissingOutputs']): void => {
-    withEventErrorHandling(
-      'OutputEvents',
-      'failed to handle updateMissingOutputs',
-      async () => {
-        await ctx.state.outputFiles.updateMissingOutputs(
-          stream,
-          storageKey,
-          filesByRound,
-        );
-        if (!ctx.webviewUpdater.isAvailable()) return;
+function handleUpdateMissingOutputs(
+  ctx: EventHandlerContext,
+  { stream, storageKey, filesByRound }: ProgressEventPayloads['updateMissingOutputs'],
+): void {
+  withEventErrorHandling('OutputEvents', 'failed to handle updateMissingOutputs', async () => {
+    await ctx.state.outputFiles.updateMissingOutputs(stream, storageKey, filesByRound);
+    if (!isWebviewAvailable(ctx)) return;
 
-        const runMissing = ctx.state.outputFiles
-          .getMissingOutputs(stream)
-          .get(storageKey);
-        const rounds = toRoundRecord(runMissing);
-        ctx.webviewUpdater.updateMissingOutputs(stream, {
-          runId: storageKey,
-          ...(rounds && { rounds }),
-        });
-      },
-    );
-  };
+    const runMissing = ctx.state.outputFiles.getMissingOutputs(stream).get(storageKey);
+    const rounds = toRoundRecord(runMissing);
+    ctx.webviewUpdater.updateMissingOutputs(stream, {
+      runId: storageKey,
+      ...(rounds && { rounds }),
+    });
+  });
 }
 
-function handleClearMissingOutputs(ctx: EventHandlerContext) {
-  return ({ stream }: ProgressEventPayloads['clearMissingOutputs']): void => {
-    withEventErrorHandling(
-      'OutputEvents',
-      'failed to handle clearMissingOutputs',
-      async () => {
-        await ctx.state.outputFiles.clearMissingOutputs(stream);
-        if (canUpdateWebview(ctx, stream)) {
-          ctx.webviewUpdater.updateMissingOutputs(stream, { reset: true });
-        }
-      },
-    );
-  };
+function handleClearMissingOutputs(
+  ctx: EventHandlerContext,
+  { stream }: ProgressEventPayloads['clearMissingOutputs'],
+): void {
+  withEventErrorHandling('OutputEvents', 'failed to handle clearMissingOutputs', async () => {
+    await ctx.state.outputFiles.clearMissingOutputs(stream);
+    if (canUpdateWebview(ctx, stream)) {
+      ctx.webviewUpdater.updateMissingOutputs(stream, { reset: true });
+    }
+  });
 }

--- a/src/progressView/events/OutputEventHandlers.ts
+++ b/src/progressView/events/OutputEventHandlers.ts
@@ -36,13 +36,6 @@ export function registerOutputEventHandlers(
   );
 }
 
-/** Convert Map<number, T[]> to Record<number, T[]> for webview */
-function toRoundRecord<T>(
-  rounds?: Map<number, T[]>,
-): Record<number, T[]> | undefined {
-  return rounds?.size ? Object.fromEntries(rounds) : undefined;
-}
-
 function handleAddOutputFiles(
   ctx: EventHandlerContext,
   { stream, storageKey, filesByRound }: ProgressEventPayloads['addOutputFiles'],
@@ -55,11 +48,8 @@ function handleAddOutputFiles(
       if (!isWebviewAvailable(ctx)) return;
 
       const runFiles = ctx.state.outputFiles.getFiles(stream).get(storageKey);
-      const rounds = toRoundRecord(runFiles);
-      ctx.webviewUpdater.updateFiles(stream, {
-        runId: storageKey,
-        ...(rounds && { rounds }),
-      });
+      const rounds = runFiles?.size ? Object.fromEntries(runFiles) : undefined;
+      ctx.webviewUpdater.updateFiles(stream, { runId: storageKey, rounds });
     },
   );
 }
@@ -86,10 +76,12 @@ function handleUpdateMissingOutputs(
       const runMissing = ctx.state.outputFiles
         .getMissingOutputs(stream)
         .get(storageKey);
-      const rounds = toRoundRecord(runMissing);
+      const rounds = runMissing?.size
+        ? Object.fromEntries(runMissing)
+        : undefined;
       ctx.webviewUpdater.updateMissingOutputs(stream, {
         runId: storageKey,
-        ...(rounds && { rounds }),
+        rounds,
       });
     },
   );

--- a/src/progressView/events/OutputEventHandlers.ts
+++ b/src/progressView/events/OutputEventHandlers.ts
@@ -22,11 +22,9 @@ export function registerOutputEventHandlers(
   ctx: EventHandlerContext,
   signal: AbortSignal,
 ): void {
-  bus.on(
-    'addOutputFiles',
-    (payload) => handleAddOutputFiles(ctx, payload),
-    { signal },
-  );
+  bus.on('addOutputFiles', (payload) => handleAddOutputFiles(ctx, payload), {
+    signal,
+  });
   bus.on(
     'updateMissingOutputs',
     (payload) => handleUpdateMissingOutputs(ctx, payload),
@@ -50,44 +48,66 @@ function handleAddOutputFiles(
   ctx: EventHandlerContext,
   { stream, storageKey, filesByRound }: ProgressEventPayloads['addOutputFiles'],
 ): void {
-  withEventErrorHandling('OutputEvents', 'failed to handle addOutputFiles', async () => {
-    await ctx.state.outputFiles.addFiles(stream, storageKey, filesByRound);
-    if (!isWebviewAvailable(ctx)) return;
+  withEventErrorHandling(
+    'OutputEvents',
+    'failed to handle addOutputFiles',
+    async () => {
+      await ctx.state.outputFiles.addFiles(stream, storageKey, filesByRound);
+      if (!isWebviewAvailable(ctx)) return;
 
-    const runFiles = ctx.state.outputFiles.getFiles(stream).get(storageKey);
-    const rounds = toRoundRecord(runFiles);
-    ctx.webviewUpdater.updateFiles(stream, {
-      runId: storageKey,
-      ...(rounds && { rounds }),
-    });
-  });
+      const runFiles = ctx.state.outputFiles.getFiles(stream).get(storageKey);
+      const rounds = toRoundRecord(runFiles);
+      ctx.webviewUpdater.updateFiles(stream, {
+        runId: storageKey,
+        ...(rounds && { rounds }),
+      });
+    },
+  );
 }
 
 function handleUpdateMissingOutputs(
   ctx: EventHandlerContext,
-  { stream, storageKey, filesByRound }: ProgressEventPayloads['updateMissingOutputs'],
+  {
+    stream,
+    storageKey,
+    filesByRound,
+  }: ProgressEventPayloads['updateMissingOutputs'],
 ): void {
-  withEventErrorHandling('OutputEvents', 'failed to handle updateMissingOutputs', async () => {
-    await ctx.state.outputFiles.updateMissingOutputs(stream, storageKey, filesByRound);
-    if (!isWebviewAvailable(ctx)) return;
+  withEventErrorHandling(
+    'OutputEvents',
+    'failed to handle updateMissingOutputs',
+    async () => {
+      await ctx.state.outputFiles.updateMissingOutputs(
+        stream,
+        storageKey,
+        filesByRound,
+      );
+      if (!isWebviewAvailable(ctx)) return;
 
-    const runMissing = ctx.state.outputFiles.getMissingOutputs(stream).get(storageKey);
-    const rounds = toRoundRecord(runMissing);
-    ctx.webviewUpdater.updateMissingOutputs(stream, {
-      runId: storageKey,
-      ...(rounds && { rounds }),
-    });
-  });
+      const runMissing = ctx.state.outputFiles
+        .getMissingOutputs(stream)
+        .get(storageKey);
+      const rounds = toRoundRecord(runMissing);
+      ctx.webviewUpdater.updateMissingOutputs(stream, {
+        runId: storageKey,
+        ...(rounds && { rounds }),
+      });
+    },
+  );
 }
 
 function handleClearMissingOutputs(
   ctx: EventHandlerContext,
   { stream }: ProgressEventPayloads['clearMissingOutputs'],
 ): void {
-  withEventErrorHandling('OutputEvents', 'failed to handle clearMissingOutputs', async () => {
-    await ctx.state.outputFiles.clearMissingOutputs(stream);
-    if (canUpdateWebview(ctx, stream)) {
-      ctx.webviewUpdater.updateMissingOutputs(stream, { reset: true });
-    }
-  });
+  withEventErrorHandling(
+    'OutputEvents',
+    'failed to handle clearMissingOutputs',
+    async () => {
+      await ctx.state.outputFiles.clearMissingOutputs(stream);
+      if (canUpdateWebview(ctx, stream)) {
+        ctx.webviewUpdater.updateMissingOutputs(stream, { reset: true });
+      }
+    },
+  );
 }

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -142,21 +142,13 @@ export class ProgressEventHandler {
     this.state.activeStream = stream;
     this.replayPendingTaskGroups(stream);
 
-    // Get current status without defaulting to RUNNING.
-    // Status should only be set to RUNNING by setupFlowUIState in executeAgent,
-    // not here. Defaulting to RUNNING here causes a race condition.
-    const status = StreamStatusService.get(stream);
-
     if (!this.webviewUpdater.isAvailable()) return;
 
-    // Update webview with stream data
+    // Update stream tabs list (required to set activeStream in frontend)
     this.webviewUpdater.updateAll(this.state, StreamStatusService.getAll());
 
-    if (status !== undefined) {
-      this.setStreamStatus(stream, status);
-    }
-
-    // Refresh stream surface and instruction panel
+    // Refresh stream content (logs, groups, metadata, status, todos)
+    // Note: refreshStreamSurface includes status update, so no separate setStreamStatus needed
     const activeRunId = this.refreshStreamSurface(stream, {
       updateInstruction: false,
     });
@@ -189,6 +181,13 @@ export class ProgressEventHandler {
         const isActiveStream = this.state.activeStream === streamTabId;
         const sessionKind = taskState.agentConfig.session.agentCategory;
 
+        // Check if filter needs updating BEFORE setting state (affects stream visibility)
+        const previousFilter = this.state.agentTypeFilter;
+        const filterMightChange =
+          isActiveStream &&
+          previousFilter !== 'all' &&
+          previousFilter !== sessionKind;
+
         this.state.setTaskState(streamTabId, taskState);
 
         if (isActiveStream) {
@@ -203,11 +202,16 @@ export class ProgressEventHandler {
           this.sendInstructionUpdate(streamTabId);
         }
 
+        // Only send full stream update if filter changed (affects visible streams)
+        // or if webview needs the updated task state metadata
         if (this.webviewUpdater.isAvailable()) {
-          this.webviewUpdater.updateAll(
-            this.state,
-            StreamStatusService.getAll(),
-          );
+          const filterChanged = this.state.agentTypeFilter !== previousFilter;
+          if (filterChanged || filterMightChange) {
+            this.webviewUpdater.updateAll(
+              this.state,
+              StreamStatusService.getAll(),
+            );
+          }
         }
       },
     );
@@ -364,7 +368,9 @@ export class ProgressEventHandler {
       this.state.runInstructions.getInstructions(stream).entries(),
     );
     const runFiles = nestedMapToRecord(this.state.outputFiles.getFiles(stream));
-    const missingByRun = nestedMapToRecord(this.state.outputFiles.getMissingOutputs(stream));
+    const runMissingOutputs = nestedMapToRecord(
+      this.state.outputFiles.getMissingOutputs(stream),
+    ) as Record<string, { [key: number]: string[] }>;
     const runUsage = Object.fromEntries(
       this.state.usageStats.getRunUsage(stream).entries(),
     ) as Record<string, TokenUsageStats>;
@@ -375,17 +381,15 @@ export class ProgressEventHandler {
     // Clear buffer before update to prevent race condition
     this.pendingTaskGroups.delete(stream);
 
-    // Send primary content update
+    // Send primary content update (includes all run-scoped data in single message)
     this.webviewUpdater.updateLogContent(stream, messages, groups, {
       runInstructions,
       activeRunId,
       runUsage,
       runFiles,
+      runMissingOutputs,
       contextState,
     });
-
-    // Send missing outputs (reset + incremental)
-    this.sendMissingOutputs(stream, missingByRun);
 
     // Send ephemeral state
     this.webviewUpdater.updateTodos(stream, todos);
@@ -409,22 +413,6 @@ export class ProgressEventHandler {
     this.webviewUpdater.updateStatus(STREAM_STATUS.READY);
     if (clearInstruction) {
       this.webviewUpdater.updateInstruction('', null);
-    }
-  }
-
-  /**
-   * Send missing outputs with reset followed by incremental updates.
-   */
-  private sendMissingOutputs(
-    stream: string,
-    missingByRun: ReturnType<typeof nestedMapToRecord>,
-  ): void {
-    this.webviewUpdater.updateMissingOutputs(stream, { reset: true });
-    for (const [runId, rounds] of Object.entries(missingByRun)) {
-      this.webviewUpdater.updateMissingOutputs(stream, {
-        runId,
-        rounds: rounds as { [key: number]: string[] },
-      });
     }
   }
 

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -314,13 +314,9 @@ export class ProgressEventHandler {
     // Persist instruction if both runId and instruction exist
     if (runId) {
       if (instructionUpdate) {
-        void this.state.runInstructions.setInstruction(
-          stream,
-          runId,
-          instructionUpdate,
-        );
+        void this.state.setRunInstruction(stream, runId, instructionUpdate);
       } else {
-        void this.state.runInstructions.deleteRun(stream, runId);
+        void this.state.deleteRunInstruction(stream, runId);
       }
     }
 
@@ -362,7 +358,7 @@ export class ProgressEventHandler {
     const activeRunId = this.state.getActiveRunId(stream);
 
     const runInstructions = Object.fromEntries(
-      this.state.runInstructions.getInstructions(stream).entries(),
+      this.state.getRunInstructions(stream).entries(),
     );
     const runFiles = nestedMapToRecord(this.state.outputFiles.getFiles(stream));
     const runMissingOutputs = nestedMapToRecord(

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -179,13 +179,7 @@ export class ProgressEventHandler {
         const { streamTabId, executionId, taskState } = data;
         const isActiveStream = this.state.activeStream === streamTabId;
         const sessionKind = taskState.agentConfig.session.agentCategory;
-
-        // Check if filter needs updating BEFORE setting state (affects stream visibility)
         const previousFilter = this.state.agentTypeFilter;
-        const filterMightChange =
-          isActiveStream &&
-          previousFilter !== 'all' &&
-          previousFilter !== sessionKind;
 
         this.state.setTaskState(streamTabId, taskState);
 
@@ -201,11 +195,12 @@ export class ProgressEventHandler {
           this.sendInstructionUpdate(streamTabId);
         }
 
-        // Only send full stream update if filter changed (affects visible streams)
-        // or if webview needs the updated task state metadata
+        // Update stream tabs when:
+        // 1. Filter changed (affects visible streams)
+        // 2. Active stream's task state changed (label needs inputFile, agent, etc.)
         if (this.webviewUpdater.isAvailable()) {
           const filterChanged = this.state.agentTypeFilter !== previousFilter;
-          if (filterChanged || filterMightChange) {
+          if (filterChanged || isActiveStream) {
             this.webviewUpdater.updateAll(
               this.state,
               StreamStatusService.getAll(),

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -33,6 +33,7 @@ import { withEventErrorHandling } from './errorHandling';
 // Re-export for consumers
 export type { UICallbacks };
 
+
 /**
  * Handles progress event bus subscriptions for the progress view.
  * Provides a clean separation between event handling and business logic
@@ -348,81 +349,46 @@ export class ProgressEventHandler {
 
     const { updateInstruction = true } = options;
 
+    // Handle empty stream (clear all content)
     if (!stream) {
-      // No active stream: explicitly clear content with action: 'clear'.
-      // This is an intentional clear (e.g., stream deleted, no streams left).
-      this.webviewUpdater.updateLogContent('', [], [], undefined, 'clear');
-      this.webviewUpdater.updateFiles('', { reset: true });
-      this.webviewUpdater.updateMissingOutputs('', { reset: true });
-      this.webviewUpdater.updateUsage('', {});
-      this.webviewUpdater.updateStatus(STREAM_STATUS.READY);
-      if (updateInstruction) {
-        this.webviewUpdater.updateInstruction('', null);
-      }
+      this.clearStreamSurface(updateInstruction);
       return null;
     }
 
+    // Collect stream data
     const messages = this.state.streamTabs.getMessages(stream);
     const groups = [...this.state.taskGroups.getStreamGroups(stream).values()];
-    const activeRunId = this.state.resolveRunId(stream, undefined, {
-      persist: false,
-    });
+    const activeRunId = this.state.resolveRunId(stream, undefined, { persist: false });
 
     const runInstructions = Object.fromEntries(
       this.state.runInstructions.getInstructions(stream).entries(),
     );
-
-    const filesByRun = nestedMapToRecord(
-      this.state.outputFiles.getFiles(stream),
-    );
-    const missingByRun = nestedMapToRecord(
-      this.state.outputFiles.getMissingOutputs(stream),
-    );
-    const usageByRun = Object.fromEntries(
+    const runFiles = nestedMapToRecord(this.state.outputFiles.getFiles(stream));
+    const missingByRun = nestedMapToRecord(this.state.outputFiles.getMissingOutputs(stream));
+    const runUsage = Object.fromEntries(
       this.state.usageStats.getRunUsage(stream).entries(),
     ) as Record<string, TokenUsageStats>;
+    const contextState = this.state.getContextState(stream);
+    const todos = this.state.getTodos(stream) ?? [];
+    const status = StreamStatusService.get(stream) ?? STREAM_STATUS.READY;
 
-    // Clear pending task groups buffer BEFORE update to prevent race condition.
-    // If new groups arrive during updateLogContent, they'll be buffered fresh.
-    // Groups already in state will be sent via updateLogContent.
+    // Clear buffer before update to prevent race condition
     this.pendingTaskGroups.delete(stream);
 
-    // Get context state for this stream (ephemeral - not persisted)
-    const contextState = this.state.getContextState(stream);
-
-    // Send data with action: 'render' (default).
-    // Frontend detects stream switch by comparing stream with lastRenderedStream.
+    // Send primary content update
     this.webviewUpdater.updateLogContent(stream, messages, groups, {
       runInstructions,
       activeRunId,
-      runUsage: usageByRun,
-      runFiles: filesByRun,
+      runUsage,
+      runFiles,
       contextState,
     });
 
-    // Note: Files are already included in UPDATE_LOGS (runFiles) and handled
-    // by handleUpdateLogs in the frontend. We don't send separate UPDATE_FILES
-    // messages here to avoid a race condition where reset: true would clear
-    // the files just populated from UPDATE_LOGS.
+    // Send missing outputs (reset + incremental)
+    this.sendMissingOutputs(stream, missingByRun);
 
-    // Reset and send all missing outputs in sequence
-    this.webviewUpdater.updateMissingOutputs(stream, { reset: true });
-    for (const [runId, rounds] of Object.entries(missingByRun)) {
-      this.webviewUpdater.updateMissingOutputs(stream, { runId, rounds });
-    }
-
-    // Refresh todos for the stream (ephemeral state)
-    // Always send update (empty array if undefined) to clear stale UI from previous stream
-    const todos = this.state.getTodos(stream) ?? [];
+    // Send ephemeral state
     this.webviewUpdater.updateTodos(stream, todos);
-
-    // Context state is already included in updateLogContent above (via contextState field)
-    // No separate UPDATE_CONTEXT_STATE message needed here
-
-    // Update status for current stream. Don't default to RUNNING - that causes a race
-    // condition where the "already running" check in executeAgent fails. Let setupFlowUIState
-    // be the only place that sets RUNNING. Use READY as fallback for uninitialized streams.
-    const status = StreamStatusService.get(stream) ?? STREAM_STATUS.READY;
     this.webviewUpdater.updateStatus(status);
 
     if (updateInstruction) {
@@ -430,6 +396,36 @@ export class ProgressEventHandler {
     }
 
     return activeRunId;
+  }
+
+  /**
+   * Clear all webview content when no stream is active.
+   */
+  private clearStreamSurface(clearInstruction: boolean): void {
+    this.webviewUpdater.updateLogContent('', [], [], undefined, 'clear');
+    this.webviewUpdater.updateFiles('', { reset: true });
+    this.webviewUpdater.updateMissingOutputs('', { reset: true });
+    this.webviewUpdater.updateUsage('', {});
+    this.webviewUpdater.updateStatus(STREAM_STATUS.READY);
+    if (clearInstruction) {
+      this.webviewUpdater.updateInstruction('', null);
+    }
+  }
+
+  /**
+   * Send missing outputs with reset followed by incremental updates.
+   */
+  private sendMissingOutputs(
+    stream: string,
+    missingByRun: ReturnType<typeof nestedMapToRecord>,
+  ): void {
+    this.webviewUpdater.updateMissingOutputs(stream, { reset: true });
+    for (const [runId, rounds] of Object.entries(missingByRun)) {
+      this.webviewUpdater.updateMissingOutputs(stream, {
+        runId,
+        rounds: rounds as { [key: number]: string[] },
+      });
+    }
   }
 
   /**

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -33,7 +33,6 @@ import { withEventErrorHandling } from './errorHandling';
 // Re-export for consumers
 export type { UICallbacks };
 
-
 /**
  * Handles progress event bus subscriptions for the progress view.
  * Provides a clean separation between event handling and business logic
@@ -309,7 +308,8 @@ export class ProgressEventHandler {
     const sessionKind = this.getStreamCategory(stream);
 
     // Use provided runId or read cached activeRunId (no expensive resolution)
-    const runId = runIdHint === undefined ? this.state.getActiveRunId(stream) : runIdHint;
+    const runId =
+      runIdHint === undefined ? this.state.getActiveRunId(stream) : runIdHint;
 
     // Persist instruction if both runId and instruction exist
     if (runId) {

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -308,11 +308,8 @@ export class ProgressEventHandler {
     const instructionUpdate = WebviewUpdater.createInstructionUpdate(taskState);
     const sessionKind = this.getStreamCategory(stream);
 
-    // Resolve runId: auto-resolve if undefined, use provided value otherwise
-    const runId =
-      runIdHint === undefined
-        ? this.state.resolveRunId(stream, undefined, { persist: false })
-        : runIdHint;
+    // Use provided runId or read cached activeRunId (no expensive resolution)
+    const runId = runIdHint === undefined ? this.state.getActiveRunId(stream) : runIdHint;
 
     // Persist instruction if both runId and instruction exist
     if (runId) {
@@ -359,10 +356,10 @@ export class ProgressEventHandler {
       return null;
     }
 
-    // Collect stream data
+    // Collect stream data (activeRunId is already set by event handlers when data arrives)
     const messages = this.state.streamTabs.getMessages(stream);
     const groups = [...this.state.taskGroups.getStreamGroups(stream).values()];
-    const activeRunId = this.state.resolveRunId(stream, undefined, { persist: false });
+    const activeRunId = this.state.getActiveRunId(stream);
 
     const runInstructions = Object.fromEntries(
       this.state.runInstructions.getInstructions(stream).entries(),
@@ -404,12 +401,13 @@ export class ProgressEventHandler {
 
   /**
    * Clear all webview content when no stream is active.
+   *
+   * Note: updateLogContent with action='clear' triggers the frontend to clear
+   * all run-scoped state (files, missing outputs, usage). No separate reset
+   * messages needed - the frontend handles this in its full rebuild path.
    */
   private clearStreamSurface(clearInstruction: boolean): void {
     this.webviewUpdater.updateLogContent('', [], [], undefined, 'clear');
-    this.webviewUpdater.updateFiles('', { reset: true });
-    this.webviewUpdater.updateMissingOutputs('', { reset: true });
-    this.webviewUpdater.updateUsage('', {});
     this.webviewUpdater.updateStatus(STREAM_STATUS.READY);
     if (clearInstruction) {
       this.webviewUpdater.updateInstruction('', null);

--- a/src/progressView/events/TodoEventHandlers.ts
+++ b/src/progressView/events/TodoEventHandlers.ts
@@ -15,26 +15,27 @@ import {
 
 /**
  * Register todo event handlers on the event bus.
- *
- * @param bus - Progress event bus
- * @param ctx - Event handler context with state and webview updater
- * @param signal - AbortController signal for cleanup
  */
 export function registerTodoEventHandlers(
   bus: ProgressEventBusLike,
   ctx: EventHandlerContext,
   signal: AbortSignal,
 ): void {
-  bus.on('updateTodos', handleUpdateTodos(ctx), { signal });
+  bus.on(
+    'updateTodos',
+    (payload) => handleUpdateTodos(ctx, payload),
+    { signal },
+  );
 }
 
-function handleUpdateTodos(ctx: EventHandlerContext) {
-  return ({ stream, todos }: ProgressEventPayloads['updateTodos']): void => {
-    withEventErrorHandling('TodoEvents', 'failed to handle updateTodos', () => {
-      ctx.state.setTodos(stream, todos);
-      if (canUpdateWebview(ctx, stream)) {
-        ctx.webviewUpdater.updateTodos(stream, todos);
-      }
-    });
-  };
+function handleUpdateTodos(
+  ctx: EventHandlerContext,
+  { stream, todos }: ProgressEventPayloads['updateTodos'],
+): void {
+  withEventErrorHandling('TodoEvents', 'failed to handle updateTodos', () => {
+    ctx.state.setTodos(stream, todos);
+    if (canUpdateWebview(ctx, stream)) {
+      ctx.webviewUpdater.updateTodos(stream, todos);
+    }
+  });
 }

--- a/src/progressView/events/TodoEventHandlers.ts
+++ b/src/progressView/events/TodoEventHandlers.ts
@@ -9,7 +9,7 @@ import type {
 } from '@eventBus/ProgressEventBus';
 import { withEventErrorHandling } from './errorHandling';
 import {
-  canUpdateWebview,
+  isWebviewAvailable,
   type EventHandlerContext,
 } from './EventHandlerContext';
 
@@ -32,7 +32,8 @@ function handleUpdateTodos(
 ): void {
   withEventErrorHandling('TodoEvents', 'failed to handle updateTodos', () => {
     ctx.state.setTodos(stream, todos);
-    if (canUpdateWebview(ctx, stream)) {
+    // Broadcast to webview - frontend decides which run to display
+    if (isWebviewAvailable(ctx)) {
       ctx.webviewUpdater.updateTodos(stream, todos);
     }
   });

--- a/src/progressView/events/TodoEventHandlers.ts
+++ b/src/progressView/events/TodoEventHandlers.ts
@@ -21,11 +21,9 @@ export function registerTodoEventHandlers(
   ctx: EventHandlerContext,
   signal: AbortSignal,
 ): void {
-  bus.on(
-    'updateTodos',
-    (payload) => handleUpdateTodos(ctx, payload),
-    { signal },
-  );
+  bus.on('updateTodos', (payload) => handleUpdateTodos(ctx, payload), {
+    signal,
+  });
 }
 
 function handleUpdateTodos(

--- a/src/progressView/events/UsageEventHandlers.ts
+++ b/src/progressView/events/UsageEventHandlers.ts
@@ -16,83 +16,63 @@ import {
 
 /**
  * Register usage event handlers on the event bus.
- *
- * @param bus - Progress event bus
- * @param ctx - Event handler context with state and webview updater
- * @param signal - AbortController signal for cleanup
  */
 export function registerUsageEventHandlers(
   bus: ProgressEventBusLike,
   ctx: EventHandlerContext,
   signal: AbortSignal,
 ): void {
-  bus.on('updateStreamUsage', handleUpdateStreamUsage(ctx), { signal });
-  bus.on('updateContextState', handleUpdateContextState(ctx), { signal });
+  bus.on(
+    'updateStreamUsage',
+    (payload) => handleUpdateStreamUsage(ctx, payload),
+    { signal },
+  );
+  bus.on(
+    'updateContextState',
+    (payload) => handleUpdateContextState(ctx, payload),
+    { signal },
+  );
 }
 
-function handleUpdateStreamUsage(ctx: EventHandlerContext) {
-  return ({
-    stream,
-    usage,
-    storageKey,
-  }: ProgressEventPayloads['updateStreamUsage']): void => {
-    withEventErrorHandling(
-      'UsageEvents',
-      'failed to handle updateStreamUsage',
-      async () => {
-        const normalizedUsage: TokenUsageStats = {
-          inputTokens: Number(usage.inputTokens ?? 0),
-          outputTokens: Number(usage.outputTokens ?? 0),
-          cost: Number(usage.cost ?? 0),
-          // Cache tokens for display (use ?? for nullish-only coalescing)
-          cacheReadInputTokens: Number(usage.cacheReadInputTokens ?? 0),
-          cacheCreationInputTokens: Number(usage.cacheCreationInputTokens ?? 0),
-        };
+function handleUpdateStreamUsage(
+  ctx: EventHandlerContext,
+  { stream, usage, storageKey }: ProgressEventPayloads['updateStreamUsage'],
+): void {
+  withEventErrorHandling('UsageEvents', 'failed to handle updateStreamUsage', async () => {
+    const normalizedUsage: TokenUsageStats = {
+      inputTokens: Number(usage.inputTokens ?? 0),
+      outputTokens: Number(usage.outputTokens ?? 0),
+      cost: Number(usage.cost ?? 0),
+      cacheReadInputTokens: Number(usage.cacheReadInputTokens ?? 0),
+      cacheCreationInputTokens: Number(usage.cacheCreationInputTokens ?? 0),
+    };
 
-        // Backend accumulates the delta and returns the accumulated value
-        // This avoids race conditions from a separate read operation
-        const accumulatedUsage = await ctx.state.usageStats.setRunUsage(
-          stream,
-          storageKey,
-          normalizedUsage,
-        );
-
-        // For tool-use sessions (no task groups), set active run ID from usage
-        // so the frontend can resolve which run's usage to display.
-        // For workflow sessions, task group creation already set this.
-        if (!ctx.state.getActiveRunId(stream)) {
-          ctx.state.setActiveRunId(stream, storageKey);
-        }
-
-        if (canUpdateWebview(ctx, stream) && accumulatedUsage) {
-          // Send accumulated value to frontend (not the delta)
-          // Frontend uses SET semantics to avoid double-counting
-          ctx.webviewUpdater.updateRunUsage(
-            stream,
-            storageKey,
-            accumulatedUsage,
-          );
-        }
-      },
+    // Backend accumulates the delta and returns the accumulated value
+    const accumulatedUsage = await ctx.state.usageStats.setRunUsage(
+      stream,
+      storageKey,
+      normalizedUsage,
     );
-  };
+
+    // For tool-use sessions (no task groups), set active run ID from usage
+    if (!ctx.state.getActiveRunId(stream)) {
+      ctx.state.setActiveRunId(stream, storageKey);
+    }
+
+    if (canUpdateWebview(ctx, stream) && accumulatedUsage) {
+      ctx.webviewUpdater.updateRunUsage(stream, storageKey, accumulatedUsage);
+    }
+  });
 }
 
-function handleUpdateContextState(ctx: EventHandlerContext) {
-  return ({
-    stream,
-    contextState,
-  }: ProgressEventPayloads['updateContextState']): void => {
-    withEventErrorHandling(
-      'UsageEvents',
-      'failed to handle updateContextState',
-      () => {
-        // Store context state for replay when switching streams
-        ctx.state.setContextState(stream, contextState);
-        if (canUpdateWebview(ctx, stream)) {
-          ctx.webviewUpdater.updateContextState(stream, contextState);
-        }
-      },
-    );
-  };
+function handleUpdateContextState(
+  ctx: EventHandlerContext,
+  { stream, contextState }: ProgressEventPayloads['updateContextState'],
+): void {
+  withEventErrorHandling('UsageEvents', 'failed to handle updateContextState', () => {
+    ctx.state.setContextState(stream, contextState);
+    if (canUpdateWebview(ctx, stream)) {
+      ctx.webviewUpdater.updateContextState(stream, contextState);
+    }
+  });
 }

--- a/src/progressView/events/UsageEventHandlers.ts
+++ b/src/progressView/events/UsageEventHandlers.ts
@@ -37,33 +37,41 @@ function handleUpdateStreamUsage(
   ctx: EventHandlerContext,
   { stream, usage, storageKey }: ProgressEventPayloads['updateStreamUsage'],
 ): void {
-  withEventErrorHandling('UsageEvents', 'failed to handle updateStreamUsage', async () => {
-    // usage is already typed as TokenUsageStats from the event payload
-    const accumulatedUsage = await ctx.state.usageStats.setRunUsage(
-      stream,
-      storageKey,
-      usage,
-    );
+  withEventErrorHandling(
+    'UsageEvents',
+    'failed to handle updateStreamUsage',
+    async () => {
+      // usage is already typed as TokenUsageStats from the event payload
+      const accumulatedUsage = await ctx.state.usageStats.setRunUsage(
+        stream,
+        storageKey,
+        usage,
+      );
 
-    // For tool-use sessions (no task groups), set active run ID from usage
-    if (!ctx.state.getActiveRunId(stream)) {
-      ctx.state.setActiveRunId(stream, storageKey);
-    }
+      // For tool-use sessions (no task groups), set active run ID from usage
+      if (!ctx.state.getActiveRunId(stream)) {
+        ctx.state.setActiveRunId(stream, storageKey);
+      }
 
-    if (canUpdateWebview(ctx, stream) && accumulatedUsage) {
-      ctx.webviewUpdater.updateRunUsage(stream, storageKey, accumulatedUsage);
-    }
-  });
+      if (canUpdateWebview(ctx, stream) && accumulatedUsage) {
+        ctx.webviewUpdater.updateRunUsage(stream, storageKey, accumulatedUsage);
+      }
+    },
+  );
 }
 
 function handleUpdateContextState(
   ctx: EventHandlerContext,
   { stream, contextState }: ProgressEventPayloads['updateContextState'],
 ): void {
-  withEventErrorHandling('UsageEvents', 'failed to handle updateContextState', () => {
-    ctx.state.setContextState(stream, contextState);
-    if (canUpdateWebview(ctx, stream)) {
-      ctx.webviewUpdater.updateContextState(stream, contextState);
-    }
-  });
+  withEventErrorHandling(
+    'UsageEvents',
+    'failed to handle updateContextState',
+    () => {
+      ctx.state.setContextState(stream, contextState);
+      if (canUpdateWebview(ctx, stream)) {
+        ctx.webviewUpdater.updateContextState(stream, contextState);
+      }
+    },
+  );
 }

--- a/src/progressView/events/UsageEventHandlers.ts
+++ b/src/progressView/events/UsageEventHandlers.ts
@@ -3,7 +3,6 @@
  *
  * Handles usage events: updateStreamUsage, updateContextState.
  */
-import type { TokenUsageStats } from '@agent/types/UsageTypes';
 import type {
   ProgressEventBusLike,
   ProgressEventPayloads,
@@ -39,19 +38,11 @@ function handleUpdateStreamUsage(
   { stream, usage, storageKey }: ProgressEventPayloads['updateStreamUsage'],
 ): void {
   withEventErrorHandling('UsageEvents', 'failed to handle updateStreamUsage', async () => {
-    const normalizedUsage: TokenUsageStats = {
-      inputTokens: Number(usage.inputTokens ?? 0),
-      outputTokens: Number(usage.outputTokens ?? 0),
-      cost: Number(usage.cost ?? 0),
-      cacheReadInputTokens: Number(usage.cacheReadInputTokens ?? 0),
-      cacheCreationInputTokens: Number(usage.cacheCreationInputTokens ?? 0),
-    };
-
-    // Backend accumulates the delta and returns the accumulated value
+    // usage is already typed as TokenUsageStats from the event payload
     const accumulatedUsage = await ctx.state.usageStats.setRunUsage(
       stream,
       storageKey,
-      normalizedUsage,
+      usage,
     );
 
     // For tool-use sessions (no task groups), set active run ID from usage

--- a/src/progressView/events/UsageEventHandlers.ts
+++ b/src/progressView/events/UsageEventHandlers.ts
@@ -9,7 +9,7 @@ import type {
 } from '@eventBus/ProgressEventBus';
 import { withEventErrorHandling } from './errorHandling';
 import {
-  canUpdateWebview,
+  isWebviewAvailable,
   type EventHandlerContext,
 } from './EventHandlerContext';
 
@@ -53,7 +53,8 @@ function handleUpdateStreamUsage(
         ctx.state.setActiveRunId(stream, storageKey);
       }
 
-      if (canUpdateWebview(ctx, stream) && accumulatedUsage) {
+      // Broadcast to webview - frontend decides which run to display
+      if (isWebviewAvailable(ctx) && accumulatedUsage) {
         ctx.webviewUpdater.updateRunUsage(stream, storageKey, accumulatedUsage);
       }
     },
@@ -69,7 +70,8 @@ function handleUpdateContextState(
     'failed to handle updateContextState',
     () => {
       ctx.state.setContextState(stream, contextState);
-      if (canUpdateWebview(ctx, stream)) {
+      // Broadcast to webview - frontend decides which run to display
+      if (isWebviewAvailable(ctx)) {
         ctx.webviewUpdater.updateContextState(stream, contextState);
       }
     },

--- a/src/progressView/events/index.ts
+++ b/src/progressView/events/index.ts
@@ -6,7 +6,7 @@ export {
   type RetryCallbacks,
   type ApprovalCallbacks,
 } from './UIEvents';
-export { type ProgressEventBusLike } from './types';
+export { type ProgressEventBusLike } from '@eventBus/ProgressEventBus';
 
 // Domain-specific event handlers (modular, focused files)
 export {

--- a/src/progressView/events/types.ts
+++ b/src/progressView/events/types.ts
@@ -1,3 +1,0 @@
-// Re-export ProgressEventBusLike from the main event bus module
-// for backwards compatibility with existing imports
-export type { ProgressEventBusLike } from '@eventBus/ProgressEventBus';

--- a/src/progressView/managers/StreamTabsManager.ts
+++ b/src/progressView/managers/StreamTabsManager.ts
@@ -73,19 +73,6 @@ export class StreamTabsManager extends PersistentMapManager<
   }
 
   /**
-   * Clear content of a specific stream (but keep the stream)
-   */
-  async clearContent(stream: StreamTabId): Promise<void> {
-    if (!this.has(stream)) {
-      return;
-    }
-
-    const messages = this.ensureMessages(stream);
-    messages.length = 0;
-    await this.save();
-  }
-
-  /**
    * Get a copy of messages for a stream (safe for external use).
    * Returns a shallow copy to prevent external mutation of internal state.
    */

--- a/src/progressView/managers/StreamTabsManager.ts
+++ b/src/progressView/managers/StreamTabsManager.ts
@@ -83,6 +83,11 @@ export class StreamTabsManager extends PersistentMapManager<
   /**
    * Update an existing message by ID.
    * Returns true if message was found and updated, false otherwise.
+   *
+   * Note: Uses fire-and-forget persistence (void this.save()) because:
+   * - Callers only need to know if message was found/updated in memory
+   * - The in-memory state is immediately correct for webview updates
+   * - Persistence is background work; failures are logged by base class
    */
   updateMessage(
     stream: StreamTabId,

--- a/src/progressView/managers/StreamTabsManager.ts
+++ b/src/progressView/managers/StreamTabsManager.ts
@@ -85,8 +85,32 @@ export class StreamTabsManager extends PersistentMapManager<
     await this.save();
   }
 
+  /**
+   * Get a copy of messages for a stream (safe for external use).
+   * Returns a shallow copy to prevent external mutation of internal state.
+   */
   getMessages(stream: StreamTabId): LogMessageData[] {
-    return this.ensureMessages(stream);
+    return [...this.ensureMessages(stream)];
+  }
+
+  /**
+   * Update an existing message by ID.
+   * Returns true if message was found and updated, false otherwise.
+   */
+  updateMessage(
+    stream: StreamTabId,
+    messageId: string,
+    updates: Partial<Omit<LogMessageData, 'id'>>,
+  ): boolean {
+    const messages = this.items.get(stream);
+    if (!messages) return false;
+
+    const index = messages.findIndex((m) => m.id === messageId);
+    if (index < 0) return false;
+
+    messages[index] = { ...messages[index], ...updates };
+    void this.save();
+    return true;
   }
 
   private ensureMessages(stream: StreamTabId): LogMessageData[] {

--- a/src/progressView/managers/TaskGroupManager.ts
+++ b/src/progressView/managers/TaskGroupManager.ts
@@ -39,13 +39,44 @@ export class TaskGroupManager extends PersistentMapManager<
     groupId: string,
     group: TaskGroup,
   ): Promise<void> {
+    this.insertGroup(stream, groupId, group);
+    await this.save();
+  }
+
+  /**
+   * Add multiple task groups in a single persistence operation.
+   * Enables efficient concurrent additions for multi-agent scenarios.
+   *
+   * @param groups - Array of { stream, group } to add
+   * @returns Number of groups added
+   */
+  async addMultipleGroups(
+    groups: Array<{ stream: StreamTabId; group: TaskGroup }>,
+  ): Promise<number> {
+    for (const { stream, group } of groups) {
+      this.insertGroup(stream, group.id, group);
+    }
+
+    if (groups.length > 0) {
+      await this.save();
+    }
+
+    return groups.length;
+  }
+
+  /**
+   * Insert a group without persisting (internal helper).
+   */
+  private insertGroup(
+    stream: StreamTabId,
+    groupId: string,
+    group: TaskGroup,
+  ): void {
     if (!this.has(stream)) {
       this.items.set(stream, new Map());
     }
-
     const streamGroups = this.get(stream)!;
     streamGroups.set(groupId, { ...group });
-    await this.save();
   }
 
   /**
@@ -58,10 +89,52 @@ export class TaskGroupManager extends PersistentMapManager<
     status,
     endTime,
   }: UpdateTaskGroupPayload): Promise<void> {
+    const updated = this.applyGroupUpdate(stream, id, status, endTime);
+    if (updated) {
+      await this.save();
+    }
+  }
+
+  /**
+   * Update multiple task groups in a single persistence operation.
+   * Enables efficient concurrent updates for multi-agent scenarios.
+   *
+   * @param updates - Array of update payloads to apply
+   * @returns Number of successfully updated groups
+   */
+  async updateMultipleGroups(
+    updates: UpdateTaskGroupPayload[],
+  ): Promise<number> {
+    let successCount = 0;
+
+    for (const { stream, id, status, endTime } of updates) {
+      if (this.applyGroupUpdate(stream, id, status, endTime)) {
+        successCount++;
+      }
+    }
+
+    if (successCount > 0) {
+      await this.save();
+    }
+
+    return successCount;
+  }
+
+  /**
+   * Apply a single group update without persisting.
+   * Used by both updateGroup and updateMultipleGroups.
+   * @returns true if update was applied, false if group not found
+   */
+  private applyGroupUpdate(
+    stream: StreamTabId,
+    id: string,
+    status: TaskGroup['status'],
+    endTime?: number,
+  ): boolean {
     const streamGroups = this.get(stream);
     if (!streamGroups) {
       this.logger.warn(`Cannot update group ${id}: stream ${stream} not found`);
-      return;
+      return false;
     }
 
     const group = streamGroups.get(id);
@@ -69,7 +142,7 @@ export class TaskGroupManager extends PersistentMapManager<
       this.logger.warn(
         `Cannot update group ${id}: group not found in stream ${stream}`,
       );
-      return;
+      return false;
     }
 
     // Apply updates - only include endTime if explicitly provided
@@ -78,7 +151,7 @@ export class TaskGroupManager extends PersistentMapManager<
       updated.endTime = endTime;
     }
     streamGroups.set(id, updated);
-    await this.save();
+    return true;
   }
 
   async endRunningGroups(now: number = Date.now()): Promise<StreamTabId[]> {

--- a/src/progressView/managers/TaskGroupManager.ts
+++ b/src/progressView/managers/TaskGroupManager.ts
@@ -39,44 +39,13 @@ export class TaskGroupManager extends PersistentMapManager<
     groupId: string,
     group: TaskGroup,
   ): Promise<void> {
-    this.insertGroup(stream, groupId, group);
-    await this.save();
-  }
-
-  /**
-   * Add multiple task groups in a single persistence operation.
-   * Enables efficient concurrent additions for multi-agent scenarios.
-   *
-   * @param groups - Array of { stream, group } to add
-   * @returns Number of groups added
-   */
-  async addMultipleGroups(
-    groups: Array<{ stream: StreamTabId; group: TaskGroup }>,
-  ): Promise<number> {
-    for (const { stream, group } of groups) {
-      this.insertGroup(stream, group.id, group);
-    }
-
-    if (groups.length > 0) {
-      await this.save();
-    }
-
-    return groups.length;
-  }
-
-  /**
-   * Insert a group without persisting (internal helper).
-   */
-  private insertGroup(
-    stream: StreamTabId,
-    groupId: string,
-    group: TaskGroup,
-  ): void {
     if (!this.has(stream)) {
       this.items.set(stream, new Map());
     }
+
     const streamGroups = this.get(stream)!;
     streamGroups.set(groupId, { ...group });
+    await this.save();
   }
 
   /**
@@ -89,52 +58,10 @@ export class TaskGroupManager extends PersistentMapManager<
     status,
     endTime,
   }: UpdateTaskGroupPayload): Promise<void> {
-    const updated = this.applyGroupUpdate(stream, id, status, endTime);
-    if (updated) {
-      await this.save();
-    }
-  }
-
-  /**
-   * Update multiple task groups in a single persistence operation.
-   * Enables efficient concurrent updates for multi-agent scenarios.
-   *
-   * @param updates - Array of update payloads to apply
-   * @returns Number of successfully updated groups
-   */
-  async updateMultipleGroups(
-    updates: UpdateTaskGroupPayload[],
-  ): Promise<number> {
-    let successCount = 0;
-
-    for (const { stream, id, status, endTime } of updates) {
-      if (this.applyGroupUpdate(stream, id, status, endTime)) {
-        successCount++;
-      }
-    }
-
-    if (successCount > 0) {
-      await this.save();
-    }
-
-    return successCount;
-  }
-
-  /**
-   * Apply a single group update without persisting.
-   * Used by both updateGroup and updateMultipleGroups.
-   * @returns true if update was applied, false if group not found
-   */
-  private applyGroupUpdate(
-    stream: StreamTabId,
-    id: string,
-    status: TaskGroup['status'],
-    endTime?: number,
-  ): boolean {
     const streamGroups = this.get(stream);
     if (!streamGroups) {
       this.logger.warn(`Cannot update group ${id}: stream ${stream} not found`);
-      return false;
+      return;
     }
 
     const group = streamGroups.get(id);
@@ -142,7 +69,7 @@ export class TaskGroupManager extends PersistentMapManager<
       this.logger.warn(
         `Cannot update group ${id}: group not found in stream ${stream}`,
       );
-      return false;
+      return;
     }
 
     // Apply updates - only include endTime if explicitly provided
@@ -151,7 +78,7 @@ export class TaskGroupManager extends PersistentMapManager<
       updated.endTime = endTime;
     }
     streamGroups.set(id, updated);
-    return true;
+    await this.save();
   }
 
   async endRunningGroups(now: number = Date.now()): Promise<StreamTabId[]> {

--- a/src/progressView/managers/WebviewUpdater.ts
+++ b/src/progressView/managers/WebviewUpdater.ts
@@ -7,9 +7,15 @@ import type { AgentTypeFilter } from '@agent/types/AgentStreamTypes';
 import type { StreamTabId } from '@agent/types/IdentifierTypes';
 import type { TokenUsageStats } from '@agent/types/UsageTypes';
 import type { StreamStatus } from '@common/constants/streamStatus';
-import type { LogMessageData } from '@logger/LogTypes';
+import type { LogMessageData, TaskGroup } from '@logger/LogTypes';
 import type { TaskState } from '@logger/TaskState';
 import type { InstructionUpdate, StreamTabInfo } from '@progressView/types';
+
+/** Message payload sent to webview */
+interface WebviewMessage {
+  command: string;
+  [key: string]: unknown;
+}
 
 // Internal imports
 import { buildStreamInfos } from '@progressView/streamInfoUtils';
@@ -54,7 +60,7 @@ export class WebviewUpdater {
   constructor(private getWebviews: () => (vscode.Webview | undefined)[]) {}
 
   /** Helper to send messages to all registered webviews */
-  private sendMessage(message: any): void {
+  private sendMessage(message: WebviewMessage): void {
     for (const webview of this.getWebviews()) {
       if (webview) {
         webview.postMessage(message);
@@ -109,7 +115,7 @@ export class WebviewUpdater {
   updateLogContent(
     stream: StreamTabId,
     messages: LogMessageData[],
-    groups: any[] = [],
+    groups: TaskGroup[] = [],
     extras?: LogContentExtras,
     action: 'render' | 'clear' = 'render',
   ): void {
@@ -324,7 +330,7 @@ export class WebviewUpdater {
   /**
    * Add a task group to the webview
    */
-  addTaskGroup(stream: StreamTabId, group: any): void {
+  addTaskGroup(stream: StreamTabId, group: TaskGroup): void {
     this.sendMessage({
       command: COMMANDS.ADD_TASK_GROUP,
       stream,

--- a/src/progressView/managers/WebviewUpdater.ts
+++ b/src/progressView/managers/WebviewUpdater.ts
@@ -34,6 +34,8 @@ export interface LogContentExtras {
   runUsage?: Record<string, TokenUsageStats>;
   /** Output files by run ID and round */
   runFiles?: Record<string, { [key: number]: OutputFileInfo[] }>;
+  /** Missing outputs by run ID and round (batched with initial render) */
+  runMissingOutputs?: Record<string, { [key: number]: string[] }>;
   /** Context window utilization state */
   contextState?: {
     inputTokens: number;

--- a/src/progressView/managers/WebviewUpdater.ts
+++ b/src/progressView/managers/WebviewUpdater.ts
@@ -223,20 +223,6 @@ export class WebviewUpdater {
   }
 
   /**
-   * Update usage statistics (full replacement)
-   */
-  updateUsage(
-    stream: StreamTabId,
-    usageByRun: Record<string, TokenUsageStats>,
-  ): void {
-    this.sendMessage({
-      command: COMMANDS.UPDATE_USAGE,
-      stream,
-      usageByRun,
-    });
-  }
-
-  /**
    * Update usage for a single run (incremental).
    * More efficient than updateUsage when only one run's usage changed.
    */

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -317,7 +317,7 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
   }
 
   /**
-   * Update run-scoped metadata (instructions, usage, files, context) from message.
+   * Update run-scoped metadata (instructions, usage, files, missing outputs, context) from message.
    * Shared by handleUpdateLogs and _handleIncrementalUpdate to avoid duplication.
    */
   _updateRunMetadata(stream, message) {
@@ -326,6 +326,7 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       [message.runInstructions, state.setRunInstruction],
       [message.runUsage, state.setRunUsage],
       [message.runFiles, state.setRunFiles],
+      [message.runMissingOutputs, state.setRunMissingOutputs],
     ];
     for (const [data, setter] of runDataSources) {
       if (!data) continue;
@@ -556,6 +557,7 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     state.taskGroups.clear();
     state.clearRunInstructions(message.stream);
     state.clearRunFiles(message.stream);
+    state.clearRunMissingOutputs(message.stream);
     state.clearRunUsage(message.stream);
     state.clearPendingInstruction(state.activeStream);
     const previousRunId = state.getActiveRunId(message.stream);

--- a/src/progressView/modules/taskManagers.js
+++ b/src/progressView/modules/taskManagers.js
@@ -303,27 +303,21 @@ export class TaskGroupDomManager {
    * @param {string|null} groupId - The run ID to show, or null to show all
    */
   showRun(groupId) {
-    // For toolUse sessions, always show all groups (they're conversation turns)
-    // See ARCHITECTURAL NOTE in messageHandlers.js for design context
-    const isToolUse = progressViewState.activeSessionKind === 'toolUse';
-    const effectiveGroupId = isToolUse ? null : groupId;
-
-    const hasTarget = Boolean(
-      effectiveGroupId && this.groupElements.has(effectiveGroupId),
-    );
+    // ToolUse sessions show all groups as conversation turns (append-only history)
+    // Workflow sessions filter to single run (mutually exclusive runs)
+    const showAll =
+      progressViewState.activeSessionKind === 'toolUse' ||
+      !groupId ||
+      !this.groupElements.has(groupId);
 
     for (const [id, element] of this.groupElements.entries()) {
-      if (!element) {
-        continue;
-      }
+      if (!element) continue;
 
       const group = progressViewState.taskGroups.get(id);
-      if (!group || group.parentGroupId) {
-        continue;
-      }
+      // Skip child groups (they follow parent visibility)
+      if (!group || group.parentGroupId) continue;
 
-      const shouldShow = hasTarget ? id === effectiveGroupId : true;
-      element.hidden = !shouldShow;
+      element.hidden = !showAll && id !== groupId;
     }
   }
 

--- a/src/progressView/state/ProgressViewState.ts
+++ b/src/progressView/state/ProgressViewState.ts
@@ -326,12 +326,14 @@ export class ProgressViewState {
     requested?: string | null,
     options?: { persist?: boolean },
   ): StorageKey | null {
+    const shouldPersist = options?.persist ?? true;
+
     // 1. Specific runId requested - validate it exists
     if (requested) {
       const candidates = this.collectRunCandidates(stream);
       if (!candidates.has(requested)) return null;
       const normalized = normalizeRunId(requested);
-      if (options?.persist ?? true) this.setActiveRunId(stream, normalized);
+      if (shouldPersist) this.setActiveRunId(stream, normalized);
       return normalized;
     }
 
@@ -339,51 +341,77 @@ export class ProgressViewState {
     const current = this.getActiveRunId(stream);
     if (current) return current;
 
-    // 3. Auto-select from candidates
+    // 3. Auto-select: collect candidates once, then pick latest or single
     const candidates = this.collectRunCandidates(stream);
+    if (candidates.size === 0) return null;
+
     const selected =
-      candidates.size === 1 ? [...candidates][0] : this.findLatestRunId(stream);
+      candidates.size === 1
+        ? [...candidates][0]
+        : this.findLatestRunId(stream, candidates);
 
     if (!selected) return null;
     const normalized = normalizeRunId(selected);
-    if (options?.persist ?? true) this.setActiveRunId(stream, normalized);
+    if (shouldPersist) this.setActiveRunId(stream, normalized);
     return normalized;
   }
 
+  /**
+   * Collect all valid run IDs for a stream.
+   *
+   * Run candidates come from:
+   * - Root task groups (workflow runs)
+   * - Run-scoped data: instructions, output files, usage stats
+   *
+   * This is the single source of truth for run discovery.
+   */
   private collectRunCandidates(stream: StreamTabId): Set<string> {
     const candidates = new Set<string>();
 
-    // Helper to add all keys from a Map
-    const addKeys = (map: Map<string, unknown>): void => {
-      for (const runId of map.keys()) {
-        if (runId) candidates.add(runId);
-      }
-    };
-
-    // Collect from all run-scoped data sources
-    addKeys(this._runInstructions.getInstructions(stream));
-    addKeys(this._outputFiles.getFiles(stream));
-    addKeys(this._outputFiles.getMissingOutputs(stream));
-    addKeys(this._usageStats.getRunUsage(stream));
-
-    // Add root task group IDs (groups without parents)
+    // Root task groups are primary run identifiers (workflow sessions)
     for (const group of this._taskGroups.getStreamGroups(stream).values()) {
       if (!group.parentGroupId) {
         candidates.add(group.id);
       }
     }
 
+    // Run-scoped data sources (tool-use sessions use these)
+    const sources = [
+      this._runInstructions.getInstructions(stream),
+      this._outputFiles.getFiles(stream),
+      this._outputFiles.getMissingOutputs(stream),
+      this._usageStats.getRunUsage(stream),
+    ];
+
+    for (const source of sources) {
+      for (const runId of source.keys()) {
+        if (runId) candidates.add(runId);
+      }
+    }
+
     return candidates;
   }
 
-  private findLatestRunId(stream: StreamTabId): string | null {
+  /**
+   * Find the most recent run from candidates.
+   * Prefers task groups by startTime, falls back to usage runs for tool-use sessions.
+   *
+   * @param stream - The stream to search in
+   * @param candidates - Pre-collected run candidates (avoids redundant iteration)
+   */
+  private findLatestRunId(
+    stream: StreamTabId,
+    candidates?: Set<string>,
+  ): string | null {
     const groups = this._taskGroups.getStreamGroups(stream);
     let latest: { id: string; start: number } | null = null;
 
+    // If candidates provided, only consider those; otherwise check all root groups
+    const candidateSet = candidates ?? this.collectRunCandidates(stream);
+
     for (const group of groups.values()) {
-      if (group.parentGroupId) {
-        continue;
-      }
+      if (group.parentGroupId) continue;
+      if (!candidateSet.has(group.id)) continue;
 
       const startTime = group.startTime;
       if (!latest || startTime >= latest.start) {

--- a/src/progressView/state/ProgressViewState.ts
+++ b/src/progressView/state/ProgressViewState.ts
@@ -50,19 +50,22 @@ export const StreamHintsSchema = z.object({
 export type StreamHints = z.infer<typeof StreamHintsSchema>;
 
 /**
- * Consolidated ephemeral state for a single stream.
+ * Consolidated session state for a single stream.
  *
- * Groups all session-only, non-persisted state that needs to be tracked per-stream.
- * This eliminates the scattered Maps pattern (5 separate Maps → 1 Map with structured values).
+ * Groups per-stream state that doesn't belong in separate managers.
+ * Contains both ephemeral (session-only) and persisted fields:
+ *
+ * - Ephemeral (not persisted): hints, todos, contextState
+ * - Persisted: activeRunId (saved to workspace storage)
  */
-interface StreamEphemeralState {
-  /** UI hints before TaskState is fully populated */
+interface StreamSessionState {
+  /** UI hints before TaskState is fully populated (ephemeral) */
   hints: StreamHints;
-  /** Todos from agent, replayed on stream switch */
+  /** Todos from agent, replayed on stream switch (ephemeral) */
   todos: TodoItem[];
-  /** Context utilization (input tokens vs context window) */
+  /** Context utilization (input tokens vs context window) (ephemeral) */
   contextState: ContextStateData | null;
-  /** Most recently viewed run for this stream */
+  /** Most recently viewed run for this stream (persisted) */
   activeRunId: StorageKey | null;
 }
 
@@ -84,15 +87,13 @@ export class ProgressViewState {
   private _executionIds: Map<StreamTabId, ExecutionId> = new Map();
 
   /**
-   * Consolidated ephemeral state per stream.
+   * Consolidated session state per stream.
    *
-   * Groups all non-persisted, session-only data:
-   * - hints: UI indicators before TaskState is populated
-   * - todos: Agent todos for replay on stream switch
-   * - contextState: Token utilization display
-   * - activeRunId: Most recently viewed run
+   * Contains both ephemeral and persisted fields:
+   * - Ephemeral: hints, todos, contextState
+   * - Persisted: activeRunId
    */
-  private _ephemeral = new Map<StreamTabId, StreamEphemeralState>();
+  private _sessionState = new Map<StreamTabId, StreamSessionState>();
 
   private readonly storage: StateStorage;
   private readonly logger: AgentLogger;
@@ -205,80 +206,80 @@ export class ProgressViewState {
   }
 
   // ============================================================================
-  // Ephemeral State Management (consolidated)
+  // Session State Management (per-stream ephemeral + persisted fields)
   // ============================================================================
 
-  /** Get or create ephemeral state for a stream */
-  private getOrCreateEphemeral(stream: StreamTabId): StreamEphemeralState {
-    let state = this._ephemeral.get(stream);
+  /** Get or create session state for a stream */
+  private getOrCreateSession(stream: StreamTabId): StreamSessionState {
+    let state = this._sessionState.get(stream);
     if (!state) {
       state = { hints: {}, todos: [], contextState: null, activeRunId: null };
-      this._ephemeral.set(stream, state);
+      this._sessionState.set(stream, state);
     }
     return state;
   }
 
   /** Update stream hints (merges with existing) */
   updateStreamHints(streamTabId: StreamTabId, hints: StreamHints): void {
-    const state = this.getOrCreateEphemeral(streamTabId);
+    const state = this.getOrCreateSession(streamTabId);
     state.hints = { ...state.hints, ...hints };
   }
 
   /** Get stream hints */
   getStreamHints(streamTabId: StreamTabId): StreamHints {
-    return this._ephemeral.get(streamTabId)?.hints ?? {};
+    return this._sessionState.get(streamTabId)?.hints ?? {};
   }
 
   /** Clear stream hints (resets to empty) */
   clearStreamHints(streamTabId: StreamTabId): void {
-    this.clearEphemeralField(streamTabId, 'hints', {});
+    this.clearSessionField(streamTabId, 'hints', {});
   }
 
   /** Set todos for a stream */
   setTodos(stream: StreamTabId, todos: TodoItem[]): void {
-    this.getOrCreateEphemeral(stream).todos = todos;
+    this.getOrCreateSession(stream).todos = todos;
   }
 
   /** Get todos for a stream */
   getTodos(stream: StreamTabId): TodoItem[] | undefined {
-    const todos = this._ephemeral.get(stream)?.todos;
+    const todos = this._sessionState.get(stream)?.todos;
     return todos?.length ? todos : undefined;
   }
 
   /** Clear todos for a stream */
   clearTodos(stream: StreamTabId): void {
-    this.clearEphemeralField(stream, 'todos', []);
+    this.clearSessionField(stream, 'todos', []);
   }
 
   /** Clear all todos across all streams */
   clearAllTodos(): void {
-    for (const state of this._ephemeral.values()) {
+    for (const state of this._sessionState.values()) {
       state.todos = [];
     }
   }
 
   /** Set context state for a stream */
   setContextState(stream: StreamTabId, contextState: ContextStateData): void {
-    this.getOrCreateEphemeral(stream).contextState = contextState;
+    this.getOrCreateSession(stream).contextState = contextState;
   }
 
   /** Get context state for a stream */
   getContextState(stream: StreamTabId): ContextStateData | undefined {
-    return this._ephemeral.get(stream)?.contextState ?? undefined; // null → undefined
+    return this._sessionState.get(stream)?.contextState ?? undefined; // null → undefined
   }
 
   /** Clear context state for a stream */
   clearContextState(stream: StreamTabId): void {
-    this.clearEphemeralField(stream, 'contextState', null);
+    this.clearSessionField(stream, 'contextState', null);
   }
 
   /** Helper to clear a specific ephemeral field */
-  private clearEphemeralField<K extends keyof StreamEphemeralState>(
+  private clearSessionField<K extends keyof StreamSessionState>(
     stream: StreamTabId,
     field: K,
-    emptyValue: StreamEphemeralState[K],
+    emptyValue: StreamSessionState[K],
   ): void {
-    const state = this._ephemeral.get(stream);
+    const state = this._sessionState.get(stream);
     if (state) {
       state[field] = emptyValue;
     }
@@ -287,18 +288,18 @@ export class ProgressViewState {
   /** Set active run ID for a stream (persisted) */
   setActiveRunId(stream: StreamTabId, runId: string | null): void {
     const storageKey = runId ? normalizeRunId(runId) : null;
-    this.getOrCreateEphemeral(stream).activeRunId = storageKey;
+    this.getOrCreateSession(stream).activeRunId = storageKey;
     this.saveActiveRunIds();
   }
 
   /** Get active run ID for a stream */
   getActiveRunId(stream: StreamTabId): StorageKey | null {
-    return this._ephemeral.get(stream)?.activeRunId ?? null;
+    return this._sessionState.get(stream)?.activeRunId ?? null;
   }
 
   /** Clear active run for a stream */
   clearActiveRun(stream: StreamTabId): void {
-    const state = this._ephemeral.get(stream);
+    const state = this._sessionState.get(stream);
     if (state && state.activeRunId !== null) {
       state.activeRunId = null;
       this.saveActiveRunIds();
@@ -440,7 +441,7 @@ export class ProgressViewState {
     // Restore active run IDs into consolidated ephemeral state
     for (const [stream, runId] of Object.entries(stored)) {
       if (runId) {
-        this.getOrCreateEphemeral(stream as StreamTabId).activeRunId =
+        this.getOrCreateSession(stream as StreamTabId).activeRunId =
           normalizeRunId(runId);
       }
     }
@@ -449,7 +450,7 @@ export class ProgressViewState {
   private saveActiveRunIds(): void {
     // Extract active run IDs from consolidated ephemeral state
     const record: Record<string, string | null> = {};
-    for (const [stream, state] of this._ephemeral.entries()) {
+    for (const [stream, state] of this._sessionState.entries()) {
       if (state.activeRunId !== null) {
         record[stream] = state.activeRunId;
       }
@@ -575,7 +576,7 @@ export class ProgressViewState {
     // Clear ephemeral state (consolidated Map)
     const removedState = this.taskStates.delete(stream);
     this._executionIds.delete(stream);
-    this._ephemeral.delete(stream);
+    this._sessionState.delete(stream);
 
     // Update active stream if necessary
     if (this._activeStream === stream) {
@@ -602,7 +603,7 @@ export class ProgressViewState {
     ]);
     this.taskStates.clear();
     this._executionIds.clear();
-    this._ephemeral.clear();
+    this._sessionState.clear();
     this._activeStream = '';
     this.saveActiveStream();
     this.saveTaskStates();

--- a/src/progressView/state/ProgressViewState.ts
+++ b/src/progressView/state/ProgressViewState.ts
@@ -23,7 +23,7 @@ import {
   isToolUseTaskState,
   isWorkflowTaskState,
 } from '@logger/TaskState';
-import type { AgentFilter } from '@progressView/types';
+import type { AgentTypeFilter } from '@agent/types/AgentStreamTypes';
 import {
   StreamTabsManager,
   TaskGroupManager,
@@ -81,7 +81,7 @@ export class ProgressViewState {
   private _runInstructions: RunInstructionManager;
   private _activeStream: StreamTabId = '';
   private _streamSortOrder = 'time';
-  private _agentTypeFilter: AgentFilter = 'all';
+  private _agentTypeFilter: AgentTypeFilter = 'all';
   private readonly taskStates = new Map<StreamTabId, TaskState>();
   private _executionIds: Map<StreamTabId, ExecutionId> = new Map();
 
@@ -187,11 +187,11 @@ export class ProgressViewState {
     this.saveStreamSortOrder();
   }
 
-  get agentTypeFilter(): AgentFilter {
+  get agentTypeFilter(): AgentTypeFilter {
     return this._agentTypeFilter;
   }
 
-  set agentTypeFilter(filter: AgentFilter) {
+  set agentTypeFilter(filter: AgentTypeFilter) {
     if (!isAgentTypeFilter(filter)) {
       this.logger.warn(`Invalid agent filter: ${filter}, defaulting to 'all'`);
       filter = 'all';

--- a/src/progressView/state/ProgressViewState.ts
+++ b/src/progressView/state/ProgressViewState.ts
@@ -11,6 +11,7 @@ import type {
   ExecutionId,
   StorageKey,
 } from '@agent/types/IdentifierTypes';
+import type { TokenUsageStats } from '@agent/types/UsageTypes';
 import type { OutputFileInfo } from '@agent/output/types';
 // Internal imports
 import { cleanupInactiveAgents } from '@agent/toolUse/ToolUseAgentRegistry';
@@ -307,81 +308,72 @@ export class ProgressViewState {
   }
 
   /**
-   * Resolve and optionally persist the active run ID for a stream.
+   * Switch to a specific run (user-initiated).
+   * Validates the run exists, then sets it as active.
    *
-   * Resolution strategy (in order):
-   * 1. If specific runId requested → validate it exists, return it or null
-   * 2. If previously active runId exists → return it (already persisted)
-   * 3. Auto-select: single candidate or most recent run
-   *
-   * For tool-use agents: The runId will be the executionId (same UUID)
-   * For workflow agents: The runId will be a task group ID
-   *
-   * @param stream - The stream to resolve for
-   * @param requested - Optional specific runId to use
-   * @param options.persist - Whether to save the resolved runId (default: true)
-   * @returns The resolved StorageKey, or null if none found
+   * @param stream - The stream to switch runs in
+   * @param runId - The run ID to switch to
+   * @returns The normalized StorageKey if valid, null if run doesn't exist
    */
-  resolveRunId(
-    stream: StreamTabId,
-    requested?: string | null,
-    options?: { persist?: boolean },
-  ): StorageKey | null {
-    const shouldPersist = options?.persist ?? true;
+  switchToRun(stream: StreamTabId, runId: string): StorageKey | null {
+    const candidates = this.collectRunCandidates(stream);
+    if (!candidates.has(runId)) return null;
+    const normalized = normalizeRunId(runId);
+    this.setActiveRunId(stream, normalized);
+    return normalized;
+  }
 
-    // 1. Specific runId requested - validate it exists
-    if (requested) {
-      const candidates = this.collectRunCandidates(stream);
-      if (!candidates.has(requested)) return null;
-      const normalized = normalizeRunId(requested);
-      if (shouldPersist) this.setActiveRunId(stream, normalized);
-      return normalized;
-    }
-
-    // 2. Use existing active run if already set (already normalized)
+  /**
+   * Ensure a stream has an active run ID set.
+   * Called during initialization when activeRunId might not be set yet.
+   * Uses auto-selection only if no cached value exists.
+   *
+   * @returns The active StorageKey (cached or auto-selected), or null if no runs
+   */
+  ensureActiveRunId(stream: StreamTabId): StorageKey | null {
     const current = this.getActiveRunId(stream);
     if (current) return current;
 
-    // 3. Auto-select: collect candidates once, then pick latest or single
-    const candidates = this.collectRunCandidates(stream);
+    const { candidates, groups, usageRuns } = this.collectRunData(stream);
     if (candidates.size === 0) return null;
 
     const selected =
       candidates.size === 1
         ? [...candidates][0]
-        : this.findLatestRunId(stream, candidates);
+        : this.findLatestRunId(candidates, groups, usageRuns);
 
     if (!selected) return null;
     const normalized = normalizeRunId(selected);
-    if (shouldPersist) this.setActiveRunId(stream, normalized);
+    this.setActiveRunId(stream, normalized);
     return normalized;
   }
 
   /**
-   * Collect all valid run IDs for a stream.
-   *
-   * Run candidates come from:
-   * - Root task groups (workflow runs)
-   * - Run-scoped data: instructions, output files, usage stats
-   *
-   * This is the single source of truth for run discovery.
+   * Collected run data for a stream.
+   * Groups query results to avoid redundant manager lookups.
    */
-  private collectRunCandidates(stream: StreamTabId): Set<string> {
+  private collectRunData(stream: StreamTabId): {
+    candidates: Set<string>;
+    groups: Map<string, TaskGroup>;
+    usageRuns: Map<string, TokenUsageStats>;
+  } {
     const candidates = new Set<string>();
+    const groups = this._taskGroups.getStreamGroups(stream);
 
     // Root task groups are primary run identifiers (workflow sessions)
-    for (const group of this._taskGroups.getStreamGroups(stream).values()) {
+    for (const group of groups.values()) {
       if (!group.parentGroupId) {
         candidates.add(group.id);
       }
     }
 
     // Run-scoped data sources (tool-use sessions use these)
+    const usageRuns = this._usageStats.getRunUsage(stream);
     const sources = [
       this._runInstructions.getInstructions(stream),
       this._outputFiles.getFiles(stream),
       this._outputFiles.getMissingOutputs(stream),
-      this._usageStats.getRunUsage(stream),
+      usageRuns,
     ];
 
     for (const source of sources) {
@@ -390,29 +382,33 @@ export class ProgressViewState {
       }
     }
 
-    return candidates;
+    return { candidates, groups, usageRuns };
   }
 
   /**
-   * Find the most recent run from candidates.
+   * Collect all valid run IDs for a stream.
+   * Delegates to collectRunData for shared implementation.
+   */
+  private collectRunCandidates(stream: StreamTabId): Set<string> {
+    return this.collectRunData(stream).candidates;
+  }
+
+  /**
+   * Find the most recent run from collected data.
    * Prefers task groups by startTime, falls back to usage runs for tool-use sessions.
-   *
-   * @param stream - The stream to search in
-   * @param candidates - Pre-collected run candidates (avoids redundant iteration)
+   * Uses pre-collected data to avoid redundant manager queries.
    */
   private findLatestRunId(
-    stream: StreamTabId,
-    candidates?: Set<string>,
+    candidates: Set<string>,
+    groups: Map<string, TaskGroup>,
+    usageRuns: Map<string, TokenUsageStats>,
   ): string | null {
-    const groups = this._taskGroups.getStreamGroups(stream);
     let latest: { id: string; start: number } | null = null;
 
-    // If candidates provided, only consider those; otherwise check all root groups
-    const candidateSet = candidates ?? this.collectRunCandidates(stream);
-
+    // Find latest root task group by startTime
     for (const group of groups.values()) {
       if (group.parentGroupId) continue;
-      if (!candidateSet.has(group.id)) continue;
+      if (!candidates.has(group.id)) continue;
 
       const startTime = group.startTime;
       if (!latest || startTime >= latest.start) {
@@ -420,16 +416,14 @@ export class ProgressViewState {
       }
     }
 
-    // For tool-use sessions, there are no task groups - fall back to usage runs
-    if (!latest) {
-      const usageRuns = this._usageStats.getRunUsage(stream);
-      if (usageRuns.size > 0) {
-        // Return the last key (most recently added run)
-        return [...usageRuns.keys()].at(-1) ?? null;
-      }
+    if (latest) return latest.id;
+
+    // For tool-use sessions (no task groups), fall back to usage runs
+    if (usageRuns.size > 0) {
+      return [...usageRuns.keys()].at(-1) ?? null;
     }
 
-    return latest?.id ?? null;
+    return null;
   }
 
   private loadActiveRunIds(): void {

--- a/src/progressView/state/ProgressViewState.ts
+++ b/src/progressView/state/ProgressViewState.ts
@@ -11,14 +11,12 @@ import type {
   ExecutionId,
   StorageKey,
 } from '@agent/types/IdentifierTypes';
-import type { TokenUsageStats } from '@agent/types/UsageTypes';
 import type { OutputFileInfo } from '@agent/output/types';
 // Internal imports
 import { cleanupInactiveAgents } from '@agent/toolUse/ToolUseAgentRegistry';
 import { normalizeRunId } from '@common/constants/runIds';
 import { workspaceSM, WorkspaceStateKey } from '@common/state/stateManager';
 import { AgentLogger, type ContextStateData } from '@logger/AgentLogger';
-import type { TaskGroup } from '@logger/LogTypes';
 import {
   TaskState,
   TaskStateSchema,
@@ -130,10 +128,6 @@ export class ProgressViewState {
 
   get usageStats(): UsageStatsManager {
     return this._usageStats;
-  }
-
-  get runInstructions(): RunInstructionManager {
-    return this._runInstructions;
   }
 
   // Active stream management
@@ -307,123 +301,32 @@ export class ProgressViewState {
     }
   }
 
-  /**
-   * Switch to a specific run (user-initiated).
-   * Validates the run exists, then sets it as active.
-   *
-   * @param stream - The stream to switch runs in
-   * @param runId - The run ID to switch to
-   * @returns The normalized StorageKey if valid, null if run doesn't exist
-   */
-  switchToRun(stream: StreamTabId, runId: string): StorageKey | null {
-    const candidates = this.collectRunCandidates(stream);
-    if (!candidates.has(runId)) return null;
-    const normalized = normalizeRunId(runId);
-    this.setActiveRunId(stream, normalized);
-    return normalized;
+  // ============================================================================
+  // Run Instruction Management (delegation to internal manager)
+  // ============================================================================
+
+  /** Get all instructions for a stream */
+  getRunInstructions(
+    stream: StreamTabId,
+  ): Map<string, import('@progressView/types').InstructionUpdate> {
+    return this._runInstructions.getInstructions(stream);
   }
 
-  /**
-   * Ensure a stream has an active run ID set.
-   * Called during initialization when activeRunId might not be set yet.
-   * Uses auto-selection only if no cached value exists.
-   *
-   * @returns The active StorageKey (cached or auto-selected), or null if no runs
-   */
-  ensureActiveRunId(stream: StreamTabId): StorageKey | null {
-    const current = this.getActiveRunId(stream);
-    if (current) return current;
-
-    const { candidates, groups, usageRuns } = this.collectRunData(stream);
-    if (candidates.size === 0) return null;
-
-    const selected =
-      candidates.size === 1
-        ? [...candidates][0]
-        : this.findLatestRunId(candidates, groups, usageRuns);
-
-    if (!selected) return null;
-    const normalized = normalizeRunId(selected);
-    this.setActiveRunId(stream, normalized);
-    return normalized;
+  /** Set or clear an instruction for a run */
+  async setRunInstruction(
+    stream: StreamTabId,
+    runId: StorageKey,
+    instruction: import('@progressView/types').InstructionUpdate | null,
+  ): Promise<void> {
+    await this._runInstructions.setInstruction(stream, runId, instruction);
   }
 
-  /**
-   * Collected run data for a stream.
-   * Groups query results to avoid redundant manager lookups.
-   */
-  private collectRunData(stream: StreamTabId): {
-    candidates: Set<string>;
-    groups: Map<string, TaskGroup>;
-    usageRuns: Map<string, TokenUsageStats>;
-  } {
-    const candidates = new Set<string>();
-    const groups = this._taskGroups.getStreamGroups(stream);
-
-    // Root task groups are primary run identifiers (workflow sessions)
-    for (const group of groups.values()) {
-      if (!group.parentGroupId) {
-        candidates.add(group.id);
-      }
-    }
-
-    // Run-scoped data sources (tool-use sessions use these)
-    const usageRuns = this._usageStats.getRunUsage(stream);
-    const sources = [
-      this._runInstructions.getInstructions(stream),
-      this._outputFiles.getFiles(stream),
-      this._outputFiles.getMissingOutputs(stream),
-      usageRuns,
-    ];
-
-    for (const source of sources) {
-      for (const runId of source.keys()) {
-        if (runId) candidates.add(runId);
-      }
-    }
-
-    return { candidates, groups, usageRuns };
-  }
-
-  /**
-   * Collect all valid run IDs for a stream.
-   * Delegates to collectRunData for shared implementation.
-   */
-  private collectRunCandidates(stream: StreamTabId): Set<string> {
-    return this.collectRunData(stream).candidates;
-  }
-
-  /**
-   * Find the most recent run from collected data.
-   * Prefers task groups by startTime, falls back to usage runs for tool-use sessions.
-   * Uses pre-collected data to avoid redundant manager queries.
-   */
-  private findLatestRunId(
-    candidates: Set<string>,
-    groups: Map<string, TaskGroup>,
-    usageRuns: Map<string, TokenUsageStats>,
-  ): string | null {
-    let latest: { id: string; start: number } | null = null;
-
-    // Find latest root task group by startTime
-    for (const group of groups.values()) {
-      if (group.parentGroupId) continue;
-      if (!candidates.has(group.id)) continue;
-
-      const startTime = group.startTime;
-      if (!latest || startTime >= latest.start) {
-        latest = { id: group.id, start: startTime };
-      }
-    }
-
-    if (latest) return latest.id;
-
-    // For tool-use sessions (no task groups), fall back to usage runs
-    if (usageRuns.size > 0) {
-      return [...usageRuns.keys()].at(-1) ?? null;
-    }
-
-    return null;
+  /** Delete instruction for a run */
+  async deleteRunInstruction(
+    stream: StreamTabId,
+    runId: StorageKey,
+  ): Promise<void> {
+    await this._runInstructions.deleteRun(stream, runId);
   }
 
   private loadActiveRunIds(): void {

--- a/src/progressView/streamInfoUtils.ts
+++ b/src/progressView/streamInfoUtils.ts
@@ -4,10 +4,11 @@ import * as path from 'path';
 // Local imports - progress view
 import { getCleanAgentName, isRemoteAgent } from '@agent/index';
 import { AgentCategory } from '@agent/core/AgentDataclass';
+import type { AgentTypeFilter } from '@agent/types/AgentStreamTypes';
 
 // Type imports
 import type { ProgressViewState } from './state/ProgressViewState';
-import type { AgentFilter, StreamTabInfo } from './types';
+import type { StreamTabInfo } from './types';
 
 const sortComparators: Record<
   string,
@@ -26,7 +27,7 @@ const sortComparators: Record<
  */
 function matchesFilter(
   category: AgentCategory | undefined,
-  filter: AgentFilter,
+  filter: AgentTypeFilter,
 ): AgentCategory | null {
   if (filter === 'all') {
     return category ?? AgentCategory.Workflow;
@@ -50,7 +51,7 @@ function buildStreamInfo(
   state: ProgressViewState,
   id: string,
   statuses: Map<string, string> | undefined,
-  filter: AgentFilter,
+  filter: AgentTypeFilter,
 ): StreamTabInfo | null {
   const taskState = state.getTaskState(id);
   const hints = state.getStreamHints(id);
@@ -106,7 +107,7 @@ function buildStreamInfo(
 export function buildStreamInfos(
   state: ProgressViewState,
   statuses?: Map<string, string>,
-  filter: AgentFilter = 'all',
+  filter: AgentTypeFilter = 'all',
 ): StreamTabInfo[] {
   const infos = state.streamTabs
     .keys()

--- a/src/progressView/types.ts
+++ b/src/progressView/types.ts
@@ -45,3 +45,19 @@ export const InstructionUpdateSchema = z.object({
   metadata: InstructionMetadataSchema.optional(),
 });
 export type InstructionUpdate = z.infer<typeof InstructionUpdateSchema>;
+
+// ============================================================================
+// Round Data Types
+// ============================================================================
+
+/**
+ * Map from round number to items for that round.
+ * Used for output files, missing outputs, etc. that are organized by round.
+ */
+export type RoundMap<T> = Map<number, T[]>;
+
+/**
+ * Map from run ID to round maps (run → round → items).
+ * Nested structure for per-run, per-round data.
+ */
+export type RunRoundMap<T> = Map<string, RoundMap<T>>;

--- a/src/progressView/types.ts
+++ b/src/progressView/types.ts
@@ -32,8 +32,6 @@ export const StreamTabInfoSchema = z.object({
 });
 export type StreamTabInfo = z.infer<typeof StreamTabInfoSchema>;
 
-export type AgentFilter = AgentTypeFilter;
-
 export const InstructionMetadataSchema = z.object({
   showToggle: z.boolean().optional(),
   expanded: z.boolean().optional(),


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Implements a broadcast-first progress view architecture and consolidates per-stream state to reduce races and simplify updates.
> 
> - Backend now broadcasts run-scoped updates regardless of active stream via `isWebviewAvailable()`; frontend determines visibility. Missing outputs are included in initial `UPDATE_LOGS` payloads. 
> - Replaces expensive `resolveRunId` with cached `getActiveRunId`; adds state APIs to get/set/delete run instructions; consolidates ephemeral data into a single session state map (hints, todos, contextState, activeRunId).
> - Refactors event handlers (logs, outputs, usage, todos) to accept payloads directly, guard INTERNAL logs, and conditionally update webview; `setTaskState` only refreshes streams when needed.
> - WebviewUpdater gains stricter types, `runMissingOutputs` support, and removes full `updateUsage`; frontend handlers clear and rebuild run-scoped caches correctly and simplify run filtering in `taskManagers`.
> - StreamTabsManager adds immutable `getMessages` and `updateMessage` helpers.
> - ProgressViewMessageHandler and follow-up/pack/clean operations now use `getActiveRunId` for storage key resolution.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0f0c2f55bcb885a9f20344ba199b0c163fec5cfe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->