### PR TITLE
Clarify Wolfram tool session behavior in description

### DIFF
--- a/src/tools/wolfram/WolframTool.ts
+++ b/src/tools/wolfram/WolframTool.ts
@@ -17,7 +17,8 @@ export type WolframInput = z.infer<typeof WolframInputSchema>;
 
 export class WolframTool extends defineTool({
   name: 'wolfram',
-  description: 'Execute Wolfram Language code',
+  description:
+    'Execute Wolfram Language code. Sessions do not persist between calls - each execution starts fresh with no memory of previous variables or definitions.',
   schema: WolframInputSchema,
 }) {
   protected async execute(input: WolframInput): Promise<ToolResult> {


### PR DESCRIPTION
## Summary
Updated the Wolfram tool description to explicitly clarify that sessions do not persist between calls, helping users understand the stateless nature of each execution.

## Changes
- Enhanced the `WolframTool` description to inform users that each execution starts fresh with no memory of previous variables or definitions
- This prevents confusion about session state and sets proper expectations for tool usage

## Details
The description now clearly communicates that:
- Each Wolfram Language code execution is independent
- Variables and definitions from previous calls are not available
- Users should not rely on state persistence between tool invocations

This is an important clarification for users who might expect session continuity similar to interactive Wolfram notebooks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Clarifies the Wolfram tool’s behavior for users.
> 
> - Updates `WolframTool` description to explicitly state sessions do not persist and each execution starts fresh with no prior variables/definitions
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bce489ece7848ebccfec946306964af3c7f30831. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->