### PR TITLE
Add live streaming output for bash tool execution

### DIFF
--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -539,6 +539,9 @@ const STREAMABLE_TOOLS = new Set(['bash']);
 /** Minimum interval between streaming output updates (ms). */
 const STREAM_THROTTLE_MS = 500;
 
+/** Maximum size of the streaming output buffer sent to the UI (bytes). */
+const STREAM_BUFFER_MAX = 50_000;
+
 /**
  * Result of executing a single tool call, capturing everything needed
  * for logging and message creation.
@@ -670,13 +673,18 @@ class ToolUseDispatchNode<C> extends BatchNode<
         }
       : undefined;
 
-    // Build throttled streaming callback for tools that support it
+    // Build throttled streaming callback for tools that support it.
+    // Keeps a rolling tail buffer (max STREAM_BUFFER_MAX) to bound memory.
     let onToolOutput: ((chunk: string) => void) | undefined;
     if (STREAMABLE_TOOLS.has(call.name)) {
       let outputBuffer = '';
       let lastFlush = 0;
       onToolOutput = (chunk: string) => {
         outputBuffer += chunk;
+        // Cap buffer to last STREAM_BUFFER_MAX chars to prevent unbounded growth
+        if (outputBuffer.length > STREAM_BUFFER_MAX) {
+          outputBuffer = outputBuffer.slice(-STREAM_BUFFER_MAX);
+        }
         const now = Date.now();
         if (now - lastFlush < STREAM_THROTTLE_MS) return;
         lastFlush = now;

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -46,6 +46,7 @@ import {
 import { AbsoluteFS, pathToLocation, type FileLocation } from '@utils/files';
 import { isNonEmptyString } from '@utils/core';
 import { formatContent } from '@utils/text/xmlUtils';
+import { bus } from '@eventBus/ProgressEventBus';
 
 // Local file imports
 import { FlowTransition } from './FlowTransitions';
@@ -532,6 +533,12 @@ const SLOW_TOOLS = new Set(['bash', 'wolfram', 'web_fetch', 'web_search']);
 /** Tools that defer in-progress logging until after approval. */
 const DEFERRED_LOG_TOOLS = new Set(['bash']);
 
+/** Tools that support streaming partial output to the UI. */
+const STREAMABLE_TOOLS = new Set(['bash']);
+
+/** Minimum interval between streaming output updates (ms). */
+const STREAM_THROTTLE_MS = 500;
+
 /**
  * Result of executing a single tool call, capturing everything needed
  * for logging and message creation.
@@ -608,6 +615,7 @@ class ToolUseDispatchNode<C> extends BatchNode<
     tracker: FileInteractionState,
     todoState: TodoState,
     onExecutionReady?: () => void,
+    onToolOutput?: (chunk: string) => void,
   ): Promise<ToolResult> {
     if (!tool) {
       return { error: `Unknown tool ${call.name}`, isError: true };
@@ -622,6 +630,7 @@ class ToolUseDispatchNode<C> extends BatchNode<
           executionId: options.executionId,
           toolCallId: call.callId,
           onExecutionReady,
+          onToolOutput,
         },
         () => tool.call(parsedInput),
       );
@@ -661,6 +670,34 @@ class ToolUseDispatchNode<C> extends BatchNode<
         }
       : undefined;
 
+    // Build throttled streaming callback for tools that support it
+    let onToolOutput: ((chunk: string) => void) | undefined;
+    if (STREAMABLE_TOOLS.has(call.name)) {
+      let outputBuffer = '';
+      let lastFlush = 0;
+      onToolOutput = (chunk: string) => {
+        outputBuffer += chunk;
+        const now = Date.now();
+        if (now - lastFlush < STREAM_THROTTLE_MS) return;
+        lastFlush = now;
+        if (!logRef.logId) return;
+        bus.emit('updateLogMessage', {
+          streamId: options.logger.streamId,
+          logMessage: {
+            id: logRef.logId,
+            groupId: logRef.groupId,
+            messageType: MESSAGE_TYPES.TOOL_USE,
+            data: {
+              toolName: call.name,
+              input: parsedInput ?? call.raw,
+              output: outputBuffer,
+              status: 'in_progress',
+            },
+          },
+        });
+      };
+    }
+
     const result = await this.invokeToolSafely(
       call,
       tool,
@@ -669,6 +706,7 @@ class ToolUseDispatchNode<C> extends BatchNode<
       tracker,
       todoState,
       onExecutionReady,
+      onToolOutput,
     );
 
     const trackedEdits = tracker.recordEdits(result.edits);

--- a/src/agent/toolUse/ToolFileInteractionContext.ts
+++ b/src/agent/toolUse/ToolFileInteractionContext.ts
@@ -14,6 +14,8 @@ export interface ToolFileInteractionContext {
   todoState?: TodoState;
   /** Called by tools with approval flows to trigger in-progress log after approval. */
   onExecutionReady?: () => void;
