### PR TITLE
perf: add markdown cache and log element lookup optimization

### DIFF
--- a/src/progressView/modules/formatters/markdownRenderer.js
+++ b/src/progressView/modules/formatters/markdownRenderer.js
@@ -10,6 +10,10 @@ import { katexMacros } from '../katexMacros.js';
 
 let markdownRenderer;
 
+// LRU cache for rendered markdown (content hash → HTML)
+const CACHE_MAX_SIZE = 500;
+const markdownCache = new Map();
+
 /**
  * Get the shared markdown renderer instance
  * @returns {MarkdownIt} Configured markdown renderer
@@ -77,12 +81,38 @@ export const restoreLatexReferences = (content) => {
 };
 
 /**
+ * Simple hash function for cache keys (FNV-1a variant)
+ * @param {string} str - String to hash
+ * @returns {string} Hash string
+ */
+const hashContent = (str) => {
+  let hash = 2166136261;
+  for (let i = 0; i < str.length; i++) {
+    hash ^= str.charCodeAt(i);
+    hash = (hash * 16777619) >>> 0;
+  }
+  return hash.toString(36);
+};
+
+/**
  * Process markdown content with LaTeX reference protection
  * @param {string} content - Raw content to process
  * @param {MarkdownIt} [renderer] - Optional custom renderer
  * @returns {string} Processed markdown HTML
  */
 export const processMarkdownContent = (content, renderer) => {
+  // Check cache first (only for default renderer)
+  const useCache = !renderer;
+  const cacheKey = useCache ? hashContent(content) : null;
+
+  if (useCache && markdownCache.has(cacheKey)) {
+    // Move to end for LRU behavior
+    const cached = markdownCache.get(cacheKey);
+    markdownCache.delete(cacheKey);
+    markdownCache.set(cacheKey, cached);
+    return cached;
+  }
+
   // Pre-process LaTeX references to protect them from markdown parsing
   // Note: Pandoc reference formats are normalized to LaTeX at the source (xmlUtils.ts)
   const protectedContent = protectLatexReferences(content);
@@ -97,5 +127,25 @@ export const processMarkdownContent = (content, renderer) => {
   let parsedMarkdown = md.render(formattedContent);
 
   // Post-process to restore and style LaTeX references
-  return restoreLatexReferences(parsedMarkdown);
+  const result = restoreLatexReferences(parsedMarkdown);
+
+  // Store in cache with LRU eviction
+  if (useCache) {
+    if (markdownCache.size >= CACHE_MAX_SIZE) {
+      // Delete oldest entry (first key)
+      const firstKey = markdownCache.keys().next().value;
+      markdownCache.delete(firstKey);
+    }
+    markdownCache.set(cacheKey, result);
+  }
+
+  return result;
+};
+
+/**
+ * Clear the markdown rendering cache.
+ * Call when switching streams or clearing content.
+ */
+export const clearMarkdownCache = () => {
+  markdownCache.clear();
 };

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -455,6 +455,7 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       this._clearActivePanels();
       const logContent = document.getElementById(ELEMENT_IDS.LOG_CONTENT);
       if (logContent) logContent.innerHTML = '';
+      dom.logEntries.clear(); // Clear log element lookup cache
       state.lastRenderedStream = '';
       state.clearRunInstructions();
       state.clearAllActiveRuns();
@@ -474,6 +475,7 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       ) {
         const logContent = document.getElementById(ELEMENT_IDS.LOG_CONTENT);
         if (logContent) logContent.innerHTML = '';
+        dom.logEntries.clear(); // Clear log element lookup cache
         state.lastRenderedStream = '';
         // Repopulate panels from cached state for the new stream
         const activeRunId = state.resolveActiveRunId(message.activeStream);
@@ -543,6 +545,7 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     const previousRunId = state.getActiveRunId(message.stream);
     pendingLogUpdates.clear();
     dom.taskGroups.clear();
+    dom.logEntries.clear(); // Clear log element lookup cache
     state.taskGroups.clear();
     state.clearStreamRunData(message.stream); // Batched clear of all run-scoped data
     logContent.innerHTML = '';

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -197,6 +197,7 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     if (shouldClear) {
       state.taskGroups.clear();
       dom.taskGroups.clear();
+      dom.logEntries.clear(); // Clear stale references to elements in removed task groups
     }
     return shouldClear;
   }

--- a/src/progressView/modules/taskManagers.js
+++ b/src/progressView/modules/taskManagers.js
@@ -470,6 +470,8 @@ export class TaskGroupDomManager {
 export class LogEntryManager {
   constructor() {
     this.entryFormatter = getSharedLogEntryFormatter();
+    // Map of logId → DOM element for O(1) lookup instead of querySelector
+    this.logElements = new Map();
   }
 
   /**
@@ -490,6 +492,11 @@ export class LogEntryManager {
             logMessage,
           );
           return true;
+        }
+
+        // Register element in lookup map for O(1) updates
+        if (logMessage.id) {
+          this.logElements.set(logMessage.id, logLineElement);
         }
 
         // Extract timestamp from the message for chronological ordering
@@ -524,7 +531,18 @@ export class LogEntryManager {
    * @returns {boolean} Whether the log entry was updated
    */
   update(logMessage) {
-    const existing = document.querySelector(`[data-log-id="${logMessage.id}"]`);
+    // Use Map lookup for O(1) access instead of querySelector O(n)
+    let existing = this.logElements.get(logMessage.id);
+
+    // Fallback to querySelector if not in map (e.g., elements from full rebuild)
+    if (!existing) {
+      existing = document.querySelector(`[data-log-id="${logMessage.id}"]`);
+      if (existing) {
+        // Register for future lookups
+        this.logElements.set(logMessage.id, existing);
+      }
+    }
+
     if (existing) {
       // Preserve the expanded/collapsed state for thinking and scratchpad
       const wasOpen = existing.hasAttribute('open');
@@ -533,12 +551,23 @@ export class LogEntryManager {
       });
       if (!newEl) {
         existing.remove();
+        this.logElements.delete(logMessage.id);
         return true;
       }
 
       existing.replaceWith(newEl);
+      // Update map with new element reference
+      this.logElements.set(logMessage.id, newEl);
       return true;
     }
     return false;
+  }
+
+  /**
+   * Clear the log element lookup map.
+   * Call when switching streams or clearing content.
+   */
+  clear() {
+    this.logElements.clear();
   }
 }


### PR DESCRIPTION
- Add LRU cache (500 entries) for markdown rendering results
  - Uses FNV-1a hash for fast content-based cache keys
  - Significantly reduces repeated markdown/KaTeX processing

- Add Map-based log element lookup in LogEntryManager
  - O(1) lookup instead of O(n) querySelector for log updates
  - Falls back to querySelector for elements not in map
  - Clear map on stream switch to prevent stale references

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves rendering and log update performance in the progress view.
> 
> - Adds 500-entry LRU cache in `formatters/markdownRenderer.js` for `processMarkdownContent` (FNV-1a hash keys) with `clearMarkdownCache()` and LRU eviction
> - Preserves LaTeX reference handling; caching only applies to default renderer path
> - Introduces `LogEntryManager.logElements` Map for O(1) `update` lookups; registers elements on `append`, updates on replace, and falls back to `querySelector` when missing
> - Wires `dom.logEntries.clear()` on stream switches, clears, and category changes; clears during full rebuild in `handleUpdateLogs`
> - No API changes; behavior preserved aside from performance
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c425e3e033aeda15c5793b9c1fe1bd710cc2cd5c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->