### PR TITLE
refactor: simplify code patterns in third batch of files

### DIFF
--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -371,7 +371,10 @@ export abstract class ModelHandler<
   }
 
   /** Provider to config suffix mapping for streaming settings */
-  private static readonly PROVIDER_STREAMING_SUFFIX: Record<ModelProvider, string> = {
+  private static readonly PROVIDER_STREAMING_SUFFIX: Record<
+    ModelProvider,
+    string
+  > = {
     [ModelProvider.ANTHROPIC]: 'Anthropic',
     [ModelProvider.OPENAI]: 'Openai',
     [ModelProvider.GOOGLE]: 'Google',
@@ -390,14 +393,23 @@ export abstract class ModelHandler<
   public getStreamingConfig(): boolean {
     const globalDefault = getConfig<boolean>('texra.model.useStreaming', false);
 
-    if (this.config.openRouterOnly || getConfig<boolean>('texra.model.useOpenRouter', false)) {
-      return getConfig<boolean>('texra.model.useStreamingOpenrouter', globalDefault);
+    if (
+      this.config.openRouterOnly ||
+      getConfig<boolean>('texra.model.useOpenRouter', false)
+    ) {
+      return getConfig<boolean>(
+        'texra.model.useStreamingOpenrouter',
+        globalDefault,
+      );
     }
 
     const suffix = ModelHandler.PROVIDER_STREAMING_SUFFIX[this.config.provider];
     if (!suffix) return globalDefault;
 
-    return getConfig<boolean>(`texra.model.useStreaming${suffix}`, globalDefault);
+    return getConfig<boolean>(
+      `texra.model.useStreaming${suffix}`,
+      globalDefault,
+    );
   }
 
   get isOReasoningModel(): boolean {

--- a/src/agent/output/OutputFileProcessor.ts
+++ b/src/agent/output/OutputFileProcessor.ts
@@ -148,8 +148,9 @@ export class OutputFileProcessor {
         case 'scratchpadOnly': {
           const hasDocumentTag = Boolean(agentSetting.documentTag);
           const hasScratchpadPrefill =
-            agentSetting.prefills?.some((p) => SCRATCHPAD_TAG_PATTERN.test(p)) ??
-            false;
+            agentSetting.prefills?.some((p) =>
+              SCRATCHPAD_TAG_PATTERN.test(p),
+            ) ?? false;
           shouldProcessXml = hasDocumentTag || hasScratchpadPrefill;
           break;
         }
@@ -261,10 +262,12 @@ export class OutputFileProcessor {
       );
       if (documentEntries.length > 0) {
         const trimmedDocuments = documentEntries.map((e) => e.content.trim());
-        tagContents[documentTag] =
-          trimmedDocuments.length === 1
-            ? trimmedDocuments[0]
-            : trimmedDocuments;
+        // Store as single string if only one document, array otherwise
+        if (trimmedDocuments.length === 1) {
+          tagContents[documentTag] = trimmedDocuments[0];
+        } else {
+          tagContents[documentTag] = trimmedDocuments;
+        }
 
         for (const entry of documentEntries) {
           const nameAttr = entry.name ? ` name="${entry.name}"` : '';

--- a/src/agent/remote/RemoteAgentLoader.ts
+++ b/src/agent/remote/RemoteAgentLoader.ts
@@ -117,7 +117,10 @@ function parseListItemRow(row: {
     agentCategory: agent_category,
   });
   if (!result.success) {
-    logger.warn(CHANNEL, `Invalid metadata for agent "${name}": ${result.error.message}`);
+    logger.warn(
+      CHANNEL,
+      `Invalid metadata for agent "${name}": ${result.error.message}`,
+    );
     return null;
   }
   return result.data;

--- a/src/agent/runtime/BasePromiseCoordinator.ts
+++ b/src/agent/runtime/BasePromiseCoordinator.ts
@@ -95,16 +95,16 @@ export abstract class BasePromiseCoordinator<
     }
 
     return new Promise<TResult>((resolve) => {
-      const timeoutId =
-        options?.timeoutMs && options.timeoutMs > 0
-          ? setTimeout(() => {
-              const req = this.requests.get(id);
-              if (req?.status === 'pending' && req.resolve === resolve) {
-                const result = options.onTimeout?.() ?? this.getTimeoutResult();
-                this.resolveRequest(id, result);
-              }
-            }, options.timeoutMs)
-          : undefined;
+      let timeoutId: NodeJS.Timeout | undefined;
+      if (options?.timeoutMs && options.timeoutMs > 0) {
+        timeoutId = setTimeout(() => {
+          const req = this.requests.get(id);
+          if (req?.status === 'pending' && req.resolve === resolve) {
+            const result = options.onTimeout?.() ?? this.getTimeoutResult();
+            this.resolveRequest(id, result);
+          }
+        }, options.timeoutMs);
+      }
 
       this.requests.set(id, {
         status: 'pending',

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -441,7 +441,8 @@ async function runFlowWithLifecycle(
 
     // Show appropriate notification based on error type
     const hasApiKeyError =
-      rawMsg.includes('Missing API key') || rawMsg.includes('API key not found');
+      rawMsg.includes('Missing API key') ||
+      rawMsg.includes('API key not found');
     if (hasApiKeyError) {
       await showApiKeyErrorNotification();
     } else {

--- a/src/agent/utils/UsageMonitor.ts
+++ b/src/agent/utils/UsageMonitor.ts
@@ -143,7 +143,9 @@ export class UsageMonitor {
 
       const payload: ExtendedTokenUsageStats = {
         ...baseStats,
-        elapsedTime: Number((stateGlobal.totalResponseTimeMs / 1000).toFixed(1)),
+        elapsedTime: Number(
+          (stateGlobal.totalResponseTimeMs / 1000).toFixed(1),
+        ),
       };
       if (cachingStats) {
         payload.percentageCached = Number((percentageCached ?? 0).toFixed(2));

--- a/src/commands/git/gitCommands.ts
+++ b/src/commands/git/gitCommands.ts
@@ -56,13 +56,21 @@ function getRecentCommits(): string[] | null {
 
   const result = execaSync(
     'git',
-    ['log', '-n', String(numberOfCommits), `--pretty=format:${COMMIT_LABEL_FORMAT}`],
+    [
+      'log',
+      '-n',
+      String(numberOfCommits),
+      `--pretty=format:${COMMIT_LABEL_FORMAT}`,
+    ],
     { cwd: workspacePath, reject: false },
   );
   if (result.exitCode !== 0) {
     return [];
   }
-  return result.stdout.toString().split('\n').map((line) => line.trim());
+  return result.stdout
+    .toString()
+    .split('\n')
+    .map((line) => line.trim());
 }
 
 function findCommitInHistory(commitHash: string): string | null {

--- a/src/common/webview/BaseViewContentProvider.ts
+++ b/src/common/webview/BaseViewContentProvider.ts
@@ -207,7 +207,10 @@ export abstract class BaseViewContentProvider {
     resolver: (webview: vscode.Webview, path: string) => vscode.Uri,
   ): Record<string, vscode.Uri> {
     return Object.fromEntries(
-      descriptors.map(({ key, path }) => [key, resolver.call(this, webview, path)]),
+      descriptors.map(({ key, path }) => [
+        key,
+        resolver.call(this, webview, path),
+      ]),
     );
   }
 

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -1220,9 +1220,8 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
 
     // Set useMultipleOutputs when we have multiple output files
     const useMultipleOutputs =
-      attachAgentOutputs && outputFiles.length > 1
-        ? true
-        : originalConfig.useMultipleOutputs;
+      (attachAgentOutputs && outputFiles.length > 1) ||
+      originalConfig.useMultipleOutputs;
 
     const newConfig = {
       ...originalConfig,

--- a/src/progressView/managers/OutputFilesManager.ts
+++ b/src/progressView/managers/OutputFilesManager.ts
@@ -84,6 +84,36 @@ export class OutputFilesManager extends PersistentMapManager<
   }
 
   /**
+   * Get or create a nested map entry for stream runs.
+   */
+  private getOrCreateNested<K, V>(
+    map: Map<K, Map<string, V>>,
+    key: K,
+  ): Map<string, V> {
+    let inner = map.get(key);
+    if (!inner) {
+      inner = new Map();
+      map.set(key, inner);
+    }
+    return inner;
+  }
+
+  /**
+   * Get or create a rounds map for a storage key.
+   */
+  private getOrCreateRounds<V>(
+    map: Map<string, Map<number, V>>,
+    key: string,
+  ): Map<number, V> {
+    let inner = map.get(key);
+    if (!inner) {
+      inner = new Map();
+      map.set(key, inner);
+    }
+    return inner;
+  }
+
+  /**
    * Add output files for a stream and round.
    *
    * @param stream - The stream tab ID
@@ -96,17 +126,8 @@ export class OutputFilesManager extends PersistentMapManager<
     filesByRound: { [key: number]: OutputFileInfo[] },
   ): Promise<void> {
     // storageKey is already branded - use directly, no normalization needed
-    let streamRuns = this.items.get(stream);
-    if (!streamRuns) {
-      streamRuns = new Map();
-      this.items.set(stream, streamRuns);
-    }
-
-    let runRounds = streamRuns.get(storageKey);
-    if (!runRounds) {
-      runRounds = new Map();
-      streamRuns.set(storageKey, runRounds);
-    }
+    const streamRuns = this.getOrCreateNested(this.items, stream);
+    const runRounds = this.getOrCreateRounds(streamRuns, storageKey);
 
     for (const [round, files] of Object.entries(filesByRound)) {
       const roundResult = RoundKeySchema.safeParse(round);
@@ -144,18 +165,8 @@ export class OutputFilesManager extends PersistentMapManager<
   ): Promise<void> {
     await this.ensureMissingOutputsLoaded();
     // storageKey is already branded - use directly, no normalization needed
-
-    let streamMissing = this._missingOutputs.get(stream);
-    if (!streamMissing) {
-      streamMissing = new Map();
-      this._missingOutputs.set(stream, streamMissing);
-    }
-
-    let runMissing = streamMissing.get(storageKey);
-    if (!runMissing) {
-      runMissing = new Map();
-      streamMissing.set(storageKey, runMissing);
-    }
+    const streamMissing = this.getOrCreateNested(this._missingOutputs, stream);
+    const runMissing = this.getOrCreateRounds(streamMissing, storageKey);
 
     for (const [round, files] of Object.entries(filesByRound)) {
       const roundResult = RoundKeySchema.safeParse(round);

--- a/src/progressView/modules/formatters/htmlBuilders.js
+++ b/src/progressView/modules/formatters/htmlBuilders.js
@@ -135,9 +135,10 @@ export function buildFileListRender(files) {
         );
       }
       if (file.source && file.source !== 'unknown') {
+        const sourceDisplay = encodeHtml(file.sourceDisplay);
         const sourceText = file.internal
-          ? `${encodeHtml(file.sourceDisplay)}, internal`
-          : encodeHtml(file.sourceDisplay);
+          ? `${sourceDisplay}, internal`
+          : sourceDisplay;
         metaParts.push(`<span class="file-source">(${sourceText})</span>`);
       }
 

--- a/src/progressView/modules/formatters/logFormatters/dataFormatters.js
+++ b/src/progressView/modules/formatters/logFormatters/dataFormatters.js
@@ -253,13 +253,13 @@ const extractLegacyFormat = (entry) => {
 const buildLatexdiffEntryHtml = (entry) => {
   if (!entry) return '';
 
-  // Extract fields based on format
-  const data =
-    entry.revised && typeof entry.revised === 'object'
-      ? extractNewFormat(entry)
-      : entry.locations
-        ? extractLegacyFormat(entry)
-        : null;
+  // Extract fields based on format - new format has revised object, legacy has locations
+  let data = null;
+  if (entry.revised && typeof entry.revised === 'object') {
+    data = extractNewFormat(entry);
+  } else if (entry.locations) {
+    data = extractLegacyFormat(entry);
+  }
 
   if (!data) return '';
 

--- a/src/progressView/modules/formatters/logFormatters/messageFormatters.js
+++ b/src/progressView/modules/formatters/logFormatters/messageFormatters.js
@@ -168,14 +168,10 @@ export function formatError(message) {
 
   // If there are no details, hide the copy button and make it non-expandable
   if (!detailText) {
-    if (bannerEntry.copyButton) {
-      bannerEntry.copyButton.style.display = 'none';
-    }
-    // Remove toggle icon for non-expandable entries
-    const toggleIcon = bannerEntry.element.querySelector('.toggle-icon');
-    if (toggleIcon) {
-      toggleIcon.style.visibility = 'hidden';
-    }
+    bannerEntry.copyButton?.style.setProperty('display', 'none');
+    bannerEntry.element
+      .querySelector('.toggle-icon')
+      ?.style.setProperty('visibility', 'hidden');
   }
 
   if (bannerEntry.contentElem) {

--- a/src/progressView/modules/formatters/logFormatters/toolFormatters.js
+++ b/src/progressView/modules/formatters/logFormatters/toolFormatters.js
@@ -40,6 +40,22 @@ const STATUS_ICONS = {
 };
 
 /**
+ * Build a tool section with appropriate code highlighting based on tool type.
+ * @param {string} label - Section label (e.g., 'Input:', 'Output:')
+ * @param {string} text - Content text to display
+ * @param {string} toolName - Name of the tool
+ * @param {string} [extraClass] - Additional CSS class for the content
+ * @returns {string} HTML for the section
+ */
+function buildToolSection(label, text, toolName, extraClass = '') {
+  const useHighlighting = TOOLS_WITH_CODE_OUTPUT.has(toolName);
+  const content = useHighlighting
+    ? wrapInHighlightedPre(text, 'bash', extraClass)
+    : wrapInPre(text, extraClass);
+  return buildToolUseSection(label, content);
+}
+
+/**
  * Determine the title prefix based on tool state.
  * @param {boolean} isUserFeedback - Whether this is user feedback
  * @param {boolean} isError - Whether this is an error state
@@ -180,40 +196,16 @@ export function formatToolUse(normalizedPayload, logId, groupId, timestamp) {
   else if (input !== undefined && input !== null) {
     const inputValue = stringifyForDisplay(input);
     if (inputValue) {
-      // Use syntax highlighting for code-related tools
-      if (TOOLS_WITH_CODE_OUTPUT.has(toolName)) {
-        sections.push(
-          buildToolUseSection(
-            'Input:',
-            wrapInHighlightedPre(inputValue, 'bash'),
-          ),
-        );
-      } else {
-        sections.push(buildToolUseSection('Input:', wrapInPre(inputValue)));
-      }
+      sections.push(buildToolSection('Input:', inputValue, toolName));
     }
   }
 
   // Show output if present (primary result from tool)
   // Skip for read/file-link tools (already shown as file link)
   if (outputText && !TOOLS_WITH_FILE_LINK.has(toolName)) {
-    // Only syntax highlight output for tools with actual code output
-    // Edit tools output human-readable status like "Replaced 1 occurrence." - not code
-    if (TOOLS_WITH_CODE_OUTPUT.has(toolName)) {
-      sections.push(
-        buildToolUseSection(
-          'Output:',
-          wrapInHighlightedPre(outputText, 'bash', 'tool-output-full'),
-        ),
-      );
-    } else {
-      sections.push(
-        buildToolUseSection(
-          'Output:',
-          wrapInPre(outputText, 'tool-output-full'),
-        ),
-      );
-    }
+    sections.push(
+      buildToolSection('Output:', outputText, toolName, 'tool-output-full'),
+    );
   }
 
   // Show error if present and not superseded by user feedback

--- a/src/tools/RunsTool.ts
+++ b/src/tools/RunsTool.ts
@@ -258,34 +258,42 @@ Use view_range: [start, end] to paginate large outputs.`,
    */
   private formatMessageContent(content: unknown): string {
     if (typeof content === 'string') {
-      return content.length > 500 ? content.slice(0, 497) + '...' : content;
+      return this.truncate(content, 500);
     }
     if (Array.isArray(content)) {
-      // Handle content blocks (text, tool_use, tool_result)
-      return content
-        .map((block) => {
-          if (typeof block === 'string') return block;
-          if (block?.type === 'text') return block.text ?? '';
-          if (block?.type === 'tool_use') {
-            const input = JSON.stringify(block.input ?? {});
-            const shortInput =
-              input.length > 100 ? input.slice(0, 97) + '...' : input;
-            return `[tool_use: ${block.name}(${shortInput})]`;
-          }
-          if (block?.type === 'tool_result') {
-            const output =
-              typeof block.content === 'string'
-                ? block.content
-                : JSON.stringify(block.content);
-            const shortOutput =
-              output.length > 100 ? output.slice(0, 97) + '...' : output;
-            return `[tool_result: ${shortOutput}]`;
-          }
-          return JSON.stringify(block).slice(0, 100);
-        })
-        .join('\n');
+      return content.map((block) => this.formatBlock(block)).join('\n');
     }
-    return JSON.stringify(content).slice(0, 500);
+    return this.truncate(JSON.stringify(content), 500);
+  }
+
+  /**
+   * Format a single content block.
+   */
+  private formatBlock(block: unknown): string {
+    if (typeof block === 'string') {
+      return block;
+    }
+    const b = block as Record<string, unknown>;
+    switch (b?.type) {
+      case 'text':
+        return (b.text as string) ?? '';
+      case 'tool_use':
+        return `[tool_use: ${b.name}(${this.truncate(JSON.stringify(b.input ?? {}), 100)})]`;
+      case 'tool_result': {
+        const output =
+          typeof b.content === 'string' ? b.content : JSON.stringify(b.content);
+        return `[tool_result: ${this.truncate(output, 100)}]`;
+      }
+      default:
+        return this.truncate(JSON.stringify(block), 100);
+    }
+  }
+
+  /**
+   * Truncate string with ellipsis if too long.
+   */
+  private truncate(str: string, maxLen: number): string {
+    return str.length > maxLen ? str.slice(0, maxLen - 3) + '...' : str;
   }
 
   /**

--- a/src/tools/TextEditorTool.ts
+++ b/src/tools/TextEditorTool.ts
@@ -89,6 +89,16 @@ export class TextEditorTool extends defineTool({
   }
 
   /**
+   * Get the list of allowed commands for this API version.
+   */
+  private getAllowedCommands(): string {
+    if (this.apiType === 'text_editor_20250429') {
+      return 'view, create, str_replace, insert';
+    }
+    return 'view, create, str_replace, insert, undo_edit';
+  }
+
+  /**
    * Execute the tool with the given arguments
    * @param input - Tool call input parameters
    */
@@ -149,12 +159,8 @@ export class TextEditorTool extends defineTool({
         logger.info(CHANNEL, `undo_edit: ${filePath}`);
         return this.undoEdit(filePath);
       default:
-        const allowedCommands =
-          this.apiType === 'text_editor_20250429'
-            ? 'view, create, str_replace, insert'
-            : 'view, create, str_replace, insert, undo_edit';
         throw new ToolError(
-          `Unrecognized command ${command}. The allowed commands for the ${this.name} tool are: ${allowedCommands}`,
+          `Unrecognized command ${command}. The allowed commands for the ${this.name} tool are: ${this.getAllowedCommands()}`,
         );
     }
   }

--- a/src/tools/approval/latexPreview.ts
+++ b/src/tools/approval/latexPreview.ts
@@ -106,14 +106,15 @@ async function createTempFile(
   const basename = path.basename(originalPath, ext);
   const tempFileName = `${basename}${suffix}-${randomUUID().slice(0, UUID_PREFIX_LENGTH)}${ext}`;
 
-  const tempDir =
-    location === 'workspaceTemp'
-      ? path.join(workspacePath, TEXRA_TEMP_DIR)
-      : path.dirname(
-          path.isAbsolute(originalPath)
-            ? originalPath
-            : path.join(workspacePath, originalPath),
-        );
+  let tempDir: string;
+  if (location === 'workspaceTemp') {
+    tempDir = path.join(workspacePath, TEXRA_TEMP_DIR);
+  } else {
+    const resolvedPath = path.isAbsolute(originalPath)
+      ? originalPath
+      : path.join(workspacePath, originalPath);
+    tempDir = path.dirname(resolvedPath);
+  }
 
   if (location === 'workspaceTemp') {
     await fs.mkdir(tempDir, { recursive: true });

--- a/src/tools/memory/MemoryTool.ts
+++ b/src/tools/memory/MemoryTool.ts
@@ -249,12 +249,9 @@ Paths must start with /memories. Use /memories to list files, /memories/file.md 
 
     if (occurrences > 1) {
       const lines = content.split(/\r?\n/);
-      const lineNumbers: number[] = [];
-      lines.forEach((line, index) => {
-        if (line.includes(oldStr)) {
-          lineNumbers.push(index + 1);
-        }
-      });
+      const lineNumbers = lines
+        .map((line, index) => (line.includes(oldStr) ? index + 1 : -1))
+        .filter((n) => n !== -1);
       throw new ToolError(
         `No replacement was performed. Multiple occurrences of old_str \`${oldStr}\` in lines: ${lineNumbers.join(
           ', ',

--- a/src/tools/zotero/ZoteroAddTool.ts
+++ b/src/tools/zotero/ZoteroAddTool.ts
@@ -235,8 +235,12 @@ export class ZoteroAddTool extends defineTool({
       results.push({ item: itemLabel, ...result });
     }
 
-    const successCount = results.filter((r) => r.status === 'success').length;
-    const errorCount = results.filter((r) => r.status === 'error').length;
+    let successCount = 0;
+    let errorCount = 0;
+    for (const r of results) {
+      if (r.status === 'success') successCount++;
+      else if (r.status === 'error') errorCount++;
+    }
 
     const output = results
       .map((r) => {

--- a/src/tools/zotero/ZoteroSearchTool.ts
+++ b/src/tools/zotero/ZoteroSearchTool.ts
@@ -36,6 +36,44 @@ const ZoteroSearchInputSchema = z.strictObject({
 
 export type ZoteroSearchInput = z.infer<typeof ZoteroSearchInputSchema>;
 
+/**
+ * Format a single search result item for display.
+ */
+function formatSearchResult(item: BbtSearchResultItem): string {
+  const citekey = item.citekey || 'unknown';
+  const title = item.title || 'Untitled';
+
+  // Handle both CSL JSON (author) and Zotero (creators) formats
+  const creatorList = item.author || item.creators || [];
+  const creators = creatorList
+    .map((c) => {
+      if (c.family) {
+        return c.given ? `${c.family}, ${c.given}` : c.family;
+      }
+      if (c.lastName) {
+        return c.firstName ? `${c.lastName}, ${c.firstName}` : c.lastName;
+      }
+      return c.name || '';
+    })
+    .filter(Boolean)
+    .join('; ');
+
+  // Handle date from CSL JSON or Zotero format
+  let year = '';
+  if (item.issued?.['date-parts']?.[0]?.[0]) {
+    year = String(item.issued['date-parts'][0][0]);
+  } else if (item.date) {
+    year = item.date;
+  }
+
+  const type = item.type || item.itemType || 'item';
+
+  // Build formatted string with optional parts
+  const creatorPart = creators ? ` - ${creators}` : '';
+  const yearPart = year ? ` (${year})` : '';
+  return `[${citekey}] ${title}${creatorPart}${yearPart} [${type}]`;
+}
+
 export class ZoteroSearchTool extends defineTool({
   name: 'zotero_search',
   description:
@@ -65,40 +103,7 @@ export class ZoteroSearchTool extends defineTool({
     }
 
     // Format results
-    const items = result.map((item) => {
-      const citekey = item.citekey || 'unknown';
-      const title = item.title || 'Untitled';
-
-      // Handle both CSL JSON (author) and Zotero (creators) formats
-      const creatorList = item.author || item.creators || [];
-      const creators = creatorList
-        .map((c) => {
-          // CSL JSON format: family/given
-          if (c.family) {
-            return `${c.family}${c.given ? `, ${c.given}` : ''}`;
-          }
-          // Zotero format: lastName/firstName
-          if (c.lastName) {
-            return `${c.lastName}${c.firstName ? `, ${c.firstName}` : ''}`;
-          }
-          // Single name format
-          return c.name || '';
-        })
-        .filter(Boolean)
-        .join('; ');
-
-      // Handle date from CSL JSON or Zotero format
-      let year = '';
-      if (item.issued?.['date-parts']?.[0]?.[0]) {
-        year = String(item.issued['date-parts'][0][0]);
-      } else if (item.date) {
-        year = item.date;
-      }
-
-      const type = item.type || item.itemType || 'item';
-
-      return `[${citekey}] ${title}${creators ? ` - ${creators}` : ''}${year ? ` (${year})` : ''} [${type}]`;
-    });
+    const items = result.map((item) => formatSearchResult(item));
 
     return {
       summary: `Found ${result.length} item${result.length === 1 ? '' : 's'} matching "${query}"`,


### PR DESCRIPTION
Simplifications across 14 files:

Backend tools:
- ZoteroSearchTool: Extract formatSearchResult helper
- ZoteroAddTool: Single-pass counting for results
- TextEditorTool: Extract getAllowedCommands method
- RunsTool: Extract formatBlock and truncate helpers
- MemoryTool: Use map/filter for line numbers
- latexPreview: Convert nested ternary to if-else

Agent runtime:
- BasePromiseCoordinator: Convert ternary to if statement
- OutputFileProcessor: Convert ternary to if-else

Progress view:
- ProgressViewMessageHandler: Simplify redundant ternary
- OutputFilesManager: Add getOrCreateNested helpers
- dataFormatters.js: Convert nested ternary to if-else
- toolFormatters.js: Add buildToolSection helper
- htmlBuilders.js: Extract source text encoding
- messageFormatters.js: Use optional chaining

https://claude.ai/code/session_01RLyqSNk7TYiUT2XaeW9FLB

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Focuses on readability and maintainability with small, localized refactors; behavior remains unchanged.
> 
> - Extracts helpers: `OutputFilesManager.getOrCreateNested/getOrCreateRounds`, `toolFormatters.buildToolSection`, `RunsTool.formatBlock/truncate`, `TextEditorTool.getAllowedCommands`, `ZoteroSearchTool.formatSearchResult`
> - Replaces nested/long ternaries with clearer `if/else` in `BasePromiseCoordinator`, `OutputFileProcessor`, `latexPreview`, `ProgressViewMessageHandler`, and others
> - Minor UI/formatting improvements: safer optional chaining in error banners, consolidated code highlighting for tool I/O, small HTML encoding cleanup in `htmlBuilders.js`
> - Minor formatting/line-wrapping in `ModelHandler`, `gitCommands`, `RemoteAgentLoader`, `UsageMonitor`, and `BaseViewContentProvider`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3504b4671e60e9a5e9fef9305857d441018d6f98. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->