### PR TITLE
Fix context window errors with chained responses by clearing server state

### DIFF
--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -1503,17 +1503,40 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         this.resetConversationState();
         // Also clear pending background response if present
         this.clearPendingBackgroundResponse();
-      } else if (isContextWindowError(error) && this.previousResponseId) {
-        // Context window overflow with chained response: the server-side context
-        // (via previous_response_id) may be larger than the pre-flight estimate.
-        // Clear the chain so retry rebuilds from local history with accurate counting.
-        this.logger.info(
-          `Context window exceeded with previousResponseId=${this.previousResponseId} - ` +
-            'clearing chain so next retry rebuilds conversation from local history',
+      } else if (
+        isContextWindowError(error) &&
+        this.previousResponseId &&
+        !compactedThisCall
+      ) {
+        // Recovery: When using previous_response_id, accumulated reasoning tokens
+        // from prior turns are stored server-side and count against the context
+        // window, but inputTokens.count() may not fully reflect them. This causes
+        // pre-flight validation to pass while the API rejects the request.
+        //
+        // Fix: Drop server-side state (clearing previous_response_id discards the
+        // hidden reasoning tokens) and compact client-side messages, then retry.
+        // The guard !compactedThisCall prevents infinite recursion.
+        this.logger.logProgress(
+          'Context window exceeded despite pre-flight check — ' +
+            'accumulated server-side reasoning tokens likely exceeded limit. ' +
+            'Clearing chained state and compacting for retry.',
         );
         this.previousResponseId = null;
-        this.resetConversationState();
+        // Don't call resetConversationState() — it zeroes cumulativeInputTokens
+        // which would prevent shouldCompact() from triggering on the retry.
         this.clearPendingBackgroundResponse();
+        this.compactionRequested = true;
+        this._diagPreFlightTokens = null;
+        // Retry internally: the recursive call will compact (shouldCompact()=true)
+        // and send all messages without server-side state.
+        return this.createResponse({
+          client,
+          messages,
+          temperature,
+          systemPrompt,
+          signal,
+          tools,
+        });
       } else if (this.previousResponseId) {
         // Log diagnostic info for other errors when chaining was active
         this.logger.debug(


### PR DESCRIPTION
## Summary
Adds recovery logic to handle context window exceeded errors when using OpenAI's `previous_response_id` feature for chained responses. The fix clears server-side state and compacts messages to retry the request.

## Problem
When chaining responses with `previous_response_id`, accumulated reasoning tokens from prior turns are stored server-side and count against the context window limit. However, the client-side token count validation (`inputTokens.count()`) doesn't fully account for these hidden server-side tokens, causing pre-flight validation to pass while the API rejects the request with a context window error.

## Solution
Added a new error recovery branch that:
- Detects context window errors when `previous_response_id` is active
- Clears the `previousResponseId` to discard hidden server-side reasoning tokens
- Requests message compaction for the retry
- Internally retries the request without resetting conversation state (preserving `cumulativeInputTokens` so compaction triggers)
- Includes a guard (`!compactedThisCall`) to prevent infinite recursion

## Implementation Details
- The fix is placed before the existing `previousResponseId` error logging to handle this specific case
- Deliberately avoids calling `resetConversationState()` to preserve token tracking needed for compaction logic
- Clears `_diagPreFlightTokens` to reset diagnostic state for the retry
- Includes detailed logging to explain the recovery action

https://claude.ai/code/session_01GzSfVTyZ7KWTWwQ3qE1spU

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core request/retry behavior for OpenAI Responses; the recursive retry/compaction path could alter conversation state or retry semantics if mis-triggered, but is narrowly scoped to context window errors during chaining.
> 
> **Overview**
> Improves resilience to `context window exceeded` errors when using OpenAI Responses chaining via `previous_response_id`.
> 
> When a context overflow occurs during a chained request, the handler now **clears `previousResponseId`, requests compaction, resets token diagnostics, and internally retries** the call (without `resetConversationState()` to preserve token history so compaction triggers), with a guard to avoid infinite retry loops.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c920c20c28a2d93c1f0b77b7a54552f4b3d12451. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->