### PR TITLE
fix(webview): resolve orchestrator agent routing to main view

### DIFF
--- a/src/agent/index/agentRegistry.ts
+++ b/src/agent/index/agentRegistry.ts
@@ -498,6 +498,19 @@ export function resolveAgentKey(
 }
 
 /**
+ * Resolve an agent identifier to its full source:name key.
+ * Handles both plain names ("criticize") and existing keys ("builtIn:criticize").
+ * Uses registry lookup priority (custom > builtIn > builtInToolUse > remote).
+ * Falls back to original identifier if agent not found.
+ */
+export function resolveAgentKey(agentIdentifier: string): string {
+  if (!agentIdentifier) return agentIdentifier;
+  const entry = getAgent(agentIdentifier);
+  if (!entry) return agentIdentifier;
+  return createKey(entry.source, entry.name);
+}
+
+/**
  * Extract the clean agent name from an identifier.
  * Handles source:name format (e.g., "custom:summarize" → "summarize").
  */

--- a/src/agent/index/agentRegistry.ts
+++ b/src/agent/index/agentRegistry.ts
@@ -498,19 +498,6 @@ export function resolveAgentKey(
 }
 
 /**
- * Resolve an agent identifier to its full source:name key.
- * Handles both plain names ("criticize") and existing keys ("builtIn:criticize").
- * Uses registry lookup priority (custom > builtIn > builtInToolUse > remote).
- * Falls back to original identifier if agent not found.
- */
-export function resolveAgentKey(agentIdentifier: string): string {
-  if (!agentIdentifier) return agentIdentifier;
-  const entry = getAgent(agentIdentifier);
-  if (!entry) return agentIdentifier;
-  return createKey(entry.source, entry.name);
-}
-
-/**
  * Extract the clean agent name from an identifier.
  * Handles source:name format (e.g., "custom:summarize" → "summarize").
  */

--- a/src/agent/index/agentRegistry.ts
+++ b/src/agent/index/agentRegistry.ts
@@ -447,6 +447,56 @@ export function createKey(source: AgentSource, name: string): string {
   return `${source}:${name}`;
 }
 
+/** Source priority for tool-use sessions (prefers tool-use agents). */
+const TOOL_USE_LOOKUP_PRIORITY: AgentSource[] = [
+  'custom',
+  'builtInToolUse',
+  'builtIn',
+  'remote',
+];
+
+/**
+ * Get an agent by identifier with session-aware priority.
+ * For tool-use sessions, prefers builtInToolUse over builtIn to handle name collisions.
+ */
+function getAgentWithPriority(
+  identifier: string,
+  preferToolUse: boolean,
+): AgentEntry | undefined {
+  // Direct lookup for source:name format (already resolved)
+  if (cache.has(identifier)) return cache.get(identifier);
+
+  // Find first match using session-appropriate priority
+  const priority = preferToolUse ? TOOL_USE_LOOKUP_PRIORITY : LOOKUP_PRIORITY;
+  for (const source of priority) {
+    const entry = cache.get(`${source}:${identifier}`);
+    if (entry) return entry;
+  }
+  return undefined;
+}
+
+/**
+ * Resolve an agent identifier to its full source:name key.
+ * Handles both plain names ("criticize") and existing keys ("builtIn:criticize").
+ *
+ * When preferToolUse is true, uses tool-use lookup priority:
+ * custom → builtInToolUse → builtIn → remote
+ *
+ * This prevents workflow agents from shadowing tool-use agents with the same name
+ * when restoring tool-use session state.
+ *
+ * Falls back to original identifier if agent not found.
+ */
+export function resolveAgentKey(
+  agentIdentifier: string,
+  preferToolUse = false,
+): string {
+  if (!agentIdentifier) return agentIdentifier;
+  const entry = getAgentWithPriority(agentIdentifier, preferToolUse);
+  if (!entry) return agentIdentifier;
+  return createKey(entry.source, entry.name);
+}
+
 /**
  * Extract the clean agent name from an identifier.
  * Handles source:name format (e.g., "custom:summarize" → "summarize").

--- a/src/agent/index/agentRegistry.ts
+++ b/src/agent/index/agentRegistry.ts
@@ -81,6 +81,14 @@ const LOOKUP_PRIORITY: AgentSource[] = [
   'remote',
 ];
 
+/** Source priority for tool-use sessions (prefers tool-use agents). */
+const TOOL_USE_LOOKUP_PRIORITY: AgentSource[] = [
+  'custom',
+  'builtInToolUse',
+  'builtIn',
+  'remote',
+];
+
 /** Default agents for dropdowns. */
 const DEFAULT_WORKFLOW_AGENT = 'correct';
 const DEFAULT_TOOL_USE_AGENT = 'chat';
