### PR TITLE
refactor: simplify code patterns across multiple files

### DIFF
--- a/src/agent/core/AgentConfig.ts
+++ b/src/agent/core/AgentConfig.ts
@@ -123,7 +123,7 @@ export const liftLegacyAgentCategory = (input: unknown): unknown => {
   // Note: The `session` field is left in place but is ignored by the schema.
   // AgentConfigFieldsSchema uses z.object() which strips unknown fields.
   const session = obj.session as Record<string, unknown> | undefined;
-  if (session && typeof session === 'object' && 'agentCategory' in session) {
+  if (session && 'agentCategory' in session) {
     return { ...obj, agentCategory: session.agentCategory };
   }
 

--- a/src/agent/core/AgentDataclass.ts
+++ b/src/agent/core/AgentDataclass.ts
@@ -203,11 +203,11 @@ export function hasEndTag(
   settings: AgentSetting,
   fileContent: string,
 ): boolean {
-  const endTagLists = [
-    settings.endTag,
-    settings.documentTag && `</${settings.documentTag}>`,
-  ];
-  return endTagLists.some((tag) => tag && fileContent.includes(tag));
+  if (settings.endTag && fileContent.includes(settings.endTag)) {
+    return true;
+  }
+  const closingTag = settings.documentTag && `</${settings.documentTag}>`;
+  return Boolean(closingTag && fileContent.includes(closingTag));
 }
 
 /** Zod schema for AgentPrompt validation */

--- a/src/agent/implementations/flows/reflection/runReflectionFlow.ts
+++ b/src/agent/implementations/flows/reflection/runReflectionFlow.ts
@@ -140,16 +140,14 @@ function computeTotalRounds(
   setting: AgentWorkflowSetting,
   prompt: RunReflectionFlowInput['prompt'],
 ): number {
-  let requests: string[];
-  if (Array.isArray(prompt.userRequest)) {
-    requests = prompt.userRequest;
-  } else if (prompt.userRequest) {
-    requests = [prompt.userRequest];
-  } else {
-    requests = [];
+  const { userRequest } = prompt;
+  let requestCount = 0;
+  if (Array.isArray(userRequest)) {
+    requestCount = userRequest.length;
+  } else if (userRequest) {
+    requestCount = 1;
   }
-
-  return Math.max(setting.rounds ?? 2, requests.length);
+  return Math.max(setting.rounds ?? 2, requestCount);
 }
 
 /** Derive configuration values from settings and prompts. */

--- a/src/agent/index/agentRegistry.ts
+++ b/src/agent/index/agentRegistry.ts
@@ -392,11 +392,11 @@ async function scanYaml(
 
     // Extract tool names (can be strings or objects with name field)
     const rawTools = rawSettings.tools as unknown[] | undefined;
-    const tools = rawTools
-      ?.map((t) =>
-        typeof t === 'string' ? t : ((t as { name?: string })?.name ?? null),
-      )
-      .filter((t): t is string => t !== null);
+    const tools = rawTools?.flatMap((t) => {
+      if (typeof t === 'string') return t;
+      const name = (t as Record<string, unknown>)?.name;
+      return typeof name === 'string' ? name : [];
+    });
 
     // Determine category from source or explicit setting
     // Backward compatibility: check both agentCategory and legacy agentType

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -370,50 +370,34 @@ export abstract class ModelHandler<
     return this.isProvider(ModelProvider.DEEPSEEK);
   }
 
+  /** Provider to config suffix mapping for streaming settings */
+  private static readonly PROVIDER_STREAMING_SUFFIX: Record<ModelProvider, string> = {
+    [ModelProvider.ANTHROPIC]: 'Anthropic',
+    [ModelProvider.OPENAI]: 'Openai',
+    [ModelProvider.GOOGLE]: 'Google',
+    [ModelProvider.DEEPSEEK]: 'Deepseek',
+    [ModelProvider.MOONSHOT]: 'Moonshot',
+    [ModelProvider.DASHSCOPE]: 'Dashscope',
+    [ModelProvider.COPILOT]: 'Copilot',
+    [ModelProvider.XAI]: 'Xai',
+    [ModelProvider.OTHERS]: '',
+  };
+
   /**
    * Gets streaming configuration for the current model provider
    * @returns Boolean indicating if streaming should be enabled
    */
   public getStreamingConfig(): boolean {
-    const useStreamingGlobal = getConfig<boolean>(
-      'texra.model.useStreaming',
-      false,
-    );
+    const globalDefault = getConfig<boolean>('texra.model.useStreaming', false);
 
-    // For OpenRouter models, use dedicated setting
-    if (
-      this.config.openRouterOnly ||
-      getConfig<boolean>('texra.model.useOpenRouter', false)
-    ) {
-      return getConfig<boolean>(
-        'texra.model.useStreamingOpenrouter',
-        useStreamingGlobal,
-      );
+    if (this.config.openRouterOnly || getConfig<boolean>('texra.model.useOpenRouter', false)) {
+      return getConfig<boolean>('texra.model.useStreamingOpenrouter', globalDefault);
     }
 
-    // Map ModelProvider enum to configuration key suffix
-    const providerConfigMap: Record<ModelProvider, string> = {
-      [ModelProvider.ANTHROPIC]: 'Anthropic',
-      [ModelProvider.OPENAI]: 'Openai',
-      [ModelProvider.GOOGLE]: 'Google',
-      [ModelProvider.DEEPSEEK]: 'Deepseek',
-      [ModelProvider.MOONSHOT]: 'Moonshot',
-      [ModelProvider.DASHSCOPE]: 'Dashscope',
-      [ModelProvider.COPILOT]: 'Copilot',
-      [ModelProvider.XAI]: 'Xai',
-      [ModelProvider.OTHERS]: '', // Will fall back to global
-    };
+    const suffix = ModelHandler.PROVIDER_STREAMING_SUFFIX[this.config.provider];
+    if (!suffix) return globalDefault;
 
-    const configSuffix = providerConfigMap[this.config.provider];
-
-    // If no mapping exists or it's the OTHERS provider, just use global setting
-    if (!configSuffix) {
-      return useStreamingGlobal;
-    }
-
-    // Build the full config key and fetch the setting
-    const configKey = `texra.model.useStreaming${configSuffix}`;
-    return getConfig<boolean>(configKey, useStreamingGlobal);
+    return getConfig<boolean>(`texra.model.useStreaming${suffix}`, globalDefault);
   }
 
   get isOReasoningModel(): boolean {
@@ -436,22 +420,13 @@ export abstract class ModelHandler<
    * @returns Valid reasoning effort string for the current provider
    */
   protected validateReasoningEffort(effort: string): string {
-    // Default implementation - return as is for most providers
-    if (this.config.provider === ModelProvider.XAI) {
-      // xAI models only support 'low' and 'high'
-      if (effort === 'low' || effort === 'high') {
-        return effort;
-      }
+    if (this.config.provider !== ModelProvider.XAI) return effort;
+    if (effort === 'low' || effort === 'high') return effort;
 
-      // Default to 'high' for other values
-      this.logger.warn(
-        `xAI models only support 'low' or 'high' reasoning effort. Converting '${effort}' to 'high'.`,
-      );
-      return 'high';
-    }
-
-    // For other providers, return effort as is
-    return effort;
+    this.logger.warn(
+      `xAI models only support 'low' or 'high' reasoning effort. Converting '${effort}' to 'high'.`,
+    );
+    return 'high';
   }
 
   /**

--- a/src/agent/output/OutputFileProcessor.ts
+++ b/src/agent/output/OutputFileProcessor.ts
@@ -138,18 +138,24 @@ export class OutputFileProcessor {
         diff: null,
       };
 
-      const hasDocumentTag = Boolean(agentSetting.documentTag);
-      const hasScratchpadPrefill =
-        agentSetting.prefills?.some((prefill) =>
-          SCRATCHPAD_TAG_PATTERN.test(prefill),
-        ) ?? false;
-
       // Determine XML processing based on xmlStructureMode setting
       const xmlMode = agentSetting.xmlStructureMode ?? 'scratchpadOnly';
-      const shouldProcessXml =
-        xmlMode === 'always' ||
-        (xmlMode === 'scratchpadOnly' &&
-          (hasDocumentTag || hasScratchpadPrefill));
+      let shouldProcessXml = false;
+      switch (xmlMode) {
+        case 'always':
+          shouldProcessXml = true;
+          break;
+        case 'scratchpadOnly': {
+          const hasDocumentTag = Boolean(agentSetting.documentTag);
+          const hasScratchpadPrefill =
+            agentSetting.prefills?.some((p) => SCRATCHPAD_TAG_PATTERN.test(p)) ??
+            false;
+          shouldProcessXml = hasDocumentTag || hasScratchpadPrefill;
+          break;
+        }
+        case 'never':
+          break;
+      }
 
       if (shouldProcessXml) {
         processed = await xmlManager.processSingleXmlOutput(

--- a/src/agent/remote/RemoteAgentLoader.ts
+++ b/src/agent/remote/RemoteAgentLoader.ts
@@ -108,20 +108,16 @@ function parseListItemRow(row: {
   visibility?: string[] | null;
   agent_category?: string | null;
 }): RemoteAgentListItem | null {
-  // Schema handles NULL -> Workflow defaulting via transform
+  const { id, name, description, visibility, agent_category } = row;
   const result = RemoteAgentListItemSchema.safeParse({
-    id: row.id,
-    name: row.name,
-    description: row.description,
-    visibility: row.visibility,
-    agentCategory: row.agent_category,
+    id,
+    name,
+    description,
+    visibility,
+    agentCategory: agent_category,
   });
-
   if (!result.success) {
-    logger.warn(
-      CHANNEL,
-      `Invalid metadata for agent "${row.name}": ${result.error.message}`,
-    );
+    logger.warn(CHANNEL, `Invalid metadata for agent "${name}": ${result.error.message}`);
     return null;
   }
   return result.data;
@@ -217,13 +213,7 @@ export class RemoteAgentLoader {
         });
 
         if (!response.ok) {
-          let errorText = 'Unknown error';
-          try {
-            errorText = await response.text();
-          } catch {
-            logger.warn(CHANNEL, 'Failed to read error response body');
-          }
-
+          const errorText = await response.text().catch(() => 'Unknown error');
           const isLastCandidate = candidateName === candidateNames.at(-1);
           const { message, shouldContinue } = mapHttpError(
             response.status,

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -440,10 +440,9 @@ async function runFlowWithLifecycle(
     const errorMsg = `Error executing agent ${agentName}: ${getSdkErrorMessage(err)}`;
 
     // Show appropriate notification based on error type
-    const isApiKeyError =
-      rawMsg.includes('Missing API key') ||
-      rawMsg.includes('API key not found');
-    if (isApiKeyError) {
+    const hasApiKeyError =
+      rawMsg.includes('Missing API key') || rawMsg.includes('API key not found');
+    if (hasApiKeyError) {
       await showApiKeyErrorNotification();
     } else {
       vscode.window.showErrorMessage(errorMsg);

--- a/src/agent/utils/UsageMonitor.ts
+++ b/src/agent/utils/UsageMonitor.ts
@@ -115,17 +115,19 @@ export class UsageMonitor {
       const totalCacheReadTokens = totals.totalCacheReadInputTokens;
       const totalCacheCreationTokens = totals.totalCacheCreationInputTokens;
 
-      const totalCacheableTokens = cachingStats
-        ? this.modelInfo.capabilities.supportsPromptCaching
+      let totalCacheableTokens = 0;
+      if (cachingStats) {
+        totalCacheableTokens = this.modelInfo.capabilities.supportsPromptCaching
           ? totalCacheCreationTokens + totalCacheReadTokens
-          : totals.totalInputTokens
-        : 0;
+          : totals.totalInputTokens;
+      }
 
-      const percentageCached = cachingStats
-        ? totalCacheableTokens > 0
-          ? (totalCacheReadTokens / totalCacheableTokens) * 100
-          : 0
-        : undefined;
+      let percentageCached: number | undefined;
+      if (cachingStats && totalCacheableTokens > 0) {
+        percentageCached = (totalCacheReadTokens / totalCacheableTokens) * 100;
+      } else if (cachingStats) {
+        percentageCached = 0;
+      }
 
       // Send per-round deltas - storage will accumulate them
       const baseStats: TokenUsageStats = {
@@ -141,20 +143,18 @@ export class UsageMonitor {
 
       const payload: ExtendedTokenUsageStats = {
         ...baseStats,
-        elapsedTime: Number(
-          (stateGlobal.totalResponseTimeMs / 1000).toFixed(1),
-        ),
-        ...(cachingStats && {
-          percentageCached: Number((percentageCached ?? 0).toFixed(2)),
-        }),
-        ...(this.modelInfo.capabilities.supportsReasoning && {
-          reasoningTokens: roundReasoningTokens,
-        }),
-        // Include tool usage if any is present
-        ...((latestUsage?.toolUsePromptTokens ?? 0) > 0 && {
-          toolUseTokens: latestUsage?.toolUsePromptTokens ?? 0,
-        }),
+        elapsedTime: Number((stateGlobal.totalResponseTimeMs / 1000).toFixed(1)),
       };
+      if (cachingStats) {
+        payload.percentageCached = Number((percentageCached ?? 0).toFixed(2));
+      }
+      if (this.modelInfo.capabilities.supportsReasoning) {
+        payload.reasoningTokens = roundReasoningTokens;
+      }
+      const toolUseTokens = latestUsage?.toolUsePromptTokens ?? 0;
+      if (toolUseTokens > 0) {
+        payload.toolUseTokens = toolUseTokens;
+      }
 
       // Get current storageKey via callback - handles mutable state correctly
       const storageKey = this.context.getStorageKey();

--- a/src/commands/git/gitCommands.ts
+++ b/src/commands/git/gitCommands.ts
@@ -38,45 +38,31 @@ function isGitRepository(): boolean {
 }
 
 function getRecentCommits(): string[] | null {
-  if (!isGitRepository()) {
+  const workspacePath = WorkspaceFS.getPath();
+  if (!workspacePath || !isGitRepository()) {
     return null;
   }
 
-  const workspacePath = WorkspaceFS.getPath();
-  if (!workspacePath) {
-    return [];
-  }
-
   const numberOfCommits = getConfig('texra.git.numberOfCommitsToShow', 20);
-
-  // Validate numberOfCommits to prevent injection
   if (
     typeof numberOfCommits !== 'number' ||
     numberOfCommits <= 0 ||
     numberOfCommits > 1000
   ) {
     throw new Error(
-      'Invalid numberOfCommits value. It must be a positive integer between 1 and 1000.',
+      'Invalid numberOfCommits value. Must be a positive integer between 1 and 1000.',
     );
   }
 
   const result = execaSync(
     'git',
-    [
-      'log',
-      '-n',
-      numberOfCommits.toString(),
-      `--pretty=format:${COMMIT_LABEL_FORMAT}`,
-    ],
+    ['log', '-n', String(numberOfCommits), `--pretty=format:${COMMIT_LABEL_FORMAT}`],
     { cwd: workspacePath, reject: false },
   );
   if (result.exitCode !== 0) {
     return [];
   }
-  return result.stdout
-    .toString()
-    .split('\n')
-    .map((line) => line.trim());
+  return result.stdout.toString().split('\n').map((line) => line.trim());
 }
 
 function findCommitInHistory(commitHash: string): string | null {

--- a/src/common/errors/errorHandlingUtils.ts
+++ b/src/common/errors/errorHandlingUtils.ts
@@ -351,14 +351,11 @@ export async function showLoggedMessageWithDocs(
 ): Promise<void> {
   logger.error(channel, message);
   const selection = await vscode.window.showErrorMessage(message, actionLabel);
-  if (selection === actionLabel) {
-    // Use try-catch to prevent uncaught errors if the command fails
-    // (e.g., during activation race conditions or if the command is not registered)
-    try {
-      await vscode.commands.executeCommand('texra.openDoc', docId);
-    } catch (err) {
-      // Log the error but don't show another error message to avoid error cascade
-      logger.error(channel, `Failed to open documentation: ${err}`);
-    }
+  if (selection !== actionLabel) return;
+
+  try {
+    await vscode.commands.executeCommand('texra.openDoc', docId);
+  } catch (err) {
+    logger.error(channel, `Failed to open documentation: ${err}`);
   }
 }

--- a/src/common/webview/BaseViewContentProvider.ts
+++ b/src/common/webview/BaseViewContentProvider.ts
@@ -111,10 +111,9 @@ export abstract class BaseViewContentProvider {
     webview: vscode.Webview,
     descriptors: readonly ModuleDescriptor[],
   ): Record<string, vscode.Uri> {
-    return descriptors.reduce<Record<string, vscode.Uri>>((acc, d) => {
-      acc[d.key] = this.getWebviewUri(webview, d.path);
-      return acc;
-    }, {});
+    return Object.fromEntries(
+      descriptors.map((d) => [d.key, this.getWebviewUri(webview, d.path)]),
+    );
   }
 
   /** URIs shared by all views */
@@ -207,11 +206,9 @@ export abstract class BaseViewContentProvider {
     descriptors: readonly ModuleDescriptor[],
     resolver: (webview: vscode.Webview, path: string) => vscode.Uri,
   ): Record<string, vscode.Uri> {
-    const uris: Record<string, vscode.Uri> = {};
-    for (const { key, path } of descriptors) {
-      uris[key] = resolver.call(this, webview, path);
-    }
-    return uris;
+    return Object.fromEntries(
+      descriptors.map(({ key, path }) => [key, resolver.call(this, webview, path)]),
+    );
   }
 
   /** Common URIs used by all views (from src/common and node_modules) */

--- a/src/progressView/managers/OutputFilesManager.ts
+++ b/src/progressView/managers/OutputFilesManager.ts
@@ -200,27 +200,22 @@ export class OutputFilesManager extends PersistentMapManager<
   ): Set<string> {
     const paths = new Set<string>();
     const runs = this.items.get(stream);
-    if (!runs) {
-      return paths;
-    }
+    if (!runs) return paths;
 
-    // storageKey is THE single source of truth
     const targetRunIds =
       options.storageKey != null ? [options.storageKey] : [...runs.keys()];
+    const workspaceOnly = options.workspaceOnly ?? false;
 
     for (const target of targetRunIds) {
       const runRounds = runs.get(target);
-      if (!runRounds) {
-        continue;
-      }
+      if (!runRounds) continue;
 
       for (const infos of runRounds.values()) {
         for (const info of infos) {
-          this.collectPaths(paths, info, options.workspaceOnly ?? false);
+          this.collectPaths(paths, info, workspaceOnly);
         }
       }
     }
-
     return paths;
   }
 
@@ -235,17 +230,16 @@ export class OutputFilesManager extends PersistentMapManager<
     info: OutputFileInfo,
     workspaceOnly: boolean,
   ): void {
-    // All locations to check: main file and lineage files
+    const { lineage } = info;
     const locations = [
       info.location,
-      info.lineage?.original,
-      info.lineage?.diffBase,
-      info.lineage?.diffFile,
+      lineage?.original,
+      lineage?.diffBase,
+      lineage?.diffFile,
     ];
 
     for (const loc of locations) {
-      if (!loc?.absolutePath) continue;
-      if (!workspaceOnly || loc.kind === 'workspace') {
+      if (loc?.absolutePath && (!workspaceOnly || loc.kind === 'workspace')) {
         target.add(loc.absolutePath);
       }
     }

--- a/src/tools/latex/ExtractBibliographyTool.ts
+++ b/src/tools/latex/ExtractBibliographyTool.ts
@@ -121,24 +121,16 @@ export class ExtractBibliographyTool extends defineTool({
       summary = `Resolved ${entryCount} bibliography ${entryWord} for ${citationCount} citation key${keyPlural} in ${display}.`;
     }
 
-    const instructions: string[] = [];
-    if (missingBibliographyFiles.length > 0) {
-      instructions.push(
+    const instructions = [
+      missingBibliographyFiles.length > 0 &&
         `Missing bibliography files: ${missingBibliographyFiles
-          .map((file) => resolveAndFormat(file).display)
+          .map((f) => resolveAndFormat(f).display)
           .join(', ')}.`,
-      );
-    }
-    if (missingKeys.length > 0) {
-      instructions.push(
-        `Missing citation keys: ${missingKeys
-          .map((key) => `\`${key}\``)
-          .join(', ')}.`,
-      );
-    }
-    if (entries.size > DEFAULT_MAX_ENTRIES) {
-      instructions.push(`Limited output to ${DEFAULT_MAX_ENTRIES} entries.`);
-    }
+      missingKeys.length > 0 &&
+        `Missing citation keys: ${missingKeys.map((k) => `\`${k}\``).join(', ')}.`,
+      entries.size > DEFAULT_MAX_ENTRIES &&
+        `Limited output to ${DEFAULT_MAX_ENTRIES} entries.`,
+    ].filter((x): x is string => Boolean(x));
 
     return {
       summary,


### PR DESCRIPTION
- hasEndTag: use early returns instead of array.some()
- computeTotalRounds: use if/else chain instead of nested ternary
- collectPaths: combine conditions with optional chaining
- buildUriRecord: use Object.fromEntries instead of reduce
- scanYaml tools: use flatMap instead of map/filter
- OutputFileProcessor XML mode: use switch statement
- RemoteAgentLoader error: use .catch() for error text
- gitCommands: consolidate workspace check, use String()
- getKnownFilePaths: extract workspaceOnly variable
- parseListItemRow: use destructuring for cleaner code

https://claude.ai/code/session_01UV7aC1zdy16S3ay9aVTUu5

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Refactor: simplify patterns and tighten utils**
> 
> - Core agents: simplify `hasEndTag`, relax legacy `agentCategory` lift, and clean `computeTotalRounds`; switch-based XML mode in `OutputFileProcessor`
> - Model handling: central provider→config suffix map for streaming; compact `validateReasoningEffort`
> - Registry/scan: extract tool names via `flatMap`; minor category logic unchanged
> - Remote agents: destructured row parsing; error text via `.catch()`; streamlined logs
> - Runtime: clearer API key error detection in `executeAgent`
> - Usage: clearer cache percentage math and payload assembly in `UsageMonitor`
> - Webview: build URI records via `Object.fromEntries`; shared resolvers simplified
> - Progress view: `OutputFilesManager` path collection and options handling streamlined
> - Git commands: consolidated repo/workspace checks; simpler args and messages
> - Errors: `showLoggedMessageWithDocs` simplified with early return/try-catch
> - LaTeX tool: concise instruction assembly for missing files/keys and entry limit
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7266dbb9f4b1c42e911245968588b124e7d5693e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->