### PR TITLE
Add code highlighting to write file

### DIFF
--- a/src/progressView/modules/formatters/constants.js
+++ b/src/progressView/modules/formatters/constants.js
@@ -53,6 +53,11 @@ export const TOOLS_WITH_DIFF_INPUT = new Set(['edit_file']);
 export const TOOLS_WITH_FILE_LINK = new Set(['read_file']);
 
 /**
+ * Tools that write files and should show file link + syntax-highlighted content.
+ */
+export const TOOLS_WITH_FILE_CONTENT = new Set(['write_file']);
+
+/**
  * Tools whose input AND output are code that benefits from syntax highlighting.
  * Maps tool name to default language hint for output.
  * Use 'bash' for shell commands, 'plaintext' for tools with variable output.
@@ -62,6 +67,62 @@ export const TOOL_OUTPUT_LANGUAGES = new Map([
   ['execute', 'plaintext'], // Could be any language - don't guess
   ['run', 'plaintext'], // Could be any language - don't guess
 ]);
+
+/**
+ * Map file extensions that don't match highlight.js language names.
+ * Focused on LaTeX research context. Unknown extensions try the extension directly.
+ */
+const EXTENSION_ALIASES = new Map([
+  // LaTeX ecosystem
+  ['tex', 'latex'],
+  ['sty', 'latex'],
+  ['cls', 'latex'],
+  ['dtx', 'latex'],
+  ['tikz', 'latex'],
+  ['bib', 'bibtex'],
+  ['bst', 'latex'],
+  // Scientific computing
+  ['py', 'python'],
+  ['jl', 'julia'],
+  ['wl', 'mathematica'],
+  ['m', 'mathematica'],
+  ['f90', 'fortran'],
+  ['f95', 'fortran'],
+  ['ipynb', 'json'],
+  // Config/docs
+  ['yml', 'yaml'],
+  ['md', 'markdown'],
+  ['sh', 'bash'],
+]);
+
+/**
+ * Get highlight.js language from file path based on extension.
+ * Uses alias map for non-standard extensions, otherwise tries the extension directly.
+ * @param {string} filePath - File path to extract extension from
+ * @returns {string} Language identifier (highlight.js validates it later)
+ */
+export function getLanguageFromPath(filePath) {
+  if (!filePath || typeof filePath !== 'string') {
+    return 'plaintext';
+  }
+
+  const fileName = filePath.split('/').pop() || filePath;
+  const lowerFileName = fileName.toLowerCase();
+
+  // Handle special filenames
+  if (lowerFileName === 'dockerfile') return 'dockerfile';
+  if (lowerFileName === 'makefile') return 'makefile';
+
+  const lastDot = fileName.lastIndexOf('.');
+  if (lastDot === -1 || lastDot === fileName.length - 1) {
+    return 'plaintext';
+  }
+
+  const ext = fileName.slice(lastDot + 1).toLowerCase();
+
+  // Check alias map first, then use extension directly
+  return EXTENSION_ALIASES.get(ext) || ext;
+}
 
 // Threshold constants for diff detection heuristics
 export const DIFF_DETECTION_LINE_LIMIT = 20;

--- a/src/progressView/modules/formatters/logFormatters/toolFormatters.js
+++ b/src/progressView/modules/formatters/logFormatters/toolFormatters.js
@@ -18,7 +18,9 @@ import { normalizeToolUseLog, stringifyWithLanguage } from '../normalizers.js';
 import {
   TOOLS_WITH_DIFF_INPUT,
   TOOLS_WITH_FILE_LINK,
+  TOOLS_WITH_FILE_CONTENT,
   TOOL_OUTPUT_LANGUAGES,
+  getLanguageFromPath,
 } from '../constants.js';
 
 // Web search provider display names
@@ -210,6 +212,23 @@ export function formatToolUse(normalizedPayload, logId, groupId, timestamp) {
       ),
     );
   }
+  // Handle write tools with file link + syntax-highlighted content
+  else if (
+    TOOLS_WITH_FILE_CONTENT.has(toolName) &&
+    filePath &&
+    input?.content !== undefined
+  ) {
+    sections.push(
+      buildToolUseSection('File:', buildFileLinkWithLines(filePath)),
+    );
+    const contentLanguage = getLanguageFromPath(filePath);
+    sections.push(
+      buildToolSection('Content:', input.content, {
+        toolName,
+        language: contentLanguage,
+      }),
+    );
+  }
   // Default handling for other tools
   else if (input !== undefined && input !== null) {
     const { text: inputValue, language: inputLanguage } =
@@ -225,8 +244,16 @@ export function formatToolUse(normalizedPayload, logId, groupId, timestamp) {
   }
 
   // Show output if present (primary result from tool)
-  // Skip for read/file-link tools (already shown as file link)
-  if (outputText && !TOOLS_WITH_FILE_LINK.has(toolName)) {
+  // Skip for read tools (already shown as file link)
+  // Skip trivial "written" for write tools, but show if user adjusted content
+  // (WriteTool outputs "written\n\n<diff>" when user modifies proposed content)
+  const isWriteTool = TOOLS_WITH_FILE_CONTENT.has(toolName);
+  const isTrivialWriteOutput = isWriteTool && outputText.trim() === 'written';
+  if (
+    outputText &&
+    !TOOLS_WITH_FILE_LINK.has(toolName) &&
+    !isTrivialWriteOutput
+  ) {
     sections.push(
       buildToolSection('Output:', outputText, {
         toolName,


### PR DESCRIPTION
Display write_file tool calls with:
- File path shown as clickable link
- Content syntax-highlighted based on file extension
- Skip redundant "Output: written" text

Extension aliases focused on LaTeX research context (tex, bib, py, yml, md, sh). Unknown extensions try the extension directly as highlight.js language name.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enhances tool log rendering for file writes with language-aware highlighting and cleaner output.
> 
> - Add `TOOLS_WITH_FILE_CONTENT` and handle `write_file` by showing a file link plus syntax-highlighted `content` (language derived via new `getLanguageFromPath`)
> - Introduce extension alias mapping (LaTeX-focused plus common langs; special cases for `Dockerfile`/`Makefile`)
> - Refine output display: continue skipping for read tools; ignore trivial `written` for write tools while still showing non-trivial outputs (e.g., diffs)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6fe718c2ce3908d9dbef61a778f30005b7a5e33f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->