### PR TITLE
Defer bash tool in-progress logging until after approval

### DIFF
--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -527,7 +527,10 @@ class ToolUseProcessNode<C> extends BaseNode<
 }
 
 /** Tools that may take a while and benefit from showing in-progress state. */
-const SLOW_TOOLS = new Set(['wolfram', 'web_fetch', 'web_search']);
+const SLOW_TOOLS = new Set(['bash', 'wolfram', 'web_fetch', 'web_search']);
+
+/** Tools that defer in-progress logging until after approval. */
+const DEFERRED_LOG_TOOLS = new Set(['bash']);
 
 /**
  * Result of executing a single tool call, capturing everything needed
@@ -604,6 +607,7 @@ class ToolUseDispatchNode<C> extends BatchNode<
     options: ToolUseCycleOptions<C>,
     tracker: FileInteractionState,
     todoState: TodoState,
+    onExecutionReady?: () => void,
   ): Promise<ToolResult> {
     if (!tool) {
       return { error: `Unknown tool ${call.name}`, isError: true };
@@ -617,6 +621,7 @@ class ToolUseDispatchNode<C> extends BatchNode<
           streamId: options.logger.streamId,
           executionId: options.executionId,
           toolCallId: call.callId,
+          onExecutionReady,
         },
         () => tool.call(parsedInput),
       );
@@ -635,11 +640,26 @@ class ToolUseDispatchNode<C> extends BatchNode<
   ): Promise<ToolExecutionResult> {
     const parsedInput = parseToolInput(call.input, call.callId, options.logger);
     const tool = options.toolRegistry.get(call.name);
+    const isDeferred = DEFERRED_LOG_TOOLS.has(call.name);
 
-    // Capture groupId at start to ensure consistent grouping for all tools
-    const logRef = SLOW_TOOLS.has(call.name)
-      ? options.logger.logToolUseStart(call.name, parsedInput ?? call.raw)
-      : { logId: undefined, groupId: options.logger.resolveActiveGroupId() };
+    // Capture groupId at start. For deferred tools, delay logging until onExecutionReady.
+    const logRef: { logId: string | undefined; groupId: string | undefined } =
+      SLOW_TOOLS.has(call.name) && !isDeferred
+        ? options.logger.logToolUseStart(call.name, parsedInput ?? call.raw)
+        : { logId: undefined, groupId: options.logger.resolveActiveGroupId() };
+
+    const onExecutionReady = isDeferred
+      ? () => {
+          if (!logRef.logId) {
+            const ref = options.logger.logToolUseStart(
+              call.name,
+              parsedInput ?? call.raw,
+              logRef.groupId,
+            );
+            logRef.logId = ref.logId;
+          }
+        }
+      : undefined;
 
     const result = await this.invokeToolSafely(
       call,
@@ -648,6 +668,7 @@ class ToolUseDispatchNode<C> extends BatchNode<
       options,
       tracker,
       todoState,
+      onExecutionReady,
     );
 
     const trackedEdits = tracker.recordEdits(result.edits);

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -527,7 +527,7 @@ class ToolUseProcessNode<C> extends BaseNode<
 }
 
 /** Tools that may take a while and benefit from showing in-progress state. */
-const SLOW_TOOLS = new Set(['bash', 'wolfram', 'web_fetch', 'web_search']);
+const SLOW_TOOLS = new Set(['wolfram', 'web_fetch', 'web_search']);
 
 /**
  * Result of executing a single tool call, capturing everything needed

--- a/src/agent/toolUse/ToolFileInteractionContext.ts
+++ b/src/agent/toolUse/ToolFileInteractionContext.ts
@@ -12,6 +12,8 @@ export interface ToolFileInteractionContext {
   tracker: FileInteractionState;
   /** Todo state for managing task lists. Optional for backward compatibility. */
   todoState?: TodoState;
+  /** Called by tools with approval flows to trigger in-progress log after approval. */
+  onExecutionReady?: () => void;
 }
 
 const contextStack: ToolFileInteractionContext[] = [];

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -1,6 +1,9 @@
 // Local imports - core
 import { z } from 'zod';
 
+// Local imports - agent
+import { getCurrentToolFileInteractionContext } from '@agent/toolUse/ToolFileInteractionContext';
+
 // Local imports - tools
 import { ToolError, ToolResult } from '@tools/result';
 import {
@@ -34,6 +37,9 @@ export class BashTool extends defineTool({
         approval.userMessage,
       );
     }
+
+    // Signal execution starting (triggers in-progress log after approval)
+    getCurrentToolFileInteractionContext()?.onExecutionReady?.();
 
     // Truncation only applies to internal logging so long-running commands keep
     // the output channel readable while still returning the complete stdout.


### PR DESCRIPTION
## Summary
This PR refactors the in-progress logging behavior for tools with approval flows (currently just `bash`) to prevent duplicate UI display. Previously, both an approval card and an in-progress "Running" log would appear simultaneously. Now, the in-progress log is deferred until after the user grants approval.

## Key Changes
- **Separated tool categories**: Moved `bash` from `SLOW_TOOLS` to a new `TOOLS_WITH_APPROVAL` set to distinguish tools that require approval from those that just take time
- **Added execution callback**: Introduced `onExecutionReady()` callback in `ToolFileInteractionContext` that tools can invoke to signal they're about to start actual execution
- **Deferred logging for approval tools**: For tools in `TOOLS_WITH_APPROVAL`, the in-progress log is now created lazily via the `onExecutionReady()` callback instead of immediately
- **Updated bash tool**: Modified `BashTool` to call `onExecutionReady()` after approval is granted but before command execution begins

## Implementation Details
- The `onExecutionReady` callback is passed through the tool execution pipeline from `ToolUseDispatchNode` to `invokeToolSafely()` and into the tool's context
- For approval tools, `logRef` is initialized with `undefined` logId, and the actual log entry is created when `onExecutionReady()` is called
- This approach maintains backward compatibility while cleanly separating the concerns of slow tools vs. tools with approval flows
- The callback pattern allows tools to control the exact timing of when the in-progress log appears relative to their execution lifecycle

https://claude.ai/code/session_016fZUXybcvqbYq84HmpsUEY

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to tool-use logging flow and `bash` execution timing; primary risk is missing/duplicated tool logs if the callback isn’t triggered in some approval paths.
> 
> **Overview**
> Defers in-progress “tool started” logging for approval-gated tools (currently `bash`) so the UI doesn’t show a running log alongside the approval card.
> 
> `ToolUseCycleFlow` now distinguishes deferred-log tools and passes an optional `onExecutionReady` callback through `withToolFileInteractionContext`; `bash` invokes this callback after approval is accepted to lazily create the in-progress log while preserving log grouping/updates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 57993855d44aa7a4aa8643c94f48e4e8b34ad7ea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->