### PR TITLE
Refactor message schemas with discriminated unions and field reuse

### DIFF
--- a/src/shared/schemas/mainView.ts
+++ b/src/shared/schemas/mainView.ts
@@ -649,7 +649,7 @@ export type LatexdiffvcOperationMessage = z.infer<
 // ============================================================
 
 const commandOnly = <T extends string>(command: T) =>
-  z.object({ command: z.literal(command) });
+  z.object({ command: z.literal(command) }).passthrough();
 
 const withOptionalFilePath = <T extends string>(command: T) =>
   z.object({ command: z.literal(command), filePath: z.string().optional() });

--- a/src/shared/schemas/mainView.ts
+++ b/src/shared/schemas/mainView.ts
@@ -595,10 +595,10 @@ const CleanLatexdiffvcMessageSchema = z.object({
   ...latexdiffvcOperationFields,
 });
 
-export const LatexdiffvcOperationMessageSchema = z.union([
-  PackLatexdiffvcMessageSchema,
-  CleanLatexdiffvcMessageSchema,
-]);
+export const LatexdiffvcOperationMessageSchema = z.discriminatedUnion(
+  'command',
+  [PackLatexdiffvcMessageSchema, CleanLatexdiffvcMessageSchema],
+);
 
 export const MainViewMessageSchema = z.discriminatedUnion('command', [
   SetModelOptionsMessageSchema,

--- a/src/shared/schemas/mainView.ts
+++ b/src/shared/schemas/mainView.ts
@@ -578,16 +578,27 @@ export const LatexdiffvcMessageSchema = z.object({
   commitHash: z.string(),
 });
 
-export const LatexdiffvcOperationMessageSchema = z.object({
-  command: z.enum([
-    MAIN_VIEW_COMMANDS.PACK_LATEXDIFFVC,
-    MAIN_VIEW_COMMANDS.CLEAN_LATEXDIFFVC,
-  ]),
+const latexdiffvcOperationFields = {
   inputFile: z.string(),
   baseFile: z.string(),
   commitHash: z.string(),
   clean: z.boolean().nullish(),
+};
+
+const PackLatexdiffvcMessageSchema = z.object({
+  command: z.literal(MAIN_VIEW_COMMANDS.PACK_LATEXDIFFVC),
+  ...latexdiffvcOperationFields,
 });
+
+const CleanLatexdiffvcMessageSchema = z.object({
+  command: z.literal(MAIN_VIEW_COMMANDS.CLEAN_LATEXDIFFVC),
+  ...latexdiffvcOperationFields,
+});
+
+export const LatexdiffvcOperationMessageSchema = z.union([
+  PackLatexdiffvcMessageSchema,
+  CleanLatexdiffvcMessageSchema,
+]);
 
 export const MainViewMessageSchema = z.discriminatedUnion('command', [
   SetModelOptionsMessageSchema,
@@ -649,7 +660,7 @@ export type LatexdiffvcOperationMessage = z.infer<
 // ============================================================
 
 const commandOnly = <T extends string>(command: T) =>
-  z.object({ command: z.literal(command) }).passthrough();
+  z.object({ command: z.literal(command) });
 
 const withOptionalFilePath = <T extends string>(command: T) =>
   z.object({ command: z.literal(command), filePath: z.string().optional() });
@@ -865,22 +876,50 @@ const BannerMessages = [
 ] as const;
 
 const GitDiffMessages = [
-  commandOnly(MAIN_VIEW_COMMANDS.REQUEST_RECENT_COMMITS),
+  RequestRecentCommitsMessageSchema,
   commandOnly(MAIN_VIEW_COMMANDS.REFRESH_COMMITS),
-  commandOnly(MAIN_VIEW_COMMANDS.LATEXDIFF),
-  commandOnly(MAIN_VIEW_COMMANDS.LATEXDIFFVC),
-  commandOnly(MAIN_VIEW_COMMANDS.PACK_LATEXDIFFVC),
-  commandOnly(MAIN_VIEW_COMMANDS.CLEAN_LATEXDIFFVC),
+  LatexdiffMessageSchema,
+  LatexdiffvcMessageSchema,
+  PackLatexdiffvcMessageSchema,
+  CleanLatexdiffvcMessageSchema,
 ] as const;
+
+const singleOperationFields = {
+  inputFile: z.string(),
+  agent: z.string(),
+  model: z.string(),
+};
+
+const PackSingleMessageSchema = z.object({
+  command: z.literal(MAIN_VIEW_COMMANDS.PACK_SINGLE),
+  ...singleOperationFields,
+});
+
+const CleanSingleMessageSchema = z.object({
+  command: z.literal(MAIN_VIEW_COMMANDS.CLEAN_SINGLE),
+  ...singleOperationFields,
+});
+
+const PackMultipleMessageSchema = z.object({
+  command: z.literal(MAIN_VIEW_COMMANDS.PACK_MULTIPLE),
+  ...singleOperationFields,
+  outputFiles: z.array(z.string()).optional(),
+});
+
+const CleanMultipleMessageSchema = z.object({
+  command: z.literal(MAIN_VIEW_COMMANDS.CLEAN_MULTIPLE),
+  ...singleOperationFields,
+  outputFiles: z.array(z.string()).optional(),
+});
 
 const HousekeepingMessages = [
   commandOnly(MAIN_VIEW_COMMANDS.CLEAN_OUTPUT),
   commandOnly(MAIN_VIEW_COMMANDS.CLEAN_BUILD),
   commandOnly(MAIN_VIEW_COMMANDS.INDENT_TEX),
-  commandOnly(MAIN_VIEW_COMMANDS.PACK_SINGLE),
-  commandOnly(MAIN_VIEW_COMMANDS.CLEAN_SINGLE),
-  commandOnly(MAIN_VIEW_COMMANDS.PACK_MULTIPLE),
-  commandOnly(MAIN_VIEW_COMMANDS.CLEAN_MULTIPLE),
+  PackSingleMessageSchema,
+  CleanSingleMessageSchema,
+  PackMultipleMessageSchema,
+  CleanMultipleMessageSchema,
 ] as const;
 
 const NavigationMessages = [


### PR DESCRIPTION
## Summary
Refactored message schema definitions to improve type safety and reduce duplication by using discriminated unions and extracting common fields into reusable objects.

## Key Changes
- **LatexdiffvcOperationMessageSchema**: Converted from a single schema with `z.enum()` to a discriminated union of `PackLatexdiffvcMessageSchema` and `CleanLatexdiffvcMessageSchema`, each with their own `z.literal()` command type
  - Extracted common fields (`inputFile`, `baseFile`, `commitHash`, `clean`) into `latexdiffvcOperationFields` object for reuse
  
- **Single/Multiple operation schemas**: Created explicit schemas for pack and clean operations:
  - `PackSingleMessageSchema` and `CleanSingleMessageSchema` with common `singleOperationFields`
  - `PackMultipleMessageSchema` and `CleanMultipleMessageSchema` extending the base fields with optional `outputFiles`
  
- **Message arrays**: Updated `GitDiffMessages` and `HousekeepingMessages` arrays to reference the new specific schemas instead of generic `commandOnly()` helpers, enabling better type inference and validation

## Benefits
- Improved type safety with discriminated unions allowing TypeScript to narrow types based on command
- Reduced schema duplication through field object reuse
- Better IDE autocomplete and type checking for message consumers
- More explicit schema definitions that clearly show required vs optional fields per command

https://claude.ai/code/session_017qXYMFu734sCEjyGmaD4gL

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Schema-only refactor that primarily strengthens runtime validation and TypeScript narrowing; main risk is rejecting previously-accepted messages that omitted newly-required fields.
> 
> **Overview**
> Refactors `src/shared/schemas/mainView.ts` to make several MainView message schemas more explicit and type-safe by extracting shared field sets and replacing generic `commandOnly()` definitions with full Zod schemas.
> 
> `LatexdiffvcOperationMessageSchema` is converted from a single `z.enum()`-based schema into a `z.discriminatedUnion('command', ...)` over `PACK_LATEXDIFFVC` vs `CLEAN_LATEXDIFFVC` (sharing `latexdiffvcOperationFields`). Similarly, `PACK_SINGLE`/`CLEAN_SINGLE` and `PACK_MULTIPLE`/`CLEAN_MULTIPLE` inbound messages now validate required fields (`inputFile`, `agent`, `model`) and (for multiple) optional `outputFiles`, and the `GitDiffMessages`/`HousekeepingMessages` lists are updated to use these concrete schemas.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c4299ae6108bfe4520026e8622f23ec85aa75e5d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->