### PR TITLE
feat: sync agent/model dropdowns between progress view and main webview

### DIFF
--- a/src/common/modules/dropdownUtils.js
+++ b/src/common/modules/dropdownUtils.js
@@ -1,0 +1,345 @@
+/**
+ * Shared dropdown utilities for agent and model options.
+ * Used by main webview and progress view for consistent dropdown rendering.
+ */
+
+import {
+  AGENT_DECORATORS,
+  getModelProviderDecorator,
+} from './iconConstants.js';
+import {
+  isSelectLikeElement,
+  getSelectOptionElements,
+  getSelectedOptionElement,
+} from './domUtils.js';
+
+// =============================================================================
+// PLACEHOLDER OPTIONS
+// =============================================================================
+
+/** Placeholder option for agent dropdowns */
+export const AGENT_PLACEHOLDER = '<vscode-option value="">Select agent</vscode-option>';
+
+/** Placeholder option for model dropdowns */
+export const MODEL_PLACEHOLDER = '<vscode-option value="">Select model</vscode-option>';
+
+/**
+ * Prepend placeholder to options HTML.
+ * @param {string} optionsHtml - The options HTML
+ * @param {string} placeholder - The placeholder HTML
+ * @returns {string} Combined HTML
+ */
+export function withPlaceholder(optionsHtml, placeholder) {
+  return placeholder + '\n' + optionsHtml;
+}
+
+// =============================================================================
+// AGENT OPTION DECORATION
+// =============================================================================
+
+/**
+ * Read agent option metadata from data attributes.
+ * @param {HTMLElement} opt - The option element
+ * @returns {{ label: string, isMultiple: boolean, isToolUse: boolean, isRemote: boolean, isCustom: boolean, description: string }}
+ */
+export function readAgentOptionMetadata(opt) {
+  const data = opt.dataset;
+  // Fallback chain: dataset.label > textContent > value attribute
+  const label =
+    data.label || opt.textContent?.trim() || opt.getAttribute('value') || '';
+  // Cache resolved label for subsequent reads
+  if (label && !data.label) {
+    opt.dataset.label = label;
+  }
+  return {
+    label,
+    isMultiple: data.multiple === 'true',
+    isToolUse: data.toolUse === 'true',
+    isRemote: data.remote === 'true',
+    isCustom: data.custom === 'true',
+    description: data.description || '',
+  };
+}
+
+/**
+ * Decorate a single agent option element with icons and tooltips.
+ * @param {HTMLElement} opt - The option element
+ */
+export function decorateAgentOption(opt) {
+  const { label, isMultiple, isToolUse, isRemote, isCustom, description } =
+    readAgentOptionMetadata(opt);
+
+  const hints = [];
+  let displayLabel = label;
+
+  // Add cloud icon for remote agents (visible indicator, at end)
+  if (isRemote) {
+    hints.push(AGENT_DECORATORS.properties.remote.hint);
+  }
+
+  // Add custom hint to tooltip (no unicode icon - too confusing)
+  if (isCustom) {
+    const { hint } = AGENT_DECORATORS.properties.custom;
+    hints.push(hint);
+  }
+
+  // Add description (primary info about the agent)
+  if (description) {
+    hints.push(description);
+  }
+
+  // Add multiple outputs hint
+  if (isMultiple) {
+    hints.push(AGENT_DECORATORS.properties.multipleOutputs.hint);
+    opt.style.opacity = '0.9';
+  } else {
+    opt.style.opacity = '';
+  }
+
+  // Add tool-use hint
+  if (isToolUse) {
+    hints.push('Can execute tools and code');
+  }
+
+  // Set text content first, then append icon spans with fixed width
+  opt.textContent = displayLabel;
+
+  // Append icons as spans with consistent sizing (order: multiple, remote)
+  if (isMultiple) {
+    const span = document.createElement('span');
+    span.className = 'agent-icon';
+    span.textContent = ` ${AGENT_DECORATORS.properties.multipleOutputs.unicode}`;
+    opt.appendChild(span);
+  }
+  if (isRemote) {
+    const span = document.createElement('span');
+    span.className = 'agent-icon';
+    span.textContent = ` ${AGENT_DECORATORS.properties.remote.unicode}`;
+    opt.appendChild(span);
+  }
+
+  if (hints.length > 0) {
+    opt.title = hints.join('\n');
+    opt.setAttribute('aria-label', `${label} (${hints.join(', ')})`);
+    opt.setAttribute('aria-description', hints.join(' '));
+  } else {
+    // Clear stale attributes when no hints
+    opt.removeAttribute('title');
+    opt.setAttribute('aria-label', label);
+    opt.removeAttribute('aria-description');
+  }
+}
+
+/**
+ * Decorate all agent options in a select element.
+ * @param {HTMLElement} selectElement - The select element
+ */
+export function decorateAgentOptions(selectElement) {
+  if (!isSelectLikeElement(selectElement)) return;
+  getSelectOptionElements(selectElement).forEach((opt) => {
+    decorateAgentOption(opt);
+  });
+}
+
+/**
+ * Update the agent select element's tooltip to show the selected agent's details.
+ * @param {HTMLElement} selectElement - The agent select element
+ */
+export function updateAgentSelectTooltip(selectElement) {
+  if (!isSelectLikeElement(selectElement)) return;
+
+  const selectedOption = getSelectedOptionElement(selectElement);
+  if (selectedOption && selectedOption.title) {
+    selectElement.title = selectedOption.title;
+  } else if (selectedOption) {
+    const label =
+      selectedOption.dataset?.label || selectedOption.textContent || '';
+    selectElement.title = label;
+  } else {
+    selectElement.title = '';
+  }
+}
+
+// =============================================================================
+// MODEL OPTION DECORATION
+// =============================================================================
+
+/**
+ * Read model option metadata from data attributes.
+ * @param {HTMLElement} opt - The option element
+ * @returns {{ provider: string, context: string, cost: string, requiresKey: boolean, modelName: string }}
+ */
+export function readModelOptionMetadata(opt) {
+  const data = opt.dataset;
+  return {
+    provider: data.provider || '',
+    context: data.context || '',
+    cost: data.cost || '',
+    requiresKey: data.requiresKey === 'true',
+    modelName: opt.textContent?.trim() || opt.getAttribute('value') || '',
+  };
+}
+
+/**
+ * Decorate a single model option element with provider icon and tooltips.
+ * @param {HTMLElement} opt - The option element
+ */
+export function decorateModelOption(opt) {
+  const { provider, context, cost, requiresKey, modelName } =
+    readModelOptionMetadata(opt);
+
+  // Get provider decorator for the icon
+  const decorator = provider
+    ? getModelProviderDecorator(provider)
+    : { unicode: '', label: '', hint: '' };
+
+  // Build display with provider icon
+  const display = decorator.unicode
+    ? `${decorator.unicode} ${modelName}`
+    : modelName;
+
+  // Set text content first, then append styled indicator if needed
+  opt.textContent = display;
+
+  // Add requires-key indicator as styled span (matches original main webview)
+  if (requiresKey) {
+    const span = document.createElement('span');
+    span.className = 'api-key-missing';
+    span.textContent = ' ✗';
+    opt.appendChild(span);
+  }
+
+  // Build tooltip with provider info
+  const hints = [];
+  if (decorator.label) hints.push(decorator.label);
+  if (context) hints.push(`Context: ${context}`);
+  if (cost) hints.push(`Cost: ${cost}`);
+
+  if (hints.length > 0) {
+    // Use pipe separator to match main webview style
+    opt.title = hints.join(' | ');
+    // Add aria-label for accessibility
+    opt.setAttribute('aria-label', `${modelName} (${hints.join(', ')})`);
+  }
+}
+
+/**
+ * Decorate all model options in a select element.
+ * @param {HTMLElement} selectElement - The select element
+ */
+export function decorateModelOptions(selectElement) {
+  if (!isSelectLikeElement(selectElement)) return;
+  getSelectOptionElements(selectElement).forEach((opt) => {
+    decorateModelOption(opt);
+  });
+}
+
+// =============================================================================
+// OPTION HTML APPLICATION
+// =============================================================================
+
+/**
+ * Mark an option as selected in HTML string before DOM insertion.
+ * Prevents vscode-single-select from defaulting to first option.
+ * @param {string} optionsHtml - The options HTML string
+ * @param {string} value - The value to mark as selected
+ * @returns {string} HTML with selected attribute added
+ */
+export function markOptionAsSelected(optionsHtml, value) {
+  if (!value || !optionsHtml) return optionsHtml || '';
+
+  const searchStr = `value="${value}"`;
+  const index = optionsHtml.indexOf(searchStr);
+
+  // Value not found - return original HTML unchanged
+  if (index === -1) return optionsHtml;
+
+  // Find the end of the opening tag
+  const tagEnd = optionsHtml.indexOf('>', index + searchStr.length);
+  if (tagEnd === -1) return optionsHtml;
+
+  // Insert selected attribute before the closing >
+  return optionsHtml.slice(0, tagEnd) + ' selected' + optionsHtml.slice(tagEnd);
+}
+
+/**
+ * Restore selection after innerHTML replacement.
+ * Handles cases where the value might not exist in options.
+ * @param {HTMLElement} selectElement - The select element
+ * @param {string} previousValue - The previous selected value
+ */
+export function restoreSelection(selectElement, previousValue) {
+  if (!previousValue || !isSelectLikeElement(selectElement)) return;
+
+  const options = getSelectOptionElements(selectElement);
+  const hasValue = options.some(
+    (opt) => opt.getAttribute('value') === previousValue,
+  );
+
+  if (hasValue) {
+    selectElement.value = previousValue;
+  }
+}
+
+/**
+ * Set innerHTML with selection preservation.
+ * Workaround for vscode-single-select's slotchange behavior that resets selection.
+ * Steps: 1) Mark option in HTML, 2) Set innerHTML, 3) Restore via callback.
+ *
+ * @param {HTMLElement} selectElement - The select element
+ * @param {string} optionsHtml - The options HTML
+ * @param {function} [restoreFn] - Custom restore function(selectElement, previousValue). Defaults to restoreSelection.
+ * @returns {string} The previous value (for chaining with decoration)
+ */
+export function setOptionsHtml(selectElement, optionsHtml, restoreFn = restoreSelection) {
+  if (!isSelectLikeElement(selectElement)) return '';
+
+  const previousValue = selectElement.value;
+  const htmlWithSelected = markOptionAsSelected(optionsHtml, previousValue);
+  selectElement.innerHTML = htmlWithSelected;
+  restoreFn(selectElement, previousValue);
+  return previousValue;
+}
+
+/**
+ * Apply agent options HTML to a select element with decoration.
+ * @param {HTMLElement} selectElement - The select element
+ * @param {string} optionsHtml - The options HTML
+ * @param {Object} [options] - Options
+ * @param {string} [options.preserveValue] - Value to preserve selection for
+ */
+export function applyAgentOptions(selectElement, optionsHtml, options = {}) {
+  if (!isSelectLikeElement(selectElement)) return;
+
+  if (options.preserveValue !== undefined) {
+    // Use explicit value - manually do the steps
+    const htmlWithSelected = markOptionAsSelected(optionsHtml, options.preserveValue);
+    selectElement.innerHTML = htmlWithSelected;
+    restoreSelection(selectElement, options.preserveValue);
+  } else {
+    // Use current value via setOptionsHtml
+    setOptionsHtml(selectElement, optionsHtml);
+  }
+  decorateAgentOptions(selectElement);
+  updateAgentSelectTooltip(selectElement);
+}
+
+/**
+ * Apply model options HTML to a select element with decoration.
+ * @param {HTMLElement} selectElement - The select element
+ * @param {string} optionsHtml - The options HTML
+ * @param {Object} [options] - Options
+ * @param {string} [options.preserveValue] - Value to preserve selection for
+ */
+export function applyModelOptions(selectElement, optionsHtml, options = {}) {
+  if (!isSelectLikeElement(selectElement)) return;
+
+  if (options.preserveValue !== undefined) {
+    const htmlWithSelected = markOptionAsSelected(optionsHtml, options.preserveValue);
+    selectElement.innerHTML = htmlWithSelected;
+    restoreSelection(selectElement, options.preserveValue);
+  } else {
+    setOptionsHtml(selectElement, optionsHtml);
+  }
+  decorateModelOptions(selectElement);
+}

