### PR TITLE
refactor: simplify code patterns across multiple files

### DIFF
--- a/src/agent/core/AgentWorkspaceState.ts
+++ b/src/agent/core/AgentWorkspaceState.ts
@@ -255,7 +255,7 @@ export type ReasoningCacheState = z.output<typeof ReasoningCacheStateSchema>;
 export function getReasoningPrimaryBlock(
   state: ReasoningCacheState,
 ): ThinkingBlock | null {
-  return state.thinkingBlocks.length > 0 ? state.thinkingBlocks[0] : null;
+  return state.thinkingBlocks[0] ?? null;
 }
 
 /** Reset reasoning cache state to initial values */

--- a/src/agent/output/LatexDiffManager.ts
+++ b/src/agent/output/LatexDiffManager.ts
@@ -72,12 +72,8 @@ export class LatexDiffManager {
    * Resolve symlinks for latexdiff compatibility.
    * (latexdiff may have issues with symlinks in some configurations)
    */
-  private async resolveSymlinks(target: string): Promise<string> {
-    try {
-      return await fs.realpath(target);
-    } catch (_err) {
-      return target;
-    }
+  private resolveSymlinks(target: string): Promise<string> {
+    return fs.realpath(target).catch(() => target);
   }
 
   /**

--- a/src/agent/output/XmlOutputManager.ts
+++ b/src/agent/output/XmlOutputManager.ts
@@ -33,6 +33,9 @@ import {
 // Local file imports
 import type { OutputFileInfo } from './types';
 
+/** Global version of DOCUMENT_NAME_REGEX for counting matches */
+const DOCUMENT_NAME_REGEX_GLOBAL = new RegExp(DOCUMENT_NAME_REGEX.source, 'g');
+
 /** Shared XMLParser configuration for scratchpad output extraction */
 const XML_PARSER_OPTIONS = {
   ignoreAttributes: false,
@@ -84,18 +87,18 @@ export class XmlOutputManager {
     const filename = path.basename(this.agentConfig.inputFile);
     const result = extractDocument(outputContent, documentTag, filename);
 
-    if (result.content) {
-      const suffix = XmlOutputManager.EXTRACTION_METHOD_MESSAGES[result.method];
-      if (suffix) {
-        this.logger.logInternal(`Recovered ${documentTag} ${suffix}`);
-      }
-      return result.content;
+    if (!result.content) {
+      this.logger.debugInternal(
+        `No ${documentTag} found in output file using fallback method`,
+      );
+      return null;
     }
 
-    this.logger.debugInternal(
-      `No ${documentTag} found in output file using fallback method`,
-    );
-    return null;
+    const suffix = XmlOutputManager.EXTRACTION_METHOD_MESSAGES[result.method];
+    if (suffix) {
+      this.logger.logInternal(`Recovered ${documentTag} ${suffix}`);
+    }
+    return result.content;
   }
 
   private extractMultipleDocumentsbyRegex(
@@ -170,10 +173,7 @@ export class XmlOutputManager {
    * what can actually be extracted, avoiding false warnings.
    */
   private countDocumentTags(content: string): number {
-    // Use global version of shared pattern (case-sensitive)
-    const globalPattern = new RegExp(DOCUMENT_NAME_REGEX.source, 'g');
-    const matches = content.match(globalPattern);
-    return matches ? matches.length : 0;
+    return content.match(DOCUMENT_NAME_REGEX_GLOBAL)?.length ?? 0;
   }
 
   /**

--- a/src/agent/runtime/InterruptManager.ts
+++ b/src/agent/runtime/InterruptManager.ts
@@ -44,17 +44,18 @@ export function createInterruptManager(): InterruptManager {
 
   const getAbortController = (): AbortController | null => abortController;
 
-  const asFlowInput = (): InterruptCallbacks => ({
+  // Cache flow input since callbacks are stable references
+  const flowInput: InterruptCallbacks = {
     checkInterruption,
     setAbortController,
     onInterrupt,
-  });
+  };
 
   return {
     checkInterruption,
     setAbortController,
     onInterrupt,
     getAbortController,
-    asFlowInput,
+    asFlowInput: () => flowInput,
   };
 }

--- a/src/agent/runtime/RetryRequestCoordinator.ts
+++ b/src/agent/runtime/RetryRequestCoordinator.ts
@@ -149,11 +149,6 @@ class RetryRequestCoordinatorImpl extends BasePromiseCoordinator<
     this.loggers.delete(streamId);
     super.clearRequest(streamId);
   }
-
-  // Legacy alias for backwards compatibility
-  hasPendingRequest(streamId: string): boolean {
-    return super.hasPendingRequest(streamId);
-  }
 }
 
 // ============================================================================

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -457,12 +457,13 @@ function showAgentNotification(config: AgentConfig): void {
     ? path.basename(config.inputFile)
     : 'selected input';
   const outputFiles = config.outputFiles ?? [];
-  const outputInfo =
-    config.useMultipleOutputs && outputFiles.length > 1
-      ? `to ${outputFiles.length} files`
-      : outputFiles[0]
-        ? `to ${path.basename(outputFiles[0])}`
-        : '';
+
+  let outputInfo = '';
+  if (config.useMultipleOutputs && outputFiles.length > 1) {
+    outputInfo = `to ${outputFiles.length} files`;
+  } else if (outputFiles[0]) {
+    outputInfo = `to ${path.basename(outputFiles[0])}`;
+  }
 
   void vscode.window
     .showInformationMessage(

--- a/src/explorer/ExplorerOperations.ts
+++ b/src/explorer/ExplorerOperations.ts
@@ -67,9 +67,9 @@ export class ExplorerOperations {
    */
   private isBuiltInPath(targetPath: string): boolean {
     return (
-      (!!this.builtInAgentsPath &&
+      (this.builtInAgentsPath !== null &&
         targetPath.startsWith(this.builtInAgentsPath)) ||
-      (!!this.builtInToolUsePath &&
+      (this.builtInToolUsePath !== null &&
         targetPath.startsWith(this.builtInToolUsePath))
     );
   }

--- a/src/explorer/ExplorerOperations.ts
+++ b/src/explorer/ExplorerOperations.ts
@@ -67,9 +67,9 @@ export class ExplorerOperations {
    */
   private isBuiltInPath(targetPath: string): boolean {
     return (
-      (this.builtInAgentsPath !== null &&
+      (Boolean(this.builtInAgentsPath) &&
         targetPath.startsWith(this.builtInAgentsPath)) ||
-      (this.builtInToolUsePath !== null &&
+      (Boolean(this.builtInToolUsePath) &&
         targetPath.startsWith(this.builtInToolUsePath))
     );
   }

--- a/src/frontend/ui/dialogs.ts
+++ b/src/frontend/ui/dialogs.ts
@@ -64,7 +64,7 @@ export async function selectFile(
   options: FileDialogOptions,
 ): Promise<string | null> {
   const paths = await selectFiles({ ...options, allowMany: false });
-  return paths ? paths[0] : null;
+  return paths?.[0] ?? null;
 }
 
 export interface FileSelectionResult {

--- a/src/latex/formatter/latexindentpt.ts
+++ b/src/latex/formatter/latexindentpt.ts
@@ -40,8 +40,7 @@ export async function runLatexIndent(filePath: string): Promise<boolean> {
     );
 
     const workspacePath = WorkspaceFS.getPath();
-    const isWorkspaceFile =
-      !!workspacePath && filePath.startsWith(workspacePath);
+    const isWorkspaceFile = workspacePath && filePath.startsWith(workspacePath);
 
     // Get latexindent config from settings
     const latexindentConfig = getConfig<string>(

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -394,7 +394,7 @@ export class ProgressViewProvider
    * Check if any view is visible (sidebar or panel)
    */
   public isViewVisible(): boolean {
-    return !!this._view?.visible || !!this._panelView?.visible;
+    return this._view?.visible === true || this._panelView?.visible === true;
   }
 
   // ===== IRunStorageService implementation =====

--- a/src/progressView/events/FollowUpEventHandlers.ts
+++ b/src/progressView/events/FollowUpEventHandlers.ts
@@ -27,33 +27,32 @@ import type { EventHandlerContext } from './EventHandlerContext';
 
 /**
  * Register follow-up queue event handlers on the event bus.
- *
- * @param bus - Progress event bus
- * @param ctx - Event handler context with state and webview updater
- * @param signal - AbortController signal for cleanup
  */
 export function registerFollowUpEventHandlers(
   bus: ProgressEventBusLike,
   ctx: EventHandlerContext,
   signal: AbortSignal,
 ): void {
-  bus.on('updateQueuedFollowUps', handleUpdateQueuedFollowUps(ctx), { signal });
+  bus.on(
+    'updateQueuedFollowUps',
+    (payload) => handleUpdateQueuedFollowUps(ctx, payload),
+    { signal },
+  );
 }
 
-function handleUpdateQueuedFollowUps(ctx: EventHandlerContext) {
-  return ({
-    streamId,
-  }: ProgressEventPayloads['updateQueuedFollowUps']): void => {
-    withEventErrorHandling(
-      'FollowUpEvents',
-      'failed to handle updateQueuedFollowUps',
-      () => {
-        // Don't filter by active stream - see module docstring for rationale
-        if (ctx.webviewUpdater.isAvailable()) {
-          const messages = ToolUseFollowUpQueue.getAll(streamId);
-          ctx.webviewUpdater.updateQueuedFollowUps(streamId, messages);
-        }
-      },
-    );
-  };
+function handleUpdateQueuedFollowUps(
+  ctx: EventHandlerContext,
+  { streamId }: ProgressEventPayloads['updateQueuedFollowUps'],
+): void {
+  withEventErrorHandling(
+    'FollowUpEvents',
+    'failed to handle updateQueuedFollowUps',
+    () => {
+      // Don't filter by active stream - see module docstring for rationale
+      if (ctx.webviewUpdater.isAvailable()) {
+        const messages = ToolUseFollowUpQueue.getAll(streamId);
+        ctx.webviewUpdater.updateQueuedFollowUps(streamId, messages);
+      }
+    },
+  );
 }

--- a/src/progressView/managers/OutputFilesManager.ts
+++ b/src/progressView/managers/OutputFilesManager.ts
@@ -310,20 +310,19 @@ export class OutputFilesManager extends PersistentMapManager<
   }
 
   private async ensureMissingOutputsLoaded(): Promise<void> {
-    if (this.missingOutputsLoaded) {
-      return;
-    }
+    if (this.missingOutputsLoaded) return;
 
     if (!this.missingOutputsLoadPromise) {
-      this.missingOutputsLoadPromise = this.loadMissingOutputs()
-        .then(() => {
+      this.missingOutputsLoadPromise = (async () => {
+        try {
+          await this.loadMissingOutputs();
           this.missingOutputsLoaded = true;
-        })
-        .catch((error) => {
+        } catch (error) {
           this.logger.error('Failed to load missing outputs', { data: error });
           this.missingOutputsLoadPromise = null;
           throw error;
-        });
+        }
+      })();
     }
 
     await this.missingOutputsLoadPromise;

--- a/src/progressView/modules/uiManagers/Status.js
+++ b/src/progressView/modules/uiManagers/Status.js
@@ -85,7 +85,7 @@ export class Status {
    * @param {string[]} buttonIds - The button IDs currently in the toolbar
    */
   setCurrentButtonIds(buttonIds) {
-    this._currentButtonIds = buttonIds || [];
+    this._currentButtonIds = buttonIds ?? [];
   }
 
   setExecutionIdAvailability(hasExecution) {

--- a/src/progressView/modules/uiManagers/WorkflowProposals.js
+++ b/src/progressView/modules/uiManagers/WorkflowProposals.js
@@ -80,7 +80,7 @@ export class WorkflowProposals extends BaseUIRequestManager {
     // File fields only exist for workflow agent proposals (agentCategory === 'workflow')
     // Tool-use agent proposals access files via their own tools (read_file, etc.)
     // The schema enforces this - tool-use proposals simply don't have file fields
-    const combine = (single, arr) => [single, ...(arr || [])].filter((f) => f);
+    const combine = (single, arr) => [single, ...(arr ?? [])].filter(Boolean);
 
     this._setFileInfo(
       element,

--- a/src/utils/core/pathCore.ts
+++ b/src/utils/core/pathCore.ts
@@ -30,13 +30,9 @@ export function getPathSegments(input: string): string[] {
 
 /** Normalize a path for LaTeX \input commands (strips leading ./). */
 export function normalizeLatexPath(value: string): string {
-  if (!value) {
-    return '';
-  }
-  const trimmed = value.trim();
-  if (!trimmed) {
-    return '';
-  }
+  const trimmed = value?.trim();
+  if (!trimmed) return '';
+
   const posix = toPosixPath(trimmed);
   // Strip leading ./ for LaTeX compatibility
   return posix.startsWith('./') ? posix.slice(2) : posix;

--- a/src/utils/files/mimeUtils.ts
+++ b/src/utils/files/mimeUtils.ts
@@ -6,6 +6,5 @@ import mime from 'mime-types';
  * Returns null when the type cannot be resolved.
  */
 export function getMimeType(filePath: string): string | null {
-  const mimeType = mime.lookup(filePath);
-  return typeof mimeType === 'string' ? mimeType : null;
+  return mime.lookup(filePath) || null;
 }

--- a/src/webview/managers/InstructionManager.ts
+++ b/src/webview/managers/InstructionManager.ts
@@ -80,8 +80,7 @@ export class InstructionManager extends BaseWebviewManager {
 
   /** Build file context for AI text polishing, filtering empty/placeholder values */
   private buildFileContext(message: PolishInstructionMessage): FileContext {
-    const isValid = (f?: string): f is string =>
-      !!f && f !== 'None' && f !== '';
+    const isValid = (f?: string): f is string => Boolean(f) && f !== 'None';
     const context: FileContext = { agent: message.agent };
 
     // Single file fields

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -701,7 +701,7 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
     const entry = Object.entries(AGENT_SELECT_IDS).find(
       ([, id]) => id === selectElement.id,
     );
-    return entry ? entry[0] : null;
+    return entry?.[0] ?? null;
   }
 
   _getSavedAgentValue(sessionType) {


### PR DESCRIPTION
- Remove legacy hasPendingRequest alias in RetryRequestCoordinator
- Simplify curried handler pattern in FollowUpEventHandlers to match other handlers
- Replace nested ternary with if/else in executeAgent showAgentNotification
- Cache asFlowInput result in InterruptManager (stable references)
- Use early return pattern in XmlOutputManager extractDocumentbyRegex
- Simplify promise handling in OutputFilesManager ensureMissingOutputsLoaded
- Simplify resolveSymlinks method in LatexDiffManager using .catch()
- Consolidate redundant null checks in pathCore normalizeLatexPath
- Cache global regex pattern in XmlOutputManager countDocumentTags

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Focuses on small, safe refactors to reduce branching and improve readability/robustness.
> 
> - Runtime: cache stable callbacks in `InterruptManager.asFlowInput()`, remove legacy `hasPendingRequest` alias in `RetryRequestCoordinator`, simplify output info formatting in `executeAgent`, and tighten `showProgressView` visibility checks in `ProgressViewProvider.isViewVisible()`
> - Output processing: simplify symlink resolution in `LatexDiffManager.resolveSymlinks()`; in `XmlOutputManager` add global `DOCUMENT_NAME_REGEX` variant, use early-return logging in `extractDocumentbyRegex()`, and streamline counting via `match()`
> - Events/UI: convert curried handler to direct payload handler in `FollowUpEventHandlers`; use nullish coalescing/Boolean checks in `Status.js`, `WorkflowProposals.js`, and webview `messageHandlers`
> - Persistence: simplify promise/early-return flow in `OutputFilesManager.ensureMissingOutputsLoaded()`
> - Utilities and misc: consolidate null trimming in `pathCore.normalizeLatexPath`, simplify `mimeUtils.getMimeType()`, and minor coalescing/boolean cleanups in `ExplorerOperations`, `dialogs.selectFile()`, `latexindentpt`, and `AgentWorkspaceState.getReasoningPrimaryBlock()`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 88bd18717481c4efdccbe9a5b34f94227f56bb9e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->