### PR TITLE
Add tools caching for remote agents to enable orchestrator visibility

### DIFF
--- a/docs/supabase/ADD_PRESENTER_SEARCH_REMOTE.sql
+++ b/docs/supabase/ADD_PRESENTER_SEARCH_REMOTE.sql
@@ -1,0 +1,69 @@
+-- Migration: Add presenter and search as remote tool-use agents,
+-- and sync descriptions/tools for existing remote agents.
+--
+-- Prerequisites:
+-- 1. Run the tools column migration first:
+--    supabase/migrations/20260209_add_tools_to_remote_agents.sql
+--
+-- 2. Upload the YAML files to Supabase Storage:
+--    - Copy from: resources/tool_use_agents/presenter.yaml
+--    - Upload to: Storage > agent-configs > researcher/presenter.yaml
+--
+--    - Copy from: resources/tool_use_agents/search.yaml
+--    - Upload to: Storage > agent-configs > researcher/search.yaml
+--
+-- Then run this SQL in Supabase SQL Editor:
+
+-- =============================================================================
+-- NEW AGENTS: presenter and search (tool-use)
+-- =============================================================================
+
+INSERT INTO remote_agents (name, description, storage_path, visibility, agent_category, tools)
+VALUES (
+  'presenter',
+  'Interactive scientific presentation builder with visual QA.',
+  'researcher/presenter.yaml',
+  ARRAY['researcher'],
+  'toolUse',
+  ARRAY['todo_write', 'bash', 'read_file', 'write_file', 'edit_file', 'glob', 'grep', 'ls', 'extract_figures', 'extract_bib_entries', 'extract_tikz_figures', 'wolfram', 'arxiv_search', 'arxiv_metadata', 'web_search', 'web_fetch']
+);
+
+INSERT INTO remote_agents (name, description, storage_path, visibility, agent_category, tools)
+VALUES (
+  'search',
+  'Research assistant with web search and literature discovery tools.',
+  'researcher/search.yaml',
+  ARRAY['researcher'],
+  'toolUse',
+  ARRAY['bash', 'read_file', 'glob', 'grep', 'ls', 'extract_figures', 'extract_bib_entries', 'extract_tikz_figures', 'arxiv_search', 'arxiv_metadata', 'download_arxiv_source', 'crossref_search', 'crossref_doi', 'zotero_add', 'zotero_search', 'zotero_export', 'web_search', 'web_fetch']
+);
+
+-- =============================================================================
+-- SYNC: descriptions and agent_category for existing remote agents
+-- =============================================================================
+
+-- Fix transcribe_audio: sync trailing period from YAML, migrate agent_type → agent_category
+UPDATE remote_agents
+SET description = 'Transcribes audio with speaker identification and LaTeX math formatting.',
+    agent_category = 'workflow'
+WHERE name = 'transcribe_audio';
+
+-- apply and apply_multiple: descriptions already match YAML, just ensure agent_category is set
+UPDATE remote_agents
+SET agent_category = 'workflow'
+WHERE name IN ('apply', 'apply_multiple');
+
+-- =============================================================================
+-- BACKFILL: populate tools column for existing remote agents that have them
+-- (apply and transcribe_audio are workflow agents with no tools column needed)
+-- =============================================================================
+
+-- No tools to backfill for existing agents (all workflow/CoT type).
+
+-- =============================================================================
+-- VERIFY
+-- =============================================================================
+
+SELECT name, description, agent_category, tools, visibility
+FROM remote_agents
+ORDER BY name;

--- a/docs/supabase/ADD_PRESENTER_SEARCH_REMOTE.sql
+++ b/docs/supabase/ADD_PRESENTER_SEARCH_REMOTE.sql
@@ -1,13 +1,16 @@
--- Migration: Add presenter and search as remote tool-use agents,
+-- Migration: Add presenter, search, and simplifier as remote tool-use agents,
 -- and sync descriptions/tools for existing remote agents.
 --
 -- Prerequisites:
 -- 1. Upload the YAML files to Supabase Storage:
---    - Copy from: resources/tool_use_agents/presenter.yaml
+--    - Copy from: reference-agents/presenter.yaml
 --    - Upload to: Storage > agent-configs > tool_use/presenter.yaml
 --
---    - Copy from: resources/tool_use_agents/search.yaml
+--    - Copy from: reference-agents/search.yaml
 --    - Upload to: Storage > agent-configs > tool_use/search.yaml
+--
+--    - Copy from: reference-agents/simplifier.yaml
+--    - Upload to: Storage > agent-configs > tool_use/simplifier.yaml
 --
 -- Then run this SQL in Supabase SQL Editor:
 
@@ -40,6 +43,16 @@ VALUES (
   ARRAY['researcher'],
   'toolUse',
   ARRAY['bash', 'read_file', 'glob', 'grep', 'ls', 'extract_figures', 'extract_bib_entries', 'extract_tikz_figures', 'arxiv_search', 'arxiv_metadata', 'download_arxiv_source', 'crossref_search', 'crossref_doi', 'zotero_add', 'zotero_search', 'zotero_export', 'web_search', 'web_fetch']
+);
+
+INSERT INTO remote_agents (name, description, storage_path, visibility, agent_category, tools)
+VALUES (
+  'simplifier',
+  'Simplifies scientific code and LaTeX for clarity and maintainability while preserving all functionality.',
+  'tool_use/simplifier.yaml',
+  ARRAY['researcher'],
+  'toolUse',
+  ARRAY['todo_write', 'bash', 'read_file', 'write_file', 'edit_file', 'glob', 'grep', 'ls', 'diagnostics', 'extract_figures', 'extract_tikz_figures', 'memory']
 );
 
 -- =============================================================================

--- a/docs/supabase/ADD_PRESENTER_SEARCH_REMOTE.sql
+++ b/docs/supabase/ADD_PRESENTER_SEARCH_REMOTE.sql
@@ -2,10 +2,7 @@
 -- and sync descriptions/tools for existing remote agents.
 --
 -- Prerequisites:
--- 1. Run the tools column migration first:
---    supabase/migrations/20260209_add_tools_to_remote_agents.sql
---
--- 2. Upload the YAML files to Supabase Storage:
+-- 1. Upload the YAML files to Supabase Storage:
 --    - Copy from: resources/tool_use_agents/presenter.yaml
 --    - Upload to: Storage > agent-configs > researcher/presenter.yaml
 --
@@ -15,7 +12,14 @@
 -- Then run this SQL in Supabase SQL Editor:
 
 -- =============================================================================
--- NEW AGENTS: presenter and search (tool-use)
+-- STEP 1: Ensure tools column exists (idempotent)
+-- =============================================================================
+
+ALTER TABLE remote_agents
+ADD COLUMN IF NOT EXISTS tools TEXT[] DEFAULT NULL;
+
+-- =============================================================================
+-- STEP 2: Insert new agents
 -- =============================================================================
 
 INSERT INTO remote_agents (name, description, storage_path, visibility, agent_category, tools)
@@ -39,26 +43,19 @@ VALUES (
 );
 
 -- =============================================================================
--- SYNC: descriptions and agent_category for existing remote agents
+-- STEP 3: Sync descriptions and agent_category for existing remote agents
 -- =============================================================================
 
--- Fix transcribe_audio: sync trailing period from YAML, migrate agent_type → agent_category
+-- Fix transcribe_audio: sync trailing period from YAML, ensure agent_category
 UPDATE remote_agents
 SET description = 'Transcribes audio with speaker identification and LaTeX math formatting.',
     agent_category = 'workflow'
 WHERE name = 'transcribe_audio';
 
--- apply and apply_multiple: descriptions already match YAML, just ensure agent_category is set
+-- apply and apply_multiple: ensure agent_category is set
 UPDATE remote_agents
 SET agent_category = 'workflow'
 WHERE name IN ('apply', 'apply_multiple');
-
--- =============================================================================
--- BACKFILL: populate tools column for existing remote agents that have them
--- (apply and transcribe_audio are workflow agents with no tools column needed)
--- =============================================================================
-
--- No tools to backfill for existing agents (all workflow/CoT type).
 
 -- =============================================================================
 -- VERIFY

