### PR TITLE
refactor: use BatchNode pattern for ToolUseDispatchNode

### DIFF
--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 
 // Local imports - core flow primitives
 import { isRemoteAgent } from '@agent/index';
-import { BaseNode, Flow } from '@agent/node';
+import { BaseNode, BatchNode, Flow } from '@agent/node';
 import {
   BaseCycleFieldsSchema,
   BaseInvocationPrepResult,
@@ -532,89 +532,55 @@ interface ToolExecutionResult {
   }>;
 }
 
-/** Data extracted by prep() for tool dispatch. */
-interface ToolUseDispatchPrepResult {
-  shouldSkip: boolean;
-  interrupted: boolean;
-  toolCalls: SdkToolCall[];
-  text?: string;
-}
-
-/** Result of exec() for tool dispatch. */
-type ToolUseDispatchExecResult =
-  | { kind: 'skipped'; interrupted: boolean }
-  | {
-      kind: 'success';
-      execResults: ToolExecutionResult[];
-      assistantText: string;
-    };
-
 /**
- * Dispatches tool calls and processes their results.
- * Batches multiple parallel calls for Google/DeepSeek handlers to preserve thought signatures.
+ * Dispatches tool calls and processes their results using BatchNode pattern.
+ *
+ * Uses BatchNode for sequential execution of tool calls. This preserves ordering
+ * guarantees when tools may have dependencies (e.g., read file then edit file).
+ *
+ * To enable parallel execution, change to extend ParallelBatchNode instead.
+ *
+ * Batches follow-up messages for Google/DeepSeek handlers to preserve thought signatures.
  */
