### PR TITLE
Refactor settings view documentation for clarity

### DIFF
--- a/docs/prd/settings-view-unified.md
+++ b/docs/prd/settings-view-unified.md
@@ -11,7 +11,9 @@
 
 Create a unified Settings View that consolidates model configuration, agent configuration, execution history, and profile/account management into a single tabbed interface. This replaces the scattered entry points with a cohesive settings experience.
 
-**Architecture**: This implementation follows the **Lit + TypeScript + Zod** architecture established in the ProgressView Modernization PRD. Settings View will be implemented as part of Phase 3 webview migrations.
+**Architecture**: This implementation follows the **Lit + TypeScript + Zod** architecture established in the ProgressView Modernization PRD.
+
+**Key Insight (2026-01-25):** With Phase 4 complete, MemoryView, HistoryView, and ProfileView are **already Lit components**. Settings View can **compose these existing components** rather than rewriting them, significantly reducing scope and risk.
 
 ---
 
@@ -884,7 +886,7 @@ SecretManager.setApiKey('anthropic', 'sk-...');
 
 ## Implementation Phases
 
-Settings View is implemented as part of **Phase 4** of the ProgressView modernization, consolidating three existing webviews (HistoryView, ProfileView, MemoryView) into a unified interface.
+Settings View is a **future consolidation** (Phase 6) that combines the NOW-EXISTING Lit-migrated views (MemoryView, HistoryView, ProfileView) into a unified tabbed interface. This is a UX enhancement, not a migration.
 
 ### ProgressView Modernization Status
 
@@ -893,19 +895,32 @@ Settings View is implemented as part of **Phase 4** of the ProgressView moderniz
 | **Phase 1** | Schema relocation to `src/shared/schemas/`   | ✅ Complete    |
 | **Phase 2** | Extract shared infrastructure                | ✅ Complete    |
 | **Phase 3** | ProgressView stabilization + native Lit      | 🟡 In Progress |
-| **Phase 4** | Migrate other webviews (including Settings)  | ⬜ Not Started |
+| **Phase 4** | Migrate other webviews                       | ✅ Complete*   |
+| **Phase 5** | MainView refactoring + message contracts     | ⬜ Not Started |
+| **Phase 6** | **Settings View unification (this PRD)**     | ⬜ Future      |
 
-### Phase 3 Sub-Status (Prerequisites for Settings View)
+\*Phase 4 complete: MemoryView, HistoryView, ProfileView all migrated to Lit.
 
-| Sub-Phase | Scope                      | Status                         |
-| --------- | -------------------------- | ------------------------------ |
-| 3a        | JS → TS shared utilities   | ✅ Complete                    |
-| 3b-1      | UI parity/stabilization    | ✅ Complete                    |
-| 3b-1.5/6  | CSS Shadow DOM migration   | ✅ Complete (11/13 components) |
-| 3b-2      | Utility conversion         | ⬜ Not Started                 |
-| 3b-3      | Formatter → TemplateResult | ⬜ Not Started                 |
+### Phase 4 Completed Migrations (Available for Reuse)
 
-**Settings View can begin once Phase 3b-1 is complete** (current status: ready).
+| Webview         | Lit Components Created                                          | Zod Validation |
+| --------------- | --------------------------------------------------------------- | -------------- |
+| **MemoryView**  | `MemoryApp.ts`, `MemoryItem.ts`, `MemoryList.ts`, `MemoryToggle.ts`, `MemoryToolbar.ts` | ✅ Complete |
+| **HistoryView** | `HistoryApp.ts`, `HistoryItem.ts`, `HistoryList.ts`, `SearchBar.ts` | ✅ Complete |
+| **ProfileView** | `ProfileApp.ts`, `AgentsTable.ts`, `ApiAccessSection.ts`, `ProfileInfo.ts`, `SignInPrompt.ts` | ✅ Complete |
+
+### Phase 5 Prerequisite Issues (May Affect Settings View)
+
+Before Settings View consolidation, Phase 5 regressions should be addressed:
+
+| ID  | View        | Issue                         | Impact on Settings View |
+| --- | ----------- | ----------------------------- | ----------------------- |
+| H1  | HistoryView | Mark highlight colors SWAPPED | Must fix before embedding |
+| P3  | ProfileView | Missing error state guidance  | UX issue to resolve     |
+| J2  | MemoryView  | vscode-checkbox timing        | May affect Memory tab   |
+| J4  | HistoryView | Filter state persistence      | Should fix for History tab |
+
+**Settings View can begin after Phase 5 critical issues are resolved** — or can proceed in parallel if embedding views rather than rewriting.
 
 ### Anti-Patterns to Avoid
 
@@ -941,28 +956,56 @@ AFTER (2 layers):
 
 ### Settings View Implementation Steps
 
+> **Key Change:** Since MemoryView, HistoryView, and ProfileView are NOW Lit components, Settings View **composes existing components** rather than rewriting them.
+
 #### Step 1: Schema Setup
 - Add settings-specific schemas to `src/shared/schemas/settings.ts`
-- Add commands to `src/shared/schemas/commands.ts`
-- No duplicate definitions - leverage existing 60+ Zod schemas
+- Add `SETTINGS_VIEW_COMMANDS` to `src/shared/schemas/commands.ts`
+- Reuse existing commands from Memory/History/Profile views
+- Add new commands only for Models tab and LaTeX tab
 
 #### Step 2: Backend Handlers
-- Create `SettingsViewMessageHandler.ts` with domain-specific handler classes
-- Use registry pattern (`Record<string, Handler>`) instead of switch statements
-- Validate all messages with Zod schemas using `safeParse()`
+- Create `SettingsViewMessageHandler.ts` as orchestrator
+- **Delegate** to existing handlers:
+  - `MemoryViewMessageHandler` for Memory tab operations
+  - `HistoryViewMessageHandler` for History tab operations
+  - `ProfileViewMessageHandler` for Profile/Account operations
+- Add new handlers for Models tab and LaTeX tab
 
-#### Step 3: Lit Frontend
-- Create `src/settingsView/frontend/` with Lit components
-- Follow native Lit patterns (Shadow DOM, static styles array, arrow handlers)
-- Implement reactive store with `@lit-labs/preact-signals`
-- Build all 5 tab components
+#### Step 3: Lit Frontend (Composition Approach)
 
-#### Step 4: Delete Legacy Views
-- Remove `src/profileView/` (636 lines JS)
-- Remove `src/historyView/` (610 lines JS)
-- Remove `src/memoryView/` (305 lines JS)
-- Update command redirects to Settings View
-- Delete legacy `constants.js` files (102 lines total)
+**Option A: Embed Existing Apps** (Recommended for faster delivery)
+```typescript
+// SettingsApp.ts - embeds existing apps
+render() {
+  return html`
+    <texra-tabs .activeTab=${this.activeTab}>
+      <models-tab slot="models"></models-tab>     <!-- NEW -->
+      <agents-tab slot="agents"></agents-tab>     <!-- NEW -->
+      <latex-tab slot="latex"></latex-tab>        <!-- NEW -->
+      <memory-app slot="memory"></memory-app>     <!-- EXISTING -->
+      <history-app slot="history"></history-app>  <!-- EXISTING -->
+    </texra-tabs>
+  `;
+}
+```
+
+**Option B: Extract & Recompose** (Better UX, more work)
+- Extract `MemoryList`, `HistoryList` from their apps
+- Create new tab components that compose these
+- Add unified toolbar and search
+
+#### Step 4: Routing & Entry Points
+- Add Settings View provider and register in extension
+- Update MainView to show ⚙️ Settings button
+- **Keep existing views working** during transition (backwards compatible)
+- After stabilization: deprecate standalone Memory/History/Profile commands
+
+#### Step 5: Deprecate Standalone Views (Future)
+- Remove standalone `memory.openView`, `history.openView`, `profile.openView` commands
+- Redirect to Settings View with appropriate tab pre-selected
+- Delete provider classes for individual views
+- Keep Lit components in `src/shared/components/` for reuse
 
 ---
 
@@ -2383,7 +2426,8 @@ Before merging Settings View implementation, verify:
 - **Phase 1 (Schema relocation):** `docs/prd-progressview-phase1.md`
 - **Phase 2 (Shared infrastructure):** `docs/prd-progressview-phase2.md` — includes anti-patterns analysis
 - **Phase 3 (Native Lit patterns):** `docs/prd-progressview-phase3.md`
-- **Phase 4 (Other webviews):** `docs/prd-progressview-phase4.md` — includes migration order and patterns checklist
+- **Phase 4 (Other webviews):** `docs/prd-progressview-phase4.md` — Memory/History/Profile migration complete
+- **Phase 5 (MainView refactoring):** `docs/prd-progressview-phase5.md` — regressions and bug fixes
 
 ### External Documentation
 - **Lit Documentation:** https://lit.dev/

--- a/docs/prd/settings-view-unified.md
+++ b/docs/prd/settings-view-unified.md
@@ -884,36 +884,85 @@ SecretManager.setApiKey('anthropic', 'sk-...');
 
 ## Implementation Phases
 
-Settings View is implemented as part of **Phase 3** of the ProgressView modernization.
+Settings View is implemented as part of **Phase 4** of the ProgressView modernization, consolidating three existing webviews (HistoryView, ProfileView, MemoryView) into a unified interface.
 
-### Prerequisites (From ProgressView PRD)
+### ProgressView Modernization Status
 
-- Phase 1 complete: Shared schemas in `src/shared/schemas/`
-- Phase 2 complete: Shared components in `src/shared/components/`
-- Webpack configuration for webview bundling
+| Phase       | Scope                                        | Status         |
+| ----------- | -------------------------------------------- | -------------- |
+| **Phase 1** | Schema relocation to `src/shared/schemas/`   | ✅ Complete    |
+| **Phase 2** | Extract shared infrastructure                | ✅ Complete    |
+| **Phase 3** | ProgressView stabilization + native Lit      | 🟡 In Progress |
+| **Phase 4** | Migrate other webviews (including Settings)  | ⬜ Not Started |
 
