### PR TITLE
Claude/bundle lit typescript zod 2jod h

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -23,9 +23,6 @@ eslint.config.mjs
 tsconfig.json
 **/*.map
 **/*.ts
-
-# Exclude codicon font (loaded via VS Code webview URI, not bundled)
-**/codicon.ttf
 **/.vscode-test.*
 
 venv/**
@@ -40,6 +37,9 @@ CLAUDE.md
 !node_modules/@vscode/codicons/dist/**
 !node_modules/split.js/**
 !node_modules/@vscode-elements/elements/dist/**
+
+# Exclude codicon font AFTER negations (loaded via VS Code webview URI, not bundled)
+**/codicon.ttf
 
 
 !resources/**

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -23,6 +23,12 @@ eslint.config.mjs
 tsconfig.json
 **/*.map
 **/*.ts
+
+# Exclude fonts emitted by vite (loaded via VS Code webview URI, not bundled)
+**/KaTeX_*.ttf
+**/KaTeX_*.woff
+**/KaTeX_*.woff2
+**/codicon.ttf
 **/.vscode-test.*
 
 venv/**

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -24,10 +24,7 @@ tsconfig.json
 **/*.map
 **/*.ts
 
-# Exclude fonts emitted by vite (loaded via VS Code webview URI, not bundled)
-**/KaTeX_*.ttf
-**/KaTeX_*.woff
-**/KaTeX_*.woff2
+# Exclude codicon font (loaded via VS Code webview URI, not bundled)
 **/codicon.ttf
 **/.vscode-test.*
 

--- a/src/webview/frontend/MainApp.ts
+++ b/src/webview/frontend/MainApp.ts
@@ -253,7 +253,7 @@ export class MainApp extends BaseWebviewApp {
   @state() private isGitRepo = true;
   private defaultOutputFiles: string[] = [];
   private apiKeyBannerForced = false;
-  private instructionSaveTimer: ReturnType<typeof setTimeout> | null = null;
+  private instructionSaveTimer: number | null = null;
 
   @query('#instruction')
   declare private instructionElement: HTMLElement | null;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -26,6 +26,9 @@ function createWebviewConfig(webviewName: string, isDev: boolean) {
       sourcemap: isDev ? 'inline' : false,
       minify: isDev ? false : 'esbuild',
       target: 'es2022',
+      // Keep default 4KB limit - fonts above this are emitted as files (not inlined as base64)
+      // KaTeX fonts are ~10-60KB each, so they will be emitted to dist/{webview}/
+      assetsInlineLimit: 4 * 1024,
       rollupOptions: {
         input: resolve(__dirname, `src/${webviewName}/frontend/index.ts`),
         output: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -26,8 +26,6 @@ function createWebviewConfig(webviewName: string, isDev: boolean) {
       sourcemap: isDev ? 'inline' : false,
       minify: isDev ? false : 'esbuild',
       target: 'es2022',
-      // Keep default 4KB inline limit - don't inline fonts
-      assetsInlineLimit: 4 * 1024,
       rollupOptions: {
         input: resolve(__dirname, `src/${webviewName}/frontend/index.ts`),
         output: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -143,16 +143,15 @@ const webviewConfigs = [
         // Used for: import 'katex/dist/katex.min.css', import './styles/index.css'
         test: /\.css$/,
         resourceQuery: { not: [/inline/] },
-        use: [
-          'style-loader',
-          {
-            loader: 'css-loader',
-            options: {
-              // Don't resolve url() - fonts are loaded via VS Code webview URI
-              url: false,
-            },
-          },
-        ],
+        use: ['style-loader', 'css-loader'],
+      },
+      {
+        // Font files - emit to same folder as bundle
+        test: /\.(woff|woff2|ttf|eot)$/,
+        type: 'asset/resource',
+        generator: {
+          filename: '[name][ext]',
+        },
       },
     ],
   },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Improves webview asset handling and packaging.
> 
> - **Webpack (webviews):** Enable `css-loader` URL resolution and add a font rule to emit `woff/woff2/ttf/eot` next to each bundle
> - **Packaging:** Update `.vscodeignore` to exclude `codicon.ttf` (loaded via VS Code webview URI)
> - **Build notes:** Clarify Vite `assetsInlineLimit` comments to ensure fonts are emitted as files
> - **UI minor fix:** Type tweak for `instructionSaveTimer` in `MainApp.ts` to `number | null`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c8edcaf4688e9f3530642a223e32fc9e4baf9a77. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->