### PR TITLE
Add string replacement tools to diff display support

### DIFF
--- a/src/progressView/frontend/formatters/constants.ts
+++ b/src/progressView/frontend/formatters/constants.ts
@@ -41,7 +41,11 @@ export const TIME_FORMAT_OPTIONS: Intl.DateTimeFormatOptions = {
  * Tools that show old/new diff display for their input.
  * Output is human-readable status, NOT code (don't syntax highlight output).
  */
-export const TOOLS_WITH_DIFF_INPUT = new Set(['edit_file']);
+export const TOOLS_WITH_DIFF_INPUT = new Set([
+  'edit_file',
+  'str_replace_editor',
+  'str_replace_based_edit_tool',
+]);
 
 /**
  * Tools that read files and should show file link instead of content.


### PR DESCRIPTION
## Summary
Extended the `TOOLS_WITH_DIFF_INPUT` set to include additional string replacement editing tools that support old/new diff display for their input.

## Changes
- Added `str_replace_editor` to tools with diff input support
- Added `str_replace_based_edit_tool` to tools with diff input support
- These tools now display human-readable status diffs alongside `edit_file`

## Details
The `TOOLS_WITH_DIFF_INPUT` constant identifies tools that present input changes in a diff format (showing old vs new content) rather than raw code. This change recognizes that string replacement tools use the same diff-based input display pattern as the existing `edit_file` tool, ensuring consistent formatting and presentation across related editing tools.

https://claude.ai/code/session_01GLDciFrUGbNApfv3bPUcDG

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, frontend-only constant change affecting how tool inputs are displayed; no data/security or behavior changes beyond formatting.
> 
> **Overview**
> Extends `TOOLS_WITH_DIFF_INPUT` to include `str_replace_editor` and `str_replace_based_edit_tool`, so these tool uses render with the old/new *diff-style* “Changes” view instead of generic input formatting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0d2e43a41ff642c9cc6f1a772c2ac3fd36bc0c07. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->