### PR TITLE
feat: add syntax highlighting and inline diffs for progress view

### DIFF
--- a/src/commands/files/openFileCommands.ts
+++ b/src/commands/files/openFileCommands.ts
@@ -15,9 +15,24 @@ import { WorkspaceFS } from '@utils/files';
 
 const CHANNEL = 'openFileCommands';
 
-export async function openFile(file: string): Promise<void> {
-  const uri = vscode.Uri.file(WorkspaceFS.toAbsolute(file));
-  await vscode.commands.executeCommand('vscode.open', uri);
+export async function openFile(file: string, line?: number): Promise<void> {
+  const absolutePath = WorkspaceFS.toAbsolute(file);
+  const uri = vscode.Uri.file(absolutePath);
+
+  if (line !== undefined && line > 0) {
+    // Open file and navigate to specific line
+    const doc = await vscode.workspace.openTextDocument(uri);
+    const editor = await vscode.window.showTextDocument(doc, { preview: true });
+    // Line numbers are 1-based from user, VS Code Position is 0-based
+    const pos = new vscode.Position(line - 1, 0);
+    editor.revealRange(
+      new vscode.Range(pos, pos),
+      vscode.TextEditorRevealType.InCenter,
+    );
+    editor.selection = new vscode.Selection(pos, pos);
+  } else {
+    await vscode.commands.executeCommand('vscode.open', uri);
+  }
 }
 
 export async function openLabel(label: string): Promise<void> {

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -76,6 +76,7 @@ import type { ProgressViewProvider } from './ProgressViewProvider';
 
 interface FileCommandMessage {
   file: string;
+  line?: number;
 }
 
 interface BaseFileCommandMessage extends FileCommandMessage {
@@ -653,7 +654,11 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
   }
 
   private async handleOpenFile(message: FileCommandMessage): Promise<void> {
-    await vscode.commands.executeCommand('texra.openFile', message.file);
+    await vscode.commands.executeCommand(
+      'texra.openFile',
+      message.file,
+      message.line,
+    );
   }
 
   private async handleOpenFileCompile(

--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -77,8 +77,7 @@
           "he": "https://esm.sh/he@1.2.0",
           "highlight.js": "https://esm.sh/highlight.js@11.11.1",
           "markdown-it-highlightjs": "https://esm.sh/markdown-it-highlightjs@4.2.0",
-          "yaml": "https://esm.sh/yaml@2.8.1",
-          "diff-match-patch": "https://esm.sh/diff-match-patch@1.0.5"
+          "yaml": "https://esm.sh/yaml@2.8.1"
         }
       }
     </script>

--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -77,7 +77,8 @@
           "he": "https://esm.sh/he@1.2.0",
           "highlight.js": "https://esm.sh/highlight.js@11.11.1",
           "markdown-it-highlightjs": "https://esm.sh/markdown-it-highlightjs@4.2.0",
-          "yaml": "https://esm.sh/yaml@2.8.1"
+          "yaml": "https://esm.sh/yaml@2.8.1",
+          "diff-match-patch": "https://esm.sh/diff-match-patch@1.0.5"
         }
       }
     </script>

--- a/src/progressView/modules/formatters/constants.js
+++ b/src/progressView/modules/formatters/constants.js
@@ -37,6 +37,26 @@ export const TIME_FORMAT_OPTIONS = {
   hour12: false,
 };
 
+// ============================================================================
+// Tool Categories for Specialized Formatting
+// ============================================================================
+
+/**
+ * Tools that show old/new diff display for their input.
+ * Output is human-readable status, NOT code (don't syntax highlight output).
+ */
+export const TOOLS_WITH_DIFF_INPUT = new Set(['edit_file']);
+
+/**
+ * Tools that read files and should show file link instead of content.
+ */
+export const TOOLS_WITH_FILE_LINK = new Set(['read_file']);
+
+/**
+ * Tools whose input AND output are code that benefits from syntax highlighting.
+ */
+export const TOOLS_WITH_CODE_OUTPUT = new Set(['bash', 'execute', 'run']);
+
 /**
  * Tool icon mapping for different tool types.
  * Maps tool names to VS Code codicon classes.

--- a/src/progressView/modules/formatters/htmlBuilders.js
+++ b/src/progressView/modules/formatters/htmlBuilders.js
@@ -3,12 +3,19 @@
  * These functions create HTML fragments from normalized data.
  */
 
+import hljs from 'highlight.js';
+import { diff_match_patch } from 'diff-match-patch';
 import { encodeHtml } from '@common/htmlEncoding.js';
 import {
   CHEVRON_RIGHT_CLASS,
   CHEVRON_DOWN_CLASS,
 } from '@common/iconConstants.js';
 import { TOOL_ICON_MAP } from './constants.js';
