### PR TITLE
Add syntax highlighting to diff code

### DIFF
--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -74,6 +74,7 @@
           "@common/iconConstants.js": "${iconConstantsUri}",
           "@common/BaseWebviewMessageHandler.js": "${baseWebviewMessageHandlerUri}",
           "@common/clipboardUtils.js": "${clipboardUtilsUri}",
+          "diff-match-patch": "https://esm.sh/diff-match-patch@1.0.5",
           "he": "https://esm.sh/he@1.2.0",
           "highlight.js": "https://esm.sh/highlight.js@11.11.1",
           "markdown-it-highlightjs": "https://esm.sh/markdown-it-highlightjs@4.2.0",

--- a/src/progressView/modules/formatters/htmlBuilders.js
+++ b/src/progressView/modules/formatters/htmlBuilders.js
@@ -258,7 +258,7 @@ export function buildFileLinkWithLines(filePath, options = {}) {
 }
 
 // ============================================================================
-// Edit Diff Display (Stacked Blocks)
+// Edit Diff Display (Inline Word-Level Diff)
 // ============================================================================
 
 /**

--- a/src/progressView/modules/formatters/htmlBuilders.js
+++ b/src/progressView/modules/formatters/htmlBuilders.js
@@ -10,6 +10,7 @@ import {
   CHEVRON_DOWN_CLASS,
 } from '@common/iconConstants.js';
 import { TOOL_ICON_MAP } from './constants.js';
+import { generateInlineDiff } from './wordDiff.js';
 
 /**
  * Build a tool-use section HTML block
@@ -261,24 +262,13 @@ export function buildFileLinkWithLines(filePath, options = {}) {
 // ============================================================================
 
 /**
- * Build edit diff section showing old_string → new_string as stacked blocks.
- * Red = old, Green = new. Colors communicate; labels don't.
+ * Build edit diff section showing old_string → new_string with inline highlighting.
+ * Deleted text shown with red strikethrough, added text shown with green highlight.
  * @param {string} oldString - Original text being replaced
  * @param {string} newString - Replacement text
  * @returns {string} HTML for the diff display
  */
 export function buildEditDiffSection(oldString, newString) {
-  // Let highlight.js auto-detect language
-  const oldHtml = wrapInHighlightedPre(
-    oldString,
-    '',
-    'diff-block diff-block-old',
-  );
-  const newHtml = wrapInHighlightedPre(
-    newString,
-    '',
-    'diff-block diff-block-new',
-  );
-
-  return `<div class="edit-diff-container">${oldHtml}${newHtml}</div>`;
+  const diffHtml = generateInlineDiff(oldString, newString);
+  return `<div class="edit-diff-container"><pre class="diff-inline-view">${diffHtml}</pre></div>`;
 }

--- a/src/progressView/modules/formatters/wordDiff.js
+++ b/src/progressView/modules/formatters/wordDiff.js
@@ -3,24 +3,24 @@
  * Provides clean inline highlighting for text changes.
  */
 
-import DiffMatchPatch from 'diff-match-patch';
+import {
+  diff_match_patch,
+  DIFF_DELETE,
+  DIFF_INSERT,
+} from 'diff-match-patch';
 import { encodeHtml } from '@common/htmlEncoding.js';
