### PR TITLE
Remove duplicate sentence in document

### DIFF
--- a/src/progressView/modules/formatters/markdownRenderer.js
+++ b/src/progressView/modules/formatters/markdownRenderer.js
@@ -87,10 +87,14 @@ export const processMarkdownContent = (content, renderer) => {
   // Note: Pandoc reference formats are normalized to LaTeX at the source (xmlUtils.ts)
   const protectedContent = protectLatexReferences(content);
 
+  // Add line break before bold text starting a new sentence (capital letter after period)
+  // This fixes OpenAI reasoning summary output which omits line breaks before bold headers
+  const formattedContent = protectedContent.replace(/\.(\*\*[A-Z])/g, '.\n$1');
+
   const md = renderer || getMarkdownRenderer();
 
   // Process content as markdown
-  let parsedMarkdown = md.render(protectedContent);
+  let parsedMarkdown = md.render(formattedContent);
 
   // Post-process to restore and style LaTeX references
   return restoreLatexReferences(parsedMarkdown);


### PR DESCRIPTION
Replace ".**[A-Z]" with ".\n**[A-Z]" in streaming content to ensure proper markdown rendering with line breaks between sentences. Only triggers when bold text starts with a capital letter to avoid false positives in code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves markdown rendering by correcting missing line breaks before bold text that starts a new sentence.
> 
> - Preprocesses content in `processMarkdownContent` to replace `.**[A-Z]` with `.\n**[A-Z]`
> - Renders `formattedContent` (instead of `protectedContent`) and preserves existing LaTeX reference protection/restoration in `markdownRenderer.js`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4dce76f83ff8f6ce27a756c84806f11aca250df8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->