### PR TITLE
docs: clarify ReasoningDetailItem local type rationale

### DIFF
--- a/src/agent/modelHandlers/modelHandlerOpenRouter.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenRouter.ts
@@ -4,8 +4,18 @@ import { isAssistantMessage } from 'openai/lib/chatCompletionUtils';
 
 /**
  * OpenRouter reasoning_details item type.
- * Defined locally since @openrouter/sdk/models subpath export requires moduleResolution: node16+
+ *
+ * Note: This type is intentionally defined locally rather than imported from
+ * `@openrouter/sdk/models` (Schema2 type) because:
+ * - The SDK uses ESM subpath exports which require `moduleResolution: "node16"` or higher
+ * - This project uses `moduleResolution: "node"` in tsconfig.json
+ * - Changing moduleResolution would have broader implications across the codebase
+ *
+ * The SDK's Schema2 type is equivalent but includes additional optional fields
+ * (signature, id, format, index) that we don't need for our use case.
+ *
  * @see https://openrouter.ai/docs/guides/best-practices/reasoning-tokens
+ * @see Schema2 in @openrouter/sdk/esm/models/schema2.d.ts for SDK equivalent
  */
 type ReasoningDetailItem =
   | { type: 'reasoning.text'; text?: string | null }


### PR DESCRIPTION
Document why ReasoningDetailItem is defined locally rather than imported
from @openrouter/sdk/models (Schema2 type):
- SDK uses ESM subpath exports requiring moduleResolution: node16+
- Project uses moduleResolution: node in tsconfig.json
- Changing moduleResolution would have broader codebase implications

Add reference to SDK equivalent type for future maintainers.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Clarifies rationale for defining `ReasoningDetailItem` locally in `modelHandlerOpenRouter.ts` and documents the SDK equivalent.
> 
> - Notes ESM subpath export constraints (`moduleResolution: "node16"+`) vs project’s `moduleResolution: "node"`
> - States that the SDK’s Schema2 adds optional fields not needed here
> - Adds direct reference to `@openrouter/sdk/esm/models/schema2.d.ts`
> 
> No functional code changes; comments/documentation only.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e4e2081a956cdc30f0829ad728b408efe420beb4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->