### PR TITLE
refactor: reduce code complexity and duplication across codebase

### DIFF
--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -437,27 +437,17 @@ class ToolUseProcessNode<C> extends BaseNode<
       }
     }
 
-    const endTurn = services.modelHandler.isEndTurnStop(stopReason);
-
-    if (!toolCalls || toolCalls.length === 0 || endTurn) {
-      return {
-        kind: 'success',
-        stopReason,
-        text: text ?? undefined,
-        endTurn: true,
-        serverToolContentBlocks: serverToolData.contentBlocks,
-        lastAssistantContent,
-        normalizedUsage,
-        responseTimeMs: prepRes.responseTimeMs,
-      };
-    }
+    const endTurn =
+      services.modelHandler.isEndTurnStop(stopReason) ||
+      !toolCalls ||
+      toolCalls.length === 0;
 
     return {
       kind: 'success',
-      toolCalls,
+      toolCalls: endTurn ? undefined : toolCalls,
       stopReason,
       text: text ?? undefined,
-      endTurn: false,
+      endTurn,
       serverToolContentBlocks: serverToolData.contentBlocks,
       lastAssistantContent,
       normalizedUsage,

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -299,29 +299,23 @@ export class ModelHandlerAnthropic extends ModelHandler<
     return true;
   }
 
-  private setCacheControlTarget(block: CacheControlEligibleBlock): void {
-    if (!this.capabilities.supportsPromptCaching) {
-      return;
-    }
-
+  /**
+   * Sets or clears the cache control target block.
+   * Pass a block to set it as the cache target, or undefined/null to clear.
+   */
+  private updateCacheControlTarget(
+    block: CacheControlEligibleBlock | undefined | null,
+  ): void {
+    // Clear existing cache_control if switching to different block
     if (this.cacheControlledBlock && this.cacheControlledBlock !== block) {
       delete this.cacheControlledBlock.cache_control;
     }
 
-    block.cache_control = EPHEMERAL_CACHE_CONTROL;
-    this.cacheControlledBlock = block;
-  }
-
-  private clearCacheControlTarget(): void {
-    if (!this.capabilities.supportsPromptCaching) {
-      this.cacheControlledBlock = undefined;
-      return;
+    if (block && this.capabilities.supportsPromptCaching) {
+      block.cache_control = EPHEMERAL_CACHE_CONTROL;
     }
 
-    if (this.cacheControlledBlock) {
-      delete this.cacheControlledBlock.cache_control;
-    }
-    this.cacheControlledBlock = undefined;
+    this.cacheControlledBlock = block ?? undefined;
   }
 
   /** Ensures a beta flag is included in options, initializing the array if needed. */
@@ -436,12 +430,12 @@ export class ModelHandlerAnthropic extends ModelHandler<
 
     const target = content?.findLast(isCacheControlEligibleBlock);
     if (target) {
-      this.setCacheControlTarget(target);
+      this.updateCacheControlTarget(target);
     } else if (Array.isArray(content) && content.length > 0) {
       this.logger.debug(
         'No eligible content block available for Anthropic cache control marker',
       );
-      this.clearCacheControlTarget();
+      this.updateCacheControlTarget(undefined);
     }
   }
 
@@ -1103,7 +1097,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
       throw new Error(errMsg);
     }
 
-    this.clearCacheControlTarget();
+    this.updateCacheControlTarget(undefined);
 
     // Create content list for the user message
     const userMessageContent: ContentBlockParam[] = [];
@@ -1457,7 +1451,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
         content: [{ type: 'text', text: fileContent }],
       });
 
-      this.clearCacheControlTarget();
+      this.updateCacheControlTarget(undefined);
 
       endTurn = true;
       return [endTurn, messages];
@@ -2055,7 +2049,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
       ? resultMsg.content.at(-1)
       : undefined;
     if (isCacheControlEligibleBlock(toolResultBlock)) {
-      this.setCacheControlTarget(toolResultBlock);
+      this.updateCacheControlTarget(toolResultBlock);
     }
 
     return [callMsg, resultMsg];

