### PR TITLE
Always include all items in local messages for response chaining

### DIFF
--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -1085,7 +1085,8 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     // server-side output items that the server already has. This prevents
     // "Duplicate item found" errors while keeping local messages complete
     // for compaction and persistence.
-    if (this.previousResponseId && !shouldSendAll) {
+    const useResponseChaining = this.shouldUseResponseChaining(shouldSendAll);
+    if (useResponseChaining) {
       newMessages = newMessages.filter(
         (item) => !this.isServerSideOutputItem(item),
       );
@@ -1107,18 +1108,14 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       : undefined;
 
     // Phase 1: BUILD - Construct provider-specific request parameters
-    // IMPORTANT: When shouldSendAll is true (after compaction), we MUST NOT include
-    // previous_response_id because:
-    // 1. Compacted messages are self-contained and complete
-    // 2. The old response ID references stale server-side state
-    // Compaction already clears previousResponseId, but we make this explicit here.
-    const usePreviousResponseId =
-      !shouldSendAll && this.previousResponseId !== null;
+    // When shouldSendAll is true (after compaction), we MUST NOT include
+    // previous_response_id because compacted messages are self-contained
+    // and the old response ID references stale server-side state.
     const baseParams = {
       model: this.config.fullName,
       input: newMessages,
       ...(systemPrompt && { instructions: systemPrompt }),
-      ...(usePreviousResponseId && {
+      ...(useResponseChaining && {
         previous_response_id: this.previousResponseId,
       }),
       ...(convertedTools?.length && { tools: convertedTools }),
@@ -1147,7 +1144,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
           signal,
           systemPrompt,
           tools: convertedTools,
-          previousResponseId: usePreviousResponseId
+          previousResponseId: useResponseChaining
             ? this.previousResponseId
             : null,
         });
@@ -2360,24 +2357,35 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
    * - user messages: user input
    */
   private isServerSideOutputItem(item: ResponseInputItem): boolean {
-    // ResponseInputItem is a union type. We need to check 'type' and 'role' fields
-    // which exist on different variants of the union.
-    const itemObj = item as { type?: string; role?: string };
-
-    // Check against the canonical list of server-side output types
-    if (itemObj.type && SERVER_SIDE_OUTPUT_TYPES.has(itemObj.type)) {
-      return true;
+    // Use 'in' operator for proper type narrowing instead of casting
+    if ('type' in item && typeof item.type === 'string') {
+      if (SERVER_SIDE_OUTPUT_TYPES.has(item.type)) {
+        return true;
+      }
     }
 
-    // Assistant messages are also server-side outputs.
-    // They can be either:
-    // - EasyInputMessage: { role: 'assistant', content: ... } (no type field)
+    // Assistant messages are server-side outputs.
+    // Covers both:
+    // - EasyInputMessage: { role: 'assistant', content: ... }
     // - ResponseInputItem.Message: { type: 'message', role: 'assistant', ... }
-    if (itemObj.role === 'assistant') {
+    if ('role' in item && item.role === 'assistant') {
       return true;
     }
 
     return false;
+  }
+
+  /**
+   * Determines if we should use response chaining (previousResponseId) for this request.
+   *
+   * Returns false when:
+   * - shouldSendAll is true (after compaction, must send complete messages)
+   * - No previousResponseId exists (first request in conversation)
+   *
+   * This centralizes the logic to avoid duplicate checks across the codebase.
+   */
+  private shouldUseResponseChaining(shouldSendAll: boolean): boolean {
+    return !shouldSendAll && this.previousResponseId !== null;
   }
 
   /** Type alias for reasoning delta events (both raw and summary). */

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -118,11 +118,11 @@ interface UploadedOpenAIResponseAttachment {
  * Note: Assistant messages (role: 'assistant') are also server-side outputs but
  * are identified by role rather than type, so handled separately in isServerSideOutputItem().
  */
-const SERVER_SIDE_OUTPUT_TYPES = [
+const SERVER_SIDE_OUTPUT_TYPES: ReadonlySet<string> = new Set([
   'function_call',
   'reasoning',
   'web_search_call',
-] as const;
+]);
 
 /**
  * Handler for OpenAI's Responses API. This implementation works directly with
@@ -965,12 +965,19 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
 
     const client = options?.client ?? (await this.getClient());
 
+    // Determine previousResponseId: explicit option takes precedence over internal state.
+    // Pass null to explicitly exclude (e.g., after compaction).
+    const prevResponseId =
+      options?.previousResponseId !== undefined
+        ? options.previousResponseId
+        : this.previousResponseId;
+
     // Build params matching what we send to the actual API call
     const countParams: InputTokenCountParams = {
       model: this.config.fullName,
       input: messages,
-      ...(this.previousResponseId && {
-        previous_response_id: this.previousResponseId,
+      ...(prevResponseId && {
+        previous_response_id: prevResponseId,
       }),
       ...(options?.systemPrompt && { instructions: options.systemPrompt }),
       ...(options?.tools?.length && {
@@ -1100,11 +1107,18 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       : undefined;
 
     // Phase 1: BUILD - Construct provider-specific request parameters
+    // IMPORTANT: When shouldSendAll is true (after compaction), we MUST NOT include
+    // previous_response_id because:
+    // 1. Compacted messages are self-contained and complete
+    // 2. The old response ID references stale server-side state
+    // Compaction already clears previousResponseId, but we make this explicit here.
+    const usePreviousResponseId =
+      !shouldSendAll && this.previousResponseId !== null;
     const baseParams = {
       model: this.config.fullName,
       input: newMessages,
       ...(systemPrompt && { instructions: systemPrompt }),
-      ...(this.previousResponseId && {
+      ...(usePreviousResponseId && {
         previous_response_id: this.previousResponseId,
       }),
       ...(convertedTools?.length && { tools: convertedTools }),
@@ -1127,12 +1141,15 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     if (this.supportsTokenCounting) {
       try {
         // Reuse built params for token counting (build once principle)
-        // IMPORTANT: Pass tools and systemPrompt for accurate count
+        // IMPORTANT: Pass tools, systemPrompt, and previousResponseId for accurate count
         const inputTokens = await this.estimateTokenCount(baseParams.input, {
           client,
           signal,
           systemPrompt,
           tools: convertedTools,
+          previousResponseId: usePreviousResponseId
+            ? this.previousResponseId
+            : null,
         });
 
         // DIAGNOSTIC: Log token count details for investigation
@@ -2343,26 +2360,21 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
    * - user messages: user input
    */
   private isServerSideOutputItem(item: ResponseInputItem): boolean {
-    if (typeof item !== 'object' || item === null) {
-      return false;
-    }
-
-    const type = (item as { type?: string }).type;
+    // ResponseInputItem is a union type. We need to check 'type' and 'role' fields
+    // which exist on different variants of the union.
+    const itemObj = item as { type?: string; role?: string };
 
     // Check against the canonical list of server-side output types
-    if (
-      type &&
-      (SERVER_SIDE_OUTPUT_TYPES as readonly string[]).includes(type)
-    ) {
+    if (itemObj.type && SERVER_SIDE_OUTPUT_TYPES.has(itemObj.type)) {
       return true;
     }
 
-    // Assistant messages are also server-side outputs (identified by role, not type)
-    if (type === 'message' || type === undefined) {
-      const role = (item as { role?: string }).role;
-      if (role === 'assistant') {
-        return true;
-      }
+    // Assistant messages are also server-side outputs.
+    // They can be either:
+    // - EasyInputMessage: { role: 'assistant', content: ... } (no type field)
+    // - ResponseInputItem.Message: { type: 'message', role: 'assistant', ... }
+    if (itemObj.role === 'assistant') {
+      return true;
     }
 
     return false;

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -1056,9 +1056,19 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     // Otherwise, only send new messages since last request.
     const shouldSendAll =
       compactedThisCall || this.conversationState.isCompacted;
-    const newMessages = shouldSendAll
+    let newMessages = shouldSendAll
       ? effectiveMessages
       : effectiveMessages.slice(this.conversationState.sentMessages);
+
+    // When using response chaining (previousResponseId is set), filter out
+    // server-side output items that the server already has. This prevents
+    // "Duplicate item found" errors while keeping local messages complete
+    // for compaction and persistence.
+    if (this.previousResponseId && !shouldSendAll) {
+      newMessages = newMessages.filter(
+        (item) => !this.isServerSideOutputItem(item),
+      );
+    }
 
     await this.uploadInlineInputFiles(client, newMessages);
 
@@ -2090,29 +2100,25 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
   ): Promise<ResponseInputItem[]> {
     const messages: ResponseInputItem[] = [];
 
-    // When using previous_response_id (response chaining), the previous response's
-    // output items (reasoning, web_search_call, function_call) are already in
-    // OpenAI's server-side history. We should only send NEW items (function_call_output).
-    // Including them again causes "Duplicate item found" errors.
-    const isResponseChaining = Boolean(this.previousResponseId);
+    // Always include all items in local messages for completeness.
+    // The slicing logic (sentMessages) handles avoiding re-sends during response chaining.
+    // This ensures local messages are a complete representation of the conversation,
+    // which is critical for compaction - the compact endpoint needs the full context
+    // to properly preserve function_call/function_call_output pairs.
 
-    if (text && !isResponseChaining) {
-      // Only include assistant text when not chaining (it's in previous response)
+    if (text) {
       messages.push(this.createAssistantMessage(text));
     }
 
     // Include server tool content blocks (reasoning, web_search_call) from workspace state.
     // These need to be preserved when both server and local tools are in the same response.
     // Reasoning items must be included when web_search_call references them.
-    // SKIP when response chaining - these items are already in previous_response_id context.
     // Always clear after processing to prevent accumulation across cycles.
     if (workspaceState?.serverToolContent.contentBlocks.length) {
-      if (!isResponseChaining) {
-        const openaiBlocks = workspaceState.serverToolContent.contentBlocks
-          .filter(isOpenAIServerToolContent)
-          .map((block) => block as ResponseInputItem);
-        messages.push(...openaiBlocks);
-      }
+      const openaiBlocks = workspaceState.serverToolContent.contentBlocks
+        .filter(isOpenAIServerToolContent)
+        .map((block) => block as ResponseInputItem);
+      messages.push(...openaiBlocks);
       workspaceState.resetServerToolContent();
     }
 
@@ -2307,6 +2313,48 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     item: ResponseOutputItem,
   ): item is ResponseOutputMessage {
     return item.type === 'message';
+  }
+
+  /**
+   * Check if an item is a server-side output item that the server already has
+   * when previous_response_id is set. These should be filtered out to avoid
+   * "Duplicate item found" errors.
+   *
+   * Server-side output items include:
+   * - function_call: model's request to call a function
+   * - reasoning: model's thinking/reasoning
+   * - web_search_call: model's web search requests
+   * - assistant messages: model's text responses
+   *
+   * Items we MUST send (not server-side output):
+   * - function_call_output: our response to tool calls
+   * - user messages: user input
+   */
+  private isServerSideOutputItem(item: ResponseInputItem): boolean {
+    if (typeof item !== 'object' || item === null) {
+      return false;
+    }
+
+    const type = (item as { type?: string }).type;
+
+    // These are model output types - server already has them via previous_response_id
+    if (
+      type === 'function_call' ||
+      type === 'reasoning' ||
+      type === 'web_search_call'
+    ) {
+      return true;
+    }
+
+    // Check for assistant messages (type 'message' with role 'assistant')
+    if (type === 'message' || type === undefined) {
+      const role = (item as { role?: string }).role;
+      if (role === 'assistant') {
+        return true;
+      }
+    }
+
+    return false;
   }
 
   /** Type alias for reasoning delta events (both raw and summary). */

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -111,6 +111,20 @@ interface UploadedOpenAIResponseAttachment {
 }
 
 /**
+ * Item types that are model outputs stored server-side via previous_response_id.
+ * These should be filtered out when sending API requests during response chaining
+ * to avoid "Duplicate item found" errors.
+ *
+ * Note: Assistant messages (role: 'assistant') are also server-side outputs but
+ * are identified by role rather than type, so handled separately in isServerSideOutputItem().
+ */
+const SERVER_SIDE_OUTPUT_TYPES = [
+  'function_call',
+  'reasoning',
+  'web_search_call',
+] as const;
+
+/**
  * Handler for OpenAI's Responses API. This implementation works directly with
  * the native response message types instead of reusing the chat completion
  * abstractions. Conversation state is maintained through `previous_response_id`
@@ -2320,11 +2334,9 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
    * when previous_response_id is set. These should be filtered out to avoid
    * "Duplicate item found" errors.
    *
-   * Server-side output items include:
-   * - function_call: model's request to call a function
-   * - reasoning: model's thinking/reasoning
-   * - web_search_call: model's web search requests
-   * - assistant messages: model's text responses
+   * Server-side output items (see SERVER_SIDE_OUTPUT_TYPES):
+   * - function_call, reasoning, web_search_call
+   * - assistant messages (role: 'assistant')
    *
    * Items we MUST send (not server-side output):
    * - function_call_output: our response to tool calls
@@ -2337,16 +2349,15 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
 
     const type = (item as { type?: string }).type;
 
-    // These are model output types - server already has them via previous_response_id
+    // Check against the canonical list of server-side output types
     if (
-      type === 'function_call' ||
-      type === 'reasoning' ||
-      type === 'web_search_call'
+      type &&
+      (SERVER_SIDE_OUTPUT_TYPES as readonly string[]).includes(type)
     ) {
       return true;
     }
 
-    // Check for assistant messages (type 'message' with role 'assistant')
+    // Assistant messages are also server-side outputs (identified by role, not type)
     if (type === 'message' || type === undefined) {
       const role = (item as { role?: string }).role;
       if (role === 'assistant') {

--- a/src/agent/modelHandlers/types/IModelHandler.ts
+++ b/src/agent/modelHandlers/types/IModelHandler.ts
@@ -37,6 +37,12 @@ export interface TokenCountOptions<C = unknown> {
   tools?: unknown[];
   /** For cancellation */
   signal?: AbortSignal;
+  /**
+   * Previous response ID for providers that support response chaining.
+   * Pass null to explicitly exclude from count (e.g., after compaction).
+   * If undefined, handler decides based on internal state.
+   */
+  previousResponseId?: string | null;
 }
 
 /**


### PR DESCRIPTION
## Summary
This change modifies the message building logic to always include all items (text, reasoning, web_search_call) in local messages, rather than conditionally skipping them during response chaining. The slicing logic (`sentMessages`) now handles avoiding re-sends to the server.

## Key Changes
- Removed the `isResponseChaining` conditional checks that were skipping assistant text and server tool content blocks
- Now always include assistant messages and OpenAI server tool content blocks in the local messages array
- Updated comments to clarify that the slicing logic (not conditional inclusion) prevents duplicate sends during response chaining

## Implementation Details
The change is motivated by ensuring local messages maintain a complete representation of the conversation. This is critical for the compact endpoint, which needs the full context to properly preserve function_call/function_call_output pairs during compaction. The server-side deduplication (via `previous_response_id`) and client-side slicing logic (`sentMessages`) together prevent duplicate items from being sent, making the conditional skipping unnecessary and potentially problematic for message compaction.

https://claude.ai/code/session_01MneUT2d2QGpint1C1AwqEa

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core request construction for OpenAI Responses (chaining, token counting, and message filtering), which can affect conversation continuity and tool-call flows if the new filtering logic is incomplete or misclassifies items.
> 
> **Overview**
> Ensures OpenAI Responses message building always retains *all* assistant text and server tool content blocks locally (reasoning/web search/function calls), rather than skipping them during response chaining, improving compaction correctness and session persistence.
> 
> To prevent OpenAI "Duplicate item found" errors, requests sent with `previous_response_id` now filter out server-stored output items (assistant messages plus `function_call`/`reasoning`/`web_search_call`) and centralize chaining enablement via `shouldUseResponseChaining()`; token counting is updated to accept an explicit `previousResponseId` option so counts match the exact request context (and can explicitly exclude chaining after compaction).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3244395256205cdaff0889cef13cc29547e45257. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->