### PR TITLE
fix GPT 5 compactization

### DIFF
--- a/src/agent/core/flows/CommonCycleTypes.ts
+++ b/src/agent/core/flows/CommonCycleTypes.ts
@@ -80,19 +80,27 @@ export function resetCycleState<T extends BaseCycleFields>(
 export interface BaseInvocationPrepResult {
   shouldStop: boolean;
   messages: ProviderMessage[];
-  /**
-   * Optional callback invoked when conversation compaction occurs.
-   * The callback receives the compacted messages and should update
-   * the caller's message array to prevent sending inflated history
-   * on subsequent calls.
-   */
-  onCompacted?: (compactedMessages: ProviderMessage[]) => void;
 }
 
 /** Base success data returned from model/tool invocations. */
 export interface BaseInvocationSuccessData {
   response: unknown;
   responseTimeMs?: number;
+  /**
+   * If messages were transformed (e.g., compaction), the updated array.
+   * Undefined means messages were not modified.
+   */
+  updatedMessages?: ProviderMessage[];
+}
+
+/**
+ * Replace array contents in-place to preserve references.
+ * Used when compaction returns new messages - mutating in-place ensures
+ * all code holding references to the array sees the updated contents.
+ */
+export function replaceMessagesInPlace<T>(target: T[], newContents: T[]): void {
+  target.length = 0;
+  target.push(...newContents);
 }
 
 // --- Cycle Result Interpretation ---

--- a/src/agent/core/flows/CommonCycleTypes.ts
+++ b/src/agent/core/flows/CommonCycleTypes.ts
@@ -80,6 +80,13 @@ export function resetCycleState<T extends BaseCycleFields>(
 export interface BaseInvocationPrepResult {
   shouldStop: boolean;
   messages: ProviderMessage[];
+  /**
+   * Optional callback invoked when conversation compaction occurs.
+   * The callback receives the compacted messages and should update
+   * the caller's message array to prevent sending inflated history
+   * on subsequent calls.
+   */
+  onCompacted?: (compactedMessages: ProviderMessage[]) => void;
 }
 
 /** Base success data returned from model/tool invocations. */

--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -15,6 +15,7 @@ import {
   BaseInvocationPrepResult,
   BaseInvocationSuccessData,
   getDebugContext,
+  replaceMessagesInPlace,
   resetCycleState,
   SkippableNodeResult,
 } from '@agent/core/flows/CommonCycleTypes';
@@ -247,12 +248,6 @@ class ResponseModelInvocationNode<C> extends RetryableInvocationNode<
       shouldStop: shared.shouldStop,
       messages: shared.messages,
       systemPrompt: shared.systemPrompt,
-      // Callback to update shared.messages when compaction occurs.
-      // Mutates the array in-place so all references see the compacted messages.
-      onCompacted: (compactedMessages) => {
-        shared.messages.length = 0;
-        shared.messages.push(...compactedMessages);
-      },
     };
   }
 
@@ -274,26 +269,31 @@ class ResponseModelInvocationNode<C> extends RetryableInvocationNode<
     const start = Date.now();
 
     return this.withAbortController(async (signal) => {
-      const { response, responseTimeMs } = await stage.run(async () => {
-        const modelResponse = await services.modelHandler.createResponse({
-          client: services.client,
-          messages: prepRes.messages,
-          temperature: services.setting.temperature,
-          systemPrompt: prepRes.systemPrompt,
-          endTag: services.setting.endTag,
-          signal,
-          tools: services.modelHandler.capabilities.supportsFunctionCalling
-            ? services.setting.tools
-            : undefined,
-          onCompacted: prepRes.onCompacted,
-        });
+      const { response, responseTimeMs, updatedMessages } = await stage.run(
+        async () => {
+          const result = await services.modelHandler.createResponse({
+            client: services.client,
+            messages: prepRes.messages,
+            temperature: services.setting.temperature,
+            systemPrompt: prepRes.systemPrompt,
+            endTag: services.setting.endTag,
+            signal,
+            tools: services.modelHandler.capabilities.supportsFunctionCalling
+              ? services.setting.tools
+              : undefined,
+          });
 
-        const elapsedMs = Date.now() - start;
+          const elapsedMs = Date.now() - start;
 
-        return { response: modelResponse, responseTimeMs: elapsedMs };
-      });
+          return {
+            response: result.response,
+            responseTimeMs: elapsedMs,
+            updatedMessages: result.updatedMessages,
+          };
+        },
+      );
 
-      return { kind: 'success', response, responseTimeMs };
+      return { kind: 'success', response, responseTimeMs, updatedMessages };
     });
   }
 
