### PR TITLE
fix(compat): improve Windows compatibility for paths and line endings

### DIFF
--- a/src/commands/agent/agentCreatorCommands.ts
+++ b/src/commands/agent/agentCreatorCommands.ts
@@ -1,3 +1,6 @@
+// Standard library imports
+import * as path from 'path';
+
 // Third-party imports
 import Anthropic from '@anthropic-ai/sdk';
 import * as vscode from 'vscode';
@@ -231,7 +234,7 @@ async function handleCreateAgentWithAI(_context: vscode.ExtensionContext) {
 
     const targetDir = await agentDirectories.custom();
 
-    const filePath = vscode.Uri.file(`${targetDir}/${agentName}.yaml`);
+    const filePath = vscode.Uri.file(path.join(targetDir, `${agentName}.yaml`));
 
     let yamlContent: string | undefined;
     try {

--- a/src/latex/extractFigure.ts
+++ b/src/latex/extractFigure.ts
@@ -93,8 +93,11 @@ export async function extractFigurePathsFromLatex(
     /\\begin\{overpic\}(?:\[.*?\])?\{(.+?)\}/g,
   ];
 
-  // Read file content
-  const content = await flexibleFS.read(latexFileLocation);
+  // Read file content and normalize line endings for Windows compatibility
+  const content = (await flexibleFS.read(latexFileLocation)).replaceAll(
+    '\r\n',
+    '\n',
+  );
 
   // Parse graphicspaths
   const paths = parseGraphicspath(content);
@@ -103,9 +106,7 @@ export async function extractFigurePathsFromLatex(
   }
 
   // Pre-process content to remove commented lines
-  // Normalize line endings first to handle Windows files
   const processedLines = content
-    .replaceAll('\r\n', '\n')
     .split('\n')
     .filter((line) => !/^\s*%/.test(line)) // Remove lines that start with whitespace + %
     .join('\n');

--- a/src/latex/extractFigure.ts
+++ b/src/latex/extractFigure.ts
@@ -103,7 +103,9 @@ export async function extractFigurePathsFromLatex(
   }
 
   // Pre-process content to remove commented lines
+  // Normalize line endings first to handle Windows files
   const processedLines = content
+    .replaceAll('\r\n', '\n')
     .split('\n')
     .filter((line) => !/^\s*%/.test(line)) // Remove lines that start with whitespace + %
     .join('\n');

--- a/src/latex/latexdiff/diffFileProcessor.ts
+++ b/src/latex/latexdiff/diffFileProcessor.ts
@@ -75,21 +75,25 @@ export class DiffFileProcessor {
     let skippingPreambleBlock = false;
     let documentStarted = false;
 
-    const processedLines = content.split('\n').flatMap((line) => {
-      if (TEX_ROOT_COMMENT.test(line)) {
-        return [];
-      }
+    // Normalize line endings (handle both \r\n and \n)
+    const processedLines = content
+      .replaceAll('\r\n', '\n')
+      .split('\n')
+      .flatMap((line) => {
+        if (TEX_ROOT_COMMENT.test(line)) {
+          return [];
+        }
 
-      const lineState = this.updateLineState(line, documentStarted);
-      documentStarted = lineState.documentStarted;
-      skippingPreambleBlock = lineState.skipBlock ?? skippingPreambleBlock;
+        const lineState = this.updateLineState(line, documentStarted);
+        documentStarted = lineState.documentStarted;
+        skippingPreambleBlock = lineState.skipBlock ?? skippingPreambleBlock;
 
-      if (skippingPreambleBlock) {
-        return [];
-      }
+        if (skippingPreambleBlock) {
+          return [];
+        }
 
-      return this.formatLine(line);
-    });
+        return this.formatLine(line);
+      });
 
     return processedLines.join('\n') + '\n';
   }

--- a/src/latex/texTools.ts
+++ b/src/latex/texTools.ts
@@ -62,9 +62,12 @@ export async function compileLatex2Pdf(
     ];
 
     // Build environment with TEXINPUTS if we have custom paths or existing TEXINPUTS
+    // Use path.delimiter for cross-platform compatibility (`:` on Unix, `;` on Windows)
     const needsTexInputs = texInputParts.length > 1 || process.env.TEXINPUTS;
     const texInputs = needsTexInputs
-      ? texInputParts.join(':') + ':' + (process.env.TEXINPUTS ?? '')
+      ? texInputParts.join(path.delimiter) +
+        path.delimiter +
+        (process.env.TEXINPUTS ?? '')
       : undefined;
     const env: Record<string, string> = {
       ...(texInputs && { TEXINPUTS: texInputs }),


### PR DESCRIPTION
- Use path.delimiter for TEXINPUTS (`:` on Unix, `;` on Windows)
- Use path.join() for agent YAML file path construction
- Normalize \r\n to \n before line splitting in LaTeX processors

https://claude.ai/code/session_01L3PLmD4peyNYtPa5yMuBM6

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized compatibility tweaks to path and newline handling; low likelihood of regressions outside file-path construction and LaTeX text processing.
> 
> **Overview**
> Improves cross-platform behavior (especially Windows) by switching agent YAML output path construction to `path.join()` and building `TEXINPUTS` using `path.delimiter` instead of hard-coded `:`.
> 
> Normalizes CRLF to LF before line-based processing in LaTeX utilities (`extractFigurePathsFromLatex` and `DiffFileProcessor.processLineByLine`) to avoid parsing issues when splitting on newlines.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4e27804dae73db26352a9f239cd248108681cfd8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- BUGBOT_STATUS --><sup><a href="https://cursor.com/dashboard?tab=bugbot">Cursor Bugbot</a> reviewed your changes and found no issues for commit <u>4e27804</u></sup><!-- /BUGBOT_STATUS -->