### PR TITLE
fix: restore permission action clicks

### DIFF
--- a/src/progressView/frontend/components/RequestPanels.ts
+++ b/src/progressView/frontend/components/RequestPanels.ts
@@ -613,13 +613,7 @@ export class RequestPanels extends LitElement {
 
   private handleActionClick = (event: MouseEvent): void => {
     // Use composedPath to get the actual clicked element inside shadow DOM
-    const path = event.composedPath();
-    const target = path[0] as Element | null;
-    if (!target) return;
-
-    const actionEl = target.closest<HTMLElement>(
-      '[data-action][data-permission-kind][data-permission-id]',
-    );
+    const actionEl = this.getActionElement(event.composedPath());
     if (!actionEl) return;
 
     const action = actionEl.dataset.action;
@@ -662,21 +656,26 @@ export class RequestPanels extends LitElement {
    */
   private handleKeydown = (event: KeyboardEvent): void => {
     // Use composedPath to get the actual element inside shadow DOM
-    const path = event.composedPath();
-    const target = path[0] as Element | null;
-    if (!target) return;
+    if (event.key !== 'Enter' && event.key !== ' ') return;
 
-    // Handle Enter/Space on buttons
-    if (event.key === 'Enter' || event.key === ' ') {
-      const actionEl = target.closest<HTMLElement>(
-        '[data-action][data-permission-kind][data-permission-id]',
-      );
-      if (actionEl) {
-        event.preventDefault();
-        actionEl.click();
+    const actionEl = this.getActionElement(event.composedPath());
+    if (!actionEl) return;
+
+    event.preventDefault();
+    actionEl.click();
+  };
+
+  private getActionElement(path: EventTarget[]): HTMLElement | null {
+    for (const entry of path) {
+      if (!(entry instanceof HTMLElement)) continue;
+      if (
+        entry.matches('[data-action][data-permission-kind][data-permission-id]')
+      ) {
+        return entry;
       }
     }
-  };
+    return null;
+  }
 
   /**
    * Handle global keyboard shortcuts for permission actions.


### PR DESCRIPTION
### Motivation

- Permission approve/reject buttons and Enter/Space activation stopped working when toolbar buttons rendered inside shadow DOM, causing the approval/reject UI to be non-responsive.
- Restore the expected click/keyboard behavior in the progress view permission panels to match the UI behavior from main.

### Description

- Updated `src/progressView/frontend/components/RequestPanels.ts` to locate action buttons by scanning the composed event path via a new helper `getActionElement(path: EventTarget[])` so elements inside shadow DOM are correctly found.
- Reused the same lookup from the `handleKeydown` handler so Enter/Space activation maps to the same elements and calls `.click()` consistently.

### Testing

- Ran `npm run format` which completed successfully.
- Ran `npm run compile` which failed in this environment due to missing dev environment modules (`style-loader` and `mark.js`).
- Ran `npm run lint` which completed with warnings (no errors) and reported lint warnings in several files including the modified `RequestPanels.ts`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69793bf79fe8832499d19f4b1f79aeb9)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Restores permission button interactions when elements render inside shadow DOM.
> 
> - Replaces ad-hoc target lookup with `getActionElement(path)` that scans `event.composedPath()` for `[data-action][data-permission-kind][data-permission-id]`
> - Updates `handleActionClick` and `handleKeydown` to use the helper; `handleKeydown` now early-returns unless `Enter`/` ` and triggers `.click()` consistently
> - Minor refactor for readability without altering other behaviors
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e38bd3e094ee3afc5faf2171c8ee9ba7d0fc8983. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->