### PR TITLE
fix: address UI regressions and unify dual-logic audit fixes

### DIFF
--- a/docs/prd-ui-regression-audit-round3.md
+++ b/docs/prd-ui-regression-audit-round3.md
@@ -563,3 +563,11 @@ This PRD consolidates **all Round 3 UI and logic regressions** from the followin
 | M-20      | round3-3         | S1          |
 | H-12      | new (2026-01-31) | -           |
 | H-13      | new (2026-01-31) | -           |
+
+---
+
+## Progress Update (2026-02-01)
+
+- ✅ HIGH severity fixes implemented (H-1 through H-13).
+- ✅ MEDIUM severity fixes implemented (M-1 through M-20).
+- ✅ LOW severity fixes implemented (L-1 through L-15).

--- a/docs/prd-ui-regression-audit-round3.md
+++ b/docs/prd-ui-regression-audit-round3.md
@@ -568,6 +568,7 @@ This PRD consolidates **all Round 3 UI and logic regressions** from the followin
 
 ## Progress Update (2026-02-01)
 
-- ✅ HIGH severity fixes implemented (H-1 through H-13).
+- ✅ HIGH severity fixes implemented (H-1 through H-12).
+- ⚠️ H-13 (KaTeX CSS in Shadow DOM) NOT IMPLEMENTED — KaTeX CSS imported globally but not adopted into Shadow DOM components via `adoptedStyleSheets`.
 - ✅ MEDIUM severity fixes implemented (M-1 through M-20).
 - ✅ LOW severity fixes implemented (L-1 through L-15).

--- a/docs/prd/dual-logic-audit-2026-02.md
+++ b/docs/prd/dual-logic-audit-2026-02.md
@@ -2,12 +2,12 @@
 
 ## Implementation Status
 
-| Item                          | Severity | Status   | Notes                                        |
-| ----------------------------- | -------- | -------- | -------------------------------------------- |
-| File watcher extensions       | HIGH     | Proposed | Active bug — .bib/.bbl/.sty not watched      |
-| useMultipleOutputs divergence | HIGH     | Proposed | Different algorithms in 3 code paths         |
-| MainView options refresh      | MEDIUM   | Proposed | loadOptions() exists but unused in providers |
-| Workflow proposal file lists  | MEDIUM   | Proposed | ~50 lines identical code in 2 components     |
+| Item                          | Severity | Status    | Notes                                         |
+| ----------------------------- | -------- | --------- | --------------------------------------------- |
+| File watcher extensions       | HIGH     | Completed | File watcher built from config extensions     |
+| useMultipleOutputs divergence | HIGH     | Completed | Single derivation helper + validation         |
+| MainView options refresh      | MEDIUM   | Completed | loadOptions() wired into providers/commands   |
+| Workflow proposal file lists  | MEDIUM   | Completed | Shared helper replaces duplicate render logic |
 
 ## Overview
 
@@ -231,3 +231,12 @@ Related completed PRDs (kept for reference):
 
 - `docs/prd/dual-logic-features.md` — ✅ Complete
 - `docs/prd/dual-logic-infrastructure.md` — ✅ Complete
+
+---
+
+## Progress Update (2026-02-01)
+
+- ✅ File watcher extensions now derive from config-backed lists.
+- ✅ `useMultipleOutputs` derivation unified across execution, follow-ups, and proposals.
+- ✅ MainView option refresh paths now use `loadOptions()` consistently.
+- ✅ Workflow proposal file list rendering consolidated into a shared helper.

--- a/docs/prd/token-counting-audit.md
+++ b/docs/prd/token-counting-audit.md
@@ -2,61 +2,149 @@
 
 ## Implementation Status
 
-| Item                                     | Severity | Status     | Notes                                      |
-| ---------------------------------------- | -------- | ---------- | ------------------------------------------ |
-| OpenAI Response API no pre-flight check  | HIGH     | Proposed   | Can overflow context on first request      |
-| Missing usage in streaming responses     | MEDIUM   | Proposed   | Defaults to 0, affects UI display          |
-| Safety buffer inconsistency (5000 vs 10) | LOW      | Documented | Intentional but may be overly conservative |
-| OpenAI Chat heuristic counting           | LOW      | Won't Fix  | Best effort with `gpt-tokenizer`           |
+| Item                                              | Severity | Status      | Notes                                             |
+| ------------------------------------------------- | -------- | ----------- | ------------------------------------------------- |
+| T1: Cumulative token tracking may be inaccurate   | HIGH     | Proposed    | `cumulativeInputTokens` assumption needs验证      |
+| T2: No pre-flight token counting                  | HIGH     | Proposed    | Use `inputTokens.count()` API                     |
+| T3: Missing usage in streaming responses          | MEDIUM   | Documented  | Defaults to 0, affects UI display                 |
+| T4: Safety buffer inconsistency (5000 vs 10)      | LOW      | Documented  | Intentional but may be overly conservative        |
+| T5: OpenAI Chat heuristic counting                | LOW      | Won't Fix   | Best effort with `gpt-tokenizer`                  |
 
 ## Overview
 
 This PRD documents token counting and context management discrepancies between model
 providers. Post-response token counts are accurate (from API), but pre-flight counting
-and edge cases have issues.
+and cumulative tracking have issues that can cause unexpected context overflow errors.
 
-## Findings
+---
 
-### Post-Response Token Counting (ACCURATE)
+## Critical Finding: Context Overflow Despite "67.7% Usage"
 
-All providers return accurate token counts from API responses:
+**Observed Behavior:**
+```
+🟢 Context: 270671/400000 tokens (67.7%)
+🟡 Request failed with previousResponseId=resp_xxx. Error: Your input exceeds the context window
+```
 
-| Provider        | Input Tokens                     | Output Tokens                        | Source       |
-| --------------- | -------------------------------- | ------------------------------------ | ------------ |
-| OpenAI Chat     | `usage.prompt_tokens`            | `usage.completion_tokens`            | API response |
-| OpenAI Response | `usage.input_tokens`             | `usage.output_tokens`                | API response |
-| Anthropic       | `usage.input_tokens`             | `usage.output_tokens`                | API response |
-| Google          | `usageMetadata.promptTokenCount` | `usageMetadata.candidatesTokenCount` | API response |
-
-**Conclusion:** No action needed for post-response counting.
+The UI showed 67.7% context usage, but the next request failed with context overflow.
+This indicates a fundamental issue with how we track cumulative token usage.
 
 ---
 
 ## Issues
 
-### T1) OpenAI Response API has no pre-flight token counting (HIGH)
+### T1) Cumulative token tracking may be inaccurate (HIGH) - NEW
 
 - **Area:** Model Handlers
-- **Type:** Logic gap
-- **Impact:** High (can overflow context on first request if prior conversation + new message > context window)
-- **Location:** `src/agent/modelHandlers/modelHandlerOpenAIResponse.ts`
-- **Root cause:** Unlike other providers, the Response API handler does NOT check token
-  counts before sending a request. It only checks `cumulativeInputTokens` AFTER receiving
-  a response to decide if compaction is needed.
-- **Code Evidence:**
-  - `modelHandlerOpenAI.ts` calls `this.applyTokenHeuristics()` during request prep
-  - `modelHandlerOpenAIResponse.ts` has no equivalent pre-flight check
-  - `shouldCompact()` at line 424 only checks after response: `cumulativeInputTokens > threshold`
-- **Comparison:**
-  - Anthropic: Calls `client.beta.messages.countTokens()` BEFORE creating message
-  - Google: Calls `client.models.countTokens()` BEFORE creating message
-  - OpenAI Response: No pre-flight check
-- **Fix Options:**
-  1. Add heuristic pre-flight check using `gpt-tokenizer` (same as OpenAI Chat)
-  2. Use a larger safety buffer to account for estimation uncertainty
-  3. Accept risk since compaction handles overflow after first response
+- **Type:** Logic bug (potential)
+- **Impact:** HIGH - context overflow despite UI showing headroom available
+- **Location:** `src/agent/modelHandlers/modelHandlerOpenAIResponse.ts` (lines 354-359)
+- **Root cause:** The code assumes `response.usage.input_tokens` represents the FULL
+  cumulative context including server-side history from `previous_response_id`. This
+  assumption needs verification.
 
-### T2) Streaming responses may have missing usage data (MEDIUM)
+**Code Evidence:**
+```typescript
+// Line 354-358 - ASSUMPTION THAT NEEDS VERIFICATION
+// Set cumulative input tokens from actual usage (not additive - this IS the total)
+// The response's input_tokens reflects the full context including server-side history
+if (response.usage?.input_tokens) {
+  this.conversationState.cumulativeInputTokens =
+    response.usage.input_tokens;
+}
+```
+
+**What `input_tokens` actually includes (per OpenAI community reports):**
+- Full conversation history when using `previous_response_id` ✓
+- Each message has 4-token overhead wrapper
+- System messages counted fully
+- Previous assistant responses included
+- A 3-token prompt finalizer
+
+**What we need to verify:**
+1. Does `input_tokens` include output tokens from previous responses that become
+   input for the next request?
+2. How does `cached_tokens` relate to `input_tokens`?
+   - `cached_tokens` is a SUBSET of `input_tokens` (tokens served from cache)
+   - `input_tokens - cached_tokens` = uncached tokens (full price)
+   - Total context = `input_tokens` (cached + uncached)
+3. After compaction, does tracking remain accurate?
+   - Compaction clears `previousResponseId` (line 536)
+   - Next request sends all messages directly
+   - `input_tokens` should then reflect actual sent tokens
+
+**Possible scenarios for the observed bug:**
+1. `input_tokens` doesn't include full server-side history (assumption wrong)
+2. `input_tokens` is accurate, but doesn't predict what NEXT request will need
+3. Output tokens from Response A become input for Response B, not accounted for
+4. Model's actual context window differs from configured 400k
+
+**Fix:** Use `inputTokens.count()` API for verification (see T2)
+
+### T2) OpenAI Response API has pre-flight token counting API (HIGH) - UPDATED
+
+- **Area:** Model Handlers
+- **Type:** Missing feature
+- **Impact:** HIGH - can prevent context overflow by checking BEFORE sending
+- **Location:** `src/agent/modelHandlers/modelHandlerOpenAIResponse.ts`
+
+**OpenAI provides a pre-flight token counting API:**
+
+```
+POST https://api.openai.com/v1/responses/input_tokens
+```
+
+**SDK Usage:**
+```typescript
+const response = await client.responses.inputTokens.count({
+  model: "gpt-5",
+  input: newMessages,
+  previous_response_id: this.previousResponseId,  // Includes server history!
+  instructions: systemPrompt,
+  tools: tools,
+});
+console.log(response.input_tokens);  // ACTUAL total context
+```
+
+**Key parameters:**
+- `previous_response_id` - includes server-side conversation history in count
+- `input` - new messages being sent
+- `instructions` - system prompt
+- `tools` - tool definitions (contribute to token count)
+- `truncation` - can check if truncation would occur
+
+**This API provides:**
+1. Accurate pre-flight token count INCLUDING server-side history
+2. Ability to check before sending and trigger compaction proactively
+3. Verification of what `usage.input_tokens` should return
+
+**Recommended implementation:**
+```typescript
+// Before createResponse()
+const preflightCount = await client.responses.inputTokens.count({
+  model: this.config.fullName,
+  input: newMessages,
+  previous_response_id: this.previousResponseId,
+  instructions: systemPrompt,
+  tools: convertedTools,
+});
+
+const utilization = preflightCount.input_tokens / this.config.contextWindow;
+if (utilization > COMPACTION_THRESHOLD) {
+  // Trigger compaction BEFORE the request fails
+  await this.compactConversation(...);
+}
+```
+
+**Comparison with other providers:**
+| Provider        | Pre-flight API                       | Includes history? |
+| --------------- | ------------------------------------ | ----------------- |
+| OpenAI Response | `client.responses.inputTokens.count` | Yes (via prev_id) |
+| Anthropic       | `client.beta.messages.countTokens`   | Yes (in messages) |
+| Google          | `client.models.countTokens`          | Yes (in contents) |
+| OpenAI Chat     | None (use gpt-tokenizer heuristic)   | N/A               |
+
+### T3) Streaming responses may have missing usage data (MEDIUM)
 
 - **Area:** Model Handlers (OpenAI)
 - **Type:** Edge case handling
