### PR TITLE
add PRD for context window compactization

### DIFF
--- a/docs/prd-context-compactization.md
+++ b/docs/prd-context-compactization.md
@@ -66,29 +66,47 @@ Key takeaway: the **system prompt is the right place** for compacted context. Ra
 
 ### 4.2 Compaction Strategies
 
-#### Strategy 1: Anthropic SDK Compaction (preferred for Anthropic)
+#### Strategy 1: Anthropic SDK-Style Compaction (replicate for Anthropic)
 
-The Anthropic SDK now supports `compactionControl` in `toolRunner`, which is better than raw `context_management` clearing:
+The Anthropic Python SDK's `toolRunner` implements compaction in `_check_and_compact()`. Since TeXRA doesn't use `toolRunner`, we replicate this logic ourselves.
 
-```typescript
-const runner = client.beta.messages.toolRunner({
-  model: 'claude-sonnet-4-5',
-  max_tokens: 4096,
-  tools: [...],
-  messages: [...],
-  compactionControl: {
-    enabled: true,
-    contextTokenThreshold: 100000,
-    model: 'claude-haiku-4-5'  // Use cheaper model for summaries
-  }
-});
+**What the SDK does (from `_beta_runner.py`):**
+
+```python
+def _check_and_compact(self) -> bool:
+    # 1. Check if compaction needed
+    tokens_used = message.usage.input_tokens + message.usage.output_tokens
+    threshold = self._compaction_control.get("context_token_threshold", 100_000)
+    if tokens_used < threshold:
+        return False
+
+    # 2. Remove pending tool_use blocks from last message
+    if messages[-1]["role"] == "assistant":
+        non_tool_blocks = [b for b in messages[-1]["content"] if b.get("type") != "tool_use"]
+        if non_tool_blocks:
+            messages[-1]["content"] = non_tool_blocks
+        else:
+            messages.pop()
+
+    # 3. Append summary prompt as user message
+    messages.append({"role": "user", "content": DEFAULT_SUMMARY_PROMPT})
+
+    # 4. Call API (non-streaming) with cheaper model
+    model = self._compaction_control.get("model", self._params["model"])
+    response = client.beta.messages.create(model=model, messages=messages, ...)
+
+    # 5. Replace ALL messages with single user message containing summary
+    self.set_messages_params({"messages": [{"role": "user", "content": response.content[0].text}]})
 ```
 
-- **Uses `<summary>` tags** — same pattern as our client-side approach
-- **Configurable summary model** — can use Haiku for cheaper/faster summaries
-- **Built-in summary prompt** — structured (Task Overview, Current State, Discoveries, Next Steps, Context to Preserve)
+**Key details:**
+- Uses token count from `message.usage` (input + output tokens)
+- Default threshold: 100,000 tokens
+- Summary prompt asks for `<summary></summary>` tags but SDK takes raw text (doesn't extract from tags)
+- Replaces entire message history with one user message containing the summary
+- Can use cheaper model (e.g., `claude-haiku-4-5`) for summary generation
 
-This replaces the lossy `context_management` clearing approach. The SDK handles compaction automatically.
+**TeXRA implementation:** Replicate this in `ModelHandlerAnthropic` since we don't use `toolRunner`.
 
 #### Strategy 2: OpenAI Responses API Compaction (existing, works well)
 - Continue using `/responses/compact` endpoint.
@@ -196,104 +214,53 @@ function getCheapestModelInFamily(modelId: string): string {
 
 ### 4.4 Structured Summary Prompt
 
-Adapted from [neu-translator's `COMPACT_INSTRUCTION`](https://github.com/neutree-ai/neu-translator/blob/main/packages/core/src/prompts/system.compact.ts), modified for TeXRA's XML conventions (output tag is `<conversation-summary>` instead of `<summary>`).
-
-**System prompt for compactor model:**
+**Use the Anthropic SDK's `DEFAULT_SUMMARY_PROMPT`** (from `_beta_compaction_control.py`):
 
 ```
-You are a helpful AI assistant tasked with summarizing conversations.
+You have been working on the task described above but have not yet completed it.
+Write a continuation summary that will allow you (or another instance of yourself)
+to resume work efficiently in a future context window where the conversation
+history will be replaced with this summary. Your summary should be structured,
+concise, and actionable. Include:
+
+1. Task Overview
+   The user's core request and success criteria
+   Any clarifications or constraints they specified
+
+2. Current State
+   What has been completed so far
+   Files created, modified, or analyzed (with paths if relevant)
+   Key outputs or artifacts produced
+
+3. Important Discoveries
+   Technical constraints or requirements uncovered
+   Decisions made and their rationale
+   Errors encountered and how they were resolved
+   What approaches were tried that didn't work (and why)
+
+4. Next Steps
+   Specific actions needed to complete the task
+   Any blockers or open questions to resolve
+   Priority order if multiple steps remain
+
+5. Context to Preserve
+   User preferences or style requirements
+   Domain-specific details that aren't obvious
+   Any promises made to the user
+
+Be concise but complete—err on the side of including information that would
+prevent duplicate work or repeated mistakes. Write in a way that enables
+immediate resumption of the task.
+
+Wrap your summary in <summary></summary> tags.
 ```
 
-**Compaction instruction (sent as user message after the conversation history):**
-
-```
-Your task is to create a detailed summary of the conversation so far, paying close
-attention to the user's explicit requests and your previous actions.
-This summary should be thorough in capturing the details that would be essential for
-continuing work without losing context.
-
-Before providing your final summary, wrap your analysis in <analysis> tags to organize
-your thoughts and ensure you've covered all necessary points. In your analysis process:
-
-1. Chronologically analyze each message and section of the conversation. For each
-   section thoroughly identify:
-   - The user's explicit requests and intents
-   - Your approach to addressing the user's requests
-   - Key decisions
-   - Specific details
-   - Pay special attention to specific user feedback that you received, especially
-     if the user told you to do something differently.
-
-2. Double-check for accuracy and completeness, addressing each required element
-   thoroughly.
-
-Your summary should include the following sections:
-1. Primary Request and Intent: Capture all of the user's explicit requests and intents
-   in detail
-2. Key Concepts: List all important concepts and topics discussed.
-3. Errors and fixes: List all errors that you ran into, and how you fixed them. Pay
-   special attention to specific user feedback that you received, especially if the
-   user told you to do something differently.
-4. Problem Solving: Document problems solved and any ongoing troubleshooting efforts.
-5. All user messages: List ALL user messages that are not tool results. These are
-   critical for understanding the users' feedback and changing intent.
-6. Pending Tasks: Outline any pending tasks that you have explicitly been asked to
-   work on.
-7. Current Work: Describe in detail precisely what was being worked on immediately
-   before this summary request.
-8. Optional Next Step: List the next step that you will take that is related to the
-   most recent work you were doing. If your last task was concluded, then only list
-   next steps if they are explicitly in line with the users request. Do not start on
-   tangential requests without confirming with the user first.
-
-If there is a next step, include direct quotes from the most recent conversation
-showing exactly what task you were working on and where you left off. This should be
-verbatim to ensure there's no drift in task interpretation.
-
-Here's an example of how your output should be structured:
-
-<example>
-<analysis>
-[Your thought process, ensuring all points are covered thoroughly and accurately]
-</analysis>
-
-<conversation-summary>
-1. Primary Request and Intent:
-   [Detailed description]
-2. Key Concepts:
-   - [Concept 1]
-   - [Concept 2]
-   - [...]
-3. Errors and fixes:
-   - [Detailed description of error 1]:
-   - [How you fixed the error]
-   - [User feedback on the error if any]
-   - [...]
-4. Problem Solving:
-   [Description of solved problems and ongoing troubleshooting]
-5. All user messages:
-   - [Detailed non tool use user message]
-   - [...]
-   [Should ignore the user message that triggered this compaction]
-6. Pending Tasks:
-   - [Task 1]
-   - [Task 2]
-   - [...]
-7. Current Work:
-   [Precise description of current work]
-8. Optional Next Step:
-   [Optional next step to take]
-</conversation-summary>
-</example>
-
-Please provide your summary based on the conversation so far, following this structure
-and ensuring precision and thoroughness in your response.
-```
+This is better than neu-translator's prompt — it's more actionable and focused on task continuation.
 
 **Notes:**
-- Output tag is `<conversation-summary>` (parsed via `extractTextFromTag()`)
-- The `<analysis>` block is discarded — only `<conversation-summary>` content is injected into the system prompt
-- The prompt is stored in `src/agent/modelHandlers/compactionPrompt.ts` so it can be iterated independently
+- The SDK prompt uses `<summary></summary>` tags, but the SDK code doesn't actually extract from tags — it takes the raw response text
+- For consistency with TeXRA's patterns, we can use `<summary>` tags and extract via `extractTextFromTag()`
+- Store prompt in `src/agent/modelHandlers/compactionPrompt.ts` so it can be iterated independently
 
 ### 4.5 Current Context Validation (Gap Analysis)
 

--- a/docs/prd-context-compactization.md
+++ b/docs/prd-context-compactization.md
@@ -39,7 +39,7 @@ The [neu-translator](https://github.com/neutree-ai/neu-translator) project uses 
 - **Compaction output replaces `activeMessages`** with a single assistant message containing the summary
 - **System prompt is rebuilt each call** via `SYSTEM_WORKFLOW` (incorporating memory + skills), so the model always gets fresh instructions alongside the compacted context
 
-Key takeaway: the **system prompt is the right place** for compacted context. Rather than replacing conversation messages with a fake assistant message (which breaks tool-use chains and feels unnatural), the summary should be injected into the system prompt. The model then receives: `[enriched system prompt with summary] + [only the most recent messages]`. This is simpler, avoids broken message sequences, and works uniformly across all providers.
+**Note:** neu-translator injects summaries into the system prompt. We chose a different approach: replace all messages with a single **user message** containing the summary (following the Anthropic SDK pattern). This keeps the system prompt focused on agent identity and avoids mutating it during the conversation. See Section 4.2 for details.
 
 ## 4. Proposed Design
 
@@ -673,7 +673,7 @@ This makes compaction a clean plug-in phase rather than deeply embedded logic.
 
 ### Completed
 
-- **Token count check after tool results** (2026-02-03): Added token count logging in `ToolUseDispatchNode.post()` at `src/agent/core/flows/ToolUseCycleFlow.ts:778-794`. This logs context utilization after tool results are attached and before the next `createResponse()`, giving visibility into token usage and setting up for compaction trigger.
+- **Token count check after tool results** (2026-02-03): Added token count logging in `ToolUseDispatchNode.post()` at `src/agent/core/flows/ToolUseCycleFlow.ts:778-795`. Only runs for providers with native token counting support (`supportsTokenCounting`). Logs context utilization after tool results are attached and before the next `createResponse()`.
 
 ### In Progress
 
@@ -686,3 +686,9 @@ This makes compaction a clean plug-in phase rather than deeply embedded logic.
 - Phase 2: Auto-compact toggle
 - Phase 3: Integration with handlers
 - Phase 4: UI — compaction visibility
+
+### Future Optimizations
+
+- **Token counting latency**: Currently `estimateTokenCount()` is called after every tool completion. To reduce overhead, track cumulative token usage from API responses (`lastUsage`) and only call `estimateTokenCount()` when utilization exceeds 50% threshold.
+- **Configurable compaction model**: Add `compactionModel` property to `ModelConfig` (requires llm-zoo changes).
+- **Button icons**: Consider using `layers` or `archive` codicons instead of `fold/unfold` for clearer compaction metaphor.

--- a/docs/prd-context-compactization.md
+++ b/docs/prd-context-compactization.md
@@ -66,13 +66,14 @@ Key takeaway: the **system prompt is the right place** for compacted context. Ra
 
 ### 4.2 Compaction Strategies
 
-#### Strategy 1: Anthropic Server-Side Clearing (existing)
-- No changes. Continue using `context_management` parameter with `clear_tool_uses` and `clear_thinking`.
-- Already well-integrated.
+#### Strategy 1: Anthropic Server-Side Clearing (existing, not ideal)
+- Continue using `context_management` parameter with `clear_tool_uses` and `clear_thinking`.
+- **Limitation**: Clearing is lossy — tool results and thinking blocks are simply dropped, not summarized. The model loses access to specific details that might be needed later.
+- Consider offering client-side summarization as an optional override for Anthropic users who want better context preservation.
 
-#### Strategy 2: OpenAI Responses API Compaction (existing)
-- No changes. Continue using `/responses/compact` endpoint.
-- Already well-integrated.
+#### Strategy 2: OpenAI Responses API Compaction (existing, works well)
+- Continue using `/responses/compact` endpoint.
+- **Works well**: Opaque but effective — handles compaction server-side with good results.
 
 #### Strategy 3: Client-Side Summarization via System Prompt Injection (new -- fallback for all providers)
 
@@ -457,23 +458,15 @@ The follow-up input has a vertical action column:
   icon="fold-down"
   label="Compact context"
   title="Compact conversation context (summarize history to free tokens)"
-  ?disabled=${!this.canCompact}
   @click=${this.emitCompact}
 ></vscode-toolbar-button>
 ```
 
 **Behavior:**
 - Visible when stream is in tool-use mode (not workflow)
