### PR TITLE
fix: activate views on open

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
   ],
   "activationEvents": [
     "onColorTheme",
+    "onView:texra.mainView",
+    "onView:texra.progressView",
+    "onView:texra.folderExplorer",
     "onCommand:texra.openGettingStarted",
     "onCommand:texra.cloneOverleafProject"
   ],


### PR DESCRIPTION
### Motivation
- The extension sometimes remained inactive/blank when users opened TeXRA views because the package did not declare view-based activation events, so VS Code did not activate the extension when those views were opened.

### Description
- Add view-based activation events to `package.json` (`onView:texra.mainView`, `onView:texra.progressView`, `onView:texra.folderExplorer`) so the extension is activated when the corresponding views are opened.

### Testing
- Ran `npm run format`, `npm run compile:fast`, and `npm run lint`; formatting and compilation completed successfully and `lint` finished with warnings (no errors).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697754d3fdf88324b9b38889ee7c5405)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures VS Code activates the extension when TeXRA views are opened.
> 
> - Add `onView:texra.mainView`, `onView:texra.progressView`, and `onView:texra.folderExplorer` to `activationEvents` in `package.json`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2565fda2837f19d6ef540a7bac533a165b013707. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->