### PR TITLE
Review tool use and progress view architecture

### DIFF
--- a/docs/architecture/TOOL_USE_PROGRESS_CHAIN_ANALYSIS.md
+++ b/docs/architecture/TOOL_USE_PROGRESS_CHAIN_ANALYSIS.md
@@ -1,0 +1,366 @@
+# Tool Use & Progress View Architecture Analysis
+
+**Date**: 2026-01-22
+**Reviewer**: Automated Architecture Review (Linus-style critical analysis)
+**Status**: Architecture is SOUND - minimal refactoring needed
+
+---
+
+## Executive Summary
+
+The tool use and progress view display chain is **well-architected** with clean separation of concerns. The codebase has already been refactored to follow the CLAUDE.md guidelines for flattening abstraction layers. There are a few minor opportunities for simplification, but no major structural issues.
+
+**Verdict**: 8/10 - Clean, maintainable, with minor cosmetic improvements possible.
+
+---
+
+## Architecture Diagrams
+
+### 1. Complete Data Flow: Tool Execution → Progress Display
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                           TOOL EXECUTION LAYER                              │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                             │
+│  runToolUseFlow()                                                           │
+│       │                                                                     │
+│       ├─→ resolveTools() [validate against registry]                        │
+│       ├─→ createToolUseRunFlow() [PocketFlow graph]                         │
+│       │                                                                     │
+│       └─→ PersistedFlow.run()                                               │
+│               │                                                             │
+│               ├─→ ToolUsePrepareNode ──────────────────────────────────┐    │
+│               │                                                        │    │
+│               └─→ ToolUseCycleNode ←───────────────────────────────────┤    │
+│                       │                                                │    │
+│                       └─→ createToolUseCycleFlow() ←──NATIVE NESTING   │    │
+│                               │                                        │    │
+│                               ├─→ ToolUsePrepNode                      │    │
+│                               ├─→ ToolUseCallNode ──→ modelHandler     │    │
+│                               ├─→ ToolUseProcessNode ──→ metrics       │    │
+│                               └─→ ToolUseDispatchNode                  │    │
+│                                       │                                │    │
+│                                       ├─→ tool.call(input)             │    │
+│                                       ├─→ logger.logToolUse()          │    │
+│                                       └─→ CONTINUE ────────────────────┘    │
+│                                                                             │
+└─────────────────────────────────────────────────────────────────────────────┘
+                                    │
+                                    │ Events emitted during execution
+                                    ▼
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                            EVENT BUS LAYER                                  │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                             │
+│  ProgressEventBus (Singleton with buffering)                                │
+│       │                                                                     │
+│       ├─→ addLogMessage      ──→ Log content for display                    │
+│       ├─→ addTaskGroup       ──→ Execution stage started                    │
+│       ├─→ updateTaskGroup    ──→ Stage completed/failed                     │
+│       ├─→ updateStreamUsage  ──→ Token usage stats                          │
+│       ├─→ addOutputFiles     ──→ Files written by agent                     │
+│       ├─→ updateTodos        ──→ Todo list changes                          │
+│       └─→ show*Prompt        ──→ UI interactions (retry/approval)           │
+│                                                                             │
+│  Buffer: MAX_BUFFER_SIZE=1000 events when no listeners                      │
+│  Replay: Events replayed on subscription (single pass per event type)       │
+│                                                                             │
+└─────────────────────────────────────────────────────────────────────────────┘
+                                    │
+                                    │ Subscribed by ProgressEventHandler
+                                    ▼
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                         PROGRESS VIEW LAYER                                 │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                             │
+│  ProgressEventHandler                                                       │
+│       │                                                                     │
+│       ├─→ Core handlers (inline):                                           │
+│       │       setActiveStream, updateStreamStatus, addTaskGroup, etc.       │
+│       │                                                                     │
+│       └─→ Domain handlers (modular files):                                  │
+│               ├─→ LogEventHandlers.ts       ──→ StreamTabsManager           │
+│               ├─→ OutputEventHandlers.ts    ──→ OutputFilesManager          │
+│               ├─→ UsageEventHandlers.ts     ──→ UsageStatsManager           │
+│               ├─→ TodoEventHandlers.ts      ──→ ProgressViewState           │
+│               ├─→ FollowUpEventHandlers.ts  ──→ External queue query        │
+│               └─→ UIEvents.ts               ──→ Callbacks to Provider       │
+│                                                                             │
+│  EventHandlerContext: {state, webviewUpdater}                               │
+│       ├─→ isWebviewAvailable()  ──→ Broadcast all run-scoped data           │
+│       └─→ canUpdateWebview()    ──→ Only current stream updates             │
+│                                                                             │
+└─────────────────────────────────────────────────────────────────────────────┘
+                                    │
+                                    │ Sends messages via WebviewUpdater
+                                    ▼
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                          WEBVIEW DISPLAY LAYER                              │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                             │
+│  WebviewUpdater                                                             │
+│       │                                                                     │
+│       ├─→ sendMessage() ──→ Iterates all webviews (sidebar + panel)         │
+│       │                                                                     │
+│       └─→ Methods:                                                          │
+│               updateStreams(), updateLogContent(), appendLogMessage(),      │
+│               updateFiles(), updateTodos(), updateStatus(),                 │
+│               showRetryRequest(), showToolEditApprovalPrompt(), etc.        │
+│                                                                             │
+│  Frontend (Browser)                                                         │
+│       │                                                                     │
+│       ├─→ messageHandlers.js  ──→ Routes incoming messages                  │
+│       ├─→ progressViewState.js ──→ Frontend state management                │
+│       ├─→ domHandlers.js      ──→ DOM manipulation                          │
+│       └─→ uiManagers/         ──→ Stream tabs, file list, etc.              │
+│                                                                             │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+### 2. Tool Use Cycle Flow (Detail)
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                    ToolUseCycleFlow (4-Node Chain)                          │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                             │
+│  ┌─────────────────┐                                                        │
+│  │ ToolUsePrepNode │◄─────────────────────────────────────┐                 │
+│  └────────┬────────┘                                      │                 │
+│           │ prep(): checkInterruption()                   │                 │
+│           │ post(): resetCycleState(), saveDebug          │                 │
+│           ▼                                               │                 │
+│  ┌─────────────────┐                                      │                 │
+│  │ ToolUseCallNode │  (extends RetryableInvocationNode)   │                 │
+│  └────────┬────────┘                                      │                 │
+│           │ exec(): modelHandler.createResponse({tools})  │                 │
+│           │        └─→ Returns {response, responseTimeMs} │                 │
+│           │ post(): shared.response = response            │                 │
+│           ▼                                               │                 │
+│  ┌──────────────────────┐                                 │                 │
+│  │ ToolUseProcessNode   │                                 │                 │
+│  └────────┬─────────────┘                                 │                 │
+│           │ exec(): (PURE - no side effects)              │                 │
+│           │   ├─→ extractToolUse(response)                │                 │
+│           │   ├─→ extractResponse(response)               │                 │
+│           │   ├─→ normalizeUsage(usage)                   │                 │
+│           │   └─→ Determine endTurn                       │                 │
+│           │                                               │                 │
+│           │ post(): (SIDE EFFECTS)                        │                 │
+│           │   ├─→ run.recordCycleMetrics()  ◄─────────────┼─ SINGLE SOURCE  │
+│           │   ├─→ onRoundFinalized(run)                   │   OF TRUTH      │
+│           │   └─→ Update shared state                     │                 │
+│           ▼                                               │                 │
+│  ┌────────────────────────┐                               │                 │
+│  │ ToolUseDispatchNode    │                               │                 │
+│  └────────┬───────────────┘                               │                 │
+│           │ prep(): Check interruption                    │                 │
+│           │                                               │                 │
+│           │ exec(): For each toolCall:                    │                 │
+│           │   ├─→ parseToolInput(call.input)              │                 │
+│           │   ├─→ toolRegistry.get(call.name)             │                 │
+│           │   ├─→ withToolFileInteractionContext()        │                 │
+│           │   │       └─→ tool.call(parsedInput)          │                 │
+│           │   ├─→ normalizeToolCallError() on failure     │                 │
+│           │   └─→ extractToolAttachments(result)          │                 │
+│           │                                               │                 │
+│           │ post(): Create follow-up messages             │                 │
+│           │   ├─→ For Google/DeepSeek: Batch all calls    │                 │
+│           │   └─→ For others: Individual follow-ups       │                 │
+│           │                                               │                 │
+│           └─→ CONTINUE ───────────────────────────────────┘                 │
+│                                                                             │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+### 3. State Management Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                          STATE ARCHITECTURE                                 │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                             │
+│  FLOW STATE (Mutable, passed as `shared`)                                   │
+│  ─────────────────────────────────────────                                  │
+│                                                                             │
+│  ┌────────────────────────────────────────────────────────────────┐         │
+│  │ ToolUseCycleShared                                             │         │
+│  ├────────────────────────────────────────────────────────────────┤         │
+│  │ From BaseCycleFieldsSchema:                                    │         │
+│  │   messages, shouldStop, endTurn, responseTimeMs,               │         │
+│  │   stopReason, lastError                                        │         │
+│  │                                                                │         │
+│  │ Tool-use specific:                                             │         │
+│  │   response, toolCalls, text, cycleIndex,                       │         │
+│  │   cycleResponseTimeMs, cycleNormalizedUsage                    │         │
+│  └────────────────────────────────────────────────────────────────┘         │
+│                                                                             │
+│  SERVICES (Immutable, accessed via `this.services`)                         │
+│  ──────────────────────────────────────────────────                         │
+│                                                                             │
+│  ┌────────────────────────────────────────────────────────────────┐         │
+│  │ ToolUseCycleServices                                           │         │
+│  ├────────────────────────────────────────────────────────────────┤         │
+│  │ Base: logger, modelHandler, client, setting, workspace         │         │
+│  │ Tool-use: toolRegistry, modelName, agentName, executionId      │         │
+│  │ State: run (AgentRunState), checkInterruption, onRoundFinalized│         │
+│  └────────────────────────────────────────────────────────────────┘         │
+│                                                                             │
+│  PROGRESS STATE (Persisted, managed by ProgressViewState)                   │
+│  ─────────────────────────────────────────────────────────                  │
+│                                                                             │
+│  ┌────────────────────────────────────────────────────────────────┐         │
+│  │ ProgressViewState (Composes 5 focused managers)                │         │
+│  ├────────────────────────────────────────────────────────────────┤         │
+│  │ StreamTabsManager    ──→ Log messages per stream (max 1000)    │         │
+│  │ TaskGroupManager     ──→ Execution stages by stream            │         │
+│  │ OutputFilesManager   ──→ Output files by (stream, run, round)  │         │
+│  │ UsageStatsManager    ──→ Token usage by (stream, run)          │         │
+│  │ RunInstructionManager ─→ Instruction text by (stream, run)     │         │
+│  │                                                                │         │
+│  │ Plus: taskStates, executionIds, sessionState (hints/todos)     │         │
+│  └────────────────────────────────────────────────────────────────┘         │
+│                                                                             │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Critical Analysis (Linus-style)
+
+### What's GOOD
+
+1. **Clean separation of concerns** - Tools don't know about UI, UI doesn't know about tools. The event bus is the **only** coupling point. This is correct.
+
+2. **Native nesting pattern** - Cycle flows run directly on outer shared state. No translation layer, no indirection. This is what code should look like.
+
+3. **Single source of truth for metrics** - `AgentRunState.recordCycleMetrics()` is called by both reflection and tool-use flows. Not two methods doing the same thing.
+
+4. **Event buffering** - The `ProgressEventBus` buffers events when no listeners exist and replays them on subscription. Handles race conditions elegantly without complex locking.
+
+5. **Domain event handlers** - Each event type has its own file (LogEventHandlers, OutputEventHandlers, etc.). Not one giant 2000-line handler.
+
+6. **Zod schemas as source of truth** - `ToolUseCycleFieldsSchema`, `BaseCycleFieldsSchema`, etc. Types derived from schemas, not duplicated.
+
+### What's QUESTIONABLE
+
+1. **Task group buffering inconsistency** (minor)
+   - `addTaskGroup` buffers in `pendingTaskGroups` Map (in-memory)
+   - `addLogMessage` persists to `StreamTabsManager` (workspace state)
+   - Different strategies for similar problems
+
+2. **Three separate pending prompt Maps** (minor)
+   - `pendingApprovalPrompts`, `pendingRetryRequests`, `pendingAgentProposals`
+   - Could be unified into single `pendingUIRequests` map
+
+3. **`parseToolInput()` is local function** (trivial)
+   - Located in `ToolUseCycleFlow.ts` at line 64
+   - Could be extracted to `@tools/utils` for reuse
+   - But it's only used in one place, so YAGNI applies
+
+4. **`normalizeToolCallError()` duplicates some logic** (trivial)
+   - Similar error normalization exists in `@tools/result`
+   - But the current implementation is clear and correct
+
+### What's WRONG
+
+**Nothing major.** The architecture has already been cleaned up according to CLAUDE.md guidelines:
+
+- ✅ No wrapper functions that just call another function
+- ✅ No factory patterns that add indirection without value
+- ✅ Nodes create and run flows directly
+- ✅ Services passed flat, not nested in wrapper objects
+
+---
+
+## Simplification Opportunities
+
+### Low Priority (Cosmetic)
+
+| Issue | Location | Effort | Impact |
+|-------|----------|--------|--------|
+| Unify pending prompt Maps | `ProgressViewProvider.ts` | Low | Code organization |
+| Extract `parseToolInput()` | `ToolUseCycleFlow.ts:64` | Trivial | Reusability |
+| Consistent task group buffering | `ProgressEventHandler.ts` | Medium | Consistency |
+
+### Not Recommended
+
+| Anti-refactoring | Reason |
+|------------------|--------|
+| Extract services creation into factory | Only called from one place |
+| Create "ToolExecutor" abstraction | Would add indirection without value |
+| Merge domain event handlers | Would create monolithic file |
+| Add EventBus "middleware" | Over-engineering for current needs |
+
+---
+
+## Event Flow Timeline
+
+```
+T=0ms    executeAgent() launches
+         │
+T=1ms    bus.emit('setActiveStream', {stream, agentCategory})
+         │  └─→ ProgressEventHandler.processSetActiveStream()
+         │       ├─→ state.streamTabs.ensureStream()
+         │       ├─→ state.updateStreamHints()
+         │       └─→ webviewUpdater.updateAll()
+         │
+T=2ms    ToolUseCycleFlow starts
+         │
+T=10ms   bus.emit('addTaskGroup', {stream, id, name, status='running'})
+         │  └─→ ProgressEventHandler.handleAddTaskGroup()
+         │       ├─→ state.taskGroups.addGroup()
+         │       └─→ webviewUpdater.addTaskGroup() OR buffer if not active
+         │
+T=50ms   Model API call completes
+         │  └─→ ToolUseProcessNode.post()
+         │       ├─→ run.recordCycleMetrics()  ◄── SINGLE SOURCE OF TRUTH
+         │       └─→ onRoundFinalized(run)
+         │            └─→ AgentUsageReporter.reportUsage()
+         │                 └─→ bus.emit('updateStreamUsage')
+         │
+T=60ms   Tool execution
+         │  └─→ ToolUseDispatchNode.exec()
+         │       ├─→ tool.call(input)
+         │       └─→ logger.logToolUse()
+         │            └─→ bus.emit('addLogMessage')
+         │                 └─→ webviewUpdater.appendLogMessage()
+         │
+T=100ms  Cycle completes
+         │  └─→ bus.emit('updateTaskGroup', {status='completed'})
+         │       └─→ webviewUpdater.updateTaskGroup()
+         │
+         ▼
+         Frontend renders updates
+```
+
+---
+
+## Conclusion
+
+The tool use and progress view architecture is **production-ready**. The codebase follows good practices:
+
+1. **PocketFlow pattern** - Clean node graph with prep/exec/post separation
+2. **Event-driven decoupling** - Tools emit events, UI subscribes
+3. **Modular handlers** - Each domain has focused responsibility
+4. **Schema-first types** - Zod schemas as source of truth
+5. **Minimal indirection** - No unnecessary wrapper layers
+
+**Recommendation**: No major refactoring needed. Address the low-priority cosmetic issues only if touching those files for other reasons.
+
+---
+
+## Files Reference
+
+| Layer | Key Files |
+|-------|-----------|
+| Tool Execution | `src/agent/core/flows/ToolUseCycleFlow.ts` |
+| Tool Dispatch | `src/agent/implementations/flows/tooluse/runToolUseFlow.ts` |
+| Event Bus | `src/eventBus/ProgressEventBus.ts` |
+| Event Handlers | `src/progressView/events/ProgressEventHandler.ts` |
+| Domain Handlers | `src/progressView/events/{Log,Output,Usage,Todo,FollowUp}EventHandlers.ts` |
+| State Management | `src/progressView/state/ProgressViewState.ts` |
+| Webview Updater | `src/progressView/managers/WebviewUpdater.ts` |
+| Tool Registry | `src/tools/registry.ts` |
+| Tool Base | `src/tools/core/base.ts` |

