### PR TITLE
Enable thinking mode with token budget

### DIFF
--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -57,6 +57,7 @@ import { calculateTokenPrice } from '@agent/utils/priceUtils';
 import {
   getSdkErrorMessage,
   isContextWindowError,
+  attachStreamDiagnostics,
 } from '@common/errors/sdkErrorUtils';
 
 // Internal imports
@@ -776,6 +777,8 @@ export class ModelHandlerAnthropic extends ModelHandler<
           },
         );
 
+        // Attach diagnostics to error for retry UI display
+        attachStreamDiagnostics(streamError, diagnostics);
         throw streamError;
       } finally {
         // Always finalize stream handler to prevent memory leaks on error

--- a/src/agent/modelHandlers/support/AnthropicStreamHandler.ts
+++ b/src/agent/modelHandlers/support/AnthropicStreamHandler.ts
@@ -9,6 +9,10 @@ import {
   type WebSearchResult,
   type WebSearchResultEntry,
 } from '@agent/modelHandlers/types/ServerToolTypes';
+import {
+  StreamDiagnosticsSchema,
+  type StreamDiagnostics,
+} from '@common/errors';
 import { MESSAGE_TYPES } from '@logger/messageTypes';
 import type { AgentLogger } from '@logger/AgentLogger';
 
@@ -52,10 +56,15 @@ interface AnthropicStreamState {
   finalized: boolean;
 }
 
+// Re-export for backward compatibility (getDiagnostics return type)
+export { StreamDiagnosticsSchema as StreamDiagnosticsOutputSchema };
+export type StreamDiagnosticsOutput = StreamDiagnostics;
+
 /**
- * Base schema for diagnostic metrics (single source of truth for shared fields).
+ * Schema for internal mutable state during streaming.
+ * Uses Set/timestamp fields for efficient tracking during stream processing.
  */
-const StreamDiagnosticsBaseSchema = z.object({
+const StreamDiagnosticsStateSchema = z.object({
   /** Characters of thinking content received */
   thinkingChars: z.number(),
   /** Characters of text content received */
@@ -66,34 +75,6 @@ const StreamDiagnosticsBaseSchema = z.object({
   eventsProcessed: z.number(),
   /** Last event type (e.g., 'content_block_delta') */
   lastEventType: z.string().nullable(),
-});
-
-/**
- * Schema for diagnostic output when debugging stream failures.
- * Extends base with serializable computed fields.
- */
-export const StreamDiagnosticsOutputSchema = StreamDiagnosticsBaseSchema.extend(
-  {
-    /** Block types seen (e.g., ['thinking', 'text']) */
-    blockTypesSeen: z.array(z.string()),
-    /** Seconds since stream started */
-    elapsedSecs: z.number(),
-    /** Seconds since last event (stall detection) */
-    secsSinceLastEvent: z.number(),
-    /** Whether handler was finalized */
-    finalized: z.boolean(),
-  },
-);
-
-export type StreamDiagnosticsOutput = z.infer<
-  typeof StreamDiagnosticsOutputSchema
->;
-
-/**
- * Schema for internal mutable state during streaming.
- * Extends base with Set/timestamp fields for efficient tracking.
- */
-const StreamDiagnosticsStateSchema = StreamDiagnosticsBaseSchema.extend({
   /** Block types seen during streaming */
   blockTypesSeen: z.instanceof(Set<string>),
   /** Timestamp when streaming started */

--- a/src/common/errors/index.ts
+++ b/src/common/errors/index.ts
@@ -20,11 +20,13 @@ export {
   ErrorContextSchema,
   ProviderErrorPartialSchema,
   RetryErrorInfoSchema,
+  StreamDiagnosticsSchema,
   type ProviderError,
   type ErrorLogData,
   type ErrorContext,
   type ProviderErrorPartial,
   type RetryErrorInfo,
+  type StreamDiagnostics,
 } from './schemas';
 
 // Error utility functions
@@ -34,4 +36,5 @@ export {
   isContextWindowError,
   isPreviousResponseIdError,
   buildErrorLogData,
+  attachStreamDiagnostics,
 } from './sdkErrorUtils';

--- a/src/common/errors/schemas.ts
+++ b/src/common/errors/schemas.ts
@@ -25,6 +25,33 @@ import { z } from 'zod';
  * - Retry request UI (errorDetails)
  * - Progress view error display
  */
+/**
+ * Stream diagnostics for debugging Anthropic streaming failures.
+ * Shows what was received before the stream errored.
+ */
+export const StreamDiagnosticsSchema = z.object({
+  /** Characters of thinking content received */
+  thinkingChars: z.number(),
+  /** Characters of text content received */
+  textChars: z.number(),
+  /** Characters of tool input JSON received */
+  toolInputChars: z.number(),
+  /** Block types seen (e.g., ['thinking', 'text']) */
+  blockTypesSeen: z.array(z.string()),
+  /** Total events processed */
+  eventsProcessed: z.number(),
+  /** Last event type (e.g., 'content_block_delta') */
+  lastEventType: z.string().nullable(),
+  /** Seconds since stream started */
+  elapsedSecs: z.number(),
+  /** Seconds since last event (stall detection) */
+  secsSinceLastEvent: z.number(),
+  /** Whether handler was finalized */
+  finalized: z.boolean(),
+});
+
+export type StreamDiagnostics = z.infer<typeof StreamDiagnosticsSchema>;
+
 export const ProviderErrorSchema = z.object({
   /** Human-readable error message (includes HTTP prefix when applicable) */
   message: z.string(),
@@ -50,6 +77,11 @@ export const ProviderErrorSchema = z.object({
   requestId: z.string().optional(),
   /** Raw error body from provider API response */
   rawErrorBody: z.unknown().optional(),
+  /**
+   * Stream diagnostics for Anthropic streaming failures.
+   * Shows what was received before the stream errored (thinking chars, text chars, etc.)
+   */
+  streamDiagnostics: StreamDiagnosticsSchema.optional(),
 });
 
 /** Core error details from a provider/SDK */

--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -39,6 +39,7 @@ import {
   type ProviderError,
   type ErrorLogData,
   type ErrorContext,
+  type StreamDiagnostics,
 } from './schemas';
 
 /** Get reason phrase, returning undefined for unknown codes (getReasonPhrase throws). */
@@ -345,6 +346,54 @@ function detectRawErrorBody(err: unknown): unknown {
   );
 }
 
+// ============================================================================
+// Stream Diagnostics (Anthropic-specific)
+// ============================================================================
+
+/**
+ * Symbol key for attaching stream diagnostics to errors.
+ * Using a symbol prevents property name collisions and keeps it internal.
+ */
+const STREAM_DIAGNOSTICS_KEY = Symbol.for('texra.streamDiagnostics');
+
+/**
+ * Attaches stream diagnostics to an error before throwing.
+ * Call this in the catch block before rethrowing stream errors.
+ *
+ * @example
+ * ```ts
+ * catch (streamError) {
+ *   const diagnostics = streamHandler.getDiagnostics();
+ *   attachStreamDiagnostics(streamError, diagnostics);
+ *   throw streamError;
+ * }
+ * ```
+ */
+export function attachStreamDiagnostics(
+  err: unknown,
+  diagnostics: StreamDiagnostics,
+): void {
+  if (isObject(err)) {
+    (err as Record<symbol, unknown>)[STREAM_DIAGNOSTICS_KEY] = diagnostics;
+  }
+}
+
+/**
+ * Extracts stream diagnostics from an error object.
+ * Returns undefined if no diagnostics are attached.
+ */
+function detectStreamDiagnostics(err: unknown): StreamDiagnostics | undefined {
+  if (!isObject(err)) {
+    return undefined;
+  }
+  const diagnostics = (err as Record<symbol, unknown>)[STREAM_DIAGNOSTICS_KEY];
+  // Basic type check - diagnostics should be an object with expected fields
+  if (isObject(diagnostics) && 'eventsProcessed' in diagnostics) {
+    return diagnostics as StreamDiagnostics;
+  }
+  return undefined;
+}
+
 /**
  * Anthropic error type strings (no dedicated SDK classes for these).
  * @see https://docs.anthropic.com/en/api/errors
@@ -394,6 +443,8 @@ function determineRetryable(
 export function formatProviderHttpError(err: unknown): ProviderError {
   // Extract raw error body for all paths - useful for debugging relay errors
   const rawErrorBody = detectRawErrorBody(err);
+  // Extract stream diagnostics if attached (Anthropic streaming errors)
+  const streamDiagnostics = detectStreamDiagnostics(err);
 
   // Detect DOMException AbortError (from AbortController.abort())
   // This covers providers without SDK-specific abort error classes (e.g., Google)
@@ -403,6 +454,7 @@ export function formatProviderHttpError(err: unknown): ProviderError {
       retryable: false,
       isRelayError: false,
       rawErrorBody,
+      streamDiagnostics,
     };
   }
 
@@ -414,7 +466,13 @@ export function formatProviderHttpError(err: unknown): ProviderError {
     const retryable =
       determineRetryable(err, sdkMatch.statusCode, rawErrorBody) ||
       sdkMatch.retryable;
-    return { ...sdkMatch, retryable, isRelayError: isRelay, rawErrorBody };
+    return {
+      ...sdkMatch,
+      retryable,
+      isRelayError: isRelay,
+      rawErrorBody,
+      streamDiagnostics,
+    };
   }
 
   // Fallback for unrecognized errors
@@ -442,6 +500,7 @@ export function formatProviderHttpError(err: unknown): ProviderError {
       isRelayError: isRelay,
       requestId,
       rawErrorBody,
+      streamDiagnostics,
     };
   }
 
@@ -455,6 +514,7 @@ export function formatProviderHttpError(err: unknown): ProviderError {
     isRelayError: isRelay,
     requestId,
     rawErrorBody,
+    streamDiagnostics,
   };
 }
 

--- a/src/progressView/modules/uiManagers/RetryRequests.js
+++ b/src/progressView/modules/uiManagers/RetryRequests.js
@@ -138,6 +138,21 @@ export class RetryRequests extends BaseUIRequestManager {
         `rawErrorBody: ${formatBody(details.rawErrorBody)}`,
     ].filter(Boolean);
 
+    // Add stream diagnostics if present (Anthropic streaming errors)
+    if (details.streamDiagnostics) {
+      const diag = details.streamDiagnostics;
+      lines.push('--- Stream Diagnostics ---');
+      lines.push(`  thinkingChars: ${diag.thinkingChars}`);
+      lines.push(`  textChars: ${diag.textChars}`);
+      lines.push(`  toolInputChars: ${diag.toolInputChars}`);
+      lines.push(`  blockTypesSeen: [${diag.blockTypesSeen?.join(', ') || ''}]`);
+      lines.push(`  eventsProcessed: ${diag.eventsProcessed}`);
+      lines.push(`  lastEventType: ${diag.lastEventType ?? 'null'}`);
+      lines.push(`  elapsedSecs: ${diag.elapsedSecs}`);
+      lines.push(`  secsSinceLastEvent: ${diag.secsSinceLastEvent}`);
+      lines.push(`  finalized: ${diag.finalized}`);
+    }
+
     return lines.length > 0 ? lines.join('\n') : null;
   }
 


### PR DESCRIPTION
Previously, when Anthropic streaming failed with errors like "stream ended without producing a Message with role=assistant", the stream diagnostics (thinking chars received, events processed, etc.) were only logged but not shown in the retry UI's Details panel.

Changes:
- Add StreamDiagnostics schema to ProviderError (optional field)
- Add attachStreamDiagnostics() to attach diagnostics to errors before throwing
- Update formatProviderHttpError() to extract diagnostics from error objects
- Update Anthropic model handler to attach diagnostics before rethrowing
- Update retry UI to display stream diagnostics in expandable Details section

Now when streaming fails, the Details panel shows:
- Standard error fields (message, retryable, isRelayError, etc.)
- Stream diagnostics section with thinkingChars, textChars, toolInputChars, blockTypesSeen, eventsProcessed, lastEventType, elapsedSecs, etc.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves visibility into Anthropic streaming failures by propagating diagnostics from the stream handler to the UI.
> 
> - Adds `StreamDiagnosticsSchema` and `type StreamDiagnostics`; extends `ProviderError` with optional `streamDiagnostics` (in `schemas.ts`, exported via `common/errors/index.ts`)
> - Introduces `attachStreamDiagnostics()` and detection in `formatProviderHttpError()` to include diagnostics in formatted errors (symbol-based attach/extract)
> - `ModelHandlerAnthropic`: on streaming failure, attaches `streamDiagnostics` before rethrow; ensures handler finalized
> - `AnthropicStreamHandler`: aligns diagnostics output with shared schema; re-exports for back-compat
> - Retry UI (`RetryRequests.js`): renders a "Stream Diagnostics" section (thinking/text/tool chars, block types, event counts, timings, finalized) in error details
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 98cd8b3b678a89a08af5743fec9c8a3b23784ac9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->