### PR TITLE
Improves responsiveness and reduces unnecessary work in the progress view.

### DIFF
--- a/src/agent/core/AgentWorkspaceState.ts
+++ b/src/agent/core/AgentWorkspaceState.ts
@@ -345,11 +345,22 @@ export class TodoState {
 
   /**
    * Update the entire todo list.
-   * Triggers the onUpdate callback if set.
+   * Only triggers callback if todos actually changed.
    */
   updateTodos(todos: TodoItem[]): void {
+    if (this._todosEqual(this._todos, todos)) return;
     this._todos = todos;
     this._onUpdate?.(todos);
+  }
+
+  private _todosEqual(a: TodoItem[], b: TodoItem[]): boolean {
+    if (a.length !== b.length) return false;
+    for (let i = 0; i < a.length; i++) {
+      if (a[i].content !== b[i].content || a[i].status !== b[i].status) {
+        return false;
+      }
+    }
+    return true;
   }
 
   /**

--- a/src/agent/core/AgentWorkspaceState.ts
+++ b/src/agent/core/AgentWorkspaceState.ts
@@ -356,7 +356,8 @@ export class TodoState {
   private _todosEqual(a: TodoItem[], b: TodoItem[]): boolean {
     if (a.length !== b.length) return false;
     for (let i = 0; i < a.length; i++) {
-      if (a[i].content !== b[i].content || a[i].status !== b[i].status) {
+      const ai = a[i], bi = b[i];
+      if (ai.content !== bi.content || ai.status !== bi.status || ai.activeForm !== bi.activeForm) {
         return false;
       }
     }

--- a/src/agent/core/AgentWorkspaceState.ts
+++ b/src/agent/core/AgentWorkspaceState.ts
@@ -357,6 +357,7 @@ export class TodoState {
     if (a.length !== b.length) return false;
     for (let i = 0; i < a.length; i++) {
       const ai = a[i], bi = b[i];
+      if (!ai || !bi) return false; // Guard against sparse arrays
       if (ai.content !== bi.content || ai.status !== bi.status || ai.activeForm !== bi.activeForm) {
         return false;
       }

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -457,8 +457,7 @@ export class ProgressEventHandler {
       this.webviewUpdater.updateAll(this.state, statusesForRefresh);
     } else {
       // Existing stream - targeted status update only
-      const logs = this.state.streamTabs.getMessages(streamId);
-      const lastTimestamp = logs.at(-1)?.timestamp;
+      const lastTimestamp = this.state.streamTabs.getLastTimestamp(streamId);
       this.webviewUpdater.updateStreamStatus(streamId, status, lastTimestamp);
     }
   }

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -196,13 +196,13 @@ export class ProgressEventHandler {
           this.sendInstructionUpdate(streamId);
         }
 
-        // Update stream tabs only when filter changed (affects visible streams).
-        // Label updates (from inputFile/agent) happen on next stream switch -
-        // no need to rebuild all tabs while user is focused on content.
+        // Update stream tabs when filter changes or active stream gets metadata.
+        // Filter change affects visible streams; active stream update ensures
+        // tab label reflects latest taskState (agent name, input file, etc.).
         if (this.webviewUpdater.isAvailable()) {
           const filterChanged =
             this.state.agentCategoryFilter !== previousFilter;
-          if (filterChanged) {
+          if (filterChanged || isActiveStream) {
             this.webviewUpdater.updateAll(
               this.state,
               StreamStatusService.getAll(),

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -151,12 +151,8 @@ export class ProgressEventHandler {
     // Update stream tabs list (required to set activeStream in frontend)
     this.webviewUpdater.updateAll(this.state, StreamStatusService.getAll());
 
-    // Refresh stream content (logs, groups, metadata, status, todos)
-    // Note: refreshStreamSurface includes status update, so no separate setStreamStatus needed
-    const activeRunId = this.refreshStreamSurface(streamId, {
-      updateInstruction: false,
-    });
-    this.sendInstructionUpdate(streamId, activeRunId);
+    // Refresh stream content: status first (critical), then logs, then todos/instruction
+    this.refreshStreamSurface(streamId, { updateInstruction: true });
   }
 
   private handleUpdateStreamStatus = (
@@ -200,13 +196,13 @@ export class ProgressEventHandler {
           this.sendInstructionUpdate(streamId);
         }
 
-        // Update stream tabs when:
-        // 1. Filter changed (affects visible streams)
-        // 2. Active stream's task state changed (label needs inputFile, agent, etc.)
+        // Update stream tabs only when filter changed (affects visible streams).
+        // Label updates (from inputFile/agent) happen on next stream switch -
+        // no need to rebuild all tabs while user is focused on content.
         if (this.webviewUpdater.isAvailable()) {
           const filterChanged =
             this.state.agentCategoryFilter !== previousFilter;
-          if (filterChanged || isActiveStream) {
+          if (filterChanged) {
             this.webviewUpdater.updateAll(
               this.state,
               StreamStatusService.getAll(),
@@ -335,6 +331,11 @@ export class ProgressEventHandler {
    * Frontend detects stream switches using its lastRenderedStream tracking
    * and decides whether to do full rebuild or incremental update.
    *
+   * NOTE: Status/todos/instruction are sent as separate small messages rather
+   * than batched into UPDATE_LOGS. This ensures critical UI feedback (status)
+   * isn't blocked by potentially large log payloads, and provides fault isolation
+   * if the large payload has issues.
+   *
    * @param stream - Stream to refresh, or empty string to clear all content.
    * @param options.updateInstruction - If true (default), also update instruction panel.
    * @returns The resolved active run ID, useful for callers that need to pass it
@@ -373,8 +374,8 @@ export class ProgressEventHandler {
     const todos = this.state.getTodos(stream) ?? [];
     const status = StreamStatusService.get(stream) ?? STREAM_STATUS.READY;
 
-    // Clear buffer before update to prevent race condition
-    this.pendingTaskGroups.delete(stream);
+    // NOTE: pendingTaskGroups already cleared by replayPendingTaskGroups() before this call.
+    // NOTE: Status already sent via updateAll() → UPDATE_STREAMS → handleUpdateStreams.
 
     // Send primary content update (includes all run-scoped data in single message)
     this.webviewUpdater.updateLogContent(stream, messages, groups, {
@@ -386,9 +387,8 @@ export class ProgressEventHandler {
       contextState,
     });
 
-    // Send ephemeral state
+    // Send ephemeral state separately (small, independent messages)
     this.webviewUpdater.updateTodos(stream, todos);
-    this.webviewUpdater.updateStatus(status);
 
     if (updateInstruction) {
       this.sendInstructionUpdate(stream, activeRunId);
@@ -424,17 +424,17 @@ export class ProgressEventHandler {
    * Set the status for a specific stream synchronously.
    * Updates StreamStatusService (single source of truth) and triggers webview updates.
    *
-   * @param streamId - Stream identifier
-   * @param status - New status to set
-   * @param previousStatus - Previous status from event payload (undefined for direct calls)
+   * For NEW streams: full refresh (adds stream to tab list)
+   * For EXISTING streams: targeted status update only (no rebuild)
+   *
+   * Tab reordering is driven by log timestamps, not status changes.
+   * Status is just a visual indicator - no need to rebuild tabs for it.
    */
   setStreamStatus(
     streamId: StreamTabId,
     status: StreamStatus,
     previousStatus?: StreamStatus,
   ): void {
-    // For direct calls (no previousStatus), update service without emitting.
-    // Event-triggered calls already mutated the service before emitting.
     const isDirectCall = previousStatus === undefined;
     if (isDirectCall) {
       StreamStatusService.set(streamId, status, { emit: false });
@@ -444,30 +444,19 @@ export class ProgressEventHandler {
       return;
     }
 
-    // Resolve previous status: from event payload or read current (for direct calls).
-    // Treat READY as "no previous status" for ordering purposes.
-    const prevStatus = previousStatus ?? StreamStatusService.get(streamId);
-    const effectivePrevious =
-      prevStatus === STREAM_STATUS.READY ? undefined : prevStatus;
-
     const streamExists = this.state.streamTabs.has(streamId);
-    const needsFullRefresh =
-      !streamExists ||
-      (this.state.streamSortOrder === 'time' &&
-        StreamStatusService.mightAffectTabOrder(effectivePrevious, status));
 
-    if (needsFullRefresh) {
-      // Ensure filter matches stream's category to keep it visible (e.g., when resuming)
+    if (!streamExists) {
+      // New stream - full refresh to add it to tab list
       const streamCategory = this.getStreamCategory(streamId);
       if (streamCategory) {
         this.maybeUpdateFilterForCategory(streamCategory);
       }
-
       const statusesForRefresh = StreamStatusService.getAll();
       statusesForRefresh.set(streamId, status);
       this.webviewUpdater.updateAll(this.state, statusesForRefresh);
     } else {
-      // Targeted update - send only status change for this stream
+      // Existing stream - targeted status update only
       const logs = this.state.streamTabs.getMessages(streamId);
       const lastTimestamp = logs.at(-1)?.timestamp;
       this.webviewUpdater.updateStreamStatus(streamId, status, lastTimestamp);
@@ -549,12 +538,9 @@ export class ProgressEventHandler {
     }
 
     // Coordinated update: UPDATE_STREAMS first (sets frontend activeStream),
-    // then UPDATE_LOGS (requires activeStream to be set)
+    // then stream content (requires activeStream to be set)
     this.webviewUpdater.updateAll(this.state, StreamStatusService.getAll());
-    const activeRunId = this.refreshStreamSurface(streamId, {
-      updateInstruction: false,
-    });
-    this.sendInstructionUpdate(streamId, activeRunId);
+    this.refreshStreamSurface(streamId, { updateInstruction: true });
   }
 
   /**

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -374,7 +374,11 @@ export class ProgressEventHandler {
     const todos = this.state.getTodos(stream) ?? [];
     const status = StreamStatusService.get(stream) ?? STREAM_STATUS.READY;
 
-    // NOTE: pendingTaskGroups already cleared by replayPendingTaskGroups() before this call.
+    // Clear pendingTaskGroups since we're doing a full refresh from state.taskGroups.
+    // This handles both: (1) processSetActiveStream flow (replayPendingTaskGroups called first),
+    // (2) updateWebview flow (called directly without replay, groups already in state).
+    this.pendingTaskGroups.delete(stream);
+
     // NOTE: Status already sent via updateAll() → UPDATE_STREAMS → handleUpdateStreams.
 
     // Send primary content update (includes all run-scoped data in single message)

--- a/src/progressView/events/UsageEventHandlers.ts
+++ b/src/progressView/events/UsageEventHandlers.ts
@@ -1,7 +1,8 @@
 /**
  * Usage event handlers for progress view.
+ * Handles: updateStreamUsage, updateContextState.
  *
- * Handles usage events: updateStreamUsage, updateContextState.
+ * These events fire per-round (not per-chunk), so direct sending is fine.
  */
 import type {
   ProgressEventBusLike,
@@ -13,9 +14,6 @@ import {
   type EventHandlerContext,
 } from './EventHandlerContext';
 
-/**
- * Register usage event handlers on the event bus.
- */
 export function registerUsageEventHandlers(
   bus: ProgressEventBusLike,
   ctx: EventHandlerContext,
@@ -37,47 +35,31 @@ function handleUpdateStreamUsage(
   ctx: EventHandlerContext,
   { streamId, usage, storageKey }: ProgressEventPayloads['updateStreamUsage'],
 ): void {
-  withEventErrorHandling(
-    'UsageEvents',
-    'failed to handle updateStreamUsage',
-    async () => {
-      // usage is already typed as TokenUsageStats from the event payload
-      const accumulatedUsage = await ctx.state.usageStats.setRunUsage(
-        streamId,
-        storageKey,
-        usage,
-      );
+  withEventErrorHandling('UsageEvents', 'updateStreamUsage', async () => {
+    const accumulated = await ctx.state.usageStats.setRunUsage(
+      streamId,
+      storageKey,
+      usage,
+    );
 
-      // For tool-use sessions (no task groups), set active run ID from usage
-      if (!ctx.state.getActiveRunId(streamId)) {
-        ctx.state.setActiveRunId(streamId, storageKey);
-      }
+    if (!ctx.state.getActiveRunId(streamId)) {
+      ctx.state.setActiveRunId(streamId, storageKey);
+    }
 
-      // Broadcast to webview - frontend decides which run to display
-      if (isWebviewAvailable(ctx) && accumulatedUsage) {
-        ctx.webviewUpdater.updateRunUsage(
-          streamId,
-          storageKey,
-          accumulatedUsage,
-        );
-      }
-    },
-  );
+    if (accumulated && isWebviewAvailable(ctx)) {
+      ctx.webviewUpdater.updateRunUsage(streamId, storageKey, accumulated);
+    }
+  });
 }
 
 function handleUpdateContextState(
   ctx: EventHandlerContext,
   { streamId, contextState }: ProgressEventPayloads['updateContextState'],
 ): void {
-  withEventErrorHandling(
-    'UsageEvents',
-    'failed to handle updateContextState',
-    () => {
-      ctx.state.setContextState(streamId, contextState);
-      // Broadcast to webview - frontend decides which run to display
-      if (isWebviewAvailable(ctx)) {
-        ctx.webviewUpdater.updateContextState(streamId, contextState);
-      }
-    },
-  );
+  withEventErrorHandling('UsageEvents', 'updateContextState', () => {
+    ctx.state.setContextState(streamId, contextState);
+    if (isWebviewAvailable(ctx)) {
+      ctx.webviewUpdater.updateContextState(streamId, contextState);
+    }
+  });
 }

--- a/src/progressView/managers/StreamTabsManager.ts
+++ b/src/progressView/managers/StreamTabsManager.ts
@@ -18,7 +18,7 @@ export class StreamTabsManager extends PersistentMapManager<
   StreamTabId,
   LogMessageData[]
 > {
-  private static readonly MAX_MESSAGE_HISTORY = 500;
+  private static readonly MAX_MESSAGE_HISTORY = 1000;
   private readonly logger: AgentLogger;
 
   constructor(storage?: StateStorage) {

--- a/src/progressView/managers/StreamTabsManager.ts
+++ b/src/progressView/managers/StreamTabsManager.ts
@@ -18,7 +18,7 @@ export class StreamTabsManager extends PersistentMapManager<
   StreamTabId,
   LogMessageData[]
 > {
-  private static readonly MAX_MESSAGE_HISTORY = 1000;
+  private static readonly MAX_MESSAGE_HISTORY = 500;
   private readonly logger: AgentLogger;
 
   constructor(storage?: StateStorage) {

--- a/src/progressView/managers/StreamTabsManager.ts
+++ b/src/progressView/managers/StreamTabsManager.ts
@@ -81,6 +81,24 @@ export class StreamTabsManager extends PersistentMapManager<
   }
 
   /**
+   * Get first timestamp for a stream (for sorting by creation time).
+   * More efficient than getMessages() when only timestamp is needed.
+   */
+  getFirstTimestamp(stream: StreamTabId): number | undefined {
+    const messages = this.items.get(stream);
+    return messages?.[0]?.timestamp;
+  }
+
+  /**
+   * Get last timestamp for a stream (for sorting by last activity).
+   * More efficient than getMessages() when only timestamp is needed.
+   */
+  getLastTimestamp(stream: StreamTabId): number | undefined {
+    const messages = this.items.get(stream);
+    return messages?.at(-1)?.timestamp;
+  }
+
+  /**
    * Update an existing message by ID.
    * Returns true if message was found and updated, false otherwise.
    *

--- a/src/progressView/managers/WebviewUpdater.ts
+++ b/src/progressView/managers/WebviewUpdater.ts
@@ -31,6 +31,10 @@ import type { TodoItem, UpdateTaskGroupPayload } from '@eventBus/schemas';
 /**
  * Extra content to include with log updates.
  * All fields are optional to support incremental updates.
+ *
+ * NOTE: Status/todos/instruction are sent as separate messages rather than
+ * batched here. This ensures critical UI feedback (status) isn't blocked by
+ * potentially large log payloads and provides fault isolation.
  */
 export interface LogContentExtras {
   /** Instructions by run ID */

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -50,7 +50,6 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     super();
     this._entryFormatter = getSharedLogEntryFormatter();
     this._lastFollowupState = null;
-    this._renderGeneration = 0;
     this._handlers = {
       ...createThemeHandlers(),
       ...this._createHandlers(),
@@ -317,42 +316,6 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       });
     }
     appendFormatted(logContent, formatted);
-  }
-
-  /**
-   * Render messages in chunks to keep UI responsive.
-   * First chunk renders immediately, remaining chunks use requestAnimationFrame.
-   * Uses _renderGeneration to cancel stale renders on stream switch.
-   */
-  _renderMessagesChunked(messages, logContent) {
-    const CHUNK_SIZE = 50;
-    const generation = ++this._renderGeneration;
-
-    if (messages.length <= CHUNK_SIZE) {
-      // Small list - render synchronously
-      messages.forEach((msg) => this._renderLogMessage(msg, logContent));
-      scrollToBottom(logContent);
-      return;
-    }
-
-    // Large list - render first chunk immediately, rest in frames
-    let i = 0;
-    const renderChunk = () => {
-      // Abort if a newer render started (stream switch)
-      if (this._renderGeneration !== generation) return;
-
-      const end = Math.min(i + CHUNK_SIZE, messages.length);
-      while (i < end) {
-        this._renderLogMessage(messages[i], logContent);
-        i++;
-      }
-      if (i < messages.length) {
-        requestAnimationFrame(renderChunk);
-      } else {
-        scrollToBottom(logContent);
-      }
-    };
-    renderChunk();
   }
 
   /**
@@ -647,8 +610,10 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       dom.taskGroups.showRun(null);
     }
 
-    // Render messages in chunks to keep UI responsive during long conversations
-    this._renderMessagesChunked(sortedMessages, logContent);
+    sortedMessages.forEach((msg) => {
+      this._renderLogMessage(msg, logContent);
+    });
+    scrollToBottom(logContent);
 
     // Use validated run ID from state (set earlier via setActiveRunId after validation)
     const activeRunId = state.resolveActiveRunId(message.stream);

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -281,44 +281,6 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
   }
 
   /**
-   * Render a log message to its appropriate container.
-   * Attempts to append to group first, falls back to main log content.
-   * @param {Object} msg - The log message to render
-   * @param {HTMLElement} logContent - The main log content container
-   * @returns {void} No return value; dom.logEntries.append returns truthy on success
-   */
-  _renderLogMessage(msg, logContent) {
-    // dom.logEntries.append returns true if message was added to its group container
-    if (msg.groupId) {
-      const wasAppendedToGroup = dom.logEntries.append(msg);
-      // DIAGNOSTIC: Track grouped message handling
-      if (!wasAppendedToGroup) {
-        console.warn(
-          '[_renderLogMessage] Message has groupId but no container:',
-          {
-            messageType: msg.messageType,
-            id: msg.id,
-            groupId: msg.groupId,
-          },
-        );
-      }
-      if (wasAppendedToGroup) return;
-    }
-    const formatted = this._entryFormatter.format(msg);
-    // DIAGNOSTIC: Log if formatter returns null
-    if (!formatted) {
-      console.warn('[_renderLogMessage] Formatter returned null for:', {
-        messageType: msg.messageType,
-        id: msg.id,
-        hasText: Boolean(msg.text),
-        hasData: Boolean(msg.data),
-        groupId: msg.groupId,
-      });
-    }
-    appendFormatted(logContent, formatted);
-  }
-
-  /**
    * Update run-scoped metadata (instructions, usage, files, missing outputs, context) from message.
    * Shared by handleUpdateLogs and _handleIncrementalUpdate to avoid duplication.
    */

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -630,10 +630,15 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       }
     }
 
-    // Append grouped messages to their containers
+    // Append grouped messages to their containers (fallback to main log if group missing)
     for (const [groupId, frag] of groupedFragments) {
       const container = dom.logEntries.getGroupContainer(groupId);
-      if (container) container.appendChild(frag);
+      if (container) {
+        container.appendChild(frag);
+      } else {
+        // Group container not found - append to main log as fallback
+        logContent.appendChild(frag);
+      }
     }
 
     // Append ungrouped messages to main log
@@ -1253,8 +1258,8 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       }
     }
 
-    // Skip if nothing changed
-    const key = `${activeStream}|${streamStatus}|${category}|${fileCount}|${instructionPreview ?? ''}`;
+    // Skip if nothing changed (use \0 separator to avoid collision with user content)
+    const key = [activeStream, streamStatus, category, fileCount, instructionPreview ?? ''].join('\0');
     if (key === this._lastFollowupState) return;
     this._lastFollowupState = key;
 

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -50,6 +50,7 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     super();
     this._entryFormatter = getSharedLogEntryFormatter();
     this._lastFollowupState = null;
+    this._renderGeneration = 0;
     this._handlers = {
       ...createThemeHandlers(),
       ...this._createHandlers(),
@@ -316,6 +317,42 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       });
     }
     appendFormatted(logContent, formatted);
+  }
+
+  /**
+   * Render messages in chunks to keep UI responsive.
+   * First chunk renders immediately, remaining chunks use requestAnimationFrame.
+   * Uses _renderGeneration to cancel stale renders on stream switch.
+   */
+  _renderMessagesChunked(messages, logContent) {
+    const CHUNK_SIZE = 50;
+    const generation = ++this._renderGeneration;
+
+    if (messages.length <= CHUNK_SIZE) {
+      // Small list - render synchronously
+      messages.forEach((msg) => this._renderLogMessage(msg, logContent));
+      scrollToBottom(logContent);
+      return;
+    }
+
+    // Large list - render first chunk immediately, rest in frames
+    let i = 0;
+    const renderChunk = () => {
+      // Abort if a newer render started (stream switch)
+      if (this._renderGeneration !== generation) return;
+
+      const end = Math.min(i + CHUNK_SIZE, messages.length);
+      while (i < end) {
+        this._renderLogMessage(messages[i], logContent);
+        i++;
+      }
+      if (i < messages.length) {
+        requestAnimationFrame(renderChunk);
+      } else {
+        scrollToBottom(logContent);
+      }
+    };
+    renderChunk();
   }
 
   /**
@@ -610,10 +647,8 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       dom.taskGroups.showRun(null);
     }
 
-    sortedMessages.forEach((msg) => {
-      this._renderLogMessage(msg, logContent);
-    });
-    scrollToBottom(logContent);
+    // Render messages in chunks to keep UI responsive during long conversations
+    this._renderMessagesChunked(sortedMessages, logContent);
 
     // Use validated run ID from state (set earlier via setActiveRunId after validation)
     const activeRunId = state.resolveActiveRunId(message.stream);

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -514,7 +514,8 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       this._focusFollowUpIfWaiting(streamStatus);
     }
 
-    this._refreshActiveRunPanels();
+    // NOTE: _refreshActiveRunPanels() NOT called here - UPDATE_LOGS always follows
+    // and calls it with the correct activeRunId. Calling here would be redundant.
     this._updateFollowupSection();
   }
 

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -610,20 +610,35 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       dom.taskGroups.showRun(null);
     }
 
-    // Batch ungrouped messages via DocumentFragment to avoid layout thrashing
-    const fragment = document.createDocumentFragment();
+    // Batch all messages via DocumentFragment to avoid layout thrashing
+    const ungroupedFragment = document.createDocumentFragment();
+    const groupedFragments = new Map(); // groupId → fragment
+
     for (const msg of sortedMessages) {
+      const formatted = this._entryFormatter.format(msg);
+      if (!formatted) continue;
+
       if (msg.groupId) {
-        // Grouped messages go to their group container
-        dom.logEntries.append(msg);
+        let frag = groupedFragments.get(msg.groupId);
+        if (!frag) {
+          frag = document.createDocumentFragment();
+          groupedFragments.set(msg.groupId, frag);
+        }
+        appendFormatted(frag, formatted);
       } else {
-        // Ungrouped messages batch into fragment
-        const formatted = this._entryFormatter.format(msg);
-        if (formatted) appendFormatted(fragment, formatted);
+        appendFormatted(ungroupedFragment, formatted);
       }
     }
-    if (fragment.childNodes.length > 0) {
-      logContent.appendChild(fragment);
+
+    // Append grouped messages to their containers
+    for (const [groupId, frag] of groupedFragments) {
+      const container = dom.logEntries.getGroupContainer(groupId);
+      if (container) container.appendChild(frag);
+    }
+
+    // Append ungrouped messages to main log
+    if (ungroupedFragment.childNodes.length > 0) {
+      logContent.appendChild(ungroupedFragment);
     }
     scrollToBottom(logContent);
 

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -49,6 +49,7 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
   constructor() {
     super();
     this._entryFormatter = getSharedLogEntryFormatter();
+    this._lastFollowupState = null;
     this._handlers = {
       ...createThemeHandlers(),
       ...this._createHandlers(),
@@ -1190,22 +1191,22 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
   /**
    * Update followup section visibility based on current stream state.
    * Called when stream status changes or streams are updated.
+   * Skips update if nothing relevant changed.
    */
   _updateFollowupSection() {
     const activeStream = state.activeStream;
     if (!activeStream) {
-      dom.followupSection?.updateForStream?.(null);
+      if (this._lastFollowupState !== null) {
+        this._lastFollowupState = null;
+        dom.followupSection?.updateForStream?.(null);
+      }
       return;
     }
 
     const streamStatus = state.streamStatuses.get(activeStream);
     const category = state.activeAgentCategory || 'workflow';
-    const hasOutputFiles = this._hasOutputFilesForActiveStream();
-
-    // Extract agent name from stream ID (format: "agentName@timestamp")
     const agentName = activeStream.split('@')[0] || activeStream;
 
-    // Get instruction text for workflow context
     const runId = state.resolveActiveRunId(activeStream);
     const instruction = runId
       ? state.getRunInstruction(activeStream, runId)
@@ -1215,42 +1216,28 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
         (instruction.text.length > 100 ? '...' : '')
       : null;
 
-    // Count output files
+    // Count files in single pass (also determines hasOutputFiles)
     const files = runId ? state.getRunFiles(activeStream, runId) : null;
-    const fileCount = files
-      ? Object.values(files).reduce(
-          (sum, roundFiles) =>
-            sum + (Array.isArray(roundFiles) ? roundFiles.length : 0),
-          0,
-        )
-      : 0;
+    let fileCount = 0;
+    if (files) {
+      for (const roundFiles of Object.values(files)) {
+        if (Array.isArray(roundFiles)) fileCount += roundFiles.length;
+      }
+    }
+
+    // Skip if nothing changed
+    const key = `${activeStream}|${streamStatus}|${category}|${fileCount}|${instructionPreview ?? ''}`;
+    if (key === this._lastFollowupState) return;
+    this._lastFollowupState = key;
 
     dom.followupSection?.updateForStream?.({
       agentCategory: category,
       status: streamStatus,
-      hasOutputFiles,
+      hasOutputFiles: fileCount > 0,
       agentName,
       instructionPreview,
       fileCount,
     });
-  }
-
-  /**
-   * Check if the active stream has output files.
-   */
-  _hasOutputFilesForActiveStream() {
-    const activeStream = state.activeStream;
-    if (!activeStream) return false;
-
-    const runId = state.resolveActiveRunId(activeStream);
-    if (!runId) return false;
-
-    const files = state.getRunFiles(activeStream, runId);
-    if (!files) return false;
-
-    return Object.values(files).some(
-      (roundFiles) => Array.isArray(roundFiles) && roundFiles.length > 0,
-    );
   }
 }
 

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -219,20 +219,21 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
    * @param {string|null} stream - The stream to clear, or null to clear all
    */
   _clearRunScopedState(stream) {
-    // Stream-scoped clear methods accept optional stream param (null = clear all)
-    state.clearRunInstructions(stream);
-    state.clearRunFiles(stream);
-    state.clearRunMissingOutputs(stream);
-    state.clearRunUsage(stream, null);
-    state.clearContextState(stream);
-
     if (stream) {
+      // Single stream: use batched clear for run-scoped data
+      state.clearStreamRunData(stream);
+      state.clearContextState(stream);
       state.clearExecutionIdAvailability(stream);
-      state.clearActiveRun(stream);
       state.clearTodos(stream);
       state.clearQueuedFollowUps(stream);
       state.clearFollowUpText(stream);
     } else {
+      // All streams: individual clear methods that support null
+      state.clearRunInstructions(null);
+      state.clearRunFiles(null);
+      state.clearRunMissingOutputs(null);
+      state.clearRunUsage(null, null);
+      state.clearContextState(null);
       state.resetExecutionIdAvailability();
       state.clearAllActiveRuns();
       state.clearAllTodos();
@@ -499,19 +500,9 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       state.clearAllQueuedFollowUps();
       state.clearAllFollowUpText();
     } else {
-      // Clear content immediately when switching streams to prevent stale display.
-      // handleUpdateLogs will repopulate with correct content, but if the new stream
-      // is empty, no logs message arrives - so we must clear proactively here.
-      // Use lastRenderedStream (not previousStream) to detect if displayed content
-      // differs from the new stream - handles cases where previousStream is unset.
-      if (
-        state.lastRenderedStream &&
-        state.lastRenderedStream !== message.activeStream
-      ) {
-        const logContent = document.getElementById(ELEMENT_IDS.LOG_CONTENT);
-        if (logContent) logContent.innerHTML = '';
-        state.lastRenderedStream = '';
-      }
+      // NOTE: Content clearing is handled by handleUpdateLogs which always follows.
+      // Backend always sends UPDATE_LOGS after UPDATE_STREAMS (even for empty streams).
+      // Clearing here would be redundant - we'd clear twice.
 
       const streamStatus = state.streamStatuses.get(message.activeStream);
       dom.status.update(streamStatus || STREAM_STATUS.STOPPED);
@@ -574,16 +565,11 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
 
     // Full rebuild path: clear and rebuild
     const logContent = document.getElementById(ELEMENT_IDS.LOG_CONTENT);
+    const previousRunId = state.getActiveRunId(message.stream);
     pendingLogUpdates.clear();
     dom.taskGroups.clear();
     state.taskGroups.clear();
-    state.clearRunInstructions(message.stream);
-    state.clearRunFiles(message.stream);
-    state.clearRunMissingOutputs(message.stream);
-    state.clearRunUsage(message.stream);
-    state.clearPendingInstruction(state.activeStream);
-    const previousRunId = state.getActiveRunId(message.stream);
-    state.clearActiveRun(message.stream);
+    state.clearStreamRunData(message.stream); // Batched clear of all run-scoped data
     logContent.innerHTML = '';
     const groups = message.groups ?? [];
 

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -501,10 +501,11 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       state.clearAllQueuedFollowUps();
       state.clearAllFollowUpText();
     } else {
-      // Clear content when switching streams to prevent stale display.
+      // Handle stream switch: clear stale content, then repopulate from cache.
       // While UPDATE_LOGS typically follows UPDATE_STREAMS, some code paths
       // (e.g., setStreamStatus for new streams with filter change) only send
-      // UPDATE_STREAMS. Clear proactively so stale content doesn't persist.
+      // UPDATE_STREAMS. We clear first, then repopulate from cached state.
+      // If UPDATE_LOGS arrives later, it will rebuild with fresh data.
       if (
         state.lastRenderedStream &&
         state.lastRenderedStream !== message.activeStream
@@ -512,8 +513,9 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
         const logContent = document.getElementById(ELEMENT_IDS.LOG_CONTENT);
         if (logContent) logContent.innerHTML = '';
         state.lastRenderedStream = '';
-        // Clear panels to prevent stale data when UPDATE_LOGS doesn't follow
-        this._clearActivePanels();
+        // Repopulate panels from cached state for the new stream
+        const activeRunId = state.resolveActiveRunId(message.activeStream);
+        this._refreshActiveRunPanels(activeRunId);
       }
 
       const streamStatus = state.streamStatuses.get(message.activeStream);
@@ -654,7 +656,8 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       if (container) {
         container.appendChild(frag);
       } else {
-        // Fallback: append to main log if container was removed
+        // Fallback: append to main log if container was removed (race condition)
+        console.warn(`[messageHandlers] Group container removed during batch: ${groupId}`);
         logContent.appendChild(frag);
       }
     }

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -512,6 +512,8 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
         const logContent = document.getElementById(ELEMENT_IDS.LOG_CONTENT);
         if (logContent) logContent.innerHTML = '';
         state.lastRenderedStream = '';
+        // Clear panels to prevent stale data when UPDATE_LOGS doesn't follow
+        this._clearActivePanels();
       }
 
       const streamStatus = state.streamStatuses.get(message.activeStream);
