### PR TITLE
Simplify and improve code clarity

### DIFF
--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -705,7 +705,7 @@ export function buildApprovalRejectedResult(
     summary: baseMessage,
     error: baseMessage,
     isError: true,
-    ...(feedback && feedback.length > 0 ? { userInstruction: feedback } : {}),
+    ...(feedback ? { userInstruction: feedback } : {}),
   };
 
   // No file attachments for user feedback; treated purely as guidance via fields.


### PR DESCRIPTION
The `feedback && feedback.length > 0` check was redundant because:
- `feedback` comes from `userMessage?.trim()` which returns string or undefined
- If feedback is truthy (non-empty string), length > 0 is guaranteed
- If feedback is '' (empty), it's already falsy

Simplify to just `feedback` for the conditional spread.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Refactor**
> 
> - Simplifies the conditional spread for `userInstruction` in `buildApprovalRejectedResult`, using `feedback` truthiness instead of redundant `feedback && feedback.length > 0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 64e510c40c18555320485974c9ec9c96c3304541. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->