### PR TITLE
Design: Subagent Output Return and Execution Modes

### DIFF
--- a/docs/design/subagent-output-design.md
+++ b/docs/design/subagent-output-design.md
@@ -347,23 +347,6 @@ The difference: 3a requires the orchestrator to still be in an active session (W
 
 ---
 
-## Comparison Matrix
-
-| Dimension | Pattern 1: Sync | Pattern 2: Await-Async | Pattern 3: Come-Back-Later |
-|-----------|-----------------|----------------------|---------------------------|
-| **Complexity** | Low | Medium | Medium-High |
-| **New tools** | 0 | 1-2 (await, check) | 0 |
-| **New infrastructure** | `executeAgentWithResult()` | + `SubagentTracker` | + result formatting + lifetime mgmt |
-| **Blocking** | Full (entire subagent run) | Partial (only at await point) | None |
-| **Parallelism** | None | Yes (launch N, await N) | Yes (natural) |
-| **Result guarantee** | Always available | Available at await | May be lost if session ends |
-| **Model complexity** | Low (call returns result) | Medium (remember IDs) | High (handle async messages) |
-| **Existing infra reuse** | `executeAgent` + `ToolResult` | + `BasePromiseCoordinator` pattern | + `FollowUpQueue` |
-| **Timeout risk** | High (long subagents) | Low-Medium | None |
-| **User interactivity** | Blocked during subagent | Partial | Full |
-
----
-
 ## Recommendation: Phased Implementation
 
 ### Phase 1: Sync (Pattern 1)
@@ -479,17 +462,259 @@ export async function executeAgentWithResult(
 
 ---
 
+## Parallel Tool Calling Considerations
+
+### Current behavior
+
+The orchestrator model can emit **multiple tool calls in a single response** (e.g., two `propose_workflow` calls for different files). Today these are dispatched through `ToolUseDispatchNode` which extends `BatchNode` — executing them **sequentially**, not in parallel (`ToolUseCycleFlow.ts:564`).
+
+A `ParallelBatchNode` exists (`node/index.ts:244-257`) that uses `Promise.all` but is **not currently used** for tool dispatch.
+
+### Impact per pattern
+
+**Pattern 1 (Sync)**: If the orchestrator emits two `propose_workflow` calls in one response, they run sequentially. Subagent A finishes, then subagent B starts. Total time = A + B. This is the worst case for parallel dispatch.
+
+To fix: Switch `ToolUseDispatchNode` from `BatchNode` to `ParallelBatchNode`. Both proposal tools would execute concurrently — each awaits its own subagent, and `Promise.all` collects both results. Total time = max(A, B). However, both tools block simultaneously, which means two approval dialogs may appear and two subagents run in parallel (API quota impact).
+
+**Pattern 2 (Await-Async)**: Natural fit. The orchestrator emits two `propose_workflow` calls in one response. Both launch immediately (non-blocking), both return subagent IDs. Later, the orchestrator emits two `await_subagent` calls in one response. With `ParallelBatchNode`, both awaits resolve concurrently. Even with `BatchNode`, the second `await` resolves near-instantly if the subagent finished while the first was being awaited.
+
+```
+Turn 1: [propose_workflow(A), propose_workflow(B)]  → "id-1", "id-2"
+Turn 2: [await_subagent(id-1), await_subagent(id-2)] → results
+```
+
+**Pattern 3 (Come-Back-Later)**: Parallel dispatch is irrelevant — all launches are non-blocking. Results arrive independently via `FollowUpQueue`.
+
+### Recommendation
+
+For Patterns 1 and 2, switching to `ParallelBatchNode` for `ToolUseDispatchNode` is a prerequisite for true parallel subagent execution. This is a one-line change (`extends ParallelBatchNode` instead of `extends BatchNode`) but has broader implications: **all** tool calls in a response would then execute concurrently, not just subagent proposals. This needs careful validation for tools that have side effects or ordering dependencies.
+
+A safer alternative: keep `BatchNode` as default, but let individual tools declare `parallelSafe: true`. The dispatch node could then partition calls into parallel-safe and sequential groups.
+
+---
+
+## Tool-Use Subagent Output Definition
+
+### Problem
+
+Workflow subagents produce structured `RoundOutput[]` (file locations, diffs, XML summaries). Tool-use subagents produce **conversational output** — there is no equivalent structured result.
+
+### Proposal: Last assistant response as output
+
+For tool-use subagents, define the output as the **last model assistant response text** from the conversation. This is already tracked:
+
+- `ToolUseProcessNode.post()` stores `workspace.assembly.lastResponse = execRes.text` when `endTurn` is true (`ToolUseCycleFlow.ts:513`)
+- The full `shared.conversation` (array of `ProviderMessage[]`) is maintained throughout the session and accessible at flow end (`ToolUseCycleNode.ts:156`)
+
+### Implementation
+
+Extend `RunToolUseFlowResult` to include the output:
+
+```typescript
+// Current
+export interface RunToolUseFlowResult {
+  status: EndGroupStatus;
+}
+
+// Proposed
+export interface RunToolUseFlowResult {
+  status: EndGroupStatus;
+  /** Last assistant text response (for subagent output reporting). */
+  lastResponse?: string;
+  /** Full conversation for detailed inspection (optional, large). */
+  conversation?: ProviderMessage[];
+}
+```
+
+In `runToolUseFlow()`, capture from the shared state before returning:
+
+```typescript
+// At end of runToolUseFlow(), before return:
+const lastAssistantMsg = shared.conversation
+  .filter(m => m.role === 'assistant')
+  .at(-1);
+const lastResponse = extractTextFromMessage(lastAssistantMsg);
+
+return { status, lastResponse };
+```
+
+### SubagentResult for tool-use agents
+
+```typescript
+// Add to the discriminated union:
+z.strictObject({
+  status: z.literal('completed'),
+  agentName: z.string(),
+  model: z.string(),
+  agentCategory: z.literal('toolUse'),
+  lastResponse: z.string(),           // Last assistant message text
+  // No roundOutputs/outputFiles — tool-use agents don't produce these
+})
+```
+
+This keeps the output lightweight (single string) while providing the meaningful content. The orchestrator can parse structured data from the response if the subagent was instructed to produce it (e.g., "return your findings as a JSON list").
+
+---
+
+## Parent-Child Agent Lineage
+
+### Problem
+
+Today, when a subagent is launched, there is no record of which orchestrator spawned it. This prevents:
+- Cascading cancellation (stop orchestrator → stop its subagents)
+- Progress tree views (show subagents nested under their parent)
+- Result routing (deliver subagent output back to the correct orchestrator)
+- Debugging (trace which agent spawned a failing subagent)
+
+### Proposal: SubagentLineage tracking
+
+Introduce a lightweight lineage record that links subagents to their parent orchestrator.
+
+```typescript
+// src/shared/schemas/subagent.ts
+
+export const SubagentLineageSchema = z.strictObject({
+  /** Unique ID for this subagent execution */
+  subagentId: z.string().uuid(),
+  /** StreamTabId of the parent orchestrator that spawned this subagent */
+  parentStreamId: StreamTabIdSchema,
+  /** ExecutionId of the parent orchestrator */
+  parentExecutionId: ExecutionIdSchema,
+  /** StreamTabId of the subagent itself */
+  childStreamId: StreamTabIdSchema,
+  /** ExecutionId of the subagent */
+  childExecutionId: ExecutionIdSchema,
+  /** Agent name of the child */
+  childAgentName: z.string(),
+  /** Agent category of the child */
+  childAgentCategory: z.enum(['workflow', 'toolUse']),
+  /** Timestamp when the subagent was launched */
+  launchedAt: z.number(),
+  /** Timestamp when the subagent completed (null if still running) */
+  completedAt: z.number().nullable(),
+});
+
+export type SubagentLineage = z.infer<typeof SubagentLineageSchema>;
+```
+
+### SubagentRegistry singleton
+
+```typescript
+class SubagentRegistry {
+  private readonly lineage = new Map<string, SubagentLineage>();
+
+  /** Register a new parent-child relationship */
+  register(entry: SubagentLineage): void {
+    this.lineage.set(entry.subagentId, entry);
+  }
+
+  /** Get all children of a parent stream */
+  getChildren(parentStreamId: StreamTabId): SubagentLineage[] {
+    return [...this.lineage.values()]
+      .filter(e => e.parentStreamId === parentStreamId);
+  }
+
+  /** Get the parent of a child stream */
+  getParent(childStreamId: StreamTabId): SubagentLineage | undefined {
+    return [...this.lineage.values()]
+      .find(e => e.childStreamId === childStreamId);
+  }
+
+  /** Mark a subagent as completed */
+  markCompleted(subagentId: string): void {
+    const entry = this.lineage.get(subagentId);
+    if (entry) entry.completedAt = Date.now();
+  }
+
+  /** Get all active (uncompleted) children of a parent */
+  getActiveChildren(parentStreamId: StreamTabId): SubagentLineage[] {
+    return this.getChildren(parentStreamId)
+      .filter(e => e.completedAt === null);
+  }
+
+  /** Clean up entries for a completed parent */
+  cleanupParent(parentStreamId: StreamTabId): void {
+    for (const [id, entry] of this.lineage) {
+      if (entry.parentStreamId === parentStreamId) {
+        this.lineage.delete(id);
+      }
+    }
+  }
+}
+
+export const subagentRegistry = new SubagentRegistry();
+```
+
+### Integration points
+
+1. **At launch time** (`WorkflowTool.ts`): When `executeAgentWithLogging()` / `executeAgentWithResult()` is called after approval, register the lineage entry. The parent's `streamId` and `executionId` are available from the tool's context (`getCurrentToolFileInteractionContext()`).
+
+2. **At completion time**: The `executeAgent()` wrapper marks the entry as completed. For Pattern 2/3, this triggers result delivery.
+
+3. **At cancellation time**: When an orchestrator is interrupted, `getActiveChildren()` can identify running subagents for cascading cancellation via `StreamStatusService`.
+
+4. **For ProgressBoard**: Emit lineage info on the event bus so the UI can render a tree:
+   ```typescript
+   bus.emit('subagentLaunched', {
+     parentStreamId,
+     childStreamId,
+     childAgentName,
+   });
+   ```
+
+### Depth limits
+
+For safety, enforce a maximum nesting depth (e.g., 3 levels). A subagent should not spawn its own subagents beyond this limit. Check at proposal time:
+
+```typescript
+function getLineageDepth(streamId: StreamTabId): number {
+  const parent = subagentRegistry.getParent(streamId);
+  if (!parent) return 0;
+  return 1 + getLineageDepth(parent.parentStreamId);
+}
+```
+
+---
+
+## Updated Comparison Matrix
+
+| Dimension | Pattern 1: Sync | Pattern 2: Await-Async | Pattern 3: Come-Back-Later |
+|-----------|-----------------|----------------------|---------------------------|
+| **Complexity** | Low | Medium | Medium-High |
+| **New tools** | 0 | 1-2 (await, check) | 0 |
+| **New infrastructure** | `executeAgentWithResult()` | + `SubagentTracker` | + result formatting + lifetime mgmt |
+| **Blocking** | Full (entire subagent run) | Partial (only at await point) | None |
+| **Parallelism** | Via ParallelBatchNode only | Yes (launch N, await N) | Yes (natural) |
+| **Parallel tool calls** | Works but serializes subagent duration | Best fit — launch is instant | Trivial — all non-blocking |
+| **Result guarantee** | Always available | Available at await | May be lost if session ends |
+| **Model complexity** | Low (call returns result) | Medium (remember IDs) | High (handle async messages) |
+| **Existing infra reuse** | `executeAgent` + `ToolResult` | + `BasePromiseCoordinator` | + `FollowUpQueue` |
+| **Timeout risk** | High (long subagents) | Low-Medium | None |
+| **User interactivity** | Blocked during subagent | Partial | Full |
+| **Lineage tracking** | Optional | Required (ID tracking) | Required (result routing) |
+| **Workflow output** | `RoundOutput[]` + file paths | Same | Same |
+| **Tool-use output** | `lastResponse` text | Same | Same |
+
+---
+
 ## Open Questions
 
-1. **Tool-use subagents**: Workflow agents produce file outputs. Tool-use agents produce conversational output (no `roundOutputs`). How should tool-use subagent results be structured? Options:
-   - Return the full conversation transcript
-   - Return only the final assistant message
-   - Return a structured summary (tool-use agents could write to a "result" field)
+1. **Output file reading**: Should the orchestrator receive file *contents* or just file *paths*? Paths are smaller but require the orchestrator to read files with a separate tool call. Contents are self-contained but can be large. A middle ground: include a short diff summary (already available in `RoundOutput.outputs[].diff`) and file paths.
 
-2. **Output file reading**: Should the orchestrator receive file *contents* or just file *paths*? Paths are smaller but require the orchestrator to read files. Contents are self-contained but can be large.
+2. **Timeout handling for Pattern 1**: What's the maximum acceptable blocking time? Should there be a configurable timeout that auto-switches to async mode? Provider-specific limits (Anthropic tool calls can run for several minutes; some providers may time out).
 
-3. **Timeout handling for Pattern 1**: What's the maximum acceptable blocking time? Should there be a configurable timeout that auto-switches to async mode?
+3. **Concurrent subagent limits**: Should there be a cap on how many subagents an orchestrator can launch simultaneously? The stream lock system prevents duplicate streams, but multiple distinct subagents could overwhelm API quotas. The `SubagentRegistry` can enforce this via `getActiveChildren().length`.
 
-4. **Concurrent subagent limits**: Should there be a cap on how many subagents an orchestrator can launch simultaneously? The stream lock system already prevents duplicate streams, but multiple distinct subagents could overwhelm API quotas.
+4. **Result formatting for Pattern 3**: How should async results be formatted when injected as follow-up messages? The model needs to distinguish subagent results from user messages. Proposal: XML-wrapped structured format that the model can parse:
+   ```xml
+   <subagent-result id="abc-123" agent="correct" status="completed">
+     <output-files>paper_correct_gemini3p_r0.tex</output-files>
+     <diff-summary>+42 -18 lines</diff-summary>
+   </subagent-result>
+   ```
 
-5. **Result formatting for Pattern 3**: How should async results be formatted when injected as follow-up messages? The model needs to distinguish subagent results from user messages. A structured prefix/wrapper would help: `[subagent-result: id=abc-123, agent=correct, status=completed]`.
+5. **ParallelBatchNode migration**: Should `ToolUseDispatchNode` switch to `ParallelBatchNode` unconditionally, or should it be opt-in per tool? Some tools may have ordering dependencies (e.g., file creation before file read). A `parallelSafe` tool metadata flag could gate this.
+
+6. **Nesting depth for subagent-of-subagent**: Proposed limit of 3 levels. Should this be configurable? What happens when a subagent tries to exceed the limit — hard error or silent degradation to sync?
+
+7. **Lineage persistence**: Should the `SubagentRegistry` persist across extension restarts (write to `ExecutionKVStore`), or is in-memory sufficient? Persistence would allow resume scenarios where the extension restarts mid-subagent-execution.

--- a/docs/design/subagent-output-design.md
+++ b/docs/design/subagent-output-design.md
@@ -302,26 +302,33 @@ One line. The tool blocks, the orchestrator waits, the result comes back as a `T
 ### Mode B: Launch-and-await (store the Promise)
 
 ```typescript
-// Launch
+// Launch — keep own reference to the promise, separate from lineage
 const promise = executeAgentCore(configPayload);
-pendingSubagents.set(subagentId, promise);
+pendingResults.set(subagentId, promise);
+registerSubagent(subagentId, parentStreamId, childStreamId, agentName, promise);
 return { output: `Launched subagent ${subagentId}` };
 
 // Later, in await_subagent tool:
-const result = await pendingSubagents.get(id);
+const result = await pendingResults.get(id);
+pendingResults.delete(id);
 return formatFlowResult(result);
 ```
 
-`pendingSubagents` is a `Map<string, Promise<AgentFlowResult>>`. That's it. Not a `SubagentTracker` class with `launch()`, `await()`, `status()`, and cleanup hooks. A Map of Promises. JavaScript already solved this problem.
+`pendingResults` is a `Map<string, Promise<AgentFlowResult>>`. It lives in the tool module, not in the lineage module. The lineage map tracks active children for lifecycle; `pendingResults` holds promises for the `await_subagent` tool to resolve. Each map has one job. The promise reference survives lineage auto-cleanup because it's a separate map.
 
 ### Mode C: Fire-and-deliver (via FollowUpQueue)
 
 ```typescript
 const orchestratorStreamId = getRequiredStreamId();
-executeAgentCore(configPayload).then(result => {
-  const msg = formatSubagentDelivery(subagentId, result);
-  ToolUseFollowUpQueue.enqueue(orchestratorStreamId, msg);
-});
+executeAgentCore(configPayload)
+  .then(result => {
+    const msg = formatSubagentDelivery(subagentId, result);
+    ToolUseFollowUpQueue.enqueue(orchestratorStreamId, msg);
+  })
+  .catch(err => {
+    const msg = formatSubagentError(subagentId, err);
+    ToolUseFollowUpQueue.enqueue(orchestratorStreamId, msg);
+  });
 return { output: `Launched subagent ${subagentId}. Result will be delivered.` };
 ```
 
@@ -496,6 +503,8 @@ Not for some future dream feature. It's needed NOW for:
 
 Don't build a registry class. Use a Map. Lives in `src/agent/runtime/` alongside `executeAgent.ts` and `StreamStatusService.ts` — it's about agent execution lifecycle, not specifically tool-use.
 
+The lineage map tracks **active children only** — for lifecycle queries (`hasActiveChildren`, `isSubagent`, cascading cancellation). It does NOT store promises or results. Mode B keeps its own `Promise` reference; mode C delivers via `.then()`. Each concern has one owner.
+
 ```typescript
 // src/agent/runtime/subagentLineage.ts
 
@@ -503,7 +512,6 @@ interface SubagentEntry {
   parentStreamId: StreamTabId;
   childStreamId: StreamTabId;
   childAgentName: string;
-  promise: Promise<AgentFlowResult>;
 }
 
 const activeSubagents = new Map<string, SubagentEntry>();
@@ -513,14 +521,16 @@ export function registerSubagent(
   parentStreamId: StreamTabId,
   childStreamId: StreamTabId,
   childAgentName: string,
-  promise: Promise<AgentFlowResult>,
+  promise: Promise<unknown>,
 ): void {
   activeSubagents.set(subagentId, {
     parentStreamId,
     childStreamId,
     childAgentName,
-    promise,
   });
+  // Auto-cleanup: entry removed when subagent settles (success or failure).
+  // By this point, Mode B already has its own reference to the promise,
+  // and Mode C has already wired .then()/.catch(). The lineage map's job is done.
   promise.finally(() => activeSubagents.delete(subagentId));
 }
 
@@ -539,9 +549,7 @@ export function isSubagent(streamId: StreamTabId): boolean {
 }
 ```
 
-No schemas. No classes. No timestamps. No `completedAt` field. The entry deletes itself when the promise settles. If you need to know it ran, check the logs.
-
-The `promise` field doubles as the handle for Mode B (launch-and-await). No separate `pendingSubagents` map needed.
+No schemas. No classes. No timestamps. No `completedAt` field. The entry deletes itself when the promise settles.
 
 ---
 

--- a/docs/design/subagent-output-design.md
+++ b/docs/design/subagent-output-design.md
@@ -1,0 +1,495 @@
+# Subagent Output Return Design
+
+## Problem Statement
+
+Today, when a tool-use orchestrator agent delegates work via `propose_workflow` or `propose_agent`, the subagent executes as **fire-and-forget**. The orchestrator receives a simple confirmation string ("Workflow agent 'correct' started. Monitor ProgressBoard for status.") and has no mechanism to receive the subagent's actual output.
+
+**Current flow** (`WorkflowTool.ts:308`):
+
+```
+Orchestrator calls propose_workflow
+  → User approves proposal
+  → executeAgentWithLogging(proposal)   // fire-and-forget, not awaited
+  → return { summary: "Started 'correct' on paper.tex" }
+```
+
+The orchestrator cannot:
+- Know when the subagent finished
+- Read the subagent's output files
+- React to subagent errors
+- Make decisions based on subagent results
+
+This document proposes three return patterns—**sync**, **await-async**, and **async-come-back-later**—and analyzes their fit with the existing architecture.
+
+---
+
+## Current Architecture Summary
+
+### What exists today
+
+| Component | Role | Key file |
+|-----------|------|----------|
+| `propose_workflow` tool | Proposes workflow agent, awaits user approval, fires agent | `src/tools/WorkflowTool.ts` |
+| `propose_agent` tool | Proposes tool-use agent, same pattern | `src/tools/WorkflowTool.ts` |
+| `AgentProposalCoordinator` | Promise-based coordinator for user approval | `src/agent/runtime/AgentProposalCoordinator.ts` |
+| `BasePromiseCoordinator` | Generic promise infrastructure (show/resolve events) | `src/agent/runtime/BasePromiseCoordinator.ts` |
+| `executeAgent()` | Resolves agent, acquires stream lock, runs flow | `src/agent/runtime/executeAgent.ts` |
+| `runReflectionFlow()` | Workflow execution, returns `{ roundOutputs, status }` | `src/agent/implementations/flows/reflection/runReflectionFlow.ts` |
+| `runToolUseFlow()` | Tool-use execution, returns `{ status }` | `src/agent/implementations/flows/tooluse/` |
+| `FollowUpQueue` | Promise-based message queue for tool-use sessions | `src/agent/toolUse/FollowUpQueue.ts` |
+| `StreamStatusService` | Tracks stream execution state (RUNNING/STOPPED/etc.) | `src/agent/runtime/StreamStatusService.ts` |
+| `ProgressEventBus` | Pub/sub with buffering for UI events | `src/eventBus/ProgressEventBus.ts` |
+
+### Key observations
+
+1. **`executeAgent()` already returns a Promise** that resolves when the flow completes. The result (`EndGroupStatus`) and `roundOutputs` are available—they just aren't surfaced to the calling tool.
+
+2. **Stream locking prevents concurrent execution** on the same streamId. Subagents get their own streamId, so they run independently.
+
+3. **The proposal coordinator pattern** (BasePromiseCoordinator) already demonstrates how to bridge async operations with promise-based waiting.
+
+4. **Workflow agents produce structured output** (`RoundOutput[]`) containing file locations, diffs, and XML summaries. Tool-use agents produce conversational output.
+
+5. **The FollowUpQueue** demonstrates a message-passing pattern between independent execution contexts.
+
+---
+
+## Proposed Patterns
+
+### Pattern 1: Synchronous (Await in Tool Call)
+
+**Concept**: The `propose_workflow` / `propose_agent` tool awaits the subagent's full execution and returns the result as part of its `ToolResult`.
+
+**Flow**:
+
+```
+Orchestrator model calls propose_workflow(agent=correct, inputFile=paper.tex)
+  → User approves
+  → const result = await executeAgentAndCollectOutput(proposal)
+  → return ToolResult { output: result.summary, files: result.outputFiles }
+```
+
+**Implementation sketch**:
+
+```typescript
+// In WorkflowTool.ts, replace executeAgentWithLogging(proposal)
+
+async function executeAgentAndCollectOutput(
+  proposal: WorkflowAgentProposal,
+): Promise<SubagentResult> {
+  const configPayload: AgentConfigPayload = { ...proposal, agentCategory: ... };
+
+  // executeAgent already returns Promise<void>, but internally has the result.
+  // New variant: executeAgentWithResult() returns the flow result.
+  const result = await executeAgentWithResult(configPayload);
+
+  return {
+    status: result.status,
+    roundOutputs: result.roundOutputs,
+    outputFiles: result.roundOutputs.flatMap(r =>
+      r.outputs.map(o => o.location.absolutePath)
+    ),
+    summary: formatSubagentSummary(result),
+  };
+}
+```
+
+**Changes required**:
+
+1. **New `executeAgentWithResult()`** in `executeAgent.ts` — like `executeAgent()` but returns `RunReflectionFlowResult` instead of `void`. Minimal change: the flow result is already computed at lines 484-490, just needs to be returned.
+
+2. **Updated `WorkflowAgentTool.execute()`** — await the execution instead of fire-and-forget. Format the result into a `ToolResult` with output file paths and summary text.
+
+3. **Streaming progress** — since the tool call blocks for the full subagent duration, the orchestrator's tool-use cycle pauses. The event bus already streams progress to the ProgressBoard UI, so the user sees real-time updates. But the orchestrator model receives nothing until completion.
+
+**Pros**:
+- Simplest mental model—tool returns result, orchestrator continues
+- No new infrastructure needed
+- Output is guaranteed available when orchestrator resumes
+- Natural fit for PocketFlow's sequential node execution
+
+**Cons**:
+- **Long blocking**: A workflow agent can run for many minutes. The orchestrator's tool-use cycle is frozen during this time. The model's connection may time out (provider-dependent).
+- **No parallelism**: Orchestrator cannot dispatch multiple subagents concurrently.
+- **Stream lock**: The orchestrator holds its own stream lock the entire time. If the user wants to interact with the orchestrator during subagent execution, they cannot.
+
+**Best for**: Short, deterministic subagent tasks (single-round corrections, quick merges).
+
+---
+
+### Pattern 2: Await-Async (Launch, Then Await)
+
+**Concept**: The tool call launches the subagent and immediately returns a handle/ticket. The orchestrator can then explicitly await the result using a second tool call (`await_subagent`), or do other work first.
+
+**Flow**:
+
+```
+1. Orchestrator calls propose_workflow(agent=correct, inputFile=paper.tex)
+     → User approves
+     → subagentId = launchSubagent(proposal)   // non-blocking
+     → return ToolResult { output: "Launched subagent abc-123" }
+
+2. Orchestrator does other work (calls other tools, reasons, etc.)
+
+3. Orchestrator calls await_subagent(id=abc-123)
+     → blocks until subagent completes
+     → return ToolResult { output: result.summary, files: result.outputFiles }
+```
+
+**Implementation sketch**:
+
+```typescript
+// New: SubagentTracker singleton
+class SubagentTracker {
+  private readonly pending = new Map<string, Promise<SubagentResult>>();
+  private readonly results = new Map<string, SubagentResult>();
+
+  launch(id: string, proposal: AgentProposal): void {
+    const promise = executeAgentWithResult(proposal)
+      .then(result => {
+        this.results.set(id, result);
+        this.pending.delete(id);
+        return result;
+      })
+      .catch(err => {
+        const errorResult: SubagentResult = { status: 'error', error: err.message };
+        this.results.set(id, errorResult);
+        this.pending.delete(id);
+        return errorResult;
+      });
+    this.pending.set(id, promise);
+  }
+
+  async await(id: string): Promise<SubagentResult> {
+    // Already completed?
+    const existing = this.results.get(id);
+    if (existing) return existing;
+
+    // Still running?
+    const pending = this.pending.get(id);
+    if (pending) return pending;
+
+    throw new Error(`Unknown subagent: ${id}`);
+  }
+
+  /** Check status without blocking */
+  status(id: string): 'pending' | 'completed' | 'error' | 'unknown' {
+    if (this.results.has(id)) {
+      return this.results.get(id)!.status === 'error' ? 'error' : 'completed';
+    }
+    if (this.pending.has(id)) return 'pending';
+    return 'unknown';
+  }
+}
+```
+
+**New tools**:
+
+```typescript
+// await_subagent tool
+const AwaitSubagentSchema = z.object({
+  id: z.string().describe('Subagent ID returned by propose_workflow/propose_agent'),
+});
+
+class AwaitSubagentTool extends defineTool({
+  name: 'await_subagent',
+  description: 'Wait for a previously launched subagent to complete and get its result.',
+  schema: AwaitSubagentSchema,
+}) {
+  async execute(input): Promise<ToolResult> {
+    const result = await subagentTracker.await(input.id);
+    return formatSubagentResult(result);
+  }
+}
+
+// check_subagent tool (optional, for polling)
+class CheckSubagentTool extends defineTool({
+  name: 'check_subagent',
+  description: 'Check the status of a launched subagent without blocking.',
+  schema: z.object({ id: z.string() }),
+}) {
+  async execute(input): Promise<ToolResult> {
+    const status = subagentTracker.status(input.id);
+    if (status === 'completed') {
+      return formatSubagentResult(subagentTracker.getResult(input.id));
+    }
+    return { output: `Subagent ${input.id}: ${status}` };
+  }
+}
+```
+
+**Changes required**:
+
+1. **`SubagentTracker`** — new singleton that manages launched subagent promises and stores their results. Lives alongside `AgentProposalCoordinator`.
+
+2. **`executeAgentWithResult()`** — same as Pattern 1.
+
+3. **Updated `propose_workflow` / `propose_agent`** — after approval, calls `subagentTracker.launch(id, proposal)` instead of `executeAgentWithLogging()`. Returns the subagent ID.
+
+4. **New `await_subagent` tool** — blocks on the tracker's promise. Returns structured result.
+
+5. **Optional `check_subagent` tool** — non-blocking status check.
+
+6. **Cleanup** — results must be evicted after the orchestrator's session ends. Tie cleanup to stream disposal via `StreamStatusService`.
+
+**Pros**:
+- Orchestrator can do useful work while subagent runs
+- Supports launching multiple subagents concurrently, then awaiting all
+- Clean separation: launch is fast, await is explicit
+- The await point is chosen by the orchestrator, not forced
+
+**Cons**:
+- Two tool calls per subagent interaction (launch + await)
+- Model must remember the subagent ID across turns
+- More complex mental model for the LLM
+- Still blocks when awaiting (though only at the orchestrator's chosen point)
+
+**Best for**: Multi-step orchestration where the orchestrator dispatches several subagents and collects results.
+
+---
+
+### Pattern 3: Async Come-Back-Later (Event-Driven Delivery)
+
+**Concept**: The subagent runs fully asynchronously. When it completes, its output is injected into the orchestrator's conversation as a follow-up message, similar to how `FollowUpQueue` works for user messages.
+
+**Flow**:
+
+```
+1. Orchestrator calls propose_workflow(agent=correct, inputFile=paper.tex)
+     → User approves
+     → launch subagent with completion callback
+     → return ToolResult { output: "Subagent abc-123 launched. Results will be delivered automatically." }
+
+2. Orchestrator continues its conversation normally
+
+3. [Subagent completes in background]
+     → Completion callback fires
+     → Result injected into orchestrator's FollowUpQueue
+     → ToolUsePrepNode picks it up before next model call
+
+4. Orchestrator's next turn sees:
+   "[Subagent result: correct on paper.tex]
+    Status: completed
+    Output files: paper_correct_gemini3p_r0.tex
+    Changes: +42 -18 lines"
+```
+
+**Implementation sketch**:
+
+```typescript
+// In WorkflowTool.ts after approval:
+const subagentId = randomUUID();
+const orchestratorStreamId = getRequiredStreamId();
+
+executeAgentWithResult(configPayload)
+  .then(result => {
+    const message = formatSubagentCompletion(subagentId, proposal, result);
+    // Inject into orchestrator's follow-up queue
+    ToolUseFollowUpQueueManager.enqueue(orchestratorStreamId, message);
+  })
+  .catch(err => {
+    const message = formatSubagentError(subagentId, proposal, err);
+    ToolUseFollowUpQueueManager.enqueue(orchestratorStreamId, message);
+  });
+
+return {
+  summary: `Launched '${input.agent}' (id: ${subagentId})`,
+  output: 'Subagent launched. Results will appear in your conversation when ready.',
+};
+```
+
+**The FollowUpQueue already supports this pattern**:
+
+- `ToolUsePrepNode` (in `ToolUseCycleFlow.ts:198-228`) checks for queued follow-ups before every model call
+- If a follow-up exists, it's injected as a user message
+- The model sees it and can react in its next response
+- The queue handles the timing: if the model is mid-generation, the message waits; if the model is idle (in WaitNode), the message triggers a new cycle
+
+**Two sub-variants**:
+
+**3a. Deliver on next turn**: Result enters `FollowUpQueue`. Orchestrator sees it only when it naturally loops back (after current tool execution completes and the model generates a response that the user follows up on — or the WaitNode triggers).
+
+**3b. Interrupt current turn**: Result enters `FollowUpQueue` and additionally signals the orchestrator's cycle to check for follow-ups. This requires cooperation from `ToolUsePrepNode` which already does this check.
+
+The difference: 3a requires the orchestrator to still be in an active session (WaitNode). 3b works even if the orchestrator is mid-generation, but the message won't be seen until the current cycle's prep phase.
+
+**Changes required**:
+
+1. **`executeAgentWithResult()`** — same as Pattern 1 and 2.
+
+2. **Updated `propose_workflow` / `propose_agent`** — after approval, launch with a completion callback that enqueues to the orchestrator's `FollowUpQueue`.
+
+3. **Subagent result formatting** — structured message format that the orchestrator's model can parse.
+
+4. **Session lifetime management** — if the orchestrator's session has ended by the time the subagent completes, the result has nowhere to go. Options:
+   - Store results in persistent storage, deliver on session resume
+   - Emit to ProgressBoard as a fallback notification
+   - Both (store + notify)
+
+5. **Optional: `SubagentResultStore`** — persistent storage for results that outlive sessions. Allows the user to resume the orchestrator and see what happened.
+
+**Pros**:
+- Zero blocking—orchestrator never waits
+- Natural conversation flow—results appear as messages
+- Leverages existing `FollowUpQueue` infrastructure
+- Subagent completion can arrive at any point in the conversation
+- Multiple subagents complete independently and results stream in
+
+**Cons**:
+- Orchestrator model must handle results arriving at unpredictable times
+- Results may arrive mid-conversation about a different topic
+- No guarantee the orchestrator is still running when results arrive
+- Requires careful session lifetime management
+- Model may not "remember" what it dispatched if many turns have passed
+- Testing is harder (non-deterministic timing)
+
+**Best for**: Long-running subagents where the orchestrator or user continues working. Research agents that take minutes. Background batch processing.
+
+---
+
+## Comparison Matrix
+
+| Dimension | Pattern 1: Sync | Pattern 2: Await-Async | Pattern 3: Come-Back-Later |
+|-----------|-----------------|----------------------|---------------------------|
+| **Complexity** | Low | Medium | Medium-High |
+| **New tools** | 0 | 1-2 (await, check) | 0 |
+| **New infrastructure** | `executeAgentWithResult()` | + `SubagentTracker` | + result formatting + lifetime mgmt |
+| **Blocking** | Full (entire subagent run) | Partial (only at await point) | None |
+| **Parallelism** | None | Yes (launch N, await N) | Yes (natural) |
+| **Result guarantee** | Always available | Available at await | May be lost if session ends |
+| **Model complexity** | Low (call returns result) | Medium (remember IDs) | High (handle async messages) |
+| **Existing infra reuse** | `executeAgent` + `ToolResult` | + `BasePromiseCoordinator` pattern | + `FollowUpQueue` |
+| **Timeout risk** | High (long subagents) | Low-Medium | None |
+| **User interactivity** | Blocked during subagent | Partial | Full |
+
+---
+
+## Recommendation: Phased Implementation
+
+### Phase 1: Sync (Pattern 1)
+
+Start here. It requires the least new code and provides immediate value:
+
+1. Add `executeAgentWithResult()` to `executeAgent.ts` — ~30 lines, wraps existing `executeAgent()` to return `RunReflectionFlowResult`.
+2. Update `WorkflowAgentTool.execute()` to await and return the result.
+3. Add a `mode: 'sync' | 'async'` parameter to the tool schema (default `'sync'`).
+
+This unblocks the core use case: orchestrator dispatches a correction agent, gets the result, decides what to do next.
+
+### Phase 2: Await-Async (Pattern 2)
+
+Add when orchestrators need to dispatch multiple subagents:
+
+1. Build `SubagentTracker` (follows `BasePromiseCoordinator` pattern).
+2. Add `await_subagent` tool.
+3. When `mode: 'async'`, launch via tracker instead of awaiting inline.
+
+### Phase 3: Come-Back-Later (Pattern 3)
+
+Add for long-running background agents:
+
+1. Wire completion callback to `FollowUpQueue`.
+2. Add `SubagentResultStore` for persistence across sessions.
+3. Integrate with ProgressBoard for result notifications.
+
+### Why this order?
+
+- Each phase builds on the previous (executeAgentWithResult → SubagentTracker → FollowUpQueue delivery)
+- Sync is the minimum viable feature
+- Await-async requires the model to understand subagent IDs (prompt engineering)
+- Come-back-later requires session lifetime management (most complex)
+
+---
+
+## Shared Infrastructure: `SubagentResult` Schema
+
+All three patterns need a common result type:
+
+```typescript
+// src/shared/schemas/subagent.ts
+
+export const SubagentResultSchema = z.discriminatedUnion('status', [
+  z.strictObject({
+    status: z.literal('completed'),
+    agentName: z.string(),
+    model: z.string(),
+    roundOutputs: RoundOutputSchema.array(),
+    outputFiles: FileLocationSchema.array(),
+    totalRounds: z.number(),
+    summary: z.string(),
+  }),
+  z.strictObject({
+    status: z.literal('error'),
+    agentName: z.string(),
+    model: z.string(),
+    error: z.string(),
+  }),
+  z.strictObject({
+    status: z.literal('cancelled'),
+    agentName: z.string(),
+    model: z.string(),
+    reason: z.string(),
+  }),
+]);
+
+export type SubagentResult = z.infer<typeof SubagentResultSchema>;
+```
+
+## Shared Infrastructure: `executeAgentWithResult()`
+
+The key enabling function for all patterns:
+
+```typescript
+// In executeAgent.ts
+
+export async function executeAgentWithResult(
+  configPayload: AgentConfigPayload,
+  executionId?: ExecutionId,
+): Promise<SubagentResult> {
+  // Reuse all existing resolution logic
+  const ctx = await resolveAgentBase(configPayload, executionId);
+  const { setting, streamId, config } = ctx;
+
+  try {
+    acquireStreamOrThrow(streamId);
+
+    // Run the flow (same as executeAgent, but capture result)
+    const flowResult = await runFlowCore(ctx, streamId);
+
+    return {
+      status: 'completed',
+      agentName: config.agent,
+      model: config.model,
+      roundOutputs: flowResult.roundOutputs ?? [],
+      outputFiles: (flowResult.roundOutputs ?? [])
+        .flatMap(r => r.outputs.map(o => o.location)),
+      totalRounds: flowResult.roundOutputs?.length ?? 0,
+      summary: buildSummary(config, flowResult),
+    };
+  } catch (err) {
+    return {
+      status: 'error',
+      agentName: config.agent,
+      model: config.model,
+      error: toErrorMessage(err),
+    };
+  }
+}
+```
+
+---
+
+## Open Questions
+
+1. **Tool-use subagents**: Workflow agents produce file outputs. Tool-use agents produce conversational output (no `roundOutputs`). How should tool-use subagent results be structured? Options:
+   - Return the full conversation transcript
+   - Return only the final assistant message
+   - Return a structured summary (tool-use agents could write to a "result" field)
+
+2. **Output file reading**: Should the orchestrator receive file *contents* or just file *paths*? Paths are smaller but require the orchestrator to read files. Contents are self-contained but can be large.
+
+3. **Timeout handling for Pattern 1**: What's the maximum acceptable blocking time? Should there be a configurable timeout that auto-switches to async mode?
+
+4. **Concurrent subagent limits**: Should there be a cap on how many subagents an orchestrator can launch simultaneously? The stream lock system already prevents duplicate streams, but multiple distinct subagents could overwhelm API quotas.
+
+5. **Result formatting for Pattern 3**: How should async results be formatted when injected as follow-up messages? The model needs to distinguish subagent results from user messages. A structured prefix/wrapper would help: `[subagent-result: id=abc-123, agent=correct, status=completed]`.

--- a/docs/design/subagent-output-design.md
+++ b/docs/design/subagent-output-design.md
@@ -1,517 +1,100 @@
 # Subagent Output Return Design
 
-## Problem Statement
+## The Actual Problem
 
-Today, when a tool-use orchestrator agent delegates work via `propose_workflow` or `propose_agent`, the subagent executes as **fire-and-forget**. The orchestrator receives a simple confirmation string ("Workflow agent 'correct' started. Monitor ProgressBoard for status.") and has no mechanism to receive the subagent's actual output.
-
-**Current flow** (`WorkflowTool.ts:308`):
+`executeAgent()` returns `void`. The flow result is computed, then discarded.
 
 ```
-Orchestrator calls propose_workflow
-  → User approves proposal
-  → executeAgentWithLogging(proposal)   // fire-and-forget, not awaited
-  → return { summary: "Started 'correct' on paper.tex" }
+WorkflowTool.execute()
+  → executeAgentWithLogging(proposal)    // fire-and-forget, discards Promise
+    → executeAgent(configPayload)        // returns Promise<void>
+      → runFlowWithLifecycle(ctx, ...)   // only passes status to lifecycle
+        → runReflectionFlow(...)         // returns { roundOutputs, status }
+        → return result.status           // ← roundOutputs thrown away here
 ```
 
-The orchestrator cannot:
-- Know when the subagent finished
-- Read the subagent's output files
-- React to subagent errors
-- Make decisions based on subagent results
+`runReflectionFlow()` already returns `{ roundOutputs: RoundOutput[], status }`. `RoundOutput` already contains everything the orchestrator needs: output file locations, diff stats, file lineage. The data exists. It's just discarded at `executeAgent.ts:490` because `runFlowWithLifecycle` only captures `EndGroupStatus`.
 
-This document proposes three return patterns—**sync**, **await-async**, and **async-come-back-later**—and analyzes their fit with the existing architecture.
+For tool-use agents, `runToolUseFlow()` returns `{ status }` — no output data at all. But the conversation and last response ARE in `shared` at flow end. They're just not surfaced.
+
+This is not a "three-pattern design problem." This is a function signature bug.
 
 ---
 
-## Current Architecture Summary
+## What Each Agent Type Actually Produces
 
-### What exists today
+### Workflow agents: Generated files
 
-| Component | Role | Key file |
-|-----------|------|----------|
-| `propose_workflow` tool | Proposes workflow agent, awaits user approval, fires agent | `src/tools/WorkflowTool.ts` |
-| `propose_agent` tool | Proposes tool-use agent, same pattern | `src/tools/WorkflowTool.ts` |
-| `AgentProposalCoordinator` | Promise-based coordinator for user approval | `src/agent/runtime/AgentProposalCoordinator.ts` |
-| `BasePromiseCoordinator` | Generic promise infrastructure (show/resolve events) | `src/agent/runtime/BasePromiseCoordinator.ts` |
-| `executeAgent()` | Resolves agent, acquires stream lock, runs flow | `src/agent/runtime/executeAgent.ts` |
-| `runReflectionFlow()` | Workflow execution, returns `{ roundOutputs, status }` | `src/agent/implementations/flows/reflection/runReflectionFlow.ts` |
-| `runToolUseFlow()` | Tool-use execution, returns `{ status }` | `src/agent/implementations/flows/tooluse/` |
-| `FollowUpQueue` | Promise-based message queue for tool-use sessions | `src/agent/toolUse/FollowUpQueue.ts` |
-| `StreamStatusService` | Tracks stream execution state (RUNNING/STOPPED/etc.) | `src/agent/runtime/StreamStatusService.ts` |
-| `ProgressEventBus` | Pub/sub with buffering for UI events | `src/eventBus/ProgressEventBus.ts` |
+The orchestrator needs the **file artifacts**, not the raw model response.
 
-### Key observations
+`OutputNode` produces a `RoundOutput` per round (`ReflectionFlow OutputNode.ts:91-213`). By flow end, `shared.roundOutputs` is a complete array. Each `RoundOutput` contains:
 
-1. **`executeAgent()` already returns a Promise** that resolves when the flow completes. The result (`EndGroupStatus`) and `roundOutputs` are available—they just aren't surfaced to the calling tool.
+```
+RoundOutput
+├── round: number
+├── rawOutput: FileLocation | null          ← raw XML/text (not useful to orchestrator)
+├── outputs: OutputFileInfo[]               ← THE ACTUAL OUTPUT
+│   ├── source: string                      ← source tag
+│   ├── location: FileLocation              ← WHERE the output file is
+│   │   ├── absolutePath: string
+│   │   ├── relativePath: string
+│   │   └── kind: 'workspace' | 'runStorage'
+│   ├── round: number
+│   ├── lineage                             ← file relationships
+│   │   ├── original: FileLocation | null   ← base input file
+│   │   ├── diffBase: FileLocation | null   ← file compared against
+│   │   └── diffFile: FileLocation | null   ← compiled diff PDF
+│   └── diff: DiffStats | null              ← WHAT CHANGED
+│       ├── added: number
+│       └── removed: number
+└── xmlSummary: OutputXmlSummary            ← XML metadata (internal)
+```
 
-2. **Stream locking prevents concurrent execution** on the same streamId. Subagents get their own streamId, so they run independently.
+What the orchestrator actually cares about from this:
 
-3. **The proposal coordinator pattern** (BasePromiseCoordinator) already demonstrates how to bridge async operations with promise-based waiting.
+| Field | Why |
+|-------|-----|
+| `outputs[].location.relativePath` | Where to find the generated file |
+| `outputs[].diff.added / .removed` | How much changed (quality signal) |
+| `outputs[].lineage.original` | Which input file this came from |
+| `status` | Did it succeed |
 
-4. **Workflow agents produce structured output** (`RoundOutput[]`) containing file locations, diffs, and XML summaries. Tool-use agents produce conversational output.
+That's it. Not the XML summary. Not the raw output. Not the conversation. The **files and their diffs**.
 
-5. **The FollowUpQueue** demonstrates a message-passing pattern between independent execution contexts.
+### Tool-use agents: Last assistant response
+
+Tool-use agents don't produce files through the flow — they produce conversational output. The right output is the **last assistant response text**.
+
+This is already tracked at `ToolUseCycleFlow.ts:513`:
+```typescript
+workspace.assembly.lastResponse = execRes.text;  // stored on endTurn
+```
+
+And the full conversation is in `shared.conversation` at flow end (`ToolUseCycleNode.ts:156`).
+
+But `runToolUseFlow()` discards both — it returns only `{ status }`.
 
 ---
 
-## Proposed Patterns
+## Root Cause: `executeAgent()` Conflates Two Concerns
 
-### Pattern 1: Synchronous (Await in Tool Call)
+`executeAgent()` does two unrelated things:
 
-**Concept**: The `propose_workflow` / `propose_agent` tool awaits the subagent's full execution and returns the result as part of its `ToolResult`.
+1. **Run the flow** — resolve agent, build context, execute, get result
+2. **Manage UI lifecycle** — acquire stream lock, show notifications, display errors, set stream status
 
-**Flow**:
+These are tangled together. The command layer (UI buttons, commands) needs #2. The tool layer (subagent proposals) needs #1. Today both callers go through the same function, so the tool layer gets the UI lifecycle it doesn't need and loses the result it does need.
 
-```
-Orchestrator model calls propose_workflow(agent=correct, inputFile=paper.tex)
-  → User approves
-  → const result = await executeAgentAndCollectOutput(proposal)
-  → return ToolResult { output: result.summary, files: result.outputFiles }
-```
+---
 
-**Implementation sketch**:
+## Proposed Refactoring: Split `executeAgent`
+
+### Step 1: Make the flows return their output
+
+**`runToolUseFlow`** — add `lastResponse` to its result:
 
 ```typescript
-// In WorkflowTool.ts, replace executeAgentWithLogging(proposal)
-
-async function executeAgentAndCollectOutput(
-  proposal: WorkflowAgentProposal,
-): Promise<SubagentResult> {
-  const configPayload: AgentConfigPayload = { ...proposal, agentCategory: ... };
-
-  // executeAgent already returns Promise<void>, but internally has the result.
-  // New variant: executeAgentWithResult() returns the flow result.
-  const result = await executeAgentWithResult(configPayload);
-
-  return {
-    status: result.status,
-    roundOutputs: result.roundOutputs,
-    outputFiles: result.roundOutputs.flatMap(r =>
-      r.outputs.map(o => o.location.absolutePath)
-    ),
-    summary: formatSubagentSummary(result),
-  };
-}
-```
-
-**Changes required**:
-
-1. **New `executeAgentWithResult()`** in `executeAgent.ts` — like `executeAgent()` but returns `RunReflectionFlowResult` instead of `void`. Minimal change: the flow result is already computed at lines 484-490, just needs to be returned.
-
-2. **Updated `WorkflowAgentTool.execute()`** — await the execution instead of fire-and-forget. Format the result into a `ToolResult` with output file paths and summary text.
-
-3. **Streaming progress** — since the tool call blocks for the full subagent duration, the orchestrator's tool-use cycle pauses. The event bus already streams progress to the ProgressBoard UI, so the user sees real-time updates. But the orchestrator model receives nothing until completion.
-
-**Pros**:
-- Simplest mental model—tool returns result, orchestrator continues
-- No new infrastructure needed
-- Output is guaranteed available when orchestrator resumes
-- Natural fit for PocketFlow's sequential node execution
-
-**Cons**:
-- **Long blocking**: A workflow agent can run for many minutes. The orchestrator's tool-use cycle is frozen during this time. The model's connection may time out (provider-dependent).
-- **No parallelism**: Orchestrator cannot dispatch multiple subagents concurrently.
-- **Stream lock**: The orchestrator holds its own stream lock the entire time. If the user wants to interact with the orchestrator during subagent execution, they cannot.
-
-**Best for**: Short, deterministic subagent tasks (single-round corrections, quick merges).
-
----
-
-### Pattern 2: Await-Async (Launch, Then Await)
-
-**Concept**: The tool call launches the subagent and immediately returns a handle/ticket. The orchestrator can then explicitly await the result using a second tool call (`await_subagent`), or do other work first.
-
-**Flow**:
-
-```
-1. Orchestrator calls propose_workflow(agent=correct, inputFile=paper.tex)
-     → User approves
-     → subagentId = launchSubagent(proposal)   // non-blocking
-     → return ToolResult { output: "Launched subagent abc-123" }
-
-2. Orchestrator does other work (calls other tools, reasons, etc.)
-
-3. Orchestrator calls await_subagent(id=abc-123)
-     → blocks until subagent completes
-     → return ToolResult { output: result.summary, files: result.outputFiles }
-```
-
-**Implementation sketch**:
-
-```typescript
-// New: SubagentTracker singleton
-class SubagentTracker {
-  private readonly pending = new Map<string, Promise<SubagentResult>>();
-  private readonly results = new Map<string, SubagentResult>();
-
-  launch(id: string, proposal: AgentProposal): void {
-    const promise = executeAgentWithResult(proposal)
-      .then(result => {
-        this.results.set(id, result);
-        this.pending.delete(id);
-        return result;
-      })
-      .catch(err => {
-        const errorResult: SubagentResult = { status: 'error', error: err.message };
-        this.results.set(id, errorResult);
-        this.pending.delete(id);
-        return errorResult;
-      });
-    this.pending.set(id, promise);
-  }
-
-  async await(id: string): Promise<SubagentResult> {
-    // Already completed?
-    const existing = this.results.get(id);
-    if (existing) return existing;
-
-    // Still running?
-    const pending = this.pending.get(id);
-    if (pending) return pending;
-
-    throw new Error(`Unknown subagent: ${id}`);
-  }
-
-  /** Check status without blocking */
-  status(id: string): 'pending' | 'completed' | 'error' | 'unknown' {
-    if (this.results.has(id)) {
-      return this.results.get(id)!.status === 'error' ? 'error' : 'completed';
-    }
-    if (this.pending.has(id)) return 'pending';
-    return 'unknown';
-  }
-}
-```
-
-**New tools**:
-
-```typescript
-// await_subagent tool
-const AwaitSubagentSchema = z.object({
-  id: z.string().describe('Subagent ID returned by propose_workflow/propose_agent'),
-});
-
-class AwaitSubagentTool extends defineTool({
-  name: 'await_subagent',
-  description: 'Wait for a previously launched subagent to complete and get its result.',
-  schema: AwaitSubagentSchema,
-}) {
-  async execute(input): Promise<ToolResult> {
-    const result = await subagentTracker.await(input.id);
-    return formatSubagentResult(result);
-  }
-}
-
-// check_subagent tool (optional, for polling)
-class CheckSubagentTool extends defineTool({
-  name: 'check_subagent',
-  description: 'Check the status of a launched subagent without blocking.',
-  schema: z.object({ id: z.string() }),
-}) {
-  async execute(input): Promise<ToolResult> {
-    const status = subagentTracker.status(input.id);
-    if (status === 'completed') {
-      return formatSubagentResult(subagentTracker.getResult(input.id));
-    }
-    return { output: `Subagent ${input.id}: ${status}` };
-  }
-}
-```
-
-**Changes required**:
-
-1. **`SubagentTracker`** — new singleton that manages launched subagent promises and stores their results. Lives alongside `AgentProposalCoordinator`.
-
-2. **`executeAgentWithResult()`** — same as Pattern 1.
-
-3. **Updated `propose_workflow` / `propose_agent`** — after approval, calls `subagentTracker.launch(id, proposal)` instead of `executeAgentWithLogging()`. Returns the subagent ID.
-
-4. **New `await_subagent` tool** — blocks on the tracker's promise. Returns structured result.
-
-5. **Optional `check_subagent` tool** — non-blocking status check.
-
-6. **Cleanup** — results must be evicted after the orchestrator's session ends. Tie cleanup to stream disposal via `StreamStatusService`.
-
-**Pros**:
-- Orchestrator can do useful work while subagent runs
-- Supports launching multiple subagents concurrently, then awaiting all
-- Clean separation: launch is fast, await is explicit
-- The await point is chosen by the orchestrator, not forced
-
-**Cons**:
-- Two tool calls per subagent interaction (launch + await)
-- Model must remember the subagent ID across turns
-- More complex mental model for the LLM
-- Still blocks when awaiting (though only at the orchestrator's chosen point)
-
-**Best for**: Multi-step orchestration where the orchestrator dispatches several subagents and collects results.
-
----
-
-### Pattern 3: Async Come-Back-Later (Event-Driven Delivery)
-
-**Concept**: The subagent runs fully asynchronously. When it completes, its output is injected into the orchestrator's conversation as a follow-up message, similar to how `FollowUpQueue` works for user messages.
-
-**Flow**:
-
-```
-1. Orchestrator calls propose_workflow(agent=correct, inputFile=paper.tex)
-     → User approves
-     → launch subagent with completion callback
-     → return ToolResult { output: "Subagent abc-123 launched. Results will be delivered automatically." }
-
-2. Orchestrator continues its conversation normally
-
-3. [Subagent completes in background]
-     → Completion callback fires
-     → Result injected into orchestrator's FollowUpQueue
-     → ToolUsePrepNode picks it up before next model call
-
-4. Orchestrator's next turn sees:
-   "[Subagent result: correct on paper.tex]
-    Status: completed
-    Output files: paper_correct_gemini3p_r0.tex
-    Changes: +42 -18 lines"
-```
-
-**Implementation sketch**:
-
-```typescript
-// In WorkflowTool.ts after approval:
-const subagentId = randomUUID();
-const orchestratorStreamId = getRequiredStreamId();
-
-executeAgentWithResult(configPayload)
-  .then(result => {
-    const message = formatSubagentCompletion(subagentId, proposal, result);
-    // Inject into orchestrator's follow-up queue
-    ToolUseFollowUpQueueManager.enqueue(orchestratorStreamId, message);
-  })
-  .catch(err => {
-    const message = formatSubagentError(subagentId, proposal, err);
-    ToolUseFollowUpQueueManager.enqueue(orchestratorStreamId, message);
-  });
-
-return {
-  summary: `Launched '${input.agent}' (id: ${subagentId})`,
-  output: 'Subagent launched. Results will appear in your conversation when ready.',
-};
-```
-
-**The FollowUpQueue already supports this pattern**:
-
-- `ToolUsePrepNode` (in `ToolUseCycleFlow.ts:198-228`) checks for queued follow-ups before every model call
-- If a follow-up exists, it's injected as a user message
-- The model sees it and can react in its next response
-- The queue handles the timing: if the model is mid-generation, the message waits; if the model is idle (in WaitNode), the message triggers a new cycle
-
-**Two sub-variants**:
-
-**3a. Deliver on next turn**: Result enters `FollowUpQueue`. Orchestrator sees it only when it naturally loops back (after current tool execution completes and the model generates a response that the user follows up on — or the WaitNode triggers).
-
-**3b. Interrupt current turn**: Result enters `FollowUpQueue` and additionally signals the orchestrator's cycle to check for follow-ups. This requires cooperation from `ToolUsePrepNode` which already does this check.
-
-The difference: 3a requires the orchestrator to still be in an active session (WaitNode). 3b works even if the orchestrator is mid-generation, but the message won't be seen until the current cycle's prep phase.
-
-**Changes required**:
-
-1. **`executeAgentWithResult()`** — same as Pattern 1 and 2.
-
-2. **Updated `propose_workflow` / `propose_agent`** — after approval, launch with a completion callback that enqueues to the orchestrator's `FollowUpQueue`.
-
-3. **Subagent result formatting** — structured message format that the orchestrator's model can parse.
-
-4. **Session lifetime management** — if the orchestrator's session has ended by the time the subagent completes, the result has nowhere to go. Options:
-   - Store results in persistent storage, deliver on session resume
-   - Emit to ProgressBoard as a fallback notification
-   - Both (store + notify)
-
-5. **Optional: `SubagentResultStore`** — persistent storage for results that outlive sessions. Allows the user to resume the orchestrator and see what happened.
-
-**Pros**:
-- Zero blocking—orchestrator never waits
-- Natural conversation flow—results appear as messages
-- Leverages existing `FollowUpQueue` infrastructure
-- Subagent completion can arrive at any point in the conversation
-- Multiple subagents complete independently and results stream in
-
-**Cons**:
-- Orchestrator model must handle results arriving at unpredictable times
-- Results may arrive mid-conversation about a different topic
-- No guarantee the orchestrator is still running when results arrive
-- Requires careful session lifetime management
-- Model may not "remember" what it dispatched if many turns have passed
-- Testing is harder (non-deterministic timing)
-
-**Best for**: Long-running subagents where the orchestrator or user continues working. Research agents that take minutes. Background batch processing.
-
----
-
-## Recommendation: Phased Implementation
-
-### Phase 1: Sync (Pattern 1)
-
-Start here. It requires the least new code and provides immediate value:
-
-1. Add `executeAgentWithResult()` to `executeAgent.ts` — ~30 lines, wraps existing `executeAgent()` to return `RunReflectionFlowResult`.
-2. Update `WorkflowAgentTool.execute()` to await and return the result.
-3. Add a `mode: 'sync' | 'async'` parameter to the tool schema (default `'sync'`).
-
-This unblocks the core use case: orchestrator dispatches a correction agent, gets the result, decides what to do next.
-
-### Phase 2: Await-Async (Pattern 2)
-
-Add when orchestrators need to dispatch multiple subagents:
-
-1. Build `SubagentTracker` (follows `BasePromiseCoordinator` pattern).
-2. Add `await_subagent` tool.
-3. When `mode: 'async'`, launch via tracker instead of awaiting inline.
-
-### Phase 3: Come-Back-Later (Pattern 3)
-
-Add for long-running background agents:
-
-1. Wire completion callback to `FollowUpQueue`.
-2. Add `SubagentResultStore` for persistence across sessions.
-3. Integrate with ProgressBoard for result notifications.
-
-### Why this order?
-
-- Each phase builds on the previous (executeAgentWithResult → SubagentTracker → FollowUpQueue delivery)
-- Sync is the minimum viable feature
-- Await-async requires the model to understand subagent IDs (prompt engineering)
-- Come-back-later requires session lifetime management (most complex)
-
----
-
-## Shared Infrastructure: `SubagentResult` Schema
-
-All three patterns need a common result type:
-
-```typescript
-// src/shared/schemas/subagent.ts
-
-export const SubagentResultSchema = z.discriminatedUnion('status', [
-  z.strictObject({
-    status: z.literal('completed'),
-    agentName: z.string(),
-    model: z.string(),
-    roundOutputs: RoundOutputSchema.array(),
-    outputFiles: FileLocationSchema.array(),
-    totalRounds: z.number(),
-    summary: z.string(),
-  }),
-  z.strictObject({
-    status: z.literal('error'),
-    agentName: z.string(),
-    model: z.string(),
-    error: z.string(),
-  }),
-  z.strictObject({
-    status: z.literal('cancelled'),
-    agentName: z.string(),
-    model: z.string(),
-    reason: z.string(),
-  }),
-]);
-
-export type SubagentResult = z.infer<typeof SubagentResultSchema>;
-```
-
-## Shared Infrastructure: `executeAgentWithResult()`
-
-The key enabling function for all patterns:
-
-```typescript
-// In executeAgent.ts
-
-export async function executeAgentWithResult(
-  configPayload: AgentConfigPayload,
-  executionId?: ExecutionId,
-): Promise<SubagentResult> {
-  // Reuse all existing resolution logic
-  const ctx = await resolveAgentBase(configPayload, executionId);
-  const { setting, streamId, config } = ctx;
-
-  try {
-    acquireStreamOrThrow(streamId);
-
-    // Run the flow (same as executeAgent, but capture result)
-    const flowResult = await runFlowCore(ctx, streamId);
-
-    return {
-      status: 'completed',
-      agentName: config.agent,
-      model: config.model,
-      roundOutputs: flowResult.roundOutputs ?? [],
-      outputFiles: (flowResult.roundOutputs ?? [])
-        .flatMap(r => r.outputs.map(o => o.location)),
-      totalRounds: flowResult.roundOutputs?.length ?? 0,
-      summary: buildSummary(config, flowResult),
-    };
-  } catch (err) {
-    return {
-      status: 'error',
-      agentName: config.agent,
-      model: config.model,
-      error: toErrorMessage(err),
-    };
-  }
-}
-```
-
----
-
-## Parallel Tool Calling Considerations
-
-### Current behavior
-
-The orchestrator model can emit **multiple tool calls in a single response** (e.g., two `propose_workflow` calls for different files). Today these are dispatched through `ToolUseDispatchNode` which extends `BatchNode` — executing them **sequentially**, not in parallel (`ToolUseCycleFlow.ts:564`).
-
-A `ParallelBatchNode` exists (`node/index.ts:244-257`) that uses `Promise.all` but is **not currently used** for tool dispatch.
-
-### Impact per pattern
-
-**Pattern 1 (Sync)**: If the orchestrator emits two `propose_workflow` calls in one response, they run sequentially. Subagent A finishes, then subagent B starts. Total time = A + B. This is the worst case for parallel dispatch.
-
-To fix: Switch `ToolUseDispatchNode` from `BatchNode` to `ParallelBatchNode`. Both proposal tools would execute concurrently — each awaits its own subagent, and `Promise.all` collects both results. Total time = max(A, B). However, both tools block simultaneously, which means two approval dialogs may appear and two subagents run in parallel (API quota impact).
-
-**Pattern 2 (Await-Async)**: Natural fit. The orchestrator emits two `propose_workflow` calls in one response. Both launch immediately (non-blocking), both return subagent IDs. Later, the orchestrator emits two `await_subagent` calls in one response. With `ParallelBatchNode`, both awaits resolve concurrently. Even with `BatchNode`, the second `await` resolves near-instantly if the subagent finished while the first was being awaited.
-
-```
-Turn 1: [propose_workflow(A), propose_workflow(B)]  → "id-1", "id-2"
-Turn 2: [await_subagent(id-1), await_subagent(id-2)] → results
-```
-
-**Pattern 3 (Come-Back-Later)**: Parallel dispatch is irrelevant — all launches are non-blocking. Results arrive independently via `FollowUpQueue`.
-
-### Recommendation
-
-For Patterns 1 and 2, switching to `ParallelBatchNode` for `ToolUseDispatchNode` is a prerequisite for true parallel subagent execution. This is a one-line change (`extends ParallelBatchNode` instead of `extends BatchNode`) but has broader implications: **all** tool calls in a response would then execute concurrently, not just subagent proposals. This needs careful validation for tools that have side effects or ordering dependencies.
-
-A safer alternative: keep `BatchNode` as default, but let individual tools declare `parallelSafe: true`. The dispatch node could then partition calls into parallel-safe and sequential groups.
-
----
-
-## Tool-Use Subagent Output Definition
-
-### Problem
-
-Workflow subagents produce structured `RoundOutput[]` (file locations, diffs, XML summaries). Tool-use subagents produce **conversational output** — there is no equivalent structured result.
-
-### Proposal: Last assistant response as output
-
-For tool-use subagents, define the output as the **last model assistant response text** from the conversation. This is already tracked:
-
-- `ToolUseProcessNode.post()` stores `workspace.assembly.lastResponse = execRes.text` when `endTurn` is true (`ToolUseCycleFlow.ts:513`)
-- The full `shared.conversation` (array of `ProviderMessage[]`) is maintained throughout the session and accessible at flow end (`ToolUseCycleNode.ts:156`)
-
-### Implementation
-
-Extend `RunToolUseFlowResult` to include the output:
-
-```typescript
-// Current
+// Current (runToolUseFlow.ts:47-50)
 export interface RunToolUseFlowResult {
   status: EndGroupStatus;
 }
@@ -519,202 +102,444 @@ export interface RunToolUseFlowResult {
 // Proposed
 export interface RunToolUseFlowResult {
   status: EndGroupStatus;
-  /** Last assistant text response (for subagent output reporting). */
   lastResponse?: string;
-  /** Full conversation for detailed inspection (optional, large). */
-  conversation?: ProviderMessage[];
 }
 ```
 
-In `runToolUseFlow()`, capture from the shared state before returning:
+Capture before return (at `runToolUseFlow.ts:178`):
 
 ```typescript
-// At end of runToolUseFlow(), before return:
-const lastAssistantMsg = shared.conversation
+// Extract last assistant text from the conversation
+const lastAssistant = shared.conversation
   .filter(m => m.role === 'assistant')
   .at(-1);
-const lastResponse = extractTextFromMessage(lastAssistantMsg);
 
-return { status, lastResponse };
+return {
+  status,
+  lastResponse: lastAssistant
+    ? services.modelHandler.extractTextFromMessage(lastAssistant)
+    : undefined,
+};
 ```
 
-### SubagentResult for tool-use agents
+**`runReflectionFlow`** — already returns `roundOutputs`. No change needed.
+
+### Step 2: Unified flow result type
 
 ```typescript
-// Add to the discriminated union:
-z.strictObject({
-  status: z.literal('completed'),
-  agentName: z.string(),
-  model: z.string(),
-  agentCategory: z.literal('toolUse'),
-  lastResponse: z.string(),           // Last assistant message text
-  // No roundOutputs/outputFiles — tool-use agents don't produce these
+// src/agent/runtime/AgentFlowResult.ts
+
+/** What a workflow agent execution produces. */
+export interface WorkflowFlowResult {
+  category: 'workflow';
+  status: EndGroupStatus;
+  outputs: OutputFileSummary[];
+}
+
+/** What a tool-use agent execution produces. */
+export interface ToolUseFlowResult {
+  category: 'toolUse';
+  status: EndGroupStatus;
+  lastResponse: string | undefined;
+}
+
+export type AgentFlowResult = WorkflowFlowResult | ToolUseFlowResult;
+
+/** Minimal file output info — what the orchestrator needs. */
+export interface OutputFileSummary {
+  /** Relative path to generated file */
+  relativePath: string;
+  /** Absolute path to generated file */
+  absolutePath: string;
+  /** Which input file produced this output */
+  originalPath: string | null;
+  /** Lines added */
+  added: number | null;
+  /** Lines removed */
+  removed: number | null;
+}
+```
+
+This is **not** a Zod schema. It's a plain TypeScript type. It doesn't need runtime validation — it's an internal boundary between two functions in the same process. No serialization, no persistence, no over-engineering.
+
+`OutputFileSummary` is a projection of `OutputFileInfo` — it extracts the 5 fields the orchestrator cares about and drops the rest. The orchestrator doesn't need `FileLocation` discriminated unions, `xmlSummary`, `rawOutput`, or `lineage.diffFile`.
+
+### Step 3: Extract `executeAgentCore()`
+
+```typescript
+// executeAgent.ts — new function
+
+/**
+ * Core agent execution. Runs the flow and returns the result.
+ * No UI side effects. No stream locking. No notifications.
+ * Callers manage their own lifecycle.
+ */
+export async function executeAgentCore(
+  configPayload: AgentConfigPayload,
+  executionId?: ExecutionId,
+): Promise<AgentFlowResult> {
+  const ctx = await resolveAgentBase(configPayload, executionId);
+  const { setting, config } = ctx;
+
+  if (setting.agentCategory === AgentCategory.ToolUse) {
+    const result = await runToolUseFlow({
+      ...ctx,
+      ...createInterruptCallbacks(),
+      getUsageRecorder: createUsageRecorder(ctx.usageMonitor, 'tool-use'),
+      setting: setting as AgentToolUseSetting,
+      onFollowUpConsumed: () =>
+        bus.emit('updateQueuedFollowUps', { streamId: ctx.streamId }),
+    });
+    return {
+      category: 'toolUse',
+      status: result.status,
+      lastResponse: result.lastResponse,
+    };
+  }
+
+  const result = await runReflectionFlow({
+    ...ctx,
+    ...createInterruptCallbacks(),
+    getUsageRecorder: createUsageRecorder(ctx.usageMonitor, 'workflow'),
+    setting: setting as AgentWorkflowSetting,
+    parentStage: ctx.parentStage,
+  });
+
+  return {
+    category: 'workflow',
+    status: result.status,
+    outputs: result.roundOutputs.flatMap(r =>
+      r.outputs.map(o => ({
+        relativePath: o.location.relativePath ?? o.location.absolutePath,
+        absolutePath: o.location.absolutePath,
+        originalPath: o.lineage?.original?.absolutePath ?? null,
+        added: o.diff?.added ?? null,
+        removed: o.diff?.removed ?? null,
+      }))
+    ),
+  };
+}
+```
+
+**`executeAgent()` becomes a thin wrapper:**
+
+```typescript
+export async function executeAgent(
+  configPayload: AgentConfigPayload,
+  executionId?: ExecutionId,
+): Promise<void> {
+  // ... same stream locking, notification, lifecycle code ...
+  // But internally calls executeAgentCore() and uses only result.status
+  // Existing callers unchanged.
+}
+```
+
+### Step 4: Update the proposal tools
+
+```typescript
+// WorkflowTool.ts — the key change
+
+// Replace:
+executeAgentWithLogging(proposal);
+return { summary: `Started '${input.agent}' on ${input.inputFile}`, ... };
+
+// With:
+const result = await executeAgentCore(configPayload);
+return formatFlowResult(result, input);
+```
+
+Where `formatFlowResult` for workflow agents returns:
+
+```typescript
+{
+  summary: `'${agent}' completed on ${inputFile}`,
+  output: [
+    `Agent '${agent}' completed with status: ${result.status}`,
+    '',
+    'Generated files:',
+    ...result.outputs.map(o =>
+      `  ${o.relativePath} (${formatDiff(o.added, o.removed)})`
+    ),
+  ].join('\n'),
+}
+```
+
+The orchestrator sees:
+```
+Agent 'correct' completed with status: completed
+
+Generated files:
+  paper_correct_gemini3p_r0.tex (+42 -18 lines)
+```
+
+Not a 500-line XML dump. Not the raw model response. Just the files and what changed.
+
+For tool-use agents:
+```
+Agent 'search' completed with status: completed
+
+Response:
+I found 4 relevant papers on efficient transformer attention...
+```
+
+---
+
+## The Three Execution Modes
+
+With `executeAgentCore()` extracted, the three modes become trivial. They're not "patterns" — they're just different ways to call a function that returns a Promise.
+
+### Mode A: Sync (await inline)
+
+```typescript
+const result = await executeAgentCore(configPayload);
+return formatFlowResult(result);
+```
+
+One line. The tool blocks, the orchestrator waits, the result comes back as a `ToolResult`.
+
+### Mode B: Launch-and-await (store the Promise)
+
+```typescript
+// Launch
+const promise = executeAgentCore(configPayload);
+pendingSubagents.set(subagentId, promise);
+return { output: `Launched subagent ${subagentId}` };
+
+// Later, in await_subagent tool:
+const result = await pendingSubagents.get(id);
+return formatFlowResult(result);
+```
+
+`pendingSubagents` is a `Map<string, Promise<AgentFlowResult>>`. That's it. Not a `SubagentTracker` class with `launch()`, `await()`, `status()`, and cleanup hooks. A Map of Promises. JavaScript already solved this problem.
+
+### Mode C: Fire-and-deliver (via FollowUpQueue)
+
+```typescript
+const orchestratorStreamId = getRequiredStreamId();
+executeAgentCore(configPayload).then(result => {
+  const msg = formatSubagentDelivery(subagentId, result);
+  ToolUseFollowUpQueue.enqueue(orchestratorStreamId, msg);
+});
+return { output: `Launched subagent ${subagentId}. Result will be delivered.` };
+```
+
+### How the orchestrator chooses
+
+Add a `mode` parameter to the tool schema:
+
+```typescript
+mode: z.enum(['sync', 'async', 'background'])
+  .prefault('sync')
+  .describe('sync: wait for result. async: launch and use await_subagent later. background: result delivered as follow-up.')
+```
+
+Default is `sync` because it's the simplest and most useful. The model can choose `async` when it wants to launch multiple subagents in parallel.
+
+---
+
+## Parallel Tool Calling
+
+### Current state
+
+`ToolUseDispatchNode` extends `BatchNode` — all tool calls in a single model response execute **sequentially** (`ToolUseCycleFlow.ts:564`). A `ParallelBatchNode` exists (`node/index.ts:244-257`) using `Promise.all` but is unused.
+
+### Impact
+
+With `sync` mode, if the model emits `[propose_workflow(A), propose_workflow(B)]` in one response, they serialize: A runs to completion, then B starts. Total time = A + B.
+
+With `async` mode, both launch instantly (non-blocking). The model later emits `[await_subagent(id-1), await_subagent(id-2)]`. Even under sequential `BatchNode`, the second await resolves near-instantly because both subagents ran concurrently.
+
+**Switching to `ParallelBatchNode`** would let sync-mode calls run concurrently too. But that affects ALL tools, not just subagent proposals. Some tools have ordering dependencies.
+
+### Pragmatic fix
+
+Don't change `BatchNode` vs `ParallelBatchNode`. Instead: `async` mode solves the parallel case naturally. The model launches N subagents (instant, non-blocking), then awaits them (also instant if already done). No infrastructure change to the dispatch node needed.
+
+If we later want true parallel sync mode, add a `parallelSafe` flag to tool metadata and have the dispatch node partition calls.
+
+---
+
+## Follow-Up Context Building (Pattern C Deep Dive)
+
+### The delivery path
+
+When a subagent completes in background mode, the result flows through:
+
+```
+executeAgentCore(configPayload).then(result => {
+  ToolUseFollowUpQueue.enqueue(orchestratorStreamId, formattedMsg);
 })
 ```
 
-This keeps the output lightweight (single string) while providing the meaningful content. The orchestrator can parse structured data from the response if the subagent was instructed to produce it (e.g., "return your findings as a JSON list").
+The follow-up queue is the static `ToolUseFollowUpQueue` manager (`ToolUseFollowUpQueueManager.ts:53`), keyed by `StreamTabId`. It auto-creates queues and works regardless of whether the orchestrator's session is active.
+
+### How the orchestrator consumes it
+
+The delivery chain:
+
+```
+1. ToolUseFollowUpQueue.enqueue(streamId, text)
+   └→ FollowUpQueue.enqueue(text) — adds to array or resolves pending waitForNext
+
+2. If orchestrator is in WaitNode (waiting for user):
+   └→ session.waitForFollowUp() resolves with the enqueued text
+   └→ ToolUseWaitNode.post() creates user follow-up message
+   └→ Returns CONTINUE → loops back to CycleNode
+
+3. If orchestrator is mid-cycle (model calling / tool executing):
+   └→ Text sits in queue
+   └→ On NEXT cycle, ToolUsePrepNode.prep() checks session.hasQueuedFollowUp()
+   └→ Drains queue, calls modelHandler.createUserFollowUpMessages()
+   └→ Appended to shared.messages as user message before next model call
+```
+
+### The semantic problem
+
+Both paths inject the subagent result as a **user-role message** via `createUserFollowUpMessages()`. The model sees:
+
+```
+[assistant]: I'll launch the correction agent...
+[tool_result]: Launched subagent abc-123
+[user]: <subagent-result agent="correct" status="completed">     ← WRONG ROLE
+          Output: paper_correct.tex (+42 -18)
+        </subagent-result>
+```
+
+The model thinks the user typed a subagent result. This is semantically confused.
+
+### Pragmatic fix: structured prefix, don't over-engineer the role
+
+The model can handle this if the system prompt explains it. Use a structured prefix:
+
+```
+[SUBAGENT COMPLETED: abc-123]
+Agent: correct
+Status: completed
+Output files:
+  paper_correct_gemini3p_r0.tex (+42 -18 lines)
+```
+
+The system prompt tells the orchestrator: "Messages prefixed with [SUBAGENT COMPLETED: ...] are automated delivery of background agent results, not user input."
+
+This is pragmatic. It works. The alternative — introducing a new message role or a parallel injection path that bypasses `createUserFollowUpMessages` — is over-engineering for a v1. If it proves to be a real problem in practice, THEN build a dedicated channel.
+
+### Session lifetime edge case
+
+If the orchestrator's session has ended (WaitNode returned stop, flow exited):
+
+1. `ToolUseFollowUpQueue.enqueue()` still works — it auto-creates the queue
+2. But nobody is listening — the orchestrator's flow has exited
+3. If the user resumes the session, `ToolUsePrepareNode` restores from snapshot and `ToolUsePrepNode` drains the queue on the next cycle
+
+So results are NOT lost — they persist in the queue until the session resumes or the queue is released. The only true loss case is if `ToolUseFollowUpQueue.release(streamId)` is called before the subagent completes. This happens in `ToolUseSessionLifecycle.dispose()`.
+
+**Fix**: Don't release the queue if there are pending subagents (check via lineage registry). Release on subagent completion instead.
 
 ---
 
-## Parent-Child Agent Lineage
+## Parent-Child Lineage
 
-### Problem
+### Why it's needed
 
-Today, when a subagent is launched, there is no record of which orchestrator spawned it. This prevents:
-- Cascading cancellation (stop orchestrator → stop its subagents)
-- Progress tree views (show subagents nested under their parent)
-- Result routing (deliver subagent output back to the correct orchestrator)
-- Debugging (trace which agent spawned a failing subagent)
+Not for some future dream feature. It's needed NOW for:
 
-### Proposal: SubagentLineage tracking
+1. **Result routing** (Mode C): which orchestrator does the subagent deliver to?
+2. **Queue lifetime**: don't dispose the orchestrator's queue while subagents are running
+3. **Cascading cancellation**: stopping the orchestrator should stop its subagents
 
-Introduce a lightweight lineage record that links subagents to their parent orchestrator.
+### Minimal implementation
 
-```typescript
-// src/shared/schemas/subagent.ts
-
-export const SubagentLineageSchema = z.strictObject({
-  /** Unique ID for this subagent execution */
-  subagentId: z.string().uuid(),
-  /** StreamTabId of the parent orchestrator that spawned this subagent */
-  parentStreamId: StreamTabIdSchema,
-  /** ExecutionId of the parent orchestrator */
-  parentExecutionId: ExecutionIdSchema,
-  /** StreamTabId of the subagent itself */
-  childStreamId: StreamTabIdSchema,
-  /** ExecutionId of the subagent */
-  childExecutionId: ExecutionIdSchema,
-  /** Agent name of the child */
-  childAgentName: z.string(),
-  /** Agent category of the child */
-  childAgentCategory: z.enum(['workflow', 'toolUse']),
-  /** Timestamp when the subagent was launched */
-  launchedAt: z.number(),
-  /** Timestamp when the subagent completed (null if still running) */
-  completedAt: z.number().nullable(),
-});
-
-export type SubagentLineage = z.infer<typeof SubagentLineageSchema>;
-```
-
-### SubagentRegistry singleton
+Don't build a registry class. Use a Map.
 
 ```typescript
-class SubagentRegistry {
-  private readonly lineage = new Map<string, SubagentLineage>();
+// src/agent/runtime/subagentLineage.ts
 
-  /** Register a new parent-child relationship */
-  register(entry: SubagentLineage): void {
-    this.lineage.set(entry.subagentId, entry);
-  }
-
-  /** Get all children of a parent stream */
-  getChildren(parentStreamId: StreamTabId): SubagentLineage[] {
-    return [...this.lineage.values()]
-      .filter(e => e.parentStreamId === parentStreamId);
-  }
-
-  /** Get the parent of a child stream */
-  getParent(childStreamId: StreamTabId): SubagentLineage | undefined {
-    return [...this.lineage.values()]
-      .find(e => e.childStreamId === childStreamId);
-  }
-
-  /** Mark a subagent as completed */
-  markCompleted(subagentId: string): void {
-    const entry = this.lineage.get(subagentId);
-    if (entry) entry.completedAt = Date.now();
-  }
-
-  /** Get all active (uncompleted) children of a parent */
-  getActiveChildren(parentStreamId: StreamTabId): SubagentLineage[] {
-    return this.getChildren(parentStreamId)
-      .filter(e => e.completedAt === null);
-  }
-
-  /** Clean up entries for a completed parent */
-  cleanupParent(parentStreamId: StreamTabId): void {
-    for (const [id, entry] of this.lineage) {
-      if (entry.parentStreamId === parentStreamId) {
-        this.lineage.delete(id);
-      }
-    }
-  }
+interface SubagentEntry {
+  parentStreamId: StreamTabId;
+  childStreamId: StreamTabId;
+  childAgentName: string;
+  promise: Promise<AgentFlowResult>;
 }
 
-export const subagentRegistry = new SubagentRegistry();
-```
+const activeSubagents = new Map<string, SubagentEntry>();
 
-### Integration points
+export function registerSubagent(
+  subagentId: string,
+  parentStreamId: StreamTabId,
+  childStreamId: StreamTabId,
+  childAgentName: string,
+  promise: Promise<AgentFlowResult>,
+): void {
+  activeSubagents.set(subagentId, {
+    parentStreamId,
+    childStreamId,
+    childAgentName,
+    promise,
+  });
+  promise.finally(() => activeSubagents.delete(subagentId));
+}
 
-1. **At launch time** (`WorkflowTool.ts`): When `executeAgentWithLogging()` / `executeAgentWithResult()` is called after approval, register the lineage entry. The parent's `streamId` and `executionId` are available from the tool's context (`getCurrentToolFileInteractionContext()`).
+export function getActiveChildren(parentStreamId: StreamTabId): SubagentEntry[] {
+  return [...activeSubagents.values()]
+    .filter(e => e.parentStreamId === parentStreamId);
+}
 
-2. **At completion time**: The `executeAgent()` wrapper marks the entry as completed. For Pattern 2/3, this triggers result delivery.
-
-3. **At cancellation time**: When an orchestrator is interrupted, `getActiveChildren()` can identify running subagents for cascading cancellation via `StreamStatusService`.
-
-4. **For ProgressBoard**: Emit lineage info on the event bus so the UI can render a tree:
-   ```typescript
-   bus.emit('subagentLaunched', {
-     parentStreamId,
-     childStreamId,
-     childAgentName,
-   });
-   ```
-
-### Depth limits
-
-For safety, enforce a maximum nesting depth (e.g., 3 levels). A subagent should not spawn its own subagents beyond this limit. Check at proposal time:
-
-```typescript
-function getLineageDepth(streamId: StreamTabId): number {
-  const parent = subagentRegistry.getParent(streamId);
-  if (!parent) return 0;
-  return 1 + getLineageDepth(parent.parentStreamId);
+export function hasActiveChildren(parentStreamId: StreamTabId): boolean {
+  return getActiveChildren(parentStreamId).length > 0;
 }
 ```
+
+No schemas. No classes. No timestamps. No `completedAt` field. The entry deletes itself when the promise settles. If you need to know it ran, check the logs.
+
+The `promise` field doubles as the handle for Mode B (launch-and-await). No separate `pendingSubagents` map needed.
 
 ---
 
-## Updated Comparison Matrix
+## Summary: What To Build
 
-| Dimension | Pattern 1: Sync | Pattern 2: Await-Async | Pattern 3: Come-Back-Later |
-|-----------|-----------------|----------------------|---------------------------|
-| **Complexity** | Low | Medium | Medium-High |
-| **New tools** | 0 | 1-2 (await, check) | 0 |
-| **New infrastructure** | `executeAgentWithResult()` | + `SubagentTracker` | + result formatting + lifetime mgmt |
-| **Blocking** | Full (entire subagent run) | Partial (only at await point) | None |
-| **Parallelism** | Via ParallelBatchNode only | Yes (launch N, await N) | Yes (natural) |
-| **Parallel tool calls** | Works but serializes subagent duration | Best fit — launch is instant | Trivial — all non-blocking |
-| **Result guarantee** | Always available | Available at await | May be lost if session ends |
-| **Model complexity** | Low (call returns result) | Medium (remember IDs) | High (handle async messages) |
-| **Existing infra reuse** | `executeAgent` + `ToolResult` | + `BasePromiseCoordinator` | + `FollowUpQueue` |
-| **Timeout risk** | High (long subagents) | Low-Medium | None |
-| **User interactivity** | Blocked during subagent | Partial | Full |
-| **Lineage tracking** | Optional | Required (ID tracking) | Required (result routing) |
-| **Workflow output** | `RoundOutput[]` + file paths | Same | Same |
-| **Tool-use output** | `lastResponse` text | Same | Same |
+### Changes to existing code (small, surgical)
+
+| File | Change | Lines |
+|------|--------|-------|
+| `runToolUseFlow.ts` | Add `lastResponse` to result | ~5 lines |
+| `executeAgent.ts` | Extract `executeAgentCore()` from `executeAgent()` | ~40 lines (move, not write) |
+| `WorkflowTool.ts` | Await result, format file info | ~20 lines |
+
+### New code
+
+| File | Purpose | Lines |
+|------|---------|-------|
+| `AgentFlowResult.ts` | `AgentFlowResult` + `OutputFileSummary` types | ~25 lines |
+| `subagentLineage.ts` | Active subagent tracking (one Map, three functions) | ~30 lines |
+
+### What NOT to build
+
+- `SubagentTracker` class — use `Map<string, SubagentEntry>`, the promise IS the tracker
+- `SubagentResult` Zod schema — internal boundary, plain types are fine
+- `SubagentRegistry` class with `register/getChildren/getParent/markCompleted/cleanupParent` — a Map with auto-cleanup via `promise.finally()`
+- `SubagentResultStore` for persistence — the FollowUpQueue already persists
+- `BasePromiseCoordinator` extension — not every async pattern needs a coordinator
+
+### Execution modes (all enabled by `executeAgentCore`)
+
+| Mode | Implementation | New tools | Blocking |
+|------|---------------|-----------|----------|
+| `sync` | `await executeAgentCore()` | 0 | Yes |
+| `async` | Store promise, return ID | 1 (`await_subagent`) | At await point |
+| `background` | `.then()` → FollowUpQueue | 0 | No |
+
+Total new infrastructure: ~95 lines of code. One type file, one lineage file, minor edits to three existing files.
 
 ---
 
 ## Open Questions
 
-1. **Output file reading**: Should the orchestrator receive file *contents* or just file *paths*? Paths are smaller but require the orchestrator to read files with a separate tool call. Contents are self-contained but can be large. A middle ground: include a short diff summary (already available in `RoundOutput.outputs[].diff`) and file paths.
+1. **Default mode**: Should the default be `sync` (simple, blocking) or `async` (parallel-friendly)? Recommendation: `sync` — it's the mode where the model needs to understand the least.
 
-2. **Timeout handling for Pattern 1**: What's the maximum acceptable blocking time? Should there be a configurable timeout that auto-switches to async mode? Provider-specific limits (Anthropic tool calls can run for several minutes; some providers may time out).
+2. **Queue lifetime for background mode**: When should the orchestrator's FollowUpQueue be released if subagents are still running? Proposal: `hasActiveChildren(streamId)` check in `ToolUseSessionLifecycle.dispose()`.
 
-3. **Concurrent subagent limits**: Should there be a cap on how many subagents an orchestrator can launch simultaneously? The stream lock system prevents duplicate streams, but multiple distinct subagents could overwhelm API quotas. The `SubagentRegistry` can enforce this via `getActiveChildren().length`.
+3. **Depth limit**: Should subagents be allowed to spawn their own subagents? Proposal: yes, with a max depth of 2 (orchestrator → subagent → sub-subagent). Check lineage depth at proposal time.
 
-4. **Result formatting for Pattern 3**: How should async results be formatted when injected as follow-up messages? The model needs to distinguish subagent results from user messages. Proposal: XML-wrapped structured format that the model can parse:
-   ```xml
-   <subagent-result id="abc-123" agent="correct" status="completed">
-     <output-files>paper_correct_gemini3p_r0.tex</output-files>
-     <diff-summary>+42 -18 lines</diff-summary>
-   </subagent-result>
-   ```
+4. **File content vs. path**: The `ToolResult` returns file paths. Should it also include a short content preview (first N lines of the output)? Probably not for v1 — the orchestrator can use `read_file` if it needs the content.
 
-5. **ParallelBatchNode migration**: Should `ToolUseDispatchNode` switch to `ParallelBatchNode` unconditionally, or should it be opt-in per tool? Some tools may have ordering dependencies (e.g., file creation before file read). A `parallelSafe` tool metadata flag could gate this.
-
-6. **Nesting depth for subagent-of-subagent**: Proposed limit of 3 levels. Should this be configurable? What happens when a subagent tries to exceed the limit — hard error or silent degradation to sync?
-
-7. **Lineage persistence**: Should the `SubagentRegistry` persist across extension restarts (write to `ExecutionKVStore`), or is in-memory sufficient? Persistence would allow resume scenarios where the extension restarts mid-subagent-execution.
+5. **Streaming progress for sync mode**: The orchestrator blocks for the full subagent duration. Should we emit progress events that the ProgressBoard shows? Already happens — the event bus is independent of the tool call. No extra work needed.

--- a/docs/design/subagent-output-design.md
+++ b/docs/design/subagent-output-design.md
@@ -441,24 +441,43 @@ So results are NOT lost — they persist in the queue until the session resumes 
 
 ---
 
-## Nesting Constraint: No Subagent-of-Subagent
+## Nesting Constraint: No Orchestrator-Launches-Orchestrator
 
-Subagents **cannot** spawn their own subagents. Only top-level tool-use orchestrator agents may call `propose_workflow` / `propose_agent`. If a subagent's tool list includes these proposal tools, they must be stripped at launch time.
+An orchestrator is an agent that has proposal tools (`propose_workflow`, `propose_agent`). Agents launched via those proposal tools **never** receive proposal tools — they are workers, not orchestrators. One level of delegation, no recursion.
 
 **Why**: Nesting adds cascading lifecycle complexity (cascading cancellation, recursive depth tracking, multi-level result routing) for no demonstrated use case. The orchestrator dispatches work; the workers do work and return results. If a task needs further decomposition, the orchestrator handles it in its next turn after collecting the subagent's output.
 
-**Enforcement**: When `executeAgentCore()` is called from a proposal tool, the calling context knows it's a subagent (the parent's `streamId` is in the tool context). Pass an `isSubagent: true` flag through `AgentConfigPayload` or resolve it from lineage. The tool resolver strips `propose_workflow` and `propose_agent` from the tool list when `isSubagent` is true.
+**Enforcement**: `resolveTools()` in `ToolUseFlowContext.ts` is where agent tool lists are resolved from YAML config against the registry. When called for a subagent, filter out proposal tools before they reach the flow:
 
 ```typescript
-// In resolveTools() or at tool-use flow setup:
-if (isSubagent) {
-  resolvedTools = resolvedTools.filter(
-    t => t.name !== 'propose_workflow' && t.name !== 'propose_agent'
-  );
+// In resolveTools() — add isSubagent parameter:
+const PROPOSAL_TOOLS = new Set(['propose_workflow', 'propose_agent']);
+
+export function resolveTools(
+  tools: AgentToolUseSetting['tools'],
+  registry: IToolRegistry,
+  logger: { warn: (msg: string) => void },
+  options?: { isSubagent?: boolean },
+): ToolDefinition[] {
+  const toolConfigs = Array.isArray(tools) ? tools : [];
+
+  const resolved = toolConfigs
+    .map((config) => (typeof config === 'string' ? { name: config } : config))
+    .filter((def) => {
+      if (options?.isSubagent && PROPOSAL_TOOLS.has(def.name)) return false;
+      if (!registry.has(def.name)) {
+        logger.warn(`Tool "${def.name}" not found in registry`);
+        return false;
+      }
+      return true;
+    });
+
+  // ... memory tool injection unchanged ...
+  return resolved;
 }
 ```
 
-This is a hard constraint, not a depth limit. No configuration, no exceptions.
+The call site in `WorkflowTool.ts` passes `{ isSubagent: true }` through to the flow setup. The subagent simply never sees proposal tools. No depth counter, no configuration flag, no exceptions.
 
 ---
 
@@ -565,7 +584,7 @@ Total new infrastructure: ~95 lines of code. One type file, one lineage file, mi
 
 ## Decisions Made
 
-1. **No nested subagents**: Subagents cannot spawn subagents. Proposal tools stripped from subagent tool lists at launch time. Hard constraint, no configuration.
+1. **No orchestrator-launches-orchestrator**: Proposal tools (`propose_workflow`, `propose_agent`) are filtered out in `resolveTools()` when `isSubagent` is true. Workers work, orchestrators orchestrate.
 
 2. **Workflow output = file artifacts**: `OutputFileSummary[]` (paths + diffs), not raw model response text. Projection of `OutputFileInfo`.
 

--- a/docs/design/subagent-output-design.md
+++ b/docs/design/subagent-output-design.md
@@ -162,6 +162,8 @@ export interface OutputFileSummary {
 
 This is **not** a Zod schema. It's a plain TypeScript type. It doesn't need runtime validation — it's an internal boundary between two functions in the same process. No serialization, no persistence, no over-engineering.
 
+If `OutputFileSummary` later needs to cross a serialization boundary (e.g., sent to a webview, persisted to KVStore), convert to a Zod schema at that point per CLAUDE.md: "Define schemas first, then derive TypeScript types using `z.infer<typeof Schema>`." Until then, a plain interface is correct.
+
 `OutputFileSummary` is a projection of `OutputFileInfo` — it extracts the 5 fields the orchestrator cares about and drops the rest. The orchestrator doesn't need `FileLocation` discriminated unions, `xmlSummary`, `rawOutput`, or `lineage.diffFile`.
 
 ### Step 3: Extract `executeAgentCore()`
@@ -333,6 +335,8 @@ mode: z.enum(['sync', 'async', 'background'])
   .describe('sync: wait for result. async: launch and use await_subagent later. background: result delivered as follow-up.')
 ```
 
+Uses `.prefault('sync')` — consistent with existing tool schemas in `WorkflowTool.ts` (e.g., `model: z.string().prefault('gemini3p')`). Per AGENTS.md, `.prefault()` normalizes input before validation, which is the right pattern for tool defaults where the LLM may omit the field entirely.
+
 Default is `sync` because it's the simplest and most useful. The model can choose `async` when it wants to launch multiple subagents in parallel.
 
 ---
@@ -437,6 +441,27 @@ So results are NOT lost — they persist in the queue until the session resumes 
 
 ---
 
+## Nesting Constraint: No Subagent-of-Subagent
+
+Subagents **cannot** spawn their own subagents. Only top-level tool-use orchestrator agents may call `propose_workflow` / `propose_agent`. If a subagent's tool list includes these proposal tools, they must be stripped at launch time.
+
+**Why**: Nesting adds cascading lifecycle complexity (cascading cancellation, recursive depth tracking, multi-level result routing) for no demonstrated use case. The orchestrator dispatches work; the workers do work and return results. If a task needs further decomposition, the orchestrator handles it in its next turn after collecting the subagent's output.
+
+**Enforcement**: When `executeAgentCore()` is called from a proposal tool, the calling context knows it's a subagent (the parent's `streamId` is in the tool context). Pass an `isSubagent: true` flag through `AgentConfigPayload` or resolve it from lineage. The tool resolver strips `propose_workflow` and `propose_agent` from the tool list when `isSubagent` is true.
+
+```typescript
+// In resolveTools() or at tool-use flow setup:
+if (isSubagent) {
+  resolvedTools = resolvedTools.filter(
+    t => t.name !== 'propose_workflow' && t.name !== 'propose_agent'
+  );
+}
+```
+
+This is a hard constraint, not a depth limit. No configuration, no exceptions.
+
+---
+
 ## Parent-Child Lineage
 
 ### Why it's needed
@@ -446,10 +471,11 @@ Not for some future dream feature. It's needed NOW for:
 1. **Result routing** (Mode C): which orchestrator does the subagent deliver to?
 2. **Queue lifetime**: don't dispose the orchestrator's queue while subagents are running
 3. **Cascading cancellation**: stopping the orchestrator should stop its subagents
+4. **Nesting enforcement**: reject proposal tools if calling agent is already a subagent
 
 ### Minimal implementation
 
-Don't build a registry class. Use a Map.
+Don't build a registry class. Use a Map. Lives in `src/agent/runtime/` alongside `executeAgent.ts` and `StreamStatusService.ts` — it's about agent execution lifecycle, not specifically tool-use.
 
 ```typescript
 // src/agent/runtime/subagentLineage.ts
@@ -486,6 +512,11 @@ export function getActiveChildren(parentStreamId: StreamTabId): SubagentEntry[] 
 
 export function hasActiveChildren(parentStreamId: StreamTabId): boolean {
   return getActiveChildren(parentStreamId).length > 0;
+}
+
+/** Check if a stream is itself a subagent (has a parent). */
+export function isSubagent(streamId: StreamTabId): boolean {
+  return [...activeSubagents.values()].some(e => e.childStreamId === streamId);
 }
 ```
 
@@ -532,14 +563,28 @@ Total new infrastructure: ~95 lines of code. One type file, one lineage file, mi
 
 ---
 
+## Decisions Made
+
+1. **No nested subagents**: Subagents cannot spawn subagents. Proposal tools stripped from subagent tool lists at launch time. Hard constraint, no configuration.
+
+2. **Workflow output = file artifacts**: `OutputFileSummary[]` (paths + diffs), not raw model response text. Projection of `OutputFileInfo`.
+
+3. **Tool-use output = last assistant response**: `lastResponse` string from `workspace.assembly.lastResponse`.
+
+4. **`.prefault('sync')` for mode default**: Consistent with existing tool schema patterns in the codebase.
+
+5. **Plain TypeScript types for internal boundary**: `AgentFlowResult` and `OutputFileSummary` are not Zod schemas. Convert to schema only if they cross a serialization boundary later.
+
+6. **Lineage in `src/agent/runtime/`**: Alongside `executeAgent.ts` and `StreamStatusService.ts` — it's execution lifecycle infrastructure.
+
+---
+
 ## Open Questions
 
 1. **Default mode**: Should the default be `sync` (simple, blocking) or `async` (parallel-friendly)? Recommendation: `sync` — it's the mode where the model needs to understand the least.
 
 2. **Queue lifetime for background mode**: When should the orchestrator's FollowUpQueue be released if subagents are still running? Proposal: `hasActiveChildren(streamId)` check in `ToolUseSessionLifecycle.dispose()`.
 
-3. **Depth limit**: Should subagents be allowed to spawn their own subagents? Proposal: yes, with a max depth of 2 (orchestrator → subagent → sub-subagent). Check lineage depth at proposal time.
+3. **File content vs. path**: The `ToolResult` returns file paths. Should it also include a short content preview (first N lines of the output)? Probably not for v1 — the orchestrator can use `read_file` if it needs the content.
 
-4. **File content vs. path**: The `ToolResult` returns file paths. Should it also include a short content preview (first N lines of the output)? Probably not for v1 — the orchestrator can use `read_file` if it needs the content.
-
-5. **Streaming progress for sync mode**: The orchestrator blocks for the full subagent duration. Should we emit progress events that the ProgressBoard shows? Already happens — the event bus is independent of the tool call. No extra work needed.
+4. **Streaming progress for sync mode**: The orchestrator blocks for the full subagent duration. Should we emit progress events that the ProgressBoard shows? Already happens — the event bus is independent of the tool call. No extra work needed.


### PR DESCRIPTION
## Summary

This design document establishes the architecture for returning results from subagent executions and supporting three execution modes (sync, async, background). It identifies and solves a fundamental issue: `executeAgent()` currently discards flow results, preventing the orchestrator from accessing generated files or tool-use responses.

## Problem Statement

- `executeAgent()` returns `void`, discarding the `Promise` entirely
- `runReflectionFlow()` produces `RoundOutput[]` with file artifacts, diffs, and lineage — all thrown away
- `runToolUseFlow()` produces conversation and last response — also discarded
- The data exists; it's just not surfaced to callers

This is a **function signature bug**, not a design problem.

## Solution Overview

### 1. Make flows return their output
- `runToolUseFlow`: Add `lastResponse?: string` to result type
- `runReflectionFlow`: Already returns `roundOutputs` (no change needed)

### 2. Unified result type
New `AgentFlowResult` discriminated union:
- `WorkflowFlowResult`: status + `OutputFileSummary[]` (file paths, diffs, lineage)
- `ToolUseFlowResult`: status + `lastResponse?: string`

`OutputFileSummary` is a minimal projection — only the 5 fields the orchestrator needs (relative path, absolute path, original file, added/removed lines).

### 3. Extract `executeAgentCore()`
- New function: runs flow, returns `AgentFlowResult`
- No UI side effects, no stream locking, no notifications
- `executeAgent()` becomes a thin wrapper for command-layer callers

### 4. Three execution modes (all enabled by `executeAgentCore`)

| Mode | Behavior | Use Case |
|------|----------|----------|
| **sync** | `await executeAgentCore()` inline | Simple, blocking, result in ToolResult |
| **async** | Store promise, return ID; later `await_subagent(id)` | Parallel subagents, orchestrator awaits later |
| **background** | `.then()` → `ToolUseFollowUpQueue` | Fire-and-forget, result delivered as follow-up |

### 5. Minimal lineage tracking
- One `Map<string, SubagentEntry>` for active subagents
- Auto-cleanup via `promise.finally()`
- Enables result routing (Mode C), queue lifetime management, cascading cancellation

## Key Design Decisions

- **No over-engineering**: Plain TypeScript types (not Zod schemas) for internal boundaries. A `Map` for tracking, not a `SubagentTracker` class.
- **Pragmatic follow-up delivery**: Subagent results injected as user-role messages with structured prefix. System prompt explains the semantics. Avoids introducing new message roles or parallel injection paths for v1.
- **Parallel tool calling**: Don't change `BatchNode` vs `ParallelBatchNode` globally. `async` mode solves parallelism naturally (launch N subagents instantly, await them later). If true parallel sync mode is needed later, add a `parallelSafe` flag to tool metadata.
- **Default mode**: `sync` — simplest for the model to understand.

## Implementation Scope

**Changes to existing code** (~65 lines total):
- `runToolUseFlow.ts`: Add `lastResponse` to result (~5 lines)
- `executeAgent.ts`: Extract `executeAgentCore()` (~40 lines, mostly moved)
- `WorkflowTool.ts`: Await result, format output (~20 lines)

**New code** (~55 lines total):
- `AgentFlowResult.ts`: Result types (~25 lines)
- `subagentLineage.ts`: Tracking Map + three functions (~30 lines)

## What NOT to Build

- `SubagentTracker` class — the promise itself is the tracker
- `SubagentResult` Zod schema — internal boundary, plain types suffice
- `SubagentRegistry` with lifecycle hooks — a Map with auto-cleanup is enough
- `BasePromiseCoordinator` extension — not

https://claude.ai/code/session_01HfxBUkVPp5fxK1iJ3vY9jy

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or behavioral impact.
> 
> **Overview**
> Adds a new design doc `docs/design/subagent-output-design.md` describing a refactor to stop discarding subagent execution results and to support returning outputs to the orchestrator.
> 
> The document proposes: (1) extending tool-use flows to return `lastResponse`, (2) introducing a unified `AgentFlowResult` (workflow file summaries vs tool-use response), (3) extracting an `executeAgentCore()` that returns this result (with `executeAgent()` as a UI/lifecycle wrapper), and (4) enabling sync/async/background subagent execution modes with minimal parent/child lineage tracking and filtering proposal tools for subagents to prevent orchestrator nesting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8a5a4426b18f168e307ffcb9f8f4bacdb4b9b1a0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->