### PR TITLE
Hide minor max tokens reduced events from UI

### DIFF
--- a/src/progressView/frontend/formatters/index.ts
+++ b/src/progressView/frontend/formatters/index.ts
@@ -48,6 +48,7 @@ const NULLABLE_TYPES: Set<MessageType> = new Set([
   'scratchpad',
   'modelResponse',
   'contextState',
+  'contextManagement',
 ]);
 
 /** Create an error fallback template when formatting fails. */

--- a/src/progressView/frontend/formatters/logFormatters/contextManagementFormatters.ts
+++ b/src/progressView/frontend/formatters/logFormatters/contextManagementFormatters.ts
@@ -9,6 +9,7 @@
 // Local imports - shared schemas
 import {
   ContextManagementDataSchema,
+  type ContextManagementData,
   type LogMessageData,
 } from '@shared/schemas';
 
@@ -70,15 +71,10 @@ const ACTION_CONFIG: Record<
   },
 };
 
-/** Build context management items from data. */
+/** Build context management items from parsed data. */
 function buildContextManagementItems(
-  data: unknown,
-): { config: ActionConfig; items: ContextStatItem[]; summary?: string } | null {
-  const result = ContextManagementDataSchema.safeParse(data);
-  if (!result.success) {
-    return null;
-  }
-
+  data: ContextManagementData,
+): { config: ActionConfig; items: ContextStatItem[]; summary?: string } {
   const {
     action,
     tokensBefore,
@@ -90,7 +86,7 @@ function buildContextManagementItems(
     reducedMaxTokens,
     details,
     summary,
-  } = result.data;
+  } = data;
 
   const config: ActionConfig = ACTION_CONFIG[action] || {
     icon: 'codicon-history',
@@ -163,10 +159,11 @@ export function formatContextManagementTemplate(
 ): FormatResult {
   const { id, data } = message;
 
-  // Hide max_tokens_reduced events when the reduced value is still comfortable
   const parsed = ContextManagementDataSchema.safeParse(data);
+  if (!parsed.success) return null;
+
+  // Hide max_tokens_reduced events when the reduced value is still comfortable
   if (
-    parsed.success &&
     parsed.data.action === 'max_tokens_reduced' &&
     parsed.data.reducedMaxTokens !== undefined &&
     parsed.data.reducedMaxTokens >= MAX_TOKENS_REDUCED_DISPLAY_THRESHOLD
@@ -174,10 +171,7 @@ export function formatContextManagementTemplate(
     return null;
   }
 
-  const result = buildContextManagementItems(data);
-  if (!result) return null;
-
-  const { config, items, summary } = result;
+  const { config, items, summary } = buildContextManagementItems(parsed.data);
 
   return html`
     <context-management

--- a/src/progressView/frontend/formatters/logFormatters/contextManagementFormatters.ts
+++ b/src/progressView/frontend/formatters/logFormatters/contextManagementFormatters.ts
@@ -24,6 +24,13 @@ import type {
   ContextStatItem,
 } from '../../components/ContextManagement';
 
+/**
+ * Minimum reduced token threshold below which the "Max Tokens Reduced" event
+ * is surfaced in the UI. When the adjusted max_tokens is still at or above
+ * this value the reduction is minor and not worth distracting the user with.
+ */
+const MAX_TOKENS_REDUCED_DISPLAY_THRESHOLD = 32_768;
+
 // Actions that show tokens freed stat
 const TOKENS_FREED_ACTIONS = new Set([
   'clear_tool_uses',
@@ -155,6 +162,18 @@ export function formatContextManagementTemplate(
   _options?: { defaultOpen?: boolean },
 ): FormatResult {
   const { id, data } = message;
+
+  // Hide max_tokens_reduced events when the reduced value is still comfortable
+  const parsed = ContextManagementDataSchema.safeParse(data);
+  if (
+    parsed.success &&
+    parsed.data.action === 'max_tokens_reduced' &&
+    parsed.data.reducedMaxTokens !== undefined &&
+    parsed.data.reducedMaxTokens >= MAX_TOKENS_REDUCED_DISPLAY_THRESHOLD
+  ) {
+    return null;
+  }
+
   const result = buildContextManagementItems(data);
   if (!result) return null;
 


### PR DESCRIPTION
## Summary
This change improves the user experience by filtering out "Max Tokens Reduced" events when the reduction is minor and not actionable. Events are now only displayed when the adjusted max_tokens value falls below a comfortable threshold.

## Key Changes
- Added `MAX_TOKENS_REDUCED_DISPLAY_THRESHOLD` constant set to 32,768 tokens to define the minimum threshold for surfacing token reduction events
- Implemented filtering logic in `formatContextManagementTemplate()` to suppress `max_tokens_reduced` events when the reduced token value remains at or above the threshold
- Added early return (`null`) for filtered events to prevent unnecessary UI rendering

## Implementation Details
- The filtering uses `ContextManagementDataSchema.safeParse()` to safely validate the message data before checking the action type and reduced token count
- Only events with `action === 'max_tokens_reduced'` and `reducedMaxTokens >= MAX_TOKENS_REDUCED_DISPLAY_THRESHOLD` are hidden
- This prevents distracting users with notifications about minor token reductions that don't require their attention

https://claude.ai/code/session_017ALKN2DgVEnpvehTXS6Xny

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only filtering and minor refactor to parsing/typing; main risk is unintentionally hiding desired `max_tokens_reduced` events due to the new threshold logic.
> 
> **Overview**
> Progress view rendering now suppresses *minor* `contextManagement` events for `max_tokens_reduced` when the resulting `reducedMaxTokens` remains >= `32_768`, returning `null` so nothing is rendered.
> 
> `contextManagement` formatting was refactored to parse/validate with `ContextManagementDataSchema` in `formatContextManagementTemplate()` and pass typed `ContextManagementData` into `buildContextManagementItems()`, and `contextManagement` is added to `NULLABLE_TYPES` so omitted renders dont fall back to the default log template.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b8f665bd63d7e7511e25c85614456b561a1ab1b7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->