### PR TITLE
Remove media files from file category logging in getFileVars

### DIFF
--- a/src/agent/utils/userVars.ts
+++ b/src/agent/utils/userVars.ts
@@ -178,13 +178,14 @@ async function getFileVars(
 ): Promise<UserVars> {
   const userVars: UserVars = {};
 
-  // Log file categories being loaded (skip for tool-use agents)
+  // Log file categories being loaded (skip for tool-use agents).
+  // Media files are excluded: they have no user vars (display-only in Init)
+  // and are already logged with full load results by MediaExtractionNode in r0.
   if (agentSetting.agentCategory !== AgentCategory.ToolUse) {
     await logFileCategoriesWithExistence(logger, [
       ['Input Files', getCategoryFiles(agentConfig, 'INPUT')],
       ['Reference Files', getCategoryFiles(agentConfig, 'REFERENCE')],
       ['Auxiliary Files', getCategoryFiles(agentConfig, 'AUXILIARY')],
-      ['Media Files', getCategoryFiles(agentConfig, 'MEDIA')],
     ]);
   }
 


### PR DESCRIPTION
## Summary
Removed media files from the file category logging in `getFileVars` function, along with clarifying comments about why media files are excluded from this logging step.

## Changes
- Removed `['Media Files', getCategoryFiles(agentConfig, 'MEDIA')]` from the `logFileCategoriesWithExistence` call
- Added explanatory comments clarifying that:
  - Media files have no user vars (they are display-only in Init)
  - Media files are already logged with full load results by `MediaExtractionNode` in r0
  - This exclusion applies to non-tool-use agents

## Rationale
Media files don't contribute user variables and their loading is already tracked elsewhere in the pipeline via `MediaExtractionNode`. This change eliminates redundant logging and clarifies the intent of the file category logging in this function.

https://claude.ai/code/session_01He12MX8bpuni6odhHPoqcq

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging-only change that removes a redundant category from existence checks; no changes to file var generation or control flow beyond what gets logged.
> 
> **Overview**
> Removes the `Media Files` category from `getFileVars` pre-load logging, so only input/reference/auxiliary categories are existence-checked and displayed for non-tool-use agents.
> 
> Adds clarifying comments explaining that media files don’t produce user vars and their load results are already logged elsewhere (`MediaExtractionNode`), reducing redundant log noise.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 99e5b9c84958da1c0624f92ce7c1c6eadfb3fb0f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->