### PR TITLE
refactor: simplify agent execution lifecycle — reduce abstraction overhead

### DIFF
--- a/resources/templates/agentTemplate-toolUse.yaml
+++ b/resources/templates/agentTemplate-toolUse.yaml
@@ -1,5 +1,5 @@
-name: {{ AGENT_NAME }}
-description: {{ DESCRIPTION }}
+name: { { AGENT_NAME } }
+description: { { DESCRIPTION } }
 
 # --- Agent Settings ---
 settings:

--- a/resources/templates/agentTemplate-workflowSingle.yaml
+++ b/resources/templates/agentTemplate-workflowSingle.yaml
@@ -1,6 +1,6 @@
 # --- Agent Inheritance (Optional) ---
 # inherits: base
-name: {{ AGENT_NAME }}
+name: { { AGENT_NAME } }
 
 # --- Agent Settings ---
 settings:
@@ -10,8 +10,8 @@ settings:
   endTag: </latex_document>
   outputExt: tex
   prefills:
-    - "<scratchpad>"
-    - "<scratchpad>"
+    - '<scratchpad>'
+    - '<scratchpad>'
 
 # --- Agent Prompts ---
 prompts:
@@ -61,7 +61,7 @@ prompts:
 
   userRequest:
     - |
-        Brainstorm your plan in <scratchpad> with bullet points.
-        Then output the revised \LaTeX wrapped in <latex_document> tags.
+      Brainstorm your plan in <scratchpad> with bullet points.
+      Then output the revised \LaTeX wrapped in <latex_document> tags.
     - |
-        Reflect on your previous revision and describe the most impactful follow-up edits in <scratchpad> before producing the updated <latex_document> output.
+      Reflect on your previous revision and describe the most impactful follow-up edits in <scratchpad> before producing the updated <latex_document> output.

--- a/src/agent/core/AgentState.ts
+++ b/src/agent/core/AgentState.ts
@@ -8,7 +8,6 @@ import {
 } from '@agent/types/NormalizedUsage';
 import {
   DEFAULT_TOTALS,
-  RunUsageAccumulator,
   RunUsageAccumulatorJSONSchema,
   createUsageAccumulator,
   recordNormalizedUsage,
@@ -50,13 +49,6 @@ export function createRoundState(
   };
 }
 
-/** Parse and validate a round state snapshot. */
-export function parseRoundState(
-  snapshot: unknown,
-): ConversationRoundStateSnapshot {
-  return ConversationRoundStateSnapshotSchema.parse(snapshot);
-}
-
 // ============================================================================
 // AgentRunState — plain data + functions
 // ============================================================================
@@ -91,11 +83,6 @@ export function createRunState(): AgentRunStateSnapshot {
   };
 }
 
-/** Parse and validate a run state snapshot. */
-export function parseRunState(snapshot: unknown): AgentRunStateSnapshot {
-  return AgentRunStateSnapshotSchema.parse(snapshot);
-}
-
 /**
  * Record cycle metrics into run state. Mutates run in place.
  * Used by both reflection flows (via recordRound) and tool-use flows (directly).
@@ -128,101 +115,3 @@ export function recordRound(
   );
 }
 
-// ============================================================================
-// Backward-compatible classes (delegate to standalone functions)
-// ============================================================================
-
-/**
- * @deprecated Use ConversationRoundStateSnapshot + standalone functions instead.
- */
-export class ConversationRoundState {
-  public roundIndex: number;
-  public continuationCount = 0;
-  public responseTimeMs = 0;
-  public normalizedUsage: NormalizedUsage | null = null;
-
-  constructor(roundIndex: number) {
-    this.roundIndex = roundIndex;
-  }
-
-  static fromSnapshot(snapshot: unknown): ConversationRoundState {
-    const parsed = ConversationRoundStateSnapshotSchema.parse(snapshot);
-    const state = new ConversationRoundState(parsed.roundIndex);
-    state.continuationCount = parsed.continuationCount;
-    state.responseTimeMs = parsed.responseTimeMs;
-    state.normalizedUsage = parsed.normalizedUsage;
-    return state;
-  }
-
-  toSnapshot(): ConversationRoundStateSnapshot {
-    return {
-      roundIndex: this.roundIndex,
-      continuationCount: this.continuationCount,
-      responseTimeMs: this.responseTimeMs,
-      normalizedUsage: this.normalizedUsage,
-    };
-  }
-
-  incrementContinuation(): void {
-    this.continuationCount += 1;
-  }
-
-  addResponseTime(durationMs: number): void {
-    this.responseTimeMs += durationMs;
-  }
-}
-
-/**
- * @deprecated Use AgentRunStateSnapshot + standalone functions instead.
- */
-export class AgentRunState {
-  public totalRounds = 0;
-  public totalResponseTimeMs = 0;
-  public readonly usageAccumulator: RunUsageAccumulator;
-
-  constructor(accumulator?: RunUsageAccumulator) {
-    this.usageAccumulator = accumulator ?? new RunUsageAccumulator();
-  }
-
-  static fromSnapshot(snapshot: unknown): AgentRunState {
-    const parsed = AgentRunStateSnapshotSchema.parse(snapshot);
-    const usageAccumulator = RunUsageAccumulator.fromSnapshot(
-      parsed.usageAccumulator,
-    );
-    const state = new AgentRunState(usageAccumulator);
-    state.totalRounds = parsed.totalRounds;
-    state.totalResponseTimeMs = parsed.totalResponseTimeMs;
-    return state;
-  }
-
-  toSnapshot(): AgentRunStateSnapshot {
-    return {
-      totalRounds: this.totalRounds,
-      totalResponseTimeMs: this.totalResponseTimeMs,
-      usageAccumulator: this.usageAccumulator.toSnapshot(),
-    };
-  }
-
-  incrementRounds(): void {
-    this.totalRounds += 1;
-  }
-
-  recordCycleMetrics(
-    cycleIndex: number,
-    responseTimeMs: number,
-    normalizedUsage: NormalizedUsage | null,
-  ): void {
-    if (normalizedUsage) {
-      this.usageAccumulator.recordNormalizedUsage(cycleIndex, normalizedUsage);
-    }
-    this.totalResponseTimeMs += responseTimeMs;
-  }
-
-  recordRound(roundState: ConversationRoundState): void {
-    this.recordCycleMetrics(
-      roundState.roundIndex,
-      roundState.responseTimeMs,
-      roundState.normalizedUsage,
-    );
-  }
-}

--- a/src/agent/core/AgentState.ts
+++ b/src/agent/core/AgentState.ts
@@ -10,7 +10,14 @@ import {
   DEFAULT_TOTALS,
   RunUsageAccumulator,
   RunUsageAccumulatorJSONSchema,
+  createUsageAccumulator,
+  recordNormalizedUsage,
+  type RunUsageAccumulatorJSON,
 } from './RunUsageAccumulator';
+
+// ============================================================================
+// ConversationRoundState — plain data + functions
+// ============================================================================
 
 /**
  * Schema for ConversationRoundState snapshot.
@@ -31,44 +38,28 @@ export type ConversationRoundStateSnapshot = z.output<
   typeof ConversationRoundStateSnapshotSchema
 >;
 
-export class ConversationRoundState {
-  public roundIndex: number;
-  public continuationCount = 0;
-  public responseTimeMs = 0;
-  public normalizedUsage: NormalizedUsage | null = null;
-
-  constructor(roundIndex: number) {
-    this.roundIndex = roundIndex;
-  }
-
-  /** Deserialize from a snapshot. Validates and applies schema defaults. */
-  static fromSnapshot(snapshot: unknown): ConversationRoundState {
-    const parsed = ConversationRoundStateSnapshotSchema.parse(snapshot);
-    const state = new ConversationRoundState(parsed.roundIndex);
-    state.continuationCount = parsed.continuationCount;
-    state.responseTimeMs = parsed.responseTimeMs;
-    state.normalizedUsage = parsed.normalizedUsage;
-    return state;
-  }
-
-  /** Serialize to a snapshot. */
-  toSnapshot(): ConversationRoundStateSnapshot {
-    return {
-      roundIndex: this.roundIndex,
-      continuationCount: this.continuationCount,
-      responseTimeMs: this.responseTimeMs,
-      normalizedUsage: this.normalizedUsage,
-    };
-  }
-
-  incrementContinuation(): void {
-    this.continuationCount += 1;
-  }
-
-  addResponseTime(durationMs: number): void {
-    this.responseTimeMs += durationMs;
-  }
+/** Create a fresh round state for the given round index. */
+export function createRoundState(
+  roundIndex: number,
+): ConversationRoundStateSnapshot {
+  return {
+    roundIndex,
+    continuationCount: 0,
+    responseTimeMs: 0,
+    normalizedUsage: null,
+  };
 }
