### PR TITLE
Add in-progress state tracking for slow tool executions

### DIFF
--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -533,8 +533,8 @@ interface ToolExecutionResult {
     source: string;
     sourceDisplay: string;
   }>;
-  /** Log ID for updating the in-progress log entry after execution */
-  logId?: string;
+  /** Log ID and groupId for updating the in-progress log entry after execution */
+  logRef?: { logId: string; groupId: string | undefined };
 }
 
 /**
@@ -626,7 +626,7 @@ class ToolUseDispatchNode<C> extends BatchNode<
     const tool = options.toolRegistry.get(call.name);
 
     // Only show in-progress for tools that can take a while
-    const logId = SLOW_TOOLS.has(call.name)
+    const logRef = SLOW_TOOLS.has(call.name)
       ? options.logger.logToolUseStart(call.name, parsedInput ?? call.raw)
       : undefined;
 
@@ -661,7 +661,7 @@ class ToolUseDispatchNode<C> extends BatchNode<
       parsedInput,
       sanitizedOutput,
       editedFiles,
-      logId,
+      logRef,
     };
   }
 
@@ -670,7 +670,7 @@ class ToolUseDispatchNode<C> extends BatchNode<
     options: ToolUseCycleOptions<C>,
     workspace: ToolUseCycleServices<C>['workspace'],
   ): Promise<void> {
-    const { call, result, parsedInput, sanitizedOutput, editedFiles, logId } =
+    const { call, result, parsedInput, sanitizedOutput, editedFiles, logRef } =
       execResult;
 
     const toolUseLog = {
@@ -681,9 +681,9 @@ class ToolUseDispatchNode<C> extends BatchNode<
       isError: Boolean(result.isError),
     };
 
-    // Update the in-progress log entry with the result, or create new if no logId
-    if (logId) {
-      options.logger.updateToolUse(logId, toolUseLog);
+    // Update the in-progress log entry with the result, or create new if no logRef
+    if (logRef) {
+      options.logger.updateToolUse(logRef.logId, toolUseLog, logRef.groupId);
     } else {
       options.logger.logToolUse({ ...toolUseLog, status: 'completed' });
     }

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -685,7 +685,7 @@ class ToolUseDispatchNode<C> extends BatchNode<
     if (logId) {
       options.logger.updateToolUse(logId, toolUseLog);
     } else {
-      options.logger.logToolUse(toolUseLog);
+      options.logger.logToolUse({ ...toolUseLog, status: 'completed' });
     }
 
     // Collect and add valid media file locations

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -530,6 +530,8 @@ interface ToolExecutionResult {
     source: string;
     sourceDisplay: string;
   }>;
+  /** Log ID for updating the in-progress log entry after execution */
+  logId?: string;
 }
 
 /**
@@ -620,6 +622,12 @@ class ToolUseDispatchNode<C> extends BatchNode<
     const parsedInput = parseToolInput(call.input, call.callId, options.logger);
     const tool = options.toolRegistry.get(call.name);
 
+    // Log in-progress state before execution so UI shows the command immediately
+    const logId = options.logger.logToolUseStart({
+      toolName: call.name,
+      input: parsedInput ?? call.raw,
+    });
+
     const result = await this.invokeToolSafely(
       call,
       tool,
@@ -651,6 +659,7 @@ class ToolUseDispatchNode<C> extends BatchNode<
       parsedInput,
       sanitizedOutput,
       editedFiles,
+      logId,
     };
   }
 
@@ -659,7 +668,7 @@ class ToolUseDispatchNode<C> extends BatchNode<
     options: ToolUseCycleOptions<C>,
     workspace: ToolUseCycleServices<C>['workspace'],
   ): Promise<void> {
-    const { call, result, parsedInput, sanitizedOutput, editedFiles } =
+    const { call, result, parsedInput, sanitizedOutput, editedFiles, logId } =
       execResult;
 
     const toolUseLog = {
@@ -669,7 +678,13 @@ class ToolUseDispatchNode<C> extends BatchNode<
       ...(editedFiles.length > 0 && { files: editedFiles }),
       isError: Boolean(result.isError),
     };
-    options.logger.logToolUse(toolUseLog);
+
+    // Update the in-progress log entry with the result, or create new if no logId
+    if (logId) {
+      options.logger.updateToolUse(logId, toolUseLog);
+    } else {
+      options.logger.logToolUse(toolUseLog);
+    }
 
     // Collect and add valid media file locations
     const files = result.files;

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -533,8 +533,8 @@ interface ToolExecutionResult {
     source: string;
     sourceDisplay: string;
   }>;
-  /** Log ID and groupId for updating the in-progress log entry after execution */
-  logRef?: { logId: string; groupId: string | undefined };
+  /** Log reference for consistent grouping. logId only set for slow tools. */
+  logRef: { logId: string | undefined; groupId: string | undefined };
 }
 
 /**
@@ -625,10 +625,10 @@ class ToolUseDispatchNode<C> extends BatchNode<
     const parsedInput = parseToolInput(call.input, call.callId, options.logger);
     const tool = options.toolRegistry.get(call.name);
 
-    // Only show in-progress for tools that can take a while
+    // Capture groupId at start to ensure consistent grouping for all tools
     const logRef = SLOW_TOOLS.has(call.name)
       ? options.logger.logToolUseStart(call.name, parsedInput ?? call.raw)
-      : undefined;
+      : { logId: undefined, groupId: options.logger.resolveActiveGroupId() };
 
     const result = await this.invokeToolSafely(
       call,
@@ -681,11 +681,15 @@ class ToolUseDispatchNode<C> extends BatchNode<
       isError: Boolean(result.isError),
     };
 
-    // Update the in-progress log entry with the result, or create new if no logRef
-    if (logRef) {
+    // Update in-progress log (slow tools) or create new log (fast tools)
+    // Both use the groupId captured at execution start for consistency
+    if (logRef.logId) {
       options.logger.updateToolUse(logRef.logId, toolUseLog, logRef.groupId);
     } else {
-      options.logger.logToolUse({ ...toolUseLog, status: 'completed' });
+      options.logger.logToolUse(
+        { ...toolUseLog, status: 'completed' },
+        logRef.groupId,
+      );
     }
 
     // Collect and add valid media file locations

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -516,7 +516,7 @@ class ToolUseProcessNode<C> extends BaseNode<
 }
 
 /** Tools that may take a while and benefit from showing in-progress state. */
