### PR TITLE
Centralize category-specific behavior with factory and config lookup

### DIFF
--- a/src/logger/TaskState.ts
+++ b/src/logger/TaskState.ts
@@ -103,3 +103,84 @@ export function isToolUseTaskState(
 ): taskState is ToolUseTaskState {
   return taskState.agentConfig.agentCategory === AgentCategory.ToolUse;
 }
+
+// -----------------------------------------------------------------------------
+// Factory Functions
+// -----------------------------------------------------------------------------
+// These factories encapsulate the category-specific TaskState construction,
+// eliminating scattered conditional logic throughout the codebase.
+
+/** Default active files record (all false) */
+const DEFAULT_ACTIVE_FILES: Record<FileType, boolean> = Object.fromEntries(
+  FILE_TYPES.map((type) => [type, false]),
+) as Record<FileType, boolean>;
+
+/**
+ * Options for creating a TaskState.
+ */
+export interface CreateTaskStateOptions {
+  /**
+   * Active files record for workflow agents.
+   * If not provided, defaults to all false.
+   * Ignored for tool-use agents.
+   */
+  activeFiles?: Partial<Record<FileType, boolean>>;
+
+  /**
+   * Tool session state for tool-use agents.
+   * Ignored for workflow agents.
+   */
+  toolSessionState?: ToolSessionState;
+}
+
+/**
+ * Create a TaskState from an AgentConfig.
+ *
+ * This factory handles the category-specific structure automatically:
+ * - Workflow agents get `activeFiles` (defaulting to all false if not provided)
+ * - ToolUse agents get `toolSessionState` (optional)
+ *
+ * @param agentConfig - The agent configuration (determines category)
+ * @param options - Optional category-specific fields
+ * @returns The appropriate TaskState variant
+ *
+ * @example
+ * ```typescript
+ * // Workflow agent with some active files
+ * const workflowState = createTaskState(workflowConfig, {
+ *   activeFiles: { input: true, reference: true },
+ * });
+ *
+ * // ToolUse agent (no options needed)
+ * const toolUseState = createTaskState(toolUseConfig);
+ * ```
+ */
+export function createTaskState(
+  agentConfig: AgentConfig,
+  options: CreateTaskStateOptions = {},
+): TaskState {
+  if (agentConfig.agentCategory === AgentCategory.Workflow) {
+    return {
+      agentConfig: agentConfig as AgentConfig & {
+        agentCategory: AgentCategory.Workflow;
+      },
+      activeFiles: {
+        ...DEFAULT_ACTIVE_FILES,
+        ...options.activeFiles,
+      },
+    };
+  }
+
+  // ToolUse agent
+  const toolUseState: ToolUseTaskState = {
+    agentConfig: agentConfig as AgentConfig & {
+      agentCategory: AgentCategory.ToolUse;
+    },
+  };
+
+  if (options.toolSessionState) {
+    toolUseState.toolSessionState = options.toolSessionState;
+  }
+
+  return toolUseState;
+}

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -29,6 +29,7 @@ import { PROGRESS_VIEW_COMMANDS } from '@common/webview';
 import { safeExecuteCommand } from '@frontend/system/commandUtils';
 import {
   isWorkflowTaskState,
+  createTaskState,
   type WorkflowTaskState,
   type TaskState,
 } from '@logger/TaskState';
@@ -606,24 +607,15 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
         ? AgentCategory.ToolUse
         : AgentCategory.Workflow;
 
-    // Build the agentConfig based on proposal type
-    // Workflow proposals have file fields; tool-use proposals don't
+    // Type narrowing check - proposal type is a discriminated union
+    // This narrows the type so TypeScript knows file fields exist
     const isWorkflow = proposal.agentCategory === 'workflow';
 
     // Helper to check if a file array has content
     const hasFiles = (arr?: string[]): boolean => (arr?.length ?? 0) > 0;
 
