### PR TITLE
Centralize feedback-eligible permission kinds and add bash feedback UI

### DIFF
--- a/src/progressView/frontend/components/PermissionCard.ts
+++ b/src/progressView/frontend/components/PermissionCard.ts
@@ -8,7 +8,10 @@ import { when } from 'lit/directives/when.js';
 import { AGENT_CATEGORY } from '@shared/schemas';
 import { getBasename } from '@shared/utils/path';
 import { getTextareaValue } from '@shared/utils/textarea';
-import { PERMISSION_KIND } from '@shared/utils/uiConstants';
+import {
+  FEEDBACK_ELIGIBLE_KINDS,
+  PERMISSION_KIND,
+} from '@shared/utils/uiConstants';
 import { postMessage } from '@shared/vscode';
 import { designTokens } from '@shared/styles/litStyles';
 import { codiconIconClasses } from '@shared/styles/codiconStyles';
@@ -64,13 +67,6 @@ const PERMISSION_TITLES: Record<PermissionState['kind'], string> = {
   [PERMISSION_KIND.RETRY]: 'Retry request',
   [PERMISSION_KIND.PROPOSAL]: 'Agent proposal',
 };
-
-/** Prompt kinds that support rejection feedback */
-const FEEDBACK_ELIGIBLE_PERMISSIONS = new Set<PermissionState['kind']>([
-  PERMISSION_KIND.TOOL_EDIT,
-  PERMISSION_KIND.BASH,
-  PERMISSION_KIND.PROPOSAL,
-]);
 
 /** Primary actions (approve/reject) for each permission type */
 const PRIMARY_ACTIONS: Record<PermissionState['kind'], ActionConfig[]> = {
@@ -438,7 +434,7 @@ export class PermissionCard extends LitElement {
   private canCollectFeedback(): boolean {
     return Boolean(
       this.permission &&
-      FEEDBACK_ELIGIBLE_PERMISSIONS.has(this.permission.kind),
+      FEEDBACK_ELIGIBLE_KINDS.has(this.permission.kind),
     );
   }
 

--- a/src/progressView/frontend/components/RequestPanels.ts
+++ b/src/progressView/frontend/components/RequestPanels.ts
@@ -51,6 +51,7 @@ import type { PermissionState } from './PermissionCard';
 
 const FEEDBACK_KINDS = new Set<PermissionState['kind']>([
   PERMISSION_KIND.TOOL_EDIT,
+  PERMISSION_KIND.BASH,
   PERMISSION_KIND.PROPOSAL,
 ]);
 
@@ -357,8 +358,16 @@ export class RequestPanels extends LitElement {
 
   private renderBashRequest(permission: PermissionState): TemplateResult {
     const data = permission.data as BashPermission;
+    const key = this.getPermissionKey(permission);
+    const isFeedbackOpen = this.feedbackOpenKeys.has(key);
     return html`
-      <div class="bash-approval-request">
+      <div
+        class=${classMap({
+          'bash-approval-request': true,
+          'bash-approval-request--feedback-active': isFeedbackOpen,
+        })}
+        data-permission-key=${key}
+      >
         <div class="bash-approval-request__details">
           <div class="bash-approval-request__command">
             ${buildCodeBlock(data.command ?? '', { language: 'bash' })}
@@ -375,15 +384,21 @@ export class RequestPanels extends LitElement {
             >Approve</vscode-toolbar-button
           >
           <vscode-toolbar-button
-            icon="close"
+            icon=${isFeedbackOpen ? 'check' : 'close'}
             data-action="reject"
             data-permission-kind=${permission.kind}
             data-permission-id=${this.getPermissionId(permission)}
-            label="Reject"
-            title="Reject this command (n)"
-            >Reject</vscode-toolbar-button
+            label=${isFeedbackOpen ? 'Submit' : 'Reject'}
+            title=${isFeedbackOpen ? 'Submit rejection (n)' : 'Reject this command (n)'}
+            >${isFeedbackOpen ? 'Submit' : 'Reject'}</vscode-toolbar-button
           >
         </vscode-toolbar-container>
+        ${this.renderFeedbackSection(
+          permission,
+          'bash-approval-request__feedback',
+          'bash-approval-request__feedback-input',
+          'Why are you rejecting?',
+        )}
       </div>
     `;
   }

--- a/src/progressView/frontend/components/RequestPanels.ts
+++ b/src/progressView/frontend/components/RequestPanels.ts
@@ -284,15 +284,7 @@ export class RequestPanels extends LitElement {
             title="Approve (y)"
             >Approve</vscode-toolbar-button
           >
-          <vscode-toolbar-button
-            icon=${isFeedbackOpen ? 'check' : 'close'}
-            data-action="reject"
-            data-permission-kind=${permission.kind}
-            data-permission-id=${this.getPermissionId(permission)}
-            label=${isFeedbackOpen ? 'Submit' : 'Reject'}
-            title=${isFeedbackOpen ? 'Submit rejection (n)' : 'Reject (n)'}
-            >${isFeedbackOpen ? 'Submit' : 'Reject'}</vscode-toolbar-button
-          >
+          ${this.renderRejectButton(permission, isFeedbackOpen, 'Reject (n)')}
         </vscode-toolbar-container>
         ${this.renderFeedbackSection(
           permission,
@@ -380,15 +372,7 @@ export class RequestPanels extends LitElement {
             title="Allow this command to execute (y)"
             >Approve</vscode-toolbar-button
           >
-          <vscode-toolbar-button
-            icon=${isFeedbackOpen ? 'check' : 'close'}
-            data-action="reject"
-            data-permission-kind=${permission.kind}
-            data-permission-id=${this.getPermissionId(permission)}
-            label=${isFeedbackOpen ? 'Submit' : 'Reject'}
-            title=${isFeedbackOpen ? 'Submit rejection (n)' : 'Reject this command (n)'}
-            >${isFeedbackOpen ? 'Submit' : 'Reject'}</vscode-toolbar-button
-          >
+          ${this.renderRejectButton(permission, isFeedbackOpen, 'Reject this command (n)')}
         </vscode-toolbar-container>
         ${this.renderFeedbackSection(
           permission,
@@ -515,15 +499,7 @@ export class RequestPanels extends LitElement {
             title="Approve (y)"
             >Approve</vscode-toolbar-button
           >
-          <vscode-toolbar-button
-            icon=${isFeedbackOpen ? 'check' : 'close'}
-            data-action="reject"
-            data-permission-kind=${permission.kind}
-            data-permission-id=${this.getPermissionId(permission)}
-            label=${isFeedbackOpen ? 'Submit' : 'Reject'}
-            title=${isFeedbackOpen ? 'Submit rejection (n)' : 'Reject (n)'}
-            >${isFeedbackOpen ? 'Submit' : 'Reject'}</vscode-toolbar-button
-          >
+          ${this.renderRejectButton(permission, isFeedbackOpen, 'Reject (n)')}
           <vscode-toolbar-button
             icon="settings-gear"
             data-action="setup"
@@ -892,6 +868,28 @@ export class RequestPanels extends LitElement {
     const raw = input?.value ?? '';
     const trimmed = raw.trim();
     return trimmed.length > 0 ? trimmed : undefined;
+  }
+
+  // ===========================================================================
+  // Shared renderers
+  // ===========================================================================
+
+  private renderRejectButton(
+    permission: PermissionState,
+    isFeedbackOpen: boolean,
+    rejectTitle: string,
+  ): TemplateResult {
+    return html`
+      <vscode-toolbar-button
+        icon=${isFeedbackOpen ? 'check' : 'close'}
+        data-action="reject"
+        data-permission-kind=${permission.kind}
+        data-permission-id=${this.getPermissionId(permission)}
+        label=${isFeedbackOpen ? 'Submit' : 'Reject'}
+        title=${isFeedbackOpen ? 'Submit rejection (n)' : rejectTitle}
+        >${isFeedbackOpen ? 'Submit' : 'Reject'}</vscode-toolbar-button
+      >
+    `;
   }
 
   // ===========================================================================

--- a/src/progressView/frontend/components/RequestPanels.ts
+++ b/src/progressView/frontend/components/RequestPanels.ts
@@ -35,7 +35,10 @@ import {
 
 // Local imports - shared utilities
 import { getBasename } from '@shared/utils/path';
-import { PERMISSION_KIND } from '@shared/utils/uiConstants';
+import {
+  FEEDBACK_ELIGIBLE_KINDS,
+  PERMISSION_KIND,
+} from '@shared/utils/uiConstants';
 import { postMessage } from '@shared/vscode';
 
 // Local imports - webview commands
@@ -48,12 +51,6 @@ import { getComposedPathElement } from '../utils';
 
 // Local imports - progress view component types
 import type { PermissionState } from './PermissionCard';
-
-const FEEDBACK_KINDS = new Set<PermissionState['kind']>([
-  PERMISSION_KIND.TOOL_EDIT,
-  PERMISSION_KIND.BASH,
-  PERMISSION_KIND.PROPOSAL,
-]);
 
 type PermissionKey = string;
 
@@ -613,7 +610,7 @@ export class RequestPanels extends LitElement {
     const key = this.getPermissionKey(permission);
     if (
       !this.feedbackOpenKeys.has(key) ||
-      !FEEDBACK_KINDS.has(permission.kind)
+      !FEEDBACK_ELIGIBLE_KINDS.has(permission.kind)
     ) {
       return nothing;
     }
@@ -688,7 +685,7 @@ export class RequestPanels extends LitElement {
     if (!permission) return;
 
     const key = this.getPermissionKey(permission);
-    if (action === 'reject' && FEEDBACK_KINDS.has(kind)) {
+    if (action === 'reject' && FEEDBACK_ELIGIBLE_KINDS.has(kind)) {
       if (!this.feedbackOpenKeys.has(key)) {
         this.openFeedback(key);
         return;
@@ -796,7 +793,7 @@ export class RequestPanels extends LitElement {
 
   /** Handle 'n' key for reject with feedback support */
   private handleRejectShortcut(permission: PermissionState): void {
-    if (!FEEDBACK_KINDS.has(permission.kind)) {
+    if (!FEEDBACK_ELIGIBLE_KINDS.has(permission.kind)) {
       this.emitAction(permission, 'reject');
       return;
     }

--- a/src/shared/styles/requestPanelStyles.ts
+++ b/src/shared/styles/requestPanelStyles.ts
@@ -189,20 +189,6 @@ export const requestPanelStyles: CSSResult = css`
     transform: rotate(180deg);
   }
 
-  .approval-request__feedback {
-    margin-top: var(--spacing-small);
-  }
-
-  .approval-request__feedback-input {
-    width: 100%;
-  }
-
-  .approval-request--feedback-active
-    .approval-request__actions
-    vscode-toolbar-button[data-action='reject']::part(control) {
-    color: var(--vscode-inputValidation-warningBorder);
-  }
-
   /* Bash approval requests */
   .bash-approval-requests {
     border: 1px solid var(--vscode-input-border);
@@ -229,20 +215,6 @@ export const requestPanelStyles: CSSResult = css`
 
   .bash-approval-request__actions vscode-toolbar-button {
     flex: 1 1 12rem;
-  }
-
-  .bash-approval-request__feedback {
-    margin-top: var(--spacing-small);
-  }
-
-  .bash-approval-request__feedback-input {
-    width: 100%;
-  }
-
-  .bash-approval-request--feedback-active
-    .bash-approval-request__actions
-    vscode-toolbar-button[data-action='reject']::part(control) {
-    color: var(--vscode-inputValidation-warningBorder);
   }
 
   /* Retry requests */
@@ -451,14 +423,25 @@ export const requestPanelStyles: CSSResult = css`
     color: var(--vscode-textLink-foreground);
   }
 
+  /* Rejection feedback (shared across approval, bash, proposal) */
+  .approval-request__feedback,
+  .bash-approval-request__feedback,
   .workflow-proposal__feedback {
     margin-top: var(--spacing-small);
   }
 
+  .approval-request__feedback-input,
+  .bash-approval-request__feedback-input,
   .workflow-proposal__feedback-input {
     width: 100%;
   }
 
+  .approval-request--feedback-active
+    .approval-request__actions
+    vscode-toolbar-button[data-action='reject']::part(control),
+  .bash-approval-request--feedback-active
+    .bash-approval-request__actions
+    vscode-toolbar-button[data-action='reject']::part(control),
   .workflow-proposal--feedback-active
     .workflow-proposal__actions
     vscode-toolbar-button[data-action='reject']::part(control) {

--- a/src/shared/styles/requestPanelStyles.ts
+++ b/src/shared/styles/requestPanelStyles.ts
@@ -231,6 +231,20 @@ export const requestPanelStyles: CSSResult = css`
     flex: 1 1 12rem;
   }
 
+  .bash-approval-request__feedback {
+    margin-top: var(--spacing-small);
+  }
+
+  .bash-approval-request__feedback-input {
+    width: 100%;
+  }
+
+  .bash-approval-request--feedback-active
+    .bash-approval-request__actions
+    vscode-toolbar-button[data-action='reject']::part(control) {
+    color: var(--vscode-inputValidation-warningBorder);
+  }
+
   /* Retry requests */
   .retry-requests {
     border: 1px solid var(--vscode-input-border);

--- a/src/shared/utils/uiConstants.ts
+++ b/src/shared/utils/uiConstants.ts
@@ -16,6 +16,13 @@ export const PERMISSION_KIND = {
 export type PermissionKind =
   (typeof PERMISSION_KIND)[keyof typeof PERMISSION_KIND];
 
+/** Permission kinds that support rejection feedback */
+export const FEEDBACK_ELIGIBLE_KINDS = new Set<PermissionKind>([
+  PERMISSION_KIND.TOOL_EDIT,
+  PERMISSION_KIND.BASH,
+  PERMISSION_KIND.PROPOSAL,
+]);
+
 /** Generates the getting started banner HTML with command links. */
 export function getGettingStartedHtml(prefix = ''): string {
   return (


### PR DESCRIPTION
## Summary
This PR centralizes the definition of permission kinds that support rejection feedback and extends feedback collection to bash permission requests.

## Key Changes
- **Centralized constant**: Moved `FEEDBACK_ELIGIBLE_PERMISSIONS` from `PermissionCard.ts` and `FEEDBACK_KINDS` from `RequestPanels.ts` to a shared `FEEDBACK_ELIGIBLE_KINDS` constant in `uiConstants.ts`
- **Bash feedback support**: Extended the feedback-eligible kinds to include `PERMISSION_KIND.BASH` (previously only `TOOL_EDIT` and `PROPOSAL` supported feedback)
- **Enhanced bash UI**: 
  - Added feedback section rendering for bash approval requests
  - Implemented dynamic button state: "Reject" → "Submit" when feedback is open
  - Added visual indicator (warning color) on the submit button when feedback is active
  - Added CSS styling for the feedback section and active state
- **Consistent imports**: Updated both component files to import the centralized constant from `uiConstants.ts`

## Implementation Details
- The `FEEDBACK_ELIGIBLE_KINDS` is now a single source of truth, reducing duplication and making it easier to add feedback support to new permission types in the future
- Bash feedback UI follows the same pattern as existing feedback implementations in other permission types
- The feedback section is conditionally rendered only when feedback is open, maintaining a clean UI when not in use

https://claude.ai/code/session_01N5H5CJyzC5eu3Jfj8Jhuc6

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily UI refactoring plus expanding rejection feedback collection to `bash` prompts; low risk aside from potential UI/UX regressions in the approval panels.
> 
> **Overview**
> Centralizes the “rejection feedback eligible” permission-kind list into shared `FEEDBACK_ELIGIBLE_KINDS` (in `uiConstants.ts`) and updates both `PermissionCard` and `RequestPanels` to use it instead of local sets.
> 
> Extends rejection feedback collection to `bash` command approvals in `RequestPanels`, including rendering a feedback textarea, toggling the reject button label/icon between Reject and Submit, and applying shared CSS to highlight the reject button when feedback is active.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bd190cb82d4c93084692eecc2faa1fdac7c83ef4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->