### PR TITLE
Add Claude Opus 4.6 support for 1M-token context beta

### DIFF
--- a/docs/guide/models.md
+++ b/docs/guide/models.md
@@ -22,7 +22,7 @@ TeXRA supports models from multiple providers. Select models from the dropdown i
 | `haiku45`   | Fast responses               | $$   | Fast   |
 | `haiku35`   | Budget option                | $    | Fast   |
 
-For 1M-token context on Sonnet 4/4.5, enable `texra.model.useAnthropic1MBeta` in settings.
+For 1M-token context on Opus 4.6 and Sonnet 4/4.5, enable `texra.model.useAnthropic1MBeta` in settings.
 
 ## OpenAI Models
 

--- a/package.json
+++ b/package.json
@@ -305,7 +305,7 @@
           "texra.model.useAnthropic1MBeta": {
             "type": "boolean",
             "default": false,
-            "description": "Attach the `context-1m-2025-08-07` beta header for Claude Sonnet 4 requests to enable the 1M-token context window (usage capped at 200 K by extension).",
+            "description": "Attach the `context-1m-2025-08-07` beta header for Claude Opus 4.6 and Sonnet 4 requests to enable the 1M-token context window (usage capped at 200 K by extension).",
             "scope": "resource"
           },
           "texra.model.instructionPolishModel": {

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -521,7 +521,8 @@ export class ModelHandlerAnthropic extends ModelHandler<
     );
     const isAnthropic1MBetaEligibleModel =
       this.config.fullName === 'claude-sonnet-4-20250514' ||
-      this.config.fullName === 'claude-sonnet-4-5';
+      this.config.fullName === 'claude-sonnet-4-5' ||
+      this.config.fullName === OPUS_46_FULLNAME;
     const isAnthropic1MBetaActive =
       useAnthropic1MBeta && isAnthropic1MBetaEligibleModel;
     const effectiveContextWindow = isAnthropic1MBetaActive
@@ -603,7 +604,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
       // The thinking configuration is now handled above for all reasoning models
     }
 
-    // Opt-in beta for 1M context window on Claude Sonnet 4 family
+    // Opt-in beta for 1M context window on eligible Claude models
     if (isAnthropic1MBetaActive) {
       this.ensureBeta(options, CONTEXT_1M_BETA);
     }


### PR DESCRIPTION
## Summary
Extends the 1M-token context window beta feature to support Claude Opus 4.6 in addition to the existing Sonnet 4/4.5 models.

## Changes
- Updated documentation to reflect that Opus 4.6 is now eligible for the 1M-token context beta feature
- Added `claude-opus-4-6` to the list of models that can use the `context-1m-2025-08-07` beta header
- Updated configuration descriptions and code comments to mention Opus 4.6 alongside Sonnet models
- Modified the eligibility check in `ModelHandlerAnthropic` to include `OPUS_46_FULLNAME`

## Implementation Details
The change adds Opus 4.6 to the `isAnthropic1MBetaEligibleModel` condition, allowing users to enable the extended context window for this model through the `texra.model.useAnthropic1MBeta` setting. The 200K usage cap per extension session remains in effect for all eligible models.

https://claude.ai/code/session_01MuboYohaLCxeEGeULaZCBY

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, opt-in change gated behind `texra.model.useAnthropic1MBeta`, primarily affecting request headers/context-window sizing for one additional model.
> 
> **Overview**
> Enables the 1M-token context beta for **Claude Opus 4.6** when `texra.model.useAnthropic1MBeta` is turned on, by expanding the eligibility check in `ModelHandlerAnthropic` to include `OPUS_46_FULLNAME` and updating the associated comment.
> 
> Updates user-facing docs and the `package.json` setting description to indicate the beta now applies to Opus 4.6 in addition to Sonnet 4/4.5.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 15042c5608a2d44eddfb49d1c239d546ca3f6285. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->