### PR TITLE
feat: migrate main view schemas to shared Zod contracts

### DIFF
--- a/src/MainViewProvider.ts
+++ b/src/MainViewProvider.ts
@@ -2,7 +2,7 @@
 import * as vscode from 'vscode';
 
 // Local imports - shared schemas
-import { MainViewPersistedStateSchema } from '@shared/schemas/mainViewState';
+import { MainViewPersistedStateSchema } from '@shared/schemas';
 
 // Local imports - agent
 import { refresh, computeAgentOptions } from '@agent/index';

--- a/src/MainViewProvider.ts
+++ b/src/MainViewProvider.ts
@@ -1,6 +1,9 @@
 // Third-party imports
 import * as vscode from 'vscode';
 
+// Local imports - shared schemas
+import { MainViewPersistedStateSchema } from '@shared/schemas/mainViewState';
+
 // Local imports - agent
 import { refresh, computeAgentOptions } from '@agent/index';
 
@@ -9,6 +12,8 @@ import { BaseWebviewProvider } from '@common/webview';
 import { getSharedLocalResourceRoots } from '@common/webview';
 import { MAIN_VIEW_COMMANDS } from '@common/webview';
 import { consumePendingState } from '@common/state';
+
+// Local imports - frontend
 import { agentDirectories } from '@frontend/agents';
 import { computeModelOptions } from '@model/computeModelOptions';
 import {
@@ -263,14 +268,20 @@ export class MainViewProvider
     });
 
     // Check if there's state to restore (consume it from pending state)
-    const pendingData = consumePendingState();
-
-    if (pendingData) {
+    let pendingData = consumePendingState();
+    while (pendingData) {
+      const parsed = MainViewPersistedStateSchema.safeParse(pendingData.state);
+      if (!parsed.success) {
+        console.warn('Invalid pending state restore payload', parsed.error);
+        pendingData = consumePendingState();
+        continue;
+      }
       webviewView.webview.postMessage({
         command: MAIN_VIEW_COMMANDS.STATE_RESTORE,
-        state: pendingData.state,
+        state: parsed.data,
         executeImmediately: pendingData.executeImmediately,
       });
+      pendingData = consumePendingState();
     }
   }
 }

--- a/src/commands/history/stateRestoreCommand.ts
+++ b/src/commands/history/stateRestoreCommand.ts
@@ -1,15 +1,10 @@
 // Third-party imports
 import * as vscode from 'vscode';
 
-// Local imports - shared schemas
-import {
-  MainViewPersistedStateSchema,
-  type MainViewPersistedState,
-} from '@shared/schemas/mainViewState';
-
 // Local imports - common
 import { showLoggedErrorMessage } from '@common/errors';
 import { setPendingState } from '@common/state';
+import { buildMainViewState } from '@common/state/mainViewStateUtils';
 import { COMMON_COMMANDS } from '@common/webview/commands';
 
 // Local imports - frontend
@@ -19,11 +14,7 @@ import { getMainWebview } from '@frontend/system/commandUtils';
 import * as logger from '@logger/logUtils';
 
 // Local imports - task state
-import {
-  isToolUseTaskState,
-  isWorkflowTaskState,
-  type TaskState,
-} from '@logger/TaskState';
+import type { TaskState } from '@logger/TaskState';
 
 const CHANNEL = 'stateRestoreCommand';
 logger.initialize(CHANNEL);
@@ -75,53 +66,4 @@ async function restoreState(state: TaskState, executeImmediately?: boolean) {
   } catch (error) {
     await showLoggedErrorMessage(CHANNEL, 'Failed to restore state', error);
   }
-}
-
-function buildMainViewState(taskState: TaskState): MainViewPersistedState {
-  const defaults = MainViewPersistedStateSchema.parse({});
-  const { agentConfig } = taskState;
-  const isToolUse = isToolUseTaskState(taskState);
-  const isWorkflow = isWorkflowTaskState(taskState);
-  const activeFiles = isWorkflow ? taskState.activeFiles : undefined;
-  const toolConfig = agentConfig.toolConfig ?? {};
-
-  const nextState: MainViewPersistedState = {
-    ...defaults,
-    sessionType: isToolUse ? 'toolUse' : 'workflow',
-    workflowAgent: isToolUse ? defaults.workflowAgent : agentConfig.agent,
-    toolUseAgent: isToolUse ? agentConfig.agent : defaults.toolUseAgent,
-    model: agentConfig.model ?? defaults.model,
-    instruction: agentConfig.instruction ?? defaults.instruction,
-    inputFile: agentConfig.inputFile ?? defaults.inputFile,
-    referenceFile: agentConfig.referenceFile ?? defaults.referenceFile,
-    auxiliaryFile: agentConfig.auxiliaryFile ?? defaults.auxiliaryFile,
-    mediaFile: agentConfig.mediaFile ?? defaults.mediaFile,
-    editedFile: agentConfig.editedFile ?? defaults.editedFile,
-    inputFiles: agentConfig.inputFiles ?? defaults.inputFiles,
-    referenceFiles: agentConfig.referenceFiles ?? defaults.referenceFiles,
-    auxiliaryFiles: agentConfig.auxiliaryFiles ?? defaults.auxiliaryFiles,
-    mediaFiles: agentConfig.mediaFiles ?? defaults.mediaFiles,
-    outputFiles: agentConfig.outputFiles ?? defaults.outputFiles,
-    inputFilesVisible: activeFiles?.input ?? defaults.inputFilesVisible,
-    referenceFilesVisible:
-      activeFiles?.reference ?? defaults.referenceFilesVisible,
-    auxiliaryFilesVisible:
-      activeFiles?.auxiliary ?? defaults.auxiliaryFilesVisible,
-    mediaFilesVisible: activeFiles?.media ?? defaults.mediaFilesVisible,
-    outputFilesVisible: activeFiles?.output ?? defaults.outputFilesVisible,
-    outputFilesActive: activeFiles?.output ?? defaults.outputFilesActive,
-    autoExtractFigure:
-      toolConfig.autoExtractFigure ?? defaults.autoExtractFigure,
-    autoExtractTikzFigure:
-      toolConfig.autoExtractTikzFigure ?? defaults.autoExtractTikzFigure,
-    autoCompileInputPdf:
-      toolConfig.autoCompileInputPdf ?? defaults.autoCompileInputPdf,
-    attachTeXCount: toolConfig.attachTeXCount ?? defaults.attachTeXCount,
-    attachDiagnostics:
-      toolConfig.attachDiagnostics ?? defaults.attachDiagnostics,
-    agent: agentConfig.agent ?? defaults.agent,
-    isToolUseAgent: isToolUse,
-  };
-
-  return MainViewPersistedStateSchema.parse(nextState);
 }

--- a/src/commands/history/stateRestoreCommand.ts
+++ b/src/commands/history/stateRestoreCommand.ts
@@ -1,13 +1,29 @@
 // Third-party imports
 import * as vscode from 'vscode';
 
-// Local imports - log
-import { showLoggedErrorMessage, toErrorMessage } from '@common/errors';
+// Local imports - shared schemas
+import {
+  MainViewPersistedStateSchema,
+  type MainViewPersistedState,
+} from '@shared/schemas/mainViewState';
+
+// Local imports - common
+import { showLoggedErrorMessage } from '@common/errors';
 import { setPendingState } from '@common/state';
+import { COMMON_COMMANDS } from '@common/webview/commands';
+
+// Local imports - frontend
 import { getMainWebview } from '@frontend/system/commandUtils';
+
+// Local imports - logging
 import * as logger from '@logger/logUtils';
-import type { TaskState } from '@logger/TaskState';
-// Type imports
+
+// Local imports - task state
+import {
+  isToolUseTaskState,
+  isWorkflowTaskState,
+  type TaskState,
+} from '@logger/TaskState';
 
 const CHANNEL = 'stateRestoreCommand';
 logger.initialize(CHANNEL);
