### PR TITLE
Track usage statistics per reflection round instead of per stage

### DIFF
--- a/src/agent/implementations/flows/reflection/runReflectionFlow.ts
+++ b/src/agent/implementations/flows/reflection/runReflectionFlow.ts
@@ -56,6 +56,7 @@ import {
   type WorkspaceFileLocation,
 } from '@utils/files';
 import { LatexMediaManager } from '@latex';
+import type { UsageMonitor } from '@agent/utils/UsageMonitor';
 
 import {
   createReflectionFlow,
@@ -86,6 +87,9 @@ export interface RunReflectionFlowInput<
 
   /** Optional custom output file location getter (used by merge). */
   getOutputFileLocation?: (round: number) => AgentFileLocation;
+
+  /** Usage monitor for tracking round statistics. */
+  usageMonitor?: UsageMonitor;
 }
 
 /**
@@ -183,6 +187,7 @@ export async function runReflectionFlow<C = unknown>(
     checkInterruption,
     setAbortController,
     getUsageRecorder = () => async () => {},
+    usageMonitor,
   } = input;
 
   let status: EndGroupStatus = END_GROUP_STATUS.STOPPED;
@@ -323,6 +328,12 @@ export async function runReflectionFlow<C = unknown>(
           return await logger.stage(`r${roundIndex}`, {
             parent: parent ?? undefined,
           });
+        },
+        onRoundStart: (context) => {
+          // Set the active group ID for statistics logging so that
+          // statistics are associated with the current round (r0, r1, etc.)
+          // instead of the parent stage
+          usageMonitor?.setActiveGroupId(context.roundStage?.id);
         },
         resetForNextRound: (s) => {
           s.workspaceSnapshot = AgentWorkspaceState.create().toSnapshot();

--- a/src/agent/utils/UsageMonitor.ts
+++ b/src/agent/utils/UsageMonitor.ts
@@ -74,11 +74,29 @@ export interface UsageMonitorContext {
 type UsageMonitorRunKind = 'workflow' | 'tool-use';
 
 export class UsageMonitor {
+  /**
+   * Active group ID for statistics logging.
+   * When set, statistics are logged with this group ID instead of storageKey.
+   * This allows statistics to be associated with individual rounds (r0, r1)
+   * rather than the parent stage.
+   */
+  private activeGroupId: string | undefined;
+
   constructor(
     private readonly modelInfo: UsageMonitorModelInfo,
     private readonly context: UsageMonitorContext,
     private readonly metadata?: UsageMonitorMetadata,
   ) {}
