### PR TITLE
Skip instruction update for tool-use agents to prevent duplicates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -201,6 +201,18 @@ const options: Options = { ... };
 - Create class instances or complex objects
 - Need to capture closures with initialization context
 
+### Render-Time Workarounds (Anti-pattern)
+
+Never compensate for data model problems at render time. Renderers should only transform and display.
+
+**Signs of broken data model:**
+
+- `Date.now()` or synthetic IDs generated during rendering
+- DOM queries to check if data exists before rendering
+- Deduplication logic comparing rendered content
+
+**Fix:** Store data once at the source with all metadata (timestamps, IDs). If renderers need to generate or deduplicate, the upstream code path is missing data.
+
 ### Path Aliases
 
 Common aliases (full list in `tsconfig.json`):

--- a/src/agent/core/AgentWorkspaceState.ts
+++ b/src/agent/core/AgentWorkspaceState.ts
@@ -356,9 +356,14 @@ export class TodoState {
   private _todosEqual(a: TodoItem[], b: TodoItem[]): boolean {
     if (a.length !== b.length) return false;
     for (let i = 0; i < a.length; i++) {
-      const ai = a[i], bi = b[i];
+      const ai = a[i],
+        bi = b[i];
       if (!ai || !bi) return false; // Guard against sparse arrays
-      if (ai.content !== bi.content || ai.status !== bi.status || ai.activeForm !== bi.activeForm) {
+      if (
+        ai.content !== bi.content ||
+        ai.status !== bi.status ||
+        ai.activeForm !== bi.activeForm
+      ) {
         return false;
       }
     }

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUsePrepareNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUsePrepareNode.ts
@@ -55,6 +55,13 @@ export class ToolUsePrepareNode<C> extends Node<
         { memoryEnabled },
       );
 
+    // Log the initial instruction as a user message (consistent with follow-ups
+    // logged in ToolUseWaitNode). This ensures the message is in stored logs
+    // with correct timestamp, avoiding duplicate rendering issues on refresh.
+    if (userRequest) {
+      logger.userMessage(userRequest);
+    }
+
     const systemMessage = systemPrompt
       ? `${systemPrompt}\n${instructionSuffix}`
       : instructionSuffix;

--- a/src/commands/latex/imageCommands.ts
+++ b/src/commands/latex/imageCommands.ts
@@ -166,4 +166,3 @@ async function handleConvertPdfToImages(): Promise<
     return undefined;
   }
 }
-