@@ -523,8 +525,6 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       this._focusFollowUpIfWaiting(streamStatus);
     }
 
-    // NOTE: _refreshActiveRunPanels() NOT called here - UPDATE_LOGS always follows
-    // and calls it with the correct activeRunId. Calling here would be redundant.
     this._updateFollowupSection();
   }
 

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -610,9 +610,21 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       dom.taskGroups.showRun(null);
     }
 
-    sortedMessages.forEach((msg) => {
-      this._renderLogMessage(msg, logContent);
-    });
+    // Batch ungrouped messages via DocumentFragment to avoid layout thrashing
+    const fragment = document.createDocumentFragment();
+    for (const msg of sortedMessages) {
+      if (msg.groupId) {
+        // Grouped messages go to their group container
+        dom.logEntries.append(msg);
+      } else {
+        // Ungrouped messages batch into fragment
+        const formatted = this._entryFormatter.format(msg);
+        if (formatted) appendFormatted(fragment, formatted);
+      }
+    }
+    if (fragment.childNodes.length > 0) {
+      logContent.appendChild(fragment);
+    }
     scrollToBottom(logContent);
 
     // Use validated run ID from state (set earlier via setActiveRunId after validation)

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -501,9 +501,18 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       state.clearAllQueuedFollowUps();
       state.clearAllFollowUpText();
     } else {
-      // NOTE: Content clearing is handled by handleUpdateLogs which always follows.
-      // Backend always sends UPDATE_LOGS after UPDATE_STREAMS (even for empty streams).
-      // Clearing here would be redundant - we'd clear twice.
+      // Clear content when switching streams to prevent stale display.
+      // While UPDATE_LOGS typically follows UPDATE_STREAMS, some code paths
+      // (e.g., setStreamStatus for new streams with filter change) only send
+      // UPDATE_STREAMS. Clear proactively so stale content doesn't persist.
+      if (
+        state.lastRenderedStream &&
+        state.lastRenderedStream !== message.activeStream
+      ) {
+        const logContent = document.getElementById(ELEMENT_IDS.LOG_CONTENT);
+        if (logContent) logContent.innerHTML = '';
+        state.lastRenderedStream = '';
+      }
 
       const streamStatus = state.streamStatuses.get(message.activeStream);
       dom.status.update(streamStatus || STREAM_STATUS.STOPPED);
@@ -638,9 +647,16 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       }
     }
 
