### PR TITLE
claude/map-abstraction-layers-DW4P7

### DIFF
--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -448,10 +448,31 @@ async function runFlowWithLifecycle(
       );
     }
     logger.debug(`Task completed with status: ${flowStatus}`);
-  } catch (error) {
+  } catch (err) {
     ctx.runStage.end(END_GROUP_STATUS.ERROR);
     StreamStatusService.set(streamTabId, STREAM_STATUS.ERROR);
-    await handleFlowError(error, agentName, ctx.logger);
+
+    // Handle flow error inline
+    const rawMsg = toErrorMessage(err);
+    const errorMsg = `Error executing agent ${agentName}: ${getSdkErrorMessage(err)}`;
+
+    // Show appropriate notification based on error type
+    const isApiKeyError =
+      rawMsg.includes('Missing API key') ||
+      rawMsg.includes('API key not found');
+    if (isApiKeyError) {
+      await showApiKeyErrorNotification();
+    } else {
+      vscode.window.showErrorMessage(errorMsg);
+    }
+
+    // Log error directly without creating a new visible group
+    // (error is already captured in runStage with ERROR status)
+    await ctx.logger.logError(errorMsg, err, {
+      operation: `execute ${agentName}`,
+    });
+
+    throw new Error(errorMsg);
   }
 }
 
@@ -506,32 +527,6 @@ async function showApiKeyErrorNotification(): Promise<void> {
     ],
     false,
   );
-}
-
-async function handleFlowError(
-  err: unknown,
-  agentName: string,
-  agentLogger: AgentLogger,
-): Promise<never> {
-  const rawMsg = toErrorMessage(err);
-  const errorMsg = `Error executing agent ${agentName}: ${getSdkErrorMessage(err)}`;
-
-  // Show appropriate notification based on error type
-  const isApiKeyError =
-    rawMsg.includes('Missing API key') || rawMsg.includes('API key not found');
-  if (isApiKeyError) {
-    await showApiKeyErrorNotification();
-  } else {
-    vscode.window.showErrorMessage(errorMsg);
-  }
-
-  // Log error directly without creating a new visible group
-  // (error is already captured in runStage with ERROR status)
-  await agentLogger.logError(errorMsg, err, {
-    operation: `execute ${agentName}`,
-  });
-
-  throw new Error(errorMsg);
 }
 
 // ============================================================================

