### PR TITLE
refactor: improve code clarity and reduce unnecessary abstractions

### DIFF
--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -365,7 +365,9 @@ class ToolUseProcessNode<C> extends BaseNode<
     };
   }
 
-  async exec(prepRes: ToolUseProcessPrepResult): Promise<ToolUseProcessExecResult> {
+  async exec(
+    prepRes: ToolUseProcessPrepResult,
+  ): Promise<ToolUseProcessExecResult> {
     if (prepRes.shouldStop || !prepRes.response) {
       return { kind: 'skipped' };
     }

--- a/src/agent/implementations/flows/reflection/runReflectionFlow.ts
+++ b/src/agent/implementations/flows/reflection/runReflectionFlow.ts
@@ -239,11 +239,12 @@ export async function runReflectionFlow<C = unknown>(
         round,
         config.editedFile || undefined,
       );
-      return (
-        useScratchpad
-          ? fileService.createRawOutputLocation(fileName)
-          : fileService.createLocation(fileName)
-      ) as AgentFileLocation;
+      if (useScratchpad) {
+        return fileService.createRawOutputLocation(
+          fileName,
+        ) as AgentFileLocation;
+      }
+      return fileService.createLocation(fileName) as AgentFileLocation;
     });
 
   // Create interruptible object for registration

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUsePrepareNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUsePrepareNode.ts
@@ -90,9 +90,10 @@ export class ToolUsePrepareNode<C> extends Node<
     execRes: NodeExecResult<PrepareResult>,
   ): Promise<string | undefined> {
     if (execRes.kind === 'error') {
-      throw execRes.error instanceof Error
-        ? execRes.error
-        : new Error(String(execRes.error));
+      if (execRes.error instanceof Error) {
+        throw execRes.error;
+      }
+      throw new Error(String(execRes.error));
     }
 
     const {

--- a/src/tools/ReadTool.ts
+++ b/src/tools/ReadTool.ts
@@ -176,13 +176,18 @@ export class ReadFileTool extends defineTool({
       startLine === endLine
         ? `line ${startLine}`
         : `lines ${startLine}-${endLine}`;
-    const base = isPartialRead
-      ? `Read ${rangeLabel} of ${path}`
-      : `Read ${path}`;
 
-    return rangeEndExceeded
-      ? `${base} (requested end ${requestedEndLine} exceeds file length ${totalLines})`
-      : base;
+    let base: string;
+    if (isPartialRead) {
+      base = `Read ${rangeLabel} of ${path}`;
+    } else {
+      base = `Read ${path}`;
+    }
+
+    if (rangeEndExceeded) {
+      return `${base} (requested end ${requestedEndLine} exceeds file length ${totalLines})`;
+    }
+    return base;
   }
 
   private getAttachmentConfig(

--- a/src/tools/TextEditorTool.ts
+++ b/src/tools/TextEditorTool.ts
@@ -31,6 +31,11 @@ const CHANNEL = 'TextEditorTool';
 logger.initialize(CHANNEL);
 const SNIPPET_LINES = 4;
 
+/** Expand tabs to 4 spaces for consistent display */
+function expandTabs(content: string): string {
+  return content.replaceAll('\t', '    ');
+}
+
 /** Maps API type versions to their corresponding tool names */
 const API_TYPE_TO_NAME = {
   text_editor_20250429: 'str_replace_based_edit_tool',
@@ -42,7 +47,11 @@ export const TextEditorInputSchema = z.strictObject({
   command: z.enum(['view', 'create', 'str_replace', 'insert', 'undo_edit']),
   path: z.string(),
   file_text: z.string().nullish(),
-  view_range: z.array(z.number()).length(2).nullish().describe('1-indexed. Use -1 for EOF.'),
+  view_range: z
+    .array(z.number())
+    .length(2)
+    .nullish()
+    .describe('1-indexed. Use -1 for EOF.'),
   old_str: z.string().nullish(),
   new_str: z.string().nullish(),
   insert_line: z.number().nullish().describe('1-indexed.'),
@@ -402,9 +411,9 @@ export class TextEditorTool extends defineTool({
       const fileContent = await WorkspaceFS.read(filePath);
 
       // Expand tabs in content and search string
-      const expandedFileContent = fileContent.replaceAll('\t', '    ');
-      const expandedOldStr = oldStr.replaceAll('\t', '    ');
-      const expandedNewStr = newStr.replaceAll('\t', '    ');
+      const expandedFileContent = expandTabs(fileContent);
+      const expandedOldStr = expandTabs(oldStr);
+      const expandedNewStr = expandTabs(newStr);
 
       // Check for occurrences of oldStr
       const occurrences = expandedFileContent.split(expandedOldStr).length - 1;
@@ -532,8 +541,8 @@ export class TextEditorTool extends defineTool({
       const fileContent = await WorkspaceFS.read(filePath);
 
       // Expand tabs in content and new string
-      const expandedFileContent = fileContent.replaceAll('\t', '    ');
-      const expandedNewStr = newStr.replaceAll('\t', '    ');
+      const expandedFileContent = expandTabs(fileContent);
+      const expandedNewStr = expandTabs(newStr);
 
       // Split content into lines
       const fileLines = expandedFileContent.split(/\r?\n/);

--- a/src/utils/config/configConversion.ts
+++ b/src/utils/config/configConversion.ts
@@ -12,25 +12,6 @@ import {
 // Local file imports
 import { FILE_TYPES, type FileType } from './constants';
 
-function createActiveFilesFromArrays(
-  src: Record<string, any>,
-): Record<FileType, boolean> {
-  const active = {} as Record<FileType, boolean>;
-  FILE_TYPES.forEach((type) => {
-    const filesField = `${type}Files`;
-    const flagField = `${filesField}Active`;
-    const useMultipleOutputs = Boolean(
-      (src as { useMultipleOutputs?: boolean }).useMultipleOutputs,
-    );
-    const multipleFlag = type === 'output' && useMultipleOutputs;
-    active[type] =
-      (Array.isArray(src[filesField]) && src[filesField].length > 0) ||
-      !!src[flagField] ||
-      multipleFlag;
-  });
-  return active;
-}
-
 /**
  * Converts an AgentConfig object to a TaskState object.
  *
@@ -44,11 +25,28 @@ export function agentConfigToTaskState(config: AgentConfig): TaskState {
         agentConfig: config as ToolUseTaskState['agentConfig'],
         toolSessionState: {},
       };
-    case AgentCategory.Workflow:
+    case AgentCategory.Workflow: {
+      // Build activeFiles inline - determines which file types are active
+      const activeFiles = {} as Record<FileType, boolean>;
+      const useMultipleOutputs = Boolean(
+        (config as { useMultipleOutputs?: boolean }).useMultipleOutputs,
+      );
+      for (const type of FILE_TYPES) {
+        const filesField = `${type}Files`;
+        const flagField = `${filesField}Active`;
+        const multipleFlag = type === 'output' && useMultipleOutputs;
+        activeFiles[type] =
+          (Array.isArray((config as Record<string, unknown>)[filesField]) &&
+            ((config as Record<string, unknown>)[filesField] as unknown[])
+              .length > 0) ||
+          !!(config as Record<string, unknown>)[flagField] ||
+          multipleFlag;
+      }
       return {
         agentConfig: config as WorkflowTaskState['agentConfig'],
-        activeFiles: createActiveFilesFromArrays(config),
+        activeFiles,
       };
+    }
     default: {
       const _exhaustive: never = config.agentCategory;
       throw new Error(`Unknown agent category: ${_exhaustive}`);

--- a/src/utils/files/fileMappingUtils.ts
+++ b/src/utils/files/fileMappingUtils.ts
@@ -96,54 +96,6 @@ export function createFileMapping(
  */
 const TEX_EXTENSION_REGEX = /\.tex$/i;
 
-/**
- * Build a string → string lookup for LaTeX \input command replacement.
- * Generates all path suffix variants (from full path down to filename) for flexible matching.
- */
-function buildReplacementLookup(
-  baseToOutputMap: Map<string, FileLocation>,
-): Map<string, string> {
-  const replacements = new Map<string, string>();
-
-  for (const [baseFile, outputLoc] of baseToOutputMap.entries()) {
-    if (!baseFile || !outputLoc) continue;
-
-    const outputFile = getComparablePath(outputLoc);
-
-    const baseSegments = getPathSegments(baseFile);
-    const outputSegments = getPathSegments(outputFile);
-    const maxDepth = Math.min(baseSegments.length, outputSegments.length);
-
-    for (let depth = maxDepth; depth >= 1; depth--) {
-      const baseSuffix = baseSegments.slice(-depth).join('/');
-      const outputSuffix = outputSegments.slice(-depth).join('/');
-
-      // Register replacement if not already present
-      const normalizedBase = normalizeLatexPath(baseSuffix);
-      if (normalizedBase && !replacements.has(normalizedBase)) {
-        replacements.set(normalizedBase, normalizeLatexPath(outputSuffix));
-      }
-
-      // Also register without .tex extension
-      const baseHasTex = TEX_EXTENSION_REGEX.test(baseSuffix);
-      const outputHasTex = TEX_EXTENSION_REGEX.test(outputSuffix);
-      if (baseHasTex && outputHasTex) {
-        const baseNoExt = normalizeLatexPath(
-          baseSuffix.replace(TEX_EXTENSION_REGEX, ''),
-        );
-        if (baseNoExt && !replacements.has(baseNoExt)) {
-          replacements.set(
-            baseNoExt,
-            normalizeLatexPath(outputSuffix.replace(TEX_EXTENSION_REGEX, '')),
-          );
-        }
-      }
-    }
-  }
-
-  return replacements;
-}
-
 export async function replaceInputCommands(
   baseFiles: FileLocation[],
   outputFiles: FileLocation[],
@@ -170,7 +122,42 @@ export async function replaceInputCommands(
       .join(', ')}`,
   );
 
-  const replacementLookup = buildReplacementLookup(baseToOutputMap);
+  // Build replacement lookup: generates all path suffix variants for flexible matching
+  const replacementLookup = new Map<string, string>();
+  for (const [baseFile, outputLoc] of baseToOutputMap.entries()) {
+    if (!baseFile || !outputLoc) continue;
+
+    const outputFile = getComparablePath(outputLoc);
+    const baseSegments = getPathSegments(baseFile);
+    const outputSegments = getPathSegments(outputFile);
+    const maxDepth = Math.min(baseSegments.length, outputSegments.length);
+
+    for (let depth = maxDepth; depth >= 1; depth--) {
+      const baseSuffix = baseSegments.slice(-depth).join('/');
+      const outputSuffix = outputSegments.slice(-depth).join('/');
+
+      // Register replacement if not already present
+      const normalizedBase = normalizeLatexPath(baseSuffix);
+      if (normalizedBase && !replacementLookup.has(normalizedBase)) {
+        replacementLookup.set(normalizedBase, normalizeLatexPath(outputSuffix));
+      }
+
+      // Also register without .tex extension
+      const baseHasTex = TEX_EXTENSION_REGEX.test(baseSuffix);
+      const outputHasTex = TEX_EXTENSION_REGEX.test(outputSuffix);
+      if (baseHasTex && outputHasTex) {
+        const baseNoExt = normalizeLatexPath(
+          baseSuffix.replace(TEX_EXTENSION_REGEX, ''),
+        );
+        if (baseNoExt && !replacementLookup.has(baseNoExt)) {
+          replacementLookup.set(
+            baseNoExt,
+            normalizeLatexPath(outputSuffix.replace(TEX_EXTENSION_REGEX, '')),
+          );
+        }
+      }
+    }
+  }
 
   if (replacementLookup.size === 0) {
     logger?.debug('No replacement entries derived from file mappings');

--- a/src/utils/files/taskRunStorage.ts
+++ b/src/utils/files/taskRunStorage.ts
@@ -123,35 +123,6 @@ type ResolvedPath =
   | { kind: 'workspace'; absolutePath: string; relativePath: string }
   | { kind: 'external'; absolutePath: string };
 
-function resolveAbsolutePathAgainstWorkspace(
-  absolutePath: string,
-  workspaceRoot: string | undefined,
-): ResolvedPath {
-  if (!workspaceRoot) {
-    return { kind: 'external', absolutePath };
-  }
-  const relative = WorkspaceFS.relativePath(absolutePath);
-  if (relative !== absolutePath && !relative.startsWith('..')) {
-    return {
-      kind: 'workspace',
-      absolutePath,
-      relativePath: relative,
-    };
-  }
-  return { kind: 'external', absolutePath };
-}
-
-function resolveRelativePathAgainstWorkspace(
-  relativePath: string,
-  workspaceRoot: string | undefined,
-): ResolvedPath {
-  if (!workspaceRoot) {
-    return { kind: 'external', absolutePath: path.resolve(relativePath) };
-  }
-  const absolutePath = path.join(workspaceRoot, relativePath);
-  return { kind: 'workspace', absolutePath, relativePath };
-}
-
 /**
  * Resolve a path (absolute or relative) against a workspace root.
  * This is the shared logic for path resolution used by createLocation,
@@ -177,10 +148,26 @@ function resolvePathAgainstWorkspace(
     // Use WorkspaceFS.relativePath() which handles symlinks correctly via
     // vscode.workspace.asRelativePath(). Direct path.relative() fails when
     // the path is inside a symlinked directory.
-    return resolveAbsolutePathAgainstWorkspace(inputPath, workspaceRoot);
+    if (!workspaceRoot) {
+      return { kind: 'external', absolutePath: inputPath };
+    }
+    const relative = WorkspaceFS.relativePath(inputPath);
+    if (relative !== inputPath && !relative.startsWith('..')) {
+      return {
+        kind: 'workspace',
+        absolutePath: inputPath,
+        relativePath: relative,
+      };
+    }
+    return { kind: 'external', absolutePath: inputPath };
   }
 
-  return resolveRelativePathAgainstWorkspace(inputPath, workspaceRoot);
+  // Relative path
+  if (!workspaceRoot) {
+    return { kind: 'external', absolutePath: path.resolve(inputPath) };
+  }
+  const absolutePath = path.join(workspaceRoot, inputPath);
+  return { kind: 'workspace', absolutePath, relativePath: inputPath };
 }
 
 /**

--- a/src/utils/text/textEnhancementUtils.ts
+++ b/src/utils/text/textEnhancementUtils.ts
@@ -59,37 +59,40 @@ export function buildFileContextFromTaskState(
   taskState: TaskState,
 ): FileContext {
   const { agentConfig } = taskState;
+  const context: FileContext = {};
 
-  return {
-    ...(agentConfig.agent && { agent: agentConfig.agent }),
-    ...(isNonEmptyString(agentConfig.inputFile) && {
-      inputFile: agentConfig.inputFile,
-    }),
-    ...(agentConfig.inputFiles.length > 0 && {
-      inputFiles: agentConfig.inputFiles,
-    }),
-    ...(isNonEmptyString(agentConfig.referenceFile) && {
-      referenceFile: agentConfig.referenceFile,
-    }),
-    ...(agentConfig.referenceFiles.length > 0 && {
-      referenceFiles: agentConfig.referenceFiles,
-    }),
-    ...(isNonEmptyString(agentConfig.auxiliaryFile) && {
-      auxiliaryFile: agentConfig.auxiliaryFile,
-    }),
-    ...(agentConfig.auxiliaryFiles.length > 0 && {
-      auxiliaryFiles: agentConfig.auxiliaryFiles,
-    }),
-    ...(isNonEmptyString(agentConfig.mediaFile) && {
-      mediaFile: agentConfig.mediaFile,
-    }),
-    ...(agentConfig.mediaFiles.length > 0 && {
-      mediaFiles: agentConfig.mediaFiles,
-    }),
-    ...(agentConfig.outputFiles.length > 0 && {
-      outputFiles: agentConfig.outputFiles,
-    }),
-  };
+  if (agentConfig.agent) {
+    context.agent = agentConfig.agent;
+  }
+  if (isNonEmptyString(agentConfig.inputFile)) {
+    context.inputFile = agentConfig.inputFile;
+  }
+  if (agentConfig.inputFiles.length > 0) {
+    context.inputFiles = agentConfig.inputFiles;
+  }
+  if (isNonEmptyString(agentConfig.referenceFile)) {
+    context.referenceFile = agentConfig.referenceFile;
+  }
+  if (agentConfig.referenceFiles.length > 0) {
+    context.referenceFiles = agentConfig.referenceFiles;
+  }
+  if (isNonEmptyString(agentConfig.auxiliaryFile)) {
+    context.auxiliaryFile = agentConfig.auxiliaryFile;
+  }
+  if (agentConfig.auxiliaryFiles.length > 0) {
+    context.auxiliaryFiles = agentConfig.auxiliaryFiles;
+  }
+  if (isNonEmptyString(agentConfig.mediaFile)) {
+    context.mediaFile = agentConfig.mediaFile;
+  }
+  if (agentConfig.mediaFiles.length > 0) {
+    context.mediaFiles = agentConfig.mediaFiles;
+  }
+  if (agentConfig.outputFiles.length > 0) {
+    context.outputFiles = agentConfig.outputFiles;
+  }
+
+  return context;
 }
 
 /**


### PR DESCRIPTION
- Replace nested ternaries with if/else in ReadTool.ts, compareCommands.ts,
  runReflectionFlow.ts, and ToolUsePrepareNode.ts
- Inline single-call wrapper functions in taskRunStorage.ts
  (resolveAbsolutePathAgainstWorkspace, resolveRelativePathAgainstWorkspace)
- Inline buildReplacementLookup in fileMappingUtils.ts
- Inline createActiveFilesFromArrays in configConversion.ts
- Refactor conditional spreading pattern to explicit if statements
  in textEnhancementUtils.ts
- Extract expandTabs helper in TextEditorTool.ts to eliminate duplication
- Apply Prettier formatting to affected files

https://claude.ai/code/session_01KT2gvA66H4s5F41BZwfDow

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Streamlines logic and reduces indirection across frequently used utilities and tools.
> 
> - Inlines helper functions: `buildReplacementLookup` into `replaceInputCommands` (fileMappingUtils), path resolvers into `resolvePathAgainstWorkspace` (taskRunStorage), and `createActiveFilesFromArrays` logic directly in `agentConfigToTaskState` (configConversion)
> - Extracts `expandTabs()` in `TextEditorTool` and reuses in `str_replace` and `insert`
> - Replaces nested/complex ternaries with explicit if/else in `ReadTool.buildSummary`, `runReflectionFlow` output location selection, and `ToolUsePrepareNode.post` error handling
> - Minor formatting and signature tidy-ups in `ToolUseCycleFlow` and schema formatting in `TextEditorTool`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6e871bef708f6a1ceb869f74560fc6e93285e012. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->