### PR TITLE
Fix grep tool usage for PDF files

### DIFF
--- a/src/agent/types/ResultTypes.ts
+++ b/src/agent/types/ResultTypes.ts
@@ -13,6 +13,8 @@ export const ExecResultSchema = z.strictObject({
   stderr: z.string().nullable(),
   /** True if the command timed out */
   timedOut: z.boolean().optional(),
+  /** Exit code from the command (undefined if not available) */
+  exitCode: z.number().optional(),
 });
 
 export type ExecResult = z.infer<typeof ExecResultSchema>;

--- a/src/tools/grep.ts
+++ b/src/tools/grep.ts
@@ -106,9 +106,11 @@ export class GrepTool extends defineTool({
     });
 
     // ripgrep exit codes: 0 = matches found, 1 = no matches, 2+ = error
-    // Only treat as error if stderr is present (real errors have stderr)
-    if (!result.success && result.stderr) {
-      throw new ToolError(`ripgrep error: ${result.stderr}`);
+    const exitCode = result.exitCode ?? (result.success ? 0 : 1);
+    if (exitCode >= 2) {
+      throw new ToolError(
+        `ripgrep error: ${result.stderr || `exit code ${exitCode}`}`,
+      );
     }
 
     const limitedOutput = applyHeadLimit(

--- a/src/tools/grep.ts
+++ b/src/tools/grep.ts
@@ -105,10 +105,10 @@ export class GrepTool extends defineTool({
       truncate: false,
     });
 
-    if (!result.success) {
-      throw new ToolError(
-        `ripgrep error: ${result.stderr || 'No error output available'}`,
-      );
+    // ripgrep exit codes: 0 = matches found, 1 = no matches, 2+ = error
+    // Only treat as error if stderr is present (real errors have stderr)
+    if (!result.success && result.stderr) {
+      throw new ToolError(`ripgrep error: ${result.stderr}`);
     }
 
     const limitedOutput = applyHeadLimit(

--- a/src/utils/system/execUtils.ts
+++ b/src/utils/system/execUtils.ts
@@ -130,6 +130,7 @@ export async function executeCommand(
       stdout: normalizedStdout,
       stderr: normalizedStderr,
       timedOut,
+      exitCode,
     };
   } catch (err) {
     logger.error(

--- a/src/utils/system/execUtils.ts
+++ b/src/utils/system/execUtils.ts
@@ -153,6 +153,7 @@ export async function executeCommand(
       stdout: null,
       stderr: normalizedError,
       timedOut: false, // Real timeouts are handled in the main flow via result.timedOut
+      exitCode: 127, // Convention for command not found / execution failure
     };
   }
 }


### PR DESCRIPTION
ripgrep uses exit code 1 for 'no matches found' (not an error) and exit code 2+ for actual errors (with stderr). Previously, any non-zero exit was treated as error, causing unhelpful "No error output available" messages when files didn't exist or globs matched nothing.

Now only throws ToolError when stderr is present (real errors).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts command execution types/utilities and `grep` tool to properly handle ripgrep exit codes and expose process exit codes.
> 
> - Adds `exitCode` to `ExecResult` (`src/agent/types/ResultTypes.ts`) and returns it from `executeCommand`, using `127` for execution failures
> - Updates `grep` to interpret ripgrep exit codes (0=match, 1=no matches, >=2=error) and only throw `ToolError` for real errors, improving error message to include `stderr` or `exit code`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f5b268a7a9c00e093ffbb864ab818576c50d4b7e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->