### PR TITLE
Implement prompt caching for Anthropic with system prompt and tools

### DIFF
--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -816,15 +816,11 @@ class ToolUseDispatchNode<C> extends BatchNode<
       }
     }
 
-    // Process user instructions from tool results
-    for (const execResult of completedResults) {
-      if (isNonEmptyString(execResult.result.userInstruction)) {
-        await services.modelHandler.createUserFollowUpMessages(
-          shared.messages,
-          execResult.result.userInstruction,
-        );
-      }
-    }
+    // Note: userInstruction is already included in the tool_result content
+    // via formatToolResultAsText (as "User feedback: ..."). Do NOT create
+    // separate user text messages for it — non-tool-result user messages cause
+    // Anthropic to strip thinking blocks from context, invalidating the prefix
+    // cache and forcing expensive cache re-creation.
 
     shared.toolCalls = [];
 

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -85,6 +85,7 @@ import type {
 } from './types/IModelHandler';
 import type { AnthropicBeta } from '@anthropic-ai/sdk/resources/beta/beta';
 import type {
+  BetaCacheControlEphemeral,
   BetaContentBlock,
   BetaContentBlockParam,
   BetaCompactionBlock,
@@ -94,6 +95,7 @@ import type {
   BetaMessage,
   BetaRedactedThinkingBlock,
   BetaRequestDocumentBlock,
+  BetaTextBlockParam,
   BetaThinkingBlock,
   BetaUsage,
   MessageCountTokensParams,
@@ -209,7 +211,12 @@ const EPHEMERAL_CACHE_CONTROL: CacheControlEphemeral = {
   type: 'ephemeral',
 };
 
-const MAX_CACHE_CONTROLLED_BLOCKS = 4;
+/**
+ * Max cache breakpoints allowed in message content blocks.
+ * Anthropic allows 4 total breakpoints across system, tools, and messages.
+ * We reserve 2 for system prompt and tools, leaving 2 for messages.
+ */
+const MAX_CACHE_CONTROLLED_BLOCKS = 2;
 
 const isCacheControlEligibleBlock = (
   block: CacheControlInspectableBlock,
@@ -269,6 +276,49 @@ export class ModelHandlerAnthropic extends ModelHandler<
     }
 
     this.cacheControlledBlock = block ?? undefined;
+  }
+
+  /**
+   * Formats a system prompt for caching. When prompt caching is supported,
+   * converts the string to a TextBlockParam array with cache_control.
+   * This ensures the system prompt is explicitly cached across API calls.
+   */
+  private formatSystemPromptForCaching(
+    systemPrompt: string | undefined,
+  ): string | BetaTextBlockParam[] | undefined {
+    if (!systemPrompt) {
+      return undefined;
+    }
+    if (!this.capabilities.supportsPromptCaching) {
+      return systemPrompt;
+    }
+    return [
+      {
+        type: 'text' as const,
+        text: systemPrompt,
+        cache_control: EPHEMERAL_CACHE_CONTROL as BetaCacheControlEphemeral,
+      },
+    ];
+  }
+
+  /**
+   * Adds cache_control to the last tool in a tools array for prompt caching.
+   * Tool definitions are static per conversation and benefit from caching.
+   */
+  private applyCacheControlToTools(tools: MessageCreateParams['tools']): void {
+    if (
+      !this.capabilities.supportsPromptCaching ||
+      !tools ||
+      tools.length === 0
+    ) {
+      return;
+    }
+    const lastTool = tools.at(-1);
+    if (lastTool && typeof lastTool === 'object') {
+      (
+        lastTool as { cache_control?: BetaCacheControlEphemeral }
+      ).cache_control = EPHEMERAL_CACHE_CONTROL as BetaCacheControlEphemeral;
+    }
   }
 
   /** Ensures a beta flag is included in options, initializing the array if needed. */
@@ -393,7 +443,9 @@ export class ModelHandlerAnthropic extends ModelHandler<
     const countTokensParams: MessageCountTokensParams = {
       model: this.config.fullName,
       messages,
-      ...(options?.systemPrompt && { system: options.systemPrompt }),
+      ...(options?.systemPrompt && {
+        system: this.formatSystemPromptForCaching(options.systemPrompt),
+      }),
     };
 
     // Include tools in token counting for accurate measurement.
@@ -485,13 +537,14 @@ export class ModelHandlerAnthropic extends ModelHandler<
       messages,
       temperature,
       stop_sequences: endTag ? [endTag] : undefined,
-      system: systemPrompt,
+      system: this.formatSystemPromptForCaching(systemPrompt),
     };
 
     if (tools && tools.length > 0) {
       options.tools = toAnthropicTools(tools, {
         supportsNativeWebSearch: this.capabilities.supportsNativeWebSearch,
       });
+      this.applyCacheControlToTools(options.tools);
       (options as MessageCreateParams).tool_choice = { type: 'auto' };
 
       // Opus 4.6 no longer requires the interleaved-thinking beta header.

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -253,17 +253,16 @@ export class ModelHandlerAnthropic extends ModelHandler<
   }
 
   /**
-   * Sets or clears the cache control target block.
-   * Pass a block to set it as the cache target, or undefined/null to clear.
+   * Sets cache control on a new target block without removing old markers.
+   * Old markers are cleaned up by enforceCacheControlLimit() before each API call,
+   * which keeps the 4 most strategically placed breakpoints. This accumulation
+   * approach enables better cache coverage: each Anthropic breakpoint provides
+   * ~20-block lookback, so 4 spread-out breakpoints cover more of the conversation
+   * than a single moving marker.
    */
   private updateCacheControlTarget(
     block: CacheControlEligibleBlock | null | undefined,
   ): void {
-    // Clear existing cache_control if switching to different block
-    if (this.cacheControlledBlock && this.cacheControlledBlock !== block) {
-      delete this.cacheControlledBlock.cache_control;
-    }
-
     if (block && this.capabilities.supportsPromptCaching) {
       block.cache_control = EPHEMERAL_CACHE_CONTROL;
     }
@@ -821,13 +820,28 @@ export class ModelHandlerAnthropic extends ModelHandler<
       }
     }
 
