### PR TITLE
Simplify and improve code clarity

### DIFF
--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -1791,7 +1791,9 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
           isImage: mimeType.startsWith('image/'),
         });
       } catch (err) {
-        // Logged via retry helper
+        this.logger.warn(
+          `Failed to upload attachment to OpenAI: ${getSdkErrorMessage(err)}`,
+        );
       } finally {
         if (buffer) {
           buffer.fill(0);

--- a/src/agent/output/LatexDiffManager.ts
+++ b/src/agent/output/LatexDiffManager.ts
@@ -126,10 +126,14 @@ export class LatexDiffManager {
     mapping: RoundFileMapping,
     stage?: AgentLogStage,
   ): Promise<void> {
-    const execute = () => this.performLatexdiffOperations(currRound, mapping);
-
     try {
-      await (stage ? stage.within(execute) : execute());
+      if (stage) {
+        await stage.within(() =>
+          this.performLatexdiffOperations(currRound, mapping),
+        );
+      } else {
+        await this.performLatexdiffOperations(currRound, mapping);
+      }
     } catch (err) {
       this.logger.error(
         `Error during latexdiff processing: ${toErrorMessage(err)}`,

--- a/src/agent/output/OutputFileProcessor.ts
+++ b/src/agent/output/OutputFileProcessor.ts
@@ -165,18 +165,16 @@ export class OutputFileProcessor {
         );
       }
 
-      const hasProcessedPath = Boolean(processed.location.absolutePath);
+      const processedFiles = processed.location.absolutePath
+        ? [processed]
+        : [];
 
-      if (hasProcessedPath) {
+      if (processedFiles.length > 0) {
         await indentLatexFile(processed.location, logger);
         logger.debug(
           `Indented single output file: ${processed.location.absolutePath}`,
         );
-      }
 
-      const processedFiles = hasProcessedPath ? [processed] : [];
-
-      if (hasProcessedPath) {
         if (baseFiles.length > 0) {
           await replaceInputCommands(
             baseFiles,
@@ -184,13 +182,12 @@ export class OutputFileProcessor {
             logger,
           );
         }
-        this.ctx.setRoundOutputs(currRound, processedFiles);
       } else {
         logger.debug(
           `No processed file was generated from ${outputLocation.absolutePath}`,
         );
-        this.ctx.setRoundOutputs(currRound, []);
       }
+      this.ctx.setRoundOutputs(currRound, processedFiles);
 
       await this.captureXmlSummary(
         currRound,

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -309,8 +309,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
       // storageKey is for logical indexing (finding file metadata in progress view state).
       // For workflow agents: activeRunId = task group ID; for tool-use: executionId.
       // Note: Physical file paths use executionId (see runId below), not storageKey.
-      const storageKey: StorageKey | null =
-        activeRunId ?? (executionId as StorageKey | undefined) ?? null;
+      const storageKey = (activeRunId ?? executionId ?? null) as StorageKey | null;
       const runOutputs = storageKey
         ? this.provider.state.getRunOutputFiles(message.stream, { storageKey })
         : undefined;
@@ -513,21 +512,13 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     const hasFiles = (arr?: string[]): boolean => (arr?.length ?? 0) > 0;
 
     // Build activeFiles - only relevant for workflow agents
-    const activeFiles = isWorkflow
-      ? {
-          input: hasFiles(proposal.inputFiles),
-          reference: hasFiles(proposal.referenceFiles),
-          auxiliary: hasFiles(proposal.auxiliaryFiles),
-          media: hasFiles(proposal.mediaFiles),
-          output: hasFiles(proposal.outputFiles),
-        }
-      : {
-          input: false,
-          reference: false,
-          auxiliary: false,
-          media: false,
-          output: false,
-        };
+    const activeFiles = {
+      input: isWorkflow && hasFiles(proposal.inputFiles),
+      reference: isWorkflow && hasFiles(proposal.referenceFiles),
+      auxiliary: isWorkflow && hasFiles(proposal.auxiliaryFiles),
+      media: isWorkflow && hasFiles(proposal.mediaFiles),
+      output: isWorkflow && hasFiles(proposal.outputFiles),
+    };
 
     // Build the agentConfig from the proposal (Zod applies defaults for missing fields)
     // For tool-use agents, file fields will get default values from AgentConfigSchema

--- a/src/progressView/managers/OutputFilesManager.ts
+++ b/src/progressView/managers/OutputFilesManager.ts
@@ -84,30 +84,12 @@ export class OutputFilesManager extends PersistentMapManager<
   }
 
   /**
-   * Get or create a nested map entry for stream runs.
+   * Get or create a nested map entry.
    */
-  private getOrCreateNested<K, V>(
-    map: Map<K, Map<string, V>>,
-    key: K,
-  ): Map<string, V> {
+  private getOrCreate<K, V>(map: Map<K, V>, key: K, factory: () => V): V {
     let inner = map.get(key);
     if (!inner) {
-      inner = new Map();
-      map.set(key, inner);
-    }
-    return inner;
-  }
-
-  /**
-   * Get or create a rounds map for a storage key.
-   */
-  private getOrCreateRounds<V>(
-    map: Map<string, Map<number, V>>,
-    key: string,
-  ): Map<number, V> {
-    let inner = map.get(key);
-    if (!inner) {
-      inner = new Map();
+      inner = factory();
       map.set(key, inner);
     }
     return inner;
@@ -126,8 +108,8 @@ export class OutputFilesManager extends PersistentMapManager<
     filesByRound: { [key: number]: OutputFileInfo[] },
   ): Promise<void> {
     // storageKey is already branded - use directly, no normalization needed
-    const streamRuns = this.getOrCreateNested(this.items, stream);
-    const runRounds = this.getOrCreateRounds(streamRuns, storageKey);
+    const streamRuns = this.getOrCreate(this.items, stream, () => new Map());
+    const runRounds = this.getOrCreate(streamRuns, storageKey, () => new Map());
 
     for (const [round, files] of Object.entries(filesByRound)) {
       const roundResult = RoundKeySchema.safeParse(round);
@@ -165,8 +147,16 @@ export class OutputFilesManager extends PersistentMapManager<
   ): Promise<void> {
     await this.ensureMissingOutputsLoaded();
     // storageKey is already branded - use directly, no normalization needed
-    const streamMissing = this.getOrCreateNested(this._missingOutputs, stream);
-    const runMissing = this.getOrCreateRounds(streamMissing, storageKey);
+    const streamMissing = this.getOrCreate(
+      this._missingOutputs,
+      stream,
+      () => new Map(),
+    );
+    const runMissing = this.getOrCreate(
+      streamMissing,
+      storageKey,
+      () => new Map(),
+    );
 
     for (const [round, files] of Object.entries(filesByRound)) {
       const roundResult = RoundKeySchema.safeParse(round);

--- a/src/tools/TextEditorTool.ts
+++ b/src/tools/TextEditorTool.ts
@@ -272,16 +272,18 @@ export class TextEditorTool extends defineTool({
           );
         }
 
-        if (endLine !== -1 && endLine > numLines) {
-          throw new ToolError(
-            `Invalid \`view_range\`: [${startLine}, ${endLine}]. Its second element \`${endLine}\` should be smaller than the number of lines in the file: \`${numLines}\``,
-          );
-        }
-
-        if (endLine !== -1 && endLine < startLine) {
-          throw new ToolError(
-            `Invalid \`view_range\`: [${startLine}, ${endLine}]. Its second element \`${endLine}\` should be larger or equal than its first \`${startLine}\``,
-          );
+        // Validate endLine when specified (not -1)
+        if (endLine !== -1) {
+          if (endLine > numLines) {
+            throw new ToolError(
+              `Invalid \`view_range\`: [${startLine}, ${endLine}]. Its second element \`${endLine}\` should be smaller than the number of lines in the file: \`${numLines}\``,
+            );
+          }
+          if (endLine < startLine) {
+            throw new ToolError(
+              `Invalid \`view_range\`: [${startLine}, ${endLine}]. Its second element \`${endLine}\` should be larger or equal than its first \`${startLine}\``,
+            );
+          }
         }
 
         initLine = startLine;
@@ -292,16 +294,12 @@ export class TextEditorTool extends defineTool({
       // Record read only after successful validation
       recordToolFileRead(filePath);
 
-      let rangeSummary: string | undefined;
-      if (viewRange) {
-        const [startLine, endLine] = viewRange;
-        rangeSummary = `${startLine}-${endLine === -1 ? 'end' : endLine}`;
-      }
+      const summary = viewRange
+        ? `View ${filePath} (${viewRange[0]}-${viewRange[1] === -1 ? 'end' : viewRange[1]})`
+        : `View ${filePath}`;
 
       return {
-        summary: rangeSummary
-          ? `View ${filePath} (${rangeSummary})`
-          : `View ${filePath}`,
+        summary,
         output: this.makeOutput(fileContent, filePath, initLine),
       };
     } catch (error) {

--- a/src/tools/WorkflowTool.ts
+++ b/src/tools/WorkflowTool.ts
@@ -95,11 +95,9 @@ function proposalResultToToolResult(
       const feedback = result.feedback?.trim();
       return {
         summary: `User rejected '${agentName}' ${label}`,
-        output: `The ${context === 'workflow' ? 'workflow agent proposal' : 'delegation proposal'} was rejected.`,
+        output: `The ${label} was rejected.`,
         isError: true,
-        ...(feedback && feedback.length > 0
-          ? { userInstruction: feedback }
-          : {}),
+        ...(feedback ? { userInstruction: feedback } : {}),
       };
     }
     case 'timeout':


### PR DESCRIPTION
- Consolidate duplicate getOrCreateNested/getOrCreateRounds helpers into single generic getOrCreate function in OutputFilesManager.ts
- Fix redundant ternary in WorkflowTool.ts by reusing label variable and simplifying feedback check
- Combine redundant endLine validation conditionals in TextEditorTool.ts
- Simplify activeFiles ternary object literal using short-circuit evaluation in ProgressViewMessageHandler.ts
- Simplify storageKey nullish coalescing chain
- Add proper error logging to empty catch block in modelHandlerOpenAIResponse.ts
- Simplify execute wrapper pattern in LatexDiffManager.ts using if-else
- Remove redundant hasProcessedPath conditional in OutputFileProcessor.ts by consolidating logic into single block

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Focuses on code clarity and consistency across agents, progress view, and tools.
> 
> - **Output management:** Consolidates nested-map helpers into a generic `getOrCreate` and applies it to outputs/missing-outputs; always sets round outputs in `OutputFileProcessor` with simplified processed-file handling
> - **Latexdiff flow:** Simplifies `stage.within` execution in `LatexDiffManager` and cleans error handling
> - **Progress view:** Compacts `storageKey` selection and simplifies `activeFiles` construction in `ProgressViewMessageHandler`
> - **Text editor tool:** Unifies `view_range` end-line validation and streamlines summary construction for `view`
> - **Workflow tool:** Simplifies rejection output text and feedback handling
> - **OpenAI Responses handler:** Adds warning log when tool attachment upload fails
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7b4c701a4d2157568b7233b242188224bd1f8dc3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->