### PR TITLE
Add workspace context to system prompts via XML block

### DIFF
--- a/src/utils/prompt/PromptBuilder.ts
+++ b/src/utils/prompt/PromptBuilder.ts
@@ -55,11 +55,7 @@ export async function getSystemPromptWithRules(
 ): Promise<string> {
   const basePrompt = await renderPrompt(systemPrompt, userVars);
   const rules = await loadTexraRules();
-  const workspaceInfo = buildWorkspaceInfoBlock();
-  const parts = [basePrompt];
-  if (rules) parts.push(rules);
-  parts.push(workspaceInfo);
-  return parts.join('\n');
+  return rules ? `${basePrompt}\n${rules}` : basePrompt;
 }
 
 /**
@@ -193,11 +189,12 @@ export async function buildInitialToolUsePrompts(
   const initial = await builder.buildInitialPrompts();
 
   // Build instruction suffix: always include tool-use instructions,
-  // optionally append memory instructions when enabled
+  // optionally append memory instructions and workspace info
   const suffixParts = [TOOL_USE_INSTRUCTIONS];
   if (options?.memoryEnabled) {
     suffixParts.push(MEMORY_TOOL_INSTRUCTIONS);
   }
+  suffixParts.push(buildWorkspaceInfoBlock());
 
   return {
     ...initial,

--- a/src/utils/prompt/PromptBuilder.ts
+++ b/src/utils/prompt/PromptBuilder.ts
@@ -5,6 +5,7 @@ import type {
 } from '@agent/core/AgentDataclass';
 import type { AgentLogger } from '@logger/AgentLogger';
 import { loadTexraRules } from '@utils/files/rulesUtils';
+import { buildWorkspaceInfoBlock } from '@utils/system/workspaceInfo';
 
 // Local imports - utilities
 import { renderPrompt } from './promptUtils';
@@ -54,7 +55,11 @@ export async function getSystemPromptWithRules(
 ): Promise<string> {
   const basePrompt = await renderPrompt(systemPrompt, userVars);
   const rules = await loadTexraRules();
-  return rules ? `${basePrompt}\n${rules}` : basePrompt;
+  const workspaceInfo = buildWorkspaceInfoBlock();
+  const parts = [basePrompt];
+  if (rules) parts.push(rules);
+  parts.push(workspaceInfo);
+  return parts.join('\n');
 }
 
 /**

--- a/src/utils/prompt/PromptBuilder.ts
+++ b/src/utils/prompt/PromptBuilder.ts
@@ -194,7 +194,7 @@ export async function buildInitialToolUsePrompts(
   if (options?.memoryEnabled) {
     suffixParts.push(MEMORY_TOOL_INSTRUCTIONS);
   }
-  suffixParts.push(buildWorkspaceInfoBlock());
+  suffixParts.push(await buildWorkspaceInfoBlock());
 
   return {
     ...initial,

--- a/src/utils/system/index.ts
+++ b/src/utils/system/index.ts
@@ -1,3 +1,4 @@
 export * from './execUtils';
 export * from './toolUtils';
 export * from './platformPaths';
+export * from './workspaceInfo';

--- a/src/utils/system/workspaceInfo.ts
+++ b/src/utils/system/workspaceInfo.ts
@@ -2,10 +2,13 @@
 import * as os from 'os';
 
 // Third-party imports
-import { execaSync } from 'execa';
+import { execa } from 'execa';
 
 // Local imports
 import { WorkspaceFS } from '@utils/files';
+
+/** Timeout for git commands in milliseconds. */
+const GIT_TIMEOUT_MS = 3000;
 
 /**
  * Gathered workspace environment information for system prompt injection.
@@ -67,47 +70,40 @@ function getPlatformLabel(): string {
  * Gather git repository information for the workspace.
  * Returns null if the workspace is not a git repo or git is unavailable.
  */