-- Disabled if context utilization is below 10% (wasteful to compact)
+- Always enabled (no threshold check — user decides when to compact)
 - On click: dispatches `COMPACT_NOW` command
 - Shows progress ring during compaction (like Polish button)
-- After completion: logs compaction event, updates context state display
-
-**State management:**
-```typescript
-@property({ type: Boolean }) canCompact = false;  // From context utilization > 10%
-@state() private compacting = false;              // Shows progress ring
-```
 
 **Why in follow-up input area?**
 - User is actively chatting → compaction is a chat-related action
@@ -517,14 +510,7 @@ Added to the vertical action column alongside Polish, Record, Clear, Send. See s
 
 ### 5.3 Context Utilization Indicator
 
-Add to `UsagePanel` or as a separate component:
-
-1. **Progress bar**: Visual bar showing context utilization
-   - Green: < 50%
-   - Yellow: 50-75%
-   - Red: > 75%
-2. **Compaction badge**: After compaction, show "Compacted: 72K → 18K"
-3. **Expandable details**: Click to see summary text (for client-side compaction)
+Existing `UsagePanel` already shows token counts. After compaction, show "Compacted: 72K → 18K" badge.
 
 ### 5.4 Chat View Compaction Divider
 
@@ -541,7 +527,6 @@ Add to `UsagePanel` or as a separate component:
 |---------|------|---------|-------------|
 | `texra.model.compactionThresholdPercent` | number | 75 | Existing. Threshold for auto-compaction. 0 = disabled. |
 | `texra.model.compactorModel` | string | "auto" | New. Model for client-side summarization. |
-| `texra.model.enableClientSideCompaction` | boolean | true | New. Enable client-side fallback when native compaction unavailable. |
 | `texra.model.enableThinkingClearing` | boolean | false | Existing. Anthropic thinking block clearing. |
 
 ## 7. Implementation Plan
@@ -609,10 +594,8 @@ This makes compaction a clean plug-in phase rather than deeply embedded logic.
 | Risk | Mitigation |
 |------|------------|
 | Client-side summary loses critical context | Structured prompt with mandatory sections; user can scroll up to see full history |
-| Compactor model call adds latency | Use cheapest/fastest available model; run async before next request |
-| Compactor model unavailable (no API key) | Fall back to naive truncation (drop oldest tool results first) |
-| Double-compaction (native + client-side) | Strategy selection is exclusive -- never both |
-| `allMessages` grows unbounded in memory | Cap at ~500 messages; beyond that, persist to disk and load on demand |
+| Compactor model call adds latency | Use cheapest/fastest available model |
+| Double-compaction (native + client-side) | Strategy selection is exclusive — never both |
 
 ## 9. Success Metrics
 