--- a/src/progressView/modules/formatters/constants.js
+++ b/src/progressView/modules/formatters/constants.js
@@ -72,9 +72,7 @@ export const TOOL_OUTPUT_LANGUAGES = new Map([
  * Tools whose input contains a `code` field that should be syntax highlighted.
  * Maps tool name to highlight.js language for the code field.
  */
-export const TOOL_CODE_LANGUAGES = new Map([
-  ['wolfram', 'mathematica'],
-]);
+export const TOOL_CODE_LANGUAGES = new Map([['wolfram', 'mathematica']]);
 
 /**
  * Map file extensions that don't match highlight.js language names.

--- a/src/progressView/modules/formatters/logFormatters/messageFormatters.js
+++ b/src/progressView/modules/formatters/logFormatters/messageFormatters.js
@@ -54,7 +54,7 @@ export function formatProgressStatus(message) {
     timestamp,
   } = message;
   const { fullTimestamp, timeDisplay, tooltipTimestamp } = formatTimestamp(
-    new Date(timestamp ?? Date.now()),
+    new Date(timestamp),
   );
 
   const summaryText =
@@ -110,7 +110,7 @@ const ERROR_DETAIL_FIELDS = [
 export function formatError(message) {
   const { normalizedPayload = {}, id, groupId, timestamp } = message;
   const { fullTimestamp, timeDisplay, tooltipTimestamp } = formatTimestamp(
-    new Date(timestamp ?? Date.now()),
+    new Date(timestamp),
   );
 
   const structured = normalizedPayload.structured ?? {};

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -108,68 +108,15 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     return typeof text === 'string' ? text.trim() : '';
   }
 
-  _hasUserMessageInLog(text) {
-    const normalized = this._normalizeInstructionText(text);
-    if (!normalized) {
-      return false;
-    }
-
-    const logContent = document.getElementById(ELEMENT_IDS.LOG_CONTENT);
-    if (!logContent) {
-      return false;
-    }
-
-    const messages = logContent.querySelectorAll('.user-message-content');
-    for (const message of messages) {
-      if ((message.textContent || '').trim() === normalized) {
-        return true;
-      }
-    }
-
-    return false;
-  }
-
-  _getToolUseInstructionForActiveStream() {
-    const stream = state.activeStream;
-    if (!stream) {
-      return null;
-    }
-
-    const pending = state.getPendingInstruction(stream);
-    if (pending?.text) {
-      return pending;
-    }
-
-    const runId =
-      state.getActiveRunId(stream) ?? state.resolveActiveRunId(stream);
-    if (!runId) {
-      return null;
-    }
-
-    return state.getRunInstruction(stream, runId) ?? null;
-  }
-
-  _refreshToolUseInstructionPanel(instruction) {
-    const text = this._normalizeInstructionText(instruction?.text);
-    if (!text) {
-      dom.instructionPanel.hide();
-      return;
-    }
-
-    const shouldShow = !this._hasUserMessageInLog(text);
-    shouldShow
-      ? dom.instructionPanel.show(text, instruction?.metadata)
-      : dom.instructionPanel.hide();
-  }
-
   /**
    * Refresh instruction panel for the active run.
+   * Tool-use agents don't use instruction panel (user messages are in log).
    * @param {string} [runId] - Optional runId to use instead of resolving
    */
   _refreshInstructionForActiveRun(runId) {
+    // Tool-use agents: no instruction panel, user messages are in log
     if (state.activeAgentCategory === 'toolUse') {
-      const instruction = this._getToolUseInstructionForActiveStream();
-      this._refreshToolUseInstructionPanel(instruction);
+      dom.instructionPanel.hide();
       return;
     }
 
@@ -790,14 +737,6 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
         appendFormatted(logContent, formatted);
       }
       scrollToBottom(logContent);
-
-      if (
-        state.activeAgentCategory === 'toolUse' &&
-        mergedLogMessage?.messageType === 'userMessage'
-      ) {
-        const instruction = this._getToolUseInstructionForActiveStream();
-        this._refreshToolUseInstructionPanel(instruction);
-      }
     }
 
     this._updatePlaceholderVisibility();
@@ -1100,17 +1039,10 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       state.clearPendingInstruction(activeStream);
     }
 
-    // Tool-use agents: show instruction only when logs don't include it.
+    // Tool-use agents: no instruction panel, user messages are in log
     if (isToolUseAgent) {
-      if (hasText) {
-        state.setPendingInstruction(activeStream, {
-          text: normalizedText,
-          metadata,
-        });
-      } else {
-        state.clearPendingInstruction(activeStream);
-      }
-      this._refreshToolUseInstructionPanel({ text: normalizedText, metadata });
+      dom.instructionPanel.hide();
+      state.clearPendingInstruction(activeStream);
       return;
     }
 

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -619,7 +619,9 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
         container.appendChild(frag);
       } else {
         // Fallback: append to main log if container was removed (race condition)
-        console.warn(`[messageHandlers] Group container removed during batch: ${groupId}`);
+        console.warn(
+          `[messageHandlers] Group container removed during batch: ${groupId}`,
+        );
         logContent.appendChild(frag);
       }
     }
@@ -1026,13 +1028,10 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       state.clearPendingInstruction(activeStream);
     }
 
-    // Tool-use agents: render instruction as user message in log
+    // Tool-use agents: instruction panel not used, user messages are in logs
     if (isToolUseAgent) {
       dom.instructionPanel.hide();
       state.clearPendingInstruction(activeStream);
-      if (hasText)
-        this._renderToolUseInstruction(activeStream, activeRunId, text);
-      else this._refreshInstructionForActiveRun();
       return;
     }
 
