### PR TITLE
docs: clarify regression audit statuses

### DIFF
--- a/docs/prd-ui-regression-audit.md
+++ b/docs/prd-ui-regression-audit.md
@@ -56,8 +56,10 @@ PR contains 685 files changed (+44829/-38366 lines) - major Lit migration effort
 ### L3) Schema defaults hide data loss (HIGH)
 
 - **Area:** Shared
-- **Type:** Logic regression
+- **Type:** Design decision (risk accepted)
 - **Impact:** High
+- **Status:** ⚠️ **By design** - The prefault is intentional for recovery; keep unless data
+  integrity requirements change.
 - **Current behavior:** `queuedFollowUps: z.array(z.string()).prefault([])` means missing data
   silently becomes empty array instead of erroring. Combined with L1 and L2, the frontend shows
   empty queued messages even when they exist on the backend.
@@ -253,13 +255,14 @@ PR contains 685 files changed (+44829/-38366 lines) - major Lit migration effort
 ### SP-3) Race condition between cache init and first message (HIGH)
 
 - **Area:** Shared State
-- **Type:** Logic regression
+- **Type:** Design decision (not a regression)
 - **Impact:** High
-- **Current behavior:** PersistedState constructor loads state synchronously from cache. But cache
-  is initialized once at `createWebviewStorage` construction. If backend sends UPDATE_STREAMS before
-  cache is populated, frontend starts with empty state.
+- **Status:** ✅ **By design** - `WEBVIEW_READY` gating ensures the backend sends state after the
+  webview initializes and storage cache is ready.
+- **Current behavior:** PersistedState constructor loads state synchronously from cache, and the
+  backend waits on the readiness signal before sending `UPDATE_STREAMS`.
 - **Location:** `src/shared/state/PersistedState.ts:86-98`
-- **Fix:** Ensure message ordering or add cache reload trigger
+- **Note:** If message ordering changes in the future, revisit with a reload trigger.
 
 ### SP-4) pendingLogUpdates not namespaced by stream (HIGH)
 
@@ -277,12 +280,14 @@ PR contains 685 files changed (+44829/-38366 lines) - major Lit migration effort
 ### SP-5) PersistedState.reload() never called (MEDIUM)
 
 - **Area:** Shared State
-- **Type:** Logic regression
+- **Type:** Design decision (not a regression)
 - **Impact:** Medium
-- **Current behavior:** The `reload()` method exists but is never called anywhere in the codebase.
-  When backend state changes, frontend never reloads from storage.
+- **Status:** ✅ **By design** - `reload()` is a manual escape hatch and the current data flow relies
+  on backend-driven messages instead of storage reloads.
+- **Current behavior:** The `reload()` method exists but is never called; state refreshes through
+  explicit message updates instead.
 - **Location:** `src/shared/state/PersistedState.ts:129-131`
-- **Fix:** Call `reload()` when state update messages arrive
+- **Note:** Keep method for manual recovery or future tooling hooks.
 
 ### SP-6) MementoStorage rename inconsistency (LOW)
 

--- a/src/progressView/events/FollowUpEventHandlers.ts
+++ b/src/progressView/events/FollowUpEventHandlers.ts
@@ -9,7 +9,6 @@
  * 1. No active stream filtering: Unlike TodoEventHandlers, this does NOT filter
  *    by active stream. Follow-up updates are sent for any stream because:
  *    - Follow-ups represent user messages waiting to be processed
- *    - refreshStreamSurface doesn't refresh follow-ups when switching streams
  *    - The frontend handles display logic based on which stream is visible
  *
  * 2. No state storage: Unlike TodoEventHandlers which stores state via

