### PR TITLE
fix: skip webpack prepublish when using fast build

### DIFF
--- a/package.json
+++ b/package.json
@@ -1625,7 +1625,7 @@
     ]
   },
   "scripts": {
-    "vscode:prepublish": "npm run package",
+    "vscode:prepublish": "[ \"$SKIP_VSCE_PREPUBLISH\" = \"1\" ] || npm run package",
     "compile": "NODE_OPTIONS=--max-old-space-size=8192 webpack",
     "watch": "NODE_OPTIONS=--max-old-space-size=8192 webpack --watch",
     "package": "NODE_OPTIONS=--max-old-space-size=8192 webpack --mode production --devtool hidden-source-map",
@@ -1645,7 +1645,7 @@
     "compile:fast": "npm run esbuild:ext && npm run vite:webviews:dev",
     "watch:fast": "concurrently \"npm run esbuild:ext:watch\" \"npm run vite:webviews:watch\"",
     "package:fast": "npm run esbuild:ext:prod && npm run vite:webviews",
-    "build:fast": "npm run package:fast && vsce package --out releases/texra-$npm_package_version.vsix"
+    "build:fast": "npm run package:fast && SKIP_VSCE_PREPUBLISH=1 vsce package --out releases/texra-$npm_package_version.vsix"
   },
   "devDependencies": {
     "@stylistic/eslint-plugin": "^5.7.1",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -143,7 +143,16 @@ const webviewConfigs = [
         // Used for: import 'katex/dist/katex.min.css', import './styles/index.css'
         test: /\.css$/,
         resourceQuery: { not: [/inline/] },
-        use: ['style-loader', 'css-loader'],
+        use: [
+          'style-loader',
+          {
+            loader: 'css-loader',
+            options: {
+              // Don't resolve url() - fonts are loaded via VS Code webview URI
+              url: false,
+            },
+          },
+        ],
       },
     ],
   },


### PR DESCRIPTION
Add SKIP_VSCE_PREPUBLISH env var check to vscode:prepublish script. Set the var in build:fast to avoid double-building with webpack.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> - **Build scripts:** Gate `vscode:prepublish` behind `SKIP_VSCE_PREPUBLISH` and set it in `build:fast` to prevent double-running `webpack` when packaging fast builds.
> - **Webpack (webviews):** Update `css-loader` options for non-inline CSS to `url: false` so `url()` paths aren’t resolved (fonts loaded via VS Code webview URIs).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5fc67eaa75853d879251bf312118870b4c820cd0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->