### PR TITLE
fix: correct edit_file field names in tool formatter and add missing tool icons

### DIFF
--- a/src/progressView/modules/formatters/constants.js
+++ b/src/progressView/modules/formatters/constants.js
@@ -101,4 +101,23 @@ export const TOOL_ICON_MAP = {
 
   // Memory
   memory: 'codicon-database',
+
+  // Zotero
+  zotero_add: 'codicon-library',
+  zotero_search: 'codicon-library',
+  zotero_export: 'codicon-library',
+
+  // Lean 4
+  lean_diagnostics: 'codicon-warning',
+  lean_file: 'codicon-file-code',
+  lean_project: 'codicon-folder-library',
+  lean_inspect: 'codicon-inspect',
+  lean_loogle: 'codicon-search',
+
+  // Workflow/delegation
+  propose_workflow: 'codicon-list-tree',
+  propose_agent: 'codicon-account',
+
+  // History
+  runs: 'codicon-history',
 };

--- a/src/progressView/modules/formatters/logFormatters/toolFormatters.js
+++ b/src/progressView/modules/formatters/logFormatters/toolFormatters.js
@@ -144,10 +144,11 @@ export function formatToolUse(normalizedPayload, logId, groupId, timestamp) {
     typeof input === 'object' && input !== null ? input.path : '';
 
   // Handle edit tools with diff display for input
+  // Note: edit_file uses old_str/new_str field names
   if (
     TOOLS_WITH_DIFF_INPUT.has(toolName) &&
-    input?.old_string &&
-    input?.new_string
+    input?.old_str &&
+    input?.new_str
   ) {
     if (filePath) {
       sections.push(
@@ -157,7 +158,7 @@ export function formatToolUse(normalizedPayload, logId, groupId, timestamp) {
     sections.push(
       buildToolUseSection(
         'Changes:',
-        buildEditDiffSection(input.old_string, input.new_string),
+        buildEditDiffSection(input.old_str, input.new_str),
       ),
     );
   }

--- a/src/progressView/modules/formatters/logFormatters/toolFormatters.js
+++ b/src/progressView/modules/formatters/logFormatters/toolFormatters.js
@@ -145,10 +145,11 @@ export function formatToolUse(normalizedPayload, logId, groupId, timestamp) {
 
   // Handle edit tools with diff display for input
   // Note: edit_file uses old_str/new_str field names
+  // old_str must be non-empty, but new_str can be empty (deletion operation)
   if (
     TOOLS_WITH_DIFF_INPUT.has(toolName) &&
     input?.old_str &&
-    input?.new_str
+    typeof input?.new_str === 'string'
   ) {
     if (filePath) {
       sections.push(


### PR DESCRIPTION
- Fix edit_file diff display: use old_str/new_str (actual field names) instead
  of old_string/new_string
- Add icons for Zotero tools (zotero_add/search/export)
- Add icons for Lean 4 tools (lean_diagnostics/file/project/inspect/loogle)
- Add icons for workflow tools (propose_workflow/propose_agent)
- Add icon for runs tool

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Fix edit diff input handling**
> 
> - `edit_file` formatter now uses `old_str`/`new_str` (instead of `old_string`/`new_string`) and accepts empty `new_str` to represent deletions
> 
> **Add missing tool icons**
> 
> - Zotero: `zotero_add`, `zotero_search`, `zotero_export`
> - Lean 4: `lean_diagnostics`, `lean_file`, `lean_project`, `lean_inspect`, `lean_loogle`
> - Workflow/delegation: `propose_workflow`, `propose_agent`
> - History: `runs`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e0a455d61d297b023c160394f024a8cfa06a9b19. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->