@@ -82,12 +170,8 @@ All providers return accurate token counts from API responses:
   ```
 - **External Reference:** https://github.com/openai/openai-agents-python/issues/1179
 - **Current Handling:** Logs warning and defaults to 0 (graceful degradation)
-- **Fix Options:**
-  1. Keep current behavior (acceptable - already logs warning)
-  2. Estimate tokens from response text length as fallback
-  3. Retry request with `stream: false` to get usage (expensive)
 
-### T3) Safety buffer inconsistency between providers (LOW)
+### T4) Safety buffer inconsistency between providers (LOW)
 
 - **Area:** Model Handlers
 - **Type:** Configuration inconsistency
@@ -98,28 +182,9 @@ All providers return accurate token counts from API responses:
 - **Root cause:** OpenAI Chat uses heuristic counting which is less accurate, so a larger
   buffer (5000 tokens) compensates for estimation errors. Providers with exact counting
   use a minimal buffer (10 tokens).
-- **Code Evidence:**
+- **Assessment:** This is intentional and documented.
 
-  ```typescript
-  // OpenAI Chat - large buffer for heuristic inaccuracy
-  const reducedMaxTokens = computeReducedMaxTokens(
-    availableTokens,
-    HEURISTIC_TOKEN_BUFFER,
-  );
-
-  // Anthropic/Google - small buffer for exact counting
-  const reducedMaxTokens = computeReducedMaxTokens(
-    availableTokens,
-    TOKEN_SAFETY_BUFFER,
-  );
-  ```
-
-- **Assessment:** This is intentional and documented. The 5000-token buffer may be overly
-  conservative but provides safety margin. Consider reducing to 1000-2000 if testing shows
-  it's too aggressive.
-- **Fix:** Document the rationale in code comments (already partially done).
-
-### T4) OpenAI Chat heuristic pre-flight counting (WON'T FIX)
+### T5) OpenAI Chat heuristic pre-flight counting (WON'T FIX)
 
 - **Area:** Model Handlers
 - **Type:** Known limitation
@@ -129,36 +194,271 @@ All providers return accurate token counts from API responses:
   - Doesn't account for message framing tokens
   - Doesn't handle multi-modal content correctly
   - May drift from OpenAI's actual tokenizer
-- **Code Evidence:** Comment in code acknowledges this:
-  ```typescript
-  // Note: This is a simplified token count. A more accurate count would
-  // need to replicate OpenAI's specific chat message formatting rules.
-  // https://github.com/openai/openai-cookbook/blob/main/examples/How_to_count_tokens_with_tiktoken.ipynb
-  ```
 - **Why Won't Fix:**
-  - OpenAI doesn't provide a pre-request token counting API
+  - OpenAI Chat API doesn't have a pre-request token counting endpoint
   - The 5000-token safety buffer compensates for inaccuracy
   - Post-response counts are accurate for billing/display
-  - Alternative (tiktoken WASM) would add significant bundle size
+
+---
+
+## Token Counting Reference
+
+### Post-Response Token Counting (ACCURATE)
+
+All providers return accurate token counts from API responses:
+
+| Provider        | Input Tokens                     | Output Tokens                        | Cached Tokens                           |
+| --------------- | -------------------------------- | ------------------------------------ | --------------------------------------- |
+| OpenAI Chat     | `usage.prompt_tokens`            | `usage.completion_tokens`            | `usage.prompt_tokens_details.cached`    |
+| OpenAI Response | `usage.input_tokens`             | `usage.output_tokens`                | `usage.input_tokens_details.cached`     |
+| Anthropic       | `usage.input_tokens`             | `usage.output_tokens`                | `usage.cache_read_input_tokens`         |
+| Google          | `usageMetadata.promptTokenCount` | `usageMetadata.candidatesTokenCount` | `usageMetadata.cachedContentTokenCount` |
+
+### Understanding `cached_tokens`
+
+When using `previous_response_id`:
+- `input_tokens` = TOTAL context (including server-side history)
+- `cached_tokens` = portion served from cache (cost reduction)
+- `input_tokens - cached_tokens` = uncached tokens
+
+**Important:** `cached_tokens` is a SUBSET of `input_tokens`, not additional.
+The total context size is `input_tokens`, not `input_tokens + cached_tokens`.
+
+### How Context Grows with `previous_response_id`
+
+```
+Request 1:
+  Send: system_prompt + user_message
+  input_tokens: 1000
+  output_tokens: 500
+
+Request 2 (with previous_response_id):
+  Server reconstructs: Request_1_context + Request_1_output + new_input
+  input_tokens: 1000 + 500 + new_tokens = ~1600+
+  cached_tokens: ~1500 (from Request 1)
+```
+
+Each response's output becomes input for the next request when using `previous_response_id`.
+
+### Interaction: `inputTokens.count()` + `compact()`
+
+**Both APIs work together for safe context management:**
+
+```
+Phase 1: Pre-flight Check
+─────────────────────────
+inputTokens.count({
+  input: newMessages,
+  previous_response_id: "resp_xxx"  ← Server history included
+}) → { input_tokens: 380000 }       ← 95% of 400k context!
+
+Phase 2: Trigger Compaction
+───────────────────────────
+responses.compact({
+  input: allMessages,
+  previous_response_id: "resp_xxx"
+}) → {
+  output: [
+    { type: "message", role: "user", ... },
+    { type: "compaction", encrypted_content: "..." }  ← Compressed history
+  ],
+  usage: { input_tokens: 120000 }  ← Reduced to 30%!
+}
+
+Phase 3: After Compaction
+─────────────────────────
+- Clear previous_response_id (no longer needed)
+- Use compacted output array for future requests
+- Compaction item contains encrypted conversation summary
+
+Phase 4: Future Pre-flight Checks
+─────────────────────────────────
+inputTokens.count({
+  input: compactedMessages,  ← Contains compaction item
+  // NO previous_response_id - history is in compaction item
+}) → { input_tokens: 125000 }  ← Accurate count of compacted context
+```
+
+**Key insight:** After compaction, the `compaction` item in the output array
+carries the conversation history. No `previous_response_id` needed - just pass
+the compacted messages to both `inputTokens.count()` and `responses.create()`.
+
+**Compacted Response Structure:**
+```json
+{
+  "output": [
+    { "type": "message", "role": "user", "content": [...] },
+    { "type": "compaction", "id": "cmp_001", "encrypted_content": "..." }
+  ],
+  "usage": {
+    "input_tokens": 42897,
+    "output_tokens": 12000,
+    "cached_tokens": 30000
+  }
+}
+```
 
 ---
 
 ## Summary
 
-| Issue           | Pre-flight              | Post-response | Action          |
-| --------------- | ----------------------- | ------------- | --------------- |
-| OpenAI Chat     | Heuristic (5000 buffer) | Accurate      | Won't fix       |
-| OpenAI Response | **None**                | Accurate      | Consider adding |
-| Anthropic       | Exact API               | Accurate      | None needed     |
-| Google          | Exact API               | Accurate      | None needed     |
+| Issue           | Pre-flight              | Post-response | Tracking Accurate? | Action               |
+| --------------- | ----------------------- | ------------- | ------------------ | -------------------- |
+| OpenAI Response | **None (should add)**   | Accurate      | **Needs验证**      | Use inputTokens.count |
+| OpenAI Chat     | Heuristic (5000 buffer) | Accurate      | N/A (no chaining)  | Won't fix            |
+| Anthropic       | Exact API               | Accurate      | Yes                | None needed          |
+| Google          | Exact API               | Accurate      | Yes                | None needed          |
 
 ## Recommended Actions
 
-1. **T1 (HIGH):** Add pre-flight token estimation to OpenAI Response API handler
-   - Use same `gpt-tokenizer` approach as OpenAI Chat
-   - Apply similar safety buffer
+### Phase 1: Verification
+1. Add diagnostic logging to compare:
+   - `cumulativeInputTokens` (our tracking)
+   - `inputTokens.count()` result (pre-flight API)
+   - `response.usage.input_tokens` (post-response)
+2. Verify the relationship: do these three values align?
 
-2. **T2 (MEDIUM):** Current handling is acceptable (logs warning, defaults to 0)
-   - Consider adding heuristic fallback if this causes user confusion
+### Phase 2: Implementation
+1. **T1/T2 (HIGH):** Add `inputTokens.count()` pre-flight check
+   - Call before `createResponse()`
+   - Use result to decide if compaction needed
+   - Replace heuristic `cumulativeInputTokens` tracking with API-verified counts
 
-3. **T3/T4 (LOW):** Document rationale, no code changes needed
+2. **T3 (MEDIUM):** Current handling acceptable (logs warning, defaults to 0)
+
+3. **T4/T5 (LOW):** Document rationale, no code changes needed
+
+---
+
+## Implementation Guide
+
+### Complete API Integration Pattern
+
+```typescript
+// In modelHandlerOpenAIResponse.ts
+
+private async getPreflightTokenCount(
+  client: OpenAI,
+  messages: ResponseInputItem[],
+  systemPrompt?: string,
+): Promise<number> {
+  const params: InputTokenCountParams = {
+    model: this.config.fullName,
+    input: messages,
+  };
+
+  if (this.previousResponseId) {
+    params.previous_response_id = this.previousResponseId;
+  }
+
+  if (systemPrompt) {
+    params.instructions = systemPrompt;
+  }
+
+  const response = await client.responses.inputTokens.count(params);
+  return response.input_tokens;
+}
+
+async createResponse(options: CreateResponseOptions): Promise<Response> {
+  const { client, messages, systemPrompt } = options;
+
+  // PRE-FLIGHT CHECK: Get accurate token count before sending
+  const preflightTokens = await this.getPreflightTokenCount(
+    client,
+    messages,
+    systemPrompt,
+  );
+
+  const utilization = preflightTokens / this.config.contextWindow;
+  this.logger.logContextState(preflightTokens, this.config.contextWindow);
+
+  // Check if compaction needed BEFORE request fails
+  if (utilization > this.getCompactionThresholdPercent() / 100) {
+    this.logger.logProgress(
+      `Pre-flight check: ${preflightTokens} tokens (${(utilization * 100).toFixed(1)}%) ` +
+      `exceeds threshold. Triggering compaction.`
+    );
+
+    const compactedMessages = await this.compactConversation(
+      client,
+      messages,
+      systemPrompt,
+    );
+
+    // Use compacted messages, no previous_response_id
+    return this.sendRequest(client, compactedMessages, systemPrompt, options);
+  }
+
+  // Send request normally
+  return this.sendRequest(client, messages, systemPrompt, options);
+}
+```
+
+### API Reference
+
+**`POST /v1/responses/input_tokens`** - Pre-flight token counting
+```typescript
+const response = await client.responses.inputTokens.count({
+  model: "gpt-5",                           // Required
+  input: messages,                          // Optional: messages to count
+  previous_response_id: "resp_xxx",         // Optional: includes server history
+  instructions: "System prompt",            // Optional: system message
+  tools: [...],                             // Optional: tool definitions
+  truncation: "disabled",                   // Optional: "auto" | "disabled"
+});
+// Returns: { object: "response.input_tokens", input_tokens: 12345 }
+```
+
+**`POST /v1/responses/compact`** - Compress conversation
+```typescript
+const compactedResponse = await client.responses.compact({
+  model: "gpt-5",                           // Required
+  input: allMessages,                       // Optional: messages to compact
+  previous_response_id: "resp_xxx",         // Optional: server history to include
+  instructions: "System prompt",            // Optional: system message
+});
+// Returns: CompactedResponse with:
+//   - output: [...messages, { type: "compaction", encrypted_content: "..." }]
+//   - usage: { input_tokens, output_tokens, cached_tokens }
+```
+
+### Migration Path
+
+**Current (broken):**
+```
+Request → Response → Store usage.input_tokens as cumulativeInputTokens
+                     (May not include full server history!)
+```
+
+**Proposed (fixed):**
+```
+inputTokens.count() → Check utilization → [Compact if needed] → Request → Response
+        ↓
+  Accurate pre-flight
+  count including
+  server history
+```
+
+### Error Handling
+
+The `inputTokens.count()` API should be non-blocking for request flow:
+
+```typescript
+try {
+  const preflightTokens = await this.getPreflightTokenCount(...);
+  // Use for compaction decision
+} catch (err) {
+  // If pre-flight fails, fall back to sending request directly
+  // Let the request fail naturally if context exceeded
+  this.logger.warn(`Pre-flight token count failed: ${err.message}`);
+}
+```
+
+---
+
+## References
+
+- [OpenAI Responses API - Input Tokens](https://platform.openai.com/docs/api-reference/responses/input-tokens)
+- [OpenAI Prompt Caching](https://platform.openai.com/docs/guides/prompt-caching)
+- [Community: Tokens usage on Response API with previous message](https://community.openai.com/t/tokens-usage-on-response-api-with-previous-message/1327213)
+- [Community: Responses API high token consumption](https://community.openai.com/t/responses-api-high-token-consumption/1293882)

--- a/src/MainViewProvider.ts
+++ b/src/MainViewProvider.ts
@@ -5,7 +5,7 @@ import * as vscode from 'vscode';
 import { MainViewPersistedStateSchema } from '@shared/schemas';
 
 // Local imports - agent
-import { refresh, computeAgentOptionsData } from '@agent/index';
+import { refresh } from '@agent/index';
 
 // Local imports - common
 import {
@@ -14,10 +14,12 @@ import {
   MAIN_VIEW_COMMANDS,
 } from '@common/webview';
 import { consumePendingState } from '@common/state';
+import { toErrorMessage } from '@common/errors';
+import { getFilterExtensions } from '@common/files/fileTypeUtils';
 
 // Local imports - frontend
 import { agentDirectories } from '@frontend/agents';
-import { computeModelOptionsData } from '@model/computeModelOptions';
+import { loadOptions } from '@frontend/agents/optionsLoader';
 import { watchConfig, getConfig, DEBOUNCE_OPTIONS_MS } from '@utils/config';
 import { debounce } from '@utils/core';
 import { checkCoreDependencies } from '@utils/system/toolUtils';
@@ -148,7 +150,14 @@ export class MainViewProvider
     // Refresh the agent index to pick up configuration changes
     await refresh();
 
-    const optionsData = await computeAgentOptionsData();
+    const options = await loadOptions((error) => {
+      const message = toErrorMessage(error);
+      void vscode.window.showErrorMessage(
+        `Failed to refresh agent options: ${message}`,
+      );
+    });
+    if (!options) return;
+    const optionsData = options.agentOptions;
     this._view.webview.postMessage({
       command: MAIN_VIEW_COMMANDS.SET_AGENT_OPTIONS,
       optionsData,
@@ -163,7 +172,15 @@ export class MainViewProvider
     if (!this._view) {
       return;
     }
-    const optionsData = await computeModelOptionsData();
+    await refresh();
+    const options = await loadOptions((error) => {
+      const message = toErrorMessage(error);
+      void vscode.window.showErrorMessage(
+        `Failed to refresh model options: ${message}`,
+      );
+    });
+    if (!options) return;
+    const optionsData = options.modelOptions;
     this._view.webview.postMessage({
       command: MAIN_VIEW_COMMANDS.SET_MODEL_OPTIONS,
       optionsData,
@@ -172,8 +189,15 @@ export class MainViewProvider
 
   private setupFileWatcher() {
     // Create a file system watcher for relevant file types
-    const filePattern =
-      '**/*.{tex,txt,md,cls,png,pdf,jpeg,jpg,svg,gif,heic,heif,webp,wav,mp3,m4a,aiff,aac,ogg,flac}';
+    const allExtensions = [
+      ...getFilterExtensions('input'),
+      ...getFilterExtensions('reference'),
+      ...getFilterExtensions('auxiliary'),
+      ...getFilterExtensions('media'),
+      ...getFilterExtensions('audio'),
+      ...getFilterExtensions('edited'),
+    ];
+    const filePattern = `**/*.{${[...new Set(allExtensions)].join(',')}}`;
     this.fileWatcher = vscode.workspace.createFileSystemWatcher(filePattern);
 
     // Handle file changes

--- a/src/commands/system/mainViewCommands.ts
+++ b/src/commands/system/mainViewCommands.ts
@@ -2,12 +2,12 @@
 import * as vscode from 'vscode';
 
 // Local imports
-import { computeAgentOptionsData, refresh } from '@agent/index';
+import { refresh } from '@agent/index';
 import { toErrorMessage } from '@common/errors';
 import { MAIN_VIEW_COMMANDS } from '@common/webview';
+import { loadOptions } from '@frontend/agents/optionsLoader';
 import { getMainWebview } from '@frontend/system/commandUtils';
 import * as logger from '@logger/logUtils';
-import { computeModelOptionsData } from '@model/computeModelOptions';
 
 const CHANNEL = 'mainViewCommands';
 
@@ -46,19 +46,19 @@ export function registerMainViewCommands(
         const webview = await getMainWebview(CHANNEL);
         if (!webview) return;
 
-        try {
-          const optionsData = await computeModelOptionsData();
-          webview.webview.postMessage({
-            command: MAIN_VIEW_COMMANDS.SET_MODEL_OPTIONS,
-            optionsData,
-          });
-        } catch (error) {
+        await refresh();
+        const options = await loadOptions((error) => {
           const message = toErrorMessage(error);
           logger.error(CHANNEL, `Failed to refresh model options: ${message}`);
           vscode.window.showErrorMessage(
             `Failed to refresh model options: ${message}`,
           );
-        }
+        });
+        if (!options) return;
+        webview.webview.postMessage({
+          command: MAIN_VIEW_COMMANDS.SET_MODEL_OPTIONS,
+          optionsData: options.modelOptions,
+        });
       },
     ),
 
@@ -68,20 +68,19 @@ export function registerMainViewCommands(
         const webview = await getMainWebview(CHANNEL);
         if (!webview) return;
 
-        try {
-          await refresh();
-          const optionsData = await computeAgentOptionsData();
-          webview.webview.postMessage({
-            command: MAIN_VIEW_COMMANDS.SET_AGENT_OPTIONS,
-            optionsData,
-          });
-        } catch (error) {
+        await refresh();
+        const options = await loadOptions((error) => {
           const message = toErrorMessage(error);
           logger.error(CHANNEL, `Failed to refresh agent options: ${message}`);
           vscode.window.showErrorMessage(
             `Failed to refresh agent options: ${message}`,
           );
-        }
+        });
+        if (!options) return;
+        webview.webview.postMessage({
+          command: MAIN_VIEW_COMMANDS.SET_AGENT_OPTIONS,
+          optionsData: options.agentOptions,
+        });
       },
     ),
 
@@ -91,27 +90,23 @@ export function registerMainViewCommands(
         const webview = await getMainWebview(CHANNEL);
         if (!webview) return;
 
-        try {
-          await refresh();
-          const [modelOptionsData, agentOptionsData] = await Promise.all([
-            computeModelOptionsData(),
-            computeAgentOptionsData(),
-          ]);
-          webview.webview.postMessage({
-            command: MAIN_VIEW_COMMANDS.SET_MODEL_OPTIONS,
-            optionsData: modelOptionsData,
-          });
-          webview.webview.postMessage({
-            command: MAIN_VIEW_COMMANDS.SET_AGENT_OPTIONS,
-            optionsData: agentOptionsData,
-          });
-        } catch (error) {
+        await refresh();
+        const options = await loadOptions((error) => {
           const message = toErrorMessage(error);
           logger.error(CHANNEL, `Failed to refresh options: ${message}`);
           vscode.window.showErrorMessage(
             `Failed to refresh options: ${message}`,
           );
-        }
+        });
+        if (!options) return;
+        webview.webview.postMessage({
+          command: MAIN_VIEW_COMMANDS.SET_MODEL_OPTIONS,
+          optionsData: options.modelOptions,
+        });
+        webview.webview.postMessage({
+          command: MAIN_VIEW_COMMANDS.SET_AGENT_OPTIONS,
+          optionsData: options.agentOptions,
+        });
       },
     ),
   );

--- a/src/common/webview/commands.ts
+++ b/src/common/webview/commands.ts
@@ -215,6 +215,7 @@ export const PROGRESS_VIEW_COMMANDS = {
   POLISH_FOLLOW_UP: 'polishFollowUp',
   FOLLOW_UP_TEXT_POLISHED: 'followUpTextPolished',
   FOLLOW_UP_TEXT_TRANSCRIBED: 'followUpTextTranscribed',
+  FOLLOW_UP_TEXT_POLISH_ERROR: 'followUpTextPolishError',
   START_RECORDING: 'startRecording',
   STOP_RECORDING: 'stopRecording',
   RECORDING_STOPPED: 'recordingStopped',

--- a/src/frontend/agents/optionsLoader.ts
+++ b/src/frontend/agents/optionsLoader.ts
@@ -13,20 +13,27 @@ export interface OptionsPayload {
   defaultMergeModel: string;
 }
 
-export async function loadOptions(): Promise<OptionsPayload> {
-  const [modelOptions, agentOptions] = await Promise.all([
-    computeModelOptionsData(),
-    computeAgentOptionsData(),
-  ]);
+export async function loadOptions(
+  onError?: (error: unknown) => void,
+): Promise<OptionsPayload | null> {
+  try {
+    const [modelOptions, agentOptions] = await Promise.all([
+      computeModelOptionsData(),
+      computeAgentOptionsData(),
+    ]);
 
-  const defaultMergeModel = getConfig<string>(
-    'texra.merge.defaultModel',
-    'gemini3f',
-  );
+    const defaultMergeModel = getConfig<string>(
+      'texra.merge.defaultModel',
+      'gemini3f',
+    );
 
-  return {
-    agentOptions,
-    modelOptions,
-    defaultMergeModel,
-  };
+    return {
+      agentOptions,
+      modelOptions,
+      defaultMergeModel,
+    };
+  } catch (error) {
+    onError?.(error);
+    return null;
+  }
 }

--- a/src/historyView/frontend/HistoryApp.ts
+++ b/src/historyView/frontend/HistoryApp.ts
@@ -149,6 +149,7 @@ export class HistoryApp extends BaseWebviewApp {
       </header>
 
       <history-search-bar
+        .searchTerm=${this.searchTerm}
         .matchCount=${this.matchCount}
         @history-search-change=${this.handleSearchChange}
         @history-search-next=${() => this.handleSearchNavigate('next')}

--- a/src/historyView/frontend/components/HistoryList.ts
+++ b/src/historyView/frontend/components/HistoryList.ts
@@ -97,6 +97,8 @@ export class HistoryList extends LitElement {
   // === Internal search operations (called from willUpdate) ===
 
   private performClearSearch(): void {
+    // Increment version FIRST to invalidate any in-flight applySearchToItems()
+    // before clearing matchCounts (prevents stale results from being applied)
     this.searchVersion += 1;
     this.matchCounts = new Map();
     this.state?.setSearchIndex(-1);

--- a/src/historyView/frontend/components/HistoryList.ts
+++ b/src/historyView/frontend/components/HistoryList.ts
@@ -49,6 +49,7 @@ export class HistoryList extends LitElement {
 
   /** Match counts per item, keyed by item.id - used to compute highlighted index */
   @state() private matchCounts: Map<string, number> = new Map();