+
+  /**
+   * Set the active group ID for statistics logging.
+   * Call this when entering a new round to associate statistics with that round.
+   *
+   * @param groupId - The round stage ID (e.g., r0, r1) or undefined to use storageKey
+   */
+  setActiveGroupId(groupId: string | undefined): void {
+    this.activeGroupId = groupId;
+  }
 
   async recordUsage(
     stateGlobal: AgentRunState,
@@ -153,7 +171,9 @@ export class UsageMonitor {
         payload.toolUseTokens = toolUseTokens;
       }
 
-      usageReporter.report(payload, this.context.storageKey);
+      // Use activeGroupId for statistics grouping if set (round-specific),
+      // otherwise fall back to storageKey (parent stage or execution ID)
+      usageReporter.report(payload, this.context.storageKey, this.activeGroupId);
 
       // Note: Context state is emitted by model handlers during token counting
       // (Anthropic, Google, OpenAI). This avoids duplicate emissions and ensures

--- a/src/logger/AgentUsageReporter.ts
+++ b/src/logger/AgentUsageReporter.ts
@@ -36,8 +36,15 @@ export class AgentUsageReporter {
    *
    * @param stats - Token usage statistics to report
    * @param storageKey - THE key for storage (from context.storageKey) - REQUIRED
+   * @param groupId - Optional group ID for statistics logging. If provided, statistics
+   *                  are logged with this group ID (e.g., round stage ID like r0, r1).
+   *                  If not provided, uses storageKey as the group ID.
    */
-  public report(stats: ExtendedTokenUsageStats, storageKey: StorageKey): void {
+  public report(
+    stats: ExtendedTokenUsageStats,
+    storageKey: StorageKey,
+    groupId?: string,
+  ): void {
     bus.emit('updateStreamUsage', {
       streamId: this.streamId,
       storageKey,
@@ -51,7 +58,8 @@ export class AgentUsageReporter {
     });
 
     if (this.agentCategory === AgentCategory.Workflow) {
-      this.logger.statistics(stats, storageKey);
+      // Use groupId if provided (round-specific), otherwise fall back to storageKey
+      this.logger.statistics(stats, groupId ?? storageKey);
     }
   }
 

--- a/src/progressView/modules/messageHandlers.js
+++ b/src/progressView/modules/messageHandlers.js
@@ -629,7 +629,11 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
 
     // Batch all messages via DocumentFragment to avoid layout thrashing.
     // Check container existence during iteration to preserve chronological order for fallbacks.
+    // For tool-use agents, separate user messages to ensure they always appear first.
     const ungroupedFragment = document.createDocumentFragment();
+    const userMessageFragment = isToolUseAgent
+      ? document.createDocumentFragment()
+      : null;
     const groupedFragments = new Map(); // groupId → fragment
 
     for (const msg of sortedMessages) {
@@ -650,18 +654,26 @@ export class ProgressViewMessageHandler extends BaseWebviewMessageHandler {
           // Group container missing - add to ungrouped to preserve chronological order
           appendFormatted(ungroupedFragment, formatted);
         }
+      } else if (isToolUseAgent && msg.messageType === 'userMessage') {
+        // For tool-use agents, user messages go to separate fragment to ensure they appear first
+        appendFormatted(userMessageFragment, formatted);
       } else {
         appendFormatted(ungroupedFragment, formatted);
       }
     }
 
-    // For tool-use agents, ungrouped messages (like user instructions) typically
-    // have earlier timestamps and should appear at the top. Prepend them before
-    // any group containers that were already rendered.
-    // For workflow agents, task groups are rendered first and ungrouped messages
-    // (if any) should appear after.
-    if (isToolUseAgent && ungroupedFragment.childNodes.length > 0) {
-      logContent.prepend(ungroupedFragment);
+    // For tool-use agents, render in order: user messages first, then other ungrouped messages.
+    // This ensures user instructions always appear at the top regardless of timestamp issues.
+    // For workflow agents, task groups are rendered first and ungrouped messages appear after.
+    if (isToolUseAgent) {
+      // Prepend other ungrouped messages first (they'll be after user messages)
+      if (ungroupedFragment.childNodes.length > 0) {
+        logContent.prepend(ungroupedFragment);
+      }
+      // Then prepend user messages (they'll be before everything else)
+      if (userMessageFragment && userMessageFragment.childNodes.length > 0) {
+        logContent.prepend(userMessageFragment);
+      }
     }
 
     // Append grouped messages to their containers


### PR DESCRIPTION
## Summary
This PR enables usage statistics to be tracked and reported at the individual reflection round level (r0, r1, etc.) rather than being aggregated at the parent stage level. This provides more granular visibility into token usage across different rounds of the reflection flow.

## Key Changes

- **UsageMonitor**: Added `activeGroupId` property and `setActiveGroupId()` method to allow overriding the default storage key for statistics logging
- **runReflectionFlow**: 
  - Added optional `usageMonitor` parameter to `RunReflectionFlowInput`
  - Implemented `onRoundStart` callback to set the active group ID to the current round's stage ID when entering a new round
- **AgentUsageReporter**: 
  - Added optional `groupId` parameter to the `report()` method
  - Updated statistics logging to use `groupId` when provided, falling back to `storageKey` otherwise

## Implementation Details

The solution uses a callback-based approach where `onRoundStart` is triggered when entering each reflection round. This sets the active group ID to the round's stage identifier (e.g., "r0", "r1"), ensuring that all statistics recorded during that round are associated with it rather than the parent stage. The `groupId` parameter flows through the reporting chain: `UsageMonitor.recordUsage()` → `AgentUsageReporter.report()` → `logger.statistics()`.

This maintains backward compatibility by making the `usageMonitor` parameter optional and using `storageKey` as a fallback when no `groupId` is provided.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces round-scoped usage reporting and a small UI ordering fix.
> 
> - Adds `usageMonitor` to `runReflectionFlow` and sets round stage ID in `onRoundStart` so stats group by each round (`r0`, `r1`, ...)
> - Extends `UsageMonitor` with `activeGroupId` and `setActiveGroupId()`, and passes it to `AgentUsageReporter.report()`
> - Updates `AgentUsageReporter.report(stats, storageKey, groupId?)` to log statistics under `groupId` when provided
> - Progress view: in `messageHandlers.js`, separates tool-use user messages and prepends them to ensure they appear first
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2eb7381bd7988046f8c5f9333d146affb18968fc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->