### PR TITLE
Reduce abstraction overhead in agent execution

### DIFF
--- a/src/agent/core/flows/CommonCycleTypes.ts
+++ b/src/agent/core/flows/CommonCycleTypes.ts
@@ -102,3 +102,33 @@ export function replaceMessagesInPlace<T>(target: T[], newContents: T[]): void {
   target.length = 0;
   target.push(...newContents);
 }
+
+// --- Cycle Outcome Interpretation ---
+
+/**
+ * Outcome of a cycle flow execution, derived from cycle shared state.
+ *
+ * Used by both ResponseCycleNode and ToolUseCycleNode to avoid duplicating
+ * the three-way interpretation of shouldStop / lastError / endTurn.
+ */
+export type CycleOutcome = 'completed' | 'cancelled' | 'failed';
+
+/**
+ * Interpret cycle shared state into a single outcome.
+ *
+ * Both cycle nodes (Response and ToolUse) use the same three-flag pattern:
+ * - shouldStop + lastError → failed
+ * - shouldStop + !lastError + !endTurn → cancelled (user stopped)
+ * - otherwise → completed
+ *
+ * This is the single source of truth for that interpretation.
+ */
+export function interpretCycleOutcome(shared: BaseCycleFields): CycleOutcome {
+  if (shared.shouldStop && shared.lastError) {
+    return 'failed';
+  }
+  if (shared.shouldStop && !shared.lastError && !shared.endTurn) {
+    return 'cancelled';
+  }
+  return 'completed';
+}

--- a/src/agent/implementations/flows/common/FlowLifecycle.ts
+++ b/src/agent/implementations/flows/common/FlowLifecycle.ts
@@ -1,0 +1,99 @@
+/**
+ * Shared flow lifecycle helper for both reflection and tool-use flows.
+ *
+ * Owns the common boilerplate:
+ * - Register/unregister interruptible
+ * - Acquire execution KV store and read persisted flow record
+ * - Cleanup: retry coordinator clear + interruptible unregistration
+ *
+ * Flow-specific logic (resume parsing, node wiring, cleanup conditions)
+ * stays in the caller via the `execute` callback.
+ */
+
+import {
+  END_GROUP_STATUS,
+  type EndGroupStatus,
+  type StreamTabId,
+  type ExecutionId,
+} from '@shared/schemas';
+import {
+  getExecutionStore,
+  type ExecutionKVStore,
+} from '@agent/storage/ExecutionKVStore';
+import {
+  registerInterruptible,
+  unregisterInterruptible,
+  type IInterruptible,
+} from '@agent/toolUse/ToolUseAgentRegistry';
+import { retryCoordinator } from '@agent/runtime/RetryRequestCoordinator';
+import type { FlowRecord } from '@agent/node/persisted-flow';
+
+/** Context provided to the execute callback. */
+export interface FlowLifecycleContext {
+  kv: ExecutionKVStore;
+  flowRecord: FlowRecord | null;
+}
+
+/** Options for withFlowLifecycle. */
+export interface FlowLifecycleOptions {
+  streamId: StreamTabId;
+  executionId: ExecutionId;
+  interruptible: IInterruptible;
+  /** Called after registration, before execute (e.g. for ToolUseFlowContext setup). */
+  onRegistered?: () => void;
+}
+
+/**
+ * Run a flow with standardized lifecycle management.
+ *
+ * Handles:
+ * 1. Register interruptible for the stream
+ * 2. Open KV store and read any persisted flow record
+ * 3. Call `execute(ctx)` — caller does resume parsing, node wiring, flow.run()
+ * 4. In finally: clear retry requests, unregister interruptible
+ *
+ * The execute callback receives the KV store and flow record, and must
+ * return an EndGroupStatus. Flow record cleanup (delete vs preserve)
+ * is the caller's responsibility inside the execute callback.
+ */
+export async function withFlowLifecycle<T>(
+  options: FlowLifecycleOptions,
+  execute: (ctx: FlowLifecycleContext) => Promise<T>,
+): Promise<T> {
+  const { streamId, executionId, interruptible, onRegistered } = options;
+
+  registerInterruptible(streamId, interruptible);
+  onRegistered?.();
+
+  const kv: ExecutionKVStore = getExecutionStore(executionId);
+  let flowRecord: FlowRecord | null = null;
+  try {
+    flowRecord =
+      (await kv.read<FlowRecord>(`flow:${executionId}`)) ?? null;
+  } catch {
+    // Resume parse failures are handled by callers — start fresh
+    flowRecord = null;
+  }
+
+  try {
+    return await execute({ kv, flowRecord });
+  } finally {
+    retryCoordinator.clearRequest(streamId);
+    unregisterInterruptible(streamId);
+  }
+}
+
+/**
+ * Delete a flow record from the KV store (best-effort, ignores errors).
+ * Shared by both flow runners for cleanup after completion.
+ */
+export async function deleteFlowRecord(
+  executionId: ExecutionId,
+): Promise<void> {
+  try {
+    const kv = getExecutionStore(executionId);
+    await kv.delete(`flow:${executionId}`);
+  } catch {
+    // Ignore cleanup errors
+  }
+}

