### PR TITLE
Fix shell command timeout handling for piped processes

### DIFF
--- a/src/progressView/frontend/components/ToolTimer.ts
+++ b/src/progressView/frontend/components/ToolTimer.ts
@@ -2,6 +2,8 @@
  * Live elapsed-time timer for in-progress tool calls.
  *
  * Renders a ticking counter (e.g. "3s", "1min 12s") that updates every second.
+ * When a timeout limit is provided, displays "elapsed / limit" so the user
+ * can see how close the command is to being killed.
  * Automatically starts on connect and stops on disconnect.
  */
 
@@ -24,10 +26,16 @@ export class ToolTimer extends LitElement {
       margin-left: 6px;
       font-variant-numeric: tabular-nums;
     }
+    .timer-limit {
+      opacity: 0.6;
+    }
   `;
 
   /** Start timestamp in milliseconds (Date.now() epoch). */
   @property({ type: Number }) startTime = 0;
+
+  /** Timeout limit in milliseconds. When set, displayed as "elapsed / limit". */
+  @property({ type: Number }) timeoutMs = 0;
 
   @state() private _elapsed = '';
 
@@ -55,6 +63,11 @@ export class ToolTimer extends LitElement {
 
   override render(): TemplateResult {
     if (!this._elapsed) return html``;
+    if (this.timeoutMs > 0) {
+      const limit = formatDuration(this.timeoutMs);
+      // prettier-ignore
+      return html`<span class="timer">${this._elapsed}<span class="timer-limit"> / ${limit}</span></span>`;
+    }
     return html`<span class="timer">${this._elapsed}</span>`;
   }
 }

--- a/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
+++ b/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
@@ -7,6 +7,9 @@
  * templates with `// prettier-ignore` to prevent whitespace issues.
  */
 