--- a/src/agent/runtime/ModelFactory.ts
+++ b/src/agent/runtime/ModelFactory.ts
@@ -34,48 +34,31 @@ const PROVIDER_HANDLERS = new Map<
   [ModelProvider.OTHERS, ModelHandlerOpenRouter],
 ]);
 
-/** Check if OpenAI model should use Responses API. */
-function shouldUseResponsesAPI(config: ModelConfig): boolean {
-  // openRouterOnly models must always route through OpenRouter
-  if (config.openRouterOnly) return false;
-  if (config.requiresResponsesAPI) return true;
-  if (!getConfig<boolean>('texra.model.useOpenRouter', false)) {
-    return (
-      getConfig<boolean>('texra.model.useOpenAIResponsesAPI', false) ||
-      config.fullName.startsWith('gpt-oss')
-    );
-  }
-  return false;
-}
-
-/** Create config with OpenRouter name for routing. */
-function withOpenRouterName(config: ModelConfig): ModelConfig {
-  return {
-    ...config,
-    openrouterFullName:
-      config.openrouterFullName || `${config.provider}/${config.fullName}`,
-  };
-}
-
 /**
  * Creates a model handler instance based on provider and routing configuration.
  */
 export function createModelHandler(config: ModelConfig): ModelHandler {
   // OpenAI Responses API (required or optional)
-  if (
-    config.provider === ModelProvider.OPENAI &&
-    shouldUseResponsesAPI(config)
-  ) {
-    logger.debug(CHANNEL, 'Using OpenAI Responses API Handler');
-    return new ModelHandlerOpenAIResponse(config);
+  const useOpenRouter = getConfig<boolean>('texra.model.useOpenRouter', false);
+  if (config.provider === ModelProvider.OPENAI && !config.openRouterOnly) {
+    const useResponsesAPI =
+      config.requiresResponsesAPI ||
+      (!useOpenRouter &&
+        (getConfig<boolean>('texra.model.useOpenAIResponsesAPI', false) ||
+          config.fullName.startsWith('gpt-oss')));
+    if (useResponsesAPI) {
+      logger.debug(CHANNEL, 'Using OpenAI Responses API Handler');
+      return new ModelHandlerOpenAIResponse(config);
+    }
   }
 
   // Route through OpenRouter if configured
-  const useOpenRouter =
-    config.openRouterOnly ||
-    getConfig<boolean>('texra.model.useOpenRouter', false);
-  if (useOpenRouter) {
-    const routerConfig = withOpenRouterName(config);
+  if (config.openRouterOnly || useOpenRouter) {
+    const routerConfig: ModelConfig = {
+      ...config,
+      openrouterFullName:
+        config.openrouterFullName || `${config.provider}/${config.fullName}`,
+    };
     if (config.provider === ModelProvider.ANTHROPIC) {
       return new ModelHandlerAnthropicViaOpenRouter(routerConfig);
     }

--- a/src/commands/agent/followUpCommand.ts
+++ b/src/commands/agent/followUpCommand.ts
@@ -84,11 +84,14 @@ async function tryAutoResume(streamId: StreamTabId): Promise<boolean> {
   const taskState = progressState?.getTaskState(streamId);
 
   if (!progressState || !executionId || !taskState) {
-    const missing = !progressState
-      ? 'ProgressViewProvider'
-      : !executionId
-        ? 'execution ID'
-        : 'task state';
+    let missing: string;
+    if (!progressState) {
+      missing = 'ProgressViewProvider';
+    } else if (!executionId) {
+      missing = 'execution ID';
+    } else {
+      missing = 'task state';
+    }
     logger.warn(`No ${missing} found for stream: ${streamId}`);
     return false;
   }

--- a/src/commands/latex/latexdiffCommands.ts
+++ b/src/commands/latex/latexdiffCommands.ts
@@ -68,6 +68,26 @@ async function ensureLatexdiffToolInstalled(
 }
 
 /**
+ * Wraps a latexdiff operation with tool verification and error handling.
+ * Eliminates repetitive try-catch patterns across handlers.
+ */
+async function withLatexdiffTool<T>(
+  tool: LatexdiffTool,
+  errorMessage: string,
+  action: () => Promise<T>,
+): Promise<T | undefined> {
+  try {
+    if (!(await ensureLatexdiffToolInstalled(tool))) {
+      return undefined;
+    }
+    return await action();
+  } catch (err) {
+    await showLoggedErrorMessage(CHANNEL, errorMessage, err);
+    return undefined;
+  }
+}
+
+/**
  * Prompts the user to select a math markup granularity for latexdiff operations.
  * @returns The selected math markup option, or undefined if the user cancels.
  */
@@ -179,11 +199,7 @@ async function handleLatexdiff(
   }
 
   const fileToUse = baseFile ?? inputFile;
-  try {
-    if (!(await ensureLatexdiffToolInstalled('latexdiff'))) {
-      return;
-    }
-
+  await withLatexdiffTool('latexdiff', 'Error creating LaTeX diff', async () => {
     const mathMarkup = await promptForLatexdiffMathMarkup();
     if (!mathMarkup) {
       logger.debug(CHANNEL, 'Math markup selection cancelled by user');
@@ -194,7 +210,6 @@ async function handleLatexdiff(
       `Running latexdiff with math markup mode: ${mathMarkup}`,
     );
 
-    // Get the result from LaTeXdiffService
     const fileToUseLocation = pathToLocation(fileToUse);
     const result = await service.runDiff(
       fileToUseLocation,
@@ -209,9 +224,7 @@ async function handleLatexdiff(
     }
 
     await openLatexdiffResult(fileToUseLocation, result.diffFileName);
-  } catch (err) {
-    await showLoggedErrorMessage(CHANNEL, 'Error creating LaTeX diff', err);
-  }
+  });
 }
 
 async function handleLatexdiffvc(
@@ -220,11 +233,7 @@ async function handleLatexdiffvc(
   commitHash: string,
 ) {
   const fileToUse = baseFile ?? inputFile;
-  try {
-    if (!(await ensureLatexdiffToolInstalled('latexdiff-vc'))) {
-      return;
-    }
-
+  await withLatexdiffTool('latexdiff-vc', 'Error creating LaTeX diff', async () => {
     const mathMarkup = await promptForLatexdiffMathMarkup();
     if (!mathMarkup) {
       logger.debug(CHANNEL, 'Math markup selection cancelled by user');
@@ -235,7 +244,6 @@ async function handleLatexdiffvc(
       `Running latexdiff-vc with math markup mode: ${mathMarkup}`,
     );
 
-    // Get the result from LaTeXdiffService
     const fileToUseLocation = pathToLocation(fileToUse);
     const result = await service.runDiffVc(
       fileToUseLocation,
@@ -248,9 +256,7 @@ async function handleLatexdiffvc(
     }
 
     await openLatexdiffResult(fileToUseLocation, result.diffFileName);
-  } catch (err) {
-    await showLoggedErrorMessage(CHANNEL, 'Error creating LaTeX diff', err);
-  }
+  });
 }
 
 async function handlePackLatexdiffvc(
@@ -259,20 +265,14 @@ async function handlePackLatexdiffvc(
   commitHash: string,
   clean: boolean,
 ) {
-  try {
-    if (!(await ensureLatexdiffToolInstalled('latexdiff-vc'))) {
-      return;
-    }
-
+  await withLatexdiffTool('latexdiff-vc', 'Error packing LaTeX diff', async () => {
     logger.debug(
       CHANNEL,
       `Command called with: inputFile=${inputFile}, baseFile=${baseFile}, commitHash=${commitHash}, clean=${clean}`,
     );
     const fileToUse = baseFile ?? inputFile;
     await runPackLatexdiffvc(fileToUse, commitHash, clean);
-  } catch (err) {
-    await showLoggedErrorMessage(CHANNEL, 'Error packing LaTeX diff', err);
-  }
+  });
 }
 
 async function handlePackLatexdiffvcMultiple(
@@ -280,20 +280,14 @@ async function handlePackLatexdiffvcMultiple(
   commitHash: string,
   clean: boolean,
 ) {
-  try {
-    if (!(await ensureLatexdiffToolInstalled('latexdiff-vc'))) {
-      return;
-    }
-
+  await withLatexdiffTool('latexdiff-vc', 'Error packing LaTeX diffs', async () => {
     logger.debug(
       CHANNEL,
       `Command called with: commitHash=${commitHash}, clean=${clean}`,
     );
     logger.debug(CHANNEL, `Input files: ${inputFiles.join(', ')}`);
     await runPackLatexdiffvcMultiple(inputFiles, commitHash, clean);
-  } catch (err) {
-    await showLoggedErrorMessage(CHANNEL, 'Error packing LaTeX diffs', err);
-  }
+  });
 }
 
 async function handleCleanLatexdiffvc(
@@ -301,37 +295,25 @@ async function handleCleanLatexdiffvc(
   baseFile: string,
   commitHash: string,
 ) {
-  try {
-    if (!(await ensureLatexdiffToolInstalled('latexdiff-vc'))) {
-      return;
-    }
-
+  await withLatexdiffTool('latexdiff-vc', 'Error cleaning LaTeX diff', async () => {
     logger.debug(
       CHANNEL,
       `Command called with: inputFile=${inputFile}, baseFile=${baseFile}, commitHash=${commitHash}`,
     );
     const fileToUse = baseFile ?? inputFile;
     await runCleanLatexdiffvc(fileToUse, commitHash);
-  } catch (err) {
-    await showLoggedErrorMessage(CHANNEL, 'Error cleaning LaTeX diff', err);
-  }
+  });
 }
 
 async function handleCleanLatexdiffvcMultiple(
   inputFiles: string[],
   commitHash: string,
 ) {
-  try {
-    if (!(await ensureLatexdiffToolInstalled('latexdiff-vc'))) {
-      return;
-    }
-
+  await withLatexdiffTool('latexdiff-vc', 'Error cleaning LaTeX diffs', async () => {
     logger.debug(CHANNEL, `Command called with: commitHash=${commitHash}`);
     logger.debug(CHANNEL, `Input files: ${inputFiles.join(', ')}`);
     await runCleanLatexdiffvcMultiple(inputFiles, commitHash);
-  } catch (err) {
-    await showLoggedErrorMessage(CHANNEL, 'Error cleaning LaTeX diffs', err);
-  }
+  });
 }
 
 /**

--- a/src/tools/arxiv/ArxivSearchTool.ts
+++ b/src/tools/arxiv/ArxivSearchTool.ts
@@ -10,7 +10,6 @@ import {
 import { z } from 'zod';
 
 // Local imports
-import { toErrorMessage } from '@common/errors';
 import { ARXIV_CONSTANTS } from '@tools/citation/constants';
 import { waitForRateLimit } from '@tools/citation/rateLimiter';
 import { defineTool } from '@tools/core/define';
@@ -20,10 +19,7 @@ import {
   extractBasePaperMetadata,
   normaliseArxivIdentifier,
 } from '@tools/latex/arxivShared';
-// eslint-disable-next-line import/order -- grouped with tools imports
-import { ToolError } from '@tools/result';
-// eslint-disable-next-line import/order -- grouped with tools imports
-import { pluralize } from '@tools/utils';
+import { pluralize, requireNonEmptyString, wrapApiCall } from '@tools/utils';
 
 const SortBySchema = z.enum(['relevance', 'lastUpdatedDate', 'submittedDate']);
 const SortOrderSchema = z.enum(['ascending', 'descending']);
@@ -50,10 +46,7 @@ export class ArxivSearchTool extends defineTool({
   schema: ArxivSearchInputSchema,
 }) {
   protected async execute(input: ArxivSearchInput) {
-    const trimmedQuery = input.query.trim();
-    if (!trimmedQuery) {
-      throw new ToolError('Search query cannot be empty.');
-    }
+    const trimmedQuery = requireNonEmptyString(input.query, 'Search query');
 
     // Select the query function based on the field parameter
     const searchField = input.field ?? 'all';
@@ -109,16 +102,10 @@ export class ArxivSearchTool extends defineTool({
       client = client.sortOrder(input.sortOrder);
     }
 
-    let entries;
-    try {
-      // Respect arXiv API rate limits
+    const entries = await wrapApiCall(async () => {
       await waitForRateLimit('arxiv', ARXIV_CONSTANTS.RATE_LIMIT_DELAY_MS);
-      entries = await client.execute();
-    } catch (error) {
-      throw new ToolError(
-        `Failed to query arXiv API: ${toErrorMessage(error)}`,
-      );
-    }
+      return client.execute();
+    }, 'Failed to query arXiv API');
 
     const results: ArxivSearchResult[] = entries.map((entry) => {
       const base = extractBasePaperMetadata(entry);

--- a/src/tools/citation/CrossrefSearchTool.ts
+++ b/src/tools/citation/CrossrefSearchTool.ts
@@ -9,11 +9,9 @@ import {
 import { z } from 'zod';
 
 // Local imports
-import { toErrorMessage } from '@common/errors';
-// eslint-disable-next-line import/order -- grouped by semantic meaning
 import { defineTool } from '@tools/core/define';
 import { ToolError } from '@tools/result';
-import { pluralize } from '@tools/utils';
+import { pluralize, requireNonEmptyString, wrapApiCall } from '@tools/utils';
 
 // Local file imports
 import { CROSSREF_CONSTANTS } from './constants';
@@ -48,10 +46,7 @@ export class CrossrefSearchTool extends defineTool({
   schema: CrossrefSearchInputSchema,
 }) {
   protected async execute(input: CrossrefSearchInput) {
-    const trimmedQuery = input.query.trim();
-    if (!trimmedQuery) {
-      throw new ToolError('Search query cannot be empty.');
-    }
+    const trimmedQuery = requireNonEmptyString(input.query, 'Search query');
 
     const options: ExtendedQueryWorksParams = {
       query: trimmedQuery,
@@ -64,17 +59,13 @@ export class CrossrefSearchTool extends defineTool({
       ...(input.filter && { filter: input.filter }),
     };
 
-    let response: Awaited<ReturnType<typeof crossrefClient.works>>;
-    try {
-      // Respect Crossref API rate limits
+    const response = await wrapApiCall(async () => {
       await waitForRateLimit(
         'crossref',
         CROSSREF_CONSTANTS.RATE_LIMIT_DELAY_MS,
       );
-      response = await crossrefClient.works(options);
-    } catch (error) {
-      throw new ToolError(`Crossref search failed: ${toErrorMessage(error)}`);
-    }
+      return crossrefClient.works(options);
+    }, 'Crossref search failed');
 
     if (!response.ok || !response.content || !response.content.message) {
       throw new ToolError('Crossref search did not return any items.');

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -146,6 +146,36 @@ export function resolveAndFormat(path?: string): {
   return { resolved, display };
 }
 
+/**
+ * Trim a string and throw a ToolError if the result is empty.
+ * Centralizes the common pattern of validating non-empty input strings.
+ */
+export function requireNonEmptyString(
+  value: string | null | undefined,
+  fieldName = 'Value',
+): string {
+  const trimmed = value?.trim() ?? '';
+  if (!trimmed) {
+    throw new ToolError(`${fieldName} cannot be empty.`);
+  }
+  return trimmed;
+}
+
+/**
+ * Wrap an async API call and convert any error to a ToolError.
+ * Simplifies the common try-catch-rethrow-as-ToolError pattern.
+ */
+export async function wrapApiCall<T>(
+  operation: () => Promise<T>,
+  errorPrefix: string,
+): Promise<T> {
+  try {
+    return await operation();
+  } catch (error) {
+    throw new ToolError(`${errorPrefix}: ${toErrorMessage(error)}`);
+  }
+}
+
 export interface BuildFileAttachmentOptions {
   /** Path to a workspace file (relative or absolute) */
   filePath: string;

--- a/src/tools/web/WebSearchTool.ts
+++ b/src/tools/web/WebSearchTool.ts
@@ -3,9 +3,9 @@ import axios from 'axios';
 import { z } from 'zod';
 
 // Internal imports
-import { toErrorMessage } from '@common/errors';
-import { ToolResult, ToolError } from '@tools/result';
 import { defineTool } from '@tools/core/define';
+import { ToolResult } from '@tools/result';
+import { wrapApiCall } from '@tools/utils';
 
 const WebSearchInputSchema = z.strictObject({
   query: z.string(),
@@ -40,17 +40,14 @@ export class WebSearchTool extends defineTool({
   protected async execute(input: WebSearchInput): Promise<ToolResult> {
     const { query } = input;
     const max_results = input.max_results ?? 3;
-    let response;
-    try {
-      response = await axios.get<DuckDuckGoResponse>(
-        'https://api.duckduckgo.com/',
-        {
+
+    const response = await wrapApiCall(
+      () =>
+        axios.get<DuckDuckGoResponse>('https://api.duckduckgo.com/', {
           params: { q: query, format: 'json', no_redirect: 1, no_html: 1 },
-        },
-      );
-    } catch (error) {
-      throw new ToolError(`Web search failed: ${toErrorMessage(error)}`);
-    }
+        }),
+      'Web search failed',
+    );
     const data = response.data;
     const results: string[] = [];
 


### PR DESCRIPTION
- Extract withLatexdiffTool wrapper for 6 duplicate try-catch patterns in latexdiffCommands.ts
- Fix nested ternary operator in followUpCommand.ts with if-else chain
- Add requireNonEmptyString and wrapApiCall utilities to tools/utils.ts
- Update ArxivSearchTool, CrossrefSearchTool, WebSearchTool to use new utilities
- Inline single-use helper functions in ModelFactory.ts
- Simplify ToolUseCycleFlow.ts by consolidating duplicate return objects
- Consolidate setCacheControlTarget/clearCacheControlTarget into updateCacheControlTarget in modelHandlerAnthropic.ts

Net reduction: ~43 lines of code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Focuses on deduplication and clearer control flow across agent and tool layers.
> 
> - **Tool-use flow:** Consolidates `endTurn` logic in `ToolUseCycleFlow.ts`, conditionally omitting `toolCalls` when ending turn, and unifies success return shape
> - **Anthropic handler:** Merges `setCacheControlTarget`/`clearCacheControlTarget` into `updateCacheControlTarget`; updates all call sites to set/clear cache markers consistently
> - **Model routing:** Inlines OpenAI Responses/OpenRouter routing logic in `ModelFactory.ts` (removes helper functions) for clearer decision flow
> - **VS Code command:** Replaces nested ternary with explicit if-else in `followUpCommand.ts` for missing dependency logging
> - **LaTeX diff commands:** Extracts `withLatexdiffTool` wrapper and applies it across handlers to centralize install checks and error handling
> - **Tool utilities:** Adds `requireNonEmptyString` and `wrapApiCall` in `tools/utils.ts` and refactors `ArxivSearchTool`, `CrossrefSearchTool`, and `WebSearchTool` to use them, removing repetitive try-catch and validation
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fd8935e1b94de2a744c078dcc59a768861014eb3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->