### PR TITLE
Optimize progress view performance with caching and binary search

### DIFF
--- a/src/progressView/modules/taskManagers.js
+++ b/src/progressView/modules/taskManagers.js
@@ -18,6 +18,8 @@ export class TaskGroupDomManager {
     this.headerFormatter = new TaskGroupHeaderFormatter();
     this.previousActiveGroupId = null;
     this.groupElements = new Map();
+    /** @type {Set<string>} IDs of root groups (runs) for faster showRun iteration */
+    this._rootGroupIds = new Set();
     this.toggleListeners = new Map();
     this.runSelector = runSelector || null;
   }
@@ -80,6 +82,10 @@ export class TaskGroupDomManager {
   _registerGroupElement(group, element) {
     progressViewState.taskGroups.set(group.id, group);
     this.groupElements.set(group.id, element);
+    // Track root groups separately for O(roots) iteration in showRun
+    if (!group.parentGroupId) {
+      this._rootGroupIds.add(group.id);
+    }
   }
 
   _resolveGroupContent(parentGroupId) {
@@ -300,6 +306,8 @@ export class TaskGroupDomManager {
    * For toolUse agents, always shows ALL groups (conversation history).
    * For workflow agents, shows only the specified run (or all if null).
    *
+   * Optimized to iterate only root groups O(roots) instead of all groups O(n).
+   *
    * @param {string|null} groupId - The run ID to show, or null to show all
    */
   showRun(groupId) {
@@ -308,16 +316,14 @@ export class TaskGroupDomManager {
     const showAll =
       progressViewState.activeAgentCategory === 'toolUse' ||
       !groupId ||
-      !this.groupElements.has(groupId);
+      !this._rootGroupIds.has(groupId);
 
-    for (const [id, element] of this.groupElements.entries()) {
-      if (!element) continue;
-
-      const group = progressViewState.taskGroups.get(id);
-      // Skip child groups (they follow parent visibility)
-      if (!group || group.parentGroupId) continue;
-
-      element.hidden = !showAll && id !== groupId;
+    // Only iterate root groups - child groups follow parent visibility via CSS
+    for (const id of this._rootGroupIds) {
+      const element = this.groupElements.get(id);
+      if (element) {
+        element.hidden = !showAll && id !== groupId;
+      }
     }
   }
 
@@ -438,6 +444,7 @@ export class TaskGroupDomManager {
       this._removeToggleListener(groupId);
     }
     this.groupElements.clear();
+    this._rootGroupIds.clear();
     this.toggleListeners.clear();
     this.previousActiveGroupId = null;
     if (this.runSelector) {
@@ -460,6 +467,7 @@ export class TaskGroupDomManager {
     }
     this._removeToggleListener(groupId);
     this.groupElements.delete(groupId);
+    this._rootGroupIds.delete(groupId);
     progressViewState.taskGroups.delete(groupId);
   }
 }

--- a/src/progressView/modules/utils.js
+++ b/src/progressView/modules/utils.js
@@ -44,8 +44,9 @@ export function appendFormatted(container, formatted) {
 
 /**
  * Insert an element into a container keeping children sorted chronologically.
- * Handles log groups and log entries by default, but a custom extractor can
- * be provided for specialized cases.
+ * Optimized with fast paths for common cases (empty, append, prepend).
+ * Falls back to linear scan for mid-insertion to correctly handle elements
+ * without timestamps interspersed in the list.
  *
  * @param {HTMLElement} container - Parent element whose children are ordered
  * @param {HTMLElement} element - Element to insert
@@ -68,23 +69,36 @@ export function insertChronologically({
     timestamp instanceof Date ? timestamp.getTime() : timestamp;
   const childExtractor = getChildTimestamp ?? defaultChildTimestamp;
 
-  const lastChild = container.lastElementChild;
-  if (!lastChild) {
+  const children = container.children;
+  const len = children.length;
+
+  // Fast path: empty container
+  if (len === 0) {
     container.appendChild(element);
     return;
   }
 
-  const lastChildTime = childExtractor(lastChild);
+  // Fast path: append at end (most common case for streaming logs)
+  const lastChildTime = childExtractor(children[len - 1]);
   if (lastChildTime !== null && targetTime >= lastChildTime) {
     container.appendChild(element);
     return;
   }
 
-  const children = Array.from(container.children);
-  for (const child of children) {
-    const childTime = childExtractor(child);
+  // Fast path: insert at beginning
+  const firstChildTime = childExtractor(children[0]);
+  if (firstChildTime !== null && targetTime < firstChildTime) {
+    container.insertBefore(element, children[0]);
+    return;
+  }
+
+  // Linear scan for mid-insertion. Binary search doesn't work reliably here
+  // because some elements (file lists, statistics) don't have timestamps,
+  // and treating nulls as "infinitely old" can skip valid insertion points.
+  for (let i = 0; i < len; i++) {
+    const childTime = childExtractor(children[i]);
     if (childTime !== null && targetTime < childTime) {
-      container.insertBefore(element, child);
+      container.insertBefore(element, children[i]);
       return;
     }
   }


### PR DESCRIPTION


<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Improves DOM performance and scalability in the progress view.
> 
> - Track root run IDs (`_rootGroupIds`) to make `showRun` iterate only root groups (O(roots)); update registration, discard, and clear paths to maintain this set
> - Keep child visibility controlled via CSS while toggling root elements, reducing unnecessary DOM touches
> - Optimize `insertChronologically` with fast paths for empty, append, and prepend cases; avoid array conversion and use a linear scan fallback to handle interspersed non-timestamped elements
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4f437cb6331cf3e1c056522e42c92259cb6772e0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->