### PR TITLE
Fix JSON Schema transform representation issue

### DIFF
--- a/src/agent/modelHandlers/toolConversion.ts
+++ b/src/agent/modelHandlers/toolConversion.ts
@@ -35,7 +35,9 @@ function convertToolSchema(
   def: ToolDefinition,
 ): Record<string, unknown> | null {
   if (def.zodSchema) {
-    return toJSONSchema(def.zodSchema) as Record<string, unknown>;
+    return toJSONSchema(def.zodSchema, {
+      unrepresentable: 'any',
+    }) as Record<string, unknown>;
   }
   return (def.parameters ?? null) as Record<string, unknown> | null;
 }
@@ -164,6 +166,7 @@ export function toAnthropicTools(
     const params = d.zodSchema
       ? (toJSONSchema(d.zodSchema, {
           reused: 'ref',
+          unrepresentable: 'any',
         }) as AnthropicTool['input_schema'])
       : (d.parameters as AnthropicTool['input_schema'] | undefined);
 


### PR DESCRIPTION
Tool schemas using .transform() (like nullish().transform() for defaults) cannot be represented in JSON Schema. Add unrepresentable: 'any' option to toJSONSchema() calls in toolConversion.ts to match the pattern used in tools/core/define.ts.

Affected functions:
- convertToolSchema() used by OpenAI Responses API and Google Gemini
- toAnthropicTools() for Anthropic API

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures tool schemas with Zod transforms (e.g., `nullish().transform()`) can be serialized to JSON Schema.
> 
> - Set `unrepresentable: 'any'` in `convertToolSchema()` and in Anthropic conversion (`toAnthropicTools` with `reused: 'ref'`) when calling `toJSONSchema`
> - Affects tool serialization for OpenAI Responses (`function` tools), Google Gemini (`functionDeclarations`), and Anthropic (`input_schema`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a6b38d175ba76b5e07a20c710b9f13227e9e11dd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->