### PR TITLE
Improve Lean build feedback with diagnostics guidance

### DIFF
--- a/resources/tool_use_agents/lean.yaml
+++ b/resources/tool_use_agents/lean.yaml
@@ -10,8 +10,7 @@ settings:
     - lean_project
     - lean_inspect
     - lean_loogle
-    - name: bash
-      description: 'Execute shell commands. Returns stdout on success, throws error with stderr on failure. Use as fallback when lean_* tools are insufficient (e.g. lake build, lake env lean <file>, lake exe cache get).'
+    - bash
     - read_file
     - write_file
     - edit_file

--- a/resources/tool_use_agents/lean.yaml
+++ b/resources/tool_use_agents/lean.yaml
@@ -10,7 +10,8 @@ settings:
     - lean_project
     - lean_inspect
     - lean_loogle
-    - bash
+    - name: bash
+      description: 'Execute shell commands. Returns stdout on success, throws error with stderr on failure. Use as fallback when lean_* tools are insufficient (e.g. lake build, lake env lean <file>, lake exe cache get).'
     - read_file
     - write_file
     - edit_file
@@ -24,10 +25,6 @@ prompts:
     You are a Lean 4 proof assistant working in the user's project folder. Help users develop formal proofs through iterative refinement.
 
     Workflow: (1) Understand the theorem and identify proof strategy; (2) Write informal proof outline; (3) Formalize in Lean 4; (4) Verify and iterate until clean
-
-    Tool priority: Prefer built-in lean_* tools (lean_diagnostics, lean_inspect, lean_project, lean_file, lean_loogle) for verification and project management. If these don't work or are inconvenient for a specific task, use bash with lake/lean CLI commands as fallback (lake build, lake env lean <file>, lake exe cache get).
-
-    After building: lean_project build does not capture build output. Always follow up with lean_diagnostics on the files you changed to check for errors and warnings. Use the "count" command first for a quick check, then "list" if errors are found.
 
     Mathematical Communication: (1) Use $...$ for inline math expressions when explaining concepts. (2) Define all notation before use. (3) Show reasoning step-by-step, connecting informal proofs to formal Lean code. (4) For complex theorems, outline the proof strategy before diving into tactics.
 

--- a/resources/tool_use_agents/lean.yaml
+++ b/resources/tool_use_agents/lean.yaml
@@ -27,6 +27,8 @@ prompts:
 
     Tool priority: Prefer built-in lean_* tools (lean_diagnostics, lean_inspect, lean_project, lean_file, lean_loogle) for verification and project management. If these don't work or are inconvenient for a specific task, use bash with lake/lean CLI commands as fallback (lake build, lake env lean <file>, lake exe cache get).
 
+    After building: lean_project build does not capture build output. Always follow up with lean_diagnostics on the files you changed to check for errors and warnings. Use the "count" command first for a quick check, then "list" if errors are found.
+
     Mathematical Communication: (1) Use $...$ for inline math expressions when explaining concepts. (2) Define all notation before use. (3) Show reasoning step-by-step, connecting informal proofs to formal Lean code. (4) For complex theorems, outline the proof strategy before diving into tactics.
 
     File operations: Read files before editing. Ask for confirmation before making significant changes. Use relative paths within the project.

--- a/src/tools/lean/LspTools.ts
+++ b/src/tools/lean/LspTools.ts
@@ -326,6 +326,14 @@ Requires: Lean 4 VS Code extension installed.`,
 
     try {
       await vscode.commands.executeCommand(config.vscode);
+
+      if (command === 'build') {
+        return {
+          summary: config.description,
+          output: `Build started. Note: this command does not capture build output directly.\n\nTo check for errors and warnings, run lean_diagnostics on the relevant .lean files.`,
+        };
+      }
+
       return {
         summary: config.description,
         output: `Executed "${command}" successfully`,

--- a/src/tools/lean/LspTools.ts
+++ b/src/tools/lean/LspTools.ts
@@ -317,6 +317,8 @@ Setup commands:
 - "update_elan": Update Elan to the latest version
 - "select_toolchain": Select the default Lean toolchain version
 
+Note: These commands do not capture output. For build output or other cases where you need captured stdout/stderr, use bash with lake CLI commands as fallback (e.g. lake build, lake env lean <file>, lake exe cache get).
+
 Requires: Lean 4 VS Code extension installed.`,
   schema: LeanProjectInputSchema,
 }) {


### PR DESCRIPTION
## Summary
This PR improves the user experience when building Lean projects by providing clear guidance on how to check for build errors and warnings, since the build command itself doesn't capture output directly.

## Changes
- **LspTools.ts**: Modified the `lean_project build` command to return a helpful message directing users to run `lean_diagnostics` on modified files to check for errors and warnings, rather than silently succeeding without output
- **lean.yaml**: Added explicit instructions to the agent prompt clarifying that `lean_project build` doesn't capture build output and recommending the workflow of using `lean_diagnostics` with the "count" command first for quick checks, then "list" if errors are found

## Implementation Details
The build command now returns a user-friendly response that:
1. Confirms the build was started
2. Explicitly notes that build output is not captured directly
3. Provides actionable next steps (running `lean_diagnostics`)
4. Guides the agent to use the "count" command first for efficiency, then "list" if needed

This prevents confusion where users might think the build succeeded when errors actually occurred, and establishes a clear workflow for verifying build results.

https://claude.ai/code/session_01GKuaZbvVQYMoBS9PsCDAen

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, user-facing messaging/prompt changes only; no changes to build execution logic or project state handling.
> 
> **Overview**
> Improves Lean build feedback by making `lean_project` explicitly note that VS Code project commands don’t capture stdout/stderr, and by giving a clearer, actionable response for `build`.
> 
> `lean_project build` now returns a “build started” message that points users to `lean_diagnostics` to check for errors/warnings instead of implying a successful build with no output, and the Lean agent prompt removes the older tool-priority guidance text.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6e7d51b239c625dea110973dc605ee6bdebf391f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->