### PR TITLE
claude/remove-workspace-path-SgzkV

### DIFF
--- a/src/agent/utils/userVars.ts
+++ b/src/agent/utils/userVars.ts
@@ -113,6 +113,7 @@ function getBasicVars(
     IS_GOOGLE_MODEL: providerFlags.isGoogle,
     WORKFLOW_AGENTS: workflowAgentsList,
     TOOL_USE_AGENTS: toolUseAgentsList,
+    CWD: WorkspaceFS.getPath() ?? '.',
   };
 }
 

--- a/src/tools/WorkflowTool.ts
+++ b/src/tools/WorkflowTool.ts
@@ -208,7 +208,7 @@ export class WorkflowAgentTool extends defineTool({
 Available agents:
 ${buildWorkflowAgentsList()}
 
-Example: agent=correct, inputFile=/workspace/paper.tex, instruction="This research paper proposes a new quantum error correction scheme. Please fix grammar errors, improve sentence clarity, and ensure consistent terminology throughout. Pay particular attention to the abstract and introduction where the key contributions are summarized."`,
+Example: agent=correct, inputFile=paper.tex, instruction="This research paper proposes a new quantum error correction scheme. Please fix grammar errors, improve sentence clarity, and ensure consistent terminology throughout. Pay particular attention to the abstract and introduction where the key contributions are summarized."`,
   schema: WorkflowAgentInputSchema,
 }) {
   protected async execute(input: WorkflowAgentInput): Promise<ToolResult> {
@@ -355,7 +355,7 @@ export class DelegateAgentTool extends defineTool({
 Available agents:
 ${buildToolUseAgentsList()}
 
-Example: agent=search, instruction="The paper at /workspace/paper.tex proposes a new attention mechanism called FlashAttention-3 that reduces memory complexity from quadratic to linear. Please search the web for three to five related papers on efficient transformer attention mechanisms, particularly those addressing memory efficiency or linear attention, that we should cite in the related work section."`,
+Example: agent=search, instruction="The paper at paper.tex proposes a new attention mechanism called FlashAttention-3 that reduces memory complexity from quadratic to linear. Please search the web for three to five related papers on efficient transformer attention mechanisms, particularly those addressing memory efficiency or linear attention, that we should cite in the related work section."`,
   schema: DelegateAgentInputSchema,
 }) {
   protected async execute(input: DelegateAgentInput): Promise<ToolResult> {

--- a/src/utils/prompt/PromptBuilder.ts
+++ b/src/utils/prompt/PromptBuilder.ts
@@ -19,6 +19,7 @@ Never mention tool names when speaking to the user.
 Do not call tools that are not provided or any multi_tool_use variants.
 Call tools sequentially and wait for the output before calling another.
 For math in responses, use $...$ or \\(...\\) for inline and $$...$$ or \\[...\\] for display math. Wrap LaTeX environments like align or gather inside $$...$$ (e.g., $$\\begin{align}...\\end{align}$$) so they render correctly.
+The current working directory is {{ CWD }}. Use relative paths when working with files.
 </tool_use_instructions>`;
 
 /** Instructions appended when memory tool is enabled */
@@ -196,6 +197,6 @@ export async function buildInitialToolUsePrompts(
 
   return {
     ...initial,
-    instructionSuffix: suffixParts.join('\n'),
+    instructionSuffix: await renderPrompt(suffixParts.join('\n'), userVars),
   };
 }


### PR DESCRIPTION
Remove /workspace/ prefix from examples since workflow agents use relative paths.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces current working directory awareness in prompts and aligns examples to relative paths.
> 
> - Adds `CWD` to user vars from `WorkspaceFS.getPath()` in `userVars.ts`
> - Updates tool-use instructions to reference `{{ CWD }}` and advise relative paths; `instructionSuffix` is now rendered via `renderPrompt` so variables interpolate
> - Revises examples in `WorkflowTool.ts` to remove `/workspace/` prefixes (use `paper.tex` instead)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 75224ce8c8a24e325c2c6409d1b656e0f25e3404. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->