@@ -180,13 +188,22 @@ async function doLoad(): Promise<void> {
 /**
  * Get an agent by identifier.
  * Supports "source:name" format or just "name" (finds first match by priority).
+ *
+ * When preferToolUse is true, uses tool-use lookup priority:
+ * custom → builtInToolUse → builtIn → remote
+ *
+ * This handles name collisions where a workflow agent shadows a tool-use agent.
  */
-export function getAgent(identifier: string): AgentEntry | undefined {
-  // Direct lookup for source:name format
+export function getAgent(
+  identifier: string,
+  preferToolUse = false,
+): AgentEntry | undefined {
+  // Direct lookup for source:name format (already resolved)
   if (cache.has(identifier)) return cache.get(identifier);
 
-  // Legacy: find first match by name across sources
-  for (const source of LOOKUP_PRIORITY) {
+  // Find first match using session-appropriate priority
+  const priority = preferToolUse ? TOOL_USE_LOOKUP_PRIORITY : LOOKUP_PRIORITY;
+  for (const source of priority) {
     const entry = cache.get(`${source}:${identifier}`);
     if (entry) return entry;
   }
@@ -447,44 +464,9 @@ export function createKey(source: AgentSource, name: string): string {
   return `${source}:${name}`;
 }
 
-/** Source priority for tool-use sessions (prefers tool-use agents). */
-const TOOL_USE_LOOKUP_PRIORITY: AgentSource[] = [
-  'custom',
-  'builtInToolUse',
-  'builtIn',
-  'remote',
-];
-
-/**
- * Get an agent by identifier with session-aware priority.
- * For tool-use sessions, prefers builtInToolUse over builtIn to handle name collisions.
- */
-function getAgentWithPriority(
-  identifier: string,
-  preferToolUse: boolean,
-): AgentEntry | undefined {
-  // Direct lookup for source:name format (already resolved)
-  if (cache.has(identifier)) return cache.get(identifier);
-
-  // Find first match using session-appropriate priority
-  const priority = preferToolUse ? TOOL_USE_LOOKUP_PRIORITY : LOOKUP_PRIORITY;
-  for (const source of priority) {
-    const entry = cache.get(`${source}:${identifier}`);
-    if (entry) return entry;
-  }
-  return undefined;
-}
-
 /**
  * Resolve an agent identifier to its full source:name key.
  * Handles both plain names ("criticize") and existing keys ("builtIn:criticize").
- *
- * When preferToolUse is true, uses tool-use lookup priority:
- * custom → builtInToolUse → builtIn → remote
- *
- * This prevents workflow agents from shadowing tool-use agents with the same name
- * when restoring tool-use session state.
- *
  * Falls back to original identifier if agent not found.
  */
 export function resolveAgentKey(
@@ -492,7 +474,7 @@ export function resolveAgentKey(
   preferToolUse = false,
 ): string {
   if (!agentIdentifier) return agentIdentifier;
-  const entry = getAgentWithPriority(agentIdentifier, preferToolUse);
+  const entry = getAgent(agentIdentifier, preferToolUse);
   if (!entry) return agentIdentifier;
   return createKey(entry.source, entry.name);
 }

--- a/src/agent/index/index.ts
+++ b/src/agent/index/index.ts
@@ -21,6 +21,7 @@ export {
   // Key helpers
   createKey,
   getCleanAgentName,
+  resolveAgentKey,
   // _multiple helpers
   getBaseName,
   getMultipleName,

--- a/src/agent/remote/remoteAgentUtils.ts
+++ b/src/agent/remote/remoteAgentUtils.ts
@@ -64,7 +64,7 @@ export async function selectAgentInMainView(
 
     webviewView.webview.postMessage({
       command: MAIN_VIEW_COMMANDS.SET_SELECTED_AGENT,
-      agentValue,
+      agentId: agentValue, // Must match schema field name
       sessionType,
     });
 

--- a/src/common/state/mainViewStateUtils.ts
+++ b/src/common/state/mainViewStateUtils.ts
@@ -5,7 +5,7 @@ import {
 } from '@shared/schemas';
 
 // Local imports - agent registry
-import { getAgent, createKey } from '@agent/index';
+import { resolveAgentKey } from '@agent/index';
 
 // Local imports - task state
 import {
@@ -13,18 +13,6 @@ import {
   isWorkflowTaskState,
   type TaskState,
 } from '@logger/TaskState';
-
-/**
- * Resolve an agent name to its full source:name key.
- * Uses the agent registry's lookup priority (custom > builtIn > builtInToolUse > remote).
- * Falls back to the original name if agent not found (e.g., stale state).
- */
-function resolveAgentKey(agentName: string): string {
-  if (!agentName) return agentName;
-  const entry = getAgent(agentName);
-  if (!entry) return agentName;
-  return createKey(entry.source, entry.name);
-}
 
 /** Convert a TaskState payload into a full main view state snapshot. */
 export function buildMainViewState(
@@ -38,7 +26,9 @@ export function buildMainViewState(
 
   // Resolve agent name to full key (e.g., "criticize" → "builtIn:criticize")
   // This ensures the frontend receives the exact key used in dropdown options.
-  const resolvedAgent = resolveAgentKey(agentConfig.agent);
+  // Pass isToolUse to prefer builtInToolUse source for tool-use sessions,
+  // preventing workflow agents from shadowing tool-use agents with same name.
+  const resolvedAgent = resolveAgentKey(agentConfig.agent, isToolUse);
 
   // Build partial state from agentConfig and toolConfig, then parse with schema
   // to apply prefault defaults for any missing fields.
@@ -70,7 +60,5 @@ export function buildMainViewState(
     autoCompileInputPdf: toolConfig.autoCompileInputPdf,
     attachTeXCount: toolConfig.attachTeXCount,
     attachDiagnostics: toolConfig.attachDiagnostics,
-    agent: resolvedAgent, // Use resolved key for consistency with workflowAgent/toolUseAgent
-    isToolUseAgent: isToolUse,
   });
 }

--- a/src/shared/schemas/mainView.ts
+++ b/src/shared/schemas/mainView.ts
@@ -96,8 +96,6 @@ export const MainViewPersistedStateSchema = UIFileFieldsSchema.merge(
   outputFilesVisible: z.boolean().prefault(false),
   outputFilesActive: z.boolean().prefault(false),
   latexdiffsVisible: z.boolean().prefault(false),
-  agent: z.string().prefault(''),
-  isToolUseAgent: z.boolean().prefault(true),
   openedFiles: z.array(z.string()).nullish(),
 });
 export type MainViewPersistedState = z.infer<

--- a/src/webview/frontend/MainApp.ts
+++ b/src/webview/frontend/MainApp.ts
@@ -452,11 +452,6 @@ export class MainApp extends BaseWebviewApp {
       autoCompileInputPdf: this.checkboxValues.autoCompileInputPdf,
       attachTeXCount: this.checkboxValues.attachTeXCount,
       attachDiagnostics: this.checkboxValues.attachDiagnostics,
-      agent:
-        this.sessionType === SESSION_TYPES.TOOL_USE
-          ? this.toolUseAgent
-          : this.workflowAgent,
-      isToolUseAgent: this.sessionType === SESSION_TYPES.TOOL_USE,
     };
 
     this.stateManager.setState(persisted);
@@ -543,7 +538,9 @@ export class MainApp extends BaseWebviewApp {
    * Validates that a selection exists in options.
    * Returns current value if found, otherwise falls back to first available option.
    */
-  private validateSelection<T extends { value: string; disabled?: boolean }>(
+  private validateSelection<
+    T extends { value: string; disabled?: boolean },
+  >(
     options: T[],
     currentValue: string,
     preferEnabled = false,


### PR DESCRIPTION
Root cause: Orchestrator proposes agents with plain names (e.g., "criticize") but dropdown options use source:name format (e.g., "builtIn:criticize"). Frontend validation failed to match.

Fix: Resolve agent names at the source (backend) using the registry's getAgent() + createKey() - single source of truth.

Backend (mainViewStateUtils.ts):
- Added resolveAgentKey() using getAgent() + createKey()
- buildMainViewState() sends resolved keys (workflowAgent/toolUseAgent)

Frontend (MainApp.ts):
- Simplified validateSelection() - exact match or fallback
- Removed redundant validation from handleRestoreState()

Schema cleanup:
- Removed redundant `agent` field (derivable from sessionType + workflowAgent/toolUseAgent)
- Removed redundant `isToolUseAgent` field (derivable from sessionType)

Bug fix (remoteAgentUtils.ts):
- Fixed field name mismatch: was sending `agentValue` but schema expects `agentId`
- Remote agent selection from dashboard now works correctly

https://claude.ai/code/session_01B94rQxAT96Qhg7UkLSHN3u

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared main-view state schema and agent-lookup semantics; mistakes could break persisted state restores or agent selection across workflow/tool-use sessions.
> 
> **Overview**
> Fixes agent selection/state restore mismatches by **resolving plain agent names to canonical `source:name` keys on the backend** via new `resolveAgentKey()` and by extending `getAgent()` with a `preferToolUse` lookup order to avoid workflow/tool-use name collisions.
> 
> Cleans up main-view state plumbing by removing redundant persisted fields (`agent`, `isToolUseAgent`) and updating remote agent selection messaging to send `agentId` (schema-aligned), so orchestrator/remote-driven agent routing reliably selects the correct dropdown entry.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a46bcbfb5af629ef259d38cb8a21a9a97f367bb4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->