### PR TITLE
Enable text selection in scratchpad view

### DIFF
--- a/src/progressView/styles/scratchpad.css
+++ b/src/progressView/styles/scratchpad.css
@@ -16,6 +16,8 @@
   overflow: hidden;
   text-overflow: ellipsis;
   min-width: 0;
+  user-select: text;
+  cursor: text;
 }
 
 .tool-use-label {


### PR DESCRIPTION
## Summary
Added CSS properties to enable text selection and provide visual feedback in the scratchpad view component.

## Changes
- Added `user-select: text` to allow users to select and copy text from the scratchpad
- Added `cursor: text` to display the text cursor when hovering over the scratchpad, improving UX by indicating the content is selectable

## Details
These changes improve the usability of the scratchpad by making it clear that the content is interactive and can be selected/copied by users. The text cursor provides visual feedback that distinguishes this element from non-interactive content.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves text interaction in the scratchpad.
> 
> - Adds `user-select: text` and `cursor: text` to `scratchpad.css` for `
>   .tool-use-title`, enabling text selection/copy and showing a text cursor
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c4ffcf4eb654da8041c82b1bcd840905e518df3a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->