### PR TITLE
Ensure stream state is created for all agent categories

### DIFF
--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -105,6 +105,10 @@ export class ProgressEventHandler {
       isRemote,
       hasMultipleOutputs,
     });
+    // Ensure stream state exists so it's included in getAllStreamStates()
+    if (agentCategory) {
+      this.state.getOrCreateStreamState(streamId, agentCategory);
+    }
     this.maybeUpdateFilterForCategory(agentCategory);
     this.state.activeStream = streamId;
     this.replayPendingTaskGroups(streamId);
@@ -441,6 +445,8 @@ export class ProgressEventHandler {
     this.state.updateStreamHints(streamId, {
       agentCategory: AgentCategory.Workflow,
     });
+    // Ensure stream state exists so it's included in getAllStreamStates()
+    this.state.getOrCreateStreamState(streamId, AgentCategory.Workflow);
     this.maybeUpdateFilterForCategory(AgentCategory.Workflow);
     this.state.activeStream = streamId;
 

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -274,28 +274,29 @@ export class ProgressEventHandler {
     const runId =
       runIdHint === undefined ? this.state.getActiveRunId(stream) : runIdHint;
 
-    const existingInstruction = runId
-      ? this.state.getRunInstruction(stream, runId)
-      : undefined;
+    // Skip update if no runId - frontend can't store instruction without it
+    if (!runId) {
+      return;
+    }
+
+    const existingInstruction = this.state.getRunInstruction(stream, runId);
     const instructionUpdate = WebviewUpdater.createInstructionUpdate(
       taskState,
       existingInstruction?.timestamp,
     );
 
     // Persist instruction if both runId and instruction exist
-    if (runId) {
-      if (instructionUpdate) {
-        void this.state.setRunInstruction(stream, runId, instructionUpdate);
-      } else {
-        void this.state.deleteRunInstruction(stream, runId);
-      }
+    if (instructionUpdate) {
+      void this.state.setRunInstruction(stream, runId, instructionUpdate);
+    } else {
+      void this.state.deleteRunInstruction(stream, runId);
     }
 
     this.webviewUpdater.updateInstruction(
       stream,
       instructionUpdate ?? null,
       category,
-      runId ?? null,
+      runId,
     );
   }
 

--- a/src/progressView/frontend/ProgressApp.ts
+++ b/src/progressView/frontend/ProgressApp.ts
@@ -308,10 +308,12 @@ export class ProgressApp extends BaseWebviewApp {
     const streamInfo = this.appState.streams.find(
       (stream) => stream.name === streamId,
     );
+    // Skip unknown streams - they'll receive full state via UPDATE_LOGS after initialization
+    if (!streamInfo) return;
     const current = getStreamState(
       this.appState,
       streamId,
-      streamInfo?.agentCategory,
+      streamInfo.agentCategory,
     );
     nextStates.set(streamId, updater(current));
     this.appState = { ...this.appState, streamStates: nextStates };

--- a/src/progressView/frontend/messageDispatcher.ts
+++ b/src/progressView/frontend/messageDispatcher.ts
@@ -170,10 +170,16 @@ function updateStreamInfo(
     const backendState = backendStates?.[stream.name];
     if (backendState) {
       const existing = nextStates.get(stream.name);
-      // Preserve frontend-owned 'ui' property when kinds match
+      // Preserve frontend-owned properties:
+      // - 'ui': frontend UI state (follow-up text, polish state, etc.)
+      // - 'logs': managed by APPEND_LOG/UPDATE_LOGS, not UPDATE_STREAMS
+      // - 'taskGroups': managed by ADD_TASK_GROUP/UPDATE_TASK_GROUP
+      // Backend's _streamStates never populates logs/taskGroups (always [])
       const preserveUI = existing && existing.kind === backendState.kind;
       nextStates.set(stream.name, {
         ...backendState,
+        logs: existing?.logs ?? backendState.logs,
+        taskGroups: existing?.taskGroups ?? backendState.taskGroups,
         ...(preserveUI && { ui: existing.ui }),
         info: stream,
       } as StreamState);

--- a/src/progressView/frontend/messageDispatcher.ts
+++ b/src/progressView/frontend/messageDispatcher.ts
@@ -18,7 +18,6 @@ import {
   type StreamTabInfo,
   type TokenUsageStats,
 } from '@shared/schemas';
-import { getEffectiveRunId } from '@shared/streams/runSelection';
 import { PERMISSION_KIND } from '@shared/utils/uiConstants';
 import { PROGRESS_VIEW_COMMANDS } from '@common/webview/commands';
 
@@ -492,18 +491,10 @@ const handlers: HandlerRegistry = {
 
   // Run-specific updates
   [PROGRESS_VIEW_COMMANDS.UPDATE_INSTRUCTION]: (data, ctx) => {
-    const { stream, instruction, runId: providedRunId } = data;
-    if (!stream) return;
+    const { stream, instruction, runId } = data;
+    if (!stream || !runId) return;
 
     updateWorkflowState(ctx, stream, (prev) => {
-      const runId =
-        providedRunId ?? getEffectiveRunId(prev, { mode: 'fallback' });
-      if (!runId) {
-        console.warn(
-          '[ProgressView] UPDATE_INSTRUCTION missing runId; skipping update.',
-        );
-        return prev;
-      }
       const { [runId]: _, ...rest } = prev.runInstructions;
       return {
         ...prev,

--- a/src/progressView/frontend/messageDispatcher.ts
+++ b/src/progressView/frontend/messageDispatcher.ts
@@ -383,6 +383,7 @@ const handlers: HandlerRegistry = {
       pendingLogUpdates.delete(getPendingLogKey(data.stream, logId));
     }
 
+    // setStreamState skips unknown streams - they'll receive full state via UPDATE_LOGS
     ctx.setStreamState(data.stream, (prev) => ({
       ...prev,
       logs: [...prev.logs, mergedLogMessage],

--- a/src/progressView/state/ProgressViewState.ts
+++ b/src/progressView/state/ProgressViewState.ts
@@ -266,7 +266,7 @@ export class ProgressViewState {
     agentCategory: (typeof AgentCategory)[keyof typeof AgentCategory],
   ): StreamState {
     const existing = this._streamStates.get(stream);
-    // Create or update if kind doesn't match (consistent with setTaskState)
+    // Create new state, or replace if kind doesn't match the agent category
     if (!existing || existing.kind !== agentCategory) {
       const state = createStreamState(agentCategory);
       this._streamStates.set(stream, state);
@@ -349,10 +349,7 @@ export class ProgressViewState {
 
     // Create or update frontend stream state with correct discriminated type
     const agentCategory = taskState.agentConfig.agentCategory;
-    const existing = this._streamStates.get(streamTabId);
-    if (!existing || existing.kind !== agentCategory) {
-      this._streamStates.set(streamTabId, createStreamState(agentCategory));
-    }
+    this.getOrCreateStreamState(streamTabId, agentCategory);
 
     this.saveTaskStates();
     this.cleanupToolUseAgentRegistry();

--- a/src/progressView/state/ProgressViewState.ts
+++ b/src/progressView/state/ProgressViewState.ts
@@ -345,9 +345,10 @@ export class ProgressViewState {
     this.taskStates.set(streamTabId, taskState);
     this.clearStreamHints(streamTabId);
 
-    // Create frontend stream state with correct discriminated type
+    // Create or update frontend stream state with correct discriminated type
     const agentCategory = taskState.agentConfig.agentCategory;
-    if (!this._streamStates.has(streamTabId)) {
+    const existing = this._streamStates.get(streamTabId);
+    if (!existing || existing.kind !== agentCategory) {
       this._streamStates.set(streamTabId, createStreamState(agentCategory));
     }
 

--- a/src/progressView/state/ProgressViewState.ts
+++ b/src/progressView/state/ProgressViewState.ts
@@ -265,12 +265,14 @@ export class ProgressViewState {
     stream: StreamTabId,
     agentCategory: (typeof AgentCategory)[keyof typeof AgentCategory],
   ): StreamState {
-    let state = this._streamStates.get(stream);
-    if (!state) {
-      state = createStreamState(agentCategory);
+    const existing = this._streamStates.get(stream);
+    // Create or update if kind doesn't match (consistent with setTaskState)
+    if (!existing || existing.kind !== agentCategory) {
+      const state = createStreamState(agentCategory);
       this._streamStates.set(stream, state);
+      return state;
     }
-    return state;
+    return existing;
   }
 
   updateStreamState(


### PR DESCRIPTION
## Summary
This PR fixes a bug where stream states were not being properly initialized for certain agent categories, causing them to be missing from `getAllStreamStates()` results.

## Key Changes
- Added explicit `getOrCreateStreamState()` calls in `ProgressEventHandler` to ensure stream state is created whenever an agent category is assigned
  - In the main stream initialization path (line 108-110)
  - In the workflow stream creation path (line 448-449)

## Implementation Details
The issue occurred because stream state creation was not guaranteed when updating stream hints with an agent category. By explicitly calling `getOrCreateStreamState()` immediately after setting the agent category, we ensure the stream state exists and will be included in subsequent `getAllStreamStates()` calls. This prevents potential issues where streams with assigned categories would be missing from state queries.

https://claude.ai/code/session_01H4KGNENn58MdAVtgiWYRym

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core progress-view state initialization/merging logic and changes when instruction updates are emitted, which could affect stream rendering and per-run instruction persistence if assumptions about run IDs or categories are wrong.
> 
> **Overview**
> Fixes missing/incorrect stream state initialization by ensuring backend `ProgressViewState.getOrCreateStreamState()` is invoked whenever a stream’s `agentCategory` is known (e.g., on `setActiveStream` and workflow stream creation), and by recreating state when an existing stream state’s `kind` doesn’t match the incoming category.
> 
> Hardens frontend state handling: `ProgressApp.setStreamState` now ignores updates for unknown streams until initialized, `UPDATE_STREAMS` merges backend streamStates while **preserving frontend-owned** `logs` and `taskGroups`, and instruction updates are now strictly run-scoped (skip backend/ frontend `UPDATE_INSTRUCTION` handling when `runId` is missing, removing the fallback run-id guess).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2dd1ff29ceea2e245b839e0608b00793abf3e971. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->