### PR TITLE
Add comprehensive descriptions to grep tool schema fields

### DIFF
--- a/src/tools/grep.ts
+++ b/src/tools/grep.ts
@@ -20,13 +20,13 @@ const GrepInputSchema = z.strictObject({
   glob: z
     .string()
     .nullish()
-    .describe('Glob filter for file names (e.g. "*.ts").'),
+    .describe('Glob filter for file names (e.g. "*.tex").'),
   output_mode: z
     .enum(OUTPUT_MODES)
     .nullish()
     .transform((v) => v ?? 'content')
     .describe(
-      'Output format: "content" (matching lines), "files_with_matches" (paths only), or "count" (match counts). NOT "context" — use -C for context lines.',
+      'Must be "content", "files_with_matches", or "count". For context lines around matches, use -C instead.',
     ),
   '-B': z
     .int()
@@ -42,15 +42,13 @@ const GrepInputSchema = z.strictObject({
     .int()
     .min(0)
     .nullish()
-    .describe(
-      'Lines of context before AND after each match (only with output_mode "content"). Use this instead of output_mode when you want surrounding context.',
-    ),
+    .describe('Lines of context before AND after each match.'),
   '-n': z.boolean().nullish().describe('Show line numbers.'),
   '-i': z.boolean().nullish().describe('Case-insensitive search.'),
   type: z
     .string()
     .nullish()
-    .describe('Ripgrep file type filter (e.g. "ts", "py").'),
+    .describe('Ripgrep file type filter (e.g. "tex", "py").'),
   offset: z.int().min(0).nullish().describe('Skip first N results.'),
   head_limit: z.int().min(1).nullish().describe('Limit to first N results.'),
   multiline: z

--- a/src/tools/grep.ts
+++ b/src/tools/grep.ts
@@ -15,22 +15,48 @@ const OUTPUT_MODES = ['content', 'files_with_matches', 'count'] as const;
 type OutputMode = (typeof OUTPUT_MODES)[number];
 
 const GrepInputSchema = z.strictObject({
-  pattern: z.string().min(1, 'pattern is required'),
-  path: z.string().nullish(),
-  glob: z.string().nullish(),
+  pattern: z.string().min(1, 'pattern is required').describe('Regex pattern.'),
+  path: z.string().nullish().describe('File or directory to search in.'),
+  glob: z
+    .string()
+    .nullish()
+    .describe('Glob filter for file names (e.g. "*.ts").'),
   output_mode: z
     .enum(OUTPUT_MODES)
     .nullish()
-    .transform((v) => v ?? 'content'),
-  '-B': z.int().min(0).nullish(),
-  '-A': z.int().min(0).nullish(),
-  '-C': z.int().min(0).nullish(),
-  '-n': z.boolean().nullish(),
-  '-i': z.boolean().nullish(),
-  type: z.string().nullish(),
-  offset: z.int().min(0).nullish(),
-  head_limit: z.int().min(1).nullish(),
-  multiline: z.boolean().nullish(),
+    .transform((v) => v ?? 'content')
+    .describe(
+      'Output format: "content" (matching lines), "files_with_matches" (paths only), or "count" (match counts). NOT "context" — use -C for context lines.',
+    ),
+  '-B': z
+    .int()
+    .min(0)
+    .nullish()
+    .describe('Lines of context BEFORE each match (only with output_mode "content").'),
+  '-A': z
+    .int()
+    .min(0)
+    .nullish()
+    .describe('Lines of context AFTER each match (only with output_mode "content").'),
+  '-C': z
+    .int()
+    .min(0)
+    .nullish()
+    .describe(
+      'Lines of context before AND after each match (only with output_mode "content"). Use this instead of output_mode when you want surrounding context.',
+    ),
+  '-n': z.boolean().nullish().describe('Show line numbers.'),
+  '-i': z.boolean().nullish().describe('Case-insensitive search.'),
+  type: z
+    .string()
+    .nullish()
+    .describe('Ripgrep file type filter (e.g. "ts", "py").'),
+  offset: z.int().min(0).nullish().describe('Skip first N results.'),
+  head_limit: z.int().min(1).nullish().describe('Limit to first N results.'),
+  multiline: z
+    .boolean()
+    .nullish()
+    .describe('Enable multiline matching (pattern can span lines).'),
   literal: z.boolean().nullish().describe('Exact string, not regex.'),
 });
 
@@ -77,7 +103,7 @@ export function buildArguments(
 export class GrepTool extends defineTool({
   name: 'grep',
   description:
-    'Search file contents using regex patterns. Supports context (-A/-B/-C), glob/type filters, and multiline matching.',
+    'Search file contents using regex patterns. output_mode must be "content", "files_with_matches", or "count" (NOT "context"). To show surrounding lines, use -C with output_mode "content".',
   schema: GrepInputSchema,
 }) {
   protected async execute(input: GrepInput): Promise<ToolResult> {


### PR DESCRIPTION
## Summary
Enhanced the grep tool's input schema with detailed descriptions for all parameters to improve clarity and usability for users and AI models consuming this tool.

## Key Changes
- Added `.describe()` documentation to all schema fields in `GrepInputSchema`
- Provided clear explanations for each parameter including:
  - Pattern format (regex)
  - File/directory search scope
  - Glob filter syntax examples
  - Output mode options with explicit note that "context" is not a valid mode
  - Context line flags (-B, -A, -C) with usage constraints
  - Search modifiers (-n for line numbers, -i for case-insensitive)
  - File type filtering
  - Result limiting and offset options
  - Multiline matching behavior
- Updated the tool's main description to clarify output_mode requirements and direct users to use -C flag instead of a non-existent "context" mode

## Notable Details
- Descriptions include practical examples (e.g., "*.ts" for glob patterns, "ts", "py" for file types)
- Added important usage notes, such as context flags only working with "content" output_mode
- Clarified the distinction between output_mode and context flags to prevent user confusion
- All descriptions are concise yet informative for both human users and LLM-based tool consumers

https://claude.ai/code/session_01RyscZk5cFJZTWb2mxJ2kvk

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only schema metadata and description changes; no execution logic or behavior is modified.
> 
> **Overview**
> Improves the `grep` tool’s ergonomics by adding detailed `.describe()` documentation to all `GrepInputSchema` fields (pattern/path/glob/output mode, context flags, filters, pagination, multiline, literal).
> 
> Updates the tool description to explicitly restrict `output_mode` to `content`, `files_with_matches`, or `count`, and clarifies that surrounding-line context should be requested via `-C` (not a non-existent "context" mode).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1536851a6f49a2e58e2dc224b24fb945beec62ee. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->