### PR TITLE
fix: resolve Round 3 UI regressions and add OpenAI Responses pre-flight token heuristics

### DIFF
--- a/docs/prd-ui-regression-audit-round3.md
+++ b/docs/prd-ui-regression-audit-round3.md
@@ -563,3 +563,11 @@ This PRD consolidates **all Round 3 UI and logic regressions** from the followin
 | M-20      | round3-3         | S1          |
 | H-12      | new (2026-01-31) | -           |
 | H-13      | new (2026-01-31) | -           |
+
+---
+
+## Progress Update (2026-02-01)
+
+- **HIGH**: H-1 through H-13 completed.
+- **MEDIUM**: M-1 through M-20 completed.
+- **LOW**: L-1 through L-15 completed.

--- a/docs/prd/token-counting-audit.md
+++ b/docs/prd/token-counting-audit.md
@@ -4,7 +4,7 @@
 
 | Item                                     | Severity | Status     | Notes                                      |
 | ---------------------------------------- | -------- | ---------- | ------------------------------------------ |
-| OpenAI Response API no pre-flight check  | HIGH     | Proposed   | Can overflow context on first request      |
+| OpenAI Response API no pre-flight check  | HIGH     | Completed  | Added heuristic pre-flight estimate        |
 | Missing usage in streaming responses     | MEDIUM   | Proposed   | Defaults to 0, affects UI display          |
 | Safety buffer inconsistency (5000 vs 10) | LOW      | Documented | Intentional but may be overly conservative |
 | OpenAI Chat heuristic counting           | LOW      | Won't Fix  | Best effort with `gpt-tokenizer`           |
@@ -145,12 +145,12 @@ All providers return accurate token counts from API responses:
 
 ## Summary
 
-| Issue           | Pre-flight              | Post-response | Action          |
-| --------------- | ----------------------- | ------------- | --------------- |
-| OpenAI Chat     | Heuristic (5000 buffer) | Accurate      | Won't fix       |
-| OpenAI Response | **None**                | Accurate      | Consider adding |
-| Anthropic       | Exact API               | Accurate      | None needed     |
-| Google          | Exact API               | Accurate      | None needed     |
+| Issue           | Pre-flight              | Post-response | Action      |
+| --------------- | ----------------------- | ------------- | ----------- |
+| OpenAI Chat     | Heuristic (5000 buffer) | Accurate      | Won't fix   |
+| OpenAI Response | Heuristic (buffered)    | Accurate      | Implemented |
+| Anthropic       | Exact API               | Accurate      | None needed |
+| Google          | Exact API               | Accurate      | None needed |
 
 ## Recommended Actions
 
@@ -162,3 +162,12 @@ All providers return accurate token counts from API responses:
    - Consider adding heuristic fallback if this causes user confusion
 
 3. **T3/T4 (LOW):** Document rationale, no code changes needed
+
+---
+
+## Progress Update (2026-02-01)
+
+- **T1 (HIGH):** Implemented heuristic pre-flight token estimation for OpenAI Responses with
+  max token adjustment.
+- **T2 (MEDIUM):** No change (warning + zero defaults retained).
+- **T3/T4 (LOW):** No change (documented behavior retained).

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -108,6 +108,10 @@ interface UploadedOpenAIResponseAttachment {
   isImage: boolean;
 }
 
+const RESPONSE_MESSAGE_OVERHEAD_TOKENS = 8;
+const RESPONSE_NON_TEXT_CONTENT_TOKENS = 1000;
+const RESPONSE_IMAGE_CONTENT_TOKENS = 2000;
+
 /**
  * Handler for OpenAI's Responses API. This implementation works directly with
  * the native response message types instead of reusing the chat completion
@@ -834,6 +838,8 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
    *
    * Supports automatic conversation compaction when cumulative input tokens
    * exceed the configured threshold (texra.model.compactionThresholdPercent).
+   *
+   * NOTE: This mutates params.max_output_tokens in place when reduction is needed.
    */
   private applyTokenHeuristics(
     params: ResponseCreateParamsBase,
@@ -844,6 +850,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       const approximateNewTokens = this.calculateApproximateTokens(
         messages,
         systemPrompt,
+        params.tools,
       );
       const existingTokens = this.previousResponseId
         ? this.conversationState.cumulativeInputTokens
@@ -854,13 +861,13 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         `Approximate token count of message: ${estimatedTotalTokens}`,
       );
 
