### PR TITLE
refactor: inline single-use helper functions across codebase

### DIFF
--- a/src/agent/core/AgentConfig.ts
+++ b/src/agent/core/AgentConfig.ts
@@ -6,23 +6,6 @@ import { AgentCategory } from './AgentDataclass';
 import { DEFAULT_TOOL_CONFIG, ToolConfigSchema } from './ToolConfig';
 
 /**
- * Checks that the number of output files does not exceed the number of input files.
- * Used internally by AgentConfigSchema refinement.
- */
-export function validateOutputFiles(cfg: {
-  inputFile: string;
-  inputFiles: string[];
-  outputFiles: string[];
-}): boolean {
-  if (cfg.outputFiles.length === 0) {
-    return true;
-  }
-
-  const inputs = [cfg.inputFile, ...cfg.inputFiles];
-  return cfg.outputFiles.length <= inputs.length;
-}
-
-/**
  * Base proposal fields shared by both workflow and tool-use agent proposals.
  * Contains only the common fields that all proposal types need.
  */
@@ -137,19 +120,17 @@ export const liftLegacyAgentCategory = (input: unknown): unknown => {
 export const AgentConfigSchema = z.preprocess(
   liftLegacyAgentCategory,
   AgentConfigFieldsSchema.superRefine((config, ctx) => {
-    if (
-      !validateOutputFiles({
-        inputFile: config.inputFile,
-        inputFiles: config.inputFiles,
-        outputFiles: config.outputFiles,
-      })
-    ) {
-      ctx.addIssue({
-        code: 'custom',
-        path: ['outputFiles'],
-        message:
-          'Number of output files must not be greater than the number of input files.',
-      });
+    // Validate that output files count doesn't exceed input files count
+    if (config.outputFiles.length > 0) {
+      const inputCount = 1 + config.inputFiles.length; // inputFile + inputFiles
+      if (config.outputFiles.length > inputCount) {
+        ctx.addIssue({
+          code: 'custom',
+          path: ['outputFiles'],
+          message:
+            'Number of output files must not be greater than the number of input files.',
+        });
+      }
     }
   }),
 );

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -404,14 +404,6 @@ function acquireStreamOrThrow(
   );
 }
 
-/** Create a usage recorder callback for flow execution. */
-function createUsageRecorder(
-  usageMonitor: UsageMonitor,
-  runKind: 'workflow' | 'tool-use' = 'workflow',
-): () => RoundFinalizedCallback {
-  return () => (run) => usageMonitor.recordUsage(run, { runKind });
-}
-
 type FlowRunner = () => Promise<EndGroupStatus>;
 
 async function runFlowWithLifecycle(
@@ -621,7 +613,8 @@ export async function executeAgent(
         const result = await runToolUseFlow({
           ...ctx,
           ...interruptManager.asFlowInput(),
-          getUsageRecorder: createUsageRecorder(ctx.usageMonitor, 'tool-use'),
+          getUsageRecorder: () => (run) =>
+            ctx.usageMonitor.recordUsage(run, { runKind: 'tool-use' }),
           setting: ctx.setting as AgentToolUseSetting,
           onFollowUpConsumed: () =>
             bus.emit('updateQueuedFollowUps', { streamId: ctx.streamId }),
@@ -634,7 +627,8 @@ export async function executeAgent(
       const result = await runReflectionFlow({
         ...ctx,
         ...interruptManager.asFlowInput(),
-        getUsageRecorder: createUsageRecorder(ctx.usageMonitor, 'workflow'),
+        getUsageRecorder: () => (run) =>
+          ctx.usageMonitor.recordUsage(run, { runKind: 'workflow' }),
         setting: ctx.setting as AgentWorkflowSetting,
         parentStage: ctx.runStage,
       });
@@ -704,7 +698,8 @@ export async function executeMergeAgent(
       const result = await runReflectionFlow({
         ...ctx,
         ...interruptManager.asFlowInput(),
-        getUsageRecorder: createUsageRecorder(ctx.usageMonitor, 'workflow'),
+        getUsageRecorder: () => (run) =>
+          ctx.usageMonitor.recordUsage(run, { runKind: 'workflow' }),
         setting: ctx.setting as AgentWorkflowSetting,
         getOutputFileLocation,
         parentStage: ctx.runStage,
@@ -767,7 +762,8 @@ export async function resumeToolUseFromSnapshot(
         {
           ...ctx,
           ...interruptManager.asFlowInput(),
-          getUsageRecorder: createUsageRecorder(ctx.usageMonitor, 'tool-use'),
+          getUsageRecorder: () => (run) =>
+            ctx.usageMonitor.recordUsage(run, { runKind: 'tool-use' }),
           setting: setting as AgentToolUseSetting,
           resumeSnapshot: snapshot,
           onFollowUpConsumed: () =>

--- a/src/agent/utils/mergeFileUtils.ts
+++ b/src/agent/utils/mergeFileUtils.ts
@@ -4,16 +4,6 @@
  */
 
 /**
- * Helper to extract the last match of a pattern from text.
- */
-function extractLastMatch(
-  text: string,
-  pattern: RegExp,
-): RegExpMatchArray | null {
-  return [...text.matchAll(pattern)].at(-1) ?? null;
-}
-
-/**
  * Extracts the last _rN_ match from a filename.
  * Use this to correctly handle nested filenames where the base contains its own _rN_ pattern.
  *
@@ -27,7 +17,7 @@ function extractLastMatch(
 export function extractLastRoundMatch(
   filename: string,
 ): RegExpMatchArray | null {
-  return extractLastMatch(filename, /_r(\d+)_/g);
+  return [...filename.matchAll(/_r(\d+)_/g)].at(-1) ?? null;
 }
 
 /**
@@ -44,7 +34,7 @@ export function extractLastRoundMatch(
 export function extractLastRoundModelMatch(
   filename: string,
 ): RegExpMatchArray | null {
-  return extractLastMatch(filename, /_r(\d+)_([^_.]+)/g);
+  return [...filename.matchAll(/_r(\d+)_([^_.]+)/g)].at(-1) ?? null;
 }
 
 /**

--- a/src/commands/history/stateRestoreCommand.ts
+++ b/src/commands/history/stateRestoreCommand.ts
@@ -48,7 +48,12 @@ async function restoreState(state: TaskState, executeImmediately?: boolean) {
       return;
     }
 
-    await storeStateForLater(state, executeImmediately);
+    // Store the state in memory for the MainViewProvider to pick up
+    setPendingState(state, executeImmediately);
+    await vscode.commands.executeCommand('texra.mainView.focus');
+    logger.info(CHANNEL, 'State stored for later restoration', {
+      data: { executeImmediately },
+    });
   } catch (error) {
     await showLoggedErrorMessage(CHANNEL, 'Failed to restore state', error);
   }
@@ -57,15 +62,3 @@ async function restoreState(state: TaskState, executeImmediately?: boolean) {
 export const stateRestoreCommand = {
   restoreState,
 };
-
-async function storeStateForLater(
-  state: TaskState,
-  executeImmediately?: boolean,
-): Promise<void> {
-  // Store the state in memory for the MainViewProvider to pick up
-  setPendingState(state, executeImmediately);
-  await vscode.commands.executeCommand('texra.mainView.focus');
-  logger.info(CHANNEL, 'State stored for later restoration', {
-    data: { executeImmediately },
-  });
-}

--- a/src/commands/latex/latexdiffCommands.ts
+++ b/src/commands/latex/latexdiffCommands.ts
@@ -430,7 +430,25 @@ async function handleRunLatexdiff(
       typeof config.runId === 'string' && config.runId.length > 0
         ? config.runId
         : undefined;
-    const outputsByRound = normalizeOutputsByRound(config.outputsByRound);
+
+    // Normalize outputsByRound from raw config
+    let outputsByRound: Map<number, OutputFileInfo[]> | null = null;
+    const rawOutputsByRound = config.outputsByRound;
+    if (rawOutputsByRound && typeof rawOutputsByRound === 'object') {
+      const roundMap = new Map<number, OutputFileInfo[]>();
+      for (const [roundKey, value] of Object.entries(rawOutputsByRound)) {
+        const roundResult = RoundKeySchema.safeParse(roundKey);
+        if (roundResult.success && Array.isArray(value) && value.length > 0) {
+          roundMap.set(roundResult.data, value);
+        }
+      }
+      if (roundMap.size > 0) {
+        outputsByRound = new Map(
+          [...roundMap.entries()].sort((a, b) => a[0] - b[0]),
+        );
+      }
+    }
+
     const fileService = new TaskRunFileService(runId);
 
     const outcome = await vscode.window.withProgress(
@@ -521,47 +539,6 @@ async function handleRunLatexdiff(
   }
 }
 
-function normalizeOutputsByRound(
-  raw?: Record<string, OutputFileInfo[]> | null,
-): Map<number, OutputFileInfo[]> | null {
-  if (!raw || typeof raw !== 'object') {
-    return null;
-  }
-
-  const entries = Object.entries(raw);
-  const roundMap = new Map<number, OutputFileInfo[]>();
-
-  for (const [roundKey, value] of entries) {
-    const roundResult = RoundKeySchema.safeParse(roundKey);
-    if (!roundResult.success || !Array.isArray(value) || value.length === 0) {
-      continue;
-    }
-    roundMap.set(roundResult.data, value);
-  }
-
-  if (roundMap.size === 0) {
-    return null;
-  }
-
-  return new Map([...roundMap.entries()].sort((a, b) => a[0] - b[0]));
-}
-
-/**
- * Get file description for display - trust source field.
- */
-function describeFile(info: OutputFileInfo): string {
-  if (info.source) {
-    return info.source;
-  }
-  if (
-    info.location.kind === 'workspace' ||
-    info.location.kind === 'runStorage'
-  ) {
-    return path.basename(info.location.relativePath);
-  }
-  return path.basename(info.location.absolutePath);
-}
-
 async function runLatexdiffFromMetadata(params: {
   rounds: Map<number, OutputFileInfo[]>;
   mathMarkup?: MathMarkupOption;
@@ -570,6 +547,15 @@ async function runLatexdiffFromMetadata(params: {
   fileService: TaskRunFileService;
 }): Promise<DiffRunOutcome> {
   const { rounds, mathMarkup, generateBetweenRoundDiffs, progress } = params;
+
+  // Get file description for display - trust source field, fall back to basename
+  const getFileLabel = (info: OutputFileInfo): string => {
+    if (info.source) return info.source;
+    const loc = info.location;
+    return loc.kind === 'workspace' || loc.kind === 'runStorage'
+      ? path.basename(loc.relativePath)
+      : path.basename(loc.absolutePath);
+  };
 
   const immediateResults: DiffRunResult[] = [];
   const operations: DiffOperation[] = [];
@@ -583,7 +569,7 @@ async function runLatexdiffFromMetadata(params: {
       const revised = info.location;
       // lineage.original is already a FileLocation | null - use directly
       const base = info.lineage?.original ?? null;
-      const description = `${describeFile(info)} (r${round})`;
+      const description = `${getFileLabel(info)} (r${round})`;
 
       if (!base) {
         immediateResults.push({
@@ -626,7 +612,7 @@ async function runLatexdiffFromMetadata(params: {
         const current = group[index];
         const base = previous.info.location;
         const revised = current.info.location;
-        const description = `${describeFile(current.info)} (r${previous.round}→r${current.round})`;
+        const description = `${getFileLabel(current.info)} (r${previous.round}→r${current.round})`;
 
         operations.push({
           type: 'between-rounds',

--- a/src/commands/progress/progressViewCommands.ts
+++ b/src/commands/progress/progressViewCommands.ts
@@ -7,17 +7,6 @@ import { ProgressViewProvider } from '@progressView/ProgressViewProvider';
 
 const CHANNEL = 'progressViewCommands';
 
-function openProgressViewInTab(): void {
-  const provider = ProgressViewProvider.getInstance();
-  if (!provider) {
-    vscode.window.showErrorMessage(
-      'Progress View is not available. Please try again.',
-    );
-    return;
-  }
-  provider.showProgressViewAsPanel();
-}
-
 export function registerProgressViewCommands(
   context: vscode.ExtensionContext,
 ): void {
@@ -25,9 +14,15 @@ export function registerProgressViewCommands(
     vscode.commands.registerCommand('texra.showProgressView', () =>
       safeExecuteCommand('texra.progressView.focus', [], CHANNEL),
     ),
-    vscode.commands.registerCommand(
-      'texra.openProgressViewInTab',
-      openProgressViewInTab,
-    ),
+    vscode.commands.registerCommand('texra.openProgressViewInTab', () => {
+      const provider = ProgressViewProvider.getInstance();
+      if (!provider) {
+        vscode.window.showErrorMessage(
+          'Progress View is not available. Please try again.',
+        );
+        return;
+      }
+      provider.showProgressViewAsPanel();
+    }),
   );
 }

--- a/src/commands/system/mainViewCommands.ts
+++ b/src/commands/system/mainViewCommands.ts
@@ -19,26 +19,6 @@ export const mainViewCommands = {
 };
 
 /**
- * Log a refresh error and notify the user.
- */
-function logRefreshError(error: unknown, context: string): void {
-  const message = toErrorMessage(error);
-  logger.error(CHANNEL, `Failed to ${context}: ${message}`);
-  vscode.window.showErrorMessage(`Failed to ${context}: ${message}`);
-}
-
-/**
- * Post options to webview. Synchronous since we don't handle postMessage result.
- */
-function postOptionsToWebview(
-  webview: vscode.WebviewView,
-  command: string,
-  options: unknown,
-): void {
-  webview.webview.postMessage({ command, options });
-}
-
-/**
  * Registers main view commands for the extension
  * @param context - The VS Code extension context
  * @returns Object containing the registered commands
@@ -73,13 +53,16 @@ export function registerMainViewCommands(context: vscode.ExtensionContext) {
 
       try {
         const options = await computeModelOptions();
-        postOptionsToWebview(
-          webview,
-          MAIN_VIEW_COMMANDS.SET_MODEL_OPTIONS,
+        webview.webview.postMessage({
+          command: MAIN_VIEW_COMMANDS.SET_MODEL_OPTIONS,
           options,
-        );
+        });
       } catch (error) {
-        logRefreshError(error, 'refresh model options');
+        const message = toErrorMessage(error);
+        logger.error(CHANNEL, `Failed to refresh model options: ${message}`);
+        vscode.window.showErrorMessage(
+          `Failed to refresh model options: ${message}`,
+        );
       }
     },
   );
@@ -96,13 +79,16 @@ export function registerMainViewCommands(context: vscode.ExtensionContext) {
       try {
         await refresh();
         const options = await computeAgentOptions();
-        postOptionsToWebview(
-          webview,
-          MAIN_VIEW_COMMANDS.SET_AGENT_OPTIONS,
+        webview.webview.postMessage({
+          command: MAIN_VIEW_COMMANDS.SET_AGENT_OPTIONS,
           options,
-        );
+        });
       } catch (error) {
-        logRefreshError(error, 'refresh agent options');
+        const message = toErrorMessage(error);
+        logger.error(CHANNEL, `Failed to refresh agent options: ${message}`);
+        vscode.window.showErrorMessage(
+          `Failed to refresh agent options: ${message}`,
+        );
       }
     },
   );
@@ -123,18 +109,18 @@ export function registerMainViewCommands(context: vscode.ExtensionContext) {
           computeModelOptions(),
           computeAgentOptions(),
         ]);
-        postOptionsToWebview(
-          webview,
-          MAIN_VIEW_COMMANDS.SET_MODEL_OPTIONS,
-          modelOptions,
-        );
-        postOptionsToWebview(
-          webview,
-          MAIN_VIEW_COMMANDS.SET_AGENT_OPTIONS,
-          agentOptions,
-        );
+        webview.webview.postMessage({
+          command: MAIN_VIEW_COMMANDS.SET_MODEL_OPTIONS,
+          options: modelOptions,
+        });
+        webview.webview.postMessage({
+          command: MAIN_VIEW_COMMANDS.SET_AGENT_OPTIONS,
+          options: agentOptions,
+        });
       } catch (error) {
-        logRefreshError(error, 'refresh options');
+        const message = toErrorMessage(error);
+        logger.error(CHANNEL, `Failed to refresh options: ${message}`);
+        vscode.window.showErrorMessage(`Failed to refresh options: ${message}`);
       }
     },
   );

--- a/src/common/webview/BaseViewContentProvider.ts
+++ b/src/common/webview/BaseViewContentProvider.ts
@@ -116,13 +116,6 @@ export abstract class BaseViewContentProvider {
     );
   }
 
-  /** URIs shared by all views */
-  private getSharedModuleUris(
-    webview: vscode.Webview,
-  ): Record<string, vscode.Uri> {
-    return this.buildUriRecord(webview, this.sharedModuleDescriptors);
-  }
-
   /**
    * Standard implementation that subclasses can override if needed
    */
@@ -130,7 +123,7 @@ export abstract class BaseViewContentProvider {
     try {
       const htmlPath = this.getWebviewPath('index.html');
       const commonUris = this.getCommonModuleUris(webview);
-      const sharedUris = this.getSharedModuleUris(webview);
+      const sharedUris = this.buildUriRecord(webview, this.sharedModuleDescriptors);
       const specificUris = this.getModuleUris(webview);
       const templateVariables = this.getTemplateVariables();
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -45,19 +45,6 @@ let statusBarItem: vscode.StatusBarItem | undefined;
 let apiKeyStatusBarItem: vscode.StatusBarItem | undefined;
 let disposeStatusListener: (() => void) | undefined;
 
-function promptToOpenFolder(message: string): void {
-  const openAction = 'Open Folder';
-  void vscode.window
-    .showInformationMessage(message, openAction)
-    .then((choice) => {
-      if (choice === openAction) {
-        void vscode.commands.executeCommand(
-          'workbench.action.files.openFolder',
-        );
-      }
-    });
-}
-
 async function refreshApiKeyStatus() {
   if (!apiKeyStatusBarItem) {
     return;
@@ -92,7 +79,15 @@ export async function activate(context: vscode.ExtensionContext) {
       !workspaceFolders || workspaceFolders.length === 0
         ? 'TeXRA requires an open workspace. Please open a folder to enable the extension.'
         : 'TeXRA supports only a single-folder workspace. Please open one folder to enable the extension.';
-    promptToOpenFolder(message);
+    void vscode.window
+      .showInformationMessage(message, 'Open Folder')
+      .then((choice) => {
+        if (choice === 'Open Folder') {
+          void vscode.commands.executeCommand(
+            'workbench.action.files.openFolder',
+          );
+        }
+      });
     return;
   }
   const workspaceRoot = workspaceFolders[0].uri.fsPath;

--- a/src/frontend/agents/register.ts
+++ b/src/frontend/agents/register.ts
@@ -35,15 +35,6 @@ export type AgentRegistrationSkipReason =
   | 'baseRegistered'
   | 'multipleRegistered';
 
-function asWorkflowSetting(
-  setting?: AgentSetting,
-): AgentWorkflowSetting | undefined {
-  if (!setting || setting.agentCategory === AgentCategory.ToolUse) {
-    return undefined;
-  }
-  return setting as AgentWorkflowSetting;
-}
-
 export function getAgentRegistrationSkipReason(
   agentName: string,
   configuredAgents: string[],
@@ -146,12 +137,14 @@ export async function validateYamlAndPromptAdd(
   }
 
   const settings = validationResult.settings;
-  const workflowSettings = asWorkflowSetting(settings);
+  const isWorkflow = settings.agentCategory !== AgentCategory.ToolUse;
+  const workflowSettings = isWorkflow
+    ? (settings as AgentWorkflowSetting)
+    : undefined;
   const defaultOutputs = settings.defaultOutputFiles ?? [];
   const hasMultipleDefaults = defaultOutputs.length > 1;
   const isMultipleOutput = Boolean(
-    workflowSettings?.isMultipleOutput ??
-    (workflowSettings && hasMultipleDefaults),
+    workflowSettings?.isMultipleOutput ?? (isWorkflow && hasMultipleDefaults),
   );
 
   const metadata: AgentVariantMetadata = {

--- a/src/frontend/vscode/vscodeEditor.ts
+++ b/src/frontend/vscode/vscodeEditor.ts
@@ -8,11 +8,6 @@ import * as vscode from 'vscode';
 
 import { WorkspaceFS } from '@utils/files';
 
-/** Convert a file path to a VS Code URI */
-function toFileUri(filePath: string): vscode.Uri {
-  return vscode.Uri.file(WorkspaceFS.toAbsolute(filePath));
-}
-
 /**
  * Open a file in VS Code editor, optionally positioning cursor at a line.
  * Reuses existing editor if file is already open.
@@ -28,7 +23,7 @@ export async function openFileInEditor(
   column?: number,
 ): Promise<string | undefined> {
   try {
-    const uri = toFileUri(filePath);
+    const uri = vscode.Uri.file(WorkspaceFS.toAbsolute(filePath));
     const absolutePath = uri.fsPath;
 
     // Check if file is already open in an editor
@@ -83,7 +78,7 @@ export async function ensureFileOpen(
   options: { preserveFocus?: boolean; save?: boolean } = {},
 ): Promise<{ editor: vscode.TextEditor; absolutePath: string } | undefined> {
   try {
-    const uri = toFileUri(filePath);
+    const uri = vscode.Uri.file(WorkspaceFS.toAbsolute(filePath));
     const absolutePath = uri.fsPath;
 
     // Check if file is already open

--- a/src/model/computeModelOptions.ts
+++ b/src/model/computeModelOptions.ts
@@ -113,14 +113,6 @@ export async function computeModelOptions(): Promise<string> {
   return optionTags.join('\n');
 }
 
-/** Build description attribute from context and cost info. */
-function buildDescription(contextStr: string, costStr: string): string {
-  const parts = [];
-  if (contextStr) parts.push(`Context: ${contextStr}`);
-  if (costStr) parts.push(`Cost (in/out per 1M): ${costStr}`);
-  return parts.length > 0 ? `description="${parts.join(' | ')}"` : '';
-}
-
 /** Build a single model option tag. */
 async function buildModelOption(
   model: string,
@@ -137,6 +129,13 @@ async function buildModelOption(
     : '';
   const costStr = formatCost(config.inputPrice, config.outputPrice);
 
+  // Build description attribute from context and cost info
+  const descParts: string[] = [];
+  if (contextStr) descParts.push(`Context: ${contextStr}`);
+  if (costStr) descParts.push(`Cost (in/out per 1M): ${costStr}`);
+  const description =
+    descParts.length > 0 ? `description="${descParts.join(' | ')}"` : '';
+
   const attrs = [
     `value="${model}"`,
     !available &&
@@ -144,7 +143,7 @@ async function buildModelOption(
     config.provider && `data-provider="${config.provider}"`,
     contextStr && `data-context="${contextStr}"`,
     costStr && `data-cost="${costStr}"`,
-    buildDescription(contextStr, costStr),
+    description,
   ].filter(Boolean);
 
   return `<vscode-option ${attrs.join(' ')}>${model}</vscode-option>`;

--- a/src/utils/files/baseFS.ts
+++ b/src/utils/files/baseFS.ts
@@ -157,46 +157,43 @@ export abstract class BaseFS {
     );
   }
 
-  /**
-   * Check if file type matches a predicate.
-   * Returns false if the target doesn't exist or an error occurs.
-   */
-  private static async checkFileType(
-    this: typeof BaseFS,
-    target: PathInput,
-    predicate: (type: vscode.FileType) => boolean,
-  ): Promise<boolean> {
-    try {
-      const stats = await this.stat(target);
-      return predicate(stats.type);
-    } catch (_err) {
-      return false;
-    }
-  }
-
   public static async isDir(
     this: typeof BaseFS,
     target: PathInput,
   ): Promise<boolean> {
-    return this.checkFileType(target, (t) => t === vscode.FileType.Directory);
+    try {
+      const stats = await this.stat(target);
+      return stats.type === vscode.FileType.Directory;
+    } catch (_err) {
+      return false;
+    }
   }
 
   public static async isFile(
     this: typeof BaseFS,
     target: PathInput,
   ): Promise<boolean> {
-    return this.checkFileType(target, (t) => t === vscode.FileType.File);
+    try {
+      const stats = await this.stat(target);
+      return stats.type === vscode.FileType.File;
+    } catch (_err) {
+      return false;
+    }
   }
 
   public static async isSymbolicLink(
     this: typeof BaseFS,
     target: PathInput,
   ): Promise<boolean> {
-    return this.checkFileType(
-      target,
-      (t) =>
-        (t & vscode.FileType.SymbolicLink) === vscode.FileType.SymbolicLink,
-    );
+    try {
+      const stats = await this.stat(target);
+      return (
+        (stats.type & vscode.FileType.SymbolicLink) ===
+        vscode.FileType.SymbolicLink
+      );
+    } catch (_err) {
+      return false;
+    }
   }
 
   // ===== Sync Methods =====

--- a/src/utils/files/fileMappingUtils.ts
+++ b/src/utils/files/fileMappingUtils.ts
@@ -104,14 +104,6 @@ export function createFileMapping(
  */
 const TEX_EXTENSION_REGEX = /\.tex$/i;
 
-function hasTexExtension(value: string): boolean {
-  return TEX_EXTENSION_REGEX.test(value);
-}
-
-function removeTexExtension(value: string): string {
-  return value.replace(TEX_EXTENSION_REGEX, '');
-}
-
 /**
  * Build a string → string lookup for LaTeX \input command replacement.
  * Generates all path suffix variants (from full path down to filename) for flexible matching.
@@ -141,12 +133,16 @@ function buildReplacementLookup(
       }
 
       // Also register without .tex extension
-      if (hasTexExtension(baseSuffix) && hasTexExtension(outputSuffix)) {
-        const baseNoExt = normalizeLatexPath(removeTexExtension(baseSuffix));
+      const baseHasTex = TEX_EXTENSION_REGEX.test(baseSuffix);
+      const outputHasTex = TEX_EXTENSION_REGEX.test(outputSuffix);
+      if (baseHasTex && outputHasTex) {
+        const baseNoExt = normalizeLatexPath(
+          baseSuffix.replace(TEX_EXTENSION_REGEX, ''),
+        );
         if (baseNoExt && !replacements.has(baseNoExt)) {
           replacements.set(
             baseNoExt,
-            normalizeLatexPath(removeTexExtension(outputSuffix)),
+            normalizeLatexPath(outputSuffix.replace(TEX_EXTENSION_REGEX, '')),
           );
         }
       }


### PR DESCRIPTION
Simplifies code by removing unnecessary abstraction layers and inlining
helper functions that were only called once or twice:

- baseFS.ts: Inline checkFileType() into isDir/isFile/isSymbolicLink
- executeAgent.ts: Remove createUsageRecorder factory, inline callbacks
- register.ts: Inline asWorkflowSetting() at its single call site
- vscodeEditor.ts: Inline toFileUri() helper
- computeModelOptions.ts: Inline buildDescription() into buildModelOption
- fileMappingUtils.ts: Inline hasTexExtension/removeTexExtension
- latexdiffCommands.ts: Inline normalizeOutputsByRound and describeFile

Net reduction of ~38 lines while preserving all functionality.

https://claude.ai/code/session_01PWy7UDkKHitDTduyLqeC4J

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Streamlines code by removing small helper wrappers and embedding logic at call sites, reducing indirection while preserving behavior.
> 
> - **Agent execution**: Remove `createUsageRecorder` factory; pass inline callbacks in `executeAgent` (including merge and resume flows).
> - **Validation**: Inline output file count check in `AgentConfigSchema`; remove `validateOutputFiles`.
> - **Webview messaging**: Replace wrapper helpers with direct `webview.postMessage` in main/progress view commands; minor cleanup in `BaseViewContentProvider` (build shared URIs inline).
> - **Latexdiff**: Inline normalization and file label helpers; construct `outputsByRound` directly from config; keep between-round logic unchanged.
> - **FS/editor utils**: Inline path/ftype helpers (`BaseFS.isDir/isFile/isSymbolicLink`, `vscodeEditor` URI creation); remove generic predicate function.
> - **Merge filename utils**: Drop generic extractor; inline regex-based last-match logic.
> - **Agent registration**: Inline workflow-setting check; compute multiple-output metadata directly.
> - **Activation**: Inline "Open Folder" prompt logic in `extension.ts`.
> 
> Risk surface: low—primarily refactors and message/utility simplifications with equivalent logic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7f298ae55bcd9ff9cde431a6016a8fc3b1fcb500. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->