### PR TITLE
Deduplicate parallel tool calls with identical arguments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "diff-match-patch": "^1.0.5",
         "dotenv": "^17.2.4",
         "execa": "^9.6.1",
+        "fast-json-stable-stringify": "^2.1.0",
         "fast-xml-parser": "^5.3.4",
         "fs-extra": "^11.3.3",
         "glob": "^13.0.1",
@@ -5423,7 +5424,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-levenshtein": {

--- a/package.json
+++ b/package.json
@@ -1516,6 +1516,7 @@
     "diff-match-patch": "^1.0.5",
     "dotenv": "^17.2.4",
     "execa": "^9.6.1",
+    "fast-json-stable-stringify": "^2.1.0",
     "fast-xml-parser": "^5.3.4",
     "fs-extra": "^11.3.3",
     "glob": "^13.0.1",

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -60,6 +60,56 @@ import type {
   ToolUseCycleParams,
 } from './CycleServices';
 
+// ============================================================================
+// Parallel call deduplication
+// ============================================================================
+
+const DUPLICATE_CALL_ERROR =
+  'Duplicate parallel call skipped. This call has the same tool name and arguments ' +
+  'as an earlier call in this batch that was already executed. ' +
+  'If you need to run this tool multiple times with the same arguments, ' +
+  'please call them sequentially in separate responses.';
+
+/**
+ * Deterministic JSON serialization for deduplication keys.
+ * Sorts object keys recursively so `{a:1,b:2}` and `{b:2,a:1}` produce
+ * the same string.
+ */
+function stableStringify(value: unknown): string {
+  return JSON.stringify(value, (_key, v) =>
+    v && typeof v === 'object' && !Array.isArray(v)
+      ? Object.fromEntries(
+          Object.entries(v as Record<string, unknown>).sort(([a], [b]) =>
+            a.localeCompare(b),
+          ),
+        )
+      : v,
+  );
+}
+
+/**
+ * Identify duplicate parallel tool calls (same name + identical arguments).
+ * Returns the set of `callId`s that should be skipped (all but the first
+ * occurrence of each unique call signature).
+ */
+function findDuplicateCallIds(toolCalls: SdkToolCall[]): Set<string> {
+  const seen = new Set<string>();
+  const duplicates = new Set<string>();
+  for (const call of toolCalls) {
+    const key = call.name + '\0' + stableStringify(call.input);
+    if (seen.has(key)) {
+      duplicates.add(call.callId);
+    } else {
+      seen.add(key);
+    }
+  }
+  return duplicates;
+}
+
+// ============================================================================
+// Tool input parsing and error handling
+// ============================================================================
+
 /** Parse tool input, handling JSON strings and other formats from model providers. */
 function parseToolInput(
   raw: unknown,
@@ -591,15 +641,7 @@ class ToolUseDispatchNode<C> extends BatchNode<
     // and identical arguments, only execute the first one. Later duplicates
     // receive a synthetic error result prompting sequential invocation.
     if (toolCalls.length > 1) {
-      const seen = new Set<string>();
-      for (const call of toolCalls) {
-        const key = call.name + '\0' + JSON.stringify(call.input);
-        if (seen.has(key)) {
-          this._duplicateCallIds.add(call.callId);
-        } else {
-          seen.add(key);
-        }
-      }
+      this._duplicateCallIds = findDuplicateCallIds(toolCalls);
 
       if (this._duplicateCallIds.size > 0) {
         this.services.logger.info(
@@ -623,16 +665,12 @@ class ToolUseDispatchNode<C> extends BatchNode<
       return {
         call,
         result: {
-          error:
-            'Duplicate parallel call skipped. This call has the same tool name and arguments ' +
-            'as an earlier call in this batch that was already executed. ' +
-            'If you need to run this tool multiple times with the same arguments, ' +
-            'please call them sequentially in separate responses.',
+          error: DUPLICATE_CALL_ERROR,
           isError: true,
         },
         parsedInput: call.input,
         sanitizedOutput: {
-          error: 'Duplicate parallel call skipped',
+          error: DUPLICATE_CALL_ERROR,
           isError: true,
         },
         editedFiles: [],

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -566,8 +566,16 @@ class ToolUseDispatchNode<C> extends BatchNode<
   ToolUseCycleParams<C>,
   ToolUseCycleServices<C>
 > {
+  /**
+   * Call IDs of duplicate parallel calls detected during prep().
+   * These are skipped during exec() and receive a synthetic error result
+   * instructing the model to call them sequentially instead.
+   */
+  private _duplicateCallIds = new Set<string>();
+
   /** Returns tool calls to execute, or empty array if skipped/interrupted. */
   async prep(shared: ToolUseCycleShared): Promise<SdkToolCall[]> {
+    this._duplicateCallIds.clear();
     const toolCalls = shared.toolCalls ?? [];
 
     if (shared.shouldStop || toolCalls.length === 0) {
@@ -579,6 +587,27 @@ class ToolUseDispatchNode<C> extends BatchNode<
       return [];
     }
 
+    // Deduplicate parallel calls: when multiple calls have the same tool name
+    // and identical arguments, only execute the first one. Later duplicates
+    // receive a synthetic error result prompting sequential invocation.
+    if (toolCalls.length > 1) {
+      const seen = new Set<string>();
+      for (const call of toolCalls) {
+        const key = call.name + '\0' + JSON.stringify(call.input);
+        if (seen.has(key)) {
+          this._duplicateCallIds.add(call.callId);
+        } else {
+          seen.add(key);
+        }
+      }
+
+      if (this._duplicateCallIds.size > 0) {
+        this.services.logger.info(
+          `Deduplicated ${this._duplicateCallIds.size} parallel tool call(s) with identical name and arguments.`,
+        );
+      }
+    }
+
     return toolCalls;
   }
 
@@ -586,6 +615,32 @@ class ToolUseDispatchNode<C> extends BatchNode<
   async exec(call: SdkToolCall): Promise<ToolExecutionResult | null> {
     if (this.services.checkInterruption()) {
       return null;
+    }
+
+    // Skip duplicate parallel calls — return a synthetic error result so
+    // the model is informed and can retry sequentially if needed.
+    if (this._duplicateCallIds.has(call.callId)) {
+      return {
+        call,
+        result: {
+          error:
+            'Duplicate parallel call skipped. This call has the same tool name and arguments ' +
+            'as an earlier call in this batch that was already executed. ' +
+            'If you need to run this tool multiple times with the same arguments, ' +
+            'please call them sequentially in separate responses.',
+          isError: true,
+        },
+        parsedInput: call.input,
+        sanitizedOutput: {
+          error: 'Duplicate parallel call skipped',
+          isError: true,
+        },
+        editedFiles: [],
+        logRef: {
+          logId: undefined,
+          groupId: this.services.logger.resolveActiveGroupId(),
+        },
+      };
     }
 
     const services = this.services;
@@ -597,6 +652,12 @@ class ToolUseDispatchNode<C> extends BatchNode<
       workspace.interactions,
       workspace.todos,
     );
+  }
+
+  clone(): this {
+    const cloned = super.clone();
+    cloned._duplicateCallIds = new Set();
+    return cloned;
   }
 
   /** Invoke a tool with error handling, returning an error result if the tool is missing. */

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -1,4 +1,5 @@
 // Third-party imports
+import stableStringify from 'fast-json-stable-stringify';
 import { z } from 'zod';
 
 // Local imports - core flow primitives
@@ -69,23 +70,6 @@ const DUPLICATE_CALL_ERROR =
   'as an earlier call in this batch that was already executed. ' +
   'If you need to run this tool multiple times with the same arguments, ' +
   'please call them sequentially in separate responses.';
-
-/**
- * Deterministic JSON serialization for deduplication keys.
- * Sorts object keys recursively so `{a:1,b:2}` and `{b:2,a:1}` produce
- * the same string.
- */
-function stableStringify(value: unknown): string {
-  return JSON.stringify(value, (_key, v) =>
-    v && typeof v === 'object' && !Array.isArray(v)
-      ? Object.fromEntries(
-          Object.entries(v as Record<string, unknown>).sort(([a], [b]) =>
-            a.localeCompare(b),
-          ),
-        )
-      : v,
-  );
-}
 
 /**
  * Identify duplicate parallel tool calls (same name + identical arguments).

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -628,8 +628,16 @@ class ToolUseDispatchNode<C> extends BatchNode<
       this._duplicateCallIds = findDuplicateCallIds(toolCalls);
 
       if (this._duplicateCallIds.size > 0) {
-        this.services.logger.info(
-          `Deduplicated ${this._duplicateCallIds.size} parallel tool call(s) with identical name and arguments.`,
+        const dupNames = [
+          ...new Set(
+            toolCalls
+              .filter((c) => this._duplicateCallIds.has(c.callId))
+              .map((c) => c.name),
+          ),
+        ];
+        this.services.logger.debug(
+          `Deduplicated ${this._duplicateCallIds.size} parallel tool call(s) ` +
+            `with identical name and arguments: ${dupNames.join(', ')}`,
         );
       }
     }


### PR DESCRIPTION
## Summary
This PR adds deduplication logic to prevent executing multiple parallel tool calls that have the same tool name and identical arguments. Duplicate calls are skipped and receive a synthetic error result instructing the model to invoke them sequentially instead.

## Key Changes
- Added `_duplicateCallIds` Set to track duplicate parallel calls detected during preparation
- Implemented deduplication logic in `prep()` that identifies calls with matching tool name and arguments, storing duplicates for later skipping
- Modified `exec()` to return a synthetic error result for duplicate calls, informing the model that the call was skipped and should be retried sequentially
- Added `clone()` method to properly reset the `_duplicateCallIds` Set when the node is cloned, preventing state leakage between executions

## Implementation Details
- Duplicate detection uses a composite key of tool name and JSON-stringified arguments (`name + '\0' + JSON.stringify(input)`)
- Only the first occurrence of a duplicate call is executed; subsequent calls with identical parameters are skipped
- The synthetic error message clearly explains why the call was skipped and guides the model toward sequential invocation
- Logging is added to track when deduplication occurs
- The `clone()` override ensures each cloned instance has a fresh `_duplicateCallIds` Set to avoid cross-contamination

https://claude.ai/code/session_015NGPB6ZH3e3WbPPRMTLgPt

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes tool execution semantics by skipping duplicate calls and injecting synthetic errors, which could affect agent behavior if repeated identical calls were previously relied upon. Scope is contained to the tool-use dispatch flow and adds a well-known dependency for stable hashing.
> 
> **Overview**
> Prevents executing multiple tool calls in the same batch when they have the **same tool name and identical arguments**.
> 
> `ToolUseDispatchNode` now detects duplicates during `prep()` (using stable JSON stringification for argument equality), logs when deduping occurs, and returns a **synthetic error result** for skipped duplicate `callId`s during `exec()` to instruct the model to retry sequentially. Adds a `clone()` override to reset dedupe state, and introduces `fast-json-stable-stringify` as a runtime dependency.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e5ee5c690f0d0bf2ee58db08e4373df95c277bca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->