@@ -1049,37 +1048,6 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     }
 
     this._refreshInstructionForActiveRun();
-  }
-
-  /**
-   * Render instruction as user message in log for tool-use agents.
-   */
-  _renderToolUseInstruction(stream, runId, text) {
-    const logContent = document.getElementById(ELEMENT_IDS.LOG_CONTENT);
-    if (!logContent) return;
-
-    const targetContentId = runId
-      ? `${GROUP_DOM_IDS.CONTENT_PREFIX}${runId}`
-      : null;
-    const scope =
-      (targetContentId && document.getElementById(targetContentId)) ||
-      logContent;
-
-    if (scope.querySelector('.user-message-container[data-instruction="true"]'))
-      return;
-
-    const userMessage = this._entryFormatter.format({
-      id: `instruction-${stream}-${runId || 'default'}`,
-      messageType: 'userMessage',
-      text,
-      timestamp: Date.now(),
-      groupId: runId || undefined,
-    });
-
-    if (userMessage) {
-      userMessage.dataset.instruction = 'true';
-      scope.insertBefore(userMessage, scope.firstChild);
-    }
   }
 
   handleDeleteStream(message) {
@@ -1242,7 +1210,13 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     }
 
     // Skip if nothing changed (use \0 separator to avoid collision with user content)
-    const key = [activeStream, streamStatus, category, fileCount, instructionPreview ?? ''].join('\0');
+    const key = [
+      activeStream,
+      streamStatus,
+      category,
+      fileCount,
+      instructionPreview ?? '',
+    ].join('\0');
     if (key === this._lastFollowupState) return;
     this._lastFollowupState = key;
 

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -104,14 +104,74 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     return runId ? { stream, runId } : null;
   }
 
