### PR TITLE
Use YAML as single source of truth for remote agent

### DIFF
--- a/src/agent/index/agentRegistry.ts
+++ b/src/agent/index/agentRegistry.ts
@@ -448,7 +448,7 @@ async function loadRemoteAgents(): Promise<AgentEntry[]> {
       if (!primary) continue;
 
       const isToolUse = primary.agentCategory === AgentCategory.ToolUse;
-      // Description not available at list time - comes from YAML when agent is loaded
+      // Description from DB is cache; updated from YAML when agent is loaded
       entries.push({
         name: base ? baseName : primary.name,
         source: 'remote' as AgentSource,
@@ -456,6 +456,7 @@ async function loadRemoteAgents(): Promise<AgentEntry[]> {
         multiplePath: multiple?.name,
         category: isToolUse ? AgentCategory.ToolUse : AgentCategory.Workflow,
         agentType: isToolUse ? AgentType.ToolUse : AgentType.CoT,
+        description: primary.description ?? undefined,
         visibility: primary.visibility ?? undefined,
       });
     }

--- a/src/agent/index/agentRegistry.ts
+++ b/src/agent/index/agentRegistry.ts
@@ -434,6 +434,7 @@ async function loadRemoteAgents(): Promise<AgentEntry[]> {
       if (!primary) continue;
 
       const isToolUse = primary.agentCategory === AgentCategory.ToolUse;
+      // Description not available at list time - comes from YAML when agent is loaded
       entries.push({
         name: base ? baseName : primary.name,
         source: 'remote' as AgentSource,
@@ -441,7 +442,6 @@ async function loadRemoteAgents(): Promise<AgentEntry[]> {
         multiplePath: multiple?.name,
         category: isToolUse ? AgentCategory.ToolUse : AgentCategory.Workflow,
         agentType: isToolUse ? AgentType.ToolUse : AgentType.CoT,
-        description: primary.description ?? undefined,
         visibility: primary.visibility ?? undefined,
       });
     }

--- a/src/agent/index/agentRegistry.ts
+++ b/src/agent/index/agentRegistry.ts
@@ -215,6 +215,20 @@ export function getAgent(identifier: string): AgentEntry | undefined {
 }
 
 /**
+ * Update an agent's description in the cache.
+ * Used to populate descriptions for remote agents after YAML is loaded.
+ */
+export function updateAgentDescription(
+  identifier: string,
+  description: string | undefined,
+): void {
+  const entry = getAgent(identifier);
+  if (entry && description) {
+    entry.description = description;
+  }
+}
+
+/**
  * Resolve an agent to its definition path, handling _multiple variant logic.
  */
 export function resolveAgent(

--- a/src/agent/index/index.ts
+++ b/src/agent/index/index.ts
@@ -16,6 +16,7 @@ export {
   ensureAgentsLoaded,
   isAgentCacheInitialized,
   getAgent,
+  updateAgentDescription,
   resolveAgent,
   getWorkflowAgents,
   getToolUseAgents,

--- a/src/agent/remote/RemoteAgentLoader.ts
+++ b/src/agent/remote/RemoteAgentLoader.ts
@@ -337,36 +337,4 @@ export class RemoteAgentLoader {
       return [];
     }
   }
-
-  /** Get list item for a specific remote agent (without description). */
-  static async getAgentMetadata(
-    agentName: string,
-  ): Promise<RemoteAgentListItem | null> {
-    try {
-      const supabase = await getAuthenticatedClient();
-      if (!supabase) return null;
-
-      const { data, error } = await supabase
-        .from('remote_agents')
-        .select('id, name, visibility, agent_category')
-        .eq('name', agentName)
-        .single();
-
-      if (error || !data) {
-        logger.warn(
-          CHANNEL,
-          `No metadata found for remote agent: ${agentName}`,
-        );
-        return null;
-      }
-
-      return parseListItemRow(data);
-    } catch (error) {
-      logger.error(
-        CHANNEL,
-        `Error fetching metadata for ${agentName}: ${toErrorMessage(error)}`,
-      );
-      return null;
-    }
-  }
 }

--- a/src/agent/remote/RemoteAgentLoader.ts
+++ b/src/agent/remote/RemoteAgentLoader.ts
@@ -105,12 +105,14 @@ function mapHttpError(
 function parseListItemRow(row: {
   id: string;
   name: string;
+  description?: string | null;
   visibility?: string[] | null;
   agent_category?: string | null;
 }): RemoteAgentListItem | null {
   const result = RemoteAgentListItemSchema.safeParse({
     id: row.id,
     name: row.name,
+    description: row.description,
     visibility: row.visibility,
     agentCategory: row.agent_category,
   });
@@ -329,7 +331,7 @@ export class RemoteAgentLoader {
 
       const { data, error } = await supabase
         .from('remote_agents')
-        .select('id, name, visibility, agent_category')
+        .select('id, name, description, visibility, agent_category')
         .order('name');
 
       if (error) {

--- a/src/agent/remote/RemoteAgentLoader.ts
+++ b/src/agent/remote/RemoteAgentLoader.ts
@@ -12,7 +12,11 @@ import {
   parseAgentSetting,
   AgentDefinitionSchema,
 } from '@agent/core/AgentDataclass';
-import { getMultipleName, getBaseName } from '@agent/index/agentRegistry';
+import {
+  getMultipleName,
+  getBaseName,
+  updateAgentDescription,
+} from '@agent/index/agentRegistry';
 import { toErrorMessage } from '@common/errors/errorHandlingUtils';
 import * as logger from '@logger/logUtils';
 import { getConfig } from '@utils/config';
@@ -269,6 +273,11 @@ export class RemoteAgentLoader {
           CHANNEL,
           `Successfully loaded remote agent: ${agentName} (resolved to ${candidateName})`,
         );
+
+        // Update registry cache with description from YAML
+        if (validated.description) {
+          updateAgentDescription(`remote:${agentName}`, validated.description);
+        }
 
         return {
           name: validated.name || responseName || agentName,

--- a/src/agent/remote/RemoteAgentLoader.ts
+++ b/src/agent/remote/RemoteAgentLoader.ts
@@ -20,7 +20,9 @@ import { SupabaseClient } from '@/auth/SupabaseClient';
 import { SUPABASE_CONFIG } from '@/auth/config';
 
 import {
+  RemoteAgentListItemSchema,
   RemoteAgentMetadataSchema,
+  type RemoteAgentListItem,
   type RemoteAgentMetadata,
   type RemoteAgentConfig,
   type RemoteAgentLoadOptions,
@@ -95,15 +97,14 @@ function mapHttpError(
   };
 }
 
-/** Maps a database row to RemoteAgentMetadata using schema validation. */
-function parseMetadataRow(row: {
+/** Maps a database row to RemoteAgentListItem using schema validation. */
+function parseListItemRow(row: {
   id: string;
   name: string;
   visibility?: string[] | null;
   agent_category?: string | null;
-}): RemoteAgentMetadata | null {
-  // Description comes from YAML (when agent is loaded), not from DB
-  const result = RemoteAgentMetadataSchema.safeParse({
+}): RemoteAgentListItem | null {
+  const result = RemoteAgentListItemSchema.safeParse({
     id: row.id,
     name: row.name,
     visibility: row.visibility,
@@ -308,7 +309,7 @@ export class RemoteAgentLoader {
   }
 
   /** List all available remote agents for the current user. */
-  static async listRemoteAgents(): Promise<RemoteAgentMetadata[]> {
+  static async listRemoteAgents(): Promise<RemoteAgentListItem[]> {
     if (!(await SupabaseClient.isAuthenticated())) return [];
 
     try {
@@ -326,8 +327,8 @@ export class RemoteAgentLoader {
       }
 
       return (data ?? [])
-        .map(parseMetadataRow)
-        .filter((item): item is RemoteAgentMetadata => item !== null);
+        .map(parseListItemRow)
+        .filter((item): item is RemoteAgentListItem => item !== null);
     } catch (error) {
       logger.error(
         CHANNEL,
@@ -337,10 +338,10 @@ export class RemoteAgentLoader {
     }
   }
 
-  /** Get metadata for a specific remote agent. */
+  /** Get list item for a specific remote agent (without description). */
   static async getAgentMetadata(
     agentName: string,
-  ): Promise<RemoteAgentMetadata | null> {
+  ): Promise<RemoteAgentListItem | null> {
     try {
       const supabase = await getAuthenticatedClient();
       if (!supabase) return null;
@@ -359,7 +360,7 @@ export class RemoteAgentLoader {
         return null;
       }
 
-      return parseMetadataRow(data);
+      return parseListItemRow(data);
     } catch (error) {
       logger.error(
         CHANNEL,

--- a/src/agent/remote/RemoteAgentLoader.ts
+++ b/src/agent/remote/RemoteAgentLoader.ts
@@ -275,8 +275,10 @@ export class RemoteAgentLoader {
         );
 
         // Update registry cache with description from YAML
+        // Use base name since registry stores entries under base name only
         if (validated.description) {
-          updateAgentDescription(`remote:${agentName}`, validated.description);
+          const baseName = getBaseName(agentName);
+          updateAgentDescription(`remote:${baseName}`, validated.description);
         }
 
         return {

--- a/src/agent/remote/RemoteAgentLoader.ts
+++ b/src/agent/remote/RemoteAgentLoader.ts
@@ -278,7 +278,8 @@ export class RemoteAgentLoader {
           metadata: RemoteAgentMetadataSchema.parse({
             id: '',
             name: responseName || agentName,
-            description,
+            // YAML is source of truth for description; response is fallback
+            description: validated.description ?? description,
             visibility,
             agentCategory,
           }),

--- a/src/agent/remote/RemoteAgentLoader.ts
+++ b/src/agent/remote/RemoteAgentLoader.ts
@@ -99,14 +99,13 @@ function mapHttpError(
 function parseMetadataRow(row: {
   id: string;
   name: string;
-  description?: string | null;
   visibility?: string[] | null;
   agent_category?: string | null;
 }): RemoteAgentMetadata | null {
+  // Description comes from YAML (when agent is loaded), not from DB
   const result = RemoteAgentMetadataSchema.safeParse({
     id: row.id,
     name: row.name,
-    description: row.description,
     visibility: row.visibility,
     agentCategory: row.agent_category,
   });
@@ -237,7 +236,6 @@ export class RemoteAgentLoader {
         const {
           config: yamlContent,
           name: responseName,
-          description,
           visibility,
           agentCategory,
         } = await response.json();
@@ -278,8 +276,7 @@ export class RemoteAgentLoader {
           metadata: RemoteAgentMetadataSchema.parse({
             id: '',
             name: responseName || agentName,
-            // YAML is source of truth for description; response is fallback
-            description: validated.description ?? description,
+            description: validated.description,
             visibility,
             agentCategory,
           }),
@@ -320,7 +317,7 @@ export class RemoteAgentLoader {
 
       const { data, error } = await supabase
         .from('remote_agents')
-        .select('id, name, description, visibility, agent_category')
+        .select('id, name, visibility, agent_category')
         .order('name');
 
       if (error) {
@@ -350,7 +347,7 @@ export class RemoteAgentLoader {
 
       const { data, error } = await supabase
         .from('remote_agents')
-        .select('id, name, description, visibility, agent_category')
+        .select('id, name, visibility, agent_category')
         .eq('name', agentName)
         .single();
 

--- a/src/agent/remote/index.ts
+++ b/src/agent/remote/index.ts
@@ -7,7 +7,9 @@
 
 // Core types and schemas
 export {
+  RemoteAgentListItemSchema,
   RemoteAgentMetadataSchema,
+  type RemoteAgentListItem,
   type RemoteAgentMetadata,
   type RemoteAgentConfig,
   type RemoteAgentLoadOptions,

--- a/src/agent/remote/types.ts
+++ b/src/agent/remote/types.ts
@@ -18,18 +18,27 @@ import {
 export type { AgentLoadOptions as RemoteAgentLoadOptions } from '@agent/runtime/agentLoad';
 
 /**
- * Schema for remote agent metadata.
- * Uses .nullish() to accept null from database and normalize to undefined.
+ * Schema for remote agent list items (from DB queries).
+ * Does NOT include description - that comes from YAML when agent is loaded.
  */
-export const RemoteAgentMetadataSchema = z.object({
+export const RemoteAgentListItemSchema = z.object({
   id: z.string(),
   name: z.string(),
-  /** Description can be NULL in the database */
-  description: z.string().nullish(),
   /** Visibility can be NULL in the database */
   visibility: z.array(z.string()).nullish(),
   /** Agent category: 'workflow' or 'toolUse' */
   agentCategory: z.enum(AgentCategory).nullish(),
+});
+
+export type RemoteAgentListItem = z.infer<typeof RemoteAgentListItemSchema>;
+
+/**
+ * Schema for full remote agent metadata (after loading YAML).
+ * Extends list item with description from YAML.
+ */
+export const RemoteAgentMetadataSchema = RemoteAgentListItemSchema.extend({
+  /** Description from YAML (not stored in DB) */
+  description: z.string().nullish(),
 });
 
 export type RemoteAgentMetadata = z.infer<typeof RemoteAgentMetadataSchema>;

--- a/src/agent/remote/types.ts
+++ b/src/agent/remote/types.ts
@@ -19,11 +19,13 @@ export type { AgentLoadOptions as RemoteAgentLoadOptions } from '@agent/runtime/
 
 /**
  * Schema for remote agent list items (from DB queries).
- * Does NOT include description - that comes from YAML when agent is loaded.
+ * Description from DB serves as cache; authoritative value comes from YAML when loaded.
  */
 export const RemoteAgentListItemSchema = z.object({
   id: z.string(),
   name: z.string(),
+  /** Cached description from DB (YAML is source of truth) */
+  description: z.string().nullish(),
   /** Visibility can be NULL in the database */
   visibility: z.array(z.string()).nullish(),
   /** Agent category: 'workflow' or 'toolUse' */
@@ -33,13 +35,10 @@ export const RemoteAgentListItemSchema = z.object({
 export type RemoteAgentListItem = z.infer<typeof RemoteAgentListItemSchema>;
 
 /**
- * Schema for full remote agent metadata (after loading YAML).
- * Extends list item with description from YAML.
+ * Full remote agent metadata. Same shape as list item.
+ * When loaded via loadRemoteAgent(), description comes from YAML.
  */
-export const RemoteAgentMetadataSchema = RemoteAgentListItemSchema.extend({
-  /** Description from YAML (not stored in DB) */
-  description: z.string().nullish(),
-});
+export const RemoteAgentMetadataSchema = RemoteAgentListItemSchema;
 
 export type RemoteAgentMetadata = z.infer<typeof RemoteAgentMetadataSchema>;
 

--- a/supabase/functions/get-agent-config/index.ts
+++ b/supabase/functions/get-agent-config/index.ts
@@ -8,7 +8,6 @@
  */
 
 import { createClient } from 'jsr:@supabase/supabase-js@2.89.0';
-import { parse as parseYaml } from 'jsr:@std/yaml@1';
 import { handleCors, getCorsHeaders } from '../_shared/cors.ts';
 
 // =============================================================================
@@ -102,9 +101,10 @@ Deno.serve(async (req: Request) => {
     }
 
     // 4. Fetch agent metadata (RLS enforces access control)
+    // Description comes from YAML (parsed client-side), not DB
     const { data: agent, error: agentError } = await userClient
       .from('remote_agents')
-      .select('id, name, description, storage_path, visibility, agent_category')
+      .select('id, name, storage_path, visibility, agent_category')
       .eq('name', body.agentName)
       .single();
 
@@ -122,24 +122,14 @@ Deno.serve(async (req: Request) => {
       return errorResponse(req, 'Failed to load agent configuration', 500);
     }
 
-    // 6. Parse YAML and extract description (YAML is source of truth)
+    // 6. Return config (client parses YAML and extracts description)
     const yamlContent = await fileData.text();
-    let yamlDescription: string | undefined;
-    try {
-      const parsed = parseYaml(yamlContent) as Record<string, unknown>;
-      yamlDescription =
-        typeof parsed?.description === 'string' ? parsed.description : undefined;
-    } catch {
-      // If YAML parsing fails, continue without description
-      console.warn('[GET_AGENT_CONFIG] Failed to parse YAML for description extraction');
-    }
 
     return jsonResponse(
       req,
       {
         config: yamlContent,
         name: agent.name,
-        description: yamlDescription,
         visibility: agent.visibility,
         agentCategory: agent.agent_category,
       },

--- a/supabase/functions/get-agent-config/index.ts
+++ b/supabase/functions/get-agent-config/index.ts
@@ -8,6 +8,7 @@
  */
 
 import { createClient } from 'jsr:@supabase/supabase-js@2.89.0';
+import { parse as parseYaml } from 'jsr:@std/yaml@1';
 import { handleCors, getCorsHeaders } from '../_shared/cors.ts';
 
 // =============================================================================
@@ -121,15 +122,24 @@ Deno.serve(async (req: Request) => {
       return errorResponse(req, 'Failed to load agent configuration', 500);
     }
 
-    // 6. Return config
+    // 6. Parse YAML and extract description (YAML is source of truth)
     const yamlContent = await fileData.text();
+    let yamlDescription: string | undefined;
+    try {
+      const parsed = parseYaml(yamlContent) as Record<string, unknown>;
+      yamlDescription =
+        typeof parsed?.description === 'string' ? parsed.description : undefined;
+    } catch {
+      // If YAML parsing fails, continue without description
+      console.warn('[GET_AGENT_CONFIG] Failed to parse YAML for description extraction');
+    }
 
     return jsonResponse(
       req,
       {
         config: yamlContent,
         name: agent.name,
-        description: agent.description,
+        description: yamlDescription,
         visibility: agent.visibility,
         agentCategory: agent.agent_category,
       },

--- a/supabase/migrations/20260121_drop_remote_agents_description.sql
+++ b/supabase/migrations/20260121_drop_remote_agents_description.sql
@@ -1,3 +1,0 @@
--- Remove description column from remote_agents table
--- Description is now read from YAML files (single source of truth)
-ALTER TABLE remote_agents DROP COLUMN IF EXISTS description;

--- a/supabase/migrations/20260121_drop_remote_agents_description.sql
+++ b/supabase/migrations/20260121_drop_remote_agents_description.sql
@@ -1,0 +1,3 @@
+-- Remove description column from remote_agents table
+-- Description is now read from YAML files (single source of truth)
+ALTER TABLE remote_agents DROP COLUMN IF EXISTS description;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Centralizes remote agent description to YAML and updates local cache post-load.
> 
> - Adds `updateAgentDescription` in `agentRegistry` and exports it; used by `RemoteAgentLoader` to write YAML description back to the registry cache
> - `RemoteAgentLoader.loadRemoteAgent()` now parses description from YAML and returns it in `metadata`; removes DB-provided description usage and drops `getAgentMetadata()`
> - Introduces `RemoteAgentListItemSchema`/`type` and makes `RemoteAgentMetadataSchema` an alias; `listRemoteAgents()` now returns list items validated via `parseListItemRow`
> - Edge function `get-agent-config` no longer selects/returns `description`; clients parse it from YAML
> - Registry still seeds remote entries with DB description as a cache placeholder until YAML is loaded
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fed3efb90afab5fe674dab6f64b76bd1471c7b6a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->