### PR TITLE
feat: add size limit for tool result text to prevent context overflow

### DIFF
--- a/src/agent/modelHandlers/contextManagementConstants.ts
+++ b/src/agent/modelHandlers/contextManagementConstants.ts
@@ -34,6 +34,13 @@ export const TOKEN_SAFETY_BUFFER = 10;
 export const HEURISTIC_TOKEN_BUFFER = 5000;
 
 /**
+ * Maximum character length for tool result text sent to models.
+ * Tool results exceeding this limit return an error to prevent context window overflow.
+ * Set to 200KB (200,000 characters) which is roughly 50,000-66,000 tokens depending on content.
+ */
+export const MAX_TOOL_RESULT_TEXT_LENGTH = 200_000;
+
+/**
  * Compute reduced max tokens when context pressure requires adjustment.
  * Ensures minimum completion tokens while respecting available space.
  *

--- a/src/agent/modelHandlers/utils/toolAttachmentUtils.ts
+++ b/src/agent/modelHandlers/utils/toolAttachmentUtils.ts
@@ -13,6 +13,9 @@ import {
   DIAGNOSTIC_TYPE_VALIDATION_ERROR,
 } from '@tools/result';
 
+// Local imports - model handlers
+import { MAX_TOOL_RESULT_TEXT_LENGTH } from '../contextManagementConstants';
+
 // Local imports - utils
 import { isNonEmptyString } from '@utils/core';
 import { WorkspaceFS } from '@utils/files';
@@ -232,8 +235,33 @@ export async function loadAttachmentBuffer(
 }
 
 /**
+ * Check if tool result text exceeds the maximum allowed length.
+ * Returns an error message if exceeded, otherwise returns null.
+ *
+ * @param text - The text to check
+ * @param maxLength - Maximum allowed length (default: MAX_TOOL_RESULT_TEXT_LENGTH)
+ * @returns Error message if limit exceeded, null otherwise
+ */
+export function checkToolResultTextLimit(
+  text: string,
+  maxLength: number = MAX_TOOL_RESULT_TEXT_LENGTH,
+): string | null {
+  if (text.length <= maxLength) {
+    return null;
+  }
+
+  const exceededBy = text.length - maxLength;
+  return (
+    `Tool result too large: ${text.length.toLocaleString()} characters ` +
+    `(limit: ${maxLength.toLocaleString()}, exceeded by ${exceededBy.toLocaleString()}). ` +
+    `The output was not included to prevent context window overflow.`
+  );
+}
+
+/**
  * Format tool result as plain text for sending to models.
  * Extracts only actionable fields - avoids JSON serialization to save tokens.
+ * Truncates output if it exceeds MAX_TOOL_RESULT_TEXT_LENGTH to prevent context overflow.
  *
  * Priority order:
  * 1. output (primary result content)
@@ -243,7 +271,7 @@ export async function loadAttachmentBuffer(
  *
  * @param result - The tool result payload
  * @param attachmentSummary - Optional attachment summary to append
- * @returns Formatted plain text string
+ * @returns Formatted plain text string (truncated if exceeds limit)
  */
 export function formatToolResultAsText(
   result: ToolResultPayload,
@@ -278,5 +306,13 @@ export function formatToolResultAsText(
 
   // 'OK' fallback is defensive - only triggers if tool sets no output, summary,
   // error, userInstruction, or attachmentSummary. All current tools set at least summary.
-  return textPieces.join('\n\n') || 'OK';
+  const combined = textPieces.join('\n\n') || 'OK';
+
+  // Check if result exceeds maximum length - return error message if so
+  const limitError = checkToolResultTextLimit(combined);
+  if (limitError) {
+    return limitError;
+  }
+
+  return combined;
 }

--- a/src/test/agent/modelHandlers/utils/toolAttachmentUtils.test.ts
+++ b/src/test/agent/modelHandlers/utils/toolAttachmentUtils.test.ts
@@ -1,0 +1,97 @@
+// Third-party imports
+import { strict as assert } from 'assert';
+
+// Local imports - utils
+import {
+  checkToolResultTextLimit,
+  formatToolResultAsText,
+} from '@agent/modelHandlers/utils/toolAttachmentUtils';
+import { MAX_TOOL_RESULT_TEXT_LENGTH } from '@agent/modelHandlers/contextManagementConstants';
+
+describe('checkToolResultTextLimit', () => {
+  it('returns null for text within limit', () => {
+    const text = 'a'.repeat(1000);
+    assert.equal(checkToolResultTextLimit(text), null);
+  });
+
+  it('returns null for text exactly at limit', () => {
+    const text = 'a'.repeat(MAX_TOOL_RESULT_TEXT_LENGTH);
+    assert.equal(checkToolResultTextLimit(text), null);
+  });
+
+  it('returns error message for text exceeding limit', () => {
+    const text = 'a'.repeat(MAX_TOOL_RESULT_TEXT_LENGTH + 100);
+    const result = checkToolResultTextLimit(text);
+    assert.ok(result !== null);
+    assert.ok(result.includes('Tool result too large'));
+    assert.ok(result.includes('exceeded by'));
+  });
+
+  it('respects custom max length', () => {
+    const text = 'a'.repeat(150);
+    assert.equal(checkToolResultTextLimit(text, 200), null);
+    const error = checkToolResultTextLimit(text, 100);
+    assert.ok(error !== null);
+    assert.ok(error.includes('exceeded by 50'));
+  });
+});
+
+describe('formatToolResultAsText', () => {
+  it('returns output when present', () => {
+    const result = formatToolResultAsText({ output: 'test output' });
+    assert.equal(result, 'test output');
+  });
+
+  it('returns summary when no output', () => {
+    const result = formatToolResultAsText({ summary: 'test summary' });
+    assert.equal(result, 'test summary');
+  });
+
+  it('returns error when no output', () => {
+    const result = formatToolResultAsText({ error: 'test error' });
+    assert.equal(result, 'test error');
+  });
+
+  it('returns OK when all fields empty', () => {
+    const result = formatToolResultAsText({});
+    assert.equal(result, 'OK');
+  });
+
+  it('includes user feedback', () => {
+    const result = formatToolResultAsText({
+      output: 'test',
+      userInstruction: 'do this instead',
+    });
+    assert.ok(result.includes('User feedback: do this instead'));
+  });
+
+  it('includes user patch', () => {
+    const result = formatToolResultAsText({
+      output: 'test',
+      userPatch: '+added line',
+    });
+    assert.ok(result.includes('User modifications:'));
+    assert.ok(result.includes('+added line'));
+  });
+
+  it('appends attachment summary', () => {
+    const result = formatToolResultAsText(
+      { output: 'test' },
+      'Attachments: file.pdf',
+    );
+    assert.ok(result.includes('Attachments: file.pdf'));
+  });
+
+  it('returns error when result exceeds limit', () => {
+    const largeOutput = 'a'.repeat(MAX_TOOL_RESULT_TEXT_LENGTH + 100);
+    const result = formatToolResultAsText({ output: largeOutput });
+    assert.ok(result.includes('Tool result too large'));
+    assert.ok(!result.includes('aaa')); // Should not contain original content
+  });
+
+  it('returns normal result when within limit', () => {
+    const normalOutput = 'a'.repeat(1000);
+    const result = formatToolResultAsText({ output: normalOutput });
+    assert.equal(result, normalOutput);
+  });
+});


### PR DESCRIPTION
Tool results that exceed 100,000 characters (MAX_TOOL_RESULT_TEXT_LENGTH)
now return an error message instead of being sent to the model, preventing
context window overflow from excessively large outputs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Imposes a hard cap on tool result text to prevent context window overflow and adds tests.
> 
> - Adds `MAX_TOOL_RESULT_TEXT_LENGTH` (200,000 chars) in `contextManagementConstants`
> - Introduces `checkToolResultTextLimit` and updates `formatToolResultAsText` to return a concise error when output exceeds the limit
> - Minor utils wiring; comprehensive unit tests for limit checking and formatting behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 298eca1d0c026854a27b1e81f4635ebb1edbaa04. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->