### PR TITLE
Streamlines error-handling interactions in the progress view.

### DIFF
--- a/src/agent/modelHandlers/toolConversion.ts
+++ b/src/agent/modelHandlers/toolConversion.ts
@@ -1,5 +1,6 @@
 // Third-party imports
 import { toJSONSchema } from 'zod';
+import { zodFunction } from 'openai/helpers/zod';
 
 // Type imports
 import type { ToolDefinition } from '@model';
@@ -12,7 +13,10 @@ import type {
   FunctionDeclaration,
   Schema,
 } from '@google/genai/dist/genai';
-import type { ChatCompletionTool } from 'openai/resources/chat/completions';
+import type {
+  ChatCompletionTool,
+  ChatCompletionFunctionTool,
+} from 'openai/resources/chat/completions';
 import type {
   FunctionTool,
   WebSearchTool,
@@ -49,16 +53,39 @@ const ANTHROPIC_TOOL_TYPE_MAP: Record<string, string> = {
 
 /**
  * Convert generic ToolDefinition objects to OpenAI ChatCompletionTool format.
+ *
+ * When a tool has a zodSchema, uses OpenAI's native zodFunction() helper which:
+ * - Converts Zod schema to JSON Schema using SDK's optimized conversion
+ * - Enables strict mode for better type safety
+ *
+ * Note: zodFunction() may throw for invalid schemas - this is intentional fail-fast
+ * behavior since invalid tool schemas are programming errors caught during development.
  */
 export function toOpenAITools(defs: ToolDefinition[]): ChatCompletionTool[] {
-  return defs.map((d) => ({
-    type: 'function',
-    function: {
-      name: d.name,
-      description: d.description,
-      parameters: convertToolSchema(d),
-    },
-  })) as ChatCompletionTool[];
+  return defs.map((d) => {
+    // Use native SDK Zod conversion when schema is available
+    // zodFunction() returns AutoParseableTool which extends ChatCompletionFunctionTool
+    // with additional parsing metadata - structurally compatible with ChatCompletionTool
+    if (d.zodSchema) {
+      return zodFunction({
+        name: d.name,
+        description: d.description,
+        parameters: d.zodSchema,
+      }) as ChatCompletionTool;
+    }
+
+    // Fallback to manual conversion for legacy definitions
+    // Cast to ChatCompletionFunctionTool since ToolDefinition.parameters
+    // is a union type that includes provider-specific schemas
+    return {
+      type: 'function',
+      function: {
+        name: d.name,
+        description: d.description,
+        parameters: d.parameters,
+      },
+    } as ChatCompletionFunctionTool;
+  });
 }
 
 /**

--- a/src/agent/modelHandlers/toolConversion.ts
+++ b/src/agent/modelHandlers/toolConversion.ts
@@ -1,6 +1,5 @@
 // Third-party imports
 import { toJSONSchema } from 'zod';
-import { zodFunction } from 'openai/helpers/zod';
 
 // Type imports
 import type { ToolDefinition } from '@model';
@@ -13,10 +12,7 @@ import type {
   FunctionDeclaration,
   Schema,
 } from '@google/genai/dist/genai';
-import type {
-  ChatCompletionTool,
-  ChatCompletionFunctionTool,
-} from 'openai/resources/chat/completions';
+import type { ChatCompletionTool } from 'openai/resources/chat/completions';
 import type {
   FunctionTool,
   WebSearchTool,
@@ -53,39 +49,16 @@ const ANTHROPIC_TOOL_TYPE_MAP: Record<string, string> = {
 
 /**
  * Convert generic ToolDefinition objects to OpenAI ChatCompletionTool format.
- *
- * When a tool has a zodSchema, uses OpenAI's native zodFunction() helper which:
- * - Converts Zod schema to JSON Schema using SDK's optimized conversion
- * - Enables strict mode for better type safety
- *
- * Note: zodFunction() may throw for invalid schemas - this is intentional fail-fast
- * behavior since invalid tool schemas are programming errors caught during development.
  */
 export function toOpenAITools(defs: ToolDefinition[]): ChatCompletionTool[] {
-  return defs.map((d) => {
-    // Use native SDK Zod conversion when schema is available
-    // zodFunction() returns AutoParseableTool which extends ChatCompletionFunctionTool
-    // with additional parsing metadata - structurally compatible with ChatCompletionTool
-    if (d.zodSchema) {
-      return zodFunction({
-        name: d.name,
-        description: d.description,
-        parameters: d.zodSchema,
-      }) as ChatCompletionTool;
-    }
-
-    // Fallback to manual conversion for legacy definitions
-    // Cast to ChatCompletionFunctionTool since ToolDefinition.parameters
-    // is a union type that includes provider-specific schemas
-    return {
-      type: 'function',
-      function: {
-        name: d.name,
-        description: d.description,
-        parameters: d.parameters,
-      },
-    } as ChatCompletionFunctionTool;
-  });
+  return defs.map((d) => ({
+    type: 'function',
+    function: {
+      name: d.name,
+      description: d.description,
+      parameters: convertToolSchema(d),
+    },
+  })) as ChatCompletionTool[];
 }
 
 /**

--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -558,18 +558,11 @@
                   <pre class="retry-request__error-body"></pre>
                 </details>
               </div>
-              <div class="retry-request__feedback" hidden>
-                <vscode-textarea
-                  class="retry-request__feedback-input"
-                  placeholder="Add guidance for the retry (optional)"
-                  rows="2"
-                ></vscode-textarea>
-              </div>
               <vscode-toolbar-container class="retry-request__actions">
                 <vscode-toolbar-button
                   icon="refresh"
                   label="Retry"
-                  title="Click to add optional guidance, then retry"
+                  title="Retry"
                   data-action="retry"
                   >Retry</vscode-toolbar-button
                 >

--- a/src/progressView/modules/uiManagers/RetryRequests.js
+++ b/src/progressView/modules/uiManagers/RetryRequests.js
@@ -20,15 +20,6 @@ export class RetryRequests extends BaseUIRequestManager {
     });
   }
 
-  _getFeedbackConfig() {
-    return {
-      containerClass: 'retry-request',
-      feedbackClass: 'retry-request__feedback',
-      inputClass: 'retry-request__feedback-input',
-      activeClass: 'retry-request--feedback-active',
-    };
-  }
-
   /** @override */
   _createRequestElement(request) {
     const element = createFromTemplate('retryRequestTemplate');
@@ -164,17 +155,6 @@ export class RetryRequests extends BaseUIRequestManager {
     const action = button.dataset.action;
     if (!streamId || !action) {
       return;
-    }
-
-    // Handle retry with optional feedback (uses shared base class logic)
-    if (action === 'retry') {
-      const handled = this._handleRejectWithFeedback(
-        button,
-        streamId,
-        COMMANDS.RETRY_STREAM_REQUEST,
-        'stream',
-      );
-      if (handled) return;
     }
 
     const actionCommands = {

--- a/src/progressView/styles/retry-requests.css
+++ b/src/progressView/styles/retry-requests.css
@@ -76,16 +76,3 @@
   border-radius: var(--border-radius-small) 0 0 var(--border-radius-small);
 }
 
-.retry-request__feedback {
-  margin-top: var(--spacing-small);
-}
-
-.retry-request__feedback-input {
-  width: 100%;
-}
-
-.retry-request--feedback-active
-  .retry-request__actions
-  vscode-toolbar-button[data-action='retry']::part(control) {
-  color: var(--vscode-inputValidation-infoBorder);
-}

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -696,18 +696,7 @@ export async function handleProgressViewToolEditApprovalAction(
     }
 
     case 'reject': {
-      let userMessage = payload.feedback?.trim();
-      if (!userMessage) {
-        // Fallback to VS Code input box if no feedback provided via progress view
-        const feedback = await vscode.window.showInputBox({
-          prompt: 'Optionally share why the change was rejected',
-          placeHolder: 'Add guidance for the assistant (press Enter to skip)',
-        });
-        if (feedback === undefined) {
-          return;
-        }
-        userMessage = feedback.trim();
-      }
+      const userMessage = payload.feedback?.trim();
       entry.settle({
         accepted: false,
         userMessage: userMessage || undefined,


### PR DESCRIPTION

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Streamlines error-handling interactions in the progress view.
> 
> - Removes optional feedback input from `retryRequestTemplate` and updates Retry button title to `"Retry"`
> - Simplifies `RetryRequests` manager: drops feedback-handling logic; actions now directly post `retry` or `dismiss`
> - Cleans up `retry-requests.css` by deleting feedback-related styles
> - In `toolEditApproval.ts`, `reject` no longer opens an input box; only uses provided `payload.feedback` (if any)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4ac3031e075b9e9ec05a04bd6ac257662d698f65. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->