-const SLOW_TOOLS = new Set(['Bash', 'Wolfram', 'WebFetch', 'WebSearch']);
+const SLOW_TOOLS = new Set(['bash', 'wolfram', 'web_fetch', 'web_search']);
 
 /**
  * Result of executing a single tool call, capturing everything needed

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -515,6 +515,9 @@ class ToolUseProcessNode<C> extends BaseNode<
   }
 }
 
+/** Tools that may take a while and benefit from showing in-progress state. */
+const SLOW_TOOLS = new Set(['Bash', 'Wolfram', 'WebFetch', 'WebSearch']);
+
 /**
  * Result of executing a single tool call, capturing everything needed
  * for logging and message creation.
@@ -622,11 +625,10 @@ class ToolUseDispatchNode<C> extends BatchNode<
     const parsedInput = parseToolInput(call.input, call.callId, options.logger);
     const tool = options.toolRegistry.get(call.name);
 
-    // Log in-progress state before execution so UI shows the command immediately
-    const logId = options.logger.logToolUseStart({
-      toolName: call.name,
-      input: parsedInput ?? call.raw,
-    });
+    // Only show in-progress for tools that can take a while
+    const logId = SLOW_TOOLS.has(call.name)
+      ? options.logger.logToolUseStart(call.name, parsedInput ?? call.raw)
+      : undefined;
 
     const result = await this.invokeToolSafely(
       call,

--- a/src/logger/AgentLogger.ts
+++ b/src/logger/AgentLogger.ts
@@ -291,6 +291,44 @@ export class AgentLogger {
     this.info('', { groupId, messageType: MESSAGE_TYPES.TOOL_USE, data });
   }
 
+  /**
+   * Log tool use start with status='in_progress'. Returns log ID for later update.
+   * Use this to show the tool command before execution completes.
+   */
+  logToolUseStart(data: { toolName: string; input: unknown }, groupId?: string): string {
+    const id = randomUUID();
+    const resolvedGroupId = groupId ?? this.resolveActiveGroupId();
+    bus.emit('addLogMessage', {
+      streamId: this.streamId,
+      logMessage: {
+        id,
+        text: '',
+        level: 'info',
+        timestamp: Date.now(),
+        groupId: resolvedGroupId,
+        messageType: MESSAGE_TYPES.TOOL_USE,
+        data: { ...data, status: 'in_progress' },
+      },
+    });
+    return id;
+  }
+
+  /**
+   * Update a tool use log entry with the completed result.
+   */
+  updateToolUse(logId: string, data: unknown, groupId?: string): void {
+    const resolvedGroupId = groupId ?? this.resolveActiveGroupId();
+    bus.emit('updateLogMessage', {
+      streamId: this.streamId,
+      logMessage: {
+        id: logId,
+        groupId: resolvedGroupId,
+        messageType: MESSAGE_TYPES.TOOL_USE,
+        data: { ...(data as object), status: 'completed' },
+      },
+    });
+  }
+
   logWebSearch(data: unknown, groupId?: string): void {
     this.info('', { groupId, messageType: MESSAGE_TYPES.WEB_SEARCH, data });
   }

