### PR TITLE
claude/scout-zod-usage-IS9LP

### DIFF
--- a/src/test/tools/grep.test.ts
+++ b/src/test/tools/grep.test.ts
@@ -5,7 +5,8 @@ import { strict as assert } from 'assert';
 import { buildArguments, type GrepInput } from '@tools/grep';
 
 describe('buildArguments', () => {
-  const baseInput: GrepInput = { pattern: 'example' };
+  // output_mode is required after transform normalizes nullish to 'content'
+  const baseInput: GrepInput = { pattern: 'example', output_mode: 'content' };
 
   it('omits --files-with-matches when using content mode', () => {
     const args = buildArguments(baseInput, 'content');

--- a/src/tools/EditTool.ts
+++ b/src/tools/EditTool.ts
@@ -24,7 +24,10 @@ const EditInputSchema = z.strictObject({
   path: z.string(),
   old_string: z.string(),
   new_string: z.string(),
-  replace_all: z.boolean().nullish(),
+  replace_all: z
+    .boolean()
+    .nullish()
+    .transform((v) => v ?? false),
 });
 
 export type EditInput = z.infer<typeof EditInputSchema>;

--- a/src/tools/EditTool.ts
+++ b/src/tools/EditTool.ts
@@ -24,10 +24,7 @@ const EditInputSchema = z.strictObject({
   path: z.string(),
   old_string: z.string(),
   new_string: z.string(),
-  replace_all: z
-    .boolean()
-    .nullish()
-    .transform((v) => v ?? false),
+  replace_all: z.boolean().nullish(),
 });
 
 export type EditInput = z.infer<typeof EditInputSchema>;

--- a/src/tools/ReadTool.ts
+++ b/src/tools/ReadTool.ts
@@ -115,7 +115,10 @@ export class ReadFileTool extends defineTool({
 
     const segments: string[] = [];
     if (visibleLines.length > 0) {
-      const numberedLines = formatLinesWithNumbers(visibleLines, startIndex + 1);
+      const numberedLines = formatLinesWithNumbers(
+        visibleLines,
+        startIndex + 1,
+      );
       segments.push(numberedLines.join('\n'));
     }
     if (truncated) {

--- a/src/tools/ReadTool.ts
+++ b/src/tools/ReadTool.ts
@@ -6,7 +6,7 @@ import { z } from 'zod';
 
 // Local imports - tools
 import { ToolResult } from '@tools/result';
-import { buildFileAttachment } from '@tools/utils';
+import { buildFileAttachment, formatLinesWithNumbers } from '@tools/utils';
 import { recordToolFileRead } from '@tools/fileInteractions';
 import { WorkspaceFS, getMimeType } from '@utils/files';
 
@@ -115,10 +115,7 @@ export class ReadFileTool extends defineTool({
 
     const segments: string[] = [];
     if (visibleLines.length > 0) {
-      const numberedLines = this.formatWithLineNumbers(
-        visibleLines,
-        startIndex + 1,
-      );
+      const numberedLines = formatLinesWithNumbers(visibleLines, startIndex + 1);
       segments.push(numberedLines.join('\n'));
     }
     if (truncated) {
@@ -148,18 +145,6 @@ export class ReadFileTool extends defineTool({
       summary,
       output: segments.join('\n'),
     };
-  }
-
-  private formatWithLineNumbers(
-    lines: string[],
-    startingLine: number,
-  ): string[] {
-    const width = 6;
-    return lines.map((line, index) => {
-      const lineNumber = startingLine + index;
-      const prefix = lineNumber.toString().padStart(width, ' ');
-      return `${prefix}\t${line}`;
-    });
   }
 
   private buildSummary({

--- a/src/tools/arxiv/ArxivDownloadTool.ts
+++ b/src/tools/arxiv/ArxivDownloadTool.ts
@@ -13,7 +13,10 @@ import { arxivProcessor } from '@latex/arxivProcessor';
 
 const ArxivDownloadInputSchema = z.strictObject({
   id: z.string(),
-  autoIndent: z.boolean().nullish(),
+  autoIndent: z
+    .boolean()
+    .nullish()
+    .transform((v) => v ?? true),
 });
 
 export type ArxivDownloadInput = z.infer<typeof ArxivDownloadInputSchema>;
@@ -39,7 +42,7 @@ export class ArxivDownloadTool extends defineTool({
       downloadPath = await arxivProcessor.downloadSource(
         arxivId,
         undefined,
-        input.autoIndent ?? true,
+        input.autoIndent,
       );
     } catch (err) {
       throw new ToolError(

--- a/src/tools/arxiv/ArxivMetadataTool.ts
+++ b/src/tools/arxiv/ArxivMetadataTool.ts
@@ -17,7 +17,10 @@ import { arxivProcessor } from '@latex/arxivProcessor';
 
 const ArxivMetadataInputSchema = z.strictObject({
   id: z.string(),
-  includeAbstract: z.boolean().nullish(),
+  includeAbstract: z
+    .boolean()
+    .nullish()
+    .transform((v) => v ?? true),
   maxAuthors: z.int().positive().max(ARXIV_CONSTANTS.MAX_AUTHORS).nullish(),
 });
 
@@ -58,7 +61,7 @@ export class ArxivMetadataTool extends defineTool({
       targetEntry,
       input.maxAuthors ?? undefined,
     );
-    const includeAbstract = input.includeAbstract ?? true;
+    const { includeAbstract } = input;
 
     const metadata: ArxivPaperMetadata = {
       ...base,

--- a/src/tools/arxiv/ArxivSearchTool.ts
+++ b/src/tools/arxiv/ArxivSearchTool.ts
@@ -27,12 +27,23 @@ const SearchFieldSchema = z.enum(['all', 'author', 'title', 'abstract']);
 
 const ArxivSearchInputSchema = z.strictObject({
   query: z.string(),
-  field: SearchFieldSchema.nullish().describe(
-    'Search field: "author" for author names, "title" for paper titles, "abstract" for abstracts, "all" (default) for all fields',
-  ),
+  field: SearchFieldSchema.nullish()
+    .transform((v) => v ?? 'all')
+    .describe(
+      'Search field: "author" for author names, "title" for paper titles, "abstract" for abstracts, "all" (default) for all fields',
+    ),
   categories: z.array(z.string()).nullish(),
-  maxResults: z.int().positive().max(ARXIV_CONSTANTS.MAX_RESULTS).nullish(),
-  start: z.int().min(0).nullish(),
+  maxResults: z
+    .int()
+    .positive()
+    .max(ARXIV_CONSTANTS.MAX_RESULTS)
+    .nullish()
+    .transform((v) => v ?? ARXIV_CONSTANTS.DEFAULT_RESULTS),
+  start: z
+    .int()
+    .min(0)
+    .nullish()
+    .transform((v) => v ?? 0),
   sortBy: SortBySchema.nullish(),
   sortOrder: SortOrderSchema.nullish(),
 });
@@ -49,7 +60,7 @@ export class ArxivSearchTool extends defineTool({
     const trimmedQuery = requireNonEmptyString(input.query, 'Search query');
 
     // Select the query function based on the field parameter
-    const searchField = input.field ?? 'all';
+    const { field: searchField } = input;
     const fieldQueryFns = {
       author: authorQuery,
       title: titleQuery,
@@ -91,8 +102,8 @@ export class ArxivSearchTool extends defineTool({
 
     let client = createArxivClient()
       .query(query)
-      .start(input.start ?? 0)
-      .maxResults(input.maxResults ?? ARXIV_CONSTANTS.DEFAULT_RESULTS);
+      .start(input.start)
+      .maxResults(input.maxResults);
 
     if (input.sortBy) {
       client = client.sortBy(input.sortBy);
@@ -121,7 +132,7 @@ export class ArxivSearchTool extends defineTool({
     const payload = {
       query: trimmedQuery,
       field: searchField,
-      start: input.start ?? 0,
+      start: input.start,
       count: results.length,
       totalResults: null, // arxiv-client doesn't expose totalResults
       results,

--- a/src/tools/citation/CrossrefSearchTool.ts
+++ b/src/tools/citation/CrossrefSearchTool.ts
@@ -19,7 +19,12 @@ import { waitForRateLimit } from './rateLimiter';
 
 const CrossrefSearchInputSchema = z.strictObject({
   query: z.string(),
-  rows: z.int().positive().max(CROSSREF_CONSTANTS.MAX_ROWS).nullish(),
+  rows: z
+    .int()
+    .positive()
+    .max(CROSSREF_CONSTANTS.MAX_ROWS)
+    .nullish()
+    .transform((v) => v ?? CROSSREF_CONSTANTS.DEFAULT_ROWS),
   offset: z.int().min(0).nullish(),
   sort: z.string().nullish(),
   order: z.enum(['asc', 'desc']).nullish(),
@@ -50,7 +55,7 @@ export class CrossrefSearchTool extends defineTool({
 
     const options: ExtendedQueryWorksParams = {
       query: trimmedQuery,
-      rows: input.rows ?? CROSSREF_CONSTANTS.DEFAULT_ROWS,
+      rows: input.rows,
       ...(typeof input.offset === 'number' && { offset: input.offset }),
       ...(input.sort && { sort: input.sort as WorkSortOptions }),
       ...(input.order && {

--- a/src/tools/grep.ts
+++ b/src/tools/grep.ts
@@ -18,7 +18,10 @@ const GrepInputSchema = z.strictObject({
   pattern: z.string().min(1, 'pattern is required'),
   path: z.string().nullish(),
   glob: z.string().nullish(),
-  output_mode: z.enum(OUTPUT_MODES).nullish(),
+  output_mode: z
+    .enum(OUTPUT_MODES)
+    .nullish()
+    .transform((v) => v ?? 'content'),
   '-B': z.int().min(0).nullish(),
   '-A': z.int().min(0).nullish(),
   '-C': z.int().min(0).nullish(),
@@ -83,7 +86,7 @@ export class GrepTool extends defineTool({
   schema: GrepInputSchema,
 }) {
   protected async execute(input: GrepInput): Promise<ToolResult> {
-    const outputMode: OutputMode = input.output_mode ?? 'content';
+    const { output_mode: outputMode } = input;
     const { resolved: searchPath, display } = resolveAndFormat(
       input.path ?? undefined,
     );

--- a/src/tools/memory/MemoryTool.ts
+++ b/src/tools/memory/MemoryTool.ts
@@ -11,29 +11,17 @@ import { StorageFS } from '@utils/files';
 // Local imports - tool core
 import { defineTool } from '../core/define';
 import { ToolError, type ToolResult } from '../result';
+import { formatLinesWithNumbers } from '../utils';
 
 // Local imports - shared memory constants and utilities
 import {
   MEMORY_DISPLAY_ROOT,
   MEMORY_STORAGE_ROOT,
   MAX_VIEW_LINES,
-  LINE_NUMBER_WIDTH,
   DIRECTORY_LISTING_DEPTH,
   shouldSkipEntry,
 } from './constants';
 import { toDisplayPath, formatSize, displayToStoragePath } from './memoryUtils';
-
-function formatLinesWithNumbers(
-  lines: string[],
-  startIndex: number = 0,
-): string[] {
-  return lines.map((line, index) => {
-    const lineNumber = (startIndex + index + 1)
-      .toString()
-      .padStart(LINE_NUMBER_WIDTH, ' ');
-    return `${lineNumber}\t${line}`;
-  });
-}
 
 const MemoryToolInputSchema = z.strictObject({
   command: z.enum([
@@ -214,7 +202,7 @@ Paths must start with /memories. Use /memories to list files, /memories/file.md 
     const startIndex = Math.max(start - 1, 0);
     const endIndex = Math.min(end, lines.length);
     const selected = lines.slice(startIndex, endIndex);
-    const numbered = formatLinesWithNumbers(selected, startIndex);
+    const numbered = formatLinesWithNumbers(selected, startIndex + 1);
 
     return {
       output: [

--- a/src/tools/memory/constants.ts
+++ b/src/tools/memory/constants.ts
@@ -12,9 +12,6 @@ export const MEMORY_STORAGE_ROOT = 'memories';
 /** Maximum lines to display in tool view output */
 export const MAX_VIEW_LINES = 999_999;
 
-/** Line number padding width for formatted output */
-export const LINE_NUMBER_WIDTH = 6;
-
 /** Maximum directory depth for listings */
 export const DIRECTORY_LISTING_DEPTH = 2;
 

--- a/src/tools/texcount/TexcountTool.ts
+++ b/src/tools/texcount/TexcountTool.ts
@@ -14,7 +14,10 @@ import {
 
 const TexcountInputSchema = z.strictObject({
   files: z.union([z.string(), z.array(z.string()).min(1)]),
-  mode: z.enum(['separate', 'include', 'sum']).nullish(),
+  mode: z
+    .enum(['separate', 'include', 'sum'])
+    .nullish()
+    .transform((v) => v ?? 'separate'),
   format: z.enum(['raw', 'stats']).nullish(),
 });
 
@@ -45,8 +48,7 @@ export class TexcountTool extends defineTool({
       throw new ToolError('No LaTeX files provided for texcount.');
     }
 
-    const mode: TexcountMode = input.mode ?? 'separate';
-    const { output, errors } = await getTeXCount(files, { mode });
+    const { output, errors } = await getTeXCount(files, { mode: input.mode });
 
     if (!output) {
       const errorMessage =

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -95,6 +95,28 @@ export function createGlobMatcher(pattern: string): (value: string) => boolean {
 export { getGitignoreMatcher, clearGitignoreCache } from './gitignore';
 export type { GitignoreMatcher } from './gitignore';
 
+/** Default width for line number padding */
+const LINE_NUMBER_WIDTH = 6;
+
+/**
+ * Format lines with line numbers for display in tool output.
+ * @param lines - Array of lines to format
+ * @param startingLine - 1-based line number for the first line (default: 1)
+ * @param width - Padding width for line numbers (default: 6)
+ * @returns Array of formatted lines with line number prefix and tab separator
+ */
+export function formatLinesWithNumbers(
+  lines: string[],
+  startingLine: number = 1,
+  width: number = LINE_NUMBER_WIDTH,
+): string[] {
+  return lines.map((line, index) => {
+    const lineNumber = startingLine + index;
+    const prefix = lineNumber.toString().padStart(width, ' ');
+    return `${prefix}\t${line}`;
+  });
+}
+
 /**
  * Pluralize a word based on count.
  * Returns the singular form for count === 1, plural form otherwise.

--- a/src/tools/web/WebSearchTool.ts
+++ b/src/tools/web/WebSearchTool.ts
@@ -9,7 +9,12 @@ import { wrapApiCall } from '@tools/utils';
 
 const WebSearchInputSchema = z.strictObject({
   query: z.string(),
-  max_results: z.number().min(1).max(5).nullish(),
+  max_results: z
+    .number()
+    .min(1)
+    .max(5)
+    .nullish()
+    .transform((v) => v ?? 3),
 });
 
 export type WebSearchInput = z.infer<typeof WebSearchInputSchema>;
@@ -38,8 +43,7 @@ export class WebSearchTool extends defineTool({
   schema: WebSearchInputSchema,
 }) {
   protected async execute(input: WebSearchInput): Promise<ToolResult> {
-    const { query } = input;
-    const max_results = input.max_results ?? 3;
+    const { query, max_results } = input;
 
     const response = await wrapApiCall(
       () =>


### PR DESCRIPTION
- Move default values from runtime code into schemas using .nullish().transform(v => v ?? defaultValue) pattern
- Extract shared formatLinesWithNumbers utility to reduce duplication
- Update tools: WebSearchTool, ArxivMetadataTool, ArxivSearchTool, ArxivDownloadTool, CrossrefSearchTool, EditTool, GrepTool, MemoryTool, TexcountTool
- Maintains API compatibility (.nullish() accepts null from APIs) while normalizing to typed defaults in parsed output

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Standardizes input handling and removes duplicated formatting logic.
> 
> - Shift runtime defaults into zod schemas using `.nullish().transform(...)` across `grep`, `web_search`, `arxiv_*`, `crossref_search`, and `texcount` (e.g., `output_mode`, `max_results`, `includeAbstract`, `autoIndent`, `start`, `maxResults`, `rows`, `mode`)
> - Extract shared `formatLinesWithNumbers` to `@tools/utils` and replace per-tool implementations in `ReadTool` and `MemoryTool`; adjust numbering to 1-based
> - Update `ArxivSearchTool` and `CrossrefSearchTool` to use transformed values directly when building client queries
> - Enhance `grep` tests and args builder (e.g., `literal` -> `--fixed-strings`); base test input now sets `output_mode: 'content'`
> - Remove unused line number width constant from memory constants
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 22a50db532dd75fda824cb3c80d7632889b98b50. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->