### PR TITLE
feat: add client-side context compaction and progress-view controls

### DIFF
--- a/package.json
+++ b/package.json
@@ -284,7 +284,7 @@
             "default": 75,
             "minimum": 0,
             "maximum": 100,
-            "description": "Percentage of context window to trigger automatic context management. For OpenAI, triggers conversation compaction via /responses/compact. For Anthropic, triggers server-side clearing of tool uses and thinking blocks. Set to 0 to disable.",
+            "description": "Percentage of context window to trigger automatic context compaction. OpenAI Responses use /responses/compact; other providers summarize client-side. Set to 0 to disable.",
             "scope": "resource"
           },
           "texra.model.enableThinkingClearing": {

--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -130,7 +130,7 @@ export function assertCycleFieldsPopulated<T extends object>(
     }
   }
 
-  if (obj['outputLocation'] == null) {
+  if (obj['outputLocation'] === null || obj['outputLocation'] === undefined) {
     throw new Error(
       `Cycle field 'outputLocation' must be set to a valid location before running cycle flow`,
     );

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -65,7 +65,7 @@ function parseToolInput(
   callId: string,
   logger: AgentLogger,
 ): unknown {
-  if (raw == null) {
+  if (raw === null || raw === undefined) {
     logger.warn(`Tool call ${callId}: Received null input, using empty object`);
     return {};
   }

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -11,6 +11,10 @@ import {
   registerInterruptible,
   unregisterInterruptible,
 } from '@agent/toolUse/ToolUseAgentRegistry';
+import {
+  isAutoCompactEnabled,
+  setAutoCompactEnabled,
+} from '@agent/toolUse/ToolUseAutoCompactState';
 import { retryCoordinator } from '@agent/runtime/RetryRequestCoordinator';
 
 import { PersistedFlow, type FlowRecord } from '@agent/node/persisted-flow';
@@ -93,6 +97,10 @@ export async function runToolUseFlow<C = unknown>(
     snapshot,
     getUsageRecorder: input.getUsageRecorder ?? (() => async () => {}),
   };
+
+  const autoCompactEnabled = isAutoCompactEnabled(streamId);
+  services.modelHandler.setAutoCompactEnabled(autoCompactEnabled);
+  setAutoCompactEnabled(streamId, autoCompactEnabled);
 
   const flowContext: ToolUseFlowContext<C> = {
     services,

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -17,6 +17,9 @@ import { AgentWorkspaceState } from '@agent/core/AgentWorkspaceState';
 import { MediaEntry } from '@agent/utils/mediaTypes';
 import type { NormalizedUsage } from '@agent/types/NormalizedUsage';
 
+// Local imports - common
+import { getSdkErrorMessage } from '@common/errors/sdkErrorUtils';
+
 // Local imports - frontend
 import { SecretManager, ApiProvider } from '@frontend/secretManager';
 
@@ -223,6 +226,11 @@ export abstract class ModelHandler<
     this.pendingCompactionRequest = true;
   }
 
+  /** Check if a manual compaction request is pending. */
+  protected hasPendingCompactionRequest(): boolean {
+    return this.pendingCompactionRequest;
+  }
+
   /** Consume a pending manual compaction request. */
   protected consumeCompactionRequest(): boolean {
     if (!this.pendingCompactionRequest) {
@@ -247,6 +255,86 @@ export abstract class ModelHandler<
       return 0;
     }
     return Math.floor((percent / 100) * contextWindow);
+  }
+
+  /**
+   * Shared orchestration for compaction across handlers.
+   * Keeps retry behavior stable by returning new message arrays rather than mutating inputs.
+   */
+  protected async maybeCompactContext<TMessage>(options: {
+    messages: TMessage[];
+    tokensBefore: number;
+    contextWindow: number;
+    forceCompaction: boolean;
+    shouldAttempt: boolean;
+    estimateTokens: (messages: TMessage[]) => Promise<number>;
+    compact: () => Promise<{
+      summaryText: string;
+      compactedMessages: TMessage[];
+      compactionModel: string;
+      compactionInputTokens?: number;
+      compactionOutputTokens?: number;
+    }>;
+    onCompactionStart?: () => void;
+  }): Promise<{
+    messages: TMessage[];
+    tokensAfter: number;
+    didCompact: boolean;
+  }> {
+    const {
+      messages,
+      tokensBefore,
+      contextWindow,
+      forceCompaction,
+      shouldAttempt,
+      estimateTokens,
+      compact,
+      onCompactionStart,
+    } = options;
+
+    if (!shouldAttempt) {
+      return { messages, tokensAfter: tokensBefore, didCompact: false };
+    }
+
+    const threshold = this.getCompactionTokenThreshold(contextWindow);
+    if (!forceCompaction && (threshold <= 0 || tokensBefore <= threshold)) {
+      return { messages, tokensAfter: tokensBefore, didCompact: false };
+    }
+
+    onCompactionStart?.();
+
+    try {
+      const compactionResult = await compact();
+      const tokensAfter = await estimateTokens(
+        compactionResult.compactedMessages,
+      );
+      const utilizationBefore = (tokensBefore / contextWindow) * 100;
+      const utilizationAfter = (tokensAfter / contextWindow) * 100;
+
+      this.logger.logContextManagement('Context compacted', {
+        action: 'compaction',
+        tokensBefore,
+        tokensAfter,
+        contextWindow,
+        utilizationBefore,
+        utilizationAfter,
+        summary: compactionResult.summaryText,
+        compactionModel: compactionResult.compactionModel,
+        compactionInputTokens: compactionResult.compactionInputTokens,
+        compactionOutputTokens: compactionResult.compactionOutputTokens,
+      });
+
+      return {
+        messages: compactionResult.compactedMessages,
+        tokensAfter,
+        didCompact: true,
+      };
+    } catch (error) {
+      this.logger.warn(
+        `Compaction failed: ${getSdkErrorMessage(error)}. Proceeding without compaction.`,
+      );
+      return { messages, tokensAfter: tokensBefore, didCompact: false };
+    }
   }
 
   /**

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -17,9 +17,6 @@ import { AgentWorkspaceState } from '@agent/core/AgentWorkspaceState';
 import { MediaEntry } from '@agent/utils/mediaTypes';
 import type { NormalizedUsage } from '@agent/types/NormalizedUsage';
 
-// Local imports - common
-import { getSdkErrorMessage } from '@common/errors/sdkErrorUtils';
-
 // Local imports - frontend
 import { SecretManager, ApiProvider } from '@frontend/secretManager';
 
@@ -303,38 +300,31 @@ export abstract class ModelHandler<
 
     onCompactionStart?.();
 
-    try {
-      const compactionResult = await compact();
-      const tokensAfter = await estimateTokens(
-        compactionResult.compactedMessages,
-      );
-      const utilizationBefore = (tokensBefore / contextWindow) * 100;
-      const utilizationAfter = (tokensAfter / contextWindow) * 100;
+    const compactionResult = await compact();
+    const tokensAfter = await estimateTokens(
+      compactionResult.compactedMessages,
+    );
+    const utilizationBefore = (tokensBefore / contextWindow) * 100;
+    const utilizationAfter = (tokensAfter / contextWindow) * 100;
 
-      this.logger.logContextManagement('Context compacted', {
-        action: 'compaction',
-        tokensBefore,
-        tokensAfter,
-        contextWindow,
-        utilizationBefore,
-        utilizationAfter,
-        summary: compactionResult.summaryText,
-        compactionModel: compactionResult.compactionModel,
-        compactionInputTokens: compactionResult.compactionInputTokens,
-        compactionOutputTokens: compactionResult.compactionOutputTokens,
-      });
+    this.logger.logContextManagement('Context compacted', {
+      action: 'compaction',
+      tokensBefore,
+      tokensAfter,
+      contextWindow,
+      utilizationBefore,
+      utilizationAfter,
+      summary: compactionResult.summaryText,
+      compactionModel: compactionResult.compactionModel,
+      compactionInputTokens: compactionResult.compactionInputTokens,
+      compactionOutputTokens: compactionResult.compactionOutputTokens,
+    });
 
-      return {
-        messages: compactionResult.compactedMessages,
-        tokensAfter,
-        didCompact: true,
-      };
-    } catch (error) {
-      this.logger.warn(
-        `Compaction failed: ${getSdkErrorMessage(error)}. Proceeding without compaction.`,
-      );
-      return { messages, tokensAfter: tokensBefore, didCompact: false };
-    }
+    return {
+      messages: compactionResult.compactedMessages,
+      tokensAfter,
+      didCompact: true,
+    };
   }
 
   /**

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -50,6 +50,7 @@ import {
 } from './types/StopReasonTypes';
 import {
   computeReducedMaxTokens,
+  DEFAULT_COMPACTION_THRESHOLD_PERCENT,
   TOKEN_SAFETY_BUFFER,
 } from './contextManagementConstants';
 
@@ -105,6 +106,8 @@ export abstract class ModelHandler<
   protected progressViewEnabled = true;
   protected agentCategory?: AgentCategory;
   protected mediaProcessor: MediaAttachmentProcessor;
+  private autoCompactEnabled = false;
+  private pendingCompactionRequest = false;
 
   /**
    * Whether the handler supports processing attachments in tool results.
@@ -203,6 +206,47 @@ export abstract class ModelHandler<
    */
   public setProgressViewEnabled(enabled: boolean): void {
     this.progressViewEnabled = enabled;
+  }
+
+  /** Enable or disable auto-compaction for this handler instance. */
+  public setAutoCompactEnabled(enabled: boolean): void {
+    this.autoCompactEnabled = enabled;
+  }
+
+  /** Check if auto-compaction is enabled for this handler instance. */
+  public isAutoCompactEnabled(): boolean {
+    return this.autoCompactEnabled;
+  }
+
+  /** Request a manual compaction on the next response cycle. */
+  public requestCompaction(): void {
+    this.pendingCompactionRequest = true;
+  }
+
+  /** Consume a pending manual compaction request. */
+  protected consumeCompactionRequest(): boolean {
+    if (!this.pendingCompactionRequest) {
+      return false;
+    }
+    this.pendingCompactionRequest = false;
+    return true;
+  }
+
+  /** Get the configured compaction threshold percentage. */
+  protected getCompactionThresholdPercent(): number {
+    return getConfig<number>(
+      'texra.model.compactionThresholdPercent',
+      DEFAULT_COMPACTION_THRESHOLD_PERCENT,
+    );
+  }
+
+  /** Calculate the absolute token threshold based on context window and configured percentage. */
+  protected getCompactionTokenThreshold(contextWindow: number): number {
+    const percent = this.getCompactionThresholdPercent();
+    if (percent <= 0) {
+      return 0;
+    }
+    return Math.floor((percent / 100) * contextWindow);
   }
 
   /**

--- a/src/agent/modelHandlers/compaction/compactionModels.ts
+++ b/src/agent/modelHandlers/compaction/compactionModels.ts
@@ -1,0 +1,28 @@
+/**
+ * Model mapping for compaction summarization.
+ * Falls back to the primary model when no mapping is available.
+ */
+const COMPACTION_MODEL_MAP: Record<string, string> = {
+  // Anthropic: opus → sonnet (both 4.5, sonnet is faster)
+  'claude-opus-4-5': 'claude-sonnet-4-5',
+  'claude-sonnet-4-5': 'claude-sonnet-4-5',
+
+  // OpenAI: gpt-5.2 → gpt-5.2 (same model, summarization uses fewer thinking tokens)
+  'gpt-5.2': 'gpt-5.2',
+
+  // Google: pro → flash
+  'gemini-3-pro': 'gemini-3-flash',
+  'gemini-2.5-pro': 'gemini-2.5-flash',
+
+  // DeepSeek: same model (no cheaper option)
+  'deepseek-chat': 'deepseek-chat',
+  'deepseek-reasoner': 'deepseek-chat',
+
+  // Kimi: same model
+  'kimi-k2': 'kimi-k2',
+  'kimi-k1.5-long': 'kimi-k1.5-long',
+};
+
+export function getCompactionModel(primaryModel: string): string {
+  return COMPACTION_MODEL_MAP[primaryModel] ?? primaryModel;
+}

--- a/src/agent/modelHandlers/compaction/compactionPrompt.ts
+++ b/src/agent/modelHandlers/compaction/compactionPrompt.ts
@@ -1,0 +1,40 @@
+/**
+ * Default compaction prompt used for client-side summarization.
+ * Based on Anthropic SDK's DEFAULT_SUMMARY_PROMPT.
+ */
+export const DEFAULT_SUMMARY_PROMPT = `You have been working on the task described above but have not yet completed it.
+Write a continuation summary that will allow you (or another instance of yourself)
+to resume work efficiently in a future context window where the conversation
+history will be replaced with this summary. Your summary should be structured,
+concise, and actionable. Include:
+
+1. Task Overview
+   The user's core request and success criteria
+   Any clarifications or constraints they specified
+
+2. Current State
+   What has been completed so far
+   Files created, modified, or analyzed (with paths if relevant)
+   Key outputs or artifacts produced
+
+3. Important Discoveries
+   Technical constraints or requirements uncovered
+   Decisions made and their rationale
+   Errors encountered and how they were resolved
+   What approaches were tried that didn't work (and why)
+
+4. Next Steps
+   Specific actions needed to complete the task
+   Any blockers or open questions to resolve
+   Priority order if multiple steps remain
+
+5. Context to Preserve
+   User preferences or style requirements
+   Domain-specific details that aren't obvious
+   Any promises made to the user
+
+Be concise but complete—err on the side of including information that would
+prevent duplicate work or repeated mistakes. Write in a way that enables
+immediate resumption of the task.
+
+Wrap your summary in <summary></summary> tags.`;

--- a/src/agent/modelHandlers/compaction/compactionUtils.ts
+++ b/src/agent/modelHandlers/compaction/compactionUtils.ts
@@ -1,0 +1,6 @@
+import { extractTextFromTag } from '@utils/text/xmlUtils';
+
+export function extractSummaryText(raw: string): string {
+  const extracted = extractTextFromTag(raw, 'summary');
+  return extracted.trim() || raw.trim();
+}

--- a/src/agent/modelHandlers/compaction/index.ts
+++ b/src/agent/modelHandlers/compaction/index.ts
@@ -1,0 +1,4 @@
+export { DEFAULT_SUMMARY_PROMPT } from './compactionPrompt';
+export { getCompactionModel } from './compactionModels';
+export { extractSummaryText } from './compactionUtils';
+export { compactOpenAICompatible } from './openaiCompatibleCompaction';

--- a/src/agent/modelHandlers/compaction/openaiCompatibleCompaction.ts
+++ b/src/agent/modelHandlers/compaction/openaiCompatibleCompaction.ts
@@ -1,0 +1,34 @@
+// Third-party imports
+import OpenAI from 'openai';
+
+// Type imports
+import type { ChatCompletionMessageParam } from 'openai/resources/chat/completions';
+
+/**
+ * Shared compaction implementation for OpenAI-compatible providers.
+ * Used by: ModelHandlerOpenAI, ModelHandlerDeepSeek, ModelHandlerKimi
+ */
+export async function compactOpenAICompatible(
+  client: OpenAI,
+  messages: ChatCompletionMessageParam[],
+  compactionModel: string,
+  summaryPrompt: string,
+): Promise<{ summary: string; inputTokens: number; outputTokens: number }> {
+  const compactionMessages: ChatCompletionMessageParam[] = [
+    ...messages,
+    { role: 'user', content: summaryPrompt },
+  ];
+
+  const response = await client.chat.completions.create({
+    model: compactionModel,
+    messages: compactionMessages,
+    stream: false,
+  });
+
+  const summary = response.choices[0]?.message?.content ?? '';
+  return {
+    summary,
+    inputTokens: response.usage?.prompt_tokens ?? 0,
+    outputTokens: response.usage?.completion_tokens ?? 0,
+  };
+}

--- a/src/agent/modelHandlers/contextManagementConstants.ts
+++ b/src/agent/modelHandlers/contextManagementConstants.ts
@@ -34,6 +34,11 @@ export const TOKEN_SAFETY_BUFFER = 10;
 export const HEURISTIC_TOKEN_BUFFER = 5000;
 
 /**
+ * Default maximum output tokens used during compaction requests.
+ */
+export const COMPACTION_MAX_TOKENS = 4096;
+
+/**
  * Maximum character length for tool result text sent to models.
  * Tool results exceeding this limit return an error to prevent context window overflow.
  * Set to 200KB (200,000 characters) which is roughly 50,000-66,000 tokens depending on content.

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -49,7 +49,6 @@ import { flexibleFS, type FileLocation } from '@utils/files';
 import { objectToLogString } from '@utils/text/stringUtils';
 
 // Local file imports
-import { DEFAULT_COMPACTION_THRESHOLD_PERCENT } from './contextManagementConstants';
 import { AnthropicStreamHandler } from './support/AnthropicStreamHandler';
 import { toAnthropicTools } from './toolConversion';
 import { ANTHROPIC_STOP } from './types/StopReasonTypes';
@@ -70,6 +69,9 @@ import {
   computeCachePercentage,
   nonZeroOrUndefined,
 } from './utils/usageNormalization';
+import { DEFAULT_SUMMARY_PROMPT } from './compaction/compactionPrompt';
+import { getCompactionModel } from './compaction/compactionModels';
+import { extractSummaryText } from './compaction/compactionUtils';
 
 // Type imports
 import type { ProviderStopReason } from './types/StopReasonTypes';
@@ -82,10 +84,6 @@ import type {
 import type { AnthropicBeta } from '@anthropic-ai/sdk/resources/beta/beta';
 import type {
   BetaContentBlock,
-  BetaContextManagementConfig,
-  BetaContextManagementResponse,
-  BetaClearToolUses20250919EditResponse,
-  BetaClearThinking20251015EditResponse,
   BetaImageBlockParam,
   BetaMessage,
   BetaRedactedThinkingBlock,
@@ -151,22 +149,7 @@ const SONNET_37_OUTPUT_BETA: AnthropicBeta = 'output-128k-2025-02-19';
 const INTERLEAVED_THINKING_BETA: AnthropicBeta =
   'interleaved-thinking-2025-05-14';
 const CONTEXT_MANAGEMENT_BETA: AnthropicBeta = 'context-management-2025-06-27';
-
-/**
- * Context management constants for Anthropic's server-side editing.
- * These are reasonable defaults that balance context efficiency with conversation continuity.
- */
-/** Number of recent tool use/result pairs to keep after context clearing */
-const CONTEXT_MANAGEMENT_KEEP_TOOL_USES = 3;
-/** Number of assistant turns with thinking blocks to keep */
-const CONTEXT_MANAGEMENT_KEEP_THINKING_TURNS = 3;
-/**
- * Minimum percentage of context to clear at once for tool uses.
- * This ensures cache invalidation is worthwhile - clearing too few tokens
- * causes frequent cache misses without meaningful benefit.
- * 25% provides more aggressive clearing to reduce frequent cache thrashing.
- */
-const CONTEXT_MANAGEMENT_CLEAR_AT_LEAST_PERCENT = 25;
+const COMPACTION_MAX_TOKENS = 4096;
 
 const ANTHROPIC_1M_CONTEXT_WINDOW = 1_000_000;
 
@@ -180,24 +163,6 @@ const THINKING_TEMPERATURE_EXCLUDED_PATTERNS = [
   'claude-haiku-4',
   'claude-3-7-sonnet',
 ];
-
-/**
- * Extended response type for countTokens with context_management.
- * The SDK doesn't export this, so we define it here for type safety.
- */
-interface CountTokensContextManagementResponse {
-  original_input_tokens: number;
-}
-
-/**
- * Options for setting up context management configuration.
- */
-interface ContextManagementSetupOptions {
-  options: MessageCreateParams;
-  contextWindow: number;
-  supportsReasoning: boolean;
-  thresholdPercent: number;
-}
 
 /**
  * Block types that support cache_control for prompt caching.
@@ -271,99 +236,6 @@ export class ModelHandlerAnthropic extends ModelHandler<
     }
   }
 
-  /**
-   * Sets up context management configuration for Anthropic's server-side editing.
-   * Must be called BEFORE token counting so countTokens returns accurate post-clearing counts.
-   */
-  private setupContextManagement({
-    options,
-    contextWindow,
-    supportsReasoning,
-    thresholdPercent,
-  }: ContextManagementSetupOptions): void {
-    if (!this.isToolUseMode()) {
-      return;
-    }
-
-    // Only enable context management if threshold is configured (> 0)
-    if (thresholdPercent <= 0) {
-      return;
-    }
-
-    this.ensureBeta(options, CONTEXT_MANAGEMENT_BETA);
-
-    const contextManagementEdits = [
-      ...(options.context_management?.edits ?? []),
-    ];
-
-    const triggerTokens = Math.floor((thresholdPercent / 100) * contextWindow);
-
-    // When context management is enabled with thinking, the API's default behavior
-    // clears thinking to keep only the last 1 turn. We must explicitly configure
-    // thinking clearing to control this behavior.
-    const enableThinkingClearing = getConfig<boolean>(
-      'texra.model.enableThinkingClearing',
-      false,
-    );
-
-    if (
-      supportsReasoning &&
-      options.thinking &&
-      !contextManagementEdits.some(
-        (edit) => edit.type === 'clear_thinking_20251015',
-      )
-    ) {
-      // Thinking clearing must come first in the edits array per API requirement.
-      // When disabled (default): preserve all thinking blocks to prevent early clearing.
-      // When enabled: keep last N turns to manage context growth.
-      contextManagementEdits.unshift({
-        type: 'clear_thinking_20251015' as const,
-        keep: enableThinkingClearing
-          ? {
-              type: 'thinking_turns' as const,
-              value: CONTEXT_MANAGEMENT_KEEP_THINKING_TURNS,
-            }
-          : ('all' as const),
-      });
-    }
-
-    // Add tool result clearing strategy with server-side trigger.
-    // The trigger ensures clearing only activates when input tokens exceed threshold.
-    if (
-      !contextManagementEdits.some(
-        (edit) => edit.type === 'clear_tool_uses_20250919',
-      )
-    ) {
-      // clear_at_least ensures cache invalidation is worthwhile:
-      // Without it, the API may clear too few tokens, causing frequent
-      // cache misses without meaningful benefit.
-      const clearAtLeastTokens = Math.floor(
-        (CONTEXT_MANAGEMENT_CLEAR_AT_LEAST_PERCENT / 100) * contextWindow,
-      );
-
-      contextManagementEdits.push({
-        type: 'clear_tool_uses_20250919' as const,
-        trigger: {
-          type: 'input_tokens' as const,
-          value: triggerTokens,
-        },
-        keep: {
-          type: 'tool_uses' as const,
-          value: CONTEXT_MANAGEMENT_KEEP_TOOL_USES,
-        },
-        clear_at_least: {
-          type: 'input_tokens' as const,
-          value: clearAtLeastTokens,
-        },
-      });
-    }
-
-    options.context_management = {
-      ...(options.context_management ?? {}),
-      edits: contextManagementEdits,
-    } satisfies BetaContextManagementConfig;
-  }
-
   private assignCacheControlToLatest(
     content: (ContentBlockParam | ContentBlock)[] | undefined,
   ): void {
@@ -380,6 +252,48 @@ export class ModelHandlerAnthropic extends ModelHandler<
       );
       this.updateCacheControlTarget(undefined);
     }
+  }
+
+  private async compactConversation(
+    client: Anthropic,
+    messages: MessageParam[],
+    systemPrompt?: string,
+    signal?: AbortSignal,
+  ): Promise<string> {
+    const compactionModel = getCompactionModel(this.config.fullName);
+    const compactionMessages: MessageParam[] = [
+      ...messages,
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'text',
+            text: DEFAULT_SUMMARY_PROMPT,
+            citations: null,
+          },
+        ],
+      },
+    ];
+
+    const response = await client.beta.messages.create(
+      {
+        model: compactionModel,
+        max_tokens: Math.min(
+          this.config.maxOutputTokens,
+          COMPACTION_MAX_TOKENS,
+        ),
+        messages: compactionMessages,
+        ...(systemPrompt && { system: systemPrompt }),
+      },
+      signal ? { signal } : undefined,
+    );
+
+    const summaryText = response.content
+      .filter((block) => block.type === 'text')
+      .map((block) => block.text ?? '')
+      .join('');
+
+    return extractSummaryText(summaryText);
   }
 
   async getClient(): Promise<Anthropic> {
@@ -414,7 +328,6 @@ export class ModelHandlerAnthropic extends ModelHandler<
     options?: TokenCountOptions<Anthropic> & {
       anthropicTools?: MessageCountTokensParams['tools'];
       thinking?: MessageCountTokensParams['thinking'];
-      contextManagement?: BetaContextManagementConfig;
       betas?: AnthropicBeta[];
     },
   ): Promise<number> {
@@ -445,18 +358,10 @@ export class ModelHandlerAnthropic extends ModelHandler<
       countTokensParams.thinking = options.thinking;
     }
 