+  @state() private searchVersion = 0;
 
   @queryAll('history-item')
   private historyItemElements!: Array<
@@ -96,6 +97,7 @@ export class HistoryList extends LitElement {
   // === Internal search operations (called from willUpdate) ===
 
   private performClearSearch(): void {
+    this.searchVersion += 1;
     this.matchCounts = new Map();
     this.state?.setSearchIndex(-1);
     this.state?.setTotalMatches(0);
@@ -111,6 +113,7 @@ export class HistoryList extends LitElement {
       this.updateMatchCount();
       return;
     }
+    this.searchVersion += 1;
     void this.applySearchToItems(term);
   }
 
@@ -161,12 +164,16 @@ export class HistoryList extends LitElement {
   }
 
   private async applySearchToItems(term: string): Promise<void> {
+    const currentVersion = this.searchVersion;
     const historyItems = this.getHistoryItems();
     const counts = await Promise.all(
       historyItems.map(
         (item) => item.applySearch?.(term) ?? Promise.resolve(0),
       ),
     );
+    if (currentVersion !== this.searchVersion) {
+      return;
+    }
 
     // Store match counts per item for computing highlighted indices
     const newMatchCounts = new Map<string, number>();

--- a/src/historyView/frontend/components/SearchBar.ts
+++ b/src/historyView/frontend/components/SearchBar.ts
@@ -18,6 +18,7 @@ import { HistoryViewEvents } from '../events';
 export class SearchBar extends LitElement {
   static override styles = [designTokens, codiconStyles, historyViewStyles];
 
+  @property({ type: String }) searchTerm = '';
   @property({ type: String }) matchCount = '';
 
   private searchTimeoutId: ReturnType<typeof setTimeout> | null = null;
@@ -66,6 +67,7 @@ export class SearchBar extends LitElement {
           class="search-input"
           type="search"
           placeholder="Search history items..."
+          .value=${this.searchTerm}
           @input=${this.handleInput}
           @keydown=${this.handleKeydown}
         ></vscode-textfield>

--- a/src/profileView/frontend/components/AgentsTable.ts
+++ b/src/profileView/frontend/components/AgentsTable.ts
@@ -43,8 +43,9 @@ export class AgentsTable extends LitElement {
 
   private renderAgentRow(agent: RemoteAgent): TemplateResult {
     const visibilityArray = this.normalizeVisibility(agent.visibility);
-    const visibilityClass =
-      visibilityArray[0] === 'public' ? 'public' : 'custom';
+    const visibilityClass = visibilityArray.includes('public')
+      ? 'public'
+      : 'custom';
     const multiOutputClass = agent.supportsMultipleOutput
       ? 'supported'
       : 'not-supported';

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -50,6 +50,7 @@ import {
 } from '@utils/files';
 import { ensureRunDir, getRunDir } from '@utils/files/taskRunStorage';
 import { renderPrompt } from '@utils/prompt/promptUtils';
+import { deriveUseMultipleOutputs } from '@utils/config/deriveUseMultipleOutputs';
 import {
   buildFileContextFromTaskState,
   polishTextWithAI,
@@ -277,6 +278,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     this.provider.eventHandler.clearPendingTaskGroups(streamId);
     cleanupApprovalsForStream(streamId);
     ToolUseFollowUpQueue.release(streamId);
+    this.clearModelOutputBackups(streamId);
     await this.provider.state.clearStream(streamId);
     // Force rebuild since we deleted a stream
     this.provider.updateWebview({ forceRebuild: true });
@@ -301,6 +303,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     for (const streamId of this.provider.state.streamTabs.keys()) {
       ToolUseFollowUpQueue.release(streamId);
     }
+    this.modelOutputBackups.clear();
     await this.provider.state.clearAll();
     // Force rebuild since we deleted all streams
     this.provider.updateWebview({ forceRebuild: true });
@@ -450,6 +453,14 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     const taskState = this.provider.state.getTaskState(data.stream);
     if (!taskState) return;
 
+    const view = this.getActiveView();
+    const postPolishError = (error?: string) => {
+      view?.webview.postMessage({
+        command: PROGRESS_VIEW_COMMANDS.FOLLOW_UP_TEXT_POLISH_ERROR,
+        error,
+      });
+    };
+
     const fileContext = buildFileContextFromTaskState(taskState);
 
     await vscode.window.withProgress(
@@ -471,16 +482,17 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
           });
 
           if (result.success) {
-            const view = this.getActiveView();
             view?.webview.postMessage({
               command: PROGRESS_VIEW_COMMANDS.FOLLOW_UP_TEXT_POLISHED,
               text: result.text,
             });
           } else if (result.error) {
+            postPolishError(result.error);
             await vscode.window.showErrorMessage(result.error);
           }
         } catch (error) {
           const messageText = toErrorMessage(error);
+          postPolishError(messageText);
           await vscode.window.showErrorMessage(
             `Error polishing follow-up: ${messageText}`,
           );
@@ -554,6 +566,16 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
           output: false,
         };
 
+    const outputFiles = isWorkflow ? proposal.outputFiles ?? [] : [];
+    const useMultipleOutputs = deriveUseMultipleOutputs({
+      isToolUse: !isWorkflow,
+      outputFiles,
+      outputFilesActive: activeFiles.output,
+      previousUseMultipleOutputs: isWorkflow
+        ? proposal.useMultipleOutputs
+        : undefined,
+    });
+
     const agentConfig = AgentConfigSchema.parse({
       agent: proposal.agent,
       model: proposal.model,
@@ -568,8 +590,8 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
         auxiliaryFiles: proposal.auxiliaryFiles,
         mediaFile: proposal.mediaFile,
         mediaFiles: proposal.mediaFiles,
-        outputFiles: proposal.outputFiles,
-        useMultipleOutputs: proposal.useMultipleOutputs,
+        outputFiles,
+        useMultipleOutputs,
         inputFilesActive: activeFiles.input,
         referenceFilesActive: activeFiles.reference,
         auxiliaryFilesActive: activeFiles.auxiliary,
@@ -682,12 +704,19 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     data: MessageFor<typeof PROGRESS_VIEW_COMMANDS.COMPARE_ORIGINAL>,
   ): Promise<void> {
     const { file, base } = data;
+    if (!base) {
+      await this.executeWithBaseFile(file, base, 'Compare original', () =>
+        Promise.resolve(),
+      );
+      return;
+    }
     const streamId = this.provider.state.activeStream;
     if (streamId && file) {
       try {
         const fileLocation = createExternalLocation(file);
         const content = await flexibleFS.read(fileLocation);
-        this.modelOutputBackups.set(file, { content, streamId });
+        const key = this.buildModelOutputBackupKey(streamId, file);
+        this.modelOutputBackups.set(key, { content, streamId });
       } catch {
         // Ignore backup errors
       }
@@ -713,19 +742,21 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     const { file, base, prev } = data;
     const previousFile = prev ?? base;
 
-    if (previousFile) {
-      await vscode.commands.executeCommand(
-        'texra.latexdiff',
-        undefined,
-        previousFile,
-        file,
-      );
+    if (!previousFile) {
+      return;
     }
+
+    await vscode.commands.executeCommand(
+      'texra.latexdiff',
+      undefined,
+      previousFile,
+      file,
+    );
 
     await vscode.commands.executeCommand(
       'texra.compare',
       pathToLocation(''), // inputFile unused
-      pathToLocation(previousFile || ''),
+      pathToLocation(previousFile),
       pathToLocation(file),
     );
   }
@@ -734,7 +765,10 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     data: MessageFor<typeof PROGRESS_VIEW_COMMANDS.ACCEPT_FILE>,
   ): Promise<void> {
     const { file, base } = data;
-    const backup = file ? this.modelOutputBackups.get(file) : null;
+    const streamId = this.provider.state.activeStream;
+    const backupKey =
+      streamId && file ? this.buildModelOutputBackupKey(streamId, file) : null;
+    const backup = backupKey ? this.modelOutputBackups.get(backupKey) : null;
     let currentContent: string | null = null;
 
     if (backup) {
@@ -775,7 +809,9 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     }
 
     if (file) {
-      this.modelOutputBackups.delete(file);
+      if (backupKey) {
+        this.modelOutputBackups.delete(backupKey);
+      }
     }
   }
 
@@ -827,23 +863,21 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     const view = this.getActiveView();
     if (!view) return;
 
-    try {
-      const { agentOptions, modelOptions, defaultMergeModel } =
-        await loadOptions();
-
-      view.webview.postMessage({
-        command: PROGRESS_VIEW_COMMANDS.SET_FOLLOWUP_OPTIONS,
-        workflowAgentsData: agentOptions.workflow,
-        toolUseAgentsData: agentOptions.toolUse,
-        modelOptionsData: modelOptions,
-        defaultMergeModel,
-      });
-    } catch (error) {
+    const options = await loadOptions((error) => {
       this.logger.error(
         this.channel,
         `Failed to get followup options: ${toErrorMessage(error)}`,
       );
-    }
+    });
+    if (!options) return;
+
+    view.webview.postMessage({
+      command: PROGRESS_VIEW_COMMANDS.SET_FOLLOWUP_OPTIONS,
+      workflowAgentsData: options.agentOptions.workflow,
+      toolUseAgentsData: options.agentOptions.toolUse,
+      modelOptionsData: options.modelOptions,
+      defaultMergeModel: options.defaultMergeModel,
+    });
   }
 
   private async handleSetupFollowup(
@@ -938,6 +972,22 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
       return;
     }
     await execute(file, base);
+  }
+
+  private buildModelOutputBackupKey(
+    streamId: StreamTabId,
+    file: string,
+  ): string {
+    return `${streamId}:${file}`;
+  }
+
+  private clearModelOutputBackups(streamId: StreamTabId): void {
+    const prefix = `${streamId}:`;
+    for (const key of this.modelOutputBackups.keys()) {
+      if (key.startsWith(prefix)) {
+        this.modelOutputBackups.delete(key);
+      }
+    }
   }
 
   private findOutputDirectory(
@@ -1193,11 +1243,14 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
         ]
       : originalConfig.outputFiles;
 
-    const useMultipleOutputs =
-      (attachAgentOutputs && outputFiles.length > 1) ||
-      originalConfig.useMultipleOutputs;
+    const useMultipleOutputs = deriveUseMultipleOutputs({
+      isToolUse: isChat,
+      outputFiles,
+      previousUseMultipleOutputs: originalConfig.useMultipleOutputs,
+      outputFilesActive: attachAgentOutputs,
+    });
 
-    const newConfig = {
+    const newConfig = AgentConfigSchema.parse({
       ...originalConfig,
       agent,
       model,
@@ -1208,7 +1261,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
       referenceFiles: mergedReferenceFiles,
       instruction,
       agentCategory,
-    } as AgentConfig;
+    });
 
     if (isChat) {
       return { agentConfig: newConfig } as TaskState;

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -75,10 +75,8 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
   vscode.WebviewView | vscode.WebviewPanel
 > {
   private readonly recordingManager: RecordingManager;
-  private readonly modelOutputBackups = new Map<
-    string,
-    { content: string; streamId: StreamTabId }
-  >();
+  // Key format: `${streamId}:${file}` (see buildModelOutputBackupKey)
+  private readonly modelOutputBackups = new Map<string, { content: string }>();
 
   /**
    * Type-safe handler registry - handlers receive typed data.
@@ -566,7 +564,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
           output: false,
         };
 
-    const outputFiles = isWorkflow ? proposal.outputFiles ?? [] : [];
+    const outputFiles = isWorkflow ? (proposal.outputFiles ?? []) : [];
     const useMultipleOutputs = deriveUseMultipleOutputs({
       isToolUse: !isWorkflow,
       outputFiles,
@@ -716,7 +714,8 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
         const fileLocation = createExternalLocation(file);
         const content = await flexibleFS.read(fileLocation);
         const key = this.buildModelOutputBackupKey(streamId, file);
-        this.modelOutputBackups.set(key, { content, streamId });
+        // Note: streamId is in the key, so no need to store it in the value
+        this.modelOutputBackups.set(key, { content });
       } catch {
         // Ignore backup errors
       }
@@ -803,7 +802,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
       const followUpText = `[System: User modified the model's suggested output for "${fileName}" before accepting. The accepted version differs from the original model output.]`;
 
       await vscode.commands.executeCommand('texra.sendFollowUp', {
-        stream: backup.streamId,
+        stream: streamId,
         text: followUpText,
       });
     }
@@ -1250,8 +1249,10 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
       outputFilesActive: attachAgentOutputs,
     });
 
+    // Spread originalConfig but explicitly omit instruction to avoid duplicate key
+    const { instruction: _originalInstruction, ...restConfig } = originalConfig;
     const newConfig = AgentConfigSchema.parse({
-      ...originalConfig,
+      ...restConfig,
       agent,
       model,
       inputFile: newInputFile,

--- a/src/progressView/frontend/ProgressApp.ts
+++ b/src/progressView/frontend/ProgressApp.ts
@@ -14,10 +14,12 @@ import { PersistedState, createWebviewStorage } from '@shared/state';
 // Local imports - shared schemas
 import {
   AGENT_CATEGORY,
+  AgentCategoryFilterSchema,
   type StreamTabId,
   type StreamTabInfo,
 } from '@shared/schemas';
 import { resolveRunId } from '@shared/streams/runSelection';
+import { StreamSortSchema } from '@shared/streams/streamSort';
 
 // Local imports - webview commands
 import { PROGRESS_VIEW_COMMANDS } from '@common/webview/commands';
@@ -35,8 +37,8 @@ import {
 
 /** Schema for persisted preferences. */
 const ProgressViewPrefsSchema = z.object({
-  streamFilter: z.string().prefault('all') as z.ZodType<StreamFilter>,
-  streamSort: z.string().prefault('time') as z.ZodType<StreamSort>,
+  streamFilter: AgentCategoryFilterSchema.catch('all'),
+  streamSort: StreamSortSchema.catch('time'),
 });
 
 type ProgressViewPreferences = z.infer<typeof ProgressViewPrefsSchema>;
@@ -247,11 +249,8 @@ export class ProgressApp extends BaseWebviewApp {
 
   private getActiveStreamInfo(): StreamTabInfo | null {
     if (!this.appState.activeStreamId) return null;
-    // Search in filtered streams to respect current filter
-    // This ensures we don't show content for streams hidden by filter
-    const filteredStreams = getFilteredStreams(this.appState);
     return (
-      filteredStreams.find(
+      this.appState.streams.find(
         (stream) => stream.name === this.appState.activeStreamId,
       ) ?? null
     );
@@ -271,13 +270,15 @@ export class ProgressApp extends BaseWebviewApp {
       activeStream.agentCategory,
     );
     const isToolUse = isToolUseState(streamState);
-    const runId = resolveRunId(streamState, { mode: 'strict' });
+    const runId = resolveRunId(streamState, { mode: 'fallback' });
+    const followupOptions =
+      this.appState.followupOptionsByStream.get(activeStream.name) ?? null;
 
     this.streamContextValue = {
       streamInfo: activeStream,
       streamState,
       runId,
-      followupOptions: this.appState.followupOptions,
+      followupOptions,
       isToolUse,
     };
     this.permissionsContextValue = this.permissions;

--- a/src/progressView/frontend/ProgressApp.ts
+++ b/src/progressView/frontend/ProgressApp.ts
@@ -270,6 +270,8 @@ export class ProgressApp extends BaseWebviewApp {
       activeStream.agentCategory,
     );
     const isToolUse = isToolUseState(streamState);
+    // Use 'fallback' mode: workflow runs may not have selectedRunId set initially,
+    // but we still need a valid runId to render logs/panels (fixes M-11 in PRD round3)
     const runId = resolveRunId(streamState, { mode: 'fallback' });
     const followupOptions =
       this.appState.followupOptionsByStream.get(activeStream.name) ?? null;

--- a/src/progressView/frontend/components/FileList.ts
+++ b/src/progressView/frontend/components/FileList.ts
@@ -9,6 +9,7 @@ import { commonViewStyles } from '@shared/styles';
 // Local imports - progress view constants
 import { COMMANDS, ELEMENT_IDS } from '../constants';
 import { ProgressEvents } from '../events';
+import { findClosestInComposedPath } from '../utils';
 
 // Local imports - shared schemas
 import type { OutputFileInfo } from '@shared/schemas';
@@ -212,7 +213,7 @@ export class FileList extends LitElement {
     if (!this.showRoundHeaders) {
       return html`${repeat(
         files,
-        (file) => file.location?.absolutePath ?? '',
+        (file, index) => `${index}-${file.location?.absolutePath ?? 'unknown'}`,
         (file) => this.renderFileItem(file),
       )}`;
     }
@@ -226,7 +227,7 @@ export class FileList extends LitElement {
         <div class="round-content">
           ${repeat(
             files,
-            (file) => file.location?.absolutePath ?? '',
+            (file) => `${round}-${file.location?.absolutePath ?? 'unknown'}`,
             (file) => this.renderFileItem(file),
           )}
         </div>
@@ -284,11 +285,11 @@ export class FileList extends LitElement {
    * All data is stored directly on command elements for unified delegation.
    */
   private handleFileClick(event: MouseEvent): void {
-    const target = event.target as Element | null;
-    if (!target) return;
-
     // Find element with data-command (all needed data is on this element)
-    const actionEl = target.closest('[data-command]');
+    const actionEl = findClosestInComposedPath<HTMLElement>(
+      event,
+      '[data-command]',
+    );
     if (!(actionEl instanceof HTMLElement)) return;
 
     const { command, file, base, prev } = actionEl.dataset;

--- a/src/progressView/frontend/components/FollowUpInput.ts
+++ b/src/progressView/frontend/components/FollowUpInput.ts
@@ -171,7 +171,7 @@ export class FollowUpInput extends LitElement {
 
   /** Handle keyboard events on the textarea - Lit-native pattern */
   private handleKeydown(event: KeyboardEvent): void {
-    if (event.key === 'Enter' && !event.shiftKey) {
+    if (event.key === 'Enter' && !event.shiftKey && !event.isComposing) {
       event.preventDefault();
       this.emitSend();
     }
@@ -274,6 +274,9 @@ export class FollowUpInput extends LitElement {
   }
 
   private emitPolish(): void {
+    if (!this.value.trim()) {
+      return;
+    }
     this.polishing = true;
     this.dispatchEvent(ProgressEvents.followupPolish());
   }
@@ -284,5 +287,9 @@ export class FollowUpInput extends LitElement {
 
   private updateValue(value: string): void {
     this.dispatchEvent(ProgressEvents.followupChange({ value }));
+  }
+
+  clearPolishState(): void {
+    this.polishing = false;
   }
 }

--- a/src/progressView/frontend/components/LatexdiffResults.ts
+++ b/src/progressView/frontend/components/LatexdiffResults.ts
@@ -154,7 +154,8 @@ export class LatexdiffResults extends LitElement {
         >
           ${repeat(
             this.entries,
-            (entry) => `${entry.baseFile}-${entry.revisedFile}`,
+            (entry) =>
+              `${entry.baseFile}-${entry.revisedFile}-${entry.revisedRound}-${entry.runId ?? ''}`,
             (entry) => this.renderEntry(entry),
           )}
         </ul>

--- a/src/progressView/frontend/components/PermissionCard.ts
+++ b/src/progressView/frontend/components/PermissionCard.ts
@@ -6,7 +6,6 @@ import { when } from 'lit/directives/when.js';
 
 // Local imports - shared
 import { AGENT_CATEGORY } from '@shared/schemas';
-import { getBasename } from '@shared/utils/path';
 import { PERMISSION_KIND } from '@shared/utils/uiConstants';
 import { postMessage } from '@shared/vscode';
 import { designTokens } from '@shared/styles/litStyles';
@@ -18,6 +17,10 @@ import { PROGRESS_VIEW_COMMANDS } from '@common/webview/commands';
 
 // Local imports - progress view
 import { ProgressEvents } from '../events';
+import {
+  buildWorkflowFileLists,
+  renderWorkflowFilesList,
+} from './helpers/workflowFilesList';
 import type {
   AgentProposalPermission,
   BashPermission,
@@ -285,52 +288,13 @@ export class PermissionCard extends LitElement {
   private renderWorkflowFiles(
     data: WorkflowAgentProposalPermission,
   ): TemplateResult {
-    const combine = (single: string | null | undefined, arr: string[] = []) =>
-      [single, ...arr].filter((f): f is string => Boolean(f));
-
-    const fileLists = [
-      { label: 'Input', files: combine(data.inputFile, data.inputFiles) },
-      {
-        label: 'Reference',
-        files: combine(data.referenceFile, data.referenceFiles),
-      },
-      {
-        label: 'Auxiliary',
-        files: combine(data.auxiliaryFile, data.auxiliaryFiles),
-      },
-      { label: 'Media', files: combine(data.mediaFile, data.mediaFiles) },
-      { label: 'Output', files: data.outputFiles ?? [] },
-    ];
-
-    return html`${repeat(
-      fileLists,
-      ({ label }) => label,
-      ({ label, files }) => this.renderFileList(label, files),
-    )}`;
-  }
-
-  private renderFileList(
-    label: string,
-    files: string[],
-  ): TemplateResult | typeof nothing {
-    if (files.length === 0) return nothing;
-
-    return html`
-      <div class="file-list">
-        <span class="file-list-label">${label}:</span>
-        ${repeat(
-          files,
-          (file) => file,
-          (file, i) =>
-            html`${i > 0 ? ', ' : ''}<span
-                class="file-link"
-                title=${file}
-                @click=${() => this.openFile(file)}
-                >${getBasename(file)}</span
-              >`,
-        )}
-      </div>
-    `;
+    const fileLists = buildWorkflowFileLists(data);
+    return renderWorkflowFilesList(fileLists, {
+      listClassName: () => 'file-list',
+      labelClassName: 'file-list-label',
+      fileClassName: 'file-link',
+      onFileClick: (file) => this.openFile(file),
+    });
   }
 
   // ===========================================================================

--- a/src/progressView/frontend/components/RequestPanels.ts
+++ b/src/progressView/frontend/components/RequestPanels.ts
@@ -892,19 +892,12 @@ export class RequestPanels extends LitElement {
     const lines = [
       details.message && `message: ${details.message}`,
       details.provider && `provider: ${details.provider}`,
-      details.statusCode !== undefined &&
-        details.statusCode !== null &&
-        `statusCode: ${details.statusCode}`,
+      details.statusCode != null && `statusCode: ${details.statusCode}`,
       details.statusText && `statusText: ${details.statusText}`,
-      details.isRelayError !== undefined &&
-        details.isRelayError !== null &&
-        `isRelayError: ${details.isRelayError}`,
-      details.retryable !== undefined &&
-        details.retryable !== null &&
-        `retryable: ${details.retryable}`,
+      details.isRelayError != null && `isRelayError: ${details.isRelayError}`,
+      details.retryable != null && `retryable: ${details.retryable}`,
       details.requestId && `requestId: ${details.requestId}`,
-      details.rawErrorBody !== undefined &&
-        details.rawErrorBody !== null &&
+      details.rawErrorBody != null &&
         `rawErrorBody: ${formatBody(details.rawErrorBody)}`,
     ].filter(Boolean);
 

--- a/src/progressView/frontend/components/RequestPanels.ts
+++ b/src/progressView/frontend/components/RequestPanels.ts
@@ -1,5 +1,11 @@
 // Third-party imports
-import { LitElement, html, nothing, type TemplateResult } from 'lit';
+import {
+  LitElement,
+  html,
+  nothing,
+  type PropertyValues,
+  type TemplateResult,
+} from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { repeat } from 'lit/directives/repeat.js';
 import { classMap } from 'lit/directives/class-map.js';
@@ -25,7 +31,6 @@ import {
 } from '@shared/schemas';
 
 // Local imports - shared utilities
-import { getBasename } from '@shared/utils/path';
 import { PERMISSION_KIND } from '@shared/utils/uiConstants';
 import { postMessage } from '@shared/vscode';
 
@@ -34,6 +39,13 @@ import { PROGRESS_VIEW_COMMANDS } from '@common/webview/commands';
 
 // Local imports - progress view events
 import { ProgressEvents } from '../events';
+import { findClosestInComposedPath } from '../utils';
+
+// Local imports - progress view component helpers
+import {
+  buildWorkflowFileLists,
+  renderWorkflowFilesList,
+} from './helpers/workflowFilesList';
 
 // Local imports - progress view component types
 import type { PermissionState } from './PermissionCard';
@@ -58,6 +70,23 @@ export class RequestPanels extends LitElement {
 
   @state() private feedbackOpenKeys: Set<PermissionKey> = new Set();
   @state() private openDiffMenuKey: PermissionKey | null = null;
+
+  protected override willUpdate(changedProperties: PropertyValues<this>): void {
+    if (!changedProperties.has('permissions')) return;
+
+    const validKeys = new Set(
+      this.permissions.map((permission) => this.getPermissionKey(permission)),
+    );
+    const nextFeedbackKeys = new Set(
+      [...this.feedbackOpenKeys].filter((key) => validKeys.has(key)),
+    );
+    if (nextFeedbackKeys.size !== this.feedbackOpenKeys.size) {
+      this.feedbackOpenKeys = nextFeedbackKeys;
+    }
+    if (this.openDiffMenuKey && !validKeys.has(this.openDiffMenuKey)) {
+      this.openDiffMenuKey = null;
+    }
+  }
 
   override connectedCallback(): void {
     super.connectedCallback();
@@ -495,58 +524,14 @@ export class RequestPanels extends LitElement {
   private renderProposalFiles(
     permission: WorkflowAgentProposalPermission,
   ): TemplateResult | typeof nothing {
-    const combine = (single: string | null | undefined, arr: string[] = []) =>
-      [single, ...arr].filter((f): f is string => Boolean(f));
-
-    const fileLists = [
-      {
-        label: 'Input',
-        files: combine(permission.inputFile, permission.inputFiles),
-      },
-      {
-        label: 'Reference',
-        files: combine(permission.referenceFile, permission.referenceFiles),
-      },
-      {
-        label: 'Auxiliary',
-        files: combine(permission.auxiliaryFile, permission.auxiliaryFiles),
-      },
-      {
-        label: 'Media',
-        files: combine(permission.mediaFile, permission.mediaFiles),
-      },
-      { label: 'Output', files: permission.outputFiles ?? [] },
-    ];
-
-    return html`${repeat(
-      fileLists,
-      ({ label }) => label,
-      ({ label, files }) => this.renderProposalFileList(label, files),
-    )}`;
-  }
-
-  private renderProposalFileList(
-    label: string,
-    files: string[],
-  ): TemplateResult | typeof nothing {
-    if (files.length === 0) return nothing;
-
-    return html`
-      <div class="workflow-proposal__${label.toLowerCase()}-files">
-        <span class="workflow-proposal__file-label">${label}:</span>
-        ${repeat(
-          files,
-          (file) => file,
-          (file, i) =>
-            html`${i > 0 ? ', ' : ''}<span
-                class="workflow-proposal__file-name"
-                title=${file}
-                @click=${() => this.openFile(file)}
-                >${getBasename(file)}</span
-              >`,
-        )}
-      </div>
-    `;
+    const fileLists = buildWorkflowFileLists(permission);
+    return renderWorkflowFilesList(fileLists, {
+      listClassName: (label) =>
+        `workflow-proposal__${label.toLowerCase()}-files`,
+      labelClassName: 'workflow-proposal__file-label',
+      fileClassName: 'workflow-proposal__file-name',
+      onFileClick: (file) => this.openFile(file),
+    });
   }
 
   private renderFeedbackSection(
@@ -778,10 +763,10 @@ export class RequestPanels extends LitElement {
   };
 
   private handleMenuClick = (event: CustomEvent): void => {
-    const target = event.target as Element | null;
-    if (!target) return;
-
-    const menuItem = target.closest('vscode-context-menu-item');
+    const menuItem = findClosestInComposedPath<HTMLElement>(
+      event,
+      'vscode-context-menu-item',
+    );
     if (!menuItem) return;
 
     const kind = menuItem.dataset.permissionKind as
@@ -907,12 +892,19 @@ export class RequestPanels extends LitElement {
     const lines = [
       details.message && `message: ${details.message}`,
       details.provider && `provider: ${details.provider}`,
-      details.statusCode != null && `statusCode: ${details.statusCode}`,
+      details.statusCode !== undefined &&
+        details.statusCode !== null &&
+        `statusCode: ${details.statusCode}`,
       details.statusText && `statusText: ${details.statusText}`,
-      details.isRelayError != null && `isRelayError: ${details.isRelayError}`,
-      details.retryable != null && `retryable: ${details.retryable}`,
+      details.isRelayError !== undefined &&
+        details.isRelayError !== null &&
+        `isRelayError: ${details.isRelayError}`,
+      details.retryable !== undefined &&
+        details.retryable !== null &&
+        `retryable: ${details.retryable}`,
       details.requestId && `requestId: ${details.requestId}`,
-      details.rawErrorBody != null &&
+      details.rawErrorBody !== undefined &&
+        details.rawErrorBody !== null &&
         `rawErrorBody: ${formatBody(details.rawErrorBody)}`,
     ].filter(Boolean);
 

--- a/src/progressView/frontend/components/StreamHeader.ts
+++ b/src/progressView/frontend/components/StreamHeader.ts
@@ -19,6 +19,7 @@ import {
   TOOLBAR_BUTTONS,
 } from '../constants';
 import { ProgressEvents } from '../events';
+import { findClosestInComposedPath } from '../utils';
 import type { StreamState } from '../store';
 
 // Local imports - shared schemas
@@ -44,6 +45,7 @@ const STATUS_LABELS: Record<string, string> = {
   [STREAM_STATUS.READY]: 'Ready',
   [STREAM_STATUS.WAITING]: 'Waiting for follow-up',
   [STREAM_STATUS.RESUMING]: 'Resuming',
+  [STREAM_STATUS.INITIALIZING]: 'Initializing',
 };
 
 /**
@@ -95,6 +97,7 @@ const ENABLED_BUTTONS_BY_STATUS: Record<string, string[]> = {
     ELEMENT_IDS.RESTORE_STATE_BTN,
     ELEMENT_IDS.OPEN_TASK_STORAGE_BTN,
   ],
+  [STREAM_STATUS.INITIALIZING]: [ELEMENT_IDS.STOP_STREAM_BTN],
 };
 
 /** Buttons that depend on having an executionId */
@@ -433,9 +436,10 @@ export class StreamHeader extends LitElement {
   }
 
   private handleToolbarClick(event: MouseEvent) {
-    const target = event.target as Element | null;
-    if (!target) return;
-    const button = target.closest('[data-command]') as HTMLElement | null;
+    const button = findClosestInComposedPath<HTMLElement>(
+      event,
+      '[data-command]',
+    );
     if (!button || button.hasAttribute('disabled')) return;
 
     const command = button.dataset.command;

--- a/src/progressView/frontend/components/StreamHeader.ts
+++ b/src/progressView/frontend/components/StreamHeader.ts
@@ -22,6 +22,9 @@ import { ProgressEvents } from '../events';
 import { findClosestInComposedPath } from '../utils';
 import type { StreamState } from '../store';
 
+// Side-effect import to register the run-selector custom element
+import './RunSelector';
+
 // Local imports - shared schemas
 import type { StreamTabInfo } from '@shared/schemas';
 

--- a/src/progressView/frontend/components/StreamTabs.ts
+++ b/src/progressView/frontend/components/StreamTabs.ts
@@ -26,7 +26,7 @@ import {
   STREAM_STATUS,
 } from '../constants';
 import { ProgressEvents } from '../events';
-import { getRadioValue } from '../utils';
+import { findClosestInComposedPath, getRadioValue } from '../utils';
 import type { StreamFilter, StreamSort } from '../store';
 
 // Local imports - shared schemas
@@ -202,6 +202,17 @@ export class StreamTabs extends LitElement {
         color: var(--vscode-errorForeground);
       }
 
+      .sort-btn.active::part(control) {
+        background-color: var(
+          --vscode-button-secondaryBackground,
+          var(--vscode-toolbar-hoverBackground)
+        );
+        color: var(
+          --vscode-button-secondaryForeground,
+          var(--vscode-foreground)
+        );
+      }
+
       .log-placeholder {
         text-align: center;
         color: var(--color-text-secondary);
@@ -272,11 +283,15 @@ export class StreamTabs extends LitElement {
               (btn) => html`
                 <vscode-toolbar-button
                   id=${btn.id}
-                  class="sort-btn"
+                  class=${classMap({
+                    'sort-btn': true,
+                    active: this.sort === btn.sort,
+                  })}
                   icon=${btn.icon}
                   label=${btn.title}
                   title=${btn.title}
                   data-sort=${btn.sort}
+                  aria-pressed=${this.sort === btn.sort ? 'true' : 'false'}
                 ></vscode-toolbar-button>
               `,
             )}
@@ -368,11 +383,11 @@ export class StreamTabs extends LitElement {
   }
 
   private handleTabClick(event: MouseEvent): void {
-    const target = event.target as Element | null;
-    if (!target) return;
-
     // Find element with data-stream and data-action (unified delegation)
-    const actionElement = target.closest('[data-stream][data-action]');
+    const actionElement = findClosestInComposedPath<HTMLElement>(
+      event,
+      '[data-stream][data-action]',
+    );
     if (!(actionElement instanceof HTMLElement)) return;
 
     const { stream: streamId, action } = actionElement.dataset;
@@ -397,11 +412,8 @@ export class StreamTabs extends LitElement {
   }
 
   private handleSortClick(event: MouseEvent): void {
-    const target = event.target as Element | null;
-    if (!target) return;
-
     // Find element with data-sort attribute (unified delegation)
-    const button = target.closest('[data-sort]');
+    const button = findClosestInComposedPath<HTMLElement>(event, '[data-sort]');
     if (!(button instanceof HTMLElement) || !button.dataset.sort) return;
 
     this.dispatchEvent(
@@ -427,7 +439,7 @@ export class StreamTabs extends LitElement {
       : mainLine;
   }
 
-  private normalizeStatus(status?: string): string {
+  private normalizeStatus(status?: string | null): string {
     return status ?? STREAM_STATUS.READY;
   }
 }

--- a/src/progressView/frontend/components/TodoList.ts
+++ b/src/progressView/frontend/components/TodoList.ts
@@ -128,7 +128,7 @@ export class TodoList extends LitElement {
         <div id=${ELEMENT_IDS.TODO_LIST} class="todo-list">
           ${repeat(
             this.todos,
-            (todo) => `${todo.content}-${todo.status}`,
+            (todo, index) => `${todo.content}-${todo.status}-${index}`,
             (todo) => this.renderTodo(todo),
           )}
         </div>

--- a/src/progressView/frontend/components/UsagePanel.ts
+++ b/src/progressView/frontend/components/UsagePanel.ts
@@ -92,7 +92,9 @@ export class UsagePanel extends LitElement {
     const hasUsage =
       (this.usage?.inputTokens ?? 0) > 0 ||
       (this.usage?.outputTokens ?? 0) > 0 ||
-      (this.usage?.cost ?? 0) > 0;
+      (this.usage?.cost ?? 0) > 0 ||
+      (this.usage?.cacheReadInputTokens ?? 0) > 0 ||
+      (this.usage?.cacheCreationInputTokens ?? 0) > 0;
     const hasContext =
       (this.contextState?.contextWindow ?? 0) > 0 &&
       this.contextState?.utilizationPercent !== undefined;

--- a/src/progressView/frontend/components/helpers/workflowFilesList.ts
+++ b/src/progressView/frontend/components/helpers/workflowFilesList.ts
@@ -1,0 +1,81 @@
+// Third-party imports
+import { html, nothing, type TemplateResult } from 'lit';
+import { repeat } from 'lit/directives/repeat.js';
+
+// Local imports - shared utilities
+import { getBasename } from '@shared/utils/path';
+
+// Local imports - shared schemas
+import type { WorkflowAgentProposalPermission } from '@shared/schemas';
+
+export interface WorkflowFileList {
+  label: string;
+  files: string[];
+}
+
+export function buildWorkflowFileLists(
+  proposal: WorkflowAgentProposalPermission,
+): WorkflowFileList[] {
+  const combine = (single: string | null | undefined, arr: string[] = []) =>
+    [single, ...arr].filter((f): f is string => Boolean(f));
+
+  return [
+    { label: 'Input', files: combine(proposal.inputFile, proposal.inputFiles) },
+    {
+      label: 'Reference',
+      files: combine(proposal.referenceFile, proposal.referenceFiles),
+    },
+    {
+      label: 'Auxiliary',
+      files: combine(proposal.auxiliaryFile, proposal.auxiliaryFiles),
+    },
+    { label: 'Media', files: combine(proposal.mediaFile, proposal.mediaFiles) },
+    { label: 'Output', files: proposal.outputFiles ?? [] },
+  ];
+}
+
+export function renderWorkflowFilesList(
+  fileLists: WorkflowFileList[],
+  options: {
+    listClassName: (label: string) => string;
+    labelClassName: string;
+    fileClassName: string;
+    onFileClick?: (file: string) => void;
+  },
+): TemplateResult {
+  return html`${repeat(
+    fileLists,
+    ({ label }) => label,
+    ({ label, files }) => renderWorkflowFileList(label, files, options),
+  )}`;
+}
+
+function renderWorkflowFileList(
+  label: string,
+  files: string[],
+  options: {
+    listClassName: (label: string) => string;
+    labelClassName: string;
+    fileClassName: string;
+    onFileClick?: (file: string) => void;
+  },
+): TemplateResult | typeof nothing {
+  if (files.length === 0) return nothing;
+
+  return html`
+    <div class=${options.listClassName(label)}>
+      <span class=${options.labelClassName}>${label}:</span>
+      ${repeat(
+        files,
+        (file, index) => `${label}-${index}-${file}`,
+        (file, index) =>
+          html`${index > 0 ? ', ' : ''}<span
+              class=${options.fileClassName}
+              title=${file}
+              @click=${() => options.onFileClick?.(file)}
+              >${getBasename(file)}</span
+            >`,
+      )}
+    </div>
+  `;
+}

--- a/src/progressView/frontend/messageDispatcher.ts
+++ b/src/progressView/frontend/messageDispatcher.ts
@@ -18,7 +18,6 @@ import {
   type StreamTabInfo,
 } from '@shared/schemas';
 import { PERMISSION_KIND } from '@shared/utils/uiConstants';
-import { resolveRunId } from '@shared/streams/runSelection';
 import { PROGRESS_VIEW_COMMANDS } from '@common/webview/commands';
 
 // Local imports - progress view
@@ -83,7 +82,7 @@ function addPermission(
   ctx: MessageHandlerContext,
   permission: PermissionState,
 ): void {
-  ctx.setPermissions([...ctx.getPermissions(), permission]);
+  ctx.setPermissions([permission, ...ctx.getPermissions()]);
 }
 
 function removePrompt(
@@ -121,6 +120,7 @@ function updateStreamInfo(
   for (const key of nextStates.keys()) {
     if (!knownStreams.has(key)) {
       nextStates.delete(key);
+      clearPendingLogUpdatesForStream(key);
     }
   }
 
@@ -164,17 +164,29 @@ const handlers: HandlerRegistry = {
   // Stream management
   [PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS]: (data, ctx) => {
     const previousState = ctx.getState();
-    const activeStream = data.activeStream ?? null;
+    const activeStream = data.activeStream ?? previousState.activeStreamId;
     const updated = updateStreamInfo(
       previousState,
       data.streams,
       data.streamStates,
     );
+    const knownStreams = new Set(data.streams.map((stream) => stream.name));
+    const nextFollowupOptions = new Map(updated.followupOptionsByStream);
+    for (const key of nextFollowupOptions.keys()) {
+      if (!knownStreams.has(key)) {
+        nextFollowupOptions.delete(key);
+      }
+    }
+    const nextActiveStreamId =
+      activeStream && knownStreams.has(activeStream)
+        ? activeStream
+        : (data.streams[0]?.name ?? null);
 
     ctx.setState(() => ({
       ...updated,
-      activeStreamId: activeStream || null,
+      activeStreamId: nextActiveStreamId,
       streamFilter: data.agentFilter,
+      followupOptionsByStream: nextFollowupOptions,
     }));
   },
 
@@ -184,6 +196,8 @@ const handlers: HandlerRegistry = {
 
     const nextStates = new Map(state.streamStates);
     nextStates.delete(streamId);
+    const nextFollowupOptions = new Map(state.followupOptionsByStream);
+    nextFollowupOptions.delete(streamId);
 
     const nextStreams = state.streams.filter((s) => s.name !== streamId);
     const nextActiveStreamId =
@@ -197,6 +211,7 @@ const handlers: HandlerRegistry = {
       streams: nextStreams,
       streamStates: nextStates,
       activeStreamId: nextActiveStreamId,
+      followupOptionsByStream: nextFollowupOptions,
     }));
   },
 
@@ -207,6 +222,7 @@ const handlers: HandlerRegistry = {
       streams: [],
       streamStates: new Map(),
       activeStreamId: null,
+      followupOptionsByStream: new Map(),
     }));
   },
 
@@ -216,7 +232,11 @@ const handlers: HandlerRegistry = {
 
     if (!stream && action === 'clear') {
       pendingLogUpdates.clear();
-      ctx.setState((prev) => ({ ...prev, streamStates: new Map() }));
+      ctx.setState((prev) => ({
+        ...prev,
+        streamStates: new Map(),
+        followupOptionsByStream: new Map(),
+      }));
       return;
     }
 
@@ -253,6 +273,17 @@ const handlers: HandlerRegistry = {
       };
 
       if (isWorkflowState(prev)) {
+        if (isClear) {
+          return {
+            ...baseUpdate,
+            activeRunId: null,
+            selectedRunId: null,
+            runInstructions: {},
+            runUsage: {},
+            runFiles: {},
+            runMissingOutputs: {},
+          };
+        }
         return {
           ...baseUpdate,
           activeRunId: activeRunId ?? prev.activeRunId,
@@ -390,9 +421,13 @@ const handlers: HandlerRegistry = {
     if (!stream) return;
 
     updateWorkflowState(ctx, stream, (prev) => {
-      // Use provided runId from backend if available, otherwise resolve from state
-      const runId =
-        providedRunId ?? resolveRunId(prev, { mode: 'fallback' }) ?? 'default';
+      if (!providedRunId) {
+        console.warn(
+          '[ProgressView] UPDATE_INSTRUCTION missing runId; skipping update.',
+        );
+        return prev;
+      }
+      const runId = providedRunId;
       const { [runId]: _, ...rest } = prev.runInstructions;
       return {
         ...prev,
@@ -436,15 +471,26 @@ const handlers: HandlerRegistry = {
     const { streamId, id, status, endTime } = data.update;
     ctx.setStreamState(streamId, (prev) => ({
       ...prev,
-      taskGroups: prev.taskGroups.map((group) =>
-        group.id === id
-          ? {
-              ...group,
-              status: status ?? group.status,
-              endTime: endTime ?? group.endTime,
-            }
-          : group,
-      ),
+      taskGroups: prev.taskGroups.some((group) => group.id === id)
+        ? prev.taskGroups.map((group) =>
+            group.id === id
+              ? {
+                  ...group,
+                  status: status ?? group.status,
+                  endTime: endTime ?? group.endTime,
+                }
+              : group,
+          )
+        : [
+            ...prev.taskGroups,
+            {
+              id,
+              name: id,
+              startTime: Date.now(),
+              status: status ?? 'running',
+              ...(endTime && { endTime }),
+            },
+          ],
     }));
   },
 
@@ -527,6 +573,10 @@ const handlers: HandlerRegistry = {
     }));
   },
 
+  [PROGRESS_VIEW_COMMANDS.FOLLOW_UP_TEXT_POLISH_ERROR]: (_data, ctx) => {
+    ctx.getFollowUpRef()?.clearPolishState();
+  },
+
   [PROGRESS_VIEW_COMMANDS.RECORDING_STARTED]: (_data, ctx) =>
     setActiveStreamRecording(ctx, true),
 
@@ -538,11 +588,14 @@ const handlers: HandlerRegistry = {
 
   [PROGRESS_VIEW_COMMANDS.SET_FOLLOWUP_OPTIONS]: (data, ctx) => {
     const { command: _command, ...options } = data;
+    const streamId = ctx.getState().activeStreamId;
+    if (!streamId) return;
 
-    ctx.setState((prev) => ({
-      ...prev,
-      followupOptions: options,
-    }));
+    ctx.setState((prev) => {
+      const next = new Map(prev.followupOptionsByStream);
+      next.set(streamId, options);
+      return { ...prev, followupOptionsByStream: next };
+    });
   },
 };
 

--- a/src/progressView/frontend/stateUtils.ts
+++ b/src/progressView/frontend/stateUtils.ts
@@ -1,13 +1,5 @@
 // Shared imports
 import { sortStreams } from '@shared/streams/streamSort';
-import type {
-  InstructionUpdate,
-  LogMessageData,
-  OutputFileInfo,
-  StreamTabId,
-  StreamTabInfo,
-  TaskGroup,
-} from '@shared/schemas';
 
 // Local imports
 import {
@@ -18,6 +10,14 @@ import {
   type WorkflowStreamState,
 } from './store';
 import type { FrontendEventHandlerContext } from './eventHandlers';
+import type {
+  InstructionUpdate,
+  LogMessageData,
+  OutputFileInfo,
+  StreamTabId,
+  StreamTabInfo,
+  TaskGroup,
+} from '@shared/schemas';
 
 /**
  * Updates a nested Record<runId, Record<round, T[]>> structure.
@@ -45,8 +45,8 @@ export function updateNestedRounds<T>(
   if (!rounds) return current;
 
   // Merge rounds into the run
-  const base = reset ? {} : current;
-  const existingRounds = base[runId] ?? {};
+  const base = reset ? { ...current } : current;
+  const existingRounds = reset ? {} : (base[runId] ?? {});
   return {
     ...base,
     [runId]: { ...existingRounds, ...rounds },

--- a/src/progressView/frontend/store.ts
+++ b/src/progressView/frontend/store.ts
@@ -35,7 +35,7 @@ export interface ProgressState {
   streamFilter: StreamFilter;
   streamSort: StreamSort;
   streamStates: Map<StreamTabId, StreamState>;
-  followupOptions: FollowupOptionsState | null;
+  followupOptionsByStream: Map<StreamTabId, FollowupOptionsState>;
 }
 
 export function createInitialState(): ProgressState {
@@ -45,7 +45,7 @@ export function createInitialState(): ProgressState {
     streamFilter: 'all',
     streamSort: 'time',
     streamStates: new Map(),
-    followupOptions: null,
+    followupOptionsByStream: new Map(),
   };
 }
 

--- a/src/progressView/frontend/utils.ts
+++ b/src/progressView/frontend/utils.ts
@@ -12,9 +12,25 @@ export type VSCodeValueElement = HTMLElement & { value?: string };
  * Prefers the clicked radio element's value, falls back to group value.
  */
 export function getRadioValue<T extends string>(event: Event): T | null {
-  const target = event.target as Element | null;
-  const radio = target?.closest('vscode-radio');
+  const radio = findClosestInComposedPath(event, 'vscode-radio');
   const radioGroup = event.currentTarget as VSCodeValueElement | null;
   const value = radio?.getAttribute('value') || radioGroup?.value;
   return (value as T) || null;
+}
+
+/**
+ * Find the closest element matching selector in the composed event path.
+ * This works across shadow DOM boundaries (vscode-* components).
+ */
+export function findClosestInComposedPath<T extends Element>(
+  event: Event,
+  selector: string,
+): T | null {
+  const path = event.composedPath?.() ?? [];
+  for (const entry of path) {
+    if (entry instanceof Element && entry.matches(selector)) {
+      return entry as T;
+    }
+  }
+  return null;
 }

--- a/src/progressView/streamInfoUtils.ts
+++ b/src/progressView/streamInfoUtils.ts
@@ -7,7 +7,11 @@ import { sortStreams } from '@shared/streams/streamSort';
 // Local imports - progress view
 import { getCleanAgentName, isRemoteAgent } from '@agent/index';
 import { AgentCategory } from '@agent/core/AgentDataclass';
-import type { AgentCategoryFilter, StreamTabInfo } from '@shared/schemas';
+import type {
+  AgentCategoryFilter,
+  StreamStatus,
+  StreamTabInfo,
+} from '@shared/schemas';
 
 // Type imports
 import type { ProgressViewState } from './state/ProgressViewState';
@@ -80,7 +84,7 @@ function buildStreamInfo(
     lastTimestamp,
     inputFile,
     creationTimestamp,
-    status: statuses?.get(id),
+    status: statuses?.get(id) as StreamStatus | undefined,
     executionId: state.getExecutionId(id),
   };
 }

--- a/src/shared/schemas/progressView.ts
+++ b/src/shared/schemas/progressView.ts
@@ -270,6 +270,11 @@ export const FollowUpTextTranscribedMessageSchema = z.object({
   text: z.string(),
 });
 
+export const FollowUpTextPolishErrorMessageSchema = z.object({
+  command: z.literal(PROGRESS_VIEW_COMMANDS.FOLLOW_UP_TEXT_POLISH_ERROR),
+  error: z.string().optional(),
+});
+
 export const ProgressRecordingStartedMessageSchema = z.object({
   command: z.literal(PROGRESS_VIEW_COMMANDS.RECORDING_STARTED),
 });
@@ -334,6 +339,7 @@ export const ProgressViewOutboundMessageSchema = z.discriminatedUnion(
     ResolveAgentProposalMessageSchema,
     FollowUpTextPolishedMessageSchema,
     FollowUpTextTranscribedMessageSchema,
+    FollowUpTextPolishErrorMessageSchema,
     ProgressRecordingStartedMessageSchema,
     ProgressRecordingStoppedMessageSchema,
     ProgressRecordingErrorMessageSchema,

--- a/src/shared/schemas/stream.ts
+++ b/src/shared/schemas/stream.ts
@@ -57,7 +57,7 @@ export const StreamTabInfoSchema = z.object({
   lastTimestamp: z.number().optional(),
   inputFile: z.string().optional(),
   creationTimestamp: z.number().optional(),
-  status: z.string().optional(),
+  status: StreamStatusSchema.nullish(),
   executionId: ExecutionIdSchema.optional(),
 });
 export type StreamTabInfo = z.infer<typeof StreamTabInfoSchema>;

--- a/src/shared/streams/streamSort.ts
+++ b/src/shared/streams/streamSort.ts
@@ -37,5 +37,6 @@ export function sortStreams(
   streams: StreamTabInfo[],
   sort: StreamSort,
 ): StreamTabInfo[] {
-  return [...streams].sort(streamComparators[sort]);
+  const comparator = streamComparators[sort] ?? streamComparators.time;
+  return [...streams].sort(comparator);
 }

--- a/src/shared/styles/requestPanelStyles.ts
+++ b/src/shared/styles/requestPanelStyles.ts
@@ -176,6 +176,7 @@ export const requestPanelStyles: CSSResult = css`
     left: 0;
     z-index: 100;
     min-width: 150px;
+    display: block;
   }
 
   .approval-request__actions .diff-dropdown .diff-dropdown-menu:not([show]) {

--- a/src/shared/styles/statusIndicatorStyles.ts
+++ b/src/shared/styles/statusIndicatorStyles.ts
@@ -50,6 +50,14 @@ export const statusIndicatorStyles: CSSResult = css`
     animation: pulse-scale 1.5s infinite;
   }
 
+  .status-indicator.is-initializing,
+  .tab-status.is-initializing {
+    background-color: var(--vscode-descriptionForeground);
+    box-shadow: 0 0 4px var(--vscode-descriptionForeground);
+    opacity: 0.85;
+    animation: pulse-scale 2.5s infinite;
+  }
+
   .status-indicator.is-ready,
   .tab-status.is-ready {
     background-color: var(--vscode-descriptionForeground);
@@ -76,5 +84,9 @@ export const statusIndicatorStyles: CSSResult = css`
   .status-text.is-waiting,
   .status-text.is-resuming {
     color: var(--vscode-textLink-foreground);
+  }
+
+  .status-text.is-initializing {
+    color: var(--vscode-descriptionForeground);
   }
 `;

--- a/src/utils/config/deriveUseMultipleOutputs.ts
+++ b/src/utils/config/deriveUseMultipleOutputs.ts
@@ -1,0 +1,24 @@
+/**
+ * Derive multiple output behavior from execution context.
+ * Keeps a single algorithm across initial runs, follow-ups, and proposals.
+ */
+export interface UseMultipleOutputsOptions {
+  isToolUse?: boolean;
+  outputFiles: string[];
+  outputFilesActive?: boolean;
+  previousUseMultipleOutputs?: boolean;
+}
+
+export function deriveUseMultipleOutputs({
+  isToolUse,
+  outputFiles,
+  outputFilesActive,
+  previousUseMultipleOutputs,
+}: UseMultipleOutputsOptions): boolean {
+  if (isToolUse) return false;
+  return (
+    Boolean(outputFilesActive) ||
+    outputFiles.length > 1 ||
+    Boolean(previousUseMultipleOutputs)
+  );
+}

--- a/src/webview/MainViewMessageHandler.ts
+++ b/src/webview/MainViewMessageHandler.ts
@@ -412,18 +412,24 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
     }
     await super.handleWebviewReady(undefined, webviewView);
     try {
-      const [{ modelOptions, agentOptions }, authStatus] = await Promise.all([
-        loadOptions(),
+      const [options, authStatus] = await Promise.all([
+        loadOptions((error) => {
+          this.logger.error(
+            this.channel,
+            `Failed to load options: ${toErrorMessage(error)}`,
+          );
+        }),
         getAuthStatus(),
       ]);
+      if (!options) return;
 
       webviewView.webview.postMessage({
         command: MAIN_VIEW_COMMANDS.SET_MODEL_OPTIONS,
-        optionsData: modelOptions,
+        optionsData: options.modelOptions,
       });
       webviewView.webview.postMessage({
         command: MAIN_VIEW_COMMANDS.SET_AGENT_OPTIONS,
-        optionsData: agentOptions,
+        optionsData: options.agentOptions,
       });
 
       // Show login banner if not authenticated and banner not dismissed

--- a/src/webview/frontend/MainApp.ts
+++ b/src/webview/frontend/MainApp.ts
@@ -627,13 +627,13 @@ export class MainApp extends BaseWebviewApp {
     const listId = this.multipleListIdMap[message.command];
     if (!listId) return;
 
-    const existing = this.multiFiles[listId] ?? [];
-    const merged = this.mergeUnique(existing, files);
-
-    this.multiFiles = { ...this.multiFiles, [listId]: merged };
-    this.multiFilesVisible = { ...this.multiFilesVisible, [listId]: true };
+    this.multiFiles = { ...this.multiFiles, [listId]: files };
+    this.multiFilesVisible = {
+      ...this.multiFilesVisible,
+      [listId]: files.length > 0,
+    };
     if (listId === ELEMENT_IDS.OUTPUT_FILES) {
-      this.outputFilesActive = true;
+      this.outputFilesActive = files.length > 0;
     }
     this.saveState();
   }
@@ -789,14 +789,14 @@ export class MainApp extends BaseWebviewApp {
       typeof MAIN_VIEW_COMMANDS.INSTRUCTION_TEXT_POLISHED
     >,
   ): void {
-    if (message.text.trim()) {
-      this.instruction = message.text;
-      this.isPolishing = false;
-      postMessage(MAIN_VIEW_COMMANDS.SHOW_INFORMATION_MESSAGE, {
-        text: 'Instruction text has been polished!',
-      });
-      this.saveState();
-    }
+    this.isPolishing = false;
+    const polishedText = message.text.trim();
+    if (!polishedText) return;
+    this.instruction = message.text;
+    postMessage(MAIN_VIEW_COMMANDS.SHOW_INFORMATION_MESSAGE, {
+      text: 'Instruction text has been polished!',
+    });
+    this.saveState();
   }
 
   private handleInstructionTextPolishError(
@@ -1059,6 +1059,10 @@ export class MainApp extends BaseWebviewApp {
     if (key in this.singleFiles) {
       this.singleFiles = { ...this.singleFiles, [key]: '' };
       this.saveState();
+      const command = FILE_SELECTED_COMMANDS[type as FileType];
+      if (command) {
+        postMessage(command, { filePath: '' });
+      }
     }
   }
 
@@ -1071,7 +1075,7 @@ export class MainApp extends BaseWebviewApp {
 
   private handleEmptyFiles(type: MultipleFileType): void {
     const listId = `${type}Files`;
-    this.multiFiles = { ...this.multiFiles, [listId]: [] };
+    this.updateMultiFiles(listId as keyof MultiFiles, []);
     this.multiFilesVisible = { ...this.multiFilesVisible, [listId]: false };
     if (type === 'output') {
       this.outputFilesActive = false;
@@ -1114,6 +1118,7 @@ export class MainApp extends BaseWebviewApp {
         ...this.multiFilesVisible,
         outputFiles: false,
       };
+      this.updateMultiFiles('outputFiles', []);
     }
     this.saveState();
   }

--- a/src/webview/frontend/components/FileSelectGroup.ts
+++ b/src/webview/frontend/components/FileSelectGroup.ts
@@ -196,10 +196,27 @@ export class FileSelectGroup extends LitElement {
   }
 
   private handleFocusOut(event: FocusEvent): void {
-    const path = event.composedPath?.() ?? [];
-    if (path.includes(this)) return;
+    // Check if focus is moving to an element within this component.
+    // We need to traverse shadow DOM boundaries because nested components (like
+    // vscode-context-menu) have their own shadow roots that aren't contained by ours.
+    const nextTarget = event.relatedTarget as Node | null;
+    if (nextTarget && this.containsAcrossShadowDOM(nextTarget)) return;
     this.autoExtractMenuOpen = false;
     this.toolConfigMenuOpen = false;
+  }
+
+  /** Check if a node is a descendant, traversing up through shadow DOM hosts. */
+  private containsAcrossShadowDOM(node: Node | null): boolean {
+    while (node) {
+      if (this.contains(node)) return true;
+      const root = node.getRootNode();
+      if (root instanceof ShadowRoot) {
+        node = root.host;
+      } else {
+        break;
+      }
+    }
+    return false;
   }
 
   private renderFileOptions(): TemplateResult {

--- a/src/webview/frontend/components/FileSelectGroup.ts
+++ b/src/webview/frontend/components/FileSelectGroup.ts
@@ -55,6 +55,8 @@ export class FileSelectGroup extends LitElement {
   @query('.multiple-files-list')
   private fileListElement?: HTMLElement;
 
+  private wasExpanded = false;
+
   private sortableController = new SortableController(
     this,
     () => this.fileListElement,
@@ -69,9 +71,11 @@ export class FileSelectGroup extends LitElement {
   );
 
   protected override updated(changedProps: Map<string, unknown>): void {
-    if (changedProps.has('config')) {
+    const isExpanded = this.currentListVisible;
+    if (changedProps.has('config') || (isExpanded && !this.wasExpanded)) {
       this.sortableController.reinitialize();
     }
+    this.wasExpanded = isExpanded;
   }
 
   private get listId(): string {
@@ -192,12 +196,8 @@ export class FileSelectGroup extends LitElement {
   }
 
   private handleFocusOut(event: FocusEvent): void {
-    const nextTarget = event.relatedTarget as Node | null;
-    // Check both light DOM and shadow DOM for focus containment
-    const containsFocus =
-      nextTarget !== null &&
-      (this.contains(nextTarget) || this.shadowRoot?.contains(nextTarget));
-    if (containsFocus) return;
+    const path = event.composedPath?.() ?? [];
+    if (path.includes(this)) return;
     this.autoExtractMenuOpen = false;
     this.toolConfigMenuOpen = false;
   }
@@ -242,10 +242,15 @@ export class FileSelectGroup extends LitElement {
           toggleable
           aria-haspopup="true"
           aria-expanded=${this.toolConfigMenuOpen ? 'true' : 'false'}
-          ?checked=${hasChecked}
+          ?checked=${this.toolConfigMenuOpen}
           @click=${() => this.toggleMenu('toolConfig')}
         >
           <i class="codicon ${chevronClass}"></i>
+          ${when(
+            hasChecked,
+            () =>
+              html`<span class="dropdown-indicator" aria-hidden="true"></span>`,
+          )}
         </vscode-toolbar-button>
         <vscode-context-menu
           id="toolConfigOptions"
@@ -301,10 +306,15 @@ export class FileSelectGroup extends LitElement {
           toggleable
           aria-haspopup="true"
           aria-expanded=${this.autoExtractMenuOpen ? 'true' : 'false'}
-          ?checked=${hasChecked}
+          ?checked=${this.autoExtractMenuOpen}
           @click=${() => this.toggleMenu('autoExtract')}
         >
           <i class="codicon ${chevronClass}"></i>
+          ${when(
+            hasChecked,
+            () =>
+              html`<span class="dropdown-indicator" aria-hidden="true"></span>`,
+          )}
         </vscode-toolbar-button>
         <vscode-context-menu
           id="autoExtractOptions"
@@ -362,11 +372,12 @@ export class FileSelectGroup extends LitElement {
       (file) => html`
         <div class="file-item" data-path=${file}>
           <span class="file-name">${file}</span>
-          <span
+          <button
+            type="button"
             class="remove-button codicon codicon-trash"
-            role="button"
+            aria-label=${`Remove ${file}`}
             @click=${() => this.handleRemoveFile(file)}
-          ></span>
+          ></button>
         </div>
       `,
     )}`;
@@ -425,14 +436,15 @@ export class FileSelectGroup extends LitElement {
               title=${config.emptyTitle}
               @click=${this.handleEmptyFile}
             ></vscode-toolbar-button>
-            <span
+            <button
+              type="button"
               id=${toggleId}
               class="toggle-icon"
               title=${config.toggleTitle}
               @click=${this.handleToggleList}
             >
               <i class="codicon ${chevronClass}"></i>
-            </span>
+            </button>
             <vscode-toolbar-button
               id="addOpened${config.type[0].toUpperCase()}${config.type.slice(
                 1,

--- a/src/webview/frontend/components/OutputFilesSection.ts
+++ b/src/webview/frontend/components/OutputFilesSection.ts
@@ -117,11 +117,12 @@ export class OutputFilesSection extends LitElement {
       (file) => html`
         <div class="file-item" data-path=${file}>
           <span class="file-name">${file}</span>
-          <span
+          <button
+            type="button"
             class="remove-button codicon codicon-trash"
-            role="button"
+            aria-label=${`Remove ${file}`}
             @click=${() => this.handleRemoveFile(file)}
-          ></span>
+          ></button>
         </div>
       `,
     )}`;
@@ -136,14 +137,15 @@ export class OutputFilesSection extends LitElement {
       <div class="file-select" data-expanded=${String(this.currentExpanded)}>
         <div class="file-select-header">
           <div class="file-select-label-group">
-            <span
+            <button
+              type="button"
               id="toggleOutputFiles"
               class="toggle-icon"
               title="Show or hide additional files for the agent's output"
               @click=${this.handleToggle}
             >
               <i class="codicon ${chevronClass}"></i>
-            </span>
+            </button>
             <span
               class="optional-label"
               title="List the files that should receive the agent's output"

--- a/src/webview/frontend/styles/fileSelectStyles.ts
+++ b/src/webview/frontend/styles/fileSelectStyles.ts
@@ -118,6 +118,8 @@ export const toggleStyles = css`
     display: flex;
     align-items: center;
     height: var(--height-control);
+    background: none;
+    border: none;
   }
 
   .file-select[data-expanded='true'] .optional-label,
@@ -170,6 +172,9 @@ export const multiFilesStyles = css`
     cursor: pointer;
     flex-shrink: 0;
     opacity: 0.7;
+    background: none;
+    border: none;
+    padding: 0;
   }
 
   .remove-button:hover {
@@ -193,6 +198,18 @@ export const dropdownStyles = css`
 
   .dropdown-container vscode-toolbar-button {
     flex-shrink: 0;
+  }
+
+  .dropdown-indicator {
+    width: 6px;
+    height: 6px;
+    margin-left: var(--spacing-tiny);
+    border-radius: 999px;
+    background-color: var(
+      --vscode-badge-background,
+      var(--vscode-terminal-ansiGreen)
+    );
+    display: inline-block;
   }
 
   .dropdown-container .dropdown-menu {

--- a/src/webview/managers/ExecutionManager.ts
+++ b/src/webview/managers/ExecutionManager.ts
@@ -1,18 +1,31 @@
+// Third-party imports
 import * as vscode from 'vscode';
 
+// Local imports - shared schemas
 import {
   DEFAULT_TOOL_CONFIG,
   ToolConfigSchema,
 } from '@shared/schemas/toolConfig';
+
+// Local imports - agent
 import type { AgentConfigInput } from '@agent/core/AgentConfig';
 import { AgentCategory } from '@agent/core/AgentDataclass';
+
+// Local imports - common
 import { validateExecutionRequest } from '@common/execution/executionRequests';
+
+// Local imports - logger
 import * as logger from '@logger/logUtils';
+
+// Local imports - utils
 import {
   getPastedImageFullPath,
   isPastedImage,
 } from '@utils/files/pastedImageUtils';
+import { deriveUseMultipleOutputs } from '@utils/config/deriveUseMultipleOutputs';
 import { capitalize } from '@utils/text/stringUtils';
+
+// Third-party imports - types
 import type { z } from 'zod';
 
 const CHANNEL = 'ExecutionManager';
@@ -83,6 +96,12 @@ export class ExecutionManager {
       : ToolConfigSchema.parse(message);
 
     // Schema provides defaults via .prefault(), we only override conditional fields
+    const useMultipleOutputs = deriveUseMultipleOutputs({
+      isToolUse,
+      outputFiles,
+      outputFilesActive: message.outputFilesActive,
+    });
+
     const request = {
       config: {
         ...message,
@@ -90,9 +109,7 @@ export class ExecutionManager {
           ? AgentCategory.ToolUse
           : AgentCategory.Workflow,
         outputFiles,
-        useMultipleOutputs:
-          !isToolUse &&
-          (Boolean(message.outputFilesActive) || outputFiles.length > 1),
+        useMultipleOutputs,
         toolConfig,
         mediaFile: mapMedia(message.mediaFile ?? null),
         mediaFiles: (message.mediaFiles ?? [])

--- a/src/webview/managers/FileManager.ts
+++ b/src/webview/managers/FileManager.ts
@@ -216,9 +216,7 @@ export class FileManager extends BaseWebviewManager {
   }
 
   handleSetMultipleFiles(message: SetMultipleFilesMessage): void {
-    if (message.files.length > 0) {
-      this.postMessage({ command: message.command, files: message.files });
-    }
+    this.postMessage({ command: message.command, files: message.files });
   }
 
   async handleSelectMultipleFiles(


### PR DESCRIPTION
### Motivation
- Implement the fixes listed in `prd-ui-regression-audit-round3.md` and the consolidation items in `dual-logic-audit-2026-02.md` to restore UI/behavior parity and prevent logic drift across execution paths.  
- Keep changes pragmatic and minimal: reuse existing helpers where possible and avoid adding new heavy abstractions.  
- Fix data-loss and backend-sync regressions that could surface as stale selections, cleared runs, or inconsistent follow-up behavior in the progress/main views.

### Description
- MainView sync and file handling: `handleEmptyFile` now notifies the extension host when a single file is cleared, `handleSetMultipleFiles` replaces (not merges) multi-file lists and updates visibility/active flags, session type switches route through `updateMultiFiles`, and the file watcher pattern is built dynamically from `getFilterExtensions` so `.sty/.bib/.bbl` and other configured extensions are watched (`src/webview/frontend/MainApp.ts`, `src/webview/managers/FileManager.ts`, `src/MainViewProvider.ts`).
- Unified multiple-output logic & options wiring: introduced `deriveUseMultipleOutputs` and used it in execution, proposal setup, and follow-up build paths to remove algorithm drift; wired `loadOptions()` into providers and command handlers with localized error callbacks (`src/utils/config/deriveUseMultipleOutputs.ts`, `src/webview/managers/ExecutionManager.ts`, `src/progressView/ProgressViewMessageHandler.ts`, `src/frontend/agents/optionsLoader.ts`, `src/commands/system/mainViewCommands.ts`, `src/webview/MainViewMessageHandler.ts`).
- ProgressView state, UI and plumbing fixes: fixed `updateNestedRounds` to reset specific runs only, cleared pending log updates for removed streams, scoped follow-up options per-stream (`followupOptionsByStream`), made model output backups stream-scoped and cleared on stream delete, added polish-error message path and clearing, added INITIALIZING label + styles and enabled appropriate toolbar buttons, and hardened sort/fallbacks (`src/progressView/frontend/stateUtils.ts`, `src/progressView/frontend/messageDispatcher.ts`, `src/progressView/frontend/store.ts`, `src/progressView/ProgressViewMessageHandler.ts`, shared schemas/styles).  
- Frontend accessibility, shadow‑DOM, and duplication cleanups: replaced fragile `target.closest()` lookups with `findClosestInComposedPath` for Shadow DOM-safe event delegation, fixed focusout races and dropdown display (`display: block`) for approval menus, converted several span controls to buttons for keyboard accessibility, deduplicated workflow file-list rendering into a shared helper used by permission/request panels, improved key stability in `repeat()` usages, and added history search binding + versioned async searches and profile visibility fix (`src/progressView/frontend/utils.ts`, `src/shared/styles/requestPanelStyles.ts`, `src/progressView/frontend/components/helpers/workflowFilesList.ts`, various frontend components).  
- Documentation: updated PRD docs to record implemented items and progress (`docs/prd-ui-regression-audit-round3.md`, `docs/prd/dual-logic-audit-2026-02.md`).

### Testing
- Ran formatting: `npm run format` — succeeded.  
- Static checks: `npm run lint` — completed with warnings only (no lint errors).  
- Build: `npm run compile` — early runs in this environment reported missing dev deps (`style-loader`, `mark.js`) that are external to these changes; after code fixes the compile completed with only warnings (no type/emit errors in the modified code paths).  
- Notes: unit/CI tests were not executed here (some test targets pull external tooling); all changes were validated with local type-aware edits and a webpack build in this environment to surface integration issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d4a7c2a88832482a63a982ee80abc)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core UI state plumbing and command/message dispatch across MainView and ProgressView; while largely bug-fix oriented, regressions could impact stream state, file selection sync, and execution configuration if edge cases were missed.
> 
> **Overview**
> Restores MainView/ProgressView parity by **fixing backend sync/data-loss regressions**: clearing single/multi file selections now notifies the extension host, multi-file lists are replaced (not merged) and visibility/active flags reflect emptiness, file watching derives patterns from configured extensions, and workflow run “clear/reset” no longer wipes unrelated run state.
> 
> Consolidates previously divergent logic by routing option refresh through a more resilient `loadOptions(onError)` API and introducing `deriveUseMultipleOutputs()` used consistently across initial execution, proposals, and follow-ups (with added schema validation).
> 
> Improves ProgressView UX/stability: per-stream follow-up options (`followupOptionsByStream`), stream deletion cleanup (pending log updates + per-stream output backups), safer runId handling, and UI fixes for `INITIALIZING` status, sort prefs/schema validation, Shadow DOM-safe event delegation, repeat-key collisions, accessibility button semantics, and follow-up polish error handling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8488128d32088baa244b9d1eee10824b892475a8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->