### PR TITLE
Support queued follow-up messages during tool execution

### DIFF
--- a/src/agent/core/flows/CycleServices.ts
+++ b/src/agent/core/flows/CycleServices.ts
@@ -14,6 +14,7 @@ import type { AgentCycleBaseOptions } from '@agent/core/AgentCycleOptions';
 import type { AgentConfig } from '@agent/core/AgentConfig';
 import type { AgentWorkspaceState } from '@agent/core/AgentWorkspaceState';
 import type { IToolRegistry } from '@agent/core/ToolTypes';
+import type { IToolUseSession } from '@agent/implementations/flows/tooluse/ToolUseSessionLifecycle';
 import type { TaskRunFileService } from '@utils/files';
 
 // ============================================================================
@@ -56,6 +57,17 @@ export interface ToolUseCycleOptions<
   toolRegistry: IToolRegistry;
   modelName?: string;
   agentName?: string;
+  /**
+   * Session for follow-up queue access.
+   * When provided, allows injecting queued user messages after tool dispatch
+   * so the model can continue without ending the turn.
+   */
+  session?: IToolUseSession;
+  /**
+   * Callback invoked when a queued follow-up message is consumed.
+   * Used to update the UI (clear the queued message display).
+   */
+  onFollowUpConsumed?: () => void;
 }
 
 // ============================================================================

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -183,25 +183,55 @@ export interface ToolUseCycleShared extends ToolUseCycleFields {
   cycleNormalizedUsage?: NormalizedUsage;
 }
 