+// Local imports - shared utilities
+import { isPlainObject } from '@shared/utils/string';
+
 // Local imports - Lit template utilities
 import {
   html,
@@ -42,6 +45,30 @@ import type { WebSearchPayload, LogMessageData } from '@shared/schemas';
 
 // Side-effect import to register <tool-timer> custom element
 import '../../components/ToolTimer';
+
+/** Default bash tool timeout (matches BASH_TIMEOUT_MS in src/tools/bash.ts). */
+const BASH_DEFAULT_TIMEOUT_MS = 120_000;
+
+/** Known per-tool default timeouts (ms) for display in the running timer. */
+const TOOL_DEFAULT_TIMEOUTS: Record<string, number> = {
+  bash: BASH_DEFAULT_TIMEOUT_MS,
+};
+
+/**
+ * Extract the effective timeout for a tool call from its input.
+ * Returns undefined for tools without a configurable timeout.
+ */
+function getToolTimeoutMs(
+  toolName: string,
+  input: unknown,
+): number | undefined {
+  const defaultTimeout = TOOL_DEFAULT_TIMEOUTS[toolName];
+  if (defaultTimeout === undefined) return undefined;
+  if (isPlainObject(input) && typeof input.timeout === 'number') {
+    return input.timeout;
+  }
+  return defaultTimeout;
+}
 
 /** Join template sections with horizontal rule separators. */
 function joinWithSeparator(sections: TemplateResult[]): TemplateResult {
@@ -340,9 +367,10 @@ export function formatToolUseTemplate(
   // prettier-ignore
   const bannerContentTemplate = html`<div class="banner-content log-entry-content" data-log-id=${ifDefined(id)} data-group-id=${ifDefined(groupId)} data-timestamp=${ifDefined(fullTimestamp)}>${contentTemplate}</div>`;
 
-  // Live timer for in-progress tools
+  // Live timer for in-progress tools, with timeout limit when available
+  const toolTimeoutMs = getToolTimeoutMs(toolName, input);
   // prettier-ignore
-  const timerTemplate = isInProgress ? html`<tool-timer .startTime=${timestamp}></tool-timer>` : undefined;
+  const timerTemplate = isInProgress ? html`<tool-timer .startTime=${timestamp} .timeoutMs=${toolTimeoutMs ?? 0}></tool-timer>` : undefined;
 
   // prettier-ignore
   return html`<details class=${classMap({

--- a/src/utils/system/execUtils.ts
+++ b/src/utils/system/execUtils.ts
@@ -101,6 +101,7 @@ export async function executeCommand(
     let subprocess: ResultPromise;
     let shellTimedOut = false;
     let shellTimeoutId: ReturnType<typeof setTimeout> | undefined;
+    let forceKillTimeoutId: ReturnType<typeof setTimeout> | undefined;
 
     if (Array.isArray(command)) {
       const [cmd, ...args] = command;
@@ -119,16 +120,23 @@ export async function executeCommand(
       // Fix: spawn in a new process group (detached) and manually kill the
       // entire group (-pid) on timeout so all children are terminated.
       //
+      // On Windows, negative-PID signaling is not supported so we fall back
+      // to subprocess.kill() (kills the shell only) + stream destruction.
+      //
       // Tradeoff: `detached` means the process group is NOT automatically
       // cleaned up if the extension host is hard-killed (SIGKILL / crash) --
       // long-running shell commands would be orphaned.  This only affects the
       // bash tool (all other callers use array-form commands which skip this
       // path).  Acceptable because the alternative is `await` hanging forever.
       const { timeout: _shellTimeout, ...execaNoTimeout } = execaOptions;
+      const isWindows = process.platform === 'win32';
       subprocess = execa(command, {
         ...execaNoTimeout,
         shell: true,
-        detached: true,
+        // On POSIX, detached creates a process group we can kill as a unit.
+        // On Windows, detached opens a new console window so we skip it and
+        // rely on subprocess.kill() + stream destruction instead.
+        detached: !isWindows,
       });
 
       if (_shellTimeout) {
@@ -137,20 +145,27 @@ export async function executeCommand(
           const pid = subprocess.pid;
           if (!pid) return;
 
-          try {
-            // Kill the entire process group (negative PID)
-            process.kill(-pid, 'SIGTERM');
-          } catch {
-            /* already exited */
+          if (isWindows) {
+            subprocess.kill('SIGTERM');
+          } else {
+            try {
+              process.kill(-pid, 'SIGTERM');
+            } catch {
+              /* already exited */
+            }
           }
 
           // Force-kill after FORCE_KILL_DELAY_MS if SIGTERM didn't work,
           // and destroy streams as a last resort to unblock `await subprocess`.
-          setTimeout(() => {
-            try {
-              process.kill(-pid, 'SIGKILL');
-            } catch {
-              /* already exited */
+          forceKillTimeoutId = setTimeout(() => {
+            if (isWindows) {
+              subprocess.kill('SIGKILL');
+            } else {
+              try {
+                process.kill(-pid, 'SIGKILL');
+              } catch {
+                /* already exited */
+              }
             }
             subprocess.stdout?.destroy();
             subprocess.stderr?.destroy();
@@ -173,6 +188,7 @@ export async function executeCommand(
 
     const result = await subprocess;
     if (shellTimeoutId !== undefined) clearTimeout(shellTimeoutId);
+    if (forceKillTimeoutId !== undefined) clearTimeout(forceKillTimeoutId);
 
     const stdout = (result.stdout as string) ?? '';
     const stderr = (result.stderr as string) ?? '';

--- a/src/utils/system/execUtils.ts
+++ b/src/utils/system/execUtils.ts
@@ -117,8 +117,10 @@ export async function executeCommand(
       // the shell process; the piped children keep stdout open which causes
       // `await subprocess` to hang indefinitely.
       //
-      // Fix: spawn in a new process group (detached) and manually kill the
-      // entire group (-pid) on timeout so all children are terminated.
+      // Fix: when a timeout is configured, spawn in a new process group
+      // (detached) and manually kill the entire group (-pid) on timeout so
+      // all children are terminated.  Without a timeout we use the normal
+      // (non-detached) path to avoid orphan risk on parent crash.
       //
       // On Windows, negative-PID signaling is not supported so we fall back
       // to subprocess.kill() (kills the shell only) + stream destruction.
@@ -130,13 +132,14 @@ export async function executeCommand(
       // path).  Acceptable because the alternative is `await` hanging forever.
       const { timeout: _shellTimeout, ...execaNoTimeout } = execaOptions;
       const isWindows = process.platform === 'win32';
+      // Only use detached when we have a timeout and need process-group killing.
+      // On POSIX, detached creates a process group we can kill as a unit.
+      // On Windows, detached opens a new console window so we always skip it.
+      const useDetached = !!_shellTimeout && !isWindows;
       subprocess = execa(command, {
         ...execaNoTimeout,
         shell: true,
-        // On POSIX, detached creates a process group we can kill as a unit.
-        // On Windows, detached opens a new console window so we skip it and
-        // rely on subprocess.kill() + stream destruction instead.
-        detached: !isWindows,
+        ...(useDetached ? { detached: true } : {}),
       });
 
       if (_shellTimeout) {

--- a/src/utils/system/execUtils.ts
+++ b/src/utils/system/execUtils.ts
@@ -70,6 +70,10 @@ export async function executeCommand(
     onStderr?: (chunk: string) => void;
   } = {},
 ): Promise<ExecResult> {
+  // Hoisted so the finally block can clear them on both success and error paths.
+  let shellTimeoutId: ReturnType<typeof setTimeout> | undefined;
+  let forceKillTimeoutId: ReturnType<typeof setTimeout> | undefined;
+
   try {
     const workspacePath = options.cwd ?? WorkspaceFS.getPath();
     if (!workspacePath) {
@@ -100,8 +104,6 @@ export async function executeCommand(
 
     let subprocess: ResultPromise;
     let shellTimedOut = false;
-    let shellTimeoutId: ReturnType<typeof setTimeout> | undefined;
-    let forceKillTimeoutId: ReturnType<typeof setTimeout> | undefined;
 
     if (Array.isArray(command)) {
       const [cmd, ...args] = command;
@@ -190,8 +192,6 @@ export async function executeCommand(
     }
 
     const result = await subprocess;
-    if (shellTimeoutId !== undefined) clearTimeout(shellTimeoutId);
-    if (forceKillTimeoutId !== undefined) clearTimeout(forceKillTimeoutId);
 
     const stdout = (result.stdout as string) ?? '';
     const stderr = (result.stderr as string) ?? '';
@@ -242,5 +242,8 @@ export async function executeCommand(
       timedOut: false, // Real timeouts are handled in the main flow via result.timedOut
       exitCode: 127, // Convention for command not found / execution failure
     };
+  } finally {
+    if (shellTimeoutId !== undefined) clearTimeout(shellTimeoutId);
+    if (forceKillTimeoutId !== undefined) clearTimeout(forceKillTimeoutId);
   }
 }

--- a/src/utils/system/execUtils.ts
+++ b/src/utils/system/execUtils.ts
@@ -118,6 +118,12 @@ export async function executeCommand(
       //
       // Fix: spawn in a new process group (detached) and manually kill the
       // entire group (-pid) on timeout so all children are terminated.
+      //
+      // Tradeoff: `detached` means the process group is NOT automatically
+      // cleaned up if the extension host is hard-killed (SIGKILL / crash) --
+      // long-running shell commands would be orphaned.  This only affects the
+      // bash tool (all other callers use array-form commands which skip this
+      // path).  Acceptable because the alternative is `await` hanging forever.
       const { timeout: _shellTimeout, ...execaNoTimeout } = execaOptions;
       subprocess = execa(command, {
         ...execaNoTimeout,

--- a/src/utils/system/execUtils.ts
+++ b/src/utils/system/execUtils.ts
@@ -1,5 +1,5 @@
 // Third-party imports
-import { execa, type Options, ExecaError } from 'execa';
+import { execa, type Options, type ResultPromise, ExecaError } from 'execa';
 import { quote as shellQuote } from 'shell-quote';
 
 /**
@@ -31,6 +31,7 @@ const CHANNEL = 'execUtils';
 logger.initialize(CHANNEL);
 
 const MAX_OUTPUT_LENGTH = 150;
+const FORCE_KILL_DELAY_MS = 5_000;
 
 /**
  * Truncate text to maxChars by keeping the end portion.
@@ -97,7 +98,10 @@ export async function executeCommand(
 
     const logChannel = options.channel ?? CHANNEL;
 
-    let subprocess;
+    let subprocess: ResultPromise;
+    let shellTimedOut = false;
+    let shellTimeoutId: ReturnType<typeof setTimeout> | undefined;
+
     if (Array.isArray(command)) {
       const [cmd, ...args] = command;
       logger.debug(
@@ -107,7 +111,46 @@ export async function executeCommand(
       subprocess = execa(cmd, args, execaOptions);
     } else {
       logger.debug(logChannel, `Running command: ${command}`);
-      subprocess = execa(command, { ...execaOptions, shell: true });
+      // Shell commands with pipes (e.g. "find / | head -2") create child
+      // processes that inherit stdout.  execa's built-in timeout only kills
+      // the shell process; the piped children keep stdout open which causes
+      // `await subprocess` to hang indefinitely.
+      //
+      // Fix: spawn in a new process group (detached) and manually kill the
+      // entire group (-pid) on timeout so all children are terminated.
+      const { timeout: _shellTimeout, ...execaNoTimeout } = execaOptions;
+      subprocess = execa(command, {
+        ...execaNoTimeout,
+        shell: true,
+        detached: true,
+      });
+
+      if (_shellTimeout) {
+        shellTimeoutId = setTimeout(() => {
+          shellTimedOut = true;
+          const pid = subprocess.pid;
+          if (!pid) return;
+
+          try {
+            // Kill the entire process group (negative PID)
+            process.kill(-pid, 'SIGTERM');
+          } catch {
+            /* already exited */
+          }
+
+          // Force-kill after FORCE_KILL_DELAY_MS if SIGTERM didn't work,
+          // and destroy streams as a last resort to unblock `await subprocess`.
+          setTimeout(() => {
+            try {
+              process.kill(-pid, 'SIGKILL');
+            } catch {
+              /* already exited */
+            }
+            subprocess.stdout?.destroy();
+            subprocess.stderr?.destroy();
+          }, FORCE_KILL_DELAY_MS);
+        }, _shellTimeout);
+      }
     }
 
     // Subscribe to stdout/stderr streams for live output if callbacks provided
@@ -123,11 +166,12 @@ export async function executeCommand(
     }
 
     const result = await subprocess;
+    if (shellTimeoutId !== undefined) clearTimeout(shellTimeoutId);
 
     const stdout = (result.stdout as string) ?? '';
     const stderr = (result.stderr as string) ?? '';
     const exitCode = result.exitCode ?? 1;
-    const timedOut = result.timedOut ?? false;
+    const timedOut = (result.timedOut ?? false) || shellTimedOut;
 
     const shouldTruncate = options.truncate ?? false;
     const formatForLog = (output: string | null) =>


### PR DESCRIPTION
## Summary
Fixed an issue where shell commands with pipes (e.g., `find / | head -2`) would hang indefinitely when a timeout was specified. The problem occurred because execa's built-in timeout only kills the shell process, leaving child processes from pipes still holding stdout open.

## Changes
- **Import `ResultPromise` type** from execa for proper subprocess type annotation
- **Add `FORCE_KILL_DELAY_MS` constant** (5 seconds) for force-kill escalation delay
- **Implement custom timeout handling for shell commands**:
  - Spawn shell commands in a detached process group to enable group-level termination
  - Remove execa's built-in timeout and implement manual timeout with `setTimeout`
  - On timeout, kill the entire process group using negative PID (`-pid`) with `SIGTERM`
  - Escalate to `SIGKILL` after 5 seconds if `SIGTERM` doesn't work
  - Destroy stdout/stderr streams as a last resort to unblock the await
- **Track timeout state** with `shellTimedOut` flag to properly report timeout status in results
- **Clear timeout** after subprocess completes to prevent memory leaks

## Implementation Details
The fix uses process group management (detached mode + negative PID in `process.kill()`) to ensure all child processes spawned by pipes are terminated together, preventing the hang that occurred when only the parent shell was killed.

https://claude.ai/code/session_01B77fe7GgYcPnWBus9ERxtP

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches process execution/termination logic and introduces detached process groups and manual kill escalation, which can impact reliability across platforms and edge cases.
> 
> **Overview**
> Fixes a hang when timing out shell string commands with pipes by bypassing `execa`’s built-in timeout and implementing manual timeout handling that terminates the full process group (with SIGTERM→SIGKILL escalation) and destroys streams as a last-resort to unblock `await`.
> 
> Updates the ProgressView running-tool timer to optionally show `elapsed / limit`, and wires tool-formatting to pass per-tool timeout defaults/overrides (currently `bash`) into `<tool-timer>`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d739d5477d68a99d74fef896bd4897e2ca300add. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->