### PR TITLE
fix: UI/logic regressions — backend sync, multi-output, follow-ups, UI

### DIFF
--- a/docs/prd-ui-regression-audit-round3.md
+++ b/docs/prd-ui-regression-audit-round3.md
@@ -9,6 +9,7 @@
 ## Overview
 
 This PRD consolidates **all Round 3 UI and logic regressions** from the following source documents:
+
 - `prd-ui-regression-audit-round3-1.md` (key collisions, IME, accessibility)
 - `prd-ui-regression-audit-round3-2.md` (backend sync issues)
 - `prd-ui-regression-audit-round3-3.md` (INITIALIZING status, schema validation)
@@ -18,11 +19,11 @@ This PRD consolidates **all Round 3 UI and logic regressions** from the followin
 
 ### Summary by Severity
 
-| Severity | Count | Primary Areas |
-|----------|-------|---------------|
-| **HIGH** | 10    | Backend sync, data loss, button availability |
-| **MEDIUM** | 20  | State leaks, UX regressions, filter issues |
-| **LOW** | 15    | Key collisions, accessibility gaps, styling |
+| Severity   | Count | Primary Areas                                |
+| ---------- | ----- | -------------------------------------------- |
+| **HIGH**   | 10    | Backend sync, data loss, button availability |
+| **MEDIUM** | 20    | State leaks, UX regressions, filter issues   |
+| **LOW**    | 15    | Key collisions, accessibility gaps, styling  |
 
 ---
 
@@ -152,7 +153,7 @@ This PRD consolidates **all Round 3 UI and logic regressions** from the followin
     left: 0;
     z-index: 100;
     min-width: 150px;
-    display: block;  /* <-- ADD THIS */
+    display: block; /* <-- ADD THIS */
   }
   ```
 
@@ -361,6 +362,7 @@ This PRD consolidates **all Round 3 UI and logic regressions** from the followin
 - **Code Evidence:** vscode-context-menu source shows `this._wrapperEl.focus()` on show.
   FileSelectGroup's `handleFocusOut` only checks `this.contains()` and `this.shadowRoot?.contains()`.
 - **Fix:** Use `event.composedPath()` to check containment across shadow DOM boundaries:
+
   ```typescript
   private handleFocusOut(event: FocusEvent): void {
     const nextTarget = event.relatedTarget as Node | null;
@@ -436,20 +438,24 @@ This PRD consolidates **all Round 3 UI and logic regressions** from the followin
 ## Implementation Priority
 
 ### Phase 1: Critical Data Integrity (HIGH)
+
 1. H-1, H-2, H-3, H-6 – Backend sync issues (fix together)
 2. H-4, H-5 – Run reset/clear data loss
 3. H-7, H-8 – INITIALIZING status + sort crash
 
 ### Phase 2: UX Blocking Issues (HIGH)
+
 4. H-9 – Follow-up options leak
 5. H-10, H-11 – Shadow DOM issues (dropdown, target.closest)
 
 ### Phase 3: State Management (MEDIUM)
+
 6. M-4 through M-15 – Various state issues
 7. M-16, M-17, M-18 – INITIALIZING styling + schema validation
 8. M-19, M-20 – Search input + schema validation
 
 ### Phase 4: Polish (LOW)
+
 9. L-1 through L-15 – Key collisions, accessibility, styling
 
 ---
@@ -457,35 +463,43 @@ This PRD consolidates **all Round 3 UI and logic regressions** from the followin
 ## Source File Mapping
 
 | Merged ID | Original Source | Original ID |
-|-----------|-----------------|-------------|
-| H-1 | round3-2/4 | M1 |
-| H-2 | round3-2/4 | M2 |
-| H-3 | round3-2/4 | M5 |
-| H-4 | round3-2/4 | P1 |
-| H-5 | round3-2/4 | P2 |
-| H-6 | round3-2/4 | M8 |
-| H-7 | round3-3 | P3 |
-| H-8 | round3-3 | P5 |
-| H-9 | round3-3 | P6 |
-| H-10 | round3-1 | P11 (NEW) |
-| H-11 | original round3 | P5-P10 |
-| M-1 | round3-2/4 | M3 |
-| M-2 | round3-2/4 | M4 |
-| M-3 | round3-1/2/4 | M1/M7 |
-| M-4 | round3-1 | P1 |
-| M-5 | round3-1 | P2 |
-| M-6 | round3-1 | P3 |
-| M-7 | round3-1 | P5 |
-| M-8 | round3-1 | P10 |
-| M-9 | round3-2/4 | P3 |
-| M-10 | round3-2/3/4 | P4/P7 |
-| M-11 | round3-2/4 | P5 |
-| M-12 | round3-2/4 | P6 |
-| M-13 | round3-2/4 | P7 |
-| M-14 | round3-2/4 | P8 |
-| M-15 | round3-2/4 | P10 |
-| M-16 | round3-3 | P1 |
-| M-17 | round3-3 | P2 |
-| M-18 | round3-3 | P4 |
-| M-19 | round3-1 | H1 |
-| M-20 | round3-3 | S1 |
+| --------- | --------------- | ----------- |
+| H-1       | round3-2/4      | M1          |
+| H-2       | round3-2/4      | M2          |
+| H-3       | round3-2/4      | M5          |
+| H-4       | round3-2/4      | P1          |
+| H-5       | round3-2/4      | P2          |
+| H-6       | round3-2/4      | M8          |
+| H-7       | round3-3        | P3          |
+| H-8       | round3-3        | P5          |
+| H-9       | round3-3        | P6          |
+| H-10      | round3-1        | P11 (NEW)   |
+| H-11      | original round3 | P5-P10      |
+| M-1       | round3-2/4      | M3          |
+| M-2       | round3-2/4      | M4          |
+| M-3       | round3-1/2/4    | M1/M7       |
+| M-4       | round3-1        | P1          |
+| M-5       | round3-1        | P2          |
+| M-6       | round3-1        | P3          |
+| M-7       | round3-1        | P5          |
+| M-8       | round3-1        | P10         |
+| M-9       | round3-2/4      | P3          |
+| M-10      | round3-2/3/4    | P4/P7       |
+| M-11      | round3-2/4      | P5          |
+| M-12      | round3-2/4      | P6          |
+| M-13      | round3-2/4      | P7          |
+| M-14      | round3-2/4      | P8          |
+| M-15      | round3-2/4      | P10         |
+| M-16      | round3-3        | P1          |
+| M-17      | round3-3        | P2          |
+| M-18      | round3-3        | P4          |
+| M-19      | round3-1        | H1          |
+| M-20      | round3-3        | S1          |
+
+---
+
+## Progress Update (2026-02-01)
+
+- ✅ All HIGH severity fixes (H-1 through H-11) implemented.
+- ✅ All MEDIUM severity fixes (M-1 through M-20) implemented.
+- ✅ All LOW severity fixes (L-1 through L-15) implemented.

--- a/docs/prd/dual-logic-audit-2026-02.md
+++ b/docs/prd/dual-logic-audit-2026-02.md
@@ -2,12 +2,12 @@
 
 ## Implementation Status
 
-| Item | Severity | Status | Notes |
-|------|----------|--------|-------|
-| File watcher extensions | HIGH | Proposed | Active bug — .bib/.bbl/.sty not watched |
-| useMultipleOutputs divergence | HIGH | Proposed | Different algorithms in 3 code paths |
-| MainView options refresh | MEDIUM | Proposed | loadOptions() exists but unused in providers |
-| Workflow proposal file lists | MEDIUM | Proposed | ~50 lines identical code in 2 components |
+| Item                          | Severity | Status    | Notes                                               |
+| ----------------------------- | -------- | --------- | --------------------------------------------------- |
+| File watcher extensions       | HIGH     | Completed | File watcher now uses config-driven extension list  |
+| useMultipleOutputs divergence | HIGH     | Completed | Unified derivation helper + validation in follow-up |
+| MainView options refresh      | MEDIUM   | Completed | loadOptions() wired into providers and commands     |
+| Workflow proposal file lists  | MEDIUM   | Completed | Shared helper renders workflow file lists           |
 
 ## Overview
 
@@ -37,11 +37,13 @@ have been removed per CLAUDE.md guidelines.
 
 **Problem:**
 `MainViewProvider.setupFileWatcher` (line 176) hardcodes file extensions:
+
 ```
 **/*.{tex,txt,md,cls,png,pdf,jpeg,jpg,svg,gif,heic,heif,webp,wav,mp3,m4a,aiff,aac,ogg,flac}
 ```
 
 **Missing from watcher but in VS Code config:**
+
 - `.sty` (auxiliary — style files)
 - `.bib`, `.bbl` (reference — bibliography files)
 
@@ -52,6 +54,7 @@ list updates. They must manually trigger refresh.
 `@common/files/fileTypeUtils.ts`) is not used here.
 
 **Fix:**
+
 ```typescript
 // In MainViewProvider.setupFileWatcher, replace hardcoded string with:
 const allExtensions = [
@@ -66,10 +69,12 @@ const filePattern = `**/*.{${[...new Set(allExtensions)].join(',')}}`;
 ```
 
 **Files:**
+
 - `src/MainViewProvider.ts:176` — hardcoded glob
 - `src/common/files/fileTypeUtils.ts:32-40` — `getIncludedExtensions()` / `getFilterExtensions()`
 
 **Acceptance Criteria:**
+
 - File watcher pattern built dynamically from config
 - Adding extensions to VS Code settings affects both file listing and watching
 
@@ -83,11 +88,11 @@ const filePattern = `**/*.{${[...new Set(allExtensions)].join(',')}}`;
 **Problem:**
 Three code paths derive `useMultipleOutputs` with different algorithms:
 
-| Location | Algorithm |
-|----------|-----------|
-| `ExecutionManager.handleExecute:80` | `!isToolUse && (outputFilesActive \|\| outputFiles.length > 1)` |
-| `buildFollowupTaskState:1180` | `(attachAgentOutputs && outputFiles.length > 1) \|\| originalConfig.useMultipleOutputs` |
-| `handleAgentProposalSetup` | No output handling (relies on original) |
+| Location                            | Algorithm                                                                               |
+| ----------------------------------- | --------------------------------------------------------------------------------------- |
+| `ExecutionManager.handleExecute:80` | `!isToolUse && (outputFilesActive \|\| outputFiles.length > 1)`                         |
+| `buildFollowupTaskState:1180`       | `(attachAgentOutputs && outputFiles.length > 1) \|\| originalConfig.useMultipleOutputs` |
+| `handleAgentProposalSetup`          | No output handling (relies on original)                                                 |
 
 **Additional issue:** Only `ExecutionManager` validates against `AgentConfigSchema`.
 ProposalSetup and BuildFollowup skip validation entirely.
@@ -96,16 +101,19 @@ ProposalSetup and BuildFollowup skip validation entirely.
 identical inputs, especially when output counts change.
 
 **Fix approach:**
+
 1. Extract `deriveUseMultipleOutputs(config, flags)` helper with single algorithm
 2. Add schema validation to ProposalSetup and BuildFollowup paths
 3. Document if any algorithm differences are intentional
 
 **Files:**
+
 - `src/webview/managers/ExecutionManager.ts:46-116`
 - `src/progressView/ProgressViewMessageHandler.ts:524-597, 1120-1226`
 - `src/utils/config/configConversion.ts:16-64` — existing `isFileTypeActive` helper
 
 **Acceptance Criteria:**
+
 - Single derivation algorithm (or documented intentional differences)
 - All execution paths validate config before dispatch
 
@@ -119,6 +127,7 @@ identical inputs, especially when output counts change.
 **Problem:**
 `loadOptions()` in `@frontend/agents/optionsLoader.ts` already does parallel computation
 of agent/model options but is not used by:
+
 - `MainViewProvider.refreshAgentOptions/refreshModelOptions` (lines 124-171)
 - `mainViewCommands.refreshAgentOptions/refreshModelOptions` (lines 43-116)
 
@@ -128,16 +137,19 @@ Both paths duplicate the compute + postMessage pattern with different error hand
 `refreshModelOptions` does not — inconsistent behavior.
 
 **Fix approach:**
+
 1. Have both `MainViewProvider` and `mainViewCommands` call `loadOptions()`
 2. Add error handling callback parameter to `loadOptions()` for view-specific UX
 3. Ensure both refresh agent index when either changes
 
 **Files:**
+
 - `src/MainViewProvider.ts:124-171`
 - `src/commands/system/mainViewCommands.ts:43-116`
 - `src/frontend/agents/optionsLoader.ts:16-32`
 
 **Acceptance Criteria:**
+
 - Both provider and commands use `loadOptions()`
 - Consistent refresh behavior for agent and model options
 
@@ -150,24 +162,29 @@ Both paths duplicate the compute + postMessage pattern with different error hand
 
 **Problem:**
 Two components have identical file list rendering:
+
 - `PermissionCard.renderWorkflowFiles()` (lines 285-334)
 - `RequestPanels.renderProposalFiles()` (lines 495-550)
 
 Both include:
+
 - Identical `combine()` helper function
 - Same category order (Input, Reference, Auxiliary, Media, Output)
 - Same template structure and click handlers
 
 **Fix:**
 Create shared helper in `src/progressView/frontend/components/helpers/workflowFilesList.ts`:
+
 - `buildWorkflowFileLists(proposal)` — assembles file categories
 - `renderWorkflowFilesList(fileLists, options)` — renders with configurable class names
 
 **Files:**
+
 - `src/progressView/frontend/components/PermissionCard.ts:285-334`
 - `src/progressView/frontend/components/RequestPanels.ts:495-550`
 
 **Acceptance Criteria:**
+
 - Both components call shared helper
 - No duplicate `combine()` function remains
 
@@ -177,27 +194,27 @@ Create shared helper in `src/progressView/frontend/components/helpers/workflowFi
 
 The following items from prior audits were evaluated and removed:
 