@@ -316,6 +316,11 @@ class ResponseModelInvocationNode<C> extends RetryableInvocationNode<
 
     if (!successRes) {
       return FlowTransition.COMPLETE;
+    }
+
+    // Handle message updates from compaction (explicit in post, not via callback)
+    if (successRes.updatedMessages !== undefined) {
+      replaceMessagesInPlace(shared.messages, successRes.updatedMessages);
     }
 
     shared.responseObject = successRes.response;

--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -247,6 +247,12 @@ class ResponseModelInvocationNode<C> extends RetryableInvocationNode<
       shouldStop: shared.shouldStop,
       messages: shared.messages,
       systemPrompt: shared.systemPrompt,
+      // Callback to update shared.messages when compaction occurs.
+      // Mutates the array in-place so all references see the compacted messages.
+      onCompacted: (compactedMessages) => {
+        shared.messages.length = 0;
+        shared.messages.push(...compactedMessages);
+      },
     };
   }
 
@@ -279,6 +285,7 @@ class ResponseModelInvocationNode<C> extends RetryableInvocationNode<
           tools: services.modelHandler.capabilities.supportsFunctionCalling
             ? services.setting.tools
             : undefined,
+          onCompacted: prepRes.onCompacted,
         });
 
         const elapsedMs = Date.now() - start;

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -11,6 +11,7 @@ import {
   BaseInvocationSuccessData,
   resetCycleState,
   getDebugContext,
+  replaceMessagesInPlace,
 } from '@agent/core/flows/CommonCycleTypes';
 import type { SdkToolCall } from '@agent/modelHandlers/types/IModelHandler';
 import type { ServerToolContentBlock } from '@agent/modelHandlers/types/ServerToolTypes';
@@ -269,12 +270,6 @@ class ToolUseCallNode<C> extends RetryableInvocationNode<
     return {
       shouldStop: shared.shouldStop,
       messages: shared.messages,
-      // Callback to update shared.messages when compaction occurs.
-      // Mutates the array in-place so all references see the compacted messages.
-      onCompacted: (compactedMessages) => {
-        shared.messages.length = 0;
-        shared.messages.push(...compactedMessages);
-      },
     };
   }
 
@@ -291,18 +286,22 @@ class ToolUseCallNode<C> extends RetryableInvocationNode<
 
     return this.withAbortController(async (signal) => {
       services.modelHandler.setOutputStreaming(true);
-      const response = await services.modelHandler.createResponse({
+      const result = await services.modelHandler.createResponse({
         client: services.client,
         messages: prepRes.messages,
         temperature: services.setting.temperature,
         signal,
         tools: services.setting.tools as ToolDefinition[] | undefined,
-        onCompacted: prepRes.onCompacted,
       });
 
       const responseTimeMs = Date.now() - start;
 
-      return { kind: 'success', response, responseTimeMs };
+      return {
+        kind: 'success',
+        response: result.response,
+        responseTimeMs,
+        updatedMessages: result.updatedMessages,
+      };
     });
   }
 
@@ -325,6 +324,11 @@ class ToolUseCallNode<C> extends RetryableInvocationNode<
 
     if (!successRes) {
       return FlowTransition.COMPLETE;
+    }
+
+    // Handle message updates from compaction (explicit in post, not via callback)
+    if (successRes.updatedMessages !== undefined) {
+      replaceMessagesInPlace(shared.messages, successRes.updatedMessages);
     }
 
     // Apply success-specific side effects

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -269,6 +269,12 @@ class ToolUseCallNode<C> extends RetryableInvocationNode<
     return {
       shouldStop: shared.shouldStop,
       messages: shared.messages,
+      // Callback to update shared.messages when compaction occurs.
+      // Mutates the array in-place so all references see the compacted messages.
+      onCompacted: (compactedMessages) => {
+        shared.messages.length = 0;
+        shared.messages.push(...compactedMessages);
+      },
     };
   }
 
