### PR TITLE
Fix display when switching to empty chat

### DIFF
--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -496,6 +496,20 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       state.clearAllQueuedFollowUps();
       state.clearAllFollowUpText();
     } else {
+      // Clear content immediately when switching streams to prevent stale display.
+      // handleUpdateLogs will repopulate with correct content, but if the new stream
+      // is empty, no logs message arrives - so we must clear proactively here.
+      // Use lastRenderedStream (not previousStream) to detect if displayed content
+      // differs from the new stream - handles cases where previousStream is unset.
+      if (
+        state.lastRenderedStream &&
+        state.lastRenderedStream !== message.activeStream
+      ) {
+        const logContent = document.getElementById(ELEMENT_IDS.LOG_CONTENT);
+        if (logContent) logContent.innerHTML = '';
+        state.lastRenderedStream = '';
+      }
+
       const streamStatus = state.streamStatuses.get(message.activeStream);
       dom.status.update(streamStatus || STREAM_STATUS.STOPPED);
       dom.todoList.update(state.getTodos(message.activeStream) ?? []);


### PR DESCRIPTION
…isplay

When switching from workflow to chat tab, the log content was not being cleared immediately. If the chat stream is empty, no UPDATE_LOGS message arrives to trigger the clear, leaving workflow content visible as "leftovers".

Now proactively clear the log content in handleUpdateStreams when switching streams. Uses lastRenderedStream (not previousStream) to detect stale content, handling cases where the previous active stream was unset but content from another stream was displayed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents stale workflow logs from persisting when switching to an empty chat/stream.
> 
> - In `handleUpdateStreams`, if `lastRenderedStream` differs from the new `activeStream`, clear `LOG_CONTENT` and reset `lastRenderedStream` before updating status and panels
> - Uses `lastRenderedStream` (not `previousStream`) to detect displayed content vs. target stream
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 31bdc687e5495b1bcdb3c1d15092437abe58f234. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->