### PR TITLE
feat(settings/history): add searchable, collapsible history list UI

### DIFF
--- a/src/settingsView/frontend/components/history/HistoryItem.ts
+++ b/src/settingsView/frontend/components/history/HistoryItem.ts
@@ -1,0 +1,337 @@
+/**
+ * HistoryItem component - displays a single history entry with collapsible details.
+ * Uses mark.js for search highlighting.
+ */
+
+// Third-party imports
+import { LitElement, html, nothing, type TemplateResult } from 'lit';
+import { customElement, property, queryAll } from 'lit/decorators.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
+import Mark from 'mark.js';
+
+// Local imports - shared styles
+import {
+  badgeStyles,
+  codiconStyles,
+  commonViewStyles,
+  designTokens,
+} from '@shared/styles';
+import { getAgentCategoryDecorator } from '@shared/utils/icons';
+
+// Local imports - history view styles
+import { historyViewStyles } from './styles';
+
+// Local imports - history view events
+import { HistoryViewEvents } from './events';
+
+// Local imports - shared schemas
+import type { HistoryItem as HistoryItemData } from '@shared/schemas';
+
+type ConfigValue = string | number | boolean | string[] | null | undefined;
+
+@customElement('history-item')
+export class HistoryItem extends LitElement {
+  static override styles = [
+    designTokens,
+    codiconStyles,
+    commonViewStyles,
+    ...badgeStyles,
+    historyViewStyles,
+  ];
+
+  @property({ attribute: false }) item?: HistoryItemData;
+  @property({ type: Boolean }) open = false;
+  /** Local index of the mark to highlight as current, or null if none in this item */
+  @property({ type: Number }) highlightedMatchIndex: number | null = null;
+
+  private markInstance: Mark | null = null;
+  private previousHighlightedIndex: number | null = null;
+  private previousItemId: string | undefined = undefined;
+
+  @queryAll('mark')
+  private markElements!: HTMLElement[];
+
+  override disconnectedCallback(): void {
+    super.disconnectedCallback();
+    this.clearMarkInstance();
+  }
+
+  protected override willUpdate(
+    changedProperties: Map<PropertyKey, unknown>,
+  ): void {
+    // Clear mark instance when item changes to avoid stale highlights
+    if (changedProperties.has('item')) {
+      const newItemId = this.item?.id;
+      if (this.previousItemId !== newItemId) {
+        this.clearMarkInstance();
+        this.previousItemId = newItemId;
+      }
+    }
+  }
+
+  private clearMarkInstance(): void {
+    if (this.markInstance) {
+      this.markInstance.unmark();
+      this.markInstance = null;
+    }
+    this.previousHighlightedIndex = null;
+  }
+
+  private handleAction(action: string): void {
+    if (!this.item) return;
+    this.dispatchEvent(
+      HistoryViewEvents.historyAction({ action, historyId: this.item.id }),
+    );
+  }
+
+  private handleToggle(event: CustomEvent<{ open?: boolean }>): void {
+    if (!this.item) return;
+    const open = event.detail?.open ?? this.open;
+    this.dispatchEvent(
+      HistoryViewEvents.toggleItem({
+        historyId: this.item.id,
+        open: Boolean(open),
+      }),
+    );
+  }
+
+  /**
+   * React to highlightedMatchIndex changes - apply current match attribute.
+   * Uses direct DOM manipulation since mark.js creates marks dynamically.
+   */
+  protected override updated(): void {
+    if (this.highlightedMatchIndex === this.previousHighlightedIndex) {
+      return;
+    }
+
+    const marks = this.getMarks();
+    const prevMark =
+      this.previousHighlightedIndex !== null
+        ? marks[this.previousHighlightedIndex]
+        : null;
+    const currMark =
+      this.highlightedMatchIndex !== null
+        ? marks[this.highlightedMatchIndex]
+        : null;
+
+    prevMark?.removeAttribute('data-current');
+
+    if (currMark) {
+      currMark.setAttribute('data-current', 'true');
+      currMark.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    }
+
+    this.previousHighlightedIndex = this.highlightedMatchIndex;
+  }
+
+  private ensureMarkInstance(): void {
+    if (!this.markInstance) {
+      this.markInstance = new Mark(this.renderRoot as DocumentFragment);
+    }
+  }
+
+  async applySearch(term: string): Promise<number> {
+    this.ensureMarkInstance();
+    return new Promise((resolve) => {
+      this.markInstance?.unmark({
+        done: () => {
+          if (!term) {
+            resolve(0);
+            return;
+          }
+          let count = 0;
+          this.markInstance?.mark(term, {
+            each: () => {
+              count += 1;
+            },
+            done: () => resolve(count),
+          });
+        },
+      });
+    });
+  }
+
+  getMarks(): HTMLElement[] {
+    return this.markElements ?? [];
+  }
+
+  private renderValue(value: ConfigValue): TemplateResult {
+    if (Array.isArray(value)) {
+      return html`${value.join(', ')}`;
+    }
+    if (typeof value === 'boolean') {
+      return html`${value ? 'Yes' : 'No'}`;
+    }
+    return html`${value ?? ''}`;
+  }
+
+  private hasValue(value: ConfigValue): boolean {
+    if (value === null || value === undefined) return false;
+    return !Array.isArray(value) || value.length > 0;
+  }
+
+  private renderConfigSection(
+    label: string | TemplateResult,
+    entries: Array<[string, ConfigValue]>,
+  ): TemplateResult | null {
+    const filtered = entries.filter(([, value]) => this.hasValue(value));
+    if (!filtered.length) return null;
+
+    return html`
+      <span class="history-label">${label}:</span>
+      <div class="history-value config-section">
+        ${filtered.map(
+          ([key, value]) => html`
+            <div class="config-item">
+              <span class="config-key">${key}:</span>
+              <span class="config-value">${this.renderValue(value)}</span>
+            </div>
+          `,
+        )}
+      </div>
+    `;
+  }
+
+  override render(): TemplateResult | typeof nothing {
+    if (!this.item) {
+      return nothing;
+    }
+
+    const config = this.item.agentConfig;
+    const timestamp = new Date(this.item.timestamp).toLocaleString();
+    const isToolUse = config.agentCategory === 'toolUse';
+    const categoryClass = isToolUse ? 'category-tool-use' : 'category-workflow';
+    const decorator = getAgentCategoryDecorator(
+      isToolUse ? 'toolUse' : 'workflow',
+    );
+    const instructionText = config.instruction?.trim()
+      ? config.instruction
+      : null;
+
+    const extraDetails: Array<TemplateResult> = [];
+
+    const referenceSection = this.renderConfigSection('Reference', [
+      ['ReferenceFile', config.referenceFile],
+      ['ReferenceFiles', config.referenceFiles],
+    ]);
+    if (referenceSection) extraDetails.push(referenceSection);
+
+    const auxiliarySection = this.renderConfigSection('Auxiliary', [
+      ['AuxiliaryFile', config.auxiliaryFile],
+      ['AuxiliaryFiles', config.auxiliaryFiles],
+    ]);
+    if (auxiliarySection) extraDetails.push(auxiliarySection);
+
+    const outputSection = this.renderConfigSection('Output Files', [
+      ['Files', config.outputFiles],
+    ]);
+    if (outputSection) extraDetails.push(outputSection);
+
+    if (config.toolConfig && !isToolUse) {
+      const toolEntries = (
+        Object.entries(config.toolConfig) as Array<[string, ConfigValue]>
+      ).filter(([, value]) => this.hasValue(value));
+      const toolSection = this.renderConfigSection(
+        html`<i class="codicon codicon-tools"></i> Config`,
+        toolEntries,
+      );
+      if (toolSection) extraDetails.push(toolSection);
+    }
+
+    return html`
+      <div class="list-item history-item">
+        <div class="list-item-header">
+          <div class="text-secondary history-timestamp">${timestamp}</div>
+          <vscode-toolbar-container class="history-actions">
+            <vscode-toolbar-button
+              icon="trash"
+              label="Delete"
+              title="Delete"
+              @click=${() => this.handleAction('delete')}
+            ></vscode-toolbar-button>
+            <vscode-toolbar-button
+              icon="reply"
+              label="Restore"
+              title="Restore"
+              @click=${() => this.handleAction('restore')}
+            ></vscode-toolbar-button>
+            <vscode-toolbar-button
+              icon="debug-rerun"
+              label="Rerun"
+              title="Rerun"
+              @click=${() => this.handleAction('rerun')}
+            ></vscode-toolbar-button>
+          </vscode-toolbar-container>
+        </div>
+        <div class="history-details basic-details">
+          <span class="history-label">Category:</span>
+          <span class="history-value">
+            <span class="badge agent-category-badge ${categoryClass}">
+              ${decorator.icon
+                ? html`<i
+                    class=${ifDefined(`codicon codicon-${decorator.icon}`)}
+                  ></i>`
+                : nothing}
+              ${decorator.label}
+            </span>
+          </span>
+          <span class="history-label">Agent:</span>
+          <span class="history-value">${config.agent ?? 'Unknown'}</span>
+          <span class="history-label">Model:</span>
+          <span class="history-value">${config.model ?? 'Unknown'}</span>
+          <span class="history-label">Instruction:</span>
+          <span class="history-value">
+            ${instructionText
+              ? instructionText
+              : html`<em class="history-none">Not set</em>`}
+          </span>
+          <span class="history-label">InputFile:</span>
+          <span class="history-value">
+            ${config.inputFile ? config.inputFile : 'None'}
+          </span>
+          ${config.inputFiles?.length
+            ? html`
+                <span class="history-label">InputFiles:</span>
+                <span class="history-value"
+                  >${config.inputFiles.join(', ')}</span
+                >
+              `
+            : nothing}
+          ${config.mediaFile
+            ? html`
+                <span class="history-label">MediaFile:</span>
+                <span class="history-value">${config.mediaFile}</span>
+              `
+            : nothing}
+          ${config.mediaFiles?.length
+            ? html`
+                <span class="history-label">MediaFiles:</span>
+                <span class="history-value"
+                  >${config.mediaFiles.join(', ')}</span
+                >
+              `
+            : nothing}
+        </div>
+        ${extraDetails.length
+          ? html`
+              <vscode-collapsible
+                class="collapsible"
+                heading="More details"
+                ?open=${this.open}
+                @vsc-collapsible-toggle=${this.handleToggle}
+                data-id=${this.item.id}
+              >
+                <div class="history-details extra-details">${extraDetails}</div>
+              </vscode-collapsible>
+            `
+          : nothing}
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'history-item': HistoryItem;
+  }
+}

--- a/src/settingsView/frontend/components/history/HistoryList.ts
+++ b/src/settingsView/frontend/components/history/HistoryList.ts
@@ -1,0 +1,271 @@
+/**
+ * HistoryList component - renders list of history items with search functionality.
+ * Receives search state via reactive properties and handles navigation.
+ */
+
+// Third-party imports
+import {
+  LitElement,
+  html,
+  type PropertyValues,
+  type TemplateResult,
+} from 'lit';
+import { customElement, property, queryAll, state } from 'lit/decorators.js';
+import { repeat } from 'lit/directives/repeat.js';
+
+// Local imports - shared styles
+import { designTokens, commonViewStyles } from '@shared/styles';
+import { historyViewStyles } from './styles';
+
+// Local imports - history view components (side-effect: register)
+import './HistoryItem';
+
+// Local imports - history view events
+import { HistoryViewEvents } from './events';
+
+// Local imports - history view state
+import type { HistoryViewState } from './state';
+
+// Local imports - shared schemas
+import type { HistoryItem as HistoryItemData } from '@shared/schemas';
+
+/** Search navigation action (reactive trigger from parent) */
+export type SearchAction = 'next' | 'prev' | null;
+
+@customElement('history-list')
+export class HistoryList extends LitElement {
+  static override styles = [designTokens, commonViewStyles, historyViewStyles];
+
+  @property({ attribute: false }) items: HistoryItemData[] = [];
+  @property({ attribute: false }) state?: HistoryViewState;
+
+  // === Reactive search properties (Lit-native Phase 9) ===
+  /** Search term from parent - triggers search when changed */
+  @property({ type: String }) searchTerm = '';
+  /** Navigation action trigger - 'next' | 'prev' | null */
+  @property({ type: String }) searchAction: SearchAction = null;
+  /** Trigger to clear search state (set true to clear, resets to false) */
+  @property({ type: Boolean }) clearSearchTrigger = false;
+
+  /** Match counts per item, keyed by item.id - used to compute highlighted index */
+  @state() private matchCounts: Map<string, number> = new Map();
+
+  @state() private searchVersion = 0;
+
+  @queryAll('history-item')
+  private historyItemElements!: Array<
+    HTMLElement & {
+      applySearch: (term: string) => Promise<number>;
+      getMarks: () => HTMLElement[];
+    }
+  >;
+
+  /**
+   * React to property changes (Lit-native approach).
+   * Replaces imperative method calls from parent with reactive updates.
+   */
+  protected willUpdate(changedProperties: PropertyValues<this>): void {
+    // Handle clearSearchTrigger - clear search state
+    if (
+      changedProperties.has('clearSearchTrigger') &&
+      this.clearSearchTrigger
+    ) {
+      this.performClearSearch();
+      // Dispatch event to reset the trigger
+      this.dispatchEvent(HistoryViewEvents.searchClearComplete());
+    }
+
+    // Handle searchTerm changes - apply search
+    if (changedProperties.has('searchTerm')) {
+      this.performSearch(this.searchTerm);
+    }
+
+    // Handle searchAction - navigate to next/prev match
+    if (changedProperties.has('searchAction') && this.searchAction) {
+      this.performNavigate(this.searchAction);
+      // Dispatch event to reset the action
+      this.dispatchEvent(HistoryViewEvents.searchNavigateComplete());
+    }
+  }
+
+  protected updated(changedProps: Map<string, unknown>): void {
+    // Re-apply search when items change (e.g., new history loaded)
+    if (changedProps.has('items') && this.searchTerm) {
+      const version = ++this.searchVersion;
+      void this.applySearchToItems(this.searchTerm, version);
+    }
+  }
+
+  // === Internal search operations (called from willUpdate) ===
+
+  private performClearSearch(): void {
+    this.searchVersion += 1;
+    this.matchCounts = new Map();
+    this.state?.setSearchIndex(-1);
+    this.state?.setTotalMatches(0);
+    this.clearItemMarks();
+    this.updateMatchCount();
+  }
+
+  private performSearch(term: string): void {
+    const version = ++this.searchVersion;
+    if (!term) {
+      this.state?.setSearchIndex(-1);
+      this.state?.setTotalMatches(0);
+      this.clearItemMarks();
+      this.updateMatchCount();
+      return;
+    }
+    void this.applySearchToItems(term, version);
+  }
+
+  private performNavigate(direction: 'next' | 'prev'): void {
+    if (!this.state || this.state.totalMatches === 0) return;
+    const delta = direction === 'next' ? 1 : -1;
+    const nextIndex =
+      (this.state.searchIndex + delta + this.state.totalMatches) %
+      this.state.totalMatches;
+    this.state.setSearchIndex(nextIndex);
+    this.updateMatchCount();
+    // Trigger re-render to update highlightedMatchIndex props
+    this.requestUpdate();
+  }
+
+  private updateMatchCount(): void {
+    if (!this.state) return;
+    const total = this.state.totalMatches;
+    const display = total === 0 ? '' : `${this.state.searchIndex + 1}/${total}`;
+    this.dispatchEvent(HistoryViewEvents.matchCount({ display }));
+  }
+
+  /**
+   * Compute the local highlighted match index for a specific item.
+   * Returns the local index within the item, or null if the current match is not in this item.
+   */
+  private getHighlightedMatchIndex(itemId: string): number | null {
+    if (!this.state || this.state.searchIndex < 0) return null;
+
+    const globalIndex = this.state.searchIndex;
+    let cumulativeIndex = 0;
+
+    for (const item of this.items) {
+      const count = this.matchCounts.get(item.id) ?? 0;
+      if (item.id === itemId) {
+        // Check if the global index falls within this item's range
+        if (
+          globalIndex >= cumulativeIndex &&
+          globalIndex < cumulativeIndex + count
+        ) {
+          return globalIndex - cumulativeIndex;
+        }
+        return null;
+      }
+      cumulativeIndex += count;
+    }
+    return null;
+  }
+
+  private async applySearchToItems(
+    term: string,
+    version: number,
+  ): Promise<void> {
+    const historyItems = this.getHistoryItems();
+    const counts = await Promise.all(
+      historyItems.map(
+        (item) => item.applySearch?.(term) ?? Promise.resolve(0),
+      ),
+    );
+    if (version !== this.searchVersion) {
+      return;
+    }
+
+    // Store match counts per item for computing highlighted indices
+    const newMatchCounts = new Map<string, number>();
+    this.items.forEach((item, index) => {
+      newMatchCounts.set(item.id, counts[index] ?? 0);
+    });
+    this.matchCounts = newMatchCounts;
+
+    const total = counts.reduce((sum, count) => sum + count, 0);
+    this.state?.setTotalMatches(total);
+    if (total > 0) {
+      this.state?.setSearchIndex(0);
+      this.updateMatchCount();
+      // Trigger re-render to update highlightedMatchIndex props
+      this.requestUpdate();
+    } else {
+      this.state?.setSearchIndex(-1);
+      this.updateMatchCount();
+    }
+  }
+
+  private clearItemMarks(): void {
+    const items = this.getHistoryItems();
+    void Promise.all(
+      items.map((item) => item.applySearch?.('') ?? Promise.resolve(0)),
+    );
+  }
+
+  private getHistoryItems(): Array<
+    HTMLElement & {
+      applySearch: (term: string) => Promise<number>;
+      getMarks: () => HTMLElement[];
+    }
+  > {
+    // @queryAll returns NodeList, not Array - convert for .map() support
+    return [...(this.historyItemElements ?? [])];
+  }
+
+  private handleToggle(
+    event: CustomEvent<{ historyId: string; open: boolean }>,
+  ): void {
+    if (!this.state) return;
+    // Ignore toggle when searching (items are auto-expanded during search)
+    if (this.searchTerm) {
+      return;
+    }
+    this.state.toggleStates.set(event.detail.historyId, event.detail.open);
+  }
+
+  private handleClear(): void {
+    this.dispatchEvent(HistoryViewEvents.clearHistory());
+  }
+
+  override render(): TemplateResult {
+    if (!this.items.length) {
+      return html`<div class="empty-state">No history items found</div>`;
+    }
+
+    const hasMatches = (this.state?.totalMatches ?? 0) > 0;
+    const forceOpen = Boolean(this.searchTerm && hasMatches);
+
+    return html`
+      <div class="clear-container">
+        <vscode-button class="button-clear" @click=${this.handleClear}
+          >Clear All History</vscode-button
+        >
+      </div>
+      <div class="history-container">
+        ${repeat(
+          this.items,
+          (item) => item.id,
+          (item) => html`
+            <history-item
+              .item=${item}
+              .open=${forceOpen ||
+              Boolean(this.state?.toggleStates.get(item.id))}
+              .highlightedMatchIndex=${this.getHighlightedMatchIndex(item.id)}
+              @history-toggle=${this.handleToggle}
+            ></history-item>
+          `,
+        )}
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'history-list': HistoryList;
+  }
+}

