### PR TITLE
fix: validate ProgressView messages with Zod schemas

### DIFF
--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -66,23 +66,19 @@ import {
   InfoMessageSchema,
   ApprovalActionMessageSchema,
   FollowupTaskMessageSchema,
+  StreamMessageSchema,
+  RetryStreamMessageSchema,
+  SendFollowUpMessageSchema,
+  SortStreamsMessageSchema,
+  FilterStreamsMessageSchema,
+  FileCommandMessageSchema,
+  BaseFileCommandMessageSchema,
+  CompareMessageSchema,
+  OpenLabelMessageSchema,
 } from '@webview/types/messages';
 
 // Type imports
 import type { ProgressViewProvider } from './ProgressViewProvider';
-
-interface FileCommandMessage {
-  file: string;
-  line?: number;
-}
-
-interface BaseFileCommandMessage extends FileCommandMessage {
-  base?: string;
-}
-
-interface CompareMessage extends BaseFileCommandMessage {
-  prev?: string;
-}
 
 export class ProgressViewMessageHandler extends BaseViewMessageHandler<
   vscode.WebviewView | vscode.WebviewPanel
@@ -211,16 +207,39 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     }
   }
 
-  private async handleSwitchStream(message: any): Promise<void> {
-    this.provider.setActiveStream(message.stream);
+  private async handleSwitchStream(message: unknown): Promise<void> {
+    await this.withValidatedMessage(
+      StreamMessageSchema,
+      message,
+      'switchStream',
+      async ({ stream }) => {
+        this.provider.setActiveStream(stream);
+      },
+    );
   }
 
-  private async handleDeleteStream(message: any): Promise<void> {
-    // Clear pending task groups to prevent memory leaks
-    this.provider.eventHandler.clearPendingTaskGroups(message.stream);
-    await this.provider.state.clearStream(message.stream);
-    // Force rebuild since we deleted a stream
-    this.provider.updateWebview({ forceRebuild: true });
+  private async handleDeleteStream(message: unknown): Promise<void> {
+    await this.withValidatedMessage(
+      StreamMessageSchema,
+      message,
+      'deleteStream',
+      async ({ stream }) => {
+        const streamId = stream as StreamTabId;
+        const hasStream =
+          this.provider.state.streamTabs.has(streamId) ||
+          Boolean(this.provider.state.getTaskState(streamId));
+
+        if (!hasStream) {
+          return;
+        }
+
+        // Clear pending task groups to prevent memory leaks
+        this.provider.eventHandler.clearPendingTaskGroups(streamId);
+        await this.provider.state.clearStream(streamId);
+        // Force rebuild since we deleted a stream
+        this.provider.updateWebview({ forceRebuild: true });
+      },
+    );
   }
 
   private async handleDeleteAll(_message: any): Promise<void> {
@@ -243,8 +262,15 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     this.provider.updateWebview({ forceRebuild: true });
   }
 
-  private async handleStopStream(message: any): Promise<void> {
-    await vscode.commands.executeCommand('texra.stopAgent', message.stream);
+  private async handleStopStream(message: unknown): Promise<void> {
+    await this.withValidatedMessage(
+      StreamMessageSchema,
+      message,
+      'stopStream',
+      async ({ stream }) => {
+        await vscode.commands.executeCommand('texra.stopAgent', stream);
+      },
+    );
   }
 
   /**
@@ -252,126 +278,198 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
    * Reuses the executionId so the flow picks up persisted state.
    * Tool-use agents use the follow-up mechanism instead.
    */
-  private async handleResume(message: any): Promise<void> {
-    const streamId = message.stream as StreamTabId;
-    const taskState = this.provider.state.getTaskState(streamId);
-    if (!taskState) {
-      return;
-    }
+  private async handleResume(message: unknown): Promise<void> {
+    await this.withValidatedMessage(
+      StreamMessageSchema,
+      message,
+      'resumeStream',
+      async ({ stream }) => {
+        const streamId = stream as StreamTabId;
+        const taskState = this.provider.state.getTaskState(streamId);
+        if (!taskState) {
+          return;
+        }
 
-    // For workflow agents, resume by passing the same executionId
-    if (isWorkflowTaskState(taskState)) {
-      const executionId = this.provider.state.getExecutionId(streamId);
-      if (executionId) {
-        // Pass executionId to resume from persisted flow state
-        await safeExecuteCommand('texra.execute', [
-          { config: taskState.agentConfig, executionId },
-        ]);
-        return;
-      }
-    }
+        // For workflow agents, resume by passing the same executionId
+        if (isWorkflowTaskState(taskState)) {
+          const executionId = this.provider.state.getExecutionId(streamId);
+          if (executionId) {
+            // Pass executionId to resume from persisted flow state
+            await safeExecuteCommand('texra.execute', [
+              { config: taskState.agentConfig, executionId },
+            ]);
+            return;
+          }
+        }
 
-    // Defensive fallback: start fresh if no executionId available.
-    // Tool-use agents shouldn't reach here (Resume button not in their toolbar).
-    await safeExecuteCommand('texra.execute', [taskState.agentConfig]);
-  }
-
-  private async handleRunNew(message: any): Promise<void> {
-    const taskState = this.provider.state.getTaskState(message.stream);
-    if (!taskState) {
-      return;
-    }
-    await safeExecuteCommand('texra.execute', [taskState.agentConfig]);
-  }
-
-  private async handleRetryStreamRequest(message: any): Promise<void> {
-    // triggerRetry is synchronous, no await needed
-    // Pass optional feedback from the UI
-    const success = retryCoordinator.triggerRetry(
-      message.stream,
-      message.feedback,
+        // Defensive fallback: start fresh if no executionId available.
+        // Tool-use agents shouldn't reach here (Resume button not in their toolbar).
+        await safeExecuteCommand('texra.execute', [taskState.agentConfig]);
+      },
     );
-    if (!success) {
-      await vscode.window.showInformationMessage(
-        'No retryable request is available for this stream yet.',
-      );
-    }
   }
 
-  private async handleCancelRetryRequest(message: any): Promise<void> {
-    retryCoordinator.cancelRetry(message.stream);
+  private async handleRunNew(message: unknown): Promise<void> {
+    await this.withValidatedMessage(
+      StreamMessageSchema,
+      message,
+      'runNew',
+      async ({ stream }) => {
+        const taskState = this.provider.state.getTaskState(stream);
+        if (!taskState) {
+          return;
+        }
+        await safeExecuteCommand('texra.execute', [taskState.agentConfig]);
+      },
+    );
   }
 
-  private async handleDiffStream(message: any): Promise<void> {
-    await this.withToolbarTaskState(message.stream, async (taskState) => {
-      const executionId = this.provider.state.getExecutionId(message.stream);
-      const activeRunId = this.provider.state.getActiveRunId(message.stream);
-      // storageKey is for logical indexing (finding file metadata in progress view state).
-      // For workflow agents: activeRunId = task group ID; for tool-use: executionId.
-      // Note: Physical file paths use executionId (see runId below), not storageKey.
-      const storageKey = (activeRunId ??
-        executionId ??
-        null) as StorageKey | null;
-      const runOutputs = storageKey
-        ? this.provider.state.getRunOutputFiles(message.stream, { storageKey })
-        : undefined;
-      const outputsByRound = runOutputs
-        ? Object.fromEntries(runOutputs.entries())
-        : undefined;
-
-      await vscode.commands.executeCommand('texra.runLatexdiff', {
-        agent: taskState.agentConfig.agent,
-        model: taskState.agentConfig.model,
-        inputFile: taskState.agentConfig.inputFile,
-        outputFiles: taskState.agentConfig.outputFiles,
-        outputFilesActive: taskState.activeFiles.output,
-        streamId: message.stream,
-        // executionId is for file system paths (taskRuns/<executionId>/...)
-        // storageKey is for logical storage indexing - different concepts
-        runId: executionId,
-        outputsByRound,
-      });
-    });
+  private async handleRetryStreamRequest(message: unknown): Promise<void> {
+    await this.withValidatedMessage(
+      RetryStreamMessageSchema,
+      message,
+      'retryStreamRequest',
+      async ({ stream, feedback }) => {
+        // triggerRetry is synchronous, no await needed
+        // Pass optional feedback from the UI
+        const success = retryCoordinator.triggerRetry(stream, feedback);
+        if (!success) {
+          await vscode.window.showInformationMessage(
+            'No retryable request is available for this stream yet.',
+          );
+        }
+      },
+    );
   }
 
-  private async handlePackStream(message: any): Promise<void> {
-    await this.withToolbarTaskState(message.stream, async (taskState) => {
-      await this.handleFileOperation(message.stream, taskState, 'texra.pack');
-    });
+  private async handleCancelRetryRequest(message: unknown): Promise<void> {
+    await this.withValidatedMessage(
+      StreamMessageSchema,
+      message,
+      'cancelRetryRequest',
+      ({ stream }) => {
+        retryCoordinator.cancelRetry(stream);
+      },
+    );
   }
 
-  private async handleCleanStream(message: any): Promise<void> {
-    await this.withToolbarTaskState(message.stream, async (taskState) => {
-      await this.handleFileOperation(message.stream, taskState, 'texra.clean');
-    });
+  private async handleDiffStream(message: unknown): Promise<void> {
+    await this.withValidatedMessage(
+      StreamMessageSchema,
+      message,
+      'diffStream',
+      async ({ stream }) => {
+        await this.withToolbarTaskState(stream, async (taskState) => {
+          const executionId = this.provider.state.getExecutionId(stream);
+          const activeRunId = this.provider.state.getActiveRunId(stream);
+          // storageKey is for logical indexing (finding file metadata in progress view state).
+          // For workflow agents: activeRunId = task group ID; for tool-use: executionId.
+          // Note: Physical file paths use executionId (see runId below), not storageKey.
+          const storageKey = (activeRunId ??
+            executionId ??
+            null) as StorageKey | null;
+          const runOutputs = storageKey
+            ? this.provider.state.getRunOutputFiles(stream, { storageKey })
+            : undefined;
+          const outputsByRound = runOutputs
+            ? Object.fromEntries(runOutputs.entries())
+            : undefined;
+
+          await vscode.commands.executeCommand('texra.runLatexdiff', {
+            agent: taskState.agentConfig.agent,
+            model: taskState.agentConfig.model,
+            inputFile: taskState.agentConfig.inputFile,
+            outputFiles: taskState.agentConfig.outputFiles,
+            outputFilesActive: taskState.activeFiles.output,
+            streamId: stream,
+            // executionId is for file system paths (taskRuns/<executionId>/...)
+            // storageKey is for logical storage indexing - different concepts
+            runId: executionId,
+            outputsByRound,
+          });
+        });
+      },
+    );
   }
 
-  private async handleSortStreams(message: any): Promise<void> {
-    this.provider.state.streamSortOrder = message.sortBy ?? 'time';
-    this.provider.updateWebview();
+  private async handlePackStream(message: unknown): Promise<void> {
+    await this.withValidatedMessage(
+      StreamMessageSchema,
+      message,
+      'packStream',
+      async ({ stream }) => {
+        await this.withToolbarTaskState(stream, async (taskState) => {
+          await this.handleFileOperation(stream, taskState, 'texra.pack');
+        });
+      },
+    );
   }
 
-  private async handleFilterStreams(message: any): Promise<void> {
-    this.provider.state.agentCategoryFilter = isAgentCategoryFilter(
-      message.filter,
-    )
-      ? message.filter
-      : 'all';
-    this.provider.updateWebview();
+  private async handleCleanStream(message: unknown): Promise<void> {
+    await this.withValidatedMessage(
+      StreamMessageSchema,
+      message,
+      'cleanStream',
+      async ({ stream }) => {
+        await this.withToolbarTaskState(stream, async (taskState) => {
+          await this.handleFileOperation(stream, taskState, 'texra.clean');
+        });
+      },
+    );
   }
 
-  private async handleRestoreState(message: any): Promise<void> {
-    const taskState = this.provider.state.getTaskState(message.stream);
-    if (taskState) {
-      await vscode.commands.executeCommand('texra.restoreState', taskState);
-    }
+  private async handleSortStreams(message: unknown): Promise<void> {
+    await this.withValidatedMessage(
+      SortStreamsMessageSchema,
+      message,
+      'sortStreams',
+      async ({ sortBy }) => {
+        this.provider.state.streamSortOrder = sortBy ?? 'time';
+        this.provider.updateWebview();
+      },
+    );
   }
 
-  private async handleSendFollowUp(message: any): Promise<void> {
-    await vscode.commands.executeCommand('texra.sendFollowUp', {
-      stream: message.stream,
-      text: message.text,
-    });
+  private async handleFilterStreams(message: unknown): Promise<void> {
+    await this.withValidatedMessage(
+      FilterStreamsMessageSchema,
+      message,
+      'filterStreams',
+      async ({ filter }) => {
+        this.provider.state.agentCategoryFilter = isAgentCategoryFilter(filter)
+          ? filter
+          : 'all';
+        this.provider.updateWebview();
+      },
+    );
+  }
+
+  private async handleRestoreState(message: unknown): Promise<void> {
+    await this.withValidatedMessage(
+      StreamMessageSchema,
+      message,
+      'restoreState',
+      async ({ stream }) => {
+        const taskState = this.provider.state.getTaskState(stream);
+        if (taskState) {
+          await vscode.commands.executeCommand('texra.restoreState', taskState);
+        }
+      },
+    );
+  }
+
+  private async handleSendFollowUp(message: unknown): Promise<void> {
+    await this.withValidatedMessage(
+      SendFollowUpMessageSchema,
+      message,
+      'sendFollowUp',
+      async ({ stream, text }) => {
+        await vscode.commands.executeCommand('texra.sendFollowUp', {
+          stream,
+          text,
+        });
+      },
+    );
   }
 
   private async handlePolishFollowUp(message: unknown): Promise<void> {
@@ -573,193 +671,260 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     );
   }
 
-  private async handleOpenTaskStorage(message: any): Promise<void> {
-    const stream = message.stream as StreamTabId | undefined;
-    if (!stream) {
-      await vscode.window.showInformationMessage(
-        'No workspace storage folder is available for this run yet.',
-      );
-      return;
-    }
+  private async handleOpenTaskStorage(message: unknown): Promise<void> {
+    await this.withValidatedMessage(
+      StreamMessageSchema,
+      message,
+      'openTaskStorage',
+      async ({ stream }) => {
+        const streamId = stream as StreamTabId;
 
-    // Use cached activeRunId (set by event handlers when data arrives)
-    const storageKey = this.provider.state.getActiveRunId(stream);
-    const runOutputs = storageKey
-      ? this.provider.state.getRunOutputFiles(stream, { storageKey })
-      : undefined;
+        // Use cached activeRunId (set by event handlers when data arrives)
+        const storageKey = this.provider.state.getActiveRunId(streamId);
+        const runOutputs = storageKey
+          ? this.provider.state.getRunOutputFiles(streamId, { storageKey })
+          : undefined;
 
-    // executionId is the physical directory name: taskRuns/<executionId>/
-    // For workflow agents, storageKey (task group ID) differs from executionId,
-    // but files are always written to the executionId directory.
-    const executionId = this.provider.state.getExecutionId(stream);
+        // executionId is the physical directory name: taskRuns/<executionId>/
+        // For workflow agents, storageKey (task group ID) differs from executionId,
+        // but files are always written to the executionId directory.
+        const executionId = this.provider.state.getExecutionId(streamId);
 
-    try {
-      let directoryToReveal: string | undefined;
+        try {
+          let directoryToReveal: string | undefined;
 
-      if (executionId) {
-        await ensureRunDir(executionId);
-        directoryToReveal = getRunDir(executionId);
-      } else if (runOutputs) {
-        // Defensive fallback: executionId and outputFiles are persisted independently,
-        // so edge cases (data migration, partial state) could leave files without executionId.
-        // Extract directory from actual file paths.
-        directoryToReveal = this.findOutputDirectory(runOutputs);
-      }
+          if (executionId) {
+            await ensureRunDir(executionId);
+            directoryToReveal = getRunDir(executionId);
+          } else if (runOutputs) {
+            // Defensive fallback: executionId and outputFiles are persisted independently,
+            // so edge cases (data migration, partial state) could leave files without executionId.
+            // Extract directory from actual file paths.
+            directoryToReveal = this.findOutputDirectory(runOutputs);
+          }
 
-      if (!directoryToReveal) {
-        await vscode.window.showInformationMessage(
-          'No workspace storage folder is available for this run yet.',
+          if (!directoryToReveal) {
+            await vscode.window.showInformationMessage(
+              'No workspace storage folder is available for this run yet.',
+            );
+            return;
+          }
+
+          await safeExecuteCommand('revealFileInOS', [
+            vscode.Uri.file(directoryToReveal),
+          ]);
+        } catch (error) {
+          const errorMessage = toErrorMessage(error);
+          this.logger.error(
+            this.channel,
+            `Failed to open task storage for stream ${streamId}, executionId ${executionId ?? 'unknown'}: ${errorMessage}`,
+            {
+              data: {
+                error: error instanceof Error ? error : undefined,
+                stream: streamId,
+                executionId,
+              },
+            },
+          );
+          await vscode.window.showErrorMessage(
+            'Unable to open the workspace storage folder for this run.',
+          );
+        }
+      },
+    );
+  }
+
+  private async handleOpenFile(message: unknown): Promise<void> {
+    await this.withValidatedMessage(
+      FileCommandMessageSchema,
+      message,
+      'openFile',
+      async ({ file, line }) => {
+        await vscode.commands.executeCommand('texra.openFile', file, line);
+      },
+    );
+  }
+
+  private async handleOpenFileCompile(message: unknown): Promise<void> {
+    await this.withValidatedMessage(
+      FileCommandMessageSchema,
+      message,
+      'openFileCompile',
+      async ({ file }) => {
+        await vscode.commands.executeCommand('texra.openFileCompile', file);
+      },
+    );
+  }
+
+  private async handleCompareOriginal(message: unknown): Promise<void> {
+    await this.withValidatedMessage(
+      BaseFileCommandMessageSchema,
+      message,
+      'compareOriginal',
+      async ({ file, base }) => {
+        // Backup model's original output before user can modify it in the diff view
+        const streamId = this.provider.state.activeStream;
+        if (streamId && file) {
+          try {
+            const fileLocation = createExternalLocation(file);
+            const content = await flexibleFS.read(fileLocation);
+            this.modelOutputBackups.set(file, { content, streamId });
+          } catch {
+            // Ignore backup errors - don't block the compare operation
+          }
+        }
+
+        await this.executeWithBaseFile(
+          file,
+          base,
+          'Compare original',
+          (targetFile, baseFile) =>
+            vscode.commands.executeCommand(
+              'texra.compare',
+              pathToLocation(''), // inputFile unused
+              pathToLocation(baseFile),
+              pathToLocation(targetFile),
+            ),
         );
-        return;
-      }
-
-      await safeExecuteCommand('revealFileInOS', [
-        vscode.Uri.file(directoryToReveal),
-      ]);
-    } catch (error) {
-      const errorMessage = toErrorMessage(error);
-      this.logger.error(
-        this.channel,
-        `Failed to open task storage for stream ${stream}, executionId ${executionId ?? 'unknown'}: ${errorMessage}`,
-        {
-          data: {
-            error: error instanceof Error ? error : undefined,
-            stream,
-            executionId,
-          },
-        },
-      );
-      await vscode.window.showErrorMessage(
-        'Unable to open the workspace storage folder for this run.',
-      );
-    }
-  }
-
-  private async handleOpenFile(message: FileCommandMessage): Promise<void> {
-    await vscode.commands.executeCommand(
-      'texra.openFile',
-      message.file,
-      message.line,
+      },
     );
   }
 
-  private async handleOpenFileCompile(
-    message: FileCommandMessage,
-  ): Promise<void> {
-    await vscode.commands.executeCommand('texra.openFileCompile', message.file);
-  }
+  private async handleComparePrevious(message: unknown): Promise<void> {
+    await this.withValidatedMessage(
+      CompareMessageSchema,
+      message,
+      'comparePrevious',
+      async ({ file, base, prev }) => {
+        const previousFile = prev ?? base;
 
-  private async handleCompareOriginal(
-    message: BaseFileCommandMessage,
-  ): Promise<void> {
-    // Backup model's original output before user can modify it in the diff view
-    const streamId = this.provider.state.activeStream;
-    if (streamId && message.file) {
-      try {
-        const fileLocation = createExternalLocation(message.file);
-        const content = await flexibleFS.read(fileLocation);
-        this.modelOutputBackups.set(message.file, { content, streamId });
-      } catch {
-        // Ignore backup errors - don't block the compare operation
-      }
-    }
+        if (previousFile) {
+          await vscode.commands.executeCommand(
+            'texra.latexdiff',
+            undefined,
+            previousFile,
+            file,
+          );
+        }
 
-    await this.executeWithBaseFile(message, 'Compare original', (file, base) =>
-      vscode.commands.executeCommand(
-        'texra.compare',
-        pathToLocation(''), // inputFile unused
-        pathToLocation(base),
-        pathToLocation(file),
-      ),
+        await vscode.commands.executeCommand(
+          'texra.compare',
+          pathToLocation(''), // inputFile unused
+          pathToLocation(previousFile || ''),
+          pathToLocation(file),
+        );
+      },
     );
   }
 
-  private async handleComparePrevious(message: CompareMessage): Promise<void> {
-    const previousFile = message.prev ?? message.base;
+  private async handleAcceptFile(message: unknown): Promise<void> {
+    await this.withValidatedMessage(
+      BaseFileCommandMessageSchema,
+      message,
+      'acceptFile',
+      async ({ file, base }) => {
+        // Check if user modified the model's output before accepting
+        const backup = file ? this.modelOutputBackups.get(file) : null;
+        let currentContent: string | null = null;
 
-    if (previousFile) {
-      await vscode.commands.executeCommand(
-        'texra.latexdiff',
-        undefined,
-        previousFile,
-        message.file,
-      );
-    }
+        if (backup) {
+          try {
+            const fileLocation = createExternalLocation(file);
+            currentContent = await flexibleFS.read(fileLocation);
+          } catch {
+            // Ignore read errors
+          }
+        }
 
-    await vscode.commands.executeCommand(
-      'texra.compare',
-      pathToLocation(''), // inputFile unused
-      pathToLocation(previousFile || ''),
-      pathToLocation(message.file),
+        await this.executeWithBaseFile(
+          file,
+          base,
+          'Accept',
+          (targetFile, baseFile) =>
+            vscode.commands.executeCommand(
+              'texra.acceptEdited',
+              pathToLocation(''), // inputFile unused
+              pathToLocation(baseFile),
+              pathToLocation(targetFile),
+            ),
+        );
+
+        // Inform the model about user modifications via follow-up
+        if (
+          backup &&
+          currentContent !== null &&
+          currentContent !== backup.content
+        ) {
+          const fileName = path.basename(file);
+          const followUpText = `[System: User modified the model's suggested output for "${fileName}" before accepting. The accepted version differs from the original model output.]`;
+
+          await vscode.commands.executeCommand('texra.sendFollowUp', {
+            stream: backup.streamId,
+            text: followUpText,
+          });
+        }
+
+        // Clean up backup
+        if (file) {
+          this.modelOutputBackups.delete(file);
+        }
+      },
     );
   }
 
-  private async handleAcceptFile(
-    message: BaseFileCommandMessage,
-  ): Promise<void> {
-    // Check if user modified the model's output before accepting
-    const backup = message.file
-      ? this.modelOutputBackups.get(message.file)
-      : null;
-    let currentContent: string | null = null;
-
-    if (backup) {
-      try {
-        const fileLocation = createExternalLocation(message.file);
-        currentContent = await flexibleFS.read(fileLocation);
-      } catch {
-        // Ignore read errors
-      }
-    }
-
-    await this.executeWithBaseFile(message, 'Accept', (file, base) =>
-      vscode.commands.executeCommand(
-        'texra.acceptEdited',
-        pathToLocation(''), // inputFile unused
-        pathToLocation(base),
-        pathToLocation(file),
-      ),
-    );
-
-    // Inform the model about user modifications via follow-up
-    if (
-      backup &&
-      currentContent !== null &&
-      currentContent !== backup.content
-    ) {
-      const fileName = path.basename(message.file);
-      const followUpText = `[System: User modified the model's suggested output for "${fileName}" before accepting. The accepted version differs from the original model output.]`;
-
-      await vscode.commands.executeCommand('texra.sendFollowUp', {
-        stream: backup.streamId,
-        text: followUpText,
-      });
-    }
-
-    // Clean up backup
-    if (message.file) {
-      this.modelOutputBackups.delete(message.file);
-    }
-  }
-
-  private async handleMergeFile(
-    message: BaseFileCommandMessage,
-  ): Promise<void> {
-    await this.executeWithBaseFile(message, 'Merge', (file, base) =>
-      vscode.commands.executeCommand('texra.merge', undefined, base, file),
+  private async handleMergeFile(message: unknown): Promise<void> {
+    await this.withValidatedMessage(
+      BaseFileCommandMessageSchema,
+      message,
+      'mergeFile',
+      async ({ file, base }) => {
+        await this.executeWithBaseFile(
+          file,
+          base,
+          'Merge',
+          (targetFile, baseFile) =>
+            vscode.commands.executeCommand(
+              'texra.merge',
+              undefined,
+              baseFile,
+              targetFile,
+            ),
+        );
+      },
     );
   }
 
-  private async handleLatexdiffFile(
-    message: BaseFileCommandMessage,
-  ): Promise<void> {
-    await this.executeWithBaseFile(message, 'Latexdiff', (file, base) =>
-      vscode.commands.executeCommand('texra.latexdiff', undefined, base, file),
+  private async handleLatexdiffFile(message: unknown): Promise<void> {
+    await this.withValidatedMessage(
+      BaseFileCommandMessageSchema,
+      message,
+      'latexdiffFile',
+      async ({ file, base }) => {
+        await this.executeWithBaseFile(
+          file,
+          base,
+          'Latexdiff',
+          (targetFile, baseFile) =>
+            vscode.commands.executeCommand(
+              'texra.latexdiff',
+              undefined,
+              baseFile,
+              targetFile,
+            ),
+        );
+      },
     );
   }
 
-  private async handleOpenLabel(message: any): Promise<void> {
-    await vscode.commands.executeCommand('texra.openLabel', message.label);
+  private async handleOpenLabel(message: unknown): Promise<void> {
+    await this.withValidatedMessage(
+      OpenLabelMessageSchema,
+      message,
+      'openLabel',
+      async ({ label }) => {
+        await vscode.commands.executeCommand('texra.openLabel', label);
+      },
+    );
   }
 
   private async handleOpenProfile(): Promise<void> {
@@ -828,19 +993,20 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
    * Returns early with a warning if base file is missing.
    */
   private async executeWithBaseFile(
-    message: BaseFileCommandMessage,
+    file: string,
+    base: string | undefined,
     actionName: string,
     execute: (file: string, base: string) => Thenable<unknown>,
   ): Promise<void> {
-    if (!message.base) {
+    if (!base) {
       this.logger.warn(
         this.channel,
         `${actionName} requested without a base path.`,
-        { data: { file: message.file } },
+        { data: { file } },
       );
       return;
     }
-    await execute(message.file, message.base);
+    await execute(file, base);
   }
 
   /**

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -17,10 +17,6 @@ import { AgentConfigSchema, type AgentConfig } from '@agent/core/AgentConfig';
 import type { OutputFileInfo } from '@agent/output/types';
 import { retryCoordinator } from '@agent/runtime/RetryRequestCoordinator';
 import { proposalCoordinator } from '@agent/runtime/AgentProposalCoordinator';
-import {
-  AgentCategoryFilter,
-  isAgentCategoryFilter,
-} from '@agent/types/AgentStreamTypes';
 import type {
   ExecutionId,
   StorageKey,
@@ -199,7 +195,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
    * This allows the provider to process any pending updates that
    * were queued while the webview was initializing.
    */
-  protected override async handleWebviewReady(message: any): Promise<void> {
+  protected override async handleWebviewReady(message: unknown): Promise<void> {
     const webviewView = this.getActiveView();
     if (webviewView) {
       await super.handleWebviewReady(message, webviewView);
@@ -242,7 +238,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     );
   }
 
-  private async handleDeleteAll(_message: any): Promise<void> {
+  private async handleDeleteAll(_message: unknown): Promise<void> {
     // Show confirmation dialog
     const confirmation = await vscode.window.showWarningMessage(
       'Are you sure you want to delete all streams? This action cannot be undone.',
@@ -424,7 +420,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
       message,
       'sortStreams',
       async ({ sortBy }) => {
-        this.provider.state.streamSortOrder = sortBy ?? 'time';
+        this.provider.state.streamSortOrder = sortBy;
         this.provider.updateWebview();
       },
     );
@@ -436,9 +432,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
       message,
       'filterStreams',
       async ({ filter }) => {
-        this.provider.state.agentCategoryFilter = isAgentCategoryFilter(filter)
-          ? filter
-          : 'all';
+        this.provider.state.agentCategoryFilter = filter;
         this.provider.updateWebview();
       },
     );
@@ -558,30 +552,29 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
   }
 
   private async handleAgentProposalAction(message: unknown): Promise<void> {
-    const parsed = AgentProposalActionMessageSchema.safeParse(message);
-    if (!parsed.success) {
-      this.logger.warn(this.channel, 'Invalid agent proposal action message', {
-        data: { message, error: parsed.error.message },
-      });
-      return;
-    }
-
-    const { proposalId, action, feedback } = parsed.data;
-
-    switch (action) {
-      case 'approve':
-        proposalCoordinator.resolveRequest(proposalId, { action: 'approve' });
-        break;
-      case 'reject':
-        proposalCoordinator.resolveRequest(proposalId, {
-          action: 'reject',
-          feedback,
-        });
-        break;
-      case 'setup':
-        await this.handleAgentProposalSetup(proposalId);
-        break;
-    }
+    await this.withValidatedMessage(
+      AgentProposalActionMessageSchema,
+      message,
+      'agentProposalAction',
+      async ({ proposalId, action, feedback }) => {
+        switch (action) {
+          case 'approve':
+            proposalCoordinator.resolveRequest(proposalId, {
+              action: 'approve',
+            });
+            break;
+          case 'reject':
+            proposalCoordinator.resolveRequest(proposalId, {
+              action: 'reject',
+              feedback,
+            });
+            break;
+          case 'setup':
+            await this.handleAgentProposalSetup(proposalId);
+            break;
+        }
+      },
+    );
   }
 
   /**

--- a/src/webview/types/messages.ts
+++ b/src/webview/types/messages.ts
@@ -2,8 +2,11 @@
  * Zod schemas for webview message types.
  * Types are derived from schemas using z.infer<> for single source of truth.
  */
+// Third-party imports
 import { z } from 'zod';
 
+// Local imports
+import { AgentCategory } from '@agent/core/AgentDataclass';
 import { PROGRESS_VIEW_APPROVAL_ACTIONS } from '@tools/approval/toolEditApproval';
 
 // --- Base Schemas (composable building blocks) ---
@@ -282,14 +285,14 @@ export type SendFollowUpMessage = z.infer<typeof SendFollowUpMessageSchema>;
 
 /** Sort streams message */
 export const SortStreamsMessageSchema = z.object({
-  sortBy: z.enum(['time', 'inputFile', 'agent']).optional(),
+  sortBy: z.enum(['time', 'inputFile', 'agent']).default('time'),
 });
 
 export type SortStreamsMessage = z.infer<typeof SortStreamsMessageSchema>;
 
 /** Filter streams message */
 export const FilterStreamsMessageSchema = z.object({
-  filter: z.enum(['all', 'workflow', 'toolUse']),
+  filter: z.union([z.literal('all'), z.enum(AgentCategory)]),
 });
 
 export type FilterStreamsMessage = z.infer<typeof FilterStreamsMessageSchema>;

--- a/src/webview/types/messages.ts
+++ b/src/webview/types/messages.ts
@@ -259,6 +259,72 @@ export const FollowupTaskMessageSchema = z.object({
 
 export type FollowupTaskMessage = z.infer<typeof FollowupTaskMessageSchema>;
 
+/** Stream-only message */
+export const StreamMessageSchema = z.object({
+  stream: z.string().min(1),
+});
+
+export type StreamMessage = z.infer<typeof StreamMessageSchema>;
+
+/** Retry message with optional feedback */
+export const RetryStreamMessageSchema = StreamMessageSchema.extend({
+  feedback: z.string().optional(),
+});
+
+export type RetryStreamMessage = z.infer<typeof RetryStreamMessageSchema>;
+
+/** Send follow-up message */
+export const SendFollowUpMessageSchema = StreamMessageSchema.extend({
+  text: TrimmedStringSchema,
+});
+
+export type SendFollowUpMessage = z.infer<typeof SendFollowUpMessageSchema>;
+
+/** Sort streams message */
+export const SortStreamsMessageSchema = z.object({
+  sortBy: z.enum(['time', 'inputFile', 'agent']).optional(),
+});
+
+export type SortStreamsMessage = z.infer<typeof SortStreamsMessageSchema>;
+
+/** Filter streams message */
+export const FilterStreamsMessageSchema = z.object({
+  filter: z.enum(['all', 'workflow', 'toolUse']),
+});
+
+export type FilterStreamsMessage = z.infer<typeof FilterStreamsMessageSchema>;
+
+/** File command message for progress view */
+export const FileCommandMessageSchema = z.object({
+  file: z.string().min(1),
+  line: z.number().int().nonnegative().optional(),
+});
+
+export type FileCommandMessage = z.infer<typeof FileCommandMessageSchema>;
+
+/** File command message requiring a base file */
+export const BaseFileCommandMessageSchema = FileCommandMessageSchema.extend({
+  base: z.string().min(1).optional(),
+});
+
+export type BaseFileCommandMessage = z.infer<
+  typeof BaseFileCommandMessageSchema
+>;
+
+/** File compare message with optional previous file */
+export const CompareMessageSchema = BaseFileCommandMessageSchema.extend({
+  prev: z.string().min(1).optional(),
+});
+
+export type CompareMessage = z.infer<typeof CompareMessageSchema>;
+
+/** Open label message */
+export const OpenLabelMessageSchema = z.object({
+  label: z.string().min(1),
+});
+
+export type OpenLabelMessage = z.infer<typeof OpenLabelMessageSchema>;
+
 // --- History View Schemas ---
 
 /** History ID message for history operations */

--- a/src/webview/types/messages.ts
+++ b/src/webview/types/messages.ts
@@ -292,7 +292,7 @@ export type SortStreamsMessage = z.infer<typeof SortStreamsMessageSchema>;
 
 /** Filter streams message */
 export const FilterStreamsMessageSchema = z.object({
-  filter: z.union([z.literal('all'), z.enum(AgentCategory)]),
+  filter: z.union([z.literal('all'), z.nativeEnum(AgentCategory)]),
 });
 
 export type FilterStreamsMessage = z.infer<typeof FilterStreamsMessageSchema>;


### PR DESCRIPTION
### Motivation
- Make ProgressView message handling robust and single-source-of-truth by validating incoming webview payloads with Zod schemas and reduce unsafe `any` usage.

### Description
- Add new progress-view message schemas to `src/webview/types/messages.ts` (stream, retry, sendFollowUp, sort/filter, file commands, compare, openLabel) so webview and handler share a single contract.
- Harden `ProgressViewMessageHandler` (`src/progressView/ProgressViewMessageHandler.ts`) to validate incoming messages with `withValidatedMessage` for stream actions, retry/cancel, sort/filter, file operations, follow-ups and label opens.
- Guard stream deletion/storage lookups by verifying the stream exists before clearing and retrieving execution/run storage, and make stream IDs explicit in handlers.
- Replace several local `any`/ad-hoc message interfaces with the central Zod-derived types and remove the old inline interfaces.
- Tidy the file-operation helper by changing `executeWithBaseFile` signature to accept explicit `file`/`base` parameters and log missing base paths consistently.

### Testing
- Ran `npm run format` successfully.
- Ran `npm run compile` (webpack completed; shows a known `nunjucks` critical dependency warning but build emitted assets).
- Ran `npm run lint` (linter completed and reported repository pre-existing warnings; no new lint errors introduced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971e8caa9d083249aebbddfc05547c3)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces strict Zod validation for ProgressView webview messages and refactors handlers for safer, typed message processing.
> 
> - Adds centralized schemas in `webview/types/messages.ts` for `stream`, `retry`, `sendFollowUp`, `sortStreams`, `filterStreams`, file commands (`open`, `compare`, `accept`, `merge`, `latexdiff`), and `openLabel`
> - Refactors `ProgressViewMessageHandler` to accept `unknown` messages and validate via `withValidatedMessage`; removes ad-hoc interfaces and unsafe `any`
> - Hardens stream actions (e.g., check existence before delete/stop), retry/cancel flows, and storage access (`openTaskStorage`) with clearer `streamId` usage
> - Updates file ops helper `executeWithBaseFile(file, base, ...)` and consistently log/early-return when base is missing
> - Minor cleanups: stricter types in `handleWebviewReady`, consistent command invocations, backup/compare workflow retained
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8fa3c702c9741bbdc499161838d074eda119c981. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->