+  _normalizeInstructionText(text) {
+    return typeof text === 'string' ? text.trim() : '';
+  }
+
+  _hasUserMessageInLog(text) {
+    const normalized = this._normalizeInstructionText(text);
+    if (!normalized) {
+      return false;
+    }
+
+    const logContent = document.getElementById(ELEMENT_IDS.LOG_CONTENT);
+    if (!logContent) {
+      return false;
+    }
+
+    const messages = logContent.querySelectorAll('.user-message-content');
+    for (const message of messages) {
+      if ((message.textContent || '').trim() === normalized) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  _getToolUseInstructionForActiveStream() {
+    const stream = state.activeStream;
+    if (!stream) {
+      return null;
+    }
+
+    const pending = state.getPendingInstruction(stream);
+    if (pending?.text) {
+      return pending;
+    }
+
+    const runId =
+      state.getActiveRunId(stream) ?? state.resolveActiveRunId(stream);
+    if (!runId) {
+      return null;
+    }
+
+    return state.getRunInstruction(stream, runId) ?? null;
+  }
+
+  _refreshToolUseInstructionPanel(instruction) {
+    const text = this._normalizeInstructionText(instruction?.text);
+    if (!text) {
+      dom.instructionPanel.hide();
+      return;
+    }
+
+    const shouldShow = !this._hasUserMessageInLog(text);
+    shouldShow
+      ? dom.instructionPanel.show(text, instruction?.metadata)
+      : dom.instructionPanel.hide();
+  }
+
   /**
    * Refresh instruction panel for the active run.
    * @param {string} [runId] - Optional runId to use instead of resolving
    */
   _refreshInstructionForActiveRun(runId) {
-    // Tool-use agents don't use instruction panel
-    if (state.activeAgentCategory === 'toolUse')
-      return dom.instructionPanel.hide();
+    if (state.activeAgentCategory === 'toolUse') {
+      const instruction = this._getToolUseInstructionForActiveStream();
+      this._refreshToolUseInstructionPanel(instruction);
+      return;
+    }
 
     const ctx = this._getActiveRunContext(runId);
     if (!ctx) return dom.instructionPanel.hide();
@@ -730,6 +790,14 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
         appendFormatted(logContent, formatted);
       }
       scrollToBottom(logContent);
+
+      if (
+        state.activeAgentCategory === 'toolUse' &&
+        mergedLogMessage?.messageType === 'userMessage'
+      ) {
+        const instruction = this._getToolUseInstructionForActiveStream();
+        this._refreshToolUseInstructionPanel(instruction);
+      }
     }
 
     this._updatePlaceholderVisibility();
@@ -1006,7 +1074,8 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     const category =
       message.agentCategory || state.activeAgentCategory || 'workflow';
     const isToolUseAgent = category === 'toolUse';
-    const hasText = typeof text === 'string' && text.trim();
+    const normalizedText = this._normalizeInstructionText(text);
+    const hasText = Boolean(normalizedText);
 
     if (message.agentCategory) this._clearAgentCategoryState(category);
     state.activeAgentCategory = category;
@@ -1021,25 +1090,38 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     // Update run instruction state
     if (activeRunId) {
       if (hasText) {
-        state.setRunInstruction(activeStream, activeRunId, { text, metadata });
+        state.setRunInstruction(activeStream, activeRunId, {
+          text: normalizedText,
+          metadata,
+        });
       } else {
         state.clearRunInstruction(activeStream, activeRunId);
       }
       state.clearPendingInstruction(activeStream);
     }
 
-    // Tool-use agents: instruction panel not used, user messages are in logs
+    // Tool-use agents: show instruction only when logs don't include it.
     if (isToolUseAgent) {
-      dom.instructionPanel.hide();
-      state.clearPendingInstruction(activeStream);
+      if (hasText) {
+        state.setPendingInstruction(activeStream, {
+          text: normalizedText,
+          metadata,
+        });
+      } else {
+        state.clearPendingInstruction(activeStream);
+      }
+      this._refreshToolUseInstructionPanel({ text: normalizedText, metadata });
       return;
     }
 
     // Workflow agents: show in panel or as pending
     if (!activeRunId) {
       if (hasText) {
-        state.setPendingInstruction(activeStream, { text, metadata });
-        dom.instructionPanel.show(text, metadata);
+        state.setPendingInstruction(activeStream, {
+          text: normalizedText,
+          metadata,
+        });
+        dom.instructionPanel.show(normalizedText, metadata);
       } else {
         state.clearPendingInstruction(activeStream);
         dom.instructionPanel.hide();

--- a/src/progressView/modules/progressViewState.js
+++ b/src/progressView/modules/progressViewState.js
@@ -418,6 +418,13 @@ export class ProgressViewState {
     });
   }
 
+  getPendingInstruction(streamId) {
+    if (streamId == null) {
+      return null;
+    }
+    return this.pendingInstructions.get(streamId) ?? null;
+  }
+
   takePendingInstruction(streamId) {
     if (streamId == null) {
       return null;


### PR DESCRIPTION
## Summary
Prevents duplicate user messages with incorrect timestamps when processing tool-use agents by skipping the instruction update for this agent category.

## Changes
- Added conditional check to skip `sendInstructionUpdate()` for `AgentCategory.ToolUse` agents
- Tool-use agents already have their user messages included in the logs sent via `updateLogContent()`, making the separate instruction update redundant
- Added explanatory comment documenting why this skip is necessary

## Implementation Details
The fix checks the stream's category before sending the instruction update. For tool-use agents, the user messages are already present in the log content with correct timestamps, so sending an additional instruction update would create duplicates with wrong timestamp information.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns tool-use logging and rendering to avoid duplicate user messages and incorrect timestamps.
> 
> - Tool-use: `ToolUsePrepareNode` now logs the initial `userRequest` via `logger.userMessage()`; progress view hides the instruction panel for tool-use and removes custom instruction log injection
> - Formatting/UX: normalize instruction text; incremental UI updates preserved; follow-up section state derivation unchanged
> - Timestamps: log formatters use `new Date(timestamp)` (no `Date.now()` fallback) to prevent render-time timestamp generation
> - Docs: add “Render-Time Workarounds (Anti-pattern)” guidance in `CLAUDE.md`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3f9407a8ccbe2a93f9645979c2cb57d0a5fb5343. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->