### PR TITLE
Add syntax highlighting for code-only tool inputs

### DIFF
--- a/src/progressView/modules/formatters/constants.js
+++ b/src/progressView/modules/formatters/constants.js
@@ -69,6 +69,14 @@ export const TOOL_OUTPUT_LANGUAGES = new Map([
 ]);
 
 /**
+ * Tools whose input contains a `code` field that should be syntax highlighted.
+ * Maps tool name to highlight.js language for the code field.
+ */
+export const TOOL_CODE_LANGUAGES = new Map([
+  ['wolfram', 'mathematica'],
+]);
+
+/**
  * Map file extensions that don't match highlight.js language names.
  * Focused on LaTeX research context. Unknown extensions try the extension directly.
  */

--- a/src/progressView/modules/formatters/logFormatters/toolFormatters.js
+++ b/src/progressView/modules/formatters/logFormatters/toolFormatters.js
@@ -14,12 +14,17 @@ import {
   buildEditDiffSection,
   buildCodeBlock,
 } from '../htmlBuilders.js';
-import { normalizeToolUseLog, stringifyWithLanguage } from '../normalizers.js';
+import {
+  normalizeToolUseLog,
+  stringifyWithLanguage,
+  extractCodeOnlyInput,
+} from '../normalizers.js';
 import {
   TOOLS_WITH_DIFF_INPUT,
   TOOLS_WITH_FILE_LINK,
   TOOLS_WITH_FILE_CONTENT,
   TOOL_OUTPUT_LANGUAGES,
+  TOOL_CODE_LANGUAGES,
   getLanguageFromPath,
 } from '../constants.js';
 
@@ -231,15 +236,31 @@ export function formatToolUse(normalizedPayload, logId, groupId, timestamp) {
   }
   // Default handling for other tools
   else if (input !== undefined && input !== null) {
-    const { text: inputValue, language: inputLanguage } =
-      stringifyWithLanguage(input);
-    if (inputValue) {
+    // Check tool language first (cheap Map lookup) before extracting code
+    const codeLanguage = TOOL_CODE_LANGUAGES.get(toolName);
+    const { isCodeOnly, code } = codeLanguage
+      ? extractCodeOnlyInput(input)
+      : { isCodeOnly: false, code: '' };
+
+    if (isCodeOnly) {
+      // Show code with appropriate syntax highlighting instead of YAML
       sections.push(
-        buildToolSection('Input:', inputValue, {
+        buildToolSection('Input:', code, {
           toolName,
-          language: inputLanguage,
+          language: codeLanguage,
         }),
       );
+    } else {
+      const { text: inputValue, language: inputLanguage } =
+        stringifyWithLanguage(input);
+      if (inputValue) {
+        sections.push(
+          buildToolSection('Input:', inputValue, {
+            toolName,
+            language: inputLanguage,
+          }),
+        );
+      }
     }
   }
 
@@ -279,16 +300,18 @@ export function formatToolUse(normalizedPayload, logId, groupId, timestamp) {
     );
   }
 
-  const { text: fallbackYaml, language: fallbackLanguage } =
-    stringifyWithLanguage(parsed);
-  contentElem.innerHTML =
-    sections.length === 0
-      ? buildCodeBlock(fallbackYaml || '', {
-          language: fallbackLanguage,
-          showLanguage: fallbackLanguage !== 'plaintext',
-          showCopy: true,
-        })
-      : sections.join('<hr class="tool-use-separator">');
+  // Only compute fallback YAML when needed (avoid wasted yaml.stringify)
+  if (sections.length === 0) {
+    const { text: fallbackYaml, language: fallbackLanguage } =
+      stringifyWithLanguage(parsed);
+    contentElem.innerHTML = buildCodeBlock(fallbackYaml || '', {
+      language: fallbackLanguage,
+      showLanguage: fallbackLanguage !== 'plaintext',
+      showCopy: true,
+    });
+  } else {
+    contentElem.innerHTML = sections.join('<hr class="tool-use-separator">');
+  }
 
   return element;
 }

--- a/src/progressView/modules/formatters/normalizers.js
+++ b/src/progressView/modules/formatters/normalizers.js
@@ -84,6 +84,23 @@ export function stringifyWithLanguage(value) {
 }
 
 /**
+ * Check if an input object is code-only (has only a `code` field with string content).
+ * @param {*} value - Value to check
+ * @returns {{isCodeOnly: boolean, code: string}} Result with code extraction
+ */
+export function extractCodeOnlyInput(value) {
+  // Check property first (cheap), then key count (allocates array)
+  if (
+    isPlainObject(value) &&
+    typeof value.code === 'string' &&
+    Object.keys(value).length === 1
+  ) {
+    return { isCodeOnly: true, code: value.code };
+  }
+  return { isCodeOnly: false, code: '' };
+}
+
+/**
  * Try to parse a string as JSON
  * @param {string} text - Text to parse
  * @returns {object|null} Parsed JSON or null


### PR DESCRIPTION
## Summary
This PR adds support for syntax highlighting code-only tool inputs. When a tool's input contains only a `code` field, it will now be displayed with appropriate syntax highlighting instead of being rendered as YAML.

## Changes
- **constants.js**: Added `TOOL_CODE_LANGUAGES` map to define which tools have code inputs and their corresponding highlight.js language (currently supports Wolfram/Mathematica)
- **normalizers.js**: Added `extractCodeOnlyInput()` function to detect and extract code from input objects that contain only a `code` field
- **toolFormatters.js**: Updated `formatToolUse()` to check for code-only inputs and apply language-specific syntax highlighting when available, falling back to YAML rendering for other input types

## Implementation Details
- The `extractCodeOnlyInput()` function validates that the input is a plain object with exactly one key named `code` containing a string value
- When a code-only input is detected and the tool has a defined code language in `TOOL_CODE_LANGUAGES`, the code is rendered with that language's syntax highlighting
- All other input types continue to use the existing `stringifyWithLanguage()` logic for YAML rendering
- This approach is extensible—new tools can be added to `TOOL_CODE_LANGUAGES` as needed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds code-only input syntax highlighting and a small performance optimization in progress view tool formatters.
> 
> - Introduces `TOOL_CODE_LANGUAGES` (e.g., `wolfram` → `mathematica`) to map tools with `code` inputs
> - Adds `extractCodeOnlyInput()` to detect inputs shaped as `{code: string}`
> - Updates `formatToolUse()` to render code-only inputs as highlighted code using mapped language; otherwise falls back to `stringifyWithLanguage()` YAML
> - Defers fallback YAML generation until needed to avoid unnecessary work
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fcb28d4635386424f56f95568339821cb05ebdaf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->