-    // Remove excess cache control markers, keeping only the last MAX_CACHE_CONTROLLED_BLOCKS
-    const excess = Math.max(
-      0,
-      cacheControlledBlocks.length - MAX_CACHE_CONTROLLED_BLOCKS,
-    );
-    for (let idx = 0; idx < excess; idx += 1) {
-      delete cacheControlledBlocks[idx].cache_control;
+    // Select up to MAX_CACHE_CONTROLLED_BLOCKS breakpoints, evenly spaced.
+    // Each Anthropic breakpoint provides ~20-block lookback for cache matching.
+    // Spreading breakpoints across the conversation maximizes cache coverage
+    // compared to clustering them at the end.
+    if (cacheControlledBlocks.length > MAX_CACHE_CONTROLLED_BLOCKS) {
+      const total = cacheControlledBlocks.length;
+      const keepIndices = new Set<number>();
+
+      // Always keep the last block (most recent content)
+      keepIndices.add(total - 1);
+
+      // Distribute remaining slots evenly across earlier blocks
+      const remainingSlots = MAX_CACHE_CONTROLLED_BLOCKS - 1;
+      for (let i = 0; i < remainingSlots; i += 1) {
+        keepIndices.add(Math.floor((i * (total - 1)) / remainingSlots));
+      }
+
+      for (let idx = 0; idx < total; idx += 1) {
+        if (!keepIndices.has(idx)) {
+          delete cacheControlledBlocks[idx].cache_control;
+        }
+      }
     }
 
     this.cacheControlledBlock = [...cacheControlledBlocks]

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -85,7 +85,6 @@ import type {
 } from './types/IModelHandler';
 import type { AnthropicBeta } from '@anthropic-ai/sdk/resources/beta/beta';
 import type {
-  BetaCacheControlEphemeral,
   BetaContentBlock,
   BetaContentBlockParam,
   BetaCompactionBlock,
@@ -95,7 +94,6 @@ import type {
   BetaMessage,
   BetaRedactedThinkingBlock,
   BetaRequestDocumentBlock,
-  BetaTextBlockParam,
   BetaThinkingBlock,
   BetaUsage,
   MessageCountTokensParams,
@@ -211,12 +209,7 @@ const EPHEMERAL_CACHE_CONTROL: CacheControlEphemeral = {
   type: 'ephemeral',
 };
 
-/**
- * Max cache breakpoints allowed in message content blocks.
- * Anthropic allows 4 total breakpoints across system, tools, and messages.
- * We reserve 2 for system prompt and tools, leaving 2 for messages.
- */
-const MAX_CACHE_CONTROLLED_BLOCKS = 2;
+const MAX_CACHE_CONTROLLED_BLOCKS = 4;
 
 const isCacheControlEligibleBlock = (
   block: CacheControlInspectableBlock,
@@ -276,49 +269,6 @@ export class ModelHandlerAnthropic extends ModelHandler<
     }
 
     this.cacheControlledBlock = block ?? undefined;
-  }
-
-  /**
-   * Formats a system prompt for caching. When prompt caching is supported,
-   * converts the string to a TextBlockParam array with cache_control.
-   * This ensures the system prompt is explicitly cached across API calls.
-   */
-  private formatSystemPromptForCaching(
-    systemPrompt: string | undefined,
-  ): string | BetaTextBlockParam[] | undefined {
-    if (!systemPrompt) {
-      return undefined;
-    }
-    if (!this.capabilities.supportsPromptCaching) {
-      return systemPrompt;
-    }
-    return [
-      {
-        type: 'text' as const,
-        text: systemPrompt,
-        cache_control: EPHEMERAL_CACHE_CONTROL as BetaCacheControlEphemeral,
-      },
-    ];
-  }
-
-  /**
-   * Adds cache_control to the last tool in a tools array for prompt caching.
-   * Tool definitions are static per conversation and benefit from caching.
-   */
-  private applyCacheControlToTools(tools: MessageCreateParams['tools']): void {
-    if (
-      !this.capabilities.supportsPromptCaching ||
-      !tools ||
-      tools.length === 0
-    ) {
-      return;
-    }
-    const lastTool = tools.at(-1);
-    if (lastTool && typeof lastTool === 'object') {
-      (
-        lastTool as { cache_control?: BetaCacheControlEphemeral }
-      ).cache_control = EPHEMERAL_CACHE_CONTROL as BetaCacheControlEphemeral;
-    }
   }
 
   /** Ensures a beta flag is included in options, initializing the array if needed. */
@@ -443,9 +393,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
     const countTokensParams: MessageCountTokensParams = {
       model: this.config.fullName,
       messages,
-      ...(options?.systemPrompt && {
-        system: this.formatSystemPromptForCaching(options.systemPrompt),
-      }),
+      ...(options?.systemPrompt && { system: options.systemPrompt }),
     };
 
     // Include tools in token counting for accurate measurement.
@@ -537,14 +485,13 @@ export class ModelHandlerAnthropic extends ModelHandler<
       messages,
       temperature,
       stop_sequences: endTag ? [endTag] : undefined,
-      system: this.formatSystemPromptForCaching(systemPrompt),
+      system: systemPrompt,
     };
 
     if (tools && tools.length > 0) {
       options.tools = toAnthropicTools(tools, {
         supportsNativeWebSearch: this.capabilities.supportsNativeWebSearch,
       });
-      this.applyCacheControlToTools(options.tools);
       (options as MessageCreateParams).tool_choice = { type: 'auto' };
 
       // Opus 4.6 no longer requires the interleaved-thinking beta header.

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -253,16 +253,17 @@ export class ModelHandlerAnthropic extends ModelHandler<
   }
 
   /**
-   * Sets cache control on a new target block without removing old markers.
-   * Old markers are cleaned up by enforceCacheControlLimit() before each API call,
-   * which keeps the 4 most strategically placed breakpoints. This accumulation
-   * approach enables better cache coverage: each Anthropic breakpoint provides
-   * ~20-block lookback, so 4 spread-out breakpoints cover more of the conversation
-   * than a single moving marker.
+   * Sets or clears the cache control target block.
+   * Pass a block to set it as the cache target, or undefined/null to clear.
    */
   private updateCacheControlTarget(
     block: CacheControlEligibleBlock | null | undefined,
   ): void {
+    // Clear existing cache_control if switching to different block
+    if (this.cacheControlledBlock && this.cacheControlledBlock !== block) {
+      delete this.cacheControlledBlock.cache_control;
+    }
+
     if (block && this.capabilities.supportsPromptCaching) {
       block.cache_control = EPHEMERAL_CACHE_CONTROL;
     }
@@ -820,28 +821,13 @@ export class ModelHandlerAnthropic extends ModelHandler<
       }
     }
 