--- a/src/common/styles/common.css
+++ b/src/common/styles/common.css
@@ -277,3 +277,10 @@ vscode-toolbar-button {
 [hidden] {
   display: none !important;
 }
+
+/* Agent icon indicators (remote, multiple outputs) - fixed width for consistent sizing */
+.agent-icon {
+  display: inline-block;
+  width: 1.2em;
+  text-align: center;
+}

--- a/src/common/webview/BaseViewContentProvider.ts
+++ b/src/common/webview/BaseViewContentProvider.ts
@@ -177,6 +177,7 @@ export abstract class BaseViewContentProvider {
       { key: 'pathUtilsUri', path: 'modules/pathUtils.js' },
       { key: 'debounceUri', path: 'modules/debounce.js' },
       { key: 'clipboardUtilsUri', path: 'modules/clipboardUtils.js' },
+      { key: 'dropdownUtilsUri', path: 'modules/dropdownUtils.js' },
       { key: 'streamStatusUri', path: 'constants/streamStatus.js' },
       { key: 'todoStatusUri', path: 'constants/todoStatus.js' },
       // Filename kept as agentTypes.js for import map compatibility in webviews

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -6,12 +6,12 @@ import * as vscode from 'vscode';
 
 // Local imports
 import {
-  getVisibleWorkflowAgents,
-  getVisibleToolUseAgents,
   getAgent,
   createKey,
   ensureAgentsLoaded,
+  computeAgentOptions,
 } from '@agent/index/agentRegistry';
+import { computeModelOptions } from '@model/computeModelOptions';
 import { AgentCategory } from '@agent/core/AgentDataclass';
 import { AgentConfigSchema, type AgentConfig } from '@agent/core/AgentConfig';
 import type { OutputFileInfo } from '@agent/output/types';
@@ -1024,30 +1024,19 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
 
   /**
    * Handle request for followup options (agents, models).
-   * Returns separate workflow and tool-use agent lists to match main webview.
+   * Returns pre-built HTML options matching main webview format.
    */
   private async handleGetFollowupOptions(_message: unknown): Promise<void> {
     const view = this.getActiveView();
     if (!view) return;
 
     try {
-      // Ensure agent cache is initialized (no re-scan if already loaded)
-      await ensureAgentsLoaded();
+      // Compute agent and model options in parallel (same as main webview)
+      const [agentOptions, modelOptionsHtml] = await Promise.all([
+        computeAgentOptions(),
+        computeModelOptions(),
+      ]);
 
-      // Get visible agents matching main webview (filtered, deduplicated)
-      const workflowAgents = getVisibleWorkflowAgents();
-      const toolUseAgents = getVisibleToolUseAgents();
-
-      // Format as source:name for consistent handling with main view
-      const workflowAgentKeys = workflowAgents.map((a) =>
-        createKey(a.source, a.name),
-      );
-      const toolUseAgentKeys = toolUseAgents.map((a) =>
-        createKey(a.source, a.name),
-      );
-
-      // Get models from config
-      const models = getConfig<string[]>('texra.models', []);
       const defaultMergeModel = getConfig<string>(
         'texra.merge.defaultModel',
         'gemini3f',
@@ -1055,9 +1044,9 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
 
       view.webview.postMessage({
         command: PROGRESS_VIEW_COMMANDS.SET_FOLLOWUP_OPTIONS,
-        workflowAgents: workflowAgentKeys,
-        toolUseAgents: toolUseAgentKeys,
-        models,
+        workflowAgentsHtml: agentOptions.workflow,
+        toolUseAgentsHtml: agentOptions.toolUse,
+        modelOptionsHtml,
         defaultMergeModel,
       });
     } catch (error) {

--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -74,6 +74,7 @@
           "@common/iconConstants.js": "${iconConstantsUri}",
           "@common/BaseWebviewMessageHandler.js": "${baseWebviewMessageHandlerUri}",
           "@common/clipboardUtils.js": "${clipboardUtilsUri}",
+          "@common/dropdownUtils.js": "${dropdownUtilsUri}",
           "diff-match-patch": "https://esm.sh/diff-match-patch@1.0.5",
           "he": "https://esm.sh/he@1.2.0",
           "highlight.js": "https://esm.sh/highlight.js@11.11.1",

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -1175,16 +1175,20 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
 
   /**
    * Handle SET_FOLLOWUP_OPTIONS command from extension host.
-   * Updates the followup section dropdowns with available agents and models.
-   * @param {{ workflowAgents: string[], toolUseAgents: string[], models: string[], defaultMergeModel: string }} message
+   * Updates the followup section dropdowns with pre-built HTML options.
+   * @param {{ workflowAgentsHtml: string, toolUseAgentsHtml: string, modelOptionsHtml: string, defaultMergeModel: string }} message
    */
   handleSetFollowupOptions(message) {
-    const { workflowAgents, toolUseAgents, models, defaultMergeModel } =
-      message;
+    const {
+      workflowAgentsHtml,
+      toolUseAgentsHtml,
+      modelOptionsHtml,
+      defaultMergeModel,
+    } = message;
     dom.followupSection?.setOptions?.({
-      workflowAgents,
-      toolUseAgents,
-      models,
+      workflowAgentsHtml,
+      toolUseAgentsHtml,
+      modelOptionsHtml,
       defaultMergeModel,
     });
   }

--- a/src/progressView/modules/uiManagers/FollowupSectionManager.js
+++ b/src/progressView/modules/uiManagers/FollowupSectionManager.js
@@ -9,6 +9,13 @@ import {
   setRadioGroupValue,
   setVisibilityState,
 } from '@common/domUtils.js';
+import {
+  applyAgentOptions,
+  applyModelOptions,
+  withPlaceholder,
+  AGENT_PLACEHOLDER,
+  MODEL_PLACEHOLDER,
+} from '@common/dropdownUtils.js';
 
 /**
  * Manages the followup section for workflow task continuation.
@@ -20,8 +27,10 @@ export class FollowupSectionManager {
     // Mode is stored in progressViewState.streamFollowupMode (single source of truth)
     this._currentStreamData = null;
     this._listeners = [];
-    this._workflowAgents = [];
-    this._toolUseAgents = [];
+    // Store pre-built HTML for agent options (same format as main webview)
+    this._workflowAgentsHtml = '';
+    this._toolUseAgentsHtml = '';
+    this._modelOptionsHtml = '';
   }
 
   /**
@@ -168,87 +177,59 @@ export class FollowupSectionManager {
 
   /**
    * Set the available agent and model options.
-   * Called when receiving options from the extension.
-   * @param {Object} options - { workflowAgents: string[], toolUseAgents: string[], models: string[], defaultMergeModel: string }
+   * Called when receiving pre-built HTML options from the extension.
+   * @param {Object} options - { workflowAgentsHtml: string, toolUseAgentsHtml: string, modelOptionsHtml: string, defaultMergeModel: string }
    */
   setOptions(options) {
     const {
-      workflowAgents = [],
-      toolUseAgents = [],
-      models = [],
+      workflowAgentsHtml = '',
+      toolUseAgentsHtml = '',
+      modelOptionsHtml = '',
       defaultMergeModel,
     } = options ?? {};
 
-    // Store both agent lists for mode switching
-    this._workflowAgents = workflowAgents;
-    this._toolUseAgents = toolUseAgents;
+    // Store pre-built HTML for mode switching (same format as main webview)
+    this._workflowAgentsHtml = workflowAgentsHtml;
+    this._toolUseAgentsHtml = toolUseAgentsHtml;
+    this._modelOptionsHtml = modelOptionsHtml;
+    this._defaultMergeModel = defaultMergeModel;
 
     // Update agent dropdown based on current mode
     this._updateAgentDropdown();
 
-    // Update model dropdown
+    // Update model dropdown with pre-built HTML
     const modelSelect = safeGetElementById(ELEMENT_IDS.FOLLOWUP_MODEL);
-    if (modelSelect) {
-      const currentValue = modelSelect.value;
-      // Use current stream's model as default, or defaultMergeModel for merge mode
-      // Fall back to first available model if no default is set
+    if (modelSelect && modelOptionsHtml) {
+      // Determine preferred model based on mode
       const preferredModel =
         this._getMode() === 'merge'
-          ? defaultMergeModel || models[0]
-          : this._currentStreamData?.model || currentValue || models[0];
-      const hasValidSelection =
-        preferredModel && models.includes(preferredModel);
+          ? defaultMergeModel
+          : this._currentStreamData?.model || modelSelect.value;
 
-      // Build options: none option first, then models
-      const noneOption = `<vscode-option value=""${!hasValidSelection ? ' selected' : ''}>Select model</vscode-option>`;
-      const modelOptions = models
-        .map(
-          (model) =>
-            `<vscode-option value="${model}"${model === preferredModel ? ' selected' : ''}>${model}</vscode-option>`,
-        )
-        .join('');
-
-      modelSelect.innerHTML = noneOption + modelOptions;
+      applyModelOptions(modelSelect, withPlaceholder(modelOptionsHtml, MODEL_PLACEHOLDER), {
+        preserveValue: preferredModel,
+      });
     }
-
-    this._defaultMergeModel = defaultMergeModel;
   }
 
   /**
    * Update the agent dropdown based on the current mode.
    * Chat mode shows tool-use agents; workflow mode shows workflow agents.
+   * Uses pre-built HTML with proper decoration (same as main webview).
    * @private
    */
   _updateAgentDropdown() {
     const agentSelect = safeGetElementById(ELEMENT_IDS.FOLLOWUP_AGENT);
     if (!agentSelect) return;
 
-    // Select the appropriate agent list based on mode
-    const agents =
-      this._getMode() === 'chat' ? this._toolUseAgents : this._workflowAgents;
+    // Select the appropriate pre-built HTML based on mode
+    const agentsHtml =
+      this._getMode() === 'chat'
+        ? this._toolUseAgentsHtml
+        : this._workflowAgentsHtml;
 
-    // Clear dropdown if no agents available for this mode
-    if (!agents || agents.length === 0) {
-      agentSelect.innerHTML =
-        '<vscode-option value="">Select agent</vscode-option>';
-      return;
-    }
-
-    // Preserve current selection only if it exists in the new list
-    const currentValue = agentSelect.value;
-    const hasValidSelection = currentValue && agents.includes(currentValue);
-
-    // Build options: none option first, then agents
-    const noneOption = `<vscode-option value=""${!hasValidSelection ? ' selected' : ''}>Select agent</vscode-option>`;
-    const agentOptions = agents
-      .map((agent) => {
-        const displayName = agent.includes(':') ? agent.split(':')[1] : agent;
-        const isSelected = agent === currentValue;
-        return `<vscode-option value="${agent}"${isSelected ? ' selected' : ''}>${displayName}</vscode-option>`;
-      })
-      .join('');
-
-    agentSelect.innerHTML = noneOption + agentOptions;
+    // Apply options with decoration (preserves current selection if valid)
+    applyAgentOptions(agentSelect, withPlaceholder(agentsHtml, AGENT_PLACEHOLDER));
   }
 
   /**

--- a/src/webview/index.html
+++ b/src/webview/index.html
@@ -47,6 +47,7 @@
           "@common/stringUtils.js": "${stringUtilsUri}",
           "@common/debounce.js": "${debounceUri}",
           "@common/iconConstants.js": "${iconConstantsUri}",
+          "@common/dropdownUtils.js": "${dropdownUtilsUri}",
           "@common/BaseWebviewMessageHandler.js": "${baseWebviewMessageHandlerUri}",
           "@common/constants/agentTypes.js": "${agentCategoriesUri}",
           "sortablejs": "https://unpkg.com/sortablejs@1.15.6/modular/sortable.esm.js",

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -41,13 +41,15 @@ import {
   waitForElement,
   isSelectLikeElement,
   getSelectOptionElements,
-  getSelectedOptionElement,
 } from '@common/domUtils.js';
 import { capitalize, uncapitalize } from '@common/stringUtils.js';
 import {
-  AGENT_DECORATORS,
-  getModelProviderDecorator,
-} from '@common/iconConstants.js';
+  decorateAgentOption,
+  decorateAgentOptions,
+  decorateModelOptions,
+  updateAgentSelectTooltip,
+  setOptionsHtml,
+} from '@common/dropdownUtils.js';
 
 // Import standardized commands
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands.js';
@@ -352,12 +354,12 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
             (opt) => opt.value === targetValue,
           );
           if (option && !option.dataset.decorated) {
-            this._decorateAgentOption(option);
+            decorateAgentOption(option);
             option.dataset.decorated = 'true';
           }
 
           // Update the select's tooltip
-          this._updateAgentSelectTooltip(selectElement);
+          updateAgentSelectTooltip(selectElement);
         } finally {
           mainViewState.unblockSave();
         }
@@ -385,186 +387,30 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
   }
 
   _applyModelOptions(selectElement, optionsHtml) {
-    if (!isSelectLikeElement(selectElement)) {
-      return;
-    }
+    if (!isSelectLikeElement(selectElement)) return;
     // Caller must wrap in blockSave()/unblockSave() - vscode-single-select
     // fires change events during innerHTML replacement which would trigger save()
-    const previous = selectElement.value;
 
-    // Two-phase selection restoration:
-    // 1. _markOptionAsSelected: Add 'selected' attribute to HTML BEFORE innerHTML assignment.
-    //    This prevents vscode-single-select's slotchange from defaulting to first option.
-    // 2. _restoreModelSelection: Handles fallback cases after innerHTML is set:
-    //    - Value not found in options (preserves user preference in state)
-    //    - Sets selectElement.value for programmatic access
-    //    Both are needed because slotchange fires asynchronously after innerHTML.
-    const htmlWithSelected = this._markOptionAsSelected(optionsHtml, previous);
-    selectElement.innerHTML = htmlWithSelected;
-    this._restoreModelSelection(selectElement, previous);
-
-    getSelectOptionElements(selectElement).forEach((opt) => {
-      this._decorateModelOption(opt);
-    });
+    // setOptionsHtml handles vscode-single-select's slotchange workaround:
+    // 1. Captures previous value
+    // 2. Marks option as selected in HTML before innerHTML assignment
+    // 3. Sets innerHTML
+    // 4. Calls restore function with custom fallback logic
+    setOptionsHtml(selectElement, optionsHtml, this._restoreModelSelection.bind(this));
+    decorateModelOptions(selectElement);
     updateModelApiKeyBanner(selectElement);
   }
 
-  _decorateModelOption(opt) {
-    const { provider, context, cost, requiresKey } = opt.dataset;
-    const modelName =
-      opt.textContent?.trim() ?? opt.getAttribute('value') ?? '';
-
-    // Get provider decorator for the icon
-    const decorator = getModelProviderDecorator(provider);
-
-    // Build tooltip with provider info
-    const hints = [];
-    hints.push(`${decorator.label}`);
-    if (context) hints.push(`Context: ${context}`);
-    if (cost) hints.push(`Cost: ${cost}`);
-
-    // Set content with provider icon, adding red ✗ via DOM if key is missing
-    opt.textContent = `${decorator.unicode} ${modelName}`;
-    if (requiresKey === 'true') {
-      const span = document.createElement('span');
-      span.className = 'api-key-missing';
-      span.textContent = ' ✗';
-      opt.appendChild(span);
-    }
-
-    if (hints.length > 0) {
-      opt.title = hints.join(' | ');
-      opt.setAttribute('aria-label', `${modelName} (${hints.join(', ')})`);
-    }
-  }
-
   _applyAgentOptions(selectElement, optionsHtml) {
-    if (!isSelectLikeElement(selectElement)) {
-      return;
-    }
+    if (!isSelectLikeElement(selectElement)) return;
     // Caller must wrap in blockSave()/unblockSave() - vscode-single-select
     // fires change events during innerHTML replacement which would trigger save()
-    const previous = selectElement.value;
 
-    // Two-phase selection restoration (see _applyModelOptions for details):
-    // 1. _markOptionAsSelected: Prevents slotchange from defaulting to first option
-    // 2. _restoreAgentSelection: Handles fallbacks (value migration, placeholder creation)
-    const htmlWithSelected = this._markOptionAsSelected(
-      optionsHtml ?? '',
-      previous,
-    );
-    selectElement.innerHTML = htmlWithSelected;
-    this._restoreAgentSelection(selectElement, previous);
-
-    getSelectOptionElements(selectElement).forEach((opt) => {
-      this._decorateAgentOption(opt);
-    });
-    // Update the select's tooltip to show selected agent info
-    this._updateAgentSelectTooltip(selectElement);
-  }
-
-  /**
-   * Update the agent select element's tooltip to show the selected agent's details.
-   * This provides immediate feedback about the currently selected agent.
-   * @param {HTMLElement} selectElement - The agent select element
-   */
-  _updateAgentSelectTooltip(selectElement) {
-    if (!isSelectLikeElement(selectElement)) {
-      return;
-    }
-
-    const selectedOption = getSelectedOptionElement(selectElement);
-    if (selectedOption && selectedOption.title) {
-      // Use the selected option's tooltip as the select's tooltip
-      selectElement.title = selectedOption.title;
-    } else if (selectedOption) {
-      // Fallback: show the agent name
-      const label =
-        selectedOption.dataset?.label || selectedOption.textContent || '';
-      selectElement.title = label;
-    } else {
-      selectElement.title = '';
-    }
-  }
-
-  _decorateAgentOption(opt) {
-    const { label, isMultiple, isToolUse, isRemote, isCustom, description } =
-      this._readAgentOptionMetadata(opt);
-
-    const hints = [];
-    let displayLabel = label;
-
-    // Add cloud icon for remote agents (visible indicator, at end)
-    if (isRemote) {
-      hints.push(AGENT_DECORATORS.properties.remote.hint);
-    }
-
-    // Add custom hint to tooltip (no unicode icon - too confusing)
-    if (isCustom) {
-      const { hint } = AGENT_DECORATORS.properties.custom;
-      hints.push(hint);
-    }
-
-    // Add description (primary info about the agent)
-    if (description) {
-      hints.push(description);
-    }
-
-    // Add multiple outputs indicator (visible indicator, at end)
-    if (isMultiple) {
-      const { unicode, hint } = AGENT_DECORATORS.properties.multipleOutputs;
-      displayLabel = `${displayLabel} ${unicode}`;
-      hints.push(hint);
-      opt.style.opacity = '0.9';
-    } else {
-      opt.style.opacity = '';
-    }
-
-    // Add cloud icon for remote agents (visible indicator, at end after multiple)
-    if (isRemote) {
-      const { unicode } = AGENT_DECORATORS.properties.remote;
-      displayLabel = `${displayLabel} ${unicode}`;
-    }
-
-    // Add tool-use hint
-    if (isToolUse) {
-      hints.push('Can execute tools and code');
-    }
-
-    // Set text content (vscode-option doesn't support HTML)
-    opt.textContent = displayLabel;
-
-    if (hints.length > 0) {
-      opt.title = hints.join('\n');
-      opt.setAttribute('aria-label', `${label} (${hints.join(', ')})`);
-      opt.setAttribute('aria-description', hints.join(' '));
-    } else {
-      opt.removeAttribute('title');
-      opt.setAttribute('aria-label', label);
-      opt.removeAttribute('aria-description');
-    }
-  }
-
-  _readAgentOptionMetadata(opt) {
-    // Extract label with fallback chain: dataset.label > textContent > value attribute
-    const label =
-      opt.dataset.label ||
-      opt.textContent?.trim() ||
-      opt.getAttribute('value') ||
-      '';
-    if (label && !opt.dataset.label) {
-      opt.dataset.label = label;
-    }
-
-    const { dataset } = opt;
-    return {
-      label,
-      isMultiple: dataset.multiple === 'true',
-      isToolUse: dataset.toolUse === 'true',
-      isRemote: dataset.remote === 'true',
-      isCustom: dataset.custom === 'true',
-      description: dataset.description ?? '',
-    };
+    // setOptionsHtml handles vscode-single-select's slotchange workaround
+    // (see _applyModelOptions). Uses custom restore for value migration and placeholder creation.
+    setOptionsHtml(selectElement, optionsHtml ?? '', this._restoreAgentSelection.bind(this));
+    decorateAgentOptions(selectElement);
+    updateAgentSelectTooltip(selectElement);
   }
 
   /**
@@ -824,52 +670,6 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
     // the model becomes available again (e.g., API key re-added).
   }
 
-  /**
-   * Mark an option as selected in HTML string by adding the 'selected' attribute.
-   *
-   * This is necessary to work around a timing issue in vscode-single-select:
-   * When innerHTML is replaced, slotchange fires asynchronously. The component's
-   * _setStateFromSlottedElements() reads el.selected from each option, and if none
-   * are selected, it defaults to index 0. By the time we set selectElement.value,
-   * the slotchange handler has already run and reset the selection.
-   *
-   * By adding 'selected' attribute to the correct option in HTML before setting
-   * innerHTML, slotchange will read selected=true and preserve the selection.
-   *
-   * Uses DOMParser for safe, encoding-aware HTML manipulation instead of regex.
-   *
-   * @param {string} html - The options HTML string
-   * @param {string} value - The value to mark as selected
-   * @returns {string} The HTML with 'selected' attribute added to matching option
-   */
-  _markOptionAsSelected(html, value) {
-    if (!value || !html) {
-      return html || '';
-    }
-
-    // Use DOMParser for safe, encoding-aware manipulation
-    const parser = new DOMParser();
-    const doc = parser.parseFromString(`<div>${html}</div>`, 'text/html');
-    const options = doc.querySelectorAll('vscode-option');
-
-    let found = false;
-    options.forEach((opt) => {
-      // getAttribute returns decoded value, so we compare directly with value
-      if (opt.getAttribute('value') === value) {
-        opt.setAttribute('selected', '');
-        found = true;
-      }
-    });
-
-    if (!found) {
-      // Value not found in options - return original HTML
-      return html;
-    }
-
-    // Return the modified HTML (with null-safety fallback)
-    return doc.querySelector('div')?.innerHTML ?? html;
-  }
-
   _getActiveAgentSelection() {
     const sessionType = this._getSessionTypeValue();
     const select = this._getAgentElementByType(sessionType);
@@ -903,11 +703,11 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
     AGENT_SELECT_LIST.forEach((selectId) => {
       const selectElement = document.getElementById(selectId);
       if (selectElement) {
-        const handler = () => this._updateAgentSelectTooltip(selectElement);
+        const handler = () => updateAgentSelectTooltip(selectElement);
         selectElement.addEventListener('change', handler);
         this._tooltipListeners.push({ element: selectElement, handler });
         // Set initial tooltip
-        this._updateAgentSelectTooltip(selectElement);
+        updateAgentSelectTooltip(selectElement);
       }
     });
   }


### PR DESCRIPTION
Create shared dropdown utilities for consistent rendering:
- Add dropdownUtils.js with agent/model option decoration functions
- Progress view now uses same pre-built HTML as main webview
- Backend sends computed options HTML instead of raw key arrays
- Both views now show the same icons, tooltips, and metadata

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Standardizes agent/model dropdown rendering and behavior across views.
> 
> - **Shared utils:** Add `common/modules/dropdownUtils.js` for option decoration, tooltip updates, placeholders, and selection-preserving HTML updates (`setOptionsHtml`, `applyAgentOptions`, `applyModelOptions`).
> - **Progress view backend:** `ProgressViewMessageHandler` now sends pre-built options (`workflowAgentsHtml`, `toolUseAgentsHtml`, `modelOptionsHtml`) using `computeAgentOptions`/`computeModelOptions` and includes `defaultMergeModel`.
> - **Progress view frontend:** `FollowupSectionManager` consumes pre-built HTML, applies placeholders, preserves selection, and updates tooltips; `messageHandlers.js` updated to pass new fields.
> - **Main webview:** Replace local decoration/restore logic with imports from `@common/dropdownUtils.js`.
> - **Plumbing:** Import maps and URIs updated to include `dropdownUtils.js`; add `.agent-icon` CSS for fixed-width inline icons.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5cbb3a78c646f34f7823c9435a573af74b7e4c4b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->