### PR TITLE
Remove unused outputFile and obsolete command handlers

### DIFF
--- a/src/agent/core/AgentState.ts
+++ b/src/agent/core/AgentState.ts
@@ -20,7 +20,6 @@ export const ConversationRoundStateSnapshotSchema = z.object({
   roundIndex: z.int().nonnegative(),
   continuationCount: z.int().nonnegative().prefault(0),
   responseTimeMs: z.number().nonnegative().prefault(0),
-  outputFile: z.string().prefault(''),
   normalizedUsage: NormalizedUsageSchema.nullable().prefault(null),
 });
 
@@ -41,14 +40,12 @@ export class ConversationRoundState {
   public roundIndex: number;
   public continuationCount: number;
   public responseTimeMs: number;
-  public outputFile: string;
   public normalizedUsage: NormalizedUsage | null;
 
   constructor(roundIndex: number) {
     this.roundIndex = roundIndex;
     this.continuationCount = ROUND_STATE_DEFAULTS.continuationCount;
     this.responseTimeMs = ROUND_STATE_DEFAULTS.responseTimeMs;
-    this.outputFile = ROUND_STATE_DEFAULTS.outputFile;
     this.normalizedUsage = ROUND_STATE_DEFAULTS.normalizedUsage;
   }
 
@@ -56,7 +53,6 @@ export class ConversationRoundState {
   private applyDefaults(): void {
     this.continuationCount = ROUND_STATE_DEFAULTS.continuationCount;
     this.responseTimeMs = ROUND_STATE_DEFAULTS.responseTimeMs;
-    this.outputFile = ROUND_STATE_DEFAULTS.outputFile;
     this.normalizedUsage = ROUND_STATE_DEFAULTS.normalizedUsage;
   }
 
@@ -66,7 +62,6 @@ export class ConversationRoundState {
     const state = new ConversationRoundState(parsed.roundIndex);
     state.continuationCount = parsed.continuationCount;
     state.responseTimeMs = parsed.responseTimeMs;
-    state.outputFile = parsed.outputFile;
     state.normalizedUsage = parsed.normalizedUsage;
     return state;
   }
@@ -77,7 +72,6 @@ export class ConversationRoundState {
       roundIndex: this.roundIndex,
       continuationCount: this.continuationCount,
       responseTimeMs: this.responseTimeMs,
-      outputFile: this.outputFile,
       normalizedUsage: this.normalizedUsage,
     };
   }

--- a/src/common/webview/commands.js
+++ b/src/common/webview/commands.js
@@ -17,7 +17,6 @@ export const MAIN_VIEW_COMMANDS = {
   // File operations
   FILE_SELECT: 'selectFile',
   FILE_SELECTED: 'fileSelected',
-  FILES_UPDATE: 'updateFiles',
 
   // Execution
   EXECUTE: 'execute',
@@ -98,7 +97,6 @@ export const MAIN_VIEW_COMMANDS = {
   DISMISS_LOGIN_BANNER: 'dismissLoginBanner',
 
   // Extension response events
-  CHECK_RESTORED_BASE_FILE: 'checkRestoredBaseFile',
   INSTRUCTION_TEXT_POLISHED: 'instructionTextPolished',
   INSTRUCTION_TEXT_POLISH_ERROR: 'instructionTextPolishError',
   INSTRUCTION_TEXT_TRANSCRIBED: 'instructionTextTranscribed',
@@ -160,7 +158,6 @@ export const PROGRESS_VIEW_COMMANDS = {
   // Stream management
   SWITCH_STREAM: 'switchStream',
   DELETE_STREAM: 'deleteStream',
-  ERASE_STREAM: 'eraseStream',
   CLEAN_STREAM: 'cleanStream',
   STOP_STREAM: 'stopStream',
   UPDATE_STREAMS: 'updateStreams',
@@ -168,7 +165,6 @@ export const PROGRESS_VIEW_COMMANDS = {
 
   // Logging
   UPDATE_LOGS: 'updateLogs',
-  CLEAR_LOGS: 'clearLogs',
   APPEND_LOG: 'appendLog',
   UPDATE_LOG: 'updateLog',
 

--- a/src/common/webview/commands.ts
+++ b/src/common/webview/commands.ts
@@ -17,7 +17,6 @@ export const MAIN_VIEW_COMMANDS = {
   // File operations
   FILE_SELECT: 'selectFile',
   FILE_SELECTED: 'fileSelected',
-  FILES_UPDATE: 'updateFiles',
 
   // Execution
   EXECUTE: 'execute',
@@ -98,7 +97,6 @@ export const MAIN_VIEW_COMMANDS = {
   DISMISS_LOGIN_BANNER: 'dismissLoginBanner',
 
   // Extension response events
-  CHECK_RESTORED_BASE_FILE: 'checkRestoredBaseFile',
   INSTRUCTION_TEXT_POLISHED: 'instructionTextPolished',
   INSTRUCTION_TEXT_POLISH_ERROR: 'instructionTextPolishError',
   INSTRUCTION_TEXT_TRANSCRIBED: 'instructionTextTranscribed',
@@ -160,7 +158,6 @@ export const PROGRESS_VIEW_COMMANDS = {
   // Stream management
   SWITCH_STREAM: 'switchStream',
   DELETE_STREAM: 'deleteStream',
-  ERASE_STREAM: 'eraseStream',
   CLEAN_STREAM: 'cleanStream',
   STOP_STREAM: 'stopStream',
   UPDATE_STREAMS: 'updateStreams',
@@ -168,7 +165,6 @@ export const PROGRESS_VIEW_COMMANDS = {
 
   // Logging
   UPDATE_LOGS: 'updateLogs',
-  CLEAR_LOGS: 'clearLogs',
   APPEND_LOG: 'appendLog',
   UPDATE_LOG: 'updateLog',
 

--- a/src/progressView/types.ts
+++ b/src/progressView/types.ts
@@ -32,7 +32,6 @@ export type StreamTabInfo = z.infer<typeof StreamTabInfoSchema>;
 
 export const InstructionMetadataSchema = z.object({
   showToggle: z.boolean().optional(),
-  expanded: z.boolean().optional(),
 });
 export type InstructionMetadata = z.infer<typeof InstructionMetadataSchema>;
 

--- a/src/webview/modules/messageHandlers.js
+++ b/src/webview/modules/messageHandlers.js
@@ -370,8 +370,6 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
   _createStateHandlers() {
     return {
       [MAIN_VIEW_COMMANDS.STATE_RESTORE]: this.handleRestoreState.bind(this),
-      [MAIN_VIEW_COMMANDS.CHECK_RESTORED_BASE_FILE]:
-        this.handleCheckRestoredBaseFile.bind(this),
     };
   }
 
@@ -1085,14 +1083,6 @@ export class MainViewMessageHandler extends BaseWebviewMessageHandler {
       // Show error to user via status or notification
       this._showError?.('Failed to restore state. Please try again.');
     }
-  }
-
-  handleCheckRestoredBaseFile() {
-    const restoredBaseFileDiv = this._getElement(BASE_FILE);
-    if (restoredBaseFileDiv && restoredBaseFileDiv.value) {
-      fileSelect.updateEdited(restoredBaseFileDiv.value);
-    }
-    this._postHandle();
   }
 
   // Instruction updates


### PR DESCRIPTION
## Summary
This PR removes unused code paths and obsolete command handlers that are no longer needed in the agent state management and webview command infrastructure.

## Key Changes

- **AgentState.ts**: Removed the `outputFile` field from `ConversationRoundState` class and its schema, including all references in the constructor, defaults application, deserialization, and serialization methods.

- **commands.ts**: Removed obsolete webview command definitions:
  - `FILES_UPDATE` - unused file update command
  - `CHECK_RESTORED_BASE_FILE` - unused base file restoration check command
  - `ERASE_STREAM` - unused stream erasure command
  - `CLEAR_LOGS` - unused log clearing command

- **types.ts**: Removed the `expanded` optional field from `InstructionMetadataSchema` in the progress view types.

- **messageHandlers.js**: Removed the `handleCheckRestoredBaseFile` message handler and its registration in the state handlers map, eliminating dead code that checked for restored base files.

## Impact
These changes clean up the codebase by removing unused state fields and command handlers that are no longer referenced or executed. This reduces maintenance burden and clarifies the actual API surface between the extension and webviews.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Cleans up unused state and commands across agent core and webviews.
> 
> - Removed `outputFile` from `ConversationRoundState` schema/class and all serialization/deserialization paths in `AgentState.ts`
> - Pruned obsolete webview commands in `commands.{ts,js}`: `FILES_UPDATE`, `CHECK_RESTORED_BASE_FILE`, `ERASE_STREAM`, `CLEAR_LOGS`
> - Deleted `handleCheckRestoredBaseFile` and its registration in `messageHandlers.js`
> - Simplified progress view types by removing `InstructionMetadata.expanded` in `types.ts`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 18ebeba7ae85900284258e8e555d8b4118e29eec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->