-### Settings View Implementation
+### Phase 3 Sub-Status (Prerequisites for Settings View)
+
+| Sub-Phase | Scope                      | Status                         |
+| --------- | -------------------------- | ------------------------------ |
+| 3a        | JS → TS shared utilities   | ✅ Complete                    |
+| 3b-1      | UI parity/stabilization    | ✅ Complete                    |
+| 3b-1.5/6  | CSS Shadow DOM migration   | ✅ Complete (11/13 components) |
+| 3b-2      | Utility conversion         | ⬜ Not Started                 |
+| 3b-3      | Formatter → TemplateResult | ⬜ Not Started                 |
+
+**Settings View can begin once Phase 3b-1 is complete** (current status: ready).
+
+### Anti-Patterns to Avoid
+
+The legacy codebase has accumulated band-aid workarounds. **These must not be replicated in Settings View:**
+
+| Pattern                 | Example                        | Problem                               |
+| ----------------------- | ------------------------------ | ------------------------------------- |
+| Render-state comparison | `lastRenderedStream`           | Duplicates state for change detection |
+| Pending ID buffers      | `_pendingActiveId`             | Two sources of truth, race conditions |
+| Global mutable maps     | `pendingLogUpdates`            | Memory leaks, race conditions         |
+| Scattered conditionals  | 18× `isToolUse` checks         | Logic spread across 1000+ lines       |
+| Manual state wipes      | `_clearAgentCategoryState()`   | Shotgun surgery on mode switch        |
+
+**See [Phase 2 Anti-Patterns](../prd-progressview-phase2.md#anti-patterns-to-avoid) for detailed analysis and Lit solutions.**
+
+### Zod-First Architecture Benefits
+
+The migration to Zod schemas as single source of truth eliminates normalizer layers:
+
+```
+BEFORE (5 layers):
+  message → normalize() → NormalizedPayload → buildRender() → HTML
+
+AFTER (2 layers):
+  message.data → Schema.safeParse() → buildRender() → HTML
+```
+
+**Key insight:** Zod schemas eliminate the need for separate "normalizer" layers:
+- Validation returns typed data directly
+- `.prefault()` / `.default()` handle missing fields
+- `.transform()` handles computed fields when needed
+- Formatters receive validated, typed data - no intermediate types needed
+
+### Settings View Implementation Steps
 
 #### Step 1: Schema Setup
 - Add settings-specific schemas to `src/shared/schemas/settings.ts`
 - Add commands to `src/shared/schemas/commands.ts`
-- No duplicate definitions
+- No duplicate definitions - leverage existing 60+ Zod schemas
 
 #### Step 2: Backend Handlers
 - Create `SettingsViewMessageHandler.ts` with domain-specific handler classes
-- Implement all command handlers
-- Validate all messages with Zod schemas
+- Use registry pattern (`Record<string, Handler>`) instead of switch statements
+- Validate all messages with Zod schemas using `safeParse()`
 
 #### Step 3: Lit Frontend
 - Create `src/settingsView/frontend/` with Lit components
-- Implement reactive store
+- Follow native Lit patterns (Shadow DOM, static styles array, arrow handlers)
+- Implement reactive store with `@lit-labs/preact-signals`
 - Build all 5 tab components
 
-#### Step 4: Delete Legacy
-- Remove `src/profileView/`
-- Remove `src/historyView/`
-- Remove `src/memoryView/`
-- Update command redirects
+#### Step 4: Delete Legacy Views
+- Remove `src/profileView/` (636 lines JS)
+- Remove `src/historyView/` (610 lines JS)
+- Remove `src/memoryView/` (305 lines JS)
+- Update command redirects to Settings View
+- Delete legacy `constants.js` files (102 lines total)
 
 ---
 
@@ -2228,6 +2277,75 @@ html`
 
 ---
 
+## Native Lit Patterns Checklist
+
+These patterns were established in ProgressView Phase 2-3. Settings View **MUST** follow them.
+
+### Component Patterns
+
+| Pattern | Requirement |
+| ------- | ----------- |
+| Shadow DOM | No `createRenderRoot()` override — use Lit default |
+| Static styles | Use `static styles = [codiconStyles, animationStyles, css\`...\`]` array composition |
+| Arrow functions | Use arrow functions for event handlers to preserve `this` binding |
+| @property vs @state | `@property` for parent inputs, `@state` for internal state |
+| @query | Use for imperative DOM access only; await `updateComplete` first |
+| Reflected properties | Use `reflect: true` for CSS `:host([attr])` targeting |
+
+### Message Handling Patterns
+
+| Pattern | Requirement |
+| ------- | ----------- |
+| Registry pattern | Use `Record<string, Handler>` instead of switch statements |
+| Zod validation | Validate at entry point with `safeParse()`, silent fail on error |
+| Context interface | Pass `getState()`/`setState()` accessors, not direct state |
+
+### Rendering Patterns
+
+| Pattern | When to Use |
+| ------- | ----------- |
+| `nothing` | Element should be absent from DOM entirely |
+| `?hidden` | Element stays in DOM but visually hidden |
+| `repeat()` | Lists with stable keys (sorted/reordered) |
+| `classMap()` | Dynamic CSS class bindings |
+| `live()` | Textarea/input to preserve cursor position |
+| `when()` | Conditional template blocks |
+| `ifDefined()` | Optional attributes |
+
+### Event Patterns
+
+| Pattern | Requirement |
+| ------- | ----------- |
+| Custom events factory | Centralized event creation with typed details |
+| bubbles + composed | All custom events must use `bubbles: true, composed: true` |
+| Event naming | Use kebab-case: `item-select`, `filter-change` |
+
+**Example:**
+
+```typescript
+// events.ts
+function createEvent<T>(type: string, detail: T): CustomEvent<T> {
+  return new CustomEvent(type, { detail, bubbles: true, composed: true });
+}
+
+export const SettingsEvents = {
+  tabChange: (detail: { tab: SettingsTab }) => createEvent('tab-change', detail),
+  modelToggle: (detail: { id: string; enabled: boolean }) => createEvent('model-toggle', detail),
+  settingChange: (detail: { key: string; value: unknown }) => createEvent('setting-change', detail),
+};
+```
+
+### CSS Patterns
+
+| Pattern | Requirement |
+| ------- | ----------- |
+| Design tokens | Access via CSS custom properties (`var(--spacing-medium)`) |
+| Shared styles | Import from `@shared/styles/litStyles.ts` |
+| Codicon styles | Import `codiconStyles` for icon fonts |
+| No external CSS | All component styles in `static styles` array |
+
+---
+
 ## Implementation Checklist
 
 Before merging Settings View implementation, verify:
@@ -2260,10 +2378,23 @@ Before merging Settings View implementation, verify:
 
 ## References
 
-- **ProgressView Modernization PRD:** `docs/prd-progressview-modernization.md`
+### ProgressView Modernization PRDs
+- **Overview:** `docs/prd-progressview-modernization.md`
+- **Phase 1 (Schema relocation):** `docs/prd-progressview-phase1.md`
+- **Phase 2 (Shared infrastructure):** `docs/prd-progressview-phase2.md` — includes anti-patterns analysis
+- **Phase 3 (Native Lit patterns):** `docs/prd-progressview-phase3.md`
+- **Phase 4 (Other webviews):** `docs/prd-progressview-phase4.md` — includes migration order and patterns checklist
+
+### External Documentation
 - **Lit Documentation:** https://lit.dev/
+- **Lit Reactive Controllers:** https://lit.dev/docs/composition/controllers/
 - **Zod Documentation:** https://zod.dev/
+- **VS Code Webview API:** https://code.visualstudio.com/api/extension-guides/webview
+- **GitLens (reference):** Production Lit webviews in VS Code
+
+### Codebase References
 - **Shared Schemas:** `src/shared/schemas/`
 - **Shared Components:** `src/shared/components/`
+- **Shared Styles:** `src/shared/styles/litStyles.ts`
 - **Base Classes:** `src/common/webview/Base*.ts`
 - **PR Review:** #2206 - Initial implementation attempt with review feedback

--- a/docs/prd/settings-view-unified.md
+++ b/docs/prd/settings-view-unified.md
@@ -979,6 +979,514 @@ vscode.setState({ activeTab: 'models' });  // Persist
 
 ---
 
+## Lessons Learned (PR #2206 Review)
+
+Based on code review feedback from the initial implementation attempt, the following issues must be addressed:
+
+### Critical: Single Source of Truth Violations
+
+#### Command Constants Duplication
+
+**Problem:** `SETTINGS_VIEW_COMMANDS` was defined in THREE places:
+- `src/settingsView/schemas.ts` (TypeScript)
+- `src/settingsView/modules/constants.js` (JavaScript)
+- `src/common/webview/commands.ts` (shared)
+
+**Impact:** Commands can drift out of sync, causing silent message routing failures.
+
+**Solution:** Define commands ONLY in `src/common/webview/commands.ts`:
+```typescript
+// src/common/webview/commands.ts - SINGLE SOURCE OF TRUTH
+export const SETTINGS_VIEW_COMMANDS = {
+  // Extension → Webview
+  SET_INITIAL_DATA: 'SET_INITIAL_DATA',
+  SET_MODELS_DATA: 'SET_MODELS_DATA',
+  // ... all commands
+} as const;
+
+// src/settingsView/schemas.ts - IMPORT, don't redefine
+import { SETTINGS_VIEW_COMMANDS } from '@common/webview/commands';
+export { SETTINGS_VIEW_COMMANDS };
+
+// src/settingsView/modules/constants.js - IMPORT from shared
+// Use import map to access common/webview/commands.js
+```
+
+#### Provider Metadata Duplication
+
+**Problem:** `PROVIDER_META` defined in both:
+- `SettingsViewMessageHandler.ts` (TypeScript backend)
+- `constants.js` (JavaScript frontend)
+
+**Solution:** Define provider metadata ONCE in backend and send to frontend via `InitialData`:
+```typescript
+// Backend: Include in collectInitialData()
+const initialData = {
+  // ... other data
+  providerMeta: PROVIDER_META,  // Send to frontend
+};
+
+// Frontend: Access from state, don't hardcode
+const provider = settingsViewState.providerMeta[providerId];
+```
+
+---
+
+### Security Issues
+
+#### XSS Vulnerability in HTML Rendering
+
+**Problem:** Template literals directly interpolate user data without escaping:
+```javascript
+// ❌ VULNERABLE - file.path could contain malicious HTML
+<div class="memory-file" data-path="${file.path}">
+  ${file.name}
+</div>
+
+// ❌ VULNERABLE - agent names from user YAML files
+<span class="agent-name">${agent.name}</span>
+```
+
+**Solution:** Always escape user-controlled data:
+```javascript
+import { escapeHtml } from '@common/modules/htmlEncoding.js';
+
+// ✅ SAFE - escape all user data
+<div class="memory-file" data-path="${escapeHtml(file.path)}">
+  ${escapeHtml(file.name)}
+</div>
+
+// ✅ SAFE - use textContent via DOM API
+const nameEl = row.querySelector('.agent-name');
+nameEl.textContent = agent.name;  // Automatically escaped
+```
+
+**Files requiring escaping:**
+- `HistoryTab.js` - `item.agentName`, `item.modelName`, `item.inputFile`, `item.id`
+- `MemoryTab.js` - `file.name`, `file.path`
+- `AgentListRenderer.js` - `agent.name`, `agent.description`
+- `ModelListRenderer.js` - `model.name`, `provider.name`
+
+#### Path Traversal in Memory Operations
+
+**Problem:** File paths from webview used directly without validation:
+```typescript
+// ❌ VULNERABLE - path could be "../../../etc/passwd"
+async ({ path: storagePath }) => {
+  const absolutePath = StorageFS.fullPath(storagePath);
+  await vscode.window.showTextDocument(uri);
+}
+```
+
+**Solution:** Validate paths are within expected directory:
+```typescript
+import { resolveMemoryStoragePath, MEMORY_STORAGE_ROOT } from '@tools/memory/memoryStorage';
+
+async ({ path: storagePath }) => {
+  // ✅ SAFE - validate path is within memory storage
+  const resolvedPath = resolveMemoryStoragePath(storagePath);
+  if (!resolvedPath) {
+    this.logger.warn('Invalid memory path attempted:', storagePath);
+    return;
+  }
+  const uri = vscode.Uri.file(resolvedPath);
+  await vscode.window.showTextDocument(uri);
+}
+```
+
+#### Unvalidated Setting Keys
+
+**Problem:** `settingKey` parameter accepted any string:
+```typescript
+// ❌ Could modify arbitrary VS Code settings
+await config.update(settingKey, value);
+```
+
+**Solution:** Whitelist allowed configuration keys in schema:
+```typescript
+export const SaveSettingSchema = z.object({
+  command: z.literal('SAVE_SETTING'),
+  key: z.enum([
+    'texra.latex.formatter',
+    'texra.latex.latexindentConfig',
+    'texra.latexdiff.mathMarkup',
+    // ... explicit whitelist
+  ]),
+  value: z.unknown(),
+});
+```
+
+---
+
+### Missing Functionality
+
+#### Missing Command Handlers
+
+**Problem:** Commands defined in frontend but handlers missing in backend:
+- `BROWSE_AGENTS_DIRECTORY` - Browse button in Agents tab
+- `OPEN_AGENTS_DIRECTORY` - Open button in Agents tab
+
+**Solution:** Ensure every command in `constants.js` has a corresponding handler in `createHandlers()`.
+
+**Checklist pattern:**
+```typescript
+// In MessageHandler, verify all commands have handlers
+protected createHandlers(): Record<string, MessageHandler> {
+  const handlers = {
+    // Verify EVERY command from SETTINGS_VIEW_COMMANDS is here
+    [SETTINGS_VIEW_COMMANDS.GET_INITIAL_DATA]: this.handleGetInitialData.bind(this),
+    [SETTINGS_VIEW_COMMANDS.BROWSE_AGENTS_DIRECTORY]: this.handleBrowseAgentsDir.bind(this),
+    [SETTINGS_VIEW_COMMANDS.OPEN_AGENTS_DIRECTORY]: this.handleOpenAgentsDir.bind(this),
+    // ...
+  };
+
+  // Optional: Runtime check that all commands have handlers
+  for (const cmd of Object.values(SETTINGS_VIEW_COMMANDS)) {
+    if (!handlers[cmd]) {
+      console.warn(`Missing handler for command: ${cmd}`);
+    }
+  }
+  return handlers;
+}
+```
+
+#### Memory/History Data Not in Initial Load
+
+**Problem:** `collectInitialData()` didn't include memory files or history items, causing tabs to be empty on first load.
+
+**Solution:** Include ALL tab data in initial payload:
+```typescript
+async collectInitialData(): Promise<InitialData> {
+  const [account, models, providers, agents, latex, history, memory] =
+    await Promise.all([
+      this.collectAccountData(),
+      this.collectModelsData(),
+      this.collectProvidersData(),
+      this.collectAgentsData(),
+      this.collectLatexSettings(),
+      this.collectHistoryData(),    // ✅ Include history
+      this.collectMemoryData(),     // ✅ Include memory
+    ]);
+
+  return {
+    account, models, providers, agents, latexSettings: latex,
+    historyItems: history,  // ✅ Must be in payload
+    memoryFiles: memory,    // ✅ Must be in payload
+    memoryEnabled: true,
+  };
+}
+```
+
+Also update `updateFromInitialData()` in state manager:
+```javascript
+updateFromInitialData(data) {
+  this.updateAccount(data.account);
+  this.updateModels(data.models);
+  this.updateAgents(data.agents);
+  this.updateLatexSettings(data.latexSettings);
+  this.updateHistoryItems(data.historyItems);  // ✅ Don't forget
+  this.updateMemoryFiles(data.memoryFiles);    // ✅ Don't forget
+}
+```
+
+#### Tab Selection Not Applied
+
+**Problem:** When opening Settings View to a specific tab (e.g., via `texra.showAgentHistory`), the requested tab was ignored.
+
+**Solution:** Apply tab selection in frontend message handler:
+```javascript
+handleSetInitialData(message) {
+  settingsViewState.updateFromInitialData(message);
+
+  // ✅ Apply selected tab from initial data
+  if (message.selectedTab) {
+    settingsViewState.selectedTab = message.selectedTab;
+    tabManager.selectTab(message.selectedTab);  // Actually switch tab
+  }
+
+  this.renderAllTabs();
+}
+```
+
+#### API Access Mode Toggle Missing
+
+**Problem:** Paid subscribers lost the ability to toggle between "included access" (TeXRA's API keys) and "personal keys" (their own API keys).
+
+**Solution:** Add API access mode to Models tab or header bar:
+```typescript
+// In SettingsViewMessageHandler
+[SETTINGS_VIEW_COMMANDS.SET_API_ACCESS_MODE]: this.handleSetApiAccessMode.bind(this),
+
+private async handleSetApiAccessMode(message: unknown): Promise<void> {
+  await this.withValidatedMessage(
+    SetApiAccessModeSchema,
+    message,
+    'setApiAccessMode',
+    async ({ mode }) => {
+      const useIncluded = mode === 'included';
+      await getServerSideKeyService().setUseIncludedModelAccess(useIncluded);
+      // Refresh UI
+    }
+  );
+}
+```
+
+---
+
+### UX Issues
+
+#### Missing Confirmation Dialogs
+
+**Problem:** Destructive actions executed immediately without user confirmation:
+- `clearAllMemory()` deletes all files
+- `handleClearHistory()` deletes all history
+
+**Solution:** Add confirmation dialogs:
+```typescript
+// Backend handler
+private async handleClearAllMemory(): Promise<void> {
+  const confirmed = await vscode.window.showWarningMessage(
+    'Delete all memory files? This cannot be undone.',
+    { modal: true },
+    'Delete All'
+  );
+
+  if (confirmed !== 'Delete All') return;
+
+  // Proceed with deletion
+}
+```
+
+Or in frontend with VS Code-style:
+```javascript
+async clearAllMemory() {
+  // Send confirmation request to backend
+  vscode.postMessage({
+    command: SETTINGS_VIEW_COMMANDS.CONFIRM_CLEAR_ALL_MEMORY,
+  });
+  // Backend shows dialog and proceeds if confirmed
+}
+```
+
+---
+
+### Data Consistency Issues
+
+#### Inconsistent Default Values
+
+**Problem:** Default values differed between Settings View and execution code:
+```typescript
+// Settings View used 'fine'
+latexdiffMathMarkup: getConfig('texra.latexdiff.mathMarkup', 'fine'),
+
+// Execution code used 'coarse'
+const mathMarkup = getConfig('texra.latexdiff.mathMarkup', 'coarse');
+```
+
+**Solution:** Define defaults in ONE place (settingsSchema.ts):
+```typescript
+// settingsSchema.ts - SINGLE SOURCE OF TRUTH
+export const MathMarkupSchema = z.enum(['off', 'whole', 'coarse', 'fine']).default('coarse');
+
+// Everywhere else - use schema default
+const mathMarkup = MathMarkupSchema.parse(getConfig('texra.latexdiff.mathMarkup'));
+```
+
+#### Provider ID Case Mismatch
+
+**Problem:** Provider IDs inconsistently cased:
+```typescript
+// Schema used camelCase
+ProviderIdSchema = z.enum(['anthropic', 'openai', 'openRouter', ...]);
+
+// Model configs used lowercase
+MODEL_CONFIGS[model].provider.toLowerCase() === 'openrouter'  // ❌ Mismatch!
+```
+
+**Solution:** Use consistent lowercase for all provider IDs:
+```typescript
+export const ProviderIdSchema = z.enum([
+  'anthropic',
+  'openai',
+  'google',
+  'openrouter',  // ✅ Lowercase
+  'deepseek',
+  'xai',
+  'moonshot',
+  'dashscope',
+]);
+```
+
+#### Settings Migration Missing
+
+**Problem:** When moving settings from VS Code config to workspace storage, existing user values were lost.
+
+**Solution:** Add migration on activation:
+```typescript
+// In extension.ts or settings initialization
+async function migrateSettings() {
+  const config = vscode.workspace.getConfiguration('texra');
+  const storage = context.workspaceState;
+
+  const settingsToMigrate = [
+    { old: 'latex.formatter', new: WorkspaceStateKey.FORMATTER },
+    { old: 'latexdiff.mathMarkup', new: WorkspaceStateKey.MATH_MARKUP },
+  ];
+
+  for (const { old, new: newKey } of settingsToMigrate) {
+    const existing = storage.get(newKey);
+    if (existing === undefined) {
+      const value = config.get(old);
+      if (value !== undefined) {
+        await storage.update(newKey, value);
+      }
+    }
+  }
+}
+```
+
+---
+
+### Architecture Recommendations
+
+#### Large MessageHandler Class
+
+**Problem:** `SettingsViewMessageHandler.ts` grew to 1000+ lines.
+
+**Solution:** Extract domain-specific handler classes:
+```
+src/settingsView/
+├── SettingsViewMessageHandler.ts      # Orchestrates, ~200 lines
+├── handlers/
+│   ├── ModelHandlers.ts               # Model/provider operations
+│   ├── AgentHandlers.ts               # Agent CRUD operations
+│   ├── LatexHandlers.ts               # LaTeX settings
+│   ├── HistoryHandlers.ts             # History operations
+│   └── MemoryHandlers.ts              # Memory file operations
+```
+
+Usage:
+```typescript
+export class SettingsViewMessageHandler extends BaseViewMessageHandler {
+  private modelHandlers: ModelHandlers;
+  private agentHandlers: AgentHandlers;
+  // ...
+
+  protected createHandlers(): Record<string, MessageHandler> {
+    return {
+      ...this.modelHandlers.getHandlers(),
+      ...this.agentHandlers.getHandlers(),
+      // ...
+    };
+  }
+}
+```
+
+#### Performance: Lazy Loading for Large Data
+
+**Problem:** Loading all memory files with content previews could be slow.
+
+**Solution:** Lazy load previews on expand:
+```javascript
+// Initial load: metadata only
+const memoryFiles = files.map(f => ({
+  name: f.name,
+  path: f.path,
+  size: f.size,
+  // preview: NOT included initially
+}));
+
+// On expand: fetch preview
+async expandFile(filePath) {
+  vscode.postMessage({
+    command: SETTINGS_VIEW_COMMANDS.GET_MEMORY_PREVIEW,
+    path: filePath,
+  });
+}
+```
+
+---
+
+### Test Coverage Requirements
+
+No tests were included in the initial implementation. Required test coverage:
+
+| Area | Test Type | Priority |
+|------|-----------|----------|
+| **Zod Schemas** | Unit tests for validation edge cases | High |
+| **Message Handlers** | Unit tests for each handler | High |
+| **State Management** | Tests for settingsViewState.js | Medium |
+| **Data Collection** | Tests for collectModelsData, etc. | Medium |
+| **Tab Switching** | Integration tests | Medium |
+| **API Key Flow** | Integration tests | High |
+| **Legacy Redirects** | Verify old commands work | Medium |
+
+Example test structure:
+```typescript
+// tests/settingsView/schemas.test.ts
+describe('SettingsView Schemas', () => {
+  describe('SaveSettingSchema', () => {
+    it('rejects unknown setting keys', () => {
+      const result = SaveSettingSchema.safeParse({
+        command: 'SAVE_SETTING',
+        key: 'texra.unknown.setting',  // Not in whitelist
+        value: 'test',
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+});
+
+// tests/settingsView/messageHandler.test.ts
+describe('SettingsViewMessageHandler', () => {
+  it('handles all defined commands', () => {
+    const handler = new SettingsViewMessageHandler(mockContext);
+    const handlers = handler['createHandlers']();
+
+    for (const cmd of Object.values(SETTINGS_VIEW_COMMANDS)) {
+      expect(handlers[cmd]).toBeDefined(`Missing handler for ${cmd}`);
+    }
+  });
+});
+```
+
+---
+
+## Implementation Checklist
+
+Before merging Settings View implementation, verify:
+
+### Single Source of Truth
+- [ ] Commands defined in ONE file only (`commands.ts`)
+- [ ] Provider metadata defined in ONE file, sent via InitialData
+- [ ] Default values defined in `settingsSchema.ts`
+- [ ] Provider IDs use consistent casing (lowercase)
+
+### Security
+- [ ] All user data escaped before HTML interpolation
+- [ ] Memory file paths validated against storage root
+- [ ] Setting keys whitelisted in schema
+- [ ] API keys use SecretManager (never in state/config)
+
+### Completeness
+- [ ] Every frontend command has a backend handler
+- [ ] All tabs receive data in InitialData
+- [ ] Tab selection from parameters actually applied
+- [ ] API access mode toggle included (for paid users)
+
+### UX Safety
+- [ ] Destructive actions have confirmation dialogs
+- [ ] Error messages shown for failed operations
+- [ ] Loading states for async operations
+
+### Testing
+- [ ] Schema validation tests
+- [ ] Handler routing tests
+- [ ] State management tests
+- [ ] Legacy command redirect tests
+
+---
+
 ## References
 
 - **VS Code Elements:** `@vscode-elements/elements` (v2.4.0)
@@ -986,3 +1494,4 @@ vscode.setState({ activeTab: 'models' });  // Persist
 - **Shared Modules:** `src/common/modules/*.js`
 - **Shared Styles:** `src/common/styles/common.css`
 - **Existing Views:** `src/profileView/`, `src/historyView/`, `src/progressView/`
+- **PR Review:** #2206 - Initial implementation attempt with review feedback

--- a/docs/prd/settings-view-unified.md
+++ b/docs/prd/settings-view-unified.md
@@ -3,7 +3,7 @@
 **Status:** Draft
 **Author:** Claude
 **Date:** 2026-01-25
-**Related:** Model dropdown, Agent dropdown, Profile View, History View
+**Related:** Model dropdown, Agent dropdown, Profile View, History View, ProgressView Modernization PRD
 
 ---
 
@@ -11,18 +11,19 @@
 
 Create a unified Settings View that consolidates model configuration, agent configuration, execution history, and profile/account management into a single tabbed interface. This replaces the scattered entry points with a cohesive settings experience.
 
+**Architecture**: This implementation follows the **Lit + TypeScript + Zod** architecture established in the ProgressView Modernization PRD. Settings View will be implemented as part of Phase 3 webview migrations.
+
 ---
 
 ## Goals
 
 1. **Single source of truth** - All configuration in one place
-2. **Easy navigation** - vscode-tabs with logical groupings, vscode-collapsible for subsections
+2. **Easy navigation** - Lit tabs with logical groupings
 3. **No auth required** - Most tabs work without login (except account features in header)
-4. **VS Code native** - Use VS Code Elements web components (`@vscode-elements/elements`)
-5. **Proper state management** - Global vs workspace state separation
+4. **Type-safe IPC** - Zod schemas for all messages, validated at boundary
+5. **Proper state management** - Reactive Lit store, global vs workspace state separation
 6. **Backwards compatible** - Extend getConfig rather than replacing it; graceful migration
-7. **Minimal custom CSS** - Only header bar needs custom styling, everything else native
-8. **Consistent patterns** - Follow existing webview architecture (vanilla JS, Zod validation)
+7. **Consistent with ProgressView** - Same patterns, shared components, shared schemas
 
 ---
 
@@ -51,11 +52,10 @@ The Settings View prioritizes simplicity and user-friendliness, inspired by Noti
 
 ### Implementation Guidelines
 
-- Use `<vscode-form-group>` for all form layouts (native VS Code styling)
-- Use `<vscode-collapsible>` for advanced/optional sections
+- Use Lit components with VS Code theme CSS variables
+- Use shared components from `src/shared/components/`
 - Keep actions visible (no hover-to-reveal complexity)
-- Use standard VS Code color variables
-- Follow existing webview patterns in the codebase
+- Follow patterns established in ProgressView modernization
 
 ---
 
@@ -76,47 +76,16 @@ Clicking ⚙️ (codicon: `settings-gear`) opens the unified Settings View.
 
 ### Header Bar + Tabs Layout
 
-Use native `vscode-tabs` for navigation with an account header bar at the top. This provides
-VS Code-native styling without custom CSS complexity.
-
 ```
 ┌─────────────────────────────────────────────────────────────────────────────┐
 │  👤 user@example.com • Pro Plan                    [Manage] [Sign Out] [×]  │
 ├─────────────────────────────────────────────────────────────────────────────┤
-│  [Models]  Agents  LaTeX  Memory  History  Advanced                         │
+│  [Models]  Agents  LaTeX  Memory  History                                   │
 │  ═══════                                                                    │
 ├─────────────────────────────────────────────────────────────────────────────┤
 │                                                                             │
-│  Tab content with vscode-collapsible for subsections                        │
+│  Tab content rendered by Lit components                                     │
 │                                                                             │
-│  ▼ Recommended Models                                                       │
-│  ┌─────────────────────────────────────────────────────────────────────┐    │
-│  │ ☑ Claude Sonnet 4.5 T    Anthropic   $3/$15    200K  🧠👁           │    │
-│  │ ☑ GPT-5.2                OpenAI      $2/$10    256K  🧠👁           │    │
-│  └─────────────────────────────────────────────────────────────────────┘    │
-│                                                                             │
-│  ▼ Anthropic                                       ✓ API Key  [Configure]   │
-│  ┌─────────────────────────────────────────────────────────────────────┐    │
-│  │ ☑ Claude Sonnet 4.5 T     200K   $3/$15    🧠👁📄                   │    │
-│  │ ☑ Claude Opus 4.5 T       200K   $15/$75   🧠👁📄🎧                 │    │
-│  └─────────────────────────────────────────────────────────────────────┘    │
-│                                                                             │
-│  ▶ OpenAI (28)                                     ✓ API Key  [Configure]   │
-│  ▶ Google (6)                                      ✗ No Key   [Configure]   │
-│                                                                             │
-└─────────────────────────────────────────────────────────────────────────────┘
-```
-
-**Not Logged In State:**
-
-```
-┌─────────────────────────────────────────────────────────────────────────────┐
-│  Use TeXRA with your own API keys                         [Sign In]    [×]  │
-├─────────────────────────────────────────────────────────────────────────────┤
-│  [Models]  Agents  LaTeX  Memory  History  Advanced                         │
-│  ═══════                                                                    │
-├─────────────────────────────────────────────────────────────────────────────┤
-│  ...                                                                        │
 └─────────────────────────────────────────────────────────────────────────────┘
 ```
 
@@ -125,7 +94,7 @@ VS Code-native styling without custom CSS complexity.
 ```
 Tab 1: Models
 ├── Routing options (radio: direct/openrouter/proxy)
-├── ▼ Recommended Models (collapsible)
+├── Recommended Models section
 └── Provider accordions (collapsible per provider)
     └── Model checkboxes + [Configure] for API key
 
@@ -133,16 +102,14 @@ Tab 2: Agents
 ├── Built-in agents list
 ├── Custom agents list
 ├── Remote agents (if logged in)
-├── ▼ Workflow Settings (collapsible subsection)
-│   └── Output storage mode
-└── ▼ Tool-Use Settings (collapsible subsection)
-    └── Edit approval, persistence, compaction, retry behavior
+├── Workflow Settings collapsible
+└── Tool-Use Settings collapsible
 
 Tab 3: LaTeX
-├── ▼ Formatter (collapsible)
-├── ▼ LaTeXdiff (collapsible)
-├── ▼ TikZ Figures (collapsible)
-└── ▼ Replacements (collapsible, advanced)
+├── Formatter collapsible
+├── LaTeXdiff collapsible
+├── TikZ Figures collapsible
+└── Replacements collapsible (advanced)
 
 Tab 4: Memory
 └── Memory file browser with expandable content preview
@@ -151,36 +118,24 @@ Tab 5: History
 └── Execution history browser (search, restore, rerun)
 ```
 
-**Deferred to Future Release:**
-
-```
-Tab 6: Advanced
-├── ▼ Multi-Agent (collapsible) - merge model, future ensemble
-├── ▼ UI Preferences (collapsible) - reminders, image dimension, sort
-├── ▼ Git Integration (collapsible)
-├── ▼ System Paths (collapsible)
-└── ▼ Debug (collapsible)
-```
-
 ---
 
 ## Architecture
 
 ### Technology Stack
 
-The Settings View follows the established webview patterns in this codebase:
+Settings View follows the **Lit + TypeScript + Zod** architecture:
 
 | Layer | Technology | Notes |
 |-------|------------|-------|
-| **UI Components** | VS Code Elements (`@vscode-elements/elements`) | Native VS Code styling |
-| **Frontend JS** | Vanilla ES6 modules | No framework (no Lit, no React) |
-| **State Management** | WebviewStateManager + VS Code API | `vscode.getState()`/`setState()` |
-| **Validation** | Zod schemas | Type-safe message validation |
-| **Styling** | CSS with VS Code theme variables | Codicons for icons |
+| **UI Framework** | Lit 3.x | Reactive components with decorators |
+| **Language** | TypeScript | Full type safety, no JS modules |
+| **State** | `@lit-labs/preact-signals` | Reactive store pattern |
+| **Validation** | Zod | Schemas in `src/shared/schemas/` |
+| **Styling** | Lit CSS + VS Code variables | Scoped styles per component |
+| **Build** | Webpack | Bundled `bundle.js` per webview |
 
 ### Three-Layer Architecture
-
-The webview architecture follows a three-layer pattern with clear separation of concerns:
 
 ```
 ┌─────────────────────────────────────────────────────────────────────┐
@@ -189,12 +144,12 @@ The webview architecture follows a three-layer pattern with clear separation of 
 │                                                                     │
 │  SettingsViewProvider (extends BaseWebviewProvider)                 │
 │  ├── Lifecycle: resolveWebviewView(), createOrShowPanel()           │
-│  ├── HTML assignment and message routing                            │
+│  ├── Loads bundled Lit app from dist/settingsView/bundle.js         │
 │  └── Disposable management                                          │
 │                                                                     │
 │  SettingsViewContentProvider (extends BaseViewContentProvider)      │
-│  ├── HTML generation with module bundling                           │
-│  ├── URI mapping for JS/CSS modules                                 │
+│  ├── HTML shell with <settings-app> custom element                  │
+│  ├── Script tag loading bundle.js                                   │
 │  └── CSP nonce generation                                           │
 │                                                                     │
 │  SettingsViewMessageHandler (extends BaseViewMessageHandler)        │
@@ -203,26 +158,23 @@ The webview architecture follows a three-layer pattern with clear separation of 
 │  └── Backend service calls                                          │
 │                                                                     │
 ├─────────────────────────────────────────────────────────────────────┤
-│                        Webview (JavaScript)                          │
+│                        Webview (Lit + TypeScript)                    │
 ├─────────────────────────────────────────────────────────────────────┤
 │                                                                     │
-│  settingsViewState.js (extends WebviewStateManager pattern)         │
-│  ├── State persistence via VS Code API                              │
-│  └── Getter/setter with auto-save                                   │
+│  store.ts (Reactive state with @lit-labs/preact-signals)            │
+│  ├── Single source of truth for UI state                            │
+│  ├── Typed state interface                                          │
+│  └── Derived state helpers                                          │
 │                                                                     │
-│  SettingsViewMessageHandler.js (extends BaseWebviewMessageHandler)  │
-│  ├── Message listener registration                                  │
-│  └── Command → handler routing                                      │
+│  SettingsApp.ts (Root Lit component)                                │
+│  ├── Message handler setup                                          │
+│  ├── Dispatches to child components                                 │
+│  └── Prompt overlay for confirmations                               │
 │                                                                     │
-│  SettingsViewDomHandler.js (extends BaseDomHandler)                 │
-│  ├── Composes UI managers as properties                             │
-│  ├── Listener tracking for cleanup                                  │
-│  └── Cascading dispose()                                            │
-│                                                                     │
-│  Tab UI Managers (ES6 classes)                                      │
-│  ├── ModelsTab.js, AgentsTab.js, LatexTab.js, etc.                  │
-│  ├── Template-based rendering                                       │
-│  └── Event listener management                                      │
+│  Tab Components (Lit custom elements)                               │
+│  ├── <models-tab>, <agents-tab>, <latex-tab>, etc.                  │
+│  ├── Reactive @property decorators                                  │
+│  └── Declarative event handlers                                     │
 │                                                                     │
 └─────────────────────────────────────────────────────────────────────┘
 ```
@@ -231,214 +183,94 @@ The webview architecture follows a three-layer pattern with clear separation of 
 
 ```
 src/
-├── settingsView/                    # NEW - Unified settings view
+├── shared/                          # From ProgressView modernization
+│   ├── schemas/                     # SINGLE SOURCE OF TRUTH
+│   │   ├── index.ts                 # Barrel export
+│   │   ├── identifiers.ts           # StreamTabId, ExecutionId
+│   │   ├── settings.ts              # Settings-specific schemas (NEW)
+│   │   ├── commands.ts              # All command constants
+│   │   └── ...                      # Other shared schemas
+│   ├── components/                  # Shared Lit components
+│   │   ├── Button.ts
+│   │   ├── Tabs.ts
+│   │   ├── Collapsible.ts
+│   │   └── index.ts
+│   ├── BaseWebviewApp.ts            # Base class for Lit apps
+│   └── vscode.ts                    # VS Code API wrapper
+│
+├── settingsView/
 │   ├── SettingsViewProvider.ts      # Extends BaseWebviewProvider
 │   ├── SettingsViewMessageHandler.ts # Extends BaseViewMessageHandler
-│   ├── SettingsViewContentProvider.ts # Extends BaseViewContentProvider
-│   ├── schemas.ts                   # Zod schemas for messages
-│   ├── index.html                   # Header bar + vscode-tabs layout
-│   ├── styles/
-│   │   └── index.css                # Minimal CSS (header bar only)
-│   └── modules/
-│       ├── script.js                # Entry point, initialization
-│       ├── settingsViewState.js     # WebviewStateManager wrapper
-│       ├── messageHandlers.js       # BaseWebviewMessageHandler extension
-│       ├── domHandlers.js           # BaseDomHandler composition
-│       ├── constants.js             # Element IDs, class names
-│       ├── tabs/                    # Tab content modules (v1)
-│       │   ├── ModelsTab.js         # Models + providers + routing
-│       │   ├── AgentsTab.js         # Agents + collapsible settings
-│       │   ├── LatexTab.js          # LaTeX settings (collapsibles)
-│       │   ├── MemoryTab.js         # Memory files browser
-│       │   └── HistoryTab.js        # History (migrated)
-│       │   # AdvancedTab.js - deferred to future release
-│       └── uiManagers/
-│           ├── HeaderBar.js         # Account header bar
-│           ├── ModelListRenderer.js
-│           ├── ProviderRenderer.js
-│           ├── AgentListRenderer.js
-│           └── HistoryRenderer.js   # From historyView
-│
-├── common/
-│   ├── webview/                     # Base classes (TypeScript)
-│   │   ├── BaseWebviewProvider.ts   # Webview lifecycle
-│   │   ├── BaseViewContentProvider.ts # HTML generation
-│   │   ├── BaseViewMessageHandler.ts # Message routing + Zod validation
-│   │   ├── commands.ts              # Centralized command constants
-│   │   └── resourceRoots.ts         # Security resource roots
-│   ├── modules/                     # Shared frontend utilities (JavaScript)
-│   │   ├── BaseDomHandler.js        # Listener tracking, dispose pattern
-│   │   ├── BaseWebviewMessageHandler.js # Message handler base
-│   │   ├── webviewState.js          # WebviewStateManager
-│   │   ├── webviewContext.js        # registerMessageHandlers()
-│   │   ├── domUtils.js              # Safe DOM utilities
-│   │   └── ToggleStateStore.js      # Boolean state management
-│   └── styles/
-│       └── common.css               # Shared styles
+│   ├── SettingsViewContentProvider.ts # HTML shell generator
+│   ├── schemas.ts                   # Re-export shared + settings-specific
+│   ├── handlers/                    # Extracted domain handlers
+│   │   ├── ModelHandlers.ts
+│   │   ├── AgentHandlers.ts
+│   │   ├── LatexHandlers.ts
+│   │   ├── HistoryHandlers.ts
+│   │   └── MemoryHandlers.ts
+│   └── frontend/                    # Lit components (bundled)
+│       ├── index.ts                 # Entry point, registers components
+│       ├── store.ts                 # Reactive state
+│       ├── SettingsApp.ts           # Root <settings-app> component
+│       └── components/
+│           ├── HeaderBar.ts
+│           ├── ModelsTab.ts
+│           ├── AgentsTab.ts
+│           ├── LatexTab.ts
+│           ├── MemoryTab.ts
+│           ├── HistoryTab.ts
+│           └── ConfirmDialog.ts
 │
 ├── profileView/                     # DEPRECATED - merge into settingsView
 ├── historyView/                     # DEPRECATED - merge into settingsView
 ├── memoryView/                      # DEPRECATED - merge into settingsView
 ```
 
-### Base Class Hierarchy
+### Webpack Configuration
 
-#### Extension Host (TypeScript)
-
-**BaseWebviewProvider** (`src/common/webview/BaseWebviewProvider.ts`):
-- Orchestrates webview lifecycle
-- Handles HTML assignment via content provider
-- Routes messages via message handler
-- Manages disposables (extension-lifetime and view-lifetime)
-
-```typescript
-export abstract class BaseWebviewProvider {
-  protected _view?: vscode.WebviewView;
-  protected abstract contentProvider: BaseViewContentProvider;
-  protected abstract messageHandler: BaseViewMessageHandler;
-
-  // Called by VS Code when view becomes visible
-  resolveWebviewView(webviewView: vscode.WebviewView): void;
-
-  // For panel-based views (History, Settings)
-  createOrShowPanel(options: PanelOptions): boolean;
-}
-```
-
-**BaseViewContentProvider** (`src/common/webview/BaseViewContentProvider.ts`):
-- Generates complete HTML with module bundling
-- Maps module paths to webview URIs
-- Handles CSP nonce generation
-
-```typescript
-export abstract class BaseViewContentProvider {
-  // Module descriptor pattern for declaring dependencies
-  protected viewModules: ModuleDescriptor[];
-
-  // Returns complete HTML string
-  getHtmlContent(webview: vscode.Webview): string;
-
-  // Override for view-specific template variables
-  protected getTemplateVariables(): Record<string, string>;
-}
-```
-
-**BaseViewMessageHandler** (`src/common/webview/BaseViewMessageHandler.ts`):
-- Routes messages by command name
-- Provides Zod validation helper
-- Error handling and logging
-
-```typescript
-export abstract class BaseViewMessageHandler {
-  // Subclasses define their command handlers
-  protected abstract createHandlers(): Record<string, MessageHandler>;
-
-  // Validates message with Zod schema before handling
-  protected async withValidatedMessage<S extends z.ZodType>(
-    schema: S,
-    message: unknown,
-    messageName: string,
-    handler: (data: z.infer<S>) => Promise<void>
-  ): Promise<void>;
-}
-```
-
-#### Webview Frontend (JavaScript)
-
-**BaseDomHandler** (`src/common/modules/BaseDomHandler.js`):
-- Tracks event listeners for automatic cleanup
-- Composes child managers as properties
-- Cascading dispose pattern
+Add to `webpack.config.js`:
 
 ```javascript
-class BaseDomHandler {
-  constructor(managers = {}) {
-    this._listeners = [];      // Track all listeners
-    this._managers = managers; // Nested managers
-    Object.assign(this, managers); // Expose as properties
-  }
+const settingsViewConfig = {
+  name: 'settingsView',
+  entry: './src/settingsView/frontend/index.ts',
+  output: {
+    path: path.resolve(__dirname, 'dist/settingsView'),
+    filename: 'bundle.js',
+  },
+  target: 'web',
+  resolve: {
+    extensions: ['.ts', '.js'],
+    alias: {
+      '@shared': path.resolve(__dirname, 'src/shared'),
+      '@settingsView': path.resolve(__dirname, 'src/settingsView'),
+      // ... other aliases
+    },
+  },
+  module: {
+    rules: [
+      { test: /\.ts$/, use: 'ts-loader', exclude: /node_modules/ },
+    ],
+  },
+};
 
-  addListener(elementOrId, event, handler) {
-    // Tracks listener for later cleanup
-  }
-
-  dispose() {
-    // Cleans up all listeners AND nested managers
-  }
-}
+module.exports = [extensionConfig, progressViewConfig, settingsViewConfig];
 ```
-
-**BaseWebviewMessageHandler** (`src/common/modules/BaseWebviewMessageHandler.js`):
-- Registers message listeners with webview context
-- Routes messages by command name
-- Cleanup on dispose
-
-```javascript
-class BaseWebviewMessageHandler {
-  constructor() {
-    this._disposeFn = null;
-    this._handlers = {};  // Command → handler map
-  }
-
-  setup() {
-    this._disposeFn = registerMessageHandlers(this._handlers);
-  }
-
-  dispose() {
-    this._disposeFn?.();
-  }
-}
-```
-
-**WebviewStateManager** (`src/common/modules/webviewState.js`):
-- Wraps VS Code's `getState()`/`setState()` APIs
-- Immutable state copies with spread operators
-- Methods: `getState()`, `setState()`, `update()`
 
 ---
 
-## Message Protocol (Zod-native)
+## Schemas (Single Source of Truth)
 
-### Schema Patterns
+### Location: `src/shared/schemas/settings.ts`
 
-Use Zod schemas as single source of truth. Follow existing patterns from `src/webview/types/messages.ts`.
-
-**File:** `src/settingsView/schemas.ts`
+All settings-related schemas in ONE file. No duplicates.
 
 ```typescript
 import { z } from 'zod';
 
 // =============================================================================
-// Command Constants
-// =============================================================================
-
-export const SETTINGS_VIEW_COMMANDS = {
-  // Extension → Webview
-  SET_MODELS_DATA: 'SET_MODELS_DATA',
-  SET_AGENTS_DATA: 'SET_AGENTS_DATA',
-  SET_LATEX_DATA: 'SET_LATEX_DATA',
-  SELECT_TAB: 'SELECT_TAB',
-  // Webview → Extension
-  GET_INITIAL_DATA: 'GET_INITIAL_DATA',
-  TAB_CHANGED: 'TAB_CHANGED',
-  SAVE_ENABLED_MODELS: 'SAVE_ENABLED_MODELS',
-  SAVE_ENABLED_AGENTS: 'SAVE_ENABLED_AGENTS',
-  SAVE_SETTING: 'SAVE_SETTING',
-  SET_API_KEY: 'SET_API_KEY',
-  SIGN_IN: 'SIGN_IN',
-  SIGN_OUT: 'SIGN_OUT',
-} as const;
-
-// =============================================================================
-// Shared Base Schemas (composition pattern)
-// =============================================================================
-
-const BaseMessageSchema = z.object({
-  command: z.string(),
-});
-
-// =============================================================================
-// Tab and Settings Schemas
+// Settings Tab Types
 // =============================================================================
 
 export const SettingsTabSchema = z.enum([
@@ -451,331 +283,525 @@ export const SettingsTabSchema = z.enum([
 export type SettingsTab = z.infer<typeof SettingsTabSchema>;
 
 // =============================================================================
-// Extension → Webview Messages
+// Provider Configuration
 // =============================================================================
 
-export const SetModelsDataSchema = z.object({
-  command: z.literal('SET_MODELS_DATA'),
-  models: z.array(z.object({
-    id: z.string(),
-    name: z.string(),
-    provider: z.string(),
-    contextWindow: z.number(),
-    inputCost: z.number(),
-    outputCost: z.number(),
-    capabilities: z.array(z.string()),
-  })),
-  enabled: z.array(z.string()),
-  providerStatus: z.record(z.object({
-    hasKey: z.boolean(),
-    keySource: z.enum(['secret', 'env', 'none']),
-  })),
-});
-
-export const SetAgentsDataSchema = z.object({
-  command: z.literal('SET_AGENTS_DATA'),
-  agents: z.array(z.object({
-    name: z.string(),
-    source: z.enum(['builtIn', 'builtInToolUse', 'custom', 'remote']),
-    category: z.enum(['workflow', 'toolUse']),
-    agentType: z.enum(['CoT', 'direct', 'toolUse']),
-    description: z.string().optional(),
-    enabled: z.boolean(),
-  })),
-});
-
-export const SelectTabSchema = z.object({
-  command: z.literal('SELECT_TAB'),
-  tab: SettingsTabSchema,
-});
-
-// Discriminated union for type-safe message handling
-export const SettingsMessageSchema = z.discriminatedUnion('command', [
-  SetModelsDataSchema,
-  SetAgentsDataSchema,
-  SelectTabSchema,
+export const ProviderIdSchema = z.enum([
+  'anthropic',
+  'openai',
+  'google',
+  'openrouter',  // ✅ Consistent lowercase
+  'deepseek',
+  'xai',
+  'moonshot',
+  'dashscope',
 ]);
+export type ProviderId = z.infer<typeof ProviderIdSchema>;
 
-export type SettingsMessage = z.infer<typeof SettingsMessageSchema>;
+export const ProviderStatusSchema = z.object({
+  hasKey: z.boolean(),
+  keySource: z.enum(['secret', 'env', 'none']),
+});
+
+export const ProviderMetaSchema = z.object({
+  name: z.string(),
+  keyUrl: z.string().url(),
+  envVar: z.string(),
+  defaultEndpoint: z.string().url().optional(),
+});
 
 // =============================================================================
-// Webview → Extension Actions
+// Model Data
 // =============================================================================
 
-export const SaveEnabledModelsSchema = z.object({
-  command: z.literal('SAVE_ENABLED_MODELS'),
-  models: z.array(z.string()),
+export const ModelDataSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  provider: ProviderIdSchema,
+  contextWindow: z.number(),
+  inputCost: z.number(),
+  outputCost: z.number(),
+  capabilities: z.array(z.string()),
+  enabled: z.boolean(),
 });
+export type ModelData = z.infer<typeof ModelDataSchema>;
 
-export const SaveEnabledAgentsSchema = z.object({
-  command: z.literal('SAVE_ENABLED_AGENTS'),
-  agents: z.array(z.string()),
+// =============================================================================
+// Agent Data
+// =============================================================================
+
+export const AgentSourceSchema = z.enum(['builtIn', 'builtInToolUse', 'custom', 'remote']);
+export const AgentCategorySchema = z.enum(['workflow', 'toolUse']);
+export const AgentTypeSchema = z.enum(['CoT', 'direct', 'toolUse', 'merge', 'reflect']);
+
+export const AgentDataSchema = z.object({
+  name: z.string(),
+  source: AgentSourceSchema,
+  category: AgentCategorySchema,
+  agentType: AgentTypeSchema,
+  description: z.string().optional(),
+  enabled: z.boolean(),
 });
+export type AgentData = z.infer<typeof AgentDataSchema>;
 
-export const SaveSettingSchema = z.object({
-  command: z.literal('SAVE_SETTING'),
-  key: z.string(),
-  value: z.unknown(),
-  scope: z.enum(['global', 'workspace']).optional(),
+// =============================================================================
+// Memory File (Recursive)
+// =============================================================================
+
+export interface MemoryFile {
+  name: string;
+  path: string;
+  size: number;
+  modified: string;
+  preview?: string;
+  lineCount?: number;
+  isDirectory?: boolean;
+  children?: MemoryFile[];
+}
+
+export const MemoryFileSchema: z.ZodType<MemoryFile> = z.lazy(() =>
+  z.object({
+    name: z.string(),
+    path: z.string(),
+    size: z.number(),
+    modified: z.string(),
+    preview: z.string().optional(),
+    lineCount: z.number().optional(),
+    isDirectory: z.boolean().optional(),
+    children: z.array(MemoryFileSchema).optional(),
+  })
+);
+
+// =============================================================================
+// Initial Data Payload
+// =============================================================================
+
+export const SettingsInitialDataSchema = z.object({
+  selectedTab: SettingsTabSchema.optional(),
+  account: z.object({
+    authenticated: z.boolean(),
+    email: z.string().optional(),
+    userId: z.string().optional(),
+    tier: z.enum(['free', 'Max', 'Ultra']).optional(),
+    useIncludedAccess: z.boolean().optional(),
+  }),
+  models: z.array(ModelDataSchema),
+  enabledModels: z.array(z.string()),
+  providers: z.record(ProviderIdSchema, ProviderStatusSchema),
+  providerMeta: z.record(ProviderIdSchema, ProviderMetaSchema),  // ✅ Sent from backend
+  agents: z.array(AgentDataSchema),
+  latexSettings: z.record(z.string(), z.unknown()),
+  selectOptions: z.record(z.string(), z.array(z.object({
+    value: z.string(),
+    label: z.string(),
+  }))),
+  historyItems: z.array(z.unknown()),  // Uses HistoryItemSchema from shared
+  memoryFiles: z.array(MemoryFileSchema),
+  memoryEnabled: z.boolean(),
 });
-
-export const SetApiKeySchema = z.object({
-  command: z.literal('SET_API_KEY'),
-  provider: z.string(),
-  key: z.string(),
-});
-
-export const SettingsActionSchema = z.discriminatedUnion('command', [
-  z.object({ command: z.literal('GET_INITIAL_DATA') }),
-  z.object({ command: z.literal('TAB_CHANGED'), tab: SettingsTabSchema }),
-  SaveEnabledModelsSchema,
-  SaveEnabledAgentsSchema,
-  SaveSettingSchema,
-  SetApiKeySchema,
-  z.object({ command: z.literal('SIGN_IN') }),
-  z.object({ command: z.literal('SIGN_OUT') }),
-]);
-
-export type SettingsAction = z.infer<typeof SettingsActionSchema>;
+export type SettingsInitialData = z.infer<typeof SettingsInitialDataSchema>;
 ```
 
-### Zod Patterns Summary
+### Location: `src/shared/schemas/commands.ts`
 
-Follow these patterns from the existing codebase:
+Command constants - SINGLE definition, no duplicates:
 
-| Pattern | Usage | Example |
-|---------|-------|---------|
-| **Schema Composition** | Reusable base schemas | `BaseMessageSchema.extend({ ... })` |
-| **`.extend()` + `.shape`** | Add fields while extending | `BaseSchema.extend(WithFilePath.shape)` |
-| **`.pick()`** | Select subset of fields | `FullSchema.pick({ field1: true })` |
-| **Type Inference** | `z.infer<typeof Schema>` | Single source of truth for types |
-| **Transform + Pipe** | Data transformation | `z.string().transform(s => s.trim()).pipe(z.string().min(1))` |
-| **Discriminated Unions** | Type-safe message routing | `z.discriminatedUnion('command', [...])` |
-| **`.prefault()`** | Defaults during parsing | `z.enum([...]).prefault('default')` |
-| **Safe Parsing** | Non-throwing validation | `schema.safeParse(data)` + callback |
+```typescript
+// =============================================================================
+// Settings View Commands - SINGLE SOURCE OF TRUTH
+// =============================================================================
+
+export const SETTINGS_VIEW_COMMANDS = {
+  // Extension → Webview
+  SET_INITIAL_DATA: 'SET_INITIAL_DATA',
+  SET_MODELS_DATA: 'SET_MODELS_DATA',
+  SET_AGENTS_DATA: 'SET_AGENTS_DATA',
+  SET_LATEX_DATA: 'SET_LATEX_DATA',
+  SET_HISTORY_DATA: 'SET_HISTORY_DATA',
+  SET_MEMORY_DATA: 'SET_MEMORY_DATA',
+  SELECT_TAB: 'SELECT_TAB',
+
+  // Webview → Extension
+  GET_INITIAL_DATA: 'GET_INITIAL_DATA',
+  TAB_CHANGED: 'TAB_CHANGED',
+  SAVE_ENABLED_MODELS: 'SAVE_ENABLED_MODELS',
+  SAVE_ENABLED_AGENTS: 'SAVE_ENABLED_AGENTS',
+  SAVE_SETTING: 'SAVE_SETTING',
+  SET_API_KEY: 'SET_API_KEY',
+  DELETE_API_KEY: 'DELETE_API_KEY',
+  SET_API_ACCESS_MODE: 'SET_API_ACCESS_MODE',
+  SIGN_IN: 'SIGN_IN',
+  SIGN_OUT: 'SIGN_OUT',
+
+  // Agent operations
+  OPEN_AGENT_SOURCE: 'OPEN_AGENT_SOURCE',
+  DELETE_AGENT: 'DELETE_AGENT',
+  BROWSE_AGENTS_DIRECTORY: 'BROWSE_AGENTS_DIRECTORY',
+  OPEN_AGENTS_DIRECTORY: 'OPEN_AGENTS_DIRECTORY',
+
+  // History operations
+  RERUN_HISTORY: 'RERUN_HISTORY',
+  RESTORE_HISTORY: 'RESTORE_HISTORY',
+  DELETE_HISTORY: 'DELETE_HISTORY',
+  CLEAR_HISTORY: 'CLEAR_HISTORY',
+
+  // Memory operations
+  OPEN_MEMORY_FILE: 'OPEN_MEMORY_FILE',
+  DELETE_MEMORY_FILE: 'DELETE_MEMORY_FILE',
+  CLEAR_ALL_MEMORY: 'CLEAR_ALL_MEMORY',
+  GET_MEMORY_PREVIEW: 'GET_MEMORY_PREVIEW',
+
+  // File browsing
+  BROWSE_FILE: 'BROWSE_FILE',
+} as const;
+
+export type SettingsViewCommand = typeof SETTINGS_VIEW_COMMANDS[keyof typeof SETTINGS_VIEW_COMMANDS];
+```
 
 ---
 
-## Frontend Implementation Patterns
+## Lit Component Patterns
 
-### ES6 Class + Singleton Pattern
+### Root Component
 
-All frontend modules use ES6 classes with singleton exports:
+```typescript
+// src/settingsView/frontend/SettingsApp.ts
+import { LitElement, html, css } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+import { state as appState } from './store';
+import { SETTINGS_VIEW_COMMANDS } from '@shared/schemas/commands';
 
-```javascript
-// settingsViewState.js
-import { WebviewStateManager } from '@common/modules/webviewState.js';
+// Import tab components
+import './components/HeaderBar';
+import './components/ModelsTab';
+import './components/AgentsTab';
+import './components/LatexTab';
+import './components/MemoryTab';
+import './components/HistoryTab';
+import './components/ConfirmDialog';
 
-class SettingsViewState {
-  constructor() {
-    this.stateManager = new WebviewStateManager();
-    this._activeTab = 'models';
-    this._enabledModels = [];
-  }
-
-  initialize() {
-    const saved = this.stateManager.getState();
-    this._activeTab = saved.activeTab ?? 'models';
-    this._enabledModels = saved.enabledModels ?? [];
-  }
-
-  get activeTab() { return this._activeTab; }
-  set activeTab(value) {
-    this._activeTab = value;
-    this.save();
-  }
-
-  save() {
-    this.stateManager.update({
-      activeTab: this._activeTab,
-      enabledModels: this._enabledModels,
-    });
-  }
-}
-
-export const settingsViewState = new SettingsViewState();
-```
-
-### DOM Handler Composition
-
-Use BaseDomHandler for listener tracking and manager composition:
-
-```javascript
-// domHandlers.js
-import { BaseDomHandler } from '@common/modules/BaseDomHandler.js';
-import { HeaderBar } from './uiManagers/HeaderBar.js';
-import { ModelsTab } from './tabs/ModelsTab.js';
-import { AgentsTab } from './tabs/AgentsTab.js';
-import { settingsViewState } from './settingsViewState.js';
-
-class SettingsViewDomHandler extends BaseDomHandler {
-  constructor() {
-    const headerBar = new HeaderBar();
-    const modelsTab = new ModelsTab(settingsViewState);
-    const agentsTab = new AgentsTab(settingsViewState);
-
-    super({
-      headerBar,
-      modelsTab,
-      agentsTab,
-      // More tabs...
-    });
-  }
-
-  initializeUI() {
-    this.headerBar.render();
-    this.showTab(settingsViewState.activeTab);
-  }
-
-  showTab(tabName) {
-    // Hide all tabs, show selected
-    Object.values(this._managers).forEach(mgr => {
-      if (mgr.hide) mgr.hide();
-    });
-    this[tabName + 'Tab']?.show();
-  }
-}
-
-export const settingsViewDomHandler = new SettingsViewDomHandler();
-```
-
-### Tab Manager Pattern
-
-Each tab extends BaseDomHandler for listener cleanup:
-
-```javascript
-// tabs/ModelsTab.js
-import { BaseDomHandler } from '@common/modules/BaseDomHandler.js';
-import { safeGetElementById } from '@common/modules/domUtils.js';
-import { ELEMENT_IDS } from '../constants.js';
-
-export class ModelsTab extends BaseDomHandler {
-  constructor(state) {
-    super();
-    this.state = state;
-    this._container = null;
-  }
-
-  get container() {
-    if (!this._container) {
-      this._container = safeGetElementById(ELEMENT_IDS.MODELS_TAB);
+@customElement('settings-app')
+export class SettingsApp extends LitElement {
+  static styles = css`
+    :host {
+      display: block;
+      height: 100vh;
+      background: var(--vscode-editor-background);
+      color: var(--vscode-foreground);
     }
-    return this._container;
+
+    .container {
+      max-width: 800px;
+      margin: 0 auto;
+      padding: var(--spacing-large, 16px);
+    }
+  `;
+
+  connectedCallback() {
+    super.connectedCallback();
+    window.addEventListener('message', this._handleMessage);
+    // Request initial data
+    vscode.postMessage({ command: SETTINGS_VIEW_COMMANDS.GET_INITIAL_DATA });
   }
 
-  render(data) {
-    this.container.innerHTML = `
-      <vscode-collapsible title="Recommended Models" open>
-        ${this.renderModelList(data.recommended)}
-      </vscode-collapsible>
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    window.removeEventListener('message', this._handleMessage);
+  }
 
-      ${data.providers.map(provider => `
-        <vscode-collapsible title="${provider.name} (${provider.models.length})">
-          <div class="provider-header">
-            ${this.renderProviderStatus(provider)}
-            <vscode-button appearance="secondary">Configure</vscode-button>
-          </div>
-          ${this.renderModelList(provider.models)}
-        </vscode-collapsible>
-      `).join('')}
+  private _handleMessage = (event: MessageEvent) => {
+    const message = event.data;
+    switch (message.command) {
+      case SETTINGS_VIEW_COMMANDS.SET_INITIAL_DATA:
+        appState.updateFromInitialData(message);
+        break;
+      // ... other handlers
+    }
+  };
+
+  render() {
+    return html`
+      <div class="container">
+        <header-bar
+          .authenticated=${appState.account.authenticated}
+          .email=${appState.account.email}
+          .tier=${appState.account.tier}
+        ></header-bar>
+
+        <texra-tabs
+          .tabs=${['models', 'agents', 'latex', 'memory', 'history']}
+          .activeTab=${appState.activeTab}
+          @tab-change=${this._onTabChange}
+        >
+          <models-tab slot="models" .state=${appState}></models-tab>
+          <agents-tab slot="agents" .state=${appState}></agents-tab>
+          <latex-tab slot="latex" .state=${appState}></latex-tab>
+          <memory-tab slot="memory" .state=${appState}></memory-tab>
+          <history-tab slot="history" .state=${appState}></history-tab>
+        </texra-tabs>
+
+        <confirm-dialog
+          ?open=${appState.confirmDialog !== null}
+          .config=${appState.confirmDialog}
+          @confirm=${this._onConfirm}
+          @cancel=${this._onCancel}
+        ></confirm-dialog>
+      </div>
     `;
-    this.attachEventListeners();
   }
 
-  renderModelList(models) {
-    return models.map(m => `
-      <vscode-checkbox id="model-${m.id}" ${m.enabled ? 'checked' : ''}>
-        ${m.name}
-        <span class="model-meta">${m.contextWindow}K • $${m.inputCost}/$${m.outputCost}</span>
-      </vscode-checkbox>
-    `).join('');
-  }
-
-  attachEventListeners() {
-    this.container.querySelectorAll('vscode-checkbox').forEach(cb => {
-      this.addListener(cb, 'change', () => this.handleModelToggle(cb));
-    });
-  }
-
-  handleModelToggle(checkbox) {
-    const modelId = checkbox.id.replace('model-', '');
+  private _onTabChange(e: CustomEvent<{ tab: string }>) {
+    appState.activeTab = e.detail.tab;
     vscode.postMessage({
-      command: 'SAVE_ENABLED_MODELS',
-      models: this.getEnabledModels(),
+      command: SETTINGS_VIEW_COMMANDS.TAB_CHANGED,
+      tab: e.detail.tab,
     });
   }
-
-  show() { this.container.style.display = 'block'; }
-  hide() { this.container.style.display = 'none'; }
 }
 ```
 
-### Message Handler Pattern
+### Tab Component Example
 
-Frontend message handler extends base class:
+```typescript
+// src/settingsView/frontend/components/ModelsTab.ts
+import { LitElement, html, css } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import { repeat } from 'lit/directives/repeat.js';
+import { classMap } from 'lit/directives/class-map.js';
+import type { SettingsState } from '../store';
+import { SETTINGS_VIEW_COMMANDS } from '@shared/schemas/commands';
 
-```javascript
-// messageHandlers.js
-import { BaseWebviewMessageHandler } from '@common/modules/BaseWebviewMessageHandler.js';
-import { SETTINGS_VIEW_COMMANDS } from './constants.js';
-import { settingsViewState } from './settingsViewState.js';
-import { settingsViewDomHandler } from './domHandlers.js';
+@customElement('models-tab')
+export class ModelsTab extends LitElement {
+  static styles = css`
+    :host {
+      display: block;
+    }
 
-class SettingsViewMessageHandler extends BaseWebviewMessageHandler {
-  constructor() {
-    super();
-    this._handlers = {
-      [SETTINGS_VIEW_COMMANDS.SET_MODELS_DATA]: (m) => this.handleSetModelsData(m),
-      [SETTINGS_VIEW_COMMANDS.SET_AGENTS_DATA]: (m) => this.handleSetAgentsData(m),
-      [SETTINGS_VIEW_COMMANDS.SELECT_TAB]: (m) => this.handleSelectTab(m),
-    };
+    .provider-section {
+      margin-bottom: 16px;
+    }
+
+    .provider-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+    }
+
+    .status-badge {
+      padding: 2px 8px;
+      border-radius: 4px;
+      font-size: 12px;
+    }
+
+    .status-badge.has-key {
+      background: var(--vscode-testing-iconPassed);
+    }
+
+    .status-badge.no-key {
+      background: var(--vscode-testing-iconFailed);
+    }
+
+    .model-item {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 4px 0;
+    }
+  `;
+
+  @property({ type: Object }) state!: SettingsState;
+
+  render() {
+    const providers = this._groupModelsByProvider();
+
+    return html`
+      <section class="recommended-section">
+        <h3>Recommended Models</h3>
+        ${this._renderModelList(this.state.recommendedModels)}
+      </section>
+
+      ${repeat(
+        Object.entries(providers),
+        ([id]) => id,
+        ([providerId, models]) => this._renderProviderSection(providerId, models)
+      )}
+    `;
   }
 
-  handleSetModelsData(message) {
-    settingsViewState.updateModels(message);
-    settingsViewDomHandler.modelsTab.render(message);
+  private _renderProviderSection(providerId: string, models: ModelData[]) {
+    const meta = this.state.providerMeta[providerId];
+    const status = this.state.providers[providerId];
+
+    return html`
+      <texra-collapsible title="${meta?.name ?? providerId} (${models.length})">
+        <div class="provider-header" slot="header-extra">
+          <span class=${classMap({
+            'status-badge': true,
+            'has-key': status?.hasKey ?? false,
+            'no-key': !status?.hasKey,
+          })}>
+            ${status?.hasKey ? '✓ API Key' : '✗ No Key'}
+          </span>
+          <button @click=${() => this._configureProvider(providerId)}>
+            Configure
+          </button>
+        </div>
+        ${this._renderModelList(models)}
+      </texra-collapsible>
+    `;
   }
 
-  handleSetAgentsData(message) {
-    settingsViewState.updateAgents(message);
-    settingsViewDomHandler.agentsTab.render(message);
+  private _renderModelList(models: ModelData[]) {
+    return html`
+      ${repeat(
+        models,
+        (m) => m.id,
+        (model) => html`
+          <div class="model-item">
+            <input
+              type="checkbox"
+              id="model-${model.id}"
+              ?checked=${model.enabled}
+              @change=${() => this._toggleModel(model.id)}
+            />
+            <label for="model-${model.id}">
+              ${model.name}
+              <span class="model-meta">
+                ${model.contextWindow}K • $${model.inputCost}/$${model.outputCost}
+              </span>
+            </label>
+          </div>
+        `
+      )}
+    `;
   }
 
-  handleSelectTab(message) {
-    settingsViewState.activeTab = message.tab;
-    settingsViewDomHandler.showTab(message.tab);
+  private _toggleModel(modelId: string) {
+    // Update local state optimistically
+    const enabled = this.state.enabledModels.includes(modelId);
+    if (enabled) {
+      this.state.enabledModels = this.state.enabledModels.filter(id => id !== modelId);
+    } else {
+      this.state.enabledModels = [...this.state.enabledModels, modelId];
+    }
+
+    // Send to backend (debounced in store)
+    vscode.postMessage({
+      command: SETTINGS_VIEW_COMMANDS.SAVE_ENABLED_MODELS,
+      models: this.state.enabledModels,
+    });
   }
 }
-
-export const messageHandler = new SettingsViewMessageHandler();
 ```
 
-### Initialization Flow
+### Reactive Store
 
-```javascript
-// script.js
-import { settingsViewState } from './modules/settingsViewState.js';
-import { settingsViewDomHandler } from './modules/domHandlers.js';
-import { messageHandler } from './modules/messageHandlers.js';
-import { SETTINGS_VIEW_COMMANDS } from './modules/constants.js';
+```typescript
+// src/settingsView/frontend/store.ts
+import { reactive } from '@lit-labs/preact-signals';
+import type {
+  SettingsTab,
+  ModelData,
+  AgentData,
+  MemoryFile,
+  ProviderMeta,
+  ProviderStatus,
+} from '@shared/schemas/settings';
 
-// 1. Initialize state from VS Code's memory
-settingsViewState.initialize();
+export interface ConfirmDialogConfig {
+  title: string;
+  message: string;
+  confirmLabel: string;
+  onConfirm: () => void;
+}
 
-// 2. Register message handlers early
-messageHandler.setup();
+export interface SettingsState {
+  // Tab state
+  activeTab: SettingsTab;
 
-// 3. When DOM is ready, initialize UI and request data
-document.addEventListener('DOMContentLoaded', () => {
-  settingsViewDomHandler.initializeUI();
-  vscode.postMessage({ command: SETTINGS_VIEW_COMMANDS.GET_INITIAL_DATA });
+  // Account
+  account: {
+    authenticated: boolean;
+    email?: string;
+    userId?: string;
+    tier?: 'free' | 'Max' | 'Ultra';
+    useIncludedAccess?: boolean;
+  };
+
+  // Models
+  models: ModelData[];
+  enabledModels: string[];
+  recommendedModels: ModelData[];
+  providers: Record<string, ProviderStatus>;
+  providerMeta: Record<string, ProviderMeta>;  // ✅ From backend, not hardcoded
+
+  // Agents
+  agents: AgentData[];
+
+  // LaTeX
+  latexSettings: Record<string, unknown>;
+  selectOptions: Record<string, Array<{ value: string; label: string }>>;
+
+  // Memory
+  memoryFiles: MemoryFile[];
+  memoryEnabled: boolean;
+
+  // History
+  historyItems: unknown[];
+
+  // UI
+  confirmDialog: ConfirmDialogConfig | null;
+}
+
+export const state = reactive<SettingsState>({
+  activeTab: 'models',
+  account: { authenticated: false },
+  models: [],
+  enabledModels: [],
+  recommendedModels: [],
+  providers: {},
+  providerMeta: {},
+  agents: [],
+  latexSettings: {},
+  selectOptions: {},
+  memoryFiles: [],
+  memoryEnabled: true,
+  historyItems: [],
+  confirmDialog: null,
 });
 
-// 4. Clean up on navigation
-window.addEventListener('beforeunload', () => {
-  settingsViewDomHandler.dispose();
-  messageHandler.dispose();
-});
+// Update from initial data
+export function updateFromInitialData(data: SettingsInitialData) {
+  if (data.selectedTab) {
+    state.activeTab = data.selectedTab;
+  }
+  state.account = data.account;
+  state.models = data.models;
+  state.enabledModels = data.enabledModels;
+  state.providers = data.providers;
+  state.providerMeta = data.providerMeta;  // ✅ From backend
+  state.agents = data.agents;
+  state.latexSettings = data.latexSettings;
+  state.selectOptions = data.selectOptions;
+  state.historyItems = data.historyItems;  // ✅ Don't forget
+  state.memoryFiles = data.memoryFiles;    // ✅ Don't forget
+  state.memoryEnabled = data.memoryEnabled;
+
+  // Derive recommended models
+  state.recommendedModels = state.models.filter(m =>
+    RECOMMENDED_MODEL_IDS.includes(m.id)
+  );
+}
+
+// Show confirmation dialog
+export function showConfirmDialog(config: ConfirmDialogConfig) {
+  state.confirmDialog = config;
+}
+
+export function hideConfirmDialog() {
+  state.confirmDialog = null;
+}
 ```
 
 ---
@@ -786,84 +812,13 @@ window.addEventListener('beforeunload', () => {
 
 **Purpose:** Combined model selection and API provider configuration.
 
-**Layout:**
-
-```
-┌─────────────────────────────────────────────────────────────────┐
-│  Models & Providers                                             │
-│  ─────────────────────────────────────────────────────────────  │
-│                                                                 │
-│  ROUTING                                                        │
-│  ● Direct to providers (recommended)                            │
-│  ○ Route all through OpenRouter                                 │
-│  ○ Use connection proxy                                         │
-│                                                                 │
-│  ⭐ RECOMMENDED MODELS                                          │
-│  ┌───────────────────────────────────────────────────────────┐  │
-│  │ ☑ Claude Sonnet 4.5 T    Anthropic   $3/$15    200K  🧠👁 │  │
-│  │ ☑ GPT-5.2                OpenAI      $2/$10    256K  🧠👁 │  │
-│  └───────────────────────────────────────────────────────────┘  │
-│                                                                 │
-│  PROVIDERS                                                      │
-│  ▼ Anthropic                         ✓ API Key    [Configure]  │
-│  ┌───────────────────────────────────────────────────────────┐  │
-│  │ ☑ Claude Sonnet 4.5 T     200K   $3/$15    🧠👁📄         │  │
-│  │ ☑ Claude Opus 4.5 T       200K   $15/$75   🧠👁📄🎧       │  │
-│  └───────────────────────────────────────────────────────────┘  │
-│                                                                 │
-│  ▶ OpenAI (28)                       ✓ API Key    [Configure]  │
-│  ▶ Google (6)                        ✗ No Key     [Configure]  │
-│                                                                 │
-└─────────────────────────────────────────────────────────────────┘
-```
-
 **Storage:** `globalState.enabledModels: string[]`, `globalState.providerConfig`
-
----
 
 ### Agents Tab
 
 **Purpose:** View and enable/disable agents, plus agent-specific settings.
 
-**Layout:**
-
-```
-┌─────────────────────────────────────────────────────────────────┐
-│  BUILT-IN AGENTS                                               │
-│  ┌───────────────────────────────────────────────────────────┐  │
-│  │ ☑ chat      Interactive conversation  $(tools) toolUse    │  │
-│  │ ☑ correct   Fix typos & LaTeX errors  $(lightbulb) CoT    │  │
-│  │ ☑ polish    Improve writing quality   $(lightbulb) CoT    │  │
-│  └───────────────────────────────────────────────────────────┘  │
-│                                                                 │
-│  CUSTOM AGENTS                                                 │
-│  ┌───────────────────────────────────────────────────────────┐  │
-│  │ ☑ my-reviewer   Reviews papers       [Source Code] [Delete]│  │
-│  └───────────────────────────────────────────────────────────┘  │
-│                                                                 │
-│  REMOTE AGENTS                                                 │
-│  ┌───────────────────────────────────────────────────────────┐  │
-│  │ ☑ team-reviewer   Team's paper reviewer                   │  │
-│  └───────────────────────────────────────────────────────────┘  │
-│                                                                 │
-│  ▼ Workflow Settings                                           │
-│  ┌───────────────────────────────────────────────────────────┐  │
-│  │ Storage mode: [Folder ▼]                                  │  │
-│  └───────────────────────────────────────────────────────────┘  │
-│                                                                 │
-│  ▼ Tool-Use Settings                                           │
-│  ┌───────────────────────────────────────────────────────────┐  │
-│  │ ☑ Require approval before file edits                      │  │
-│  │ ☑ Persist sessions across VS Code restarts                │  │
-│  │ Compaction threshold: [85 %]                              │  │
-│  │ Max retry attempts: [3 ▼]                                 │  │
-│  └───────────────────────────────────────────────────────────┘  │
-└─────────────────────────────────────────────────────────────────┘
-```
-
 **Storage:** `workspaceState.enabledAgents: string[]`, VS Code configuration
-
----
 
 ### LaTeX Tab
 
@@ -878,26 +833,22 @@ window.addEventListener('beforeunload', () => {
 | **TikZ Figures** | `texra.latex.tikzInputDirectory`, `includeWorkspaceInTexinputs`, `tikzTemplate` |
 | **Replacements** | `texra.latex.wrapCritiqueInAlign`, `enabledReplacements`, `enabledReplacementsRegex` |
 
----
-
 ### Memory Tab
 
 **Purpose:** Browse and manage memory files created by tool-use agents.
 
 **Features:**
-- Memory file browser with expandable content preview
-- Click to expand and show content (first ~20 lines)
+- Memory file browser with lazy-loaded content preview
+- Click to expand and show content (fetched on demand)
 - [View Full] opens file in editor
-- [Delete] removes file
-
----
+- [Delete] removes file with confirmation
 
 ### History Tab
 
 **Purpose:** Browse and restore previous agent executions.
 
 **Features:**
-- Search with highlighting (mark.js)
+- Search with highlighting
 - Delete, Restore, Rerun actions
 - Collapsible details per item
 
@@ -929,106 +880,67 @@ SecretManager.getApiKey('anthropic');
 SecretManager.setApiKey('anthropic', 'sk-...');
 ```
 
-### Webview State
-
-UI state persisted via VS Code API:
-
-```javascript
-// Frontend
-const state = vscode.getState();  // Restore on reopen
-vscode.setState({ activeTab: 'models' });  // Persist
-```
-
 ---
 
 ## Implementation Phases
 
-### v1 Release (5 Tabs)
+Settings View is implemented as part of **Phase 3** of the ProgressView modernization.
 
-#### Phase 1: Core Structure
-- Create settingsView with vscode-tabs + header bar
-- Implement base classes (Provider, ContentProvider, MessageHandler)
-- Add main webview entry point (gear icon)
+### Prerequisites (From ProgressView PRD)
 
-#### Phase 2: Models Tab
-- Provider collapsibles with API status
-- Model checkboxes with capabilities
-- Provider configuration modal
+- Phase 1 complete: Shared schemas in `src/shared/schemas/`
+- Phase 2 complete: Shared components in `src/shared/components/`
+- Webpack configuration for webview bundling
 
-#### Phase 3: Agents Tab
-- Agent list with category badges
-- Workflow Settings collapsible
-- Tool-Use Settings collapsible
+### Settings View Implementation
 
-#### Phase 4: LaTeX Tab
-- Formatter, latexdiff, TikZ collapsibles
-- Wire up to VS Code configuration
+#### Step 1: Schema Setup
+- Add settings-specific schemas to `src/shared/schemas/settings.ts`
+- Add commands to `src/shared/schemas/commands.ts`
+- No duplicate definitions
 
-#### Phase 5: Memory Tab
-- Migrate memoryView
-- Expandable content preview
+#### Step 2: Backend Handlers
+- Create `SettingsViewMessageHandler.ts` with domain-specific handler classes
+- Implement all command handlers
+- Validate all messages with Zod schemas
 
-#### Phase 6: History Tab + Cleanup
-- Move history rendering
-- Delete deprecated views
+#### Step 3: Lit Frontend
+- Create `src/settingsView/frontend/` with Lit components
+- Implement reactive store
+- Build all 5 tab components
 
-### Future Release
-
-- **Advanced Tab** - Multi-Agent, UI preferences, debug
-- **Agent Creation Wizard** - Form-based agent creation
+#### Step 4: Delete Legacy
+- Remove `src/profileView/`
+- Remove `src/historyView/`
+- Remove `src/memoryView/`
+- Update command redirects
 
 ---
 
 ## Lessons Learned (PR #2206 Review)
 
-Based on code review feedback from the initial implementation attempt, the following issues must be addressed:
+Based on code review feedback from the initial vanilla JS implementation attempt, the following issues were identified. **The Lit+TypeScript architecture solves many of these automatically.**
 
 ### Critical: Single Source of Truth Violations
 
 #### Command Constants Duplication
 
-**Problem:** `SETTINGS_VIEW_COMMANDS` was defined in THREE places:
-- `src/settingsView/schemas.ts` (TypeScript)
-- `src/settingsView/modules/constants.js` (JavaScript)
-- `src/common/webview/commands.ts` (shared)
+**Problem:** Commands defined in multiple files (schemas.ts, constants.js, commands.ts).
 
-**Impact:** Commands can drift out of sync, causing silent message routing failures.
-
-**Solution:** Define commands ONLY in `src/common/webview/commands.ts`:
-```typescript
-// src/common/webview/commands.ts - SINGLE SOURCE OF TRUTH
-export const SETTINGS_VIEW_COMMANDS = {
-  // Extension → Webview
-  SET_INITIAL_DATA: 'SET_INITIAL_DATA',
-  SET_MODELS_DATA: 'SET_MODELS_DATA',
-  // ... all commands
-} as const;
-
-// src/settingsView/schemas.ts - IMPORT, don't redefine
-import { SETTINGS_VIEW_COMMANDS } from '@common/webview/commands';
-export { SETTINGS_VIEW_COMMANDS };
-
-// src/settingsView/modules/constants.js - IMPORT from shared
-// Use import map to access common/webview/commands.js
-```
+**Lit Architecture Solution:**
+- Commands defined ONCE in `src/shared/schemas/commands.ts`
+- TypeScript imports everywhere - no JavaScript constants.js needed
+- Webpack bundles ensure single definition
 
 #### Provider Metadata Duplication
 
-**Problem:** `PROVIDER_META` defined in both:
-- `SettingsViewMessageHandler.ts` (TypeScript backend)
-- `constants.js` (JavaScript frontend)
+**Problem:** `PROVIDER_META` defined in both TypeScript and JavaScript.
 
-**Solution:** Define provider metadata ONCE in backend and send to frontend via `InitialData`:
-```typescript
-// Backend: Include in collectInitialData()
-const initialData = {
-  // ... other data
-  providerMeta: PROVIDER_META,  // Send to frontend
-};
-
-// Frontend: Access from state, don't hardcode
-const provider = settingsViewState.providerMeta[providerId];
-```
+**Lit Architecture Solution:**
+- Define ONCE in backend (`SettingsViewMessageHandler.ts`)
+- Send to frontend via `InitialData.providerMeta`
+- Store in reactive state: `state.providerMeta`
+- Components access from state, not hardcoded constants
 
 ---
 
@@ -1036,79 +948,48 @@ const provider = settingsViewState.providerMeta[providerId];
 
 #### XSS Vulnerability in HTML Rendering
 
-**Problem:** Template literals directly interpolate user data without escaping:
-```javascript
-// ❌ VULNERABLE - file.path could contain malicious HTML
-<div class="memory-file" data-path="${file.path}">
-  ${file.name}
-</div>
+**Problem:** Template literals directly interpolate user data.
 
-// ❌ VULNERABLE - agent names from user YAML files
-<span class="agent-name">${agent.name}</span>
-```
+**Lit Architecture Solution:**
+- Lit automatically escapes interpolated values in templates
+- `html\`<span>${userInput}</span>\`` is safe by default
+- No manual `escapeHtml()` needed for standard cases
 
-**Solution:** Always escape user-controlled data:
-```javascript
-import { escapeHtml } from '@common/modules/htmlEncoding.js';
-
-// ✅ SAFE - escape all user data
-<div class="memory-file" data-path="${escapeHtml(file.path)}">
-  ${escapeHtml(file.name)}
-</div>
-
-// ✅ SAFE - use textContent via DOM API
-const nameEl = row.querySelector('.agent-name');
-nameEl.textContent = agent.name;  // Automatically escaped
-```
-
-**Files requiring escaping:**
-- `HistoryTab.js` - `item.agentName`, `item.modelName`, `item.inputFile`, `item.id`
-- `MemoryTab.js` - `file.name`, `file.path`
-- `AgentListRenderer.js` - `agent.name`, `agent.description`
-- `ModelListRenderer.js` - `model.name`, `provider.name`
-
-#### Path Traversal in Memory Operations
-
-**Problem:** File paths from webview used directly without validation:
 ```typescript
-// ❌ VULNERABLE - path could be "../../../etc/passwd"
-async ({ path: storagePath }) => {
-  const absolutePath = StorageFS.fullPath(storagePath);
-  await vscode.window.showTextDocument(uri);
+// ✅ SAFE in Lit - automatic escaping
+render() {
+  return html`<span class="file-name">${this.file.name}</span>`;
 }
 ```
 
-**Solution:** Validate paths are within expected directory:
+#### Path Traversal in Memory Operations
+
+**Problem:** File paths from webview used directly without validation.
+
+**Solution (still required):** Validate paths in backend handlers:
 ```typescript
-import { resolveMemoryStoragePath, MEMORY_STORAGE_ROOT } from '@tools/memory/memoryStorage';
+import { resolveMemoryStoragePath } from '@tools/memory/memoryStorage';
 
 async ({ path: storagePath }) => {
-  // ✅ SAFE - validate path is within memory storage
   const resolvedPath = resolveMemoryStoragePath(storagePath);
   if (!resolvedPath) {
     this.logger.warn('Invalid memory path attempted:', storagePath);
     return;
   }
-  const uri = vscode.Uri.file(resolvedPath);
-  await vscode.window.showTextDocument(uri);
+  // Proceed with validated path
 }
 ```
 
 #### Unvalidated Setting Keys
 
-**Problem:** `settingKey` parameter accepted any string:
-```typescript
-// ❌ Could modify arbitrary VS Code settings
-await config.update(settingKey, value);
-```
+**Problem:** `settingKey` parameter accepted any string.
 
-**Solution:** Whitelist allowed configuration keys in schema:
+**Solution:** Whitelist allowed keys in Zod schema:
 ```typescript
-export const SaveSettingSchema = z.object({
-  command: z.literal('SAVE_SETTING'),
+export const SaveSettingActionSchema = z.object({
+  command: z.literal(SETTINGS_VIEW_COMMANDS.SAVE_SETTING),
   key: z.enum([
     'texra.latex.formatter',
-    'texra.latex.latexindentConfig',
     'texra.latexdiff.mathMarkup',
     // ... explicit whitelist
   ]),
@@ -1122,112 +1003,48 @@ export const SaveSettingSchema = z.object({
 
 #### Missing Command Handlers
 
-**Problem:** Commands defined in frontend but handlers missing in backend:
-- `BROWSE_AGENTS_DIRECTORY` - Browse button in Agents tab
-- `OPEN_AGENTS_DIRECTORY` - Open button in Agents tab
+**Problem:** Commands defined but handlers not implemented.
 
-**Solution:** Ensure every command in `constants.js` has a corresponding handler in `createHandlers()`.
-
-**Checklist pattern:**
+**Lit Architecture Solution:**
+- TypeScript ensures type safety
+- Create handler interface that requires all commands:
 ```typescript
-// In MessageHandler, verify all commands have handlers
-protected createHandlers(): Record<string, MessageHandler> {
-  const handlers = {
-    // Verify EVERY command from SETTINGS_VIEW_COMMANDS is here
-    [SETTINGS_VIEW_COMMANDS.GET_INITIAL_DATA]: this.handleGetInitialData.bind(this),
-    [SETTINGS_VIEW_COMMANDS.BROWSE_AGENTS_DIRECTORY]: this.handleBrowseAgentsDir.bind(this),
-    [SETTINGS_VIEW_COMMANDS.OPEN_AGENTS_DIRECTORY]: this.handleOpenAgentsDir.bind(this),
-    // ...
-  };
+type SettingsHandlers = {
+  [K in SettingsViewCommand]: MessageHandler;
+};
 
-  // Optional: Runtime check that all commands have handlers
-  for (const cmd of Object.values(SETTINGS_VIEW_COMMANDS)) {
-    if (!handlers[cmd]) {
-      console.warn(`Missing handler for command: ${cmd}`);
-    }
-  }
-  return handlers;
-}
+// TypeScript error if any command missing
+const handlers: SettingsHandlers = {
+  [SETTINGS_VIEW_COMMANDS.GET_INITIAL_DATA]: this.handleGetInitialData,
+  [SETTINGS_VIEW_COMMANDS.BROWSE_AGENTS_DIRECTORY]: this.handleBrowseAgentsDir,
+  // ... must implement ALL commands
+};
 ```
 
 #### Memory/History Data Not in Initial Load
 
-**Problem:** `collectInitialData()` didn't include memory files or history items, causing tabs to be empty on first load.
+**Problem:** Tabs empty on first load because data wasn't included.
 
-**Solution:** Include ALL tab data in initial payload:
+**Solution:** Schema enforces required fields:
 ```typescript
-async collectInitialData(): Promise<InitialData> {
-  const [account, models, providers, agents, latex, history, memory] =
-    await Promise.all([
-      this.collectAccountData(),
-      this.collectModelsData(),
-      this.collectProvidersData(),
-      this.collectAgentsData(),
-      this.collectLatexSettings(),
-      this.collectHistoryData(),    // ✅ Include history
-      this.collectMemoryData(),     // ✅ Include memory
-    ]);
-
-  return {
-    account, models, providers, agents, latexSettings: latex,
-    historyItems: history,  // ✅ Must be in payload
-    memoryFiles: memory,    // ✅ Must be in payload
-    memoryEnabled: true,
-  };
-}
-```
-
-Also update `updateFromInitialData()` in state manager:
-```javascript
-updateFromInitialData(data) {
-  this.updateAccount(data.account);
-  this.updateModels(data.models);
-  this.updateAgents(data.agents);
-  this.updateLatexSettings(data.latexSettings);
-  this.updateHistoryItems(data.historyItems);  // ✅ Don't forget
-  this.updateMemoryFiles(data.memoryFiles);    // ✅ Don't forget
-}
+export const SettingsInitialDataSchema = z.object({
+  // ...
+  historyItems: z.array(z.unknown()),  // Required, not optional
+  memoryFiles: z.array(MemoryFileSchema),  // Required, not optional
+});
 ```
 
 #### Tab Selection Not Applied
 
-**Problem:** When opening Settings View to a specific tab (e.g., via `texra.showAgentHistory`), the requested tab was ignored.
+**Problem:** Requested tab ignored when opening Settings View.
 
-**Solution:** Apply tab selection in frontend message handler:
-```javascript
-handleSetInitialData(message) {
-  settingsViewState.updateFromInitialData(message);
-
-  // ✅ Apply selected tab from initial data
-  if (message.selectedTab) {
-    settingsViewState.selectedTab = message.selectedTab;
-    tabManager.selectTab(message.selectedTab);  // Actually switch tab
-  }
-
-  this.renderAllTabs();
-}
-```
-
-#### API Access Mode Toggle Missing
-
-**Problem:** Paid subscribers lost the ability to toggle between "included access" (TeXRA's API keys) and "personal keys" (their own API keys).
-
-**Solution:** Add API access mode to Models tab or header bar:
+**Solution:** Handle in `updateFromInitialData()`:
 ```typescript
-// In SettingsViewMessageHandler
-[SETTINGS_VIEW_COMMANDS.SET_API_ACCESS_MODE]: this.handleSetApiAccessMode.bind(this),
-
-private async handleSetApiAccessMode(message: unknown): Promise<void> {
-  await this.withValidatedMessage(
-    SetApiAccessModeSchema,
-    message,
-    'setApiAccessMode',
-    async ({ mode }) => {
-      const useIncluded = mode === 'included';
-      await getServerSideKeyService().setUseIncludedModelAccess(useIncluded);
-      // Refresh UI
-    }
-  );
+export function updateFromInitialData(data: SettingsInitialData) {
+  if (data.selectedTab) {
+    state.activeTab = data.selectedTab;  // ✅ Apply tab
+  }
+  // ... rest of state updates
 }
 ```
 
@@ -1237,34 +1054,25 @@ private async handleSetApiAccessMode(message: unknown): Promise<void> {
 
 #### Missing Confirmation Dialogs
 
-**Problem:** Destructive actions executed immediately without user confirmation:
-- `clearAllMemory()` deletes all files
-- `handleClearHistory()` deletes all history
+**Problem:** Destructive actions executed without user confirmation.
 
-**Solution:** Add confirmation dialogs:
+**Lit Architecture Solution:** Centralized confirm dialog component:
 ```typescript
-// Backend handler
-private async handleClearAllMemory(): Promise<void> {
-  const confirmed = await vscode.window.showWarningMessage(
-    'Delete all memory files? This cannot be undone.',
-    { modal: true },
-    'Delete All'
-  );
-
-  if (confirmed !== 'Delete All') return;
-
-  // Proceed with deletion
+// In store
+export function showConfirmDialog(config: ConfirmDialogConfig) {
+  state.confirmDialog = config;
 }
-```
 
-Or in frontend with VS Code-style:
-```javascript
-async clearAllMemory() {
-  // Send confirmation request to backend
-  vscode.postMessage({
-    command: SETTINGS_VIEW_COMMANDS.CONFIRM_CLEAR_ALL_MEMORY,
+// In component
+private _clearAllMemory() {
+  showConfirmDialog({
+    title: 'Delete All Memory Files',
+    message: 'This cannot be undone. Are you sure?',
+    confirmLabel: 'Delete All',
+    onConfirm: () => {
+      vscode.postMessage({ command: SETTINGS_VIEW_COMMANDS.CLEAR_ALL_MEMORY });
+    },
   });
-  // Backend shows dialog and proceeds if confirmed
 }
 ```
 
@@ -1274,180 +1082,75 @@ async clearAllMemory() {
 
 #### Inconsistent Default Values
 
-**Problem:** Default values differed between Settings View and execution code:
-```typescript
-// Settings View used 'fine'
-latexdiffMathMarkup: getConfig('texra.latexdiff.mathMarkup', 'fine'),
+**Problem:** Defaults differed between UI and execution code.
 
-// Execution code used 'coarse'
-const mathMarkup = getConfig('texra.latexdiff.mathMarkup', 'coarse');
-```
-
-**Solution:** Define defaults in ONE place (settingsSchema.ts):
+**Solution:** Define defaults in schemas using `.default()`:
 ```typescript
-// settingsSchema.ts - SINGLE SOURCE OF TRUTH
+// src/shared/schemas/settings.ts
 export const MathMarkupSchema = z.enum(['off', 'whole', 'coarse', 'fine']).default('coarse');
 
-// Everywhere else - use schema default
-const mathMarkup = MathMarkupSchema.parse(getConfig('texra.latexdiff.mathMarkup'));
+// Usage everywhere
+const mathMarkup = MathMarkupSchema.parse(rawValue);  // Gets default if undefined
 ```
 
 #### Provider ID Case Mismatch
 
-**Problem:** Provider IDs inconsistently cased:
-```typescript
-// Schema used camelCase
-ProviderIdSchema = z.enum(['anthropic', 'openai', 'openRouter', ...]);
+**Problem:** `openRouter` vs `openrouter` causing lookup failures.
 
-// Model configs used lowercase
-MODEL_CONFIGS[model].provider.toLowerCase() === 'openrouter'  // ❌ Mismatch!
-```
-
-**Solution:** Use consistent lowercase for all provider IDs:
+**Solution:** Zod schema enforces consistent casing:
 ```typescript
 export const ProviderIdSchema = z.enum([
   'anthropic',
   'openai',
-  'google',
-  'openrouter',  // ✅ Lowercase
-  'deepseek',
-  'xai',
-  'moonshot',
-  'dashscope',
+  'openrouter',  // ✅ Lowercase only
+  // ...
 ]);
-```
-
-#### Settings Migration Missing
-
-**Problem:** When moving settings from VS Code config to workspace storage, existing user values were lost.
-
-**Solution:** Add migration on activation:
-```typescript
-// In extension.ts or settings initialization
-async function migrateSettings() {
-  const config = vscode.workspace.getConfiguration('texra');
-  const storage = context.workspaceState;
-
-  const settingsToMigrate = [
-    { old: 'latex.formatter', new: WorkspaceStateKey.FORMATTER },
-    { old: 'latexdiff.mathMarkup', new: WorkspaceStateKey.MATH_MARKUP },
-  ];
-
-  for (const { old, new: newKey } of settingsToMigrate) {
-    const existing = storage.get(newKey);
-    if (existing === undefined) {
-      const value = config.get(old);
-      if (value !== undefined) {
-        await storage.update(newKey, value);
-      }
-    }
-  }
-}
 ```
 
 ---
 
-### Architecture Recommendations
+### Architecture Improvements
 
 #### Large MessageHandler Class
 
-**Problem:** `SettingsViewMessageHandler.ts` grew to 1000+ lines.
+**Problem:** 1000+ line handler file.
 
 **Solution:** Extract domain-specific handler classes:
 ```
 src/settingsView/
-├── SettingsViewMessageHandler.ts      # Orchestrates, ~200 lines
+├── SettingsViewMessageHandler.ts  # ~200 lines, orchestrates
 ├── handlers/
-│   ├── ModelHandlers.ts               # Model/provider operations
-│   ├── AgentHandlers.ts               # Agent CRUD operations
-│   ├── LatexHandlers.ts               # LaTeX settings
-│   ├── HistoryHandlers.ts             # History operations
-│   └── MemoryHandlers.ts              # Memory file operations
+│   ├── ModelHandlers.ts           # Model/provider operations
+│   ├── AgentHandlers.ts           # Agent CRUD
+│   ├── LatexHandlers.ts           # LaTeX settings
+│   ├── HistoryHandlers.ts         # History operations
+│   └── MemoryHandlers.ts          # Memory file operations
 ```
 
-Usage:
-```typescript
-export class SettingsViewMessageHandler extends BaseViewMessageHandler {
-  private modelHandlers: ModelHandlers;
-  private agentHandlers: AgentHandlers;
-  // ...
+#### Performance: Lazy Loading
 
-  protected createHandlers(): Record<string, MessageHandler> {
-    return {
-      ...this.modelHandlers.getHandlers(),
-      ...this.agentHandlers.getHandlers(),
-      // ...
-    };
+**Problem:** Loading all memory file previews could be slow.
+
+**Solution:** Lazy load on expand:
+```typescript
+// Initial load: metadata only (no preview)
+// On expand: fetch preview via GET_MEMORY_PREVIEW command
+@customElement('memory-item')
+class MemoryItem extends LitElement {
+  @property() file!: MemoryFile;
+  @state() private _expanded = false;
+  @state() private _preview?: string;
+
+  private async _expand() {
+    this._expanded = true;
+    if (!this._preview) {
+      vscode.postMessage({
+        command: SETTINGS_VIEW_COMMANDS.GET_MEMORY_PREVIEW,
+        path: this.file.path,
+      });
+    }
   }
 }
-```
-
-#### Performance: Lazy Loading for Large Data
-
-**Problem:** Loading all memory files with content previews could be slow.
-
-**Solution:** Lazy load previews on expand:
-```javascript
-// Initial load: metadata only
-const memoryFiles = files.map(f => ({
-  name: f.name,
-  path: f.path,
-  size: f.size,
-  // preview: NOT included initially
-}));
-
-// On expand: fetch preview
-async expandFile(filePath) {
-  vscode.postMessage({
-    command: SETTINGS_VIEW_COMMANDS.GET_MEMORY_PREVIEW,
-    path: filePath,
-  });
-}
-```
-
----
-
-### Test Coverage Requirements
-
-No tests were included in the initial implementation. Required test coverage:
-
-| Area | Test Type | Priority |
-|------|-----------|----------|
-| **Zod Schemas** | Unit tests for validation edge cases | High |
-| **Message Handlers** | Unit tests for each handler | High |
-| **State Management** | Tests for settingsViewState.js | Medium |
-| **Data Collection** | Tests for collectModelsData, etc. | Medium |
-| **Tab Switching** | Integration tests | Medium |
-| **API Key Flow** | Integration tests | High |
-| **Legacy Redirects** | Verify old commands work | Medium |
-
-Example test structure:
-```typescript
-// tests/settingsView/schemas.test.ts
-describe('SettingsView Schemas', () => {
-  describe('SaveSettingSchema', () => {
-    it('rejects unknown setting keys', () => {
-      const result = SaveSettingSchema.safeParse({
-        command: 'SAVE_SETTING',
-        key: 'texra.unknown.setting',  // Not in whitelist
-        value: 'test',
-      });
-      expect(result.success).toBe(false);
-    });
-  });
-});
-
-// tests/settingsView/messageHandler.test.ts
-describe('SettingsViewMessageHandler', () => {
-  it('handles all defined commands', () => {
-    const handler = new SettingsViewMessageHandler(mockContext);
-    const handlers = handler['createHandlers']();
-
-    for (const cmd of Object.values(SETTINGS_VIEW_COMMANDS)) {
-      expect(handlers[cmd]).toBeDefined(`Missing handler for ${cmd}`);
-    }
-  });
-});
 ```
 
 ---
@@ -1457,41 +1160,37 @@ describe('SettingsViewMessageHandler', () => {
 Before merging Settings View implementation, verify:
 
 ### Single Source of Truth
-- [ ] Commands defined in ONE file only (`commands.ts`)
-- [ ] Provider metadata defined in ONE file, sent via InitialData
-- [ ] Default values defined in `settingsSchema.ts`
-- [ ] Provider IDs use consistent casing (lowercase)
+- [ ] Commands defined ONLY in `src/shared/schemas/commands.ts`
+- [ ] Provider metadata sent from backend via InitialData
+- [ ] Default values defined in Zod schemas with `.default()`
+- [ ] Provider IDs use consistent lowercase
 
 ### Security
-- [ ] All user data escaped before HTML interpolation
 - [ ] Memory file paths validated against storage root
-- [ ] Setting keys whitelisted in schema
+- [ ] Setting keys whitelisted in Zod schema
 - [ ] API keys use SecretManager (never in state/config)
+- [ ] Lit handles XSS automatically (verify no `unsafeHTML` misuse)
 
 ### Completeness
-- [ ] Every frontend command has a backend handler
+- [ ] Every command in schema has a handler
 - [ ] All tabs receive data in InitialData
-- [ ] Tab selection from parameters actually applied
+- [ ] Tab selection from parameters applied
 - [ ] API access mode toggle included (for paid users)
+- [ ] All handlers call `withValidatedMessage()` with schema
 
 ### UX Safety
-- [ ] Destructive actions have confirmation dialogs
+- [ ] Destructive actions use confirm dialog
 - [ ] Error messages shown for failed operations
 - [ ] Loading states for async operations
-
-### Testing
-- [ ] Schema validation tests
-- [ ] Handler routing tests
-- [ ] State management tests
-- [ ] Legacy command redirect tests
 
 ---
 
 ## References
 
-- **VS Code Elements:** `@vscode-elements/elements` (v2.4.0)
+- **ProgressView Modernization PRD:** `docs/prd-progressview-modernization.md`
+- **Lit Documentation:** https://lit.dev/
+- **Zod Documentation:** https://zod.dev/
+- **Shared Schemas:** `src/shared/schemas/`
+- **Shared Components:** `src/shared/components/`
 - **Base Classes:** `src/common/webview/Base*.ts`
-- **Shared Modules:** `src/common/modules/*.js`
-- **Shared Styles:** `src/common/styles/common.css`
-- **Existing Views:** `src/profileView/`, `src/historyView/`, `src/progressView/`
 - **PR Review:** #2206 - Initial implementation attempt with review feedback

--- a/docs/prd/settings-view-unified.md
+++ b/docs/prd/settings-view-unified.md
@@ -1155,6 +1155,1079 @@ class MemoryItem extends LitElement {
 
 ---
 
+## Detailed Component Specifications
+
+This section provides comprehensive Lit component specifications for each part of the Settings View. Components are organized hierarchically with clear props, state, events, and patterns derived from existing views.
+
+### Component Hierarchy Overview
+
+```
+<settings-app>                          # Root orchestrator
+├── <header-bar>                        # Account status + actions
+├── <texra-tabs>                        # Shared tab container
+│   ├── <models-tab>
+│   │   ├── <routing-options>           # Direct/OpenRouter/Proxy radio
+│   │   ├── <recommended-section>       # Curated model list
+│   │   └── <provider-accordion>*       # Per-provider collapsible
+│   │       ├── <provider-header>       # Status badge + Configure
+│   │       └── <model-checkbox>*       # Individual model toggle
+│   │
+│   ├── <agents-tab>
+│   │   ├── <agent-list section="builtIn">
+│   │   ├── <agent-list section="toolUse">
+│   │   ├── <agent-list section="custom">
+│   │   ├── <agent-settings-group title="Workflow">
+│   │   └── <agent-settings-group title="Tool-Use">
+│   │
+│   ├── <latex-tab>
+│   │   ├── <settings-group title="Formatter">
+│   │   ├── <settings-group title="LaTeXdiff">
+│   │   ├── <settings-group title="TikZ Figures">
+│   │   └── <settings-group title="Replacements">
+│   │
+│   ├── <memory-tab>
+│   │   ├── <memory-toolbar>            # Search + Clear All
+│   │   └── <memory-tree>               # Recursive file tree
+│   │       └── <memory-item>*          # Individual file/folder
+│   │
+│   └── <history-tab>
+│       ├── <history-toolbar>           # Search + Clear All
+│       └── <history-list>
+│           └── <history-item>*         # Individual execution
+│
+└── <confirm-dialog>                    # Modal overlay
+```
+
+### Shared Components (from `src/shared/components/`)
+
+These components are reusable across all webviews, extracted during Phase 2 of ProgressView modernization.
+
+#### `<texra-tabs>`
+
+Tab container with VS Code styling.
+
+```typescript
+@customElement('texra-tabs')
+export class TexraTabs extends LitElement {
+  @property({ type: Array }) tabs: string[] = [];
+  @property() activeTab: string = '';
+
+  // Events
+  @event() 'tab-change': CustomEvent<{ tab: string }>;
+
+  render() {
+    return html`
+      <div class="tab-bar" role="tablist">
+        ${this.tabs.map(tab => html`
+          <button
+            role="tab"
+            class=${classMap({ active: tab === this.activeTab })}
+            @click=${() => this._selectTab(tab)}
+          >
+            ${this._formatTabLabel(tab)}
+          </button>
+        `)}
+      </div>
+      <div class="tab-content">
+        <slot name=${this.activeTab}></slot>
+      </div>
+    `;
+  }
+}
+```
+
+#### `<texra-collapsible>`
+
+Accordion section with header and expandable content.
+
+```typescript
+@customElement('texra-collapsible')
+export class TexraCollapsible extends LitElement {
+  @property() title: string = '';
+  @property({ type: Boolean }) open: boolean = false;
+
+  render() {
+    return html`
+      <div class="collapsible ${this.open ? 'open' : ''}">
+        <button class="header" @click=${this._toggle}>
+          <span class="chevron">${this.open ? '▼' : '▶'}</span>
+          <span class="title">${this.title}</span>
+          <slot name="header-extra"></slot>
+        </button>
+        ${this.open ? html`<div class="content"><slot></slot></div>` : ''}
+      </div>
+    `;
+  }
+}
+```
+
+#### `<texra-confirm-dialog>`
+
+Modal confirmation dialog.
+
+```typescript
+@customElement('texra-confirm-dialog')
+export class TexraConfirmDialog extends LitElement {
+  @property({ type: Boolean }) open: boolean = false;
+  @property() title: string = '';
+  @property() message: string = '';
+  @property() confirmLabel: string = 'Confirm';
+  @property() cancelLabel: string = 'Cancel';
+  @property({ type: Boolean }) destructive: boolean = false;
+
+  // Events
+  @event() 'confirm': CustomEvent<void>;
+  @event() 'cancel': CustomEvent<void>;
+}
+```
+
+### `<header-bar>` Component
+
+Account status and actions, migrated from Profile View.
+
+```typescript
+// src/settingsView/frontend/components/HeaderBar.ts
+@customElement('header-bar')
+export class HeaderBar extends LitElement {
+  static styles = css`
+    :host {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 12px 16px;
+      border-bottom: 1px solid var(--vscode-panel-border);
+      background: var(--vscode-sideBar-background);
+    }
+
+    .account-info {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+
+    .tier-badge {
+      padding: 2px 8px;
+      border-radius: 4px;
+      font-size: 11px;
+      background: var(--vscode-badge-background);
+      color: var(--vscode-badge-foreground);
+    }
+
+    .actions {
+      display: flex;
+      gap: 8px;
+    }
+  `;
+
+  // Props from parent
+  @property({ type: Boolean }) authenticated = false;
+  @property() email?: string;
+  @property() tier?: 'free' | 'Max' | 'Ultra';
+  @property({ type: Boolean }) useIncludedAccess = false;
+
+  render() {
+    if (!this.authenticated) {
+      return html`
+        <div class="account-info">
+          <span>Not signed in</span>
+        </div>
+        <div class="actions">
+          <vscode-button @click=${this._signIn}>Sign In</vscode-button>
+        </div>
+      `;
+    }
+
+    return html`
+      <div class="account-info">
+        <span class="codicon codicon-account"></span>
+        <span>${this.email}</span>
+        ${this.tier ? html`<span class="tier-badge">${this.tier}</span>` : ''}
+      </div>
+      <div class="actions">
+        ${this._renderAccessToggle()}
+        <vscode-button appearance="secondary" @click=${this._manage}>
+          Manage
+        </vscode-button>
+        <vscode-button appearance="secondary" @click=${this._signOut}>
+          Sign Out
+        </vscode-button>
+      </div>
+    `;
+  }
+
+  private _renderAccessToggle() {
+    // Only show for paid tiers
+    if (this.tier === 'free') return '';
+
+    return html`
+      <label class="access-toggle">
+        <input
+          type="checkbox"
+          ?checked=${this.useIncludedAccess}
+          @change=${this._toggleAccess}
+        />
+        Use included API access
+      </label>
+    `;
+  }
+
+  private _signIn() {
+    vscode.postMessage({ command: SETTINGS_VIEW_COMMANDS.SIGN_IN });
+  }
+
+  private _signOut() {
+    vscode.postMessage({ command: SETTINGS_VIEW_COMMANDS.SIGN_OUT });
+  }
+
+  private _manage() {
+    vscode.postMessage({ command: SETTINGS_VIEW_COMMANDS.OPEN_ACCOUNT_PORTAL });
+  }
+
+  private _toggleAccess(e: Event) {
+    const checked = (e.target as HTMLInputElement).checked;
+    vscode.postMessage({
+      command: SETTINGS_VIEW_COMMANDS.SET_API_ACCESS_MODE,
+      useIncludedAccess: checked,
+    });
+  }
+}
+```
+
+### `<models-tab>` Component
+
+Model selection and provider configuration.
+
+**Data Flow:**
+```
+MODEL_CONFIGS (backend)          →  InitialData.models
+SecretManager.hasKey(provider)   →  InitialData.providers[id].hasKey
+getModelMetadata(provider)       →  InitialData.providerMeta[id]
+globalState.enabledModels        →  InitialData.enabledModels
+```
+
+```typescript
+// src/settingsView/frontend/components/ModelsTab.ts
+@customElement('models-tab')
+export class ModelsTab extends LitElement {
+  @property({ type: Object }) state!: SettingsState;
+
+  // Derived state - computed when state changes
+  private get _modelsByProvider(): Map<ProviderId, ModelData[]> {
+    const map = new Map<ProviderId, ModelData[]>();
+    for (const model of this.state.models) {
+      const list = map.get(model.provider) || [];
+      list.push(model);
+      map.set(model.provider, list);
+    }
+    return map;
+  }
+
+  render() {
+    return html`
+      <section class="routing-section">
+        <h3>API Routing</h3>
+        <routing-options
+          .mode=${this.state.routingMode}
+          @mode-change=${this._onRoutingChange}
+        ></routing-options>
+      </section>
+
+      <section class="recommended-section">
+        <h3>Recommended Models</h3>
+        <p class="hint">These models are known to work well with TeXRA.</p>
+        ${this._renderModelList(this.state.recommendedModels)}
+      </section>
+
+      <section class="all-providers">
+        <h3>All Providers</h3>
+        ${Array.from(this._modelsByProvider.entries()).map(
+          ([providerId, models]) => html`
+            <provider-accordion
+              .providerId=${providerId}
+              .models=${models}
+              .meta=${this.state.providerMeta[providerId]}
+              .status=${this.state.providers[providerId]}
+              .enabledModels=${this.state.enabledModels}
+              @model-toggle=${this._onModelToggle}
+              @configure=${this._onConfigureProvider}
+            ></provider-accordion>
+          `
+        )}
+      </section>
+    `;
+  }
+
+  private _onModelToggle(e: CustomEvent<{ modelId: string; enabled: boolean }>) {
+    const { modelId, enabled } = e.detail;
+    const newEnabled = enabled
+      ? [...this.state.enabledModels, modelId]
+      : this.state.enabledModels.filter(id => id !== modelId);
+
+    // Optimistic update
+    this.state.enabledModels = newEnabled;
+
+    // Persist
+    vscode.postMessage({
+      command: SETTINGS_VIEW_COMMANDS.SAVE_ENABLED_MODELS,
+      models: newEnabled,
+    });
+  }
+
+  private _onConfigureProvider(e: CustomEvent<{ providerId: ProviderId }>) {
+    const { providerId } = e.detail;
+    const meta = this.state.providerMeta[providerId];
+
+    // Show API key input dialog
+    showApiKeyDialog({
+      provider: providerId,
+      providerName: meta.name,
+      keyUrl: meta.keyUrl,
+      envVar: meta.envVar,
+      onSubmit: (key) => {
+        vscode.postMessage({
+          command: SETTINGS_VIEW_COMMANDS.SET_API_KEY,
+          provider: providerId,
+          key,
+        });
+      },
+    });
+  }
+}
+```
+
+### `<agents-tab>` Component
+
+Agent management and settings, consolidating agent dropdown and settings.
+
+**Data Flow:**
+```
+agentRegistry.getAllAgents()     →  InitialData.agents
+workspaceState.enabledAgents     →  (filter which are enabled)
+Custom YAML files                →  source: 'custom'
+```
+
+```typescript
+// src/settingsView/frontend/components/AgentsTab.ts
+@customElement('agents-tab')
+export class AgentsTab extends LitElement {
+  @property({ type: Object }) state!: SettingsState;
+
+  // Group agents by source
+  private get _builtInAgents() {
+    return this.state.agents.filter(a => a.source === 'builtIn');
+  }
+
+  private get _toolUseAgents() {
+    return this.state.agents.filter(a => a.source === 'builtInToolUse');
+  }
+
+  private get _customAgents() {
+    return this.state.agents.filter(a => a.source === 'custom');
+  }
+
+  render() {
+    return html`
+      <section class="agent-section">
+        <h3>Built-in Agents</h3>
+        <p class="hint">Standard agents for common tasks.</p>
+        <agent-list
+          .agents=${this._builtInAgents}
+          @toggle=${this._onAgentToggle}
+          @view-source=${this._onViewSource}
+        ></agent-list>
+      </section>
+
+      <section class="agent-section">
+        <h3>Tool-Use Agents</h3>
+        <p class="hint">Agents with autonomous tool execution.</p>
+        <agent-list
+          .agents=${this._toolUseAgents}
+          @toggle=${this._onAgentToggle}
+          @view-source=${this._onViewSource}
+        ></agent-list>
+      </section>
+
+      <section class="agent-section">
+        <h3>Custom Agents</h3>
+        <p class="hint">User-defined agents from YAML files.</p>
+        <div class="custom-actions">
+          <vscode-button @click=${this._browseAgentsDir}>
+            Browse Directory
+          </vscode-button>
+          <vscode-button appearance="secondary" @click=${this._openAgentsDir}>
+            Open in Explorer
+          </vscode-button>
+        </div>
+        <agent-list
+          .agents=${this._customAgents}
+          ?showDelete=${true}
+          @toggle=${this._onAgentToggle}
+          @view-source=${this._onViewSource}
+          @delete=${this._onDeleteAgent}
+        ></agent-list>
+      </section>
+
+      <texra-collapsible title="Workflow Settings">
+        <settings-group
+          .settings=${WORKFLOW_SETTINGS}
+          .values=${this.state.latexSettings}
+          @change=${this._onSettingChange}
+        ></settings-group>
+      </texra-collapsible>
+
+      <texra-collapsible title="Tool-Use Settings">
+        <settings-group
+          .settings=${TOOL_USE_SETTINGS}
+          .values=${this.state.latexSettings}
+          @change=${this._onSettingChange}
+        ></settings-group>
+      </texra-collapsible>
+    `;
+  }
+
+  private _onDeleteAgent(e: CustomEvent<{ agent: AgentData }>) {
+    const { agent } = e.detail;
+    showConfirmDialog({
+      title: 'Delete Agent',
+      message: `Delete custom agent "${agent.name}"? This cannot be undone.`,
+      confirmLabel: 'Delete',
+      destructive: true,
+      onConfirm: () => {
+        vscode.postMessage({
+          command: SETTINGS_VIEW_COMMANDS.DELETE_AGENT,
+          name: agent.name,
+        });
+      },
+    });
+  }
+}
+```
+
+### `<memory-tab>` Component
+
+Memory file browser, migrated from Memory View.
+
+**Data Flow:**
+```
+memoryStorage.getFiles()         →  InitialData.memoryFiles (tree structure)
+globalState.memoryEnabled        →  InitialData.memoryEnabled
+```
+
+**Key Pattern:** Lazy-load file previews on expand.
+
+```typescript
+// src/settingsView/frontend/components/MemoryTab.ts
+@customElement('memory-tab')
+export class MemoryTab extends LitElement {
+  @property({ type: Object }) state!: SettingsState;
+  @state() private _searchQuery = '';
+  @state() private _expandedPaths = new Set<string>();
+  @state() private _loadedPreviews = new Map<string, string>();
+
+  render() {
+    return html`
+      <div class="toolbar">
+        <vscode-text-field
+          placeholder="Search memory files..."
+          .value=${this._searchQuery}
+          @input=${this._onSearchInput}
+        >
+          <span slot="start" class="codicon codicon-search"></span>
+        </vscode-text-field>
+
+        <vscode-button
+          appearance="secondary"
+          ?disabled=${this.state.memoryFiles.length === 0}
+          @click=${this._clearAll}
+        >
+          Clear All
+        </vscode-button>
+      </div>
+
+      ${this.state.memoryFiles.length === 0
+        ? html`<div class="empty-state">No memory files yet.</div>`
+        : html`
+            <div class="memory-tree">
+              ${this._renderTree(this._filteredFiles)}
+            </div>
+          `}
+    `;
+  }
+
+  private get _filteredFiles(): MemoryFile[] {
+    if (!this._searchQuery) return this.state.memoryFiles;
+    const query = this._searchQuery.toLowerCase();
+    return this._filterTree(this.state.memoryFiles, query);
+  }
+
+  private _renderTree(files: MemoryFile[]): TemplateResult {
+    return html`
+      ${repeat(
+        files,
+        (f) => f.path,
+        (file) => html`
+          <memory-item
+            .file=${file}
+            .expanded=${this._expandedPaths.has(file.path)}
+            .preview=${this._loadedPreviews.get(file.path)}
+            @expand=${() => this._expand(file)}
+            @collapse=${() => this._collapse(file)}
+            @open=${() => this._openFile(file)}
+            @delete=${() => this._deleteFile(file)}
+          >
+            ${file.children && this._expandedPaths.has(file.path)
+              ? this._renderTree(file.children)
+              : ''}
+          </memory-item>
+        `
+      )}
+    `;
+  }
+
+  private async _expand(file: MemoryFile) {
+    this._expandedPaths = new Set([...this._expandedPaths, file.path]);
+
+    // Lazy load preview if not already loaded
+    if (!file.isDirectory && !this._loadedPreviews.has(file.path)) {
+      vscode.postMessage({
+        command: SETTINGS_VIEW_COMMANDS.GET_MEMORY_PREVIEW,
+        path: file.path,
+      });
+    }
+  }
+
+  private _clearAll() {
+    showConfirmDialog({
+      title: 'Clear All Memory Files',
+      message: 'This will delete all memory files. This action cannot be undone.',
+      confirmLabel: 'Delete All',
+      destructive: true,
+      onConfirm: () => {
+        vscode.postMessage({ command: SETTINGS_VIEW_COMMANDS.CLEAR_ALL_MEMORY });
+      },
+    });
+  }
+}
+```
+
+### `<history-tab>` Component
+
+Execution history browser, migrated from History View.
+
+**Data Flow:**
+```
+stateTracker.getHistory()        →  InitialData.historyItems
+```
+
+**Key Patterns:**
+- Search with highlighting
+- Collapsible details per item
+- Actions: Rerun, Restore, Delete
+
+```typescript
+// src/settingsView/frontend/components/HistoryTab.ts
+@customElement('history-tab')
+export class HistoryTab extends LitElement {
+  @property({ type: Object }) state!: SettingsState;
+  @state() private _searchQuery = '';
+  @state() private _expandedIds = new Set<string>();
+
+  render() {
+    return html`
+      <div class="toolbar">
+        <vscode-text-field
+          placeholder="Search history..."
+          .value=${this._searchQuery}
+          @input=${(e: Event) => {
+            this._searchQuery = (e.target as HTMLInputElement).value;
+          }}
+        >
+          <span slot="start" class="codicon codicon-search"></span>
+        </vscode-text-field>
+
+        <vscode-button
+          appearance="secondary"
+          ?disabled=${this.state.historyItems.length === 0}
+          @click=${this._clearAll}
+        >
+          Clear All
+        </vscode-button>
+      </div>
+
+      ${this.state.historyItems.length === 0
+        ? html`<div class="empty-state">No execution history yet.</div>`
+        : html`
+            <div class="history-list">
+              ${repeat(
+                this._filteredItems,
+                (item: any) => item.id,
+                (item) => this._renderItem(item)
+              )}
+            </div>
+          `}
+    `;
+  }
+
+  private _renderItem(item: HistoryItem) {
+    const expanded = this._expandedIds.has(item.id);
+
+    return html`
+      <div class="history-item ${expanded ? 'expanded' : ''}">
+        <div class="item-header" @click=${() => this._toggleExpand(item.id)}>
+          <span class="chevron">${expanded ? '▼' : '▶'}</span>
+          <span class="agent-name">${item.agentName}</span>
+          <span class="timestamp">${this._formatTime(item.timestamp)}</span>
+          <span class="model">${item.modelId}</span>
+        </div>
+
+        ${expanded ? html`
+          <div class="item-details">
+            <div class="input-preview">
+              <strong>Input:</strong>
+              ${this._highlightSearch(item.inputPreview)}
+            </div>
+            <div class="output-preview">
+              <strong>Output:</strong>
+              ${this._highlightSearch(item.outputPreview)}
+            </div>
+            <div class="actions">
+              <vscode-button @click=${() => this._rerun(item)}>
+                <span class="codicon codicon-debug-restart"></span> Rerun
+              </vscode-button>
+              <vscode-button @click=${() => this._restore(item)}>
+                <span class="codicon codicon-history"></span> Restore
+              </vscode-button>
+              <vscode-button appearance="secondary" @click=${() => this._delete(item)}>
+                <span class="codicon codicon-trash"></span>
+              </vscode-button>
+            </div>
+          </div>
+        ` : ''}
+      </div>
+    `;
+  }
+
+  private _highlightSearch(text: string): TemplateResult {
+    if (!this._searchQuery) return html`${text}`;
+
+    const parts = text.split(new RegExp(`(${this._escapeRegex(this._searchQuery)})`, 'gi'));
+    return html`${parts.map(part =>
+      part.toLowerCase() === this._searchQuery.toLowerCase()
+        ? html`<mark>${part}</mark>`
+        : part
+    )}`;
+  }
+
+  private _clearAll() {
+    showConfirmDialog({
+      title: 'Clear All History',
+      message: 'This will delete all execution history. This action cannot be undone.',
+      confirmLabel: 'Clear History',
+      destructive: true,
+      onConfirm: () => {
+        vscode.postMessage({ command: SETTINGS_VIEW_COMMANDS.CLEAR_HISTORY });
+      },
+    });
+  }
+}
+```
+
+### `<latex-tab>` Component
+
+LaTeX settings organized in collapsible groups.
+
+**Data Flow:**
+```
+vscode.workspace.getConfiguration('texra.latex')     →  InitialData.latexSettings
+generateDropdownOptions()                            →  InitialData.selectOptions
+```
+
+```typescript
+// src/settingsView/frontend/components/LatexTab.ts
+
+// Setting definitions - single source of truth for UI
+const FORMATTER_SETTINGS: SettingDef[] = [
+  {
+    key: 'texra.latex.formatter',
+    label: 'Formatter',
+    type: 'select',
+    options: 'formatter',  // References selectOptions.formatter
+    description: 'LaTeX code formatter to use',
+  },
+  {
+    key: 'texra.latex.latexindentConfig',
+    label: 'latexindent Config',
+    type: 'file',
+    filter: { yaml: ['yml', 'yaml'] },
+    description: 'Custom latexindent configuration file',
+  },
+  // ... more settings
+];
+
+const LATEXDIFF_SETTINGS: SettingDef[] = [
+  {
+    key: 'texra.latexdiff.mathMarkup',
+    label: 'Math Markup',
+    type: 'select',
+    options: 'mathMarkup',
+    default: 'coarse',
+  },
+  {
+    key: 'texra.latexdiff.timeoutMs',
+    label: 'Timeout (ms)',
+    type: 'number',
+    min: 1000,
+    max: 60000,
+    default: 10000,
+  },
+  // ... more settings
+];
+
+@customElement('latex-tab')
+export class LatexTab extends LitElement {
+  @property({ type: Object }) state!: SettingsState;
+
+  render() {
+    return html`
+      <texra-collapsible title="Formatter" open>
+        <settings-group
+          .settings=${FORMATTER_SETTINGS}
+          .values=${this.state.latexSettings}
+          .selectOptions=${this.state.selectOptions}
+          @change=${this._onSettingChange}
+          @browse=${this._onBrowseFile}
+        ></settings-group>
+      </texra-collapsible>
+
+      <texra-collapsible title="LaTeXdiff">
+        <settings-group
+          .settings=${LATEXDIFF_SETTINGS}
+          .values=${this.state.latexSettings}
+          .selectOptions=${this.state.selectOptions}
+          @change=${this._onSettingChange}
+        ></settings-group>
+      </texra-collapsible>
+
+      <texra-collapsible title="TikZ Figures">
+        <settings-group
+          .settings=${TIKZ_SETTINGS}
+          .values=${this.state.latexSettings}
+          .selectOptions=${this.state.selectOptions}
+          @change=${this._onSettingChange}
+          @browse=${this._onBrowseFile}
+        ></settings-group>
+      </texra-collapsible>
+
+      <texra-collapsible title="Replacements (Advanced)">
+        <settings-group
+          .settings=${REPLACEMENT_SETTINGS}
+          .values=${this.state.latexSettings}
+          .selectOptions=${this.state.selectOptions}
+          @change=${this._onSettingChange}
+        ></settings-group>
+      </texra-collapsible>
+    `;
+  }
+
+  private _onSettingChange(e: CustomEvent<{ key: string; value: unknown }>) {
+    const { key, value } = e.detail;
+
+    // Optimistic update
+    this.state.latexSettings = {
+      ...this.state.latexSettings,
+      [key]: value,
+    };
+
+    // Persist
+    vscode.postMessage({
+      command: SETTINGS_VIEW_COMMANDS.SAVE_SETTING,
+      key,
+      value,
+    });
+  }
+
+  private _onBrowseFile(e: CustomEvent<{ key: string; filter: object }>) {
+    const { key, filter } = e.detail;
+    vscode.postMessage({
+      command: SETTINGS_VIEW_COMMANDS.BROWSE_FILE,
+      settingKey: key,
+      filter,
+    });
+  }
+}
+```
+
+### `<settings-group>` Reusable Component
+
+Generic settings renderer that handles different input types.
+
+```typescript
+// src/settingsView/frontend/components/SettingsGroup.ts
+interface SettingDef {
+  key: string;
+  label: string;
+  type: 'select' | 'checkbox' | 'text' | 'number' | 'file';
+  options?: string;  // Key in selectOptions
+  default?: unknown;
+  description?: string;
+  min?: number;
+  max?: number;
+  filter?: Record<string, string[]>;
+}
+
+@customElement('settings-group')
+export class SettingsGroup extends LitElement {
+  @property({ type: Array }) settings: SettingDef[] = [];
+  @property({ type: Object }) values: Record<string, unknown> = {};
+  @property({ type: Object }) selectOptions: Record<string, SelectOption[]> = {};
+
+  render() {
+    return html`
+      <div class="settings-list">
+        ${this.settings.map(setting => this._renderSetting(setting))}
+      </div>
+    `;
+  }
+
+  private _renderSetting(setting: SettingDef) {
+    const value = this.values[setting.key] ?? setting.default;
+
+    return html`
+      <div class="setting-row">
+        <label for=${setting.key}>${setting.label}</label>
+        ${setting.description
+          ? html`<p class="description">${setting.description}</p>`
+          : ''}
+        ${this._renderInput(setting, value)}
+      </div>
+    `;
+  }
+
+  private _renderInput(setting: SettingDef, value: unknown) {
+    switch (setting.type) {
+      case 'select':
+        const options = this.selectOptions[setting.options!] || [];
+        return html`
+          <vscode-dropdown
+            id=${setting.key}
+            .value=${String(value ?? '')}
+            @change=${(e: Event) => this._onChange(setting.key, (e.target as any).value)}
+          >
+            ${options.map(opt => html`
+              <vscode-option value=${opt.value}>${opt.label}</vscode-option>
+            `)}
+          </vscode-dropdown>
+        `;
+
+      case 'checkbox':
+        return html`
+          <vscode-checkbox
+            id=${setting.key}
+            ?checked=${Boolean(value)}
+            @change=${(e: Event) => this._onChange(setting.key, (e.target as any).checked)}
+          ></vscode-checkbox>
+        `;
+
+      case 'number':
+        return html`
+          <vscode-text-field
+            id=${setting.key}
+            type="number"
+            .value=${String(value ?? '')}
+            min=${setting.min}
+            max=${setting.max}
+            @change=${(e: Event) => this._onChange(setting.key, Number((e.target as any).value))}
+          ></vscode-text-field>
+        `;
+
+      case 'file':
+        return html`
+          <div class="file-input">
+            <vscode-text-field
+              id=${setting.key}
+              .value=${String(value ?? '')}
+              readonly
+            ></vscode-text-field>
+            <vscode-button @click=${() => this._onBrowse(setting)}>
+              Browse
+            </vscode-button>
+          </div>
+        `;
+
+      default:
+        return html`
+          <vscode-text-field
+            id=${setting.key}
+            .value=${String(value ?? '')}
+            @change=${(e: Event) => this._onChange(setting.key, (e.target as any).value)}
+          ></vscode-text-field>
+        `;
+    }
+  }
+
+  private _onChange(key: string, value: unknown) {
+    this.dispatchEvent(new CustomEvent('change', {
+      detail: { key, value },
+      bubbles: true,
+      composed: true,
+    }));
+  }
+
+  private _onBrowse(setting: SettingDef) {
+    this.dispatchEvent(new CustomEvent('browse', {
+      detail: { key: setting.key, filter: setting.filter },
+      bubbles: true,
+      composed: true,
+    }));
+  }
+}
+```
+
+---
+
+## How Lit + Zod + TypeScript Simplifies Development
+
+This section explains concrete benefits of the Lit architecture for Settings View.
+
+### 1. Type-Safe Message Passing
+
+**Problem with vanilla JS:** Runtime errors when message shapes don't match.
+
+**Lit + Zod solution:**
+
+```typescript
+// Shared schema (both sides import)
+export const SaveSettingMessageSchema = z.object({
+  command: z.literal(SETTINGS_VIEW_COMMANDS.SAVE_SETTING),
+  key: AllowedSettingKeySchema,  // Whitelist
+  value: z.unknown(),
+});
+
+// Backend handler with validation
+this.withValidatedMessage(SaveSettingMessageSchema, message, async (data) => {
+  // data.key is typed as AllowedSettingKey
+  await vscode.workspace.getConfiguration().update(data.key, data.value);
+});
+
+// Frontend - TypeScript ensures shape matches
+vscode.postMessage({
+  command: SETTINGS_VIEW_COMMANDS.SAVE_SETTING,  // TS error if wrong command
+  key: 'texra.latex.formatter',  // TS error if not in whitelist
+  value: 'latexindent',
+});
+```
+
+### 2. Automatic XSS Protection
+
+**Problem with vanilla JS:** Must manually escape all user data.
+
+**Lit solution:** Auto-escaping by default.
+
+```typescript
+// ✅ SAFE - Lit escapes automatically
+render() {
+  return html`
+    <span class="filename">${this.file.name}</span>
+    <pre class="preview">${this.preview}</pre>
+  `;
+}
+
+// Only use unsafeHTML for trusted content (markdown rendering)
+import { unsafeHTML } from 'lit/directives/unsafe-html.js';
+render() {
+  return html`${unsafeHTML(this.trustedMarkdownHtml)}`;
+}
+```
+
+### 3. Reactive Updates Without Manual DOM
+
+**Problem with vanilla JS:** Manual `querySelector`, `innerHTML`, event rebinding.
+
+**Lit solution:** Declarative templates with automatic updates.
+
+```typescript
+@customElement('model-item')
+class ModelItem extends LitElement {
+  @property({ type: Boolean }) enabled = false;
+  @property() name = '';
+
+  // Template re-renders automatically when props change
+  render() {
+    return html`
+      <input
+        type="checkbox"
+        ?checked=${this.enabled}
+        @change=${this._toggle}
+      />
+      <span>${this.name}</span>
+    `;
+  }
+
+  private _toggle() {
+    // Dispatch event - parent handles state
+    this.dispatchEvent(new CustomEvent('toggle', {
+      detail: { enabled: !this.enabled },
+    }));
+  }
+}
+```
+
+### 4. Single Source of Truth for Data
+
+**Problem with vanilla JS:** State scattered across DOM, JS variables, backend.
+
+**Lit + signals solution:** Centralized reactive store.
+
+```typescript
+// store.ts - single source of truth
+export const state = reactive<SettingsState>({
+  models: [],
+  enabledModels: [],
+  // ...
+});
+
+// Any component can access
+@customElement('models-count')
+class ModelsCount extends LitElement {
+  render() {
+    return html`${state.enabledModels.length} models enabled`;
+  }
+}
+
+// Updates propagate automatically
+state.enabledModels = [...state.enabledModels, 'new-model'];
+// All components using state.enabledModels re-render
+```
+
+### 5. Component Composition
+
+**Problem with vanilla JS:** Copy-paste HTML strings, inconsistent behavior.
+
+**Lit solution:** Reusable components with typed props.
+
+```typescript
+// Define once
+@customElement('texra-collapsible')
+class Collapsible extends LitElement {
+  @property() title = '';
+  @property({ type: Boolean }) open = false;
+  // ...
+}
+
+// Use everywhere with consistent behavior
+html`
+  <texra-collapsible title="Formatter" open>
+    ${formatterContent}
+  </texra-collapsible>
+
+  <texra-collapsible title="LaTeXdiff">
+    ${latexdiffContent}
+  </texra-collapsible>
+`;
+```
+
+---
+
 ## Implementation Checklist
 
 Before merging Settings View implementation, verify:

--- a/docs/prd/settings-view-unified.md
+++ b/docs/prd/settings-view-unified.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft
 **Author:** Claude
-**Date:** 2026-01-11
+**Date:** 2026-01-25
 **Related:** Model dropdown, Agent dropdown, Profile View, History View
 
 ---
@@ -18,10 +18,11 @@ Create a unified Settings View that consolidates model configuration, agent conf
 1. **Single source of truth** - All configuration in one place
 2. **Easy navigation** - vscode-tabs with logical groupings, vscode-collapsible for subsections
 3. **No auth required** - Most tabs work without login (except account features in header)
-4. **VS Code native** - Use vscode-tabs, vscode-collapsible, vscode-form-group (native components)
+4. **VS Code native** - Use VS Code Elements web components (`@vscode-elements/elements`)
 5. **Proper state management** - Global vs workspace state separation
 6. **Backwards compatible** - Extend getConfig rather than replacing it; graceful migration
 7. **Minimal custom CSS** - Only header bar needs custom styling, everything else native
+8. **Consistent patterns** - Follow existing webview architecture (vanilla JS, Zod validation)
 
 ---
 
@@ -161,1075 +162,89 @@ Tab 6: Advanced
 └── ▼ Debug (collapsible)
 ```
 
-### HTML Structure (vscode-tabs + header bar)
-
-```html
-<div class="settings-container">
-  <!-- Header Bar (only custom CSS needed) -->
-  <header class="settings-header">
-    <div class="account-info">
-      <!-- Logged in state -->
-      <span class="codicon codicon-account"></span>
-      <span class="user-email">user@example.com</span>
-      <span class="separator">•</span>
-      <span class="user-plan">Pro Plan</span>
-    </div>
-    <div class="account-actions">
-      <vscode-button appearance="secondary">Manage</vscode-button>
-      <vscode-button appearance="secondary">Sign Out</vscode-button>
-    </div>
-  </header>
-
-  <!-- Native vscode-tabs (no custom CSS) -->
-  <vscode-tabs selected-index="0">
-    <vscode-tab-header slot="header">Models</vscode-tab-header>
-    <vscode-tab-header slot="header">Agents</vscode-tab-header>
-    <vscode-tab-header slot="header">LaTeX</vscode-tab-header>
-    <vscode-tab-header slot="header">Memory</vscode-tab-header>
-    <vscode-tab-header slot="header">History</vscode-tab-header>
-    <!-- Advanced tab deferred to future release -->
-
-    <!-- Models Tab -->
-    <vscode-tab-panel>
-      <div class="tab-content">
-        <vscode-collapsible title="Recommended Models" open>
-          <!-- Model checkboxes -->
-        </vscode-collapsible>
-
-        <vscode-collapsible title="Anthropic" open>
-          <!-- Provider models + Configure button -->
-        </vscode-collapsible>
-
-        <vscode-collapsible title="OpenAI">
-          <!-- Provider models + Configure button -->
-        </vscode-collapsible>
-        <!-- More providers... -->
-      </div>
-    </vscode-tab-panel>
-
-    <!-- Agents Tab -->
-    <vscode-tab-panel>
-      <div class="tab-content">
-        <!-- Agent list (no collapsible needed for main content) -->
-        <div class="agents-list">
-          <!-- Agent checkboxes with badges -->
-        </div>
-
-        <vscode-collapsible title="Workflow Settings">
-          <!-- Output storage mode -->
-        </vscode-collapsible>
-
-        <vscode-collapsible title="Tool-Use Settings">
-          <!-- Edit approval, persistence, compaction -->
-        </vscode-collapsible>
-      </div>
-    </vscode-tab-panel>
-
-    <!-- LaTeX Tab -->
-    <vscode-tab-panel>
-      <div class="tab-content">
-        <vscode-collapsible title="Formatter" open>
-          <!-- Formatter settings -->
-        </vscode-collapsible>
-
-        <vscode-collapsible title="LaTeXdiff">
-          <!-- Diff settings -->
-        </vscode-collapsible>
-
-        <vscode-collapsible title="TikZ Figures">
-          <!-- TikZ settings -->
-        </vscode-collapsible>
-
-        <vscode-collapsible title="Replacements">
-          <!-- Replacement rules -->
-        </vscode-collapsible>
-      </div>
-    </vscode-tab-panel>
-
-    <!-- Memory Tab -->
-    <vscode-tab-panel>
-      <div class="tab-content">
-        <!-- Memory file browser -->
-      </div>
-    </vscode-tab-panel>
-
-    <!-- History Tab -->
-    <vscode-tab-panel>
-      <div class="tab-content">
-        <!-- History browser -->
-      </div>
-    </vscode-tab-panel>
-
-    <!-- Advanced Tab - deferred to future release -->
-  </vscode-tabs>
-</div>
-```
-
-### Header Bar CSS (minimal custom styles)
-
-```css
-/* Only custom CSS needed - everything else is native vscode-elements */
-.settings-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: var(--spacing-medium);
-  border-bottom: 1px solid var(--vscode-widget-border);
-  background: var(--vscode-sideBar-background);
-}
-
-.account-info {
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-small);
-  color: var(--vscode-foreground);
-}
-
-.account-info .separator {
-  color: var(--vscode-descriptionForeground);
-}
-
-.account-actions {
-  display: flex;
-  gap: var(--spacing-small);
-}
-
-/* Tab content padding */
-.tab-content {
-  padding: var(--spacing-large);
-  max-width: 720px;
-}
-```
-
----
-
-## Tab Specifications
-
-### Models Tab
-
-**Purpose:** Combined model selection and API provider configuration. Each provider shows API status + model selection together.
-
-**Layout:**
-
-```
-┌─────────────────────────────────────────────────────────────────┐
-│  Models & Providers                                             │
-│  ─────────────────────────────────────────────────────────────  │
-│                                                                 │
-│  ROUTING                                                        │
-│  ─────────────────────────────────────────────────────────────  │
-│  ● Direct to providers (recommended)                            │
-│  ○ Route all through OpenRouter                                 │
-│  ○ Use connection proxy                                         │
-│                                                                 │
-│  ⭐ RECOMMENDED MODELS                                          │
-│  ┌───────────────────────────────────────────────────────────┐  │
-│  │ ☑ Claude Sonnet 4.5 T    Anthropic   $3/$15    200K  🧠👁 │  │
-│  │ ☑ GPT-5.2                OpenAI      $2/$10    256K  🧠👁 │  │
-│  │ ☑ Gemini 3 Pro           Google      $1.25/$5  1M    🧠👁 │  │
-│  │ ☑ DeepSeek R1            DeepSeek    $0.55/$2  64K   🧠   │  │
-│  └───────────────────────────────────────────────────────────┘  │
-│                                                                 │
-│  PROVIDERS                                                      │
-│  ─────────────────────────────────────────────────────────────  │
-│                                                                 │
-│  ▼ Anthropic                         ✓ API Key    [Configure]  │
-│  ┌───────────────────────────────────────────────────────────┐  │
-│  │ ☑ Claude Sonnet 4.5 T     200K   $3/$15    🧠👁📄         │  │
-│  │ ☑ Claude Opus 4.5 T       200K   $15/$75   🧠👁📄🎧       │  │
-│  │ ☐ Claude Sonnet 4.5       200K   $3/$15    👁📄           │  │
-│  │ ☐ Claude Haiku 3.5        200K   $0.8/$4   👁             │  │
-│  │   ... more (21 models)                      [Enable All]  │  │
-│  └───────────────────────────────────────────────────────────┘  │
-│                                                                 │
-│  ▶ OpenAI (28)                       ✓ API Key    [Configure]  │
-│  ▶ Google (6)                        ✗ No Key     [Configure]  │
-│  ▶ DeepSeek (7)                      ✓ API Key    [Configure]  │
-│  ▶ xAI (5)                           ✗ No Key     [Configure]  │
-│  ▶ Moonshot (8)                      ✗ No Key     [Configure]  │
-│  ▶ DashScope (3)                     ✗ No Key     [Configure]  │
-│                                                                 │
-│  ▼ OpenRouter                        ✓ API Key    [Configure]  │
-│  ┌───────────────────────────────────────────────────────────┐  │
-│  │ OpenRouter provides access to 200+ models with one key.   │  │
-│  │ Routing: ● OpenRouter-only  ○ Route ALL through OR        │  │
-│  └───────────────────────────────────────────────────────────┘  │
-│                                                                 │
-│  ─────────────────────────────────────────────────────────────  │
-│  Selected: 12 models                                            │
-└─────────────────────────────────────────────────────────────────┘
-```
-
-**Key Design:**
-
-- Each provider accordion shows: status indicator + [Configure] button + model list
-- Provider status: `✓ API Key`, `✗ No Key`, or `🔑 Env Var`
-- Clicking [Configure] opens provider modal (API key + endpoint + streaming toggle)
-- Models are listed under their provider for clear ownership
-
-**Data Source:** `llm-zoo` package (ModelRegistry)
-
-**Model Metadata Displayed:**
-
-- Name (display name)
-- Context window
-- Cost (input/output per 1M tokens)
-- Capabilities icons: 🧠 Reasoning, 👁 Vision, 📄 PDF, 🎧 Audio, 💬 Tools, ⚡ Cache
-
-**Recommended Models (hardcoded):**
-
-```typescript
-const RECOMMENDED_MODELS = [
-  'sonnet45T',
-  'opus45T',
-  'gpt52',
-  'gemini3p',
-  'grok4',
-  'deepseekT',
-  'kimi2T',
-  'qwen3max',
-];
-```
-
-**Storage:** `globalState.enabledModels: string[]`, `globalState.providerConfig`
-
----
-
-### Agents Tab
-
-**Purpose:** View and enable/disable agents, plus agent-specific settings. Supersedes the FolderExplorer/agent explorer.
-
-**Scope (Phase 1):** View-only with enable/disable. Agent creation wizard deferred to Future Scope.
-
-**Agent Metadata Displayed:**
-| Field | Source | Display |
-|-------|--------|---------|
-| Name | YAML `name` | Text |
-| Description | YAML `description` | Text (truncated) |
-| Category | Derived (see Agent Category Derivation) | Badge: `[workflow]` or `[toolUse]` |
-| Type | `settings.agentType` | Label: `CoT`, `Direct`, `Merge`, `Reflect` |
-| Rounds | `settings.rounds` | Label: `×2`, `×3` (if > 1) |
-| Inherits | `inherits` | Codicon: `$(extensions)` + parent name |
-| Source | File location | `Built-in`, `Custom`, `Remote` |
-
-**Agent Type Icons (codicons):**
-
-- `$(lightbulb)` CoT (Chain-of-Thought)
-- `$(zap)` Direct
-- `$(git-merge)` Merge
-- `$(sync)` Reflect
-- `$(tools)` Tool-Use
-
-**Layout:**
-
-```
-┌─────────────────────────────────────────────────────────────────┐
-│  Select which agents appear in the dropdown.                    │
-│  Settings are saved per workspace.                              │
-│                                                                 │
-│  BUILT-IN AGENTS                                               │
-│  ─────────────────────────────────────────────────────────────  │
-│  ┌───────────────────────────────────────────────────────────┐  │
-│  │ ☑ chat      Interactive conversation                      │  │
-│  │             $(tools) toolUse                              │  │
-│  │                                                           │  │
-│  │ ☑ correct   Fix typos & LaTeX errors                      │  │
-│  │             $(lightbulb) CoT  ×2  $(extensions) polish    │  │
-│  │                                                           │  │
-│  │ ☑ polish    Improve writing quality                       │  │
-│  │             $(lightbulb) CoT  ×2                          │  │
-│  │   ...                                                     │  │
-│  └───────────────────────────────────────────────────────────┘  │
-│                                                                 │
-│  CUSTOM AGENTS                                                 │
-│  ─────────────────────────────────────────────────────────────  │
-│  ┌───────────────────────────────────────────────────────────┐  │
-│  │ ☑ my-reviewer   Reviews papers for clarity                │  │
-│  │                 $(lightbulb) CoT  $(extensions) correct   │  │
-│  │                              [Source Code] [Delete]       │  │
-│  └───────────────────────────────────────────────────────────┘  │
-│  📁 Custom agents are stored in: .texra/agents/                 │
-│                                                                 │
-│  REMOTE AGENTS                                                 │
-│  ─────────────────────────────────────────────────────────────  │
-│  ☑ Auto-show remote agents if available                        │
-│  ┌───────────────────────────────────────────────────────────┐  │
-│  │ ☑ team-reviewer   Team's paper reviewer                   │  │
-│  │                   $(lightbulb) CoT  ×3                    │  │
-│  │ ☐ grant-writer    Grant proposal helper                   │  │
-│  │                   $(tools) toolUse                        │  │
-│  └───────────────────────────────────────────────────────────┘  │
-│                        ─ or if not logged in ─                  │
-│  ┌───────────────────────────────────────────────────────────┐  │
-│  │  🔒 Sign in to access shared team agents       [Sign In]  │  │
-│  └───────────────────────────────────────────────────────────┘  │
-│                                                                 │
-│  ─────────────────────────────────────────────────────────────  │
-│                                                                 │
-│  ▼ Workflow Settings                                           │
-│  ┌───────────────────────────────────────────────────────────┐  │
-│  │ Settings for workflow agents (correct, polish, etc.)      │  │
-│  │                                                           │  │
-│  │ Storage mode: [Folder ▼]                                  │  │
-│  │   How to store agent outputs.                             │  │
-│  │   Options: In-place (overwrite), Folder (texra-outputs/)  │  │
-│  └───────────────────────────────────────────────────────────┘  │
-│                                                                 │
-│  ▼ Tool-Use Settings                                           │
-│  ┌───────────────────────────────────────────────────────────┐  │
-│  │ Settings for tool-use agents (chat, research, etc.)       │  │
-│  │                                                           │  │
-│  │ ☑ Require approval before file edits                      │  │
-│  │   Show diff preview and require confirmation.             │  │
-│  │                                                           │  │
-│  │ ☑ Persist sessions across VS Code restarts                │  │
-│  │   Session retention: [72 hours ▼]                         │  │
-│  │                                                           │  │
-│  │ Compaction threshold: [85 %]                              │  │
-│  │   Compact context when usage exceeds this percentage.     │  │
-│  │                                                           │  │
-│  │ ─────────────────────────────────────────────────────────│  │
-│  │ Retry Behavior                                            │  │
-│  │ Max attempts: [3 ▼]                                       │  │
-│  │   Maximum retry attempts for failed API requests.         │  │
-│  │                                                           │  │
-│  │ Backoff delay: [1000 ms]                                  │  │
-│  │   Initial delay before retry (exponential backoff).       │  │
-│  └───────────────────────────────────────────────────────────┘  │
-│                                                                 │
-│  ▶ Advanced                                                    │
-│  ┌───────────────────────────────────────────────────────────┐  │
-│  │ Custom agents directory: [.texra/agents       ] [Browse]  │  │
-│  └───────────────────────────────────────────────────────────┘  │
-│                                                                 │
-└─────────────────────────────────────────────────────────────────┘
-```
-
-**Custom Agent Actions:**
-
-- `[Source Code]` - Opens agent YAML file in editor
-- `[Delete]` - Deletes custom agent YAML file
-
-**Note:** Agent creation wizard and form-based editing are deferred to Future Scope.
-
-**Settings Mapping:**
-| UI Element | VS Code Setting |
-|------------|-----------------|
-| Auto-show remote agents | `texra.remoteAgents.autoShow` |
-| Storage mode dropdown | `texra.agentOutputs.storageMode` |
-| Require approval checkbox | `texra.toolUse.requireEditApproval` |
-| Persist sessions checkbox | `texra.toolUse.persistence.enabled` |
-| Session retention dropdown | `texra.toolUse.persistence.ttlHours` |
-| Compaction threshold | `texra.model.compactionThresholdPercent` |
-| Max attempts | `texra.model.retry.maxAttempts` |
-| Backoff delay | `texra.model.retry.backoffMs` |
-| Custom agents directory | `texra.explorer.agentsDirectory` (Advanced collapsible) |
-
-**Storage:** `workspaceState.enabledAgents: string[]`, VS Code configuration for settings
-
----
-
-### LaTeX Tab
-
-**Purpose:** Configure LaTeX formatting, latexdiff, and TikZ compilation settings.
-
-**Design Philosophy:** Consolidate scattered LaTeX-related VS Code settings into a visual, grouped interface. Settings remain in VS Code configuration for backwards compatibility.
-
-**Layout:**
-
-```
-┌─────────────────────────────────────────────────────────────────┐
-│  Configure LaTeX formatting and processing options.             │
-│                                                                 │
-│  FORMATTER                                                     │
-│  ─────────────────────────────────────────────────────────────  │
-│                                                                 │
-│  Formatter:  [latexindent ▼]                                   │
-│              Options: latexindent, texfmt, none                 │
-│                                                                 │
-│  Config file (optional):                                       │
-│  ┌───────────────────────────────────────────────────────────┐  │
-│  │ /path/to/latexindent.yaml                       [Browse]  │  │
-│  └───────────────────────────────────────────────────────────┘  │
-│                                                                 │
-│  ☑ Show warning if latexindent is not installed                │
-│                                                                 │
-│  ─────────────────────────────────────────────────────────────  │
-│                                                                 │
-│  LATEXDIFF                                                     │
-│  ─────────────────────────────────────────────────────────────  │
-│                                                                 │
-│  Timeout: [30000 ms ▼]                                         │
-│                                                                 │
-│  Math markup:  [fine ▼]                                        │
-│                Options: off, whole, coarse, fine                │
-│                                                                 │
-│  Picture environments (regex):                                 │
-│  ┌───────────────────────────────────────────────────────────┐  │
-│  │ (?:picture|tikzpicture|scope|DIFnomarkup)[\w\d*@]*        │  │
-│  └───────────────────────────────────────────────────────────┘  │
-│                                                                 │
-│  ☐ Generate diffs between rounds (multi-round agents)          │
-│                                                                 │
-│  ─────────────────────────────────────────────────────────────  │
-│                                                                 │
-│  TIKZ FIGURES                                                  │
-│  ─────────────────────────────────────────────────────────────  │
-│                                                                 │
-│  Extra input directory (TEXINPUTS):                            │
-│  ┌───────────────────────────────────────────────────────────┐  │
-│  │ /path/to/tikz/inputs                            [Browse]  │  │
-│  └───────────────────────────────────────────────────────────┘  │
-│                                                                 │
-│  ☑ Include workspace root in TEXINPUTS                         │
-│                                                                 │
-│  ▶ TikZ template (advanced)                                    │
-│                                                                 │
-│  ─────────────────────────────────────────────────────────────  │
-│                                                                 │
-│  REPLACEMENTS                                                  │
-│  ─────────────────────────────────────────────────────────────  │
-│                                                                 │
-│  ☑ Wrap critique in align environment                          │
-│                                                                 │
-│  Enabled replacement categories:                               │
-│  ☑ latex_spacing      ☑ latex_forbidden_commands               │
-│  ☑ latex_xml          ☑ latex_document                         │
-│  ☐ latexdiff                                                   │
-│                                                                 │
-│  Enabled regex replacements:                                   │
-│  ☑ latexdiff_markup   ☐ (others)                               │
-│                                                                 │
-│  ▶ Custom replacements (advanced)                              │
-│                                                                 │
-└─────────────────────────────────────────────────────────────────┘
-```
-
-**Settings Mapping:**
-| UI Element | VS Code Setting |
-|------------|-----------------|
-| Formatter dropdown | `texra.latex.formatter` |
-| Config file path | `texra.latex.latexindentConfig` / `texra.latex.texfmtConfig` |
-| Show warning checkbox | `texra.latex.showLatexindentWarning` |
-| Timeout | `texra.latexdiff.timeoutMs` |
-| Math markup | `texra.latexdiff.mathMarkup` |
-| Picture environments | `texra.latexdiff.pictureEnvironments` |
-| Generate between-round diffs | `texra.latexdiff.generateBetweenRoundDiffs` |
-| TikZ input directory | `texra.latex.tikzInputDirectory` |
-| Include workspace | `texra.latex.includeWorkspaceInTexinputs` |
-| TikZ template | `texra.latex.tikzTemplate` |
-| Wrap critique | `texra.latex.wrapCritiqueInAlign` |
-| Replacement categories | `texra.latex.enabledReplacements` |
-| Regex replacements | `texra.latex.enabledReplacementsRegex` |
-| Custom replacements | `texra.latex.customReplacements` / `texra.latex.customReplacementsRegex` |
-
-**Storage:** VS Code configuration (`texra.latex.*`, `texra.latexdiff.*`)
-
-**Note:** Unlike other tabs that use globalState/workspaceState, LaTeX settings remain in VS Code configuration for backwards compatibility and to allow users to configure via settings.json if preferred.
-
----
-
-### Memory Tab
-
-**Purpose:** Browse and manage persistent memory files created by tool-use agents.
-
-**Note:** Tool-use settings (edit approval, session persistence) are in the Agents tab under Tool-Use Settings collapsible.
-
-**Key Design:** Show memory content on expand (like current memoryView implementation).
-
-**Layout:**
-
-```
-┌─────────────────────────────────────────────────────────────────┐
-│  Memory                                                         │
-│  ─────────────────────────────────────────────────────────────  │
-│  Memory files created by tool-use agents.                       │
-│                                                                 │
-│  MEMORY FILES                                     [Refresh]    │
-│  ─────────────────────────────────────────────────────────────  │
-│  Agent-created memory files stored in /memories                 │
-│                                                                 │
-│  ▼ 📄 project-notes.md           12 KB    Jan 11, 2:34 PM      │
-│  ┌───────────────────────────────────────────────────────────┐  │
-│  │ # Project Notes                                           │  │
-│  │                                                           │  │
-│  │ ## Key Decisions                                          │  │
-│  │ - Using XYZ framework for...                              │  │
-│  │ - Architecture follows...                                 │  │
-│  │                                        [View Full] [Delete]│  │
-│  └───────────────────────────────────────────────────────────┘  │
-│                                                                 │
-│  ▶ 📄 research-findings.md       8 KB     Jan 10, 4:12 PM      │
-│                                                                 │
-│  ▶ 📄 citations.bib              2 KB     Jan 9, 3:00 PM       │
-│                                                                 │
-│  ▶ 📁 figures/                   3 files  Jan 9, 11:00 AM      │
-│                                                                 │
-│  ─────────────────────────────────────────────────────────────  │
-│  Total: 5 files, 24 KB                        [Clear All]      │
-│                                                                 │
-└─────────────────────────────────────────────────────────────────┘
-```
-
-**Features:** (Migrated from memoryView)
-
-- Memory file browser with expandable content preview
-- Click file to expand and show content preview (first ~20 lines)
-- [View Full] opens file in editor
-- [Delete] removes file
-- Directory browsing (2-level deep)
-- Storage usage display
-
-**Data Sources:**
-
-- Memory files: `/memories` directory managed by MemoryTool
-
-**Storage:** File system (no extension state needed)
-
----
-
-### History Tab
-
-**Purpose:** Browse and restore previous agent executions.
-
-**Layout:** (Migrated from existing historyView)
-
-```
-┌─────────────────────────────────────────────────────────────────┐
-│  ┌──────────────────────────────────────────────────────────┐   │
-│  │ 🔍 Search history items...            [◀] [▶] 3 matches  │   │
-│  └──────────────────────────────────────────────────────────┘   │
-│                                                                 │
-│  [Clear All History]                                           │
-│                                                                 │
-│  ┌───────────────────────────────────────────────────────────┐  │
-│  │ Jan 11, 2026 2:34 PM              [🗑] [↩ Restore] [▶ Run]│  │
-│  │ Agent: correct • Model: sonnet45T                         │  │
-│  │ Input: paper.tex • Output: paper_corrected.tex            │  │
-│  │ ▶ Show details                                            │  │
-│  └───────────────────────────────────────────────────────────┘  │
-│                                                                 │
-│  ┌───────────────────────────────────────────────────────────┐  │
-│  │ Jan 11, 2026 1:15 PM              [🗑] [↩ Restore] [▶ Run]│  │
-│  │ Agent: polish • Model: gpt52                              │  │
-│  │ ...                                                       │  │
-│  └───────────────────────────────────────────────────────────┘  │
-│                                                                 │
-└─────────────────────────────────────────────────────────────────┘
-```
-
-**Features:** (Same as current historyView)
-
-- Search with highlighting (mark.js)
-- Delete, Restore, Rerun actions
-- Collapsible details per item
-
-**Storage:** Existing history storage mechanism
-
----
-
-### Provider Configuration Modal (from Models Tab)
-
-When clicking [Edit] or [Configure] on a provider:
-
-**Standard Provider (Anthropic, OpenAI, Google, etc.):**
-
-```
-┌─────────────────────────────────────────────────────────────────┐
-│  Configure Anthropic                                     [×]   │
-├─────────────────────────────────────────────────────────────────┤
-│                                                                 │
-│  API Key                                                       │
-│  ┌───────────────────────────────────────────────────────────┐  │
-│  │ sk-ant-api03-●●●●●●●●●●●●●●●●●●●●            [👁] [Clear] │  │
-│  └───────────────────────────────────────────────────────────┘  │
-│  Get your key at: console.anthropic.com                        │
-│                                                                 │
-│  ─────────────────────────────────────────────────────────────  │
-│                                                                 │
-│  Alternative: Environment Variable                             │
-│  Set ANTHROPIC_API_KEY in your environment or .env file        │
-│                                                                 │
-│  ─────────────────────────────────────────────────────────────  │
-│                                                                 │
-│  ▶ Advanced Options                                            │
-│  ┌───────────────────────────────────────────────────────────┐  │
-│  │ Custom Endpoint (optional)                                │  │
-│  │ ┌─────────────────────────────────────────────────────┐   │  │
-│  │ │                                                     │   │  │
-│  │ └─────────────────────────────────────────────────────┘   │  │
-│  │ Leave empty for default (api.anthropic.com)               │  │
-│  │ Use for: proxies, Azure OpenAI, self-hosted models        │  │
-│  │                                                           │  │
-│  │ ☑ Enable streaming                                        │  │
-│  │   Stream responses in real-time for this provider.        │  │
-│  │   Disable if experiencing issues with proxies.            │  │
-│  └───────────────────────────────────────────────────────────┘  │
-│                                                                 │
-│  ─────────────────────────────────────────────────────────────  │
-│                                            [Cancel]   [Save]   │
-└─────────────────────────────────────────────────────────────────┘
-```
-
-**Streaming Settings (per provider):**
-Each provider's modal streaming toggle maps to its specific setting:
-
-| Provider Modal    | VS Code Setting                      |
-| ----------------- | ------------------------------------ |
-| Anthropic         | `texra.model.useStreamingAnthropic`  |
-| OpenAI            | `texra.model.useStreamingOpenai`     |
-| Google            | `texra.model.useStreamingGoogle`     |
-| DeepSeek          | `texra.model.useStreamingDeepseek`   |
-| xAI               | `texra.model.useStreamingXai`        |
-| Moonshot          | `texra.model.useStreamingMoonshot`   |
-| Dashscope         | `texra.model.useStreamingDashscope`  |
-| OpenRouter        | `texra.model.useStreamingOpenrouter` |
-| (Global fallback) | `texra.model.useStreaming`           |
-
-Per-provider settings override the global `useStreaming` setting.
-
-**OpenRouter (Special Case):**
-
-```
-┌─────────────────────────────────────────────────────────────────┐
-│  Configure OpenRouter                                    [×]   │
-├─────────────────────────────────────────────────────────────────┤
-│                                                                 │
-│  OpenRouter provides access to 200+ AI models from multiple    │
-│  providers through a single API key and unified billing.       │
-│                                                                 │
-│  API Key                                                       │
-│  ┌───────────────────────────────────────────────────────────┐  │
-│  │ sk-or-v1-●●●●●●●●●●●●●●●●●●●●●●●●            [👁] [Clear] │  │
-│  └───────────────────────────────────────────────────────────┘  │
-│  Get your key at: openrouter.ai/keys                           │
-│                                                                 │
-│  ─────────────────────────────────────────────────────────────  │
-│                                                                 │
-│  Routing Mode                                                  │
-│  ─────────────────────────────────────────────────────────────  │
-│                                                                 │
-│  ● OpenRouter-only models                                      │
-│    Only use OpenRouter for models that require it              │
-│    (marked with 🔀 in model list)                              │
-│                                                                 │
-│  ○ Route ALL models through OpenRouter                         │
-│    Use OpenRouter for every model request                      │
-│    Benefits: unified billing, usage tracking, fallbacks        │
-│    Note: Slightly higher latency, OpenRouter pricing applies   │
-│                                                                 │
-│  ─────────────────────────────────────────────────────────────  │
-│                                            [Cancel]   [Save]   │
-└─────────────────────────────────────────────────────────────────┘
-```
-
-**Settings mapping:**
-| UI Element | VS Code Setting |
-|------------|-----------------|
-| API Key | SecretStorage `openrouter` |
-| Routing Mode | `texra.model.useOpenRouter` (boolean: false = only required, true = all models) |
-
----
-
-### Provider Status Indicators
-
-In the Models tab, show provider/routing status on each model:
-
-```
-┌───────────────────────────────────────────────────────────────┐
-│ ☑ Claude Sonnet 4.5 T    $3/$15   200K   🧠👁  ✓ Ready       │  ← Key configured
-│ ☑ GPT-5.2                $2/$10   256K   🧠👁  ✓ Ready       │
-│ ☐ Gemini 3 Pro           $1.25/$5 1M     🧠👁  ⚠ No key      │  ← Missing key
-│ ☑ Llama 3 405B           $0.90/$0 128K   🧠    🔀 OpenRouter │  ← OpenRouter only
-└───────────────────────────────────────────────────────────────┘
-```
-
-**Status Icons:**
-
-- `✓ Ready` - API key configured, model available
-- `⚠ No key` - Provider not configured (click to configure)
-- `🔀 OpenRouter` - Available via OpenRouter only
-- `🔒 Premium` - Requires subscription tier (if using included access)
-
----
-
-### Advanced Tab (DEFERRED TO FUTURE RELEASE)
-
-> **Note:** This tab is not included in v1. Specifications kept for future reference.
-
-**Purpose:** Multi-agent settings, UI preferences, retry behavior, system paths, and developer options. Uses vscode-collapsible for organization.
-
-**Layout:**
-
-```
-┌─────────────────────────────────────────────────────────────────┐
-│  Advanced settings and system configuration.                    │
-│                                                                 │
-│  ▼ Multi-Agent                                                 │
-│  ┌───────────────────────────────────────────────────────────┐  │
-│  │ Configure multi-agent operations and ensemble runs.       │  │
-│  │                                                           │  │
-│  │ Default merge model: [Claude Sonnet 4.5 ▼]                │  │
-│  │   Model used for combining outputs from multiple agents.  │  │
-│  │                                                           │  │
-│  │ ─────────────────────────────────────────────────────────│  │
-│  │ COMING SOON                                               │  │
-│  │ • Ensemble runs across multiple models                    │  │
-│  │ • Agent pipeline configurations                           │  │
-│  │ • Output voting and consensus                             │  │
-│  └───────────────────────────────────────────────────────────┘  │
-│                                                                 │
-│  ▼ UI Preferences                                              │
-│  ┌───────────────────────────────────────────────────────────┐  │
-│  │ General interface preferences.                            │  │
-│  │                                                           │  │
-│  │ ☑ Show API key reminders                                  │  │
-│  │   Show reminders when API keys are missing.               │  │
-│  │                                                           │  │
-│  │ ☑ Show dependency reminders                               │  │
-│  │   Show reminders for missing dependencies (latexindent).  │  │
-│  │                                                           │  │
-│  │ ☑ Show login banner                                       │  │
-│  │   Show banner suggesting to sign in.                      │  │
-│  │                                                           │  │
-│  │ Max image dimension: [2048 ▼]                             │  │
-│  │   Larger images resized before sending to models.         │  │
-│  │   Options: 1024, 2048, 4096                               │  │
-│  │                                                           │  │
-│  │ Progress board sort: [Timestamp descending ▼]             │  │
-│  │   Options: Timestamp ascending, Timestamp descending      │  │
-│  └───────────────────────────────────────────────────────────┘  │
-│                                                                 │
-│  ▶ Git Integration                                             │
-│  ┌───────────────────────────────────────────────────────────┐  │
-│  │ Commits to show: [50 ▼]                                   │  │
-│  └───────────────────────────────────────────────────────────┘  │
-│                                                                 │
-│  ▶ System Paths                                                │
-│  ┌───────────────────────────────────────────────────────────┐  │
-│  │ Sox audio path: [/usr/bin/sox            ] [Browse]       │  │
-│  └───────────────────────────────────────────────────────────┘  │
-│                                                                 │
-│  ▶ Debug (Developer)                                           │
-│  ┌───────────────────────────────────────────────────────────┐  │
-│  │ ☐ Enable debug logging                                    │  │
-│  │ ☐ Enable verbose output                                   │  │
-│  └───────────────────────────────────────────────────────────┘  │
-│                                                                 │
-└─────────────────────────────────────────────────────────────────┘
-```
-
-**Settings Mapping:**
-| UI Element | VS Code Setting |
-|------------|-----------------|
-| Default merge model | `texra.merge.defaultModel` |
-| Show API key reminders | `texra.ui.showApiKeyReminders` |
-| Show dependency reminders | `texra.ui.showDependencyReminders` |
-| Show login banner | `texra.ui.showLoginBanner` |
-| Max image dimension | `texra.maxImageDimension` |
-| Progress board sort | `texra.progressBoard.streamSortOrder` |
-| Commits to show | `texra.git.numberOfCommitsToShow` |
-| Sox audio path | `texra.audio.soxPath` |
-| Debug mode | `texra.logger.debugMode` |
-| Save debug objects | `texra.debug.saveDebugObjects` |
-| Save input prompt | `texra.debug.saveInputPrompt` |
-
-**Storage:** VS Code configuration (backwards compatible)
-
-**Note:** Multi-Agent is included now, but ensemble features are awaiting multi-agent feature maturity. Retry settings are in the Agents tab (Tool-Use Settings).
-
----
-
-### Features Summary
-
-**Tab Layout with Header Bar (v1 - 5 tabs):**
-
-- **Header Bar** - Account info, sign in/out, manage account (always visible)
-- **Models Tab** - Provider configuration, model selection, routing options
-- **Agents Tab** - Agent list, Workflow Settings (collapsible), Tool-Use Settings (collapsible)
-- **LaTeX Tab** - Formatter, latexdiff, TikZ (all as collapsibles)
-- **Memory Tab** - Memory file browser with expandable content preview
-- **History Tab** - Execution history browser
-
-**Deferred to Later Release:**
-
-- **Advanced Tab** - Multi-Agent, UI preferences, git, system paths, debug (all collapsibles)
-
-**Key Features:**
-
-- Account info in header bar (minimal custom CSS, always visible)
-- Native vscode-tabs for navigation (no custom styling)
-- vscode-collapsible for subsections within tabs
-- Per-provider configuration in Models tab
-- Provider modal with API key + custom endpoint + streaming toggle
-- OpenRouter special configuration (routing mode)
-- Global routing options (direct/OpenRouter/proxy)
-- Environment variable hints
-
-**Key UX Improvements:**
-
-1. **Works without login** - Configure API keys without account
-2. **Visual provider status** - See which providers are configured at a glance
-3. **Custom endpoints exposed** - No more hidden VS Code settings
-4. **OpenRouter simplified** - Clear explanation and routing options
-5. **Model availability feedback** - See which models are ready in Models tab
-6. **Minimal custom CSS** - Only header bar needs styling, tabs and collapsibles are native
-
----
-
-## State Management
-
-### VS Code Configuration (Primary)
-
-Settings View reads/writes directly to VS Code configuration using `ConfigurationTarget`:
-
-```typescript
-const config = vscode.workspace.getConfiguration('texra');
-
-// Global settings (user-level, all workspaces)
-await config.update('models', enabledModels, ConfigurationTarget.Global);
-await config.update('maxImageDimension', 2048, ConfigurationTarget.Global);
-
-// Workspace settings (project-level, .vscode/settings.json)
-await config.update('agents', enabledAgents, ConfigurationTarget.Workspace);
-await config.update(
-  'agentOutputs.storageMode',
-  'folder',
-  ConfigurationTarget.Workspace,
-);
-```
-
-**Setting Scopes:**
-| Setting | ConfigurationTarget | Reason |
-|---------|---------------------|--------|
-| `texra.models` | Global | Same models everywhere |
-| `texra.maxImageDimension` | Global | User preference |
-| Provider endpoints | Global | Same API setup everywhere |
-| `texra.agents` | Workspace | Different projects need different agents |
-| `texra.agentOutputs.storageMode` | Workspace | Project-specific output location |
-| `texra.toolUse.*` | Global | Consistent behavior |
-| `texra.latex.*` | Global/Workspace | User choice |
-
-**Benefits of VS Code Config:**
-
-- No extension state migration needed
-- Works with VS Code Settings Sync automatically
-- Users can still edit settings.json directly
-- Respects VS Code conventions
-
-### Extension State (Minimal)
-
-Only for caching and truly ephemeral UI state:
-
-```typescript
-// globalState - only for caching
-context.globalState.get('modelMetadataCache'); // Cached llm-zoo data
-
-// No settings stored in extension state
-```
-
-### Secret Storage (`context.secrets`)
-
-Secure credential storage (VS Code SecretStorage API).
-
-```typescript
-// Keys stored in secrets (unchanged from current implementation)
-// apiKey.anthropic
-// apiKey.openai
-// apiKey.google
-// apiKey.openRouter
-// apiKey.deepseek
-// apiKey.xai
-// apiKey.moonshot
-// apiKey.dashscope
-
-// Access via SecretManager
-SecretManager.getApiKey('anthropic');
-SecretManager.setApiKey('anthropic', 'sk-...');
-SecretManager.deleteApiKey('anthropic');
-```
-
-### Environment Variable Fallback
-
-API keys can also be set via environment variables (existing behavior):
-
-```bash
-# In shell or .env file
-ANTHROPIC_API_KEY=sk-ant-...
-OPENAI_API_KEY=sk-...
-GOOGLE_API_KEY=...
-OPENROUTER_API_KEY=sk-or-...
-DEEPSEEK_API_KEY=...
-XAI_API_KEY=...
-```
-
-**Priority order:**
-
-1. VS Code Secrets (highest)
-2. Environment variables
-3. `.env` file in workspace
-
-### Defaults (Hardcoded)
-
-```typescript
-const RECOMMENDED_MODELS = [
-  'sonnet45T',
-  'opus45T',
-  'gpt52',
-  'gemini3p',
-  'grok4',
-  'deepseekT',
-  'kimi2T',
-  'qwen3max',
-];
-
-const DEFAULT_ENABLED_MODELS = [
-  'sonnet45T',
-  'opus45T',
-  'gpt52',
-  'gpt52pro',
-  'gpt41',
-  'gemini3p',
-  'gemini3f',
-  'grok4',
-  'deepseekT',
-  'kimi2T',
-  'kimi2',
-  'qwen3max',
-];
-
-const DEFAULT_ENABLED_AGENTS = [
-  'ask',
-  'chat',
-  'correct',
-  'draw',
-  'ocr',
-  'paper2slide',
-  'paper2poster',
-  'polish',
-  'research',
-  'search',
-];
-
-const DEFAULT_ROUTING = {
-  mode: 'direct',
-  openRouterMode: 'exclusive',
-};
-
-// Provider metadata (for display)
-const PROVIDERS = {
-  anthropic: {
-    name: 'Anthropic',
-    keyUrl: 'https://console.anthropic.com/settings/keys',
-    envVar: 'ANTHROPIC_API_KEY',
-    defaultEndpoint: 'https://api.anthropic.com',
-  },
-  openai: {
-    name: 'OpenAI',
-    keyUrl: 'https://platform.openai.com/api-keys',
-    envVar: 'OPENAI_API_KEY',
-    defaultEndpoint: 'https://api.openai.com/v1',
-  },
-  google: {
-    name: 'Google',
-    keyUrl: 'https://aistudio.google.com/apikey',
-    envVar: 'GOOGLE_API_KEY',
-    defaultEndpoint: 'https://generativelanguage.googleapis.com',
-  },
-  openRouter: {
-    name: 'OpenRouter',
-    keyUrl: 'https://openrouter.ai/keys',
-    envVar: 'OPENROUTER_API_KEY',
-    defaultEndpoint: 'https://openrouter.ai/api/v1',
-    description: 'Access 200+ models with a single API key',
-  },
-  deepseek: {
-    name: 'DeepSeek',
-    keyUrl: 'https://platform.deepseek.com/api_keys',
-    envVar: 'DEEPSEEK_API_KEY',
-    defaultEndpoint: 'https://api.deepseek.com',
-  },
-  xai: {
-    name: 'xAI (Grok)',
-    keyUrl: 'https://console.x.ai',
-    envVar: 'XAI_API_KEY',
-    defaultEndpoint: 'https://api.x.ai/v1',
-  },
-  moonshot: {
-    name: 'Moonshot (Kimi)',
-    keyUrl: 'https://platform.moonshot.cn/console/api-keys',
-    envVar: 'MOONSHOT_API_KEY',
-    defaultEndpoint: 'https://api.moonshot.cn/v1',
-  },
-  dashscope: {
-    name: 'DashScope (Qwen)',
-    keyUrl: 'https://dashscope.console.aliyun.com/apiKey',
-    envVar: 'DASHSCOPE_API_KEY',
-    defaultEndpoint: 'https://dashscope-intl.aliyuncs.com/compatible-mode/v1',
-  },
-};
-```
-
----
-
-## Migration Plan
-
-### Critical: API Keys Storage - NO CHANGE
-
-**API keys remain in VS Code SecretStorage.** This is non-negotiable:
-
-```typescript
-// UNCHANGED - Keys stay in VS Code Secrets
-context.secrets.get('apiKey.anthropic');
-context.secrets.store('apiKey.anthropic', 'sk-...');
-
-// Environment variable fallback also unchanged
-process.env.ANTHROPIC_API_KEY;
-```
-
-Users who have configured API keys will continue to work without any action.
-
----
-
-### No Migration Needed
-
-Since Settings View reads/writes directly to VS Code configuration:
-
-1. **Existing settings.json configurations continue to work unchanged**
-2. **No extension state migration required**
-3. **Settings View is just a GUI wrapper around existing VS Code settings**
-
-```typescript
-// Settings View simply reads and writes VS Code config
-const config = vscode.workspace.getConfiguration('texra');
-
-// Read
-const models = config.get<string[]>('models');
-
-// Write with appropriate scope
-await config.update('models', newModels, ConfigurationTarget.Global);
-await config.update('agents', newAgents, ConfigurationTarget.Workspace);
-```
-
 ---
 
 ## Architecture
+
+### Technology Stack
+
+The Settings View follows the established webview patterns in this codebase:
+
+| Layer | Technology | Notes |
+|-------|------------|-------|
+| **UI Components** | VS Code Elements (`@vscode-elements/elements`) | Native VS Code styling |
+| **Frontend JS** | Vanilla ES6 modules | No framework (no Lit, no React) |
+| **State Management** | WebviewStateManager + VS Code API | `vscode.getState()`/`setState()` |
+| **Validation** | Zod schemas | Type-safe message validation |
+| **Styling** | CSS with VS Code theme variables | Codicons for icons |
+
+### Three-Layer Architecture
+
+The webview architecture follows a three-layer pattern with clear separation of concerns:
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                        Extension Host (TypeScript)                   │
+├─────────────────────────────────────────────────────────────────────┤
+│                                                                     │
+│  SettingsViewProvider (extends BaseWebviewProvider)                 │
+│  ├── Lifecycle: resolveWebviewView(), createOrShowPanel()           │
+│  ├── HTML assignment and message routing                            │
+│  └── Disposable management                                          │
+│                                                                     │
+│  SettingsViewContentProvider (extends BaseViewContentProvider)      │
+│  ├── HTML generation with module bundling                           │
+│  ├── URI mapping for JS/CSS modules                                 │
+│  └── CSP nonce generation                                           │
+│                                                                     │
+│  SettingsViewMessageHandler (extends BaseViewMessageHandler)        │
+│  ├── Command routing (createHandlers())                             │
+│  ├── Zod validation (withValidatedMessage())                        │
+│  └── Backend service calls                                          │
+│                                                                     │
+├─────────────────────────────────────────────────────────────────────┤
+│                        Webview (JavaScript)                          │
+├─────────────────────────────────────────────────────────────────────┤
+│                                                                     │
+│  settingsViewState.js (extends WebviewStateManager pattern)         │
+│  ├── State persistence via VS Code API                              │
+│  └── Getter/setter with auto-save                                   │
+│                                                                     │
+│  SettingsViewMessageHandler.js (extends BaseWebviewMessageHandler)  │
+│  ├── Message listener registration                                  │
+│  └── Command → handler routing                                      │
+│                                                                     │
+│  SettingsViewDomHandler.js (extends BaseDomHandler)                 │
+│  ├── Composes UI managers as properties                             │
+│  ├── Listener tracking for cleanup                                  │
+│  └── Cascading dispose()                                            │
+│                                                                     │
+│  Tab UI Managers (ES6 classes)                                      │
+│  ├── ModelsTab.js, AgentsTab.js, LatexTab.js, etc.                  │
+│  ├── Template-based rendering                                       │
+│  └── Event listener management                                      │
+│                                                                     │
+└─────────────────────────────────────────────────────────────────────┘
+```
 
 ### File Structure
 
 ```
 src/
 ├── settingsView/                    # NEW - Unified settings view
-│   ├── SettingsViewProvider.ts      # WebviewViewProvider
-│   ├── SettingsViewMessageHandler.ts
-│   ├── SettingsViewContentProvider.ts
+│   ├── SettingsViewProvider.ts      # Extends BaseWebviewProvider
+│   ├── SettingsViewMessageHandler.ts # Extends BaseViewMessageHandler
+│   ├── SettingsViewContentProvider.ts # Extends BaseViewContentProvider
+│   ├── schemas.ts                   # Zod schemas for messages
 │   ├── index.html                   # Header bar + vscode-tabs layout
-│   ├── styles.css                   # Minimal CSS (header bar only)
+│   ├── styles/
+│   │   └── index.css                # Minimal CSS (header bar only)
 │   └── modules/
-│       ├── main.js                  # Entry point
-│       ├── messageHandlers.js
-│       ├── settingsViewState.js
-│       ├── headerBar.js             # Account header bar logic
+│       ├── script.js                # Entry point, initialization
+│       ├── settingsViewState.js     # WebviewStateManager wrapper
+│       ├── messageHandlers.js       # BaseWebviewMessageHandler extension
+│       ├── domHandlers.js           # BaseDomHandler composition
+│       ├── constants.js             # Element IDs, class names
 │       ├── tabs/                    # Tab content modules (v1)
 │       │   ├── ModelsTab.js         # Models + providers + routing
 │       │   ├── AgentsTab.js         # Agents + collapsible settings
@@ -1238,80 +253,163 @@ src/
 │       │   └── HistoryTab.js        # History (migrated)
 │       │   # AdvancedTab.js - deferred to future release
 │       └── uiManagers/
+│           ├── HeaderBar.js         # Account header bar
 │           ├── ModelListRenderer.js
 │           ├── ProviderRenderer.js
 │           ├── AgentListRenderer.js
-│           ├── LatexSettingsRenderer.js
-│           ├── MemoryRenderer.js    # From memoryView
 │           └── HistoryRenderer.js   # From historyView
+│
+├── common/
+│   ├── webview/                     # Base classes (TypeScript)
+│   │   ├── BaseWebviewProvider.ts   # Webview lifecycle
+│   │   ├── BaseViewContentProvider.ts # HTML generation
+│   │   ├── BaseViewMessageHandler.ts # Message routing + Zod validation
+│   │   ├── commands.ts              # Centralized command constants
+│   │   └── resourceRoots.ts         # Security resource roots
+│   ├── modules/                     # Shared frontend utilities (JavaScript)
+│   │   ├── BaseDomHandler.js        # Listener tracking, dispose pattern
+│   │   ├── BaseWebviewMessageHandler.js # Message handler base
+│   │   ├── webviewState.js          # WebviewStateManager
+│   │   ├── webviewContext.js        # registerMessageHandlers()
+│   │   ├── domUtils.js              # Safe DOM utilities
+│   │   └── ToggleStateStore.js      # Boolean state management
+│   └── styles/
+│       └── common.css               # Shared styles
 │
 ├── profileView/                     # DEPRECATED - merge into settingsView
 ├── historyView/                     # DEPRECATED - merge into settingsView
 ├── memoryView/                      # DEPRECATED - merge into settingsView
 ```
 
-### Commands
+### Base Class Hierarchy
 
-**File:** `src/commands/settings/settingsCommands.ts`
+#### Extension Host (TypeScript)
 
-Follow existing pattern from `historyCommands.ts`:
+**BaseWebviewProvider** (`src/common/webview/BaseWebviewProvider.ts`):
+- Orchestrates webview lifecycle
+- Handles HTML assignment via content provider
+- Routes messages via message handler
+- Manages disposables (extension-lifetime and view-lifetime)
 
 ```typescript
-// src/commands/settings/settingsCommands.ts
-import * as vscode from 'vscode';
-import { SettingsViewProvider } from '@settingsView/SettingsViewProvider';
-import type { SettingsTab } from '@settingsView/schemas';
+export abstract class BaseWebviewProvider {
+  protected _view?: vscode.WebviewView;
+  protected abstract contentProvider: BaseViewContentProvider;
+  protected abstract messageHandler: BaseViewMessageHandler;
 
-export const settingsCommands = {
-  openSettings: 'texra.openSettings',
-  openModelSettings: 'texra.openModelSettings',
-  openAgentSettings: 'texra.openAgentSettings',
-  openLatexSettings: 'texra.openLatexSettings',
-} as const;
+  // Called by VS Code when view becomes visible
+  resolveWebviewView(webviewView: vscode.WebviewView): void;
 
-export function registerSettingsCommands(context: vscode.ExtensionContext) {
-  const settingsViewProvider = new SettingsViewProvider(context);
-
-  context.subscriptions.push(
-    vscode.commands.registerCommand(
-      settingsCommands.openSettings,
-      async (tab?: SettingsTab) => {
-        await settingsViewProvider.show();
-        if (tab) settingsViewProvider.selectTab(tab);
-      },
-    ),
-    vscode.commands.registerCommand(settingsCommands.openModelSettings, () =>
-      vscode.commands.executeCommand(settingsCommands.openSettings, 'models'),
-    ),
-    vscode.commands.registerCommand(settingsCommands.openAgentSettings, () =>
-      vscode.commands.executeCommand(settingsCommands.openSettings, 'agents'),
-    ),
-    vscode.commands.registerCommand(settingsCommands.openLatexSettings, () =>
-      vscode.commands.executeCommand(settingsCommands.openSettings, 'latex'),
-    ),
-  );
-
-  return { settingsViewProvider };
+  // For panel-based views (History, Settings)
+  createOrShowPanel(options: PanelOptions): boolean;
 }
 ```
 
-**Register in:** `src/commands/index.ts`
+**BaseViewContentProvider** (`src/common/webview/BaseViewContentProvider.ts`):
+- Generates complete HTML with module bundling
+- Maps module paths to webview URIs
+- Handles CSP nonce generation
 
-### Message Protocol (Zod-native)
+```typescript
+export abstract class BaseViewContentProvider {
+  // Module descriptor pattern for declaring dependencies
+  protected viewModules: ModuleDescriptor[];
+
+  // Returns complete HTML string
+  getHtmlContent(webview: vscode.Webview): string;
+
+  // Override for view-specific template variables
+  protected getTemplateVariables(): Record<string, string>;
+}
+```
+
+**BaseViewMessageHandler** (`src/common/webview/BaseViewMessageHandler.ts`):
+- Routes messages by command name
+- Provides Zod validation helper
+- Error handling and logging
+
+```typescript
+export abstract class BaseViewMessageHandler {
+  // Subclasses define their command handlers
+  protected abstract createHandlers(): Record<string, MessageHandler>;
+
+  // Validates message with Zod schema before handling
+  protected async withValidatedMessage<S extends z.ZodType>(
+    schema: S,
+    message: unknown,
+    messageName: string,
+    handler: (data: z.infer<S>) => Promise<void>
+  ): Promise<void>;
+}
+```
+
+#### Webview Frontend (JavaScript)
+
+**BaseDomHandler** (`src/common/modules/BaseDomHandler.js`):
+- Tracks event listeners for automatic cleanup
+- Composes child managers as properties
+- Cascading dispose pattern
+
+```javascript
+class BaseDomHandler {
+  constructor(managers = {}) {
+    this._listeners = [];      // Track all listeners
+    this._managers = managers; // Nested managers
+    Object.assign(this, managers); // Expose as properties
+  }
+
+  addListener(elementOrId, event, handler) {
+    // Tracks listener for later cleanup
+  }
+
+  dispose() {
+    // Cleans up all listeners AND nested managers
+  }
+}
+```
+
+**BaseWebviewMessageHandler** (`src/common/modules/BaseWebviewMessageHandler.js`):
+- Registers message listeners with webview context
+- Routes messages by command name
+- Cleanup on dispose
+
+```javascript
+class BaseWebviewMessageHandler {
+  constructor() {
+    this._disposeFn = null;
+    this._handlers = {};  // Command → handler map
+  }
+
+  setup() {
+    this._disposeFn = registerMessageHandlers(this._handlers);
+  }
+
+  dispose() {
+    this._disposeFn?.();
+  }
+}
+```
+
+**WebviewStateManager** (`src/common/modules/webviewState.js`):
+- Wraps VS Code's `getState()`/`setState()` APIs
+- Immutable state copies with spread operators
+- Methods: `getState()`, `setState()`, `update()`
+
+---
+
+## Message Protocol (Zod-native)
+
+### Schema Patterns
+
+Use Zod schemas as single source of truth. Follow existing patterns from `src/webview/types/messages.ts`.
 
 **File:** `src/settingsView/schemas.ts`
 
-Use Zod schemas as single source of truth. Reference existing types from the codebase.
-
 ```typescript
-// src/settingsView/schemas.ts
 import { z } from 'zod';
-import { ModelConfigSchema } from '@model/ModelConfig'; // From llm-zoo
-import { AgentSource } from '@agent/core/AgentDataclass'; // Zod enum
-import type { AgentEntry } from '@agent/index/agentRegistry'; // Existing interface
 
 // =============================================================================
-// Command Constants (following src/common/webview/commands.ts pattern)
+// Command Constants
 // =============================================================================
 
 export const SETTINGS_VIEW_COMMANDS = {
@@ -1332,7 +430,15 @@ export const SETTINGS_VIEW_COMMANDS = {
 } as const;
 
 // =============================================================================
-// Shared Schemas
+// Shared Base Schemas (composition pattern)
+// =============================================================================
+
+const BaseMessageSchema = z.object({
+  command: z.string(),
+});
+
+// =============================================================================
+// Tab and Settings Schemas
 // =============================================================================
 
 export const SettingsTabSchema = z.enum([
@@ -1350,28 +456,32 @@ export type SettingsTab = z.infer<typeof SettingsTabSchema>;
 
 export const SetModelsDataSchema = z.object({
   command: z.literal('SET_MODELS_DATA'),
-  models: z.array(ModelConfigSchema), // Use llm-zoo schema directly
+  models: z.array(z.object({
+    id: z.string(),
+    name: z.string(),
+    provider: z.string(),
+    contextWindow: z.number(),
+    inputCost: z.number(),
+    outputCost: z.number(),
+    capabilities: z.array(z.string()),
+  })),
   enabled: z.array(z.string()),
+  providerStatus: z.record(z.object({
+    hasKey: z.boolean(),
+    keySource: z.enum(['secret', 'env', 'none']),
+  })),
 });
 
 export const SetAgentsDataSchema = z.object({
   command: z.literal('SET_AGENTS_DATA'),
-  agents: z.array(
-    z.object({
-      // Mirrors AgentEntry + enabled flag
-      name: z.string(),
-      source: AgentSource,
-      category: z.enum(['workflow', 'toolUse']),
-      agentType: z.enum(['CoT', 'direct', 'toolUse']),
-      description: z.string().optional(),
-      enabled: z.boolean(),
-    }),
-  ),
-});
-
-export const SetLatexDataSchema = z.object({
-  command: z.literal('SET_LATEX_DATA'),
-  settings: z.record(z.unknown()), // VS Code config snapshot
+  agents: z.array(z.object({
+    name: z.string(),
+    source: z.enum(['builtIn', 'builtInToolUse', 'custom', 'remote']),
+    category: z.enum(['workflow', 'toolUse']),
+    agentType: z.enum(['CoT', 'direct', 'toolUse']),
+    description: z.string().optional(),
+    enabled: z.boolean(),
+  })),
 });
 
 export const SelectTabSchema = z.object({
@@ -1379,12 +489,11 @@ export const SelectTabSchema = z.object({
   tab: SettingsTabSchema,
 });
 
+// Discriminated union for type-safe message handling
 export const SettingsMessageSchema = z.discriminatedUnion('command', [
   SetModelsDataSchema,
   SetAgentsDataSchema,
-  SetLatexDataSchema,
   SelectTabSchema,
-  // History, Memory, Profile use existing view schemas
 ]);
 
 export type SettingsMessage = z.infer<typeof SettingsMessageSchema>;
@@ -1393,97 +502,442 @@ export type SettingsMessage = z.infer<typeof SettingsMessageSchema>;
 // Webview → Extension Actions
 // =============================================================================
 
+export const SaveEnabledModelsSchema = z.object({
+  command: z.literal('SAVE_ENABLED_MODELS'),
+  models: z.array(z.string()),
+});
+
+export const SaveEnabledAgentsSchema = z.object({
+  command: z.literal('SAVE_ENABLED_AGENTS'),
+  agents: z.array(z.string()),
+});
+
+export const SaveSettingSchema = z.object({
+  command: z.literal('SAVE_SETTING'),
+  key: z.string(),
+  value: z.unknown(),
+  scope: z.enum(['global', 'workspace']).optional(),
+});
+
+export const SetApiKeySchema = z.object({
+  command: z.literal('SET_API_KEY'),
+  provider: z.string(),
+  key: z.string(),
+});
+
 export const SettingsActionSchema = z.discriminatedUnion('command', [
   z.object({ command: z.literal('GET_INITIAL_DATA') }),
   z.object({ command: z.literal('TAB_CHANGED'), tab: SettingsTabSchema }),
-  z.object({
-    command: z.literal('SAVE_ENABLED_MODELS'),
-    models: z.array(z.string()),
-  }),
-  z.object({
-    command: z.literal('SAVE_ENABLED_AGENTS'),
-    agents: z.array(z.string()),
-  }),
-  z.object({
-    command: z.literal('SAVE_SETTING'),
-    key: z.string(),
-    value: z.unknown(),
-  }),
-  z.object({
-    command: z.literal('SET_API_KEY'),
-    provider: z.string(),
-    key: z.string(),
-  }),
+  SaveEnabledModelsSchema,
+  SaveEnabledAgentsSchema,
+  SaveSettingSchema,
+  SetApiKeySchema,
   z.object({ command: z.literal('SIGN_IN') }),
   z.object({ command: z.literal('SIGN_OUT') }),
-  // History/Memory actions reuse existing schemas
 ]);
 
 export type SettingsAction = z.infer<typeof SettingsActionSchema>;
 ```
 
-**Key points:**
+### Zod Patterns Summary
 
-- `ModelConfigSchema` from `@model/ModelConfig` (mirrors llm-zoo types)
-- `AgentSource` Zod enum from `@agent/core/AgentDataclass`
-- `AgentEntry` interface from `@agent/index/agentRegistry` (no duplication)
-- Use `z.discriminatedUnion` for type-safe message handling
+Follow these patterns from the existing codebase:
 
-### Agent Category Derivation
+| Pattern | Usage | Example |
+|---------|-------|---------|
+| **Schema Composition** | Reusable base schemas | `BaseMessageSchema.extend({ ... })` |
+| **`.extend()` + `.shape`** | Add fields while extending | `BaseSchema.extend(WithFilePath.shape)` |
+| **`.pick()`** | Select subset of fields | `FullSchema.pick({ field1: true })` |
+| **Type Inference** | `z.infer<typeof Schema>` | Single source of truth for types |
+| **Transform + Pipe** | Data transformation | `z.string().transform(s => s.trim()).pipe(z.string().min(1))` |
+| **Discriminated Unions** | Type-safe message routing | `z.discriminatedUnion('command', [...])` |
+| **`.prefault()`** | Defaults during parsing | `z.enum([...]).prefault('default')` |
+| **Safe Parsing** | Non-throwing validation | `schema.safeParse(data)` + callback |
 
-**Use existing functions - do NOT re-implement:**
+---
 
-```typescript
-// Settings View should call these existing functions:
-import {
-  getWorkflowAgents, // Returns AgentEntry[] with category already set
-  getToolUseAgents, // Returns AgentEntry[] with category already set
-  buildAgentOptions, // Returns HTML <option> elements (if needed)
-} from '@agent/index/agentRegistry';
+## Frontend Implementation Patterns
 
-// Category is already derived in AgentEntry - just use it
-const agents = [...getWorkflowAgents(), ...getToolUseAgents()];
+### ES6 Class + Singleton Pattern
+
+All frontend modules use ES6 classes with singleton exports:
+
+```javascript
+// settingsViewState.js
+import { WebviewStateManager } from '@common/modules/webviewState.js';
+
+class SettingsViewState {
+  constructor() {
+    this.stateManager = new WebviewStateManager();
+    this._activeTab = 'models';
+    this._enabledModels = [];
+  }
+
+  initialize() {
+    const saved = this.stateManager.getState();
+    this._activeTab = saved.activeTab ?? 'models';
+    this._enabledModels = saved.enabledModels ?? [];
+  }
+
+  get activeTab() { return this._activeTab; }
+  set activeTab(value) {
+    this._activeTab = value;
+    this.save();
+  }
+
+  save() {
+    this.stateManager.update({
+      activeTab: this._activeTab,
+      enabledModels: this._enabledModels,
+    });
+  }
+}
+
+export const settingsViewState = new SettingsViewState();
 ```
 
-**Implementation detail (for reference only):**
+### DOM Handler Composition
 
-- Local agents: category derived from `source === 'builtInToolUse' || agentType === 'toolUse'`
-- Remote agents: uses `agentCategory` field from remote definition
-- Config override: `texra.toolUseAgents` setting can override any agent
+Use BaseDomHandler for listener tracking and manager composition:
 
-**Note:** Local agent YAML files don't have an `agentCategory` field.
+```javascript
+// domHandlers.js
+import { BaseDomHandler } from '@common/modules/BaseDomHandler.js';
+import { HeaderBar } from './uiManagers/HeaderBar.js';
+import { ModelsTab } from './tabs/ModelsTab.js';
+import { AgentsTab } from './tabs/AgentsTab.js';
+import { settingsViewState } from './settingsViewState.js';
+
+class SettingsViewDomHandler extends BaseDomHandler {
+  constructor() {
+    const headerBar = new HeaderBar();
+    const modelsTab = new ModelsTab(settingsViewState);
+    const agentsTab = new AgentsTab(settingsViewState);
+
+    super({
+      headerBar,
+      modelsTab,
+      agentsTab,
+      // More tabs...
+    });
+  }
+
+  initializeUI() {
+    this.headerBar.render();
+    this.showTab(settingsViewState.activeTab);
+  }
+
+  showTab(tabName) {
+    // Hide all tabs, show selected
+    Object.values(this._managers).forEach(mgr => {
+      if (mgr.hide) mgr.hide();
+    });
+    this[tabName + 'Tab']?.show();
+  }
+}
+
+export const settingsViewDomHandler = new SettingsViewDomHandler();
+```
+
+### Tab Manager Pattern
+
+Each tab extends BaseDomHandler for listener cleanup:
+
+```javascript
+// tabs/ModelsTab.js
+import { BaseDomHandler } from '@common/modules/BaseDomHandler.js';
+import { safeGetElementById } from '@common/modules/domUtils.js';
+import { ELEMENT_IDS } from '../constants.js';
+
+export class ModelsTab extends BaseDomHandler {
+  constructor(state) {
+    super();
+    this.state = state;
+    this._container = null;
+  }
+
+  get container() {
+    if (!this._container) {
+      this._container = safeGetElementById(ELEMENT_IDS.MODELS_TAB);
+    }
+    return this._container;
+  }
+
+  render(data) {
+    this.container.innerHTML = `
+      <vscode-collapsible title="Recommended Models" open>
+        ${this.renderModelList(data.recommended)}
+      </vscode-collapsible>
+
+      ${data.providers.map(provider => `
+        <vscode-collapsible title="${provider.name} (${provider.models.length})">
+          <div class="provider-header">
+            ${this.renderProviderStatus(provider)}
+            <vscode-button appearance="secondary">Configure</vscode-button>
+          </div>
+          ${this.renderModelList(provider.models)}
+        </vscode-collapsible>
+      `).join('')}
+    `;
+    this.attachEventListeners();
+  }
+
+  renderModelList(models) {
+    return models.map(m => `
+      <vscode-checkbox id="model-${m.id}" ${m.enabled ? 'checked' : ''}>
+        ${m.name}
+        <span class="model-meta">${m.contextWindow}K • $${m.inputCost}/$${m.outputCost}</span>
+      </vscode-checkbox>
+    `).join('');
+  }
+
+  attachEventListeners() {
+    this.container.querySelectorAll('vscode-checkbox').forEach(cb => {
+      this.addListener(cb, 'change', () => this.handleModelToggle(cb));
+    });
+  }
+
+  handleModelToggle(checkbox) {
+    const modelId = checkbox.id.replace('model-', '');
+    vscode.postMessage({
+      command: 'SAVE_ENABLED_MODELS',
+      models: this.getEnabledModels(),
+    });
+  }
+
+  show() { this.container.style.display = 'block'; }
+  hide() { this.container.style.display = 'none'; }
+}
+```
+
+### Message Handler Pattern
+
+Frontend message handler extends base class:
+
+```javascript
+// messageHandlers.js
+import { BaseWebviewMessageHandler } from '@common/modules/BaseWebviewMessageHandler.js';
+import { SETTINGS_VIEW_COMMANDS } from './constants.js';
+import { settingsViewState } from './settingsViewState.js';
+import { settingsViewDomHandler } from './domHandlers.js';
+
+class SettingsViewMessageHandler extends BaseWebviewMessageHandler {
+  constructor() {
+    super();
+    this._handlers = {
+      [SETTINGS_VIEW_COMMANDS.SET_MODELS_DATA]: (m) => this.handleSetModelsData(m),
+      [SETTINGS_VIEW_COMMANDS.SET_AGENTS_DATA]: (m) => this.handleSetAgentsData(m),
+      [SETTINGS_VIEW_COMMANDS.SELECT_TAB]: (m) => this.handleSelectTab(m),
+    };
+  }
+
+  handleSetModelsData(message) {
+    settingsViewState.updateModels(message);
+    settingsViewDomHandler.modelsTab.render(message);
+  }
+
+  handleSetAgentsData(message) {
+    settingsViewState.updateAgents(message);
+    settingsViewDomHandler.agentsTab.render(message);
+  }
+
+  handleSelectTab(message) {
+    settingsViewState.activeTab = message.tab;
+    settingsViewDomHandler.showTab(message.tab);
+  }
+}
+
+export const messageHandler = new SettingsViewMessageHandler();
+```
+
+### Initialization Flow
+
+```javascript
+// script.js
+import { settingsViewState } from './modules/settingsViewState.js';
+import { settingsViewDomHandler } from './modules/domHandlers.js';
+import { messageHandler } from './modules/messageHandlers.js';
+import { SETTINGS_VIEW_COMMANDS } from './modules/constants.js';
+
+// 1. Initialize state from VS Code's memory
+settingsViewState.initialize();
+
+// 2. Register message handlers early
+messageHandler.setup();
+
+// 3. When DOM is ready, initialize UI and request data
+document.addEventListener('DOMContentLoaded', () => {
+  settingsViewDomHandler.initializeUI();
+  vscode.postMessage({ command: SETTINGS_VIEW_COMMANDS.GET_INITIAL_DATA });
+});
+
+// 4. Clean up on navigation
+window.addEventListener('beforeunload', () => {
+  settingsViewDomHandler.dispose();
+  messageHandler.dispose();
+});
+```
 
 ---
 
-## Open Questions
+## Tab Specifications
 
-1. **Deep linking:** Should clicking model dropdown gear go directly to Models tab?
-   - **Proposed:** Yes, via `texra.openSettings` command with tab parameter
+### Models Tab
 
-2. **History size:** History tab may have many items - pagination or virtual scroll?
-   - **Proposed:** Keep current approach (load all, search/filter client-side)
+**Purpose:** Combined model selection and API provider configuration.
 
-3. **Remote agents in profile:** Remove completely or keep summary?
-   - **Proposed:** Remove from profile, fully in Agents tab
+**Layout:**
 
-4. **Settings sync:** Future cloud sync of preferences?
-   - **Proposed:** Out of scope for v1, design state structure to support later
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  Models & Providers                                             │
+│  ─────────────────────────────────────────────────────────────  │
+│                                                                 │
+│  ROUTING                                                        │
+│  ● Direct to providers (recommended)                            │
+│  ○ Route all through OpenRouter                                 │
+│  ○ Use connection proxy                                         │
+│                                                                 │
+│  ⭐ RECOMMENDED MODELS                                          │
+│  ┌───────────────────────────────────────────────────────────┐  │
+│  │ ☑ Claude Sonnet 4.5 T    Anthropic   $3/$15    200K  🧠👁 │  │
+│  │ ☑ GPT-5.2                OpenAI      $2/$10    256K  🧠👁 │  │
+│  └───────────────────────────────────────────────────────────┘  │
+│                                                                 │
+│  PROVIDERS                                                      │
+│  ▼ Anthropic                         ✓ API Key    [Configure]  │
+│  ┌───────────────────────────────────────────────────────────┐  │
+│  │ ☑ Claude Sonnet 4.5 T     200K   $3/$15    🧠👁📄         │  │
+│  │ ☑ Claude Opus 4.5 T       200K   $15/$75   🧠👁📄🎧       │  │
+│  └───────────────────────────────────────────────────────────┘  │
+│                                                                 │
+│  ▶ OpenAI (28)                       ✓ API Key    [Configure]  │
+│  ▶ Google (6)                        ✗ No Key     [Configure]  │
+│                                                                 │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+**Storage:** `globalState.enabledModels: string[]`, `globalState.providerConfig`
 
 ---
 
-## Success Metrics
+### Agents Tab
 
-### v1 Release
+**Purpose:** View and enable/disable agents, plus agent-specific settings.
 
-1. Single entry point for 5 core tabs (Models, Agents, LaTeX, Memory, History)
-2. Native vscode-tabs navigation (keyboard accessible)
-3. Settings properly scoped (models global, agents per-workspace via ConfigurationTarget)
-4. History search and restore working
-5. Account info visible in header bar (minimal custom CSS)
-6. LaTeX settings functional and synced with VS Code config
-7. vscode-collapsible used effectively for subsections
-8. Only header bar needs custom styling (everything else native)
-9. Existing settings.json configurations continue to work unchanged
+**Layout:**
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  BUILT-IN AGENTS                                               │
+│  ┌───────────────────────────────────────────────────────────┐  │
+│  │ ☑ chat      Interactive conversation  $(tools) toolUse    │  │
+│  │ ☑ correct   Fix typos & LaTeX errors  $(lightbulb) CoT    │  │
+│  │ ☑ polish    Improve writing quality   $(lightbulb) CoT    │  │
+│  └───────────────────────────────────────────────────────────┘  │
+│                                                                 │
+│  CUSTOM AGENTS                                                 │
+│  ┌───────────────────────────────────────────────────────────┐  │
+│  │ ☑ my-reviewer   Reviews papers       [Source Code] [Delete]│  │
+│  └───────────────────────────────────────────────────────────┘  │
+│                                                                 │
+│  REMOTE AGENTS                                                 │
+│  ┌───────────────────────────────────────────────────────────┐  │
+│  │ ☑ team-reviewer   Team's paper reviewer                   │  │
+│  └───────────────────────────────────────────────────────────┘  │
+│                                                                 │
+│  ▼ Workflow Settings                                           │
+│  ┌───────────────────────────────────────────────────────────┐  │
+│  │ Storage mode: [Folder ▼]                                  │  │
+│  └───────────────────────────────────────────────────────────┘  │
+│                                                                 │
+│  ▼ Tool-Use Settings                                           │
+│  ┌───────────────────────────────────────────────────────────┐  │
+│  │ ☑ Require approval before file edits                      │  │
+│  │ ☑ Persist sessions across VS Code restarts                │  │
+│  │ Compaction threshold: [85 %]                              │  │
+│  │ Max retry attempts: [3 ▼]                                 │  │
+│  └───────────────────────────────────────────────────────────┘  │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+**Storage:** `workspaceState.enabledAgents: string[]`, VS Code configuration
+
+---
+
+### LaTeX Tab
+
+**Purpose:** Configure LaTeX formatting, latexdiff, and TikZ settings.
+
+**Settings Groups:**
+
+| Group | Settings |
+|-------|----------|
+| **Formatter** | `texra.latex.formatter`, `latexindentConfig`, `texfmtConfig`, `showLatexindentWarning` |
+| **LaTeXdiff** | `texra.latexdiff.mathMarkup`, `timeoutMs`, `pictureEnvironments`, `generateBetweenRoundDiffs` |
+| **TikZ Figures** | `texra.latex.tikzInputDirectory`, `includeWorkspaceInTexinputs`, `tikzTemplate` |
+| **Replacements** | `texra.latex.wrapCritiqueInAlign`, `enabledReplacements`, `enabledReplacementsRegex` |
+
+---
+
+### Memory Tab
+
+**Purpose:** Browse and manage memory files created by tool-use agents.
+
+**Features:**
+- Memory file browser with expandable content preview
+- Click to expand and show content (first ~20 lines)
+- [View Full] opens file in editor
+- [Delete] removes file
+
+---
+
+### History Tab
+
+**Purpose:** Browse and restore previous agent executions.
+
+**Features:**
+- Search with highlighting (mark.js)
+- Delete, Restore, Rerun actions
+- Collapsible details per item
+
+---
+
+## State Management
+
+### VS Code Configuration (Primary)
+
+Settings View reads/writes directly to VS Code configuration:
+
+```typescript
+const config = vscode.workspace.getConfiguration('texra');
+
+// Global settings (user-level)
+await config.update('models', enabledModels, ConfigurationTarget.Global);
+
+// Workspace settings (.vscode/settings.json)
+await config.update('agents', enabledAgents, ConfigurationTarget.Workspace);
+```
+
+### Secret Storage
+
+API keys use VS Code SecretStorage:
+
+```typescript
+// Access via SecretManager
+SecretManager.getApiKey('anthropic');
+SecretManager.setApiKey('anthropic', 'sk-...');
+```
+
+### Webview State
+
+UI state persisted via VS Code API:
+
+```javascript
+// Frontend
+const state = vscode.getState();  // Restore on reopen
+vscode.setState({ activeTab: 'models' });  // Persist
+```
 
 ---
 
@@ -1492,638 +946,43 @@ const agents = [...getWorkflowAgents(), ...getToolUseAgents()];
 ### v1 Release (5 Tabs)
 
 #### Phase 1: Core Structure
-
 - Create settingsView with vscode-tabs + header bar
-- Implement header bar (account info, sign in/out - minimal custom CSS)
+- Implement base classes (Provider, ContentProvider, MessageHandler)
 - Add main webview entry point (gear icon)
-- Deep link support (open to specific tab)
 
 #### Phase 2: Models Tab
-
-- Implement Models tab with provider collapsibles
-- Provider accordions with API status + model list
-- Provider configuration modal (API key + endpoint + streaming toggle)
-- Routing options (radio group at top)
-- Migrate provider config from old profileView
+- Provider collapsibles with API status
+- Model checkboxes with capabilities
+- Provider configuration modal
 
 #### Phase 3: Agents Tab
-
-- Implement Agents tab with agent list
-- Show category badges (workflow/toolUse) and source (built-in/custom/remote)
-- Add Workflow Settings collapsible (output storage mode)
-- Add Tool-Use Settings collapsible (edit approval, persistence, compaction, retry behavior)
-- Include Advanced collapsible (custom agents directory)
-- **Note:** Supersedes FolderExplorer/agent explorer view
+- Agent list with category badges
+- Workflow Settings collapsible
+- Tool-Use Settings collapsible
 
 #### Phase 4: LaTeX Tab
-
-- Implement LaTeX tab with collapsible sections:
-  - Formatter (collapsible)
-  - LaTeXdiff (collapsible)
-  - TikZ Figures (collapsible)
-  - Replacements (collapsible)
-- Wire up to existing VS Code configuration
-- Add file browser for config paths
+- Formatter, latexdiff, TikZ collapsibles
+- Wire up to VS Code configuration
 
 #### Phase 5: Memory Tab
+- Migrate memoryView
+- Expandable content preview
 
-- Migrate memoryView to Memory tab
-- Implement expandable content preview
-- Delete old memoryView
+#### Phase 6: History Tab + Cleanup
+- Move history rendering
+- Delete deprecated views
 
-#### Phase 6: History Tab + v1 Cleanup
+### Future Release
 
-- Move history rendering to History tab
-- Preserve search, delete, restore, rerun functionality
-- Delete old historyView
-- Remove deprecated views (profileView, historyView, memoryView)
-- Remove FolderExplorer/agent explorer (superseded)
-- Documentation
-
-### Future Release (Deferred)
-
-#### Advanced Tab
-
-- Multi-Agent (merge model + ensemble features)
-- UI Preferences (reminders, image dimension, sort order)
-- Git Integration
-- System Paths
-- Debug
-
-#### Agent Creation Wizard
-
-- AI-assisted agent creation from plain English description
-- Form-based editing without YAML knowledge
-
-#### Multi-Agent Ensemble
-
-- Run across multiple models with voting/consensus
-
----
-
-## Settings Coverage Summary
-
-Based on 79 total settings in package.json:
-
-### v1 Release - Covered by Settings View
-
-| Tab         | Settings Covered                                                                                                                                                                                                                     |
-| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **Models**  | `texra.models`, `texra.model.useStreaming*` (9), `texra.model.useOpenRouter`, `texra.model.useImprovedConnection`, `texra.model.improvedConnectionDomain`, `texra.model.baseUrlDeepSeek`                                             |
-| **Agents**  | `texra.agents`, `texra.toolUseAgents`, `texra.remoteAgents.autoShow`, `texra.explorer.agentsDirectory`, `texra.agentOutputs.storageMode`, `texra.toolUse.*` (3), `texra.model.compactionThresholdPercent`, `texra.model.retry.*` (2) |
-| **LaTeX**   | `texra.latex.*` (7), `texra.latexdiff.*` (4)                                                                                                                                                                                         |
-| **Memory**  | Memory file browser (no config, file system)                                                                                                                                                                                         |
-| **History** | History browser (existing storage)                                                                                                                                                                                                   |
-
-### Deferred to Future Release (Advanced Tab)
-
-| Section             | Settings                                                                           |
-| ------------------- | ---------------------------------------------------------------------------------- |
-| **Multi-Agent**     | `texra.merge.defaultModel`                                                         |
-| **UI Preferences**  | `texra.ui.*` (3), `texra.progressBoard.streamSortOrder`, `texra.maxImageDimension` |
-| **Git Integration** | `texra.git.numberOfCommitsToShow`                                                  |
-| **System Paths**    | `texra.audio.soxPath`                                                              |
-| **Debug**           | `texra.debug.*`, `texra.logger.*`                                                  |
-
-### Remain as VS Code Settings Only
-
-These are advanced/power-user settings that don't need UI exposure:
-
-- `texra.files.*` (16) - File type filtering patterns (power user)
-- `texra.auth.*` (3) - System-level authentication endpoints
-- Other system-level paths and debug flags
-
----
-
-## Integration Surface Areas
-
-Key integration points that need updating when implementing the Settings View:
-
-### 1. Main Webview Entry Points
-
-| Location                                                  | Current Behavior                         | New Behavior                 |
-| --------------------------------------------------------- | ---------------------------------------- | ---------------------------- |
-| `src/webview/index.html` line 524                         | Agent settings button → VS Code settings | → Settings View (Agents tab) |
-| `src/webview/index.html` line 552                         | Model settings button → VS Code settings | → Settings View (Models tab) |
-| `src/webview/modules/uiManagers/SettingsButtonManager.js` | Opens VS Code settings                   | Opens Settings View          |
-
-### 2. Commands to Update
-
-| Command              | File                   | Change                                         |
-| -------------------- | ---------------------- | ---------------------------------------------- |
-| `texra.openSettings` | `src/commands/system/` | Open Settings View instead of VS Code settings |
-
-**New commands to add (shortcuts):**
-
-- `texra.openAgentSettings` → Opens Settings View → Agents tab
-- `texra.openModelSettings` → Opens Settings View → Models tab
-
-### 3. Dropdown Options Computation
-
-| Function                | File                               | Impact                                 |
-| ----------------------- | ---------------------------------- | -------------------------------------- |
-| `computeAgentOptions()` | `src/agent/index/agentRegistry.ts` | No change - still reads VS Code config |
-| `computeModelOptions()` | `src/model/computeModelOptions.ts` | No change - still reads VS Code config |
-
-### 4. Configuration Watchers
-
-`src/MainViewProvider.ts` (lines 84-120) watches for config changes.
-
-- No change needed - Settings View writes to VS Code config
-- Existing watchers will pick up changes automatically
-
-### 5. View Registrations (package.json)
-
-| View                  | Current                         | After Implementation       |
-| --------------------- | ------------------------------- | -------------------------- |
-| `texra.profileView`   | Registered in contributes.views | Remove after Phase 6       |
-| `texra.historyView`   | Command-opened panel            | Remove after Phase 5       |
-| `texra.memoryView`    | Command-opened panel            | Remove after Phase 4       |
-| `texra.agentExplorer` | TreeView in sidebar             | Remove after Phase 2       |
-| `texra.settingsView`  | N/A                             | Add new panel registration |
-
-### 6. Message Handlers to Migrate
-
-| Handler                     | From               | To                            |
-| --------------------------- | ------------------ | ----------------------------- |
-| `ProfileViewMessageHandler` | `src/profileView/` | `src/settingsView/` (compose) |
-| `HistoryViewMessageHandler` | `src/historyView/` | `src/settingsView/` (compose) |
-| `MemoryViewMessageHandler`  | `src/memoryView/`  | `src/settingsView/` (compose) |
-
-### 7. No State Migration Needed
-
-Settings View reads/writes directly to VS Code configuration - no migration required.
-
----
-
-## Component Mapping (vscode-elements)
-
-### Tab Layout
-
-```html
-<vscode-tabs>                   <!-- Tab container -->
-  <vscode-tab-header>           <!-- Tab buttons -->
-  <vscode-tab-panel>            <!-- Tab content panels -->
-</vscode-tabs>
-```
-
-### Form Components by Tab
-
-| UI Pattern              | Component                | Example Usage                      |
-| ----------------------- | ------------------------ | ---------------------------------- |
-| **Single selection**    | `<vscode-single-select>` | Formatter dropdown, Math markup    |
-| **Checkbox**            | `<vscode-checkbox>`      | Enable/disable toggles             |
-| **Text input**          | `<vscode-textfield>`     | API keys, file paths               |
-| **Multiline text**      | `<vscode-textarea>`      | TikZ template, agent instructions  |
-| **Radio group**         | `<vscode-radio-group>`   | Routing mode, access mode          |
-| **Collapsible section** | `<vscode-collapsible>`   | Advanced options, provider details |
-| **Button**              | `<vscode-button>`        | Save, Browse, Create Agent         |
-| **Badge**               | `<vscode-badge>`         | Category badges (workflow/toolUse) |
-
-### Form Layout Components
-
-```html
-<!-- Standard form group with label -->
-<vscode-form-group>
-  <vscode-label>Formatter</vscode-label>
-  <vscode-single-select>
-    <vscode-option value="latexindent">latexindent</vscode-option>
-    <vscode-option value="tex-fmt">tex-fmt</vscode-option>
-    <vscode-option value="none">none</vscode-option>
-  </vscode-single-select>
-</vscode-form-group>
-
-<!-- Checkbox (self-labeled) -->
-<vscode-checkbox id="showWarning">
-  Show warning if latexindent is not installed
-</vscode-checkbox>
-
-<!-- File path with browse button -->
-<vscode-form-group>
-  <vscode-label>Config file</vscode-label>
-  <div class="input-with-button">
-    <vscode-textfield placeholder="/path/to/config"></vscode-textfield>
-    <vscode-button appearance="secondary">Browse</vscode-button>
-  </div>
-</vscode-form-group>
-
-<!-- Section header using vscode-label -->
-<vscode-label class="section-label">FORMATTER</vscode-label>
-```
-
-### Models Tab Components
-
-- `<vscode-collapsible>` - Provider accordions (Anthropic, OpenAI, etc.)
-- `<vscode-checkbox>` - Model enable/disable
-- `<vscode-badge>` - Capability icons, status indicators
-
-### Agents Tab Components
-
-- `<vscode-checkbox>` - Agent enable/disable
-- `<vscode-badge>` - Category badges (workflow/toolUse), source badges
-- `<vscode-button>` - Create Agent, Edit, Delete
-- `<vscode-single-select>` - Category dropdown, inheritance dropdown
-- `<vscode-textarea>` - Agent instructions
-
-### LaTeX Tab Components
-
-- `<vscode-single-select>` - Formatter, math markup
-- `<vscode-checkbox>` - Boolean settings
-- `<vscode-textfield>` - File paths, regex patterns
-- `<vscode-textarea>` - TikZ template
-- `<vscode-collapsible>` - Advanced sections
-
-### Header Bar + Provider Modal Components
-
-- `<vscode-button>` - Manage, Sign In/Out
-- `<vscode-textfield type="password">` - API keys (in modal)
-- `<vscode-radio-group>` - Routing mode (in Models tab)
-- `<vscode-collapsible>` - Provider details (in Models tab)
-
----
-
-## Code Reuse Patterns
-
-### Base Classes (Extend Existing Infrastructure)
-
-```
-src/settingsView/
-├── SettingsViewProvider.ts         # extends BaseWebviewProvider
-├── SettingsViewMessageHandler.ts   # extends BaseViewMessageHandler
-├── SettingsViewContentProvider.ts  # extends BaseViewContentProvider
-```
-
-### Provider Pattern
-
-```typescript
-// SettingsViewProvider.ts
-export class SettingsViewProvider
-  extends BaseWebviewProvider
-  implements vscode.WebviewViewProvider
-{
-  public static readonly viewType = 'texra.settingsView';
-
-  protected contentProvider: SettingsViewContentProvider;
-  protected messageHandler: SettingsViewMessageHandler;
-
-  constructor(context: vscode.ExtensionContext) {
-    super(context);
-    this.contentProvider = new SettingsViewContentProvider(context);
-    this.messageHandler = new SettingsViewMessageHandler(context);
-  }
-
-  public resolveWebviewView(webviewView: vscode.WebviewView): void {
-    webviewView.webview.options = {
-      enableScripts: true,
-      localResourceRoots: getSharedLocalResourceRoots(
-        this.context,
-        'settingsView',
-      ),
-    };
-    super.resolveWebviewViewInternal(webviewView);
-  }
-
-  /** Open settings to specific tab */
-  public async showSettings(tab?: SettingsTab): Promise<void> {
-    const isNew = this.createOrShowPanel({
-      viewType: SettingsViewProvider.viewType,
-      title: 'TeXRA Settings',
-      viewPath: 'settingsView',
-    });
-    if (tab) {
-      await this.messageHandler.selectTab(this._view?.webview, tab);
-    }
-  }
-}
-```
-
-### Module Descriptors Pattern
-
-```typescript
-// SettingsViewContentProvider.ts
-const SETTINGS_VIEW_MODULES = [
-  { key: 'settingsViewStateUri', path: 'modules/settingsViewState.js' },
-  { key: 'headerBarUri', path: 'modules/headerBar.js' },
-  { key: 'modelsTabUri', path: 'modules/tabs/ModelsTab.js' },
-  { key: 'agentsTabUri', path: 'modules/tabs/AgentsTab.js' },
-  { key: 'latexTabUri', path: 'modules/tabs/LatexTab.js' },
-  { key: 'memoryTabUri', path: 'modules/tabs/MemoryTab.js' },
-  { key: 'historyTabUri', path: 'modules/tabs/HistoryTab.js' },
-  { key: 'advancedTabUri', path: 'modules/tabs/AdvancedTab.js' },
-] as const;
-
-export class SettingsViewContentProvider extends BaseViewContentProvider {
-  constructor(context: vscode.ExtensionContext) {
-    super(context, 'SettingsView', [...SETTINGS_VIEW_MODULES]);
-  }
-  protected getViewPath(): string {
-    return 'settingsView';
-  }
-}
-```
-
-### Tab Manager Pattern (Frontend)
-
-**Extend existing `BaseDomHandler.js`** - do not create a parallel hierarchy:
-
-```javascript
-// modules/tabs/ModelsTab.js - Example tab extending BaseDomHandler
-import { BaseDomHandler } from '@common/modules/BaseDomHandler.js';
-
-export class ModelsTab extends BaseDomHandler {
-  constructor(containerSelector) {
-    super(); // BaseDomHandler provides addListener, removeListener, dispose
-    this.container = document.querySelector(containerSelector);
-  }
-
-  render(data) {
-    this.container.innerHTML = `
-      <vscode-collapsible title="Recommended Models" open>
-        ${data.recommended
-          .map(
-            (m) => `
-          <vscode-checkbox id="model-${m.name}" ${m.enabled ? 'checked' : ''}>
-            ${m.fullName} - ${m.provider}
-          </vscode-checkbox>
-        `,
-          )
-          .join('')}
-      </vscode-collapsible>
-    `;
-    this.attachEventListeners();
-  }
-
-  attachEventListeners() {
-    // Use inherited addListener for automatic cleanup on dispose()
-    this.container.querySelectorAll('vscode-checkbox').forEach((cb) => {
-      this.addListener(cb, 'change', () => this.handleModelToggle(cb));
-    });
-  }
-}
-```
-
-**Key point:** `BaseDomHandler` already provides:
-
-- `addListener(element, event, handler)` - with automatic cleanup
-- `removeListener(element, event, handler)`
-- `dispose()` - cleans up all registered listeners
-
-### Minimal Custom CSS (extend common.css)
-
-```css
-/* settingsView/styles/index.css */
-/* Rely on vscode-form-group and vscode-elements for layout */
-/* Only add minimal custom styles where needed */
-
-.settings-container {
-  max-width: 720px;
-  margin: 0 auto;
-  padding: var(--spacing-large);
-}
-
-/* Section dividers */
-.section + .section {
-  border-top: 1px solid var(--vscode-widget-border);
-  padding-top: var(--spacing-large);
-  margin-top: var(--spacing-large);
-}
-
-/* Section labels (uppercase headers) */
-.section-label {
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
-  margin-bottom: var(--spacing-medium);
-}
-
-/* Input + button combos */
-.input-with-button {
-  display: flex;
-  gap: var(--spacing-small);
-}
-.input-with-button vscode-textfield {
-  flex: 1;
-}
-```
-
-### Message Handler Composition
-
-```typescript
-// SettingsViewMessageHandler.ts
-export class SettingsViewMessageHandler extends BaseViewMessageHandler<...> {
-  // Compose handlers from existing views where possible
-  private historyHandlers: HistoryHandlers;
-  private profileHandlers: ProfileHandlers;
-
-  constructor(context: vscode.ExtensionContext) {
-    super('SettingsView');
-    this.historyHandlers = new HistoryHandlers(context);
-    this.profileHandlers = new ProfileHandlers(context);
-  }
-
-  protected createHandlers(): Record<string, MessageHandler<...>> {
-    return {
-      // Models tab
-      [SETTINGS_COMMANDS.GET_MODELS_DATA]: this.handleGetModels.bind(this),
-      [SETTINGS_COMMANDS.SAVE_ENABLED_MODELS]: this.handleSaveModels.bind(this),
-
-      // Agents tab
-      [SETTINGS_COMMANDS.GET_AGENTS_DATA]: this.handleGetAgents.bind(this),
-      [SETTINGS_COMMANDS.SAVE_ENABLED_AGENTS]: this.handleSaveAgents.bind(this),
-
-      // LaTeX tab (direct VS Code config read/write)
-      [SETTINGS_COMMANDS.GET_LATEX_DATA]: this.handleGetLatex.bind(this),
-      [SETTINGS_COMMANDS.SAVE_LATEX_SETTING]: this.handleSaveLatex.bind(this),
-
-      // Delegate to existing handlers
-      ...this.historyHandlers.getHandlers(),
-      ...this.profileHandlers.getHandlers(),
-    };
-  }
-}
-```
-
-### Reducing Boilerplate: Setting Renderer Factory
-
-```javascript
-// modules/utils/SettingRenderer.js
-export const SettingRenderer = {
-  /** Render a dropdown setting row */
-  dropdown(id, label, options, value, onChange) {
-    return `
-      <div class="setting-row">
-        <span class="setting-label">${label}</span>
-        <vscode-single-select id="${id}" value="${value}">
-          ${options.map((o) => `<vscode-option value="${o.value}">${o.label}</vscode-option>`).join('')}
-        </vscode-single-select>
-      </div>
-    `;
-  },
-
-  /** Render a checkbox setting row */
-  checkbox(id, label, checked, description) {
-    return `
-      <div class="setting-row setting-row--checkbox">
-        <vscode-checkbox id="${id}" ${checked ? 'checked' : ''}>
-          ${label}
-        </vscode-checkbox>
-        ${description ? `<span class="setting-description">${description}</span>` : ''}
-      </div>
-    `;
-  },
-
-  /** Render a file path setting row */
-  filePath(id, label, value, placeholder) {
-    return `
-      <div class="setting-row">
-        <span class="setting-label">${label}</span>
-        <div class="setting-input-group">
-          <vscode-textfield id="${id}" value="${value}" placeholder="${placeholder}"></vscode-textfield>
-          <vscode-button appearance="secondary" data-browse="${id}">Browse</vscode-button>
-        </div>
-      </div>
-    `;
-  },
-
-  /** Render a section with settings */
-  section(title, settingsHtml) {
-    return `
-      <div class="section">
-        <div class="section-header">${title}</div>
-        ${settingsHtml}
-      </div>
-    `;
-  },
-};
-```
-
----
-
-## LaTeX Settings Grouping
-
-Based on actual `package.json` configuration (14 settings total):
-
-### Group 1: Formatter (4 settings)
-
-| Setting                              | UI Component                                        |
-| ------------------------------------ | --------------------------------------------------- |
-| `texra.latex.formatter`              | `<vscode-single-select>` (latexindent/tex-fmt/none) |
-| `texra.latex.latexindentConfig`      | `<vscode-textfield>` + Browse                       |
-| `texra.latex.texfmtConfig`           | `<vscode-textfield>` + Browse                       |
-| `texra.latex.showLatexindentWarning` | `<vscode-checkbox>`                                 |
-
-### Group 2: LaTeXdiff (4 settings)
-
-| Setting                                     | UI Component                                     |
-| ------------------------------------------- | ------------------------------------------------ |
-| `texra.latexdiff.mathMarkup`                | `<vscode-single-select>` (off/whole/coarse/fine) |
-| `texra.latexdiff.timeoutMs`                 | `<vscode-textfield type="number">`               |
-| `texra.latexdiff.pictureEnvironments`       | `<vscode-textfield>` (regex)                     |
-| `texra.latexdiff.generateBetweenRoundDiffs` | `<vscode-checkbox>`                              |
-
-### Group 3: TikZ Figures (3 settings)
-
-| Setting                                   | UI Component                                 |
-| ----------------------------------------- | -------------------------------------------- |
-| `texra.latex.tikzInputDirectory`          | `<vscode-textfield>` + Browse                |
-| `texra.latex.includeWorkspaceInTexinputs` | `<vscode-checkbox>`                          |
-| `texra.latex.tikzTemplate`                | `<vscode-collapsible>` + `<vscode-textarea>` |
-
-### Group 4: Replacements (5 settings) - Collapsible Advanced
-
-| Setting                                | UI Component                         |
-| -------------------------------------- | ------------------------------------ |
-| `texra.latex.wrapCritiqueInAlign`      | `<vscode-checkbox>`                  |
-| `texra.latex.enabledReplacements`      | Checkbox group (14 options)          |
-| `texra.latex.enabledReplacementsRegex` | Checkbox group (6 options)           |
-| `texra.latex.customReplacements`       | `<vscode-collapsible>` + JSON editor |
-| `texra.latex.customReplacementsRegex`  | `<vscode-collapsible>` + JSON editor |
-
----
-
-## General Implementation Guidelines
-
-### Code Style
-
-1. **Use TypeScript** for all backend code (`.ts` files)
-2. **Use JavaScript** for frontend webview modules (`.js` files) - no bundler
-3. **Follow existing patterns** in `src/common/` for base classes and utilities
-4. **Use path aliases** (`@settingsView/*`, `@common/*`) as defined in `tsconfig.json`
-
-### VS Code Configuration Best Practices
-
-```typescript
-// Always specify ConfigurationTarget explicitly
-await config.update(key, value, ConfigurationTarget.Global); // User settings
-await config.update(key, value, ConfigurationTarget.Workspace); // .vscode/settings.json
-
-// Read with type safety
-const models = config.get<string[]>('models', []); // Always provide default
-
-// Batch updates when possible (reduces config change events)
-const edit = new vscode.WorkspaceEdit();
-// ... multiple changes
-await vscode.workspace.applyEdit(edit);
-```
-
-### Event Listener Cleanup
-
-Use `BaseDomHandler` for automatic cleanup:
-
-```javascript
-// Extend BaseDomHandler - dispose() cleans up all listeners
-class ModelsTab extends BaseDomHandler {
-  attachEventListeners() {
-    this.addListener(this.saveButton, 'click', this.handleSave.bind(this));
-  }
-}
-// On tab switch: oldTab.dispose() removes all listeners automatically
-```
-
-### Error Handling
-
-```typescript
-// Backend: Use typed errors from @common/errors
-throw new TeXRAError('Provider not configured', { provider: providerId });
-
-// Frontend: Show user-friendly messages
-try {
-  await saveSettings();
-} catch (error) {
-  vscode.postMessage({ command: 'SHOW_ERROR', message: error.message });
-}
-```
-
-### Testing Considerations
-
-1. **Unit test** message handlers independently
-2. **Mock VS Code API** using existing test utilities
-3. **Test ConfigurationTarget** scoping (global vs workspace)
-4. **Verify backwards compatibility** - existing settings.json should work unchanged
-
-### Accessibility
-
-1. Use native vscode-elements (built-in keyboard navigation)
-2. Provide `aria-label` for icon-only buttons
-3. Ensure tab order is logical
-4. Test with keyboard-only navigation
-
-### Performance
-
-1. **Lazy load** tab content (don't render all tabs on initial load)
-2. **Debounce** settings saves (avoid rapid config updates)
-3. **Cache** model metadata from llm-zoo in globalState
-4. **Virtualize** long lists (agents, models) if > 50 items
+- **Advanced Tab** - Multi-Agent, UI preferences, debug
+- **Agent Creation Wizard** - Form-based agent creation
 
 ---
 
 ## References
 
-- VS Code Elements: `@vscode-elements/elements`
-  - Tabs: `vscode-tabs`, `vscode-tab-header`, `vscode-tab-panel`
-  - Forms: `vscode-single-select`, `vscode-checkbox`, `vscode-textfield`, `vscode-textarea`
-  - Layout: `vscode-collapsible`, `vscode-form-group` (avoid for Notion-style)
-  - Actions: `vscode-button`, `vscode-badge`
-- Base Classes: `src/common/webview/Base*.ts`
-- Shared Styles: `src/common/styles/common.css`
-- LLM Zoo: Model metadata source
-- Existing views: `src/profileView/`, `src/historyView/`, `src/memoryView/`
+- **VS Code Elements:** `@vscode-elements/elements` (v2.4.0)
+- **Base Classes:** `src/common/webview/Base*.ts`
+- **Shared Modules:** `src/common/modules/*.js`
+- **Shared Styles:** `src/common/styles/common.css`
+- **Existing Views:** `src/profileView/`, `src/historyView/`, `src/progressView/`


### PR DESCRIPTION
## Summary
Significantly restructured and condensed the settings view unified documentation to improve readability and maintainability while preserving essential information.

## Key Changes
- Removed redundant or outdated content (1779 lines removed)
- Reorganized documentation structure for better clarity (+638 lines added)
- Streamlined settings view specifications and requirements
- Improved document focus on core unified settings view functionality

## Implementation Details
The net reduction in file size (-1141 lines) suggests a consolidation effort, likely removing duplicate sections, verbose explanations, or deprecated specifications. The restructuring maintains the document's purpose as a product requirements document while making it more concise and easier to navigate.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Major documentation and build guidance update focused on ProgressView modernization and webview architecture.
> 
> - **Add PRDs**: New phase docs (`prd-progressview-phase1..4.md`) detailing schemas, Lit migration plan, patterns, and current status; significantly rewrite `prd-progressview-modernization.md`
> - **Build guidance**: Update `CLAUDE.md` to require `NODE_OPTIONS=--max-old-space-size=8192` for `package/build/compile`; note memory needs and add troubleshooting
> - **Dev workflow**: Update `AGENTS.md` to skip `npm test` and clarify commit/lint steps
> - **Packaging**: Adjust `.vscodeignore` to include `src/shared/styles/*.css` and ensure `releases/**` is included
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ff6f15ce80bb73bc8e8c7f9d785e992000071950. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->