--- a/src/agent/implementations/flows/reflection/nodes/ResponseCycleNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/ResponseCycleNode.ts
@@ -32,6 +32,7 @@ import type {
   ConversationRoundStateSnapshot,
 } from '@agent/core/AgentState';
 import { buildCycleServices } from '@agent/core/flows/CycleServices';
+import { interpretCycleOutcome } from '@agent/core/flows/CommonCycleTypes';
 import type { AgentFileLocation } from '@utils/files';
 
 import type { ReflectionFlowShared } from '../ReflectionFlowState';
@@ -157,18 +158,15 @@ export class ResponseCycleNode<C = unknown> extends Node<
       );
       await flow.run(cycleShared);
 
-      // Determine outcome from cycle state (single interpretation)
-      if (cycleShared.shouldStop && cycleShared.lastError) {
+      // Interpret outcome using shared helper (single source of truth)
+      const outcome = interpretCycleOutcome(cycleShared);
+      if (outcome === 'failed') {
         return {
           outcome: 'failed',
-          error: new Error(cycleShared.lastError.message),
+          error: new Error(cycleShared.lastError!.message),
         };
       }
-      if (
-        cycleShared.shouldStop &&
-        !cycleShared.lastError &&
-        !cycleShared.endTurn
-      ) {
+      if (outcome === 'cancelled') {
         return { outcome: 'cancelled' };
       }
       return { outcome: 'completed', endTurn: cycleShared.endTurn };

--- a/src/agent/implementations/flows/reflection/runReflectionFlow.ts
+++ b/src/agent/implementations/flows/reflection/runReflectionFlow.ts
@@ -31,10 +31,6 @@ import {
 } from '@shared/schemas';
 import { executionToEndStatus } from '@common/constants/streamStatus';
 import {
-  getExecutionStore,
-  type ExecutionKVStore,
-} from '@agent/storage/ExecutionKVStore';
-import {
   createOutputState,
   setActiveRun,
   getOutputFilesByRound,
@@ -42,18 +38,17 @@ import {
 } from '@agent/output/outputState';
 import { XmlOutputManager } from '@agent/output/XmlOutputManager';
 import { LatexDiffManager } from '@agent/output/LatexDiffManager';
-import {
-  registerInterruptible,
-  unregisterInterruptible,
-  type IInterruptible,
-} from '@agent/toolUse/ToolUseAgentRegistry';
+import type { IInterruptible } from '@agent/toolUse/ToolUseAgentRegistry';
 import type { BaseFlowContextInit } from '@agent/implementations/flows/common/BaseFlowServices';
+import {
+  withFlowLifecycle,
+  deleteFlowRecord,
+} from '@agent/implementations/flows/common/FlowLifecycle';
 import { retryCoordinator } from '@agent/runtime/RetryRequestCoordinator';
 import { getOutputFileName } from '@agent/utils/outputFileUtils';
 import { createRunState } from '@agent/core/AgentState';
 import { AgentWorkspaceState } from '@agent/core/AgentWorkspaceState';
 import type { AgentWorkflowSetting } from '@agent/core/AgentDataclass';
-import { type FlowRecord } from '@agent/node/persisted-flow';
 import { RoundPersistedFlow } from '@agent/node/round-persisted-flow';
 import type { UsageMonitor } from '@agent/utils/UsageMonitor';
 import type { AgentLogStage } from '@logger/AgentLogger';
@@ -276,130 +271,115 @@ export async function runReflectionFlow<C = unknown>(
     storageKey,
   );
 
-  try {
-    // Register for interrupt handling
-    registerInterruptible(streamId, interruptible);
-
-    // Get execution-scoped storage for persistence
-    const kv: ExecutionKVStore = getExecutionStore(executionId);
-
-    // Try to restore full state from persisted flow (resume scenario)
-    const flowRecord = await kv.read<FlowRecord>(`flow:${executionId}`);
-    const validated = flowRecord?.shared
-      ? ReflectionFlowStateSchema.safeParse(flowRecord.shared)
-      : null;
-    const isResume = validated?.success ?? false;
-
-    if (validated?.success) {
-      shared = validated.data as ReflectionFlowShared;
-      logger.debug(
-        `Resuming reflection flow from round ${shared.currentRound}/${shared.totalRounds}`,
-      );
-    }
-
-    // Create fresh state if not resuming
-    if (!shared) {
-      shared = {
-        currentRound: 0,
-        totalRounds,
-        workspaceSnapshot: AgentWorkspaceState.create().toSnapshot(),
-        context: null,
-        outputLocation: null,
-        conversation: [],
-        runStateSnapshot: createRunState(),
-        roundStateSnapshots: [],
-        roundOutputs: [],
-        continueRounds: true,
-        endTurn: false,
-      };
-    }
-
-    // Create flow nodes and wire transitions inline
-    // Wire the linear node chain: prep → texcount → media → cycle → output.
-    // Round looping is handled by RoundPersistedFlow (no dedicated decision node).
-    const prepContextNode = new PrepareContextNode<C>();
-    const texCountNode = new TeXCountNode<C>();
-    const mediaNode = new MediaExtractionNode<C>();
-    const responseCycleNode = new ResponseCycleNode<C>();
-    const outputNode = new OutputNode<C>();
-
-    prepContextNode.next(texCountNode);
-    texCountNode.next(mediaNode);
-    mediaNode.next(responseCycleNode);
-    responseCycleNode.next(outputNode);
-
-    const startNode = prepContextNode;
-    const pf = new RoundPersistedFlow<
-      ReflectionFlowShared,
-      Record<string, unknown>,
-      ReflectionServices<C>
-    >(startNode, kv, {
-      parentStage,
-      callbacks: {
-        createRoundStage: async (roundIndex, parent) => {
-          return await logger.stage(`r${roundIndex}`, {
-            parent: parent ?? undefined,
-          });
-        },
-        onStageCreated: (stage) => {
-          usageMonitor?.setActiveGroupId(stage.id);
-        },
-        resetForNextRound: (s) => {
-          s.workspaceSnapshot = AgentWorkspaceState.create().toSnapshot();
-        },
-        checkInterruption,
-      },
-    });
-
-    // Build services: spread input + add computed fields
-    // ReflectionServices structurally satisfies OutputDependencies, so no
-    // separate outputDeps object is needed — output functions accept services directly.
-    services = {
-      ...input,
-      onRoundFinalized,
-      outputState,
-      xmlManager,
-      diffManager,
-      latexMediaManager,
-      promptBuilder,
-      fileService,
-      getOutputFileLocation,
-      shouldEnsureXmlStructure,
-      baseFiles,
-    };
-    pf.setServices(services);
-
-    if (isResume) {
-      logger.debug('Resuming reflection flow from persistence');
-    }
-
-    const flowStatus = await pf.run(shared);
-    shared = await pf.getShared();
-    status = executionToEndStatus(flowStatus) as EndGroupStatus;
-  } catch (error) {
-    status = END_GROUP_STATUS.ERROR;
-    throw error;
-  } finally {
-    // Only delete flow record on successful completion
-    // Keep it for interrupted/error flows to enable resume
-    // Note: END_GROUP_STATUS.STOPPED means "completed" (not user-stopped)
-    if (status === END_GROUP_STATUS.STOPPED) {
+  return withFlowLifecycle(
+    { streamId, executionId, interruptible },
+    async ({ kv, flowRecord }) => {
       try {
-        const kv = getExecutionStore(executionId);
-        await kv.delete(`flow:${executionId}`);
-      } catch {
-        // Ignore cleanup errors
+        // Try to restore full state from persisted flow (resume scenario)
+        const validated = flowRecord?.shared
+          ? ReflectionFlowStateSchema.safeParse(flowRecord.shared)
+          : null;
+        const isResume = validated?.success ?? false;
+
+        if (validated?.success) {
+          shared = validated.data as ReflectionFlowShared;
+          logger.debug(
+            `Resuming reflection flow from round ${shared.currentRound}/${shared.totalRounds}`,
+          );
+        }
+
+        // Create fresh state if not resuming
+        if (!shared) {
+          shared = {
+            currentRound: 0,
+            totalRounds,
+            workspaceSnapshot: AgentWorkspaceState.create().toSnapshot(),
+            context: null,
+            outputLocation: null,
+            conversation: [],
+            runStateSnapshot: createRunState(),
+            roundStateSnapshots: [],
+            roundOutputs: [],
+            continueRounds: true,
+            endTurn: false,
+          };
+        }
+
+        // Create flow nodes and wire transitions inline
+        // Wire the linear node chain: prep → texcount → media → cycle → output.
+        // Round looping is handled by RoundPersistedFlow (no dedicated decision node).
+        const prepContextNode = new PrepareContextNode<C>();
+        const texCountNode = new TeXCountNode<C>();
+        const mediaNode = new MediaExtractionNode<C>();
+        const responseCycleNode = new ResponseCycleNode<C>();
+        const outputNode = new OutputNode<C>();
+
+        prepContextNode.next(texCountNode);
+        texCountNode.next(mediaNode);
+        mediaNode.next(responseCycleNode);
+        responseCycleNode.next(outputNode);
+
+        const startNode = prepContextNode;
+        const pf = new RoundPersistedFlow<
+          ReflectionFlowShared,
+          Record<string, unknown>,
+          ReflectionServices<C>
+        >(startNode, kv, {
+          parentStage,
+          callbacks: {
+            createRoundStage: async (roundIndex, parent) => {
+              return await logger.stage(`r${roundIndex}`, {
+                parent: parent ?? undefined,
+              });
+            },
+            onStageCreated: (stage) => {
+              usageMonitor?.setActiveGroupId(stage.id);
+            },
+            resetForNextRound: (s) => {
+              s.workspaceSnapshot = AgentWorkspaceState.create().toSnapshot();
+            },
+            checkInterruption,
+          },
+        });
+
+        // Build services: spread input + add computed fields
+        services = {
+          ...input,
+          onRoundFinalized,
+          outputState,
+          xmlManager,
+          diffManager,
+          latexMediaManager,
+          promptBuilder,
+          fileService,
+          getOutputFileLocation,
+          shouldEnsureXmlStructure,
+          baseFiles,
+        };
+        pf.setServices(services);
+
+        if (isResume) {
+          logger.debug('Resuming reflection flow from persistence');
+        }
+
+        const flowStatus = await pf.run(shared);
+        shared = await pf.getShared();
+        status = executionToEndStatus(flowStatus) as EndGroupStatus;
+      } catch (error) {
+        status = END_GROUP_STATUS.ERROR;
+        throw error;
+      } finally {
+        // Only delete flow record on successful completion
+        // Keep it for interrupted/error flows to enable resume
+        if (status === END_GROUP_STATUS.STOPPED) {
+          await deleteFlowRecord(executionId);
+        }
       }
-    }
 
-    // Clean up retry coordinator
-    retryCoordinator.clearRequest(streamId);
-
-    unregisterInterruptible(streamId);
-  }
-
-  return {
-    roundOutputs: shared?.roundOutputs ?? [],
-    status,
-  };
+      return {
+        roundOutputs: shared?.roundOutputs ?? [],
+        status,
+      };
+    },
+  );
 }

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
@@ -11,6 +11,7 @@ import {
   createToolUseCycleShared,
 } from '@agent/core/flows/ToolUseCycleFlow';
 import { buildCycleServices } from '@agent/core/flows/CycleServices';
+import { interpretCycleOutcome } from '@agent/core/flows/CommonCycleTypes';
 import { bus } from '@eventBus/ProgressEventBus';
 
 import {
@@ -92,18 +93,15 @@ export class ToolUseCycleNode<C> extends Node<
     try {
       await flow.run(cycleShared);
 
-      // Determine outcome directly from shared state flags (single interpretation)
-      if (cycleShared.shouldStop && cycleShared.lastError) {
+      // Interpret outcome using shared helper (single source of truth)
+      const outcome = interpretCycleOutcome(cycleShared);
+      if (outcome === 'failed') {
         return {
           outcome: 'failed',
-          message: cycleShared.lastError.message ?? 'Cycle failed',
+          message: cycleShared.lastError?.message ?? 'Cycle failed',
         };
       }
-      if (
-        cycleShared.shouldStop &&
-        !cycleShared.lastError &&
-        !cycleShared.endTurn
-      ) {
+      if (outcome === 'cancelled') {
         return { outcome: 'cancelled' };
       }
       return { outcome: 'completed', messages: cycleShared.messages };

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -11,14 +11,13 @@ import {
   type EndGroupStatus,
 } from '@shared/schemas';
 import { executionToEndStatus } from '@common/constants/streamStatus';
-import { getExecutionStore, type ExecutionKVStore } from '@agent/storage';
-import {
-  registerInterruptible,
-  unregisterInterruptible,
-} from '@agent/toolUse/ToolUseAgentRegistry';
 import { retryCoordinator } from '@agent/runtime/RetryRequestCoordinator';
+import {
+  withFlowLifecycle,
+  deleteFlowRecord,
+} from '@agent/implementations/flows/common/FlowLifecycle';
 
-import { PersistedFlow, type FlowRecord } from '@agent/node/persisted-flow';
+import { PersistedFlow } from '@agent/node/persisted-flow';
 
 import type { AgentToolUseSetting } from '@agent/core/AgentDataclass';
 import type { IToolRegistry } from '@agent/core/ToolTypes';
@@ -149,83 +148,78 @@ export async function runToolUseFlow<C = unknown>(
     },
   };
 
-  let status: EndGroupStatus = END_GROUP_STATUS.STOPPED;
-
-  // Shared state is declared outside try block for access in finally (cleanup decision based on userCancelledRetry)
+  // Shared state is declared outside the lifecycle callback for access after completion
   const shared: ToolUseRunShared = {
     messages: [],
     shouldSkipCycle: false,
     stateSlices: null,
   };
 
-  try {
-    registerInterruptible(streamId, flowContext);
-    onSetup?.(flowContext);
+  let status: EndGroupStatus = END_GROUP_STATUS.STOPPED;
 
-    const kv: ExecutionKVStore = getExecutionStore(executionId);
-    let flowRecord: FlowRecord | null = null;
-    try {
-      flowRecord = (await kv.read<FlowRecord>(`flow:${executionId}`)) ?? null;
-    } catch (error) {
-      logger.debug(
-        `Resume parse failed, starting fresh: ${error instanceof Error ? error.message : 'unknown'}`,
-      );
-    }
-    if (flowRecord?.shared) {
-      logger.debug('Resuming tool-use flow from persistence');
-      // Migrate legacy nested format to flat format if needed
-      const migrationResult = migrateSharedState(flowRecord.shared);
-      if (migrationResult === null) {
-        logger.warn('Failed to parse flow record shared state, starting fresh');
-        await kv.delete(`flow:${executionId}`);
-        flowRecord = null;
-      } else if (migrationResult.migrated) {
-        logger.debug('Migrated legacy shared state to flat format');
-        flowRecord.shared = migrationResult.data;
-        await kv.write(`flow:${executionId}`, flowRecord);
-      }
-    }
-
-    // Create flow nodes and wire transitions inline
-    const prepareNode = new ToolUsePrepareNode<C>();
-    const cycleNode = new ToolUseCycleNode<C>();
-    const waitNode = new ToolUseWaitNode<C>();
-    prepareNode.next(cycleNode);
-    cycleNode.next(waitNode);
-    waitNode.on(FlowTransition.CONTINUE, cycleNode);
-    const startNode = prepareNode;
-    const pf = new PersistedFlow<
-      ToolUseRunShared,
-      Record<string, unknown>,
-      ToolUseServices<C>
-    >(startNode, kv);
-    pf.setServices(services);
-    await pf.run(shared);
-
-    const execStatus = input.checkInterruption()
-      ? EXECUTION_STATUS.INTERRUPTED
-      : EXECUTION_STATUS.COMPLETED;
-    status = executionToEndStatus(execStatus) as EndGroupStatus;
-  } catch (error) {
-    status = END_GROUP_STATUS.ERROR;
-    throw error;
-  } finally {
-    // Preserve flow record if user cancelled retry (for resume), otherwise delete
-    // Use the local shared object directly - it's updated in place during pf.run()
-    if (shared.userCancelledRetry) {
-      logger.debug('Flow record preserved for resume after retry cancellation');
-    } else {
+  await withFlowLifecycle(
+    {
+      streamId,
+      executionId,
+      interruptible: flowContext,
+      onRegistered: () => onSetup?.(flowContext),
+    },
+    async ({ kv, flowRecord }) => {
       try {
-        const kv = getExecutionStore(executionId);
-        await kv.delete(`flow:${executionId}`);
-      } catch {
-        // Ignore cleanup errors
-      }
-    }
+        // Migrate persisted state if resuming
+        if (flowRecord?.shared) {
+          logger.debug('Resuming tool-use flow from persistence');
+          const migrationResult = migrateSharedState(flowRecord.shared);
+          if (migrationResult === null) {
+            logger.warn(
+              'Failed to parse flow record shared state, starting fresh',
+            );
+            await kv.delete(`flow:${executionId}`);
+            flowRecord = null;
+          } else if (migrationResult.migrated) {
+            logger.debug('Migrated legacy shared state to flat format');
+            flowRecord.shared = migrationResult.data;
+            await kv.write(`flow:${executionId}`, flowRecord);
+          }
+        }
 
-    sessionLifecycle.dispose();
-    unregisterInterruptible(streamId);
-  }
+        // Create flow nodes and wire transitions inline
+        const prepareNode = new ToolUsePrepareNode<C>();
+        const cycleNode = new ToolUseCycleNode<C>();
+        const waitNode = new ToolUseWaitNode<C>();
+        prepareNode.next(cycleNode);
+        cycleNode.next(waitNode);
+        waitNode.on(FlowTransition.CONTINUE, cycleNode);
+        const startNode = prepareNode;
+        const pf = new PersistedFlow<
+          ToolUseRunShared,
+          Record<string, unknown>,
+          ToolUseServices<C>
+        >(startNode, kv);
+        pf.setServices(services);
+        await pf.run(shared);
+
+        const execStatus = input.checkInterruption()
+          ? EXECUTION_STATUS.INTERRUPTED
+          : EXECUTION_STATUS.COMPLETED;
+        status = executionToEndStatus(execStatus) as EndGroupStatus;
+      } catch (error) {
+        status = END_GROUP_STATUS.ERROR;
+        throw error;
+      } finally {
+        // Preserve flow record if user cancelled retry (for resume), otherwise delete
+        if (shared.userCancelledRetry) {
+          logger.debug(
+            'Flow record preserved for resume after retry cancellation',
+          );
+        } else {
+          await deleteFlowRecord(executionId);
+        }
+
+        sessionLifecycle.dispose();
+      }
+    },
+  );
 
   // Extract last assistant text using the model handler's typed extraction
   let lastResponse: string | undefined;

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -30,6 +30,7 @@ import {
 } from '@agent/implementations/flows/tooluse';
 import { runReflectionFlow } from '@agent/implementations/flows/reflection/runReflectionFlow';
 import type { AgentCore } from '@agent/implementations/flows/common/BaseFlowServices';
+import type { RunToolUseFlowResult } from '@agent/implementations/flows/tooluse/runToolUseFlow';
 import {
   AgentConfigSchema,
   type AgentConfig,
@@ -71,7 +72,11 @@ import { getRunStorageService } from './RunStorageService';
 import { StreamStatusService } from './StreamStatusService';
 import { createInterruptCallbacks } from './InterruptManager';
 import { trackExecution, untrackExecution } from './executionRegistry';
-import type { AgentFlowResult, OutputFileSummary } from './AgentFlowResult';
+import type {
+  AgentFlowResult,
+  AgentFlowMeta,
+  OutputFileSummary,
+} from './AgentFlowResult';
 
 const CHANNEL = 'executeAgent';
 const logger = new AgentLogger(CHANNEL);
@@ -304,14 +309,44 @@ function toOutputSummaries(roundOutputs: RoundOutput[]): OutputFileSummary[] {
   );
 }
 
+// ---------------------------------------------------------------------------
+// Unified AgentFlowResult builders
+// ---------------------------------------------------------------------------
+
+/** Build a workflow AgentFlowResult from flow result and execution metadata. */
+function toWorkflowFlowResult(
+  result: { status: EndGroupStatus; roundOutputs: RoundOutput[] },
+  meta: AgentFlowMeta,
+): AgentFlowResult {
+  return {
+    category: 'workflow' as const,
+    status: result.status,
+    outputs: toOutputSummaries(result.roundOutputs),
+    ...meta,
+  };
+}
+
+/** Build a tool-use AgentFlowResult from flow result and execution metadata. */
+function toToolUseFlowResult(
+  result: RunToolUseFlowResult,
+  meta: AgentFlowMeta,
+): AgentFlowResult {
+  return {
+    category: 'toolUse' as const,
+    status: result.status,
+    lastResponse: result.lastResponse,
+    ...meta,
+  };
+}
+
 async function runFlowWithLifecycle(
   ctx: ResolvedAgentBase,
   streamId: StreamTabId,
   agentName: string,
   runner: () => Promise<AgentFlowResult>,
-  options?: { isSubagent?: boolean },
+  options?: { isSubagent?: boolean; parentExecutionId?: string },
 ): Promise<AgentFlowResult> {
-  trackExecution(ctx.executionId, streamId);
+  trackExecution(ctx.executionId, streamId, options?.parentExecutionId);
   try {
     const result = await runner();
     untrackExecution(ctx.executionId);
@@ -518,6 +553,12 @@ export interface ExecuteAgentOptions {
   isSubagent?: boolean;
   /** Fires early with the real streamId, before flow execution starts. */
   onStreamResolved?: (streamId: StreamTabId) => void;
+  /**
+   * Parent execution ID for subagent lineage tracking.
+   * When set, enables cascading interrupt: stopping the parent
+   * also stops this execution and all its descendants.
+   */
+  parentExecutionId?: string;
 }
 
 export async function executeAgent(
@@ -546,6 +587,8 @@ export async function executeAgent(
         logger.info(`Executing ${agentName} with model ${config.model}`);
         const interrupts = createInterruptCallbacks();
 
+        const meta = { executionId: ctx.executionId, streamId };
+
         if (setting.agentCategory === AgentCategory.ToolUse) {
           const result = await runToolUseFlow({
             ...ctx,
@@ -557,13 +600,7 @@ export async function executeAgent(
             onFollowUpConsumed: () =>
               bus.emit('updateQueuedFollowUps', { streamId: ctx.streamId }),
           });
-          return {
-            category: 'toolUse' as const,
-            status: result.status,
-            lastResponse: result.lastResponse,
-            executionId: ctx.executionId,
-            streamId,
-          };
+          return toToolUseFlowResult(result, meta);
         }
 
         const result = await runReflectionFlow({
@@ -574,16 +611,10 @@ export async function executeAgent(
           setting: ctx.setting as AgentWorkflowSetting,
           parentStage: ctx.parentStage,
         });
-        return {
-          category: 'workflow' as const,
-          status: result.status,
-          outputs: toOutputSummaries(result.roundOutputs),
-          executionId: ctx.executionId,
-          streamId,
-        };
+        return toWorkflowFlowResult(result, meta);
       });
     },
-    { isSubagent },
+    { isSubagent, parentExecutionId: options?.parentExecutionId },
   );
 }
 
@@ -624,13 +655,10 @@ export async function executeMergeAgent(
         ),
         parentStage: ctx.parentStage,
       });
-      return {
-        category: 'workflow' as const,
-        status: result.status,
-        outputs: toOutputSummaries(result.roundOutputs),
+      return toWorkflowFlowResult(result, {
         executionId: ctx.executionId,
         streamId,
-      };
+      });
     });
   });
 }