-    // Build activeFiles - only relevant for workflow agents
-    const activeFiles = {
-      input: isWorkflow && hasFiles(proposal.inputFiles),
-      reference: isWorkflow && hasFiles(proposal.referenceFiles),
-      auxiliary: isWorkflow && hasFiles(proposal.auxiliaryFiles),
-      media: isWorkflow && hasFiles(proposal.mediaFiles),
-      output: isWorkflow && hasFiles(proposal.outputFiles),
-    };
-
     // Build the agentConfig from the proposal (Zod applies defaults for missing fields)
-    // For tool-use agents, file fields will get default values from AgentConfigSchema
+    // File fields only relevant for workflow agents (type narrowing via isWorkflow)
     const agentConfig = AgentConfigSchema.parse({
       agent: proposal.agent,
       model: proposal.model,
@@ -642,21 +634,27 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
         outputFiles: proposal.outputFiles,
         useMultipleOutputs: proposal.useMultipleOutputs,
         // Set visibility flags for file arrays that have content
-        inputFilesActive: activeFiles.input,
-        referenceFilesActive: activeFiles.reference,
-        auxiliaryFilesActive: activeFiles.auxiliary,
-        mediaFilesActive: activeFiles.media,
-        outputFilesActive: activeFiles.output,
+        inputFilesActive: hasFiles(proposal.inputFiles),
+        referenceFilesActive: hasFiles(proposal.referenceFiles),
+        auxiliaryFilesActive: hasFiles(proposal.auxiliaryFiles),
+        mediaFilesActive: hasFiles(proposal.mediaFiles),
+        outputFilesActive: hasFiles(proposal.outputFiles),
       }),
     });
 
-    // Build the appropriate TaskState variant based on agent category
-    // WorkflowTaskState requires activeFiles; ToolUseTaskState does not
-    // Cast needed because agentConfig.agentCategory is typed as the general
-    // AgentCategory enum, not the specific literal type that TaskState requires
-    const taskState = (
-      isWorkflow ? { agentConfig, activeFiles } : { agentConfig }
-    ) as TaskState;
+    // Build the appropriate TaskState variant using the factory
+    // Factory handles category-specific fields automatically
+    const taskState = createTaskState(agentConfig, {
+      activeFiles: isWorkflow
+        ? {
+            input: hasFiles(proposal.inputFiles),
+            reference: hasFiles(proposal.referenceFiles),
+            auxiliary: hasFiles(proposal.auxiliaryFiles),
+            media: hasFiles(proposal.mediaFiles),
+            output: hasFiles(proposal.outputFiles),
+          }
+        : undefined,
+    });
 
     // Resolve the proposal with 'setup' action to dismiss it from the UI
     // (user will manually execute from the main view after editing)