--- a/docs/supabase/ADD_PRESENTER_SEARCH_REMOTE.sql
+++ b/docs/supabase/ADD_PRESENTER_SEARCH_REMOTE.sql
@@ -4,10 +4,10 @@
 -- Prerequisites:
 -- 1. Upload the YAML files to Supabase Storage:
 --    - Copy from: resources/tool_use_agents/presenter.yaml
---    - Upload to: Storage > agent-configs > researcher/presenter.yaml
+--    - Upload to: Storage > agent-configs > tool_use/presenter.yaml
 --
 --    - Copy from: resources/tool_use_agents/search.yaml
---    - Upload to: Storage > agent-configs > researcher/search.yaml
+--    - Upload to: Storage > agent-configs > tool_use/search.yaml
 --
 -- Then run this SQL in Supabase SQL Editor:
 
@@ -26,7 +26,7 @@ INSERT INTO remote_agents (name, description, storage_path, visibility, agent_ca
 VALUES (
   'presenter',
   'Interactive scientific presentation builder with visual QA.',
-  'researcher/presenter.yaml',
+  'tool_use/presenter.yaml',
   ARRAY['researcher'],
   'toolUse',
   ARRAY['todo_write', 'bash', 'read_file', 'write_file', 'edit_file', 'glob', 'grep', 'ls', 'extract_figures', 'extract_bib_entries', 'extract_tikz_figures', 'wolfram', 'arxiv_search', 'arxiv_metadata', 'web_search', 'web_fetch']
@@ -36,7 +36,7 @@ INSERT INTO remote_agents (name, description, storage_path, visibility, agent_ca
 VALUES (
   'search',
   'Research assistant with web search and literature discovery tools.',
-  'researcher/search.yaml',
+  'tool_use/search.yaml',
   ARRAY['researcher'],
   'toolUse',
   ARRAY['bash', 'read_file', 'glob', 'grep', 'ls', 'extract_figures', 'extract_bib_entries', 'extract_tikz_figures', 'arxiv_search', 'arxiv_metadata', 'download_arxiv_source', 'crossref_search', 'crossref_doi', 'zotero_add', 'zotero_search', 'zotero_export', 'web_search', 'web_fetch']

--- a/docs/supabase/SUPABASE_SETUP.md
+++ b/docs/supabase/SUPABASE_SETUP.md
@@ -223,6 +223,7 @@ CREATE TABLE profiles (
 -- Remote agents metadata table
 -- visibility: array of group names that can access the agent (e.g., ARRAY['math', 'cs'])
 -- agent_category: 'workflow' (multi-turn) or 'toolUse' (single-turn with tools)
+-- tools: cached tool names from YAML for tool-use agents (e.g., ARRAY['web_search', 'arxiv_search'])
 CREATE TABLE remote_agents (
   id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
   name TEXT UNIQUE NOT NULL,
@@ -230,6 +231,7 @@ CREATE TABLE remote_agents (
   storage_path TEXT NOT NULL,
   visibility TEXT[] DEFAULT ARRAY['public'],
   agent_category TEXT DEFAULT 'workflow' CHECK (agent_category IN ('workflow', 'toolUse')),
+  tools TEXT[] DEFAULT NULL,
   created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
   updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );
@@ -612,6 +614,9 @@ Notes:
 
 - `visibility` is an array - agents can be visible to multiple groups
 - `agent_category` can be `'workflow'` (multi-turn) or `'toolUse'` (single-turn with tools)
+- `tools` is an optional array of tool names for tool-use agents (cached from YAML).
+  Populate this so orchestrator agents can see what tools remote agents have without fetching YAML.
+  Example: `ARRAY['web_search', 'arxiv_search', 'web_fetch']`
 
 ---
 

--- a/docs/supabase/SYNC_REFERENCE_AGENTS.sql
+++ b/docs/supabase/SYNC_REFERENCE_AGENTS.sql
@@ -1,0 +1,301 @@
+-- Sync all reference-agents to the remote_agents table.
+-- This upserts every agent in reference-agents/ so descriptions, tools,
+-- and agent_category match the YAML source of truth.
+--
+-- Prerequisites:
+-- 1. Upload each YAML from reference-agents/ to Supabase Storage under
+--    agent-configs/{workflow|tool_use}/{name}.yaml
+-- 2. Ensure the tools column exists (idempotent ALTER below).
+--
+-- Run this SQL in the Supabase SQL Editor.
+
+-- =============================================================================
+-- STEP 1: Ensure tools column exists (idempotent)
+-- =============================================================================
+
+ALTER TABLE remote_agents
+ADD COLUMN IF NOT EXISTS tools TEXT[] DEFAULT NULL;
+
+-- =============================================================================
+-- STEP 2: Upsert all reference agents
+-- =============================================================================
+
+-- ---------------------------------------------------------------------------
+-- Workflow agents
+-- ---------------------------------------------------------------------------
+
+INSERT INTO remote_agents (name, description, storage_path, visibility, agent_category, tools)
+VALUES (
+  'apply',
+  'Implements suggestions from review agents (criticize, enhance, logic, notation, etc.). Reads inline annotations, works through the issues, and applies corrections.',
+  'workflow/apply.yaml',
+  ARRAY['researcher'],
+  'workflow',
+  NULL
+)
+ON CONFLICT (name) DO UPDATE SET
+  description  = EXCLUDED.description,
+  agent_category = EXCLUDED.agent_category;
+
+INSERT INTO remote_agents (name, description, storage_path, visibility, agent_category, tools)
+VALUES (
+  'apply_multiple',
+  'Implements suggestions from review agents across multiple documents. Reads inline annotations, works through issues, and applies corrections while maintaining cross-document consistency.',
+  'workflow/apply_multiple.yaml',
+  ARRAY['researcher'],
+  'workflow',
+  NULL
+)
+ON CONFLICT (name) DO UPDATE SET
+  description  = EXCLUDED.description,
+  agent_category = EXCLUDED.agent_category;
+
+INSERT INTO remote_agents (name, description, storage_path, visibility, agent_category, tools)
+VALUES (
+  'criticize',
+  'Critical reviewer for mathematical physics papers. Inserts inline comments using \criticize{}{severity}{confidence} without modifying original content.',
+  'workflow/criticize.yaml',
+  ARRAY['researcher'],
+  'workflow',
+  NULL
+)
+ON CONFLICT (name) DO UPDATE SET
+  description  = EXCLUDED.description,
+  agent_category = EXCLUDED.agent_category;
+
+INSERT INTO remote_agents (name, description, storage_path, visibility, agent_category, tools)
+VALUES (
+  'criticize_multiple',
+  'Critical reviewer for multiple related documents. Inserts inline comments using \criticize{}{severity}{confidence} across papers without modifying original content.',
+  'workflow/criticize_multiple.yaml',
+  ARRAY['researcher'],
+  'workflow',
+  NULL
+)
+ON CONFLICT (name) DO UPDATE SET
+  description  = EXCLUDED.description,
+  agent_category = EXCLUDED.agent_category;
+
+INSERT INTO remote_agents (name, description, storage_path, visibility, agent_category, tools)
+VALUES (
+  'devise',
+  'Mathematical paper enhancer with two-phase workflow. Rewrites document by first adding rigorous derivations then revising to publication-ready scientific style.',
+  'workflow/devise.yaml',
+  ARRAY['researcher'],
+  'workflow',
+  NULL
+)
+ON CONFLICT (name) DO UPDATE SET
+  description  = EXCLUDED.description,
+  agent_category = EXCLUDED.agent_category;
+
+INSERT INTO remote_agents (name, description, storage_path, visibility, agent_category, tools)
+VALUES (
+  'devise_multiple',
+  'Multi-paper enhancement workflow with derivation and revision phases. Rewrites documents through two-phase process ensuring consistent notation and rigor across collections.',
+  'workflow/devise_multiple.yaml',
+  ARRAY['researcher'],
+  'workflow',
+  NULL
+)
+ON CONFLICT (name) DO UPDATE SET
+  description  = EXCLUDED.description,
+  agent_category = EXCLUDED.agent_category;
+
+INSERT INTO remote_agents (name, description, storage_path, visibility, agent_category, tools)
+VALUES (
+  'enhance',
+  'Mathematical substance enhancer for research papers. Identifies elegant proofs and stronger results.',
+  'workflow/enhance.yaml',
+  ARRAY['researcher'],
+  'workflow',
+  NULL
+)
+ON CONFLICT (name) DO UPDATE SET
+  description  = EXCLUDED.description,
+  agent_category = EXCLUDED.agent_category;
+
+INSERT INTO remote_agents (name, description, storage_path, visibility, agent_category, tools)
+VALUES (
+  'enhance_multiple',
+  'Multi-document mathematical enhancer for research papers. Improves proofs and results across paper collections.',
+  'workflow/enhance_multiple.yaml',
+  ARRAY['researcher'],
+  'workflow',
+  NULL
+)
+ON CONFLICT (name) DO UPDATE SET
+  description  = EXCLUDED.description,
+  agent_category = EXCLUDED.agent_category;
+
+INSERT INTO remote_agents (name, description, storage_path, visibility, agent_category, tools)
+VALUES (
+  'generic',
+  'General-purpose LaTeX document editor. Flexibly processes research papers following academic standards and user instructions. Detects and uses existing comment styles (\todo, \comment, %).',
+  'workflow/generic.yaml',
+  ARRAY['researcher'],
+  'workflow',
+  NULL
+)
+ON CONFLICT (name) DO UPDATE SET
+  description  = EXCLUDED.description,
+  agent_category = EXCLUDED.agent_category;
+
+INSERT INTO remote_agents (name, description, storage_path, visibility, agent_category, tools)
+VALUES (
+  'generic_multiple',
+  'General-purpose LaTeX document editor for multiple documents. Flexibly processes research papers following academic standards while maintaining consistency.',
+  'workflow/generic_multiple.yaml',
+  ARRAY['researcher'],
+  'workflow',
+  NULL
+)
+ON CONFLICT (name) DO UPDATE SET
+  description  = EXCLUDED.description,
+  agent_category = EXCLUDED.agent_category;
+
+INSERT INTO remote_agents (name, description, storage_path, visibility, agent_category, tools)
+VALUES (
+  'logic',
+  'Logical flow analyzer for research papers. Improves argument structure and coherence.',
+  'workflow/logic.yaml',
+  ARRAY['researcher'],
+  'workflow',
+  NULL
+)
+ON CONFLICT (name) DO UPDATE SET
+  description  = EXCLUDED.description,
+  agent_category = EXCLUDED.agent_category;
+
+INSERT INTO remote_agents (name, description, storage_path, visibility, agent_category, tools)
+VALUES (
+  'logic_multiple',
+  'Multi-document logical flow analyzer for research papers. Ensures coherent argumentation across paper collections.',
+  'workflow/logic_multiple.yaml',
+  ARRAY['researcher'],
+  'workflow',
+  NULL
+)
+ON CONFLICT (name) DO UPDATE SET
+  description  = EXCLUDED.description,
+  agent_category = EXCLUDED.agent_category;
+
+INSERT INTO remote_agents (name, description, storage_path, visibility, agent_category, tools)
+VALUES (
+  'notation',
+  'Notation consistency checker for research papers. Ensures consistent symbol usage throughout documents.',
+  'workflow/notation.yaml',
+  ARRAY['researcher'],
+  'workflow',
+  NULL
+)
+ON CONFLICT (name) DO UPDATE SET
+  description  = EXCLUDED.description,
+  agent_category = EXCLUDED.agent_category;
+
+INSERT INTO remote_agents (name, description, storage_path, visibility, agent_category, tools)
+VALUES (
+  'notation_multiple',
+  'Multi-document notation checker for research papers. Ensures consistent symbols across paper collections.',
+  'workflow/notation_multiple.yaml',
+  ARRAY['researcher'],
+  'workflow',
+  NULL
+)
+ON CONFLICT (name) DO UPDATE SET
+  description  = EXCLUDED.description,
+  agent_category = EXCLUDED.agent_category;
+
+INSERT INTO remote_agents (name, description, storage_path, visibility, agent_category, tools)
+VALUES (
+  'verifyFix',
+  'Three-phase verification and fix agent for research papers. Expands, critiques with verification, then fixes with documentation.',
+  'workflow/verifyFix.yaml',
+  ARRAY['researcher'],
+  'workflow',
+  NULL
+)
+ON CONFLICT (name) DO UPDATE SET
+  description  = EXCLUDED.description,
+  agent_category = EXCLUDED.agent_category;
+
+INSERT INTO remote_agents (name, description, storage_path, visibility, agent_category, tools)
+VALUES (
+  'verifyFix_multiple',
+  'Multi-document verification and fix agent for research papers. Comprehensive three-phase review across paper collections.',
+  'workflow/verifyFix_multiple.yaml',
+  ARRAY['researcher'],
+  'workflow',
+  NULL
+)
+ON CONFLICT (name) DO UPDATE SET
+  description  = EXCLUDED.description,
+  agent_category = EXCLUDED.agent_category;
+
+-- ---------------------------------------------------------------------------
+-- Tool-use agents
+-- ---------------------------------------------------------------------------
+
+INSERT INTO remote_agents (name, description, storage_path, visibility, agent_category, tools)
+VALUES (
+  'orchestrator',
+  'AI scientist that analyzes documents, tracks progress, and proposes agent tasks.',
+  'tool_use/orchestrator.yaml',
+  ARRAY['researcher'],
+  'toolUse',
+  ARRAY['propose_workflow', 'propose_agent', 'runs', 'todo_write', 'read_file', 'write_file', 'edit_file', 'bash', 'glob', 'grep', 'ls', 'extract_figures', 'extract_bib_entries', 'texcount']
+)
+ON CONFLICT (name) DO UPDATE SET
+  description    = EXCLUDED.description,
+  agent_category = EXCLUDED.agent_category,
+  tools          = EXCLUDED.tools;
+
+INSERT INTO remote_agents (name, description, storage_path, visibility, agent_category, tools)
+VALUES (
+  'presenter',
+  'Interactive scientific presentation builder with visual QA.',
+  'tool_use/presenter.yaml',
+  ARRAY['researcher'],
+  'toolUse',
+  ARRAY['todo_write', 'bash', 'read_file', 'write_file', 'edit_file', 'glob', 'grep', 'ls', 'extract_figures', 'extract_bib_entries', 'extract_tikz_figures', 'wolfram', 'arxiv_search', 'arxiv_metadata', 'web_search', 'web_fetch']
+)
+ON CONFLICT (name) DO UPDATE SET
+  description    = EXCLUDED.description,
+  agent_category = EXCLUDED.agent_category,
+  tools          = EXCLUDED.tools;
+
+INSERT INTO remote_agents (name, description, storage_path, visibility, agent_category, tools)
+VALUES (
+  'search',
+  'Research assistant with web search and literature discovery tools.',
+  'tool_use/search.yaml',
+  ARRAY['researcher'],
+  'toolUse',
+  ARRAY['bash', 'read_file', 'glob', 'grep', 'ls', 'extract_figures', 'extract_bib_entries', 'extract_tikz_figures', 'arxiv_search', 'arxiv_metadata', 'download_arxiv_source', 'crossref_search', 'crossref_doi', 'zotero_add', 'zotero_search', 'zotero_export', 'web_search', 'web_fetch']
+)
+ON CONFLICT (name) DO UPDATE SET
+  description    = EXCLUDED.description,
+  agent_category = EXCLUDED.agent_category,
+  tools          = EXCLUDED.tools;
+
+INSERT INTO remote_agents (name, description, storage_path, visibility, agent_category, tools)
+VALUES (
+  'simplifier',
+  'Simplifies scientific code and LaTeX for clarity and maintainability while preserving all functionality.',
+  'tool_use/simplifier.yaml',
+  ARRAY['researcher'],
+  'toolUse',
+  ARRAY['todo_write', 'bash', 'read_file', 'write_file', 'edit_file', 'glob', 'grep', 'ls', 'diagnostics', 'extract_figures', 'extract_tikz_figures', 'memory']
+)
+ON CONFLICT (name) DO UPDATE SET
+  description    = EXCLUDED.description,
+  agent_category = EXCLUDED.agent_category,
+  tools          = EXCLUDED.tools;
+
+-- =============================================================================
+-- VERIFY
+-- =============================================================================
+
+SELECT name, description, agent_category, tools, visibility
+FROM remote_agents
+ORDER BY agent_category, name;

--- a/reference-agents/presenter.yaml
+++ b/reference-agents/presenter.yaml
@@ -1,0 +1,126 @@
+name: presenter
+description: Interactive scientific presentation builder with visual QA.
+
+settings:
+  agentCategory: toolUse
+  tools:
+    - todo_write
+    - bash
+    - read_file
+    - write_file
+    - edit_file
+    - glob
+    - grep
+    - ls
+    - extract_figures
+    - extract_bib_entries
+    - extract_tikz_figures
+    - wolfram
+    - arxiv_search
+    - arxiv_metadata
+    - web_search
+    - web_fetch
+
+prompts:
+  systemPrompt: |
+    You are an expert scientific presenter and programmer. Your role is to help researchers create compelling LaTeX Beamer presentations, posters, and visual materials that showcase scientific code, algorithms, computational methods, and results. You work interactively, building and refining presentations through conversation.
+
+    Core Workflow:
+    (0) Read the template: If the user provides a .tex template or .sty theme files, ALWAYS read them first with read_file. Respect the template exactly — use its theme, color scheme, fonts, and structure. Do not override with defaults.
+    (1) Understand the codebase: Use glob and grep to survey the project structure, then read_file for key files. Identify the main algorithms, data pipelines, and results.
+    (2) Plan the presentation: Use todo_write to outline the presentation structure (title, motivation, methods, algorithms, results, conclusion). Discuss the plan with the user.
+    (3) Build iteratively: Write LaTeX files with write_file, compile with bash (latexmk -outdir=build) to verify correctness, and refine with edit_file based on feedback.
+    (4) Generate supporting materials: Run code with bash to produce figures and outputs. Use wolfram for symbolic computations and formula verification.
+    (5) Visual QA: After every compilation, read the output PDF with read_file to visually inspect every slide/page. Fix all layout issues before moving on.
+
+    Visual Quality Assurance (CRITICAL):
+    After compiling, you MUST visually inspect the output. Use read_file on the PDF directly (it renders pages as images). For large PDFs, read specific page ranges.
+    Check for and fix these common issues:
+    (1) Overflow: Text, equations, or code listings running off the slide/page boundary. Content-heavy slides (results, algorithms, code listings) are the most common offenders. Fix by reducing font size, splitting content across slides, or using \resizebox/\adjustbox.
+    (2) Overlapping elements: Figures overlapping text, captions colliding with content, columns bleeding into each other. Fix spacing, use \vspace/\hspace, or restructure the layout.
+    (3) Aspect ratio problems: Stretched or squished figures. Always use keepaspectratio with \includegraphics and set explicit width or height, not both.
+    (4) Truncated content: Tables or listings cut off at the bottom. Use \resizebox, smaller fonts, or split across frames with allowframebreaks.
+    (5) Unreadable text: Font too small, poor contrast, dense slides. Minimum 14pt for slide body text. Use color contrast that works in both projected and printed form.
+    (6) Figure quality: Axes labels missing or cut off, legends overlapping data, missing units, unlabeled axes. When generating plots with code, set tight_layout(), proper figsize, and explicit DPI.
+    (7) Whitespace imbalance: Too much empty space on some slides, too little on others. Distribute content evenly.
+    (8) Poster-specific: Column heights unbalanced, section blocks overlapping, header/footer clipping. Check every column and block boundary.
+    Iterate: compile → read PDF → fix → recompile → re-read until every page is publication-ready. Do not skip this step.
+
+    Presentation Design Principles:
+    (1) Code should tell a story: frame algorithms as solutions to problems, not isolated listings.
+    (2) Use algorithm environments (\usepackage{algorithm2e} or \usepackage{algorithmicx}) for pseudocode, not raw code dumps.
+    (3) Use lstlisting or minted environments for actual source code snippets. Keep listings short (10-15 lines max per slide).
+    (4) Create TikZ diagrams for data flow, architecture, and computational graphs. Visualize, don't just describe.
+    (5) Show results with properly labeled figures: axes, units, legends, and captions. Run the actual code to generate plots when possible.
+    (6) Balance mathematical rigor with accessibility. Define notation, show key derivations in align environments, and connect equations to code.
+    (7) Use progressive disclosure: introduce concepts one slide at a time, build complexity gradually.
+
+    LaTeX/Beamer Best Practices:
+    (1) Theme selection: Do NOT use Madrid/dolphin — it is overused and looks generic. Prefer modern, minimal themes: metropolis (recommended), focus, moloch, or custom themes. If the user provides a template, use that theme exactly.
+    (2) Use \frametitle{} on every slide. Use \framesubtitle{} when helpful.
+    (3) Include slide numbers and section navigation.
+    (4) Use \pause and overlays (\only, \onslide, \visible) for progressive reveals in algorithm walkthroughs.
+    (5) Use `` and '' for quotes, $...$ for inline math, and proper environments (equation, align) for display math.
+    (6) Cite sources with \cite{AuthorYearTitle} format.
+    (7) Always compile with bash using an output directory to keep the workspace clean (e.g. latexmk -pdf -interaction=nonstopmode -outdir=build file.tex). This keeps .aux, .log, .synctex.gz and other temporaries out of the main folder.
+    (8) For posters, use the beamerposter package or a0poster. Balance columns, use color blocks for sections.
+
+    Code Presentation Strategies:
+    (1) Syntax highlighting: Use minted (preferred) or lstlisting with language-specific settings.
+    (2) Code walkthroughs: Use overlays to highlight specific lines on successive slides. Example:
+        \begin{lstlisting}[escapechar=|]
+        |\only<2>{\color{red}}|key_line_here
+        \end{lstlisting}
+    (3) Side-by-side: Use columns environment to show code alongside its output, mathematical formulation, or diagram.
+    (4) Complexity analysis: Present Big-O alongside algorithmic steps. Use tables to compare approaches.
+    (5) Benchmarks and results: Generate actual benchmark data by running code. Present as pgfplots figures.
+
+    Figure Generation:
+    (1) When code produces matplotlib/pgfplots figures, run it with bash to generate PDFs/PNGs.
+    (2) Use \includegraphics[width=\linewidth,keepaspectratio]{...} for generated figures. Never set both width and height.
+    (3) For TikZ diagrams, write them inline in the Beamer source. Use extract_tikz_figures to preview.
+    (4) For Wolfram-generated plots, export to PDF and include.
+    (5) After generating any plot, read the image file with read_file to verify: axes labels visible, legend not overlapping data, no clipping, proper aspect ratio. Regenerate if issues found.
+
+    TikZ Diagram Verification (CRITICAL — Iterative):
+    Whenever you generate or modify TikZ code, use extract_tikz_figures to preview each diagram individually. Iterate (extract → inspect → fix → re-extract) until every diagram passes. Check for:
+      (a) Rendering: No overflows, clipped edges, missing labels, or overlapping nodes/edges.
+      (b) Layout: Even spacing, clean edge routing, readable non-colliding labels.
+      (c) Mathematical accuracy: For tensor networks, Feynman diagrams, commutative diagrams, circuit diagrams, etc., verify the topology matches the math (correct leg count, correct vertex/propagator types, correct morphism directions). Labels must match surrounding formulas exactly.
+      (d) Equation consistency: Cross-reference against adjacent align/equation environments.
+    A broken or inaccurate diagram is worse than none.
+
+    Mathematical Communication:
+    (1) Use $...$ for inline math.
+    (2) Use align environments with line breaks (multiple &= paired with \\) for multi-step derivations.
+    (3) Define notation before use. Use \newcommand for recurring symbols.
+    (4) Connect math to code: show the equation, then show the corresponding implementation.
+
+    File Operations:
+    (1) Read files before editing. Use glob and grep to survey structure before reading individual files.
+    (2) Compile with bash (latexmk -outdir=build) after every major change to catch errors immediately.
+    (3) After compilation, always read the output PDF with read_file to visually inspect the result.
+    (4) Prefer editing existing files over creating new ones.
+    (5) Do not create scratch files (STATUS_UPDATE.md, FINAL_STATUS.md, *_analysis.md, *_REPORT.md, temporary .tex files, etc.). Work directly on the deliverables. If you do create any intermediate files, delete them before finishing.
+    {% if IS_ANTHROPIC_MODEL %}
+    (6) Do not create markdown files or documentation unless explicitly requested.
+    {% endif %}
+
+    CRITICAL - File Output Rule: A third-person reader must be able to read any document you output without knowledge of this conversation. No self-referential talk ("I will..."), no meta-commentary to user, no parenthetical asides, no conversation references. Standard academic prose is fine ("We present...", "Algorithm 1 shows..."). Define notation before use; ensure logical flow.
+
+    Presentation Types You Can Create:
+    - Conference talk slides (10-20 slides, Beamer)
+    - Poster presentations (A0/A1, beamerposter)
+    - Code documentation slides (API walkthrough, architecture overview)
+    - Tutorial/workshop materials (step-by-step with exercises)
+    - Lightning talks (5-minute, 5-7 slides)
+    - Research group presentations (detailed, with derivations)
+
+    Guidelines on using Tools:
+    (1) Use glob and grep to survey a project before reading individual files.
+    (2) Compile LaTeX via bash (latexmk -outdir=build), then read the PDF from build/ with read_file to verify output visually.
+    (3) For bash operations, distinguish between safe and potentially risky commands.
+    (4) Use todo_write to track progress on complex multi-slide presentations.
+    (5) For some tool use, users have the option to reject or edit changes. Pay attention to feedback.
+  userRequest: |
+    {{ INSTRUCTION }}

--- a/reference-agents/search.yaml
+++ b/reference-agents/search.yaml
@@ -1,0 +1,59 @@
+name: search
+description: Research assistant with web search and literature discovery tools.
+
+settings:
+  agentCategory: toolUse
+  tools:
+    - bash
+    - read_file
+    - glob
+    - grep
+    - ls
+    - extract_figures
+    - extract_bib_entries
+    - extract_tikz_figures
+    - arxiv_search
+    - arxiv_metadata
+    - download_arxiv_source
+    - crossref_search
+    - crossref_doi
+    - zotero_add
+    - zotero_search
+    - zotero_export
+    - web_search
+    - web_fetch
+prompts:
+  systemPrompt: |
+    You are a research assistant helping the user discover and synthesize information from the web and academic literature. Reason deeply.
+
+    Mathematical Communication: (1) Use $...$ for inline math expressions. (2) Define all notation before use. (3) Show reasoning step-by-step, not just final results. (4) For complex problems, outline your approach before diving into details.
+
+    LaTeX Best Practices: (1) Use `` and '' instead of "..." for quotes. (2) Follow chktex best practices (no warnings). (3) Use appropriate mathematical environments (equation, align, etc.). (4) Keep mathematical notation consistent throughout. (5) All inline mathematical variables must be enclosed in $...$, not backticks.
+
+    Research Workflow:
+    (1) Use web_search and web_fetch to find current information, news, and general resources.
+    (2) Use arxiv_search and arxiv_metadata for preprints and recent academic work.
+    (3) Use download_arxiv_source to download LaTeX source files from arXiv only when explicitly requested by the user or for extremely relevant papers that require detailed analysis.
+    (4) Use crossref_search and crossref_doi for published literature and citations.
+    (5) Use zotero_search to check if a reference already exists in the user's Zotero library, and zotero_export to get BibTeX entries (requires Better BibTeX plugin).
+    (6) Use zotero_add to save new references to the user's Zotero library (requires Zotero to be running).
+    (7) Cross-reference multiple sources to verify information.
+    (8) Synthesize findings into coherent summaries with proper citations.
+
+    Source Handling:
+    (1) Always cite sources with URLs, DOIs, or arXiv IDs.
+    (2) Distinguish between peer-reviewed publications, preprints, and web sources.
+    (3) Note publication dates to assess recency of information.
+    (4) When conflicting information is found, present multiple perspectives.
+
+    File Operations:
+    (1) You can read files to understand context but cannot edit or create files.
+    (2) Use read_file, glob, grep, and ls to explore the user's workspace.
+    (3) Use extract_figures, extract_bib_entries, and extract_tikz_figures to analyze LaTeX documents.
+
+    Guidelines on using Tools:
+    (1) For bash operations, only execute safe read-only commands: ls, pwd, cat, echo, grep, find, which, date, whoami.
+    (2) Do not execute commands that modify files or system state.
+    (3) Clearly explain what any command will do before executing it.
+  userRequest: |
+    {{ INSTRUCTION }}

--- a/reference-agents/simplifier.yaml
+++ b/reference-agents/simplifier.yaml
@@ -1,0 +1,75 @@
+name: simplifier
+description: Simplifies scientific code and LaTeX for clarity and maintainability while preserving all functionality.
+
+settings:
+  agentCategory: toolUse
+  tools:
+    - todo_write
+    - bash
+    - read_file
+    - write_file
+    - edit_file
+    - glob
+    - grep
+    - ls
+    - diagnostics
+    - extract_figures
+    - extract_tikz_figures
+    - memory
+
+prompts:
+  systemPrompt: |
+    You are an expert code and writing simplification specialist for scientific projects. You make code, LaTeX, and prose clearer, more direct, and more idiomatic while preserving exact correctness. You prioritize readable, explicit code and clean scientific writing over compact solutions.
+
+    You will analyze code and documents and apply refinements that:
+
+    1. **Preserve Functionality**: Never change what the code does — only how it expresses it. All outputs, side effects, and mathematical results must remain identical.
+
+    2. **Remove Duplication**: Find copy-pasted blocks, near-identical functions, and repeated logic across files using grep and glob systematically. Consolidate into single implementations — but verify duplicates are truly identical in purpose, not just in shape. Also scan LaTeX documents, progress records, and local project files for massive duplications that are often LLM agent artifacts (repeated paragraphs, duplicated sections, redundant entries).
+
+    3. **Reduce Abstraction and Indirection**: Inline single-use wrappers. Remove factories called once. Collapse class hierarchies that add indirection without value. Delete dead code, unreachable branches, commented-out blocks, and TODO stubs never implemented. Flatten deeply nested conditionals with early returns. Replace hand-rolled implementations with tested standard library or native equivalents — scientific codebases often reinvent sorting, interpolation, linear algebra, file parsing, or numerical routines that already exist in NumPy, SciPy, LinearAlgebra.jl, MATLAB builtins, or Mathlib. Watch for spaghetti control flow: excessive round trips between functions, layers of resolve/dispatch/delegate that could be a direct call, double parsing or double computation of the same data.
+
+    4. **Clean Up Writing**: Scientific LaTeX and prose often accumulate AI-generated bloat. Watch for these signatures and fix them:
+       - Filler openings: "It is important to note that...", "It is worth mentioning that...", "In this section, we will discuss..."
+       - Formulaic transitions stacking in sequence: "Furthermore," "Moreover," "Additionally," "Notably,"
+       - The restate-explain-restate sandwich: saying the same thing three times in setup, body, and summary
+       - Buzzword inflation: "novel," "robust," "comprehensive," "leveraging," "utilizing" where plain words work
+       - Generic significance claims: "This has profound implications for..." without saying what they are
+       - Excessive signposting: "The remainder of this section is organized as follows..."
+       - Symmetrical list structures where every item has the same rhythm and cadence
+       - Hedging pileups: "may potentially," "could possibly," "it is likely that perhaps"
+       - Restating the obvious: "As mentioned above," "As previously discussed,"
+       - Overuse of \emph{} and \textbf{} — LaTeX is not markdown. Academic prose carries emphasis through sentence structure, not formatting
+       - Markdown-style LaTeX: excessive \begin{enumerate}/\begin{itemize} with \textbf{Term:} entries where flowing prose belongs. Scientific papers use lists sparingly; most content should be reader-facing paragraphs
+       - Meta-narration about the writing process itself: "We now turn to discussing...", "In what follows, we shall demonstrate..." — but preserve standard mathematical discourse ("We proceed by induction," "Let $x$ be..." "Consider the case where...")
+       - Empty intensifiers: "significant," "importantly," "crucial," "key," "essential" used as filler rather than to mark genuine importance
+       Tighten sentences — say things once and directly. Replace vague claims with specific statements or delete them. Ensure notation is introduced once, used consistently, and not re-explained.
+
+    5. **Apply Idiomatic Patterns**: Use language-native idioms that improve clarity and often performance — in scientific code, replacing manual nested loops with vectorized operations is not just cleaner but typically orders of magnitude faster:
+       - *Python*: Vectorized NumPy ops over explicit loops, comprehensions, context managers, `enumerate`/`zip`, `pathlib`, `dataclasses`, f-strings
+       - *Julia*: Broadcasting dot syntax, multiple dispatch, `@views`, typed structs over `Dict`, `eachindex`/`axes`
+       - *MATLAB*: Element-wise operators, logical indexing, preallocation, local functions
+       - *Lean 4*: `simp`/`omega`/`decide` over verbose tactic chains, `calc` blocks, pattern matching
+       - *LaTeX/TikZ*: `\tikzset` for repeated styles, `\foreach` over copy-pasted nodes, shared `commands.tex`, `siunitx`
+       - *Wolfram*: `Map`/`Apply`/`Table` over loops, functional chains, pattern matching
+       - For other languages in the codebase, apply equivalent idiomatic patterns
+
+    6. **Maintain Balance**: Avoid over-simplification that could:
+       - Remove abstractions that genuinely organize code (e.g., a base class shared by multiple solvers)
+       - Combine too many concerns into one function just to reduce line count
+       - Use nested ternaries or dense one-liners where if/else is clearer
+       - Consolidate functions that look similar but encode different physics, boundary conditions, or mathematical regimes
+       - Add new abstractions, annotations, or comments to code you didn't change
+
+    7. **Focus Scope**: Only simplify code the user points to, unless explicitly asked to review broader scope. Read files before editing. Prefer edit_file for targeted modifications.
+
+    Your refinement process:
+
+    1. Survey the target code with glob and grep to understand structure and find duplication hotspots
+    2. Read files fully before making any changes
+    3. Run existing tests if they exist. If no test suite, verify correctness manually (run scripts, compare outputs, check LaTeX compiles)
+    4. Plan changes with todo_write, ordered from safest to riskiest
+    5. Apply one logical simplification per edit, verify after each change
+    6. If something breaks, revert immediately
+  userRequest: |
+    {{ INSTRUCTION }}

--- a/src/agent/index/agentRegistry.ts
+++ b/src/agent/index/agentRegistry.ts
@@ -280,6 +280,22 @@ export function updateAgentTools(
   const entry = getAgent(identifier);
   if (entry && tools?.length) {
     entry.tools = tools;
+    persistRemoteAgentMeta(entry.name, { tools });
+  }
+}
+
+/**
+ * Update an agent's default output files in the cache.
+ * Used to populate defaultOutputFiles for remote agents after YAML is loaded.
+ */
+export function updateAgentDefaultOutputFiles(
+  identifier: string,
+  defaultOutputFiles: string[] | undefined,
+): void {
+  const entry = getAgent(identifier);
+  if (entry && defaultOutputFiles?.length) {
+    entry.defaultOutputFiles = defaultOutputFiles;
+    persistRemoteAgentMeta(entry.name, { defaultOutputFiles });
   }
 }
 
@@ -480,10 +496,51 @@ async function scanYaml(
   }
 }
 
+// =============================================================================
+// REMOTE AGENT METADATA PERSISTENCE
+// =============================================================================
+
+/**
+ * Cached metadata for a remote agent, persisted in globalState.
+ * Populated lazily when a remote agent's YAML is first loaded.
+ */
+interface RemoteAgentMetaCache {
+  [agentName: string]: {
+    tools?: string[];
+    defaultOutputFiles?: string[];
+  };
+}
+
+/** Persist remote agent metadata to globalState for cross-session availability. */
+function persistRemoteAgentMeta(
+  agentName: string,
+  meta: { tools?: string[]; defaultOutputFiles?: string[] },
+): void {
+  if (!globalSM) return;
+  const cache =
+    globalSM.get<RemoteAgentMetaCache>(
+      GlobalStateKey.REMOTE_AGENT_META_CACHE,
+      {},
+    ) ?? {};
+  cache[agentName] = { ...cache[agentName], ...meta };
+  void globalSM.update(GlobalStateKey.REMOTE_AGENT_META_CACHE, cache);
+}
+
+/** Load persisted remote agent metadata from globalState. */
+function getPersistedRemoteAgentMeta(): RemoteAgentMetaCache {
+  return (
+    globalSM?.get<RemoteAgentMetaCache>(
+      GlobalStateKey.REMOTE_AGENT_META_CACHE,
+      {},
+    ) ?? {}
+  );
+}
+
 async function loadRemoteAgents(): Promise<AgentEntry[]> {
   try {
     const remotes = await RemoteAgentLoader.listRemoteAgents();
     const grouped = groupByVariants(remotes, (r) => r.name);
+    const metaCache = getPersistedRemoteAgentMeta();
 
     // Build entries from grouped agents
     const entries: AgentEntry[] = [];
@@ -491,16 +548,22 @@ async function loadRemoteAgents(): Promise<AgentEntry[]> {
       const primary = base || multiple;
       if (!primary) continue;
 
+      const name = base ? baseName : primary.name;
       const isToolUse = primary.agentCategory === AgentCategory.ToolUse;
-      // Description from DB is cache; updated from YAML when agent is loaded
+      const cached = metaCache[name];
+
+      // Description from DB is cache; updated from YAML when agent is loaded.
+      // Tools and defaultOutputFiles hydrated from persistent cache.
       entries.push({
-        name: base ? baseName : primary.name,
+        name,
         source: 'remote' as AgentSource,
         path: '',
         multiplePath: multiple?.name,
         category: isToolUse ? AgentCategory.ToolUse : AgentCategory.Workflow,
         description: primary.description ?? undefined,
         visibility: primary.visibility ?? undefined,
+        tools: cached?.tools,
+        defaultOutputFiles: cached?.defaultOutputFiles,
       });
     }
 

--- a/src/agent/index/agentRegistry.ts
+++ b/src/agent/index/agentRegistry.ts
@@ -269,6 +269,21 @@ export function updateAgentDescription(
 }
 
 /**
+ * Update an agent's tool list in the cache.
+ * Used to populate tools for remote agents after YAML is loaded,
+ * so orchestrator agents can see what tools remote agents have.
+ */
+export function updateAgentTools(
+  identifier: string,
+  tools: string[] | undefined,
+): void {
+  const entry = getAgent(identifier);
+  if (entry && tools?.length) {
+    entry.tools = tools;
+  }
+}
+
+/**
  * Resolve an agent to its definition path, handling _multiple variant logic.
  */
 export function resolveAgent(

--- a/src/agent/index/agentRegistry.ts
+++ b/src/agent/index/agentRegistry.ts
@@ -272,31 +272,33 @@ export function updateAgentDescription(
  * Update an agent's tool list in the cache.
  * Used to populate tools for remote agents after YAML is loaded,
  * so orchestrator agents can see what tools remote agents have.
+ * Passing undefined/empty clears stale tools if the YAML removed them.
  */
 export function updateAgentTools(
   identifier: string,
   tools: string[] | undefined,
 ): void {
   const entry = getAgent(identifier);
-  if (entry && tools?.length) {
-    entry.tools = tools;
-    persistRemoteAgentMeta(entry.name, { tools });
-  }
+  if (!entry) return;
+  const value = tools?.length ? tools : undefined;
+  entry.tools = value;
+  persistRemoteAgentMeta(entry.name, { tools: value });
 }
 
 /**
  * Update an agent's default output files in the cache.
  * Used to populate defaultOutputFiles for remote agents after YAML is loaded.
+ * Passing undefined/empty clears stale values.
  */
 export function updateAgentDefaultOutputFiles(
   identifier: string,
   defaultOutputFiles: string[] | undefined,
 ): void {
   const entry = getAgent(identifier);
-  if (entry && defaultOutputFiles?.length) {
-    entry.defaultOutputFiles = defaultOutputFiles;
-    persistRemoteAgentMeta(entry.name, { defaultOutputFiles });
-  }
+  if (!entry) return;
+  const value = defaultOutputFiles?.length ? defaultOutputFiles : undefined;
+  entry.defaultOutputFiles = value;
+  persistRemoteAgentMeta(entry.name, { defaultOutputFiles: value });
 }
 
 /**
@@ -369,6 +371,20 @@ export async function refresh(): Promise<void> {
 // =============================================================================
 // HELPERS
 // =============================================================================
+
+/**
+ * Extract tool names from raw YAML tool configs.
+ * Tools can be plain strings ("web_search") or objects ({ name: "web_search", ... }).
+ */
+export function extractToolNames(
+  rawTools: unknown[] | undefined,
+): string[] | undefined {
+  return rawTools?.flatMap((t) => {
+    if (typeof t === 'string') return t;
+    const name = (t as Record<string, unknown>)?.name;
+    return typeof name === 'string' ? name : [];
+  });
+}
 
 async function scanDirectory(
   dir: string,
@@ -459,13 +475,7 @@ async function scanYaml(
       | string[]
       | undefined;
 
-    // Extract tool names (can be strings or objects with name field)
-    const rawTools = rawSettings.tools as unknown[] | undefined;
-    const tools = rawTools?.flatMap((t) => {
-      if (typeof t === 'string') return t;
-      const name = (t as Record<string, unknown>)?.name;
-      return typeof name === 'string' ? name : [];
-    });
+    const tools = extractToolNames(rawSettings.tools as unknown[] | undefined);
 
     // Determine category from source or explicit setting
     // Backward compatibility: check both agentCategory and legacy agentType
@@ -517,13 +527,13 @@ function persistRemoteAgentMeta(
   meta: { tools?: string[]; defaultOutputFiles?: string[] },
 ): void {
   if (!globalSM) return;
-  const cache =
+  const stored =
     globalSM.get<RemoteAgentMetaCache>(
       GlobalStateKey.REMOTE_AGENT_META_CACHE,
       {},
     ) ?? {};
-  cache[agentName] = { ...cache[agentName], ...meta };
-  void globalSM.update(GlobalStateKey.REMOTE_AGENT_META_CACHE, cache);
+  stored[agentName] = { ...stored[agentName], ...meta };
+  void globalSM.update(GlobalStateKey.REMOTE_AGENT_META_CACHE, stored);
 }
 
 /** Load persisted remote agent metadata from globalState. */

--- a/src/agent/index/agentRegistry.ts
+++ b/src/agent/index/agentRegistry.ts
@@ -552,8 +552,9 @@ async function loadRemoteAgents(): Promise<AgentEntry[]> {
       const isToolUse = primary.agentCategory === AgentCategory.ToolUse;
       const cached = metaCache[name];
 
-      // Description from DB is cache; updated from YAML when agent is loaded.
-      // Tools and defaultOutputFiles hydrated from persistent cache.
+      // Tools: prefer DB column (authoritative), fall back to persistent cache.
+      // defaultOutputFiles: from persistent cache (no DB column yet).
+      const dbTools = primary.tools?.length ? primary.tools : undefined;
       entries.push({
         name,
         source: 'remote' as AgentSource,
@@ -562,7 +563,7 @@ async function loadRemoteAgents(): Promise<AgentEntry[]> {
         category: isToolUse ? AgentCategory.ToolUse : AgentCategory.Workflow,
         description: primary.description ?? undefined,
         visibility: primary.visibility ?? undefined,
-        tools: cached?.tools,
+        tools: dbTools ?? cached?.tools,
         defaultOutputFiles: cached?.defaultOutputFiles,
       });
     }

--- a/src/agent/remote/RemoteAgentLoader.ts
+++ b/src/agent/remote/RemoteAgentLoader.ts
@@ -10,6 +10,8 @@ import {
 import {
   getMultipleName,
   getBaseName,
+  getAgent,
+  extractToolNames,
   updateAgentDescription,
   updateAgentTools,
   updateAgentDefaultOutputFiles,
@@ -138,20 +140,21 @@ export class RemoteAgentLoader {
           isLastCandidate,
         );
 
-        // Update registry cache with metadata from YAML
+        // Update registry cache with metadata from YAML.
+        // Try base name first (normal case), then full name (_multiple-only agents
+        // are registered under their full name, not the stripped base).
         const baseName = getBaseName(agentName);
+        const registryId = getAgent(`remote:${baseName}`)
+          ? `remote:${baseName}`
+          : `remote:${agentName}`;
         if (config.description) {
-          updateAgentDescription(`remote:${baseName}`, config.description);
+          updateAgentDescription(registryId, config.description);
         }
-        if (config.tools?.length) {
-          updateAgentTools(`remote:${baseName}`, config.tools);
-        }
-        if (config.defaultOutputFiles?.length) {
-          updateAgentDefaultOutputFiles(
-            `remote:${baseName}`,
-            config.defaultOutputFiles,
-          );
-        }
+        updateAgentTools(registryId, config.tools);
+        updateAgentDefaultOutputFiles(
+          registryId,
+          config.defaultOutputFiles,
+        );
 
         logger.info(
           CHANNEL,
@@ -286,10 +289,7 @@ async function fetchAgentConfig(
   // Extract metadata before resolving tools to full definitions (for registry cache)
   const settings: Partial<AgentSetting> = validated.settings;
   const rawTools = settings.tools as (string | { name: string })[] | undefined;
-  const toolNames = rawTools?.flatMap((t) => {
-    if (typeof t === 'string') return t;
-    return typeof t?.name === 'string' ? t.name : [];
-  });
+  const toolNames = extractToolNames(rawTools);
   const defaultOutputFiles = settings.defaultOutputFiles as
     | string[]
     | undefined;

--- a/src/agent/remote/RemoteAgentLoader.ts
+++ b/src/agent/remote/RemoteAgentLoader.ts
@@ -77,6 +77,7 @@ function parseListItemRow(row: {
   name: string;
   description?: string | null;
   visibility?: string[] | null;
+  tools?: string[] | null;
   agent_category?: string | null;
 }): RemoteAgentListItem | null {
   const result = RemoteAgentListItemSchema.safeParse({
@@ -84,6 +85,7 @@ function parseListItemRow(row: {
     name: row.name,
     description: row.description,
     visibility: row.visibility,
+    tools: row.tools,
     agentCategory: row.agent_category,
   });
 
@@ -201,7 +203,7 @@ export class RemoteAgentLoader {
 
       const { data, error } = await supabase
         .from('remote_agents')
-        .select('id, name, description, visibility, agent_category')
+        .select('id, name, description, visibility, tools, agent_category')
         .order('name');
 
       if (error) {

--- a/src/agent/remote/RemoteAgentLoader.ts
+++ b/src/agent/remote/RemoteAgentLoader.ts
@@ -204,10 +204,23 @@ export class RemoteAgentLoader {
         refresh_token: tokens.refreshToken,
       });
 
-      const { data, error } = await supabase
+      // Query with tools column; fall back without it for pre-migration databases.
+      // PostgREST returns 400 if the column doesn't exist.
+      let { data, error } = await supabase
         .from('remote_agents')
         .select('id, name, description, visibility, tools, agent_category')
         .order('name');
+
+      if (error) {
+        logger.debug(
+          CHANNEL,
+          `Query with tools column failed, retrying without: ${error.message}`,
+        );
+        ({ data, error } = await supabase
+          .from('remote_agents')
+          .select('id, name, description, visibility, agent_category')
+          .order('name'));
+      }
 
       if (error) {
         logger.error(CHANNEL, `Failed to list remote agents: ${error.message}`);

--- a/src/agent/remote/RemoteAgentLoader.ts
+++ b/src/agent/remote/RemoteAgentLoader.ts
@@ -12,6 +12,7 @@ import {
   getBaseName,
   updateAgentDescription,
   updateAgentTools,
+  updateAgentDefaultOutputFiles,
 } from '@agent/index/agentRegistry';
 import type { AgentLoadOptions } from '@agent/runtime/agentLoad';
 import { toErrorMessage } from '@common/errors/errorHandlingUtils';
@@ -135,13 +136,19 @@ export class RemoteAgentLoader {
           isLastCandidate,
         );
 
-        // Update registry cache with description and tools from YAML
+        // Update registry cache with metadata from YAML
         const baseName = getBaseName(agentName);
         if (config.description) {
           updateAgentDescription(`remote:${baseName}`, config.description);
         }
         if (config.tools?.length) {
           updateAgentTools(`remote:${baseName}`, config.tools);
+        }
+        if (config.defaultOutputFiles?.length) {
+          updateAgentDefaultOutputFiles(
+            `remote:${baseName}`,
+            config.defaultOutputFiles,
+          );
         }
 
         logger.info(
@@ -240,6 +247,7 @@ async function fetchAgentConfig(
   prompts: RemoteAgentConfig['prompts'];
   description?: string;
   tools?: string[];
+  defaultOutputFiles?: string[];
 }> {
   const token = await SupabaseClient.getAccessToken();
   if (!token) {
@@ -273,13 +281,16 @@ async function fetchAgentConfig(
   const parsed = yaml.parse(responseData.config);
   const validated = AgentDefinitionSchema.parse(parsed);
 
-  // Extract tool names before resolving to full definitions (for registry cache)
+  // Extract metadata before resolving tools to full definitions (for registry cache)
   const settings: Partial<AgentSetting> = validated.settings;
   const rawTools = settings.tools as (string | { name: string })[] | undefined;
   const toolNames = rawTools?.flatMap((t) => {
     if (typeof t === 'string') return t;
     return typeof t?.name === 'string' ? t.name : [];
   });
+  const defaultOutputFiles = settings.defaultOutputFiles as
+    | string[]
+    | undefined;
 
   // Process tool definitions (remote agents are self-contained)
   if (Array.isArray(settings.tools)) {
@@ -294,5 +305,8 @@ async function fetchAgentConfig(
     prompts: AgentPromptSchema.parse(validated.prompts),
     description: validated.description,
     tools: toolNames?.length ? toolNames : undefined,
+    defaultOutputFiles: defaultOutputFiles?.length
+      ? defaultOutputFiles
+      : undefined,
   };
 }

--- a/src/agent/remote/RemoteAgentLoader.ts
+++ b/src/agent/remote/RemoteAgentLoader.ts
@@ -11,6 +11,7 @@ import {
   getMultipleName,
   getBaseName,
   updateAgentDescription,
+  updateAgentTools,
 } from '@agent/index/agentRegistry';
 import type { AgentLoadOptions } from '@agent/runtime/agentLoad';
 import { toErrorMessage } from '@common/errors/errorHandlingUtils';
@@ -134,10 +135,13 @@ export class RemoteAgentLoader {
           isLastCandidate,
         );
 
-        // Update registry cache with description from YAML
+        // Update registry cache with description and tools from YAML
+        const baseName = getBaseName(agentName);
         if (config.description) {
-          const baseName = getBaseName(agentName);
           updateAgentDescription(`remote:${baseName}`, config.description);
+        }
+        if (config.tools?.length) {
+          updateAgentTools(`remote:${baseName}`, config.tools);
         }
 
         logger.info(
@@ -235,6 +239,7 @@ async function fetchAgentConfig(
   settings: RemoteAgentConfig['settings'];
   prompts: RemoteAgentConfig['prompts'];
   description?: string;
+  tools?: string[];
 }> {
   const token = await SupabaseClient.getAccessToken();
   if (!token) {
@@ -268,11 +273,18 @@ async function fetchAgentConfig(
   const parsed = yaml.parse(responseData.config);
   const validated = AgentDefinitionSchema.parse(parsed);
 
-  // Process tool definitions (remote agents are self-contained)
+  // Extract tool names before resolving to full definitions (for registry cache)
   const settings: Partial<AgentSetting> = validated.settings;
+  const rawTools = settings.tools as (string | { name: string })[] | undefined;
+  const toolNames = rawTools?.flatMap((t) => {
+    if (typeof t === 'string') return t;
+    return typeof t?.name === 'string' ? t.name : [];
+  });
+
+  // Process tool definitions (remote agents are self-contained)
   if (Array.isArray(settings.tools)) {
     settings.tools = resolveToolDefinitions(
-      settings.tools as (string | { name: string })[],
+      rawTools!,
       (name) => logger.warn(CHANNEL, `Tool "${name}" not found in registry`),
     );
   }
@@ -281,5 +293,6 @@ async function fetchAgentConfig(
     settings: AgentSettingSchema.parse(settings),
     prompts: AgentPromptSchema.parse(validated.prompts),
     description: validated.description,
+    tools: toolNames?.length ? toolNames : undefined,
   };
 }

--- a/src/agent/remote/types.ts
+++ b/src/agent/remote/types.ts
@@ -12,6 +12,8 @@ export const RemoteAgentListItemSchema = z.object({
   name: z.string(),
   description: z.string().nullish(),
   visibility: z.array(z.string()).nullish(),
+  /** Cached tool names from YAML. Available when DB column is populated. */
+  tools: z.array(z.string()).nullish(),
   /** Defaults to Workflow for backward compatibility with existing DB rows. */
   agentCategory: z
     .enum(AgentCategory)

--- a/src/common/state/stateManager.ts
+++ b/src/common/state/stateManager.ts
@@ -47,6 +47,7 @@ export enum GlobalStateKey {
   // Agent settings (migrated from VS Code config)
   CUSTOM_AGENT_DIR = 'texra.customAgentDir',
   AUTO_SHOW_REMOTE_AGENTS = 'texra.autoShowRemoteAgents',
+  REMOTE_AGENT_META_CACHE = 'texra.remoteAgentMetaCache',
 
   // Endpoint settings
   ENDPOINT_OPENAI = 'texra.endpoint.openai',

--- a/supabase/migrations/20260209_add_tools_to_remote_agents.sql
+++ b/supabase/migrations/20260209_add_tools_to_remote_agents.sql
@@ -1,0 +1,14 @@
+-- Migration: Add tools column to remote_agents table
+-- Purpose: Store tool names for tool-use agents so orchestrator agents can see
+-- what tools remote agents have without needing to fetch the full YAML config.
+--
+-- The column is a TEXT[] array of tool name strings (e.g. ARRAY['web_search', 'arxiv_search']).
+-- NULL means no tools (workflow agents) or not yet populated.
+
+ALTER TABLE remote_agents
+ADD COLUMN IF NOT EXISTS tools TEXT[] DEFAULT NULL;
+
+-- Update the comment on the table to reflect the new column
+COMMENT ON COLUMN remote_agents.tools IS
+  'Cached tool names from agent YAML. Populated when uploading agent configs. '
+  'Allows orchestrator agents to see remote agent capabilities without fetching YAML.';


### PR DESCRIPTION
## Summary
This PR adds support for caching tool metadata from remote agent YAML configurations, enabling orchestrator agents to discover what tools remote agents have without fetching full YAML files. This improves performance and enables better agent composition.

## Key Changes

- **Database Schema**: Added `tools` column to `remote_agents` table to store cached tool names as a TEXT[] array
- **Agent Registry**: 
  - New `updateAgentTools()` and `updateAgentDefaultOutputFiles()` functions to update cached metadata
  - Persistent metadata cache in globalState (`REMOTE_AGENT_META_CACHE`) for cross-session availability
  - Updated `loadRemoteAgents()` to populate tools from DB (authoritative) or persistent cache
- **Remote Agent Loader**:
  - Extract tool names and defaultOutputFiles from YAML during agent loading
  - Automatically update registry cache when agents are loaded
  - Include `tools` column in Supabase queries
- **Type Updates**: Added `tools` field to `RemoteAgentListItem` schema
- **Migration**: SQL migration to add the new `tools` column with appropriate documentation

## Implementation Details

- Tools are extracted from agent YAML settings and cached both in the database and in-memory state
- The DB column is authoritative; persistent cache serves as fallback for metadata not yet persisted to DB
- Tool names are extracted before resolving full tool definitions, keeping the cache lightweight
- Metadata is lazily populated when agents are first loaded, avoiding unnecessary DB updates
- Backward compatible: existing agents without tools continue to work normally

https://claude.ai/code/session_01RmBEHKCeZLUj7H8fRtEoXC

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a schema change (`remote_agents.tools`) plus new cross-session metadata caching logic, so regressions could affect remote agent listing/loading or display of capabilities if migrations/backfills are incomplete.
> 
> **Overview**
> Adds cached tool metadata for remote agents so clients (notably orchestrators) can see a remote agent’s available tools without fetching its YAML.
> 
> This introduces a `tools TEXT[]` column on `remote_agents`, updates Supabase listing queries and Zod types to read it (with a fallback query for pre-migration DBs), and adds registry support to extract tool names from YAML, persist them to global state, and hydrate remote agent entries from DB tools or the persisted cache. The remote YAML loader now extracts and caches `tools` and `defaultOutputFiles` on load, and new SQL/docs scripts add syncing/backfill guidance plus new `presenter`, `search`, and `simplifier` reference agents.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3ea738429ffbf4329820f537e70359eb6ec40129. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->