--- a/docs/architecture/TOOL_USE_PROGRESS_CHAIN_ANALYSIS.md
+++ b/docs/architecture/TOOL_USE_PROGRESS_CHAIN_ANALYSIS.md
@@ -678,20 +678,53 @@ cursor.setParams(params as any);  // Double cast
 
 ## Recommended Action Plan
 
-**Phase 1 - Quick Wins (Low Risk)**:
-1. Extract tool edit approval helper → Single PR
+**Phase 1 - Quick Wins (Low Risk)**: ✅ COMPLETED
+1. ✅ Extract tool edit approval helper → `src/tools/approval/executeApprovalFlow.ts`
 2. Add error context to tool failures → Single PR
 3. Fix Zod detection to use `instanceof` → Single PR
 
-**Phase 2 - Event Handlers (Medium Risk)**:
+**Phase 2 - Event Handlers (Medium Risk)**: ✅ PARTIALLY COMPLETED
 1. Add UI notification for event handler errors
 2. Create state→webview update helper
-3. Add message schemas for 16 handlers
+3. ✅ Add message schemas for 16 handlers → `src/webview/types/messages.ts`
 
-**Phase 3 - Abstractions (Medium Risk)**:
+**Phase 3 - Abstractions (Medium Risk)**: ✅ PARTIALLY COMPLETED
 1. Evaluate PersistentMapManager consolidation
 2. Consider event handler file consolidation
 3. Add type safety to model handlers
+4. ✅ Simplify coordinator subclasses → Factory function for AgentProposalCoordinator
+
+## Completed Refactorings
+
+### 1. Tool Edit Approval Flow Consolidation
+- **Created**: `src/tools/approval/executeApprovalFlow.ts`
+- **Functions**:
+  - `executeToolEditApprovalFlow()` - Standard 6-step approval sequence
+  - `executeToolEditApprovalFlowWithResult()` - For post-processing (TextEditorTool history)
+- **Updated tools**:
+  - `WriteTool.ts`: 88→43 lines (~50% reduction)
+  - `EditTool.ts`: 127→87 lines (~30% reduction)
+  - `TextEditorTool.ts`: 4 methods simplified
+
+### 2. Type-Safe Message Handlers
+- **Updated**: `src/progressView/ProgressViewMessageHandler.ts`
+- **Added schemas**: `src/webview/types/messages.ts`
+  - `StreamMessageSchema`, `RetryStreamMessageSchema`
+  - `SendFollowUpMessageSchema`, `SortStreamsMessageSchema`
+  - `FilterStreamsMessageSchema`, `OpenLabelMessageSchema`
+- **Pattern**: Changed from `(message: any)` to `(message: unknown)` + `safeParse()`
+
+### 3. Coordinator Subclass Simplification
+- **Refactored**: `src/agent/runtime/BasePromiseCoordinator.ts`
+  - Changed from abstract class to concrete `PromiseCoordinator`
+  - Config now passed via constructor instead of abstract property
+  - `defaultCancelResult` moved to config object
+- **Simplified**: `src/agent/runtime/AgentProposalCoordinator.ts`
+  - Changed from class inheritance to factory function + composition
+  - `createProposalCoordinator()` wraps `PromiseCoordinator` instance
+- **Updated**: `src/agent/runtime/RetryRequestCoordinator.ts`
+  - Still extends `PromiseCoordinator` (justified: has `loggers` Map state)
+  - Passes config via constructor
 
 ---
 

--- a/docs/architecture/TOOL_USE_PROGRESS_CHAIN_ANALYSIS.md
+++ b/docs/architecture/TOOL_USE_PROGRESS_CHAIN_ANALYSIS.md
@@ -351,6 +351,350 @@ The tool use and progress view architecture is **production-ready**. The codebas
 
 ---
 