@@ -673,13 +701,10 @@ export async function resumeToolUseFromSnapshot(
         undefined,
         setupSession ? (context) => setupSession(context.session) : undefined,
       );
-      return {
-        category: 'toolUse' as const,
-        status: result.status,
-        lastResponse: result.lastResponse,
+      return toToolUseFlowResult(result, {
         executionId: ctx.executionId,
         streamId,
-      };
+      });
     },
   );
 }

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -1,30 +1,183 @@
 /**
- * Lightweight registry mapping executionId → streamId for active executions.
+ * Execution registry with parent-child lineage for active agent executions.
  *
- * Used by the runs tool to look up current stream status for an execution.
- * Entries are added when an execution starts and removed when it completes.
+ * Tracks executionId → streamId mappings and parent-child relationships.
+ * Enables cascading interrupt: when a parent is interrupted, all descendant
+ * executions are interrupted too.
+ *
+ * Used by:
+ * - executeAgent (track/untrack on start/end)
+ * - RunsTool (look up stream status for an execution)
+ * - agentCommands (cascading interrupt via interruptWithDescendants)
  */
 
+import { getInterruptible } from '@agent/toolUse/ToolUseAgentRegistry';
 import type { StreamTabId } from '@shared/schemas';
 
-const registry = new Map<string, StreamTabId>();
+// ---------------------------------------------------------------------------
+// Core registry
+// ---------------------------------------------------------------------------
 