+  /** Called by tools to push partial output for live streaming to the UI. */
+  onToolOutput?: (chunk: string) => void;
 }
 
 const contextStack: ToolFileInteractionContext[] = [];

--- a/src/progressView/frontend/components/ToolTimer.ts
+++ b/src/progressView/frontend/components/ToolTimer.ts
@@ -1,0 +1,66 @@
+/**
+ * Live elapsed-time timer for in-progress tool calls.
+ *
+ * Renders a ticking counter (e.g. "3s", "1min 12s") that updates every second.
+ * Automatically starts on connect and stops on disconnect.
+ */
+
+// Third-party imports
+import { LitElement, html, css, type TemplateResult } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+
+// Local imports
+import { formatDuration } from '../formatters/timestampUtils';
+
+@customElement('tool-timer')
+export class ToolTimer extends LitElement {
+  static override styles = css`
+    :host {
+      display: inline;
+    }
+    .timer {
+      font-size: var(--font-size-sm, 11px);
+      opacity: 0.8;
+      margin-left: 6px;
+      font-variant-numeric: tabular-nums;
+    }
+  `;
+
+  /** Start timestamp in milliseconds (Date.now() epoch). */
+  @property({ type: Number }) startTime = 0;
+
+  @state() private _elapsed = '';
+
+  private _intervalId: ReturnType<typeof setInterval> | null = null;
+
+  override connectedCallback(): void {
+    super.connectedCallback();
+    this._update();
+    this._intervalId = setInterval(() => this._update(), 1000);
+  }
+
+  override disconnectedCallback(): void {
+    super.disconnectedCallback();
+    if (this._intervalId !== null) {
+      clearInterval(this._intervalId);
+      this._intervalId = null;
+    }
+  }
+
+  private _update(): void {
+    if (!this.startTime) return;
+    const elapsed = Date.now() - this.startTime;
+    this._elapsed = formatDuration(elapsed);
+  }
+
+  override render(): TemplateResult {
+    if (!this._elapsed) return html``;
+    return html`<span class="timer">${this._elapsed}</span>`;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'tool-timer': ToolTimer;
+  }
+}

--- a/src/progressView/frontend/components/index.ts
+++ b/src/progressView/frontend/components/index.ts
@@ -29,6 +29,7 @@ export { TaskGroupHeader } from './TaskGroupHeader';
 export { TaskGroupItem } from './TaskGroupItem';
 export { TaskGroupList } from './TaskGroupList';
 export { TodoList } from './TodoList';
+export { ToolTimer } from './ToolTimer';
 export { ToolUseStreamContent } from './ToolUseStreamContent';
 export { UsagePanel } from './UsagePanel';
 export { UserMessage } from './UserMessage';

--- a/src/progressView/frontend/formatters/htmlBuilders.ts
+++ b/src/progressView/frontend/formatters/htmlBuilders.ts
@@ -127,6 +127,8 @@ export interface DetailsSummaryOptions {
     content?: string;
     contentId?: string;
   };
+  /** Extra Lit template content rendered after the label (e.g. a live timer). */
+  extraContent?: TemplateResult;
 }
 
 /** Build a details summary element with icon, label, and optional extras. */
@@ -140,6 +142,7 @@ export function buildDetailsSummary(
     includeIconClass = true,
     timestamp,
     copyButton,
+    extraContent,
   } = options;
   const iconClasses = includeIconClass
     ? `codicon icon ${iconClass}`
@@ -155,9 +158,10 @@ export function buildDetailsSummary(
         contentId: copyButton.contentId,
       })
     : nothing;
+  const extraTemplate = extraContent ?? nothing;
   // Toggle icon uses CSS rotation via details[open] selector - always start with chevron-right
   // prettier-ignore
