### PR TITLE
refactor: simplify god objects with better patterns and defaults

### DIFF
--- a/src/agent/output/OutputHandler.ts
+++ b/src/agent/output/OutputHandler.ts
@@ -44,6 +44,23 @@ interface RoundData {
   xmlSummary: OutputXmlSummary;
 }
 
+/** Default empty XML summary */
+const EMPTY_XML_SUMMARY: OutputXmlSummary = {
+  tagContents: {},
+  documents: [],
+  singleOutputFile: null,
+  sourceLocation: null,
+};
+
+/** Create empty RoundData with default values */
+function createEmptyRoundData(): RoundData {
+  return {
+    outputs: [],
+    rawOutput: null,
+    xmlSummary: { ...EMPTY_XML_SUMMARY },
+  };
+}
+
 /** Handles output file processing and validation for agent responses. */
 export class OutputHandler implements IOutputHandler {
   public agentSetting: AgentWorkflowSetting;
@@ -191,16 +208,7 @@ export class OutputHandler implements IOutputHandler {
   private ensureRoundData(round: number): RoundData {
     let data = this.rounds.get(round);
     if (!data) {
-      data = {
-        outputs: [],
-        rawOutput: null,
-        xmlSummary: {
-          tagContents: {},
-          documents: [],
-          singleOutputFile: null,
-          sourceLocation: null,
-        },
-      };
+      data = createEmptyRoundData();
       this.rounds.set(round, data);
     }
     return data;
@@ -503,13 +511,6 @@ export class OutputHandler implements IOutputHandler {
 
   public getRoundXmlSummary(round: number): OutputXmlSummary {
     const data = this.rounds.get(round);
-    return (
-      data?.xmlSummary ?? {
-        tagContents: {},
-        documents: [],
-        singleOutputFile: null,
-        sourceLocation: null,
-      }
-    );
+    return data?.xmlSummary ?? EMPTY_XML_SUMMARY;
   }
 }

--- a/src/agent/output/OutputHandler.ts
+++ b/src/agent/output/OutputHandler.ts
@@ -46,12 +46,7 @@ import {
 const RoundDataSchema = z.object({
   outputs: OutputFileInfoSchema.array().prefault(() => []),
   rawOutput: FileLocationSchema.nullable().prefault(null),
-  xmlSummary: OutputXmlSummarySchema.prefault(() => ({
-    tagContents: {},
-    documents: [],
-    singleOutputFile: null,
-    sourceLocation: null,
-  })),
+  xmlSummary: OutputXmlSummarySchema.prefault(() => ({})),
 });
 
 type RoundData = z.infer<typeof RoundDataSchema>;

--- a/src/agent/output/OutputHandler.ts
+++ b/src/agent/output/OutputHandler.ts
@@ -1,5 +1,6 @@
 // Third-party imports
 import { diff_match_patch } from 'diff-match-patch';
+import { z } from 'zod';
 
 // Local imports - agent
 import type { AgentConfig } from '@agent/core/AgentConfig';
@@ -21,6 +22,7 @@ import {
   flexibleFS,
   pathToLocation,
   getComparablePath,
+  FileLocationSchema,
   type FileLocation,
 } from '@utils/files';
 import { bus } from '@eventBus/ProgressEventBus';
@@ -31,34 +33,32 @@ import { OutputFileProcessor } from './OutputFileProcessor';
 import { XmlOutputManager } from './XmlOutputManager';
 
 import type { IOutputHandler } from './IOutputHandler';
-import type {
-  OutputFileInfo,
-  OutputXmlSummary,
-  RoundFileMapping,
-  RoundOutput,
+import {
+  OutputFileInfoSchema,
+  OutputXmlSummarySchema,
+  type OutputFileInfo,
+  type OutputXmlSummary,
+  type RoundFileMapping,
+  type RoundOutput,
 } from './types';
 
-interface RoundData {
-  outputs: OutputFileInfo[];
-  rawOutput: FileLocation | null;
-  xmlSummary: OutputXmlSummary;
-}
+/** Schema for internal round data storage */
+const RoundDataSchema = z.object({
+  outputs: OutputFileInfoSchema.array().prefault(() => []),
+  rawOutput: FileLocationSchema.nullable().prefault(null),
+  xmlSummary: OutputXmlSummarySchema.prefault(() => ({
+    tagContents: {},
+    documents: [],
+    singleOutputFile: null,
+    sourceLocation: null,
+  })),
+});
 
-/** Default empty XML summary */
-const EMPTY_XML_SUMMARY: OutputXmlSummary = {
-  tagContents: {},
-  documents: [],
-  singleOutputFile: null,
-  sourceLocation: null,
-};
+type RoundData = z.infer<typeof RoundDataSchema>;
 
-/** Create empty RoundData with default values */
+/** Create empty RoundData with schema defaults */
 function createEmptyRoundData(): RoundData {
-  return {
-    outputs: [],
-    rawOutput: null,
-    xmlSummary: { ...EMPTY_XML_SUMMARY },
-  };
+  return RoundDataSchema.parse({});
 }
 
 /** Handles output file processing and validation for agent responses. */
@@ -511,6 +511,6 @@ export class OutputHandler implements IOutputHandler {
 
   public getRoundXmlSummary(round: number): OutputXmlSummary {
     const data = this.rounds.get(round);
-    return data?.xmlSummary ?? EMPTY_XML_SUMMARY;
+    return data?.xmlSummary ?? OutputXmlSummarySchema.parse({});
   }
 }

--- a/src/agent/output/types.ts
+++ b/src/agent/output/types.ts
@@ -37,8 +37,8 @@ export const OutputXmlSummarySchema = z.strictObject({
     .record(z.string(), z.union([z.string(), z.array(z.string())]))
     .prefault(() => ({})),
   documents: z.array(z.string()).prefault(() => []),
-  singleOutputFile: z.string().nullable(),
-  sourceLocation: FileLocationSchema.nullable(),
+  singleOutputFile: z.string().nullable().prefault(null),
+  sourceLocation: FileLocationSchema.nullable().prefault(null),
 });
 export type OutputXmlSummary = z.infer<typeof OutputXmlSummarySchema>;
 

--- a/src/agent/utils/userVars.ts
+++ b/src/agent/utils/userVars.ts
@@ -192,8 +192,10 @@ async function getFileVars(
   // Build collection vars for each category using the centralized config
   for (const prefix of ['INPUT', 'REFERENCE', 'AUXILIARY', 'EDITED']) {
     const cat = FILE_CATEGORIES[prefix];
-    const additionalFiles =
+    const rawAdditionalFiles =
       (agentConfig[cat.multiple] as string[] | undefined) ?? [];
+    // Filter empty strings to prevent file read errors
+    const additionalFiles = rawAdditionalFiles.filter(Boolean);
     const allFiles = getCategoryFiles(agentConfig, prefix);
 
     userVars[`ADDITIONAL_${prefix}S`] =

--- a/src/agent/utils/userVars.ts
+++ b/src/agent/utils/userVars.ts
@@ -121,12 +121,39 @@ function getBasicVars(
   };
 }
 
+/**
+ * File category configuration for consistent handling across the codebase.
+ * Maps category name to { single, multiple } field accessors from AgentConfig.
+ */
+type FileCategoryConfig = {
+  single: keyof AgentConfig;
+  multiple: keyof AgentConfig;
+};
+
+const FILE_CATEGORIES: Record<string, FileCategoryConfig> = {
+  INPUT: { single: 'inputFile', multiple: 'inputFiles' },
+  REFERENCE: { single: 'referenceFile', multiple: 'referenceFiles' },
+  AUXILIARY: { single: 'auxiliaryFile', multiple: 'auxiliaryFiles' },
+  MEDIA: { single: 'mediaFile', multiple: 'mediaFiles' },
+  EDITED: { single: 'editedFile', multiple: 'editedFiles' },
+};
+
 /** Combine a single file with an array, filtering out empty values */
 function combineFiles(
-  single: string | undefined,
-  multiple: string[],
+  single: string | null | undefined,
+  multiple: string[] | undefined,
 ): string[] {
-  return [single, ...multiple].filter((f): f is string => Boolean(f));
+  return [single, ...(multiple ?? [])].filter((f): f is string => Boolean(f));
+}
+
+/** Get combined files for a category from AgentConfig */
+function getCategoryFiles(config: AgentConfig, category: string): string[] {
+  const cat = FILE_CATEGORIES[category];
+  if (!cat) return [];
+  return combineFiles(
+    config[cat.single] as string | null | undefined,
+    config[cat.multiple] as string[] | undefined,
+  );
 }
 
 async function getFileVars(
@@ -136,22 +163,10 @@ async function getFileVars(
 ): Promise<UserVars> {
   const userVars: UserVars = {};
 
-  const allInputFiles = combineFiles(
-    agentConfig.inputFile,
-    agentConfig.inputFiles,
-  );
-  const allReferenceFiles = combineFiles(
-    agentConfig.referenceFile ?? undefined,
-    agentConfig.referenceFiles,
-  );
-  const allAuxiliaryFiles = combineFiles(
-    agentConfig.auxiliaryFile ?? undefined,
-    agentConfig.auxiliaryFiles,
-  );
-  const allMediaFiles = combineFiles(
-    agentConfig.mediaFile ?? undefined,
-    agentConfig.mediaFiles,
-  );
+  const allInputFiles = getCategoryFiles(agentConfig, 'INPUT');
+  const allReferenceFiles = getCategoryFiles(agentConfig, 'REFERENCE');
+  const allAuxiliaryFiles = getCategoryFiles(agentConfig, 'AUXILIARY');
+  const allMediaFiles = getCategoryFiles(agentConfig, 'MEDIA');
 
   // Log file categories being loaded (processed sequentially to preserve UI display order)
   // Skip for tool-use agents as they don't need this UI feedback
@@ -164,48 +179,29 @@ async function getFileVars(
     ]);
   }
 
-  const singleFileMappings = {
-    INPUT: agentConfig.inputFile,
-    REFERENCE: agentConfig.referenceFile,
-    AUXILIARY: agentConfig.auxiliaryFile,
-    EDITED: agentConfig.editedFile,
-  } as Record<string, string | undefined>;
-
-  for (const [prefix, filePath] of Object.entries(singleFileMappings)) {
-    userVars[`${prefix}_FILE`] = filePath;
+  // Build single file vars for each category
+  for (const prefix of ['INPUT', 'REFERENCE', 'AUXILIARY', 'EDITED']) {
+    const cat = FILE_CATEGORIES[prefix];
+    const filePath = agentConfig[cat.single] as string | null | undefined;
+    userVars[`${prefix}_FILE`] = filePath ?? null;
     userVars[`${prefix}_CONTENT`] = filePath
       ? await WorkspaceFS.read(filePath)
       : null;
   }
 
-  const filterStrings = (arr: string[]): string[] =>
-    arr.filter((s): s is string => Boolean(s));
+  // Build collection vars for each category using the centralized config
+  for (const prefix of ['INPUT', 'REFERENCE', 'AUXILIARY', 'EDITED']) {
+    const cat = FILE_CATEGORIES[prefix];
+    const additionalFiles =
+      (agentConfig[cat.multiple] as string[] | undefined) ?? [];
+    const allFiles = getCategoryFiles(agentConfig, prefix);
 
-  // Build all edited files list (editedFile + editedFiles)
-  const allEditedFiles = [
-    agentConfig.editedFile,
-    ...filterStrings(agentConfig.editedFiles ?? []),
-  ].filter((f): f is string => Boolean(f));
-
-  const collectionMappings: Record<string, [string[], string[]]> = {
-    INPUT: [filterStrings(agentConfig.inputFiles), allInputFiles],
-    REFERENCE: [filterStrings(agentConfig.referenceFiles), allReferenceFiles],
-    AUXILIARY: [filterStrings(agentConfig.auxiliaryFiles), allAuxiliaryFiles],
-    EDITED: [filterStrings(agentConfig.editedFiles ?? []), allEditedFiles],
-  };
-
-  for (const [prefix, [additionalFiles, allFiles]] of Object.entries(
-    collectionMappings,
-  )) {
-    const additionalXml =
+    userVars[`ADDITIONAL_${prefix}S`] =
       additionalFiles.length > 0
         ? await getXmlFormatFromFiles(additionalFiles)
         : null;
-    const allXml =
+    userVars[`ALL_${prefix}S`] =
       allFiles.length > 0 ? await getXmlFormatFromFiles(allFiles) : null;
-
-    userVars[`ADDITIONAL_${prefix}S`] = additionalXml;
-    userVars[`ALL_${prefix}S`] = allXml;
     userVars[`LIST_OF_ALL_${prefix}S`] = getListOfFiles(allFiles);
   }
 
@@ -255,18 +251,12 @@ async function logFileCategoriesWithExistence(
   }
 }
 
-/** Result from processing a required file map */
-type RequiredFileMapResult = {
-  vars: UserVars;
-  files: LoadedFileEntry[];
-};
-
 async function processRequiredFileMap(
   fileMap: Record<string, string> | undefined,
   logger: AgentLogger,
   source: string,
   basePath?: string,
-): Promise<RequiredFileMapResult> {
+): Promise<FileVarsResult> {
   if (!fileMap) return { vars: {}, files: [] };
 
   const vars: UserVars = {};
@@ -326,64 +316,44 @@ async function getPatternBasedFileVars(
   const userVars: UserVars = {};
   const files: LoadedFileEntry[] = [];
 
-  if (agentSetting.filePatternsContain) {
-    for (const patternConfig of agentSetting.filePatternsContain) {
-      const pattern = patternConfig.pattern.toLowerCase();
-      const varName = patternConfig.varName;
-      const categories = patternConfig.categories;
+  if (!agentSetting.filePatternsContain) {
+    return { vars: userVars, files };
+  }
 
-      for (const category of categories) {
-        // Type-safe access to agent config properties
-        const categoryValue = agentConfig[
-          category as keyof AgentConfig
-        ] as unknown;
+  for (const {
+    pattern: rawPattern,
+    varName,
+    categories,
+  } of agentSetting.filePatternsContain) {
+    const pattern = rawPattern.toLowerCase();
+    const source = `Pattern '${pattern}'`;
 
-        if (category.endsWith('File')) {
-          if (
-            categoryValue &&
-            typeof categoryValue === 'string' &&
-            categoryValue.toLowerCase().includes(pattern)
-          ) {
-            const ok = await setVarFromFile(
-              categoryValue,
-              varName,
-              userVars,
-              logger,
-              `Pattern '${pattern}'`,
-            );
-            files.push({
-              path: categoryValue,
-              ok,
-              varName,
-              source: `Pattern '${pattern}'`,
-            });
-          }
-        } else if (category.endsWith('Files')) {
-          if (categoryValue && Array.isArray(categoryValue)) {
-            for (const file of categoryValue) {
-              if (
-                typeof file === 'string' &&
-                file.toLowerCase().includes(pattern)
-              ) {
-                const ok = await setVarFromFile(
-                  file,
-                  varName,
-                  userVars,
-                  logger,
-                  `Pattern '${pattern}'`,
-                );
-                files.push({
-                  path: file,
-                  ok,
-                  varName,
-                  source: `Pattern '${pattern}'`,
-                });
-                if (ok) {
-                  break;
-                }
-              }
-            }
-          }
+    // Helper to try setting a var from a file that matches the pattern
+    async function trySetVar(filePath: string): Promise<boolean> {
+      if (!filePath.toLowerCase().includes(pattern)) return false;
+      const ok = await setVarFromFile(
+        filePath,
+        varName,
+        userVars,
+        logger,
+        source,
+      );
+      files.push({ path: filePath, ok, varName, source });
+      return ok;
+    }
+
+    // Check each category for matching files
+    for (const category of categories) {
+      const categoryValue = agentConfig[
+        category as keyof AgentConfig
+      ] as unknown;
+
+      if (category.endsWith('File') && typeof categoryValue === 'string') {
+        await trySetVar(categoryValue);
+      } else if (category.endsWith('Files') && Array.isArray(categoryValue)) {
+        // Try each file until one succeeds
+        for (const file of categoryValue) {
+          if (typeof file === 'string' && (await trySetVar(file))) break;
         }
       }
     }

--- a/src/common/errors/schemas.ts
+++ b/src/common/errors/schemas.ts
@@ -28,26 +28,29 @@ import { z } from 'zod';
 /**
  * Stream diagnostics for debugging Anthropic streaming failures.
  * Shows what was received before the stream errored.
+ *
+ * Uses prefault() for sensible defaults - allows partial creation
+ * while ensuring all fields are present in output.
  */
 export const StreamDiagnosticsSchema = z.object({
   /** Characters of thinking content received */
-  thinkingChars: z.number(),
+  thinkingChars: z.number().prefault(0),
   /** Characters of text content received */
-  textChars: z.number(),
+  textChars: z.number().prefault(0),
   /** Characters of tool input JSON received */
-  toolInputChars: z.number(),
+  toolInputChars: z.number().prefault(0),
   /** Block types seen (e.g., ['thinking', 'text']) */
-  blockTypesSeen: z.array(z.string()),
+  blockTypesSeen: z.array(z.string()).prefault([]),
   /** Total events processed */
-  eventsProcessed: z.number(),
+  eventsProcessed: z.number().prefault(0),
   /** Last event type (e.g., 'content_block_delta') */
-  lastEventType: z.string().nullable(),
+  lastEventType: z.string().nullable().prefault(null),
   /** Seconds since stream started */
-  elapsedSecs: z.number(),
+  elapsedSecs: z.number().prefault(0),
   /** Seconds since last event (stall detection) */
-  secsSinceLastEvent: z.number(),
+  secsSinceLastEvent: z.number().prefault(0),
   /** Whether handler was finalized */
-  finalized: z.boolean(),
+  finalized: z.boolean().prefault(false),
 });
 
 export type StreamDiagnostics = z.infer<typeof StreamDiagnosticsSchema>;


### PR DESCRIPTION
- Extract FILE_CATEGORIES config for centralized file handling in userVars.ts
- Replace repetitive combineFiles calls with getCategoryFiles helper
- Consolidate collection and single file mapping loops
- Remove redundant RequiredFileMapResult type alias (reuse FileVarsResult)
- Simplify getPatternBasedFileVars with inner trySetVar helper
- Add prefault() defaults to StreamDiagnosticsSchema fields
- Extract EMPTY_XML_SUMMARY constant and createEmptyRoundData factory
- Apply Prettier formatting to long function signatures

https://claude.ai/code/session_01Mpoaif5SusGmPEF2hWBiju

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors file and schema handling for clarity and safer defaults.
> 
> - Centralizes file category config via `FILE_CATEGORIES` with `getCategoryFiles`/`combineFiles`, consolidating single/collection var building and pattern-based file matching in `userVars.ts`
> - Simplifies required file handling by reusing `FileVarsResult` and parallelizing map processing; improves logging order while checking existence in parallel
> - Introduces `RoundDataSchema` with defaults and `createEmptyRoundData`; `OutputHandler` now relies on Zod defaults and `OutputXmlSummarySchema.parse({})` for safe fallbacks
> - Adds `prefault()` defaults across `OutputXmlSummarySchema` and `StreamDiagnosticsSchema` for robust partial creations
> - Minor internal cleanup and formatting; no new external APIs
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c4a645e70328abf847e95e45d2fd7ed2eccca31b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->