### PR TITLE
fix: include 'none' option in progress view followup dropdowns

### DIFF
--- a/src/progressView/modules/uiManagers/FollowupSectionManager.js
+++ b/src/progressView/modules/uiManagers/FollowupSectionManager.js
@@ -192,17 +192,23 @@ export class FollowupSectionManager {
       const currentValue = modelSelect.value;
       // Use current stream's model as default, or defaultMergeModel for merge mode
       // Fall back to first available model if no default is set
-      const defaultModel =
+      const preferredModel =
         this._getMode() === 'merge'
           ? defaultMergeModel || models[0]
           : this._currentStreamData?.model || currentValue || models[0];
+      const hasValidSelection =
+        preferredModel && models.includes(preferredModel);
 
-      modelSelect.innerHTML = models
+      // Build options: none option first, then models
+      const noneOption = `<vscode-option value=""${!hasValidSelection ? ' selected' : ''}>Select model</vscode-option>`;
+      const modelOptions = models
         .map(
           (model) =>
-            `<vscode-option value="${model}"${model === defaultModel ? ' selected' : ''}>${model}</vscode-option>`,
+            `<vscode-option value="${model}"${model === preferredModel ? ' selected' : ''}>${model}</vscode-option>`,
         )
         .join('');
+
+      modelSelect.innerHTML = noneOption + modelOptions;
     }
 
     this._defaultMergeModel = defaultMergeModel;
@@ -223,22 +229,26 @@ export class FollowupSectionManager {
 
     // Clear dropdown if no agents available for this mode
     if (!agents || agents.length === 0) {
-      agentSelect.innerHTML = '';
+      agentSelect.innerHTML =
+        '<vscode-option value="">Select agent</vscode-option>';
       return;
     }
 
-    // Preserve current selection if valid in the new list
+    // Preserve current selection only if it exists in the new list
     const currentValue = agentSelect.value;
-    const isCurrentValid = agents.includes(currentValue);
+    const hasValidSelection = currentValue && agents.includes(currentValue);
 
-    agentSelect.innerHTML = agents
+    // Build options: none option first, then agents
+    const noneOption = `<vscode-option value=""${!hasValidSelection ? ' selected' : ''}>Select agent</vscode-option>`;
+    const agentOptions = agents
       .map((agent) => {
-        // Extract display name from source:name format
         const displayName = agent.includes(':') ? agent.split(':')[1] : agent;
-        const isSelected = isCurrentValid && agent === currentValue;
+        const isSelected = agent === currentValue;
         return `<vscode-option value="${agent}"${isSelected ? ' selected' : ''}>${displayName}</vscode-option>`;
       })
       .join('');
+
+    agentSelect.innerHTML = noneOption + agentOptions;
   }
 
   /**


### PR DESCRIPTION
When restoring agent config from progress view, undefined or null values
should display the "Select agent" / "Select model" placeholder options
instead of leaving the dropdown empty.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces explicit placeholder options and tighter selection handling in followup dropdowns.
> 
> - Prepends `"Select model"` / `"Select agent"` options; shows placeholder when no valid selection or when agent list is empty
> - Preserves current selection only if it exists in the available list; simplifies selected-state logic
> - Renames `defaultModel` to `preferredModel` and builds model options from this computed default based on mode/current stream
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7b7b5e992bdf14a3c3a56ea12db99356ac3acf06. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->