### PR TITLE
Improve agent creator prompts with clearer rules and examples

### DIFF
--- a/resources/templates/agentCreatorToolUse.yaml
+++ b/resources/templates/agentCreatorToolUse.yaml
@@ -12,29 +12,54 @@ prompts:
     When generating tool-use agent YAML definitions, follow the schema below exactly.
     Tool-use agents call tools interactively instead of producing a single document output.
     They have access to tools like file I/O, shell commands, web search, and academic APIs.
-    All fields with defaults can be omitted if the default value is acceptable.
+
+    CRITICAL RULES:
+    - agentCategory MUST be "toolUse" (not "workflow").
+    - Pick only the tools relevant to the agent's purpose from the available list.
+    - userRequest MUST be a single string (not an array), and MUST contain {{ INSTRUCTION }}
+      so the user's free-text instruction is passed through at runtime.
+    - temperature should be 0.7 for exploratory tasks, lower for precise tasks.
+    - All fields with defaults can be omitted if the default value is acceptable.
     Respond only with the YAML wrapped in <yaml> tags.
+
+    TEMPLATE VARIABLES available in prompts (Nunjucks double-brace syntax):
+    - {{ INPUT_FILE }}: path of the main input file
+    - {{ INPUT_CONTENT }}: full text of the main input file
+    - {{ ALL_AUXILIARYS }}: auxiliary files (preamble.tex, commands.tex, etc.)
+    - {{ ALL_REFERENCES }}: reference/bibliography files
+    - {{ ADDITIONAL_INPUTS }}: extra context files
+    - {{ INSTRUCTION }}: the user's free-text instruction for this run
 
   userRequest: |
     Generate a YAML definition for a **tool-use** agent named "{{ AGENT_NAME }}".
-    The YAML must follow this layout:
+    Goal: {{ DESCRIPTION }}.
+
+    The YAML must follow this exact structure:
+
     name: {{ AGENT_NAME }}
+    description: <one-line description>
     settings:
       agentCategory: toolUse
+      temperature: 0.7
       tools:
         - <tool1>
         - <tool2>
     prompts:
       systemPrompt: |
-        ...
+        <Role and task description. Explain what the agent does and how it should use tools.>
       userPrefix: |
-        ...
+        <Context block with input documents. Use {{ ALL_AUXILIARYS }}, {{ ALL_REFERENCES }},
+         {{ ADDITIONAL_INPUTS }}, and wrap {{ INPUT_CONTENT }} in <document> tags.>
       userRequest: |
-        ...
-    Available tools include: bash, read_file, write_file, edit_file, glob, grep, ls,
-    web_search, web_fetch, arxiv_search, arxiv_metadata, download_arxiv_source,
-    crossref_search, crossref_doi, extract_figures, extract_bib_entries,
-    texcount, memory, wolfram, todo_write, diagnostics.
-    Pick the tools that are most relevant for the agent's purpose.
-    The userRequest should be a single string (not an array) containing the template variable INSTRUCTION wrapped in double curly braces.
-    Goal: {{ DESCRIPTION }}.
+        {{ INSTRUCTION }}
+
+    Available tools (pick only what is relevant):
+      File I/O: bash, read_file, write_file, edit_file, glob, grep, ls
+      Web: web_search, web_fetch
+      Academic: arxiv_search, arxiv_metadata, download_arxiv_source, crossref_search, crossref_doi
+      LaTeX: extract_figures, extract_bib_entries, texcount
+      Other: memory, wolfram, todo_write, diagnostics
+
+    IMPORTANT REMINDERS:
+    - userRequest must be a single string containing {{ INSTRUCTION }} (not an array).
+    - Only include tools that the agent actually needs.

--- a/resources/templates/agentCreatorWorkflow.yaml
+++ b/resources/templates/agentCreatorWorkflow.yaml
@@ -13,37 +13,114 @@ prompts:
   systemPrompt: |
     You are an expert on the TeXRA codebase, a VS Code extension that runs YAML-defined AI agents.
     When generating workflow agent YAML definitions, follow the schema below exactly.
-    Workflow agents process documents in fixed rounds, producing LaTeX or text output
+    Workflow agents process LaTeX documents in fixed rounds (default 2), producing output
     wrapped in a documentTag. They use a chain-of-thought workflow with <scratchpad>
