### PR TITLE
fix(model): add fallback token cap when counting fails for GPT-5

### DIFF
--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -52,7 +52,6 @@ import { ModelHandler } from './ModelHandler';
 import {
   DEFAULT_COMPACTION_THRESHOLD_PERCENT,
   TOKEN_SAFETY_BUFFER,
-  TOOL_USE_MAX_OUTPUT_FACTOR,
   TOOL_USE_SAFETY_BUFFER,
 } from './contextManagementConstants';
 import {
@@ -512,6 +511,19 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
   }
 
   /**
+   * Get the appropriate safety buffer for token validation.
+   * Uses larger buffer (2000) when:
+   * - Tool-use mode: tool results can have counting discrepancies
+   * - previous_response_id is set: server-side history may differ from token count
+   * Otherwise uses small buffer (10) for exact counting.
+   */
+  private getTokenSafetyBuffer(): number {
+    const needsLargerBuffer =
+      this.isToolUseMode() || this.previousResponseId !== null;
+    return needsLargerBuffer ? TOOL_USE_SAFETY_BUFFER : TOKEN_SAFETY_BUFFER;
+  }
+
+  /**
    * Compact the conversation to reduce context size.
    * Uses OpenAI's `/responses/compact` endpoint to replace prior assistant messages,
    * tool calls, and results with a single encrypted compaction item.
@@ -549,9 +561,9 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       compactParams.instructions = systemPrompt;
     }
 
-    if (this.previousResponseId) {
-      compactParams.previous_response_id = this.previousResponseId;
-    }
+    // NOTE: Do NOT pass previous_response_id here.
+    // We're sending the full message history in `input`, so passing
+    // previous_response_id would cause double-counting and exceed context window.
 
     try {
       const compactedResponse: CompactedResponse =
@@ -1061,13 +1073,6 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
 
     let maxOutputTokens = this.getEffectiveMaxOutputTokens();
 
-    // DEBUG: Log effective max output tokens calculation
-    this.logger.debug(
-      `[TOKEN_DEBUG] maxOutputTokens=${maxOutputTokens}, isToolUseMode=${this.isToolUseMode()}, ` +
-        `configMax=${this.config.maxOutputTokens}, factor=${this.isToolUseMode() ? TOOL_USE_MAX_OUTPUT_FACTOR : 1.0}, ` +
-        `agentCategory=${this.agentCategory}`,
-    );
-
     // Phase 2: COUNT - Estimate input tokens using built params
     // Phase 3: VALIDATE - Adjust max_output_tokens if needed
     //
@@ -1115,27 +1120,12 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         );
 
         // Validate and adjust max_output_tokens if needed (throws if context window exceeded)
-        // Use larger safety buffer for:
-        // - Tool-use mode: account for tool result counting discrepancies
-        // - previous_response_id: server-side history may differ from token count
-        const needsLargerBuffer =
-          this.isToolUseMode() || this.previousResponseId !== null;
-        const tokenBuffer = needsLargerBuffer
-          ? TOOL_USE_SAFETY_BUFFER
-          : undefined;
+        const tokenBuffer = this.getTokenSafetyBuffer();
         const validation = this.validateTokenLimits(
           inputTokens,
           maxOutputTokens,
           this.config.contextWindow,
           tokenBuffer,
-        );
-
-        // DEBUG: Log validation details
-        const availableForOutput = this.config.contextWindow - inputTokens;
-        this.logger.debug(
-          `[TOKEN_DEBUG] Validation: inputTokens=${inputTokens}, maxOutputTokens=${maxOutputTokens}, ` +
-            `available=${availableForOutput}, buffer=${tokenBuffer ?? 'default'}, ` +
-            `adjusted=${validation.adjustedMaxTokens}, total=${inputTokens + validation.adjustedMaxTokens}`,
         );
 
         if (validation.adjustedMaxTokens !== maxOutputTokens) {
@@ -1165,9 +1155,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         // Skip on first turn (no history to overflow).
         const inputEstimate = this.getBestInputTokenEstimate();
         if (inputEstimate > 0) {
-          const buffer = this.isToolUseMode()
-            ? TOOL_USE_SAFETY_BUFFER
-            : TOKEN_SAFETY_BUFFER;
+          const buffer = this.getTokenSafetyBuffer();
           const available =
             this.config.contextWindow - inputEstimate - buffer;
           const capped = Math.min(maxOutputTokens, Math.max(0, available));
@@ -1188,13 +1176,6 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       store: true,
       ...(convertedTools?.length && { tool_choice: 'auto' as const }),
     };
-
-    // DEBUG: Log final API params
-    this.logger.debug(
-      `[TOKEN_DEBUG] API call: max_output_tokens=${maxOutputTokens}, ` +
-        `previous_response_id=${this.previousResponseId ?? 'none'}, ` +
-        `inputMessageCount=${newMessages.length}, model=${this.config.fullName}`,
-    );
 
     if (useBackgroundResponses) {
       this.logger.debug(


### PR DESCRIPTION
When token counting fails, cap max_output_tokens based on best available estimate to prevent context overflow.

Changes:
- Add getBestInputTokenEstimate() - uses compaction result or cumulative
- Add getTokenSafetyBuffer() - DRY helper for buffer calculation
- Use larger buffer (2000) when tool-use OR previous_response_id is set
- Skip fallback on first turn (no history to overflow)
- Fix compaction: don't pass previous_response_id when sending full message history (was causing double-counting and 400 errors)

https://claude.ai/code/session_01Uuhts7sasHm2MpfQpzhr9e

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches token counting/validation and compaction request parameters for OpenAI Responses; mistakes could cause context overflows or regress long-running/tool-heavy conversations, but scope is localized and primarily defensive.
> 
> **Overview**
> Improves OpenAI Responses context-safety by centralizing token buffer selection in `getTokenSafetyBuffer()` (using the larger tool-use buffer when tool mode is active *or* `previous_response_id` is set) and removing noisy token-debug logging.
> 
> Fixes compaction to **not** send `previous_response_id` when the full message history is provided to `/responses/compact`, avoiding double-counting/context-window errors.
> 
> When native token counting fails, adds a fallback that caps `max_output_tokens` based on the best available input-token estimate (post-compaction tokens or prior cumulative usage), and skips this cap on the first turn.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f75c9a7dc07755ce341736998a42cdcaecfe20e0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- BUGBOT_STATUS --><sup><a href="https://cursor.com/dashboard?tab=bugbot">Cursor Bugbot</a> reviewed your changes and found no issues for commit <u>f75c9a7</u></sup><!-- /BUGBOT_STATUS -->