### PR TITLE
refactor(main/progress): extract MainApp Lit components and optimize progress view rendering

### DIFF
--- a/docs/prd-progressview-phase5.md
+++ b/docs/prd-progressview-phase5.md
@@ -16,14 +16,14 @@ Phase 5 addresses technical debt accumulated during the MainView Lit migration. 
 
 > **Overall Phase 5 Completion: 100% (regressions & validation)**
 >
-> Remaining refactoring tasks moved to [Phase 6](./prd-progressview-phase6.md).
+> Remaining refactoring tasks completed in [Phase 6](./prd-progressview-phase6.md).
 >
 > - ✅ All critical regressions fixed (R1-R16, H1-H15, J1-J2, P1-P3, R11)
 > - ✅ Zod message validation complete (mainViewMessages.ts, commonViewMessages.ts)
 > - ✅ Cross-webview infrastructure unified (BaseWebviewApp pattern)
 > - ✅ All JavaScript behavioral issues resolved (debounce, checkbox timing)
-> - ➡️ Component extraction → [Phase 6](./prd-progressview-phase6.md)
-> - ➡️ Formatters migration → [Phase 6](./prd-progressview-phase6.md)
+> - ✅ Component extraction completed in [Phase 6](./prd-progressview-phase6.md)
+> - ✅ Formatters migration completed (Phase 5)
 
 ### Critical Issues (Fix Immediately)
 
@@ -83,29 +83,29 @@ Phase 5 addresses technical debt accumulated during the MainView Lit migration. 
 
 ### Refactoring Tasks
 
-| Task                           | Status         | Impact                           |
-| ------------------------------ | -------------- | -------------------------------- |
-| Extract FileSelectGroup        | ➡️ Phase 6    | -300 lines from MainApp          |
-| Extract BannerGroup components | ➡️ Phase 6    | -150 lines from MainApp          |
-| Extract LatexDiffsSection      | ➡️ Phase 6    | -200 lines from MainApp          |
-| Create shared message schemas  | ✅ Complete    | mainViewMessages.ts (46 schemas) |
-| Add Zod validation to MainApp  | ✅ Complete    | All 34 message types validated   |
-| Convert 37 inline arrows       | ➡️ Phase 6    | Performance                      |
-| Delete duplicate debug handler | ✅ Complete    | commonMessageHandlers.ts         |
-| Install @types/sortablejs      | ✅ Complete    | Complete type definitions        |
+| Task                           | Status                | Impact                           |
+| ------------------------------ | --------------------- | -------------------------------- |
+| Extract FileSelectGroup        | ✅ Complete (Phase 6) | -300 lines from MainApp          |
+| Extract BannerGroup components | ✅ Complete (Phase 6) | -150 lines from MainApp          |
+| Extract LatexDiffsSection      | ✅ Complete (Phase 6) | -200 lines from MainApp          |
+| Create shared message schemas  | ✅ Complete           | mainViewMessages.ts (46 schemas) |
+| Add Zod validation to MainApp  | ✅ Complete           | All 34 message types validated   |
+| Convert 37 inline arrows       | ✅ Complete (Phase 6) | Performance                      |
+| Delete duplicate debug handler | ✅ Complete           | commonMessageHandlers.ts         |
+| Install @types/sortablejs      | ✅ Complete           | Complete type definitions        |
 
 ### Architectural Tasks (NEW - Phase 5 Scope)
 
