### PR TITLE
Add proposal restore functionality to progress view

### DIFF
--- a/src/common/webview/commands.ts
+++ b/src/common/webview/commands.ts
@@ -227,6 +227,7 @@ export const PROGRESS_VIEW_COMMANDS = {
   TOGGLE_TOOL_EDIT_APPROVAL_BYPASS: 'toggleToolEditApprovalBypass',
   AGENT_PROPOSAL_ACTION: 'agentProposalAction',
   BASH_APPROVAL_ACTION: 'bashApprovalAction',
+  RESTORE_PROPOSAL_CONFIG: 'restoreProposalConfig',
 
   // Memory
   OPEN_MEMORY_VIEW: 'openMemoryView',

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -167,6 +167,8 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
       },
       [PROGRESS_VIEW_COMMANDS.AGENT_PROPOSAL_ACTION]: (data) =>
         this.handleAgentProposalAction(data),
+      [PROGRESS_VIEW_COMMANDS.RESTORE_PROPOSAL_CONFIG]: (data) =>
+        this.handleRestoreProposalConfig(data),
       [PROGRESS_VIEW_COMMANDS.BASH_APPROVAL_ACTION]: (data) =>
         handleProgressViewBashApprovalAction(data),
 
@@ -545,19 +547,62 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     }
 
     const isWorkflow = proposal.agentCategory === 'workflow';
