### PR TITLE
refactor: extract shared file content preparation utility

### DIFF
--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -60,7 +60,6 @@ import {
 } from '@common/errors/sdkErrorUtils';
 
 // Internal imports
-import { cleanFileContent } from '@replacement/engine';
 import replacementEngine from '@replacement/engine';
 
 // Type imports
@@ -72,11 +71,11 @@ import { getConfig } from '@utils/config';
 import { flexibleFS } from '@utils/files';
 import { isNonEmptyString } from '@utils/core';
 import { objectToLogString } from '@utils/text/stringUtils';
-import { extractScratchpad } from '@utils/text/xmlUtils';
 import {
   computeCachePercentage,
   nonZeroOrUndefined,
 } from './utils/usageNormalization';
+import { prepareExistingOutputContent } from './utils/fileContentUtils';
 
 // Local file imports
 import {
@@ -1429,21 +1428,12 @@ export class ModelHandlerAnthropic extends ModelHandler<
       return [endTurn, messages];
     }
 
-    // Get prefill from existing and non-trivial file
-    let fileContent = await flexibleFS.read(outputLocation);
-    fileContent = cleanFileContent(fileContent);
-
-    // Extract any existing scratchpad content
-    const scratchpad = await extractScratchpad(fileContent, 'scratchpad');
-    if (scratchpad) {
-      this.logger.logScratchpad(scratchpad);
-    }
-
-    await flexibleFS.write(outputLocation, fileContent);
-
-    // Update the workspaceState with the actual file content
-    workspaceState.assembly.accumulatedOutput = fileContent;
-    workspaceState.assembly.lastResponse = fileContent;
+    // Prepare existing file content (read, clean, extract scratchpad, update state)
+    const { content: fileContent } = await prepareExistingOutputContent(
+      outputLocation,
+      workspaceState,
+      this.logger,
+    );
 
     if (hasEndTag(agentSetting, fileContent)) {
       this.logger.debug(

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -50,7 +50,6 @@ import { AgentLogger } from '@logger/AgentLogger';
 import { ReasoningEffort } from '@model/ModelConfig';
 
 // Internal imports
-import { cleanFileContent } from '@replacement/engine';
 import replacementEngine from '@replacement/engine';
 
 // Local imports - tools
@@ -63,11 +62,11 @@ import type { FileLocation } from '@utils/files';
 import { K_SLICE } from '@utils/config';
 import { isNonEmptyString } from '@utils/core';
 import { flexibleFS, getShortDisplayPath } from '@utils/files';
-import { extractScratchpad } from '@utils/text/xmlUtils';
 import {
   computeCachePercentage,
   nonZeroOrUndefined,
 } from './utils/usageNormalization';
+import { prepareExistingOutputContent } from './utils/fileContentUtils';
 
 // Local file imports
 import {
@@ -1063,24 +1062,13 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
     this.logger.debug(
       `Output file ${outputLocation.absolutePath} exists and is non-trivial. Reading content.`,
     );
-    let fileContent = await flexibleFS.read(outputLocation);
-    fileContent = cleanFileContent(fileContent);
 
-    // Extract any existing scratchpad content
-    const scratchpad = await extractScratchpad(fileContent, 'scratchpad');
-    if (scratchpad) {
-      this.logger.logScratchpad(scratchpad);
-    }
-
-    await flexibleFS.write(outputLocation, fileContent);
-    this.logger.debug(
-      `Cleaned and saved existing content to ${outputLocation.absolutePath}.`,
+    // Prepare existing file content (read, clean, extract scratchpad, update state)
+    const { content: fileContent } = await prepareExistingOutputContent(
+      outputLocation,
+      workspaceState,
+      this.logger,
     );
-
-    // Update workspace state - critical for multi-round agents on resume
-    // so that subsequent rounds have correct context
-    workspaceState.assembly.accumulatedOutput = fileContent;
-    workspaceState.assembly.lastResponse = fileContent;
 
     messages.push(createModelContent(createPartFromText(fileContent)));
     this.logger.debug(

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -41,18 +41,17 @@ import {
 import type { ToolDefinition } from '@model';
 
 // Internal imports
-import { cleanFileContent } from '@replacement/engine';
 import type { ToolFileAttachment } from '@tools/result';
 import { isNonEmptyString } from '@utils/core';
 import type { FileLocation } from '@utils/files';
 import { K_SLICE, MESSAGE_PREVIEW_LENGTH } from '@utils/config';
 import { flexibleFS } from '@utils/files';
 import { objectToLogString } from '@utils/text/stringUtils';
-import { extractScratchpad } from '@utils/text/xmlUtils';
 import {
   computeCachePercentage,
   nonZeroOrUndefined,
 } from './utils/usageNormalization';
+import { prepareExistingOutputContent } from './utils/fileContentUtils';
 
 // Local file imports
 import { OPENAI_CHAT_FINISH } from './types/StopReasonTypes';
@@ -858,23 +857,12 @@ export class ModelHandlerOpenAI<
       return [endTurn, messages];
     }
 
-    // Get prefill from existing and non-trivial file
-    let fileContent = await flexibleFS.read(outputLocation);
-    fileContent = cleanFileContent(fileContent);
-
-    // Extract any existing scratchpad content
-    const scratchpad = await extractScratchpad(fileContent, 'scratchpad');
-    if (scratchpad) {
-      this.logger.logScratchpad(scratchpad);
-    }
-
-    // Write file content to output file
-    await flexibleFS.write(outputLocation, fileContent);
-
-    // Update workspace state - critical for multi-round agents on resume
-    // so that subsequent rounds have correct context
-    workspaceState.assembly.accumulatedOutput = fileContent;
-    workspaceState.assembly.lastResponse = fileContent;
+    // Prepare existing file content (read, clean, extract scratchpad, update state)
+    const { content: fileContent } = await prepareExistingOutputContent(
+      outputLocation,
+      workspaceState,
+      this.logger,
+    );
 
     messages.push({
       role: 'assistant',

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -24,9 +24,6 @@ import {
 // Type imports
 import type { ModelConfig } from '@model';
 
-// Internal imports
-import { cleanFileContent } from '@replacement/engine';
-
 // Type imports
 import type { ToolFileAttachment } from '@tools/result';
 import type { FileLocation } from '@utils/files';
@@ -36,11 +33,11 @@ import { K_SLICE, getConfig } from '@utils/config';
 import { sleepWithAbort } from '@utils/core';
 import { flexibleFS } from '@utils/files';
 import { isNonEmptyString } from '@utils/core';
-import { extractScratchpad } from '@utils/text/xmlUtils';
 import {
   computeCachePercentage,
   nonZeroOrUndefined,
 } from './utils/usageNormalization';
+import { prepareExistingOutputContent } from './utils/fileContentUtils';
 
 // Local file imports
 import {
@@ -1366,20 +1363,12 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       return [endTurn, messages];
     }
 
-    let fileContent = await flexibleFS.read(outputLocation);
-    fileContent = cleanFileContent(fileContent);
-
-    const scratchpad = await extractScratchpad(fileContent, 'scratchpad');
-    if (scratchpad) {
-      this.logger.logScratchpad(scratchpad);
-    }
-
-    await flexibleFS.write(outputLocation, fileContent);
-
-    // Update workspace state - critical for multi-round agents on resume
-    // so that subsequent rounds have correct context
-    workspaceState.assembly.accumulatedOutput = fileContent;
-    workspaceState.assembly.lastResponse = fileContent;
+    // Prepare existing file content (read, clean, extract scratchpad, update state)
+    const { content: fileContent } = await prepareExistingOutputContent(
+      outputLocation,
+      workspaceState,
+      this.logger,
+    );
 
     messages.push(this.createAssistantMessage(fileContent));
 

--- a/src/agent/modelHandlers/utils/fileContentUtils.ts
+++ b/src/agent/modelHandlers/utils/fileContentUtils.ts
@@ -1,0 +1,95 @@
+/**
+ * Shared utilities for file content preparation in model handlers.
+ * Consolidates duplicated patterns across Anthropic, OpenAI, and Google handlers.
+ */
+
+// Local imports - agent workspace
+import type { AgentWorkspaceState } from '@agent/core/AgentWorkspaceState';
+
+// Local imports - replacement
+import { cleanFileContent } from '@replacement/engine';
+
+// Local imports - files
+import { flexibleFS, type FileLocation } from '@utils/files';
+
+// Local imports - xml
+import { extractScratchpad } from '@utils/text/xmlUtils';
+
+// Local imports - logger
+import type { AgentLogger } from '@logger/AgentLogger';
+
+/**
+ * Result of preparing file content for a model handler.
+ */
+export interface PreparedFileContent {
+  /** The cleaned file content */
+  content: string;
+  /** Whether a scratchpad was found and logged */
+  hadScratchpad: boolean;
+}
+
+/**
+ * Prepares existing output file content for model processing.
+ *
+ * This is the shared implementation for the pattern that appears in:
+ * - modelHandlerAnthropic.ts (initializeOutputAndPrefill)
+ * - modelHandlerOpenAI.ts (initializeOutputAndPrefill)
+ * - modelHandlerGoogleGenAI.ts (initializeOutputAndPrefill)
+ *
+ * The function:
+ * 1. Reads file content from the output location
+ * 2. Cleans the content (applies replacement rules)
+ * 3. Extracts and logs any scratchpad content
+ * 4. Writes cleaned content back to the file
+ * 5. Updates workspace state with the content
+ *
+ * @param outputLocation - Location of the output file
+ * @param workspaceState - Workspace state to update with file content
+ * @param logger - Logger for scratchpad output
+ * @returns The prepared file content and metadata
+ */
+export async function prepareExistingOutputContent(
+  outputLocation: FileLocation,
+  workspaceState: AgentWorkspaceState,
+  logger: AgentLogger,
+): Promise<PreparedFileContent> {
+  // Read and clean the file content
+  let content = await flexibleFS.read(outputLocation);
+  content = cleanFileContent(content);
+
+  // Extract any existing scratchpad content and log it
+  const scratchpad = await extractScratchpad(content, 'scratchpad');
+  if (scratchpad) {
+    logger.logScratchpad(scratchpad);
+  }
+
+  // Write cleaned content back to file
+  await flexibleFS.write(outputLocation, content);
+
+  // Update workspace state - critical for multi-round agents on resume
+  // so that subsequent rounds have correct context
+  workspaceState.assembly.accumulatedOutput = content;
+  workspaceState.assembly.lastResponse = content;
+
+  return {
+    content,
+    hadScratchpad: Boolean(scratchpad),
+  };
+}
+
+/**
+ * Updates workspace state with file content.
+ *
+ * Simplified helper for cases where only state update is needed
+ * without the full preparation flow.
+ *
+ * @param workspaceState - Workspace state to update
+ * @param content - Content to set in assembly state
+ */
+export function updateWorkspaceWithContent(
+  workspaceState: AgentWorkspaceState,
+  content: string,
+): void {
+  workspaceState.assembly.accumulatedOutput = content;
+  workspaceState.assembly.lastResponse = content;
+}

--- a/src/commands/housekeeping/cleanCommands.ts
+++ b/src/commands/housekeeping/cleanCommands.ts
@@ -4,7 +4,7 @@ import { z } from 'zod';
 
 // Local imports
 import type { FileOpResult } from '@agent/types/ResultTypes';
-import { formatZodError, showLoggedMessage } from '@common/errors';
+import { parseWithErrorDisplay } from '@common/errors';
 import * as logger from '@logger/logUtils';
 import {
   runCleanSingle,
@@ -63,24 +63,6 @@ function showCleanResult(result: FileOpResult, inputFile: string): void {
   }
 }
 
-/** Validate clean params and log error if invalid. Returns parsed data or null. */
-async function validateCleanParams(
-  inputFile: string,
-  agent: string,
-  model: string,
-  commandName: string,
-): Promise<z.infer<typeof CleanParamsSchema> | null> {
-  const parsed = CleanParamsSchema.safeParse({ inputFile, agent, model });
-  if (!parsed.success) {
-    await showLoggedMessage(
-      CHANNEL,
-      `Invalid params for ${commandName}: ${formatZodError(parsed.error)}`,
-    );
-    return null;
-  }
-  return parsed.data;
-}
-
 export function registerCleanCommands(context: vscode.ExtensionContext): void {
   context.subscriptions.push(
     vscode.commands.registerCommand('texra.clean', handleClean),
@@ -96,11 +78,11 @@ async function handleCleanSingle(
   agent: string,
   model: string,
 ): Promise<void> {
-  const data = await validateCleanParams(
-    inputFile,
-    agent,
-    model,
-    'cleanSingle',
+  const data = await parseWithErrorDisplay(
+    CHANNEL,
+    CleanParamsSchema,
+    { inputFile, agent, model },
+    'cleanSingle params',
   );
   if (!data) return;
 
@@ -115,11 +97,11 @@ async function handleCleanMultiple(
   model: string,
   outputFiles: string[] = [],
 ): Promise<void> {
-  const data = await validateCleanParams(
-    inputFile,
-    agent,
-    model,
-    'cleanMultiple',
+  const data = await parseWithErrorDisplay(
+    CHANNEL,
+    CleanParamsSchema,
+    { inputFile, agent, model },
+    'cleanMultiple params',
   );
   if (!data) return;
 
@@ -136,14 +118,8 @@ async function handleCleanMultiple(
 }
 
 export async function handleClean(config: unknown): Promise<void> {
-  const parsed = CleanConfigSchema.safeParse(config);
-  if (!parsed.success) {
-    await showLoggedMessage(
-      CHANNEL,
-      `Invalid config: ${formatZodError(parsed.error)}`,
-    );
-    return;
-  }
+  const data = await parseWithErrorDisplay(CHANNEL, CleanConfigSchema, config, 'config');
+  if (!data) return;
 
   const {
     agent,
@@ -153,11 +129,11 @@ export async function handleClean(config: unknown): Promise<void> {
     useMultipleOutputs,
     streamId,
     skipProgressViewClear,
-  } = parsed.data;
+  } = data;
 
   logger.debug(
     CHANNEL,
-    `Clean command called with config: ${JSON.stringify(parsed.data)}`,
+    `Clean command called with config: ${JSON.stringify(data)}`,
   );
 
   const result =

--- a/src/commands/housekeeping/packCommands.ts
+++ b/src/commands/housekeeping/packCommands.ts
@@ -4,7 +4,7 @@ import { z } from 'zod';
 
 // Local imports
 import type { FileOpResult } from '@agent/types/ResultTypes';
-import { formatZodError, showLoggedMessage } from '@common/errors';
+import { parseWithErrorDisplay } from '@common/errors';
 import * as logger from '@logger/logUtils';
 import { WorkspaceFS } from '@utils/files';
 import { runPack, runPackSingle, runPackMultiple } from '@housekeeping';
@@ -97,14 +97,8 @@ function showPackResult(result: FileOpResult, inputFile: string): void {
 // --- Handlers ---
 
 async function handlePack(config: unknown): Promise<void> {
-  const parsed = PackConfigSchema.safeParse(config);
-  if (!parsed.success) {
-    await showLoggedMessage(
-      CHANNEL,
-      `Invalid config: ${formatZodError(parsed.error)}`,
-    );
-    return;
-  }
+  const data = await parseWithErrorDisplay(CHANNEL, PackConfigSchema, config, 'config');
+  if (!data) return;
 
   const {
     agent,
@@ -114,7 +108,7 @@ async function handlePack(config: unknown): Promise<void> {
     useMultipleOutputs,
     streamId,
     skipProgressViewClear,
-  } = parsed.data;
+  } = data;
 
   if (outputFiles.length > 1 && !useMultipleOutputs) {
     logger.warn(
@@ -147,16 +141,14 @@ async function handlePackSingle(
   agent: string,
   model: string,
 ): Promise<void> {
-  const parsed = PackParamsSchema.safeParse({ inputFile, agent, model });
-  if (!parsed.success) {
-    await showLoggedMessage(
-      CHANNEL,
-      `Invalid params: ${formatZodError(parsed.error)}`,
-    );
-    return;
-  }
+  const data = await parseWithErrorDisplay(
+    CHANNEL,
+    PackParamsSchema,
+    { inputFile, agent, model },
+    'params',
+  );
+  if (!data) return;
 
-  const data = parsed.data;
   const result = await runPackSingle(data.model, data.inputFile, data.agent);
   showPackResult(result, data.inputFile);
   emitClearMissingOutputs(data.agent, data.model, data.inputFile, false);
@@ -168,21 +160,13 @@ async function handlePackMultiple(
   model: string,
   outputFiles: string[] = [],
 ): Promise<void> {
-  const parsed = PackMultipleSchema.safeParse({
-    inputFile,
-    agent,
-    model,
-    outputFiles,
-  });
-  if (!parsed.success) {
-    await showLoggedMessage(
-      CHANNEL,
-      `Invalid params: ${formatZodError(parsed.error)}`,
-    );
-    return;
-  }
-
-  const data = parsed.data;
+  const data = await parseWithErrorDisplay(
+    CHANNEL,
+    PackMultipleSchema,
+    { inputFile, agent, model, outputFiles },
+    'params',
+  );
+  if (!data) return;
   const result = await runPackMultiple(
     data.model,
     data.inputFile,

--- a/src/common/errors/errorHandlingUtils.ts
+++ b/src/common/errors/errorHandlingUtils.ts
@@ -119,6 +119,42 @@ export function formatZodError(error: z.ZodError): string {
 }
 
 /**
+ * Parse data with a Zod schema and show a user-friendly error if parsing fails.
+ *
+ * This consolidates the common pattern of:
+ * 1. Parse with safeParse
+ * 2. If failure, show a logged error message with formatted Zod errors
+ * 3. Return null on failure, parsed data on success
+ *
+ * @param channel - The logger channel for the error message
+ * @param schema - The Zod schema to parse against
+ * @param data - The data to parse
+ * @param context - Optional context for the error message (e.g., "config", "params")
+ * @returns The parsed data if successful, null if validation failed
+ *
+ * @example
+ * ```typescript
+ * const result = await parseWithErrorDisplay(CHANNEL, ConfigSchema, config, 'config');
+ * if (!result) return; // Validation failed, error already shown to user
+ * // Use result safely here
+ * ```
+ */
+export async function parseWithErrorDisplay<T>(
+  channel: string,
+  schema: z.ZodSchema<T>,
+  data: unknown,
+  context?: string,
+): Promise<T | null> {
+  const result = schema.safeParse(data);
+  if (!result.success) {
+    const prefix = context ? `Invalid ${context}` : 'Invalid input';
+    await showLoggedMessage(channel, `${prefix}: ${formatZodError(result.error)}`);
+    return null;
+  }
+  return result.data;
+}
+
+/**
  * Check if an error represents a file-not-found condition.
  *
  * Handles both Node.js filesystem errors (ENOENT) and VS Code FileSystemError.

--- a/src/common/errors/index.ts
+++ b/src/common/errors/index.ts
@@ -3,6 +3,7 @@ export {
   DocId,
   formatError,
   formatZodError,
+  parseWithErrorDisplay,
   isFileNotFoundError,
   toErrorMessage,
   logErrorMessage,


### PR DESCRIPTION
Consolidate duplicated file content preparation logic from four model
handlers into a shared utility function `prepareExistingOutputContent`.

The duplicated pattern (read, clean, extract scratchpad, write, update
workspace state) was repeated identically in:
- modelHandlerAnthropic.ts
- modelHandlerOpenAI.ts
- modelHandlerGoogleGenAI.ts
- modelHandlerOpenAIResponse.ts

This reduces code by ~45 lines and ensures consistent behavior across
all model handlers.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Consolidates duplicated model-handler logic**
> 
> - Introduces `prepareExistingOutputContent` in `utils/fileContentUtils` to read/clean content, extract/log `scratchpad`, rewrite output, and update `workspaceState`
> - Replaces inline logic in `modelHandlerAnthropic.ts`, `modelHandlerOpenAI.ts`, `modelHandlerOpenAIResponse.ts`, and `modelHandlerGoogleGenAI.ts` with the shared utility
> 
> **Centralizes command param validation**
> 
> - Adds `parseWithErrorDisplay` to `common/errors` and exports it from the barrel
> - Refactors `cleanCommands.ts` and `packCommands.ts` to use `parseWithErrorDisplay` instead of in-file `safeParse`/custom helpers, simplifying handlers and error messaging
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 888789e3ee5e48c9065259173ec398f4fbc37e42. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->