--- a/src/logger/AgentLogger.ts
+++ b/src/logger/AgentLogger.ts
@@ -295,6 +295,7 @@ export class AgentLogger {
   /**
    * Log tool use start with status='in_progress'.
    * Returns log ID and resolved groupId for consistent update.
+   * Note: Emits directly to bus (like createStream) for immediate UI update.
    */
   logToolUseStart(
     toolName: string,
@@ -303,6 +304,7 @@ export class AgentLogger {
   ): { logId: string; groupId: string | undefined } {
     const id = randomUUID();
     const resolvedGroupId = groupId ?? this.resolveActiveGroupId();
+    this.debug(`Tool started: ${toolName}`, { groupId: resolvedGroupId });
     bus.emit('addLogMessage', {
       streamId: this.streamId,
       logMessage: {

--- a/src/logger/AgentLogger.ts
+++ b/src/logger/AgentLogger.ts
@@ -293,9 +293,8 @@ export class AgentLogger {
 
   /**
    * Log tool use start with status='in_progress'. Returns log ID for later update.
-   * Use this to show the tool command before execution completes.
    */
-  logToolUseStart(data: { toolName: string; input: unknown }, groupId?: string): string {
+  logToolUseStart(toolName: string, input: unknown, groupId?: string): string {
     const id = randomUUID();
     const resolvedGroupId = groupId ?? this.resolveActiveGroupId();
     bus.emit('addLogMessage', {
@@ -307,7 +306,7 @@ export class AgentLogger {
         timestamp: Date.now(),
         groupId: resolvedGroupId,
         messageType: MESSAGE_TYPES.TOOL_USE,
-        data: { ...data, status: 'in_progress' },
+        data: { toolName, input, status: 'in_progress' },
       },
     });
     return id;
@@ -316,7 +315,7 @@ export class AgentLogger {
   /**
    * Update a tool use log entry with the completed result.
    */
-  updateToolUse(logId: string, data: unknown, groupId?: string): void {
+  updateToolUse(logId: string, toolUseLog: Record<string, unknown>, groupId?: string): void {
     const resolvedGroupId = groupId ?? this.resolveActiveGroupId();
     bus.emit('updateLogMessage', {
       streamId: this.streamId,
@@ -324,7 +323,7 @@ export class AgentLogger {
         id: logId,
         groupId: resolvedGroupId,
         messageType: MESSAGE_TYPES.TOOL_USE,
-        data: { ...(data as object), status: 'completed' },
+        data: { ...toolUseLog, status: 'completed' },
       },
     });
   }

--- a/src/logger/AgentLogger.ts
+++ b/src/logger/AgentLogger.ts
@@ -476,7 +476,8 @@ export class AgentLogger {
     logger.endGroup(this.streamId, groupId, status, this.isAgentLogger);
   }
 
-  private resolveActiveGroupId(): string | undefined {
+  /** Get the currently active group ID for this logger's stream. */
+  resolveActiveGroupId(): string | undefined {
     return logger.getActiveGroupId(this.streamId, this.isAgentLogger);
   }
 }

--- a/src/logger/AgentLogger.ts
+++ b/src/logger/AgentLogger.ts
@@ -292,9 +292,14 @@ export class AgentLogger {
   }
 
   /**
-   * Log tool use start with status='in_progress'. Returns log ID for later update.
+   * Log tool use start with status='in_progress'.
+   * Returns log ID and resolved groupId for consistent update.
    */
-  logToolUseStart(toolName: string, input: unknown, groupId?: string): string {
+  logToolUseStart(
+    toolName: string,
+    input: unknown,
+    groupId?: string,
+  ): { logId: string; groupId: string | undefined } {
     const id = randomUUID();
     const resolvedGroupId = groupId ?? this.resolveActiveGroupId();
     bus.emit('addLogMessage', {
@@ -309,19 +314,23 @@ export class AgentLogger {
         data: { toolName, input, status: 'in_progress' },
       },
     });
-    return id;
+    return { logId: id, groupId: resolvedGroupId };
   }
 
   /**
    * Update a tool use log entry with the completed result.
+   * Pass the groupId returned from logToolUseStart for consistency.
    */
-  updateToolUse(logId: string, toolUseLog: Record<string, unknown>, groupId?: string): void {
-    const resolvedGroupId = groupId ?? this.resolveActiveGroupId();
+  updateToolUse(
+    logId: string,
+    toolUseLog: Record<string, unknown>,
+    groupId: string | undefined,
+  ): void {
     bus.emit('updateLogMessage', {
       streamId: this.streamId,
       logMessage: {
         id: logId,
-        groupId: resolvedGroupId,
+        groupId,
         messageType: MESSAGE_TYPES.TOOL_USE,
         data: { ...toolUseLog, status: 'completed' },
       },

--- a/src/logger/AgentLogger.ts
+++ b/src/logger/AgentLogger.ts
@@ -9,6 +9,7 @@ import {
   type ExtendedTokenUsageStats,
   type FileListEntry,
   type MessageType,
+  type ToolUseLog,
 } from '@shared/schemas';
 import { buildErrorLogData } from '@common/errors/sdkErrorUtils';
 import { delay } from '@utils/core';
@@ -323,7 +324,7 @@ export class AgentLogger {
    */
   updateToolUse(
     logId: string,
-    toolUseLog: Record<string, unknown>,
+    toolUseLog: Omit<ToolUseLog, 'status'>,
     groupId: string | undefined,
   ): void {
     bus.emit('updateLogMessage', {

--- a/src/progressView/frontend/formatters/logDataParsers.ts
+++ b/src/progressView/frontend/formatters/logDataParsers.ts
@@ -102,5 +102,6 @@ export function normalizeToolUseData(data: unknown): NormalizedToolUse | null {
     isError: Boolean(validated.isError || nested.isError || errorText),
     isUserFeedback,
     headerSummary: summaryText || (isUserFeedback ? '' : errorText),
+    status: validated.status,
   };
 }

--- a/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
+++ b/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
@@ -153,7 +153,11 @@ export function formatToolUseTemplate(
       : getToolIconClass(toolName, showAsError);
 
   // Build title
-  const titlePrefix = getToolTitlePrefix(isUserFeedback, showAsError, isInProgress);
+  const titlePrefix = getToolTitlePrefix(
+    isUserFeedback,
+    showAsError,
+    isInProgress,
+  );
   const isNormalToolUse = !isUserFeedback && !showAsError && !isInProgress;
   const titleBase = buildTitleBase(toolName, titlePrefix, isNormalToolUse);
 

--- a/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
+++ b/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
@@ -101,9 +101,14 @@ function buildToolSection(
 }
 
 /** Title prefix lookup based on tool state. */
-function getToolTitlePrefix(isUserFeedback: boolean, isError: boolean): string {
+function getToolTitlePrefix(
+  isUserFeedback: boolean,
+  isError: boolean,
+  isInProgress: boolean,
+): string {
   if (isUserFeedback) return 'User Feedback';
   if (isError) return 'Tool Error';
+  if (isInProgress) return 'Running';
   return 'Tool Use';
 }
 
@@ -135,17 +140,21 @@ export function formatToolUseTemplate(
     userInstructionText,
     input,
     isUserFeedback,
+    status,
   } = normalizedToolLog;
 
   // Determine display state
+  const isInProgress = status === 'in_progress';
   const showAsError = normalizedToolLog.isError && !isUserFeedback;
   const iconClass = isUserFeedback
     ? 'codicon-comment'
-    : getToolIconClass(toolName, showAsError);
+    : isInProgress
+      ? 'codicon codicon-sync spin'
+      : getToolIconClass(toolName, showAsError);
 
   // Build title
-  const titlePrefix = getToolTitlePrefix(isUserFeedback, showAsError);
-  const isNormalToolUse = !isUserFeedback && !showAsError;
+  const titlePrefix = getToolTitlePrefix(isUserFeedback, showAsError, isInProgress);
+  const isNormalToolUse = !isUserFeedback && !showAsError && !isInProgress;
   const titleBase = buildTitleBase(toolName, titlePrefix, isNormalToolUse);
 
   const headerSummary = normalizedToolLog.headerSummary ?? '';
@@ -306,7 +315,8 @@ export function formatToolUseTemplate(
       : joinWithSeparator(sections);
 
   const fullTimestamp = new Date(timestamp).toISOString();
-  const shouldOpen = options?.defaultOpen ?? false;
+  // Auto-open in-progress tools so users see the command immediately
+  const shouldOpen = options?.defaultOpen ?? isInProgress;
   // prettier-ignore
   const bannerContentTemplate = html`<div class="banner-content log-entry-content" data-log-id=${ifDefined(id)} data-group-id=${ifDefined(groupId)} data-timestamp=${ifDefined(fullTimestamp)}>${contentTemplate}</div>`;
 
@@ -316,6 +326,7 @@ export function formatToolUseTemplate(
     'tool-use-details': true,
     'tool-use-error': showAsError,
     'tool-use-user-feedback': isUserFeedback,
+    'tool-use-in-progress': isInProgress,
   })} ?open=${shouldOpen}>${buildDetailsSummary({
     iconClass,
     label: titleText,

--- a/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
+++ b/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
@@ -149,7 +149,7 @@ export function formatToolUseTemplate(
   const iconClass = isUserFeedback
     ? 'codicon-comment'
     : isInProgress
-      ? 'codicon codicon-sync spin'
+      ? 'codicon-sync spin'
       : getToolIconClass(toolName, showAsError);
 
   // Build title

--- a/src/progressView/frontend/styles/toolUseStyles.ts
+++ b/src/progressView/frontend/styles/toolUseStyles.ts
@@ -94,15 +94,6 @@ export const toolUseStyles = css`
     animation: spin 1s linear infinite;
   }
 
-  @keyframes spin {
-    from {
-      transform: rotate(0deg);
-    }
-    to {
-      transform: rotate(360deg);
-    }
-  }
-
   :is(.tool-user-feedback, .tool-error-content, .tool-output-full) {
     white-space: pre-wrap;
     word-break: break-word;

--- a/src/progressView/frontend/styles/toolUseStyles.ts
+++ b/src/progressView/frontend/styles/toolUseStyles.ts
@@ -90,6 +90,7 @@ export const toolUseStyles = css`
     color: var(--vscode-charts-yellow, #cca700);
   }
 
+  /* Uses @keyframes spin from animationStyles (included via logStyles) */
   .tool-use-in-progress > .details-summary .codicon.spin {
     animation: spin 1s linear infinite;
   }

--- a/src/progressView/frontend/styles/toolUseStyles.ts
+++ b/src/progressView/frontend/styles/toolUseStyles.ts
@@ -85,6 +85,24 @@ export const toolUseStyles = css`
     color: var(--vscode-textLink-foreground, #3794ff);
   }
 
+  .tool-use-in-progress > .details-summary .tool-use-title,
+  .tool-use-in-progress > .details-summary .codicon {
+    color: var(--vscode-charts-yellow, #cca700);
+  }
+
+  .tool-use-in-progress > .details-summary .codicon.spin {
+    animation: spin 1s linear infinite;
+  }
+
+  @keyframes spin {
+    from {
+      transform: rotate(0deg);
+    }
+    to {
+      transform: rotate(360deg);
+    }
+  }
+
   :is(.tool-user-feedback, .tool-error-content, .tool-output-full) {
     white-space: pre-wrap;
     word-break: break-word;

--- a/src/shared/schemas/progressView.ts
+++ b/src/shared/schemas/progressView.ts
@@ -54,6 +54,9 @@ export const MissingOutputsPayloadSchema = z.object({
 });
 export type MissingOutputsPayload = z.infer<typeof MissingOutputsPayloadSchema>;
 
+export const ToolUseStatusSchema = z.enum(['in_progress', 'completed']);
+export type ToolUseStatus = z.infer<typeof ToolUseStatusSchema>;
+
 export const ToolUseLogSchema = z.object({
   toolName: z.string().optional(),
   tool: z.string().optional(),
@@ -63,6 +66,7 @@ export const ToolUseLogSchema = z.object({
   error: z.string().optional(),
   isError: z.boolean().optional(),
   userInstruction: z.string().optional(),
+  status: ToolUseStatusSchema.optional(),
 });
 export type ToolUseLog = z.infer<typeof ToolUseLogSchema>;
 
@@ -76,6 +80,7 @@ export const NormalizedToolUseSchema = z.object({
   isError: z.boolean(),
   isUserFeedback: z.boolean(),
   headerSummary: z.string(),
+  status: ToolUseStatusSchema.optional(),
 });
 export type NormalizedToolUse = z.infer<typeof NormalizedToolUseSchema>;
 

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -261,10 +261,7 @@ function computeLineChangeSummary(
  * Compute the 0-based line number where the first change occurs.
  * Returns null if the content is identical.
  */
-function firstChangedLine(
-  original: string,
-  proposed: string,
-): number | null {
+function firstChangedLine(original: string, proposed: string): number | null {
   if (original === proposed) {
     return null;
   }

--- a/src/webview/frontend/MainApp.ts
+++ b/src/webview/frontend/MainApp.ts
@@ -538,9 +538,7 @@ export class MainApp extends BaseWebviewApp {
    * Validates that a selection exists in options.
    * Returns current value if found, otherwise falls back to first available option.
    */
-  private validateSelection<
-    T extends { value: string; disabled?: boolean },
-  >(
+  private validateSelection<T extends { value: string; disabled?: boolean }>(
     options: T[],
     currentValue: string,
     preferEnabled = false,


### PR DESCRIPTION
## Summary
This PR adds support for displaying in-progress state for long-running tools (Bash, Wolfram, WebFetch, WebSearch) in the progress view. Users now see a "Running" status with a spinning icon immediately when these tools start executing, and the log entry is updated with the final result once execution completes.

## Key Changes

- **Tool execution tracking**: Added `SLOW_TOOLS` set to identify tools that benefit from in-progress visualization
- **Logger enhancements**: 
  - New `logToolUseStart()` method that creates an in-progress log entry and returns a log ID
  - New `updateToolUse()` method that updates an existing log entry with the final result
- **Dispatch flow updates**: Modified `ToolUseDispatchNode` to call `logToolUseStart()` for slow tools before execution and use `updateToolUse()` after completion
- **Frontend display improvements**:
  - Added `status` field to tool use logs (in_progress/completed)
  - Updated title prefix logic to show "Running" for in-progress tools
  - Added spinning sync icon for in-progress state
  - Auto-open in-progress tool details so users see commands immediately
  - Added `tool-use-in-progress` CSS class for styling
- **Schema updates**: Added `ToolUseStatus` enum and `status` field to relevant schemas

## Implementation Details

The solution uses a two-phase logging approach:
1. When a slow tool starts, `logToolUseStart()` creates a log entry with `status: 'in_progress'` and returns its ID
2. After execution completes, `updateToolUse()` updates that same entry with the final result and `status: 'completed'`

This provides immediate visual feedback to users while tools are running, improving the perceived responsiveness of the agent.

https://claude.ai/code/session_01Gfsw8CZ8s1NAHYsx8GZoyX

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the logging/event-bus path and progress-view rendering, so regressions could cause missing/duplicated tool logs or incorrect grouping, but it’s scoped to status display and tool-use messages.
> 
> **Overview**
> Adds **in-progress tool logging** for long-running tools so the progress view can show a running state immediately and then update the same log entry on completion.
> 
> Backend now identifies `SLOW_TOOLS` and emits `status: 'in_progress'` via new `AgentLogger.logToolUseStart()` (returning a log id + resolved `groupId`), then finalizes via `AgentLogger.updateToolUse()`; fast tools keep emitting a single `status: 'completed'` log. Frontend schemas/parsers/formatters are extended with a `status` field to render a “Running” title, spinning icon, auto-open details, and yellow styling for in-progress entries.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a1004a895c52516da276ff42aaeb4ca90f39eca4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->