### PR TITLE
fix: use userInstruction field for proposal rejection feedback

### DIFF
--- a/src/progressView/styles/requests-shared.css
+++ b/src/progressView/styles/requests-shared.css
@@ -96,4 +96,3 @@
   justify-content: flex-start;
   gap: var(--spacing-small);
 }
-

--- a/src/tools/WorkflowTool.ts
+++ b/src/tools/WorkflowTool.ts
@@ -107,13 +107,14 @@ function proposalResultToToolResult(
 
   switch (result.action) {
     case 'reject': {
-      const feedback = result.feedback
-        ? `\n\nUser feedback: ${result.feedback}`
-        : '';
+      const feedback = result.feedback?.trim();
       return {
         summary: `User rejected '${agentName}' ${label}`,
-        output: `The ${context === 'workflow' ? 'workflow agent proposal' : 'delegation proposal'} was rejected.${feedback}`,
+        output: `The ${context === 'workflow' ? 'workflow agent proposal' : 'delegation proposal'} was rejected.`,
         isError: true,
+        ...(feedback && feedback.length > 0
+          ? { userInstruction: feedback }
+          : {}),
       };
     }
     case 'timeout':


### PR DESCRIPTION
## Summary
- Aligns proposal rejection handling with file edit rejections by using the dedicated `userInstruction` field instead of embedding feedback in the output string
- Ensures `ToolUseCycleFlow` properly extracts feedback and sends it as a follow-up user message to the model
- Previously, file edit rejections used `userInstruction` (properly handled), while proposal rejections embedded feedback in `output` (no special handling)

## Test plan
- [ ] Reject a workflow agent proposal with feedback and verify feedback appears as a separate user instruction to the model
- [ ] Reject a delegate agent proposal with feedback and verify same behavior
- [ ] Verify file edit rejections still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Routes proposal rejection feedback through the dedicated `userInstruction` field and stops embedding it in `output`.
> 
> - In `WorkflowTool.ts` `proposalResultToToolResult('reject')`: trim feedback and, if present, set `userInstruction`; remove feedback from `output`; keep `isError: true`
> - No changes to other result cases (`timeout`, `setup`, `approve`)
> - Minor CSS tidy in `requests-shared.css`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e609ccd90e1679f05b20e9be21915621c51a2c0b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->