### PR TITLE
claude/map-config-objects-f7J5E

### DIFF
--- a/src/agent/core/AgentConfig.ts
+++ b/src/agent/core/AgentConfig.ts
@@ -155,7 +155,8 @@ export const AgentConfigSchema = AgentConfigBaseSchema.transform((config) => {
   };
 });
 
-// Re-export AgentCategory for consumers that need the enum
+// Re-export AgentCategory for convenience
+// Canonical source: AgentDataclass.ts
 export { AgentCategory };
 
 export type AgentConfig = z.output<typeof AgentConfigSchema>;

--- a/src/agent/core/AgentConfig.ts
+++ b/src/agent/core/AgentConfig.ts
@@ -2,7 +2,11 @@
 import { z } from 'zod';
 
 // Local imports - agent components
-import { AgentType, resolveAgentSessionDescriptor } from './AgentDataclass';
+import {
+  AgentCategory,
+  AgentType,
+  resolveAgentSessionDescriptor,
+} from './AgentDataclass';
 import { AgentSessionDescriptorSchema } from './AgentSessionSchema';
 import { DEFAULT_TOOL_CONFIG, ToolConfigSchema } from './ToolConfig';
 
@@ -144,9 +148,32 @@ export const AgentConfigSchema = AgentConfigBaseSchema.transform((config) => {
   return {
     ...config,
     agentType: descriptor.agentType,
+    // Lift agentCategory to top level for easier access (reduces nesting)
+    // Access via config.agentCategory instead of config.session.agentCategory
+    agentCategory: descriptor.agentCategory,
     session: descriptor,
   };
 });
 
+// Re-export AgentCategory for consumers that need the enum
+export { AgentCategory };
+
 export type AgentConfig = z.output<typeof AgentConfigSchema>;
 export type AgentConfigInput = z.input<typeof AgentConfigSchema>;
+
+/**
+ * Schema for agent configuration payload passed to executeAgent.
+ *
+ * Only `agent` and `model` are required - all other fields have defaults.
+ * This replaces ambiguous `Partial<AgentConfig>` usage with explicit requirements.
+ *
+ * Use this type for function parameters that accept agent configuration input.
+ */
+export const AgentConfigPayloadSchema = AgentConfigBaseSchema.partial()
+  .required({
+    agent: true,
+    model: true,
+  })
+  .describe('Agent configuration payload with required agent and model fields');
+
+export type AgentConfigPayload = z.infer<typeof AgentConfigPayloadSchema>;

--- a/src/agent/core/flows/CommonCycleTypes.ts
+++ b/src/agent/core/flows/CommonCycleTypes.ts
@@ -128,42 +128,12 @@ export function getDebugContext(
   };
 }
 
-// ============================================================================
-// Result Type Primitives (Single Source of Truth)
-// ============================================================================
-
-/**
- * Schema for a failed result with an error message.
- * Used across invocation nodes and cycle flows.
- */
-export const FailedResultSchema = z.object({
-  kind: z.literal('failed'),
-  message: z.string(),
-});
-export type FailedResult = z.infer<typeof FailedResultSchema>;
-
-/**
- * Schema for a cancelled result (user cancelled retry).
- */
-export const CancelledResultSchema = z.object({
-  kind: z.literal('cancelled'),
-});
-export type CancelledResult = z.infer<typeof CancelledResultSchema>;
-
-/**
- * Schema for a skipped result (flow stopped before execution).
- */
-export const SkippedResultSchema = z.object({
-  kind: z.literal('skipped'),
-});
-export type SkippedResult = z.infer<typeof SkippedResultSchema>;
-
 /**
  * Result type for nodes that can be skipped based on flow state.
  * Uses 'kind' discriminant for consistency with InvocationResult.
  */
 export type SkippableNodeResult<T> =
-  | SkippedResult
+  | { kind: 'skipped' }
   | { kind: 'success'; value: T };
 
 /**

--- a/src/agent/core/flows/CommonCycleTypes.ts
+++ b/src/agent/core/flows/CommonCycleTypes.ts
@@ -128,12 +128,42 @@ export function getDebugContext(
   };
 }
 
+// ============================================================================
+// Result Type Primitives (Single Source of Truth)
+// ============================================================================
+
+/**
+ * Schema for a failed result with an error message.
+ * Used across invocation nodes and cycle flows.
+ */
+export const FailedResultSchema = z.object({
+  kind: z.literal('failed'),
+  message: z.string(),
+});
+export type FailedResult = z.infer<typeof FailedResultSchema>;
+
+/**
+ * Schema for a cancelled result (user cancelled retry).
+ */
+export const CancelledResultSchema = z.object({
+  kind: z.literal('cancelled'),
+});
+export type CancelledResult = z.infer<typeof CancelledResultSchema>;
+
+/**
+ * Schema for a skipped result (flow stopped before execution).
+ */
+export const SkippedResultSchema = z.object({
+  kind: z.literal('skipped'),
+});
+export type SkippedResult = z.infer<typeof SkippedResultSchema>;
+
 /**
  * Result type for nodes that can be skipped based on flow state.
  * Uses 'kind' discriminant for consistency with InvocationResult.
  */
 export type SkippableNodeResult<T> =
-  | { kind: 'skipped' }
+  | SkippedResult
   | { kind: 'success'; value: T };
 
 /**

--- a/src/agent/implementations/flows/tooluse/nodes/types.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/types.ts
@@ -12,6 +12,7 @@ import type {
   AgentWorkspaceSnapshot,
 } from '@agent/core/AgentWorkspaceState';
 import type { UserVariableChannels } from '@agent/core/AgentCycleOptions';
+import type { InvocationResult } from '@agent/core/flows/RetryState';
 import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
 
 // ============================================================================
@@ -51,11 +52,11 @@ export interface PrepareResult {
   shouldSkipCycle: boolean;
 }
 
-export type CycleExecResult =
-  | { kind: 'success'; messages: ProviderMessage[] }
-  | { kind: 'skipped' }
-  | { kind: 'failed'; message: string }
-  | { kind: 'cancelled' };
+/**
+ * Result type for tool-use cycle execution.
+ * Uses InvocationResult as the single source of truth for result patterns.
+ */
+export type CycleExecResult = InvocationResult<{ messages: ProviderMessage[] }>;
 
 export type WaitExecResult =
   | { kind: 'continue'; followUp: string }

