### PR TITLE
Fix VS Code theme colors in progress view

### DIFF
--- a/src/profileView/styles/index.css
+++ b/src/profileView/styles/index.css
@@ -58,8 +58,12 @@ h2 {
 }
 
 .tier-badge.ultra {
-  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-  color: #ffffff;
+  background: linear-gradient(
+    135deg,
+    var(--vscode-textLink-foreground) 0%,
+    var(--vscode-textLink-activeForeground) 100%
+  );
+  color: var(--vscode-button-foreground);
 }
 
 /* Not authenticated state */
@@ -122,7 +126,7 @@ h2 {
 
 .badge.visibility-badge.public {
   background: var(--vscode-testing-iconPassed);
-  color: white;
+  color: var(--vscode-button-foreground);
 }
 
 .badge.visibility-badge.custom {

--- a/src/progressView/styles/file-list.css
+++ b/src/progressView/styles/file-list.css
@@ -7,7 +7,7 @@
 /* Collapsible container styling */
 .files-collapsible {
   margin: 0;
-  border-top: 1px solid var(--color-border);
+  border-top: var(--border-thin) solid var(--color-border);
 }
 
 .files-collapsible[hidden] {

--- a/src/progressView/styles/file-list.css
+++ b/src/progressView/styles/file-list.css
@@ -14,9 +14,11 @@
   display: none;
 }
 
-/* Override vscode-collapsible header padding */
+/* Override vscode-collapsible header padding and theming */
 .files-collapsible::part(header) {
   padding: var(--spacing-tiny) var(--spacing-medium);
+  background-color: var(--vscode-sideBarSectionHeader-background, transparent);
+  color: var(--vscode-sideBarTitle-foreground, var(--vscode-foreground));
 }
 
 .files-collapsible::part(body) {

--- a/src/progressView/styles/follow-up-input.css
+++ b/src/progressView/styles/follow-up-input.css
@@ -8,7 +8,7 @@
   display: none;
   grid-template-columns: 1fr auto;
   padding: var(--spacing-medium);
-  border-top: 1px solid var(--color-border);
+  border-top: var(--border-thin) solid var(--color-border);
   gap: var(--spacing-small);
 }
 

--- a/src/progressView/styles/followup-section.css
+++ b/src/progressView/styles/followup-section.css
@@ -6,6 +6,12 @@
   margin-top: var(--spacing-medium, 8px);
 }
 
+/* Override vscode-collapsible header theming */
+.followup-collapsible::part(header) {
+  background-color: var(--vscode-sideBarSectionHeader-background, transparent);
+  color: var(--vscode-sideBarTitle-foreground, var(--vscode-foreground));
+}
+
 .followup-section {
   display: flex;
   flex-direction: column;

--- a/src/progressView/styles/followup-section.css
+++ b/src/progressView/styles/followup-section.css
@@ -3,7 +3,7 @@
  */
 
 .followup-collapsible {
-  margin-top: var(--spacing-medium, 8px);
+  margin-top: var(--spacing-medium);
 }
 
 /* Override vscode-collapsible header theming */
@@ -15,8 +15,8 @@
 .followup-section {
   display: flex;
   flex-direction: column;
-  gap: var(--spacing-medium, 8px);
-  padding: var(--spacing-small, 4px) 0;
+  gap: var(--spacing-medium);
+  padding: var(--spacing-small) 0;
 }
 
 .followup-mode-toggle {
@@ -26,19 +26,19 @@
 
 .followup-mode-toggle vscode-radio-group {
   display: flex;
-  gap: var(--spacing-large, 16px);
+  gap: var(--spacing-large);
 }
 
 .followup-selects {
   display: flex;
-  gap: var(--spacing-medium, 8px);
+  gap: var(--spacing-medium);
   flex-wrap: wrap;
 }
 
 .followup-select-group {
   display: flex;
   align-items: center;
-  gap: var(--spacing-small, 4px);
+  gap: var(--spacing-small);
   flex: 1;
   min-width: 120px;
 }
@@ -88,7 +88,7 @@
 .followup-options {
   display: flex;
   align-items: center;
-  gap: var(--spacing-medium, 8px);
+  gap: var(--spacing-medium);
 }
 
 /* Hide options in chat/merge modes */
@@ -100,8 +100,8 @@
 .followup-actions {
   display: flex;
   justify-content: flex-end;
-  gap: var(--spacing-small, 4px);
-  margin-top: var(--spacing-small, 4px);
+  gap: var(--spacing-small);
+  margin-top: var(--spacing-small);
 }
 
 .followup-actions vscode-button {

--- a/src/progressView/styles/instruction-panel.css
+++ b/src/progressView/styles/instruction-panel.css
@@ -4,8 +4,8 @@
 
 .instruction-panel {
   display: none;
-  border-top: 1px solid var(--color-border);
-  border-bottom: 1px solid var(--color-border);
+  border-top: var(--border-thin) solid var(--color-border);
+  border-bottom: var(--border-thin) solid var(--color-border);
   background-color: transparent;
 }
 

--- a/src/progressView/styles/logs.css
+++ b/src/progressView/styles/logs.css
@@ -77,7 +77,7 @@
 }
 
 .message-warn {
-  color: var(--vscode-inputValidation-warningForeground, #dd8500d6);
+  color: var(--color-warning);
 }
 
 .message-error {
@@ -225,9 +225,13 @@
   opacity: var(--opacity-full);
 }
 
-.status-indicator.is-ready {
-  background-color: var(--vscode-descriptionForeground, #888888);
+.status-indicator.is-ready,
+.status-indicator.is-stopped {
+  background-color: var(--vscode-descriptionForeground);
   box-shadow: none;
+}
+
+.status-indicator.is-ready {
   opacity: var(--opacity-disabled);
 }
 
@@ -242,20 +246,17 @@
   box-shadow: 0 0 4px var(--color-error);
 }
 
-.status-indicator.is-stopped {
-  background-color: var(--vscode-descriptionForeground, #888888);
-  box-shadow: none;
+.status-indicator.is-waiting,
+.status-indicator.is-resuming {
+  background-color: var(--vscode-textLink-foreground);
+  box-shadow: 0 0 4px var(--vscode-textLink-foreground);
 }
 
 .status-indicator.is-waiting {
-  background-color: var(--vscode-textLink-foreground, #3794ff);
-  box-shadow: 0 0 4px var(--vscode-textLink-foreground, #3794ff);
   animation: pulse-scale 3s infinite;
 }
 
 .status-indicator.is-resuming {
-  background-color: var(--vscode-textLink-foreground, #3794ff);
-  box-shadow: 0 0 4px var(--vscode-textLink-foreground, #3794ff);
   animation: pulse-scale 1.5s infinite;
 }
 

--- a/src/progressView/styles/logs.css
+++ b/src/progressView/styles/logs.css
@@ -375,6 +375,8 @@
 .round-collapsible::part(header) {
   padding: var(--spacing-tiny) 0;
   font-size: var(--font-size-sm);
+  background-color: var(--vscode-sideBarSectionHeader-background, transparent);
+  color: var(--vscode-sideBarTitle-foreground, var(--vscode-foreground));
 }
 
 .round-collapsible::part(body) {

--- a/src/progressView/styles/logs.css
+++ b/src/progressView/styles/logs.css
@@ -91,7 +91,7 @@
   flex-direction: column;
   gap: var(--spacing-small);
   color: var(--color-text-secondary);
-  border-bottom: 1px solid var(--color-border);
+  border-bottom: var(--border-thin) solid var(--color-border);
 }
 
 .log-header__primary {
@@ -270,7 +270,7 @@
 }
 
 .usage-summary-footer {
-  border-top: 1px solid var(--color-border);
+  border-top: var(--border-thin) solid var(--color-border);
   background-color: var(--vscode-sideBarSectionHeader-background);
   padding: var(--spacing-small) var(--spacing-medium);
   display: flex;
@@ -366,7 +366,7 @@
 
 /* Round collapsible - vscode-collapsible for workflow mode */
 .round-collapsible {
-  border-top: 1px solid var(--color-border);
+  border-top: var(--border-thin) solid var(--color-border);
 }
 
 .round-collapsible:first-child {

--- a/src/progressView/styles/markdown.css
+++ b/src/progressView/styles/markdown.css
@@ -28,27 +28,23 @@
 .markdown-content h3,
 .markdown-content h4 {
   color: var(--vscode-textLink-foreground, #3794ff);
-  margin-top: 1em;
-  margin-bottom: 0.5em;
+  font-size: var(--font-size-lg);
   font-weight: 600;
   line-height: 1.25;
+  margin-top: 1em;
+  margin-bottom: 0.5em;
 }
 
-.markdown-content h1:first-child,
-.markdown-content h2:first-child,
-.markdown-content h3:first-child,
-.markdown-content h4:first-child {
+.markdown-content :is(h1, h2, h3, h4):first-child {
   margin-top: 0;
 }
 
 .markdown-content h1 {
-  font-size: var(--font-size-lg);
   border-bottom: var(--border-thin) solid var(--color-border);
   padding-bottom: var(--spacing-small);
 }
 
 .markdown-content h2 {
-  font-size: var(--font-size-lg);
   padding-left: var(--spacing-medium);
   margin-top: var(--spacing-large);
   margin-bottom: var(--spacing-small);
@@ -58,14 +54,6 @@
   padding-bottom: var(--spacing-tiny);
   border-radius: var(--border-radius) 0 0 var(--border-radius);
   color: var(--color-text-link);
-}
-
-.markdown-content h3 {
-  font-size: var(--font-size-lg);
-}
-
-.markdown-content h4 {
-  font-size: var(--font-size-lg);
 }
 
 /* Add styles to control paragraph spacing */

--- a/src/progressView/styles/queued-follow-ups.css
+++ b/src/progressView/styles/queued-follow-ups.css
@@ -5,7 +5,7 @@
 
 /* Collapsible container styling */
 .queued-follow-ups-collapsible {
-  border-radius: var(--radius);
+  border-radius: var(--border-radius);
   background-color: var(--vscode-inputValidation-infoBackground);
   border: 1px solid var(--vscode-inputValidation-infoBorder);
 }
@@ -41,7 +41,7 @@
   font-size: var(--font-size);
   line-height: 1.4;
   background-color: var(--vscode-editor-background);
-  border-radius: var(--radius-sm);
+  border-radius: var(--border-radius-small);
   border: 1px solid var(--color-border);
 }
 
@@ -57,5 +57,5 @@
   flex: 1;
   word-break: break-word;
   white-space: pre-wrap;
-  color: var(--color-text);
+  color: var(--vscode-foreground);
 }

--- a/src/progressView/styles/queued-follow-ups.css
+++ b/src/progressView/styles/queued-follow-ups.css
@@ -42,7 +42,7 @@
   line-height: 1.4;
   background-color: var(--vscode-editor-background);
   border-radius: var(--border-radius-small);
-  border: 1px solid var(--color-border);
+  border: var(--border-thin) solid var(--color-border);
 }
 
 .queued-follow-up-icon {

--- a/src/progressView/styles/queued-follow-ups.css
+++ b/src/progressView/styles/queued-follow-ups.css
@@ -15,10 +15,12 @@
   display: none;
 }
 
-/* Override vscode-collapsible header padding */
+/* Override vscode-collapsible header padding and theming */
 .queued-follow-ups-collapsible::part(header) {
   padding: var(--spacing-small) var(--spacing-medium);
   font-weight: 500;
+  background-color: transparent;
+  color: var(--vscode-sideBarTitle-foreground, var(--vscode-foreground));
 }
 
 .queued-follow-ups-collapsible::part(body) {

--- a/src/progressView/styles/requests-shared.css
+++ b/src/progressView/styles/requests-shared.css
@@ -13,7 +13,7 @@
   margin: var(--spacing-large) 0;
   padding: var(--spacing-large);
   border-radius: var(--border-radius-large);
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
+  box-shadow: 0 2px 8px var(--vscode-widget-shadow, rgba(0, 0, 0, 0.12));
   display: none;
   flex-direction: column;
   gap: var(--spacing-large);

--- a/src/progressView/styles/retry-requests.css
+++ b/src/progressView/styles/retry-requests.css
@@ -5,8 +5,8 @@
 
 /* Container theme - warning style */
 .retry-requests {
-  border: 1px solid var(--vscode-inputValidation-warningBorder, #856404);
-  background: var(--vscode-inputValidation-warningBackground, #fff3cd);
+  border: 1px solid var(--vscode-inputValidation-warningBorder);
+  background: var(--vscode-inputValidation-warningBackground);
 }
 
 .retry-requests__header .codicon {

--- a/src/progressView/styles/retry-requests.css
+++ b/src/progressView/styles/retry-requests.css
@@ -38,7 +38,7 @@
 
 /* Expandable error details */
 .retry-request__error-details {
-  margin-top: var(--spacing-xs);
+  margin-top: var(--spacing-tiny);
   font-size: var(--font-size-xs);
 }
 
@@ -51,7 +51,7 @@
   color: var(--vscode-descriptionForeground);
   display: flex;
   align-items: center;
-  gap: var(--spacing-xs);
+  gap: var(--spacing-tiny);
   user-select: none;
 }
 
@@ -60,7 +60,7 @@
 }
 
 .retry-request__error-body {
-  margin: var(--spacing-xs) 0 0 0;
+  margin: var(--spacing-tiny) 0 0 0;
   padding: var(--spacing-small);
   background: var(--vscode-textBlockQuote-background, rgba(0, 0, 0, 0.1));
   border-radius: var(--border-radius-small);

--- a/src/progressView/styles/scratchpad.css
+++ b/src/progressView/styles/scratchpad.css
@@ -42,7 +42,7 @@
 .tool-use-separator {
   margin: var(--spacing-small) 0;
   border: none;
-  border-top: 1px solid var(--color-border);
+  border-top: var(--border-thin) solid var(--color-border);
   opacity: 0.3;
 }
 

--- a/src/progressView/styles/scratchpad.css
+++ b/src/progressView/styles/scratchpad.css
@@ -63,10 +63,6 @@
     rgba(255, 0, 0, 0.1)
   );
   border-radius: var(--border-radius-small);
-}
-
-/* Pre-wrapped text content */
-.banner-content--error .error-details {
   white-space: pre-wrap;
   word-break: break-word;
 }
@@ -97,29 +93,30 @@
   color: var(--vscode-textLink-foreground, #3794ff);
 }
 
-.tool-user-feedback {
-  white-space: pre-wrap;
-  word-break: break-word;
-  padding: var(--spacing-small);
-  background-color: var(
-    --vscode-inputValidation-infoBackground,
-    rgba(55, 148, 255, 0.1)
-  );
-  border-radius: var(--border-radius-small);
-  border-left: 3px solid var(--vscode-textLink-foreground, #3794ff);
-}
-
-/* Error content styling - mirrors user feedback but with error colors */
+/* Shared content block styling */
+.tool-user-feedback,
 .tool-error-content {
   white-space: pre-wrap;
   word-break: break-word;
   padding: var(--spacing-small);
+  border-radius: var(--border-radius-small);
+  border-left: 3px solid;
+}
+
+.tool-user-feedback {
+  background-color: var(
+    --vscode-inputValidation-infoBackground,
+    rgba(55, 148, 255, 0.1)
+  );
+  border-left-color: var(--vscode-textLink-foreground, #3794ff);
+}
+
+.tool-error-content {
   background-color: var(
     --vscode-inputValidation-errorBackground,
     rgba(255, 0, 0, 0.1)
   );
-  border-radius: var(--border-radius-small);
-  border-left: 3px solid var(--color-error);
+  border-left-color: var(--color-error);
   color: var(--color-error);
 }
 

--- a/src/progressView/styles/tabs.css
+++ b/src/progressView/styles/tabs.css
@@ -53,10 +53,7 @@
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  padding-top: var(--spacing-small);
-  padding-right: var(--spacing-small);
-  padding-bottom: var(--spacing-small);
-  padding-left: var(--spacing-small);
+  padding: var(--spacing-small);
   cursor: pointer;
   border: none;
   background: none;

--- a/src/progressView/styles/todo-list.css
+++ b/src/progressView/styles/todo-list.css
@@ -10,9 +10,11 @@
   border-bottom: 1px solid var(--color-border);
 }
 
-/* Override vscode-collapsible header padding */
+/* Override vscode-collapsible header padding and theming */
 .todo-collapsible::part(header) {
   padding: var(--spacing-small) var(--spacing-medium);
+  background-color: var(--vscode-sideBarSectionHeader-background, transparent);
+  color: var(--vscode-sideBarTitle-foreground, var(--vscode-foreground));
 }
 
 .todo-collapsible::part(body) {

--- a/src/progressView/styles/todo-list.css
+++ b/src/progressView/styles/todo-list.css
@@ -6,8 +6,8 @@
 /* Collapsible container styling */
 .todo-collapsible {
   margin: var(--spacing-small) 0;
-  border-top: 1px solid var(--color-border);
-  border-bottom: 1px solid var(--color-border);
+  border-top: var(--border-thin) solid var(--color-border);
+  border-bottom: var(--border-thin) solid var(--color-border);
 }
 
 /* Override vscode-collapsible header padding and theming */

--- a/src/progressView/styles/workflow-proposals.css
+++ b/src/progressView/styles/workflow-proposals.css
@@ -54,7 +54,7 @@
 
 .workflow-proposal__agent {
   font-family: var(--vscode-editor-font-family);
-  font-size: var(--font-size-base);
+  font-size: var(--font-size);
   font-weight: 600;
   color: var(--vscode-textLink-foreground);
 }

--- a/src/progressView/styles/workflow-proposals.css
+++ b/src/progressView/styles/workflow-proposals.css
@@ -5,8 +5,8 @@
 
 /* Container theme - info style */
 .workflow-proposals {
-  border: 1px solid var(--vscode-inputValidation-infoBorder, #007acc);
-  background: var(--vscode-inputValidation-infoBackground, #d6ecf2);
+  border: 1px solid var(--vscode-inputValidation-infoBorder);
+  background: var(--vscode-inputValidation-infoBackground);
 }
 
 .workflow-proposals__header .codicon {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Unifies styling across ProgressView and ProfileView to use VS Code theme tokens for consistent theming and accessibility.
> 
> - Replaces hardcoded colors/border widths with `var(--vscode-*)`, `--color-*`, and `--border-*` tokens across multiple CSS files
> - Themed `vscode-collapsible` headers (`::part(header)`) to match sidebar section styles in file lists, todo, follow-up, and round/queued panels
> - Adjusts badges and labels (e.g., `tier-badge.ultra`, visibility/public) to use theme foregrounds and gradients
> - Refines status indicator states: merges/stylistically aligns `is-stopped` with ready; uses link colors for waiting/resuming, adds header/footer border consistency
> - Normalizes spacing/radius vars and font sizes (e.g., markdown headings use `--font-size-lg`; removed fallback values)
> - Standardizes warning/info panels and retry/workflow proposal containers to VS Code validation colors; updates shadows to `--vscode-widget-shadow`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3552f0e0874a56350bfaca9d69578b08e939577b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->