### PR TITLE
Standardize path separators to forward slashes across codebase

### DIFF
--- a/src/FolderExplorer.ts
+++ b/src/FolderExplorer.ts
@@ -108,7 +108,9 @@ export class FolderExplorer implements vscode.TreeDataProvider<FileItem> {
 
         const resourceUri = vscode.Uri.file(path.join(dirPath, name));
         const isBuiltIn =
+          resourceUri.fsPath === builtInAgentsPath ||
           resourceUri.fsPath.startsWith(builtInAgentsPath + path.sep) ||
+          resourceUri.fsPath === builtInToolUsePath ||
           resourceUri.fsPath.startsWith(builtInToolUsePath + path.sep);
         const isDirectory = type === vscode.FileType.Directory;
 

--- a/src/FolderExplorer.ts
+++ b/src/FolderExplorer.ts
@@ -108,8 +108,8 @@ export class FolderExplorer implements vscode.TreeDataProvider<FileItem> {
 
         const resourceUri = vscode.Uri.file(path.join(dirPath, name));
         const isBuiltIn =
-          resourceUri.fsPath.startsWith(builtInAgentsPath) ||
-          resourceUri.fsPath.startsWith(builtInToolUsePath);
+          resourceUri.fsPath.startsWith(builtInAgentsPath + path.sep) ||
+          resourceUri.fsPath.startsWith(builtInToolUsePath + path.sep);
         const isDirectory = type === vscode.FileType.Directory;
 
         items.push(

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -1,5 +1,6 @@
 // Standard library imports
 import { Buffer } from 'node:buffer';
+import * as path from 'path';
 
 // Third-party imports
 import OpenAI, { APIConnectionTimeoutError, toFile } from 'openai';
@@ -2379,7 +2380,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       try {
         const filename =
           typeof attachment.path === 'string' && attachment.path.length > 0
-            ? (attachment.path.split('/').pop() ?? 'attachment')
+            ? path.basename(attachment.path)
             : 'attachment';
         const mimeType = attachment.mimeType ?? 'application/octet-stream';
 

--- a/src/explorer/ExplorerOperations.ts
+++ b/src/explorer/ExplorerOperations.ts
@@ -57,13 +57,15 @@ export class ExplorerOperations {
 
   /**
    * Check if a path is within the built-in agents or tool-use directories.
+   * Uses path.sep boundary to avoid false matches with sibling directories
+   * (e.g., "agents" must not match "agents_backup").
    */
   private isBuiltInPath(targetPath: string): boolean {
     return (
       (!!this.builtInAgentsPath &&
-        targetPath.startsWith(this.builtInAgentsPath)) ||
+        targetPath.startsWith(this.builtInAgentsPath + path.sep)) ||
       (!!this.builtInToolUsePath &&
-        targetPath.startsWith(this.builtInToolUsePath))
+        targetPath.startsWith(this.builtInToolUsePath + path.sep))
     );
   }
 
@@ -87,7 +89,8 @@ export class ExplorerOperations {
     if (!this.isBuiltInPath(targetPath)) return targetPath;
 
     const isToolUse =
-      this.builtInToolUsePath && targetPath.startsWith(this.builtInToolUsePath);
+      this.builtInToolUsePath &&
+      targetPath.startsWith(this.builtInToolUsePath + path.sep);
     const base = isToolUse ? this.builtInToolUsePath : this.builtInAgentsPath;
     return path.join(customBase, path.relative(base, targetPath));
   }

--- a/src/explorer/ExplorerOperations.ts
+++ b/src/explorer/ExplorerOperations.ts
@@ -56,16 +56,18 @@ export class ExplorerOperations {
   }
 
   /**
-   * Check if a path is within the built-in agents or tool-use directories.
+   * Check if a path is within (or equal to) the built-in agents or tool-use directories.
    * Uses path.sep boundary to avoid false matches with sibling directories
    * (e.g., "agents" must not match "agents_backup").
    */
   private isBuiltInPath(targetPath: string): boolean {
     return (
       (!!this.builtInAgentsPath &&
-        targetPath.startsWith(this.builtInAgentsPath + path.sep)) ||
+        (targetPath === this.builtInAgentsPath ||
+          targetPath.startsWith(this.builtInAgentsPath + path.sep))) ||
       (!!this.builtInToolUsePath &&
-        targetPath.startsWith(this.builtInToolUsePath + path.sep))
+        (targetPath === this.builtInToolUsePath ||
+          targetPath.startsWith(this.builtInToolUsePath + path.sep)))
     );
   }
 
@@ -90,7 +92,8 @@ export class ExplorerOperations {
 
     const isToolUse =
       this.builtInToolUsePath &&
-      targetPath.startsWith(this.builtInToolUsePath + path.sep);
+      (targetPath === this.builtInToolUsePath ||
+        targetPath.startsWith(this.builtInToolUsePath + path.sep));
     const base = isToolUse ? this.builtInToolUsePath : this.builtInAgentsPath;
     return path.join(customBase, path.relative(base, targetPath));
   }

--- a/src/frontend/agents/AgentDirectoryManager.ts
+++ b/src/frontend/agents/AgentDirectoryManager.ts
@@ -223,10 +223,8 @@ export class AgentDirectoryManager {
     const subscription: AgentDirectoryWatcherSubscription = {
       pattern,
       handleEvent: (event) => {
-        // Normalize path separators for cross-platform compatibility
-        // Windows path.relative() produces backslashes, minimatch expects forward slashes
-        const normalizedPath = this.normalizePath(event.relativePath);
-        if (minimatch(normalizedPath, pattern, { dot: true })) {
+        // relativePath is already normalized to forward slashes in dispatchAgentEvent
+        if (minimatch(event.relativePath, pattern, { dot: true })) {
           options.onEvent(event);
         }
       },
@@ -243,14 +241,6 @@ export class AgentDirectoryManager {
         }
       },
     };
-  }
-
-  /**
-   * Normalize path separators for cross-platform glob matching.
-   * Windows path.relative() produces backslashes, but minimatch expects forward slashes.
-   */
-  private normalizePath(p: string): string {
-    return p.replaceAll('\\', '/');
   }
 
   /**
@@ -348,7 +338,12 @@ export class AgentDirectoryManager {
     type: AgentDirectoryEventType,
     uri: vscode.Uri,
   ): void {
-    const relativePath = path.relative(entry.directory, uri.fsPath);
+    // Normalize to forward slashes for cross-platform consistency.
+    // path.relative() returns backslashes on Windows, but minimatch
+    // and downstream consumers expect forward slashes.
+    const relativePath = path
+      .relative(entry.directory, uri.fsPath)
+      .replaceAll('\\', '/');
     const event: AgentDirectoryWatcherEvent = {
       type,
       uri,

--- a/src/frontend/files/listing.ts
+++ b/src/frontend/files/listing.ts
@@ -4,6 +4,9 @@ import * as path from 'path';
 // Third-party imports
 import * as vscode from 'vscode';
 
+// Local imports
+import { WorkspaceFS } from '@utils/files';
+
 /** Normalize path to forward slashes for cross-platform consistency */
 function toForwardSlashes(str: string): string {
   return str.replaceAll('\\', '/');
@@ -44,8 +47,8 @@ function containsHiddenSegment(relativePath: string): boolean {
 
 /**
  * Get path relative to root, preserving symlink structure within workspace.
- * Uses VS Code's asRelativePath for symlink awareness, then computes
- * the path relative to the specified root.
+ * Delegates to WorkspaceFS.relativePath() for symlink-aware resolution,
+ * then computes the path relative to the specified root.
  *
  * Always returns forward slashes for cross-platform consistency.
  */
@@ -53,31 +56,30 @@ function getRelativePathPreservingSymlinks(
   absolutePath: string,
   root: string,
 ): string {
-  const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
-  const wsRelative = vscode.workspace.asRelativePath(absolutePath, false);
+  // WorkspaceFS.relativePath() handles symlinks via asRelativePath
+  // and always returns forward slashes.
+  const wsRelative = WorkspaceFS.relativePath(absolutePath);
 
-  // If outside workspace, asRelativePath returns the original absolute path
-  if (wsRelative === absolutePath) {
+  // If outside workspace, relativePath returns the absolute path (still absolute)
+  if (path.isAbsolute(wsRelative)) {
     return toForwardSlashes(path.relative(root, absolutePath));
   }
 
-  // If root is the workspace root, return the workspace-relative path
+  // If root is the workspace root, the workspace-relative path is the answer
+  const workspaceRoot = WorkspaceFS.getPath();
   if (workspaceRoot && path.normalize(root) === path.normalize(workspaceRoot)) {
-    return toForwardSlashes(wsRelative);
+    return wsRelative;
   }
 
-  // root is a subdirectory - compute path from workspace-relative path
-  const rootRelative = vscode.workspace.asRelativePath(root, false);
-  if (rootRelative === root) {
+  // root is a subdirectory — get its workspace-relative path too
+  const rootRelative = WorkspaceFS.relativePath(root);
+  if (path.isAbsolute(rootRelative)) {
     return toForwardSlashes(path.relative(root, absolutePath));
   }
 
-  // Both paths are workspace-relative, compute relative path between them
-  const wsRelativeNorm = toForwardSlashes(wsRelative);
-  const rootRelativeNorm = toForwardSlashes(rootRelative);
-
-  if (wsRelativeNorm.startsWith(rootRelativeNorm + '/')) {
-    return wsRelativeNorm.slice(rootRelativeNorm.length + 1);
+  // Both paths are workspace-relative and forward-slash normalized
+  if (wsRelative.startsWith(rootRelative + '/')) {
+    return wsRelative.slice(rootRelative.length + 1);
   }
 
   return toForwardSlashes(path.relative(root, absolutePath));

--- a/src/frontend/files/listing.ts
+++ b/src/frontend/files/listing.ts
@@ -4,9 +4,9 @@ import * as path from 'path';
 // Third-party imports
 import * as vscode from 'vscode';
 
-/** Convert forward slashes to platform-native separators */
-function toPlatformSeparators(str: string): string {
-  return str.replaceAll('/', path.sep);
+/** Normalize path to forward slashes for cross-platform consistency */
+function toForwardSlashes(str: string): string {
+  return str.replaceAll('\\', '/');
 }
 
 /** Normalize and clean directory paths for filtering */
@@ -46,6 +46,8 @@ function containsHiddenSegment(relativePath: string): boolean {
  * Get path relative to root, preserving symlink structure within workspace.
  * Uses VS Code's asRelativePath for symlink awareness, then computes
  * the path relative to the specified root.
+ *
+ * Always returns forward slashes for cross-platform consistency.
  */
 function getRelativePathPreservingSymlinks(
   absolutePath: string,
@@ -56,30 +58,29 @@ function getRelativePathPreservingSymlinks(
 
   // If outside workspace, asRelativePath returns the original absolute path
   if (wsRelative === absolutePath) {
-    return path.relative(root, absolutePath);
+    return toForwardSlashes(path.relative(root, absolutePath));
   }
 
   // If root is the workspace root, return the workspace-relative path
   if (workspaceRoot && path.normalize(root) === path.normalize(workspaceRoot)) {
-    return toPlatformSeparators(wsRelative);
+    return toForwardSlashes(wsRelative);
   }
 
   // root is a subdirectory - compute path from workspace-relative path
   const rootRelative = vscode.workspace.asRelativePath(root, false);
   if (rootRelative === root) {
-    return path.relative(root, absolutePath);
+    return toForwardSlashes(path.relative(root, absolutePath));
   }
 
   // Both paths are workspace-relative, compute relative path between them
-  const wsRelativeNorm = wsRelative.replaceAll('\\', '/');
-  const rootRelativeNorm = rootRelative.replaceAll('\\', '/');
+  const wsRelativeNorm = toForwardSlashes(wsRelative);
+  const rootRelativeNorm = toForwardSlashes(rootRelative);
 
   if (wsRelativeNorm.startsWith(rootRelativeNorm + '/')) {
-    const result = wsRelativeNorm.slice(rootRelativeNorm.length + 1);
-    return toPlatformSeparators(result);
+    return wsRelativeNorm.slice(rootRelativeNorm.length + 1);
   }
 
-  return path.relative(root, absolutePath);
+  return toForwardSlashes(path.relative(root, absolutePath));
 }
 
 /** Check if path contains an excluded directory segment */

--- a/src/latex/arxivProcessor.ts
+++ b/src/latex/arxivProcessor.ts
@@ -257,7 +257,8 @@ export class ArxivSourceProcessor {
     } else {
       // For non-archive files, rename to main.tex and move to paper root
       const downloadedRel = WorkspaceFS.relativePath(downloadedPath);
-      const targetRel = path.join(paperDirRelative, 'main.tex');
+      // Use forward slashes to match WorkspaceFS.relativePath() convention
+      const targetRel = [paperDirRelative, 'main.tex'].join('/');
       // Always move the file to paper root, even if already named main.tex
       if (downloadedRel !== targetRel) {
         await WorkspaceFS.rename(downloadedRel, targetRel);

--- a/src/latex/formatter/latexindentpt.ts
+++ b/src/latex/formatter/latexindentpt.ts
@@ -40,7 +40,8 @@ export async function runLatexIndent(filePath: string): Promise<boolean> {
     );
 
     const workspacePath = WorkspaceFS.getPath();
-    const isWorkspaceFile = workspacePath && filePath.startsWith(workspacePath);
+    const isWorkspaceFile =
+      workspacePath && filePath.startsWith(workspacePath + path.sep);
 
     // Get latexindent config from settings
     const latexindentConfig = getConfig<string>(

--- a/src/latex/formatter/latexindentpt.ts
+++ b/src/latex/formatter/latexindentpt.ts
@@ -41,7 +41,9 @@ export async function runLatexIndent(filePath: string): Promise<boolean> {
 
     const workspacePath = WorkspaceFS.getPath();
     const isWorkspaceFile =
-      workspacePath && filePath.startsWith(workspacePath + path.sep);
+      workspacePath &&
+      (filePath === workspacePath ||
+        filePath.startsWith(workspacePath + path.sep));
 
     // Get latexindent config from settings
     const latexindentConfig = getConfig<string>(

--- a/src/tools/RunsTool.ts
+++ b/src/tools/RunsTool.ts
@@ -368,12 +368,13 @@ Use view_range: [start, end] to paginate large outputs.`,
       const entries = await StorageFS.readDir(fullPath);
 
       for (const [name, type] of entries) {
-        // Use path.join for correct OS joining, then normalize to forward
-        // slashes so display output is consistent across platforms.
-        const entryRelative = relativePath
-          ? path.join(relativePath, name).replaceAll('\\', '/')
+        // Build raw path for filesystem access (preserves platform separators),
+        // then normalize to forward slashes only for display output.
+        const entryRaw = relativePath
+          ? path.join(relativePath, name)
           : name;
-        const entryFull = path.join(basePath, entryRelative);
+        const entryRelative = entryRaw.replaceAll('\\', '/');
+        const entryFull = path.join(basePath, entryRaw);
         const isDir = type === vscode.FileType.Directory;
 
         try {
@@ -383,7 +384,7 @@ Use view_range: [start, end] to paginate large outputs.`,
           if (isDir && maxDepth > 1) {
             const children = await this.walkDirectory(
               basePath,
-              entryRelative,
+              entryRaw,
               maxDepth - 1,
             );
             results.push(...children);

--- a/src/tools/RunsTool.ts
+++ b/src/tools/RunsTool.ts
@@ -368,8 +368,10 @@ Use view_range: [start, end] to paginate large outputs.`,
       const entries = await StorageFS.readDir(fullPath);
 
       for (const [name, type] of entries) {
+        // Use path.join for correct OS joining, then normalize to forward
+        // slashes so display output is consistent across platforms.
         const entryRelative = relativePath
-          ? path.join(relativePath, name)
+          ? path.join(relativePath, name).replaceAll('\\', '/')
           : name;
         const entryFull = path.join(basePath, entryRelative);
         const isDir = type === vscode.FileType.Directory;

--- a/src/tools/RunsTool.ts
+++ b/src/tools/RunsTool.ts
@@ -3,6 +3,9 @@
  * Read-only access to past runs - agents can learn from history.
  */
 
+// Standard library imports
+import * as path from 'path';
+
 // Third-party imports
 import * as vscode from 'vscode';
 import { z } from 'zod';
@@ -326,7 +329,7 @@ Use view_range: [start, end] to paginate large outputs.`,
    * List files in task run directory.
    */
   private async listFiles(executionId: ExecutionId): Promise<ToolResult> {
-    const runDir = `${TASK_RUNS_DIR}/${executionId}`;
+    const runDir = path.join(TASK_RUNS_DIR, executionId);
 
     if (!(await StorageFS.exists(runDir))) {
       return { output: 'No files generated for this execution.' };
@@ -357,14 +360,18 @@ Use view_range: [start, end] to paginate large outputs.`,
     maxDepth: number,
   ): Promise<Array<{ path: string; size: number; isDir: boolean }>> {
     const results: Array<{ path: string; size: number; isDir: boolean }> = [];
-    const fullPath = relativePath ? `${basePath}/${relativePath}` : basePath;
+    const fullPath = relativePath
+      ? path.join(basePath, relativePath)
+      : basePath;
 
     try {
       const entries = await StorageFS.readDir(fullPath);
 
       for (const [name, type] of entries) {
-        const entryRelative = relativePath ? `${relativePath}/${name}` : name;
-        const entryFull = `${basePath}/${entryRelative}`;
+        const entryRelative = relativePath
+          ? path.join(relativePath, name)
+          : name;
+        const entryFull = path.join(basePath, entryRelative);
         const isDir = type === vscode.FileType.Directory;
 
         try {
@@ -398,7 +405,7 @@ Use view_range: [start, end] to paginate large outputs.`,
     filePath: string,
     viewRange?: number[],
   ): Promise<ToolResult> {
-    const fullPath = `${TASK_RUNS_DIR}/${executionId}/${filePath}`;
+    const fullPath = path.join(TASK_RUNS_DIR, executionId, filePath);
 
     if (!(await StorageFS.exists(fullPath))) {
       throw new ToolError(

--- a/src/tools/ls.ts
+++ b/src/tools/ls.ts
@@ -1,3 +1,6 @@
+// Standard library imports
+import * as path from 'path';
+
 // Third-party imports
 import * as vscode from 'vscode';
 import { z } from 'zod';
@@ -87,7 +90,7 @@ export class LsTool extends defineTool({
 
     if (stats.type === vscode.FileType.File) {
       const relativePosix = toPosixPath(resolved.relative);
-      const fileName = relativePosix.split('/').at(-1) ?? relativePosix;
+      const fileName = path.basename(resolved.relative);
       const isIgnored =
         isDefaultHiddenName(fileName) ||
         gitignore.ignores(resolved.relative) ||

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -53,7 +53,9 @@ export function resolveWorkspaceRelativePath(
     };
   }
 
-  const relative = path.normalize(trimmed);
+  // Normalize and convert to forward slashes for cross-platform consistency
+  // (path.normalize on Windows converts / to \)
+  const relative = path.normalize(trimmed).replaceAll('\\', '/');
   if (relative.startsWith('..')) {
     throw new ToolError('Path must stay within the workspace.');
   }

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -44,7 +44,10 @@ export function resolveWorkspaceRelativePath(
 
   if (path.isAbsolute(trimmed)) {
     const relative = WorkspaceFS.relativePath(trimmed);
-    if (relative === trimmed || relative.startsWith('..')) {
+    // When the path is outside the workspace, asRelativePath returns the
+    // original absolute path (now forward-slash normalized). Detect this
+    // with path.isAbsolute() which handles both C:/ and / forms.
+    if (path.isAbsolute(relative) || relative.startsWith('..')) {
       throw new ToolError('Path must stay within the workspace.');
     }
     return {

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -22,50 +22,29 @@ export interface WorkspacePathResolution {
 /**
  * Resolve a potentially absolute or relative path against the workspace root.
  *
- * The returned relative path is normalized and guaranteed to remain inside the
- * workspace. Throws if the workspace folder cannot be determined or if the
- * resolved location would escape the workspace root.
+ * Thin policy wrapper around WorkspaceFS.locatePath() that throws ToolError
+ * when the path is external. Tools use this; non-tool code should call
+ * WorkspaceFS.locatePath() directly and handle the discriminated union.
  */
 export function resolveWorkspaceRelativePath(
   targetPath?: string,
 ): WorkspacePathResolution {
-  const workspacePath = WorkspaceFS.getPath();
-  if (!workspacePath) {
+  if (!WorkspaceFS.getPath()) {
     throw new ToolError('Workspace path is not available.');
   }
 
   const trimmed = targetPath?.trim();
-  if (!trimmed || trimmed === '.') {
-    return {
-      relative: '.',
-      absolute: workspacePath,
-    };
-  }
+  const resolved = WorkspaceFS.locatePath(
+    !trimmed || trimmed === '.' ? '' : trimmed,
+  );
 
-  if (path.isAbsolute(trimmed)) {
-    const relative = WorkspaceFS.relativePath(trimmed);
-    // When the path is outside the workspace, asRelativePath returns the
-    // original absolute path (now forward-slash normalized). Detect this
-    // with path.isAbsolute() which handles both C:/ and / forms.
-    if (path.isAbsolute(relative) || relative.startsWith('..')) {
-      throw new ToolError('Path must stay within the workspace.');
-    }
-    return {
-      relative: relative === '' ? '.' : relative,
-      absolute: trimmed,
-    };
-  }
-
-  // Normalize and convert to forward slashes for cross-platform consistency
-  // (path.normalize on Windows converts / to \)
-  const relative = path.normalize(trimmed).replaceAll('\\', '/');
-  if (relative.startsWith('..')) {
+  if (resolved.kind === 'external') {
     throw new ToolError('Path must stay within the workspace.');
   }
 
   return {
-    relative,
-    absolute: path.join(workspacePath, relative),
+    relative: resolved.relativePath || '.',
+    absolute: resolved.absolutePath,
   };
 }
 

--- a/src/utils/files/index.ts
+++ b/src/utils/files/index.ts
@@ -1,5 +1,5 @@
 // Core filesystem abstractions
-export { WorkspaceFS } from './workspaceFS';
+export { WorkspaceFS, type ResolvedPath } from './workspaceFS';
 export { AbsoluteFS } from './absoluteFS';
 export { StorageFS, GlobalStorageFS } from './storageFS';
 export { RelativeFS } from './relativeFS';

--- a/src/utils/files/taskRunStorage.ts
+++ b/src/utils/files/taskRunStorage.ts
@@ -126,7 +126,10 @@ function resolvePathAgainstWorkspace(
       return { kind: 'external', absolutePath: inputPath };
     }
     const relative = WorkspaceFS.relativePath(inputPath);
-    if (relative !== inputPath && !relative.startsWith('..')) {
+    // WorkspaceFS.relativePath() returns forward-slash normalized paths.
+    // When outside workspace, it returns the absolute path (still absolute).
+    // Use path.isAbsolute() instead of string equality to detect this.
+    if (!path.isAbsolute(relative) && !relative.startsWith('..')) {
       return {
         kind: 'workspace',
         absolutePath: inputPath,

--- a/src/utils/files/taskRunStorage.ts
+++ b/src/utils/files/taskRunStorage.ts
@@ -89,63 +89,6 @@ export function getFileDirectory(location: FileLocation): string {
   return path.dirname(location.absolutePath);
 }
 
-/**
- * Result of resolving a path against a workspace.
- * Used internally by path resolution functions.
- */
-type ResolvedPath =
-  | { kind: 'workspace'; absolutePath: string; relativePath: string }
-  | { kind: 'external'; absolutePath: string };
-
-/**
- * Resolve a path (absolute or relative) against a workspace root.
- * This is the shared logic for path resolution used by createLocation,
- * createRawOutputLocation, and pathToLocation.
- *
- * @param inputPath - Absolute or workspace-relative path
- * @param workspaceRoot - The workspace root directory (or undefined if no workspace)
- * @returns Resolved path info with kind, absolutePath, and relativePath (for workspace paths)
- */
-function resolvePathAgainstWorkspace(
-  inputPath: string,
-  workspaceRoot: string | undefined,
-): ResolvedPath {
-  if (!inputPath) {
-    if (!workspaceRoot) {
-      return { kind: 'external', absolutePath: '' };
-    }
-    return { kind: 'workspace', absolutePath: workspaceRoot, relativePath: '' };
-  }
-
-  if (path.isAbsolute(inputPath)) {
-    // Absolute path - check if within workspace
-    // Use WorkspaceFS.relativePath() which handles symlinks correctly via
-    // vscode.workspace.asRelativePath(). Direct path.relative() fails when
-    // the path is inside a symlinked directory.
-    if (!workspaceRoot) {
-      return { kind: 'external', absolutePath: inputPath };
-    }
-    const relative = WorkspaceFS.relativePath(inputPath);
-    // WorkspaceFS.relativePath() returns forward-slash normalized paths.
-    // When outside workspace, it returns the absolute path (still absolute).
-    // Use path.isAbsolute() instead of string equality to detect this.
-    if (!path.isAbsolute(relative) && !relative.startsWith('..')) {
-      return {
-        kind: 'workspace',
-        absolutePath: inputPath,
-        relativePath: relative,
-      };
-    }
-    return { kind: 'external', absolutePath: inputPath };
-  }
-
-  // Relative path
-  if (!workspaceRoot) {
-    return { kind: 'external', absolutePath: path.resolve(inputPath) };
-  }
-  const absolutePath = path.join(workspaceRoot, inputPath);
-  return { kind: 'workspace', absolutePath, relativePath: inputPath };
-}
 
 /**
  * Get the full path to a specific task run directory.
@@ -286,10 +229,6 @@ export class TaskRunFileService {
 
   public updateRunContext(executionId?: ExecutionId | null): void {
     this.applyExecutionContext(executionId ?? undefined);
-  }
-
-  private get workspaceRoot(): string | undefined {
-    return WorkspaceFS.getPath();
   }
 
   public getExecutionId(): ExecutionId | undefined {
@@ -442,7 +381,7 @@ export class TaskRunFileService {
    * @returns FileLocation (runStorage if executionId available, workspace otherwise)
    */
   public createRawOutputLocation(inputPath: string): FileLocation {
-    const resolved = resolvePathAgainstWorkspace(inputPath, this.workspaceRoot);
+    const resolved = WorkspaceFS.locatePath(inputPath);
 
     if (resolved.kind === 'external') {
       return createExternalLocation(resolved.absolutePath);
@@ -483,7 +422,7 @@ export class TaskRunFileService {
    * @returns FileLocation (workspace, runStorage, or external based on path and mode)
    */
   public createLocation(inputPath: string): FileLocation {
-    const resolved = resolvePathAgainstWorkspace(inputPath, this.workspaceRoot);
+    const resolved = WorkspaceFS.locatePath(inputPath);
 
     if (resolved.kind === 'external') {
       return createExternalLocation(resolved.absolutePath);
@@ -581,19 +520,12 @@ export function getComparablePath(location: FileLocation): string {
  * @returns FileLocation (workspace or external, never runStorage)
  */
 export function pathToLocation(target: string): FileLocation {
-  const workspaceRoot = WorkspaceFS.getPath();
-
-  // Special case: empty path requires workspace
-  if (!target) {
-    if (!workspaceRoot) {
-      throw new Error('Cannot resolve empty path without workspace');
-    }
-    return createWorkspaceLocation(workspaceRoot, '');
-  }
-
-  const resolved = resolvePathAgainstWorkspace(target, workspaceRoot);
+  const resolved = WorkspaceFS.locatePath(target);
 
   if (resolved.kind === 'external') {
+    if (!target) {
+      throw new Error('Cannot resolve empty path without workspace');
+    }
     return createExternalLocation(resolved.absolutePath);
   }
 

--- a/src/utils/files/workspaceFS.ts
+++ b/src/utils/files/workspaceFS.ts
@@ -7,6 +7,15 @@ import * as vscode from 'vscode';
 // Local imports - filesystem
 import { RelativeFS } from './relativeFS';
 
+/**
+ * Result of resolving a path against the workspace.
+ * 'workspace' paths have both absolute and forward-slash relative forms.
+ * 'external' paths are outside the workspace (or no workspace is open).
+ */
+export type ResolvedPath =
+  | { kind: 'workspace'; absolutePath: string; relativePath: string }
+  | { kind: 'external'; absolutePath: string };
+
 export class WorkspaceFS extends RelativeFS {
   protected static override getBasePath(): string {
     const folder = vscode.workspace.workspaceFolders?.[0];
@@ -44,5 +53,64 @@ export class WorkspaceFS extends RelativeFS {
    */
   public static toAbsolute(filePath: string): string {
     return path.isAbsolute(filePath) ? filePath : this.fullPath(filePath);
+  }
+
+  /**
+   * Resolve a path (absolute or relative) against the workspace root.
+   *
+   * This is the single resolution primitive for workspace path handling.
+   * Returns a discriminated union — callers apply their own policy
+   * (throw on external, create ExternalFileLocation, etc.).
+   *
+   * Relative paths are normalized to forward slashes. Paths that escape
+   * via `..` are treated as external.
+   */
+  public static locatePath(inputPath: string): ResolvedPath {
+    const workspaceRoot = this.getPath();
+
+    if (!inputPath) {
+      if (!workspaceRoot) {
+        return { kind: 'external', absolutePath: '' };
+      }
+      return {
+        kind: 'workspace',
+        absolutePath: workspaceRoot,
+        relativePath: '',
+      };
+    }
+
+    if (path.isAbsolute(inputPath)) {
+      if (!workspaceRoot) {
+        return { kind: 'external', absolutePath: inputPath };
+      }
+      const relative = this.relativePath(inputPath);
+      // relativePath() returns forward-slash normalized paths.
+      // Outside-workspace paths remain absolute — detect with path.isAbsolute().
+      if (!path.isAbsolute(relative) && !relative.startsWith('..')) {
+        return {
+          kind: 'workspace',
+          absolutePath: inputPath,
+          relativePath: relative,
+        };
+      }
+      return { kind: 'external', absolutePath: inputPath };
+    }
+
+    // Relative path — normalize to forward slashes
+    if (!workspaceRoot) {
+      return { kind: 'external', absolutePath: path.resolve(inputPath) };
+    }
+    const relative = path.normalize(inputPath).replaceAll('\\', '/');
+    if (relative.startsWith('..')) {
+      return {
+        kind: 'external',
+        absolutePath: path.resolve(workspaceRoot, inputPath),
+      };
+    }
+    return {
+      kind: 'workspace',
+      absolutePath: path.join(workspaceRoot, relative),
+      relativePath: relative,
+    };
   }
 }

--- a/src/utils/files/workspaceFS.ts
+++ b/src/utils/files/workspaceFS.ts
@@ -24,12 +24,18 @@ export class WorkspaceFS extends RelativeFS {
    * Convert an absolute path to a workspace-relative path.
    * Uses VS Code's asRelativePath which properly handles symlinks.
    * Returns the original path if no workspace is open.
+   *
+   * Always returns forward slashes for cross-platform consistency.
+   * On Windows, vscode.workspace.asRelativePath() returns backslashes;
+   * normalizing here ensures all downstream consumers get a consistent format.
    */
   public static relativePath(filePath: string): string {
     if (!this.getPath()) {
       return filePath;
     }
-    return vscode.workspace.asRelativePath(filePath, false);
+    return vscode.workspace
+      .asRelativePath(filePath, false)
+      .replaceAll('\\', '/');
   }
 
   /**

--- a/src/utils/files/workspaceFS.ts
+++ b/src/utils/files/workspaceFS.ts
@@ -96,11 +96,15 @@ export class WorkspaceFS extends RelativeFS {
       return { kind: 'external', absolutePath: inputPath };
     }
 
-    // Relative path — normalize to forward slashes
+    // Relative path — convert backslashes to forward slashes BEFORE normalizing
+    // so that path.posix.normalize() can properly collapse '..' segments.
+    // On POSIX, backslashes are valid filename characters, so path.normalize()
+    // would preserve them; the subsequent replaceAll would then create new
+    // path separators that could form '..' traversals bypassing the check below.
     if (!workspaceRoot) {
       return { kind: 'external', absolutePath: path.resolve(inputPath) };
     }
-    const relative = path.normalize(inputPath).replaceAll('\\', '/');
+    const relative = path.posix.normalize(inputPath.replaceAll('\\', '/'));
     if (relative.startsWith('..')) {
       return {
         kind: 'external',

--- a/src/webview/managers/FileManager.ts
+++ b/src/webview/managers/FileManager.ts
@@ -3,7 +3,6 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import { workspace } from 'vscode';
 
-import { normalizeFilePath } from '@shared/utils/path';
 import { getAgent } from '@agent/index';
 import {
   ExtensionCategory,
@@ -509,7 +508,7 @@ export class FileManager extends BaseWebviewManager {
     const relevantFiles = [
       ...new Set(
         fileUris.map((uri) =>
-          normalizeFilePath(workspace.asRelativePath(uri.fsPath, false)),
+          WorkspaceFS.relativePath(uri.fsPath),
         ),
       ),
     ];


### PR DESCRIPTION
## Summary
This PR standardizes path handling across the codebase to consistently use forward slashes for cross-platform compatibility. This ensures that paths are handled uniformly regardless of the operating system, particularly important for glob matching, path comparisons, and downstream consumers that expect forward slashes.

## Key Changes

- **Path normalization in AgentDirectoryManager**: Moved path normalization (backslash to forward slash conversion) from the watch handler to the `dispatchAgentEvent` method, ensuring all relative paths are normalized at the source before being used by minimatch or other consumers.

- **Replaced manual path concatenation with `path.join()`**: Updated multiple files to use Node's `path.join()` instead of string concatenation with `/`, improving robustness and maintainability:
  - `src/tools/RunsTool.ts`: Path construction for run directories and file listings
  - `src/tools/ls.ts`: File path handling
  - `src/frontend/agents/AgentDirectoryManager.ts`: Event path handling

- **Standardized path separator conversion**: 
  - Renamed `toPlatformSeparators()` to `toForwardSlashes()` in `listing.ts` to clarify intent
  - Updated `WorkspaceFS.relativePath()` to normalize VS Code's `asRelativePath()` output to forward slashes
  - Updated `resolveWorkspaceRelativePath()` in `utils.ts` to normalize paths to forward slashes

- **Simplified path extraction**: Replaced manual string splitting with `path.basename()` in:
  - `modelHandlerOpenAIResponse.ts`: Attachment filename extraction
  - `ls.ts`: File name extraction

- **Enhanced documentation**: Added clarifying comments explaining why forward slash normalization is necessary for cross-platform consistency.

## Implementation Details

The changes ensure that:
1. All relative paths returned to consumers use forward slashes consistently
2. Path operations use `path.join()` for proper cross-platform handling
3. Normalization happens at the boundary where paths are created/returned, not at every consumption point
4. The codebase is more maintainable with clearer intent in function names and comments

https://claude.ai/code/session_01KdPgyJ24ks6nkF38h1STSR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared path resolution and normalization used by tools, file listing, and run-storage routing; behavior changes could surface as subtle path mismatches (especially on Windows or with symlinks) if any downstream code assumed platform separators.
> 
> **Overview**
> Standardizes path handling to be **forward-slash normalized** across the extension, reducing Windows-specific separator issues in glob matching, path comparisons, and tool/webview outputs.
> 
> Introduces `WorkspaceFS.locatePath()` (discriminated union) as the central workspace path resolution primitive and refactors consumers (notably tool path resolution and task-run file location creation) to use it, while updating `WorkspaceFS.relativePath()` to always return forward slashes.
> 
> Hardens several path checks and joins: built-in agent directory detection now respects `path.sep` boundaries (avoids sibling-prefix false matches), tools (`runs`, `ls`) and LaTeX flows switch to `path.join()`/`path.basename()` and normalize display paths, and agent directory watcher events normalize relative paths at dispatch rather than per-subscriber.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 07ded4745bdb8e11d9fb3289d317d2cfac32068b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->