### PR TITLE
Remove default open state from todo list collapsible

### DIFF
--- a/src/progressView/frontend/components/TodoList.ts
+++ b/src/progressView/frontend/components/TodoList.ts
@@ -115,7 +115,6 @@ export class TodoList extends LitElement {
         id=${ELEMENT_IDS.TODO_LIST_CONTAINER}
         class="todo-collapsible panel-collapsible"
         title="Task Progress"
-        open
       >
         <div id=${ELEMENT_IDS.TODO_LIST} class="todo-list">
           ${repeat(


### PR DESCRIPTION
## Summary
Removed the `open` attribute from the todo list collapsible panel to change its default behavior from expanded to collapsed on initial load.

## Changes
- Removed the `open` attribute from the todo-collapsible element in TodoList component
- The task progress panel will now default to a collapsed state instead of being expanded by default

## Details
This change affects the initial UI state of the task progress section. Users will need to click to expand the todo list rather than having it open automatically. This can improve the initial page load experience by reducing visual clutter and allowing users to focus on other content first.

https://claude.ai/code/session_01UwnhHXrxxTnpQEB2w27Dt9

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single UI-default change (collapsed vs expanded) with no data or control-flow impact.
> 
> **Overview**
> The `Task Progress` `vscode-collapsible` in `TodoList` no longer sets the `open` attribute, so the todo panel defaults to *collapsed* instead of expanded on initial render.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e22e33967ca5c7d7caed63cce11f469a7c8f4cea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->