### PR TITLE
fix(auth): prevent sign-in timeout when auth provider fails to register

### DIFF
--- a/src/MainViewProvider.ts
+++ b/src/MainViewProvider.ts
@@ -21,7 +21,7 @@ import { computeModelOptionsData } from '@model/computeModelOptions';
 import { watchConfig, getConfig, DEBOUNCE_OPTIONS_MS } from '@utils/config';
 import { debounce } from '@utils/core';
 import { checkCoreDependencies } from '@utils/system/toolUtils';
-import { getServerSideKeyService } from '@/auth/serverKeys';
+import { getServerSideKeyService } from '@auth/serverKeys';
 
 // Local file imports
 import { MainViewMessageHandler } from './webview/MainViewMessageHandler';

--- a/src/agent/remote/RemoteAgentLoader.ts
+++ b/src/agent/remote/RemoteAgentLoader.ts
@@ -17,8 +17,8 @@ import { toErrorMessage } from '@common/errors/errorHandlingUtils';
 import * as logger from '@logger/logUtils';
 import { resolveToolDefinitions } from '@tools/registry';
 import { getConfig } from '@utils/config';
-import { SupabaseClient } from '@/auth/SupabaseClient';
-import { SUPABASE_CONFIG } from '@/auth/config';
+import { SupabaseClient } from '@auth/SupabaseClient';
+import { SUPABASE_CONFIG } from '@auth/config';
 
 import {
   RemoteAgentListItemSchema,

--- a/src/agent/runtime/agentLoad.ts
+++ b/src/agent/runtime/agentLoad.ts
@@ -22,6 +22,8 @@ import {
 } from '@agent/core/AgentDataclass';
 import { toErrorMessage } from '@common/errors/errorHandlingUtils';
 import * as logger from '@logger/logUtils';
+import { RemoteAgentLoader } from '@agent/remote/RemoteAgentLoader';
+import { resolveToolDefinitions } from '@tools/registry';
 
 // Internal imports
 import { AbsoluteFS } from '@utils/files';
@@ -114,8 +116,6 @@ export async function loadAgentSettingAndPrompts(
 
     // Handle remote agents
     if (entry.source === 'remote') {
-      const { RemoteAgentLoader } =
-        await import('@agent/remote/RemoteAgentLoader');
       const remoteConfig = await RemoteAgentLoader.loadRemoteAgent(
         resolution.resolvedName,
         { preferMultiple: options?.preferMultiple },
@@ -158,7 +158,6 @@ export async function loadAgentSettingAndPrompts(
 
     // Resolve tool names to definitions using shared utility
     if (Array.isArray(settings.tools)) {
-      const { resolveToolDefinitions } = await import('@tools/registry');
       settings.tools = resolveToolDefinitions(
         settings.tools as (string | { name: string })[],
         (name) => logger.warn(CHANNEL, `Tool "${name}" not found in registry`),

--- a/src/auth/SupabaseClient.ts
+++ b/src/auth/SupabaseClient.ts
@@ -11,7 +11,6 @@ import {
   type UserTier,
   UserAuthContextSchema,
   SUPABASE_SESSION_KEY,
-  isAuthProviderRegistered,
 } from './config';
 
 /** Interface for auth provider to avoid circular imports. */
@@ -21,6 +20,7 @@ interface AuthTokenProvider {
 
 /**
  * Singleton Supabase client with authentication helpers.
+ * This is the single source of truth for auth initialization state.
  */
 export class SupabaseClient {
   private static instance: Client | null = null;
@@ -29,11 +29,60 @@ export class SupabaseClient {
   private static authProvider: AuthTokenProvider | null = null;
 
   /**
+   * Whether VS Code's auth provider registration succeeded.
+   * This is separate from authProvider being set (which happens in constructor).
+   */
+  private static vscodeProviderRegistered = false;
+
+  /**
+   * Error that occurred during initialization, if any.
+   * Used to provide meaningful error messages to users.
+   */
+  private static initError: Error | null = null;
+
+  /**
    * Register an auth provider for token refresh.
    * Called by SupabaseAuthProvider on initialization.
    */
   static setAuthProvider(provider: AuthTokenProvider): void {
     this.authProvider = provider;
+  }
+
+  /**
+   * Mark VS Code auth provider as successfully registered.
+   * Called after vscode.authentication.registerAuthenticationProvider() succeeds.
+   */
+  static setVSCodeProviderRegistered(): void {
+    this.vscodeProviderRegistered = true;
+  }
+
+  /**
+   * Record an initialization error for later retrieval.
+   * Allows surfacing meaningful error messages to users.
+   */
+  static setInitError(error: Error): void {
+    this.initError = error;
+  }
+
+  /**
+   * Get initialization error if any occurred.
+   */
+  static getInitError(): Error | null {
+    return this.initError;
+  }
+
+  /**
+   * Check if auth system is fully initialized and ready for use.
+   * Use this before calling vscode.authentication.getSession('texra-supabase', ...)
+   * to avoid timeout errors.
+   */
+  static isReady(): boolean {
+    return (
+      this.instance !== null &&
+      this.authProvider !== null &&
+      this.vscodeProviderRegistered &&
+      this.initError === null
+    );
   }
 
   /**
@@ -98,12 +147,12 @@ export class SupabaseClient {
       }
 
       // Fallback to VS Code's authentication API
-      // Only attempt if provider was successfully registered, otherwise VS Code
-      // will timeout waiting for a provider that was never registered
-      if (!isAuthProviderRegistered()) {
+      // Only attempt if auth system is ready, otherwise VS Code will timeout
+      // waiting for a provider that was never registered
+      if (!this.isReady()) {
         logger.debug(
           'SupabaseClient',
-          'Skipping VS Code auth fallback - provider not registered with VS Code',
+          'Skipping VS Code auth fallback - auth system not ready',
         );
         return null;
       }

--- a/src/auth/SupabaseClient.ts
+++ b/src/auth/SupabaseClient.ts
@@ -73,8 +73,6 @@ export class SupabaseClient {
 
   /**
    * Check if auth system is fully initialized and ready for use.
-   * Use this before calling vscode.authentication.getSession('texra-supabase', ...)
-   * to avoid timeout errors.
    */
   static isReady(): boolean {
     return (
@@ -123,46 +121,18 @@ export class SupabaseClient {
   }
 
   /**
-   * Get the current user's access token from VS Code authentication.
-   * Automatically refreshes the token if it's about to expire via the registered auth provider.
-   * @param forceRefresh - When true, forces a token refresh regardless of local expiry (e.g., after relay 401).
+   * Get the current user's access token.
+   * Returns null if not authenticated or auth system not ready.
+   * @param forceRefresh - When true, forces a token refresh (e.g., after relay 401).
    */
   static async getAccessToken(forceRefresh?: boolean): Promise<string | null> {
+    if (!this.authProvider) {
+      // Auth provider not set - system not initialized
+      return null;
+    }
+
     try {
-      // Use registered auth provider for proactive token refresh
-      if (this.authProvider) {
-        const token = await this.authProvider.ensureFreshToken(forceRefresh);
-        if (token) {
-          return token;
-        }
-        logger.debug(
-          'SupabaseClient',
-          'ensureFreshToken returned null, falling back to VS Code auth',
-        );
-      } else {
-        logger.debug(
-          'SupabaseClient',
-          'Auth provider not registered, using VS Code auth fallback',
-        );
-      }
-
-      // Fallback to VS Code's authentication API
-      // Only attempt if auth system is ready, otherwise VS Code will timeout
-      // waiting for a provider that was never registered
-      if (!this.isReady()) {
-        logger.debug(
-          'SupabaseClient',
-          'Skipping VS Code auth fallback - auth system not ready',
-        );
-        return null;
-      }
-
-      const session = await vscode.authentication.getSession(
-        'texra-supabase',
-        [],
-        { silent: true },
-      );
-      return session?.accessToken || null;
+      return await this.authProvider.ensureFreshToken(forceRefresh);
     } catch (error) {
       logger.error(
         'SupabaseClient',

--- a/src/auth/SupabaseClient.ts
+++ b/src/auth/SupabaseClient.ts
@@ -11,6 +11,7 @@ import {
   type UserTier,
   UserAuthContextSchema,
   SUPABASE_SESSION_KEY,
+  isAuthProviderRegistered,
 } from './config';
 
 /** Interface for auth provider to avoid circular imports. */
@@ -97,6 +98,16 @@ export class SupabaseClient {
       }
 
       // Fallback to VS Code's authentication API
+      // Only attempt if provider was successfully registered, otherwise VS Code
+      // will timeout waiting for a provider that was never registered
+      if (!isAuthProviderRegistered()) {
+        logger.debug(
+          'SupabaseClient',
+          'Skipping VS Code auth fallback - provider not registered with VS Code',
+        );
+        return null;
+      }
+
       const session = await vscode.authentication.getSession(
         'texra-supabase',
         [],

--- a/src/auth/authCommands.ts
+++ b/src/auth/authCommands.ts
@@ -3,11 +3,7 @@ import { toErrorMessage } from '@common/errors/errorHandlingUtils';
 import { getConfig } from '@utils/config';
 import { SupabaseClient } from './SupabaseClient';
 import { SupabaseAuthProvider } from './SupabaseAuthProvider';
-import {
-  type OAuthProvider,
-  getExternalAuthCallbackUri,
-  isAuthProviderRegistered,
-} from './config';
+import { type OAuthProvider, getExternalAuthCallbackUri } from './config';
 
 const AUTH_PROVIDER_ID = 'texra-supabase';
 
@@ -28,8 +24,8 @@ function isVSCodeGitHubEnabled(): boolean {
 async function getExistingSession(): Promise<
   vscode.AuthenticationSession | undefined
 > {
-  // Skip VS Code auth API if provider was never registered to avoid timeout
-  if (!isAuthProviderRegistered()) {
+  // Skip VS Code auth API if auth system not ready to avoid timeout
+  if (!SupabaseClient.isReady()) {
     return undefined;
   }
   return vscode.authentication.getSession(AUTH_PROVIDER_ID, [], {
@@ -77,10 +73,14 @@ function getSignInOptions(): SignInOption[] {
 
 export async function signIn(): Promise<void> {
   try {
-    // Check if auth provider was registered - if not, provide clear error
-    if (!isAuthProviderRegistered()) {
+    // Check if auth system is ready - if not, provide clear error with reason
+    if (!SupabaseClient.isReady()) {
+      const initError = SupabaseClient.getInitError();
+      const reason = initError
+        ? initError.message
+        : 'Authentication service not initialized';
       void vscode.window.showErrorMessage(
-        'Sign in failed: Authentication service not initialized. Please reload VS Code and try again. If the issue persists, check the TeXRA output channel for errors.',
+        `Sign in failed: ${reason}. Please reload VS Code and try again. If the issue persists, check the TeXRA output channel for errors.`,
       );
       return;
     }

--- a/src/auth/authCommands.ts
+++ b/src/auth/authCommands.ts
@@ -4,14 +4,11 @@ import { getConfig } from '@utils/config';
 import { SupabaseClient } from './SupabaseClient';
 import { SupabaseAuthProvider } from './SupabaseAuthProvider';
 import { type OAuthProvider, getExternalAuthCallbackUri } from './config';
+import { AUTH_PROVIDER_ID, AUTH_COMMANDS } from './constants';
+import { showSettingsView } from '@commands/settings';
 
-const AUTH_PROVIDER_ID = 'texra-supabase';
-
-export const AUTH_COMMANDS = {
-  SIGN_IN: 'texra.auth.signIn',
-  SIGN_OUT: 'texra.auth.signOut',
-  VIEW_PROFILE: 'texra.auth.viewProfile',
-} as const;
+// Re-export for backwards compatibility
+export { AUTH_COMMANDS } from './constants';
 
 type AuthMethod = OAuthProvider | 'github-browser' | 'email';
 
@@ -191,8 +188,6 @@ export async function signOut(): Promise<void> {
 
 export async function viewProfile(): Promise<void> {
   try {
-    // Import dynamically to avoid circular dependencies
-    const { showSettingsView } = await import('@commands/settings');
     await showSettingsView();
   } catch (error) {
     void vscode.window.showErrorMessage(

--- a/src/auth/authCommands.ts
+++ b/src/auth/authCommands.ts
@@ -3,7 +3,11 @@ import { toErrorMessage } from '@common/errors/errorHandlingUtils';
 import { getConfig } from '@utils/config';
 import { SupabaseClient } from './SupabaseClient';
 import { SupabaseAuthProvider } from './SupabaseAuthProvider';
-import { type OAuthProvider, getExternalAuthCallbackUri } from './config';
+import {
+  type OAuthProvider,
+  getExternalAuthCallbackUri,
+  isAuthProviderRegistered,
+} from './config';
 
 const AUTH_PROVIDER_ID = 'texra-supabase';
 
@@ -24,6 +28,10 @@ function isVSCodeGitHubEnabled(): boolean {
 async function getExistingSession(): Promise<
   vscode.AuthenticationSession | undefined
 > {
+  // Skip VS Code auth API if provider was never registered to avoid timeout
+  if (!isAuthProviderRegistered()) {
+    return undefined;
+  }
   return vscode.authentication.getSession(AUTH_PROVIDER_ID, [], {
     silent: true,
   });
@@ -69,6 +77,14 @@ function getSignInOptions(): SignInOption[] {
 
 export async function signIn(): Promise<void> {
   try {
+    // Check if auth provider was registered - if not, provide clear error
+    if (!isAuthProviderRegistered()) {
+      void vscode.window.showErrorMessage(
+        'Sign in failed: Authentication service not initialized. Please reload VS Code and try again. If the issue persists, check the TeXRA output channel for errors.',
+      );
+      return;
+    }
+
     const existing = await getExistingSession();
     if (existing) {
       const user = await SupabaseClient.getUser();

--- a/src/auth/config.ts
+++ b/src/auth/config.ts
@@ -201,13 +201,6 @@ export const EXTENSION_ID = 'texra-ai.texra';
 let runtimeExtensionId: string | null = null;
 
 /**
- * Flag indicating whether the VS Code auth provider was successfully registered.
- * When false, calls to vscode.authentication.getSession('texra-supabase', ...) will
- * time out waiting for a provider that was never registered.
- */
-let authProviderRegistered = false;
-
-/**
  * Set the runtime extension ID from the extension context.
  * Should be called during extension activation with context.extension.id
  */
@@ -221,23 +214,6 @@ export function setRuntimeExtensionId(id: string): void {
  */
 export function getExtensionId(): string {
   return runtimeExtensionId ?? EXTENSION_ID;
-}
-
-/**
- * Mark the auth provider as successfully registered with VS Code.
- * Should be called immediately after vscode.authentication.registerAuthenticationProvider() succeeds.
- */
-export function setAuthProviderRegistered(): void {
-  authProviderRegistered = true;
-}
-
-/**
- * Check if the auth provider has been registered with VS Code.
- * Use this before calling vscode.authentication.getSession('texra-supabase', ...)
- * to avoid timeout errors when the provider was never registered.
- */
-export function isAuthProviderRegistered(): boolean {
-  return authProviderRegistered;
 }
 
 /**

--- a/src/auth/config.ts
+++ b/src/auth/config.ts
@@ -201,6 +201,13 @@ export const EXTENSION_ID = 'texra-ai.texra';
 let runtimeExtensionId: string | null = null;
 
 /**
+ * Flag indicating whether the VS Code auth provider was successfully registered.
+ * When false, calls to vscode.authentication.getSession('texra-supabase', ...) will
+ * time out waiting for a provider that was never registered.
+ */
+let authProviderRegistered = false;
+
+/**
  * Set the runtime extension ID from the extension context.
  * Should be called during extension activation with context.extension.id
  */
@@ -214,6 +221,23 @@ export function setRuntimeExtensionId(id: string): void {
  */
 export function getExtensionId(): string {
   return runtimeExtensionId ?? EXTENSION_ID;
+}
+
+/**
+ * Mark the auth provider as successfully registered with VS Code.
+ * Should be called immediately after vscode.authentication.registerAuthenticationProvider() succeeds.
+ */
+export function setAuthProviderRegistered(): void {
+  authProviderRegistered = true;
+}
+
+/**
+ * Check if the auth provider has been registered with VS Code.
+ * Use this before calling vscode.authentication.getSession('texra-supabase', ...)
+ * to avoid timeout errors when the provider was never registered.
+ */
+export function isAuthProviderRegistered(): boolean {
+  return authProviderRegistered;
 }
 
 /**

--- a/src/auth/constants.ts
+++ b/src/auth/constants.ts
@@ -1,0 +1,15 @@
+/**
+ * Auth-related constants.
+ * Separated from authCommands.ts to avoid circular dependencies.
+ * SettingsViewMessageHandler needs AUTH_COMMANDS but authCommands needs settings.
+ */
+
+/** VS Code authentication provider ID for TeXRA. */
+export const AUTH_PROVIDER_ID = 'texra-supabase';
+
+/** Command IDs for authentication operations. */
+export const AUTH_COMMANDS = {
+  SIGN_IN: 'texra.auth.signIn',
+  SIGN_OUT: 'texra.auth.signOut',
+  VIEW_PROFILE: 'texra.auth.viewProfile',
+} as const;

--- a/src/commands/auth/index.ts
+++ b/src/commands/auth/index.ts
@@ -4,7 +4,7 @@ import {
   signIn,
   signOut,
   viewProfile,
-} from '@/auth/authCommands';
+} from '@auth/authCommands';
 
 /**
  * Register authentication-related commands.
@@ -23,4 +23,4 @@ export function registerAuthCommands(
 }
 
 // Re-export AUTH_COMMANDS for external use
-export { AUTH_COMMANDS, getAuthStatus } from '@/auth/authCommands';
+export { AUTH_COMMANDS, getAuthStatus } from '@auth/authCommands';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -133,8 +133,11 @@ export async function activate(context: vscode.ExtensionContext) {
     try {
       const { SupabaseAuthProvider } =
         await import('@/auth/SupabaseAuthProvider');
-      const { isSupabaseConfigured, setRuntimeExtensionId } =
-        await import('@/auth/config');
+      const {
+        isSupabaseConfigured,
+        setRuntimeExtensionId,
+        setAuthProviderRegistered,
+      } = await import('@/auth/config');
 
       // Set the runtime extension ID for OAuth redirects
       // This ensures the redirect URI matches the actual extension ID
@@ -157,6 +160,9 @@ export async function activate(context: vscode.ExtensionContext) {
             { supportsMultipleAccounts: false },
           ),
         );
+
+        // Mark provider as registered so auth commands know it's safe to use
+        setAuthProviderRegistered();
 
         // Register URI handler for OAuth callbacks
         const { SupabaseUriHandler } = await import('@/auth/UriHandler');

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -29,6 +29,13 @@ import { TASK_RUNS_DIR } from '@utils/files/taskRunStorage';
 import { bus } from '@eventBus/ProgressEventBus';
 import { initializeServerSideKeyAccess } from '@/auth/serverKeys';
 import { SupabaseClient } from '@/auth/SupabaseClient';
+import { SupabaseAuthProvider } from '@/auth/SupabaseAuthProvider';
+import { SupabaseUriHandler } from '@/auth/UriHandler';
+import {
+  isSupabaseConfigured,
+  setRuntimeExtensionId,
+  setAuthProviderRegistered,
+} from '@/auth/config';
 
 // Local imports - components
 import { ProgressViewProvider } from './progressView/ProgressViewProvider';
@@ -131,14 +138,6 @@ export async function activate(context: vscode.ExtensionContext) {
 
   if (authEnabled) {
     try {
-      const { SupabaseAuthProvider } =
-        await import('@/auth/SupabaseAuthProvider');
-      const {
-        isSupabaseConfigured,
-        setRuntimeExtensionId,
-        setAuthProviderRegistered,
-      } = await import('@/auth/config');
-
       // Set the runtime extension ID for OAuth redirects
       // This ensures the redirect URI matches the actual extension ID
       setRuntimeExtensionId(context.extension.id);
@@ -165,7 +164,6 @@ export async function activate(context: vscode.ExtensionContext) {
         setAuthProviderRegistered();
 
         // Register URI handler for OAuth callbacks
-        const { SupabaseUriHandler } = await import('@/auth/UriHandler');
         const uriHandler = new SupabaseUriHandler();
         context.subscriptions.push(
           vscode.window.registerUriHandler(uriHandler),

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -155,9 +155,6 @@ export async function activate(context: vscode.ExtensionContext) {
           ),
         );
 
-        // Mark provider as registered so auth commands know it's safe to use
-        SupabaseClient.setVSCodeProviderRegistered();
-
         // Register URI handler for OAuth callbacks
         const uriHandler = new SupabaseUriHandler();
         context.subscriptions.push(
@@ -167,21 +164,32 @@ export async function activate(context: vscode.ExtensionContext) {
         // Connect URI handler to auth provider
         authProvider.setUriHandler(uriHandler);
 
+        // Mark provider as registered AFTER all auth-critical setup succeeds
+        SupabaseClient.setVSCodeProviderRegistered();
+
+        logger.info('extension', 'Supabase authentication provider registered');
+
         // Note: Auth state change listener is handled in MainViewProvider.setupAuthListener()
         // to avoid duplicate refresh calls when user logs in/out.
 
         // Initialize usage logging service for backend analytics (only when auth is available)
-        const extensionVersion =
-          typeof context.extension.packageJSON?.version === 'string'
-            ? context.extension.packageJSON.version
-            : undefined;
-        UsageLogService.initialize({}, extensionVersion);
-        // Add safety net disposable in case deactivate() isn't called
-        context.subscriptions.push({
-          dispose: () => void UsageLogService.dispose(),
-        });
-
-        logger.info('extension', 'Supabase authentication provider registered');
+        // This is separate from auth - failures here shouldn't block sign-in
+        try {
+          const extensionVersion =
+            typeof context.extension.packageJSON?.version === 'string'
+              ? context.extension.packageJSON.version
+              : undefined;
+          UsageLogService.initialize({}, extensionVersion);
+          // Add safety net disposable in case deactivate() isn't called
+          context.subscriptions.push({
+            dispose: () => void UsageLogService.dispose(),
+          });
+        } catch (usageError) {
+          logger.warn(
+            'extension',
+            `Usage logging service failed to initialize: ${toErrorMessage(usageError)}`,
+          );
+        }
       }
     } catch (error) {
       const initError =

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -31,11 +31,7 @@ import { initializeServerSideKeyAccess } from '@/auth/serverKeys';
 import { SupabaseClient } from '@/auth/SupabaseClient';
 import { SupabaseAuthProvider } from '@/auth/SupabaseAuthProvider';
 import { SupabaseUriHandler } from '@/auth/UriHandler';
-import {
-  isSupabaseConfigured,
-  setRuntimeExtensionId,
-  setAuthProviderRegistered,
-} from '@/auth/config';
+import { isSupabaseConfigured, setRuntimeExtensionId } from '@/auth/config';
 
 // Local imports - components
 import { ProgressViewProvider } from './progressView/ProgressViewProvider';
@@ -161,7 +157,7 @@ export async function activate(context: vscode.ExtensionContext) {
         );
 
         // Mark provider as registered so auth commands know it's safe to use
-        setAuthProviderRegistered();
+        SupabaseClient.setVSCodeProviderRegistered();
 
         // Register URI handler for OAuth callbacks
         const uriHandler = new SupabaseUriHandler();
@@ -189,6 +185,9 @@ export async function activate(context: vscode.ExtensionContext) {
         logger.info('extension', 'Supabase authentication provider registered');
       }
     } catch (error) {
+      const initError =
+        error instanceof Error ? error : new Error(toErrorMessage(error));
+      SupabaseClient.setInitError(initError);
       logger.error(
         'extension',
         `Failed to initialize Supabase authentication: ${toErrorMessage(error)}`,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -32,6 +32,7 @@ import { SupabaseClient } from '@/auth/SupabaseClient';
 import { SupabaseAuthProvider } from '@/auth/SupabaseAuthProvider';
 import { SupabaseUriHandler } from '@/auth/UriHandler';
 import { isSupabaseConfigured, setRuntimeExtensionId } from '@/auth/config';
+import { loadAgents } from '@agent/index';
 
 // Local imports - components
 import { ProgressViewProvider } from './progressView/ProgressViewProvider';
@@ -118,8 +119,6 @@ export async function activate(context: vscode.ExtensionContext) {
   await refreshModelListIfNeeded();
 
   // Initialize agent index (single source of truth for agent metadata)
-  const { loadAgents } = await import('@agent/index');
-
   // Start loading the agent index in the background
   // This will scan all directories and fetch remote agents
   loadAgents().catch((err) => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -27,11 +27,11 @@ import { StorageFS } from '@utils/files';
 import { watchConfig, getConfig } from '@utils/config';
 import { TASK_RUNS_DIR } from '@utils/files/taskRunStorage';
 import { bus } from '@eventBus/ProgressEventBus';
-import { initializeServerSideKeyAccess } from '@/auth/serverKeys';
-import { SupabaseClient } from '@/auth/SupabaseClient';
-import { SupabaseAuthProvider } from '@/auth/SupabaseAuthProvider';
-import { SupabaseUriHandler } from '@/auth/UriHandler';
-import { isSupabaseConfigured, setRuntimeExtensionId } from '@/auth/config';
+import { initializeServerSideKeyAccess } from '@auth/serverKeys';
+import { SupabaseClient } from '@auth/SupabaseClient';
+import { SupabaseAuthProvider } from '@auth/SupabaseAuthProvider';
+import { SupabaseUriHandler } from '@auth/UriHandler';
+import { isSupabaseConfigured, setRuntimeExtensionId } from '@auth/config';
 import { loadAgents } from '@agent/index';
 
 // Local imports - components

--- a/src/logger/UsageLogService.ts
+++ b/src/logger/UsageLogService.ts
@@ -1,8 +1,8 @@
 import { randomUUID } from 'crypto';
 
 import * as logger from '@logger/logUtils';
-import { SupabaseClient } from '@/auth/SupabaseClient';
-import { SUPABASE_CUSTOM_DOMAIN } from '@/auth/config';
+import { SupabaseClient } from '@auth/SupabaseClient';
+import { SUPABASE_CUSTOM_DOMAIN } from '@auth/config';
 
 import { UsageLogResponseSchema } from './UsageLogTypes';
 import type {

--- a/src/settingsView/SettingsViewMessageHandler.ts
+++ b/src/settingsView/SettingsViewMessageHandler.ts
@@ -41,10 +41,10 @@ import { runExecuteCommand } from '@commands/agent/executeCommand';
 import type { RemoteAgent } from '@shared/schemas/profileViewMessages';
 import { getAgentsBySource, loadAgents } from '@agent/index';
 import { selectAgentInMainView } from '@agent/remote/remoteAgentUtils';
-import { SupabaseClient } from '@/auth/SupabaseClient';
-import { AUTH_COMMANDS } from '@/auth/constants';
-import { ULTRA_TIER, MAX_TIER } from '@/auth/config';
-import { getServerSideKeyService } from '@/auth/serverKeys';
+import { SupabaseClient } from '@auth/SupabaseClient';
+import { AUTH_COMMANDS } from '@auth/constants';
+import { ULTRA_TIER, MAX_TIER } from '@auth/config';
+import { getServerSideKeyService } from '@auth/serverKeys';
 
 // Type helper for extracting specific message types
 type MessageFor<C extends SettingsViewInboundMessage['command']> = Extract<

--- a/src/settingsView/SettingsViewMessageHandler.ts
+++ b/src/settingsView/SettingsViewMessageHandler.ts
@@ -42,7 +42,7 @@ import type { RemoteAgent } from '@shared/schemas/profileViewMessages';
 import { getAgentsBySource, loadAgents } from '@agent/index';
 import { selectAgentInMainView } from '@agent/remote/remoteAgentUtils';
 import { SupabaseClient } from '@/auth/SupabaseClient';
-import { AUTH_COMMANDS } from '@/auth/authCommands';
+import { AUTH_COMMANDS } from '@/auth/constants';
 import { ULTRA_TIER, MAX_TIER } from '@/auth/config';
 import { getServerSideKeyService } from '@/auth/serverKeys';
 


### PR DESCRIPTION
Add registration status tracking to avoid VS Code timeout errors when
the authentication provider was never registered. Previously, if the
auth provider failed to register (e.g., due to config errors), calls
to vscode.authentication.getSession('texra-supabase', ...) would wait
indefinitely and eventually timeout.

Changes:
- Add isAuthProviderRegistered flag in config.ts
- Set flag after successful registerAuthenticationProvider() call
- Skip VS Code auth fallback in SupabaseClient.getAccessToken() when
  provider not registered

https://claude.ai/code/session_01L3PLmD4peyNYtPa5yMuBM6

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches extension auth initialization and token/session retrieval paths; mis-ordering readiness flags could block sign-in or disable remote-agent/usage-log auth, but changes are localized and add explicit fallbacks.
> 
> **Overview**
> Prevents `vscode.authentication.getSession()` timeouts when the Supabase auth provider fails to register by adding explicit auth readiness tracking in `SupabaseClient` (`isReady()`, registration flag, and captured init error).
> 
> Extension activation now marks the provider as registered only after all auth-critical setup succeeds and stores initialization failures so `signIn()` can show a clear error instead of hanging; token retrieval (`getAccessToken`) no longer falls back to the VS Code auth API when the provider isn’t initialized.
> 
> Cleans up related dependency/circular-import issues by moving auth command IDs to new `auth/constants.ts`, switching several imports from `@/auth/*` to `@auth/*`, and removing dynamic imports for `RemoteAgentLoader`, `resolveToolDefinitions`, and settings navigation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 48ab42c795c662deed0a9076b22ec611cc62164a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- BUGBOT_STATUS --><sup><a href="https://cursor.com/dashboard?tab=bugbot">Cursor Bugbot</a> reviewed your changes and found no issues for commit <u>48ab42c</u></sup><!-- /BUGBOT_STATUS -->