### PR TITLE
fix: guard progress view persistence and fix model index exports

### DIFF
--- a/src/model/index.ts
+++ b/src/model/index.ts
@@ -4,9 +4,9 @@ export {
   ReasoningEffort,
   DEFAULT_CONTEXT_WINDOW,
   DEFAULT_MODEL_CAPABILITIES,
-} from './ModelConfig.js';
-export type { ModelConfig, ModelCapabilities } from './ModelConfig.js';
+} from './ModelConfig';
+export type { ModelConfig, ModelCapabilities } from './ModelConfig';
 
 // ToolDefinition - schema, type, and utilities
-export { ToolDefinitionSchema, hasZodSchema } from './ToolDefinition.js';
-export type { ToolDefinition } from './ToolDefinition.js';
+export { ToolDefinitionSchema, hasZodSchema } from './ToolDefinition';
+export type { ToolDefinition } from './ToolDefinition';

--- a/src/progressView/persistence/PersistentMapManager.ts
+++ b/src/progressView/persistence/PersistentMapManager.ts
@@ -94,13 +94,16 @@ export abstract class PersistentMapManager<K extends string, V> {
 
   /** Load state from persistence */
   async load(): Promise<void> {
-    const saved = this.storage.get<Record<string, unknown>>(
+    const saved = this.storage.get<Record<string, unknown> | null>(
       this.storageKey,
       {},
     );
 
-    if (Object.keys(saved).length > 0) {
-      await this.populateFromRecord(saved);
+    const record =
+      saved && typeof saved === 'object' && !Array.isArray(saved) ? saved : {};
+
+    if (Object.keys(record).length > 0) {
+      await this.populateFromRecord(record);
     } else {
       this.items.clear();
     }


### PR DESCRIPTION
### Motivation
- Prevent activation-time crash caused by attempting `Object.keys`/`Object.entries` on a `null` persisted record when loading progress view state. 
- Align model re-exports with TypeScript/module resolution so the bundler doesn't fail resolving `.js` suffixed imports.

### Description
- Normalize persisted storage value in `src/progressView/persistence/PersistentMapManager.ts` by accepting `null` and coercing to an empty record before calling `Object.keys`/`Object.entries` to avoid runtime exceptions. 
- Update `src/model/index.ts` to re-export from `./ModelConfig` and `./ToolDefinition` (remove `.js` suffix) and keep type exports consistent with TypeScript resolution.

### Testing
- Ran `npm run format` which completed successfully. 
- Ran `npm run compile` (webpack) which completed successfully but emitted a non-blocking warning about a dynamic dependency in `nunjucks`. 
- Ran `npm run lint` which finished with warnings (no errors) related to existing style/eqeqeq and import ordering rules.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a0842afd8832487037329ab771859)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents crashes on loading progress view state and aligns model exports with TS resolution.
> 
> - In `PersistentMapManager.load`, accept `null` from storage, coerce to an empty record, and only call `populateFromRecord` when the normalized `record` has keys; otherwise clear items
> - Update `src/model/index.ts` to re-export from `./ModelConfig` and `./ToolDefinition` without the `.js` suffix, keeping type exports consistent
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 021fbbbcbafde577d633d8dac50b4b47bfab4d70. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->