--- a/src/historyView/HistoryViewMessageHandler.ts
+++ b/src/historyView/HistoryViewMessageHandler.ts
@@ -63,7 +63,8 @@ export class HistoryViewMessageHandler extends BaseViewMessageHandler<
       operationName,
       async ({ historyId }) => {
         try {
-          const historyItem = await AgentHistoryManager.getHistoryItemById(historyId);
+          const historyItem =
+            await AgentHistoryManager.getHistoryItemById(historyId);
           if (!historyItem) {
             await vscode.window.showErrorMessage('History item not found');
             return;
@@ -118,7 +119,8 @@ export class HistoryViewMessageHandler extends BaseViewMessageHandler<
       'deleteAgent',
       async ({ historyId }) => {
         try {
-          const deleted = await AgentHistoryManager.deleteHistoryItemById(historyId);
+          const deleted =
+            await AgentHistoryManager.deleteHistoryItemById(historyId);
           if (deleted) {
             await this.sendHistoryData(view.webview);
           } else {

--- a/src/webview/managers/ExecutionManager.ts
+++ b/src/webview/managers/ExecutionManager.ts
@@ -124,7 +124,7 @@ export class ExecutionManager {
     const files = message.outputFiles?.join(', ') ?? '';
     logger.info(
       CHANNEL,
-      `${capitalize(operation)} multiple files: ${message.inputFile}, ${files}`,
+      \`\${capitalize(operation)} multiple files: \${message.inputFile}, \${files}\`,
     );
     this.runCommand(message, ['inputFile', 'agent', 'model', 'outputFiles']);
   }
@@ -134,7 +134,7 @@ export class ExecutionManager {
     paramKeys: (keyof CommandMessage)[],
   ): void {
     void vscode.commands.executeCommand(
-      `texra.${message.command}`,
+      \`texra.\${message.command}\`,
       ...paramKeys.map((k) => message[k]),
     );
   }

--- a/src/webview/managers/ExecutionManager.ts
+++ b/src/webview/managers/ExecutionManager.ts
@@ -85,7 +85,7 @@ export class ExecutionManager {
       : ToolConfigSchema.parse(message);
 
     // Schema provides defaults via .prefault(), we only override conditional fields
-    const config = AgentConfigSchema.parse({
+    const parseResult = AgentConfigSchema.safeParse({
       ...message,
       session: isToolUse
         ? { agentType: AgentType.ToolUse, agentCategory: AgentCategory.ToolUse }
@@ -102,7 +102,20 @@ export class ExecutionManager {
       editedFile: null,
     });
 
-    await vscode.commands.executeCommand('texra.execute', config);
+    if (!parseResult.success) {
+      const issue = parseResult.error.issues[0];
+      const errorPath = issue?.path.join('.') || 'unknown';
+      vscode.window.showErrorMessage(
+        `Invalid configuration (${errorPath}): ${issue?.message ?? 'validation failed'}`,
+      );
+      logger.error(
+        CHANNEL,
+        `AgentConfig validation failed: ${parseResult.error.message}`,
+      );
+      return;
+    }
+
+    await vscode.commands.executeCommand('texra.execute', parseResult.data);
   }
 
   handleFileOperation(message: CommandMessage): void {

--- a/src/webview/managers/ExecutionManager.ts
+++ b/src/webview/managers/ExecutionManager.ts
@@ -2,14 +2,14 @@
 import * as vscode from 'vscode';
 
 // Local imports - agent core
-import type { AgentConfigPayload } from '@agent/core/AgentConfig';
-// Internal imports
 import {
-  AgentCategory,
-  AgentType,
-  type AgentSessionDescriptor,
-} from '@agent/core/AgentDataclass';
-import { DEFAULT_TOOL_CONFIG, ToolConfig } from '@agent/core/ToolConfig';
+  AgentConfigSchema,
+  type AgentConfigInput,
+} from '@agent/core/AgentConfig';
+// Internal imports
+import { AgentCategory, AgentType } from '@agent/core/AgentDataclass';
+import { DEFAULT_TOOL_CONFIG, ToolConfigSchema } from '@agent/core/ToolConfig';
+import type { z } from 'zod';
 import * as logger from '@logger/logUtils';
 import { capitalize } from '@utils/text/stringUtils';
 import {
@@ -20,12 +20,47 @@ import {
 const CHANNEL = 'ExecutionManager';
 logger.initialize(CHANNEL);
 
+/**
+ * Message shape from webview for agent execution.
+ * Extends AgentConfigInput with UI-specific fields.
+ * ToolConfig fields are sent flat from the UI form.
+ */
+type ExecuteMessage = AgentConfigInput & {
+  /** UI toggle indicating tool-use vs workflow agent */
+  isToolUseAgent?: boolean;
+  /** UI toggle for multiple outputs mode */
+  outputFilesActive?: boolean;
+  /** Media files may contain nulls from UI (filtered during processing) */
+  mediaFiles?: (string | null)[];
+} & z.input<typeof ToolConfigSchema>;
+
+/** Message shape for command-based operations. */
+interface CommandMessage {
+  command: string;
+  inputFile?: string;
+  baseFile?: string;
+  editedFile?: string;
+  agent?: string;
+  model?: string;
+  outputFiles?: string[];
+}
+
 export class ExecutionManager {
-  async handleExecute(message: any): Promise<void> {
-    const isToolUseAgent = Boolean(message.isToolUseAgent);
+  async handleExecute(message: ExecuteMessage): Promise<void> {
+    // IMPORTANT: Validate required fields before schema parsing.
+    // AgentConfigSchema uses .prefault() for agent/model (see AgentConfig.ts:96-97),
+    // which would silently provide defaults instead of failing on missing values.
+    if (!message.agent || !message.model) {
+      vscode.window.showErrorMessage(
+        'Agent and model selection required. Please select both before running.',
+      );
+      return;
+    }
+
+    const isToolUse = Boolean(message.isToolUseAgent);
 
     // Tool-use agents don't need input file validation
-    if (!isToolUseAgent && !message.inputFile) {
+    if (!isToolUse && !message.inputFile) {
       const openDocs = 'File Management Guide';
       const choice = await vscode.window.showErrorMessage(
         'Please select an input file.',
@@ -37,87 +72,56 @@ export class ExecutionManager {
       return;
     }
 
-    const config = this.composeAgentConfig(message, isToolUseAgent);
-    await vscode.commands.executeCommand('texra.execute', config);
-  }
-
-  private composeAgentConfig(
-    message: any,
-    isToolUse: boolean,
-  ): AgentConfigPayload {
-    // Session descriptor depends on agent type
-    const session: AgentSessionDescriptor = isToolUse
-      ? { agentType: AgentType.ToolUse, agentCategory: AgentCategory.ToolUse }
-      : { agentCategory: AgentCategory.Workflow };
+    // Map media file paths (pasted images need full path resolution)
+    const mapMedia = (f: string | null): string | null =>
+      f && isPastedImage(f) ? getPastedImageFullPath(f) : f;
 
     // Tool-use agents don't produce output files
     const outputFiles: string[] = isToolUse ? [] : (message.outputFiles ?? []);
-    const useMultipleOutputs =
-      !isToolUse &&
-      (Boolean(message.outputFilesActive) || outputFiles.length > 1);
 
-    // Tool config: workflow agents use message values, tool-use uses defaults
-    const toolConfig: ToolConfig = isToolUse
+    // Tool config: tool-use uses defaults, workflow agents use message values (schema provides defaults)
+    const toolConfig = isToolUse
       ? DEFAULT_TOOL_CONFIG
-      : {
-          autoExtractFigure: message.autoExtractFigure,
-          autoExtractTikzFigure: message.autoExtractTikzFigure,
-          attachTeXCount: message.attachTeXCount,
-          attachDiagnostics: message.attachDiagnostics,
-          autoCompileInputPdf: message.autoCompileInputPdf,
-        };
+      : ToolConfigSchema.parse(message);
 
-    // Map media file paths, filtering out null values
-    const mapMedia = (f: string | null): string | null => this.mapMediaPath(f);
-    const mediaFiles = (message.mediaFiles ?? [])
-      .map(mapMedia)
-      .filter((f: string | null): f is string => f !== null);
-
-    return {
-      agent: message.agent,
-      model: message.model,
-      instruction: message.instruction,
-      inputFile: message.inputFile ?? '',
-      inputFiles: message.inputFiles ?? [],
-      referenceFile: message.referenceFile ?? null,
-      referenceFiles: message.referenceFiles ?? [],
-      auxiliaryFile: message.auxiliaryFile ?? null,
-      auxiliaryFiles: message.auxiliaryFiles ?? [],
-      mediaFile: mapMedia(message.mediaFile ?? null),
-      mediaFiles,
-      editedFile: null,
-      editedFiles: message.editedFiles ?? [],
-      agentType: session.agentType,
-      session,
-      toolConfig,
-      useMultipleOutputs,
+    // Schema provides defaults via .prefault(), we only override conditional fields
+    const config = AgentConfigSchema.parse({
+      ...message,
+      session: isToolUse
+        ? { agentType: AgentType.ToolUse, agentCategory: AgentCategory.ToolUse }
+        : { agentCategory: AgentCategory.Workflow },
       outputFiles,
-    };
+      useMultipleOutputs:
+        !isToolUse &&
+        (Boolean(message.outputFilesActive) || outputFiles.length > 1),
+      toolConfig,
+      mediaFile: mapMedia(message.mediaFile ?? null),
+      mediaFiles: (message.mediaFiles ?? [])
+        .map(mapMedia)
+        .filter((f: string | null): f is string => f !== null),
+      editedFile: null,
+    });
+
+    await vscode.commands.executeCommand('texra.execute', config);
   }
 
-  private mapMediaPath(f: string | null): string | null {
-    return f && isPastedImage(f) ? getPastedImageFullPath(f) : f;
-  }
-
-  handleFileOperation(message: any): void {
+  handleFileOperation(message: CommandMessage): void {
     this.runCommand(message, ['inputFile', 'baseFile', 'editedFile']);
   }
 
-  handleHousekeeping(message: any): void {
+  handleHousekeeping(message: CommandMessage): void {
     this.runCommand(message, []);
   }
 
-  handleSingleOperation(message: any): void {
+  handleSingleOperation(message: CommandMessage): void {
     this.runCommand(message, ['inputFile', 'agent', 'model']);
   }
 
-  handleMultipleOperation(message: any): void {
+  handleMultipleOperation(message: CommandMessage): void {
     const operation = message.command.startsWith('pack')
       ? 'Packing'
       : 'Cleaning';
-    const files = Array.isArray(message.outputFiles)
-      ? message.outputFiles.join(', ')
-      : '';
+    const files = message.outputFiles?.join(', ') ?? '';
     logger.info(
       CHANNEL,
       `${capitalize(operation)} multiple files: ${message.inputFile}, ${files}`,
@@ -125,7 +129,10 @@ export class ExecutionManager {
     this.runCommand(message, ['inputFile', 'agent', 'model', 'outputFiles']);
   }
 
-  private runCommand(message: any, paramKeys: string[]): void {
+  private runCommand(
+    message: CommandMessage,
+    paramKeys: (keyof CommandMessage)[],
+  ): void {
     void vscode.commands.executeCommand(
       `texra.${message.command}`,
       ...paramKeys.map((k) => message[k]),

--- a/src/webview/managers/ExecutionManager.ts
+++ b/src/webview/managers/ExecutionManager.ts
@@ -124,7 +124,7 @@ export class ExecutionManager {
     const files = message.outputFiles?.join(', ') ?? '';
     logger.info(
       CHANNEL,
-      \`\${capitalize(operation)} multiple files: \${message.inputFile}, \${files}\`,
+      `${capitalize(operation)} multiple files: ${message.inputFile}, ${files}`,
     );
     this.runCommand(message, ['inputFile', 'agent', 'model', 'outputFiles']);
   }
@@ -134,7 +134,7 @@ export class ExecutionManager {
     paramKeys: (keyof CommandMessage)[],
   ): void {
     void vscode.commands.executeCommand(
-      \`texra.\${message.command}\`,
+      `texra.${message.command}`,
       ...paramKeys.map((k) => message[k]),
     );
   }


### PR DESCRIPTION
- Inline handleFlowError() into runFlowWithLifecycle() catch block (single call site, no reuse benefit)

- Inline composeAgentConfig() and mapMediaPath() into handleExecute() (private methods called once, added indirection without value)

- Use AgentConfigSchema.parse() with spread to leverage .prefault() defaults instead of manual `?? ''` / `?? []` for every field

Reduces call chain depth from 17 to 15 layers for "run agent" action.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Refactors execution path and error handling**
> 
> - Rewrites `ExecutionManager.handleExecute` to validate inputs early and build config via `AgentConfigSchema.safeParse` and `ToolConfigSchema`, with defaults applied and proper error surfacing; maps media paths and differentiates tool-use vs workflow (output files, session metadata) before invoking `texra.execute`.
> - Strongly types webview messages (`ExecuteMessage`, `CommandMessage`) and handlers; simplifies command routing and logging.
> - Inlines flow error handling inside `runFlowWithLifecycle` in `executeAgent.ts`, showing API key guidance, logging via `ctx.logger.logError`, and rethrowing a normalized error; removes the unused `handleFlowError` helper.
> - Minor formatting/cleanup in history view message handling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 39424db787364a81b5ba33dda721b92ebed40879. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->