### PR TITLE
Remove unused internal methods and type exports

### DIFF
--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -5,12 +5,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 
 // Local imports
-import {
-  getAgent,
-  createKey,
-  ensureAgentsLoaded,
-  computeAgentOptions,
-} from '@agent/index/agentRegistry';
+import { getAgent, computeAgentOptions } from '@agent/index/agentRegistry';
 import { computeModelOptions } from '@model/computeModelOptions';
 import { AgentCategory } from '@agent/core/AgentDataclass';
 import { AgentConfigSchema, type AgentConfig } from '@agent/core/AgentConfig';

--- a/src/progressView/events/EventHandlerContext.ts
+++ b/src/progressView/events/EventHandlerContext.ts
@@ -52,7 +52,7 @@ export function isWebviewAvailable(ctx: EventHandlerContext): boolean {
  * Check if the stream is the currently active stream.
  * Use to determine if immediate UI updates should occur.
  */
-export function isActiveStream(
+function isActiveStream(
   ctx: EventHandlerContext,
   stream: StreamTabId,
 ): boolean {

--- a/src/progressView/events/UIEvents.ts
+++ b/src/progressView/events/UIEvents.ts
@@ -19,7 +19,7 @@ import { withEventErrorHandling } from './errorHandling';
 const MODULE = 'UIEvents';
 
 /** Callbacks for retry event handling. */
-export interface RetryCallbacks {
+interface RetryCallbacks {
   showRetryRequest: (
     payload: ProgressEventPayloads['showRetryRequest'],
   ) => void;
@@ -27,7 +27,7 @@ export interface RetryCallbacks {
 }
 
 /** Callbacks for approval event handling. */
-export interface ApprovalCallbacks {
+interface ApprovalCallbacks {
   showToolEditApprovalPrompt: (
     payload: ProgressEventPayloads['showToolEditApprovalPrompt'],
   ) => void;
@@ -39,7 +39,7 @@ export interface ApprovalCallbacks {
 }
 
 /** Callbacks for bash approval event handling. */
-export interface BashApprovalCallbacks {
+interface BashApprovalCallbacks {
   showBashApprovalPrompt: (
     payload: ProgressEventPayloads['showBashApprovalPrompt'],
   ) => void;
@@ -47,7 +47,7 @@ export interface BashApprovalCallbacks {
 }
 
 /** Callbacks for agent proposal handling (workflow or tool-use). */
-export interface AgentProposalCallbacks {
+interface AgentProposalCallbacks {
   showAgentProposal: (
     payload: ProgressEventPayloads['showAgentProposal'],
   ) => void;

--- a/src/progressView/events/index.ts
+++ b/src/progressView/events/index.ts
@@ -1,11 +1,7 @@
 // Barrel export for progress view events
 export { withEventErrorHandling } from './errorHandling';
 export { ProgressEventHandler, type UICallbacks } from './ProgressEventHandler';
-export {
-  registerUIEvents,
-  type RetryCallbacks,
-  type ApprovalCallbacks,
-} from './UIEvents';
+export { registerUIEvents } from './UIEvents';
 export { type ProgressEventBusLike } from '@eventBus/ProgressEventBus';
 
 // Domain-specific event handlers (modular, focused files)

--- a/src/progressView/managers/TaskGroupManager.ts
+++ b/src/progressView/managers/TaskGroupManager.ts
@@ -113,14 +113,6 @@ export class TaskGroupManager extends PersistentMapManager<
   }
 
   /**
-   * Get a specific task group
-   */
-  getGroup(stream: StreamTabId, groupId: string): TaskGroup | undefined {
-    const streamGroups = this.get(stream);
-    return streamGroups?.get(groupId);
-  }
-
-  /**
    * Get all groups for a stream
    */
   getStreamGroups(stream: StreamTabId): Map<string, TaskGroup> {

--- a/src/progressView/managers/UsageStatsManager.ts
+++ b/src/progressView/managers/UsageStatsManager.ts
@@ -166,29 +166,6 @@ export class UsageStatsManager extends PersistentMapManager<
   }
 
   /**
-   * Get usage for a specific key without copying the entire map.
-   * More efficient for single-key lookups in read-only scenarios
-   * (e.g., refreshStreamSurface bulk updates, displaying current usage).
-   */
-  getUsageForKey(
-    stream: StreamTabId,
-    storageKey: StorageKey,
-  ): TokenUsageStats | undefined {
-    return this.items.get(stream)?.get(storageKey);
-  }
-
-  /**
-   * Get total usage across all runs for a stream
-   */
-  getStreamTotals(stream: StreamTabId): TokenUsageStats | undefined {
-    const runs = this.items.get(stream);
-    if (!runs || runs.size === 0) {
-      return undefined;
-    }
-    return sumUsageStats(runs.values());
-  }
-
-  /**
    * Set all usage statistics (used during loading).
    * Handles both RunUsageMap entries and legacy single TokenUsageStats entries.
    */
@@ -229,16 +206,6 @@ export class UsageStatsManager extends PersistentMapManager<
     }
 
     return new Map([[normalizeRunId(null), usage]]);
-  }
-
-  /**
-   * Calculate total usage across all streams
-   */
-  getTotalUsage(): TokenUsageStats {
-    const allUsage = [...this.items.values()].flatMap((runMap) => [
-      ...runMap.values(),
-    ]);
-    return sumUsageStats(allUsage);
   }
 
   /**

--- a/src/progressView/state/ProgressViewState.ts
+++ b/src/progressView/state/ProgressViewState.ts
@@ -26,7 +26,6 @@ import {
   TaskState,
   TaskStateSchema,
   isToolUseTaskState,
-  isWorkflowTaskState,
 } from '@logger/TaskState';
 import {
   StreamTabsManager,
@@ -385,44 +384,6 @@ export class ProgressViewState {
     void this.storage.update(WorkspaceStateKey.ACTIVE_RUN_IDS, record);
   }
 
-  /**
-   * Reset workflow output metadata for the provided stream.
-   *
-   * Clears outputFiles, useMultipleOutputs, and the output flag.
-   * Returns true when state was modified and persisted, false when
-   * already cleared or not a workflow task.
-   */
-  clearOutputState(streamTabId: StreamTabId): boolean {
-    const taskState = this.getTaskState(streamTabId);
-    if (!taskState || !isWorkflowTaskState(taskState)) {
-      return false;
-    }
-
-    const hasPersistedOutputs = taskState.agentConfig.outputFiles.length > 0;
-    const usesMultipleOutputs = taskState.agentConfig.useMultipleOutputs;
-    const outputFlagEnabled = taskState.activeFiles.output;
-
-    if (!hasPersistedOutputs && !usesMultipleOutputs && !outputFlagEnabled) {
-      return false;
-    }
-
-    const updatedState = {
-      ...taskState,
-      agentConfig: {
-        ...taskState.agentConfig,
-        outputFiles: [],
-        useMultipleOutputs: false,
-      },
-      activeFiles: {
-        ...taskState.activeFiles,
-        output: false,
-      },
-    };
-
-    this.setTaskState(streamTabId, updatedState);
-    return true;
-  }
-
   // Task state management
   setTaskState(streamTabId: StreamTabId, taskState: TaskState): void {
     this.taskStates.set(streamTabId, taskState);
@@ -474,14 +435,6 @@ export class ProgressViewState {
 
   getExecutionId(streamTabId: StreamTabId): ExecutionId | undefined {
     return this._executionIds.get(streamTabId);
-  }
-
-  /**
-   * Get all execution IDs as a read-only Map.
-   * Used for detecting waiting streams from persisted flows on startup.
-   */
-  getAllExecutionIds(): ReadonlyMap<StreamTabId, ExecutionId> {
-    return this._executionIds;
   }
 
   clearExecutionId(streamTabId: StreamTabId): void {

--- a/src/progressView/state/ProgressViewState.ts
+++ b/src/progressView/state/ProgressViewState.ts
@@ -405,10 +405,6 @@ export class ProgressViewState {
     }
   }
 
-  getAllTaskStates(): Map<StreamTabId, TaskState> {
-    return new Map(this.taskStates);
-  }
-
   /**
    * Get output files for a stream using storageKey.
    *
@@ -435,11 +431,6 @@ export class ProgressViewState {
 
   getExecutionId(streamTabId: StreamTabId): ExecutionId | undefined {
     return this._executionIds.get(streamTabId);
-  }
-
-  clearExecutionId(streamTabId: StreamTabId): void {
-    this._executionIds.delete(streamTabId);
-    this.saveExecutionIds();
   }
 
   // Stream cleanup operations


### PR DESCRIPTION
## Summary
This PR removes unused internal methods and type exports across the progress view module to reduce code complexity and improve maintainability.

## Key Changes
- **src/progressView/events/index.ts**: Removed unused type exports `RetryCallbacks` and `ApprovalCallbacks` from the barrel export
- **src/progressView/managers/TaskGroupManager.ts**: Removed unused `getGroup()` method that retrieved a specific task group
- **src/progressView/managers/UsageStatsManager.ts**: Removed three unused methods:
  - `getUsageForKey()` - single-key usage lookup
  - `getStreamTotals()` - stream-level usage aggregation
  - `getTotalUsage()` - global usage aggregation
- **src/progressView/state/ProgressViewState.ts**: Removed two unused methods:
  - `clearOutputState()` - workflow output metadata reset
  - `getAllExecutionIds()` - read-only execution ID map accessor
- Removed unused import of `isWorkflowTaskState` from TaskState

## Notes
These methods were identified as dead code with no internal or external callers. Removing them reduces the API surface and makes the codebase easier to maintain.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Streamlines the progress view by pruning dead code and tightening module exports with no functional changes.
> 
> - Remove unused methods: `TaskGroupManager.getGroup`, `UsageStatsManager.getUsageForKey`/`getStreamTotals`/`getTotalUsage`, `ProgressViewState.clearOutputState`/`getAllTaskStates`/`getAllExecutionIds`/`clearExecutionId`
> - Make internal-only: `isActiveStream` (no longer exported), callback interfaces in `UIEvents.ts` (keep `UICallbacks` export)
> - Barrel cleanup: stop re-exporting `RetryCallbacks`/`ApprovalCallbacks`; only export `registerUIEvents`
> - Import cleanup: drop unused agents registry imports and `isWorkflowTaskState` from files where not needed
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d4ff1e28e688cc5460fef9268eb1525ad9deb695. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->