-    // Append grouped messages to their containers (container guaranteed to exist)
+    // Append grouped messages to their containers
     for (const [groupId, frag] of groupedFragments) {
-      dom.logEntries.getGroupContainer(groupId).appendChild(frag);
+      const container = dom.logEntries.getGroupContainer(groupId);
+      // Container should exist (we checked during batching), but guard against DOM changes
+      if (container) {
+        container.appendChild(frag);
+      } else {
+        // Fallback: append to main log if container was removed
+        logContent.appendChild(frag);
+      }
     }
 
     // Append ungrouped messages (and fallback grouped) to main log

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -610,7 +610,8 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       dom.taskGroups.showRun(null);
     }
 
-    // Batch all messages via DocumentFragment to avoid layout thrashing
+    // Batch all messages via DocumentFragment to avoid layout thrashing.
+    // Check container existence during iteration to preserve chronological order for fallbacks.
     const ungroupedFragment = document.createDocumentFragment();
     const groupedFragments = new Map(); // groupId → fragment
 
@@ -619,29 +620,30 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       if (!formatted) continue;
 
       if (msg.groupId) {
-        let frag = groupedFragments.get(msg.groupId);
-        if (!frag) {
-          frag = document.createDocumentFragment();
-          groupedFragments.set(msg.groupId, frag);
+        const container = dom.logEntries.getGroupContainer(msg.groupId);
+        if (container) {
+          // Group container exists - batch to grouped fragment
+          let frag = groupedFragments.get(msg.groupId);
+          if (!frag) {
+            frag = document.createDocumentFragment();
+            groupedFragments.set(msg.groupId, frag);
+          }
+          appendFormatted(frag, formatted);
+        } else {
+          // Group container missing - add to ungrouped to preserve chronological order
+          appendFormatted(ungroupedFragment, formatted);
         }
-        appendFormatted(frag, formatted);
       } else {
         appendFormatted(ungroupedFragment, formatted);
       }
     }
 
