### PR TITLE
Remove "Tool Use:" prefix from normal tool use log titles

### DIFF
--- a/src/progressView/modules/formatters/logFormatters/toolFormatters.js
+++ b/src/progressView/modules/formatters/logFormatters/toolFormatters.js
@@ -157,8 +157,15 @@ export function formatToolUse(normalizedPayload, logId, groupId, timestamp) {
   const { element, headerLabel, contentElem } = toolElement;
 
   // Build title based on state
+  // For normal tool use, just show the tool name (no "Tool Use:" prefix)
+  // Keep prefixes for special states: "Tool Error:" and "User Feedback:"
   const titlePrefix = getToolTitlePrefix(isUserFeedback, showAsError);
-  const titleBase = toolName ? `${titlePrefix}: ${toolName}` : titlePrefix;
+  const isNormalToolUse = !isUserFeedback && !showAsError;
+  const titleBase = toolName
+    ? isNormalToolUse
+      ? toolName
+      : `${titlePrefix}: ${toolName}`
+    : titlePrefix;
 
   const headerSummary = normalizedToolLog.headerSummary ?? '';
 


### PR DESCRIPTION
## Summary
Updated the tool log formatter to display cleaner titles for normal tool use cases by removing the "Tool Use:" prefix, while preserving prefixes for special states like errors and user feedback.

## Changes
- Modified `formatToolUse()` in `toolFormatters.js` to conditionally apply the title prefix
- Normal tool use now displays only the tool name (e.g., "Calculator" instead of "Tool Use: Calculator")
- Special states retain their prefixes: "Tool Error:" for errors and "User Feedback:" for feedback
- Added logic to detect normal tool use state (`!isUserFeedback && !showAsError`)

## Implementation Details
The title formatting now uses a ternary operator to check if the log represents normal tool use. When true, it uses just the tool name; otherwise, it preserves the original behavior of prepending the title prefix. This provides a cleaner UI for the common case while maintaining clarity for exceptional states.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Simplifies tool log titles in `formatToolUse` for normal tool executions while retaining prefixes for special states.
> 
> - Adjusts title construction in `toolFormatters.js` to show just the tool name for normal cases; keeps `Tool Error:` and `User Feedback:` prefixes when applicable
> - No changes to icons, content sections, or error/user feedback rendering beyond the header text
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b77a0513cf719502ddeaf6feee051f3541c05ad8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->