### PR TITLE
Increase context clearing threshold and add debug logging

### DIFF
--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -221,9 +221,9 @@ const CONTEXT_MANAGEMENT_KEEP_THINKING_TURNS = 3;
  * Minimum percentage of context to clear at once for tool uses.
  * This ensures cache invalidation is worthwhile - clearing too few tokens
  * causes frequent cache misses without meaningful benefit.
- * 10% is a reasonable balance between cache efficiency and context retention.
+ * 25% provides more aggressive clearing to reduce frequent cache thrashing.
  */
-const CONTEXT_MANAGEMENT_CLEAR_AT_LEAST_PERCENT = 10;
+const CONTEXT_MANAGEMENT_CLEAR_AT_LEAST_PERCENT = 25;
 
 const ANTHROPIC_1M_CONTEXT_WINDOW = 1_000_000;
 
@@ -805,6 +805,13 @@ export class ModelHandlerAnthropic extends ModelHandler<
         context_management?: BetaContextManagementResponse | null;
       }
     ).context_management;
+
+    // Debug logging to diagnose context management response
+    if (contextManagement) {
+      this.logger.debug(
+        `Context management response received: ${JSON.stringify(contextManagement)}`,
+      );
+    }
 
     if (!contextManagement?.applied_edits?.length) {
       return;


### PR DESCRIPTION
## Summary
This PR improves context management efficiency in the Anthropic model handler by increasing the minimum context clearing threshold and adding debug logging for troubleshooting.

## Key Changes
- **Increased `CONTEXT_MANAGEMENT_CLEAR_AT_LEAST_PERCENT` from 10% to 25%**: This more aggressive clearing strategy reduces frequent cache thrashing by ensuring larger context chunks are cleared at once, improving overall cache efficiency despite potentially retaining less context per operation.
- **Added debug logging for context management responses**: New debug log statement captures the context management response payload to help diagnose and troubleshoot context management behavior in production environments.

## Implementation Details
- Updated the comment explaining the rationale for the 25% threshold to reflect the new aggressive clearing strategy
- Debug logging is conditionally executed only when a context management response is received, minimizing performance impact
- The log output includes the full context management response as JSON for comprehensive debugging information

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves server-side context management behavior and observability.
> 
> - Increase `CONTEXT_MANAGEMENT_CLEAR_AT_LEAST_PERCENT` from `10` to `25`, updating rationale comment
> - Add debug log to print `context_management` payload when present for easier diagnostics
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 998db215a12010eb4e4da74bd2b8404c78fde9cf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->