### PR TITLE
feat: add Anthropic server-side compaction support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.35.9",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@anthropic-ai/sdk": "^0.72.1",
+        "@anthropic-ai/sdk": "^0.73.0",
         "@cantoo/pdf-lib": "^2.5.3",
         "@google/genai": "^1.40.0",
         "@jamesgopsill/crossref-client": "^1.1.0",
@@ -17,7 +17,7 @@
         "@lit/context": "^1.1.6",
         "@modelcontextprotocol/sdk": "^1.26.0",
         "@openrouter/sdk": "^0.5.1",
-        "@supabase/supabase-js": "^2.95.1",
+        "@supabase/supabase-js": "^2.95.2",
         "@vscode-elements/elements": "^2.4.0",
         "@vscode/codicons": "^0.0.44",
         "arxiv-client": "^0.0.9",
@@ -113,9 +113,9 @@
       "license": "MIT"
     },
     "node_modules/@anthropic-ai/sdk": {
-      "version": "0.72.1",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.72.1.tgz",
-      "integrity": "sha512-MiUnue7qN7DvLIoYHgkedN2z05mRf2CutBzjXXY2krzOhG2r/rIfISS2uVkNLikgToB5hYIzw+xp2jdOtRkqYQ==",
+      "version": "0.73.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.73.0.tgz",
+      "integrity": "sha512-URURVzhxXGJDGUGFunIOtBlSl7KWvZiAAKY/ttTkZAkXT9bTPqdk2eK0b8qqSxXpikh3QKPnPYpiyX98zf5ebw==",
       "license": "MIT",
       "dependencies": {
         "json-schema-to-ts": "^3.1.1"
@@ -2012,9 +2012,9 @@
       }
     },
     "node_modules/@supabase/auth-js": {
-      "version": "2.95.1",
-      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.95.1.tgz",
-      "integrity": "sha512-fl1MeO3GgRXX0fQZ1/ty2bIlEWGzHsC1dwtrmxr0OkjRf0QjkHQ+SMjby4iqN9WnASHb8AH4sP6FjG3bJVo3fg==",
+      "version": "2.95.2",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.95.2.tgz",
+      "integrity": "sha512-0dW1Y0vFcjkQpjJb/vR92lVqVaWSjM8v6VBPoaJfiIQ94+F/qnc+yV1ZTSZ96LqM61TaLAhqt7S2fLS//lc8ew==",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.1"
@@ -2024,9 +2024,9 @@
       }
     },
     "node_modules/@supabase/functions-js": {
-      "version": "2.95.1",
-      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.95.1.tgz",
-      "integrity": "sha512-JiF16+aCkh0Kqyc3xXGh6cUEuTKIFPix3dZNl/SjCb5vaWuMSeQaROwPnQ89BeTH1Z7VS43ydPUzD0zcaxULGA==",
+      "version": "2.95.2",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.95.2.tgz",
+      "integrity": "sha512-SInf19qm2aWEp49O5OJ+gftzifSPeaA5w0L1qF96Ul13tilRbQOlQAk1e7py9xH4tPkOkCDMf6n+H5Js5uzIUQ==",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.1"
@@ -2036,9 +2036,9 @@
       }
     },
     "node_modules/@supabase/postgrest-js": {
-      "version": "2.95.1",
-      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.95.1.tgz",
-      "integrity": "sha512-1g97xV0jmEA5wmRGpJfbuO0F3bNJn+JERkRu0/YiUeodg7GKT4o06+LoayFDwrquXK+kzrxnDUZAkSOPELbGsg==",
+      "version": "2.95.2",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.95.2.tgz",
+      "integrity": "sha512-v0DHzy3vFALRLaFNZPbBWK7PESPvI+cC7/A2HtqwmLuX7XdOwdHwaz2yooNOfcYkoNOLS5p8WbgCA9DDXs+QlQ==",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.1"
@@ -2048,9 +2048,9 @@
       }
     },
     "node_modules/@supabase/realtime-js": {
-      "version": "2.95.1",
-      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.95.1.tgz",
-      "integrity": "sha512-ZBzxkAqPq8D4vfoAG2D6H1lZuaOE2PpUVZs0tGIeKpgRYMsfG2wn/njKKNQdXEuu0ngXva/QI98GsZF8Pbqyhg==",
+      "version": "2.95.2",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.95.2.tgz",
+      "integrity": "sha512-8LhHR28Xv1/jjtfiospyqMdE+sL0SVdk24ziio4vmgsUHApzh4ucr+sVY3LXInzSVycrgNnYwStMiWuTZUVxoA==",
       "license": "MIT",
       "dependencies": {
         "@types/phoenix": "^1.6.6",
@@ -2063,9 +2063,9 @@
       }
     },
     "node_modules/@supabase/storage-js": {
-      "version": "2.95.1",
-      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.95.1.tgz",
-      "integrity": "sha512-OB2TvLx5hXJ9MWd3LFze9+kAB2Ap/EWSwLeEdxQZrV+JhGtUxuS2wxHnVMEhNiu/k3gyRNAdI9888RRmC2wnLA==",
+      "version": "2.95.2",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.95.2.tgz",
+      "integrity": "sha512-vUNMnHgbyHIHGFmwkQkp1VUdWVGWoFqaEgAAmlXx3Ca0+GzlyScwhkYm8dvtM+mgUo/nJQXwPRPOcWTZMo/tpg==",
       "license": "MIT",
       "dependencies": {
         "iceberg-js": "^0.8.1",
@@ -2076,16 +2076,16 @@
       }
     },
     "node_modules/@supabase/supabase-js": {
-      "version": "2.95.1",
-      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.95.1.tgz",
-      "integrity": "sha512-ow3ZqJfb3JkLF8MDxVOl3FAy39pGF1uWgr5nitcwEMwjJTt7yk/s8sQPcGrTL29xOqQB+v5hQDWYr7906k4a3A==",
+      "version": "2.95.2",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.95.2.tgz",
+      "integrity": "sha512-CkNIPJCdOkokX5E92RJt6yHNyHprJ2V8wRuGK8wCPwbaEmWvW0CvMj+qr4uGozwnOd1ixeAsQUSg6+roA0+muA==",
       "license": "MIT",
       "dependencies": {
-        "@supabase/auth-js": "2.95.1",
-        "@supabase/functions-js": "2.95.1",
-        "@supabase/postgrest-js": "2.95.1",
-        "@supabase/realtime-js": "2.95.1",
-        "@supabase/storage-js": "2.95.1"
+        "@supabase/auth-js": "2.95.2",
+        "@supabase/functions-js": "2.95.2",
+        "@supabase/postgrest-js": "2.95.2",
+        "@supabase/realtime-js": "2.95.2",
+        "@supabase/storage-js": "2.95.2"
       },
       "engines": {
         "node": ">=20.0.0"

--- a/package.json
+++ b/package.json
@@ -227,7 +227,7 @@
             "default": 75,
             "minimum": 0,
             "maximum": 100,
-            "description": "Percentage of context window to trigger automatic context management. For OpenAI, triggers conversation compaction via /responses/compact. For Anthropic, triggers server-side clearing of tool uses and thinking blocks. Set to 0 to disable.",
+            "description": "Percentage of context window to trigger automatic context management. For OpenAI, triggers conversation compaction via /responses/compact. For Anthropic, triggers server-side clearing (all models) and native compaction on Claude Opus 4.6. Set to 0 to disable.",
             "scope": "resource"
           },
           "texra.model.enableThinkingClearing": {
@@ -1648,7 +1648,7 @@
   },
   "homepage": "https://texra.ai",
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.72.1",
+    "@anthropic-ai/sdk": "^0.73.0",
     "@cantoo/pdf-lib": "^2.5.3",
     "@google/genai": "^1.40.0",
     "@jamesgopsill/crossref-client": "^1.1.0",
@@ -1656,7 +1656,7 @@
     "@lit/context": "^1.1.6",
     "@modelcontextprotocol/sdk": "^1.26.0",
     "@openrouter/sdk": "^0.5.1",
-    "@supabase/supabase-js": "^2.95.1",
+    "@supabase/supabase-js": "^2.95.2",
     "@vscode-elements/elements": "^2.4.0",
     "@vscode/codicons": "^0.0.44",
     "arxiv-client": "^0.0.9",

--- a/package.json
+++ b/package.json
@@ -227,13 +227,7 @@
             "default": 75,
             "minimum": 0,
             "maximum": 100,
-            "description": "Percentage of context window to trigger automatic context management. For OpenAI, triggers conversation compaction via /responses/compact. For Anthropic, triggers server-side clearing (all models) and native compaction on Claude Opus 4.6. Set to 0 to disable.",
-            "scope": "resource"
-          },
-          "texra.model.enableThinkingClearing": {
-            "type": "boolean",
-            "default": false,
-            "description": "Enable Anthropic's thinking block clearing strategy. When enabled, old thinking blocks are cleared alongside tool uses. Disabled by default because thinking clearing runs before tool use clearing and may prevent tool use clearing from triggering.",
+            "description": "Percentage of context window to trigger automatic context management. For OpenAI, triggers conversation compaction via /responses/compact. For Anthropic, triggers native server-side compaction on Claude Opus 4.6. Set to 0 to disable.",
             "scope": "resource"
           },
           "texra.model.gpt5ReasoningSummary": {

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -35,9 +35,9 @@ import {
 import type { ToolFileAttachment } from '@tools/result';
 
 // Local imports - utils
-import { getConfig, K_SLICE } from '@utils/config';
+import { K_SLICE } from '@utils/config';
+import { getProviderStreaming, getGlobalStreaming } from '@utils/config/constants';
 import type { FileLocation } from '@utils/files';
-import { capitalize } from '@utils/text/stringUtils';
 import { MediaAttachmentProcessor } from './support/MediaAttachmentProcessor';
 import {
   resolveBaseUrl,
@@ -404,27 +404,16 @@ export abstract class ModelHandler<
    * @returns Boolean indicating if streaming should be enabled
    */
   public getStreamingConfig(): boolean {
-    const globalDefault = getConfig<boolean>('texra.model.useStreaming', true);
-
-    if (
-      this.config.openRouterOnly ||
-      getConfig<boolean>('texra.model.useOpenRouter', false)
-    ) {
-      // OpenRouter defaults to streaming off (different from other providers)
-      return getConfig<boolean>('texra.model.useStreamingOpenrouter', false);
+    if (shouldUseOpenRouter(this.config)) {
+      return getProviderStreaming('openrouter');
     }
 
     // ModelProvider.OTHERS has no provider-specific streaming config
     if (this.config.provider === ModelProvider.OTHERS) {
-      return globalDefault;
+      return getGlobalStreaming();
     }
 
-    // Derive config key suffix from provider enum value (e.g., 'openai' -> 'Openai')
-    const suffix = capitalize(this.config.provider);
-    return getConfig<boolean>(
-      `texra.model.useStreaming${suffix}`,
-      globalDefault,
-    );
+    return getProviderStreaming(this.config.provider);
   }
 
   get isOReasoningModel(): boolean {

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -89,7 +89,6 @@ import type {
   BetaCompactionBlock,
   BetaCompactionIterationUsage,
   BetaContextManagementConfig,
-  BetaContextManagementResponse,
   BetaImageBlockParam,
   BetaMessage,
   BetaRedactedThinkingBlock,
@@ -160,21 +159,6 @@ const COMPACTION_BETA: AnthropicBeta = 'compact-2026-01-12';
 
 const OPUS_46_FULLNAME = 'claude-opus-4-6';
 
-/**
- * Context management constants for Anthropic's server-side editing.
- * These are reasonable defaults that balance context efficiency with conversation continuity.
- */
-/** Number of recent tool use/result pairs to keep after context clearing */
-const CONTEXT_MANAGEMENT_KEEP_TOOL_USES = 3;
-/** Number of assistant turns with thinking blocks to keep */
-const CONTEXT_MANAGEMENT_KEEP_THINKING_TURNS = 3;
-/**
- * Minimum percentage of context to clear at once for tool uses.
- * This ensures cache invalidation is worthwhile - clearing too few tokens
- * causes frequent cache misses without meaningful benefit.
- * 25% provides more aggressive clearing to reduce frequent cache thrashing.
- */
-const CONTEXT_MANAGEMENT_CLEAR_AT_LEAST_PERCENT = 25;
 /** Compaction must be triggered at or above this minimum input token threshold. */
 const MIN_COMPACTION_TRIGGER_TOKENS = 50_000;
 
@@ -192,20 +176,11 @@ const THINKING_TEMPERATURE_EXCLUDED_PATTERNS = [
 ];
 
 /**
- * Extended response type for countTokens with context_management.
- * The SDK doesn't export this, so we define it here for type safety.
- */
-interface CountTokensContextManagementResponse {
-  original_input_tokens: number;
-}
-
-/**
  * Options for setting up context management configuration.
  */
 interface ContextManagementSetupOptions {
   options: MessageCreateParams;
   contextWindow: number;
-  supportsReasoning: boolean;
   thresholdPercent: number;
 }
 
@@ -302,12 +277,11 @@ export class ModelHandlerAnthropic extends ModelHandler<
 
   /**
    * Sets up context management configuration for Anthropic's server-side editing.
-   * Must be called BEFORE token counting so countTokens returns accurate post-clearing counts.
+   * Must be called before token counting so estimate options match create options.
    */
   private setupContextManagement({
     options,
     contextWindow,
-    supportsReasoning,
     thresholdPercent,
   }: ContextManagementSetupOptions): void {
     if (!this.isToolUseMode()) {
@@ -319,76 +293,17 @@ export class ModelHandlerAnthropic extends ModelHandler<
       return;
     }
 
+    if (!this.isClaudeOpus46()) {
+      return;
+    }
+
     this.ensureBeta(options, CONTEXT_MANAGEMENT_BETA);
 
     const contextManagementEdits = [
       ...(options.context_management?.edits ?? []),
     ];
 
-    const triggerTokens = Math.floor((thresholdPercent / 100) * contextWindow);
-
-    // When context management is enabled with thinking, the API's default behavior
-    // clears thinking to keep only the last 1 turn. We must explicitly configure
-    // thinking clearing to control this behavior.
-    const enableThinkingClearing = getConfig<boolean>(
-      'texra.model.enableThinkingClearing',
-      false,
-    );
-
     if (
-      supportsReasoning &&
-      options.thinking &&
-      !contextManagementEdits.some(
-        (edit) => edit.type === 'clear_thinking_20251015',
-      )
-    ) {
-      // Thinking clearing must come first in the edits array per API requirement.
-      // When disabled (default): preserve all thinking blocks to prevent early clearing.
-      // When enabled: keep last N turns to manage context growth.
-      contextManagementEdits.unshift({
-        type: 'clear_thinking_20251015' as const,
-        keep: enableThinkingClearing
-          ? {
-              type: 'thinking_turns' as const,
-              value: CONTEXT_MANAGEMENT_KEEP_THINKING_TURNS,
-            }
-          : ('all' as const),
-      });
-    }
-
-    // Add tool result clearing strategy with server-side trigger.
-    // The trigger ensures clearing only activates when input tokens exceed threshold.
-    if (
-      !contextManagementEdits.some(
-        (edit) => edit.type === 'clear_tool_uses_20250919',
-      )
-    ) {
-      // clear_at_least ensures cache invalidation is worthwhile:
-      // Without it, the API may clear too few tokens, causing frequent
-      // cache misses without meaningful benefit.
-      const clearAtLeastTokens = Math.floor(
-        (CONTEXT_MANAGEMENT_CLEAR_AT_LEAST_PERCENT / 100) * contextWindow,
-      );
-
-      contextManagementEdits.push({
-        type: 'clear_tool_uses_20250919' as const,
-        trigger: {
-          type: 'input_tokens' as const,
-          value: triggerTokens,
-        },
-        keep: {
-          type: 'tool_uses' as const,
-          value: CONTEXT_MANAGEMENT_KEEP_TOOL_USES,
-        },
-        clear_at_least: {
-          type: 'input_tokens' as const,
-          value: clearAtLeastTokens,
-        },
-      });
-    }
-
-    if (
-      this.isClaudeOpus46() &&
       !contextManagementEdits.some((edit) => edit.type === 'compact_20260112')
     ) {
       this.ensureBeta(options, COMPACTION_BETA);
@@ -494,10 +409,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
       countTokensParams.thinking = options.thinking;
     }
 
-    // Include context_management in token counting to get accurate
-    // post-clearing token counts. This is critical for:
-    // 1. Correctly adjusting max_tokens based on actual available context
-    // 2. Allowing both clearing strategies to work together
+    // Include context_management in token counting so estimates match request options.
     if (options?.contextManagement) {
       countTokensParams.context_management = options.contextManagement;
     }
@@ -517,32 +429,9 @@ export class ModelHandlerAnthropic extends ModelHandler<
     const responseTokenCount =
       await client.beta.messages.countTokens(countTokensParams);
 
-    // Log both original and post-clearing token counts if available
-    const contextMgmtResponse = (
-      responseTokenCount as typeof responseTokenCount & {
-        context_management?: CountTokensContextManagementResponse;
-      }
-    ).context_management;
-
-    if (contextMgmtResponse?.original_input_tokens) {
-      const tokenDelta =
-        contextMgmtResponse.original_input_tokens -
-        responseTokenCount.input_tokens;
-
-      if (tokenDelta >= 0) {
-        this.logger.debug(
-          `Token count: ${responseTokenCount.input_tokens} (after clearing ${tokenDelta} tokens from ${contextMgmtResponse.original_input_tokens})`,
-        );
-      } else {
-        this.logger.debug(
-          `Token count: ${responseTokenCount.input_tokens} (context management increased count by ${Math.abs(tokenDelta)} tokens from ${contextMgmtResponse.original_input_tokens})`,
-        );
-      }
-    } else {
-      this.logger.debug(
-        `Token count of message: ${responseTokenCount.input_tokens}`,
-      );
-    }
+    this.logger.debug(
+      `Token count of message: ${responseTokenCount.input_tokens}`,
+    );
 
     return responseTokenCount.input_tokens;
   }
@@ -658,8 +547,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
       this.ensureBeta(options, CONTEXT_1M_BETA);
     }
 
-    // Set up context management BEFORE token counting so countTokens can
-    // return accurate post-clearing token counts.
+    // Set up context management before token counting so estimates use matching options.
     const compactionThresholdPercent = getConfig<number>(
       'texra.model.compactionThresholdPercent',
       DEFAULT_COMPACTION_THRESHOLD_PERCENT,
@@ -667,7 +555,6 @@ export class ModelHandlerAnthropic extends ModelHandler<
     this.setupContextManagement({
       options,
       contextWindow: effectiveContextWindow,
-      supportsReasoning: this.capabilities.supportsReasoning,
       thresholdPercent: compactionThresholdPercent,
     });
 
@@ -837,7 +724,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
       response = await client.beta.messages.create(options, { signal });
     }
 
-    // Log context management events if any edits were applied
+    // Log server-side compaction events when present in response content.
     this.logContextManagementFromResponse(response, effectiveContextWindow);
 
     return { response };
@@ -845,26 +732,12 @@ export class ModelHandlerAnthropic extends ModelHandler<
 
   /**
    * Log context management events from the Anthropic response.
-   * The response includes applied_edits when server-side context editing was performed.
+   * Compaction events are surfaced via `content` blocks and usage iterations.
    */
   private logContextManagementFromResponse(
     response: BetaMessage,
     contextWindow: number,
   ): void {
-    const contextManagement = (
-      response as BetaMessage & {
-        context_management?: BetaContextManagementResponse | null;
-      }
-    ).context_management;
-
-    // Debug logging to diagnose context management response
-    if (contextManagement?.applied_edits?.length) {
-      this.logger.debug(
-        `Context management response received: ${JSON.stringify(contextManagement)}`,
-      );
-    }
-
-    const appliedEdits = contextManagement?.applied_edits ?? [];
     // Anthropic's input_tokens excludes cached tokens (unlike OpenAI where it's the total).
     // Per SDK docs: "Total input tokens is the summation of input_tokens,
     // cache_creation_input_tokens, and cache_read_input_tokens."
@@ -872,35 +745,6 @@ export class ModelHandlerAnthropic extends ModelHandler<
       response.usage.input_tokens +
       (response.usage.cache_read_input_tokens ?? 0) +
       (response.usage.cache_creation_input_tokens ?? 0);
-
-    for (const edit of appliedEdits) {
-      const clearedTokens = edit.cleared_input_tokens;
-      if (!clearedTokens || clearedTokens <= 0) {
-        continue;
-      }
-
-      const isToolUses = edit.type === 'clear_tool_uses_20250919';
-      const clearedCount = isToolUses
-        ? (edit.cleared_tool_uses ?? 0)
-        : (edit.cleared_thinking_turns ?? 0);
-      const itemLabel = isToolUses ? 'tool use(s)' : 'thinking turn(s)';
-      const action = isToolUses ? 'clear_tool_uses' : 'clear_thinking';
-      const utilizationReduction = (clearedTokens / contextWindow) * 100;
-
-      this.logger.logContextManagement(
-        `Cleared ${clearedCount} ${itemLabel}: ${clearedTokens.toLocaleString()} tokens freed (${utilizationReduction.toFixed(1)}% of context)`,
-        {
-          action,
-          tokensBefore: totalInputTokens + clearedTokens,
-          tokensAfter: totalInputTokens,
-          contextWindow,
-          utilizationBefore:
-            ((totalInputTokens + clearedTokens) / contextWindow) * 100,
-          utilizationAfter: (totalInputTokens / contextWindow) * 100,
-          details: `Anthropic server-side: cleared ${clearedCount} ${itemLabel}`,
-        },
-      );
-    }
 
     const compactionBlock = response.content.find(
       (block): block is BetaCompactionBlock => block.type === 'compaction',

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -771,6 +771,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
     const details = compactionBlock.content
       ? `Anthropic native compaction (${compactionBlock.content.length.toLocaleString()} chars)`
       : 'Anthropic native compaction (empty summary)';
+    const summary = compactionBlock.content?.trim() || undefined;
 
     this.logger.logContextManagement(
       `Server-side compaction: summarized context`,
@@ -782,6 +783,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
         utilizationBefore: (tokensBefore / contextWindow) * 100,
         utilizationAfter: (totalInputTokens / contextWindow) * 100,
         details,
+        summary,
       },
     );
   }

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -199,6 +199,12 @@ interface CacheControlCompactionBlock {
   cache_control?: CacheControlEphemeral | null;
 }
 
+type CacheControlInspectableBlock =
+  | ContentBlockParam
+  | ContentBlock
+  | CacheControlCompactionBlock
+  | undefined;
+
 const EPHEMERAL_CACHE_CONTROL: CacheControlEphemeral = {
   type: 'ephemeral',
 };
@@ -206,7 +212,7 @@ const EPHEMERAL_CACHE_CONTROL: CacheControlEphemeral = {
 const MAX_CACHE_CONTROLLED_BLOCKS = 4;
 
 const isCacheControlEligibleBlock = (
-  block: unknown,
+  block: CacheControlInspectableBlock,
 ): block is CacheControlEligibleBlock => {
   if (!block || typeof block !== 'object') {
     return false;
@@ -217,7 +223,7 @@ const isCacheControlEligibleBlock = (
 };
 
 const isCompactionCacheControlBlock = (
-  block: unknown,
+  block: CacheControlInspectableBlock,
 ): block is CacheControlCompactionBlock => {
   if (!block || typeof block !== 'object') {
     return false;

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -525,12 +525,19 @@ export class ModelHandlerAnthropic extends ModelHandler<
     ).context_management;
 
     if (contextMgmtResponse?.original_input_tokens) {
-      const clearedTokens =
+      const tokenDelta =
         contextMgmtResponse.original_input_tokens -
         responseTokenCount.input_tokens;
-      this.logger.debug(
-        `Token count: ${responseTokenCount.input_tokens} (after clearing ${clearedTokens} tokens from ${contextMgmtResponse.original_input_tokens})`,
-      );
+
+      if (tokenDelta >= 0) {
+        this.logger.debug(
+          `Token count: ${responseTokenCount.input_tokens} (after clearing ${tokenDelta} tokens from ${contextMgmtResponse.original_input_tokens})`,
+        );
+      } else {
+        this.logger.debug(
+          `Token count: ${responseTokenCount.input_tokens} (context management increased count by ${Math.abs(tokenDelta)} tokens from ${contextMgmtResponse.original_input_tokens})`,
+        );
+      }
     } else {
       this.logger.debug(
         `Token count of message: ${responseTokenCount.input_tokens}`,
@@ -851,7 +858,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
     ).context_management;
 
     // Debug logging to diagnose context management response
-    if (contextManagement) {
+    if (contextManagement?.applied_edits?.length) {
       this.logger.debug(
         `Context management response received: ${JSON.stringify(contextManagement)}`,
       );

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -177,10 +177,6 @@ const CONTEXT_MANAGEMENT_KEEP_THINKING_TURNS = 3;
 const CONTEXT_MANAGEMENT_CLEAR_AT_LEAST_PERCENT = 25;
 /** Compaction must be triggered at or above this minimum input token threshold. */
 const MIN_COMPACTION_TRIGGER_TOKENS = 50_000;
-/** Compaction trigger runs after clearing to avoid frequent summary calls. */
-const COMPACTION_TRIGGER_OFFSET_PERCENT = 15;
-/** Upper bound for compaction trigger percentage. */
-const COMPACTION_TRIGGER_MAX_PERCENT = 95;
 
 const ANTHROPIC_1M_CONTEXT_WINDOW = 1_000_000;
 
@@ -222,6 +218,12 @@ type CacheControlEligibleBlock = Extract<
   { type: 'text' | 'tool_result' }
 >;
 
+/** Compaction block shape from beta responses that may carry cache_control when replayed. */
+interface CacheControlCompactionBlock {
+  type: 'compaction';
+  cache_control?: CacheControlEphemeral | null;
+}
+
 const EPHEMERAL_CACHE_CONTROL: CacheControlEphemeral = {
   type: 'ephemeral',
 };
@@ -229,7 +231,7 @@ const EPHEMERAL_CACHE_CONTROL: CacheControlEphemeral = {
 const MAX_CACHE_CONTROLLED_BLOCKS = 4;
 
 const isCacheControlEligibleBlock = (
-  block: ContentBlockParam | ContentBlock | undefined,
+  block: unknown,
 ): block is CacheControlEligibleBlock => {
   if (!block || typeof block !== 'object') {
     return false;
@@ -237,6 +239,15 @@ const isCacheControlEligibleBlock = (
 
   const blockType = (block as { type?: string }).type;
   return blockType === 'text' || blockType === 'tool_result';
+};
+
+const isCompactionCacheControlBlock = (
+  block: unknown,
+): block is CacheControlCompactionBlock => {
+  if (!block || typeof block !== 'object') {
+    return false;
+  }
+  return (block as { type?: string }).type === 'compaction';
 };
 
 export class ModelHandlerAnthropic extends ModelHandler<
@@ -381,13 +392,9 @@ export class ModelHandlerAnthropic extends ModelHandler<
       !contextManagementEdits.some((edit) => edit.type === 'compact_20260112')
     ) {
       this.ensureBeta(options, COMPACTION_BETA);
-      const compactionPercent = Math.min(
-        thresholdPercent + COMPACTION_TRIGGER_OFFSET_PERCENT,
-        COMPACTION_TRIGGER_MAX_PERCENT,
-      );
       const compactionTriggerTokens = Math.max(
         MIN_COMPACTION_TRIGGER_TOKENS,
-        Math.floor((compactionPercent / 100) * contextWindow),
+        Math.floor((thresholdPercent / 100) * contextWindow),
       );
 
       contextManagementEdits.push({
@@ -927,7 +934,9 @@ export class ModelHandlerAnthropic extends ModelHandler<
       return;
     }
 
-    const cacheControlledBlocks: CacheControlEligibleBlock[] = [];
+    const cacheControlledBlocks: Array<
+      CacheControlEligibleBlock | CacheControlCompactionBlock
+    > = [];
 
     for (const message of messages) {
       const content = message.content;
@@ -937,7 +946,10 @@ export class ModelHandlerAnthropic extends ModelHandler<
 
       for (const block of content) {
         // Clear cache_control from ineligible blocks (defensive cleanup)
-        if (!isCacheControlEligibleBlock(block)) {
+        if (
+          !isCacheControlEligibleBlock(block) &&
+          !isCompactionCacheControlBlock(block)
+        ) {
           if (block && typeof block === 'object' && 'cache_control' in block) {
             delete (block as { cache_control?: unknown }).cache_control;
           }
@@ -959,7 +971,9 @@ export class ModelHandlerAnthropic extends ModelHandler<
       delete cacheControlledBlocks[idx].cache_control;
     }
 
-    this.cacheControlledBlock = cacheControlledBlocks.at(-1);
+    this.cacheControlledBlock = [...cacheControlledBlocks]
+      .reverse()
+      .find(isCacheControlEligibleBlock);
   }
 
   private async replaceDocumentDataWithUploads(

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -86,6 +86,7 @@ import type {
 import type { AnthropicBeta } from '@anthropic-ai/sdk/resources/beta/beta';
 import type {
   BetaContentBlock,
+  BetaContentBlockParam,
   BetaCompactionBlock,
   BetaCompactionIterationUsage,
   BetaContextManagementConfig,
@@ -193,16 +194,15 @@ type CacheControlEligibleBlock = Extract<
   { type: 'text' | 'tool_result' }
 >;
 
-/** Compaction block shape from beta responses that may carry cache_control when replayed. */
-interface CacheControlCompactionBlock {
-  type: 'compaction';
-  cache_control?: CacheControlEphemeral | null;
-}
+type CacheControlCompactionBlock = Extract<
+  BetaContentBlockParam,
+  { type: 'compaction' }
+>;
 
 type CacheControlInspectableBlock =
   | ContentBlockParam
   | ContentBlock
-  | CacheControlCompactionBlock
+  | BetaContentBlockParam
   | undefined;
 
 const EPHEMERAL_CACHE_CONTROL: CacheControlEphemeral = {

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -86,15 +86,16 @@ import type {
 import type { AnthropicBeta } from '@anthropic-ai/sdk/resources/beta/beta';
 import type {
   BetaContentBlock,
+  BetaCompactionBlock,
+  BetaCompactionIterationUsage,
   BetaContextManagementConfig,
   BetaContextManagementResponse,
-  BetaClearToolUses20250919EditResponse,
-  BetaClearThinking20251015EditResponse,
   BetaImageBlockParam,
   BetaMessage,
   BetaRedactedThinkingBlock,
   BetaRequestDocumentBlock,
   BetaThinkingBlock,
+  BetaUsage,
   MessageCountTokensParams,
   MessageCreateParams,
 } from '@anthropic-ai/sdk/resources/beta/messages';
@@ -155,6 +156,7 @@ const SONNET_37_OUTPUT_BETA: AnthropicBeta = 'output-128k-2025-02-19';
 const INTERLEAVED_THINKING_BETA: AnthropicBeta =
   'interleaved-thinking-2025-05-14';
 const CONTEXT_MANAGEMENT_BETA: AnthropicBeta = 'context-management-2025-06-27';
+const COMPACTION_BETA: AnthropicBeta = 'compact-2026-01-12';
 
 const OPUS_46_FULLNAME = 'claude-opus-4-6';
 
@@ -173,6 +175,12 @@ const CONTEXT_MANAGEMENT_KEEP_THINKING_TURNS = 3;
  * 25% provides more aggressive clearing to reduce frequent cache thrashing.
  */
 const CONTEXT_MANAGEMENT_CLEAR_AT_LEAST_PERCENT = 25;
+/** Compaction must be triggered at or above this minimum input token threshold. */
+const MIN_COMPACTION_TRIGGER_TOKENS = 50_000;
+/** Compaction trigger runs after clearing to avoid frequent summary calls. */
+const COMPACTION_TRIGGER_OFFSET_PERCENT = 15;
+/** Upper bound for compaction trigger percentage. */
+const COMPACTION_TRIGGER_MAX_PERCENT = 95;
 
 const ANTHROPIC_1M_CONTEXT_WINDOW = 1_000_000;
 
@@ -368,6 +376,30 @@ export class ModelHandlerAnthropic extends ModelHandler<
       });
     }
 
+    if (
+      this.isClaudeOpus46() &&
+      !contextManagementEdits.some((edit) => edit.type === 'compact_20260112')
+    ) {
+      this.ensureBeta(options, COMPACTION_BETA);
+      const compactionPercent = Math.min(
+        thresholdPercent + COMPACTION_TRIGGER_OFFSET_PERCENT,
+        COMPACTION_TRIGGER_MAX_PERCENT,
+      );
+      const compactionTriggerTokens = Math.max(
+        MIN_COMPACTION_TRIGGER_TOKENS,
+        Math.floor((compactionPercent / 100) * contextWindow),
+      );
+
+      contextManagementEdits.push({
+        type: 'compact_20260112',
+        trigger: {
+          type: 'input_tokens',
+          value: compactionTriggerTokens,
+        },
+        pause_after_compaction: false,
+      });
+    }
+
     options.context_management = {
       ...(options.context_management ?? {}),
       edits: contextManagementEdits,
@@ -466,7 +498,10 @@ export class ModelHandlerAnthropic extends ModelHandler<
     // Strip betas that only apply to message creation (e.g., output length)
     // while keeping context headers needed for accurate token counting.
     const countTokenBetas = options?.betas?.filter(
-      (beta) => beta === CONTEXT_1M_BETA || beta === CONTEXT_MANAGEMENT_BETA,
+      (beta) =>
+        beta === CONTEXT_1M_BETA ||
+        beta === CONTEXT_MANAGEMENT_BETA ||
+        beta === COMPACTION_BETA,
     );
     if (countTokenBetas && countTokenBetas.length > 0) {
       countTokensParams.betas = countTokenBetas;
@@ -789,7 +824,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
     }
 
     // Log context management events if any edits were applied
-    this.logContextManagementFromResponse(response);
+    this.logContextManagementFromResponse(response, effectiveContextWindow);
 
     return { response };
   }
@@ -798,7 +833,10 @@ export class ModelHandlerAnthropic extends ModelHandler<
    * Log context management events from the Anthropic response.
    * The response includes applied_edits when server-side context editing was performed.
    */
-  private logContextManagementFromResponse(response: BetaMessage): void {
+  private logContextManagementFromResponse(
+    response: BetaMessage,
+    contextWindow: number,
+  ): void {
     const contextManagement = (
       response as BetaMessage & {
         context_management?: BetaContextManagementResponse | null;
@@ -812,11 +850,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
       );
     }
 
-    if (!contextManagement?.applied_edits?.length) {
-      return;
-    }
-
-    const contextWindow = this.config.contextWindow;
+    const appliedEdits = contextManagement?.applied_edits ?? [];
     // Anthropic's input_tokens excludes cached tokens (unlike OpenAI where it's the total).
     // Per SDK docs: "Total input tokens is the summation of input_tokens,
     // cache_creation_input_tokens, and cache_read_input_tokens."
@@ -825,11 +859,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
       (response.usage.cache_read_input_tokens ?? 0) +
       (response.usage.cache_creation_input_tokens ?? 0);
 
-    type AppliedEdit =
-      | BetaClearToolUses20250919EditResponse
-      | BetaClearThinking20251015EditResponse;
-
-    for (const edit of contextManagement.applied_edits as AppliedEdit[]) {
+    for (const edit of appliedEdits) {
       const clearedTokens = edit.cleared_input_tokens;
       if (!clearedTokens || clearedTokens <= 0) {
         continue;
@@ -837,10 +867,8 @@ export class ModelHandlerAnthropic extends ModelHandler<
 
       const isToolUses = edit.type === 'clear_tool_uses_20250919';
       const clearedCount = isToolUses
-        ? ((edit as BetaClearToolUses20250919EditResponse).cleared_tool_uses ??
-          0)
-        : ((edit as BetaClearThinking20251015EditResponse)
-            .cleared_thinking_turns ?? 0);
+        ? (edit.cleared_tool_uses ?? 0)
+        : (edit.cleared_thinking_turns ?? 0);
       const itemLabel = isToolUses ? 'tool use(s)' : 'thinking turn(s)';
       const action = isToolUses ? 'clear_tool_uses' : 'clear_thinking';
       const utilizationReduction = (clearedTokens / contextWindow) * 100;
@@ -859,6 +887,39 @@ export class ModelHandlerAnthropic extends ModelHandler<
         },
       );
     }
+
+    const compactionBlock = response.content.find(
+      (block): block is BetaCompactionBlock => block.type === 'compaction',
+    );
+    if (!compactionBlock) {
+      return;
+    }
+
+    const compactionIteration = (response.usage as BetaUsage).iterations?.find(
+      (iteration): iteration is BetaCompactionIterationUsage =>
+        iteration.type === 'compaction',
+    );
+    const tokensBefore = compactionIteration
+      ? compactionIteration.input_tokens +
+        compactionIteration.cache_read_input_tokens +
+        compactionIteration.cache_creation_input_tokens
+      : totalInputTokens;
+    const details = compactionBlock.content
+      ? `Anthropic native compaction (${compactionBlock.content.length.toLocaleString()} chars)`
+      : 'Anthropic native compaction (empty summary)';
+
+    this.logger.logContextManagement(
+      `Server-side compaction: summarized context`,
+      {
+        action: 'compaction',
+        tokensBefore,
+        tokensAfter: totalInputTokens,
+        contextWindow,
+        utilizationBefore: (tokensBefore / contextWindow) * 100,
+        utilizationAfter: (totalInputTokens / contextWindow) * 100,
+        details,
+      },
+    );
   }
 
   private enforceCacheControlLimit(messages: MessageParam[]): void {
@@ -1529,31 +1590,24 @@ export class ModelHandlerAnthropic extends ModelHandler<
     }
 
     // Note: Anthropic doesn't provide tool_use_tokens in their API response
+    const usageTotals = this.getUsageTokenTotals(responseUsage);
 
     let basePrice = calculateTokenPrice(
-      responseUsage.input_tokens,
-      responseUsage.output_tokens,
+      usageTotals.baseInputTokens,
+      usageTotals.outputTokens,
       this.config.inputPrice,
       this.config.outputPrice,
     );
 
     if (this.capabilities.supportsPromptCaching) {
-      if (
-        'cache_creation_input_tokens' in responseUsage &&
-        responseUsage.cache_creation_input_tokens !== null
-      ) {
+      if (usageTotals.cacheCreationTokens > 0) {
         basePrice +=
-          (responseUsage.cache_creation_input_tokens *
-            this.config.inputPrice *
-            1.25) /
+          (usageTotals.cacheCreationTokens * this.config.inputPrice * 1.25) /
           1e6;
       }
-      if (
-        'cache_read_input_tokens' in responseUsage &&
-        responseUsage.cache_read_input_tokens !== null
-      ) {
+      if (usageTotals.cacheReadTokens > 0) {
         basePrice +=
-          (responseUsage.cache_read_input_tokens *
+          (usageTotals.cacheReadTokens *
             this.config.inputPrice *
             this.capabilities.cacheDiscountFactor) /
           1e6;
@@ -1578,28 +1632,71 @@ export class ModelHandlerAnthropic extends ModelHandler<
       };
     }
 
-    // Anthropic: total = input_tokens + cache_read + cache_creation
-    const baseInput = rawUsage.input_tokens ?? 0;
-    const cacheRead = rawUsage.cache_read_input_tokens ?? 0;
-    const cacheCreation = rawUsage.cache_creation_input_tokens ?? 0;
-    const totalInput = baseInput + cacheRead + cacheCreation;
+    const usageTotals = this.getUsageTokenTotals(rawUsage);
+    const totalInput =
+      usageTotals.baseInputTokens +
+      usageTotals.cacheReadTokens +
+      usageTotals.cacheCreationTokens;
 
     return {
       inputTokens: totalInput,
-      outputTokens: rawUsage.output_tokens ?? 0,
+      outputTokens: usageTotals.outputTokens,
       cost: this.computePrice(rawUsage),
       responseTimeMs,
       provider: 'anthropic',
-      cachedInputTokens: nonZeroOrUndefined(cacheRead),
-      cacheCreationTokens: nonZeroOrUndefined(cacheCreation),
+      cachedInputTokens: nonZeroOrUndefined(usageTotals.cacheReadTokens),
+      cacheCreationTokens: nonZeroOrUndefined(usageTotals.cacheCreationTokens),
       percentageCached: computeCachePercentage(
-        cacheRead + cacheCreation,
+        usageTotals.cacheReadTokens + usageTotals.cacheCreationTokens,
         totalInput,
       ),
       serverToolRequests: nonZeroOrUndefined(
         rawUsage.server_tool_use?.web_search_requests,
       ),
       _native: rawUsage,
+    };
+  }
+
+  /**
+   * Gets Anthropic input/output/cache token totals.
+   * Uses per-iteration usage when available so compaction requests are fully billed.
+   */
+  private getUsageTokenTotals(responseUsage: AnthropicUsage): {
+    baseInputTokens: number;
+    outputTokens: number;
+    cacheReadTokens: number;
+    cacheCreationTokens: number;
+  } {
+    const usageWithIterations = responseUsage as AnthropicUsage & {
+      iterations?: BetaUsage['iterations'];
+    };
+    const iterations = usageWithIterations.iterations;
+    if (Array.isArray(iterations) && iterations.length > 0) {
+      let baseInputTokens = 0;
+      let outputTokens = 0;
+      let cacheReadTokens = 0;
+      let cacheCreationTokens = 0;
+
+      for (const iteration of iterations) {
+        baseInputTokens += iteration.input_tokens;
+        outputTokens += iteration.output_tokens;
+        cacheReadTokens += iteration.cache_read_input_tokens;
+        cacheCreationTokens += iteration.cache_creation_input_tokens;
+      }
+
+      return {
+        baseInputTokens,
+        outputTokens,
+        cacheReadTokens,
+        cacheCreationTokens,
+      };
+    }
+
+    return {
+      baseInputTokens: responseUsage.input_tokens ?? 0,
+      outputTokens: responseUsage.output_tokens ?? 0,
+      cacheReadTokens: responseUsage.cache_read_input_tokens ?? 0,
+      cacheCreationTokens: responseUsage.cache_creation_input_tokens ?? 0,
     };
   }
 
@@ -1872,7 +1969,18 @@ export class ModelHandlerAnthropic extends ModelHandler<
       return [];
     }
 
-    return responseObject.content.filter((block) => block.type !== 'tool_use');
+    const assistantContent = responseObject.content.filter(
+      (block) => block.type !== 'tool_use',
+    );
+    if (!this.capabilities.supportsPromptCaching) {
+      return assistantContent;
+    }
+
+    return assistantContent.map((block) =>
+      block.type === 'compaction'
+        ? { ...block, cache_control: EPHEMERAL_CACHE_CONTROL }
+        : block,
+    );
   }
 
   async createToolUseFollowUpMessages(

--- a/src/agent/modelHandlers/support/AnthropicStreamHandler.ts
+++ b/src/agent/modelHandlers/support/AnthropicStreamHandler.ts
@@ -244,6 +244,10 @@ export class AnthropicStreamHandler {
         blockIndex,
         this.factories.createThinkingStream(),
       );
+    } else if (blockType === 'compaction') {
+      // Compaction summaries are internal context artifacts and should not be streamed.
+      this.logger.debug('Compaction block started in stream');
+      this.finalizeOutputStream();
     } else if (blockType === 'text' && this.config.outputEnabled) {
       // Consecutive text blocks share a stream
       // Consecutive means: immediately following (by index) AND previous was text
@@ -313,6 +317,12 @@ export class AnthropicStreamHandler {
             break;
           }
         }
+        break;
+      case 'compaction_delta':
+        // Compaction content arrives as a single summary delta and is not user-visible output.
+        this.logger.debug(
+          `Compaction summary delta received (${event.delta.content?.length ?? 0} chars)`,
+        );
         break;
     }
   }

--- a/src/commands/agent/followUpCommand.ts
+++ b/src/commands/agent/followUpCommand.ts
@@ -158,7 +158,7 @@ async function handleFollowUpResult(
         if (!resumed) {
           // Fallback: show message if auto-resume fails
           await vscode.window.showInformationMessage(
-            'Message queued. Click Resume to process it.',
+            'Message queued. Auto-resume failed — start a new agent task to continue.',
           );
         }
       }

--- a/src/common/state/stateManager.ts
+++ b/src/common/state/stateManager.ts
@@ -24,6 +24,26 @@ export enum GlobalStateKey {
   LAST_KNOWN_VERSION = 'lastKnownVersion',
   MODEL_LIST_VERSION = 'modelListVersion',
   MEMORY_ENABLED = 'texra.memory.enabled',
+
+  // Streaming settings
+  STREAMING_GLOBAL = 'texra.streaming.global',
+  STREAMING_OPENAI = 'texra.streaming.openai',
+  STREAMING_ANTHROPIC = 'texra.streaming.anthropic',
+  STREAMING_OPENROUTER = 'texra.streaming.openrouter',
+  STREAMING_GOOGLE = 'texra.streaming.google',
+  STREAMING_XAI = 'texra.streaming.xai',
+  STREAMING_DEEPSEEK = 'texra.streaming.deepseek',
+  STREAMING_MOONSHOT = 'texra.streaming.moonshot',
+  STREAMING_DASHSCOPE = 'texra.streaming.dashscope',
+
+  // Endpoint settings
+  ENDPOINT_OPENAI = 'texra.endpoint.openai',
+  ENDPOINT_ANTHROPIC = 'texra.endpoint.anthropic',
+  ENDPOINT_GOOGLE = 'texra.endpoint.google',
+  ENDPOINT_DEEPSEEK = 'texra.endpoint.deepseek',
+  ENDPOINT_XAI = 'texra.endpoint.xai',
+  ENDPOINT_MOONSHOT = 'texra.endpoint.moonshot',
+  ENDPOINT_DASHSCOPE = 'texra.endpoint.dashscope',
 }
 
 /** Prefix used for per-instruction suppression flags */

--- a/src/progressView/frontend/components/ContextManagement.ts
+++ b/src/progressView/frontend/components/ContextManagement.ts
@@ -75,6 +75,31 @@ export class ContextManagement extends LitElement {
       .stat-item .codicon {
         opacity: 0.7;
       }
+
+      .summary-block {
+        margin-top: var(--spacing-small);
+        display: block;
+        width: 100%;
+      }
+
+      .summary-title {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--spacing-tiny);
+        font-size: var(--font-size-sm);
+        font-weight: 500;
+        margin-bottom: var(--spacing-tiny);
+      }
+
+      .summary-text {
+        margin: 0;
+        padding: var(--spacing-small);
+        white-space: pre-wrap;
+        word-break: break-word;
+        border: 1px solid var(--vscode-widget-border);
+        border-radius: var(--radius-sm);
+        background: var(--vscode-editorWidget-background);
+      }
     `,
   ];
 
@@ -90,6 +115,9 @@ export class ContextManagement extends LitElement {
 
   /** Statistics items to display */
   @property({ type: Array }) items: ContextStatItem[] = [];
+
+  /** Optional summary text for compaction events */
+  @property({ type: String }) summary = '';
 
   override render(): TemplateResult {
     if (this.items.length === 0) {
@@ -119,6 +147,17 @@ export class ContextManagement extends LitElement {
               </span>
             `,
           )}
+          ${this.summary
+            ? html`
+                <div class="summary-block">
+                  <div class="summary-title">
+                    <i class="codicon codicon-note"></i>
+                    Compaction summary
+                  </div>
+                  <pre class="summary-text">${this.summary}</pre>
+                </div>
+              `
+            : nothing}
         </div>
       </details>
     `;

--- a/src/progressView/frontend/formatters/logFormatters/contextManagementFormatters.ts
+++ b/src/progressView/frontend/formatters/logFormatters/contextManagementFormatters.ts
@@ -66,7 +66,7 @@ const ACTION_CONFIG: Record<
 /** Build context management items from data. */
 function buildContextManagementItems(
   data: unknown,
-): { config: ActionConfig; items: ContextStatItem[] } | null {
+): { config: ActionConfig; items: ContextStatItem[]; summary?: string } | null {
   const result = ContextManagementDataSchema.safeParse(data);
   if (!result.success) {
     return null;
@@ -82,6 +82,7 @@ function buildContextManagementItems(
     originalMaxTokens,
     reducedMaxTokens,
     details,
+    summary,
   } = result.data;
 
   const config: ActionConfig = ACTION_CONFIG[action] || {
@@ -145,7 +146,7 @@ function buildContextManagementItems(
     });
   }
 
-  return { config, items };
+  return { config, items, summary };
 }
 
 /** Format context management event as TemplateResult. */
@@ -157,13 +158,14 @@ export function formatContextManagementTemplate(
   const result = buildContextManagementItems(data);
   if (!result) return null;
 
-  const { config, items } = result;
+  const { config, items, summary } = result;
 
   return html`
     <context-management
       .logId=${id}
       .config=${config}
       .items=${items}
+      .summary=${summary ?? ''}
     ></context-management>
   `;
 }

--- a/src/settingsView/SettingsViewMessageHandler.ts
+++ b/src/settingsView/SettingsViewMessageHandler.ts
@@ -31,12 +31,18 @@ import {
 import { SecretManager, type ApiProvider } from '@frontend/secretManager';
 import { MEMORY_STORAGE_ROOT } from '@tools/memory/constants';
 import { resolveMemoryStoragePath } from '@tools/memory/memoryUtils';
-import { getConfig, updateConfig } from '@utils/config';
 import { StorageFS } from '@utils/files';
 import { agentConfigToTaskState } from '@utils/config/configConversion';
 import {
   getToolUseMemoryEnabled,
   setToolUseMemoryEnabled,
+  getGlobalStreaming,
+  setGlobalStreaming,
+  getProviderStreaming,
+  setProviderStreaming,
+  getProviderEndpoint,
+  setProviderEndpoint,
+  supportsCustomEndpoint,
 } from '@utils/config/constants';
 import { PROVIDER_URLS } from '@commands/api/apiKeyCommands';
 import { runExecuteCommand } from '@commands/agent/executeCommand';
@@ -64,35 +70,6 @@ const PROVIDER_DISPLAY_NAMES: Record<ApiProvider, string> = {
   wolframllmapp: 'Wolfram',
 };
 
-/**
- * Map from ApiProvider to the VS Code config key for per-provider streaming.
- * Providers not listed here (e.g., 'wolframllmapp') have no streaming config.
- *
- * Keys use short form (without 'texra.' prefix) so getConfig() resolves them
- * correctly via getConfiguration('texra').get(key).
- */
-const STREAMING_CONFIG_KEY: Partial<Record<ApiProvider, string>> = {
-  openai: 'model.useStreamingOpenai',
-  anthropic: 'model.useStreamingAnthropic',
-  openRouter: 'model.useStreamingOpenrouter',
-  google: 'model.useStreamingGoogle',
-  xai: 'model.useStreamingXai',
-  deepseek: 'model.useStreamingDeepseek',
-  moonshot: 'model.useStreamingMoonshot',
-  dashscope: 'model.useStreamingDashscope',
-};
-
-/** Map from ApiProvider to the VS Code config key for custom endpoint. */
-const ENDPOINT_CONFIG_KEY: Partial<Record<ApiProvider, string>> = {
-  openai: 'model.baseUrlOpenai',
-  anthropic: 'model.baseUrlAnthropic',
-  google: 'model.baseUrlGoogle',
-  deepseek: 'model.baseUrlDeepSeek',
-  xai: 'model.baseUrlXai',
-  moonshot: 'model.baseUrlMoonshot',
-  dashscope: 'model.baseUrlDashscope',
-};
-
 async function getProviderKeyStatuses(): Promise<ProviderKeyStatus[]> {
   return Promise.all(
     SecretManager.API_PROVIDERS.map(async (provider) => {
@@ -110,28 +87,14 @@ async function getProviderKeyStatuses(): Promise<ProviderKeyStatus[]> {
         status = 'not-set';
       }
 
-      const globalStreaming = getConfig<boolean>('model.useStreaming', true);
-      const streamingKey = STREAMING_CONFIG_KEY[provider];
-      // OpenRouter defaults to streaming off (different from other providers)
-      const streamingDefault =
-        provider === 'openRouter' ? false : globalStreaming;
-      const streaming = streamingKey
-        ? getConfig<boolean>(streamingKey, streamingDefault)
-        : globalStreaming;
-
-      const endpointKey = ENDPOINT_CONFIG_KEY[provider];
-      const customEndpoint = endpointKey
-        ? getConfig<string>(endpointKey, '')
-        : '';
-
       return {
         provider,
         displayName: PROVIDER_DISPLAY_NAMES[provider],
         status,
         keyUrl: PROVIDER_URLS[provider],
-        streaming,
-        customEndpoint,
-        supportsCustomEndpoint: Boolean(endpointKey),
+        streaming: getProviderStreaming(provider),
+        customEndpoint: getProviderEndpoint(provider),
+        supportsCustomEndpoint: supportsCustomEndpoint(provider),
       };
     }),
   );
@@ -272,10 +235,7 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
     const isAuthenticated = await SupabaseClient.isAuthenticated();
     const providerKeyStatuses = await getProviderKeyStatuses();
 
-    const globalStreamingDefault = getConfig<boolean>(
-      'model.useStreaming',
-      true,
-    );
+    const globalStreamingDefault = getGlobalStreaming();
 
     if (!isAuthenticated) {
       await webview.postMessage({
@@ -687,11 +647,7 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
   private async handleSetProviderStreaming(
     data: MessageFor<typeof SETTINGS_VIEW_CMD.SET_PROVIDER_STREAMING>,
   ): Promise<void> {
-    const provider = data.provider as ApiProvider;
-    const configKey = STREAMING_CONFIG_KEY[provider];
-    if (!configKey) return;
-
-    await updateConfig(configKey, data.enabled);
+    await setProviderStreaming(data.provider, data.enabled);
 
     const view = this.getActiveView();
     if (view) {
@@ -702,11 +658,7 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
   private async handleSetProviderEndpoint(
     data: MessageFor<typeof SETTINGS_VIEW_CMD.SET_PROVIDER_ENDPOINT>,
   ): Promise<void> {
-    const provider = data.provider as ApiProvider;
-    const configKey = ENDPOINT_CONFIG_KEY[provider];
-    if (!configKey) return;
-
-    await updateConfig(configKey, data.endpoint);
+    await setProviderEndpoint(data.provider, data.endpoint);
 
     const view = this.getActiveView();
     if (view) {
@@ -717,7 +669,7 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
   private async handleSetGlobalStreaming(
     data: MessageFor<typeof SETTINGS_VIEW_CMD.SET_GLOBAL_STREAMING>,
   ): Promise<void> {
-    await updateConfig('model.useStreaming', data.enabled);
+    await setGlobalStreaming(data.enabled);
 
     const view = this.getActiveView();
     if (view) {

--- a/src/shared/schemas/contextManagement.ts
+++ b/src/shared/schemas/contextManagement.ts
@@ -17,6 +17,7 @@ export const ContextManagementDataSchema = z.object({
   utilizationBefore: z.number().nonnegative(),
   utilizationAfter: z.number().nonnegative().optional(),
   details: z.string().optional(),
+  summary: z.string().optional(),
   originalMaxTokens: z.number().positive().optional(),
   reducedMaxTokens: z.number().positive().optional(),
 });

--- a/src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts
+++ b/src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts
@@ -1218,9 +1218,11 @@ describe('ModelHandlerAnthropic message guards', () => {
       action: string;
       tokensBefore: number;
       tokensAfter: number;
+      summary?: string;
     };
     assert.equal(eventData.action, 'compaction');
     assert.equal(eventData.tokensBefore, 185000);
     assert.equal(eventData.tokensAfter, 25600);
+    assert.equal(eventData.summary, '<summary>state</summary>');
   });
 });

--- a/src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts
+++ b/src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts
@@ -2,6 +2,7 @@
 import { strict as assert } from 'assert';
 
 // Local imports - agent
+import { AgentCategory } from '@agent/core/AgentDataclass';
 import { ModelHandlerAnthropic } from '@agent/modelHandlers/modelHandlerAnthropic';
 
 // Type imports
@@ -896,5 +897,302 @@ describe('ModelHandlerAnthropic message guards', () => {
       betas.includes('context-1m-2025-08-07'),
       'should include the 1M context beta header when enabled',
     );
+  });
+
+  it('adds native compaction context edit for Claude Opus 4.6 tool-use runs', async () => {
+    const handler = createAnthropicHandler({
+      supportsTokenCounting: false,
+      supportsReasoning: false,
+    });
+    handler.config.fullName = 'claude-opus-4-6';
+    handler.setAgentCategory(AgentCategory.ToolUse);
+
+    const loggerStub = {
+      streamId: 'test',
+      debug: () => {},
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+      fileList: () => {},
+      withCurrentGroup: () => undefined,
+      runWithinCurrentGroup: async (fn: () => any) => fn(),
+      runWithGroup: async (_groupId: string | undefined, fn: () => any) => fn(),
+      logContextManagement: () => {},
+    };
+    handler.setLogger(loggerStub as unknown as AgentLogger);
+    (handler as any).getStreamingConfig = () => false;
+
+    const messages: MessageParam[] = [
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'hello', citations: null }],
+      },
+    ];
+    const messageOptions: any[] = [];
+    const client = {
+      beta: {
+        messages: {
+          create: async (opts: any) => {
+            messageOptions.push(opts);
+            return {
+              id: 'msg',
+              type: 'message',
+              role: 'assistant',
+              model: 'claude-opus-4-6',
+              content: [{ type: 'text', text: 'ok' }],
+              stop_reason: 'end_turn',
+              usage: { input_tokens: 1, output_tokens: 1 },
+            } as any;
+          },
+        },
+      },
+    } as any;
+
+    const originalGetConfig = configModule.getConfig;
+    try {
+      (configModule as any).getConfig = (
+        path: string,
+        defaultValue?: unknown,
+      ) => {
+        if (path === 'texra.model.compactionThresholdPercent') return 75;
+        return defaultValue as unknown;
+      };
+
+      await handler.createResponse({ client, messages, temperature: 0 });
+    } finally {
+      (configModule as any).getConfig = originalGetConfig;
+    }
+
+    const options = messageOptions[0] ?? {};
+    const betas: string[] = options.betas ?? [];
+    assert.ok(
+      betas.includes('compact-2026-01-12'),
+      'should include compaction beta header',
+    );
+
+    const edits = options.context_management?.edits ?? [];
+    const compactionEdit = edits.find(
+      (edit: { type: string }) => edit.type === 'compact_20260112',
+    );
+    assert.ok(compactionEdit, 'should configure compact_20260112 context edit');
+    assert.equal(compactionEdit.pause_after_compaction, false);
+    assert.equal(compactionEdit.trigger?.type, 'input_tokens');
+    assert.equal(
+      compactionEdit.trigger?.value,
+      180000,
+      'should trigger compaction at 90% of 200K context window',
+    );
+    assert.equal(
+      compactionEdit.instructions,
+      undefined,
+      'should rely on Anthropic default compaction instructions',
+    );
+  });
+
+  it('does not add native compaction context edit for non-Opus models', async () => {
+    const handler = createAnthropicHandler({
+      supportsTokenCounting: false,
+      supportsReasoning: false,
+    });
+    handler.config.fullName = 'claude-sonnet-4-5';
+    handler.setAgentCategory(AgentCategory.ToolUse);
+
+    const loggerStub = {
+      streamId: 'test',
+      debug: () => {},
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+      fileList: () => {},
+      withCurrentGroup: () => undefined,
+      runWithinCurrentGroup: async (fn: () => any) => fn(),
+      runWithGroup: async (_groupId: string | undefined, fn: () => any) => fn(),
+      logContextManagement: () => {},
+    };
+    handler.setLogger(loggerStub as unknown as AgentLogger);
+    (handler as any).getStreamingConfig = () => false;
+
+    const messages: MessageParam[] = [
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'hello', citations: null }],
+      },
+    ];
+    const messageOptions: any[] = [];
+    const client = {
+      beta: {
+        messages: {
+          create: async (opts: any) => {
+            messageOptions.push(opts);
+            return {
+              id: 'msg',
+              type: 'message',
+              role: 'assistant',
+              model: 'claude-sonnet-4-5',
+              content: [{ type: 'text', text: 'ok' }],
+              stop_reason: 'end_turn',
+              usage: { input_tokens: 1, output_tokens: 1 },
+            } as any;
+          },
+        },
+      },
+    } as any;
+
+    const originalGetConfig = configModule.getConfig;
+    try {
+      (configModule as any).getConfig = (
+        path: string,
+        defaultValue?: unknown,
+      ) => {
+        if (path === 'texra.model.compactionThresholdPercent') return 75;
+        return defaultValue as unknown;
+      };
+
+      await handler.createResponse({ client, messages, temperature: 0 });
+    } finally {
+      (configModule as any).getConfig = originalGetConfig;
+    }
+
+    const options = messageOptions[0] ?? {};
+    const betas: string[] = options.betas ?? [];
+    assert.equal(
+      betas.includes('compact-2026-01-12'),
+      false,
+      'non-Opus models should not opt into compact beta',
+    );
+
+    const edits = options.context_management?.edits ?? [];
+    const compactionEdit = edits.find(
+      (edit: { type: string }) => edit.type === 'compact_20260112',
+    );
+    assert.equal(
+      compactionEdit,
+      undefined,
+      'non-Opus models should not include compact_20260112 edit',
+    );
+  });
+
+  it('normalizes Anthropic usage using per-iteration totals when available', () => {
+    const handler = createAnthropicHandler();
+    const usage = handler.normalizeUsage(
+      {
+        input_tokens: 111,
+        output_tokens: 22,
+        cache_read_input_tokens: 3,
+        cache_creation_input_tokens: 4,
+        server_tool_use: null,
+        service_tier: 'standard',
+        iterations: [
+          {
+            type: 'compaction',
+            input_tokens: 1000,
+            output_tokens: 100,
+            cache_read_input_tokens: 90,
+            cache_creation_input_tokens: 40,
+            cache_creation: null,
+          },
+          {
+            type: 'message',
+            input_tokens: 200,
+            output_tokens: 80,
+            cache_read_input_tokens: 10,
+            cache_creation_input_tokens: 5,
+            cache_creation: null,
+          },
+        ],
+      } as any,
+      1000,
+    );
+
+    assert.equal(
+      usage.inputTokens,
+      1345,
+      'input tokens should sum all iteration input and cache tokens',
+    );
+    assert.equal(
+      usage.outputTokens,
+      180,
+      'output tokens should sum all iteration outputs',
+    );
+    assert.equal(
+      usage.cachedInputTokens,
+      100,
+      'cached read tokens should come from iteration totals',
+    );
+    assert.equal(
+      usage.cacheCreationTokens,
+      45,
+      'cache creation tokens should come from iteration totals',
+    );
+  });
+
+  it('logs server-side compaction events from compaction blocks', () => {
+    const handler = createAnthropicHandler();
+    const events: Array<{ message: string; data: unknown }> = [];
+
+    const loggerStub = {
+      streamId: 'test',
+      debug: () => {},
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+      fileList: () => {},
+      withCurrentGroup: () => undefined,
+      runWithinCurrentGroup: async (fn: () => any) => fn(),
+      runWithGroup: async (_groupId: string | undefined, fn: () => any) => fn(),
+      logContextManagement: (message: string, data: unknown) => {
+        events.push({ message, data });
+      },
+    };
+    handler.setLogger(loggerStub as unknown as AgentLogger);
+
+    (handler as any).logContextManagementFromResponse(
+      {
+        content: [
+          { type: 'compaction', content: '<summary>state</summary>' },
+          { type: 'text', text: 'ok' },
+        ],
+        usage: {
+          input_tokens: 24000,
+          output_tokens: 1200,
+          cache_read_input_tokens: 1200,
+          cache_creation_input_tokens: 400,
+          iterations: [
+            {
+              type: 'compaction',
+              input_tokens: 180000,
+              output_tokens: 3200,
+              cache_read_input_tokens: 4000,
+              cache_creation_input_tokens: 1000,
+              cache_creation: null,
+            },
+            {
+              type: 'message',
+              input_tokens: 23000,
+              output_tokens: 1000,
+              cache_read_input_tokens: 1000,
+              cache_creation_input_tokens: 200,
+              cache_creation: null,
+            },
+          ],
+        },
+      } as any,
+      200000,
+    );
+
+    assert.equal(
+      events.length,
+      1,
+      'compaction block should emit one log event',
+    );
+    assert.match(events[0].message, /Server-side compaction/i);
+    const eventData = events[0].data as {
+      action: string;
+      tokensBefore: number;
+      tokensAfter: number;
+    };
+    assert.equal(eventData.action, 'compaction');
+    assert.equal(eventData.tokensBefore, 185000);
+    assert.equal(eventData.tokensAfter, 25600);
   });
 });

--- a/src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts
+++ b/src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts
@@ -380,6 +380,34 @@ describe('ModelHandlerAnthropic message guards', () => {
     );
   });
 
+  it('preserves compaction cache markers during cache control enforcement', () => {
+    const handler = createAnthropicHandler();
+    const compactionBlock = {
+      type: 'compaction',
+      content: '<summary>state</summary>',
+      cache_control: { type: 'ephemeral' },
+    };
+    const messageContent: ContentBlockParam[] = [
+      { type: 'text', text: 'block-0', citations: null },
+      compactionBlock as unknown as ContentBlockParam,
+      { type: 'text', text: 'block-1', citations: null },
+    ];
+    const messages: MessageParam[] = [
+      { role: 'assistant', content: messageContent },
+    ];
+
+    (handler as any).enforceCacheControlLimit(messages);
+
+    const preservedCompaction = (messages[0].content as any[]).find(
+      (block) => block.type === 'compaction',
+    );
+    assert.deepEqual(
+      preservedCompaction?.cache_control,
+      { type: 'ephemeral' },
+      'compaction cache marker should remain on replayed assistant content',
+    );
+  });
+
   it('trims follow-up text and rejects empty follow-ups', async () => {
     const handler = createAnthropicHandler();
     const baseMessages = await handler.initializeMessages('prefix', 'request');
@@ -979,8 +1007,8 @@ describe('ModelHandlerAnthropic message guards', () => {
     assert.equal(compactionEdit.trigger?.type, 'input_tokens');
     assert.equal(
       compactionEdit.trigger?.value,
-      180000,
-      'should trigger compaction at 90% of 200K context window',
+      150000,
+      'should trigger compaction at configured threshold (75%) of 200K context window',
     );
     assert.equal(
       compactionEdit.instructions,

--- a/src/utils/config/constants.ts
+++ b/src/utils/config/constants.ts
@@ -89,6 +89,85 @@ export async function setToolUseMemoryEnabled(enabled: boolean): Promise<void> {
   await globalSM?.update(GlobalStateKey.MEMORY_ENABLED, enabled);
 }
 
+// ---------------------------------------------------------------------------
+// Streaming / Endpoint settings (globalSM-backed)
+// ---------------------------------------------------------------------------
+
+/** Map from provider string to GlobalStateKey for per-provider streaming. */
+const STREAMING_KEY: Record<string, GlobalStateKey> = {
+  openai: GlobalStateKey.STREAMING_OPENAI,
+  anthropic: GlobalStateKey.STREAMING_ANTHROPIC,
+  openrouter: GlobalStateKey.STREAMING_OPENROUTER,
+  google: GlobalStateKey.STREAMING_GOOGLE,
+  xai: GlobalStateKey.STREAMING_XAI,
+  deepseek: GlobalStateKey.STREAMING_DEEPSEEK,
+  moonshot: GlobalStateKey.STREAMING_MOONSHOT,
+  dashscope: GlobalStateKey.STREAMING_DASHSCOPE,
+};
+
+/** Map from provider string to GlobalStateKey for per-provider endpoint. */
+const ENDPOINT_KEY: Record<string, GlobalStateKey> = {
+  openai: GlobalStateKey.ENDPOINT_OPENAI,
+  anthropic: GlobalStateKey.ENDPOINT_ANTHROPIC,
+  google: GlobalStateKey.ENDPOINT_GOOGLE,
+  deepseek: GlobalStateKey.ENDPOINT_DEEPSEEK,
+  xai: GlobalStateKey.ENDPOINT_XAI,
+  moonshot: GlobalStateKey.ENDPOINT_MOONSHOT,
+  dashscope: GlobalStateKey.ENDPOINT_DASHSCOPE,
+};
+
+/** Read the global streaming default. */
+export function getGlobalStreaming(): boolean {
+  return globalSM?.get<boolean>(GlobalStateKey.STREAMING_GLOBAL, true) ?? true;
+}
+
+/** Set the global streaming default. */
+export async function setGlobalStreaming(enabled: boolean): Promise<void> {
+  await globalSM?.update(GlobalStateKey.STREAMING_GLOBAL, enabled);
+}
+
+/** Read per-provider streaming setting, falling back to global default. */
+export function getProviderStreaming(provider: string): boolean {
+  const key = STREAMING_KEY[provider.toLowerCase()];
+  if (!key) return getGlobalStreaming();
+  const global = getGlobalStreaming();
+  return globalSM?.get<boolean>(key, global) ?? global;
+}
+
+/** Set per-provider streaming setting. */
+export async function setProviderStreaming(
+  provider: string,
+  enabled: boolean,
+): Promise<void> {
+  const key = STREAMING_KEY[provider.toLowerCase()];
+  if (key) {
+    await globalSM?.update(key, enabled);
+  }
+}
+
+/** Read per-provider custom endpoint. Returns empty string when unset. */
+export function getProviderEndpoint(provider: string): string {
+  const key = ENDPOINT_KEY[provider.toLowerCase()];
+  if (!key) return '';
+  return globalSM?.get<string>(key, '') ?? '';
+}
+
+/** Set per-provider custom endpoint. */
+export async function setProviderEndpoint(
+  provider: string,
+  endpoint: string,
+): Promise<void> {
+  const key = ENDPOINT_KEY[provider.toLowerCase()];
+  if (key) {
+    await globalSM?.update(key, endpoint);
+  }
+}
+
+/** Whether the given provider has a configurable custom endpoint. */
+export function supportsCustomEndpoint(provider: string): boolean {
+  return provider.toLowerCase() in ENDPOINT_KEY;
+}
+
 /** Get the maximum number of automatic retry attempts for model calls. */
 export function getModelRetryMaxAttempts(): number {
   return getConfig<number>('texra.model.retry.maxAttempts', 1);


### PR DESCRIPTION
## Summary
- add native Anthropic server-side compaction config (`compact_20260112`) for Claude Opus 4.6 tool-use runs
- keep existing context clearing edits and layer compaction trigger above clearing trigger
- include compaction beta in count-tokens beta filtering for accurate preflight behavior
- extend Anthropic response logging to record compaction events (with iteration-aware token context)
- extend Anthropic stream handler to recognize `compaction` / `compaction_delta` events without streaming them to user output
- update Anthropic usage normalization and pricing to use `usage.iterations` totals when present
- preserve compaction blocks in assistant content and add ephemeral cache control marker when prompt caching is enabled
- add unit tests for compaction edit insertion, model gating, iteration-based usage normalization, and compaction logging

## Config/Deps
- update `@anthropic-ai/sdk` to `^0.73.0` to use native compaction types
- update compaction threshold setting description to mention Anthropic native compaction on Opus 4.6

## Validation
- `npm run compile-tests`
- `npm run compile:fast`
- `npm run lint` (existing repo warnings only; no new lint errors)

## Notes
- intentionally relies on Anthropic default compaction instructions (no custom `instructions` override)
- `npm test` is not run, per repo guidance to avoid VS Code test environment download/runtime issues

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core Anthropic request construction/stream handling and changes how token usage/cost is computed (iteration-aware), which could affect billing metrics and long-running tool-use sessions; changes are gated to Opus 4.6 tool-use and are covered by new tests.
> 
> **Overview**
> Adds Anthropic native server-side compaction support by configuring the `compact_20260112` context edit (gated to Claude Opus 4.6 tool-use sessions) and opting into the `compact-2026-01-12` beta so preflight token counting matches the actual request options.
> 
> Updates Anthropic handling to treat `compaction` blocks as internal artifacts (not streamed to user output), log compaction events with iteration-aware token totals, and include compaction summaries in the progress view UI via schema/formatter/component changes.
> 
> Refactors streaming and custom-endpoint preferences to be stored in global state (new `GlobalStateKey`s) with shared helpers (`getProviderStreaming`, `getProviderEndpoint`, etc.), and updates `ModelHandler` + settings view code to use these helpers. Also bumps `@anthropic-ai/sdk` to `^0.73.0` (and `@supabase/supabase-js` patch) and adds unit tests covering compaction insertion/gating, cache marker behavior, usage normalization, and compaction logging.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2b2424250a08f9113d30885d9e4b8556d825d786. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->