### PR TITLE
Fix YAML indentation in agent template and Prettier configuration

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+# YAML templates contain Nunjucks {{ }} syntax that conflicts with YAML flow mapping parsing
+resources/templates/agentTemplate-*.yaml

--- a/resources/templates/agentTemplate-workflowMultiple.yaml
+++ b/resources/templates/agentTemplate-workflowMultiple.yaml
@@ -12,7 +12,7 @@ settings:
   documentTag: latex_documents
   endTag: </latex_documents>
   defaultOutputFiles:
-{{ OUTPUT_FILES }}
+    {{ OUTPUT_FILES }}
   outputExt: tex
   prefills:
     - "<scratchpad>"

--- a/src/commands/agent/agentCreatorCommands.ts
+++ b/src/commands/agent/agentCreatorCommands.ts
@@ -246,6 +246,7 @@ async function createWorkflowAgent(
   const isMultipleOutput = outputChoice === 'Multiple output files';
 
   let outputFilesYaml = '';
+  let outputFilesNote = '';
   if (isMultipleOutput) {
     const filesInput = await vscode.window.showInputBox({
       prompt: 'Enter default output filenames (comma separated)',
@@ -258,6 +259,7 @@ async function createWorkflowAgent(
       .map((s) => s.trim())
       .filter((s) => s.length > 0);
     outputFilesYaml = files.map((f) => `- ${f}`).join('\n    ');
+    outputFilesNote = files.map((f) => `    - ${f}`).join('\n');
   }
 
   const filePath = await resolveAgentFilePath(agentName);
@@ -270,7 +272,7 @@ async function createWorkflowAgent(
         '- In userRequest, instruct the model to wrap each file in <latex_documents> with <document name="..."> blocks',
         '- Reference {{ OUTPUT_FILES_ORDER }} for the expected output order',
         'Default output files:',
-        outputFilesYaml,
+        outputFilesNote,
       ].join('\n')
     : '';
   const vars = {

--- a/src/commands/agent/agentCreatorCommands.ts
+++ b/src/commands/agent/agentCreatorCommands.ts
@@ -257,7 +257,7 @@ async function createWorkflowAgent(
       .split(',')
       .map((s) => s.trim())
       .filter((s) => s.length > 0);
-    outputFilesYaml = files.map((f) => `    - ${f}`).join('\n');
+    outputFilesYaml = files.map((f) => `- ${f}`).join('\n    ');
   }
 
   const filePath = await resolveAgentFilePath(agentName);


### PR DESCRIPTION
## Summary
Fixed YAML indentation issues in the agent template file and updated the template generation logic to produce correctly formatted output. Added Prettier configuration to exclude YAML templates that contain Nunjucks syntax.

## Key Changes
- **Added `.prettierignore`**: Excludes YAML template files from Prettier formatting since they contain Nunjucks `{{ }}` syntax that conflicts with YAML flow mapping parsing
- **Fixed YAML indentation in `agentTemplate-workflowMultiple.yaml`**: Corrected the indentation of the `{{ OUTPUT_FILES }}` placeholder to align with proper YAML structure
- **Updated output file generation logic**: Modified the `outputFilesYaml` construction in `agentCreatorCommands.ts` to generate properly indented YAML list items by adjusting how the template string is built

## Implementation Details
The changes ensure that when workflow agents are created with multiple output files, the generated YAML maintains correct indentation. The template generation now produces list items with proper spacing (`- filename` format) that are joined with newlines and indentation, rather than pre-indenting each item individually.

https://claude.ai/code/session_018hKPK9ZfaRzEbcD6VhKH5t

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk formatting-only changes affecting generated agent YAML and developer formatting tooling; main risk is minor template/output regression if indentation assumptions differ.
> 
> **Overview**
> Fixes formatting issues for workflow agents with multiple output files by correcting the `defaultOutputFiles` placeholder indentation in `agentTemplate-workflowMultiple.yaml` and adjusting `createWorkflowAgent` to generate properly indented YAML list items.
> 
> Adds a `.prettierignore` rule to exclude `resources/templates/agentTemplate-*.yaml` from Prettier formatting to avoid conflicts with embedded Nunjucks `{{ }}` syntax.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a1e94399e3aa42fbcb3ad91c11e170cb1f2d154b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->