### PR TITLE
Review LaTeX tool detection chain

### DIFF
--- a/src/utils/system/toolUtils.ts
+++ b/src/utils/system/toolUtils.ts
@@ -234,15 +234,22 @@ export async function checkToolInstalled(
       reject: false,
     };
 
+    // Log PATH info once (not per-command)
+    logger.debug(
+      CHANNEL,
+      `PATH contains ${extendedPath.split(path.delimiter).length} entries, ` +
+        `includes /usr/bin: ${extendedPath.includes('/usr/bin')}`,
+    );
+
+    // Check if output contains version-like pattern (e.g., "3.7.1")
+    const hasVersionOutput = (result: { stdout?: string; stderr?: string }) =>
+      result.stdout?.match(/\d+\.\d+/) || result.stderr?.match(/\d+\.\d+/);
+
     // Helper function to execute a command with fallback
     const executeWithFallback = (cmd: string, args: string[]): boolean => {
       logger.debug(
         CHANNEL,
         `Checking tool '${cmd}' with args [${args.join(', ')}]`,
-      );
-      logger.debug(
-        CHANNEL,
-        `PATH contains ${extendedPath.split(':').length} entries, includes /usr/bin: ${extendedPath.includes('/usr/bin')}`,
       );
 
       let result;
@@ -264,9 +271,7 @@ export async function checkToolInstalled(
 
       // Accept if exit code is 0, OR if we got version-like output
       // (some tools return non-zero for --version but still output version info)
-      const hasVersionOutput =
-        result.stdout?.match(/\d+\.\d+/) || result.stderr?.match(/\d+\.\d+/);
-      if (result.exitCode === 0 || hasVersionOutput) {
+      if (result.exitCode === 0 || hasVersionOutput(result)) {
         logger.debug(CHANNEL, `Tool '${cmd}' detected successfully`);
         return true;
       }
@@ -303,9 +308,7 @@ export async function checkToolInstalled(
             `stderr=${result.stderr?.slice(0, 100) || '(empty)'}`,
         );
 
-        const fallbackHasVersion =
-          result.stdout?.match(/\d+\.\d+/) || result.stderr?.match(/\d+\.\d+/);
-        if (result.exitCode === 0 || fallbackHasVersion) {
+        if (result.exitCode === 0 || hasVersionOutput(result)) {
           return true;
         }
       }

--- a/src/utils/system/toolUtils.ts
+++ b/src/utils/system/toolUtils.ts
@@ -15,6 +15,7 @@ import { extendEnvPath, findToolInCommonPaths } from './platformPaths';
 import { executeCommand } from './execUtils';
 
 const CHANNEL = 'toolUtils';
+logger.initialize(CHANNEL);
 
 // Interface for tool configuration
 export interface ToolConfig {
@@ -227,28 +228,95 @@ export async function checkToolInstalled(
 
     let isInstalled = false;
 
+    const extendedPath = extendEnvPath();
     const execOptions = {
-      env: { ...process.env, PATH: extendEnvPath() },
+      env: { ...process.env, PATH: extendedPath },
       reject: false,
     };
 
     // Helper function to execute a command with fallback
     const executeWithFallback = (cmd: string, args: string[]): boolean => {
-      let result = execaSync(cmd, args, execOptions);
-      if (result.exitCode === 0) {
+      logger.debug(
+        CHANNEL,
+        `Checking tool '${cmd}' with args [${args.join(', ')}]`,
+      );
+      logger.debug(
+        CHANNEL,
+        `PATH contains ${extendedPath.split(':').length} entries, includes /usr/bin: ${extendedPath.includes('/usr/bin')}`,
+      );
+
+      let result;
+      try {
+        result = execaSync(cmd, args, execOptions);
+      } catch (execErr) {
+        logger.info(
+          CHANNEL,
+          `Exception executing '${cmd}': ${execErr instanceof Error ? execErr.message : String(execErr)}`,
+        );
+        return false;
+      }
+      logger.debug(
+        CHANNEL,
+        `Initial check for '${cmd}': exitCode=${result.exitCode}, ` +
+          `stdout=${result.stdout?.slice(0, 100) || '(empty)'}, ` +
+          `stderr=${result.stderr?.slice(0, 100) || '(empty)'}`,
+      );
+
+      // Accept if exit code is 0, OR if we got version-like output
+      // (some tools return non-zero for --version but still output version info)
+      const hasVersionOutput =
+        result.stdout?.match(/\d+\.\d+/) || result.stderr?.match(/\d+\.\d+/);
+      if (result.exitCode === 0 || hasVersionOutput) {
+        logger.debug(CHANNEL, `Tool '${cmd}' detected successfully`);
         return true;
       }
 
       const fallback = findToolInCommonPaths(cmd);
+      logger.debug(
+        CHANNEL,
+        `Fallback search for '${cmd}': ${fallback || 'not found'}`,
+      );
+
       if (fallback) {
         const needsPerl =
           fallback.toLowerCase().endsWith('.pl') ||
           (process.platform === 'win32' && path.extname(fallback) === '');
-        result = needsPerl
-          ? execaSync('perl', [fallback, ...args], execOptions)
-          : execaSync(fallback, args, execOptions);
-        return result.exitCode === 0;
+        logger.debug(
+          CHANNEL,
+          `Running fallback '${fallback}' (needsPerl=${needsPerl})`,
+        );
+        try {
+          result = needsPerl
+            ? execaSync('perl', [fallback, ...args], execOptions)
+            : execaSync(fallback, args, execOptions);
+        } catch (fallbackErr) {
+          logger.info(
+            CHANNEL,
+            `Exception executing fallback '${fallback}': ${fallbackErr instanceof Error ? fallbackErr.message : String(fallbackErr)}`,
+          );
+          return false;
+        }
+        logger.debug(
+          CHANNEL,
+          `Fallback result: exitCode=${result.exitCode}, ` +
+            `stdout=${result.stdout?.slice(0, 100) || '(empty)'}, ` +
+            `stderr=${result.stderr?.slice(0, 100) || '(empty)'}`,
+        );
+
+        const fallbackHasVersion =
+          result.stdout?.match(/\d+\.\d+/) || result.stderr?.match(/\d+\.\d+/);
+        if (result.exitCode === 0 || fallbackHasVersion) {
+          return true;
+        }
       }
+
+      // Log at info level so it shows in output channel by default
+      logger.info(
+        CHANNEL,
+        `Tool '${cmd}' not detected. Last result: exitCode=${result.exitCode}, ` +
+          `stdout=${result.stdout?.slice(0, 200) || '(empty)'}, ` +
+          `stderr=${result.stderr?.slice(0, 200) || '(empty)'}`,
+      );
       return false;
     };
 


### PR DESCRIPTION
Addresses issue where latexindent/latexdiff work in terminal but TeXRA reports them as not installed.

Changes:
- Add debug/info logging throughout checkToolInstalled() to diagnose failures
- Log PATH info (entry count, whether /usr/bin is present)
- Accept tools that return non-zero exit code but produce version-like output (e.g., "3.7.1" in stdout/stderr) - some tools return non-zero for --version
- Add try-catch around execaSync to catch unexpected execution errors
- Upgrade failure logs to info level so they appear in output channel

With this fix, when detection fails, the TeXRA output channel will show:
- What command was attempted
- Exit code, stdout, and stderr from the attempt
- Whether /usr/bin was in the PATH

This helps identify whether the issue is PATH-related, Perl module errors, or something else.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves robustness and observability of `checkToolInstalled` in `toolUtils.ts`.
> 
> - Initialize logger for `toolUtils` and add detailed debug/info logs (PATH entry count, `/usr/bin` presence, command/fallback attempts, exit codes, truncated stdout/stderr)
> - Guard `execaSync` calls with try/catch for both primary and fallback executions; promote failure logs to info level
> - Accept tools as installed if `--version` outputs a version-like string even with non-zero exit code
> - Minor refactor: compute `extendedPath` once and reuse in exec env
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c8bad9dbc824dbd6d9d1ed8b20ae6bb3b7c84729. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->