-/** Track an active execution. */
+interface ExecutionEntry {
+  streamId: StreamTabId;
+  parentExecutionId?: string;
+}
+
+const registry = new Map<string, ExecutionEntry>();
+
+/** Index: parentExecutionId → set of child executionIds. */
+const children = new Map<string, Set<string>>();
+
+// ---------------------------------------------------------------------------
+// Track / Untrack
+// ---------------------------------------------------------------------------
+
+/**
+ * Track an active execution, optionally linking it to a parent.
+ *
+ * @param executionId - Unique ID for this execution
+ * @param streamId - Stream tab ID associated with this execution
+ * @param parentExecutionId - If this is a subagent, the parent's execution ID
+ */
 export function trackExecution(
   executionId: string,
   streamId: StreamTabId,
+  parentExecutionId?: string,
 ): void {
-  registry.set(executionId, streamId);
+  registry.set(executionId, { streamId, parentExecutionId });
+
+  if (parentExecutionId) {
+    let childSet = children.get(parentExecutionId);
+    if (!childSet) {
+      childSet = new Set();
+      children.set(parentExecutionId, childSet);
+    }
+    childSet.add(executionId);
+  }
 }
 
-/** Remove a completed execution. */
+/** Remove a completed execution and clean up parent-child links. */
 export function untrackExecution(executionId: string): void {
+  const entry = registry.get(executionId);
+  if (entry?.parentExecutionId) {
+    const siblings = children.get(entry.parentExecutionId);
+    if (siblings) {
+      siblings.delete(executionId);
+      if (siblings.size === 0) {
+        children.delete(entry.parentExecutionId);
+      }
+    }
+  }
+
+  // Also clean up any children index entry for this execution
+  children.delete(executionId);
   registry.delete(executionId);
 }
