### PR TITLE
feat(mainview): migrate MainView persisted state to shared Zod schemas and validate restore flow

### DIFF
--- a/docs/testing/mainview-manual-tests.md
+++ b/docs/testing/mainview-manual-tests.md
@@ -1,0 +1,20 @@
+## MainView Manual Test Checklist
+
+### State Persistence
+
+- [ ] Set all form fields, close/reopen VS Code → fields restored
+- [ ] Switch session type (workflow ↔ tool-use) → correct agent shown
+- [ ] Add multiple files to lists → lists restored after reload
+- [ ] Toggle visibility on file lists → visibility preserved
+
+### State Restore (Cross-webview)
+
+- [ ] From HistoryView: click "Restore" → MainView populated correctly
+- [ ] From ProgressView: click "Setup Followup" → MainView populated correctly
+
+### Component Interactions
+
+- [ ] File dropdowns: select file → field updates
+- [ ] Checkboxes: toggle → state saves
+- [ ] Banners: API key missing → banner shows, add key → banner hides
+- [ ] Execute button: click → progress view opens

--- a/src/MainViewProvider.ts
+++ b/src/MainViewProvider.ts
@@ -1,6 +1,9 @@
 // Third-party imports
 import * as vscode from 'vscode';
 
+// Local imports - shared schemas
+import { MainViewPersistedStateSchema } from '@shared/schemas/mainViewState';
+
 // Local imports - agent
 import { refresh, computeAgentOptions } from '@agent/index';
 
@@ -266,9 +269,15 @@ export class MainViewProvider
     const pendingData = consumePendingState();
 
     if (pendingData) {
+      const parsedState = MainViewPersistedStateSchema.partial().safeParse(
+        pendingData.state,
+      );
+      if (!parsedState.success) {
+        return;
+      }
       webviewView.webview.postMessage({
         command: MAIN_VIEW_COMMANDS.STATE_RESTORE,
-        state: pendingData.state,
+        state: parsedState.data,
         executeImmediately: pendingData.executeImmediately,
       });
     }

--- a/src/commands/history/stateRestoreCommand.ts
+++ b/src/commands/history/stateRestoreCommand.ts
@@ -1,12 +1,23 @@
 // Third-party imports
 import * as vscode from 'vscode';
 
-// Local imports - log
+// Local imports - shared schemas
+import { MainViewPersistedStateSchema } from '@shared/schemas/mainViewState';
+
+// Local imports - common
 import { showLoggedErrorMessage, toErrorMessage } from '@common/errors';
-import { setPendingState } from '@common/state';
+import {
+  buildMainViewStateFromTaskState,
+  setPendingState,
+} from '@common/state';
+import { COMMON_COMMANDS } from '@common/webview/commands';
+
+// Local imports - frontend
 import { getMainWebview } from '@frontend/system/commandUtils';
+
+// Local imports - logger
 import * as logger from '@logger/logUtils';
-import type { TaskState } from '@logger/TaskState';
+import { TaskStateSchema, type TaskState } from '@logger/TaskState';
 // Type imports
 
 const CHANNEL = 'stateRestoreCommand';