--- a/docs/prd-context-compactization.md
+++ b/docs/prd-context-compactization.md
@@ -165,10 +165,43 @@ Messages: [
 - System prompt remains unchanged (agent identity preserved)
 - The next user request is appended after the summary message
 
+**Compaction event logging:**
+
+When compaction occurs, emit a special message type (like existing `CONTEXT_MANAGEMENT`) with the summary inside:
+
+```typescript
+// In src/shared/schemas/contextManagement.ts
+export const CompactionEventSchema = z.object({
+  action: z.literal('compaction'),
+  tokensBefore: z.number(),
+  tokensAfter: z.number(),
+  contextWindow: z.number(),
+  utilizationBefore: z.number(),
+  utilizationAfter: z.number(),
+  summary: z.string(),  // The full summary text
+  compactionModel: z.string(),
+});
+
+// Logger call
+this.logger.logContextManagement('Context compacted', {
+  action: 'compaction',
+  tokensBefore: 72000,
+  tokensAfter: 3000,
+  contextWindow: 200000,
+  utilizationBefore: 36,
+  utilizationAfter: 1.5,
+  summary: summaryText,
+  compactionModel: 'claude-sonnet-4-5',
+});
+```
+
+This makes the summary visible in the progress view and preserves it for debugging/review.
+
 **Why this is simple:**
 - No streaming — single blocking call to compactor model
 - No message surgery — drop everything, replace with summary
 - Works identically across all providers
+- Summary preserved in logs for visibility
 
 ### 4.3 Compaction Model Selection
 

--- a/docs/prd-context-compactization.md
+++ b/docs/prd-context-compactization.md
@@ -180,8 +180,8 @@ const COMPACTION_MODEL_MAP: Record<string, string> = {
   'claude-opus-4-5': 'claude-sonnet-4-5',
   'claude-sonnet-4-5': 'claude-sonnet-4-5',
 
-  // OpenAI: gpt5 → gpt5 (same model, summarization uses fewer thinking tokens)
-  'gpt-5': 'gpt-5',
+  // OpenAI: gpt-5.2 → gpt-5.2 (same model, summarization uses fewer thinking tokens)
+  'gpt-5.2': 'gpt-5.2',
 
   // Google: pro → flash
   'gemini-3-pro': 'gemini-3-flash',
@@ -192,7 +192,8 @@ const COMPACTION_MODEL_MAP: Record<string, string> = {
   'deepseek-reasoner': 'deepseek-chat',
 
   // Kimi: same model
-  'moonshot-v1-128k': 'moonshot-v1-128k',
+  'kimi-k2': 'kimi-k2',
+  'kimi-k1.5-long': 'kimi-k1.5-long',
 };
 
 function getCompactionModel(primaryModel: string): string {

--- a/docs/prd-context-compactization.md
+++ b/docs/prd-context-compactization.md
@@ -134,18 +134,104 @@ Add a new configuration:
 
 ### 4.4 Structured Summary Prompt
 
-The compaction prompt must preserve:
+Adapted from [neu-translator's `COMPACT_INSTRUCTION`](https://github.com/neutree-ai/neu-translator/blob/main/packages/core/src/prompts/system.compact.ts), modified for TeXRA's XML conventions (output tag is `<conversation-summary>` instead of `<summary>`).
 
-| Section | Purpose |
-|---------|---------|
-| **Task Objective** | Original user request and constraints |
-| **Key Decisions** | Important choices made during execution |
-| **Tool Results Summary** | Condensed results from tool calls (file contents, search results) |
-| **Errors & Corrections** | What went wrong and how it was fixed |
-| **Current State** | Exact point of progress, including verbatim code/text being worked on |
-| **Pending Work** | What still needs to be done |
+**System prompt for compactor model:**
 
-The prompt should be defined in a dedicated file (`src/agent/modelHandlers/compactionPrompt.ts`) so it can be iterated on independently.
+```
+You are a helpful AI assistant tasked with summarizing conversations.
+```
+
+**Compaction instruction (sent as user message after the conversation history):**
+
+```
+Your task is to create a detailed summary of the conversation so far, paying close
+attention to the user's explicit requests and your previous actions.
+This summary should be thorough in capturing the details that would be essential for
+continuing work without losing context.
+
+Before providing your final summary, wrap your analysis in <analysis> tags to organize
+your thoughts and ensure you've covered all necessary points. In your analysis process:
+
+1. Chronologically analyze each message and section of the conversation. For each
+   section thoroughly identify:
+   - The user's explicit requests and intents
+   - Your approach to addressing the user's requests
+   - Key decisions
+   - Specific details
+   - Pay special attention to specific user feedback that you received, especially
+     if the user told you to do something differently.
+
+2. Double-check for accuracy and completeness, addressing each required element
+   thoroughly.
+
+Your summary should include the following sections:
+1. Primary Request and Intent: Capture all of the user's explicit requests and intents
+   in detail
+2. Key Concepts: List all important concepts and topics discussed.
+3. Errors and fixes: List all errors that you ran into, and how you fixed them. Pay
+   special attention to specific user feedback that you received, especially if the
+   user told you to do something differently.
+4. Problem Solving: Document problems solved and any ongoing troubleshooting efforts.
+5. All user messages: List ALL user messages that are not tool results. These are
+   critical for understanding the users' feedback and changing intent.
+6. Pending Tasks: Outline any pending tasks that you have explicitly been asked to
+   work on.
+7. Current Work: Describe in detail precisely what was being worked on immediately
+   before this summary request.
+8. Optional Next Step: List the next step that you will take that is related to the
+   most recent work you were doing. If your last task was concluded, then only list
+   next steps if they are explicitly in line with the users request. Do not start on
+   tangential requests without confirming with the user first.
+
+If there is a next step, include direct quotes from the most recent conversation
+showing exactly what task you were working on and where you left off. This should be
+verbatim to ensure there's no drift in task interpretation.
+
+Here's an example of how your output should be structured:
+
+<example>
+<analysis>
+[Your thought process, ensuring all points are covered thoroughly and accurately]
+</analysis>
+
+<conversation-summary>
+1. Primary Request and Intent:
+   [Detailed description]
+2. Key Concepts:
+   - [Concept 1]
+   - [Concept 2]
+   - [...]
+3. Errors and fixes:
+   - [Detailed description of error 1]:
+   - [How you fixed the error]
+   - [User feedback on the error if any]
+   - [...]
+4. Problem Solving:
+   [Description of solved problems and ongoing troubleshooting]
+5. All user messages:
+   - [Detailed non tool use user message]
+   - [...]
+   [Should ignore the user message that triggered this compaction]
+6. Pending Tasks:
+   - [Task 1]
+   - [Task 2]
+   - [...]
+7. Current Work:
+   [Precise description of current work]
+8. Optional Next Step:
+   [Optional next step to take]
+</conversation-summary>
+</example>
+
+Please provide your summary based on the conversation so far, following this structure
+and ensuring precision and thoroughness in your response.
+```
+
+**Notes:**
+- Output tag is `<conversation-summary>` (parsed via `extractTextFromTag()`)
+- The `<analysis>` block is discarded — only `<conversation-summary>` content is injected into the system prompt
+- The prompt is stored in `src/agent/modelHandlers/compactionPrompt.ts` so it can be iterated independently
 
 ### 4.5 Integration with ModelHandler Base Class
 

--- a/docs/prd-context-compactization.md
+++ b/docs/prd-context-compactization.md
@@ -66,118 +66,109 @@ Key takeaway: the **system prompt is the right place** for compacted context. Ra
 
 ### 4.2 Compaction Strategies
 
-#### Strategy 1: Anthropic SDK-Style Compaction (replicate for Anthropic)
-
-The Anthropic Python SDK's `toolRunner` implements compaction in `_check_and_compact()`. Since TeXRA doesn't use `toolRunner`, we replicate this logic ourselves.
-
-**What the SDK does (from `_beta_runner.py`):**
-
-```python
-def _check_and_compact(self) -> bool:
-    # 1. Check if compaction needed
-    tokens_used = message.usage.input_tokens + message.usage.output_tokens
-    threshold = self._compaction_control.get("context_token_threshold", 100_000)
-    if tokens_used < threshold:
-        return False
-
-    # 2. Remove pending tool_use blocks from last message
-    if messages[-1]["role"] == "assistant":
-        non_tool_blocks = [b for b in messages[-1]["content"] if b.get("type") != "tool_use"]
-        if non_tool_blocks:
-            messages[-1]["content"] = non_tool_blocks
-        else:
-            messages.pop()
-
-    # 3. Append summary prompt as user message
-    messages.append({"role": "user", "content": DEFAULT_SUMMARY_PROMPT})
-
-    # 4. Call API (non-streaming) with cheaper model
-    model = self._compaction_control.get("model", self._params["model"])
-    response = client.beta.messages.create(model=model, messages=messages, ...)
-
-    # 5. Replace ALL messages with single user message containing summary
-    self.set_messages_params({"messages": [{"role": "user", "content": response.content[0].text}]})
-```
-
-**Key details:**
-- Uses token count from `message.usage` (input + output tokens)
-- Default threshold: 100,000 tokens
-- Summary prompt asks for `<summary></summary>` tags but SDK takes raw text (doesn't extract from tags)
-- Replaces entire message history with one user message containing the summary
-- Can use cheaper model (e.g., `claude-haiku-4-5`) for summary generation
-
-**TeXRA implementation:** Replicate this in `ModelHandlerAnthropic` since we don't use `toolRunner`.
-
-#### Strategy 2: OpenAI Responses API Compaction (existing, works well)
+#### Strategy 1: OpenAI Responses API Compaction (existing, prioritized)
 - Continue using `/responses/compact` endpoint.
 - **Works well**: Opaque but effective — handles compaction server-side with good results.
+- No changes needed.
 
-#### Strategy 3: Client-Side Summarization via System Prompt Injection (new -- fallback for all providers)
+#### Strategy 2: Client-Side Summarization (for all other providers)
 
-This is the new capability. It covers all providers that lack a native compaction API:
+Copy the Anthropic SDK's `_check_and_compact()` pattern but make it work for **all providers** (Anthropic, DeepSeek, Kimi, Gemini, OpenAI Chat, etc.).
 
-| Provider | Native Compaction | Needs Client-Side |
-|----------|------------------|-------------------|
-| Anthropic | SDK `compactionControl` (uses Haiku for summaries) | No |
-| OpenAI Responses API | `/responses/compact` endpoint | No |
-| OpenAI Chat Completions | None | **Yes** |
-| Google GenAI (Gemini) | None | **Yes** |
-| DeepSeek | None | **Yes** |
-| Kimi (Moonshot) | None | **Yes** |
-| Any future provider | None by default | **Yes** |
+**Implementation (from Anthropic SDK `_beta_runner.py`, adapted for TeXRA):**
 
-Client-side summarization is the **fallback** for providers without native compaction. Anthropic and OpenAI Responses have native paths that work well.
+```typescript
+async function checkAndCompact(
+  messages: Message[],
+  lastUsage: TokenUsage,
+  threshold: number,
+  compactionModel: string,
+): Promise<{ compacted: boolean; newMessages: Message[] }> {
+  // 1. Check if compaction needed
+  const tokensUsed = lastUsage.inputTokens + lastUsage.outputTokens;
+  if (tokensUsed < threshold) {
+    return { compacted: false, newMessages: messages };
+  }
 
-**Core insight: inject the summary into the system prompt, not into messages.**
+  // 2. Remove pending tool_use blocks from last message
+  const cleanedMessages = [...messages];
+  const lastMsg = cleanedMessages[cleanedMessages.length - 1];
+  if (lastMsg?.role === 'assistant') {
+    const nonToolBlocks = lastMsg.content.filter(b => b.type !== 'tool_use');
+    if (nonToolBlocks.length > 0) {
+      lastMsg.content = nonToolBlocks;
+    } else {
+      cleanedMessages.pop();
+    }
+  }
 
-Replacing conversation messages with a fake assistant summary message is problematic:
-- Breaks tool-use call/result pairs (providers validate these sequences)
-- Creates an unnatural message history (assistant "remembering" things it didn't say)
-- Requires complex logic to decide which messages to keep vs. replace
+  // 3. Append summary prompt as user message
+  cleanedMessages.push({ role: 'user', content: DEFAULT_SUMMARY_PROMPT });
 
-Instead, the approach is simple:
+  // 4. Call API (non-streaming) with cheaper model
+  const response = await createResponse(compactionModel, cleanedMessages, { stream: false });
 
-**Compaction Flow (non-streaming):**
-
+  // 5. Replace ALL messages with single user message containing summary
+  const summary = response.content[0].text;
+  return {
+    compacted: true,
+    newMessages: [{ role: 'user', content: summary }]
+  };
+}
 ```
-1. Trigger: shouldCompact() returns true (threshold exceeded or manual button)
 
-2. Call compactor model (non-streaming):
-   - System prompt: replaced with COMPACTOR_SYSTEM_PROMPT
-   - Messages: allMessages (full history)
-   - User message: COMPACT_INSTRUCTION
+**Key change: Check AFTER tool results are added.**
 
-3. Parse response:
-   - Extract content from <conversation-summary> tag using extractTextFromTag()
-   - Discard <analysis> block
-
-4. Update state:
-   - Store summary in compactionState
-   - allMessages remains unchanged (append-only for UI)
-
-5. Next API call to primary model:
-   - System prompt: original agent prompt (unchanged)
-   - Messages: [summary message, current user message]
+The current flow has a gap:
+```
+1. createResponse() → validates tokens → sends request
+2. Model returns tool_use
+3. Tool executes → produces result (potentially large)
+4. Result appended to messages  ← TOKENS INCREASE HERE
+5. createResponse() → [MAY OVERFLOW]
 ```
 
-**Post-compaction message structure:**
+**New flow with compaction check:**
+```
+1. createResponse() → sends request
+2. Model returns tool_use + usage stats
+3. Tool executes → produces result
+4. Result appended to messages
+5. CHECK: if (usage.inputTokens + usage.outputTokens > threshold) → compact
+6. createResponse() → now within limits
+```
+
+The check uses the **last response's usage stats** (available from step 2) to predict if we'll overflow, then compacts BEFORE the next API call.
+
+| Provider | Strategy |
+|----------|----------|
+| OpenAI Responses API | Native `/responses/compact` (keep existing) |
+| Anthropic | Client-side (uses Haiku for summaries) |
+| Google GenAI (Gemini) | Client-side (uses Flash Lite for summaries) |
+| DeepSeek | Client-side (same model, no cheaper option) |
+| Kimi (Moonshot) | Client-side (uses moonshot-v1-8k) |
+| OpenAI Chat Completions | Client-side (uses gpt-4.1-mini) |
+
+**Only OpenAI Responses uses native compaction.** All other providers use the same client-side implementation with provider-appropriate cheaper models.
+
+**Post-compaction state (following Anthropic SDK pattern):**
 
 ```
 System prompt: "You are a LaTeX research assistant..."  ← unchanged
 
 Messages: [
-  { role: "user", content: "<conversation-summary>...[summary content]...</conversation-summary>" },
-  { role: "user", content: "[current user request]" }
+  { role: "user", content: "[summary from compactor model]" }
 ]
 ```
 
-For providers supporting developer/system messages in the array (OpenAI), the summary can use `role: "developer"` for clearer separation.
+- Replace ALL messages with a single user message containing the summary
+- System prompt remains unchanged (agent identity preserved)
+- The next user request is appended after the summary message
 
 **Why this is simple:**
-- No streaming — just a single blocking call to the compactor model
-- No message surgery — drop everything, prepend summary
-- System prompt untouched — agent identity preserved
-- Clean handoff — summary becomes context for next turn
+- No streaming — single blocking call to compactor model
+- No message surgery — drop everything, replace with summary
+- Works identically across all providers
 
 ### 4.3 Compaction Model Selection
 

--- a/docs/prd-context-compactization.md
+++ b/docs/prd-context-compactization.md
@@ -97,16 +97,30 @@ Replacing conversation messages with a fake assistant summary message is problem
 - Creates an unnatural message history (assistant "remembering" things it didn't say)
 - Requires complex logic to decide which messages to keep vs. replace
 
-Instead, the approach is:
+Instead, the approach is simple:
 
-1. When `shouldCompact()` returns true and no native strategy is available:
-2. Send the full message history to a **compactor model** with a structured summarization prompt
-3. The compactor returns the summary inside a `<conversation-summary>` XML tag
-4. Parse the summary using the existing `extractTextFromTag()` utility (`src/utils/text/xmlExtraction.ts:55`)
-5. **Drop all old messages**
-6. **Prepend the summary as a message** — the original system prompt remains unchanged
-7. The model receives: `[original system prompt]` + `[summary message, current user message]`
-8. Record compaction metadata (tokens before/after, summary text)
+**Compaction Flow (non-streaming):**
+
+```
+1. Trigger: shouldCompact() returns true (threshold exceeded or manual button)
+
+2. Call compactor model (non-streaming):
+   - System prompt: replaced with COMPACTOR_SYSTEM_PROMPT
+   - Messages: allMessages (full history)
+   - User message: COMPACT_INSTRUCTION
+
+3. Parse response:
+   - Extract content from <conversation-summary> tag using extractTextFromTag()
+   - Discard <analysis> block
+
+4. Update state:
+   - Store summary in compactionState
+   - allMessages remains unchanged (append-only for UI)
+
+5. Next API call to primary model:
+   - System prompt: original agent prompt (unchanged)
+   - Messages: [summary message, current user message]
+```
 
 **Post-compaction message structure:**
 
@@ -121,11 +135,11 @@ Messages: [
 
 For providers supporting developer/system messages in the array (OpenAI), the summary can use `role: "developer"` for clearer separation.
 
-**Why a separate summary message (not injected into system prompt)?**
-- System prompt remains stable — agent identity and instructions don't change
-- No string manipulation or replacement of `<conversation-summary>` blocks needed
-- Clear separation: system prompt = instructions, summary message = context
-- The summary is explicitly "context from previous conversation", not part of core instructions
+**Why this is simple:**
+- No streaming — just a single blocking call to the compactor model
+- No message surgery — drop everything, prepend summary
+- System prompt untouched — agent identity preserved
+- Clean handoff — summary becomes context for next turn
 
 ### 4.3 Compactor Model Selection
 
@@ -246,7 +260,46 @@ and ensuring precision and thoroughness in your response.
 - The `<analysis>` block is discarded — only `<conversation-summary>` content is injected into the system prompt
 - The prompt is stored in `src/agent/modelHandlers/compactionPrompt.ts` so it can be iterated independently
 
-### 4.5 Integration with ModelHandler Base Class
+### 4.5 Current Context Validation (Gap Analysis)
+
+**Where validation currently happens:**
+
+Context overflow is checked in `createResponse()` methods **before each API call**:
+
+```
+modelHandlerAnthropic.ts:620-631   → estimateTokenCount() → validateTokenLimits()
+modelHandlerOpenAI.ts:395-411     → estimateTokenCount() → validateTokenLimits()
+modelHandlerGoogleGenAI.ts:491-503 → estimateTokenCount() → validateTokenLimits()
+modelHandlerOpenAIResponse.ts:994-1003 → estimateTokenCount() → validateTokenLimits()
+```
+
+**Current gap: Tool results can overflow BETWEEN validation and append.**
+
+The tool-use flow is:
+```
+1. createResponse() → validates tokens → sends request
+2. Model returns tool_use
+3. Tool executes → produces result (potentially large)
+4. Result appended to messages
+5. createResponse() → validates tokens → [MIGHT OVERFLOW HERE]
+```
+
+The problem: between steps 4 and 5, the messages array grows with potentially large tool results. If the result pushes total tokens over the context window, step 5 will hard-fail.
+
+**How compaction addresses this:**
+
+With auto-compact enabled, step 5 becomes:
+```
+5. createResponse():
+   a. estimateTokenCount()
+   b. IF tokens > threshold: compactIfNeeded() → summarize → replace messages
+   c. validateTokenLimits() → now passes
+   d. send request
+```
+
+Compaction happens **before validation**, so large tool results trigger compaction rather than failure.
+
+### 4.6 Integration with ModelHandler Base Class
 
 Extend `ModelHandler.ts`:
 
@@ -341,43 +394,141 @@ On each compaction:
 
 **UI display**: The webview renders from `allMessages`, showing the full conversation with a visual divider indicating which messages are "in context" vs "compacted away".
 
-### 4.7 Automatic vs Manual Trigger
+### 4.7 Auto-Compact Toggle (like YOLO mode)
 
-- **Automatic**: Existing threshold-based trigger (`compactionThresholdPercent` setting, default 75%) applies to all strategies
-- **Manual**: Add a command `texra.compactContext` that users can invoke mid-conversation
-  - Useful when users notice the model "forgetting" things
-  - Always uses client-side summarization (gives user full visibility)
+Add an **Auto-Compact toggle button** in the toolbar, following the same pattern as the YOLO mode button (`src/progressView/frontend/constants.ts:154-163`).
+
+**Button definition:**
+
+```typescript
+// In src/progressView/frontend/constants.ts
+const AUTO_COMPACT_TOGGLE_BUTTON = Object.freeze({
+  id: ELEMENT_IDS.AUTO_COMPACT_TOGGLE_BTN,
+  icon: 'fold',                    // collapsed state icon
+  iconActive: 'unfold',            // expanded/active state icon
+  command: COMMANDS.TOGGLE_AUTO_COMPACT,
+  title: 'Enable auto-compact (summarize context when threshold exceeded)',
+  titleActive: 'Auto-compact active - click to disable',
+  className: 'auto-compact-toggle-button',
+  isToggle: true,
+});
+
+// Add to TOOL_USE_TOOLBAR alongside YOLO button
+const TOOL_USE_TOOLBAR = [
+  STOP_STREAM_BUTTON,
+  YOLO_TOGGLE_BUTTON,
+  AUTO_COMPACT_TOGGLE_BUTTON,  // New
+  RESTORE_STATE_BUTTON,
+  { ...OPEN_TASK_STORAGE_BUTTON },
+];
+```
+
+**Behavior:**
+
+| Auto-Compact State | Threshold Exceeded | Action |
+|--------------------|-------------------|--------|
+| OFF | Yes | Hard fail with "context window exceeded" error |
+| ON | Yes | Trigger compaction automatically, then continue |
+| ON | No | Normal operation |
+
+### 4.8 Manual "Compact Now" Button
+
+In addition to the auto-compact toggle, add a **Compact Now** button that immediately triggers compaction when clicked.
+
+**Button definition:**
+
+```typescript
+const COMPACT_NOW_BUTTON = Object.freeze({
+  id: ELEMENT_IDS.COMPACT_NOW_BTN,
+  icon: 'fold-down',
+  command: COMMANDS.COMPACT_NOW,
+  title: 'Compact context now (summarize conversation history)',
+  className: 'compact-now-button',
+});
+
+// Add to TOOL_USE_TOOLBAR
+const TOOL_USE_TOOLBAR = [
+  STOP_STREAM_BUTTON,
+  YOLO_TOGGLE_BUTTON,
+  AUTO_COMPACT_TOGGLE_BUTTON,
+  COMPACT_NOW_BUTTON,  // Active button - always available
+  RESTORE_STATE_BUTTON,
+  { ...OPEN_TASK_STORAGE_BUTTON },
+];
+```
+
+**Behavior:**
+- Enabled when stream is RUNNING, WAITING, or RESUMING
+- Disabled if context utilization is below 10% (wasteful to compact)
+- On click: immediately triggers compaction (non-streaming call to compactor)
+- Shows progress indicator during compaction
+- After completion: logs compaction event, updates context state display
+
+**Why both buttons?**
+- **Auto-Compact Toggle**: Set-and-forget mode for long sessions
+- **Compact Now**: Manual control when user notices model "forgetting" or wants to proactively free context
 
 ## 5. UI Changes
 
-### 5.1 Context Utilization Bar (Progress View)
+### 5.1 Toolbar Buttons (StreamHeader)
 
-**Current state**: The `UsagePanel` shows token counts and "context left" percentage. The `ContextManagement` component shows compaction events in a log format.
+Location: `src/progressView/frontend/components/StreamHeader.ts`
 
-**Proposed changes:**
+**Two new buttons following YOLO pattern:**
 
-1. **Context bar indicator**: Add a visual progress bar showing context utilization (green < 50%, yellow 50-75%, red > 75%)
-2. **Compaction badge**: When compaction has occurred, show a badge with "Compacted" and the compression ratio (e.g., "72K -> 18K tokens")
-3. **Expandable compaction details**: Click the badge to see:
-   - Summary text (for client-side compaction)
-   - Strategy used (clearing / compact / summarization)
-   - What was dropped (tool results count, thinking blocks count)
+1. **Auto-Compact Toggle** (like YOLO):
+   - Toggle button with active/inactive states
+   - Visual glow when active (blue instead of red)
+   - Persisted per-stream
 
-### 5.2 Chat View (Webview)
+2. **Compact Now** (action button):
+   - One-shot action button
+   - Disabled when context utilization < 10%
+   - Shows spinner during compaction
 
-1. **Compaction divider**: Insert a visual divider in the chat when compaction occurs, similar to "older messages cleared" in chat apps
-   - Shows: "Context compacted -- {strategy} -- {tokens freed}"
-   - Collapsed by default; expandable to show summary
-2. **Faded messages**: Messages that were compacted away should appear faded/collapsed above the divider (sourced from `allMessages`)
-   - Users can scroll up to see full history even though the model no longer "sees" it
-   - Clear visual distinction between "in context" and "compacted away"
+**Styling:**
 
-### 5.3 Manual Compact Command
+```css
+.auto-compact-toggle-button {
+  flex-shrink: 0;
+  transition: all 0.2s ease;
+}
 
-- Add button in the chat toolbar (next to existing action buttons)
-- Tooltip: "Compact conversation context"
-- Disabled when utilization is below 25% (compaction would be wasteful)
-- Shows confirmation with estimated token savings before executing
+.auto-compact-toggle-button.is-active {
+  color: var(--color-info);
+  background-color: color-mix(in srgb, var(--color-info) 15%, transparent);
+  border-radius: var(--border-radius);
+  box-shadow: 0 0 8px color-mix(in srgb, var(--color-info) 40%, transparent);
+}
+
+.compact-now-button {
+  flex-shrink: 0;
+}
+
+.compact-now-button:disabled {
+  opacity: 0.5;
+}
+```
+
+### 5.2 Context Utilization Indicator
+
+Add to `UsagePanel` or as a separate component:
+
+1. **Progress bar**: Visual bar showing context utilization
+   - Green: < 50%
+   - Yellow: 50-75%
+   - Red: > 75%
+2. **Compaction badge**: After compaction, show "Compacted: 72K → 18K"
+3. **Expandable details**: Click to see summary text (for client-side compaction)
+
+### 5.3 Chat View Compaction Divider
+
+1. **Visual divider**: When compaction occurs, insert a divider in the message list
+   - Text: "Context compacted — {tokens freed} tokens freed"
+   - Expandable to show summary
+2. **Faded messages**: Messages above the divider appear faded (from `allMessages`)
+   - User can scroll up to see full history
+   - Clear visual distinction: "in context" vs "compacted away"
 
 ## 6. Configuration Summary
 
@@ -390,28 +541,63 @@ On each compaction:
 
 ## 7. Implementation Plan
 
+### Phase 0: Refactor createResponse for Modularity
+
+The `createResponse()` methods in model handlers (especially `modelHandlerAnthropic.ts:580+`) are monolithic, mixing:
+- Parameter building
+- Token counting
+- Context management setup
+- Streaming vs non-streaming logic
+- Response handling
+
+**Proposed refactoring:**
+
+```typescript
+// Extract into composable phases
+class ModelHandlerAnthropic {
+  async createResponse(...) {
+    // Phase 1: Build
+    const params = this.buildRequestParams(messages, options);
+
+    // Phase 2: Count & Validate (optional)
+    const validation = await this.validateContext(params);
+
+    // Phase 3: Compact if needed (NEW)
+    if (validation.shouldCompact && this.autoCompactEnabled) {
+      const compacted = await this.compactContext(messages);
+      params.messages = compacted.messages;
+    }
+
+    // Phase 4: Execute
+    return this.executeRequest(params, options);
+  }
+}
+```
+
+This makes compaction a clean plug-in phase rather than deeply embedded logic.
+
 ### Phase 1: Client-Side Summarization Engine
-- Create `CompactionStrategy` interface and `ClientSideSummarizationStrategy`
-- Create compaction prompt template
-- Add compactor model selection logic
-- Add `allMessages` / `activeMessages` split to message management
-- Wire into `ModelHandler.compactIfNeeded()`
+- Create `ContextCompactor` class in `src/agent/modelHandlers/contextCompaction/`
+- Implement `COMPACTOR_SYSTEM_PROMPT` and `COMPACT_INSTRUCTION` prompts
+- Add `extractTextFromTag()` call for `<conversation-summary>`
+- Add `compactionState` to agent execution state schema
 
-### Phase 2: Integration with OpenAI Chat & Google Handlers
-- Enable auto-compaction for `ModelHandlerOpenAI` and `ModelHandlerGoogleGenAI`
-- Add token counting fallback (character-based heuristic) for providers without native counting
-- Ensure existing Anthropic and OpenAI Responses paths are unaffected
+### Phase 2: Auto-Compact Toggle
+- Add `AUTO_COMPACT_TOGGLE_BTN` to `constants.ts` (following YOLO pattern)
+- Add `TOGGLE_AUTO_COMPACT` command
+- Wire toggle state through `ProgressViewMessageHandler`
+- Persist per-stream (like YOLO state)
 
-### Phase 3: UI -- Compaction Visibility
-- Add context utilization bar to progress view
+### Phase 3: Integration with Handlers
+- Add `compactIfNeeded()` to `ModelHandler` base class
+- Integrate into OpenAI Chat, Google GenAI, DeepSeek, Kimi handlers
+- Ensure Anthropic and OpenAI Responses use their native paths
+
+### Phase 4: UI -- Compaction Visibility
+- Add context utilization bar to `UsagePanel`
 - Add compaction divider to chat webview
-- Implement faded/collapsed messages for compacted history
-- Add compaction badge with expandable details
-
-### Phase 4: Manual Compact Command
-- Register `texra.compactContext` command
-- Add toolbar button to chat view
-- Add confirmation dialog with token savings estimate
+- Implement faded messages for compacted history
+- Add compaction badge with expandable summary
 
 ## 8. Risks and Mitigations
 

--- a/docs/prd-context-compactization.md
+++ b/docs/prd-context-compactization.md
@@ -93,10 +93,11 @@ Instead, the approach is:
 
 1. When `shouldCompact()` returns true and no native strategy is available:
 2. Send the full message history to a **compactor model** with a structured summarization prompt
-3. **Append the summary to the system prompt** as a `<conversation-summary>` section
-4. **Drop old messages**, keeping only the most recent N turns (configurable, default: last 2 user/assistant pairs)
-5. The model now receives: `[system prompt + summary] + [recent messages only]`
-6. Record compaction metadata (tokens before/after, summary text)
+3. The compactor returns the summary inside a `<conversation-summary>` XML tag
+4. **Replace the system prompt**: parse the summary from the XML tag and append it to the original system prompt
+5. **Drop all old messages** -- the summary in the system prompt is now the sole representation of prior context
+6. The model receives: `[system prompt + summary]` + `[only the current user message]`
+7. Record compaction metadata (tokens before/after, summary text)
 
 **Why the system prompt?**
 - All providers support system prompts uniformly
@@ -155,7 +156,8 @@ public async compactIfNeeded(
   // 1. Check threshold via estimateTokenCount()
   // 2. If native strategy exists (Anthropic/OpenAI Responses), defer to it (no-op here)
   // 3. Otherwise: send messages to compactor model → get summary
-  // 4. Return { systemPrompt: systemPrompt + summary, messages: recentOnly, metadata }
+  // 4. Return { systemPrompt: systemPrompt + summary, messages: [], metadata }
+  //    All old messages are dropped; only the current user message will be appended by the caller
 }
 ```
 
@@ -192,14 +194,16 @@ After compaction:
 
 Maintain two representations:
 
-1. **Full history** (`allMessages`): Append-only. Used for UI display and for generating the next compaction summary (so repeated compactions don't lose information through summarization-of-summaries).
-2. **Active messages** (`activeMessages`): The truncated recent messages actually sent to the model alongside the enriched system prompt.
+1. **Full history** (`allMessages`): Append-only. Never sent to the primary model after compaction. Used for:
+   - UI display (so the user can still scroll through the full conversation)
+   - Generating the next compaction summary (avoids lossy summarization-of-summaries)
+2. **Active messages**: Empty after compaction. Only the current user message is sent alongside the enriched system prompt.
 
 On each compaction:
 - `allMessages` remains unchanged (append-only)
-- `activeMessages` is replaced with only the last N turns
-- The system prompt gains/updates a `<conversation-summary>` block
-- On subsequent compactions, the compactor model receives `allMessages` (not `activeMessages`), so it always works from the full history
+- All prior messages are dropped from the API call
+- The system prompt gains/updates a `<conversation-summary>` block parsed from the compactor's XML output
+- On subsequent compactions, the compactor model receives `allMessages` (the full history), so it always works from ground truth
 
 ### 4.7 Automatic vs Manual Trigger
 

--- a/docs/prd-context-compactization.md
+++ b/docs/prd-context-compactization.md
@@ -35,10 +35,11 @@ The [neu-translator](https://github.com/neutree-ai/neu-translator) project uses 
 
 - **Dual message arrays**: `messages` (full history, immutable) and `activeMessages` (working set sent to model)
 - **Dedicated compactor model**: Uses a cheap/fast model (Gemini Flash Lite) to summarize
-- **Structured summary prompt**: Enforces sections (Primary Request, Key Concepts, Errors/Fixes, Pending Tasks, Current Work) to retain critical context
-- **Manual trigger**: Caller decides when to compact, not automatic
+- **Structured summary prompt** (`SYSTEM_COMPACT`): Enforces 8 sections -- primary request, key concepts, errors/resolutions, problem-solving, user messages, outstanding tasks, current work status, next steps. Requires `<analysis>` tags for chronological review before the summary.
+- **Compaction output replaces `activeMessages`** with a single assistant message containing the summary
+- **System prompt is rebuilt each call** via `SYSTEM_WORKFLOW` (incorporating memory + skills), so the model always gets fresh instructions alongside the compacted context
 
-Key takeaway: client-side summarization with a structured prompt is viable and provides full transparency.
+Key takeaway: the **system prompt is the right place** for compacted context. Rather than replacing conversation messages with a fake assistant message (which breaks tool-use chains and feels unnatural), the summary should be injected into the system prompt. The model then receives: `[enriched system prompt with summary] + [only the most recent messages]`. This is simpler, avoids broken message sequences, and works uniformly across all providers.
 
 ## 4. Proposed Design
 
@@ -73,7 +74,7 @@ Key takeaway: client-side summarization with a structured prompt is viable and p
 - No changes. Continue using `/responses/compact` endpoint.
 - Already well-integrated.
 
-#### Strategy 3: Client-Side Summarization (new -- fallback for all providers)
+#### Strategy 3: Client-Side Summarization via System Prompt Injection (new -- fallback for all providers)
 
 This is the new capability, used when:
 - Provider is OpenAI Chat Completions (no native compaction)
@@ -81,13 +82,28 @@ This is the new capability, used when:
 - Provider is any other handler without native support
 - User explicitly requests client-side compaction (override)
 
-**Implementation:**
+**Core insight: inject the summary into the system prompt, not into messages.**
+
+Replacing conversation messages with a fake assistant summary message is problematic:
+- Breaks tool-use call/result pairs (providers validate these sequences)
+- Creates an unnatural message history (assistant "remembering" things it didn't say)
+- Requires complex logic to decide which messages to keep vs. replace
+
+Instead, the approach is:
 
 1. When `shouldCompact()` returns true and no native strategy is available:
-2. Take current `messages` array
-3. Send to a designated **compactor model** (configurable, defaults to a cheap/fast model) with a structured summarization prompt
-4. Replace messages with: `[system_prompt, {role: "assistant", content: summary}]` + any pending user message
-5. Record compaction metadata (tokens before/after, what was summarized)
+2. Send the full message history to a **compactor model** with a structured summarization prompt
+3. **Append the summary to the system prompt** as a `<conversation-summary>` section
+4. **Drop old messages**, keeping only the most recent N turns (configurable, default: last 2 user/assistant pairs)
+5. The model now receives: `[system prompt + summary] + [recent messages only]`
+6. Record compaction metadata (tokens before/after, summary text)
+
+**Why the system prompt?**
+- All providers support system prompts uniformly
+- No message sequence validation issues
+- The model treats it as authoritative context (system > conversation history)
+- Easy to re-summarize: just replace the `<conversation-summary>` section on next compaction
+- Works identically across Anthropic, OpenAI, Google, and any future provider
 
 ### 4.3 Compactor Model Selection
 
@@ -127,34 +143,63 @@ The prompt should be defined in a dedicated file (`src/agent/modelHandlers/compa
 Extend `ModelHandler.ts`:
 
 ```typescript
-// New abstract-optional methods
+// New methods on ModelHandler base class
 protected getCompactionStrategy(): CompactionStrategy | null {
   return null; // Providers override if they have native support
 }
 
-public async compactIfNeeded(messages: Message[]): Promise<CompactionResult> {
-  // 1. Check threshold
-  // 2. Try native strategy first
-  // 3. Fall back to client-side summarization
-  // 4. Log compaction event
-  // 5. Return new messages + metadata
+public async compactIfNeeded(
+  systemPrompt: string,
+  messages: Message[]
+): Promise<CompactionResult> {
+  // 1. Check threshold via estimateTokenCount()
+  // 2. If native strategy exists (Anthropic/OpenAI Responses), defer to it (no-op here)
+  // 3. Otherwise: send messages to compactor model → get summary
+  // 4. Return { systemPrompt: systemPrompt + summary, messages: recentOnly, metadata }
 }
 ```
 
 Each handler overrides `getCompactionStrategy()`:
-- `ModelHandlerAnthropic` → returns `AnthropicClearingStrategy` (existing behavior, no change)
+- `ModelHandlerAnthropic` → returns `AnthropicClearingStrategy` (existing behavior, no change -- compaction handled server-side)
 - `ModelHandlerOpenAIResponse` → returns `OpenAICompactStrategy` (existing behavior, no change)
-- `ModelHandlerOpenAI` → returns `null` (uses client-side fallback)
-- `ModelHandlerGoogleGenAI` → returns `null` (uses client-side fallback)
+- `ModelHandlerOpenAI` → returns `null` → triggers system-prompt summarization
+- `ModelHandlerGoogleGenAI` → returns `null` → triggers system-prompt summarization
+
+**System prompt mutation flow:**
+
+```
+Original system prompt:
+  "You are a LaTeX research assistant..."
+
+After compaction:
+  "You are a LaTeX research assistant...
+
+  <conversation-summary>
+  ## Task Objective
+  User asked to rewrite Section 3 of their paper on quantum error correction...
+
+  ## Current State
+  Completed rewrite of 3.1 and 3.2. Working on 3.3 (stabilizer codes).
+  Last generated text: "The stabilizer formalism provides..."
+
+  ## Pending Work
+  - Complete section 3.3
+  - Add citations for [Gottesman1997] and [Knill2005]
+  </conversation-summary>"
+```
 
 ### 4.6 Message History Preservation
 
-Following neu-translator's pattern, maintain two representations:
+Maintain two representations:
 
-1. **Full history** (`allMessages`): Never modified. Used for display and re-compaction.
-2. **Active context** (`activeMessages`): Sent to the model. Replaced on compaction.
+1. **Full history** (`allMessages`): Append-only. Used for UI display and for generating the next compaction summary (so repeated compactions don't lose information through summarization-of-summaries).
+2. **Active messages** (`activeMessages`): The truncated recent messages actually sent to the model alongside the enriched system prompt.
 
-This is a change from current behavior where messages are mutated in place. The full history must be persisted to the agent execution state so it survives VS Code restarts.
+On each compaction:
+- `allMessages` remains unchanged (append-only)
+- `activeMessages` is replaced with only the last N turns
+- The system prompt gains/updates a `<conversation-summary>` block
+- On subsequent compactions, the compactor model receives `allMessages` (not `activeMessages`), so it always works from the full history
 
 ### 4.7 Automatic vs Manual Trigger
 

--- a/docs/prd-context-compactization.md
+++ b/docs/prd-context-compactization.md
@@ -289,18 +289,37 @@ After compaction:
 
 ### 4.6 Message History Preservation
 
-Maintain two representations:
+**Single source of truth**: `allMessages` is the only persistent message array. There is no separately-maintained "active messages" array that could diverge.
 
-1. **Full history** (`allMessages`): Append-only. Never sent to the primary model after compaction. Used for:
-   - UI display (so the user can still scroll through the full conversation)
-   - Generating the next compaction summary (avoids lossy summarization-of-summaries)
-2. **Active messages**: Empty after compaction. Only the current user message is sent alongside the enriched system prompt.
+**How it works:**
+
+1. `allMessages`: Append-only array containing the full conversation history. This is the sole source of truth, persisted to agent execution state.
+
+2. At each API call, the messages to send are **derived** (not stored separately):
+   - Before compaction: send `allMessages` directly
+   - After compaction: send `[]` (empty) — the summary lives in the system prompt
+
+3. The derivation logic is a pure function:
+   ```typescript
+   function getMessagesToSend(allMessages: Message[], compactionState: CompactionState | null): Message[] {
+     if (compactionState === null) {
+       return allMessages; // No compaction yet — send everything
+     }
+     return []; // Post-compaction — summary is in system prompt, send no history
+   }
+   ```
+
+**Why not a dual-array design?**
+
+Maintaining two arrays (`allMessages` + `activeMessages`) creates an invariant that every append must update both. This is error-prone — any code path that forgets to update both causes silent divergence. By deriving the active set from `allMessages` + compaction state, correctness is guaranteed.
 
 On each compaction:
 - `allMessages` remains unchanged (append-only)
-- All prior messages are dropped from the API call
-- The system prompt gains/updates a `<conversation-summary>` block parsed from the compactor's XML output
-- On subsequent compactions, the compactor model receives `allMessages` (the full history), so it always works from ground truth
+- `compactionState` is updated with the new summary and timestamp
+- The system prompt is rebuilt to include the `<conversation-summary>` block
+- Subsequent compactions re-summarize from `allMessages` (the full history), avoiding lossy summarization-of-summaries
+
+**UI display**: The webview renders from `allMessages`, showing the full conversation with a visual divider indicating which messages are "in context" vs "compacted away".
 
 ### 4.7 Automatic vs Manual Trigger
 

--- a/docs/prd-context-compactization.md
+++ b/docs/prd-context-compactization.md
@@ -10,24 +10,24 @@
 
 TeXRA supports long-running agent conversations (multi-step research, tool-use cycles, reflection loops) that can exhaust a model's context window. Currently, each model handler has its own ad-hoc approach:
 
-- **Anthropic**: Server-side clearing of tool uses and thinking blocks via `context_management` beta parameter
-- **OpenAI Responses API**: Opaque `/responses/compact` endpoint that returns encrypted compacted state
-- **OpenAI Chat / Google GenAI**: No compaction at all -- only dynamic `max_tokens` reduction, which eventually fails when input alone exceeds the window
+- **Anthropic**: Server-side clearing of tool uses and thinking blocks via `context_management` beta parameter (opaque — user can't see what was removed)
+- **OpenAI Responses API**: `/responses/compact` endpoint that works well but returns encrypted compacted state
+- **OpenAI Chat / Google GenAI / DeepSeek / Kimi**: No compaction at all — only dynamic `max_tokens` reduction, which eventually fails when input alone exceeds the window
 
 This creates several issues:
 
 1. **Inconsistent behavior**: Users on Google or OpenAI Chat models hit hard failures that Anthropic/OpenAI Responses users don't
 2. **No user control**: Compaction happens silently; users can't inspect what was dropped or override decisions
-3. **Opaque compaction**: OpenAI's encrypted compaction gives zero visibility into what was preserved
+3. **Opaque compaction**: Both Anthropic's clearing and OpenAI's encrypted compaction give zero visibility into what was preserved
 4. **No client-side fallback**: When provider-side compaction isn't available, there's no fallback strategy
-5. **UI gaps**: The progress view shows compaction *events* but not the *state* of context -- users can't see what the model "remembers"
+5. **UI gaps**: The progress view shows compaction *events* but not the *state* of context — users can't see what the model "remembers"
 
 ## 2. Goals
 
 1. **Universal compaction**: Every model handler gets a compaction path, even if the provider doesn't natively support it
-2. **Layered strategy**: Prefer provider-native compaction when available; fall back to client-side summarization
+2. **Client-side summarization**: Use the same visible summarization approach for all providers except OpenAI Responses API
 3. **User visibility**: Show what was compacted, what remains, and allow manual trigger
-4. **Preserve existing behavior**: Provider-native compaction (Anthropic clearing, OpenAI `/compact`) stays as the primary path for those providers
+4. **OpenAI Responses keeps native**: Only OpenAI Responses API continues using `/responses/compact` (it works well)
 
 ## 3. Reference: neu-translator Approach
 
@@ -54,15 +54,16 @@ Key takeaway: the **system prompt is the right place** for compacted context. Ra
                     │  getCompactionState()│
                     └──────┬───────────────┘
                            │
-              ┌────────────┼────────────────┐
-              ▼            ▼                ▼
-     ┌────────────┐ ┌───────────┐  ┌──────────────┐
-     │ Anthropic   │ │ OpenAI    │  │ Client-Side  │
-     │ Strategy    │ │ Response  │  │ Summarization│
-     │ (clearing)  │ │ Strategy  │  │ Strategy     │
-     │             │ │ (compact) │  │ (fallback)   │
-     └────────────┘ └───────────┘  └──────────────┘
+              ┌────────────┴────────────────┐
+              ▼                             ▼
+     ┌───────────────────┐     ┌──────────────────────┐
+     │ OpenAI Responses  │     │ Client-Side          │
+     │ Strategy          │     │ Summarization        │
+     │ (/compact)        │     │ (all other providers)│
+     └───────────────────┘     └──────────────────────┘
 ```
+
+**Note:** Anthropic's server-side `context_management` (clearing tool uses/thinking blocks) is **not used**. All providers except OpenAI Responses API use client-side summarization for consistent, visible compaction.
 
 ### 4.2 Compaction Strategies
 
@@ -379,13 +380,15 @@ public async compactIfNeeded(
 ```
 
 Each handler overrides `getCompactionStrategy()`:
-- `ModelHandlerAnthropic` → returns `AnthropicClearingStrategy` (existing behavior, no change -- compaction handled server-side)
-- `ModelHandlerOpenAIResponse` → returns `OpenAICompactStrategy` (existing behavior, no change)
-- `ModelHandlerOpenAI` → returns `null` → triggers system-prompt summarization
-- `ModelHandlerGoogleGenAI` → returns `null` → triggers system-prompt summarization
-- `ModelHandlerDeepSeek` → returns `null` → triggers system-prompt summarization
-- `ModelHandlerKimi` → returns `null` → triggers system-prompt summarization
+- `ModelHandlerOpenAIResponse` → returns `OpenAICompactStrategy` (existing `/responses/compact` endpoint)
+- `ModelHandlerAnthropic` → returns `null` → triggers client-side summarization
+- `ModelHandlerOpenAI` → returns `null` → triggers client-side summarization
+- `ModelHandlerGoogleGenAI` → returns `null` → triggers client-side summarization
+- `ModelHandlerDeepSeek` → returns `null` → triggers client-side summarization
+- `ModelHandlerKimi` → returns `null` → triggers client-side summarization
 - Any new handler → returns `null` by default (safe fallback)
+
+**Why not use Anthropic's `context_management`?** The server-side clearing (removing tool uses and thinking blocks) is opaque and loses context. Client-side summarization preserves the conversation summary visibly in the message history, giving users transparency into what the model "remembers".
 
 **Example post-compaction API call:**
 
@@ -655,9 +658,9 @@ This makes compaction a clean plug-in phase rather than deeply embedded logic.
 
 ## 9. Success Metrics
 
-- Users on Google/OpenAI Chat models can run conversations 3x longer before hitting context errors
+- Users on Anthropic/Google/OpenAI Chat models can run conversations 3x longer before hitting context errors
 - Compaction events are visible in UI with < 2 clicks
-- No regression in Anthropic or OpenAI Responses compaction behavior
+- No regression in OpenAI Responses compaction behavior
 - Client-side summarization completes in < 5 seconds with the default compactor model
 
 ## 10. Out of Scope
@@ -665,3 +668,21 @@ This makes compaction a clean plug-in phase rather than deeply embedded logic.
 - Cross-session memory / persistent knowledge base (like neu-translator's `Memory` class)
 - Automatic prompt optimization / compression (token-level compression)
 - Streaming compaction (compacting while the model is still generating)
+
+## 11. Implementation Progress
+
+### Completed
+
+- **Token count check after tool results** (2026-02-03): Added token count logging in `ToolUseDispatchNode.post()` at `src/agent/core/flows/ToolUseCycleFlow.ts:778-794`. This logs context utilization after tool results are attached and before the next `createResponse()`, giving visibility into token usage and setting up for compaction trigger.
+
+### In Progress
+
+- PRD finalization and review
+
+### Pending
+
+- Phase 0: Refactor createResponse for modularity
+- Phase 1: Client-side summarization engine
+- Phase 2: Auto-compact toggle
+- Phase 3: Integration with handlers
+- Phase 4: UI — compaction visibility

--- a/docs/prd-context-compactization.md
+++ b/docs/prd-context-compactization.md
@@ -1,0 +1,252 @@
+# PRD: Context Window Compactization
+
+## Status: Draft
+## Author: Claude
+## Date: 2026-02-02
+
+---
+
+## 1. Problem Statement
+
+TeXRA supports long-running agent conversations (multi-step research, tool-use cycles, reflection loops) that can exhaust a model's context window. Currently, each model handler has its own ad-hoc approach:
+
+- **Anthropic**: Server-side clearing of tool uses and thinking blocks via `context_management` beta parameter
+- **OpenAI Responses API**: Opaque `/responses/compact` endpoint that returns encrypted compacted state
+- **OpenAI Chat / Google GenAI**: No compaction at all -- only dynamic `max_tokens` reduction, which eventually fails when input alone exceeds the window
+
+This creates several issues:
+
+1. **Inconsistent behavior**: Users on Google or OpenAI Chat models hit hard failures that Anthropic/OpenAI Responses users don't
+2. **No user control**: Compaction happens silently; users can't inspect what was dropped or override decisions
+3. **Opaque compaction**: OpenAI's encrypted compaction gives zero visibility into what was preserved
+4. **No client-side fallback**: When provider-side compaction isn't available, there's no fallback strategy
+5. **UI gaps**: The progress view shows compaction *events* but not the *state* of context -- users can't see what the model "remembers"
+
+## 2. Goals
+
+1. **Universal compaction**: Every model handler gets a compaction path, even if the provider doesn't natively support it
+2. **Layered strategy**: Prefer provider-native compaction when available; fall back to client-side summarization
+3. **User visibility**: Show what was compacted, what remains, and allow manual trigger
+4. **Preserve existing behavior**: Provider-native compaction (Anthropic clearing, OpenAI `/compact`) stays as the primary path for those providers
+
+## 3. Reference: neu-translator Approach
+
+The [neu-translator](https://github.com/neutree-ai/neu-translator) project uses a clean client-side compaction design:
+
+- **Dual message arrays**: `messages` (full history, immutable) and `activeMessages` (working set sent to model)
+- **Dedicated compactor model**: Uses a cheap/fast model (Gemini Flash Lite) to summarize
+- **Structured summary prompt**: Enforces sections (Primary Request, Key Concepts, Errors/Fixes, Pending Tasks, Current Work) to retain critical context
+- **Manual trigger**: Caller decides when to compact, not automatic
+
+Key takeaway: client-side summarization with a structured prompt is viable and provides full transparency.
+
+## 4. Proposed Design
+
+### 4.1 Architecture
+
+```
+                    ┌──────────────────────┐
+                    │   CompactionManager   │  (new, in src/agent/modelHandlers/)
+                    │                      │
+                    │  shouldCompact()     │
+                    │  compact()           │
+                    │  getCompactionState()│
+                    └──────┬───────────────┘
+                           │
+              ┌────────────┼────────────────┐
+              ▼            ▼                ▼
+     ┌────────────┐ ┌───────────┐  ┌──────────────┐
+     │ Anthropic   │ │ OpenAI    │  │ Client-Side  │
+     │ Strategy    │ │ Response  │  │ Summarization│
+     │ (clearing)  │ │ Strategy  │  │ Strategy     │
+     │             │ │ (compact) │  │ (fallback)   │
+     └────────────┘ └───────────┘  └──────────────┘
+```
+
+### 4.2 Compaction Strategies
+
+#### Strategy 1: Anthropic Server-Side Clearing (existing)
+- No changes. Continue using `context_management` parameter with `clear_tool_uses` and `clear_thinking`.
+- Already well-integrated.
+
+#### Strategy 2: OpenAI Responses API Compaction (existing)
+- No changes. Continue using `/responses/compact` endpoint.
+- Already well-integrated.
+
+#### Strategy 3: Client-Side Summarization (new -- fallback for all providers)
+
+This is the new capability, used when:
+- Provider is OpenAI Chat Completions (no native compaction)
+- Provider is Google GenAI (no native compaction)
+- Provider is any other handler without native support
+- User explicitly requests client-side compaction (override)
+
+**Implementation:**
+
+1. When `shouldCompact()` returns true and no native strategy is available:
+2. Take current `messages` array
+3. Send to a designated **compactor model** (configurable, defaults to a cheap/fast model) with a structured summarization prompt
+4. Replace messages with: `[system_prompt, {role: "assistant", content: summary}]` + any pending user message
+5. Record compaction metadata (tokens before/after, what was summarized)
+
+### 4.3 Compactor Model Selection
+
+Add a new configuration:
+
+```json
+"texra.model.compactorModel": {
+  "type": "string",
+  "default": "auto",
+  "description": "Model used for client-side context summarization. 'auto' uses the cheapest available model from the active provider, or 'same' uses the current model."
+}
+```
+
+**"auto" resolution order:**
+1. If Anthropic key available: `claude-haiku-4-0`
+2. If OpenAI key available: `gpt-4.1-mini`
+3. If Google key available: `gemini-2.5-flash-lite`
+4. Fall back to current model
+
+### 4.4 Structured Summary Prompt
+
+The compaction prompt must preserve:
+
+| Section | Purpose |
+|---------|---------|
+| **Task Objective** | Original user request and constraints |
+| **Key Decisions** | Important choices made during execution |
+| **Tool Results Summary** | Condensed results from tool calls (file contents, search results) |
+| **Errors & Corrections** | What went wrong and how it was fixed |
+| **Current State** | Exact point of progress, including verbatim code/text being worked on |
+| **Pending Work** | What still needs to be done |
+
+The prompt should be defined in a dedicated file (`src/agent/modelHandlers/compactionPrompt.ts`) so it can be iterated on independently.
+
+### 4.5 Integration with ModelHandler Base Class
+
+Extend `ModelHandler.ts`:
+
+```typescript
+// New abstract-optional methods
+protected getCompactionStrategy(): CompactionStrategy | null {
+  return null; // Providers override if they have native support
+}
+
+public async compactIfNeeded(messages: Message[]): Promise<CompactionResult> {
+  // 1. Check threshold
+  // 2. Try native strategy first
+  // 3. Fall back to client-side summarization
+  // 4. Log compaction event
+  // 5. Return new messages + metadata
+}
+```
+
+Each handler overrides `getCompactionStrategy()`:
+- `ModelHandlerAnthropic` → returns `AnthropicClearingStrategy` (existing behavior, no change)
+- `ModelHandlerOpenAIResponse` → returns `OpenAICompactStrategy` (existing behavior, no change)
+- `ModelHandlerOpenAI` → returns `null` (uses client-side fallback)
+- `ModelHandlerGoogleGenAI` → returns `null` (uses client-side fallback)
+
+### 4.6 Message History Preservation
+
+Following neu-translator's pattern, maintain two representations:
+
+1. **Full history** (`allMessages`): Never modified. Used for display and re-compaction.
+2. **Active context** (`activeMessages`): Sent to the model. Replaced on compaction.
+
+This is a change from current behavior where messages are mutated in place. The full history must be persisted to the agent execution state so it survives VS Code restarts.
+
+### 4.7 Automatic vs Manual Trigger
+
+- **Automatic**: Existing threshold-based trigger (`compactionThresholdPercent` setting, default 75%) applies to all strategies
+- **Manual**: Add a command `texra.compactContext` that users can invoke mid-conversation
+  - Useful when users notice the model "forgetting" things
+  - Always uses client-side summarization (gives user full visibility)
+
+## 5. UI Changes
+
+### 5.1 Context Utilization Bar (Progress View)
+
+**Current state**: The `UsagePanel` shows token counts and "context left" percentage. The `ContextManagement` component shows compaction events in a log format.
+
+**Proposed changes:**
+
+1. **Context bar indicator**: Add a visual progress bar showing context utilization (green < 50%, yellow 50-75%, red > 75%)
+2. **Compaction badge**: When compaction has occurred, show a badge with "Compacted" and the compression ratio (e.g., "72K -> 18K tokens")
+3. **Expandable compaction details**: Click the badge to see:
+   - Summary text (for client-side compaction)
+   - Strategy used (clearing / compact / summarization)
+   - What was dropped (tool results count, thinking blocks count)
+
+### 5.2 Chat View (Webview)
+
+1. **Compaction divider**: Insert a visual divider in the chat when compaction occurs, similar to "older messages cleared" in chat apps
+   - Shows: "Context compacted -- {strategy} -- {tokens freed}"
+   - Collapsed by default; expandable to show summary
+2. **Faded messages**: Messages that were compacted away should appear faded/collapsed above the divider (sourced from `allMessages`)
+   - Users can scroll up to see full history even though the model no longer "sees" it
+   - Clear visual distinction between "in context" and "compacted away"
+
+### 5.3 Manual Compact Command
+
+- Add button in the chat toolbar (next to existing action buttons)
+- Tooltip: "Compact conversation context"
+- Disabled when utilization is below 25% (compaction would be wasteful)
+- Shows confirmation with estimated token savings before executing
+
+## 6. Configuration Summary
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `texra.model.compactionThresholdPercent` | number | 75 | Existing. Threshold for auto-compaction. 0 = disabled. |
+| `texra.model.compactorModel` | string | "auto" | New. Model for client-side summarization. |
+| `texra.model.enableClientSideCompaction` | boolean | true | New. Enable client-side fallback when native compaction unavailable. |
+| `texra.model.enableThinkingClearing` | boolean | false | Existing. Anthropic thinking block clearing. |
+
+## 7. Implementation Plan
+
+### Phase 1: Client-Side Summarization Engine
+- Create `CompactionStrategy` interface and `ClientSideSummarizationStrategy`
+- Create compaction prompt template
+- Add compactor model selection logic
+- Add `allMessages` / `activeMessages` split to message management
+- Wire into `ModelHandler.compactIfNeeded()`
+
+### Phase 2: Integration with OpenAI Chat & Google Handlers
+- Enable auto-compaction for `ModelHandlerOpenAI` and `ModelHandlerGoogleGenAI`
+- Add token counting fallback (character-based heuristic) for providers without native counting
+- Ensure existing Anthropic and OpenAI Responses paths are unaffected
+
+### Phase 3: UI -- Compaction Visibility
+- Add context utilization bar to progress view
+- Add compaction divider to chat webview
+- Implement faded/collapsed messages for compacted history
+- Add compaction badge with expandable details
+
+### Phase 4: Manual Compact Command
+- Register `texra.compactContext` command
+- Add toolbar button to chat view
+- Add confirmation dialog with token savings estimate
+
+## 8. Risks and Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Client-side summary loses critical context | Structured prompt with mandatory sections; user can scroll up to see full history |
+| Compactor model call adds latency | Use cheapest/fastest available model; run async before next request |
+| Compactor model unavailable (no API key) | Fall back to naive truncation (drop oldest tool results first) |
+| Double-compaction (native + client-side) | Strategy selection is exclusive -- never both |
+| `allMessages` grows unbounded in memory | Cap at ~500 messages; beyond that, persist to disk and load on demand |
+
+## 9. Success Metrics
+
+- Users on Google/OpenAI Chat models can run conversations 3x longer before hitting context errors
+- Compaction events are visible in UI with < 2 clicks
+- No regression in Anthropic or OpenAI Responses compaction behavior
+- Client-side summarization completes in < 5 seconds with the default compactor model
+
+## 10. Out of Scope
+
+- Cross-session memory / persistent knowledge base (like neu-translator's `Memory` class)
+- Automatic prompt optimization / compression (token-level compression)
+- Streaming compaction (compacting while the model is still generating)

--- a/docs/prd-context-compactization.md
+++ b/docs/prd-context-compactization.md
@@ -102,17 +102,30 @@ Instead, the approach is:
 1. When `shouldCompact()` returns true and no native strategy is available:
 2. Send the full message history to a **compactor model** with a structured summarization prompt
 3. The compactor returns the summary inside a `<conversation-summary>` XML tag
-4. **Replace the system prompt**: parse the summary using the existing `extractTextFromTag()` utility (`src/utils/text/xmlExtraction.ts:55`) and append it to the original system prompt. This is the same extraction pattern already used for `<revised>`, `<scratchpad>`, and `<document>` tags throughout the agent output pipeline.
-5. **Drop all old messages** -- the summary in the system prompt is now the sole representation of prior context
-6. The model receives: `[system prompt + summary]` + `[only the current user message]`
-7. Record compaction metadata (tokens before/after, summary text)
+4. Parse the summary using the existing `extractTextFromTag()` utility (`src/utils/text/xmlExtraction.ts:55`)
+5. **Drop all old messages**
+6. **Prepend the summary as a message** — the original system prompt remains unchanged
+7. The model receives: `[original system prompt]` + `[summary message, current user message]`
+8. Record compaction metadata (tokens before/after, summary text)
 
-**Why the system prompt?**
-- All providers support system prompts uniformly
-- No message sequence validation issues
-- The model treats it as authoritative context (system > conversation history)
-- Easy to re-summarize: just replace the `<conversation-summary>` section on next compaction
-- Works identically across Anthropic, OpenAI, Google, and any future provider
+**Post-compaction message structure:**
+
+```
+System prompt: "You are a LaTeX research assistant..."  ← unchanged
+
+Messages: [
+  { role: "user", content: "<conversation-summary>...[summary content]...</conversation-summary>" },
+  { role: "user", content: "[current user request]" }
+]
+```
+
+For providers supporting developer/system messages in the array (OpenAI), the summary can use `role: "developer"` for clearer separation.
+
+**Why a separate summary message (not injected into system prompt)?**
+- System prompt remains stable — agent identity and instructions don't change
+- No string manipulation or replacement of `<conversation-summary>` blocks needed
+- Clear separation: system prompt = instructions, summary message = context
+- The summary is explicitly "context from previous conversation", not part of core instructions
 
 ### 4.3 Compactor Model Selection
 
@@ -264,27 +277,29 @@ Each handler overrides `getCompactionStrategy()`:
 - `ModelHandlerKimi` → returns `null` → triggers system-prompt summarization
 - Any new handler → returns `null` by default (safe fallback)
 
-**System prompt mutation flow:**
+**Example post-compaction API call:**
 
 ```
-Original system prompt:
-  "You are a LaTeX research assistant..."
+System prompt (unchanged):
+  "You are a LaTeX research assistant. Help the user with their academic writing..."
 
-After compaction:
-  "You are a LaTeX research assistant...
-
-  <conversation-summary>
-  ## Task Objective
-  User asked to rewrite Section 3 of their paper on quantum error correction...
-
-  ## Current State
-  Completed rewrite of 3.1 and 3.2. Working on 3.3 (stabilizer codes).
-  Last generated text: "The stabilizer formalism provides..."
-
-  ## Pending Work
-  - Complete section 3.3
-  - Add citations for [Gottesman1997] and [Knill2005]
-  </conversation-summary>"
+Messages array:
+  [
+    {
+      role: "user",
+      content: "<conversation-summary>
+        1. Primary Request: Rewrite Section 3 on quantum error correction
+        2. Key Concepts: stabilizer codes, Gottesman-Knill theorem
+        3. Errors and fixes: Fixed citation format per user feedback
+        4. Current Work: Completed 3.1 and 3.2, working on 3.3
+        5. Pending Tasks: Complete 3.3, add citations [Gottesman1997], [Knill2005]
+        </conversation-summary>"
+    },
+    {
+      role: "user",
+      content: "Continue with section 3.3 on stabilizer codes"
+    }
+  ]
 ```
 
 ### 4.6 Message History Preservation
@@ -297,7 +312,7 @@ After compaction:
 
 2. At each API call, the messages to send are **derived** (not stored separately):
    - Before compaction: send `allMessages` directly
-   - After compaction: send `[]` (empty) — the summary lives in the system prompt
+   - After compaction: send `[summary message]` — old messages are dropped, summary provides context
 
 3. The derivation logic is a pure function:
    ```typescript
@@ -305,7 +320,12 @@ After compaction:
      if (compactionState === null) {
        return allMessages; // No compaction yet — send everything
      }
-     return []; // Post-compaction — summary is in system prompt, send no history
+     // Post-compaction — return only the summary message
+     // The current user message is appended by the caller
+     return [{
+       role: 'user', // or 'developer' for OpenAI
+       content: `<conversation-summary>${compactionState.summary}</conversation-summary>`
+     }];
    }
    ```
 
@@ -316,7 +336,7 @@ Maintaining two arrays (`allMessages` + `activeMessages`) creates an invariant t
 On each compaction:
 - `allMessages` remains unchanged (append-only)
 - `compactionState` is updated with the new summary and timestamp
-- The system prompt is rebuilt to include the `<conversation-summary>` block
+- The system prompt remains unchanged — summary is prepended as a message
 - Subsequent compactions re-summarize from `allMessages` (the full history), avoiding lossy summarization-of-summaries
 
 **UI display**: The webview renders from `allMessages`, showing the full conversation with a visual divider indicating which messages are "in context" vs "compacted away".

--- a/docs/prd-context-compactization.md
+++ b/docs/prd-context-compactization.md
@@ -117,7 +117,7 @@ async function checkAndCompact(
 }
 ```
 
-**Key change: Check AFTER tool results are added.**
+**Key change: Check AFTER tool results are added, BEFORE next createResponse.**
 
 The current flow has a gap:
 ```
@@ -128,17 +128,46 @@ The current flow has a gap:
 5. createResponse() → [MAY OVERFLOW]
 ```
 
-**New flow with compaction check:**
+**New flow with token count check:**
 ```
 1. createResponse() → sends request
 2. Model returns tool_use + usage stats
 3. Tool executes → produces result
 4. Result appended to messages
-5. CHECK: if (usage.inputTokens + usage.outputTokens > threshold) → compact
-6. createResponse() → now within limits
+5. TOKEN COUNT CHECK  ← NEW
+6. If exceeds threshold → compact
+7. createResponse() → now within limits
 ```
 
-The check uses the **last response's usage stats** (available from step 2) to predict if we'll overflow, then compacts BEFORE the next API call.
+**Insertion point:** `ToolUseDispatchNode.post()` in `src/agent/core/flows/ToolUseCycleFlow.ts:764`
+
+```typescript
+// In ToolUseDispatchNode.post(), after line 764 (after all follow-up messages pushed)
+// and before line 778 (return FlowTransition.CONTINUE)
+
+// NEW: Token count check after tool results attached
+const tokenCount = await services.modelHandler.estimateTokenCount(shared.messages);
+const threshold = getCompactionThreshold(services.modelHandler.config.contextWindow);
+
+this.logger.logContextState({
+  inputTokens: tokenCount,
+  contextWindow: services.modelHandler.config.contextWindow,
+  utilizationPercent: (tokenCount / services.modelHandler.config.contextWindow) * 100,
+});
+
+if (tokenCount > threshold) {
+  // Trigger compaction before next createResponse
+  const compactionResult = await checkAndCompact(shared.messages, tokenCount, threshold, ...);
+  if (compactionResult.compacted) {
+    shared.messages = compactionResult.newMessages;
+    this.logger.logContextManagement('Context compacted', { ... });
+  }
+}
+
+return FlowTransition.CONTINUE;
+```
+
+This gives visibility into token count right after tool results are attached, and allows compaction before the next API call.
 
 | Provider | Strategy |
 |----------|----------|

--- a/docs/prd-context-compactization.md
+++ b/docs/prd-context-compactization.md
@@ -66,10 +66,29 @@ Key takeaway: the **system prompt is the right place** for compacted context. Ra
 
 ### 4.2 Compaction Strategies
 
-#### Strategy 1: Anthropic Server-Side Clearing (existing, not ideal)
-- Continue using `context_management` parameter with `clear_tool_uses` and `clear_thinking`.
-- **Limitation**: Clearing is lossy — tool results and thinking blocks are simply dropped, not summarized. The model loses access to specific details that might be needed later.
-- Consider offering client-side summarization as an optional override for Anthropic users who want better context preservation.
+#### Strategy 1: Anthropic SDK Compaction (preferred for Anthropic)
+
+The Anthropic SDK now supports `compactionControl` in `toolRunner`, which is better than raw `context_management` clearing:
+
+```typescript
+const runner = client.beta.messages.toolRunner({
+  model: 'claude-sonnet-4-5',
+  max_tokens: 4096,
+  tools: [...],
+  messages: [...],
+  compactionControl: {
+    enabled: true,
+    contextTokenThreshold: 100000,
+    model: 'claude-haiku-4-5'  // Use cheaper model for summaries
+  }
+});
+```
+
+- **Uses `<summary>` tags** — same pattern as our client-side approach
+- **Configurable summary model** — can use Haiku for cheaper/faster summaries
+- **Built-in summary prompt** — structured (Task Overview, Current State, Discoveries, Next Steps, Context to Preserve)
+
+This replaces the lossy `context_management` clearing approach. The SDK handles compaction automatically.
 
 #### Strategy 2: OpenAI Responses API Compaction (existing, works well)
 - Continue using `/responses/compact` endpoint.
@@ -81,15 +100,15 @@ This is the new capability. It covers all providers that lack a native compactio
 
 | Provider | Native Compaction | Needs Client-Side |
 |----------|------------------|-------------------|
-| Anthropic | Server-side clearing (`context_management`) | No (but available as optional override) |
-| OpenAI Responses API | `/responses/compact` endpoint | No (but available as optional override) |
+| Anthropic | SDK `compactionControl` (uses Haiku for summaries) | No |
+| OpenAI Responses API | `/responses/compact` endpoint | No |
 | OpenAI Chat Completions | None | **Yes** |
 | Google GenAI (Gemini) | None | **Yes** |
 | DeepSeek | None | **Yes** |
 | Kimi (Moonshot) | None | **Yes** |
 | Any future provider | None by default | **Yes** |
 
-This makes client-side summarization the **default compaction strategy** for the majority of providers. Only Anthropic and OpenAI Responses have native paths.
+Client-side summarization is the **fallback** for providers without native compaction. Anthropic and OpenAI Responses have native paths that work well.
 
 **Core insight: inject the summary into the system prompt, not into messages.**
 
@@ -142,23 +161,38 @@ For providers supporting developer/system messages in the array (OpenAI), the su
 - System prompt untouched — agent identity preserved
 - Clean handoff — summary becomes context for next turn
 
-### 4.3 Compactor Model Selection
+### 4.3 Compaction Model Selection
 
-Add a new configuration:
+Add a new configuration (named `compactionModel` for consistency with `compactionThresholdPercent`):
 
 ```json
-"texra.model.compactorModel": {
+"texra.model.compactionModel": {
   "type": "string",
   "default": "auto",
-  "description": "Model used for client-side context summarization. 'auto' uses the cheapest available model from the active provider, or 'same' uses the current model."
+  "description": "Model used for context summarization. 'auto' uses the cheapest model from the same provider family."
 }
 ```
 
-**"auto" resolution order:**
-1. If Anthropic key available: `claude-haiku-4-0`
-2. If OpenAI key available: `gpt-4.1-mini`
-3. If Google key available: `gemini-2.5-flash-lite`
-4. Fall back to current model
+**"auto" resolution — get cheapest model from same provider family:**
+
+| Primary Model | Compaction Model |
+|--------------|------------------|
+| `claude-sonnet-4-5`, `claude-opus-4-5` | `claude-haiku-4-5` |
+| `gpt-4.1`, `gpt-4o` | `gpt-4.1-mini` |
+| `gemini-2.5-pro` | `gemini-2.5-flash-lite` |
+| `deepseek-chat`, `deepseek-reasoner` | `deepseek-chat` (no cheaper option) |
+| `moonshot-v1-*` | `moonshot-v1-8k` |
+
+This uses the same provider (same API key, same base URL for OpenRouter), just the cheapest model in that family.
+
+**Implementation:**
+
+```typescript
+function getCheapestModelInFamily(modelId: string): string {
+  const family = getModelFamily(modelId);  // e.g., "anthropic", "openai", "google"
+  return CHEAPEST_MODEL_BY_FAMILY[family] ?? modelId;
+}
+```
 
 ### 4.4 Structured Summary Prompt
 
@@ -526,8 +560,8 @@ Existing `UsagePanel` already shows token counts. After compaction, show "Compac
 | Setting | Type | Default | Description |
 |---------|------|---------|-------------|
 | `texra.model.compactionThresholdPercent` | number | 75 | Existing. Threshold for auto-compaction. 0 = disabled. |
-| `texra.model.compactorModel` | string | "auto" | New. Model for client-side summarization. |
-| `texra.model.enableThinkingClearing` | boolean | false | Existing. Anthropic thinking block clearing. |
+| `texra.model.compactionModel` | string | "auto" | New. Model for summarization. "auto" = cheapest in same provider family. |
+| `texra.model.enableThinkingClearing` | boolean | false | Existing. Anthropic thinking block clearing (deprecated — use SDK compaction instead). |
 
 ## 7. Implementation Plan
 

--- a/docs/prd-context-compactization.md
+++ b/docs/prd-context-compactization.md
@@ -433,58 +433,65 @@ const TOOL_USE_TOOLBAR = [
 
 ### 4.8 Manual "Compact Now" Button
 
-In addition to the auto-compact toggle, add a **Compact Now** button that immediately triggers compaction when clicked.
+In addition to the auto-compact toggle in the toolbar, add a **Compact Now** button in the **follow-up input section** alongside the existing action buttons (Polish, Record, Clear, Send).
+
+**Location:** `src/progressView/frontend/components/FollowUpInput.ts:196-237`
+
+The follow-up input has a vertical action column:
+```
+┌─────────────────────────────────────────┐
+│ [Textarea]            │ [Polish]        │
+│                       │ [Record]        │
+│                       │ [Clear]         │
+│                       │ [Compact] ← NEW │
+│                       │ [Send]          │
+└─────────────────────────────────────────┘
+```
 
 **Button definition:**
 
 ```typescript
-const COMPACT_NOW_BUTTON = Object.freeze({
-  id: ELEMENT_IDS.COMPACT_NOW_BTN,
-  icon: 'fold-down',
-  command: COMMANDS.COMPACT_NOW,
-  title: 'Compact context now (summarize conversation history)',
-  className: 'compact-now-button',
-});
-
-// Add to TOOL_USE_TOOLBAR
-const TOOL_USE_TOOLBAR = [
-  STOP_STREAM_BUTTON,
-  YOLO_TOGGLE_BUTTON,
-  AUTO_COMPACT_TOGGLE_BUTTON,
-  COMPACT_NOW_BUTTON,  // Active button - always available
-  RESTORE_STATE_BUTTON,
-  { ...OPEN_TASK_STORAGE_BUTTON },
-];
+// In FollowUpInput.ts render() method, add to .follow-up-actions
+<vscode-toolbar-button
+  id=${ELEMENT_IDS.COMPACT_NOW_BTN}
+  icon="fold-down"
+  label="Compact context"
+  title="Compact conversation context (summarize history to free tokens)"
+  ?disabled=${!this.canCompact}
+  @click=${this.emitCompact}
+></vscode-toolbar-button>
 ```
 
 **Behavior:**
-- Enabled when stream is RUNNING, WAITING, or RESUMING
+- Visible when stream is in tool-use mode (not workflow)
 - Disabled if context utilization is below 10% (wasteful to compact)
-- On click: immediately triggers compaction (non-streaming call to compactor)
-- Shows progress indicator during compaction
+- On click: dispatches `COMPACT_NOW` command
+- Shows progress ring during compaction (like Polish button)
 - After completion: logs compaction event, updates context state display
 
-**Why both buttons?**
-- **Auto-Compact Toggle**: Set-and-forget mode for long sessions
-- **Compact Now**: Manual control when user notices model "forgetting" or wants to proactively free context
+**State management:**
+```typescript
+@property({ type: Boolean }) canCompact = false;  // From context utilization > 10%
+@state() private compacting = false;              // Shows progress ring
+```
+
+**Why in follow-up input area?**
+- User is actively chatting → compaction is a chat-related action
+- Follows the existing pattern (Polish, Record, Clear, Send are all chat actions)
+- Auto-compact toggle stays in toolbar (system-level setting)
+- Compact Now is contextual to the current input
 
 ## 5. UI Changes
 
-### 5.1 Toolbar Buttons (StreamHeader)
+### 5.1 Auto-Compact Toggle Button (StreamHeader Toolbar)
 
 Location: `src/progressView/frontend/components/StreamHeader.ts`
 
-**Two new buttons following YOLO pattern:**
-
-1. **Auto-Compact Toggle** (like YOLO):
-   - Toggle button with active/inactive states
-   - Visual glow when active (blue instead of red)
-   - Persisted per-stream
-
-2. **Compact Now** (action button):
-   - One-shot action button
-   - Disabled when context utilization < 10%
-   - Shows spinner during compaction
+**Single new toggle button** (like YOLO):
+- Toggle button with active/inactive states
+- Visual glow when active (blue instead of red)
+- Persisted per-stream
+- Located in toolbar next to YOLO toggle
 
 **Styling:**
 
@@ -500,17 +507,15 @@ Location: `src/progressView/frontend/components/StreamHeader.ts`
   border-radius: var(--border-radius);
   box-shadow: 0 0 8px color-mix(in srgb, var(--color-info) 40%, transparent);
 }
-
-.compact-now-button {
-  flex-shrink: 0;
-}
-
-.compact-now-button:disabled {
-  opacity: 0.5;
-}
 ```
 
-### 5.2 Context Utilization Indicator
+### 5.2 Compact Now Button (FollowUpInput)
+
+Location: `src/progressView/frontend/components/FollowUpInput.ts`
+
+Added to the vertical action column alongside Polish, Record, Clear, Send. See section 4.8 for details.
+
+### 5.3 Context Utilization Indicator
 
 Add to `UsagePanel` or as a separate component:
 
@@ -521,7 +526,7 @@ Add to `UsagePanel` or as a separate component:
 2. **Compaction badge**: After compaction, show "Compacted: 72K → 18K"
 3. **Expandable details**: Click to see summary text (for client-side compaction)
 
-### 5.3 Chat View Compaction Divider
+### 5.4 Chat View Compaction Divider
 
 1. **Visual divider**: When compaction occurs, insert a divider in the message list
    - Text: "Context compacted — {tokens freed} tokens freed"

--- a/docs/prd-context-compactization.md
+++ b/docs/prd-context-compactization.md
@@ -76,11 +76,19 @@ Key takeaway: the **system prompt is the right place** for compacted context. Ra
 
 #### Strategy 3: Client-Side Summarization via System Prompt Injection (new -- fallback for all providers)
 
-This is the new capability, used when:
-- Provider is OpenAI Chat Completions (no native compaction)
-- Provider is Google GenAI (no native compaction)
-- Provider is any other handler without native support
-- User explicitly requests client-side compaction (override)
+This is the new capability. It covers all providers that lack a native compaction API:
+
+| Provider | Native Compaction | Needs Client-Side |
+|----------|------------------|-------------------|
+| Anthropic | Server-side clearing (`context_management`) | No (but available as optional override) |
+| OpenAI Responses API | `/responses/compact` endpoint | No (but available as optional override) |
+| OpenAI Chat Completions | None | **Yes** |
+| Google GenAI (Gemini) | None | **Yes** |
+| DeepSeek | None | **Yes** |
+| Kimi (Moonshot) | None | **Yes** |
+| Any future provider | None by default | **Yes** |
+
+This makes client-side summarization the **default compaction strategy** for the majority of providers. Only Anthropic and OpenAI Responses have native paths.
 
 **Core insight: inject the summary into the system prompt, not into messages.**
 
@@ -166,6 +174,9 @@ Each handler overrides `getCompactionStrategy()`:
 - `ModelHandlerOpenAIResponse` → returns `OpenAICompactStrategy` (existing behavior, no change)
 - `ModelHandlerOpenAI` → returns `null` → triggers system-prompt summarization
 - `ModelHandlerGoogleGenAI` → returns `null` → triggers system-prompt summarization
+- `ModelHandlerDeepSeek` → returns `null` → triggers system-prompt summarization
+- `ModelHandlerKimi` → returns `null` → triggers system-prompt summarization
+- Any new handler → returns `null` by default (safe fallback)
 
 **System prompt mutation flow:**
 

--- a/docs/prd-context-compactization.md
+++ b/docs/prd-context-compactization.md
@@ -172,36 +172,37 @@ Messages: [
 
 ### 4.3 Compaction Model Selection
 
-Add a new configuration (named `compactionModel` for consistency with `compactionThresholdPercent`):
-
-```json
-"texra.model.compactionModel": {
-  "type": "string",
-  "default": "auto",
-  "description": "Model used for context summarization. 'auto' uses the cheapest model from the same provider family."
-}
-```
-
-**"auto" resolution — get cheapest model from same provider family:**
-
-| Primary Model | Compaction Model |
-|--------------|------------------|
-| `claude-sonnet-4-5`, `claude-opus-4-5` | `claude-haiku-4-5` |
-| `gpt-4.1`, `gpt-4o` | `gpt-4.1-mini` |
-| `gemini-2.5-pro` | `gemini-2.5-flash-lite` |
-| `deepseek-chat`, `deepseek-reasoner` | `deepseek-chat` (no cheaper option) |
-| `moonshot-v1-*` | `moonshot-v1-8k` |
-
-This uses the same provider (same API key, same base URL for OpenRouter), just the cheapest model in that family.
-
-**Implementation:**
+Simple constant map — use a capable but faster/cheaper model from the same family:
 
 ```typescript
-function getCheapestModelInFamily(modelId: string): string {
-  const family = getModelFamily(modelId);  // e.g., "anthropic", "openai", "google"
-  return CHEAPEST_MODEL_BY_FAMILY[family] ?? modelId;
+const COMPACTION_MODEL_MAP: Record<string, string> = {
+  // Anthropic: opus → sonnet (both 4.5, sonnet is faster)
+  'claude-opus-4-5': 'claude-sonnet-4-5',
+  'claude-sonnet-4-5': 'claude-sonnet-4-5',
+
+  // OpenAI: gpt5 → gpt5 (same model, summarization uses fewer thinking tokens)
+  'gpt-5': 'gpt-5',
+
+  // Google: pro → flash
+  'gemini-3-pro': 'gemini-3-flash',
+  'gemini-2.5-pro': 'gemini-2.5-flash',
+
+  // DeepSeek: same model (no cheaper option)
+  'deepseek-chat': 'deepseek-chat',
+  'deepseek-reasoner': 'deepseek-chat',
+
+  // Kimi: same model
+  'moonshot-v1-128k': 'moonshot-v1-128k',
+};
+
+function getCompactionModel(primaryModel: string): string {
+  return COMPACTION_MODEL_MAP[primaryModel] ?? primaryModel;
 }
 ```
+
+Fallback: if model not in map, use the same model.
+
+**No thinking mode for summarizer.** The Anthropic SDK's compaction call doesn't pass thinking parameters — summarization is straightforward and doesn't need extended thinking. Keeps compaction faster and cheaper.
 
 ### 4.4 Structured Summary Prompt
 
@@ -518,8 +519,8 @@ Existing `UsagePanel` already shows token counts. After compaction, show "Compac
 | Setting | Type | Default | Description |
 |---------|------|---------|-------------|
 | `texra.model.compactionThresholdPercent` | number | 75 | Existing. Threshold for auto-compaction. 0 = disabled. |
-| `texra.model.compactionModel` | string | "auto" | New. Model for summarization. "auto" = cheapest in same provider family. |
-| `texra.model.enableThinkingClearing` | boolean | false | Existing. Anthropic thinking block clearing (deprecated — use SDK compaction instead). |
+
+Compaction model is determined by constant map (`COMPACTION_MODEL_MAP`), not configurable.
 
 ## 7. Implementation Plan
 

--- a/docs/prd-context-compactization.md
+++ b/docs/prd-context-compactization.md
@@ -102,7 +102,7 @@ Instead, the approach is:
 1. When `shouldCompact()` returns true and no native strategy is available:
 2. Send the full message history to a **compactor model** with a structured summarization prompt
 3. The compactor returns the summary inside a `<conversation-summary>` XML tag
-4. **Replace the system prompt**: parse the summary from the XML tag and append it to the original system prompt
+4. **Replace the system prompt**: parse the summary using the existing `extractTextFromTag()` utility (`src/utils/text/xmlExtraction.ts:55`) and append it to the original system prompt. This is the same extraction pattern already used for `<revised>`, `<scratchpad>`, and `<document>` tags throughout the agent output pipeline.
 5. **Drop all old messages** -- the summary in the system prompt is now the sole representation of prior context
 6. The model receives: `[system prompt + summary]` + `[only the current user message]`
 7. Record compaction metadata (tokens before/after, summary text)

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -775,6 +775,24 @@ class ToolUseDispatchNode<C> extends BatchNode<
 
     shared.toolCalls = [];
 
+    // Log context state after tool results attached (for compaction planning).
+    // This gives visibility into token count BEFORE the next createResponse,
+    // allowing compaction to trigger if threshold exceeded.
+    const { contextWindow } = services.modelHandler.config;
+    if (contextWindow > 0) {
+      try {
+        const tokenCount = await services.modelHandler.estimateTokenCount(
+          shared.messages,
+          { client: services.client },
+        );
+        if (tokenCount > 0) {
+          services.logger.logContextState(tokenCount, contextWindow);
+        }
+      } catch {
+        // Token counting not available for this provider - silently skip
+      }
+    }
+
     return FlowTransition.CONTINUE;
   }
 }

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -778,8 +778,9 @@ class ToolUseDispatchNode<C> extends BatchNode<
     // Log context state after tool results attached (for compaction planning).
     // This gives visibility into token count BEFORE the next createResponse,
     // allowing compaction to trigger if threshold exceeded.
+    // Only run for providers with native token counting support.
     const { contextWindow } = services.modelHandler.config;
-    if (contextWindow > 0) {
+    if (contextWindow > 0 && services.modelHandler.supportsTokenCounting) {
       try {
         const tokenCount = await services.modelHandler.estimateTokenCount(
           shared.messages,
@@ -789,7 +790,7 @@ class ToolUseDispatchNode<C> extends BatchNode<
           services.logger.logContextState(tokenCount, contextWindow);
         }
       } catch {
-        // Token counting not available for this provider - silently skip
+        // Token counting failed - silently skip
       }
     }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Mostly documentation plus a guarded logging-only change in the tool-use flow; behavior changes are minimal aside from possible extra token-counting overhead for providers that support it.
> 
> **Overview**
> Adds a draft PRD (`docs/prd-context-compactization.md`) proposing a unified, user-visible context compaction approach (native `/responses/compact` for OpenAI Responses; client-side summarization for other providers) and outlining planned UI controls/logging.
> 
> Implements the first small runtime step toward that plan by logging post-tool token utilization in `ToolUseDispatchNode.post()` via `estimateTokenCount()` (guarded by `contextWindow > 0` and `supportsTokenCounting`, with failures silently ignored) so context growth from tool results is visible before the next `createResponse()` call.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ccdee0109f18b25df4a0e8fd56d32817084e9c6f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->