+
+// ---------------------------------------------------------------------------
+// Queries
+// ---------------------------------------------------------------------------
 
 /** Get the stream ID for an active execution (undefined if not running). */
 export function getStreamIdForExecution(
   executionId: string,
 ): StreamTabId | undefined {
-  return registry.get(executionId);
+  return registry.get(executionId)?.streamId;
+}
+
+/** Reverse lookup: find the execution ID for a given stream (undefined if none). */
+export function getExecutionIdForStream(
+  streamId: StreamTabId,
+): string | undefined {
+  for (const [execId, entry] of registry) {
+    if (entry.streamId === streamId) return execId;
+  }
+  return undefined;
+}
+
+/** Get the parent execution ID (undefined if top-level). */
+export function getParentExecutionId(
+  executionId: string,
+): string | undefined {
+  return registry.get(executionId)?.parentExecutionId;
+}
+
+/** Get direct child execution IDs for a parent. */
+export function getChildExecutionIds(
+  parentExecutionId: string,
+): ReadonlySet<string> {
+  return children.get(parentExecutionId) ?? new Set();
+}
+
+/** Check if an execution has any active children. */
+export function hasActiveChildren(executionId: string): boolean {
+  const childSet = children.get(executionId);
+  return childSet !== undefined && childSet.size > 0;
+}
+
+/**
+ * Collect all descendant execution IDs (children, grandchildren, etc.)
+ * using breadth-first traversal.
+ */
+export function getDescendantExecutionIds(
+  rootExecutionId: string,
+): string[] {
+  const descendants: string[] = [];
+  const queue = [rootExecutionId];
+
+  while (queue.length > 0) {
+    const current = queue.shift()!;
+    const childSet = children.get(current);
+    if (childSet) {
+      for (const childId of childSet) {
+        descendants.push(childId);
+        queue.push(childId);
+      }
+    }
+  }
+
+  return descendants;
+}
+
+// ---------------------------------------------------------------------------
+// Cascading Interrupt
+// ---------------------------------------------------------------------------
+
+/**
+ * Interrupt an execution and all its descendants.
+ *
+ * Walks the execution tree breadth-first, calling interrupt() on each
+ * registered interruptible via the ToolUseAgentRegistry.
+ *
+ * @returns The set of stream IDs that were interrupted
+ */
+export function interruptWithDescendants(
+  executionId: string,
+): Set<StreamTabId> {
+  const interruptedStreams = new Set<StreamTabId>();
+
+  // Interrupt the root
+  const rootEntry = registry.get(executionId);
+  if (rootEntry) {
+    const interruptible = getInterruptible(rootEntry.streamId);
+    if (interruptible) {
+      interruptible.interrupt();
+      interruptedStreams.add(rootEntry.streamId);
+    }
+  }
+
+  // Interrupt all descendants
+  const descendants = getDescendantExecutionIds(executionId);
+  for (const descendantId of descendants) {
+    const entry = registry.get(descendantId);
+    if (entry) {
+      const interruptible = getInterruptible(entry.streamId);
+      if (interruptible) {
+        interruptible.interrupt();
+        interruptedStreams.add(entry.streamId);
+      }
+    }
+  }
+
+  return interruptedStreams;
 }

