### PR TITLE
fix: disable multiple outputs when agent lacks _multiple variant

### DIFF
--- a/src/agent/output/OutputHandler.ts
+++ b/src/agent/output/OutputHandler.ts
@@ -461,7 +461,11 @@ export class OutputHandler implements IOutputHandler {
         data.rawOutput ??= outputLocation;
         const rawLocation = data.rawOutput;
 
+        // Route to multiple outputs only when explicitly enabled AND files are specified.
+        // This ensures agents without _multiple variants use single output processing
+        // even if output files were specified in the config.
         if (
+          this.agentConfig.useMultipleOutputs &&
           Array.isArray(this.agentConfig.outputFiles) &&
           this.agentConfig.outputFiles.length > 0
         ) {

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -44,6 +44,7 @@ import {
 } from '@agent/core/AgentConfig';
 import {
   AgentCategory,
+  isWorkflowSetting,
   type AgentSetting,
   type AgentPrompt,
   type AgentWorkflowSetting,
@@ -243,8 +244,20 @@ async function resolveAgentBase(
 
   // 2. Validate and create model handler
   await validateAndGetModelConfig(fullConfig.model);
+
+  // Only enable multiple outputs if:
+  // 1. User requested it (fullConfig.useMultipleOutputs)
+  // 2. The loaded agent actually supports it (isMultipleOutput in settings)
+  // This handles both local agents (where _multiple variant may not exist)
+  // and remote agents (where fallback happens inside RemoteAgentLoader)
+  const agentSupportsMultiple =
+    isWorkflowSetting(setting) && setting.isMultipleOutput;
+  const useMultipleOutputs =
+    fullConfig.useMultipleOutputs && agentSupportsMultiple;
+
   const config: AgentConfig = {
     ...fullConfig,
+    useMultipleOutputs,
     agentCategory: setting.agentCategory,
   };
   const modelHandler = createModelHandler(MODEL_CONFIGS[fullConfig.model]);
@@ -280,7 +293,7 @@ async function resolveAgentBase(
     stream: streamId,
     agentCategory: setting.agentCategory,
     isRemote: isRemoteAgent(fullConfig.agent),
-    hasMultipleOutputs: fullConfig.useMultipleOutputs,
+    hasMultipleOutputs: config.useMultipleOutputs,
   });
 
   // 5. Define mutable storage key with callbacks
@@ -552,12 +565,21 @@ export async function executeAgent(
   const { setting, streamId: streamTabId, config } = ctx;
   const agentName = config.agent;
 
-  // Verify stream IDs match (paranoid check for ID computation consistency)
+  // Handle stream ID mismatch when useMultipleOutputs was corrected based on agent support.
+  // Release the preliminary stream and acquire the correct one.
   if (streamTabId !== preliminaryStreamId) {
-    logger.warn(
-      `Stream ID mismatch: preliminary=${preliminaryStreamId}, resolved=${streamTabId}. ` +
-        'This may indicate a bug in stream ID computation.',
+    logger.debug(
+      `Stream ID changed: preliminary=${preliminaryStreamId}, resolved=${streamTabId}. ` +
+        'Corrected useMultipleOutputs based on agent support.',
     );
+    StreamStatusService.releaseIfInitializing(preliminaryStreamId);
+    try {
+      acquireStreamOrThrow(streamTabId);
+    } catch (err) {
+      // Clean up runStage if reacquisition fails (resolved stream already in use)
+      ctx.runStage.end(END_GROUP_STATUS.ERROR);
+      throw err;
+    }
   }
 
   await runFlowWithLifecycle(ctx, streamTabId, agentName, async () => {

--- a/src/commands/housekeeping/cleanCommands.ts
+++ b/src/commands/housekeeping/cleanCommands.ts
@@ -41,7 +41,7 @@ const CleanConfigSchema = z
   })
   .transform((c) => ({
     ...c,
-    useMultipleOutputs: c.useMultipleOutputs ?? c.outputFiles.length > 1,
+    useMultipleOutputs: c.useMultipleOutputs ?? c.outputFiles.length > 0,
   }));
 
 // --- Helpers ---

--- a/src/commands/housekeeping/packCommands.ts
+++ b/src/commands/housekeeping/packCommands.ts
@@ -37,7 +37,7 @@ const PackConfigSchema = z
   })
   .transform((c) => ({
     ...c,
-    useMultipleOutputs: c.useMultipleOutputs ?? c.outputFiles.length > 1,
+    useMultipleOutputs: c.useMultipleOutputs ?? c.outputFiles.length > 0,
   }));
 
 /** For packMultiple - inputFile optional if outputFiles provided */


### PR DESCRIPTION
When useMultipleOutputs=true but the agent doesn't support multiple
outputs, the system would:
1. Fall back to base agent (with single-output prompts)
2. Still route to processMultipleOutputs (expecting <document name="...">)
3. Fail extraction because formats don't match

This fix:
- Checks the loaded agent's isMultipleOutput setting directly
- Only enables useMultipleOutputs if both user requested AND agent supports it
- Works for both local and remote agents (remote fallback happens in loader)
- Adds check in OutputHandler to require both flags for multiple processing

This ensures agents without _multiple variants correctly use the single
output extraction path that matches their prompts and documentTag.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Purpose**
> Ensure multi-output processing only occurs when the agent supports it, preventing extraction failures.
> 
> - Validate agent capability (`isMultipleOutput`) and set `config.useMultipleOutputs` accordingly; emit `hasMultipleOutputs` based on resolved config
> - In `OutputHandler`, route to `processMultipleOutputs` only when `useMultipleOutputs` is true and `outputFiles` are specified; otherwise use single-output processing
> - Handle stream ID changes caused by corrected `useMultipleOutputs`: release preliminary stream and reacquire the resolved one
> - Update `clean` and `pack` command schemas to infer `useMultipleOutputs` when `outputFiles.length > 0`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5ce6d07961e699a1ea75089d2f5199ea5d2c0d2b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->