### PR TITLE
Support pasted arxiv links in download source

### DIFF
--- a/src/commands/latex/arXivCommands.ts
+++ b/src/commands/latex/arXivCommands.ts
@@ -26,10 +26,10 @@ export function registerArXivCommands(context: vscode.ExtensionContext) {
     arXivCommands.downloadArXivSource,
     async () => {
       try {
-        // Ask for arXiv ID
+        // Ask for arXiv ID or URL
         const arxivId = await vscode.window.showInputBox({
-          placeHolder: 'e.g., 2404.12175',
-          prompt: 'Enter arXiv ID',
+          placeHolder: 'e.g., 2404.12175 or https://arxiv.org/abs/2404.12175',
+          prompt: 'Enter arXiv ID or URL',
           validateInput: arxivProcessor.validateId.bind(arxivProcessor),
         });
 

--- a/src/latex/arxivProcessor.ts
+++ b/src/latex/arxivProcessor.ts
@@ -25,6 +25,9 @@ export interface ExtractOptions {
   channel?: string;
 }
 
+const INVALID_ARXIV_INPUT_ERROR =
+  'Invalid arXiv ID or URL. Please provide a valid arXiv ID (e.g., 2404.12175) or URL (e.g., https://arxiv.org/abs/2404.12175)';
+
 export class ArxivSourceProcessor {
   constructor(private readonly channel: string = 'arxivProcessor') {
     logger.initialize(this.channel);
@@ -87,7 +90,7 @@ export class ArxivSourceProcessor {
 
     const normalized = this.normalizeInput(input);
     if (!normalized) {
-      return 'Invalid arXiv ID or URL. Please provide a valid arXiv ID (e.g., 2404.12175) or URL (e.g., https://arxiv.org/abs/2404.12175)';
+      return INVALID_ARXIV_INPUT_ERROR;
     }
 
     return null;
@@ -189,9 +192,7 @@ export class ArxivSourceProcessor {
     // Normalize input (URL or ID) to plain arXiv ID
     const id = this.normalizeInput(input);
     if (!id) {
-      throw new Error(
-        'Invalid arXiv ID or URL. Please provide a valid arXiv ID (e.g., 2404.12175) or URL (e.g., https://arxiv.org/abs/2404.12175)',
-      );
+      throw new Error(INVALID_ARXIV_INPUT_ERROR);
     }
 
     logger.info(this.channel, `Downloading arXiv source for ID: ${id}`);

--- a/src/latex/arxivProcessor.ts
+++ b/src/latex/arxivProcessor.ts
@@ -11,6 +11,7 @@ import * as tar from 'tar';
 // Local imports - log
 import { toErrorMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
+import { normaliseArxivIdentifier } from '@tools/latex/arxivShared';
 import { WorkspaceFS, AbsoluteFS } from '@utils/files';
 import { indentLatexFilesInDirectory } from '@housekeeping/indent';
 
@@ -58,13 +59,35 @@ export class ArxivSourceProcessor {
     return extractedIds.length > 0 && extractedIds.includes(id);
   }
 
-  public validateId(id: string): string | null {
-    if (!id) {
-      return 'arXiv ID is required';
+  /**
+   * Normalize input that may be a URL or plain ID into a valid arXiv ID.
+   * Accepts formats like:
+   * - Plain ID: 2404.12175, 2404.12175v2, cs/0501072
+   * - URLs: https://arxiv.org/abs/2404.12175, https://arxiv.org/pdf/2404.12175.pdf
+   * @returns The normalized arXiv ID, or null if extraction fails
+   */
+  public normalizeInput(input: string): string | null {
+    if (!input) {
+      return null;
     }
 
-    if (!this.isValidId(id)) {
-      return 'Invalid arXiv ID format. Please provide a valid arXiv ID like YYMM.NNNNN, YYMM.NNNNNvN, or category/YYMM.NNNNN';
+    const normalized = normaliseArxivIdentifier(input.trim());
+    // Verify the normalized result is a valid arXiv ID
+    return this.isValidId(normalized) ? normalized : null;
+  }
+
+  /**
+   * Validate input that may be a URL or plain arXiv ID.
+   * @returns Error message if invalid, null if valid
+   */
+  public validateId(input: string): string | null {
+    if (!input) {
+      return 'arXiv ID or URL is required';
+    }
+
+    const normalized = this.normalizeInput(input);
+    if (!normalized) {
+      return 'Invalid arXiv ID or URL. Please provide a valid arXiv ID (e.g., 2404.12175) or URL (e.g., https://arxiv.org/abs/2404.12175)';
     }
 
     return null;
@@ -159,16 +182,19 @@ export class ArxivSourceProcessor {
   }
 
   public async downloadSource(
-    id: string,
+    input: string,
     progressCallback?: (msg: string, increment?: number) => void,
     autoIndent = true,
   ): Promise<string> {
-    logger.info(this.channel, `Downloading arXiv source for ID: ${id}`);
-
-    const validationError = this.validateId(id);
-    if (validationError) {
-      throw new Error(validationError);
+    // Normalize input (URL or ID) to plain arXiv ID
+    const id = this.normalizeInput(input);
+    if (!id) {
+      throw new Error(
+        'Invalid arXiv ID or URL. Please provide a valid arXiv ID (e.g., 2404.12175) or URL (e.g., https://arxiv.org/abs/2404.12175)',
+      );
     }
+
+    logger.info(this.channel, `Downloading arXiv source for ID: ${id}`);
 
     const workspacePath = WorkspaceFS.getPath();
     if (!workspacePath) {


### PR DESCRIPTION
Accept full arXiv URLs (e.g., https://arxiv.org/abs/2404.12175) in addition to plain IDs. Uses the existing normaliseArxivIdentifier utility to extract IDs from URLs, making the download command more convenient to use.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables arXiv URL or ID input, normalizing to a valid ID before download.
> 
> - Accepts URLs (e.g., `https://arxiv.org/abs/2404.12175`) or plain IDs in the `Download arXiv Source` prompt; updated placeholder/prompt in `arXivCommands.ts`
> - Adds `normalizeInput` and expands `validateId` in `arxivProcessor.ts` using `normaliseArxivIdentifier`; introduces clearer `INVALID_ARXIV_INPUT_ERROR`
> - `downloadSource` now takes raw input, normalizes to an ID, and proceeds with existing download/extract/indent flow
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 71f6259901a8bba968f51056d5130c517d24c120. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->