--- a/src/commands/agent/agentCommands.ts
+++ b/src/commands/agent/agentCommands.ts
@@ -8,6 +8,10 @@ import {
   getToolUseFlowContext,
 } from '@agent/toolUse/ToolUseAgentRegistry';
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
+import {
+  getExecutionIdForStream,
+  interruptWithDescendants,
+} from '@agent/runtime/executionRegistry';
 import type { StreamTabId } from '@shared/schemas';
 
 export function registerAgentCommands(context: vscode.ExtensionContext): void {
@@ -15,7 +19,19 @@ export function registerAgentCommands(context: vscode.ExtensionContext): void {
     vscode.commands.registerCommand(
       'texra.stopAgent',
       (streamId: StreamTabId) => {
-        getInterruptible(streamId)?.interrupt();
+        // Cascade interrupt to all descendant subagents
+        const executionId = getExecutionIdForStream(streamId);
+        if (executionId) {
+          const interrupted = interruptWithDescendants(executionId);
+          for (const childStreamId of interrupted) {
+            if (childStreamId !== streamId) {
+              StreamStatusService.set(childStreamId, STREAM_STATUS.STOPPED);
+            }
+          }
+        } else {
+          // Fallback: no execution found, interrupt directly
+          getInterruptible(streamId)?.interrupt();
+        }
         StreamStatusService.set(streamId, STREAM_STATUS.STOPPED);
       },
     ),

--- a/src/tools/WorkflowTool.ts
+++ b/src/tools/WorkflowTool.ts
@@ -100,6 +100,9 @@ function toConfigPayload(
  * Execute a subagent in the requested mode.
  * Pre-generates executionId so all IDs (tool return, XML delivery, error)
  * are consistent and usable with the runs tool.
+ *
+ * Passes parentExecutionId to enable cascading interrupt:
+ * when the orchestrator is stopped, all subagents are stopped too.
  */
 function executeSubagent(
   configPayload: AgentConfigPayload,
@@ -109,16 +112,20 @@ function executeSubagent(
   inputFile?: string,
 ): ToolResult | Promise<ToolResult> {
   const executionId = randomUUID() as ExecutionId;
+  const parentExecutionId =
+    getCurrentToolFileInteractionContext()?.executionId;
 
   if (mode === 'sync') {
     return executeAgent(configPayload, executionId, {
       isSubagent: true,
+      parentExecutionId,
     }).then((result) => formatFlowResult(result, agentName, inputFile));
   }
 
   // Async: launch, deliver result via FollowUpQueue, return execution ID for progress checks
   const promise = executeAgent(configPayload, executionId, {
     isSubagent: true,
+    parentExecutionId,
     onStreamResolved: (childStreamId) => {
       registerSubagent(
         executionId,


### PR DESCRIPTION
https://claude.ai/code/session_01YSyAXdbnRHwS3kA3GzmzQw

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches agent execution lifecycle and interruption tracking; failures could leave persisted flow records around or interrupt the wrong set of streams, but changes are mostly refactors with straightforward control flow.
> 
> **Overview**
> Adds shared helpers to reduce duplicated agent-flow boilerplate: `withFlowLifecycle`/`deleteFlowRecord` centralize interruptible registration, persisted flow record loading, retry cleanup, and best-effort record deletion for both reflection and tool-use runners.
> 
> Unifies cycle termination handling by introducing `interpretCycleOutcome` and using it in both `ResponseCycleNode` and `ToolUseCycleNode` to consistently map `shouldStop`/`lastError`/`endTurn` into completed/cancelled/failed outcomes.
> 
> Extends runtime execution tracking to record parent→child execution lineage and implements cascading interrupt: `executeAgent` now accepts/propagates `parentExecutionId`, subagent launches pass it from tool context, `texra.stopAgent` interrupts the whole descendant tree, and `executeAgent` refactors `AgentFlowResult` construction via shared builders.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c53f8af8a568ac2e575dfec3c59cbedff550e23d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->