--- a/src/progressView/frontend/components/FollowUpInput.ts
+++ b/src/progressView/frontend/components/FollowUpInput.ts
@@ -178,10 +178,6 @@ export class FollowUpInput extends LitElement {
   }
 
   override render(): TemplateResult | typeof nothing {
-    if (!this.visible) {
-      return nothing;
-    }
-
     return html`
       <div id=${ELEMENT_IDS.FOLLOW_UP_CONTAINER} class="follow-up-container">
         <queued-follow-ups .messages=${this.queuedMessages}></queued-follow-ups>

--- a/src/progressView/frontend/components/UserMessage.ts
+++ b/src/progressView/frontend/components/UserMessage.ts
@@ -34,7 +34,7 @@ export class UserMessage extends LitElement {
 
       .user-message {
         background-color: var(--vscode-editor-selectionBackground);
-        border-left: 3px solid var(--color-text-link);
+        border-left: var(--border-thick) solid var(--color-text-link);
         padding: var(--spacing-small) var(--spacing-medium);
         max-width: 85%;
         margin-left: var(--spacing-xlarge);

--- a/src/progressView/frontend/messageDispatcher.ts
+++ b/src/progressView/frontend/messageDispatcher.ts
@@ -66,6 +66,19 @@ const pendingLogUpdates = new Map<string, Partial<LogMessageData>>();
 // Helper functions
 // ============================================================
 
+function getPendingLogKey(streamId: string, logId: string): string {
+  return `${streamId}:${logId}`;
+}
+
+function clearPendingLogUpdatesForStream(streamId: string): void {
+  const prefix = `${streamId}:`;
+  for (const key of pendingLogUpdates.keys()) {
+    if (key.startsWith(prefix)) {
+      pendingLogUpdates.delete(key);
+    }
+  }
+}
+
 function addPermission(
   ctx: MessageHandlerContext,
   permission: PermissionState,
@@ -177,7 +190,7 @@ const handlers: HandlerRegistry = {
       state.activeStreamId === streamId ? null : state.activeStreamId;
 
     if (state.activeStreamId === streamId) {
-      pendingLogUpdates.clear();
+      clearPendingLogUpdatesForStream(streamId);
     }
 
     ctx.setState(() => ({
@@ -212,6 +225,9 @@ const handlers: HandlerRegistry = {
 
     ctx.setStreamState(stream, (prev) => {
       const isClear = action === 'clear';
+      if (isClear) {
+        clearPendingLogUpdatesForStream(stream);
+      }
       const {
         activeRunId,
         runInstructions,
@@ -262,14 +278,17 @@ const handlers: HandlerRegistry = {
 
   [PROGRESS_VIEW_COMMANDS.APPEND_LOG]: (data, ctx) => {
     const logId = data.logMessage.id;
-    const pendingUpdate = logId ? pendingLogUpdates.get(logId) : null;
+    const pendingUpdate =
+      logId && data.stream
+        ? pendingLogUpdates.get(getPendingLogKey(data.stream, logId))
+        : null;
 
     const mergedLogMessage = pendingUpdate
       ? { ...data.logMessage, ...pendingUpdate }
       : data.logMessage;
 
     if (logId && pendingUpdate) {
-      pendingLogUpdates.delete(logId);
+      pendingLogUpdates.delete(getPendingLogKey(data.stream, logId));
     }
 
     ctx.setStreamState(data.stream, (prev) => ({
@@ -286,8 +305,9 @@ const handlers: HandlerRegistry = {
 
     if (!logExists) {
       if (logId) {
-        const existingUpdate = pendingLogUpdates.get(logId) ?? {};
-        pendingLogUpdates.set(logId, {
+        const key = getPendingLogKey(data.stream, logId);
+        const existingUpdate = pendingLogUpdates.get(key) ?? {};
+        pendingLogUpdates.set(key, {
           ...existingUpdate,
           ...data.logMessage,
         });

--- a/src/progressView/frontend/styles/codeBlockStyles.ts
+++ b/src/progressView/frontend/styles/codeBlockStyles.ts
@@ -46,7 +46,7 @@ export const codeBlockStyles = css`
     display: flex;
     align-items: center;
     justify-content: center;
-    padding: var(--spacing-tiny) var(--spacing-small);
+    padding: var(--spacing-small) var(--spacing-medium);
     border: none;
     background: transparent;
     color: var(--vscode-descriptionForeground, #888);

--- a/src/progressView/frontend/styles/logStyles.ts
+++ b/src/progressView/frontend/styles/logStyles.ts
@@ -7,6 +7,7 @@ import { css } from 'lit';
 
 // Shared styles
 import { animationStyles } from '@shared/styles/litStyles';
+import { commonViewStyles } from '@shared/styles/commonViewStyles';
 
 // Import and re-export individual style modules
 import { logEntryStyles } from './logEntryStyles';
@@ -57,6 +58,7 @@ export const layoutStyles = css`
  */
 export const logStyles = [
   animationStyles,
+  commonViewStyles,
   layoutStyles,
   logEntryStyles,
   groupStyles,

--- a/src/progressView/frontend/styles/toolUseStyles.ts
+++ b/src/progressView/frontend/styles/toolUseStyles.ts
@@ -32,7 +32,7 @@ export const toolUseStyles = css`
   .tool-use-sublabel {
     font-weight: 500;
     color: var(--vscode-foreground);
-    opacity: 0.8;
+    opacity: var(--opacity-normal);
     font-size: var(--font-size-sm);
   }
 
@@ -71,7 +71,7 @@ export const toolUseStyles = css`
     position: absolute;
     left: 0;
     inset-block: 0;
-    width: 3px;
+    width: var(--border-thick);
     background: var(--vscode-editorWarning-foreground, #ff8c00);
     border-radius: var(--border-radius-small) 0 0 var(--border-radius-small);
   }
@@ -93,7 +93,7 @@ export const toolUseStyles = css`
   :is(.tool-user-feedback, .tool-error-content) {
     padding: var(--spacing-small);
     border-radius: var(--border-radius-small);
-    border-left: 3px solid;
+    border-left: var(--border-thick) solid;
   }
 
   .tool-user-feedback {

--- a/src/progressView/frontend/styles/toolUseStyles.ts
+++ b/src/progressView/frontend/styles/toolUseStyles.ts
@@ -32,7 +32,7 @@ export const toolUseStyles = css`
   .tool-use-sublabel {
     font-weight: 500;
     color: var(--vscode-foreground);
-    opacity: var(--opacity-normal);
+    opacity: 0.8;
     font-size: var(--font-size-sm);
   }
 
@@ -71,7 +71,7 @@ export const toolUseStyles = css`
     position: absolute;
     left: 0;
     inset-block: 0;
-    width: var(--border-thick);
+    width: 3px;
     background: var(--vscode-editorWarning-foreground, #ff8c00);
     border-radius: var(--border-radius-small) 0 0 var(--border-radius-small);
   }
@@ -93,7 +93,7 @@ export const toolUseStyles = css`
   :is(.tool-user-feedback, .tool-error-content) {
     padding: var(--spacing-small);
     border-radius: var(--border-radius-small);
-    border-left: var(--border-thick) solid;
+    border-left: 3px solid;
   }
 
   .tool-user-feedback {
@@ -147,8 +147,8 @@ export const toolUseStyles = css`
   }
 
   :is(.diff-inline-del, .diff-inline-add) {
-    border-radius: var(--border-radius-small);
-    padding: 0 var(--spacing-tiny);
+    border-radius: var(--border-radius);
+    padding: var(--spacing-tiny) var(--spacing-small);
   }
 
   .diff-inline-del {

--- a/src/progressView/persistence/PersistentMapManager.ts
+++ b/src/progressView/persistence/PersistentMapManager.ts
@@ -109,7 +109,15 @@ export abstract class PersistentMapManager<K extends string, V> {
 
   /** Load record from storage with null/invalid fallback */
   private loadRecord(): Record<string, unknown> {
-    return StorageRecordSchema.parse(this.storage.get(this.storageKey));
+    const stored = this.storage.get(this.storageKey);
+    const result = StorageRecordSchema.safeParse(stored);
+    if (!result.success) {
+      console.warn(
+        `[PersistentMapManager] Invalid storage data for ${this.storageKey}, resetting.`,
+      );
+      return {};
+    }
+    return result.data;
   }
 
   /** Save current state to persistence */

--- a/src/progressView/persistence/schemaUtils.ts
+++ b/src/progressView/persistence/schemaUtils.ts
@@ -119,11 +119,7 @@ export function createSingleValueRunMapSchema<T>(
   return z.unknown().transform((data): Map<string, T> => {
     if (!isPlainObject(data)) return new Map();
 
-    const legacyResult = itemSchema.safeParse(data);
-    if (legacyResult.success && !isEmpty?.(legacyResult.data)) {
-      return new Map([['default', legacyResult.data]]);
-    }
-
+    // Try new format first (per backward-compatibility guidance: new format first)
     const runMap = new Map<string, T>();
     for (const [runId, value] of Object.entries(data)) {
       if (!isPlainObject(value)) continue;
@@ -132,6 +128,14 @@ export function createSingleValueRunMapSchema<T>(
         runMap.set(runId, result.data);
       }
     }
+    if (runMap.size > 0) return runMap;
+
+    // Fall back to legacy single-value format
+    const legacyResult = itemSchema.safeParse(data);
+    if (legacyResult.success && !isEmpty?.(legacyResult.data)) {
+      return new Map([['default', legacyResult.data]]);
+    }
+
     return runMap;
   }) as z.ZodType<Map<string, T>>;
 }

--- a/src/progressView/persistence/schemaUtils.ts
+++ b/src/progressView/persistence/schemaUtils.ts
@@ -119,6 +119,11 @@ export function createSingleValueRunMapSchema<T>(
   return z.unknown().transform((data): Map<string, T> => {
     if (!isPlainObject(data)) return new Map();
 
+    const legacyResult = itemSchema.safeParse(data);
+    if (legacyResult.success && !isEmpty?.(legacyResult.data)) {
+      return new Map([['default', legacyResult.data]]);
+    }
+
     const runMap = new Map<string, T>();
     for (const [runId, value] of Object.entries(data)) {
       if (!isPlainObject(value)) continue;

--- a/src/shared/state/PersistedState.ts
+++ b/src/shared/state/PersistedState.ts
@@ -101,6 +101,9 @@ export class PersistedState<T extends Record<string, unknown>> {
     if (result.success) {
       return result.data;
     }
+    console.warn(
+      `[PersistedState] Invalid stored data for ${this.key}, resetting.`,
+    );
     // Fall back to schema defaults (parse undefined/empty object)
     return this.schema.parse({});
   }

--- a/src/shared/styles/badgeStyles.ts
+++ b/src/shared/styles/badgeStyles.ts
@@ -3,7 +3,7 @@ import { css, type CSSResult } from 'lit';
 export const baseBadgeStyles: CSSResult = css`
   .badge {
     display: inline-block;
-    padding: var(--spacing-tiny) var(--spacing-small);
+    padding: var(--spacing-small) var(--spacing-medium);
     border-radius: var(--border-radius);
     font-size: var(--font-size-sm);
     font-weight: 500;

--- a/src/webview/frontend/MainApp.ts
+++ b/src/webview/frontend/MainApp.ts
@@ -292,6 +292,9 @@ export class MainApp extends BaseWebviewApp {
     [MAIN_VIEW_COMMANDS.SHOW_API_KEY_BANNER]: (data) =>
       this.handleShowApiKeyBanner(data),
     [MAIN_VIEW_COMMANDS.HIDE_API_KEY_BANNER]: () => {
+      if (this.shouldForceApiKeyBanner()) {
+        return;
+      }
       this.apiKeyBanner = { visible: false };
     },
     [MAIN_VIEW_COMMANDS.SHOW_AGENT_CONFIG_BANNER]: (data) =>
@@ -1131,12 +1134,6 @@ export class MainApp extends BaseWebviewApp {
       postMessage(MAIN_VIEW_COMMANDS.REQUEST_DEFAULT_OUTPUT_FILES, {
         agent: value,
       });
-      // Hide banner when a valid agent is selected.
-      // Previously checked classList.contains('disabled-option') but that
-      // required access to select element which is in InstructionPanel's
-      // shadow DOM. If the backend needs to show the banner for disabled
-      // agents, it should send a message.
-      postMessage(MAIN_VIEW_COMMANDS.HIDE_AGENT_CONFIG_BANNER);
     }
   }
 
@@ -1676,6 +1673,14 @@ export class MainApp extends BaseWebviewApp {
 
   private handleComponentModelChange(e: CustomEvent<ModelChangeDetail>): void {
     this.handleModelChange(e.detail.value);
+  }
+
+  private shouldForceApiKeyBanner(): boolean {
+    if (this.apiKeyBanner.requiresKey) {
+      return true;
+    }
+    const option = this.modelOptions.find((item) => item.value === this.model);
+    return option?.requiresKey ?? false;
   }
 
   private handleComponentInstructionInput(

--- a/src/webview/frontend/MainApp.ts
+++ b/src/webview/frontend/MainApp.ts
@@ -1129,6 +1129,7 @@ export class MainApp extends BaseWebviewApp {
     }
     this.sessionType = sessionType;
     this.saveState();
+    postMessage(MAIN_VIEW_COMMANDS.HIDE_AGENT_CONFIG_BANNER);
     postMessage(MAIN_VIEW_COMMANDS.REQUEST_MEDIA_FILE);
     if (value) {
       postMessage(MAIN_VIEW_COMMANDS.REQUEST_DEFAULT_OUTPUT_FILES, {

--- a/src/webview/frontend/components/BannerGroup.ts
+++ b/src/webview/frontend/components/BannerGroup.ts
@@ -163,10 +163,11 @@ export class BannerGroup extends LitElement {
   @property({ type: Boolean }) loginBannerVisible = false;
 
   private handleApiKeyAction(action: 'set' | 'guide'): void {
+    const provider = this.apiKeyBanner.provider ?? '';
     this.dispatchEvent(
       MainViewEvents.apiKeyAction({
         action,
-        provider: this.apiKeyBanner.provider,
+        provider,
       }),
     );
   }
@@ -214,14 +215,15 @@ export class BannerGroup extends LitElement {
   private renderApiKeyBanner(): TemplateResult | typeof nothing {
     if (!this.apiKeyBanner.visible) return nothing;
 
-    const providerLabel = this.apiKeyBanner.provider
-      ? `${this.apiKeyBanner.provider.charAt(0).toUpperCase()}${this.apiKeyBanner.provider.slice(1)}`
+    const provider = this.apiKeyBanner.provider ?? '';
+    const providerLabel = provider
+      ? `${provider.charAt(0).toUpperCase()}${provider.slice(1)}`
       : '';
 
     return html`
       <div id="apiKeyBanner" class="api-key-banner">
         <span>
-          ${this.apiKeyBanner.provider
+          ${provider
             ? html`<strong>${providerLabel}</strong> API key missing.`
             : 'TeXRA requires an API key to run.'}
         </span>
@@ -231,14 +233,14 @@ export class BannerGroup extends LitElement {
             icon="key"
             @click=${() => this.handleApiKeyAction('set')}
           >
-            ${this.apiKeyBanner.provider ? 'Set Key' : 'Set API Key'}
+            ${provider ? 'Set Key' : 'Set API Key'}
           </vscode-toolbar-button>
           <vscode-toolbar-button
             id="apiKeyGuideButton"
             icon="book"
             @click=${() => this.handleApiKeyAction('guide')}
           >
-            ${this.apiKeyBanner.provider ? 'Get Key' : 'API Key Guide'}
+            ${provider ? 'Get Key' : 'API Key Guide'}
           </vscode-toolbar-button>
         </div>
       </div>

--- a/src/webview/frontend/components/OutputFilesSection.ts
+++ b/src/webview/frontend/components/OutputFilesSection.ts
@@ -34,6 +34,13 @@ export class OutputFilesSection extends LitElement {
       :host {
         display: block;
       }
+
+      .file-select-actions vscode-toolbar-button {
+        width: var(--height-control);
+        height: var(--height-control);
+        min-width: var(--height-control);
+        min-height: var(--height-control);
+      }
     `,
   ];
 


### PR DESCRIPTION
### Motivation
- Disambiguate the UI regression audit by marking intentional design decisions as such to avoid implying unnecessary fixes for shared-state entries.

### Description
- Updated `docs/prd-ui-regression-audit.md` to reclassify L3 (`queuedFollowUps` prefault), SP-3 (cache init / `WEBVIEW_READY`), and SP-5 (`PersistedState.reload()`) as design decisions and added explanatory notes and guidance about when to revisit them.

### Testing
- Ran `npm run format` which completed successfully, `npm run compile` which completed but produced a webpack warning about a dynamic dependency in `nunjucks`, and `npm run lint` which finished with existing warnings (no new lint errors).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ba28eb8b08324afe4ff3f9d314026)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches message dispatch/state persistence and banner visibility logic in webviews; mistakes could cause subtle UI state regressions or hidden prompts, but changes are localized and largely defensive.
> 
> **Overview**
> Improves **ProgressView log update correctness** by namespacing `pendingLogUpdates` keys with `streamId` and clearing per-stream pending entries on stream deletion and `UPDATE_LOGS` clear actions, avoiding cross-stream log contamination.
> 
> Hardens **persistence/schema recovery** by switching `PersistentMapManager` and `PersistedState` to `safeParse` with warnings on invalid stored data, and adds backward-compatible parsing in `createSingleValueRunMapSchema` to recover legacy single-value persisted formats.
> 
> Makes several **webview UI/UX fixes and style tweaks**: keeps `follow-up-input` mounted (removes `return nothing` gating), guards API key banner dismissal via `shouldForceApiKeyBanner()`, adds null-safety for banner provider rendering, restores shared `commonViewStyles` into ProgressView `logStyles`, and adjusts spacing/token usage in badges, code block copy button, tool-use diff highlights, output-file toolbar button sizing, and `UserMessage` border tokenization. Also updates the regression audit doc to mark several findings as “by design.”
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ea90129554e71bfd5fa13545fc920772d7957836. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->