### PR TITLE
refactor: improve code highlighting with explicit language tracking

### DIFF
--- a/src/progressView/modules/formatters/constants.js
+++ b/src/progressView/modules/formatters/constants.js
@@ -54,8 +54,18 @@ export const TOOLS_WITH_FILE_LINK = new Set(['read_file']);
 
 /**
  * Tools whose input AND output are code that benefits from syntax highlighting.
+ * Maps tool name to default language hint for output.
+ * Use 'bash' for shell commands, 'plaintext' for tools with variable output.
  */
-export const TOOLS_WITH_CODE_OUTPUT = new Set(['bash', 'execute', 'run']);
+export const TOOL_OUTPUT_LANGUAGES = new Map([
+  ['bash', 'bash'],
+  ['execute', 'plaintext'], // Could be any language - don't guess
+  ['run', 'plaintext'], // Could be any language - don't guess
+]);
+
+// Threshold constants for diff detection heuristics
+export const DIFF_DETECTION_LINE_LIMIT = 20;
+export const DIFF_MARKER_THRESHOLD = 2;
 
 /**
  * Tool icon mapping for different tool types.

--- a/src/progressView/modules/formatters/htmlBuilders.js
+++ b/src/progressView/modules/formatters/htmlBuilders.js
@@ -9,7 +9,11 @@ import {
   CHEVRON_RIGHT_CLASS,
   CHEVRON_DOWN_CLASS,
 } from '@common/iconConstants.js';
-import { TOOL_ICON_MAP } from './constants.js';
+import {
+  TOOL_ICON_MAP,
+  DIFF_DETECTION_LINE_LIMIT,
+  DIFF_MARKER_THRESHOLD,
+} from './constants.js';
 import { generateInlineDiff } from './wordDiff.js';
 
 /**
@@ -53,17 +57,18 @@ function getDiffLineClass(line) {
 }
 
 /**
- * Check if text appears to be diff output
+ * Check if text appears to be diff output.
+ * Examines first N lines for diff markers (@@, +++, ---).
  * @param {string} text - Text to check
  * @returns {boolean} True if text looks like diff output
  */
 function isDiffContent(text) {
-  const lines = text.split('\n').slice(0, 20);
+  const lines = text.split('\n').slice(0, DIFF_DETECTION_LINE_LIMIT);
   const diffMarkers = lines.filter(
     (line) =>
       line.startsWith('@@') || line.startsWith('+++') || line.startsWith('---'),
   ).length;
-  return diffMarkers >= 2;
+  return diffMarkers >= DIFF_MARKER_THRESHOLD;
 }
 
 /**
@@ -201,29 +206,107 @@ export function getToolIconClass(toolName, isError = false) {
 // Syntax Highlighting
 // ============================================================================
 
+/** Human-readable labels for language badges */
+const LANGUAGE_LABELS = {
+  bash: 'Bash',
+  json: 'JSON',
+  yaml: 'YAML',
+  javascript: 'JavaScript',
+  typescript: 'TypeScript',
+  python: 'Python',
+  plaintext: 'Text',
+};
+
 /**
- * Wrap code in a pre element with syntax highlighting using highlight.js
+ * Get display label for a language
+ * @param {string} language - Language identifier
+ * @returns {string} Human-readable label
+ */
+function getLanguageLabel(language) {
+  return LANGUAGE_LABELS[language] || language || 'Text';
+}
+
+/**
+ * Build a code block with optional syntax highlighting, language badge, and copy button.
+ * Does NOT use auto-detection - requires explicit language or defaults to plaintext.
+ *
+ * @param {string} text - Code text to display
+ * @param {object} [options] - Configuration options
+ * @param {string} [options.language='plaintext'] - Language for syntax highlighting
+ * @param {string} [options.className] - Additional CSS class for the pre element
+ * @param {boolean} [options.showLanguage=false] - Show language badge
+ * @param {boolean} [options.showCopy=false] - Show copy button
+ * @returns {string} HTML string for the code block
+ */
+export function buildCodeBlock(text, options = {}) {
+  const {
+    language = 'plaintext',
+    className = '',
+    showLanguage = false,
+    showCopy = false,
+  } = options;
+
+  const classes = ['code-block', className].filter(Boolean).join(' ');
+  const preClasses = ['hljs', className].filter(Boolean).join(' ');
+
+  // Build code content with or without highlighting
+  let codeContent;
+  const isHighlightable = language && language !== 'plaintext';
+
+  if (isHighlightable && hljs.getLanguage(language)) {
+    try {
+      const result = hljs.highlight(text, { language, ignoreIllegals: true });
+      codeContent = result.value;
+    } catch {
+      codeContent = encodeHtml(text);
+    }
+  } else {
+    codeContent = encodeHtml(text);
+  }
+
+  // Build header with optional badge and copy button
+  const headerParts = [];
+  if (showLanguage) {
+    const label = getLanguageLabel(language);
+    headerParts.push(`<span class="code-block-language">${encodeHtml(label)}</span>`);
+  }
+  if (showCopy) {
+    headerParts.push(
+      `<button class="code-block-copy" title="Copy to clipboard"><i class="codicon codicon-copy"></i></button>`,
+    );
+  }
+
+  const header =
+    headerParts.length > 0
+      ? `<div class="code-block-header">${headerParts.join('')}</div>`
+      : '';
+
+  return `<div class="${classes}" data-language="${encodeHtml(language)}">${header}<pre class="${preClasses}"><code>${codeContent}</code></pre></div>`;
+}
+
+/**
+ * Wrap code in a pre element with syntax highlighting using highlight.js.
+ * Legacy API - prefer buildCodeBlock for new code.
+ *
  * @param {string} text - Code text to highlight
- * @param {string} [language] - Optional language hint (e.g., 'bash', 'json')
+ * @param {string} [language='plaintext'] - Language hint (e.g., 'bash', 'json', 'yaml')
  * @param {string} [className] - Optional additional CSS class
  * @returns {string} HTML string with syntax highlighting
  */
