### PR TITLE
fix: use convertToolSchema() for OpenAI tools to handle Zod transforms

### DIFF
--- a/src/agent/modelHandlers/toolConversion.ts
+++ b/src/agent/modelHandlers/toolConversion.ts
@@ -1,6 +1,5 @@
 // Third-party imports
 import { toJSONSchema } from 'zod';
-import { zodFunction } from 'openai/helpers/zod';
 
 // Type imports
 import type { ToolDefinition } from '@model';
@@ -13,10 +12,7 @@ import type {
   FunctionDeclaration,
   Schema,
 } from '@google/genai/dist/genai';
-import type {
-  ChatCompletionTool,
-  ChatCompletionFunctionTool,
-} from 'openai/resources/chat/completions';
+import type { ChatCompletionTool } from 'openai/resources/chat/completions';
 import type {
   FunctionTool,
   WebSearchTool,
@@ -54,38 +50,21 @@ const ANTHROPIC_TOOL_TYPE_MAP: Record<string, string> = {
 /**
  * Convert generic ToolDefinition objects to OpenAI ChatCompletionTool format.
  *
- * When a tool has a zodSchema, uses OpenAI's native zodFunction() helper which:
- * - Converts Zod schema to JSON Schema using SDK's optimized conversion
- * - Enables strict mode for better type safety
+ * Uses convertToolSchema() with unrepresentable: 'any' to handle Zod transforms
+ * that cannot be represented in JSON Schema (e.g., default value transforms).
  *
- * Note: zodFunction() may throw for invalid schemas - this is intentional fail-fast
- * behavior since invalid tool schemas are programming errors caught during development.
+ * Note: We intentionally don't use zodFunction() here because it doesn't support
+ * the unrepresentable option, causing failures with tool schemas that use .transform().
  */
 export function toOpenAITools(defs: ToolDefinition[]): ChatCompletionTool[] {
-  return defs.map((d) => {
-    // Use native SDK Zod conversion when schema is available
-    // zodFunction() returns AutoParseableTool which extends ChatCompletionFunctionTool
-    // with additional parsing metadata - structurally compatible with ChatCompletionTool
-    if (d.zodSchema) {
-      return zodFunction({
-        name: d.name,
-        description: d.description,
-        parameters: d.zodSchema,
-      }) as ChatCompletionTool;
-    }
-
-    // Fallback to manual conversion for legacy definitions
-    // Cast to ChatCompletionFunctionTool since ToolDefinition.parameters
-    // is a union type that includes provider-specific schemas
-    return {
-      type: 'function',
-      function: {
-        name: d.name,
-        description: d.description,
-        parameters: d.parameters,
-      },
-    } as ChatCompletionFunctionTool;
-  });
+  return defs.map((d) => ({
+    type: 'function',
+    function: {
+      name: d.name,
+      description: d.description,
+      parameters: convertToolSchema(d),
+    },
+  })) as ChatCompletionTool[];
 }
 
 /**


### PR DESCRIPTION
Replace zodFunction() with convertToolSchema() which uses the
unrepresentable: 'any' option. This fixes "Transforms cannot be
represented in JSON Schema" errors for DeepSeek and Kimi models
when tool schemas use .transform() for default values.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches OpenAI Chat Completions tool conversion to a shared JSON Schema path to avoid Zod transform failures.
> 
> - Introduces `convertToolSchema()` using `toJSONSchema(..., { unrepresentable: 'any' })` for robust conversion of `zod` schemas with `.transform()`
> - Updates `toOpenAITools()` to always build `function` tools with `parameters` from `convertToolSchema`, removing reliance on `openai/helpers/zod`
> - Reuses the same converter across Anthropic, OpenAI Responses, and Gemini paths for consistency; minor type import cleanup in `src/agent/modelHandlers/toolConversion.ts`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 30f77919b4c5b6de824387dae28e1421393010aa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->