### PR TITLE
Review tool use and progress view architecture

### DIFF
--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
@@ -48,7 +48,7 @@ export class ToolUseCycleNode<C> extends Node<
       const recoveredTodos = prepRes.workspaceState.todos.todos;
       if (recoveredTodos.length > 0) {
         bus.emit('updateTodos', {
-          stream: this.services.streamId,
+          streamId: this.services.streamId,
           todos: recoveredTodos,
         });
       }
@@ -85,7 +85,7 @@ export class ToolUseCycleNode<C> extends Node<
 
     prepRes.workspaceState.todos.setOnUpdate((todos: TodoItem[]) => {
       bus.emit('updateTodos', {
-        stream: this.services.streamId,
+        streamId: this.services.streamId,
         todos,
       });
     });

--- a/src/agent/output/OutputFileProcessor.ts
+++ b/src/agent/output/OutputFileProcessor.ts
@@ -209,7 +209,7 @@ export class OutputFileProcessor {
       };
       logger.missingOutputs(missingOutputsData);
       bus.emit('updateMissingOutputs', {
-        stream: channel,
+        streamId: channel,
         storageKey,
         filesByRound: { [currRound]: [] },
       });

--- a/src/agent/output/OutputHandler.ts
+++ b/src/agent/output/OutputHandler.ts
@@ -327,7 +327,7 @@ export class OutputHandler implements IOutputHandler {
         const expected = this.agentConfig.outputFiles;
         if (!expected || expected.length === 0) {
           bus.emit('updateMissingOutputs', {
-            stream: this.channel,
+            streamId: this.channel,
             storageKey,
             filesByRound: { [currRound]: [] },
           });
@@ -372,7 +372,7 @@ export class OutputHandler implements IOutputHandler {
         }
 
         bus.emit('updateMissingOutputs', {
-          stream: this.channel,
+          streamId: this.channel,
           storageKey,
           filesByRound: { [currRound]: missing },
         });
@@ -419,7 +419,7 @@ export class OutputHandler implements IOutputHandler {
         }
 
         bus.emit('addOutputFiles', {
-          stream: this.channel,
+          streamId: this.channel,
           storageKey,
           filesByRound: { [currRound]: fileInfos },
         });

--- a/src/agent/runtime/AgentProposalCoordinator.ts
+++ b/src/agent/runtime/AgentProposalCoordinator.ts
@@ -42,25 +42,37 @@ interface ProposalShowPayload {
 }
 
 // ============================================================================
-// Coordinator Implementation
+// Factory-created Coordinator
 // ============================================================================
 
-/** Manages pending agent proposals (workflow and tool-use). */
-class AgentProposalCoordinatorImpl extends BasePromiseCoordinator<
-  ProposalResult,
-  ProposalShowPayload
-> {
-  constructor() {
-    super({
-      showEventName: 'showAgentProposal',
-      resolveEventName: 'resolveAgentProposal',
-      idFieldName: 'proposalId',
-      defaultCancelResult: { action: 'reject' },
-    });
-  }
-
+/** Extended coordinator with proposal-specific method. */
+export interface ProposalCoordinator
+  extends BasePromiseCoordinator<ProposalResult, ProposalShowPayload> {
   /** Wait for user action on a proposal. */
   waitForProposal(
+    streamId: string,
+    options: ProposalRequestOptions,
+  ): Promise<ProposalResult>;
+}
+
+/**
+ * Create a proposal coordinator instance.
+ * Uses composition over inheritance for this thin wrapper.
+ */
+function createProposalCoordinator(): ProposalCoordinator {
+  const coordinator = new BasePromiseCoordinator<
+    ProposalResult,
+    ProposalShowPayload
+  >({
+    showEventName: 'showAgentProposal',
+    resolveEventName: 'resolveAgentProposal',
+    idFieldName: 'proposalId',
+    defaultCancelResult: { action: 'reject' },
+  });
+
+  // Add the proposal-specific method
+  const extended = coordinator as ProposalCoordinator;
+  extended.waitForProposal = function (
     streamId: string,
     options: ProposalRequestOptions,
   ): Promise<ProposalResult> {
@@ -74,7 +86,9 @@ class AgentProposalCoordinatorImpl extends BasePromiseCoordinator<
       { proposalId, streamId, ...proposal },
       { timeoutMs },
     );
-  }
+  };
+
+  return extended;
 }
 
 // ============================================================================
@@ -82,4 +96,4 @@ class AgentProposalCoordinatorImpl extends BasePromiseCoordinator<
 // ============================================================================
 
 /** Singleton coordinator instance. */
-export const proposalCoordinator = new AgentProposalCoordinatorImpl();
+export const proposalCoordinator = createProposalCoordinator();

--- a/src/agent/runtime/AgentProposalCoordinator.ts
+++ b/src/agent/runtime/AgentProposalCoordinator.ts
@@ -42,37 +42,25 @@ interface ProposalShowPayload {
 }
 
 // ============================================================================
-// Factory-created Coordinator
+// Coordinator Implementation
 // ============================================================================
 
-/** Extended coordinator with proposal-specific method. */
-export interface ProposalCoordinator
-  extends BasePromiseCoordinator<ProposalResult, ProposalShowPayload> {
+/** Manages pending agent proposals (workflow and tool-use). */
+class AgentProposalCoordinatorImpl extends BasePromiseCoordinator<
+  ProposalResult,
+  ProposalShowPayload
+> {
+  constructor() {
+    super({
+      showEventName: 'showAgentProposal',
+      resolveEventName: 'resolveAgentProposal',
+      idFieldName: 'proposalId',
+      defaultCancelResult: { action: 'reject' },
+    });
+  }
+
   /** Wait for user action on a proposal. */
   waitForProposal(
-    streamId: string,
-    options: ProposalRequestOptions,
-  ): Promise<ProposalResult>;
-}
-
-/**
- * Create a proposal coordinator instance.
- * Uses composition over inheritance for this thin wrapper.
- */
-function createProposalCoordinator(): ProposalCoordinator {
-  const coordinator = new BasePromiseCoordinator<
-    ProposalResult,
-    ProposalShowPayload
-  >({
-    showEventName: 'showAgentProposal',
-    resolveEventName: 'resolveAgentProposal',
-    idFieldName: 'proposalId',
-    defaultCancelResult: { action: 'reject' },
-  });
-
-  // Add the proposal-specific method
-  const extended = coordinator as ProposalCoordinator;
-  extended.waitForProposal = function (
     streamId: string,
     options: ProposalRequestOptions,
   ): Promise<ProposalResult> {
@@ -86,9 +74,7 @@ function createProposalCoordinator(): ProposalCoordinator {
       { proposalId, streamId, ...proposal },
       { timeoutMs },
     );
-  };
-
-  return extended;
+  }
 }
 
 // ============================================================================
@@ -96,4 +82,4 @@ function createProposalCoordinator(): ProposalCoordinator {
 // ============================================================================
 
 /** Singleton coordinator instance. */
-export const proposalCoordinator = createProposalCoordinator();
+export const proposalCoordinator = new AgentProposalCoordinatorImpl();

--- a/src/agent/runtime/AgentProposalCoordinator.ts
+++ b/src/agent/runtime/AgentProposalCoordinator.ts
@@ -14,10 +14,7 @@
 // Local imports
 import { safeExecuteCommand } from '@frontend/system/commandUtils';
 import type { AgentProposal } from '@eventBus/types';
-import {
-  BasePromiseCoordinator,
-  type CoordinatorConfig,
-} from './BasePromiseCoordinator';
+import { BasePromiseCoordinator } from './BasePromiseCoordinator';
 
 // ============================================================================
 // Types
@@ -45,26 +42,37 @@ interface ProposalShowPayload {
 }
 
 // ============================================================================
-// Coordinator Implementation
+// Factory-created Coordinator
 // ============================================================================
 
-/** Manages pending agent proposals (workflow and tool-use). */
-class AgentProposalCoordinatorImpl extends BasePromiseCoordinator<
-  ProposalResult,
-  ProposalShowPayload
-> {
-  protected readonly config: CoordinatorConfig = {
+/** Extended coordinator with proposal-specific method. */
+export interface ProposalCoordinator
+  extends BasePromiseCoordinator<ProposalResult, ProposalShowPayload> {
+  /** Wait for user action on a proposal. */
+  waitForProposal(
+    streamId: string,
+    options: ProposalRequestOptions,
+  ): Promise<ProposalResult>;
+}
+
+/**
+ * Create a proposal coordinator instance.
+ * Uses composition over inheritance for this thin wrapper.
+ */
+function createProposalCoordinator(): ProposalCoordinator {
+  const coordinator = new BasePromiseCoordinator<
+    ProposalResult,
+    ProposalShowPayload
+  >({
     showEventName: 'showAgentProposal',
     resolveEventName: 'resolveAgentProposal',
     idFieldName: 'proposalId',
-  };
+    defaultCancelResult: { action: 'reject' },
+  });
 
-  protected getDefaultCancelResult(): ProposalResult {
-    return { action: 'reject' };
-  }
-
-  /** Wait for user action on a proposal. Uses different signature from base class. */
-  waitForProposal(
+  // Add the proposal-specific method
+  const extended = coordinator as ProposalCoordinator;
+  extended.waitForProposal = function (
     streamId: string,
     options: ProposalRequestOptions,
   ): Promise<ProposalResult> {
@@ -78,7 +86,9 @@ class AgentProposalCoordinatorImpl extends BasePromiseCoordinator<
       { proposalId, streamId, ...proposal },
       { timeoutMs },
     );
-  }
+  };
+
+  return extended;
 }
 
 // ============================================================================
@@ -86,4 +96,4 @@ class AgentProposalCoordinatorImpl extends BasePromiseCoordinator<
 // ============================================================================
 
 /** Singleton coordinator instance. */
-export const proposalCoordinator = new AgentProposalCoordinatorImpl();
+export const proposalCoordinator = createProposalCoordinator();

--- a/src/agent/runtime/BasePromiseCoordinator.ts
+++ b/src/agent/runtime/BasePromiseCoordinator.ts
@@ -41,13 +41,15 @@ type RequestState<TResult> =
   | { status: 'resolved' };
 
 /** Configuration for coordinator behavior */
-export interface CoordinatorConfig {
+export interface CoordinatorConfig<TResult extends BaseResult> {
   /** Event name emitted to show UI (e.g., 'showRetryRequest') */
   showEventName: keyof ProgressEventPayloads;
   /** Event name emitted to resolve/hide UI (e.g., 'resolveRetryRequest') */
   resolveEventName: keyof ProgressEventPayloads;
   /** Field name for ID in resolve event payload (e.g., 'streamId', 'proposalId') */
   idFieldName: string;
+  /** Default result for cancelled/replaced requests */
+  defaultCancelResult: TResult;
 }
 
 // ============================================================================
@@ -56,9 +58,9 @@ export interface CoordinatorConfig {
 
 /**
  * Generic coordinator for promise-based user interaction flows.
- * Subclasses provide specific result types and event configurations.
+ * Can be used directly with config or extended for additional behavior.
  */
-export abstract class BasePromiseCoordinator<
+export class BasePromiseCoordinator<
   TResult extends BaseResult,
   TShowPayload extends Record<string, unknown>,
 > {
@@ -66,13 +68,19 @@ export abstract class BasePromiseCoordinator<
   protected readonly requests = new Map<string, RequestState<TResult>>();
 
   /** Configuration for this coordinator */
-  protected abstract readonly config: CoordinatorConfig;
+  protected readonly config: CoordinatorConfig<TResult>;
+
+  constructor(config: CoordinatorConfig<TResult>) {
+    this.config = config;
+  }
 
   /**
    * Get the default result for cancelled/replaced requests.
-   * Subclasses override to provide appropriate default (e.g., { action: 'cancel' }).
+   * Override in subclasses for custom behavior.
    */
-  protected abstract getDefaultCancelResult(): TResult;
+  protected getDefaultCancelResult(): TResult {
+    return this.config.defaultCancelResult;
+  }
 
   /**
    * Wait for user action. Emits show event and returns Promise.

--- a/src/agent/runtime/RetryRequestCoordinator.ts
+++ b/src/agent/runtime/RetryRequestCoordinator.ts
@@ -12,10 +12,7 @@
 // Local imports
 import type { AgentLogger } from '@logger/AgentLogger';
 import type { RetryErrorDetails } from '@eventBus/types';
-import {
-  BasePromiseCoordinator,
-  type CoordinatorConfig,
-} from './BasePromiseCoordinator';
+import { BasePromiseCoordinator } from './BasePromiseCoordinator';
 
 // ============================================================================
 // Types
@@ -63,23 +60,22 @@ interface RetryShowPayload extends Record<string, unknown> {
 
 /**
  * Manages pending retry requests.
- * Extends BasePromiseCoordinator with retry-specific behavior.
+ * Extends BasePromiseCoordinator with retry-specific behavior (logger tracking).
  */
 class RetryRequestCoordinatorImpl extends BasePromiseCoordinator<
   RetryResult,
   RetryShowPayload
 > {
-  protected readonly config: CoordinatorConfig = {
-    showEventName: 'showRetryRequest',
-    resolveEventName: 'resolveRetryRequest',
-    idFieldName: 'streamId',
-  };
-
   /** Track logger per request for debug messages */
   private readonly loggers = new Map<string, AgentLogger>();
 
-  protected getDefaultCancelResult(): RetryResult {
-    return { action: 'cancel' };
+  constructor() {
+    super({
+      showEventName: 'showRetryRequest',
+      resolveEventName: 'resolveRetryRequest',
+      idFieldName: 'streamId',
+      defaultCancelResult: { action: 'cancel' },
+    });
   }
 
   /**

--- a/src/agent/runtime/StreamStatusService.ts
+++ b/src/agent/runtime/StreamStatusService.ts
@@ -91,7 +91,7 @@ export const StreamStatusService = {
     }
 
     if (emit) {
-      bus.emit('updateStreamStatus', { stream, status, previousStatus });
+      bus.emit('updateStreamStatus', { streamId: stream, status, previousStatus });
     }
   },
 

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -277,7 +277,7 @@ async function resolveAgentBase(
   // This ensures the frontend has state.activeStream set when addTaskGroup arrives,
   // preventing the race condition where groups are dropped.
   bus.emit('setActiveStream', {
-    stream: streamId,
+    streamId,
     agentCategory: setting.agentCategory,
     isRemote: isRemoteAgent(fullConfig.agent),
     hasMultipleOutputs: fullConfig.useMultipleOutputs,

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -585,7 +585,7 @@ export async function executeAgent(
       showAgentNotification(config);
     }
     bus.emit('setTaskState', {
-      streamTabId,
+      streamId: streamTabId,
       executionId,
       taskState: agentConfigToTaskState(config),
     });

--- a/src/commands/housekeeping/streamEventUtils.ts
+++ b/src/commands/housekeeping/streamEventUtils.ts
@@ -22,7 +22,7 @@ export function emitClearMissingOutputs(
 ): void {
   const { streamConfig, useMultipleOutputs, streamIdOverride } = options;
   bus.emit('clearMissingOutputs', {
-    stream:
+    streamId:
       streamIdOverride ||
       getStreamTabId(
         streamConfig.agent,

--- a/src/eventBus/ProgressEventBus.ts
+++ b/src/eventBus/ProgressEventBus.ts
@@ -26,13 +26,13 @@ import type {
 const MAX_BUFFER_SIZE = 1000;
 
 export interface ProgressEventPayloads {
-  addLogMessage: { stream: StreamTabId; logMessage: LogMessageData };
-  updateLogMessage: { stream: StreamTabId; logMessage: LogMessageUpdate };
+  addLogMessage: { streamId: StreamTabId; logMessage: LogMessageData };
+  updateLogMessage: { streamId: StreamTabId; logMessage: LogMessageUpdate };
   addTaskGroup: AddTaskGroupPayload;
   updateTaskGroup: UpdateTaskGroupPayload;
   setActiveStream: SetActiveStreamPayload;
   updateStreamStatus: {
-    stream: StreamTabId;
+    streamId: StreamTabId;
     status: StreamStatus;
     /** Previous status before this update, for detecting transitions */
     previousStatus: StreamStatus;
@@ -43,13 +43,13 @@ export interface ProgressEventPayloads {
   updateMissingOutputs: RunScopedPayload & {
     filesByRound: { [key: number]: string[] };
   };
-  clearMissingOutputs: { stream: StreamTabId };
+  clearMissingOutputs: { streamId: StreamTabId };
   setTaskState: SetTaskStatePayload;
   updateStreamUsage: RunScopedPayload & {
     usage: TokenUsageStats;
   };
   updateContextState: {
-    stream: StreamTabId;
+    streamId: StreamTabId;
     contextState: ContextStateData;
   };
   showRetryRequest: RetryRequestPrompt;

--- a/src/eventBus/schemas.ts
+++ b/src/eventBus/schemas.ts
@@ -42,14 +42,14 @@ export { TaskGroupStatusSchema, type TaskGroupStatus };
  * Uses TaskGroupSchema fields directly - no field renaming to avoid mapping overhead.
  */
 export const AddTaskGroupPayloadSchema = z.strictObject({
-  stream: StreamTabIdSchema,
+  streamId: StreamTabIdSchema,
   ...TaskGroupSchema.shape,
 });
 export type AddTaskGroupPayload = z.infer<typeof AddTaskGroupPayloadSchema>;
 
 /** Payload for updating a task group (subset of AddTaskGroupPayload) */
 export const UpdateTaskGroupPayloadSchema = AddTaskGroupPayloadSchema.pick({
-  stream: true,
+  streamId: true,
   id: true,
   status: true,
   endTime: true,
@@ -60,7 +60,7 @@ export type UpdateTaskGroupPayload = z.infer<
 
 /** Base payload for storage-scoped events (files, usage, etc.) */
 export const RunScopedPayloadSchema = z.strictObject({
-  stream: StreamTabIdSchema,
+  streamId: StreamTabIdSchema,
   storageKey: StorageKeySchema,
   executionId: ExecutionIdSchema.optional(),
 });
@@ -98,7 +98,7 @@ export type TodoItem = z.infer<typeof TodoItemSchema>;
 
 /** Payload for updating todos in a stream */
 export const UpdateTodosPayloadSchema = z.strictObject({
-  stream: StreamTabIdSchema,
+  streamId: StreamTabIdSchema,
   todos: z.array(TodoItemSchema),
 });
 export type UpdateTodosPayload = z.infer<typeof UpdateTodosPayloadSchema>;
@@ -109,7 +109,7 @@ export type UpdateTodosPayload = z.infer<typeof UpdateTodosPayloadSchema>;
 
 /** Payload for setting the active stream with optional category hint */
 export const SetActiveStreamPayloadSchema = z.strictObject({
-  stream: StreamTabIdSchema.nullable(),
+  streamId: StreamTabIdSchema.nullable(),
   agentCategory: z.nativeEnum(AgentCategory).optional(),
   /** Hint whether this is a remote agent (for UI display before TaskState is set) */
   isRemote: z.boolean().optional(),

--- a/src/eventBus/schemas.ts
+++ b/src/eventBus/schemas.ts
@@ -129,7 +129,7 @@ export type SetActiveStreamPayload = z.infer<
  * error messages from the underlying schema.
  */
 export const SetTaskStatePayloadSchema = z.strictObject({
-  streamTabId: StreamTabIdSchema,
+  streamId: StreamTabIdSchema,
   executionId: ExecutionIdSchema.optional(),
   // Validate with TaskStateSchema, then cast output to full TaskState type
   taskState: TaskStateSchema.pipe(z.custom<TaskState>(() => true)),

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -243,11 +243,11 @@ export async function activate(context: vscode.ExtensionContext) {
 
   disposeStatusListener = bus.on(
     'updateStreamStatus',
-    ({ stream, status }: { stream: string; status: StreamStatus }) => {
+    ({ streamId, status }: { streamId: string; status: StreamStatus }) => {
       if (status === STREAM_STATUS.RUNNING) {
-        runningStreams.add(stream);
+        runningStreams.add(streamId);
       } else if (isTerminalStatus(status)) {
-        runningStreams.delete(stream);
+        runningStreams.delete(streamId);
       }
       updateStatusBarText();
     },

--- a/src/logger/AgentLogger.ts
+++ b/src/logger/AgentLogger.ts
@@ -623,7 +623,7 @@ export class AgentLogger {
     const emitMessage = (isNew: boolean, text: string): void => {
       if (isNew) {
         bus.emit('addLogMessage', {
-          stream: emitStreamId,
+          streamId: emitStreamId,
           logMessage: {
             id,
             text,
@@ -636,7 +636,7 @@ export class AgentLogger {
         });
       } else {
         bus.emit('updateLogMessage', {
-          stream: emitStreamId,
+          streamId: emitStreamId,
           logMessage: { id, text, groupId, messageType: type },
         });
       }

--- a/src/logger/AgentUsageReporter.ts
+++ b/src/logger/AgentUsageReporter.ts
@@ -39,7 +39,7 @@ export class AgentUsageReporter {
    */
   public report(stats: ExtendedTokenUsageStats, storageKey: StorageKey): void {
     bus.emit('updateStreamUsage', {
-      stream: this.streamId,
+      streamId: this.streamId,
       storageKey,
       usage: {
         inputTokens: stats.inputTokens,

--- a/src/logger/transports/VSCodeTransport.ts
+++ b/src/logger/transports/VSCodeTransport.ts
@@ -63,7 +63,7 @@ export class VSCodeTransport extends Transport {
   startGroup(groupName: string, id: string, parentGroupId?: string): string {
     if (this.isAgentChannel) {
       bus.emit('addTaskGroup', {
-        stream: this.streamName,
+        streamId: this.streamName,
         id,
         name: groupName,
         startTime: Date.now(),
@@ -78,7 +78,7 @@ export class VSCodeTransport extends Transport {
   endGroup(groupId: string, status: EndGroupStatus): void {
     if (!this.isAgentChannel) return;
     bus.emit('updateTaskGroup', {
-      stream: this.streamName,
+      streamId: this.streamName,
       id: groupId,
       status,
       endTime: Date.now(),
@@ -129,7 +129,7 @@ export class VSCodeTransport extends Transport {
     if (!shouldEmit) return;
 
     bus.emit('addLogMessage', {
-      stream: this.streamName,
+      streamId: this.streamName,
       logMessage: {
         id: randomUUID(),
         text: event.message,
@@ -172,7 +172,7 @@ export class VSCodeTransport extends Transport {
    */
   private emitContextState(contextState: ContextStateData): void {
     bus.emit('updateContextState', {
-      stream: this.streamName,
+      streamId: this.streamName,
       contextState,
     });
   }

--- a/src/progressView/events/LogEventHandlers.ts
+++ b/src/progressView/events/LogEventHandlers.ts
@@ -35,16 +35,16 @@ export function registerLogEventHandlers(
 
 function handleAddLogMessage(
   ctx: EventHandlerContext,
-  { stream, logMessage }: ProgressEventPayloads['addLogMessage'],
+  { streamId, logMessage }: ProgressEventPayloads['addLogMessage'],
 ): void {
   withEventErrorHandling(
     'LogEvents',
     'failed to handle addLogMessage',
     async () => {
-      const isNew = await ctx.state.streamTabs.addMessage(stream, logMessage);
+      const isNew = await ctx.state.streamTabs.addMessage(streamId, logMessage);
       // Send to webview if available (regardless of active stream - messages persist)
       if (isNew && isWebviewAvailable(ctx)) {
-        ctx.webviewUpdater.appendLogMessage(stream, logMessage);
+        ctx.webviewUpdater.appendLogMessage(streamId, logMessage);
       }
     },
   );
@@ -52,7 +52,7 @@ function handleAddLogMessage(
 
 function handleUpdateLogMessage(
   ctx: EventHandlerContext,
-  { stream, logMessage }: ProgressEventPayloads['updateLogMessage'],
+  { streamId, logMessage }: ProgressEventPayloads['updateLogMessage'],
 ): void {
   withEventErrorHandling(
     'LogEvents',
@@ -62,23 +62,23 @@ function handleUpdateLogMessage(
       if (logMessage.messageType === MESSAGE_TYPES.INTERNAL) return;
 
       // Guard: don't create phantom streams for updates to non-existent streams
-      if (!ctx.state.streamTabs.has(stream)) return;
+      if (!ctx.state.streamTabs.has(streamId)) return;
 
       // Find existing message
-      const messages = ctx.state.streamTabs.getMessages(stream);
+      const messages = ctx.state.streamTabs.getMessages(streamId);
       const existing = messages.find((m) => m.id === logMessage.id);
       if (!existing || existing.messageType === MESSAGE_TYPES.INTERNAL) return;
 
       // Update state and notify webview
       const { id: _id, ...updates } = logMessage;
       const updated = ctx.state.streamTabs.updateMessage(
-        stream,
+        streamId,
         logMessage.id,
         updates,
       );
 
-      if (updated && canUpdateWebview(ctx, stream)) {
-        ctx.webviewUpdater.updateLogMessage(stream, {
+      if (updated && canUpdateWebview(ctx, streamId)) {
+        ctx.webviewUpdater.updateLogMessage(streamId, {
           ...existing,
           ...updates,
         });

--- a/src/progressView/events/OutputEventHandlers.ts
+++ b/src/progressView/events/OutputEventHandlers.ts
@@ -45,18 +45,18 @@ export function registerOutputEventHandlers(
 
 function handleAddOutputFiles(
   ctx: EventHandlerContext,
-  { stream, storageKey, filesByRound }: ProgressEventPayloads['addOutputFiles'],
+  { streamId, storageKey, filesByRound }: ProgressEventPayloads['addOutputFiles'],
 ): void {
   withEventErrorHandling(
     'OutputEvents',
     'failed to handle addOutputFiles',
     async () => {
-      await ctx.state.outputFiles.addFiles(stream, storageKey, filesByRound);
+      await ctx.state.outputFiles.addFiles(streamId, storageKey, filesByRound);
       if (!isWebviewAvailable(ctx)) return;
 
-      const runFiles = ctx.state.outputFiles.getFiles(stream).get(storageKey);
+      const runFiles = ctx.state.outputFiles.getFiles(streamId).get(storageKey);
       const rounds = mapToRecordIfNonEmpty(runFiles);
-      ctx.webviewUpdater.updateFiles(stream, { runId: storageKey, rounds });
+      ctx.webviewUpdater.updateFiles(streamId, { runId: storageKey, rounds });
     },
   );
 }
@@ -64,7 +64,7 @@ function handleAddOutputFiles(
 function handleUpdateMissingOutputs(
   ctx: EventHandlerContext,
   {
-    stream,
+    streamId,
     storageKey,
     filesByRound,
   }: ProgressEventPayloads['updateMissingOutputs'],
@@ -74,17 +74,17 @@ function handleUpdateMissingOutputs(
     'failed to handle updateMissingOutputs',
     async () => {
       await ctx.state.outputFiles.updateMissingOutputs(
-        stream,
+        streamId,
         storageKey,
         filesByRound,
       );
       if (!isWebviewAvailable(ctx)) return;
 
       const runMissing = ctx.state.outputFiles
-        .getMissingOutputs(stream)
+        .getMissingOutputs(streamId)
         .get(storageKey);
       const rounds = mapToRecordIfNonEmpty(runMissing);
-      ctx.webviewUpdater.updateMissingOutputs(stream, {
+      ctx.webviewUpdater.updateMissingOutputs(streamId, {
         runId: storageKey,
         rounds,
       });
@@ -94,16 +94,16 @@ function handleUpdateMissingOutputs(
 
 function handleClearMissingOutputs(
   ctx: EventHandlerContext,
-  { stream }: ProgressEventPayloads['clearMissingOutputs'],
+  { streamId }: ProgressEventPayloads['clearMissingOutputs'],
 ): void {
   withEventErrorHandling(
     'OutputEvents',
     'failed to handle clearMissingOutputs',
     async () => {
-      await ctx.state.outputFiles.clearMissingOutputs(stream);
+      await ctx.state.outputFiles.clearMissingOutputs(streamId);
       // Broadcast to webview - frontend decides which run to display
       if (isWebviewAvailable(ctx)) {
-        ctx.webviewUpdater.updateMissingOutputs(stream, { reset: true });
+        ctx.webviewUpdater.updateMissingOutputs(streamId, { reset: true });
       }
     },
   );

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -130,18 +130,18 @@ export class ProgressEventHandler {
   private async processSetActiveStream(
     payload: ProgressEventPayloads['setActiveStream'],
   ): Promise<void> {
-    const { stream, agentCategory, isRemote, hasMultipleOutputs } = payload;
-    if (!stream) return;
+    const { streamId, agentCategory, isRemote, hasMultipleOutputs } = payload;
+    if (!streamId) return;
 
-    await this.state.streamTabs.ensureStream(stream);
-    this.state.updateStreamHints(stream, {
+    await this.state.streamTabs.ensureStream(streamId);
+    this.state.updateStreamHints(streamId, {
       agentCategory,
       isRemote,
       hasMultipleOutputs,
     });
     this.maybeUpdateFilterForCategory(agentCategory);
-    this.state.activeStream = stream;
-    this.replayPendingTaskGroups(stream);
+    this.state.activeStream = streamId;
+    this.replayPendingTaskGroups(streamId);
 
     if (!this.webviewUpdater.isAvailable()) return;
 
@@ -150,10 +150,10 @@ export class ProgressEventHandler {
 
     // Refresh stream content (logs, groups, metadata, status, todos)
     // Note: refreshStreamSurface includes status update, so no separate setStreamStatus needed
-    const activeRunId = this.refreshStreamSurface(stream, {
+    const activeRunId = this.refreshStreamSurface(streamId, {
       updateInstruction: false,
     });
-    this.sendInstructionUpdate(stream, activeRunId);
+    this.sendInstructionUpdate(streamId, activeRunId);
   }
 
   private handleUpdateStreamStatus = (
@@ -164,7 +164,7 @@ export class ProgressEventHandler {
       'failed to handle updateStreamStatus',
       () =>
         this.setStreamStatus(
-          payload.stream,
+          payload.streamId,
           payload.status,
           payload.previousStatus,
         ),
@@ -221,22 +221,22 @@ export class ProgressEventHandler {
       'TaskGroup',
       'failed to handle addTaskGroup',
       async () => {
-        const { stream, ...group } = data;
+        const { streamId, ...group } = data;
         const { id, parentGroupId } = group;
 
-        const hasStream = this.state.streamTabs.has(stream);
+        const hasStream = this.state.streamTabs.has(streamId);
         const addGroupPromise = this.state.taskGroups.addGroup(
-          stream,
+          streamId,
           id,
           group,
         );
 
         if (!parentGroupId) {
-          this.state.setActiveRunId(stream, id);
+          this.state.setActiveRunId(streamId, id);
         }
 
         if (!hasStream) {
-          await this.initializeStreamForTaskGroup(stream);
+          await this.initializeStreamForTaskGroup(streamId);
         }
 
         // Send to webview if available and stream is active, otherwise buffer.
@@ -244,11 +244,11 @@ export class ProgressEventHandler {
         // from being dropped during initialization (e.g., Init stage).
         if (
           this.webviewUpdater.isAvailable() &&
-          stream === this.state.activeStream
+          streamId === this.state.activeStream
         ) {
-          this.webviewUpdater.addTaskGroup(stream, group);
+          this.webviewUpdater.addTaskGroup(streamId, group);
         } else {
-          this.bufferTaskGroupForReplay(stream, group);
+          this.bufferTaskGroupForReplay(streamId, group);
         }
 
         await addGroupPromise;
@@ -265,7 +265,7 @@ export class ProgressEventHandler {
       async () => {
         await this.state.taskGroups.updateGroup(data);
 
-        if (canUpdateWebview(this.ctx, data.stream)) {
+        if (canUpdateWebview(this.ctx, data.streamId)) {
           this.webviewUpdater.updateTaskGroup(data);
         }
       },

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -178,23 +178,23 @@ export class ProgressEventHandler {
       'StreamStatus',
       'failed to handle setTaskState',
       () => {
-        const { streamTabId, executionId, taskState } = data;
-        const isActiveStream = this.state.activeStream === streamTabId;
+        const { streamId, executionId, taskState } = data;
+        const isActiveStream = this.state.activeStream === streamId;
         const category = taskState.agentConfig.agentCategory;
         const previousFilter = this.state.agentCategoryFilter;
 
-        this.state.setTaskState(streamTabId, taskState);
+        this.state.setTaskState(streamId, taskState);
 
         if (isActiveStream) {
           this.maybeUpdateFilterForCategory(category);
         }
 
         if (executionId) {
-          this.state.setExecutionId(streamTabId, executionId);
+          this.state.setExecutionId(streamId, executionId);
         }
 
         if (isActiveStream) {
-          this.sendInstructionUpdate(streamTabId);
+          this.sendInstructionUpdate(streamId);
         }
 
         // Update stream tabs when:

--- a/src/progressView/events/TodoEventHandlers.ts
+++ b/src/progressView/events/TodoEventHandlers.ts
@@ -28,13 +28,13 @@ export function registerTodoEventHandlers(
 
 function handleUpdateTodos(
   ctx: EventHandlerContext,
-  { stream, todos }: ProgressEventPayloads['updateTodos'],
+  { streamId, todos }: ProgressEventPayloads['updateTodos'],
 ): void {
   withEventErrorHandling('TodoEvents', 'failed to handle updateTodos', () => {
-    ctx.state.setTodos(stream, todos);
+    ctx.state.setTodos(streamId, todos);
     // Broadcast to webview - frontend decides which run to display
     if (isWebviewAvailable(ctx)) {
-      ctx.webviewUpdater.updateTodos(stream, todos);
+      ctx.webviewUpdater.updateTodos(streamId, todos);
     }
   });
 }

--- a/src/progressView/events/UsageEventHandlers.ts
+++ b/src/progressView/events/UsageEventHandlers.ts
@@ -35,7 +35,7 @@ export function registerUsageEventHandlers(
 
 function handleUpdateStreamUsage(
   ctx: EventHandlerContext,
-  { stream, usage, storageKey }: ProgressEventPayloads['updateStreamUsage'],
+  { streamId, usage, storageKey }: ProgressEventPayloads['updateStreamUsage'],
 ): void {
   withEventErrorHandling(
     'UsageEvents',
@@ -43,19 +43,19 @@ function handleUpdateStreamUsage(
     async () => {
       // usage is already typed as TokenUsageStats from the event payload
       const accumulatedUsage = await ctx.state.usageStats.setRunUsage(
-        stream,
+        streamId,
         storageKey,
         usage,
       );
 
       // For tool-use sessions (no task groups), set active run ID from usage
-      if (!ctx.state.getActiveRunId(stream)) {
-        ctx.state.setActiveRunId(stream, storageKey);
+      if (!ctx.state.getActiveRunId(streamId)) {
+        ctx.state.setActiveRunId(streamId, storageKey);
       }
 
       // Broadcast to webview - frontend decides which run to display
       if (isWebviewAvailable(ctx) && accumulatedUsage) {
-        ctx.webviewUpdater.updateRunUsage(stream, storageKey, accumulatedUsage);
+        ctx.webviewUpdater.updateRunUsage(streamId, storageKey, accumulatedUsage);
       }
     },
   );
@@ -63,16 +63,16 @@ function handleUpdateStreamUsage(
 
 function handleUpdateContextState(
   ctx: EventHandlerContext,
-  { stream, contextState }: ProgressEventPayloads['updateContextState'],
+  { streamId, contextState }: ProgressEventPayloads['updateContextState'],
 ): void {
   withEventErrorHandling(
     'UsageEvents',
     'failed to handle updateContextState',
     () => {
-      ctx.state.setContextState(stream, contextState);
+      ctx.state.setContextState(streamId, contextState);
       // Broadcast to webview - frontend decides which run to display
       if (isWebviewAvailable(ctx)) {
-        ctx.webviewUpdater.updateContextState(stream, contextState);
+        ctx.webviewUpdater.updateContextState(streamId, contextState);
       }
     },
   );

--- a/src/progressView/managers/TaskGroupManager.ts
+++ b/src/progressView/managers/TaskGroupManager.ts
@@ -53,21 +53,21 @@ export class TaskGroupManager extends PersistentMapManager<
    * Uses UpdateTaskGroupPayload from event bus schema as single source of truth.
    */
   async updateGroup({
-    stream,
+    streamId,
     id,
     status,
     endTime,
   }: UpdateTaskGroupPayload): Promise<void> {
-    const streamGroups = this.get(stream);
+    const streamGroups = this.get(streamId);
     if (!streamGroups) {
-      this.logger.warn(`Cannot update group ${id}: stream ${stream} not found`);
+      this.logger.warn(`Cannot update group ${id}: stream ${streamId} not found`);
       return;
     }
 
     const group = streamGroups.get(id);
     if (!group) {
       this.logger.warn(
-        `Cannot update group ${id}: group not found in stream ${stream}`,
+        `Cannot update group ${id}: group not found in stream ${streamId}`,
       );
       return;
     }

--- a/src/test/logger/AgentLoggerFileList.test.ts
+++ b/src/test/logger/AgentLoggerFileList.test.ts
@@ -15,7 +15,7 @@ describe('AgentLogger.logFileCategory', () => {
     logger = new AgentLogger('TestFileListLogger');
     capturedMessages = [];
     unsubscribe = bus.on('addLogMessage', (payload) => {
-      if (payload.stream === 'TestFileListLogger') {
+      if (payload.streamId === 'TestFileListLogger') {
         capturedMessages.push(payload.logMessage);
       }
     });

--- a/src/test/logger/errorData.test.ts
+++ b/src/test/logger/errorData.test.ts
@@ -11,7 +11,7 @@ describe('AgentLogger error data', () => {
     const err = new Error('test failure');
     let captured: any;
     const off = bus.on('addLogMessage', (payload) => {
-      if (payload.stream === 'TestErrorLogger') {
+      if (payload.streamId === 'TestErrorLogger') {
         captured = payload.logMessage;
       }
     });


### PR DESCRIPTION
Renamed `stream` to `streamId` in all event payloads for consistency:
- ProgressEventBus.ts interface
- Event schemas in schemas.ts
- All event handlers that destructure payloads
- All emit sites across the codebase

This addresses the inconsistency where some events used `stream` (addLogMessage, updateStreamStatus) while others used `streamId` (resolveRetryRequest, showRetryRequest).

The backend now consistently uses `streamId` in event payloads, while the WebviewUpdater interface keeps `runId` for frontend-facing APIs where it's more user-friendly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Unifies event payloads and simplifies coordinator architecture for consistency and maintainability.
> 
> - Switches all ProgressEventBus payloads from `stream` to `streamId` and updates schemas, emitters, handlers, transports, services, and tests (e.g., logs, task groups, outputs, usage, context, todos, stream status)
> - Refactors `BasePromiseCoordinator` from abstract to configurable generic with `defaultCancelResult`; updates `RetryRequestCoordinator` to use constructor config
> - Reimplements `AgentProposalCoordinator` as a factory wrapper over `BasePromiseCoordinator` exposing `waitForProposal`
> - Updates call sites across agent runtime (e.g., `executeAgent`, `StreamStatusService`, `ToolUseCycleNode`, `OutputHandler`/`OutputFileProcessor`, `VSCodeTransport`, extension status bar) to emit/use `streamId`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4fdc6f915c5f1efb6cfee2d0bb60a7b1aadf82ef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->