### PR TITLE
Add bash command approval workflow with YOLO mode support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1012,6 +1012,12 @@
             "description": "Require user approval in a diff view before tool-driven edits modify workspace files",
             "scope": "resource"
           },
+          "texra.toolUse.requireBashApproval": {
+            "type": "boolean",
+            "default": true,
+            "description": "Require user approval before tool-use agents execute bash commands",
+            "scope": "resource"
+          },
           "texra.toolUse.persistence.enabled": {
             "type": "boolean",
             "default": true,

--- a/src/common/webview/commands.js
+++ b/src/common/webview/commands.js
@@ -193,6 +193,8 @@ export const PROGRESS_VIEW_COMMANDS = {
   SHOW_TOOL_EDIT_APPROVAL: 'showToolEditApproval',
   RESOLVE_TOOL_EDIT_APPROVAL: 'resolveToolEditApproval',
   UPDATE_TOOL_EDIT_APPROVAL_STATE: 'updateToolEditApprovalState',
+  SHOW_BASH_APPROVAL: 'showBashApproval',
+  RESOLVE_BASH_APPROVAL: 'resolveBashApproval',
   SHOW_RETRY_REQUEST: 'showRetryRequest',
   RESOLVE_RETRY_REQUEST: 'resolveRetryRequest',
   SHOW_AGENT_PROPOSAL: 'showAgentProposal',
@@ -227,6 +229,7 @@ export const PROGRESS_VIEW_COMMANDS = {
   TOOL_EDIT_APPROVAL_ACTION: 'toolEditApprovalAction',
   TOGGLE_TOOL_EDIT_APPROVAL_BYPASS: 'toggleToolEditApprovalBypass',
   AGENT_PROPOSAL_ACTION: 'agentProposalAction',
+  BASH_APPROVAL_ACTION: 'bashApprovalAction',
 
   // Memory
   OPEN_MEMORY_VIEW: 'openMemoryView',

--- a/src/common/webview/commands.ts
+++ b/src/common/webview/commands.ts
@@ -193,6 +193,9 @@ export const PROGRESS_VIEW_COMMANDS = {
   SHOW_TOOL_EDIT_APPROVAL: 'showToolEditApproval',
   RESOLVE_TOOL_EDIT_APPROVAL: 'resolveToolEditApproval',
   UPDATE_TOOL_EDIT_APPROVAL_STATE: 'updateToolEditApprovalState',
+  SHOW_BASH_APPROVAL: 'showBashApproval',
+  RESOLVE_BASH_APPROVAL: 'resolveBashApproval',
+  UPDATE_BASH_APPROVAL_STATE: 'updateBashApprovalState',
   SHOW_RETRY_REQUEST: 'showRetryRequest',
   RESOLVE_RETRY_REQUEST: 'resolveRetryRequest',
   SHOW_AGENT_PROPOSAL: 'showAgentProposal',
@@ -227,6 +230,8 @@ export const PROGRESS_VIEW_COMMANDS = {
   TOOL_EDIT_APPROVAL_ACTION: 'toolEditApprovalAction',
   TOGGLE_TOOL_EDIT_APPROVAL_BYPASS: 'toggleToolEditApprovalBypass',
   AGENT_PROPOSAL_ACTION: 'agentProposalAction',
+  BASH_APPROVAL_ACTION: 'bashApprovalAction',
+  TOGGLE_BASH_APPROVAL_BYPASS: 'toggleBashApprovalBypass',
 
   // Memory
   OPEN_MEMORY_VIEW: 'openMemoryView',

--- a/src/common/webview/commands.ts
+++ b/src/common/webview/commands.ts
@@ -195,7 +195,6 @@ export const PROGRESS_VIEW_COMMANDS = {
   UPDATE_TOOL_EDIT_APPROVAL_STATE: 'updateToolEditApprovalState',
   SHOW_BASH_APPROVAL: 'showBashApproval',
   RESOLVE_BASH_APPROVAL: 'resolveBashApproval',
-  UPDATE_BASH_APPROVAL_STATE: 'updateBashApprovalState',
   SHOW_RETRY_REQUEST: 'showRetryRequest',
   RESOLVE_RETRY_REQUEST: 'resolveRetryRequest',
   SHOW_AGENT_PROPOSAL: 'showAgentProposal',
@@ -231,7 +230,6 @@ export const PROGRESS_VIEW_COMMANDS = {
   TOGGLE_TOOL_EDIT_APPROVAL_BYPASS: 'toggleToolEditApprovalBypass',
   AGENT_PROPOSAL_ACTION: 'agentProposalAction',
   BASH_APPROVAL_ACTION: 'bashApprovalAction',
-  TOGGLE_BASH_APPROVAL_BYPASS: 'toggleBashApprovalBypass',
 
   // Memory
   OPEN_MEMORY_VIEW: 'openMemoryView',

--- a/src/eventBus/ProgressEventBus.ts
+++ b/src/eventBus/ProgressEventBus.ts
@@ -19,6 +19,7 @@ import type {
 import type {
   RetryRequestPrompt,
   ToolEditApprovalPrompt,
+  BashApprovalPrompt,
   AgentProposalPrompt,
 } from './types';
 
@@ -57,6 +58,12 @@ export interface ProgressEventPayloads {
   showToolEditApprovalPrompt: ToolEditApprovalPrompt;
   resolveToolEditApprovalPrompt: { requestId: string };
   updateToolEditApprovalBypassState: {
+    streamId: StreamTabId;
+    bypassActive: boolean;
+  };
+  showBashApprovalPrompt: BashApprovalPrompt;
+  resolveBashApprovalPrompt: { requestId: string };
+  updateBashApprovalBypassState: {
     streamId: StreamTabId;
     bypassActive: boolean;
   };

--- a/src/eventBus/ProgressEventBus.ts
+++ b/src/eventBus/ProgressEventBus.ts
@@ -63,10 +63,6 @@ export interface ProgressEventPayloads {
   };
   showBashApprovalPrompt: BashApprovalPrompt;
   resolveBashApprovalPrompt: { requestId: string };
-  updateBashApprovalBypassState: {
-    streamId: StreamTabId;
-    bypassActive: boolean;
-  };
   showAgentProposal: AgentProposalPrompt;
   resolveAgentProposal: { proposalId: string };
   updateTodos: UpdateTodosPayload;

--- a/src/eventBus/types.ts
+++ b/src/eventBus/types.ts
@@ -13,6 +13,16 @@ import {
   type ProviderErrorPartial,
 } from '@common/errors/schemas';
 
+/**
+ * Optional stream ID schema - allows empty string for cases where stream context
+ * may not be available (e.g., approval requests during initialization).
+ */
+export const OptionalStreamIdSchema = z.union([
+  StreamTabIdSchema,
+  z.literal(''),
+]);
+export type OptionalStreamId = z.infer<typeof OptionalStreamIdSchema>;
+
 /** Tool edit approval request prompt */
 export const ToolEditApprovalPromptSchema = z.strictObject({
   requestId: z.string(),
@@ -20,7 +30,7 @@ export const ToolEditApprovalPromptSchema = z.strictObject({
   relativePath: z.string(),
   sourceTool: z.string(),
   allowBypass: z.boolean(),
-  streamId: z.union([StreamTabIdSchema, z.literal('')]),
+  streamId: OptionalStreamIdSchema,
   addedLines: z.int().nonnegative(),
   removedLines: z.int().nonnegative(),
   isLatex: z.boolean(),
@@ -34,7 +44,7 @@ export const BashApprovalPromptSchema = z.strictObject({
   requestId: z.string(),
   command: z.string(),
   allowBypass: z.boolean(),
-  streamId: z.union([StreamTabIdSchema, z.literal('')]),
+  streamId: OptionalStreamIdSchema,
 });
 export type BashApprovalPrompt = z.infer<typeof BashApprovalPromptSchema>;
 

--- a/src/eventBus/types.ts
+++ b/src/eventBus/types.ts
@@ -29,6 +29,15 @@ export type ToolEditApprovalPrompt = z.infer<
   typeof ToolEditApprovalPromptSchema
 >;
 
+/** Bash approval request prompt */
+export const BashApprovalPromptSchema = z.strictObject({
+  requestId: z.string(),
+  command: z.string(),
+  allowBypass: z.boolean(),
+  streamId: z.union([StreamTabIdSchema, z.literal('')]),
+});
+export type BashApprovalPrompt = z.infer<typeof BashApprovalPromptSchema>;
+
 export const RetryRequestPromptSchema = z.strictObject({
   streamId: StreamTabIdSchema,
   operation: z.string(),

--- a/src/progressView/ProgressViewContentProvider.ts
+++ b/src/progressView/ProgressViewContentProvider.ts
@@ -33,6 +33,10 @@ const PROGRESS_VIEW_MODULES = [
     key: 'approvalRequestsUri',
     path: 'modules/uiManagers/ApprovalRequests.js',
   },
+  {
+    key: 'bashApprovalRequestsUri',
+    path: 'modules/uiManagers/BashApprovalRequests.js',
+  },
   { key: 'retryRequestsUri', path: 'modules/uiManagers/RetryRequests.js' },
   {
     key: 'workflowProposalsUri',

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -41,9 +41,9 @@ import {
   cleanupAllApprovals,
   cleanupApprovalsForStream,
   handleProgressViewToolEditApprovalAction,
+  handleProgressViewBashApprovalAction,
   toggleToolEditApprovalSessionBypass,
-} from '@tools/approval/toolEditApproval';
-import { handleProgressViewBashApprovalAction } from '@tools/approval/bashApproval';
+} from '@tools/approval';
 import { getConfig } from '@utils/config';
 import { isNonEmptyString } from '@utils/core';
 import {

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -41,15 +41,11 @@ import {
   clearAllApprovalBypass,
   clearApprovalBypassForStream,
   handleProgressViewToolEditApprovalAction,
-  rejectAllPendingToolEditApprovals,
-  rejectPendingToolEditApprovalsForStream,
+  rejectAllPendingApprovals,
+  rejectPendingApprovalsForStream,
   toggleToolEditApprovalSessionBypass,
 } from '@tools/approval/toolEditApproval';
-import {
-  handleProgressViewBashApprovalAction,
-  rejectPendingBashApprovalsForStream,
-  rejectAllPendingBashApprovals,
-} from '@tools/approval/bashApproval';
+import { handleProgressViewBashApprovalAction } from '@tools/approval/bashApproval';
 import { getConfig } from '@utils/config';
 import { isNonEmptyString } from '@utils/core';
 import {
@@ -242,8 +238,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
 
         // Clear pending task groups, approvals, and YOLO state to prevent memory leaks
         this.provider.eventHandler.clearPendingTaskGroups(streamId);
-        rejectPendingToolEditApprovalsForStream(streamId);
-        rejectPendingBashApprovalsForStream(streamId);
+        rejectPendingApprovalsForStream(streamId);
         clearApprovalBypassForStream(streamId);
         await this.provider.state.clearStream(streamId);
         // Force rebuild since we deleted a stream
@@ -267,8 +262,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
 
     // Clear all pending task groups, approvals, and YOLO state to prevent memory leaks
     this.provider.eventHandler.clearAllPendingTaskGroups();
-    rejectAllPendingToolEditApprovals();
-    rejectAllPendingBashApprovals();
+    rejectAllPendingApprovals();
     clearAllApprovalBypass();
     await this.provider.state.clearAll();
     // Force rebuild since we deleted all streams

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -43,6 +43,12 @@ import {
   handleProgressViewToolEditApprovalAction,
   toggleToolEditApprovalSessionBypass,
 } from '@tools/approval/toolEditApproval';
+import {
+  clearAllBashApprovalBypass,
+  clearBashApprovalBypassForStream,
+  handleProgressViewBashApprovalAction,
+  toggleBashApprovalSessionBypass,
+} from '@tools/approval/bashApproval';
 import { getConfig } from '@utils/config';
 import { isNonEmptyString } from '@utils/core';
 import {
@@ -63,6 +69,7 @@ import {
   PolishFollowUpMessageSchema,
   InfoMessageSchema,
   ApprovalActionMessageSchema,
+  BashApprovalActionMessageSchema,
   FollowupTaskMessageSchema,
   StreamMessageSchema,
   RetryStreamMessageSchema,
@@ -160,6 +167,10 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
         this.handleToggleToolEditApprovalBypass.bind(this),
       [PROGRESS_VIEW_COMMANDS.AGENT_PROPOSAL_ACTION]:
         this.handleAgentProposalAction.bind(this),
+      [PROGRESS_VIEW_COMMANDS.BASH_APPROVAL_ACTION]:
+        this.handleBashApprovalAction.bind(this),
+      [PROGRESS_VIEW_COMMANDS.TOGGLE_BASH_APPROVAL_BYPASS]:
+        this.handleToggleBashApprovalBypass.bind(this),
 
       // Profile
       [PROGRESS_VIEW_COMMANDS.OPEN_PROFILE]: this.handleOpenProfile.bind(this),
@@ -233,6 +244,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
         // Clear pending task groups and YOLO state to prevent memory leaks
         this.provider.eventHandler.clearPendingTaskGroups(streamId);
         clearApprovalBypassForStream(streamId);
+        clearBashApprovalBypassForStream(streamId);
         await this.provider.state.clearStream(streamId);
         // Force rebuild since we deleted a stream
         this.provider.updateWebview({ forceRebuild: true });
@@ -256,6 +268,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     // Clear all pending task groups and YOLO state to prevent memory leaks
     this.provider.eventHandler.clearAllPendingTaskGroups();
     clearAllApprovalBypass();
+    clearAllBashApprovalBypass();
     await this.provider.state.clearAll();
     // Force rebuild since we deleted all streams
     this.provider.updateWebview({ forceRebuild: true });
@@ -555,6 +568,32 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
         const infoMessage = isNowEnabled
           ? 'YOLO mode enabled: Tool edits will be auto-approved for this stream.'
           : 'YOLO mode disabled: Tool edits will prompt for approval.';
+        await vscode.window.showInformationMessage(infoMessage);
+      },
+    );
+  }
+
+  private async handleBashApprovalAction(message: unknown): Promise<void> {
+    await this.withValidatedMessage(
+      BashApprovalActionMessageSchema,
+      message,
+      'bashApprovalAction',
+      handleProgressViewBashApprovalAction,
+    );
+  }
+
+  private async handleToggleBashApprovalBypass(
+    message: unknown,
+  ): Promise<void> {
+    await this.withValidatedMessage(
+      StreamMessageSchema,
+      message,
+      'toggleBashApprovalBypass',
+      async ({ stream: streamId }) => {
+        const isNowEnabled = toggleBashApprovalSessionBypass(streamId);
+        const infoMessage = isNowEnabled
+          ? 'YOLO mode enabled: Bash commands will be auto-approved for this stream.'
+          : 'YOLO mode disabled: Bash commands will prompt for approval.';
         await vscode.window.showInformationMessage(infoMessage);
       },
     );

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -38,11 +38,9 @@ import {
   type FollowupInstructionVars,
 } from '@progressView/templates/followupInstructionTemplates';
 import {
-  clearAllApprovalBypass,
-  clearApprovalBypassForStream,
+  cleanupAllApprovals,
+  cleanupApprovalsForStream,
   handleProgressViewToolEditApprovalAction,
-  rejectAllPendingApprovals,
-  rejectPendingApprovalsForStream,
   toggleToolEditApprovalSessionBypass,
 } from '@tools/approval/toolEditApproval';
 import { handleProgressViewBashApprovalAction } from '@tools/approval/bashApproval';
@@ -238,8 +236,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
 
         // Clear pending task groups, approvals, and YOLO state to prevent memory leaks
         this.provider.eventHandler.clearPendingTaskGroups(streamId);
-        rejectPendingApprovalsForStream(streamId);
-        clearApprovalBypassForStream(streamId);
+        cleanupApprovalsForStream(streamId);
         await this.provider.state.clearStream(streamId);
         // Force rebuild since we deleted a stream
         this.provider.updateWebview({ forceRebuild: true });
@@ -262,8 +259,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
 
     // Clear all pending task groups, approvals, and YOLO state to prevent memory leaks
     this.provider.eventHandler.clearAllPendingTaskGroups();
-    rejectAllPendingApprovals();
-    clearAllApprovalBypass();
+    cleanupAllApprovals();
     await this.provider.state.clearAll();
     // Force rebuild since we deleted all streams
     this.provider.updateWebview({ forceRebuild: true });

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -41,6 +41,8 @@ import {
   clearAllApprovalBypass,
   clearApprovalBypassForStream,
   handleProgressViewToolEditApprovalAction,
+  rejectAllPendingToolEditApprovals,
+  rejectPendingToolEditApprovalsForStream,
   toggleToolEditApprovalSessionBypass,
 } from '@tools/approval/toolEditApproval';
 import {
@@ -240,6 +242,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
 
         // Clear pending task groups, approvals, and YOLO state to prevent memory leaks
         this.provider.eventHandler.clearPendingTaskGroups(streamId);
+        rejectPendingToolEditApprovalsForStream(streamId);
         rejectPendingBashApprovalsForStream(streamId);
         clearApprovalBypassForStream(streamId);
         await this.provider.state.clearStream(streamId);
@@ -264,6 +267,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
 
     // Clear all pending task groups, approvals, and YOLO state to prevent memory leaks
     this.provider.eventHandler.clearAllPendingTaskGroups();
+    rejectAllPendingToolEditApprovals();
     rejectAllPendingBashApprovals();
     clearAllApprovalBypass();
     await this.provider.state.clearAll();

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -43,7 +43,11 @@ import {
   handleProgressViewToolEditApprovalAction,
   toggleToolEditApprovalSessionBypass,
 } from '@tools/approval/toolEditApproval';
-import { handleProgressViewBashApprovalAction } from '@tools/approval/bashApproval';
+import {
+  handleProgressViewBashApprovalAction,
+  rejectPendingBashApprovalsForStream,
+  rejectAllPendingBashApprovals,
+} from '@tools/approval/bashApproval';
 import { getConfig } from '@utils/config';
 import { isNonEmptyString } from '@utils/core';
 import {
@@ -234,8 +238,9 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
           return;
         }
 
-        // Clear pending task groups and YOLO state to prevent memory leaks
+        // Clear pending task groups, approvals, and YOLO state to prevent memory leaks
         this.provider.eventHandler.clearPendingTaskGroups(streamId);
+        rejectPendingBashApprovalsForStream(streamId);
         clearApprovalBypassForStream(streamId);
         await this.provider.state.clearStream(streamId);
         // Force rebuild since we deleted a stream
@@ -257,8 +262,9 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
       return;
     }
 
-    // Clear all pending task groups and YOLO state to prevent memory leaks
+    // Clear all pending task groups, approvals, and YOLO state to prevent memory leaks
     this.provider.eventHandler.clearAllPendingTaskGroups();
+    rejectAllPendingBashApprovals();
     clearAllApprovalBypass();
     await this.provider.state.clearAll();
     // Force rebuild since we deleted all streams

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -43,12 +43,7 @@ import {
   handleProgressViewToolEditApprovalAction,
   toggleToolEditApprovalSessionBypass,
 } from '@tools/approval/toolEditApproval';
-import {
-  clearAllBashApprovalBypass,
-  clearBashApprovalBypassForStream,
-  handleProgressViewBashApprovalAction,
-  toggleBashApprovalSessionBypass,
-} from '@tools/approval/bashApproval';
+import { handleProgressViewBashApprovalAction } from '@tools/approval/bashApproval';
 import { getConfig } from '@utils/config';
 import { isNonEmptyString } from '@utils/core';
 import {
@@ -169,8 +164,6 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
         this.handleAgentProposalAction.bind(this),
       [PROGRESS_VIEW_COMMANDS.BASH_APPROVAL_ACTION]:
         this.handleBashApprovalAction.bind(this),
-      [PROGRESS_VIEW_COMMANDS.TOGGLE_BASH_APPROVAL_BYPASS]:
-        this.handleToggleBashApprovalBypass.bind(this),
 
       // Profile
       [PROGRESS_VIEW_COMMANDS.OPEN_PROFILE]: this.handleOpenProfile.bind(this),
@@ -244,7 +237,6 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
         // Clear pending task groups and YOLO state to prevent memory leaks
         this.provider.eventHandler.clearPendingTaskGroups(streamId);
         clearApprovalBypassForStream(streamId);
-        clearBashApprovalBypassForStream(streamId);
         await this.provider.state.clearStream(streamId);
         // Force rebuild since we deleted a stream
         this.provider.updateWebview({ forceRebuild: true });
@@ -268,7 +260,6 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     // Clear all pending task groups and YOLO state to prevent memory leaks
     this.provider.eventHandler.clearAllPendingTaskGroups();
     clearAllApprovalBypass();
-    clearAllBashApprovalBypass();
     await this.provider.state.clearAll();
     // Force rebuild since we deleted all streams
     this.provider.updateWebview({ forceRebuild: true });
@@ -566,8 +557,8 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
       async ({ stream: streamId }) => {
         const isNowEnabled = toggleToolEditApprovalSessionBypass(streamId);
         const infoMessage = isNowEnabled
-          ? 'YOLO mode enabled: Tool edits will be auto-approved for this stream.'
-          : 'YOLO mode disabled: Tool edits will prompt for approval.';
+          ? 'YOLO mode enabled: Tool actions will be auto-approved for this stream.'
+          : 'YOLO mode disabled: Tool actions will prompt for approval.';
         await vscode.window.showInformationMessage(infoMessage);
       },
     );
@@ -579,23 +570,6 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
       message,
       'bashApprovalAction',
       handleProgressViewBashApprovalAction,
-    );
-  }
-
-  private async handleToggleBashApprovalBypass(
-    message: unknown,
-  ): Promise<void> {
-    await this.withValidatedMessage(
-      StreamMessageSchema,
-      message,
-      'toggleBashApprovalBypass',
-      async ({ stream: streamId }) => {
-        const isNowEnabled = toggleBashApprovalSessionBypass(streamId);
-        const infoMessage = isNowEnabled
-          ? 'YOLO mode enabled: Bash commands will be auto-approved for this stream.'
-          : 'YOLO mode disabled: Bash commands will prompt for approval.';
-        await vscode.window.showInformationMessage(infoMessage);
-      },
     );
   }
 

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -10,7 +10,6 @@ import { BaseWebviewProvider } from '@common/webview';
 import { getSharedLocalResourceRoots } from '@common/webview';
 import { AgentLogger } from '@logger/AgentLogger';
 import { isApprovalBypassedForStream } from '@tools/approval/toolEditApproval';
-import { isBashApprovalBypassedForStream } from '@tools/approval/bashApproval';
 
 // Local file imports
 import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
@@ -118,8 +117,6 @@ export class ProgressViewProvider
           this.updateToolEditApprovalBypassState.bind(this),
         showBashApprovalPrompt: this.showBashApprovalPrompt.bind(this),
         resolveBashApprovalPrompt: this.resolveBashApprovalPrompt.bind(this),
-        updateBashApprovalBypassState:
-          this.updateBashApprovalBypassState.bind(this),
         showAgentProposal: this.showAgentProposal.bind(this),
         resolveAgentProposal: this.resolveAgentProposal.bind(this),
       },
@@ -284,25 +281,18 @@ export class ProgressViewProvider
   /**
    * Send YOLO mode state to the frontend for a stream.
    * When no stream is active, sends false to reset the UI.
-   * Sends both tool edit and bash approval YOLO states.
+   * YOLO mode is shared between tool edits and bash commands.
    */
   private sendYoloStateForStream(streamId: StreamTabId): void {
-    const toolEditBypassActive = streamId
+    const bypassActive = streamId
       ? isApprovalBypassedForStream(streamId)
       : false;
-    const bashBypassActive = streamId
-      ? isBashApprovalBypassedForStream(streamId)
-      : false;
-    this.sendIfReady(() => {
+    this.sendIfReady(() =>
       this.webviewUpdater.updateToolEditApprovalState(
         streamId || ('' as StreamTabId),
-        toolEditBypassActive,
-      );
-      this.webviewUpdater.updateBashApprovalState(
-        streamId || ('' as StreamTabId),
-        bashBypassActive,
-      );
-    });
+        bypassActive,
+      ),
+    );
   }
 
   /**
@@ -390,17 +380,6 @@ export class ProgressViewProvider
     this.pendingBashApprovalPrompts.delete(requestId);
     this.sendIfReady(() =>
       this.webviewUpdater.resolveBashApprovalPrompt(requestId),
-    );
-  }
-
-  public updateBashApprovalBypassState(
-    streamId: StreamTabId,
-    bypassActive: boolean,
-  ): void {
-    // bashApproval.ts is the single source of truth for bash YOLO state
-    // This method just relays the state change to the webview
-    this.sendIfReady(() =>
-      this.webviewUpdater.updateBashApprovalState(streamId, bypassActive),
     );
   }
 

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -9,16 +9,18 @@ import type { StreamTabId, StorageKey } from '@agent/types/IdentifierTypes';
 import { BaseWebviewProvider } from '@common/webview';
 import { getSharedLocalResourceRoots } from '@common/webview';
 import { AgentLogger } from '@logger/AgentLogger';
+import { isApprovalBypassedForStream } from '@tools/approval/toolEditApproval';
+import { isBashApprovalBypassedForStream } from '@tools/approval/bashApproval';
 
 // Local file imports
 import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
 import type {
   ToolEditApprovalPrompt,
+  BashApprovalPrompt,
   AgentProposalPrompt,
 } from '@eventBus/types';
 import { ProgressEventHandler } from './events/ProgressEventHandler';
 import { WebviewUpdater } from './managers';
-import { isApprovalBypassedForStream } from '@tools/approval/toolEditApproval';
 import { ProgressViewContentProvider } from './ProgressViewContentProvider';
 import { ProgressViewMessageHandler } from './ProgressViewMessageHandler';
 import { ProgressViewState } from './state/ProgressViewState';
@@ -75,6 +77,10 @@ export class ProgressViewProvider
     string,
     ToolEditApprovalPrompt
   >();
+  private readonly pendingBashApprovalPrompts = new Map<
+    string,
+    BashApprovalPrompt
+  >();
   private readonly pendingRetryRequests = new Map<
     string,
     ProgressEventPayloads['showRetryRequest']
@@ -110,6 +116,10 @@ export class ProgressViewProvider
           this.resolveToolEditApprovalPrompt.bind(this),
         updateToolEditApprovalBypassState:
           this.updateToolEditApprovalBypassState.bind(this),
+        showBashApprovalPrompt: this.showBashApprovalPrompt.bind(this),
+        resolveBashApprovalPrompt: this.resolveBashApprovalPrompt.bind(this),
+        updateBashApprovalBypassState:
+          this.updateBashApprovalBypassState.bind(this),
         showAgentProposal: this.showAgentProposal.bind(this),
         resolveAgentProposal: this.resolveAgentProposal.bind(this),
       },
@@ -274,17 +284,25 @@ export class ProgressViewProvider
   /**
    * Send YOLO mode state to the frontend for a stream.
    * When no stream is active, sends false to reset the UI.
+   * Sends both tool edit and bash approval YOLO states.
    */
   private sendYoloStateForStream(streamId: StreamTabId): void {
-    const bypassActive = streamId
+    const toolEditBypassActive = streamId
       ? isApprovalBypassedForStream(streamId)
       : false;
-    this.sendIfReady(() =>
+    const bashBypassActive = streamId
+      ? isBashApprovalBypassedForStream(streamId)
+      : false;
+    this.sendIfReady(() => {
       this.webviewUpdater.updateToolEditApprovalState(
         streamId || ('' as StreamTabId),
-        bypassActive,
-      ),
-    );
+        toolEditBypassActive,
+      );
+      this.webviewUpdater.updateBashApprovalState(
+        streamId || ('' as StreamTabId),
+        bashBypassActive,
+      );
+    });
   }
 
   /**
@@ -318,6 +336,10 @@ export class ProgressViewProvider
 
     for (const prompt of this.pendingApprovalPrompts.values()) {
       this.webviewUpdater.showToolEditApprovalPrompt(prompt);
+    }
+
+    for (const prompt of this.pendingBashApprovalPrompts.values()) {
+      this.webviewUpdater.showBashApprovalPrompt(prompt);
     }
 
     // Send per-stream YOLO state for active stream (handles empty stream case)
@@ -354,6 +376,31 @@ export class ProgressViewProvider
     // This method just relays the state change to the webview
     this.sendIfReady(() =>
       this.webviewUpdater.updateToolEditApprovalState(streamId, bypassActive),
+    );
+  }
+
+  public showBashApprovalPrompt(prompt: BashApprovalPrompt): void {
+    this.pendingBashApprovalPrompts.set(prompt.requestId, prompt);
+    this.sendIfReady(() =>
+      this.webviewUpdater.showBashApprovalPrompt(prompt),
+    );
+  }
+
+  public resolveBashApprovalPrompt(requestId: string): void {
+    this.pendingBashApprovalPrompts.delete(requestId);
+    this.sendIfReady(() =>
+      this.webviewUpdater.resolveBashApprovalPrompt(requestId),
+    );
+  }
+
+  public updateBashApprovalBypassState(
+    streamId: StreamTabId,
+    bypassActive: boolean,
+  ): void {
+    // bashApproval.ts is the single source of truth for bash YOLO state
+    // This method just relays the state change to the webview
+    this.sendIfReady(() =>
+      this.webviewUpdater.updateBashApprovalState(streamId, bypassActive),
     );
   }
 

--- a/src/progressView/events/UIEvents.ts
+++ b/src/progressView/events/UIEvents.ts
@@ -44,10 +44,6 @@ export interface BashApprovalCallbacks {
     payload: ProgressEventPayloads['showBashApprovalPrompt'],
   ) => void;
   resolveBashApprovalPrompt: (requestId: string) => void;
-  updateBashApprovalBypassState: (
-    streamId: string,
-    bypassActive: boolean,
-  ) => void;
 }
 
 /** Callbacks for agent proposal handling (workflow or tool-use). */
@@ -142,14 +138,6 @@ export function registerUIEvents(
     'resolveBashApprovalPrompt',
     (p) => callbacks.resolveBashApprovalPrompt(p.requestId),
     'failed to resolve bash approval prompt',
-    signal,
-  );
-  registerEvent(
-    bus,
-    'updateBashApprovalBypassState',
-    (p) =>
-      callbacks.updateBashApprovalBypassState(p.streamId, p.bypassActive),
-    'failed to update bash approval bypass state',
     signal,
   );
 

--- a/src/progressView/events/UIEvents.ts
+++ b/src/progressView/events/UIEvents.ts
@@ -38,6 +38,18 @@ export interface ApprovalCallbacks {
   ) => void;
 }
 
+/** Callbacks for bash approval event handling. */
+export interface BashApprovalCallbacks {
+  showBashApprovalPrompt: (
+    payload: ProgressEventPayloads['showBashApprovalPrompt'],
+  ) => void;
+  resolveBashApprovalPrompt: (requestId: string) => void;
+  updateBashApprovalBypassState: (
+    streamId: string,
+    bypassActive: boolean,
+  ) => void;
+}
+
 /** Callbacks for agent proposal handling (workflow or tool-use). */
 export interface AgentProposalCallbacks {
   showAgentProposal: (
@@ -49,6 +61,7 @@ export interface AgentProposalCallbacks {
 /** Combined UI callbacks interface. */
 export type UICallbacks = RetryCallbacks &
   ApprovalCallbacks &
+  BashApprovalCallbacks &
   AgentProposalCallbacks;
 
 /** Helper to register an event with error handling wrapper. */
@@ -113,6 +126,30 @@ export function registerUIEvents(
     (p) =>
       callbacks.updateToolEditApprovalBypassState(p.streamId, p.bypassActive),
     'failed to update approval bypass state',
+    signal,
+  );
+
+  // Bash approval events
+  registerEvent(
+    bus,
+    'showBashApprovalPrompt',
+    callbacks.showBashApprovalPrompt,
+    'failed to show bash approval prompt',
+    signal,
+  );
+  registerEvent(
+    bus,
+    'resolveBashApprovalPrompt',
+    (p) => callbacks.resolveBashApprovalPrompt(p.requestId),
+    'failed to resolve bash approval prompt',
+    signal,
+  );
+  registerEvent(
+    bus,
+    'updateBashApprovalBypassState',
+    (p) =>
+      callbacks.updateBashApprovalBypassState(p.streamId, p.bypassActive),
+    'failed to update bash approval bypass state',
     signal,
   );
 

--- a/src/progressView/events/index.ts
+++ b/src/progressView/events/index.ts
@@ -5,7 +5,6 @@ export {
   registerUIEvents,
   type RetryCallbacks,
   type ApprovalCallbacks,
-  type BashApprovalCallbacks,
 } from './UIEvents';
 export { type ProgressEventBusLike } from '@eventBus/ProgressEventBus';
 

--- a/src/progressView/events/index.ts
+++ b/src/progressView/events/index.ts
@@ -5,6 +5,7 @@ export {
   registerUIEvents,
   type RetryCallbacks,
   type ApprovalCallbacks,
+  type BashApprovalCallbacks,
 } from './UIEvents';
 export { type ProgressEventBusLike } from '@eventBus/ProgressEventBus';
 

--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -47,6 +47,7 @@
           "./modules/uiManagers/InstructionPanel.js": "${instructionPanelUri}",
           "./modules/uiManagers/FollowUpInputManager.js": "${followUpInputManagerUri}",
           "./modules/uiManagers/ApprovalRequests.js": "${approvalRequestsUri}",
+          "./modules/uiManagers/BashApprovalRequests.js": "${bashApprovalRequestsUri}",
           "./modules/uiManagers/RetryRequests.js": "${retryRequestsUri}",
           "./modules/uiManagers/WorkflowProposals.js": "${workflowProposalsUri}",
           "./modules/uiManagers/TodoList.js": "${todoListUri}",
@@ -181,6 +182,13 @@
               <span>Pending approvals</span>
             </div>
             <div class="approval-requests__list"></div>
+          </div>
+          <div id="bashApprovalRequests" class="bash-approval-requests" hidden>
+            <div class="bash-approval-requests__header">
+              <i class="codicon codicon-terminal"></i>
+              <span>Command approval</span>
+            </div>
+            <div class="bash-approval-requests__list"></div>
           </div>
           <div id="retryRequests" class="retry-requests" hidden>
             <div class="retry-requests__header">
@@ -691,6 +699,29 @@
                   icon="close"
                   label="Reject"
                   title="Reject (click to add feedback)"
+                  data-action="reject"
+                  >Reject</vscode-toolbar-button
+                >
+              </vscode-toolbar-container>
+            </div>
+          </template>
+          <template id="bashApprovalRequestTemplate">
+            <div class="bash-approval-request">
+              <div class="bash-approval-request__details">
+                <div class="bash-approval-request__command"></div>
+              </div>
+              <vscode-toolbar-container class="bash-approval-request__actions">
+                <vscode-toolbar-button
+                  icon="check"
+                  label="Approve"
+                  title="Allow this command to execute"
+                  data-action="approve"
+                  >Approve</vscode-toolbar-button
+                >
+                <vscode-toolbar-button
+                  icon="close"
+                  label="Reject"
+                  title="Reject this command"
                   data-action="reject"
                   >Reject</vscode-toolbar-button
                 >

--- a/src/progressView/managers/WebviewUpdater.ts
+++ b/src/progressView/managers/WebviewUpdater.ts
@@ -24,6 +24,7 @@ import { ProgressViewState } from '@progressView/state/ProgressViewState';
 import type {
   RetryRequestPrompt,
   ToolEditApprovalPrompt,
+  BashApprovalPrompt,
   AgentProposalPrompt,
 } from '@eventBus/types';
 import type { TodoItem, UpdateTaskGroupPayload } from '@eventBus/schemas';
@@ -208,6 +209,28 @@ export class WebviewUpdater {
   ): void {
     this.sendMessage({
       command: COMMANDS.UPDATE_TOOL_EDIT_APPROVAL_STATE,
+      stream,
+      bypassActive,
+    });
+  }
+
+  showBashApprovalPrompt(prompt: BashApprovalPrompt): void {
+    this.sendMessage({
+      command: COMMANDS.SHOW_BASH_APPROVAL,
+      request: prompt,
+    });
+  }
+
+  resolveBashApprovalPrompt(requestId: string): void {
+    this.sendMessage({
+      command: COMMANDS.RESOLVE_BASH_APPROVAL,
+      requestId,
+    });
+  }
+
+  updateBashApprovalState(stream: StreamTabId, bypassActive: boolean): void {
+    this.sendMessage({
+      command: COMMANDS.UPDATE_BASH_APPROVAL_STATE,
       stream,
       bypassActive,
     });

--- a/src/progressView/managers/WebviewUpdater.ts
+++ b/src/progressView/managers/WebviewUpdater.ts
@@ -228,14 +228,6 @@ export class WebviewUpdater {
     });
   }
 
-  updateBashApprovalState(stream: StreamTabId, bypassActive: boolean): void {
-    this.sendMessage({
-      command: COMMANDS.UPDATE_BASH_APPROVAL_STATE,
-      stream,
-      bypassActive,
-    });
-  }
-
   showRetryRequest(request: RetryRequestPrompt): void {
     this.sendMessage({
       command: COMMANDS.SHOW_RETRY_REQUEST,

--- a/src/progressView/modules/domHandlers.js
+++ b/src/progressView/modules/domHandlers.js
@@ -12,6 +12,7 @@ import { InstructionPanel } from './uiManagers/InstructionPanel.js';
 import { FollowUpInputManager } from './uiManagers/FollowUpInputManager.js';
 import { FollowupSectionManager } from './uiManagers/FollowupSectionManager.js';
 import { ApprovalRequests } from './uiManagers/ApprovalRequests.js';
+import { BashApprovalRequests } from './uiManagers/BashApprovalRequests.js';
 import { RetryRequests } from './uiManagers/RetryRequests.js';
 import { WorkflowProposals } from './uiManagers/WorkflowProposals.js';
 import { Toolbar } from './uiManagers/Toolbar.js';
@@ -44,6 +45,7 @@ class ProgressViewDomHandler extends BaseDomHandler {
       followUpInput: new FollowUpInputManager(vscode),
       followupSection: new FollowupSectionManager(vscode),
       approvalRequests: new ApprovalRequests(),
+      bashApprovalRequests: new BashApprovalRequests(),
       retryRequests: new RetryRequests(),
       workflowProposals: new WorkflowProposals(),
       todoList: new TodoList(),

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -385,6 +385,9 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
         this.handleResolveToolEditApproval.bind(this),
       [COMMANDS.UPDATE_TOOL_EDIT_APPROVAL_STATE]:
         this.handleUpdateToolEditApprovalState.bind(this),
+      [COMMANDS.SHOW_BASH_APPROVAL]: this.handleShowBashApproval.bind(this),
+      [COMMANDS.RESOLVE_BASH_APPROVAL]:
+        this.handleResolveBashApproval.bind(this),
       [COMMANDS.SHOW_RETRY_REQUEST]: this.handleShowRetryRequest.bind(this),
       [COMMANDS.RESOLVE_RETRY_REQUEST]:
         this.handleResolveRetryRequest.bind(this),
@@ -477,6 +480,7 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     // No need to restore from frontend cache here
 
     dom.approvalRequests.setActiveStream(message.activeStream, isToolAgent);
+    dom.bashApprovalRequests.setActiveStream(message.activeStream, isToolAgent);
     dom.retryRequests.setActiveStream(message.activeStream, isToolAgent);
     dom.workflowProposals.setActiveStream(message.activeStream, isToolAgent);
 
@@ -953,6 +957,14 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
 
   handleResolveToolEditApproval(message) {
     if (message?.requestId) dom.approvalRequests.resolve(message.requestId);
+  }
+
+  handleShowBashApproval(message) {
+    if (message?.request) dom.bashApprovalRequests.show(message.request);
+  }
+
+  handleResolveBashApproval(message) {
+    if (message?.requestId) dom.bashApprovalRequests.resolve(message.requestId);
   }
 
   handleUpdateToolEditApprovalState(message) {

--- a/src/progressView/modules/uiManagers/BashApprovalRequests.js
+++ b/src/progressView/modules/uiManagers/BashApprovalRequests.js
@@ -1,0 +1,70 @@
+// Local imports - progress view
+import { COMMANDS } from '../constants.js';
+import { BaseUIRequestManager } from './BaseUIRequestManager.js';
+
+// Local imports - common helpers
+import { createFromTemplate } from '@common/templateUtils.js';
+import { vscode } from '@common/webviewContext.js';
+
+/** Manages approval request popups for bash command execution. */
+export class BashApprovalRequests extends BaseUIRequestManager {
+  constructor() {
+    super({
+      containerId: 'bashApprovalRequests',
+      listSelector: '.bash-approval-requests__list',
+      idAttribute: 'requestId',
+    });
+  }
+
+  _createRequestElement(request) {
+    const element = createFromTemplate('bashApprovalRequestTemplate');
+    if (!element) {
+      console.error('BashApprovalRequests: template not found');
+      return document.createElement('div');
+    }
+
+    this._setRequestId(
+      [element, ...element.querySelectorAll('[data-action]')],
+      request.requestId,
+    );
+
+    this._updateRequestElement(element, request);
+    return element;
+  }
+
+  _updateRequestElement(element, request) {
+    const commandElem = element.querySelector('.bash-approval-request__command');
+    element.dataset.streamId = request.streamId || '';
+
+    if (commandElem) {
+      // Display command in a code-like format
+      const code = document.createElement('code');
+      code.textContent = request.command || '';
+      commandElem.textContent = '';
+      commandElem.appendChild(code);
+    }
+  }
+
+  _handleAction(event) {
+    if (!(event.target instanceof Element)) return;
+
+    const button = event.target.closest('[data-request-id][data-action]');
+    if (!button) return;
+
+    const { requestId, action } = button.dataset;
+    if (!requestId || !action) return;
+
+    const validActions = ['approve', 'reject'];
+    if (!validActions.includes(action)) return;
+
+    vscode.postMessage({
+      command: COMMANDS.BASH_APPROVAL_ACTION,
+      requestId,
+      action,
+    });
+  }
+
+  _setRequestId(elements, requestId) {
+    elements.forEach((el) => el && (el.dataset.requestId = requestId));
+  }
+}

--- a/src/progressView/styles/approval-requests.css
+++ b/src/progressView/styles/approval-requests.css
@@ -98,3 +98,36 @@
   vscode-toolbar-button[data-action='reject']::part(control) {
   color: var(--vscode-inputValidation-warningBorder);
 }
+
+/**
+ * Bash approval requests styles
+ */
+
+.bash-approval-requests {
+  border: 1px solid var(--vscode-input-border);
+  background: var(--vscode-editor-background);
+}
+
+.bash-approval-requests__header .codicon {
+  color: var(--vscode-terminal-ansiYellow);
+}
+
+.bash-approval-request__command {
+  font-family: var(--vscode-editor-font-family);
+  font-size: var(--font-size-sm);
+}
+
+.bash-approval-request__command code {
+  display: block;
+  padding: var(--spacing-medium);
+  background: var(--vscode-textCodeBlock-background);
+  border-radius: var(--border-radius);
+  color: var(--vscode-terminal-foreground);
+  white-space: pre-wrap;
+  word-break: break-word;
+  overflow-x: auto;
+}
+
+.bash-approval-request__actions vscode-toolbar-button {
+  flex: 1 1 12rem;
+}

--- a/src/progressView/styles/requests-shared.css
+++ b/src/progressView/styles/requests-shared.css
@@ -3,6 +3,7 @@
  */
 
 .approval-requests,
+.bash-approval-requests,
 .retry-requests,
 .workflow-proposals {
   margin: var(--spacing-large) 0;
@@ -15,12 +16,14 @@
 }
 
 .approval-requests.is-visible,
+.bash-approval-requests.is-visible,
 .retry-requests.is-visible,
 .workflow-proposals.is-visible {
   display: flex;
 }
 
 .approval-requests__header,
+.bash-approval-requests__header,
 .retry-requests__header,
 .workflow-proposals__header {
   display: flex;
@@ -31,6 +34,7 @@
 }
 
 .approval-requests__list,
+.bash-approval-requests__list,
 .retry-requests__list,
 .workflow-proposals__list {
   display: flex;
@@ -39,6 +43,7 @@
 }
 
 .approval-request,
+.bash-approval-request,
 .retry-request,
 .workflow-proposal {
   display: flex;
@@ -51,6 +56,7 @@
 }
 
 .approval-request__details,
+.bash-approval-request__details,
 .retry-request__details,
 .workflow-proposal__details {
   display: flex;
@@ -69,6 +75,7 @@
 }
 
 .approval-request__actions,
+.bash-approval-request__actions,
 .retry-request__actions,
 .workflow-proposal__actions {
   display: flex;
@@ -77,6 +84,7 @@
 }
 
 .approval-request__actions::part(container),
+.bash-approval-request__actions::part(container),
 .retry-request__actions::part(container),
 .workflow-proposal__actions::part(container) {
   display: flex;
@@ -85,12 +93,14 @@
 }
 
 .approval-request__actions vscode-toolbar-button,
+.bash-approval-request__actions vscode-toolbar-button,
 .retry-request__actions vscode-toolbar-button,
 .workflow-proposal__actions vscode-toolbar-button {
   min-width: auto;
 }
 
 .approval-request__actions vscode-toolbar-button::part(control),
+.bash-approval-request__actions vscode-toolbar-button::part(control),
 .retry-request__actions vscode-toolbar-button::part(control),
 .workflow-proposal__actions vscode-toolbar-button::part(control) {
   justify-content: flex-start;

--- a/src/test/tools/ToolEditApprovalGate.test.ts
+++ b/src/test/tools/ToolEditApprovalGate.test.ts
@@ -12,7 +12,7 @@ import {
   setToolEditApprovalSessionBypass,
   toggleToolEditApprovalSessionBypass,
   type ToolEditApprovalRequest,
-} from '@tools/approval/toolEditApproval';
+} from '@tools/approval';
 import * as configModule from '@utils/config';
 import { WorkspaceFS } from '@utils/files';
 

--- a/src/test/tools/ToolEditApprovalGate.test.ts
+++ b/src/test/tools/ToolEditApprovalGate.test.ts
@@ -7,7 +7,7 @@ import type { StreamTabId } from '@agent/types/IdentifierTypes';
 // Local imports - tools
 import { WriteFileTool } from '@tools/WriteTool';
 import {
-  clearAllApprovalBypass,
+  cleanupAllApprovals,
   setToolEditApprovalHandler,
   setToolEditApprovalSessionBypass,
   toggleToolEditApprovalSessionBypass,
@@ -32,7 +32,7 @@ describe('Tool edit approval gating', () => {
     originalWrite = WorkspaceFS.write;
     originalAppend = WorkspaceFS.appendFile;
     originalGetConfig = configModule.getConfig;
-    clearAllApprovalBypass();
+    cleanupAllApprovals();
   });
 
   afterEach(() => {
@@ -43,7 +43,7 @@ describe('Tool edit approval gating', () => {
     (configModule as { getConfig: typeof originalGetConfig }).getConfig =
       originalGetConfig;
     setToolEditApprovalHandler();
-    clearAllApprovalBypass();
+    cleanupAllApprovals();
   });
 
   it('write_file applies changes after approval', async () => {

--- a/src/tools/approval/bashApproval.ts
+++ b/src/tools/approval/bashApproval.ts
@@ -10,6 +10,9 @@ import { safeExecuteCommand } from '@frontend/system/commandUtils';
 import { getConfig } from '@utils/config';
 import { bus } from '@eventBus/ProgressEventBus';
 
+// Local file imports - use shared YOLO state
+import { isApprovalBypassedForStream } from './toolEditApproval';
+
 export interface BashApprovalRequest {
   command: string;
   streamId?: StreamTabId;
@@ -47,51 +50,6 @@ let customHandler:
   | undefined;
 let approvalCounter = 0;
 const pendingApprovals = new Map<string, PendingBashApprovalEntry>();
-/** Per-stream YOLO mode state tracking (single source of truth) */
-const approvalsBypassedByStream = new Map<StreamTabId, boolean>();
-
-function notifyProgressViewApprovalBypassState(streamId: StreamTabId): void {
-  if (!initialized) {
-    return;
-  }
-  const bypassActive = approvalsBypassedByStream.get(streamId) ?? false;
-  bus.emit('updateBashApprovalBypassState', {
-    streamId,
-    bypassActive,
-  });
-}
-
-export function setBashApprovalSessionBypass(
-  streamId: StreamTabId,
-  enabled: boolean,
-): void {
-  approvalsBypassedByStream.set(streamId, enabled);
-  notifyProgressViewApprovalBypassState(streamId);
-}
-
-export function toggleBashApprovalSessionBypass(streamId: StreamTabId): boolean {
-  const currentState = approvalsBypassedByStream.get(streamId) ?? false;
-  const newState = !currentState;
-  setBashApprovalSessionBypass(streamId, newState);
-  return newState;
-}
-
-/** Check if YOLO mode is enabled for a specific stream */
-export function isBashApprovalBypassedForStream(
-  streamId: StreamTabId,
-): boolean {
-  return approvalsBypassedByStream.get(streamId) ?? false;
-}
-
-/** Clear YOLO mode state for a deleted stream (prevents memory leak) */
-export function clearBashApprovalBypassForStream(streamId: StreamTabId): void {
-  approvalsBypassedByStream.delete(streamId);
-}
-
-/** Clear all YOLO mode state (used when deleting all streams) */
-export function clearAllBashApprovalBypass(): void {
-  approvalsBypassedByStream.clear();
-}
 
 export function initializeBashApproval(): void {
   if (initialized) {
@@ -112,7 +70,8 @@ async function showProgressViewApprovalPrompt(
 ): Promise<void> {
   await safeExecuteCommand('texra.showProgressView');
   const streamId = request.streamId;
-  const isBypassed = streamId && isBashApprovalBypassedForStream(streamId);
+  // Use shared YOLO state from toolEditApproval
+  const isBypassed = streamId && isApprovalBypassedForStream(streamId);
   bus.emit('showBashApprovalPrompt', {
     requestId,
     command: request.command,
@@ -167,7 +126,6 @@ async function nativeRequestApproval(
 async function enqueueApproval(
   request: BashApprovalRequest,
 ): Promise<BashApprovalResult> {
-  // Note: YOLO bypass is checked in requestBashApproval before enqueueing
   const run = async () =>
     customHandler ? customHandler(request) : nativeRequestApproval(request);
 
@@ -190,9 +148,9 @@ export async function requestBashApproval(
       ? request
       : { ...request, streamId: context.streamId };
 
-  // Check global config and per-stream YOLO mode
+  // Check global config and shared YOLO mode (same as tool edits)
   const streamId = preparedRequest.streamId;
-  const isStreamBypassed = streamId && isBashApprovalBypassedForStream(streamId);
+  const isStreamBypassed = streamId && isApprovalBypassedForStream(streamId);
   if (!approvalsEnabled || isStreamBypassed) {
     return { accepted: true };
   }
@@ -228,7 +186,13 @@ export async function handleProgressViewBashApprovalAction(
 export function buildBashApprovalRejectedResult(
   command: string,
   userMessage?: string,
-): { output: string; summary: string; error: string; isError: true; userInstruction?: string } {
+): {
+  output: string;
+  summary: string;
+  error: string;
+  isError: true;
+  userInstruction?: string;
+} {
   const commandPreview =
     command.length > 60 ? `${command.slice(0, 57)}…` : command;
   const baseMessage = `User rejected bash command: ${commandPreview}`;

--- a/src/tools/approval/bashApproval.ts
+++ b/src/tools/approval/bashApproval.ts
@@ -1,6 +1,3 @@
-// Third-party imports
-import * as vscode from 'vscode';
-
 // Local imports - agent types
 import type { StreamTabId } from '@agent/types/IdentifierTypes';
 
@@ -25,162 +22,79 @@ export interface BashApprovalResult {
 
 export const BASH_APPROVAL_CONFIG_KEY = 'texra.toolUse.requireBashApproval';
 
-interface PendingBashApprovalEntry {
-  request: BashApprovalRequest;
-  streamId?: StreamTabId;
-  settle: (result: BashApprovalResult) => void;
-  isSettled: () => boolean;
-}
-
 /** All valid approval actions for bash prompts */
 export const BASH_APPROVAL_ACTIONS = ['approve', 'reject'] as const;
 
 export type BashApprovalAction = (typeof BASH_APPROVAL_ACTIONS)[number];
 
-interface BashApprovalActionPayload {
-  requestId: string;
-  action: BashApprovalAction;
-  feedback?: string;
-}
-
+// Approval queue state
 let queue: Promise<void> = Promise.resolve();
-let initialized = false;
-let customHandler:
-  | ((request: BashApprovalRequest) => Promise<BashApprovalResult>)
-  | undefined;
 let approvalCounter = 0;
-const pendingApprovals = new Map<string, PendingBashApprovalEntry>();
-
-export function initializeBashApproval(): void {
-  if (initialized) {
-    return;
-  }
-  initialized = true;
-}
-
-export function setBashApprovalHandler(
-  handler?: (request: BashApprovalRequest) => Promise<BashApprovalResult>,
-): void {
-  customHandler = handler;
-}
-
-async function showProgressViewApprovalPrompt(
-  requestId: string,
-  request: BashApprovalRequest,
-): Promise<void> {
-  await safeExecuteCommand('texra.showProgressView');
-  const streamId = request.streamId;
-  // Use shared YOLO state from toolEditApproval
-  const isBypassed = streamId && isApprovalBypassedForStream(streamId);
-  bus.emit('showBashApprovalPrompt', {
-    requestId,
-    command: request.command,
-    allowBypass: !isBypassed,
-    streamId: streamId ?? '',
-  });
-}
-
-function resolveProgressViewApprovalPrompt(requestId: string): void {
-  bus.emit('resolveBashApprovalPrompt', { requestId });
-}
-
-async function nativeRequestApproval(
-  request: BashApprovalRequest,
-): Promise<BashApprovalResult> {
-  const { command, streamId } = request;
-
-  approvalCounter += 1;
-  const requestId = `bash-approval-${Date.now().toString(36)}-${approvalCounter}`;
-
-  let result: BashApprovalResult = { accepted: false };
-  try {
-    result = await new Promise<BashApprovalResult>((resolve) => {
-      let settled = false;
-
-      const settle = (value: BashApprovalResult) => {
-        if (settled) {
-          return;
-        }
-        settled = true;
-        resolve(value);
-      };
-
-      const entry: PendingBashApprovalEntry = {
-        request,
-        streamId,
-        isSettled: () => settled,
-        settle,
-      };
-
-      pendingApprovals.set(requestId, entry);
-      void showProgressViewApprovalPrompt(requestId, request);
-    });
-
-    return result;
-  } finally {
-    pendingApprovals.delete(requestId);
-    resolveProgressViewApprovalPrompt(requestId);
-  }
-}
-
-async function enqueueApproval(
-  request: BashApprovalRequest,
-): Promise<BashApprovalResult> {
-  const run = async () =>
-    customHandler ? customHandler(request) : nativeRequestApproval(request);
-
-  const operation = queue.then(run);
-  queue = operation.then(
-    () => {},
-    () => {},
-  );
-  return operation;
-}
+const pendingApprovals = new Map<
+  string,
+  { settle: (result: BashApprovalResult) => void; isSettled: () => boolean }
+>();
 
 export async function requestBashApproval(
   request: BashApprovalRequest,
 ): Promise<BashApprovalResult> {
   const approvalsEnabled = getConfig<boolean>(BASH_APPROVAL_CONFIG_KEY, true);
 
+  // Resolve streamId from context if not provided
   const context = getCurrentToolFileInteractionContext();
-  const preparedRequest =
-    request.streamId || !context?.streamId
-      ? request
-      : { ...request, streamId: context.streamId };
+  const streamId = request.streamId ?? context?.streamId;
 
-  // Check global config and shared YOLO mode (same as tool edits)
-  const streamId = preparedRequest.streamId;
-  const isStreamBypassed = streamId && isApprovalBypassedForStream(streamId);
-  if (!approvalsEnabled || isStreamBypassed) {
+  // Skip if globally disabled or YOLO mode active
+  if (!approvalsEnabled || (streamId && isApprovalBypassedForStream(streamId))) {
     return { accepted: true };
   }
 
-  return enqueueApproval(preparedRequest);
+  // Enqueue to serialize approval prompts
+  const operation = queue.then(() => showApprovalPrompt(request, streamId));
+  queue = operation.then(() => {}, () => {});
+  return operation;
 }
 
-export async function handleProgressViewBashApprovalAction(
-  payload: BashApprovalActionPayload,
-): Promise<void> {
-  const entry = pendingApprovals.get(payload.requestId);
-  if (!entry || entry.isSettled()) {
-    return;
-  }
+async function showApprovalPrompt(
+  request: BashApprovalRequest,
+  streamId?: StreamTabId,
+): Promise<BashApprovalResult> {
+  const requestId = `bash-${Date.now().toString(36)}-${++approvalCounter}`;
 
-  switch (payload.action) {
-    case 'approve': {
-      entry.settle({ accepted: true });
-      break;
-    }
-
-    case 'reject': {
-      const userMessage = payload.feedback?.trim();
-      entry.settle({
-        accepted: false,
-        userMessage: userMessage || undefined,
+  try {
+    return await new Promise<BashApprovalResult>((resolve) => {
+      let settled = false;
+      pendingApprovals.set(requestId, {
+        settle: (result) => { if (!settled) { settled = true; resolve(result); } },
+        isSettled: () => settled,
       });
-      break;
-    }
+
+      void safeExecuteCommand('texra.showProgressView');
+      bus.emit('showBashApprovalPrompt', {
+        requestId,
+        command: request.command,
+        allowBypass: !(streamId && isApprovalBypassedForStream(streamId)),
+        streamId: streamId ?? '',
+      });
+    });
+  } finally {
+    pendingApprovals.delete(requestId);
+    bus.emit('resolveBashApprovalPrompt', { requestId });
   }
+}
+
+export async function handleProgressViewBashApprovalAction(payload: {
+  requestId: string;
+  action: BashApprovalAction;
+  feedback?: string;
+}): Promise<void> {
+  const entry = pendingApprovals.get(payload.requestId);
+  if (!entry || entry.isSettled()) return;
+
+  entry.settle({
+    accepted: payload.action === 'approve',
+    userMessage: payload.action === 'reject' ? payload.feedback?.trim() : undefined,
+  });
 }
 
 export function buildBashApprovalRejectedResult(
@@ -193,15 +107,13 @@ export function buildBashApprovalRejectedResult(
   isError: true;
   userInstruction?: string;
 } {
-  const commandPreview =
-    command.length > 60 ? `${command.slice(0, 57)}…` : command;
-  const baseMessage = `User rejected bash command: ${commandPreview}`;
-  const feedback = userMessage?.trim();
+  const preview = command.length > 60 ? `${command.slice(0, 57)}…` : command;
+  const message = `User rejected bash command: ${preview}`;
   return {
-    output: baseMessage,
-    summary: baseMessage,
-    error: baseMessage,
+    output: message,
+    summary: message,
+    error: message,
     isError: true,
-    ...(feedback ? { userInstruction: feedback } : {}),
+    ...(userMessage?.trim() ? { userInstruction: userMessage.trim() } : {}),
   };
 }

--- a/src/tools/approval/bashApproval.ts
+++ b/src/tools/approval/bashApproval.ts
@@ -35,7 +35,11 @@ let queue: Promise<void> = Promise.resolve();
 let approvalCounter = 0;
 const pendingApprovals = new Map<
   string,
-  { settle: (result: BashApprovalResult) => void; isSettled: () => boolean }
+  {
+    streamId?: StreamTabId;
+    settle: (result: BashApprovalResult) => void;
+    isSettled: () => boolean;
+  }
 >();
 
 export async function requestBashApproval(
@@ -74,6 +78,7 @@ async function showApprovalPrompt(
       };
 
       pendingApprovals.set(requestId, {
+        streamId,
         settle,
         isSettled: () => settled,
       });
@@ -104,6 +109,25 @@ export async function handleProgressViewBashApprovalAction(payload: {
     accepted: payload.action === 'approve',
     userMessage: payload.action === 'reject' ? payload.feedback?.trim() : undefined,
   });
+}
+
+/** Reject all pending bash approvals for a deleted stream (prevents memory leak) */
+export function rejectPendingBashApprovalsForStream(streamId: StreamTabId): void {
+  for (const entry of pendingApprovals.values()) {
+    if (entry.streamId === streamId && !entry.isSettled()) {
+      // Settling triggers finally block which emits resolveBashApprovalPrompt
+      entry.settle({ accepted: false });
+    }
+  }
+}
+
+/** Reject all pending bash approvals (used when deleting all streams) */
+export function rejectAllPendingBashApprovals(): void {
+  for (const entry of pendingApprovals.values()) {
+    if (!entry.isSettled()) {
+      entry.settle({ accepted: false });
+    }
+  }
 }
 
 export function buildBashApprovalRejectedResult(

--- a/src/tools/approval/bashApproval.ts
+++ b/src/tools/approval/bashApproval.ts
@@ -1,0 +1,243 @@
+// Third-party imports
+import * as vscode from 'vscode';
+
+// Local imports - agent types
+import type { StreamTabId } from '@agent/types/IdentifierTypes';
+
+// Local imports - utils
+import { getCurrentToolFileInteractionContext } from '@agent/toolUse/ToolFileInteractionContext';
+import { safeExecuteCommand } from '@frontend/system/commandUtils';
+import { getConfig } from '@utils/config';
+import { bus } from '@eventBus/ProgressEventBus';
+
+export interface BashApprovalRequest {
+  command: string;
+  streamId?: StreamTabId;
+}
+
+export interface BashApprovalResult {
+  accepted: boolean;
+  userMessage?: string;
+}
+
+export const BASH_APPROVAL_CONFIG_KEY = 'texra.toolUse.requireBashApproval';
+
+interface PendingBashApprovalEntry {
+  request: BashApprovalRequest;
+  streamId?: StreamTabId;
+  settle: (result: BashApprovalResult) => void;
+  isSettled: () => boolean;
+}
+
+/** All valid approval actions for bash prompts */
+export const BASH_APPROVAL_ACTIONS = ['approve', 'reject'] as const;
+
+export type BashApprovalAction = (typeof BASH_APPROVAL_ACTIONS)[number];
+
+interface BashApprovalActionPayload {
+  requestId: string;
+  action: BashApprovalAction;
+  feedback?: string;
+}
+
+let queue: Promise<void> = Promise.resolve();
+let initialized = false;
+let customHandler:
+  | ((request: BashApprovalRequest) => Promise<BashApprovalResult>)
+  | undefined;
+let approvalCounter = 0;
+const pendingApprovals = new Map<string, PendingBashApprovalEntry>();
+/** Per-stream YOLO mode state tracking (single source of truth) */
+const approvalsBypassedByStream = new Map<StreamTabId, boolean>();
+
+function notifyProgressViewApprovalBypassState(streamId: StreamTabId): void {
+  if (!initialized) {
+    return;
+  }
+  const bypassActive = approvalsBypassedByStream.get(streamId) ?? false;
+  bus.emit('updateBashApprovalBypassState', {
+    streamId,
+    bypassActive,
+  });
+}
+
+export function setBashApprovalSessionBypass(
+  streamId: StreamTabId,
+  enabled: boolean,
+): void {
+  approvalsBypassedByStream.set(streamId, enabled);
+  notifyProgressViewApprovalBypassState(streamId);
+}
+
+export function toggleBashApprovalSessionBypass(streamId: StreamTabId): boolean {
+  const currentState = approvalsBypassedByStream.get(streamId) ?? false;
+  const newState = !currentState;
+  setBashApprovalSessionBypass(streamId, newState);
+  return newState;
+}
+
+/** Check if YOLO mode is enabled for a specific stream */
+export function isBashApprovalBypassedForStream(
+  streamId: StreamTabId,
+): boolean {
+  return approvalsBypassedByStream.get(streamId) ?? false;
+}
+
+/** Clear YOLO mode state for a deleted stream (prevents memory leak) */
+export function clearBashApprovalBypassForStream(streamId: StreamTabId): void {
+  approvalsBypassedByStream.delete(streamId);
+}
+
+/** Clear all YOLO mode state (used when deleting all streams) */
+export function clearAllBashApprovalBypass(): void {
+  approvalsBypassedByStream.clear();
+}
+
+export function initializeBashApproval(): void {
+  if (initialized) {
+    return;
+  }
+  initialized = true;
+}
+
+export function setBashApprovalHandler(
+  handler?: (request: BashApprovalRequest) => Promise<BashApprovalResult>,
+): void {
+  customHandler = handler;
+}
+
+async function showProgressViewApprovalPrompt(
+  requestId: string,
+  request: BashApprovalRequest,
+): Promise<void> {
+  await safeExecuteCommand('texra.showProgressView');
+  const streamId = request.streamId;
+  const isBypassed = streamId && isBashApprovalBypassedForStream(streamId);
+  bus.emit('showBashApprovalPrompt', {
+    requestId,
+    command: request.command,
+    allowBypass: !isBypassed,
+    streamId: streamId ?? '',
+  });
+}
+
+function resolveProgressViewApprovalPrompt(requestId: string): void {
+  bus.emit('resolveBashApprovalPrompt', { requestId });
+}
+
+async function nativeRequestApproval(
+  request: BashApprovalRequest,
+): Promise<BashApprovalResult> {
+  const { command, streamId } = request;
+
+  approvalCounter += 1;
+  const requestId = `bash-approval-${Date.now().toString(36)}-${approvalCounter}`;
+
+  let result: BashApprovalResult = { accepted: false };
+  try {
+    result = await new Promise<BashApprovalResult>((resolve) => {
+      let settled = false;
+
+      const settle = (value: BashApprovalResult) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        resolve(value);
+      };
+
+      const entry: PendingBashApprovalEntry = {
+        request,
+        streamId,
+        isSettled: () => settled,
+        settle,
+      };
+
+      pendingApprovals.set(requestId, entry);
+      void showProgressViewApprovalPrompt(requestId, request);
+    });
+
+    return result;
+  } finally {
+    pendingApprovals.delete(requestId);
+    resolveProgressViewApprovalPrompt(requestId);
+  }
+}
+
+async function enqueueApproval(
+  request: BashApprovalRequest,
+): Promise<BashApprovalResult> {
+  // Note: YOLO bypass is checked in requestBashApproval before enqueueing
+  const run = async () =>
+    customHandler ? customHandler(request) : nativeRequestApproval(request);
+
+  const operation = queue.then(run);
+  queue = operation.then(
+    () => {},
+    () => {},
+  );
+  return operation;
+}
+
+export async function requestBashApproval(
+  request: BashApprovalRequest,
+): Promise<BashApprovalResult> {
+  const approvalsEnabled = getConfig<boolean>(BASH_APPROVAL_CONFIG_KEY, true);
+
+  const context = getCurrentToolFileInteractionContext();
+  const preparedRequest =
+    request.streamId || !context?.streamId
+      ? request
+      : { ...request, streamId: context.streamId };
+
+  // Check global config and per-stream YOLO mode
+  const streamId = preparedRequest.streamId;
+  const isStreamBypassed = streamId && isBashApprovalBypassedForStream(streamId);
+  if (!approvalsEnabled || isStreamBypassed) {
+    return { accepted: true };
+  }
+
+  return enqueueApproval(preparedRequest);
+}
+
+export async function handleProgressViewBashApprovalAction(
+  payload: BashApprovalActionPayload,
+): Promise<void> {
+  const entry = pendingApprovals.get(payload.requestId);
+  if (!entry || entry.isSettled()) {
+    return;
+  }
+
+  switch (payload.action) {
+    case 'approve': {
+      entry.settle({ accepted: true });
+      break;
+    }
+
+    case 'reject': {
+      const userMessage = payload.feedback?.trim();
+      entry.settle({
+        accepted: false,
+        userMessage: userMessage || undefined,
+      });
+      break;
+    }
+  }
+}
+
+export function buildBashApprovalRejectedResult(
+  command: string,
+  userMessage?: string,
+): { output: string; summary: string; error: string; isError: true; userInstruction?: string } {
+  const commandPreview =
+    command.length > 60 ? `${command.slice(0, 57)}…` : command;
+  const baseMessage = `User rejected bash command: ${commandPreview}`;
+  const feedback = userMessage?.trim();
+  return {
+    output: baseMessage,
+    summary: baseMessage,
+    error: baseMessage,
+    isError: true,
+    ...(feedback ? { userInstruction: feedback } : {}),
+  };
+}

--- a/src/tools/approval/bashApproval.ts
+++ b/src/tools/approval/bashApproval.ts
@@ -86,6 +86,11 @@ async function showApprovalPrompt(
   request: BashApprovalRequest,
   streamId?: StreamTabId,
 ): Promise<BashApprovalResult> {
+  // Re-check YOLO mode: user may have enabled it while this request was queued
+  if (streamId && isApprovalBypassedForStream(streamId)) {
+    return { accepted: true };
+  }
+
   const requestId = `bash-${Date.now().toString(36)}-${++approvalCounter}`;
 
   try {

--- a/src/tools/approval/bashApproval.ts
+++ b/src/tools/approval/bashApproval.ts
@@ -111,8 +111,8 @@ export async function handleProgressViewBashApprovalAction(payload: {
   });
 }
 
-/** Reject all pending bash approvals for a stream (called by unified cleanup) */
-export function rejectPendingBashApprovalsForStream(streamId: StreamTabId): void {
+/** @internal Called by unified cleanup in toolEditApproval.ts */
+export function _rejectPendingBashApprovalsForStream(streamId: StreamTabId): void {
   for (const entry of pendingApprovals.values()) {
     if (entry.streamId === streamId && !entry.isSettled()) {
       entry.settle({ accepted: false });
@@ -120,8 +120,8 @@ export function rejectPendingBashApprovalsForStream(streamId: StreamTabId): void
   }
 }
 
-/** Reject all pending bash approvals (called by unified cleanup) */
-export function rejectAllPendingBashApprovals(): void {
+/** @internal Called by unified cleanup in toolEditApproval.ts */
+export function _rejectAllPendingBashApprovals(): void {
   for (const entry of pendingApprovals.values()) {
     if (!entry.isSettled()) {
       entry.settle({ accepted: false });

--- a/src/tools/approval/bashApproval.ts
+++ b/src/tools/approval/bashApproval.ts
@@ -1,13 +1,16 @@
 // Local imports - agent types
 import type { StreamTabId } from '@agent/types/IdentifierTypes';
 
+// Local imports - tools
+import type { ToolResult } from '@tools/result';
+
 // Local imports - utils
 import { getCurrentToolFileInteractionContext } from '@agent/toolUse/ToolFileInteractionContext';
 import { safeExecuteCommand } from '@frontend/system/commandUtils';
 import { getConfig } from '@utils/config';
 import { bus } from '@eventBus/ProgressEventBus';
 
-// Local file imports - use shared YOLO state
+// Local file imports - shared YOLO state (cleanup handled by toolEditApproval.ts)
 import { isApprovalBypassedForStream } from './toolEditApproval';
 
 export interface BashApprovalRequest {
@@ -27,7 +30,7 @@ export const BASH_APPROVAL_ACTIONS = ['approve', 'reject'] as const;
 
 export type BashApprovalAction = (typeof BASH_APPROVAL_ACTIONS)[number];
 
-// Approval queue state
+// Approval queue state (pendingApprovals self-cleans via finally block)
 let queue: Promise<void> = Promise.resolve();
 let approvalCounter = 0;
 const pendingApprovals = new Map<
@@ -64,8 +67,14 @@ async function showApprovalPrompt(
   try {
     return await new Promise<BashApprovalResult>((resolve) => {
       let settled = false;
+      const settle = (result: BashApprovalResult) => {
+        if (settled) return;
+        settled = true;
+        resolve(result);
+      };
+
       pendingApprovals.set(requestId, {
-        settle: (result) => { if (!settled) { settled = true; resolve(result); } },
+        settle,
         isSettled: () => settled,
       });
 
@@ -73,7 +82,7 @@ async function showApprovalPrompt(
       bus.emit('showBashApprovalPrompt', {
         requestId,
         command: request.command,
-        allowBypass: !(streamId && isApprovalBypassedForStream(streamId)),
+        allowBypass: true, // YOLO already checked in requestBashApproval
         streamId: streamId ?? '',
       });
     });
@@ -100,13 +109,7 @@ export async function handleProgressViewBashApprovalAction(payload: {
 export function buildBashApprovalRejectedResult(
   command: string,
   userMessage?: string,
-): {
-  output: string;
-  summary: string;
-  error: string;
-  isError: true;
-  userInstruction?: string;
-} {
+): ToolResult {
   const preview = command.length > 60 ? `${command.slice(0, 57)}…` : command;
   const message = `User rejected bash command: ${preview}`;
   return {

--- a/src/tools/approval/bashApproval.ts
+++ b/src/tools/approval/bashApproval.ts
@@ -30,6 +30,26 @@ export const BASH_APPROVAL_ACTIONS = ['approve', 'reject'] as const;
 
 export type BashApprovalAction = (typeof BASH_APPROVAL_ACTIONS)[number];
 
+/** Common interface for pending approval entries that can be rejected */
+export interface RejectablePendingEntry {
+  streamId?: StreamTabId;
+  isSettled: () => boolean;
+  settle: (result: { accepted: false }) => void;
+}
+
+/** Reject all pending entries in a map, optionally filtered by streamId */
+export function rejectPendingEntries<T extends RejectablePendingEntry>(
+  entries: Iterable<T>,
+  streamId?: StreamTabId,
+): void {
+  for (const entry of entries) {
+    const matches = streamId === undefined || entry.streamId === streamId;
+    if (matches && !entry.isSettled()) {
+      entry.settle({ accepted: false });
+    }
+  }
+}
+
 // Approval queue state (pendingApprovals self-cleans via finally block)
 let queue: Promise<void> = Promise.resolve();
 let approvalCounter = 0;
@@ -113,20 +133,12 @@ export async function handleProgressViewBashApprovalAction(payload: {
 
 /** @internal Called by unified cleanup in toolEditApproval.ts */
 export function _rejectPendingBashApprovalsForStream(streamId: StreamTabId): void {
-  for (const entry of pendingApprovals.values()) {
-    if (entry.streamId === streamId && !entry.isSettled()) {
-      entry.settle({ accepted: false });
-    }
-  }
+  rejectPendingEntries(pendingApprovals.values(), streamId);
 }
 
 /** @internal Called by unified cleanup in toolEditApproval.ts */
 export function _rejectAllPendingBashApprovals(): void {
-  for (const entry of pendingApprovals.values()) {
-    if (!entry.isSettled()) {
-      entry.settle({ accepted: false });
-    }
-  }
+  rejectPendingEntries(pendingApprovals.values());
 }
 
 export function buildBashApprovalRejectedResult(

--- a/src/tools/approval/bashApproval.ts
+++ b/src/tools/approval/bashApproval.ts
@@ -111,17 +111,16 @@ export async function handleProgressViewBashApprovalAction(payload: {
   });
 }
 
-/** Reject all pending bash approvals for a deleted stream (prevents memory leak) */
+/** Reject all pending bash approvals for a stream (called by unified cleanup) */
 export function rejectPendingBashApprovalsForStream(streamId: StreamTabId): void {
   for (const entry of pendingApprovals.values()) {
     if (entry.streamId === streamId && !entry.isSettled()) {
-      // Settling triggers finally block which emits resolveBashApprovalPrompt
       entry.settle({ accepted: false });
     }
   }
 }
 
-/** Reject all pending bash approvals (used when deleting all streams) */
+/** Reject all pending bash approvals (called by unified cleanup) */
 export function rejectAllPendingBashApprovals(): void {
   for (const entry of pendingApprovals.values()) {
     if (!entry.isSettled()) {

--- a/src/tools/approval/index.ts
+++ b/src/tools/approval/index.ts
@@ -1,0 +1,77 @@
+/**
+ * Unified approval system exports.
+ *
+ * This module serves as the coordination point for approval cleanup,
+ * breaking the circular dependency between bashApproval and toolEditApproval.
+ *
+ * Import cleanup functions from here, not from individual modules.
+ */
+
+// Local imports - agent types
+import type { StreamTabId } from '@agent/types/IdentifierTypes';
+
+// Local file imports - individual approval modules
+import {
+  _rejectAllPendingBashApprovals,
+  _rejectPendingBashApprovalsForStream,
+} from './bashApproval';
+import {
+  _clearAllApprovalBypass,
+  _clearApprovalBypassForStream,
+  _rejectAllPendingToolEditApprovals,
+  _rejectPendingToolEditApprovalsForStream,
+} from './toolEditApproval';
+
+/**
+ * Clean up all approval state for a deleted stream.
+ * Handles pending approvals (tool edits + bash) and YOLO mode state.
+ */
+export function cleanupApprovalsForStream(streamId: StreamTabId): void {
+  _rejectPendingToolEditApprovalsForStream(streamId);
+  _rejectPendingBashApprovalsForStream(streamId);
+  _clearApprovalBypassForStream(streamId);
+}
+
+/**
+ * Clean up all approval state when deleting all streams.
+ * Handles pending approvals (tool edits + bash) and YOLO mode state.
+ */
+export function cleanupAllApprovals(): void {
+  _rejectAllPendingToolEditApprovals();
+  _rejectAllPendingBashApprovals();
+  _clearAllApprovalBypass();
+}
+
+// Re-export commonly used functions from individual modules
+export {
+  // Bash approval
+  requestBashApproval,
+  buildBashApprovalRejectedResult,
+  handleProgressViewBashApprovalAction,
+  BASH_APPROVAL_CONFIG_KEY,
+  BASH_APPROVAL_ACTIONS,
+  type BashApprovalAction,
+  type BashApprovalRequest,
+  type BashApprovalResult,
+} from './bashApproval';
+
+export {
+  // Tool edit approval
+  requestToolEditApproval,
+  buildApprovalRejectedResult,
+  handleProgressViewToolEditApprovalAction,
+  initializeToolEditApproval,
+  setToolEditApprovalHandler,
+  setToolEditApprovalSessionBypass,
+  toggleToolEditApprovalSessionBypass,
+  isApprovalBypassedForStream,
+  getApprovedContent,
+  writeApprovedContent,
+  formatUnifiedApprovalUserDiff,
+  TOOL_EDIT_APPROVAL_CONFIG_KEY,
+  TOOL_EDIT_APPROVAL_ACTIONS,
+  type ToolEditApprovalAction,
+  type ToolEditApprovalRequest,
+  type ToolEditApprovalResult,
+  type WriteApprovedContentResult,
+} from './toolEditApproval';

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -33,6 +33,7 @@ import {
 import {
   _rejectAllPendingBashApprovals,
   _rejectPendingBashApprovalsForStream,
+  rejectPendingEntries,
 } from './bashApproval';
 
 export interface ToolEditApprovalRequest {
@@ -165,15 +166,8 @@ export function isApprovalBypassedForStream(streamId: StreamTabId): boolean {
  * Handles pending approvals (tool edits + bash) and YOLO mode state.
  */
 export function cleanupApprovalsForStream(streamId: StreamTabId): void {
-  // Reject pending tool edit approvals
-  for (const entry of pendingApprovals.values()) {
-    if (entry.streamId === streamId && !entry.isSettled()) {
-      entry.settle({ accepted: false });
-    }
-  }
-  // Reject pending bash approvals
+  rejectPendingEntries(pendingApprovals.values(), streamId);
   _rejectPendingBashApprovalsForStream(streamId);
-  // Clear YOLO mode state
   approvalsBypassedByStream.delete(streamId);
 }
 
@@ -182,15 +176,8 @@ export function cleanupApprovalsForStream(streamId: StreamTabId): void {
  * Handles pending approvals (tool edits + bash) and YOLO mode state.
  */
 export function cleanupAllApprovals(): void {
-  // Reject pending tool edit approvals
-  for (const entry of pendingApprovals.values()) {
-    if (!entry.isSettled()) {
-      entry.settle({ accepted: false });
-    }
-  }
-  // Reject pending bash approvals
+  rejectPendingEntries(pendingApprovals.values());
   _rejectAllPendingBashApprovals();
-  // Clear all YOLO mode state
   approvalsBypassedByStream.clear();
 }
 

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -31,8 +31,8 @@ import {
   runLatexdiff,
 } from './latexPreview';
 import {
-  rejectAllPendingBashApprovals,
-  rejectPendingBashApprovalsForStream,
+  _rejectAllPendingBashApprovals,
+  _rejectPendingBashApprovalsForStream,
 } from './bashApproval';
 
 export interface ToolEditApprovalRequest {
@@ -159,15 +159,6 @@ export function isApprovalBypassedForStream(streamId: StreamTabId): boolean {
   return approvalsBypassedByStream.get(streamId) ?? false;
 }
 
-/** Clear YOLO mode state for a deleted stream (prevents memory leak) */
-export function clearApprovalBypassForStream(streamId: StreamTabId): void {
-  approvalsBypassedByStream.delete(streamId);
-}
-
-/** Clear all YOLO mode state (used when deleting all streams) */
-export function clearAllApprovalBypass(): void {
-  approvalsBypassedByStream.clear();
-}
 
 /**
  * Clean up all approval state for a deleted stream.
@@ -181,7 +172,7 @@ export function cleanupApprovalsForStream(streamId: StreamTabId): void {
     }
   }
   // Reject pending bash approvals
-  rejectPendingBashApprovalsForStream(streamId);
+  _rejectPendingBashApprovalsForStream(streamId);
   // Clear YOLO mode state
   approvalsBypassedByStream.delete(streamId);
 }
@@ -198,7 +189,7 @@ export function cleanupAllApprovals(): void {
     }
   }
   // Reject pending bash approvals
-  rejectAllPendingBashApprovals();
+  _rejectAllPendingBashApprovals();
   // Clear all YOLO mode state
   approvalsBypassedByStream.clear();
 }

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -30,11 +30,7 @@ import {
   previewProposedLatex,
   runLatexdiff,
 } from './latexPreview';
-import {
-  _rejectAllPendingBashApprovals,
-  _rejectPendingBashApprovalsForStream,
-  rejectPendingEntries,
-} from './bashApproval';
+import { rejectPendingEntries } from './bashApproval';
 
 export interface ToolEditApprovalRequest {
   path: string;
@@ -66,7 +62,7 @@ interface PendingApprovalEntry extends LatexPreviewEntry {
 }
 
 /** All valid approval actions for tool edit prompts */
-export const PROGRESS_VIEW_APPROVAL_ACTIONS = [
+export const TOOL_EDIT_APPROVAL_ACTIONS = [
   'approve',
   'reject',
   'openDiff',
@@ -74,12 +70,12 @@ export const PROGRESS_VIEW_APPROVAL_ACTIONS = [
   'previewProposed',
 ] as const;
 
-export type ProgressViewApprovalAction =
-  (typeof PROGRESS_VIEW_APPROVAL_ACTIONS)[number];
+export type ToolEditApprovalAction =
+  (typeof TOOL_EDIT_APPROVAL_ACTIONS)[number];
 
-interface ProgressViewApprovalActionPayload {
+interface ToolEditApprovalActionPayload {
   requestId: string;
-  action: ProgressViewApprovalAction;
+  action: ToolEditApprovalAction;
   feedback?: string;
 }
 
@@ -161,23 +157,25 @@ export function isApprovalBypassedForStream(streamId: StreamTabId): boolean {
 }
 
 
-/**
- * Clean up all approval state for a deleted stream.
- * Handles pending approvals (tool edits + bash) and YOLO mode state.
- */
-export function cleanupApprovalsForStream(streamId: StreamTabId): void {
+/** @internal Called by unified cleanup in index.ts */
+export function _rejectPendingToolEditApprovalsForStream(
+  streamId: StreamTabId,
+): void {
   rejectPendingEntries(pendingApprovals.values(), streamId);
-  _rejectPendingBashApprovalsForStream(streamId);
+}
+
+/** @internal Called by unified cleanup in index.ts */
+export function _rejectAllPendingToolEditApprovals(): void {
+  rejectPendingEntries(pendingApprovals.values());
+}
+
+/** @internal Called by unified cleanup in index.ts */
+export function _clearApprovalBypassForStream(streamId: StreamTabId): void {
   approvalsBypassedByStream.delete(streamId);
 }
 
-/**
- * Clean up all approval state when deleting all streams.
- * Handles pending approvals (tool edits + bash) and YOLO mode state.
- */
-export function cleanupAllApprovals(): void {
-  rejectPendingEntries(pendingApprovals.values());
-  _rejectAllPendingBashApprovals();
+/** @internal Called by unified cleanup in index.ts */
+export function _clearAllApprovalBypass(): void {
   approvalsBypassedByStream.clear();
 }
 
@@ -679,7 +677,7 @@ export async function writeApprovedContent(
 }
 
 export async function handleProgressViewToolEditApprovalAction(
-  payload: ProgressViewApprovalActionPayload,
+  payload: ToolEditApprovalActionPayload,
 ): Promise<void> {
   const entry = pendingApprovals.get(payload.requestId);
   if (!entry || entry.isSettled()) {

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -170,33 +170,37 @@ export function clearAllApprovalBypass(): void {
 }
 
 /**
- * Reject all pending approvals (tool edits + bash) for a deleted stream.
- * Unified cleanup function that handles both approval types.
+ * Clean up all approval state for a deleted stream.
+ * Handles pending approvals (tool edits + bash) and YOLO mode state.
  */
-export function rejectPendingApprovalsForStream(streamId: StreamTabId): void {
-  // Tool edit approvals
+export function cleanupApprovalsForStream(streamId: StreamTabId): void {
+  // Reject pending tool edit approvals
   for (const entry of pendingApprovals.values()) {
     if (entry.streamId === streamId && !entry.isSettled()) {
       entry.settle({ accepted: false });
     }
   }
-  // Bash approvals
+  // Reject pending bash approvals
   rejectPendingBashApprovalsForStream(streamId);
+  // Clear YOLO mode state
+  approvalsBypassedByStream.delete(streamId);
 }
 
 /**
- * Reject all pending approvals (tool edits + bash).
- * Unified cleanup function used when deleting all streams.
+ * Clean up all approval state when deleting all streams.
+ * Handles pending approvals (tool edits + bash) and YOLO mode state.
  */
-export function rejectAllPendingApprovals(): void {
-  // Tool edit approvals
+export function cleanupAllApprovals(): void {
+  // Reject pending tool edit approvals
   for (const entry of pendingApprovals.values()) {
     if (!entry.isSettled()) {
       entry.settle({ accepted: false });
     }
   }
-  // Bash approvals
+  // Reject pending bash approvals
   rejectAllPendingBashApprovals();
+  // Clear all YOLO mode state
+  approvalsBypassedByStream.clear();
 }
 
 export function initializeToolEditApproval(

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -30,6 +30,10 @@ import {
   previewProposedLatex,
   runLatexdiff,
 } from './latexPreview';
+import {
+  rejectAllPendingBashApprovals,
+  rejectPendingBashApprovalsForStream,
+} from './bashApproval';
 
 export interface ToolEditApprovalRequest {
   path: string;
@@ -165,25 +169,34 @@ export function clearAllApprovalBypass(): void {
   approvalsBypassedByStream.clear();
 }
 
-/** Reject all pending tool edit approvals for a deleted stream (prevents memory leak) */
-export function rejectPendingToolEditApprovalsForStream(
-  streamId: StreamTabId,
-): void {
+/**
+ * Reject all pending approvals (tool edits + bash) for a deleted stream.
+ * Unified cleanup function that handles both approval types.
+ */
+export function rejectPendingApprovalsForStream(streamId: StreamTabId): void {
+  // Tool edit approvals
   for (const entry of pendingApprovals.values()) {
     if (entry.streamId === streamId && !entry.isSettled()) {
-      // Settling triggers finally block which cleans up temp files and emits resolve event
       entry.settle({ accepted: false });
     }
   }
+  // Bash approvals
+  rejectPendingBashApprovalsForStream(streamId);
 }
 
-/** Reject all pending tool edit approvals (used when deleting all streams) */
-export function rejectAllPendingToolEditApprovals(): void {
+/**
+ * Reject all pending approvals (tool edits + bash).
+ * Unified cleanup function used when deleting all streams.
+ */
+export function rejectAllPendingApprovals(): void {
+  // Tool edit approvals
   for (const entry of pendingApprovals.values()) {
     if (!entry.isSettled()) {
       entry.settle({ accepted: false });
     }
   }
+  // Bash approvals
+  rejectAllPendingBashApprovals();
 }
 
 export function initializeToolEditApproval(

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -165,6 +165,27 @@ export function clearAllApprovalBypass(): void {
   approvalsBypassedByStream.clear();
 }
 
+/** Reject all pending tool edit approvals for a deleted stream (prevents memory leak) */
+export function rejectPendingToolEditApprovalsForStream(
+  streamId: StreamTabId,
+): void {
+  for (const entry of pendingApprovals.values()) {
+    if (entry.streamId === streamId && !entry.isSettled()) {
+      // Settling triggers finally block which cleans up temp files and emits resolve event
+      entry.settle({ accepted: false });
+    }
+  }
+}
+
+/** Reject all pending tool edit approvals (used when deleting all streams) */
+export function rejectAllPendingToolEditApprovals(): void {
+  for (const entry of pendingApprovals.values()) {
+    if (!entry.isSettled()) {
+      entry.settle({ accepted: false });
+    }
+  }
+}
+
 export function initializeToolEditApproval(
   context: vscode.ExtensionContext,
 ): void {

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -2,7 +2,11 @@
 import { z } from 'zod';
 
 // Local imports - tools
-import { ToolResult, ToolError } from '@tools/result';
+import { ToolError, ToolResult } from '@tools/result';
+import {
+  buildBashApprovalRejectedResult,
+  requestBashApproval,
+} from '@tools/approval/bashApproval';
 import { executeCommand } from '@utils/system/execUtils';
 
 // Local file imports
@@ -21,6 +25,16 @@ export class BashTool extends defineTool({
   schema: BashInputSchema,
 }) {
   protected async execute(input: BashInput): Promise<ToolResult> {
+    // Request approval before executing the command
+    const approval = await requestBashApproval({ command: input.command });
+
+    if (!approval.accepted) {
+      return buildBashApprovalRejectedResult(
+        input.command,
+        approval.userMessage,
+      );
+    }
+
     // Truncation only applies to internal logging so long-running commands keep
     // the output channel readable while still returning the complete stdout.
     const result = await executeCommand(input.command, { truncate: true });

--- a/src/webview/types/messages.ts
+++ b/src/webview/types/messages.ts
@@ -8,8 +8,10 @@ import { z } from 'zod';
 // Local imports
 import { AgentCategory } from '@agent/core/AgentDataclass';
 import { StreamTabIdSchema } from '@agent/types/IdentifierTypes';
-import { PROGRESS_VIEW_APPROVAL_ACTIONS } from '@tools/approval/toolEditApproval';
-import { BASH_APPROVAL_ACTIONS } from '@tools/approval/bashApproval';
+import {
+  TOOL_EDIT_APPROVAL_ACTIONS,
+  BASH_APPROVAL_ACTIONS,
+} from '@tools/approval';
 
 // --- Base Schemas (composable building blocks) ---
 
@@ -243,7 +245,7 @@ export type InfoMessage = z.infer<typeof InfoMessageSchema>;
 /** Approval action message from progress view */
 export const ApprovalActionMessageSchema = z.object({
   requestId: z.string().min(1),
-  action: z.enum(PROGRESS_VIEW_APPROVAL_ACTIONS),
+  action: z.enum(TOOL_EDIT_APPROVAL_ACTIONS),
   feedback: z.string().optional(),
 });
 

--- a/src/webview/types/messages.ts
+++ b/src/webview/types/messages.ts
@@ -9,6 +9,7 @@ import { z } from 'zod';
 import { AgentCategory } from '@agent/core/AgentDataclass';
 import { StreamTabIdSchema } from '@agent/types/IdentifierTypes';
 import { PROGRESS_VIEW_APPROVAL_ACTIONS } from '@tools/approval/toolEditApproval';
+import { BASH_APPROVAL_ACTIONS } from '@tools/approval/bashApproval';
 
 // --- Base Schemas (composable building blocks) ---
 
@@ -247,6 +248,17 @@ export const ApprovalActionMessageSchema = z.object({
 });
 
 export type ApprovalActionMessage = z.infer<typeof ApprovalActionMessageSchema>;
+
+/** Bash approval action message from progress view */
+export const BashApprovalActionMessageSchema = z.object({
+  requestId: z.string().min(1),
+  action: z.enum(BASH_APPROVAL_ACTIONS),
+  feedback: z.string().optional(),
+});
+
+export type BashApprovalActionMessage = z.infer<
+  typeof BashApprovalActionMessageSchema
+>;
 
 /** Followup task message from progress view */
 export const FollowupTaskMessageSchema = z.object({


### PR DESCRIPTION
## Summary
This PR implements a comprehensive bash command approval system that mirrors the existing tool edit approval workflow. Users can now approve or reject bash commands before execution, with support for per-stream YOLO mode (auto-approval) to streamline workflows.

## Key Changes

### Core Approval Infrastructure
- **New `bashApproval.ts` module**: Implements bash approval request handling with:
  - Queue-based approval processing to ensure sequential handling
  - Per-stream YOLO mode state tracking (single source of truth)
  - Support for custom approval handlers
  - Rejection feedback collection from users
  
- **BashTool integration**: Modified `bash.ts` to request approval before command execution and handle rejections gracefully

### Event Bus & Type System
- Added `BashApprovalPrompt` type schema in `types.ts` with command, requestId, allowBypass, and streamId fields
- Extended `ProgressEventBus` with three new event types:
  - `showBashApprovalPrompt`: Display approval dialog
  - `resolveBashApprovalPrompt`: Clear resolved prompts
  - `updateBashApprovalBypassState`: Sync YOLO mode state

### UI Command & Message Handling
- Added 4 new progress view commands: `SHOW_BASH_APPROVAL`, `RESOLVE_BASH_APPROVAL`, `UPDATE_BASH_APPROVAL_STATE`, `BASH_APPROVAL_ACTION`, `TOGGLE_BASH_APPROVAL_BYPASS`
- Implemented `BashApprovalActionMessage` schema for webview communication
- Added message handlers in `ProgressViewMessageHandler` for approval actions and YOLO mode toggling

### State Management
- Extended `ProgressViewProvider` with `pendingBashApprovalPrompts` map to track in-flight approvals
- Integrated bash approval state into webview rebuild process
- Added cleanup methods to prevent memory leaks when streams are deleted

### UI Updates
- Extended `WebviewUpdater` with methods to send bash approval prompts and state updates to frontend
- Updated `UIEvents` registration to handle bash approval callbacks
- Modified `sendYoloStateForStream()` to send both tool edit and bash approval bypass states

## Implementation Details

- **YOLO Mode**: Per-stream bypass state is stored in `approvalsBypassedByStream` map and synced to the progress view whenever state changes
- **Request Queuing**: Approvals are processed sequentially via promise chaining to maintain order
- **Memory Management**: Bypass state is cleared when streams are deleted or all streams are cleared
- **Feedback Support**: Users can provide rejection feedback which is included in the tool result
- **Config Integration**: Respects `texra.toolUse.requireBashApproval` config setting (defaults to true)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a first-class approval flow for `bash` execution, parallel to tool edit approvals, with shared YOLO (auto-approve) state and unified cleanup.
> 
> - New approval module `tools/approval/bashApproval.ts` and unified entrypoint `tools/approval/index.ts` (centralizes cleanup and actions for tool edits + bash)
> - `BashTool` now requests approval before running commands; builds explicit rejection results
> - Extends event bus with `BashApprovalPrompt` and handlers; adds schemas and message types
> - Progress view integration: new commands (`SHOW_BASH_APPROVAL`, `RESOLVE_BASH_APPROVAL`, `BASH_APPROVAL_ACTION`), message handlers, and provider state (`pendingBashApprovalPrompts`)
> - Frontend UI: new `BashApprovalRequests` manager, section, template, and styles; YOLO toggle messaging generalized to "Tool actions"
> - Config: adds `texra.toolUse.requireBashApproval` (default `true`)
> - Cleanup/refactor: unified approval cleanup APIs, updated tests, and minor naming normalization (`TOOL_EDIT_APPROVAL_ACTIONS`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cc88757038bbc81e452a2fec6c89f90c1482ab9d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->