### PR TITLE
Preserve instruction timestamps across runs and fix message ordering

### DIFF
--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -301,12 +301,20 @@ export class ProgressEventHandler {
     }
 
     const taskState = this.state.getTaskState(stream);
-    const instructionUpdate = WebviewUpdater.createInstructionUpdate(taskState);
     const category = this.getStreamCategory(stream);
 
     // Use provided runId or read cached activeRunId (no expensive resolution)
     const runId =
       runIdHint === undefined ? this.state.getActiveRunId(stream) : runIdHint;
+
+    // Preserve existing timestamp if instruction already stored for this run
+    const existingInstruction = runId
+      ? this.state.getRunInstruction(stream, runId)
+      : null;
+    const instructionUpdate = WebviewUpdater.createInstructionUpdate(
+      taskState,
+      existingInstruction?.timestamp,
+    );
 
     // Persist instruction if both runId and instruction exist
     if (runId) {

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -310,7 +310,7 @@ export class ProgressEventHandler {
     // Preserve existing timestamp if instruction already stored for this run
     const existingInstruction = runId
       ? this.state.getRunInstruction(stream, runId)
-      : null;
+      : undefined;
     const instructionUpdate = WebviewUpdater.createInstructionUpdate(
       taskState,
       existingInstruction?.timestamp,

--- a/src/progressView/managers/WebviewUpdater.ts
+++ b/src/progressView/managers/WebviewUpdater.ts
@@ -76,6 +76,7 @@ export class WebviewUpdater {
 
   static createInstructionUpdate(
     taskState?: TaskState,
+    existingTimestamp?: number,
   ): InstructionUpdate | undefined {
     const text = taskState?.agentConfig?.instruction?.trim();
     if (!text) {
@@ -84,7 +85,11 @@ export class WebviewUpdater {
 
     const lineCount = text.split(/\r?\n/).length;
     const showToggle = lineCount > 6 || text.length > 600;
-    return showToggle ? { text, metadata: { showToggle: true } } : { text };
+    // Preserve existing timestamp or set new one when instruction is first created
+    const timestamp = existingTimestamp ?? Date.now();
+    return showToggle
+      ? { text, metadata: { showToggle: true }, timestamp }
+      : { text, timestamp };
   }
 
   /**

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -581,8 +581,10 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
         const instruction = instructions[0];
 
         if (instruction?.text) {
-          // Place instruction just before the first message for correct ordering
-          const timestamp = (firstMsg.timestamp ?? Date.now()) - 1;
+          // Use stored instruction timestamp if available, otherwise fall back
+          // to just before the first message for correct ordering
+          const timestamp =
+            instruction.timestamp ?? (firstMsg.timestamp ?? Date.now()) - 1;
           sortedMessages.unshift({
             id: `compat-instruction-${message.stream}`,
             messageType: 'userMessage',
@@ -653,6 +655,14 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       }
     }
 
+    // For tool-use agents, ungrouped messages (like user instructions) typically
+    // have earlier timestamps and should appear at the top. Insert them first.
+    // For workflow agents, task groups are rendered first and ungrouped messages
+    // (if any) should appear after.
+    if (isToolUseAgent && ungroupedFragment.childNodes.length > 0) {
+      logContent.appendChild(ungroupedFragment);
+    }
+
     // Append grouped messages to their containers
     for (const [groupId, frag] of groupedFragments) {
       const container = dom.logEntries.getGroupContainer(groupId);
@@ -668,8 +678,8 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
       }
     }
 
-    // Append ungrouped messages (and fallback grouped) to main log
-    if (ungroupedFragment.childNodes.length > 0) {
+    // Append ungrouped messages for workflow agents (tool-use already handled above)
+    if (!isToolUseAgent && ungroupedFragment.childNodes.length > 0) {
       logContent.appendChild(ungroupedFragment);
     }
     scrollToBottom(logContent);

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -656,11 +656,12 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
     }
 
     // For tool-use agents, ungrouped messages (like user instructions) typically
-    // have earlier timestamps and should appear at the top. Insert them first.
+    // have earlier timestamps and should appear at the top. Prepend them before
+    // any group containers that were already rendered.
     // For workflow agents, task groups are rendered first and ungrouped messages
     // (if any) should appear after.
     if (isToolUseAgent && ungroupedFragment.childNodes.length > 0) {
-      logContent.appendChild(ungroupedFragment);
+      logContent.prepend(ungroupedFragment);
     }
 
     // Append grouped messages to their containers

--- a/src/progressView/modules/progressViewState.js
+++ b/src/progressView/modules/progressViewState.js
@@ -462,6 +462,7 @@ export class ProgressViewState {
     this.runInstructions.set(targetStream, runId, {
       text: text.trim(),
       metadata: instruction?.metadata,
+      timestamp: instruction?.timestamp,
     });
   }
 

--- a/src/progressView/state/ProgressViewState.ts
+++ b/src/progressView/state/ProgressViewState.ts
@@ -341,6 +341,14 @@ export class ProgressViewState {
     return this._runInstructions.getInstructions(stream);
   }
 
+  /** Get instruction for a specific run */
+  getRunInstruction(
+    stream: StreamTabId,
+    runId: StorageKey,
+  ): InstructionUpdate | undefined {
+    return this._runInstructions.getInstructions(stream).get(runId);
+  }
+
   /** Set or clear an instruction for a run */
   async setRunInstruction(
     stream: StreamTabId,

--- a/src/progressView/types.ts
+++ b/src/progressView/types.ts
@@ -39,6 +39,8 @@ export type InstructionMetadata = z.infer<typeof InstructionMetadataSchema>;
 export const InstructionUpdateSchema = z.object({
   text: z.string(),
   metadata: InstructionMetadataSchema.optional(),
+  /** Timestamp when the instruction was submitted (epoch milliseconds) */
+  timestamp: z.number().optional(),
 });
 export type InstructionUpdate = z.infer<typeof InstructionUpdateSchema>;
 


### PR DESCRIPTION
## Summary
This PR improves instruction handling by preserving timestamps across runs and fixes message ordering in the progress view to ensure instructions appear at the correct position in the message timeline.

## Key Changes

- **Preserve instruction timestamps**: When an instruction already exists for a run, reuse its original timestamp instead of creating a new one. This ensures instructions maintain their position in the message timeline across updates.

- **Add timestamp to InstructionUpdate**: Extended the `InstructionUpdate` type to include an optional `timestamp` field (epoch milliseconds) that tracks when an instruction was submitted.

- **Fix message ordering for tool-use agents**: Ungrouped messages (like user instructions) now appear at the top for tool-use agents, ensuring they display before grouped task messages. For workflow agents, the original behavior is preserved with ungrouped messages appearing after task groups.

- **Improve instruction timestamp fallback logic**: When rendering instructions, use the stored timestamp if available; otherwise fall back to just before the first message timestamp for correct ordering.

- **Add state accessor method**: Introduced `getRunInstruction()` method to retrieve a specific run's instruction from state, enabling timestamp preservation during instruction updates.

## Implementation Details

- The timestamp is set once when an instruction is first created (`Date.now()`) and preserved on subsequent updates
- Message ordering now respects agent type: tool-use agents show ungrouped messages first, workflow agents show them last
- All changes maintain backward compatibility with existing instructions that may not have timestamps

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> - **Instruction timestamps preserved**: `ProgressEventHandler.sendInstructionUpdate` reuses the existing run's instruction timestamp, and `WebviewUpdater.createInstructionUpdate` accepts `existingTimestamp` to avoid resetting it.
> - **Schema/state updates**: `InstructionUpdate` now includes optional `timestamp`; state persists it (`progressViewState.js`) and exposes `getRunInstruction()` in `ProgressViewState.ts`.
> - **Frontend ordering fixes (tool-use)**: When rebuilding logs, if the first message isn’t a user message, prepend the stored instruction using its timestamp (fallback to just before first message). Ungrouped messages are prepended for tool-use agents and appended for workflow agents.
> - **Minor**: Toggle metadata behavior unchanged; update paths wired through existing webview messages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 03156174de8da1bc97f3d55f9e73100399ed522c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->