-    // Include context_management in token counting to get accurate
-    // post-clearing token counts. This is critical for:
-    // 1. Correctly adjusting max_tokens based on actual available context
-    // 2. Allowing both clearing strategies to work together
-    if (options?.contextManagement) {
-      countTokensParams.context_management = options.contextManagement;
-    }
-
     // Strip betas that only apply to message creation (e.g., output length)
     // while keeping context headers needed for accurate token counting.
     const countTokenBetas = options?.betas?.filter(
-      (beta) => beta === CONTEXT_1M_BETA || beta === CONTEXT_MANAGEMENT_BETA,
+      (beta) => beta === CONTEXT_1M_BETA,
     );
     if (countTokenBetas && countTokenBetas.length > 0) {
       countTokensParams.betas = countTokenBetas;
@@ -465,25 +370,9 @@ export class ModelHandlerAnthropic extends ModelHandler<
     const responseTokenCount =
       await client.beta.messages.countTokens(countTokensParams);
 
-    // Log both original and post-clearing token counts if available
-    const contextMgmtResponse = (
-      responseTokenCount as typeof responseTokenCount & {
-        context_management?: CountTokensContextManagementResponse;
-      }
-    ).context_management;
-
-    if (contextMgmtResponse?.original_input_tokens) {
-      const clearedTokens =
-        contextMgmtResponse.original_input_tokens -
-        responseTokenCount.input_tokens;
-      this.logger.debug(
-        `Token count: ${responseTokenCount.input_tokens} (after clearing ${clearedTokens} tokens from ${contextMgmtResponse.original_input_tokens})`,
-      );
-    } else {
-      this.logger.debug(
-        `Token count of message: ${responseTokenCount.input_tokens}`,
-      );
-    }
+    this.logger.debug(
+      `Token count of message: ${responseTokenCount.input_tokens}`,
+    );
 
     return responseTokenCount.input_tokens;
   }
@@ -505,6 +394,9 @@ export class ModelHandlerAnthropic extends ModelHandler<
     const useStreaming = this.getStreamingConfig();
     // Track input token count for client-side context management triggering
     let measuredInputTokens: number | undefined;
+    const forceCompaction = this.consumeCompactionRequest();
+    const shouldAttemptCompaction =
+      this.isToolUseMode() && (this.isAutoCompactEnabled() || forceCompaction);
     const useAnthropic1MBeta = getConfig<boolean>(
       'texra.model.useAnthropic1MBeta',
       false,
@@ -520,7 +412,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
 
     this.enforceCacheControlLimit(messages);
 
-    const documentAnalysis = this.analyzeDocumentSources(messages);
+    let documentAnalysis = this.analyzeDocumentSources(messages);
     let hasFileReference = documentAnalysis.hasFileSource;
 
     // Phase 1: BUILD - Construct provider-specific request parameters
@@ -592,19 +484,6 @@ export class ModelHandlerAnthropic extends ModelHandler<
       this.ensureBeta(options, CONTEXT_1M_BETA);
     }
 
-    // Set up context management BEFORE token counting so countTokens can
-    // return accurate post-clearing token counts.
-    const compactionThresholdPercent = getConfig<number>(
-      'texra.model.compactionThresholdPercent',
-      DEFAULT_COMPACTION_THRESHOLD_PERCENT,
-    );
-    this.setupContextManagement({
-      options,
-      contextWindow: effectiveContextWindow,
-      supportsReasoning: this.capabilities.supportsReasoning,
-      thresholdPercent: compactionThresholdPercent,
-    });
-
     // Phase 2: COUNT - Estimate input tokens using built params
     // Phase 3: VALIDATE - Adjust max_tokens if needed
     if (this.supportsTokenCounting) {
@@ -622,14 +501,65 @@ export class ModelHandlerAnthropic extends ModelHandler<
             systemPrompt,
             anthropicTools: options.tools,
             thinking: options.thinking,
-            contextManagement: options.context_management ?? undefined,
             betas: options.betas,
           });
           measuredInputTokens = inputTokens;
 