-    // Append grouped messages to their containers (fallback to main log if group missing)
+    // Append grouped messages to their containers (container guaranteed to exist)
     for (const [groupId, frag] of groupedFragments) {
-      const container = dom.logEntries.getGroupContainer(groupId);
-      if (container) {
-        container.appendChild(frag);
-      } else {
-        // Group container not found - append to main log as fallback
-        logContent.appendChild(frag);
-      }
+      dom.logEntries.getGroupContainer(groupId).appendChild(frag);
     }
 
-    // Append ungrouped messages to main log
+    // Append ungrouped messages (and fallback grouped) to main log
     if (ungroupedFragment.childNodes.length > 0) {
       logContent.appendChild(ungroupedFragment);
     }

--- a/src/progressView/modules/progressViewState.js
+++ b/src/progressView/modules/progressViewState.js
@@ -580,6 +580,21 @@ export class ProgressViewState {
     this.contextState.delete(streamId);
   }
 
+  /**
+   * Clear all run-scoped data for a stream in a single call.
+   * More efficient than calling individual clear methods separately.
+   * @param {string} streamId - The stream ID to clear data for
+   */
+  clearStreamRunData(streamId) {
+    if (!streamId) return;
+    this.runInstructions.clearStream(streamId);
+    this.runFiles.clearStream(streamId);
+    this.runMissingOutputs.clearStream(streamId);
+    this.runUsage.clearStream(streamId);
+    this.clearPendingInstruction(streamId);
+    this.clearActiveRun(streamId);
+  }
+
   deleteRunMissingOutputs(streamId, runId) {
     this.runMissingOutputs.delete(streamId, runId);
   }

