### PR TITLE
feat(lean): expose goal completion state in lean_inspect

### DIFF
--- a/src/tools/lean/LspTools.ts
+++ b/src/tools/lean/LspTools.ts
@@ -378,7 +378,7 @@ Types:
 
 Goal results include a goalState payload with:
 - count: number of goals
-- isComplete: true when count is 0 (proof complete at that position)
+- status: "noGoals" when count is 0 (proof may be complete, or cursor may be outside a tactic block), "open" when goals remain
 - goals: raw goal list from Lean
 
 Line and column are 1-indexed.
@@ -435,7 +435,7 @@ Requires: Lean 4 VS Code extension installed and active.`,
       return {
         summary: 'No goals',
         output: 'No goals at this position. The proof may be complete here.',
-        goalState: { goals: [], count: 0, isComplete: true },
+        goalState: { goals: [], count: 0, status: 'noGoals' as const },
       };
     }
 
@@ -443,7 +443,7 @@ Requires: Lean 4 VS Code extension installed and active.`,
     return {
       summary: `${goalCount} goal${goalCount > 1 ? 's' : ''}`,
       output: data.rendered,
-      goalState: { goals: data.goals, count: goalCount, isComplete: false },
+      goalState: { goals: data.goals, count: goalCount, status: 'open' as const },
     };
   }
 

--- a/src/tools/lean/LspTools.ts
+++ b/src/tools/lean/LspTools.ts
@@ -376,6 +376,11 @@ Types:
 - "term_goal": Get expected type at cursor in term mode
 - "hover": Get type signature and documentation for an identifier
 
+Goal results include a goalState payload with:
+- count: number of goals
+- isComplete: true when count is 0 (proof complete at that position)
+- goals: raw goal list from Lean
+
 Line and column are 1-indexed.
 
 Requires: Lean 4 VS Code extension installed and active.`,
@@ -430,6 +435,7 @@ Requires: Lean 4 VS Code extension installed and active.`,
       return {
         summary: 'No goals',
         output: 'No goals at this position. The proof may be complete here.',
+        goalState: { goals: [], count: 0, isComplete: true },
       };
     }
 
@@ -437,7 +443,7 @@ Requires: Lean 4 VS Code extension installed and active.`,
     return {
       summary: `${goalCount} goal${goalCount > 1 ? 's' : ''}`,
       output: data.rendered,
-      goalState: { goals: data.goals, count: goalCount },
+      goalState: { goals: data.goals, count: goalCount, isComplete: false },
     };
   }
 


### PR DESCRIPTION
### Motivation
- Give agents a reliable way to detect when a Lean proof is complete at a cursor position instead of inferring completion from the absence of warnings.

### Description
- Add an explicit `goalState` payload to `lean_inspect` goal results (`src/tools/lean/LspTools.ts`) containing `count`, `isComplete`, and `goals`, and document the new payload in the tool description; `isComplete` is set to `true` when `count` is `0`.

### Testing
- Ran `npm run format` (succeeded), `npm run compile` (succeeded, emitted a webpack warning about nunjucks), and `npm run lint` (succeeded with existing warnings but no errors).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978fda7149083248d2eea7b795e2e3b)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds/changes the structured output shape for `lean_inspect` goal results, which may affect downstream consumers that assume the prior `goalState` fields or absence of `goalState` on zero-goal responses.
> 
> **Overview**
> `lean_inspect` "goal" responses now always include a `goalState` payload that reports goal `count`, raw `goals`, and an explicit `status` (`noGoals` vs `open`) so callers can detect when no goals remain without inferring from rendered output.
> 
> The tool description is updated to document the new `goalState` fields, and the zero-goal path now returns `goalState` instead of only a message.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1372c499328dac1615183ae0ca9548ae0bfff2c1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->