-function getGitInfo(workspacePath: string): GitInfo | null {
+async function getGitInfo(workspacePath: string): Promise<GitInfo | null> {
   try {
+    const opts = { cwd: workspacePath, reject: false, timeout: GIT_TIMEOUT_MS } as const;
+
     // Check if inside a git repo
-    const isRepo = execaSync('git', ['rev-parse', '--is-inside-work-tree'], {
-      cwd: workspacePath,
-      reject: false,
-    });
+    const isRepo = await execa('git', ['rev-parse', '--is-inside-work-tree'], opts);
     if (isRepo.exitCode !== 0) return null;
 
-    // Get current branch
-    const branchResult = execaSync(
-      'git',
-      ['symbolic-ref', '--short', 'HEAD'],
-      { cwd: workspacePath, reject: false },
-    );
+    // Run branch and status checks in parallel
+    const [branchResult, statusResult] = await Promise.all([
+      execa('git', ['symbolic-ref', '--short', 'HEAD'], opts),
+      execa('git', ['status', '--porcelain'], opts),
+    ]);
+
     const branch =
       branchResult.exitCode === 0
-        ? branchResult.stdout.toString().trim()
+        ? branchResult.stdout.trim()
         : null; // detached HEAD
 
-    // Check for uncommitted changes
-    const statusResult = execaSync('git', ['status', '--porcelain'], {
-      cwd: workspacePath,
-      reject: false,
-    });
     const dirty =
       statusResult.exitCode === 0 &&
-      statusResult.stdout.toString().trim().length > 0;
+      statusResult.stdout.trim().length > 0;
 
     return { isRepo: true, branch, dirty };
   } catch {
-    // git not installed or not on PATH (ENOENT)
+    // git not installed or not on PATH (ENOENT), or timed out
     return null;
   }
 }
 
 /**
  * Gather workspace environment information.
- * All operations are lightweight and synchronous.
  */
-function gatherWorkspaceInfo(): WorkspaceInfo {
+async function gatherWorkspaceInfo(): Promise<WorkspaceInfo> {
   const workspacePath = WorkspaceFS.getPath();
 
   return {
@@ -115,7 +111,7 @@ function gatherWorkspaceInfo(): WorkspaceInfo {
     platform: getPlatformLabel(),
     shell: detectShell(),
     date: new Date().toISOString().slice(0, 10), // YYYY-MM-DD
-    git: workspacePath ? getGitInfo(workspacePath) : null,
+    git: workspacePath ? await getGitInfo(workspacePath) : null,
   };
 }
 
@@ -133,8 +129,8 @@ function escapeXml(value: string): string {
  * Returns a `<workspace_info>` XML block with key environment details
  * that help the LLM understand the user's workspace context.
  */
-export function buildWorkspaceInfoBlock(): string {
-  const info = gatherWorkspaceInfo();
+export async function buildWorkspaceInfoBlock(): Promise<string> {
+  const info = await gatherWorkspaceInfo();
 
   const lines: string[] = [];
 

--- a/src/utils/system/workspaceInfo.ts
+++ b/src/utils/system/workspaceInfo.ts
@@ -68,34 +68,39 @@ function getPlatformLabel(): string {
  * Returns null if the workspace is not a git repo or git is unavailable.
  */
 function getGitInfo(workspacePath: string): GitInfo | null {
-  // Check if inside a git repo
-  const isRepo = execaSync('git', ['rev-parse', '--is-inside-work-tree'], {
-    cwd: workspacePath,
-    reject: false,
-  });
-  if (isRepo.exitCode !== 0) return null;
+  try {
+    // Check if inside a git repo
+    const isRepo = execaSync('git', ['rev-parse', '--is-inside-work-tree'], {
+      cwd: workspacePath,
+      reject: false,
+    });
+    if (isRepo.exitCode !== 0) return null;
 
-  // Get current branch
-  const branchResult = execaSync(
-    'git',
-    ['symbolic-ref', '--short', 'HEAD'],
-    { cwd: workspacePath, reject: false },
-  );
-  const branch =
-    branchResult.exitCode === 0
-      ? branchResult.stdout.toString().trim()
-      : null; // detached HEAD
+    // Get current branch
+    const branchResult = execaSync(
+      'git',
+      ['symbolic-ref', '--short', 'HEAD'],
+      { cwd: workspacePath, reject: false },
+    );
+    const branch =
+      branchResult.exitCode === 0
+        ? branchResult.stdout.toString().trim()
+        : null; // detached HEAD
 
-  // Check for uncommitted changes
-  const statusResult = execaSync('git', ['status', '--porcelain'], {
-    cwd: workspacePath,
-    reject: false,
-  });
-  const dirty =
-    statusResult.exitCode === 0 &&
-    statusResult.stdout.toString().trim().length > 0;
+    // Check for uncommitted changes
+    const statusResult = execaSync('git', ['status', '--porcelain'], {
+      cwd: workspacePath,
+      reject: false,
+    });
+    const dirty =
+      statusResult.exitCode === 0 &&
+      statusResult.stdout.toString().trim().length > 0;
 
-  return { isRepo: true, branch, dirty };
+    return { isRepo: true, branch, dirty };
+  } catch {
+    // git not installed or not on PATH (ENOENT)
+    return null;
+  }
 }
 
 /**
@@ -114,6 +119,14 @@ function gatherWorkspaceInfo(): WorkspaceInfo {
   };
 }
 
+/** Escape XML special characters in a string. */
+function escapeXml(value: string): string {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;');
+}
+
 /**
  * Build a formatted workspace info block for system prompt injection.
  *
@@ -126,13 +139,13 @@ export function buildWorkspaceInfoBlock(): string {
   const lines: string[] = [];
 
   if (info.workspacePath) {
-    lines.push(`Workspace: ${info.workspacePath}`);
+    lines.push(`Workspace: ${escapeXml(info.workspacePath)}`);
   }
 
-  lines.push(`Platform: ${info.platform}`);
+  lines.push(`Platform: ${escapeXml(info.platform)}`);
 
   if (info.shell) {
-    lines.push(`Shell: ${info.shell}`);
+    lines.push(`Shell: ${escapeXml(info.shell)}`);
   }
 
   lines.push(`Date: ${info.date}`);
@@ -140,7 +153,7 @@ export function buildWorkspaceInfoBlock(): string {
   if (info.git) {
     const parts = ['Git: yes'];
     if (info.git.branch) {
-      parts.push(`branch=${info.git.branch}`);
+      parts.push(`branch=${escapeXml(info.git.branch)}`);
     } else {
       parts.push('detached HEAD');
     }

--- a/src/utils/system/workspaceInfo.ts
+++ b/src/utils/system/workspaceInfo.ts
@@ -1,0 +1,154 @@
+// Standard library imports
+import * as os from 'os';
+
+// Third-party imports
+import { execaSync } from 'execa';
+
+// Local imports
+import { WorkspaceFS } from '@utils/files';
+
+/**
+ * Gathered workspace environment information for system prompt injection.
+ */
+interface WorkspaceInfo {
+  workspacePath: string | undefined;
+  platform: string;
+  shell: string | undefined;
+  date: string;
+  git: GitInfo | null;
+}
+
+interface GitInfo {
+  isRepo: true;
+  branch: string | null;
+  dirty: boolean;
+}
+
+/**
+ * Detect the user's default shell from environment.
+ * Returns the shell basename (e.g., "bash", "zsh", "fish") or undefined.
+ */
+function detectShell(): string | undefined {
+  if (process.platform === 'win32') {
+    // On Windows, check for common shells
+    const comspec = process.env.ComSpec;
+    if (comspec) {
+      const name = comspec.split(/[\\/]/).pop()?.toLowerCase();
+      if (name === 'powershell.exe' || name === 'pwsh.exe') return 'PowerShell';
+      if (name === 'cmd.exe') return 'cmd';
+      return name?.replace(/\.exe$/, '');
+    }
+    return undefined;
+  }
+
+  // Unix: SHELL env var is the login shell
+  const shell = process.env.SHELL;
+  if (!shell) return undefined;
+  return shell.split('/').pop(); // "bash", "zsh", "fish", etc.
+}
+
+/**
+ * Get a human-readable platform name.
+ */
+function getPlatformLabel(): string {
+  switch (process.platform) {
+    case 'darwin':
+      return `macOS (${os.arch()})`;
+    case 'win32':
+      return `Windows (${os.arch()})`;
+    case 'linux':
+      return `Linux (${os.arch()})`;
+    default:
+      return `${process.platform} (${os.arch()})`;
+  }
+}
+
+/**
+ * Gather git repository information for the workspace.
+ * Returns null if the workspace is not a git repo or git is unavailable.
+ */
+function getGitInfo(workspacePath: string): GitInfo | null {
+  // Check if inside a git repo
+  const isRepo = execaSync('git', ['rev-parse', '--is-inside-work-tree'], {
+    cwd: workspacePath,
+    reject: false,
+  });
+  if (isRepo.exitCode !== 0) return null;
+
+  // Get current branch
+  const branchResult = execaSync(
+    'git',
+    ['symbolic-ref', '--short', 'HEAD'],
+    { cwd: workspacePath, reject: false },
+  );
+  const branch =
+    branchResult.exitCode === 0
+      ? branchResult.stdout.toString().trim()
+      : null; // detached HEAD
+
+  // Check for uncommitted changes
+  const statusResult = execaSync('git', ['status', '--porcelain'], {
+    cwd: workspacePath,
+    reject: false,
+  });
+  const dirty =
+    statusResult.exitCode === 0 &&
+    statusResult.stdout.toString().trim().length > 0;
+
+  return { isRepo: true, branch, dirty };
+}
+
+/**
+ * Gather workspace environment information.
+ * All operations are lightweight and synchronous.
+ */
+function gatherWorkspaceInfo(): WorkspaceInfo {
+  const workspacePath = WorkspaceFS.getPath();
+
+  return {
+    workspacePath,
+    platform: getPlatformLabel(),
+    shell: detectShell(),
+    date: new Date().toISOString().slice(0, 10), // YYYY-MM-DD
+    git: workspacePath ? getGitInfo(workspacePath) : null,
+  };
+}
+
+/**
+ * Build a formatted workspace info block for system prompt injection.
+ *
+ * Returns a `<workspace_info>` XML block with key environment details
+ * that help the LLM understand the user's workspace context.
+ */
+export function buildWorkspaceInfoBlock(): string {
+  const info = gatherWorkspaceInfo();
+
+  const lines: string[] = [];
+
+  if (info.workspacePath) {
+    lines.push(`Workspace: ${info.workspacePath}`);
+  }
+
+  lines.push(`Platform: ${info.platform}`);
+
+  if (info.shell) {
+    lines.push(`Shell: ${info.shell}`);
+  }
+
+  lines.push(`Date: ${info.date}`);
+
+  if (info.git) {
+    const parts = ['Git: yes'];
+    if (info.git.branch) {
+      parts.push(`branch=${info.git.branch}`);
+    } else {
+      parts.push('detached HEAD');
+    }
+    if (info.git.dirty) {
+      parts.push('uncommitted changes');
+    }
+    lines.push(parts.join(', '));
+  }
+
+  return `\n<workspace_info>\n${lines.join('\n')}\n</workspace_info>`;
+}


### PR DESCRIPTION
## Summary
This PR enhances system prompts with contextual workspace information by injecting a `<workspace_info>` XML block. This helps the LLM understand the user's environment, including platform, shell, git status, and workspace path.

## Changes
- **New module**: `src/utils/system/workspaceInfo.ts`
  - `buildWorkspaceInfoBlock()`: Generates a formatted XML block with workspace environment details
  - `gatherWorkspaceInfo()`: Collects platform, shell, date, workspace path, and git repository information
  - `detectShell()`: Identifies the user's default shell (cross-platform support for Windows, macOS, Linux)
  - `getGitInfo()`: Retrieves git branch and dirty state using `git` CLI commands
  - `getPlatformLabel()`: Returns human-readable platform and architecture info

- **Updated**: `src/utils/prompt/PromptBuilder.ts`
  - Modified `getSystemPromptWithRules()` to include workspace info block in system prompts
  - Refactored prompt assembly to use array-based composition for better maintainability

- **Updated**: `src/utils/system/index.ts`
  - Exported new `workspaceInfo` module

## Implementation Details
- All workspace info gathering is **synchronous** and lightweight to avoid blocking prompt generation
- Git operations gracefully degrade if git is unavailable or workspace is not a repo
- Shell detection handles platform-specific differences (Windows PowerShell/cmd vs Unix shells)
- Workspace info is appended after rules, ensuring it's always present in the final prompt
- Uses XML tags (`<workspace_info>`) for clear LLM parsing and structured context injection

https://claude.ai/code/session_01DJDwa8DSw5xUxgeym8mPXp

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes prompt construction to include dynamic, environment-derived data and runs `git` subprocesses during prompt build, which could impact latency or leak local path/git state into model context if not desired.
> 
> **Overview**
> Adds a new `buildWorkspaceInfoBlock()` utility that collects basic environment metadata (workspace path, OS/arch, shell, date, and git branch/dirty status with timeouts) and formats it as a `<workspace_info>` XML block.
> 
> Updates `buildInitialToolUsePrompts()` to always append this workspace block to the tool-use instruction suffix (and exports the new module via `src/utils/system/index.ts`), so tool-use runs receive workspace context in the final system message.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 26d82e40fc005c4ddac1bc7566f8e9e30870d3e1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->