--- a/src/progressView/config/categoryConfig.ts
+++ b/src/progressView/config/categoryConfig.ts
@@ -1,0 +1,120 @@
+/**
+ * Centralized configuration for agent category-specific behavior.
+ *
+ * This module eliminates scattered conditional checks (e.g., `if (category === 'toolUse')`)
+ * throughout the progressView codebase by consolidating all category-dependent behavior
+ * into a single lookup table.
+ *
+ * ## Design Rationale
+ *
+ * The "task group" abstraction has different semantics per agent category:
+ *
+ * - **Workflow agents**: Each group is a distinct "run" (user can switch between runs,
+ *   only one visible at a time via run selector dropdown)
+ *
+ * - **ToolUse agents**: Each group is a conversation "turn" (user message → agent
+ *   response with tool calls). All turns are always visible as continuous conversation history.
+ *
+ * Rather than scattering `isToolUse` checks throughout the code, we define the behavioral
+ * differences here and look them up via `getCategoryConfig()`.
+ */
+
+import { AgentCategory } from '@agent/core/AgentDataclass';
+
+/**
+ * Configuration for category-specific UI and behavior differences.
+ */
+export interface CategoryConfig {
+  /** Whether to show the run selector dropdown (workflow: switch runs, toolUse: N/A) */
+  readonly showRunSelector: boolean;
+
+  /** Whether to show round headers in the output file list */
+  readonly showRoundHeaders: boolean;
+
+  /** Whether to show the instruction panel */
+  readonly showInstructionPanel: boolean;
+
+  /** Whether task groups represent switchable runs (vs append-only history) */
+  readonly taskGroupsAreSwitchable: boolean;
+
+  /** Whether resume functionality is available */
+  readonly supportsResume: boolean;
+
+  /** Whether file fields are relevant for this category */
+  readonly hasFileFields: boolean;
+}
+
+/**
+ * Workflow agent configuration.
+ * - Runs are discrete and switchable via the run selector
+ * - Round headers provide meaningful context
+ * - Instruction panel shows the current run's instruction
+ * - File fields are relevant for document processing
+ */
+const WORKFLOW_CONFIG: CategoryConfig = {
+  showRunSelector: true,
+  showRoundHeaders: true,
+  showInstructionPanel: true,
+  taskGroupsAreSwitchable: true,
+  supportsResume: true,
+  hasFileFields: true,
+};
+
+/**
+ * ToolUse agent configuration.
+ * - Conversation turns are append-only (all visible)
+ * - Round headers are not meaningful in conversation context
+ * - Instruction panel is not used (conversation is self-documenting)
+ * - File fields are not relevant for interactive sessions
+ */
+const TOOL_USE_CONFIG: CategoryConfig = {
+  showRunSelector: false,
+  showRoundHeaders: false,
+  showInstructionPanel: false,
+  taskGroupsAreSwitchable: false,
+  supportsResume: false,
+  hasFileFields: false,
+};
+
+/**
+ * Category configuration lookup table.
+ * Indexed by AgentCategory enum values for direct access.
+ */
+const CATEGORY_CONFIGS: Record<AgentCategory, CategoryConfig> = {
+  [AgentCategory.Workflow]: WORKFLOW_CONFIG,
+  [AgentCategory.ToolUse]: TOOL_USE_CONFIG,
+};
+
+/**
+ * Get the configuration for an agent category.
+ *
+ * @param category - The agent category (from AgentCategory enum or string literal)
+ * @returns The category-specific configuration
+ *
+ * @example
+ * ```typescript
+ * const config = getCategoryConfig(AgentCategory.ToolUse);
+ * if (config.showInstructionPanel) {
+ *   dom.instructionPanel.show(instruction);
+ * }
+ * ```
+ */
+export function getCategoryConfig(category: AgentCategory): CategoryConfig {
+  return CATEGORY_CONFIGS[category];
+}
+
+/**
+ * Check if a category is workflow.
+ * Convenience function for cases where a simple boolean is clearer.
+ */
+export function isWorkflowCategory(category: AgentCategory): boolean {
+  return category === AgentCategory.Workflow;
+}
+
+/**
+ * Check if a category is toolUse.
+ * Convenience function for cases where a simple boolean is clearer.
+ */
+export function isToolUseCategory(category: AgentCategory): boolean {
+  return category === AgentCategory.ToolUse;
+}

--- a/src/progressView/config/index.ts
+++ b/src/progressView/config/index.ts
@@ -1,0 +1,6 @@
+export {
+  getCategoryConfig,
+  isWorkflowCategory,
+  isToolUseCategory,
+  type CategoryConfig,
+} from './categoryConfig';

--- a/src/progressView/modules/constants.d.ts
+++ b/src/progressView/modules/constants.d.ts
@@ -30,3 +30,21 @@ export declare const FILTER_BUTTONS: ReadonlyArray<{
   label: string;
   filter: string;
 }>;
+
+export interface CategoryUIConfig {
+  readonly showRunSelector: boolean;
+  readonly showRoundHeaders: boolean;
+  readonly showInstructionPanel: boolean;
+  readonly taskGroupsAreSwitchable: boolean;
+  readonly hasFileFields: boolean;
+  readonly toolbar: ReadonlyArray<Record<string, unknown>>;
+}
+
+export declare const CATEGORY_UI_CONFIG: Readonly<{
+  workflow: CategoryUIConfig;
+  toolUse: CategoryUIConfig;
+}>;
+
+export declare function getCategoryUIConfig(
+  category: string,
+): CategoryUIConfig;

