### PR TITLE
Add file navigation support and fix string replacement in edit tools

### DIFF
--- a/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
+++ b/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
@@ -172,9 +172,20 @@ export function formatToolUseTemplate(
     typeof (input as { old_str?: string }).old_str === 'string' &&
     typeof (input as { new_str?: string }).new_str === 'string'
   ) {
+    // Extract startLine from output.edits[0] for file link navigation
+    const outputData = parsed.output;
+    const edits =
+      outputData && typeof outputData === 'object' && 'edits' in outputData
+        ? (outputData as { edits?: Array<{ startLine?: number }> }).edits
+        : undefined;
+    const startLine = edits?.[0]?.startLine;
+
     if (filePath) {
       sections.push(
-        buildToolUseSection('File:', buildFileLinkWithLines(filePath)),
+        buildToolUseSection(
+          'File:',
+          buildFileLinkWithLines(filePath, { startLine }),
+        ),
       );
     }
     sections.push(

--- a/src/tools/EditTool.ts
+++ b/src/tools/EditTool.ts
@@ -76,12 +76,18 @@ export class EditFileTool extends defineTool({
       );
     }
 
-    // Escape $ in replacement string to prevent special replacement patterns
-    // ($&, $', $`, $<digits> have special meaning in String.replace)
-    const safeNewStr = new_str.replace(/\$/g, '$$$$');
-    const updatedContent = replace_all
-      ? currentContent.replaceAll(old_str, safeNewStr)
-      : currentContent.replace(old_str, safeNewStr);
+    // Use split/join and indexOf/slice for literal replacement
+    // (String.replace has special patterns like $$, $&, $' that corrupt LaTeX)
+    let updatedContent: string;
+    if (replace_all) {
+      updatedContent = currentContent.split(old_str).join(new_str);
+    } else {
+      const idx = currentContent.indexOf(old_str);
+      updatedContent =
+        currentContent.slice(0, idx) +
+        new_str +
+        currentContent.slice(idx + old_str.length);
+    }
 
     const approval = await requestToolEditApproval({
       path: targetPath,

--- a/src/tools/EditTool.ts
+++ b/src/tools/EditTool.ts
@@ -10,7 +10,6 @@ import {
 import { pluralize } from '@tools/utils';
 import {
   buildApprovalRejectedResult,
-  firstChangedLine,
   formatUnifiedApprovalUserDiff,
   getApprovedContent,
   requestToolEditApproval,
@@ -77,9 +76,12 @@ export class EditFileTool extends defineTool({
       );
     }
 
+    // Escape $ in replacement string to prevent special replacement patterns
+    // ($&, $', $`, $<digits> have special meaning in String.replace)
+    const safeNewStr = new_str.replace(/\$/g, '$$$$');
     const updatedContent = replace_all
-      ? currentContent.replaceAll(old_str, new_str)
-      : currentContent.replace(old_str, new_str);
+      ? currentContent.replaceAll(old_str, safeNewStr)
+      : currentContent.replace(old_str, safeNewStr);
 
     const approval = await requestToolEditApproval({
       path: targetPath,
@@ -118,16 +120,16 @@ export class EditFileTool extends defineTool({
       ? `${replacementSummary}\n\n${userDiffNote}`
       : replacementSummary;
 
-    // Compute first changed line (convert from 0-based to 1-based for display)
-    const changedLine = firstChangedLine(currentContent, appliedContent);
-    const startLine = changedLine !== null ? changedLine + 1 : undefined;
-
     return {
       summary,
       output,
       userPatch: approval.userPatch,
       edits: [
-        { path: targetPath, lineChanges: approval.lineChanges, startLine },
+        {
+          path: targetPath,
+          lineChanges: approval.lineChanges,
+          startLine: approval.startLine,
+        },
       ],
     };
   }

--- a/src/tools/EditTool.ts
+++ b/src/tools/EditTool.ts
@@ -10,6 +10,7 @@ import {
 import { pluralize } from '@tools/utils';
 import {
   buildApprovalRejectedResult,
+  firstChangedLine,
   formatUnifiedApprovalUserDiff,
   getApprovedContent,
   requestToolEditApproval,
@@ -117,11 +118,17 @@ export class EditFileTool extends defineTool({
       ? `${replacementSummary}\n\n${userDiffNote}`
       : replacementSummary;
 
+    // Compute first changed line (convert from 0-based to 1-based for display)
+    const changedLine = firstChangedLine(currentContent, appliedContent);
+    const startLine = changedLine !== null ? changedLine + 1 : undefined;
+
     return {
       summary,
       output,
       userPatch: approval.userPatch,
-      edits: [{ path: targetPath, lineChanges: approval.lineChanges }],
+      edits: [
+        { path: targetPath, lineChanges: approval.lineChanges, startLine },
+      ],
     };
   }
 }

--- a/src/tools/WriteTool.ts
+++ b/src/tools/WriteTool.ts
@@ -11,7 +11,6 @@ import {
 } from '@tools/fileInteractions';
 import {
   buildApprovalRejectedResult,
-  firstChangedLine,
   formatUnifiedApprovalUserDiff,
   getApprovedContent,
   requestToolEditApproval,
@@ -88,15 +87,17 @@ export class WriteFileTool extends defineTool({
         ? `Replaced ${originalLineCount} lines with ${newLineCount} lines.`
         : undefined;
 
-    // Compute first changed line (convert from 0-based to 1-based for display)
-    const changedLine = firstChangedLine(originalContent, appliedContent);
-    const startLine = changedLine !== null ? changedLine + 1 : 1;
-
     return {
       summary,
       output,
       userPatch: approval.userPatch,
-      edits: [{ path: input.path, lineChanges: approval.lineChanges, startLine }],
+      edits: [
+        {
+          path: input.path,
+          lineChanges: approval.lineChanges,
+          startLine: approval.startLine,
+        },
+      ],
       ...(userInstruction && { userInstruction }),
     };
   }

--- a/src/tools/WriteTool.ts
+++ b/src/tools/WriteTool.ts
@@ -11,6 +11,7 @@ import {
 } from '@tools/fileInteractions';
 import {
   buildApprovalRejectedResult,
+  firstChangedLine,
   formatUnifiedApprovalUserDiff,
   getApprovedContent,
   requestToolEditApproval,
@@ -87,11 +88,15 @@ export class WriteFileTool extends defineTool({
         ? `Replaced ${originalLineCount} lines with ${newLineCount} lines.`
         : undefined;
 
+    // Compute first changed line (convert from 0-based to 1-based for display)
+    const changedLine = firstChangedLine(originalContent, appliedContent);
+    const startLine = changedLine !== null ? changedLine + 1 : 1;
+
     return {
       summary,
       output,
       userPatch: approval.userPatch,
-      edits: [{ path: input.path, lineChanges: approval.lineChanges }],
+      edits: [{ path: input.path, lineChanges: approval.lineChanges, startLine }],
       ...(userInstruction && { userInstruction }),
     };
   }

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -255,7 +255,18 @@ function computeLineChangeSummary(
   return { added, removed };
 }
 
-function firstChangedLine(original: string, proposed: string): number | null {
+/**
+ * Compute the 0-based line number where the first change occurs.
+ * Returns null if the content is identical.
+ *
+ * @param original - Original content
+ * @param proposed - Proposed content
+ * @returns 0-based line number of first change, or null if identical
+ */
+export function firstChangedLine(
+  original: string,
+  proposed: string,
+): number | null {
   if (original === proposed) {
     return null;
   }

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -41,6 +41,8 @@ export interface ToolEditApprovalResult {
   appliedContent?: string;
   userPatch?: string;
   lineChanges?: LineChanges;
+  /** 1-based line number where the first change occurs (for navigation) */
+  startLine?: number;
 }
 
 export const TOOL_EDIT_APPROVAL_CONFIG_KEY =
@@ -258,12 +260,8 @@ function computeLineChangeSummary(
 /**
  * Compute the 0-based line number where the first change occurs.
  * Returns null if the content is identical.
- *
- * @param original - Original content
- * @param proposed - Proposed content
- * @returns 0-based line number of first change, or null if identical
  */
-export function firstChangedLine(
+function firstChangedLine(
   original: string,
   proposed: string,
 ): number | null {
@@ -583,6 +581,10 @@ function finalizeApprovalResult(
     result.userPatch ??
     computeUserPatch(request.proposedContent, appliedContent);
 
+  // Compute startLine once here (convert 0-based to 1-based)
+  const changedLine = firstChangedLine(request.originalContent, appliedContent);
+  const startLine = changedLine !== null ? changedLine + 1 : 1;
+
   return {
     ...result,
     appliedContent,
@@ -590,6 +592,7 @@ function finalizeApprovalResult(
     lineChanges:
       result.lineChanges ??
       computeLineChangeSummary(request.originalContent, appliedContent),
+    startLine,
   };
 }
 

--- a/src/tools/result.ts
+++ b/src/tools/result.ts
@@ -51,6 +51,8 @@ export type ToolFileAttachment = z.infer<typeof ToolFileAttachmentSchema>;
 export const EditRecordSchema = z.object({
   path: z.string(),
   lineChanges: LineChangesSchema.optional(),
+  /** 1-based line number where the edit starts (for navigation) */
+  startLine: z.number().optional(),
 });
 export type EditRecord = z.infer<typeof EditRecordSchema>;
 


### PR DESCRIPTION
## Summary
This PR enhances the file editing tools with navigation capabilities and fixes a critical bug in string replacement that was corrupting LaTeX and other special content.

## Key Changes

- **File Navigation**: Added `startLine` tracking to edit operations, allowing the UI to automatically navigate to the first changed line when displaying edited files
  - Compute the first changed line in `finalizeApprovalResult()` and convert from 0-based to 1-based indexing
  - Pass `startLine` through the edit result chain (EditTool, WriteTool, and result schemas)
  - Use `startLine` when building file links in the formatter

- **String Replacement Fix**: Replaced `String.replace()` and `String.replaceAll()` with literal split/join and indexOf/slice operations
  - `String.replace()` interprets special patterns like `$$`, `$&`, and `$'` which corrupts LaTeX and other content with these sequences
  - New implementation treats the replacement strings as literal text without pattern interpretation
  - Handles both single and all-occurrence replacements correctly

- **Type Updates**: Extended `ToolEditApprovalResult` and `EditRecord` schemas to include the new `startLine` field with proper documentation

## Implementation Details

- The `startLine` value is computed once in `finalizeApprovalResult()` to avoid redundant calculations
- Line numbers are stored as 1-based (user-friendly) but computed as 0-based internally
- The formatter extracts `startLine` from the output edits array and passes it to `buildFileLinkWithLines()`
- All changes maintain backward compatibility with optional fields

https://claude.ai/code/session_01CZpSmZVf24nCdpndiTRDCn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core file-editing and approval plumbing plus result schemas/formatting, so regressions could affect edit correctness or navigation. Changes are localized and mostly additive, but the replacement logic change is behavior-critical.
> 
> **Overview**
> Adds **edit navigation metadata** by computing the first-changed line during tool edit approval, threading it through `ToolEditApprovalResult` → tool `edits[]` records (`EditTool`, `WriteTool`, `EditRecordSchema`), and using it in the progress view formatter to generate file links that jump to the change location.
> 
> Fixes a **content-corrupting replacement bug** in `edit_file` by replacing `String.replace/replaceAll` with literal `split/join` and `indexOf/slice` so `$`-style replacement sequences (notably in LaTeX) are not interpreted.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 64649d858eada7c3983e2e932deb3ebcf00a63d0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->