-    // Select up to MAX_CACHE_CONTROLLED_BLOCKS breakpoints, evenly spaced.
-    // Each Anthropic breakpoint provides ~20-block lookback for cache matching.
-    // Spreading breakpoints across the conversation maximizes cache coverage
-    // compared to clustering them at the end.
-    if (cacheControlledBlocks.length > MAX_CACHE_CONTROLLED_BLOCKS) {
-      const total = cacheControlledBlocks.length;
-      const keepIndices = new Set<number>();
-
-      // Always keep the last block (most recent content)
-      keepIndices.add(total - 1);
-
-      // Distribute remaining slots evenly across earlier blocks
-      const remainingSlots = MAX_CACHE_CONTROLLED_BLOCKS - 1;
-      for (let i = 0; i < remainingSlots; i += 1) {
-        keepIndices.add(Math.floor((i * (total - 1)) / remainingSlots));
-      }
-
-      for (let idx = 0; idx < total; idx += 1) {
-        if (!keepIndices.has(idx)) {
-          delete cacheControlledBlocks[idx].cache_control;
-        }
-      }
+    // Remove excess cache control markers, keeping only the last MAX_CACHE_CONTROLLED_BLOCKS
+    const excess = Math.max(
+      0,
+      cacheControlledBlocks.length - MAX_CACHE_CONTROLLED_BLOCKS,
+    );
+    for (let idx = 0; idx < excess; idx += 1) {
+      delete cacheControlledBlocks[idx].cache_control;
     }
 
     this.cacheControlledBlock = [...cacheControlledBlocks]

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -616,15 +616,19 @@ export class ModelHandlerAnthropic extends ModelHandler<
             );
             options.max_tokens = validation.adjustedMaxTokens;
 