+
+/** Parse and validate a round state snapshot. */
+export function parseRoundState(
+  snapshot: unknown,
+): ConversationRoundStateSnapshot {
+  return ConversationRoundStateSnapshotSchema.parse(snapshot);
+}
+
+// ============================================================================
+// AgentRunState — plain data + functions
+// ============================================================================
 
 /**
  * Schema for AgentRunState snapshot.
@@ -91,6 +82,99 @@ export type AgentRunStateSnapshot = z.output<
   typeof AgentRunStateSnapshotSchema
 >;
 
+/** Create a fresh run state (all zeros). */
+export function createRunState(): AgentRunStateSnapshot {
+  return {
+    totalRounds: 0,
+    totalResponseTimeMs: 0,
+    usageAccumulator: createUsageAccumulator(),
+  };
+}
+
+/** Parse and validate a run state snapshot. */
+export function parseRunState(snapshot: unknown): AgentRunStateSnapshot {
+  return AgentRunStateSnapshotSchema.parse(snapshot);
+}
+
+/**
+ * Record cycle metrics into run state. Mutates run in place.
+ * Used by both reflection flows (via recordRound) and tool-use flows (directly).
+ */
+export function recordCycleMetrics(
+  run: AgentRunStateSnapshot,
+  cycleIndex: number,
+  responseTimeMs: number,
+  normalizedUsage: NormalizedUsage | null,
+): void {
+  if (normalizedUsage) {
+    recordNormalizedUsage(run.usageAccumulator, cycleIndex, normalizedUsage);
+  }
+  run.totalResponseTimeMs += responseTimeMs;
+}
+
+/**
+ * Record round metrics from a ConversationRoundState snapshot.
+ * Delegates to recordCycleMetrics() for the actual work.
+ */
+export function recordRound(
+  run: AgentRunStateSnapshot,
+  roundState: ConversationRoundStateSnapshot,
+): void {
+  recordCycleMetrics(
+    run,
+    roundState.roundIndex,
+    roundState.responseTimeMs,
+    roundState.normalizedUsage,
+  );
+}
+
+// ============================================================================
+// Backward-compatible classes (delegate to standalone functions)
+// ============================================================================
+
+/**
+ * @deprecated Use ConversationRoundStateSnapshot + standalone functions instead.
+ */
+export class ConversationRoundState {
+  public roundIndex: number;
+  public continuationCount = 0;
+  public responseTimeMs = 0;
+  public normalizedUsage: NormalizedUsage | null = null;
+
+  constructor(roundIndex: number) {
+    this.roundIndex = roundIndex;
+  }
+
+  static fromSnapshot(snapshot: unknown): ConversationRoundState {
+    const parsed = ConversationRoundStateSnapshotSchema.parse(snapshot);
+    const state = new ConversationRoundState(parsed.roundIndex);
+    state.continuationCount = parsed.continuationCount;
+    state.responseTimeMs = parsed.responseTimeMs;
+    state.normalizedUsage = parsed.normalizedUsage;
+    return state;
+  }
+
+  toSnapshot(): ConversationRoundStateSnapshot {
+    return {
+      roundIndex: this.roundIndex,
+      continuationCount: this.continuationCount,
+      responseTimeMs: this.responseTimeMs,
+      normalizedUsage: this.normalizedUsage,
+    };
+  }
+
+  incrementContinuation(): void {
+    this.continuationCount += 1;
+  }
+
+  addResponseTime(durationMs: number): void {
+    this.responseTimeMs += durationMs;
+  }
+}
+
+/**
+ * @deprecated Use AgentRunStateSnapshot + standalone functions instead.
+ */
 export class AgentRunState {
   public totalRounds = 0;
   public totalResponseTimeMs = 0;
@@ -100,7 +184,6 @@ export class AgentRunState {
     this.usageAccumulator = accumulator ?? new RunUsageAccumulator();
   }
 
-  /** Deserialize from a snapshot. Validates and applies schema defaults. */
   static fromSnapshot(snapshot: unknown): AgentRunState {
     const parsed = AgentRunStateSnapshotSchema.parse(snapshot);
     const usageAccumulator = RunUsageAccumulator.fromSnapshot(
@@ -112,7 +195,6 @@ export class AgentRunState {
     return state;
   }
 
-  /** Serialize to a snapshot. */
   toSnapshot(): AgentRunStateSnapshot {
     return {
       totalRounds: this.totalRounds,
@@ -125,10 +207,6 @@ export class AgentRunState {
     this.totalRounds += 1;
   }
 
-  /**
-   * Record cycle metrics (single source of truth).
-   * Used by both reflection flows (via recordRound) and tool-use flows (directly).
-   */
   recordCycleMetrics(
     cycleIndex: number,
     responseTimeMs: number,
@@ -140,10 +218,6 @@ export class AgentRunState {
     this.totalResponseTimeMs += responseTimeMs;
   }
 
-  /**
-   * Record round metrics from a ConversationRoundState object.
-   * Delegates to recordCycleMetrics() for the actual work.
-   */
   recordRound(roundState: ConversationRoundState): void {
     this.recordCycleMetrics(
       roundState.roundIndex,

--- a/src/agent/core/AgentState.ts
+++ b/src/agent/core/AgentState.ts
@@ -114,4 +114,3 @@ export function recordRound(
     roundState.normalizedUsage,
   );
 }
-

--- a/src/agent/core/RunUsageAccumulator.ts
+++ b/src/agent/core/RunUsageAccumulator.ts
@@ -126,4 +126,3 @@ export function mergeAccumulators(
 
   target.normalizedSnapshots.push(...source.normalizedSnapshots);
 }
-

--- a/src/agent/core/RunUsageAccumulator.ts
+++ b/src/agent/core/RunUsageAccumulator.ts
@@ -82,11 +82,6 @@ export function createUsageAccumulator(): RunUsageAccumulatorJSON {
   return { totals: { ...DEFAULT_TOTALS }, normalizedSnapshots: [] };
 }
 
-/** Parse a snapshot, applying schema defaults. */
-export function parseUsageAccumulator(snapshot: unknown): RunUsageAccumulatorJSON {
-  return RunUsageAccumulatorJSONSchema.parse(snapshot);
-}
-
 /** Record a normalized usage entry. Mutates acc in place. */
 export function recordNormalizedUsage(
   acc: RunUsageAccumulatorJSON,
@@ -132,47 +127,3 @@ export function mergeAccumulators(
   target.normalizedSnapshots.push(...source.normalizedSnapshots);
 }
 
-// ============================================================================
-// Backward-compatible class (delegates to standalone functions)
-// ============================================================================
-
-/**
- * @deprecated Use plain RunUsageAccumulatorJSON + standalone functions instead.
- * Kept for backward compatibility during migration.
- */
-export class RunUsageAccumulator {
-  private data: RunUsageAccumulatorJSON;
-
-  constructor() {
-    this.data = createUsageAccumulator();
-  }
-
-  static fromSnapshot(snapshot: unknown): RunUsageAccumulator {
-    const acc = new RunUsageAccumulator();
-    acc.data = parseUsageAccumulator(snapshot);
-    return acc;
-  }
-
-  toSnapshot(): RunUsageAccumulatorJSON {
-    return {
-      totals: this.data.totals,
-      normalizedSnapshots: [...this.data.normalizedSnapshots],
-    };
-  }
-
-  recordNormalizedUsage(round: number, usage: NormalizedUsage): void {
-    recordNormalizedUsage(this.data, round, usage);
-  }
-
-  merge(other: RunUsageAccumulator): void {
-    mergeAccumulators(this.data, other.data);
-  }
-
-  getTotals(): RunUsageTotals {
-    return this.data.totals;
-  }
-
-  getNormalizedSnapshots(): readonly { round: number; usage: NormalizedUsage }[] {
-    return this.data.normalizedSnapshots;
-  }
-}

--- a/src/agent/core/RunUsageAccumulator.ts
+++ b/src/agent/core/RunUsageAccumulator.ts
@@ -48,14 +48,13 @@ const RunUsageTotalsSchema = z.object({
     .number()
     .prefault(DEFAULT_TOTALS.totalServerToolRequests),
 });
-type RunUsageTotals = z.infer<typeof RunUsageTotalsSchema>;
+export type RunUsageTotals = z.infer<typeof RunUsageTotalsSchema>;
 
 /** Schema for normalized usage snapshot. Internal only. */
 const NormalizedUsageSnapshotSchema = z.object({
   round: z.number(),
   usage: NormalizedUsageSchema,
 });
-type NormalizedUsageSnapshot = z.infer<typeof NormalizedUsageSnapshotSchema>;
 
 /**
  * Schema for RunUsageAccumulator JSON serialization.
@@ -74,68 +73,106 @@ export type RunUsageAccumulatorJSON = z.output<
   typeof RunUsageAccumulatorJSONSchema
 >;
 
-export class RunUsageAccumulator {
-  private totals: RunUsageTotals = { ...DEFAULT_TOTALS };
-  private readonly normalizedSnapshots: NormalizedUsageSnapshot[] = [];
+// ============================================================================
+// Standalone functions operating on RunUsageAccumulatorJSON
+// ============================================================================
 
-  /** Deserialize from a snapshot. Schema transform handles default merging. */
+/** Create a fresh accumulator (all zeros). */
+export function createUsageAccumulator(): RunUsageAccumulatorJSON {
+  return { totals: { ...DEFAULT_TOTALS }, normalizedSnapshots: [] };
+}
+
+/** Parse a snapshot, applying schema defaults. */
+export function parseUsageAccumulator(snapshot: unknown): RunUsageAccumulatorJSON {
+  return RunUsageAccumulatorJSONSchema.parse(snapshot);
+}
+
+/** Record a normalized usage entry. Mutates acc in place. */
+export function recordNormalizedUsage(
+  acc: RunUsageAccumulatorJSON,
+  round: number,
+  usage: NormalizedUsage,
+): void {
+  if (acc.totals.firstInputTokens === 0) {
+    acc.totals.firstInputTokens = usage.inputTokens;
+  }
+
+  acc.totals.totalInputTokens += usage.inputTokens;
+  acc.totals.totalOutputTokens += usage.outputTokens;
+  acc.totals.totalCost += usage.cost;
+  acc.totals.totalCacheReadInputTokens += usage.cachedInputTokens ?? 0;
+  acc.totals.totalCacheCreationInputTokens += usage.cacheCreationTokens ?? 0;
+  acc.totals.totalReasoningTokens += usage.reasoningTokens ?? 0;
+  acc.totals.totalToolUsePromptTokens += usage.toolUsePromptTokens ?? 0;
+  acc.totals.totalServerToolRequests += usage.serverToolRequests ?? 0;
+
+  acc.normalizedSnapshots.push({ round, usage });
+}
+
+/** Merge another accumulator's data into this one. Mutates target in place. */
+export function mergeAccumulators(
+  target: RunUsageAccumulatorJSON,
+  source: RunUsageAccumulatorJSON,
+): void {
+  const src = source.totals;
+  if (target.totals.firstInputTokens === 0) {
+    target.totals.firstInputTokens = src.firstInputTokens;
+  }
+
+  target.totals.totalInputTokens += src.totalInputTokens;
+  target.totals.totalOutputTokens += src.totalOutputTokens;
+  target.totals.totalCost += src.totalCost;
+  target.totals.totalCacheReadInputTokens += src.totalCacheReadInputTokens;
+  target.totals.totalCacheCreationInputTokens +=
+    src.totalCacheCreationInputTokens;
+  target.totals.totalReasoningTokens += src.totalReasoningTokens;
+  target.totals.totalToolUsePromptTokens += src.totalToolUsePromptTokens;
+  target.totals.totalServerToolRequests += src.totalServerToolRequests;
+
+  target.normalizedSnapshots.push(...source.normalizedSnapshots);
+}
+
+// ============================================================================
+// Backward-compatible class (delegates to standalone functions)
+// ============================================================================
+
+/**
+ * @deprecated Use plain RunUsageAccumulatorJSON + standalone functions instead.
+ * Kept for backward compatibility during migration.
+ */
+export class RunUsageAccumulator {
+  private data: RunUsageAccumulatorJSON;
+
+  constructor() {
+    this.data = createUsageAccumulator();
+  }
+
   static fromSnapshot(snapshot: unknown): RunUsageAccumulator {
-    const parsed = RunUsageAccumulatorJSONSchema.parse(snapshot);
     const acc = new RunUsageAccumulator();
-    acc.totals = parsed.totals;
-    acc.normalizedSnapshots.push(...parsed.normalizedSnapshots);
+    acc.data = parseUsageAccumulator(snapshot);
     return acc;
   }
 
-  /** Serialize to a snapshot. */
   toSnapshot(): RunUsageAccumulatorJSON {
     return {
-      totals: this.totals,
-      normalizedSnapshots: [...this.normalizedSnapshots],
+      totals: this.data.totals,
+      normalizedSnapshots: [...this.data.normalizedSnapshots],
     };
   }
 
   recordNormalizedUsage(round: number, usage: NormalizedUsage): void {
-    if (this.totals.firstInputTokens === 0) {
-      this.totals.firstInputTokens = usage.inputTokens;
-    }
-
-    this.totals.totalInputTokens += usage.inputTokens;
-    this.totals.totalOutputTokens += usage.outputTokens;
-    this.totals.totalCost += usage.cost;
-    this.totals.totalCacheReadInputTokens += usage.cachedInputTokens ?? 0;
-    this.totals.totalCacheCreationInputTokens += usage.cacheCreationTokens ?? 0;
-    this.totals.totalReasoningTokens += usage.reasoningTokens ?? 0;
-    this.totals.totalToolUsePromptTokens += usage.toolUsePromptTokens ?? 0;
-    this.totals.totalServerToolRequests += usage.serverToolRequests ?? 0;
-
-    this.normalizedSnapshots.push({ round, usage });
+    recordNormalizedUsage(this.data, round, usage);
   }
 
   merge(other: RunUsageAccumulator): void {
-    const src = other.totals;
-    if (this.totals.firstInputTokens === 0) {
-      this.totals.firstInputTokens = src.firstInputTokens;
-    }
-
-    this.totals.totalInputTokens += src.totalInputTokens;
-    this.totals.totalOutputTokens += src.totalOutputTokens;
-    this.totals.totalCost += src.totalCost;
-    this.totals.totalCacheReadInputTokens += src.totalCacheReadInputTokens;
-    this.totals.totalCacheCreationInputTokens +=
-      src.totalCacheCreationInputTokens;
-    this.totals.totalReasoningTokens += src.totalReasoningTokens;
-    this.totals.totalToolUsePromptTokens += src.totalToolUsePromptTokens;
-    this.totals.totalServerToolRequests += src.totalServerToolRequests;
-
-    this.normalizedSnapshots.push(...other.normalizedSnapshots);
+    mergeAccumulators(this.data, other.data);
   }
 
   getTotals(): RunUsageTotals {
-    return this.totals;
+    return this.data.totals;
   }
 
-  getNormalizedSnapshots(): readonly NormalizedUsageSnapshot[] {
-    return this.normalizedSnapshots;
+  getNormalizedSnapshots(): readonly { round: number; usage: NormalizedUsage }[] {
+    return this.data.normalizedSnapshots;
   }
 }

--- a/src/agent/core/flows/CycleServices.ts
+++ b/src/agent/core/flows/CycleServices.ts
@@ -4,8 +4,8 @@
  */
 
 import type {
-  AgentRunState,
-  ConversationRoundState,
+  AgentRunStateSnapshot,
+  ConversationRoundStateSnapshot,
 } from '@agent/core/AgentState';
 import type { AgentCycleBaseOptions } from '@agent/core/AgentCycleOptions';
 import type { AgentConfig } from '@agent/core/AgentConfig';
@@ -20,19 +20,19 @@ import type { TaskRunFileService } from '@utils/files';
 
 /** Callback invoked when a round/cycle completes for usage tracking. */
 export type RoundFinalizedCallback = (
-  run: AgentRunState,
+  run: AgentRunStateSnapshot,
 ) => void | Promise<void>;
 
 /** Base state slices common to all cycle flows. */
 export interface BaseCycleStateSlices {
-  readonly run: AgentRunState;
+  readonly run: AgentRunStateSnapshot;
   readonly workspace: AgentWorkspaceState;
   readonly onRoundFinalized?: RoundFinalizedCallback;
 }
 
 /** State slices for response cycle flows (includes round for workflow agents). */
 export interface CycleStateSlices extends BaseCycleStateSlices {
-  round: ConversationRoundState;
+  round: ConversationRoundStateSnapshot;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -9,6 +9,7 @@ import {
 } from '@shared/schemas';
 import { isRemoteAgent } from '@agent/index';
 import { BaseNode, Flow } from '@agent/node';
+import { recordRound } from '@agent/core/AgentState';
 import type { NormalizedUsage } from '@agent/types/NormalizedUsage';
 import {
   BaseCycleFieldsSchema,
@@ -556,7 +557,7 @@ class ResponseProcessNode<C> extends BaseNode<
     const result = execRes.value;
 
     if (shared.responseTimeMs !== undefined) {
-      round.addResponseTime(shared.responseTimeMs);
+      round.responseTimeMs += shared.responseTimeMs;
     }
 
     if (result.normalizedUsage) {
@@ -669,7 +670,7 @@ class ResponseCycleFinalizeNode<C> extends BaseNode<
   /** Finalize the round by recording stats and invoking callback. */
   async exec(): Promise<void> {
     const { round, run, onRoundFinalized } = this.services;
-    run.recordRound(round);
+    recordRound(run, round);
     if (onRoundFinalized) {
       await onRoundFinalized(run);
     }
@@ -778,7 +779,7 @@ class ResponseContinuationNode<C> extends BaseNode<
       return FlowTransition.COMPLETE;
     }
 
-    round.incrementContinuation();
+    round.continuationCount += 1;
     logger.info(`Starting continuation #${round.continuationCount}`, {
       messageType: MESSAGE_TYPES.PROGRESS_STATUS,
     });

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -6,6 +6,7 @@ import { z } from 'zod';
 import { MESSAGE_TYPES } from '@shared/schemas';
 import { isRemoteAgent } from '@agent/index';
 import { BaseNode, BatchNode, Flow } from '@agent/node';
+import { recordCycleMetrics } from '@agent/core/AgentState';
 import {
   BaseCycleFieldsSchema,
   BaseInvocationPrepResult,
@@ -527,7 +528,8 @@ class ToolUseProcessNode<C> extends BaseNode<
       shared.cycleNormalizedUsage = execRes.normalizedUsage;
     }
 
-    run.recordCycleMetrics(
+    recordCycleMetrics(
+      run,
       shared.cycleIndex,
       shared.cycleResponseTimeMs,
       shared.cycleNormalizedUsage ?? null,
@@ -535,7 +537,7 @@ class ToolUseProcessNode<C> extends BaseNode<
     if (onRoundFinalized) {
       await onRoundFinalized(run);
     }
-    run.incrementRounds();
+    run.totalRounds += 1;
 
     shared.stopReason = execRes.stopReason;
 

--- a/src/agent/core/index.ts
+++ b/src/agent/core/index.ts
@@ -18,4 +18,3 @@ export { AgentConfigSchema, type AgentConfig } from './AgentConfig';
 
 // State classes - commonly instantiated
 export { AgentWorkspaceState } from './AgentWorkspaceState';
-export { ConversationRoundState } from './AgentState';

--- a/src/agent/implementations/flows/reflection/ReflectionFlowState.ts
+++ b/src/agent/implementations/flows/reflection/ReflectionFlowState.ts
@@ -14,7 +14,6 @@ import { z } from 'zod';
 import { AgentFileLocationSchema, RoundOutputSchema } from '@shared/schemas';
 import {
   AgentRunStateSnapshotSchema,
-  ConversationRoundState,
   ConversationRoundStateSnapshotSchema,
   type AgentRunStateSnapshot,
   type ConversationRoundStateSnapshot,

--- a/src/agent/implementations/flows/reflection/nodes/PrepareContextNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/PrepareContextNode.ts
@@ -6,7 +6,7 @@
  */
 
 import { Node } from '@agent/node';
-import { ConversationRoundState } from '@agent/core/AgentState';
+import { createRoundState } from '@agent/core/AgentState';
 import { FlowTransition } from '@agent/core/flows/FlowTransitions';
 import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
 
@@ -32,7 +32,7 @@ export class PrepareContextNode<C = unknown> extends Node<
     const { promptBuilder, modelHandler, logger } = this.services;
     const { currentRound, conversation } = shared;
 
-    const stateRound = new ConversationRoundState(currentRound);
+    const stateRound = createRoundState(currentRound);
     const isFirstRound = currentRound === 0;
 
     let messages: ProviderMessage[];
@@ -62,7 +62,7 @@ export class PrepareContextNode<C = unknown> extends Node<
     return {
       messages,
       prefill: prefill ?? '',
-      stateRoundSnapshot: stateRound.toSnapshot(),
+      stateRoundSnapshot: stateRound,
     };
   }
 

--- a/src/agent/implementations/flows/reflection/nodes/ResponseCycleNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/ResponseCycleNode.ts
@@ -23,7 +23,7 @@
 
 import { Node } from '@agent/node';
 import { FlowTransition } from '@agent/core/flows/FlowTransitions';
-import { ConversationRoundState, AgentRunState } from '@agent/core/AgentState';
+import { recordRound, parseRunState } from '@agent/core/AgentState';
 import { AgentWorkspaceState } from '@agent/core/AgentWorkspaceState';
 import {
   createResponseCycleFlow,
@@ -92,14 +92,13 @@ export class ResponseCycleNode<C = unknown> extends Node<
       );
     }
 
-    // Reconstruct state instances from snapshots
+    // Reconstruct workspace from snapshot (has internal data structures: Sets, Maps)
     const workspace = AgentWorkspaceState.fromSnapshot(
       shared.workspaceSnapshot,
     );
-    const run = AgentRunState.fromSnapshot(shared.runStateSnapshot);
-    const round = ConversationRoundState.fromSnapshot(
-      context.stateRoundSnapshot,
-    );
+    // Run and round are plain data — use directly from shared state
+    const run = parseRunState(shared.runStateSnapshot);
+    const round = context.stateRoundSnapshot;
 
     return {
       shared,
@@ -171,7 +170,18 @@ export class ResponseCycleNode<C = unknown> extends Node<
       const flowServices: ResponseCycleServices<C> & {
         refreshClient: () => Promise<void>;
       } = {
-        ...this.services,
+        // Explicit field selection — only pass what cycle flow actually uses
+        modelHandler: this.services.modelHandler,
+        setting: this.services.setting,
+        prompt: this.services.prompt,
+        logger: this.services.logger,
+        streamId: this.services.streamId,
+        executionId: this.services.executionId,
+        userVarChannels: this.services.userVarChannels,
+        checkInterruption: this.services.checkInterruption,
+        setAbortController: this.services.setAbortController,
+        config: this.services.config,
+        fileService: this.services.fileService,
         get client() {
           return clientRef.current;
         },
@@ -197,7 +207,7 @@ export class ResponseCycleNode<C = unknown> extends Node<
       };
     } catch (error) {
       // Error path: finalize round on unexpected errors
-      prepRes.run.recordRound(prepRes.round);
+      recordRound(prepRes.run, prepRes.round);
       if (onRoundFinalized) {
         await onRoundFinalized(prepRes.run);
       }
@@ -260,7 +270,7 @@ export class ResponseCycleNode<C = unknown> extends Node<
     shared.lastError = undefined;
 
     // Update snapshots from slices (accessed via prepRes, not execRes)
-    shared.runStateSnapshot = prepRes.run.toSnapshot();
+    shared.runStateSnapshot = prepRes.run;
     shared.workspaceSnapshot = prepRes.workspace.toSnapshot();
 
     // Sync conversation state - messages modified in-place during cycle

--- a/src/agent/implementations/flows/reflection/nodes/ResponseCycleNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/ResponseCycleNode.ts
@@ -23,7 +23,7 @@
 
 import { Node } from '@agent/node';
 import { FlowTransition } from '@agent/core/flows/FlowTransitions';
-import { recordRound, parseRunState } from '@agent/core/AgentState';
+import { recordRound } from '@agent/core/AgentState';
 import { AgentWorkspaceState } from '@agent/core/AgentWorkspaceState';
 import {
   createResponseCycleFlow,
@@ -97,7 +97,7 @@ export class ResponseCycleNode<C = unknown> extends Node<
       shared.workspaceSnapshot,
     );
     // Run and round are plain data — use directly from shared state
-    const run = parseRunState(shared.runStateSnapshot);
+    const run = shared.runStateSnapshot;
     const round = context.stateRoundSnapshot;
 
     return {

--- a/src/agent/implementations/flows/reflection/runReflectionFlow.ts
+++ b/src/agent/implementations/flows/reflection/runReflectionFlow.ts
@@ -22,9 +22,7 @@
 import * as path from 'path';
 
 import {
-  EXECUTION_STATUS,
   type EndGroupStatus,
-  type ExecutionStatus,
   type RoundOutput,
   type StorageKey,
 } from '@shared/schemas';
@@ -49,7 +47,7 @@ import {
 import type { BaseFlowContextInit } from '@agent/implementations/flows/common/BaseFlowServices';
 import { retryCoordinator } from '@agent/runtime/RetryRequestCoordinator';
 import { getOutputFileName } from '@agent/utils/outputFileUtils';
-import { AgentRunState } from '@agent/core/AgentState';
+import { createRunState } from '@agent/core/AgentState';
 import { AgentWorkspaceState } from '@agent/core/AgentWorkspaceState';
 import type { AgentWorkflowSetting } from '@agent/core/AgentDataclass';
 import { type FlowRecord } from '@agent/node/persisted-flow';
@@ -311,7 +309,7 @@ export async function runReflectionFlow<C = unknown>(
         context: null,
         outputLocation: null,
         conversation: [],
-        runStateSnapshot: new AgentRunState().toSnapshot(),
+        runStateSnapshot: createRunState(),
         roundStateSnapshots: [],
         roundOutputs: [],
         continueRounds: true,
@@ -321,34 +319,25 @@ export async function runReflectionFlow<C = unknown>(
 
     // Create RoundPersistedFlow with the start node
     const startNode = createReflectionFlow<C>().start;
-    const flowResult = {
-      status: EXECUTION_STATUS.COMPLETED as ExecutionStatus,
-    };
     const pf = new RoundPersistedFlow<
       ReflectionFlowShared,
       Record<string, unknown>,
       ReflectionServices<C>
     >(startNode, kv, {
       parentStage,
-      hooks: {
+      callbacks: {
         createRoundStage: async (roundIndex, parent) => {
           return await logger.stage(`r${roundIndex}`, {
             parent: parent ?? undefined,
           });
         },
-        onRoundStart: (context) => {
-          // Set the active group ID for statistics logging so that
-          // statistics are associated with the current round (r0, r1, etc.)
-          // instead of the parent stage
-          usageMonitor?.setActiveGroupId(context.roundStage?.id);
+        onStageCreated: (stage) => {
+          usageMonitor?.setActiveGroupId(stage.id);
         },
         resetForNextRound: (s) => {
           s.workspaceSnapshot = AgentWorkspaceState.create().toSnapshot();
         },
         checkInterruption,
-        onFlowEnd: (_shared, flowEndStatus) => {
-          flowResult.status = flowEndStatus;
-        },
       },
     });
 
@@ -373,9 +362,9 @@ export async function runReflectionFlow<C = unknown>(
       logger.debug('Resuming reflection flow from persistence');
     }
 
-    await pf.run(shared);
+    const flowStatus = await pf.run(shared);
     shared = await pf.getShared();
-    status = toEndStatus(flowResult.status);
+    status = toEndStatus(flowStatus);
   } catch (error) {
     status = ERROR_STATUS;
     throw error;

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
@@ -5,7 +5,7 @@
  */
 import { Node } from '@agent/node';
 import { FlowTransition } from '@agent/core/flows/FlowTransitions';
-import { AgentRunState } from '@agent/core/AgentState';
+import { parseRunState } from '@agent/core/AgentState';
 import { AgentWorkspaceState } from '@agent/core/AgentWorkspaceState';
 import {
   createToolUseCycleFlow,
@@ -38,7 +38,7 @@ export class ToolUseCycleNode<C> extends Node<
     return {
       shouldSkip: shared.shouldSkipCycle,
       conversation: shared.conversation,
-      runState: AgentRunState.fromSnapshot(shared.stateSlices.runStateSnapshot),
+      runState: parseRunState(shared.stateSlices.runStateSnapshot),
       workspaceState: AgentWorkspaceState.fromSnapshot(
         shared.stateSlices.workspaceSnapshot,
       ),
@@ -89,8 +89,19 @@ export class ToolUseCycleNode<C> extends Node<
     const flowServices: ToolUseCycleServices<C> & {
       refreshClient: () => Promise<void>;
     } = {
-      ...this.services,
+      // Explicit field selection — only pass what cycle flow actually uses
+      modelHandler,
       setting: { ...setting, tools: resolvedTools },
+      prompt: this.services.prompt,
+      logger: this.services.logger,
+      streamId,
+      executionId: this.services.executionId,
+      userVarChannels: this.services.userVarChannels,
+      checkInterruption: this.services.checkInterruption,
+      setAbortController: this.services.setAbortController,
+      toolRegistry: this.services.toolRegistry,
+      session: this.services.session,
+      onFollowUpConsumed: this.services.onFollowUpConsumed,
       get client() {
         return clientRef.current;
       },
@@ -146,7 +157,7 @@ export class ToolUseCycleNode<C> extends Node<
     }
 
     shared.stateSlices = {
-      runStateSnapshot: prepRes.runState.toSnapshot(),
+      runStateSnapshot: prepRes.runState,
       workspaceSnapshot: prepRes.workspaceState.toSnapshot(),
       userChannels: prepRes.userChannels,
     };

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
@@ -5,7 +5,6 @@
  */
 import { Node } from '@agent/node';
 import { FlowTransition } from '@agent/core/flows/FlowTransitions';
-import { parseRunState } from '@agent/core/AgentState';
 import { AgentWorkspaceState } from '@agent/core/AgentWorkspaceState';
 import {
   createToolUseCycleFlow,
@@ -38,7 +37,7 @@ export class ToolUseCycleNode<C> extends Node<
     return {
       shouldSkip: shared.shouldSkipCycle,
       conversation: shared.conversation,
-      runState: parseRunState(shared.stateSlices.runStateSnapshot),
+      runState: shared.stateSlices.runStateSnapshot,
       workspaceState: AgentWorkspaceState.fromSnapshot(
         shared.stateSlices.workspaceSnapshot,
       ),

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUsePrepareNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUsePrepareNode.ts
@@ -5,7 +5,7 @@
  */
 import { Node } from '@agent/node';
 import { FlowTransition } from '@agent/core/flows/FlowTransitions';
-import { AgentRunState } from '@agent/core/AgentState';
+import { createRunState, parseRunState } from '@agent/core/AgentState';
 import { AgentWorkspaceState } from '@agent/core/AgentWorkspaceState';
 import { buildInitialToolUsePrompts } from '@utils/prompt';
 
@@ -33,7 +33,7 @@ export class ToolUsePrepareNode<C> extends Node<
         kind: 'success',
         result: {
           messages: snapshot.messages,
-          runState: AgentRunState.fromSnapshot(snapshot.run),
+          runState: parseRunState(snapshot.run),
           workspaceState: AgentWorkspaceState.fromSnapshot(snapshot.workspace),
           userChannels: {
             input: Object.freeze({ ...snapshot.user.input }),
@@ -44,7 +44,7 @@ export class ToolUsePrepareNode<C> extends Node<
       };
     }
 
-    const runState = new AgentRunState();
+    const runState = createRunState();
     const workspaceState = AgentWorkspaceState.create();
     const memoryEnabled = this.services.resolvedTools.some(
       (t) => t.name === 'memory',
@@ -113,7 +113,7 @@ export class ToolUsePrepareNode<C> extends Node<
     shared.conversation = [...messages];
     shared.shouldSkipCycle = shouldSkipCycle;
     shared.stateSlices = {
-      runStateSnapshot: runState.toSnapshot(),
+      runStateSnapshot: runState,
       workspaceSnapshot: workspaceState.toSnapshot(),
       userChannels,
     };

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUsePrepareNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUsePrepareNode.ts
@@ -5,7 +5,7 @@
  */
 import { Node } from '@agent/node';
 import { FlowTransition } from '@agent/core/flows/FlowTransitions';
-import { createRunState, parseRunState } from '@agent/core/AgentState';
+import { createRunState } from '@agent/core/AgentState';
 import { AgentWorkspaceState } from '@agent/core/AgentWorkspaceState';
 import { buildInitialToolUsePrompts } from '@utils/prompt';
 
@@ -33,7 +33,7 @@ export class ToolUsePrepareNode<C> extends Node<
         kind: 'success',
         result: {
           messages: snapshot.messages,
-          runState: parseRunState(snapshot.run),
+          runState: snapshot.run,
           workspaceState: AgentWorkspaceState.fromSnapshot(snapshot.workspace),
           userChannels: {
             input: Object.freeze({ ...snapshot.user.input }),

--- a/src/agent/implementations/flows/tooluse/nodes/types.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/types.ts
@@ -3,10 +3,7 @@
  */
 import { z } from 'zod';
 
-import type {
-  AgentRunState,
-  AgentRunStateSnapshot,
-} from '@agent/core/AgentState';
+import type { AgentRunStateSnapshot } from '@agent/core/AgentState';
 import type {
   AgentWorkspaceState,
   AgentWorkspaceSnapshot,
@@ -30,7 +27,7 @@ export interface ToolUseRunShared {
 }
 
 interface NodeResultStateBase {
-  runState: AgentRunState;
+  runState: AgentRunStateSnapshot;
   workspaceState: AgentWorkspaceState;
   userChannels: UserVariableChannels;
 }

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -12,7 +12,10 @@ import { getServerSideKeyService } from '@auth/serverKeys';
 // Local imports - agent
 import type { AgentConfig } from '@agent/core/AgentConfig';
 import { AgentCategory, type AgentSetting } from '@agent/core/AgentDataclass';
-import type { ConversationRoundStateSnapshot, AgentRunStateSnapshot } from '@agent/core/AgentState';
+import type {
+  ConversationRoundStateSnapshot,
+  AgentRunStateSnapshot,
+} from '@agent/core/AgentState';
 import { AgentWorkspaceState } from '@agent/core/AgentWorkspaceState';
 import { MediaEntry } from '@agent/utils/mediaTypes';
 import type { NormalizedUsage } from '@agent/types/NormalizedUsage';

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -12,7 +12,7 @@ import { getServerSideKeyService } from '@auth/serverKeys';
 // Local imports - agent
 import type { AgentConfig } from '@agent/core/AgentConfig';
 import { AgentCategory, type AgentSetting } from '@agent/core/AgentDataclass';
-import { ConversationRoundState, AgentRunState } from '@agent/core/AgentState';
+import type { ConversationRoundStateSnapshot, AgentRunStateSnapshot } from '@agent/core/AgentState';
 import { AgentWorkspaceState } from '@agent/core/AgentWorkspaceState';
 import { MediaEntry } from '@agent/utils/mediaTypes';
 import type { NormalizedUsage } from '@agent/types/NormalizedUsage';
@@ -510,12 +510,12 @@ export abstract class ModelHandler<
   public checkStopConditions(
     stopReason: ProviderStopReason,
     newResponse: string,
-    stateRound: ConversationRoundState,
-    stateGlobal: AgentRunState,
+    stateRound: ConversationRoundStateSnapshot,
+    stateGlobal: AgentRunStateSnapshot,
     agentSetting: AgentSetting,
   ): StopConditionsResult {
     // Compute token-based stop flags
-    const totals = stateGlobal.usageAccumulator.getTotals();
+    const totals = stateGlobal.usageAccumulator.totals;
     const maxOutputTokens =
       totals.firstInputTokens > 0
         ? this.maxOutputTokensFactor * totals.firstInputTokens

--- a/src/agent/modelHandlers/types/IModelHandler.ts
+++ b/src/agent/modelHandlers/types/IModelHandler.ts
@@ -2,7 +2,10 @@
 import type { AgentConfig } from '@agent/core/AgentConfig';
 // Internal imports
 import { AgentCategory, type AgentSetting } from '@agent/core/AgentDataclass';
-import type { ConversationRoundStateSnapshot, AgentRunStateSnapshot } from '@agent/core/AgentState';
+import type {
+  ConversationRoundStateSnapshot,
+  AgentRunStateSnapshot,
+} from '@agent/core/AgentState';
 import { AgentWorkspaceState } from '@agent/core/AgentWorkspaceState';
 import type { ProviderUsage } from '@agent/core/ResponseUsage';
 import type { NormalizedUsage } from '@agent/types/NormalizedUsage';

--- a/src/agent/modelHandlers/types/IModelHandler.ts
+++ b/src/agent/modelHandlers/types/IModelHandler.ts
@@ -2,7 +2,7 @@
 import type { AgentConfig } from '@agent/core/AgentConfig';
 // Internal imports
 import { AgentCategory, type AgentSetting } from '@agent/core/AgentDataclass';
-import { ConversationRoundState, AgentRunState } from '@agent/core/AgentState';
+import type { ConversationRoundStateSnapshot, AgentRunStateSnapshot } from '@agent/core/AgentState';
 import { AgentWorkspaceState } from '@agent/core/AgentWorkspaceState';
 import type { ProviderUsage } from '@agent/core/ResponseUsage';
 import type { NormalizedUsage } from '@agent/types/NormalizedUsage';
@@ -337,8 +337,8 @@ export interface IModelHandler<
   checkStopConditions(
     stopReason: ProviderStopReason,
     newResponse: string,
-    stateRound: ConversationRoundState,
-    stateGlobal: AgentRunState,
+    stateRound: ConversationRoundStateSnapshot,
+    stateGlobal: AgentRunStateSnapshot,
     agentSetting: AgentSetting,
   ): StopConditionsResult;
 

--- a/src/agent/node/round-persisted-flow.ts
+++ b/src/agent/node/round-persisted-flow.ts
@@ -1,47 +1,18 @@
 /**
  * RoundPersistedFlow - Flow-level round management with persistence.
  *
- * ## Design Philosophy
- *
- * Round lifecycle is a FLOW-level concern. This class extends PersistedFlow
- * to centrally manage round transitions, including:
+ * Extends PersistedFlow to centrally manage round transitions:
  * - Round counter increment (single source of truth)
  * - Round stage creation/ending
  * - Workspace reset between rounds
  *
- * ## Command-Based Round Transitions
+ * Nodes signal intent via FlowTransitions (CONTINUE_NEXT_ROUND or FINALIZE),
+ * and this class handles all round management.
  *
- * Nodes signal their intent via FlowTransitions, not by mutating state:
- * - `CONTINUE_NEXT_ROUND`: Round completed successfully, continue to next
- * - `FINALIZE`: All rounds complete or interrupted, exit flow
- *
- * RoundPersistedFlow reads these signals and OWNS the increment:
- * - Increments currentRound centrally (single source of truth)
- * - Triggers lifecycle hooks (stages, workspace reset)
- * - Checks bounds before incrementing
- *
- * ## Inheritance Pattern
- *
+ * Inheritance:
  * ```
- * Flow (base orchestration)
- *   ↓ extends
- * PersistedFlow (adds node-level persistence via step())
- *   ↓ extends
- * RoundPersistedFlow (adds round management)
+ * Flow → PersistedFlow → RoundPersistedFlow
  * ```
- *
- * ## What Flow Owns
- *
- * - Round counter increment (currentRound)
- * - Round stage creation/end
- * - Workspace reset between rounds
- * - Bounds checking (single source of truth)
- *
- * ## What Nodes Do
- *
- * - Signal intent (CONTINUE_NEXT_ROUND or FINALIZE)
- * - Pure domain logic (prepare context, run model, process output)
- * - Set flags like continueRounds=false to request interruption
  */
 
 import { EXECUTION_STATUS, type ExecutionStatus } from '@shared/schemas';
@@ -59,13 +30,7 @@ import { isRoundAtOrBeyondLimit } from './round-bounds';
 
 /**
  * Minimum state interface for round-aware flows.
- *
- * Flows using RoundPersistedFlow must have shared state that includes these fields.
- * This ensures the flow can track round progression and control continuation.
- *
- * Note: This interface is intentionally minimal. Domain-specific fields like
- * `endTurn` belong in flow-specific state types (e.g., ReflectionFlowShared),
- * not here. RoundPersistedFlow only needs these core orchestration fields.
+ * RoundPersistedFlow only needs these core orchestration fields.
  */
 export interface RoundAwareState {
   /** Current round index (0-based) */
@@ -79,84 +44,16 @@ export interface RoundAwareState {
 }
 
 // ============================================================================
-// Lifecycle Hooks Interface
+// Callbacks
 // ============================================================================
 
 /**
- * Context passed to lifecycle hooks.
- *
- * Access round info via shared state (no duplication):
- * - context.shared.currentRound (0-based index)
- * - context.shared.totalRounds
- * - context.shared.continueRounds
+ * Callbacks for round orchestration. All are optional.
  */
-export interface RoundHookContext<S extends RoundAwareState> {
-  /** Current shared state (readonly in hooks) */
-  shared: Readonly<S>;
-
-  /** Current round stage (for logging) */
-  roundStage: AgentLogStage | null;
-}
-
-/**
- * Lifecycle hooks for round orchestration.
- *
- * All hooks are optional and async-capable.
- */
-export interface RoundLifecycleHooks<S extends RoundAwareState, Svc = unknown> {
+export interface RoundCallbacks<S extends RoundAwareState> {
   /**
-   * Called at the start of each round, after stage is created.
-   *
-   * Use for:
-   * - Logging round start
-   * - Registering usage tracking callbacks
-   * - Pre-round validation
-   */
-  onRoundStart?: (
-    context: RoundHookContext<S>,
-    services: Svc,
-  ) => void | Promise<void>;
-
-  /**
-   * Called at the end of each round, before stage is closed.
-   *
-   * Use for:
-   * - Recording round results
-   * - Cleanup before next round
-   * - Logging round completion
-   */
-  onRoundEnd?: (
-    context: RoundHookContext<S>,
-    services: Svc,
-  ) => void | Promise<void>;
-
-  /**
-   * Called when all rounds complete (success or interruption).
-   *
-   * Use for:
-   * - Final cleanup
-   * - Aggregate reporting
-   * - Resource deallocation
-   */
-  onFlowEnd?: (
-    shared: S,
-    status: ExecutionStatus,
-    services: Svc,
-  ) => void | Promise<void>;
-
-  /**
-   * Called to check if execution should be interrupted.
-   *
-   * If not provided, rounds continue until totalRounds or continueRounds=false.
-   */
-  checkInterruption?: () => boolean;
-
-  /**
-   * Called to create a round stage for logging.
-   *
-   * @param roundIndex - The round index (0-based)
-   * @param parentStage - The parent run stage
-   * @returns The created round stage
+   * Create a round stage for logging. Also receives the created stage
+   * for side effects (e.g. registering usage tracking).
    */
   createRoundStage?: (
     roundIndex: number,
@@ -164,26 +61,16 @@ export interface RoundLifecycleHooks<S extends RoundAwareState, Svc = unknown> {
   ) => Promise<AgentLogStage>;
 
   /**
-   * Called to reset workspace state for a new round.
-   *
-   * @param shared - The shared state to mutate
+   * Called after a new round stage is created.
+   * Use for registering usage tracking callbacks etc.
    */
+  onStageCreated?: (stage: AgentLogStage) => void;
+
+  /** Check if execution should be interrupted. */
+  checkInterruption?: () => boolean;
+
+  /** Reset workspace state for a new round. */
   resetForNextRound?: (shared: S) => void;
-}
-
-// ============================================================================
-// Round Flow Configuration
-// ============================================================================
-
-/**
- * Configuration for RoundPersistedFlow.
- */
-export interface RoundFlowConfig<S extends RoundAwareState, Svc = unknown> {
-  /** Lifecycle hooks (all optional) */
-  hooks?: RoundLifecycleHooks<S, Svc>;
-
-  /** Parent stage for round stages (optional) */
-  parentStage?: AgentLogStage | null;
 }
 
 // ============================================================================
@@ -193,66 +80,39 @@ export interface RoundFlowConfig<S extends RoundAwareState, Svc = unknown> {
 /**
  * A PersistedFlow that manages round lifecycle automatically.
  *
- * Extends PersistedFlow with command-based round transitions.
  * Nodes signal intent via FlowTransitions (CONTINUE_NEXT_ROUND or FINALIZE),
- * and this class handles all round management:
+ * and this class handles incrementing, stages, resets, and bounds checking.
  *
- * - Incrementing currentRound (single source of truth)
- * - Creating/ending round stages
- * - Resetting workspace between rounds
- * - Checking bounds to prevent over-iteration
- *
- * ## Usage
- *
- * ```typescript
- * const flow = new RoundPersistedFlow(startNode, kv, {
- *   hooks: {
- *     createRoundStage: async (idx, parent) => {
- *       return await logger.stage(`r${idx}`, { parent });
- *     },
- *     resetForNextRound: (shared) => {
- *       shared.workspaceSnapshot = createFreshWorkspaceSnapshot();
- *     },
- *   },
- *   parentStage: runStage,
- * });
- *
- * await flow.run(shared);
- * // After run, use getShared() to get final state
- * const finalState = await flow.getShared();
- * ```
- *
- * @template S - Shared state type (must extend RoundAwareState)
- * @template P - Params type
- * @template Svc - Services type
+ * Returns ExecutionStatus directly from run() — no onFlowEnd callback needed.
  */
 export class RoundPersistedFlow<
   S extends RoundAwareState = RoundAwareState,
   P extends Record<string, unknown> = Record<string, unknown>,
   Svc = unknown,
 > extends PersistedFlow<S, P, Svc> {
-  private readonly config: RoundFlowConfig<S, Svc>;
+  private readonly callbacks: RoundCallbacks<S>;
+  private readonly parentStage: AgentLogStage | null;
   private currentRoundStage: AgentLogStage | null = null;
 
   constructor(
     start: BaseNode<any, any>,
     kv: ExecutionKVStore,
-    config?: RoundFlowConfig<S, Svc>,
+    options?: {
+      callbacks?: RoundCallbacks<S>;
+      parentStage?: AgentLogStage | null;
+    },
     runId?: string,
   ) {
     super(start, kv, runId);
-    this.config = config ?? {};
+    this.callbacks = options?.callbacks ?? {};
+    this.parentStage = options?.parentStage ?? null;
   }
 
   /**
    * Execute an async operation within the current round stage's context.
-   *
-   * This ensures the AsyncLocalStorage context is properly set so that
-   * logger.withCurrentGroup() can resolve the active group ID for logging.
-   * Without this wrapper, logs emitted during node execution would not
-   * be associated with the r0/r1/etc. groups in the progress view.
+   * Ensures AsyncLocalStorage context is set for proper log grouping.
    */
-  private async runWithinStageContext<T>(fn: () => Promise<T>): Promise<T> {
+  private async inStage<T>(fn: () => Promise<T>): Promise<T> {
     if (this.currentRoundStage) {
       return this.currentRoundStage.within(fn);
     }
@@ -261,91 +121,46 @@ export class RoundPersistedFlow<
 
   /**
    * Run the flow with automatic round management.
-   *
-   * Uses stepWithResult() to efficiently get both action and shared state
-   * in a single storage read per step (no redundant reads).
-   *
-   * Note: The passed `shared` parameter is used for initialization only.
-   * After run() completes, use getShared() to get the final state.
+   * Returns the execution status directly.
    */
-  async run(shared: S): Promise<string | undefined> {
-    const { hooks } = this.config;
+  async run(shared: S): Promise<ExecutionStatus> {
+    const { callbacks } = this;
     let status: ExecutionStatus = EXECUTION_STATUS.COMPLETED;
 
-    // Initialize flow record with initial shared state
     await this.init(shared);
-
-    // Current shared state reference (updated from stepWithResult)
     let currentShared = shared;
 
     try {
       // Create initial round stage (r0)
-      if (hooks?.createRoundStage) {
-        this.currentRoundStage = await hooks.createRoundStage(
-          currentShared.currentRound,
-          this.config.parentStage ?? null,
-        );
-      }
+      await this.createStage(currentShared.currentRound);
 
-      // Hook: Initial round start (within stage context for proper logging)
-      if (hooks?.onRoundStart) {
-        await this.runWithinStageContext(async () => {
-          await hooks.onRoundStart!(
-            this.createHookContext(currentShared),
-            this._services as Svc,
-          );
-        });
-      }
-
-      // Execute nodes via stepWithResult() - single read per step
-      // Each step runs within the current stage context for proper log grouping
-      let stepResult = await this.runWithinStageContext(() =>
-        this.stepWithResult(),
-      );
+      // Execute nodes via stepWithResult()
+      let stepResult = await this.inStage(() => this.stepWithResult());
       while (stepResult.hasMore) {
-        // Use the shared state returned by stepWithResult (authoritative)
         currentShared = stepResult.shared;
 
-        // Check interruption before round transition for responsive cancellation
-        if (hooks?.checkInterruption?.()) {
+        if (callbacks.checkInterruption?.()) {
           currentShared.continueRounds = false;
           break;
         }
 
-        // Handle round transition if signaled (manages stage context internally)
         if (stepResult.action === FlowTransition.CONTINUE_NEXT_ROUND) {
-          await this.handleContinueToNextRound(currentShared);
+          await this.transitionToNextRound(currentShared);
         }
 
-        // Execute next step within current stage context
-        stepResult = await this.runWithinStageContext(() =>
-          this.stepWithResult(),
-        );
+        stepResult = await this.inStage(() => this.stepWithResult());
       }
 
-      // Get final shared state from last step
       currentShared = stepResult.shared;
 
-      // Hook: Final round end (within stage context for proper logging)
-      if (hooks?.onRoundEnd) {
-        await this.runWithinStageContext(async () => {
-          await hooks.onRoundEnd!(
-            this.createHookContext(currentShared),
-            this._services as Svc,
-          );
-        });
-      }
-
-      // Determine final status: interrupted if stopped before completing all rounds
+      // Determine final status
       const completedAllRounds = isRoundAtOrBeyondLimit(
         currentShared.currentRound + 1,
         currentShared.totalRounds,
       );
-      // Only mark as interrupted if we didn't complete all rounds
-      // (either user interrupted or continueRounds was set to false)
       const wasInterrupted =
         !completedAllRounds &&
-        (hooks?.checkInterruption?.() || !currentShared.continueRounds);
+        (callbacks.checkInterruption?.() || !currentShared.continueRounds);
       if (wasInterrupted) {
         status = EXECUTION_STATUS.INTERRUPTED;
       }
@@ -353,87 +168,47 @@ export class RoundPersistedFlow<
       status = EXECUTION_STATUS.ERROR;
       throw error;
     } finally {
-      // End final round stage
       this.currentRoundStage?.end();
       this.currentRoundStage = null;
-
-      // Hook: Flow end
-      if (hooks?.onFlowEnd) {
-        await hooks.onFlowEnd(currentShared, status, this._services as Svc);
-      }
     }
 
-    return undefined;
+    return status;
   }
 
   /**
    * Handle continuation to next round.
-   *
-   * Called when a node returns CONTINUE_NEXT_ROUND.
    * This is the SINGLE SOURCE OF TRUTH for round increment.
-   *
-   * The increment is persisted atomically with the next step() call,
-   * avoiding double-write race conditions.
    */
-  private async handleContinueToNextRound(shared: S): Promise<void> {
-    const { hooks } = this.config;
-
-    // Hook: Previous round end (within OLD stage context for proper logging)
-    if (hooks?.onRoundEnd) {
-      await this.runWithinStageContext(async () => {
-        await hooks.onRoundEnd!(
-          this.createHookContext(shared),
-          this._services as Svc,
-        );
-      });
-    }
-
+  private async transitionToNextRound(shared: S): Promise<void> {
     // End previous round stage
     this.currentRoundStage?.end();
     this.currentRoundStage = null;
 
-    // === SINGLE SOURCE OF TRUTH: Flow owns the increment ===
+    // Increment round (single source of truth)
     shared.currentRound += 1;
-    const newRound = shared.currentRound;
 
-    // Reset state for next round (workspace, etc.)
-    if (hooks?.resetForNextRound) {
-      hooks.resetForNextRound(shared);
-    }
+    // Reset state for next round
+    this.callbacks.resetForNextRound?.(shared);
 
-    // Persist the updated state (increment + reset) atomically
+    // Persist the updated state atomically
     await this.setShared(shared);
 
-    // Check bounds - if we've exceeded, the step() loop will end naturally
-    // because nodes will return FINALIZE when they see currentRound >= totalRounds
-    if (!isRoundAtOrBeyondLimit(newRound, shared.totalRounds)) {
-      // Create new round stage only if we're still in bounds
-      if (hooks?.createRoundStage) {
-        this.currentRoundStage = await hooks.createRoundStage(
-          newRound,
-          this.config.parentStage ?? null,
-        );
-      }
-
-      // Hook: New round start (within NEW stage context for proper logging)
-      if (hooks?.onRoundStart) {
-        await this.runWithinStageContext(async () => {
-          await hooks.onRoundStart!(
-            this.createHookContext(shared),
-            this._services as Svc,
-          );
-        });
-      }
+    // Create new stage if still in bounds
+    if (!isRoundAtOrBeyondLimit(shared.currentRound, shared.totalRounds)) {
+      await this.createStage(shared.currentRound);
     }
   }
 
   /**
-   * Create hook context from current state.
+   * Create a round stage and notify callback.
    */
-  private createHookContext(shared: S): RoundHookContext<S> {
-    return {
-      shared,
-      roundStage: this.currentRoundStage,
-    };
+  private async createStage(roundIndex: number): Promise<void> {
+    if (this.callbacks.createRoundStage) {
+      this.currentRoundStage = await this.callbacks.createRoundStage(
+        roundIndex,
+        this.parentStage,
+      );
+      this.callbacks.onStageCreated?.(this.currentRoundStage);
+    }
   }
 }

--- a/src/agent/utils/UsageMonitor.ts
+++ b/src/agent/utils/UsageMonitor.ts
@@ -3,7 +3,8 @@ import { getServerSideKeyService } from '@auth/serverKeys';
 
 // Internal imports
 import { AgentCategory } from '@agent/core/AgentDataclass';
-import { AgentRunState } from '@agent/core/AgentState';
+import type { AgentRunStateSnapshot } from '@agent/core/AgentState';
+import type { RunUsageTotals } from '@agent/core/RunUsageAccumulator';
 import { UsageProviderSchema } from '@agent/types/NormalizedUsage';
 import {
   UsageLogService,
@@ -98,16 +99,16 @@ export class UsageMonitor {
   }
 
   async recordUsage(
-    stateGlobal: AgentRunState,
+    stateGlobal: AgentRunStateSnapshot,
     options?: { runKind?: UsageMonitorRunKind },
   ): Promise<void> {
     const { logger, usageReporter } = this.context;
     const runKind: UsageMonitorRunKind = options?.runKind ?? 'workflow';
 
     try {
-      const totals = stateGlobal.usageAccumulator.getTotals();
+      const totals = stateGlobal.usageAccumulator.totals;
       const latestUsage = stateGlobal.usageAccumulator
-        .getNormalizedSnapshots()
+        .normalizedSnapshots
         .at(-1)?.usage;
 
       // Per-round usage - sent to both UI (for accumulation) and backend analytics
@@ -178,7 +179,7 @@ export class UsageMonitor {
    */
   private calculateCachePercentage(
     supportsCaching: boolean,
-    totals: ReturnType<AgentRunState['usageAccumulator']['getTotals']>,
+    totals: RunUsageTotals,
   ): number {
     if (!supportsCaching) return 0;
 

--- a/src/agent/utils/UsageMonitor.ts
+++ b/src/agent/utils/UsageMonitor.ts
@@ -107,9 +107,8 @@ export class UsageMonitor {
 
     try {
       const totals = stateGlobal.usageAccumulator.totals;
-      const latestUsage = stateGlobal.usageAccumulator
-        .normalizedSnapshots
-        .at(-1)?.usage;
+      const latestUsage =
+        stateGlobal.usageAccumulator.normalizedSnapshots.at(-1)?.usage;
 
       // Per-round usage - sent to both UI (for accumulation) and backend analytics
       const roundInputTokens = latestUsage?.inputTokens ?? 0;

--- a/src/commands/agent/agentCreatorCommands.ts
+++ b/src/commands/agent/agentCreatorCommands.ts
@@ -77,7 +77,9 @@ function renderFallbackTemplate(
       ...vars,
     });
   } catch (err) {
-    throw new Error(`Failed to render fallback template: ${toErrorMessage(err)}`);
+    throw new Error(
+      `Failed to render fallback template: ${toErrorMessage(err)}`,
+    );
   }
 }
 
@@ -150,7 +152,8 @@ async function loadCreatorConfig(
   ]);
   const wf = yaml.parse(workflowYaml) as ParsedCreatorYaml;
   const tu = yaml.parse(toolUseYaml) as ParsedCreatorYaml;
-  const defaultRetry = 'The previous attempt failed validation: {{ VALIDATION_ERROR }}. Please fix and return only the YAML.';
+  const defaultRetry =
+    'The previous attempt failed validation: {{ VALIDATION_ERROR }}. Please fix and return only the YAML.';
   creatorConfig = {
     workflow: wf.prompts,
     toolUse: tu.prompts,

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -322,10 +322,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
   private async handleCompactResponse(
     data: MessageFor<typeof PROGRESS_VIEW_COMMANDS.COMPACT_RESPONSE>,
   ): Promise<void> {
-    await vscode.commands.executeCommand(
-      'texra.compactResponse',
-      data.stream,
-    );
+    await vscode.commands.executeCommand('texra.compactResponse', data.stream);
   }
 
   // ============================================================

--- a/src/progressView/frontend/components/PermissionCard.ts
+++ b/src/progressView/frontend/components/PermissionCard.ts
@@ -433,8 +433,7 @@ export class PermissionCard extends LitElement {
 
   private canCollectFeedback(): boolean {
     return Boolean(
-      this.permission &&
-      FEEDBACK_ELIGIBLE_KINDS.has(this.permission.kind),
+      this.permission && FEEDBACK_ELIGIBLE_KINDS.has(this.permission.kind),
     );
   }
 

--- a/src/progressView/frontend/components/RequestPanels.ts
+++ b/src/progressView/frontend/components/RequestPanels.ts
@@ -355,7 +355,11 @@ export class RequestPanels extends LitElement {
             title="Allow this command to execute (y)"
             >Approve</vscode-toolbar-button
           >
-          ${this.renderRejectButton(permission, isFeedbackOpen, 'Reject this command (n)')}
+          ${this.renderRejectButton(
+            permission,
+            isFeedbackOpen,
+            'Reject this command (n)',
+          )}
         </vscode-toolbar-container>
         ${this.renderFeedbackSection(
           permission,

--- a/src/progressView/frontend/constants.ts
+++ b/src/progressView/frontend/constants.ts
@@ -167,7 +167,8 @@ const COMPACT_RESPONSE_BUTTON = Object.freeze({
   id: ELEMENT_IDS.COMPACT_RESPONSE_BTN,
   icon: 'fold',
   command: COMMANDS.COMPACT_RESPONSE,
-  title: 'Compact conversation context (summarize history to reduce token usage)',
+  title:
+    'Compact conversation context (summarize history to reduce token usage)',
   className: 'compact-button',
   disabled: true,
 });

--- a/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
+++ b/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
@@ -286,7 +286,11 @@ export function formatToolUseTemplate(
     );
   }
   // Handle memory tool with specialized formatting based on command
-  else if (toolName === 'memory' && typeof input === 'object' && input !== null) {
+  else if (
+    toolName === 'memory' &&
+    typeof input === 'object' &&
+    input !== null
+  ) {
     const memInput = input as MemoryToolInput;
     const command = memInput.command;
     const memPath = memInput.path ?? '';
@@ -312,7 +316,9 @@ export function formatToolUseTemplate(
       );
     } else if (command === 'create' && memInput.file_text != null) {
       // create: show file content (like write_file)
-      const contentLanguage = memPath ? getLanguageFromPath(memPath) : 'plaintext';
+      const contentLanguage = memPath
+        ? getLanguageFromPath(memPath)
+        : 'plaintext';
       sections.push(
         buildToolSection('Content:', memInput.file_text, {
           language: contentLanguage,
@@ -326,7 +332,9 @@ export function formatToolUseTemplate(
           memInput.insert_line != null
             ? `Insert at line ${memInput.insert_line}:`
             : 'Insert:';
-        const contentLanguage = memPath ? getLanguageFromPath(memPath) : 'plaintext';
+        const contentLanguage = memPath
+          ? getLanguageFromPath(memPath)
+          : 'plaintext';
         sections.push(
           buildToolSection(lineLabel, insertText, {
             language: contentLanguage,
@@ -339,10 +347,7 @@ export function formatToolUseTemplate(
       const newPath = memInput.new_path;
       if (oldPath != null && newPath != null) {
         sections.push(
-          buildToolUseSection(
-            'Rename:',
-            wrapInPre(`${oldPath} → ${newPath}`),
-          ),
+          buildToolUseSection('Rename:', wrapInPre(`${oldPath} → ${newPath}`)),
         );
       }
     }

--- a/src/test/agent/toolUse/ToolUseFollowUp.test.ts
+++ b/src/test/agent/toolUse/ToolUseFollowUp.test.ts
@@ -4,7 +4,7 @@ import { strict as assert } from 'assert';
 // Local imports - agent
 import { AgentConfigSchema } from '@agent/core/AgentConfig';
 import { AgentWorkspaceState } from '@agent/core/AgentWorkspaceState';
-import { AgentRunState } from '@agent/core/AgentState';
+import { createRunState } from '@agent/core/AgentState';
 import { sendFollowUp } from '@agent/toolUse/ToolUseFollowUp';
 // Type imports
 import type { ToolUseSessionSnapshot } from '@agent/implementations/flows/tooluse/ToolUseSessionTypes';
@@ -15,7 +15,6 @@ describe('ToolUseFollowUp', () => {
   const streamId = 'stream-follow-up' as StreamTabId;
 
   // Create state snapshots directly (no store wrapper needed)
-  const runState = new AgentRunState();
   const workspaceState = AgentWorkspaceState.create();
 
   const snapshot: ToolUseSessionSnapshot = {
@@ -29,7 +28,7 @@ describe('ToolUseFollowUp', () => {
     }),
     messages: [],
     // State slices stored directly (v2 schema)
-    run: runState.toSnapshot(),
+    run: createRunState(),
     workspace: workspaceState.toSnapshot(),
     user: {
       input: {},

--- a/src/test/tools/BashTool.test.ts
+++ b/src/test/tools/BashTool.test.ts
@@ -4,7 +4,7 @@ import { strict as assert } from 'assert';
 // Local imports - agent core
 import { AgentCategory } from '@agent/core/AgentDataclass';
 import type { AgentPrompt, AgentSetting } from '@agent/core/AgentDataclass';
-import { AgentRunState } from '@agent/core/AgentState';
+import { createRunState } from '@agent/core/AgentState';
 import { AgentWorkspaceState } from '@agent/core/AgentWorkspaceState';
 import {
   createToolUseCycleFlow,
@@ -169,7 +169,7 @@ describe('BashTool', () => {
       executionId: 'test-execution-id',
     };
 
-    const run = new AgentRunState();
+    const run = createRunState();
 
     const messages: ProviderMessage[] = [];
 


### PR DESCRIPTION
Three targeted simplifications to the agent execution and flow layers:

1. RoundPersistedFlow (#5): Remove hook ceremony — collapse 6 lifecycle
   hooks to 4 focused callbacks, eliminate RoundHookContext wrapper,
   return ExecutionStatus directly instead of via onFlowEnd callback.
   run() shrinks from 95 to 50 lines (439→214 total).

2. Snapshot round-trip (#3): Convert ConversationRoundState and
   AgentRunState from classes to plain snapshot types + standalone
   functions. Cycle services now accept snapshot types directly,
   eliminating fromSnapshot/toSnapshot bridge code at every cycle
   boundary. RunUsageAccumulator exports standalone functions alongside
   backward-compatible class.

3. Service spreading (#4): Replace `...this.services` spread in
   ResponseCycleNode and ToolUseCycleNode with explicit field selection.
   Makes cycle flow dependencies visible and prevents accidental coupling
   to unused parent service fields.

Net: -104 lines across 17 files, with clearer data flow and explicit
dependency surfaces.

https://claude.ai/code/session_01QiQUAA9NuTWeWMGzE6KcFe

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core agent execution/persistence and usage tracking paths; although behavior should be equivalent, snapshot mutation and callback changes could affect resume/round accounting if any edge cases were missed.
> 
> **Overview**
> **Refactors agent execution state to be snapshot-first and function-based.** `ConversationRoundState`/`AgentRunState` and `RunUsageAccumulator` are converted from classes to plain JSON snapshot types with helpers like `createRunState`, `createRoundState`, `recordRound`, and `recordCycleMetrics`, and call sites (workflow + tool-use flows, `ModelHandler`, `UsageMonitor`, tests) are updated to mutate/read snapshots directly.
> 
> **Simplifies round orchestration and flow wiring.** `RoundPersistedFlow` collapses lifecycle hooks into a smaller callback surface and returns `ExecutionStatus` directly from `run()`, with `runReflectionFlow` updated accordingly.
> 
> **Tightens dependency surfaces.** Cycle nodes stop spreading `...this.services` and instead pass explicit service fields into `ResponseCycleFlow`/`ToolUseCycleFlow`, reducing accidental coupling. Minor template/formatting tweaks are included.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6b143cc5cd413426c7091fc5d4d84094fcbb0a23. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->