-| Item | Reason |
-|------|--------|
-| Open-file behavior | 3 functions serve different purposes (command, tool reuse, linting). Not duplication — intentionally distinct APIs |
-| Timestamp formatting | 1 line using toLocaleString vs utility. Inconsistency, not duplication. Not worth a shared helper |
-| Permission rejection feedback flow | Only 2 components (~15 lines each), different state shapes (boolean vs Set). Premature abstraction |
-| Secondary panel orchestration (showXView) | 3 providers, ~10 lines each, slight differences. At "premature abstraction" boundary per CLAUDE.md |
-| Content provider getModuleUris | 5-line pattern × 4 files, never changes, zero drift risk |
-| Schema dispatch boilerplate | Handlers are identical but intentionally decoupled for independent evolution |
-| Text polishing flows | Core logic (polishTextWithAI) is already shared; differences are intentional UX |
-| Latexdiff assembly | Minor arg divergence, underlying command handles both patterns |
-| State restore pipeline | Architectural difference, not direct code duplication |
-| File context formatting | Different formatting is intentional for different audiences |
+| Item                                      | Reason                                                                                                             |
+| ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| Open-file behavior                        | 3 functions serve different purposes (command, tool reuse, linting). Not duplication — intentionally distinct APIs |
+| Timestamp formatting                      | 1 line using toLocaleString vs utility. Inconsistency, not duplication. Not worth a shared helper                  |
+| Permission rejection feedback flow        | Only 2 components (~15 lines each), different state shapes (boolean vs Set). Premature abstraction                 |
+| Secondary panel orchestration (showXView) | 3 providers, ~10 lines each, slight differences. At "premature abstraction" boundary per CLAUDE.md                 |
+| Content provider getModuleUris            | 5-line pattern × 4 files, never changes, zero drift risk                                                           |
+| Schema dispatch boilerplate               | Handlers are identical but intentionally decoupled for independent evolution                                       |
+| Text polishing flows                      | Core logic (polishTextWithAI) is already shared; differences are intentional UX                                    |
+| Latexdiff assembly                        | Minor arg divergence, underlying command handles both patterns                                                     |
+| State restore pipeline                    | Architectural difference, not direct code duplication                                                              |
+| File context formatting                   | Different formatting is intentional for different audiences                                                        |
 
 ---
 
 ## Risks & Mitigations
 
-| Risk | Mitigation |
-|------|------------|
-| File watcher change breaks extension loading | Test with various file types after change |
-| useMultipleOutputs unification changes behavior | Document current behavior first, add tests |
+| Risk                                            | Mitigation                                    |
+| ----------------------------------------------- | --------------------------------------------- |
+| File watcher change breaks extension loading    | Test with various file types after change     |
+| useMultipleOutputs unification changes behavior | Document current behavior first, add tests    |
 | loadOptions() error handling differs by context | Add callback parameter, not forced uniformity |
 
 ---
@@ -205,10 +222,18 @@ The following items from prior audits were evaluated and removed:
 ## Supersedes
 
 This PRD supersedes and consolidates:
+
 - `docs/prd/prd-dual-logic-audit-2026-02.md` (deleted)
 - `docs/prd/dual-logic-impact-audit.md` (deleted)
 - `docs/prd-dual-logic-audit-2026-02.md` (deleted)
 
 Related completed PRDs (kept for reference):
+
 - `docs/prd/dual-logic-features.md` — ✅ Complete
 - `docs/prd/dual-logic-infrastructure.md` — ✅ Complete
+
+---
+
+## Progress Update (2026-02-01)
+
+- ✅ All listed dual-logic audit items implemented.

--- a/src/MainViewProvider.ts
+++ b/src/MainViewProvider.ts
@@ -5,7 +5,7 @@ import * as vscode from 'vscode';
 import { MainViewPersistedStateSchema } from '@shared/schemas';
 
 // Local imports - agent
-import { refresh, computeAgentOptionsData } from '@agent/index';
+import { refresh } from '@agent/index';
 
 // Local imports - common
 import {
@@ -14,10 +14,12 @@ import {
   MAIN_VIEW_COMMANDS,
 } from '@common/webview';
 import { consumePendingState } from '@common/state';
+import { toErrorMessage } from '@common/errors';
+import { getFilterExtensions } from '@common/files/fileTypeUtils';
 
 // Local imports - frontend
 import { agentDirectories } from '@frontend/agents';
-import { computeModelOptionsData } from '@model/computeModelOptions';
+import { loadOptions } from '@frontend/agents/optionsLoader';
 import { watchConfig, getConfig, DEBOUNCE_OPTIONS_MS } from '@utils/config';
 import { debounce } from '@utils/core';
 import { checkCoreDependencies } from '@utils/system/toolUtils';
@@ -145,13 +147,22 @@ export class MainViewProvider
     if (!this._view) {
       return;
     }
-    // Refresh the agent index to pick up configuration changes
-    await refresh();
+    const options = await loadOptions({
+      onError: (error) => {
+        vscode.window.showErrorMessage(
+          `Failed to refresh agent options: ${toErrorMessage(error)}`,
+        );
+      },
+    });
+    if (!options) return;
 
-    const optionsData = await computeAgentOptionsData();
     this._view.webview.postMessage({
       command: MAIN_VIEW_COMMANDS.SET_AGENT_OPTIONS,
-      optionsData,
+      optionsData: options.agentOptions,
+    });
+    this._view.webview.postMessage({
+      command: MAIN_VIEW_COMMANDS.SET_MODEL_OPTIONS,
+      optionsData: options.modelOptions,
     });
   }
 
@@ -163,17 +174,36 @@ export class MainViewProvider
     if (!this._view) {
       return;
     }
-    const optionsData = await computeModelOptionsData();
+    const options = await loadOptions({
+      onError: (error) => {
+        vscode.window.showErrorMessage(
+          `Failed to refresh model options: ${toErrorMessage(error)}`,
+        );
+      },
+    });
+    if (!options) return;
+
+    this._view.webview.postMessage({
+      command: MAIN_VIEW_COMMANDS.SET_AGENT_OPTIONS,
+      optionsData: options.agentOptions,
+    });
     this._view.webview.postMessage({
       command: MAIN_VIEW_COMMANDS.SET_MODEL_OPTIONS,
-      optionsData,
+      optionsData: options.modelOptions,
     });
   }
 
   private setupFileWatcher() {
     // Create a file system watcher for relevant file types
-    const filePattern =
-      '**/*.{tex,txt,md,cls,png,pdf,jpeg,jpg,svg,gif,heic,heif,webp,wav,mp3,m4a,aiff,aac,ogg,flac}';
+    const allExtensions = [
+      ...getFilterExtensions('input'),
+      ...getFilterExtensions('reference'),
+      ...getFilterExtensions('auxiliary'),
+      ...getFilterExtensions('media'),
+      ...getFilterExtensions('audio'),
+      ...getFilterExtensions('edited'),
+    ];
+    const filePattern = `**/*.{${[...new Set(allExtensions)].join(',')}}`;
     this.fileWatcher = vscode.workspace.createFileSystemWatcher(filePattern);
 
     // Handle file changes

--- a/src/commands/system/mainViewCommands.ts
+++ b/src/commands/system/mainViewCommands.ts
@@ -2,12 +2,11 @@
 import * as vscode from 'vscode';
 
 // Local imports
-import { computeAgentOptionsData, refresh } from '@agent/index';
 import { toErrorMessage } from '@common/errors';
 import { MAIN_VIEW_COMMANDS } from '@common/webview';
+import { loadOptions } from '@frontend/agents/optionsLoader';
 import { getMainWebview } from '@frontend/system/commandUtils';
 import * as logger from '@logger/logUtils';
-import { computeModelOptionsData } from '@model/computeModelOptions';
 
 const CHANNEL = 'mainViewCommands';
 
@@ -46,19 +45,28 @@ export function registerMainViewCommands(
         const webview = await getMainWebview(CHANNEL);
         if (!webview) return;
 
-        try {
-          const optionsData = await computeModelOptionsData();
-          webview.webview.postMessage({
-            command: MAIN_VIEW_COMMANDS.SET_MODEL_OPTIONS,
-            optionsData,
-          });
-        } catch (error) {
-          const message = toErrorMessage(error);
-          logger.error(CHANNEL, `Failed to refresh model options: ${message}`);
-          vscode.window.showErrorMessage(
-            `Failed to refresh model options: ${message}`,
-          );
-        }
+        const options = await loadOptions({
+          onError: (error) => {
+            const message = toErrorMessage(error);
+            logger.error(
+              CHANNEL,
+              `Failed to refresh model options: ${message}`,
+            );
+            vscode.window.showErrorMessage(
+              `Failed to refresh model options: ${message}`,
+            );
+          },
+        });
+        if (!options) return;
+
+        webview.webview.postMessage({
+          command: MAIN_VIEW_COMMANDS.SET_MODEL_OPTIONS,
+          optionsData: options.modelOptions,
+        });
+        webview.webview.postMessage({
+          command: MAIN_VIEW_COMMANDS.SET_AGENT_OPTIONS,
+          optionsData: options.agentOptions,
+        });
       },
     ),
 
@@ -68,20 +76,28 @@ export function registerMainViewCommands(
         const webview = await getMainWebview(CHANNEL);
         if (!webview) return;
 
-        try {
-          await refresh();
-          const optionsData = await computeAgentOptionsData();
-          webview.webview.postMessage({
-            command: MAIN_VIEW_COMMANDS.SET_AGENT_OPTIONS,
-            optionsData,
-          });
-        } catch (error) {
-          const message = toErrorMessage(error);
-          logger.error(CHANNEL, `Failed to refresh agent options: ${message}`);
-          vscode.window.showErrorMessage(
-            `Failed to refresh agent options: ${message}`,
-          );
-        }
+        const options = await loadOptions({
+          onError: (error) => {
+            const message = toErrorMessage(error);
+            logger.error(
+              CHANNEL,
+              `Failed to refresh agent options: ${message}`,
+            );
+            vscode.window.showErrorMessage(
+              `Failed to refresh agent options: ${message}`,
+            );
+          },
+        });
+        if (!options) return;
+
+        webview.webview.postMessage({
+          command: MAIN_VIEW_COMMANDS.SET_AGENT_OPTIONS,
+          optionsData: options.agentOptions,
+        });
+        webview.webview.postMessage({
+          command: MAIN_VIEW_COMMANDS.SET_MODEL_OPTIONS,
+          optionsData: options.modelOptions,
+        });
       },
     ),
 
@@ -91,27 +107,25 @@ export function registerMainViewCommands(
         const webview = await getMainWebview(CHANNEL);
         if (!webview) return;
 
-        try {
-          await refresh();
-          const [modelOptionsData, agentOptionsData] = await Promise.all([
-            computeModelOptionsData(),
-            computeAgentOptionsData(),
-          ]);
-          webview.webview.postMessage({
-            command: MAIN_VIEW_COMMANDS.SET_MODEL_OPTIONS,
-            optionsData: modelOptionsData,
-          });
-          webview.webview.postMessage({
-            command: MAIN_VIEW_COMMANDS.SET_AGENT_OPTIONS,
-            optionsData: agentOptionsData,
-          });
-        } catch (error) {
-          const message = toErrorMessage(error);
-          logger.error(CHANNEL, `Failed to refresh options: ${message}`);
-          vscode.window.showErrorMessage(
-            `Failed to refresh options: ${message}`,
-          );
-        }
+        const options = await loadOptions({
+          onError: (error) => {
+            const message = toErrorMessage(error);
+            logger.error(CHANNEL, `Failed to refresh options: ${message}`);
+            vscode.window.showErrorMessage(
+              `Failed to refresh options: ${message}`,
+            );
+          },
+        });
+        if (!options) return;
+
+        webview.webview.postMessage({
+          command: MAIN_VIEW_COMMANDS.SET_MODEL_OPTIONS,
+          optionsData: options.modelOptions,
+        });
+        webview.webview.postMessage({
+          command: MAIN_VIEW_COMMANDS.SET_AGENT_OPTIONS,
+          optionsData: options.agentOptions,
+        });
       },
     ),
   );