-    planning and support single or multiple output files.
-    All fields with defaults can be omitted if the default value is acceptable.
+    planning before the final output, and support single or multiple output files.
+
+    CRITICAL RULES:
+    - outputExt MUST be "tex" (not "md", "txt", or anything else). TeXRA is a LaTeX tool.
+    - documentTag defines the XML wrapper for output (e.g. "latex_document").
+    - endTag MUST match documentTag as a closing XML tag (e.g. "</latex_document>").
+    - isRewrite should be true when the agent rewrites/edits an existing document.
+    - prefills should contain "<scratchpad>" entries (one per round) to trigger chain-of-thought.
+    - temperature should be low (0.1) for rewriting tasks, higher for creative tasks.
+    - All fields with defaults can be omitted if the default value is acceptable,
+      BUT outputExt defaults to "txt" so it must always be set explicitly to "tex".
     Respond only with the YAML wrapped in <yaml> tags.
+
+    TEMPLATE VARIABLES available in prompts (Nunjucks double-brace syntax):
+    - {{ INPUT_FILE }}: path of the main input file
+    - {{ INPUT_CONTENT }}: full text of the main input file
+    - {{ ALL_INPUTS }}: XML list of ALL input files (when multiple files selected)
+    - {{ ALL_AUXILIARYS }}: auxiliary files (preamble.tex, commands.tex, etc.)
+    - {{ ALL_REFERENCES }}: reference/bibliography files
+    - {{ ADDITIONAL_INPUTS }}: extra context files
+    - {{ INSTRUCTION }}: the user's free-text instruction for this run
+    - {{ REFERENCE_CONTENT }}: content of reference files
+    - {{ AUXILIARY_CONTENT }}: content of auxiliary files
+    - {{ OUTPUT_FILES_ORDER }}: ordered list of output filenames (multiple-output agents only)
+    Use these variables in the prompts section. They are substituted at runtime.
 
   userRequest: |
     Generate a YAML definition for a workflow agent named "{{ AGENT_NAME }}".
-    The YAML must follow this layout:
+    Goal: {{ DESCRIPTION }}.
+
+    The YAML must follow this exact structure:
+
     name: {{ AGENT_NAME }}
-    # inherits: base
+    description: <one-line description>
     settings:
-      ...
-    prompts:
-      systemPrompt: |
-        ...
-      userPrefix: |
-        ...
-      userRequest:
-        - |
-          ...
-        - |
-          [Optional reflection prompt]
-    For reference, built-in agents start like:
-    name: polish
-    settings:
+      agentCategory: workflow
       documentTag: latex_document
       endTag: </latex_document>
       outputExt: tex
