### PR TITLE
Fix missing merge_multiple agent configuration

### DIFF
--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -1276,13 +1276,15 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
       await safeExecuteCommand('texra.execute', [
         {
           config: {
-            agent: 'merge_multiple',
+            agent: 'merge',
             model,
             inputFile: baseFiles[0],
             inputFiles: baseFiles.slice(1),
             editedFile: editedFiles[0],
             editedFiles: editedFiles.slice(1),
+            outputFiles: baseFiles,
             instruction: '',
+            useMultipleOutputs: true,
           },
         },
       ]);


### PR DESCRIPTION
The agent registry groups merge.yaml and merge_multiple.yaml under a single "merge" entry. When looking up "merge_multiple" directly, getAgent() fails because there's no entry with that key.

The correct approach is to pass agent: "merge" with useMultipleOutputs: true, which causes resolveAgent to use the entry's multiplePath field to load the merge_multiple.yaml definition.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes multi-file merge configuration in `ProgressViewMessageHandler.ts`.
> 
> - Use `agent: "merge"` (instead of `merge_multiple`) when executing multi-file merges
> - Set `useMultipleOutputs: true` and pass `outputFiles` to align with agent registry expectations
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 576446a17892cd353ce5b0d046b4a41b4f6ee636. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->