@@ -291,6 +297,7 @@ class ToolUseCallNode<C> extends RetryableInvocationNode<
         temperature: services.setting.temperature,
         signal,
         tools: services.setting.tools as ToolDefinition[] | undefined,
+        onCompacted: prepRes.onCompacted,
       });
 
       const responseTimeMs = Date.now() - start;

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -61,6 +61,7 @@ import type { ToolResultPayload } from './utils/toolAttachmentUtils';
 import type {
   IModelHandler,
   CreateResponseOptions,
+  CreateResponseResult,
   ExtractResponseResult,
   SdkToolCall,
   StopConditionsResult,
@@ -596,9 +597,11 @@ export abstract class ModelHandler<
   /**
    * Generates a model response using the provider's API.
    * @param options Options for creating the response
-   * @returns Promise resolving to provider-specific response object
+   * @returns Promise resolving to result containing response and optionally updated messages
    */
-  abstract createResponse(options: CreateResponseOptions<M, C>): Promise<Resp>;
+  abstract createResponse(
+    options: CreateResponseOptions<M, C>,
+  ): Promise<CreateResponseResult<Resp, M>>;
 
   /**
    * Creates initial message array for conversation with optional images and system prompt.

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -78,6 +78,7 @@ import {
 import type { ProviderStopReason } from './types/StopReasonTypes';
 import type {
   CreateResponseOptions,
+  CreateResponseResult,
   ExtractResponseResult,
   AnthropicToolCall,
   TokenCountOptions,
@@ -494,7 +495,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
   /** Creates a chat completion response using Anthropic's API with specified parameters and optional system prompt. */
   async createResponse(
     requestOptions: CreateResponseOptions<MessageParam, Anthropic>,
-  ): Promise<BetaMessage> {
+  ): Promise<CreateResponseResult<BetaMessage, MessageParam>> {
     const {
       client,
       messages,
@@ -775,7 +776,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
     // Log context management events if any edits were applied
     this.logContextManagementFromResponse(response);
 
-    return response;
+    return { response };
   }
 
   /**

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -84,6 +84,7 @@ import type { MediaFileResult } from './support/MediaAttachmentProcessor';
 import type { ProviderStopReason } from './types/StopReasonTypes';
 import type {
   CreateResponseOptions,
+  CreateResponseResult,
   ExtractResponseResult,
   GoogleToolCall,
   TokenCountOptions,
@@ -438,7 +439,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
   /** Creates a chat completion response using Google's GenAI API with specified parameters and optional system prompt. */
   async createResponse(
     options: CreateResponseOptions<Content, GoogleGenAI>,
-  ): Promise<GenerateContentResponse> {
+  ): Promise<CreateResponseResult<GenerateContentResponse, Content>> {
     const {
       client,
       messages,
@@ -685,7 +686,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
           candidateContent.parts = filteredParts;
         }
 
-        return baseResponse;
+        return { response: baseResponse };
       }
 
       const sendParams: SendMessageParameters = {
@@ -693,7 +694,8 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
         config: { ...generationConfig, abortSignal: signal },
       };
 
-      return chat.sendMessage(sendParams);
+      const response = await chat.sendMessage(sendParams);
+      return { response };
     } catch (error) {
       // Error logging follows "log at the boundary" principle - Node's retryPrompt
       // or execFallback will log the error once. We only add debug diagnostics here

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -448,11 +448,19 @@ export class ModelHandlerOpenAI<
 
     // Phase 4: EXECUTE
     if (useStreaming) {
-      const response = await this.executeStreamingChat(client, baseParams, signal);
+      const response = await this.executeStreamingChat(
+        client,
+        baseParams,
+        signal,
+      );
       return { response };
     }
 
-    const response = await this.executeNonStreamingChat(client, baseParams, signal);
+    const response = await this.executeNonStreamingChat(
+      client,
+      baseParams,
+      signal,
+    );
     return { response };
   }
 

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -67,6 +67,7 @@ import { ModelHandler } from './ModelHandler';
 import { TOOL_USE_SAFETY_BUFFER } from './contextManagementConstants';
 import type {
   CreateResponseOptions,
+  CreateResponseResult,
   ExtractResponseResult,
   DeepSeekToolCall,
   OpenAIToolCall,
@@ -364,7 +365,7 @@ export class ModelHandlerOpenAI<
   /** Creates a chat completion with model-specific parameters. */
   async createResponse(
     options: CreateResponseOptions<ChatCompletionMessageParam, OpenAI>,
-  ): Promise<ChatCompletion> {
+  ): Promise<CreateResponseResult<ChatCompletion, ChatCompletionMessageParam>> {
     const {
       client,
       messages: rawMessages,
@@ -447,10 +448,12 @@ export class ModelHandlerOpenAI<
 
     // Phase 4: EXECUTE
     if (useStreaming) {
-      return this.executeStreamingChat(client, baseParams, signal);
+      const response = await this.executeStreamingChat(client, baseParams, signal);
+      return { response };
     }
 
-    return this.executeNonStreamingChat(client, baseParams, signal);
+    const response = await this.executeNonStreamingChat(client, baseParams, signal);
+    return { response };
   }
 
   /**

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -1172,8 +1172,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         const inputEstimate = this.getBestInputTokenEstimate();
         if (inputEstimate > 0) {
           const buffer = this.getTokenSafetyBuffer();
-          const available =
-            this.config.contextWindow - inputEstimate - buffer;
+          const available = this.config.contextWindow - inputEstimate - buffer;
           const capped = Math.min(maxOutputTokens, Math.max(0, available));
           if (capped !== maxOutputTokens) {
             this.logger.debug(

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -68,6 +68,7 @@ import {
 import type { ProviderStopReason } from './types/StopReasonTypes';
 import type {
   CreateResponseOptions,
+  CreateResponseResult,
   ExtractResponseResult,
   OpenAIResponseToolCall,
   TokenCountOptions,
@@ -325,11 +326,10 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     response: Response,
     effectiveMessagesCount: number,
     compactedThisCall: boolean,
-    onCompacted?: (compactedMessages: ResponseInputItem[]) => void,
   ): void {
     // Apply compaction state if compaction happened this call
     if (compactedThisCall) {
-      this.applyCompactionState(onCompacted);
+      this.applyCompactionState();
     }
 
     // Only chain from completed responses - failed/incomplete can't be used
@@ -610,34 +610,25 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
 
   /**
    * Apply compaction state updates after successful API call.
-   * Clears the pending compaction result and updates conversation state.
-   * If onCompacted callback is provided, invokes it with compacted messages
-   * so the caller can update their message array.
+   * Updates conversation state flags. Does NOT clear compactionResult -
+   * it's needed for the return value and gets cleared on next createResponse() call.
    *
    * Note: cumulativeInputTokens is NOT updated here - it will be set from
    * response.usage.input_tokens after the API call to reflect actual usage.
    */
-  private applyCompactionState(
-    onCompacted?: (compactedMessages: ResponseInputItem[]) => void,
-  ): void {
+  private applyCompactionState(): void {
     if (!this.compactionResult) return;
-
-    // Notify caller with compacted messages BEFORE clearing the result
-    // This allows caller to update their shared.messages array
-    if (onCompacted) {
-      onCompacted(this.compactionResult.compactedMessages);
-    }
 
     // Reset sent messages counter since we're using compacted output
     this.conversationState.sentMessages = 0;
     // Mark as compacted so subsequent requests know to send all messages
     this.conversationState.isCompacted = true;
-    // Note: previousResponseId is cleared immediately after compaction (before API call)
-    // to avoid "No tool output found" errors. This is a defensive no-op.
-    this.previousResponseId = null;
 
-    // Clear the pending result
-    this.compactionResult = undefined;
+    // Note: previousResponseId is already cleared immediately after compaction
+    // (before API call) to avoid "No tool output found" errors.
+
+    // Note: compactionResult is NOT cleared here - it's read for the return value.
+    // It gets cleared at the start of the next createResponse() call.
   }
 
   /** Creates a configured OpenAI client instance. */
@@ -989,22 +980,17 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
    *
    * Supports automatic conversation compaction when cumulative input tokens
    * exceed the configured threshold (texra.model.compactionThresholdPercent).
+   *
+   * @returns Result containing the response and optionally updated messages if compaction occurred
    */
   async createResponse(
     options: CreateResponseOptions<ResponseInputItem, OpenAI>,
-  ): Promise<Response> {
+  ): Promise<CreateResponseResult<Response, ResponseInputItem>> {
     // Clear any stale compaction result from previous attempts (ensures clean state on retries)
     this.compactionResult = undefined;
 
-    const {
-      client,
-      messages,
-      temperature,
-      systemPrompt,
-      signal,
-      tools,
-      onCompacted,
-    } = options;
+    const { client, messages, temperature, systemPrompt, signal, tools } =
+      options;
     const streamingToggleEnabled = this.getStreamingConfig();
     const backgroundToggleEnabled = getConfig<boolean>(
       'texra.model.useBackgroundResponses',
@@ -1039,6 +1025,8 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     let effectiveMessages = messages;
     // Track if compaction happened in THIS call (not previous calls)
     let compactedThisCall = false;
+    // Store compacted messages for return value (captured when compaction succeeds)
+    let compactedMessages: ResponseInputItem[] | undefined;
     if (this.shouldCompact()) {
       const threshold = this.getCompactionTokenThreshold();
       this.logger.logProgress(
@@ -1058,6 +1046,8 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         // reference the old response ID - it may have pending tool calls that
         // aren't in the compacted messages, causing "No tool output found" errors.
         this.previousResponseId = null;
+        // Capture compacted messages now (used in return value)
+        compactedMessages = this.compactionResult!.compactedMessages;
       }
     }
 
@@ -1252,14 +1242,15 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
           signal,
         );
         if (resumedResponse) {
-          // Successfully resumed - finalize and return
           this.finalizeResponse(
             resumedResponse,
             effectiveMessages.length,
             compactedThisCall,
-            onCompacted,
           );
-          return resumedResponse;
+          return {
+            response: resumedResponse,
+            updatedMessages: compactedMessages,
+          };
         }
         // Resume failed or response failed remotely - fall through to create new request
       }
@@ -1345,9 +1336,11 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
           response,
           effectiveMessages.length,
           compactedThisCall,
-          onCompacted,
         );
-        return response;
+        return {
+          response,
+          updatedMessages: compactedMessages,
+        };
       }
 
       // Non-streaming path
@@ -1395,9 +1388,11 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         response,
         effectiveMessages.length,
         compactedThisCall,
-        onCompacted,
       );
-      return response;
+      return {
+        response,
+        updatedMessages: compactedMessages,
+      };
     } catch (error) {
       // Extract error details for diagnostics (useful for relay errors)
       const { rawErrorBody } = formatProviderHttpError(error);

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -325,10 +325,11 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     response: Response,
     effectiveMessagesCount: number,
     compactedThisCall: boolean,
+    onCompacted?: (compactedMessages: ResponseInputItem[]) => void,
   ): void {
     // Apply compaction state if compaction happened this call
     if (compactedThisCall) {
-      this.applyCompactionState();
+      this.applyCompactionState(onCompacted);
     }
 
     // Only chain from completed responses - failed/incomplete can't be used
@@ -610,18 +611,29 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
   /**
    * Apply compaction state updates after successful API call.
    * Clears the pending compaction result and updates conversation state.
+   * If onCompacted callback is provided, invokes it with compacted messages
+   * so the caller can update their message array.
    *
    * Note: cumulativeInputTokens is NOT updated here - it will be set from
    * response.usage.input_tokens after the API call to reflect actual usage.
    */
-  private applyCompactionState(): void {
+  private applyCompactionState(
+    onCompacted?: (compactedMessages: ResponseInputItem[]) => void,
+  ): void {
     if (!this.compactionResult) return;
+
+    // Notify caller with compacted messages BEFORE clearing the result
+    // This allows caller to update their shared.messages array
+    if (onCompacted) {
+      onCompacted(this.compactionResult.compactedMessages);
+    }
 
     // Reset sent messages counter since we're using compacted output
     this.conversationState.sentMessages = 0;
     // Mark as compacted so subsequent requests know to send all messages
     this.conversationState.isCompacted = true;
-    // Clear previous_response_id - compacted output replaces server-side history
+    // Note: previousResponseId is cleared immediately after compaction (before API call)
+    // to avoid "No tool output found" errors. This is a defensive no-op.
     this.previousResponseId = null;
 
     // Clear the pending result
@@ -984,8 +996,15 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     // Clear any stale compaction result from previous attempts (ensures clean state on retries)
     this.compactionResult = undefined;
 
-    const { client, messages, temperature, systemPrompt, signal, tools } =
-      options;
+    const {
+      client,
+      messages,
+      temperature,
+      systemPrompt,
+      signal,
+      tools,
+      onCompacted,
+    } = options;
     const streamingToggleEnabled = this.getStreamingConfig();
     const backgroundToggleEnabled = getConfig<boolean>(
       'texra.model.useBackgroundResponses',
@@ -1033,6 +1052,13 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       );
       // compactionResult is set if compaction succeeded
       compactedThisCall = this.compactionResult !== undefined;
+      if (compactedThisCall) {
+        // CRITICAL: Clear previousResponseId IMMEDIATELY after successful compaction.
+        // The compacted output replaces the server-side history, so we must not
+        // reference the old response ID - it may have pending tool calls that
+        // aren't in the compacted messages, causing "No tool output found" errors.
+        this.previousResponseId = null;
+      }
     }
 
     // After compaction in THIS call, send all compacted messages.
@@ -1231,6 +1257,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
             resumedResponse,
             effectiveMessages.length,
             compactedThisCall,
+            onCompacted,
           );
           return resumedResponse;
         }