+    const success = await this.restoreProposalToMainView(proposal, isWorkflow);
+    if (!success) return;
+
+    proposalCoordinator.resolveRequest(proposalId, { action: 'setup' });
+
+    this.logger.info(
+      this.channel,
+      `Agent proposal ${proposalId} set up in main view`,
+      {
+        data: { agent: proposal.agent },
+      },
+    );
+  }
+
+  private async handleRestoreProposalConfig(
+    data: MessageFor<typeof PROGRESS_VIEW_COMMANDS.RESTORE_PROPOSAL_CONFIG>,
+  ): Promise<void> {
+    const { toolName, input } = data;
+    if (!input.agent) {
+      this.logger.warn(
+        this.channel,
+        'Cannot restore proposal config: missing agent field',
+      );
+      return;
+    }
+
+    const isWorkflow = toolName === 'propose_workflow';
+    const success = await this.restoreProposalToMainView(input, isWorkflow);
+    if (success) {
+      this.logger.info(
+        this.channel,
+        `Restored proposal config to main view`,
+        { data: { agent: input.agent, toolName } },
+      );
+    }
+  }
+
+  /** Build TaskState from proposal fields and restore to main view. */
+  private async restoreProposalToMainView(
+    source: Record<string, unknown>,
+    isWorkflow: boolean,
+  ): Promise<boolean> {
     const agentCategory = isWorkflow
       ? AgentCategory.Workflow
       : AgentCategory.ToolUse;
 
-    const hasFiles = (arr?: string[]): boolean => (arr?.length ?? 0) > 0;
+    const hasFiles = (arr?: unknown): boolean =>
+      Array.isArray(arr) && arr.length > 0;
 
     const activeFiles = isWorkflow
       ? {
-          input: hasFiles(proposal.inputFiles),
-          reference: hasFiles(proposal.referenceFiles),
-          auxiliary: hasFiles(proposal.auxiliaryFiles),
-          media: hasFiles(proposal.mediaFiles),
-          output: hasFiles(proposal.outputFiles),
+          input: hasFiles(source.inputFiles),
+          reference: hasFiles(source.referenceFiles),
+          auxiliary: hasFiles(source.auxiliaryFiles),
+          media: hasFiles(source.mediaFiles),
+          output: hasFiles(source.outputFiles),
         }
       : {
           input: false,
@@ -567,22 +612,22 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
           output: false,
         };
 
-    const agentConfig = AgentConfigSchema.parse({
-      agent: proposal.agent,
-      model: proposal.model,
-      instruction: proposal.instruction,
+    const result = AgentConfigSchema.safeParse({
+      agent: source.agent,
+      model: source.model,
+      instruction: source.instruction,
       agentCategory,
       ...(isWorkflow && {
-        inputFile: proposal.inputFile,
-        inputFiles: proposal.inputFiles,
-        referenceFile: proposal.referenceFile,
-        referenceFiles: proposal.referenceFiles,
-        auxiliaryFile: proposal.auxiliaryFile,
-        auxiliaryFiles: proposal.auxiliaryFiles,
-        mediaFile: proposal.mediaFile,
-        mediaFiles: proposal.mediaFiles,
-        outputFiles: proposal.outputFiles,
-        useMultipleOutputs: proposal.useMultipleOutputs,
+        inputFile: source.inputFile,
+        inputFiles: source.inputFiles,
+        referenceFile: source.referenceFile,
+        referenceFiles: source.referenceFiles,
+        auxiliaryFile: source.auxiliaryFile,
+        auxiliaryFiles: source.auxiliaryFiles,
+        mediaFile: source.mediaFile,
+        mediaFiles: source.mediaFiles,
+        outputFiles: source.outputFiles,
+        useMultipleOutputs: source.useMultipleOutputs,
         inputFilesActive: activeFiles.input,
         referenceFilesActive: activeFiles.reference,
         auxiliaryFilesActive: activeFiles.auxiliary,
@@ -591,22 +636,22 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
       }),
     });
 
-    const taskState = (
-      isWorkflow ? { agentConfig, activeFiles } : { agentConfig }
-    ) as TaskState;
+    if (!result.success) {
+      this.logger.warn(this.channel, 'Invalid proposal config', {
+        data: { errors: result.error.issues },
+      });
+      return false;
+    }
 
-    proposalCoordinator.resolveRequest(proposalId, { action: 'setup' });
+    const taskState = (
+      isWorkflow
+        ? { agentConfig: result.data, activeFiles }
+        : { agentConfig: result.data }
+    ) as TaskState;
 
     await vscode.commands.executeCommand('texra.mainView.focus');
     await vscode.commands.executeCommand('texra.restoreState', taskState);
-
-    this.logger.info(
-      this.channel,
-      `Agent proposal ${proposalId} set up in main view`,
-      {
-        data: { agent: proposal.agent },
-      },
-    );
+    return true;
   }
 
   private async handleOpenTaskStorage(

--- a/src/progressView/frontend/components/LogList.ts
+++ b/src/progressView/frontend/components/LogList.ts
@@ -42,6 +42,7 @@ import { logStyles } from '../styles/logStyles';
 
 // Local imports - progress view formatters
 import { getCopyContent } from '../formatters/copyContentStore';
+import { getProposalInput } from '../formatters/proposalInputStore';
 
 // Local imports - progress view components (type-only for @query reference)
 import type { TaskGroupList } from './TaskGroupList';
@@ -216,6 +217,22 @@ export class LogList extends LitElement {
     const latexRef = this.findTargetInPath<HTMLElement>(event, '.latex-ref');
     if (latexRef?.dataset.label) {
       postMessage(COMMANDS.OPEN_LABEL, { label: latexRef.dataset.label });
+      return;
+    }
+
+    // Handle proposal restore links
+    const proposalLink = this.findTargetInPath<HTMLElement>(
+      event,
+      '.proposal-restore-link',
+    );
+    if (proposalLink?.dataset.proposalId) {
+      const stored = getProposalInput(proposalLink.dataset.proposalId);
+      if (stored) {
+        postMessage(COMMANDS.RESTORE_PROPOSAL_CONFIG, {
+          toolName: stored.toolName,
+          input: stored.input,
+        });
+      }
       return;
     }
 

--- a/src/progressView/frontend/formatters/copyContentStore.ts
+++ b/src/progressView/frontend/formatters/copyContentStore.ts
@@ -4,17 +4,10 @@
  * Stores copyable content by ID to avoid duplicating large strings in DOM attributes.
  */
 
+import { hashString } from './hashUtils';
+
 // Local module state
 const copyContentStore = new Map<string, string>();
-
-function hashString(input: string): string {
-  let hash = 0;
-  for (let i = 0; i < input.length; i += 1) {
-    hash = (hash << 5) - hash + input.charCodeAt(i);
-    hash |= 0;
-  }
-  return (hash >>> 0).toString(36);
-}
 
 function buildDefaultId(content: string): string {
   const normalized = content ?? '';

--- a/src/progressView/frontend/formatters/hashUtils.ts
+++ b/src/progressView/frontend/formatters/hashUtils.ts
@@ -1,0 +1,12 @@
+/**
+ * Simple string hash for generating stable content-based IDs.
+ * Shared by copyContentStore and proposalInputStore.
+ */
+export function hashString(input: string): string {
+  let hash = 0;
+  for (let i = 0; i < input.length; i += 1) {
+    hash = (hash << 5) - hash + input.charCodeAt(i);
+    hash |= 0;
+  }
+  return (hash >>> 0).toString(36);
+}

--- a/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
+++ b/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
@@ -27,6 +27,7 @@ import {
   buildDetailsSummary,
 } from '../htmlBuilders';
 import { normalizeToolUseData } from '../logDataParsers';
+import { registerProposalInput } from '../proposalInputStore';
 import { stringifyWithLanguage, extractCodeOnlyInput } from '../parseUtils';
 import {
   TOOLS_WITH_DIFF_INPUT,
@@ -66,6 +67,16 @@ const STATUS_ICONS: Record<string, string> = {
   failed: 'codicon codicon-error',
   in_progress: 'codicon codicon-sync spin',
 };
+
+/** Tools that represent agent proposals (have restorable config). */
+const PROPOSAL_TOOLS = new Set(['propose_agent', 'propose_workflow']);
+
+/** Check if input is a plain object suitable for proposal restore. */
+function isProposalInput(
+  input: unknown,
+): input is Record<string, unknown> {
+  return input !== null && typeof input === 'object' && !Array.isArray(input);
+}
 
 type ToolSectionOptions = {
   toolName?: string;
@@ -289,6 +300,17 @@ export function formatToolUseTemplate(
         extraClass: 'tool-output-full',
       }),
     );
+  }
+
+  // Add "Setup" restore link for completed proposal tools (including rejected/timed-out)
+  if (
+    PROPOSAL_TOOLS.has(toolName) &&
+    !isInProgress &&
+    isProposalInput(input)
+  ) {
+    const proposalId = registerProposalInput(input, toolName);
+    // prettier-ignore
+    sections.push(html`<div class="proposal-restore-action"><span class="proposal-restore-link" data-proposal-id=${proposalId} title="Restore this proposal configuration to the main view"><i class="codicon codicon-reply"></i> Setup</span></div>`);
   }
 
   // Show error if present

--- a/src/progressView/frontend/formatters/proposalInputStore.ts
+++ b/src/progressView/frontend/formatters/proposalInputStore.ts
@@ -1,0 +1,44 @@
+/**
+ * Proposal input registry for progress view.
+ *
+ * Stores proposal tool inputs by ID so they can be retrieved when the user
+ * clicks the "Setup" link on a completed proposal log entry.
+ *
+ * Uses content-based hashing (like copyContentStore) so re-rendering the
+ * same message produces the same ID — no memory leak on stream switches.
+ */
+
+import { hashString } from './hashUtils';
+
+interface StoredProposal {
+  input: Record<string, unknown>;
+  toolName: string;
+}
+
+const proposalInputStore = new Map<string, StoredProposal>();
+
+function buildId(input: Record<string, unknown>, toolName: string): string {
+  const serialized = JSON.stringify({ t: toolName, i: input });
+  return `proposal:${serialized.length}:${hashString(serialized)}`;
+}
+
+/**
+ * Register proposal input and return a stable ID for lookup.
+ */
+export function registerProposalInput(
+  input: Record<string, unknown>,
+  toolName: string,
+): string {
+  const id = buildId(input, toolName);
+  if (!proposalInputStore.has(id)) {
+    proposalInputStore.set(id, { input, toolName });
+  }
+  return id;
+}
+
+/**
+ * Retrieve proposal input by ID.
+ */
+export function getProposalInput(id: string): StoredProposal | undefined {
+  return proposalInputStore.get(id);
+}

--- a/src/progressView/frontend/styles/toolUseStyles.ts
+++ b/src/progressView/frontend/styles/toolUseStyles.ts
@@ -134,6 +134,25 @@ export const toolUseStyles = css`
     overflow: auto;
   }
 
+  /* Proposal restore link */
+  .proposal-restore-action {
+    margin: var(--spacing-small) 0;
+  }
+
+  .proposal-restore-link {
+    color: var(--color-text-link);
+    cursor: pointer;
+    font-size: var(--font-size-sm);
+    font-weight: 500;
+    display: inline-flex;
+    align-items: center;
+    gap: var(--spacing-tiny);
+  }
+
+  .proposal-restore-link:hover {
+    text-decoration: underline;
+  }
+
   /* Diff styles */
   .diff-add {
     color: var(--vscode-gitDecoration-addedResourceForeground, #3fb950);

--- a/src/shared/schemas/progressView.ts
+++ b/src/shared/schemas/progressView.ts
@@ -563,6 +563,12 @@ const AgentProposalActionMessageSchema = z.object({
   feedback: z.string().optional(),
 });
 
+const RestoreProposalConfigMessageSchema = z.object({
+  command: z.literal(PROGRESS_VIEW_COMMANDS.RESTORE_PROPOSAL_CONFIG),
+  toolName: z.string().min(1),
+  input: z.record(z.string(), z.unknown()),
+});
+
 const OpenFileMessageSchema = z.object({
   command: z.literal(PROGRESS_VIEW_COMMANDS.OPEN_FILE),
   file: z.string().min(1),
@@ -657,6 +663,7 @@ export const ProgressViewInboundMessageSchema = z.discriminatedUnion(
     ToggleToolEditApprovalBypassMessageSchema,
     BashApprovalActionMessageSchema,
     AgentProposalActionMessageSchema,
+    RestoreProposalConfigMessageSchema,
     ShowInformationMessageSchema,
     OpenProfileMessageSchema,
     OpenMemoryViewMessageSchema,


### PR DESCRIPTION
## Summary
This PR adds the ability to restore completed agent and workflow proposals from the progress view back to the main view. Users can now click a "Setup" link on completed proposal log entries to restore the proposal configuration without re-running the tool.

## Key Changes

- **New Command**: Added `RESTORE_PROPOSAL_CONFIG` command to handle proposal restoration from progress view
- **Message Handler**: Implemented `handleRestoreProposalConfig()` to process restore requests and refactored proposal setup logic into reusable `restoreProposalToMainView()` method
- **Proposal Input Registry**: Created `proposalInputStore.ts` to store proposal inputs by content-based hash (similar to existing copy content store), enabling stable ID generation across re-renders
- **UI Integration**: 
  - Added "Setup" restore link to completed proposal tool logs (both `propose_agent` and `propose_workflow`)
  - Styled the restore link with hover effects and reply icon
  - Added click handler in LogList to trigger restoration
- **Schema Updates**: Added `RestoreProposalConfigMessageSchema` for message validation

## Implementation Details

- The proposal input store uses content-based hashing to generate stable IDs, preventing memory leaks when streams are switched or messages are re-rendered
- The `restoreProposalToMainView()` method is now shared between agent proposal action handling and explicit restore requests, reducing code duplication
- The restore link appears for all completed proposal tools (including rejected/timed-out), allowing users to recover partial configurations
- Type-safe message handling with Zod schema validation for the new restore command

https://claude.ai/code/session_017EJsTRrtpJ8zUqSN9Vex2n

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new cross-webview message path that restores `TaskState` into the main view; incorrect or malformed proposal inputs could lead to failed restores or unexpected state being applied, though validation via `safeParse` reduces impact.
> 
> **Overview**
> Allows users to restore completed `propose_agent`/`propose_workflow` configurations from the progress view back into the main view via a new `RESTORE_PROPOSAL_CONFIG` command and inbound schema.
> 
> The progress-view UI now renders a clickable **Setup** action on finished proposal tool logs, stores the original proposal input in a new hashed `proposalInputStore`, and posts the stored config to the extension. The backend refactors proposal “setup” into `restoreProposalToMainView()` (now used by both pending proposal setup and the new restore flow) and switches to `AgentConfigSchema.safeParse` to validate configs before calling `texra.restoreState`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ad55c5ae558d615ffb4d2c9b51336f3a575e0ba0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->