-/** Prepares a tool-use cycle by checking interruptions. */
+/**
+ * Prepares a tool-use cycle by checking interruptions and injecting queued follow-ups.
+ *
+ * If there are queued user messages (typed during previous tool execution),
+ * they are injected here BEFORE calling the model. This ensures the model's
+ * thinking/response considers the user's feedback.
+ */
 class ToolUsePrepNode<C> extends BaseNode<
   ToolUseCycleShared,
   ToolUseCycleParams<C>,
   ToolUseCycleServices<C>
 > {
-  async prep(shared: ToolUseCycleShared): Promise<{ interrupted: boolean }> {
+  async prep(
+    shared: ToolUseCycleShared,
+  ): Promise<{ interrupted: boolean; queuedFollowUp: string | null }> {
     const interrupted = this.services.checkInterruption();
-    return { interrupted };
+
+    // Check for queued follow-ups to inject before the model call
+    let queuedFollowUp: string | null = null;
+    const session = this.services.session;
+    if (session?.hasQueuedFollowUp()) {
+      // Drain without waiting (we know there's something)
+      queuedFollowUp = await session.waitForFollowUp(() => false);
+    }
+
+    return { interrupted, queuedFollowUp };
   }
 
   async post(
     shared: ToolUseCycleShared,
-    prepRes: { interrupted: boolean },
+    prepRes: { interrupted: boolean; queuedFollowUp: string | null },
   ): Promise<string | undefined> {
     if (prepRes.interrupted) {
       shared.shouldStop = true;
       shared.endTurn = false;
       return FlowTransition.COMPLETE;
+    }
+
+    // Inject queued follow-up BEFORE the model call
+    // This ensures user's message typed during tool execution is seen
+    // before the model starts thinking/responding
+    if (prepRes.queuedFollowUp) {
+      this.services.logger.userMessage(prepRes.queuedFollowUp);
+      shared.messages =
+        await this.services.modelHandler.createUserFollowUpMessages(
+          shared.messages,
+          prepRes.queuedFollowUp,
+        );
+      this.services.onFollowUpConsumed?.();
     }
 
     resetCycleState(shared, [
@@ -783,99 +813,16 @@ class ToolUseDispatchNode<C> extends BatchNode<
 }
 
 /**
- * Checks for queued follow-up messages after tool dispatch.
- *
- * If the cycle is about to complete (model ended turn) but there are queued
- * user messages, this node injects them and continues the cycle so the model
- * can respond to user input without ending the turn.
- *
- * This enables "steering" behavior where users can type during tool execution
- * and have their message processed in the same turn.
- */
-class ToolUseFollowUpInjectNode<C> extends BaseNode<
-  ToolUseCycleShared,
-  ToolUseCycleParams<C>,
-  ToolUseCycleServices<C>
-> {
-  async prep(shared: ToolUseCycleShared): Promise<{
-    shouldInject: boolean;
-    endingTurn: boolean;
-  }> {
-    const session = this.services.session;
-
-    // Only check for follow-ups if session is available
-    if (!session) {
-      return { shouldInject: false, endingTurn: shared.endTurn };
-    }
-
-    // Check if cycle would end and there are queued messages
-    const endingTurn = shared.endTurn && shared.shouldStop;
-    const hasQueuedFollowUp = session.hasQueuedFollowUp();
-
-    return {
-      shouldInject: endingTurn && hasQueuedFollowUp,
-      endingTurn,
-    };
-  }
-
-  async exec(prepRes: {
-    shouldInject: boolean;
-    endingTurn: boolean;
-  }): Promise<string | null> {
-    if (!prepRes.shouldInject) {
-      return null;
-    }
-
-    const session = this.services.session;
-    if (!session) {
-      return null;
-    }
-
-    // Drain all queued follow-ups without waiting
-    // Use checkInterruption that always returns false since we're just draining
-    const followUp = await session.waitForFollowUp(() => false);
-    return followUp;
-  }
-
-  async post(
-    shared: ToolUseCycleShared,
-    prepRes: { shouldInject: boolean; endingTurn: boolean },
-    execRes: string | null,
-  ): Promise<string | undefined> {
-    // If no injection needed, proceed normally (will COMPLETE)
-    if (!prepRes.shouldInject || execRes === null) {
-      return FlowTransition.DEFAULT;
-    }
-
-    // Inject user follow-up as a message
-    this.services.logger.userMessage(execRes);
-    shared.messages = await this.services.modelHandler.createUserFollowUpMessages(
-      shared.messages,
-      execRes,
-    );
-
-    // Reset cycle state to continue
-    shared.shouldStop = false;
-    shared.endTurn = false;
-
-    // Notify that follow-up was consumed (for UI update)
-    this.services.onFollowUpConsumed?.();
-
-    return FlowTransition.CONTINUE;
-  }
-}
-
-/**
  * Creates a tool-use cycle flow with services injected via params.
  *
  * Flow structure:
- *   Prep → Call → Process → Dispatch → FollowUpInject
- *     ↑                                      |
- *     └──────────── CONTINUE ────────────────┘
+ *   Prep → Call → Process → Dispatch
+ *     ↑                        |
+ *     └────── CONTINUE ────────┘
  *
- * The FollowUpInject node checks for queued user messages after tool dispatch.
- * If the model wants to end the turn but there are queued messages, it injects
- * them and continues the cycle so the model can respond without waiting.
+ * Queued user messages (typed during tool execution) are injected in PrepNode
+ * BEFORE calling the model, so the model's thinking/response considers the
+ * user's feedback.
  */
 export function createToolUseCycleFlow<C>(): Flow<
   ToolUseCycleShared,
@@ -885,16 +832,11 @@ export function createToolUseCycleFlow<C>(): Flow<
   const callNode = new ToolUseCallNode<C>();
   const processNode = new ToolUseProcessNode<C>();
   const dispatchNode = new ToolUseDispatchNode<C>();
-  const followUpInjectNode = new ToolUseFollowUpInjectNode<C>();
 
   prepNode.next(callNode);
   callNode.next(processNode);
   processNode.next(dispatchNode);
-  dispatchNode.next(followUpInjectNode);
-  // Both dispatch CONTINUE (more tool calls) and followUpInject CONTINUE (injected message)
-  // loop back to prep for the next model call
   dispatchNode.on(FlowTransition.CONTINUE, prepNode);
-  followUpInjectNode.on(FlowTransition.CONTINUE, prepNode);
 
   return new Flow<ToolUseCycleShared, ToolUseCycleParams<C>>(prepNode);
 }

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -781,7 +781,102 @@ class ToolUseDispatchNode<C> extends BatchNode<
     return FlowTransition.CONTINUE;
   }
 }
-/** Creates a tool-use cycle flow with services injected via params. */
+
+/**
+ * Checks for queued follow-up messages after tool dispatch.
+ *
+ * If the cycle is about to complete (model ended turn) but there are queued
+ * user messages, this node injects them and continues the cycle so the model
+ * can respond to user input without ending the turn.
+ *
+ * This enables "steering" behavior where users can type during tool execution
+ * and have their message processed in the same turn.
+ */
+class ToolUseFollowUpInjectNode<C> extends BaseNode<
+  ToolUseCycleShared,
+  ToolUseCycleParams<C>,
+  ToolUseCycleServices<C>
+> {
+  async prep(shared: ToolUseCycleShared): Promise<{
+    shouldInject: boolean;
+    endingTurn: boolean;
+  }> {
+    const session = this.services.session;
+
+    // Only check for follow-ups if session is available
+    if (!session) {
+      return { shouldInject: false, endingTurn: shared.endTurn };
+    }
+
+    // Check if cycle would end and there are queued messages
+    const endingTurn = shared.endTurn && shared.shouldStop;
+    const hasQueuedFollowUp = session.hasQueuedFollowUp();
+
+    return {
+      shouldInject: endingTurn && hasQueuedFollowUp,
+      endingTurn,
+    };
+  }
+
+  async exec(prepRes: {
+    shouldInject: boolean;
+    endingTurn: boolean;
+  }): Promise<string | null> {
+    if (!prepRes.shouldInject) {
+      return null;
+    }
+
+    const session = this.services.session;
+    if (!session) {
+      return null;
+    }
+
+    // Drain all queued follow-ups without waiting
+    // Use checkInterruption that always returns false since we're just draining
+    const followUp = await session.waitForFollowUp(() => false);
+    return followUp;
+  }
+
+  async post(
+    shared: ToolUseCycleShared,
+    prepRes: { shouldInject: boolean; endingTurn: boolean },
+    execRes: string | null,
+  ): Promise<string | undefined> {
+    // If no injection needed, proceed normally (will COMPLETE)
+    if (!prepRes.shouldInject || execRes === null) {
+      return FlowTransition.DEFAULT;
+    }
+
+    // Inject user follow-up as a message
+    this.services.logger.userMessage(execRes);
+    shared.messages = await this.services.modelHandler.createUserFollowUpMessages(
+      shared.messages,
+      execRes,
+    );
+
+    // Reset cycle state to continue
+    shared.shouldStop = false;
+    shared.endTurn = false;
+
+    // Notify that follow-up was consumed (for UI update)
+    this.services.onFollowUpConsumed?.();
+
+    return FlowTransition.CONTINUE;
+  }
+}
+
+/**
+ * Creates a tool-use cycle flow with services injected via params.
+ *
+ * Flow structure:
+ *   Prep → Call → Process → Dispatch → FollowUpInject
+ *     ↑                                      |
+ *     └──────────── CONTINUE ────────────────┘
+ *
+ * The FollowUpInject node checks for queued user messages after tool dispatch.
+ * If the model wants to end the turn but there are queued messages, it injects
+ * them and continues the cycle so the model can respond without waiting.
+ */
 export function createToolUseCycleFlow<C>(): Flow<
   ToolUseCycleShared,
   ToolUseCycleParams<C>
@@ -790,11 +885,16 @@ export function createToolUseCycleFlow<C>(): Flow<
   const callNode = new ToolUseCallNode<C>();
   const processNode = new ToolUseProcessNode<C>();
   const dispatchNode = new ToolUseDispatchNode<C>();
+  const followUpInjectNode = new ToolUseFollowUpInjectNode<C>();
 
   prepNode.next(callNode);
   callNode.next(processNode);
   processNode.next(dispatchNode);
+  dispatchNode.next(followUpInjectNode);
+  // Both dispatch CONTINUE (more tool calls) and followUpInject CONTINUE (injected message)
+  // loop back to prep for the next model call
   dispatchNode.on(FlowTransition.CONTINUE, prepNode);
+  followUpInjectNode.on(FlowTransition.CONTINUE, prepNode);
 
   return new Flow<ToolUseCycleShared, ToolUseCycleParams<C>>(prepNode);
 }

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
@@ -81,6 +81,8 @@ export class ToolUseCycleNode<C> extends Node<
       onRoundFinalized: services.getUsageRecorder(),
       modelName: services.config.model,
       agentName: services.config.agent,
