### PR TITLE
Downgrade token counting errors from warn to debug level

### DIFF
--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -634,7 +634,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
             throw err;
           }
           // Soft failure for token counting API errors - proceed without adjustment
-          this.logger.warn(
+          this.logger.debug(
             `Token counting failed: ${getSdkErrorMessage(err)}. Proceeding without token adjustment.`,
           );
         }

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -548,7 +548,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
           throw err;
         }
         // Soft failure for token counting API errors - proceed without adjustment
-        this.logger.warn(
+        this.logger.debug(
           `Token counting failed: ${getSdkErrorMessage(err)}. Proceeding without token adjustment.`,
         );
       }

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -440,7 +440,7 @@ export class ModelHandlerOpenAI<
         }
       } catch (err) {
         if (isContextWindowError(err)) throw err;
-        this.logger.warn(
+        this.logger.debug(
           `Token counting failed: ${getSdkErrorMessage(err)}. Proceeding without token adjustment.`,
         );
       }

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -1164,7 +1164,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         }
       } catch (err) {
         if (isContextWindowError(err)) throw err;
-        this.logger.warn(
+        this.logger.debug(
           `Token counting failed: ${getSdkErrorMessage(err)}. Applying fallback cap.`,
         );
         // Fallback: cap output based on best available estimate.
@@ -1414,7 +1414,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         this.clearPendingBackgroundResponse();
       } else if (this.previousResponseId) {
         // Log diagnostic info for other errors when chaining was active
-        this.logger.warn(
+        this.logger.debug(
           `Request failed with previousResponseId=${this.previousResponseId}. ` +
             `Error: ${getSdkErrorMessage(error)}`,
         );


### PR DESCRIPTION
## Summary
Changed log level for token counting API errors from `warn` to `debug` across all model handler implementations. These errors are non-critical soft failures that don't require operator attention, as the system gracefully continues with fallback behavior.

## Changes
- **modelHandlerAnthropic.ts**: Downgraded token counting failure log from `warn` to `debug`
- **modelHandlerGoogleGenAI.ts**: Downgraded token counting failure log from `warn` to `debug`
- **modelHandlerOpenAI.ts**: Downgraded token counting failure log from `warn` to `debug`
- **modelHandlerOpenAIResponse.ts**: 
  - Downgraded token counting failure log from `warn` to `debug`
  - Downgraded request failure diagnostic log from `warn` to `debug` (when chaining was active)

## Rationale
Token counting API failures are expected to be handled gracefully with fallback mechanisms (proceeding without adjustment or applying fallback caps). These are not critical errors requiring operator intervention, so they should be logged at `debug` level rather than `warn` to reduce noise in production logs and focus warnings on genuinely problematic issues.

https://claude.ai/code/session_01PYGz8egbd9zKoqB1hSnFBV

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging-only changes (severity downgrades) with no functional impact on request execution or validation behavior.
> 
> **Overview**
> Downgrades *soft-failure* token-counting error logs from `warn` to `debug` in the Anthropic, Google GenAI, and OpenAI chat model handlers, so transient token counting API issues no longer surface as warnings while requests continue with fallback behavior.
> 
> In `modelHandlerOpenAIResponse.ts`, also downgrades the diagnostic log emitted when a request fails while `previousResponseId` chaining is active from `warn` to `debug`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d63fc75f84007e4500a7f4920ece88675732510d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->