+## Detailed Improvement Opportunities
+
+### HIGH PRIORITY: Code Duplication (50+ instances)
+
+#### 1. Tool Edit Approval Flow - Repeated 5+ times
+
+**Problem**: The 6-step approval sequence is copy-pasted across WriteTool, EditTool, and TextEditorTool (5 times in TextEditorTool alone).
+
+**Pattern repeated:**
+```typescript
+// Step 1: Check read gate
+const readGate = requireFileReadForEdit(path, exists);
+if (readGate) return readGate;
+
+// Step 2: Request approval
+const approval = await requestToolEditApproval({ path, originalContent, proposedContent, sourceTool });
+
+// Step 3: Handle rejection
+if (!approval.accepted) {
+  return buildApprovalRejectedResult(path, 'tool_name', approval.userMessage);
+}
+
+// Step 4: Write content
+const finalContent = getApprovedContent(approval, proposedContent);
+const { appliedContent } = await writeApprovedContent(path, originalContent, finalContent);
+
+// Step 5: Record read
+recordToolFileRead(path);
+
+// Step 6: Return result
+return { summary: 'Wrote...', output: '...', edits: [...] };
+```
+
+**Files affected:**
+- `src/tools/WriteTool.ts:37-87`
+- `src/tools/EditTool.ts:49-115`
+- `src/tools/TextEditorTool.ts:314-360, 404-464, 520-592, 610-685`
+
+**Fix**: Extract to single helper:
+```typescript
+async function executeApprovedEdit(params: {
+  path: string;
+  exists: boolean;
+  originalContent: string;
+  proposedContent: string;
+  sourceTool: string;
+  buildResult: (appliedContent: string) => ToolResult;
+}): Promise<ToolResult> {
+  // All 6 steps in one place
+}
+```
+
+**Impact**: ~200 lines removed, single source of truth for edit flow.
+
+---
+
+#### 2. Event Handler State→Webview Pattern - Repeated ~10 times
+
+**Problem**: Every event handler follows identical 3-step sequence.
+
+**Pattern repeated:**
+```typescript
+// Step 1: Update state
+await ctx.state.outputFiles.addFiles(stream, storageKey, filesByRound);
+
+// Step 2: Check webview
+if (!isWebviewAvailable(ctx)) return;
+
+// Step 3: Update webview
+ctx.webviewUpdater.updateFiles(stream, { runId: storageKey, rounds });
+```
+
+**Files affected:**
+- `src/progressView/events/LogEventHandlers.ts:36-50`
+- `src/progressView/events/OutputEventHandlers.ts:46-61`
+- `src/progressView/events/UsageEventHandlers.ts:36-61`
+- `src/progressView/events/TodoEventHandlers.ts:29-40`
+
+**Fix**: Create helper that encapsulates pattern:
+```typescript
+async function updateStateAndWebview<T>(
+  ctx: EventHandlerContext,
+  stateUpdate: () => Promise<T>,
+  webviewUpdate: (result: T) => void,
+): Promise<void> {
+  const result = await stateUpdate();
+  if (isWebviewAvailable(ctx)) {
+    webviewUpdate(result);
+  }
+}
+```
+
+---
+
+#### 3. Debug Saving Pattern - Repeated 4 times
+
+**Problem**: Identical `maybeSaveDebugObject()` calls with same structure.
+
+**Files affected:**
+- `src/agent/core/flows/ResponseCycleFlow.ts:210-222, 353-365`
+- `src/agent/core/flows/ToolUseCycleFlow.ts:218-229, 319-330`
+
+**Fix**: Extract to shared helper with default context builder.
+
+---
+
+### MEDIUM PRIORITY: Unnecessary Abstractions
+
+#### 1. Factory Functions Called Once
+
+| Factory | Location | Caller |
+|---------|----------|--------|
+| `createResponseCycleFlow()` | ResponseCycleFlow.ts:875 | ResponseCycleNode.ts:168 only |
+| `createToolUseCycleFlow()` | ToolUseCycleFlow.ts:814 | ToolUseCycleNode.ts:74 only |
+
+**Assessment**: These factories exist for testability and could be kept for that reason. However, per CLAUDE.md, if they're only called from one place, consider inlining.
+
+---
+
+#### 2. PersistentMapManager - 5 Thin Subclasses
+
+**Problem**: All 5 subclasses (UsageStatsManager, OutputFilesManager, TaskGroupManager, StreamTabsManager, RunInstructionManager) only override `serialize()`/`deserialize()` with 1-line implementations.
+
+**Current**:
+```typescript
+// RunInstructionManager.ts - 94 lines for essentially:
+protected override serialize(value: InstructionMap): unknown {
+  return mapToRecord(value);  // 1 line
+}
+protected override deserialize(data: unknown): InstructionMap {
+  return recordToMap<InstructionUpdate>(data);  // 1 line
+}
+```
+
+**Fix**: Consolidate to configurable manager:
+```typescript
+class PersistentMapManager<K, V> {
+  constructor(
+    private key: WorkspaceStateKey,
+    private serializer: (v: V) => unknown,
+    private deserializer: (d: unknown) => V,
+  ) {}
+}
+
+// Usage:
+const instructionManager = new PersistentMapManager(
+  WorkspaceStateKey.RUN_INSTRUCTIONS,
+  mapToRecord,
+  recordToMap<InstructionUpdate>,
+);
+```
+
+**Impact**: ~400 lines → ~150 lines.
+
+---
+
+#### 3. Separate Event Handler Files - Could Be Inlined
+
+**Current**: 5 separate files each with `registerXxxEventHandlers()` function called from one place.
+
+**Files**:
+- `LogEventHandlers.ts` (89 lines)
+- `OutputEventHandlers.ts` (111 lines)
+- `UsageEventHandlers.ts` (80 lines)
+- `TodoEventHandlers.ts` (~40 lines)
+- `FollowUpEventHandlers.ts` (~50 lines)
+
+**Assessment**: This is a **judgment call**. Separate files provide organization, but add ~30 lines of boilerplate per file. If each handler is <50 lines of actual logic, consider consolidating into `ProgressEventHandler.ts`.
+
+---
+
+### HIGH PRIORITY: Error Handling Issues
+
+#### 1. Event Handler Failures Silent to UI
+
+**File**: `src/progressView/events/errorHandling.ts:40-42`
+
+**Problem**:
+```typescript
+Promise.resolve(result).catch((error) =>
+  logError(moduleName, context, error),  // Logged but UI never knows
+);
+```
+
+**Fix**: Emit error event for UI notification:
+```typescript
+Promise.resolve(result).catch((error) => {
+  logError(moduleName, context, error);
+  bus.emit('eventHandlerError', { moduleName, context, error: toErrorMessage(error) });
+});
+```
+
+---
+
+#### 2. Tool Errors Lose Context
+
+**File**: `src/agent/core/flows/ToolUseCycleFlow.ts:111-112`
+
+**Problem**:
+```typescript
+return {
+  message: `${toolName}: Invalid parameters provided`,  // Generic, no param info
+};
+```
+
+**Fix**: Include parameter path:
+```typescript
+return {
+  message: `${toolName}: Invalid parameter at ${issue.path.join('.')}: ${issue.message}`,
+};
+```
+
+---
+
+#### 3. Zod Detection Uses Duck Typing
+
+**File**: `src/agent/core/flows/ToolUseCycleFlow.ts:89-97`
+
+**Problem**: Duck typing (`'issues' in error`) could match non-Zod errors.
+
+**Fix**:
+```typescript
+import { ZodError } from 'zod';
+function isZodError(error: unknown): error is ZodError {
+  return error instanceof ZodError;
+}
+```
+
+---
+
+#### 4. Silent Tool Registry Fallbacks
+
+**File**: `src/tools/registry.ts:154, 160`
+
+**Problem**:
+```typescript
+return ToolDefinitionSchema.catch({ name }).parse(item);  // Silent fallback to name-only
+```
+
+**Fix**: Throw with context instead:
+```typescript
+const result = ToolDefinitionSchema.safeParse(item);
+if (!result.success) {
+  throw new Error(`Tool '${name}' has invalid schema: ${result.error.message}`);
+}
+return result.data;
+```
+
+---
+
+### MEDIUM PRIORITY: Type Safety Gaps
+
+#### 1. 16 Message Handlers Accept `any`
+
+**File**: `src/progressView/ProgressViewMessageHandler.ts`
+
+**Lines**: 206, 214, 218, 226, 246, 255, 279, 287, 301, 305, 336, 342, 348, 353, 362, 369
+
+**Problem**:
+```typescript
+private async handleSwitchStream(message: any): Promise<void> {
+  this.provider.setActiveStream(message.stream);  // No validation
+}
+```
+
+**Fix**: Define message schemas:
+```typescript
+const SwitchStreamMessageSchema = z.object({ stream: StreamTabIdSchema });
+
+private async handleSwitchStream(message: unknown): Promise<void> {
+  const parsed = SwitchStreamMessageSchema.safeParse(message);
+  if (!parsed.success) return;
+  this.provider.setActiveStream(parsed.data.stream);
+}
+```
+
+---
+
+#### 2. Model Handler Uses `any[]` and `any` Parameters
+
+**File**: `src/agent/modelHandlers/ModelHandler.ts:603, 612-613`
+
+**Problem**:
+```typescript
+abstract createMediaContent(mediaMessage: MediaEntry[]): any[];
+abstract extractResponse(responseObject: any, endTag: string): ExtractResponseResult;
+```
+
+**Fix**: Define proper types:
+```typescript
+abstract createMediaContent(mediaMessage: MediaEntry[]): MediaContentPart[];
+abstract extractResponse(responseObject: unknown, endTag: string): ExtractResponseResult;
+```
+
+---
+
+#### 3. Persisted Flow Unsafe Casts
+
+**File**: `src/agent/node/persisted-flow.ts:127, 134-145`
+
+**Problem**:
+```typescript
+const params = flow.params as P;  // No validation
+const shared = flow.shared as S;  // No validation
+cursor.setParams(params as any);  // Double cast
+```
+
+**Fix**: Add Zod validation at deserialization.
+
+---
+
+## Refactoring Priority Matrix
+
+| Category | Items | Lines Saved | Risk | Priority |
+|----------|-------|-------------|------|----------|
+| Tool approval extraction | 1 helper | ~200 | Low | **HIGH** |
+| Event handler pattern helper | 1 helper | ~50 | Low | **HIGH** |
+| Error handling improvements | 4 fixes | 0 | Low | **HIGH** |
+| Type safety (message handlers) | 16 handlers | 0 | Medium | **MEDIUM** |
+| PersistentMapManager consolidation | 5 classes | ~250 | Medium | **MEDIUM** |
+| Debug saving helper | 1 helper | ~40 | Low | **LOW** |
+| Factory inlining | 2 factories | ~20 | Low | **LOW** |
+
+---
+
+## Recommended Action Plan
+
+**Phase 1 - Quick Wins (Low Risk)**:
+1. Extract tool edit approval helper → Single PR
+2. Add error context to tool failures → Single PR
+3. Fix Zod detection to use `instanceof` → Single PR
+
+**Phase 2 - Event Handlers (Medium Risk)**:
+1. Add UI notification for event handler errors
+2. Create state→webview update helper
+3. Add message schemas for 16 handlers
+
+**Phase 3 - Abstractions (Medium Risk)**:
+1. Evaluate PersistentMapManager consolidation
+2. Consider event handler file consolidation
+3. Add type safety to model handlers
+
+---
+
 ## Files Reference
 
 | Layer | Key Files |

