### PR TITLE
Find and refactor pass-through functions

### DIFF
--- a/src/agent/runtime/AgentProposalCoordinator.ts
+++ b/src/agent/runtime/AgentProposalCoordinator.ts
@@ -80,30 +80,6 @@ class AgentProposalCoordinatorImpl extends BasePromiseCoordinator<
     );
   }
 
-  /** Approve a proposal. Returns true if approved, false if no pending proposal. */
-  approveProposal(proposalId: string): boolean {
-    return this.resolveRequest(proposalId, { action: 'approve' });
-  }
-
-  /** Reject a proposal with optional feedback. Returns true if rejected. */
-  rejectProposal(proposalId: string, feedback?: string): boolean {
-    return this.resolveRequest(proposalId, { action: 'reject', feedback });
-  }
-
-  /** Open proposal in main view for editing. Returns true if initiated. */
-  setupProposal(proposalId: string): boolean {
-    return this.resolveRequest(proposalId, { action: 'setup' });
-  }
-
-  /** Check if a proposal is pending. */
-  hasPendingProposal(proposalId: string): boolean {
-    return this.hasPendingRequest(proposalId);
-  }
-
-  /** Clear a pending proposal. */
-  clearProposal(proposalId: string): void {
-    this.clearRequest(proposalId);
-  }
 }
 
 // ============================================================================

--- a/src/agent/runtime/BasePromiseCoordinator.ts
+++ b/src/agent/runtime/BasePromiseCoordinator.ts
@@ -162,7 +162,7 @@ export abstract class BasePromiseCoordinator<
   /**
    * Resolve a pending request with a result.
    */
-  protected resolveRequest(id: string, result: TResult): boolean {
+  resolveRequest(id: string, result: TResult): boolean {
     const req = this.getPendingRequest(id);
     if (!req) return false;
 

--- a/src/auth/serverKeys/ServerSideKeyService.ts
+++ b/src/auth/serverKeys/ServerSideKeyService.ts
@@ -215,15 +215,6 @@ export class ServerSideKeyService {
   // ==========================================================================
 
   /**
-   * Get the cached list of enabled providers (synchronous).
-   * Returns empty array if tier config not fetched yet.
-   * Call canUseServerSideKeys() first to prime the cache.
-   */
-  getEnabledProvidersSync(): string[] {
-    return this.tierService.getProviders();
-  }
-
-  /**
    * Check if a provider has API keys configured on the server.
    * All tiers have access to the same providers.
    */

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -471,10 +471,13 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
 
     switch (action) {
       case 'approve':
-        proposalCoordinator.approveProposal(proposalId);
+        proposalCoordinator.resolveRequest(proposalId, { action: 'approve' });
         break;
       case 'reject':
-        proposalCoordinator.rejectProposal(proposalId, feedback);
+        proposalCoordinator.resolveRequest(proposalId, {
+          action: 'reject',
+          feedback,
+        });
         break;
       case 'setup':
         await this.handleAgentProposalSetup(proposalId);
@@ -574,7 +577,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
 
     // Resolve the proposal with 'setup' action to dismiss it from the UI
     // (user will manually execute from the main view after editing)
-    proposalCoordinator.setupProposal(proposalId);
+    proposalCoordinator.resolveRequest(proposalId, { action: 'setup' });
 
     // Open the main view with the proposal details
     await vscode.commands.executeCommand('texra.mainView.focus');


### PR DESCRIPTION
- Remove 5 pass-through methods from AgentProposalCoordinator (approveProposal, rejectProposal, setupProposal, hasPendingProposal, clearProposal) - callers now use base class resolveRequest directly
- Make BasePromiseCoordinator.resolveRequest public to support this
- Remove unused getEnabledProvidersSync from ServerSideKeyService (duplicate of getEffectiveProvidersForCurrentUser)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors proposal handling to remove redundant pass-throughs and call the base coordinator directly.
> 
> - Remove 5 pass-through methods from `AgentProposalCoordinator` and rely on `BasePromiseCoordinator.resolveRequest`
> - Make `resolveRequest` public in `BasePromiseCoordinator`
> - Update `ProgressViewMessageHandler` to call `proposalCoordinator.resolveRequest` for `approve`/`reject`/`setup`
> - Remove unused `getEnabledProvidersSync` from `ServerSideKeyService`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d00d5fbb7cdf1830516385e3a853e3cd95c62f65. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->