### PR TITLE
Add batched Loogle queries and improve tool documentation

### DIFF
--- a/resources/tool_use_agents/lean.yaml
+++ b/resources/tool_use_agents/lean.yaml
@@ -25,6 +25,8 @@ prompts:
 
     Workflow: (1) Understand the theorem and identify proof strategy; (2) Write informal proof outline; (3) Formalize in Lean 4; (4) Verify and iterate until clean
 
+    Finding lemmas and definitions: Use lean_loogle for type-signature or name searches (supports batched queries via an array). When the project has a .lake/packages directory (created by `lake build` or `lake exe cache get`), also use grep and glob to search Mathlib and dependency sources directly — e.g. `grep` for identifier names or patterns in `.lake/packages/mathlib/Mathlib/`, or `glob` to find files like `.lake/packages/mathlib/Mathlib/**/*Matrix*.lean`. This is especially useful when loogle returns no results or when you need to read the actual source/proof of a lemma.
+
     Mathematical Communication: (1) Use $...$ for inline math expressions when explaining concepts. (2) Define all notation before use. (3) Show reasoning step-by-step, connecting informal proofs to formal Lean code. (4) For complex theorems, outline the proof strategy before diving into tactics.
 
     File operations: Read files before editing. Ask for confirmation before making significant changes. Use relative paths within the project.

--- a/resources/tool_use_agents/lean.yaml
+++ b/resources/tool_use_agents/lean.yaml
@@ -25,7 +25,7 @@ prompts:
 
     Workflow: (1) Understand the theorem and identify proof strategy; (2) Write informal proof outline; (3) Formalize in Lean 4; (4) Verify and iterate until clean
 
-    Finding lemmas and definitions: Use lean_loogle for type-signature or name searches (supports batched queries via an array). When the project has a .lake/packages directory (created by `lake build` or `lake exe cache get`), also use grep and glob to search Mathlib and dependency sources directly — e.g. `grep` for identifier names or patterns in `.lake/packages/mathlib/Mathlib/`, or `glob` to find files like `.lake/packages/mathlib/Mathlib/**/*Matrix*.lean`. This is especially useful when loogle returns no results or when you need to read the actual source/proof of a lemma.
+    Finding lemmas and definitions: You have two complementary strategies — use both freely depending on what's most efficient for the situation. (1) lean_loogle: search by type signature or name pattern (supports batched queries via an array). (2) grep and glob on .lake/packages/: when the project has a .lake/packages directory (created by `lake build` or `lake exe cache get`), search Mathlib and dependency sources directly — e.g. `grep` for identifier names in `.lake/packages/mathlib/Mathlib/`, or `glob` for files like `.lake/packages/mathlib/Mathlib/**/*Matrix*.lean`. grep is often faster for exact identifier lookups and lets you read the actual source and proof context.
 
     Mathematical Communication: (1) Use $...$ for inline math expressions when explaining concepts. (2) Define all notation before use. (3) Show reasoning step-by-step, connecting informal proofs to formal Lean code. (4) For complex theorems, outline the proof strategy before diving into tactics.
 

--- a/src/progressView/frontend/formatters/logFormatters/contextManagementFormatters.ts
+++ b/src/progressView/frontend/formatters/logFormatters/contextManagementFormatters.ts
@@ -72,9 +72,11 @@ const ACTION_CONFIG: Record<
 };
 
 /** Build context management items from parsed data. */