+
+// diff-match-patch constants
+const DIFF_DELETE = -1;
+const DIFF_INSERT = 1;
+const DIFF_EQUAL = 0;
 
 /**
  * Build a tool-use section HTML block
@@ -192,4 +199,201 @@ export function buildDetailItem(iconClass, content, options = {}) {
 export function getToolIconClass(toolName, isError = false) {
   if (isError) return 'codicon-error';
   return TOOL_ICON_MAP[toolName] || 'codicon-wrench';
+}
+
+// ============================================================================
+// Syntax Highlighting
+// ============================================================================
+
+/**
+ * Wrap code in a pre element with syntax highlighting using highlight.js
+ * @param {string} text - Code text to highlight
+ * @param {string} [language] - Optional language hint (e.g., 'bash', 'json')
+ * @param {string} [className] - Optional additional CSS class
+ * @returns {string} HTML string with syntax highlighting
+ */
+export function wrapInHighlightedPre(text, language = '', className = '') {
+  const classes = ['hljs', className].filter(Boolean).join(' ');
+  const classAttr = classes ? ` class="${classes}"` : '';
+
+  try {
+    let result;
+    if (language && hljs.getLanguage(language)) {
+      result = hljs.highlight(text, { language, ignoreIllegals: true });
+    } else {
+      result = hljs.highlightAuto(text);
+    }
+    return `<pre${classAttr}><code>${result.value}</code></pre>`;
+  } catch {
+    // Fallback to plain text if highlighting fails
+    return `<pre${classAttr}><code>${encodeHtml(text)}</code></pre>`;
+  }
+}
+
+/**
+ * Detect language from file path extension
+ * @param {string} filePath - File path to check
+ * @returns {string} Language identifier for highlight.js
+ */
+export function detectLanguageFromPath(filePath) {
+  if (!filePath) return '';
+
+  const ext = filePath.split('.').pop()?.toLowerCase();
+  const langMap = {
+    js: 'javascript',
+    jsx: 'javascript',
+    ts: 'typescript',
+    tsx: 'typescript',
+    py: 'python',
+    rb: 'ruby',
+    sh: 'bash',
+    bash: 'bash',
+    zsh: 'bash',
+    tex: 'latex',
+    latex: 'latex',
+    json: 'json',
+    yaml: 'yaml',
+    yml: 'yaml',
+    xml: 'xml',
+    html: 'html',
+    css: 'css',
+    md: 'markdown',
+    rs: 'rust',
+    go: 'go',
+    java: 'java',
+    c: 'c',
+    cpp: 'cpp',
+    h: 'c',
+    hpp: 'cpp',
+    sql: 'sql',
+  };
+
+  return langMap[ext] || '';
+}
+
+// ============================================================================
+// File Links with Line Numbers
+// ============================================================================
+
+/**
+ * Build a file link with optional line number for VS Code navigation
+ * @param {string} filePath - Absolute file path
+ * @param {object} [options] - Options
+ * @param {number} [options.startLine] - Starting line number (1-based)
+ * @param {number} [options.endLine] - Ending line number (1-based)
+ * @param {number} [options.totalLines] - Total lines in file
+ * @returns {string} HTML string for the file link
+ */
+export function buildFileLinkWithLines(filePath, options = {}) {
+  if (!filePath) return '';
+
+  const { startLine, endLine, totalLines } = options;
+  const fileName = filePath.split('/').pop() || filePath;
+
+  // Build line info string
+  let lineInfo = '';
+  if (startLine && endLine && startLine !== endLine) {
+    lineInfo = `:${startLine}-${endLine}`;
+  } else if (startLine) {
+    lineInfo = `:${startLine}`;
+  }
+
+  // Build display text
+  let displayText = fileName + lineInfo;
+  if (totalLines !== undefined) {
+    displayText += ` (${totalLines} lines)`;
+  }
+
+  // data-file-line attribute enables opening at specific line
+  const lineAttr = startLine ? ` data-file-line="${startLine}"` : '';
+
+  return `<span class="file-link clickable-link" data-file="${encodeHtml(filePath)}"${lineAttr}><i class="codicon codicon-file"></i> ${encodeHtml(displayText)}</span>`;
+}
+
+// ============================================================================
+// Inline Character Diff Rendering
+// ============================================================================
+
+/**
+ * Create inline character-level diff HTML between old and new strings
+ * Uses diff-match-patch for semantic diff computation
+ * @param {string} oldText - Original text
+ * @param {string} newText - New text
+ * @returns {string} HTML with inline diff highlighting
+ */
+export function renderInlineDiff(oldText, newText) {
+  if (!oldText && !newText) return '';
+  if (!oldText) {
+    return `<pre class="inline-diff"><span class="diff-add">${encodeHtml(newText)}</span></pre>`;
+  }
+  if (!newText) {
+    return `<pre class="inline-diff"><span class="diff-remove">${encodeHtml(oldText)}</span></pre>`;
+  }
+
+  try {
+    const dmp = new diff_match_patch();
+    const diffs = dmp.diff_main(oldText, newText);
+    dmp.diff_cleanupSemantic(diffs);
+
+    const html = diffs
+      .map(([op, text]) => {
+        const encoded = encodeHtml(text);
+        switch (op) {
+          case DIFF_DELETE:
+            return `<del class="diff-remove">${encoded}</del>`;
+          case DIFF_INSERT:
+            return `<ins class="diff-add">${encoded}</ins>`;
+          default:
+            return encoded;
+        }
+      })
+      .join('');
+
+    return `<pre class="inline-diff">${html}</pre>`;
+  } catch {
+    // Fallback: show old and new separately
+    return `<pre class="inline-diff"><del class="diff-remove">${encodeHtml(oldText)}</del><ins class="diff-add">${encodeHtml(newText)}</ins></pre>`;
+  }
+}
+
+/**
+ * Build edit diff section showing old_string → new_string transformation
+ * @param {string} oldString - Original text being replaced
+ * @param {string} newString - Replacement text
+ * @param {string} [filePath] - Optional file path for syntax hint
+ * @returns {string} HTML for the diff display
+ */
+export function buildEditDiffSection(oldString, newString, filePath = '') {
+  const language = detectLanguageFromPath(filePath);
+
+  // For very short strings, show simple inline diff
+  const isShort = oldString.length < 200 && newString.length < 200;
+  const lineCountOld = oldString.split('\n').length;
+  const lineCountNew = newString.split('\n').length;
+  const isMultiLine = lineCountOld > 3 || lineCountNew > 3;
+
+  if (isShort && !isMultiLine) {
+    return renderInlineDiff(oldString, newString);
+  }
+
+  // For longer content, use stacked blocks with syntax highlighting
+  const oldHtml = language
+    ? wrapInHighlightedPre(oldString, language, 'diff-block diff-block-old')
+    : `<pre class="diff-block diff-block-old">${encodeHtml(oldString)}</pre>`;
+
+  const newHtml = language
+    ? wrapInHighlightedPre(newString, language, 'diff-block diff-block-new')
+    : `<pre class="diff-block diff-block-new">${encodeHtml(newString)}</pre>`;
+
+  return `
+    <div class="edit-diff-container">
+      <div class="edit-diff-old">
+        <span class="edit-diff-label diff-remove"><i class="codicon codicon-remove"></i> Old</span>
+        ${oldHtml}
+      </div>
+      <div class="edit-diff-new">
+        <span class="edit-diff-label diff-add"><i class="codicon codicon-add"></i> New</span>
+        ${newHtml}
+      </div>
+    </div>`;
 }