-  return html`<summary class="details-summary"><i class="${CHEVRON_RIGHT_CLASS} toggle-icon"></i> <i class=${iconClasses}></i> <span class=${labelClass}>${label}</span>${timestampTemplate}${copyTemplate}</summary>`;
+  return html`<summary class="details-summary"><i class="${CHEVRON_RIGHT_CLASS} toggle-icon"></i> <i class=${iconClasses}></i> <span class=${labelClass}>${label}</span>${extraTemplate}${timestampTemplate}${copyTemplate}</summary>`;
 }
 
 /** Build rendered templates for file list. */

--- a/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
+++ b/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
@@ -10,6 +10,7 @@
 // Local imports - Lit template utilities
 import {
   html,
+  nothing,
   classMap,
   ifDefined,
   type TemplateResult,
@@ -38,6 +39,9 @@ import {
   getLanguageFromPath,
 } from '../constants';
 import type { WebSearchPayload, LogMessageData } from '@shared/schemas';
+
+// Side-effect import to register <tool-timer> custom element
+import '../../components/ToolTimer';
 
 /** Join template sections with horizontal rule separators. */
 function joinWithSeparator(sections: TemplateResult[]): TemplateResult {
@@ -324,6 +328,10 @@ export function formatToolUseTemplate(
   // prettier-ignore
   const bannerContentTemplate = html`<div class="banner-content log-entry-content" data-log-id=${ifDefined(id)} data-group-id=${ifDefined(groupId)} data-timestamp=${ifDefined(fullTimestamp)}>${contentTemplate}</div>`;
 
+  // Live timer for in-progress tools
+  // prettier-ignore
+  const timerTemplate = isInProgress ? html`<tool-timer .startTime=${timestamp}></tool-timer>` : nothing;
+
   // prettier-ignore
   return html`<details class=${classMap({
     'banner-details': true,
@@ -336,6 +344,7 @@ export function formatToolUseTemplate(
     label: titleText,
     labelClass: 'tool-use-title',
     includeIconClass: false,
+    extraContent: timerTemplate,
   })}${bannerContentTemplate}</details>`;
 }
 

--- a/src/progressView/frontend/styles/toolUseStyles.ts
+++ b/src/progressView/frontend/styles/toolUseStyles.ts
@@ -101,6 +101,10 @@ export const toolUseStyles = css`
     animation: spin 1s linear infinite;
   }
 
+  .tool-use-in-progress > .details-summary tool-timer {
+    color: var(--vscode-charts-yellow, #cca700);
+  }
+
   :is(.tool-user-feedback, .tool-error-content, .tool-output-full) {
     white-space: pre-wrap;
     word-break: break-word;

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -51,7 +51,8 @@ export class BashTool extends defineTool({
     }
 
     // Signal execution starting (triggers in-progress log after approval)
-    getCurrentToolFileInteractionContext()?.onExecutionReady?.();
+    const ctx = getCurrentToolFileInteractionContext();
+    ctx?.onExecutionReady?.();
 
     const timeoutMs = input.timeout ?? BASH_TIMEOUT_MS;
 
@@ -60,6 +61,7 @@ export class BashTool extends defineTool({
     const result = await executeCommand(input.command, {
       truncate: true,
       timeout: timeoutMs,
+      onStdout: ctx?.onToolOutput,
     });
 
     if (result.timedOut) {

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -58,10 +58,12 @@ export class BashTool extends defineTool({
 
     // Truncation only applies to internal logging so long-running commands keep
     // the output channel readable while still returning the complete stdout.
+    // Stream both stdout and stderr through the same callback for live UI updates.
     const result = await executeCommand(input.command, {
       truncate: true,
       timeout: timeoutMs,
       onStdout: ctx?.onToolOutput,
+      onStderr: ctx?.onToolOutput,
     });
 
     if (result.timedOut) {

--- a/src/utils/system/execUtils.ts
+++ b/src/utils/system/execUtils.ts
@@ -63,6 +63,8 @@ export async function executeCommand(
     timeout?: number;
     cwd?: string;
     stdin?: string;
+    /** Called with stdout chunks as they arrive, enabling live output streaming. */
+    onStdout?: (chunk: string) => void;
   } = {},
 ): Promise<ExecResult> {
   try {
@@ -93,18 +95,27 @@ export async function executeCommand(
 
     const logChannel = options.channel ?? CHANNEL;
 
-    let result;
+    let subprocess;
     if (Array.isArray(command)) {
       const [cmd, ...args] = command;
       logger.debug(
         logChannel,
         `Running command: ${shellQuote([cmd, ...args])}`,
       );
-      result = await execa(cmd, args, execaOptions);
+      subprocess = execa(cmd, args, execaOptions);
     } else {
       logger.debug(logChannel, `Running command: ${command}`);
-      result = await execa(command, { ...execaOptions, shell: true });
+      subprocess = execa(command, { ...execaOptions, shell: true });
     }
+
+    // Subscribe to stdout stream for live output if callback provided
+    if (options.onStdout && subprocess.stdout) {
+      subprocess.stdout.on('data', (chunk: Buffer | string) => {
+        options.onStdout!(String(chunk));
+      });
+    }
+
+    const result = await subprocess;
 
     const stdout = (result.stdout as string) ?? '';
     const stderr = (result.stderr as string) ?? '';

--- a/src/utils/system/execUtils.ts
+++ b/src/utils/system/execUtils.ts
@@ -65,6 +65,8 @@ export async function executeCommand(
     stdin?: string;
     /** Called with stdout chunks as they arrive, enabling live output streaming. */
     onStdout?: (chunk: string) => void;
+    /** Called with stderr chunks as they arrive, enabling live error streaming. */
+    onStderr?: (chunk: string) => void;
   } = {},
 ): Promise<ExecResult> {
   try {
@@ -108,10 +110,15 @@ export async function executeCommand(
       subprocess = execa(command, { ...execaOptions, shell: true });
     }
 
-    // Subscribe to stdout stream for live output if callback provided
+    // Subscribe to stdout/stderr streams for live output if callbacks provided
     if (options.onStdout && subprocess.stdout) {
       subprocess.stdout.on('data', (chunk: Buffer | string) => {
         options.onStdout!(String(chunk));
+      });
+    }
+    if (options.onStderr && subprocess.stderr) {
+      subprocess.stderr.on('data', (chunk: Buffer | string) => {
+        options.onStderr!(String(chunk));
       });
     }
 


### PR DESCRIPTION
## Summary
This PR adds real-time streaming of bash command output to the UI, allowing users to see tool execution progress as it happens rather than waiting for completion. It includes a live elapsed-time timer for in-progress tool calls and infrastructure for streaming partial output updates.

## Key Changes

- **Streaming Infrastructure**: Added `onToolOutput` callback to `ToolFileInteractionContext` to enable tools to push partial output chunks to the UI
- **Bash Tool Integration**: Modified `BashTool` to stream stdout chunks via the `onStdout` callback in `executeCommand`
- **Live Output Updates**: Implemented throttled (500ms) event emission to update log messages with in-progress tool output via `ProgressEventBus`
- **Live Timer Component**: Created new `ToolTimer` Lit component that displays elapsed time (e.g., "3s", "1min 12s") for in-progress tool calls, updating every second
- **UI Enhancements**: 
  - Extended `buildDetailsSummary` to support extra content (the timer) in tool use headers
  - Added styling for the timer with yellow accent color for in-progress tools
  - Integrated timer into tool use template rendering

## Implementation Details

- Streaming is currently limited to tools in `STREAMABLE_TOOLS` set (bash only)
- Output updates are throttled to prevent excessive event emission and UI updates
- The timer automatically starts on component connection and stops on disconnection
- Streaming callbacks are optional and gracefully handled by tools that don't support them
- All changes maintain backward compatibility with existing tool implementations

https://claude.ai/code/session_01XWdmjsCQor88B63UYXnKXb

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches subprocess execution and log update plumbing; throttling/buffering helps, but streaming output could impact UI performance or leak large/undesired output if not handled carefully.
> 
> **Overview**
> Adds live streaming of `bash` tool output to the progress UI by threading an optional `onToolOutput` callback through `ToolFileInteractionContext` and emitting throttled `updateLogMessage` events during execution (rolling buffer capped to 50k, updates every 500ms).
> 
> Updates `executeCommand` to expose stdout/stderr chunk callbacks and wires `BashTool` to forward both streams after approval, while the progress view gains a new `<tool-timer>` element and formatter support (`buildDetailsSummary.extraContent`) to show an elapsed-time counter for in-progress tool logs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 654d9710a2d6172b222c42346856d8b4d94d9f9d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->