-function buildContextManagementItems(
-  data: ContextManagementData,
-): { config: ActionConfig; items: ContextStatItem[]; summary?: string } {
+function buildContextManagementItems(data: ContextManagementData): {
+  config: ActionConfig;
+  items: ContextStatItem[];
+  summary?: string;
+} {
   const {
     action,
     tokensBefore,

--- a/src/tools/lean/LoogleTool.ts
+++ b/src/tools/lean/LoogleTool.ts
@@ -8,7 +8,7 @@ import axios from 'axios';
 import { z } from 'zod';
 
 import { toErrorMessage } from '@common/errors';
-import { ToolResult, ToolError } from '@tools/result';
+import { ToolResult } from '@tools/result';
 import { isTimeoutErrorCode, buildTimeoutMessage } from '@tools/timeouts';
 import { defineTool } from '@tools/core/define';
 
@@ -19,15 +19,19 @@ const LOOGLE_TIMEOUT_MS = 10_000; // 10 s
 // ============================================================================
 
 const LeanLoogleInputSchema = z.strictObject({
-  /** Search query - can be a type signature like "Nat → Nat → Nat" or name pattern */
-  query: z.string().describe('Search query (type signature or name pattern)'),
-  /** Maximum number of results to return */
+  /** Search query - single string or array for batched searches */
+  query: z
+    .union([z.string(), z.array(z.string()).min(1).max(10)])
+    .describe(
+      'Search query (type signature or name pattern). Pass an array of strings to batch multiple searches in one call.',
+    ),
+  /** Maximum number of results to return per query */
   limit: z
     .int()
     .min(1)
     .max(20)
     .prefault(10)
-    .describe('Max results (default: 10)'),
+    .describe('Max results per query (default: 10)'),
 });
 
 export type LeanLoogleInput = z.infer<typeof LeanLoogleInputSchema>;
@@ -104,14 +108,21 @@ Example queries:
 - "|- tsum _ = _ * tsum _" - search by main conclusion
 - "|- _ < _ → tsum _ < tsum _" - search by hypothesis pattern
 
+Supports batched queries: pass an array of strings to search multiple identifiers in one call.
+Example: query: ["Matrix.mul_assoc", "Matrix.transpose_mul", "List.map_append"]
+
 Returns: name, type signature, module (for imports), and documentation.
 
 Useful for finding the right lemma when you know roughly what type it should have.`,
   schema: LeanLoogleInputSchema,
 }) {
-  protected async execute(input: LeanLoogleInput): Promise<ToolResult> {
-    const { query, limit } = input;
-
+  /**
+   * Execute a single Loogle query and return a per-query result.
+   */
+  private async executeSingle(
+    query: string,
+    limit: number,
+  ): Promise<{ query: string; result: ToolResult }> {
     try {
       const response = await axios.get<LoogleResponse>(LOOGLE_API_URL, {
         params: { q: query },
@@ -130,9 +141,12 @@ Useful for finding the right lemma when you know roughly what type it should hav
             ? `\n\nSuggestions:\n${suggestions.map((s) => `  - ${s}`).join('\n')}`
             : '';
         return {
-          summary: 'No results',
-          output: `Error: ${data.error}${suggestionText}`,
-          isError: true,
+          query,
+          result: {
+            summary: 'No results',
+            output: `Error: ${data.error}${suggestionText}`,
+            isError: true,
+          },
         };
       }
 
@@ -140,8 +154,11 @@ Useful for finding the right lemma when you know roughly what type it should hav
 
       if (hits.length === 0) {
         return {
-          summary: 'No results',
-          output: `No theorems found matching: ${query}\n\nTry a different type signature or name pattern.`,
+          query,
+          result: {
+            summary: 'No results',
+            output: `No theorems found matching: ${query}\n\nTry a different type signature or name pattern.`,
+          },
         };
       }
 
@@ -150,21 +167,77 @@ Useful for finding the right lemma when you know roughly what type it should hav
         .join('\n\n');
 
       return {
-        summary: `${hits.length} result${hits.length > 1 ? 's' : ''}`,
-        output: formatted,
-        results: hits,
+        query,
+        result: {
+          summary: `${hits.length} result${hits.length > 1 ? 's' : ''}`,
+          output: formatted,
+          results: hits,
+        },
       };
     } catch (error) {
       if (axios.isAxiosError(error) && isTimeoutErrorCode(error.code)) {
-        throw new ToolError(
-          buildTimeoutMessage('Loogle API request', LOOGLE_TIMEOUT_MS),
-        );
+        return {
+          query,
+          result: {
+            summary: 'Timeout',
+            output: buildTimeoutMessage('Loogle API request', LOOGLE_TIMEOUT_MS),
+            isError: true,
+          },
+        };
       }
       return {
-        summary: 'Loogle search failed',
-        output: `Error: ${toErrorMessage(error)}`,
-        isError: true,
+        query,
+        result: {
+          summary: 'Loogle search failed',
+          output: `Error: ${toErrorMessage(error)}`,
+          isError: true,
+        },
       };
     }
+  }
+
+  protected async execute(input: LeanLoogleInput): Promise<ToolResult> {
+    const { query, limit } = input;
+    const queries = Array.isArray(query) ? query : [query];
+
+    // Single query: return directly (backward-compatible format)
+    if (queries.length === 1) {
+      const { result } = await this.executeSingle(queries[0], limit);
+      return result;
+    }
+
+    // Batched queries: run concurrently and combine results
+    const results = await Promise.all(
+      queries.map((q) => this.executeSingle(q, limit)),
+    );
+
+    const allResults: LoogleHit[] = [];
+    const sections: string[] = [];
+    let errorCount = 0;
+
+    for (const { query: q, result } of results) {
+      sections.push(`## Query: \`${q}\`\n\n${result.output}`);
+      if (result.isError) {
+        errorCount++;
+      }
+      if (result.results) {
+        allResults.push(...(result.results as LoogleHit[]));
+      }
+    }
+
+    const totalHits = allResults.length;
+    const summary =
+      totalHits > 0
+        ? `${totalHits} result${totalHits > 1 ? 's' : ''} across ${queries.length} queries`
+        : errorCount === queries.length
+          ? `All ${queries.length} queries failed`
+          : `No results across ${queries.length} queries`;
+
+    return {
+      summary,
+      output: sections.join('\n\n---\n\n'),
+      results: allResults.length > 0 ? allResults : undefined,
+      isError: errorCount === queries.length ? true : undefined,
+    };
   }
 }

