### PR TITLE
feat: add unified PersistedState abstraction for frontend and backend

### DIFF
--- a/src/common/modules/persistedState.js
+++ b/src/common/modules/persistedState.js
@@ -1,0 +1,116 @@
+// @ts-check
+import { vscode } from '@common/webviewContext.js';
+
+/**
+ * @template T
+ * @typedef {import('zod').ZodType<T>} ZodType
+ */
+
+/**
+ * Manages persistence of a typed state object with Zod schema validation.
+ *
+ * Works with vscode.getState/setState for webview state persistence.
+ * Uses Zod schemas for validation and default values via `.catch()`.
+ *
+ * @template {Record<string, unknown>} T
+ *
+ * @example
+ * import { z } from 'zod';
+ *
+ * const PrefsSchema = z.object({
+ *   filter: z.string().catch('all'),
+ *   sort: z.string().catch('time'),
+ * });
+ *
+ * const prefs = new PersistedState('prefs', PrefsSchema);
+ * console.log(prefs.get('filter')); // 'all' (default)
+ * prefs.update({ filter: 'active' });
+ */
+export class PersistedState {
+  /** @type {T} */
+  #state;
+
+  /** @type {string} */
+  #key;
+
+  /** @type {ZodType<T>} */
+  #schema;
+
+  /**
+   * @param {string} key - Storage key for this state
+   * @param {ZodType<T>} schema - Zod schema with .catch() for defaults
+   */
+  constructor(key, schema) {
+    this.#key = key;
+    this.#schema = schema;
+    this.#state = this.#load();
+  }
+
+  /**
+   * Load state from storage with schema validation.
+   * @returns {T}
+   */
+  #load() {
+    const allState = vscode.getState() || {};
+    const saved = allState[this.#key];
+    return this.#schema.parse(saved);
+  }
+
+  /**
+   * Save state to storage.
+   */
+  #save() {
+    const allState = vscode.getState() || {};
+    vscode.setState({ ...allState, [this.#key]: this.#state });
+  }
+
+  /**
+   * Get current state (shallow copy).
+   * @returns {T}
+   */
+  getState() {
+    return { ...this.#state };
+  }
+
+  /**
+   * Get a single field.
+   * @template {keyof T} K
+   * @param {K} field
+   * @returns {T[K]}
+   */
+  get(field) {
+    return this.#state[field];
+  }
+
+  /**
+   * Replace entire state.
+   * @param {T} state
+   */
+  setState(state) {
+    this.#state = { ...state };
+    this.#save();
+  }
+
+  /**
+   * Partial update (merge).
+   * @param {Partial<T>} partial
+   */
+  update(partial) {
+    this.setState({ ...this.#state, ...partial });
+  }
+
+  /**
+   * Reset to schema defaults (by parsing undefined).
+   */
+  reset() {
+    this.#state = this.#schema.parse(undefined);
+    this.#save();
+  }
+
+  /**
+   * Reload from storage (useful after external changes).
+   */
+  reload() {
+    this.#state = this.#load();
+  }
+}

--- a/src/common/state/PersistedState.ts
+++ b/src/common/state/PersistedState.ts
@@ -1,0 +1,127 @@
+import { z } from 'zod';
+
+/**
+ * Generic storage interface that works for both:
+ * - Backend: vscode.Memento (workspace/global state)
+ * - Frontend: vscode.getState()/setState() (webview state)
+ */
+export interface StateStorage {
+  get<T>(key: string): T | undefined;
+  get<T>(key: string, defaultValue: T): T;
+  update(key: string, value: unknown): void | Thenable<void>;
+}
+
+/**
+ * Single-key storage adapter for webview state (vscode.getState/setState).
+ * Stores all state under one key since webview state is already scoped.
+ */
+export interface SingleKeyStorage {
+  getState(): unknown;
+  setState(value: unknown): void;
+}
+
+/**
+ * Adapts SingleKeyStorage (webview) to StateStorage interface.
+ * All keys share the same underlying state object.
+ */
+export function createWebviewStorageAdapter(
+  storage: SingleKeyStorage,
+): StateStorage {
+  return {
+    get<T>(key: string, defaultValue?: T): T | undefined {
+      const state = (storage.getState() as Record<string, unknown>) ?? {};
+      const value = state[key];
+      return value !== undefined ? (value as T) : defaultValue;
+    },
+    update(key: string, value: unknown): void {
+      const state = (storage.getState() as Record<string, unknown>) ?? {};
+      storage.setState({ ...state, [key]: value });
+    },
+  };
+}
+
+/**
+ * Manages persistence of a typed state object with Zod schema validation.
+ *
+ * Works with both backend (vscode.Memento) and frontend (vscode.getState/setState)
+ * storage through the common StateStorage interface.
+ *
+ * Features:
+ * - Zod schema validation on load with `.catch()` for defaults
+ * - Type-safe get/set/update operations
+ * - Supports legacy format migration via union schemas
+ *
+ * @example
+ * // Backend usage (workspace state)
+ * const prefs = new PersistedState(
+ *   workspaceSM,
+ *   'texra.viewPrefs',
+ *   z.object({
+ *     sortOrder: z.string().catch('time'),
+ *     filter: z.string().catch('all'),
+ *   }),
+ * );
+ *
+ * @example
+ * // Frontend usage (webview state)
+ * const state = new PersistedState(
+ *   createWebviewStorageAdapter(vscode),
+ *   'prefs',
+ *   PrefsSchema,
+ * );
+ *
+ * @example
+ * // Legacy format migration with union schema
+ * const LegacySchema = z.object({ old: z.string() })
+ *   .transform((v) => ({ new: v.old }));
+ * const CurrentSchema = z.object({ new: z.string() });
+ * const MigratingSchema = z.union([CurrentSchema, LegacySchema]);
+ */
+export class PersistedState<T extends Record<string, unknown>> {
+  private state: T;
+
+  constructor(
+    private readonly storage: StateStorage,
+    private readonly key: string,
+    private readonly schema: z.ZodType<T>,
+  ) {
+    this.state = this.load();
+  }
+
+  private load(): T {
+    const saved = this.storage.get(this.key);
+    return this.schema.parse(saved);
+  }
+
+  /** Get current state (shallow copy) */
+  getState(): T {
+    return { ...this.state };
+  }
+
+  /** Get a single field */
+  get<K extends keyof T>(field: K): T[K] {
+    return this.state[field];
+  }
+
+  /** Replace entire state */
+  setState(state: T): void {
+    this.state = { ...state };
+    void this.storage.update(this.key, this.state);
+  }
+
+  /** Partial update (merge) */
+  update(partial: Partial<T>): void {
+    this.setState({ ...this.state, ...partial });
+  }
+
+  /** Reset to schema defaults (by parsing undefined) */
+  reset(): void {
+    this.state = this.schema.parse(undefined);
+    void this.storage.update(this.key, this.state);
+  }
+
+  /** Reload from storage (useful after external changes) */
+  reload(): void {
+    this.state = this.load();
+  }
+}

--- a/src/common/state/index.ts
+++ b/src/common/state/index.ts
@@ -1,2 +1,3 @@
 export * from './stateManager';
 export * from './pendingStateManager';
+export * from './PersistedState';

--- a/src/progressView/persistence/PersistentMapManager.ts
+++ b/src/progressView/persistence/PersistentMapManager.ts
@@ -1,5 +1,6 @@
 // Local imports
 import { workspaceSM, WorkspaceStateKey } from '@common/state/stateManager';
+import { StorageRecordSchema } from './schemaUtils';
 
 export interface StateStorage {
   get<T>(key: string): T | undefined;
@@ -69,6 +70,20 @@ export abstract class PersistentMapManager<K extends string, V> {
     this.items = new Map(entries);
   }
 
+  /**
+   * Get or create an entry with lazy initialization.
+   * Returns existing value or creates new one using factory function.
+   * Note: Does NOT persist - call save() after modifications.
+   */
+  protected getOrCreateEntry(key: K, factory: () => V): V {
+    let value = this.items.get(key);
+    if (!value) {
+      value = factory();
+      this.items.set(key, value);
+    }
+    return value;
+  }
+
   /** Serialize a value before saving. Override for custom serialization. */
   protected serialize(value: V, _key: K): unknown {
     return value;
@@ -81,16 +96,17 @@ export abstract class PersistentMapManager<K extends string, V> {
 
   /** Load state from persistence */
   async load(): Promise<void> {
-    const saved = this.storage.get<Record<string, unknown>>(
-      this.storageKey,
-      {},
-    );
-
-    if (Object.keys(saved).length > 0) {
-      await this.populateFromRecord(saved);
+    const record = this.loadRecord();
+    if (Object.keys(record).length > 0) {
+      await this.populateFromRecord(record);
     } else {
       this.items.clear();
     }
+  }
+
+  /** Load record from storage with null/invalid fallback */
+  protected loadRecord(): Record<string, unknown> {
+    return StorageRecordSchema.parse(this.storage.get(this.storageKey));
   }
 
   /** Save current state to persistence */

--- a/src/progressView/persistence/schemaUtils.ts
+++ b/src/progressView/persistence/schemaUtils.ts
@@ -2,6 +2,17 @@
 import { z } from 'zod';
 
 /**
+ * Schema for storage records with null/invalid fallback to empty object.
+ * Use this when loading records from storage that may be null, undefined,
+ * or invalid (e.g., an array instead of object).
+ *
+ * @example
+ * const data = StorageRecordSchema.parse(storage.get(key));
+ * // Always returns Record<string, unknown>, never null/undefined
+ */
+export const StorageRecordSchema = z.record(z.string(), z.unknown()).catch({});
+
+/**
  * Coerces and validates integer round keys from string record keys.
  */
 export const RoundKeySchema = z.coerce.number().int();


### PR DESCRIPTION
## Summary

- Add `PersistedState<T>` class that works with both backend (vscode.Memento) and frontend (vscode.getState/setState)
- Provides Zod schema validation with `.catch()` for defaults
- Supports legacy format migration via union schemas
- Add `StorageRecordSchema` for safe storage loading with null guard
- Update `PersistentMapManager` to use the new schema utilities

## Key Changes

**New files:**
- `src/common/state/PersistedState.ts` - TypeScript version for backend
- `src/common/modules/persistedState.js` - JavaScript version for webview frontend

**Updated files:**
- `src/progressView/persistence/schemaUtils.ts` - Add `StorageRecordSchema`
- `src/progressView/persistence/PersistentMapManager.ts` - Use `StorageRecordSchema` for safe loading

## Usage Examples

**Backend (workspace state):**
```typescript
const prefs = new PersistedState(
  workspaceSM,
  'texra.viewPrefs',
  z.object({
    sortOrder: z.string().catch('time'),
    filter: z.string().catch('all'),
  }),
);
prefs.update({ sortOrder: 'name' });
```

**Frontend (webview state):**
```javascript
const prefs = new PersistedState('prefs', PrefsSchema);
prefs.update({ filter: 'active' });
```

## Test plan
- [ ] Type check passes (`npx tsc --noEmit`)
- [ ] Extension compiles and loads
- [ ] State persistence works in progress view
- [ ] State persistence works in webviews

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches persistence primitives used by webviews and workspace state; schema-based parsing/defaulting can change behavior for previously malformed or unexpected stored values.
> 
> **Overview**
> Adds a new Zod-validated `PersistedState` abstraction for persisted key/value state: a JS version for webviews using `vscode.getState/setState`, and a TS version that works across back-end `Memento` storage and webviews via a shared `StateStorage` interface (including a `createWebviewStorageAdapter`).
> 
> Hardens persisted map loading by introducing `StorageRecordSchema` (null/invalid → `{}`) and updating `PersistentMapManager` to parse loaded records through it; also adds a `getOrCreateEntry` helper and re-exports the new `PersistedState` from `src/common/state/index.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6470b6b593ff506c81a0eff14f9a057b85a32d3d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->