### PR TITLE
Unify model invocation nodes into reusable ModelInvocationNode

### DIFF
--- a/src/agent/core/flows/CommonCycleTypes.ts
+++ b/src/agent/core/flows/CommonCycleTypes.ts
@@ -80,6 +80,7 @@ export function resetCycleState<T extends BaseCycleFields>(
 export interface BaseInvocationPrepResult {
   shouldStop: boolean;
   messages: ProviderMessage[];
+  systemPrompt?: string;
 }
 
 /** Base success data returned from model/tool invocations. */

--- a/src/agent/core/flows/ModelInvocationNode.ts
+++ b/src/agent/core/flows/ModelInvocationNode.ts
@@ -1,12 +1,3 @@
-/**
- * Unified model invocation node for both response and tool-use cycles.
- *
- * Parameterized by a config object that controls streaming mode, system prompt
- * extraction, end tag extraction, response storage, and debug save behavior.
- *
- * Replaces the near-identical ResponseModelInvocationNode and ToolUseCallNode.
- */
-
 import type { NonIterableObject } from '@agent/node';
 import type { AgentSetting } from '@agent/core/AgentDataclass';
 import {
@@ -28,41 +19,18 @@ import {
   handleInvocationResult,
 } from './RetryState';
 
-// ---------------------------------------------------------------------------
-// Config
-// ---------------------------------------------------------------------------
-
-/** Configuration for a ModelInvocationNode instance. */
 export interface ModelInvocationConfig<TShared, TServices> {
-  /** Operation name for logs and retry prompts (e.g., 'Model invocation', 'Tool-use call'). */
   operationName: string;
-
-  /** Whether to enable output streaming on the model handler. */
   streaming: boolean;
-
-  /** Extract system prompt from shared state. Omit for no system prompt. */
   getSystemPrompt?: (shared: TShared) => string | undefined;
-
-  /** Extract end tag from services. Omit for no end tag. */
   getEndTag?: (services: TServices) => string | undefined;
-
-  /** Get tools to pass to createResponse. Defaults to `services.setting.tools`. */
   getTools?: (services: TServices) => ToolDefinition[] | undefined;
-
-  /** Store the model response and timing on shared state. */
   storeResponse: (
     shared: TShared,
     response: unknown,
     responseTimeMs: number | undefined,
   ) => void;
-
-  /** Check if background mode is active (enables minimum retry count). Defaults to false. */
   isBackgroundModeActive?: (services: TServices) => boolean;
-
-  /**
-   * Get debug save options for maybeSaveDebugObject in post().
-   * Omit to skip debug save entirely.
-   */
   getDebugSaveOptions?: (
     shared: TShared,
     services: TServices,
@@ -76,11 +44,6 @@ export interface ModelInvocationConfig<TShared, TServices> {
   };
 }
 
-// ---------------------------------------------------------------------------
-// Minimum service constraint
-// ---------------------------------------------------------------------------
-
-/** Minimum services required by ModelInvocationNode's own implementation. */
 export interface ModelInvocationServices {
   readonly modelHandler: IModelHandler<any, any, any, any, any>;
   readonly client: unknown;
@@ -92,36 +55,10 @@ export interface ModelInvocationServices {
   readonly refreshClient?: () => Promise<void>;
 }
 
-// ---------------------------------------------------------------------------
-// Prep result
-// ---------------------------------------------------------------------------
-
-/** Data extracted by prep() for model invocation. */
 interface ModelInvocationPrepResult extends BaseInvocationPrepResult {
   systemPrompt?: string;
 }
 
-// ---------------------------------------------------------------------------
-// Node
-// ---------------------------------------------------------------------------
-
-/**
- * Unified model invocation node with retry support.
- *
- * Handles both response-cycle and tool-use-cycle invocations via config:
- * - Response cycle: streaming=false, passes systemPrompt + endTag
- * - Tool-use cycle: streaming=true, no systemPrompt/endTag
- *
- * Extends RetryableInvocationNode for shared retry logic:
- * - maxRetries and wait configured from user settings
- * - exec() throws on error, Node retries automatically
- * - retryPrompt() shows UI when auto-retries exhausted (if error is retryable)
- * - execFallback() called only when user cancels or error is non-retryable
- *
- * Flow transitions:
- * - default: Continue to next node on success
- * - COMPLETE: All retries exhausted, non-retryable error, or user cancelled
- */
 export class ModelInvocationNode<
   TShared extends BaseCycleFields,
   TParams extends NonIterableObject = NonIterableObject,

--- a/src/agent/core/flows/ModelInvocationNode.ts
+++ b/src/agent/core/flows/ModelInvocationNode.ts
@@ -1,0 +1,235 @@
+/**
+ * Unified model invocation node for both response and tool-use cycles.
+ *
+ * Parameterized by a config object that controls streaming mode, system prompt
+ * extraction, end tag extraction, response storage, and debug save behavior.
+ *
+ * Replaces the near-identical ResponseModelInvocationNode and ToolUseCallNode.
+ */
+
+import type { NonIterableObject } from '@agent/node';
+import type { AgentSetting } from '@agent/core/AgentDataclass';
+import {
+  type BaseInvocationPrepResult,
+  type BaseInvocationSuccessData,
+  type BaseCycleFields,
+  getDebugContext,
+  replaceMessagesInPlace,
+} from '@agent/core/flows/CommonCycleTypes';
+import type { IModelHandler } from '@agent/modelHandlers/types/IModelHandler';
+import { maybeSaveDebugObject } from '@agent/utils/debugMessageSaver';
+import type { AgentLogger } from '@logger/AgentLogger';
+import type { ToolDefinition } from '@model';
+
+import { FlowTransition } from './FlowTransitions';
+import {
+  type InvocationResult,
+  RetryableInvocationNode,
+  handleInvocationResult,
+} from './RetryState';
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+/** Configuration for a ModelInvocationNode instance. */
+export interface ModelInvocationConfig<TShared, TServices> {
+  /** Operation name for logs and retry prompts (e.g., 'Model invocation', 'Tool-use call'). */
+  operationName: string;
+
+  /** Whether to enable output streaming on the model handler. */
+  streaming: boolean;
+
+  /** Extract system prompt from shared state. Omit for no system prompt. */
+  getSystemPrompt?: (shared: TShared) => string | undefined;
+
+  /** Extract end tag from services. Omit for no end tag. */
+  getEndTag?: (services: TServices) => string | undefined;
+
+  /** Get tools to pass to createResponse. Defaults to `services.setting.tools`. */
+  getTools?: (services: TServices) => ToolDefinition[] | undefined;
+
+  /** Store the model response and timing on shared state. */
+  storeResponse: (
+    shared: TShared,
+    response: unknown,
+    responseTimeMs: number | undefined,
+  ) => void;
+
+  /** Check if background mode is active (enables minimum retry count). Defaults to false. */
+  isBackgroundModeActive?: (services: TServices) => boolean;
+
+  /**
+   * Get debug save options for maybeSaveDebugObject in post().
+   * Omit to skip debug save entirely.
+   */
+  getDebugSaveOptions?: (
+    shared: TShared,
+    services: TServices,
+  ) => {
+    context: { modelName?: string; isRemote?: boolean };
+    fileOptions: {
+      continuationCount: number;
+      baseName: string;
+      outputFile?: string;
+    };
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Minimum service constraint
+// ---------------------------------------------------------------------------
+
+/** Minimum services required by ModelInvocationNode's own implementation. */
+export interface ModelInvocationServices {
+  readonly modelHandler: IModelHandler<any, any, any, any, any>;
+  readonly client: unknown;
+  readonly setting: AgentSetting;
+  readonly logger: AgentLogger;
+  readonly streamId: string;
+  readonly executionId: string;
+  readonly setAbortController: (ctrl: AbortController | null) => void;
+  readonly refreshClient?: () => Promise<void>;
+}
+
+// ---------------------------------------------------------------------------
+// Prep result
+// ---------------------------------------------------------------------------
+
+/** Data extracted by prep() for model invocation. */
+interface ModelInvocationPrepResult extends BaseInvocationPrepResult {
+  systemPrompt?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Node
+// ---------------------------------------------------------------------------
+
+/**
+ * Unified model invocation node with retry support.
+ *
+ * Handles both response-cycle and tool-use-cycle invocations via config:
+ * - Response cycle: streaming=false, passes systemPrompt + endTag
+ * - Tool-use cycle: streaming=true, no systemPrompt/endTag
+ *
+ * Extends RetryableInvocationNode for shared retry logic:
+ * - maxRetries and wait configured from user settings
+ * - exec() throws on error, Node retries automatically
+ * - retryPrompt() shows UI when auto-retries exhausted (if error is retryable)
+ * - execFallback() called only when user cancels or error is non-retryable
+ *
+ * Flow transitions:
+ * - default: Continue to next node on success
+ * - COMPLETE: All retries exhausted, non-retryable error, or user cancelled
+ */
+export class ModelInvocationNode<
+  TShared extends BaseCycleFields,
+  TParams extends NonIterableObject = NonIterableObject,
+  TServices extends ModelInvocationServices = ModelInvocationServices,
+> extends RetryableInvocationNode<TShared, TParams, TServices> {
+  private readonly _config: ModelInvocationConfig<TShared, TServices>;
+
+  constructor(config: ModelInvocationConfig<TShared, TServices>) {
+    super();
+    this._config = config;
+  }
+
+  protected getOperationName(): string {
+    return this._config.operationName;
+  }
+
+  protected override isBackgroundModeActive(): boolean {
+    return this._config.isBackgroundModeActive?.(this.services) ?? false;
+  }
+
+  async prep(shared: TShared): Promise<ModelInvocationPrepResult> {
+    return {
+      shouldStop: shared.shouldStop,
+      messages: shared.messages,
+      systemPrompt: this._config.getSystemPrompt?.(shared),
+    };
+  }
+
+  async exec(
+    prepRes: ModelInvocationPrepResult,
+  ): Promise<InvocationResult<BaseInvocationSuccessData>> {
+    if (prepRes.shouldStop) {
+      return { kind: 'skipped' };
+    }
+
+    const services = this.services;
+    services.modelHandler.setOutputStreaming(this._config.streaming);
+
+    const start = Date.now();
+
+    return this.withAbortController(async (signal) => {
+      const result = await services.modelHandler.createResponse({
+        client: services.client,
+        messages: prepRes.messages,
+        temperature: services.setting.temperature,
+        systemPrompt: prepRes.systemPrompt,
+        endTag: this._config.getEndTag?.(services),
+        signal,
+        tools: this._config.getTools
+          ? this._config.getTools(services)
+          : services.setting.tools,
+      });
+
+      const responseTimeMs = Date.now() - start;
+
+      return {
+        kind: 'success',
+        response: result.response,
+        responseTimeMs,
+        updatedMessages: result.updatedMessages,
+      };
+    });
+  }
+
+  async execFallback(
+    _prepRes: ModelInvocationPrepResult,
+    error: Error,
+  ): Promise<InvocationResult<BaseInvocationSuccessData>> {
+    return this.getFallbackResult(error);
+  }
+
+  async post(
+    shared: TShared,
+    _prepRes: ModelInvocationPrepResult,
+    execRes: InvocationResult<BaseInvocationSuccessData>,
+  ): Promise<string | undefined> {
+    const successRes = handleInvocationResult(execRes, shared, shared, {
+      logger: this.services.logger,
+      operationName: this._config.operationName,
+    });
+
+    if (!successRes) {
+      return FlowTransition.COMPLETE;
+    }
+
+    if (successRes.updatedMessages !== undefined) {
+      replaceMessagesInPlace(shared.messages, successRes.updatedMessages);
+    }
+
+    this._config.storeResponse(
+      shared,
+      successRes.response,
+      successRes.responseTimeMs,
+    );
+
+    if (this._config.getDebugSaveOptions) {
+      const { context, fileOptions } = this._config.getDebugSaveOptions(
+        shared,
+        this.services,
+      );
+      await maybeSaveDebugObject({
+        object: successRes.response,
+        objectType: 'response',
+        context: getDebugContext(this.services, context),
+        fileOptions,
+      });
+    }
+
+    return FlowTransition.DEFAULT;
+  }
+}

--- a/src/agent/core/flows/ModelInvocationNode.ts
+++ b/src/agent/core/flows/ModelInvocationNode.ts
@@ -91,7 +91,10 @@ export class ModelInvocationNode<
         systemPrompt: prepRes.systemPrompt,
         endTag: this._config.getEndTag?.(services),
         signal,
-        tools: this._config.getTools?.(services) ?? services.setting.tools,
+        tools:
+          this._config.getTools !== undefined
+            ? this._config.getTools(services)
+            : services.setting.tools,
       });
 
       return {

--- a/src/agent/core/flows/ModelInvocationNode.ts
+++ b/src/agent/core/flows/ModelInvocationNode.ts
@@ -1,5 +1,4 @@
 import type { NonIterableObject } from '@agent/node';
-import type { AgentSetting } from '@agent/core/AgentDataclass';
 import {
   type BaseInvocationPrepResult,
   type BaseInvocationSuccessData,
@@ -7,9 +6,8 @@ import {
   getDebugContext,
   replaceMessagesInPlace,
 } from '@agent/core/flows/CommonCycleTypes';
-import type { IModelHandler } from '@agent/modelHandlers/types/IModelHandler';
+import type { BaseFlowContextInit } from '@agent/implementations/flows/common/BaseFlowServices';
 import { maybeSaveDebugObject } from '@agent/utils/debugMessageSaver';
-import type { AgentLogger } from '@logger/AgentLogger';
 import type { ToolDefinition } from '@model';
 
 import { FlowTransition } from './FlowTransitions';
@@ -39,21 +37,15 @@ export interface ModelInvocationConfig<TShared, TServices> {
   };
 }
 
-export interface ModelInvocationServices {
-  readonly modelHandler: IModelHandler<any, any, any, any, any>;
+type InvocationServices = BaseFlowContextInit<any> & {
   readonly client: unknown;
-  readonly setting: AgentSetting;
-  readonly logger: AgentLogger;
-  readonly streamId: string;
-  readonly executionId: string;
-  readonly setAbortController: (ctrl: AbortController | null) => void;
   readonly refreshClient?: () => Promise<void>;
-}
+};
 
 export class ModelInvocationNode<
   TShared extends BaseCycleFields,
   TParams extends NonIterableObject = NonIterableObject,
-  TServices extends ModelInvocationServices = ModelInvocationServices,
+  TServices extends InvocationServices = InvocationServices,
 > extends RetryableInvocationNode<TShared, TParams, TServices> {
   private readonly _config: ModelInvocationConfig<TShared, TServices>;
 
@@ -71,9 +63,7 @@ export class ModelInvocationNode<
     return this.services.modelHandler.isBackgroundModeActive();
   }
 
-  async prep(
-    shared: TShared,
-  ): Promise<BaseInvocationPrepResult & { systemPrompt?: string }> {
+  async prep(shared: TShared): Promise<BaseInvocationPrepResult> {
     return {
       shouldStop: shared.shouldStop,
       messages: shared.messages,
@@ -82,7 +72,7 @@ export class ModelInvocationNode<
   }
 
   async exec(
-    prepRes: BaseInvocationPrepResult & { systemPrompt?: string },
+    prepRes: BaseInvocationPrepResult,
   ): Promise<InvocationResult<BaseInvocationSuccessData>> {
     if (prepRes.shouldStop) {
       return { kind: 'skipped' };

--- a/src/agent/core/flows/ModelInvocationNode.ts
+++ b/src/agent/core/flows/ModelInvocationNode.ts
@@ -20,6 +20,7 @@ import {
 export interface ModelInvocationConfig<TShared, TServices> {
   operationName: string;
   streaming: boolean;
+  backgroundModeAware?: boolean;
   getSystemPrompt?: (shared: TShared) => string | undefined;
   getEndTag?: (services: TServices) => string | undefined;
   getTools?: (services: TServices) => ToolDefinition[] | undefined;
@@ -60,7 +61,10 @@ export class ModelInvocationNode<
   }
 
   protected override isBackgroundModeActive(): boolean {
-    return this.services.modelHandler.isBackgroundModeActive();
+    return (
+      this._config.backgroundModeAware === true &&
+      this.services.modelHandler.isBackgroundModeActive()
+    );
   }
 
   async prep(shared: TShared): Promise<BaseInvocationPrepResult> {

--- a/src/agent/core/flows/ModelInvocationNode.ts
+++ b/src/agent/core/flows/ModelInvocationNode.ts
@@ -25,12 +25,7 @@ export interface ModelInvocationConfig<TShared, TServices> {
   getSystemPrompt?: (shared: TShared) => string | undefined;
   getEndTag?: (services: TServices) => string | undefined;
   getTools?: (services: TServices) => ToolDefinition[] | undefined;
-  storeResponse: (
-    shared: TShared,
-    response: unknown,
-    responseTimeMs: number | undefined,
-  ) => void;
-  isBackgroundModeActive?: (services: TServices) => boolean;
+  storeResponse: (shared: TShared, response: unknown) => void;
   getDebugSaveOptions?: (
     shared: TShared,
     services: TServices,
@@ -55,10 +50,6 @@ export interface ModelInvocationServices {
   readonly refreshClient?: () => Promise<void>;
 }
 
-interface ModelInvocationPrepResult extends BaseInvocationPrepResult {
-  systemPrompt?: string;
-}
-
 export class ModelInvocationNode<
   TShared extends BaseCycleFields,
   TParams extends NonIterableObject = NonIterableObject,
@@ -71,15 +62,18 @@ export class ModelInvocationNode<
     this._config = config;
   }
 
+  // Required by abstract base class RetryableInvocationNode
   protected getOperationName(): string {
     return this._config.operationName;
   }
 
   protected override isBackgroundModeActive(): boolean {
-    return this._config.isBackgroundModeActive?.(this.services) ?? false;
+    return this.services.modelHandler.isBackgroundModeActive();
   }
 
-  async prep(shared: TShared): Promise<ModelInvocationPrepResult> {
+  async prep(
+    shared: TShared,
+  ): Promise<BaseInvocationPrepResult & { systemPrompt?: string }> {
     return {
       shouldStop: shared.shouldStop,
       messages: shared.messages,
@@ -88,7 +82,7 @@ export class ModelInvocationNode<
   }
 
   async exec(
-    prepRes: ModelInvocationPrepResult,
+    prepRes: BaseInvocationPrepResult & { systemPrompt?: string },
   ): Promise<InvocationResult<BaseInvocationSuccessData>> {
     if (prepRes.shouldStop) {
       return { kind: 'skipped' };
@@ -107,24 +101,20 @@ export class ModelInvocationNode<
         systemPrompt: prepRes.systemPrompt,
         endTag: this._config.getEndTag?.(services),
         signal,
-        tools: this._config.getTools
-          ? this._config.getTools(services)
-          : services.setting.tools,
+        tools: this._config.getTools?.(services) ?? services.setting.tools,
       });
-
-      const responseTimeMs = Date.now() - start;
 
       return {
         kind: 'success',
         response: result.response,
-        responseTimeMs,
+        responseTimeMs: Date.now() - start,
         updatedMessages: result.updatedMessages,
       };
     });
   }
 
   async execFallback(
-    _prepRes: ModelInvocationPrepResult,
+    _prepRes: BaseInvocationPrepResult,
     error: Error,
   ): Promise<InvocationResult<BaseInvocationSuccessData>> {
     return this.getFallbackResult(error);
@@ -132,7 +122,7 @@ export class ModelInvocationNode<
 
   async post(
     shared: TShared,
-    _prepRes: ModelInvocationPrepResult,
+    _prepRes: BaseInvocationPrepResult,
     execRes: InvocationResult<BaseInvocationSuccessData>,
   ): Promise<string | undefined> {
     const successRes = handleInvocationResult(execRes, shared, shared, {
@@ -148,11 +138,8 @@ export class ModelInvocationNode<
       replaceMessagesInPlace(shared.messages, successRes.updatedMessages);
     }
 
-    this._config.storeResponse(
-      shared,
-      successRes.response,
-      successRes.responseTimeMs,
-    );
+    shared.responseTimeMs = successRes.responseTimeMs;
+    this._config.storeResponse(shared, successRes.response);
 
     if (this._config.getDebugSaveOptions) {
       const { context, fileOptions } = this._config.getDebugSaveOptions(

--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -10,10 +10,7 @@ import { recordRound } from '@agent/core/AgentState';
 import type { NormalizedUsage } from '@agent/types/NormalizedUsage';
 import {
   BaseCycleFieldsSchema,
-  BaseInvocationPrepResult,
-  BaseInvocationSuccessData,
   getDebugContext,
-  replaceMessagesInPlace,
   resetCycleState,
   SkippableNodeResult,
 } from '@agent/core/flows/CommonCycleTypes';
@@ -34,11 +31,7 @@ import { extractScratchpad } from '@utils/text/xmlUtils';
 import { bestConnectionMethod } from '@latex';
 
 import { FlowTransition } from './FlowTransitions';
-import {
-  type InvocationResult,
-  RetryableInvocationNode,
-  handleInvocationResult,
-} from './RetryState';
+import { ModelInvocationNode } from './ModelInvocationNode';
 import { type CycleParams, type ResponseCycleServices } from './CycleServices';
 
 // All debug options (context + file options) are derived at maybeSaveDebugObject call sites.
@@ -171,143 +164,6 @@ class ResponsePrepNode<C> extends BaseNode<
   }
 }
 
-/**
- * Data extracted by prep() for model invocation.
- * Extends base with optional system prompt for response generation.
- */
-interface InvocationPrepResult extends BaseInvocationPrepResult {
-  systemPrompt?: string;
-}
-
-/**
- * Handles model invocation with PocketFlow's built-in retry.
- *
- * Extends RetryableInvocationNode for shared retry logic:
- * - maxRetries and wait configured from user settings
- * - exec() throws on error, Node retries automatically
- * - retryPrompt() shows UI when auto-retries exhausted (if error is retryable)
- * - execFallback() called only when user cancels or error is non-retryable
- *
- * Flow transitions:
- * - default: Continue to next node on success
- * - COMPLETE: All retries exhausted, non-retryable error, or user cancelled
- *
- * Services accessed via `this.services` following PocketFlow service injection.
- */
-class ResponseModelInvocationNode<C> extends RetryableInvocationNode<
-  ResponseCycleShared,
-  CycleParams,
-  ResponseCycleServices<C>
-> {
-  protected getOperationName(): string {
-    return 'Model invocation';
-  }
-
-  /** Check if background mode is active (enables minimum retry count). */
-  protected override isBackgroundModeActive(): boolean {
-    return this.services.modelHandler.isBackgroundModeActive();
-  }
-
-  async prep(shared: ResponseCycleShared): Promise<InvocationPrepResult> {
-    return {
-      shouldStop: shared.shouldStop,
-      messages: shared.messages,
-      systemPrompt: shared.systemPrompt,
-    };
-  }
-
-  async exec(
-    prepRes: InvocationPrepResult,
-  ): Promise<InvocationResult<BaseInvocationSuccessData>> {
-    const services = this.services;
-
-    if (prepRes.shouldStop) {
-      return { kind: 'skipped' };
-    }
-
-    services.modelHandler.setOutputStreaming(false);
-
-    const stage = await services.logger.stage('Model invocation', {
-      skip: true,
-    });
-
-    const start = Date.now();
-
-    return this.withAbortController(async (signal) => {
-      const { response, responseTimeMs, updatedMessages } = await stage.run(
-        async () => {
-          const result = await services.modelHandler.createResponse({
-            client: services.client,
-            messages: prepRes.messages,
-            temperature: services.setting.temperature,
-            systemPrompt: prepRes.systemPrompt,
-            endTag: services.setting.endTag,
-            signal,
-            tools: services.modelHandler.capabilities.supportsFunctionCalling
-              ? services.setting.tools
-              : undefined,
-          });
-
-          const elapsedMs = Date.now() - start;
-
-          return {
-            response: result.response,
-            responseTimeMs: elapsedMs,
-            updatedMessages: result.updatedMessages,
-          };
-        },
-      );
-
-      return { kind: 'success', response, responseTimeMs, updatedMessages };
-    });
-  }
-
-  async execFallback(
-    _prepRes: InvocationPrepResult,
-    error: Error,
-  ): Promise<InvocationResult<BaseInvocationSuccessData>> {
-    return this.getFallbackResult(error);
-  }
-
-  async post(
-    shared: ResponseCycleShared,
-    _prepRes: InvocationPrepResult,
-    execRes: InvocationResult<BaseInvocationSuccessData>,
-  ): Promise<string | undefined> {
-    const successRes = handleInvocationResult(execRes, shared, shared, {
-      logger: this.services.logger,
-      operationName: this.getOperationName(),
-    });
-
-    if (!successRes) {
-      return FlowTransition.COMPLETE;
-    }
-
-    // Handle message updates from compaction (explicit in post, not via callback)
-    if (successRes.updatedMessages !== undefined) {
-      replaceMessagesInPlace(shared.messages, successRes.updatedMessages);
-    }
-
-    shared.responseObject = successRes.response;
-    shared.responseTimeMs = successRes.responseTimeMs;
-
-    await maybeSaveDebugObject({
-      object: successRes.response,
-      objectType: 'response',
-      context: getDebugContext(this.services, {
-        modelName: this.services.config.model,
-        isRemote: isRemoteAgent(this.services.config.agent),
-      }),
-      fileOptions: {
-        continuationCount: this.services.round.continuationCount,
-        baseName: 'response',
-        outputFile: shared.outputLocation!.relativePath,
-      },
-    });
-
-    return FlowTransition.DEFAULT;
-  }
-}
 
 /**
  * Data extracted by prep() for response processing.
@@ -795,7 +651,37 @@ export function createResponseCycleFlow<C>(): Flow<
   CycleParams
 > {
   const prepNode = new ResponsePrepNode<C>();
-  const invokeNode = new ResponseModelInvocationNode<C>();
+  const invokeNode = new ModelInvocationNode<
+    ResponseCycleShared,
+    CycleParams,
+    ResponseCycleServices<C>
+  >({
+    operationName: 'Model invocation',
+    streaming: false,
+    getSystemPrompt: (shared) => shared.systemPrompt,
+    getEndTag: (services) => services.setting.endTag,
+    getTools: (services) =>
+      services.modelHandler.capabilities.supportsFunctionCalling
+        ? services.setting.tools
+        : undefined,
+    storeResponse: (shared, response, responseTimeMs) => {
+      shared.responseObject = response;
+      shared.responseTimeMs = responseTimeMs;
+    },
+    isBackgroundModeActive: (services) =>
+      services.modelHandler.isBackgroundModeActive(),
+    getDebugSaveOptions: (shared, services) => ({
+      context: {
+        modelName: services.config.model,
+        isRemote: isRemoteAgent(services.config.agent),
+      },
+      fileOptions: {
+        continuationCount: services.round.continuationCount,
+        baseName: 'response',
+        outputFile: shared.outputLocation!.relativePath,
+      },
+    }),
+  });
   const processNode = new ResponseProcessNode<C>();
   const continuationNode = new ResponseContinuationNode<C>();
   const finalizeNode = new ResponseCycleFinalizeNode<C>();

--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -164,7 +164,6 @@ class ResponsePrepNode<C> extends BaseNode<
   }
 }
 
-
 /**
  * Data extracted by prep() for response processing.
  * Note: outputLocation and outputExists are accessed directly from shared
@@ -664,12 +663,9 @@ export function createResponseCycleFlow<C>(): Flow<
       services.modelHandler.capabilities.supportsFunctionCalling
         ? services.setting.tools
         : undefined,
-    storeResponse: (shared, response, responseTimeMs) => {
+    storeResponse: (shared, response) => {
       shared.responseObject = response;
-      shared.responseTimeMs = responseTimeMs;
     },
-    isBackgroundModeActive: (services) =>
-      services.modelHandler.isBackgroundModeActive(),
     getDebugSaveOptions: (shared, services) => ({
       context: {
         modelName: services.config.model,

--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -657,6 +657,7 @@ export function createResponseCycleFlow<C>(): Flow<
   >({
     operationName: 'Model invocation',
     streaming: false,
+    backgroundModeAware: true,
     getSystemPrompt: (shared) => shared.systemPrompt,
     getEndTag: (services) => services.setting.endTag,
     getTools: (services) =>

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -9,11 +9,8 @@ import { BaseNode, BatchNode, Flow } from '@agent/node';
 import { recordCycleMetrics } from '@agent/core/AgentState';
 import {
   BaseCycleFieldsSchema,
-  BaseInvocationPrepResult,
-  BaseInvocationSuccessData,
   resetCycleState,
   getDebugContext,
-  replaceMessagesInPlace,
 } from '@agent/core/flows/CommonCycleTypes';
 import type { SdkToolCall } from '@agent/modelHandlers/types/IModelHandler';
 import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
@@ -40,7 +37,6 @@ import { toErrorMessage } from '@common/errors';
 // Local imports - logging
 import { AgentLogger } from '@logger/AgentLogger';
 // Type imports
-import type { ToolDefinition } from '@model';
 import {
   DIAGNOSTIC_TYPE_VALIDATION_ERROR,
   formatZodIssuesForDiagnostics,
@@ -53,11 +49,7 @@ import { bus } from '@eventBus/ProgressEventBus';
 
 // Local file imports
 import { FlowTransition } from './FlowTransitions';
-import {
-  type InvocationResult,
-  RetryableInvocationNode,
-  handleInvocationResult,
-} from './RetryState';
+import { ModelInvocationNode } from './ModelInvocationNode';
 import type { CycleParams, ToolUseCycleServices } from './CycleServices';
 
 // ============================================================================
@@ -313,104 +305,6 @@ class ToolUsePrepNode<C> extends BaseNode<
   }
 }
 
-/**
- * Handles model invocation for tool-use cycles with PocketFlow's built-in retry.
- * Uses RetryableInvocationNode for automatic retry logic with user prompts.
- */
-class ToolUseCallNode<C> extends RetryableInvocationNode<
-  ToolUseCycleShared,
-  CycleParams,
-  ToolUseCycleServices<C>
-> {
-  protected getOperationName(): string {
-    return 'Tool-use call';
-  }
-
-  async prep(shared: ToolUseCycleShared): Promise<BaseInvocationPrepResult> {
-    return {
-      shouldStop: shared.shouldStop,
-      messages: shared.messages,
-    };
-  }
-
-  async exec(
-    prepRes: BaseInvocationPrepResult,
-  ): Promise<InvocationResult<BaseInvocationSuccessData>> {
-    const services = this.services;
-
-    if (prepRes.shouldStop) {
-      return { kind: 'skipped' };
-    }
-
-    const start = Date.now();
-
-    return this.withAbortController(async (signal) => {
-      services.modelHandler.setOutputStreaming(true);
-      const result = await services.modelHandler.createResponse({
-        client: services.client,
-        messages: prepRes.messages,
-        temperature: services.setting.temperature,
-        signal,
-        tools: services.setting.tools as ToolDefinition[] | undefined,
-      });
-
-      const responseTimeMs = Date.now() - start;
-
-      return {
-        kind: 'success',
-        response: result.response,
-        responseTimeMs,
-        updatedMessages: result.updatedMessages,
-      };
-    });
-  }
-
-  async execFallback(
-    _prepRes: BaseInvocationPrepResult,
-    error: Error,
-  ): Promise<InvocationResult<BaseInvocationSuccessData>> {
-    return this.getFallbackResult(error);
-  }
-
-  async post(
-    shared: ToolUseCycleShared,
-    _prepRes: BaseInvocationPrepResult,
-    execRes: InvocationResult<BaseInvocationSuccessData>,
-  ): Promise<string | undefined> {
-    const successRes = handleInvocationResult(execRes, shared, shared, {
-      logger: this.services.logger,
-      operationName: this.getOperationName(),
-    });
-
-    if (!successRes) {
-      return FlowTransition.COMPLETE;
-    }
-
-    // Handle message updates from compaction (explicit in post, not via callback)
-    if (successRes.updatedMessages !== undefined) {
-      replaceMessagesInPlace(shared.messages, successRes.updatedMessages);
-    }
-
-    // Apply success-specific side effects
-    shared.response = successRes.response;
-    shared.responseTimeMs = successRes.responseTimeMs;
-
-    await maybeSaveDebugObject({
-      object: successRes.response,
-      objectType: 'response',
-      context: getDebugContext(this.services, {
-        modelName: this.services.modelName,
-        isRemote: isRemoteAgent(this.services.agentName),
-      }),
-      fileOptions: {
-        continuationCount: shared.cycleIndex,
-        baseName: 'tooluse_response',
-      },
-    });
-
-    return FlowTransition.DEFAULT;
-  }
-}
 
 /** Result of exec() containing extracted data needed for post() side effects. */
 type ToolUseProcessExecResult =
@@ -1008,7 +902,28 @@ export function createToolUseCycleFlow<C>(): Flow<
   CycleParams
 > {
   const prepNode = new ToolUsePrepNode<C>();
-  const callNode = new ToolUseCallNode<C>();
+  const callNode = new ModelInvocationNode<
+    ToolUseCycleShared,
+    CycleParams,
+    ToolUseCycleServices<C>
+  >({
+    operationName: 'Tool-use call',
+    streaming: true,
+    storeResponse: (shared, response, responseTimeMs) => {
+      shared.response = response;
+      shared.responseTimeMs = responseTimeMs;
+    },
+    getDebugSaveOptions: (shared, services) => ({
+      context: {
+        modelName: services.modelName,
+        isRemote: isRemoteAgent(services.agentName),
+      },
+      fileOptions: {
+        continuationCount: shared.cycleIndex,
+        baseName: 'tooluse_response',
+      },
+    }),
+  });
   const processNode = new ToolUseProcessNode<C>();
   const dispatchNode = new ToolUseDispatchNode<C>();
 

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -305,7 +305,6 @@ class ToolUsePrepNode<C> extends BaseNode<
   }
 }
 
-
 /** Result of exec() containing extracted data needed for post() side effects. */
 type ToolUseProcessExecResult =
   | { kind: 'skipped' }
@@ -909,9 +908,8 @@ export function createToolUseCycleFlow<C>(): Flow<
   >({
     operationName: 'Tool-use call',
     streaming: true,
-    storeResponse: (shared, response, responseTimeMs) => {
+    storeResponse: (shared, response) => {
       shared.response = response;
-      shared.responseTimeMs = responseTimeMs;
     },
     getDebugSaveOptions: (shared, services) => ({
       context: {


### PR DESCRIPTION
## Summary
Consolidates the nearly-identical `ResponseModelInvocationNode` and `ToolUseCallNode` into a single, parameterized `ModelInvocationNode` class. This eliminates code duplication while maintaining full feature parity and improving maintainability.

## Key Changes
- **New `ModelInvocationNode` class**: A generic, config-driven model invocation handler that replaces two separate implementations
  - Parameterized by `ModelInvocationConfig` to control streaming mode, system prompt extraction, end tag extraction, response storage, and debug save behavior
  - Extends `RetryableInvocationNode` for consistent retry logic across both response and tool-use cycles
  
- **Removed duplicate implementations**:
  - Deleted `ResponseModelInvocationNode` from `ResponseCycleFlow.ts`
  - Deleted `ToolUseCallNode` from `ToolUseCycleFlow.ts`
  
- **Updated flow instantiation**:
  - `ResponseCycleFlow` now instantiates `ModelInvocationNode` with response-cycle-specific config (streaming=false, system prompt, end tag)
  - `ToolUseCycleFlow` now instantiates `ModelInvocationNode` with tool-use-cycle-specific config (streaming=true, no system prompt/end tag)

## Implementation Details
- The new node accepts a flexible config object that allows callers to specify:
  - Operation name for logging
  - Streaming behavior
  - Optional system prompt and end tag extractors
  - Custom tool provider (defaults to `services.setting.tools`)
  - Response storage callback
  - Background mode detection
  - Debug save options
  
- Both flows maintain identical behavior while sharing the underlying retry and invocation logic
- Removed unused imports (`BaseInvocationPrepResult`, `BaseInvocationSuccessData`, `replaceMessagesInPlace`) from flow files where they're no longer needed

https://claude.ai/code/session_01P3feP9eZ8hDcX1AhknHKm8

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors core flow execution by centralizing model invocation/retry behavior; small config differences (tools selection, background-mode retries, debug saving) could subtly change runtime behavior if misconfigured.
> 
> **Overview**
> Introduces a generic, config-driven `ModelInvocationNode` that encapsulates model/tool invocation, retry handling, message compaction updates, response timing, and optional debug persistence.
> 
> Refactors `ResponseCycleFlow` and `ToolUseCycleFlow` to replace their bespoke invocation nodes with `ModelInvocationNode` instances configured per flow (system prompt/end tag/tools/streaming/response storage), and updates shared invocation prep types to support an optional `systemPrompt`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7baaf24929dbc358c4972dfc97e710ba2e566a5a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->