### PR TITLE
docs: guide agent on wolfram tool vs file+bash choice

### DIFF
--- a/resources/tool_use_agents/research.yaml
+++ b/resources/tool_use_agents/research.yaml
@@ -28,14 +28,16 @@ prompts:
     (4) Mathematical proofs and derivations
 
     Wolfram Language Guidelines:
-    (1) Use the wolfram tool to execute Wolfram Language code for computations.
-    (2) Always verify symbolic results by substituting test values.
-    (3) For complex derivations, break down into intermediate steps.
-    (4) Use FullSimplify, Expand, Factor strategically to present clean results.
-    (5) Convert final results to LaTeX using TeXForm when appropriate.
-    (6) For numerical work, check convergence and precision.
-    (7) When solving differential equations, verify solutions satisfy the original equation.
-    (8) Use Assumptions to specify variable domains (e.g., Assuming[x > 0, Integrate[...]]).
+    (1) Use the wolfram tool for quick calculations and one-off evaluations.
+    (2) Sessions do NOT persist between wolfram tool calls - each execution starts fresh. For scripts needing persistence or iterative development, write to a .wl file and run via bash.
+    (3) Always verify symbolic results by substituting test values.
+    (4) For complex derivations, break down into intermediate steps.
+    (5) Use FullSimplify, Expand, Factor strategically to present clean results.
+    (6) Convert final results to LaTeX using TeXForm when appropriate.
+    (7) For numerical work, check convergence and precision.
+    (8) When solving differential equations, verify solutions satisfy the original equation.
+    (9) Use Assumptions to specify variable domains (e.g., Assuming[x > 0, Integrate[...]]).
+    (10) Use VerificationTest to verify computed properties - never hardcode expected values in Print statements.
 
     Mathematical Communication:
     (1) Use $...$ for inline math expressions.

--- a/src/tools/wolfram/WolframTool.ts
+++ b/src/tools/wolfram/WolframTool.ts
@@ -17,7 +17,7 @@ export type WolframInput = z.infer<typeof WolframInputSchema>;
 
 export class WolframTool extends defineTool({
   name: 'wolfram',
-  description: `Execute Wolfram Language code. Use this tool for quick calculations, symbolic math, and one-off evaluations. Sessions do NOT persist between calls - each execution starts fresh with no memory of previous variables or definitions. For complex scripts requiring session persistence, iterative development, or saving intermediate results, write to a .wl file and run via bash instead. IMPORTANT: Never hardcode expected values in Print statements - always compute and display actual results dynamically. Use conditional checks (If, Which) to verify properties and print computed values, not predetermined strings.`,
+  description: `Execute Wolfram Language code. Use this tool for quick calculations, symbolic math, and one-off evaluations. Sessions do NOT persist between calls - each execution starts fresh with no memory of previous variables or definitions. For complex scripts requiring session persistence, iterative development, or saving intermediate results, write to a .wl file and run via bash instead. IMPORTANT: Never hardcode expected values in Print statements - always compute and display actual results dynamically. Write tests using VerificationTest or assertions to verify properties, printing computed values rather than predetermined strings.`,
   schema: WolframInputSchema,
 }) {
   protected async execute(input: WolframInput): Promise<ToolResult> {

--- a/src/tools/wolfram/WolframTool.ts
+++ b/src/tools/wolfram/WolframTool.ts
@@ -17,8 +17,7 @@ export type WolframInput = z.infer<typeof WolframInputSchema>;
 
 export class WolframTool extends defineTool({
   name: 'wolfram',
-  description:
-    'Execute Wolfram Language code. Sessions do not persist between calls - each execution starts fresh with no memory of previous variables or definitions.',
+  description: `Execute Wolfram Language code. Use this tool for quick calculations, symbolic math, and one-off evaluations. Sessions do NOT persist between calls - each execution starts fresh with no memory of previous variables or definitions. For complex scripts requiring session persistence, iterative development, or saving intermediate results, write to a .wl file and run via bash instead.`,
   schema: WolframInputSchema,
 }) {
   protected async execute(input: WolframInput): Promise<ToolResult> {

--- a/src/tools/wolfram/WolframTool.ts
+++ b/src/tools/wolfram/WolframTool.ts
@@ -17,7 +17,7 @@ export type WolframInput = z.infer<typeof WolframInputSchema>;
 
 export class WolframTool extends defineTool({
   name: 'wolfram',
-  description: `Execute Wolfram Language code. Use this tool for quick calculations, symbolic math, and one-off evaluations. Sessions do NOT persist between calls - each execution starts fresh with no memory of previous variables or definitions. For complex scripts requiring session persistence, iterative development, or saving intermediate results, write to a .wl file and run via bash instead.`,
+  description: `Execute Wolfram Language code. Use this tool for quick calculations, symbolic math, and one-off evaluations. Sessions do NOT persist between calls - each execution starts fresh with no memory of previous variables or definitions. For complex scripts requiring session persistence, iterative development, or saving intermediate results, write to a .wl file and run via bash instead. IMPORTANT: Never hardcode expected values in Print statements - always compute and display actual results dynamically. Use conditional checks (If, Which) to verify properties and print computed values, not predetermined strings.`,
   schema: WolframInputSchema,
 }) {
   protected async execute(input: WolframInput): Promise<ToolResult> {


### PR DESCRIPTION
Help agents decide when to use the wolfram tool (quick calculations, one-off evaluations) vs writing to a .wl file and running via bash (session persistence, iterative development, intermediate results).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Strengthens guidance around Wolfram usage and testing practices.
> 
> - Updates `research.yaml` Wolfram guidelines to: prefer the `wolfram` tool for quick/one-off tasks, note non-persistent sessions, recommend `.wl` + bash for persistent/iterative workflows, and use `VerificationTest` instead of hardcoded `Print` expectations.
> - Expands `WolframTool` description to mirror these points and discourage hardcoded expected outputs; no functional code changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 65297290387c9bb152148c114ce189432eea3780. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->