-| Task                              | Status            | Impact                            |
-| --------------------------------- | ----------------- | --------------------------------- |
-| Formatters → TemplateResult       | ✅ Complete       | 14 formatters use Lit templates; bridge pattern intentional for Light DOM streaming |
-| renderLogs incremental updates    | 🟡 Hybrid         | appendLog/updateLog are incremental; full rebuild only on stream switch |
+| Task                           | Status      | Impact                                                                              |
+| ------------------------------ | ----------- | ----------------------------------------------------------------------------------- |
+| Formatters → TemplateResult    | ✅ Complete | 14 formatters use Lit templates; bridge pattern intentional for Light DOM streaming |
+| renderLogs incremental updates | 🟡 Hybrid   | appendLog/updateLog are incremental; full rebuild only on stream switch             |
 
 > **Open to ideas:** We welcome suggestions for more native Lit patterns that could improve the architecture. See [Phase 6 section 6.2b](./prd-progressview-phase6.md#62b-lit-directive--native-feature-improvements) for areas open for exploration.
-| Create commonViewMessages.ts      | ✅ Complete       | Zod schemas for 5 common cmds     |
-| themeHandlers.ts Zod migration    | ✅ Complete       | commonMessageHandlers.ts          |
-| Eliminate normalization layers    | ✅ Complete       | -160 lines (done in Phase 3)      |
-| Cross-webview command unification | ✅ Complete       | BaseWebviewApp pattern            |
+> | Create commonViewMessages.ts | ✅ Complete | Zod schemas for 5 common cmds |
+> | themeHandlers.ts Zod migration | ✅ Complete | commonMessageHandlers.ts |
+> | Eliminate normalization layers | ✅ Complete | -160 lines (done in Phase 3) |
+> | Cross-webview command unification | ✅ Complete | BaseWebviewApp pattern |
 
 ---
 

--- a/docs/prd-progressview-phase6.md
+++ b/docs/prd-progressview-phase6.md
@@ -15,17 +15,17 @@ Phase 6 addresses remaining technical debt from the Lit migration. Phase 5 compl
 
 ## Status Summary
 
-| Task | Status | Impact |
-|------|--------|--------|
-| Extract FileSelectGroup | ⬜ Not Started | -300 lines from MainApp |
-| Extract BannerGroup components | ⬜ Not Started | -150 lines from MainApp |
-| Extract LatexDiffsSection | ⬜ Not Started | -200 lines from MainApp |
-| Convert 37 inline arrows | ⬜ Not Started | Performance |
-| Formatters → TemplateResult | ✅ Done (Phase 5) | Bridge pattern is intentional for Light DOM; open to future improvements |
-| renderLogs incremental updates | 🟡 Hybrid | appendLog/updateLog incremental; full rebuild on stream switch only |
-| TaskGroupDomManager refactor | ⬜ Not Started | Separation of concerns |
-| Replace .map() with repeat() | ⬜ Not Started | Keyed list updates in RunSelector, FileList, StreamHeader, PromptOverlay |
-| Add guard() memoization | ⬜ Not Started | ToolUseStreamContent, WorkflowStreamContent caching |
+| Task                           | Status            | Impact                                                                   |
+| ------------------------------ | ----------------- | ------------------------------------------------------------------------ |
+| Extract FileSelectGroup        | ✅ Done           | -300 lines from MainApp                                                  |
+| Extract BannerGroup components | ✅ Done           | -150 lines from MainApp                                                  |
+| Extract LatexDiffsSection      | ✅ Done           | -200 lines from MainApp                                                  |
+| Convert 37 inline arrows       | ✅ Done           | Performance                                                              |
+| Formatters → TemplateResult    | ✅ Done (Phase 5) | Bridge pattern is intentional for Light DOM; open to future improvements |
+| renderLogs incremental updates | 🟡 Hybrid         | appendLog/updateLog incremental; full rebuild on stream switch only      |
+| TaskGroupDomManager refactor   | ✅ Done           | Separation of concerns                                                   |
+| Replace .map() with repeat()   | ✅ Done           | Keyed list updates in RunSelector, FileList, StreamHeader, PromptOverlay |
+| Add guard() memoization        | ✅ Done           | ToolUseStreamContent, WorkflowStreamContent caching                      |
 
 ---
 
@@ -35,14 +35,14 @@ Phase 6 addresses remaining technical debt from the Lit migration. Phase 5 compl
 
 **Analysis by section:**
 
-| Section | Lines | Description |
-|---------|-------|-------------|
+| Section                  | Lines     | Description                    |
+| ------------------------ | --------- | ------------------------------ |
 | File selection rendering | 1700-2345 | Repetitive file list templates |
-| Banner components | 2347-2508 | API key, agent config, etc. |
-| LaTeXDiffs section | 2547-2736 | Diff configuration panel |
-| Message handler switch | 297-400+ | 58-case switch statement |
-| Event handlers | 450-700 | Click, input, form handlers |
-| State management | 100-296 | @state properties |
+| Banner components        | 2347-2508 | API key, agent config, etc.    |
+| LaTeXDiffs section       | 2547-2736 | Diff configuration panel       |
+| Message handler switch   | 297-400+  | 58-case switch statement       |
+| Event handlers           | 450-700   | Click, input, form handlers    |
+| State management         | 100-296   | @state properties              |
 
 **Target Structure:**
 
@@ -123,31 +123,31 @@ private handleFileAction = (e: Event) => {
 
 ## 6.2b Lit Directive & Native Feature Improvements
 
-**Status: ⬜ Not Started | Open to Ideas**
+**Status: ✅ Memoization complete | Open to Ideas**
 
 We actively welcome more native Lit approaches where they're more suitable. The current codebase uses some Lit features but there may be better patterns we haven't discovered yet.
 
 ### Currently Used Directives
 
-| Directive | Files | Notes |
-|-----------|-------|-------|
-| `repeat()` | 5 | Keyed list iteration |
-| `when()` | 5 | Conditional rendering |
-| `classMap()` | 6 | Dynamic CSS classes |
-| `ifDefined()` | 4 | Optional attributes |
-| `live()` | 2 | Form input preservation |
-| `ref()` | 3 | Element references |
+| Directive     | Files | Notes                   |
+| ------------- | ----- | ----------------------- |
+| `repeat()`    | 5     | Keyed list iteration    |
+| `when()`      | 5     | Conditional rendering   |
+| `classMap()`  | 6     | Dynamic CSS classes     |
+| `ifDefined()` | 4     | Optional attributes     |
+| `live()`      | 2     | Form input preservation |
+| `ref()`       | 3     | Element references      |
 
 ### Not Yet Used (Explore These)
 
-| Directive | Stability | Potential Use Case |
-|-----------|-----------|-------------------|
-| `guard()` | ⭐⭐⭐ Excellent | Memoize expensive template sections |
-| `cache()` | ⭐⭐⭐ Excellent | Preserve DOM when toggling visibility |
-| `until()` | ⭐⭐⭐ Excellent | Async data loading with placeholders |
-| `keyed()` | ⭐⭐ Good | Force re-render on identity change |
-| `templateContent()` | ⭐⭐ Good | Reuse `<template>` elements |
-| `asyncAppend()` / `asyncReplace()` | ⭐ Niche | Streaming content (rarely needed with async/await) |
+| Directive                          | Stability        | Potential Use Case                                 |
+| ---------------------------------- | ---------------- | -------------------------------------------------- |
+| `guard()`                          | ⭐⭐⭐ Excellent | Memoize expensive template sections                |
+| `cache()`                          | ⭐⭐⭐ Excellent | Preserve DOM when toggling visibility              |
+| `until()`                          | ⭐⭐⭐ Excellent | Async data loading with placeholders               |
+| `keyed()`                          | ⭐⭐ Good        | Force re-render on identity change                 |
+| `templateContent()`                | ⭐⭐ Good        | Reuse `<template>` elements                        |
+| `asyncAppend()` / `asyncReplace()` | ⭐ Niche         | Streaming content (rarely needed with async/await) |
 
 **Recommendation:** Start with `guard()` - it can replace ~10 private cache variables and ~30 lines of `willUpdate()` boilerplate in `ToolUseStreamContent.ts` (lines 65-98) and `WorkflowStreamContent.ts` (lines 79-108). See concrete before/after examples below.
 
@@ -155,20 +155,20 @@ We actively welcome more native Lit approaches where they're more suitable. The 
 
 **Replace `.map()` with `repeat()`:**
 
-| File | Line | Current | Suggested |
-|------|------|---------|-----------|
-| `RunSelector.ts` | 47 | `.map()` | `repeat(sortedRuns, r => r.id, ...)` |
-| `FileList.ts` | 205, 215 | `.map()` | `repeat(files, f => f.location.absolutePath, ...)` |
-| `StreamHeader.ts` | 344 | `.map()` | `repeat(buttons, b => b.id, ...)` |
-| `PromptOverlay.ts` | 478, 516 | `.map()` | `repeat(fileLists, f => f.label, ...)` |
-| `StreamTabs.ts` | 290, 303 | `.map()` | `repeat(FILTER_BUTTONS, b => b.id, ...)` |
+| File               | Line     | Current  | Suggested                                          |
+| ------------------ | -------- | -------- | -------------------------------------------------- |
+| `RunSelector.ts`   | 47       | `.map()` | `repeat(sortedRuns, r => r.id, ...)`               |
+| `FileList.ts`      | 205, 215 | `.map()` | `repeat(files, f => f.location.absolutePath, ...)` |
+| `StreamHeader.ts`  | 344      | `.map()` | `repeat(buttons, b => b.id, ...)`                  |
+| `PromptOverlay.ts` | 478, 516 | `.map()` | `repeat(fileLists, f => f.label, ...)`             |
+| `StreamTabs.ts`    | 290, 303 | `.map()` | `repeat(FILTER_BUTTONS, b => b.id, ...)`           |
 
-**Replace manual caching with `guard()`:**
+**Replace manual caching with `guard()` (or a single cached pass):**
 
-| File | Variables | Lines |
-|------|-----------|-------|
-| `ToolUseStreamContent.ts` | `_cachedFilteredPrompts`, `_cachedRunGroups`, `_prevStreamId`, `_prevPrompts`, `_prevTaskGroups` | 65-98 |
-| `WorkflowStreamContent.ts` | `_cachedRunGroups`, `_cachedRunValues`, `_prevTaskGroups`, `_prevRunId`, `_prevState` | 79-108 |
+| File                       | Variables                                    | Lines  |
+| -------------------------- | -------------------------------------------- | ------ |
+| `ToolUseStreamContent.ts`  | Cached prompt state computed once per update | 65-98  |
+| `WorkflowStreamContent.ts` | Cached run values computed once per update   | 79-108 |
 
 **Current pattern (manual memoization):**
 
@@ -297,14 +297,14 @@ export function renderToElement(template: TemplateResult): HTMLElement | null {
 
 **Completed scope (14 formatters):**
 
-| Formatter File | Functions | Status |
-|----------------|-----------|--------|
-| `bannerFormatters.ts` | 2 | ✅ Lit templates |
-| `messageFormatters.ts` | 4 | ✅ Lit templates |
-| `toolFormatters.ts` | 2 | ✅ Lit templates |
-| `dataFormatters.ts` | 4 | ✅ Lit templates |
-| `contextManagementFormatters.ts` | 1 | ✅ Lit templates |
-| `taskGroupFormatter.ts` | 1 | ✅ Lit templates |
+| Formatter File                   | Functions | Status           |
+| -------------------------------- | --------- | ---------------- |
+| `bannerFormatters.ts`            | 2         | ✅ Lit templates |
+| `messageFormatters.ts`           | 4         | ✅ Lit templates |
+| `toolFormatters.ts`              | 2         | ✅ Lit templates |
+| `dataFormatters.ts`              | 4         | ✅ Lit templates |
+| `contextManagementFormatters.ts` | 1         | ✅ Lit templates |
+| `taskGroupFormatter.ts`          | 1         | ✅ Lit templates |
 
 ---
 
@@ -316,13 +316,13 @@ Incremental updates already work for append/update operations. Full rebuild only
 
 **Current state:**
 
-| Method | Pattern | Performance | Status |
-|--------|---------|-------------|--------|
-| `appendLog()` | Incremental append | O(1) | ✅ Complete |
-| `updateLog()` | Single element replace | O(1) | ✅ Complete |
-| `addGroup()` | Incremental insert | O(m) | ✅ Complete |
-| `updateGroup()` | Micro-updates (icon, duration) | O(1) | ✅ Complete |
-| `renderLogs()` | Full rebuild | O(n log n) | ❌ Still rebuilds |
+| Method          | Pattern                        | Performance | Status            |
+| --------------- | ------------------------------ | ----------- | ----------------- |
+| `appendLog()`   | Incremental append             | O(1)        | ✅ Complete       |
+| `updateLog()`   | Single element replace         | O(1)        | ✅ Complete       |
+| `addGroup()`    | Incremental insert             | O(m)        | ✅ Complete       |
+| `updateGroup()` | Micro-updates (icon, duration) | O(1)        | ✅ Complete       |
+| `renderLogs()`  | Full rebuild                   | O(n log n)  | ❌ Still rebuilds |
 
 **Typical flow (mostly incremental):**
 
@@ -370,12 +370,12 @@ renderLogs(logs: LogEntry[]): void {
 
 **Problem:** TaskGroupDomManager mixes several unrelated concerns:
 
-| Concern | Lines | Coupling Issue |
-|---------|-------|----------------|
-| DOM element management | 74-165 | Core responsibility |
-| Toggle state persistence | 45-72 | Should be in state manager |
-| Audio notifications | `playSystemSound()` | Should be dedicated service |
-| Traversal/hierarchy logic | 180-220 | Could be separate utility |
+| Concern                   | Lines               | Coupling Issue              |
+| ------------------------- | ------------------- | --------------------------- |
+| DOM element management    | 74-165              | Core responsibility         |
+| Toggle state persistence  | 45-72               | Should be in state manager  |
+| Audio notifications       | `playSystemSound()` | Should be dedicated service |
+| Traversal/hierarchy logic | 180-220             | Could be separate utility   |
 
 **Recommendation:** Extract concerns into focused modules:
 
@@ -383,8 +383,10 @@ renderLogs(logs: LogEntry[]): void {
 managers/
 ├── TaskGroupDomManager.ts    # DOM operations only
 ├── TaskGroupStateManager.ts  # Toggle persistence
-├── AudioNotificationService.ts # System sounds
+├── services/AudioNotificationService.ts # System sounds
 └── utils/taskGroupTraversal.ts # Hierarchy navigation
+
+**Status:** ✅ Implemented (TaskGroupDomManager now delegates toggle state, audio, and traversal concerns).
 ```
 
 ### A2. Light DOM in ProgressView (MEDIUM)
@@ -476,14 +478,14 @@ Fix known bugs before refactoring to establish stable baseline.
 
 ## Success Metrics
 
-| Metric | Before | Current | Target |
-|--------|--------|---------|--------|
-| MainApp.ts lines | 2,900 | 2,900 | ~500 |
-| Extracted components | 0 | 0 | 6+ |
-| Inline arrow functions | 37 | 37 | 0 |
-| Formatters using Lit templates | 0 | 14 ✅ | 14 (complete) |
-| `.map()` → `repeat()` migrations | 0 | 4 | 8+ |
-| Incremental log updates | partial | hybrid ✅ | hybrid (acceptable) |
+| Metric                           | Before  | Current   | Target              |
+| -------------------------------- | ------- | --------- | ------------------- |
+| MainApp.ts lines                 | 2,900   | 2,900     | ~500                |
+| Extracted components             | 0       | 0         | 6+                  |
+| Inline arrow functions           | 37      | 37        | 0                   |
+| Formatters using Lit templates   | 0       | 14 ✅     | 14 (complete)       |
+| `.map()` → `repeat()` migrations | 0       | 4         | 8+                  |
+| Incremental log updates          | partial | hybrid ✅ | hybrid (acceptable) |
 
 ---
 
@@ -494,6 +496,7 @@ Fix known bugs before refactoring to establish stable baseline.
 MainApp has complex state shared across file selection, agent config, and execution.
 
 **Mitigation:**
+
 - Extract leaf components first (FileItem, banners)
 - Use events to communicate back to MainApp
 - Keep shared state in MainApp until extraction stabilizes
@@ -503,6 +506,7 @@ MainApp has complex state shared across file selection, agent config, and execut
 Breaking existing functionality while extracting components.
 
 **Mitigation:**
+
 - Extract one component at a time
 - Manual testing after each extraction
 - Keep original code commented until verified

--- a/src/progressView/frontend/components/FileList.ts
+++ b/src/progressView/frontend/components/FileList.ts
@@ -202,7 +202,11 @@ export class FileList extends LitElement {
 
   private renderRound(round: number, files: OutputFileInfo[]): TemplateResult {
     if (!this.showRoundHeaders) {
-      return html`${files.map((file) => this.renderFileItem(file))}`;
+      return html`${repeat(
+        files,
+        (file) => file.location?.absolutePath ?? file.label ?? '',
+        (file) => this.renderFileItem(file),
+      )}`;
     }
 
     return html`
@@ -212,7 +216,11 @@ export class FileList extends LitElement {
         ?open=${true}
       >
         <div class="round-content">
-          ${files.map((file) => this.renderFileItem(file))}
+          ${repeat(
+            files,
+            (file) => file.location?.absolutePath ?? file.label ?? '',
+            (file) => this.renderFileItem(file),
+          )}
         </div>
       </vscode-collapsible>
     `;

--- a/src/progressView/frontend/components/LogList.ts
+++ b/src/progressView/frontend/components/LogList.ts
@@ -22,6 +22,7 @@ import {
   TaskGroupDomManager,
   LogEntryManager,
 } from '../managers/TaskGroupDomManager';
+import { TaskGroupStateManager } from '../managers/TaskGroupStateManager';
 
 // Local imports - shared schemas
 import type {
@@ -60,7 +61,12 @@ export class LogList extends LitElement {
     if (Array.isArray(previous?.groupToggleStates)) {
       this.toggleStates.load(previous.groupToggleStates);
     }
-    this.groupManager = new TaskGroupDomManager(this.toggleStates, this);
+    const groupStateManager = new TaskGroupStateManager(this.toggleStates);
+    this.groupManager = new TaskGroupDomManager(
+      groupStateManager,
+      undefined,
+      this,
+    );
     this.logManager = new LogEntryManager(this);
     this.lastRenderedStream = '';
   }

--- a/src/progressView/frontend/components/PromptOverlay.ts
+++ b/src/progressView/frontend/components/PromptOverlay.ts
@@ -1,6 +1,7 @@
 // Third-party imports
 import { LitElement, html, css, nothing, type TemplateResult } from 'lit';
 import { customElement, property, query, state } from 'lit/decorators.js';
+import { repeat } from 'lit/directives/repeat.js';
 import { when } from 'lit/directives/when.js';
 
 // Local imports - shared
@@ -475,8 +476,10 @@ export class PromptOverlay extends LitElement {
       { label: 'Output', files: prompt.outputFiles ?? [] },
     ];
 
-    return html`${fileLists.map(({ label, files }) =>
-      this.renderFileList(label, files),
+    return html`${repeat(
+      fileLists,
+      ({ label }) => label,
+      ({ label, files }) => this.renderFileList(label, files),
     )}`;
   }
 
@@ -489,12 +492,15 @@ export class PromptOverlay extends LitElement {
     return html`
       <div class="file-list">
         <span class="file-list-label">${label}:</span>
-        ${files.map(
-          (file, i) =>
-            html`${i > 0 ? ', ' : ''}<span
+        ${repeat(
+          files,
+          (file) => file,
+          (file, index) =>
+            html`${index > 0 ? ', ' : ''}<span
                 class="file-link"
                 title=${file}
-                @click=${() => this.openFile(file)}
+                data-file-path=${file}
+                @click=${this.handleFileLinkClick}
                 >${getBasename(file)}</span
               >`,
         )}
@@ -513,12 +519,18 @@ export class PromptOverlay extends LitElement {
     const secondaryActions = SECONDARY_ACTIONS[this.prompt.kind];
 
     return html`
-      ${primaryActions.map((config) => this.renderActionButton(config))}
+      ${repeat(
+        primaryActions,
+        (config) => config.action,
+        (config) => this.renderActionButton(config),
+      )}
       ${secondaryActions.length > 0
         ? html`
             <div class="secondary-actions">
-              ${secondaryActions.map((config) =>
-                this.renderActionButton(config),
+              ${repeat(
+                secondaryActions,
+                (config) => config.action,
+                (config) => this.renderActionButton(config),
               )}
             </div>
           `
@@ -548,6 +560,13 @@ export class PromptOverlay extends LitElement {
   // ===========================================================================
   // Event handlers
   // ===========================================================================
+
+  private handleFileLinkClick = (event: Event): void => {
+    const target = event.currentTarget as HTMLElement | null;
+    const filePath = target?.dataset.filePath;
+    if (!filePath) return;
+    this.openFile(filePath);
+  };
 
   private handleActionClick = (event: MouseEvent): void => {
     const target = event.currentTarget as HTMLElement | null;

--- a/src/progressView/frontend/components/RunSelector.ts
+++ b/src/progressView/frontend/components/RunSelector.ts
@@ -1,6 +1,7 @@
 // Third-party imports
 import { LitElement, html, css, type TemplateResult } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
+import { repeat } from 'lit/directives/repeat.js';
 
 // Local imports - progress view
 // Note: Design tokens from tokens.css are inherited into Shadow DOM via :root
@@ -44,7 +45,9 @@ export class RunSelector extends LitElement {
         @change=${this.handleChange}
       >
         <span slot="placeholder">No sessions</span>
-        ${sortedRuns.map(
+        ${repeat(
+          sortedRuns,
+          (run) => run.id,
           (run) => html`
             <vscode-option value=${run.id}>
               ${this.formatRunLabel(run)}

--- a/src/progressView/frontend/components/StreamHeader.ts
+++ b/src/progressView/frontend/components/StreamHeader.ts
@@ -3,6 +3,7 @@ import { LitElement, html, css, nothing, type TemplateResult } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
+import { repeat } from 'lit/directives/repeat.js';
 
 // Local imports - shared styles
 // Note: Design tokens from tokens.css are inherited into Shadow DOM via :root
@@ -341,34 +342,38 @@ export class StreamHeader extends LitElement {
               data-agent-mode=${agentCategory}
               @click=${this.handleToolbarClick}
             >
-              ${(toolbarButtons as ToolbarButton[]).map((btn) => {
-                const { disabled, hidden } = this.resolveButtonState(
-                  btn.id,
-                  status,
-                  hasExecutionId,
-                );
-                const isActive = Boolean(btn.isToggle && this.yoloActive);
-                const icon =
-                  isActive && btn.iconActive ? btn.iconActive : btn.icon;
-                const title =
-                  isActive && btn.titleActive ? btn.titleActive : btn.title;
-                return html`
-                  <vscode-toolbar-button
-                    id=${btn.id}
-                    icon=${icon}
-                    label=${title}
-                    title=${title}
-                    data-command=${btn.command}
-                    aria-hidden=${hidden ? 'true' : 'false'}
-                    ?disabled=${disabled}
-                    class=${classMap({
-                      [btn.className || '']: Boolean(btn.className),
-                      'toolbar-button--hidden': hidden,
-                      'is-active': isActive,
-                    })}
-                  ></vscode-toolbar-button>
-                `;
-              })}
+              ${repeat(
+                toolbarButtons as ToolbarButton[],
+                (btn) => btn.id,
+                (btn) => {
+                  const { disabled, hidden } = this.resolveButtonState(
+                    btn.id,
+                    status,
+                    hasExecutionId,
+                  );
+                  const isActive = Boolean(btn.isToggle && this.yoloActive);
+                  const icon =
+                    isActive && btn.iconActive ? btn.iconActive : btn.icon;
+                  const title =
+                    isActive && btn.titleActive ? btn.titleActive : btn.title;
+                  return html`
+                    <vscode-toolbar-button
+                      id=${btn.id}
+                      icon=${icon}
+                      label=${title}
+                      title=${title}
+                      data-command=${btn.command}
+                      aria-hidden=${hidden ? 'true' : 'false'}
+                      ?disabled=${disabled}
+                      class=${classMap({
+                        [btn.className || '']: Boolean(btn.className),
+                        'toolbar-button--hidden': hidden,
+                        'is-active': isActive,
+                      })}
+                    ></vscode-toolbar-button>
+                  `;
+                },
+              )}
             </vscode-toolbar-container>
           </div>
         </div>

--- a/src/progressView/frontend/components/StreamTabs.ts
+++ b/src/progressView/frontend/components/StreamTabs.ts
@@ -287,7 +287,9 @@ export class StreamTabs extends LitElement {
             .value=${this.filter}
             @change=${this.handleFilterChange}
           >
-            ${FILTER_BUTTONS.map(
+            ${repeat(
+              FILTER_BUTTONS,
+              (btn) => btn.id,
               (btn) => html`
                 <vscode-radio id=${btn.id} value=${btn.filter}>
                   ${btn.label}
@@ -300,7 +302,9 @@ export class StreamTabs extends LitElement {
             id="sortButtons"
             @click=${this.handleSortClick}
           >
-            ${SORT_BUTTONS.map(
+            ${repeat(
+              SORT_BUTTONS,
+              (btn) => btn.id,
               (btn) => html`
                 <vscode-toolbar-button
                   id=${btn.id}

--- a/src/progressView/frontend/components/ToolUseStreamContent.ts
+++ b/src/progressView/frontend/components/ToolUseStreamContent.ts
@@ -19,7 +19,12 @@
  */
 
 // Third-party imports
-import { LitElement, html, type TemplateResult } from 'lit';
+import {
+  LitElement,
+  html,
+  type PropertyValues,
+  type TemplateResult,
+} from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { guard } from 'lit/directives/guard.js';
 import { createRef, ref, type Ref } from 'lit/directives/ref.js';
@@ -58,8 +63,21 @@ export class ToolUseStreamContent extends LitElement {
   private logListRef: Ref<LogList> = createRef();
   /** Ref for FollowUpInput - exposed for parent access */
   private followUpRef: Ref<FollowUpInput> = createRef();
+  /** Cached prompts filtered for the active stream */
+  private filteredPrompts: PromptState[] = [];
+
+  protected willUpdate(changedProperties: PropertyValues<this>): void {
+    if (
+      changedProperties.has('prompts') ||
+      changedProperties.has('streamInfo')
+    ) {
+      this.filteredPrompts = this.computeFilteredPrompts();
+    }
+  }
 
   render(): TemplateResult {
+    const hasPrompts = this.filteredPrompts.length > 0;
+    const activePrompt = this.filteredPrompts.at(0) ?? null;
     return html`
       <stream-header
         .stream=${this.streamInfo}
@@ -72,14 +90,8 @@ export class ToolUseStreamContent extends LitElement {
       ></stream-header>
 
       <prompt-overlay
-        ?hidden=${guard(
-          [this.prompts, this.streamInfo?.name],
-          () => this.computeFilteredPrompts().length === 0,
-        )}
-        .prompt=${guard(
-          [this.prompts, this.streamInfo?.name],
-          () => this.computeFilteredPrompts().at(0) ?? null,
-        )}
+        ?hidden=${!hasPrompts}
+        .prompt=${activePrompt}
       ></prompt-overlay>
 
       <todo-list .todos=${this.state.todos}></todo-list>

--- a/src/progressView/frontend/components/ToolUseStreamContent.ts
+++ b/src/progressView/frontend/components/ToolUseStreamContent.ts
@@ -19,13 +19,9 @@
  */
 
 // Third-party imports
-import {
-  LitElement,
-  html,
-  type PropertyValues,
-  type TemplateResult,
-} from 'lit';
+import { LitElement, html, type TemplateResult } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
+import { guard } from 'lit/directives/guard.js';
 import { createRef, ref, type Ref } from 'lit/directives/ref.js';
 
 // Local imports - shared schemas
@@ -46,9 +42,6 @@ import './TaskGroupList';
 import './UsagePanel';
 import './FollowUpInput';
 
-/** Run group info for the run selector */
-type RunGroup = { id: string; name: string; startTime: number };
-
 @customElement('tool-use-stream-content')
 export class ToolUseStreamContent extends LitElement {
   // Use Light DOM so document-level CSS (logs.css, groups.css, etc.)
@@ -61,44 +54,10 @@ export class ToolUseStreamContent extends LitElement {
   @property({ type: Object }) streamInfo!: StreamTabInfo;
   @property({ type: Array }) prompts: PromptState[] = [];
 
-  // Cached derived values - recomputed only when dependencies change
-  private _cachedFilteredPrompts: PromptState[] = [];
-  private _cachedRunGroups: RunGroup[] = [];
-  private _prevStreamId: string | null = null;
-  private _prevPrompts: PromptState[] | null = null;
-  private _prevTaskGroups: unknown[] | null = null;
-
   /** Ref for LogList - exposed for parent access via getLogListRef() */
   private logListRef: Ref<LogList> = createRef();
   /** Ref for FollowUpInput - exposed for parent access */
   private followUpRef: Ref<FollowUpInput> = createRef();
-
-  protected willUpdate(changedProperties: PropertyValues<this>): void {
-    // Recompute filtered prompts when prompts or streamInfo changes
-    if (
-      changedProperties.has('prompts') ||
-      changedProperties.has('streamInfo')
-    ) {
-      const streamId = this.streamInfo?.name;
-      if (
-        this._prevPrompts !== this.prompts ||
-        this._prevStreamId !== streamId
-      ) {
-        this._cachedFilteredPrompts = this.computeFilteredPrompts();
-        this._prevPrompts = this.prompts;
-        this._prevStreamId = streamId ?? null;
-      }
-    }
-
-    // Recompute run groups when state.taskGroups changes
-    if (changedProperties.has('state')) {
-      const taskGroups = this.state?.taskGroups;
-      if (this._prevTaskGroups !== taskGroups) {
-        this._cachedRunGroups = getRunGroups(taskGroups ?? []);
-        this._prevTaskGroups = taskGroups ?? null;
-      }
-    }
-  }
 
   render(): TemplateResult {
     return html`
@@ -106,13 +65,21 @@ export class ToolUseStreamContent extends LitElement {
         .stream=${this.streamInfo}
         .streamState=${this.state}
         .runId=${null}
-        .runs=${this._cachedRunGroups}
+        .runs=${guard([this.state?.taskGroups], () =>
+          getRunGroups(this.state?.taskGroups ?? []),
+        )}
         .yoloActive=${Boolean(this.state.toolEditBypass)}
       ></stream-header>
 
       <prompt-overlay
-        ?hidden=${this._cachedFilteredPrompts.length === 0}
-        .prompt=${this._cachedFilteredPrompts.at(0) ?? null}
+        ?hidden=${guard(
+          [this.prompts, this.streamInfo?.name],
+          () => this.computeFilteredPrompts().length === 0,
+        )}
+        .prompt=${guard(
+          [this.prompts, this.streamInfo?.name],
+          () => this.computeFilteredPrompts().at(0) ?? null,
+        )}
       ></prompt-overlay>
 
       <todo-list .todos=${this.state.todos}></todo-list>

--- a/src/progressView/frontend/components/WorkflowStreamContent.ts
+++ b/src/progressView/frontend/components/WorkflowStreamContent.ts
@@ -20,7 +20,12 @@
  */
 
 // Third-party imports
-import { LitElement, html, type TemplateResult } from 'lit';
+import {
+  LitElement,
+  html,
+  type PropertyValues,
+  type TemplateResult,
+} from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { guard } from 'lit/directives/guard.js';
 import { createRef, ref, type Ref } from 'lit/directives/ref.js';
@@ -70,8 +75,22 @@ export class WorkflowStreamContent extends LitElement {
 
   /** Ref for LogList - exposed for parent access via getLogListRef() */
   private logListRef: Ref<LogList> = createRef();
+  /** Cached derived values for the currently selected run */
+  private runValues: RunDerivedValues = {
+    instruction: null,
+    usage: null,
+    files: {},
+    hasFiles: false,
+  };
+
+  protected willUpdate(changedProperties: PropertyValues<this>): void {
+    if (changedProperties.has('runId') || changedProperties.has('state')) {
+      this.runValues = this.computeRunValues();
+    }
+  }
 
   render(): TemplateResult {
+    const runValues = this.runValues;
     return html`
       <stream-header
         .stream=${this.streamInfo}
@@ -84,37 +103,25 @@ export class WorkflowStreamContent extends LitElement {
       ></stream-header>
 
       <instruction-panel
-        .instruction=${guard(
-          [this.runId, this.state],
-          () => this.computeRunValues().instruction,
-        )}
+        .instruction=${runValues.instruction}
       ></instruction-panel>
 
       <task-group-list ${ref(this.logListRef)}></task-group-list>
 
       <usage-panel
-        .usage=${guard(
-          [this.runId, this.state],
-          () => this.computeRunValues().usage,
-        )}
+        .usage=${runValues.usage}
         .contextState=${this.state.contextState ?? null}
       ></usage-panel>
 
       <file-list
-        .filesByRound=${guard(
-          [this.runId, this.state],
-          () => this.computeRunValues().files,
-        )}
+        .filesByRound=${runValues.files}
         .showRoundHeaders=${true}
       ></file-list>
 
       <followup-section
         .agentCategory=${this.streamInfo.agentCategory}
         .status=${this.state.status ?? this.streamInfo.status ?? ''}
-        .hasOutputFiles=${guard(
-          [this.runId, this.state],
-          () => this.computeRunValues().hasFiles,
-        )}
+        .hasOutputFiles=${runValues.hasFiles}
         .options=${this.followupOptions}
         .mode=${this.state.followupMode}
         .streamModel=${this.streamInfo.model ?? null}

--- a/src/progressView/frontend/components/WorkflowStreamContent.ts
+++ b/src/progressView/frontend/components/WorkflowStreamContent.ts
@@ -20,13 +20,9 @@
  */
 
 // Third-party imports
-import {
-  LitElement,
-  html,
-  type PropertyValues,
-  type TemplateResult,
-} from 'lit';
+import { LitElement, html, type TemplateResult } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
+import { guard } from 'lit/directives/guard.js';
 import { createRef, ref, type Ref } from 'lit/directives/ref.js';
 
 // Local imports - shared schemas
@@ -50,9 +46,6 @@ import './UsagePanel';
 import './FileList';
 import './FollowupSection';
 
-/** Run group info for the run selector */
-type RunGroup = { id: string; name: string; startTime: number };
-
 /** Cached derived values for a specific runId */
 interface RunDerivedValues {
   instruction: InstructionUpdate | null;
@@ -75,68 +68,53 @@ export class WorkflowStreamContent extends LitElement {
   @property({ type: Object }) followupOptions: FollowupOptionsState | null =
     null;
 
-  // Cached derived values - recomputed only when dependencies change
-  private _cachedRunGroups: RunGroup[] = [];
-  private _cachedRunValues: RunDerivedValues = {
-    instruction: null,
-    usage: null,
-    files: {},
-    hasFiles: false,
-  };
-  private _prevTaskGroups: unknown[] | null = null;
-  private _prevRunId: string | null = null;
-  private _prevState: WorkflowStreamState | null = null;
-
   /** Ref for LogList - exposed for parent access via getLogListRef() */
   private logListRef: Ref<LogList> = createRef();
 
-  protected willUpdate(changedProperties: PropertyValues<this>): void {
-    // Recompute run groups when state.taskGroups changes
-    if (changedProperties.has('state')) {
-      const taskGroups = this.state?.taskGroups;
-      if (this._prevTaskGroups !== taskGroups) {
-        this._cachedRunGroups = getRunGroups(taskGroups ?? []);
-        this._prevTaskGroups = taskGroups ?? null;
-      }
-    }
-
-    // Recompute run-specific values when runId or state changes
-    if (changedProperties.has('runId') || changedProperties.has('state')) {
-      if (this._prevRunId !== this.runId || this._prevState !== this.state) {
-        this._cachedRunValues = this.computeRunValues();
-        this._prevRunId = this.runId;
-        this._prevState = this.state;
-      }
-    }
-  }
-
   render(): TemplateResult {
-    const { instruction, usage, files, hasFiles } = this._cachedRunValues;
-
     return html`
       <stream-header
         .stream=${this.streamInfo}
         .streamState=${this.state}
         .runId=${this.runId}
-        .runs=${this._cachedRunGroups}
+        .runs=${guard([this.state?.taskGroups], () =>
+          getRunGroups(this.state?.taskGroups ?? []),
+        )}
         .yoloActive=${false}
       ></stream-header>
 
-      <instruction-panel .instruction=${instruction}></instruction-panel>
+      <instruction-panel
+        .instruction=${guard(
+          [this.runId, this.state],
+          () => this.computeRunValues().instruction,
+        )}
+      ></instruction-panel>
 
       <task-group-list ${ref(this.logListRef)}></task-group-list>
 
       <usage-panel
-        .usage=${usage}
+        .usage=${guard(
+          [this.runId, this.state],
+          () => this.computeRunValues().usage,
+        )}
         .contextState=${this.state.contextState ?? null}
       ></usage-panel>
 
-      <file-list .filesByRound=${files} .showRoundHeaders=${true}></file-list>
+      <file-list
+        .filesByRound=${guard(
+          [this.runId, this.state],
+          () => this.computeRunValues().files,
+        )}
+        .showRoundHeaders=${true}
+      ></file-list>
 
       <followup-section
         .agentCategory=${this.streamInfo.agentCategory}
         .status=${this.state.status ?? this.streamInfo.status ?? ''}
-        .hasOutputFiles=${hasFiles}
+        .hasOutputFiles=${guard(
+          [this.runId, this.state],
+          () => this.computeRunValues().hasFiles,
+        )}
         .options=${this.followupOptions}
         .mode=${this.state.followupMode}
         .streamModel=${this.streamInfo.model ?? null}

--- a/src/progressView/frontend/managers/TaskGroupDomManager.ts
+++ b/src/progressView/frontend/managers/TaskGroupDomManager.ts
@@ -1,8 +1,5 @@
 // Local imports - Lit template utilities
-import { ToggleStateStore } from '@shared/state/ToggleStateStore';
 import { html, render, renderToElement } from '../formatters/litTemplates';
-
-// Local imports - shared state
 
 // Local imports - progress view constants
 import { ELEMENT_IDS, GROUP_DOM_IDS, STREAM_STATUS } from '../constants';
@@ -16,11 +13,20 @@ import {
 
 // Local imports - progress view helpers
 import { insertChronologically } from '../utils';
+import {
+  collapseGroupTree,
+  findActiveGroupId,
+} from '../utils/taskGroupTraversal';
+
+// Local imports - progress view services
+import { AudioNotificationService } from '../services/AudioNotificationService';
+
+// Local imports - progress view managers
+import { TaskGroupStateManager } from './TaskGroupStateManager';
 
 // Local imports - shared schemas
 import type { LogMessageData, TaskGroup } from '@shared/schemas';
 
-type ToggleListener = (event: Event) => void;
 type RootElement = Document | Element;
 type LogFormatOptions = {
   preservedOpen?: boolean;
@@ -32,21 +38,25 @@ export class TaskGroupDomManager {
   private previousActiveGroupId: string | null;
   private groupElements: Map<string, HTMLElement>;
   private _rootGroupIds: Set<string>;
-  private toggleListeners: Map<string, ToggleListener>;
   private taskGroups: Map<string, TaskGroup>;
   private currentGroupId: string | null;
-  private toggleStates: ToggleStateStore;
+  private stateManager: TaskGroupStateManager;
+  private audioService: AudioNotificationService;
   private root: RootElement;
 
-  constructor(toggleStates?: ToggleStateStore, root?: RootElement) {
+  constructor(
+    stateManager?: TaskGroupStateManager,
+    audioService?: AudioNotificationService,
+    root?: RootElement,
+  ) {
     this.headerFormatter = new TaskGroupHeaderFormatter();
     this.previousActiveGroupId = null;
     this.groupElements = new Map();
     this._rootGroupIds = new Set();
-    this.toggleListeners = new Map();
     this.taskGroups = new Map();
     this.currentGroupId = null;
-    this.toggleStates = toggleStates ?? new ToggleStateStore();
+    this.stateManager = stateManager ?? new TaskGroupStateManager();
+    this.audioService = audioService ?? new AudioNotificationService();
     this.root = root ?? document;
   }
 
@@ -191,7 +201,7 @@ export class TaskGroupDomManager {
 
     // Play sound when a run group completes (name matches r1, r2, etc.)
     if (wasRunning && isNowComplete && /^r\d+$/.test(group.name)) {
-      this.playSystemSound();
+      this.audioService.playCompletionBeep();
     }
 
     const header = this._getById(`${GROUP_DOM_IDS.HEADER_PREFIX}${id}`);
@@ -215,32 +225,6 @@ export class TaskGroupDomManager {
       durationElem.textContent = durationMs
         ? this.headerFormatter._formatDuration(durationMs)
         : '';
-    }
-  }
-
-  /**
-   * Plays a short system beep to notify the user that a run has completed.
-   */
-  playSystemSound(): void {
-    try {
-      const AudioCtx =
-        window.AudioContext ||
-        (window as Window & { webkitAudioContext?: typeof AudioContext })
-          .webkitAudioContext;
-      if (!AudioCtx) return;
-
-      const ctx = new AudioCtx();
-      const osc = ctx.createOscillator();
-      osc.type = 'sine';
-      osc.frequency.value = 880;
-      osc.connect(ctx.destination);
-      osc.start();
-      setTimeout(() => {
-        osc.stop();
-        ctx.close();
-      }, 150);
-    } catch {
-      // Ignore errors (e.g., autoplay restrictions)
     }
   }
 
@@ -278,54 +262,27 @@ export class TaskGroupDomManager {
   }
 
   collapseGroupAndChildren(groupId: string): void {
-    for (const [childId, group] of this.taskGroups.entries()) {
-      if (group.parentGroupId === groupId) {
-        this.collapseGroupAndChildren(childId);
+    collapseGroupTree(groupId, this.taskGroups, (id) => {
+      const detailsElem = this.groupElements.get(id);
+      if (detailsElem instanceof HTMLDetailsElement) {
+        detailsElem.open = false;
+        this.stateManager.setCollapsed(id, true);
       }
-    }
-
-    const detailsElem = this.groupElements.get(groupId);
-    if (detailsElem instanceof HTMLDetailsElement) {
-      detailsElem.open = false;
-      this.toggleStates.set(groupId, true);
-    }
+    });
   }
 
   findCurrentActiveGroup(): string | null {
-    const current = this.currentGroupId
-      ? this.taskGroups.get(this.currentGroupId)
-      : undefined;
-    if (current) return current.id;
-
-    let latestGroup: string | null = null;
-    let latestTime = 0;
-    for (const [id, element] of this.groupElements.entries()) {
-      if (!element) continue;
-      const group = this.taskGroups.get(id);
-      if (!group) continue;
-
-      const isRootGroup = !group.parentGroupId;
-      const isVisible = isRootGroup
-        ? !element.hidden
-        : element instanceof HTMLDetailsElement && element.open === true;
-      if (!isVisible) continue;
-
-      if (group.startTime > latestTime) {
-        latestGroup = id;
-        latestTime = group.startTime;
-      }
-    }
-
-    return latestGroup;
+    return findActiveGroupId(
+      this.currentGroupId,
+      this.taskGroups,
+      this.groupElements,
+    );
   }
 
   clear(): void {
-    for (const groupId of this.groupElements.keys()) {
-      this._removeToggleListener(groupId);
-    }
+    this.stateManager.clear(this.groupElements);
     this.groupElements.clear();
     this._rootGroupIds.clear();
-    this.toggleListeners.clear();
     this.taskGroups.clear();
     this.previousActiveGroupId = null;
   }
@@ -380,20 +337,9 @@ export class TaskGroupDomManager {
     // Insert header before content
     detailsElem.insertBefore(headerElement, detailsElem.firstChild);
 
-    this._setupToggleState(group.id, detailsElem);
+    this.stateManager.applyToggleState(group.id, detailsElem);
     this._registerGroupElement(group, detailsElem);
     return detailsElem;
-  }
-
-  _setupToggleState(groupId: string, detailsElem: HTMLDetailsElement): void {
-    const isCollapsed = this.toggleStates.get(groupId) === true;
-    detailsElem.open = !isCollapsed;
-
-    const toggleListener: ToggleListener = () => {
-      this.toggleStates.set(groupId, !detailsElem.open);
-    };
-    detailsElem.addEventListener('toggle', toggleListener);
-    this.toggleListeners.set(groupId, toggleListener);
   }
 
   _registerGroupElement(group: TaskGroup, element: HTMLElement): void {
@@ -420,12 +366,8 @@ export class TaskGroupDomManager {
   }
 
   _removeToggleListener(groupId: string): void {
-    const listener = this.toggleListeners.get(groupId);
     const element = this.groupElements.get(groupId);
-    if (listener && element) {
-      element.removeEventListener('toggle', listener);
-    }
-    this.toggleListeners.delete(groupId);
+    this.stateManager.removeToggleListener(groupId, element ?? null);
   }
 
   _discardGroup(groupId: string): void {

--- a/src/progressView/frontend/managers/TaskGroupStateManager.ts
+++ b/src/progressView/frontend/managers/TaskGroupStateManager.ts
@@ -1,0 +1,49 @@
+// Local imports - shared state
+import { ToggleStateStore } from '@shared/state/ToggleStateStore';
+
+type ToggleListener = (event: Event) => void;
+
+type GroupElements = Map<string, HTMLElement>;
+
+/**
+ * Tracks task group toggle state and synchronizes it with DOM elements.
+ */
+export class TaskGroupStateManager {
+  private toggleStates: ToggleStateStore;
+  private toggleListeners: Map<string, ToggleListener>;
+
+  constructor(toggleStates?: ToggleStateStore) {
+    this.toggleStates = toggleStates ?? new ToggleStateStore();
+    this.toggleListeners = new Map();
+  }
+
+  applyToggleState(groupId: string, detailsElem: HTMLDetailsElement): void {
+    const isCollapsed = this.toggleStates.get(groupId) === true;
+    detailsElem.open = !isCollapsed;
+
+    const toggleListener: ToggleListener = () => {
+      this.toggleStates.set(groupId, !detailsElem.open);
+    };
+    detailsElem.addEventListener('toggle', toggleListener);
+    this.toggleListeners.set(groupId, toggleListener);
+  }
+
+  setCollapsed(groupId: string, isCollapsed: boolean): void {
+    this.toggleStates.set(groupId, isCollapsed);
+  }
+
+  removeToggleListener(groupId: string, element: HTMLElement | null): void {
+    const listener = this.toggleListeners.get(groupId);
+    if (listener && element) {
+      element.removeEventListener('toggle', listener);
+    }
+    this.toggleListeners.delete(groupId);
+  }
+
+  clear(groupElements: GroupElements): void {
+    for (const [groupId, element] of groupElements.entries()) {
+      this.removeToggleListener(groupId, element);
+    }
+    this.toggleListeners.clear();
+  }
+}

--- a/src/progressView/frontend/services/AudioNotificationService.ts
+++ b/src/progressView/frontend/services/AudioNotificationService.ts
@@ -1,0 +1,27 @@
+/**
+ * Plays lightweight audio notifications for progress view events.
+ */
+export class AudioNotificationService {
+  playCompletionBeep(): void {
+    try {
+      const AudioCtx =
+        window.AudioContext ||
+        (window as Window & { webkitAudioContext?: typeof AudioContext })
+          .webkitAudioContext;
+      if (!AudioCtx) return;
+
+      const ctx = new AudioCtx();
+      const osc = ctx.createOscillator();
+      osc.type = 'sine';
+      osc.frequency.value = 880;
+      osc.connect(ctx.destination);
+      osc.start();
+      setTimeout(() => {
+        osc.stop();
+        ctx.close();
+      }, 150);
+    } catch {
+      // Ignore errors (e.g., autoplay restrictions)
+    }
+  }
+}

--- a/src/progressView/frontend/utils/taskGroupTraversal.ts
+++ b/src/progressView/frontend/utils/taskGroupTraversal.ts
@@ -1,0 +1,47 @@
+// Local imports - shared schemas
+import type { TaskGroup } from '@shared/schemas';
+
+type GroupElements = Map<string, HTMLElement>;
+
+export function collapseGroupTree(
+  groupId: string,
+  taskGroups: Map<string, TaskGroup>,
+  onCollapse: (id: string) => void,
+): void {
+  for (const [childId, group] of taskGroups.entries()) {
+    if (group.parentGroupId === groupId) {
+      collapseGroupTree(childId, taskGroups, onCollapse);
+    }
+  }
+
+  onCollapse(groupId);
+}
+
+export function findActiveGroupId(
+  currentGroupId: string | null,
+  taskGroups: Map<string, TaskGroup>,
+  groupElements: GroupElements,
+): string | null {
+  const current = currentGroupId ? taskGroups.get(currentGroupId) : undefined;
+  if (current) return current.id;
+
+  let latestGroup: string | null = null;
+  let latestTime = 0;
+  for (const [id, element] of groupElements.entries()) {
+    const group = taskGroups.get(id);
+    if (!group) continue;
+
+    const isRootGroup = !group.parentGroupId;
+    const isVisible = isRootGroup
+      ? !element.hidden
+      : element instanceof HTMLDetailsElement && element.open === true;
+    if (!isVisible) continue;
+
+    if (group.startTime > latestTime) {
+      latestGroup = id;
+      latestTime = group.startTime;
+    }
+  }
+
+  return latestGroup;
+}

--- a/src/webview/frontend/MainApp.ts
+++ b/src/webview/frontend/MainApp.ts
@@ -2,7 +2,6 @@
 import { html, type TemplateResult } from 'lit';
 import { customElement, state, query } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
-import { repeat } from 'lit/directives/repeat.js';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import Sortable from 'sortablejs';
 
@@ -35,6 +34,32 @@ import {
 // Local imports - webview commands
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands';
 
+// Local imports - main view components
+import '@webview/frontend/components/ApiKeyBanner';
+import '@webview/frontend/components/AgentConfigBanner';
+import '@webview/frontend/components/DependencyBanner';
+import '@webview/frontend/components/FileSelectGroup';
+import '@webview/frontend/components/GettingStartedBanner';
+import '@webview/frontend/components/LatexDiffsSection';
+import '@webview/frontend/components/LoginBanner';
+import '@webview/frontend/components/OutputFilesGroup';
+
+// Type imports - main view components
+import type { ApiKeyBannerActionDetail } from '@webview/frontend/components/ApiKeyBanner';
+import type { AgentConfigBannerActionDetail } from '@webview/frontend/components/AgentConfigBanner';
+import type { DependencyBannerActionDetail } from '@webview/frontend/components/DependencyBanner';
+import type {
+  FileSelectActionDetail,
+  FileSelectConfig,
+  FileSelectFocusDetail,
+} from '@webview/frontend/components/FileSelectGroup';
+import type { LoginBannerActionDetail } from '@webview/frontend/components/LoginBanner';
+import type { OutputFilesActionDetail } from '@webview/frontend/components/OutputFilesGroup';
+import type {
+  LatexDiffsActionDetail,
+  LatexDiffsChangeDetail,
+} from '@webview/frontend/components/LatexDiffsSection';
+
 // Local imports - main view
 import {
   AGENT_SELECT_LIST,
@@ -49,10 +74,10 @@ import {
   type SessionType,
   parseSessionType,
 } from './constants';
-import { mainViewStyles } from './styles';
 import { handleImagePaste } from './pasteHandler';
+import { mainViewStyles } from './styles';
 
-// Type imports
+// Type imports - shared schemas
 import type { StateRestoreMessage } from '@shared/schemas/commonViewMessages';
 
 interface MainViewPersistedState extends Record<string, unknown> {
@@ -1257,6 +1282,27 @@ export class MainApp extends BaseWebviewApp {
     }
   }
 
+  private handleMenuToggle = (event: Event): void => {
+    const target = event.currentTarget as HTMLElement | null;
+    const action = target?.dataset.action;
+    if (action === 'toggle-auto-extract') {
+      this.toggleMenu('autoExtract');
+      return;
+    }
+    if (action === 'toggle-tool-config') {
+      this.toggleMenu('toolConfig');
+    }
+  };
+
+  private handleCheckboxToggle = (event: Event): void => {
+    const target = event.currentTarget as HTMLInputElement | null;
+    const checkboxId = target?.dataset.checkboxId as
+      | keyof typeof this.checkboxValues
+      | undefined;
+    if (!target || !checkboxId) return;
+    this.handleCheckboxChange(checkboxId, target.checked);
+  };
+
   private handleCheckboxChange(
     id: keyof typeof this.checkboxValues,
     value: boolean,
@@ -1446,12 +1492,13 @@ export class MainApp extends BaseWebviewApp {
     const provider = selectedOption?.dataset?.provider;
 
     if (requiresKey) {
-      this.apiKeyBannerForced = false;
+      const wasForced = this.apiKeyBannerForced;
       this.apiKeyBanner = {
         visible: true,
         provider: provider || '',
         requiresKey: true,
       };
+      this.apiKeyBannerForced = wasForced;
       return;
     }
 
@@ -1545,6 +1592,61 @@ export class MainApp extends BaseWebviewApp {
       this.instructionSaveTimer = null;
     }, 300);
   }
+
+  private handleSessionTypeToggle = (event: Event): void => {
+    const target = event.currentTarget as HTMLInputElement | null;
+    this.handleSessionTypeChange(target?.value ?? '');
+  };
+
+  private handlePackCleanAction = (event: Event): void => {
+    const target = event.currentTarget as HTMLElement | null;
+    const action = target?.dataset.action as 'pack' | 'clean' | undefined;
+    if (!action) return;
+    this.handlePackClean(action);
+  };
+
+  private handleEraseInstruction = (): void => {
+    this.instruction = '';
+    this.saveState();
+  };
+
+  private handleAgentSelectChange = (event: Event): void => {
+    const target = event.currentTarget as HTMLInputElement | null;
+    const sessionType = parseSessionType(
+      target?.dataset.sessionType ?? undefined,
+    );
+    if (!sessionType || !target) return;
+    this.handleAgentChange(sessionType, target.value, target);
+  };
+
+  private handleModelSelectChange = (event: Event): void => {
+    const target = event.currentTarget as HTMLInputElement | null;
+    if (!target) return;
+    this.handleModelChange(target.value);
+  };
+
+  private handleFocusInstruction = (event: Event): void => {
+    const target = event.currentTarget as HTMLElement | null;
+    const key = target?.dataset.instructionKey;
+    const text = target?.dataset.instructionText;
+    if (!key || !text) return;
+    postMessage(MAIN_VIEW_COMMANDS.SHOW_INSTRUCTION, { key, text });
+  };
+
+  private handleAgentSettingsAction = (event: Event): void => {
+    const target = event.currentTarget as HTMLElement | null;
+    const action = target?.dataset.action as
+      | 'edit'
+      | 'dir'
+      | 'docs'
+      | undefined;
+    if (!action) return;
+    this.handleAgentConfigAction(action);
+  };
+
+  private handleModelSettingsClick = (): void => {
+    postMessage(MAIN_VIEW_COMMANDS.OPEN_MODEL_SETTINGS);
+  };
 
   private startPlaceholderRotation(): void {
     if (this.placeholderTimer) return;
@@ -1802,32 +1904,192 @@ export class MainApp extends BaseWebviewApp {
     this.dependencyBanner = { visible: false };
   }
 
-  private renderFileList(listId: string): TemplateResult {
-    const files = this.multiFiles[listId] ?? [];
-    if (files.length === 0) {
-      if (listId === ELEMENT_IDS.OUTPUT_FILES) {
-        return html`<div class="file-list-placeholder">
-          No extra outputs selected. Click "Add" to choose files.
-        </div>`;
-      }
-      return html`<div class="file-list-placeholder">No files selected.</div>`;
+  private handleFileSelectActionEvent = (event: Event): void => {
+    const detail = (event as CustomEvent<FileSelectActionDetail>).detail;
+    const { action, fileType, listId, filePath, value } = detail;
+    switch (action) {
+      case 'refresh':
+        this.handleRefreshFiles(fileType);
+        break;
+      case 'current':
+        this.handleGetCurrentFile(fileType);
+        break;
+      case 'empty':
+        this.handleEmptyFile(fileType);
+        break;
+      case 'toggle':
+        this.toggleListVisibility(listId);
+        break;
+      case 'add-opened':
+        this.handleAddOpenedFiles(fileType);
+        break;
+      case 'empty-list':
+        this.handleEmptyFiles(fileType);
+        break;
+      case 'select-list':
+        this.handleSelectMultipleFiles(listId);
+        break;
+      case 'remove':
+        if (filePath) {
+          this.handleRemoveFile(listId, filePath);
+        }
+        break;
+      case 'change':
+        this.handleSingleFileChange(fileType, value ?? '');
+        break;
+      default:
+        break;
     }
+  };
 
-    return html`${repeat(
-      files,
-      (file) => file,
-      (file) => html`
-        <div class="file-item" data-path=${file}>
-          <span class="file-name">${file}</span>
-          <span
-            class="remove-button codicon codicon-trash"
-            role="button"
-            @click=${() => this.handleRemoveFile(listId, file)}
-          ></span>
-        </div>
-      `,
-    )}`;
-  }
+  private handleFileSelectFocusEvent = (event: Event): void => {
+    const detail = (event as CustomEvent<FileSelectFocusDetail>).detail;
+    if (!detail) return;
+    postMessage(MAIN_VIEW_COMMANDS.SHOW_INSTRUCTION, detail);
+  };
+
+  private handleOutputFilesActionEvent = (event: Event): void => {
+    const detail = (event as CustomEvent<OutputFilesActionDetail>).detail;
+    switch (detail.action) {
+      case 'toggle':
+        this.toggleListVisibility(ELEMENT_IDS.OUTPUT_FILES);
+        break;
+      case 'empty-list':
+        this.handleEmptyFiles('output');
+        break;
+      case 'select-list':
+        this.handleSelectMultipleFiles(ELEMENT_IDS.OUTPUT_FILES);
+        break;
+      case 'remove':
+        if (detail.filePath) {
+          this.handleRemoveFile(ELEMENT_IDS.OUTPUT_FILES, detail.filePath);
+        }
+        break;
+      default:
+        break;
+    }
+  };
+
+  private handleApiKeyBannerActionEvent = (event: Event): void => {
+    const detail = (event as CustomEvent<ApiKeyBannerActionDetail>).detail;
+    if (!detail) return;
+    this.handleApiKeyBannerAction(detail.action);
+  };
+
+  private handleAgentConfigBannerActionEvent = (event: Event): void => {
+    const detail = (event as CustomEvent<AgentConfigBannerActionDetail>).detail;
+    if (!detail) return;
+    this.handleAgentConfigAction(detail.action);
+  };
+
+  private handleDependencyBannerActionEvent = (event: Event): void => {
+    const detail = (event as CustomEvent<DependencyBannerActionDetail>).detail;
+    if (!detail) return;
+    const action = detail.action;
+    switch (action) {
+      case 'recheck':
+        postMessage(MAIN_VIEW_COMMANDS.RECHECK_DEPENDENCIES);
+        break;
+      case 'dismiss':
+        this.handleDependencyDismiss();
+        break;
+      case 'install':
+        if (detail.tool) {
+          postMessage(MAIN_VIEW_COMMANDS.OPEN_INSTALL_GUIDE, {
+            tool: detail.tool,
+          });
+        }
+        break;
+      default:
+        break;
+    }
+  };
+
+  private handleLoginBannerActionEvent = (event: Event): void => {
+    const detail = (event as CustomEvent<LoginBannerActionDetail>).detail;
+    if (!detail) return;
+    const action = detail.action;
+    if (action === 'sign-in') {
+      postMessage(MAIN_VIEW_COMMANDS.SIGN_IN_FROM_BANNER);
+      return;
+    }
+    postMessage(MAIN_VIEW_COMMANDS.DISMISS_LOGIN_BANNER);
+  };
+
+  private handleLatexDiffsActionEvent = (event: Event): void => {
+    const detail = (event as CustomEvent<LatexDiffsActionDetail>).detail;
+    if (!detail) return;
+    const action = detail.action;
+    switch (action) {
+      case 'toggle':
+        this.latexdiffsVisible = !this.latexdiffsVisible;
+        this.saveState();
+        break;
+      case 'current-base':
+        this.handleGetCurrentFile('base');
+        break;
+      case 'empty-base':
+        this.handleEmptyFile('base');
+        break;
+      case 'refresh-edited':
+        this.handleRefreshEditedFiles();
+        break;
+      case 'current-edited':
+        this.handleGetCurrentFile('edited');
+        break;
+      case 'empty-edited':
+        this.handleEmptyFile('edited');
+        break;
+      case 'refresh-commits':
+        postMessage(MAIN_VIEW_COMMANDS.REFRESH_COMMITS);
+        break;
+      case 'run-latexdiff':
+        this.handleLatexdiff();
+        break;
+      case 'run-latexdiffvc':
+        this.handleLatexdiffVC();
+        break;
+      case 'pack-latexdiffvc':
+        this.handleLatexdiffVCPack('pack');
+        break;
+      case 'clean-latexdiffvc':
+        this.handleLatexdiffVCPack('clean');
+        break;
+      case 'merge':
+        this.handleMerge();
+        break;
+      case 'compare':
+        this.handleCompare(MAIN_VIEW_COMMANDS.COMPARE);
+        break;
+      case 'accept':
+        this.handleCompare(MAIN_VIEW_COMMANDS.ACCEPT_EDITED);
+        break;
+      default:
+        break;
+    }
+  };
+
+  private handleLatexDiffsChangeEvent = (event: Event): void => {
+    const detail = (event as CustomEvent<LatexDiffsChangeDetail>).detail;
+    if (!detail) return;
+    const field = detail.field;
+    if (field === 'base') {
+      this.handleBaseFileChange(detail.value);
+      return;
+    }
+    if (field === 'edited') {
+      this.singleFiles = {
+        ...this.singleFiles,
+        editedFile: detail.value,
+      };
+      this.saveState();
+      return;
+    }
+    if (field === 'commit') {
+      this.commit = detail.value;
+      this.saveState();
+    }
+  };
 
   private hasOptionValue(optionsHtml: string, value: string): boolean {
     if (!value) {
@@ -1867,8 +2129,12 @@ export class MainApp extends BaseWebviewApp {
     return markOptionAsSelected(optionsHtml, this.commit);
   }
 
+  private get isToolUse(): boolean {
+    return this.sessionType === SESSION_TYPES.TOOL_USE;
+  }
+
   render(): TemplateResult {
-    const isToolUse = this.sessionType === SESSION_TYPES.TOOL_USE;
+    const isToolUse = this.isToolUse;
     const fileSelectionClasses = classMap({
       'file-selection-group': true,
       'file-selection-group--disabled': isToolUse,
@@ -1900,125 +2166,117 @@ export class MainApp extends BaseWebviewApp {
       <div class="content-wrapper">
         <div class="main-content">
           <div class=${fileSelectionClasses}>
-            ${this.renderFileSelect({
-              type: 'input',
-              label: 'Input',
-              icon: 'file-code',
-              refreshTitle: 'Refresh input files',
-              currentTitle: 'Set current file as input',
-              emptyTitle: 'Clear input file',
-              toggleTitle: 'Show or hide additional input files',
-              addOpenedLabel: 'Add opened files as input',
-              emptyListLabel: 'Clear all input files',
-              selectListLabel: 'Add input files',
-              tooltip:
-                'Primary files the agent processes, such as .tex, .txt, or .md',
-              toolConfig: 'tool',
-              focusInstruction: {
-                key: 'inputFileSelect',
-                text: 'Choose the main LaTeX file to process. Use the Current button to pick the active editor.',
-              },
-            })}
-            ${this.renderFileSelect({
-              type: 'reference',
-              label: 'Reference',
-              icon: 'book',
-              refreshTitle: 'Refresh reference files',
-              currentTitle: 'Set current file as reference',
-              emptyTitle: 'Clear reference file',
-              toggleTitle: 'Show or hide additional reference files',
-              addOpenedLabel: 'Add opened files as reference',
-              emptyListLabel: 'Clear all reference files',
-              selectListLabel: 'Add reference files',
-              tooltip:
-                "Context files such as .bib/.bbl or other papers that guide output but won't be modified",
-            })}
-            ${this.renderFileSelect({
-              type: 'auxiliary',
-              label: 'Auxiliary',
-              icon: 'archive',
-              refreshTitle: 'Refresh auxiliary files',
-              currentTitle: 'Set current file as auxiliary',
-              emptyTitle: 'Clear auxiliary file',
-              toggleTitle: 'Show or hide additional auxiliary files',
-              addOpenedLabel: 'Add opened files as auxiliary',
-              emptyListLabel: 'Clear all auxiliary files',
-              selectListLabel: 'Add auxiliary files',
-              tooltip:
-                'Files such as .cls/.sty that define document structure and styles',
-            })}
-            ${this.renderFileSelect({
-              type: 'media',
-              label: 'Media',
-              icon: 'device-camera-video',
-              refreshTitle: 'Refresh media files',
-              currentTitle: 'Set current file as media',
-              emptyTitle: 'Clear media file',
-              toggleTitle: 'Show or hide additional media files',
-              addOpenedLabel: 'Add opened files as media',
-              emptyListLabel: 'Clear all media files',
-              selectListLabel: 'Add media files',
-              tooltip: 'Images, figures, and media assets used by the document',
-              toolConfig: 'autoExtract',
-            })}
-            <div
-              class="file-select"
-              data-expanded=${String(this.outputFilesActive)}
-            >
-              <div class="file-select-header">
-                <div class="file-select-label-group">
-                  <span
-                    id="toggleOutputFiles"
-                    class="toggle-icon"
-                    title="Show or hide additional files for the agent's output"
-                    @click=${() => this.toggleListVisibility('outputFiles')}
-                  >
-                    <i
-                      class="codicon ${this.outputFilesActive
-                        ? 'codicon-chevron-up'
-                        : 'codicon-chevron-down'}"
-                    ></i>
-                  </span>
-                  <span
-                    class="optional-label"
-                    title="List the files that should receive the agent’s output"
-                    >Multiple Outputs</span
-                  >
-                </div>
-                <vscode-toolbar-container class="file-select-actions">
-                  <vscode-toolbar-button
-                    id="emptyOutputFilesButton"
-                    class="file-action-button"
-                    icon="trash"
-                    label="Clear all output files"
-                    title="Clear all output files"
-                    @click=${() => this.handleEmptyFiles('output')}
-                  ></vscode-toolbar-button>
-                  <vscode-toolbar-button
-                    id="selectOutputFilesButton"
-                    class="file-action-button"
-                    icon="add"
-                    label="Add output files"
-                    title="Add output files"
-                    @click=${() =>
-                      this.handleSelectMultipleFiles('outputFiles')}
-                  ></vscode-toolbar-button>
-                </vscode-toolbar-container>
-              </div>
-              <div
-                id="outputFilesContainer"
-                class="multiple-files-container"
-                style=${this.outputFilesActive
-                  ? 'display: block'
-                  : 'display: none'}
-              >
-                <div class="multiple-files-content">
-                  <div id="outputFiles" class="multiple-files-list">
-                    ${this.renderFileList('outputFiles')}
-                  </div>
-                </div>
-              </div>
-            </div>
+            <file-select-group
+              .config=${{
+                type: 'input',
+                label: 'Input',
+                icon: 'file-code',
+                refreshTitle: 'Refresh input files',
+                currentTitle: 'Set current file as input',
+                emptyTitle: 'Clear input file',
+                toggleTitle: 'Show or hide additional input files',
+                addOpenedLabel: 'Add opened files as input',
+                emptyListLabel: 'Clear all input files',
+                selectListLabel: 'Add input files',
+                tooltip:
+                  'Primary files the agent processes, such as .tex, .txt, or .md',
+                focusInstruction: {
+                  key: 'inputFileSelect',
+                  text: 'Choose the main LaTeX file to process. Use the Current button to pick the active editor.',
+                },
+              } satisfies FileSelectConfig}
+              .selectedValue=${this.singleFiles.inputFile}
+              .optionsHtml=${this.buildOptionsHtml(
+                this.fileOptions.inputFile ?? [],
+                this.singleFiles.inputFile,
+              )}
+              .isVisible=${this.multiFilesVisible.inputFiles}
+              .files=${this.multiFiles.inputFiles ?? []}
+              .toolConfigMenu=${this.renderToolConfigMenu()}
+              @file-select-action=${this.handleFileSelectActionEvent}
+              @file-select-focus=${this.handleFileSelectFocusEvent}
+            ></file-select-group>
+            <file-select-group
+              .config=${{
+                type: 'reference',
+                label: 'Reference',
+                icon: 'book',
+                refreshTitle: 'Refresh reference files',
+                currentTitle: 'Set current file as reference',
+                emptyTitle: 'Clear reference file',
+                toggleTitle: 'Show or hide additional reference files',
+                addOpenedLabel: 'Add opened files as reference',
+                emptyListLabel: 'Clear all reference files',
+                selectListLabel: 'Add reference files',
+                tooltip:
+                  'Context files such as .bib/.bbl or other papers that guide output but will not be modified',
+              } satisfies FileSelectConfig}
+              .selectedValue=${this.singleFiles.referenceFile}
+              .optionsHtml=${this.buildOptionsHtml(
+                this.fileOptions.referenceFile ?? [],
+                this.singleFiles.referenceFile,
+              )}
+              .isVisible=${this.multiFilesVisible.referenceFiles}
+              .files=${this.multiFiles.referenceFiles ?? []}
+              @file-select-action=${this.handleFileSelectActionEvent}
+              @file-select-focus=${this.handleFileSelectFocusEvent}
+            ></file-select-group>
+            <file-select-group
+              .config=${{
+                type: 'auxiliary',
+                label: 'Auxiliary',
+                icon: 'archive',
+                refreshTitle: 'Refresh auxiliary files',
+                currentTitle: 'Set current file as auxiliary',
+                emptyTitle: 'Clear auxiliary file',
+                toggleTitle: 'Show or hide additional auxiliary files',
+                addOpenedLabel: 'Add opened files as auxiliary',
+                emptyListLabel: 'Clear all auxiliary files',
+                selectListLabel: 'Add auxiliary files',
+                tooltip:
+                  'Files such as .cls/.sty that define document structure and styles',
+              } satisfies FileSelectConfig}
+              .selectedValue=${this.singleFiles.auxiliaryFile}
+              .optionsHtml=${this.buildOptionsHtml(
+                this.fileOptions.auxiliaryFile ?? [],
+                this.singleFiles.auxiliaryFile,
+              )}
+              .isVisible=${this.multiFilesVisible.auxiliaryFiles}
+              .files=${this.multiFiles.auxiliaryFiles ?? []}
+              @file-select-action=${this.handleFileSelectActionEvent}
+              @file-select-focus=${this.handleFileSelectFocusEvent}
+            ></file-select-group>
+            <file-select-group
+              .config=${{
+                type: 'media',
+                label: 'Media',
+                icon: 'device-camera-video',
+                refreshTitle: 'Refresh media files',
+                currentTitle: 'Set current file as media',
+                emptyTitle: 'Clear media file',
+                toggleTitle: 'Show or hide additional media files',
+                addOpenedLabel: 'Add opened files as media',
+                emptyListLabel: 'Clear all media files',
+                selectListLabel: 'Add media files',
+                tooltip:
+                  'Images, figures, and media assets used by the document',
+              } satisfies FileSelectConfig}
+              .selectedValue=${this.singleFiles.mediaFile}
+              .optionsHtml=${this.buildOptionsHtml(
+                this.fileOptions.mediaFile ?? [],
+                this.singleFiles.mediaFile,
+              )}
+              .isVisible=${this.multiFilesVisible.mediaFiles}
+              .files=${this.multiFiles.mediaFiles ?? []}
+              .toolConfigMenu=${this.renderAutoExtractMenu()}
+              @file-select-action=${this.handleFileSelectActionEvent}
+              @file-select-focus=${this.handleFileSelectFocusEvent}
+            ></file-select-group>
+            <output-files-group
+              .files=${this.multiFiles.outputFiles ?? []}
+              .isActive=${this.outputFilesActive}
+              @output-files-action=${this.handleOutputFilesActionEvent}
+            ></output-files-group>
           </div>
 
           <div class="instruction-box">
@@ -2035,10 +2293,7 @@ export class MainApp extends BaseWebviewApp {
                     aria-label="Choose the session type"
                     orientation="horizontal"
                     .value=${this.sessionType}
-                    @change=${(event: Event) => {
-                      const target = event.target as HTMLInputElement | null;
-                      this.handleSessionTypeChange(target?.value ?? '');
-                    }}
+                    @change=${this.handleSessionTypeToggle}
                   >
                     <vscode-radio
                       value="toolUse"
@@ -2066,7 +2321,8 @@ export class MainApp extends BaseWebviewApp {
                   label="Pack output to History"
                   title="Pack the output for this agent into the History folder"
                   style=${this.debugMode ? '' : 'display: none'}
-                  @click=${() => this.handlePackClean('pack')}
+                  data-action="pack"
+                  @click=${this.handlePackCleanAction}
                 ></vscode-toolbar-button>
                 <vscode-toolbar-button
                   id="cleanButton"
@@ -2074,7 +2330,8 @@ export class MainApp extends BaseWebviewApp {
                   label="Clean output"
                   title="Clean the output for this agent"
                   style=${this.debugMode ? '' : 'display: none'}
-                  @click=${() => this.handlePackClean('clean')}
+                  data-action="clean"
+                  @click=${this.handlePackCleanAction}
                 ></vscode-toolbar-button>
                 <vscode-toolbar-button
                   id="magicPolishButton"
@@ -2104,10 +2361,7 @@ export class MainApp extends BaseWebviewApp {
                   icon="clear-all"
                   label="Erase instruction"
                   title="Erase instruction"
-                  @click=${() => {
-                    this.instruction = '';
-                    this.saveState();
-                  }}
+                  @click=${this.handleEraseInstruction}
                 ></vscode-toolbar-button>
               </vscode-toolbar-container>
             </div>
@@ -2125,7 +2379,8 @@ export class MainApp extends BaseWebviewApp {
                     id="agentSettingsButton"
                     class="codicon codicon-sparkle clickable"
                     title="Agent settings"
-                    @click=${() => this.handleAgentConfigAction('edit')}
+                    data-action="edit"
+                    @click=${this.handleAgentSettingsAction}
                   ></i>
                   <div class="agent-select-controls">
                     <div class="agent-select-dropdowns">
@@ -2149,20 +2404,10 @@ export class MainApp extends BaseWebviewApp {
                           : 'true'}
                         position="above"
                         .value=${this.workflowAgent}
-                        @focus=${() =>
-                          postMessage(MAIN_VIEW_COMMANDS.SHOW_INSTRUCTION, {
-                            key: 'agentPicker',
-                            text: 'Select which agent will handle your request.',
-                          })}
-                        @change=${(event: Event) => {
-                          const target =
-                            event.currentTarget as HTMLInputElement;
-                          this.handleAgentChange(
-                            SESSION_TYPES.WORKFLOW,
-                            target.value,
-                            target,
-                          );
-                        }}
+                        data-instruction-key="agentPicker"
+                        data-instruction-text="Select which agent will handle your request."
+                        @focus=${this.handleFocusInstruction}
+                        @change=${this.handleAgentSelectChange}
                       >
                         ${unsafeHTML(workflowOptions)}
                       </vscode-single-select>
@@ -2179,20 +2424,10 @@ export class MainApp extends BaseWebviewApp {
                         aria-label="Tool-use agent"
                         position="above"
                         .value=${this.toolUseAgent}
-                        @focus=${() =>
-                          postMessage(MAIN_VIEW_COMMANDS.SHOW_INSTRUCTION, {
-                            key: 'agentPicker',
-                            text: 'Select which agent will handle your request.',
-                          })}
-                        @change=${(event: Event) => {
-                          const target =
-                            event.currentTarget as HTMLInputElement;
-                          this.handleAgentChange(
-                            SESSION_TYPES.TOOL_USE,
-                            target.value,
-                            target,
-                          );
-                        }}
+                        data-instruction-key="agentPicker"
+                        data-instruction-text="Select which agent will handle your request."
+                        @focus=${this.handleFocusInstruction}
+                        @change=${this.handleAgentSelectChange}
                       >
                         ${unsafeHTML(toolUseOptions)}
                       </vscode-single-select>
@@ -2204,23 +2439,17 @@ export class MainApp extends BaseWebviewApp {
                     id="modelSettingsButton"
                     class="codicon codicon-robot clickable"
                     title="Model settings"
-                    @click=${() =>
-                      postMessage(MAIN_VIEW_COMMANDS.OPEN_MODEL_SETTINGS)}
+                    @click=${this.handleModelSettingsClick}
                   ></i>
                   <vscode-single-select
                     id="model"
                     position="above"
                     aria-label="Model"
                     .value=${this.model}
-                    @focus=${() =>
-                      postMessage(MAIN_VIEW_COMMANDS.SHOW_INSTRUCTION, {
-                        key: 'modelPicker',
-                        text: 'Choose the AI model used by the selected agent.',
-                      })}
-                    @change=${(event: Event) => {
-                      const target = event.currentTarget as HTMLInputElement;
-                      this.handleModelChange(target.value);
-                    }}
+                    data-instruction-key="modelPicker"
+                    data-instruction-text="Choose the AI model used by the selected agent."
+                    @focus=${this.handleFocusInstruction}
+                    @change=${this.handleModelSelectChange}
                   >
                     ${unsafeHTML(modelOptions)}
                   </vscode-single-select>
@@ -2236,10 +2465,51 @@ export class MainApp extends BaseWebviewApp {
             </div>
           </div>
 
-          ${this.renderBanners()}
+          <api-key-banner
+            .visible=${this.apiKeyBanner.visible}
+            .provider=${this.apiKeyBanner.provider ?? ''}
+            .requiresKey=${this.apiKeyBanner.requiresKey ?? false}
+            @api-key-banner-action=${this.handleApiKeyBannerActionEvent}
+          ></api-key-banner>
+          <agent-config-banner
+            .visible=${this.agentConfigBanner.visible}
+            .agentName=${this.agentConfigBanner.agentName ?? ''}
+            .customDirSet=${this.agentConfigBanner.customDirSet ?? false}
+            @agent-config-banner-action=${this
+              .handleAgentConfigBannerActionEvent}
+          ></agent-config-banner>
+          <dependency-banner
+            .visible=${this.dependencyBanner.visible}
+            .missingTools=${this.dependencyBanner.missingTools ?? []}
+            @dependency-banner-action=${this.handleDependencyBannerActionEvent}
+          ></dependency-banner>
+          <getting-started-banner
+            .visible=${this.gettingStartedVisible}
+          ></getting-started-banner>
+          <login-banner
+            .visible=${this.loginBannerVisible}
+            @login-banner-action=${this.handleLoginBannerActionEvent}
+          ></login-banner>
         </div>
 
-        ${this.renderLatexdiffsSection()}
+        <latexdiffs-section
+          .visible=${this.latexdiffsVisible}
+          .baseFile=${this.singleFiles.baseFile}
+          .editedFile=${this.singleFiles.editedFile}
+          .commit=${this.commit}
+          .isGitRepo=${this.isGitRepo}
+          .baseOptionsHtml=${this.buildOptionsHtml(
+            this.fileOptions.baseFile ?? [],
+            this.singleFiles.baseFile,
+          )}
+          .editedOptionsHtml=${this.buildOptionsHtml(
+            this.fileOptions.editedFile ?? [],
+            this.singleFiles.editedFile,
+          )}
+          .commitOptionsHtml=${this.buildCommitOptions()}
+          @latexdiffs-action=${this.handleLatexDiffsActionEvent}
+          @latexdiffs-change=${this.handleLatexDiffsChangeEvent}
+        ></latexdiffs-section>
       </div>
     `;
   }
@@ -2262,7 +2532,8 @@ export class MainApp extends BaseWebviewApp {
           aria-haspopup="true"
           aria-expanded=${this.autoExtractMenuOpen ? 'true' : 'false'}
           ?checked=${hasChecked}
-          @click=${() => this.toggleMenu('autoExtract')}
+          data-action="toggle-auto-extract"
+          @click=${this.handleMenuToggle}
         >
           <i class="codicon ${chevronClass}"></i>
         </vscode-toolbar-button>
@@ -2275,33 +2546,24 @@ export class MainApp extends BaseWebviewApp {
             <vscode-checkbox
               id="autoExtractFigure"
               ?checked=${this.checkboxValues.autoExtractFigure}
-              @change=${(event: Event) =>
-                this.handleCheckboxChange(
-                  'autoExtractFigure',
-                  (event.target as HTMLInputElement).checked,
-                )}
+              data-checkbox-id="autoExtractFigure"
+              @change=${this.handleCheckboxToggle}
             >
               Figures
             </vscode-checkbox>
             <vscode-checkbox
               id="autoExtractTikzFigure"
               ?checked=${this.checkboxValues.autoExtractTikzFigure}
-              @change=${(event: Event) =>
-                this.handleCheckboxChange(
-                  'autoExtractTikzFigure',
-                  (event.target as HTMLInputElement).checked,
-                )}
+              data-checkbox-id="autoExtractTikzFigure"
+              @change=${this.handleCheckboxToggle}
             >
               TikZ Figures
             </vscode-checkbox>
             <vscode-checkbox
               id="autoCompileInputPdf"
               ?checked=${this.checkboxValues.autoCompileInputPdf}
-              @change=${(event: Event) =>
-                this.handleCheckboxChange(
-                  'autoCompileInputPdf',
-                  (event.target as HTMLInputElement).checked,
-                )}
+              data-checkbox-id="autoCompileInputPdf"
+              @change=${this.handleCheckboxToggle}
             >
               Compile Input PDF
             </vscode-checkbox>
@@ -2312,7 +2574,6 @@ export class MainApp extends BaseWebviewApp {
   }
 
   private renderToolConfigMenu(): TemplateResult {
-    const isToolUse = this.sessionType === SESSION_TYPES.TOOL_USE;
     const hasChecked = CHECK_BOXES_TOOL_USE.some(
       (id) => this.checkboxValues[id],
     );
@@ -2330,7 +2591,8 @@ export class MainApp extends BaseWebviewApp {
           aria-haspopup="true"
           aria-expanded=${this.toolConfigMenuOpen ? 'true' : 'false'}
           ?checked=${hasChecked}
-          @click=${() => this.toggleMenu('toolConfig')}
+          data-action="toggle-tool-config"
+          @click=${this.handleMenuToggle}
         >
           <i class="codicon ${chevronClass}"></i>
         </vscode-toolbar-button>
@@ -2343,581 +2605,23 @@ export class MainApp extends BaseWebviewApp {
             <vscode-checkbox
               id="attachTeXCount"
               ?checked=${this.checkboxValues.attachTeXCount}
-              ?disabled=${isToolUse}
-              @change=${(event: Event) =>
-                this.handleCheckboxChange(
-                  'attachTeXCount',
-                  (event.target as HTMLInputElement).checked,
-                )}
+              ?disabled=${this.isToolUse}
+              data-checkbox-id="attachTeXCount"
+              @change=${this.handleCheckboxToggle}
             >
               Attach TeX Count
             </vscode-checkbox>
             <vscode-checkbox
               id="attachDiagnostics"
               ?checked=${this.checkboxValues.attachDiagnostics}
-              ?disabled=${isToolUse}
-              @change=${(event: Event) =>
-                this.handleCheckboxChange(
-                  'attachDiagnostics',
-                  (event.target as HTMLInputElement).checked,
-                )}
+              ?disabled=${this.isToolUse}
+              data-checkbox-id="attachDiagnostics"
+              @change=${this.handleCheckboxToggle}
             >
               Attach Diagnostics
             </vscode-checkbox>
           </div>
         </vscode-context-menu>
-      </div>
-    `;
-  }
-
-  private renderFileSelect(config: {
-    type: FileType;
-    label: string;
-    icon: string;
-    refreshTitle: string;
-    currentTitle: string;
-    emptyTitle: string;
-    toggleTitle: string;
-    addOpenedLabel: string;
-    emptyListLabel: string;
-    selectListLabel: string;
-    tooltip: string;
-    toolConfig?: 'tool' | 'autoExtract';
-    focusInstruction?: { key: string; text: string };
-  }): TemplateResult {
-    const listId = `${config.type}Files`;
-    const selectId = `${config.type}File` as keyof typeof this.singleFiles;
-    const toggleId = `toggle${config.type[0].toUpperCase()}${config.type.slice(1)}Files`;
-    const isVisible = this.multiFilesVisible[listId];
-    const selectedValue = this.singleFiles[selectId];
-    const chevronClass = isVisible
-      ? 'codicon-chevron-up'
-      : 'codicon-chevron-down';
-    const toolConfigMenu =
-      config.toolConfig === 'tool'
-        ? this.renderToolConfigMenu()
-        : config.toolConfig === 'autoExtract'
-          ? this.renderAutoExtractMenu()
-          : null;
-    const focusHandler = config.focusInstruction
-      ? () =>
-          postMessage(MAIN_VIEW_COMMANDS.SHOW_INSTRUCTION, {
-            key: config.focusInstruction?.key,
-            text: config.focusInstruction?.text,
-          })
-      : undefined;
-
-    return html`
-      <div class="file-select" data-expanded=${String(isVisible)}>
-        <div class="file-select-header">
-          <div class="file-select-label-group">
-            <vscode-toolbar-button
-              id="refresh${config.type[0].toUpperCase()}${config.type.slice(
-                1,
-              )}FileButton"
-              icon=${config.icon}
-              label=${config.refreshTitle}
-              title=${config.refreshTitle}
-              @click=${() => this.handleRefreshFiles(config.type)}
-            ></vscode-toolbar-button>
-            <label for=${selectId} title=${config.tooltip}
-              >${config.label}</label
-            >
-            ${toolConfigMenu}
-          </div>
-          <vscode-toolbar-container class="file-select-actions">
-            <vscode-toolbar-button
-              id="current${config.type[0].toUpperCase()}${config.type.slice(
-                1,
-              )}FileButton"
-              icon="file-code"
-              label=${config.currentTitle}
-              title=${config.currentTitle}
-              @click=${() => this.handleGetCurrentFile(config.type)}
-            ></vscode-toolbar-button>
-            <vscode-toolbar-button
-              id="empty${config.type[0].toUpperCase()}${config.type.slice(
-                1,
-              )}FileButton"
-              icon="close"
-              label=${config.emptyTitle}
-              title=${config.emptyTitle}
-              @click=${() => this.handleEmptyFile(config.type)}
-            ></vscode-toolbar-button>
-            <span
-              id=${toggleId}
-              class="toggle-icon"
-              title=${config.toggleTitle}
-              @click=${() => this.toggleListVisibility(listId)}
-            >
-              <i class="codicon ${chevronClass}"></i>
-            </span>
-            <vscode-toolbar-button
-              id="addOpened${config.type[0].toUpperCase()}${config.type.slice(
-                1,
-              )}FilesButton"
-              class="file-action-button"
-              icon="folder-opened"
-              label=${config.addOpenedLabel}
-              title=${config.addOpenedLabel}
-              @click=${() => this.handleAddOpenedFiles(config.type)}
-            ></vscode-toolbar-button>
-            <vscode-toolbar-button
-              id="empty${config.type[0].toUpperCase()}${config.type.slice(
-                1,
-              )}FilesButton"
-              class="file-action-button"
-              icon="trash"
-              label=${config.emptyListLabel}
-              title=${config.emptyListLabel}
-              @click=${() => this.handleEmptyFiles(config.type)}
-            ></vscode-toolbar-button>
-            <vscode-toolbar-button
-              id="select${config.type[0].toUpperCase()}${config.type.slice(
-                1,
-              )}FilesButton"
-              class="file-action-button"
-              icon="add"
-              label=${config.selectListLabel}
-              title=${config.selectListLabel}
-              @click=${() => this.handleSelectMultipleFiles(listId)}
-            ></vscode-toolbar-button>
-          </vscode-toolbar-container>
-        </div>
-        <vscode-single-select
-          id=${selectId}
-          .value=${selectedValue}
-          @focus=${focusHandler}
-          @change=${(event: Event) => {
-            const target = event.currentTarget as HTMLInputElement;
-            this.handleSingleFileChange(config.type, target.value);
-          }}
-        >
-          ${unsafeHTML(
-            this.buildOptionsHtml(
-              this.fileOptions[selectId] ?? [],
-              selectedValue,
-            ),
-          )}
-        </vscode-single-select>
-        <div
-          id="${listId}Container"
-          class="multiple-files-container"
-          style=${isVisible ? 'display: block' : 'display: none'}
-        >
-          <div class="multiple-files-content">
-            <div id=${listId} class="multiple-files-list">
-              ${this.renderFileList(listId)}
-            </div>
-          </div>
-        </div>
-      </div>
-    `;
-  }
-
-  private renderBanners(): TemplateResult {
-    const providerLabel = this.apiKeyBanner.provider
-      ? `${this.apiKeyBanner.provider.charAt(0).toUpperCase()}${this.apiKeyBanner.provider.slice(1)}`
-      : '';
-    return html`
-      <div
-        id="apiKeyBanner"
-        class="api-key-banner"
-        style=${this.apiKeyBanner.visible ? 'display: flex' : 'display: none'}
-      >
-        <span>
-          ${this.apiKeyBanner.provider
-            ? html`<strong>${providerLabel}</strong> API key missing.`
-            : 'TeXRA requires an API key to run.'}
-        </span>
-        <div class="actions">
-          <vscode-toolbar-button
-            id="apiKeyBannerButton"
-            icon="key"
-            @click=${() => this.handleApiKeyBannerAction('set')}
-          >
-            ${this.apiKeyBanner.provider ? 'Set Key' : 'Set API Key'}
-          </vscode-toolbar-button>
-          <vscode-toolbar-button
-            id="apiKeyGuideButton"
-            icon="book"
-            @click=${() => this.handleApiKeyBannerAction('guide')}
-          >
-            ${this.apiKeyBanner.provider ? 'Get Key' : 'API Key Guide'}
-          </vscode-toolbar-button>
-        </div>
-      </div>
-
-      <div
-        id="agentConfigBanner"
-        class="agent-config-banner"
-        style=${this.agentConfigBanner.visible
-          ? 'display: flex'
-          : 'display: none'}
-        data-custom-dir-set=${this.agentConfigBanner.customDirSet
-          ? 'true'
-          : 'false'}
-      >
-        <span>
-          ${this.agentConfigBanner.agentName
-            ? `Agent file for "${this.agentConfigBanner.agentName}" is missing.`
-            : 'Agent configuration is missing.'}
-        </span>
-        <div class="actions">
-          <vscode-toolbar-button
-            id="agentConfigEditButton"
-            icon="edit"
-            @click=${() => this.handleAgentConfigAction('edit')}
-          >
-            Edit Agents
-          </vscode-toolbar-button>
-          <vscode-toolbar-button
-            id="agentConfigDirButton"
-            icon="folder"
-            @click=${() => this.handleAgentConfigAction('dir')}
-          >
-            ${this.agentConfigBanner.customDirSet
-              ? 'Open Directory'
-              : 'Set Directory'}
-          </vscode-toolbar-button>
-          <vscode-toolbar-button
-            id="agentConfigDocButton"
-            icon="book"
-            @click=${() => this.handleAgentConfigAction('docs')}
-          >
-            Docs
-          </vscode-toolbar-button>
-        </div>
-      </div>
-
-      <div
-        id="dependencyBanner"
-        class="dependency-banner"
-        style=${this.dependencyBanner.visible
-          ? 'display: flex'
-          : 'display: none'}
-      >
-        <span class="missing-tools"> ${this.renderDependencyContent()} </span>
-        <div class="actions">
-          <vscode-toolbar-button
-            id="dependencyRecheckButton"
-            icon="refresh"
-            @click=${() => postMessage(MAIN_VIEW_COMMANDS.RECHECK_DEPENDENCIES)}
-          >
-            Re-check
-          </vscode-toolbar-button>
-          <vscode-toolbar-button
-            id="dependencyDismissButton"
-            class="btn-secondary"
-            title="Dismiss (can be re-enabled in settings)"
-            icon="close"
-            @click=${this.handleDependencyDismiss}
-          >
-            Dismiss
-          </vscode-toolbar-button>
-        </div>
-      </div>
-
-      <div
-        id="gettingStartedBanner"
-        class="getting-started-banner"
-        style=${this.gettingStartedVisible ? 'display: block' : 'display: none'}
-      >
-        <span class="getting-started-text">
-          No files found in workspace. Try
-          <a href="command:texra.openGettingStarted"
-            >opening the getting started walkthrough</a
-          >,
-          <a href="command:texra.createSampleProject"
-            >creating a sample project</a
-          >,
-          <a href="command:texra.cloneOverleafProject"
-            >cloning an Overleaf project</a
-          >, or
-          <a href="command:texra.downloadArXivSource"
-            >downloading an arXiv source</a
-          >.
-        </span>
-      </div>
-
-      <div
-        id="loginBanner"
-        class="login-banner"
-        style=${this.loginBannerVisible ? 'display: flex' : 'display: none'}
-      >
-        <div class="login-banner-content">
-          <span class="login-banner-icon"
-            ><i class="codicon codicon-sparkle"></i
-          ></span>
-          <div class="login-banner-text">
-            <span class="login-banner-title">Researcher Access Program</span>
-            <span class="login-banner-description">
-              Sign in to access AI models and remote agents without your own API
-              keys.
-            </span>
-          </div>
-        </div>
-        <div class="actions">
-          <vscode-button
-            id="loginBannerButton"
-            appearance="primary"
-            @click=${() => postMessage(MAIN_VIEW_COMMANDS.SIGN_IN_FROM_BANNER)}
-          >
-            <span slot="start" class="codicon codicon-sign-in"></span>
-            Sign In
-          </vscode-button>
-          <vscode-toolbar-button
-            id="loginBannerDismissButton"
-            icon="close"
-            title="Dismiss (can be re-enabled in settings)"
-            aria-label="Dismiss login banner"
-            @click=${() => postMessage(MAIN_VIEW_COMMANDS.DISMISS_LOGIN_BANNER)}
-          ></vscode-toolbar-button>
-        </div>
-      </div>
-    `;
-  }
-
-  private renderDependencyContent(): TemplateResult {
-    const missing = this.dependencyBanner.missingTools ?? [];
-    if (missing.length === 0) {
-      return html`Missing dependencies: none`;
-    }
-
-    const tools = missing.flatMap((tool) =>
-      tool === 'gm/magick' ? ['gm', 'magick'] : [tool],
-    );
-
-    return html`${repeat(
-      tools,
-      (tool) => tool,
-      (tool) => {
-        const label =
-          tool === 'gm'
-            ? 'GraphicsMagick'
-            : tool === 'magick'
-              ? 'ImageMagick'
-              : tool;
-        return html`
-          <div class="dependency-item">
-            <span>${label}</span>
-            <vscode-toolbar-button
-              class="btn-secondary dependency-install-button"
-              icon="cloud-download"
-              @click=${() =>
-                postMessage(MAIN_VIEW_COMMANDS.OPEN_INSTALL_GUIDE, { tool })}
-            >
-              Install
-            </vscode-toolbar-button>
-          </div>
-        `;
-      },
-    )}`;
-  }
-
-  private renderLatexdiffsSection(): TemplateResult {
-    return html`
-      <div
-        class="latexdiffs-section"
-        data-expanded=${String(this.latexdiffsVisible)}
-      >
-        <div class="file-select-header">
-          <div class="file-select-label-group">
-            <span
-              id="toggleLatexdiffs"
-              class="toggle-icon"
-              title="LaTeXDiffs"
-              @click=${() => {
-                this.latexdiffsVisible = !this.latexdiffsVisible;
-                this.saveState();
-              }}
-            >
-              <i
-                class="codicon ${this.latexdiffsVisible
-                  ? 'codicon-chevron-up'
-                  : 'codicon-chevron-down'}"
-              ></i>
-            </span>
-            <span class="optional-label"
-              ><i class="codicon codicon-source-control"></i> LaTeXDiffs</span
-            >
-          </div>
-        </div>
-        <div
-          id="latexdiffsContent"
-          style=${this.latexdiffsVisible ? 'display: block' : 'display: none'}
-        >
-          <div class="file-select">
-            <div class="file-select-header">
-              <div class="file-select-label-group">
-                <label for="baseFile">Base</label>
-              </div>
-              <vscode-toolbar-container class="file-select-actions">
-                <vscode-toolbar-button
-                  id="currentBaseFileButton"
-                  icon="file-code"
-                  label="Set current file as base"
-                  title="Set current file as base"
-                  @click=${() => this.handleGetCurrentFile('base')}
-                ></vscode-toolbar-button>
-                <vscode-toolbar-button
-                  id="emptyBaseFileButton"
-                  icon="close"
-                  label="Clear base file"
-                  title="Clear base file"
-                  @click=${() => this.handleEmptyFile('base')}
-                ></vscode-toolbar-button>
-              </vscode-toolbar-container>
-            </div>
-            <vscode-single-select
-              id="baseFile"
-              .value=${this.singleFiles.baseFile}
-              @change=${(event: Event) => {
-                const target = event.currentTarget as HTMLInputElement;
-                this.handleBaseFileChange(target.value);
-              }}
-            >
-              ${unsafeHTML(
-                this.buildOptionsHtml(
-                  this.fileOptions.baseFile ?? [],
-                  this.singleFiles.baseFile,
-                ),
-              )}
-            </vscode-single-select>
-          </div>
-          <div class="file-select">
-            <div class="file-select-header">
-              <div class="file-select-label-group">
-                <label for="editedFile">Edited</label>
-              </div>
-              <vscode-toolbar-container class="file-select-actions">
-                <vscode-toolbar-button
-                  id="refreshEditedFileButton"
-                  icon="edit"
-                  label="Refresh edited files"
-                  title="Refresh edited files"
-                  @click=${this.handleRefreshEditedFiles}
-                ></vscode-toolbar-button>
-                <vscode-toolbar-button
-                  id="currentEditedFileButton"
-                  icon="file-code"
-                  label="Set current file as edited"
-                  title="Set current file as edited"
-                  @click=${() => this.handleGetCurrentFile('edited')}
-                ></vscode-toolbar-button>
-                <vscode-toolbar-button
-                  id="emptyEditedFileButton"
-                  icon="close"
-                  label="Clear edited file"
-                  title="Clear edited file"
-                  @click=${() => this.handleEmptyFile('edited')}
-                ></vscode-toolbar-button>
-              </vscode-toolbar-container>
-            </div>
-            <vscode-single-select
-              id="editedFile"
-              .value=${this.singleFiles.editedFile}
-              @change=${(event: Event) => {
-                const target = event.currentTarget as HTMLInputElement;
-                this.singleFiles = {
-                  ...this.singleFiles,
-                  editedFile: target.value,
-                };
-                this.saveState();
-              }}
-            >
-              ${unsafeHTML(
-                this.buildOptionsHtml(
-                  this.fileOptions.editedFile ?? [],
-                  this.singleFiles.editedFile,
-                ),
-              )}
-            </vscode-single-select>
-          </div>
-          <div class="file-select">
-            <div class="file-select-header">
-              <div class="file-select-label-group">
-                <label for="commit">
-                  <i class="codicon codicon-git-commit"></i> Commit
-                </label>
-              </div>
-              <vscode-toolbar-container class="file-select-actions">
-                <vscode-toolbar-button
-                  id="refreshCommitsButton"
-                  icon="refresh"
-                  label="Refresh commits"
-                  title="Refresh commits"
-                  @click=${() =>
-                    postMessage(MAIN_VIEW_COMMANDS.REFRESH_COMMITS)}
-                ></vscode-toolbar-button>
-              </vscode-toolbar-container>
-            </div>
-            <vscode-single-select
-              id="commit"
-              .value=${this.commit}
-              ?disabled=${!this.isGitRepo}
-              @change=${(event: Event) => {
-                const target = event.currentTarget as HTMLInputElement;
-                this.commit = target.value;
-                this.saveState();
-              }}
-            >
-              ${unsafeHTML(this.buildCommitOptions())}
-            </vscode-single-select>
-          </div>
-          <div class="instruction-controls">
-            <vscode-toolbar-button
-              id="latexdiffButton"
-              icon="compare-changes"
-              label="Run LaTeXDiff"
-              title="Run LaTeXDiff"
-              @click=${this.handleLatexdiff}
-            ></vscode-toolbar-button>
-            <vscode-toolbar-button
-              id="latexdiffvcButton"
-              icon="compare-changes"
-              label="Run LaTeXDiff with version control"
-              title="Run LaTeXDiff with version control"
-              @click=${this.handleLatexdiffVC}
-            ></vscode-toolbar-button>
-            <vscode-toolbar-button
-              id="packLatexdiffvcButton"
-              icon="archive"
-              label="Pack LaTeXDiff VC"
-              title="Pack LaTeXDiff VC"
-              @click=${() => this.handleLatexdiffVCPack('pack')}
-            ></vscode-toolbar-button>
-            <vscode-toolbar-button
-              id="cleanLatexdiffvcButton"
-              icon="trash"
-              label="Clean LaTeXDiff VC"
-              title="Clean LaTeXDiff VC"
-              @click=${() => this.handleLatexdiffVCPack('clean')}
-            ></vscode-toolbar-button>
-            <vscode-toolbar-button
-              id="mergeButton"
-              icon="merge"
-              label="Merge edits"
-              title="Merge edits"
-              @click=${this.handleMerge}
-            ></vscode-toolbar-button>
-            <vscode-toolbar-button
-              id="compareButton"
-              icon="diff"
-              label="Compare"
-              title="Compare"
-              @click=${() => this.handleCompare(MAIN_VIEW_COMMANDS.COMPARE)}
-            ></vscode-toolbar-button>
-            <vscode-toolbar-button
-              id="acceptButton"
-              icon="check"
-              label="Accept"
-              title="Accept"
-              @click=${() =>
-                this.handleCompare(MAIN_VIEW_COMMANDS.ACCEPT_EDITED)}
-            ></vscode-toolbar-button>
-          </div>
-        </div>
       </div>
     `;
   }

--- a/src/webview/frontend/MainApp.ts
+++ b/src/webview/frontend/MainApp.ts
@@ -180,6 +180,70 @@ const ONBOARDING_PLACEHOLDERS: Record<SessionType, string[]> = {
   ],
 };
 
+const FILE_SELECT_CONFIGS = {
+  input: {
+    type: 'input',
+    label: 'Input',
+    icon: 'file-code',
+    refreshTitle: 'Refresh input files',
+    currentTitle: 'Set current file as input',
+    emptyTitle: 'Clear input file',
+    toggleTitle: 'Show or hide additional input files',
+    addOpenedLabel: 'Add opened files as input',
+    emptyListLabel: 'Clear all input files',
+    selectListLabel: 'Add input files',
+    tooltip: 'Primary files the agent processes, such as .tex, .txt, or .md',
+    focusInstruction: {
+      key: 'inputFileSelect',
+      text: 'Choose the main LaTeX file to process. Use the Current button to pick the active editor.',
+    },
+  },
+  reference: {
+    type: 'reference',
+    label: 'Reference',
+    icon: 'book',
+    refreshTitle: 'Refresh reference files',
+    currentTitle: 'Set current file as reference',
+    emptyTitle: 'Clear reference file',
+    toggleTitle: 'Show or hide additional reference files',
+    addOpenedLabel: 'Add opened files as reference',
+    emptyListLabel: 'Clear all reference files',
+    selectListLabel: 'Add reference files',
+    tooltip:
+      'Context files such as .bib/.bbl or other papers that guide output but will not be modified',
+  },
+  auxiliary: {
+    type: 'auxiliary',
+    label: 'Auxiliary',
+    icon: 'archive',
+    refreshTitle: 'Refresh auxiliary files',
+    currentTitle: 'Set current file as auxiliary',
+    emptyTitle: 'Clear auxiliary file',
+    toggleTitle: 'Show or hide additional auxiliary files',
+    addOpenedLabel: 'Add opened files as auxiliary',
+    emptyListLabel: 'Clear all auxiliary files',
+    selectListLabel: 'Add auxiliary files',
+    tooltip:
+      'Files such as .cls/.sty that define document structure and styles',
+  },
+  media: {
+    type: 'media',
+    label: 'Media',
+    icon: 'device-camera-video',
+    refreshTitle: 'Refresh media files',
+    currentTitle: 'Set current file as media',
+    emptyTitle: 'Clear media file',
+    toggleTitle: 'Show or hide additional media files',
+    addOpenedLabel: 'Add opened files as media',
+    emptyListLabel: 'Clear all media files',
+    selectListLabel: 'Add media files',
+    tooltip: 'Images, figures, and media assets used by the document',
+  },
+} satisfies Record<
+  'input' | 'reference' | 'auxiliary' | 'media',
+  FileSelectConfig
+>;
+
 type MainViewMessageHandler = (message: MainViewMessage) => void;
 type MainViewMessageFor<C extends MainViewMessage['command']> = Extract<
   MainViewMessage,
@@ -2167,24 +2231,7 @@ export class MainApp extends BaseWebviewApp {
         <div class="main-content">
           <div class=${fileSelectionClasses}>
             <file-select-group
-              .config=${{
-                type: 'input',
-                label: 'Input',
-                icon: 'file-code',
-                refreshTitle: 'Refresh input files',
-                currentTitle: 'Set current file as input',
-                emptyTitle: 'Clear input file',
-                toggleTitle: 'Show or hide additional input files',
-                addOpenedLabel: 'Add opened files as input',
-                emptyListLabel: 'Clear all input files',
-                selectListLabel: 'Add input files',
-                tooltip:
-                  'Primary files the agent processes, such as .tex, .txt, or .md',
-                focusInstruction: {
-                  key: 'inputFileSelect',
-                  text: 'Choose the main LaTeX file to process. Use the Current button to pick the active editor.',
-                },
-              } satisfies FileSelectConfig}
+              .config=${FILE_SELECT_CONFIGS.input}
               .selectedValue=${this.singleFiles.inputFile}
               .optionsHtml=${this.buildOptionsHtml(
                 this.fileOptions.inputFile ?? [],
@@ -2197,20 +2244,7 @@ export class MainApp extends BaseWebviewApp {
               @file-select-focus=${this.handleFileSelectFocusEvent}
             ></file-select-group>
             <file-select-group
-              .config=${{
-                type: 'reference',
-                label: 'Reference',
-                icon: 'book',
-                refreshTitle: 'Refresh reference files',
-                currentTitle: 'Set current file as reference',
-                emptyTitle: 'Clear reference file',
-                toggleTitle: 'Show or hide additional reference files',
-                addOpenedLabel: 'Add opened files as reference',
-                emptyListLabel: 'Clear all reference files',
-                selectListLabel: 'Add reference files',
-                tooltip:
-                  'Context files such as .bib/.bbl or other papers that guide output but will not be modified',
-              } satisfies FileSelectConfig}
+              .config=${FILE_SELECT_CONFIGS.reference}
               .selectedValue=${this.singleFiles.referenceFile}
               .optionsHtml=${this.buildOptionsHtml(
                 this.fileOptions.referenceFile ?? [],
@@ -2222,20 +2256,7 @@ export class MainApp extends BaseWebviewApp {
               @file-select-focus=${this.handleFileSelectFocusEvent}
             ></file-select-group>
             <file-select-group
-              .config=${{
-                type: 'auxiliary',
-                label: 'Auxiliary',
-                icon: 'archive',
-                refreshTitle: 'Refresh auxiliary files',
-                currentTitle: 'Set current file as auxiliary',
-                emptyTitle: 'Clear auxiliary file',
-                toggleTitle: 'Show or hide additional auxiliary files',
-                addOpenedLabel: 'Add opened files as auxiliary',
-                emptyListLabel: 'Clear all auxiliary files',
-                selectListLabel: 'Add auxiliary files',
-                tooltip:
-                  'Files such as .cls/.sty that define document structure and styles',
-              } satisfies FileSelectConfig}
+              .config=${FILE_SELECT_CONFIGS.auxiliary}
               .selectedValue=${this.singleFiles.auxiliaryFile}
               .optionsHtml=${this.buildOptionsHtml(
                 this.fileOptions.auxiliaryFile ?? [],
@@ -2247,20 +2268,7 @@ export class MainApp extends BaseWebviewApp {
               @file-select-focus=${this.handleFileSelectFocusEvent}
             ></file-select-group>
             <file-select-group
-              .config=${{
-                type: 'media',
-                label: 'Media',
-                icon: 'device-camera-video',
-                refreshTitle: 'Refresh media files',
-                currentTitle: 'Set current file as media',
-                emptyTitle: 'Clear media file',
-                toggleTitle: 'Show or hide additional media files',
-                addOpenedLabel: 'Add opened files as media',
-                emptyListLabel: 'Clear all media files',
-                selectListLabel: 'Add media files',
-                tooltip:
-                  'Images, figures, and media assets used by the document',
-              } satisfies FileSelectConfig}
+              .config=${FILE_SELECT_CONFIGS.media}
               .selectedValue=${this.singleFiles.mediaFile}
               .optionsHtml=${this.buildOptionsHtml(
                 this.fileOptions.mediaFile ?? [],

--- a/src/webview/frontend/components/AgentConfigBanner.ts
+++ b/src/webview/frontend/components/AgentConfigBanner.ts
@@ -1,0 +1,94 @@
+// Third-party imports
+import { LitElement, html, type TemplateResult } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+
+// Local imports - shared styles
+import { designTokens, commonViewStyles, codiconStyles } from '@shared/styles';
+
+// Local imports - main view
+import { mainViewStyles } from '@webview/frontend/styles';
+
+export type AgentConfigBannerAction = 'edit' | 'dir' | 'docs';
+
+export interface AgentConfigBannerActionDetail {
+  action: AgentConfigBannerAction;
+}
+
+@customElement('agent-config-banner')
+export class AgentConfigBanner extends LitElement {
+  static styles = [
+    designTokens,
+    commonViewStyles,
+    codiconStyles,
+    mainViewStyles,
+  ];
+
+  @property({ type: Boolean }) visible = false;
+  @property({ type: String }) agentName = '';
+  @property({ type: Boolean }) customDirSet = false;
+
+  private emitAction(action: AgentConfigBannerAction): void {
+    this.dispatchEvent(
+      new CustomEvent<AgentConfigBannerActionDetail>(
+        'agent-config-banner-action',
+        {
+          detail: { action },
+          bubbles: true,
+          composed: true,
+        },
+      ),
+    );
+  }
+
+  private handleActionClick = (event: Event): void => {
+    const target = event.currentTarget as HTMLElement | null;
+    const action = target?.dataset.action as
+      | AgentConfigBannerAction
+      | undefined;
+    if (!action) return;
+    this.emitAction(action);
+  };
+
+  render(): TemplateResult {
+    return html`
+      <div
+        id="agentConfigBanner"
+        class="agent-config-banner"
+        style=${this.visible ? 'display: flex' : 'display: none'}
+        data-custom-dir-set=${this.customDirSet ? 'true' : 'false'}
+      >
+        <span>
+          ${this.agentName
+            ? `Agent file for "${this.agentName}" is missing.`
+            : 'Agent configuration is missing.'}
+        </span>
+        <div class="actions">
+          <vscode-toolbar-button
+            id="agentConfigEditButton"
+            icon="edit"
+            data-action="edit"
+            @click=${this.handleActionClick}
+          >
+            Edit Agents
+          </vscode-toolbar-button>
+          <vscode-toolbar-button
+            id="agentConfigDirButton"
+            icon="folder"
+            data-action="dir"
+            @click=${this.handleActionClick}
+          >
+            ${this.customDirSet ? 'Open Directory' : 'Set Directory'}
+          </vscode-toolbar-button>
+          <vscode-toolbar-button
+            id="agentConfigDocButton"
+            icon="book"
+            data-action="docs"
+            @click=${this.handleActionClick}
+          >
+            Docs
+          </vscode-toolbar-button>
+        </div>
+      </div>
+    `;
+  }
+}

--- a/src/webview/frontend/components/AgentConfigBanner.ts
+++ b/src/webview/frontend/components/AgentConfigBanner.ts
@@ -6,7 +6,7 @@ import { customElement, property } from 'lit/decorators.js';
 import { designTokens, commonViewStyles, codiconStyles } from '@shared/styles';
 
 // Local imports - main view
-import { mainViewStyles } from '@webview/frontend/styles';
+import { bannerStyles } from '@webview/frontend/styles';
 
 export type AgentConfigBannerAction = 'edit' | 'dir' | 'docs';
 
@@ -16,12 +16,7 @@ export interface AgentConfigBannerActionDetail {
 
 @customElement('agent-config-banner')
 export class AgentConfigBanner extends LitElement {
-  static styles = [
-    designTokens,
-    commonViewStyles,
-    codiconStyles,
-    mainViewStyles,
-  ];
+  static styles = [designTokens, commonViewStyles, codiconStyles, bannerStyles];
 
   @property({ type: Boolean }) visible = false;
   @property({ type: String }) agentName = '';

--- a/src/webview/frontend/components/ApiKeyBanner.ts
+++ b/src/webview/frontend/components/ApiKeyBanner.ts
@@ -6,7 +6,7 @@ import { customElement, property } from 'lit/decorators.js';
 import { designTokens, commonViewStyles, codiconStyles } from '@shared/styles';
 
 // Local imports - main view
-import { mainViewStyles } from '@webview/frontend/styles';
+import { bannerStyles } from '@webview/frontend/styles';
 
 export type ApiKeyBannerAction = 'set' | 'guide';
 
@@ -16,12 +16,7 @@ export interface ApiKeyBannerActionDetail {
 
 @customElement('api-key-banner')
 export class ApiKeyBanner extends LitElement {
-  static styles = [
-    designTokens,
-    commonViewStyles,
-    codiconStyles,
-    mainViewStyles,
-  ];
+  static styles = [designTokens, commonViewStyles, codiconStyles, bannerStyles];
 
   @property({ type: Boolean }) visible = false;
   @property({ type: String }) provider = '';

--- a/src/webview/frontend/components/ApiKeyBanner.ts
+++ b/src/webview/frontend/components/ApiKeyBanner.ts
@@ -1,0 +1,83 @@
+// Third-party imports
+import { LitElement, html, type TemplateResult } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+
+// Local imports - shared styles
+import { designTokens, commonViewStyles, codiconStyles } from '@shared/styles';
+
+// Local imports - main view
+import { mainViewStyles } from '@webview/frontend/styles';
+
+export type ApiKeyBannerAction = 'set' | 'guide';
+
+export interface ApiKeyBannerActionDetail {
+  action: ApiKeyBannerAction;
+}
+
+@customElement('api-key-banner')
+export class ApiKeyBanner extends LitElement {
+  static styles = [
+    designTokens,
+    commonViewStyles,
+    codiconStyles,
+    mainViewStyles,
+  ];
+
+  @property({ type: Boolean }) visible = false;
+  @property({ type: String }) provider = '';
+  @property({ type: Boolean }) requiresKey = false;
+
+  private emitAction(action: ApiKeyBannerAction): void {
+    this.dispatchEvent(
+      new CustomEvent<ApiKeyBannerActionDetail>('api-key-banner-action', {
+        detail: { action },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+  }
+
+  private handleActionClick = (event: Event): void => {
+    const target = event.currentTarget as HTMLElement | null;
+    const action = target?.dataset.action as ApiKeyBannerAction | undefined;
+    if (!action) return;
+    this.emitAction(action);
+  };
+
+  render(): TemplateResult {
+    const providerLabel = this.provider
+      ? `${this.provider.charAt(0).toUpperCase()}${this.provider.slice(1)}`
+      : '';
+    return html`
+      <div
+        id="apiKeyBanner"
+        class="api-key-banner"
+        style=${this.visible ? 'display: flex' : 'display: none'}
+      >
+        <span>
+          ${this.provider
+            ? html`<strong>${providerLabel}</strong> API key missing.`
+            : 'TeXRA requires an API key to run.'}
+        </span>
+        <div class="actions">
+          <vscode-toolbar-button
+            id="apiKeyBannerButton"
+            icon="key"
+            data-action="set"
+            @click=${this.handleActionClick}
+          >
+            ${this.provider ? 'Set Key' : 'Set API Key'}
+          </vscode-toolbar-button>
+          <vscode-toolbar-button
+            id="apiKeyGuideButton"
+            icon="book"
+            data-action="guide"
+            @click=${this.handleActionClick}
+          >
+            ${this.provider ? 'Get Key' : 'API Key Guide'}
+          </vscode-toolbar-button>
+        </div>
+      </div>
+    `;
+  }
+}

--- a/src/webview/frontend/components/DependencyBanner.ts
+++ b/src/webview/frontend/components/DependencyBanner.ts
@@ -7,7 +7,7 @@ import { repeat } from 'lit/directives/repeat.js';
 import { designTokens, commonViewStyles, codiconStyles } from '@shared/styles';
 
 // Local imports - main view
-import { mainViewStyles } from '@webview/frontend/styles';
+import { bannerStyles } from '@webview/frontend/styles';
 
 export type DependencyBannerAction = 'recheck' | 'dismiss' | 'install';
 
@@ -18,12 +18,7 @@ export interface DependencyBannerActionDetail {
 
 @customElement('dependency-banner')
 export class DependencyBanner extends LitElement {
-  static styles = [
-    designTokens,
-    commonViewStyles,
-    codiconStyles,
-    mainViewStyles,
-  ];
+  static styles = [designTokens, commonViewStyles, codiconStyles, bannerStyles];
 
   @property({ type: Boolean }) visible = false;
   @property({ type: Array }) missingTools: string[] = [];

--- a/src/webview/frontend/components/DependencyBanner.ts
+++ b/src/webview/frontend/components/DependencyBanner.ts
@@ -1,0 +1,120 @@
+// Third-party imports
+import { LitElement, html, type TemplateResult } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import { repeat } from 'lit/directives/repeat.js';
+
+// Local imports - shared styles
+import { designTokens, commonViewStyles, codiconStyles } from '@shared/styles';
+
+// Local imports - main view
+import { mainViewStyles } from '@webview/frontend/styles';
+
+export type DependencyBannerAction = 'recheck' | 'dismiss' | 'install';
+
+export interface DependencyBannerActionDetail {
+  action: DependencyBannerAction;
+  tool?: string;
+}
+
+@customElement('dependency-banner')
+export class DependencyBanner extends LitElement {
+  static styles = [
+    designTokens,
+    commonViewStyles,
+    codiconStyles,
+    mainViewStyles,
+  ];
+
+  @property({ type: Boolean }) visible = false;
+  @property({ type: Array }) missingTools: string[] = [];
+
+  private emitAction(detail: DependencyBannerActionDetail): void {
+    this.dispatchEvent(
+      new CustomEvent<DependencyBannerActionDetail>(
+        'dependency-banner-action',
+        {
+          detail,
+          bubbles: true,
+          composed: true,
+        },
+      ),
+    );
+  }
+
+  private handleActionClick = (event: Event): void => {
+    const target = event.currentTarget as HTMLElement | null;
+    const action = target?.dataset.action as DependencyBannerAction | undefined;
+    const tool = target?.dataset.tool;
+    if (!action) return;
+    this.emitAction({ action, tool });
+  };
+
+  private renderDependencyContent(): TemplateResult {
+    if (this.missingTools.length === 0) {
+      return html`Missing dependencies: none`;
+    }
+
+    const tools = this.missingTools.flatMap((tool) =>
+      tool === 'gm/magick' ? ['gm', 'magick'] : [tool],
+    );
+
+    return html`${repeat(
+      tools,
+      (tool) => tool,
+      (tool) => {
+        const label =
+          tool === 'gm'
+            ? 'GraphicsMagick'
+            : tool === 'magick'
+              ? 'ImageMagick'
+              : tool;
+        return html`
+          <div class="dependency-item">
+            <span>${label}</span>
+            <vscode-toolbar-button
+              class="btn-secondary dependency-install-button"
+              icon="cloud-download"
+              data-action="install"
+              data-tool=${tool}
+              @click=${this.handleActionClick}
+            >
+              Install
+            </vscode-toolbar-button>
+          </div>
+        `;
+      },
+    )}`;
+  }
+
+  render(): TemplateResult {
+    return html`
+      <div
+        id="dependencyBanner"
+        class="dependency-banner"
+        style=${this.visible ? 'display: flex' : 'display: none'}
+      >
+        <span class="missing-tools"> ${this.renderDependencyContent()} </span>
+        <div class="actions">
+          <vscode-toolbar-button
+            id="dependencyRecheckButton"
+            icon="refresh"
+            data-action="recheck"
+            @click=${this.handleActionClick}
+          >
+            Re-check
+          </vscode-toolbar-button>
+          <vscode-toolbar-button
+            id="dependencyDismissButton"
+            class="btn-secondary"
+            title="Dismiss (can be re-enabled in settings)"
+            icon="close"
+            data-action="dismiss"
+            @click=${this.handleActionClick}
+          >
+            Dismiss
+          </vscode-toolbar-button>
+        </div>
+      </div>
+    `;
+  }
+}

--- a/src/webview/frontend/components/FileSelectGroup.ts
+++ b/src/webview/frontend/components/FileSelectGroup.ts
@@ -1,0 +1,272 @@
+// Third-party imports
+import { LitElement, html, type TemplateResult } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import { repeat } from 'lit/directives/repeat.js';
+import { unsafeHTML } from 'lit/directives/unsafe-html.js';
+
+// Local imports - shared styles
+import { designTokens, commonViewStyles, codiconStyles } from '@shared/styles';
+
+// Local imports - main view
+import { mainViewStyles } from '@webview/frontend/styles';
+import type { FileType } from '@webview/frontend/constants';
+
+export type FileSelectAction =
+  | 'refresh'
+  | 'current'
+  | 'empty'
+  | 'toggle'
+  | 'add-opened'
+  | 'empty-list'
+  | 'select-list'
+  | 'remove'
+  | 'change';
+
+export interface FileSelectActionDetail {
+  action: FileSelectAction;
+  fileType: FileType;
+  listId: string;
+  value?: string;
+  filePath?: string;
+}
+
+export interface FileSelectFocusDetail {
+  key: string;
+  text: string;
+}
+
+export interface FileSelectConfig {
+  type: FileType;
+  label: string;
+  icon: string;
+  refreshTitle: string;
+  currentTitle: string;
+  emptyTitle: string;
+  toggleTitle: string;
+  addOpenedLabel: string;
+  emptyListLabel: string;
+  selectListLabel: string;
+  tooltip: string;
+  focusInstruction?: { key: string; text: string };
+}
+
+@customElement('file-select-group')
+export class FileSelectGroup extends LitElement {
+  static styles = [
+    designTokens,
+    commonViewStyles,
+    codiconStyles,
+    mainViewStyles,
+  ];
+
+  @property({ type: Object }) config!: FileSelectConfig;
+  @property({ type: String }) selectedValue = '';
+  @property({ type: String }) optionsHtml = '';
+  @property({ type: Boolean }) isVisible = false;
+  @property({ type: Array }) files: string[] = [];
+  @property({ attribute: false }) toolConfigMenu: TemplateResult | null = null;
+
+  private get listId(): string {
+    return `${this.config.type}Files`;
+  }
+
+  private get selectId(): string {
+    return `${this.config.type}File`;
+  }
+
+  private get toggleId(): string {
+    const { type } = this.config;
+    return `toggle${type[0].toUpperCase()}${type.slice(1)}Files`;
+  }
+
+  private emitAction(detail: FileSelectActionDetail): void {
+    this.dispatchEvent(
+      new CustomEvent<FileSelectActionDetail>('file-select-action', {
+        detail,
+        bubbles: true,
+        composed: true,
+      }),
+    );
+  }
+
+  private emitFocus = (): void => {
+    if (!this.config.focusInstruction) {
+      return;
+    }
+    this.dispatchEvent(
+      new CustomEvent<FileSelectFocusDetail>('file-select-focus', {
+        detail: this.config.focusInstruction,
+        bubbles: true,
+        composed: true,
+      }),
+    );
+  };
+
+  private handleActionClick = (event: Event): void => {
+    const target = event.currentTarget as HTMLElement | null;
+    const action = target?.dataset.action as FileSelectAction | undefined;
+    if (!action) return;
+    this.emitAction({
+      action,
+      fileType: this.config.type,
+      listId: this.listId,
+    });
+  };
+
+  private handleRemoveClick = (event: Event): void => {
+    const target = event.currentTarget as HTMLElement | null;
+    const filePath = target?.dataset.filePath;
+    if (!filePath) return;
+    this.emitAction({
+      action: 'remove',
+      fileType: this.config.type,
+      listId: this.listId,
+      filePath,
+    });
+  };
+
+  private handleSelectChange = (event: Event): void => {
+    const target = event.currentTarget as HTMLInputElement | null;
+    if (!target) return;
+    this.emitAction({
+      action: 'change',
+      fileType: this.config.type,
+      listId: this.listId,
+      value: target.value,
+    });
+  };
+
+  render(): TemplateResult {
+    const chevronClass = this.isVisible
+      ? 'codicon-chevron-up'
+      : 'codicon-chevron-down';
+
+    return html`
+      <div class="file-select" data-expanded=${String(this.isVisible)}>
+        <div class="file-select-header">
+          <div class="file-select-label-group">
+            <vscode-toolbar-button
+              id="refresh${this.config.type[0].toUpperCase()}${this.config.type.slice(
+                1,
+              )}FileButton"
+              icon=${this.config.icon}
+              label=${this.config.refreshTitle}
+              title=${this.config.refreshTitle}
+              data-action="refresh"
+              @click=${this.handleActionClick}
+            ></vscode-toolbar-button>
+            <label for=${this.selectId} title=${this.config.tooltip}
+              >${this.config.label}</label
+            >
+            ${this.toolConfigMenu}
+          </div>
+          <vscode-toolbar-container class="file-select-actions">
+            <vscode-toolbar-button
+              id="current${this.config.type[0].toUpperCase()}${this.config.type.slice(
+                1,
+              )}FileButton"
+              icon="file-code"
+              label=${this.config.currentTitle}
+              title=${this.config.currentTitle}
+              data-action="current"
+              @click=${this.handleActionClick}
+            ></vscode-toolbar-button>
+            <vscode-toolbar-button
+              id="empty${this.config.type[0].toUpperCase()}${this.config.type.slice(
+                1,
+              )}FileButton"
+              icon="close"
+              label=${this.config.emptyTitle}
+              title=${this.config.emptyTitle}
+              data-action="empty"
+              @click=${this.handleActionClick}
+            ></vscode-toolbar-button>
+            <span
+              id=${this.toggleId}
+              class="toggle-icon"
+              title=${this.config.toggleTitle}
+              data-action="toggle"
+              @click=${this.handleActionClick}
+            >
+              <i class="codicon ${chevronClass}"></i>
+            </span>
+            <vscode-toolbar-button
+              id="addOpened${this.config.type[0].toUpperCase()}${this.config.type.slice(
+                1,
+              )}FilesButton"
+              class="file-action-button"
+              icon="folder-opened"
+              label=${this.config.addOpenedLabel}
+              title=${this.config.addOpenedLabel}
+              data-action="add-opened"
+              @click=${this.handleActionClick}
+            ></vscode-toolbar-button>
+            <vscode-toolbar-button
+              id="empty${this.config.type[0].toUpperCase()}${this.config.type.slice(
+                1,
+              )}FilesButton"
+              class="file-action-button"
+              icon="trash"
+              label=${this.config.emptyListLabel}
+              title=${this.config.emptyListLabel}
+              data-action="empty-list"
+              @click=${this.handleActionClick}
+            ></vscode-toolbar-button>
+            <vscode-toolbar-button
+              id="select${this.config.type[0].toUpperCase()}${this.config.type.slice(
+                1,
+              )}FilesButton"
+              class="file-action-button"
+              icon="add"
+              label=${this.config.selectListLabel}
+              title=${this.config.selectListLabel}
+              data-action="select-list"
+              @click=${this.handleActionClick}
+            ></vscode-toolbar-button>
+          </vscode-toolbar-container>
+        </div>
+        <vscode-single-select
+          id=${this.selectId}
+          .value=${this.selectedValue}
+          @focus=${this.emitFocus}
+          @change=${this.handleSelectChange}
+        >
+          ${unsafeHTML(this.optionsHtml)}
+        </vscode-single-select>
+        <div
+          id="${this.listId}Container"
+          class="multiple-files-container"
+          style=${this.isVisible ? 'display: block' : 'display: none'}
+        >
+          <div class="multiple-files-content">
+            <div id=${this.listId} class="multiple-files-list">
+              ${this.renderFileList()}
+            </div>
+          </div>
+        </div>
+      </div>
+    `;
+  }
+
+  private renderFileList(): TemplateResult {
+    if (this.files.length === 0) {
+      return html`<div class="file-list-placeholder">No files selected.</div>`;
+    }
+
+    return html`${repeat(
+      this.files,
+      (file) => file,
+      (file) => html`
+        <div class="file-item" data-path=${file}>
+          <span class="file-name">${file}</span>
+          <span
+            class="remove-button codicon codicon-trash"
+            role="button"
+            data-file-path=${file}
+            @click=${this.handleRemoveClick}
+          ></span>
+        </div>
+      `,
+    )}`;
+  }
+}

--- a/src/webview/frontend/components/GettingStartedBanner.ts
+++ b/src/webview/frontend/components/GettingStartedBanner.ts
@@ -6,16 +6,11 @@ import { customElement, property } from 'lit/decorators.js';
 import { designTokens, commonViewStyles, codiconStyles } from '@shared/styles';
 
 // Local imports - main view
-import { mainViewStyles } from '@webview/frontend/styles';
+import { bannerStyles } from '@webview/frontend/styles';
 
 @customElement('getting-started-banner')
 export class GettingStartedBanner extends LitElement {
-  static styles = [
-    designTokens,
-    commonViewStyles,
-    codiconStyles,
-    mainViewStyles,
-  ];
+  static styles = [designTokens, commonViewStyles, codiconStyles, bannerStyles];
 
   @property({ type: Boolean }) visible = false;
 

--- a/src/webview/frontend/components/GettingStartedBanner.ts
+++ b/src/webview/frontend/components/GettingStartedBanner.ts
@@ -1,0 +1,47 @@
+// Third-party imports
+import { LitElement, html, type TemplateResult } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+
+// Local imports - shared styles
+import { designTokens, commonViewStyles, codiconStyles } from '@shared/styles';
+
+// Local imports - main view
+import { mainViewStyles } from '@webview/frontend/styles';
+
+@customElement('getting-started-banner')
+export class GettingStartedBanner extends LitElement {
+  static styles = [
+    designTokens,
+    commonViewStyles,
+    codiconStyles,
+    mainViewStyles,
+  ];
+
+  @property({ type: Boolean }) visible = false;
+
+  render(): TemplateResult {
+    return html`
+      <div
+        id="gettingStartedBanner"
+        class="getting-started-banner"
+        style=${this.visible ? 'display: block' : 'display: none'}
+      >
+        <span class="getting-started-text">
+          No files found in workspace. Try
+          <a href="command:texra.openGettingStarted"
+            >opening the getting started walkthrough</a
+          >,
+          <a href="command:texra.createSampleProject"
+            >creating a sample project</a
+          >,
+          <a href="command:texra.cloneOverleafProject"
+            >cloning an Overleaf project</a
+          >, or
+          <a href="command:texra.downloadArXivSource"
+            >downloading an arXiv source</a
+          >.
+        </span>
+      </div>
+    `;
+  }
+}

--- a/src/webview/frontend/components/LatexDiffsSection.ts
+++ b/src/webview/frontend/components/LatexDiffsSection.ts
@@ -1,0 +1,290 @@
+// Third-party imports
+import { LitElement, html, type TemplateResult } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import { unsafeHTML } from 'lit/directives/unsafe-html.js';
+
+// Local imports - shared styles
+import { designTokens, commonViewStyles, codiconStyles } from '@shared/styles';
+
+// Local imports - main view
+import { mainViewStyles } from '@webview/frontend/styles';
+
+export type LatexDiffsAction =
+  | 'toggle'
+  | 'current-base'
+  | 'empty-base'
+  | 'refresh-edited'
+  | 'current-edited'
+  | 'empty-edited'
+  | 'refresh-commits'
+  | 'run-latexdiff'
+  | 'run-latexdiffvc'
+  | 'pack-latexdiffvc'
+  | 'clean-latexdiffvc'
+  | 'merge'
+  | 'compare'
+  | 'accept';
+
+export type LatexDiffsField = 'base' | 'edited' | 'commit';
+
+export interface LatexDiffsActionDetail {
+  action: LatexDiffsAction;
+}
+
+export interface LatexDiffsChangeDetail {
+  field: LatexDiffsField;
+  value: string;
+}
+
+@customElement('latexdiffs-section')
+export class LatexDiffsSection extends LitElement {
+  static styles = [
+    designTokens,
+    commonViewStyles,
+    codiconStyles,
+    mainViewStyles,
+  ];
+
+  @property({ type: Boolean }) visible = false;
+  @property({ type: String }) baseFile = '';
+  @property({ type: String }) editedFile = '';
+  @property({ type: String }) commit = '';
+  @property({ type: Boolean }) isGitRepo = true;
+  @property({ type: String }) baseOptionsHtml = '';
+  @property({ type: String }) editedOptionsHtml = '';
+  @property({ type: String }) commitOptionsHtml = '';
+
+  private emitAction(action: LatexDiffsAction): void {
+    this.dispatchEvent(
+      new CustomEvent<LatexDiffsActionDetail>('latexdiffs-action', {
+        detail: { action },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+  }
+
+  private emitChange(field: LatexDiffsField, value: string): void {
+    this.dispatchEvent(
+      new CustomEvent<LatexDiffsChangeDetail>('latexdiffs-change', {
+        detail: { field, value },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+  }
+
+  private handleActionClick = (event: Event): void => {
+    const target = event.currentTarget as HTMLElement | null;
+    const action = target?.dataset.action as LatexDiffsAction | undefined;
+    if (!action) return;
+    this.emitAction(action);
+  };
+
+  private handleBaseChange = (event: Event): void => {
+    const target = event.currentTarget as HTMLInputElement | null;
+    if (!target) return;
+    this.emitChange('base', target.value);
+  };
+
+  private handleEditedChange = (event: Event): void => {
+    const target = event.currentTarget as HTMLInputElement | null;
+    if (!target) return;
+    this.emitChange('edited', target.value);
+  };
+
+  private handleCommitChange = (event: Event): void => {
+    const target = event.currentTarget as HTMLInputElement | null;
+    if (!target) return;
+    this.emitChange('commit', target.value);
+  };
+
+  render(): TemplateResult {
+    const chevronClass = this.visible
+      ? 'codicon-chevron-up'
+      : 'codicon-chevron-down';
+
+    return html`
+      <div class="latexdiffs-section" data-expanded=${String(this.visible)}>
+        <div class="file-select-header">
+          <div class="file-select-label-group">
+            <span
+              id="toggleLatexdiffs"
+              class="toggle-icon"
+              title="LaTeXDiffs"
+              data-action="toggle"
+              @click=${this.handleActionClick}
+            >
+              <i class="codicon ${chevronClass}"></i>
+            </span>
+            <span class="optional-label"
+              ><i class="codicon codicon-source-control"></i> LaTeXDiffs</span
+            >
+          </div>
+        </div>
+        <div
+          id="latexdiffsContent"
+          style=${this.visible ? 'display: block' : 'display: none'}
+        >
+          <div class="file-select">
+            <div class="file-select-header">
+              <div class="file-select-label-group">
+                <label for="baseFile">Base</label>
+              </div>
+              <vscode-toolbar-container class="file-select-actions">
+                <vscode-toolbar-button
+                  id="currentBaseFileButton"
+                  icon="file-code"
+                  label="Set current file as base"
+                  title="Set current file as base"
+                  data-action="current-base"
+                  @click=${this.handleActionClick}
+                ></vscode-toolbar-button>
+                <vscode-toolbar-button
+                  id="emptyBaseFileButton"
+                  icon="close"
+                  label="Clear base file"
+                  title="Clear base file"
+                  data-action="empty-base"
+                  @click=${this.handleActionClick}
+                ></vscode-toolbar-button>
+              </vscode-toolbar-container>
+            </div>
+            <vscode-single-select
+              id="baseFile"
+              .value=${this.baseFile}
+              @change=${this.handleBaseChange}
+            >
+              ${unsafeHTML(this.baseOptionsHtml)}
+            </vscode-single-select>
+          </div>
+          <div class="file-select">
+            <div class="file-select-header">
+              <div class="file-select-label-group">
+                <label for="editedFile">Edited</label>
+              </div>
+              <vscode-toolbar-container class="file-select-actions">
+                <vscode-toolbar-button
+                  id="refreshEditedFileButton"
+                  icon="edit"
+                  label="Refresh edited files"
+                  title="Refresh edited files"
+                  data-action="refresh-edited"
+                  @click=${this.handleActionClick}
+                ></vscode-toolbar-button>
+                <vscode-toolbar-button
+                  id="currentEditedFileButton"
+                  icon="file-code"
+                  label="Set current file as edited"
+                  title="Set current file as edited"
+                  data-action="current-edited"
+                  @click=${this.handleActionClick}
+                ></vscode-toolbar-button>
+                <vscode-toolbar-button
+                  id="emptyEditedFileButton"
+                  icon="close"
+                  label="Clear edited file"
+                  title="Clear edited file"
+                  data-action="empty-edited"
+                  @click=${this.handleActionClick}
+                ></vscode-toolbar-button>
+              </vscode-toolbar-container>
+            </div>
+            <vscode-single-select
+              id="editedFile"
+              .value=${this.editedFile}
+              @change=${this.handleEditedChange}
+            >
+              ${unsafeHTML(this.editedOptionsHtml)}
+            </vscode-single-select>
+          </div>
+          <div class="file-select">
+            <div class="file-select-header">
+              <div class="file-select-label-group">
+                <label for="commit">
+                  <i class="codicon codicon-git-commit"></i> Commit
+                </label>
+              </div>
+              <vscode-toolbar-container class="file-select-actions">
+                <vscode-toolbar-button
+                  id="refreshCommitsButton"
+                  icon="refresh"
+                  label="Refresh commits"
+                  title="Refresh commits"
+                  data-action="refresh-commits"
+                  @click=${this.handleActionClick}
+                ></vscode-toolbar-button>
+              </vscode-toolbar-container>
+            </div>
+            <vscode-single-select
+              id="commit"
+              .value=${this.commit}
+              ?disabled=${!this.isGitRepo}
+              @change=${this.handleCommitChange}
+            >
+              ${unsafeHTML(this.commitOptionsHtml)}
+            </vscode-single-select>
+          </div>
+          <div class="instruction-controls">
+            <vscode-toolbar-button
+              id="latexdiffButton"
+              icon="compare-changes"
+              label="Run LaTeXDiff"
+              title="Run LaTeXDiff"
+              data-action="run-latexdiff"
+              @click=${this.handleActionClick}
+            ></vscode-toolbar-button>
+            <vscode-toolbar-button
+              id="latexdiffvcButton"
+              icon="compare-changes"
+              label="Run LaTeXDiff with version control"
+              title="Run LaTeXDiff with version control"
+              data-action="run-latexdiffvc"
+              @click=${this.handleActionClick}
+            ></vscode-toolbar-button>
+            <vscode-toolbar-button
+              id="packLatexdiffvcButton"
+              icon="archive"
+              label="Pack LaTeXDiff VC"
+              title="Pack LaTeXDiff VC"
+              data-action="pack-latexdiffvc"
+              @click=${this.handleActionClick}
+            ></vscode-toolbar-button>
+            <vscode-toolbar-button
+              id="cleanLatexdiffvcButton"
+              icon="trash"
+              label="Clean LaTeXDiff VC"
+              title="Clean LaTeXDiff VC"
+              data-action="clean-latexdiffvc"
+              @click=${this.handleActionClick}
+            ></vscode-toolbar-button>
+            <vscode-toolbar-button
+              id="mergeButton"
+              icon="merge"
+              label="Merge edits"
+              title="Merge edits"
+              data-action="merge"
+              @click=${this.handleActionClick}
+            ></vscode-toolbar-button>
+            <vscode-toolbar-button
+              id="compareButton"
+              icon="diff"
+              label="Compare"
+              title="Compare"
+              data-action="compare"
+              @click=${this.handleActionClick}
+            ></vscode-toolbar-button>
+            <vscode-toolbar-button
+              id="acceptButton"
+              icon="check"
+              label="Accept"
+              title="Accept"
+              data-action="accept"
+              @click=${this.handleActionClick}
+            ></vscode-toolbar-button>
+          </div>
+        </div>
+      </div>
+    `;
+  }
+}

--- a/src/webview/frontend/components/LoginBanner.ts
+++ b/src/webview/frontend/components/LoginBanner.ts
@@ -1,0 +1,86 @@
+// Third-party imports
+import { LitElement, html, type TemplateResult } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+
+// Local imports - shared styles
+import { designTokens, commonViewStyles, codiconStyles } from '@shared/styles';
+
+// Local imports - main view
+import { mainViewStyles } from '@webview/frontend/styles';
+
+export type LoginBannerAction = 'sign-in' | 'dismiss';
+
+export interface LoginBannerActionDetail {
+  action: LoginBannerAction;
+}
+
+@customElement('login-banner')
+export class LoginBanner extends LitElement {
+  static styles = [
+    designTokens,
+    commonViewStyles,
+    codiconStyles,
+    mainViewStyles,
+  ];
+
+  @property({ type: Boolean }) visible = false;
+
+  private emitAction(action: LoginBannerAction): void {
+    this.dispatchEvent(
+      new CustomEvent<LoginBannerActionDetail>('login-banner-action', {
+        detail: { action },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+  }
+
+  private handleActionClick = (event: Event): void => {
+    const target = event.currentTarget as HTMLElement | null;
+    const action = target?.dataset.action as LoginBannerAction | undefined;
+    if (!action) return;
+    this.emitAction(action);
+  };
+
+  render(): TemplateResult {
+    return html`
+      <div
+        id="loginBanner"
+        class="login-banner"
+        style=${this.visible ? 'display: flex' : 'display: none'}
+      >
+        <div class="login-banner-content">
+          <span class="login-banner-icon"
+            ><i class="codicon codicon-sparkle"></i
+          ></span>
+          <div class="login-banner-text">
+            <span class="login-banner-title">Researcher Access Program</span>
+            <span class="login-banner-description">
+              Sign in to access AI models and remote agents without your own API
+              keys.
+            </span>
+          </div>
+        </div>
+        <div class="actions">
+          <vscode-button
+            id="loginBannerButton"
+            appearance="primary"
+            data-action="sign-in"
+            @click=${this.handleActionClick}
+          >
+            <span slot="start" class="codicon codicon-sign-in"></span>
+            Sign In
+          </vscode-button>
+          <vscode-toolbar-button
+            id="loginBannerDismissButton"
+            icon="close"
+            title="Dismiss (can be re-enabled in settings)"
+            aria-label="Dismiss login banner"
+            data-action="dismiss"
+            @click=${this.handleActionClick}
+          ></vscode-toolbar-button>
+        </div>
+      </div>
+    `;
+  }
+}

--- a/src/webview/frontend/components/LoginBanner.ts
+++ b/src/webview/frontend/components/LoginBanner.ts
@@ -6,7 +6,7 @@ import { customElement, property } from 'lit/decorators.js';
 import { designTokens, commonViewStyles, codiconStyles } from '@shared/styles';
 
 // Local imports - main view
-import { mainViewStyles } from '@webview/frontend/styles';
+import { bannerStyles } from '@webview/frontend/styles';
 
 export type LoginBannerAction = 'sign-in' | 'dismiss';
 
@@ -16,12 +16,7 @@ export interface LoginBannerActionDetail {
 
 @customElement('login-banner')
 export class LoginBanner extends LitElement {
-  static styles = [
-    designTokens,
-    commonViewStyles,
-    codiconStyles,
-    mainViewStyles,
-  ];
+  static styles = [designTokens, commonViewStyles, codiconStyles, bannerStyles];
 
   @property({ type: Boolean }) visible = false;
 

--- a/src/webview/frontend/components/OutputFilesGroup.ts
+++ b/src/webview/frontend/components/OutputFilesGroup.ts
@@ -1,0 +1,142 @@
+// Third-party imports
+import { LitElement, html, type TemplateResult } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import { repeat } from 'lit/directives/repeat.js';
+
+// Local imports - shared styles
+import { designTokens, commonViewStyles, codiconStyles } from '@shared/styles';
+
+// Local imports - main view
+import { mainViewStyles } from '@webview/frontend/styles';
+
+export type OutputFilesAction =
+  | 'toggle'
+  | 'empty-list'
+  | 'select-list'
+  | 'remove';
+
+export interface OutputFilesActionDetail {
+  action: OutputFilesAction;
+  listId: string;
+  filePath?: string;
+}
+
+@customElement('output-files-group')
+export class OutputFilesGroup extends LitElement {
+  static styles = [
+    designTokens,
+    commonViewStyles,
+    codiconStyles,
+    mainViewStyles,
+  ];
+
+  @property({ type: Array }) files: string[] = [];
+  @property({ type: Boolean }) isActive = false;
+
+  private emitAction(detail: OutputFilesActionDetail): void {
+    this.dispatchEvent(
+      new CustomEvent<OutputFilesActionDetail>('output-files-action', {
+        detail,
+        bubbles: true,
+        composed: true,
+      }),
+    );
+  }
+
+  private handleActionClick = (event: Event): void => {
+    const target = event.currentTarget as HTMLElement | null;
+    const action = target?.dataset.action as OutputFilesAction | undefined;
+    if (!action) return;
+    this.emitAction({ action, listId: 'outputFiles' });
+  };
+
+  private handleRemoveClick = (event: Event): void => {
+    const target = event.currentTarget as HTMLElement | null;
+    const filePath = target?.dataset.filePath;
+    if (!filePath) return;
+    this.emitAction({ action: 'remove', listId: 'outputFiles', filePath });
+  };
+
+  render(): TemplateResult {
+    const chevronClass = this.isActive
+      ? 'codicon-chevron-up'
+      : 'codicon-chevron-down';
+    return html`
+      <div class="file-select" data-expanded=${String(this.isActive)}>
+        <div class="file-select-header">
+          <div class="file-select-label-group">
+            <span
+              id="toggleOutputFiles"
+              class="toggle-icon"
+              title="Show or hide additional files for the agent's output"
+              data-action="toggle"
+              @click=${this.handleActionClick}
+            >
+              <i class="codicon ${chevronClass}"></i>
+            </span>
+            <span
+              class="optional-label"
+              title="List the files that should receive the agent’s output"
+              >Multiple Outputs</span
+            >
+          </div>
+          <vscode-toolbar-container class="file-select-actions">
+            <vscode-toolbar-button
+              id="emptyOutputFilesButton"
+              class="file-action-button"
+              icon="trash"
+              label="Clear all output files"
+              title="Clear all output files"
+              data-action="empty-list"
+              @click=${this.handleActionClick}
+            ></vscode-toolbar-button>
+            <vscode-toolbar-button
+              id="selectOutputFilesButton"
+              class="file-action-button"
+              icon="add"
+              label="Add output files"
+              title="Add output files"
+              data-action="select-list"
+              @click=${this.handleActionClick}
+            ></vscode-toolbar-button>
+          </vscode-toolbar-container>
+        </div>
+        <div
+          id="outputFilesContainer"
+          class="multiple-files-container"
+          style=${this.isActive ? 'display: block' : 'display: none'}
+        >
+          <div class="multiple-files-content">
+            <div id="outputFiles" class="multiple-files-list">
+              ${this.renderFileList()}
+            </div>
+          </div>
+        </div>
+      </div>
+    `;
+  }
+
+  private renderFileList(): TemplateResult {
+    if (this.files.length === 0) {
+      return html`<div class="file-list-placeholder">
+        No extra outputs selected. Click "Add" to choose files.
+      </div>`;
+    }
+
+    return html`${repeat(
+      this.files,
+      (file) => file,
+      (file) => html`
+        <div class="file-item" data-path=${file}>
+          <span class="file-name">${file}</span>
+          <span
+            class="remove-button codicon codicon-trash"
+            role="button"
+            data-file-path=${file}
+            @click=${this.handleRemoveClick}
+          ></span>
+        </div>
+      `,
+    )}`;
+  }
+}

--- a/src/webview/frontend/styles.ts
+++ b/src/webview/frontend/styles.ts
@@ -209,119 +209,9 @@ export const mainViewStyles: CSSResult = css`
     align-items: center;
   }
 
-  .api-key-banner .actions,
-  .agent-config-banner .actions,
-  .dependency-banner .actions {
-    display: flex;
-    align-items: center;
-    gap: var(--spacing-small);
-  }
-
-  .dependency-banner .dependency-item {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: var(--spacing-small);
-  }
-
   .remove-button {
     color: var(--vscode-errorForeground);
     cursor: pointer;
-  }
-
-  .api-key-banner,
-  .agent-config-banner,
-  .dependency-banner,
-  .getting-started-banner {
-    border-radius: var(--border-radius);
-    padding: var(--spacing-small) var(--spacing-medium);
-    margin-bottom: var(--spacing-large);
-  }
-
-  .api-key-banner,
-  .agent-config-banner,
-  .dependency-banner {
-    background-color: var(--vscode-inputValidation-warningBackground);
-    color: var(--vscode-inputValidation-warningForeground);
-    border: 1px solid var(--vscode-inputValidation-warningBorder);
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-  }
-
-  .getting-started-banner {
-    background-color: var(--vscode-inputValidation-infoBackground);
-    color: var(--vscode-inputValidation-infoForeground);
-    border: 1px solid var(--vscode-inputValidation-infoBorder);
-    line-height: 1.5;
-  }
-
-  .getting-started-banner a {
-    color: var(--color-text-link);
-    text-decoration: none;
-  }
-
-  .getting-started-banner a:hover {
-    text-decoration: underline;
-  }
-
-  .login-banner {
-    background: linear-gradient(
-      135deg,
-      var(--vscode-inputValidation-infoBackground) 0%,
-      color-mix(
-          in srgb,
-          var(--vscode-inputValidation-infoBackground) 80%,
-          var(--vscode-button-background)
-        )
-        100%
-    );
-    color: var(--vscode-inputValidation-infoForeground);
-    border: 1px solid var(--vscode-inputValidation-infoBorder);
-    border-radius: var(--border-radius);
-    padding: var(--spacing-medium);
-    margin-bottom: var(--spacing-large);
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    gap: var(--spacing-medium);
-  }
-
-  .login-banner-content {
-    display: flex;
-    align-items: center;
-    gap: var(--spacing-medium);
-    flex: 1;
-  }
-
-  .login-banner-icon {
-    font-size: 1.5em;
-    color: var(--vscode-button-background);
-    display: flex;
-    align-items: center;
-  }
-
-  .login-banner-text {
-    display: flex;
-    flex-direction: column;
-    gap: var(--spacing-tiny);
-  }
-
-  .login-banner-title {
-    font-weight: 600;
-    font-size: 1em;
-  }
-
-  .login-banner-description {
-    font-size: 0.9em;
-    opacity: 0.9;
-  }
-
-  .login-banner .actions {
-    display: flex;
-    align-items: center;
-    gap: var(--spacing-small);
-    flex-shrink: 0;
   }
 
   .file-select {
@@ -572,5 +462,117 @@ export const mainViewStyles: CSSResult = css`
   #model::part(listbox) {
     bottom: 100%;
     top: auto;
+  }
+`;
+
+export const bannerStyles: CSSResult = css`
+  .api-key-banner .actions,
+  .agent-config-banner .actions,
+  .dependency-banner .actions {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-small);
+  }
+
+  .dependency-banner .dependency-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--spacing-small);
+  }
+
+  .api-key-banner,
+  .agent-config-banner,
+  .dependency-banner,
+  .getting-started-banner {
+    border-radius: var(--border-radius);
+    padding: var(--spacing-small) var(--spacing-medium);
+    margin-bottom: var(--spacing-large);
+  }
+
+  .api-key-banner,
+  .agent-config-banner,
+  .dependency-banner {
+    background-color: var(--vscode-inputValidation-warningBackground);
+    color: var(--vscode-inputValidation-warningForeground);
+    border: 1px solid var(--vscode-inputValidation-warningBorder);
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+
+  .getting-started-banner {
+    background-color: var(--vscode-inputValidation-infoBackground);
+    color: var(--vscode-inputValidation-infoForeground);
+    border: 1px solid var(--vscode-inputValidation-infoBorder);
+    line-height: 1.5;
+  }
+
+  .getting-started-banner a {
+    color: var(--color-text-link);
+    text-decoration: none;
+  }
+
+  .getting-started-banner a:hover {
+    text-decoration: underline;
+  }
+
+  .login-banner {
+    background: linear-gradient(
+      135deg,
+      var(--vscode-inputValidation-infoBackground) 0%,
+      color-mix(
+          in srgb,
+          var(--vscode-inputValidation-infoBackground) 80%,
+          var(--vscode-button-background)
+        )
+        100%
+    );
+    color: var(--vscode-inputValidation-infoForeground);
+    border: 1px solid var(--vscode-inputValidation-infoBorder);
+    border-radius: var(--border-radius);
+    padding: var(--spacing-medium);
+    margin-bottom: var(--spacing-large);
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: var(--spacing-medium);
+  }
+
+  .login-banner-content {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-medium);
+    flex: 1;
+  }
+
+  .login-banner-icon {
+    font-size: 1.5em;
+    color: var(--vscode-button-background);
+    display: flex;
+    align-items: center;
+  }
+
+  .login-banner-text {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-tiny);
+  }
+
+  .login-banner-title {
+    font-weight: 600;
+    font-size: 1em;
+  }
+
+  .login-banner-description {
+    font-size: 0.9em;
+    opacity: 0.9;
+  }
+
+  .login-banner .actions {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-small);
+    flex-shrink: 0;
   }
 `;


### PR DESCRIPTION
### Motivation
- Reduce MainApp size and surface area by extracting file-selection, banners, output-files, and LaTeX-diff UI into focused Lit components to follow the Phase 6 extraction plan. 
- Replace many inline template handlers and non-keyed list rendering to improve runtime performance and reduce re-render churn. 
- Centralize event routing in MainApp so shared state remains in one place while UI responsibilities are isolated.

### Description
- Introduced new Lit components under `src/webview/frontend/components/`: `FileSelectGroup`, `OutputFilesGroup`, `ApiKeyBanner`, `AgentConfigBanner`, `DependencyBanner`, `GettingStartedBanner`, `LoginBanner`, and `LatexDiffsSection`, each exposing typed CustomEvent payloads for interaction. 
- Rewrote `MainApp.ts` to mount those components, wire their events to centralized handlers (e.g., `handleFileSelectActionEvent`, `handleOutputFilesActionEvent`, `handleApiKeyBannerActionEvent`, `handleLatexDiffsActionEvent`), and removed the original large inline file-selection template and many inline arrow handlers. 
- Migrated multiple progress-view components to more performant Lit patterns: replaced `.map()` with `repeat()` in `RunSelector`, `FileList`, `StreamHeader`, `StreamTabs`, and `PromptOverlay`, and added `guard()` memoization in `ToolUseStreamContent` and `WorkflowStreamContent` to avoid expensive recomputation. 
- Consolidated menu/checkbox interactions to use `data-*` attributes and stable event handlers (`handleMenuToggle`, `handleCheckboxToggle`) to eliminate per-render arrow allocations and standardize behavior. 
- Preserved existing behavior and fixed a banner-related edge case by keeping `apiKeyBannerForced` across model updates when appropriate, and added a small `isToolUse` getter for clarity.

### Testing
- Ran `npm run format` and successfully formatted the repository. (succeeded) 
- Ran `npm run compile:fast` which executed the esbuild extension build and Vite webview builds for `progressView`, `memoryView`, `historyView`, `profileView`, and `webview`, producing bundles (succeeded). 
- Ran `npm run lint` which completed with warnings (no errors); warnings are existing code-style/eqeqeq and import order items outside the modified files (succeeded with warnings).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976c82cd0bc83248ff2337995d6164a)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Major UI and architecture cleanup with performance-focused Lit patterns.
> 
> - Extracts `FileSelectGroup`, `OutputFilesGroup`, `ApiKeyBanner`, `AgentConfigBanner`, `DependencyBanner`, `GettingStartedBanner`, `LoginBanner`, and `LatexDiffsSection`; `MainApp.ts` now composes these and handles their typed events (centralized handlers, data-* attributes, fewer inline arrows), plus minor banner/UX fixes
> - ProgressView perf: replace `.map()` with `repeat()` in `RunSelector`, `FileList`, `StreamHeader`, `StreamTabs`, `PromptOverlay`; add `guard()` memoization in `ToolUseStreamContent` and `WorkflowStreamContent`
> - Decouples `TaskGroupDomManager`: new `TaskGroupStateManager`, `AudioNotificationService`, and `utils/taskGroupTraversal` (collapse/find active); `LogList` updated to use state manager and constructor wiring
> - Styles: move banner styles into shared `bannerStyles`; docs (Phase 5/6 PRDs) updated to mark tasks complete and tables normalized
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d896e9d7c40132e849e007da86f366ff2c05079d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->