### PR TITLE
Display proposal mode badges in workflow and tool summaries

### DIFF
--- a/src/progressView/frontend/components/LogList.ts
+++ b/src/progressView/frontend/components/LogList.ts
@@ -220,12 +220,13 @@ export class LogList extends LitElement {
       return;
     }
 
-    // Handle proposal restore links
+    // Handle proposal restore links (may be inside <summary>, so prevent toggle)
     const proposalLink = this.findTargetInPath<HTMLElement>(
       event,
       '.proposal-restore-link',
     );
     if (proposalLink?.dataset.proposalId) {
+      event.preventDefault();
       const stored = getProposalInput(proposalLink.dataset.proposalId);
       if (stored) {
         postMessage(COMMANDS.RESTORE_PROPOSAL_CONFIG, {

--- a/src/progressView/frontend/components/RequestPanels.ts
+++ b/src/progressView/frontend/components/RequestPanels.ts
@@ -530,9 +530,15 @@ export class RequestPanels extends LitElement {
               : html`<span class="workflow-proposal__model"
                   >${data.model}</span
                 >`}
-            ${data.mode === 'async'
-              ? html`<span class="workflow-proposal__mode-badge">async</span>`
-              : nothing}
+            <span
+              class=${classMap({
+                'workflow-proposal__mode-badge': true,
+                'workflow-proposal__mode-badge--async': data.mode === 'async',
+                'workflow-proposal__mode-badge--sync': data.mode !== 'async',
+              })}
+            >
+              ${data.mode === 'async' ? 'async' : 'sync'}
+            </span>
           </div>
           <div class="workflow-proposal__instruction">${data.instruction}</div>
           ${isWorkflow

--- a/src/progressView/frontend/components/RequestPanels.ts
+++ b/src/progressView/frontend/components/RequestPanels.ts
@@ -534,10 +534,10 @@ export class RequestPanels extends LitElement {
               class=${classMap({
                 'workflow-proposal__mode-badge': true,
                 'workflow-proposal__mode-badge--async': data.mode === 'async',
-                'workflow-proposal__mode-badge--sync': data.mode !== 'async',
+                'workflow-proposal__mode-badge--sync': data.mode === 'sync',
               })}
             >
-              ${data.mode === 'async' ? 'async' : 'sync'}
+              ${data.mode}
             </span>
           </div>
           <div class="workflow-proposal__instruction">${data.instruction}</div>

--- a/src/progressView/frontend/components/RequestPanels.ts
+++ b/src/progressView/frontend/components/RequestPanels.ts
@@ -16,6 +16,7 @@ import {
   codiconIconClasses,
   commonViewStyles,
   designTokens,
+  proposalModeBadgeStyles,
   requestPanelStyles,
   selectStyles,
 } from '@shared/styles';
@@ -118,6 +119,7 @@ export class RequestPanels extends LitElement {
     codiconIconClasses,
     codeBlockStyles,
     requestPanelStyles,
+    proposalModeBadgeStyles,
     selectStyles,
   ];
 
@@ -532,9 +534,9 @@ export class RequestPanels extends LitElement {
                 >`}
             <span
               class=${classMap({
-                'workflow-proposal__mode-badge': true,
-                'workflow-proposal__mode-badge--async': data.mode === 'async',
-                'workflow-proposal__mode-badge--sync': data.mode === 'sync',
+                'proposal-mode-badge': true,
+                'proposal-mode-badge--async': data.mode === 'async',
+                'proposal-mode-badge--sync': data.mode === 'sync',
               })}
             >
               ${data.mode}

--- a/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
+++ b/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
@@ -14,6 +14,7 @@ import type { MemoryToolInput } from '@tools/memory/MemoryTool';
 // Local imports - Lit template utilities
 import {
   html,
+  nothing,
   classMap,
   ifDefined,
   type TemplateResult,
@@ -395,15 +396,6 @@ export function formatToolUseTemplate(
     );
   }
 
-  // Add "Setup" restore link for completed proposal tools (including rejected/timed-out)
-  if (PROPOSAL_TOOLS.has(toolName) && !isInProgress) {
-    const proposalId = registerProposalInput(input, toolName);
-    if (proposalId) {
-      // prettier-ignore
-      sections.push(html`<div class="proposal-restore-action"><span class="proposal-restore-link" data-proposal-id=${proposalId} title="Restore this proposal configuration to the main view"><i class="codicon codicon-reply"></i> Setup</span></div>`);
-    }
-  }
-
   // Show error if present
   if (errorText && !isUserFeedback) {
     sections.push(
@@ -442,6 +434,20 @@ export function formatToolUseTemplate(
   // prettier-ignore
   const timerTemplate = isInProgress ? html`<tool-timer .startTime=${timestamp} .timeoutMs=${toolTimeoutMs ?? 0}></tool-timer>` : undefined;
 
+  // Proposal banner extras: mode badge + setup link (shown in summary row)
+  const isProposal = PROPOSAL_TOOLS.has(toolName);
+  const proposalMode =
+    isProposal && isPlainObject(input) && typeof input.mode === 'string'
+      ? input.mode
+      : '';
+  const proposalId =
+    isProposal && !isInProgress
+      ? registerProposalInput(input, toolName)
+      : null;
+
+  // prettier-ignore
+  const extraContent = html`${timerTemplate ?? nothing}${proposalMode ? html`<span class=${classMap({ 'proposal-banner-badge': true, 'proposal-banner-badge--async': proposalMode === 'async', 'proposal-banner-badge--sync': proposalMode === 'sync' })}>${proposalMode}</span>` : nothing}${proposalId ? html`<span class="proposal-restore-link proposal-banner-setup" data-proposal-id=${proposalId} title="Restore this proposal configuration"><i class="codicon codicon-reply"></i> Setup</span>` : nothing}`;
+
   // prettier-ignore
   return html`<details class=${classMap({
     'banner-details': true,
@@ -454,7 +460,7 @@ export function formatToolUseTemplate(
     label: titleText,
     labelClass: 'tool-use-title',
     includeIconClass: false,
-    extraContent: timerTemplate,
+    extraContent,
   })}${bannerContentTemplate}</details>`;
 }
 

--- a/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
+++ b/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
@@ -446,7 +446,7 @@ export function formatToolUseTemplate(
       : null;
 
   // prettier-ignore
-  const extraContent = html`${timerTemplate ?? nothing}${proposalMode ? html`<span class=${classMap({ 'proposal-banner-badge': true, 'proposal-banner-badge--async': proposalMode === 'async', 'proposal-banner-badge--sync': proposalMode === 'sync' })}>${proposalMode}</span>` : nothing}${proposalId ? html`<span class="proposal-restore-link proposal-banner-setup" data-proposal-id=${proposalId} title="Restore this proposal configuration"><i class="codicon codicon-reply"></i> Setup</span>` : nothing}`;
+  const extraContent = html`${timerTemplate ?? nothing}${proposalMode ? html`<span class=${classMap({ 'proposal-mode-badge': true, 'proposal-mode-badge--async': proposalMode === 'async', 'proposal-mode-badge--sync': proposalMode === 'sync' })}>${proposalMode}</span>` : nothing}${proposalId ? html`<span class="proposal-restore-link proposal-banner-setup" data-proposal-id=${proposalId} title="Restore this proposal configuration"><i class="codicon codicon-reply"></i> Setup</span>` : nothing}`;
 
   // prettier-ignore
   return html`<details class=${classMap({

--- a/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
+++ b/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
@@ -439,7 +439,9 @@ export function formatToolUseTemplate(
   const proposalMode =
     isProposal && isPlainObject(input) && typeof input.mode === 'string'
       ? input.mode
-      : '';
+      : isProposal
+        ? 'sync'
+        : '';
   const proposalId =
     isProposal && !isInProgress
       ? registerProposalInput(input, toolName)

--- a/src/progressView/frontend/styles/logStyles.ts
+++ b/src/progressView/frontend/styles/logStyles.ts
@@ -9,6 +9,7 @@ import katexStyles from 'katex/dist/katex.min.css?inline';
 // Shared styles
 import { animationStyles } from '@shared/styles/litStyles';
 import { commonViewStyles } from '@shared/styles/commonViewStyles';
+import { proposalModeBadgeStyles } from '@shared/styles/badgeStyles';
 
 // Import and re-export individual style modules
 import { logEntryStyles } from './logEntryStyles';
@@ -69,5 +70,6 @@ export const logStyles = [
   groupStyles,
   codeBlockStyles,
   toolUseStyles,
+  proposalModeBadgeStyles,
   markdownStyles,
 ];

--- a/src/progressView/frontend/styles/toolUseStyles.ts
+++ b/src/progressView/frontend/styles/toolUseStyles.ts
@@ -138,27 +138,6 @@ export const toolUseStyles = css`
     overflow: auto;
   }
 
-  /* Proposal banner badge (sync/async mode indicator in summary row) */
-  .proposal-banner-badge {
-    font-size: var(--font-size-xs);
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-    padding: 1px 5px;
-    border-radius: var(--border-radius);
-    white-space: nowrap;
-  }
-
-  .proposal-banner-badge--async {
-    background: var(--vscode-editorWarning-foreground);
-    color: var(--vscode-editor-background);
-  }
-
-  .proposal-banner-badge--sync {
-    background: var(--vscode-editorWidget-border);
-    color: var(--vscode-editor-foreground);
-  }
-
   /* Proposal setup link (in summary row and body) */
   .proposal-restore-link {
     color: var(--color-text-link);

--- a/src/progressView/frontend/styles/toolUseStyles.ts
+++ b/src/progressView/frontend/styles/toolUseStyles.ts
@@ -138,11 +138,28 @@ export const toolUseStyles = css`
     overflow: auto;
   }
 
-  /* Proposal restore link */
-  .proposal-restore-action {
-    margin: var(--spacing-small) 0;
+  /* Proposal banner badge (sync/async mode indicator in summary row) */
+  .proposal-banner-badge {
+    font-size: var(--font-size-xs);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    padding: 1px 5px;
+    border-radius: var(--border-radius);
+    white-space: nowrap;
   }
 
+  .proposal-banner-badge--async {
+    background: var(--vscode-editorWarning-foreground);
+    color: var(--vscode-editor-background);
+  }
+
+  .proposal-banner-badge--sync {
+    background: var(--vscode-editorWidget-border);
+    color: var(--vscode-editor-foreground);
+  }
+
+  /* Proposal setup link (in summary row and body) */
   .proposal-restore-link {
     color: var(--color-text-link);
     cursor: pointer;
@@ -155,6 +172,10 @@ export const toolUseStyles = css`
 
   .proposal-restore-link:hover {
     text-decoration: underline;
+  }
+
+  .proposal-banner-setup {
+    margin-left: auto;
   }
 
   /* Diff styles */

--- a/src/shared/styles/badgeStyles.ts
+++ b/src/shared/styles/badgeStyles.ts
@@ -82,6 +82,28 @@ export const emptyStateStyles: CSSResult = css`
   }
 `;
 
+export const proposalModeBadgeStyles: CSSResult = css`
+  .proposal-mode-badge {
+    font-size: var(--font-size-xs);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    padding: 2px 6px;
+    border-radius: var(--border-radius);
+    white-space: nowrap;
+  }
+
+  .proposal-mode-badge--async {
+    background: var(--vscode-editorWarning-foreground);
+    color: var(--vscode-editor-background);
+  }
+
+  .proposal-mode-badge--sync {
+    background: var(--vscode-editorWidget-border);
+    color: var(--vscode-editor-foreground);
+  }
+`;
+
 export const badgeStyles = [
   baseBadgeStyles,
   categoryBadgeStyles,

--- a/src/shared/styles/index.ts
+++ b/src/shared/styles/index.ts
@@ -10,7 +10,7 @@ export { permissionCardStyles } from './permissionCardStyles';
 export { requestPanelStyles } from './requestPanelStyles';
 
 // Badge styles (combined array used by multiple views)
-export { badgeStyles } from './badgeStyles';
+export { badgeStyles, proposalModeBadgeStyles } from './badgeStyles';
 
 // History/search styles
 export {

--- a/src/shared/styles/requestPanelStyles.ts
+++ b/src/shared/styles/requestPanelStyles.ts
@@ -373,26 +373,6 @@ export const requestPanelStyles: CSSResult = css`
     max-width: 12rem;
   }
 
-  .workflow-proposal__mode-badge {
-    font-size: var(--font-size-xs);
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-    padding: 2px 6px;
-    border-radius: var(--border-radius);
-    white-space: nowrap;
-  }
-
-  .workflow-proposal__mode-badge--async {
-    background: var(--vscode-editorWarning-foreground);
-    color: var(--vscode-editor-background);
-  }
-
-  .workflow-proposal__mode-badge--sync {
-    background: var(--vscode-editorWidget-border);
-    color: var(--vscode-editor-foreground);
-  }
-
   .workflow-proposal__instruction {
     font-size: var(--font-size-sm);
     color: var(--vscode-editor-foreground);

--- a/src/shared/styles/requestPanelStyles.ts
+++ b/src/shared/styles/requestPanelStyles.ts
@@ -381,8 +381,16 @@ export const requestPanelStyles: CSSResult = css`
     padding: 2px 6px;
     border-radius: var(--border-radius);
     white-space: nowrap;
+  }
+
+  .workflow-proposal__mode-badge--async {
     background: var(--vscode-editorWarning-foreground);
     color: var(--vscode-editor-background);
+  }
+
+  .workflow-proposal__mode-badge--sync {
+    background: var(--vscode-badge-background);
+    color: var(--vscode-badge-foreground);
   }
 
   .workflow-proposal__instruction {

--- a/src/shared/styles/requestPanelStyles.ts
+++ b/src/shared/styles/requestPanelStyles.ts
@@ -389,8 +389,8 @@ export const requestPanelStyles: CSSResult = css`
   }
 
   .workflow-proposal__mode-badge--sync {
-    background: var(--vscode-badge-background);
-    color: var(--vscode-badge-foreground);
+    background: var(--vscode-editorWidget-border);
+    color: var(--vscode-editor-foreground);
   }
 
   .workflow-proposal__instruction {


### PR DESCRIPTION
## Summary
Enhanced the UI to consistently display proposal mode indicators (sync/async) in workflow proposals and tool use summaries, with improved styling and layout.

## Key Changes

- **RequestPanels.ts**: Refactored mode badge rendering to always display the mode value with conditional styling based on sync/async state, replacing the previous conditional rendering that only showed async badges

- **toolFormatters.ts**: 
  - Moved proposal mode badge and setup link rendering from tool body to the summary row's `extraContent`
  - Removed the separate "Setup" restore link section from tool details
  - Added logic to extract proposal mode from input and conditionally render mode badge and setup link in the summary

- **toolUseStyles.ts**: 
  - Added new `.proposal-banner-badge` styles for mode indicators in summary rows with async/sync variants
  - Added `.proposal-banner-setup` class to right-align the setup link in the summary
  - Reorganized proposal-related styles with clearer comments

- **requestPanelStyles.ts**: 
  - Split mode badge styling into base class and mode-specific variants (`.workflow-proposal__mode-badge--async` and `.workflow-proposal__mode-badge--sync`)
  - Maintains consistent color scheme with warning colors for async and widget border colors for sync

## Implementation Details

- Both sync and async modes now display badges consistently (previously only async was shown)
- Mode badges use the same color scheme across workflow proposals and tool summaries
- Setup link is now positioned in the summary row with `margin-left: auto` for right alignment
- Proposal mode is extracted from the input object with type safety checks

https://claude.ai/code/session_01Hg73CLkQNJVEeDFgTmNXvA

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only rendering/styling changes around proposal/tool banners; low risk aside from minor layout/toggle behavior regressions in log `details` summaries.
> 
> **Overview**
> Adds a consistent *proposal mode* badge (`sync`/`async`) across workflow proposal cards and tool-use log banners, backed by shared `proposalModeBadgeStyles` and applied in both `RequestPanels` and `logStyles`.
> 
> Moves proposal tool “Setup” restore affordance from the tool body into the tool banner summary `extraContent` (alongside the in-progress timer), and updates click handling in `LogList` to `preventDefault()` so clicking the restore link inside a `<summary>` doesn’t toggle the enclosing `details`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8b4cf02c8e746a62887adeef12fc84b87844b8af. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->