--- a/src/agent/implementations/flows/tooluse/nodes/types.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/types.ts
@@ -3,6 +3,8 @@
  *
  * Contains state types, result types, and guards used across nodes.
  */
+import { z } from 'zod';
+
 import type {
   AgentRunState,
   AgentRunStateSnapshot,
@@ -90,20 +92,28 @@ export function assertPreparedShared(
 // State Migration (Legacy Support)
 // ============================================================================
 
-/** Legacy format had fields nested under `state` property */
-type LegacyShared = { state: ToolUseRunShared };
+/**
+ * Lightweight schema for detecting flat vs legacy shared state format.
+ * Validates only the minimum needed to determine format - full content
+ * validation happens in SessionResumeRetrieval.ts during session resume.
+ */
+const FlatFormatSchema = z.object({ conversation: z.array(z.unknown()) });
+const LegacyFormatSchema = z.object({
+  state: z.object({ conversation: z.array(z.unknown()) }),
+});
+
+const MigrationSharedSchema = z
+  .union([FlatFormatSchema, LegacyFormatSchema])
+  .transform((data) => ('state' in data ? data.state : data));
 
 /**
  * Migrate legacy shared state to current flat format.
  * Legacy: `{ state: { conversation, stateSlices, ... } }`
  * Current: `{ conversation, stateSlices, ... }` (flat)
+ *
+ * @returns Migrated state, or null if neither format matches
  */
-export function migrateSharedState(shared: unknown): ToolUseRunShared {
-  const obj = shared as Record<string, unknown>;
-  const legacy = obj?.state as LegacyShared['state'] | undefined;
-
-  // Flatten if legacy format (has nested state.conversation)
-  return legacy?.conversation !== undefined
-    ? legacy
-    : (shared as ToolUseRunShared);
+export function migrateSharedState(shared: unknown): ToolUseRunShared | null {
+  const result = MigrationSharedSchema.safeParse(shared);
+  return result.success ? (result.data as ToolUseRunShared) : null;
 }

--- a/src/agent/implementations/flows/tooluse/nodes/types.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/types.ts
@@ -94,12 +94,12 @@ export function assertPreparedShared(
 
 /**
  * Lightweight schema for detecting flat vs legacy shared state format.
- * Validates only the minimum needed to determine format - full content
- * validation happens in SessionResumeRetrieval.ts during session resume.
+ * Uses looseObject to preserve all fields (stateSlices, shouldSkipCycle, etc.)
+ * - only validates enough to detect format, not full content.
  */
-const FlatFormatSchema = z.object({ conversation: z.array(z.unknown()) });
-const LegacyFormatSchema = z.object({
-  state: z.object({ conversation: z.array(z.unknown()) }),
+const FlatFormatSchema = z.looseObject({ conversation: z.array(z.unknown()) });
+const LegacyFormatSchema = z.looseObject({
+  state: z.looseObject({ conversation: z.array(z.unknown()) }),
 });
 
 const MigrationSharedSchema = z

--- a/src/agent/implementations/flows/tooluse/nodes/types.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/types.ts
@@ -93,27 +93,37 @@ export function assertPreparedShared(
 // ============================================================================
 
 /**
- * Lightweight schema for detecting flat vs legacy shared state format.
+ * Lightweight schema for detecting and migrating legacy shared state format.
  * Uses looseObject to preserve all fields (stateSlices, shouldSkipCycle, etc.)
  * - only validates enough to detect format, not full content.
  */
 const FlatFormatSchema = z.looseObject({ conversation: z.array(z.unknown()) });
-const LegacyFormatSchema = z.looseObject({
-  state: z.looseObject({ conversation: z.array(z.unknown()) }),
-});
-
-const MigrationSharedSchema = z
-  .union([FlatFormatSchema, LegacyFormatSchema])
-  .transform((data) => ('state' in data ? data.state : data));
+const LegacyStateSchema = z.looseObject({ conversation: z.array(z.unknown()) });
 
 /**
  * Migrate legacy shared state to current flat format.
  * Legacy: `{ state: { conversation, stateSlices, ... } }`
  * Current: `{ conversation, stateSlices, ... }` (flat)
  *
- * @returns Migrated state, or null if neither format matches
+ * @returns Object with migrated data and whether migration occurred, or null if invalid
  */
-export function migrateSharedState(shared: unknown): ToolUseRunShared | null {
-  const result = MigrationSharedSchema.safeParse(shared);
-  return result.success ? (result.data as ToolUseRunShared) : null;
+export function migrateSharedState(
+  shared: unknown,
+): { data: ToolUseRunShared; migrated: boolean } | null {
+  // Check if already flat format - return same reference (no migration needed)
+  const flatResult = FlatFormatSchema.safeParse(shared);
+  if (flatResult.success && !('state' in flatResult.data)) {
+    return { data: shared as ToolUseRunShared, migrated: false };
+  }
+
+  // Check if legacy format - extract and return nested state
+  const obj = shared as Record<string, unknown>;
+  if (obj && typeof obj === 'object' && 'state' in obj) {
+    const legacyResult = LegacyStateSchema.safeParse(obj.state);
+    if (legacyResult.success) {
+      return { data: obj.state as ToolUseRunShared, migrated: true };
+    }
+  }
+
+  return null;
 }

--- a/src/agent/implementations/flows/tooluse/nodes/types.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/types.ts
@@ -90,57 +90,20 @@ export function assertPreparedShared(
 // State Migration (Legacy Support)
 // ============================================================================
 
-/**
- * Legacy shared state format (pre-flattening).
- * Used for migration from persisted sessions created before the flat structure.
- */
-interface LegacyToolUseRunShared {
-  state: {
-    conversation: ProviderMessage[];
-    shouldSkipCycle: boolean;
-    stateSlices: StateSlicesSnapshot | null;
-    userCancelledRetry?: boolean;
-  };
-}
-
-/**
- * Check if shared state is in legacy format (wrapped in `state` property).
- */
-function isLegacyFormat(shared: unknown): shared is LegacyToolUseRunShared {
-  return (
-    typeof shared === 'object' &&
-    shared !== null &&
-    'state' in shared &&
-    typeof (shared as LegacyToolUseRunShared).state === 'object' &&
-    (shared as LegacyToolUseRunShared).state !== null &&
-    'conversation' in (shared as LegacyToolUseRunShared).state
-  );
-}
+/** Legacy format had fields nested under `state` property */
+type LegacyShared = { state: ToolUseRunShared };
 
 /**
  * Migrate legacy shared state to current flat format.
- *
- * PersistedFlow loads shared state from disk on resume. If a user upgrades
- * with an in-progress tool-use session, the stored shared still has the old
- * `{ state: { conversation, stateSlices, ... } }` structure.
- *
- * This function detects and migrates legacy format to prevent failures when
- * the cycle node tries to read `shared.stateSlices` (which would be undefined
- * in legacy format).
- *
- * @param shared - The shared state loaded from persistence (may be legacy format)
- * @returns Shared state in current flat format
+ * Legacy: `{ state: { conversation, stateSlices, ... } }`
+ * Current: `{ conversation, stateSlices, ... }` (flat)
  */
 export function migrateSharedState(shared: unknown): ToolUseRunShared {
-  if (isLegacyFormat(shared)) {
-    return {
-      conversation: shared.state.conversation,
-      shouldSkipCycle: shared.state.shouldSkipCycle,
-      stateSlices: shared.state.stateSlices,
-      userCancelledRetry: shared.state.userCancelledRetry,
-    };
-  }
+  const obj = shared as Record<string, unknown>;
+  const legacy = obj?.state as LegacyShared['state'] | undefined;
 
-  // Already in current format or fresh start
-  return shared as ToolUseRunShared;
+  // Flatten if legacy format (has nested state.conversation)
+  return legacy?.conversation !== undefined
+    ? legacy
+    : (shared as ToolUseRunShared);
 }

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -149,20 +149,23 @@ export async function runToolUseFlow<C = unknown>(
         `Resume parse failed, starting fresh: ${error instanceof Error ? error.message : 'unknown'}`,
       );
     }
-    if (flowRecord?.shared) {
+    let isResume = Boolean(flowRecord?.shared);
+    if (isResume) {
       logger.debug('Resuming tool-use flow from persistence');
 
       // Migrate legacy shared state format if needed.
       // Pre-flattening sessions stored shared as { state: { conversation, ... } }
       // which would cause failures when cycle node reads shared.stateSlices.
-      const migratedShared = migrateSharedState(flowRecord.shared);
+      const migratedShared = migrateSharedState(flowRecord!.shared);
       if (migratedShared === null) {
-        logger.warn(
-          'Failed to parse flow record shared state, skipping resume',
-        );
-      } else if (migratedShared !== flowRecord.shared) {
+        // Corrupted/unparseable state - delete and start fresh
+        logger.warn('Failed to parse flow record shared state, starting fresh');
+        await kv.delete(`flow:${executionId}`);
+        flowRecord = null;
+        isResume = false;
+      } else if (migratedShared !== flowRecord!.shared) {
         logger.debug('Migrated legacy shared state to flat format');
-        flowRecord.shared = migratedShared;
+        flowRecord!.shared = migratedShared;
         // Persist the migrated format so future resumes use the new structure
         await kv.write(`flow:${executionId}`, flowRecord);
       }

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -156,16 +156,16 @@ export async function runToolUseFlow<C = unknown>(
       // Migrate legacy shared state format if needed.
       // Pre-flattening sessions stored shared as { state: { conversation, ... } }
       // which would cause failures when cycle node reads shared.stateSlices.
-      const migratedShared = migrateSharedState(flowRecord!.shared);
-      if (migratedShared === null) {
+      const migrationResult = migrateSharedState(flowRecord!.shared);
+      if (migrationResult === null) {
         // Corrupted/unparseable state - delete and start fresh
         logger.warn('Failed to parse flow record shared state, starting fresh');
         await kv.delete(`flow:${executionId}`);
         flowRecord = null;
         isResume = false;
-      } else if (migratedShared !== flowRecord!.shared) {
+      } else if (migrationResult.migrated) {
         logger.debug('Migrated legacy shared state to flat format');
-        flowRecord!.shared = migratedShared;
+        flowRecord!.shared = migrationResult.data;
         // Persist the migrated format so future resumes use the new structure
         await kv.write(`flow:${executionId}`, flowRecord);
       }
@@ -214,10 +214,11 @@ export async function runToolUseFlow<C = unknown>(
       const kv = getExecutionStore(executionId);
       const flowRecord = await kv.read<FlowRecord>(`flow:${executionId}`);
       // Handle both legacy { state: { userCancelledRetry } } and new flat format
-      const migratedShared = flowRecord?.shared
+      const migrationResult = flowRecord?.shared
         ? migrateSharedState(flowRecord.shared)
-        : undefined;
-      const userCancelledRetry = migratedShared?.userCancelledRetry === true;
+        : null;
+      const userCancelledRetry =
+        migrationResult?.data?.userCancelledRetry === true;
 
       if (userCancelledRetry) {
         // Preserve flow record for resume - user can continue from last successful breakpoint

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -156,7 +156,11 @@ export async function runToolUseFlow<C = unknown>(
       // Pre-flattening sessions stored shared as { state: { conversation, ... } }
       // which would cause failures when cycle node reads shared.stateSlices.
       const migratedShared = migrateSharedState(flowRecord.shared);
-      if (migratedShared !== flowRecord.shared) {
+      if (migratedShared === null) {
+        logger.warn(
+          'Failed to parse flow record shared state, skipping resume',
+        );
+      } else if (migratedShared !== flowRecord.shared) {
         logger.debug('Migrated legacy shared state to flat format');
         flowRecord.shared = migratedShared;
         // Persist the migrated format so future resumes use the new structure

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -498,7 +498,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
       });
       (options as MessageCreateParams).tool_choice = { type: 'auto' };
 
-      if (this.config.capabilities.supportsInterleavedThinking) {
+      if (this.capabilities.supportsInterleavedThinking) {
         this.ensureBeta(options, INTERLEAVED_THINKING_BETA);
       }
 
@@ -1110,7 +1110,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
     }
 
     // Add media if provided (images and native PDFs)
-    if (mediaFiles && this.config.capabilities.supportsVision) {
+    if (mediaFiles && this.capabilities.supportsVision) {
       const formattedMediaContent = await this.createMediaMessage(mediaFiles);
       userMessageContent.push(...formattedMediaContent);
     }
@@ -1148,7 +1148,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
     if (
       mediaFiles &&
       mediaFiles.length > 0 &&
-      this.config.capabilities.supportsVision
+      this.capabilities.supportsVision
     ) {
       try {
         const formattedMediaContent = await this.createMediaMessage(mediaFiles);
@@ -2082,7 +2082,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
     messages: MessageParam[],
     mediaFiles: FileLocation[],
   ): Promise<void> {
-    if (!mediaFiles.length || !this.config.capabilities.supportsVision) return;
+    if (!mediaFiles.length || !this.capabilities.supportsVision) return;
 
     const lastUserMsg = messages.findLast((m) => m.role === 'user');
     if (!lastUserMsg) return;

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -161,8 +161,8 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
 
   private supportsFileUploads(): boolean {
     return (
-      this.config.capabilities.supportsVision ||
-      this.config.capabilities.supportsNativeAudio
+      this.capabilities.supportsVision ||
+      this.capabilities.supportsNativeAudio
     );
   }
 
@@ -1474,7 +1474,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
     messages: Content[],
     mediaFiles: FileLocation[],
   ): Promise<void> {
-    if (!mediaFiles.length || !this.config.capabilities.supportsVision) return;
+    if (!mediaFiles.length || !this.capabilities.supportsVision) return;
 
     const lastUserMsg = messages.findLast((m) => m.role === 'user' && m.parts);
     if (!lastUserMsg?.parts) return;

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -161,8 +161,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
 
   private supportsFileUploads(): boolean {
     return (
-      this.capabilities.supportsVision ||
-      this.capabilities.supportsNativeAudio
+      this.capabilities.supportsVision || this.capabilities.supportsNativeAudio
     );
   }
 

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -822,9 +822,7 @@ export class ModelHandlerOpenAI<
       `Adding continuation message to conversation. Continuation message:\n ${userMessageContinuation}`,
     );
 
-    const role = this.capabilities.supportsIntermDevMsgs
-      ? 'system'
-      : 'user';
+    const role = this.capabilities.supportsIntermDevMsgs ? 'system' : 'user';
     messages.push({
       role,
       content: [{ type: 'text', text: userMessageContinuation }],

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -179,12 +179,12 @@ export class ModelHandlerOpenAI<
     }
 
     if (
-      this.config.capabilities.supportsReasoning &&
-      this.config.capabilities.supportsReasoningEffort &&
-      this.config.capabilities.reasoningEffort
+      this.capabilities.supportsReasoning &&
+      this.capabilities.supportsReasoningEffort &&
+      this.capabilities.reasoningEffort
     ) {
       baseParams.reasoning_effort = this.validateReasoningEffort(
-        this.config.capabilities.reasoningEffort,
+        this.capabilities.reasoningEffort,
       ) as ChatCompletionRequestBase['reasoning_effort'];
     }
 
@@ -196,7 +196,7 @@ export class ModelHandlerOpenAI<
 
     if (
       this.config.fullName === 'deepseek-chat' &&
-      !this.config.capabilities.supportsReasoning
+      !this.capabilities.supportsReasoning
     ) {
       this.logger.debug(
         `Setting max_tokens to ${DEEPSEEK_OFFICIAL_API_MAX_TOKENS} for DeepSeek-chat models from the official api`,
@@ -513,7 +513,7 @@ export class ModelHandlerOpenAI<
 
     // Handle system prompt differently for O1 models
     if (systemPrompt) {
-      if (this.config.capabilities.supportsSystemPrompt) {
+      if (this.capabilities.supportsSystemPrompt) {
         // note that for openai native o1 full or above reasoning models, they have been renamed to "developer" but "system" still works
         messages.push({
           role: 'system',
@@ -536,8 +536,8 @@ export class ModelHandlerOpenAI<
     // Add media if provided
     if (
       mediaFiles &&
-      (this.config.capabilities.supportsVision ||
-        this.config.capabilities.supportsNativeAudio)
+      (this.capabilities.supportsVision ||
+        this.capabilities.supportsNativeAudio)
     ) {
       // createMediaMessage returns an array of objects formatted by createMediaContent
       const formattedMediaContent = await this.createMediaMessage(mediaFiles);
@@ -553,7 +553,7 @@ export class ModelHandlerOpenAI<
     }
 
     // Add final user request
-    const requestRole = this.config.capabilities.supportsIntermDevMsgs
+    const requestRole = this.capabilities.supportsIntermDevMsgs
       ? 'system'
       : 'user';
     const lastMessage = messages.at(-1);
@@ -588,8 +588,8 @@ export class ModelHandlerOpenAI<
     if (
       mediaFiles &&
       mediaFiles.length > 0 &&
-      (this.config.capabilities.supportsVision ||
-        this.config.capabilities.supportsNativeAudio)
+      (this.capabilities.supportsVision ||
+        this.capabilities.supportsNativeAudio)
     ) {
       try {
         const formattedMediaContent = await this.createMediaMessage(mediaFiles);
@@ -645,7 +645,7 @@ export class ModelHandlerOpenAI<
         return this.buildStandardVisionParts(media);
       } else if (
         media.media_category === 'audio' &&
-        this.config.capabilities.supportsNativeAudio
+        this.capabilities.supportsNativeAudio
       ) {
         // Currently OpenRouter's OpenAI-compatible audio branch is the only consumer
         // Extract format from mime type (e.g., 'wav' from 'audio/wav')
@@ -822,7 +822,7 @@ export class ModelHandlerOpenAI<
       `Adding continuation message to conversation. Continuation message:\n ${userMessageContinuation}`,
     );
 
-    const role = this.config.capabilities.supportsIntermDevMsgs
+    const role = this.capabilities.supportsIntermDevMsgs
       ? 'system'
       : 'user';
     messages.push({
@@ -1378,7 +1378,7 @@ export class ModelHandlerOpenAI<
     messages: ChatCompletionMessageParam[],
     mediaFiles: FileLocation[],
   ): Promise<void> {
-    if (!mediaFiles.length || !this.config.capabilities.supportsVision) return;
+    if (!mediaFiles.length || !this.capabilities.supportsVision) return;
 
     const lastUserMsg = messages.findLast((m) => m.role === 'user');
     if (!lastUserMsg || !('content' in lastUserMsg)) return;

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -2046,7 +2046,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     messages: ResponseInputItem[],
     mediaFiles: FileLocation[],
   ): Promise<void> {
-    if (!mediaFiles.length || !this.config.capabilities.supportsVision) return;
+    if (!mediaFiles.length || !this.capabilities.supportsVision) return;
 
     const lastUserMsg = messages.findLast(
       (m) => (m as { role?: string }).role === 'user',

--- a/src/agent/modelHandlers/modelHandlerOpenRouter.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenRouter.ts
@@ -115,15 +115,15 @@ export class ModelHandlerOpenRouter extends ModelHandlerOpenAI {
     // - O1-style models: use reasoning.effort + include_reasoning
     // - DeepSeek V3.2: use reasoning.enabled (no include_reasoning needed,
     //   reasoning_details is returned automatically when enabled)
-    if (this.config.capabilities.supportsReasoning) {
+    if (this.capabilities.supportsReasoning) {
       if (
-        this.config.capabilities.supportsReasoningEffort &&
-        this.config.capabilities.reasoningEffort
+        this.capabilities.supportsReasoningEffort &&
+        this.capabilities.reasoningEffort
       ) {
         // O1-style models with effort levels
         kwargs.reasoning = {
           effort: this.validateReasoningEffort(
-            this.config.capabilities.reasoningEffort,
+            this.capabilities.reasoningEffort,
           ),
         };
         kwargs.include_reasoning = true;

--- a/src/agent/remote/types.ts
+++ b/src/agent/remote/types.ts
@@ -14,8 +14,8 @@ import {
   AgentPromptSchema,
 } from '@agent/core/AgentDataclass';
 
-// Re-export LoadAgentOptions as RemoteAgentLoadOptions for API consistency
-export type { LoadAgentOptions as RemoteAgentLoadOptions } from '@agent/runtime/agentLoad';
+// Re-export AgentLoadOptions as RemoteAgentLoadOptions for API consistency
+export type { AgentLoadOptions as RemoteAgentLoadOptions } from '@agent/runtime/agentLoad';
 
 /**
  * Schema for remote agent metadata.

--- a/src/agent/runtime/SessionResumeRetrieval.ts
+++ b/src/agent/runtime/SessionResumeRetrieval.ts
@@ -88,55 +88,32 @@ const StateSlicesSchema = z.object({
   userChannels: UserVariableChannelsSchema,
 });
 
-/**
- * Current flat format schema (introduced with state flattening refactor).
- * Shared state has conversation and stateSlices at top level.
- */
-const FlatToolUseFlowRecordStateSchema = z.object({
+/** Core fields schema (shared between flat and legacy formats) */
+const ToolUseStateFieldsSchema = z.object({
   conversation: z.array(ProviderMessageSchema),
   stateSlices: StateSlicesSchema,
 });
 
 /**
- * Legacy format schema (pre-flattening).
- * Shared state is wrapped in a `state` property.
+ * Schema that accepts both flat and legacy formats, normalizing to flat.
+ * - Flat format: { conversation, stateSlices, ... }
+ * - Legacy format: { state: { conversation, stateSlices, ... } }
  */
-const LegacyToolUseFlowRecordStateSchema = z.object({
-  state: z.object({
-    conversation: z.array(ProviderMessageSchema),
-    stateSlices: StateSlicesSchema,
-  }),
-});
+const ToolUseFlowRecordStateSchema = z
+  .union([
+    ToolUseStateFieldsSchema,
+    z.object({ state: ToolUseStateFieldsSchema }),
+  ])
+  .transform((data) => ('state' in data ? data.state : data));
 
-/**
- * Normalized result from parsing either format.
- * Both schemas are transformed to this common structure.
- */
-interface NormalizedToolUseState {
-  conversation: z.infer<typeof ProviderMessageSchema>[];
-  stateSlices: z.infer<typeof StateSlicesSchema>;
-}
+type NormalizedToolUseState = z.infer<typeof ToolUseFlowRecordStateSchema>;
 
-/**
- * Parse tool-use flow record shared state, supporting both flat and legacy formats.
- * Returns normalized state structure regardless of input format.
- */
+/** Parse tool-use flow record state, returns null if invalid. */
 function parseToolUseFlowRecordState(
   shared: unknown,
 ): NormalizedToolUseState | null {
-  // Try flat format first (current)
-  const flatResult = FlatToolUseFlowRecordStateSchema.safeParse(shared);
-  if (flatResult.success) {
-    return flatResult.data;
-  }
-
-  // Fall back to legacy format (unwrap nested state)
-  const legacyResult = LegacyToolUseFlowRecordStateSchema.safeParse(shared);
-  if (legacyResult.success) {
-    return legacyResult.data.state;
-  }
-
-  return null;
+  const result = ToolUseFlowRecordStateSchema.safeParse(shared);
+  return result.success ? result.data : null;
 }
 
 /**

--- a/src/agent/runtime/agentLoad.ts
+++ b/src/agent/runtime/agentLoad.ts
@@ -75,14 +75,17 @@ export async function loadYaml(absolutePath: string): Promise<object> {
 }
 
 /**
- * Loads agent settings and prompts with inheritance support.
- * Merges with parent configurations if specified in the inherits field.
+ * Options for loading agent definitions.
  *
- * The {@link LoadAgentOptions.preferMultiple} flag only affects the initial
+ * The {@link AgentLoadOptions.preferMultiple} flag only affects the initial
  * agent being resolved. Parent definitions always load their base variant so
  * that inherited prompts remain consistent with the author's expectations.
+ *
+ * This is the unified options type for agent loading/resolution operations,
+ * replacing the duplicate AgentResolveOptions.
  */
-export interface LoadAgentOptions {
+export interface AgentLoadOptions {
+  /** When true, prefer _multiple agent variant for multiple outputs support */
   preferMultiple?: boolean;
 }
 
@@ -98,7 +101,7 @@ export function ensureAgentTypeForSource<T extends { agentType?: AgentType }>(
 
 export async function loadAgentSettingAndPrompts(
   resolution: ResolvedAgent,
-  options?: LoadAgentOptions,
+  options?: AgentLoadOptions,
 ): Promise<[AgentSetting, AgentPrompt]> {
   try {
     if (options?.preferMultiple && resolution.usedFallback) {

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -37,7 +37,11 @@ import {
   type IToolUseSession,
 } from '@agent/implementations/flows/tooluse';
 import { runReflectionFlow } from '@agent/implementations/flows/reflection/runReflectionFlow';
-import { AgentConfigSchema, type AgentConfig } from '@agent/core/AgentConfig';
+import {
+  AgentConfigSchema,
+  type AgentConfig,
+  type AgentConfigPayload,
+} from '@agent/core/AgentConfig';
 import {
   AgentSetting,
   AgentPrompt,
@@ -52,6 +56,7 @@ import type { RoundFinalizedCallback } from '@agent/core/flows/CycleServices';
 import {
   loadAgentSettingAndPrompts,
   ensureAgentTypeForSource,
+  type AgentLoadOptions,
 } from '@agent/runtime/agentLoad';
 import { createModelHandler } from '@agent/runtime/ModelFactory';
 import { buildUserVars } from '@agent/utils/userVars';
@@ -91,9 +96,13 @@ const logger = new AgentLogger(CHANNEL);
 // Types
 // ============================================================================
 
-export interface AgentResolveOptions {
-  preferMultiple?: boolean;
-}
+// AgentLoadOptions is imported from agentLoad.ts (single source of truth)
+// Re-export for API compatibility
+export type { AgentLoadOptions };
+
+// AgentConfigPayload is imported from AgentConfig.ts - explicit required fields
+// Re-export for callers that need to build agent configurations
+export type { AgentConfigPayload };
 
 /**
  * Common base for flow inputs after agent resolution.
@@ -127,7 +136,7 @@ interface ResolvedAgentBase extends StorageKeyManager {
  * to get agentType synchronously, avoiding the need for YAML loading.
  */
 function computePreliminaryStreamId(
-  configPayload: Partial<AgentConfig>,
+  configPayload: AgentConfigPayload,
   executionId?: ExecutionId,
 ): StreamTabId {
   const { agent, model, inputFile, useMultipleOutputs } = configPayload;
@@ -154,7 +163,7 @@ function computePreliminaryStreamId(
 
 export async function getAgentPath(
   agentIdentifier: string,
-  options?: AgentResolveOptions,
+  options?: AgentLoadOptions,
 ): Promise<ResolvedAgent> {
   const result = resolveAgent(agentIdentifier, options?.preferMultiple);
   if (result) return result;
@@ -209,7 +218,7 @@ interface ResolveAgentOptions {
  */
 async function resolveAgentBase(
   agentName: string,
-  configPayload: Partial<AgentConfig>,
+  configPayload: AgentConfigPayload,
   providedExecutionId?: ExecutionId,
   options?: ResolveAgentOptions,
 ): Promise<ResolvedAgentBase> {
@@ -537,7 +546,7 @@ async function handleFlowError(
  * For resuming paused tool-use sessions, use resumeToolUseFromSnapshot instead.
  */
 export async function executeAgent(
-  configPayload: Partial<AgentConfig>,
+  configPayload: AgentConfigPayload,
   executionId?: ExecutionId,
 ): Promise<void> {
   if (!configPayload.model || !configPayload.agent) {

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -96,12 +96,12 @@ const logger = new AgentLogger(CHANNEL);
 // Types
 // ============================================================================
 
-// AgentLoadOptions is imported from agentLoad.ts (single source of truth)
 // Re-export for API compatibility
+// Canonical source: agentLoad.ts
 export type { AgentLoadOptions };
 
-// AgentConfigPayload is imported from AgentConfig.ts - explicit required fields
 // Re-export for callers that need to build agent configurations
+// Canonical source: AgentConfig.ts
 export type { AgentConfigPayload };
 
 /**

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -249,6 +249,7 @@ async function resolveAgentBase(
   const config: AgentConfig = {
     ...fullConfig,
     agentType: sessionDescriptor.agentType,
+    agentCategory: sessionDescriptor.agentCategory,
     session: sessionDescriptor,
   };
   const modelHandler = createModelHandler(MODEL_CONFIGS[fullConfig.model]);

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -227,10 +227,8 @@ async function resolveAgentBase(
     providedExecutionId ?? (randomUUID() as ExecutionId);
 
   // 1. Resolve agent definition
-  const fullConfig = AgentConfigSchema.parse({
-    agent: agentName,
-    ...configPayload,
-  });
+  // configPayload already contains agent (required by AgentConfigPayload)
+  const fullConfig = AgentConfigSchema.parse(configPayload);
   const resolution = await getAgentPath(fullConfig.agent, {
     preferMultiple: fullConfig.useMultipleOutputs,
   });

--- a/src/logger/TaskState.ts
+++ b/src/logger/TaskState.ts
@@ -2,10 +2,7 @@
 import { z } from 'zod';
 
 // Local imports
-import type { AgentConfig } from '@agent/core/AgentConfig';
-// Internal imports
-import { AgentCategory } from '@agent/core/AgentDataclass';
-import type { AgentSessionDescriptor } from '@agent/core/AgentSessionSchema';
+import { AgentCategory, type AgentConfig } from '@agent/core/AgentConfig';
 
 // Type imports
 import { FILE_TYPES, type FileType } from '@utils/config';
@@ -28,31 +25,29 @@ const ActiveFilesSchema = z.partialRecord(
   z.boolean(),
 ) as z.ZodType<Record<FileType, boolean>>;
 
-/** Minimal agentConfig schema - just validates the discriminator exists */
-const AgentConfigWithSessionSchema = z.looseObject({
-  session: z.object({
-    agentCategory: z.enum(AgentCategory),
-  }),
+/**
+ * Minimal agentConfig schema - validates the top-level agentCategory discriminant.
+ * Uses the lifted agentCategory field (added via transform in AgentConfigSchema)
+ * for simpler validation without deep nesting.
+ */
+const AgentConfigWithCategorySchema = z.looseObject({
+  agentCategory: z.enum(AgentCategory),
 });
 
 /** Schema for workflow task state */
 const WorkflowTaskStateSchema = z.object({
-  agentConfig: AgentConfigWithSessionSchema.refine(
-    (c) => c.session.agentCategory === AgentCategory.Workflow,
-    {
-      error: 'Expected Workflow category',
-    },
+  agentConfig: AgentConfigWithCategorySchema.refine(
+    (c) => c.agentCategory === AgentCategory.Workflow,
+    { error: 'Expected Workflow category' },
   ),
   activeFiles: ActiveFilesSchema,
 });
 
 /** Schema for tool-use task state */
 const ToolUseTaskStateSchema = z.object({
-  agentConfig: AgentConfigWithSessionSchema.refine(
-    (c) => c.session.agentCategory === AgentCategory.ToolUse,
-    {
-      error: 'Expected ToolUse category',
-    },
+  agentConfig: AgentConfigWithCategorySchema.refine(
+    (c) => c.agentCategory === AgentCategory.ToolUse,
+    { error: 'Expected ToolUse category' },
   ),
   toolSessionState: ToolSessionStateSchema.optional(),
 });
@@ -75,16 +70,12 @@ export const TaskStateSchema = z.union([
 export type ToolSessionState = z.infer<typeof ToolSessionStateSchema>;
 
 export interface WorkflowTaskState {
-  agentConfig: AgentConfig & {
-    session: AgentSessionDescriptor & { agentCategory: AgentCategory.Workflow };
-  };
+  agentConfig: AgentConfig & { agentCategory: AgentCategory.Workflow };
   activeFiles: Record<FileType, boolean>;
 }
 
 export interface ToolUseTaskState {
-  agentConfig: AgentConfig & {
-    session: AgentSessionDescriptor & { agentCategory: AgentCategory.ToolUse };
-  };
+  agentConfig: AgentConfig & { agentCategory: AgentCategory.ToolUse };
   toolSessionState?: ToolSessionState;
 }
 
@@ -98,12 +89,12 @@ export type TaskState = WorkflowTaskState | ToolUseTaskState;
 export function isWorkflowTaskState(
   taskState: TaskState,
 ): taskState is WorkflowTaskState {
-  return taskState.agentConfig.session.agentCategory === AgentCategory.Workflow;
+  return taskState.agentConfig.agentCategory === AgentCategory.Workflow;
 }
 
 /** Type guard for TaskState narrowing to ToolUseTaskState */
 export function isToolUseTaskState(
   taskState: TaskState,
 ): taskState is ToolUseTaskState {
-  return taskState.agentConfig.session.agentCategory === AgentCategory.ToolUse;
+  return taskState.agentConfig.agentCategory === AgentCategory.ToolUse;
 }

--- a/src/logger/TaskState.ts
+++ b/src/logger/TaskState.ts
@@ -26,59 +26,25 @@ const ActiveFilesSchema = z.partialRecord(
 ) as z.ZodType<Record<FileType, boolean>>;
 
 /**
- * Helper to extract agentCategory from either new or legacy format.
- * - New format: agentConfig.agentCategory (lifted to top level)
- * - Legacy format: agentConfig.session.agentCategory (nested in session)
+ * AgentConfig schema that normalizes legacy format on parse.
+ * Lifts session.agentCategory to top level if not already present.
  */
-function getAgentCategory(
-  config: Record<string, unknown>,
-): AgentCategory | undefined {
-  // Try new format first (top-level agentCategory)
-  if (
-    'agentCategory' in config &&
-    typeof config.agentCategory === 'string' &&
-    Object.values(AgentCategory).includes(config.agentCategory as AgentCategory)
-  ) {
-    return config.agentCategory as AgentCategory;
-  }
-
-  // Fall back to legacy format (nested in session)
-  if (
-    'session' in config &&
-    typeof config.session === 'object' &&
-    config.session !== null &&
-    'agentCategory' in config.session
-  ) {
-    const session = config.session as Record<string, unknown>;
-    if (
-      typeof session.agentCategory === 'string' &&
-      Object.values(AgentCategory).includes(
-        session.agentCategory as AgentCategory,
-      )
-    ) {
-      return session.agentCategory as AgentCategory;
-    }
-  }
-
-  return undefined;
-}
-
-/**
- * Minimal agentConfig schema - validates category from either location.
- * Accepts both new format (agentConfig.agentCategory) and legacy format
- * (agentConfig.session.agentCategory) for backwards compatibility with
- * persisted task states.
- */
-const AgentConfigWithCategorySchema = z
-  .looseObject({})
-  .refine((c) => getAgentCategory(c) !== undefined, {
-    error: 'Missing agentCategory in agentConfig',
-  });
+const AgentConfigSchema = z
+  .looseObject({
+    agentCategory: z.enum(AgentCategory).optional(),
+    session: z.object({ agentCategory: z.enum(AgentCategory) }).optional(),
+  })
+  .transform((c) => ({
+    ...c,
+    // Lift from session if not at top level (legacy format migration)
+    agentCategory: c.agentCategory ?? c.session?.agentCategory,
+  }))
+  .pipe(z.looseObject({ agentCategory: z.enum(AgentCategory) }));
 
 /** Schema for workflow task state */
 const WorkflowTaskStateSchema = z.object({
-  agentConfig: AgentConfigWithCategorySchema.refine(
-    (c) => getAgentCategory(c) === AgentCategory.Workflow,
+  agentConfig: AgentConfigSchema.refine(
+    (c) => c.agentCategory === AgentCategory.Workflow,
     { error: 'Expected Workflow category' },
   ),
   activeFiles: ActiveFilesSchema,
@@ -86,8 +52,8 @@ const WorkflowTaskStateSchema = z.object({
 
 /** Schema for tool-use task state */
 const ToolUseTaskStateSchema = z.object({
-  agentConfig: AgentConfigWithCategorySchema.refine(
-    (c) => getAgentCategory(c) === AgentCategory.ToolUse,
+  agentConfig: AgentConfigSchema.refine(
+    (c) => c.agentCategory === AgentCategory.ToolUse,
     { error: 'Expected ToolUse category' },
   ),
   toolSessionState: ToolSessionStateSchema.optional(),

--- a/src/logger/TaskState.ts
+++ b/src/logger/TaskState.ts
@@ -26,18 +26,59 @@ const ActiveFilesSchema = z.partialRecord(
 ) as z.ZodType<Record<FileType, boolean>>;
 
 /**
- * Minimal agentConfig schema - validates the top-level agentCategory discriminant.
- * Uses the lifted agentCategory field (added via transform in AgentConfigSchema)
- * for simpler validation without deep nesting.
+ * Helper to extract agentCategory from either new or legacy format.
+ * - New format: agentConfig.agentCategory (lifted to top level)
+ * - Legacy format: agentConfig.session.agentCategory (nested in session)
  */
-const AgentConfigWithCategorySchema = z.looseObject({
-  agentCategory: z.enum(AgentCategory),
-});
+function getAgentCategory(
+  config: Record<string, unknown>,
+): AgentCategory | undefined {
+  // Try new format first (top-level agentCategory)
+  if (
+    'agentCategory' in config &&
+    typeof config.agentCategory === 'string' &&
+    Object.values(AgentCategory).includes(config.agentCategory as AgentCategory)
+  ) {
+    return config.agentCategory as AgentCategory;
+  }
+
+  // Fall back to legacy format (nested in session)
+  if (
+    'session' in config &&
+    typeof config.session === 'object' &&
+    config.session !== null &&
+    'agentCategory' in config.session
+  ) {
+    const session = config.session as Record<string, unknown>;
+    if (
+      typeof session.agentCategory === 'string' &&
+      Object.values(AgentCategory).includes(
+        session.agentCategory as AgentCategory,
+      )
+    ) {
+      return session.agentCategory as AgentCategory;
+    }
+  }
+
+  return undefined;
+}
+
+/**
+ * Minimal agentConfig schema - validates category from either location.
+ * Accepts both new format (agentConfig.agentCategory) and legacy format
+ * (agentConfig.session.agentCategory) for backwards compatibility with
+ * persisted task states.
+ */
+const AgentConfigWithCategorySchema = z
+  .looseObject({})
+  .refine((c) => getAgentCategory(c) !== undefined, {
+    error: 'Missing agentCategory in agentConfig',
+  });
 
 /** Schema for workflow task state */
 const WorkflowTaskStateSchema = z.object({
   agentConfig: AgentConfigWithCategorySchema.refine(
-    (c) => c.agentCategory === AgentCategory.Workflow,
+    (c) => getAgentCategory(c) === AgentCategory.Workflow,
     { error: 'Expected Workflow category' },
   ),
   activeFiles: ActiveFilesSchema,
@@ -46,7 +87,7 @@ const WorkflowTaskStateSchema = z.object({
 /** Schema for tool-use task state */
 const ToolUseTaskStateSchema = z.object({
   agentConfig: AgentConfigWithCategorySchema.refine(
-    (c) => c.agentCategory === AgentCategory.ToolUse,
+    (c) => getAgentCategory(c) === AgentCategory.ToolUse,
     { error: 'Expected ToolUse category' },
   ),
   toolSessionState: ToolSessionStateSchema.optional(),

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -569,7 +569,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
 
     // Build the appropriate TaskState variant based on agent category
     // WorkflowTaskState requires activeFiles; ToolUseTaskState does not
-    // Cast needed because agentConfig.session.agentCategory is typed as the general
+    // Cast needed because agentConfig.agentCategory is typed as the general
     // AgentCategory enum, not the specific literal type that TaskState requires
     const taskState = (
       isWorkflow ? { agentConfig, activeFiles } : { agentConfig }

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -181,7 +181,7 @@ export class ProgressEventHandler {
       () => {
         const { streamTabId, executionId, taskState } = data;
         const isActiveStream = this.state.activeStream === streamTabId;
-        const sessionKind = taskState.agentConfig.session.agentCategory;
+        const sessionKind = taskState.agentConfig.agentCategory;
         const previousFilter = this.state.agentTypeFilter;
 
         this.state.setTaskState(streamTabId, taskState);

--- a/src/webview/managers/ExecutionManager.ts
+++ b/src/webview/managers/ExecutionManager.ts
@@ -2,7 +2,7 @@
 import * as vscode from 'vscode';
 
 // Local imports - agent core
-import type { AgentConfig } from '@agent/core/AgentConfig';
+import type { AgentConfigPayload } from '@agent/core/AgentConfig';
 // Internal imports
 import {
   AgentCategory,
@@ -41,7 +41,7 @@ export class ExecutionManager {
     await vscode.commands.executeCommand('texra.execute', config);
   }
 
-  private composeAgentConfig(message: any, isToolUse: boolean): AgentConfig {
+  private composeAgentConfig(message: any, isToolUse: boolean): AgentConfigPayload {
     // Session descriptor depends on agent type
     const session: AgentSessionDescriptor = isToolUse
       ? { agentType: AgentType.ToolUse, agentCategory: AgentCategory.ToolUse }

--- a/src/webview/managers/ExecutionManager.ts
+++ b/src/webview/managers/ExecutionManager.ts
@@ -41,7 +41,10 @@ export class ExecutionManager {
     await vscode.commands.executeCommand('texra.execute', config);
   }
 
-  private composeAgentConfig(message: any, isToolUse: boolean): AgentConfigPayload {
+  private composeAgentConfig(
+    message: any,
+    isToolUse: boolean,
+  ): AgentConfigPayload {
     // Session descriptor depends on agent type
     const session: AgentSessionDescriptor = isToolUse
       ? { agentType: AgentType.ToolUse, agentCategory: AgentCategory.ToolUse }


### PR DESCRIPTION
- Merge AgentResolveOptions + LoadAgentOptions into unified AgentLoadOptions (removes duplicate single-field interface)

- Standardize ModelHandler.capabilities access pattern (fix 26 violations using this.config.capabilities instead of this.capabilities)

- Create AgentConfigPayloadSchema with explicit required fields (replaces ambiguous Partial<AgentConfig> with clear agent/model requirements)

- Add result type primitives (FailedResultSchema, CancelledResultSchema, SkippedResultSchema) to CommonCycleTypes.ts for schema composition

- Consolidate CycleExecResult to use InvocationResult<T> as single source of truth

- Lift agentCategory to AgentConfig top level (reduces nesting depth: config.agentCategory instead of config.session.agentCategory)

- Update TaskState types and guards to use lifted agentCategory

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> - **AgentConfig/TaskState**: Lift `agentCategory` to top-level in `AgentConfig`; re-export `AgentCategory`; update TaskState schemas/guards and UI handlers to read `config.agentCategory`.
> - **Config input typing**: Introduce `AgentConfigPayloadSchema` (requires `agent` and `model`) and use across execution entrypoints (`executeAgent`, `ExecutionManager`, preliminary stream ID).
> - **Load options**: Merge `LoadAgentOptions`/`AgentResolveOptions` into unified `AgentLoadOptions`; update `getAgentPath` and `loadAgentSettingAndPrompts`; re-export types for API compatibility.
> - **Model handlers**: Replace `this.config.capabilities.*` with `this.capabilities.*` in Anthropic, Google, OpenAI, and OpenRouter handlers.
> - **Tool-use flow**: Consolidate `CycleExecResult` to `InvocationResult<T>`; add zod-based legacy shared-state migration with null handling; resume path persists migrated state or clears corrupt records; simplify resume parsing in `SessionResumeRetrieval`.
> - **Remote types**: Fix re-export to `AgentLoadOptions` for consistency.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 53d49e39046d272a3212b1051383036ada399763. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->