+      session: services.session,
+      onFollowUpConsumed: services.onFollowUpConsumed,
     });
 
     prepRes.workspaceState.todos.setOnUpdate((todos: TodoItem[]) => {


### PR DESCRIPTION
## Summary
This PR adds support for injecting queued user messages into the tool-use cycle flow. When users type messages while tools are being executed, those messages are now captured and injected into the model's context before the next model call, ensuring the model considers user feedback in its thinking and response.

## Key Changes

- **Added `IToolUseSession` support**: New optional `session` parameter in `ToolUseCycleOptions` allows access to queued follow-up messages
- **Added follow-up consumption callback**: New `onFollowUpConsumed` callback in `ToolUseCycleOptions` to notify the UI when queued messages are consumed
- **Enhanced `ToolUsePrepNode`**: 
  - Now checks for queued follow-ups before the model call via `session.hasQueuedFollowUp()`
  - Injects queued messages into the message history using `modelHandler.createUserFollowUpMessages()`
  - Triggers the `onFollowUpConsumed` callback after injection
- **Updated flow documentation**: Added clarifying comments explaining the flow structure and when follow-ups are injected
- **Wired up session in `ToolUseCycleNode`**: Passes `session` and `onFollowUpConsumed` from services to the cycle options

## Implementation Details

The queued follow-up injection happens in the `ToolUsePrepNode.post()` method, which is strategically placed BEFORE the model call in the flow. This ensures:
- User messages typed during tool execution are visible to the model
- The model's thinking and response incorporate the user's feedback
- The UI is notified to clear the queued message display via the callback

The implementation uses a non-blocking drain pattern (`waitForFollowUp(() => false)`) to check for queued messages without waiting, since we've already confirmed their existence with `hasQueuedFollowUp()`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements queued follow-up message handling so user inputs typed during tool execution are injected before the next model call.
> 
> - Adds optional `session?: IToolUseSession` and `onFollowUpConsumed?: () => void` to `ToolUseCycleOptions` in `CycleServices.ts`
> - Enhances `ToolUsePrepNode` to drain queued follow-ups (`session.hasQueuedFollowUp()` → `waitForFollowUp`) and inject via `modelHandler.createUserFollowUpMessages()`, logging with `logger.userMessage` and invoking `onFollowUpConsumed`
> - Documents flow structure and follow-up injection timing in `createToolUseCycleFlow`
> - Wires `session` and `onFollowUpConsumed` from services into the flow in `ToolUseCycleNode`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aad5f13b681ad5eb6625c7e4227e9eeaa3150aaf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->