-    Mention variables INPUT_CONTENT, ALL_INPUTS, OUTPUT_FILES_ORDER, REFERENCE_CONTENT, AUXILIARY_CONTENT and ADDITIONAL_INPUTS when relevant.
-    Goal: {{ DESCRIPTION }}.
+      isRewrite: true
+      temperature: 0.1
+      prefills:
+        - "<scratchpad>"
+        - "<scratchpad>"
+    prompts:
+      systemPrompt: |
+        <Role and task description. Written in LaTeX style using \begin{itemize} for lists.
+         Must include LaTeX conventions: chktex compliance, consistent notation, preserve comments,
+         use `` and '' instead of straight quotes, no markdown-style enumerations.>
+      userPrefix: |
+        <Context block wrapping input documents in <documents> XML tags.
+         Must reference {{ ALL_AUXILIARYS }}, {{ ALL_REFERENCES }}, {{ ADDITIONAL_INPUTS }},
+         and wrap {{ INPUT_CONTENT }} in <document name="{{ INPUT_FILE }}"> tags.
+         Should include an <instruction>{{ INSTRUCTION }}</instruction> block.>
+      userRequest:
+        - |
+          <Round 1: Ask for brainstorming in <scratchpad>, then output in <latex_document> tags.>
+        - |
+          <Round 2: Ask for reflection and refinement in <scratchpad>, then updated <latex_document>.>
+
+    Here is a complete real-world example for reference (the "polish" agent):
+
+    name: polish
+    description: Improves writing quality and clarity based on your specific instructions.
+    settings:
+      agentCategory: workflow
+      documentTag: latex_document
+      endTag: </latex_document>
+      outputExt: tex
+      prefills:
+        - <scratchpad>
+        - <scratchpad>
+    prompts:
+      systemPrompt: |
+        You are a professional scientist. Your task is to improve a LaTeX research paper
+        focusing solely on addressing the given instructions.
+        When writing a professional *.tex \LaTeX document, you must:
+        \begin{itemize}
+            \item Follow chktex-friendly conventions.
+            \item Use appropriate notation consistently.
+            \item Preserve comments starting with `%'.
+            \item Use `` or '' rather than straight quotes.
+            \item \textbf{IMPORTANT:} Give complete output with all sections in original order.
+        \end{itemize}
+      userPrefix: |
+        <documents>
+        {{ ALL_AUXILIARYS }}
+        {{ ALL_REFERENCES }}
+        {{ ADDITIONAL_INPUTS }}
+        <document name="{{ INPUT_FILE }}">
+        {{ INPUT_CONTENT }}
+        </document>
+        </documents>
+        <instruction>{{ INSTRUCTION }}</instruction>
+      userRequest:
+        - |
+          Brainstorm in <scratchpad>, then output revised \LaTeX in <latex_document> tags.
+        - |
+          Reflect on changes in <scratchpad>, then output improved <latex_document>.
+
+    IMPORTANT REMINDERS:
+    - outputExt MUST be "tex", never "md" or "txt".
+    - The documentTag in prompts must match the settings.documentTag.
+    - userRequest must be an array of strings (one per round).
+    - Include {{ INSTRUCTION }} somewhere in the prompts so the user's instructions are passed through.
+    - Write prompt text in LaTeX style (\begin{itemize}, \textbf{}, etc.), not markdown.
 
   retryPrompt: |
     The previous attempt failed validation: {{ VALIDATION_ERROR }}. Please fix and return only the YAML.

--- a/resources/templates/agentCreatorWorkflow.yaml
+++ b/resources/templates/agentCreatorWorkflow.yaml
@@ -122,5 +122,7 @@ prompts:
     - Include {{ INSTRUCTION }} somewhere in the prompts so the user's instructions are passed through.
     - Write prompt text in LaTeX style (\begin{itemize}, \textbf{}, etc.), not markdown.
 
+    {{ MULTIPLE_OUTPUT_NOTE }}
+
   retryPrompt: |
     The previous attempt failed validation: {{ VALIDATION_ERROR }}. Please fix and return only the YAML.

--- a/resources/templates/agentTemplate-toolUse.yaml
+++ b/resources/templates/agentTemplate-toolUse.yaml
@@ -1,5 +1,5 @@
-name: { { AGENT_NAME } }
-description: { { DESCRIPTION } }
+name: {{ AGENT_NAME }}
+description: {{ DESCRIPTION }}
 
 # --- Agent Settings ---
 settings:

--- a/resources/templates/agentTemplate-workflowMultiple.yaml
+++ b/resources/templates/agentTemplate-workflowMultiple.yaml
@@ -1,9 +1,11 @@
 # --- Agent Inheritance (Optional) ---
 # inherits: base
 name: {{ AGENT_NAME }}
+description: {{ DESCRIPTION }}
 
 # --- Agent Settings ---
 settings:
+  agentCategory: workflow
   isMultipleOutput: true
   temperature: 0.1
   isRewrite: true

--- a/resources/templates/agentTemplate-workflowSingle.yaml
+++ b/resources/templates/agentTemplate-workflowSingle.yaml
@@ -1,6 +1,6 @@
 # --- Agent Inheritance (Optional) ---
 # inherits: base
-name: { { AGENT_NAME } }
+name: {{ AGENT_NAME }}
 
 # --- Agent Settings ---
 settings:

--- a/resources/templates/agentTemplate-workflowSingle.yaml
+++ b/resources/templates/agentTemplate-workflowSingle.yaml
@@ -1,9 +1,11 @@
 # --- Agent Inheritance (Optional) ---
 # inherits: base
 name: {{ AGENT_NAME }}
+description: {{ DESCRIPTION }}
 
 # --- Agent Settings ---
 settings:
+  agentCategory: workflow
   temperature: 0.1
   isRewrite: true
   documentTag: latex_document

--- a/src/commands/agent/agentCreatorCommands.ts
+++ b/src/commands/agent/agentCreatorCommands.ts
@@ -350,12 +350,20 @@ async function tryAIGeneration(
     handler.setProgressViewEnabled(false);
     const client = await handler.getClient();
 
-    // Build prompts
+    // Build prompts – include RUNTIME_PASSTHROUGH so that template variable
+    // references like {{ INPUT_FILE }} in the creator prompts survive Nunjucks
+    // rendering as literal text for the AI to see.
     const prompts = config[category];
     const schemaRef = getSchemaReference(category);
+    const renderVars = { ...RUNTIME_PASSTHROUGH, ...vars };
     const systemPrompt =
-      nunjucksEnv.renderString(prompts.systemPrompt, vars) + '\n' + schemaRef;
-    const baseUserRequest = nunjucksEnv.renderString(prompts.userRequest, vars);
+      nunjucksEnv.renderString(prompts.systemPrompt, renderVars) +
+      '\n' +
+      schemaRef;
+    const baseUserRequest = nunjucksEnv.renderString(
+      prompts.userRequest,
+      renderVars,
+    );
 
     let userMessage = baseUserRequest;
     for (let attempt = 0; attempt < 2; attempt++) {

--- a/src/commands/agent/agentCreatorCommands.ts
+++ b/src/commands/agent/agentCreatorCommands.ts
@@ -261,7 +261,23 @@ async function createWorkflowAgent(
   }
 
   const filePath = await resolveAgentFilePath(agentName);
-  const vars = { AGENT_NAME: agentName, DESCRIPTION: description };
+  const multipleNote = isMultipleOutput
+    ? [
+        'IMPORTANT: This agent must handle MULTIPLE output files. Adjust the structure above:',
+        '- Set isMultipleOutput: true',
+        '- Use documentTag: "latex_documents" (plural) and endTag: "</latex_documents>"',
+        '- Add defaultOutputFiles with the file list below',
+        '- In userRequest, instruct the model to wrap each file in <latex_documents> with <document name="..."> blocks',
+        '- Reference {{ OUTPUT_FILES_ORDER }} for the expected output order',
+        'Default output files:',
+        outputFilesYaml,
+      ].join('\n')
+    : '';
+  const vars = {
+    AGENT_NAME: agentName,
+    DESCRIPTION: description,
+    MULTIPLE_OUTPUT_NOTE: multipleNote,
+  };
   let yamlContent = await tryAIGeneration(config, 'workflow', vars);
 
   if (!yamlContent) {


### PR DESCRIPTION
## Summary
Enhanced the agent creator system prompts and templates with more explicit rules, better documentation, and a complete real-world example. This improves the quality and consistency of AI-generated agent YAML definitions.

## Key Changes

### Agent Creator Prompts
- **Tool-use agents** (`agentCreatorToolUse.yaml`):
  - Added "CRITICAL RULES" section emphasizing `agentCategory: "toolUse"`, single-string `userRequest` with `{{ INSTRUCTION }}`, and temperature guidance
  - Documented all available template variables (INPUT_FILE, INPUT_CONTENT, ALL_AUXILIARYS, etc.)
  - Reorganized tool list by category (File I/O, Web, Academic, LaTeX, Other)
  - Added "IMPORTANT REMINDERS" section for common mistakes

- **Workflow agents** (`agentCreatorWorkflow.yaml`):
  - Added "CRITICAL RULES" section with emphasis on `outputExt: "tex"` (must be explicit), documentTag/endTag matching, and scratchpad usage
  - Documented all template variables available in workflow prompts
  - Added complete real-world example of the "polish" agent showing proper structure and LaTeX-style formatting
  - Included guidance on multiple-output agents with `{{ MULTIPLE_OUTPUT_NOTE }}`
  - Added "IMPORTANT REMINDERS" section covering common pitfalls

### Agent Templates
- Fixed template variable syntax in `agentTemplate-toolUse.yaml` and `agentTemplate-workflowSingle.yaml` (removed spaces in `{{ }}`)
- Added `description` field to all workflow templates (`agentTemplate-workflowSingle.yaml`, `agentTemplate-workflowMultiple.yaml`)
- Added explicit `agentCategory: workflow` to workflow templates

### Code Implementation
- Enhanced `createWorkflowAgent()` to generate `MULTIPLE_OUTPUT_NOTE` variable when `isMultipleOutput` is true, providing detailed instructions for multi-file agents
- Updated `tryAIGeneration()` to use `RUNTIME_PASSTHROUGH` constant when rendering creator prompts, ensuring template variable references (like `{{ INPUT_FILE }}`) survive Nunjucks rendering as literal text for the AI to see

## Notable Details
- The real-world "polish" agent example demonstrates proper LaTeX conventions, scratchpad usage, and document wrapping
- Template variables are now clearly documented with their purposes and when to use them
- Multiple-output agent guidance is dynamically injected into the prompt based on user selection
- Separation of concerns: creator prompts use `RUNTIME_PASSTHROUGH` to preserve agent template variables for AI generation

https://claude.ai/code/session_01TpnuzErvyHrzp5Lv1srkyz

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly prompt/template text changes plus small variable/rendering tweaks in agent creation; low risk aside from potentially altering the shape/content of newly generated agent YAMLs.
> 
> **Overview**
> Tightens the agent-creator prompt templates for both tool-use and workflow agents with **explicit rules**, documented runtime template variables, and clearer required YAML structure (including `description`, correct `agentCategory`, and workflow `outputExt: tex`/tag matching), plus a full workflow example and categorized tool lists.
> 
> Updates fallback agent templates to fix Nunjucks variable syntax, add missing `description`, and explicitly set `agentCategory: workflow` for workflow templates.
> 
> Enhances agent creation logic to (1) inject a `MULTIPLE_OUTPUT_NOTE` into workflow generation when multi-file output is selected, and (2) render creator prompts with `RUNTIME_PASSTHROUGH` so runtime variables like `{{ INPUT_FILE }}` survive Nunjucks rendering and reach the model unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 33d912d45a2901c78a38066275bddac93eba75d8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->