### PR TITLE
fix: resume background responses on retry

### DIFF
--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -189,6 +189,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     ['completed', 'failed', 'cancelled', 'incomplete'];
 
   private previousResponseId: string | null = null;
+  private pendingBackgroundResponseId: string | null = null;
 
   /**
    * Conversation state for tracking messages, tokens, and compaction.
@@ -239,6 +240,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       this.previousResponseId = null;
     }
 
+    this.pendingBackgroundResponseId = null;
     this.conversationState.sentMessages = effectiveMessagesCount;
 
     // Set cumulative input tokens from actual usage (not additive - this IS the total)
@@ -854,6 +856,34 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       params.reasoning = reasoning;
     }
 
+    if (useBackgroundResponses && this.pendingBackgroundResponseId) {
+      this.logger.debug(
+        `Resuming background polling for response ${this.pendingBackgroundResponseId} after retry.`,
+        {
+          data: {
+            responseId: this.pendingBackgroundResponseId,
+          },
+        },
+      );
+      const requestOptions = signal ? { signal } : undefined;
+      const existingResponse = await client.responses.retrieve(
+        this.pendingBackgroundResponseId,
+        undefined,
+        requestOptions,
+      );
+      const response = await this.waitForBackgroundCompletion(
+        client,
+        existingResponse,
+        signal,
+      );
+      this.finalizeResponse(
+        response,
+        effectiveMessages.length,
+        compactedThisCall,
+      );
+      return response;
+    }
+
     // Wrap execution in try-catch to handle previousResponseId errors
     // When an error indicates the response ID is invalid, we clear it so
     // the retry logic can recover by starting a fresh conversation.
@@ -951,6 +981,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
             },
           },
         );
+        this.pendingBackgroundResponseId = response.id ?? null;
         this.logger.logProgress(
           `Running OpenAI Responses in background mode for response ${response.id}; polling every 15s. Completion may take longer than usual.`,
         );
@@ -1298,6 +1329,9 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
           },
         },
       );
+      if (this.pendingBackgroundResponseId === responseId) {
+        this.pendingBackgroundResponseId = null;
+      }
       throw new Error(
         `Background response ${responseId} ended with status ${fallbackStatus}: ${errorDetail}. Retrieve the latest status with client.responses.retrieve("${responseId}").`,
       );


### PR DESCRIPTION
### Motivation
- Prevent resubmitting background `responses.create` requests after transient connection/retry errors by reusing the original background response and continuing polling. This avoids duplicate background jobs and preserves server-side progress.

### Description
- Track an in-flight background response with a new field `pendingBackgroundResponseId` on `ModelHandlerOpenAIResponse` and set it when a background response is created.
- On successful completion or terminal failure, clear `pendingBackgroundResponseId` in `finalizeResponse` and `waitForBackgroundCompletion` respectively.
- When `createResponse` is retried and `useBackgroundResponses` is enabled, resume polling the existing background response by calling `client.responses.retrieve` and `waitForBackgroundCompletion` instead of creating a new background request. Logs are added to surface resume/clear events.

### Testing
- Ran `npm run format` (succeeded). 
- Ran `npm run compile` (webpack) which failed due to missing modules (`p-map` and `delay`) unrelated to this change. 
- Ran `npm run lint` which completed with warnings only (no errors).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69724cd9604c8324b21f5673045b0208)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures background Responses are resumed on retry rather than re-created, preventing duplicate jobs and preserving server-side progress.
> 
> - Track in-flight background response via `pendingBackgroundResponseId`; set on create, cleared on success or terminal failure
> - On retry with background mode, `responses.retrieve` and `waitForBackgroundCompletion` are used to resume polling existing response
> - Updated logging to surface resume/clear events and background polling lifecycle
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 26a523210bac7ba42aaedf24fae441fa6ad2a15e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->