### PR TITLE
Fix instruction display for tool-use agents with legacy data

### DIFF
--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -563,6 +563,33 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     // Tool-use agents don't create task groups but still have usage data
     this._updateRunMetadata(message.stream, message);
 
+    // Backward compatibility: For tool-use agents with old persisted data,
+    // the instruction may not be in the message log (it was sent via UPDATE_INSTRUCTION).
+    // If the first message is not a user message, prepend the instruction.
+    const isToolUseAgent = state.activeAgentCategory === 'toolUse';
+    if (isToolUseAgent && sortedMessages.length > 0) {
+      const firstMsg = sortedMessages[0];
+      const hasUserMessageFirst = firstMsg.messageType === 'userMessage';
+
+      if (!hasUserMessageFirst && message.runInstructions) {
+        // Find instruction from runInstructions (any run - tool-use doesn't use runs)
+        const instructions = Object.values(message.runInstructions);
+        const instruction = instructions[0];
+
+        if (instruction?.text) {
+          // Place instruction just before the first message for correct ordering
+          const timestamp = (firstMsg.timestamp ?? Date.now()) - 1;
+          sortedMessages.unshift({
+            id: `compat-instruction-${message.stream}`,
+            messageType: 'userMessage',
+            text: instruction.text,
+            timestamp,
+            level: 'info',
+          });
+        }
+      }
+    }
+
     if (groups.length > 0) {
       const parentGroups = groups.filter((g) => !g.parentGroupId);
       dom.runSelector.setRuns(parentGroups);


### PR DESCRIPTION
## Summary
Add backward compatibility handling for tool-use agents that have persisted data from before instructions were included in the message log. This ensures instructions are properly displayed even when they were originally sent via `UPDATE_INSTRUCTION` messages.

## Changes
- Added logic to detect when a tool-use agent's first message is not a user message (indicating legacy data structure)
- When detected, prepend the instruction from `runInstructions` as a user message to maintain correct message ordering
- Assign the instruction a timestamp just before the first message to ensure proper chronological ordering
- Mark the synthetic instruction message with a compatible ID (`compat-instruction-{stream}`) for identification

## Implementation Details
- The fix only applies to tool-use agents (`activeAgentCategory === 'toolUse'`)
- Checks if the first message in `sortedMessages` is a user message; if not and instructions exist, prepends the instruction
- Uses `Object.values(message.runInstructions)[0]` to extract the instruction since tool-use agents don't use the run-based structure
- The prepended message is created as a `userMessage` type with `level: 'info'` to match the expected message format

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds backward-compat handling so instructions are shown for legacy tool-use sessions where they weren’t logged.
> 
> - During `UPDATE_LOGS` full rebuilds, if the first entry isn’t a `userMessage` and `runInstructions` exist, prepend a synthetic `userMessage` with the instruction (`id: compat-instruction-{stream}`) and a timestamp just before the first message
> - Continues updating run metadata (`runInstructions`, `runUsage`, `runFiles`, `runMissingOutputs`) regardless of task groups
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 013e31d7fc105dcf2bcec5357bb24b0f059a8102. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->