### PR TITLE
Improve AI assistant prompt guidance for file operations

### DIFF
--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -36,7 +36,7 @@ export type BashInput = z.infer<typeof BashInputSchema>;
 export class BashTool extends defineTool({
   name: 'bash',
   description:
-    'Execute shell commands. Returns stdout on success, throws error with stderr on failure.',
+    'Execute shell commands. Commands run from the workspace directory — do not cd to it first. Never use `find /` as it searches the entire filesystem; use the glob tool or limit searches to the workspace. Returns stdout on success, throws error with stderr on failure.',
   schema: BashInputSchema,
 }) {
   protected async execute(input: BashInput): Promise<ToolResult> {

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -36,7 +36,7 @@ export type BashInput = z.infer<typeof BashInputSchema>;
 export class BashTool extends defineTool({
   name: 'bash',
   description:
-    'Execute shell commands. Commands run from the workspace directory — do not cd to it first. Never use `find /` as it searches the entire filesystem; use the glob tool or limit searches to the workspace. Returns stdout on success, throws error with stderr on failure.',
+    'Execute shell commands. Returns stdout on success, throws error with stderr on failure.',
   schema: BashInputSchema,
 }) {
   protected async execute(input: BashInput): Promise<ToolResult> {

--- a/src/utils/prompt/PromptBuilder.ts
+++ b/src/utils/prompt/PromptBuilder.ts
@@ -23,6 +23,8 @@ Do not call tools that are not provided or any multi_tool_use variants.
 Call tools sequentially and wait for the output before calling another.
 For math in responses, use $...$ or \\(...\\) for inline and $$...$$ or \\[...\\] for display math. Wrap LaTeX environments like align or gather inside $$...$$ (e.g., $$\\begin{align}...\\end{align}$$) so they render correctly.
 The current working directory is {{ CWD }}. Use relative paths when working with files.
+Bash commands already execute from the workspace directory — do not cd to it or run ls as a first step; it is unnecessary.
+Never use \`find /\` or \`find / -name\` as it searches the entire filesystem and is extremely slow. Use the glob or grep tools to find files, or limit find to the workspace directory.
 {% if DEFAULT_BIB_PATH %}The default bibliography file is {{ DEFAULT_BIB_PATH }}. You can grep or read this file to search for citations and references.{% endif %}
 </tool_use_instructions>`;
 

--- a/src/utils/prompt/PromptBuilder.ts
+++ b/src/utils/prompt/PromptBuilder.ts
@@ -23,7 +23,7 @@ Do not call tools that are not provided or any multi_tool_use variants.
 Call tools sequentially and wait for the output before calling another.
 For math in responses, use $...$ or \\(...\\) for inline and $$...$$ or \\[...\\] for display math. Wrap LaTeX environments like align or gather inside $$...$$ (e.g., $$\\begin{align}...\\end{align}$$) so they render correctly.
 The current working directory is {{ CWD }}. Use relative paths when working with files.
-Bash commands already execute from the workspace directory — do not cd to it or run ls as a first step; it is unnecessary.
+Bash commands already execute from the workspace directory — do not cd to the absolute workspace path as a first step; it is unnecessary.
 Never use \`find /\` or \`find / -name\` as it searches the entire filesystem and is extremely slow. Use the glob or grep tools to find files, or limit find to the workspace directory.
 {% if DEFAULT_BIB_PATH %}The default bibliography file is {{ DEFAULT_BIB_PATH }}. You can grep or read this file to search for citations and references.{% endif %}
 </tool_use_instructions>`;


### PR DESCRIPTION
## Summary
Updated the AI assistant prompt instructions to provide clearer guidance on file operations and workspace navigation, improving efficiency and preventing unnecessary filesystem searches.

## Changes
- Added clarification that bash commands already execute from the workspace directory, eliminating the need for redundant `cd` operations to the absolute workspace path
- Added warning against using `find /` or `find / -name` commands due to their extreme slowness when searching the entire filesystem
- Recommended using the glob or grep tools as alternatives, or limiting find operations to the workspace directory

## Details
These changes address common inefficiencies in AI-generated bash commands by:
1. Reducing unnecessary directory navigation overhead
2. Preventing expensive full filesystem searches that can significantly slow down operations
3. Guiding the assistant toward more efficient file discovery methods appropriate for the workspace context

https://claude.ai/code/session_01DDENvWpwM7hpQCwPjAydzD

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> String-only prompt guidance changes; no runtime logic or data-flow modifications, but could subtly affect agent behavior in shell/file discovery.
> 
> **Overview**
> Updates `TOOL_USE_INSTRUCTIONS` in `PromptBuilder.ts` to better constrain AI-generated file operations.
> 
> The prompt now clarifies that bash commands already run from the workspace directory (avoiding redundant `cd`), and explicitly discourages `find /`-style full-filesystem searches in favor of glob/grep or limiting `find` to the workspace.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0c5b6af2840013134ffe8fadb3718fcd106a0a39. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->