--- a/src/progressView/modules/formatters/htmlBuilders.js
+++ b/src/progressView/modules/formatters/htmlBuilders.js
@@ -4,18 +4,12 @@
  */
 
 import hljs from 'highlight.js';
-import { diff_match_patch } from 'diff-match-patch';
 import { encodeHtml } from '@common/htmlEncoding.js';
 import {
   CHEVRON_RIGHT_CLASS,
   CHEVRON_DOWN_CLASS,
 } from '@common/iconConstants.js';
 import { TOOL_ICON_MAP } from './constants.js';
-
-// diff-match-patch constants
-const DIFF_DELETE = -1;
-const DIFF_INSERT = 1;
-const DIFF_EQUAL = 0;
 
 /**
  * Build a tool-use section HTML block
@@ -311,53 +305,13 @@ export function buildFileLinkWithLines(filePath, options = {}) {
 }
 
 // ============================================================================
-// Inline Character Diff Rendering
+// Edit Diff Display (Stacked Blocks)
 // ============================================================================
 
 /**
- * Create inline character-level diff HTML between old and new strings
- * Uses diff-match-patch for semantic diff computation
- * @param {string} oldText - Original text
- * @param {string} newText - New text
- * @returns {string} HTML with inline diff highlighting
- */
-export function renderInlineDiff(oldText, newText) {
-  if (!oldText && !newText) return '';
-  if (!oldText) {
-    return `<pre class="inline-diff"><span class="diff-add">${encodeHtml(newText)}</span></pre>`;
-  }
-  if (!newText) {
-    return `<pre class="inline-diff"><span class="diff-remove">${encodeHtml(oldText)}</span></pre>`;
-  }
-
-  try {
-    const dmp = new diff_match_patch();
-    const diffs = dmp.diff_main(oldText, newText);
-    dmp.diff_cleanupSemantic(diffs);
-
-    const html = diffs
-      .map(([op, text]) => {
-        const encoded = encodeHtml(text);
-        switch (op) {
-          case DIFF_DELETE:
-            return `<del class="diff-remove">${encoded}</del>`;
-          case DIFF_INSERT:
-            return `<ins class="diff-add">${encoded}</ins>`;
-          default:
-            return encoded;
-        }
-      })
-      .join('');
-
-    return `<pre class="inline-diff">${html}</pre>`;
-  } catch {
-    // Fallback: show old and new separately
-    return `<pre class="inline-diff"><del class="diff-remove">${encodeHtml(oldText)}</del><ins class="diff-add">${encodeHtml(newText)}</ins></pre>`;
-  }
-}
-
-/**
- * Build edit diff section showing old_string → new_string transformation
+ * Build edit diff section showing old_string → new_string as stacked blocks.
+ * Uses simple stacked display with syntax highlighting.
+ * TODO: Consider integrating diff2html for richer diff rendering.
  * @param {string} oldString - Original text being replaced
  * @param {string} newString - Replacement text
  * @param {string} [filePath] - Optional file path for syntax hint
@@ -366,17 +320,7 @@ export function renderInlineDiff(oldText, newText) {
 export function buildEditDiffSection(oldString, newString, filePath = '') {
   const language = detectLanguageFromPath(filePath);
 
-  // For very short strings, show simple inline diff
-  const isShort = oldString.length < 200 && newString.length < 200;
-  const lineCountOld = oldString.split('\n').length;
-  const lineCountNew = newString.split('\n').length;
-  const isMultiLine = lineCountOld > 3 || lineCountNew > 3;
-
-  if (isShort && !isMultiLine) {
-    return renderInlineDiff(oldString, newString);
-  }
-
-  // For longer content, use stacked blocks with syntax highlighting
+  // Use stacked blocks with syntax highlighting
   const oldHtml = language
     ? wrapInHighlightedPre(oldString, language, 'diff-block diff-block-old')
     : `<pre class="diff-block diff-block-old">${encodeHtml(oldString)}</pre>`;

--- a/src/progressView/modules/formatters/htmlBuilders.js
+++ b/src/progressView/modules/formatters/htmlBuilders.js
@@ -224,47 +224,6 @@ export function wrapInHighlightedPre(text, language = '', className = '') {
   }
 }
 
-/**
- * Detect language from file path extension
- * @param {string} filePath - File path to check
- * @returns {string} Language identifier for highlight.js
- */
-export function detectLanguageFromPath(filePath) {
-  if (!filePath) return '';
-
-  const ext = filePath.split('.').pop()?.toLowerCase();
-  const langMap = {
-    js: 'javascript',
-    jsx: 'javascript',
-    ts: 'typescript',
-    tsx: 'typescript',
-    py: 'python',
-    rb: 'ruby',
-    sh: 'bash',
-    bash: 'bash',
-    zsh: 'bash',
-    tex: 'latex',
-    latex: 'latex',
-    json: 'json',
-    yaml: 'yaml',
-    yml: 'yaml',
-    xml: 'xml',
-    html: 'html',
-    css: 'css',
-    md: 'markdown',
-    rs: 'rust',
-    go: 'go',
-    java: 'java',
-    c: 'c',
-    cpp: 'cpp',
-    h: 'c',
-    hpp: 'cpp',
-    sql: 'sql',
-  };
-
-  return langMap[ext] || '';
-}
-
 // ============================================================================
 // File Links with Line Numbers
 // ============================================================================
