### PR TITLE
Fix latexdiff display in refactored format

### DIFF
--- a/src/agent/output/OutputFileProcessor.ts
+++ b/src/agent/output/OutputFileProcessor.ts
@@ -57,8 +57,10 @@ export class OutputFileProcessor {
     );
 
     try {
-      const processedPairs =
-        await xmlManager.processMultipleXmlOutputs(outputLocation);
+      const processedPairs = await xmlManager.processMultipleXmlOutputs(
+        outputLocation,
+        currRound,
+      );
 
       if (processedPairs.length > 0) {
         await indentLatexFiles(

--- a/src/agent/output/XmlOutputManager.ts
+++ b/src/agent/output/XmlOutputManager.ts
@@ -293,13 +293,7 @@ export class XmlOutputManager {
 
       const { ext } = path.parse(source);
       const extension = ext.replace('.', '') || 'tex';
-      const texFile = getOutputFileName(
-        source,
-        agent,
-        model,
-        extension,
-        round,
-      );
+      const texFile = getOutputFileName(source, agent, model, extension, round);
       const texLocation = this.fileService.createLocation(texFile);
       const cleanedContent = this.removeTrailingEndDocument(
         doc.content.trim(),

--- a/src/agent/output/XmlOutputManager.ts
+++ b/src/agent/output/XmlOutputManager.ts
@@ -9,7 +9,6 @@ import type { AgentConfig } from '@agent/core/AgentConfig';
 // Internal imports
 import { AgentSetting } from '@agent/core/AgentDataclass';
 import { getOutputFileName } from '@agent/utils/outputFileUtils';
-import { extractLastRoundMatch } from '@agent/utils/mergeFileUtils';
 import { toErrorMessage } from '@common/errors/errorHandlingUtils';
 import { AgentLogger } from '@logger/AgentLogger';
 import {
@@ -204,6 +203,7 @@ export class XmlOutputManager {
   async splitScratchpadMultipleOutputXml(
     outputLocation: FileLocation,
     documentTag: string,
+    round: number,
     thinkingTag: string = 'scratchpad',
   ): Promise<OutputFileInfo[]> {
     let outputContent = await AbsoluteFS.read(outputLocation.absolutePath);
@@ -225,7 +225,11 @@ export class XmlOutputManager {
           expectedDocumentCount,
           fallbackDocs.length,
         );
-        return this.processMultipleLatexDocuments(fallbackDocs, outputLocation);
+        return this.processMultipleLatexDocuments(
+          fallbackDocs,
+          outputLocation,
+          round,
+        );
       }
       this.warnPartialExtraction(outputLocation, expectedDocumentCount, 0);
       return null;
@@ -242,7 +246,11 @@ export class XmlOutputManager {
           expectedDocumentCount,
           documents.length,
         );
-        return this.processMultipleLatexDocuments(documents, outputLocation);
+        return this.processMultipleLatexDocuments(
+          documents,
+          outputLocation,
+          round,
+        );
       }
 
       this.logger.debugInternal(
@@ -262,14 +270,12 @@ export class XmlOutputManager {
   async processMultipleLatexDocuments(
     latexDocuments: Array<{ content: string; name: string }>,
     outputLocation: FileLocation,
+    round: number,
   ): Promise<OutputFileInfo[]> {
     const outputFiles: OutputFileInfo[] = [];
     const outputParts = path.basename(outputLocation.absolutePath).split('_');
     const agent = outputParts.at(-3) ?? '';
     const model = outputParts.at(-1)?.split('.')[0] ?? '';
-
-    const lastRoundMatch = extractLastRoundMatch(outputLocation.absolutePath);
-    const currRound = lastRoundMatch ? parseInt(lastRoundMatch[1]) : 0;
 
     for (const doc of latexDocuments) {
       if (!doc.name || doc.name === 'unknown' || !doc.content) {
@@ -292,7 +298,7 @@ export class XmlOutputManager {
         agent,
         model,
         extension,
-        currRound,
+        round,
       );
       const texLocation = this.fileService.createLocation(texFile);
       const cleanedContent = this.removeTrailingEndDocument(
@@ -302,7 +308,7 @@ export class XmlOutputManager {
       await AbsoluteFS.write(texLocation.absolutePath, cleanedContent);
       outputFiles.push({
         source,
-        round: currRound,
+        round,
         location: texLocation,
         lineage: null,
         diff: null,
@@ -346,6 +352,7 @@ export class XmlOutputManager {
 
   async processMultipleXmlOutputs(
     outputLocation: FileLocation,
+    round: number,
   ): Promise<OutputFileInfo[]> {
     this.logger.debug(
       `Splitting multiple scratchpad output XML: ${outputLocation.absolutePath}`,
@@ -353,6 +360,7 @@ export class XmlOutputManager {
     return this.splitScratchpadMultipleOutputXml(
       outputLocation,
       this.agentSetting.documentTag,
+      round,
     );
   }
 

--- a/src/progressView/modules/formatters/logFormatters/dataFormatters.js
+++ b/src/progressView/modules/formatters/logFormatters/dataFormatters.js
@@ -202,6 +202,17 @@ const extractNewFormat = (entry) => {
 };
 
 /**
+ * Extract round number from a label like "[r1]" or "file.tex [r2]"
+ * @param {string|undefined} label - Label that might contain round info
+ * @returns {number|null} Round number or null if not found
+ */
+const parseRoundFromLabel = (label) => {
+  if (typeof label !== 'string') return null;
+  const match = label.match(/\[r(\d+)\]/);
+  return match ? parseInt(match[1], 10) : null;
+};
+
+/**
  * Extract display data from legacy format (locations + labels).
  * @param {object} entry - Legacy entry
  * @returns {object} Extracted fields for rendering
@@ -210,17 +221,23 @@ const extractLegacyFormat = (entry) => {
   const { locations } = entry;
   const baseFile = locations.base?.absolutePath || entry.basePath || '';
 
+  // Try to get round info from entry fields first, then parse from labels
+  const baseRound =
+    entry.baseRound ?? parseRoundFromLabel(entry.baseLabel) ?? null;
+  const revisedRound =
+    entry.revisedRound ?? parseRoundFromLabel(entry.revisedLabel) ?? 0;
+
   return {
     baseFile,
     revisedFile: locations.revised?.absolutePath || entry.revisedPath || '',
     diffFile: locations.diff?.absolutePath || entry.diffPath || '',
     displayName:
       entry.originalFileName ||
-      entry.baseLabel ||
+      entry.baseLabel?.replace(/\s*\[r\d+\]/, '') || // Strip round from label
       getBasename(baseFile) ||
       'unknown',
-    baseRound: null,
-    revisedRound: 0,
+    baseRound,
+    revisedRound,
     status: entry.status || 'error',
     message: entry.message,
     runId: entry.runId,

--- a/src/progressView/modules/formatters/logFormatters/dataFormatters.js
+++ b/src/progressView/modules/formatters/logFormatters/dataFormatters.js
@@ -215,7 +215,10 @@ const extractLegacyFormat = (entry) => {
     revisedFile: locations.revised?.absolutePath || entry.revisedPath || '',
     diffFile: locations.diff?.absolutePath || entry.diffPath || '',
     displayName:
-      entry.originalFileName || entry.baseLabel || getBasename(baseFile) || 'unknown',
+      entry.originalFileName ||
+      entry.baseLabel ||
+      getBasename(baseFile) ||
+      'unknown',
     baseRound: null,
     revisedRound: 0,
     status: entry.status || 'error',
@@ -234,23 +237,37 @@ const buildLatexdiffEntryHtml = (entry) => {
   if (!entry) return '';
 
   // Extract fields based on format
-  const data = entry.revised && typeof entry.revised === 'object'
-    ? extractNewFormat(entry)
-    : entry.locations
-      ? extractLegacyFormat(entry)
-      : null;
+  const data =
+    entry.revised && typeof entry.revised === 'object'
+      ? extractNewFormat(entry)
+      : entry.locations
+        ? extractLegacyFormat(entry)
+        : null;
 
   if (!data) return '';
 
-  const { baseFile, revisedFile, diffFile, displayName, baseRound, revisedRound, status, message, runId } = data;
+  const {
+    baseFile,
+    revisedFile,
+    diffFile,
+    displayName,
+    baseRound,
+    revisedRound,
+    status,
+    message,
+    runId,
+  } = data;
 
   const icon = getLatexdiffStatusIcon(status);
   const msg = toStringOrEmpty(message);
   const titleAttr = msg ? ` title="${encodeHtml(msg)}"` : '';
-  const runAttr = runId ? ` data-run-id="${encodeHtml(toStringOrEmpty(runId))}"` : '';
+  const runAttr = runId
+    ? ` data-run-id="${encodeHtml(toStringOrEmpty(runId))}"`
+    : '';
 
   // Build display: "essay.tex → [r0] (diff)" or "essay.tex [r0] → [r1] (diff)"
-  const baseLabel = baseRound === null ? displayName : `${displayName} [r${baseRound}]`;
+  const baseLabel =
+    baseRound === null ? displayName : `${displayName} [r${baseRound}]`;
   const revisedLabel = `[r${revisedRound}]`;
 
   const baseLink = buildFileLink(baseFile, baseLabel);

--- a/src/progressView/styles/retry-requests.css
+++ b/src/progressView/styles/retry-requests.css
@@ -75,4 +75,3 @@
   background: var(--vscode-editorWarning-foreground, #ff8c00);
   border-radius: var(--border-radius-small) 0 0 var(--border-radius-small);
 }
-


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Fix latexdiff display and round handling**
> 
> - ProgressView latexdiff formatter: parse round numbers from labels for legacy entries, strip `[rN]` from display names, and preserve run IDs; maintains support for new DiffResult format
> 
> **Refactor multi-XML output processing**
> 
> - Pass explicit `round` through `processMultipleXmlOutputs` → `splitScratchpadMultipleOutputXml` → `processMultipleLatexDocuments`
> - Use provided round when generating output filenames and `OutputFileInfo`, removing filename-based round parsing
> 
> - Minor CSS cleanup in `retry-requests.css`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8886e9130e5550451101cdc370dd6530d2683516. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->