--- a/src/progressView/modules/taskManagers.js
+++ b/src/progressView/modules/taskManagers.js
@@ -509,6 +509,16 @@ export class LogEntryManager {
   }
 
   /**
+   * Get the container element for a group (for batch appending).
+   * @param {string} groupId - The group ID
+   * @returns {HTMLElement|null} The group content container or null
+   */
+  getGroupContainer(groupId) {
+    const groupContentId = `${GROUP_DOM_IDS.CONTENT_PREFIX}${groupId}`;
+    return safeGetElementById(groupContentId);
+  }
+
+  /**
    * Update an existing log entry identified by ID
    * @param {Object} logMessage - The log message with updated content
    * @returns {boolean} Whether the log entry was updated

--- a/src/progressView/modules/uiManagers/StreamTabs.js
+++ b/src/progressView/modules/uiManagers/StreamTabs.js
@@ -32,10 +32,11 @@ export class StreamTabs {
     }
     tabsContainer.innerHTML = '';
     let activeInfo = null;
-    streams.forEach((info) => {
+    const fragment = document.createDocumentFragment();
+    for (const info of streams) {
       if (!info || typeof info !== 'object') {
         console.warn('StreamTabs.update: invalid stream value:', info);
-        return;
+        continue;
       }
       const tooltip = this._buildTooltip(info);
       const tabEl = createFromTemplate('streamTabTemplate', {
@@ -54,16 +55,16 @@ export class StreamTabs {
           '.tab-delete': { stream: info.name },
         },
       });
-      if (!tabEl) return;
+      if (!tabEl) continue;
       this._applyStatus(tabEl.querySelector('.tab-status'), info.status);
-      // Apply agent decorators from shared config
       this._applyAgentDecorators(tabEl, info);
       if (info.name === activeStream) {
         tabEl.classList.add('is-active');
         activeInfo = info;
       }
-      tabsContainer.appendChild(tabEl);
-    });
+      fragment.appendChild(tabEl);
+    }
+    tabsContainer.appendChild(fragment);
 
     // Update active stream name
     const streamNameElem = document.getElementById(

--- a/src/progressView/modules/uiManagers/StreamTabs.js
+++ b/src/progressView/modules/uiManagers/StreamTabs.js
@@ -13,10 +13,58 @@ const STATUS_CLASSES = Object.values(STREAM_STATUS).map((s) => `is-${s}`);
 
 /**
  * Manages stream tab UI updates.
+ * Uses surgical DOM updates when possible to avoid full rebuilds.
  */
 export class StreamTabs {
+  constructor() {
+    this._lastStreamNames = [];
+  }
+
   /**
-   * Updates UI to show stream tabs and highlight the active stream
+   * Check if only metadata changed (same streams in same order).
+   * @param {Array} streams
+   * @returns {boolean}
+   */
+  _canUpdateInPlace(streams) {
+    if (streams.length !== this._lastStreamNames.length) return false;
+    for (let i = 0; i < streams.length; i++) {
+      if (streams[i]?.name !== this._lastStreamNames[i]) return false;
+    }
+    return true;
+  }
+
+  /**
+   * Update a single tab's metadata in place.
+   * @param {HTMLElement} tabEl - The tab wrapper element
+   * @param {Object} info - Stream info
+   * @param {boolean} isActive - Whether this is the active stream
+   */
+  _updateTabInPlace(tabEl, info, isActive) {
+    const tooltip = this._buildTooltip(info);
+    const tab = tabEl.querySelector('.tab');
+
+    // Update text content
+    const titleEl = tabEl.querySelector('.tab-title');
+    if (titleEl) titleEl.textContent = info.label || info.name;
+
+    const modelEl = tabEl.querySelector('.model');
+    if (modelEl) modelEl.textContent = info.model || '';
+
+    const lastActiveEl = tabEl.querySelector('.last-active');
+    if (lastActiveEl) lastActiveEl.textContent = formatRelativeTime(info.lastTimestamp);
+
+    // Update tooltip
+    tabEl.title = tooltip;
+    if (tab) tab.title = tooltip;
+
+    // Update status and active state
+    this._applyStatus(tabEl.querySelector('.tab-status'), info.status);
+    tabEl.classList.toggle('is-active', isActive);
+  }
+
+  /**
+   * Updates UI to show stream tabs and highlight the active stream.
+   * Uses surgical updates when stream list is unchanged (only metadata changed).
    * @param {Array} streams - Array of stream metadata objects
    * @param {string} activeStream - Currently active stream
    */
@@ -30,8 +78,24 @@ export class StreamTabs {
       console.error('StreamTabs.update: streamTabs container not found');
       return;
     }
-    tabsContainer.innerHTML = '';
+
     let activeInfo = null;
+
+    // Fast path: same streams in same order, update in place
+    if (this._canUpdateInPlace(streams)) {
+      const tabs = tabsContainer.children;
+      streams.forEach((info, i) => {
+        if (!info || typeof info !== 'object') return;
+        const isActive = info.name === activeStream;
+        this._updateTabInPlace(tabs[i], info, isActive);
+        if (isActive) activeInfo = info;
+      });
+      this._updateStreamNameHeader(activeInfo);
+      return;
+    }
+
+    // Slow path: stream list changed, full rebuild required
+    tabsContainer.innerHTML = '';
     streams.forEach((info) => {
       if (!info || typeof info !== 'object') {
         console.warn('StreamTabs.update: invalid stream value:', info);
@@ -65,7 +129,17 @@ export class StreamTabs {
       tabsContainer.appendChild(tabEl);
     });
 
-    // Update active stream name
+    // Track stream names for next diff check
+    this._lastStreamNames = streams.map((s) => s?.name).filter(Boolean);
+
+    this._updateStreamNameHeader(activeInfo);
+  }
+
+  /**
+   * Update the active stream name header element.
+   * @param {Object|null} activeInfo
+   */
+  _updateStreamNameHeader(activeInfo) {
     const streamNameElem = document.getElementById(
       ELEMENT_IDS.ACTIVE_STREAM_NAME,
     );

--- a/src/progressView/modules/uiManagers/StreamTabs.js
+++ b/src/progressView/modules/uiManagers/StreamTabs.js
@@ -13,58 +13,10 @@ const STATUS_CLASSES = Object.values(STREAM_STATUS).map((s) => `is-${s}`);
 
 /**
  * Manages stream tab UI updates.
- * Uses surgical DOM updates when possible to avoid full rebuilds.
  */
 export class StreamTabs {
-  constructor() {
-    this._lastStreamNames = [];
-  }
-
   /**
-   * Check if only metadata changed (same streams in same order).
-   * @param {Array} streams
-   * @returns {boolean}
-   */
-  _canUpdateInPlace(streams) {
-    if (streams.length !== this._lastStreamNames.length) return false;
-    for (let i = 0; i < streams.length; i++) {
-      if (streams[i]?.name !== this._lastStreamNames[i]) return false;
-    }
-    return true;
-  }
-
-  /**
-   * Update a single tab's metadata in place.
-   * @param {HTMLElement} tabEl - The tab wrapper element
-   * @param {Object} info - Stream info
-   * @param {boolean} isActive - Whether this is the active stream
-   */
-  _updateTabInPlace(tabEl, info, isActive) {
-    const tooltip = this._buildTooltip(info);
-    const tab = tabEl.querySelector('.tab');
-
-    // Update text content
-    const titleEl = tabEl.querySelector('.tab-title');
-    if (titleEl) titleEl.textContent = info.label || info.name;
-
-    const modelEl = tabEl.querySelector('.model');
-    if (modelEl) modelEl.textContent = info.model || '';
-
-    const lastActiveEl = tabEl.querySelector('.last-active');
-    if (lastActiveEl) lastActiveEl.textContent = formatRelativeTime(info.lastTimestamp);
-
-    // Update tooltip
-    tabEl.title = tooltip;
-    if (tab) tab.title = tooltip;
-
-    // Update status and active state
-    this._applyStatus(tabEl.querySelector('.tab-status'), info.status);
-    tabEl.classList.toggle('is-active', isActive);
-  }
-
-  /**
-   * Updates UI to show stream tabs and highlight the active stream.
-   * Uses surgical updates when stream list is unchanged (only metadata changed).
+   * Updates UI to show stream tabs and highlight the active stream
    * @param {Array} streams - Array of stream metadata objects
    * @param {string} activeStream - Currently active stream
    */
@@ -78,24 +30,8 @@ export class StreamTabs {
       console.error('StreamTabs.update: streamTabs container not found');
       return;
     }
-
-    let activeInfo = null;
-
-    // Fast path: same streams in same order, update in place
-    if (this._canUpdateInPlace(streams)) {
-      const tabs = tabsContainer.children;
-      streams.forEach((info, i) => {
-        if (!info || typeof info !== 'object') return;
-        const isActive = info.name === activeStream;
-        this._updateTabInPlace(tabs[i], info, isActive);
-        if (isActive) activeInfo = info;
-      });
-      this._updateStreamNameHeader(activeInfo);
-      return;
-    }
-
-    // Slow path: stream list changed, full rebuild required
     tabsContainer.innerHTML = '';
+    let activeInfo = null;
     streams.forEach((info) => {
       if (!info || typeof info !== 'object') {
         console.warn('StreamTabs.update: invalid stream value:', info);
@@ -129,17 +65,7 @@ export class StreamTabs {
       tabsContainer.appendChild(tabEl);
     });
 
-    // Track stream names for next diff check
-    this._lastStreamNames = streams.map((s) => s?.name).filter(Boolean);
-
-    this._updateStreamNameHeader(activeInfo);
-  }
-
-  /**
-   * Update the active stream name header element.
-   * @param {Object|null} activeInfo
-   */
-  _updateStreamNameHeader(activeInfo) {
+    // Update active stream name
     const streamNameElem = document.getElementById(
       ELEMENT_IDS.ACTIVE_STREAM_NAME,
     );

--- a/src/progressView/modules/uiManagers/TodoList.js
+++ b/src/progressView/modules/uiManagers/TodoList.js
@@ -26,53 +26,11 @@ const STATUS_CLASSES = {
 /**
  * Manages the todo list display in the progress view.
  * Shows task progress for tool-use agents using native VS Code collapsible.
- * Uses surgical DOM updates when only status changes (common case).
  */
 export class TodoList {
   constructor() {
     this._elements = null;
     this._currentTodos = [];
-  }
-
-  /**
-   * Check if todos can be updated surgically (same items, only status changed).
-   * @param {Array} oldTodos
-   * @param {Array} newTodos
-   * @returns {boolean}
-   */
-  _canUpdateInPlace(oldTodos, newTodos) {
-    if (oldTodos.length !== newTodos.length) return false;
-    for (let i = 0; i < oldTodos.length; i++) {
-      if (oldTodos[i].content !== newTodos[i].content) return false;
-    }
-    return true;
-  }
-
-  /**
-   * Update a single todo item's status in place.
-   * @param {HTMLElement} item - The todo item element
-   * @param {{content: string, status: string, activeForm: string}} todo
-   */
-  _updateItemStatus(item, todo) {
-    const { status } = todo;
-    const isInProgress = status === TODO_STATUS.IN_PROGRESS;
-
-    // Update status class
-    item.classList.remove(...Object.values(STATUS_CLASSES));
-    if (STATUS_CLASSES[status]) item.classList.add(STATUS_CLASSES[status]);
-
-    // Update icon
-    const icon = item.querySelector('.todo-item__icon');
-    if (icon) {
-      icon.className = `codicon codicon-${STATUS_ICONS[status] ?? STATUS_ICONS[TODO_STATUS.PENDING]} todo-item__icon`;
-      icon.classList.toggle('spin', isInProgress);
-    }
-
-    // Update text (activeForm vs content based on status)
-    const content = item.querySelector('.todo-item__content');
-    if (content) {
-      content.textContent = isInProgress ? todo.activeForm : todo.content;
-    }
   }
 
   /**
@@ -96,7 +54,6 @@ export class TodoList {
 
   /**
    * Update the todo list display.
-   * Uses surgical updates when only status changed (avoids full DOM rebuild).
    * @param {Array<{content: string, status: string, activeForm: string}>} todos - The todo items
    */
   update(todos) {
@@ -105,30 +62,14 @@ export class TodoList {
       return;
     }
 
-    const newTodos = todos ?? [];
+    this._currentTodos = todos ?? [];
 
-    if (newTodos.length === 0) {
-      this._currentTodos = [];
+    if (this._currentTodos.length === 0) {
       this.hide();
       return;
     }
 
-    // Fast path: same items, only status/activeForm may have changed
-    // This is the common case during task execution
-    if (this._canUpdateInPlace(this._currentTodos, newTodos)) {
-      const items = elements.list.children;
-      for (let i = 0; i < newTodos.length; i++) {
-        // Only update if status actually changed
-        if (this._currentTodos[i].status !== newTodos[i].status) {
-          this._updateItemStatus(items[i], newTodos[i]);
-        }
-      }
-      this._currentTodos = newTodos;
-      return;
-    }
-
-    // Slow path: list structure changed, full rebuild required
-    this._currentTodos = newTodos;
+    // Clear and rebuild the list
     elements.list.innerHTML = '';
 
     for (const todo of this._currentTodos) {

--- a/src/progressView/modules/uiManagers/TodoList.js
+++ b/src/progressView/modules/uiManagers/TodoList.js
@@ -69,14 +69,13 @@ export class TodoList {
       return;
     }
 
-    // Clear and rebuild the list
+    // Clear and rebuild the list using DocumentFragment
     elements.list.innerHTML = '';
-
+    const fragment = document.createDocumentFragment();
     for (const todo of this._currentTodos) {
-      const item = this._createTodoItem(todo);
-      elements.list.appendChild(item);
+      fragment.appendChild(this._createTodoItem(todo));
     }
-
+    elements.list.appendChild(fragment);
     this.show();
   }
 

--- a/src/progressView/modules/uiManagers/TodoList.js
+++ b/src/progressView/modules/uiManagers/TodoList.js
@@ -26,11 +26,53 @@ const STATUS_CLASSES = {
 /**
  * Manages the todo list display in the progress view.
  * Shows task progress for tool-use agents using native VS Code collapsible.
+ * Uses surgical DOM updates when only status changes (common case).
  */
 export class TodoList {
   constructor() {
     this._elements = null;
     this._currentTodos = [];
+  }
+
+  /**
+   * Check if todos can be updated surgically (same items, only status changed).
+   * @param {Array} oldTodos
+   * @param {Array} newTodos
+   * @returns {boolean}
+   */
+  _canUpdateInPlace(oldTodos, newTodos) {
+    if (oldTodos.length !== newTodos.length) return false;
+    for (let i = 0; i < oldTodos.length; i++) {
+      if (oldTodos[i].content !== newTodos[i].content) return false;
+    }
+    return true;
+  }
+
+  /**
+   * Update a single todo item's status in place.
+   * @param {HTMLElement} item - The todo item element
+   * @param {{content: string, status: string, activeForm: string}} todo
+   */
+  _updateItemStatus(item, todo) {
+    const { status } = todo;
+    const isInProgress = status === TODO_STATUS.IN_PROGRESS;
+
+    // Update status class
+    item.classList.remove(...Object.values(STATUS_CLASSES));
+    if (STATUS_CLASSES[status]) item.classList.add(STATUS_CLASSES[status]);
+
+    // Update icon
+    const icon = item.querySelector('.todo-item__icon');
+    if (icon) {
+      icon.className = `codicon codicon-${STATUS_ICONS[status] ?? STATUS_ICONS[TODO_STATUS.PENDING]} todo-item__icon`;
+      icon.classList.toggle('spin', isInProgress);
+    }
+
+    // Update text (activeForm vs content based on status)
+    const content = item.querySelector('.todo-item__content');
+    if (content) {
+      content.textContent = isInProgress ? todo.activeForm : todo.content;
+    }
   }
 
   /**
@@ -54,6 +96,7 @@ export class TodoList {
 
   /**
    * Update the todo list display.
+   * Uses surgical updates when only status changed (avoids full DOM rebuild).
    * @param {Array<{content: string, status: string, activeForm: string}>} todos - The todo items
    */
   update(todos) {
@@ -62,14 +105,30 @@ export class TodoList {
       return;
     }
 
-    this._currentTodos = todos ?? [];
+    const newTodos = todos ?? [];
 
-    if (this._currentTodos.length === 0) {
+    if (newTodos.length === 0) {
+      this._currentTodos = [];
       this.hide();
       return;
     }
 
-    // Clear and rebuild the list
+    // Fast path: same items, only status/activeForm may have changed
+    // This is the common case during task execution
+    if (this._canUpdateInPlace(this._currentTodos, newTodos)) {
+      const items = elements.list.children;
+      for (let i = 0; i < newTodos.length; i++) {
+        // Only update if status actually changed
+        if (this._currentTodos[i].status !== newTodos[i].status) {
+          this._updateItemStatus(items[i], newTodos[i]);
+        }
+      }
+      this._currentTodos = newTodos;
+      return;
+    }
+
+    // Slow path: list structure changed, full rebuild required
+    this._currentTodos = newTodos;
     elements.list.innerHTML = '';
 
     for (const todo of this._currentTodos) {

--- a/src/progressView/streamInfoUtils.ts
+++ b/src/progressView/streamInfoUtils.ts
@@ -62,11 +62,9 @@ function buildStreamInfo(
   const category = matchesFilter(rawCategory, filter);
   if (category === null) return null;
 
-  // Extract timestamps from logs
-  const logs = state.streamTabs.getMessages(id);
-  const hasLogs = logs.length > 0;
-  const lastTimestamp = hasLogs ? logs.at(-1)?.timestamp : undefined;
-  const creationTimestamp = hasLogs ? logs[0].timestamp : undefined;
+  // Extract timestamps directly (avoids copying entire messages array)
+  const lastTimestamp = state.streamTabs.getLastTimestamp(id);
+  const creationTimestamp = state.streamTabs.getFirstTimestamp(id);
 
   // Agent and file info (with fallbacks to hints)
   const inputFile = config?.inputFile ?? '';


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Improves responsiveness by restructuring update flow and reducing unnecessary work across backend and frontend.
> 
> - Decouples `status`/`todos`/`instruction` from large `UPDATE_LOGS` payloads; `updateAll()` handles status, logs sent separately, and todos/instruction sent as small independent messages
> - Stream status updates: new streams trigger full refresh; existing streams use targeted `updateStreamStatus` with `lastTimestamp` from efficient getters
> - Frontend render path: clears on stream switch, repopulates panels from cache, and performs full rebuilds using `DocumentFragment` batching (grouped/ungrouped) to avoid layout thrash; incremental path updates metadata only
> - Adds helpers: `StreamTabsManager.getFirstTimestamp/getLastTimestamp`, `progressViewState.clearStreamRunData`, `logEntries.getGroupContainer`; batches UI updates in `StreamTabs` and `TodoList`
> - Prevents redundant updates: `TodoState.updateTodos` no-ops if unchanged; follow-up section memoized via last-state key
> - Usage handlers simplified; usage/context updates sent directly per run/stream
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b8a03fc9ec1086dca13bf032ded430a7d223a96d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->