### PR TITLE
refactor: add explicit return types and improve variable naming

### DIFF
--- a/src/commands/agent/agentCreatorCommands.ts
+++ b/src/commands/agent/agentCreatorCommands.ts
@@ -178,7 +178,7 @@ function validateAgentYamlString(content: string): string | null {
   }
 }
 
-export function registerAgentCreatorCommands(context: vscode.ExtensionContext) {
+export function registerAgentCreatorCommands(context: vscode.ExtensionContext): typeof agentCreatorCommands {
   context.subscriptions.push(
     vscode.commands.registerCommand(
       agentCreatorCommands.createAgentWithAI,
@@ -188,7 +188,7 @@ export function registerAgentCreatorCommands(context: vscode.ExtensionContext) {
   return agentCreatorCommands;
 }
 
-async function handleCreateAgentWithAI(_context: vscode.ExtensionContext) {
+async function handleCreateAgentWithAI(_context: vscode.ExtensionContext): Promise<void> {
   try {
     const agentName = await vscode.window.showInputBox({
       prompt: 'Enter a name for the new agent (without .yaml)',

--- a/src/commands/agent/executeCommand.ts
+++ b/src/commands/agent/executeCommand.ts
@@ -17,7 +17,7 @@ const CHANNEL = 'ExecuteCommand';
 
 // --- Command ---
 
-export function registerExecuteCommand(context: vscode.ExtensionContext) {
+export function registerExecuteCommand(context: vscode.ExtensionContext): void {
   context.subscriptions.push(
     vscode.commands.registerCommand('texra.execute', runExecuteCommand),
   );

--- a/src/commands/agent/followUpCommand.ts
+++ b/src/commands/agent/followUpCommand.ts
@@ -174,7 +174,7 @@ async function handleFollowUpResult(
   }
 }
 
-export function registerFollowUpCommand(context: vscode.ExtensionContext) {
+export function registerFollowUpCommand(context: vscode.ExtensionContext): void {
   context.subscriptions.push(
     vscode.commands.registerCommand(
       'texra.sendFollowUp',

--- a/src/commands/api/apiKeyCommands.ts
+++ b/src/commands/api/apiKeyCommands.ts
@@ -86,7 +86,7 @@ async function setApiKeyForProvider(
   }
 }
 
-export function registerApiKeyCommands(context: vscode.ExtensionContext) {
+export function registerApiKeyCommands(context: vscode.ExtensionContext): void {
   // Command to set API key (accepts optional provider parameter)
   const setApiKeyCommand = vscode.commands.registerCommand(
     apiKeyCommands.setApiKey,

--- a/src/commands/files/openFileCommands.ts
+++ b/src/commands/files/openFileCommands.ts
@@ -64,7 +64,7 @@ export const openFileCommands = {
   openLabel,
 };
 
-export function registerOpenFileCommands(context: vscode.ExtensionContext) {
+export function registerOpenFileCommands(context: vscode.ExtensionContext): typeof openFileCommands {
   context.subscriptions.push(
     vscode.commands.registerCommand(
       'texra.openFileCompile',

--- a/src/commands/history/stateRestoreCommand.ts
+++ b/src/commands/history/stateRestoreCommand.ts
@@ -15,7 +15,7 @@ logger.initialize(CHANNEL);
 /**
  * Register state restore command with VS Code
  */
-export function registerStateRestoreCommand(context: vscode.ExtensionContext) {
+export function registerStateRestoreCommand(context: vscode.ExtensionContext): void {
   context.subscriptions.push(
     vscode.commands.registerCommand('texra.restoreState', restoreState),
   );
@@ -28,7 +28,7 @@ export function registerStateRestoreCommand(context: vscode.ExtensionContext) {
  * @param state - The TaskState to restore
  * @param executeImmediately - If true, execute the agent after restoring state (for followup)
  */
-async function restoreState(state: TaskState, executeImmediately?: boolean) {
+async function restoreState(state: TaskState, executeImmediately?: boolean): Promise<void> {
   logger.debug(CHANNEL, 'Restoring main webview state', {
     data: { executeImmediately },
   });

--- a/src/commands/housekeeping/cleanCommands.ts
+++ b/src/commands/housekeeping/cleanCommands.ts
@@ -96,17 +96,17 @@ async function handleCleanSingle(
   agent: string,
   model: string,
 ): Promise<void> {
-  const data = await validateCleanParams(
+  const cleanParams = await validateCleanParams(
     inputFile,
     agent,
     model,
     'cleanSingle',
   );
-  if (!data) return;
+  if (!cleanParams) return;
 
-  const result = await runCleanSingle(data.model, data.inputFile, data.agent);
-  showCleanResult(result, data.inputFile);
-  emitClearMissingOutputs(data.agent, data.model, data.inputFile, false);
+  const result = await runCleanSingle(cleanParams.model, cleanParams.inputFile, cleanParams.agent);
+  showCleanResult(result, cleanParams.inputFile);
+  emitClearMissingOutputs(cleanParams.agent, cleanParams.model, cleanParams.inputFile, false);
 }
 
 async function handleCleanMultiple(
@@ -115,24 +115,24 @@ async function handleCleanMultiple(
   model: string,
   outputFiles: string[] = [],
 ): Promise<void> {
-  const data = await validateCleanParams(
+  const cleanParams = await validateCleanParams(
     inputFile,
     agent,
     model,
     'cleanMultiple',
   );
-  if (!data) return;
+  if (!cleanParams) return;
 
   logger.debug(CHANNEL, `Additional files: ${outputFiles.join(', ')}`);
 
   const result = await runCleanMultiple(
-    data.model,
-    data.inputFile,
-    data.agent,
+    cleanParams.model,
+    cleanParams.inputFile,
+    cleanParams.agent,
     outputFiles,
   );
-  showCleanResult(result, data.inputFile);
-  emitClearMissingOutputs(data.agent, data.model, data.inputFile, true);
+  showCleanResult(result, cleanParams.inputFile);
+  emitClearMissingOutputs(cleanParams.agent, cleanParams.model, cleanParams.inputFile, true);
 }
 
 export async function handleClean(config: unknown): Promise<void> {

--- a/src/commands/housekeeping/packCommands.ts
+++ b/src/commands/housekeeping/packCommands.ts
@@ -156,10 +156,10 @@ async function handlePackSingle(
     return;
   }
 
-  const data = parsed.data;
-  const result = await runPackSingle(data.model, data.inputFile, data.agent);
-  showPackResult(result, data.inputFile);
-  emitClearMissingOutputs(data.agent, data.model, data.inputFile, false);
+  const packParams = parsed.data;
+  const result = await runPackSingle(packParams.model, packParams.inputFile, packParams.agent);
+  showPackResult(result, packParams.inputFile);
+  emitClearMissingOutputs(packParams.agent, packParams.model, packParams.inputFile, false);
 }
 
 async function handlePackMultiple(
@@ -182,15 +182,15 @@ async function handlePackMultiple(
     return;
   }
 
-  const data = parsed.data;
+  const packParams = parsed.data;
   const result = await runPackMultiple(
-    data.model,
-    data.inputFile,
-    data.agent,
-    data.outputFiles,
+    packParams.model,
+    packParams.inputFile,
+    packParams.agent,
+    packParams.outputFiles,
   );
-  showPackResult(result, data.inputFile);
-  emitClearMissingOutputs(data.agent, data.model, data.inputFile, true);
+  showPackResult(result, packParams.inputFile);
+  emitClearMissingOutputs(packParams.agent, packParams.model, packParams.inputFile, true);
 }
 
 // --- Registration ---

--- a/src/commands/latex/arXivCommands.ts
+++ b/src/commands/latex/arXivCommands.ts
@@ -18,7 +18,7 @@ export const arXivCommands = {
  * @param context The extension context
  * @returns An object with the registered commands
  */
-export function registerArXivCommands(context: vscode.ExtensionContext) {
+export function registerArXivCommands(context: vscode.ExtensionContext): void {
   logger.initialize(CHANNEL);
 
   // Register the download arXiv source command

--- a/src/commands/latex/compareCommands.ts
+++ b/src/commands/latex/compareCommands.ts
@@ -61,7 +61,7 @@ async function validateFilesExist(
 /**
  * Register comparison related commands
  */
-export function registerCompareCommands(context: vscode.ExtensionContext) {
+export function registerCompareCommands(context: vscode.ExtensionContext): void {
   context.subscriptions.push(
     vscode.commands.registerCommand('texra.compare', handleCompare),
     vscode.commands.registerCommand('texra.acceptEdited', handleAcceptEdited),

--- a/src/commands/latex/figCommands.ts
+++ b/src/commands/latex/figCommands.ts
@@ -36,7 +36,7 @@ async function runLaTeXCommand(
   }
 }
 
-export function registerFigureCommands(context: vscode.ExtensionContext) {
+export function registerFigureCommands(context: vscode.ExtensionContext): void {
   context.subscriptions.push(
     vscode.commands.registerCommand(
       'texra.extractFigurePaths',

--- a/src/commands/latex/imageCommands.ts
+++ b/src/commands/latex/imageCommands.ts
@@ -25,7 +25,7 @@ function logTruncatedBase64(base64String: string): void {
   );
 }
 
-export function registerImageCommands(context: vscode.ExtensionContext) {
+export function registerImageCommands(context: vscode.ExtensionContext): void {
   context.subscriptions.push(
     vscode.commands.registerCommand('texra.countPdfPages', handleCountPdfPages),
     vscode.commands.registerCommand(

--- a/src/commands/latex/latexCommands.ts
+++ b/src/commands/latex/latexCommands.ts
@@ -14,7 +14,7 @@ import { runIndentTeX } from '@housekeeping';
 const CHANNEL = 'LaTeXCommands';
 logger.initialize(CHANNEL);
 
-export function registerLatexCommands(context: vscode.ExtensionContext) {
+export function registerLatexCommands(context: vscode.ExtensionContext): void {
   context.subscriptions.push(
     vscode.commands.registerCommand(
       'texra.indentCurrentTeX',

--- a/src/commands/latex/latexdiffCommands.ts
+++ b/src/commands/latex/latexdiffCommands.ts
@@ -158,7 +158,7 @@ async function handleLatexdiff(
   inputFile: string,
   baseFile: string,
   editedFile: string,
-) {
+): Promise<void> {
   if (!(baseFile || inputFile)) {
     await showLoggedMessageWithDocs(
       CHANNEL,
@@ -218,7 +218,7 @@ async function handleLatexdiffvc(
   inputFile: string,
   baseFile: string,
   commitHash: string,
-) {
+): Promise<void> {
   const fileToUse = baseFile ?? inputFile;
   try {
     if (!(await ensureLatexdiffToolInstalled('latexdiff-vc'))) {
@@ -258,7 +258,7 @@ async function handlePackLatexdiffvc(
   baseFile: string,
   commitHash: string,
   clean: boolean,
-) {
+): Promise<void> {
   try {
     if (!(await ensureLatexdiffToolInstalled('latexdiff-vc'))) {
       return;
@@ -279,7 +279,7 @@ async function handlePackLatexdiffvcMultiple(
   inputFiles: string[],
   commitHash: string,
   clean: boolean,
-) {
+): Promise<void> {
   try {
     if (!(await ensureLatexdiffToolInstalled('latexdiff-vc'))) {
       return;
@@ -300,7 +300,7 @@ async function handleCleanLatexdiffvc(
   inputFile: string,
   baseFile: string,
   commitHash: string,
-) {
+): Promise<void> {
   try {
     if (!(await ensureLatexdiffToolInstalled('latexdiff-vc'))) {
       return;
@@ -320,7 +320,7 @@ async function handleCleanLatexdiffvc(
 async function handleCleanLatexdiffvcMultiple(
   inputFiles: string[],
   commitHash: string,
-) {
+): Promise<void> {
   try {
     if (!(await ensureLatexdiffToolInstalled('latexdiff-vc'))) {
       return;

--- a/src/commands/system/mainViewCommands.ts
+++ b/src/commands/system/mainViewCommands.ts
@@ -42,7 +42,7 @@ function postOptionsToWebview(
  * @param context - The VS Code extension context
  * @returns Object containing the registered commands
  */
-export function registerMainViewCommands(context: vscode.ExtensionContext) {
+export function registerMainViewCommands(context: vscode.ExtensionContext): typeof mainViewCommands {
   const resetCommand = vscode.commands.registerCommand(
     mainViewCommands.reset,
     async () => {
@@ -144,4 +144,6 @@ export function registerMainViewCommands(context: vscode.ExtensionContext) {
     refreshAgentOptionsCommand,
     refreshAllOptionsCommand,
   );
+
+  return mainViewCommands;
 }

--- a/src/commands/system/textEditorCommands.ts
+++ b/src/commands/system/textEditorCommands.ts
@@ -14,7 +14,7 @@ import { WorkspaceFS } from '@utils/files';
 const CHANNEL = 'TextEditorCommands';
 logger.initialize(CHANNEL);
 
-export function registerTextEditorCommands(context: vscode.ExtensionContext) {
+export function registerTextEditorCommands(context: vscode.ExtensionContext): void {
   context.subscriptions.push(
     vscode.commands.registerCommand(
       'texra.testTextEditor',

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -58,7 +58,7 @@ function promptToOpenFolder(message: string): void {
     });
 }
 
-async function refreshApiKeyStatus() {
+async function refreshApiKeyStatus(): Promise<void> {
   if (!apiKeyStatusBarItem) {
     return;
   }
@@ -84,7 +84,7 @@ async function refreshApiKeyStatus() {
   }
 }
 
-export async function activate(context: vscode.ExtensionContext) {
+export async function activate(context: vscode.ExtensionContext): Promise<void> {
   const workspaceFolders = vscode.workspace.workspaceFolders;
 
   if (!workspaceFolders || workspaceFolders.length !== 1) {
@@ -332,7 +332,7 @@ export async function activate(context: vscode.ExtensionContext) {
   }
 }
 
-export async function deactivate() {
+export async function deactivate(): Promise<void> {
   disposeStatusListener?.();
 
   // Flush any pending usage logs before deactivating

--- a/src/frontend/setup.ts
+++ b/src/frontend/setup.ts
@@ -35,7 +35,7 @@ const LEGACY_AGENT_FILES = [
  * Copies default agent files from the extension resources to the global storage directory
  * @param context The extension context
  */
-export async function copyDefaultAgents(context: vscode.ExtensionContext) {
+export async function copyDefaultAgents(context: vscode.ExtensionContext): Promise<void> {
   // Initialize StorageFS with the context
   StorageFS.initialize(context);
 
@@ -210,7 +210,7 @@ const GLOBAL_IF_UNSET = {
 /**
  * Configure LaTeX-related workspace settings if LaTeX Workshop extension is installed
  */
-export async function configureLatexSettings() {
+export async function configureLatexSettings(): Promise<void> {
   try {
     // Check if latex-workshop extension is installed
     const latexWorkshop = vscode.extensions.getExtension(


### PR DESCRIPTION
- Add explicit return type annotations to all register* functions
- Add Promise<void> return types to async handlers and functions
- Rename generic 'data' variables to domain-specific names (packParams, cleanParams)
- Improves type safety and code readability across command files

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves type safety and readability across command modules without changing behavior.
> 
> - Add explicit return types (e.g., `void`, `Promise<void>`, specific command maps) to `register*` functions and async handlers across agent, latex, housekeeping, system, and extension files
> - Rename ambiguous variables to domain-specific ones (e.g., `data` -> `cleanParams`, `packParams`) and propagate usages
> - Some `register*` functions now return their command map objects (e.g., `agentCreatorCommands`, `openFileCommands`, `mainViewCommands`) for easier testing/composition
> - Minor consistency cleanups (typing helper functions, parameter names)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bc3aa0174d949fd41008e6f8ec963ef5c1f7a6b6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->