--- a/src/common/webview/commands.ts
+++ b/src/common/webview/commands.ts
@@ -214,6 +214,7 @@ export const PROGRESS_VIEW_COMMANDS = {
   SEND_FOLLOW_UP: 'sendFollowUp',
   POLISH_FOLLOW_UP: 'polishFollowUp',
   FOLLOW_UP_TEXT_POLISHED: 'followUpTextPolished',
+  FOLLOW_UP_TEXT_POLISH_ERROR: 'followUpTextPolishError',
   FOLLOW_UP_TEXT_TRANSCRIBED: 'followUpTextTranscribed',
   START_RECORDING: 'startRecording',
   STOP_RECORDING: 'stopRecording',

--- a/src/frontend/agents/optionsLoader.ts
+++ b/src/frontend/agents/optionsLoader.ts
@@ -1,5 +1,5 @@
 // Local imports - agent options
-import { computeAgentOptionsData } from '@agent/index';
+import { computeAgentOptionsData, refresh } from '@agent/index';
 
 // Local imports - model options
 import { computeModelOptionsData } from '@model/computeModelOptions';
@@ -13,20 +13,37 @@ export interface OptionsPayload {
   defaultMergeModel: string;
 }
 
-export async function loadOptions(): Promise<OptionsPayload> {
-  const [modelOptions, agentOptions] = await Promise.all([
-    computeModelOptionsData(),
-    computeAgentOptionsData(),
-  ]);
+export interface LoadOptionsParams {
+  refreshAgents?: boolean;
+  onError?: (error: unknown) => void;
+}
 
-  const defaultMergeModel = getConfig<string>(
-    'texra.merge.defaultModel',
-    'gemini3f',
-  );
+export async function loadOptions(
+  params: LoadOptionsParams = {},
+): Promise<OptionsPayload | null> {
+  const { refreshAgents = true, onError } = params;
 
-  return {
-    agentOptions,
-    modelOptions,
-    defaultMergeModel,
-  };
+  try {
+    if (refreshAgents) {
+      await refresh();
+    }
+    const [modelOptions, agentOptions] = await Promise.all([
+      computeModelOptionsData(),
+      computeAgentOptionsData(),
+    ]);
+
+    const defaultMergeModel = getConfig<string>(
+      'texra.merge.defaultModel',
+      'gemini3f',
+    );
+
+    return {
+      agentOptions,
+      modelOptions,
+      defaultMergeModel,
+    };
+  } catch (error) {
+    onError?.(error);
+    return null;
+  }
 }

--- a/src/historyView/frontend/HistoryApp.ts
+++ b/src/historyView/frontend/HistoryApp.ts
@@ -150,6 +150,7 @@ export class HistoryApp extends BaseWebviewApp {
 
       <history-search-bar
         .matchCount=${this.matchCount}
+        .searchTerm=${this.searchTerm}
         @history-search-change=${this.handleSearchChange}
         @history-search-next=${() => this.handleSearchNavigate('next')}
         @history-search-prev=${() => this.handleSearchNavigate('prev')}

--- a/src/historyView/frontend/components/HistoryList.ts
+++ b/src/historyView/frontend/components/HistoryList.ts
@@ -50,6 +50,8 @@ export class HistoryList extends LitElement {
   /** Match counts per item, keyed by item.id - used to compute highlighted index */
   @state() private matchCounts: Map<string, number> = new Map();
 
+  private searchVersion = 0;
+
   @queryAll('history-item')
   private historyItemElements!: Array<
     HTMLElement & {
@@ -89,13 +91,15 @@ export class HistoryList extends LitElement {
   protected updated(changedProps: Map<string, unknown>): void {
     // Re-apply search when items change (e.g., new history loaded)
     if (changedProps.has('items') && this.searchTerm) {
-      void this.applySearchToItems(this.searchTerm);
+      const version = (this.searchVersion += 1);
+      void this.applySearchToItems(this.searchTerm, version);
     }
   }
 
   // === Internal search operations (called from willUpdate) ===
 
   private performClearSearch(): void {
+    this.searchVersion += 1;
     this.matchCounts = new Map();
     this.state?.setSearchIndex(-1);
     this.state?.setTotalMatches(0);
@@ -111,7 +115,8 @@ export class HistoryList extends LitElement {
       this.updateMatchCount();
       return;
     }
-    void this.applySearchToItems(term);
+    const version = (this.searchVersion += 1);
+    void this.applySearchToItems(term, version);
   }
 
   private performNavigate(direction: 'next' | 'prev'): void {
@@ -160,13 +165,17 @@ export class HistoryList extends LitElement {
     return null;
   }
 
-  private async applySearchToItems(term: string): Promise<void> {
+  private async applySearchToItems(
+    term: string,
+    version: number,
+  ): Promise<void> {
     const historyItems = this.getHistoryItems();
     const counts = await Promise.all(
       historyItems.map(
         (item) => item.applySearch?.(term) ?? Promise.resolve(0),
       ),
     );
+    if (version !== this.searchVersion) return;
 
     // Store match counts per item for computing highlighted indices
     const newMatchCounts = new Map<string, number>();

--- a/src/historyView/frontend/components/SearchBar.ts
+++ b/src/historyView/frontend/components/SearchBar.ts
@@ -6,6 +6,7 @@
 // Third-party imports
 import { LitElement, html, type TemplateResult } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
+import { live } from 'lit/directives/live.js';
 
 // Local imports - shared styles
 import { designTokens, codiconStyles } from '@shared/styles';
@@ -19,6 +20,7 @@ export class SearchBar extends LitElement {
   static override styles = [designTokens, codiconStyles, historyViewStyles];
 
   @property({ type: String }) matchCount = '';
+  @property({ type: String }) searchTerm = '';
 
   private searchTimeoutId: ReturnType<typeof setTimeout> | null = null;
 
@@ -66,6 +68,7 @@ export class SearchBar extends LitElement {
           class="search-input"
           type="search"
           placeholder="Search history items..."
+          .value=${live(this.searchTerm)}
           @input=${this.handleInput}
           @keydown=${this.handleKeydown}
         ></vscode-textfield>

--- a/src/profileView/frontend/components/AgentsTable.ts
+++ b/src/profileView/frontend/components/AgentsTable.ts
@@ -43,8 +43,9 @@ export class AgentsTable extends LitElement {
 
   private renderAgentRow(agent: RemoteAgent): TemplateResult {
     const visibilityArray = this.normalizeVisibility(agent.visibility);
-    const visibilityClass =
-      visibilityArray[0] === 'public' ? 'public' : 'custom';
+    const visibilityClass = visibilityArray.includes('public')
+      ? 'public'
+      : 'custom';
     const multiOutputClass = agent.supportsMultipleOutput
       ? 'supported'
       : 'not-supported';

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -6,6 +6,7 @@ import {
   type ProgressViewInboundHandlerRegistry,
   type ProgressViewInboundMessage,
 } from '@shared/schemas/progressView';
+import { deriveUseMultipleOutputs } from '@shared/utils/useMultipleOutputs';
 import { AgentCategory } from '@agent/core/AgentDataclass';
 import { AgentConfigSchema, type AgentConfig } from '@agent/core/AgentConfig';
 import { getAgent } from '@agent/index/agentRegistry';
@@ -178,8 +179,8 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
         this.handleOpenMemoryView(),
 
       // Followup task
-      [PROGRESS_VIEW_COMMANDS.GET_FOLLOWUP_OPTIONS]: () =>
-        this.handleGetFollowupOptions(),
+      [PROGRESS_VIEW_COMMANDS.GET_FOLLOWUP_OPTIONS]: (data) =>
+        this.handleGetFollowupOptions(data),
       [PROGRESS_VIEW_COMMANDS.SETUP_FOLLOWUP]: (data) =>
         this.handleSetupFollowup(data),
       [PROGRESS_VIEW_COMMANDS.RUN_FOLLOWUP]: (data) =>
@@ -277,6 +278,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     this.provider.eventHandler.clearPendingTaskGroups(streamId);
     cleanupApprovalsForStream(streamId);
     ToolUseFollowUpQueue.release(streamId);
+    this.clearModelOutputBackups(streamId);
     await this.provider.state.clearStream(streamId);
     // Force rebuild since we deleted a stream
     this.provider.updateWebview({ forceRebuild: true });
@@ -301,6 +303,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     for (const streamId of this.provider.state.streamTabs.keys()) {
       ToolUseFollowUpQueue.release(streamId);
     }
+    this.modelOutputBackups.clear();
     await this.provider.state.clearAll();
     // Force rebuild since we deleted all streams
     this.provider.updateWebview({ forceRebuild: true });
@@ -478,12 +481,22 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
             });
           } else if (result.error) {
             await vscode.window.showErrorMessage(result.error);
+            const view = this.getActiveView();
+            view?.webview.postMessage({
+              command: PROGRESS_VIEW_COMMANDS.FOLLOW_UP_TEXT_POLISH_ERROR,
+              error: result.error,
+            });
           }
         } catch (error) {
           const messageText = toErrorMessage(error);
           await vscode.window.showErrorMessage(
             `Error polishing follow-up: ${messageText}`,
           );
+          const view = this.getActiveView();
+          view?.webview.postMessage({
+            command: PROGRESS_VIEW_COMMANDS.FOLLOW_UP_TEXT_POLISH_ERROR,
+            error: messageText,
+          });
           this.logger.error(
             this.channel,
             `Error polishing follow-up: ${messageText}`,
@@ -569,7 +582,12 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
         mediaFile: proposal.mediaFile,
         mediaFiles: proposal.mediaFiles,
         outputFiles: proposal.outputFiles,
-        useMultipleOutputs: proposal.useMultipleOutputs,
+        useMultipleOutputs: deriveUseMultipleOutputs({
+          isToolUse: !isWorkflow,
+          outputFiles: proposal.outputFiles ?? [],
+          outputFilesActive: activeFiles.output,
+          useMultipleOutputs: proposal.useMultipleOutputs,
+        }),
         inputFilesActive: activeFiles.input,
         referenceFilesActive: activeFiles.reference,
         auxiliaryFilesActive: activeFiles.auxiliary,
@@ -682,12 +700,16 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     data: MessageFor<typeof PROGRESS_VIEW_COMMANDS.COMPARE_ORIGINAL>,
   ): Promise<void> {
     const { file, base } = data;
+    if (!base) return;
     const streamId = this.provider.state.activeStream;
     if (streamId && file) {
       try {
         const fileLocation = createExternalLocation(file);
         const content = await flexibleFS.read(fileLocation);
-        this.modelOutputBackups.set(file, { content, streamId });
+        this.modelOutputBackups.set(
+          this.getModelOutputBackupKey(streamId, file),
+          { content, streamId },
+        );
       } catch {
         // Ignore backup errors
       }
@@ -713,19 +735,18 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     const { file, base, prev } = data;
     const previousFile = prev ?? base;
 
-    if (previousFile) {
-      await vscode.commands.executeCommand(
-        'texra.latexdiff',
-        undefined,
-        previousFile,
-        file,
-      );
-    }
+    if (!previousFile) return;
+    await vscode.commands.executeCommand(
+      'texra.latexdiff',
+      undefined,
+      previousFile,
+      file,
+    );
 
     await vscode.commands.executeCommand(
       'texra.compare',
       pathToLocation(''), // inputFile unused
-      pathToLocation(previousFile || ''),
+      pathToLocation(previousFile),
       pathToLocation(file),
     );
   }
@@ -734,7 +755,13 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     data: MessageFor<typeof PROGRESS_VIEW_COMMANDS.ACCEPT_FILE>,
   ): Promise<void> {
     const { file, base } = data;
-    const backup = file ? this.modelOutputBackups.get(file) : null;
+    const streamId = this.provider.state.activeStream;
+    const backup =
+      file && streamId
+        ? this.modelOutputBackups.get(
+            this.getModelOutputBackupKey(streamId, file),
+          )
+        : null;
     let currentContent: string | null = null;
 
     if (backup) {
@@ -774,8 +801,23 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
       });
     }
 
-    if (file) {
-      this.modelOutputBackups.delete(file);
+    if (file && streamId) {
+      this.modelOutputBackups.delete(
+        this.getModelOutputBackupKey(streamId, file),
+      );
+    }
+  }
+
+  private getModelOutputBackupKey(streamId: StreamTabId, file: string): string {
+    return `${streamId}:${file}`;
+  }
+
+  private clearModelOutputBackups(streamId: StreamTabId): void {
+    const prefix = `${streamId}:`;
+    for (const key of this.modelOutputBackups.keys()) {
+      if (key.startsWith(prefix)) {
+        this.modelOutputBackups.delete(key);
+      }
     }
   }
 
@@ -823,16 +865,30 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
   // Followup task handlers
   // ============================================================
 
-  private async handleGetFollowupOptions(): Promise<void> {
+  private async handleGetFollowupOptions(
+    data: MessageFor<typeof PROGRESS_VIEW_COMMANDS.GET_FOLLOWUP_OPTIONS>,
+  ): Promise<void> {
     const view = this.getActiveView();
     if (!view) return;
 
     try {
-      const { agentOptions, modelOptions, defaultMergeModel } =
-        await loadOptions();
+      const options = await loadOptions({
+        refreshAgents: false,
+        onError: (error) => {
+          this.logger.error(
+            this.channel,
+            `Failed to get followup options: ${toErrorMessage(error)}`,
+          );
+        },
+      });
+      if (!options) return;
+      const { agentOptions, modelOptions, defaultMergeModel } = options;
+      const stream = data.stream ?? this.provider.state.activeStream;
+      if (!stream) return;
 
       view.webview.postMessage({
         command: PROGRESS_VIEW_COMMANDS.SET_FOLLOWUP_OPTIONS,
+        stream,
         workflowAgentsData: agentOptions.workflow,
         toolUseAgentsData: agentOptions.toolUse,
         modelOptionsData: modelOptions,
@@ -893,10 +949,12 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     const outputFiles = [...new Set(allFiles)];
 
     // Priority: explicit config > activeFiles flag > infer from file count
-    const useMultipleOutputs =
-      taskState.agentConfig.useMultipleOutputs ??
-      taskState.activeFiles.output ??
-      outputFiles.length > 1;
+    const useMultipleOutputs = deriveUseMultipleOutputs({
+      isToolUse: false,
+      outputFiles,
+      outputFilesActive: taskState.activeFiles.output,
+      useMultipleOutputs: taskState.agentConfig.useMultipleOutputs,
+    });
 
     await vscode.commands.executeCommand(command, {
       streamId,
@@ -1193,9 +1251,13 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
         ]
       : originalConfig.outputFiles;
 
-    const useMultipleOutputs =
-      (attachAgentOutputs && outputFiles.length > 1) ||
-      originalConfig.useMultipleOutputs;
+    const useMultipleOutputs = deriveUseMultipleOutputs({
+      isToolUse: isChat,
+      outputFiles,
+      outputFilesActive: originalTaskState.activeFiles.output,
+      useMultipleOutputs: originalConfig.useMultipleOutputs,
+      attachAgentOutputs,
+    });
 
     const newConfig = {
       ...originalConfig,
@@ -1209,9 +1271,10 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
       instruction,
       agentCategory,
     } as AgentConfig;
+    const validatedConfig = AgentConfigSchema.parse(newConfig);
 
     if (isChat) {
-      return { agentConfig: newConfig } as TaskState;
+      return { agentConfig: validatedConfig } as TaskState;
     }
 
     const activeFiles = {
@@ -1221,7 +1284,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     };
 
     return {
-      agentConfig: newConfig,
+      agentConfig: validatedConfig,
       activeFiles,
     } as TaskState;
   }

--- a/src/progressView/frontend/ProgressApp.ts
+++ b/src/progressView/frontend/ProgressApp.ts
@@ -14,10 +14,12 @@ import { PersistedState, createWebviewStorage } from '@shared/state';
 // Local imports - shared schemas
 import {
   AGENT_CATEGORY,
+  AgentCategoryFilterSchema,
   type StreamTabId,
   type StreamTabInfo,
 } from '@shared/schemas';
 import { resolveRunId } from '@shared/streams/runSelection';
+import { StreamSortSchema } from '@shared/streams/streamSort';
 
 // Local imports - webview commands
 import { PROGRESS_VIEW_COMMANDS } from '@common/webview/commands';
@@ -35,8 +37,8 @@ import {
 
 /** Schema for persisted preferences. */
 const ProgressViewPrefsSchema = z.object({
-  streamFilter: z.string().prefault('all') as z.ZodType<StreamFilter>,
-  streamSort: z.string().prefault('time') as z.ZodType<StreamSort>,
+  streamFilter: AgentCategoryFilterSchema.catch('all'),
+  streamSort: StreamSortSchema.catch('time'),
 });
 
 type ProgressViewPreferences = z.infer<typeof ProgressViewPrefsSchema>;
@@ -247,11 +249,8 @@ export class ProgressApp extends BaseWebviewApp {
 
   private getActiveStreamInfo(): StreamTabInfo | null {
     if (!this.appState.activeStreamId) return null;
-    // Search in filtered streams to respect current filter
-    // This ensures we don't show content for streams hidden by filter
-    const filteredStreams = getFilteredStreams(this.appState);
     return (
-      filteredStreams.find(
+      this.appState.streams.find(
         (stream) => stream.name === this.appState.activeStreamId,
       ) ?? null
     );
@@ -271,13 +270,15 @@ export class ProgressApp extends BaseWebviewApp {
       activeStream.agentCategory,
     );
     const isToolUse = isToolUseState(streamState);
-    const runId = resolveRunId(streamState, { mode: 'strict' });
+    const runId = resolveRunId(streamState, { mode: 'fallback' });
+    const followupOptions =
+      this.appState.followupOptionsByStream.get(activeStream.name) ?? null;
 
     this.streamContextValue = {
       streamInfo: activeStream,
       streamState,
       runId,
-      followupOptions: this.appState.followupOptions,
+      followupOptions,
       isToolUse,
     };
     this.permissionsContextValue = this.permissions;

--- a/src/progressView/frontend/components/FileList.ts
+++ b/src/progressView/frontend/components/FileList.ts
@@ -212,7 +212,7 @@ export class FileList extends LitElement {
     if (!this.showRoundHeaders) {
       return html`${repeat(
         files,
-        (file) => file.location?.absolutePath ?? '',
+        (file) => `${round}-${file.location?.absolutePath ?? ''}`,
         (file) => this.renderFileItem(file),
       )}`;
     }
@@ -226,7 +226,7 @@ export class FileList extends LitElement {
         <div class="round-content">
           ${repeat(
             files,
-            (file) => file.location?.absolutePath ?? '',
+            (file) => `${round}-${file.location?.absolutePath ?? ''}`,
             (file) => this.renderFileItem(file),
           )}
         </div>
@@ -284,12 +284,12 @@ export class FileList extends LitElement {
    * All data is stored directly on command elements for unified delegation.
    */
   private handleFileClick(event: MouseEvent): void {
-    const target = event.target as Element | null;
-    if (!target) return;
-
-    // Find element with data-command (all needed data is on this element)
-    const actionEl = target.closest('[data-command]');
-    if (!(actionEl instanceof HTMLElement)) return;
+    const path = event.composedPath?.() ?? [];
+    const actionEl = path.find(
+      (entry) =>
+        entry instanceof HTMLElement && entry.matches('[data-command]'),
+    ) as HTMLElement | undefined;
+    if (!actionEl) return;
 
     const { command, file, base, prev } = actionEl.dataset;
     if (!command || !file) return;

--- a/src/progressView/frontend/components/FollowUpInput.ts
+++ b/src/progressView/frontend/components/FollowUpInput.ts
@@ -108,6 +108,7 @@ export class FollowUpInput extends LitElement {
   // Reactive properties for Lit-native patterns (Phase 9e)
   @property({ type: Boolean }) shouldFocus = false;
   @property({ type: String }) polishedText: string | null = null;
+  @property({ type: String }) polishError: string | null = null;
   @property({ type: String }) transcribedText: string | null = null;
   @property({ type: Boolean }) recording = false;
 
@@ -141,6 +142,10 @@ export class FollowUpInput extends LitElement {
       this.focusInput({ scrollIntoView: true });
     }
 
+    if (changedProperties.has('polishError') && this.polishError !== null) {
+      this.polishing = false;
+    }
+
     // React to transcribedText property change
     if (
       changedProperties.has('transcribedText') &&
@@ -171,7 +176,7 @@ export class FollowUpInput extends LitElement {
 
   /** Handle keyboard events on the textarea - Lit-native pattern */
   private handleKeydown(event: KeyboardEvent): void {
-    if (event.key === 'Enter' && !event.shiftKey) {
+    if (event.key === 'Enter' && !event.shiftKey && !event.isComposing) {
       event.preventDefault();
       this.emitSend();
     }
@@ -274,6 +279,7 @@ export class FollowUpInput extends LitElement {
   }
 
   private emitPolish(): void {
+    if (!this.value.trim()) return;
     this.polishing = true;
     this.dispatchEvent(ProgressEvents.followupPolish());
   }

--- a/src/progressView/frontend/components/LatexdiffResults.ts
+++ b/src/progressView/frontend/components/LatexdiffResults.ts
@@ -154,7 +154,8 @@ export class LatexdiffResults extends LitElement {
         >
           ${repeat(
             this.entries,
-            (entry) => `${entry.baseFile}-${entry.revisedFile}`,
+            (entry) =>
+              `${entry.baseFile}-${entry.revisedFile}-${entry.baseRound ?? 'base'}-${entry.revisedRound}-${entry.runId ?? ''}`,
             (entry) => this.renderEntry(entry),
           )}
         </ul>

--- a/src/progressView/frontend/components/PermissionCard.ts
+++ b/src/progressView/frontend/components/PermissionCard.ts
@@ -6,7 +6,6 @@ import { when } from 'lit/directives/when.js';
 
 // Local imports - shared
 import { AGENT_CATEGORY } from '@shared/schemas';
-import { getBasename } from '@shared/utils/path';
 import { PERMISSION_KIND } from '@shared/utils/uiConstants';
 import { postMessage } from '@shared/vscode';
 import { designTokens } from '@shared/styles/litStyles';
@@ -18,6 +17,10 @@ import { PROGRESS_VIEW_COMMANDS } from '@common/webview/commands';
 
 // Local imports - progress view
 import { ProgressEvents } from '../events';
+import {
+  buildWorkflowFileLists,
+  renderWorkflowFilesList,
+} from './helpers/workflowFilesList';
 import type {
   AgentProposalPermission,
   BashPermission,
@@ -285,52 +288,13 @@ export class PermissionCard extends LitElement {
   private renderWorkflowFiles(
     data: WorkflowAgentProposalPermission,
   ): TemplateResult {
-    const combine = (single: string | null | undefined, arr: string[] = []) =>
-      [single, ...arr].filter((f): f is string => Boolean(f));
-
-    const fileLists = [
-      { label: 'Input', files: combine(data.inputFile, data.inputFiles) },
-      {
-        label: 'Reference',
-        files: combine(data.referenceFile, data.referenceFiles),
-      },
-      {
-        label: 'Auxiliary',
-        files: combine(data.auxiliaryFile, data.auxiliaryFiles),
-      },
-      { label: 'Media', files: combine(data.mediaFile, data.mediaFiles) },
-      { label: 'Output', files: data.outputFiles ?? [] },
-    ];
-
-    return html`${repeat(
-      fileLists,
-      ({ label }) => label,
-      ({ label, files }) => this.renderFileList(label, files),
-    )}`;
-  }
-
-  private renderFileList(
-    label: string,
-    files: string[],
-  ): TemplateResult | typeof nothing {
-    if (files.length === 0) return nothing;
-
-    return html`
-      <div class="file-list">
-        <span class="file-list-label">${label}:</span>
-        ${repeat(
-          files,
-          (file) => file,
-          (file, i) =>
-            html`${i > 0 ? ', ' : ''}<span
-                class="file-link"
-                title=${file}
-                @click=${() => this.openFile(file)}
-                >${getBasename(file)}</span
-              >`,
-        )}
-      </div>
-    `;
+    const fileLists = buildWorkflowFileLists(data);
+    return renderWorkflowFilesList(fileLists, {
+      getContainerClass: () => 'file-list',
+      labelClass: 'file-list-label',
+      fileClass: 'file-link',
+      onFileClick: (file) => this.openFile(file),
+    });
   }
 
   // ===========================================================================

--- a/src/progressView/frontend/components/RequestPanels.ts
+++ b/src/progressView/frontend/components/RequestPanels.ts
@@ -1,5 +1,11 @@
 // Third-party imports
-import { LitElement, html, nothing, type TemplateResult } from 'lit';
+import {
+  LitElement,
+  html,
+  nothing,
+  type PropertyValues,
+  type TemplateResult,
+} from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { repeat } from 'lit/directives/repeat.js';
 import { classMap } from 'lit/directives/class-map.js';
@@ -25,7 +31,6 @@ import {
 } from '@shared/schemas';
 
 // Local imports - shared utilities
-import { getBasename } from '@shared/utils/path';
 import { PERMISSION_KIND } from '@shared/utils/uiConstants';
 import { postMessage } from '@shared/vscode';
 
@@ -36,6 +41,10 @@ import { PROGRESS_VIEW_COMMANDS } from '@common/webview/commands';
 import { ProgressEvents } from '../events';
 
 // Local imports - progress view component types
+import {
+  buildWorkflowFileLists,
+  renderWorkflowFilesList,
+} from './helpers/workflowFilesList';
 import type { PermissionState } from './PermissionCard';
 
 const FEEDBACK_KINDS = new Set<PermissionState['kind']>([
@@ -73,6 +82,23 @@ export class RequestPanels extends LitElement {
     document.removeEventListener('click', this.handleOutsideClick, true);
     document.removeEventListener('keydown', this.handleGlobalKeydown);
     super.disconnectedCallback();
+  }
+
+  protected override willUpdate(changedProperties: PropertyValues<this>): void {
+    if (changedProperties.has('permissions')) {
+      const validKeys = new Set(
+        this.permissions.map((permission) => this.getPermissionKey(permission)),
+      );
+      if (this.openDiffMenuKey && !validKeys.has(this.openDiffMenuKey)) {
+        this.openDiffMenuKey = null;
+      }
+      const nextFeedbackKeys = new Set(
+        [...this.feedbackOpenKeys].filter((key) => validKeys.has(key)),
+      );
+      if (nextFeedbackKeys.size !== this.feedbackOpenKeys.size) {
+        this.feedbackOpenKeys = nextFeedbackKeys;
+      }
+    }
   }
 
   override render(): TemplateResult | typeof nothing {
@@ -495,58 +521,14 @@ export class RequestPanels extends LitElement {
   private renderProposalFiles(
     permission: WorkflowAgentProposalPermission,
   ): TemplateResult | typeof nothing {
-    const combine = (single: string | null | undefined, arr: string[] = []) =>
-      [single, ...arr].filter((f): f is string => Boolean(f));
-
-    const fileLists = [
-      {
-        label: 'Input',
-        files: combine(permission.inputFile, permission.inputFiles),
-      },
-      {
-        label: 'Reference',
-        files: combine(permission.referenceFile, permission.referenceFiles),
-      },
-      {
-        label: 'Auxiliary',
-        files: combine(permission.auxiliaryFile, permission.auxiliaryFiles),
-      },
-      {
-        label: 'Media',
-        files: combine(permission.mediaFile, permission.mediaFiles),
-      },
-      { label: 'Output', files: permission.outputFiles ?? [] },
-    ];
-
-    return html`${repeat(
-      fileLists,
-      ({ label }) => label,
-      ({ label, files }) => this.renderProposalFileList(label, files),
-    )}`;
-  }
-
-  private renderProposalFileList(
-    label: string,
-    files: string[],
-  ): TemplateResult | typeof nothing {
-    if (files.length === 0) return nothing;
-
-    return html`
-      <div class="workflow-proposal__${label.toLowerCase()}-files">
-        <span class="workflow-proposal__file-label">${label}:</span>
-        ${repeat(
-          files,
-          (file) => file,
-          (file, i) =>
-            html`${i > 0 ? ', ' : ''}<span
-                class="workflow-proposal__file-name"
-                title=${file}
-                @click=${() => this.openFile(file)}
-                >${getBasename(file)}</span
-              >`,
-        )}
-      </div>
-    `;
+    const fileLists = buildWorkflowFileLists(permission);
+    return renderWorkflowFilesList(fileLists, {
+      getContainerClass: (label) =>
+        `workflow-proposal__${label.toLowerCase()}-files`,
+      labelClass: 'workflow-proposal__file-label',
+      fileClass: 'workflow-proposal__file-name',
+      onFileClick: (file) => this.openFile(file),
+    });
   }
 
   private renderFeedbackSection(
@@ -778,10 +760,12 @@ export class RequestPanels extends LitElement {
   };
 
   private handleMenuClick = (event: CustomEvent): void => {
-    const target = event.target as Element | null;
-    if (!target) return;
-
-    const menuItem = target.closest('vscode-context-menu-item');
+    const path = event.composedPath?.() ?? [];
+    const menuItem = path.find(
+      (entry) =>
+        entry instanceof HTMLElement &&
+        entry.matches('vscode-context-menu-item'),
+    ) as HTMLElement | undefined;
     if (!menuItem) return;
 
     const kind = menuItem.dataset.permissionKind as
@@ -907,12 +891,19 @@ export class RequestPanels extends LitElement {
     const lines = [
       details.message && `message: ${details.message}`,
       details.provider && `provider: ${details.provider}`,
-      details.statusCode != null && `statusCode: ${details.statusCode}`,
+      details.statusCode !== undefined &&
+        details.statusCode !== null &&
+        `statusCode: ${details.statusCode}`,
       details.statusText && `statusText: ${details.statusText}`,
-      details.isRelayError != null && `isRelayError: ${details.isRelayError}`,
-      details.retryable != null && `retryable: ${details.retryable}`,
+      details.isRelayError !== undefined &&
+        details.isRelayError !== null &&
+        `isRelayError: ${details.isRelayError}`,
+      details.retryable !== undefined &&
+        details.retryable !== null &&
+        `retryable: ${details.retryable}`,
       details.requestId && `requestId: ${details.requestId}`,
-      details.rawErrorBody != null &&
+      details.rawErrorBody !== undefined &&
+        details.rawErrorBody !== null &&
         `rawErrorBody: ${formatBody(details.rawErrorBody)}`,
     ].filter(Boolean);
 

--- a/src/progressView/frontend/components/StreamHeader.ts
+++ b/src/progressView/frontend/components/StreamHeader.ts
@@ -44,6 +44,7 @@ const STATUS_LABELS: Record<string, string> = {
   [STREAM_STATUS.READY]: 'Ready',
   [STREAM_STATUS.WAITING]: 'Waiting for follow-up',
   [STREAM_STATUS.RESUMING]: 'Resuming',
+  [STREAM_STATUS.INITIALIZING]: 'Initializing',
 };
 
 /**
@@ -51,6 +52,7 @@ const STATUS_LABELS: Record<string, string> = {
  * Maps status to array of button IDs that should be enabled.
  */
 const ENABLED_BUTTONS_BY_STATUS: Record<string, string[]> = {
+  [STREAM_STATUS.INITIALIZING]: [ELEMENT_IDS.STOP_STREAM_BTN],
   [STREAM_STATUS.RUNNING]: [
     ELEMENT_IDS.STOP_STREAM_BTN,
     ELEMENT_IDS.YOLO_TOGGLE_BTN,
@@ -433,9 +435,11 @@ export class StreamHeader extends LitElement {
   }
 
   private handleToolbarClick(event: MouseEvent) {
-    const target = event.target as Element | null;
-    if (!target) return;
-    const button = target.closest('[data-command]') as HTMLElement | null;
+    const path = event.composedPath?.() ?? [];
+    const button = path.find(
+      (entry) =>
+        entry instanceof HTMLElement && entry.matches('[data-command]'),
+    ) as HTMLElement | undefined;
     if (!button || button.hasAttribute('disabled')) return;
 
     const command = button.dataset.command;

--- a/src/progressView/frontend/components/StreamTabs.ts
+++ b/src/progressView/frontend/components/StreamTabs.ts
@@ -33,7 +33,7 @@ import type { StreamFilter, StreamSort } from '../store';
 import type { StreamTabInfo } from '@shared/schemas';
 
 /** Format status string for display (capitalize first letter) */
-function formatStatusLabel(status: string): string {
+function formatStatusLabel(status?: string | null): string {
   return status ? status.charAt(0).toUpperCase() + status.slice(1) : '';
 }
 
@@ -92,6 +92,14 @@ export class StreamTabs extends LitElement {
       .agent-filter-group vscode-radio {
         min-width: auto;
         flex: 0 0 auto;
+      }
+
+      .sort-btn.active::part(control) {
+        background-color: var(
+          --vscode-button-secondaryBackground,
+          var(--vscode-button-background)
+        );
+        color: var(--vscode-button-foreground);
       }
 
       .tab-container {
@@ -272,11 +280,15 @@ export class StreamTabs extends LitElement {
               (btn) => html`
                 <vscode-toolbar-button
                   id=${btn.id}
-                  class="sort-btn"
+                  class=${classMap({
+                    'sort-btn': true,
+                    active: this.sort === btn.sort,
+                  })}
                   icon=${btn.icon}
                   label=${btn.title}
                   title=${btn.title}
                   data-sort=${btn.sort}
+                  aria-pressed=${this.sort === btn.sort ? 'true' : 'false'}
                 ></vscode-toolbar-button>
               `,
             )}
@@ -368,12 +380,11 @@ export class StreamTabs extends LitElement {
   }
 
   private handleTabClick(event: MouseEvent): void {
-    const target = event.target as Element | null;
-    if (!target) return;
-
-    // Find element with data-stream and data-action (unified delegation)
-    const actionElement = target.closest('[data-stream][data-action]');
-    if (!(actionElement instanceof HTMLElement)) return;
+    const actionElement = this.getActionElement(
+      event.composedPath?.() ?? [],
+      '[data-stream][data-action]',
+    );
+    if (!actionElement) return;
 
     const { stream: streamId, action } = actionElement.dataset;
     if (!streamId) return;
@@ -397,12 +408,11 @@ export class StreamTabs extends LitElement {
   }
 
   private handleSortClick(event: MouseEvent): void {
-    const target = event.target as Element | null;
-    if (!target) return;
-
-    // Find element with data-sort attribute (unified delegation)
-    const button = target.closest('[data-sort]');
-    if (!(button instanceof HTMLElement) || !button.dataset.sort) return;
+    const button = this.getActionElement(
+      event.composedPath?.() ?? [],
+      '[data-sort]',
+    );
+    if (!button || !button.dataset.sort) return;
 
     this.dispatchEvent(
       ProgressEvents.sortChange({ sort: button.dataset.sort as StreamSort }),
@@ -411,6 +421,17 @@ export class StreamTabs extends LitElement {
 
   private handleDeleteAll(): void {
     this.dispatchEvent(ProgressEvents.deleteAll());
+  }
+
+  private getActionElement(
+    path: EventTarget[],
+    selector: string,
+  ): HTMLElement | null {
+    for (const entry of path) {
+      if (!(entry instanceof HTMLElement)) continue;
+      if (entry.matches(selector)) return entry;
+    }
+    return null;
   }
 
   private buildTooltip(info: StreamTabInfo): string {
@@ -427,7 +448,7 @@ export class StreamTabs extends LitElement {
       : mainLine;
   }
 
-  private normalizeStatus(status?: string): string {
+  private normalizeStatus(status?: string | null): string {
     return status ?? STREAM_STATUS.READY;
   }
 }

--- a/src/progressView/frontend/components/TodoList.ts
+++ b/src/progressView/frontend/components/TodoList.ts
@@ -128,7 +128,7 @@ export class TodoList extends LitElement {
         <div id=${ELEMENT_IDS.TODO_LIST} class="todo-list">
           ${repeat(
             this.todos,
-            (todo) => `${todo.content}-${todo.status}`,
+            (todo, index) => `${index}-${todo.content}-${todo.status}`,
             (todo) => this.renderTodo(todo),
           )}
         </div>

--- a/src/progressView/frontend/components/ToolUseStreamContent.ts
+++ b/src/progressView/frontend/components/ToolUseStreamContent.ts
@@ -155,6 +155,7 @@ export class ToolUseStreamContent extends LitElement {
         .queuedMessages=${currentState.queuedFollowUps}
         .shouldFocus=${currentState.shouldFocusFollowUp ?? false}
         .polishedText=${currentState.polishedText ?? null}
+        .polishError=${currentState.polishError ?? null}
         .transcribedText=${currentState.transcribedText ?? null}
         .recording=${currentState.recording ?? false}
         @focus-complete=${this.handleFocusComplete}

--- a/src/progressView/frontend/components/UsagePanel.ts
+++ b/src/progressView/frontend/components/UsagePanel.ts
@@ -92,6 +92,8 @@ export class UsagePanel extends LitElement {
     const hasUsage =
       (this.usage?.inputTokens ?? 0) > 0 ||
       (this.usage?.outputTokens ?? 0) > 0 ||
+      (this.usage?.cacheReadInputTokens ?? 0) > 0 ||
+      (this.usage?.cacheCreationInputTokens ?? 0) > 0 ||
       (this.usage?.cost ?? 0) > 0;
     const hasContext =
       (this.contextState?.contextWindow ?? 0) > 0 &&

--- a/src/progressView/frontend/components/helpers/workflowFilesList.ts
+++ b/src/progressView/frontend/components/helpers/workflowFilesList.ts
@@ -1,0 +1,71 @@
+// Third-party imports
+import { html, nothing, type TemplateResult } from 'lit';
+import { repeat } from 'lit/directives/repeat.js';
+
+// Local imports - shared utilities
+import { getBasename } from '@shared/utils/path';
+
+// Local imports - shared schemas
+import type { WorkflowAgentProposalPermission } from '@shared/schemas';
+
+export interface WorkflowFileListEntry {
+  label: string;
+  files: string[];
+}
+
+export interface WorkflowFilesRenderOptions {
+  getContainerClass: (label: string) => string;
+  labelClass: string;
+  fileClass: string;
+  onFileClick?: (file: string) => void;
+}
+
+export function buildWorkflowFileLists(
+  proposal: WorkflowAgentProposalPermission,
+): WorkflowFileListEntry[] {
+  const combine = (single: string | null | undefined, arr: string[] = []) =>
+    [single, ...arr].filter((f): f is string => Boolean(f));
+
+  return [
+    { label: 'Input', files: combine(proposal.inputFile, proposal.inputFiles) },
+    {
+      label: 'Reference',
+      files: combine(proposal.referenceFile, proposal.referenceFiles),
+    },
+    {
+      label: 'Auxiliary',
+      files: combine(proposal.auxiliaryFile, proposal.auxiliaryFiles),
+    },
+    { label: 'Media', files: combine(proposal.mediaFile, proposal.mediaFiles) },
+    { label: 'Output', files: proposal.outputFiles ?? [] },
+  ];
+}
+
+export function renderWorkflowFilesList(
+  fileLists: WorkflowFileListEntry[],
+  options: WorkflowFilesRenderOptions,
+): TemplateResult {
+  return html`${repeat(
+    fileLists,
+    ({ label }) => label,
+    ({ label, files }) => {
+      if (files.length === 0) return nothing;
+      return html`
+        <div class=${options.getContainerClass(label)}>
+          <span class=${options.labelClass}>${label}:</span>
+          ${repeat(
+            files,
+            (file) => file,
+            (file, index) =>
+              html`${index > 0 ? ', ' : ''}<span
+                  class=${options.fileClass}
+                  title=${file}
+                  @click=${() => options.onFileClick?.(file)}
+                  >${getBasename(file)}</span
+                >`,
+          )}
+        </div>
+      `;
+    },
+  )}`;
+}

--- a/src/progressView/frontend/messageDispatcher.ts
+++ b/src/progressView/frontend/messageDispatcher.ts
@@ -13,12 +13,12 @@
 import {
   createStreamState,
   ProgressViewOutboundMessageSchema,
+  STREAM_STATUS,
   type LogMessageData,
   type ProgressViewOutboundMessage,
   type StreamTabInfo,
 } from '@shared/schemas';
 import { PERMISSION_KIND } from '@shared/utils/uiConstants';
-import { resolveRunId } from '@shared/streams/runSelection';
 import { PROGRESS_VIEW_COMMANDS } from '@common/webview/commands';
 
 // Local imports - progress view
@@ -83,7 +83,7 @@ function addPermission(
   ctx: MessageHandlerContext,
   permission: PermissionState,
 ): void {
-  ctx.setPermissions([...ctx.getPermissions(), permission]);
+  ctx.setPermissions([permission, ...ctx.getPermissions()]);
 }
 
 function removePrompt(
@@ -121,6 +121,7 @@ function updateStreamInfo(
   for (const key of nextStates.keys()) {
     if (!knownStreams.has(key)) {
       nextStates.delete(key);
+      clearPendingLogUpdatesForStream(key);
     }
   }
 
@@ -170,10 +171,17 @@ const handlers: HandlerRegistry = {
       data.streams,
       data.streamStates,
     );
+    const candidateActive = activeStream || updated.activeStreamId;
+    const hasCandidate = candidateActive
+      ? updated.streams.some((stream) => stream.name === candidateActive)
+      : false;
+    const nextActiveStreamId = hasCandidate
+      ? candidateActive
+      : (updated.streams[0]?.name ?? null);
 
     ctx.setState(() => ({
       ...updated,
-      activeStreamId: activeStream || null,
+      activeStreamId: nextActiveStreamId,
       streamFilter: data.agentFilter,
     }));
   },
@@ -255,19 +263,28 @@ const handlers: HandlerRegistry = {
       if (isWorkflowState(prev)) {
         return {
           ...baseUpdate,
-          activeRunId: activeRunId ?? prev.activeRunId,
-          runInstructions: runInstructions
-            ? { ...prev.runInstructions, ...runInstructions }
-            : prev.runInstructions,
-          runUsage: runUsage
-            ? { ...prev.runUsage, ...runUsage }
-            : prev.runUsage,
-          runFiles: runFiles
-            ? { ...prev.runFiles, ...runFiles }
-            : prev.runFiles,
-          runMissingOutputs: runMissingOutputs
-            ? { ...prev.runMissingOutputs, ...runMissingOutputs }
-            : prev.runMissingOutputs,
+          activeRunId: isClear ? null : (activeRunId ?? prev.activeRunId),
+          selectedRunId: isClear ? null : prev.selectedRunId,
+          runInstructions: isClear
+            ? {}
+            : runInstructions
+              ? { ...prev.runInstructions, ...runInstructions }
+              : prev.runInstructions,
+          runUsage: isClear
+            ? {}
+            : runUsage
+              ? { ...prev.runUsage, ...runUsage }
+              : prev.runUsage,
+          runFiles: isClear
+            ? {}
+            : runFiles
+              ? { ...prev.runFiles, ...runFiles }
+              : prev.runFiles,
+          runMissingOutputs: isClear
+            ? {}
+            : runMissingOutputs
+              ? { ...prev.runMissingOutputs, ...runMissingOutputs }
+              : prev.runMissingOutputs,
         };
       }
 
@@ -388,11 +405,13 @@ const handlers: HandlerRegistry = {
   [PROGRESS_VIEW_COMMANDS.UPDATE_INSTRUCTION]: (data, ctx) => {
     const { stream, instruction, runId: providedRunId } = data;
     if (!stream) return;
+    if (providedRunId === null || providedRunId === undefined) {
+      console.warn('[ProgressView] UPDATE_INSTRUCTION missing runId.');
+      return;
+    }
 
     updateWorkflowState(ctx, stream, (prev) => {
-      // Use provided runId from backend if available, otherwise resolve from state
-      const runId =
-        providedRunId ?? resolveRunId(prev, { mode: 'fallback' }) ?? 'default';
+      const runId = providedRunId;
       const { [runId]: _, ...rest } = prev.runInstructions;
       return {
         ...prev,
@@ -436,15 +455,26 @@ const handlers: HandlerRegistry = {
     const { streamId, id, status, endTime } = data.update;
     ctx.setStreamState(streamId, (prev) => ({
       ...prev,
-      taskGroups: prev.taskGroups.map((group) =>
-        group.id === id
-          ? {
-              ...group,
-              status: status ?? group.status,
-              endTime: endTime ?? group.endTime,
-            }
-          : group,
-      ),
+      taskGroups: prev.taskGroups.some((group) => group.id === id)
+        ? prev.taskGroups.map((group) =>
+            group.id === id
+              ? {
+                  ...group,
+                  status: status ?? group.status,
+                  endTime: endTime ?? group.endTime,
+                }
+              : group,
+          )
+        : [
+            ...prev.taskGroups,
+            {
+              id,
+              name: id,
+              startTime: endTime ?? Date.now(),
+              status: status ?? STREAM_STATUS.RUNNING,
+              endTime,
+            },
+          ],
     }));
   },
 
@@ -512,7 +542,18 @@ const handlers: HandlerRegistry = {
       ...prev,
       followUpText: data.text,
       polishedText: data.text,
+      polishError: null,
       shouldFocusFollowUp: true,
+    }));
+  },
+
+  [PROGRESS_VIEW_COMMANDS.FOLLOW_UP_TEXT_POLISH_ERROR]: (data, ctx) => {
+    const streamId = ctx.getState().activeStreamId;
+    if (!streamId) return;
+
+    updateToolUseState(ctx, streamId, (prev) => ({
+      ...prev,
+      polishError: data.error ?? 'Polish failed.',
     }));
   },
 
@@ -523,6 +564,7 @@ const handlers: HandlerRegistry = {
     updateToolUseState(ctx, streamId, (prev) => ({
       ...prev,
       transcribedText: data.text,
+      polishError: null,
       shouldFocusFollowUp: true,
     }));
   },
@@ -537,12 +579,15 @@ const handlers: HandlerRegistry = {
     setActiveStreamRecording(ctx, false),
 
   [PROGRESS_VIEW_COMMANDS.SET_FOLLOWUP_OPTIONS]: (data, ctx) => {
-    const { command: _command, ...options } = data;
+    const { command: _command, stream, ...options } = data;
+    const streamId = stream ?? ctx.getState().activeStreamId;
+    if (!streamId) return;
 
-    ctx.setState((prev) => ({
-      ...prev,
-      followupOptions: options,
-    }));
+    ctx.setState((prev) => {
+      const next = new Map(prev.followupOptionsByStream);
+      next.set(streamId, options);
+      return { ...prev, followupOptionsByStream: next };
+    });
   },
 };
 

--- a/src/progressView/frontend/stateUtils.ts
+++ b/src/progressView/frontend/stateUtils.ts
@@ -1,5 +1,10 @@
 // Shared imports
 import { sortStreams } from '@shared/streams/streamSort';
+
+// Local imports
+import { isToolUseState, isWorkflowState } from './store';
+
+// Type imports
 import type {
   InstructionUpdate,
   LogMessageData,
@@ -8,14 +13,10 @@ import type {
   StreamTabInfo,
   TaskGroup,
 } from '@shared/schemas';
-
-// Local imports
-import {
-  isToolUseState,
-  isWorkflowState,
-  type ProgressState,
-  type ToolUseStreamState,
-  type WorkflowStreamState,
+import type {
+  ProgressState,
+  ToolUseStreamState,
+  WorkflowStreamState,
 } from './store';
 import type { FrontendEventHandlerContext } from './eventHandlers';
 
@@ -45,7 +46,7 @@ export function updateNestedRounds<T>(
   if (!rounds) return current;
 
   // Merge rounds into the run
-  const base = reset ? {} : current;
+  const base = reset ? { ...current, [runId]: {} } : current;
   const existingRounds = base[runId] ?? {};
   return {
     ...base,

--- a/src/progressView/frontend/store.ts
+++ b/src/progressView/frontend/store.ts
@@ -27,7 +27,10 @@ export type { ContextState };
 export type { StreamSort };
 
 /** Followup options derived from schema (minus command field) */
-export type FollowupOptionsState = Omit<SetFollowupOptionsMessage, 'command'>;
+export type FollowupOptionsState = Omit<
+  SetFollowupOptionsMessage,
+  'command' | 'stream'
+>;
 
 export interface ProgressState {
   activeStreamId: StreamTabId | null;
@@ -35,7 +38,7 @@ export interface ProgressState {
   streamFilter: StreamFilter;
   streamSort: StreamSort;
   streamStates: Map<StreamTabId, StreamState>;
-  followupOptions: FollowupOptionsState | null;
+  followupOptionsByStream: Map<StreamTabId, FollowupOptionsState>;
 }
 
 export function createInitialState(): ProgressState {
@@ -45,7 +48,7 @@ export function createInitialState(): ProgressState {
     streamFilter: 'all',
     streamSort: 'time',
     streamStates: new Map(),
-    followupOptions: null,
+    followupOptionsByStream: new Map(),
   };
 }
 

--- a/src/progressView/frontend/utils.ts
+++ b/src/progressView/frontend/utils.ts
@@ -12,8 +12,12 @@ export type VSCodeValueElement = HTMLElement & { value?: string };
  * Prefers the clicked radio element's value, falls back to group value.
  */
 export function getRadioValue<T extends string>(event: Event): T | null {
-  const target = event.target as Element | null;
-  const radio = target?.closest('vscode-radio');
+  const path = event.composedPath?.() ?? [];
+  const radio = path.find(
+    (entry) =>
+      entry instanceof HTMLElement &&
+      entry.tagName.toLowerCase() === 'vscode-radio',
+  ) as HTMLElement | undefined;
   const radioGroup = event.currentTarget as VSCodeValueElement | null;
   const value = radio?.getAttribute('value') || radioGroup?.value;
   return (value as T) || null;

--- a/src/progressView/managers/WebviewUpdater.ts
+++ b/src/progressView/managers/WebviewUpdater.ts
@@ -410,7 +410,7 @@ export class WebviewUpdater {
    */
   updateAll(
     state: ProgressViewState,
-    statuses?: Map<string, string>,
+    statuses?: Map<string, StreamStatus>,
     theme?: 'dark' | 'light',
   ): StreamTabId {
     const streams = buildStreamInfos(

--- a/src/progressView/streamInfoUtils.ts
+++ b/src/progressView/streamInfoUtils.ts
@@ -7,7 +7,11 @@ import { sortStreams } from '@shared/streams/streamSort';
 // Local imports - progress view
 import { getCleanAgentName, isRemoteAgent } from '@agent/index';
 import { AgentCategory } from '@agent/core/AgentDataclass';
-import type { AgentCategoryFilter, StreamTabInfo } from '@shared/schemas';
+import type {
+  AgentCategoryFilter,
+  StreamStatus,
+  StreamTabInfo,
+} from '@shared/schemas';
 
 // Type imports
 import type { ProgressViewState } from './state/ProgressViewState';
@@ -39,7 +43,7 @@ function matchesFilter(
 function buildStreamInfo(
   state: ProgressViewState,
   id: string,
-  statuses: Map<string, string> | undefined,
+  statuses: Map<string, StreamStatus> | undefined,
   filter: AgentCategoryFilter,
 ): StreamTabInfo | null {
   const taskState = state.getTaskState(id);
@@ -90,7 +94,7 @@ function buildStreamInfo(
  */
 export function buildStreamInfos(
   state: ProgressViewState,
-  statuses?: Map<string, string>,
+  statuses?: Map<string, StreamStatus>,
   filter: AgentCategoryFilter = 'all',
 ): StreamTabInfo[] {
   const infos = state.streamTabs

--- a/src/shared/schemas/progressView.ts
+++ b/src/shared/schemas/progressView.ts
@@ -265,6 +265,11 @@ export const FollowUpTextPolishedMessageSchema = z.object({
   text: z.string(),
 });
 
+export const FollowUpTextPolishErrorMessageSchema = z.object({
+  command: z.literal(PROGRESS_VIEW_COMMANDS.FOLLOW_UP_TEXT_POLISH_ERROR),
+  error: z.string().optional(),
+});
+
 export const FollowUpTextTranscribedMessageSchema = z.object({
   command: z.literal(PROGRESS_VIEW_COMMANDS.FOLLOW_UP_TEXT_TRANSCRIBED),
   text: z.string(),
@@ -284,6 +289,7 @@ export const ProgressRecordingErrorMessageSchema = z.object({
 
 export const SetFollowupOptionsMessageSchema = z.object({
   command: z.literal(PROGRESS_VIEW_COMMANDS.SET_FOLLOWUP_OPTIONS),
+  stream: StreamTabIdSchema,
   workflowAgentsData: z.array(AgentOptionDataSchema).optional(),
   toolUseAgentsData: z.array(AgentOptionDataSchema).optional(),
   modelOptionsData: z.array(ModelOptionDataSchema).optional(),
@@ -333,6 +339,7 @@ export const ProgressViewOutboundMessageSchema = z.discriminatedUnion(
     ShowAgentProposalMessageSchema,
     ResolveAgentProposalMessageSchema,
     FollowUpTextPolishedMessageSchema,
+    FollowUpTextPolishErrorMessageSchema,
     FollowUpTextTranscribedMessageSchema,
     ProgressRecordingStartedMessageSchema,
     ProgressRecordingStoppedMessageSchema,
@@ -414,6 +421,7 @@ const OpenMemoryViewMessageSchema = z.object({
 
 const GetFollowupOptionsMessageSchema = z.object({
   command: z.literal(PROGRESS_VIEW_COMMANDS.GET_FOLLOWUP_OPTIONS),
+  stream: StreamTabIdSchema.optional(),
 });
 
 const StartRecordingMessageSchema = z.object({

--- a/src/shared/schemas/stream.ts
+++ b/src/shared/schemas/stream.ts
@@ -57,7 +57,7 @@ export const StreamTabInfoSchema = z.object({
   lastTimestamp: z.number().optional(),
   inputFile: z.string().optional(),
   creationTimestamp: z.number().optional(),
-  status: z.string().optional(),
+  status: StreamStatusSchema.nullish(),
   executionId: ExecutionIdSchema.optional(),
 });
 export type StreamTabInfo = z.infer<typeof StreamTabInfoSchema>;

--- a/src/shared/schemas/streamState.ts
+++ b/src/shared/schemas/streamState.ts
@@ -48,6 +48,7 @@ export const ToolUseStreamStateSchema = BaseStreamStateSchema.extend({
   toolEditBypass: z.boolean().optional(),
   shouldFocusFollowUp: z.boolean().prefault(false),
   polishedText: z.string().nullable().prefault(null),
+  polishError: z.string().nullable().prefault(null),
   transcribedText: z.string().nullable().prefault(null),
   recording: z.boolean().prefault(false),
 });

--- a/src/shared/streams/streamSort.ts
+++ b/src/shared/streams/streamSort.ts
@@ -37,5 +37,6 @@ export function sortStreams(
   streams: StreamTabInfo[],
   sort: StreamSort,
 ): StreamTabInfo[] {
-  return [...streams].sort(streamComparators[sort]);
+  const comparator = streamComparators[sort] ?? streamComparators.time;
+  return [...streams].sort(comparator);
 }

--- a/src/shared/styles/requestPanelStyles.ts
+++ b/src/shared/styles/requestPanelStyles.ts
@@ -176,6 +176,7 @@ export const requestPanelStyles: CSSResult = css`
     left: 0;
     z-index: 100;
     min-width: 150px;
+    display: block;
   }
 
   .approval-request__actions .diff-dropdown .diff-dropdown-menu:not([show]) {

--- a/src/shared/styles/statusIndicatorStyles.ts
+++ b/src/shared/styles/statusIndicatorStyles.ts
@@ -56,6 +56,14 @@ export const statusIndicatorStyles: CSSResult = css`
     opacity: var(--opacity-disabled, 0.5);
   }
 
+  .status-indicator.is-initializing,
+  .tab-status.is-initializing {
+    background-color: var(--vscode-descriptionForeground);
+    box-shadow: 0 0 4px var(--vscode-descriptionForeground);
+    opacity: 1;
+    animation: pulse-scale 1.8s infinite;
+  }
+
   .status-text {
     font-size: var(--font-size-sm, 12px);
     text-transform: capitalize;
@@ -76,5 +84,9 @@ export const statusIndicatorStyles: CSSResult = css`
   .status-text.is-waiting,
   .status-text.is-resuming {
     color: var(--vscode-textLink-foreground);
+  }
+
+  .status-text.is-initializing {
+    color: var(--vscode-descriptionForeground);
   }
 `;

--- a/src/shared/utils/useMultipleOutputs.ts
+++ b/src/shared/utils/useMultipleOutputs.ts
@@ -1,0 +1,26 @@
+export interface UseMultipleOutputsOptions {
+  isToolUse: boolean;
+  outputFiles?: string[];
+  outputFilesActive?: boolean;
+  useMultipleOutputs?: boolean | null;
+  attachAgentOutputs?: boolean;
+}
+
+export function deriveUseMultipleOutputs(
+  options: UseMultipleOutputsOptions,
+): boolean {
+  const {
+    isToolUse,
+    outputFiles = [],
+    outputFilesActive,
+    useMultipleOutputs,
+    attachAgentOutputs,
+  } = options;
+
+  if (isToolUse) return false;
+  if (useMultipleOutputs !== undefined && useMultipleOutputs !== null) {
+    return useMultipleOutputs;
+  }
+  if (attachAgentOutputs) return outputFiles.length > 1;
+  return Boolean(outputFilesActive) || outputFiles.length > 1;
+}

--- a/src/webview/MainViewMessageHandler.ts
+++ b/src/webview/MainViewMessageHandler.ts
@@ -412,10 +412,19 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
     }
     await super.handleWebviewReady(undefined, webviewView);
     try {
-      const [{ modelOptions, agentOptions }, authStatus] = await Promise.all([
-        loadOptions(),
+      const [options, authStatus] = await Promise.all([
+        loadOptions({
+          onError: (error) => {
+            this.logger.error(
+              this.channel,
+              `Failed to load main view options: ${toErrorMessage(error)}`,
+            );
+          },
+        }),
         getAuthStatus(),
       ]);
+      if (!options) return;
+      const { modelOptions, agentOptions } = options;
 
       webviewView.webview.postMessage({
         command: MAIN_VIEW_COMMANDS.SET_MODEL_OPTIONS,

--- a/src/webview/frontend/MainApp.ts
+++ b/src/webview/frontend/MainApp.ts
@@ -627,13 +627,12 @@ export class MainApp extends BaseWebviewApp {
     const listId = this.multipleListIdMap[message.command];
     if (!listId) return;
 
-    const existing = this.multiFiles[listId] ?? [];
-    const merged = this.mergeUnique(existing, files);
-
-    this.multiFiles = { ...this.multiFiles, [listId]: merged };
-    this.multiFilesVisible = { ...this.multiFilesVisible, [listId]: true };
+    this.multiFiles = { ...this.multiFiles, [listId]: files };
+    if (files.length > 0) {
+      this.multiFilesVisible = { ...this.multiFilesVisible, [listId]: true };
+    }
     if (listId === ELEMENT_IDS.OUTPUT_FILES) {
-      this.outputFilesActive = true;
+      this.outputFilesActive = files.length > 0;
     }
     this.saveState();
   }
@@ -789,9 +788,9 @@ export class MainApp extends BaseWebviewApp {
       typeof MAIN_VIEW_COMMANDS.INSTRUCTION_TEXT_POLISHED
     >,
   ): void {
+    this.isPolishing = false;
     if (message.text.trim()) {
       this.instruction = message.text;
-      this.isPolishing = false;
       postMessage(MAIN_VIEW_COMMANDS.SHOW_INFORMATION_MESSAGE, {
         text: 'Instruction text has been polished!',
       });
@@ -1060,6 +1059,10 @@ export class MainApp extends BaseWebviewApp {
       this.singleFiles = { ...this.singleFiles, [key]: '' };
       this.saveState();
     }
+    const command = FILE_SELECTED_COMMANDS[type];
+    if (command) {
+      postMessage(command, { filePath: '' });
+    }
   }
 
   private handleRefreshEditedFiles(): void {
@@ -1071,12 +1074,11 @@ export class MainApp extends BaseWebviewApp {
 
   private handleEmptyFiles(type: MultipleFileType): void {
     const listId = `${type}Files`;
-    this.multiFiles = { ...this.multiFiles, [listId]: [] };
+    this.updateMultiFiles(listId as keyof MultiFiles, []);
     this.multiFilesVisible = { ...this.multiFilesVisible, [listId]: false };
     if (type === 'output') {
       this.outputFilesActive = false;
     }
-    this.saveState();
   }
 
   private handleRefreshFiles(type: FileType): void {
@@ -1109,7 +1111,7 @@ export class MainApp extends BaseWebviewApp {
     this.sessionType = parsed;
     if (parsed === SESSION_TYPES.TOOL_USE) {
       this.outputFilesActive = false;
-      this.multiFiles = { ...this.multiFiles, outputFiles: [] };
+      this.updateMultiFiles('outputFiles', []);
       this.multiFilesVisible = {
         ...this.multiFilesVisible,
         outputFiles: false,

--- a/src/webview/frontend/components/FileSelectGroup.ts
+++ b/src/webview/frontend/components/FileSelectGroup.ts
@@ -52,6 +52,8 @@ export class FileSelectGroup extends LitElement {
   /** Tool config menu open state */
   @state() private toolConfigMenuOpen = false;
 
+  @state() private wasExpanded = false;
+
   @query('.multiple-files-list')
   private fileListElement?: HTMLElement;
 
@@ -71,6 +73,13 @@ export class FileSelectGroup extends LitElement {
   protected override updated(changedProps: Map<string, unknown>): void {
     if (changedProps.has('config')) {
       this.sortableController.reinitialize();
+    }
+    if (changedProps.has('fileState')) {
+      const isExpanded = this.currentListVisible;
+      if (isExpanded && !this.wasExpanded) {
+        this.sortableController.reinitialize();
+      }
+      this.wasExpanded = isExpanded;
     }
   }
 
@@ -193,11 +202,15 @@ export class FileSelectGroup extends LitElement {
 
   private handleFocusOut(event: FocusEvent): void {
     const nextTarget = event.relatedTarget as Node | null;
-    // Check both light DOM and shadow DOM for focus containment
-    const containsFocus =
-      nextTarget !== null &&
-      (this.contains(nextTarget) || this.shadowRoot?.contains(nextTarget));
-    if (containsFocus) return;
+    if (!nextTarget) {
+      this.autoExtractMenuOpen = false;
+      this.toolConfigMenuOpen = false;
+      return;
+    }
+
+    const path = event.composedPath?.() ?? [];
+    if (path.includes(this)) return;
+
     this.autoExtractMenuOpen = false;
     this.toolConfigMenuOpen = false;
   }
@@ -237,12 +250,13 @@ export class FileSelectGroup extends LitElement {
       <div class="dropdown-container">
         <vscode-toolbar-button
           id="toggleToolConfig"
+          class=${hasChecked ? 'has-options' : ''}
           icon="tools"
           title="Tool configuration options"
           toggleable
           aria-haspopup="true"
           aria-expanded=${this.toolConfigMenuOpen ? 'true' : 'false'}
-          ?checked=${hasChecked}
+          ?checked=${this.toolConfigMenuOpen}
           @click=${() => this.toggleMenu('toolConfig')}
         >
           <i class="codicon ${chevronClass}"></i>
@@ -296,12 +310,13 @@ export class FileSelectGroup extends LitElement {
       <div class="dropdown-container">
         <vscode-toolbar-button
           id="toggleAutoExtract"
+          class=${hasChecked ? 'has-options' : ''}
           icon="wand"
           title="Auto-extract options"
           toggleable
           aria-haspopup="true"
           aria-expanded=${this.autoExtractMenuOpen ? 'true' : 'false'}
-          ?checked=${hasChecked}
+          ?checked=${this.autoExtractMenuOpen}
           @click=${() => this.toggleMenu('autoExtract')}
         >
           <i class="codicon ${chevronClass}"></i>
@@ -362,11 +377,12 @@ export class FileSelectGroup extends LitElement {
       (file) => html`
         <div class="file-item" data-path=${file}>
           <span class="file-name">${file}</span>
-          <span
+          <button
+            type="button"
             class="remove-button codicon codicon-trash"
-            role="button"
+            aria-label="Remove file"
             @click=${() => this.handleRemoveFile(file)}
-          ></span>
+          ></button>
         </div>
       `,
     )}`;
@@ -425,14 +441,15 @@ export class FileSelectGroup extends LitElement {
               title=${config.emptyTitle}
               @click=${this.handleEmptyFile}
             ></vscode-toolbar-button>
-            <span
+            <button
+              type="button"
               id=${toggleId}
               class="toggle-icon"
               title=${config.toggleTitle}
               @click=${this.handleToggleList}
             >
               <i class="codicon ${chevronClass}"></i>
-            </span>
+            </button>
             <vscode-toolbar-button
               id="addOpened${config.type[0].toUpperCase()}${config.type.slice(
                 1,

--- a/src/webview/frontend/components/OutputFilesSection.ts
+++ b/src/webview/frontend/components/OutputFilesSection.ts
@@ -117,11 +117,12 @@ export class OutputFilesSection extends LitElement {
       (file) => html`
         <div class="file-item" data-path=${file}>
           <span class="file-name">${file}</span>
-          <span
+          <button
+            type="button"
             class="remove-button codicon codicon-trash"
-            role="button"
+            aria-label="Remove output file"
             @click=${() => this.handleRemoveFile(file)}
-          ></span>
+          ></button>
         </div>
       `,
     )}`;
@@ -136,14 +137,15 @@ export class OutputFilesSection extends LitElement {
       <div class="file-select" data-expanded=${String(this.currentExpanded)}>
         <div class="file-select-header">
           <div class="file-select-label-group">
-            <span
+            <button
+              type="button"
               id="toggleOutputFiles"
               class="toggle-icon"
               title="Show or hide additional files for the agent's output"
               @click=${this.handleToggle}
             >
               <i class="codicon ${chevronClass}"></i>
-            </span>
+            </button>
             <span
               class="optional-label"
               title="List the files that should receive the agent's output"

--- a/src/webview/frontend/styles/fileSelectStyles.ts
+++ b/src/webview/frontend/styles/fileSelectStyles.ts
@@ -113,11 +113,14 @@ export const toggleStyles = css`
     user-select: none;
     margin: 0;
     position: relative;
+    background: none;
+    border: none;
     padding: 0 var(--spacing-tiny);
     color: var(--text-color);
     display: flex;
     align-items: center;
     height: var(--height-control);
+    font: inherit;
   }
 
   .file-select[data-expanded='true'] .optional-label,
@@ -170,6 +173,9 @@ export const multiFilesStyles = css`
     cursor: pointer;
     flex-shrink: 0;
     opacity: 0.7;
+    background: none;
+    border: none;
+    padding: 0;
   }
 
   .remove-button:hover {
@@ -193,6 +199,20 @@ export const dropdownStyles = css`
 
   .dropdown-container vscode-toolbar-button {
     flex-shrink: 0;
+    position: relative;
+  }
+
+  .dropdown-container vscode-toolbar-button.has-options::after {
+    content: '';
+    position: absolute;
+    top: 2px;
+    right: 2px;
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--vscode-button-background);
+    box-shadow: 0 0 0 1px
+      var(--vscode-button-foreground, var(--vscode-foreground));
   }
 
   .dropdown-container .dropdown-menu {

--- a/src/webview/managers/ExecutionManager.ts
+++ b/src/webview/managers/ExecutionManager.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_TOOL_CONFIG,
   ToolConfigSchema,
 } from '@shared/schemas/toolConfig';
+import { deriveUseMultipleOutputs } from '@shared/utils/useMultipleOutputs';
 import type { AgentConfigInput } from '@agent/core/AgentConfig';
 import { AgentCategory } from '@agent/core/AgentDataclass';
 import { validateExecutionRequest } from '@common/execution/executionRequests';
@@ -90,9 +91,12 @@ export class ExecutionManager {
           ? AgentCategory.ToolUse
           : AgentCategory.Workflow,
         outputFiles,
-        useMultipleOutputs:
-          !isToolUse &&
-          (Boolean(message.outputFilesActive) || outputFiles.length > 1),
+        useMultipleOutputs: deriveUseMultipleOutputs({
+          isToolUse,
+          outputFiles,
+          outputFilesActive: message.outputFilesActive,
+          useMultipleOutputs: message.useMultipleOutputs,
+        }),
         toolConfig,
         mediaFile: mapMedia(message.mediaFile ?? null),
         mediaFiles: (message.mediaFiles ?? [])

--- a/src/webview/managers/FileManager.ts
+++ b/src/webview/managers/FileManager.ts
@@ -216,9 +216,7 @@ export class FileManager extends BaseWebviewManager {
   }
 
   handleSetMultipleFiles(message: SetMultipleFilesMessage): void {
-    if (message.files.length > 0) {
-      this.postMessage({ command: message.command, files: message.files });
-    }
+    this.postMessage({ command: message.command, files: message.files });
   }
 
   async handleSelectMultipleFiles(


### PR DESCRIPTION
### Motivation

- Consolidate and fix multiple Round‑3 PRD issues (backend sync, data loss, follow‑up options, INITIALIZING status and UI regressions) identified in `prd-ui-regression-audit-round3.md` and the dual‑logic audit `dual-logic-audit-2026-02.md`.
- Remove divergent logic paths for `useMultipleOutputs` and ensure UI state changes are reliably propagated to the extension host to prevent stale state and data loss.

### Description

- MainView + FileManager: ensure clears notify backend and multi-file lists are replaced (not merged) by using `updateMultiFiles()` and posting empty lists; removed guard that ignored empty lists in `FileManager.handleSetMultipleFiles`.【src/webview/frontend/MainApp.ts】【src/webview/managers/FileManager.ts】
- Multi‑output unification: add `deriveUseMultipleOutputs()` helper and apply it across execution and follow‑up paths; validate configs where needed so follow‑up runs behave like initial runs.【src/shared/utils/useMultipleOutputs.ts】【src/webview/managers/ExecutionManager.ts】【src/progressView/ProgressViewMessageHandler.ts】
- ProgressView state hardening: fix `updateNestedRounds()` reset semantics to avoid wiping all runs, clear pending log updates for removed streams, reset run‑scoped maps and active/selected run ids on log clears, and make follow‑up options per‑stream instead of global.【src/progressView/frontend/stateUtils.ts】【src/progressView/frontend/messageDispatcher.ts】【src/progressView/frontend/store.ts】
- Model output backups: key backups by `${streamId}:${file}` and clear backups when streams are deleted or accepted to avoid collisions and leaks.【src/progressView/ProgressViewMessageHandler.ts】
- Shadow DOM + delegation fixes: replace multiple `target.closest()` usages with `event.composedPath()` traversal (StreamTabs, StreamHeader, FileList, RequestPanels, utils) so clicks inside VS Code web components work reliably across shadow boundaries.【src/progressView/frontend/components/StreamTabs.ts】【src/progressView/frontend/components/StreamHeader.ts】【src/progressView/frontend/components/FileList.ts】【src/progressView/frontend/components/RequestPanels.ts】【src/progressView/frontend/utils.ts】
- UI/Accessibility fixes: convert click‑only spans to buttons, add aria/pressed states to sort buttons, ensure dropdowns stay open across focus boundaries, add INITIALIZING label and styling, and fix CSS for approval diff dropdown menu display.【src/webview/frontend/components/FileSelectGroup.ts】【src/webview/frontend/components/OutputFilesSection.ts】【src/webview/frontend/styles/fileSelectStyles.ts】【src/shared/styles/requestPanelStyles.ts】【src/progressView/frontend/components/StreamHeader.ts】【src/shared/styles/statusIndicatorStyles.ts】
- DRY: extract workflow file list builder & renderer and reuse from PermissionCard and RequestPanels to remove duplicated logic.【src/progressView/frontend/components/helpers/workflowFilesList.ts】【src/progressView/frontend/components/PermissionCard.ts】【src/progressView/frontend/components/RequestPanels.ts】
- Misc: safer prefs parsing (Zod schemas for filters/sorts), sort fallback guard, usage panel accounts for cache tokens, history search versioning to avoid stale highlights, and other small schema/type corrections to avoid runtime/type mismatches.【src/progressView/frontend/ProgressApp.ts】【src/shared/streams/streamSort.ts】【src/progressView/frontend/components/UsagePanel.ts】【src/historyView/frontend/components/HistoryList.ts】【src/shared/schemas/*】

### Testing

- Ran `npm run format` and formatted the tree (completed successfully).
- Built webviews: `npm run compile:fast` completed successfully (Vite/esbuild build used for webviews; bundles emitted with minor warnings only).
- Full extension bundle: `npm run compile` (webpack) completed after fixes; build produced the extension bundles (final run completed with a non‑blocking warning about a dynamic nunjucks require).
- Lint: `npm run lint` completed with warnings only (no blocking errors); relevant warnings are stylistic (`eqeqeq`, import ordering) and unrelated to the functional fixes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d4a7c2a88832482a63a982ee80abc)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core execution/follow-up configuration and ProgressView state management, so regressions could affect run behavior or stream rendering. Changes are largely targeted bug fixes with added validation and fallbacks, reducing long-term risk.
> 
> **Overview**
> Fixes several state-sync and UI regressions across MainView/ProgressView, notably ensuring file clear actions and multi-file updates reliably propagate to the extension host (including empty lists) and that option refresh paths are unified via a hardened `loadOptions()` API.
> 
> Unifies `useMultipleOutputs` derivation across initial execution and follow-up paths via `deriveUseMultipleOutputs()`, adds missing schema validation for follow-up configs, and makes follow-up options *per-stream* (with safer active-stream/runId resolution and cleanup of run-scoped/pending state on clears/removals).
> 
> Improves webview UX robustness: replaces `target.closest()` with `event.composedPath()` for Shadow DOM compatibility in multiple click handlers, fixes dropdown focus-out behavior, adds INITIALIZING status label/styling/button enablement, resolves list key collisions, and adds small accessibility/polish fixes (button semantics, sort pressed state, history search input binding + async search race guard).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cd1d74c4a047396c14ae4a8edcd1449d16bccbb9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->