@@ -34,14 +50,16 @@ async function restoreState(state: TaskState, executeImmediately?: boolean) {
   });
 
   try {
+    const nextState = buildMainViewState(state);
+
     // Focus the webview panel first to make sure it's visible
     await vscode.commands.executeCommand('texra.mainView.focus');
 
     const webviewView = await getMainWebview(CHANNEL);
     if (webviewView) {
       webviewView.webview.postMessage({
-        command: 'restoreState',
-        state,
+        command: COMMON_COMMANDS.STATE_RESTORE,
+        state: nextState,
         executeImmediately,
       });
       logger.info(CHANNEL, 'State restored via direct webview access');
@@ -49,7 +67,7 @@ async function restoreState(state: TaskState, executeImmediately?: boolean) {
     }
 
     // Store the state in memory for the MainViewProvider to pick up
-    setPendingState(state, executeImmediately);
+    setPendingState(nextState, executeImmediately);
     await vscode.commands.executeCommand('texra.mainView.focus');
     logger.info(CHANNEL, 'State stored for later restoration', {
       data: { executeImmediately },
@@ -57,4 +75,53 @@ async function restoreState(state: TaskState, executeImmediately?: boolean) {
   } catch (error) {
     await showLoggedErrorMessage(CHANNEL, 'Failed to restore state', error);
   }
+}
+
+function buildMainViewState(taskState: TaskState): MainViewPersistedState {
+  const defaults = MainViewPersistedStateSchema.parse({});
+  const { agentConfig } = taskState;
+  const isToolUse = isToolUseTaskState(taskState);
+  const isWorkflow = isWorkflowTaskState(taskState);
+  const activeFiles = isWorkflow ? taskState.activeFiles : undefined;
+  const toolConfig = agentConfig.toolConfig ?? {};
+
+  const nextState: MainViewPersistedState = {
+    ...defaults,
+    sessionType: isToolUse ? 'toolUse' : 'workflow',
+    workflowAgent: isToolUse ? defaults.workflowAgent : agentConfig.agent,
+    toolUseAgent: isToolUse ? agentConfig.agent : defaults.toolUseAgent,
+    model: agentConfig.model ?? defaults.model,
+    instruction: agentConfig.instruction ?? defaults.instruction,
+    inputFile: agentConfig.inputFile ?? defaults.inputFile,
+    referenceFile: agentConfig.referenceFile ?? defaults.referenceFile,
+    auxiliaryFile: agentConfig.auxiliaryFile ?? defaults.auxiliaryFile,
+    mediaFile: agentConfig.mediaFile ?? defaults.mediaFile,
+    editedFile: agentConfig.editedFile ?? defaults.editedFile,
+    inputFiles: agentConfig.inputFiles ?? defaults.inputFiles,
+    referenceFiles: agentConfig.referenceFiles ?? defaults.referenceFiles,
+    auxiliaryFiles: agentConfig.auxiliaryFiles ?? defaults.auxiliaryFiles,
+    mediaFiles: agentConfig.mediaFiles ?? defaults.mediaFiles,
+    outputFiles: agentConfig.outputFiles ?? defaults.outputFiles,
+    inputFilesVisible: activeFiles?.input ?? defaults.inputFilesVisible,
+    referenceFilesVisible:
+      activeFiles?.reference ?? defaults.referenceFilesVisible,
+    auxiliaryFilesVisible:
+      activeFiles?.auxiliary ?? defaults.auxiliaryFilesVisible,
+    mediaFilesVisible: activeFiles?.media ?? defaults.mediaFilesVisible,
+    outputFilesVisible: activeFiles?.output ?? defaults.outputFilesVisible,
+    outputFilesActive: activeFiles?.output ?? defaults.outputFilesActive,
+    autoExtractFigure:
+      toolConfig.autoExtractFigure ?? defaults.autoExtractFigure,
+    autoExtractTikzFigure:
+      toolConfig.autoExtractTikzFigure ?? defaults.autoExtractTikzFigure,
+    autoCompileInputPdf:
+      toolConfig.autoCompileInputPdf ?? defaults.autoCompileInputPdf,
+    attachTeXCount: toolConfig.attachTeXCount ?? defaults.attachTeXCount,
+    attachDiagnostics:
+      toolConfig.attachDiagnostics ?? defaults.attachDiagnostics,
+    agent: agentConfig.agent ?? defaults.agent,
+    isToolUseAgent: isToolUse,
+  };
+
+  return MainViewPersistedStateSchema.parse(nextState);
 }

--- a/src/common/state/mainViewStateUtils.ts
+++ b/src/common/state/mainViewStateUtils.ts
@@ -1,0 +1,66 @@
+// Local imports - shared schemas
+import {
+  MainViewPersistedStateSchema,
+  type MainViewPersistedState,
+} from '@shared/schemas';
+
+// Local imports - task state
+import {
+  isToolUseTaskState,
+  isWorkflowTaskState,
+  type TaskState,
+} from '@logger/TaskState';
+
+/**
+ * Convert a TaskState payload into a full main view state snapshot.
+ */
+export function buildMainViewState(
+  taskState: TaskState,
+): MainViewPersistedState {
+  const defaults = MainViewPersistedStateSchema.parse({});
+  const { agentConfig } = taskState;
+  const isToolUse = isToolUseTaskState(taskState);
+  const isWorkflow = isWorkflowTaskState(taskState);
+  const activeFiles = isWorkflow ? taskState.activeFiles : undefined;
+  const toolConfig = agentConfig.toolConfig ?? {};
+
+  const nextState: MainViewPersistedState = {
+    ...defaults,
+    sessionType: isToolUse ? 'toolUse' : 'workflow',
+    workflowAgent: isToolUse ? defaults.workflowAgent : agentConfig.agent,
+    toolUseAgent: isToolUse ? agentConfig.agent : defaults.toolUseAgent,
+    model: agentConfig.model ?? defaults.model,
+    instruction: agentConfig.instruction ?? defaults.instruction,
+    inputFile: agentConfig.inputFile ?? defaults.inputFile,
+    referenceFile: agentConfig.referenceFile ?? defaults.referenceFile,
+    auxiliaryFile: agentConfig.auxiliaryFile ?? defaults.auxiliaryFile,
+    mediaFile: agentConfig.mediaFile ?? defaults.mediaFile,
+    editedFile: agentConfig.editedFile ?? defaults.editedFile,
+    inputFiles: agentConfig.inputFiles ?? defaults.inputFiles,
+    referenceFiles: agentConfig.referenceFiles ?? defaults.referenceFiles,
+    auxiliaryFiles: agentConfig.auxiliaryFiles ?? defaults.auxiliaryFiles,
+    mediaFiles: agentConfig.mediaFiles ?? defaults.mediaFiles,
+    outputFiles: agentConfig.outputFiles ?? defaults.outputFiles,
+    inputFilesVisible: activeFiles?.input ?? defaults.inputFilesVisible,
+    referenceFilesVisible:
+      activeFiles?.reference ?? defaults.referenceFilesVisible,
+    auxiliaryFilesVisible:
+      activeFiles?.auxiliary ?? defaults.auxiliaryFilesVisible,
+    mediaFilesVisible: activeFiles?.media ?? defaults.mediaFilesVisible,
+    outputFilesVisible: activeFiles?.output ?? defaults.outputFilesVisible,
+    outputFilesActive: activeFiles?.output ?? defaults.outputFilesActive,
+    autoExtractFigure:
+      toolConfig.autoExtractFigure ?? defaults.autoExtractFigure,
+    autoExtractTikzFigure:
+      toolConfig.autoExtractTikzFigure ?? defaults.autoExtractTikzFigure,
+    autoCompileInputPdf:
+      toolConfig.autoCompileInputPdf ?? defaults.autoCompileInputPdf,
+    attachTeXCount: toolConfig.attachTeXCount ?? defaults.attachTeXCount,
+    attachDiagnostics:
+      toolConfig.attachDiagnostics ?? defaults.attachDiagnostics,
+    agent: agentConfig.agent ?? defaults.agent,
+    isToolUseAgent: isToolUse,
+  };
+
+  return MainViewPersistedStateSchema.parse(nextState);
+}

--- a/src/common/state/pendingStateManager.ts
+++ b/src/common/state/pendingStateManager.ts
@@ -3,26 +3,26 @@
  * This is used to pass state from the restore command to the MainViewProvider
  * when the webview is not yet available.
  */
-
-import type { TaskState } from '@logger/TaskState';
+// Local imports - shared schemas
+import type { MainViewPersistedState } from '@shared/schemas/mainViewState';
 
 interface PendingStateData {
-  state: TaskState;
+  state: MainViewPersistedState;
   executeImmediately?: boolean;
 }
 
-let pendingStateData: PendingStateData | undefined = undefined;
+const pendingStateQueue: PendingStateData[] = [];
 
 /**
  * Store state for later restoration.
- * @param state - The TaskState to restore
+ * @param state - The MainView state to restore
  * @param executeImmediately - If true, execute the agent after restoring state (for followup)
  */
 export function setPendingState(
-  state: TaskState,
+  state: MainViewPersistedState,
   executeImmediately?: boolean,
 ): void {
-  pendingStateData = { state, executeImmediately };
+  pendingStateQueue.push({ state, executeImmediately });
 }
 
 /**
@@ -30,7 +30,5 @@ export function setPendingState(
  * @returns The pending state data if any, undefined otherwise
  */
 export function consumePendingState(): PendingStateData | undefined {
-  const result = pendingStateData;
-  pendingStateData = undefined;
-  return result;
+  return pendingStateQueue.shift();
 }

--- a/src/common/state/pendingStateManager.ts
+++ b/src/common/state/pendingStateManager.ts
@@ -4,13 +4,14 @@
  * when the webview is not yet available.
  */
 // Local imports - shared schemas
-import type { MainViewPersistedState } from '@shared/schemas/mainViewState';
+import type { MainViewPersistedState } from '@shared/schemas';
 
 interface PendingStateData {
   state: MainViewPersistedState;
   executeImmediately?: boolean;
 }
 
+const MAX_PENDING_STATES = 10;
 const pendingStateQueue: PendingStateData[] = [];
 
 /**
@@ -22,6 +23,9 @@ export function setPendingState(
   state: MainViewPersistedState,
   executeImmediately?: boolean,
 ): void {
+  if (pendingStateQueue.length >= MAX_PENDING_STATES) {
+    pendingStateQueue.shift();
+  }
   pendingStateQueue.push({ state, executeImmediately });
 }
 

--- a/src/historyView/HistoryViewMessageHandler.ts
+++ b/src/historyView/HistoryViewMessageHandler.ts
@@ -41,7 +41,7 @@ export class HistoryViewMessageHandler extends BaseViewMessageHandler<
   }
 
   private async handleGetHistoryData(
-    _message: any,
+    _message: unknown,
     view: vscode.WebviewView | vscode.WebviewPanel,
   ): Promise<void> {
     await this.sendHistoryData(view.webview);

--- a/src/memoryView/MemoryViewMessageHandler.ts
+++ b/src/memoryView/MemoryViewMessageHandler.ts
@@ -40,14 +40,8 @@ import {
   MemoryEnabledMessageSchema,
 } from '@webview/types/messages';
 
-interface MemoryViewItem {
-  displayPath: string;
-  storagePath: string;
-  size: number;
-  mtime: string;
-  lineCount: number;
-  preview: string;
-}
+// Local imports - shared schemas
+import type { MemoryViewItem } from '@shared/schemas';
 
 export class MemoryViewMessageHandler extends BaseViewMessageHandler<
   vscode.WebviewView | vscode.WebviewPanel

--- a/src/shared/schemas/commonViewMessages.ts
+++ b/src/shared/schemas/commonViewMessages.ts
@@ -2,7 +2,7 @@
 import { z } from 'zod';
 
 // Local imports - shared schemas
-import { MainViewPersistedStateSchema } from '@shared/schemas/mainViewState';
+import { MainViewPersistedStateSchema } from '@shared/schemas';
 
 // Local imports - shared commands
 import { COMMON_COMMANDS } from '@common/webview/commands';
@@ -19,7 +19,7 @@ export const SetDebugModeMessageSchema = z.object({
 
 export const StateRestoreMessageSchema = z.object({
   command: z.literal(COMMON_COMMANDS.STATE_RESTORE),
-  state: MainViewPersistedStateSchema.partial().nullish(),
+  state: MainViewPersistedStateSchema.nullish(),
   executeImmediately: z.boolean().nullish(),
   isResetOperation: z.boolean().nullish(),
 });

--- a/src/shared/schemas/commonViewMessages.ts
+++ b/src/shared/schemas/commonViewMessages.ts
@@ -1,6 +1,9 @@
 // Third-party imports
 import { z } from 'zod';
 
+// Local imports - shared schemas
+import { MainViewPersistedStateSchema } from '@shared/schemas/mainViewState';
+
 // Local imports - shared commands
 import { COMMON_COMMANDS } from '@common/webview/commands';
 
@@ -16,7 +19,7 @@ export const SetDebugModeMessageSchema = z.object({
 
 export const StateRestoreMessageSchema = z.object({
   command: z.literal(COMMON_COMMANDS.STATE_RESTORE),
-  state: z.record(z.string(), z.unknown()).nullish(),
+  state: MainViewPersistedStateSchema.partial().nullish(),
   executeImmediately: z.boolean().nullish(),
   isResetOperation: z.boolean().nullish(),
 });

--- a/src/shared/schemas/index.ts
+++ b/src/shared/schemas/index.ts
@@ -14,6 +14,8 @@ export * from './proposalFields';
 export * from './stream';
 export * from './contextManagement';
 export * from './diffResult';
+export * from './mainViewState';
+export * from './mainViewEvents';
 
 // Message schemas (depend on data schemas) - must come before streamState
 export * from './progressViewMessages';

--- a/src/shared/schemas/index.ts
+++ b/src/shared/schemas/index.ts
@@ -16,6 +16,8 @@ export * from './contextManagement';
 export * from './diffResult';
 export * from './mainViewState';
 export * from './mainViewEvents';
+export * as mainViewMessages from './mainViewMessages';
+export type { MainViewMessage } from './mainViewMessages';
 
 // Message schemas (depend on data schemas) - must come before streamState
 export * from './progressViewMessages';

--- a/src/shared/schemas/mainViewEvents.ts
+++ b/src/shared/schemas/mainViewEvents.ts
@@ -16,14 +16,15 @@ export type FileSelectChangeDetail = z.infer<
   typeof FileSelectChangeDetailSchema
 >;
 
-export const BaseFileChangeDetailSchema = z.object({
+export const StringValueDetailSchema = z.object({
   value: z.string(),
 });
+export type StringValueDetail = z.infer<typeof StringValueDetailSchema>;
+
+export const BaseFileChangeDetailSchema = StringValueDetailSchema;
 export type BaseFileChangeDetail = z.infer<typeof BaseFileChangeDetailSchema>;
 
-export const EditedFileChangeDetailSchema = z.object({
-  value: z.string(),
-});
+export const EditedFileChangeDetailSchema = StringValueDetailSchema;
 export type EditedFileChangeDetail = z.infer<
   typeof EditedFileChangeDetailSchema
 >;
@@ -93,9 +94,7 @@ export type LatexDiffsActionDetail = z.infer<
   typeof LatexDiffsActionDetailSchema
 >;
 
-export const CommitChangeDetailSchema = z.object({
-  value: z.string(),
-});
+export const CommitChangeDetailSchema = StringValueDetailSchema;
 export type CommitChangeDetail = z.infer<typeof CommitChangeDetailSchema>;
 
 export const FocusInstructionDetailSchema = z.object({
@@ -119,14 +118,10 @@ export const AgentChangeDetailSchema = z.object({
 });
 export type AgentChangeDetail = z.infer<typeof AgentChangeDetailSchema>;
 
-export const ModelChangeDetailSchema = z.object({
-  value: z.string(),
-});
+export const ModelChangeDetailSchema = StringValueDetailSchema;
 export type ModelChangeDetail = z.infer<typeof ModelChangeDetailSchema>;
 
-export const InstructionChangeDetailSchema = z.object({
-  value: z.string(),
-});
+export const InstructionChangeDetailSchema = StringValueDetailSchema;
 export type InstructionChangeDetail = z.infer<
   typeof InstructionChangeDetailSchema
 >;

--- a/src/shared/schemas/mainViewEvents.ts
+++ b/src/shared/schemas/mainViewEvents.ts
@@ -1,0 +1,137 @@
+/**
+ * Main view event detail schemas.
+ */
+
+// Third-party imports
+import { z } from 'zod';
+
+// Local imports - main view state
+import { FileTypeSchema, SessionTypeSchema } from './mainViewState';
+
+export const FileSelectChangeDetailSchema = z.object({
+  type: FileTypeSchema,
+  value: z.string(),
+});
+export type FileSelectChangeDetail = z.infer<
+  typeof FileSelectChangeDetailSchema
+>;
+
+export const BaseFileChangeDetailSchema = z.object({
+  value: z.string(),
+});
+export type BaseFileChangeDetail = z.infer<typeof BaseFileChangeDetailSchema>;
+
+export const EditedFileChangeDetailSchema = z.object({
+  value: z.string(),
+});
+export type EditedFileChangeDetail = z.infer<
+  typeof EditedFileChangeDetailSchema
+>;
+
+export const FileActionDetailSchema = z.object({
+  type: z.union([FileTypeSchema, z.enum(['base', 'edited'])]),
+});
+export type FileActionDetail = z.infer<typeof FileActionDetailSchema>;
+
+export const MultipleFilesActionDetailSchema = z.object({
+  listId: z.string(),
+});
+export type MultipleFilesActionDetail = z.infer<
+  typeof MultipleFilesActionDetailSchema
+>;
+
+export const MultipleFilesTypeActionDetailSchema = z.object({
+  type: z.enum(['input', 'reference', 'auxiliary', 'media', 'output']),
+});
+export type MultipleFilesTypeActionDetail = z.infer<
+  typeof MultipleFilesTypeActionDetailSchema
+>;
+
+export const RemoveFileDetailSchema = z.object({
+  listId: z.string(),
+  file: z.string(),
+});
+export type RemoveFileDetail = z.infer<typeof RemoveFileDetailSchema>;
+
+export const CheckboxChangeDetailSchema = z.object({
+  id: z.string(),
+  checked: z.boolean(),
+});
+export type CheckboxChangeDetail = z.infer<typeof CheckboxChangeDetailSchema>;
+
+export const BannerActionDetailSchema = z.object({
+  action: z.string(),
+  provider: z.string().nullish(),
+  customDirSet: z.boolean().nullish(),
+});
+export type BannerActionDetail = z.infer<typeof BannerActionDetailSchema>;
+
+export const InstallGuideDetailSchema = z.object({
+  tool: z.string(),
+});
+export type InstallGuideDetail = z.infer<typeof InstallGuideDetailSchema>;
+
+export const LatexDiffsToggleDetailSchema = z.object({
+  visible: z.boolean(),
+});
+export type LatexDiffsToggleDetail = z.infer<
+  typeof LatexDiffsToggleDetailSchema
+>;
+
+export const LatexDiffsActionDetailSchema = z.object({
+  action: z.enum([
+    'latexdiff',
+    'latexdiffvc',
+    'packLatexdiffvc',
+    'cleanLatexdiffvc',
+    'merge',
+    'compare',
+    'accept',
+  ]),
+});
+export type LatexDiffsActionDetail = z.infer<
+  typeof LatexDiffsActionDetailSchema
+>;
+
+export const CommitChangeDetailSchema = z.object({
+  value: z.string(),
+});
+export type CommitChangeDetail = z.infer<typeof CommitChangeDetailSchema>;
+
+export const FocusInstructionDetailSchema = z.object({
+  key: z.string(),
+  text: z.string(),
+});
+export type FocusInstructionDetail = z.infer<
+  typeof FocusInstructionDetailSchema
+>;
+
+export const SessionTypeChangeDetailSchema = z.object({
+  value: SessionTypeSchema,
+});
+export type SessionTypeChangeDetail = z.infer<
+  typeof SessionTypeChangeDetailSchema
+>;
+
+export const AgentChangeDetailSchema = z.object({
+  sessionType: SessionTypeSchema,
+  value: z.string(),
+});
+export type AgentChangeDetail = z.infer<typeof AgentChangeDetailSchema>;
+
+export const ModelChangeDetailSchema = z.object({
+  value: z.string(),
+});
+export type ModelChangeDetail = z.infer<typeof ModelChangeDetailSchema>;
+
+export const InstructionChangeDetailSchema = z.object({
+  value: z.string(),
+});
+export type InstructionChangeDetail = z.infer<
+  typeof InstructionChangeDetailSchema
+>;
+
+export const ActionDetailSchema = z.object({
+  action: z.string(),
+});
+export type ActionDetail = z.infer<typeof ActionDetailSchema>;

--- a/src/shared/schemas/mainViewMessages.ts
+++ b/src/shared/schemas/mainViewMessages.ts
@@ -220,6 +220,40 @@ export const SetSelectedAgentMessageSchema = z.object({
   sessionType: z.string().nullish(),
 });
 
+// =============================================================================
+// Frontend → Backend payload schemas (MainView actions)
+// =============================================================================
+
+export const RequestRecentCommitsMessageSchema = z.object({
+  command: z.literal(MAIN_VIEW_COMMANDS.REQUEST_RECENT_COMMITS),
+  notifyWhenEmpty: z.boolean().nullish(),
+});
+
+export const LatexdiffMessageSchema = z.object({
+  command: z.literal(MAIN_VIEW_COMMANDS.LATEXDIFF),
+  inputFile: z.string(),
+  baseFile: z.string(),
+  editedFile: z.string(),
+});
+
+export const LatexdiffvcMessageSchema = z.object({
+  command: z.literal(MAIN_VIEW_COMMANDS.LATEXDIFFVC),
+  inputFile: z.string(),
+  baseFile: z.string(),
+  commitHash: z.string(),
+});
+
+export const LatexdiffvcOperationMessageSchema = z.object({
+  command: z.enum([
+    MAIN_VIEW_COMMANDS.PACK_LATEXDIFFVC,
+    MAIN_VIEW_COMMANDS.CLEAN_LATEXDIFFVC,
+  ]),
+  inputFile: z.string(),
+  baseFile: z.string(),
+  commitHash: z.string(),
+  clean: z.boolean().nullish(),
+});
+
 export const MainViewMessageSchema = z.discriminatedUnion('command', [
   SetModelOptionsMessageSchema,
   SetAgentOptionsMessageSchema,
@@ -266,3 +300,11 @@ export const MainViewMessageSchema = z.discriminatedUnion('command', [
 ]);
 
 export type MainViewMessage = z.infer<typeof MainViewMessageSchema>;
+export type RequestRecentCommitsMessage = z.infer<
+  typeof RequestRecentCommitsMessageSchema
+>;
+export type LatexdiffMessage = z.infer<typeof LatexdiffMessageSchema>;
+export type LatexdiffvcMessage = z.infer<typeof LatexdiffvcMessageSchema>;
+export type LatexdiffvcOperationMessage = z.infer<
+  typeof LatexdiffvcOperationMessageSchema
+>;

--- a/src/shared/schemas/mainViewState.ts
+++ b/src/shared/schemas/mainViewState.ts
@@ -1,0 +1,136 @@
+/**
+ * Main view state and UI schema definitions.
+ */
+
+// Third-party imports
+import { z } from 'zod';
+
+// =============================================================================
+// Core enums
+// =============================================================================
+
+export const SessionTypeSchema = z.enum(['toolUse', 'workflow']);
+export type SessionType = z.infer<typeof SessionTypeSchema>;
+
+export const FileTypeSchema = z.enum([
+  'input',
+  'reference',
+  'auxiliary',
+  'media',
+]);
+export type FileType = z.infer<typeof FileTypeSchema>;
+
+export const MultipleFileTypeSchema = z.enum([
+  'input',
+  'reference',
+  'auxiliary',
+  'media',
+  'output',
+]);
+export type MultipleFileType = z.infer<typeof MultipleFileTypeSchema>;
+
+// =============================================================================
+// Persisted state schema
+// =============================================================================
+
+export const MainViewPersistedStateSchema = z.object({
+  sessionType: SessionTypeSchema.prefault('toolUse'),
+  workflowAgent: z.string().prefault('correct'),
+  toolUseAgent: z.string().prefault('chat'),
+  model: z.string().prefault('gemini3p'),
+  commit: z.string().prefault('HEAD'),
+  instruction: z.string().prefault(''),
+  inputFile: z.string().prefault(''),
+  referenceFile: z.string().prefault(''),
+  auxiliaryFile: z.string().prefault(''),
+  mediaFile: z.string().prefault(''),
+  editedFile: z.string().prefault(''),
+  baseFile: z.string().prefault(''),
+  inputFiles: z.array(z.string()).prefault([]),
+  referenceFiles: z.array(z.string()).prefault([]),
+  auxiliaryFiles: z.array(z.string()).prefault([]),
+  mediaFiles: z.array(z.string()).prefault([]),
+  outputFiles: z.array(z.string()).prefault([]),
+  inputFilesVisible: z.boolean().prefault(false),
+  referenceFilesVisible: z.boolean().prefault(false),
+  auxiliaryFilesVisible: z.boolean().prefault(false),
+  mediaFilesVisible: z.boolean().prefault(false),
+  outputFilesVisible: z.boolean().prefault(false),
+  outputFilesActive: z.boolean().prefault(false),
+  latexdiffsVisible: z.boolean().prefault(false),
+  autoExtractFigure: z.boolean().prefault(false),
+  autoExtractTikzFigure: z.boolean().prefault(false),
+  autoCompileInputPdf: z.boolean().prefault(false),
+  attachTeXCount: z.boolean().prefault(false),
+  attachDiagnostics: z.boolean().prefault(false),
+  agent: z.string().prefault(''),
+  isToolUseAgent: z.boolean().prefault(true),
+  openedFiles: z.array(z.string()).nullish(),
+});
+
+export type MainViewPersistedState = z.infer<
+  typeof MainViewPersistedStateSchema
+>;
+
+// =============================================================================
+// Banner UI schemas
+// =============================================================================
+
+export const BannerStateSchema = z.object({
+  visible: z.boolean(),
+});
+export type BannerState = z.infer<typeof BannerStateSchema>;
+
+export const ApiKeyBannerStateSchema = BannerStateSchema.extend({
+  provider: z.string().nullish(),
+  requiresKey: z.boolean().nullish(),
+});
+export type ApiKeyBannerState = z.infer<typeof ApiKeyBannerStateSchema>;
+
+export const AgentConfigBannerStateSchema = BannerStateSchema.extend({
+  agentName: z.string().nullish(),
+  customDirSet: z.boolean().nullish(),
+});
+export type AgentConfigBannerState = z.infer<
+  typeof AgentConfigBannerStateSchema
+>;
+
+export const DependencyBannerStateSchema = BannerStateSchema.extend({
+  missingTools: z.array(z.string()).nullish(),
+});
+export type DependencyBannerState = z.infer<typeof DependencyBannerStateSchema>;
+
+// =============================================================================
+// UI configuration schemas
+// =============================================================================
+
+export const FileSelectConfigSchema = z.object({
+  type: FileTypeSchema,
+  label: z.string(),
+  icon: z.string(),
+  refreshTitle: z.string(),
+  currentTitle: z.string(),
+  emptyTitle: z.string(),
+  toggleTitle: z.string(),
+  addOpenedLabel: z.string(),
+  emptyListLabel: z.string(),
+  selectListLabel: z.string(),
+  tooltip: z.string(),
+  toolConfig: z.enum(['tool', 'autoExtract']).nullish(),
+  focusInstruction: z
+    .object({
+      key: z.string(),
+      text: z.string(),
+    })
+    .nullish(),
+});
+export type FileSelectConfig = z.infer<typeof FileSelectConfigSchema>;
+
+export const CheckboxValuesSchema = z.object({
+  autoExtractFigure: z.boolean(),
+  autoExtractTikzFigure: z.boolean(),
+  autoCompileInputPdf: z.boolean(),
+  attachTeXCount: z.boolean(),
+  attachDiagnostics: z.boolean(),
+});
+export type CheckboxValues = z.infer<typeof CheckboxValuesSchema>;

--- a/src/shared/schemas/mainViewState.ts
+++ b/src/shared/schemas/mainViewState.ts
@@ -126,11 +126,11 @@ export const FileSelectConfigSchema = z.object({
 });
 export type FileSelectConfig = z.infer<typeof FileSelectConfigSchema>;
 
-export const CheckboxValuesSchema = z.object({
-  autoExtractFigure: z.boolean(),
-  autoExtractTikzFigure: z.boolean(),
-  autoCompileInputPdf: z.boolean(),
-  attachTeXCount: z.boolean(),
-  attachDiagnostics: z.boolean(),
+export const CheckboxValuesSchema = MainViewPersistedStateSchema.pick({
+  autoExtractFigure: true,
+  autoExtractTikzFigure: true,
+  autoCompileInputPdf: true,
+  attachTeXCount: true,
+  attachDiagnostics: true,
 });
 export type CheckboxValues = z.infer<typeof CheckboxValuesSchema>;

--- a/src/shared/state/WebviewStateManager.ts
+++ b/src/shared/state/WebviewStateManager.ts
@@ -18,10 +18,20 @@ export class WebviewStateManager<T extends Record<string, unknown>> {
   ) {
     this.defaultState = { ...defaultState } as T;
     const saved = vscode.getState();
-    const parsed = schema?.safeParse(saved);
-    this.state = parsed?.success
-      ? { ...this.defaultState, ...parsed.data }
-      : { ...this.defaultState };
+    if (schema) {
+      const parsed = schema.safeParse(saved);
+      if (!parsed.success) {
+        console.warn(
+          '[WebviewStateManager] Failed to parse saved state.',
+          parsed.error,
+        );
+      }
+      this.state = parsed.success
+        ? { ...this.defaultState, ...parsed.data }
+        : { ...this.defaultState, ...(saved ?? {}) };
+      return;
+    }
+    this.state = { ...this.defaultState, ...(saved ?? {}) };
   }
 
   /**

--- a/src/shared/state/WebviewStateManager.ts
+++ b/src/shared/state/WebviewStateManager.ts
@@ -1,6 +1,9 @@
 // Local imports
 import { vscode } from '../vscode';
 
+// Third-party imports
+import type { z } from 'zod';
+
 /**
  * Manages persistence of state for a single webview.
  * Wraps the VS Code `getState` and `setState` APIs.
@@ -9,10 +12,16 @@ export class WebviewStateManager<T extends Record<string, unknown>> {
   private defaultState: T;
   private state: T;
 
-  constructor(defaultState: Partial<T> = {} as Partial<T>) {
+  constructor(
+    defaultState: Partial<T> = {} as Partial<T>,
+    schema?: z.ZodType<T>,
+  ) {
     this.defaultState = { ...defaultState } as T;
-    const saved = (vscode.getState() as T | undefined) ?? ({} as T);
-    this.state = { ...this.defaultState, ...saved };
+    const saved = vscode.getState();
+    const parsed = schema?.safeParse(saved);
+    this.state = parsed?.success
+      ? { ...this.defaultState, ...parsed.data }
+      : { ...this.defaultState };
   }
 
   /**

--- a/src/shared/utils/path.ts
+++ b/src/shared/utils/path.ts
@@ -1,4 +1,11 @@
 /**
+ * Normalize a file path to forward slashes for consistent comparisons.
+ */
+export function normalizeFilePath(filePath: string): string {
+  return filePath.replaceAll('\\', '/');
+}
+
+/**
  * Extract the base name (filename) from a file path.
  * Handles platform-specific separators (\ on Windows, / on Unix).
  *
@@ -11,8 +18,7 @@
 export function getBasename(filePath: string | undefined | null): string {
   if (!filePath) return '';
 
-  // Normalize path separators to forward slashes
-  const normalized = filePath.replaceAll('\\', '/');
+  const normalized = normalizeFilePath(filePath);
 
   // Remove trailing slashes except for root
   const cleaned = normalized.replace(/\/+$/, '') || '/';

--- a/src/webview/frontend/MainApp.ts
+++ b/src/webview/frontend/MainApp.ts
@@ -30,6 +30,13 @@ import {
   MainViewMessageSchema,
   type MainViewMessage,
 } from '@shared/schemas/mainViewMessages';
+import {
+  MainViewPersistedStateSchema,
+  type MainViewPersistedState,
+  type ApiKeyBannerState,
+  type AgentConfigBannerState,
+  type DependencyBannerState,
+} from '@shared/schemas';
 
 // Local imports - webview commands
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands';
@@ -65,40 +72,30 @@ import {
   PLACEHOLDER_ROTATION_MS,
   ONBOARDING_PLACEHOLDERS,
   FILE_SELECT_CONFIGS,
-  type MainViewPersistedState,
-  type BannerState,
 } from './store';
 
-// Local imports - main view component types
+// Type imports
 import type {
-  FileSelectConfig,
-  ApiKeyBannerState,
-  AgentConfigBannerState,
-  DependencyBannerState,
-  SessionTypeChangeDetail,
-  AgentChangeDetail,
-  ModelChangeDetail,
-  InstructionChangeDetail,
   ActionDetail,
-} from './components';
-import type {
-  FileSelectChangeDetail,
+  AgentChangeDetail,
+  BannerActionDetail,
+  BaseFileChangeDetail,
+  CheckboxChangeDetail,
+  CommitChangeDetail,
+  EditedFileChangeDetail,
   FileActionDetail,
+  FileSelectChangeDetail,
+  FocusInstructionDetail,
+  InstallGuideDetail,
+  InstructionChangeDetail,
+  LatexDiffsActionDetail,
+  LatexDiffsToggleDetail,
+  ModelChangeDetail,
   MultipleFilesActionDetail,
   MultipleFilesTypeActionDetail,
   RemoveFileDetail,
-  CheckboxChangeDetail,
-  BannerActionDetail,
-  InstallGuideDetail,
-  LatexDiffsToggleDetail,
-  LatexDiffsActionDetail,
-  BaseFileChangeDetail,
-  EditedFileChangeDetail,
-  CommitChangeDetail,
-  FocusInstructionDetail,
-} from './events';
-
-// Type imports
+  SessionTypeChangeDetail,
+} from '@shared/schemas';
 import type { StateRestoreMessage } from '@shared/schemas/commonViewMessages';
 
 type MainViewMessageHandler = (message: MainViewMessage) => void;
@@ -186,9 +183,13 @@ export class MainApp extends BaseWebviewApp {
   @state() private modelOptionsHtml = '';
   @state() private workflowAgentOptionsHtml = '';
   @state() private toolUseAgentOptionsHtml = '';
-  @state() private apiKeyBanner: BannerState = { visible: false };
-  @state() private agentConfigBanner: BannerState = { visible: false };
-  @state() private dependencyBanner: BannerState = { visible: false };
+  @state() private apiKeyBanner: ApiKeyBannerState = { visible: false };
+  @state() private agentConfigBanner: AgentConfigBannerState = {
+    visible: false,
+  };
+  @state() private dependencyBanner: DependencyBannerState = {
+    visible: false,
+  };
   @state() private gettingStartedVisible = false;
   @state() private loginBannerVisible = false;
   @state() private instructionPlaceholder =
@@ -212,7 +213,10 @@ export class MainApp extends BaseWebviewApp {
   declare private toolUseAgentElement: HTMLElement | null;
 
   private readonly stateManager =
-    new WebviewStateManager<MainViewPersistedState>(DEFAULT_STATE);
+    new WebviewStateManager<MainViewPersistedState>(
+      DEFAULT_STATE,
+      MainViewPersistedStateSchema,
+    );
   private saveBlockCount = 0;
   private placeholderTimer: number | null = null;
   private sortables: Sortable[] = [];
@@ -522,13 +526,9 @@ export class MainApp extends BaseWebviewApp {
   }
 
   private restorePersistedState(): void {
-    const saved = this.stateManager.getState();
-    const state = { ...DEFAULT_STATE, ...saved };
+    const state = this.stateManager.getState();
 
-    const sessionType =
-      parseSessionType(state.sessionType) ?? DEFAULT_STATE.sessionType;
-
-    this.sessionType = sessionType;
+    this.sessionType = state.sessionType;
     this.workflowAgent = state.workflowAgent || this.workflowAgent;
     this.toolUseAgent = state.toolUseAgent || this.toolUseAgent;
     this.model = state.model || this.model;
@@ -850,31 +850,26 @@ export class MainApp extends BaseWebviewApp {
   ): void {
     this.blockSave();
     try {
-      const messageValues = message as unknown as Record<
-        string,
-        string[] | null | undefined
-      >;
       const updates: Record<string, string[]> = {};
-      (
-        [
-          'inputFiles',
-          'referenceFiles',
-          'auxiliaryFiles',
-          'mediaFiles',
-        ] as const
-      ).forEach((key) => {
-        const files = messageValues[key] ?? [];
-        if (Array.isArray(files)) {
-          const target = key.replace('Files', 'File');
-          updates[target] = files;
-          const currentValue =
-            this.singleFiles[target as keyof typeof this.singleFiles];
-          if (currentValue && !files.includes(currentValue)) {
-            this.singleFiles = {
-              ...this.singleFiles,
-              [target]: '',
-            };
-          }
+      const fileGroups = [
+        { files: message.inputFiles, target: 'inputFile' },
+        { files: message.referenceFiles, target: 'referenceFile' },
+        { files: message.auxiliaryFiles, target: 'auxiliaryFile' },
+        { files: message.mediaFiles, target: 'mediaFile' },
+      ];
+
+      fileGroups.forEach(({ files, target }) => {
+        if (!files || !Array.isArray(files)) {
+          return;
+        }
+        updates[target] = files;
+        const currentValue =
+          this.singleFiles[target as keyof typeof this.singleFiles];
+        if (currentValue && !files.includes(currentValue)) {
+          this.singleFiles = {
+            ...this.singleFiles,
+            [target]: '',
+          };
         }
       });
       this.fileOptions = { ...this.fileOptions, ...updates };
@@ -959,54 +954,49 @@ export class MainApp extends BaseWebviewApp {
       this.clearForNewSession();
       return;
     }
-    if (!message.state || typeof message.state !== 'object') {
+    if (!message.state) {
       return;
     }
-    const state = message.state as Record<string, unknown>;
+
+    const parsed = MainViewPersistedStateSchema.partial().safeParse(
+      message.state,
+    );
+    if (!parsed.success) {
+      this.logSchemaError(
+        '[MainApp] State restore validation failed.',
+        parsed.error,
+      );
+      return;
+    }
+    const state = MainViewPersistedStateSchema.parse(parsed.data);
     this.blockSave();
     try {
-      const sessionType = this.determineSessionType(state);
-      this.sessionType = sessionType;
-      this.workflowAgent = this.extractAgentValue(state, false, sessionType);
-      this.toolUseAgent = this.extractAgentValue(state, true, sessionType);
-      if (typeof state.model === 'string') {
-        this.model = state.model;
-      }
-      this.instruction =
-        typeof state.instruction === 'string' ? state.instruction : '';
+      this.sessionType = state.sessionType;
+      this.workflowAgent = state.workflowAgent;
+      this.toolUseAgent = state.toolUseAgent;
+      this.model = state.model;
+      this.commit = state.commit;
+      this.instruction = state.instruction;
       this.singleFiles = {
-        inputFile: typeof state.inputFile === 'string' ? state.inputFile : '',
-        referenceFile:
-          typeof state.referenceFile === 'string' ? state.referenceFile : '',
-        auxiliaryFile:
-          typeof state.auxiliaryFile === 'string' ? state.auxiliaryFile : '',
-        mediaFile: typeof state.mediaFile === 'string' ? state.mediaFile : '',
-        editedFile:
-          typeof state.editedFile === 'string' ? state.editedFile : '',
-        baseFile: typeof state.baseFile === 'string' ? state.baseFile : '',
+        inputFile: state.inputFile,
+        referenceFile: state.referenceFile,
+        auxiliaryFile: state.auxiliaryFile,
+        mediaFile: state.mediaFile,
+        editedFile: state.editedFile,
+        baseFile: state.baseFile,
       };
 
-      const toolConfig = (state.toolConfig as Record<string, unknown>) ?? {};
       this.checkboxValues = {
-        autoExtractFigure: Boolean(
-          state.autoExtractFigure ?? toolConfig.autoExtractFigure,
-        ),
-        autoExtractTikzFigure: Boolean(
-          state.autoExtractTikzFigure ?? toolConfig.autoExtractTikzFigure,
-        ),
-        autoCompileInputPdf: Boolean(
-          state.autoCompileInputPdf ?? toolConfig.autoCompileInputPdf,
-        ),
-        attachTeXCount: Boolean(
-          state.attachTeXCount ?? toolConfig.attachTeXCount,
-        ),
-        attachDiagnostics: Boolean(
-          state.attachDiagnostics ?? toolConfig.attachDiagnostics,
-        ),
+        autoExtractFigure: state.autoExtractFigure,
+        autoExtractTikzFigure: state.autoExtractTikzFigure,
+        autoCompileInputPdf: state.autoCompileInputPdf,
+        attachTeXCount: state.attachTeXCount,
+        attachDiagnostics: state.attachDiagnostics,
       };
+      this.outputFilesActive = state.outputFilesActive;
+      this.latexdiffsVisible = state.latexdiffsVisible;
 
-      const activeFiles = (state.activeFiles as Record<string, boolean>) ?? {};
-      this.restoreFileArrays(state, activeFiles);
+      this.restoreFileArrays(state);
     } finally {
       this.unblockSave();
     }
@@ -1017,40 +1007,7 @@ export class MainApp extends BaseWebviewApp {
     }
   }
 
-  private determineSessionType(state: Record<string, unknown>): SessionType {
-    const candidate = state.agentCategory ?? state.sessionType;
-    const parsed = parseSessionType(
-      typeof candidate === 'string' ? candidate : undefined,
-    );
-    if (parsed) return parsed;
-    if (state.isToolUseAgent) return SESSION_TYPES.TOOL_USE;
-    return SESSION_TYPES.WORKFLOW;
-  }
-
-  private extractAgentValue(
-    state: Record<string, unknown>,
-    forToolUse: boolean,
-    sessionType: SessionType,
-  ): string {
-    const explicit = forToolUse ? state.toolUseAgent : state.workflowAgent;
-    if (typeof explicit === 'string') {
-      return explicit;
-    }
-
-    if (
-      typeof state.agent === 'string' &&
-      forToolUse === (sessionType === SESSION_TYPES.TOOL_USE)
-    ) {
-      return state.agent;
-    }
-
-    return '';
-  }
-
-  private restoreFileArrays(
-    state: Record<string, unknown>,
-    activeFiles: Record<string, boolean>,
-  ): void {
+  private restoreFileArrays(state: MainViewPersistedState): void {
     const updatedFiles: Record<string, string[]> = { ...this.multiFiles };
     const updatedVisibility: Record<string, boolean> = {
       ...this.multiFilesVisible,
@@ -1058,11 +1015,9 @@ export class MainApp extends BaseWebviewApp {
 
     MULTIPLE_FILE_TYPES.forEach((fileType) => {
       const key = `${fileType}Files`;
-      const files = (state[key] as string[]) ?? [];
+      const files = state[key as keyof MainViewPersistedState];
       const visible =
-        activeFiles[fileType] ??
-        (state[`${key}Active`] as boolean | undefined) ??
-        (state[`${key}Visible`] as boolean | undefined);
+        state[`${key}Visible` as keyof MainViewPersistedState] ?? false;
       updatedFiles[key] = Array.isArray(files) ? files : [];
       updatedVisibility[key] = Boolean(visible);
     });
@@ -1856,7 +1811,11 @@ export class MainApp extends BaseWebviewApp {
     const selectElement = this.renderRoot.querySelector(
       `#${selectId}`,
     ) as HTMLElement | null;
-    this.handleAgentChange(e.detail.sessionType, e.detail.value, selectElement ?? undefined);
+    this.handleAgentChange(
+      e.detail.sessionType,
+      e.detail.value,
+      selectElement ?? undefined,
+    );
   };
 
   private handleComponentModelChange = (
@@ -1994,7 +1953,8 @@ export class MainApp extends BaseWebviewApp {
                   @toggle-list=${this.handleComponentToggleList}
                   @add-opened-files=${this.handleComponentAddOpenedFiles}
                   @empty-files=${this.handleComponentEmptyFiles}
-                  @select-multiple-files=${this.handleComponentSelectMultipleFiles}
+                  @select-multiple-files=${this
+                    .handleComponentSelectMultipleFiles}
                   @remove-file=${this.handleComponentRemoveFile}
                   @checkbox-change=${this.handleComponentCheckboxChange}
                   @focus-instruction=${this.handleComponentFocusInstruction}

--- a/src/webview/frontend/MainApp.ts
+++ b/src/webview/frontend/MainApp.ts
@@ -27,11 +27,9 @@ import { designTokens, commonViewStyles, codiconStyles } from '@shared/styles';
 
 // Local imports - shared schemas
 import {
-  MainViewMessageSchema,
-  type MainViewMessage,
-} from '@shared/schemas/mainViewMessages';
-import {
+  mainViewMessages,
   MainViewPersistedStateSchema,
+  type MainViewMessage,
   type MainViewPersistedState,
   type ApiKeyBannerState,
   type AgentConfigBannerState,
@@ -407,7 +405,7 @@ export class MainApp extends BaseWebviewApp {
   }
 
   protected handleMessage(raw: unknown): void {
-    const result = MainViewMessageSchema.safeParse(raw);
+    const result = mainViewMessages.MainViewMessageSchema.safeParse(raw);
     if (!result.success) {
       this.logSchemaError(
         '[MainApp] Main view message validation failed.',
@@ -958,9 +956,7 @@ export class MainApp extends BaseWebviewApp {
       return;
     }
 
-    const parsed = MainViewPersistedStateSchema.partial().safeParse(
-      message.state,
-    );
+    const parsed = MainViewPersistedStateSchema.safeParse(message.state);
     if (!parsed.success) {
       this.logSchemaError(
         '[MainApp] State restore validation failed.',
@@ -968,7 +964,7 @@ export class MainApp extends BaseWebviewApp {
       );
       return;
     }
-    const state = MainViewPersistedStateSchema.parse(parsed.data);
+    const state = parsed.data;
     this.blockSave();
     try {
       this.sessionType = state.sessionType;

--- a/src/webview/frontend/components/BannerGroup.ts
+++ b/src/webview/frontend/components/BannerGroup.ts
@@ -14,25 +14,12 @@ import { when } from 'lit/directives/when.js';
 // Local imports - main view
 import { MainViewEvents } from '../events';
 
-/** State for API key banner */
-export interface ApiKeyBannerState {
-  visible: boolean;
-  provider?: string;
-  requiresKey?: boolean;
-}
-
-/** State for agent config banner */
-export interface AgentConfigBannerState {
-  visible: boolean;
-  agentName?: string;
-  customDirSet?: boolean;
-}
-
-/** State for dependency banner */
-export interface DependencyBannerState {
-  visible: boolean;
-  missingTools?: string[];
-}
+// Local imports - shared schemas
+import type {
+  AgentConfigBannerState,
+  ApiKeyBannerState,
+  DependencyBannerState,
+} from '@shared/schemas';
 
 @customElement('banner-group')
 export class BannerGroup extends LitElement {

--- a/src/webview/frontend/components/FileSelectGroup.ts
+++ b/src/webview/frontend/components/FileSelectGroup.ts
@@ -17,33 +17,9 @@ import { markOptionAsSelected, withPlaceholder } from '@shared/utils/dropdown';
 
 // Local imports - main view
 import { MainViewEvents } from '../events';
-import type { FileType } from '../constants';
 
-/** Configuration for a file select group */
-export interface FileSelectConfig {
-  type: FileType;
-  label: string;
-  icon: string;
-  refreshTitle: string;
-  currentTitle: string;
-  emptyTitle: string;
-  toggleTitle: string;
-  addOpenedLabel: string;
-  emptyListLabel: string;
-  selectListLabel: string;
-  tooltip: string;
-  toolConfig?: 'tool' | 'autoExtract';
-  focusInstruction?: { key: string; text: string };
-}
-
-/** Checkbox values for auto-extract and tool config */
-export interface CheckboxValues {
-  autoExtractFigure: boolean;
-  autoExtractTikzFigure: boolean;
-  autoCompileInputPdf: boolean;
-  attachTeXCount: boolean;
-  attachDiagnostics: boolean;
-}
+// Local imports - shared schemas
+import type { CheckboxValues, FileSelectConfig } from '@shared/schemas';
 
 @customElement('file-select-group')
 export class FileSelectGroup extends LitElement {
@@ -255,9 +231,8 @@ export class FileSelectGroup extends LitElement {
   @state() private toolConfigMenuOpen = false;
 
   /** Document click handler bound to this instance */
-  private readonly boundDocumentClickHandler = this.handleDocumentClick.bind(
-    this,
-  );
+  private readonly boundDocumentClickHandler =
+    this.handleDocumentClick.bind(this);
 
   override connectedCallback(): void {
     super.connectedCallback();
@@ -543,7 +518,9 @@ export class FileSelectGroup extends LitElement {
         <div class="file-select-header">
           <div class="file-select-label-group">
             <vscode-toolbar-button
-              id="refresh${config.type[0].toUpperCase()}${config.type.slice(1)}FileButton"
+              id="refresh${config.type[0].toUpperCase()}${config.type.slice(
+                1,
+              )}FileButton"
               icon=${config.icon}
               label=${config.refreshTitle}
               title=${config.refreshTitle}
@@ -552,25 +529,27 @@ export class FileSelectGroup extends LitElement {
             <label for=${this.selectId} title=${config.tooltip}
               >${config.label}</label
             >
-            ${when(
-              config.toolConfig === 'tool',
-              () => this.renderToolConfigMenu(),
+            ${when(config.toolConfig === 'tool', () =>
+              this.renderToolConfigMenu(),
             )}
-            ${when(
-              config.toolConfig === 'autoExtract',
-              () => this.renderAutoExtractMenu(),
+            ${when(config.toolConfig === 'autoExtract', () =>
+              this.renderAutoExtractMenu(),
             )}
           </div>
           <vscode-toolbar-container class="file-select-actions">
             <vscode-toolbar-button
-              id="current${config.type[0].toUpperCase()}${config.type.slice(1)}FileButton"
+              id="current${config.type[0].toUpperCase()}${config.type.slice(
+                1,
+              )}FileButton"
               icon="file-code"
               label=${config.currentTitle}
               title=${config.currentTitle}
               @click=${this.handleGetCurrentFile}
             ></vscode-toolbar-button>
             <vscode-toolbar-button
-              id="empty${config.type[0].toUpperCase()}${config.type.slice(1)}FileButton"
+              id="empty${config.type[0].toUpperCase()}${config.type.slice(
+                1,
+              )}FileButton"
               icon="close"
               label=${config.emptyTitle}
               title=${config.emptyTitle}
@@ -585,7 +564,9 @@ export class FileSelectGroup extends LitElement {
               <i class="codicon ${chevronClass}"></i>
             </span>
             <vscode-toolbar-button
-              id="addOpened${config.type[0].toUpperCase()}${config.type.slice(1)}FilesButton"
+              id="addOpened${config.type[0].toUpperCase()}${config.type.slice(
+                1,
+              )}FilesButton"
               class="file-action-button"
               icon="folder-opened"
               label=${config.addOpenedLabel}
@@ -593,7 +574,9 @@ export class FileSelectGroup extends LitElement {
               @click=${this.handleAddOpenedFiles}
             ></vscode-toolbar-button>
             <vscode-toolbar-button
-              id="empty${config.type[0].toUpperCase()}${config.type.slice(1)}FilesButton"
+              id="empty${config.type[0].toUpperCase()}${config.type.slice(
+                1,
+              )}FilesButton"
               class="file-action-button"
               icon="trash"
               label=${config.emptyListLabel}
@@ -601,7 +584,9 @@ export class FileSelectGroup extends LitElement {
               @click=${this.handleEmptyFiles}
             ></vscode-toolbar-button>
             <vscode-toolbar-button
-              id="select${config.type[0].toUpperCase()}${config.type.slice(1)}FilesButton"
+              id="select${config.type[0].toUpperCase()}${config.type.slice(
+                1,
+              )}FilesButton"
               class="file-action-button"
               icon="add"
               label=${config.selectListLabel}

--- a/src/webview/frontend/components/InstructionPanel.ts
+++ b/src/webview/frontend/components/InstructionPanel.ts
@@ -18,31 +18,14 @@ import { markOptionAsSelected, withPlaceholder } from '@shared/utils/dropdown';
 import { MainViewEvents } from '../events';
 import { SESSION_TYPES, type SessionType } from '../constants';
 
-/** Session type change event detail */
-export interface SessionTypeChangeDetail {
-  value: string;
-}
-
-/** Agent change event detail */
-export interface AgentChangeDetail {
-  sessionType: SessionType;
-  value: string;
-}
-
-/** Model change event detail */
-export interface ModelChangeDetail {
-  value: string;
-}
-
-/** Instruction change event detail */
-export interface InstructionChangeDetail {
-  value: string;
-}
-
-/** Action event detail */
-export interface ActionDetail {
-  action: string;
-}
+// Local imports - shared schemas
+import type {
+  ActionDetail,
+  AgentChangeDetail,
+  InstructionChangeDetail,
+  ModelChangeDetail,
+  SessionTypeChangeDetail,
+} from '@shared/schemas';
 
 @customElement('instruction-panel')
 export class InstructionPanel extends LitElement {
@@ -213,7 +196,7 @@ export class InstructionPanel extends LitElement {
     return new CustomEvent(type, { detail, bubbles: true, composed: true });
   }
 
-  private handleSessionTypeChange(value: string): void {
+  private handleSessionTypeChange(value: SessionType): void {
     this.dispatchEvent(
       this.createEvent<SessionTypeChangeDetail>('session-type-change', {
         value,
@@ -243,11 +226,15 @@ export class InstructionPanel extends LitElement {
   }
 
   private handleAction(action: string): void {
-    this.dispatchEvent(this.createEvent<ActionDetail>('panel-action', { action }));
+    this.dispatchEvent(
+      this.createEvent<ActionDetail>('panel-action', { action }),
+    );
   }
 
   private handleExecute(): void {
-    this.dispatchEvent(new CustomEvent('execute', { bubbles: true, composed: true }));
+    this.dispatchEvent(
+      new CustomEvent('execute', { bubbles: true, composed: true }),
+    );
   }
 
   private handleAgentSettings(): void {
@@ -263,9 +250,7 @@ export class InstructionPanel extends LitElement {
   }
 
   private handleFocus(key: string, text: string): void {
-    this.dispatchEvent(
-      MainViewEvents.focusInstruction({ key, text }),
-    );
+    this.dispatchEvent(MainViewEvents.focusInstruction({ key, text }));
   }
 
   override render(): TemplateResult {
@@ -308,7 +293,11 @@ export class InstructionPanel extends LitElement {
                 .value=${this.sessionType}
                 @change=${(event: Event) => {
                   const target = event.target as HTMLInputElement | null;
-                  this.handleSessionTypeChange(target?.value ?? '');
+                  const nextValue =
+                    target?.value === SESSION_TYPES.WORKFLOW
+                      ? SESSION_TYPES.WORKFLOW
+                      : SESSION_TYPES.TOOL_USE;
+                  this.handleSessionTypeChange(nextValue);
                 }}
               >
                 <vscode-radio
@@ -427,7 +416,10 @@ export class InstructionPanel extends LitElement {
                       )}
                     @change=${(event: Event) => {
                       const target = event.currentTarget as HTMLInputElement;
-                      this.handleAgentChange(SESSION_TYPES.WORKFLOW, target.value);
+                      this.handleAgentChange(
+                        SESSION_TYPES.WORKFLOW,
+                        target.value,
+                      );
                     }}
                   >
                     ${unsafeHTML(workflowOptions)}
@@ -452,7 +444,10 @@ export class InstructionPanel extends LitElement {
                       )}
                     @change=${(event: Event) => {
                       const target = event.currentTarget as HTMLInputElement;
-                      this.handleAgentChange(SESSION_TYPES.TOOL_USE, target.value);
+                      this.handleAgentChange(
+                        SESSION_TYPES.TOOL_USE,
+                        target.value,
+                      );
                     }}
                   >
                     ${unsafeHTML(toolUseOptions)}

--- a/src/webview/frontend/components/index.ts
+++ b/src/webview/frontend/components/index.ts
@@ -4,15 +4,8 @@
  * Import all components to ensure they are registered with Lit.
  */
 
-export { FileSelectGroup, type FileSelectConfig, type CheckboxValues } from './FileSelectGroup';
-export { BannerGroup, type ApiKeyBannerState, type AgentConfigBannerState, type DependencyBannerState } from './BannerGroup';
+export { FileSelectGroup } from './FileSelectGroup';
+export { BannerGroup } from './BannerGroup';
 export { LatexDiffsSection } from './LatexDiffsSection';
-export {
-  InstructionPanel,
-  type SessionTypeChangeDetail,
-  type AgentChangeDetail,
-  type ModelChangeDetail,
-  type InstructionChangeDetail,
-  type ActionDetail,
-} from './InstructionPanel';
+export { InstructionPanel } from './InstructionPanel';
 export { OutputFilesSection } from './OutputFilesSection';

--- a/src/webview/frontend/constants.ts
+++ b/src/webview/frontend/constants.ts
@@ -1,16 +1,25 @@
+// Local imports - shared schemas
+import {
+  FileTypeSchema,
+  MultipleFileTypeSchema,
+  SessionTypeSchema,
+  type FileType,
+  type MultipleFileType,
+  type SessionType,
+} from '@shared/schemas';
+
+const [toolUseSessionType, workflowSessionType] = SessionTypeSchema.options;
+
 // Local constants - session types
 export const SESSION_TYPES = {
-  TOOL_USE: 'toolUse',
-  WORKFLOW: 'workflow',
+  TOOL_USE: toolUseSessionType,
+  WORKFLOW: workflowSessionType,
 } as const;
 
-export type SessionType = (typeof SESSION_TYPES)[keyof typeof SESSION_TYPES];
+export type { SessionType, FileType, MultipleFileType };
 
-export const FILE_TYPES = ['input', 'reference', 'auxiliary', 'media'] as const;
-export type FileType = (typeof FILE_TYPES)[number];
-
-export const MULTIPLE_FILE_TYPES = [...FILE_TYPES, 'output'] as const;
-export type MultipleFileType = (typeof MULTIPLE_FILE_TYPES)[number];
+export const FILE_TYPES = FileTypeSchema.options;
+export const MULTIPLE_FILE_TYPES = MultipleFileTypeSchema.options;
 
 export const CHECK_BOXES_AUTO_EXTRACT = [
   'autoExtractFigure',

--- a/src/webview/frontend/events.ts
+++ b/src/webview/frontend/events.ts
@@ -4,94 +4,23 @@
  * Both dispatch and handler sides use these types.
  */
 
-import type { FileType, MultipleFileType } from './constants';
-
-// =============================================================================
-// Event Detail Types
-// =============================================================================
-
-/** File select dropdown change */
-export interface FileSelectChangeDetail {
-  type: FileType;
-  value: string;
-}
-
-/** Base file select change */
-export interface BaseFileChangeDetail {
-  value: string;
-}
-
-/** Edited file select change */
-export interface EditedFileChangeDetail {
-  value: string;
-}
-
-/** Single file action (refresh, current, empty) */
-export interface FileActionDetail {
-  type: FileType | 'base' | 'edited';
-}
-
-/** Multiple files action (toggle, select) */
-export interface MultipleFilesActionDetail {
-  listId: string;
-}
-
-/** Multiple files type action (add opened, empty) */
-export interface MultipleFilesTypeActionDetail {
-  type: FileType | MultipleFileType;
-}
-
-/** Remove file from list */
-export interface RemoveFileDetail {
-  listId: string;
-  file: string;
-}
-
-/** Checkbox change */
-export interface CheckboxChangeDetail {
-  id: string;
-  checked: boolean;
-}
-
-/** Banner action */
-export interface BannerActionDetail {
-  action: string;
-  provider?: string;
-  customDirSet?: boolean;
-}
-
-/** Install guide action */
-export interface InstallGuideDetail {
-  tool: string;
-}
-
-/** LaTeXDiffs visibility toggle */
-export interface LatexDiffsToggleDetail {
-  visible: boolean;
-}
-
-/** LaTeXDiffs action (diff, merge, compare, etc.) */
-export interface LatexDiffsActionDetail {
-  action:
-    | 'latexdiff'
-    | 'latexdiffvc'
-    | 'packLatexdiffvc'
-    | 'cleanLatexdiffvc'
-    | 'merge'
-    | 'compare'
-    | 'accept';
-}
-
-/** Commit change */
-export interface CommitChangeDetail {
-  value: string;
-}
-
-/** Focus instruction detail */
-export interface FocusInstructionDetail {
-  key: string;
-  text: string;
-}
+// Local imports - shared schemas
+import type {
+  BaseFileChangeDetail,
+  BannerActionDetail,
+  CheckboxChangeDetail,
+  CommitChangeDetail,
+  EditedFileChangeDetail,
+  FileActionDetail,
+  FileSelectChangeDetail,
+  FocusInstructionDetail,
+  InstallGuideDetail,
+  LatexDiffsActionDetail,
+  LatexDiffsToggleDetail,
+  MultipleFilesActionDetail,
+  MultipleFilesTypeActionDetail,
+  RemoveFileDetail,
+} from '@shared/schemas';
 
 // =============================================================================
 // Event Creators - use these to dispatch typed events

--- a/src/webview/frontend/store.ts
+++ b/src/webview/frontend/store.ts
@@ -4,119 +4,32 @@
  * Centralizes state management concerns for MainApp.
  */
 
+// Local imports - shared schemas
+import {
+  MainViewPersistedStateSchema,
+  type MainViewPersistedState,
+  type FileSelectConfig,
+  type CheckboxValues,
+} from '@shared/schemas';
+
+// Local imports - webview commands
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands';
-import { SESSION_TYPES, type SessionType, type MultipleFileType, type FileType } from './constants';
-
-// =========================================================================
-// State Types
-// =========================================================================
-
-/** Persisted state for MainView across sessions */
-export interface MainViewPersistedState extends Record<string, unknown> {
-  sessionType: SessionType;
-  workflowAgent: string;
-  toolUseAgent: string;
-  model: string;
-  commit: string;
-  instruction: string;
-  inputFile: string;
-  referenceFile: string;
-  auxiliaryFile: string;
-  mediaFile: string;
-  editedFile: string;
-  baseFile: string;
-  inputFiles: string[];
-  referenceFiles: string[];
-  auxiliaryFiles: string[];
-  mediaFiles: string[];
-  outputFiles: string[];
-  inputFilesVisible: boolean;
-  referenceFilesVisible: boolean;
-  auxiliaryFilesVisible: boolean;
-  mediaFilesVisible: boolean;
-  outputFilesVisible: boolean;
-  outputFilesActive: boolean;
-  latexdiffsVisible: boolean;
-  autoExtractFigure: boolean;
-  autoExtractTikzFigure: boolean;
-  autoCompileInputPdf: boolean;
-  attachTeXCount: boolean;
-  attachDiagnostics: boolean;
-  agent: string;
-  isToolUseAgent: boolean;
-  openedFiles?: string[];
-}
-
-/** Banner display state */
-export interface BannerState {
-  visible: boolean;
-  provider?: string;
-  requiresKey?: boolean;
-  agentName?: string;
-  customDirSet?: boolean;
-  missingTools?: string[];
-}
-
-/** Single file selections state */
-export interface SingleFilesState {
-  inputFile: string;
-  referenceFile: string;
-  auxiliaryFile: string;
-  mediaFile: string;
-  baseFile: string;
-  editedFile: string;
-}
-
-/** Checkbox configuration values */
-export interface CheckboxValuesState {
-  autoExtractFigure: boolean;
-  autoExtractTikzFigure: boolean;
-  autoCompileInputPdf: boolean;
-  attachTeXCount: boolean;
-  attachDiagnostics: boolean;
-}
+import {
+  SESSION_TYPES,
+  type SessionType,
+  type MultipleFileType,
+} from './constants';
 
 // =========================================================================
 // Default State
 // =========================================================================
 
 /** Default persisted state values */
-export const DEFAULT_STATE: MainViewPersistedState = {
-  sessionType: SESSION_TYPES.TOOL_USE,
-  workflowAgent: 'correct',
-  toolUseAgent: 'chat',
-  model: 'gemini3p',
-  commit: 'HEAD',
-  instruction: '',
-  inputFile: '',
-  referenceFile: '',
-  auxiliaryFile: '',
-  mediaFile: '',
-  editedFile: '',
-  baseFile: '',
-  inputFiles: [],
-  referenceFiles: [],
-  auxiliaryFiles: [],
-  mediaFiles: [],
-  outputFiles: [],
-  inputFilesVisible: false,
-  referenceFilesVisible: false,
-  auxiliaryFilesVisible: false,
-  mediaFilesVisible: false,
-  outputFilesVisible: false,
-  outputFilesActive: false,
-  latexdiffsVisible: false,
-  autoExtractFigure: false,
-  autoExtractTikzFigure: false,
-  autoCompileInputPdf: false,
-  attachTeXCount: false,
-  attachDiagnostics: false,
-  agent: '',
-  isToolUseAgent: true,
-};
+export const DEFAULT_STATE: MainViewPersistedState =
+  MainViewPersistedStateSchema.parse({});
 
 /** Default single files state */
-export const DEFAULT_SINGLE_FILES: SingleFilesState = {
+export const DEFAULT_SINGLE_FILES = {
   inputFile: DEFAULT_STATE.inputFile,
   referenceFile: DEFAULT_STATE.referenceFile,
   auxiliaryFile: DEFAULT_STATE.auxiliaryFile,
@@ -154,7 +67,7 @@ export const DEFAULT_MULTI_FILES_VISIBLE: Record<string, boolean> = {
 };
 
 /** Default checkbox values */
-export const DEFAULT_CHECKBOX_VALUES: CheckboxValuesState = {
+export const DEFAULT_CHECKBOX_VALUES: CheckboxValues = {
   autoExtractFigure: DEFAULT_STATE.autoExtractFigure,
   autoExtractTikzFigure: DEFAULT_STATE.autoExtractTikzFigure,
   autoCompileInputPdf: DEFAULT_STATE.autoCompileInputPdf,
@@ -212,32 +125,8 @@ export const ONBOARDING_PLACEHOLDERS: Record<SessionType, string[]> = {
   ],
 };
 
-// =========================================================================
-// File Selector Configuration
-// =========================================================================
-
-/** File selector config type (matches FileSelectGroup.ts) */
-export interface FileSelectConfigData {
-  type: FileType;
-  label: string;
-  icon: string;
-  refreshTitle: string;
-  currentTitle: string;
-  emptyTitle: string;
-  toggleTitle: string;
-  addOpenedLabel: string;
-  emptyListLabel: string;
-  selectListLabel: string;
-  tooltip: string;
-  toolConfig?: 'tool' | 'autoExtract';
-  focusInstruction?: {
-    key: string;
-    text: string;
-  };
-}
-
 /** Static configuration for each file selector type */
-export const FILE_SELECT_CONFIGS: ReadonlyArray<FileSelectConfigData> = [
+export const FILE_SELECT_CONFIGS: ReadonlyArray<FileSelectConfig> = [
   {
     type: 'input',
     label: 'Input',
@@ -281,7 +170,8 @@ export const FILE_SELECT_CONFIGS: ReadonlyArray<FileSelectConfigData> = [
     addOpenedLabel: 'Add opened files as auxiliary',
     emptyListLabel: 'Clear all auxiliary files',
     selectListLabel: 'Add auxiliary files',
-    tooltip: 'Files such as .cls/.sty that define document structure and styles',
+    tooltip:
+      'Files such as .cls/.sty that define document structure and styles',
   },
   {
     type: 'media',

--- a/src/webview/managers/DiffManager.ts
+++ b/src/webview/managers/DiffManager.ts
@@ -1,9 +1,21 @@
 // Third-party imports
 import * as vscode from 'vscode';
 
+// Local imports - shared schemas
+import {
+  LatexdiffMessageSchema,
+  LatexdiffvcMessageSchema,
+  LatexdiffvcOperationMessageSchema,
+  RequestRecentCommitsMessageSchema,
+} from '@shared/schemas/mainViewMessages';
+
 // Local imports - webview commands
 import { MAIN_VIEW_COMMANDS } from '@common/webview';
+
+// Local imports - logging
 import * as logger from '@logger/logUtils';
+
+// Local imports - webview managers
 import { BaseWebviewManager } from './BaseWebviewManager';
 
 const CHANNEL = 'DiffManager';
@@ -12,24 +24,45 @@ logger.initialize(CHANNEL);
 export class DiffManager extends BaseWebviewManager {
   protected readonly channel = CHANNEL;
 
-  handleLatexdiff(message: any): void {
-    this.runDiffCommand('latexdiff', message, [
+  handleLatexdiff(message: unknown): void {
+    const parsed = LatexdiffMessageSchema.safeParse(message);
+    if (!parsed.success) {
+      logger.warn(CHANNEL, 'Invalid latexdiff message', {
+        data: parsed.error,
+      });
+      return;
+    }
+    this.runDiffCommand(parsed.data.command, parsed.data, [
       'inputFile',
       'baseFile',
       'editedFile',
     ]);
   }
 
-  handleLatexdiffvc(message: any): void {
-    this.runDiffCommand('latexdiffvc', message, [
+  handleLatexdiffvc(message: unknown): void {
+    const parsed = LatexdiffvcMessageSchema.safeParse(message);
+    if (!parsed.success) {
+      logger.warn(CHANNEL, 'Invalid latexdiffvc message', {
+        data: parsed.error,
+      });
+      return;
+    }
+    this.runDiffCommand(parsed.data.command, parsed.data, [
       'inputFile',
       'baseFile',
       'commitHash',
     ]);
   }
 
-  handleLatexdiffvcOperation(message: any): void {
-    this.runDiffCommand(message.command, message, [
+  handleLatexdiffvcOperation(message: unknown): void {
+    const parsed = LatexdiffvcOperationMessageSchema.safeParse(message);
+    if (!parsed.success) {
+      logger.warn(CHANNEL, 'Invalid latexdiffvc operation message', {
+        data: parsed.error,
+      });
+      return;
+    }
+    this.runDiffCommand(parsed.data.command, parsed.data, [
       'inputFile',
       'baseFile',
       'commitHash',
@@ -39,7 +72,7 @@ export class DiffManager extends BaseWebviewManager {
 
   private runDiffCommand(
     command: string,
-    message: any,
+    message: Record<string, unknown>,
     paramKeys: string[],
   ): void {
     void vscode.commands.executeCommand(
@@ -64,12 +97,19 @@ export class DiffManager extends BaseWebviewManager {
     return { commits, isGitRepo: true };
   }
 
-  async handleRequestRecentCommits(message: any): Promise<void> {
+  async handleRequestRecentCommits(message: unknown): Promise<void> {
+    const parsed = RequestRecentCommitsMessageSchema.safeParse(message);
+    if (!parsed.success) {
+      logger.warn(CHANNEL, 'Invalid request recent commits message', {
+        data: parsed.error,
+      });
+      return;
+    }
     const result = await this._fetchRecentCommits();
 
     // Notify user when empty if requested
     const shouldNotify =
-      message?.notifyWhenEmpty &&
+      parsed.data.notifyWhenEmpty &&
       (result.commits.length === 0 || !result.isGitRepo);
     if (shouldNotify) {
       const infoMessage = result.isGitRepo

--- a/src/webview/managers/DiffManager.ts
+++ b/src/webview/managers/DiffManager.ts
@@ -2,12 +2,7 @@
 import * as vscode from 'vscode';
 
 // Local imports - shared schemas
-import {
-  LatexdiffMessageSchema,
-  LatexdiffvcMessageSchema,
-  LatexdiffvcOperationMessageSchema,
-  RequestRecentCommitsMessageSchema,
-} from '@shared/schemas/mainViewMessages';
+import { mainViewMessages } from '@shared/schemas';
 
 // Local imports - webview commands
 import { MAIN_VIEW_COMMANDS } from '@common/webview';
@@ -25,7 +20,7 @@ export class DiffManager extends BaseWebviewManager {
   protected readonly channel = CHANNEL;
 
   handleLatexdiff(message: unknown): void {
-    const parsed = LatexdiffMessageSchema.safeParse(message);
+    const parsed = mainViewMessages.LatexdiffMessageSchema.safeParse(message);
     if (!parsed.success) {
       logger.warn(CHANNEL, 'Invalid latexdiff message', {
         data: parsed.error,
@@ -40,7 +35,7 @@ export class DiffManager extends BaseWebviewManager {
   }
 
   handleLatexdiffvc(message: unknown): void {
-    const parsed = LatexdiffvcMessageSchema.safeParse(message);
+    const parsed = mainViewMessages.LatexdiffvcMessageSchema.safeParse(message);
     if (!parsed.success) {
       logger.warn(CHANNEL, 'Invalid latexdiffvc message', {
         data: parsed.error,
@@ -55,7 +50,8 @@ export class DiffManager extends BaseWebviewManager {
   }
 
   handleLatexdiffvcOperation(message: unknown): void {
-    const parsed = LatexdiffvcOperationMessageSchema.safeParse(message);
+    const parsed =
+      mainViewMessages.LatexdiffvcOperationMessageSchema.safeParse(message);
     if (!parsed.success) {
       logger.warn(CHANNEL, 'Invalid latexdiffvc operation message', {
         data: parsed.error,
@@ -98,7 +94,8 @@ export class DiffManager extends BaseWebviewManager {
   }
 
   async handleRequestRecentCommits(message: unknown): Promise<void> {
-    const parsed = RequestRecentCommitsMessageSchema.safeParse(message);
+    const parsed =
+      mainViewMessages.RequestRecentCommitsMessageSchema.safeParse(message);
     if (!parsed.success) {
       logger.warn(CHANNEL, 'Invalid request recent commits message', {
         data: parsed.error,

--- a/src/webview/managers/FileManager.ts
+++ b/src/webview/managers/FileManager.ts
@@ -5,6 +5,9 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import { workspace } from 'vscode';
 
+// Local imports - shared utils
+import { normalizeFilePath } from '@shared/utils/path';
+
 // Local imports - webview
 import { getAgent } from '@agent/index';
 import { showLoggedErrorMessage, toErrorMessage } from '@common/errors';
@@ -15,13 +18,18 @@ import {
 } from '@common/files/fileTypeUtils';
 import { fileLister } from '@frontend/files';
 import { selectFiles } from '@frontend/ui/dialogs';
+
+// Local imports - logging
 import * as logger from '@logger/logUtils';
+
+// Local imports - utils
 import {
   WorkspaceFS,
   parseLatexDiffMetadata,
   deriveBaseFileFromLatexDiff,
 } from '@utils/files';
-import { uncapitalize } from '@utils/text/stringUtils';
+
+// Local imports - webview managers
 import { BaseWebviewManager } from './BaseWebviewManager';
 
 // Local imports - types
@@ -47,20 +55,91 @@ type FileUpdateOptions = {
   additionalPayload?: Record<string, unknown>;
 };
 
+const FILE_SELECTION_COMMANDS = new Map<string, string>([
+  [MAIN_VIEW_COMMANDS.SELECT_INPUT_FILE, 'texra.selectInputFile'],
+  [MAIN_VIEW_COMMANDS.SELECT_REFERENCE_FILE, 'texra.selectReferenceFile'],
+  [MAIN_VIEW_COMMANDS.SELECT_AUXILIARY_FILE, 'texra.selectAuxiliaryFile'],
+  [MAIN_VIEW_COMMANDS.SELECT_MEDIA_FILE, 'texra.selectMediaFile'],
+]);
+
+const FILE_SELECTION_RESPONSES = new Map<string, string>([
+  [
+    MAIN_VIEW_COMMANDS.SELECT_INPUT_FILE,
+    MAIN_VIEW_COMMANDS.INPUT_FILE_SELECTED,
+  ],
+  [
+    MAIN_VIEW_COMMANDS.SELECT_REFERENCE_FILE,
+    MAIN_VIEW_COMMANDS.REFERENCE_FILE_SELECTED,
+  ],
+  [
+    MAIN_VIEW_COMMANDS.SELECT_AUXILIARY_FILE,
+    MAIN_VIEW_COMMANDS.AUXILIARY_FILE_SELECTED,
+  ],
+  [
+    MAIN_VIEW_COMMANDS.SELECT_MEDIA_FILE,
+    MAIN_VIEW_COMMANDS.MEDIA_FILE_SELECTED,
+  ],
+]);
+
+const MULTIPLE_FILE_COMMANDS = new Map<
+  string,
+  { selectCommand: string; responseCommand: string }
+>([
+  [
+    'InputFiles',
+    {
+      selectCommand: 'texra.selectInputFiles',
+      responseCommand: MAIN_VIEW_COMMANDS.SET_INPUT_FILES,
+    },
+  ],
+  [
+    'ReferenceFiles',
+    {
+      selectCommand: 'texra.selectReferenceFiles',
+      responseCommand: MAIN_VIEW_COMMANDS.SET_REFERENCE_FILES,
+    },
+  ],
+  [
+    'AuxiliaryFiles',
+    {
+      selectCommand: 'texra.selectAuxiliaryFiles',
+      responseCommand: MAIN_VIEW_COMMANDS.SET_AUXILIARY_FILES,
+    },
+  ],
+  [
+    'MediaFiles',
+    {
+      selectCommand: 'texra.selectMediaFiles',
+      responseCommand: MAIN_VIEW_COMMANDS.SET_MEDIA_FILES,
+    },
+  ],
+  [
+    'OutputFiles',
+    {
+      selectCommand: 'texra.selectOutputFiles',
+      responseCommand: MAIN_VIEW_COMMANDS.SET_OUTPUT_FILES,
+    },
+  ],
+]);
+
 export class FileManager extends BaseWebviewManager {
   protected readonly channel = CHANNEL;
 
   async handleFileSelection(message: FileSelectionMessage): Promise<void> {
+    const executeCommand = FILE_SELECTION_COMMANDS.get(message.command);
+    const responseCommand = FILE_SELECTION_RESPONSES.get(message.command);
     const singleFileType = message.command.replace('select', '');
-    logger.debug(CHANNEL, `Selecting ${singleFileType}`);
+    if (!executeCommand || !responseCommand) {
+      logger.warn(CHANNEL, `Unsupported file command: ${message.command}`);
+      return;
+    }
 
-    const file = await vscode.commands.executeCommand<string>(
-      `texra.${message.command}`,
-    );
+    logger.debug(CHANNEL, `Selecting ${singleFileType}`);
+    const file = await vscode.commands.executeCommand<string>(executeCommand);
     if (file) {
       logger.debug(CHANNEL, `Selected ${singleFileType}: ${file}`);
       this.postMessage({
-        command: `${uncapitalize(singleFileType)}Selected`,
+        command: responseCommand,
         filePath: file,
       });
     }
@@ -174,17 +253,25 @@ export class FileManager extends BaseWebviewManager {
     message: SelectMultipleFilesMessage,
   ): Promise<void> {
     const { fileType, currentFile } = message;
+    const commands = MULTIPLE_FILE_COMMANDS.get(fileType);
+    if (!commands) {
+      logger.warn(CHANNEL, `Unsupported multiple file selection: ${fileType}`);
+      return;
+    }
     try {
       const selectedFiles =
         fileType === 'OutputFiles'
           ? await this.selectOutputFiles(currentFile)
           : await vscode.commands.executeCommand<string[]>(
-              `texra.select${fileType.replace('Files', '')}Files`,
+              commands.selectCommand,
               currentFile,
             );
 
       if (selectedFiles) {
-        this.postMessage({ command: `set${fileType}`, files: selectedFiles });
+        this.postMessage({
+          command: commands.responseCommand,
+          files: selectedFiles,
+        });
       }
     } catch (error) {
       await showLoggedErrorMessage(
@@ -478,7 +565,9 @@ export class FileManager extends BaseWebviewManager {
     // Convert to relative paths and deduplicate
     const relevantFiles = [
       ...new Set(
-        fileUris.map((uri) => workspace.asRelativePath(uri.fsPath, false)),
+        fileUris.map((uri) =>
+          normalizeFilePath(workspace.asRelativePath(uri.fsPath, false)),
+        ),
       ),
     ];
 


### PR DESCRIPTION
### Motivation
- Centralize MainView data contracts with Zod so runtime state/persistence is validated and TypeScript types are derived from a single source of truth.
- Prevent type drift and unsafe casts during cross-webview state restore and message handling by validating payloads at the extension/webview boundary.
- Reduce duplicated interface definitions in the frontend and align MainView with the ProgressView Zod-native pattern described in the PRD.

### Description
- Add shared Zod schemas: `MainViewPersistedStateSchema` and UI/event schemas in `src/shared/schemas/mainViewState.ts` and `src/shared/schemas/mainViewEvents.ts` and export them from `src/shared/schemas/index.ts`.
- Use typed, validated state for restore flows by updating `StateRestoreMessageSchema`, implementing a `buildMainViewState` conversion for `TaskState` in `src/commands/history/stateRestoreCommand.ts`, validating pending payloads in `MainViewProvider`, and switching `WebviewStateManager` to optionally accept a schema for safe parse.
- Harden frontend and managers: `MainApp` now reads/validates `MainViewPersistedStateSchema` on restore and via `WebviewStateManager`, `DiffManager` and `FileManager` validate incoming messages and use whitelisted VS Code command mappings, and many MainView components import shared types instead of local interfaces.
- Replace single global pending-state with a queue in `src/common/state/pendingStateManager.ts` and stream queued restores to the webview; add path normalization helper `normalizeFilePath` and wiring to use it for opened file lists.

### Testing
- Ran `npm run format` which completed successfully.
- Built bundles with `npm run compile` and `npm run compile:fast` (esbuild + vite webviews); builds completed (webpack/vite runs finished with the normal single warning content), indicating compilation succeeded.
- Ran `npm run lint`; linter completed with only warnings (no errors) from existing code paths, so CI-style checks pass but some non-blocking warnings remain.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69775f47ff748324becf48c5b83865c1)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Centralizes MainView contracts in shared Zod schemas and enforces runtime validation across extension ↔ webview boundaries.
> 
> - Introduces `MainViewPersistedStateSchema`, event/message schemas, and exports via `@shared/schemas`; frontend components now import shared types
> - Validates state restore: `StateRestoreMessageSchema` tightened; `MainViewProvider` loops and validates queued restores; `WebviewStateManager` accepts optional schema; new `buildMainViewState` converts `TaskState`→`MainViewPersistedState`
> - Replaces single pending-state with a bounded FIFO queue in `pendingStateManager`
> - Hardens managers: `DiffManager` and `FileManager` parse incoming messages with shared schemas and use whitelisted VS Code command mappings
> - Frontend `MainApp` validates all messages and restore payloads, simplifies `SET_ALL_SINGLE_FILES` handling, and uses schema-typed state throughout
> - Adds `normalizeFilePath` and applies to opened file detection; minor typing cleanups (`unknown` in handlers)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 10fbdf65281fdb9b37bd213dad5fde9af61b2a43. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->