@@ -1318,6 +1345,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
           response,
           effectiveMessages.length,
           compactedThisCall,
+          onCompacted,
         );
         return response;
       }
@@ -1367,6 +1395,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         response,
         effectiveMessages.length,
         compactedThisCall,
+        onCompacted,
       );
       return response;
     } catch (error) {

--- a/src/agent/modelHandlers/modelHandlerOpenRouter.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenRouter.ts
@@ -30,7 +30,10 @@ import { isNonEmptyString } from '@utils/core';
 // Local file imports
 import { ModelHandlerOpenAI } from './modelHandlerOpenAI';
 import { toOpenAITools } from './toolConversion';
-import type { CreateResponseOptions } from './types/IModelHandler';
+import type {
+  CreateResponseOptions,
+  CreateResponseResult,
+} from './types/IModelHandler';
 import type {
   ChatCompletion,
   ChatCompletionChunk,
@@ -108,7 +111,7 @@ export class ModelHandlerOpenRouter extends ModelHandlerOpenAI {
   /** Creates a response using OpenRouter's API with model-specific configuration. */
   async createResponse(
     options: CreateResponseOptions<ChatCompletionMessageParam, OpenAI>,
-  ): Promise<ChatCompletion> {
+  ): Promise<CreateResponseResult<ChatCompletion, ChatCompletionMessageParam>> {
     const { client, messages, temperature, endTag, signal, tools } = options;
     // Get streaming config
     const useStreaming = this.getStreamingConfig();
@@ -184,10 +187,11 @@ export class ModelHandlerOpenRouter extends ModelHandlerOpenAI {
       thinking.finalize(finalReasoning ?? undefined);
       const finalOutput = response.choices?.[0]?.message?.content ?? '';
       if (output) output.finalize(finalOutput);
-      return response;
+      return { response };
     }
 
-    return client.chat.completions.create(kwargs, { signal });
+    const response = await client.chat.completions.create(kwargs, { signal });
+    return { response };
   }
 
   /**

--- a/src/agent/modelHandlers/types/IModelHandler.ts
+++ b/src/agent/modelHandlers/types/IModelHandler.ts
@@ -73,6 +73,13 @@ export interface CreateResponseOptions<
   signal?: AbortSignal;
   /** Optional tool definitions for function calling */
   tools?: ToolDefinition[];
+  /**
+   * Optional callback invoked after successful conversation compaction.
+   * The caller should replace their messages array with the compacted messages
+   * to prevent sending inflated history on subsequent calls.
+   * Uses ProviderMessage[] base type to avoid contravariance issues with generics.
+   */
+  onCompacted?: (compactedMessages: ProviderMessage[]) => void;
 }
 
 /**

--- a/src/agent/modelHandlers/types/IModelHandler.ts
+++ b/src/agent/modelHandlers/types/IModelHandler.ts
@@ -73,13 +73,26 @@ export interface CreateResponseOptions<
   signal?: AbortSignal;
   /** Optional tool definitions for function calling */
   tools?: ToolDefinition[];
+}
+
+/**
+ * Result from createResponse, optionally including updated messages
+ * after compaction or other transformations.
+ *
+ * @template Resp - Provider-specific response type
+ * @template M - Provider-specific message type
+ */
+export interface CreateResponseResult<
+  Resp,
+  M extends ProviderMessage = ProviderMessage,
+> {
+  /** The provider response */
+  response: Resp;
   /**
-   * Optional callback invoked after successful conversation compaction.
-   * The caller should replace their messages array with the compacted messages
-   * to prevent sending inflated history on subsequent calls.
-   * Uses ProviderMessage[] base type to avoid contravariance issues with generics.
+   * If messages were transformed (e.g., compaction), the new array.
+   * Undefined means messages were not modified - caller keeps original.
    */
-  onCompacted?: (compactedMessages: ProviderMessage[]) => void;
+  updatedMessages?: M[];
 }
 
 /**
@@ -222,8 +235,11 @@ export interface IModelHandler<
   /**
    * Generate a response from the model.
    * @param options Options for creating the response
+   * @returns Result containing the response and optionally updated messages
    */
-  createResponse(options: CreateResponseOptions<M, C>): Promise<Resp>;
+  createResponse(
+    options: CreateResponseOptions<M, C>,
+  ): Promise<CreateResponseResult<Resp, M>>;
 
   /** Initialize the conversation for the first round. */
   initializeMessages(

--- a/src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts
+++ b/src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts
@@ -486,7 +486,7 @@ describe('ModelHandlerAnthropic message guards', () => {
       'request should opt into the Files API beta',
     );
 
-    assert.equal(response.stop_reason, 'end_turn');
+    assert.equal(response.response.stop_reason, 'end_turn');
   });
 
   it('sanitizes uploaded PDF filenames to strip directories and forbidden characters', async () => {
@@ -643,7 +643,7 @@ describe('ModelHandlerAnthropic message guards', () => {
       'request should opt into the Files API beta when referencing file IDs',
     );
 
-    assert.equal(response.stop_reason, 'end_turn');
+    assert.equal(response.response.stop_reason, 'end_turn');
   });
 
   it('skips token counting when messages include file-based document sources', async () => {
@@ -723,7 +723,7 @@ describe('ModelHandlerAnthropic message guards', () => {
       0,
       'should skip token counting for file sources',
     );
-    assert.equal(response.stop_reason, 'end_turn');
+    assert.equal(response.response.stop_reason, 'end_turn');
   });
 
   it('counts tokens before uploading PDF documents', async () => {
@@ -801,7 +801,7 @@ describe('ModelHandlerAnthropic message guards', () => {
     });
 
     assert.deepEqual(callOrder, ['countTokens', 'upload', 'create']);
-    assert.equal(response.stop_reason, 'end_turn');
+    assert.equal(response.response.stop_reason, 'end_turn');
   });
 
   it('does not warn about context overflow when 1M beta header is active', async () => {
@@ -873,7 +873,7 @@ describe('ModelHandlerAnthropic message guards', () => {
         messages,
         temperature: 0,
       });
-      assert.equal(response.stop_reason, 'end_turn');
+      assert.equal(response.response.stop_reason, 'end_turn');
     } finally {
       (configModule as any).getConfig = originalGetConfig;
     }

--- a/src/test/modelHandlers/ModelHandlerGoogle.test.ts
+++ b/src/test/modelHandlers/ModelHandlerGoogle.test.ts
@@ -330,16 +330,16 @@ describe('ModelHandlerGoogleGenAI.createResponse', () => {
     });
 
     assert.ok(response, 'expected a response to be returned');
-    const candidate = response.candidates?.[0];
+    const candidate = response.response.candidates?.[0];
     assert.ok(candidate, 'expected a candidate in the aggregated response');
     assert.equal(
       candidate.content?.parts?.length,
       2,
       'expected both streamed parts to be present',
     );
-    assert.equal(response.text, 'Hello world');
+    assert.equal(response.response.text, 'Hello world');
     assert.equal(candidate.finishReason, FinishReason.STOP);
-    assert.deepEqual(response.usageMetadata, chunkTwo.usageMetadata);
+    assert.deepEqual(response.response.usageMetadata, chunkTwo.usageMetadata);
   });
 
   it('concatenates automaticFunctionCallingHistory across streamed chunks', async () => {
@@ -423,12 +423,12 @@ describe('ModelHandlerGoogleGenAI.createResponse', () => {
       temperature: 0,
     });
 
-    assert.ok(response.automaticFunctionCallingHistory);
-    assert.equal(response.automaticFunctionCallingHistory?.length, 2);
-    assert.deepEqual(response.automaticFunctionCallingHistory?.[0], {
+    assert.ok(response.response.automaticFunctionCallingHistory);
+    assert.equal(response.response.automaticFunctionCallingHistory?.length, 2);
+    assert.deepEqual(response.response.automaticFunctionCallingHistory?.[0], {
       name: 'callOne',
     });
-    assert.deepEqual(response.automaticFunctionCallingHistory?.[1], {
+    assert.deepEqual(response.response.automaticFunctionCallingHistory?.[1], {
       name: 'callTwo',
     });
   });

--- a/src/utils/text/textEnhancementUtils.ts
+++ b/src/utils/text/textEnhancementUtils.ts
@@ -271,11 +271,12 @@ ${text}`;
 
       let response;
       try {
-        response = await handler.createResponse({
+        const result = await handler.createResponse({
           client,
           messages,
           temperature: 0,
         });
+        response = result.response;
       } catch (error) {
         logger.error(
           CHANNEL,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core model invocation plumbing and response handlers across providers; mistakes could break all model calls or corrupt conversation state, though changes are mostly type/return-shape and targeted compaction state fixes.
> 
> **Overview**
> Fixes GPT‑5/OpenAI Responses API compaction integration by changing `IModelHandler.createResponse()` to return `{ response, updatedMessages? }` and updating all model handlers/call sites to use this structured result.
> 
> `ResponseCycleFlow` and `ToolUseCycleFlow` now apply `updatedMessages` (when present) by replacing the shared `messages` array contents *in place* via new `replaceMessagesInPlace()`, ensuring existing references see compacted history. `ModelHandlerOpenAIResponse` captures compacted message output, clears `previousResponseId` immediately after compaction to avoid “No tool output found” errors, and returns the compacted messages to callers; associated unit tests/utilities were updated for the new return shape.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 298e0f48169b8eae6bfd4ad4ff39b41417e09671. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->