+          let effectiveInputTokens = inputTokens;
+          if (shouldAttemptCompaction) {
+            const threshold = this.getCompactionTokenThreshold(
+              effectiveContextWindow,
+            );
+            if (forceCompaction || (threshold > 0 && inputTokens > threshold)) {
+              const summaryText = await this.compactConversation(
+                client,
+                messages,
+                systemPrompt,
+                signal,
+              );
+              const compactedMessage: MessageParam = {
+                role: 'user',
+                content: [
+                  {
+                    type: 'text',
+                    text: summaryText,
+                    citations: null,
+                  },
+                ],
+              };
+              messages.splice(0, messages.length, compactedMessage);
+              documentAnalysis = this.analyzeDocumentSources(messages);
+              hasFileReference = documentAnalysis.hasFileSource;
+              const tokensAfter = await this.estimateTokenCount(messages, {
+                client,
+                systemPrompt,
+                anthropicTools: options.tools,
+                thinking: options.thinking,
+                betas: options.betas,
+              });
+              measuredInputTokens = tokensAfter;
+              effectiveInputTokens = tokensAfter;
+              const utilizationBefore =
+                (inputTokens / effectiveContextWindow) * 100;
+              const utilizationAfter =
+                (tokensAfter / effectiveContextWindow) * 100;
+              const compactionModel = getCompactionModel(this.config.fullName);
+              this.logger.logContextManagement('Context compacted', {
+                action: 'compaction',
+                tokensBefore: inputTokens,
+                tokensAfter,
+                contextWindow: effectiveContextWindow,
+                utilizationBefore,
+                utilizationAfter,
+                summary: summaryText,
+                compactionModel,
+              });
+            }
+          }
+
           // Validate and adjust max_tokens if needed (throws if context window exceeded)
           const validation = this.validateTokenLimits(
-            inputTokens,
+            effectiveInputTokens,
             options.max_tokens,
             effectiveContextWindow,
           );
@@ -776,77 +706,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
       response = await client.beta.messages.create(options, { signal });
     }
 
-    // Log context management events if any edits were applied
-    this.logContextManagementFromResponse(response);
-
     return response;
-  }
-
-  /**
-   * Log context management events from the Anthropic response.
-   * The response includes applied_edits when server-side context editing was performed.
-   */
-  private logContextManagementFromResponse(response: BetaMessage): void {
-    const contextManagement = (
-      response as BetaMessage & {
-        context_management?: BetaContextManagementResponse | null;
-      }
-    ).context_management;
-
-    // Debug logging to diagnose context management response
-    if (contextManagement) {
-      this.logger.debug(
-        `Context management response received: ${JSON.stringify(contextManagement)}`,
-      );
-    }
-
-    if (!contextManagement?.applied_edits?.length) {
-      return;
-    }
-
-    const contextWindow = this.config.contextWindow;
-    // Anthropic's input_tokens excludes cached tokens (unlike OpenAI where it's the total).
-    // Per SDK docs: "Total input tokens is the summation of input_tokens,
-    // cache_creation_input_tokens, and cache_read_input_tokens."
-    const totalInputTokens =
-      response.usage.input_tokens +
-      (response.usage.cache_read_input_tokens ?? 0) +
-      (response.usage.cache_creation_input_tokens ?? 0);
-
-    type AppliedEdit =
-      | BetaClearToolUses20250919EditResponse
-      | BetaClearThinking20251015EditResponse;
-
-    for (const edit of contextManagement.applied_edits as AppliedEdit[]) {
-      const clearedTokens = edit.cleared_input_tokens;
-      if (!clearedTokens || clearedTokens <= 0) {
-        continue;
-      }
-
-      const isToolUses = edit.type === 'clear_tool_uses_20250919';
-      const clearedCount = isToolUses
-        ? ((edit as BetaClearToolUses20250919EditResponse).cleared_tool_uses ??
-          0)
-        : ((edit as BetaClearThinking20251015EditResponse)
-            .cleared_thinking_turns ?? 0);
-      const itemLabel = isToolUses ? 'tool use(s)' : 'thinking turn(s)';
-      const action = isToolUses ? 'clear_tool_uses' : 'clear_thinking';
-      const utilizationReduction = (clearedTokens / contextWindow) * 100;
-
-      this.logger.logContextManagement(
-        `Cleared ${clearedCount} ${itemLabel}: ${clearedTokens.toLocaleString()} tokens freed (${utilizationReduction.toFixed(1)}% of context)`,
-        {
-          action,
-          tokensBefore: totalInputTokens + clearedTokens,
-          tokensAfter: totalInputTokens,
-          contextWindow,
-          utilizationBefore:
-            ((totalInputTokens + clearedTokens) / contextWindow) * 100,
-          utilizationAfter: (totalInputTokens / contextWindow) * 100,
-          details: `Anthropic server-side: cleared ${clearedCount} ${itemLabel}`,
-        },
-      );
-    }
   }
 
   private enforceCacheControlLimit(messages: MessageParam[]): void {

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -72,6 +72,7 @@ import {
 import { DEFAULT_SUMMARY_PROMPT } from './compaction/compactionPrompt';
 import { getCompactionModel } from './compaction/compactionModels';
 import { extractSummaryText } from './compaction/compactionUtils';
+import { COMPACTION_MAX_TOKENS } from './contextManagementConstants';
 
 // Type imports
 import type { ProviderStopReason } from './types/StopReasonTypes';
@@ -149,7 +150,6 @@ const SONNET_37_OUTPUT_BETA: AnthropicBeta = 'output-128k-2025-02-19';
 const INTERLEAVED_THINKING_BETA: AnthropicBeta =
   'interleaved-thinking-2025-05-14';
 const CONTEXT_MANAGEMENT_BETA: AnthropicBeta = 'context-management-2025-06-27';
-const COMPACTION_MAX_TOKENS = 4096;
 
 const ANTHROPIC_1M_CONTEXT_WINDOW = 1_000_000;
 
@@ -269,7 +269,6 @@ export class ModelHandlerAnthropic extends ModelHandler<
           {
             type: 'text',
             text: DEFAULT_SUMMARY_PROMPT,
-            citations: null,
           },
         ],
       },
@@ -390,11 +389,12 @@ export class ModelHandlerAnthropic extends ModelHandler<
       signal,
       tools,
     } = requestOptions;
+    let effectiveMessages = messages;
     // Get streaming config
     const useStreaming = this.getStreamingConfig();
     // Track input token count for client-side context management triggering
     let measuredInputTokens: number | undefined;
