### PR TITLE
Fix diff filename generation for round-vs-original comparisons

### DIFF
--- a/src/latex/latexdiff/diffFileNameManager.ts
+++ b/src/latex/latexdiff/diffFileNameManager.ts
@@ -38,23 +38,33 @@ function generateRoundBasedFileName(
 
 /**
  * Generate a diff filename based on input and edited file names.
- * Uses round-based naming if both files have rounds AND rounds differ.
+ * Uses round-based naming only for between-round diffs (same operation chain).
+ * Falls back to suffix for round-vs-original diffs (edited builds on input).
  */
 export function generateDiffFileName(
   inputFile: string,
   editedFile: string,
   suffix: string,
 ): string {
+  const inputFileName = path.basename(inputFile);
   const editedFileName = path.basename(editedFile);
-  const inputRoundMatch = extractLastRoundModelMatch(path.basename(inputFile));
+  const inputBaseName = path.parse(inputFileName).name;
+  const editedBaseName = path.parse(editedFileName).name;
+
+  const inputRoundMatch = extractLastRoundModelMatch(inputFileName);
   const editedRoundMatch = extractLastRoundModelMatch(editedFileName);
 
-  // Only use round-based naming if both files have rounds AND rounds differ.
-  // Same-round comparisons (e.g., original vs proposed temp files) fall back to suffix.
+  // Only use round-based naming if:
+  // 1. Both files have rounds AND rounds differ
+  // 2. The edited file does NOT start with the input file's base name
+  //    (if it does, the input's round is part of the base, not a round to diff against)
+  // This distinguishes between-round diffs (r0→r1 in same chain) from
+  // round-vs-original diffs (original_r0 → original_r0_agent_r1).
   if (
     inputRoundMatch &&
     editedRoundMatch &&
-    inputRoundMatch[1] !== editedRoundMatch[1]
+    inputRoundMatch[1] !== editedRoundMatch[1] &&
+    !editedBaseName.startsWith(inputBaseName)
   ) {
     return generateRoundBasedFileName(
       editedFileName,
@@ -63,5 +73,5 @@ export function generateDiffFileName(
     );
   }
 
-  return `${path.parse(editedFileName).name}${suffix}.tex`;
+  return `${editedBaseName}${suffix}.tex`;
 }


### PR DESCRIPTION
## Summary
Improved the logic in `generateDiffFileName` to correctly distinguish between two types of diff scenarios: between-round diffs (comparing consecutive rounds in the same operation chain) and round-vs-original diffs (comparing an original file against an edited version that builds on it).

## Changes
- **Enhanced round-based naming condition**: Added a check to ensure the edited file's base name doesn't start with the input file's base name. This prevents incorrectly using round-based naming when the input's round number is actually part of the base filename (e.g., `original_r0` → `original_r0_agent_r1`).
- **Improved variable extraction**: Extracted `inputFileName` and base names (`inputBaseName`, `editedBaseName`) at the start for clarity and to avoid redundant `path.parse()` calls.
- **Updated documentation**: Clarified the comment to explain the distinction between between-round diffs (same operation chain) and round-vs-original diffs (edited builds on input).
- **Code cleanup**: Simplified the final return statement to use the pre-extracted `editedBaseName` variable.

## Implementation Details
The key insight is that when an edited file's base name starts with the input file's base name, it indicates the input file is a dependency/base for the edited file, not a previous round in the same chain. In such cases, suffix-based naming should be used instead of round-based naming to avoid ambiguity.

Example scenarios:
- **Between-round diff** (use round-based): `file_r0.tex` → `file_r1.tex` → generates `file_r0_r1.tex`
- **Round-vs-original diff** (use suffix): `original_r0.tex` → `original_r0_agent_r1.tex` → generates `original_r0_agent_r1_diff.tex`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refines diff filename logic to correctly separate between-round vs round-vs-original comparisons.
> 
> - Tightens condition to use round-based naming only when both files have differing rounds and `editedBaseName` does not start with `inputBaseName`
> - Extracts `inputFileName`, `inputBaseName`, and `editedBaseName` once; simplifies final return path
> - Updates comments to document the distinction and intent
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8b01b7a63c7d8682de134ce79066ec6a7d88a4b1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->