-      if (estimatedTotalTokens > this.config.contextWindow) {
+      const availableTokens = this.config.contextWindow - estimatedTotalTokens;
+      if (availableTokens < 0) {
         const errorMsg = `Approximate token count of message exceeds context window: ${estimatedTotalTokens} > ${this.config.contextWindow}`;
         this.logger.error(errorMsg);
         throw new Error(errorMsg);
       }
 
-      const availableTokens = this.config.contextWindow - estimatedTotalTokens;
       const currentMax = params.max_output_tokens;
       if (typeof currentMax === 'number' && availableTokens < currentMax) {
         const utilizationPercent =
@@ -871,12 +878,12 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         );
         params.max_output_tokens = reducedMaxTokens;
 
-        const isOverflow = availableTokens <= 0;
-        const detailsMsg = isOverflow
-          ? 'OpenAI Responses: max_output_tokens forced to 1 due to context overflow'
+        const noOutputBudget = availableTokens <= 0;
+        const detailsMsg = noOutputBudget
+          ? 'OpenAI Responses: no remaining tokens for output; max_output_tokens forced to 1'
           : 'OpenAI Responses: max_output_tokens reduced to fit context window';
-        const logMsg = isOverflow
-          ? `Approximate token count (${estimatedTotalTokens}) already exceeds context window (${this.config.contextWindow}). Forcing max_output_tokens to ${reducedMaxTokens} token.`
+        const logMsg = noOutputBudget
+          ? `Approximate token count (${estimatedTotalTokens}) leaves no room for output in context window (${this.config.contextWindow}). Forcing max_output_tokens to ${reducedMaxTokens} token.`
           : `Approximate token count (${estimatedTotalTokens}) + max_output_tokens (${currentMax}) exceeds context window (${this.config.contextWindow}). Reducing max_output_tokens to ${reducedMaxTokens}.`;
 
         this.logger.logContextManagement(logMsg, {
@@ -899,16 +906,30 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     }
   }
 
+  /**
+   * Estimate tokens for response inputs and tool definitions using rough heuristics.
+   * Includes per-item overhead and conservative fixed costs for non-text content.
+   */
   private calculateApproximateTokens(
     messages: ResponseInputItem[],
     systemPrompt?: string,
+    tools?: ResponseCreateParamsBase['tools'],
   ): number {
     let total = 0;
     if (systemPrompt) {
       total += countTokens(systemPrompt);
+      total += RESPONSE_MESSAGE_OVERHEAD_TOKENS;
+    }
+
+    if (tools && tools.length > 0) {
+      for (const tool of tools) {
+        total += RESPONSE_MESSAGE_OVERHEAD_TOKENS;
+        total += countTokens(JSON.stringify(tool));
+      }
     }
 
     for (const message of messages) {
+      total += RESPONSE_MESSAGE_OVERHEAD_TOKENS;
       if (this.isMessageItem(message)) {
         const content = message.content;
         if (typeof content === 'string') {
@@ -925,12 +946,21 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
               typeof text === 'string'
             ) {
               total += countTokens(text);
+            } else if (type === 'input_image') {
+              total += RESPONSE_IMAGE_CONTENT_TOKENS;
+            } else if (
+              type === 'input_file' ||
+              type === 'input_audio' ||
+              type === 'input_video'
+            ) {
+              total += RESPONSE_NON_TEXT_CONTENT_TOKENS;
             }
           }
         }
       }
 
-      if ((message as { type?: unknown }).type === 'function_call_output') {
+      const messageType = (message as { type?: unknown }).type;
+      if (messageType === 'function_call_output') {
         const output = (message as { output?: unknown }).output;
         if (typeof output === 'string') {
           total += countTokens(output);
@@ -938,11 +968,33 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
           for (const part of output) {
             const type = (part as { type?: unknown }).type;
             const text = (part as { text?: unknown }).text;
-            if (type === 'input_text' && typeof text === 'string') {
+            if (
+              (type === 'input_text' || type === 'output_text') &&
+              typeof text === 'string'
+            ) {
               total += countTokens(text);
             }
           }
         }
+      } else if (messageType === 'function_call') {
+        const name = (message as { name?: unknown }).name;
+        const args = (message as { arguments?: unknown }).arguments;
+        if (typeof name === 'string') {
+          total += countTokens(name);
+        }
+        if (typeof args === 'string') {
+          total += countTokens(args);
+        }
+      } else if (
+        messageType === 'input_image' ||
+        messageType === 'input_file' ||
+        messageType === 'input_audio' ||
+        messageType === 'input_video'
+      ) {
+        total +=
+          messageType === 'input_image'
+            ? RESPONSE_IMAGE_CONTENT_TOKENS
+            : RESPONSE_NON_TEXT_CONTENT_TOKENS;
       }
     }
 

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -3,6 +3,7 @@ import { Buffer } from 'node:buffer';
 
 // Third-party imports
 import OpenAI, { APIConnectionTimeoutError, toFile } from 'openai';
+import { countTokens } from 'gpt-tokenizer';
 
 // Local imports - agent
 import type { AgentConfig } from '@agent/core/AgentConfig';
@@ -16,6 +17,7 @@ import { calculateTokenPrice } from '@agent/utils/priceUtils';
 import {
   formatProviderHttpError,
   getSdkErrorMessage,
+  isContextWindowError,
   isPreviousResponseIdError,
 } from '@common/errors/sdkErrorUtils';
 
@@ -47,7 +49,11 @@ import {
 import { OPENAI_CHAT_FINISH } from './types/StopReasonTypes';
 import { toOpenAIResponseTools } from './toolConversion';
 import { ModelHandler } from './ModelHandler';
-import { DEFAULT_COMPACTION_THRESHOLD_PERCENT } from './contextManagementConstants';
+import {
+  DEFAULT_COMPACTION_THRESHOLD_PERCENT,
+  HEURISTIC_TOKEN_BUFFER,
+  computeReducedMaxTokens,
+} from './contextManagementConstants';
 import {
   buildOpenAIWebSearchResult,
   extractOpenAIWebSearchResults,
@@ -829,6 +835,120 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
    * Supports automatic conversation compaction when cumulative input tokens
    * exceed the configured threshold (texra.model.compactionThresholdPercent).
    */
+  private applyTokenHeuristics(
+    params: ResponseCreateParamsBase,
+    messages: ResponseInputItem[],
+    systemPrompt?: string,
+  ): void {
+    try {
+      const approximateNewTokens = this.calculateApproximateTokens(
+        messages,
+        systemPrompt,
+      );
+      const existingTokens = this.previousResponseId
+        ? this.conversationState.cumulativeInputTokens
+        : 0;
+      const estimatedTotalTokens = approximateNewTokens + existingTokens;
+
+      this.logger.debug(
+        `Approximate token count of message: ${estimatedTotalTokens}`,
+      );
+
+      if (estimatedTotalTokens > this.config.contextWindow) {
+        const errorMsg = `Approximate token count of message exceeds context window: ${estimatedTotalTokens} > ${this.config.contextWindow}`;
+        this.logger.error(errorMsg);
+        throw new Error(errorMsg);
+      }
+
+      const availableTokens = this.config.contextWindow - estimatedTotalTokens;
+      const currentMax = params.max_output_tokens;
+      if (typeof currentMax === 'number' && availableTokens < currentMax) {
+        const utilizationPercent =
+          (estimatedTotalTokens / this.config.contextWindow) * 100;
+        const reducedMaxTokens = computeReducedMaxTokens(
+          availableTokens,
+          HEURISTIC_TOKEN_BUFFER,
+        );
+        params.max_output_tokens = reducedMaxTokens;
+
+        const isOverflow = availableTokens <= 0;
+        const detailsMsg = isOverflow
+          ? 'OpenAI Responses: max_output_tokens forced to 1 due to context overflow'
+          : 'OpenAI Responses: max_output_tokens reduced to fit context window';
+        const logMsg = isOverflow
+          ? `Approximate token count (${estimatedTotalTokens}) already exceeds context window (${this.config.contextWindow}). Forcing max_output_tokens to ${reducedMaxTokens} token.`
+          : `Approximate token count (${estimatedTotalTokens}) + max_output_tokens (${currentMax}) exceeds context window (${this.config.contextWindow}). Reducing max_output_tokens to ${reducedMaxTokens}.`;
+
+        this.logger.logContextManagement(logMsg, {
+          action: 'max_tokens_reduced',
+          tokensBefore: estimatedTotalTokens,
+          contextWindow: this.config.contextWindow,
+          utilizationBefore: utilizationPercent,
+          originalMaxTokens: currentMax,
+          reducedMaxTokens,
+          details: detailsMsg,
+        });
+      }
+    } catch (err) {
+      if (isContextWindowError(err)) {
+        throw err;
+      }
+      this.logger.warn(
+        `Token counting failed: ${getSdkErrorMessage(err)}. Proceeding without token adjustment.`,
+      );
+    }
+  }
+
+  private calculateApproximateTokens(
+    messages: ResponseInputItem[],
+    systemPrompt?: string,
+  ): number {
+    let total = 0;
+    if (systemPrompt) {
+      total += countTokens(systemPrompt);
+    }
+
+    for (const message of messages) {
+      if (this.isMessageItem(message)) {
+        const content = message.content;
+        if (typeof content === 'string') {
+          total += countTokens(content);
+          continue;
+        }
+
+        if (Array.isArray(content)) {
+          for (const part of content) {
+            const type = (part as { type?: unknown }).type;
+            const text = (part as { text?: unknown }).text;
+            if (
+              (type === 'input_text' || type === 'output_text') &&
+              typeof text === 'string'
+            ) {
+              total += countTokens(text);
+            }
+          }
+        }
+      }
+
+      if ((message as { type?: unknown }).type === 'function_call_output') {
+        const output = (message as { output?: unknown }).output;
+        if (typeof output === 'string') {
+          total += countTokens(output);
+        } else if (Array.isArray(output)) {
+          for (const part of output) {
+            const type = (part as { type?: unknown }).type;
+            const text = (part as { text?: unknown }).text;
+            if (type === 'input_text' && typeof text === 'string') {
+              total += countTokens(text);
+            }
+          }
+        }
+      }
+    }
+
+    return total;
+  }
+
   async createResponse(
     options: CreateResponseOptions<ResponseInputItem, OpenAI>,
   ): Promise<Response> {
@@ -964,6 +1084,8 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       }
       params.reasoning = reasoning;
     }
+
+    this.applyTokenHeuristics(params, newMessages, systemPrompt);
 
     // Wrap execution in try-catch to handle previousResponseId errors
     // When an error indicates the response ID is invalid, we clear it so

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -108,9 +108,10 @@ interface UploadedOpenAIResponseAttachment {
   isImage: boolean;
 }
 
-const RESPONSE_MESSAGE_OVERHEAD_TOKENS = 8;
-const RESPONSE_NON_TEXT_CONTENT_TOKENS = 1000;
-const RESPONSE_IMAGE_CONTENT_TOKENS = 2000;
+// Rough estimates for heuristic token counting (conservative on non-text payloads).
+const RESPONSE_MESSAGE_OVERHEAD_TOKENS = 8; // Role/content wrappers + item framing.
+const RESPONSE_NON_TEXT_CONTENT_TOKENS = 1000; // Files/audio/video payload overhead.
+const RESPONSE_IMAGE_CONTENT_TOKENS = 2000; // Images are typically larger than other files.
 
 /**
  * Handler for OpenAI's Responses API. This implementation works directly with
@@ -862,11 +863,6 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       );
 
       const availableTokens = this.config.contextWindow - estimatedTotalTokens;
-      if (availableTokens < 0) {
-        const errorMsg = `Approximate token count of message exceeds context window: ${estimatedTotalTokens} > ${this.config.contextWindow}`;
-        this.logger.error(errorMsg);
-        throw new Error(errorMsg);
-      }
 
       const currentMax = params.max_output_tokens;
       if (typeof currentMax === 'number' && availableTokens < currentMax) {
@@ -879,11 +875,14 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         params.max_output_tokens = reducedMaxTokens;
 
         const noOutputBudget = availableTokens <= 0;
+        const overflow = availableTokens < 0;
         const detailsMsg = noOutputBudget
           ? 'OpenAI Responses: no remaining tokens for output; max_output_tokens forced to 1'
           : 'OpenAI Responses: max_output_tokens reduced to fit context window';
         const logMsg = noOutputBudget
-          ? `Approximate token count (${estimatedTotalTokens}) leaves no room for output in context window (${this.config.contextWindow}). Forcing max_output_tokens to ${reducedMaxTokens} token.`
+          ? `Approximate token count (${estimatedTotalTokens}) ${
+              overflow ? 'exceeds' : 'leaves no room in'
+            } context window (${this.config.contextWindow}). Forcing max_output_tokens to ${reducedMaxTokens} token.`
           : `Approximate token count (${estimatedTotalTokens}) + max_output_tokens (${currentMax}) exceeds context window (${this.config.contextWindow}). Reducing max_output_tokens to ${reducedMaxTokens}.`;
 
         this.logger.logContextManagement(logMsg, {
@@ -909,6 +908,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
   /**
    * Estimate tokens for response inputs and tool definitions using rough heuristics.
    * Includes per-item overhead and conservative fixed costs for non-text content.
+   * This remains a heuristic and does not capture all protocol framing tokens.
    */
   private calculateApproximateTokens(
     messages: ResponseInputItem[],
@@ -916,15 +916,48 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     tools?: ResponseCreateParamsBase['tools'],
   ): number {
     let total = 0;
+
+    const addTextTokens = (value: unknown): void => {
+      if (typeof value === 'string') {
+        total += countTokens(value);
+      }
+    };
+
+    const addContentPartTokens = (part: unknown): void => {
+      const type = (part as { type?: unknown }).type;
+      const text = (part as { text?: unknown }).text;
+      if (
+        (type === 'input_text' || type === 'output_text') &&
+        typeof text === 'string'
+      ) {
+        total += countTokens(text);
+        return;
+      }
+
+      if (type === 'input_image') {
+        total += RESPONSE_IMAGE_CONTENT_TOKENS;
+        return;
+      }
+
+      if (
+        type === 'input_file' ||
+        type === 'input_audio' ||
+        type === 'input_video'
+      ) {
+        total += RESPONSE_NON_TEXT_CONTENT_TOKENS;
+      }
+    };
+
     if (systemPrompt) {
-      total += countTokens(systemPrompt);
+      addTextTokens(systemPrompt);
       total += RESPONSE_MESSAGE_OVERHEAD_TOKENS;
     }
 
     if (tools && tools.length > 0) {
       for (const tool of tools) {
         total += RESPONSE_MESSAGE_OVERHEAD_TOKENS;
-        total += countTokens(JSON.stringify(tool));
+        // Tool definitions can be large; include a conservative JSON size estimate.
+        addTextTokens(JSON.stringify(tool));
       }
     }
 
@@ -933,28 +966,13 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       if (this.isMessageItem(message)) {
         const content = message.content;
         if (typeof content === 'string') {
-          total += countTokens(content);
+          addTextTokens(content);
           continue;
         }
 
         if (Array.isArray(content)) {
           for (const part of content) {
-            const type = (part as { type?: unknown }).type;
-            const text = (part as { text?: unknown }).text;
-            if (
-              (type === 'input_text' || type === 'output_text') &&
-              typeof text === 'string'
-            ) {
-              total += countTokens(text);
-            } else if (type === 'input_image') {
-              total += RESPONSE_IMAGE_CONTENT_TOKENS;
-            } else if (
-              type === 'input_file' ||
-              type === 'input_audio' ||
-              type === 'input_video'
-            ) {
-              total += RESPONSE_NON_TEXT_CONTENT_TOKENS;
-            }
+            addContentPartTokens(part);
           }
         }
       }
@@ -963,28 +981,17 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       if (messageType === 'function_call_output') {
         const output = (message as { output?: unknown }).output;
         if (typeof output === 'string') {
-          total += countTokens(output);
+          addTextTokens(output);
         } else if (Array.isArray(output)) {
           for (const part of output) {
-            const type = (part as { type?: unknown }).type;
-            const text = (part as { text?: unknown }).text;
-            if (
-              (type === 'input_text' || type === 'output_text') &&
-              typeof text === 'string'
-            ) {
-              total += countTokens(text);
-            }
+            addContentPartTokens(part);
           }
         }
       } else if (messageType === 'function_call') {
         const name = (message as { name?: unknown }).name;
         const args = (message as { arguments?: unknown }).arguments;
-        if (typeof name === 'string') {
-          total += countTokens(name);
-        }
-        if (typeof args === 'string') {
-          total += countTokens(args);
-        }
+        addTextTokens(name);
+        addTextTokens(args);
       } else if (
         messageType === 'input_image' ||
         messageType === 'input_file' ||

--- a/src/common/webview/commands.ts
+++ b/src/common/webview/commands.ts
@@ -214,6 +214,7 @@ export const PROGRESS_VIEW_COMMANDS = {
   SEND_FOLLOW_UP: 'sendFollowUp',
   POLISH_FOLLOW_UP: 'polishFollowUp',
   FOLLOW_UP_TEXT_POLISHED: 'followUpTextPolished',
+  FOLLOW_UP_TEXT_POLISH_ERROR: 'followUpTextPolishError',
   FOLLOW_UP_TEXT_TRANSCRIBED: 'followUpTextTranscribed',
   START_RECORDING: 'startRecording',
   STOP_RECORDING: 'stopRecording',

--- a/src/historyView/frontend/HistoryApp.ts
+++ b/src/historyView/frontend/HistoryApp.ts
@@ -150,6 +150,7 @@ export class HistoryApp extends BaseWebviewApp {
 
       <history-search-bar
         .matchCount=${this.matchCount}
+        .searchTerm=${this.searchTerm}
         @history-search-change=${this.handleSearchChange}
         @history-search-next=${() => this.handleSearchNavigate('next')}
         @history-search-prev=${() => this.handleSearchNavigate('prev')}

--- a/src/historyView/frontend/components/HistoryList.ts
+++ b/src/historyView/frontend/components/HistoryList.ts
@@ -50,6 +50,8 @@ export class HistoryList extends LitElement {
   /** Match counts per item, keyed by item.id - used to compute highlighted index */
   @state() private matchCounts: Map<string, number> = new Map();
 
+  private searchVersion = 0;
+
   @queryAll('history-item')
   private historyItemElements!: Array<
     HTMLElement & {
@@ -89,13 +91,15 @@ export class HistoryList extends LitElement {
   protected updated(changedProps: Map<string, unknown>): void {
     // Re-apply search when items change (e.g., new history loaded)
     if (changedProps.has('items') && this.searchTerm) {
-      void this.applySearchToItems(this.searchTerm);
+      const currentVersion = ++this.searchVersion;
+      void this.applySearchToItems(this.searchTerm, currentVersion);
     }
   }
 
   // === Internal search operations (called from willUpdate) ===
 
   private performClearSearch(): void {
+    this.searchVersion += 1;
     this.matchCounts = new Map();
     this.state?.setSearchIndex(-1);
     this.state?.setTotalMatches(0);
@@ -111,7 +115,8 @@ export class HistoryList extends LitElement {
       this.updateMatchCount();
       return;
     }
-    void this.applySearchToItems(term);
+    const currentVersion = ++this.searchVersion;
+    void this.applySearchToItems(term, currentVersion);
   }
 
   private performNavigate(direction: 'next' | 'prev'): void {
@@ -160,13 +165,17 @@ export class HistoryList extends LitElement {
     return null;
   }
 
-  private async applySearchToItems(term: string): Promise<void> {
+  private async applySearchToItems(
+    term: string,
+    version: number,
+  ): Promise<void> {
     const historyItems = this.getHistoryItems();
     const counts = await Promise.all(
       historyItems.map(
         (item) => item.applySearch?.(term) ?? Promise.resolve(0),
       ),
     );
+    if (version !== this.searchVersion) return;
 
     // Store match counts per item for computing highlighted indices
     const newMatchCounts = new Map<string, number>();
@@ -202,7 +211,7 @@ export class HistoryList extends LitElement {
     }
   > {
     // @queryAll returns NodeList, not Array - convert for .map() support
-    return Array.from(this.historyItemElements ?? []);
+    return this.historyItemElements ? [...this.historyItemElements] : [];
   }
 
   private handleToggle(

--- a/src/historyView/frontend/components/SearchBar.ts
+++ b/src/historyView/frontend/components/SearchBar.ts
@@ -19,6 +19,7 @@ export class SearchBar extends LitElement {
   static override styles = [designTokens, codiconStyles, historyViewStyles];
 
   @property({ type: String }) matchCount = '';
+  @property({ type: String }) searchTerm = '';
 
   private searchTimeoutId: ReturnType<typeof setTimeout> | null = null;
 
@@ -66,6 +67,7 @@ export class SearchBar extends LitElement {
           class="search-input"
           type="search"
           placeholder="Search history items..."
+          .value=${this.searchTerm}
           @input=${this.handleInput}
           @keydown=${this.handleKeydown}
         ></vscode-textfield>

--- a/src/profileView/frontend/components/AgentsTable.ts
+++ b/src/profileView/frontend/components/AgentsTable.ts
@@ -43,8 +43,9 @@ export class AgentsTable extends LitElement {
 
   private renderAgentRow(agent: RemoteAgent): TemplateResult {
     const visibilityArray = this.normalizeVisibility(agent.visibility);
-    const visibilityClass =
-      visibilityArray[0] === 'public' ? 'public' : 'custom';
+    const visibilityClass = visibilityArray.includes('public')
+      ? 'public'
+      : 'custom';
     const multiOutputClass = agent.supportsMultipleOutput
       ? 'supported'
       : 'not-supported';

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -806,10 +806,11 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
 
   private clearModelOutputBackups(streamId: StreamTabId): void {
     const prefix = `${streamId}:`;
-    for (const key of this.modelOutputBackups.keys()) {
-      if (key.startsWith(prefix)) {
-        this.modelOutputBackups.delete(key);
-      }
+    const keysToDelete = [...this.modelOutputBackups.keys()].filter((key) =>
+      key.startsWith(prefix),
+    );
+    for (const key of keysToDelete) {
+      this.modelOutputBackups.delete(key);
     }
   }
 

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -178,8 +178,8 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
         this.handleOpenMemoryView(),
 
       // Followup task
-      [PROGRESS_VIEW_COMMANDS.GET_FOLLOWUP_OPTIONS]: () =>
-        this.handleGetFollowupOptions(),
+      [PROGRESS_VIEW_COMMANDS.GET_FOLLOWUP_OPTIONS]: (data) =>
+        this.handleGetFollowupOptions(data),
       [PROGRESS_VIEW_COMMANDS.SETUP_FOLLOWUP]: (data) =>
         this.handleSetupFollowup(data),
       [PROGRESS_VIEW_COMMANDS.RUN_FOLLOWUP]: (data) =>
@@ -277,6 +277,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     this.provider.eventHandler.clearPendingTaskGroups(streamId);
     cleanupApprovalsForStream(streamId);
     ToolUseFollowUpQueue.release(streamId);
+    this.clearModelOutputBackups(streamId);
     await this.provider.state.clearStream(streamId);
     // Force rebuild since we deleted a stream
     this.provider.updateWebview({ forceRebuild: true });
@@ -301,6 +302,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     for (const streamId of this.provider.state.streamTabs.keys()) {
       ToolUseFollowUpQueue.release(streamId);
     }
+    this.modelOutputBackups.clear();
     await this.provider.state.clearAll();
     // Force rebuild since we deleted all streams
     this.provider.updateWebview({ forceRebuild: true });
@@ -478,12 +480,20 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
             });
           } else if (result.error) {
             await vscode.window.showErrorMessage(result.error);
+            this.postToActiveView({
+              command: PROGRESS_VIEW_COMMANDS.FOLLOW_UP_TEXT_POLISH_ERROR,
+              error: result.error,
+            });
           }
         } catch (error) {
           const messageText = toErrorMessage(error);
           await vscode.window.showErrorMessage(
             `Error polishing follow-up: ${messageText}`,
           );
+          this.postToActiveView({
+            command: PROGRESS_VIEW_COMMANDS.FOLLOW_UP_TEXT_POLISH_ERROR,
+            error: messageText,
+          });
           this.logger.error(
             this.channel,
             `Error polishing follow-up: ${messageText}`,
@@ -682,12 +692,16 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     data: MessageFor<typeof PROGRESS_VIEW_COMMANDS.COMPARE_ORIGINAL>,
   ): Promise<void> {
     const { file, base } = data;
+    if (!base) return;
     const streamId = this.provider.state.activeStream;
     if (streamId && file) {
       try {
         const fileLocation = createExternalLocation(file);
         const content = await flexibleFS.read(fileLocation);
-        this.modelOutputBackups.set(file, { content, streamId });
+        this.modelOutputBackups.set(
+          this.getModelOutputBackupKey(streamId, file),
+          { content, streamId },
+        );
       } catch {
         // Ignore backup errors
       }
@@ -713,14 +727,16 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     const { file, base, prev } = data;
     const previousFile = prev ?? base;
 
-    if (previousFile) {
-      await vscode.commands.executeCommand(
-        'texra.latexdiff',
-        undefined,
-        previousFile,
-        file,
-      );
+    if (!previousFile) {
+      return;
     }
+
+    await vscode.commands.executeCommand(
+      'texra.latexdiff',
+      undefined,
+      previousFile,
+      file,
+    );
 
     await vscode.commands.executeCommand(
       'texra.compare',
@@ -734,7 +750,10 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     data: MessageFor<typeof PROGRESS_VIEW_COMMANDS.ACCEPT_FILE>,
   ): Promise<void> {
     const { file, base } = data;
-    const backup = file ? this.modelOutputBackups.get(file) : null;
+    const streamId = this.provider.state.activeStream;
+    const backupKey =
+      streamId && file ? this.getModelOutputBackupKey(streamId, file) : null;
+    const backup = backupKey ? this.modelOutputBackups.get(backupKey) : null;
     let currentContent: string | null = null;
 
     if (backup) {
@@ -775,7 +794,22 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     }
 
     if (file) {
-      this.modelOutputBackups.delete(file);
+      if (backupKey) {
+        this.modelOutputBackups.delete(backupKey);
+      }
+    }
+  }
+
+  private getModelOutputBackupKey(streamId: StreamTabId, file: string): string {
+    return `${streamId}:${file}`;
+  }
+
+  private clearModelOutputBackups(streamId: StreamTabId): void {
+    const prefix = `${streamId}:`;
+    for (const key of this.modelOutputBackups.keys()) {
+      if (key.startsWith(prefix)) {
+        this.modelOutputBackups.delete(key);
+      }
     }
   }
 
@@ -823,9 +857,12 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
   // Followup task handlers
   // ============================================================
 
-  private async handleGetFollowupOptions(): Promise<void> {
+  private async handleGetFollowupOptions(
+    data: MessageFor<typeof PROGRESS_VIEW_COMMANDS.GET_FOLLOWUP_OPTIONS>,
+  ): Promise<void> {
     const view = this.getActiveView();
     if (!view) return;
+    const streamId = data.stream ?? this.provider.state.activeStream;
 
     try {
       const { agentOptions, modelOptions, defaultMergeModel } =
@@ -833,6 +870,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
 
       view.webview.postMessage({
         command: PROGRESS_VIEW_COMMANDS.SET_FOLLOWUP_OPTIONS,
+        stream: streamId ?? undefined,
         workflowAgentsData: agentOptions.workflow,
         toolUseAgentsData: agentOptions.toolUse,
         modelOptionsData: modelOptions,

--- a/src/progressView/frontend/ProgressApp.ts
+++ b/src/progressView/frontend/ProgressApp.ts
@@ -14,9 +14,11 @@ import { PersistedState, createWebviewStorage } from '@shared/state';
 // Local imports - shared schemas
 import {
   AGENT_CATEGORY,
+  AgentCategoryFilterSchema,
   type StreamTabId,
   type StreamTabInfo,
 } from '@shared/schemas';
+import { StreamSortSchema } from '@shared/streams/streamSort';
 import { resolveRunId } from '@shared/streams/runSelection';
 
 // Local imports - webview commands
@@ -28,15 +30,13 @@ import {
   getStreamState,
   isToolUseState,
   type ProgressState,
-  type StreamFilter,
-  type StreamSort,
   type StreamState,
 } from './store';
 
 /** Schema for persisted preferences. */
 const ProgressViewPrefsSchema = z.object({
-  streamFilter: z.string().prefault('all') as z.ZodType<StreamFilter>,
-  streamSort: z.string().prefault('time') as z.ZodType<StreamSort>,
+  streamFilter: AgentCategoryFilterSchema.catch('all'),
+  streamSort: StreamSortSchema.catch('time'),
 });
 
 type ProgressViewPreferences = z.infer<typeof ProgressViewPrefsSchema>;
@@ -247,11 +247,8 @@ export class ProgressApp extends BaseWebviewApp {
 
   private getActiveStreamInfo(): StreamTabInfo | null {
     if (!this.appState.activeStreamId) return null;
-    // Search in filtered streams to respect current filter
-    // This ensures we don't show content for streams hidden by filter
-    const filteredStreams = getFilteredStreams(this.appState);
     return (
-      filteredStreams.find(
+      this.appState.streams.find(
         (stream) => stream.name === this.appState.activeStreamId,
       ) ?? null
     );
@@ -271,13 +268,15 @@ export class ProgressApp extends BaseWebviewApp {
       activeStream.agentCategory,
     );
     const isToolUse = isToolUseState(streamState);
-    const runId = resolveRunId(streamState, { mode: 'strict' });
+    const runId = resolveRunId(streamState, { mode: 'fallback' });
+    const followupOptions =
+      this.appState.followupOptionsByStream.get(activeStream.name) ?? null;
 
     this.streamContextValue = {
       streamInfo: activeStream,
       streamState,
       runId,
-      followupOptions: this.appState.followupOptions,
+      followupOptions,
       isToolUse,
     };
     this.permissionsContextValue = this.permissions;

--- a/src/progressView/frontend/components/FileList.ts
+++ b/src/progressView/frontend/components/FileList.ts
@@ -212,7 +212,7 @@ export class FileList extends LitElement {
     if (!this.showRoundHeaders) {
       return html`${repeat(
         files,
-        (file) => file.location?.absolutePath ?? '',
+        (file) => `${round}-${file.location?.absolutePath ?? ''}`,
         (file) => this.renderFileItem(file),
       )}`;
     }
@@ -226,7 +226,7 @@ export class FileList extends LitElement {
         <div class="round-content">
           ${repeat(
             files,
-            (file) => file.location?.absolutePath ?? '',
+            (file) => `${round}-${file.location?.absolutePath ?? ''}`,
             (file) => this.renderFileItem(file),
           )}
         </div>
@@ -284,12 +284,12 @@ export class FileList extends LitElement {
    * All data is stored directly on command elements for unified delegation.
    */
   private handleFileClick(event: MouseEvent): void {
-    const target = event.target as Element | null;
-    if (!target) return;
-
     // Find element with data-command (all needed data is on this element)
-    const actionEl = target.closest('[data-command]');
-    if (!(actionEl instanceof HTMLElement)) return;
+    const path = event.composedPath() as Element[];
+    const actionEl = path.find(
+      (item) => item instanceof HTMLElement && item.dataset.command,
+    ) as HTMLElement | undefined;
+    if (!actionEl) return;
 
     const { command, file, base, prev } = actionEl.dataset;
     if (!command || !file) return;

--- a/src/progressView/frontend/components/FollowUpInput.ts
+++ b/src/progressView/frontend/components/FollowUpInput.ts
@@ -135,10 +135,12 @@ export class FollowUpInput extends LitElement {
     }
 
     // React to polishedText property change
-    if (changedProperties.has('polishedText') && this.polishedText !== null) {
+    if (changedProperties.has('polishedText')) {
       this.polishing = false;
-      this.updateValue(this.polishedText);
-      this.focusInput({ scrollIntoView: true });
+      if (this.polishedText !== null) {
+        this.updateValue(this.polishedText);
+        this.focusInput({ scrollIntoView: true });
+      }
     }
 
     // React to transcribedText property change
@@ -171,7 +173,7 @@ export class FollowUpInput extends LitElement {
 
   /** Handle keyboard events on the textarea - Lit-native pattern */
   private handleKeydown(event: KeyboardEvent): void {
-    if (event.key === 'Enter' && !event.shiftKey) {
+    if (event.key === 'Enter' && !event.shiftKey && !event.isComposing) {
       event.preventDefault();
       this.emitSend();
     }
@@ -274,6 +276,10 @@ export class FollowUpInput extends LitElement {
   }
 
   private emitPolish(): void {
+    if (!this.value.trim()) {
+      this.polishing = false;
+      return;
+    }
     this.polishing = true;
     this.dispatchEvent(ProgressEvents.followupPolish());
   }

--- a/src/progressView/frontend/components/FollowUpInput.ts
+++ b/src/progressView/frontend/components/FollowUpInput.ts
@@ -109,6 +109,7 @@ export class FollowUpInput extends LitElement {
   @property({ type: Boolean }) shouldFocus = false;
   @property({ type: String }) polishedText: string | null = null;
   @property({ type: String }) transcribedText: string | null = null;
+  @property({ type: Number }) polishErrorId = 0;
   @property({ type: Boolean }) recording = false;
 
   @state() private polishing = false;
@@ -141,6 +142,10 @@ export class FollowUpInput extends LitElement {
         this.updateValue(this.polishedText);
         this.focusInput({ scrollIntoView: true });
       }
+    }
+
+    if (changedProperties.has('polishErrorId')) {
+      this.polishing = false;
     }
 
     // React to transcribedText property change

--- a/src/progressView/frontend/components/FollowupSection.ts
+++ b/src/progressView/frontend/components/FollowupSection.ts
@@ -27,12 +27,8 @@ import { STREAM_STATUS } from '@shared/schemas';
 import { ELEMENT_IDS } from '../constants';
 import { ProgressEvents } from '../events';
 import { getRadioValue } from '../utils';
-import type { FollowupMode } from '../store';
-import type {
-  SetFollowupOptionsMessage,
-  AgentOptionData,
-  ModelOptionData,
-} from '@shared/schemas';
+import type { FollowupMode, FollowupOptionsState } from '../store';
+import type { AgentOptionData, ModelOptionData } from '@shared/schemas';
 
 /** Agent name used for merge mode (fixed, not user-selectable) */
 const MERGE_AGENT_NAME = 'merge';
@@ -48,15 +44,6 @@ export interface FollowupFormData {
   attachOutputs: boolean;
   initialQuestion: string;
 }
-
-/**
- * Followup options received from backend.
- * Derived from SetFollowupOptionsMessage schema (minus command field).
- */
-export type FollowupOptions = Omit<
-  SetFollowupOptionsMessage,
-  'command' | 'stream'
->;
 
 @customElement('followup-section')
 export class FollowupSection extends LitElement {
@@ -184,7 +171,7 @@ export class FollowupSection extends LitElement {
   @property({ type: Boolean }) hasOutputFiles: boolean = false;
 
   // Configuration props
-  @property({ type: Object }) options: FollowupOptions | null = null;
+  @property({ type: Object }) options: FollowupOptionsState | null = null;
   @property({ type: String }) mode: FollowupMode = 'chat';
   @property({ type: String }) streamModel: string | null = null;
 

--- a/src/progressView/frontend/components/FollowupSection.ts
+++ b/src/progressView/frontend/components/FollowupSection.ts
@@ -53,7 +53,10 @@ export interface FollowupFormData {
  * Followup options received from backend.
  * Derived from SetFollowupOptionsMessage schema (minus command field).
  */
-export type FollowupOptions = Omit<SetFollowupOptionsMessage, 'command'>;
+export type FollowupOptions = Omit<
+  SetFollowupOptionsMessage,
+  'command' | 'stream'
+>;
 
 @customElement('followup-section')
 export class FollowupSection extends LitElement {

--- a/src/progressView/frontend/components/LatexdiffResults.ts
+++ b/src/progressView/frontend/components/LatexdiffResults.ts
@@ -154,7 +154,8 @@ export class LatexdiffResults extends LitElement {
         >
           ${repeat(
             this.entries,
-            (entry) => `${entry.baseFile}-${entry.revisedFile}`,
+            (entry, index) =>
+              `${entry.runId ?? this.runId}-${entry.baseRound}-${entry.revisedRound}-${entry.baseFile}-${entry.revisedFile}-${index}`,
             (entry) => this.renderEntry(entry),
           )}
         </ul>

--- a/src/progressView/frontend/components/RequestPanels.ts
+++ b/src/progressView/frontend/components/RequestPanels.ts
@@ -1,5 +1,11 @@
 // Third-party imports
-import { LitElement, html, nothing, type TemplateResult } from 'lit';
+import {
+  LitElement,
+  html,
+  nothing,
+  type PropertyValues,
+  type TemplateResult,
+} from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { repeat } from 'lit/directives/repeat.js';
 import { classMap } from 'lit/directives/class-map.js';
@@ -58,6 +64,22 @@ export class RequestPanels extends LitElement {
 
   @state() private feedbackOpenKeys: Set<PermissionKey> = new Set();
   @state() private openDiffMenuKey: PermissionKey | null = null;
+
+  protected override willUpdate(changedProperties: PropertyValues<this>): void {
+    if (!changedProperties.has('permissions')) return;
+    const validKeys = new Set(
+      this.permissions.map((permission) => this.getPermissionKey(permission)),
+    );
+    const nextFeedback = new Set(
+      [...this.feedbackOpenKeys].filter((key) => validKeys.has(key)),
+    );
+    if (nextFeedback.size !== this.feedbackOpenKeys.size) {
+      this.feedbackOpenKeys = nextFeedback;
+    }
+    if (this.openDiffMenuKey && !validKeys.has(this.openDiffMenuKey)) {
+      this.openDiffMenuKey = null;
+    }
+  }
 
   override connectedCallback(): void {
     super.connectedCallback();
@@ -778,10 +800,12 @@ export class RequestPanels extends LitElement {
   };
 
   private handleMenuClick = (event: CustomEvent): void => {
-    const target = event.target as Element | null;
-    if (!target) return;
-
-    const menuItem = target.closest('vscode-context-menu-item');
+    const path = event.composedPath() as Element[];
+    const menuItem = path.find(
+      (item) =>
+        item instanceof HTMLElement &&
+        item.tagName === 'VSCODE-CONTEXT-MENU-ITEM',
+    ) as HTMLElement | undefined;
     if (!menuItem) return;
 
     const kind = menuItem.dataset.permissionKind as
@@ -907,12 +931,19 @@ export class RequestPanels extends LitElement {
     const lines = [
       details.message && `message: ${details.message}`,
       details.provider && `provider: ${details.provider}`,
-      details.statusCode != null && `statusCode: ${details.statusCode}`,
+      details.statusCode !== undefined &&
+        details.statusCode !== null &&
+        `statusCode: ${details.statusCode}`,
       details.statusText && `statusText: ${details.statusText}`,
-      details.isRelayError != null && `isRelayError: ${details.isRelayError}`,
-      details.retryable != null && `retryable: ${details.retryable}`,
+      details.isRelayError !== undefined &&
+        details.isRelayError !== null &&
+        `isRelayError: ${details.isRelayError}`,
+      details.retryable !== undefined &&
+        details.retryable !== null &&
+        `retryable: ${details.retryable}`,
       details.requestId && `requestId: ${details.requestId}`,
-      details.rawErrorBody != null &&
+      details.rawErrorBody !== undefined &&
+        details.rawErrorBody !== null &&
         `rawErrorBody: ${formatBody(details.rawErrorBody)}`,
     ].filter(Boolean);
 

--- a/src/progressView/frontend/components/StreamHeader.ts
+++ b/src/progressView/frontend/components/StreamHeader.ts
@@ -44,6 +44,7 @@ const STATUS_LABELS: Record<string, string> = {
   [STREAM_STATUS.READY]: 'Ready',
   [STREAM_STATUS.WAITING]: 'Waiting for follow-up',
   [STREAM_STATUS.RESUMING]: 'Resuming',
+  [STREAM_STATUS.INITIALIZING]: 'Initializing',
 };
 
 /**
@@ -94,6 +95,10 @@ const ENABLED_BUTTONS_BY_STATUS: Record<string, string[]> = {
     ELEMENT_IDS.YOLO_TOGGLE_BTN,
     ELEMENT_IDS.RESTORE_STATE_BTN,
     ELEMENT_IDS.OPEN_TASK_STORAGE_BTN,
+  ],
+  [STREAM_STATUS.INITIALIZING]: [
+    ELEMENT_IDS.STOP_STREAM_BTN,
+    ELEMENT_IDS.CLEAN_STREAM_BTN,
   ],
 };
 
@@ -433,9 +438,10 @@ export class StreamHeader extends LitElement {
   }
 
   private handleToolbarClick(event: MouseEvent) {
-    const target = event.target as Element | null;
-    if (!target) return;
-    const button = target.closest('[data-command]') as HTMLElement | null;
+    const path = event.composedPath() as Element[];
+    const button = path.find(
+      (item) => item instanceof HTMLElement && item.dataset.command,
+    ) as HTMLElement | undefined;
     if (!button || button.hasAttribute('disabled')) return;
 
     const command = button.dataset.command;

--- a/src/progressView/frontend/components/StreamTabs.ts
+++ b/src/progressView/frontend/components/StreamTabs.ts
@@ -202,6 +202,10 @@ export class StreamTabs extends LitElement {
         color: var(--vscode-errorForeground);
       }
 
+      .sort-btn.active::part(control) {
+        background-color: var(--vscode-toolbar-hoverBackground);
+      }
+
       .log-placeholder {
         text-align: center;
         color: var(--color-text-secondary);
@@ -272,11 +276,15 @@ export class StreamTabs extends LitElement {
               (btn) => html`
                 <vscode-toolbar-button
                   id=${btn.id}
-                  class="sort-btn"
+                  class=${classMap({
+                    'sort-btn': true,
+                    active: this.sort === btn.sort,
+                  })}
                   icon=${btn.icon}
                   label=${btn.title}
                   title=${btn.title}
                   data-sort=${btn.sort}
+                  aria-pressed=${this.sort === btn.sort ? 'true' : 'false'}
                 ></vscode-toolbar-button>
               `,
             )}
@@ -368,12 +376,15 @@ export class StreamTabs extends LitElement {
   }
 
   private handleTabClick(event: MouseEvent): void {
-    const target = event.target as Element | null;
-    if (!target) return;
-
     // Find element with data-stream and data-action (unified delegation)
-    const actionElement = target.closest('[data-stream][data-action]');
-    if (!(actionElement instanceof HTMLElement)) return;
+    const path = event.composedPath() as Element[];
+    const actionElement = path.find(
+      (item) =>
+        item instanceof HTMLElement &&
+        item.dataset.stream &&
+        item.dataset.action,
+    ) as HTMLElement | undefined;
+    if (!actionElement) return;
 
     const { stream: streamId, action } = actionElement.dataset;
     if (!streamId) return;
@@ -397,12 +408,12 @@ export class StreamTabs extends LitElement {
   }
 
   private handleSortClick(event: MouseEvent): void {
-    const target = event.target as Element | null;
-    if (!target) return;
-
     // Find element with data-sort attribute (unified delegation)
-    const button = target.closest('[data-sort]');
-    if (!(button instanceof HTMLElement) || !button.dataset.sort) return;
+    const path = event.composedPath() as Element[];
+    const button = path.find(
+      (item) => item instanceof HTMLElement && item.dataset.sort,
+    ) as HTMLElement | undefined;
+    if (!button?.dataset.sort) return;
 
     this.dispatchEvent(
       ProgressEvents.sortChange({ sort: button.dataset.sort as StreamSort }),
@@ -427,7 +438,7 @@ export class StreamTabs extends LitElement {
       : mainLine;
   }
 
-  private normalizeStatus(status?: string): string {
+  private normalizeStatus(status?: string | null): string {
     return status ?? STREAM_STATUS.READY;
   }
 }

--- a/src/progressView/frontend/components/TodoList.ts
+++ b/src/progressView/frontend/components/TodoList.ts
@@ -119,6 +119,19 @@ export class TodoList extends LitElement {
     }
 
     const keyCounts = new Map<string, number>();
+    const keyedTodos = this.todos.map((todo) => {
+      const baseKey = [
+        todo.content,
+        todo.status ?? TODO_STATUS.PENDING,
+        todo.activeForm ?? '',
+      ].join('|');
+      const count = (keyCounts.get(baseKey) ?? 0) + 1;
+      keyCounts.set(baseKey, count);
+      return {
+        key: `${baseKey}-${count}`,
+        todo,
+      };
+    });
     return html`
       <vscode-collapsible
         id=${ELEMENT_IDS.TODO_LIST_CONTAINER}
@@ -128,18 +141,9 @@ export class TodoList extends LitElement {
       >
         <div id=${ELEMENT_IDS.TODO_LIST} class="todo-list">
           ${repeat(
-            this.todos,
-            (todo) => {
-              const baseKey = [
-                todo.content,
-                todo.status ?? TODO_STATUS.PENDING,
-                todo.activeForm ?? '',
-              ].join('|');
-              const count = (keyCounts.get(baseKey) ?? 0) + 1;
-              keyCounts.set(baseKey, count);
-              return `${baseKey}-${count}`;
-            },
-            (todo) => this.renderTodo(todo),
+            keyedTodos,
+            (item) => item.key,
+            (item) => this.renderTodo(item.todo),
           )}
         </div>
       </vscode-collapsible>

--- a/src/progressView/frontend/components/TodoList.ts
+++ b/src/progressView/frontend/components/TodoList.ts
@@ -128,7 +128,7 @@ export class TodoList extends LitElement {
         <div id=${ELEMENT_IDS.TODO_LIST} class="todo-list">
           ${repeat(
             this.todos,
-            (todo) => `${todo.content}-${todo.status}`,
+            (_todo, index) => `${index}`,
             (todo) => this.renderTodo(todo),
           )}
         </div>

--- a/src/progressView/frontend/components/TodoList.ts
+++ b/src/progressView/frontend/components/TodoList.ts
@@ -118,6 +118,7 @@ export class TodoList extends LitElement {
       return nothing;
     }
 
+    const keyCounts = new Map<string, number>();
     return html`
       <vscode-collapsible
         id=${ELEMENT_IDS.TODO_LIST_CONTAINER}
@@ -128,7 +129,16 @@ export class TodoList extends LitElement {
         <div id=${ELEMENT_IDS.TODO_LIST} class="todo-list">
           ${repeat(
             this.todos,
-            (_todo, index) => `${index}`,
+            (todo) => {
+              const baseKey = [
+                todo.content,
+                todo.status ?? TODO_STATUS.PENDING,
+                todo.activeForm ?? '',
+              ].join('|');
+              const count = (keyCounts.get(baseKey) ?? 0) + 1;
+              keyCounts.set(baseKey, count);
+              return `${baseKey}-${count}`;
+            },
             (todo) => this.renderTodo(todo),
           )}
         </div>

--- a/src/progressView/frontend/components/ToolUseStreamContent.ts
+++ b/src/progressView/frontend/components/ToolUseStreamContent.ts
@@ -156,6 +156,7 @@ export class ToolUseStreamContent extends LitElement {
         .shouldFocus=${currentState.shouldFocusFollowUp ?? false}
         .polishedText=${currentState.polishedText ?? null}
         .transcribedText=${currentState.transcribedText ?? null}
+        .polishErrorId=${currentState.polishErrorId ?? 0}
         .recording=${currentState.recording ?? false}
         @focus-complete=${this.handleFocusComplete}
       ></follow-up-input>

--- a/src/progressView/frontend/components/UsagePanel.ts
+++ b/src/progressView/frontend/components/UsagePanel.ts
@@ -92,7 +92,9 @@ export class UsagePanel extends LitElement {
     const hasUsage =
       (this.usage?.inputTokens ?? 0) > 0 ||
       (this.usage?.outputTokens ?? 0) > 0 ||
-      (this.usage?.cost ?? 0) > 0;
+      (this.usage?.cost ?? 0) > 0 ||
+      (this.usage?.cacheReadInputTokens ?? 0) > 0 ||
+      (this.usage?.cacheCreationInputTokens ?? 0) > 0;
     const hasContext =
       (this.contextState?.contextWindow ?? 0) > 0 &&
       this.contextState?.utilizationPercent !== undefined;

--- a/src/progressView/frontend/index.ts
+++ b/src/progressView/frontend/index.ts
@@ -1,5 +1,2 @@
-// Third-party styles
-import 'katex/dist/katex.min.css';
-
 // Local imports - progress view frontend
 import './ProgressApp';

--- a/src/progressView/frontend/messageDispatcher.ts
+++ b/src/progressView/frontend/messageDispatcher.ts
@@ -580,6 +580,7 @@ const handlers: HandlerRegistry = {
     updateToolUseState(ctx, streamId, (prev) => ({
       ...prev,
       polishedText: null,
+      polishErrorId: (prev.polishErrorId ?? 0) + 1,
     }));
   },
 

--- a/src/progressView/frontend/messageDispatcher.ts
+++ b/src/progressView/frontend/messageDispatcher.ts
@@ -18,7 +18,6 @@ import {
   type StreamTabInfo,
 } from '@shared/schemas';
 import { PERMISSION_KIND } from '@shared/utils/uiConstants';
-import { resolveRunId } from '@shared/streams/runSelection';
 import { PROGRESS_VIEW_COMMANDS } from '@common/webview/commands';
 
 // Local imports - progress view
@@ -83,7 +82,7 @@ function addPermission(
   ctx: MessageHandlerContext,
   permission: PermissionState,
 ): void {
-  ctx.setPermissions([...ctx.getPermissions(), permission]);
+  ctx.setPermissions([permission, ...ctx.getPermissions()]);
 }
 
 function removePrompt(
@@ -121,13 +120,23 @@ function updateStreamInfo(
   for (const key of nextStates.keys()) {
     if (!knownStreams.has(key)) {
       nextStates.delete(key);
+      clearPendingLogUpdatesForStream(key);
     }
   }
 
   for (const stream of streams) {
     const backendState = backendStates?.[stream.name];
     if (backendState) {
-      nextStates.set(stream.name, { ...backendState, info: stream });
+      const existing = nextStates.get(stream.name);
+      const frontendOnlyFields =
+        existing && isToolUseState(existing)
+          ? { followUpText: existing.followUpText }
+          : {};
+      nextStates.set(stream.name, {
+        ...backendState,
+        ...frontendOnlyFields,
+        info: stream,
+      });
     } else {
       const existing =
         nextStates.get(stream.name) ?? createStreamState(stream.agentCategory);
@@ -170,11 +179,26 @@ const handlers: HandlerRegistry = {
       data.streams,
       data.streamStates,
     );
+    const knownStreams = new Set(data.streams.map((stream) => stream.name));
+    const resolvedActiveStream =
+      activeStream && knownStreams.has(activeStream)
+        ? activeStream
+        : (data.streams.at(0)?.name ?? null);
+    const nextFollowupOptions = new Map();
+    for (const [
+      streamId,
+      options,
+    ] of updated.followupOptionsByStream.entries()) {
+      if (knownStreams.has(streamId)) {
+        nextFollowupOptions.set(streamId, options);
+      }
+    }
 
     ctx.setState(() => ({
       ...updated,
-      activeStreamId: activeStream || null,
+      activeStreamId: resolvedActiveStream,
       streamFilter: data.agentFilter,
+      followupOptionsByStream: nextFollowupOptions,
     }));
   },
 
@@ -184,6 +208,9 @@ const handlers: HandlerRegistry = {
 
     const nextStates = new Map(state.streamStates);
     nextStates.delete(streamId);
+
+    const nextFollowupOptions = new Map(state.followupOptionsByStream);
+    nextFollowupOptions.delete(streamId);
 
     const nextStreams = state.streams.filter((s) => s.name !== streamId);
     const nextActiveStreamId =
@@ -197,6 +224,7 @@ const handlers: HandlerRegistry = {
       streams: nextStreams,
       streamStates: nextStates,
       activeStreamId: nextActiveStreamId,
+      followupOptionsByStream: nextFollowupOptions,
     }));
   },
 
@@ -207,6 +235,7 @@ const handlers: HandlerRegistry = {
       streams: [],
       streamStates: new Map(),
       activeStreamId: null,
+      followupOptionsByStream: new Map(),
     }));
   },
 
@@ -253,6 +282,17 @@ const handlers: HandlerRegistry = {
       };
 
       if (isWorkflowState(prev)) {
+        if (isClear) {
+          return {
+            ...baseUpdate,
+            activeRunId: null,
+            selectedRunId: null,
+            runInstructions: {},
+            runUsage: {},
+            runFiles: {},
+            runMissingOutputs: {},
+          };
+        }
         return {
           ...baseUpdate,
           activeRunId: activeRunId ?? prev.activeRunId,
@@ -389,10 +429,13 @@ const handlers: HandlerRegistry = {
     const { stream, instruction, runId: providedRunId } = data;
     if (!stream) return;
 
+    if (!providedRunId) {
+      console.warn('Skipping instruction update without runId', data);
+      return;
+    }
+
     updateWorkflowState(ctx, stream, (prev) => {
-      // Use provided runId from backend if available, otherwise resolve from state
-      const runId =
-        providedRunId ?? resolveRunId(prev, { mode: 'fallback' }) ?? 'default';
+      const runId = providedRunId;
       const { [runId]: _, ...rest } = prev.runInstructions;
       return {
         ...prev,
@@ -436,15 +479,27 @@ const handlers: HandlerRegistry = {
     const { streamId, id, status, endTime } = data.update;
     ctx.setStreamState(streamId, (prev) => ({
       ...prev,
-      taskGroups: prev.taskGroups.map((group) =>
-        group.id === id
-          ? {
-              ...group,
-              status: status ?? group.status,
-              endTime: endTime ?? group.endTime,
-            }
-          : group,
-      ),
+      taskGroups: prev.taskGroups.some((group) => group.id === id)
+        ? prev.taskGroups.map((group) =>
+            group.id === id
+              ? {
+                  ...group,
+                  status: status ?? group.status,
+                  endTime: endTime ?? group.endTime,
+                }
+              : group,
+          )
+        : [
+            ...prev.taskGroups,
+            {
+              id,
+              name: '',
+              status: status ?? 'running',
+              startTime: Date.now(),
+              endTime,
+              parentGroupId: undefined,
+            },
+          ],
     }));
   },
 
@@ -516,6 +571,18 @@ const handlers: HandlerRegistry = {
     }));
   },
 
+  [PROGRESS_VIEW_COMMANDS.FOLLOW_UP_TEXT_POLISH_ERROR]: (data, ctx) => {
+    const streamId = ctx.getState().activeStreamId;
+    if (!streamId) return;
+    if (data.error) {
+      console.warn(`Follow-up polish failed: ${data.error}`);
+    }
+    updateToolUseState(ctx, streamId, (prev) => ({
+      ...prev,
+      polishedText: null,
+    }));
+  },
+
   [PROGRESS_VIEW_COMMANDS.FOLLOW_UP_TEXT_TRANSCRIBED]: (data, ctx) => {
     const streamId = ctx.getState().activeStreamId;
     if (!streamId) return;
@@ -537,11 +604,16 @@ const handlers: HandlerRegistry = {
     setActiveStreamRecording(ctx, false),
 
   [PROGRESS_VIEW_COMMANDS.SET_FOLLOWUP_OPTIONS]: (data, ctx) => {
-    const { command: _command, ...options } = data;
+    const { command: _command, stream, ...options } = data;
+    const streamId = stream ?? ctx.getState().activeStreamId;
+    if (!streamId) return;
 
     ctx.setState((prev) => ({
       ...prev,
-      followupOptions: options,
+      followupOptionsByStream: new Map(prev.followupOptionsByStream).set(
+        streamId,
+        options,
+      ),
     }));
   },
 };

--- a/src/progressView/frontend/stateUtils.ts
+++ b/src/progressView/frontend/stateUtils.ts
@@ -1,13 +1,5 @@
 // Shared imports
 import { sortStreams } from '@shared/streams/streamSort';
-import type {
-  InstructionUpdate,
-  LogMessageData,
-  OutputFileInfo,
-  StreamTabId,
-  StreamTabInfo,
-  TaskGroup,
-} from '@shared/schemas';
 
 // Local imports
 import {
@@ -18,6 +10,16 @@ import {
   type WorkflowStreamState,
 } from './store';
 import type { FrontendEventHandlerContext } from './eventHandlers';
+
+// Shared imports - schemas
+import type {
+  InstructionUpdate,
+  LogMessageData,
+  OutputFileInfo,
+  StreamTabId,
+  StreamTabInfo,
+  TaskGroup,
+} from '@shared/schemas';
 
 /**
  * Updates a nested Record<runId, Record<round, T[]>> structure.
@@ -45,8 +47,8 @@ export function updateNestedRounds<T>(
   if (!rounds) return current;
 
   // Merge rounds into the run
-  const base = reset ? {} : current;
-  const existingRounds = base[runId] ?? {};
+  const base = reset ? { ...current } : current;
+  const existingRounds = reset ? {} : (base[runId] ?? {});
   return {
     ...base,
     [runId]: { ...existingRounds, ...rounds },

--- a/src/progressView/frontend/store.ts
+++ b/src/progressView/frontend/store.ts
@@ -27,7 +27,10 @@ export type { ContextState };
 export type { StreamSort };
 
 /** Followup options derived from schema (minus command field) */
-export type FollowupOptionsState = Omit<SetFollowupOptionsMessage, 'command'>;
+export type FollowupOptionsState = Omit<
+  SetFollowupOptionsMessage,
+  'command' | 'stream'
+>;
 
 export interface ProgressState {
   activeStreamId: StreamTabId | null;
@@ -35,7 +38,7 @@ export interface ProgressState {
   streamFilter: StreamFilter;
   streamSort: StreamSort;
   streamStates: Map<StreamTabId, StreamState>;
-  followupOptions: FollowupOptionsState | null;
+  followupOptionsByStream: Map<StreamTabId, FollowupOptionsState | null>;
 }
 
 export function createInitialState(): ProgressState {
@@ -45,7 +48,7 @@ export function createInitialState(): ProgressState {
     streamFilter: 'all',
     streamSort: 'time',
     streamStates: new Map(),
-    followupOptions: null,
+    followupOptionsByStream: new Map(),
   };
 }
 

--- a/src/progressView/frontend/styles/logStyles.ts
+++ b/src/progressView/frontend/styles/logStyles.ts
@@ -4,6 +4,7 @@
 
 // Third-party imports
 import { css } from 'lit';
+import katexStyles from 'katex/dist/katex.min.css?inline';
 
 // Shared styles
 import { animationStyles } from '@shared/styles/litStyles';
@@ -52,6 +53,9 @@ export const layoutStyles = css`
   }
 `;
 
+const katexStyleSheet = new CSSStyleSheet();
+katexStyleSheet.replaceSync(katexStyles);
+
 /**
  * Combined log styles - includes layout and all modular styles.
  * Use this for components that need the full set of log styles.
@@ -65,4 +69,5 @@ export const logStyles = [
   codeBlockStyles,
   toolUseStyles,
   markdownStyles,
+  katexStyleSheet,
 ];

--- a/src/progressView/frontend/utils.ts
+++ b/src/progressView/frontend/utils.ts
@@ -12,8 +12,10 @@ export type VSCodeValueElement = HTMLElement & { value?: string };
  * Prefers the clicked radio element's value, falls back to group value.
  */
 export function getRadioValue<T extends string>(event: Event): T | null {
-  const target = event.target as Element | null;
-  const radio = target?.closest('vscode-radio');
+  const path = event.composedPath() as Element[];
+  const radio = path.find(
+    (item) => item instanceof Element && item.tagName === 'VSCODE-RADIO',
+  ) as Element | undefined;
   const radioGroup = event.currentTarget as VSCodeValueElement | null;
   const value = radio?.getAttribute('value') || radioGroup?.value;
   return (value as T) || null;

--- a/src/progressView/streamInfoUtils.ts
+++ b/src/progressView/streamInfoUtils.ts
@@ -65,6 +65,7 @@ function buildStreamInfo(
     category !== AgentCategory.ToolUse && inputFile
       ? `${agentName}: ${path.basename(inputFile)}`
       : agentName;
+  const status = statuses?.get(id) as StreamTabInfo['status'];
 
   return {
     name: id,
@@ -80,7 +81,7 @@ function buildStreamInfo(
     lastTimestamp,
     inputFile,
     creationTimestamp,
-    status: statuses?.get(id),
+    status,
     executionId: state.getExecutionId(id),
   };
 }

--- a/src/shared/schemas/progressView.ts
+++ b/src/shared/schemas/progressView.ts
@@ -265,6 +265,11 @@ export const FollowUpTextPolishedMessageSchema = z.object({
   text: z.string(),
 });
 
+export const FollowUpTextPolishErrorMessageSchema = z.object({
+  command: z.literal(PROGRESS_VIEW_COMMANDS.FOLLOW_UP_TEXT_POLISH_ERROR),
+  error: z.string().optional(),
+});
+
 export const FollowUpTextTranscribedMessageSchema = z.object({
   command: z.literal(PROGRESS_VIEW_COMMANDS.FOLLOW_UP_TEXT_TRANSCRIBED),
   text: z.string(),
@@ -284,6 +289,7 @@ export const ProgressRecordingErrorMessageSchema = z.object({
 
 export const SetFollowupOptionsMessageSchema = z.object({
   command: z.literal(PROGRESS_VIEW_COMMANDS.SET_FOLLOWUP_OPTIONS),
+  stream: StreamTabIdSchema.nullish(),
   workflowAgentsData: z.array(AgentOptionDataSchema).optional(),
   toolUseAgentsData: z.array(AgentOptionDataSchema).optional(),
   modelOptionsData: z.array(ModelOptionDataSchema).optional(),
@@ -333,6 +339,7 @@ export const ProgressViewOutboundMessageSchema = z.discriminatedUnion(
     ShowAgentProposalMessageSchema,
     ResolveAgentProposalMessageSchema,
     FollowUpTextPolishedMessageSchema,
+    FollowUpTextPolishErrorMessageSchema,
     FollowUpTextTranscribedMessageSchema,
     ProgressRecordingStartedMessageSchema,
     ProgressRecordingStoppedMessageSchema,
@@ -414,6 +421,7 @@ const OpenMemoryViewMessageSchema = z.object({
 
 const GetFollowupOptionsMessageSchema = z.object({
   command: z.literal(PROGRESS_VIEW_COMMANDS.GET_FOLLOWUP_OPTIONS),
+  stream: StreamTabIdSchema.nullish(),
 });
 
 const StartRecordingMessageSchema = z.object({

--- a/src/shared/schemas/stream.ts
+++ b/src/shared/schemas/stream.ts
@@ -57,7 +57,7 @@ export const StreamTabInfoSchema = z.object({
   lastTimestamp: z.number().optional(),
   inputFile: z.string().optional(),
   creationTimestamp: z.number().optional(),
-  status: z.string().optional(),
+  status: StreamStatusSchema.nullish(),
   executionId: ExecutionIdSchema.optional(),
 });
 export type StreamTabInfo = z.infer<typeof StreamTabInfoSchema>;

--- a/src/shared/schemas/streamState.ts
+++ b/src/shared/schemas/streamState.ts
@@ -49,6 +49,7 @@ export const ToolUseStreamStateSchema = BaseStreamStateSchema.extend({
   shouldFocusFollowUp: z.boolean().prefault(false),
   polishedText: z.string().nullable().prefault(null),
   transcribedText: z.string().nullable().prefault(null),
+  polishErrorId: z.int().prefault(0),
   recording: z.boolean().prefault(false),
 });
 

--- a/src/shared/streams/streamSort.ts
+++ b/src/shared/streams/streamSort.ts
@@ -37,5 +37,6 @@ export function sortStreams(
   streams: StreamTabInfo[],
   sort: StreamSort,
 ): StreamTabInfo[] {
-  return [...streams].sort(streamComparators[sort]);
+  const comparator = streamComparators[sort] ?? streamComparators.time;
+  return [...streams].sort(comparator);
 }

--- a/src/shared/styles/requestPanelStyles.ts
+++ b/src/shared/styles/requestPanelStyles.ts
@@ -176,6 +176,7 @@ export const requestPanelStyles: CSSResult = css`
     left: 0;
     z-index: 100;
     min-width: 150px;
+    display: block;
   }
 
   .approval-request__actions .diff-dropdown .diff-dropdown-menu:not([show]) {

--- a/src/shared/styles/statusIndicatorStyles.ts
+++ b/src/shared/styles/statusIndicatorStyles.ts
@@ -50,6 +50,14 @@ export const statusIndicatorStyles: CSSResult = css`
     animation: pulse-scale 1.5s infinite;
   }
 
+  .status-indicator.is-initializing,
+  .tab-status.is-initializing {
+    background-color: var(--vscode-descriptionForeground);
+    box-shadow: 0 0 4px var(--vscode-descriptionForeground);
+    opacity: 0.9;
+    animation: pulse-scale 2.5s infinite;
+  }
+
   .status-indicator.is-ready,
   .tab-status.is-ready {
     background-color: var(--vscode-descriptionForeground);
@@ -76,5 +84,9 @@ export const statusIndicatorStyles: CSSResult = css`
   .status-text.is-waiting,
   .status-text.is-resuming {
     color: var(--vscode-textLink-foreground);
+  }
+
+  .status-text.is-initializing {
+    color: var(--color-text-secondary, var(--vscode-descriptionForeground));
   }
 `;

--- a/src/webview/frontend/MainApp.ts
+++ b/src/webview/frontend/MainApp.ts
@@ -627,13 +627,12 @@ export class MainApp extends BaseWebviewApp {
     const listId = this.multipleListIdMap[message.command];
     if (!listId) return;
 
-    const existing = this.multiFiles[listId] ?? [];
-    const merged = this.mergeUnique(existing, files);
-
-    this.multiFiles = { ...this.multiFiles, [listId]: merged };
-    this.multiFilesVisible = { ...this.multiFilesVisible, [listId]: true };
+    this.multiFiles = { ...this.multiFiles, [listId]: files };
+    const isVisible =
+      files.length > 0 ? true : (this.multiFilesVisible[listId] ?? false);
+    this.multiFilesVisible = { ...this.multiFilesVisible, [listId]: isVisible };
     if (listId === ELEMENT_IDS.OUTPUT_FILES) {
-      this.outputFilesActive = true;
+      this.outputFilesActive = files.length > 0 ? true : this.outputFilesActive;
     }
     this.saveState();
   }
@@ -789,14 +788,13 @@ export class MainApp extends BaseWebviewApp {
       typeof MAIN_VIEW_COMMANDS.INSTRUCTION_TEXT_POLISHED
     >,
   ): void {
-    if (message.text.trim()) {
-      this.instruction = message.text;
-      this.isPolishing = false;
-      postMessage(MAIN_VIEW_COMMANDS.SHOW_INFORMATION_MESSAGE, {
-        text: 'Instruction text has been polished!',
-      });
-      this.saveState();
-    }
+    this.isPolishing = false;
+    if (!message.text.trim()) return;
+    this.instruction = message.text;
+    postMessage(MAIN_VIEW_COMMANDS.SHOW_INFORMATION_MESSAGE, {
+      text: 'Instruction text has been polished!',
+    });
+    this.saveState();
   }
 
   private handleInstructionTextPolishError(
@@ -1059,6 +1057,10 @@ export class MainApp extends BaseWebviewApp {
     if (key in this.singleFiles) {
       this.singleFiles = { ...this.singleFiles, [key]: '' };
       this.saveState();
+      const command = FILE_SELECTED_COMMANDS[type];
+      if (command) {
+        postMessage(command, { filePath: '' });
+      }
     }
   }
 
@@ -1071,12 +1073,11 @@ export class MainApp extends BaseWebviewApp {
 
   private handleEmptyFiles(type: MultipleFileType): void {
     const listId = `${type}Files`;
-    this.multiFiles = { ...this.multiFiles, [listId]: [] };
     this.multiFilesVisible = { ...this.multiFilesVisible, [listId]: false };
     if (type === 'output') {
       this.outputFilesActive = false;
     }
-    this.saveState();
+    this.updateMultiFiles(listId as keyof MultiFiles, []);
   }
 
   private handleRefreshFiles(type: FileType): void {
@@ -1109,11 +1110,11 @@ export class MainApp extends BaseWebviewApp {
     this.sessionType = parsed;
     if (parsed === SESSION_TYPES.TOOL_USE) {
       this.outputFilesActive = false;
-      this.multiFiles = { ...this.multiFiles, outputFiles: [] };
       this.multiFilesVisible = {
         ...this.multiFilesVisible,
         outputFiles: false,
       };
+      this.updateMultiFiles('outputFiles', []);
     }
     this.saveState();
   }

--- a/src/webview/frontend/components/FileSelectGroup.ts
+++ b/src/webview/frontend/components/FileSelectGroup.ts
@@ -55,6 +55,9 @@ export class FileSelectGroup extends LitElement {
   @query('.multiple-files-list')
   private fileListElement?: HTMLElement;
 
+  /** Track previous expanded state to detect visibility changes */
+  private wasExpanded = false;
+
   private sortableController = new SortableController(
     this,
     () => this.fileListElement,
@@ -69,9 +72,11 @@ export class FileSelectGroup extends LitElement {
   );
 
   protected override updated(changedProps: Map<string, unknown>): void {
-    if (changedProps.has('config')) {
+    const listVisible = this.currentListVisible;
+    if (changedProps.has('config') || (listVisible && !this.wasExpanded)) {
       this.sortableController.reinitialize();
     }
+    this.wasExpanded = listVisible;
   }
 
   private get listId(): string {
@@ -193,11 +198,15 @@ export class FileSelectGroup extends LitElement {
 
   private handleFocusOut(event: FocusEvent): void {
     const nextTarget = event.relatedTarget as Node | null;
-    // Check both light DOM and shadow DOM for focus containment
-    const containsFocus =
-      nextTarget !== null &&
-      (this.contains(nextTarget) || this.shadowRoot?.contains(nextTarget));
-    if (containsFocus) return;
+    if (!nextTarget) {
+      this.autoExtractMenuOpen = false;
+      this.toolConfigMenuOpen = false;
+      return;
+    }
+
+    const path = event.composedPath();
+    const staysInComponent = path.includes(this);
+    if (staysInComponent) return;
     this.autoExtractMenuOpen = false;
     this.toolConfigMenuOpen = false;
   }
@@ -242,10 +251,15 @@ export class FileSelectGroup extends LitElement {
           toggleable
           aria-haspopup="true"
           aria-expanded=${this.toolConfigMenuOpen ? 'true' : 'false'}
-          ?checked=${hasChecked}
+          ?checked=${this.toolConfigMenuOpen}
           @click=${() => this.toggleMenu('toolConfig')}
         >
           <i class="codicon ${chevronClass}"></i>
+          <span
+            class="menu-indicator"
+            title="Tool options configured"
+            ?hidden=${!hasChecked}
+          ></span>
         </vscode-toolbar-button>
         <vscode-context-menu
           id="toolConfigOptions"
@@ -301,10 +315,15 @@ export class FileSelectGroup extends LitElement {
           toggleable
           aria-haspopup="true"
           aria-expanded=${this.autoExtractMenuOpen ? 'true' : 'false'}
-          ?checked=${hasChecked}
+          ?checked=${this.autoExtractMenuOpen}
           @click=${() => this.toggleMenu('autoExtract')}
         >
           <i class="codicon ${chevronClass}"></i>
+          <span
+            class="menu-indicator"
+            title="Auto-extract options configured"
+            ?hidden=${!hasChecked}
+          ></span>
         </vscode-toolbar-button>
         <vscode-context-menu
           id="autoExtractOptions"
@@ -425,14 +444,16 @@ export class FileSelectGroup extends LitElement {
               title=${config.emptyTitle}
               @click=${this.handleEmptyFile}
             ></vscode-toolbar-button>
-            <span
+            <button
               id=${toggleId}
+              type="button"
               class="toggle-icon"
               title=${config.toggleTitle}
+              aria-label=${config.toggleTitle}
               @click=${this.handleToggleList}
             >
               <i class="codicon ${chevronClass}"></i>
-            </span>
+            </button>
             <vscode-toolbar-button
               id="addOpened${config.type[0].toUpperCase()}${config.type.slice(
                 1,

--- a/src/webview/frontend/components/FileSelectGroup.ts
+++ b/src/webview/frontend/components/FileSelectGroup.ts
@@ -204,8 +204,10 @@ export class FileSelectGroup extends LitElement {
       return;
     }
 
-    const path = event.composedPath();
-    const staysInComponent = path.includes(this);
+    const staysInComponent =
+      nextTarget === this ||
+      this.contains(nextTarget) ||
+      (this.shadowRoot?.contains(nextTarget) ?? false);
     if (staysInComponent) return;
     this.autoExtractMenuOpen = false;
     this.toolConfigMenuOpen = false;

--- a/src/webview/frontend/components/OutputFilesSection.ts
+++ b/src/webview/frontend/components/OutputFilesSection.ts
@@ -117,11 +117,12 @@ export class OutputFilesSection extends LitElement {
       (file) => html`
         <div class="file-item" data-path=${file}>
           <span class="file-name">${file}</span>
-          <span
+          <button
+            type="button"
             class="remove-button codicon codicon-trash"
-            role="button"
+            aria-label=${`Remove ${file}`}
             @click=${() => this.handleRemoveFile(file)}
-          ></span>
+          ></button>
         </div>
       `,
     )}`;
@@ -136,14 +137,16 @@ export class OutputFilesSection extends LitElement {
       <div class="file-select" data-expanded=${String(this.currentExpanded)}>
         <div class="file-select-header">
           <div class="file-select-label-group">
-            <span
+            <button
               id="toggleOutputFiles"
+              type="button"
               class="toggle-icon"
               title="Show or hide additional files for the agent's output"
+              aria-label="Show or hide additional files for the agent's output"
               @click=${this.handleToggle}
             >
               <i class="codicon ${chevronClass}"></i>
-            </span>
+            </button>
             <span
               class="optional-label"
               title="List the files that should receive the agent's output"

--- a/src/webview/frontend/styles/fileSelectStyles.ts
+++ b/src/webview/frontend/styles/fileSelectStyles.ts
@@ -118,6 +118,9 @@ export const toggleStyles = css`
     display: flex;
     align-items: center;
     height: var(--height-control);
+    background: none;
+    border: none;
+    font: inherit;
   }
 
   .file-select[data-expanded='true'] .optional-label,
@@ -170,6 +173,9 @@ export const multiFilesStyles = css`
     cursor: pointer;
     flex-shrink: 0;
     opacity: 0.7;
+    background: none;
+    border: none;
+    padding: 0;
   }
 
   .remove-button:hover {
@@ -230,6 +236,15 @@ export const dropdownStyles = css`
 
   .dropdown-container .dropdown-menu vscode-checkbox:hover {
     background: var(--vscode-list-hoverBackground);
+  }
+
+  .dropdown-container .menu-indicator {
+    display: inline-block;
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    margin-left: var(--spacing-tiny);
+    background-color: var(--vscode-textLink-foreground);
   }
 `;
 

--- a/src/webview/managers/FileManager.ts
+++ b/src/webview/managers/FileManager.ts
@@ -216,9 +216,7 @@ export class FileManager extends BaseWebviewManager {
   }
 
   handleSetMultipleFiles(message: SetMultipleFilesMessage): void {
-    if (message.files.length > 0) {
-      this.postMessage({ command: message.command, files: message.files });
-    }
+    this.postMessage({ command: message.command, files: message.files });
   }
 
   async handleSelectMultipleFiles(


### PR DESCRIPTION
### Motivation
- Address the Round‑3 UI and logic regressions that caused backend sync issues, state loss across runs/streams, Shadow DOM interaction failures, KaTeX styling loss in Shadow DOM, and other UX regressions collected in the Round‑3 audit.
- Prevent context overflow for the OpenAI Responses API by adding a pre‑flight token estimate similar to the chat handler's heuristic.
- Keep changes pragmatic and localized (no heavy new abstractions), preserve frontend-only state at merge points, and update PRD tracking/docs to reflect completion.

### Description
- MainView fixes: replace additive merge of multi-file lists with authoritative replace in `handleSetMultipleFiles`, preserve multi-list visibility when lists become empty, route empty multi-list clears through `updateMultiFiles`, and post `FILE_SELECTED_COMMANDS[type]` with empty `filePath` when single files are cleared (files/visibility sync with backend). (files: `src/webview/frontend/MainApp.ts`, `src/webview/managers/FileManager.ts`)
- ProgressView state and UI fixes: limit `updateNestedRounds` reset to target run only, reset run‑scoped maps on `UPDATE_LOGS` clear, preserve frontend-only fields when merging backend stream state, store follow‑up options per stream (`followupOptionsByStream`) and prune on stream removal, clear pending log updates for removed streams, make stream sort robust to invalid prefs, add `INITIALIZING` labels/styles and enable sensible toolbar buttons for it. (files: `src/progressView/frontend/stateUtils.ts`, `src/progressView/frontend/messageDispatcher.ts`, `src/progressView/frontend/store.ts`, `src/progressView/frontend/ProgressApp.ts`, `src/progressView/frontend/components/StreamHeader.ts`, `src/shared/styles/statusIndicatorStyles.ts`, `src/shared/streams/streamSort.ts`)
- Shadow DOM and event handling: replace brittle `target.closest()` lookups with `event.composedPath()` traversal in multiple components and utilities to correctly handle events coming from shadow roots (StreamTabs, StreamHeader, FileList, RequestPanels, radio util). (files: `src/progressView/frontend/components/*`, `src/progressView/frontend/utils.ts`)
- KaTeX in Shadow DOM: stop importing KaTeX CSS globally; instead import as inline CSS and create an adoptable `CSSStyleSheet` pushed into `logStyles` so KaTeX rules apply inside progress view shadow roots. (files: `src/progressView/frontend/styles/logStyles.ts`, `src/progressView/frontend/index.ts`)
- UI/CSS and accessibility tweaks: show diff dropdown by adding `display:block` for visible state, convert several click-only spans to `<button>` with proper ARIA, add menu indicators, guard IME composition on follow‑up Enter, preserve polish spinner semantics, add aria-pressed/active state to stream sort buttons, unique keys for repeats (TodoList/Latexdiff/FileList), history search wiring. (files: many under `src/webview/frontend/*` and `src/progressView/frontend/components/*`)
- Model handler changes: add pre-flight heuristic token estimation for OpenAI Responses using `gpt-tokenizer`, estimate combined existing + new tokens, and reduce `max_output_tokens` when necessary; keep robust fallback behavior and log context management events. (files: `src/agent/modelHandlers/modelHandlerOpenAIResponse.ts`, `src/agent/modelHandlers/contextManagementConstants.ts` used)
- Model output backup fixes: key backups by composite key `${streamId}:${file}`, clear backups on stream deletion and on delete-all. (file: `src/progressView/ProgressViewMessageHandler.ts`)
- Misc: schema/type hardening (stream status schema usage), follow‑up polish error signaling added, history search race guard with versioning, and multiple small bugfixes across components and managers. Documentation updates: PRD progress entries updated for both the UI audit and token counting audit. (files: `docs/prd-ui-regression-audit-round3.md`, `docs/prd/token-counting-audit.md`)

### Testing
- Formatted code with `npm run format` (succeeded).
- Built extension bundles: `npm run compile` and `npm run compile:fast` were executed; final builds completed successfully (vite/webview builds and esbuild extension build), with one informational webpack warning earlier resolved; KaTeX assets are included in `dist` as expected.
- Linting: `npm run lint` completed with warnings but no errors (warnings are existing non-blocking issues flagged in other files).
- Verified runtime behaviors via code review and local builds: stream tab/toolbar enablement for `INITIALIZING`, follow‑up options scoped per stream, file list updates now replace lists and backend receives empty lists, Shadow DOM click/keyboard handlers now use `composedPath()` and are resilient to shadow roots, and OpenAI Responses pre‑flight heuristics adjust `max_output_tokens` when estimated context would overflow (logged via context management logger).

If you'd like, I can split this large PR into smaller focused PRs (UI sync, Shadow DOM fixes, KaTeX adoption, and model handler token heuristics) for easier review.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697dd892f75c8324be5559676b1c9604)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches both model request shaping (`max_output_tokens` adjustment) and several webview state-management paths, so regressions could affect request behavior or UI state persistence, though changes are localized and largely additive/defensive.
> 
> **Overview**
> **Adds a pre-flight token estimation step for OpenAI’s Responses API** using `gpt-tokenizer` plus conservative overhead heuristics, and dynamically reduces `max_output_tokens` (with context-management logging) to avoid first-request context overflows.
> 
> **Fixes multiple Round-3 webview regressions** across MainView/ProgressView/HistoryView: state syncing now treats backend multi-file lists as authoritative (including empty clears), follow-up options are scoped per stream and stale per-run/per-stream state is properly reset/pruned, and model output backups are keyed per stream and cleared on stream deletion.
> 
> **Hardens Shadow DOM UI interactions and rendering** by switching several delegated event handlers from `closest()` to `event.composedPath()`, ensuring stable `repeat()` keys, restoring KaTeX styling inside Shadow DOM via an adoptable stylesheet, and adding small UX/accessibility improvements (INITIALIZING status support, sort button active state, IME-safe Enter handling, and follow-up polish error signaling).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fcae455bb08eb7d39e088b19bd47498f98091593. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->