-    const forceCompaction = this.consumeCompactionRequest();
+    const forceCompaction = this.hasPendingCompactionRequest();
     const shouldAttemptCompaction =
       this.isToolUseMode() && (this.isAutoCompactEnabled() || forceCompaction);
     const useAnthropic1MBeta = getConfig<boolean>(
@@ -410,16 +410,16 @@ export class ModelHandlerAnthropic extends ModelHandler<
       ? ANTHROPIC_1M_CONTEXT_WINDOW
       : this.config.contextWindow;
 
-    this.enforceCacheControlLimit(messages);
+    this.enforceCacheControlLimit(effectiveMessages);
 
-    let documentAnalysis = this.analyzeDocumentSources(messages);
+    let documentAnalysis = this.analyzeDocumentSources(effectiveMessages);
     let hasFileReference = documentAnalysis.hasFileSource;
 
     // Phase 1: BUILD - Construct provider-specific request parameters
     const options: MessageCreateParams = {
       model: this.config.fullName,
       max_tokens: this.config.maxOutputTokens,
-      messages,
+      messages: effectiveMessages,
       temperature,
       stop_sequences: endTag ? [endTag] : undefined,
       system: systemPrompt,
@@ -491,12 +491,17 @@ export class ModelHandlerAnthropic extends ModelHandler<
         this.logger.debug(
           'Skipping token counting because Anthropic countTokens does not support file-based document sources.',
         );
+        if (forceCompaction) {
+          this.logger.debug(
+            'Deferring manual compaction request until token counting is available.',
+          );
+        }
       } else {
         // Token counting uses soft failure - if it fails, we proceed without adjustment
         // and let the API enforce limits. This avoids unnecessary retries for non-critical operations.
         try {
           // Reuse built params for token counting (build once principle)
-          const inputTokens = await this.estimateTokenCount(messages, {
+          const inputTokens = await this.estimateTokenCount(effectiveMessages, {
             client,
             systemPrompt,
             anthropicTools: options.tools,
@@ -506,14 +511,24 @@ export class ModelHandlerAnthropic extends ModelHandler<
           measuredInputTokens = inputTokens;
 
           let effectiveInputTokens = inputTokens;
-          if (shouldAttemptCompaction) {
-            const threshold = this.getCompactionTokenThreshold(
-              effectiveContextWindow,
-            );
-            if (forceCompaction || (threshold > 0 && inputTokens > threshold)) {
+          const compactionOutcome = await this.maybeCompactContext({
+            messages: effectiveMessages,
+            tokensBefore: inputTokens,
+            contextWindow: effectiveContextWindow,
+            forceCompaction,
+            shouldAttempt: shouldAttemptCompaction,
+            estimateTokens: (nextMessages) =>
+              this.estimateTokenCount(nextMessages, {
+                client,
+                systemPrompt,
+                anthropicTools: options.tools,
+                thinking: options.thinking,
+                betas: options.betas,
+              }),
+            compact: async () => {
               const summaryText = await this.compactConversation(
                 client,
-                messages,
+                effectiveMessages,
                 systemPrompt,
                 signal,
               );
@@ -523,39 +538,29 @@ export class ModelHandlerAnthropic extends ModelHandler<
                   {
                     type: 'text',
                     text: summaryText,
-                    citations: null,
                   },
                 ],
               };
-              messages.splice(0, messages.length, compactedMessage);
-              documentAnalysis = this.analyzeDocumentSources(messages);
-              hasFileReference = documentAnalysis.hasFileSource;
-              const tokensAfter = await this.estimateTokenCount(messages, {
-                client,
-                systemPrompt,
-                anthropicTools: options.tools,
-                thinking: options.thinking,
-                betas: options.betas,
-              });
-              measuredInputTokens = tokensAfter;
-              effectiveInputTokens = tokensAfter;
-              const utilizationBefore =
-                (inputTokens / effectiveContextWindow) * 100;
-              const utilizationAfter =
-                (tokensAfter / effectiveContextWindow) * 100;
-              const compactionModel = getCompactionModel(this.config.fullName);
-              this.logger.logContextManagement('Context compacted', {
-                action: 'compaction',
-                tokensBefore: inputTokens,
-                tokensAfter,
-                contextWindow: effectiveContextWindow,
-                utilizationBefore,
-                utilizationAfter,
-                summary: summaryText,
-                compactionModel,
-              });
-            }
+              return {
+                summaryText,
+                compactedMessages: [compactedMessage],
+                compactionModel: getCompactionModel(this.config.fullName),
+              };
+            },
+            onCompactionStart: () => {
+              this.consumeCompactionRequest();
+            },
+          });
+
+          if (compactionOutcome.didCompact) {
+            effectiveMessages = compactionOutcome.messages;
+            options.messages = effectiveMessages;
+            documentAnalysis = this.analyzeDocumentSources(effectiveMessages);
+            hasFileReference = documentAnalysis.hasFileSource;
           }
+
+          effectiveInputTokens = compactionOutcome.tokensAfter;
+          measuredInputTokens = compactionOutcome.tokensAfter;
 
           // Validate and adjust max_tokens if needed (throws if context window exceeded)
           const validation = this.validateTokenLimits(
@@ -620,7 +625,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
     if (documentAnalysis.hasBase64Pdf) {
       const uploadResult = await this.replaceDocumentDataWithUploads(
         client,
-        messages,
+        effectiveMessages,
       );
       if (uploadResult.hasFileReference) {
         hasFileReference = true;

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -41,35 +41,41 @@ import { ModelHandler } from '@agent/modelHandlers/ModelHandler';
 import type { NormalizedUsage } from '@agent/types/NormalizedUsage';
 import { MediaEntry } from '@agent/utils/mediaTypes';
 import { calculateTokenPrice } from '@agent/utils/priceUtils';
+
+// Local imports - common
 import {
   getSdkErrorMessage,
   isContextWindowError,
 } from '@common/errors/sdkErrorUtils';
+
+// Local imports - logger
 import { AgentLogger } from '@logger/AgentLogger';
 
+// Local imports - model
 import { ReasoningEffort } from '@model/ModelConfig';
 
-// Internal imports
+// Local imports - replacement
 import replacementEngine from '@replacement/engine';
 
 // Local imports - tools
 import type { ToolFileAttachment } from '@tools/result';
-import type { FileLocation } from '@utils/files';
 
-// Google finish reasons are re-exported from the SDK
-
-// Local constant
+// Local imports - utils
 import { K_SLICE } from '@utils/config';
 import { isNonEmptyString } from '@utils/core';
+import type { FileLocation } from '@utils/files';
 import { flexibleFS, getShortDisplayPath } from '@utils/files';
+
+// Local file imports
+import { COMPACTION_MAX_TOKENS } from './contextManagementConstants';
+import { DEFAULT_SUMMARY_PROMPT } from './compaction/compactionPrompt';
+import { getCompactionModel } from './compaction/compactionModels';
+import { extractSummaryText } from './compaction/compactionUtils';
 import {
   computeCachePercentage,
   nonZeroOrUndefined,
 } from './utils/usageNormalization';
 import { prepareExistingOutputContent } from './utils/fileContentUtils';
-const COMPACTION_MAX_TOKENS = 4096;
-
-// Local file imports
 import {
   DEFAULT_ATTACHMENT_MIME_TYPE,
   formatAttachmentSummary,
@@ -78,9 +84,6 @@ import {
   type ToolResultPayload,
 } from './utils/toolAttachmentUtils';
 import { toGoogleTools } from './toolConversion';
-import { DEFAULT_SUMMARY_PROMPT } from './compaction/compactionPrompt';
-import { getCompactionModel } from './compaction/compactionModels';
-import { extractSummaryText } from './compaction/compactionUtils';
 
 // Type imports
 import type { MediaFileResult } from './support/MediaAttachmentProcessor';
@@ -443,8 +446,8 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
     messages: Content[],
     systemPrompt?: string,
     signal?: AbortSignal,
+    compactionModel: string = getCompactionModel(this.config.fullName),
   ): Promise<string> {
-    const compactionModel = getCompactionModel(this.config.fullName);
     const compactionMessages: Content[] = [
       ...messages,
       createUserContent([createPartFromText(DEFAULT_SUMMARY_PROMPT)]),
@@ -496,7 +499,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
       throw new Error('Messages array cannot be empty.');
     }
 
-    const forceCompaction = this.consumeCompactionRequest();
+    const forceCompaction = this.hasPendingCompactionRequest();
     const shouldAttemptCompaction =
       this.isToolUseMode() && (this.isAutoCompactEnabled() || forceCompaction);
     let effectiveMessages = messages;
@@ -551,51 +554,59 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
         });
         let effectiveInputTokens = totalTokens;
 
-        if (shouldAttemptCompaction) {
-          const threshold = this.getCompactionTokenThreshold(
-            this.config.contextWindow,
-          );
-          if (forceCompaction || (threshold > 0 && totalTokens > threshold)) {
+        const compactionOutcome = await this.maybeCompactContext({
+          messages: effectiveMessages,
+          tokensBefore: totalTokens,
+          contextWindow: this.config.contextWindow,
+          forceCompaction,
+          shouldAttempt: shouldAttemptCompaction,
+          estimateTokens: async (nextMessages) => {
+            const nextHistory = nextMessages.slice(0, -1);
+            const nextLastMessage = nextMessages.at(-1);
+            const nextLastMessageParts = Array.isArray(nextLastMessage?.parts)
+              ? nextLastMessage.parts
+              : [];
+            return this.estimateTokenCount(nextHistory, {
+              client,
+              systemPrompt,
+              lastMessageParts: nextLastMessageParts,
+              googleTools: generationConfig.tools as GeminiTool[] | undefined,
+              signal,
+            });
+          },
+          compact: async () => {
+            const compactionModel = getCompactionModel(this.config.fullName);
             const summaryText = await this.compactConversation(
               client,
               effectiveMessages,
               systemPrompt,
               signal,
-            );
-            effectiveMessages = [
-              createUserContent([createPartFromText(summaryText)]),
-            ];
-            history = effectiveMessages.slice(0, -1);
-            lastMessage = effectiveMessages.at(-1);
-            lastMessageParts = Array.isArray(lastMessage?.parts)
-              ? lastMessage.parts
-              : [];
-            validateGoogleMessageHistory(history, this.logger);
-            const tokensAfter = await this.estimateTokenCount(history, {
-              client,
-              systemPrompt,
-              lastMessageParts,
-              googleTools: generationConfig.tools as GeminiTool[] | undefined,
-              signal,
-            });
-            effectiveInputTokens = tokensAfter;
-            const utilizationBefore =
-              (totalTokens / this.config.contextWindow) * 100;
-            const utilizationAfter =
-              (tokensAfter / this.config.contextWindow) * 100;
-            const compactionModel = getCompactionModel(this.config.fullName);
-            this.logger.logContextManagement('Context compacted', {
-              action: 'compaction',
-              tokensBefore: totalTokens,
-              tokensAfter,
-              contextWindow: this.config.contextWindow,
-              utilizationBefore,
-              utilizationAfter,
-              summary: summaryText,
               compactionModel,
-            });
-          }
+            );
+            return {
+              summaryText,
+              compactedMessages: [
+                createUserContent([createPartFromText(summaryText)]),
+              ],
+              compactionModel,
+            };
+          },
+          onCompactionStart: () => {
+            this.consumeCompactionRequest();
+          },
+        });
+
+        if (compactionOutcome.didCompact) {
+          effectiveMessages = compactionOutcome.messages;
+          history = effectiveMessages.slice(0, -1);
+          lastMessage = effectiveMessages.at(-1);
+          lastMessageParts = Array.isArray(lastMessage?.parts)
+            ? lastMessage.parts
+            : [];
+          validateGoogleMessageHistory(history, this.logger);
         }
+
+        effectiveInputTokens = compactionOutcome.tokensAfter;
 
         // Validate and adjust maxOutputTokens if needed (throws if context window exceeded)
         const originalMaxTokens = generationConfig.maxOutputTokens ?? 8192;
@@ -633,6 +644,10 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
           `Token counting failed: ${getSdkErrorMessage(err)}. Proceeding without token adjustment.`,
         );
       }
+    } else if (forceCompaction) {
+      this.logger.debug(
+        'Deferring manual compaction request until token counting is available.',
+      );
     }
 
     const chatParams: CreateChatParameters = {

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -67,6 +67,7 @@ import {
   nonZeroOrUndefined,
 } from './utils/usageNormalization';
 import { prepareExistingOutputContent } from './utils/fileContentUtils';
+const COMPACTION_MAX_TOKENS = 4096;
 
 // Local file imports
 import {
@@ -77,6 +78,9 @@ import {
   type ToolResultPayload,
 } from './utils/toolAttachmentUtils';
 import { toGoogleTools } from './toolConversion';
+import { DEFAULT_SUMMARY_PROMPT } from './compaction/compactionPrompt';
+import { getCompactionModel } from './compaction/compactionModels';
+import { extractSummaryText } from './compaction/compactionUtils';
 
 // Type imports
 import type { MediaFileResult } from './support/MediaAttachmentProcessor';
@@ -434,6 +438,46 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
     return totalTokens;
   }
 
+  private async compactConversation(
+    client: GoogleGenAI,
+    messages: Content[],
+    systemPrompt?: string,
+    signal?: AbortSignal,
+  ): Promise<string> {
+    const compactionModel = getCompactionModel(this.config.fullName);
+    const compactionMessages: Content[] = [
+      ...messages,
+      createUserContent([createPartFromText(DEFAULT_SUMMARY_PROMPT)]),
+    ];
+    const compactionHistory = compactionMessages.slice(0, -1);
+    const lastCompactionMessage = compactionMessages.at(-1);
+    const lastCompactionParts = Array.isArray(lastCompactionMessage?.parts)
+      ? lastCompactionMessage.parts
+      : [];
+
+    const chat = client.chats.create({
+      model: compactionModel,
+      history: compactionHistory,
+      config: {
+        maxOutputTokens: Math.min(
+          this.config.maxOutputTokens ?? COMPACTION_MAX_TOKENS,
+          COMPACTION_MAX_TOKENS,
+        ),
+      },
+      ...(systemPrompt && { systemInstruction: systemPrompt }),
+    });
+
+    const response = await chat.sendMessage({
+      message: [...lastCompactionParts],
+      config: { abortSignal: signal },
+    });
+
+    const responseParts = response.candidates?.[0]?.content?.parts ?? [];
+    const rawText =
+      response.text || extractNonThinkingText(responseParts, true);
+    return extractSummaryText(rawText);
+  }
+
   /** Creates a chat completion response using Google's GenAI API with specified parameters and optional system prompt. */
   async createResponse(
     options: CreateResponseOptions<Content, GoogleGenAI>,
@@ -452,20 +496,24 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
       throw new Error('Messages array cannot be empty.');
     }
 
+    const forceCompaction = this.consumeCompactionRequest();
+    const shouldAttemptCompaction =
+      this.isToolUseMode() && (this.isAutoCompactEnabled() || forceCompaction);
+    let effectiveMessages = messages;
+
     // History excludes the final user message - we send it separately via sendMessage
-    const history = messages.slice(0, -1);
-    const lastMessage = messages.at(-1);
-
-    // Messages should already be properly formatted with alternating turns
-    validateGoogleMessageHistory(history, this.logger);
-
-    const lastMessageParts = Array.isArray(lastMessage?.parts)
+    let history = effectiveMessages.slice(0, -1);
+    let lastMessage = effectiveMessages.at(-1);
+    let lastMessageParts = Array.isArray(lastMessage?.parts)
       ? lastMessage.parts
       : [];
     if (lastMessageParts.length === 0) {
       this.logger.error('Could not extract valid parts from the last message.');
       throw new Error('Last message conversion resulted in empty parts.');
     }
+
+    // Messages should already be properly formatted with alternating turns
+    validateGoogleMessageHistory(history, this.logger);
 
     // Phase 1: BUILD - Construct provider-specific request parameters
     const generationConfig: GenerateContentConfig = {
@@ -487,13 +535,6 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
       generationConfig.tools = toGoogleTools(tools);
     }
 
-    const chatParams: CreateChatParameters = {
-      model: this.config.fullName,
-      history,
-      config: generationConfig,
-      ...(systemPrompt && { systemInstruction: systemPrompt }),
-    };
-
     // Phase 2: COUNT - Estimate input tokens using built params
     // Phase 3: VALIDATE - Adjust maxOutputTokens if needed
     if (this.supportsTokenCounting) {
@@ -508,11 +549,58 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
           googleTools: generationConfig.tools as GeminiTool[] | undefined,
           signal,
         });
+        let effectiveInputTokens = totalTokens;
+
+        if (shouldAttemptCompaction) {
+          const threshold = this.getCompactionTokenThreshold(
+            this.config.contextWindow,
+          );
+          if (forceCompaction || (threshold > 0 && totalTokens > threshold)) {
+            const summaryText = await this.compactConversation(
+              client,
+              effectiveMessages,
+              systemPrompt,
+              signal,
+            );
+            effectiveMessages = [
+              createUserContent([createPartFromText(summaryText)]),
+            ];
+            history = effectiveMessages.slice(0, -1);
+            lastMessage = effectiveMessages.at(-1);
+            lastMessageParts = Array.isArray(lastMessage?.parts)
+              ? lastMessage.parts
+              : [];
+            validateGoogleMessageHistory(history, this.logger);
+            const tokensAfter = await this.estimateTokenCount(history, {
+              client,
+              systemPrompt,
+              lastMessageParts,
+              googleTools: generationConfig.tools as GeminiTool[] | undefined,
+              signal,
+            });
+            effectiveInputTokens = tokensAfter;
+            const utilizationBefore =
+              (totalTokens / this.config.contextWindow) * 100;
+            const utilizationAfter =
+              (tokensAfter / this.config.contextWindow) * 100;
+            const compactionModel = getCompactionModel(this.config.fullName);
+            this.logger.logContextManagement('Context compacted', {
+              action: 'compaction',
+              tokensBefore: totalTokens,
+              tokensAfter,
+              contextWindow: this.config.contextWindow,
+              utilizationBefore,
+              utilizationAfter,
+              summary: summaryText,
+              compactionModel,
+            });
+          }
+        }
 
         // Validate and adjust maxOutputTokens if needed (throws if context window exceeded)
         const originalMaxTokens = generationConfig.maxOutputTokens ?? 8192;
         const validation = this.validateTokenLimits(
-          totalTokens,
+          effectiveInputTokens,
           originalMaxTokens,
           this.config.contextWindow,
         );
@@ -546,6 +634,13 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
         );
       }
     }
+
+    const chatParams: CreateChatParameters = {
+      model: this.config.fullName,
+      history,
+      config: generationConfig,
+      ...(systemPrompt && { systemInstruction: systemPrompt }),
+    };
 
     // Phase 4: EXECUTE - Make the API call
     const useStreaming = this.getStreamingConfig();

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -50,6 +50,10 @@ import {
   nonZeroOrUndefined,
 } from './utils/usageNormalization';
 import { prepareExistingOutputContent } from './utils/fileContentUtils';
+import { DEFAULT_SUMMARY_PROMPT } from './compaction/compactionPrompt';
+import { getCompactionModel } from './compaction/compactionModels';
+import { compactOpenAICompatible } from './compaction/openaiCompatibleCompaction';
+import { extractSummaryText } from './compaction/compactionUtils';
 
 // Local file imports
 import { OPENAI_CHAT_FINISH } from './types/StopReasonTypes';
@@ -69,6 +73,7 @@ import type {
   ExtractResponseResult,
   DeepSeekToolCall,
   OpenAIToolCall,
+  TokenCountOptions,
 } from './types/IModelHandler';
 
 // Type imports
@@ -90,6 +95,7 @@ function extractReasoningText(content: ReasoningContent | undefined): string {
 }
 
 const DEEPSEEK_OFFICIAL_API_MAX_TOKENS = 8192;
+const TOKEN_ESTIMATION_DIVISOR = 4;
 
 export interface StreamingAggregator {
   appendContent(delta: string): void;
@@ -119,6 +125,66 @@ export class ModelHandlerOpenAI<
   OpenAI,
   ChatCompletion
 > {
+  /**
+   * Estimates token count using a heuristic for OpenAI-compatible messages.
+   * Subclasses can override for native token counting APIs.
+   */
+  override async estimateTokenCount(
+    messages: ChatCompletionMessageParam[],
+    _options?: TokenCountOptions<OpenAI>,
+  ): Promise<number> {
+    const serialized = messages
+      .map((message) => {
+        const content = this.stringifyMessageContent(message.content);
+        const toolCalls = 'tool_calls' in message ? message.tool_calls : null;
+        const functionCall =
+          'function_call' in message ? message.function_call : null;
+        return [
+          message.role,
+          content,
+          toolCalls ? JSON.stringify(toolCalls) : '',
+          functionCall ? JSON.stringify(functionCall) : '',
+        ]
+          .filter(Boolean)
+          .join(' ');
+      })
+      .join('\n');
+
+    return Math.ceil(serialized.length / TOKEN_ESTIMATION_DIVISOR);
+  }
+
+  private stringifyMessageContent(
+    content: ChatCompletionMessageParam['content'],
+  ): string {
+    if (!content) return '';
+    if (typeof content === 'string') return content;
+    if (!Array.isArray(content)) return '';
+    return content
+      .map((part) =>
+        part && 'text' in part && typeof part.text === 'string'
+          ? part.text
+          : '',
+      )
+      .filter(Boolean)
+      .join('\n');
+  }
+
+  private buildCompactedMessages(
+    messages: ChatCompletionMessageParam[],
+    summary: string,
+  ): ChatCompletionMessageParam[] {
+    const preserved: ChatCompletionMessageParam[] = [];
+    for (const message of messages) {
+      if (message.role === 'system' || message.role === 'developer') {
+        preserved.push(message);
+      } else {
+        break;
+      }
+    }
+
+    return [...preserved, { role: 'user', content: summary }];
+  }
+
   /**
    * Creates a new OpenAI client using the stored credentials.
    * Handles API key retrieval, base URL resolution, and logging.
@@ -377,6 +443,54 @@ export class ModelHandlerOpenAI<
     const messages = normOptions
       ? this.prepareNormalizedMessages(rawMessages, normOptions)
       : rawMessages;
+
+    const forceCompaction = this.consumeCompactionRequest();
+    const shouldAttemptCompaction =
+      this.isToolUseMode() && (this.isAutoCompactEnabled() || forceCompaction);
+    if (shouldAttemptCompaction) {
+      const tokensBefore = await this.estimateTokenCount(messages, {
+        client,
+        systemPrompt,
+        signal,
+      });
+      const threshold = this.getCompactionTokenThreshold(
+        this.config.contextWindow,
+      );
+      if (forceCompaction || (threshold > 0 && tokensBefore > threshold)) {
+        const compactionModel = getCompactionModel(this.config.fullName);
+        const compactionResult = await compactOpenAICompatible(
+          client,
+          messages,
+          compactionModel,
+          DEFAULT_SUMMARY_PROMPT,
+        );
+        const summaryText = extractSummaryText(compactionResult.summary);
+        const compactedMessages = this.buildCompactedMessages(
+          messages,
+          summaryText,
+        );
+        const tokensAfter = await this.estimateTokenCount(compactedMessages, {
+          client,
+          systemPrompt,
+          signal,
+        });
+        const utilizationBefore =
+          (tokensBefore / this.config.contextWindow) * 100;
+        const utilizationAfter =
+          (tokensAfter / this.config.contextWindow) * 100;
+        this.logger.logContextManagement('Context compacted', {
+          action: 'compaction',
+          tokensBefore,
+          tokensAfter,
+          contextWindow: this.config.contextWindow,
+          utilizationBefore,
+          utilizationAfter,
+          summary: summaryText,
+          compactionModel,
+        });
+        messages.splice(0, messages.length, ...compactedMessages);
+      }
+    }
 
     // Phase 1: BUILD - Construct provider-specific request parameters
     const useStreaming = this.getStreamingConfig();

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -95,7 +95,8 @@ function extractReasoningText(content: ReasoningContent | undefined): string {
 }
 
 const DEEPSEEK_OFFICIAL_API_MAX_TOKENS = 8192;
-const TOKEN_ESTIMATION_DIVISOR = 4;
+// Heuristic token estimation: lower divisor slightly to overcount for non-English/code-heavy content.
+const TOKEN_ESTIMATION_DIVISOR = 3.5;
 
 export interface StreamingAggregator {
   appendContent(delta: string): void;
@@ -443,59 +444,61 @@ export class ModelHandlerOpenAI<
     const messages = normOptions
       ? this.prepareNormalizedMessages(rawMessages, normOptions)
       : rawMessages;
+    let effectiveMessages = messages;
 
-    const forceCompaction = this.consumeCompactionRequest();
+    const forceCompaction = this.hasPendingCompactionRequest();
     const shouldAttemptCompaction =
       this.isToolUseMode() && (this.isAutoCompactEnabled() || forceCompaction);
     if (shouldAttemptCompaction) {
-      const tokensBefore = await this.estimateTokenCount(messages, {
+      const tokensBefore = await this.estimateTokenCount(effectiveMessages, {
         client,
         systemPrompt,
         signal,
       });
-      const threshold = this.getCompactionTokenThreshold(
-        this.config.contextWindow,
-      );
-      if (forceCompaction || (threshold > 0 && tokensBefore > threshold)) {
-        const compactionModel = getCompactionModel(this.config.fullName);
-        const compactionResult = await compactOpenAICompatible(
-          client,
-          messages,
-          compactionModel,
-          DEFAULT_SUMMARY_PROMPT,
-        );
-        const summaryText = extractSummaryText(compactionResult.summary);
-        const compactedMessages = this.buildCompactedMessages(
-          messages,
-          summaryText,
-        );
-        const tokensAfter = await this.estimateTokenCount(compactedMessages, {
-          client,
-          systemPrompt,
-          signal,
-        });
-        const utilizationBefore =
-          (tokensBefore / this.config.contextWindow) * 100;
-        const utilizationAfter =
-          (tokensAfter / this.config.contextWindow) * 100;
-        this.logger.logContextManagement('Context compacted', {
-          action: 'compaction',
-          tokensBefore,
-          tokensAfter,
-          contextWindow: this.config.contextWindow,
-          utilizationBefore,
-          utilizationAfter,
-          summary: summaryText,
-          compactionModel,
-        });
-        messages.splice(0, messages.length, ...compactedMessages);
-      }
+      const compactionOutcome = await this.maybeCompactContext({
+        messages: effectiveMessages,
+        tokensBefore,
+        contextWindow: this.config.contextWindow,
+        forceCompaction,
+        shouldAttempt: shouldAttemptCompaction,
+        estimateTokens: (nextMessages) =>
+          this.estimateTokenCount(nextMessages, {
+            client,
+            systemPrompt,
+            signal,
+          }),
+        compact: async () => {
+          const compactionModel = getCompactionModel(this.config.fullName);
+          const compactionResult = await compactOpenAICompatible(
+            client,
+            effectiveMessages,
+            compactionModel,
+            DEFAULT_SUMMARY_PROMPT,
+          );
+          const summaryText = extractSummaryText(compactionResult.summary);
+          const compactedMessages = this.buildCompactedMessages(
+            effectiveMessages,
+            summaryText,
+          );
+          return {
+            summaryText,
+            compactedMessages,
+            compactionModel,
+            compactionInputTokens: compactionResult.inputTokens,
+            compactionOutputTokens: compactionResult.outputTokens,
+          };
+        },
+        onCompactionStart: () => {
+          this.consumeCompactionRequest();
+        },
+      });
+      effectiveMessages = compactionOutcome.messages;
     }
 
     // Phase 1: BUILD - Construct provider-specific request parameters
     const useStreaming = this.getStreamingConfig();
     const baseParams = this.buildChatBaseParams(
-      messages,
+      effectiveMessages,
       temperature,
       systemPrompt,
       endTag,
@@ -506,7 +509,7 @@ export class ModelHandlerOpenAI<
     // Phase 3: VALIDATE - Adjust max_tokens if needed
     if (this.supportsTokenCounting) {
       try {
-        const inputTokens = await this.estimateTokenCount(messages, {
+        const inputTokens = await this.estimateTokenCount(effectiveMessages, {
           client,
           systemPrompt,
           signal,

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -3,7 +3,6 @@ import { Buffer } from 'node:buffer';
 
 // Third-party imports
 import OpenAI, { APIConnectionTimeoutError, toFile } from 'openai';
-import type { InputTokenCountParams } from 'openai/resources/responses/input-tokens';
 
 // Local imports - agent
 import type { AgentConfig } from '@agent/core/AgentConfig';
@@ -49,7 +48,6 @@ import {
 import { OPENAI_CHAT_FINISH } from './types/StopReasonTypes';
 import { toOpenAIResponseTools } from './toolConversion';
 import { ModelHandler } from './ModelHandler';
-import { DEFAULT_COMPACTION_THRESHOLD_PERCENT } from './contextManagementConstants';
 import {
   buildOpenAIWebSearchResult,
   extractOpenAIWebSearchResults,
@@ -62,6 +60,7 @@ import {
 
 // Type imports
 import type { ProviderStopReason } from './types/StopReasonTypes';
+import type { InputTokenCountParams } from 'openai/resources/responses/input-tokens';
 import type {
   CreateResponseOptions,
   ExtractResponseResult,
@@ -437,39 +436,17 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
   }
 
   /**
-   * Get the configured compaction threshold percentage.
-   * Returns 0 if compaction is disabled.
-   */
-  private getCompactionThresholdPercent(): number {
-    return getConfig<number>(
-      'texra.model.compactionThresholdPercent',
-      DEFAULT_COMPACTION_THRESHOLD_PERCENT,
-    );
-  }
-
-  /**
-   * Calculate the absolute token threshold based on the model's context window
-   * and the configured percentage threshold.
-   */
-  private getCompactionTokenThreshold(): number {
-    const percent = this.getCompactionThresholdPercent();
-    if (percent <= 0) {
-      return 0;
-    }
-    // Calculate threshold as percentage of context window
-    return Math.floor((percent / 100) * this.config.contextWindow);
-  }
-
-  /**
    * Check if the conversation should be compacted based on cumulative input tokens.
    * Compaction is only triggered when:
    * - Threshold percentage is greater than 0 (not disabled)
    * - Cumulative input tokens exceed the calculated threshold (percentage of context window)
    * - Not running through OpenRouter (which may not support compaction)
    */
-  private shouldCompact(): boolean {
-    const thresholdPercent = this.getCompactionThresholdPercent();
-    if (thresholdPercent <= 0) {
+  private shouldCompact(forceCompaction: boolean): boolean {
+    if (!this.isToolUseMode()) {
+      return false;
+    }
+    if (!this.isAutoCompactEnabled() && !forceCompaction) {
       return false;
     }
     if (this.isOpenRouterRoutingEnabled()) {
@@ -479,7 +456,16 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       }
       return false;
     }
-    const threshold = this.getCompactionTokenThreshold();
+    if (forceCompaction) {
+      return true;
+    }
+    const thresholdPercent = this.getCompactionThresholdPercent();
+    if (thresholdPercent <= 0) {
+      return false;
+    }
+    const threshold = this.getCompactionTokenThreshold(
+      this.config.contextWindow,
+    );
     return this.conversationState.cumulativeInputTokens > threshold;
   }
 
@@ -554,6 +540,8 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
           contextWindow,
           utilizationBefore: Number(utilizationBefore.toFixed(1)),
           utilizationAfter: Number(utilizationAfter.toFixed(1)),
+          summary: 'Server-side compaction (details not available)',
+          compactionModel: this.config.fullName,
           details: `OpenAI Responses API compaction: ${compactedResponse.output.length} items`,
         },
       );
@@ -990,11 +978,15 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     let effectiveMessages = messages;
     // Track if compaction happened in THIS call (not previous calls)
     let compactedThisCall = false;
-    if (this.shouldCompact()) {
-      const threshold = this.getCompactionTokenThreshold();
-      this.logger.logProgress(
-        `Compacting conversation (${this.conversationState.cumulativeInputTokens} tokens exceed ${this.getCompactionThresholdPercent()}% threshold of ${threshold} tokens)`,
+    const forceCompaction = this.consumeCompactionRequest();
+    if (this.shouldCompact(forceCompaction)) {
+      const threshold = this.getCompactionTokenThreshold(
+        this.config.contextWindow,
       );
+      const compactionLabel = forceCompaction
+        ? 'Compacting conversation (manual request)'
+        : `Compacting conversation (${this.conversationState.cumulativeInputTokens} tokens exceed ${this.getCompactionThresholdPercent()}% threshold of ${threshold} tokens)`;
+      this.logger.logProgress(compactionLabel);
       effectiveMessages = await this.compactConversation(
         client,
         messages,

--- a/src/agent/modelHandlers/openAIMessageUtils.ts
+++ b/src/agent/modelHandlers/openAIMessageUtils.ts
@@ -33,7 +33,7 @@ function mergeMessageContent(
   const currContent = current.content;
 
   // No previous content: use current
-  if (prevContent == null) {
+  if (prevContent === null || prevContent === undefined) {
     previous.content = currContent;
     return;
   }

--- a/src/agent/modelHandlers/types/IModelHandler.ts
+++ b/src/agent/modelHandlers/types/IModelHandler.ts
@@ -209,6 +209,15 @@ export interface IModelHandler<
   /** Retrieve the agent category currently associated with the handler, if any. */
   getAgentCategory(): AgentCategory | undefined;
 
+  /** Enable or disable auto-compaction for this handler instance. */
+  setAutoCompactEnabled(enabled: boolean): void;
+
+  /** Check if auto-compaction is enabled for this handler instance. */
+  isAutoCompactEnabled(): boolean;
+
+  /** Request a manual compaction on the next response cycle. */
+  requestCompaction(): void;
+
   /** Retrieve an authenticated client instance. */
   getClient(): Promise<C>;
 

--- a/src/agent/toolUse/ToolUseAutoCompactState.ts
+++ b/src/agent/toolUse/ToolUseAutoCompactState.ts
@@ -21,6 +21,9 @@ export function setAutoCompactEnabled(
   streamId: StreamTabId,
   enabled: boolean,
 ): boolean {
+  if (autoCompactByStream.get(streamId) === enabled) {
+    return enabled;
+  }
   autoCompactByStream.set(streamId, enabled);
   bus.emit('updateAutoCompactState', { streamId, enabled });
   return enabled;

--- a/src/agent/toolUse/ToolUseAutoCompactState.ts
+++ b/src/agent/toolUse/ToolUseAutoCompactState.ts
@@ -1,0 +1,39 @@
+import { DEFAULT_COMPACTION_THRESHOLD_PERCENT } from '@agent/modelHandlers/contextManagementConstants';
+import { getConfig } from '@utils/config';
+import { bus } from '@eventBus/ProgressEventBus';
+import type { StreamTabId } from '@shared/schemas';
+
+const autoCompactByStream = new Map<StreamTabId, boolean>();
+
+export function isAutoCompactEnabled(streamId: StreamTabId): boolean {
+  const existing = autoCompactByStream.get(streamId);
+  if (existing !== undefined) {
+    return existing;
+  }
+  const thresholdPercent = getConfig<number>(
+    'texra.model.compactionThresholdPercent',
+    DEFAULT_COMPACTION_THRESHOLD_PERCENT,
+  );
+  return thresholdPercent > 0;
+}
+
+export function setAutoCompactEnabled(
+  streamId: StreamTabId,
+  enabled: boolean,
+): boolean {
+  autoCompactByStream.set(streamId, enabled);
+  bus.emit('updateAutoCompactState', { streamId, enabled });
+  return enabled;
+}
+
+export function toggleAutoCompactEnabled(streamId: StreamTabId): boolean {
+  return setAutoCompactEnabled(streamId, !isAutoCompactEnabled(streamId));
+}
+
+export function clearAutoCompactStateForStream(streamId: StreamTabId): void {
+  autoCompactByStream.delete(streamId);
+}
+
+export function clearAllAutoCompactState(): void {
+  autoCompactByStream.clear();
+}

--- a/src/common/webview/commands.ts
+++ b/src/common/webview/commands.ts
@@ -225,6 +225,8 @@ export const PROGRESS_VIEW_COMMANDS = {
   OPEN_TASK_STORAGE: 'openTaskStorage',
   TOOL_EDIT_APPROVAL_ACTION: 'toolEditApprovalAction',
   TOGGLE_TOOL_EDIT_APPROVAL_BYPASS: 'toggleToolEditApprovalBypass',
+  TOGGLE_AUTO_COMPACT: 'toggleAutoCompact',
+  COMPACT_NOW: 'compactNow',
   AGENT_PROPOSAL_ACTION: 'agentProposalAction',
   BASH_APPROVAL_ACTION: 'bashApprovalAction',
 
@@ -249,6 +251,7 @@ export const PROGRESS_VIEW_COMMANDS = {
   RUN_FOLLOWUP: 'runFollowup',
   GET_FOLLOWUP_OPTIONS: 'getFollowupOptions',
   SET_FOLLOWUP_OPTIONS: 'setFollowupOptions',
+  UPDATE_AUTO_COMPACT_STATE: 'updateAutoCompactState',
 } as const;
 
 // History view specific commands

--- a/src/eventBus/ProgressEventBus.ts
+++ b/src/eventBus/ProgressEventBus.ts
@@ -80,6 +80,10 @@ export interface ProgressEventPayloads {
     streamId: StreamTabId;
     bypassActive: boolean;
   };
+  updateAutoCompactState: {
+    streamId: StreamTabId;
+    enabled: boolean;
+  };
   showBashPermission: BashPermission;
   resolveBashPermission: { requestId: string };
   showAgentProposal: AgentProposalPermission;

--- a/src/latex/extractBibliography.ts
+++ b/src/latex/extractBibliography.ts
@@ -127,7 +127,7 @@ export async function extractBibliographyContext(
 }
 
 function formatFieldValue(value: unknown): string {
-  if (value == null) {
+  if (value === null || value === undefined) {
     return '{}';
   }
   if (typeof value === 'number') {

--- a/src/latex/latexdiff/diffFileNameManager.ts
+++ b/src/latex/latexdiff/diffFileNameManager.ts
@@ -44,7 +44,7 @@ export function generateDiffFileName(
     // Extract base name from edited filename using round pattern
     const name = path.parse(editedFileName).name;
     const lastMatch = extractLastRoundMatch(name);
-    if (lastMatch?.index == null) {
+    if (lastMatch?.index === null || lastMatch?.index === undefined) {
       throw new Error(
         `Failed to extract base name from edited file: ${editedFileName}`,
       );

--- a/src/logger/transports/VSCodeTransport.ts
+++ b/src/logger/transports/VSCodeTransport.ts
@@ -88,7 +88,11 @@ export class VSCodeTransport extends Transport {
     const prefix = this.isAgentChannel ? '' : `[${this.streamId}] `;
     this.channel.appendLine(`${emoji} [${timestamp}] ${prefix}${message}`);
 
-    if (structuredData != null && this.includeStructuredData?.()) {
+    if (
+      structuredData !== null &&
+      structuredData !== undefined &&
+      this.includeStructuredData?.()
+    ) {
       const dataString =
         typeof structuredData === 'string'
           ? structuredData

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -12,6 +12,12 @@ import { getAgent } from '@agent/index/agentRegistry';
 import { proposalCoordinator } from '@agent/runtime/AgentProposalCoordinator';
 import { retryCoordinator } from '@agent/runtime/RetryRequestCoordinator';
 import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
+import {
+  clearAllAutoCompactState,
+  clearAutoCompactStateForStream,
+  toggleAutoCompactEnabled,
+} from '@agent/toolUse/ToolUseAutoCompactState';
+import { getToolUseFlowContext } from '@agent/toolUse/ToolUseAgentRegistry';
 import { toErrorMessage } from '@common/errors';
 import {
   BaseViewMessageHandler,
@@ -165,6 +171,28 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
           : 'YOLO mode disabled: Tool actions will prompt for approval.';
         await vscode.window.showInformationMessage(msg);
       },
+      [PROGRESS_VIEW_COMMANDS.TOGGLE_AUTO_COMPACT]: async (data) => {
+        const isNowEnabled = toggleAutoCompactEnabled(data.stream);
+        const flowContext = getToolUseFlowContext(data.stream);
+        flowContext?.services.modelHandler.setAutoCompactEnabled(isNowEnabled);
+        const msg = isNowEnabled
+          ? 'Auto-compact enabled: context will be summarized when threshold is exceeded.'
+          : 'Auto-compact disabled.';
+        await vscode.window.showInformationMessage(msg);
+      },
+      [PROGRESS_VIEW_COMMANDS.COMPACT_NOW]: async (data) => {
+        const flowContext = getToolUseFlowContext(data.stream);
+        if (!flowContext) {
+          await vscode.window.showInformationMessage(
+            'No active tool-use session available for compaction.',
+          );
+          return;
+        }
+        flowContext.services.modelHandler.requestCompaction();
+        await vscode.window.showInformationMessage(
+          'Compaction requested. The next model call will summarize context.',
+        );
+      },
       [PROGRESS_VIEW_COMMANDS.AGENT_PROPOSAL_ACTION]: (data) =>
         this.handleAgentProposalAction(data),
       [PROGRESS_VIEW_COMMANDS.BASH_APPROVAL_ACTION]: (data) =>
@@ -276,6 +304,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     // Clear pending task groups, approvals, queued follow-ups, and YOLO state to prevent memory leaks
     this.provider.eventHandler.clearPendingTaskGroups(streamId);
     cleanupApprovalsForStream(streamId);
+    clearAutoCompactStateForStream(streamId);
     ToolUseFollowUpQueue.release(streamId);
     this.clearModelOutputBackups(streamId);
     await this.provider.state.clearStream(streamId);
@@ -299,6 +328,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     // Clear all pending task groups, approvals, queued follow-ups, and YOLO state to prevent memory leaks
     this.provider.eventHandler.clearAllPendingTaskGroups();
     cleanupAllApprovals();
+    clearAllAutoCompactState();
     for (const streamId of this.provider.state.streamTabs.keys()) {
       ToolUseFollowUpQueue.release(streamId);
     }

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -125,6 +125,11 @@ export class ProgressViewProvider
               bypassActive,
             );
         },
+        updateAutoCompactState: (streamId, enabled) => {
+          if (canSend()) {
+            u.updateAutoCompactState(streamId as StreamTabId, enabled);
+          }
+        },
         showBashPermission: (p) => this.bashApprovalHandler.show(p),
         resolveBashPermission: (id) => this.bashApprovalHandler.resolve(id),
         showAgentProposal: (p) => this.agentProposalHandler.show(p),

--- a/src/progressView/events/UIEvents.ts
+++ b/src/progressView/events/UIEvents.ts
@@ -37,6 +37,11 @@ interface ApprovalCallbacks {
   ) => void;
 }
 
+/** Callbacks for auto-compact toggle state handling. */
+interface AutoCompactCallbacks {
+  updateAutoCompactState: (streamId: string, enabled: boolean) => void;
+}
+
 /** Callbacks for bash approval event handling. */
 interface BashApprovalCallbacks {
   showBashPermission: (
@@ -56,6 +61,7 @@ interface AgentProposalCallbacks {
 /** Combined UI callbacks interface. */
 export type UICallbacks = RetryCallbacks &
   ApprovalCallbacks &
+  AutoCompactCallbacks &
   BashApprovalCallbacks &
   AgentProposalCallbacks;
 
@@ -121,6 +127,14 @@ export function registerUIEvents(
     (p) =>
       callbacks.updateToolEditApprovalBypassState(p.streamId, p.bypassActive),
     'failed to update approval bypass state',
+    signal,
+  );
+
+  registerEvent(
+    bus,
+    'updateAutoCompactState',
+    (p) => callbacks.updateAutoCompactState(p.streamId, p.enabled),
+    'failed to update auto-compact state',
     signal,
   );
 

--- a/src/progressView/frontend/ProgressApp.ts
+++ b/src/progressView/frontend/ProgressApp.ts
@@ -47,6 +47,7 @@ import {
   handleFilterChange,
   handleFollowUpChange,
   handleFollowUpClear,
+  handleFollowUpCompact,
   handleFollowUpPolish,
   handleFollowUpSend,
   handleFollowupModeChange,
@@ -234,6 +235,7 @@ export class ProgressApp extends BaseWebviewApp {
           @followup-send=${this.onFollowUpSend}
           @followup-polish=${this.onFollowUpPolish}
           @followup-clear=${this.onFollowUpClear}
+          @followup-compact=${this.onFollowUpCompact}
           @followup-focus-complete=${this.onFollowUpFocusComplete}
         ></tool-use-stream-content>
       `;
@@ -384,6 +386,9 @@ export class ProgressApp extends BaseWebviewApp {
 
   private onFollowUpClear = (): void =>
     handleFollowUpClear(this.getEventHandlerContext());
+
+  private onFollowUpCompact = (): void =>
+    handleFollowUpCompact(this.getEventHandlerContext());
 
   private onFollowupRequestOptions = (): void =>
     handleFollowupRequestOptions(this.getEventHandlerContext());

--- a/src/progressView/frontend/components/ContextManagement.ts
+++ b/src/progressView/frontend/components/ContextManagement.ts
@@ -75,6 +75,22 @@ export class ContextManagement extends LitElement {
       .stat-item .codicon {
         opacity: 0.7;
       }
+
+      .summary-block {
+        flex-basis: 100%;
+        margin-top: var(--spacing-small);
+        padding: var(--spacing-small);
+        border-radius: var(--border-radius);
+        background: color-mix(
+          in srgb,
+          var(--accent-color, var(--vscode-foreground)) 8%,
+          transparent
+        );
+        white-space: pre-wrap;
+        font-family: var(--font-family-monospace);
+        font-size: var(--font-size-sm);
+        line-height: 1.4;
+      }
     `,
   ];
 
@@ -90,6 +106,9 @@ export class ContextManagement extends LitElement {
 
   /** Statistics items to display */
   @property({ type: Array }) items: ContextStatItem[] = [];
+
+  /** Optional summary text shown when compaction occurs */
+  @property({ type: String }) summary = '';
 
   override render(): TemplateResult {
     if (this.items.length === 0) {
@@ -119,6 +138,9 @@ export class ContextManagement extends LitElement {
               </span>
             `,
           )}
+          ${this.summary
+            ? html`<div class="summary-block">${this.summary}</div>`
+            : nothing}
         </div>
       </details>
     `;

--- a/src/progressView/frontend/components/FollowUpInput.ts
+++ b/src/progressView/frontend/components/FollowUpInput.ts
@@ -235,6 +235,13 @@ export class FollowUpInput extends LitElement {
                 @click=${this.emitClear}
               ></vscode-toolbar-button>
               <vscode-toolbar-button
+                id=${ELEMENT_IDS.COMPACT_NOW_BTN}
+                icon="fold-down"
+                label="Compact context"
+                title="Compact conversation context (summarize history to free tokens)"
+                @click=${this.emitCompact}
+              ></vscode-toolbar-button>
+              <vscode-toolbar-button
                 id=${ELEMENT_IDS.SEND_FOLLOW_UP_BTN}
                 icon="send"
                 label="Send"
@@ -289,6 +296,10 @@ export class FollowUpInput extends LitElement {
 
   private emitClear(): void {
     this.dispatchEvent(ProgressEvents.followupClear());
+  }
+
+  private emitCompact(): void {
+    this.dispatchEvent(ProgressEvents.followupCompact());
   }
 
   private updateValue(value: string): void {

--- a/src/progressView/frontend/components/RequestPanels.ts
+++ b/src/progressView/frontend/components/RequestPanels.ts
@@ -19,9 +19,6 @@ import {
   requestPanelStyles,
 } from '@shared/styles';
 
-// Local imports - progress view styles
-import { codeBlockStyles } from '../styles/codeBlockStyles';
-
 // Local imports - shared schemas
 import {
   AGENT_CATEGORY,
@@ -40,6 +37,9 @@ import { postMessage } from '@shared/vscode';
 
 // Local imports - webview commands
 import { PROGRESS_VIEW_COMMANDS } from '@common/webview/commands';
+
+// Local imports - progress view styles
+import { codeBlockStyles } from '../styles/codeBlockStyles';
 
 // Local imports - progress view events
 import { ProgressEvents } from '../events';
@@ -940,12 +940,19 @@ export class RequestPanels extends LitElement {
     const lines = [
       details.message && `message: ${details.message}`,
       details.provider && `provider: ${details.provider}`,
-      details.statusCode != null && `statusCode: ${details.statusCode}`,
+      details.statusCode !== null &&
+        details.statusCode !== undefined &&
+        `statusCode: ${details.statusCode}`,
       details.statusText && `statusText: ${details.statusText}`,
-      details.isRelayError != null && `isRelayError: ${details.isRelayError}`,
-      details.retryable != null && `retryable: ${details.retryable}`,
+      details.isRelayError !== null &&
+        details.isRelayError !== undefined &&
+        `isRelayError: ${details.isRelayError}`,
+      details.retryable !== null &&
+        details.retryable !== undefined &&
+        `retryable: ${details.retryable}`,
       details.requestId && `requestId: ${details.requestId}`,
-      details.rawErrorBody != null &&
+      details.rawErrorBody !== null &&
+        details.rawErrorBody !== undefined &&
         `rawErrorBody: ${formatBody(details.rawErrorBody)}`,
     ].filter(Boolean);
 

--- a/src/progressView/frontend/components/StreamHeader.ts
+++ b/src/progressView/frontend/components/StreamHeader.ts
@@ -58,6 +58,7 @@ const ENABLED_BUTTONS_BY_STATUS: Record<string, string[]> = {
   [STREAM_STATUS.RUNNING]: [
     ELEMENT_IDS.STOP_STREAM_BTN,
     ELEMENT_IDS.YOLO_TOGGLE_BTN,
+    ELEMENT_IDS.AUTO_COMPACT_TOGGLE_BTN,
     ELEMENT_IDS.RESTORE_STATE_BTN,
     ELEMENT_IDS.OPEN_TASK_STORAGE_BTN,
   ],
@@ -90,12 +91,14 @@ const ENABLED_BUTTONS_BY_STATUS: Record<string, string[]> = {
   [STREAM_STATUS.WAITING]: [
     ELEMENT_IDS.STOP_STREAM_BTN,
     ELEMENT_IDS.YOLO_TOGGLE_BTN,
+    ELEMENT_IDS.AUTO_COMPACT_TOGGLE_BTN,
     ELEMENT_IDS.RESTORE_STATE_BTN,
     ELEMENT_IDS.OPEN_TASK_STORAGE_BTN,
   ],
   [STREAM_STATUS.RESUMING]: [
     ELEMENT_IDS.STOP_STREAM_BTN,
     ELEMENT_IDS.YOLO_TOGGLE_BTN,
+    ELEMENT_IDS.AUTO_COMPACT_TOGGLE_BTN,
     ELEMENT_IDS.RESTORE_STATE_BTN,
     ELEMENT_IDS.OPEN_TASK_STORAGE_BTN,
   ],
@@ -280,6 +283,33 @@ export class StreamHeader extends LitElement {
           color-mix(in srgb, var(--color-error) 60%, transparent);
       }
 
+      .auto-compact-toggle-button {
+        flex-shrink: 0;
+        transition: all 0.2s ease;
+      }
+
+      .auto-compact-toggle-button.is-active {
+        color: var(--color-info);
+        background-color: color-mix(
+          in srgb,
+          var(--color-info) 15%,
+          transparent
+        );
+        border-radius: var(--border-radius);
+        box-shadow: 0 0 8px
+          color-mix(in srgb, var(--color-info) 40%, transparent);
+      }
+
+      .auto-compact-toggle-button.is-active:hover {
+        background-color: color-mix(
+          in srgb,
+          var(--color-info) 25%,
+          transparent
+        );
+        box-shadow: 0 0 12px
+          color-mix(in srgb, var(--color-info) 60%, transparent);
+      }
+
       @media (max-width: 500px) {
         .log-header {
           flex-wrap: wrap;
@@ -306,6 +336,7 @@ export class StreamHeader extends LitElement {
     startTime: number;
   }> = [];
   @property({ type: Boolean }) yoloActive = false;
+  @property({ type: Boolean }) autoCompactActive = false;
 
   override render(): TemplateResult | typeof nothing {
     if (!this.stream) {
@@ -356,7 +387,13 @@ export class StreamHeader extends LitElement {
                     status,
                     hasExecutionId,
                   );
-                  const isActive = Boolean(btn.isToggle && this.yoloActive);
+                  const isActive = Boolean(
+                    btn.isToggle &&
+                    ((btn.id === ELEMENT_IDS.YOLO_TOGGLE_BTN &&
+                      this.yoloActive) ||
+                      (btn.id === ELEMENT_IDS.AUTO_COMPACT_TOGGLE_BTN &&
+                        this.autoCompactActive)),
+                  );
                   const icon =
                     isActive && btn.iconActive ? btn.iconActive : btn.icon;
                   const title =

--- a/src/progressView/frontend/components/ToolUseStreamContent.ts
+++ b/src/progressView/frontend/components/ToolUseStreamContent.ts
@@ -19,6 +19,7 @@
  * @fires followup-send - When follow-up is submitted
  * @fires followup-polish - When polish button is clicked
  * @fires followup-clear - When clear button is clicked
+ * @fires followup-compact - When compact context is clicked
  */
 
 // Third-party imports
@@ -136,6 +137,7 @@ export class ToolUseStreamContent extends LitElement {
         .runId=${null}
         .runs=${this.runGroups}
         .yoloActive=${Boolean(currentState.toolEditBypass)}
+        .autoCompactActive=${Boolean(currentState.autoCompactEnabled)}
       ></stream-header>
 
       <request-panels .permissions=${this.filteredPermissions}></request-panels>

--- a/src/progressView/frontend/constants.ts
+++ b/src/progressView/frontend/constants.ts
@@ -48,8 +48,10 @@ export const ELEMENT_IDS = {
   QUEUED_FOLLOW_UPS_LIST: 'queuedFollowUpsList',
   RECORD_FOLLOW_UP_BTN: 'recordFollowUpBtn',
   YOLO_TOGGLE_BTN: 'yoloToggleBtn',
+  AUTO_COMPACT_TOGGLE_BTN: 'autoCompactToggleBtn',
   POLISH_FOLLOW_UP_BTN: 'polishFollowUpBtn',
   CLEAR_FOLLOW_UP_BTN: 'clearFollowUpBtn',
+  COMPACT_NOW_BTN: 'compactNowBtn',
   SEND_FOLLOW_UP_BTN: 'sendFollowUpBtn',
   AGENT_FILTER_CONTAINER: 'agentFilterButtons',
   FILTER_ALL_BTN: 'filterAllBtn',
@@ -162,9 +164,21 @@ const YOLO_TOGGLE_BUTTON = Object.freeze({
   isToggle: true,
 });
 
+const AUTO_COMPACT_TOGGLE_BUTTON = Object.freeze({
+  id: ELEMENT_IDS.AUTO_COMPACT_TOGGLE_BTN,
+  icon: 'fold',
+  iconActive: 'unfold',
+  command: COMMANDS.TOGGLE_AUTO_COMPACT,
+  title: 'Enable auto-compact (summarize context when threshold exceeded)',
+  titleActive: 'Auto-compact active - click to disable',
+  className: 'auto-compact-toggle-button',
+  isToggle: true,
+});
+
 const TOOL_USE_TOOLBAR = [
   STOP_STREAM_BUTTON,
   YOLO_TOGGLE_BUTTON,
+  AUTO_COMPACT_TOGGLE_BUTTON,
   RESTORE_STATE_BUTTON,
   { ...OPEN_TASK_STORAGE_BUTTON },
 ];

--- a/src/progressView/frontend/eventHandlers.ts
+++ b/src/progressView/frontend/eventHandlers.ts
@@ -199,6 +199,12 @@ export function handleFollowUpClear(ctx: FrontendEventHandlerContext): void {
   });
 }
 
+export function handleFollowUpCompact(ctx: FrontendEventHandlerContext): void {
+  const streamId = ctx.getState().activeStreamId;
+  if (!streamId) return;
+  postMessage(PROGRESS_VIEW_COMMANDS.COMPACT_NOW, { stream: streamId });
+}
+
 export function handleFollowupRequestOptions(
   ctx: FrontendEventHandlerContext,
 ): void {

--- a/src/progressView/frontend/events.ts
+++ b/src/progressView/frontend/events.ts
@@ -106,6 +106,8 @@ export const ProgressEvents = {
 
   followupClear: () => createEvent('followup-clear', undefined),
 
+  followupCompact: () => createEvent('followup-compact', undefined),
+
   followupRequestOptions: () =>
     createEvent('followup-request-options', undefined),
 

--- a/src/progressView/frontend/formatters/htmlBuilders.ts
+++ b/src/progressView/frontend/formatters/htmlBuilders.ts
@@ -109,7 +109,10 @@ export function buildCopyButton(
   options: { hidden?: boolean; content?: string; contentId?: string } = {},
 ): TemplateResult {
   const { hidden = false, content, contentId } = options;
-  const copyId = content != null ? registerCopyContent(content, contentId) : '';
+  const copyId =
+    content !== null && content !== undefined
+      ? registerCopyContent(content, contentId)
+      : '';
   // prettier-ignore
   return html`<vscode-toolbar-button class="banner-content-copy" icon="copy" title=${title} aria-label=${title} data-default-title=${title} data-success-title="Copied!" data-copy-id=${ifDefined(copyId || undefined)} data-copy-type="banner" ?hidden=${hidden}></vscode-toolbar-button>`;
 }

--- a/src/progressView/frontend/formatters/logFormatters/contextManagementFormatters.ts
+++ b/src/progressView/frontend/formatters/logFormatters/contextManagementFormatters.ts
@@ -66,7 +66,7 @@ const ACTION_CONFIG: Record<
 /** Build context management items from data. */
 function buildContextManagementItems(
   data: unknown,
-): { config: ActionConfig; items: ContextStatItem[] } | null {
+): { config: ActionConfig; items: ContextStatItem[]; summary?: string } | null {
   const result = ContextManagementDataSchema.safeParse(data);
   if (!result.success) {
     return null;
@@ -82,6 +82,8 @@ function buildContextManagementItems(
     originalMaxTokens,
     reducedMaxTokens,
     details,
+    summary,
+    compactionModel,
   } = result.data;
 
   const config: ActionConfig = ACTION_CONFIG[action] || {
@@ -145,7 +147,15 @@ function buildContextManagementItems(
     });
   }
 
-  return { config, items };
+  if (compactionModel) {
+    items.push({
+      icon: 'codicon-hubot',
+      label: 'Compaction model',
+      value: compactionModel,
+    });
+  }
+
+  return { config, items, summary };
 }
 
 /** Format context management event as TemplateResult. */
@@ -157,13 +167,14 @@ export function formatContextManagementTemplate(
   const result = buildContextManagementItems(data);
   if (!result) return null;
 
-  const { config, items } = result;
+  const { config, items, summary } = result;
 
   return html`
     <context-management
       .logId=${id}
       .config=${config}
       .items=${items}
+      .summary=${summary ?? ''}
     ></context-management>
   `;
 }

--- a/src/progressView/frontend/messageDispatcher.ts
+++ b/src/progressView/frontend/messageDispatcher.ts
@@ -615,6 +615,13 @@ const handlers: HandlerRegistry = {
     }));
   },
 
+  [PROGRESS_VIEW_COMMANDS.UPDATE_AUTO_COMPACT_STATE]: (data, ctx) => {
+    updateToolUseState(ctx, data.stream, (prev) => ({
+      ...prev,
+      autoCompactEnabled: data.enabled,
+    }));
+  },
+
   [PROGRESS_VIEW_COMMANDS.SHOW_BASH_APPROVAL]: (data, ctx) => {
     addPermission(ctx, { kind: PERMISSION_KIND.BASH, data: data.request });
   },

--- a/src/progressView/managers/OutputFilesManager.ts
+++ b/src/progressView/managers/OutputFilesManager.ts
@@ -209,7 +209,9 @@ export class OutputFilesManager extends PersistentMapManager<
     if (!runs) return paths;
 
     const targetRunIds =
-      options.storageKey != null ? [options.storageKey] : [...runs.keys()];
+      options.storageKey !== null && options.storageKey !== undefined
+        ? [options.storageKey]
+        : [...runs.keys()];
     const workspaceOnly = options.workspaceOnly ?? false;
 
     for (const target of targetRunIds) {

--- a/src/progressView/managers/WebviewUpdater.ts
+++ b/src/progressView/managers/WebviewUpdater.ts
@@ -221,6 +221,14 @@ export class WebviewUpdater {
     });
   }
 
+  updateAutoCompactState(stream: StreamTabId, enabled: boolean): void {
+    this.sendMessage({
+      command: PROGRESS_VIEW_COMMANDS.UPDATE_AUTO_COMPACT_STATE,
+      stream,
+      enabled,
+    });
+  }
+
   showBashPermission(permission: BashPermission): void {
     this.sendMessage({
       command: PROGRESS_VIEW_COMMANDS.SHOW_BASH_APPROVAL,

--- a/src/settingsView/SettingsViewMessageHandler.ts
+++ b/src/settingsView/SettingsViewMessageHandler.ts
@@ -6,45 +6,55 @@
  */
 import * as vscode from 'vscode';
 
-// Shared schemas and dispatchers
+// Local imports - shared schemas
 import {
   dispatchSettingsViewInbound,
   type SettingsViewInboundHandlerRegistry,
   type SettingsViewInboundMessage,
   SETTINGS_VIEW_CMD,
 } from '@shared/schemas/settingsViewMessages';
+
+// Local imports - agent
+import { getAgentsBySource, loadAgents } from '@agent/index';
+import { selectAgentInMainView } from '@agent/remote/remoteAgentUtils';
+
+// Local imports - common
 import { showLoggedErrorMessage } from '@common/errors';
 import {
   BaseViewMessageHandler,
   SETTINGS_VIEW_COMMANDS,
 } from '@common/webview';
+import {
+  AgentHistoryManager,
+  type AgentHistoryItem,
+} from '@common/history/AgentHistoryManager';
 
-// Memory-related imports
+// Local imports - tools
 import { MEMORY_STORAGE_ROOT } from '@tools/memory/constants';
 import { resolveMemoryStoragePath } from '@tools/memory/memoryUtils';
+
+// Local imports - utils
 import { StorageFS } from '@utils/files';
-import { loadMemoryItems } from './utils/memoryFileSystem';
+import { agentConfigToTaskState } from '@utils/config/configConversion';
 import {
   getToolUseMemoryEnabled,
   setToolUseMemoryEnabled,
 } from '@utils/config/constants';
 
-// History-related imports
-import {
-  AgentHistoryManager,
-  type AgentHistoryItem,
-} from '@common/history/AgentHistoryManager';
-import { agentConfigToTaskState } from '@utils/config/configConversion';
+// Local imports - commands
 import { runExecuteCommand } from '@commands/agent/executeCommand';
 
-// Profile-related imports
-import type { RemoteAgent } from '@shared/schemas/profileViewMessages';
-import { getAgentsBySource, loadAgents } from '@agent/index';
-import { selectAgentInMainView } from '@agent/remote/remoteAgentUtils';
+// Local imports - auth
 import { SupabaseClient } from '@/auth/SupabaseClient';
 import { AUTH_COMMANDS } from '@/auth/authCommands';
-import { ULTRA_TIER, MAX_TIER } from '@/auth/config';
+import { MAX_TIER, ULTRA_TIER } from '@/auth/config';
 import { getServerSideKeyService } from '@/auth/serverKeys';
+
+// Local imports - settings view utils
+import { loadMemoryItems } from './utils/memoryFileSystem';
+
+// Local imports - shared schemas
+import type { RemoteAgent } from '@shared/schemas/profileViewMessages';
 
 // Type helper for extracting specific message types
 type MessageFor<C extends SettingsViewInboundMessage['command']> = Extract<

--- a/src/settingsView/SettingsViewProvider.ts
+++ b/src/settingsView/SettingsViewProvider.ts
@@ -1,15 +1,15 @@
 // Third-party imports
 import * as vscode from 'vscode';
 
+// Local imports - shared schemas
+import { type SettingsTab } from '@shared/schemas/settingsViewMessages';
+
 // Local imports - common webview
 import { BaseWebviewProvider, SETTINGS_VIEW_COMMANDS } from '@common/webview';
 
 // Local imports - settings view components
 import { SettingsViewContentProvider } from './SettingsViewContentProvider';
 import { SettingsViewMessageHandler } from './SettingsViewMessageHandler';
-
-// Local imports - shared schemas
-import { type SettingsTab } from '@shared/schemas/settingsViewMessages';
 
 export class SettingsViewProvider
   extends BaseWebviewProvider

--- a/src/settingsView/frontend/SettingsApp.ts
+++ b/src/settingsView/frontend/SettingsApp.ts
@@ -6,7 +6,6 @@
 // Third-party imports
 import { html, css, type TemplateResult } from 'lit';
 import { customElement, state, query } from 'lit/decorators.js';
-import type { VscTabsSelectEvent } from '@vscode-elements/elements/dist/vscode-tabs/vscode-tabs.js';
 
 // Local imports - shared webview
 import { BaseWebviewApp } from '@shared/BaseWebviewApp';
@@ -38,6 +37,9 @@ import { SETTINGS_VIEW_COMMANDS } from '@common/webview/commands';
 
 // Local imports - settings view styles
 import { settingsViewStyles } from './styles';
+
+// Type imports
+import type { VscTabsSelectEvent } from '@vscode-elements/elements/dist/vscode-tabs/vscode-tabs.js';
 
 // Local imports - settings view tabs (side-effect: register)
 import './tabs/MemoryTab';

--- a/src/settingsView/frontend/tabs/HistoryTab.ts
+++ b/src/settingsView/frontend/tabs/HistoryTab.ts
@@ -15,11 +15,12 @@ import {
   historyStyles,
 } from '@shared/styles';
 
+// Local imports - settings view components
+import { HistoryViewState } from '../components/history/state';
+
 // Local imports - shared schemas
 import type { HistoryItem } from '@shared/schemas';
 
-// Local imports - settings view components
-import { HistoryViewState } from '../components/history/state';
 import '../components/history/SearchBar';
 import '../components/history/HistoryList';
 import type { SearchAction } from '../components/history/HistoryList';

--- a/src/settingsView/utils/memoryFileSystem.ts
+++ b/src/settingsView/utils/memoryFileSystem.ts
@@ -8,7 +8,6 @@
 import * as path from 'path';
 import * as vscode from 'vscode';
 
-import type { MemoryViewItem } from '@shared/schemas/settingsViewMessages';
 import {
   MEMORY_STORAGE_ROOT,
   MAX_PREVIEW_LINES,
@@ -17,6 +16,7 @@ import {
 } from '@tools/memory/constants';
 import { relativeToDisplayPath } from '@tools/memory/memoryUtils';
 import { StorageFS } from '@utils/files';
+import type { MemoryViewItem } from '@shared/schemas/settingsViewMessages';
 
 /**
  * Builds a preview of content with truncation info.

--- a/src/shared/schemas/contextManagement.ts
+++ b/src/shared/schemas/contextManagement.ts
@@ -19,6 +19,8 @@ export const ContextManagementDataSchema = z.object({
   details: z.string().optional(),
   originalMaxTokens: z.number().positive().optional(),
   reducedMaxTokens: z.number().positive().optional(),
+  summary: z.string().optional(),
+  compactionModel: z.string().optional(),
 });
 
 export type ContextManagementData = z.infer<typeof ContextManagementDataSchema>;

--- a/src/shared/schemas/contextManagement.ts
+++ b/src/shared/schemas/contextManagement.ts
@@ -21,6 +21,8 @@ export const ContextManagementDataSchema = z.object({
   reducedMaxTokens: z.number().positive().optional(),
   summary: z.string().optional(),
   compactionModel: z.string().optional(),
+  compactionInputTokens: z.number().nonnegative().optional(),
+  compactionOutputTokens: z.number().nonnegative().optional(),
 });
 
 export type ContextManagementData = z.infer<typeof ContextManagementDataSchema>;

--- a/src/shared/schemas/progressView.ts
+++ b/src/shared/schemas/progressView.ts
@@ -230,6 +230,12 @@ export const UpdateToolEditApprovalStateMessageSchema = z.object({
   bypassActive: z.boolean(),
 });
 
+export const UpdateAutoCompactStateMessageSchema = z.object({
+  command: z.literal(PROGRESS_VIEW_COMMANDS.UPDATE_AUTO_COMPACT_STATE),
+  stream: StreamTabIdSchema,
+  enabled: z.boolean(),
+});
+
 export const ShowBashApprovalMessageSchema = z.object({
   command: z.literal(PROGRESS_VIEW_COMMANDS.SHOW_BASH_APPROVAL),
   request: BashPermissionSchema,
@@ -334,6 +340,7 @@ export const ProgressViewOutboundMessageSchema = z.discriminatedUnion(
     ShowToolEditApprovalMessageSchema,
     ResolveToolEditApprovalMessageSchema,
     UpdateToolEditApprovalStateMessageSchema,
+    UpdateAutoCompactStateMessageSchema,
     ShowBashApprovalMessageSchema,
     ResolveBashApprovalMessageSchema,
     ShowRetryRequestMessageSchema,
@@ -504,6 +511,16 @@ const ToggleToolEditApprovalBypassMessageSchema = z.object({
   stream: StreamTabIdSchema,
 });
 
+const ToggleAutoCompactMessageSchema = z.object({
+  command: z.literal(PROGRESS_VIEW_COMMANDS.TOGGLE_AUTO_COMPACT),
+  stream: StreamTabIdSchema,
+});
+
+const CompactNowMessageSchema = z.object({
+  command: z.literal(PROGRESS_VIEW_COMMANDS.COMPACT_NOW),
+  stream: StreamTabIdSchema,
+});
+
 const SendFollowUpMessageSchema = z.object({
   command: z.literal(PROGRESS_VIEW_COMMANDS.SEND_FOLLOW_UP),
   stream: StreamTabIdSchema,
@@ -650,6 +667,8 @@ export const ProgressViewInboundMessageSchema = z.discriminatedUnion(
     StopRecordingMessageSchema,
     ToolEditApprovalActionMessageSchema,
     ToggleToolEditApprovalBypassMessageSchema,
+    ToggleAutoCompactMessageSchema,
+    CompactNowMessageSchema,
     BashApprovalActionMessageSchema,
     AgentProposalActionMessageSchema,
     ShowInformationMessageSchema,

--- a/src/shared/schemas/streamState.ts
+++ b/src/shared/schemas/streamState.ts
@@ -59,6 +59,7 @@ export const ToolUseStreamStateSchema = BaseStreamStateSchema.extend({
   todos: z.array(TodoItemSchema).prefault([]),
   queuedFollowUps: z.array(z.string()).prefault([]),
   toolEditBypass: z.boolean().optional(),
+  autoCompactEnabled: z.boolean().optional(),
   sessionUsage: TokenUsageStatsSchema.nullable().prefault(null),
   // Frontend-owned (nested under ui)
   ui: ToolUseUIStateSchema.prefault({}),

--- a/src/tools/ReadTool.ts
+++ b/src/tools/ReadTool.ts
@@ -133,7 +133,9 @@ export class ReadFileTool extends defineTool({
       rangeProvided: Boolean(input.range),
 
       rangeEndExceeded:
-        input.range?.end != null && input.range.end > totalLines,
+        input.range?.end !== null &&
+        input.range?.end !== undefined &&
+        input.range.end > totalLines,
     });
 
     return {

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -261,10 +261,7 @@ function computeLineChangeSummary(
  * Compute the 0-based line number where the first change occurs.
  * Returns null if the content is identical.
  */
-function firstChangedLine(
-  original: string,
-  proposed: string,
-): number | null {
+function firstChangedLine(original: string, proposed: string): number | null {
   if (original === proposed) {
     return null;
   }

--- a/src/tools/latex/arxivShared.ts
+++ b/src/tools/latex/arxivShared.ts
@@ -89,7 +89,9 @@ export function getAuthorNames(
   maxAuthors?: number,
 ): string[] {
   const names = authors.map((author) => author.name);
-  return maxAuthors != null ? names.slice(0, maxAuthors) : names;
+  return maxAuthors !== null && maxAuthors !== undefined
+    ? names.slice(0, maxAuthors)
+    : names;
 }
 
 /** Normalize entry title by trimming whitespace */

--- a/src/tools/todo/TodoTool.ts
+++ b/src/tools/todo/TodoTool.ts
@@ -9,6 +9,14 @@
 // Third-party imports
 import { z } from 'zod';
 
+// Local imports - shared schemas
+import {
+  TODO_STATUS,
+  TodoItemSchema,
+  type TodoItem,
+  type TodoStatus,
+} from '@shared/schemas';
+
 // Local imports - tools
 import { getCurrentToolFileInteractionContext } from '@agent/toolUse/ToolFileInteractionContext';
 import { AgentLogger } from '@logger/AgentLogger';
@@ -16,14 +24,6 @@ import { type ToolResult } from '@tools/result';
 import { defineTool } from '@tools/core/define';
 
 const logger = new AgentLogger('TodoWriteTool');
-
-// Import todo schemas from single source of truth
-import {
-  TODO_STATUS,
-  TodoItemSchema,
-  type TodoItem,
-  type TodoStatus,
-} from '@shared/schemas';
 
 /** Configuration for displaying todo status - icon and label for each status */
 const STATUS_DISPLAY: Record<TodoStatus, { icon: string; label: string }> = {

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -195,7 +195,7 @@ export function requireField<T>(
   fieldName: string,
   command: string,
 ): T {
-  if (value == null) {
+  if (value === null || value === undefined) {
     throw new ToolError(
       `Parameter \`${fieldName}\` is required for command: ${command}`,
     );

--- a/src/webview/frontend/MainApp.ts
+++ b/src/webview/frontend/MainApp.ts
@@ -538,9 +538,7 @@ export class MainApp extends BaseWebviewApp {
    * Validates that a selection exists in options.
    * Returns current value if found, otherwise falls back to first available option.
    */
-  private validateSelection<
-    T extends { value: string; disabled?: boolean },
-  >(
+  private validateSelection<T extends { value: string; disabled?: boolean }>(
     options: T[],
     currentValue: string,
     preferEnabled = false,


### PR DESCRIPTION
### Motivation

- Prevent hard failures when large tool results push conversations over provider context windows by providing a visible, consistent compaction strategy for all providers (client-side summarization for non-Responses APIs).  
- Give users control and visibility into compaction via the Progress view (auto-toggle + manual Compact Now) and surface compacted summaries in context-management logs.

### Description

- Add a compactation engine and prompts under `src/agent/modelHandlers/compaction/` with `DEFAULT_SUMMARY_PROMPT`, model mapping (`getCompactionModel`) and helpers (`compactOpenAICompatible`, `extractSummaryText`).  
- Add compaction integration to handlers: OpenAI chat (`modelHandlerOpenAI`), Google GenAI (`modelHandlerGoogleGenAI`), Anthropic (`modelHandlerAnthropic`) and keep `OpenAI Responses` native `/responses/compact` path with improved structured logging.  
- Extend the ModelHandler base with auto-compact controls and manual compaction request API: `setAutoCompactEnabled`, `isAutoCompactEnabled`, `requestCompaction`, and threshold helpers `getCompactionTokenThreshold`.  
- Add per-stream auto-compact state and controls: `ToolUseAutoCompactState`, progress-view toolbar toggle (`AUTO_COMPACT_TOGGLE_BTN`) and a follow-up `Compact Now` button; wire UI → backend commands (`TOGGLE_AUTO_COMPACT`, `COMPACT_NOW`) and message handling to trigger compaction.  
- Surface compaction metadata and summary in logs/UI by extending `ContextManagementDataSchema` with `summary` and `compactionModel`, updating formatter and `ContextManagement` component to render the summary block.  
- Wire flow integration so tool-use runs initialize model handlers with the per-stream auto-compact state and accept manual compaction requests (`runToolUseFlow` / `ToolUseSession` integration).  

### Testing

- Formatted the repo with `npm run format` (succeeded).  
- Built the extension bundle with `npm run compile` (webpack completed successfully, with one unrelated nunjucks dynamic dependency warning).  
- Ran linter with `npm run lint` (no errors, only existing/leftover warnings such as `eqeqeq` and some import-order warnings in unrelated files).  

Files of note: new compaction helpers (`src/agent/modelHandlers/compaction/*`), `ModelHandler` and provider handler updates (`modelHandlerOpenAI.ts`, `modelHandlerAnthropic.ts`, `modelHandlerGoogleGenAI.ts`, `modelHandlerOpenAIResponse.ts`), UI changes under `src/progressView/frontend/` and supporting state/events under `src/agent/toolUse/ToolUseAutoCompactState.ts` and `src/progressView/*`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698285084ffc8324908862f56476941c)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core model handler request flow and token-limit behavior across multiple providers, so incorrect thresholds/token estimation or compaction edge cases could alter prompts and affect response quality or reliability.
> 
> **Overview**
> Adds a **shared context-compaction pipeline** to `ModelHandler` (auto-compact enablement, manual compaction requests, threshold calculation, and a `maybeCompactContext` orchestration helper) and introduces a new `modelHandlers/compaction` module with a default summary prompt, provider→compaction-model mapping, and OpenAI-compatible summarization helpers.
> 
> Integrates compaction across providers: **Anthropic and Google** switch from server-side context editing to *client-side summarization* when in tool-use mode and token pressure exceeds the configured threshold (or when manually requested); **OpenAI Chat Completions** gains heuristic token estimation plus client-side compaction while preserving system/developer messages; **OpenAI Responses** keeps `/responses/compact` but now supports manual compaction and logs richer compaction metadata.
> 
> Adds **Progress view controls and state** for compaction: per-stream auto-compact state (`ToolUseAutoCompactState`) wired into tool-use flow initialization, new UI commands (`TOGGLE_AUTO_COMPACT`, `COMPACT_NOW`), toolbar toggle + follow-up button, and schema/UI updates to surface compaction summaries and model metadata in context-management logs. Includes a broad sweep of `== null` → explicit null/undefined checks and minor import/type cleanups.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 667396b9b8b67f2212c1ec8f28bbeefdf4c51b9e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->