### PR TITLE
fix: hide KaTeX MathML to prevent duplicate text rendering

### DIFF
--- a/src/progressView/styles/markdown.css
+++ b/src/progressView/styles/markdown.css
@@ -2,6 +2,16 @@
  * Markdown content styles for ProgressView
  */
 
+/**
+ * KaTeX CDN fallback: Hide MathML container when external katex.min.css
+ * fails to load (common in VS Code webviews with network/proxy issues).
+ * MathML is kept for accessibility and copy-tex LaTeX extraction.
+ * See: https://github.com/KaTeX/KaTeX/issues/645
+ */
+.markdown-content .katex-mathml {
+  display: none;
+}
+
 .markdown-content {
   overflow: visible;
 }


### PR DESCRIPTION
KaTeX renders both .katex-mathml (for copy-paste) and .katex-html
(visual rendering). Without hiding the MathML container, both appear
visible, causing math expressions to display twice.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents duplicate math text in ProgressView when KaTeX’s external CSS isn’t available (e.g., VS Code webviews with network/proxy constraints).
> 
> - Add CSS rule in `src/progressView/styles/markdown.css` to set `display: none` on `.markdown-content .katex-mathml` while keeping MathML for accessibility/copy-tex
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 911b25e223d19231ff64ec0aefe81349c390ab5d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->