-
-const DIFF_DELETE = -1;
-const DIFF_INSERT = 1;
-const DIFF_EQUAL = 0;
 
 /**
  * Generate inline diff HTML showing changes between old and new text.
  * Uses Google's diff-match-patch for reliable diffing.
  *
- * @param {string} oldText - Original text
- * @param {string} newText - New text
+ * @param {string} oldText - Original text (null/undefined treated as empty)
+ * @param {string} newText - New text (null/undefined treated as empty)
  * @returns {string} HTML string with inline diff highlighting
  */
 export function generateInlineDiff(oldText, newText) {
-  const dmp = new DiffMatchPatch();
-  const diffs = dmp.diff_main(oldText, newText);
+  const dmp = new diff_match_patch();
+  const diffs = dmp.diff_main(oldText ?? '', newText ?? '');
   dmp.diff_cleanupSemantic(diffs);
 
   return diffs

--- a/src/progressView/modules/formatters/wordDiff.js
+++ b/src/progressView/modules/formatters/wordDiff.js
@@ -1,0 +1,39 @@
+/**
+ * Word-level diff utilities using diff-match-patch.
+ * Provides clean inline highlighting for text changes.
+ */
+
+import DiffMatchPatch from 'diff-match-patch';
+import { encodeHtml } from '@common/htmlEncoding.js';
+
+const DIFF_DELETE = -1;
+const DIFF_INSERT = 1;
+const DIFF_EQUAL = 0;
+
+/**
+ * Generate inline diff HTML showing changes between old and new text.
+ * Uses Google's diff-match-patch for reliable diffing.
+ *
+ * @param {string} oldText - Original text
+ * @param {string} newText - New text
+ * @returns {string} HTML string with inline diff highlighting
+ */
+export function generateInlineDiff(oldText, newText) {
+  const dmp = new DiffMatchPatch();
+  const diffs = dmp.diff_main(oldText, newText);
+  dmp.diff_cleanupSemantic(diffs);
+
+  return diffs
+    .map(([op, text]) => {
+      const encoded = encodeHtml(text);
+      switch (op) {
+        case DIFF_DELETE:
+          return `<span class="diff-inline-del">${encoded}</span>`;
+        case DIFF_INSERT:
+          return `<span class="diff-inline-add">${encoded}</span>`;
+        default:
+          return encoded;
+      }
+    })
+    .join('');
+}

--- a/src/progressView/styles/scratchpad.css
+++ b/src/progressView/styles/scratchpad.css
@@ -130,34 +130,43 @@
   color: var(--vscode-gitDecoration-modifiedResourceForeground, #d29922);
 }
 
-/* Edit diff container - stacked old/new blocks. Colors say it all. */
+/* Edit diff container - inline word-level diff view */
 .edit-diff-container {
   display: flex;
   flex-direction: column;
-  gap: var(--spacing-small);
 }
 
-.diff-block {
+.diff-inline-view {
   margin: 0;
+  padding: var(--spacing-small);
   border-radius: var(--border-radius-small);
+  background-color: var(--vscode-editor-background, #1e1e1e);
+  white-space: pre-wrap;
+  word-break: break-word;
+  line-height: 1.5;
 }
 
-.diff-block-old {
-  border-left: 3px solid
-    var(--vscode-gitDecoration-deletedResourceForeground, #f85149);
+/* Inline diff: deleted text - red with strikethrough */
+.diff-inline-del {
   background-color: var(
     --vscode-diffEditor-removedTextBackground,
-    rgba(255, 0, 0, 0.1)
+    rgba(255, 0, 0, 0.2)
   );
+  color: var(--vscode-gitDecoration-deletedResourceForeground, #f85149);
+  text-decoration: line-through;
+  border-radius: 2px;
+  padding: 0 2px;
 }
 
-.diff-block-new {
-  border-left: 3px solid
-    var(--vscode-gitDecoration-addedResourceForeground, #3fb950);
+/* Inline diff: added text - green highlight */
+.diff-inline-add {
   background-color: var(
     --vscode-diffEditor-insertedTextBackground,
-    rgba(0, 255, 0, 0.1)
+    rgba(0, 255, 0, 0.2)
   );
+  color: var(--vscode-gitDecoration-addedResourceForeground, #3fb950);
+  border-radius: 2px;
+  padding: 0 2px;
 }
 
 /* Syntax highlighted code blocks */


### PR DESCRIPTION
Use diff-match-patch to show character-level changes inline instead of just showing old/new blocks with colored borders. Deleted text appears in red with strikethrough, added text appears in green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces inline word-level diff rendering to improve readability of text edits.
> 
> - Replace stacked diff blocks with inline highlighting via `buildEditDiffSection` using `generateInlineDiff`
> - Add `wordDiff.js` implementing `generateInlineDiff` using `diff-match-patch`; add import map entry in `index.html`
> - Update styles in `scratchpad.css` for `.diff-inline-view`, `.diff-inline-del`, and `.diff-inline-add` (backgrounds, colors, strikethrough)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b9d58b6a2bd77c5e89e17fae0ac31060a562436f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->