@@ -275,16 +234,15 @@ export function detectLanguageFromPath(filePath) {
  * @param {object} [options] - Options
  * @param {number} [options.startLine] - Starting line number (1-based)
  * @param {number} [options.endLine] - Ending line number (1-based)
- * @param {number} [options.totalLines] - Total lines in file
  * @returns {string} HTML string for the file link
  */
 export function buildFileLinkWithLines(filePath, options = {}) {
   if (!filePath) return '';
 
-  const { startLine, endLine, totalLines } = options;
+  const { startLine, endLine } = options;
   const fileName = filePath.split('/').pop() || filePath;
 
-  // Build line info string
+  // Build line info string (only if range explicitly provided)
   let lineInfo = '';
   if (startLine && endLine && startLine !== endLine) {
     lineInfo = `:${startLine}-${endLine}`;
@@ -292,13 +250,7 @@ export function buildFileLinkWithLines(filePath, options = {}) {
     lineInfo = `:${startLine}`;
   }
 
-  // Build display text
-  let displayText = fileName + lineInfo;
-  if (totalLines !== undefined) {
-    displayText += ` (${totalLines} lines)`;
-  }
-
-  // data-file-line attribute enables opening at specific line
+  const displayText = fileName + lineInfo;
   const lineAttr = startLine ? ` data-file-line="${startLine}"` : '';
 
   return `<span class="file-link clickable-link" data-file="${encodeHtml(filePath)}"${lineAttr}><i class="codicon codicon-file"></i> ${encodeHtml(displayText)}</span>`;
@@ -310,34 +262,15 @@ export function buildFileLinkWithLines(filePath, options = {}) {
 
 /**
  * Build edit diff section showing old_string → new_string as stacked blocks.
- * Uses simple stacked display with syntax highlighting.
- * TODO: Consider integrating diff2html for richer diff rendering.
+ * Red = old, Green = new. Colors communicate; labels don't.
  * @param {string} oldString - Original text being replaced
  * @param {string} newString - Replacement text
- * @param {string} [filePath] - Optional file path for syntax hint
  * @returns {string} HTML for the diff display
  */
-export function buildEditDiffSection(oldString, newString, filePath = '') {
-  const language = detectLanguageFromPath(filePath);
+export function buildEditDiffSection(oldString, newString) {
+  // Let highlight.js auto-detect language
+  const oldHtml = wrapInHighlightedPre(oldString, '', 'diff-block diff-block-old');
+  const newHtml = wrapInHighlightedPre(newString, '', 'diff-block diff-block-new');
 
-  // Use stacked blocks with syntax highlighting
-  const oldHtml = language
-    ? wrapInHighlightedPre(oldString, language, 'diff-block diff-block-old')
-    : `<pre class="diff-block diff-block-old">${encodeHtml(oldString)}</pre>`;
-
-  const newHtml = language
-    ? wrapInHighlightedPre(newString, language, 'diff-block diff-block-new')
-    : `<pre class="diff-block diff-block-new">${encodeHtml(newString)}</pre>`;
-
-  return `
-    <div class="edit-diff-container">
-      <div class="edit-diff-old">
-        <span class="edit-diff-label diff-remove"><i class="codicon codicon-remove"></i> Old</span>
-        ${oldHtml}
-      </div>
-      <div class="edit-diff-new">
-        <span class="edit-diff-label diff-add"><i class="codicon codicon-add"></i> New</span>
-        ${newHtml}
-      </div>
-    </div>`;
+  return `<div class="edit-diff-container">${oldHtml}${newHtml}</div>`;
 }

--- a/src/progressView/modules/formatters/logFormatters/toolFormatters.js
+++ b/src/progressView/modules/formatters/logFormatters/toolFormatters.js
@@ -13,14 +13,13 @@ import {
   buildFileLinkWithLines,
   buildEditDiffSection,
   wrapInHighlightedPre,
-  detectLanguageFromPath,
 } from '../htmlBuilders.js';
 import { normalizeToolUseLog, stringifyForDisplay } from '../normalizers.js';
-
-// Tools that benefit from specialized formatting
-const EDIT_TOOLS = new Set(['edit_file', 'write_file']);
-const READ_TOOLS = new Set(['read_file']);
-const CODE_OUTPUT_TOOLS = new Set(['bash', 'execute', 'run']);
+import {
+  TOOLS_WITH_DIFF_INPUT,
+  TOOLS_WITH_FILE_LINK,
+  TOOLS_WITH_CODE_OUTPUT,
+} from '../constants.js';
 
 // Web search provider display names
 const PROVIDER_LABELS = {
@@ -144,8 +143,8 @@ export function formatToolUse(normalizedPayload, logId, groupId, timestamp) {
   const filePath =
     typeof input === 'object' && input !== null ? input.path : '';
 
-  // Handle edit tools with inline diff display
-  if (EDIT_TOOLS.has(toolName) && input?.old_string && input?.new_string) {
+  // Handle edit tools with diff display for input
+  if (TOOLS_WITH_DIFF_INPUT.has(toolName) && input?.old_string && input?.new_string) {
     // Show file path as link
     if (filePath) {
       sections.push(
@@ -155,7 +154,7 @@ export function formatToolUse(normalizedPayload, logId, groupId, timestamp) {
         ),
       );
     }
-    // Show inline diff for old_string → new_string
+    // Show diff for old_string → new_string
     sections.push(
       buildToolUseSection(
         'Changes:',
@@ -164,7 +163,7 @@ export function formatToolUse(normalizedPayload, logId, groupId, timestamp) {
     );
   }
   // Handle read tools with file link instead of full content
-  else if (READ_TOOLS.has(toolName) && filePath) {
+  else if (TOOLS_WITH_FILE_LINK.has(toolName) && filePath) {
     // Only use line info if explicitly provided in range
     // Don't default to line 1 - this breaks binary files (PDFs, images)
     const range = input?.range;
@@ -193,7 +192,7 @@ export function formatToolUse(normalizedPayload, logId, groupId, timestamp) {
     const inputValue = stringifyForDisplay(input);
     if (inputValue) {
       // Use syntax highlighting for code-related tools
-      if (CODE_OUTPUT_TOOLS.has(toolName)) {
+      if (TOOLS_WITH_CODE_OUTPUT.has(toolName)) {
         sections.push(
           buildToolUseSection('Input:', wrapInHighlightedPre(inputValue, 'bash')),
         );
@@ -204,13 +203,13 @@ export function formatToolUse(normalizedPayload, logId, groupId, timestamp) {
   }
 
   // Show output if present (primary result from tool)
-  // Skip for read tools (already shown as file link)
-  if (outputText && !READ_TOOLS.has(toolName)) {
-    // Use syntax highlighting for code outputs
-    const language = detectLanguageFromPath(filePath) || (CODE_OUTPUT_TOOLS.has(toolName) ? 'bash' : '');
-    if (language) {
+  // Skip for read/file-link tools (already shown as file link)
+  if (outputText && !TOOLS_WITH_FILE_LINK.has(toolName)) {
+    // Only syntax highlight output for tools with actual code output
+    // Edit tools output human-readable status like "Replaced 1 occurrence." - not code
+    if (TOOLS_WITH_CODE_OUTPUT.has(toolName)) {
       sections.push(
-        buildToolUseSection('Output:', wrapInHighlightedPre(outputText, language, 'tool-output-full')),
+        buildToolUseSection('Output:', wrapInHighlightedPre(outputText, 'bash', 'tool-output-full')),
       );
     } else {
       sections.push(

--- a/src/progressView/modules/formatters/logFormatters/toolFormatters.js
+++ b/src/progressView/modules/formatters/logFormatters/toolFormatters.js
@@ -165,9 +165,10 @@ export function formatToolUse(normalizedPayload, logId, groupId, timestamp) {
   }
   // Handle read tools with file link instead of full content
   else if (READ_TOOLS.has(toolName) && filePath) {
-    // Parse line info from output summary or input range
+    // Only use line info if explicitly provided in range
+    // Don't default to line 1 - this breaks binary files (PDFs, images)
     const range = input?.range;
-    const startLine = range?.start ?? 1;
+    const startLine = range?.start;
     const endLine = range?.end;
 
     // Count total lines from output if available

--- a/src/progressView/modules/formatters/logFormatters/toolFormatters.js
+++ b/src/progressView/modules/formatters/logFormatters/toolFormatters.js
@@ -10,8 +10,17 @@ import {
   buildToolUseSection,
   wrapInPre,
   getToolIconClass,
+  buildFileLinkWithLines,
+  buildEditDiffSection,
+  wrapInHighlightedPre,
+  detectLanguageFromPath,
 } from '../htmlBuilders.js';
 import { normalizeToolUseLog, stringifyForDisplay } from '../normalizers.js';
+
+// Tools that benefit from specialized formatting
+const EDIT_TOOLS = new Set(['edit_file', 'write_file']);
+const READ_TOOLS = new Set(['read_file']);
+const CODE_OUTPUT_TOOLS = new Set(['bash', 'execute', 'run']);
 
 // Web search provider display names
 const PROVIDER_LABELS = {
@@ -131,19 +140,82 @@ export function formatToolUse(normalizedPayload, logId, groupId, timestamp) {
 
   const sections = [];
 
-  // Show full input (key info is already in header summary)
-  if (input !== undefined && input !== null) {
+  // Get file path from input for specialized formatting
+  const filePath =
+    typeof input === 'object' && input !== null ? input.path : '';
+
+  // Handle edit tools with inline diff display
+  if (EDIT_TOOLS.has(toolName) && input?.old_string && input?.new_string) {
+    // Show file path as link
+    if (filePath) {
+      sections.push(
+        buildToolUseSection(
+          'File:',
+          buildFileLinkWithLines(filePath, {}),
+        ),
+      );
+    }
+    // Show inline diff for old_string → new_string
+    sections.push(
+      buildToolUseSection(
+        'Changes:',
+        buildEditDiffSection(input.old_string, input.new_string, filePath),
+      ),
+    );
+  }
+  // Handle read tools with file link instead of full content
+  else if (READ_TOOLS.has(toolName) && filePath) {
+    // Parse line info from output summary or input range
+    const range = input?.range;
+    const startLine = range?.start ?? 1;
+    const endLine = range?.end;
+
+    // Count total lines from output if available
+    const outputLines = outputText ? outputText.split('\n').length : undefined;
+
+    sections.push(
+      buildToolUseSection(
+        'File:',
+        buildFileLinkWithLines(filePath, {
+          startLine,
+          endLine,
+          totalLines: outputLines,
+        }),
+      ),
+    );
+
+    // Don't show full file content - just the link
+    // Output is available via the file link click
+  }
+  // Default handling for other tools
+  else if (input !== undefined && input !== null) {
     const inputValue = stringifyForDisplay(input);
     if (inputValue) {
-      sections.push(buildToolUseSection('Input:', wrapInPre(inputValue)));
+      // Use syntax highlighting for code-related tools
+      if (CODE_OUTPUT_TOOLS.has(toolName)) {
+        sections.push(
+          buildToolUseSection('Input:', wrapInHighlightedPre(inputValue, 'bash')),
+        );
+      } else {
+        sections.push(buildToolUseSection('Input:', wrapInPre(inputValue)));
+      }
     }
   }
 
   // Show output if present (primary result from tool)
-  if (outputText) {
-    sections.push(
-      buildToolUseSection('Output:', wrapInPre(outputText, 'tool-output-full')),
-    );
+  // Skip for read tools (already shown as file link)
+  if (outputText && !READ_TOOLS.has(toolName)) {
+    // Use syntax highlighting for code outputs
+    const language = detectLanguageFromPath(filePath) || (CODE_OUTPUT_TOOLS.has(toolName) ? 'bash' : '');
+    if (language) {
+      sections.push(
+        buildToolUseSection('Output:', wrapInHighlightedPre(outputText, language, 'tool-output-full')),
+      );
+    } else {
+      sections.push(
+        buildToolUseSection('Output:', wrapInPre(outputText, 'tool-output-full')),
+      );
+    }
   }
 
   // Show error if present and not superseded by user feedback

--- a/src/progressView/modules/formatters/logFormatters/toolFormatters.js
+++ b/src/progressView/modules/formatters/logFormatters/toolFormatters.js
@@ -145,47 +145,20 @@ export function formatToolUse(normalizedPayload, logId, groupId, timestamp) {
 
   // Handle edit tools with diff display for input
   if (TOOLS_WITH_DIFF_INPUT.has(toolName) && input?.old_string && input?.new_string) {
-    // Show file path as link
     if (filePath) {
-      sections.push(
-        buildToolUseSection(
-          'File:',
-          buildFileLinkWithLines(filePath, {}),
-        ),
-      );
+      sections.push(buildToolUseSection('File:', buildFileLinkWithLines(filePath)));
     }
-    // Show diff for old_string → new_string
-    sections.push(
-      buildToolUseSection(
-        'Changes:',
-        buildEditDiffSection(input.old_string, input.new_string, filePath),
-      ),
-    );
+    sections.push(buildToolUseSection('Changes:', buildEditDiffSection(input.old_string, input.new_string)));
   }
   // Handle read tools with file link instead of full content
   else if (TOOLS_WITH_FILE_LINK.has(toolName) && filePath) {
-    // Only use line info if explicitly provided in range
-    // Don't default to line 1 - this breaks binary files (PDFs, images)
     const range = input?.range;
-    const startLine = range?.start;
-    const endLine = range?.end;
-
-    // Count total lines from output if available
-    const outputLines = outputText ? outputText.split('\n').length : undefined;
-
     sections.push(
       buildToolUseSection(
         'File:',
-        buildFileLinkWithLines(filePath, {
-          startLine,
-          endLine,
-          totalLines: outputLines,
-        }),
+        buildFileLinkWithLines(filePath, { startLine: range?.start, endLine: range?.end }),
       ),
     );
-
-    // Don't show full file content - just the link
-    // Output is available via the file link click
   }
   // Default handling for other tools
   else if (input !== undefined && input !== null) {

--- a/src/progressView/modules/uiManagers/EventsManager.js
+++ b/src/progressView/modules/uiManagers/EventsManager.js
@@ -178,10 +178,15 @@ export class EventsManager {
       // File link clicks
       const fileLink = e.target.closest('.file-link');
       if (fileLink?.dataset.file) {
-        vscode.postMessage({
+        const message = {
           command: COMMANDS.OPEN_FILE,
           file: fileLink.dataset.file,
-        });
+        };
+        // Include line number if specified
+        if (fileLink.dataset.fileLine) {
+          message.line = parseInt(fileLink.dataset.fileLine, 10);
+        }
+        vscode.postMessage(message);
         return;
       }
 

--- a/src/progressView/styles/scratchpad.css
+++ b/src/progressView/styles/scratchpad.css
@@ -130,39 +130,16 @@
   color: var(--vscode-gitDecoration-modifiedResourceForeground, #d29922);
 }
 
-/* Edit diff container for stacked old/new blocks */
+/* Edit diff container - stacked old/new blocks. Colors say it all. */
 .edit-diff-container {
   display: flex;
   flex-direction: column;
   gap: var(--spacing-small);
 }
 
-.edit-diff-old,
-.edit-diff-new {
-  position: relative;
-}
-
-.edit-diff-label {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--spacing-tiny);
-  font-size: var(--font-size-sm);
-  font-weight: 500;
-  padding: var(--spacing-tiny) var(--spacing-small);
-  border-radius: var(--border-radius-small) var(--border-radius-small) 0 0;
-}
-
-.edit-diff-label.diff-remove {
-  background-color: var(--vscode-diffEditor-removedTextBackground, rgba(255, 0, 0, 0.2));
-}
-
-.edit-diff-label.diff-add {
-  background-color: var(--vscode-diffEditor-insertedTextBackground, rgba(0, 255, 0, 0.2));
-}
-
 .diff-block {
   margin: 0;
-  border-radius: 0 var(--border-radius-small) var(--border-radius-small) var(--border-radius-small);
+  border-radius: var(--border-radius-small);
 }
 
 .diff-block-old {

--- a/src/progressView/styles/scratchpad.css
+++ b/src/progressView/styles/scratchpad.css
@@ -129,3 +129,79 @@
 .diff-hunk {
   color: var(--vscode-gitDecoration-modifiedResourceForeground, #d29922);
 }
+
+/* Inline diff styles for character-level diffs */
+.inline-diff {
+  white-space: pre-wrap;
+  word-break: break-word;
+  line-height: 1.5;
+}
+
+.inline-diff del,
+.inline-diff .diff-remove {
+  background-color: var(--vscode-diffEditor-removedTextBackground, rgba(255, 0, 0, 0.2));
+  text-decoration: line-through;
+  text-decoration-color: var(--vscode-gitDecoration-deletedResourceForeground, #f85149);
+}
+
+.inline-diff ins,
+.inline-diff .diff-add {
+  background-color: var(--vscode-diffEditor-insertedTextBackground, rgba(0, 255, 0, 0.2));
+  text-decoration: none;
+}
+
+/* Edit diff container for stacked old/new blocks */
+.edit-diff-container {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-small);
+}
+
+.edit-diff-old,
+.edit-diff-new {
+  position: relative;
+}
+
+.edit-diff-label {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-tiny);
+  font-size: var(--font-size-sm);
+  font-weight: 500;
+  padding: var(--spacing-tiny) var(--spacing-small);
+  border-radius: var(--border-radius-small) var(--border-radius-small) 0 0;
+}
+
+.edit-diff-label.diff-remove {
+  background-color: var(--vscode-diffEditor-removedTextBackground, rgba(255, 0, 0, 0.2));
+}
+
+.edit-diff-label.diff-add {
+  background-color: var(--vscode-diffEditor-insertedTextBackground, rgba(0, 255, 0, 0.2));
+}
+
+.diff-block {
+  margin: 0;
+  border-radius: 0 var(--border-radius-small) var(--border-radius-small) var(--border-radius-small);
+}
+
+.diff-block-old {
+  border-left: 3px solid var(--vscode-gitDecoration-deletedResourceForeground, #f85149);
+  background-color: var(--vscode-diffEditor-removedTextBackground, rgba(255, 0, 0, 0.1));
+}
+
+.diff-block-new {
+  border-left: 3px solid var(--vscode-gitDecoration-addedResourceForeground, #3fb950);
+  background-color: var(--vscode-diffEditor-insertedTextBackground, rgba(0, 255, 0, 0.1));
+}
+
+/* Syntax highlighted code blocks */
+pre.hljs {
+  padding: var(--spacing-small);
+  overflow-x: auto;
+}
+
+pre.hljs code {
+  background: transparent;
+  padding: 0;
+}

--- a/src/progressView/styles/scratchpad.css
+++ b/src/progressView/styles/scratchpad.css
@@ -130,26 +130,6 @@
   color: var(--vscode-gitDecoration-modifiedResourceForeground, #d29922);
 }
 
-/* Inline diff styles for character-level diffs */
-.inline-diff {
-  white-space: pre-wrap;
-  word-break: break-word;
-  line-height: 1.5;
-}
-
-.inline-diff del,
-.inline-diff .diff-remove {
-  background-color: var(--vscode-diffEditor-removedTextBackground, rgba(255, 0, 0, 0.2));
-  text-decoration: line-through;
-  text-decoration-color: var(--vscode-gitDecoration-deletedResourceForeground, #f85149);
-}
-
-.inline-diff ins,
-.inline-diff .diff-add {
-  background-color: var(--vscode-diffEditor-insertedTextBackground, rgba(0, 255, 0, 0.2));
-  text-decoration: none;
-}
-
 /* Edit diff container for stacked old/new blocks */
 .edit-diff-container {
   display: flex;


### PR DESCRIPTION
- Add syntax highlighting for tool code outputs using highlight.js auto-detect
- Show file links with line numbers instead of full content for read_file tool
- Display inline character-level diffs for edit_file old_string → new_string
- Support opening files at specific line numbers from file links
- Add CSS styles for inline diffs with VS Code theme colors

Uses existing dependencies (highlight.js, diff-match-patch) without adding new ones.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enhances progress view readability and navigation with code highlighting, targeted file links, and specialized tool rendering.
> 
> - Introduces `highlight.js` formatting via `wrapInHighlightedPre` and styles for `.hljs` blocks
> - Adds specialized tool display: `edit_file` shows stacked old/new diff blocks; `read_file` shows file links (with optional line ranges) instead of full content; code tools (`bash/execute/run`) get syntax-highlighted input/output
> - Implements file-link clicks that include `data-file-line` and updates message handling and `openFile(file, line?)` command to navigate directly to a line
> - Adds CSS for inline edit diffs using VS Code theme colors and tweaks for highlighted code blocks
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2b3052a8f00d14e1ef4314970cb62cef605a25da. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->