### PR TITLE
Improve model dropdown resilience with fallback to basic model list

### DIFF
--- a/src/model/computeModelOptions.ts
+++ b/src/model/computeModelOptions.ts
@@ -154,6 +154,25 @@ async function buildModelOptionData(
   };
 }
 
+/**
+ * Build basic model options from static config only (synchronous).
+ * Includes provider, context, and cost metadata but skips async
+ * availability checks. All models are shown as enabled.
+ */
+export function buildBasicModelOptionsData(): ModelOptionData[] {
+  return getVisibleModels().map((model) => {
+    const config = MODEL_CONFIGS[model];
+    if (!config) return { value: model, label: model };
+    return {
+      value: model,
+      label: model,
+      provider: config.provider,
+      context: formatContext(config.contextWindow),
+      cost: formatCost(config.inputPrice, config.outputPrice),
+    };
+  });
+}
+
 /** Compute typed model options data for Lit-native rendering. */
 export async function computeModelOptionsData(): Promise<ModelOptionData[]> {
   const models = getVisibleModels();

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -8,8 +8,8 @@ import {
 } from '@common/webview';
 import { AgentLogger } from '@logger/AgentLogger';
 import {
+  buildBasicModelOptionsData,
   computeModelOptionsData,
-  getVisibleModels,
 } from '@model/computeModelOptions';
 import { ApprovalRequestHandler } from '@progressView/managers/ApprovalRequestHandler';
 import { WebviewUpdater } from '@progressView/managers/WebviewUpdater';
@@ -192,9 +192,9 @@ export class ProgressViewProvider
     try {
       modelOptions = await this.getCachedModelOptions();
     } catch {
-      // Full availability check failed — fall back to basic model list
-      // so the dropdown still appears (without availability/cost metadata).
-      modelOptions = getVisibleModels().map((m) => ({ value: m, label: m }));
+      // Availability check failed (e.g. ServerSideKeyService not yet initialized) —
+      // fall back to static model metadata so the dropdown still appears.
+      modelOptions = buildBasicModelOptionsData();
     }
     if (!this.agentProposalHandler.get(proposal.proposalId)) return;
     this.webviewUpdater.showAgentProposal(proposal, modelOptions);

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -118,8 +118,10 @@ export class ProgressViewProvider
     this.agentProposalHandler = new ApprovalRequestHandler(
       'proposalId',
       (p) => {
-        u.showAgentProposal(p); // Synchronous — proposal appears immediately
-        void this.sendProposalModelOptions(p); // Progressive enhancement
+        // Show proposal immediately with basic model dropdown (synchronous)
+        u.showAgentProposal(p, buildBasicModelOptionsData());
+        // Then upgrade with availability metadata if possible
+        void this.sendProposalModelOptions(p);
       },
       (id) => u.resolveAgentProposal(id),
       canSend,

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -7,7 +7,10 @@ import {
   getSharedLocalResourceRoots,
 } from '@common/webview';
 import { AgentLogger } from '@logger/AgentLogger';
-import { computeModelOptionsData } from '@model/computeModelOptions';
+import {
+  computeModelOptionsData,
+  getVisibleModels,
+} from '@model/computeModelOptions';
 import { ApprovalRequestHandler } from '@progressView/managers/ApprovalRequestHandler';
 import { WebviewUpdater } from '@progressView/managers/WebviewUpdater';
 import { isApprovalBypassedForStream } from '@tools/approval/toolEditApproval';
@@ -185,13 +188,16 @@ export class ProgressViewProvider
   private async sendProposalModelOptions(
     proposal: AgentProposalPermission,
   ): Promise<void> {
+    let modelOptions: ModelOptionData[];
     try {
-      const modelOptions = await this.getCachedModelOptions();
-      if (!this.agentProposalHandler.get(proposal.proposalId)) return;
-      this.webviewUpdater.showAgentProposal(proposal, modelOptions);
+      modelOptions = await this.getCachedModelOptions();
     } catch {
-      // Model dropdown won't appear — static label fallback is fine
+      // Full availability check failed — fall back to basic model list
+      // so the dropdown still appears (without availability/cost metadata).
+      modelOptions = getVisibleModels().map((m) => ({ value: m, label: m }));
     }
+    if (!this.agentProposalHandler.get(proposal.proposalId)) return;
+    this.webviewUpdater.showAgentProposal(proposal, modelOptions);
   }
 
   private async getCachedModelOptions(): Promise<ModelOptionData[]> {


### PR DESCRIPTION
## Summary
Enhanced the proposal model options handling to gracefully degrade when full model metadata (availability/cost) cannot be fetched, ensuring the model dropdown always appears to users.

## Key Changes
- Added import of `getVisibleModels` from `@model/computeModelOptions` to provide a fallback model list
- Modified `sendProposalModelOptions()` error handling to fall back to a basic model list when `getCachedModelOptions()` fails
- Moved the proposal handler existence check after model options are determined, ensuring it doesn't prevent fallback behavior
- Updated error comment to clarify the fallback strategy

## Implementation Details
- When full model options (with availability/cost metadata) cannot be retrieved, the code now falls back to `getVisibleModels()` and maps it to basic `ModelOptionData` objects with value and label only
- This ensures the model dropdown UI component still renders even if the availability check fails, providing a better user experience
- The proposal handler check is now performed after model options are ready, preventing early returns that would skip the webview update

https://claude.ai/code/session_01TLpBzDZ3L7RjbpUmtY5xXz

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-side resilience change that mainly affects how proposal model dropdown options are populated; minimal logic change and no auth/data writes, but could slightly alter enabled/disabled display when async availability fails.
> 
> **Overview**
> Makes the proposal model dropdown resilient by introducing `buildBasicModelOptionsData()` (sync, static metadata only) and using it to render proposals immediately.
> 
> `ProgressViewProvider` now progressively enhances proposals: it first shows basic model options, then attempts to refresh with full async availability via `computeModelOptionsData()`, and falls back to the basic list if that async computation fails before re-showing the proposal.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bcdb8cd7c97085ea41dc91b3bd7494ca275ed987. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->