### PR TITLE
Improve Wolfram tool error handling for stdout errors

### DIFF
--- a/src/tools/wolfram/WolframTool.ts
+++ b/src/tools/wolfram/WolframTool.ts
@@ -31,8 +31,9 @@ export class WolframTool extends defineTool({
         output: result.output ?? '',
       };
     }
-    throw new ToolError(
-      `Wolfram execution failed: ${result.error ?? 'No error details available'}`,
-    );
+    // Wolfram often outputs errors to stdout rather than stderr
+    const errorDetails =
+      result.error || result.output || 'No error details available';
+    throw new ToolError(`Wolfram execution failed: ${errorDetails}`);
   }
 }


### PR DESCRIPTION
## Summary
Enhanced error reporting in the WolframTool to better handle cases where Wolfram outputs errors to stdout instead of stderr, improving debugging and error visibility.

## Key Changes
- Modified error handling logic to check `result.output` as a fallback when `result.error` is unavailable
- Added clarifying comment explaining that Wolfram often outputs errors to stdout rather than stderr
- Improved error message quality by prioritizing error details in order: `result.error` → `result.output` → fallback message

## Implementation Details
The change recognizes that Wolfram's command-line tool may write error information to standard output rather than standard error. By checking both `result.error` and `result.output` when constructing error messages, the tool now provides more complete error context to users, making it easier to diagnose and troubleshoot execution failures.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves failure diagnostics for `WolframTool`.
> 
> - On non-success, error details now use `result.error || result.output || 'No error details available'`
> - Adds a clarifying comment that Wolfram may emit errors to stdout
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 70a8d52cf1ed6fd50726612bee6b91ca2dce0336. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->