--- a/src/agent/runtime/AgentProposalCoordinator.ts
+++ b/src/agent/runtime/AgentProposalCoordinator.ts
@@ -14,10 +14,7 @@
 // Local imports
 import { safeExecuteCommand } from '@frontend/system/commandUtils';
 import type { AgentProposal } from '@eventBus/types';
-import {
-  BasePromiseCoordinator,
-  type CoordinatorConfig,
-} from './BasePromiseCoordinator';
+import { PromiseCoordinator } from './BasePromiseCoordinator';
 
 // ============================================================================
 // Types
@@ -45,40 +42,55 @@ interface ProposalShowPayload {
 }
 
 // ============================================================================
-// Coordinator Implementation
+// Factory Function
 // ============================================================================
 
-/** Manages pending agent proposals (workflow and tool-use). */
-class AgentProposalCoordinatorImpl extends BasePromiseCoordinator<
-  ProposalResult,
-  ProposalShowPayload
-> {
-  protected readonly config: CoordinatorConfig = {
+/**
+ * Create the proposal coordinator with its specialized API.
+ * Uses factory function + composition instead of class inheritance
+ * since only the config and one wrapper method are needed.
+ */
+function createProposalCoordinator() {
+  const coordinator = new PromiseCoordinator<ProposalResult, ProposalShowPayload>({
     showEventName: 'showAgentProposal',
     resolveEventName: 'resolveAgentProposal',
     idFieldName: 'proposalId',
+    defaultCancelResult: { action: 'reject' },
+  });
+
+  return {
+    /** Wait for user action on a proposal. */
+    waitForProposal(
+      streamId: string,
+      options: ProposalRequestOptions,
+    ): Promise<ProposalResult> {
+      const { proposalId, proposal, timeoutMs } = options;
+
+      // Show progress view to ensure user sees the proposal
+      void safeExecuteCommand('texra.showProgressView');
+
+      return coordinator.waitForUserAction(
+        proposalId,
+        { proposalId, streamId, ...proposal },
+        { timeoutMs },
+      );
+    },
+
+    /** Check if a proposal is pending. */
+    hasPendingRequest(proposalId: string): boolean {
+      return coordinator.hasPendingRequest(proposalId);
+    },
+
+    /** Resolve a pending proposal. */
+    resolveRequest(proposalId: string, result: ProposalResult): boolean {
+      return coordinator.resolveRequest(proposalId, result);
+    },
+
+    /** Clear a pending proposal without user action. */
+    clearRequest(proposalId: string): void {
+      coordinator.clearRequest(proposalId);
+    },
   };
-
-  protected getDefaultCancelResult(): ProposalResult {
-    return { action: 'reject' };
-  }
-
-  /** Wait for user action on a proposal. Uses different signature from base class. */
-  waitForProposal(
-    streamId: string,
-    options: ProposalRequestOptions,
-  ): Promise<ProposalResult> {
-    const { proposalId, proposal, timeoutMs } = options;
-
-    // Show progress view to ensure user sees the proposal
-    void safeExecuteCommand('texra.showProgressView');
-
-    return this.waitForUserAction(
-      proposalId,
-      { proposalId, streamId, ...proposal },
-      { timeoutMs },
-    );
-  }
 }
 
 // ============================================================================
@@ -86,4 +98,4 @@ class AgentProposalCoordinatorImpl extends BasePromiseCoordinator<
 // ============================================================================
 
 /** Singleton coordinator instance. */
-export const proposalCoordinator = new AgentProposalCoordinatorImpl();
+export const proposalCoordinator = createProposalCoordinator();

--- a/src/agent/runtime/BasePromiseCoordinator.ts
+++ b/src/agent/runtime/BasePromiseCoordinator.ts
@@ -41,24 +41,26 @@ type RequestState<TResult> =
   | { status: 'resolved' };
 
 /** Configuration for coordinator behavior */
-export interface CoordinatorConfig {
+export interface CoordinatorConfig<TResult extends BaseResult> {
   /** Event name emitted to show UI (e.g., 'showRetryRequest') */
   showEventName: keyof ProgressEventPayloads;
   /** Event name emitted to resolve/hide UI (e.g., 'resolveRetryRequest') */
   resolveEventName: keyof ProgressEventPayloads;
   /** Field name for ID in resolve event payload (e.g., 'streamId', 'proposalId') */
   idFieldName: string;
+  /** Default result for cancelled/replaced requests */
+  defaultCancelResult: TResult;
 }
 
 // ============================================================================
-// Base Coordinator Implementation
+// Coordinator Implementation
 // ============================================================================
 
 /**
  * Generic coordinator for promise-based user interaction flows.
- * Subclasses provide specific result types and event configurations.
+ * Can be used directly with config or extended for specialized behavior.
  */
-export abstract class BasePromiseCoordinator<
+export class PromiseCoordinator<
   TResult extends BaseResult,
   TShowPayload extends Record<string, unknown>,
 > {
@@ -66,13 +68,18 @@ export abstract class BasePromiseCoordinator<
   protected readonly requests = new Map<string, RequestState<TResult>>();
 
   /** Configuration for this coordinator */
-  protected abstract readonly config: CoordinatorConfig;
+  protected readonly config: CoordinatorConfig<TResult>;
+
+  constructor(config: CoordinatorConfig<TResult>) {
+    this.config = config;
+  }
 
   /**
    * Get the default result for cancelled/replaced requests.
-   * Subclasses override to provide appropriate default (e.g., { action: 'cancel' }).
    */
-  protected abstract getDefaultCancelResult(): TResult;
+  protected getDefaultCancelResult(): TResult {
+    return this.config.defaultCancelResult;
+  }
 
   /**
    * Wait for user action. Emits show event and returns Promise.

--- a/src/agent/runtime/RetryRequestCoordinator.ts
+++ b/src/agent/runtime/RetryRequestCoordinator.ts
@@ -12,10 +12,7 @@
 // Local imports
 import type { AgentLogger } from '@logger/AgentLogger';
 import type { RetryErrorDetails } from '@eventBus/types';
-import {
-  BasePromiseCoordinator,
-  type CoordinatorConfig,
-} from './BasePromiseCoordinator';
+import { PromiseCoordinator } from './BasePromiseCoordinator';
 
 // ============================================================================
 // Types
@@ -63,23 +60,22 @@ interface RetryShowPayload extends Record<string, unknown> {
 
 /**
  * Manages pending retry requests.
- * Extends BasePromiseCoordinator with retry-specific behavior.
+ * Extends PromiseCoordinator with retry-specific behavior (logger tracking).
  */
-class RetryRequestCoordinatorImpl extends BasePromiseCoordinator<
+class RetryRequestCoordinatorImpl extends PromiseCoordinator<
   RetryResult,
   RetryShowPayload
 > {
-  protected readonly config: CoordinatorConfig = {
-    showEventName: 'showRetryRequest',
-    resolveEventName: 'resolveRetryRequest',
-    idFieldName: 'streamId',
-  };
-
   /** Track logger per request for debug messages */
   private readonly loggers = new Map<string, AgentLogger>();
 
-  protected getDefaultCancelResult(): RetryResult {
-    return { action: 'cancel' };
+  constructor() {
+    super({
+      showEventName: 'showRetryRequest',
+      resolveEventName: 'resolveRetryRequest',
+      idFieldName: 'streamId',
+      defaultCancelResult: { action: 'cancel' },
+    });
   }
 
   /**

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -66,6 +66,12 @@ import {
   InfoMessageSchema,
   ApprovalActionMessageSchema,
   FollowupTaskMessageSchema,
+  StreamMessageSchema,
+  RetryStreamMessageSchema,
+  SendFollowUpMessageSchema,
+  SortStreamsMessageSchema,
+  FilterStreamsMessageSchema,
+  OpenLabelMessageSchema,
 } from '@webview/types/messages';
 
 // Type imports
@@ -203,7 +209,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
    * This allows the provider to process any pending updates that
    * were queued while the webview was initializing.
    */
-  protected override async handleWebviewReady(message: any): Promise<void> {
+  protected override async handleWebviewReady(message: unknown): Promise<void> {
     const webviewView = this.getActiveView();
     if (webviewView) {
       await super.handleWebviewReady(message, webviewView);
@@ -211,19 +217,24 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     }
   }
 
-  private async handleSwitchStream(message: any): Promise<void> {
-    this.provider.setActiveStream(message.stream);
+  private async handleSwitchStream(message: unknown): Promise<void> {
+    const parsed = StreamMessageSchema.safeParse(message);
+    if (!parsed.success) return;
+    this.provider.setActiveStream(parsed.data.stream);
   }
 
-  private async handleDeleteStream(message: any): Promise<void> {
+  private async handleDeleteStream(message: unknown): Promise<void> {
+    const parsed = StreamMessageSchema.safeParse(message);
+    if (!parsed.success) return;
+    const { stream } = parsed.data;
     // Clear pending task groups to prevent memory leaks
-    this.provider.eventHandler.clearPendingTaskGroups(message.stream);
-    await this.provider.state.clearStream(message.stream);
+    this.provider.eventHandler.clearPendingTaskGroups(stream);
+    await this.provider.state.clearStream(stream);
     // Force rebuild since we deleted a stream
     this.provider.updateWebview({ forceRebuild: true });
   }
 
-  private async handleDeleteAll(_message: any): Promise<void> {
+  private async handleDeleteAll(_message: unknown): Promise<void> {
     // Show confirmation dialog
     const confirmation = await vscode.window.showWarningMessage(
       'Are you sure you want to delete all streams? This action cannot be undone.',
@@ -243,8 +254,10 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     this.provider.updateWebview({ forceRebuild: true });
   }
 
-  private async handleStopStream(message: any): Promise<void> {
-    await vscode.commands.executeCommand('texra.stopAgent', message.stream);
+  private async handleStopStream(message: unknown): Promise<void> {
+    const parsed = StreamMessageSchema.safeParse(message);
+    if (!parsed.success) return;
+    await vscode.commands.executeCommand('texra.stopAgent', parsed.data.stream);
   }
 
   /**
@@ -252,8 +265,10 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
    * Reuses the executionId so the flow picks up persisted state.
    * Tool-use agents use the follow-up mechanism instead.
    */
-  private async handleResume(message: any): Promise<void> {
-    const streamId = message.stream as StreamTabId;
+  private async handleResume(message: unknown): Promise<void> {
+    const parsed = StreamMessageSchema.safeParse(message);
+    if (!parsed.success) return;
+    const streamId = parsed.data.stream as StreamTabId;
     const taskState = this.provider.state.getTaskState(streamId);
     if (!taskState) {
       return;
@@ -276,21 +291,23 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     await safeExecuteCommand('texra.execute', [taskState.agentConfig]);
   }
 
-  private async handleRunNew(message: any): Promise<void> {
-    const taskState = this.provider.state.getTaskState(message.stream);
+  private async handleRunNew(message: unknown): Promise<void> {
+    const parsed = StreamMessageSchema.safeParse(message);
+    if (!parsed.success) return;
+    const taskState = this.provider.state.getTaskState(parsed.data.stream);
     if (!taskState) {
       return;
     }
     await safeExecuteCommand('texra.execute', [taskState.agentConfig]);
   }
 
-  private async handleRetryStreamRequest(message: any): Promise<void> {
+  private async handleRetryStreamRequest(message: unknown): Promise<void> {
+    const parsed = RetryStreamMessageSchema.safeParse(message);
+    if (!parsed.success) return;
+    const { stream, feedback } = parsed.data;
     // triggerRetry is synchronous, no await needed
     // Pass optional feedback from the UI
-    const success = retryCoordinator.triggerRetry(
-      message.stream,
-      message.feedback,
-    );
+    const success = retryCoordinator.triggerRetry(stream, feedback);
     if (!success) {
       await vscode.window.showInformationMessage(
         'No retryable request is available for this stream yet.',
@@ -298,21 +315,26 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     }
   }
 
-  private async handleCancelRetryRequest(message: any): Promise<void> {
-    retryCoordinator.cancelRetry(message.stream);
+  private async handleCancelRetryRequest(message: unknown): Promise<void> {
+    const parsed = StreamMessageSchema.safeParse(message);
+    if (!parsed.success) return;
+    retryCoordinator.cancelRetry(parsed.data.stream);
   }
 
-  private async handleDiffStream(message: any): Promise<void> {
-    await this.withToolbarTaskState(message.stream, async (taskState) => {
-      const executionId = this.provider.state.getExecutionId(message.stream);
-      const activeRunId = this.provider.state.getActiveRunId(message.stream);
+  private async handleDiffStream(message: unknown): Promise<void> {
+    const parsed = StreamMessageSchema.safeParse(message);
+    if (!parsed.success) return;
+    const { stream } = parsed.data;
+    await this.withToolbarTaskState(stream, async (taskState) => {
+      const executionId = this.provider.state.getExecutionId(stream);
+      const activeRunId = this.provider.state.getActiveRunId(stream);
       // storageKey is for logical indexing (finding file metadata in progress view state).
       // For workflow agents: activeRunId = task group ID; for tool-use: executionId.
       // Note: Physical file paths use executionId (see runId below), not storageKey.
       const storageKey: StorageKey | null =
         activeRunId ?? (executionId as StorageKey | undefined) ?? null;
       const runOutputs = storageKey
-        ? this.provider.state.getRunOutputFiles(message.stream, { storageKey })
+        ? this.provider.state.getRunOutputFiles(stream, { storageKey })
         : undefined;
       const outputsByRound = runOutputs
         ? Object.fromEntries(runOutputs.entries())
@@ -324,7 +346,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
         inputFile: taskState.agentConfig.inputFile,
         outputFiles: taskState.agentConfig.outputFiles,
         outputFilesActive: taskState.activeFiles.output,
-        streamId: message.stream,
+        streamId: stream,
         // executionId is for file system paths (taskRuns/<executionId>/...)
         // storageKey is for logical storage indexing - different concepts
         runId: executionId,
@@ -333,43 +355,58 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     });
   }
 
-  private async handlePackStream(message: any): Promise<void> {
-    await this.withToolbarTaskState(message.stream, async (taskState) => {
-      await this.handleFileOperation(message.stream, taskState, 'texra.pack');
+  private async handlePackStream(message: unknown): Promise<void> {
+    const parsed = StreamMessageSchema.safeParse(message);
+    if (!parsed.success) return;
+    const { stream } = parsed.data;
+    await this.withToolbarTaskState(stream, async (taskState) => {
+      await this.handleFileOperation(stream, taskState, 'texra.pack');
     });
   }
 
-  private async handleCleanStream(message: any): Promise<void> {
-    await this.withToolbarTaskState(message.stream, async (taskState) => {
-      await this.handleFileOperation(message.stream, taskState, 'texra.clean');
+  private async handleCleanStream(message: unknown): Promise<void> {
+    const parsed = StreamMessageSchema.safeParse(message);
+    if (!parsed.success) return;
+    const { stream } = parsed.data;
+    await this.withToolbarTaskState(stream, async (taskState) => {
+      await this.handleFileOperation(stream, taskState, 'texra.clean');
     });
   }
 
-  private async handleSortStreams(message: any): Promise<void> {
-    this.provider.state.streamSortOrder = message.sortBy ?? 'time';
+  private async handleSortStreams(message: unknown): Promise<void> {
+    const parsed = SortStreamsMessageSchema.safeParse(message);
+    if (!parsed.success) return;
+    this.provider.state.streamSortOrder = parsed.data.sortBy ?? 'time';
     this.provider.updateWebview();
   }
 
-  private async handleFilterStreams(message: any): Promise<void> {
+  private async handleFilterStreams(message: unknown): Promise<void> {
+    const parsed = FilterStreamsMessageSchema.safeParse(message);
+    if (!parsed.success) return;
     this.provider.state.agentCategoryFilter = isAgentCategoryFilter(
-      message.filter,
+      parsed.data.filter,
     )
-      ? message.filter
+      ? parsed.data.filter
       : 'all';
     this.provider.updateWebview();
   }
 
-  private async handleRestoreState(message: any): Promise<void> {
-    const taskState = this.provider.state.getTaskState(message.stream);
+  private async handleRestoreState(message: unknown): Promise<void> {
+    const parsed = StreamMessageSchema.safeParse(message);
+    if (!parsed.success) return;
+    const taskState = this.provider.state.getTaskState(parsed.data.stream);
     if (taskState) {
       await vscode.commands.executeCommand('texra.restoreState', taskState);
     }
   }
 
-  private async handleSendFollowUp(message: any): Promise<void> {
+  private async handleSendFollowUp(message: unknown): Promise<void> {
+    const parsed = SendFollowUpMessageSchema.safeParse(message);
+    if (!parsed.success) return;
+    const { stream, text } = parsed.data;
     await vscode.commands.executeCommand('texra.sendFollowUp', {
-      stream: message.stream,
-      text: message.text,
+      stream,
+      text,
     });
   }
 
@@ -580,14 +617,15 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     );
   }
 
-  private async handleOpenTaskStorage(message: any): Promise<void> {
-    const stream = message.stream as StreamTabId | undefined;
-    if (!stream) {
+  private async handleOpenTaskStorage(message: unknown): Promise<void> {
+    const parsed = StreamMessageSchema.safeParse(message);
+    if (!parsed.success) {
       await vscode.window.showInformationMessage(
         'No workspace storage folder is available for this run yet.',
       );
       return;
     }
+    const stream = parsed.data.stream as StreamTabId;
 
     // Use cached activeRunId (set by event handlers when data arrives)
     const storageKey = this.provider.state.getActiveRunId(stream);
@@ -765,8 +803,10 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     );
   }
 
-  private async handleOpenLabel(message: any): Promise<void> {
-    await vscode.commands.executeCommand('texra.openLabel', message.label);
+  private async handleOpenLabel(message: unknown): Promise<void> {
+    const parsed = OpenLabelMessageSchema.safeParse(message);
+    if (!parsed.success) return;
+    await vscode.commands.executeCommand('texra.openLabel', parsed.data.label);
   }
 
   private async handleOpenProfile(): Promise<void> {

--- a/src/tools/EditTool.ts
+++ b/src/tools/EditTool.ts
@@ -3,18 +3,9 @@ import { z } from 'zod';
 
 // Local imports - tools
 import { ToolError, ToolResult } from '@tools/result';
-import {
-  recordToolFileRead,
-  requireFileReadForEdit,
-} from '@tools/fileInteractions';
+import { requireFileReadForEdit } from '@tools/fileInteractions';
 import { pluralize } from '@tools/utils';
-import {
-  buildApprovalRejectedResult,
-  formatUnifiedApprovalUserDiff,
-  getApprovedContent,
-  requestToolEditApproval,
-  writeApprovedContent,
-} from '@tools/approval/toolEditApproval';
+import { executeToolEditApprovalFlow } from '@tools/approval/executeApprovalFlow';
 import { WorkspaceFS } from '@utils/files';
 
 // Local file imports
@@ -55,12 +46,14 @@ export class EditFileTool extends defineTool({
       );
     }
 
+    // Validation: file must exist and have been read
     const exists = await WorkspaceFS.exists(targetPath);
     const readGate = requireFileReadForEdit(targetPath, exists);
     if (readGate) {
       return readGate;
     }
 
+    // Validation: old_str must be found
     const currentContent = await WorkspaceFS.read(targetPath);
     const occurrences = countOccurrences(currentContent, old_str);
 
@@ -76,52 +69,23 @@ export class EditFileTool extends defineTool({
       );
     }
 
+    // Build proposed content
     const updatedContent = replace_all
       ? currentContent.replaceAll(old_str, new_str)
       : currentContent.replace(old_str, new_str);
 
-    const approval = await requestToolEditApproval({
+    const count = replace_all ? occurrences : 1;
+    const replacementSummary = `Replaced ${count} ${pluralize(count, 'occurrence')}.`;
+
+    // Execute approval flow (skip read check since we already validated above)
+    return executeToolEditApprovalFlow({
       path: targetPath,
       originalContent: currentContent,
       proposedContent: updatedContent,
       sourceTool: 'edit_file',
+      summaryMessage: `Edited ${targetPath}: replaced ${count} ${pluralize(count, 'occurrence')}`,
+      successOutputPrefix: replacementSummary,
+      skipFileReadCheck: true,
     });
-
-    if (!approval.accepted) {
-      return buildApprovalRejectedResult(
-        targetPath,
-        'edit_file',
-        approval.userMessage,
-      );
-    }
-
-    const finalContent = getApprovedContent(approval, updatedContent);
-    const { appliedContent } = await writeApprovedContent(
-      targetPath,
-      currentContent,
-      finalContent,
-    );
-
-    recordToolFileRead(targetPath);
-
-    const count = replace_all ? occurrences : 1;
-    const replacementSummary = `Replaced ${count} ${pluralize(count, 'occurrence')}.`;
-    const summary = `Edited ${targetPath}: replaced ${count} ${pluralize(count, 'occurrence')}`;
-
-    const userDiffNote = formatUnifiedApprovalUserDiff(
-      targetPath,
-      updatedContent,
-      appliedContent,
-    );
-    const output = userDiffNote
-      ? `${replacementSummary}\n\n${userDiffNote}`
-      : replacementSummary;
-
-    return {
-      summary,
-      output,
-      userPatch: approval.userPatch,
-      edits: [{ path: targetPath, lineChanges: approval.lineChanges }],
-    };
   }
 }

--- a/src/tools/TextEditorTool.ts
+++ b/src/tools/TextEditorTool.ts
@@ -14,12 +14,10 @@ import {
   requireFileReadForEdit,
 } from '@tools/fileInteractions';
 import {
-  buildApprovalRejectedResult,
-  formatUnifiedApprovalUserDiff,
-  getApprovedContent,
-  requestToolEditApproval,
-  writeApprovedContent,
-} from '@tools/approval/toolEditApproval';
+  executeToolEditApprovalFlow,
+  executeToolEditApprovalFlowWithResult,
+} from '@tools/approval/executeApprovalFlow';
+import { formatUnifiedApprovalUserDiff } from '@tools/approval/toolEditApproval';
 import { WorkspaceFS, AbsoluteFS } from '@utils/files';
 
 // Local file imports
@@ -320,56 +318,26 @@ export class TextEditorTool extends defineTool({
    */
   private async create(filePath: string, content: string): Promise<ToolResult> {
     try {
-      const proposedContent = isTexFile(filePath)
-        ? replacementEngine.applyAll(content)
-        : content;
-      const approval = await requestToolEditApproval({
-        path: filePath,
-        originalContent: '',
-        proposedContent: proposedContent,
-        sourceTool: 'text_editor:create',
-      });
-
-      if (!approval.accepted) {
-        return buildApprovalRejectedResult(
-          filePath,
-          'text_editor:create',
-          approval.userMessage,
-        );
-      }
-
       // Create parent directories if they don't exist
       const dirPath = path.dirname(filePath);
       if (dirPath !== '.') {
         await WorkspaceFS.ensureDir(dirPath);
       }
 
-      const finalContent = getApprovedContent(approval, proposedContent);
-      const { appliedContent } = await writeApprovedContent(
-        filePath,
-        '',
-        finalContent,
-      );
+      // Apply LaTeX transformations before approval
+      const proposedContent = isTexFile(filePath)
+        ? replacementEngine.applyAll(content)
+        : content;
 
-      // Record file as "read" after creation so subsequent edits don't require
-      // an explicit read - this is essential for newly created files.
-      recordToolFileRead(filePath);
-
-      const userDiffNote = formatUnifiedApprovalUserDiff(
-        filePath,
+      return executeToolEditApprovalFlow({
+        path: filePath,
+        originalContent: '',
         proposedContent,
-        appliedContent,
-      );
-      const output = userDiffNote
-        ? `File created successfully at: ${filePath}\n\n${userDiffNote}`
-        : `File created successfully at: ${filePath}`;
-
-      return {
-        summary: `Created file ${filePath}`,
-        output,
-        userPatch: approval.userPatch,
-        edits: [{ path: filePath, lineChanges: approval.lineChanges }],
-      };
+        sourceTool: 'text_editor:create',
+        summaryMessage: `Created file ${filePath}`,
+        successOutputPrefix: `File created successfully at: ${filePath}`,
+        skipFileReadCheck: true,
+      });
     } catch (error) {
       throw new ToolError(`Error creating file ${filePath}: ${error}`);
     }
@@ -388,7 +356,7 @@ export class TextEditorTool extends defineTool({
     newStr: string,
   ): Promise<ToolResult> {
     try {
-      // Read file content
+      // Validation: file must exist and have been read
       const exists = await WorkspaceFS.exists(filePath);
       const readGate = requireFileReadForEdit(filePath, exists);
       if (readGate) {
@@ -401,7 +369,7 @@ export class TextEditorTool extends defineTool({
       const expandedOldStr = oldStr.replaceAll('\t', '    ');
       const expandedNewStr = newStr.replaceAll('\t', '    ');
 
-      // Check for occurrences of oldStr
+      // Validation: old_str must be found exactly once
       const occurrences = expandedFileContent.split(expandedOldStr).length - 1;
 
       if (occurrences === 0) {
@@ -411,7 +379,6 @@ export class TextEditorTool extends defineTool({
       }
 
       if (occurrences > 1) {
-        // Find line numbers where oldStr occurs
         const lines = expandedFileContent.split('\n');
         const lineNumbers = lines
           .map((line, index) =>
@@ -424,43 +391,13 @@ export class TextEditorTool extends defineTool({
         );
       }
 
-      // Perform replacement
+      // Build proposed content
       const newFileContent = expandedFileContent.replace(
         expandedOldStr,
         expandedNewStr,
       );
 
-      const approval = await requestToolEditApproval({
-        path: filePath,
-        originalContent: fileContent,
-        proposedContent: newFileContent,
-        sourceTool: 'text_editor:str_replace',
-      });
-
-      if (!approval.accepted) {
-        return buildApprovalRejectedResult(
-          filePath,
-          'text_editor:str_replace',
-          approval.userMessage,
-        );
-      }
-
-      const approvedContent = getApprovedContent(approval, newFileContent);
-      const { appliedContent, baseContent } = await writeApprovedContent(
-        filePath,
-        fileContent,
-        approvedContent,
-      );
-      if (appliedContent !== baseContent) {
-        this.addToHistory(filePath, baseContent);
-      }
-      const finalContent = appliedContent;
-
-      // Record file as "read" after editing so subsequent edits don't require
-      // an explicit read again.
-      recordToolFileRead(filePath);
-
-      // Create a snippet of the edited section
+      // Calculate snippet position for output
       const textBeforeReplacement =
         expandedFileContent.split(expandedOldStr)[0];
       const replacementLine =
@@ -469,34 +406,53 @@ export class TextEditorTool extends defineTool({
       const endLine =
         replacementLine + SNIPPET_LINES + (newStr.match(/\n/g) ?? []).length;
 
-      const newFileLines = finalContent.split('\n');
-      const snippet = newFileLines.slice(startLine - 1, endLine).join('\n');
+      // Execute approval flow with history tracking
+      return executeToolEditApprovalFlowWithResult(
+        {
+          path: filePath,
+          originalContent: fileContent,
+          proposedContent: newFileContent,
+          sourceTool: 'text_editor:str_replace',
+          summaryMessage: `Updated ${filePath}`,
+          skipFileReadCheck: true,
+        },
+        (writeResult, approval) => {
+          const { appliedContent, baseContent } = writeResult;
 
-      // Prepare success message
-      const userDiffNote = formatUnifiedApprovalUserDiff(
-        filePath,
-        newFileContent,
-        finalContent,
-      );
-      const successIntro = `The file ${filePath} has been edited.`;
-      const snippetOutput = this.makeOutput(
-        snippet,
-        `a snippet of ${filePath}`,
-        startLine,
-      );
-      const reviewMessage =
-        'Review the changes and make sure they are as expected. Edit the file again if necessary.';
-      const baseMsg = `${successIntro} ${snippetOutput}${reviewMessage}`;
-      const successMsg = userDiffNote
-        ? `${baseMsg}\n\n${userDiffNote}`
-        : baseMsg;
+          // Track history for undo support
+          if (appliedContent !== baseContent) {
+            this.addToHistory(filePath, baseContent);
+          }
 
-      return {
-        summary: `Updated ${filePath}`,
-        output: successMsg,
-        userPatch: approval.userPatch,
-        edits: [{ path: filePath, lineChanges: approval.lineChanges }],
-      };
+          // Build snippet output
+          const newFileLines = appliedContent.split('\n');
+          const snippet = newFileLines.slice(startLine - 1, endLine).join('\n');
+          const snippetOutput = this.makeOutput(
+            snippet,
+            `a snippet of ${filePath}`,
+            startLine,
+          );
+
+          // Format output
+          const userDiffNote = formatUnifiedApprovalUserDiff(
+            filePath,
+            newFileContent,
+            appliedContent,
+          );
+          const successIntro = `The file ${filePath} has been edited.`;
+          const reviewMessage =
+            'Review the changes and make sure they are as expected. Edit the file again if necessary.';
+          const baseMsg = `${successIntro} ${snippetOutput}${reviewMessage}`;
+          const output = userDiffNote ? `${baseMsg}\n\n${userDiffNote}` : baseMsg;
+
+          return {
+            summary: `Updated ${filePath}`,
+            output,
+            userPatch: approval.userPatch,
+            edits: [{ path: filePath, lineChanges: approval.lineChanges }],
+          };
+        },
+      );
     } catch (error) {
       if (error instanceof ToolError) {
         throw error;
@@ -518,7 +474,7 @@ export class TextEditorTool extends defineTool({
     newStr: string,
   ): Promise<ToolResult> {
     try {
-      // Read file content
+      // Validation: file must exist and have been read
       const exists = await WorkspaceFS.exists(filePath);
       const readGate = requireFileReadForEdit(filePath, exists);
       if (readGate) {
@@ -530,94 +486,80 @@ export class TextEditorTool extends defineTool({
       const expandedFileContent = fileContent.replaceAll('\t', '    ');
       const expandedNewStr = newStr.replaceAll('\t', '    ');
 
-      // Split content into lines
+      // Validation: insert line must be in range
       const fileLines = expandedFileContent.split('\n');
       const numLines = fileLines.length;
 
-      // Validate insert line
       if (insertLine < 0 || insertLine > numLines) {
         throw new ToolError(
           `Invalid \`insert_line\` parameter: ${insertLine}. It should be within the range of lines of the file: [0, ${numLines}]`,
         );
       }
 
-      // Insert new text
+      // Build proposed content
       const newStrLines = expandedNewStr.split('\n');
       const newFileLines = [
         ...fileLines.slice(0, insertLine),
         ...newStrLines,
         ...fileLines.slice(insertLine),
       ];
-
-      // Write new content to file
       const newFileContent = newFileLines.join('\n');
 
-      const approval = await requestToolEditApproval({
-        path: filePath,
-        originalContent: fileContent,
-        proposedContent: newFileContent,
-        sourceTool: 'text_editor:insert',
-      });
+      // Execute approval flow with history tracking
+      return executeToolEditApprovalFlowWithResult(
+        {
+          path: filePath,
+          originalContent: fileContent,
+          proposedContent: newFileContent,
+          sourceTool: 'text_editor:insert',
+          summaryMessage: `Inserted text into ${filePath}`,
+          skipFileReadCheck: true,
+        },
+        (writeResult, approval) => {
+          const { appliedContent, baseContent } = writeResult;
 
-      if (!approval.accepted) {
-        return buildApprovalRejectedResult(
-          filePath,
-          'text_editor:insert',
-          approval.userMessage,
-        );
-      }
+          // Track history for undo support
+          if (appliedContent !== baseContent) {
+            this.addToHistory(filePath, baseContent);
+          }
 
-      const approvedContent = getApprovedContent(approval, newFileContent);
-      const { appliedContent, baseContent } = await writeApprovedContent(
-        filePath,
-        fileContent,
-        approvedContent,
+          // Build snippet output
+          const previewLines = appliedContent.split('\n');
+          const snippetStart = Math.max(0, insertLine - SNIPPET_LINES);
+          const snippetEnd = Math.min(
+            previewLines.length,
+            insertLine + newStrLines.length + SNIPPET_LINES,
+          );
+          const snippetText = previewLines
+            .slice(snippetStart, snippetEnd)
+            .join('\n');
+          const startLine = snippetStart + 1;
+          const snippetOutput = this.makeOutput(
+            snippetText,
+            'a snippet of the edited file',
+            startLine,
+          );
+
+          // Format output
+          const userDiffNote = formatUnifiedApprovalUserDiff(
+            filePath,
+            newFileContent,
+            appliedContent,
+          );
+          const successIntro = `The file ${filePath} has been edited.`;
+          const reviewNote =
+            'Review the changes and make sure they are as expected (correct indentation, no duplicate lines, etc). Edit the file again if necessary.';
+          const baseMsg = `${successIntro} ${snippetOutput}${reviewNote}`;
+          const output = userDiffNote ? `${baseMsg}\n\n${userDiffNote}` : baseMsg;
+
+          return {
+            summary: `Inserted text into ${filePath}`,
+            output,
+            userPatch: approval.userPatch,
+            edits: [{ path: filePath, lineChanges: approval.lineChanges }],
+          };
+        },
       );
-      if (appliedContent !== baseContent) {
-        this.addToHistory(filePath, baseContent);
-      }
-      const finalContent = appliedContent;
-
-      // Record file as "read" after editing so subsequent edits don't require
-      // an explicit read again.
-      recordToolFileRead(filePath);
-
-      // Prepare success message
-      const previewLines = finalContent.split('\n');
-      const snippetStart = Math.max(0, insertLine - SNIPPET_LINES);
-      const snippetEnd = Math.min(
-        previewLines.length,
-        insertLine + newStrLines.length + SNIPPET_LINES,
-      );
-      const snippetText = previewLines
-        .slice(snippetStart, snippetEnd)
-        .join('\n');
-      const startLine = snippetStart + 1;
-      const userDiffNote = formatUnifiedApprovalUserDiff(
-        filePath,
-        newFileContent,
-        finalContent,
-      );
-
-      const successIntro = `The file ${filePath} has been edited.`;
-      const snippetOutput = this.makeOutput(
-        snippetText,
-        'a snippet of the edited file',
-        startLine,
-      );
-      const reviewNote =
-        'Review the changes and make sure they are as expected (correct indentation, no duplicate lines, etc). Edit the file again if necessary.';
-      const baseMsg = `${successIntro} ${snippetOutput}${reviewNote}`;
-      const successMsg = userDiffNote
-        ? `${baseMsg}\n\n${userDiffNote}`
-        : baseMsg;
-
-      return {
-        summary: `Inserted text into ${filePath}`,
-        output: successMsg,
-        userPatch: approval.userPatch,
-        edits: [{ path: filePath, lineChanges: approval.lineChanges }],
-      };
     } catch (error) {
       if (error instanceof ToolError) {
         throw error;
@@ -633,71 +575,58 @@ export class TextEditorTool extends defineTool({
    */
   private async undoEdit(filePath: string): Promise<ToolResult> {
     try {
-      // Check if there's history for this file
+      // Validation: must have edit history
       const history = this.fileHistory.get(filePath);
       if (!history || history.length === 0) {
         throw new ToolError(`No edit history found for ${filePath}.`);
       }
 
+      // Validation: file must exist and have been read
       const exists = await WorkspaceFS.exists(filePath);
       const readGate = requireFileReadForEdit(filePath, exists);
       if (readGate) {
         return readGate;
       }
 
-      // Restore previous content
       const previousContent = history.at(-1)!;
       const currentContent = await WorkspaceFS.read(filePath);
 
-      const approval = await requestToolEditApproval({
-        path: filePath,
-        originalContent: currentContent,
-        proposedContent: previousContent,
-        sourceTool: 'text_editor:undo_edit',
-      });
+      // Execute approval flow with history cleanup
+      return executeToolEditApprovalFlowWithResult(
+        {
+          path: filePath,
+          originalContent: currentContent,
+          proposedContent: previousContent,
+          sourceTool: 'text_editor:undo_edit',
+          summaryMessage: `Undid edit on ${filePath}`,
+          skipFileReadCheck: true,
+        },
+        (writeResult, approval) => {
+          const { appliedContent } = writeResult;
 
-      if (!approval.accepted) {
-        return buildApprovalRejectedResult(
-          filePath,
-          'text_editor:undo_edit',
-          approval.userMessage,
-        );
-      }
+          // Pop from history after successful write
+          history.pop();
+          if (history.length === 0) {
+            this.fileHistory.delete(filePath);
+          }
 
-      const approvedContent = getApprovedContent(approval, previousContent);
-      const { appliedContent } = await writeApprovedContent(
-        filePath,
-        currentContent,
-        approvedContent,
+          // Format output
+          const userDiffNote = formatUnifiedApprovalUserDiff(
+            filePath,
+            previousContent,
+            appliedContent,
+          );
+          const baseOutput = `Last edit to ${filePath} undone successfully. ${this.makeOutput(appliedContent, filePath)}`;
+          const output = userDiffNote ? `${baseOutput}\n${userDiffNote}` : baseOutput;
+
+          return {
+            summary: `Undid edit on ${filePath}`,
+            output,
+            userPatch: approval.userPatch,
+            edits: [{ path: filePath, lineChanges: approval.lineChanges }],
+          };
+        },
       );
-      history.pop();
-      const finalContent = appliedContent;
-
-      // Record file as "read" after undo so subsequent edits don't require
-      // an explicit read again.
-      recordToolFileRead(filePath);
-
-      // If the history is now empty, delete the entry
-      if (history.length === 0) {
-        this.fileHistory.delete(filePath);
-      }
-
-      const userDiffNote = formatUnifiedApprovalUserDiff(
-        filePath,
-        previousContent,
-        finalContent,
-      );
-      const baseOutput = `Last edit to ${filePath} undone successfully. ${this.makeOutput(finalContent, filePath)}`;
-      const output = userDiffNote
-        ? `${baseOutput}\n${userDiffNote}`
-        : baseOutput;
-
-      return {
-        summary: `Undid edit on ${filePath}`,
-        output,
-        userPatch: approval.userPatch,
-        edits: [{ path: filePath, lineChanges: approval.lineChanges }],
-      };
     } catch (error) {
       if (error instanceof ToolError) {
         throw error;

--- a/src/tools/WriteTool.ts
+++ b/src/tools/WriteTool.ts
@@ -5,17 +5,7 @@ import { z } from 'zod';
 import { isTexFile } from '@common/files/fileTypeUtils';
 import replacementEngine from '@replacement/engine';
 import { ToolResult } from '@tools/result';
-import {
-  recordToolFileRead,
-  requireFileReadForEdit,
-} from '@tools/fileInteractions';
-import {
-  buildApprovalRejectedResult,
-  formatUnifiedApprovalUserDiff,
-  getApprovedContent,
-  requestToolEditApproval,
-  writeApprovedContent,
-} from '@tools/approval/toolEditApproval';
+import { executeToolEditApprovalFlow } from '@tools/approval/executeApprovalFlow';
 import { WorkspaceFS } from '@utils/files';
 
 // Local file imports
@@ -36,53 +26,21 @@ export class WriteFileTool extends defineTool({
 }) {
   protected async execute(input: WriteInput): Promise<ToolResult> {
     const exists = await WorkspaceFS.exists(input.path);
-    const readGate = requireFileReadForEdit(input.path, exists);
-    if (readGate) {
-      return readGate;
-    }
-
     const originalContent = exists ? await WorkspaceFS.read(input.path) : '';
 
+    // Apply LaTeX transformations before approval
     const proposedContent = isTexFile(input.path)
       ? replacementEngine.applyAll(input.content)
       : input.content;
 
-    const approval = await requestToolEditApproval({
+    return executeToolEditApprovalFlow({
       path: input.path,
       originalContent,
       proposedContent,
       sourceTool: 'write_file',
+      summaryMessage: `Wrote ${input.path}`,
+      successOutputPrefix: 'written',
+      skipFileReadCheck: !exists,
     });
-
-    if (!approval.accepted) {
-      return buildApprovalRejectedResult(
-        input.path,
-        'write_file',
-        approval.userMessage,
-      );
-    }
-
-    const finalContent = getApprovedContent(approval, proposedContent);
-    const { appliedContent } = await writeApprovedContent(
-      input.path,
-      originalContent,
-      finalContent,
-    );
-
-    recordToolFileRead(input.path);
-
-    const userDiffNote = formatUnifiedApprovalUserDiff(
-      input.path,
-      proposedContent,
-      appliedContent,
-    );
-    const output = userDiffNote ? `written\n\n${userDiffNote}` : 'written';
-
-    return {
-      summary: `Wrote ${input.path}`,
-      output,
-      userPatch: approval.userPatch,
-      edits: [{ path: input.path, lineChanges: approval.lineChanges }],
-    };
   }
 }

--- a/src/tools/approval/executeApprovalFlow.ts
+++ b/src/tools/approval/executeApprovalFlow.ts
@@ -1,0 +1,212 @@
+/**
+ * Consolidated tool edit approval flow.
+ *
+ * This module provides a single entry point for the 6-step approval sequence
+ * used across WriteTool, EditTool, and TextEditorTool operations.
+ */
+
+// Local imports - tools
+import { type ToolResult, type LineChanges } from '@tools/result';
+import { recordToolFileRead, requireFileReadForEdit } from '@tools/fileInteractions';
+import { WorkspaceFS } from '@utils/files';
+
+// Local imports - approval helpers
+import {
+  requestToolEditApproval,
+  buildApprovalRejectedResult,
+  getApprovedContent,
+  writeApprovedContent,
+  formatUnifiedApprovalUserDiff,
+} from './toolEditApproval';
+
+/**
+ * Options for executing a tool edit approval flow.
+ */
+export interface ExecuteApprovalFlowOptions {
+  /** File path being edited */
+  path: string;
+
+  /** Original content before edit (empty string for new files) */
+  originalContent: string;
+
+  /** Proposed new content */
+  proposedContent: string;
+
+  /** Tool identifier (e.g., 'write_file', 'text_editor:str_replace') */
+  sourceTool: string;
+
+  /** Summary message for successful result (e.g., 'Wrote file.tex') */
+  summaryMessage: string;
+
+  /** Optional: Additional output text before user diff */
+  successOutputPrefix?: string;
+
+  /** Optional: Context lines for unified diff formatting (default: 3) */
+  contextLines?: number;
+
+  /** Optional: Skip file read requirement check (for new file creation) */
+  skipFileReadCheck?: boolean;
+}
+
+/**
+ * Result from a successful approval flow.
+ * Contains the applied content and base content for optional post-processing.
+ */
+export interface ApprovalFlowWriteResult {
+  appliedContent: string;
+  baseContent: string;
+}
+
+/**
+ * Execute the standard tool edit approval flow for file modifications.
+ *
+ * Handles the complete approval workflow:
+ * 1. File read requirement check (unless skipped)
+ * 2. User approval request
+ * 3. Rejection handling
+ * 4. Content writing with merge support
+ * 5. File interaction recording
+ * 6. Result formatting with user diff
+ *
+ * @param options Configuration for the approval flow
+ * @returns Promise<ToolResult> - Success result with edits, or rejection result
+ */
+export async function executeToolEditApprovalFlow(
+  options: ExecuteApprovalFlowOptions,
+): Promise<ToolResult> {
+  const {
+    path,
+    originalContent,
+    proposedContent,
+    sourceTool,
+    summaryMessage,
+    successOutputPrefix,
+    contextLines,
+    skipFileReadCheck = false,
+  } = options;
+
+  // Step 1: Check file read requirement (unless creating new file)
+  if (!skipFileReadCheck) {
+    const exists = await WorkspaceFS.exists(path);
+    const readGate = requireFileReadForEdit(path, exists);
+    if (readGate) return readGate;
+  }
+
+  // Step 2: Request user approval
+  const approval = await requestToolEditApproval({
+    path,
+    originalContent,
+    proposedContent,
+    sourceTool,
+  });
+
+  // Step 3: Handle rejection
+  if (!approval.accepted) {
+    return buildApprovalRejectedResult(path, sourceTool, approval.userMessage);
+  }
+
+  // Step 4: Write approved content (with merge support for concurrent edits)
+  const finalContent = getApprovedContent(approval, proposedContent);
+  const { appliedContent } = await writeApprovedContent(
+    path,
+    originalContent,
+    finalContent,
+  );
+
+  // Step 5: Record file interaction
+  recordToolFileRead(path);
+
+  // Step 6: Format output with user diff
+  const userDiffNote = formatUnifiedApprovalUserDiff(
+    path,
+    proposedContent,
+    appliedContent,
+    contextLines ? { contextLines } : undefined,
+  );
+
+  const output = buildOutputMessage(successOutputPrefix, userDiffNote);
+
+  // Step 7: Return success result
+  return {
+    summary: summaryMessage,
+    output,
+    userPatch: approval.userPatch,
+    edits: [{ path, lineChanges: approval.lineChanges }],
+  };
+}
+
+/**
+ * Execute approval flow and return write result for post-processing.
+ *
+ * Use this when you need access to appliedContent/baseContent after approval,
+ * for example to update edit history in TextEditorTool.
+ *
+ * @param options Configuration for the approval flow
+ * @param buildResult Callback to build the final ToolResult from write result
+ * @returns Promise<ToolResult> - Success result from callback, or rejection result
+ */
+export async function executeToolEditApprovalFlowWithResult(
+  options: ExecuteApprovalFlowOptions,
+  buildResult: (
+    writeResult: ApprovalFlowWriteResult,
+    approval: { userPatch?: string; lineChanges?: LineChanges },
+  ) => ToolResult,
+): Promise<ToolResult> {
+  const {
+    path,
+    originalContent,
+    proposedContent,
+    sourceTool,
+    skipFileReadCheck = false,
+  } = options;
+
+  // Step 1: Check file read requirement (unless creating new file)
+  if (!skipFileReadCheck) {
+    const exists = await WorkspaceFS.exists(path);
+    const readGate = requireFileReadForEdit(path, exists);
+    if (readGate) return readGate;
+  }
+
+  // Step 2: Request user approval
+  const approval = await requestToolEditApproval({
+    path,
+    originalContent,
+    proposedContent,
+    sourceTool,
+  });
+
+  // Step 3: Handle rejection
+  if (!approval.accepted) {
+    return buildApprovalRejectedResult(path, sourceTool, approval.userMessage);
+  }
+
+  // Step 4: Write approved content
+  const finalContent = getApprovedContent(approval, proposedContent);
+  const writeResult = await writeApprovedContent(
+    path,
+    originalContent,
+    finalContent,
+  );
+
+  // Step 5: Record file interaction
+  recordToolFileRead(path);
+
+  // Step 6: Delegate result building to caller
+  return buildResult(writeResult, {
+    userPatch: approval.userPatch,
+    lineChanges: approval.lineChanges,
+  });
+}
+
+/**
+ * Build output message combining prefix and user diff.
+ */
+function buildOutputMessage(
+  prefix: string | undefined,
+  userDiff: string | undefined,
+): string {
+  if (prefix && userDiff) {
+    return `${prefix}\n\n${userDiff}`;
+  }
+  return userDiff ?? prefix ?? 'Operation completed.';
+}

--- a/src/webview/types/messages.ts
+++ b/src/webview/types/messages.ts
@@ -308,3 +308,52 @@ export const MemoryEnabledMessageSchema = z.object({
 });
 
 export type MemoryEnabledMessage = z.infer<typeof MemoryEnabledMessageSchema>;
+
+// --- Progress View Stream Management Schemas ---
+
+/** Stream identifier - non-empty string */
+const StreamIdSchema = z.string().min(1);
+
+/** Message with stream identifier */
+export const StreamMessageSchema = z.object({
+  stream: StreamIdSchema,
+});
+
+export type StreamMessage = z.infer<typeof StreamMessageSchema>;
+
+/** Retry stream request with optional feedback */
+export const RetryStreamMessageSchema = z.object({
+  stream: StreamIdSchema,
+  feedback: z.string().optional(),
+});
+
+export type RetryStreamMessage = z.infer<typeof RetryStreamMessageSchema>;
+
+/** Send follow-up message */
+export const SendFollowUpMessageSchema = z.object({
+  stream: StreamIdSchema,
+  text: z.string(),
+});
+
+export type SendFollowUpMessage = z.infer<typeof SendFollowUpMessageSchema>;
+
+/** Sort streams by criteria */
+export const SortStreamsMessageSchema = z.object({
+  sortBy: z.enum(['time', 'name']).optional(),
+});
+
+export type SortStreamsMessage = z.infer<typeof SortStreamsMessageSchema>;
+
+/** Filter streams by agent category */
+export const FilterStreamsMessageSchema = z.object({
+  filter: z.string().optional(),
+});
+
+export type FilterStreamsMessage = z.infer<typeof FilterStreamsMessageSchema>;
+
+/** Open label message */
+export const OpenLabelMessageSchema = z.object({
+  label: z.string().min(1),
+});
+
+export type OpenLabelMessage = z.infer<typeof OpenLabelMessageSchema>;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> - **Tools**: Extracts unified `executeToolEditApprovalFlow(… )` (+ `…WithResult`) and refactors `WriteTool`, `EditTool`, and `TextEditorTool` to use it (less duplication, consistent approval/merge handling, history updates). Adds small validation/UX tweaks and LaTeX transforms pre-approval.
> - **Runtime**: Replaces abstract `BasePromiseCoordinator` with configurable `PromiseCoordinator`; converts `AgentProposalCoordinator` to a factory using composition; updates `RetryRequestCoordinator` to pass config via constructor while keeping logger tracking.
> - **Webview/Progress**: Hardens `ProgressViewMessageHandler` by replacing `any` with Zod-validated schemas from new `webview/types/messages.ts` (`StreamMessageSchema`, `RetryStreamMessageSchema`, `SendFollowUpMessageSchema`, `SortStreamsMessageSchema`, `FilterStreamsMessageSchema`, `OpenLabelMessageSchema`).
> - **Docs**: Adds `docs/architecture/TOOL_USE_PROGRESS_CHAIN_ANALYSIS.md` describing the tool-use → event bus → progress view pipeline.
> 
> Overall: reduces code duplication, simplifies coordinator architecture, and improves type safety in message handling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1ee26733ee1e706847c4b19dcf21e3fb843c6b5f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->