### PR TITLE
Fix stream tab delete button clipped at narrow panel widths

### DIFF
--- a/src/progressView/frontend/components/StreamTabs.ts
+++ b/src/progressView/frontend/components/StreamTabs.ts
@@ -66,7 +66,7 @@ export class StreamTabs extends LitElement {
         display: flex;
         flex-direction: column;
         flex: 1;
-        min-width: 200px;
+        min-width: 0;
         font-size: var(--font-size-sm);
         border-left: var(--border-thin) solid var(--color-border);
         height: 100%;


### PR DESCRIPTION
The .tabs container had min-width: 200px, which forced it wider
than its parent when the split-layout end panel was narrow. Since
the host has overflow: hidden, the rightmost content (the delete
button) was clipped. Changing to min-width: 0 lets the flex layout
shrink naturally—.tab (flex:1) truncates its text while .tab-delete
(flex-shrink:0) stays visible at any width.

https://claude.ai/code/session_012TGoHES7j73eUj5nb9Gh3P

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only change scoped to the stream tabs layout; minimal behavioral risk aside from minor layout differences at small widths.
> 
> **Overview**
> Adjusts the `StreamTabs` sidebar flex styling so it can shrink within narrow split-panel widths.
> 
> Specifically changes `.tabs` from `min-width: 200px` to `min-width: 0`, preventing horizontal overflow that previously caused the tab delete button to be clipped.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7989f3e16ee5e235ad703f02eeb584349ecfd755. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->