### PR TITLE
fix: restore Lit migration UI styles

### DIFF
--- a/src/historyView/frontend/styles.ts
+++ b/src/historyView/frontend/styles.ts
@@ -5,17 +5,15 @@ export const historyViewStyles: CSSResult = css`
   .search-container {
     display: flex;
     align-items: center;
-    gap: var(--spacing-small);
-    margin-bottom: var(--spacing-medium);
-    padding: var(--spacing-small);
-    border: var(--border-thin) solid var(--color-border);
-    border-radius: var(--border-radius);
-    background: var(--vscode-editor-background);
+    margin-bottom: var(--spacing-xlarge);
+    gap: var(--spacing-medium);
+    width: 100%;
   }
 
   .search-input {
     flex: 1;
-    width: 100%;
+    padding: var(--spacing-medium);
+    font-size: var(--font-size);
   }
 
   .search-controls {
@@ -25,14 +23,17 @@ export const historyViewStyles: CSSResult = css`
   }
 
   .search-nav-btn {
-    flex-shrink: 0;
+    min-width: var(--height-button);
+    height: var(--height-button);
+    padding: 0;
+    font-size: var(--font-size);
   }
 
   .match-count {
     font-size: var(--font-size-sm);
     color: var(--color-text-secondary);
-    min-width: 40px;
-    text-align: right;
+    min-width: calc(var(--height-button) * 2);
+    text-align: center;
   }
 
   .history-container {
@@ -45,18 +46,26 @@ export const historyViewStyles: CSSResult = css`
     margin-bottom: var(--spacing-small);
   }
 
+  .button-clear {
+    margin-bottom: var(--spacing-small);
+    padding: var(--spacing-tiny) var(--spacing-small);
+  }
+
   .history-details {
     display: grid;
-    grid-template-columns: max-content 1fr;
-    gap: var(--spacing-small) var(--spacing-medium);
-    margin-top: var(--spacing-small);
+    grid-template-columns: 100px 1fr;
+    gap: var(--spacing-small);
+    margin-top: var(--spacing-medium);
   }
 
   .history-label {
-    font-weight: 600;
+    font-weight: bold;
+    color: var(--vscode-editor-foreground);
   }
 
   .history-value {
+    color: var(--vscode-editor-foreground);
+    padding: var(--spacing-small) 0;
     word-break: break-word;
   }
 
@@ -69,6 +78,10 @@ export const historyViewStyles: CSSResult = css`
     color: var(--vscode-list-activeSelectionForeground);
   }
 