@@ -34,14 +45,21 @@ async function restoreState(state: TaskState, executeImmediately?: boolean) {
   });
 
   try {
+    const parsedTaskState = TaskStateSchema.safeParse(state);
+    if (!parsedTaskState.success) {
+      throw new Error('Invalid task state provided for restoration.');
+    }
+    const restoredState = buildMainViewStateFromTaskState(state);
+    const validatedState = MainViewPersistedStateSchema.parse(restoredState);
+
     // Focus the webview panel first to make sure it's visible
     await vscode.commands.executeCommand('texra.mainView.focus');
 
     const webviewView = await getMainWebview(CHANNEL);
     if (webviewView) {
       webviewView.webview.postMessage({
-        command: 'restoreState',
-        state,
+        command: COMMON_COMMANDS.STATE_RESTORE,
+        state: validatedState,
         executeImmediately,
       });
       logger.info(CHANNEL, 'State restored via direct webview access');
@@ -49,7 +67,7 @@ async function restoreState(state: TaskState, executeImmediately?: boolean) {
     }
 
     // Store the state in memory for the MainViewProvider to pick up
-    setPendingState(state, executeImmediately);
+    setPendingState(validatedState, executeImmediately);
     await vscode.commands.executeCommand('texra.mainView.focus');
     logger.info(CHANNEL, 'State stored for later restoration', {
       data: { executeImmediately },

--- a/src/common/state/index.ts
+++ b/src/common/state/index.ts
@@ -1,2 +1,3 @@
 export * from './stateManager';
 export * from './pendingStateManager';
+export * from './mainViewState';

--- a/src/common/state/mainViewState.ts
+++ b/src/common/state/mainViewState.ts
@@ -1,0 +1,80 @@
+// Local imports - shared schemas
+import {
+  MainViewPersistedStateSchema,
+  type MainViewPersistedState,
+} from '@shared/schemas/mainViewState';
+
+// Local imports - agent
+import { AgentCategory } from '@agent/core/AgentDataclass';
+
+// Local imports - logger
+import { type TaskState, isWorkflowTaskState } from '@logger/TaskState';
+
+const DEFAULT_MAIN_VIEW_STATE = MainViewPersistedStateSchema.parse({});
+
+/**
+ * Build MainView persisted state from a TaskState payload.
+ */
+export function buildMainViewStateFromTaskState(
+  taskState: TaskState,
+): MainViewPersistedState {
+  const { agentConfig } = taskState;
+  const isToolUse = agentConfig.agentCategory === AgentCategory.ToolUse;
+  const activeFiles = isWorkflowTaskState(taskState)
+    ? taskState.activeFiles
+    : {
+        input: false,
+        reference: false,
+        auxiliary: false,
+        media: false,
+        output: false,
+      };
+  const toolConfig = agentConfig.toolConfig ?? {};
+  const inputFiles = agentConfig.inputFiles ?? [];
+  const referenceFiles = agentConfig.referenceFiles ?? [];
+  const auxiliaryFiles = agentConfig.auxiliaryFiles ?? [];
+  const mediaFiles = agentConfig.mediaFiles ?? [];
+  const outputFiles = agentConfig.outputFiles ?? [];
+  const hasInputFiles = inputFiles.length > 0;
+  const hasReferenceFiles = referenceFiles.length > 0;
+  const hasAuxiliaryFiles = auxiliaryFiles.length > 0;
+  const hasMediaFiles = mediaFiles.length > 0;
+  const hasOutputFiles = outputFiles.length > 0;
+
+  return {
+    ...DEFAULT_MAIN_VIEW_STATE,
+    sessionType: isToolUse ? 'toolUse' : 'workflow',
+    workflowAgent: isToolUse ? '' : (agentConfig.agent ?? ''),
+    toolUseAgent: isToolUse ? (agentConfig.agent ?? '') : '',
+    model: agentConfig.model ?? '',
+    instruction: agentConfig.instruction ?? '',
+    inputFile: agentConfig.inputFile ?? '',
+    referenceFile: agentConfig.referenceFile ?? '',
+    auxiliaryFile: agentConfig.auxiliaryFile ?? '',
+    mediaFile: agentConfig.mediaFile ?? '',
+    editedFile: agentConfig.editedFile ?? '',
+    inputFiles,
+    referenceFiles,
+    auxiliaryFiles,
+    mediaFiles,
+    outputFiles,
+    inputFilesVisible: Boolean(activeFiles.input) || hasInputFiles,
+    referenceFilesVisible: Boolean(activeFiles.reference) || hasReferenceFiles,
+    auxiliaryFilesVisible: Boolean(activeFiles.auxiliary) || hasAuxiliaryFiles,
+    mediaFilesVisible: Boolean(activeFiles.media) || hasMediaFiles,
+    outputFilesVisible: Boolean(activeFiles.output) || hasOutputFiles,
+    outputFilesActive:
+      Boolean(activeFiles.output) ||
+      Boolean(
+        (agentConfig as { useMultipleOutputs?: boolean }).useMultipleOutputs,
+      ) ||
+      hasOutputFiles,
+    autoExtractFigure: Boolean(toolConfig.autoExtractFigure),
+    autoExtractTikzFigure: Boolean(toolConfig.autoExtractTikzFigure),
+    autoCompileInputPdf: Boolean(toolConfig.autoCompileInputPdf),
+    attachTeXCount: Boolean(toolConfig.attachTeXCount),
+    attachDiagnostics: Boolean(toolConfig.attachDiagnostics),
+    agent: agentConfig.agent ?? '',
+    isToolUseAgent: isToolUse,
+  };
+}

--- a/src/common/state/pendingStateManager.ts
+++ b/src/common/state/pendingStateManager.ts
@@ -4,25 +4,26 @@
  * when the webview is not yet available.
  */
 
-import type { TaskState } from '@logger/TaskState';
+// Local imports - shared schemas
+import type { MainViewPersistedState } from '@shared/schemas/mainViewState';
 
 interface PendingStateData {
-  state: TaskState;
+  state: MainViewPersistedState;
   executeImmediately?: boolean;
 }
 
-let pendingStateData: PendingStateData | undefined = undefined;
+const pendingStateQueue: PendingStateData[] = [];
 
 /**
  * Store state for later restoration.
- * @param state - The TaskState to restore
+ * @param state - The MainView state to restore
  * @param executeImmediately - If true, execute the agent after restoring state (for followup)
  */
 export function setPendingState(
-  state: TaskState,
+  state: MainViewPersistedState,
   executeImmediately?: boolean,
 ): void {
-  pendingStateData = { state, executeImmediately };
+  pendingStateQueue.push({ state, executeImmediately });
 }
 
 /**
@@ -30,7 +31,5 @@ export function setPendingState(
  * @returns The pending state data if any, undefined otherwise
  */
 export function consumePendingState(): PendingStateData | undefined {
-  const result = pendingStateData;
-  pendingStateData = undefined;
-  return result;
+  return pendingStateQueue.shift();
 }

--- a/src/historyView/HistoryViewMessageHandler.ts
+++ b/src/historyView/HistoryViewMessageHandler.ts
@@ -41,7 +41,7 @@ export class HistoryViewMessageHandler extends BaseViewMessageHandler<
   }
 
   private async handleGetHistoryData(
-    _message: any,
+    _message: unknown,
     view: vscode.WebviewView | vscode.WebviewPanel,
   ): Promise<void> {
     await this.sendHistoryData(view.webview);

--- a/src/memoryView/MemoryViewMessageHandler.ts
+++ b/src/memoryView/MemoryViewMessageHandler.ts
@@ -40,14 +40,8 @@ import {
   MemoryEnabledMessageSchema,
 } from '@webview/types/messages';
 
-interface MemoryViewItem {
-  displayPath: string;
-  storagePath: string;
-  size: number;
-  mtime: string;
-  lineCount: number;
-  preview: string;
-}
+// Local imports - shared schemas
+import type { MemoryViewItem } from '@shared/schemas';
 
 export class MemoryViewMessageHandler extends BaseViewMessageHandler<
   vscode.WebviewView | vscode.WebviewPanel

--- a/src/shared/schemas/commonViewMessages.ts
+++ b/src/shared/schemas/commonViewMessages.ts
@@ -4,6 +4,9 @@ import { z } from 'zod';
 // Local imports - shared commands
 import { COMMON_COMMANDS } from '@common/webview/commands';
 
+// Local imports - shared schemas
+import { MainViewPersistedStateSchema } from './mainViewState';
+
 export const SetThemeMessageSchema = z.object({
   command: z.literal(COMMON_COMMANDS.THEME_SET),
   theme: z.enum(['dark', 'light', 'high-contrast']),
@@ -16,7 +19,7 @@ export const SetDebugModeMessageSchema = z.object({
 
 export const StateRestoreMessageSchema = z.object({
   command: z.literal(COMMON_COMMANDS.STATE_RESTORE),
-  state: z.record(z.string(), z.unknown()).nullish(),
+  state: MainViewPersistedStateSchema.partial().nullish(),
   executeImmediately: z.boolean().nullish(),
   isResetOperation: z.boolean().nullish(),
 });

--- a/src/shared/schemas/index.ts
+++ b/src/shared/schemas/index.ts
@@ -14,6 +14,8 @@ export * from './proposalFields';
 export * from './stream';
 export * from './contextManagement';
 export * from './diffResult';
+export * from './mainViewState';
+export * from './mainViewEvents';
 
 // Message schemas (depend on data schemas) - must come before streamState
 export * from './progressViewMessages';

--- a/src/shared/schemas/mainViewEvents.ts
+++ b/src/shared/schemas/mainViewEvents.ts
@@ -1,0 +1,138 @@
+// Third-party imports
+import { z } from 'zod';
+
+// Local imports - shared schemas
+import {
+  CheckboxIdSchema,
+  FileTypeSchema,
+  MultipleFileTypeSchema,
+  SessionTypeSchema,
+} from './mainViewState';
+
+export const FileSelectChangeDetailSchema = z.object({
+  type: FileTypeSchema,
+  value: z.string(),
+});
+export type FileSelectChangeDetail = z.infer<
+  typeof FileSelectChangeDetailSchema
+>;
+
+export const BaseFileChangeDetailSchema = z.object({
+  value: z.string(),
+});
+export type BaseFileChangeDetail = z.infer<typeof BaseFileChangeDetailSchema>;
+
+export const EditedFileChangeDetailSchema = z.object({
+  value: z.string(),
+});
+export type EditedFileChangeDetail = z.infer<
+  typeof EditedFileChangeDetailSchema
+>;
+
+export const FileActionDetailSchema = z.object({
+  type: z.enum([...FileTypeSchema.options, 'base', 'edited']),
+});
+export type FileActionDetail = z.infer<typeof FileActionDetailSchema>;
+
+export const MultipleFilesActionDetailSchema = z.object({
+  listId: z.string(),
+});
+export type MultipleFilesActionDetail = z.infer<
+  typeof MultipleFilesActionDetailSchema
+>;
+
+export const MultipleFilesTypeActionDetailSchema = z.object({
+  type: MultipleFileTypeSchema,
+});
+export type MultipleFilesTypeActionDetail = z.infer<
+  typeof MultipleFilesTypeActionDetailSchema
+>;
+
+export const RemoveFileDetailSchema = z.object({
+  listId: z.string(),
+  file: z.string(),
+});
+export type RemoveFileDetail = z.infer<typeof RemoveFileDetailSchema>;
+
+export const CheckboxChangeDetailSchema = z.object({
+  id: CheckboxIdSchema,
+  checked: z.boolean(),
+});
+export type CheckboxChangeDetail = z.infer<typeof CheckboxChangeDetailSchema>;
+
+export const BannerActionDetailSchema = z.object({
+  action: z.enum(['set', 'guide', 'edit', 'dir', 'docs']),
+  provider: z.string().nullish(),
+  customDirSet: z.boolean().nullish(),
+});
+export type BannerActionDetail = z.infer<typeof BannerActionDetailSchema>;
+
+export const InstallGuideDetailSchema = z.object({
+  tool: z.string(),
+});
+export type InstallGuideDetail = z.infer<typeof InstallGuideDetailSchema>;
+
+export const LatexDiffsToggleDetailSchema = z.object({
+  visible: z.boolean(),
+});
+export type LatexDiffsToggleDetail = z.infer<
+  typeof LatexDiffsToggleDetailSchema
+>;
+
+export const LatexDiffsActionDetailSchema = z.object({
+  action: z.enum([
+    'latexdiff',
+    'latexdiffvc',
+    'packLatexdiffvc',
+    'cleanLatexdiffvc',
+    'merge',
+    'compare',
+    'accept',
+  ]),
+});
+export type LatexDiffsActionDetail = z.infer<
+  typeof LatexDiffsActionDetailSchema
+>;
+
+export const CommitChangeDetailSchema = z.object({
+  value: z.string(),
+});
+export type CommitChangeDetail = z.infer<typeof CommitChangeDetailSchema>;
+
+export const FocusInstructionDetailSchema = z.object({
+  key: z.string(),
+  text: z.string(),
+});
+export type FocusInstructionDetail = z.infer<
+  typeof FocusInstructionDetailSchema
+>;
+
+export const SessionTypeChangeDetailSchema = z.object({
+  value: SessionTypeSchema,
+});
+export type SessionTypeChangeDetail = z.infer<
+  typeof SessionTypeChangeDetailSchema
+>;
+
+export const AgentChangeDetailSchema = z.object({
+  sessionType: SessionTypeSchema,
+  value: z.string(),
+});
+export type AgentChangeDetail = z.infer<typeof AgentChangeDetailSchema>;
+
+export const ModelChangeDetailSchema = z.object({
+  value: z.string(),
+});
+export type ModelChangeDetail = z.infer<typeof ModelChangeDetailSchema>;
+
+export const InstructionChangeDetailSchema = z.object({
+  value: z.string(),
+});
+export type InstructionChangeDetail = z.infer<
+  typeof InstructionChangeDetailSchema
+>;
+
+export const ActionDetailSchema = z.object({
+  action: z.enum(['pack', 'clean', 'polish', 'record', 'erase']),
+});
+export type ActionDetail = z.infer<typeof ActionDetailSchema>;

--- a/src/shared/schemas/mainViewMessages.ts
+++ b/src/shared/schemas/mainViewMessages.ts
@@ -4,6 +4,9 @@ import { z } from 'zod';
 // Local imports - shared commands
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands';
 
+// Local imports - shared schemas
+import { FileTypeSchema, SessionTypeSchema } from './mainViewState';
+
 const FileListSchema = z.array(z.string());
 
 const FilesPayloadSchema = z.object({
@@ -118,7 +121,7 @@ export const SetRecentCommitsMessageSchema = z.object({
 export const SetCurrentFileMessageSchema = z.object({
   command: z.literal(MAIN_VIEW_COMMANDS.SET_CURRENT_FILE),
   filePath: z.string(),
-  fileType: z.string(),
+  fileType: z.enum([...FileTypeSchema.options, 'base', 'edited']),
 });
 
 export const SetSelectedCommitMessageSchema = z.object({
@@ -130,7 +133,7 @@ export const SetSelectedCommitMessageSchema = z.object({
 export const SetOpenedFilesMessageSchema = z.object({
   command: z.literal(MAIN_VIEW_COMMANDS.SET_OPENED_FILES),
   files: FileListSchema,
-  fileType: z.string(),
+  fileType: FileTypeSchema,
   shouldFilter: z.boolean().nullish(),
 });
 
@@ -217,7 +220,7 @@ export const HideLoginBannerMessageSchema = z.object({
 export const SetSelectedAgentMessageSchema = z.object({
   command: z.literal(MAIN_VIEW_COMMANDS.SET_SELECTED_AGENT),
   agentId: z.string().nullish(),
-  sessionType: z.string().nullish(),
+  sessionType: SessionTypeSchema.nullish(),
 });
 
 export const MainViewMessageSchema = z.discriminatedUnion('command', [

--- a/src/shared/schemas/mainViewState.ts
+++ b/src/shared/schemas/mainViewState.ts
@@ -1,0 +1,126 @@
+// Third-party imports
+import { z } from 'zod';
+
+export const SessionTypeSchema = z.enum(['toolUse', 'workflow']);
+export type SessionType = z.infer<typeof SessionTypeSchema>;
+
+export const FileTypeSchema = z.enum([
+  'input',
+  'reference',
+  'auxiliary',
+  'media',
+]);
+export type FileType = z.infer<typeof FileTypeSchema>;
+
+export const MultipleFileTypeSchema = z.enum([
+  'input',
+  'reference',
+  'auxiliary',
+  'media',
+  'output',
+]);
+export type MultipleFileType = z.infer<typeof MultipleFileTypeSchema>;
+
+export const CheckboxIdSchema = z.enum([
+  'autoExtractFigure',
+  'autoExtractTikzFigure',
+  'autoCompileInputPdf',
+  'attachTeXCount',
+  'attachDiagnostics',
+]);
+export type CheckboxId = z.infer<typeof CheckboxIdSchema>;
+
+export const CheckboxValuesSchema = z.object({
+  autoExtractFigure: z.boolean(),
+  autoExtractTikzFigure: z.boolean(),
+  autoCompileInputPdf: z.boolean(),
+  attachTeXCount: z.boolean(),
+  attachDiagnostics: z.boolean(),
+});
+export type CheckboxValues = z.infer<typeof CheckboxValuesSchema>;
+
+export const ApiKeyBannerStateSchema = z.object({
+  visible: z.boolean(),
+  provider: z.string().nullish(),
+  requiresKey: z.boolean().nullish(),
+});
+export type ApiKeyBannerState = z.infer<typeof ApiKeyBannerStateSchema>;
+
+export const AgentConfigBannerStateSchema = z.object({
+  visible: z.boolean(),
+  agentName: z.string().nullish(),
+  customDirSet: z.boolean().nullish(),
+});
+export type AgentConfigBannerState = z.infer<
+  typeof AgentConfigBannerStateSchema
+>;
+
+export const DependencyBannerStateSchema = z.object({
+  visible: z.boolean(),
+  missingTools: z.array(z.string()).nullish(),
+});
+export type DependencyBannerState = z.infer<typeof DependencyBannerStateSchema>;
+
+export const FocusInstructionSchema = z.object({
+  key: z.string(),
+  text: z.string(),
+});
+export type FocusInstruction = z.infer<typeof FocusInstructionSchema>;
+
+export const FileSelectConfigSchema = z.object({
+  type: FileTypeSchema,
+  label: z.string(),
+  icon: z.string(),
+  refreshTitle: z.string(),
+  currentTitle: z.string(),
+  emptyTitle: z.string(),
+  toggleTitle: z.string(),
+  addOpenedLabel: z.string(),
+  emptyListLabel: z.string(),
+  selectListLabel: z.string(),
+  tooltip: z.string(),
+  toolConfig: z.enum(['tool', 'autoExtract']).nullish(),
+  focusInstruction: FocusInstructionSchema.nullish(),
+});
+export type FileSelectConfig = z.infer<typeof FileSelectConfigSchema>;
+
+const stringArrayField = () => z.array(z.string()).prefault([]);
+
+export const MainViewPersistedStateSchema = z.object({
+  sessionType: SessionTypeSchema.prefault('toolUse'),
+  workflowAgent: z.string().prefault('correct'),
+  toolUseAgent: z.string().prefault('chat'),
+  model: z.string().prefault('gemini3p'),
+  commit: z.string().prefault('HEAD'),
+  instruction: z.string().prefault(''),
+  inputFile: z.string().prefault(''),
+  referenceFile: z.string().prefault(''),
+  auxiliaryFile: z.string().prefault(''),
+  mediaFile: z.string().prefault(''),
+  editedFile: z.string().prefault(''),
+  baseFile: z.string().prefault(''),
+  inputFiles: stringArrayField(),
+  referenceFiles: stringArrayField(),
+  auxiliaryFiles: stringArrayField(),
+  mediaFiles: stringArrayField(),
+  outputFiles: stringArrayField(),
+  inputFilesVisible: z.boolean().prefault(false),
+  referenceFilesVisible: z.boolean().prefault(false),
+  auxiliaryFilesVisible: z.boolean().prefault(false),
+  mediaFilesVisible: z.boolean().prefault(false),
+  outputFilesVisible: z.boolean().prefault(false),
+  outputFilesActive: z.boolean().prefault(false),
+  latexdiffsVisible: z.boolean().prefault(false),
+  autoExtractFigure: z.boolean().prefault(false),
+  autoExtractTikzFigure: z.boolean().prefault(false),
+  autoCompileInputPdf: z.boolean().prefault(false),
+  attachTeXCount: z.boolean().prefault(false),
+  attachDiagnostics: z.boolean().prefault(false),
+  agent: z.string().prefault(''),
+  isToolUseAgent: z.boolean().prefault(true),
+  openedFiles: stringArrayField(),
+});
+
+export type MainViewPersistedState = z.infer<
+  typeof MainViewPersistedStateSchema
+>;

--- a/src/shared/state/WebviewStateManager.ts
+++ b/src/shared/state/WebviewStateManager.ts
@@ -1,6 +1,9 @@
 // Local imports
 import { vscode } from '../vscode';
 
+// Third-party imports
+import type { z } from 'zod';
+
 /**
  * Manages persistence of state for a single webview.
  * Wraps the VS Code `getState` and `setState` APIs.
@@ -8,11 +11,23 @@ import { vscode } from '../vscode';
 export class WebviewStateManager<T extends Record<string, unknown>> {
   private defaultState: T;
   private state: T;
+  private schema: z.ZodType<T> | undefined;
 
-  constructor(defaultState: Partial<T> = {} as Partial<T>) {
+  constructor(
+    defaultState: Partial<T> = {} as Partial<T>,
+    schema?: z.ZodType<T>,
+  ) {
     this.defaultState = { ...defaultState } as T;
-    const saved = (vscode.getState() as T | undefined) ?? ({} as T);
-    this.state = { ...this.defaultState, ...saved };
+    this.schema = schema;
+    const saved = vscode.getState();
+    if (this.schema) {
+      const parsed = this.schema.safeParse(saved);
+      this.state = parsed.success
+        ? { ...this.defaultState, ...parsed.data }
+        : { ...this.defaultState };
+      return;
+    }
+    this.state = { ...this.defaultState, ...(saved as T | undefined) };
   }
 
   /**

--- a/src/shared/utils/path.ts
+++ b/src/shared/utils/path.ts
@@ -24,3 +24,13 @@ export function getBasename(filePath: string | undefined | null): string {
   const parts = cleaned.split('/');
   return parts.at(-1) ?? '';
 }
+
+/**
+ * Normalize a file path to use forward slashes and trim extra separators.
+ *
+ * @example
+ * normalizeFilePath('C:\\Users\\file.txt') // returns 'C:/Users/file.txt'
+ */
+export function normalizeFilePath(filePath: string): string {
+  return filePath.replaceAll('\\', '/').replace(/\/+$/, '');
+}

--- a/src/test/webview/stateMigration.test.ts
+++ b/src/test/webview/stateMigration.test.ts
@@ -1,0 +1,104 @@
+// Standard library imports
+import { strict as assert } from 'assert';
+
+// Local imports - agent
+import { AgentConfigSchema } from '@agent/core/AgentConfig';
+import { AgentCategory } from '@agent/core/AgentDataclass';
+
+// Local imports - common state
+import { buildMainViewStateFromTaskState } from '@common/state';
+import type { ToolUseTaskState, WorkflowTaskState } from '@logger/TaskState';
+
+describe('buildMainViewStateFromTaskState', () => {
+  it('maps workflow task state into persisted MainView state', () => {
+    const agentConfig = AgentConfigSchema.parse({
+      agentCategory: AgentCategory.Workflow,
+      agent: 'correct',
+      model: 'gemini3p',
+      instruction: 'Fix the intro section.',
+      inputFile: 'main.tex',
+      inputFiles: ['appendix.tex'],
+      referenceFiles: ['refs.bib'],
+      outputFiles: ['main.out.tex'],
+      useMultipleOutputs: true,
+      toolConfig: {
+        autoExtractFigure: true,
+        autoExtractTikzFigure: false,
+        autoCompileInputPdf: true,
+        attachTeXCount: true,
+        attachDiagnostics: false,
+      },
+    });
+
+    const taskState: WorkflowTaskState = {
+      agentConfig: agentConfig as WorkflowTaskState['agentConfig'],
+      activeFiles: {
+        input: true,
+        reference: true,
+        auxiliary: false,
+        media: false,
+        output: true,
+      },
+    };
+
+    const state = buildMainViewStateFromTaskState(taskState);
+    assert.equal(state.sessionType, 'workflow');
+    assert.equal(state.workflowAgent, 'correct');
+    assert.equal(state.toolUseAgent, '');
+    assert.equal(state.inputFile, 'main.tex');
+    assert.deepEqual(state.inputFiles, ['appendix.tex']);
+    assert.equal(state.inputFilesVisible, true);
+    assert.equal(state.referenceFilesVisible, true);
+    assert.equal(state.outputFilesVisible, true);
+    assert.equal(state.outputFilesActive, true);
+    assert.equal(state.autoExtractFigure, true);
+    assert.equal(state.autoCompileInputPdf, true);
+    assert.equal(state.attachTeXCount, true);
+  });
+
+  it('maps tool-use task state to tool-use session defaults', () => {
+    const agentConfig = AgentConfigSchema.parse({
+      agentCategory: AgentCategory.ToolUse,
+      agent: 'chat',
+      model: 'gemini3p',
+      instruction: 'Summarize the draft.',
+    });
+
+    const taskState: ToolUseTaskState = {
+      agentConfig: agentConfig as ToolUseTaskState['agentConfig'],
+      toolSessionState: {},
+    };
+    const state = buildMainViewStateFromTaskState(taskState);
+
+    assert.equal(state.sessionType, 'toolUse');
+    assert.equal(state.toolUseAgent, 'chat');
+    assert.equal(state.workflowAgent, '');
+    assert.equal(state.outputFilesActive, false);
+  });
+
+  it('shows output files when restored task state includes them', () => {
+    const agentConfig = AgentConfigSchema.parse({
+      agentCategory: AgentCategory.Workflow,
+      agent: 'correct',
+      model: 'gemini3p',
+      instruction: 'Review the conclusion.',
+      inputFile: 'main.tex',
+      outputFiles: ['main.out.tex'],
+    });
+
+    const taskState: WorkflowTaskState = {
+      agentConfig: agentConfig as WorkflowTaskState['agentConfig'],
+      activeFiles: {
+        input: true,
+        reference: false,
+        auxiliary: false,
+        media: false,
+        output: false,
+      },
+    };
+
+    const state = buildMainViewStateFromTaskState(taskState);
+    assert.equal(state.outputFilesVisible, true);
+    assert.equal(state.outputFilesActive, true);
+  });
+});

--- a/src/webview/frontend/MainApp.ts
+++ b/src/webview/frontend/MainApp.ts
@@ -30,6 +30,32 @@ import {
   MainViewMessageSchema,
   type MainViewMessage,
 } from '@shared/schemas/mainViewMessages';
+import {
+  MainViewPersistedStateSchema,
+  type ActionDetail,
+  type AgentChangeDetail,
+  type AgentConfigBannerState,
+  type ApiKeyBannerState,
+  type BannerActionDetail,
+  type BaseFileChangeDetail,
+  type CheckboxChangeDetail,
+  type CommitChangeDetail,
+  type DependencyBannerState,
+  type EditedFileChangeDetail,
+  type FileActionDetail,
+  type FileSelectChangeDetail,
+  type FocusInstructionDetail,
+  type InstallGuideDetail,
+  type InstructionChangeDetail,
+  type LatexDiffsActionDetail,
+  type LatexDiffsToggleDetail,
+  type MainViewPersistedState,
+  type ModelChangeDetail,
+  type MultipleFilesActionDetail,
+  type MultipleFilesTypeActionDetail,
+  type RemoveFileDetail,
+  type SessionTypeChangeDetail,
+} from '@shared/schemas';
 
 // Local imports - webview commands
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands';
@@ -65,38 +91,7 @@ import {
   PLACEHOLDER_ROTATION_MS,
   ONBOARDING_PLACEHOLDERS,
   FILE_SELECT_CONFIGS,
-  type MainViewPersistedState,
-  type BannerState,
 } from './store';
-
-// Local imports - main view component types
-import type {
-  FileSelectConfig,
-  ApiKeyBannerState,
-  AgentConfigBannerState,
-  DependencyBannerState,
-  SessionTypeChangeDetail,
-  AgentChangeDetail,
-  ModelChangeDetail,
-  InstructionChangeDetail,
-  ActionDetail,
-} from './components';
-import type {
-  FileSelectChangeDetail,
-  FileActionDetail,
-  MultipleFilesActionDetail,
-  MultipleFilesTypeActionDetail,
-  RemoveFileDetail,
-  CheckboxChangeDetail,
-  BannerActionDetail,
-  InstallGuideDetail,
-  LatexDiffsToggleDetail,
-  LatexDiffsActionDetail,
-  BaseFileChangeDetail,
-  EditedFileChangeDetail,
-  CommitChangeDetail,
-  FocusInstructionDetail,
-} from './events';
 
 // Type imports
 import type { StateRestoreMessage } from '@shared/schemas/commonViewMessages';
@@ -186,9 +181,13 @@ export class MainApp extends BaseWebviewApp {
   @state() private modelOptionsHtml = '';
   @state() private workflowAgentOptionsHtml = '';
   @state() private toolUseAgentOptionsHtml = '';
-  @state() private apiKeyBanner: BannerState = { visible: false };
-  @state() private agentConfigBanner: BannerState = { visible: false };
-  @state() private dependencyBanner: BannerState = { visible: false };
+  @state() private apiKeyBanner: ApiKeyBannerState = { visible: false };
+  @state() private agentConfigBanner: AgentConfigBannerState = {
+    visible: false,
+  };
+  @state() private dependencyBanner: DependencyBannerState = {
+    visible: false,
+  };
   @state() private gettingStartedVisible = false;
   @state() private loginBannerVisible = false;
   @state() private instructionPlaceholder =
@@ -212,7 +211,10 @@ export class MainApp extends BaseWebviewApp {
   declare private toolUseAgentElement: HTMLElement | null;
 
   private readonly stateManager =
-    new WebviewStateManager<MainViewPersistedState>(DEFAULT_STATE);
+    new WebviewStateManager<MainViewPersistedState>(
+      DEFAULT_STATE,
+      MainViewPersistedStateSchema,
+    );
   private saveBlockCount = 0;
   private placeholderTimer: number | null = null;
   private sortables: Sortable[] = [];
@@ -516,6 +518,7 @@ export class MainApp extends BaseWebviewApp {
           ? this.toolUseAgent
           : this.workflowAgent,
       isToolUseAgent: this.sessionType === SESSION_TYPES.TOOL_USE,
+      openedFiles: [],
     };
 
     this.stateManager.setState(persisted);
@@ -525,45 +528,42 @@ export class MainApp extends BaseWebviewApp {
     const saved = this.stateManager.getState();
     const state = { ...DEFAULT_STATE, ...saved };
 
-    const sessionType =
-      parseSessionType(state.sessionType) ?? DEFAULT_STATE.sessionType;
-
-    this.sessionType = sessionType;
-    this.workflowAgent = state.workflowAgent || this.workflowAgent;
-    this.toolUseAgent = state.toolUseAgent || this.toolUseAgent;
-    this.model = state.model || this.model;
-    this.commit = state.commit || this.commit;
-    this.instruction = state.instruction || '';
+    this.sessionType = state.sessionType;
+    this.workflowAgent = state.workflowAgent;
+    this.toolUseAgent = state.toolUseAgent;
+    this.model = state.model;
+    this.commit = state.commit;
+    this.instruction = state.instruction;
     this.singleFiles = {
-      inputFile: state.inputFile || '',
-      referenceFile: state.referenceFile || '',
-      auxiliaryFile: state.auxiliaryFile || '',
-      mediaFile: state.mediaFile || '',
-      editedFile: state.editedFile || '',
-      baseFile: state.baseFile || '',
+      inputFile: state.inputFile,
+      referenceFile: state.referenceFile,
+      auxiliaryFile: state.auxiliaryFile,
+      mediaFile: state.mediaFile,
+      editedFile: state.editedFile,
+      baseFile: state.baseFile,
     };
     this.multiFiles = {
-      inputFiles: state.inputFiles ?? [],
-      referenceFiles: state.referenceFiles ?? [],
-      auxiliaryFiles: state.auxiliaryFiles ?? [],
-      mediaFiles: state.mediaFiles ?? [],
-      outputFiles: state.outputFiles ?? [],
+      inputFiles: state.inputFiles,
+      referenceFiles: state.referenceFiles,
+      auxiliaryFiles: state.auxiliaryFiles,
+      mediaFiles: state.mediaFiles,
+      outputFiles: state.outputFiles,
     };
     this.multiFilesVisible = {
-      inputFiles: state.inputFilesVisible ?? false,
-      referenceFiles: state.referenceFilesVisible ?? false,
-      auxiliaryFiles: state.auxiliaryFilesVisible ?? false,
-      mediaFiles: state.mediaFilesVisible ?? false,
-      outputFiles: state.outputFilesVisible ?? false,
+      inputFiles: state.inputFilesVisible,
+      referenceFiles: state.referenceFilesVisible,
+      auxiliaryFiles: state.auxiliaryFilesVisible,
+      mediaFiles: state.mediaFilesVisible,
+      outputFiles: state.outputFilesVisible,
     };
-    this.outputFilesActive = state.outputFilesActive ?? false;
-    this.latexdiffsVisible = state.latexdiffsVisible ?? false;
+    this.outputFilesActive = state.outputFilesActive;
+    this.latexdiffsVisible = state.latexdiffsVisible;
     this.checkboxValues = {
-      autoExtractFigure: state.autoExtractFigure ?? false,
-      autoExtractTikzFigure: state.autoExtractTikzFigure ?? false,
-      autoCompileInputPdf: state.autoCompileInputPdf ?? false,
-      attachTeXCount: state.attachTeXCount ?? false,
-      attachDiagnostics: state.attachDiagnostics ?? false,
+      autoExtractFigure: state.autoExtractFigure,
+      autoExtractTikzFigure: state.autoExtractTikzFigure,
+      autoCompileInputPdf: state.autoCompileInputPdf,
+      attachTeXCount: state.attachTeXCount,
+      attachDiagnostics: state.attachDiagnostics,
     };
   }
 
@@ -850,10 +850,6 @@ export class MainApp extends BaseWebviewApp {
   ): void {
     this.blockSave();
     try {
-      const messageValues = message as unknown as Record<
-        string,
-        string[] | null | undefined
-      >;
       const updates: Record<string, string[]> = {};
       (
         [
@@ -863,18 +859,16 @@ export class MainApp extends BaseWebviewApp {
           'mediaFiles',
         ] as const
       ).forEach((key) => {
-        const files = messageValues[key] ?? [];
-        if (Array.isArray(files)) {
-          const target = key.replace('Files', 'File');
-          updates[target] = files;
-          const currentValue =
-            this.singleFiles[target as keyof typeof this.singleFiles];
-          if (currentValue && !files.includes(currentValue)) {
-            this.singleFiles = {
-              ...this.singleFiles,
-              [target]: '',
-            };
-          }
+        const files = message[key] ?? [];
+        const target = key.replace('Files', 'File');
+        updates[target] = files;
+        const currentValue =
+          this.singleFiles[target as keyof typeof this.singleFiles];
+        if (currentValue && !files.includes(currentValue)) {
+          this.singleFiles = {
+            ...this.singleFiles,
+            [target]: '',
+          };
         }
       });
       this.fileOptions = { ...this.fileOptions, ...updates };
@@ -959,54 +953,100 @@ export class MainApp extends BaseWebviewApp {
       this.clearForNewSession();
       return;
     }
-    if (!message.state || typeof message.state !== 'object') {
+    if (message.state === null || message.state === undefined) {
       return;
     }
-    const state = message.state as Record<string, unknown>;
+    const parseResult = MainViewPersistedStateSchema.partial().safeParse(
+      message.state,
+    );
+    if (!parseResult.success) {
+      this.logSchemaError(
+        '[MainApp] Invalid restore state payload.',
+        parseResult.error,
+      );
+      return;
+    }
+    const state = parseResult.data;
     this.blockSave();
     try {
-      const sessionType = this.determineSessionType(state);
-      this.sessionType = sessionType;
-      this.workflowAgent = this.extractAgentValue(state, false, sessionType);
-      this.toolUseAgent = this.extractAgentValue(state, true, sessionType);
-      if (typeof state.model === 'string') {
+      if (state.sessionType !== undefined) {
+        this.sessionType = state.sessionType;
+      }
+      if (state.workflowAgent !== undefined) {
+        this.workflowAgent = state.workflowAgent;
+      }
+      if (state.toolUseAgent !== undefined) {
+        this.toolUseAgent = state.toolUseAgent;
+      }
+      if (state.model !== undefined) {
         this.model = state.model;
       }
-      this.instruction =
-        typeof state.instruction === 'string' ? state.instruction : '';
-      this.singleFiles = {
-        inputFile: typeof state.inputFile === 'string' ? state.inputFile : '',
-        referenceFile:
-          typeof state.referenceFile === 'string' ? state.referenceFile : '',
-        auxiliaryFile:
-          typeof state.auxiliaryFile === 'string' ? state.auxiliaryFile : '',
-        mediaFile: typeof state.mediaFile === 'string' ? state.mediaFile : '',
-        editedFile:
-          typeof state.editedFile === 'string' ? state.editedFile : '',
-        baseFile: typeof state.baseFile === 'string' ? state.baseFile : '',
-      };
+      if (state.commit !== undefined) {
+        this.commit = state.commit;
+      }
+      if (state.instruction !== undefined) {
+        this.instruction = state.instruction;
+      }
 
-      const toolConfig = (state.toolConfig as Record<string, unknown>) ?? {};
-      this.checkboxValues = {
-        autoExtractFigure: Boolean(
-          state.autoExtractFigure ?? toolConfig.autoExtractFigure,
-        ),
-        autoExtractTikzFigure: Boolean(
-          state.autoExtractTikzFigure ?? toolConfig.autoExtractTikzFigure,
-        ),
-        autoCompileInputPdf: Boolean(
-          state.autoCompileInputPdf ?? toolConfig.autoCompileInputPdf,
-        ),
-        attachTeXCount: Boolean(
-          state.attachTeXCount ?? toolConfig.attachTeXCount,
-        ),
-        attachDiagnostics: Boolean(
-          state.attachDiagnostics ?? toolConfig.attachDiagnostics,
-        ),
-      };
+      const singleFiles = { ...this.singleFiles };
+      (
+        [
+          'inputFile',
+          'referenceFile',
+          'auxiliaryFile',
+          'mediaFile',
+          'editedFile',
+          'baseFile',
+        ] as const
+      ).forEach((key) => {
+        if (state[key] !== undefined) {
+          singleFiles[key] = state[key];
+        }
+      });
+      this.singleFiles = singleFiles;
 
-      const activeFiles = (state.activeFiles as Record<string, boolean>) ?? {};
-      this.restoreFileArrays(state, activeFiles);
+      const updatedFiles: Record<string, string[]> = { ...this.multiFiles };
+      const updatedVisibility: Record<string, boolean> = {
+        ...this.multiFilesVisible,
+      };
+      MULTIPLE_FILE_TYPES.forEach((fileType) => {
+        const listKey = `${fileType}Files` as keyof MainViewPersistedState;
+        const visibilityKey =
+          `${fileType}FilesVisible` as keyof MainViewPersistedState;
+        const files = state[listKey] as string[] | undefined;
+        if (files !== undefined) {
+          updatedFiles[listKey as string] = files ?? [];
+        }
+        const visible = state[visibilityKey];
+        if (visible !== undefined) {
+          updatedVisibility[listKey as string] = Boolean(visible);
+        }
+      });
+      this.multiFiles = updatedFiles;
+      this.multiFilesVisible = updatedVisibility;
+
+      if (state.outputFilesActive !== undefined) {
+        this.outputFilesActive = state.outputFilesActive;
+      }
+      if (state.latexdiffsVisible !== undefined) {
+        this.latexdiffsVisible = state.latexdiffsVisible;
+      }
+
+      const checkboxValues = { ...this.checkboxValues };
+      (
+        [
+          'autoExtractFigure',
+          'autoExtractTikzFigure',
+          'autoCompileInputPdf',
+          'attachTeXCount',
+          'attachDiagnostics',
+        ] as const
+      ).forEach((key) => {
+        if (state[key] !== undefined) {
+          checkboxValues[key] = state[key];
+        }
+      });
+      this.checkboxValues = checkboxValues;
     } finally {
       this.unblockSave();
     }
@@ -1015,60 +1055,6 @@ export class MainApp extends BaseWebviewApp {
     if (message.executeImmediately) {
       this.executeAgent();
     }
-  }
-
-  private determineSessionType(state: Record<string, unknown>): SessionType {
-    const candidate = state.agentCategory ?? state.sessionType;
-    const parsed = parseSessionType(
-      typeof candidate === 'string' ? candidate : undefined,
-    );
-    if (parsed) return parsed;
-    if (state.isToolUseAgent) return SESSION_TYPES.TOOL_USE;
-    return SESSION_TYPES.WORKFLOW;
-  }
-
-  private extractAgentValue(
-    state: Record<string, unknown>,
-    forToolUse: boolean,
-    sessionType: SessionType,
-  ): string {
-    const explicit = forToolUse ? state.toolUseAgent : state.workflowAgent;
-    if (typeof explicit === 'string') {
-      return explicit;
-    }
-
-    if (
-      typeof state.agent === 'string' &&
-      forToolUse === (sessionType === SESSION_TYPES.TOOL_USE)
-    ) {
-      return state.agent;
-    }
-
-    return '';
-  }
-
-  private restoreFileArrays(
-    state: Record<string, unknown>,
-    activeFiles: Record<string, boolean>,
-  ): void {
-    const updatedFiles: Record<string, string[]> = { ...this.multiFiles };
-    const updatedVisibility: Record<string, boolean> = {
-      ...this.multiFilesVisible,
-    };
-
-    MULTIPLE_FILE_TYPES.forEach((fileType) => {
-      const key = `${fileType}Files`;
-      const files = (state[key] as string[]) ?? [];
-      const visible =
-        activeFiles[fileType] ??
-        (state[`${key}Active`] as boolean | undefined) ??
-        (state[`${key}Visible`] as boolean | undefined);
-      updatedFiles[key] = Array.isArray(files) ? files : [];
-      updatedVisibility[key] = Boolean(visible);
-    });
-
-    this.multiFiles = updatedFiles;
-    this.multiFilesVisible = updatedVisibility;
   }
 
   private clearForNewSession(): void {
@@ -1246,11 +1232,10 @@ export class MainApp extends BaseWebviewApp {
     postMessage(MAIN_VIEW_COMMANDS.REQUEST_EDITED_FILE, { baseFile: value });
   }
 
-  private handleSessionTypeChange(value: string): void {
-    const parsed = parseSessionType(value) ?? SESSION_TYPES.WORKFLOW;
-    if (parsed === this.sessionType) return;
-    this.sessionType = parsed;
-    if (parsed === SESSION_TYPES.TOOL_USE) {
+  private handleSessionTypeChange(value: SessionType): void {
+    if (value === this.sessionType) return;
+    this.sessionType = value;
+    if (value === SESSION_TYPES.TOOL_USE) {
       this.outputFilesActive = false;
       this.multiFiles = { ...this.multiFiles, outputFiles: [] };
       this.multiFilesVisible = {
@@ -1744,13 +1729,19 @@ export class MainApp extends BaseWebviewApp {
   private handleComponentApiKeyAction = (
     e: CustomEvent<BannerActionDetail>,
   ): void => {
-    this.handleApiKeyBannerAction(e.detail.action as 'set' | 'guide');
+    const { action } = e.detail;
+    if (action === 'set' || action === 'guide') {
+      this.handleApiKeyBannerAction(action);
+    }
   };
 
   private handleComponentAgentConfigAction = (
     e: CustomEvent<BannerActionDetail>,
   ): void => {
-    this.handleAgentConfigAction(e.detail.action as 'edit' | 'dir' | 'docs');
+    const { action } = e.detail;
+    if (action === 'edit' || action === 'dir' || action === 'docs') {
+      this.handleAgentConfigAction(action);
+    }
   };
 
   private handleComponentDependencyDismiss = (): void => {
@@ -1856,7 +1847,11 @@ export class MainApp extends BaseWebviewApp {
     const selectElement = this.renderRoot.querySelector(
       `#${selectId}`,
     ) as HTMLElement | null;
-    this.handleAgentChange(e.detail.sessionType, e.detail.value, selectElement ?? undefined);
+    this.handleAgentChange(
+      e.detail.sessionType,
+      e.detail.value,
+      selectElement ?? undefined,
+    );
   };
 
   private handleComponentModelChange = (
@@ -1994,7 +1989,8 @@ export class MainApp extends BaseWebviewApp {
                   @toggle-list=${this.handleComponentToggleList}
                   @add-opened-files=${this.handleComponentAddOpenedFiles}
                   @empty-files=${this.handleComponentEmptyFiles}
-                  @select-multiple-files=${this.handleComponentSelectMultipleFiles}
+                  @select-multiple-files=${this
+                    .handleComponentSelectMultipleFiles}
                   @remove-file=${this.handleComponentRemoveFile}
                   @checkbox-change=${this.handleComponentCheckboxChange}
                   @focus-instruction=${this.handleComponentFocusInstruction}

--- a/src/webview/frontend/components/BannerGroup.ts
+++ b/src/webview/frontend/components/BannerGroup.ts
@@ -13,26 +13,12 @@ import { when } from 'lit/directives/when.js';
 
 // Local imports - main view
 import { MainViewEvents } from '../events';
-
-/** State for API key banner */
-export interface ApiKeyBannerState {
-  visible: boolean;
-  provider?: string;
-  requiresKey?: boolean;
-}
-
-/** State for agent config banner */
-export interface AgentConfigBannerState {
-  visible: boolean;
-  agentName?: string;
-  customDirSet?: boolean;
-}
-
-/** State for dependency banner */
-export interface DependencyBannerState {
-  visible: boolean;
-  missingTools?: string[];
-}
+// Local imports - shared schemas
+import type {
+  AgentConfigBannerState,
+  ApiKeyBannerState,
+  DependencyBannerState,
+} from '@shared/schemas';
 
 @customElement('banner-group')
 export class BannerGroup extends LitElement {

--- a/src/webview/frontend/components/FileSelectGroup.ts
+++ b/src/webview/frontend/components/FileSelectGroup.ts
@@ -17,33 +17,13 @@ import { markOptionAsSelected, withPlaceholder } from '@shared/utils/dropdown';
 
 // Local imports - main view
 import { MainViewEvents } from '../events';
-import type { FileType } from '../constants';
 
-/** Configuration for a file select group */
-export interface FileSelectConfig {
-  type: FileType;
-  label: string;
-  icon: string;
-  refreshTitle: string;
-  currentTitle: string;
-  emptyTitle: string;
-  toggleTitle: string;
-  addOpenedLabel: string;
-  emptyListLabel: string;
-  selectListLabel: string;
-  tooltip: string;
-  toolConfig?: 'tool' | 'autoExtract';
-  focusInstruction?: { key: string; text: string };
-}
-
-/** Checkbox values for auto-extract and tool config */
-export interface CheckboxValues {
-  autoExtractFigure: boolean;
-  autoExtractTikzFigure: boolean;
-  autoCompileInputPdf: boolean;
-  attachTeXCount: boolean;
-  attachDiagnostics: boolean;
-}
+// Local imports - shared schemas
+import type {
+  CheckboxId,
+  CheckboxValues,
+  FileSelectConfig,
+} from '@shared/schemas';
 
 @customElement('file-select-group')
 export class FileSelectGroup extends LitElement {
@@ -255,9 +235,8 @@ export class FileSelectGroup extends LitElement {
   @state() private toolConfigMenuOpen = false;
 
   /** Document click handler bound to this instance */
-  private readonly boundDocumentClickHandler = this.handleDocumentClick.bind(
-    this,
-  );
+  private readonly boundDocumentClickHandler =
+    this.handleDocumentClick.bind(this);
 
   override connectedCallback(): void {
     super.connectedCallback();
@@ -355,7 +334,7 @@ export class FileSelectGroup extends LitElement {
     );
   }
 
-  private handleCheckboxChange(id: string, checked: boolean): void {
+  private handleCheckboxChange(id: CheckboxId, checked: boolean): void {
     this.dispatchEvent(MainViewEvents.checkboxChange({ id, checked }));
   }
 
@@ -543,7 +522,9 @@ export class FileSelectGroup extends LitElement {
         <div class="file-select-header">
           <div class="file-select-label-group">
             <vscode-toolbar-button
-              id="refresh${config.type[0].toUpperCase()}${config.type.slice(1)}FileButton"
+              id="refresh${config.type[0].toUpperCase()}${config.type.slice(
+                1,
+              )}FileButton"
               icon=${config.icon}
               label=${config.refreshTitle}
               title=${config.refreshTitle}
@@ -552,25 +533,27 @@ export class FileSelectGroup extends LitElement {
             <label for=${this.selectId} title=${config.tooltip}
               >${config.label}</label
             >
-            ${when(
-              config.toolConfig === 'tool',
-              () => this.renderToolConfigMenu(),
+            ${when(config.toolConfig === 'tool', () =>
+              this.renderToolConfigMenu(),
             )}
-            ${when(
-              config.toolConfig === 'autoExtract',
-              () => this.renderAutoExtractMenu(),
+            ${when(config.toolConfig === 'autoExtract', () =>
+              this.renderAutoExtractMenu(),
             )}
           </div>
           <vscode-toolbar-container class="file-select-actions">
             <vscode-toolbar-button
-              id="current${config.type[0].toUpperCase()}${config.type.slice(1)}FileButton"
+              id="current${config.type[0].toUpperCase()}${config.type.slice(
+                1,
+              )}FileButton"
               icon="file-code"
               label=${config.currentTitle}
               title=${config.currentTitle}
               @click=${this.handleGetCurrentFile}
             ></vscode-toolbar-button>
             <vscode-toolbar-button
-              id="empty${config.type[0].toUpperCase()}${config.type.slice(1)}FileButton"
+              id="empty${config.type[0].toUpperCase()}${config.type.slice(
+                1,
+              )}FileButton"
               icon="close"
               label=${config.emptyTitle}
               title=${config.emptyTitle}
@@ -585,7 +568,9 @@ export class FileSelectGroup extends LitElement {
               <i class="codicon ${chevronClass}"></i>
             </span>
             <vscode-toolbar-button
-              id="addOpened${config.type[0].toUpperCase()}${config.type.slice(1)}FilesButton"
+              id="addOpened${config.type[0].toUpperCase()}${config.type.slice(
+                1,
+              )}FilesButton"
               class="file-action-button"
               icon="folder-opened"
               label=${config.addOpenedLabel}
@@ -593,7 +578,9 @@ export class FileSelectGroup extends LitElement {
               @click=${this.handleAddOpenedFiles}
             ></vscode-toolbar-button>
             <vscode-toolbar-button
-              id="empty${config.type[0].toUpperCase()}${config.type.slice(1)}FilesButton"
+              id="empty${config.type[0].toUpperCase()}${config.type.slice(
+                1,
+              )}FilesButton"
               class="file-action-button"
               icon="trash"
               label=${config.emptyListLabel}
@@ -601,7 +588,9 @@ export class FileSelectGroup extends LitElement {
               @click=${this.handleEmptyFiles}
             ></vscode-toolbar-button>
             <vscode-toolbar-button
-              id="select${config.type[0].toUpperCase()}${config.type.slice(1)}FilesButton"
+              id="select${config.type[0].toUpperCase()}${config.type.slice(
+                1,
+              )}FilesButton"
               class="file-action-button"
               icon="add"
               label=${config.selectListLabel}

--- a/src/webview/frontend/components/InstructionPanel.ts
+++ b/src/webview/frontend/components/InstructionPanel.ts
@@ -16,33 +16,20 @@ import { markOptionAsSelected, withPlaceholder } from '@shared/utils/dropdown';
 
 // Local imports - main view
 import { MainViewEvents } from '../events';
-import { SESSION_TYPES, type SessionType } from '../constants';
+import {
+  SESSION_TYPES,
+  parseSessionType,
+  type SessionType,
+} from '../constants';
 
-/** Session type change event detail */
-export interface SessionTypeChangeDetail {
-  value: string;
-}
-
-/** Agent change event detail */
-export interface AgentChangeDetail {
-  sessionType: SessionType;
-  value: string;
-}
-
-/** Model change event detail */
-export interface ModelChangeDetail {
-  value: string;
-}
-
-/** Instruction change event detail */
-export interface InstructionChangeDetail {
-  value: string;
-}
-
-/** Action event detail */
-export interface ActionDetail {
-  action: string;
-}
+// Local imports - shared schemas
+import type {
+  ActionDetail,
+  AgentChangeDetail,
+  InstructionChangeDetail,
+  ModelChangeDetail,
+  SessionTypeChangeDetail,
+} from '@shared/schemas';
 
 @customElement('instruction-panel')
 export class InstructionPanel extends LitElement {
@@ -214,9 +201,13 @@ export class InstructionPanel extends LitElement {
   }
 
   private handleSessionTypeChange(value: string): void {
+    const parsed = parseSessionType(value);
+    if (!parsed) {
+      return;
+    }
     this.dispatchEvent(
       this.createEvent<SessionTypeChangeDetail>('session-type-change', {
-        value,
+        value: parsed,
       }),
     );
   }
@@ -242,12 +233,16 @@ export class InstructionPanel extends LitElement {
     );
   }
 
-  private handleAction(action: string): void {
-    this.dispatchEvent(this.createEvent<ActionDetail>('panel-action', { action }));
+  private handleAction(action: ActionDetail['action']): void {
+    this.dispatchEvent(
+      this.createEvent<ActionDetail>('panel-action', { action }),
+    );
   }
 
   private handleExecute(): void {
-    this.dispatchEvent(new CustomEvent('execute', { bubbles: true, composed: true }));
+    this.dispatchEvent(
+      new CustomEvent('execute', { bubbles: true, composed: true }),
+    );
   }
 
   private handleAgentSettings(): void {
@@ -263,9 +258,7 @@ export class InstructionPanel extends LitElement {
   }
 
   private handleFocus(key: string, text: string): void {
-    this.dispatchEvent(
-      MainViewEvents.focusInstruction({ key, text }),
-    );
+    this.dispatchEvent(MainViewEvents.focusInstruction({ key, text }));
   }
 
   override render(): TemplateResult {
@@ -427,7 +420,10 @@ export class InstructionPanel extends LitElement {
                       )}
                     @change=${(event: Event) => {
                       const target = event.currentTarget as HTMLInputElement;
-                      this.handleAgentChange(SESSION_TYPES.WORKFLOW, target.value);
+                      this.handleAgentChange(
+                        SESSION_TYPES.WORKFLOW,
+                        target.value,
+                      );
                     }}
                   >
                     ${unsafeHTML(workflowOptions)}
@@ -452,7 +448,10 @@ export class InstructionPanel extends LitElement {
                       )}
                     @change=${(event: Event) => {
                       const target = event.currentTarget as HTMLInputElement;
-                      this.handleAgentChange(SESSION_TYPES.TOOL_USE, target.value);
+                      this.handleAgentChange(
+                        SESSION_TYPES.TOOL_USE,
+                        target.value,
+                      );
                     }}
                   >
                     ${unsafeHTML(toolUseOptions)}

--- a/src/webview/frontend/components/index.ts
+++ b/src/webview/frontend/components/index.ts
@@ -4,15 +4,8 @@
  * Import all components to ensure they are registered with Lit.
  */
 
-export { FileSelectGroup, type FileSelectConfig, type CheckboxValues } from './FileSelectGroup';
-export { BannerGroup, type ApiKeyBannerState, type AgentConfigBannerState, type DependencyBannerState } from './BannerGroup';
+export { FileSelectGroup } from './FileSelectGroup';
+export { BannerGroup } from './BannerGroup';
 export { LatexDiffsSection } from './LatexDiffsSection';
-export {
-  InstructionPanel,
-  type SessionTypeChangeDetail,
-  type AgentChangeDetail,
-  type ModelChangeDetail,
-  type InstructionChangeDetail,
-  type ActionDetail,
-} from './InstructionPanel';
+export { InstructionPanel } from './InstructionPanel';
 export { OutputFilesSection } from './OutputFilesSection';

--- a/src/webview/frontend/constants.ts
+++ b/src/webview/frontend/constants.ts
@@ -1,16 +1,23 @@
+// Local imports - shared schemas
+import type {
+  FileType as SharedFileType,
+  MultipleFileType as SharedMultipleFileType,
+  SessionType as SharedSessionType,
+} from '@shared/schemas';
+
 // Local constants - session types
 export const SESSION_TYPES = {
   TOOL_USE: 'toolUse',
   WORKFLOW: 'workflow',
 } as const;
 
-export type SessionType = (typeof SESSION_TYPES)[keyof typeof SESSION_TYPES];
+export type SessionType = SharedSessionType;
 
 export const FILE_TYPES = ['input', 'reference', 'auxiliary', 'media'] as const;
-export type FileType = (typeof FILE_TYPES)[number];
+export type FileType = SharedFileType;
 
 export const MULTIPLE_FILE_TYPES = [...FILE_TYPES, 'output'] as const;
-export type MultipleFileType = (typeof MULTIPLE_FILE_TYPES)[number];
+export type MultipleFileType = SharedMultipleFileType;
 
 export const CHECK_BOXES_AUTO_EXTRACT = [
   'autoExtractFigure',

--- a/src/webview/frontend/events.ts
+++ b/src/webview/frontend/events.ts
@@ -4,94 +4,23 @@
  * Both dispatch and handler sides use these types.
  */
 
-import type { FileType, MultipleFileType } from './constants';
-
-// =============================================================================
-// Event Detail Types
-// =============================================================================
-
-/** File select dropdown change */
-export interface FileSelectChangeDetail {
-  type: FileType;
-  value: string;
-}
-
-/** Base file select change */
-export interface BaseFileChangeDetail {
-  value: string;
-}
-
-/** Edited file select change */
-export interface EditedFileChangeDetail {
-  value: string;
-}
-
-/** Single file action (refresh, current, empty) */
-export interface FileActionDetail {
-  type: FileType | 'base' | 'edited';
-}
-
-/** Multiple files action (toggle, select) */
-export interface MultipleFilesActionDetail {
-  listId: string;
-}
-
-/** Multiple files type action (add opened, empty) */
-export interface MultipleFilesTypeActionDetail {
-  type: FileType | MultipleFileType;
-}
-
-/** Remove file from list */
-export interface RemoveFileDetail {
-  listId: string;
-  file: string;
-}
-
-/** Checkbox change */
-export interface CheckboxChangeDetail {
-  id: string;
-  checked: boolean;
-}
-
-/** Banner action */
-export interface BannerActionDetail {
-  action: string;
-  provider?: string;
-  customDirSet?: boolean;
-}
-
-/** Install guide action */
-export interface InstallGuideDetail {
-  tool: string;
-}
-
-/** LaTeXDiffs visibility toggle */
-export interface LatexDiffsToggleDetail {
-  visible: boolean;
-}
-
-/** LaTeXDiffs action (diff, merge, compare, etc.) */
-export interface LatexDiffsActionDetail {
-  action:
-    | 'latexdiff'
-    | 'latexdiffvc'
-    | 'packLatexdiffvc'
-    | 'cleanLatexdiffvc'
-    | 'merge'
-    | 'compare'
-    | 'accept';
-}
-
-/** Commit change */
-export interface CommitChangeDetail {
-  value: string;
-}
-
-/** Focus instruction detail */
-export interface FocusInstructionDetail {
-  key: string;
-  text: string;
-}
+// Local imports - shared schemas
+import type {
+  BannerActionDetail,
+  BaseFileChangeDetail,
+  CheckboxChangeDetail,
+  CommitChangeDetail,
+  EditedFileChangeDetail,
+  FileActionDetail,
+  FileSelectChangeDetail,
+  FocusInstructionDetail,
+  InstallGuideDetail,
+  LatexDiffsActionDetail,
+  LatexDiffsToggleDetail,
+  MultipleFilesActionDetail,
+  MultipleFilesTypeActionDetail,
+  RemoveFileDetail,
+} from '@shared/schemas';
 
 // =============================================================================
 // Event Creators - use these to dispatch typed events

--- a/src/webview/frontend/store.ts
+++ b/src/webview/frontend/store.ts
@@ -4,116 +4,39 @@
  * Centralizes state management concerns for MainApp.
  */
 
+// Local imports - webview commands
+// Local imports - shared schemas
+import {
+  MainViewPersistedStateSchema,
+  type CheckboxValues,
+  type FileSelectConfig,
+  type MainViewPersistedState,
+  type SessionType,
+} from '@shared/schemas';
+
+// Local imports - webview commands
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands';
-import { SESSION_TYPES, type SessionType, type MultipleFileType, type FileType } from './constants';
 
-// =========================================================================
-// State Types
-// =========================================================================
+// Local imports - main view constants
+import { SESSION_TYPES, type MultipleFileType } from './constants';
 
-/** Persisted state for MainView across sessions */
-export interface MainViewPersistedState extends Record<string, unknown> {
-  sessionType: SessionType;
-  workflowAgent: string;
-  toolUseAgent: string;
-  model: string;
-  commit: string;
-  instruction: string;
-  inputFile: string;
-  referenceFile: string;
-  auxiliaryFile: string;
-  mediaFile: string;
-  editedFile: string;
-  baseFile: string;
-  inputFiles: string[];
-  referenceFiles: string[];
-  auxiliaryFiles: string[];
-  mediaFiles: string[];
-  outputFiles: string[];
-  inputFilesVisible: boolean;
-  referenceFilesVisible: boolean;
-  auxiliaryFilesVisible: boolean;
-  mediaFilesVisible: boolean;
-  outputFilesVisible: boolean;
-  outputFilesActive: boolean;
-  latexdiffsVisible: boolean;
-  autoExtractFigure: boolean;
-  autoExtractTikzFigure: boolean;
-  autoCompileInputPdf: boolean;
-  attachTeXCount: boolean;
-  attachDiagnostics: boolean;
-  agent: string;
-  isToolUseAgent: boolean;
-  openedFiles?: string[];
-}
-
-/** Banner display state */
-export interface BannerState {
-  visible: boolean;
-  provider?: string;
-  requiresKey?: boolean;
-  agentName?: string;
-  customDirSet?: boolean;
-  missingTools?: string[];
-}
-
-/** Single file selections state */
-export interface SingleFilesState {
-  inputFile: string;
-  referenceFile: string;
-  auxiliaryFile: string;
-  mediaFile: string;
-  baseFile: string;
-  editedFile: string;
-}
-
-/** Checkbox configuration values */
-export interface CheckboxValuesState {
-  autoExtractFigure: boolean;
-  autoExtractTikzFigure: boolean;
-  autoCompileInputPdf: boolean;
-  attachTeXCount: boolean;
-  attachDiagnostics: boolean;
-}
+type SingleFilesState = Pick<
+  MainViewPersistedState,
+  | 'inputFile'
+  | 'referenceFile'
+  | 'auxiliaryFile'
+  | 'mediaFile'
+  | 'baseFile'
+  | 'editedFile'
+>;
 
 // =========================================================================
 // Default State
 // =========================================================================
 
 /** Default persisted state values */
-export const DEFAULT_STATE: MainViewPersistedState = {
-  sessionType: SESSION_TYPES.TOOL_USE,
-  workflowAgent: 'correct',
-  toolUseAgent: 'chat',
-  model: 'gemini3p',
-  commit: 'HEAD',
-  instruction: '',
-  inputFile: '',
-  referenceFile: '',
-  auxiliaryFile: '',
-  mediaFile: '',
-  editedFile: '',
-  baseFile: '',
-  inputFiles: [],
-  referenceFiles: [],
-  auxiliaryFiles: [],
-  mediaFiles: [],
-  outputFiles: [],
-  inputFilesVisible: false,
-  referenceFilesVisible: false,
-  auxiliaryFilesVisible: false,
-  mediaFilesVisible: false,
-  outputFilesVisible: false,
-  outputFilesActive: false,
-  latexdiffsVisible: false,
-  autoExtractFigure: false,
-  autoExtractTikzFigure: false,
-  autoCompileInputPdf: false,
-  attachTeXCount: false,
-  attachDiagnostics: false,
-  agent: '',
-  isToolUseAgent: true,
-};
+export const DEFAULT_STATE: MainViewPersistedState =
+  MainViewPersistedStateSchema.parse({});
 
 /** Default single files state */
 export const DEFAULT_SINGLE_FILES: SingleFilesState = {
@@ -154,7 +77,7 @@ export const DEFAULT_MULTI_FILES_VISIBLE: Record<string, boolean> = {
 };
 
 /** Default checkbox values */
-export const DEFAULT_CHECKBOX_VALUES: CheckboxValuesState = {
+export const DEFAULT_CHECKBOX_VALUES: CheckboxValues = {
   autoExtractFigure: DEFAULT_STATE.autoExtractFigure,
   autoExtractTikzFigure: DEFAULT_STATE.autoExtractTikzFigure,
   autoCompileInputPdf: DEFAULT_STATE.autoCompileInputPdf,
@@ -217,27 +140,8 @@ export const ONBOARDING_PLACEHOLDERS: Record<SessionType, string[]> = {
 // =========================================================================
 
 /** File selector config type (matches FileSelectGroup.ts) */
-export interface FileSelectConfigData {
-  type: FileType;
-  label: string;
-  icon: string;
-  refreshTitle: string;
-  currentTitle: string;
-  emptyTitle: string;
-  toggleTitle: string;
-  addOpenedLabel: string;
-  emptyListLabel: string;
-  selectListLabel: string;
-  tooltip: string;
-  toolConfig?: 'tool' | 'autoExtract';
-  focusInstruction?: {
-    key: string;
-    text: string;
-  };
-}
-
 /** Static configuration for each file selector type */
-export const FILE_SELECT_CONFIGS: ReadonlyArray<FileSelectConfigData> = [
+export const FILE_SELECT_CONFIGS: ReadonlyArray<FileSelectConfig> = [
   {
     type: 'input',
     label: 'Input',
@@ -281,7 +185,8 @@ export const FILE_SELECT_CONFIGS: ReadonlyArray<FileSelectConfigData> = [
     addOpenedLabel: 'Add opened files as auxiliary',
     emptyListLabel: 'Clear all auxiliary files',
     selectListLabel: 'Add auxiliary files',
-    tooltip: 'Files such as .cls/.sty that define document structure and styles',
+    tooltip:
+      'Files such as .cls/.sty that define document structure and styles',
   },
   {
     type: 'media',

--- a/src/webview/managers/DiffManager.ts
+++ b/src/webview/managers/DiffManager.ts
@@ -3,8 +3,19 @@ import * as vscode from 'vscode';
 
 // Local imports - webview commands
 import { MAIN_VIEW_COMMANDS } from '@common/webview';
+
+// Local imports - logging
 import * as logger from '@logger/logUtils';
+
+// Local imports - webview managers
 import { BaseWebviewManager } from './BaseWebviewManager';
+
+// Local imports - message schemas
+import {
+  LatexdiffMessageSchema,
+  LatexdiffvcMessageSchema,
+  LatexdiffvcOperationMessageSchema,
+} from '../types/messages';
 
 const CHANNEL = 'DiffManager';
 logger.initialize(CHANNEL);
@@ -12,24 +23,45 @@ logger.initialize(CHANNEL);
 export class DiffManager extends BaseWebviewManager {
   protected readonly channel = CHANNEL;
 
-  handleLatexdiff(message: any): void {
-    this.runDiffCommand('latexdiff', message, [
+  handleLatexdiff(message: unknown): void {
+    const parsed = LatexdiffMessageSchema.safeParse(message);
+    if (!parsed.success) {
+      logger.warn(CHANNEL, 'Invalid latexdiff message', {
+        data: parsed.error,
+      });
+      return;
+    }
+    this.runDiffCommand(MAIN_VIEW_COMMANDS.LATEXDIFF, parsed.data, [
       'inputFile',
       'baseFile',
       'editedFile',
     ]);
   }
 
-  handleLatexdiffvc(message: any): void {
-    this.runDiffCommand('latexdiffvc', message, [
+  handleLatexdiffvc(message: unknown): void {
+    const parsed = LatexdiffvcMessageSchema.safeParse(message);
+    if (!parsed.success) {
+      logger.warn(CHANNEL, 'Invalid latexdiffvc message', {
+        data: parsed.error,
+      });
+      return;
+    }
+    this.runDiffCommand(MAIN_VIEW_COMMANDS.LATEXDIFFVC, parsed.data, [
       'inputFile',
       'baseFile',
       'commitHash',
     ]);
   }
 
-  handleLatexdiffvcOperation(message: any): void {
-    this.runDiffCommand(message.command, message, [
+  handleLatexdiffvcOperation(message: unknown): void {
+    const parsed = LatexdiffvcOperationMessageSchema.safeParse(message);
+    if (!parsed.success) {
+      logger.warn(CHANNEL, 'Invalid latexdiffvc operation message', {
+        data: parsed.error,
+      });
+      return;
+    }
+    this.runDiffCommand(parsed.data.command, parsed.data, [
       'inputFile',
       'baseFile',
       'commitHash',
@@ -39,7 +71,7 @@ export class DiffManager extends BaseWebviewManager {
 
   private runDiffCommand(
     command: string,
-    message: any,
+    message: Record<string, unknown>,
     paramKeys: string[],
   ): void {
     void vscode.commands.executeCommand(

--- a/src/webview/managers/FileManager.ts
+++ b/src/webview/managers/FileManager.ts
@@ -5,6 +5,9 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import { workspace } from 'vscode';
 
+// Local imports - shared utils
+import { normalizeFilePath } from '@shared/utils/path';
+
 // Local imports - webview
 import { getAgent } from '@agent/index';
 import { showLoggedErrorMessage, toErrorMessage } from '@common/errors';
@@ -21,7 +24,6 @@ import {
   parseLatexDiffMetadata,
   deriveBaseFileFromLatexDiff,
 } from '@utils/files';
-import { uncapitalize } from '@utils/text/stringUtils';
 import { BaseWebviewManager } from './BaseWebviewManager';
 
 // Local imports - types
@@ -47,11 +49,67 @@ type FileUpdateOptions = {
   additionalPayload?: Record<string, unknown>;
 };
 
+const FILE_SELECT_COMMANDS = new Map<
+  string,
+  { singleFileType: string; selectedCommand: string }
+>([
+  [
+    MAIN_VIEW_COMMANDS.SELECT_INPUT_FILE,
+    {
+      singleFileType: 'InputFile',
+      selectedCommand: MAIN_VIEW_COMMANDS.INPUT_FILE_SELECTED,
+    },
+  ],
+  [
+    MAIN_VIEW_COMMANDS.SELECT_REFERENCE_FILE,
+    {
+      singleFileType: 'ReferenceFile',
+      selectedCommand: MAIN_VIEW_COMMANDS.REFERENCE_FILE_SELECTED,
+    },
+  ],
+  [
+    MAIN_VIEW_COMMANDS.SELECT_AUXILIARY_FILE,
+    {
+      singleFileType: 'AuxiliaryFile',
+      selectedCommand: MAIN_VIEW_COMMANDS.AUXILIARY_FILE_SELECTED,
+    },
+  ],
+  [
+    MAIN_VIEW_COMMANDS.SELECT_MEDIA_FILE,
+    {
+      singleFileType: 'MediaFile',
+      selectedCommand: MAIN_VIEW_COMMANDS.MEDIA_FILE_SELECTED,
+    },
+  ],
+]);
+
+const FILE_UPDATE_COMMANDS = new Map<string, string>([
+  [MAIN_VIEW_COMMANDS.UPDATE_INPUT_FILES, MAIN_VIEW_COMMANDS.SET_INPUT_FILES],
+  [
+    MAIN_VIEW_COMMANDS.UPDATE_REFERENCE_FILES,
+    MAIN_VIEW_COMMANDS.SET_REFERENCE_FILES,
+  ],
+  [
+    MAIN_VIEW_COMMANDS.UPDATE_AUXILIARY_FILES,
+    MAIN_VIEW_COMMANDS.SET_AUXILIARY_FILES,
+  ],
+  [MAIN_VIEW_COMMANDS.UPDATE_MEDIA_FILES, MAIN_VIEW_COMMANDS.SET_MEDIA_FILES],
+  [MAIN_VIEW_COMMANDS.UPDATE_OUTPUT_FILES, MAIN_VIEW_COMMANDS.SET_OUTPUT_FILES],
+]);
+
 export class FileManager extends BaseWebviewManager {
   protected readonly channel = CHANNEL;
 
   async handleFileSelection(message: FileSelectionMessage): Promise<void> {
-    const singleFileType = message.command.replace('select', '');
+    const config = FILE_SELECT_COMMANDS.get(message.command);
+    if (!config) {
+      logger.warn(
+        CHANNEL,
+        `Invalid file selection command: ${message.command}`,
+      );
+      return;
+    }
+    const { singleFileType, selectedCommand } = config;
     logger.debug(CHANNEL, `Selecting ${singleFileType}`);
 
     const file = await vscode.commands.executeCommand<string>(
@@ -60,7 +118,7 @@ export class FileManager extends BaseWebviewManager {
     if (file) {
       logger.debug(CHANNEL, `Selected ${singleFileType}: ${file}`);
       this.postMessage({
-        command: `${uncapitalize(singleFileType)}Selected`,
+        command: selectedCommand,
         filePath: file,
       });
     }
@@ -385,12 +443,16 @@ export class FileManager extends BaseWebviewManager {
   }
 
   async handleUpdateFiles(message: UpdateFilesMessage): Promise<void> {
-    const fileType = message.command.replace('update', '');
+    const command = FILE_UPDATE_COMMANDS.get(message.command);
+    if (!command) {
+      logger.warn(CHANNEL, `Invalid update command: ${message.command}`);
+      return;
+    }
     logger.debug(
       CHANNEL,
-      `Updating ${fileType} with ${message.files?.length ?? 0} files`,
+      `Updating ${message.command} with ${message.files?.length ?? 0} files`,
     );
-    this.postMessage({ command: `set${fileType}`, files: message.files ?? [] });
+    this.postMessage({ command, files: message.files ?? [] });
   }
 
   async selectOutputFiles(currentInputFile?: string): Promise<string[] | null> {
@@ -478,7 +540,9 @@ export class FileManager extends BaseWebviewManager {
     // Convert to relative paths and deduplicate
     const relevantFiles = [
       ...new Set(
-        fileUris.map((uri) => workspace.asRelativePath(uri.fsPath, false)),
+        fileUris.map((uri) =>
+          normalizeFilePath(workspace.asRelativePath(uri.fsPath, false)),
+        ),
       ),
     ];
 

--- a/src/webview/types/messages.ts
+++ b/src/webview/types/messages.ts
@@ -8,6 +8,7 @@ import { z } from 'zod';
 // Local imports
 import { StreamTabIdSchema } from '@shared/schemas';
 import { AgentCategory } from '@agent/core/AgentDataclass';
+import { MAIN_VIEW_COMMANDS } from '@common/webview/commands';
 import {
   TOOL_EDIT_APPROVAL_ACTIONS,
   BASH_APPROVAL_ACTIONS,
@@ -217,6 +218,48 @@ export const SetAllSingleFilesMessageSchema = BaseMessageSchema.extend(
 
 export type SetAllSingleFilesMessage = z.infer<
   typeof SetAllSingleFilesMessageSchema
+>;
+
+/**
+ * LaTeX diff message from webview
+ */
+export const LatexdiffMessageSchema = z.object({
+  command: z.literal(MAIN_VIEW_COMMANDS.LATEXDIFF),
+  inputFile: z.string(),
+  baseFile: z.string(),
+  editedFile: z.string(),
+});
+
+export type LatexdiffMessage = z.infer<typeof LatexdiffMessageSchema>;
+
+/**
+ * LaTeX diff with version control message from webview
+ */
+export const LatexdiffvcMessageSchema = z.object({
+  command: z.literal(MAIN_VIEW_COMMANDS.LATEXDIFFVC),
+  inputFile: z.string(),
+  baseFile: z.string(),
+  commitHash: z.string(),
+});
+
+export type LatexdiffvcMessage = z.infer<typeof LatexdiffvcMessageSchema>;
+
+/**
+ * LaTeX diff VC pack/clean message from webview
+ */
+export const LatexdiffvcOperationMessageSchema = z.object({
+  command: z.enum([
+    MAIN_VIEW_COMMANDS.PACK_LATEXDIFFVC,
+    MAIN_VIEW_COMMANDS.CLEAN_LATEXDIFFVC,
+  ]),
+  inputFile: z.string(),
+  baseFile: z.string(),
+  commitHash: z.string(),
+  clean: z.boolean(),
+});
+
+export type LatexdiffvcOperationMessage = z.infer<
+  typeof LatexdiffvcOperationMessageSchema
 >;
 
 // --- Common Utilities ---


### PR DESCRIPTION
### Motivation

- Centralize MainView persisted state and event types in Zod schemas so frontend and backend share a single source of truth and runtime validation. 
- Eliminate unsafe casts and fragile restore logic that allowed type drift, legacy fallbacks, and hidden file-list state on cross-webview restores. 
- Make restore flow robust for followups (Progress/History → MainView) and normalize file visibility/active flags from actual file arrays.

### Description

- Added shared Zod schemas for MainView state and events under `src/shared/schemas/` (`mainViewState.ts`, `mainViewEvents.ts`) and exported them from the shared barrel. 
- Updated `StateRestoreMessageSchema` to accept a typed partial `MainViewPersistedStateSchema` so restore payloads are validated at the message boundary. 
- Implemented `buildMainViewStateFromTaskState` in `src/common/state/mainViewState.ts` to convert `TaskState` → `MainViewPersistedState` (preserves file list visibility when file arrays are present). 
- Switched the restore pipeline to validate/convert and transmit typed MainView state: `src/commands/history/stateRestoreCommand.ts`, `src/MainViewProvider.ts`, and `src/common/state/pendingStateManager.ts` (now a queue of typed MainView state). 
- Migrated frontend MainView to Zod-derived types and schema-backed state: `src/webview/frontend/MainApp.ts` now uses `MainViewPersistedStateSchema` and `WebviewStateManager` accepts an optional schema for safe loading; removed legacy/unsafe casts and fallbacks. 
- Added/updated webview message schemas and message validation: `src/webview/types/messages.ts`, `src/shared/schemas/mainViewMessages.ts`. 
- Hardened manager handlers to validate incoming messages (DiffManager, FileManager) and centralized some file command mappings and path normalization via `src/shared/utils/path.ts`. 
- Replaced several local component/event interfaces with imports from shared schemas and updated component typings (BannerGroup, FileSelectGroup, InstructionPanel, events barrel). 
- Added a manual test checklist `docs/testing/mainview-manual-tests.md`. 
- Added a unit test `src/test/webview/stateMigration.test.ts` exercising `buildMainViewStateFromTaskState` and a regression for output-file visibility.

### Testing

- Ran `npm run format`; formatting completed successfully. 
- Built the project: `npm run compile` / `npm run compile:fast`; builds completed (fast build + vite webview bundles succeeded). 
- Ran linter: `npm run lint`; completed with only existing warnings (import order / eqeqeq) and no new errors. 
- Added unit test `src/test/webview/stateMigration.test.ts` (not executed via `npm test` in CI per repo guidance), test verifies mapping from TaskState to MainView persisted state including output-file visibility.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69775f47ff748324becf48c5b83865c1)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Unifies MainView state and event types across backend/frontend using shared Zod schemas and validates all restore and message payloads to prevent type drift.
> 
> - Adds `MainViewPersistedStateSchema`, `mainViewEvents`, and typed `mainViewMessages`; exports via shared barrel
> - Implements `buildMainViewStateFromTaskState` and switches restore path to produce/validate typed state (`stateRestoreCommand`, `MainViewProvider`, pending state queue)
> - Migrates `MainApp` and components to schema-backed state; removes unsafe casts, simplifies restore logic, and uses `WebviewStateManager` with optional schema
> - Tightens webview managers: validates diff/file messages, centralizes command mappings, and normalizes paths
> - Updates history/memory handlers to use `unknown`+schema validation; minor type fixes
> - Adds manual test checklist and unit test for state mapping/visibility
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4a7e420de97a8fefc7ce723bbe082bcce5139d61. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->