### PR TITLE
refactor: simplify agent flow code with targeted cleanups

### DIFF
--- a/src/agent/core/AgentWorkspaceState.ts
+++ b/src/agent/core/AgentWorkspaceState.ts
@@ -263,13 +263,6 @@ const REASONING_CACHE_DEFAULTS: ReasoningCacheState = {
   thinkingAdded: false,
 };
 
-/** Get the primary thinking block, or null if none */
-export function getReasoningPrimaryBlock(
-  state: ReasoningCacheState,
-): ThinkingBlock | null {
-  return state.thinkingBlocks[0] ?? null;
-}
-
 // ============================================================================
 // ServerToolContentState - Plain object (no class needed)
 // ============================================================================

--- a/src/agent/core/ToolConfig.ts
+++ b/src/agent/core/ToolConfig.ts
@@ -19,11 +19,19 @@ export const DEFAULT_TOOL_CONFIG = {
  */
 export const ToolConfigSchema = z
   .object({
-    autoExtractFigure: z.boolean().prefault(false),
-    autoExtractTikzFigure: z.boolean().prefault(false),
-    attachTeXCount: z.boolean().prefault(false),
-    attachDiagnostics: z.boolean().prefault(false),
-    autoCompileInputPdf: z.boolean().prefault(false),
+    autoExtractFigure: z
+      .boolean()
+      .prefault(DEFAULT_TOOL_CONFIG.autoExtractFigure),
+    autoExtractTikzFigure: z
+      .boolean()
+      .prefault(DEFAULT_TOOL_CONFIG.autoExtractTikzFigure),
+    attachTeXCount: z.boolean().prefault(DEFAULT_TOOL_CONFIG.attachTeXCount),
+    attachDiagnostics: z
+      .boolean()
+      .prefault(DEFAULT_TOOL_CONFIG.attachDiagnostics),
+    autoCompileInputPdf: z
+      .boolean()
+      .prefault(DEFAULT_TOOL_CONFIG.autoCompileInputPdf),
   })
   .prefault(DEFAULT_TOOL_CONFIG);
 

--- a/src/agent/core/ToolConfig.ts
+++ b/src/agent/core/ToolConfig.ts
@@ -11,28 +11,19 @@ export const DEFAULT_TOOL_CONFIG = {
 
 /**
  * Zod schema for validating ToolConfig objects.
- * Defaults are defined at the property level and the schema itself
- * defaults to an empty object, allowing omission of the entire
- * configuration section.
+ * Schema-level prefault provides all defaults from DEFAULT_TOOL_CONFIG.
+ * Field-level prefaults match the schema default to handle partial inputs.
  *
  * We explicitly strip unknown properties to remain backward compatible
  * with legacy settings that may still include removed flags.
  */
 export const ToolConfigSchema = z
   .object({
-    autoExtractFigure: z
-      .boolean()
-      .prefault(DEFAULT_TOOL_CONFIG.autoExtractFigure),
-    autoExtractTikzFigure: z
-      .boolean()
-      .prefault(DEFAULT_TOOL_CONFIG.autoExtractTikzFigure),
-    attachTeXCount: z.boolean().prefault(DEFAULT_TOOL_CONFIG.attachTeXCount),
-    attachDiagnostics: z
-      .boolean()
-      .prefault(DEFAULT_TOOL_CONFIG.attachDiagnostics),
-    autoCompileInputPdf: z
-      .boolean()
-      .prefault(DEFAULT_TOOL_CONFIG.autoCompileInputPdf),
+    autoExtractFigure: z.boolean().prefault(false),
+    autoExtractTikzFigure: z.boolean().prefault(false),
+    attachTeXCount: z.boolean().prefault(false),
+    attachDiagnostics: z.boolean().prefault(false),
+    autoCompileInputPdf: z.boolean().prefault(false),
   })
   .prefault(DEFAULT_TOOL_CONFIG);
 

--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -137,15 +137,6 @@ export function assertCycleFieldsPopulated<T extends object>(
   }
 }
 
-/**
- * Reset cycle state for a new iteration.
- * Called at the start of each cycle to clear transient fields.
- * Reuses resetCycleState for base fields, adds response-specific fields.
- */
-function resetResponseCycleShared(shared: ResponseCycleShared): void {
-  resetCycleState(shared, ['responseObject', 'processedResponse']);
-}
-
 // Each node in the response cycle progressively hydrates the shared cycle
 // object. Mutations performed in `prep`, `exec`, and `post` stages are
 // intentionally visible to downstream nodes so that debug metadata and model
@@ -196,7 +187,7 @@ class ResponsePrepNode<C> extends BaseNode<
     },
   ): Promise<string | undefined> {
     if (prepRes.interrupted) {
-      resetResponseCycleShared(shared);
+      resetCycleState(shared, ['responseObject', 'processedResponse']);
       shared.shouldStop = true;
       return FlowTransition.COMPLETE;
     }
@@ -205,7 +196,7 @@ class ResponsePrepNode<C> extends BaseNode<
     shared.outputExists = prepRes.exists;
     shared.systemPrompt = prepRes.systemPrompt;
     shared.outputLocation = prepRes.outputLocation;
-    resetResponseCycleShared(shared);
+    resetCycleState(shared, ['responseObject', 'processedResponse']);
 
     await maybeSaveDebugObject({
       object: shared.messages,
@@ -232,11 +223,6 @@ class ResponsePrepNode<C> extends BaseNode<
 interface InvocationPrepResult extends BaseInvocationPrepResult {
   systemPrompt?: string;
 }
-
-/**
- * Result type for model invocation (uses shared InvocationResult).
- */
-type InvocationExecResult = InvocationResult<BaseInvocationSuccessData>;
 
 /**
  * Handles model invocation with PocketFlow's built-in retry.
@@ -282,7 +268,7 @@ class ResponseModelInvocationNode<C> extends RetryableInvocationNode<
     };
   }
 
-  async exec(prepRes: InvocationPrepResult): Promise<InvocationExecResult> {
+  async exec(prepRes: InvocationPrepResult): Promise<InvocationResult<BaseInvocationSuccessData>> {
     const services = this.services;
 
     if (prepRes.shouldStop) {
@@ -327,14 +313,14 @@ class ResponseModelInvocationNode<C> extends RetryableInvocationNode<
   async execFallback(
     _prepRes: InvocationPrepResult,
     error: Error,
-  ): Promise<InvocationExecResult> {
+  ): Promise<InvocationResult<BaseInvocationSuccessData>> {
     return this.getFallbackResult(error);
   }
 
   async post(
     shared: ResponseCycleShared,
     _prepRes: InvocationPrepResult,
-    execRes: InvocationExecResult,
+    execRes: InvocationResult<BaseInvocationSuccessData>,
   ): Promise<string | undefined> {
     const { logger, config, round } = this.services;
 

--- a/src/agent/core/flows/RetryState.ts
+++ b/src/agent/core/flows/RetryState.ts
@@ -12,7 +12,7 @@
  * - Base class for retryable invocation nodes (single source of truth)
  */
 
-import { Node } from '@agent/node';
+import { Node, type NonIterableObject } from '@agent/node';
 import {
   retryCoordinator,
   type RetryResult,
@@ -131,11 +131,6 @@ interface RetryableNodeServices {
   setAbortController: (ac: AbortController | null) => void;
 }
 
-/** Type constraint for Node params (matches PocketFlow's NonIterableObject). */
-type NodeParams = Partial<Record<string, unknown>> & {
-  [Symbol.iterator]?: never;
-};
-
 /**
  * Base class for model/tool invocation nodes with retry support.
  *
@@ -164,7 +159,7 @@ type NodeParams = Partial<Record<string, unknown>> & {
  */
 export abstract class RetryableInvocationNode<
   S,
-  P extends NodeParams = NodeParams,
+  P extends NonIterableObject = NonIterableObject,
   Svc extends RetryableNodeServices = RetryableNodeServices,
 > extends Node<S, P, Svc> {
   /**

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -1,5 +1,6 @@
 // Third-party imports
 import { z } from 'zod';
+import type { ZodIssue } from 'zod';
 
 // Local imports - core flow primitives
 import { isRemoteAgent } from '@agent/index';
@@ -85,30 +86,31 @@ function parseToolInput(
   }
 }
 
+/** Check if an error has Zod-like issues array (duck typing). */
+function hasZodIssues(error: unknown): error is { issues: ZodIssue[] } {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'issues' in error &&
+    Array.isArray((error as { issues?: unknown }).issues)
+  );
+}
+
 /** Normalize a tool call error into a user-friendly message with optional diagnostics. */
 function normalizeToolCallError(
   toolName: string,
   error: unknown,
 ): { message: string; diagnostics?: ValidationErrorDiagnostics } {
-  // Check if error has Zod-like issues array (duck typing)
-  const hasZodIssues =
-    typeof error === 'object' &&
-    error !== null &&
-    'issues' in error &&
-    Array.isArray((error as { issues?: unknown }).issues);
-
-  if (!hasZodIssues) {
+  if (!hasZodIssues(error)) {
     return { message: `${toolName}: ${toErrorMessage(error)}` };
   }
 
-  const issues = (error as { issues: ValidationErrorDiagnostics['issues'] })
-    .issues;
   return {
     message: `${toolName}: Invalid parameters provided`,
     diagnostics: {
       type: DIAGNOSTIC_TYPE_VALIDATION_ERROR,
-      issues,
-      formatted: formatZodIssuesForDiagnostics(issues),
+      issues: error.issues,
+      formatted: formatZodIssuesForDiagnostics(error.issues),
     },
   };
 }

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -85,28 +85,24 @@ function parseToolInput(
   }
 }
 
-/** Check if an error has Zod-like issues array (duck typing). */
-function hasZodIssues(
-  error: unknown,
-): error is { issues: Array<{ path: (string | number)[]; message: string }> } {
-  return (
-    typeof error === 'object' &&
-    error !== null &&
-    'issues' in error &&
-    Array.isArray((error as { issues?: unknown }).issues)
-  );
-}
-
 /** Normalize a tool call error into a user-friendly message with optional diagnostics. */
 function normalizeToolCallError(
   toolName: string,
   error: unknown,
 ): { message: string; diagnostics?: ValidationErrorDiagnostics } {
-  if (!hasZodIssues(error)) {
+  // Check if error has Zod-like issues array (duck typing)
+  const hasZodIssues =
+    typeof error === 'object' &&
+    error !== null &&
+    'issues' in error &&
+    Array.isArray((error as { issues?: unknown }).issues);
+
+  if (!hasZodIssues) {
     return { message: `${toolName}: ${toErrorMessage(error)}` };
   }
 
-  const issues = error.issues as ValidationErrorDiagnostics['issues'];
+  const issues = (error as { issues: ValidationErrorDiagnostics['issues'] })
+    .issues;
   return {
     message: `${toolName}: Invalid parameters provided`,
     diagnostics: {
@@ -330,13 +326,6 @@ class ToolUseCallNode<C> extends RetryableInvocationNode<
   }
 }
 
-/** Data extracted by prep() for tool-use process. */
-interface ToolUseProcessPrepResult {
-  shouldStop: boolean;
-  response?: unknown;
-  responseTimeMs?: number;
-}
-
 /** Result of exec() containing extracted data needed for post() side effects. */
 type ToolUseProcessExecResult =
   | { kind: 'skipped' }
@@ -358,7 +347,7 @@ class ToolUseProcessNode<C> extends BaseNode<
   ToolUseCycleParams<C>,
   ToolUseCycleServices<C>
 > {
-  async prep(shared: ToolUseCycleShared): Promise<ToolUseProcessPrepResult> {
+  async prep(shared: ToolUseCycleShared): Promise<{ shouldStop: boolean; response?: unknown; responseTimeMs?: number }> {
     return {
       shouldStop: shared.shouldStop,
       response: shared.response,
@@ -367,7 +356,7 @@ class ToolUseProcessNode<C> extends BaseNode<
   }
 
   async exec(
-    prepRes: ToolUseProcessPrepResult,
+    prepRes: { shouldStop: boolean; response?: unknown; responseTimeMs?: number },
   ): Promise<ToolUseProcessExecResult> {
     if (prepRes.shouldStop || !prepRes.response) {
       return { kind: 'skipped' };
@@ -454,7 +443,7 @@ class ToolUseProcessNode<C> extends BaseNode<
 
   async post(
     shared: ToolUseCycleShared,
-    _prepRes: ToolUseProcessPrepResult,
+    _prepRes: { shouldStop: boolean; response?: unknown; responseTimeMs?: number },
     execRes: ToolUseProcessExecResult,
   ): Promise<string | undefined> {
     const services = this.services;
@@ -668,42 +657,30 @@ class ToolUseDispatchNode<C> extends BatchNode<
     };
     options.logger.logToolUse(toolUseLog);
 
-    const mediaLocations = await this.collectValidMediaLocations(
-      result.files,
-      options.logger,
-    );
-    if (mediaLocations.length > 0) {
-      workspace.media.addMediaFiles(mediaLocations);
-    }
-  }
-
-  /** Collect valid file locations from tool result attachments. */
-  private async collectValidMediaLocations(
-    files: ToolResult['files'],
-    logger: AgentLogger,
-  ): Promise<FileLocation[]> {
-    if (!files || files.length === 0) {
-      return [];
-    }
-
-    const validLocations: FileLocation[] = [];
-    for (const attachment of files) {
-      const filePath = attachment.path;
-      if (typeof filePath !== 'string' || filePath.trim() === '') {
-        continue;
-      }
-      const location = pathToLocation(filePath);
-      try {
-        if (await AbsoluteFS.exists(location.absolutePath)) {
-          validLocations.push(location);
+    // Collect and add valid media file locations
+    const files = result.files;
+    if (files && files.length > 0) {
+      const validLocations: FileLocation[] = [];
+      for (const attachment of files) {
+        const filePath = attachment.path;
+        if (typeof filePath !== 'string' || filePath.trim() === '') {
+          continue;
         }
-      } catch (err) {
-        logger.debug(
-          `Skipping inaccessible media file: ${filePath} (${err instanceof Error ? err.message : 'unknown error'})`,
-        );
+        const location = pathToLocation(filePath);
+        try {
+          if (await AbsoluteFS.exists(location.absolutePath)) {
+            validLocations.push(location);
+          }
+        } catch (err) {
+          options.logger.debug(
+            `Skipping inaccessible media file: ${filePath} (${err instanceof Error ? err.message : 'unknown error'})`,
+          );
+        }
+      }
+      if (validLocations.length > 0) {
+        workspace.media.addMediaFiles(validLocations);
       }
     }
-    return validLocations;
   }
 
   /**

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -228,9 +228,6 @@ class ToolUsePrepNode<C> extends BaseNode<
   }
 }
 
-/** Result type for tool-use call. */
-type ToolUseCallResult = InvocationResult<BaseInvocationSuccessData>;
-
 /**
  * Handles model invocation for tool-use cycles with PocketFlow's built-in retry.
  * Uses RetryableInvocationNode for automatic retry logic with user prompts.
@@ -251,7 +248,7 @@ class ToolUseCallNode<C> extends RetryableInvocationNode<
     };
   }
 
-  async exec(prepRes: BaseInvocationPrepResult): Promise<ToolUseCallResult> {
+  async exec(prepRes: BaseInvocationPrepResult): Promise<InvocationResult<BaseInvocationSuccessData>> {
     const services = this.services;
 
     if (prepRes.shouldStop) {
@@ -279,14 +276,14 @@ class ToolUseCallNode<C> extends RetryableInvocationNode<
   async execFallback(
     _prepRes: BaseInvocationPrepResult,
     error: Error,
-  ): Promise<ToolUseCallResult> {
+  ): Promise<InvocationResult<BaseInvocationSuccessData>> {
     return this.getFallbackResult(error);
   }
 
   async post(
     shared: ToolUseCycleShared,
     _prepRes: BaseInvocationPrepResult,
-    execRes: ToolUseCallResult,
+    execRes: InvocationResult<BaseInvocationSuccessData>,
   ): Promise<string | undefined> {
     const services = this.services;
 

--- a/src/agent/implementations/flows/reflection/nodes/OutputNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/OutputNode.ts
@@ -34,8 +34,6 @@ interface OutputPrepInput {
 // Helpers
 // ============================================================================
 
-type WarnLogger = { warn: (msg: string) => void };
-
 /**
  * Execute an operation that can fail gracefully.
  * Logs warnings on failure but doesn't throw.
@@ -43,7 +41,7 @@ type WarnLogger = { warn: (msg: string) => void };
 async function tryOperation(
   label: string,
   operation: () => Promise<void>,
-  logger: WarnLogger,
+  logger: { warn: (msg: string) => void },
 ): Promise<void> {
   try {
     await operation();

--- a/src/agent/implementations/flows/reflection/runReflectionFlow.ts
+++ b/src/agent/implementations/flows/reflection/runReflectionFlow.ts
@@ -103,39 +103,30 @@ export interface RunReflectionFlowResult {
 // Configuration Derivation
 // ============================================================================
 
-interface DerivedConfig {
+/** Derive configuration values from settings and prompts. */
+function deriveConfig(
+  setting: AgentWorkflowSetting,
+  prompt: RunReflectionFlowInput['prompt'],
+): {
   useScratchpad: boolean;
   shouldEnsureXmlStructure: boolean;
   totalRounds: number;
   outputExt: string;
-}
+} {
+  const useScratchpad = setting.prefills?.includes('<scratchpad>') ?? false;
 
-/** Determine if XML structure enforcement is needed based on settings and scratchpad usage. */
-function shouldEnforceXmlStructure(
-  setting: AgentWorkflowSetting,
-  useScratchpad: boolean,
-): boolean {
+  // Determine XML structure enforcement based on mode
   const mode = setting.xmlStructureMode ?? 'scratchpadOnly';
-
-  switch (mode) {
-    case 'always':
-      return true;
-    case 'never':
-      return false;
-    case 'scratchpadOnly':
-      return useScratchpad;
-    default: {
-      const _exhaustive: never = mode;
-      throw new Error(`Unknown xmlStructureMode: ${_exhaustive}`);
-    }
+  let shouldEnsureXmlStructure: boolean;
+  if (mode === 'always') {
+    shouldEnsureXmlStructure = true;
+  } else if (mode === 'never') {
+    shouldEnsureXmlStructure = false;
+  } else {
+    shouldEnsureXmlStructure = useScratchpad;
   }
-}
 
-/** Compute the total number of rounds: max(setting.rounds, userRequest.length) */
-function computeTotalRounds(
-  setting: AgentWorkflowSetting,
-  prompt: RunReflectionFlowInput['prompt'],
-): number {
+  // Compute total rounds: max(setting.rounds, userRequest.length)
   const { userRequest } = prompt;
   let requestCount = 0;
   if (Array.isArray(userRequest)) {
@@ -143,20 +134,12 @@ function computeTotalRounds(
   } else if (userRequest) {
     requestCount = 1;
   }
-  return Math.max(setting.rounds ?? 2, requestCount);
-}
-
-/** Derive configuration values from settings and prompts. */
-function deriveConfig(
-  setting: AgentWorkflowSetting,
-  prompt: RunReflectionFlowInput['prompt'],
-): DerivedConfig {
-  const useScratchpad = setting.prefills?.includes('<scratchpad>') ?? false;
+  const totalRounds = Math.max(setting.rounds ?? 2, requestCount);
 
   return {
     useScratchpad,
-    shouldEnsureXmlStructure: shouldEnforceXmlStructure(setting, useScratchpad),
-    totalRounds: computeTotalRounds(setting, prompt),
+    shouldEnsureXmlStructure,
+    totalRounds,
     outputExt: useScratchpad ? 'xml' : setting.outputExt,
   };
 }

--- a/src/agent/implementations/flows/reflection/runReflectionFlow.ts
+++ b/src/agent/implementations/flows/reflection/runReflectionFlow.ts
@@ -103,30 +103,39 @@ export interface RunReflectionFlowResult {
 // Configuration Derivation
 // ============================================================================
 
-/** Derive configuration values from settings and prompts. */
-function deriveConfig(
-  setting: AgentWorkflowSetting,
-  prompt: RunReflectionFlowInput['prompt'],
-): {
+interface DerivedConfig {
   useScratchpad: boolean;
   shouldEnsureXmlStructure: boolean;
   totalRounds: number;
   outputExt: string;
-} {
-  const useScratchpad = setting.prefills?.includes('<scratchpad>') ?? false;
+}
 
-  // Determine XML structure enforcement based on mode
+/** Determine if XML structure enforcement is needed based on settings and scratchpad usage. */
+function shouldEnforceXmlStructure(
+  setting: AgentWorkflowSetting,
+  useScratchpad: boolean,
+): boolean {
   const mode = setting.xmlStructureMode ?? 'scratchpadOnly';
-  let shouldEnsureXmlStructure: boolean;
-  if (mode === 'always') {
-    shouldEnsureXmlStructure = true;
-  } else if (mode === 'never') {
-    shouldEnsureXmlStructure = false;
-  } else {
-    shouldEnsureXmlStructure = useScratchpad;
-  }
 
-  // Compute total rounds: max(setting.rounds, userRequest.length)
+  switch (mode) {
+    case 'always':
+      return true;
+    case 'never':
+      return false;
+    case 'scratchpadOnly':
+      return useScratchpad;
+    default: {
+      const _exhaustive: never = mode;
+      throw new Error(`Unknown xmlStructureMode: ${_exhaustive}`);
+    }
+  }
+}
+
+/** Compute the total number of rounds: max(setting.rounds, userRequest.length) */
+function computeTotalRounds(
+  setting: AgentWorkflowSetting,
+  prompt: RunReflectionFlowInput['prompt'],
+): number {
   const { userRequest } = prompt;
   let requestCount = 0;
   if (Array.isArray(userRequest)) {
@@ -134,12 +143,20 @@ function deriveConfig(
   } else if (userRequest) {
     requestCount = 1;
   }
-  const totalRounds = Math.max(setting.rounds ?? 2, requestCount);
+  return Math.max(setting.rounds ?? 2, requestCount);
+}
+
+/** Derive configuration values from settings and prompts. */
+function deriveConfig(
+  setting: AgentWorkflowSetting,
+  prompt: RunReflectionFlowInput['prompt'],
+): DerivedConfig {
+  const useScratchpad = setting.prefills?.includes('<scratchpad>') ?? false;
 
   return {
     useScratchpad,
-    shouldEnsureXmlStructure,
-    totalRounds,
+    shouldEnsureXmlStructure: shouldEnforceXmlStructure(setting, useScratchpad),
+    totalRounds: computeTotalRounds(setting, prompt),
     outputExt: useScratchpad ? 'xml' : setting.outputExt,
   };
 }

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUsePrepareNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUsePrepareNode.ts
@@ -18,8 +18,6 @@ export class ToolUsePrepareNode<C> extends Node<
   ToolUseFlowParams,
   ToolUseServices<C>
 > {
-  async prep(_shared: ToolUseRunShared): Promise<void> {}
-
   async exec(
     _prepRes: void,
   ): Promise<{ kind: 'success'; result: PrepareResult }> {

--- a/src/agent/implementations/flows/tooluse/nodes/types.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/types.ts
@@ -93,12 +93,11 @@ export function assertPreparedShared(
 // ============================================================================
 
 /**
- * Lightweight schema for detecting and migrating legacy shared state format.
+ * Lightweight schema for detecting shared state format.
  * Uses looseObject to preserve all fields (stateSlices, shouldSkipCycle, etc.)
  * - only validates enough to detect format, not full content.
  */
-const FlatFormatSchema = z.looseObject({ conversation: z.array(z.unknown()) });
-const LegacyStateSchema = z.looseObject({ conversation: z.array(z.unknown()) });
+const ConversationSchema = z.looseObject({ conversation: z.array(z.unknown()) });
 
 /**
  * Migrate legacy shared state to current flat format.
@@ -111,7 +110,7 @@ export function migrateSharedState(
   shared: unknown,
 ): { data: ToolUseRunShared; migrated: boolean } | null {
   // Check if already flat format - return same reference (no migration needed)
-  const flatResult = FlatFormatSchema.safeParse(shared);
+  const flatResult = ConversationSchema.safeParse(shared);
   if (flatResult.success && !('state' in flatResult.data)) {
     return { data: shared as ToolUseRunShared, migrated: false };
   }
@@ -119,7 +118,7 @@ export function migrateSharedState(
   // Check if legacy format - extract and return nested state
   const obj = shared as Record<string, unknown>;
   if (obj && typeof obj === 'object' && 'state' in obj) {
-    const legacyResult = LegacyStateSchema.safeParse(obj.state);
+    const legacyResult = ConversationSchema.safeParse(obj.state);
     if (legacyResult.success) {
       return { data: obj.state as ToolUseRunShared, migrated: true };
     }

--- a/src/agent/runtime/SessionResumeRetrieval.ts
+++ b/src/agent/runtime/SessionResumeRetrieval.ts
@@ -163,6 +163,27 @@ export async function retrieveSessionResumeData(
 // =============================================================================
 
 /**
+ * Read flow record from execution store.
+ * Returns the flow record if found and valid, null otherwise.
+ */
+async function readFlowRecord(
+  executionId: ExecutionId,
+  agentType: 'tool-use' | 'workflow',
+): Promise<FlowRecord | null> {
+  const kv = getExecutionStore(executionId);
+  const flowRecord = await kv.read<FlowRecord>(`flow:${executionId}`);
+
+  if (!flowRecord?.shared) {
+    logger.warn(
+      `No flow record found for ${agentType} execution: ${executionId}`,
+    );
+    return null;
+  }
+
+  return flowRecord;
+}
+
+/**
  * Retrieve resume data for a tool-use session.
  */
 async function retrieveToolUseResumeData(
@@ -171,11 +192,8 @@ async function retrieveToolUseResumeData(
   taskState: TaskState,
 ): Promise<ToolUseResumeData | null> {
   try {
-    const kv = getExecutionStore(executionId);
-    const flowRecord = await kv.read<FlowRecord>(`flow:${executionId}`);
-
-    if (!flowRecord?.shared) {
-      logger.warn(`No flow record found for execution: ${executionId}`);
+    const flowRecord = await readFlowRecord(executionId, 'tool-use');
+    if (!flowRecord) {
       return null;
     }
 
@@ -237,13 +255,8 @@ async function retrieveWorkflowResumeData(
   taskState: TaskState,
 ): Promise<WorkflowResumeData | null> {
   try {
-    const kv = getExecutionStore(executionId);
-    const flowRecord = await kv.read<FlowRecord>(`flow:${executionId}`);
-
-    if (!flowRecord?.shared) {
-      logger.warn(
-        `No flow record found for workflow execution: ${executionId}`,
-      );
+    const flowRecord = await readFlowRecord(executionId, 'workflow');
+    if (!flowRecord) {
       return null;
     }
 


### PR DESCRIPTION
- Inline config derivation functions in runReflectionFlow.ts (removed
  shouldEnforceXmlStructure and computeTotalRounds helpers called once)
- Remove redundant WarnLogger type alias in OutputNode.ts (inline type)
- Remove empty prep method in ToolUsePrepareNode.ts (base class default)
- Consolidate duplicate schemas in migration types (single ConversationSchema)
- Use NonIterableObject from node module instead of duplicate NodeParams

https://claude.ai/code/session_01R9pLePLQsf5UXcGYWHLDJx

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Streamlines agent flow code and unifies result/ retry patterns.
> 
> - Standardizes invocation typings: `InvocationResult` used across response/tool-use flows; node method signatures aligned; `RetryableInvocationNode` now extends `Node<S, P extends NonIterableObject>` and enforces background-mode min retries
> - Simplifies state resets: inlined `resetCycleState` calls; removed `resetResponseCycleShared`
> - Schema/validation cleanup: consolidated conversation/legacy detection to `ConversationSchema`; improved Zod issue typing via `ZodIssue`; `ToolConfigSchema` now uses schema-level defaults
> - Tool-use flow refactors: extracted media file handling (validations via `AbsoluteFS.exists`); batched follow-up messaging preserved; removed empty `prep` in `ToolUsePrepareNode`
> - Reflection/output tweaks: inlined warn-logger type in `tryOperation`
> - Session resume: factored `readFlowRecord()` helper; clearer warnings and reuse across tool-use/workflow resume paths
> - Removed unused helper `getReasoningPrimaryBlock` from workspace state
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e0fcf203a303b7dfa12ab4593116e6c752346531. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->