-export function wrapInHighlightedPre(text, language = '', className = '') {
-  const classes = ['hljs', className].filter(Boolean).join(' ');
-  const classAttr = classes ? ` class="${classes}"` : '';
+export function wrapInHighlightedPre(text, language = 'plaintext', className = '') {
+  // Delegate to buildCodeBlock without header elements for backwards compatibility
+  const preClasses = ['hljs', className].filter(Boolean).join(' ');
 
-  try {
-    let result;
-    if (language && hljs.getLanguage(language)) {
-      result = hljs.highlight(text, { language, ignoreIllegals: true });
-    } else {
-      result = hljs.highlightAuto(text);
+  if (language && language !== 'plaintext' && hljs.getLanguage(language)) {
+    try {
+      const result = hljs.highlight(text, { language, ignoreIllegals: true });
+      return `<pre class="${preClasses}"><code>${result.value}</code></pre>`;
+    } catch {
+      // Fall through to plaintext
     }
-    return `<pre${classAttr}><code>${result.value}</code></pre>`;
-  } catch {
-    // Fallback to plain text if highlighting fails
-    return `<pre${classAttr}><code>${encodeHtml(text)}</code></pre>`;
   }
+
+  return `<pre class="${preClasses}"><code>${encodeHtml(text)}</code></pre>`;
 }
 
 // ============================================================================

--- a/src/progressView/modules/formatters/htmlBuilders.js
+++ b/src/progressView/modules/formatters/htmlBuilders.js
@@ -246,7 +246,7 @@ export function buildCodeBlock(text, options = {}) {
     showCopy = false,
   } = options;
 
-  const classes = ['code-block', className].filter(Boolean).join(' ');
+  const classes = ['code-block'].filter(Boolean).join(' ');
   const preClasses = ['hljs', className].filter(Boolean).join(' ');
 
   // Build code content with or without highlighting
@@ -268,7 +268,9 @@ export function buildCodeBlock(text, options = {}) {
   const headerParts = [];
   if (showLanguage) {
     const label = getLanguageLabel(language);
-    headerParts.push(`<span class="code-block-language">${encodeHtml(label)}</span>`);
+    headerParts.push(
+      `<span class="code-block-language">${encodeHtml(label)}</span>`,
+    );
   }
   if (showCopy) {
     headerParts.push(
@@ -282,31 +284,6 @@ export function buildCodeBlock(text, options = {}) {
       : '';
 
   return `<div class="${classes}" data-language="${encodeHtml(language)}">${header}<pre class="${preClasses}"><code>${codeContent}</code></pre></div>`;
-}
-
-/**
- * Wrap code in a pre element with syntax highlighting using highlight.js.
- * Legacy API - prefer buildCodeBlock for new code.
- *
- * @param {string} text - Code text to highlight
- * @param {string} [language='plaintext'] - Language hint (e.g., 'bash', 'json', 'yaml')
- * @param {string} [className] - Optional additional CSS class
- * @returns {string} HTML string with syntax highlighting
- */
-export function wrapInHighlightedPre(text, language = 'plaintext', className = '') {
-  // Delegate to buildCodeBlock without header elements for backwards compatibility
-  const preClasses = ['hljs', className].filter(Boolean).join(' ');
-
-  if (language && language !== 'plaintext' && hljs.getLanguage(language)) {
-    try {
-      const result = hljs.highlight(text, { language, ignoreIllegals: true });
-      return `<pre class="${preClasses}"><code>${result.value}</code></pre>`;
-    } catch {
-      // Fall through to plaintext
-    }
-  }
-
-  return `<pre class="${preClasses}"><code>${encodeHtml(text)}</code></pre>`;
 }
 
 // ============================================================================

--- a/src/progressView/modules/formatters/htmlBuilders.js
+++ b/src/progressView/modules/formatters/htmlBuilders.js
@@ -246,7 +246,6 @@ export function buildCodeBlock(text, options = {}) {
     showCopy = false,
   } = options;
 
-  const classes = ['code-block'].filter(Boolean).join(' ');
   const preClasses = ['hljs', className].filter(Boolean).join(' ');
 
   // Build code content with or without highlighting
@@ -283,7 +282,7 @@ export function buildCodeBlock(text, options = {}) {
       ? `<div class="code-block-header">${headerParts.join('')}</div>`
       : '';
 
-  return `<div class="${classes}" data-language="${encodeHtml(language)}">${header}<pre class="${preClasses}"><code>${codeContent}</code></pre></div>`;
+  return `<div class="code-block" data-language="${encodeHtml(language)}">${header}<pre class="${preClasses}"><code>${codeContent}</code></pre></div>`;
 }
 
 // ============================================================================

--- a/src/progressView/modules/formatters/logFormatters/toolFormatters.js
+++ b/src/progressView/modules/formatters/logFormatters/toolFormatters.js
@@ -12,13 +12,13 @@ import {
   getToolIconClass,
   buildFileLinkWithLines,
   buildEditDiffSection,
-  wrapInHighlightedPre,
+  buildCodeBlock,
 } from '../htmlBuilders.js';
-import { normalizeToolUseLog, stringifyForDisplay } from '../normalizers.js';
+import { normalizeToolUseLog, stringifyWithLanguage } from '../normalizers.js';
 import {
   TOOLS_WITH_DIFF_INPUT,
   TOOLS_WITH_FILE_LINK,
-  TOOLS_WITH_CODE_OUTPUT,
+  TOOL_OUTPUT_LANGUAGES,
 } from '../constants.js';
 
 // Web search provider display names
@@ -40,18 +40,36 @@ const STATUS_ICONS = {
 };
 
 /**
- * Build a tool section with appropriate code highlighting based on tool type.
+ * Build a tool section with appropriate code highlighting based on tool type and content.
+ * Uses explicit language from tool config or content metadata - never auto-detects.
+ *
  * @param {string} label - Section label (e.g., 'Input:', 'Output:')
  * @param {string} text - Content text to display
- * @param {string} toolName - Name of the tool
- * @param {string} [extraClass] - Additional CSS class for the content
+ * @param {object} options - Display options
+ * @param {string} options.toolName - Name of the tool
+ * @param {string} [options.language] - Explicit language override (from stringifyWithLanguage)
+ * @param {string} [options.extraClass] - Additional CSS class for the content
  * @returns {string} HTML for the section
  */
-function buildToolSection(label, text, toolName, extraClass = '') {
-  const useHighlighting = TOOLS_WITH_CODE_OUTPUT.has(toolName);
-  const content = useHighlighting
-    ? wrapInHighlightedPre(text, 'bash', extraClass)
+function buildToolSection(label, text, options = {}) {
+  const { toolName = '', language: contentLanguage, extraClass = '' } = options;
+
+  // Determine language: tool config > content metadata > plaintext
+  const toolLanguage = TOOL_OUTPUT_LANGUAGES.get(toolName);
+  const language = toolLanguage || contentLanguage || 'plaintext';
+
+  // Only use highlighting for known languages, show badge for non-plaintext
+  const shouldHighlight = language && language !== 'plaintext';
+
+  const content = shouldHighlight
+    ? buildCodeBlock(text, {
+        language,
+        className: extraClass,
+        showLanguage: true,
+        showCopy: true,
+      })
     : wrapInPre(text, extraClass);
+
   return buildToolUseSection(label, content);
 }
 
@@ -194,9 +212,15 @@ export function formatToolUse(normalizedPayload, logId, groupId, timestamp) {
   }
   // Default handling for other tools
   else if (input !== undefined && input !== null) {
-    const inputValue = stringifyForDisplay(input);
+    const { text: inputValue, language: inputLanguage } =
+      stringifyWithLanguage(input);
     if (inputValue) {
-      sections.push(buildToolSection('Input:', inputValue, toolName));
+      sections.push(
+        buildToolSection('Input:', inputValue, {
+          toolName,
+          language: inputLanguage,
+        }),
+      );
     }
   }
 
@@ -204,7 +228,10 @@ export function formatToolUse(normalizedPayload, logId, groupId, timestamp) {
   // Skip for read/file-link tools (already shown as file link)
   if (outputText && !TOOLS_WITH_FILE_LINK.has(toolName)) {
     sections.push(
-      buildToolSection('Output:', outputText, toolName, 'tool-output-full'),
+      buildToolSection('Output:', outputText, {
+        toolName,
+        extraClass: 'tool-output-full',
+      }),
     );
   }
 
@@ -225,10 +252,15 @@ export function formatToolUse(normalizedPayload, logId, groupId, timestamp) {
     );
   }
 
-  const fallbackYaml = stringifyForDisplay(parsed);
+  const { text: fallbackYaml, language: fallbackLanguage } =
+    stringifyWithLanguage(parsed);
   contentElem.innerHTML =
     sections.length === 0
-      ? wrapInPre(fallbackYaml || '')
+      ? buildCodeBlock(fallbackYaml || '', {
+          language: fallbackLanguage,
+          showLanguage: fallbackLanguage !== 'plaintext',
+          showCopy: true,
+        })
       : sections.join('<hr class="tool-use-separator">');
 
   return element;

--- a/src/progressView/modules/formatters/normalizers.js
+++ b/src/progressView/modules/formatters/normalizers.js
@@ -39,25 +39,42 @@ function extractString(primary, fallback) {
 }
 
 /**
- * Convert a value to a display-friendly string
- * @param {*} value - Value to stringify
- * @returns {string} Display string
+ * @typedef {Object} StringifyResult
+ * @property {string} text - The stringified text
+ * @property {string} language - Language hint for syntax highlighting ('yaml', 'json', 'plaintext')
  */
-export function stringifyForDisplay(value) {
+
+/**
+ * Convert a value to a display-friendly string with language metadata.
+ * Avoids repeated parsing by tracking the serialization format used.
+ * @param {*} value - Value to stringify
+ * @returns {StringifyResult} Object with text and language hint
+ */
+export function stringifyWithLanguage(value) {
   if (value === undefined || value === null) {
-    return '';
+    return { text: '', language: 'plaintext' };
   }
 
   if (typeof value === 'string') {
-    return value;
+    return { text: value, language: 'plaintext' };
   }
 
   try {
     const yamlString = yaml.stringify(value);
-    return typeof yamlString === 'string' ? yamlString.trimEnd() : '';
+    const text = typeof yamlString === 'string' ? yamlString.trimEnd() : '';
+    return { text, language: 'yaml' };
   } catch {
-    return String(value);
+    return { text: String(value), language: 'plaintext' };
   }
+}
+
+/**
+ * Convert a value to a display-friendly string (legacy API)
+ * @param {*} value - Value to stringify
+ * @returns {string} Display string
+ */
+export function stringifyForDisplay(value) {
+  return stringifyWithLanguage(value).text;
 }
 
 /**

--- a/src/progressView/modules/uiManagers/EventsManager.js
+++ b/src/progressView/modules/uiManagers/EventsManager.js
@@ -220,6 +220,25 @@ export class EventsManager {
             'Copy content',
           successTitle: copyButton.dataset.successTitle || 'Copied!',
         });
+        return;
+      }
+
+      // Code block copy button
+      const codeBlockCopy = e.target.closest('.code-block-copy');
+      if (codeBlockCopy) {
+        e.stopPropagation();
+        const codeBlock = codeBlockCopy.closest('.code-block');
+        const codeElem = codeBlock?.querySelector('code');
+        if (!codeElem) return;
+
+        const textToCopy = codeElem.textContent ?? '';
+        if (!textToCopy.trim()) return;
+
+        await copyWithFeedback(codeBlockCopy, textToCopy, {
+          defaultTitle: 'Copy to clipboard',
+          successTitle: 'Copied!',
+          successClass: 'copied',
+        });
       }
     });
   }

--- a/src/progressView/styles/code-block.css
+++ b/src/progressView/styles/code-block.css
@@ -1,0 +1,58 @@
+/**
+ * Code Block Component - syntax highlighted code with language badge and copy button
+ * Used by buildCodeBlock() in htmlBuilders.js
+ */
+
+.code-block {
+  position: relative;
+  border-radius: var(--border-radius-small);
+  overflow: hidden;
+}
+
+.code-block-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--spacing-tiny) var(--spacing-small);
+  background-color: var(--vscode-editorGroupHeader-tabsBackground, #252526);
+  border-bottom: var(--border-thin) solid var(--color-border);
+  font-size: var(--font-size-xs);
+}
+
+.code-block-language {
+  color: var(--vscode-descriptionForeground, #888);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  font-weight: 500;
+}
+
+.code-block-copy {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2px 6px;
+  border: none;
+  background: transparent;
+  color: var(--vscode-descriptionForeground, #888);
+  cursor: pointer;
+  border-radius: var(--border-radius-small);
+  transition: background-color 0.15s, color 0.15s;
+}
+
+.code-block-copy:hover {
+  background-color: var(--vscode-toolbar-hoverBackground, rgba(90, 93, 94, 0.31));
+  color: var(--vscode-foreground);
+}
+
+.code-block-copy:active {
+  background-color: var(--vscode-toolbar-activeBackground, rgba(99, 102, 103, 0.31));
+}
+
+.code-block-copy.copied {
+  color: var(--vscode-gitDecoration-addedResourceForeground, #3fb950);
+}
+
+.code-block pre.hljs {
+  margin: 0;
+  border-radius: 0;
+}

--- a/src/progressView/styles/code-block.css
+++ b/src/progressView/styles/code-block.css
@@ -36,16 +36,24 @@
   color: var(--vscode-descriptionForeground, #888);
   cursor: pointer;
   border-radius: var(--border-radius-small);
-  transition: background-color 0.15s, color 0.15s;
+  transition:
+    background-color 0.15s,
+    color 0.15s;
 }
 
 .code-block-copy:hover {
-  background-color: var(--vscode-toolbar-hoverBackground, rgba(90, 93, 94, 0.31));
+  background-color: var(
+    --vscode-toolbar-hoverBackground,
+    rgba(90, 93, 94, 0.31)
+  );
   color: var(--vscode-foreground);
 }
 
 .code-block-copy:active {
-  background-color: var(--vscode-toolbar-activeBackground, rgba(99, 102, 103, 0.31));
+  background-color: var(
+    --vscode-toolbar-activeBackground,
+    rgba(99, 102, 103, 0.31)
+  );
 }
 
 .code-block-copy.copied {

--- a/src/progressView/styles/index.css
+++ b/src/progressView/styles/index.css
@@ -18,6 +18,7 @@
 @import './groups.css';
 @import './markdown.css';
 @import './scratchpad.css';
+@import './code-block.css';
 @import './file-list.css';
 @import './latexdiff.css';
 @import './statistics.css';

--- a/src/progressView/styles/scratchpad.css
+++ b/src/progressView/styles/scratchpad.css
@@ -179,3 +179,61 @@ pre.hljs code {
   background: transparent;
   padding: 0;
 }
+
+/* ============================================================================
+ * Code Block Component - container with language badge and copy button
+ * ============================================================================ */
+
+.code-block {
+  position: relative;
+  border-radius: var(--border-radius-small);
+  overflow: hidden;
+}
+
+.code-block-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--spacing-tiny) var(--spacing-small);
+  background-color: var(--vscode-editorGroupHeader-tabsBackground, #252526);
+  border-bottom: var(--border-thin) solid var(--color-border);
+  font-size: var(--font-size-xs);
+}
+
+.code-block-language {
+  color: var(--vscode-descriptionForeground, #888);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  font-weight: 500;
+}
+
+.code-block-copy {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2px 6px;
+  border: none;
+  background: transparent;
+  color: var(--vscode-descriptionForeground, #888);
+  cursor: pointer;
+  border-radius: var(--border-radius-small);
+  transition: background-color 0.15s, color 0.15s;
+}
+
+.code-block-copy:hover {
+  background-color: var(--vscode-toolbar-hoverBackground, rgba(90, 93, 94, 0.31));
+  color: var(--vscode-foreground);
+}
+
+.code-block-copy:active {
+  background-color: var(--vscode-toolbar-activeBackground, rgba(99, 102, 103, 0.31));
+}
+
+.code-block-copy.copied {
+  color: var(--vscode-gitDecoration-addedResourceForeground, #3fb950);
+}
+
+.code-block pre.hljs {
+  margin: 0;
+  border-radius: 0;
+}

--- a/src/progressView/styles/scratchpad.css
+++ b/src/progressView/styles/scratchpad.css
@@ -169,7 +169,7 @@
   padding: 0 2px;
 }
 
-/* Syntax highlighted code blocks */
+/* Syntax highlighted code blocks (base hljs styling) */
 pre.hljs {
   padding: var(--spacing-small);
   overflow-x: auto;
@@ -178,62 +178,4 @@ pre.hljs {
 pre.hljs code {
   background: transparent;
   padding: 0;
-}
-
-/* ============================================================================
- * Code Block Component - container with language badge and copy button
- * ============================================================================ */
-
-.code-block {
-  position: relative;
-  border-radius: var(--border-radius-small);
-  overflow: hidden;
-}
-
-.code-block-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: var(--spacing-tiny) var(--spacing-small);
-  background-color: var(--vscode-editorGroupHeader-tabsBackground, #252526);
-  border-bottom: var(--border-thin) solid var(--color-border);
-  font-size: var(--font-size-xs);
-}
-
-.code-block-language {
-  color: var(--vscode-descriptionForeground, #888);
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
-  font-weight: 500;
-}
-
-.code-block-copy {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 2px 6px;
-  border: none;
-  background: transparent;
-  color: var(--vscode-descriptionForeground, #888);
-  cursor: pointer;
-  border-radius: var(--border-radius-small);
-  transition: background-color 0.15s, color 0.15s;
-}
-
-.code-block-copy:hover {
-  background-color: var(--vscode-toolbar-hoverBackground, rgba(90, 93, 94, 0.31));
-  color: var(--vscode-foreground);
-}
-
-.code-block-copy:active {
-  background-color: var(--vscode-toolbar-activeBackground, rgba(99, 102, 103, 0.31));
-}
-
-.code-block-copy.copied {
-  color: var(--vscode-gitDecoration-addedResourceForeground, #3fb950);
-}
-
-.code-block pre.hljs {
-  margin: 0;
-  border-radius: 0;
 }


### PR DESCRIPTION
- Replace TOOLS_WITH_CODE_OUTPUT Set with TOOL_OUTPUT_LANGUAGES Map
  to specify language hints per tool instead of blanket 'bash' assumption
- Add stringifyWithLanguage() to track serialization format (yaml/json)
  through the pipeline, avoiding redundant auto-detection
- Remove highlightAuto fallback - use explicit language or plaintext
- Add buildCodeBlock() with language badge and copy button support
- Extract DIFF_DETECTION_LINE_LIMIT and DIFF_MARKER_THRESHOLD constants
- Add CSS for code-block-header, language badge, and copy button
- Wire up copy button click handler in EventsManager

This eliminates guessing and repeated parsing while providing better UX
with visible language labels and one-click copy functionality.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Shifts code rendering to explicit language hints and introduces a reusable code block UI with copy support, improving clarity and consistency while removing auto-detection.
> 
> - Replace `TOOLS_WITH_CODE_OUTPUT` with `TOOL_OUTPUT_LANGUAGES` map; propagate language hints through formatters
> - Add `stringifyWithLanguage()` to carry serialization format (e.g., `yaml`) and use it in tool input/fallback rendering
> - Introduce `buildCodeBlock()` (no auto-detect) with optional language badge and copy button; remove `wrapInHighlightedPre`
> - Wire tool sections to use `buildCodeBlock()` based on tool/content language; default to `plaintext`
> - Add diff detection thresholds (`DIFF_DETECTION_LINE_LIMIT`, `DIFF_MARKER_THRESHOLD`) and apply in `wrapInPre()`
> - Implement code-block copy handling in `EventsManager`
> - Add `code-block.css` and import in `styles/index.css`; keep base `hljs` styling in `scratchpad.css`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dd24053bc6bb5bd9ba9325a1334129faf53b4903. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->