### PR TITLE
fix: make agent/model dropdowns open upward

### DIFF
--- a/src/webview/index.html
+++ b/src/webview/index.html
@@ -534,6 +534,7 @@
                       aria-label="Workflow agent"
                       tabindex="-1"
                       aria-hidden="true"
+                      position="above"
                     >
                       ${workflowAgentOptions}
                     </vscode-single-select>
@@ -542,6 +543,7 @@
                       class="agent-select agent-select--active"
                       data-session-type="toolUse"
                       aria-label="Tool-use agent"
+                      position="above"
                     >
                       ${toolUseAgentOptions}
                     </vscode-single-select>
@@ -554,7 +556,7 @@
                   class="codicon codicon-robot clickable"
                   title="Model settings"
                 ></i>
-                <vscode-single-select id="model">
+                <vscode-single-select id="model" position="above">
                   ${modelOptions}
                 </vscode-single-select>
               </div>


### PR DESCRIPTION
## Summary
- Add `position="above"` to `#workflowAgent`, `#toolUseAgent`, and `#model` select elements in the main webview footer
- Makes dropdown listboxes open upward instead of downward, consistent with other footer dropdowns

## Test plan
- [ ] Verify agent dropdown opens upward when clicked
- [ ] Verify model dropdown opens upward when clicked
- [ ] Ensure dropdowns don't clip or overflow

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns footer select components to open upward for consistency and to avoid overflow.
> 
> - Adds `position="above"` to `#workflowAgent`, `#toolUseAgent`, and `#model` `vscode-single-select` elements in `src/webview/index.html`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e2064f375c8d258d98e0fb460065f37e6dd19e25. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->