-class ToolUseDispatchNode<C> extends BaseNode<
+class ToolUseDispatchNode<C> extends BatchNode<
   ToolUseCycleShared,
   ToolUseCycleParams<C>,
   ToolUseCycleServices<C>
 > {
-  async prep(shared: ToolUseCycleShared): Promise<ToolUseDispatchPrepResult> {
-    const services = this.services;
+  /**
+   * Returns the array of tool calls to execute.
+   * Returns empty array if should skip (no tools, stopped, or interrupted).
+   */
+  async prep(shared: ToolUseCycleShared): Promise<SdkToolCall[]> {
     const toolCalls = shared.toolCalls ?? [];
 
-    const shouldSkip = shared.shouldStop || toolCalls.length === 0;
-    const interrupted = shouldSkip
-      ? false
-      : Boolean(await services.checkInterruption());
+    // Skip if no tool calls or already stopped
+    if (shared.shouldStop || toolCalls.length === 0) {
+      return [];
+    }
 
-    return {
-      shouldSkip,
-      interrupted,
-      toolCalls,
-      text: shared.text,
-    };
+    // Check for interruption before starting batch execution
+    if (this.services.checkInterruption()) {
+      shared.shouldStop = true;
+      return [];
+    }
+
+    return toolCalls;
   }
 
-  async exec(
-    prepRes: ToolUseDispatchPrepResult,
-  ): Promise<ToolUseDispatchExecResult> {
-    if (prepRes.shouldSkip) {
-      return { kind: 'skipped', interrupted: false };
-    }
-
-    if (prepRes.interrupted) {
-      return { kind: 'skipped', interrupted: true };
-    }
-
+  /**
+   * Execute a single tool call. Called sequentially for each tool in the batch.
+   */
+  async exec(call: SdkToolCall): Promise<ToolExecutionResult> {
     const services = this.services;
     const { workspace } = services;
-    const tracker = workspace.interactions;
-    const todoState = workspace.todos;
-    const assistantText = prepRes.text ?? '';
 
-    const execResults: ToolExecutionResult[] = [];
-    for (const call of prepRes.toolCalls) {
-      if (services.checkInterruption()) {
-        break;
-      }
-      const execResult = await this.executeToolCall(
-        call,
-        services,
-        tracker,
-        todoState,
-      );
-      execResults.push(execResult);
-    }
-
-    if (execResults.length === 0 && services.checkInterruption()) {
-      return { kind: 'skipped', interrupted: true };
-    }
-
-    return {
-      kind: 'success',
-      execResults,
-      assistantText,
-    };
+    return this.executeToolCall(
+      call,
+      services,
+      workspace.interactions,
+      workspace.todos,
+    );
   }
 
   /**
@@ -737,23 +703,29 @@ class ToolUseDispatchNode<C> extends BaseNode<
     return validLocations;
   }
 
+  /**
+   * Process all tool execution results and create follow-up messages.
+   *
+   * @param shared - Mutable shared state
+   * @param toolCalls - Array of tool calls from prep()
+   * @param execResults - Array of execution results from exec() calls
+   */
   async post(
     shared: ToolUseCycleShared,
-    _prepRes: ToolUseDispatchPrepResult,
-    execRes: ToolUseDispatchExecResult,
+    toolCalls: SdkToolCall[],
+    execResults: ToolExecutionResult[],
   ): Promise<string | undefined> {
     const services = this.services;
     const { workspace } = services;
 
-    if (execRes.kind === 'skipped') {
-      if (execRes.interrupted) {
-        shared.shouldStop = true;
-      }
+    // If no tools were executed (skipped or interrupted), complete the flow
+    if (execResults.length === 0) {
       return FlowTransition.COMPLETE;
     }
 
-    const { execResults, assistantText } = execRes;
+    const assistantText = shared.text ?? '';
 
+    // Log and process media files for each result
     for (const execResult of execResults) {
       await this.logAndProcessMediaFiles(execResult, services, workspace);
     }
@@ -796,6 +768,7 @@ class ToolUseDispatchNode<C> extends BaseNode<
       }
     }
 
+    // Process user instructions from tool results
     for (const execResult of execResults) {
       if (isNonEmptyString(execResult.result.userInstruction)) {
         await services.modelHandler.createUserFollowUpMessages(

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -570,8 +570,14 @@ class ToolUseDispatchNode<C> extends BatchNode<
 
   /**
    * Execute a single tool call. Called sequentially for each tool in the batch.
+   * Checks for interruption before each execution to allow cancellation mid-batch.
    */
-  async exec(call: SdkToolCall): Promise<ToolExecutionResult> {
+  async exec(call: SdkToolCall): Promise<ToolExecutionResult | null> {
+    // Check for interruption before each tool call (replaces old for-loop check)
+    if (this.services.checkInterruption()) {
+      return null; // Signal to skip remaining tools
+    }
+
     const services = this.services;
     const { workspace } = services;
 
@@ -708,32 +714,42 @@ class ToolUseDispatchNode<C> extends BatchNode<
    *
    * @param shared - Mutable shared state
    * @param toolCalls - Array of tool calls from prep()
-   * @param execResults - Array of execution results from exec() calls
+   * @param execResults - Array of execution results from exec() calls (null if interrupted)
    */
   async post(
     shared: ToolUseCycleShared,
     toolCalls: SdkToolCall[],
-    execResults: ToolExecutionResult[],
+    execResults: (ToolExecutionResult | null)[],
   ): Promise<string | undefined> {
     const services = this.services;
     const { workspace } = services;
 
+    // Filter out null results (interrupted tool calls)
+    const completedResults = execResults.filter(
+      (r): r is ToolExecutionResult => r !== null,
+    );
+
+    // If interrupted mid-batch, mark as stopped
+    if (completedResults.length < execResults.length) {
+      shared.shouldStop = true;
+    }
+
     // If no tools were executed (skipped or interrupted), complete the flow
-    if (execResults.length === 0) {
+    if (completedResults.length === 0) {
       return FlowTransition.COMPLETE;
     }
 
     const assistantText = shared.text ?? '';
 
     // Log and process media files for each result
-    for (const execResult of execResults) {
+    for (const execResult of completedResults) {
       await this.logAndProcessMediaFiles(execResult, services, workspace);
     }
 
-    const extracted = execResults.map((er) =>
+    const extracted = completedResults.map((er) =>
       extractToolAttachments(er.result),
     );
-    const calls = execResults.map((er) => er.call);
+    const calls = completedResults.map((er) => er.call);
 
     // For Google/DeepSeek handlers with multiple parallel calls, batch all tool calls
     // into a single message to preserve thought signatures.
@@ -753,7 +769,7 @@ class ToolUseDispatchNode<C> extends BatchNode<
       );
       shared.messages.push(...followUpMsgs);
     } else {
-      for (const [index, execResult] of execResults.entries()) {
+      for (const [index, execResult] of completedResults.entries()) {
         const { sanitizedResult, attachments } = extracted[index];
         const followUpMsgs =
           await services.modelHandler.createToolUseFollowUpMessages(
@@ -769,7 +785,7 @@ class ToolUseDispatchNode<C> extends BatchNode<
     }
 
     // Process user instructions from tool results
-    for (const execResult of execResults) {
+    for (const execResult of completedResults) {
       if (isNonEmptyString(execResult.result.userInstruction)) {
         await services.modelHandler.createUserFollowUpMessages(
           shared.messages,

--- a/src/agent/output/OutputFileProcessor.ts
+++ b/src/agent/output/OutputFileProcessor.ts
@@ -165,9 +165,7 @@ export class OutputFileProcessor {
         );
       }
 
-      const processedFiles = processed.location.absolutePath
-        ? [processed]
-        : [];
+      const processedFiles = processed.location.absolutePath ? [processed] : [];
 
       if (processedFiles.length > 0) {
         await indentLatexFile(processed.location, logger);

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -309,7 +309,9 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
       // storageKey is for logical indexing (finding file metadata in progress view state).
       // For workflow agents: activeRunId = task group ID; for tool-use: executionId.
       // Note: Physical file paths use executionId (see runId below), not storageKey.
-      const storageKey = (activeRunId ?? executionId ?? null) as StorageKey | null;
+      const storageKey = (activeRunId ??
+        executionId ??
+        null) as StorageKey | null;
       const runOutputs = storageKey
         ? this.provider.state.getRunOutputFiles(message.stream, { storageKey })
         : undefined;


### PR DESCRIPTION
Refactor tool dispatch to use PocketFlow's BatchNode abstraction instead
of a manual for-loop. This simplifies the code structure while maintaining
sequential execution guarantees (tools may have dependencies).

The BatchNode pattern provides:
- Cleaner separation of prep/exec/post phases
- Consistent abort signal handling
- Foundation for parallel execution (swap to ParallelBatchNode)
- Reduced boilerplate (-27 lines)

This change prepares the architecture for agent-to-agent communication
where multiple agent executions could be batched together.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors tool-use dispatch to the PocketFlow `BatchNode` pattern with sequential execution.
> 
> - Replaces custom loop in `ToolUseDispatchNode` with `BatchNode` (`prep` returns `SdkToolCall[]`, `exec` handles one call at a time, `post` aggregates results)
> - Adds interruption checks before and during batch execution; marks `shouldStop` if interrupted mid-batch
> - Preserves Google/DeepSeek follow-up batching and per-tool follow-up message generation
> - Centralizes media attachment collection/logging and edited-file metadata into per-call results
> - Keeps flow wiring intact (`post` returns `FlowTransition.CONTINUE` and clears `shared.toolCalls`)
> - Minor formatting cleanups in `OutputFileProcessor` and `ProgressViewMessageHandler`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9ec81e6f7ca7f4a1ec8d5421a62f53029d3689e4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->