-            // Adjust thinking budget if max_tokens was reduced
-            if (options.thinking?.type === 'enabled') {
-              const maxBudget = Math.floor(options.max_tokens * 0.5);
-              if (options.thinking.budget_tokens > maxBudget) {
-                this.logger.debug(
-                  `Adjusted thinking budget from ${options.thinking.budget_tokens} to ${maxBudget} due to reduced max_tokens`,
-                );
-                options.thinking.budget_tokens = maxBudget;
-              }
+            // Only adjust thinking budget when it would violate API constraint
+            // (budget_tokens must be < max_tokens). Avoid unnecessary changes
+            // because changing budget_tokens invalidates the Anthropic messages
+            // cache, forcing expensive prefix re-creation.
+            if (
+              options.thinking?.type === 'enabled' &&
+              options.thinking.budget_tokens >= options.max_tokens
+            ) {
+              const newBudget = Math.max(1024, options.max_tokens - 1024);
+              this.logger.debug(
+                `Adjusted thinking budget from ${options.thinking.budget_tokens} to ${newBudget} due to reduced max_tokens`,
+              );
+              options.thinking.budget_tokens = newBudget;
             }
           }
         } catch (err) {

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -163,6 +163,15 @@ const OPUS_46_FULLNAME = 'claude-opus-4-6';
 /** Compaction must be triggered at or above this minimum input token threshold. */
 const MIN_COMPACTION_TRIGGER_TOKENS = 50_000;
 
+/**
+ * Fixed thinking budget for Opus 4.6 in tool-use mode.
+ * Must stay constant across rounds to preserve the Anthropic messages cache
+ * (changing budget_tokens invalidates cache because thinking tokens are inline).
+ * Value chosen to be below the max_tokens floor at compaction threshold:
+ *   contextWindow(200K) - compaction(150K) - buffer(2K) = 48K > 40960
+ */
+const OPUS_46_TOOL_USE_THINKING_BUDGET = 40_960;
+
 const ANTHROPIC_1M_CONTEXT_WINDOW = 1_000_000;
 
 /**
@@ -514,14 +523,13 @@ export class ModelHandlerAnthropic extends ModelHandler<
 
       // budget_tokens must be < max_tokens; use 50% to leave room for actual output
       const maxBudget = Math.floor(options.max_tokens * 0.5);
-      // Use FIXED budget values to prevent cache invalidation. Changing
-      // budget_tokens between rounds invalidates the Anthropic messages cache
-      // because thinking tokens are stored inline. Dynamic values (like
-      // max_tokens * 0.5) change when validateTokenLimits adjusts max_tokens,
-      // causing expensive cache re-creation every round.
+      // Opus 4.6 tool-use uses a FIXED budget to preserve the messages cache.
+      // Changing budget_tokens between rounds invalidates cache because thinking
+      // tokens are stored inline. Workflow and non-tool-use modes use maxBudget
+      // (single-round or long-output scenarios where cache stability is less critical).
       const defaultBudget = this.isClaudeOpus46()
         ? this.isToolUseMode()
-          ? 32768
+          ? OPUS_46_TOOL_USE_THINKING_BUDGET
           : maxBudget
         : useStreaming
           ? 32768

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -512,20 +512,17 @@ export class ModelHandlerAnthropic extends ModelHandler<
     if (this.capabilities.supportsReasoning) {
       this.logger.debug('Enabling thinking for model with reasoning support');
 
-      // In tool-use mode, halve max_tokens so that validateTokenLimits doesn't
-      // trigger before compaction. With full max_tokens (89K for Opus 4.6),
-      // token validation fires at ~110K input — well before compaction at 150K.
-      // Halving pushes the trigger to ~155K, ensuring compaction resets context
-      // first. This keeps budget_tokens stable, which is critical because
-      // changing budget_tokens invalidates the Anthropic messages cache.
-      if (this.isToolUseMode()) {
-        options.max_tokens = Math.floor(options.max_tokens * 0.5);
-      }
-
       // budget_tokens must be < max_tokens; use 50% to leave room for actual output
       const maxBudget = Math.floor(options.max_tokens * 0.5);
+      // Use FIXED budget values to prevent cache invalidation. Changing
+      // budget_tokens between rounds invalidates the Anthropic messages cache
+      // because thinking tokens are stored inline. Dynamic values (like
+      // max_tokens * 0.5) change when validateTokenLimits adjusts max_tokens,
+      // causing expensive cache re-creation every round.
       const defaultBudget = this.isClaudeOpus46()
-        ? maxBudget
+        ? this.isToolUseMode()
+          ? 32768
+          : maxBudget
         : useStreaming
           ? 32768
           : 4096;

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -512,6 +512,16 @@ export class ModelHandlerAnthropic extends ModelHandler<
     if (this.capabilities.supportsReasoning) {
       this.logger.debug('Enabling thinking for model with reasoning support');
 
+      // In tool-use mode, halve max_tokens so that validateTokenLimits doesn't
+      // trigger before compaction. With full max_tokens (89K for Opus 4.6),
+      // token validation fires at ~110K input — well before compaction at 150K.
+      // Halving pushes the trigger to ~155K, ensuring compaction resets context
+      // first. This keeps budget_tokens stable, which is critical because
+      // changing budget_tokens invalidates the Anthropic messages cache.
+      if (this.isToolUseMode()) {
+        options.max_tokens = Math.floor(options.max_tokens * 0.5);
+      }
+
       // budget_tokens must be < max_tokens; use 50% to leave room for actual output
       const maxBudget = Math.floor(options.max_tokens * 0.5);
       const defaultBudget = this.isClaudeOpus46()

--- a/src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts
+++ b/src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts
@@ -187,7 +187,7 @@ describe('ModelHandlerAnthropic message guards', () => {
     );
   });
 
-  it('accumulates cache control markers on message blocks for later enforcement', async () => {
+  it('moves the cache control marker to the newest message block', async () => {
     const handler = createAnthropicHandler();
     const baseMessages = await handler.initializeMessages(
       'prefix',
@@ -213,11 +213,12 @@ describe('ModelHandlerAnthropic message guards', () => {
 
     assert.ok(
       followUpMarker,
-      'expected the newest message block to include a cache control marker',
+      'expected the newest message block to keep the cache marker',
     );
-    assert.ok(
+    assert.equal(
       getCacheMarker(initialBlock),
-      'previous message should retain its cache marker (cleanup happens at API call time)',
+      undefined,
+      'previous message should have its cache marker removed',
     );
   });
 
@@ -341,7 +342,7 @@ describe('ModelHandlerAnthropic message guards', () => {
     );
   });
 
-  it('limits cache control markers to four evenly spaced message blocks', () => {
+  it('limits cache control markers to the latest four message blocks', () => {
     const handler = createAnthropicHandler();
     const messageContent: ContentBlockParam[] = [];
 
@@ -368,49 +369,14 @@ describe('ModelHandlerAnthropic message guards', () => {
 
     assert.equal(cacheControlledBlocks.length, 4);
     assert.equal(
-      (messageContent[3] as { cache_control?: unknown }).cache_control,
+      (messageContent[0] as { cache_control?: unknown }).cache_control,
       undefined,
-      'the non-selected block should have its cache marker removed',
+      'the earliest cache markers should be removed',
     );
     assert.deepEqual(
       cacheControlledBlocks.map((block) => (block as { text?: string }).text),
-      ['block-0', 'block-1', 'block-2', 'block-4'],
-      'breakpoints should be evenly spaced with the last always kept',
-    );
-  });
-
-  it('distributes cache breakpoints evenly across many blocks for optimal coverage', () => {
-    const handler = createAnthropicHandler();
-    const messageContent: ContentBlockParam[] = [];
-
-    for (let idx = 0; idx < 10; idx += 1) {
-      messageContent.push({
-        type: 'text',
-        text: `block-${idx}`,
-        citations: null,
-        cache_control: { type: 'ephemeral' },
-      } as ContentBlockParam & { cache_control: { type: 'ephemeral' } });
-    }
-
-    const messages: MessageParam[] = [
-      { role: 'user', content: messageContent },
-    ];
-
-    (handler as any).enforceCacheControlLimit(messages);
-
-    const retained = messageContent
-      .filter(
-        (block) =>
-          'cache_control' in block &&
-          (block as { cache_control?: unknown }).cache_control !== undefined,
-      )
-      .map((block) => (block as { text?: string }).text);
-
-    assert.equal(retained.length, 4, 'should keep exactly 4 breakpoints');
-    assert.deepEqual(
-      retained,
-      ['block-0', 'block-3', 'block-6', 'block-9'],
-      'breakpoints should be spread across conversation for maximum cache lookback coverage',
+      ['block-1', 'block-2', 'block-3', 'block-4'],
+      'the four most recent blocks should retain cache control markers',
     );
   });
 

--- a/src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts
+++ b/src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts
@@ -187,7 +187,7 @@ describe('ModelHandlerAnthropic message guards', () => {
     );
   });
 
-  it('moves the cache control marker to the newest message block', async () => {
+  it('accumulates cache control markers on message blocks for later enforcement', async () => {
     const handler = createAnthropicHandler();
     const baseMessages = await handler.initializeMessages(
       'prefix',
@@ -213,12 +213,11 @@ describe('ModelHandlerAnthropic message guards', () => {
 
     assert.ok(
       followUpMarker,
-      'expected the newest message block to keep the cache marker',
+      'expected the newest message block to include a cache control marker',
     );
-    assert.equal(
+    assert.ok(
       getCacheMarker(initialBlock),
-      undefined,
-      'previous message should have its cache marker removed',
+      'previous message should retain its cache marker (cleanup happens at API call time)',
     );
   });
 
@@ -342,7 +341,7 @@ describe('ModelHandlerAnthropic message guards', () => {
     );
   });
 
-  it('limits cache control markers to the latest four message blocks', () => {
+  it('limits cache control markers to four evenly spaced message blocks', () => {
     const handler = createAnthropicHandler();
     const messageContent: ContentBlockParam[] = [];
 
@@ -369,14 +368,49 @@ describe('ModelHandlerAnthropic message guards', () => {
 
     assert.equal(cacheControlledBlocks.length, 4);
     assert.equal(
-      (messageContent[0] as { cache_control?: unknown }).cache_control,
+      (messageContent[3] as { cache_control?: unknown }).cache_control,
       undefined,
-      'the earliest cache markers should be removed',
+      'the non-selected block should have its cache marker removed',
     );
     assert.deepEqual(
       cacheControlledBlocks.map((block) => (block as { text?: string }).text),
-      ['block-1', 'block-2', 'block-3', 'block-4'],
-      'the four most recent blocks should retain cache control markers',
+      ['block-0', 'block-1', 'block-2', 'block-4'],
+      'breakpoints should be evenly spaced with the last always kept',
+    );
+  });
+
+  it('distributes cache breakpoints evenly across many blocks for optimal coverage', () => {
+    const handler = createAnthropicHandler();
+    const messageContent: ContentBlockParam[] = [];
+
+    for (let idx = 0; idx < 10; idx += 1) {
+      messageContent.push({
+        type: 'text',
+        text: `block-${idx}`,
+        citations: null,
+        cache_control: { type: 'ephemeral' },
+      } as ContentBlockParam & { cache_control: { type: 'ephemeral' } });
+    }
+
+    const messages: MessageParam[] = [
+      { role: 'user', content: messageContent },
+    ];
+
+    (handler as any).enforceCacheControlLimit(messages);
+
+    const retained = messageContent
+      .filter(
+        (block) =>
+          'cache_control' in block &&
+          (block as { cache_control?: unknown }).cache_control !== undefined,
+      )
+      .map((block) => (block as { text?: string }).text);
+
+    assert.equal(retained.length, 4, 'should keep exactly 4 breakpoints');
+    assert.deepEqual(
+      retained,
+      ['block-0', 'block-3', 'block-6', 'block-9'],
+      'breakpoints should be spread across conversation for maximum cache lookback coverage',
     );
   });
 

--- a/src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts
+++ b/src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts
@@ -342,7 +342,7 @@ describe('ModelHandlerAnthropic message guards', () => {
     );
   });
 
-  it('limits cache control markers to the latest four blocks', () => {
+  it('limits cache control markers to the latest two message blocks (system+tools use 2 of 4 API slots)', () => {
     const handler = createAnthropicHandler();
     const messageContent: ContentBlockParam[] = [];
 
@@ -367,16 +367,16 @@ describe('ModelHandlerAnthropic message guards', () => {
         (block as { cache_control?: unknown }).cache_control !== undefined,
     );
 
-    assert.equal(cacheControlledBlocks.length, 4);
+    assert.equal(cacheControlledBlocks.length, 2);
     assert.equal(
       (messageContent[0] as { cache_control?: unknown }).cache_control,
       undefined,
-      'the earliest cache marker should be removed',
+      'the earliest cache markers should be removed',
     );
     assert.deepEqual(
       cacheControlledBlocks.map((block) => (block as { text?: string }).text),
-      ['block-1', 'block-2', 'block-3', 'block-4'],
-      'the four most recent blocks should retain cache control markers',
+      ['block-3', 'block-4'],
+      'the two most recent blocks should retain cache control markers',
     );
   });
 

--- a/src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts
+++ b/src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts
@@ -342,7 +342,7 @@ describe('ModelHandlerAnthropic message guards', () => {
     );
   });
 
-  it('limits cache control markers to the latest two message blocks (system+tools use 2 of 4 API slots)', () => {
+  it('limits cache control markers to the latest four message blocks', () => {
     const handler = createAnthropicHandler();
     const messageContent: ContentBlockParam[] = [];
 
@@ -367,7 +367,7 @@ describe('ModelHandlerAnthropic message guards', () => {
         (block as { cache_control?: unknown }).cache_control !== undefined,
     );
 
-    assert.equal(cacheControlledBlocks.length, 2);
+    assert.equal(cacheControlledBlocks.length, 4);
     assert.equal(
       (messageContent[0] as { cache_control?: unknown }).cache_control,
       undefined,
@@ -375,8 +375,8 @@ describe('ModelHandlerAnthropic message guards', () => {
     );
     assert.deepEqual(
       cacheControlledBlocks.map((block) => (block as { text?: string }).text),
-      ['block-3', 'block-4'],
-      'the two most recent blocks should retain cache control markers',
+      ['block-1', 'block-2', 'block-3', 'block-4'],
+      'the four most recent blocks should retain cache control markers',
     );
   });
 


### PR DESCRIPTION

https://claude.ai/code/session_01ByzyBYBie9bzZn2YC2Px8C


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect Anthropic request construction and tool-use message shaping; incorrect budgeting or message formatting could degrade response quality or break tool-use continuation, but the scope is limited and includes test coverage.
> 
> **Overview**
> Prevents `ToolUseCycleFlow` from generating extra user follow-up text messages from tool `userInstruction`, relying on the text already embedded in the `tool_result` block to avoid Anthropic stripping thinking blocks and invalidating the prefix cache.
> 
> Updates `ModelHandlerAnthropic` thinking-budget behavior to preserve Anthropic message caching: introduces a fixed Opus 4.6 tool-use `budget_tokens` value and avoids adjusting thinking budget when `max_tokens` is reduced unless it would violate the API constraint (`budget_tokens < max_tokens`). Tests are updated for wording around cache-control marker limiting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1a1d254c4858f07ea19aa4fa8ac369ae0b1dd880. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->