### PR TITLE
claude/scout-data-transforms-r0Wnb

### DIFF
--- a/src/commands/latex/latexdiffCommands.ts
+++ b/src/commands/latex/latexdiffCommands.ts
@@ -15,6 +15,7 @@ import {
 } from '@common/errors';
 import { openBuildDisplayIfTex } from '@frontend/latex/openBuild';
 import * as logger from '@logger/logUtils';
+import { RoundKeySchema } from '@progressView/persistence/schemaUtils';
 import { getConfig } from '@utils/config';
 import {
   WorkspaceFS,
@@ -525,11 +526,11 @@ function normalizeOutputsByRound(
   const roundMap = new Map<number, OutputFileInfo[]>();
 
   for (const [roundKey, value] of entries) {
-    const round = Number.parseInt(roundKey, 10);
-    if (Number.isNaN(round) || !Array.isArray(value) || value.length === 0) {
+    const roundResult = RoundKeySchema.safeParse(roundKey);
+    if (!roundResult.success || !Array.isArray(value) || value.length === 0) {
       continue;
     }
-    roundMap.set(round, value);
+    roundMap.set(roundResult.data, value);
   }
 
   if (roundMap.size === 0) {
@@ -763,11 +764,11 @@ async function runLatexdiffViaWorkspaceScan(params: {
         continue;
       }
 
-      const round = Number.parseInt(match[1], 10);
-      if (Number.isNaN(round)) {
+      const roundResult = RoundKeySchema.safeParse(match[1]);
+      if (!roundResult.success) {
         continue;
       }
-      roundOutputsMap.set(round, path.join(outputDirPath, fileName));
+      roundOutputsMap.set(roundResult.data, path.join(outputDirPath, fileName));
     }
 
     if (roundOutputsMap.size > 0) {

--- a/src/progressView/managers/OutputFilesManager.ts
+++ b/src/progressView/managers/OutputFilesManager.ts
@@ -109,8 +109,8 @@ export class OutputFilesManager extends PersistentMapManager<
     }
 
     for (const [round, files] of Object.entries(filesByRound)) {
-      const roundNum = Number.parseInt(round, 10);
-      if (Number.isNaN(roundNum)) {
+      const roundResult = RoundKeySchema.safeParse(round);
+      if (!roundResult.success) {
         this.logger.warn(
           `Invalid round number '${round}' for stream ${stream}`,
         );
@@ -120,11 +120,11 @@ export class OutputFilesManager extends PersistentMapManager<
         Array.isArray(files) ? files : [],
       );
       if (normalizedFiles.length === 0) {
-        runRounds.delete(roundNum);
+        runRounds.delete(roundResult.data);
         continue;
       }
 
-      runRounds.set(roundNum, normalizedFiles);
+      runRounds.set(roundResult.data, normalizedFiles);
     }
 
     await this.save();
@@ -158,14 +158,14 @@ export class OutputFilesManager extends PersistentMapManager<
     }
 
     for (const [round, files] of Object.entries(filesByRound)) {
-      const roundNum = Number.parseInt(round, 10);
-      if (Number.isNaN(roundNum)) {
+      const roundResult = RoundKeySchema.safeParse(round);
+      if (!roundResult.success) {
         this.logger.warn(
           `Invalid missing-output round '${round}' for stream ${stream}`,
         );
         continue;
       }
-      runMissing.set(roundNum, files);
+      runMissing.set(roundResult.data, files);
     }
 
     await this.saveMissingOutputs();


### PR DESCRIPTION
Replace manual parseInt + isNaN validation with existing RoundKeySchema from schemaUtils.ts for consistent round number parsing from string keys. This consolidates the pattern and uses z.coerce.number().int() validation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Standardizes round key parsing by replacing manual `parseInt`/`isNaN` checks with `RoundKeySchema.safeParse`.
> 
> - `latexdiffCommands.ts`: use `RoundKeySchema` when normalizing `outputsByRound` and when scanning workspace outputs to build round maps
> - `OutputFilesManager.ts`: validate round keys with `RoundKeySchema` in `addFiles` and `updateMissingOutputs`; associated schemas already leverage it
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fd22ad452530f7d6251bcf93df6de94c22a75a83. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->