--- a/src/tools/lean/LoogleTool.ts
+++ b/src/tools/lean/LoogleTool.ts
@@ -180,7 +180,10 @@ Useful for finding the right lemma when you know roughly what type it should hav
           query,
           result: {
             summary: 'Timeout',
-            output: buildTimeoutMessage('Loogle API request', LOOGLE_TIMEOUT_MS),
+            output: buildTimeoutMessage(
+              'Loogle API request',
+              LOOGLE_TIMEOUT_MS,
+            ),
             isError: true,
           },
         };

--- a/src/tools/zotero/bbtClient.ts
+++ b/src/tools/zotero/bbtClient.ts
@@ -178,9 +178,7 @@ export async function callBetterBibTeX<T = unknown>(
     return response.data.result as T;
   } catch (error) {
     if (axios.isAxiosError(error) && isTimeoutErrorCode(error.code)) {
-      throw new ToolError(
-        buildTimeoutMessage('Zotero API request', timeout),
-      );
+      throw new ToolError(buildTimeoutMessage('Zotero API request', timeout));
     }
     if (axios.isAxiosError(error) && error.code === 'ECONNREFUSED') {
       throw new ToolError(


### PR DESCRIPTION
## Summary
This PR enhances the Loogle search tool to support batched queries, allowing multiple searches in a single call. It also updates documentation to guide users on searching Mathlib sources and improves code formatting consistency.

## Key Changes

### Loogle Tool Enhancement (src/tools/lean/LoogleTool.ts)
- **Batched query support**: Modified `LeanLoogleInputSchema` to accept either a single string or an array of strings (1-10 queries)
- **Refactored execution**: Extracted single-query logic into a new `executeSingle()` private method that returns per-query results
- **Concurrent processing**: Batched queries are executed concurrently using `Promise.all()`
- **Combined results**: Multiple queries are aggregated with separate sections for each query and a unified summary
- **Backward compatibility**: Single queries return results in the original format; batched queries return organized sections with combined hit counts
- **Removed unused import**: Cleaned up unused `ToolError` import

### Documentation Updates (resources/tool_use_agents/lean.yaml)
- Added comprehensive guidance on finding lemmas and definitions
- Documented `lean_loogle` for type-signature and name searches with batched query support
- Provided examples of using `grep` and `glob` to search Mathlib sources in `.lake/packages/` directory
- Explained when to use direct source searching as a fallback when Loogle returns no results

### Code Formatting
- Reformatted `buildContextManagementItems()` function signature in contextManagementFormatters.ts for improved readability
- Simplified error handling in bbtClient.ts for consistency

## Implementation Details
- Batched queries maintain individual result limits per query while providing aggregate statistics
- Error handling is preserved for each query independently; overall error status only set if all queries fail
- The implementation gracefully handles mixed success/failure scenarios across multiple queries

https://claude.ai/code/session_01WqeVZ6jiD8UEzsdtt3d3uw

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the `lean_loogle` tool input/output contract (new array form and aggregated outputs), which may affect any callers that assume the prior single-query shape or parse the output text.
> 
> **Overview**
> Adds **batched query support** to the `lean_loogle` tool by allowing `query` to be a string or an array, executing queries concurrently, and returning a combined multi-section output plus aggregated results/summary while keeping single-query output backward-compatible.
> 
> Updates the Lean agent prompt docs to recommend `lean_loogle` + `.lake/packages` `grep`/`glob` workflows for lemma discovery, and includes minor consistency cleanups (function signature formatting in `contextManagementFormatters.ts` and a small timeout-error formatting tweak in `bbtClient.ts`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 06d05e2d3768a35cc11fad7d711977e887fba7cf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->