### PR TITLE
Fix invalid schema for runs function

### DIFF
--- a/src/tools/RunsTool.ts
+++ b/src/tools/RunsTool.ts
@@ -34,7 +34,8 @@ const RunsToolInputSchema = z.strictObject({
 
   /** Optional line range [start, end] for large outputs */
   view_range: z
-    .tuple([z.int().min(1), z.int().min(1)])
+    .array(z.int().min(1))
+    .length(2)
     .refine(([start, end]) => end >= start, {
       message: 'view_range[1] must be >= view_range[0]',
     })


### PR DESCRIPTION
The z.tuple() schema doesn't convert properly to JSON Schema for OpenAI models - it creates an anyOf structure without the required 'items' field. Using z.array().length(2) produces a valid JSON Schema with proper items definition that OpenAI/GPT-5 can accept.

Fixes HTTP 400: "Invalid schema for function 'runs': In context= ('properties', 'view_range', 'anyOf', '0'), array schema missing items."

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures the `runs` tool schema is compatible with JSON Schema/function calling.
> 
> - Changes `view_range` from `z.tuple([z.int().min(1), z.int().min(1)])` to `z.array(z.int().min(1)).length(2)` with the same validation, producing a valid `items` definition and avoiding HTTP 400s from invalid schemas
> - No changes to runtime behavior beyond schema serialization
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eebac0cd52e2fad21bdbb6dfc04203040f4bdf1a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->