### PR TITLE
Optimize re-renders with memoization and shouldUpdate checks

### DIFF
--- a/src/progressView/frontend/components/LogEntry.ts
+++ b/src/progressView/frontend/components/LogEntry.ts
@@ -4,12 +4,7 @@
  */
 
 // Third-party imports
-import {
-  LitElement,
-  html,
-  type PropertyValues,
-  type TemplateResult,
-} from 'lit';
+import { LitElement, html, type TemplateResult } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
 // Local imports - formatters
@@ -33,15 +28,6 @@ export class LogEntry extends LitElement {
 
   @property({ type: Object }) message!: LogMessageData;
   @property({ type: Boolean }) defaultOpen = false;
-
-  /** Only re-render when message or defaultOpen actually change. */
-  protected override shouldUpdate(
-    changedProperties: PropertyValues<this>,
-  ): boolean {
-    return (
-      changedProperties.has('message') || changedProperties.has('defaultOpen')
-    );
-  }
 
   override render(): TemplateResult {
     if (!this.message) return html``;

--- a/src/progressView/frontend/components/LogEntry.ts
+++ b/src/progressView/frontend/components/LogEntry.ts
@@ -4,7 +4,12 @@
  */
 
 // Third-party imports
-import { LitElement, html, type TemplateResult } from 'lit';
+import {
+  LitElement,
+  html,
+  type PropertyValues,
+  type TemplateResult,
+} from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
 // Local imports - formatters
@@ -28,6 +33,15 @@ export class LogEntry extends LitElement {
 
   @property({ type: Object }) message!: LogMessageData;
   @property({ type: Boolean }) defaultOpen = false;
+
+  /** Only re-render when message or defaultOpen actually change. */
+  protected override shouldUpdate(
+    changedProperties: PropertyValues<this>,
+  ): boolean {
+    return (
+      changedProperties.has('message') || changedProperties.has('defaultOpen')
+    );
+  }
 
   override render(): TemplateResult {
     if (!this.message) return html``;

--- a/src/progressView/frontend/components/RequestPanels.ts
+++ b/src/progressView/frontend/components/RequestPanels.ts
@@ -121,6 +121,12 @@ export class RequestPanels extends LitElement {
   @state() private feedbackOpenKeys: Set<PermissionKey> = new Set();
   @state() private openDiffMenuKey: PermissionKey | null = null;
 
+  /** Memoized permission groups - recomputed in willUpdate() when permissions change */
+  private approvalPermissions: PermissionState[] = [];
+  private bashPermissions: PermissionState[] = [];
+  private retryPermissions: PermissionState[] = [];
+  private proposalPermissions: PermissionState[] = [];
+
   protected override willUpdate(changedProperties: PropertyValues<this>): void {
     if (!changedProperties.has('permissions')) {
       return;
@@ -136,6 +142,20 @@ export class RequestPanels extends LitElement {
     if (this.openDiffMenuKey && !activeKeys.has(this.openDiffMenuKey)) {
       this.openDiffMenuKey = null;
     }
+
+    // Memoize filtered permission groups so render() doesn't re-filter
+    this.approvalPermissions = this.permissions.filter(
+      (p) => p.kind === PERMISSION_KIND.TOOL_EDIT,
+    );
+    this.bashPermissions = this.permissions.filter(
+      (p) => p.kind === PERMISSION_KIND.BASH,
+    );
+    this.retryPermissions = this.permissions.filter(
+      (p) => p.kind === PERMISSION_KIND.RETRY,
+    );
+    this.proposalPermissions = this.permissions.filter(
+      (p) => p.kind === PERMISSION_KIND.PROPOSAL,
+    );
   }
 
   override connectedCallback(): void {
@@ -157,14 +177,11 @@ export class RequestPanels extends LitElement {
   override render(): TemplateResult | typeof nothing {
     if (this.permissions.length === 0) return nothing;
 
-    const byKind = (kind: PermissionState['kind']) =>
-      this.permissions.filter((p) => p.kind === kind);
-
     return html`
-      ${this.renderApprovalSection(byKind(PERMISSION_KIND.TOOL_EDIT))}
-      ${this.renderBashSection(byKind(PERMISSION_KIND.BASH))}
-      ${this.renderRetrySection(byKind(PERMISSION_KIND.RETRY))}
-      ${this.renderProposalSection(byKind(PERMISSION_KIND.PROPOSAL))}
+      ${this.renderApprovalSection(this.approvalPermissions)}
+      ${this.renderBashSection(this.bashPermissions)}
+      ${this.renderRetrySection(this.retryPermissions)}
+      ${this.renderProposalSection(this.proposalPermissions)}
     `;
   }
 

--- a/src/progressView/frontend/components/TaskGroupList.ts
+++ b/src/progressView/frontend/components/TaskGroupList.ts
@@ -77,6 +77,14 @@ export class TaskGroupList extends LitElement {
   /** Track previous group statuses to detect completion */
   @state() private previousStatuses = new Map<string, string>();
 
+  /** Memoized tree output from buildGroupTree() - recomputed only when inputs change */
+  private cachedTree: GroupTree[] = [];
+  private cachedUserMessages: LogMessageData[] = [];
+  private cachedOtherUngrouped: LogMessageData[] = [];
+
+  /** Memoized set of root group IDs for isGroupVisible() */
+  private cachedRootGroupIds: Set<string> = new Set();
+
   /** Reference to the scroll container */
   @query(`#${ELEMENT_IDS.LOG_CONTENT}`)
   private scrollContainer?: HTMLElement;
@@ -98,6 +106,22 @@ export class TaskGroupList extends LitElement {
   override willUpdate(changedProperties: Map<string, unknown>): void {
     if (changedProperties.has('groups')) {
       this.checkForCompletedRuns();
+    }
+    // Recompute tree only when groups or messages actually change
+    if (changedProperties.has('groups') || changedProperties.has('messages')) {
+      const [tree, userMessages, otherUngrouped] = this.buildGroupTree();
+      this.cachedTree = tree;
+      this.cachedUserMessages = userMessages;
+      this.cachedOtherUngrouped = otherUngrouped;
+    }
+    // Recompute root group IDs when groups or activeRunId change
+    if (
+      changedProperties.has('groups') ||
+      changedProperties.has('activeRunId')
+    ) {
+      this.cachedRootGroupIds = new Set(
+        this.groups.filter((g) => !g.parentGroupId).map((g) => g.id),
+      );
     }
   }
 
@@ -212,10 +236,7 @@ export class TaskGroupList extends LitElement {
 
     // Fallback: if activeRunId doesn't match any root group, show all
     // This prevents blank content when run IDs are mismatched
-    const rootGroupIds = new Set(
-      this.groups.filter((g) => !g.parentGroupId).map((g) => g.id),
-    );
-    if (!rootGroupIds.has(this.activeRunId)) return true;
+    if (!this.cachedRootGroupIds.has(this.activeRunId)) return true;
 
     // Normal case: only show the selected run
     return groupId === this.activeRunId;
@@ -296,8 +317,6 @@ export class TaskGroupList extends LitElement {
   }
 
   override render(): TemplateResult {
-    const [tree, userMessages, otherUngrouped] = this.buildGroupTree();
-
     // Show placeholder only when there are no streams in the current filter
     // (not when a specific stream is empty)
     if (!this.hasStreams) {
@@ -310,6 +329,11 @@ export class TaskGroupList extends LitElement {
         </vscode-scrollable>
       `;
     }
+
+    // Use memoized tree data computed in willUpdate()
+    const tree = this.cachedTree;
+    const userMessages = this.cachedUserMessages;
+    const otherUngrouped = this.cachedOtherUngrouped;
 
     // Tool-use: user messages first, then tree, then other ungrouped (errors etc)
     // This preserves chronological order for errors while ensuring user prompts appear first.

--- a/src/progressView/frontend/components/ToolTimer.ts
+++ b/src/progressView/frontend/components/ToolTimer.ts
@@ -58,7 +58,11 @@ export class ToolTimer extends LitElement {
   private _update(): void {
     if (!this.startTime) return;
     const elapsed = Date.now() - this.startTime;
-    this._elapsed = formatDuration(elapsed);
+    const formatted = formatDuration(elapsed);
+    // Only trigger re-render when the display string actually changes
+    if (formatted !== this._elapsed) {
+      this._elapsed = formatted;
+    }
   }
 
   override render(): TemplateResult {


### PR DESCRIPTION
## Summary
This PR improves rendering performance across multiple components by implementing memoization strategies and selective update checks. The changes prevent unnecessary re-renders by caching computed values and only updating when relevant properties actually change.

## Key Changes

- **LogEntry.ts**: Added `shouldUpdate()` override to only re-render when `message` or `defaultOpen` properties change, preventing unnecessary renders from parent updates.

- **RequestPanels.ts**: Memoized permission group filtering in `willUpdate()` instead of computing filters on every render. Stores filtered permission arrays (`approvalPermissions`, `bashPermissions`, `retryPermissions`, `proposalPermissions`) that are recomputed only when the `permissions` property changes.

- **TaskGroupList.ts**: Memoized expensive tree building and root group ID computation in `willUpdate()`. Caches `cachedTree`, `cachedUserMessages`, `cachedOtherUngrouped`, and `cachedRootGroupIds` to avoid recomputing these values on every render cycle.

- **ToolTimer.ts**: Added a guard to only update the `_elapsed` property when the formatted duration string actually changes, preventing unnecessary property assignments and re-renders.

## Implementation Details

All changes follow the Lit lifecycle pattern:
- Expensive computations are moved to `willUpdate()` where they're only executed when relevant properties change
- Computed values are cached as private properties
- The `render()` method uses cached values instead of computing them on-the-fly
- This approach maintains reactivity while eliminating redundant calculations

These optimizations are particularly beneficial for frequently-updating components like `ToolTimer` and `TaskGroupList` that may receive parent updates unrelated to their displayed content.

https://claude.ai/code/session_01LG5QeunFoaWd6rtGJV3g3X

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure UI performance optimizations that should not change behavior, but memoization correctness depends on `willUpdate()` being triggered for all relevant input changes.
> 
> **Overview**
> Improves progress-view rendering performance by moving repeated computations out of `render()` and into `willUpdate()`-time memoization.
> 
> `RequestPanels` now caches permission subsets by kind when `permissions` changes, and `TaskGroupList` caches the expensive `buildGroupTree()` output plus root-group ID lookup state, reusing them during rendering and visibility checks. `ToolTimer` now only updates its `_elapsed` state when the formatted duration string changes to avoid unnecessary re-renders.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 31711d5a13b1fe1bc03c244b56bb3be2c267163a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->