### PR TITLE
Deduplicate tool calls within the same batch execution

### DIFF
--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -526,6 +526,11 @@ interface ToolExecutionResult {
   }>;
 }
 
+/** Create a signature for deduplicating tool calls */
+function createToolCallSignature(name: string, input: unknown): string {
+  return `${name}:${JSON.stringify(input ?? {})}`;
+}
+
 /**
  * Dispatches tool calls and processes their results using BatchNode pattern.
  *
@@ -535,18 +540,27 @@ interface ToolExecutionResult {
  * To enable parallel execution, change to extend ParallelBatchNode instead.
  *
  * Batches follow-up messages for Google/DeepSeek handlers to preserve thought signatures.
+ *
+ * Deduplicates tool calls within the same batch - if the model requests the same
+ * tool with identical parameters multiple times, only the first is executed.
  */
 class ToolUseDispatchNode<C> extends BatchNode<
   ToolUseCycleShared,
   ToolUseCycleParams<C>,
   ToolUseCycleServices<C>
 > {
+  /** Tracks tool calls executed in the current batch for deduplication */
+  private executedInBatch = new Set<string>();
+
   /**
    * Returns the array of tool calls to execute.
    * Returns empty array if should skip (no tools, stopped, or interrupted).
    */
   async prep(shared: ToolUseCycleShared): Promise<SdkToolCall[]> {
     const toolCalls = shared.toolCalls ?? [];
+
+    // Reset batch deduplication tracker at start of each batch
+    this.executedInBatch.clear();
 
     // Skip if no tool calls or already stopped
     if (shared.shouldStop || toolCalls.length === 0) {
@@ -585,6 +599,8 @@ class ToolUseDispatchNode<C> extends BatchNode<
 
   /**
    * Execute a single tool call and return the result with metadata.
+   * Checks for duplicate calls within the batch and returns a synthetic result
+   * if the same tool with same parameters was already executed.
    */
   private async executeToolCall(
     call: SdkToolCall,
@@ -595,6 +611,25 @@ class ToolUseDispatchNode<C> extends BatchNode<
     const tool = options.toolRegistry.get(call.name);
     let result: ToolResult;
     const parsedInput = parseToolInput(call.input, call.callId, options.logger);
+
+    // Check for duplicate tool call within this batch
+    const signature = createToolCallSignature(call.name, parsedInput);
+    if (this.executedInBatch.has(signature)) {
+      options.logger.debug(
+        `Skipping duplicate tool call: ${call.name} (same parameters already executed in this batch)`,
+      );
+      result = {
+        content: `This ${call.name} operation was just performed with identical parameters. See the result above.`,
+        isError: false,
+      };
+      return {
+        call,
+        result,
+        parsedInput,
+        sanitizedOutput: { content: result.content },
+        editedFiles: [],
+      };
+    }
 
     if (!tool) {
       result = {
@@ -613,6 +648,8 @@ class ToolUseDispatchNode<C> extends BatchNode<
           },
           () => tool.call(parsedInput),
         );
+        // Record successful execution for deduplication
+        this.executedInBatch.add(signature);
       } catch (err) {
         const { message, diagnostics } = normalizeToolCallError(call.name, err);
         result = {

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -618,15 +618,16 @@ class ToolUseDispatchNode<C> extends BatchNode<
       options.logger.debug(
         `Skipping duplicate tool call: ${call.name} (same parameters already executed in this batch)`,
       );
+      const dedupeMessage = `This ${call.name} operation was just performed with identical parameters. See the result above.`;
       result = {
-        content: `This ${call.name} operation was just performed with identical parameters. See the result above.`,
+        output: dedupeMessage,
         isError: false,
       };
       return {
         call,
         result,
         parsedInput,
-        sanitizedOutput: { content: result.content },
+        sanitizedOutput: { output: dedupeMessage },
         editedFiles: [],
       };
     }
@@ -648,8 +649,10 @@ class ToolUseDispatchNode<C> extends BatchNode<
           },
           () => tool.call(parsedInput),
         );
-        // Record successful execution for deduplication
-        this.executedInBatch.add(signature);
+        // Only deduplicate successful calls - failed calls can be re-attempted
+        if (!result.isError) {
+          this.executedInBatch.add(signature);
+        }
       } catch (err) {
         const { message, diagnostics } = normalizeToolCallError(call.name, err);
         result = {


### PR DESCRIPTION
## Summary
This PR adds deduplication logic to the `ToolUseDispatchNode` to prevent executing the same tool with identical parameters multiple times within a single batch. When a duplicate is detected, a synthetic result is returned instead of re-executing the tool.

## Changes
- **Added `createToolCallSignature()` helper function** - Creates a deterministic signature from tool name and input parameters for comparison
- **Added `executedInBatch` Set to `ToolUseDispatchNode`** - Tracks tool call signatures that have already been executed in the current batch
- **Reset deduplication tracker in `prep()` method** - Clears the executed set at the start of each new batch to ensure deduplication is scoped per batch
- **Added duplicate detection in `executeToolCall()` method** - Checks if a tool call signature already exists in the batch before execution; if found, returns a synthetic result instead of calling the tool
- **Record successful executions** - Adds the signature to the tracking set after successful tool execution

## Implementation Details
- Deduplication is scoped to individual batches - the tracker is reset at the start of each batch via `prep()`
- Only successfully executed tool calls are recorded for deduplication; failed calls don't prevent re-attempts
- Duplicate calls receive a user-friendly message indicating the operation was already performed
- The signature is based on both tool name and parsed input parameters, ensuring exact matches are required for deduplication

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements per-batch deduplication to avoid redundant tool executions and preserve ordering.
> 
> - Adds `createToolCallSignature(name, input)` and `executedInBatch` Set to track executed calls
> - Resets deduplication tracker in `prep()`; scope is one batch
> - In `executeToolCall()`, skips calls with an existing signature and returns a synthetic success message
> - Records signatures only for successful executions; failures can be retried
> - Maintains existing logging, file edit tracking, and follow-up message handling
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 39283b86671a728435c3fb0eb50ae1bdd6b52ea9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->