+  .history-item {
+    margin-bottom: var(--spacing-medium);
+  }
+
   .history-actions {
     display: flex;
     gap: var(--spacing-small);
@@ -76,31 +89,36 @@ export const historyViewStyles: CSSResult = css`
 
   .history-timestamp {
     font-size: var(--font-size-sm);
+    margin-bottom: var(--spacing-small);
   }
 
   .history-none {
-    opacity: 0.8;
+    color: var(--color-text-secondary);
+    font-style: italic;
   }
 
   .config-section {
     display: flex;
     flex-direction: column;
-    gap: var(--spacing-tiny);
-    background-color: var(--vscode-editor-background);
-    padding: var(--spacing-small);
+    gap: var(--spacing-small);
+    background-color: var(--vscode-editor-inactiveSelectionBackground);
+    padding: var(--spacing-medium);
     border-radius: var(--border-radius);
-    margin-top: var(--spacing-small);
+    margin: var(--spacing-medium) 0;
   }
 
   .config-item {
     display: flex;
-    gap: var(--spacing-small);
+    gap: var(--spacing-medium);
+    align-items: baseline;
   }
 
   .config-key {
-    font-weight: 600;
+    font-weight: 500;
     color: var(--vscode-editorInfo-foreground);
-    min-width: 80px;
+    min-width: calc(
+      var(--width-button-min) + var(--spacing-xlarge) + var(--spacing-xlarge)
+    );
   }
 
   .config-value {
@@ -110,45 +128,49 @@ export const historyViewStyles: CSSResult = css`
 
   .badge {
     display: inline-block;
-    padding: 2px 6px;
-    border-radius: 10px;
-    font-size: 11px;
+    padding: var(--spacing-tiny) var(--spacing-small);
+    border-radius: var(--border-radius);
+    font-size: var(--font-size-sm);
     font-weight: 500;
   }
 
   .agent-category-badge {
     display: inline-flex;
     align-items: center;
-    gap: var(--spacing-tiny);
+    gap: var(--spacing-small);
   }
 
   .agent-category-badge .codicon {
-    font-size: 12px;
+    font-size: var(--font-size-sm);
   }
 
   .category-workflow {
-    background-color: var(--vscode-editorInfo-background);
-    color: var(--vscode-editorInfo-foreground);
+    background-color: var(
+      --vscode-editorInfo-background,
+      rgba(0, 127, 212, 0.15)
+    );
+    color: var(--vscode-editorInfo-foreground, #3794ff);
   }
 
   .category-tool-use {
-    background-color: var(--vscode-editorWarning-background);
-    color: var(--vscode-editorWarning-foreground);
+    background-color: var(
+      --vscode-editorWarning-background,
+      rgba(255, 204, 0, 0.15)
+    );
+    color: var(--vscode-editorWarning-foreground, #cca700);
   }
 
   mark {
     background-color: var(
       --vscode-editor-findMatchHighlightBackground,
-      #ffd33d
+      #ffef0b80
     );
-    color: var(--vscode-editor-findMatchHighlightForeground, inherit);
-    padding: 0 2px;
-    border-radius: 2px;
+    padding: 0;
+    border-radius: var(--border-radius-small);
   }
 
   mark.current-match {
-    background-color: var(--vscode-editor-findMatchBackground, #ffdf5d);
-    color: var(--vscode-editor-findMatchForeground, inherit);
-    outline: 1px solid var(--vscode-editor-findMatchBorder, transparent);
+    background-color: var(--vscode-editor-findMatchBackground, #ff8b0088);
+    outline: var(--border-thin) solid var(--vscode-focusBorder);
   }
 `;

--- a/src/profileView/frontend/styles.ts
+++ b/src/profileView/frontend/styles.ts
@@ -213,6 +213,7 @@ export const profileViewStyles: CSSResult = css`
 
   .option-title {
     font-weight: 600;
+    color: var(--vscode-foreground);
   }
 
   .option-description {

--- a/src/progressView/frontend/components/FollowUpInput.ts
+++ b/src/progressView/frontend/components/FollowUpInput.ts
@@ -68,9 +68,10 @@ export class FollowUpInput extends LitElement {
       overflow-y: auto;
     }
 
-    .follow-up-actions {
+    .follow-up-actions,
+    vscode-toolbar-container.follow-up-actions {
       display: flex;
-      flex-direction: column;
+      flex-direction: column !important;
       align-items: center;
       gap: var(--spacing-small);
     }

--- a/src/progressView/styles/logs.css
+++ b/src/progressView/styles/logs.css
@@ -69,6 +69,81 @@ follow-up-input {
   overflow: visible;
 }
 
+/* Light DOM formatter styles */
+.file-list-content {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.file-list-content .file-var {
+  color: var(--color-text-secondary);
+  opacity: 0.8;
+  font-size: 0.9em;
+  margin-left: var(--spacing-tiny);
+}
+
+.file-list-content .file-source {
+  color: var(--color-text-secondary);
+  opacity: 0.6;
+  font-size: 0.85em;
+  font-style: italic;
+}
+
+.xml-link-container {
+  margin-top: var(--spacing-small);
+  padding-top: var(--spacing-small);
+  border-top: var(--border-thin) solid var(--vscode-widget-border);
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--spacing-small);
+}
+
+.xml-link-container .codicon {
+  opacity: var(--opacity-subtle);
+}
+
+.xml-link-container .document-tag {
+  color: var(--color-text-secondary);
+  opacity: 0.8;
+  font-style: italic;
+}
+
+.xml-link-container .xml-fix-hint {
+  flex-basis: 100%;
+  margin-top: var(--spacing-tiny);
+  color: var(--color-text-secondary);
+  font-size: 0.9em;
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-tiny);
+}
+
+.xml-link-container .xml-fix-hint .codicon {
+  opacity: 1;
+  color: var(--color-text-link);
+}
+
+.xml-link-container .xml-fix-hint strong {
+  color: var(--color-text-link);
+}
+
+.detail-item {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-small);
+}
+
+.file-link {
+  color: var(--color-text-link);
+  cursor: pointer;
+}
+
+.file-link:hover {
+  text-decoration: underline;
+}
+
 .banner-content-copy {
   min-width: 0;
   padding: 0 var(--spacing-tiny);

--- a/src/webview/frontend/components/FileSelectGroup.ts
+++ b/src/webview/frontend/components/FileSelectGroup.ts
@@ -32,6 +32,10 @@ export class FileSelectGroup extends LitElement {
       margin-bottom: var(--spacing-large);
     }
 
+    .file-select:has(.optional-label) {
+      margin-bottom: var(--spacing-tiny);
+    }
+
     .file-select-header {
       display: flex;
       justify-content: space-between;
@@ -56,8 +60,19 @@ export class FileSelectGroup extends LitElement {
       opacity: 1;
     }
 
+    .file-select-header > vscode-toolbar-button {
+      opacity: 1;
+      flex-shrink: 0;
+    }
+
     .file-select-label-group label {
       margin-right: var(--spacing-small);
+    }
+
+    .file-select-label-group vscode-textfield {
+      flex: 1;
+      min-width: 0;
+      margin: 0;
     }
 
     .file-select-actions,
@@ -83,8 +98,23 @@ export class FileSelectGroup extends LitElement {
       display: none;
     }
 
+    .file-select[data-expanded='true'] .optional-label {
+      color: var(--vscode-foreground);
+    }
+
     .file-select[data-expanded='true'] .toggle-icon {
       color: var(--vscode-foreground);
+    }
+
+    .optional-label {
+      color: var(--text-color);
+      font-weight: normal;
+      font-size: var(--font-size);
+      white-space: nowrap;
+      min-width: calc(var(--width-button-min) * 2);
+      display: flex;
+      align-items: center;
+      height: var(--height-control);
     }
 
     .toggle-icon {

--- a/src/webview/frontend/components/InstructionPanel.ts
+++ b/src/webview/frontend/components/InstructionPanel.ts
@@ -105,6 +105,17 @@ export class InstructionPanel extends LitElement {
       gap: var(--spacing-tiny);
     }
 
+    .select-group .codicon {
+      margin-right: var(--spacing-small);
+      color: var(--text-color);
+      vertical-align: text-bottom;
+    }
+
+    .select-group vscode-single-select {
+      min-width: 6rem;
+      max-width: 10rem;
+    }
+
     .agent-select-group {
       flex: 1;
       min-width: 0;
@@ -112,12 +123,15 @@ export class InstructionPanel extends LitElement {
 
     .agent-select-controls {
       flex: 1;
-      min-width: 0;
+      min-width: 10rem;
+      max-width: 14rem;
     }
 
     .agent-select-dropdowns {
       position: relative;
       width: 100%;
+      min-width: 10rem;
+      max-width: 14rem;
     }
 
     .agent-select {
@@ -138,6 +152,27 @@ export class InstructionPanel extends LitElement {
 
     .clickable:hover {
       color: var(--vscode-foreground);
+    }
+
+    .codicon.clickable:hover {
+      color: var(--button-hover-background);
+    }
+
+    vscode-option {
+      font-family: var(--vscode-font-family);
+    }
+
+    vscode-option.disabled-option,
+    vscode-option.disabled-model,
+    vscode-option.disabled-agent,
+    vscode-option[data-requires-key='true'] {
+      color: var(--color-text-secondary);
+      opacity: var(--opacity-subtle);
+      font-style: italic;
+    }
+
+    vscode-option[data-tool-use='true'] {
+      font-style: italic;
     }
 
     .recording {

--- a/src/webview/frontend/components/OutputFilesSection.ts
+++ b/src/webview/frontend/components/OutputFilesSection.ts
@@ -79,6 +79,10 @@ export class OutputFilesSection extends LitElement {
       font-weight: normal;
       font-size: var(--font-size);
       white-space: nowrap;
+      min-width: calc(var(--width-button-min) * 2);
+      display: flex;
+      align-items: center;
+      height: var(--height-control);
     }
 
     .multiple-files-container {

--- a/src/webview/frontend/store.ts
+++ b/src/webview/frontend/store.ts
@@ -112,18 +112,18 @@ export const FILE_SELECTED_COMMANDS: Record<string, string> = {
 export const PLACEHOLDER_ROTATION_MS = 12000;
 
 /** Onboarding placeholder texts by session type */
-export const ONBOARDING_PLACEHOLDERS: Record<SessionType, string[]> = {
-  [SESSION_TYPES.WORKFLOW]: [
+export const ONBOARDING_PLACEHOLDERS = {
+  workflow: [
     'Correct LaTeX errors, tighten language, and keep math notation intact.',
     'Convert this section into Beamer slides with bullet points.',
     'Derive the gradient of the loss function step by step.',
   ],
-  [SESSION_TYPES.TOOL_USE]: [
+  toolUse: [
     'Find missing citations, then suggest BibTeX entries.',
     'Scan for TODOs and draft fixes with file paths.',
     'Run LaTeX checks and report compilation warnings.',
   ],
-};
+} satisfies Record<SessionType, string[]>;
 
 /** Static configuration for each file selector type */
 export const FILE_SELECT_CONFIGS: ReadonlyArray<FileSelectConfig> = [


### PR DESCRIPTION
### Motivation
- Address UI regressions introduced by the Lit migration where deleted external CSS stopped applying to Shadow DOM and Light DOM-generated HTML, causing layout and visual inconsistencies in MainView, HistoryView, ProfileView, and ProgressView.
- Ensure important UX affordances (dropdown sizing, icon hover color, optional labels, and Light DOM formatter styles) are restored without large refactors.

### Description
- Restored select and dropdown constraints, codicon spacing/hover rules, and `vscode-option` state styles inside `InstructionPanel` to fix agent/model dropdown sizing and hover colors (`src/webview/frontend/components/InstructionPanel.ts`).
- Added `.optional-label` and related header/toolbar rules to `FileSelectGroup` and `OutputFilesSection` so optional labels, list layouts, and toolbar buttons align with design tokens (`src/webview/frontend/components/FileSelectGroup.ts`, `src/webview/frontend/components/OutputFilesSection.ts`).
- Reinstated follow-up actions selector variant and `!important` flex-direction, and tuned history/profile view tokens to restore spacing, grid, badges, and mark highlight styles (`src/progressView/frontend/components/FollowUpInput.ts`, `src/historyView/frontend/styles.ts`, `src/profileView/frontend/styles.ts`).
- Added Light DOM formatter styles used by progress view formatters (file lists, xml-link containers, file-link/detail-item rules) into `src/progressView/styles/logs.css` and tightened onboarding placeholder typing in `src/webview/frontend/store.ts` to satisfy `Record<SessionType, string[]>`.

### Testing
- Ran `npm run format` which completed successfully and formatted sources. (succeeded)
- Ran `npm run compile` and confirmed the project builds; webpack emitted a single warning about `nunjucks` dynamic require but compilation completed successfully. (compiled with 1 warning)
- Ran `npm run lint` which finished with non-failing warnings (no errors). (succeeded with warnings)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697789a1f7f08324b5a90840633acb28)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Restores UI consistency and affordances lost during the Lit migration with focused style updates and minor typing adjustments.
> 
> - InstructionPanel: reintroduces dropdown size limits, icon spacing/hover colors, and `vscode-option` disabled/requires-key states
> - FileSelectGroup/OutputFilesSection: adds `optional-label` styling, header/toolbar alignment, input/textfield sizing, and column layout fixes
> - FollowUpInput: ensures follow-up actions layout (including toolbar container variant) with column direction enforced
> - History/Profile styles: restores spacing, grid, labels/badges, timestamps, and `mark` highlight tokens
> - ProgressView logs.css: adds Light DOM formatter styles for file lists, XML link container, links, and detail items
> - store.ts: tightens `ONBOARDING_PLACEHOLDERS` typing with `satisfies Record<SessionType, string[]>`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 495d3def055284fb292bd93e96199ed1e70877e2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->