--- a/src/progressView/modules/constants.js
+++ b/src/progressView/modules/constants.js
@@ -182,7 +182,7 @@ const WORKFLOW_TOOLBAR = [
 const TOOL_USE_TOOLBAR = [
   STOP_STREAM_BUTTON,
   RESTORE_STATE_BUTTON,
-  { ...OPEN_TASK_STORAGE_BUTTON },
+  OPEN_TASK_STORAGE_BUTTON,
 ];
 
 /** @type {Record<'workflow' | 'toolUse', ToolbarButtonDefinition[]>} */
@@ -190,6 +190,50 @@ export const TOOLBAR_BUTTONS = {
   workflow: WORKFLOW_TOOLBAR,
   toolUse: TOOL_USE_TOOLBAR,
 };
+
+/**
+ * Centralized configuration for category-specific UI behavior.
+ *
+ * This eliminates scattered conditional checks (e.g., `if (category === 'toolUse')`)
+ * by consolidating all category-dependent behavior into a single lookup.
+ *
+ * @typedef {Object} CategoryUIConfig
+ * @property {boolean} showRunSelector - Whether to show the run selector dropdown
+ * @property {boolean} showRoundHeaders - Whether to show round headers in file list
+ * @property {boolean} showInstructionPanel - Whether to show the instruction panel
+ * @property {boolean} taskGroupsAreSwitchable - Whether task groups represent switchable runs
+ * @property {boolean} hasFileFields - Whether file fields are relevant for this category
+ * @property {ToolbarButtonDefinition[]} toolbar - Toolbar buttons for this category
+ */
+
+/** @type {Record<'workflow' | 'toolUse', CategoryUIConfig>} */
+export const CATEGORY_UI_CONFIG = Object.freeze({
+  workflow: Object.freeze({
+    showRunSelector: true,
+    showRoundHeaders: true,
+    showInstructionPanel: true,
+    taskGroupsAreSwitchable: true,
+    hasFileFields: true,
+    toolbar: WORKFLOW_TOOLBAR,
+  }),
+  toolUse: Object.freeze({
+    showRunSelector: false,
+    showRoundHeaders: false,
+    showInstructionPanel: false,
+    taskGroupsAreSwitchable: false,
+    hasFileFields: false,
+    toolbar: TOOL_USE_TOOLBAR,
+  }),
+});
+
+/**
+ * Get the UI configuration for an agent category.
+ * @param {string} category - 'workflow' or 'toolUse'
+ * @returns {CategoryUIConfig}
+ */
+export function getCategoryUIConfig(category) {
+  return CATEGORY_UI_CONFIG[category] ?? CATEGORY_UI_CONFIG.workflow;
+}
 
 export const SORT_BUTTONS = [
   {

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -4,6 +4,7 @@ import {
   STREAM_STATUS,
   ELEMENT_IDS,
   GROUP_DOM_IDS,
+  getCategoryUIConfig,
 } from './constants.js';
 import { progressViewDomHandler } from './domHandlers.js';
 import { createThemeHandlers } from './handlers/themeHandlers.js';
@@ -21,7 +22,7 @@ import { scrollToBottom, setRadioGroupValue } from '@common/domUtils.js';
 /**
  * ARCHITECTURAL NOTE: Task Groups have different semantics per agent category
  *
- * The "task group" abstraction is currently overloaded:
+ * The "task group" abstraction is overloaded with different meanings:
  *
  * - Workflow agents: Each group is a distinct "run" (user can switch between runs,
  *   only one visible at a time via run selector dropdown)
@@ -30,12 +31,15 @@ import { scrollToBottom, setRadioGroupValue } from '@common/domUtils.js';
  *   response with tool calls). All turns should always be visible as continuous
  *   conversation history.
  *
- * This semantic mismatch requires special handling throughout (checking isToolUse
- * before calling showRun). A cleaner design would separate these concepts:
- * - WorkflowRunManager for workflow agents (switching between runs)
- * - ConversationTurnManager for toolUse agents (append-only history)
+ * Category-specific behavior is now centralized in CATEGORY_UI_CONFIG (constants.js)
+ * and accessed via getCategoryUIConfig(). This eliminates scattered `isToolUse` checks
+ * and makes behavioral differences explicit and discoverable.
  *
- * TODO: Consider refactoring to separate these concerns in a future PR.
+ * Key config properties:
+ * - showRunSelector: Whether to show run switching UI
+ * - showRoundHeaders: Whether round numbers are meaningful
+ * - showInstructionPanel: Whether instruction panel is used
+ * - taskGroupsAreSwitchable: Whether groups represent discrete switchable runs
  */
 
 // Create shorter aliases for internal use
@@ -109,9 +113,10 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
    * @param {string} [runId] - Optional runId to use instead of resolving
    */
   _refreshInstructionForActiveRun(runId) {
-    // Tool-use agents don't use instruction panel
-    if (state.activeAgentCategory === 'toolUse')
+    const categoryConfig = getCategoryUIConfig(state.activeAgentCategory);
+    if (!categoryConfig.showInstructionPanel) {
       return dom.instructionPanel.hide();
+    }
 
     const ctx = this._getActiveRunContext(runId);
     if (!ctx) return dom.instructionPanel.hide();
@@ -131,9 +136,10 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     const filesByRound = ctx
       ? (state.getRunFiles(ctx.stream, ctx.runId) ?? {})
       : {};
-    // Hide round headers for tool-use agents where round numbers don't have meaning
-    const showRoundHeaders = state.activeAgentCategory !== 'toolUse';
-    dom.fileList.update(filesByRound, { showRoundHeaders });
+    const categoryConfig = getCategoryUIConfig(state.activeAgentCategory);
+    dom.fileList.update(filesByRound, {
+      showRoundHeaders: categoryConfig.showRoundHeaders,
+    });
   }
 
   _refreshUsageForActiveRun() {
@@ -413,7 +419,7 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       (s) => s.name === message.activeStream,
     );
     const category = this._resolveAgentCategory(activeStreamInfo);
-    const isToolAgent = category === 'toolUse';
+    const categoryConfig = getCategoryUIConfig(category);
 
     // Only clear state if we have confirmed stream info for the category change
     if (activeStreamInfo) {
@@ -422,15 +428,16 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     state.activeAgentCategory = category;
 
     dom.runSelector.setDisplayEnabled(
-      Boolean(message.activeStream) && !isToolAgent,
+      Boolean(message.activeStream) && categoryConfig.showRunSelector,
     );
 
     const container = document.getElementById(ELEMENT_IDS.FOLLOW_UP_CONTAINER);
+    const showFollowUp = !categoryConfig.taskGroupsAreSwitchable; // ToolUse agents show follow-up
     if (container) {
-      container.classList.toggle('is-visible', isToolAgent);
-      container.setAttribute('aria-hidden', isToolAgent ? 'false' : 'true');
+      container.classList.toggle('is-visible', showFollowUp);
+      container.setAttribute('aria-hidden', showFollowUp ? 'false' : 'true');
     }
-    dom.followUpInput.setContainerVisibility(Boolean(isToolAgent && container));
+    dom.followUpInput.setContainerVisibility(Boolean(showFollowUp && container));
 
     // Restore follow-up text for the new stream
     if (message.activeStream && previousStream !== message.activeStream) {
@@ -440,9 +447,9 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     // YOLO state is sent by backend via updateToolEditApprovalState message
     // No need to restore from frontend cache here
 
-    dom.approvalRequests.setActiveStream(message.activeStream, isToolAgent);
-    dom.retryRequests.setActiveStream(message.activeStream, isToolAgent);
-    dom.workflowProposals.setActiveStream(message.activeStream, isToolAgent);
+    dom.approvalRequests.setActiveStream(message.activeStream, showFollowUp);
+    dom.retryRequests.setActiveStream(message.activeStream, showFollowUp);
+    dom.workflowProposals.setActiveStream(message.activeStream, showFollowUp);
 
     dom.toolbar.render(category);
 
@@ -1005,7 +1012,7 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     const metadata = message.instruction?.metadata;
     const category =
       message.agentCategory || state.activeAgentCategory || 'workflow';
-    const isToolUseAgent = category === 'toolUse';
+    const categoryConfig = getCategoryUIConfig(category);
     const hasText = typeof text === 'string' && text.trim();
 
     if (message.agentCategory) this._clearAgentCategoryState(category);
@@ -1029,7 +1036,7 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     }
 
     // Tool-use agents: render instruction as user message in log
-    if (isToolUseAgent) {
+    if (!categoryConfig.showInstructionPanel) {
       dom.instructionPanel.hide();
       state.clearPendingInstruction(activeStream);
       if (hasText)

--- a/src/progressView/modules/taskManagers.js
+++ b/src/progressView/modules/taskManagers.js
@@ -1,5 +1,5 @@
 // Local imports - progress view
-import { ELEMENT_IDS, GROUP_DOM_IDS } from './constants.js';
+import { ELEMENT_IDS, GROUP_DOM_IDS, getCategoryUIConfig } from './constants.js';
 import {
   TaskGroupHeaderFormatter,
   getSharedLogEntryFormatter,
@@ -297,16 +297,20 @@ export class TaskGroupDomManager {
   /**
    * Show/hide task groups based on the selected run.
    *
-   * For toolUse agents, always shows ALL groups (conversation history).
-   * For workflow agents, shows only the specified run (or all if null).
+   * Uses centralized category config to determine visibility behavior:
+   * - taskGroupsAreSwitchable=false: Show ALL groups (conversation history)
+   * - taskGroupsAreSwitchable=true: Show only the specified run
    *
    * @param {string|null} groupId - The run ID to show, or null to show all
    */
   showRun(groupId) {
-    // ToolUse agents show all groups as conversation turns (append-only history)
-    // Workflow agents filter to single run (mutually exclusive runs)
+    const categoryConfig = getCategoryUIConfig(
+      progressViewState.activeAgentCategory,
+    );
+    // Non-switchable groups (e.g., toolUse conversation turns) always show all
+    // Switchable groups (e.g., workflow runs) filter to single run
     const showAll =
-      progressViewState.activeAgentCategory === 'toolUse' ||
+      !categoryConfig.taskGroupsAreSwitchable ||
       !groupId ||
       !this.groupElements.has(groupId);
 

--- a/src/progressView/modules/uiManagers/FollowupSectionManager.js
+++ b/src/progressView/modules/uiManagers/FollowupSectionManager.js
@@ -1,5 +1,5 @@
 // Local imports - progress view
-import { COMMANDS, ELEMENT_IDS } from '../constants.js';
+import { COMMANDS, ELEMENT_IDS, getCategoryUIConfig } from '../constants.js';
 import { progressViewState } from '../progressViewState.js';
 
 // Local imports - common helpers
@@ -151,17 +151,20 @@ export class FollowupSectionManager {
 
   /**
    * Update the followup section visibility based on stream data.
-   * Shows the section for completed workflow or tool-use streams with output files.
+   * Shows the section for completed workflow streams with output files.
+   * Uses centralized category config to determine eligibility.
    * @param {Object} streamData - The stream data
    */
   updateForStream(streamData) {
     this._currentStreamData = streamData;
     const collapsible = safeGetElementById(ELEMENT_IDS.FOLLOWUP_COLLAPSIBLE);
 
-    // Show for workflow streams that have generated files
-    const isValidCategory = streamData?.agentCategory === 'workflow';
+    // Show for categories that have file fields (workflow agents) when stopped with outputs
+    const categoryConfig = getCategoryUIConfig(
+      streamData?.agentCategory || 'workflow',
+    );
     const shouldShow =
-      isValidCategory &&
+      categoryConfig.hasFileFields &&
       streamData?.status === 'stopped' &&
       streamData?.hasOutputFiles;
 


### PR DESCRIPTION
## Summary

This PR eliminates scattered conditional logic throughout the codebase by introducing two key abstractions:

1. **TaskState Factory** (`createTaskState`): Encapsulates category-specific TaskState construction, automatically handling the different field requirements for Workflow vs ToolUse agents
2. **Category Config Lookup** (`getCategoryUIConfig`): Centralizes all category-dependent UI behavior in a single configuration object, replacing dozens of `if (category === 'toolUse')` checks

## Key Changes

### TaskState Factory (src/logger/TaskState.ts)
- Added `createTaskState()` factory function that automatically constructs the correct TaskState variant based on AgentConfig
- Handles default `activeFiles` initialization for Workflow agents
- Eliminates type casting and conditional logic at call sites
- Updated `ProgressViewMessageHandler` to use the factory instead of manual object construction

### Category Configuration (src/progressView/config/)
- Created new `categoryConfig.ts` module with centralized `CategoryConfig` interface
- Defines all category-specific behavioral differences in one place:
  - `showRunSelector`: Whether run switching UI is visible
  - `showRoundHeaders`: Whether round numbers are meaningful
  - `showInstructionPanel`: Whether instruction panel is used
  - `taskGroupsAreSwitchable`: Whether groups represent discrete runs vs append-only history
  - `supportsResume`: Whether resume functionality is available
  - `hasFileFields`: Whether file fields are relevant
- Added convenience functions: `getCategoryConfig()`, `isWorkflowCategory()`, `isToolUseCategory()`

### JavaScript Constants (src/progressView/modules/constants.js)
- Mirrored category config in JavaScript with `CATEGORY_UI_CONFIG` and `getCategoryUIConfig()`
- Includes toolbar button definitions alongside UI behavior config
- Provides type definitions in `constants.d.ts`

### Refactored Call Sites
- **messageHandlers.js**: Replaced 8+ `isToolAgent` checks with `getCategoryUIConfig()` lookups
- **taskManagers.js**: Updated `showRun()` to use `taskGroupsAreSwitchable` config property
- **FollowupSectionManager.js**: Uses `hasFileFields` config instead of category string comparison

## Benefits

- **Maintainability**: All category-specific behavior is now in one place, making it easy to add new categories or modify existing behavior
- **Discoverability**: New developers can see all behavioral differences by reading the config objects
- **Type Safety**: TypeScript factory ensures correct TaskState construction
- **Reduced Duplication**: Eliminates repeated conditional checks throughout the codebase
- **Testability**: Config objects can be easily mocked or tested independently

## Architectural Note

The "task group" abstraction previously had overloaded semantics:
- **Workflow agents**: Discrete runs that can be switched via dropdown
- **ToolUse agents**: Conversation turns that are always visible as history

This PR makes those semantic differences explicit and centralized, laying groundwork for potential future refactoring into separate `WorkflowRunManager` and `ConversationTurnManager` classes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Unifies category-specific behavior and removes scattered conditionals across the progress view.
> 
> - Adds `createTaskState(agentConfig, options)` in `logger/TaskState.ts` to construct `TaskState` for Workflow/ToolUse (defaults `activeFiles`, optional `toolSessionState`)
> - Introduces `progressView/config` with `getCategoryConfig`, `isWorkflowCategory`, `isToolUseCategory` for TS; mirrors in JS via `CATEGORY_UI_CONFIG` and `getCategoryUIConfig()` with toolbar integration and d.ts types
> - Refactors `messageHandlers.js`, `taskManagers.js`, `FollowupSectionManager.js` to use centralized config (run selector, round headers, instruction panel, task group visibility, follow-up UI)
> - Updates proposal setup in `ProgressViewMessageHandler.ts` to use `createTaskState` and direct `hasFiles` checks; minor toolbar cleanup for `OPEN_TASK_STORAGE_BUTTON` usage
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 346106c5e413a2d4e5135ff25eea7e1553e8dec1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->