### PR TITLE
EditTool input schema and usage updated

### DIFF
--- a/src/tools/EditTool.ts
+++ b/src/tools/EditTool.ts
@@ -22,8 +22,8 @@ import { defineTool } from './core/define';
 
 const EditInputSchema = z.strictObject({
   path: z.string(),
-  old_string: z.string(),
-  new_string: z.string(),
+  old_str: z.string(),
+  new_str: z.string(),
   replace_all: z.boolean().nullish(),
 });
 
@@ -47,11 +47,11 @@ export class EditFileTool extends defineTool({
   schema: EditInputSchema,
 }) {
   protected async execute(input: EditInput): Promise<ToolResult> {
-    const { path: targetPath, old_string, new_string, replace_all } = input;
+    const { path: targetPath, old_str, new_str, replace_all } = input;
 
-    if (old_string.length === 0) {
+    if (old_str.length === 0) {
       throw new ToolError(
-        `old_string must not be empty for ${targetPath}. Provide the exact text to replace from read_file output after the line-number prefix.`,
+        `old_str must not be empty for ${targetPath}. Provide the exact text to replace from read_file output after the line-number prefix.`,
       );
     }
 
@@ -62,23 +62,23 @@ export class EditFileTool extends defineTool({
     }
 
     const currentContent = await WorkspaceFS.read(targetPath);
-    const occurrences = countOccurrences(currentContent, old_string);
+    const occurrences = countOccurrences(currentContent, old_str);
 
     if (occurrences === 0) {
       throw new ToolError(
-        `The provided old_string was not found in ${targetPath}. Ensure it matches the read_file output exactly after the line-number prefix.`,
+        `The provided old_str was not found in ${targetPath}. Ensure it matches the read_file output exactly after the line-number prefix.`,
       );
     }
 
     if (!replace_all && occurrences > 1) {
       throw new ToolError(
-        `old_string is not unique within ${targetPath}. Include more surrounding context or set replace_all to true.`,
+        `old_str is not unique within ${targetPath}. Include more surrounding context or set replace_all to true.`,
       );
     }
 
     const updatedContent = replace_all
-      ? currentContent.replaceAll(old_string, new_string)
-      : currentContent.replace(old_string, new_string);
+      ? currentContent.replaceAll(old_str, new_str)
+      : currentContent.replace(old_str, new_str);
 
     const approval = await requestToolEditApproval({
       path: targetPath,


### PR DESCRIPTION
Rename old_string/new_string to old_str/new_str in EditTool to match the naming convention used by TextEditorTool and MemoryTool. This eliminates confusion when models mix up parameter names between tools.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **EditTool input schema and usage updated**
> 
> - Renames `EditInputSchema` fields from `old_string/new_string` to `old_str/new_str` and updates all references in `execute`
> - Adjusts validation and error messages to use the new keys
> - Updates replacement logic to call `replace`/`replaceAll` with `old_str`/`new_str`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e6f3a73ff81f953d72aa322e8a3694234435eb20. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->