### PR TITLE
fix: limit gpt5 xhigh reasoning for Max tier

### DIFF
--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -3,6 +3,7 @@ import { FinishReason } from '@google/genai';
 
 // Local imports - agent components
 import { SupabaseClient } from '@auth/SupabaseClient';
+import { MAX_TIER } from '@auth/config';
 import { getServerSideKeyService } from '@auth/serverKeys';
 import type { AgentConfig } from '@agent/core/AgentConfig';
 // Internal imports
@@ -20,6 +21,7 @@ import {
   ModelConfig,
   ModelProvider,
   ModelCapabilities,
+  ReasoningEffort,
 } from '@model/ModelConfig';
 import type { ToolFileAttachment } from '@tools/result';
 import { getConfig } from '@utils/config';
@@ -439,6 +441,36 @@ export abstract class ModelHandler<
       `xAI models only support 'low' or 'high' reasoning effort. Converting '${effort}' to 'high'.`,
     );
     return 'high';
+  }
+
+  /**
+   * Returns the effective reasoning effort for the current user and model.
+   * Max tier users should not receive xhigh reasoning on GPT-5 models when
+   * using included (server-side) access.
+   */
+  protected getEffectiveReasoningEffort(): ReasoningEffort | null {
+    const { supportsReasoningEffort, reasoningEffort } = this.capabilities;
+    if (!supportsReasoningEffort || !reasoningEffort) {
+      return null;
+    }
+
+    if (reasoningEffort === ReasoningEffort.NONE) {
+      return null;
+    }
+
+    const isGpt5 = this.config.name.startsWith('gpt5');
+    if (
+      isGpt5 &&
+      reasoningEffort === ReasoningEffort.XHIGH &&
+      this.shouldUseServerSideKeys()
+    ) {
+      const userTier = getServerSideKeyService().getUserTier();
+      if (userTier === MAX_TIER) {
+        return ReasoningEffort.HIGH;
+      }
+    }
+
+    return reasoningEffort;
   }
 
   /**

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -178,13 +178,10 @@ export class ModelHandlerOpenAI<
       baseParams.temperature = temperature;
     }
 
-    if (
-      this.capabilities.supportsReasoning &&
-      this.capabilities.supportsReasoningEffort &&
-      this.capabilities.reasoningEffort
-    ) {
+    const reasoningEffort = this.getEffectiveReasoningEffort();
+    if (this.capabilities.supportsReasoning && reasoningEffort) {
       baseParams.reasoning_effort = this.validateReasoningEffort(
-        this.capabilities.reasoningEffort,
+        reasoningEffort,
       ) as ChatCompletionRequestBase['reasoning_effort'];
     }
 

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -844,12 +844,9 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       if (includeSummary) {
         reasoning.summary = 'auto';
       }
-      if (
-        this.capabilities.supportsReasoningEffort &&
-        this.capabilities.reasoningEffort &&
-        this.capabilities.reasoningEffort !== 'none'
-      ) {
-        reasoning.effort = this.capabilities.reasoningEffort;
+      const reasoningEffort = this.getEffectiveReasoningEffort();
+      if (reasoningEffort) {
+        reasoning.effort = reasoningEffort;
       }
       params.reasoning = reasoning;
     }


### PR DESCRIPTION
### Motivation

- Prevent Max-tier users from receiving `xhigh` reasoning for GPT‑5 models when using included (server-side) access, matching tier-based access/cost policy.

### Description

- Add a tier-aware resolver `getEffectiveReasoningEffort()` in `src/agent/modelHandlers/ModelHandler.ts` that downgrades `xhigh`→`high` for GPT‑5 models when the request will use server-side (included) keys and the user tier is `MAX_TIER`.
- Import `MAX_TIER` and `ReasoningEffort` and wire the new helper into the model handler logic.
- Update OpenAI chat params to use the effective effort via `getEffectiveReasoningEffort()` in `src/agent/modelHandlers/modelHandlerOpenAI.ts`.
- Update OpenAI Responses handling to reuse the effective reasoning effort in `src/agent/modelHandlers/modelHandlerOpenAIResponse.ts`.
- Modified files: `src/agent/modelHandlers/ModelHandler.ts`, `src/agent/modelHandlers/modelHandlerOpenAI.ts`, `src/agent/modelHandlers/modelHandlerOpenAIResponse.ts`.

### Testing

- Ran `npm run format` which completed successfully.
- Ran `npm run compile` which succeeded; webpack emitted a warning about a dynamic dependency in `nunjucks` (non-blocking).
- Ran `npm run lint` which completed with the repository's preexisting warnings (no new lint errors introduced).
- Ran `npm test` which failed due to a VS Code test harness download error (download length mismatch), so extension tests could not complete in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971f91c93b08324a63eaf9e67ae85f7)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements tier-aware reasoning effort and routes it through OpenAI handlers.
> 
> - Adds `getEffectiveReasoningEffort()` in `ModelHandler` to compute the final effort; downgrades `xhigh`→`high` for `gpt5*` when using server-side keys and user tier is `MAX_TIER`
> - Updates OpenAI chat (`modelHandlerOpenAI.ts`) to set `reasoning_effort` from the effective value (with provider-specific validation)
> - Updates OpenAI Responses (`modelHandlerOpenAIResponse.ts`) to set `params.reasoning.effort` from the effective value, preserving optional summary behavior
> - Imports `MAX_TIER` and `ReasoningEffort`; centralizes effort logic instead of using `capabilities.reasoningEffort` directly
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c74000210d30b29d217e15a92144d31eb377017c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->