--- a/src/settingsView/frontend/components/history/SearchBar.ts
+++ b/src/settingsView/frontend/components/history/SearchBar.ts
@@ -1,0 +1,100 @@
+/**
+ * SearchBar component - search input with navigation controls.
+ * Debounces input and dispatches search events to parent.
+ */
+
+// Third-party imports
+import { LitElement, html, type TemplateResult } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+
+// Local imports - shared styles
+import { designTokens, codiconStyles } from '@shared/styles';
+import { historyViewStyles } from './styles';
+
+// Local imports - history view events
+import { HistoryViewEvents } from './events';
+
+@customElement('history-search-bar')
+export class SearchBar extends LitElement {
+  static override styles = [designTokens, codiconStyles, historyViewStyles];
+
+  @property({ type: String }) searchTerm = '';
+  @property({ type: String }) matchCount = '';
+
+  private searchTimeoutId: ReturnType<typeof setTimeout> | null = null;
+
+  override disconnectedCallback(): void {
+    if (this.searchTimeoutId) {
+      clearTimeout(this.searchTimeoutId);
+      this.searchTimeoutId = null;
+    }
+    super.disconnectedCallback();
+  }
+
+  private handleInput(event: Event): void {
+    const target = event.target as HTMLInputElement | null;
+    const term = target?.value?.trim() ?? '';
+    if (this.searchTimeoutId) {
+      clearTimeout(this.searchTimeoutId);
+    }
+    this.searchTimeoutId = setTimeout(() => {
+      this.dispatchEvent(HistoryViewEvents.searchChange({ term }));
+    }, 300);
+  }
+
+  private handleNext(): void {
+    this.dispatchEvent(HistoryViewEvents.searchNext());
+  }
+
+  private handlePrev(): void {
+    this.dispatchEvent(HistoryViewEvents.searchPrev());
+  }
+
+  private handleKeydown(event: KeyboardEvent): void {
+    if (event.key !== 'Enter') return;
+    event.preventDefault();
+    if (event.shiftKey) {
+      this.handlePrev();
+    } else {
+      this.handleNext();
+    }
+  }
+
+  override render(): TemplateResult {
+    return html`
+      <div class="search-container">
+        <vscode-textfield
+          class="search-input"
+          type="search"
+          placeholder="Search history items..."
+          .value=${this.searchTerm}
+          @input=${this.handleInput}
+          @keydown=${this.handleKeydown}
+        ></vscode-textfield>
+        <vscode-toolbar-container class="search-controls">
+          <vscode-toolbar-button
+            class="search-nav-btn"
+            icon="chevron-up"
+            label="Previous match"
+            title="Previous match"
+            @click=${this.handlePrev}
+          ></vscode-toolbar-button>
+          <vscode-toolbar-button
+            class="search-nav-btn"
+            icon="chevron-down"
+            label="Next match"
+            title="Next match"
+            @click=${this.handleNext}
+          ></vscode-toolbar-button>
+          <span class="match-count">${this.matchCount}</span>
+        </vscode-toolbar-container>
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'history-search-bar': SearchBar;
+  }
+}

--- a/src/settingsView/frontend/components/history/events.ts
+++ b/src/settingsView/frontend/components/history/events.ts
@@ -1,0 +1,18 @@
+import { createEvent } from '@shared/utils/events';
+
+export const HistoryViewEvents = {
+  searchChange: (detail: { term: string }) =>
+    createEvent('history-search-change', detail),
+  searchNext: () => createEvent('history-search-next', undefined),
+  searchPrev: () => createEvent('history-search-prev', undefined),
+  toggleItem: (detail: { historyId: string; open: boolean }) =>
+    createEvent('history-toggle', detail),
+  historyAction: (detail: { action: string; historyId: string }) =>
+    createEvent('history-action', detail),
+  clearHistory: () => createEvent('history-clear', undefined),
+  matchCount: (detail: { display: string }) =>
+    createEvent('history-match-count', detail),
+  searchClearComplete: () => createEvent('search-clear-complete', undefined),
+  searchNavigateComplete: () =>
+    createEvent('search-navigate-complete', undefined),
+} as const;

--- a/src/settingsView/frontend/components/history/state.ts
+++ b/src/settingsView/frontend/components/history/state.ts
@@ -1,0 +1,50 @@
+import { z } from 'zod';
+
+// Local imports - shared state
+import { vscode } from '@shared/vscode';
+import { ToggleStateStore } from '@shared/state/ToggleStateStore';
+import { PersistedState, createWebviewStorage } from '@shared/state';
+
+const HistoryViewStateSchema = z.object({
+  searchIndex: z.number().catch(0),
+  totalMatches: z.number().catch(0),
+  toggleStates: z.array(z.tuple([z.string(), z.boolean()])).catch([]),
+});
+
+type HistoryViewPersistedState = z.infer<typeof HistoryViewStateSchema>;
+
+export class HistoryViewState {
+  private readonly state = new PersistedState<HistoryViewPersistedState>(
+    createWebviewStorage(vscode),
+    'historyView',
+    HistoryViewStateSchema,
+  );
+  public readonly toggleStates = new ToggleStateStore(() => this.save());
+  public searchIndex = 0;
+  public totalMatches = 0;
+
+  initialize(): void {
+    const saved = this.state.getState();
+    this.searchIndex = saved.searchIndex;
+    this.totalMatches = saved.totalMatches;
+    this.toggleStates.load(saved.toggleStates);
+  }
+
+  setSearchIndex(index: number): void {
+    this.searchIndex = index;
+    this.save();
+  }
+
+  setTotalMatches(count: number): void {
+    this.totalMatches = count;
+    this.save();
+  }
+
+  save(): void {
+    this.state.update({
+      searchIndex: this.searchIndex,
+      totalMatches: this.totalMatches,
+      toggleStates: this.toggleStates.entries(),
+    });
+  }
+}

--- a/src/settingsView/frontend/components/history/styles.ts
+++ b/src/settingsView/frontend/components/history/styles.ts
@@ -1,0 +1,123 @@
+// Third-party imports
+import { css, type CSSResult } from 'lit';
+
+// Shared badge/category styles are imported in HistoryApp.ts from @shared/styles
+// This file contains only history-view-specific styles
+
+export const historyViewStyles: CSSResult = css`
+  .search-container {
+    display: flex;
+    align-items: center;
+    margin-bottom: var(--spacing-xlarge);
+    gap: var(--spacing-medium);
+    width: 100%;
+  }
+
+  .search-input {
+    flex: 1;
+    padding: var(--spacing-medium);
+    font-size: var(--font-size);
+  }
+
+  .search-controls {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-small);
+  }
+
+  .search-nav-btn {
+    min-width: var(--height-button);
+    height: var(--height-button);
+    padding: 0;
+    font-size: var(--font-size);
+  }
+
+  .match-count {
+    font-size: var(--font-size-sm);
+    color: var(--color-text-secondary);
+    min-width: calc(var(--height-button) * 2);
+    text-align: center;
+  }
+
+  .history-container {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-medium);
+  }
+
+  .clear-container {
+    margin-bottom: var(--spacing-xlarge);
+  }
+
+  .button-clear {
+    padding: var(--spacing-medium) var(--spacing-large);
+  }
+
+  .history-details {
+    display: grid;
+    grid-template-columns: 100px 1fr;
+    gap: var(--spacing-small);
+    margin-top: var(--spacing-medium);
+  }
+
+  .history-label {
+    font-weight: bold;
+    color: var(--vscode-editor-foreground);
+  }
+
+  .history-value {
+    color: var(--vscode-editor-foreground);
+    padding: var(--spacing-small) 0;
+    word-break: break-word;
+  }
+
+  .history-item.selected {
+    background-color: var(--vscode-list-activeSelectionBackground);
+    color: var(--vscode-list-activeSelectionForeground);
+  }
+
+  .history-item {
+    margin-bottom: var(--spacing-medium);
+  }
+
+  .history-actions {
+    display: flex;
+    gap: var(--spacing-small);
+  }
+
+  .history-timestamp {
+    font-size: var(--font-size-sm);
+    margin-bottom: var(--spacing-small);
+  }
+
+  .config-section {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-small);
+    background-color: var(--vscode-editor-inactiveSelectionBackground);
+    padding: var(--spacing-medium);
+    border-radius: var(--border-radius);
+    margin: var(--spacing-medium) 0;
+  }
+
+  .config-item {
+    display: flex;
+    gap: var(--spacing-medium);
+    align-items: baseline;
+  }
+
+  .config-key {
+    font-weight: 500;
+    color: var(--vscode-editorInfo-foreground);
+    min-width: calc(
+      var(--width-button-min) + var(--spacing-xlarge) + var(--spacing-xlarge)
+    );
+  }
+
+  .config-value {
+    color: var(--vscode-descriptionForeground);
+    word-break: break-word;
+  }
+
+  /* Note: .history-none and mark styles are provided by badgeStyles from @shared/styles */
+`;


### PR DESCRIPTION
- Implement HistoryList, HistoryItem, and SearchBar components
- Add search with match highlighting and navigation
- Support collapsible details and history actions (delete, restore, rerun)
- Persist toggle and search state
- Add history view styles and event definitions

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Primarily new frontend UI/state logic; main risk is search/highlighting + async match counting causing incorrect navigation/highlighting or UI jank, but no auth/data-write logic is introduced here.
> 
> **Overview**
> Adds a new Lit-based history UI composed of `history-list`, `history-item`, and `history-search-bar`, including per-item actions (delete/restore/rerun) and an optional “More details” collapsible section for additional config fields.
> 
> Introduces search across history items using `mark.js` with next/prev navigation, per-item match highlighting + auto-scroll, and match count reporting via new `HistoryViewEvents`.
> 
> Persists history view state (`searchIndex`, `totalMatches`, and per-item toggle open/closed) via `HistoryViewState`, and adds dedicated `historyViewStyles` for layout and config section styling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 274e45ea2f3914575a003f6c27d0bcdcf60e70ab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->