### PR TITLE
Add bash tool support to code syntax highlighting

### DIFF
--- a/src/progressView/modules/formatters/constants.js
+++ b/src/progressView/modules/formatters/constants.js
@@ -69,10 +69,14 @@ export const TOOL_OUTPUT_LANGUAGES = new Map([
 ]);
 
 /**
- * Tools whose input contains a `code` field that should be syntax highlighted.
+ * Tools whose input contains a code field that should be syntax highlighted.
  * Maps tool name to highlight.js language for the code field.
+ * Supports 'code' field (wolfram) and 'command' field (bash).
  */
-export const TOOL_CODE_LANGUAGES = new Map([['wolfram', 'mathematica']]);
+export const TOOL_CODE_LANGUAGES = new Map([
+  ['bash', 'bash'],
+  ['wolfram', 'mathematica'],
+]);
 
 /**
  * Map file extensions that don't match highlight.js language names.

--- a/src/progressView/modules/formatters/normalizers.js
+++ b/src/progressView/modules/formatters/normalizers.js
@@ -84,18 +84,19 @@ export function stringifyWithLanguage(value) {
 }
 
 /**
- * Check if an input object is code-only (has only a `code` field with string content).
+ * Check if an input object is code-only (has only a code/command field with string content).
+ * Supports 'code' field (wolfram) and 'command' field (bash).
  * @param {*} value - Value to check
  * @returns {{isCodeOnly: boolean, code: string}} Result with code extraction
  */
 export function extractCodeOnlyInput(value) {
-  // Check property first (cheap), then key count (allocates array)
-  if (
-    isPlainObject(value) &&
-    typeof value.code === 'string' &&
-    Object.keys(value).length === 1
-  ) {
-    return { isCodeOnly: true, code: value.code };
+  if (!isPlainObject(value) || Object.keys(value).length !== 1) {
+    return { isCodeOnly: false, code: '' };
+  }
+  // Support both 'code' (wolfram) and 'command' (bash) field names
+  const codeValue = value.code ?? value.command;
+  if (typeof codeValue === 'string') {
+    return { isCodeOnly: true, code: codeValue };
   }
   return { isCodeOnly: false, code: '' };
 }


### PR DESCRIPTION
## Summary
Extended code syntax highlighting support to include the bash tool in addition to wolfram. The bash tool uses a `command` field instead of `code`, so the code extraction logic was updated to support both field names.

## Changes
- **constants.js**: Added `['bash', 'bash']` entry to `TOOL_CODE_LANGUAGES` map to enable syntax highlighting for bash commands
- **normalizers.js**: Updated `extractCodeOnlyInput()` function to support both `code` field (wolfram) and `command` field (bash)
  - Refactored logic for better readability and efficiency
  - Now checks for either field name using nullish coalescing operator
  - Updated JSDoc comments to reflect support for both field types

## Implementation Details
- The function maintains backward compatibility with existing wolfram tool behavior
- Early returns improve code clarity and reduce nesting
- Both field names are checked in a single operation, avoiding redundant object key lookups

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds bash support alongside wolfram for code formatting and improves input normalization logic.
> 
> - Expand `TOOL_CODE_LANGUAGES` to include `['bash', 'bash']`; clarify comments about supported fields
> - Refactor `extractCodeOnlyInput()` to detect single-field code inputs from either `code` (wolfram) or `command` (bash), with early return and simplified checks
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 395943009be177cf56fd77727e5534be94d32dd5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->