### PR TITLE
Block stream acquisition when waiting for retry

### DIFF
--- a/src/agent/runtime/StreamStatusService.ts
+++ b/src/agent/runtime/StreamStatusService.ts
@@ -36,16 +36,20 @@ export const StreamStatusService = {
    * Returns true if acquired (sets INITIALIZING), false if already active.
    *
    * This is an atomic check-and-set to prevent race conditions when launching
-   * workflows concurrently. Blocks on RUNNING, RESUMING, and INITIALIZING.
+   * workflows concurrently. Blocks on RUNNING, RESUMING, INITIALIZING, and WAITING.
+   *
+   * WAITING is blocked because the stream is awaiting user action (e.g., retry
+   * after 429 rate limit). Starting a new stream would interrupt the retry flow.
    */
   tryAcquire(stream: StreamTabId): boolean {
     const current = statusMemory.get(stream);
 
-    // Block if already active (running/resuming) or initializing
+    // Block if already active (running/resuming), initializing, or waiting for retry
     if (
       current === STREAM_STATUS.RUNNING ||
       current === STREAM_STATUS.RESUMING ||
-      current === STREAM_STATUS.INITIALIZING
+      current === STREAM_STATUS.INITIALIZING ||
+      current === STREAM_STATUS.WAITING
     ) {
       return false;
     }

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -323,6 +323,7 @@ const STATUS_MESSAGES: Record<string, string> = {
   [STREAM_STATUS.INITIALIZING]: 'already launching',
   [STREAM_STATUS.RESUMING]: 'resuming',
   [STREAM_STATUS.RUNNING]: 'already running',
+  [STREAM_STATUS.WAITING]: 'waiting for retry',
 };
 
 /**


### PR DESCRIPTION
## Summary
Prevent concurrent stream launches when a stream is in WAITING status (e.g., awaiting retry after rate limiting). This ensures retry flows are not interrupted by new stream initialization.

## Changes
- Updated `StreamStatusService.tryAcquire()` to block acquisition when stream status is WAITING
- Added WAITING status check alongside existing RUNNING, RESUMING, and INITIALIZING checks
- Added user-facing status message "waiting for retry" for WAITING status in `executeAgent.ts`
- Updated JSDoc comments to document the WAITING status blocking behavior and its rationale

## Implementation Details
The WAITING status represents a stream that is actively awaiting user action or system recovery (e.g., rate limit retry). By blocking `tryAcquire()` during this state, we prevent race conditions where a new workflow launch could interrupt an in-progress retry flow, ensuring better reliability and user experience.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures retry flows aren’t interrupted by new launches.
> 
> - Update `StreamStatusService.tryAcquire()` to block acquisition when status is `WAITING`, alongside `RUNNING`, `RESUMING`, and `INITIALIZING`
> - Add `WAITING` -> "waiting for retry" in `STATUS_MESSAGES` within `executeAgent.ts`
> - Expand JSDoc to document the WAITING blocking behavior and rationale
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3aeb9a2c598adce184ef8e14a264df60fdf7d7ee. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->